### PR TITLE
Add authentication for tesla powerwall

### DIFF
--- a/meter/tesla.go
+++ b/meter/tesla.go
@@ -1,8 +1,14 @@
 package meter
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
 	"strings"
 
 	"github.com/andig/evcc/api"
@@ -13,8 +19,9 @@ import (
 // credits to https://github.com/vloschiavo/powerwall2
 
 const (
-	teslaMeterURI   = "/api/meters/aggregates"
-	teslaBatteryURI = "/api/system_status/soe"
+	teslaMeterURI   = "/meters/aggregates"
+	teslaBatteryURI = "/system_status/soe"
+	teslaLoginURI   = "/login/Basic"
 )
 
 type teslaMeterResponse map[string]struct {
@@ -39,7 +46,9 @@ type teslaBatteryResponse struct {
 // Tesla is the tesla powerwall meter
 type Tesla struct {
 	*request.Helper
-	uri, usage string
+	uri      *url.URL
+	usage    string
+	password string
 }
 
 func init() {
@@ -51,7 +60,7 @@ func init() {
 // NewTeslaFromConfig creates a Tesla Powerwall Meter from generic config
 func NewTeslaFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI, Usage string
+		URI, Usage, Password string
 	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -62,6 +71,15 @@ func NewTeslaFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, errors.New("missing usage setting")
 	}
 
+	if cc.Password == "" {
+		return nil, errors.New("missing password setting")
+	}
+
+	uri, err := url.Parse(cc.URI)
+	if err != nil {
+		return nil, fmt.Errorf("%s is invalid: %s", cc.URI, err)
+	}
+
 	// support default meter names
 	switch strings.ToLower(cc.Usage) {
 	case "grid":
@@ -70,21 +88,32 @@ func NewTeslaFromConfig(other map[string]interface{}) (api.Meter, error) {
 		cc.Usage = "solar"
 	}
 
-	return NewTesla(cc.URI, cc.Usage)
+	return NewTesla(uri, cc.Usage, cc.Password)
 }
 
 // NewTesla creates a Tesla Meter
-func NewTesla(uri, usage string) (api.Meter, error) {
+func NewTesla(uri *url.URL, usage string, password string) (api.Meter, error) {
 	log := util.NewLogger("tesla")
 
+	uri.Scheme = "https"
+	// normalize path to '/api' so user input with a path won't cause any trouble
+	uri.Path = "/api"
+
 	m := &Tesla{
-		Helper: request.NewHelper(log),
-		uri:    util.DefaultScheme(uri, "https"),
-		usage:  strings.ToLower(usage),
+		Helper:   request.NewHelper(log),
+		uri:      uri,
+		usage:    strings.ToLower(usage),
+		password: password,
 	}
 
 	// ignore the self signed certificate
 	m.Client.Transport = request.NewTripper(log, request.InsecureTransport())
+	// create cookie jar to save login tokens
+	m.Client.Jar, _ = cookiejar.New(nil)
+
+	if err := m.Login(); err != nil {
+		return nil, err
+	}
 
 	// decorate api.MeterEnergy
 	var totalEnergy func() (float64, error)
@@ -101,10 +130,38 @@ func NewTesla(uri, usage string) (api.Meter, error) {
 	return decorateTesla(m, totalEnergy, batterySoC), nil
 }
 
+// Login calls login and saves the returned cookie
+func (m *Tesla) Login() error {
+	// username for the powerwall seems to always be customer; email is not required for authentication
+	payload := map[string]interface{}{"password": m.password, "username": "customer"}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	// returns cookie which is saved in the cookie jar
+	resp, err := m.Client.Post(m.uri.String()+teslaLoginURI, "application/json", bytes.NewReader(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("failed to post: %s", err)
+	}
+
+	defer resp.Body.Close()
+	// failed to login
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %s", err)
+		}
+		return fmt.Errorf("couldn't login: %s", body)
+	}
+
+	return nil
+}
+
 // CurrentPower implements the Meter.CurrentPower interface
 func (m *Tesla) CurrentPower() (float64, error) {
 	var res teslaMeterResponse
-	if err := m.GetJSON(m.uri+teslaMeterURI, &res); err != nil {
+	if err := m.GetJSON(m.uri.String()+teslaMeterURI, &res); err != nil {
 		return 0, err
 	}
 
@@ -118,7 +175,7 @@ func (m *Tesla) CurrentPower() (float64, error) {
 // totalEnergy implements the api.MeterEnergy interface
 func (m *Tesla) totalEnergy() (float64, error) {
 	var res teslaMeterResponse
-	if err := m.GetJSON(m.uri+teslaMeterURI, &res); err != nil {
+	if err := m.GetJSON(m.uri.String()+teslaMeterURI, &res); err != nil {
 		return 0, err
 	}
 
@@ -137,7 +194,7 @@ func (m *Tesla) totalEnergy() (float64, error) {
 // batterySoC implements the api.Battery interface
 func (m *Tesla) batterySoC() (float64, error) {
 	var res teslaBatteryResponse
-	err := m.GetJSON(m.uri+teslaBatteryURI, &res)
+	err := m.GetJSON(m.uri.String()+teslaBatteryURI, &res)
 
 	return res.Percentage, err
 }


### PR DESCRIPTION
This adds authentication for the tesla powerwall to make the meter usable again.

Fixes #733