### PR TITLE
add testcase PVHysteresis: do not enable before enable timer expired

### DIFF
--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -345,76 +345,77 @@ func TestConsumedPower(t *testing.T) {
 func TestPVHysteresis(t *testing.T) {
 	dt := time.Minute
 	type se struct {
+		site    float64
 		delay   time.Duration // test case delay since start
 		current int64
 	}
 	tc := []struct {
 		enabled               bool
-		site, enable, disable float64
+		enable, disable float64
 		series                []se
 	}{
 		// keep disabled
-		{false, 0, 0, 0, []se{
-			{0, 0},
-			{1, 0},
-			{dt - 1, 0},
-			{dt + 1, 0},
+		{false, 0, 0, []se{
+			{0, 0, 0},
+			{0, 1, 0},
+			{0, dt - 1, 0},
+			{0, dt + 1, 0},
 		}},
 		// enable when threshold not configured but min power met
-		{false, -6 * 100 * 10, 0, 0, []se{
-			{0, 0},
-			{1, 0},
-			{dt - 1, 0},
-			{dt + 1, lpMinCurrent},
+		{false, 0, 0, []se{
+			{-6 * 100 * 10, 0, 0},
+			{-6 * 100 * 10, 1, 0},
+			{-6 * 100 * 10, dt - 1, 0},
+			{-6 * 100 * 10, dt + 1, lpMinCurrent},
 		}},
 		// keep disabled when threshold not configured
-		{false, -400, 0, 0, []se{
-			{0, 0},
-			{1, 0},
-			{dt - 1, 0},
-			{dt + 1, 0},
+		{false, 0, 0, []se{
+			{-400, 0, 0},
+			{-400, 1, 0},
+			{-400, dt - 1, 0},
+			{-400, dt + 1, 0},
 		}},
 		// keep disabled when threshold not met
-		{false, -400, -500, 0, []se{
-			{0, 0},
-			{1, 0},
-			{dt - 1, 0},
-			{dt + 1, 0},
+		{false, -500, 0, []se{
+			{-400, 0, 0},
+			{-400, 1, 0},
+			{-400, dt - 1, 0},
+			{-400, dt + 1, 0},
 		}},
 		// enable when threshold met
-		{false, -500, -500, 0, []se{
-			{0, 0},
-			{1, 0},
-			{dt - 1, 0},
-			{dt + 1, lpMinCurrent},
+		{false, -500, 0, []se{
+			{-500, 0, 0},
+			{-500, 1, 0},
+			{-500, dt - 1, 0},
+			{-500, dt + 1, lpMinCurrent},
 		}},
 		// keep enabled at max
-		{true, -16 * 100 * 10, 500, 0, []se{
-			{0, lpMaxCurrent},
-			{1, lpMaxCurrent},
-			{dt - 1, lpMaxCurrent},
-			{dt + 1, lpMaxCurrent},
+		{true, 500, 0, []se{
+			{-16 * 100 * 10, 0, lpMaxCurrent},
+			{-16 * 100 * 10, 1, lpMaxCurrent},
+			{-16 * 100 * 10, dt - 1, lpMaxCurrent},
+			{-16 * 100 * 10, dt + 1, lpMaxCurrent},
 		}},
 		// keep enabled at min
-		{true, -6 * 100 * 10, 500, 0, []se{
-			{0, lpMinCurrent},
-			{1, lpMinCurrent},
-			{dt - 1, lpMinCurrent},
-			{dt + 1, lpMinCurrent},
+		{true, 500, 0, []se{
+			{-6 * 100 * 10, 0, lpMinCurrent},
+			{-6 * 100 * 10, 1, lpMinCurrent},
+			{-6 * 100 * 10, dt - 1, lpMinCurrent},
+			{-6 * 100 * 10, dt + 1, lpMinCurrent},
 		}},
 		// keep enabled at min (negative threshold)
-		{true, -500, 0, 500, []se{
-			{0, lpMinCurrent},
-			{1, lpMinCurrent},
-			{dt - 1, lpMinCurrent},
-			{dt + 1, lpMinCurrent},
+		{true, 0, 500, []se{
+			{-500, 0, lpMinCurrent},
+			{-500, 1, lpMinCurrent},
+			{-500, dt - 1, lpMinCurrent},
+			{-500, dt + 1, lpMinCurrent},
 		}},
 		// disable when threshold met
-		{true, 500, 0, 500, []se{
-			{0, lpMinCurrent},
-			{1, lpMinCurrent},
-			{dt - 1, lpMinCurrent},
-			{dt + 1, 0},
+		{true, 0, 500, []se{
+			{500, 0, lpMinCurrent},
+			{500, 1, lpMinCurrent},
+			{500, dt - 1, lpMinCurrent},
+			{500, dt + 1, 0},
 		}},
 	}
 
@@ -441,14 +442,14 @@ func TestPVHysteresis(t *testing.T) {
 					Delay:     dt,
 				},
 			},
-			gridPower: tc.site,
+			gridPower: 0,
 		}
 
 		start := clck.Now()
-		_ = lp.maxCurrent(api.ModePV)
 
 		for step, se := range tc.series {
 			clck.Set(start.Add(se.delay))
+			lp.gridPower = se.site
 			current := lp.maxCurrent(api.ModePV)
 
 			if current != se.current {

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -417,6 +417,24 @@ func TestPVHysteresis(t *testing.T) {
 			{500, dt - 1, lpMinCurrent},
 			{500, dt + 1, 0},
 		}},
+		// reset enable timer during threshold not met
+		{false, 500, 0, []se{
+			{-500, 0, 0},
+			{-500, 1, 0},
+			{-499, dt - 1, 0}, // should reset timer
+			{-500, dt + 1, 0}, // new begin of timer
+			{-500, 2 * dt, 0},
+			{-500, 2 * dt + 2, lpMinCurrent},
+		}},
+		// reset disable timer during threshold not met
+		{true, 0, 500, []se{
+			{500, 0, lpMinCurrent},
+			{500, 1, lpMinCurrent},
+			{499, dt - 1, lpMinCurrent}, // should reset timer
+			{500, dt + 1, lpMinCurrent}, // new begin of timer
+			{500, 2 * dt, lpMinCurrent},
+			{500, 2 * dt + 2, 0},
+		}},
 	}
 
 	for _, tc := range tc {


### PR DESCRIPTION
Testcase für enable/disable Timer. Up to now those tests fail.
I do not know if intervall time is used for testing, this could lead to additional errors if in range of 10sec or above.