### PR TITLE
Changed max charge current debug output to fixed one digit format

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -678,7 +678,7 @@ func (lp *LoadPoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64) float6
 	deltaCurrent := powerToCurrent(-sitePower, lp.Phases)
 	targetCurrent := math.Max(math.Min(effectiveCurrent+deltaCurrent, float64(lp.MaxCurrent)), 0)
 
-	lp.log.DEBUG.Printf("max charge current: %.2gA = %.2gA + %.2gA (%.0fW @ %dp)", targetCurrent, effectiveCurrent, deltaCurrent, sitePower, lp.Phases)
+	lp.log.DEBUG.Printf("max charge current: %.1fA = %.1fA + %.1fA (%.0fW @ %dp)", targetCurrent, effectiveCurrent, deltaCurrent, sitePower, lp.Phases)
 
 	// in MinPV mode return at least minCurrent
 	if mode == api.ModeMinPV && targetCurrent < float64(lp.MinCurrent) {


### PR DESCRIPTION
Die Formatierung `%.2g` führte bei Werten ab 10 dazu, dass keine Nachkommastellen angezeigt werden. Keine Ahnung, warum go dies als Optimierung angesehen hat, wenn auch Nachkommastellen vorhanden waren.

`[lp-1  ] DEBUG 2021/04/18 12:33:02 max charge current: 14A = 13A + 11A (-2500W @ 1p)`

Mit der Formatierung `%.1f` wird zwar immer eine Nachkommastelle angezeigt, aber diese wird auch bei hohen Werten benötigt.

`[lp-1  ] DEBUG 2021/04/18 12:30:59 max charge current: 14.0A = 12.8A + 14.6A (-3360W @ 1p)`