### PR TITLE
Fixed unmarshaling bug for `ChargePowerKW` with VW ID vehicles

### DIFF
--- a/internal/vehicle/id/api.go
+++ b/internal/vehicle/id/api.go
@@ -95,10 +95,10 @@ type BatteryStatus struct {
 // ChargingStatus is the /status.chargingStatus api
 type ChargingStatus struct {
 	CarCapturedTimestamp               string
-	ChargingState                      string // readyForCharging
-	RemainingChargingTimeToCompleteMin int    `json:"remainingChargingTimeToComplete_min"`
-	ChargePowerKW                      int    `json:"chargePower_kW"`
-	ChargeRateKmph                     int    `json:"chargeRate_kmph"`
+	ChargingState                      string  // readyForCharging
+	RemainingChargingTimeToCompleteMin int     `json:"remainingChargingTimeToComplete_min"`
+	ChargePowerKW                      float64 `json:"chargePower_kW"`
+	ChargeRateKmph                     int     `json:"chargeRate_kmph"`
 }
 
 // ChargingSettings is the /status.chargingSettings api


### PR DESCRIPTION
This fixes the error messages:
```
[lp-2  ] WARN 2021/03/31 12:18:44 updating soc failed: json: cannot unmarshal number 5.5 into Go struct field ChargingStatus.Data.ChargingStatus.chargePower_kW of type int,
[lp-2  ] ERROR 2021/03/31 12:18:44 vehicle error: json: cannot unmarshal number 5.5 into Go struct field ChargingStatus.Data.ChargingStatus.chargePower_kW of type int,
```

An example dataset for the `ChargingStatus` struct for the ID vehicles looks like this:

```
    "chargingSettings": {,
      "carCapturedTimestamp": "2021-03-31T10:39:48Z",,
      "maxChargeCurrentAC": "reduced",,
      "autoUnlockPlugWhenCharged": "off",,
      "targetSOC_pct": 80,
    },,
```

The current code expects `chargePower_kW` to be `int`, but it is actually a float value.