### PR TITLE
Implement modbus setters

### DIFF
--- a/charger/charger.go
+++ b/charger/charger.go
@@ -40,7 +40,7 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Charger, error
 
 	status, err := provider.NewStringGetterFromConfig(cc.Status)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("status: %w", err)
 	}
 
 	enabled, err := provider.NewBoolGetterFromConfig(cc.Enabled)

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -117,13 +117,13 @@ func NewModbusFromConfig(other map[string]interface{}) (IntProvider, error) {
 	return mb, nil
 }
 
-func (m *Modbus) bytesGetter() (bytes []byte, err error) {
+func (m *Modbus) bytesGetter() ([]byte, error) {
 	if op := m.op.MBMD; op.FuncCode != 0 {
 		switch op.FuncCode {
 		case rs485.ReadHoldingReg:
-			bytes, err = m.conn.ReadHoldingRegisters(op.OpCode, op.ReadLen)
+			return m.conn.ReadHoldingRegisters(op.OpCode, op.ReadLen)
 		case rs485.ReadInputReg:
-			bytes, err = m.conn.ReadInputRegisters(op.OpCode, op.ReadLen)
+			return m.conn.ReadInputRegisters(op.OpCode, op.ReadLen)
 		default:
 			return nil, fmt.Errorf("unknown function code %d", op.FuncCode)
 		}
@@ -230,7 +230,7 @@ func (m *Modbus) IntSetter(param string) func(int64) error {
 			case modbus.WriteSingleRegister:
 				_, err = m.conn.WriteSingleRegister(op.OpCode, uval)
 			default:
-				return fmt.Errorf("unknown function code %d", op.FuncCode)
+				err = fmt.Errorf("unknown function code %d", op.FuncCode)
 			}
 		} else {
 			err = errors.New("modbus plugin does not support writing to sunspec")

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -1,10 +1,10 @@
 package provider
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/andig/evcc/util"
@@ -213,7 +213,17 @@ func (m *Modbus) BoolGetter() func() (bool, error) {
 			return false, err
 		}
 
-		return strconv.ParseBool(strings.TrimSpace(string(bytes)))
+		var u uint64
+		switch len(bytes) {
+		case 2:
+			u = uint64(binary.BigEndian.Uint16(bytes))
+		case 4:
+			u = uint64(binary.BigEndian.Uint32(bytes))
+		case 8:
+			u = binary.BigEndian.Uint64(bytes)
+		}
+
+		return u > 0, nil
 	}
 }
 

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -205,6 +205,22 @@ func (m *Modbus) StringGetter() func() (string, error) {
 	}
 }
 
+// UintFromBytes converts byte slice to bigendian uint value
+func UintFromBytes(bytes []byte) (u uint64, err error) {
+	switch l := len(bytes); l {
+	case 2:
+		u = uint64(binary.BigEndian.Uint16(bytes))
+	case 4:
+		u = uint64(binary.BigEndian.Uint32(bytes))
+	case 8:
+		u = binary.BigEndian.Uint64(bytes)
+	default:
+		err = fmt.Errorf("unexpected length: %d", l)
+	}
+
+	return u, err
+}
+
 // BoolGetter executes configured modbus read operation and implements IntProvider
 func (m *Modbus) BoolGetter() func() (bool, error) {
 	return func() (bool, error) {
@@ -213,17 +229,8 @@ func (m *Modbus) BoolGetter() func() (bool, error) {
 			return false, err
 		}
 
-		var u uint64
-		switch len(bytes) {
-		case 2:
-			u = uint64(binary.BigEndian.Uint16(bytes))
-		case 4:
-			u = uint64(binary.BigEndian.Uint32(bytes))
-		case 8:
-			u = binary.BigEndian.Uint64(bytes)
-		}
-
-		return u > 0, nil
+		u, err := UintFromBytes(bytes)
+		return u > 0, err
 	}
 }
 

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -13,6 +13,9 @@ import (
 	"github.com/volkszaehler/mbmd/meters/sunspec"
 )
 
+// WriteSingleRegister 16-bit wise write access
+const WriteSingleRegister = 6 // modbus.FuncCodeWriteSingleRegister
+
 // Settings contains the ModBus settings
 type Settings struct {
 	ID                  uint8
@@ -225,6 +228,8 @@ func RegisterOperation(r Register) (rs485.Operation, error) {
 		op.FuncCode = rs485.ReadHoldingReg
 	case "input":
 		op.FuncCode = rs485.ReadInputReg
+	case "writesingle":
+		op.FuncCode = WriteSingleRegister // modbus.FuncCodeWriteSingleRegister
 	default:
 		return rs485.Operation{}, fmt.Errorf("invalid register type: %s", r.Type)
 	}


### PR DESCRIPTION
With this PR, the modbus plugin can be used to control arbitrary devices, e.g. for implementing access to the Schrack CION charger using the default charger with modbus plugin.