### PR TITLE
evcc.dist.yaml: linted version

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -107,7 +107,7 @@ loadpoints:
     disable:          # pv mode disable behavior
       delay: 10m      # threshold must be exceeded for this long
       threshold: 200  # maximum import power (W)
-    # Avoid switch of charger contactor more often than guardduration
+    # avoid switch of charger contactor more often than guardduration
     guardduration: 5m  # (default 10m)
     mincurrent: 6      # minimum charge current (default 6A)
     maxcurrent: 16     # maximum charge current (default 16A)

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -1,5 +1,6 @@
-uri: 0.0.0.0:7070 # uri for ui
-interval: 10s # control cycle interval
+---
+uri: 0.0.0.0:7070  # uri for ui
+interval: 10s      # control cycle interval
 
 # sponsor token enables optional features (request at https://cloud.evcc.io)
 # sponsortoken:
@@ -12,133 +13,142 @@ levels:
   lp-2: debug
 
 # meter definitions
-# name can be freely chosen and is used as reference when assigning meters to site and loadpoints
+# name can be freely chosen
+# and is used as reference when assigning meters to site and loadpoints
 # for examples see https://github.com/andig/evcc-config#meters
 meters:
-- name: grid
-  type: modbus
-  model: sdm # SDM630
-  uri: rs485.fritz.box:23
-  rtu: true # rs485 device connected using ethernet adapter
-  id: 2
-  power: Power # default value, optionally override
-  energy: Sum # default value, optionally override
-- name: pv
-  type: ...
-- name: battery
-  type: ...
-- name: charge
-  type: ...
+  - name: grid
+    type: modbus
+    model: sdm  # SDM630
+    uri: rs485.fritz.box:23
+    rtu: true   # rs485 device connected using ethernet adapter
+    id: 2
+    power: Power  # default value, optionally override
+    energy: Sum   # default value, optionally override
+  - name: pv
+    type: ...
+  - name: battery
+    type: ...
+  - name: charge
+    type: ...
 
 # charger definitions
-# name can be freely chosen and is used as reference when assigning charger to vehicle
+# name can be freely chosen and
+# is used as reference when assigning charger to vehicle
 # for examples see https://github.com/andig/evcc-config#chargers
 chargers:
-- name: wallbe
-  type: wallbe # Wallbe charger
-  uri: 192.168.0.8:502 # ModBus address
-- name: keba
-  type: ...
+  - name: wallbe
+    type: wallbe          # Wallbe charger
+    uri: 192.168.0.8:502  # ModBus address
+  - name: keba
+    type: ...
 
 # vehicle definitions
-# name can be freely chosen and is used as reference when assigning vehicle to loadpoint
+# name can be freely chosen and
+# is used as reference when assigning vehicle to loadpoint
 # for examples see https://github.com/andig/evcc-config#vehicles
 vehicles:
-- name: renault
-  type: renault
-  title: Zoe
-  capacity: 60 # kWh
-  user: # user
-  password: # password
-  vin: WREN...
-  cache: 5m
+  - name: renault
+    type: renault
+    title: Zoe
+    capacity: 60  # kWh
+    user:         # user
+    password:     # password
+    vin: WREN...
+    cache: 5m
 
 # site describes the EVU connection, PV and home battery
 site:
-  title: Home # display name for UI
+  title: Home         # display name for UI
   meters:
-    grid: grid # grid meter
-    pv: pv # pv meter
-    battery: battery # battery meter
-  prioritySoC: 60 # give home battery priority up to this soc (0 to disable)
+    grid: grid        # grid meter
+    pv: pv            # pv meter
+    battery: battery  # battery meter
+  prioritySoC: 60     # give home battery priority up to this soc (0 to disable)
 
 # loadpoint describes the charger, charge meter and connected vehicle
 loadpoints:
-- title: Garage # display name for UI
-  charger: wallbe # charger
-  meters:
-    charge: charge # charge meter
-  vehicle: audi
-  # vehicles: # use if multiple vehicles allowed to charge on this loadpoint
-  # - ID.3
-  # - e-Up
-  mode: pv
-  soc:
+  - title: Garage     # display name for UI
+    charger: wallbe   # charger
+    meters:
+      charge: charge  # charge meter
+    vehicle: audi
+    # vehicles: # use if multiple vehicles allowed to charge on this loadpoint
+    # - ID.3
+    # - e-Up
+    mode: pv
+    soc:
     # polling defines usage of the vehicle APIs
