### PR TITLE
Fixed porsche bug when VIN is provided

### DIFF
--- a/internal/vehicle/porsche/identity.go
+++ b/internal/vehicle/porsche/identity.go
@@ -220,7 +220,7 @@ func (v *Identity) FindVehicle(accessTokens AccessTokens, vin string) (Vehicle, 
 	var foundVehicle VehicleResponse
 	var foundEmobilityVehicle bool
 
-	if err == nil && vin == "" {
+	if err == nil {
 		if vin == "" && len(vehicles) == 1 {
 			foundVehicle = vehicles[0]
 		} else {


### PR DESCRIPTION
The API didn't work, as no VIN is then assigned to the car and all requests return errors.