### PR TITLE
Ford-API: Request status update if required, Get Range & Charge State

### DIFF
--- a/internal/vehicle/ford.go
+++ b/internal/vehicle/ford.go
@@ -111,6 +111,7 @@ func (v *Ford) login() (oauth.Token, error) {
 }
 
 var _ oauth.TokenRefresher = (*Ford)(nil)
+var fordForDebugOnly = false
 
 // Refresh implements the oauth.TokenRefresher interface
 func (v *Ford) Refresh(token *oauth2.Token) (*oauth2.Token, error) {
@@ -133,10 +134,17 @@ func (v *Ford) Refresh(token *oauth2.Token) (*oauth2.Token, error) {
 
 	v.log.DEBUG.Printf("New token: %v", res)
 
+	if !fordForDebugOnly {
+		v.log.DEBUG.Printf("Simulate failed token refresh to force relogin")
+		err = fmt.Errorf("Simulated failed token refresh to force relogin")
+	}
+
 	if err != nil {
 		res, err = v.login()
 		v.log.DEBUG.Printf("Token after new login: %v", res)
 	}
+
+	fordForDebugOnly = true
 
 	return (*oauth2.Token)(&res), err
 }

--- a/internal/vehicle/ford.go
+++ b/internal/vehicle/ford.go
@@ -184,8 +184,8 @@ func (v *Ford) vehicleStatus() (fordVehicleStatus, error) {
 		var lastUpdate time.Time
 		lastUpdate, err = time.Parse(fordTimeFormat, res.VehicleStatus.LastRefresh)
 
-		if err == nil && time.Since(lastUpdate) > fordOutdatedAfter {
-			v.log.DEBUG.Printf("vehicle status is outdated (age %v > %v), requesting refresh", time.Since(lastUpdate), fordOutdatedAfter)
+		if elapsed := time.Since(lastUpdate); err == nil && elapsed > fordOutdatedAfter {
+			v.log.DEBUG.Printf("vehicle status is outdated (age %v > %v), requesting refresh", elapsed, fordOutdatedAfter)
 			res, err = v.vehicleStatusRefresh()
 		}
 	}

--- a/internal/vehicle/ford.go
+++ b/internal/vehicle/ford.go
@@ -53,6 +53,10 @@ func NewFordFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, fmt.Errorf("missing credentials")
+	}
+
 	log := util.NewLogger("ford")
 
 	v := &Ford{

--- a/internal/vehicle/ford.go
+++ b/internal/vehicle/ford.go
@@ -15,18 +15,24 @@ import (
 )
 
 const (
-	fordAuth = "https://fcis.ice.ibmcloud.com"
-	fordAPI  = "https://usapi.cv.ford.com"
+	fordAuth          = "https://fcis.ice.ibmcloud.com"
+	fordAPI           = "https://usapi.cv.ford.com"
+	fordVehicleList   = "https://api.mps.ford.com/api/users/vehicles"
+	outdatedAfterMins = 5 // if returned status value is older than x minutes, evcc will init refresh
 )
 
 // Ford is an api.Vehicle implementation for Ford cars
 type Ford struct {
 	*embed
 	*request.Helper
+	log                 *util.Logger
 	user, password, vin string
 	tokens              oauth.Token
 	chargeStateG        func() (float64, error)
+	statusG             func() (interface{}, error)
 }
+
+/* Initialization of vehicle */
 
 func init() {
 	registry.Add("ford", NewFordFromConfig)
@@ -52,23 +58,30 @@ func NewFordFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	v := &Ford{
 		embed:    &embed{cc.Title, cc.Capacity},
 		Helper:   request.NewHelper(log),
+		log:      log,
 		user:     cc.User,
 		password: cc.Password,
 		vin:      strings.ToUpper(cc.VIN),
 	}
 
-	v.chargeStateG = provider.NewCached(v.chargeState, cc.Cache).FloatGetter()
+	v.statusG = provider.NewCached(func() (interface{}, error) {
+		return v.VehicleStatus()
+	}, cc.Cache).InterfaceGetter()
+
+	// v.chargeStateG = provider.NewCached(v.chargeState, cc.Cache).FloatGetter()
 
 	var err error
 	if cc.VIN == "" {
 		v.vin, err = findVehicle(v.vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", v.vin)
+			v.log.DEBUG.Printf("found vehicle: %v", v.vin)
 		}
 	}
 
 	return v, err
 }
+
+/* Authentication */
 
 func (v *Ford) login(user, password string) error {
 	data := url.Values{
@@ -92,20 +105,45 @@ func (v *Ford) login(user, password string) error {
 	return err
 }
 
-func (v *Ford) request(uri string) (*http.Request, error) {
+/* Helper to send API requests */
+
+func (v *Ford) request(method string, uri string) (*http.Request, error) {
 	if v.tokens.AccessToken == "" || time.Until(v.tokens.Expiry) < time.Minute {
 		if err := v.login(v.user, v.password); err != nil {
 			return nil, err
 		}
 	}
 
-	req, err := request.New(http.MethodGet, uri, nil, map[string]string{
+	req, err := request.New(method, uri, nil, map[string]string{
 		"Content-type":   "application/json",
 		"Application-Id": "71A3AD0A-CF46-4CCF-B473-FC7FE5BC4592",
 		"Auth-Token":     v.tokens.AccessToken,
 	})
 
 	return req, err
+}
+
+type vehicleStatus struct {
+	VehicleStatus struct {
+		BatteryFillLevel struct {
+			Value     float64
+			Timestamp string
+		}
+		ElVehDTE struct {
+			Value     float64
+			Timestamp string
+		}
+		ChargingStatus struct {
+			Value     string
+			Timestamp string
+		}
+		PlugStatus struct {
+			Value     int
+			Timestamp string
+		}
+		LastRefresh string
+	}
+	Status int
 }
 
 // vehicles implements returns the list of user vehicles
@@ -120,7 +158,7 @@ func (v *Ford) vehicles() ([]string, error) {
 
 	var vehicles []string
 
-	req, err := v.request("https://api.mps.ford.com/api/users/vehicles")
+	req, err := v.request(http.MethodGet, fordVehicleList)
 	if err == nil {
 		err = v.DoJSON(req, &resp)
 	}
@@ -134,36 +172,139 @@ func (v *Ford) vehicles() ([]string, error) {
 	return vehicles, err
 }
 
-// chargeState implements the api.Vehicle interface
-func (v *Ford) chargeState() (float64, error) {
-	var resp struct {
-		VehicleStatus struct {
-			Battery struct {
-				BatteryStatusActual struct {
-					Value int
-				}
-			}
-			BatteryFillLevel struct {
-				Value float64
-			}
-		}
+func (v *Ford) CalculateAge(timestamp string) (age time.Duration, err error) {
+	var timestampTime time.Time
+	const dateFormat = "01-02-2006 15:04:05"
+	timestampTime, err = time.Parse(dateFormat, timestamp)
+	age = time.Now().Sub(timestampTime)
 
-		// "chargingStatus": { "value": "EvseNotDetected", ...
-		// "plugStatus": { "value": 1, ...
-		// "batteryChargeStatus": null, ...
+	return age, err
+}
+
+// VehicleStatus implements the /status response
+func (v *Ford) VehicleStatus() (res vehicleStatus, err error) {
+	uri := fmt.Sprintf("%s/api/vehicles/v3/%s/status", fordAPI, v.vin)
+
+	req, err := v.request(http.MethodGet, uri)
+	if err == nil {
+		err = v.DoJSON(req, &res)
 	}
 
-	uri := fmt.Sprintf("%s/api/vehicles/v4/%s/status", fordAPI, v.vin)
+	var statusAge time.Duration
+	statusAge, err = v.CalculateAge(res.VehicleStatus.LastRefresh)
+	v.log.DEBUG.Printf("Vehicle Status Age: %v", statusAge)
+	// todo - Fehlerbehandlung, Timestamp-Format
 
-	req, err := v.request(uri)
+	if statusAge > outdatedAfterMins*time.Minute {
+		// received data is considered outdated, server is requested to poll updated data from vehicle
+		v.log.DEBUG.Print("Vehicle Status is considered as outdated, requesting refresh")
+		var updatedRes vehicleStatus
+		updatedRes, err = v.VehicleStatusRefresh()
+		if err == nil {
+			res = updatedRes
+			statusAge, err = v.CalculateAge(res.VehicleStatus.LastRefresh)
+			v.log.DEBUG.Printf("Refreshed Status Age: %v", statusAge)
+		}
+	}
+
+	return res, err
+}
+
+// Status implements the /status response
+func (v *Ford) VehicleStatusRefresh() (res vehicleStatus, err error) {
+	var commandId string
+	commandId, err = v.requestRefresh()
+
+	if err == nil {
+		uri := fmt.Sprintf("%s/api/vehicles/v3/%s/statusrefresh/%s", fordAPI, v.vin, commandId)
+
+		var req *http.Request
+
+		counter := 0
+		const maxTrials = 20
+		for counter < maxTrials {
+			req, err = v.request(http.MethodGet, uri)
+			if err == nil {
+				err = v.DoJSON(req, &res)
+			} else {
+				break
+			}
+
+			// if status = 200, the update is complete
+			if res.Status == 200 {
+				break
+			}
+
+			v.log.TRACE.Printf("Status of data refresh: %v", res.Status)
+
+			time.Sleep(1500 * time.Millisecond)
+			counter++
+		}
+
+		if counter >= maxTrials && res.Status != 200 {
+			err = fmt.Errorf("update of SoC not completed after timeout")
+			v.log.DEBUG.Print("update of SoC not completed after timeout")
+		}
+	}
+
+	return res, err
+}
+
+// Request API to poll vehicle for updated data
+// returns commandId to get the result after server received data from vehicle
+func (v *Ford) requestRefresh() (string, error) {
+	var resp struct {
+		CommandId string
+	}
+
+	uri := fmt.Sprintf("%s/api/vehicles/v2/%s/status", fordAPI, v.vin)
+	req, err := v.request(http.MethodPut, uri)
 	if err == nil {
 		err = v.DoJSON(req, &resp)
 	}
 
-	return resp.VehicleStatus.BatteryFillLevel.Value, err
+	return resp.CommandId, err
 }
+
+var _ api.Battery = (*Ford)(nil)
 
 // SoC implements the api.Vehicle interface
 func (v *Ford) SoC() (float64, error) {
-	return v.chargeStateG()
+	res, err := v.statusG()
+	if res, ok := res.(vehicleStatus); err == nil && ok {
+		return float64(res.VehicleStatus.BatteryFillLevel.Value), nil
+	}
+
+	return 0, err
+}
+
+var _ api.VehicleRange = (*Ford)(nil)
+
+// Range implements the api.VehicleRange interface
+func (v *Ford) Range() (int64, error) {
+	res, err := v.statusG()
+	if res, ok := res.(vehicleStatus); err == nil && ok {
+		return int64(res.VehicleStatus.ElVehDTE.Value), nil
+	}
+
+	return 0, err
+}
+
+var _ api.ChargeState = (*Ford)(nil)
+
+// Status implements the api.ChargeState interface
+func (v *Ford) Status() (api.ChargeStatus, error) {
+	status := api.StatusA // disconnected
+
+	res, err := v.statusG()
+	if res, ok := res.(vehicleStatus); err == nil && ok {
+		if res.VehicleStatus.PlugStatus.Value == 1 {
+			status = api.StatusB
+		}
+		if res.VehicleStatus.ChargingStatus.Value == "ChargingAC" {
+			status = api.StatusC
+		}
+	}
+
+	return status, err
 }

--- a/internal/vehicle/ford.go
+++ b/internal/vehicle/ford.go
@@ -211,7 +211,7 @@ func (v *Ford) vehicleStatus() (fordVehicleStatus, error) {
 		lastUpdate, err = time.Parse(fordTimeFormat, res.VehicleStatus.LastRefresh)
 
 		if elapsed := time.Since(lastUpdate); err == nil && elapsed > fordOutdatedAfter {
-			v.log.DEBUG.Printf("API provided outdated status (age %v > %v), request refresh from vehicle", elapsed, fordOutdatedAfter)
+			v.log.DEBUG.Printf("vehicle status is outdated (age %v > %v), requesting refresh", elapsed, fordOutdatedAfter)
 			res, err = v.vehicleStatusRefresh()
 		}
 	}


### PR DESCRIPTION
- if server returns an outdated vehicle status (older than 5 minutes), a refresh is requested (Fixes #833)
- vehicle range added for Ford vehicles
- charge state added for Ford vehicles

Tested with Kuga PHEV, no Explorer PHEV and Mach-E available for testing

```me@Johanness-MBP evcc % ./evcc vehicle                           
[main  ] INFO 2021/04/10 20:25:21 evcc 0.50 (b629d07)
[main  ] INFO 2021/04/10 20:25:21 using config file /Users/me/evcc/evcc.yaml
[ford  ] DEBUG 2021/04/10 20:25:23 Vehicle Status is outdated (age 20m28.058948s > 5m), requesting refresh
[ford  ] DEBUG 2021/04/10 20:25:34 Refreshed Status Age: 2.641977s
SoC:           78%
Charge status: A
Capacity:      12kWh
Vehicle range: 33km
```