-    # Modifying the default settings it NOT recommended. It MAY deplete your vehicle's battery
-    # or lead to vehicle manufacturer banning you from API use. USE AT YOUR OWN RISK.
+    # Modifying the default settings it NOT recommended.
+    # It MAY deplete your vehicle's battery or
+    # lead to vehicle manufacturer banning you from API use.
+    # USE AT YOUR OWN RISK.
     poll:
-      # poll mode defines under which condition the vehicle API is called:
-      #   charging: update vehicle ONLY when charging (this is the recommended default)
-      #   connected: update vehicle when connected (not only charging), interval defines how often
-      #   always: always update vehicle regardless of connection state, interval defines how often
+      # mode defines under which condition the vehicle API is called:
+      #  charging - update vehicle ONLY when charging (recommended default)
+      #  connected - update vehicle when connected (not only charging)
+      #  always - always update vehicle regardless of connection state
       mode: charging
-      # poll interval defines how often the vehicle API may be polled if NOT charging
+      # interval defines in which frequency the vehicle API
+      # may be polled if NOT charging in poll modes connected or always
       interval: 60m
-    min: 0 # immediately charge to 0% regardless of mode unless "off" (disabled)
-    target: 100 # always charge to 100%
-    estimate: false # set true to interpolate between api updates
-  onDisconnect: # set defaults when vehicle disconnects
-    mode: pv # switch back to pv mode
-    targetSoC: 100 # charge to 100%
-  phases: 3 # ev phases (default 3)
-  enable: # pv mode enable behavior
-    delay: 1m # threshold must be exceeded for this long
-    threshold: 0 # minimum export power (W). If zero, export must exceed minimum charge power to enable
-  disable: # pv mode disable behavior
-    delay: 10m # threshold must be exceeded for this long
-    threshold: 200 # maximum import power (W)
-  guardduration: 5m # switch charger contactor not more often than this (default 10m)
-  mincurrent: 6 # minimum charge current (default 6A)
-  maxcurrent: 16 # maximum charge current (default 16A)
+    min: 0  # instant charge to 0% regardless of mode unless "off" (disabled)
+    target: 100       # always charge to 100%
+    estimate: false   # set true to interpolate between api updates
+    onDisconnect:     # set defaults when vehicle disconnects
+      mode: pv        # switch back to pv mode
+      targetSoC: 100  # charge to 100%
+    phases: 3         # ev phases (default 3)
+    enable:           # pv mode enable behavior
+      delay: 1m       # threshold must be exceeded for this long
+      # minimum export power threshold (W). If zero,
+      # export must exceed minimum charge power to enable
+      threshold: 0
+    disable:          # pv mode disable behavior
+      delay: 10m      # threshold must be exceeded for this long
+      threshold: 200  # maximum import power (W)
+    # Avoid switch of charger contactor more often than guardduration
+    guardduration: 5m  # (default 10m)
+    mincurrent: 6      # minimum charge current (default 6A)
+    maxcurrent: 16     # maximum charge current (default 16A)
 
 # mqtt message broker
 mqtt:
-  # broker: localhost:1883
-  # topic: evcc # root topic for publishing, set empty to disable
-  # user:
-  # password:
+# broker: localhost:1883
+# topic: evcc # root topic for publishing, set empty to disable
+# user:
+# password:
 
 # influx database
 influx:
-  # url: http://localhost:8086
-  # database: evcc
-  # user:
-  # password:
+# url: http://localhost:8086
+# database: evcc
+# user:
+# password:
 
 # push messages
 messaging:
   events:
-    start: # charge start event
+    start:       # charge start event
       title: Charge started
       msg: Started charging in "${mode}" mode
-    stop: # charge stop event
+    stop:        # charge stop event
       title: Charge finished
       msg: Finished charging ${chargedEnergy:%.1fk}kWh in ${chargeDuration}.
-    connect: # vehicle connect event
+    connect:     # vehicle connect event
       title: Car connected
       msg: "Car connected at ${pvPower:%.1fk}kW PV"
-    disconnect: # vehicle connected event
+    disconnect:  # vehicle connected event
       title: Car disconnected
       msg: Car disconnected after ${connectedDuration}
   services:
   # - type: pushover
-  #   app: # app id
+  #   app:  # app id
   #   recipients:
   #   - # list of recipient ids
   # - type: telegram
-  #   token: # bot id
+  #   token:  # bot id
   #   chats:
   #   - # list of chat ids
   # - type: email
