### PR TITLE
always cut the current instantly but raise slowly

### DIFF
--- a/core/chargerhandler.go
+++ b/core/chargerhandler.go
@@ -106,7 +106,7 @@ func (lp *ChargerHandler) rampUpDown(target int64) error {
 	if current < target {
 		step = min(current+lp.Sensitivity, target)
 	} else if current > target {
-		step = max(current-lp.Sensitivity, target)
+		step = target
 	}
 
 	step = clamp(step, lp.MinCurrent, lp.MaxCurrent)


### PR DESCRIPTION
This mainly reduces grid import when other loads are switched on or on cloudy weather conditions.
Maybe this needs to be configurable in other usage scenarios or other charger/vehicle combinations.