### PR TITLE
Sync Easee Smart with Now/PV Modes

### DIFF
--- a/internal/charger/easee.go
+++ b/internal/charger/easee.go
@@ -129,9 +129,9 @@ func (c *Easee) chargerDetails() (res easee.Site, err error) {
 	return res, err
 }
 
-func (c *Easee) syncSmartCharging() {
+func (c *Easee) syncSmartCharging() error {
 	if c.lp == nil {
-		return
+		return nil
 	}
 
 	if c.lp.GetMode() != c.lastChargeMode {
@@ -154,7 +154,7 @@ func (c *Easee) syncSmartCharging() {
 			c.lastChargeMode = c.lp.GetMode()
 			c.lastSmartCharging = newSmartCharging
 		}
-		return
+		return err
 	}
 
 	if c.lastSmartCharging != c.status.SmartCharging {
@@ -167,6 +167,7 @@ func (c *Easee) syncSmartCharging() {
 		c.lastSmartCharging = c.status.SmartCharging
 		c.lastChargeMode = c.lp.GetMode()
 	}
+	return nil
 }
 
 func (c *Easee) state() (easee.ChargerStatus, error) {
@@ -178,7 +179,7 @@ func (c *Easee) state() (easee.ChargerStatus, error) {
 	req, err := request.New(http.MethodGet, uri, nil, request.JSONEncoding)
 	if err == nil {
 		if err = c.DoJSON(req, &c.status); err == nil {
-			c.syncSmartCharging()
+			err = c.syncSmartCharging()
 			c.updated = time.Now()
 		}
 	}

--- a/internal/charger/easee.go
+++ b/internal/charger/easee.go
@@ -18,12 +18,15 @@ import (
 // Easee charger implementation
 type Easee struct {
 	*request.Helper
-	charger       string
-	site, circuit int
-	status        easee.ChargerStatus
-	updated       time.Time
-	cache         time.Duration
-	lp            core.LoadPointAPI
+	charger           string
+	site, circuit     int
+	status            easee.ChargerStatus
+	updated           time.Time
+	cache             time.Duration
+	lp                core.LoadPointAPI
+	lastSmartCharging bool
+	lastChargeMode    api.ChargeMode
+	log               *util.Logger
 }
 
 func init() {
@@ -60,6 +63,7 @@ func NewEasee(user, password, charger string, cache time.Duration) (*Easee, erro
 		Helper:  request.NewHelper(log),
 		charger: charger,
 		cache:   cache,
+		log:     log,
 	}
 
 	ts, err := easee.TokenSource(log, user, password)
@@ -125,6 +129,46 @@ func (c *Easee) chargerDetails() (res easee.Site, err error) {
 	return res, err
 }
 
+func (c *Easee) syncSmartCharging() {
+	if c.lp == nil {
+		return
+	}
+
+	if c.lp.GetMode() != c.lastChargeMode {
+		c.log.DEBUG.Printf("charge mode changed by loadpoint: %v -> %v", c.lastChargeMode, c.lp.GetMode())
+		newSmartCharging := false
+		if c.lp.GetMode() == api.ModePV {
+			newSmartCharging = true
+		}
+
+		data := easee.ChargerSettings{
+			SmartCharging: &newSmartCharging,
+		}
+
+		var req *http.Request
+		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
+		req, err := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
+		if err == nil {
+			_, err = c.Do(req)
+			c.updated = time.Time{} // clear cache
+			c.lastChargeMode = c.lp.GetMode()
+			c.lastSmartCharging = newSmartCharging
+		}
+		return
+	}
+
+	if c.lastSmartCharging != c.status.SmartCharging {
+		c.log.DEBUG.Printf("smart status changed by charger: %v -> %v", c.lastSmartCharging, c.status.SmartCharging)
+		if c.status.SmartCharging {
+			c.lp.SetMode(api.ModePV)
+		} else {
+			c.lp.SetMode(api.ModeNow)
+		}
+		c.lastSmartCharging = c.status.SmartCharging
+		c.lastChargeMode = c.lp.GetMode()
+	}
+}
+
 func (c *Easee) state() (easee.ChargerStatus, error) {
 	if time.Since(c.updated) < c.cache {
 		return c.status, nil
@@ -134,6 +178,7 @@ func (c *Easee) state() (easee.ChargerStatus, error) {
 	req, err := request.New(http.MethodGet, uri, nil, request.JSONEncoding)
 	if err == nil {
 		if err = c.DoJSON(req, &c.status); err == nil {
+			c.syncSmartCharging()
 			c.updated = time.Now()
 		}
 	}


### PR DESCRIPTION
Easee charges have a physical button to toggle the smart-mode (smart on => blue led, smart of => white led). This PR implements a two-way sync so that mode-changes in evcc will result in led-change of the wallbox. Switching modes on the wallbox itself will toggle between NOW and PV mode in evcc as well.

Since easee is currently implemented with HTTP polling the change is not reflected instantly. Its dependent on the configure cache time.

Moving to a streaming integration later ([SignalR, AMQP are available](https://www.notion.so/Partner-API-OCPP-guide-e12ffff332fb42c1a91c58ad70f4fe3f#858dd507a5184ca5851d0c9728b4b215)) will make this more elegant.