### PR TITLE
Close modbus connection if operation fails to reestablish connection

### DIFF
--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -105,7 +105,9 @@ func (m *Modbus) floatGetter(op modbus.Operation) (float64, error) {
 		}
 	}
 
-	if err == nil {
+	if err != nil {
+		m.conn.Close() // close connection in case of modbus error
+	} else {
 		m.log.TRACE.Printf("%+v", res)
 	}
 

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -124,6 +124,7 @@ func (m *Modbus) FloatGetter() (float64, error) {
 		}
 
 		if err != nil {
+			m.conn.Close() // close connection in case of modbus error
 			return 0, errors.Wrap(err, "read failed")
 		}
 
@@ -144,7 +145,9 @@ func (m *Modbus) FloatGetter() (float64, error) {
 		}
 	}
 
-	if err == nil {
+	if err != nil {
+		m.conn.Close() // close connection in case of modbus error
+	} else {
 		m.log.TRACE.Printf("%+v", res)
 	}
 


### PR DESCRIPTION
Fixes a problem where meter reading doesn't recover from i/o timeout.