### PR TITLE
Update index.html => Supportlink auf _blank

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -75,7 +75,7 @@
       <div class="navbar-nav">
         <router-link class="nav-item nav-link pb-1" to="/">Laden</router-link>
         <router-link class="nav-item nav-link pb-1" to="/config">Konfiguration</router-link>
-        <a class="nav-item nav-link pb-1" href="https://github.com/andig/evcc/issues">Support</a>
+        <a class="nav-item nav-link pb-1" href="https://github.com/andig/evcc/issues" target="_blank">Support</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
target="_blank" für den Supportlink. Das verhindert Probleme wenn evcc eingebettet ist (Home Assistant beispielsweise).