### PR TITLE
Revert "Switch to go-e amx api"

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ In general, due to the minimum value of 5% for signalling the EV duty cycle, the
 Charger is responsible for handling EV state and adjusting charge current. Available charger implementations are:
 
 - `evsewifi`: chargers with SimpleEVSE controllers using [EVSE-WiFi](https://www.evse-wifi.de/)
-- `go-e`: go-eCharger chargers (both local and cloud API are supported, firmware 40.0 required)
+- `go-e`: go-eCharger chargers (both local and cloud API are supported)
 - `keba`: KEBA KeContact P20/P30 and BMW chargers (see [Preparation](#keba-preparation))
 - `mcc`: Mobile Charger Connect devices (Audi, Bentley, Porsche)
 - `openWB`: openWB chargers using openWB's MQTT interface

--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -28,8 +28,7 @@ type goeStatusResponse struct {
 	Fwv string `json:"fwv"`        // firmware version - indicates local response
 	Car int    `json:"car,string"` // car status
 	Alw int    `json:"alw,string"` // allow charging
-	Amp int    `json:"amp,string"` // current [A], goes to EEPROM
-	Amx int    `json:"amx,string"` // current [A], doesn't go to EEPROM
+	Amp int    `json:"amp,string"` // current [A]
 	Err int    `json:"err,string"` // error
 	Stp int    `json:"stp,string"` // stop state
 	Tmp int    `json:"tmp,string"` // temperature [°C]
@@ -194,7 +193,7 @@ func (c *GoE) Enable(enable bool) error {
 
 	status, err := c.apiUpdate(fmt.Sprintf("alw=%d", b))
 	if err == nil && isValid(status) && status.Alw != b {
-		return fmt.Errorf("alw update failed: %d", status.Alw)
+		return fmt.Errorf("alw update failed: %d", status.Amp)
 	}
 
 	return err
@@ -202,9 +201,9 @@ func (c *GoE) Enable(enable bool) error {
 
 // MaxCurrent implements the Charger.MaxCurrent interface
 func (c *GoE) MaxCurrent(current int64) error {
-	status, err := c.apiUpdate(fmt.Sprintf("amx=%d", current))
-	if err == nil && isValid(status) && int64(status.Amx) != current {
-		return fmt.Errorf("amx update failed: %d", status.Amx)
+	status, err := c.apiUpdate(fmt.Sprintf("amp=%d", current))
+	if err == nil && isValid(status) && int64(status.Amp) != current {
+		return fmt.Errorf("amp update failed: %d", status.Amp)
 	}
 
 	return err


### PR DESCRIPTION
Reverts andig/evcc#442, refs #439.