### PR TITLE
Allow obtaining soc from charger instead of vehicle

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -883,6 +883,7 @@ func (lp *LoadPoint) publishSoCAndRange() {
 	if lp.socPollAllowed() {
 		lp.socUpdated = lp.clock.Now()
 
+		// soc
 		f, err := lp.socEstimator.SoC(lp.chargedEnergy)
 		if err == nil {
 			lp.socCharge = math.Trunc(f)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -574,7 +574,7 @@ func (lp *LoadPoint) setActiveVehicle(vehicle api.Vehicle) {
 	}
 
 	lp.vehicle = vehicle
-	lp.socEstimator = soc.NewEstimator(lp.log, vehicle, lp.SoC.Estimate)
+	lp.socEstimator = soc.NewEstimator(lp.log, lp.charger, vehicle, lp.SoC.Estimate)
 
 	lp.publish("socTitle", lp.vehicle.Title())
 	lp.publish("socCapacity", lp.vehicle.Capacity())

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -372,7 +372,7 @@ func TestDisableAndEnableAtTargetSoC(t *testing.T) {
 
 	// wrap vehicle with estimator
 	vehicle.EXPECT().Capacity().Return(int64(10))
-	socEstimator := soc.NewEstimator(util.NewLogger("foo"), vehicle, false)
+	socEstimator := soc.NewEstimator(util.NewLogger("foo"), nil, vehicle, false)
 
 	lp := &LoadPoint{
 		log:          util.NewLogger("foo"),

--- a/core/soc/socestimator_test.go
+++ b/core/soc/socestimator_test.go
@@ -12,10 +12,11 @@ import (
 func TestRemainingChargeDuration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vehicle := mock.NewMockVehicle(ctrl)
-	//9 kWh userBatCap => 10 kWh virtualBatCap
+
+	// 9 kWh userBatCap => 10 kWh virtualBatCap
 	vehicle.EXPECT().Capacity().Return(int64(9))
 
-	ce := NewEstimator(util.NewLogger("foo"), vehicle, false)
+	ce := NewEstimator(util.NewLogger("foo"), nil, vehicle, false)
 	ce.socCharge = 20.0
 
 	chargePower := 1000.0
@@ -34,7 +35,7 @@ func TestSoCEstimation(t *testing.T) {
 	var capacity int64 = 9
 	vehicle.EXPECT().Capacity().Return(capacity)
 
-	ce := NewEstimator(util.NewLogger("foo"), vehicle, true)
+	ce := NewEstimator(util.NewLogger("foo"), nil, vehicle, true)
 	ce.socCharge = 20.0
 
 	tc := []struct {


### PR DESCRIPTION
/cc @DerAndereAndi if charger cannot currently return soc return `api.ErrNotAvailable`.