### PR TITLE
Fix creating RS485 meters as Sunspec when RTU is not enabled

### DIFF
--- a/internal/meter/modbus.go
+++ b/internal/meter/modbus.go
@@ -38,6 +38,9 @@ func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
 		Timeout            time.Duration
 	}{
 		Power: "Power",
+		Settings: modbus.Settings{
+			ID: 1,
+		},
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -65,7 +68,7 @@ func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {
 	conn.Logger(log.TRACE)
 
 	// prepare device
-	device, err := modbus.NewDevice(cc.Model, cc.SubDevice, *cc.RTU)
+	device, err := modbus.NewDevice(cc.Model, cc.SubDevice)
 
 	if err == nil {
 		err = device.Initialize(conn)

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -75,7 +75,7 @@ func NewModbusFromConfig(other map[string]interface{}) (IntProvider, error) {
 
 	// no registered configured - need device
 	if cc.Register.Decode == "" {
-		device, err = modbus.NewDevice(cc.Model, cc.SubDevice, *cc.RTU)
+		device, err = modbus.NewDevice(cc.Model, cc.SubDevice)
 
 		// prepare device
 		if err == nil {

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -177,8 +177,8 @@ func NewConnection(uri, device, comset string, baudrate int, rtu bool, slaveID u
 }
 
 // NewDevice creates physical modbus device from config
-func NewDevice(model string, subdevice int, isRS485 bool) (device meters.Device, err error) {
-	if isRS485 {
+func NewDevice(model string, subdevice int) (device meters.Device, err error) {
+	if IsRS485(model) {
 		device, err = rs485.NewDevice(strings.ToUpper(model))
 	} else {
 		device = sunspec.NewDevice(strings.ToUpper(model), subdevice)


### PR DESCRIPTION
Fix https://github.com/andig/evcc/discussions/958

For RS485 meters attached via ModbusTCP, make sure to add `rtu: false` to the configuration.