### PR TITLE
NRGKick-BT charger: handle missing BT device

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-runewidth v0.0.12 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/muka/go-bluetooth v0.0.0-20201211051136-07f31c601d33
+	github.com/muka/go-bluetooth v0.0.0-20210508070623-03c23c62f181
 	github.com/mxschmitt/golang-combinations v1.1.0
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5/go.mod h1:yV39+EVOWdnoTe75NyKdo9iuyI3Slyh4t7eQvElUbWE=
 github.com/muka/go-bluetooth v0.0.0-20201211051136-07f31c601d33 h1:p3srutpE8TpQmOUQ5Qw94jYFUdoG2jBbILeYLroQNoI=
 github.com/muka/go-bluetooth v0.0.0-20201211051136-07f31c601d33/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
+github.com/muka/go-bluetooth v0.0.0-20210508070623-03c23c62f181 h1:2WJZHTfZO2VOzRuVeEXI8Vjy+UAIvugGa+bVhni576I=
+github.com/muka/go-bluetooth v0.0.0-20210508070623-03c23c62f181/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxschmitt/golang-combinations v1.1.0 h1:WlIZCnDm+Xlb2pRPf+R/qPKlGOU1w8lpN69/uy5z+Zg=

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5/go.mod h1:yV39+EVOWdnoTe75NyKdo9iuyI3Slyh4t7eQvElUbWE=
-github.com/muka/go-bluetooth v0.0.0-20201211051136-07f31c601d33 h1:p3srutpE8TpQmOUQ5Qw94jYFUdoG2jBbILeYLroQNoI=
-github.com/muka/go-bluetooth v0.0.0-20201211051136-07f31c601d33/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
 github.com/muka/go-bluetooth v0.0.0-20210508070623-03c23c62f181 h1:2WJZHTfZO2VOzRuVeEXI8Vjy+UAIvugGa+bVhni576I=
 github.com/muka/go-bluetooth v0.0.0-20210508070623-03c23c62f181/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/internal/charger/config_test.go
+++ b/internal/charger/config_test.go
@@ -16,6 +16,7 @@ func TestChargers(t *testing.T) {
 		"invalid charger type: nrgkick-bluetooth",
 		"NRGKick bluetooth is only supported on linux",
 		"invalid pin:",
+		"hciconfig provided no response",
 		"connect: no route to host",
 		"connect: connection refused",
 		"error connecting: Network Error",

--- a/internal/charger/nrgble_linux.go
+++ b/internal/charger/nrgble_linux.go
@@ -60,14 +60,19 @@ func NewNRGKickBLEFromConfig(other map[string]interface{}) (api.Charger, error) 
 func NewNRGKickBLE(device, mac string, pin int) (*NRGKickBLE, error) {
 	logger := util.NewLogger("nrg-bt")
 
+	ainfo, err := hw.GetAdapter(device)
+	if err != nil {
+		return nil, err
+	}
+
 	// set LE mode
-	btmgmt := hw.NewBtMgmt(device)
+	btmgmt := hw.NewBtMgmt(ainfo.AdapterID)
 
 	if len(os.Getenv("DOCKER")) > 0 {
 		btmgmt.BinPath = "./docker-btmgmt"
 	}
 
-	err := btmgmt.SetPowered(false)
+	err = btmgmt.SetPowered(false)
 	if err == nil {
 		err = btmgmt.SetLe(true)
 		if err == nil {
@@ -82,7 +87,7 @@ func NewNRGKickBLE(device, mac string, pin int) (*NRGKickBLE, error) {
 		return nil, err
 	}
 
-	adapt, err := adapter.NewAdapter1FromAdapterID(device)
+	adapt, err := adapter.NewAdapter1FromAdapterID(ainfo.AdapterID)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +110,7 @@ func NewNRGKickBLE(device, mac string, pin int) (*NRGKickBLE, error) {
 	nrg := &NRGKickBLE{
 		log:     logger,
 		timer:   time.NewTimer(1),
-		device:  device,
+		device:  ainfo.AdapterID,
 		mac:     mac,
 		pin:     pin,
 		adapter: adapt,


### PR DESCRIPTION
Das NRGKick-BT charger modul prüft jetzt initial, ob überhaupt ein BT Adapter existiert (`hw.GetAdapter(device)`) und nutzt dann die zurückgegebene `adapterID` für die folgenden BT-Funktionsaufrufe.

Die `charger/config_test.go` Routine ignoriert die BT Fehlermeldung `hciconfig provided no response`, falls sie auf einem System ohn BT Adapter ausgeführt wird.

Das go-bluetooth Modul muss als Voraussetzung auf die neue Version aktualisiert werden:
`github.com/muka/go-bluetooth v0.0.0-20210508070623-03c23c62f181`  