### PR TITLE
Ford API: implement async update, when status refresh in progress

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -896,14 +896,7 @@ func (lp *LoadPoint) publishSoCAndRange() {
 			lp.publish("chargeRemainingEnergy", chargeRemainingEnergy)
 		} else {
 			if errors.Is(err, api.ErrMustRetry) {
-<<<<<<< HEAD
-<<<<<<< HEAD
 				lp.socUpdated = time.Time{}
-=======
->>>>>>> Allow vehicles to request soc update
-=======
-				lp.socUpdated = time.Time{}
->>>>>>> Always mark updated in case of errors
 				lp.log.DEBUG.Printf("vehicle: waiting for update")
 			} else {
 				lp.log.ERROR.Printf("vehicle: %v", err)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -882,8 +882,6 @@ func (lp *LoadPoint) publishSoCAndRange() {
 
 		f, err := lp.socEstimator.SoC(lp.chargedEnergy)
 		if err == nil {
-			lp.socUpdated = lp.clock.Now()
-
 			lp.socCharge = math.Trunc(f)
 			lp.log.DEBUG.Printf("vehicle soc: %.0f%%", lp.socCharge)
 			lp.publish("socCharge", lp.socCharge)
@@ -899,9 +897,13 @@ func (lp *LoadPoint) publishSoCAndRange() {
 		} else {
 			if errors.Is(err, api.ErrMustRetry) {
 <<<<<<< HEAD
+<<<<<<< HEAD
 				lp.socUpdated = time.Time{}
 =======
 >>>>>>> Allow vehicles to request soc update
+=======
+				lp.socUpdated = time.Time{}
+>>>>>>> Always mark updated in case of errors
 				lp.log.DEBUG.Printf("vehicle: waiting for update")
 			} else {
 				lp.log.ERROR.Printf("vehicle: %v", err)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -882,6 +882,8 @@ func (lp *LoadPoint) publishSoCAndRange() {
 
 		f, err := lp.socEstimator.SoC(lp.chargedEnergy)
 		if err == nil {
+			lp.socUpdated = lp.clock.Now()
+
 			lp.socCharge = math.Trunc(f)
 			lp.log.DEBUG.Printf("vehicle soc: %.0f%%", lp.socCharge)
 			lp.publish("socCharge", lp.socCharge)
@@ -896,7 +898,10 @@ func (lp *LoadPoint) publishSoCAndRange() {
 			lp.publish("chargeRemainingEnergy", chargeRemainingEnergy)
 		} else {
 			if errors.Is(err, api.ErrMustRetry) {
+<<<<<<< HEAD
 				lp.socUpdated = time.Time{}
+=======
+>>>>>>> Allow vehicles to request soc update
 				lp.log.DEBUG.Printf("vehicle: waiting for update")
 			} else {
 				lp.log.ERROR.Printf("vehicle: %v", err)

--- a/provider/cache.go
+++ b/provider/cache.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"errors"
 	"sync"
 	"time"
 
+	"github.com/andig/evcc/api"
 	"github.com/andig/evcc/util"
 	"github.com/asaskevich/EventBus"
 	"github.com/benbjohnson/clock"
@@ -180,7 +182,7 @@ func (c *Cached) InterfaceGetter() func() (interface{}, error) {
 		c.mux.Lock()
 		defer c.mux.Unlock()
 
-		if c.clock.Since(c.updated) > c.cache {
+		if c.clock.Since(c.updated) > c.cache || errors.Is(c.err, api.ErrMustRetry) && c.clock.Since(c.updated) > 5*time.Second {
 			c.val, c.err = g()
 			c.updated = c.clock.Now()
 		}


### PR DESCRIPTION
Ich möchte das hier zur Diskussion stellen - ich habe mit dem Cache gekämpft, da der Fehler "mustRetry" natürlich im Cache landet und beim Folgeaufruf keine Aktualisierung der Daten zulässt.
Nach längerem Abwägen habe ich mich dazu entschieden, den Cache selbst anzufassen, bin mir nicht sicher ob du da mitgehst. Daher habe ich aktuell nur den InterfaceGetter angepasst, quasi als PoC.

Erklärung zu folgender Bedingung: `c.clock.Since(c.updated) > 5*time.Second`
Es werden hintereinander direkt SoC und Range aktualisiert, es macht aber keinen Sinn innerhalb von einem Kontrollzyklus 2x auf Abschluss der Operation zu prüfen. Daher der Mindestabstand 5 Sekunden.