### PR TITLE
TP-Link charger: add ChargedEnergy based on get_daystat cmd

### DIFF
--- a/internal/charger/tplink/types.go
+++ b/internal/charger/tplink/types.go
@@ -41,7 +41,7 @@ type EmeterResponse struct {
 	} `json:"emeter"`
 }
 
-// EmeterResponse is the TP-Link plug/outlet api emeter get_realtime get_daystat response
+// DayStatResponse is the TP-Link plug/outlet api emeter get_realtime get_daystat response
 type DayStatResponse struct {
 	Emeter struct {
 		GetDaystat struct {

--- a/internal/charger/tplink/types.go
+++ b/internal/charger/tplink/types.go
@@ -21,21 +21,41 @@ type SystemResponse struct {
 	} `json:"system"`
 }
 
-// EmeterResponse is the TP-Link plug/outlet api emeter response
+// EmeterResponse is the TP-Link plug/outlet api emeter get_realtime response
 type EmeterResponse struct {
 	Emeter struct {
 		GetRealtime struct {
-			// 1st plug generation E-Meter Response
+			// 1st plug generation E-Meter get_realtime Response
 			Current float64 `json:"current,omitempty"`
 			Voltage float64 `json:"voltage,omitempty"`
 			Power   float64 `json:"power,omitempty"`
 			Total   float64 `json:"total,omitempty"`
-			// 2nd plug generation E-Meter Response
+			// 2nd plug generation E-Meter get_realtime Response
 			CurrentMa float64 `json:"current_ma,omitempty"`
 			VoltageMv float64 `json:"voltage_mv,omitempty"`
 			PowerMw   float64 `json:"power_mw,omitempty"`
 			TotalWh   float64 `json:"total_wh,omitempty"`
-			ErrCode   int     `json:"err_code,omitempty"`
+			// Common E-Meter get_realtime Response
+			ErrCode int `json:"err_code,omitempty"`
 		} `json:"get_realtime"`
+	} `json:"emeter"`
+}
+
+// EmeterResponse is the TP-Link plug/outlet api emeter get_realtime get_daystat response
+type DayStatResponse struct {
+	Emeter struct {
+		GetDaystat struct {
+			DayList []struct {
+				Year  int `json:"year,omitempty"`
+				Month int `json:"month,omitempty"`
+				Day   int `json:"day,omitempty"`
+				// 1st plug generation E-Meter get_daystat Response
+				Energy float64 `json:"energy,omitempty"`
+				// 2nd plug generation E-Meter get_daystat Response
+				EnergyWh float64 `json:"energy_wh,omitempty"`
+			} `json:"day_list"`
+			// Common E-Meter get_daystat Response
+			ErrCode int `json:"err_code,omitempty"`
+		} `json:"get_daystat"`
 	} `json:"emeter"`
 }

--- a/internal/charger/tplink/types_test.go
+++ b/internal/charger/tplink/types_test.go
@@ -41,7 +41,7 @@ func TestUnmarshalTPLinkSystemResponses(t *testing.T) {
 		t.Error("GetSysinfo.Feature")
 	}
 
-	// Test 1st emeter generation response
+	// Test 1st emeter generation get_realtime response
 	var emeresp EmeterResponse
 	jsonstr = `{"emeter":{"get_realtime":{"current":0.033759,"voltage":234.824322,"power":3.121391,"total":0.015000,"err_code":0}}}`
 	if err := json.Unmarshal([]byte(jsonstr), &emeresp); err != nil {
@@ -63,9 +63,9 @@ func TestUnmarshalTPLinkSystemResponses(t *testing.T) {
 		t.Error("GetRealtime.ErrCode")
 	}
 
-	// Test 2nd emeter generation response
+	// Test 2nd emeter generation get_realtime response
 	var emeresp2 EmeterResponse
-	jsonstr = ` {"emeter":{"get_realtime":{"voltage_mv":237119,"current_ma":218,"power_mw":31259,"total_wh":107,"err_code":0}}}`
+	jsonstr = `{"emeter":{"get_realtime":{"voltage_mv":237119,"current_ma":218,"power_mw":31259,"total_wh":107,"err_code":0}}}`
 	if err := json.Unmarshal([]byte(jsonstr), &emeresp2); err != nil {
 		t.Error(err)
 	}
@@ -85,4 +85,47 @@ func TestUnmarshalTPLinkSystemResponses(t *testing.T) {
 		t.Error("GetRealtime.ErrCode")
 	}
 
+	// Test 1st emeter generation get_daystat response
+	var dstatresp DayStatResponse
+	jsonstr = `{"emeter":{"get_daystat":{"day_list":[{"year":2021,"month":4,"day":22,"energy":0},{"year":2021,"month":4,"day":23,"energy":0.016000},{"year":2021,"month":4,"day":24,"energy":0.020000},{"year":2021,"month":4,"day":25,"energy":0.005000},{"year":2021,"month":4,"day":26,"energy":0.245000}],"err_code":0}}}`
+	if err := json.Unmarshal([]byte(jsonstr), &dstatresp); err != nil {
+		t.Error(err)
+	}
+	if dstatresp.Emeter.GetDaystat.DayList[len(dstatresp.Emeter.GetDaystat.DayList)-1].Year != 2021 {
+		t.Error("GetDaystat.DayList[last].Year")
+	}
+	if dstatresp.Emeter.GetDaystat.DayList[len(dstatresp.Emeter.GetDaystat.DayList)-1].Month != 4 {
+		t.Error("GetDaystat.DayList[last].Month")
+	}
+	if dstatresp.Emeter.GetDaystat.DayList[len(dstatresp.Emeter.GetDaystat.DayList)-1].Day != 26 {
+		t.Error("GetDaystat.DayList[last].Day")
+	}
+	if dstatresp.Emeter.GetDaystat.DayList[len(dstatresp.Emeter.GetDaystat.DayList)-1].Energy != 0.245 {
+		t.Error("GetDaystat.DayList[last].Energy")
+	}
+	if dstatresp.Emeter.GetDaystat.ErrCode != 0 {
+		t.Error("GetDaystat.ErrCode")
+	}
+
+	// Test 2nd emeter generation get_daystat response
+	var dstatresp2 DayStatResponse
+	jsonstr = `{"emeter":{"get_daystat":{"day_list":[{"year":2021,"month":4,"day":18,"energy_wh":3},{"year":2021,"month":4,"day":19,"energy_wh":0},{"year":2021,"month":4,"day":20,"energy_wh":2029},{"year":2021,"month":4,"day":21,"energy_wh":1201},{"year":2021,"month":4,"day":22,"energy_wh":0},{"year":2021,"month":4,"day":23,"energy_wh":1059}],"err_code":0}}}`
+	if err := json.Unmarshal([]byte(jsonstr), &dstatresp2); err != nil {
+		t.Error(err)
+	}
+	if dstatresp2.Emeter.GetDaystat.DayList[len(dstatresp2.Emeter.GetDaystat.DayList)-1].Year != 2021 {
+		t.Error("GetDaystat.DayList[last].Year")
+	}
+	if dstatresp2.Emeter.GetDaystat.DayList[len(dstatresp2.Emeter.GetDaystat.DayList)-1].Month != 4 {
+		t.Error("GetDaystat.DayList[last].Month")
+	}
+	if dstatresp2.Emeter.GetDaystat.DayList[len(dstatresp2.Emeter.GetDaystat.DayList)-1].Day != 23 {
+		t.Error("GetDaystat.DayList[last].Day")
+	}
+	if dstatresp2.Emeter.GetDaystat.DayList[len(dstatresp2.Emeter.GetDaystat.DayList)-1].EnergyWh != 1059 {
+		t.Error("GetDaystat.DayList[last].EnergyWh")
+	}
+	if dstatresp2.Emeter.GetDaystat.ErrCode != 0 {
+		t.Error("GetDaystat.ErrCode")
+	}
 }


### PR DESCRIPTION
Charger provides charged energy based on internal daily statistic.

```
xxx@xxx:~/evcc/git/evcc$ ./evcc -c evcc_tplink.yaml charger -l trace
[main  ] INFO 2021/04/26 22:30:26 evcc 0.53 (fb4dde7)
[main  ] INFO 2021/04/26 22:30:26 using config file evcc_tplink.yaml
[tplink] TRACE 2021/04/26 22:30:26 recv: {"emeter":{"get_realtime":{"current":0.016668,"voltage":233.582539,"power":0,"total":0.077000,"err_code":0}}}
[tplink] TRACE 2021/04/26 22:30:26 recv: {"emeter":{"get_realtime":{"current":0.016668,"voltage":233.582539,"power":0,"total":0.077000,"err_code":0}}}
[tplink] TRACE 2021/04/26 22:30:26 recv: {"system":{"get_sysinfo":{"err_code":0,"sw_ver":"1.2.6 Build 200727 Rel.120821","hw_ver":"1.0","type":"IOT.SMARTPLUGSWITCH","model":"HS110(EU)","mac":"50:C7:BF:42:60:9B","deviceId":"80068B6B73AAD8C4A4D0F7B9AB5F8B1B1838EEAC","hwId":"45E29DA8382494D2E82688B52A0B2EB5","fwId":"00000000000000000000000000000000","oemId":"3D341ECE302C0642C99E31CE2430544B","alias":"evcc-charger","dev_name":"Wi-Fi Smart Plug With Energy Monitoring","icon_hash":"","relay_state":1,"on_time":685657,"active_mode":"schedule","feature":"TIM:ENE","updating":0,"rssi":-56,"led_off":0,"latitude":49.817090,"longitude":9.056194}}}
[tplink] TRACE 2021/04/26 22:30:26 recv: {"emeter":{"get_daystat":{"day_list":[{"year":2021,"month":4,"day":22,"energy":0},{"year":2021,"month":4,"day":23,"energy":0.016000},{"year":2021,"month":4,"day":24,"energy":0.020000},{"year":2021,"month":4,"day":25,"energy":0.005000},{"year":2021,"month":4,"day":26,"energy":0}],"err_code":0}}}
Power:         0W
Charge status: B
Enabled:       true
Charged:       0.0kWh
```