### PR TITLE
Allow accessing SunSpec subdevices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,9 +32,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0
-	github.com/spf13/viper v1.7.0
+	github.com/spf13/viper v1.7.1
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
-	github.com/volkszaehler/mbmd v0.0.0-20200802164800-51eb643c23c6
+	github.com/volkszaehler/mbmd v0.0.0-20200804054214-122815825570
 	github.com/yuin/goldmark v1.1.32
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6

--- a/go.sum
+++ b/go.sum
@@ -345,6 +345,8 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/spf13/viper v1.6.3/go.mod h1:jUMtyi0/lB5yZH/FjyGAoH7IMNrIhlBf6pXZmbMDvzw=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
+github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -370,8 +372,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/volkszaehler/mbmd v0.0.0-20200717102329-c4d965bd1eac h1:LnvR04M0HuzjTbRzMpE5jRHcNu46CvG1FOtMcZAX8C4=
 github.com/volkszaehler/mbmd v0.0.0-20200717102329-c4d965bd1eac/go.mod h1:sldLyJCKVO9GQkit55U5WPNr9U4KmUn1SCdqFN9Gjb4=
-github.com/volkszaehler/mbmd v0.0.0-20200802164800-51eb643c23c6 h1:cs1lwT44CyqStjTmYe0vGDhQHEaBpYZh0dgXPQLeEpY=
-github.com/volkszaehler/mbmd v0.0.0-20200802164800-51eb643c23c6/go.mod h1:sldLyJCKVO9GQkit55U5WPNr9U4KmUn1SCdqFN9Gjb4=
+github.com/volkszaehler/mbmd v0.0.0-20200804054214-122815825570 h1:3rchiOlxTpN0tmbHT29PdsnM9CTBgHPuaEMLlsdbW9I=
+github.com/volkszaehler/mbmd v0.0.0-20200804054214-122815825570/go.mod h1:siHIaeDcajqQjZ/fXHxszesqyo41sKI0YDMUzuFtk6w=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -46,7 +46,7 @@ func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
 	// prepare device
 	var device meters.Device
 	if err == nil {
-		device, err = modbus.NewDevice(cc.Model, *cc.RTU)
+		device, err = modbus.NewDevice(cc.Model, cc.SubDevice, *cc.RTU)
 	}
 
 	if err == nil {

--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -54,7 +54,7 @@ func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
 		err = device.Initialize(conn.ModbusClient())
 
 		// silence Kostal implementation errors
-		if _, partial := err.(meters.SunSpecPartiallyInitialized); partial {
+		if errors.Is(err, meters.ErrPartiallyOpened) {
 			err = nil
 		}
 	}

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -92,7 +92,7 @@ func NewModbusFromConfig(other map[string]interface{}) (*Modbus, error) {
 			err = device.Initialize(conn.ModbusClient())
 
 			// silence KOSTAL implementation errors
-			if _, partial := err.(meters.SunSpecPartiallyInitialized); partial {
+			if errors.Is(err, meters.ErrPartiallyOpened) {
 				err = nil
 			}
 		}

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -84,7 +84,7 @@ func NewModbusFromConfig(other map[string]interface{}) (*Modbus, error) {
 
 	// model configured
 	if cc.Model != "" {
-		device, err = modbus.NewDevice(cc.Model, *cc.RTU)
+		device, err = modbus.NewDevice(cc.Model, cc.SubDevice, *cc.RTU)
 
 		// prepare device
 		if err == nil {

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -20,6 +20,7 @@ type Settings struct {
 // Connection contains the ModBus connection configuration
 type Connection struct {
 	ID                  uint8
+	SubDevice           int
 	URI, Device, Comset string
 	Baudrate            int
 	RTU                 *bool // indicates RTU over TCP if true
@@ -62,11 +63,11 @@ func NewConnection(uri, device, comset string, baudrate int, rtu bool) (conn met
 }
 
 // NewDevice creates physical modbus device from config
-func NewDevice(model string, isRS485 bool) (device meters.Device, err error) {
+func NewDevice(model string, subdevice int, isRS485 bool) (device meters.Device, err error) {
 	if isRS485 {
 		device, err = rs485.NewDevice(strings.ToUpper(model))
 	} else {
-		device = sunspec.NewDevice(strings.ToUpper(model))
+		device = sunspec.NewDevice(strings.ToUpper(model), subdevice)
 	}
 
 	if device == nil {


### PR DESCRIPTION
With this PR, modbus meters attached to grid inverters become accessible as secondary devices