### PR TITLE
Verbesserte Prognosen / Wirkungsgrad

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -28,6 +28,13 @@ const (
 	minActiveCurrent = 1.0 // minimum current at which a phase is treated as active
 )
 
+type SoCConfig struct {
+	AlwaysUpdate bool    `mapstructure:"alwaysUpdate"`
+	Levels       []int   `mapstructure:"levels"`
+	Estimate     bool    `mapstructure:"estimate"`
+	Efficiency   float64 `mapstructure:"efficiency"`
+}
+
 // ThresholdConfig defines enable/disable hysteresis parameters
 type ThresholdConfig struct {
 	Delay     time.Duration
@@ -56,16 +63,11 @@ type LoadPoint struct {
 	Meters     struct {
 		ChargeMeterRef string `mapstructure:"charge"` // Charge meter reference
 	}
-	SoC struct {
-		AlwaysUpdate bool    `mapstructure:"alwaysUpdate"`
-		Levels       []int   `mapstructure:"levels"`
-		Estimate     bool    `mapstructure:"estimate"`
-		Efficiency   float64 `mapstructure:"efficiency"`
-	}
 	OnDisconnect struct {
 		Mode      api.ChargeMode `mapstructure:"mode"`      // Charge mode to apply when car disconnected
 		TargetSoC int            `mapstructure:"targetSoC"` // Target SoC to apply when car disconnected
 	}
+	SoC             SoCConfig
 	Enable, Disable ThresholdConfig
 
 	handler       Handler
@@ -151,6 +153,9 @@ func NewLoadPoint(log *util.Logger) *LoadPoint {
 		Mode:   api.ModeOff,
 		Phases: 1,
 		status: api.StatusNone,
+		SoC: SoCConfig{
+			Efficiency: 0.9,
+		},
 		HandlerConfig: HandlerConfig{
 			MinCurrent:    6,  // A
 			MaxCurrent:    16, // A

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -57,9 +57,10 @@ type LoadPoint struct {
 		ChargeMeterRef string `mapstructure:"charge"` // Charge meter reference
 	}
 	SoC struct {
-		AlwaysUpdate bool  `mapstructure:"alwaysUpdate"`
-		Levels       []int `mapstructure:"levels"`
-		Estimate     bool  `mapstructure:"estimate"`
+		AlwaysUpdate bool    `mapstructure:"alwaysUpdate"`
+		Levels       []int   `mapstructure:"levels"`
+		Estimate     bool    `mapstructure:"estimate"`
+		Efficiency   float64 `mapstructure:"efficiency"`
 	}
 	OnDisconnect struct {
 		Mode      api.ChargeMode `mapstructure:"mode"`      // Charge mode to apply when car disconnected
@@ -114,7 +115,7 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 	}
 	if lp.VehicleRef != "" {
 		lp.vehicle = cp.Vehicle(lp.VehicleRef)
-		lp.socEstimator = wrapper.NewSocEstimator(log, lp.vehicle, lp.SoC.Estimate)
+		lp.socEstimator = wrapper.NewSocEstimator(log, lp.vehicle, lp.SoC.Estimate, lp.SoC.Efficiency)
 	}
 
 	if lp.ChargerRef == "" {

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -375,7 +375,7 @@ func TestDisableAndEnableAtTargetSoC(t *testing.T) {
 
 	// wrap vehicle with estimator
 	vehicle.EXPECT().Capacity().Return(int64(10))
-	socEstimator := wrapper.NewSocEstimator(util.NewLogger("foo"), vehicle, false)
+	socEstimator := wrapper.NewSocEstimator(util.NewLogger("foo"), vehicle, false, 1.0)
 
 	lp := &LoadPoint{
 		log:         util.NewLogger("foo"),

--- a/core/wrapper/socestimator.go
+++ b/core/wrapper/socestimator.go
@@ -16,6 +16,8 @@ type SocEstimator struct {
 	estimate bool
 
 	capacity          float64 // vehicle capacity in Wh cached to simplify testing
+	virtualCapacity   float64 // estimated virtual vehicle capacity in Wh
+	efficiency        float64 // efficiency of stored energy to charged energy
 	socCharge         float64 // estimated vehicle SoC
 	prevSoC           float64 // previous vehicle SoC in %
 	prevChargedEnergy float64 // previous charged energy in Wh
@@ -23,11 +25,12 @@ type SocEstimator struct {
 }
 
 // NewSocEstimator creates new estimator
-func NewSocEstimator(log *util.Logger, vehicle api.Vehicle, estimate bool) *SocEstimator {
+func NewSocEstimator(log *util.Logger, vehicle api.Vehicle, estimate bool, efficiency float64) *SocEstimator {
 	s := &SocEstimator{
-		log:      log,
-		vehicle:  vehicle,
-		estimate: estimate,
+		log:        log,
+		vehicle:    vehicle,
+		estimate:   estimate,
+		efficiency: efficiency,
 	}
 
 	s.Reset()
@@ -40,7 +43,8 @@ func (s *SocEstimator) Reset() {
 	s.prevSoC = 0
 	s.prevChargedEnergy = 0
 	s.capacity = float64(s.vehicle.Capacity()) * 1e3 // cache to simplify debugging
-	s.energyPerSocStep = s.capacity / 100
+	s.virtualCapacity = s.capacity / s.efficiency
+	s.energyPerSocStep = s.virtualCapacity / 100
 }
 
 // RemainingChargeDuration returns the remaining duration estimate based on SoC, target and charge power
@@ -51,7 +55,7 @@ func (s *SocEstimator) RemainingChargeDuration(chargePower float64, targetSoC in
 			return 0
 		}
 
-		whRemaining := percentRemaining / 100 * s.capacity
+		whRemaining := percentRemaining / 100 * s.virtualCapacity
 		return time.Duration(float64(time.Hour) * whRemaining / chargePower).Round(time.Second)
 	}
 
@@ -75,14 +79,15 @@ func (s *SocEstimator) SoC(chargedEnergy float64) (float64, error) {
 			// calculate gradient, wh per soc %
 			if socDelta > 1 && energyDelta > 0 && s.prevSoC > 0 {
 				s.energyPerSocStep = energyDelta / socDelta
-				s.log.TRACE.Printf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualBatCap: %0.1fkWh", s.energyPerSocStep, s.energyPerSocStep*100/1e3)
+				s.virtualCapacity = s.energyPerSocStep * 100 / 1e3
+				s.log.TRACE.Printf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualBatCap: %0.1fkWh", s.energyPerSocStep, s.virtualCapacity)
 			}
 
 			// sample charged energy at soc change, reset energy delta
 			s.prevChargedEnergy = math.Max(chargedEnergy, 0)
 			s.prevSoC = s.socCharge
 		} else {
-			s.socCharge = math.Min(f + energyDelta / s.energyPerSocStep, 100)
+			s.socCharge = math.Min(f+energyDelta/s.energyPerSocStep, 100)
 			s.log.TRACE.Printf("soc estimated: %.2f%% (vehicle: %.2f%%)", s.socCharge, f)
 		}
 	}

--- a/core/wrapper/socestimator.go
+++ b/core/wrapper/socestimator.go
@@ -66,7 +66,11 @@ func (s *SocEstimator) RemainingChargeDuration(chargePower float64, targetSoC in
 func (s *SocEstimator) SoC(chargedEnergy float64) (float64, error) {
 	f, err := s.vehicle.ChargeState()
 	if err != nil {
-		return s.socCharge, err
+		// try to recover from temporary vehicle-api errors
+		if s.prevSoC == 0 { // never received a soc value
+			return s.socCharge, err
+		}
+		f = s.prevSoC // recover last received soc
 	}
 
 	s.socCharge = f

--- a/core/wrapper/socestimator.go
+++ b/core/wrapper/socestimator.go
@@ -84,7 +84,7 @@ func (s *SocEstimator) SoC(chargedEnergy float64) (float64, error) {
 			if socDelta > 1 && energyDelta > 0 && s.prevSoC > 0 {
 				s.energyPerSocStep = energyDelta / socDelta
 				s.virtualCapacity = s.energyPerSocStep * 100 / 1e3
-				s.log.TRACE.Printf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualBatCap: %0.1fkWh", s.energyPerSocStep, s.virtualCapacity)
+				s.log.TRACE.Printf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualCapacity: %0.1fkWh", s.energyPerSocStep, s.virtualCapacity)
 			}
 
 			// sample charged energy at soc change, reset energy delta

--- a/core/wrapper/socestimator_test.go
+++ b/core/wrapper/socestimator_test.go
@@ -14,7 +14,7 @@ func TestRemainingChargeDuration(t *testing.T) {
 	vehicle := mock.NewMockVehicle(ctrl)
 	vehicle.EXPECT().Capacity().Return(int64(10))
 
-	ce := NewSocEstimator(util.NewLogger("foo"), vehicle, false)
+	ce := NewSocEstimator(util.NewLogger("foo"), vehicle, false, 1.0)
 	ce.socCharge = 20.0
 
 	chargePower := 1000.0
@@ -30,7 +30,7 @@ func TestSoCEstimation(t *testing.T) {
 	vehicle := mock.NewMockVehicle(ctrl)
 	vehicle.EXPECT().Capacity().Return(int64(10))
 
-	ce := NewSocEstimator(util.NewLogger("foo"), vehicle, true)
+	ce := NewSocEstimator(util.NewLogger("foo"), vehicle, true, 1.0)
 	ce.socCharge = 20.0
 
 	tc := []struct {

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -133,6 +133,7 @@ loadpoints:
   soc:
     alwaysUpdate: false # set true to update vehicle soc even when disconnected
     estimate: false # set true to interpolate between api updates
+    efficiency: 0.9 # charged to stored energy efficiency
     levels: # target soc levels for UI
     - 30
     - 50


### PR DESCRIPTION
Einführung einer neuen vehice-Konfig-Option "efficiency" die die Berücksichtigung des Wirkungsgrads zwischen geladener und tatsächlich im Fahrzeug gespeicherten Energiemenge berücksichtigt.

Im ersten Schritt wird dies erstmal nur dazu verwendet die initiale SoC-Prognose ohne API-Update sowie die Laderestzeitprognose weiter zu verbessern.

Ein typischer Defaultwert für efficiency könnte 0.9 (=90 %) sein.

Im Endeffekt wird dies genutzt um die größere virtuelle Batteriekapazität (also dass was man an Netzenergie inkl. aller Energieverluste reinstecken muss) aus der vom Nutzer angegebenen Batteriekapazität zu berechnen.