### PR TITLE
Add metrics and profile options

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,6 +16,8 @@ import (
 type config struct {
 	URI        string
 	Log        string
+	Metrics    bool
+	Profile    bool
 	Levels     map[string]string
 	Interval   time.Duration
 	Mqtt       provider.MqttConfig


### PR DESCRIPTION
This PR adds:

- `--metrics` for Prometheus metrics
- `--profile` for `pprof` diagnostics