### PR TITLE
Allow vehicles to request soc update

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -5,6 +5,9 @@ import "errors"
 // ErrNotAvailable indicates that a feature is not available
 var ErrNotAvailable = errors.New("not available")
 
+// ErrMustRetry indicates that a rate-limited operation should be retried
+var ErrMustRetry = errors.New("must retry")
+
 // ErrTimeout is the error returned when a timeout happened.
 // Modeled after context.DeadlineError
 var ErrTimeout error = errTimeoutError{}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -878,10 +878,10 @@ func (lp *LoadPoint) publishSoCAndRange() {
 	}
 
 	if lp.socPollAllowed() {
+		lp.socUpdated = lp.clock.Now()
+
 		f, err := lp.socEstimator.SoC(lp.chargedEnergy)
 		if err == nil {
-			lp.socUpdated = lp.clock.Now()
-
 			lp.socCharge = math.Trunc(f)
 			lp.log.DEBUG.Printf("vehicle soc: %.0f%%", lp.socCharge)
 			lp.publish("socCharge", lp.socCharge)
@@ -896,6 +896,7 @@ func (lp *LoadPoint) publishSoCAndRange() {
 			lp.publish("chargeRemainingEnergy", chargeRemainingEnergy)
 		} else {
 			if errors.Is(err, api.ErrMustRetry) {
+				lp.socUpdated = time.Time{}
 				lp.log.DEBUG.Printf("vehicle: waiting for update")
 			} else {
 				lp.log.ERROR.Printf("vehicle: %v", err)

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -699,7 +699,13 @@ func TestSoCPoll(t *testing.T) {
 		lp.SoC.Poll.Mode = tc.mode
 		lp.status = tc.status
 
-		if res := lp.socPollAllowed(); tc.res != res {
+		res := lp.socPollAllowed()
+		if res {
+			// mimic update outside of socPollAllowed
+			lp.socUpdated = clock.Now()
+		}
+
+		if tc.res != res {
 			t.Errorf("expected %v, got %v", tc.res, res)
 		}
 	}


### PR DESCRIPTION
@MrJayC willst Du mit diesem Ansatz mal probieren den Ford SoC update asynchron zu bauen? 

Einfach- falls es ein Update braucht- `api.ErrMustRetry` zurück geben und im nächsten Durchlauf wirds wieder aufgerufen. Solange, bis Du das aktualisierte Ergebnis vorliegen hast oder den Versuch final als Fehler abbrichst.

Note: the vehicle implementation must ensure that the `ErrMustRetry` value does not get cached.