### PR TITLE
Keba / BMW Charge Plus timing fix: ena 0

### DIFF
--- a/charger/keba.go
+++ b/charger/keba.go
@@ -238,6 +238,8 @@ func (c *Keba) Enable(enable bool) error {
 	var resp string
 	_ = c.roundtrip(fmt.Sprintf("ena %d", d), 0, &resp)
 
+	time.Sleep(2 * time.Second)
+
 	// ...and verify value
 	res, err := c.Enabled()
 	if err == nil && res != enable {


### PR DESCRIPTION
After some testings it turned out, that a delay between "ena 0" and the verfication request solves the Keba / Bmw Charge Plus error messages on stop.