### PR TITLE
Fixed token refresh not working for Nissan

### DIFF
--- a/internal/vehicle/nissan.go
+++ b/internal/vehicle/nissan.go
@@ -253,8 +253,7 @@ func (v *Nissan) refreshToken() error {
 	uri += "?" + data.Encode()
 	req, err := request.New(http.MethodPost, uri, nil, request.URLEncoding)
 	if err == nil {
-		var tokens oidc.Token
-		if err = v.DoJSON(req, &tokens); err == nil && v.tokens.AccessToken == "" {
+		if err = v.DoJSON(req, &v.tokens); err == nil && v.tokens.AccessToken == "" {
 			err = errors.New("missing access token")
 		}
 	}


### PR DESCRIPTION
The bug reported via #825 leeds to the conclusion that this could fix the issue.

This needs to be tested with proper credentials, as I don’t have any!