### PR TITLE
Update go-e.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ In general, due to the minimum value of 5% for signalling the EV duty cycle, the
 Charger is responsible for handling EV state and adjusting charge current. Available charger implementations are:
 
 - `evsewifi`: chargers with SimpleEVSE controllers using [EVSE-WiFi](https://www.evse-wifi.de/)
-- `go-e`: go-eCharger chargers (both local and cloud API are supported)
+- `go-e`: go-eCharger chargers (both local and cloud API are supported, firmware 40.0 required)
 - `keba`: KEBA KeContact P20/P30 and BMW chargers (see [Preparation](#keba-preparation))
 - `mcc`: Mobile Charger Connect devices (Audi, Bentley, Porsche)
 - `openWB`: openWB chargers using openWB's MQTT interface

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ In general, due to the minimum value of 5% for signalling the EV duty cycle, the
 Charger is responsible for handling EV state and adjusting charge current. Available charger implementations are:
 
 - `evsewifi`: chargers with SimpleEVSE controllers using [EVSE-WiFi](https://www.evse-wifi.de/)
-- `go-e`: go-eCharger chargers (both local and cloud API are supported, firmware 40.0 required)
+- `go-e`: go-eCharger chargers (both local and cloud API are supported, at least firmware 040.0 required)
 - `keba`: KEBA KeContact P20/P30 and BMW chargers (see [Preparation](#keba-preparation))
 - `mcc`: Mobile Charger Connect devices (Audi, Bentley, Porsche)
 - `openWB`: openWB chargers using openWB's MQTT interface

--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -201,7 +201,7 @@ func (c *GoE) Enable(enable bool) error {
 
 // MaxCurrent implements the Charger.MaxCurrent interface
 func (c *GoE) MaxCurrent(current int64) error {
-	status, err := c.apiUpdate(fmt.Sprintf("amp=%d", current))
+	status, err := c.apiUpdate(fmt.Sprintf("amx=%d", current))
 	if err == nil && isValid(status) && int64(status.Amp) != current {
 		return fmt.Errorf("amp update failed: %d", status.Amp)
 	}


### PR DESCRIPTION
Use amx payload to set charging amp.
"Ampere value for the PWM signaling in whole ampere of 6-32A Will not be written on flash but acts like you set amp instead. Only on the next reboot, the amp value will be restored to the last value set with amp. Recommended for PV charging"