### PR TITLE
Pseudo charger/feature sync

### DIFF
--- a/internal/charger/fritzdect.go
+++ b/internal/charger/fritzdect.go
@@ -215,8 +215,7 @@ func (c *FritzDECT) ChargedEnergy() (float64, error) {
 
 	// select energy value of current day
 	energylist := strings.Split(statsresp.Energy.Values[1], ",")
-	var energy float64
-	energy, err = strconv.ParseFloat(energylist[0], 64)
+	energy, err := strconv.ParseFloat(energylist[0], 64)
 
 	return energy / 1000, err
 }

--- a/internal/charger/fritzdect.go
+++ b/internal/charger/fritzdect.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"math"
 	"net/url"
 	"strconv"
 	"strings"
@@ -205,20 +204,19 @@ func (c *FritzDECT) ChargedEnergy() (float64, error) {
 	// fetch basicdevicestats
 	resp, err := c.execFritzDectCmd("getbasicdevicestats")
 	if err != nil {
-		return math.NaN(), err
+		return 0, err
 	}
 
 	// unmarshal devicestats
 	var statsresp fritzdect.Devicestats
-	err = xml.Unmarshal([]byte(resp), &statsresp)
-	if err != nil {
-		return math.NaN(), err
+	if err = xml.Unmarshal([]byte(resp), &statsresp); err != nil {
+		return 0, err
 	}
 
 	// select energy value of current day
-	energylst := strings.Split(statsresp.Energy.Values[1], ",")
+	energylist := strings.Split(statsresp.Energy.Values[1], ",")
 	var energy float64
-	energy, err = strconv.ParseFloat(energylst[0], 64)
+	energy, err = strconv.ParseFloat(energylist[0], 64)
 
 	return energy / 1000, err
 }

--- a/internal/charger/fritzdect/types.go
+++ b/internal/charger/fritzdect/types.go
@@ -1,0 +1,14 @@
+package fritzdect
+
+import "encoding/xml"
+
+// getdevicestats command response (AHA-HTTP-Interface)
+type Devicestats struct {
+	XMLName xml.Name `xml:"devicestats"`
+	Energy  Energy   `xml:"energy"`
+}
+
+type Energy struct {
+	XMLName xml.Name `xml:"energy"`
+	Values  []string `xml:"stats"`
+}

--- a/internal/charger/fritzdect/types.go
+++ b/internal/charger/fritzdect/types.go
@@ -2,12 +2,13 @@ package fritzdect
 
 import "encoding/xml"
 
-// getdevicestats command response (AHA-HTTP-Interface)
+// Devicestats structures getbasicdevicesstats command response (AHA-HTTP-Interface)
 type Devicestats struct {
 	XMLName xml.Name `xml:"devicestats"`
 	Energy  Energy   `xml:"energy"`
 }
 
+// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
 type Energy struct {
 	XMLName xml.Name `xml:"energy"`
 	Values  []string `xml:"stats"`

--- a/internal/charger/tasmota.go
+++ b/internal/charger/tasmota.go
@@ -139,6 +139,21 @@ func (c *Tasmota) CurrentPower() (float64, error) {
 	return power, err
 }
 
+var _ api.ChargeRater = (*Tasmota)(nil)
+
+// ChargedEnergy implements the api.ChargeRater interface
+func (c *Tasmota) ChargedEnergy() (float64, error) {
+	var tStatusSNS tasmota.StatusSNSResponse
+
+	// Execute Tasmota Status 8 command
+	err := c.GetJSON(c.cmdUri("Status 8"), &tStatusSNS)
+	if err != nil {
+		return math.NaN(), err
+	}
+
+	return float64(tStatusSNS.StatusSNS.Energy.Today), err
+}
+
 // cmdUri creates the Tasmota command web request
 // https://tasmota.github.io/docs/Commands/#with-web-requests
 func (c *Tasmota) cmdUri(cmd string) string {

--- a/internal/charger/tasmota.go
+++ b/internal/charger/tasmota.go
@@ -36,7 +36,6 @@ func NewTasmotaFromConfig(other map[string]interface{}) (api.Charger, error) {
 		Password     string
 		StandbyPower float64
 	}{}
-
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
@@ -51,7 +50,6 @@ func NewTasmotaFromConfig(other map[string]interface{}) (api.Charger, error) {
 // NewTasmota creates Tasmota charger
 func NewTasmota(uri, user, password string, standbypower float64) (*Tasmota, error) {
 	log := util.NewLogger("tasmota")
-
 	c := &Tasmota{
 		Helper:       request.NewHelper(log),
 		uri:          strings.TrimRight(uri, "/"),
@@ -59,7 +57,6 @@ func NewTasmota(uri, user, password string, standbypower float64) (*Tasmota, err
 		password:     password,
 		standbypower: standbypower,
 	}
-
 	c.Client.Transport = request.NewTripper(log, request.InsecureTransport())
 
 	return c, nil
@@ -68,23 +65,18 @@ func NewTasmota(uri, user, password string, standbypower float64) (*Tasmota, err
 // Enabled implements the api.Charger interface
 func (c *Tasmota) Enabled() (bool, error) {
 	var resp tasmota.StatusResponse
-
-	// Execute Tasmota Status 0 command
 	err := c.GetJSON(c.cmdUri("Status 0"), &resp)
 
-	return int(1) == resp.Status.Power, err
+	return resp.Status.Power == 1, err
 }
 
 // Enable implements the api.Charger interface
 func (c *Tasmota) Enable(enable bool) error {
 	var resp tasmota.PowerResponse
-
 	cmd := "Power off"
 	if enable {
 		cmd = "Power on"
 	}
-
-	// Execute Tasmota Power on/off command
 	err := c.GetJSON(c.cmdUri(cmd), &resp)
 
 	switch {
@@ -121,8 +113,6 @@ var _ api.Meter = (*Tasmota)(nil)
 // CurrentPower implements the api.Meter interface
 func (c *Tasmota) CurrentPower() (float64, error) {
 	var resp tasmota.StatusSNSResponse
-
-	// Execute Tasmota Status 8 command
 	err := c.GetJSON(c.cmdUri("Status 8"), &resp)
 	power := float64(resp.StatusSNS.Energy.Power)
 
@@ -139,8 +129,6 @@ var _ api.ChargeRater = (*Tasmota)(nil)
 // ChargedEnergy implements the api.ChargeRater interface
 func (c *Tasmota) ChargedEnergy() (float64, error) {
 	var resp tasmota.StatusSNSResponse
-
-	// Execute Tasmota Status 8 command
 	err := c.GetJSON(c.cmdUri("Status 8"), &resp)
 
 	return float64(resp.StatusSNS.Energy.Today), err


### PR DESCRIPTION
Dieser PR führt auch für die "pseudo" Charger FritzDect und Tasmato die ChargedEnergy Funktion auf Basis des in den Steckdosen mitgeschnittenen täglichen Energieverbrauchs ein.
Damit wären dann alle evcc "pseudo" Charger Feature-mäßig in sync.   