### PR TITLE
Fixed failed requests in charger version 2925

### DIFF
--- a/charger/mcc.go
+++ b/charger/mcc.go
@@ -127,7 +127,10 @@ func (mcc *MobileConnect) login(password string) error {
 		"pass": []string{mcc.password},
 	}
 
-	req, err := request.New(http.MethodPost, uri, strings.NewReader(data.Encode()), request.URLEncoding)
+	req, err := request.New(http.MethodPost, uri, strings.NewReader(data.Encode()), map[string]string{
+		"Referer":      fmt.Sprintf("%s/login", mcc.uri),
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
 	if err != nil {
 		return err
 	}
@@ -172,6 +175,7 @@ func (mcc *MobileConnect) request(method, uri string) (*http.Request, error) {
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", mcc.token))
+	req.Header.Set("Referer", fmt.Sprintf("%s/dashboard", mcc.uri))
 
 	return req, nil
 }


### PR DESCRIPTION
The new charger software version 2925 now requires all requests to be a referer value, otherwise all requests will fail with HTTP 401