### PR TITLE
Add CurrentPower and TotalEnergy back into Mobile Charger Connect

### DIFF
--- a/charger/mcc.go
+++ b/charger/mcc.go
@@ -19,6 +19,7 @@ const (
 	apiRefresh                 apiFunction = "jwt/refresh"
 	apiChargeState             apiFunction = "v1/api/WebServer/properties/chargeState"
 	apiCurrentSession          apiFunction = "v1/api/WebServer/properties/swaggerCurrentSession"
+	apiEnergy                  apiFunction = "v1/api/iCAN/properties/propjIcanEnergy"
 	apiSetCurrentLimit         apiFunction = "v1/api/SCC/properties/propHMICurrentLimit?value="
 	apiCurrentCableInformation apiFunction = "v1/api/SCC/properties/json_CurrentCableInformation"
 )
@@ -302,6 +303,24 @@ func (mcc *MobileConnect) MaxCurrent(current int64) error {
 	}
 
 	return nil
+}
+
+// CurrentPower implements the Meter interface.
+func (mcc *MobileConnect) CurrentPower() (float64, error) {
+	var energy MCCEnergy
+	err := mcc.getEscapedJSON(mcc.apiURL(apiEnergy), &energy)
+
+	return energy.L1.Power + energy.L2.Power + energy.L3.Power, err
+}
+
+// ChargedEnergy implements the ChargeRater interface.
+func (mcc *MobileConnect) ChargedEnergy() (float64, error) {
+	var currentSession MCCCurrentSession
+	if err := mcc.getEscapedJSON(mcc.apiURL(apiCurrentSession), &currentSession); err != nil {
+		return 0, err
+	}
+
+	return currentSession.EnergySumKwh, nil
 }
 
 // ChargingTime yields current charge run duration

--- a/charger/mcc_test.go
+++ b/charger/mcc_test.go
@@ -237,6 +237,81 @@ func TestMobileConnect_MaxCurrent(t *testing.T) {
 	}
 }
 
+func TestMobileConnect_CurrentPower(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses []apiResponse
+		want      float64
+		wantErr   bool
+	}{
+		// test cases for software version 2914
+		{
+			"home plug - charging",
+			[]apiResponse{
+				{apiEnergy, "\"{\\n    \\\"L1\\\": {\\n        \\\"Ampere\\\": 9.9000000000000004,\\n        \\\"Power\\\": 2308,\\n        \\\"Volts\\\": 230.5\\n    },\\n    \\\"L2\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 13.700000000000001\\n    },\\n    \\\"L3\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 13.9\\n    }\\n}\\n\""},
+			},
+			2308, false,
+		},
+		{
+			"home plug - error response",
+			[]apiResponse{
+				{apiEnergy, "\"{\\n    \\\"L1\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 246.60000000000002\\n    },\\n    \\\"L2\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 16.800000000000001\\n    },\\n    \\\"L3\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 16.300000000000001\\n    }\\n}\\n\""},
+			}, 0, false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mcc := NewTestMobileConnect(t, tc.responses)
+
+			got, err := mcc.CurrentPower()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("MobileConnect.CurrentPower() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("MobileConnect.CurrentPower() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMobileConnect_ChargedEnergy(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses []apiResponse
+		want      float64
+		wantErr   bool
+	}{
+		// test cases for software version 2914
+		{
+			"valid response",
+			[]apiResponse{
+				{apiCurrentSession, "\"{\\n    \\\"account\\\": \\\"PRIVATE\\\",\\n    \\\"chargingRate\\\": 0,\\n    \\\"chargingType\\\": \\\"AC\\\",\\n    \\\"clockSrc\\\": \\\"NTP\\\",\\n    \\\"costs\\\": 0,\\n    \\\"currency\\\": \\\"\\\",\\n    \\\"departTime\\\": \\\"\\\",\\n    \\\"duration\\\": 30789,\\n    \\\"endOfChargeTime\\\": \\\"\\\",\\n    \\\"endSoc\\\": 0,\\n    \\\"endTime\\\": \\\"\\\",\\n    \\\"energySumKwh\\\": 18.832000000000001,\\n    \\\"evChargingRatekW\\\": 0,\\n    \\\"evTargetSoc\\\": -1,\\n    \\\"evVasAvailability\\\": false,\\n    \\\"pcid\\\": \\\"\\\",\\n    \\\"powerRange\\\": 0,\\n    \\\"selfEnergy\\\": 0,\\n    \\\"sessionId\\\": 13,\\n    \\\"soc\\\": -1,\\n    \\\"solarEnergyShare\\\": 0,\\n    \\\"startSoc\\\": 0,\\n    \\\"startTime\\\": \\\"2020-04-15T10:07:22+02:00\\\",\\n    \\\"totalRange\\\": 0,\\n    \\\"vehicleBrand\\\": \\\"\\\",\\n    \\\"vehicleModel\\\": \\\"\\\",\\n    \\\"whitelist\\\": false\\n}\\n\""},
+			}, 18.832000000000001, false,
+		},
+		{
+			"error response",
+			[]apiResponse{
+				{apiCurrentSession, "\"\""},
+			}, 0, true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mcc := NewTestMobileConnect(t, tc.responses)
+
+			got, err := mcc.ChargedEnergy()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("MobileConnect.ChargedEnergy() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("MobileConnect.ChargedEnergy() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMobileConnect_ChargingTime(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
This reverts commit fdfb8dee062ddc859769ea1b9faeb4c02f4c0807.

Previously the implementations of `CurrentPower` and `TotalEnergy` where removed from MCC as we thought it could confuse calculation of the actual charge power setting.

But leaving it out resulted in non accurate data being shown, especially when the actual charger power was lower than the chargers minimum setting.

Setting the residualPower property in the settings improved the situation. So the general implementation shouldn't be removed but rather be monitored and improved.