### PR TITLE
Esimate soc between soc reads from vehicle api, refs #255

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -241,6 +241,7 @@ loadpoints:
   targetSoC: 100 # charge to 100%
   soc:
     alwaysUpdate: false # set true to update vehicle soc even when disconnected
+    estimate: false # set true to calculate soc during cache time
     levels: # target soc levels for UI
     - 30
     - 50


### PR DESCRIPTION
Eine einfache Implementierung zur Berechnung des SoC zwischen den Lesezugriffen auf die Auto-API.
PR zur Diskussion.
