### PR TITLE
Add Niu vehicle api

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ EVCC is an extensible EV Charge Controller with PV integration implemented in [G
 - simple and clean user interface
 - multiple [chargers](#charger): Wallbe, Phoenix (includes ESL Walli), go-eCharger, NRGkick (direct Bluetooth or via Connect device), SimpleEVSE, EVSEWifi, KEBA/BMW, openWB, Mobile Charger Connect, Fritz!DECT outlets, Tasmota outlets and any other charger using scripting
 - multiple [meters](#meter): ModBus (Eastron SDM, MPM3PM, SBC ALE3 and many more), Discovergy (using HTTP plugin), SMA Sunny Home Manager and Energy Meter, KOSTAL Smart Energy Meter (KSEM, EMxx), any Sunspec-compatible inverter or home battery devices (Fronius, SMA, SolarEdge, KOSTAL, STECA, E3DC, ...), Tesla PowerWall
-- wide support of vendor-specific [vehicles](#vehicle) interfaces (remote charge, battery and preconditioning status): Audi, BMW, Ford, Hyundai, Kia, Nissan, Porsche, Renault, Seat, Skoda, Tesla, Volkswagen, Volvo and any other connected vehicle using scripting
+- wide support of vendor-specific [vehicles](#vehicle) interfaces (remote charge, battery and preconditioning status): Audi, BMW, Ford, Hyundai, Kia, Nissan, Niu, Porsche, Renault, Seat, Skoda, Tesla, Volkswagen, Volvo and any other connected vehicle using scripting
 - [plugins](#plugins) for integrating with hardware devices and home automation: Modbus (meters and grid inverters), HTTP, MQTT, Javascript, WebSockets and shell scripts
 - status notifications using [Telegram](https://telegram.org) and [PushOver](https://pushover.net)
 - logging using [InfluxDB](https://www.influxdata.com) and [Grafana](https://grafana.com/grafana/)
@@ -246,6 +246,7 @@ Available vehicle remote interface implementations are:
 - `kia`: Kia (Bluelink vehicles like Soul 2019)
 - `hyundai`: Hyundai (Bluelink vehicles like Kona or Ioniq)
 - `nissan`: Nissan (Leaf)
+- `niu`: Niu Scooter
 - `tesla`: Tesla (any model)
 - `renault`: Renault (all ZE models: Zoe, Twingo Electric, Master, Kangoo)
 - `porsche`: Porsche (Taycan)

--- a/internal/vehicle/niu.go
+++ b/internal/vehicle/niu.go
@@ -97,11 +97,7 @@ func (v *Niu) getAccessToken() error {
 
 	uri := niuAuth + "/v3/api/oauth2/token"
 	req, err := request.New(http.MethodPost, uri, strings.NewReader(data.Encode()), map[string]string{
-		"token":           "",
-		"Content-Type":    "application/x-www-form-urlencoded",
-		"Host":            "account-fk.niu.com",
-		"Connection":      "Keep-Alive",
-		"Accept-Encoding": "gzip",
+		"Content-Type": "application/x-www-form-urlencoded",
 	})
 	if err != nil {
 		return err
@@ -125,10 +121,7 @@ func (v *Niu) request(uri string) (*http.Request, error) {
 	}
 
 	req, err := request.New(http.MethodGet, uri, nil, map[string]string{
-		"Content-Type":    "application/json",
-		"token":           v.tokens.Data.Token.AccessToken,
-		"Connection":      "Keep-Alive",
-		"Accept-Encoding": "gzip",
+		"token": v.tokens.Data.Token.AccessToken,
 	})
 
 	return req, err

--- a/internal/vehicle/niu.go
+++ b/internal/vehicle/niu.go
@@ -87,9 +87,15 @@ func (v *Niu) chargeState() (float64, error) {
 
 // getAccessToken implements the Niu oauth2 api
 func (v *Niu) getAccessToken() error {
+
+	md5hash, err := getMD5Hash(v.password)
+	if err != nil {
+		return err
+	}
+
 	data := url.Values{
 		"account":    []string{v.user},
-		"password":   []string{getMD5Hash(v.password)},
+		"password":   []string{md5hash},
 		"grant_type": []string{"password"},
 		"scope":      []string{"base"},
 		"app_id":     []string{"niu_8xt1afu6"},
@@ -128,8 +134,10 @@ func (v *Niu) request(uri string) (*http.Request, error) {
 }
 
 // getMD5Hash creates a MD5 hash based on a string
-func getMD5Hash(text string) string {
+func getMD5Hash(text string) (string, error) {
 	hasher := md5.New()
-	hasher.Write([]byte(text))
-	return hex.EncodeToString(hasher.Sum(nil))
+	if _, err := hasher.Write([]byte(text)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }

--- a/internal/vehicle/niu.go
+++ b/internal/vehicle/niu.go
@@ -1,0 +1,142 @@
+package vehicle
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/andig/evcc/api"
+	"github.com/andig/evcc/internal/vehicle/niu"
+	"github.com/andig/evcc/provider"
+	"github.com/andig/evcc/util"
+	"github.com/andig/evcc/util/request"
+)
+
+const (
+	niuAuth = "https://account-fk.niu.com"
+	niuAPI  = "https://app-api-fk.niu.com"
+)
+
+// Niu is an api.Vehicle implementation for Niu vehicles
+type Niu struct {
+	*embed
+	*request.Helper
+	user, password, sn string
+	tokens             niu.Token
+	accessTokenExpiry  time.Time
+	chargeStateG       func() (float64, error)
+}
+
+func init() {
+	registry.Add("niu", NewNiuFromConfig)
+}
+
+// NewFordFromConfig creates a new vehicle
+func NewNiuFromConfig(other map[string]interface{}) (api.Vehicle, error) {
+	cc := struct {
+		Title              string
+		Capacity           int64
+		User, Password, SN string
+		Cache              time.Duration
+	}{
+		Cache: interval,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.User == "" || cc.Password == "" || cc.SN == "" {
+		return nil, errors.New("missing user, password or sn")
+	}
+
+	log := util.NewLogger("niu")
+
+	v := &Niu{
+		embed:    &embed{cc.Title, cc.Capacity},
+		Helper:   request.NewHelper(log),
+		user:     cc.User,
+		password: cc.Password,
+		sn:       strings.ToUpper(cc.SN),
+	}
+
+	v.chargeStateG = provider.NewCached(v.chargeState, cc.Cache).FloatGetter()
+
+	return v, nil
+}
+
+// SoC implements the api.Vehicle interface
+func (v *Niu) SoC() (float64, error) {
+	return v.chargeStateG()
+}
+
+// chargeState implements the api.Vehicle interface
+func (v *Niu) chargeState() (float64, error) {
+	var socResp niu.SoC
+
+	socReq, err := v.createRequest(niuAPI + "/v3/motor_data/index_info?sn=" + v.sn)
+	if err == nil {
+		err = v.DoJSON(socReq, &socResp)
+	}
+	return float64(socResp.Data.Batteries.CompartmentA.BatteryCharging), err
+}
+
+// getAccessToken implements the Niu oauth2 api
+func (v *Niu) getAccessToken() error {
+	data := url.Values{
+		"account":    []string{v.user},
+		"password":   []string{getMD5Hash(v.password)},
+		"grant_type": []string{"password"},
+		"scope":      []string{"base"},
+		"app_id":     []string{"niu_8xt1afu6"},
+	}
+
+	uri := niuAuth + "/v3/api/oauth2/token"
+	req, err := request.New(http.MethodPost, uri, strings.NewReader(data.Encode()), map[string]string{
+		"token":           "",
+		"Content-Type":    "application/x-www-form-urlencoded",
+		"Host":            "account-fk.niu.com",
+		"Connection":      "Keep-Alive",
+		"Accept-Encoding": "gzip",
+	})
+	if err != nil {
+		return err
+	}
+
+	var tokens niu.Token
+	if err = v.DoJSON(req, &tokens); err == nil {
+		v.tokens = tokens
+		v.accessTokenExpiry = time.Unix(v.tokens.Data.Token.TokenExpiresIn, 0)
+	}
+
+	return err
+}
+
+// createRequest implements the Niu web request
+func (v *Niu) createRequest(uri string) (*http.Request, error) {
+	if v.tokens.Data.Token.AccessToken == "" || v.accessTokenExpiry.Before(time.Now()) {
+		if err := v.getAccessToken(); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := request.New(http.MethodGet, uri, nil, map[string]string{
+		"Content-Type":    "application/json",
+		"token":           v.tokens.Data.Token.AccessToken,
+		"Connection":      "Keep-Alive",
+		"Accept-Encoding": "gzip",
+	})
+
+	return req, err
+}
+
+// getMD5Hash creates a MD5 hash based on a string
+func getMD5Hash(text string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(text))
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/vehicle/niu.go
+++ b/internal/vehicle/niu.go
@@ -78,7 +78,7 @@ func (v *Niu) SoC() (float64, error) {
 func (v *Niu) chargeState() (float64, error) {
 	var socResp niu.SoC
 
-	socReq, err := v.createRequest(niuAPI + "/v3/motor_data/index_info?sn=" + v.sn)
+	socReq, err := v.request(niuAPI + "/v3/motor_data/index_info?sn=" + v.sn)
 	if err == nil {
 		err = v.DoJSON(socReq, &socResp)
 	}
@@ -116,8 +116,8 @@ func (v *Niu) getAccessToken() error {
 	return err
 }
 
-// createRequest implements the Niu web request
-func (v *Niu) createRequest(uri string) (*http.Request, error) {
+// request implements the Niu web request
+func (v *Niu) request(uri string) (*http.Request, error) {
 	if v.tokens.Data.Token.AccessToken == "" || v.accessTokenExpiry.Before(time.Now()) {
 		if err := v.getAccessToken(); err != nil {
 			return nil, err

--- a/internal/vehicle/niu/types.go
+++ b/internal/vehicle/niu/types.go
@@ -1,0 +1,26 @@
+package niu
+
+// Token is the Niu oauth2 api response
+// https://account-fk.niu.com/v3/api/oauth2/token?account=<NiuUser>&app_id=niu_8xt1afu6&grant_type=password&password=<MD5PasswordHash>&scope=base
+type Token struct {
+	Data struct {
+		Token struct {
+			AccessToken           string `json:"access_token,omitempty"`
+			RefreshToken          string `json:"refresh_token,omitempty"`
+			RefreshTokenExpiresIn int64  `json:"refresh_token_expires_in,omitempty"`
+			TokenExpiresIn        int64  `json:"token_expires_in,omitempty"`
+		}
+	}
+}
+
+// SoC is the Niu motor_data api response
+// https://app-api-fk.niu.com/v3/motor_data/index_info?sn=<ScooterSerialNumber>
+type SoC struct {
+	Data struct {
+		Batteries struct {
+			CompartmentA struct {
+				BatteryCharging int64 `json:"batteryCharging,omitempty"`
+			} `json:"compartmentA"`
+		}
+	}
+}

--- a/internal/vehicle/niu/types.go
+++ b/internal/vehicle/niu/types.go
@@ -1,5 +1,10 @@
 package niu
 
+const (
+	Auth = "https://account-fk.niu.com"
+	API  = "https://app-api-fk.niu.com"
+)
+
 // Token is the Niu oauth2 api response
 // https://account-fk.niu.com/v3/api/oauth2/token?account=<NiuUser>&app_id=niu_8xt1afu6&grant_type=password&password=<MD5PasswordHash>&scope=base
 type Token struct {


### PR DESCRIPTION
Hier eine erste Version der niu vehicle api.
Vehicle Config Beispiel:
```
# vehicle definitions
# name can be freely chosen and is used as reference when assigning vehicle to loadpoint
# for examples see https://github.com/andig/evcc-config#vehicles
vehicles:
- name: niu
  title: Niu Scooter  # display name for UI
  capacity: 10 # 10kWh
  type: niu
  user: xxxxxxxxx # Niu app user
  password: xxxxxxxxx # Niu app password
  sn: NXXXXXXXXXXX1 # Niu scooter serial number liek shown in app 
  cache: 5s
```