### PR TITLE
fixed not follow enable threshold higher than minCurrent

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -713,7 +713,7 @@ func (lp *LoadPoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64) float6
 
 	if mode == api.ModePV && !lp.enabled {
 		// kick off enable sequence
-		if targetCurrent >= float64(lp.MinCurrent) ||
+		if (lp.Enable.Threshold == 0 && targetCurrent >= float64(lp.MinCurrent)) ||
 			(lp.Enable.Threshold != 0 && sitePower <= lp.Enable.Threshold) {
 			lp.log.DEBUG.Printf("site power %.0fW < enable threshold %.0fW", sitePower, lp.Enable.Threshold)
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -208,7 +208,7 @@ func TestPVHysteresis(t *testing.T) {
 			{-400, dt + 1, 0},
 		}},
 		// keep disabled when threshold (lower minCurrent) not met
-		{false, -600, 0, []se{
+		{false, -500, 0, []se{
 			{-400, 0, 0},
 			{-400, 1, 0},
 			{-400, dt - 1, 0},

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -208,11 +208,11 @@ func TestPVHysteresis(t *testing.T) {
 			{-400, dt + 1, 0},
 		}},
 		// keep disabled when threshold not met
-		{false, -500, 0, []se{
-			{-400, 0, 0},
-			{-400, 1, 0},
-			{-400, dt - 1, 0},
-			{-400, dt + 1, 0},
+		{false, -7 * 100 * 10, 0, []se{
+			{-6 * 100 * 10, 0, 0},
+			{-6 * 100 * 10, 1, 0},
+			{-6 * 100 * 10, dt - 1, 0},
+			{-6 * 100 * 10, dt + 1, 0},
 		}},
 		// enable when threshold met
 		{false, -500, 0, []se{

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -207,7 +207,14 @@ func TestPVHysteresis(t *testing.T) {
 			{-400, dt - 1, 0},
 			{-400, dt + 1, 0},
 		}},
-		// keep disabled when threshold not met
+		// keep disabled when threshold (lower minCurrent) not met
+		{false, -600, 0, []se{
+			{-400, 0, 0},
+			{-400, 1, 0},
+			{-400, dt - 1, 0},
+			{-400, dt + 1, 0},
+		}},
+		// keep disabled when threshold (higher minCurrent) not met
 		{false, -7 * 100 * 10, 0, []se{
 			{-6 * 100 * 10, 0, 0},
 			{-6 * 100 * 10, 1, 0},


### PR DESCRIPTION
The enable threshold was only considered if it is smaller than minCurrent * numberOfPhases * voltage.

I want to enable charging with 1-phase only, if more than 1600 W is fed in. This threshold was not followed, because the TargetCurrent always exceeded the 6A minCurrent before.