### PR TITLE
Add battery meter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ EVCC is an extensible EV Charge Controller with PV integration implemented in [G
   - [Charge Modes](#charge-modes)
   - [PV generator configuration](#pv-generator-configuration)
   - [Charger configuration](#charger-configuration)
-- [Implementation](#implementation)
+- [Configuration](#configuration)
   - [Charger](#charger)
     - [Wallbe hardware preparation](#wallbe-hardware-preparation)
     - [OpenWB slave mode](#openwb-slave-mode)
@@ -121,9 +121,9 @@ If *total energy* is supplied, it can be used to calculate the *charged energy* 
 - **No charge meter**: If no charge meter is installed, *charge power* is deducted from *charge current* as controlled by the charger. This method is less accurate than using a *charge meter* since the EV may chose to use less power than EVCC has allowed for consumption.
 If the charger supplies *total energy* for the charging cycle this value is preferred over the *charge meter*'s value (if present).
 
-## Implementation
+## Configuration
 
-EVCC consists of four basic elements: *Charger*, *Meter*, *SoC* and *Loadpoint*. Their APIs are described in [api/api.go](https://github.com/andig/evcc/blob/master/api/api.go).
+The EVCC consists of four basic elements: *Charger*, *Meter* and *Vehicle* individually configured and attached to *Loadpoints*.
 
 ### Charger
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ For both PV modes, EVCC needs to assess how much residual PV power is available 
 
   In this setup, *residual power* is used as margin to account for fluctuations in PV production that may be faster than EVCC's control loop.
 
+- **Battery meter**: *battery meter* is used if a home battery is installed and you want charging the EV take priority over charging the home battery. As the home battery would otherwise "grab" all available PV power, this meter measures the home battery charging power.
+
+  With *grid meter* the charger is then allowed to consume:
+
+      Charge Power = Current Charge Power - Grid Meter Power + Battery Meter Power - Residual Power
+
+  or without *grid meter*
+
+      Charge Power = PV Meter Power + Battery Meter Power - Residual Power
+
+  The *battery meter* is expected to deliver negative values when charging, positives values signal discharging and are ignored.
+
 ### Charger configuration
 
 When using a *grid meter* for accurate control of PV utilization, EVCC needs to be able to determine the current charge power. There are two configurations for determining the *current charge power*:

--- a/core/api.go
+++ b/core/api.go
@@ -63,20 +63,18 @@ func (lp *LoadPoint) hasChargeMeter() bool {
 
 // Dump loadpoint configuration
 func (lp *LoadPoint) Dump() {
-	vehicle := lp.vehicle != nil
-	grid := lp.gridMeter != nil
-	pv := lp.pvMeter != nil
-	log.INFO.Printf("%s config: vehicle %s grid %s pv %s charge %s", lp.Name,
-		presence[vehicle],
-		presence[grid],
-		presence[pv],
+	log.INFO.Printf("%s loadpoint config: vehicle %s grid %s pv %s battery %s charge %s", lp.Name,
+		presence[lp.vehicle != nil],
+		presence[lp.gridMeter != nil],
+		presence[lp.pvMeter != nil],
+		presence[lp.batteryMeter != nil],
 		presence[lp.hasChargeMeter()],
 	)
 
 	_, power := lp.charger.(api.Meter)
 	_, energy := lp.charger.(api.ChargeRater)
 	_, timer := lp.charger.(api.ChargeTimer)
-	log.INFO.Printf("%s charger: power %s energy %s timer %s", lp.Name,
+	log.INFO.Printf("%s charger config: power %s energy %s timer %s", lp.Name,
 		presence[power],
 		presence[energy],
 		presence[timer],

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -55,6 +55,12 @@ meters:
     type: mqtt
     topic: mbmd/sdm1-2/Power
     timeout: 10s # don't use older values
+- name: battery
+  type: default
+  power:
+    type: mqtt
+    topic: mbmd/sma1-1/Power
+    timeout: 10s # don't use older values
 - name: charge
   type: default
   power:
@@ -79,8 +85,9 @@ chargers:
   uri: 192.168.0.8:502 # ModBus address
 # legacy: true # enable for older Wallbes with Phoenix EV-CC-AC1-M3-CBC-RCM controller
 - name: phoenix
-  type: phoenix # Charger with Phoenix Contact controller
+  type: phoenix-emcp # Charger with Phoenix Contact controller
   uri: 192.168.0.8:502 # ModBus address
+  id: 1
 - name: simpleevse-tcp
   type: simpleevse # Charger with Phoenix Contact controller
   uri: 192.168.0.8:502 # TCP ModBus address
@@ -169,10 +176,12 @@ loadpoints:
 - name: main # name for logging
   vehicle: audi
   charger: wallbe # charger
-  gridmeter: grid # grid meter
-  pvmeter: pv # pv meter
-  chargemeter: charge # charge meter
-  sensitivity: 1 # current raise/lower steps size (default 1A)
+  meters:
+    grid: grid # grid meter
+    pv: pv # pv meter
+    battery: battery # battery meter
+    charge: charge # charge meter
   guardduration: 10m # switch charger contactor not more often than this (default 10m)
   maxcurrent: 16 # maximum charge current (default 16A)
   phases: 3 # ev phases (default 3)
+  sensitivity: 1 # current raise/lower step size (default 10A)


### PR DESCRIPTION
Fix #52 to give EV charging priority over home battery charging.

The additional battery/ battery charger can be configured like this:

```yaml
meters:
- name: battery
  type: modbus
  model: sunny-island # generic name for sunspec-compatible inverter
  uri: 192.168.0.23:502
  id: 126

loadpoints:
- name: home
  meters:
    grid: ...
    battery: battery
```

**Breaking change**: `meters` has now become a hierarchy level in the `loadpoint` configuration.