### PR TITLE
Enable with OUT signal of Phoenix EV-CC-AC1-M3-CBC-SER controller possible; Autoselect enable mode

### DIFF
--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -65,8 +65,8 @@ func NewPhoenixEVCC(uri, device, comset string, baudrate int, id uint8) (*Phoeni
 		enMode: enMode,
 	}
 
-	wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 1)  //write to registers for debugging
-	wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 0) //write to registers for debugging
+//	wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 1)  //write to registers for debugging
+//	wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 0) //write to registers for debugging
 
 	RegEnConfig, err := wb.conn.ReadInputRegisters(phEVCCRegEnConfig, 1)
 	if err != nil {

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -84,10 +84,10 @@ func (wb *PhoenixEVCC) Enabled() (bool, error) {
 // Enable implements the Charger.Enable interface
 func (wb *PhoenixEVCC) Enable(enable bool) error {
 	var u uint16
-	if !enable {
+	if enable {
 		u = 0x0001
 	}
-//Low-signal on  pin OUT of the EV_CC_AC1-M  board ("Invert" relay necessary necessary!!) 
+//High-signal on pin OUT of the EV_CC_AC1-M  board (wire bridge between OUT and ENABLE necessary!!) 
 	_, err := wb.conn.WriteSingleRegister(phEVCCRegOUT, u)
 
 	return err

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -17,7 +17,8 @@ const (
 
 // PhoenixEVCC is an api.ChargeController implementation for Phoenix EV-CC-AC1-M wallboxes.
 // It uses Modbus TCP to communicate with the wallbox at modbus client id 255.
-type PhoenixEVCC struct {
+type PhoenixEVCC struct { 
+	log *util.Logger 
 	conn *modbus.Connection
 }
 
@@ -54,7 +55,8 @@ func NewPhoenixEVCC(uri, device, comset string, baudrate int, id uint8) (*Phoeni
 	log := util.NewLogger("evcc")
 	conn.Logger(log.TRACE)
 
-	wb := &PhoenixEVCC{
+	wb := &PhoenixEVCC{ 
+		log: log, 
 		conn: conn,
 	}
 
@@ -77,8 +79,8 @@ func (wb *PhoenixEVCC) Enabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	wb.log.TRACE.Printf("enabled: %t", b[1] == 1)
 
-//        return b[0], nil
 	return b[1] == 1, nil
 }
 
@@ -88,7 +90,7 @@ func (wb *PhoenixEVCC) Enable(enable bool) error {
 	if enable {
 		u = 0x0001
 	}
-//High-signal on pin OUT of the EV_CC_AC1-M  board (wire bridge between OUT and ENABLE necessary!!) 
+	//High-signal on pin OUT of the EV_CC_AC1-M  board (wire bridge between OUT and ENABLE necessary!!) 
 	_, err := wb.conn.WriteSingleRegister(phEVCCRegOUT, u)
 
 	return err

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	phEVCCRegEnConfig   =  4000 // Holding, Remanent
-        phEVCCRegOutConfig  =  5500 // Holding, Remanent
- 	phEVCCRegEnable     = 20000 // Coil
+	phEVCCRegEnConfig   = 4000  // Holding, Remanent
+	phEVCCRegOutConfig  = 5500  // Holding, Remanent
+	phEVCCRegEnable     = 20000 // Coil
 	phEVCCRegOUT        = 23000 // Holding
 	phEVCCRegMaxCurrent = 22000 // Holding
 	phEVCCRegStatus     = 24000 // Input
@@ -19,9 +19,9 @@ const (
 
 // PhoenixEVCC is an api.ChargeController implementation for Phoenix EV-CC-AC1-M wallboxes.
 // It uses Modbus TCP to communicate with the wallbox at modbus client id 255.
-type PhoenixEVCC struct { 
-	log *util.Logger 
-	conn *modbus.Connection
+type PhoenixEVCC struct {
+	log    *util.Logger
+	conn   *modbus.Connection
 	enMode string
 }
 
@@ -55,45 +55,44 @@ func NewPhoenixEVCC(uri, device, comset string, baudrate int, id uint8) (*Phoeni
 		return nil, err
 	}
 	var enMode string
-//	enMode = "modbus"
+	//	enMode = "modbus"
 	log := util.NewLogger("evcc")
 	conn.Logger(log.TRACE)
 
-	wb := &PhoenixEVCC{ 
-		log: log, 
-		conn: conn,
+	wb := &PhoenixEVCC{
+		log:    log,
+		conn:   conn,
 		enMode: enMode,
 	}
 
-//		wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 1)   //write to registers for debugging
-//		wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 0)  //write to registers for debugging
- 
+	wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 1)  //write to registers for debugging
+	wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 0) //write to registers for debugging
 
-        RegEnConfig, err := wb.conn.ReadInputRegisters(phEVCCRegEnConfig, 1)
-        if err != nil {
-                return nil, err
-        }
-        wb.log.TRACE.Printf("Register 4000 is %d",RegEnConfig[1])
+	RegEnConfig, err := wb.conn.ReadInputRegisters(phEVCCRegEnConfig, 1)
+	if err != nil {
+		return nil, err
+	}
+	wb.log.TRACE.Printf("Register 4000 is %d", RegEnConfig[1])
 
 	RegOutConfig, err := wb.conn.ReadInputRegisters(phEVCCRegOutConfig, 1)
-        if err != nil {
-                return nil, err
-        }
-        wb.log.TRACE.Printf("Register 5500 is %d", RegOutConfig[1])
+	if err != nil {
+		return nil, err
+	}
+	wb.log.TRACE.Printf("Register 5500 is %d", RegOutConfig[1])
 
- 	if  RegEnConfig[1] == 1 && RegOutConfig[1] == 0 {
+	if RegEnConfig[1] == 1 && RegOutConfig[1] == 0 {
 
-                enMode = "out-pin"
-	        wb.log.TRACE.Printf("enMode: %s; Charger is enabled by switching the digital OUT on.", enMode)
+		enMode = "out-pin"
+		wb.log.TRACE.Printf("enMode: %s; Charger is enabled by switching the digital OUT on.", enMode)
 
-        }else if RegEnConfig[1] == 3 {
-                enMode = "modbus"
-                wb.log.TRACE.Printf("enMode: %s; Charger is enabled by modbus.", enMode)
+	} else if RegEnConfig[1] == 3 {
+		enMode = "modbus"
+		wb.log.TRACE.Printf("enMode: %s; Charger is enabled by modbus.", enMode)
 
-        }else {
+	} else {
 		wb.log.ERROR.Printf("Registers 4000 = %d (and 5500 = %d) of Phoenix evcc are not configured for remote enabling", RegEnConfig[1], RegOutConfig[1])
-        }
-	
+	}
+
 	wb.enMode = enMode
 
 	return wb, nil
@@ -111,26 +110,25 @@ func (wb *PhoenixEVCC) Status() (api.ChargeStatus, error) {
 
 // Enabled implements the Charger.Enabled interface
 func (wb *PhoenixEVCC) Enabled() (bool, error) {
-        var EN bool
+	var EN bool
 	wb.log.TRACE.Printf("enMode: %s;", wb.enMode)
-
 
 	d, err := wb.conn.ReadInputRegisters(phEVCCRegOUT, 1)
 	if err != nil {
-      	        return false, err
-       }
-        wb.log.TRACE.Printf("Register 23000 is %d)", d)
+		return false, err
+	}
+	wb.log.TRACE.Printf("Register 23000 is %d)", d)
 
 	b, err := wb.conn.ReadCoils(phEVCCRegEnable, 1)
-        if err != nil {
-	return false, err
+	if err != nil {
+		return false, err
 	}
-        wb.log.TRACE.Printf("Register 20000 is %d)", b)
+	wb.log.TRACE.Printf("Register 20000 is %d)", b)
 
-        if wb.enMode == "out-pin" {
- 		EN = d[1] == 1
-	}else {
-                EN = b[0] == 1
+	if wb.enMode == "out-pin" {
+		EN = d[1] == 1
+	} else {
+		EN = b[0] == 1
 	}
 	wb.log.TRACE.Printf("enabled: %t", EN)
 
@@ -140,29 +138,29 @@ func (wb *PhoenixEVCC) Enabled() (bool, error) {
 // Enable implements the Charger.Enable interface
 func (wb *PhoenixEVCC) Enable(enable bool) error {
 	var u uint16
-wb.log.TRACE.Printf("enMode: %s;", wb.enMode)
+	wb.log.TRACE.Printf("enMode: %s;", wb.enMode)
 
-wb.log.TRACE.Printf("enable: %t;", enable)
+	wb.log.TRACE.Printf("enable: %t;", enable)
 
-        if enable {
+	if enable {
 		u = 0xFF00
 	}
-        _, err := wb.conn.WriteSingleCoil(phEVCCRegEnable, u)
-        if err != nil {
-                return err
-        }
-  
-        if wb.enMode == "out-pin" {
-	        if enable {
-	                u = 0x0001
-	        }
-	 	//High-signal on pin OUT of the EV_CC_AC1-M  board (wire bridge between OUT and ENABLE necessary!!) 
+	_, err := wb.conn.WriteSingleCoil(phEVCCRegEnable, u)
+	if err != nil {
+		return err
+	}
+
+	if wb.enMode == "out-pin" {
+		if enable {
+			u = 0x0001
+		}
+		//High-signal on pin OUT of the EV_CC_AC1-M  board (wire bridge between OUT and ENABLE necessary!!)
 		_, err := wb.conn.WriteSingleRegister(phEVCCRegOUT, u)
-                if err != nil {
-                        return err
-               }
- 	
- 	}
+		if err != nil {
+			return err
+		}
+
+	}
 
 	return err
 }

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	phEVCCRegEnable     = 20000 // Coil
+	phEVCCRegOUT        = 23000 // Coil
 	phEVCCRegMaxCurrent = 22000 // Holding
 	phEVCCRegStatus     = 24000 // Input
 )
@@ -83,11 +84,11 @@ func (wb *PhoenixEVCC) Enabled() (bool, error) {
 // Enable implements the Charger.Enable interface
 func (wb *PhoenixEVCC) Enable(enable bool) error {
 	var u uint16
-	if enable {
+	if !enable {
 		u = 0xFF00
 	}
-
-	_, err := wb.conn.WriteSingleCoil(phEVCCRegEnable, u)
+//Low-signal on  pin OUT of the EV_CC_AC1-M  board ("Invert" relay necessary necessary!!) 
+	_, err := wb.conn.WriteSingleCoil(phEVCCRegOUT, u)
 
 	return err
 }

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -73,12 +73,13 @@ func (wb *PhoenixEVCC) Status() (api.ChargeStatus, error) {
 
 // Enabled implements the Charger.Enabled interface
 func (wb *PhoenixEVCC) Enabled() (bool, error) {
-	b, err := wb.conn.ReadCoils(phEVCCRegEnable, 1)
+	b, err := wb.conn.ReadInputRegisters(phEVCCRegOUT, 1)
 	if err != nil {
 		return false, err
 	}
 
-	return b[0] == 1, nil
+//        return b[0], nil
+	return b[1] == 1, nil
 }
 
 // Enable implements the Charger.Enable interface

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -65,11 +65,8 @@ func NewPhoenixEVCC(uri, device, comset string, baudrate int, id uint8) (*Phoeni
 		enMode: enMode,
 	}
 
-wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 3)
-wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 1)
-//if err != nil {
-//        return nil, err
-//}
+		//wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 1)   //write to registers for debugging
+		//wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 0)  //write to registers for debugging
  
 
         RegEnConfig, err := wb.conn.ReadInputRegisters(phEVCCRegEnConfig, 1)

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	phEVCCRegEnable     = 20000 // Coil
-	phEVCCRegOUT        = 23000 // Coil
+	phEVCCRegOUT        = 23000 // Holding
 	phEVCCRegMaxCurrent = 22000 // Holding
 	phEVCCRegStatus     = 24000 // Input
 )
@@ -85,10 +85,10 @@ func (wb *PhoenixEVCC) Enabled() (bool, error) {
 func (wb *PhoenixEVCC) Enable(enable bool) error {
 	var u uint16
 	if !enable {
-		u = 0xFF00
+		u = 0x0001
 	}
 //Low-signal on  pin OUT of the EV_CC_AC1-M  board ("Invert" relay necessary necessary!!) 
-	_, err := wb.conn.WriteSingleCoil(phEVCCRegOUT, u)
+	_, err := wb.conn.WriteSingleRegister(phEVCCRegOUT, u)
 
 	return err
 }

--- a/charger/phoenix-evcc.go
+++ b/charger/phoenix-evcc.go
@@ -65,8 +65,8 @@ func NewPhoenixEVCC(uri, device, comset string, baudrate int, id uint8) (*Phoeni
 		enMode: enMode,
 	}
 
-		//wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 1)   //write to registers for debugging
-		//wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 0)  //write to registers for debugging
+//		wb.conn.WriteSingleRegister(phEVCCRegEnConfig, 1)   //write to registers for debugging
+//		wb.conn.WriteSingleRegister(phEVCCRegOutConfig, 0)  //write to registers for debugging
  
 
         RegEnConfig, err := wb.conn.ReadInputRegisters(phEVCCRegEnConfig, 1)
@@ -74,7 +74,7 @@ func NewPhoenixEVCC(uri, device, comset string, baudrate int, id uint8) (*Phoeni
                 return nil, err
         }
         wb.log.TRACE.Printf("Register 4000 is %d",RegEnConfig[1])
-        
+
 	RegOutConfig, err := wb.conn.ReadInputRegisters(phEVCCRegOutConfig, 1)
         if err != nil {
                 return nil, err
@@ -112,26 +112,26 @@ func (wb *PhoenixEVCC) Status() (api.ChargeStatus, error) {
 // Enabled implements the Charger.Enabled interface
 func (wb *PhoenixEVCC) Enabled() (bool, error) {
         var EN bool
-wb.log.TRACE.Printf("enMode: %s;", wb.enMode)
+	wb.log.TRACE.Printf("enMode: %s;", wb.enMode)
 
-	if wb.enMode == "out-pin" { 
- 		b, err := wb.conn.ReadInputRegisters(phEVCCRegOUT, 1)
-       		if err != nil {
-        	        return false, err
- 	       }
- 	        wb.log.TRACE.Printf("Register 23000 is %d)", b)
 
-		EN = b[1] == 1
-	}else if wb.enMode == "modbus" {
-		b, err := wb.conn.ReadCoils(phEVCCRegEnable, 1)
-                if err != nil {
-                        return false, err
-               }
-                wb.log.TRACE.Printf("Register 20000 is %d)", b)
+	d, err := wb.conn.ReadInputRegisters(phEVCCRegOUT, 1)
+	if err != nil {
+      	        return false, err
+       }
+        wb.log.TRACE.Printf("Register 23000 is %d)", d)
 
-                 EN = b[0] == 1
+	b, err := wb.conn.ReadCoils(phEVCCRegEnable, 1)
+        if err != nil {
+	return false, err
 	}
+        wb.log.TRACE.Printf("Register 20000 is %d)", b)
 
+        if wb.enMode == "out-pin" {
+ 		EN = d[1] == 1
+	}else {
+                EN = b[0] == 1
+	}
 	wb.log.TRACE.Printf("enabled: %t", EN)
 
 	return EN, nil
@@ -141,6 +141,8 @@ wb.log.TRACE.Printf("enMode: %s;", wb.enMode)
 func (wb *PhoenixEVCC) Enable(enable bool) error {
 	var u uint16
 wb.log.TRACE.Printf("enMode: %s;", wb.enMode)
+
+wb.log.TRACE.Printf("enable: %t;", enable)
 
         if enable {
 		u = 0xFF00


### PR DESCRIPTION
This change makes two options of enabling the charger possible. 
1: Directly writing into the enable register (20000) of the charger (possible without this modification). 
2: Drive the OUT port of the charger (register 23000) and feed the signal with a simple wire-bridge to the ENable port. (new)

The SW checks the registers 4000 and 5500 and uses the proper enabling mode automatically. 

For the first setup of a new evcc system the user has to do ONE of the following (both would work, too):
**1: Set register 4000 -> 3 in the EV-CC-AC1-M3-CBC-SER** 
     Advantage: no HW modification necessary.
     Disadvantage 1: Phoenix SW with RS485 adapter or other modbus equipment necessary.
     Disadvantage 2: The EV-CC-AC1-M3-CBC-SER is disabled after power-up and can not be 
     enabled without working evcc SW or other modbus tool.
**2: Add a wire bridge between ENable input and digital OUT terminal on the EV-CC-AC1-M3-CBC-SER**
    Advantage 1: Easy HW-modification Modbus registers can stay in factory default.
    Advantage 2: ENable can be manually connected to 12V (override switch). 
                         Charging is still possible, when the evcc-system is not working for whatever reason.
    Disadvantage: only possible, when OUT is not used otherwise.

The topic was discussed in #452, but I left out the thing with the relay, in favor to a simple wire bridge solution.