### PR TITLE
Use setCurrent of current evse firmware

### DIFF
--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -86,12 +86,7 @@ func (evse *EVSEWifi) getParameters() (EVSEListEntry, error) {
 		return EVSEListEntry{}, fmt.Errorf("unexpected response: %s", string(body))
 	}
 
-	params := pr.List[0]
-	if params.AlwaysActive {
-		evse.HTTPHelper.Log.WARN.Println("cannot control evse- alwaysactive is on")
-	}
-
-	return params, nil
+	return pr.List[0], nil
 }
 
 // Status implements the Charger.Status interface
@@ -102,6 +97,8 @@ func (evse *EVSEWifi) Status() (api.ChargeStatus, error) {
 	}
 
 	switch params.VehicleState {
+	case 0: // error
+		return api.StatusF, nil
 	case 1: // ready
 		return api.StatusA, nil
 	case 2: // EV is present
@@ -133,7 +130,7 @@ func (evse *EVSEWifi) checkError(b []byte, err error) error {
 
 // Enable implements the Charger.Enable interface
 func (evse *EVSEWifi) Enable(enable bool) error {
-	url := fmt.Sprintf("%s?active=%v", evse.apiURL(evseSetStatus), enable)
+	url := fmt.Sprintf("%s?current=%d", evse.apiURL(evseSetCurrent), 0)
 	return evse.checkError(evse.Get(url))
 }
 

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -97,8 +97,6 @@ func (evse *EVSEWifi) Status() (api.ChargeStatus, error) {
 	}
 
 	switch params.VehicleState {
-	case 0: // error
-		return api.StatusF, nil
 	case 1: // ready
 		return api.StatusA, nil
 	case 2: // EV is present
@@ -110,7 +108,7 @@ func (evse *EVSEWifi) Status() (api.ChargeStatus, error) {
 	case 5: // failure (e.g. diode check, RCD failure)
 		return api.StatusE, nil
 	default:
-		return api.StatusNone, errors.New("invalid response")
+		return api.StatusNone, fmt.Errorf("invalid status: %d", params.VehicleState)
 	}
 }
 
@@ -130,7 +128,11 @@ func (evse *EVSEWifi) checkError(b []byte, err error) error {
 
 // Enable implements the Charger.Enable interface
 func (evse *EVSEWifi) Enable(enable bool) error {
-	url := fmt.Sprintf("%s?current=%d", evse.apiURL(evseSetCurrent), 0)
+	current := 0
+	if enable {
+		current = 6
+	}
+	url := fmt.Sprintf("%s?current=%d", evse.apiURL(evseSetCurrent), current)
 	return evse.checkError(evse.Get(url))
 }
 


### PR DESCRIPTION
Fix #280

/cc @schenlap könnte das so passen? Bin unsicher ob der `Enabled` Status richtig gelesen wird? Da müssten wir sonst experimentieren oder der in jedem Modus z.B. aus `maxCurrent` gelesen werden könnte?

Könntest Du testen/bestätigen ob das jetzt auch unabhängig von EVSE Modus funktioniert?