### PR TITLE
Allow charger to access loadpoint by implementing core.LoadpointController

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -421,6 +421,11 @@ func (lp *LoadPoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 	} else {
 		lp.log.ERROR.Printf("charger error: %v", err)
 	}
+
+	// allow charger to  access loadpoint
+	if ctrl, ok := lp.charger.(LoadpointController); ok {
+		ctrl.LoadpointControl(lp)
+	}
 }
 
 func (lp *LoadPoint) syncCharger() {

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -7,6 +7,11 @@ import (
 	"github.com/andig/evcc/core/wrapper"
 )
 
+// LoadpointController gives access to loadpoint
+type LoadpointController interface {
+	LoadpointControl(LoadPointAPI)
+}
+
 // LoadPointAPI is the external loadpoint API
 type LoadPointAPI interface {
 	Name() string

--- a/internal/charger/easee.go
+++ b/internal/charger/easee.go
@@ -23,6 +23,7 @@ type Easee struct {
 	status        easee.ChargerStatus
 	updated       time.Time
 	cache         time.Duration
+	lp            core.LoadPointAPI
 }
 
 func init() {
@@ -257,4 +258,11 @@ func (c *Easee) Currents() (float64, float64, float64, error) {
 		res.CircuitTotalPhaseConductorCurrentL2,
 		res.CircuitTotalPhaseConductorCurrentL3,
 		err
+}
+
+var _ core.LoadpointController = (*Easee)(nil)
+
+// LoadpointControl implements core.LoadpointController
+func (c *Easee) LoadpointControl(lp core.LoadPointAPI) {
+	c.lp = lp
 }


### PR DESCRIPTION
@naltatis damit kannst Du die Methoden von `core.LoadPointAPI` aus https://github.com/andig/evcc/blob/master/core/loadpoint_api.go#L11 aufrufen.