### PR TITLE
Add useRFID to evseWifi config

### DIFF
--- a/internal/charger/evsewifi.go
+++ b/internal/charger/evsewifi.go
@@ -287,7 +287,7 @@ func (evse *EVSEWifi) Enable(enable bool) error {
 func (evse *EVSEWifi) MaxCurrent(current int64) error {
 	// in rfid mode, when evse is not active - never set less than 6 otherwise it would not be possible
 	// to iniate a charge by the evse again
-	if evse.useRfid && !evse.unlocked {
+	if evse.useRfid {
 		params, err := evse.getParameters()
 		if err != nil {
 			return err


### PR DESCRIPTION
- if set to true the evse should be set to "normal mode" with api enabled
- in "rfid" mode the evse will be considered "leading" and evcc is "just" power control
- charging needs to be started at the evse using rfid or evse webgui
- evvc will not initiate a charge by itself
- evcc will continue an interrupted charge if a charge was sucessfully started until the car is disconnected
- everything else should be business as usual (pv mode should work as expected etc.)