### PR TITLE
Improve invalid JSON responses in MCC chargers

### DIFF
--- a/charger/mcc.go
+++ b/charger/mcc.go
@@ -201,13 +201,12 @@ func (mcc *MobileConnect) getEscapedJSON(uri string, result interface{}) error {
 
 	b, err := mcc.Request(req)
 	if err == nil {
-		var s string
-		// ""\n is usually returned if no data is present, e.g. after a restart
+		var s = strings.Trim(string(b), "\n")
+
+		// "" is usually returned if no data is present, e.g. after a restart
 		// we know this is no valid json so we make sure we don't treat this as an error
-		if string(b) == "\"\"\n" {
-			return nil
-		} else {
-			if s, err = strconv.Unquote(strings.Trim(string(b), "\n")); err == nil {
+		if s != "\"\"" {
+			if s, err = strconv.Unquote(s); err == nil {
 				err = json.Unmarshal([]byte(s), &result)
 			}
 		}

--- a/charger/mcc.go
+++ b/charger/mcc.go
@@ -202,8 +202,14 @@ func (mcc *MobileConnect) getEscapedJSON(uri string, result interface{}) error {
 	b, err := mcc.Request(req)
 	if err == nil {
 		var s string
-		if s, err = strconv.Unquote(strings.Trim(string(b), "\n")); err == nil {
-			err = json.Unmarshal([]byte(s), &result)
+		// ""\n is usually returned if no data is present, e.g. after a restart
+		// we know this is no valid json so we make sure we don't treat this as an error
+		if string(b) == "\"\"\n" {
+			return nil
+		} else {
+			if s, err = strconv.Unquote(strings.Trim(string(b), "\n")); err == nil {
+				err = json.Unmarshal([]byte(s), &result)
+			}
 		}
 	}
 

--- a/charger/mcc_test.go
+++ b/charger/mcc_test.go
@@ -304,7 +304,7 @@ func TestMobileConnect_ChargedEnergy(t *testing.T) {
 		{
 			"error response",
 			[]apiResponse{
-				{mccAPICurrentSession, "\"\""},
+				{mccAPICurrentSession, "invalidjson"},
 			}, 0, true,
 		},
 	}
@@ -346,7 +346,7 @@ func TestMobileConnect_ChargingTime(t *testing.T) {
 		{
 			"error response",
 			[]apiResponse{
-				{mccAPICurrentSession, "\"\""},
+				{mccAPICurrentSession, "invalidjson"},
 			}, 0, true,
 		},
 	}

--- a/charger/mcc_test.go
+++ b/charger/mcc_test.go
@@ -253,6 +253,12 @@ func TestMobileConnect_CurrentPower(t *testing.T) {
 			2308, false,
 		},
 		{
+			"no data response",
+			[]apiResponse{
+				{mccAPIEnergy, "\"\"\n"},
+			}, 0, false,
+		},
+		{
 			"home plug - error response",
 			[]apiResponse{
 				{mccAPIEnergy, "\"{\\n    \\\"L1\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 246.60000000000002\\n    },\\n    \\\"L2\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 16.800000000000001\\n    },\\n    \\\"L3\\\": {\\n        \\\"Ampere\\\": 0,\\n        \\\"Power\\\": 0,\\n        \\\"Volts\\\": 16.300000000000001\\n    }\\n}\\n\""},
@@ -290,6 +296,12 @@ func TestMobileConnect_ChargedEnergy(t *testing.T) {
 			}, 18.832000000000001, false,
 		},
 		{
+			"no data response",
+			[]apiResponse{
+				{mccAPICurrentSession, "\"\"\n"},
+			}, 0, false,
+		},
+		{
 			"error response",
 			[]apiResponse{
 				{mccAPICurrentSession, "\"\""},
@@ -324,6 +336,12 @@ func TestMobileConnect_ChargingTime(t *testing.T) {
 			[]apiResponse{
 				{mccAPICurrentSession, "\"{\\n    \\\"account\\\": \\\"PRIVATE\\\",\\n    \\\"chargingRate\\\": 0,\\n    \\\"chargingType\\\": \\\"AC\\\",\\n    \\\"clockSrc\\\": \\\"NTP\\\",\\n    \\\"costs\\\": 0,\\n    \\\"currency\\\": \\\"\\\",\\n    \\\"departTime\\\": \\\"\\\",\\n    \\\"duration\\\": 30789,\\n    \\\"endOfChargeTime\\\": \\\"\\\",\\n    \\\"endSoc\\\": 0,\\n    \\\"endTime\\\": \\\"\\\",\\n    \\\"energySumKwh\\\": 18.832000000000001,\\n    \\\"evChargingRatekW\\\": 0,\\n    \\\"evTargetSoc\\\": -1,\\n    \\\"evVasAvailability\\\": false,\\n    \\\"pcid\\\": \\\"\\\",\\n    \\\"powerRange\\\": 0,\\n    \\\"selfEnergy\\\": 0,\\n    \\\"sessionId\\\": 13,\\n    \\\"soc\\\": -1,\\n    \\\"solarEnergyShare\\\": 0,\\n    \\\"startSoc\\\": 0,\\n    \\\"startTime\\\": \\\"2020-04-15T10:07:22+02:00\\\",\\n    \\\"totalRange\\\": 0,\\n    \\\"vehicleBrand\\\": \\\"\\\",\\n    \\\"vehicleModel\\\": \\\"\\\",\\n    \\\"whitelist\\\": false\\n}\\n\""},
 			}, 30789 * time.Second, false,
+		},
+		{
+			"no data response",
+			[]apiResponse{
+				{mccAPICurrentSession, "\"\"\n"},
+			}, 0, false,
 		},
 		{
 			"error response",


### PR DESCRIPTION
When no car is connected or no prior charging occurred after a restart, the device would return `“”\n` responses instead of expected escaped json strings.
This workaround intercepts these so the json parsing error will not propagate and spam the error logs