### PR TITLE
Fix KEBA roundtrip timing out

### DIFF
--- a/charger/keba.go
+++ b/charger/keba.go
@@ -58,8 +58,8 @@ func NewKebaFromConfig(other map[string]interface{}) (api.Charger, error) {
 func NewKeba(uri, serial string, rfid RFID, timeout time.Duration) (api.Charger, error) {
 	log := util.NewLogger("keba")
 
-	var err error
 	if keba.Instance == nil {
+		var err error
 		keba.Instance, err = keba.New(log)
 		if err != nil {
 			return nil, err
@@ -68,7 +68,7 @@ func NewKeba(uri, serial string, rfid RFID, timeout time.Duration) (api.Charger,
 
 	// add default port
 	conn := util.DefaultPort(uri, keba.Port)
-	sender, err := keba.NewSender(uri)
+	sender, err := keba.NewSender(log, conn)
 
 	c := &Keba{
 		log:     log,

--- a/charger/keba/sender.go
+++ b/charger/keba/sender.go
@@ -10,11 +10,13 @@ import (
 
 // Sender is a KEBA UDP sender
 type Sender struct {
+	log  *util.Logger
+	addr string
 	conn *net.UDPConn
 }
 
 // NewSender creates KEBA UDP sender
-func NewSender(addr string) (*Sender, error) {
+func NewSender(log *util.Logger, addr string) (*Sender, error) {
 	addr = util.DefaultPort(addr, Port)
 	raddr, err := net.ResolveUDPAddr("udp", addr)
 
@@ -24,6 +26,8 @@ func NewSender(addr string) (*Sender, error) {
 	}
 
 	c := &Sender{
+		log:  log,
+		addr: addr,
 		conn: conn,
 	}
 
@@ -32,6 +36,7 @@ func NewSender(addr string) (*Sender, error) {
 
 // Send msg to receiver
 func (c *Sender) Send(msg string) error {
+	c.log.TRACE.Printf("send to %s %v", c.addr, msg)
 	_, err := io.Copy(c.conn, strings.NewReader(msg))
 	return err
 }

--- a/detect/keba.go
+++ b/detect/keba.go
@@ -50,7 +50,7 @@ func (h *KEBAHandler) Test(log *util.Logger, ip string) []interface{} {
 	resC := make(chan keba.UDPMsg)
 	h.listener.Subscribe(ip, resC)
 
-	sender, err := keba.NewSender(ip)
+	sender, err := keba.NewSender(log, ip)
 	if err != nil {
 		log.ERROR.Println("keba:", err)
 		return nil


### PR DESCRIPTION
#429 introduced a bug when KEBA was configured using serial number. 

The `TCH :OK` messages received from KEBA could not be routed to the subscriber since they don't contain serial numbers. This PR adds  a serial<->address cache to the listener for maintaining this mapping and hence make the OK responses routable.

/cc @mark-sch & @mode2k