-  #   uri: smtp://<user>:<password>@<host>:<port>/?fromAddress=<from>&toAddresses=<to>
+  #   uri: smtp://<usr>:<pwd>@<host>:<port>/?fromAddress=<from>&toAddresses=<to>


### PR DESCRIPTION
Ich habe meine evcc Entwicklungs-Configs mal über [yamllint](http://manpages.ubuntu.com/manpages/groovy/man1/yamllint.1.html) laufen lassen, um sie sauber zu strukturieren.
Hab' dass dann auch mal für die evcc.dist.yaml gemacht (Log siehe unten).
Die Version hier im PR wirft keine Meldungen mehr aus. 
Ist evtl. auch Tip für Einsteiger, die Probleme mit dem Erstellen ihrer ersten evcc.yaml haben.
```
xxxx@xxxx:~/evcc/git/evcc$ yamllint ./evcc.dist.yaml
./evcc.dist.yaml
  1:1       warning  missing document start "---"  (document-start)
  1:19      warning  too few spaces before comment  (comments)
  2:15      warning  too few spaces before comment  (comments)
  15:81     error    line too long (97 > 80 characters)  (line-length)
  18:1      error    wrong indentation: expected 2 but found 0  (indentation)
  20:14     warning  too few spaces before comment  (comments)
  22:13     warning  too few spaces before comment  (comments)
  24:16     warning  too few spaces before comment  (comments)
  25:15     warning  too few spaces before comment  (comments)
  34:81     error    line too long (86 > 80 characters)  (line-length)
  37:1      error    wrong indentation: expected 2 but found 0  (indentation)
  38:16     warning  too few spaces before comment  (comments)
  39:24     warning  too few spaces before comment  (comments)
  44:81     error    line too long (88 > 80 characters)  (line-length)
  47:1      error    wrong indentation: expected 2 but found 0  (indentation)
  50:16     warning  too few spaces before comment  (comments)
  51:9      warning  too few spaces before comment  (comments)
  52:13     warning  too few spaces before comment  (comments)
  58:15     warning  too few spaces before comment  (comments)
  60:16     warning  too few spaces before comment  (comments)
  61:12     warning  too few spaces before comment  (comments)
  62:22     warning  too few spaces before comment  (comments)
  63:19     warning  too few spaces before comment  (comments)
  67:1      error    wrong indentation: expected 2 but found 0  (indentation)
  67:17     warning  too few spaces before comment  (comments)
  68:19     warning  too few spaces before comment  (comments)
  70:20     warning  too few spaces before comment  (comments)
  78:81     error    line too long (94 > 80 characters)  (line-length)
  79:81     error    line too long (85 > 80 characters)  (line-length)
  82:81     error    line too long (87 > 80 characters)  (line-length)
  83:81     error    line too long (98 > 80 characters)  (line-length)
  84:81     error    line too long (98 > 80 characters)  (line-length)
  86:81     error    line too long (85 > 80 characters)  (line-length)
  88:12     warning  too few spaces before comment  (comments)
  89:17     warning  too few spaces before comment  (comments)
  90:21     warning  too few spaces before comment  (comments)
  91:17     warning  too few spaces before comment  (comments)
  92:14     warning  too few spaces before comment  (comments)
  93:20     warning  too few spaces before comment  (comments)
  94:13     warning  too few spaces before comment  (comments)
  95:11     warning  too few spaces before comment  (comments)
  96:15     warning  too few spaces before comment  (comments)
  97:18     warning  too few spaces before comment  (comments)
  97:81     error    line too long (103 > 80 characters)  (line-length)
  98:12     warning  too few spaces before comment  (comments)
  99:16     warning  too few spaces before comment  (comments)
  100:20    warning  too few spaces before comment  (comments)
  101:21    warning  too few spaces before comment  (comments)
  101:81    error    line too long (85 > 80 characters)  (line-length)
  102:17    warning  too few spaces before comment  (comments)
  103:18    warning  too few spaces before comment  (comments)
  107:3     warning  comment not indented like content  (comments-indentation)
  114:3     warning  comment not indented like content  (comments-indentation)
  122:12    warning  too few spaces before comment  (comments)
  125:11    warning  too few spaces before comment  (comments)
  128:14    warning  too few spaces before comment  (comments)
  131:17    warning  too few spaces before comment  (comments)
  144:81    error    line too long (86 > 80 characters)  (line-length)
```