### PR TITLE
Use generator to simplify interface composition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ clean:
 	rm -rf dist/
 
 install:
-	go install golang.org/x/tools/cmd/stringer
 	go install github.com/mjibson/esc
 	go install github.com/golang/mock/mockgen
 

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -91,9 +91,8 @@ func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {
 // NewEVSEWifi creates EVSEWifi charger
 func NewEVSEWifi(uri string) (*EVSEWifi, error) {
 	evse := &EVSEWifi{
-		HTTPHelper:   util.NewHTTPHelper(util.NewLogger("wifi")),
-		uri:          strings.TrimRight(uri, "/"),
-		alwaysActive: true,
+		HTTPHelper: util.NewHTTPHelper(util.NewLogger("wifi")),
+		uri:        strings.TrimRight(uri, "/"),
 	}
 
 	return evse, nil

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -54,14 +54,14 @@ func init() {
 	registry.Add("evsewifi", NewEVSEWifiFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -p charger -b api.Charger -o evsewifi_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p charger -b api.Charger -o evsewifi_decorators -t "api.Meter,CurrentPower,func() (float64, error)" -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
 
 // NewEVSEWifiFromConfig creates a EVSEWifi charger from generic config
 func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
 		URI   string
 		Meter struct {
-			Energy, Currents bool
+			Power, Energy, Currents bool
 		}
 	}{}
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -71,6 +71,12 @@ func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {
 	evse, err := NewEVSEWifi(cc.URI)
 	if err != nil {
 		return evse, err
+	}
+
+	// decorate Charger with Meter
+	var currentPower func() (float64, error)
+	if cc.Meter.Power {
+		currentPower = evse.currentPower
 	}
 
 	// decorate Charger with MeterEnergy
@@ -85,7 +91,7 @@ func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {
 		currents = evse.currents
 	}
 
-	return decorate(evse, totalEnergy, currents), nil
+	return decorate(evse, currentPower, totalEnergy, currents), nil
 }
 
 // NewEVSEWifi creates EVSEWifi charger
@@ -185,6 +191,12 @@ func (evse *EVSEWifi) MaxCurrent(current int64) error {
 func (evse *EVSEWifi) ChargingTime() (time.Duration, error) {
 	params, err := evse.getParameters()
 	return time.Duration(params.Duration) * time.Millisecond, err
+}
+
+// CurrentPower implements the Meter interface
+func (evse *EVSEWifi) currentPower() (float64, error) {
+	params, err := evse.getParameters()
+	return params.ActualPower, err
 }
 
 // TotalEnergy implements the MeterEnergy interface

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -54,7 +54,7 @@ func init() {
 	registry.Add("evsewifi", NewEVSEWifiFromConfig)
 }
 
-//go:generate go run github.com/andig/evcc/cmd/tools/decorate.go -p charger -b api.Charger -o evsewifi_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p charger -b api.Charger -o evsewifi_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
 
 // NewEVSEWifiFromConfig creates a EVSEWifi charger from generic config
 func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -46,7 +46,7 @@ type EVSEListEntry struct {
 // EVSEWifi charger implementation
 type EVSEWifi struct {
 	*util.HTTPHelper
-	uri string
+	uri          string
 	alwaysActive bool
 }
 
@@ -54,22 +54,46 @@ func init() {
 	registry.Add("evsewifi", NewEVSEWifiFromConfig)
 }
 
+//go:generate go run github.com/andig/evcc/cmd/tools/decorate.go -p charger -b api.Charger -o evsewifi_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+
 // NewEVSEWifiFromConfig creates a EVSEWifi charger from generic config
 func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {
-	cc := struct{ URI string }{}
+	cc := struct {
+		URI   string
+		Meter struct {
+			Energy, Currents bool
+		}
+	}{}
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewEVSEWifi(cc.URI)
+	evse, err := NewEVSEWifi(cc.URI)
+	if err != nil {
+		return evse, err
+	}
+
+	// decorate Charger with MeterEnergy
+	var energyDeco func() (float64, error)
+	if cc.Meter.Energy {
+		energyDeco = evse.totalEnergy
+	}
+
+	// decorate Charger with MeterCurrent
+	var currentsDeco func() (float64, float64, float64, error)
+	if cc.Meter.Currents {
+		currentsDeco = evse.currents
+	}
+
+	return decorate(evse, energyDeco, currentsDeco), nil
 }
 
 // NewEVSEWifi creates EVSEWifi charger
-func NewEVSEWifi(uri string) (api.Charger, error) {
+func NewEVSEWifi(uri string) (*EVSEWifi, error) {
 	evse := &EVSEWifi{
-		HTTPHelper:        util.NewHTTPHelper(util.NewLogger("wifi")),
-		uri:               strings.TrimRight(uri, "/"),
-		alwaysActive:      true,
+		HTTPHelper:   util.NewHTTPHelper(util.NewLogger("wifi")),
+		uri:          strings.TrimRight(uri, "/"),
+		alwaysActive: true,
 	}
 
 	return evse, nil
@@ -164,20 +188,20 @@ func (evse *EVSEWifi) ChargingTime() (time.Duration, error) {
 	return time.Duration(params.Duration) * time.Millisecond, err
 }
 
-// // TotalEnergy implements the MeterEnergy interface
-// func (evse *EVSEWifi) TotalEnergy() (float64, error) {
-// 	params, err := evse.getParameters()
-// 	return params.MeterReading, err
-// }
+// TotalEnergy implements the MeterEnergy interface
+func (evse *EVSEWifi) totalEnergy() (float64, error) {
+	params, err := evse.getParameters()
+	return params.MeterReading, err
+}
+
+// Currents implements the MeterCurrents interface
+func (evse *EVSEWifi) currents() (float64, float64, float64, error) {
+	params, err := evse.getParameters()
+	return float64(params.CurrentP1), float64(params.CurrentP2), float64(params.CurrentP3), err
+}
 
 // // ChargedEnergy implements the ChargeRater interface
 // func (evse *EVSEWifi) ChargedEnergy() (float64, error) {
 // 	params, err := evse.getParameters()
 // 	return params.Energy, err
-// }
-
-// // Currents implements the MeterCurrents interface
-// func (evse *EVSEWifi) Currents() (float64, float64, float64, error) {
-// 	params, err := evse.getParameters()
-// 	return float64(params.CurrentP1), float64(params.CurrentP2), float64(params.CurrentP3), err
 // }

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -74,18 +74,18 @@ func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {
 	}
 
 	// decorate Charger with MeterEnergy
-	var energyDeco func() (float64, error)
+	var totalEnergy func() (float64, error)
 	if cc.Meter.Energy {
-		energyDeco = evse.totalEnergy
+		totalEnergy = evse.totalEnergy
 	}
 
 	// decorate Charger with MeterCurrent
-	var currentsDeco func() (float64, float64, float64, error)
+	var currents func() (float64, float64, float64, error)
 	if cc.Meter.Currents {
-		currentsDeco = evse.currents
+		currents = evse.currents
 	}
 
-	return decorate(evse, energyDeco, currentsDeco), nil
+	return decorate(evse, totalEnergy, currents), nil
 }
 
 // NewEVSEWifi creates EVSEWifi charger

--- a/charger/evsewifi_decorators.go
+++ b/charger/evsewifi_decorators.go
@@ -17,7 +17,7 @@ func decorate(base api.Charger, meterEnergy func() (float64, error), meterCurren
 			api.MeterEnergy
 		}{
 			Charger: base,
-			MeterEnergy: &meterEnergyImpl{
+			MeterEnergy: &decorateMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -28,7 +28,7 @@ func decorate(base api.Charger, meterEnergy func() (float64, error), meterCurren
 			api.MeterCurrent
 		}{
 			Charger: base,
-			MeterCurrent: &meterCurrentImpl{
+			MeterCurrent: &decorateMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
 		}
@@ -40,10 +40,10 @@ func decorate(base api.Charger, meterEnergy func() (float64, error), meterCurren
 			api.MeterEnergy
 		}{
 			Charger: base,
-			MeterCurrent: &meterCurrentImpl{
+			MeterCurrent: &decorateMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
-			MeterEnergy: &meterEnergyImpl{
+			MeterEnergy: &decorateMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -52,18 +52,18 @@ func decorate(base api.Charger, meterEnergy func() (float64, error), meterCurren
 	return nil
 }
 
-type meterCurrentImpl struct {
+type decorateMeterCurrentImpl struct {
 	meterCurrent func() (float64, float64, float64, error)
 }
 
-func (impl *meterCurrentImpl) Currents() (float64, float64, float64, error) {
+func (impl *decorateMeterCurrentImpl) Currents() (float64, float64, float64, error) {
 	return impl.meterCurrent()
 }
 
-type meterEnergyImpl struct {
+type decorateMeterEnergyImpl struct {
 	meterEnergy func() (float64, error)
 }
 
-func (impl *meterEnergyImpl) TotalEnergy() (float64, error) {
+func (impl *decorateMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
 }

--- a/charger/evsewifi_decorators.go
+++ b/charger/evsewifi_decorators.go
@@ -1,0 +1,69 @@
+package charger
+
+// This file has been generated - do not modify
+
+import (
+	"github.com/andig/evcc/api"
+)
+
+func decorate(base api.Charger, meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Charger {
+	switch {
+	case meterCurrent == nil && meterEnergy == nil:
+		return base
+
+	case meterCurrent == nil && meterEnergy != nil:
+		return &struct{
+			api.Charger
+			api.MeterEnergy
+		}{
+			Charger: base,
+			MeterEnergy: &meterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+
+	case meterCurrent != nil && meterEnergy == nil:
+		return &struct{
+			api.Charger
+			api.MeterCurrent
+		}{
+			Charger: base,
+			MeterCurrent: &meterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+		}
+
+	case meterCurrent != nil && meterEnergy != nil:
+		return &struct{
+			api.Charger
+			api.MeterCurrent
+			api.MeterEnergy
+		}{
+			Charger: base,
+			MeterCurrent: &meterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+			MeterEnergy: &meterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+	}
+
+	return nil
+}
+
+type meterCurrentImpl struct {
+	meterCurrent func() (float64, float64, float64, error)
+}
+
+func (impl *meterCurrentImpl) Currents() (float64, float64, float64, error) {
+	return impl.meterCurrent()
+}
+
+type meterEnergyImpl struct {
+	meterEnergy func() (float64, error)
+}
+
+func (impl *meterEnergyImpl) TotalEnergy() (float64, error) {
+	return impl.meterEnergy()
+}

--- a/charger/evsewifi_decorators.go
+++ b/charger/evsewifi_decorators.go
@@ -6,104 +6,44 @@ import (
 	"github.com/andig/evcc/api"
 )
 
-func decorate(base api.Charger, meter func() (float64, error), meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Charger {
+func decorateEVSE(base api.Charger, meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Charger {
 	switch {
-	case meter == nil && meterCurrent == nil && meterEnergy == nil:
+	case meterCurrent == nil && meterEnergy == nil:
 		return base
 
-	case meter != nil && meterCurrent == nil && meterEnergy == nil:
-		return &struct{
-			api.Charger
-			api.Meter
-		}{
-			Charger: base,
-			Meter: &decorateMeterImpl{
-				meter: meter,
-			},
-		}
-
-	case meter == nil && meterCurrent == nil && meterEnergy != nil:
+	case meterCurrent == nil && meterEnergy != nil:
 		return &struct{
 			api.Charger
 			api.MeterEnergy
 		}{
 			Charger: base,
-			MeterEnergy: &decorateMeterEnergyImpl{
+			MeterEnergy: &decorateEVSEMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
 
-	case meter != nil && meterCurrent == nil && meterEnergy != nil:
-		return &struct{
-			api.Charger
-			api.Meter
-			api.MeterEnergy
-		}{
-			Charger: base,
-			Meter: &decorateMeterImpl{
-				meter: meter,
-			},
-			MeterEnergy: &decorateMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-		}
-
-	case meter == nil && meterCurrent != nil && meterEnergy == nil:
+	case meterCurrent != nil && meterEnergy == nil:
 		return &struct{
 			api.Charger
 			api.MeterCurrent
 		}{
 			Charger: base,
-			MeterCurrent: &decorateMeterCurrentImpl{
+			MeterCurrent: &decorateEVSEMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
 		}
 
-	case meter != nil && meterCurrent != nil && meterEnergy == nil:
-		return &struct{
-			api.Charger
-			api.Meter
-			api.MeterCurrent
-		}{
-			Charger: base,
-			Meter: &decorateMeterImpl{
-				meter: meter,
-			},
-			MeterCurrent: &decorateMeterCurrentImpl{
-				meterCurrent: meterCurrent,
-			},
-		}
-
-	case meter == nil && meterCurrent != nil && meterEnergy != nil:
+	case meterCurrent != nil && meterEnergy != nil:
 		return &struct{
 			api.Charger
 			api.MeterCurrent
 			api.MeterEnergy
 		}{
 			Charger: base,
-			MeterCurrent: &decorateMeterCurrentImpl{
+			MeterCurrent: &decorateEVSEMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
-			MeterEnergy: &decorateMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-		}
-
-	case meter != nil && meterCurrent != nil && meterEnergy != nil:
-		return &struct{
-			api.Charger
-			api.Meter
-			api.MeterCurrent
-			api.MeterEnergy
-		}{
-			Charger: base,
-			Meter: &decorateMeterImpl{
-				meter: meter,
-			},
-			MeterCurrent: &decorateMeterCurrentImpl{
-				meterCurrent: meterCurrent,
-			},
-			MeterEnergy: &decorateMeterEnergyImpl{
+			MeterEnergy: &decorateEVSEMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -112,26 +52,18 @@ func decorate(base api.Charger, meter func() (float64, error), meterEnergy func(
 	return nil
 }
 
-type decorateMeterImpl struct {
-	meter func() (float64, error)
-}
-
-func (impl *decorateMeterImpl) CurrentPower() (float64, error) {
-	return impl.meter()
-}
-
-type decorateMeterCurrentImpl struct {
+type decorateEVSEMeterCurrentImpl struct {
 	meterCurrent func() (float64, float64, float64, error)
 }
 
-func (impl *decorateMeterCurrentImpl) Currents() (float64, float64, float64, error) {
+func (impl *decorateEVSEMeterCurrentImpl) Currents() (float64, float64, float64, error) {
 	return impl.meterCurrent()
 }
 
-type decorateMeterEnergyImpl struct {
+type decorateEVSEMeterEnergyImpl struct {
 	meterEnergy func() (float64, error)
 }
 
-func (impl *decorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+func (impl *decorateEVSEMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
 }

--- a/charger/evsewifi_test.go
+++ b/charger/evsewifi_test.go
@@ -9,6 +9,7 @@ import (
 func TestEvseWifi(t *testing.T) {
 	evse, err := NewEVSEWifiFromConfig(map[string]interface{}{
 		"meter": map[string]interface{}{
+			"power":    true,
 			"energy":   true,
 			"currents": true,
 		},
@@ -16,6 +17,10 @@ func TestEvseWifi(t *testing.T) {
 
 	if err != nil {
 		t.Error(err)
+	}
+
+	if _, ok := evse.(api.Meter); !ok {
+		t.Error("missing api.Meter")
 	}
 
 	if _, ok := evse.(api.MeterEnergy); !ok {

--- a/charger/evsewifi_test.go
+++ b/charger/evsewifi_test.go
@@ -19,10 +19,6 @@ func TestEvseWifi(t *testing.T) {
 		t.Error(err)
 	}
 
-	if _, ok := evse.(api.Meter); !ok {
-		t.Error("missing api.Meter")
-	}
-
 	if _, ok := evse.(api.MeterEnergy); !ok {
 		t.Error("missing api.MeterEnergy")
 	}

--- a/charger/evsewifi_test.go
+++ b/charger/evsewifi_test.go
@@ -1,0 +1,28 @@
+package charger
+
+import (
+	"testing"
+
+	"github.com/andig/evcc/api"
+)
+
+func TestEvseWifi(t *testing.T) {
+	evse, err := NewEVSEWifiFromConfig(map[string]interface{}{
+		"meter": map[string]interface{}{
+			"energy":   true,
+			"currents": true,
+		},
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if _, ok := evse.(api.MeterEnergy); !ok {
+		t.Error("missing api.MeterEnergy")
+	}
+
+	if _, ok := evse.(api.MeterCurrent); !ok {
+		t.Error("missing api.MeterCurrent")
+	}
+}

--- a/cmd/tools/decorate.go
+++ b/cmd/tools/decorate.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package main
 
 import (

--- a/cmd/tools/decorate.go
+++ b/cmd/tools/decorate.go
@@ -26,30 +26,42 @@ import (
 {{- $combo := .Combo}}
 {{- $prefix := .Prefix}}
 {{- $idx := 0}}
-	case{{range $typ, $def := .Types}}{{if gt $idx 0}} &&{{else}}{{$idx = 1}}{{end}} {{$def.VarName}} {{if contains $combo $typ}}!={{else}}=={{end}} nil{{end}}:
+	case {{- range $typ, $def := .Types}}
+		{{- if gt $idx 0}} &&{{else}}{{$idx = 1}}{{end}} {{$def.VarName}} {{if contains $combo $typ}}!={{else}}=={{end}} nil
+	{{- end}}:
 		return &struct{
 			{{.BaseType}}
-{{- range $typ, $def := .Types}}{{if contains $combo $typ}}
-			{{$typ}}{{end}}{{end}}
+{{- range $typ, $def := .Types}}
+	{{- if contains $combo $typ}}
+			{{$typ}}
+	{{- end}}
+{{- end}}
 		}{
 			{{.ShortBase}}: base,
-{{- range $typ, $def := .Types}}{{if contains $combo $typ}}
+{{- range $typ, $def := .Types}}
+	{{- if contains $combo $typ}}
 			{{$def.ShortType}}: &{{$prefix}}{{$def.ShortType}}Impl{
 				{{$def.VarName}}: {{$def.VarName}},
-			},{{end}}{{end}}
+			},
+	{{- end}}
+{{- end}}
 		}
 {{end -}}
 
 func {{.Function}}(base {{.BaseType}}{{range ordered}}, {{.VarName}} func() {{slice .Signature 7}}{{end}}) {{.BaseType}} {
-	switch {
 {{- $basetype := .BaseType}}
 {{- $shortbase := .ShortBase}}
 {{- $prefix := .Function}}
 {{- $types := .Types}}
 {{- $idx := 0}}
-	case{{range $typ, $def := .Types}}{{if gt $idx 0}} &&{{else}}{{$idx = 1}}{{end}} {{$def.VarName}} == nil{{end}}:
+	switch {
+	case {{- range $typ, $def := .Types}}
+		{{- if gt $idx 0}} &&{{else}}{{$idx = 1}}{{end}} {{$def.VarName}} == nil
+	{{- end}}:
 		return base
-{{range $combo := .Combinations}}{{template "case" dict "BaseType" $basetype "Prefix" $prefix "ShortBase" $shortbase "Types" $types "Combo" $combo}}{{end}}	}
+{{range $combo := .Combinations}}
+	{{- template "case" dict "BaseType" $basetype "Prefix" $prefix "ShortBase" $shortbase "Types" $types "Combo" $combo -}}
+{{end}}	}
 
 	return nil
 }

--- a/cmd/tools/decorate.go
+++ b/cmd/tools/decorate.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	combinations "github.com/mxschmitt/golang-combinations"
+	"github.com/spf13/pflag"
+)
+
+var srcTmpl = `
+package {{.Package}}
+
+// This file has been generated - do not modify
+
+import (
+	"{{.API}}"
+)
+
+{{define "case"}}
+{{- $combo := .Combo}}
+{{- $idx := 0}}
+	case{{range $typ, $def := .Types}}{{if gt $idx 0}} &&{{else}}{{$idx = 1}}{{end}} {{$def.VarName}} {{if contains $combo $typ}}!={{else}}=={{end}} nil{{end}}:
+		return &struct{
+			{{.BaseType}}
+{{- range $typ, $def := .Types}}{{if contains $combo $typ}}
+			{{$typ}}{{end}}{{end}}
+		}{
+			Meter: base,
+{{- range $typ, $def := .Types}}{{if contains $combo $typ}}
+			{{$def.ShortType}}: &{{$def.VarName}}Impl{
+				{{$def.VarName}}: {{$def.VarName}},
+			},{{end}}{{end}}
+		}
+{{end -}}
+
+func decorate(base {{.BaseType}}{{range ordered}}, {{.VarName}} func() {{slice .Signature 7}}{{end}}) {{.BaseType}} {
+	switch {
+{{- $basetype := .BaseType}}
+{{- $types := .Types}}
+{{- $idx := 0}}
+	case{{range $typ, $def := .Types}}{{if gt $idx 0}} &&{{else}}{{$idx = 1}}{{end}} {{$def.VarName}} == nil{{end}}:
+		return base
+{{range $combo := .Combinations}}{{template "case" dict "BaseType" $basetype "Types" $types "Combo" $combo}}{{end}}	}
+
+	return nil
+}
+
+{{range .Types}}type {{.VarName}}Impl struct {
+	{{.VarName}} {{.Signature}}
+}
+
+func (impl *{{.VarName}}Impl) {{.Function}}{{slice .Signature 4}} {
+	return impl.{{.VarName}}()
+}
+
+{{end}}
+`
+
+type dynamicType struct {
+	typ, function, signature string
+}
+
+type typeStruct struct {
+	Type, ShortType, Signature, Function, VarName string
+}
+
+func generate(baseType string, dynamicTypes ...dynamicType) {
+	types := make(map[string]typeStruct, len(dynamicTypes))
+	combos := make([]string, 0)
+
+	tmpl, err := template.New("gen").Funcs(template.FuncMap{
+		// dict combines key value pairs for passing structs into templates
+		"dict": func(values ...interface{}) (map[string]interface{}, error) {
+			if len(values)%2 != 0 {
+				return nil, errors.New("invalid dict call")
+			}
+			dict := make(map[string]interface{}, len(values)/2)
+			for i := 0; i < len(values); i += 2 {
+				key, ok := values[i].(string)
+				if !ok {
+					return nil, errors.New("dict keys must be strings")
+				}
+				dict[key] = values[i+1]
+			}
+			return dict, nil
+		},
+		// contains checks if slice contains string
+		"contains": func(combo []string, typ string) bool {
+			for _, v := range combo {
+				if v == typ {
+					return true
+				}
+			}
+			return false
+		},
+		// ordered checks if slice ordered string
+		"ordered": func() []typeStruct {
+			ordered := make([]typeStruct, 0)
+			for _, k := range dynamicTypes {
+				ordered = append(ordered, types[k.typ])
+			}
+
+			return ordered
+		},
+	}).Parse(srcTmpl)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, dt := range dynamicTypes {
+		parts := strings.SplitN(dt.typ, ".", 2)
+		varName := strings.ToLower(parts[1][:1]) + parts[1][1:]
+
+		types[dt.typ] = typeStruct{
+			Type:      dt.typ,
+			ShortType: parts[1],
+			Signature: dt.signature,
+			Function:  dt.function,
+			VarName:   varName,
+		}
+
+		combos = append(combos, dt.typ)
+	}
+
+	vars := struct {
+		Package, API string
+		BaseType     string
+		Types        map[string]typeStruct
+		Combinations [][]string
+	}{
+		Package:      "meter",
+		API:          "github.com/andig/evcc/api",
+		BaseType:     baseType,
+		Types:        types,
+		Combinations: combinations.All(combos),
+	}
+
+	tmpl.Execute(os.Stdout, vars)
+}
+
+var (
+	base  = pflag.StringP("base", "b", "", "base type")
+	types = pflag.StringArrayP("type", "t", nil, "comma-separated list of type definitions")
+)
+
+// Usage prints flags usage
+func Usage() {
+	fmt.Fprintf(os.Stderr, "Usage of decorate:\n")
+	fmt.Fprintf(os.Stderr, "\ndecorate [flags] -type interface,interface function,function signature\n")
+	fmt.Fprintf(os.Stderr, "\nFlags:\n")
+	pflag.PrintDefaults()
+}
+
+func main() {
+	// generate("api.Meter", []dynamicType{
+	// 	dynamicType{"api.MeterEnergy", "TotalEnergy", "func() (float64, error)"},
+	// 	dynamicType{"api.MeterCurrent", "Currents", "func() (float64, float64, float64, error)"},
+	// }...)
+	pflag.Usage = Usage
+	pflag.Parse()
+
+	if *base == "" || len(*types) == 0 {
+		Usage()
+		os.Exit(2)
+	}
+
+	var dynamicTypes []dynamicType
+	for _, v := range *types {
+		split := strings.SplitN(v, ",", 3)
+		dt := dynamicType{split[0], split[1], split[2]}
+		dynamicTypes = append(dynamicTypes, dt)
+	}
+
+	generate(*base, dynamicTypes...)
+}

--- a/cmd/tools/decorate.go
+++ b/cmd/tools/decorate.go
@@ -23,10 +23,11 @@ import (
 )
 
 {{define "case"}}
-{{- $combo := .Combo}}
-{{- $prefix := .Prefix}}
-{{- $idx := 0}}
-	case {{- range $typ, $def := .Types}}
+	{{- $combo := .Combo}}
+	{{- $prefix := .Prefix}}
+	{{- $idx := 0}}
+
+	{{- range $typ, $def := .Types}}
 		{{- if gt $idx 0}} &&{{else}}{{$idx = 1}}{{end}} {{$def.VarName}} {{if contains $combo $typ}}!={{else}}=={{end}} nil
 	{{- end}}:
 		return &struct{
@@ -46,7 +47,7 @@ import (
 	{{- end}}
 {{- end}}
 		}
-{{end -}}
+{{- end -}}
 
 func {{.Function}}(base {{.BaseType}}{{range ordered}}, {{.VarName}} func() {{slice .Signature 7}}{{end}}) {{.BaseType}} {
 {{- $basetype := .BaseType}}
@@ -60,13 +61,14 @@ func {{.Function}}(base {{.BaseType}}{{range ordered}}, {{.VarName}} func() {{sl
 	{{- end}}:
 		return base
 {{range $combo := .Combinations}}
-	{{- template "case" dict "BaseType" $basetype "Prefix" $prefix "ShortBase" $shortbase "Types" $types "Combo" $combo -}}
+	case {{- template "case" dict "BaseType" $basetype "Prefix" $prefix "ShortBase" $shortbase "Types" $types "Combo" $combo}}
 {{end}}	}
 
 	return nil
 }
 
-{{range .Types}}type {{$prefix}}{{.ShortType}}Impl struct {
+{{range .Types -}}
+type {{$prefix}}{{.ShortType}}Impl struct {
 	{{.VarName}} {{.Signature}}
 }
 

--- a/cmd/tools/decorate.go
+++ b/cmd/tools/decorate.go
@@ -147,7 +147,10 @@ func generate(out io.Writer, packageName, functionName, baseType string, dynamic
 		Combinations: combinations.All(combos),
 	}
 
-	tmpl.Execute(out, vars)
+	if err := tmpl.Execute(out, vars); err != nil {
+		println(err)
+		os.Exit(2)
+	}
 }
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/mjibson/esc v0.2.0
 	github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5
-	github.com/mxschmitt/golang-combinations v1.0.1-0.20200702132438-341af75e2cab
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/mjibson/esc v0.2.0
 	github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5
+	github.com/mxschmitt/golang-combinations v1.0.1-0.20200702132438-341af75e2cab
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -28,9 +28,11 @@ require (
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/mjibson/esc v0.2.0
 	github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5
+	github.com/mxschmitt/golang-combinations v1.0.0
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	github.com/volkszaehler/mbmd v0.0.0-20200804054214-122815825570

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,5 @@ require (
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	github.com/volkszaehler/mbmd v0.0.0-20200804054214-122815825570
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
-	golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 )

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5 h1:xnTS/7y0g28W2SJeWNLMYTiTOmfW2P/YdPByoQnPvVo=
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5/go.mod h1:yV39+EVOWdnoTe75NyKdo9iuyI3Slyh4t7eQvElUbWE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxschmitt/golang-combinations v1.0.0 h1:NFoO7CSP8MUcFlHpe1YdewKwMa15dgDbaqkVLC5DUPI=
+github.com/mxschmitt/golang-combinations v1.0.0/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da/go.mod h1:DvuJJ/w1Y59rG8UTDxsMk5U+UJXJwuvUgbiJSm9yhX8=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,10 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5 h1:xnTS/7y0g28W2SJeWNLMYTiTOmfW2P/YdPByoQnPvVo=
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5/go.mod h1:yV39+EVOWdnoTe75NyKdo9iuyI3Slyh4t7eQvElUbWE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxschmitt/golang-combinations v1.0.0 h1:NFoO7CSP8MUcFlHpe1YdewKwMa15dgDbaqkVLC5DUPI=
+github.com/mxschmitt/golang-combinations v1.0.0/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
+github.com/mxschmitt/golang-combinations v1.0.1-0.20200702132438-341af75e2cab h1:eAgXCP8tgeMOzVdFgbO0NFcRMbuXOr4bdbVodKaIEhk=
+github.com/mxschmitt/golang-combinations v1.0.1-0.20200702132438-341af75e2cab/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da/go.mod h1:DvuJJ/w1Y59rG8UTDxsMk5U+UJXJwuvUgbiJSm9yhX8=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/go.sum
+++ b/go.sum
@@ -267,10 +267,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5 h1:xnTS/7y0g28W2SJeWNLMYTiTOmfW2P/YdPByoQnPvVo=
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5/go.mod h1:yV39+EVOWdnoTe75NyKdo9iuyI3Slyh4t7eQvElUbWE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/mxschmitt/golang-combinations v1.0.0 h1:NFoO7CSP8MUcFlHpe1YdewKwMa15dgDbaqkVLC5DUPI=
-github.com/mxschmitt/golang-combinations v1.0.0/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
-github.com/mxschmitt/golang-combinations v1.0.1-0.20200702132438-341af75e2cab h1:eAgXCP8tgeMOzVdFgbO0NFcRMbuXOr4bdbVodKaIEhk=
-github.com/mxschmitt/golang-combinations v1.0.1-0.20200702132438-341af75e2cab/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da/go.mod h1:DvuJJ/w1Y59rG8UTDxsMk5U+UJXJwuvUgbiJSm9yhX8=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -13,7 +13,7 @@ func init() {
 	registry.Add("default", NewConfigurableFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -p meter -b api.Meter -o meter_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p meter -f meterDecorate -b api.Meter -o meter_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
 
 // NewConfigurableFromConfig creates api.Meter from config
 func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -70,7 +70,7 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) 
 		currentsDeco = m.currents
 	}
 
-	res := decorate(m, energyDeco, currentsDeco)
+	res := meterDecorate(m, energyDeco, currentsDeco)
 
 	return res, nil
 }

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -13,7 +13,7 @@ func init() {
 	registry.Add("default", NewConfigurableFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -p meter -f meterDecorate -b api.Meter -o meter_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p meter -f decorateMeter -b api.Meter -o meter_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
 
 // NewConfigurableFromConfig creates api.Meter from config
 func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -70,7 +70,7 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) 
 		currents = m.currents
 	}
 
-	res := meterDecorate(m, totalEnergy, currents)
+	res := decorateMeter(m, totalEnergy, currents)
 
 	return res, nil
 }

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -13,6 +13,8 @@ func init() {
 	registry.Add("default", NewConfigurableFromConfig)
 }
 
+// go:generate github.com/andig/evcc/cmd/tools/decorate.go -b api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+
 // NewConfigurableFromConfig creates api.Meter from config
 func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
@@ -39,63 +41,42 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) 
 	m, _ := NewConfigurable(power)
 
 	// decorate Meter with MeterEnergy
+	var energyDeco func() (float64, error)
 	if cc.Energy != nil {
-		energy, err := NewMeterEnergy(*cc.Energy)
+		m.totalEnergyG, err = provider.NewFloatGetterFromConfig(*cc.Energy)
 		if err != nil {
 			return nil, err
 		}
-
-		type EnergyDecorator struct {
-			api.Meter
-			api.MeterEnergy
-		}
-
-		m = &EnergyDecorator{
-			Meter:       m,
-			MeterEnergy: energy,
-		}
+		energyDeco = m.totalEnergy
 	}
 
 	// decorate Meter with MeterCurrent
+	var currentsDeco func() (float64, float64, float64, error)
 	if len(cc.Currents) > 0 {
-		currents, err := NewCurrents(cc.Currents)
-		if err != nil {
-			return nil, err
+		if len(cc.Currents) != 3 {
+			return nil, errors.New("need 3 currents")
 		}
 
-		type PowerEnergy interface {
-			api.Meter
-			api.MeterEnergy
+		var currentsG []func() (float64, error)
+		for _, cc := range cc.Currents {
+			c, err := provider.NewFloatGetterFromConfig(cc)
+			if err != nil {
+				return nil, err
+			}
+
+			m.currentsG = append(currentsG, c)
 		}
 
-		if pe, ok := m.(PowerEnergy); ok {
-			type CurrentDecorator struct {
-				PowerEnergy
-				api.MeterCurrent
-			}
-
-			m = &CurrentDecorator{
-				PowerEnergy:  pe,
-				MeterCurrent: currents,
-			}
-		} else {
-			type CurrentDecorator struct {
-				api.Meter
-				api.MeterCurrent
-			}
-
-			m = &CurrentDecorator{
-				Meter:        m,
-				MeterCurrent: currents,
-			}
-		}
+		currentsDeco = m.currents
 	}
 
-	return m, nil
+	res := decorate(m, energyDeco, currentsDeco)
+
+	return res, nil
 }
 
-// NewConfigurable creates a new charger
-func NewConfigurable(currentPowerG func() (float64, error)) (api.Meter, error) {
+// NewConfigurable creates a new meter
+func NewConfigurable(currentPowerG func() (float64, error)) (*Meter, error) {
 	m := &Meter{
 		currentPowerG: currentPowerG,
 	}
@@ -105,6 +86,8 @@ func NewConfigurable(currentPowerG func() (float64, error)) (api.Meter, error) {
 // Meter is an api.Meter implementation with configurable getters and setters.
 type Meter struct {
 	currentPowerG func() (float64, error)
+	totalEnergyG  func() (float64, error)
+	currentsG     []func() (float64, error)
 }
 
 // CurrentPower implements the Meter.CurrentPower interface
@@ -112,62 +95,15 @@ func (m *Meter) CurrentPower() (float64, error) {
 	return m.currentPowerG()
 }
 
-// MeterEnergy is an api.MeterEnergy implementation with configurable getters and setters.
-type MeterEnergy struct {
-	totalEnergyG func() (float64, error)
-}
-
-// NewMeterEnergy creates a new api.MeterEnergy
-func NewMeterEnergy(ccEnergy provider.Config) (api.MeterEnergy, error) {
-	totalEnergyG, err := provider.NewFloatGetterFromConfig(ccEnergy)
-	if err != nil {
-		return nil, err
-	}
-
-	e := &MeterEnergy{
-		totalEnergyG: totalEnergyG,
-	}
-
-	return e, nil
-}
-
-// TotalEnergy implements the Meter.TotalEnergy interface
-func (m *MeterEnergy) TotalEnergy() (float64, error) {
+// totalEnergy implements the Meter.TotalEnergy interface
+func (m *Meter) totalEnergy() (float64, error) {
 	return m.totalEnergyG()
 }
 
-// Currents is an api.MeterCurrent implementation
-type Currents struct {
-	currentsG []func() (float64, error)
-}
-
-// NewCurrents creates a new api.MeterCurrent
-func NewCurrents(ccCurrents []provider.Config) (api.MeterCurrent, error) {
-	if len(ccCurrents) != 3 {
-		return nil, errors.New("need 3 currents")
-	}
-
-	var currentsG []func() (float64, error)
-	for _, cc := range ccCurrents {
-		c, err := provider.NewFloatGetterFromConfig(cc)
-		if err != nil {
-			return nil, err
-		}
-
-		currentsG = append(currentsG, c)
-	}
-
-	c := &Currents{
-		currentsG: currentsG,
-	}
-
-	return c, nil
-}
-
-// Currents implements the api.Currents interface
-func (c *Currents) Currents() (float64, float64, float64, error) {
+// currents implements the Meter.Currents interface
+func (m *Meter) currents() (float64, float64, float64, error) {
 	var currents []float64
-	for _, currentG := range c.currentsG {
+	for _, currentG := range m.currentsG {
 		c, err := currentG()
 		if err != nil {
 			return 0, 0, 0, err

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -13,7 +13,7 @@ func init() {
 	registry.Add("default", NewConfigurableFromConfig)
 }
 
-//go:generate go run github.com/andig/evcc/cmd/tools/decorate.go -b api.Meter -o meter_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p meter -b api.Meter -o meter_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
 
 // NewConfigurableFromConfig creates api.Meter from config
 func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) {

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -13,7 +13,7 @@ func init() {
 	registry.Add("default", NewConfigurableFromConfig)
 }
 
-// go:generate github.com/andig/evcc/cmd/tools/decorate.go -b api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
+//go:generate go run github.com/andig/evcc/cmd/tools/decorate.go -b api.Meter -o meter_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.MeterCurrent,Currents,func() (float64, float64, float64, error)"
 
 // NewConfigurableFromConfig creates api.Meter from config
 func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) {

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -41,17 +41,17 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) 
 	m, _ := NewConfigurable(power)
 
 	// decorate Meter with MeterEnergy
-	var energyDeco func() (float64, error)
+	var totalEnergy func() (float64, error)
 	if cc.Energy != nil {
 		m.totalEnergyG, err = provider.NewFloatGetterFromConfig(*cc.Energy)
 		if err != nil {
 			return nil, err
 		}
-		energyDeco = m.totalEnergy
+		totalEnergy = m.totalEnergy
 	}
 
 	// decorate Meter with MeterCurrent
-	var currentsDeco func() (float64, float64, float64, error)
+	var currents func() (float64, float64, float64, error)
 	if len(cc.Currents) > 0 {
 		if len(cc.Currents) != 3 {
 			return nil, errors.New("need 3 currents")
@@ -67,10 +67,10 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Meter, error) 
 			m.currentsG = append(currentsG, c)
 		}
 
-		currentsDeco = m.currents
+		currents = m.currents
 	}
 
-	res := meterDecorate(m, energyDeco, currentsDeco)
+	res := meterDecorate(m, totalEnergy, currents)
 
 	return res, nil
 }

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/andig/evcc/api"
 )
 
-func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Meter {
+func meterDecorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Meter {
 	switch {
 	case meterCurrent == nil && meterEnergy == nil:
 		return base
@@ -17,7 +17,7 @@ func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent 
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MeterEnergy: &meterEnergyImpl{
+			MeterEnergy: &meterDecorateMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -28,7 +28,7 @@ func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent 
 			api.MeterCurrent
 		}{
 			Meter: base,
-			MeterCurrent: &meterCurrentImpl{
+			MeterCurrent: &meterDecorateMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
 		}
@@ -40,10 +40,10 @@ func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent 
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MeterCurrent: &meterCurrentImpl{
+			MeterCurrent: &meterDecorateMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
-			MeterEnergy: &meterEnergyImpl{
+			MeterEnergy: &meterDecorateMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -52,18 +52,18 @@ func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent 
 	return nil
 }
 
-type meterCurrentImpl struct {
+type meterDecorateMeterCurrentImpl struct {
 	meterCurrent func() (float64, float64, float64, error)
 }
 
-func (impl *meterCurrentImpl) Currents() (float64, float64, float64, error) {
+func (impl *meterDecorateMeterCurrentImpl) Currents() (float64, float64, float64, error) {
 	return impl.meterCurrent()
 }
 
-type meterEnergyImpl struct {
+type meterDecorateMeterEnergyImpl struct {
 	meterEnergy func() (float64, error)
 }
 
-func (impl *meterEnergyImpl) TotalEnergy() (float64, error) {
+func (impl *meterDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
 }

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -1,0 +1,69 @@
+package meter
+
+// This file has been generated - do not modify
+
+import (
+	"github.com/andig/evcc/api"
+)
+
+func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Meter {
+	switch {
+	case meterCurrent == nil && meterEnergy == nil:
+		return base
+
+	case meterCurrent == nil && meterEnergy != nil:
+		return &struct {
+			api.Meter
+			api.MeterEnergy
+		}{
+			Meter: base,
+			MeterEnergy: &meterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+
+	case meterCurrent != nil && meterEnergy == nil:
+		return &struct {
+			api.Meter
+			api.MeterCurrent
+		}{
+			Meter: base,
+			MeterCurrent: &meterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+		}
+
+	case meterCurrent != nil && meterEnergy != nil:
+		return &struct {
+			api.Meter
+			api.MeterCurrent
+			api.MeterEnergy
+		}{
+			Meter: base,
+			MeterCurrent: &meterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+			MeterEnergy: &meterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+	}
+
+	return nil
+}
+
+type meterCurrentImpl struct {
+	meterCurrent func() (float64, float64, float64, error)
+}
+
+func (impl *meterCurrentImpl) Currents() (float64, float64, float64, error) {
+	return impl.meterCurrent()
+}
+
+type meterEnergyImpl struct {
+	meterEnergy func() (float64, error)
+}
+
+func (impl *meterEnergyImpl) TotalEnergy() (float64, error) {
+	return impl.meterEnergy()
+}

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -12,7 +12,7 @@ func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent 
 		return base
 
 	case meterCurrent == nil && meterEnergy != nil:
-		return &struct {
+		return &struct{
 			api.Meter
 			api.MeterEnergy
 		}{
@@ -23,7 +23,7 @@ func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent 
 		}
 
 	case meterCurrent != nil && meterEnergy == nil:
-		return &struct {
+		return &struct{
 			api.Meter
 			api.MeterCurrent
 		}{
@@ -34,7 +34,7 @@ func decorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent 
 		}
 
 	case meterCurrent != nil && meterEnergy != nil:
-		return &struct {
+		return &struct{
 			api.Meter
 			api.MeterCurrent
 			api.MeterEnergy

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/andig/evcc/api"
 )
 
-func meterDecorate(base api.Meter, meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Meter {
+func decorateMeter(base api.Meter, meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Meter {
 	switch {
 	case meterCurrent == nil && meterEnergy == nil:
 		return base
@@ -17,7 +17,7 @@ func meterDecorate(base api.Meter, meterEnergy func() (float64, error), meterCur
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MeterEnergy: &meterDecorateMeterEnergyImpl{
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -28,7 +28,7 @@ func meterDecorate(base api.Meter, meterEnergy func() (float64, error), meterCur
 			api.MeterCurrent
 		}{
 			Meter: base,
-			MeterCurrent: &meterDecorateMeterCurrentImpl{
+			MeterCurrent: &decorateMeterMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
 		}
@@ -40,10 +40,10 @@ func meterDecorate(base api.Meter, meterEnergy func() (float64, error), meterCur
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MeterCurrent: &meterDecorateMeterCurrentImpl{
+			MeterCurrent: &decorateMeterMeterCurrentImpl{
 				meterCurrent: meterCurrent,
 			},
-			MeterEnergy: &meterDecorateMeterEnergyImpl{
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -52,18 +52,18 @@ func meterDecorate(base api.Meter, meterEnergy func() (float64, error), meterCur
 	return nil
 }
 
-type meterDecorateMeterCurrentImpl struct {
+type decorateMeterMeterCurrentImpl struct {
 	meterCurrent func() (float64, float64, float64, error)
 }
 
-func (impl *meterDecorateMeterCurrentImpl) Currents() (float64, float64, float64, error) {
+func (impl *decorateMeterMeterCurrentImpl) Currents() (float64, float64, float64, error) {
 	return impl.meterCurrent()
 }
 
-type meterDecorateMeterEnergyImpl struct {
+type decorateMeterMeterEnergyImpl struct {
 	meterEnergy func() (float64, error)
 }
 
-func (impl *meterDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+func (impl *decorateMeterMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
 }

--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -25,6 +25,8 @@ func init() {
 	registry.Add("modbus", NewModbusFromConfig)
 }
 
+//go:generate go run ../cmd/tools/decorate.go -p meter -f modbusDecorate -b api.Meter -o modbus_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
+
 // NewModbusFromConfig creates api.Meter from config
 func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
@@ -84,15 +86,16 @@ func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
 	}
 
 	// decorate energy reading
+	var totalEnergy func() (float64, error)
 	if cc.Energy != "" {
 		if err := modbus.ParseOperation(device, cc.Energy, &m.opEnergy); err != nil {
 			log.FATAL.Fatalf("invalid measurement for energy: %s", cc.Power)
 		}
 
-		return &ModbusEnergy{m}, nil
+		totalEnergy = m.totalEnergy
 	}
 
-	return m, nil
+	return modbusDecorate(m, totalEnergy), nil
 }
 
 // floatGetter executes configured modbus read operation and implements func() (float64, error)
@@ -139,12 +142,7 @@ func (m *Modbus) CurrentPower() (float64, error) {
 	return m.floatGetter(m.opPower)
 }
 
-// ModbusEnergy decorates Modbus with api.MeterEnergy interface
-type ModbusEnergy struct {
-	*Modbus
-}
-
-// TotalEnergy implements the Meter.TotalEnergy interface
-func (m *ModbusEnergy) TotalEnergy() (float64, error) {
+// totalEnergy implements the Meter.TotalEnergy interface
+func (m *Modbus) totalEnergy() (float64, error) {
 	return m.floatGetter(m.opEnergy)
 }

--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -25,7 +25,7 @@ func init() {
 	registry.Add("modbus", NewModbusFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -p meter -f modbusDecorate -b api.Meter -o modbus_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p meter -f decorateModbus -b api.Meter -o modbus_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
 
 // NewModbusFromConfig creates api.Meter from config
 func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -95,7 +95,7 @@ func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
 		totalEnergy = m.totalEnergy
 	}
 
-	return modbusDecorate(m, totalEnergy), nil
+	return decorateModbus(m, totalEnergy), nil
 }
 
 // floatGetter executes configured modbus read operation and implements func() (float64, error)

--- a/meter/modbus_decorators.go
+++ b/meter/modbus_decorators.go
@@ -1,0 +1,35 @@
+package meter
+
+// This file has been generated - do not modify
+
+import (
+	"github.com/andig/evcc/api"
+)
+
+func modbusDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
+	switch {
+	case meterEnergy == nil:
+		return base
+
+	case meterEnergy != nil:
+		return &struct{
+			api.Meter
+			api.MeterEnergy
+		}{
+			Meter: base,
+			MeterEnergy: &modbusDecorateMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+	}
+
+	return nil
+}
+
+type modbusDecorateMeterEnergyImpl struct {
+	meterEnergy func() (float64, error)
+}
+
+func (impl *modbusDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+	return impl.meterEnergy()
+}

--- a/meter/modbus_decorators.go
+++ b/meter/modbus_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/andig/evcc/api"
 )
 
-func modbusDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
+func decorateModbus(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
 	switch {
 	case meterEnergy == nil:
 		return base
@@ -17,7 +17,7 @@ func modbusDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Met
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MeterEnergy: &modbusDecorateMeterEnergyImpl{
+			MeterEnergy: &decorateModbusMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -26,10 +26,10 @@ func modbusDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Met
 	return nil
 }
 
-type modbusDecorateMeterEnergyImpl struct {
+type decorateModbusMeterEnergyImpl struct {
 	meterEnergy func() (float64, error)
 }
 
-func (impl *modbusDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+func (impl *decorateModbusMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
 }

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -37,6 +37,8 @@ func init() {
 	registry.Add("sma", NewSMAFromConfig)
 }
 
+//go:generate go run ../cmd/tools/decorate.go -p meter -f smaDecorate -b api.Meter -o sma_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
+
 // NewSMAFromConfig creates a SMA Meter from generic config
 func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
@@ -77,14 +79,15 @@ func NewSMA(uri, serial, power, energy string) (api.Meter, error) {
 		return nil, errors.New("missing uri or serial")
 	}
 
-	go sm.receive()
-
 	// decorate api.MeterEnergy
+	var totalEnergy func() (float64, error)
 	if energy != "" {
-		return &SMAEnergy{SMA: sm}, nil
+		totalEnergy = sm.totalEnergy
 	}
 
-	return sm, nil
+	go sm.receive()
+
+	return smaDecorate(sm, totalEnergy), nil
 }
 
 // update the actual meter data
@@ -168,13 +171,8 @@ func (sm *SMA) Currents() (float64, float64, float64, error) {
 	return values.currentL1, sm.values.currentL2, sm.values.currentL3, err
 }
 
-// SMAEnergy decorates SMA with api.MeterEnergy interface
-type SMAEnergy struct {
-	*SMA
-}
-
-// TotalEnergy implements the api.MeterEnergy interface
-func (sm *SMAEnergy) TotalEnergy() (float64, error) {
+// totalEnergy implements the api.MeterEnergy interface
+func (sm *SMA) totalEnergy() (float64, error) {
 	values, err := sm.hasValue()
 	return values.energy, err
 }

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -37,7 +37,7 @@ func init() {
 	registry.Add("sma", NewSMAFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -p meter -f smaDecorate -b api.Meter -o sma_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p meter -f decorateSMA -b api.Meter -o sma_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
 
 // NewSMAFromConfig creates a SMA Meter from generic config
 func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -87,7 +87,7 @@ func NewSMA(uri, serial, power, energy string) (api.Meter, error) {
 
 	go sm.receive()
 
-	return smaDecorate(sm, totalEnergy), nil
+	return decorateSMA(sm, totalEnergy), nil
 }
 
 // update the actual meter data

--- a/meter/sma_decorators.go
+++ b/meter/sma_decorators.go
@@ -1,0 +1,35 @@
+package meter
+
+// This file has been generated - do not modify
+
+import (
+	"github.com/andig/evcc/api"
+)
+
+func smaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
+	switch {
+	case meterEnergy == nil:
+		return base
+
+	case meterEnergy != nil:
+		return &struct{
+			api.Meter
+			api.MeterEnergy
+		}{
+			Meter: base,
+			MeterEnergy: &smaDecorateMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+	}
+
+	return nil
+}
+
+type smaDecorateMeterEnergyImpl struct {
+	meterEnergy func() (float64, error)
+}
+
+func (impl *smaDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+	return impl.meterEnergy()
+}

--- a/meter/sma_decorators.go
+++ b/meter/sma_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/andig/evcc/api"
 )
 
-func smaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
+func decorateSMA(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
 	switch {
 	case meterEnergy == nil:
 		return base
@@ -17,7 +17,7 @@ func smaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter 
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MeterEnergy: &smaDecorateMeterEnergyImpl{
+			MeterEnergy: &decorateSMAMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -26,10 +26,10 @@ func smaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter 
 	return nil
 }
 
-type smaDecorateMeterEnergyImpl struct {
+type decorateSMAMeterEnergyImpl struct {
 	meterEnergy func() (float64, error)
 }
 
-func (impl *smaDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+func (impl *decorateSMAMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
 }

--- a/meter/tesla.go
+++ b/meter/tesla.go
@@ -39,7 +39,7 @@ func init() {
 	registry.Add("tesla", NewTeslaFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -p meter -f teslaDecorate -b api.Meter -o tesla_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
+//go:generate go run ../cmd/tools/decorate.go -p meter -f decorateTesla -b api.Meter -o tesla_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
 
 // NewTeslaFromConfig creates a Tesla Powerwall Meter from generic config
 func NewTeslaFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -87,7 +87,7 @@ func NewTesla(uri, usage string) (api.Meter, error) {
 		totalEnergy = m.totalEnergy
 	}
 
-	return teslaDecorate(m, totalEnergy), nil
+	return decorateTesla(m, totalEnergy), nil
 }
 
 // CurrentPower implements the Meter.CurrentPower interface

--- a/meter/tesla.go
+++ b/meter/tesla.go
@@ -39,6 +39,8 @@ func init() {
 	registry.Add("tesla", NewTeslaFromConfig)
 }
 
+//go:generate go run ../cmd/tools/decorate.go -p meter -f teslaDecorate -b api.Meter -o tesla_decorators -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
+
 // NewTeslaFromConfig creates a Tesla Powerwall Meter from generic config
 func NewTeslaFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
@@ -80,11 +82,12 @@ func NewTesla(uri, usage string) (api.Meter, error) {
 	m.HTTPHelper.Client.Transport = customTransport
 
 	// decorate api.MeterEnergy
+	var totalEnergy func() (float64, error)
 	if m.usage == "load" || m.usage == "solar" {
-		return &TeslaEnergy{Tesla: m}, nil
+		totalEnergy = m.totalEnergy
 	}
 
-	return m, nil
+	return teslaDecorate(m, totalEnergy), nil
 }
 
 // CurrentPower implements the Meter.CurrentPower interface
@@ -101,13 +104,8 @@ func (m *Tesla) CurrentPower() (float64, error) {
 	return 0, fmt.Errorf("invalid usage: %s", m.usage)
 }
 
-// TeslaEnergy decorates Tesla with api.MeterEnergy interface
-type TeslaEnergy struct {
-	*Tesla
-}
-
-// TotalEnergy implements the api.MeterEnergy interface
-func (m *TeslaEnergy) TotalEnergy() (float64, error) {
+// totalEnergy implements the api.MeterEnergy interface
+func (m *Tesla) totalEnergy() (float64, error) {
 	var tr teslaResponse
 	_, err := m.GetJSON(m.uri, &tr)
 

--- a/meter/tesla_decorators.go
+++ b/meter/tesla_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/andig/evcc/api"
 )
 
-func teslaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
+func decorateTesla(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
 	switch {
 	case meterEnergy == nil:
 		return base
@@ -17,7 +17,7 @@ func teslaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Mete
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MeterEnergy: &teslaDecorateMeterEnergyImpl{
+			MeterEnergy: &decorateTeslaMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
@@ -26,10 +26,10 @@ func teslaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Mete
 	return nil
 }
 
-type teslaDecorateMeterEnergyImpl struct {
+type decorateTeslaMeterEnergyImpl struct {
 	meterEnergy func() (float64, error)
 }
 
-func (impl *teslaDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+func (impl *decorateTeslaMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
 }

--- a/meter/tesla_decorators.go
+++ b/meter/tesla_decorators.go
@@ -1,0 +1,35 @@
+package meter
+
+// This file has been generated - do not modify
+
+import (
+	"github.com/andig/evcc/api"
+)
+
+func teslaDecorate(base api.Meter, meterEnergy func() (float64, error)) api.Meter {
+	switch {
+	case meterEnergy == nil:
+		return base
+
+	case meterEnergy != nil:
+		return &struct{
+			api.Meter
+			api.MeterEnergy
+		}{
+			Meter: base,
+			MeterEnergy: &teslaDecorateMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+	}
+
+	return nil
+}
+
+type teslaDecorateMeterEnergyImpl struct {
+	meterEnergy func() (float64, error)
+}
+
+func (impl *teslaDecorateMeterEnergyImpl) TotalEnergy() (float64, error) {
+	return impl.meterEnergy()
+}

--- a/tools.go
+++ b/tools.go
@@ -5,5 +5,4 @@ package main
 import (
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/mjibson/esc"
-	_ "golang.org/x/tools/cmd/stringer"
 )

--- a/tools.go
+++ b/tools.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	_ "github.com/andig/evcc/cmd/tools/decorate"
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/mjibson/esc"
 	_ "golang.org/x/tools/cmd/stringer"

--- a/tools.go
+++ b/tools.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	_ "github.com/andig/evcc/cmd/tools/decorate"
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/mjibson/esc"
 	_ "golang.org/x/tools/cmd/stringer"


### PR DESCRIPTION
Dieser PR implementiert einen Code Generator um dynamische Interface Komposition zu implementieren. Damit sinkt die Komplexität für Implementierung unterschiedlicher Zähler- und Chargereigenschaften die sich erst zur Laufzeit ergeben und daher nicht statisch typisiert werden können.

/cc @schenlap mit diesem PR kann die EVSE optional auch Energie und Ströme. Der Code dafür ist automatisch generiert.

Konfigurationsoption:

```
  meter:
     energy: true
     currents: true
```

Zugehörige golang-nuts Diskussion: https://groups.google.com/g/golang-nuts/c/Oo9Nwm4AZRI/m/mjMLeMcSBQAJ