### PR TITLE
Add Shelly pseudo charger

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ EVCC is an extensible EV Charge Controller with PV integration implemented in [G
 - simple and clean user interface
 - multiple [chargers](#charger):
   - Wallbe, Phoenix (includes ESL Walli), go-eCharger, NRGkick (direct Bluetooth or via Connect device), SimpleEVSE, EVSEWifi, KEBA/BMW, openWB, Mobile Charger Connect and any other charger using scripting
-  - Smart-Home outlets: FritzDECT, Tasmota, TP-Link
+  - Smart-Home outlets: FritzDECT, Shelly, Tasmota, TP-Link
 - multiple [meters](#meter): ModBus (Eastron SDM, MPM3PM, SBC ALE3 and many more), Discovergy (using HTTP plugin), SMA Sunny Home Manager and Energy Meter, KOSTAL Smart Energy Meter (KSEM, EMxx), any Sunspec-compatible inverter or home battery devices (Fronius, SMA, SolarEdge, KOSTAL, STECA, E3DC, ...), Tesla PowerWall
 - wide support of vendor-specific [vehicles](#vehicle) interfaces (remote charge, battery and preconditioning status): Audi, BMW, Ford, Hyundai, Kia, Nissan, Niu, Porsche, Renault, Seat, Skoda, Tesla, Volkswagen, Volvo and any other connected vehicle using scripting
 - [plugins](#plugins) for integrating with hardware devices and home automation: Modbus (meters and grid inverters), HTTP, MQTT, Javascript, WebSockets and shell scripts
@@ -188,7 +188,8 @@ Available charger implementations are:
 
 Smart-Home outlet charger implementations:
 - `fritzdect`: Fritz!DECT 200/210 outlets
-- `tasmota`: Tasmota outlets
+- `shelly`: Shelly switch controled outlets 
+- `tasmota`: Tasmota switch controled outlets
 - `tplink`: TP-Link HSXXX series outlets
 
 Configuration examples are documented at [andig/evcc-config#chargers](https://github.com/andig/evcc-config#chargers)

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ Available charger implementations are:
 
 Smart-Home outlet charger implementations:
 - `fritzdect`: Fritz!DECT 200/210 outlets
-- `shelly`: Shelly switch controled outlets 
-- `tasmota`: Tasmota switch controled outlets
+- `shelly`: Shelly outlets 
+- `tasmota`: Tasmota outlets
 - `tplink`: TP-Link HSXXX series outlets
 
 Configuration examples are documented at [andig/evcc-config#chargers](https://github.com/andig/evcc-config#chargers)

--- a/detect/definitions.go
+++ b/detect/definitions.go
@@ -38,6 +38,7 @@ const (
 	taskMeter        = "meter"
 	taskFronius      = "fronius"
 	taskTasmota      = "tasmota"
+	taskShelly       = "shelly"
 	// taskTPLink       = "tplink"
 )
 
@@ -252,7 +253,7 @@ func init() {
 		Type:    tasks.Http,
 		Depends: TaskHttp,
 		Config: map[string]interface{}{
-			"path": "//cm?cmnd=Module",
+			"path": "/cm?cmnd=Module",
 			"jq":   ".Module",
 		},
 	})
@@ -275,6 +276,16 @@ func init() {
 		Config: map[string]interface{}{
 			"path": "/middleware.php/entity.json",
 			"jq":   ".version",
+		},
+	})
+
+	taskList.Add(tasks.Task{
+		ID:      taskShelly,
+		Type:    tasks.Http,
+		Depends: TaskHttp,
+		Config: map[string]interface{}{
+			"path": "/shelly",
+			"jq":   ".type",
 		},
 	})
 }

--- a/internal/charger/shelly.go
+++ b/internal/charger/shelly.go
@@ -72,7 +72,7 @@ func NewShelly(uri string, channel int, standbypower float64) (*Shelly, error) {
 // Enabled implements the api.Charger interface
 func (c *Shelly) Enabled() (bool, error) {
 	var resp shellyRelayResponse
-	err := c.GetJSON(fmt.Sprintf("%s/%s", c.uri, "relay/"+strconv.Itoa(c.channel)), &resp)
+	err := c.GetJSON(fmt.Sprintf("%s/relay/%d", c.uri, c.channel), &resp)
 
 	return resp.Ison, err
 }
@@ -80,11 +80,8 @@ func (c *Shelly) Enabled() (bool, error) {
 // Enable implements the api.Charger interface
 func (c *Shelly) Enable(enable bool) error {
 	var resp shellyRelayResponse
-	cmd := map[bool]string{
-		true:  "on",
-		false: "off",
-	}
-	err := c.GetJSON(fmt.Sprintf("%s/relay/%s?turn=%s", c.uri, strconv.Itoa(c.channel), cmd[enable]), &resp)
+	onoff := map[bool]string{true: "on", false: "off"}
+	err := c.GetJSON(fmt.Sprintf("%s/relay/%d?turn=%s", c.uri, c.channel, onoff[enable]), &resp)
 
 	switch {
 	case err != nil:

--- a/internal/charger/shelly.go
+++ b/internal/charger/shelly.go
@@ -43,9 +43,7 @@ func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
 		URI          string
 		Channel      int
 		StandbyPower float64
-	}{
-		Channel: 0,
-	}
+	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -104,7 +102,6 @@ func (c *Shelly) MaxCurrent(current int64) error {
 // Status implements the api.Charger interface
 func (c *Shelly) Status() (api.ChargeStatus, error) {
 	power, err := c.CurrentPower()
-
 	if power > 0 {
 		return api.StatusC, err
 	}
@@ -117,6 +114,7 @@ var _ api.Meter = (*Shelly)(nil)
 func (c *Shelly) CurrentPower() (float64, error) {
 	var resp shellyStatusResponse
 	err := c.GetJSON(fmt.Sprintf("%s/%s", c.uri, "status"), &resp)
+	
 	if c.channel >= len(resp.Meters) {
 		return 0, errors.New("invalid channel, power meter missing")
 	}

--- a/internal/charger/shelly.go
+++ b/internal/charger/shelly.go
@@ -80,11 +80,11 @@ func (c *Shelly) Enabled() (bool, error) {
 // Enable implements the api.Charger interface
 func (c *Shelly) Enable(enable bool) error {
 	var resp shellyRelayResponse
-	cmd := "relay/" + strconv.Itoa(c.channel) + "?turn=off"
-	if enable {
-		cmd = "relay/" + strconv.Itoa(c.channel) + "?turn=on"
+	cmd := map[bool]string{
+		true:  "on",
+		false: "off",
 	}
-	err := c.GetJSON(fmt.Sprintf("%s/%s", c.uri, cmd), &resp)
+	err := c.GetJSON(fmt.Sprintf("%s/relay/%s?turn=%s", c.uri, strconv.Itoa(c.channel), cmd[enable]), &resp)
 
 	switch {
 	case err != nil:

--- a/internal/charger/shelly.go
+++ b/internal/charger/shelly.go
@@ -3,7 +3,6 @@ package charger
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/andig/evcc/api"
@@ -44,7 +43,9 @@ func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
 		URI          string
 		Channel      int
 		StandbyPower float64
-	}{}
+	}{
+		Channel: 0,
+	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -116,6 +117,9 @@ var _ api.Meter = (*Shelly)(nil)
 func (c *Shelly) CurrentPower() (float64, error) {
 	var resp shellyStatusResponse
 	err := c.GetJSON(fmt.Sprintf("%s/%s", c.uri, "status"), &resp)
+	if c.channel >= len(resp.Meters) {
+		return 0, errors.New("invalid channel, power meter missing")
+	}
 	power := resp.Meters[c.channel].Power
 
 	// ignore standby power

--- a/internal/charger/shelly.go
+++ b/internal/charger/shelly.go
@@ -1,0 +1,136 @@
+package charger
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/andig/evcc/api"
+	"github.com/andig/evcc/util"
+	"github.com/andig/evcc/util/request"
+)
+
+// Shelly api homepage
+// https://shelly-api-docs.shelly.cloud/#common-http-api
+
+// shellyRelayResponse provides the evcc shelly charger enabled information
+type shellyRelayResponse struct {
+	Ison bool `json:"ison,omitempty"`
+}
+
+// shellyStatusResponse provides the evcc shelly charger current power information
+type shellyStatusResponse struct {
+	Meters []struct {
+		Power float64 `json:"power,omitempty"`
+	} `json:"meters,omitempty"`
+}
+
+// Shelly charger implementation
+type Shelly struct {
+	*request.Helper
+	uri, user, password string
+	channel             int
+	standbypower        float64
+}
+
+func init() {
+	registry.Add("shelly", NewShellyFromConfig)
+}
+
+// NewShellyFromConfig creates a Shelly charger from generic config
+func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
+	cc := struct {
+		URI          string
+		User         string
+		Password     string
+		Channel      int
+		StandbyPower float64
+	}{}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.URI == "" {
+		return nil, errors.New("missing uri")
+	}
+
+	return NewShelly(cc.URI, cc.User, cc.Password, cc.Channel, cc.StandbyPower)
+}
+
+// NewShelly creates Shelly charger
+func NewShelly(uri, user, password string, channel int, standbypower float64) (*Shelly, error) {
+	c := &Shelly{
+		Helper:       request.NewHelper(util.NewLogger("shelly")),
+		uri:          strings.TrimRight(uri, "/"),
+		user:         user,
+		password:     password,
+		channel:      channel,
+		standbypower: standbypower,
+	}
+
+	return c, nil
+}
+
+// Enabled implements the api.Charger interface
+func (c *Shelly) Enabled() (bool, error) {
+	var resp shellyRelayResponse
+	err := c.GetJSON(fmt.Sprintf("%s/%s", c.uri, "relay/"+strconv.Itoa(c.channel)), &resp)
+
+	return resp.Ison, err
+}
+
+// Enable implements the api.Charger interface
+func (c *Shelly) Enable(enable bool) error {
+	var resp shellyRelayResponse
+	cmd := "relay/" + strconv.Itoa(c.channel) + "?turn=off"
+	if enable {
+		cmd = "relay/" + strconv.Itoa(c.channel) + "?turn=on"
+	}
+	err := c.GetJSON(fmt.Sprintf("%s/%s", c.uri, cmd), &resp)
+
+	switch {
+	case err != nil:
+		return err
+	case enable && !resp.Ison:
+		return errors.New("switchOn failed")
+	case !enable && resp.Ison:
+		return errors.New("switchOff failed")
+	default:
+		return nil
+	}
+}
+
+// MaxCurrent implements the api.Charger interface
+func (c *Shelly) MaxCurrent(current int64) error {
+	return nil
+}
+
+// Status implements the api.Charger interface
+func (c *Shelly) Status() (api.ChargeStatus, error) {
+	power, err := c.CurrentPower()
+
+	switch {
+	case power > 0:
+		return api.StatusC, err
+	default:
+		return api.StatusB, err
+	}
+}
+
+var _ api.Meter = (*Shelly)(nil)
+
+// CurrentPower implements the api.Meter interface
+func (c *Shelly) CurrentPower() (float64, error) {
+	var resp shellyStatusResponse
+	err := c.GetJSON(fmt.Sprintf("%s/%s", c.uri, "status"), &resp)
+	power := resp.Meters[c.channel].Power
+
+	// ignore standby power
+	if power < c.standbypower {
+		power = 0
+	}
+
+	return power, err
+}

--- a/internal/charger/shelly.go
+++ b/internal/charger/shelly.go
@@ -29,9 +29,9 @@ type shellyStatusResponse struct {
 // Shelly charger implementation
 type Shelly struct {
 	*request.Helper
-	uri, user, password string
-	channel             int
-	standbypower        float64
+	uri          string
+	channel      int
+	standbypower float64
 }
 
 func init() {
@@ -42,8 +42,6 @@ func init() {
 func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
 		URI          string
-		User         string
-		Password     string
 		Channel      int
 		StandbyPower float64
 	}{}
@@ -56,16 +54,14 @@ func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, errors.New("missing uri")
 	}
 
-	return NewShelly(cc.URI, cc.User, cc.Password, cc.Channel, cc.StandbyPower)
+	return NewShelly(cc.URI, cc.Channel, cc.StandbyPower)
 }
 
 // NewShelly creates Shelly charger
-func NewShelly(uri, user, password string, channel int, standbypower float64) (*Shelly, error) {
+func NewShelly(uri string, channel int, standbypower float64) (*Shelly, error) {
 	c := &Shelly{
 		Helper:       request.NewHelper(util.NewLogger("shelly")),
 		uri:          strings.TrimRight(uri, "/"),
-		user:         user,
-		password:     password,
 		channel:      channel,
 		standbypower: standbypower,
 	}

--- a/internal/charger/shelly.go
+++ b/internal/charger/shelly.go
@@ -107,12 +107,10 @@ func (c *Shelly) MaxCurrent(current int64) error {
 func (c *Shelly) Status() (api.ChargeStatus, error) {
 	power, err := c.CurrentPower()
 
-	switch {
-	case power > 0:
+	if power > 0 {
 		return api.StatusC, err
-	default:
-		return api.StatusB, err
 	}
+	return api.StatusB, err
 }
 
 var _ api.Meter = (*Shelly)(nil)


### PR DESCRIPTION
Introduction of shelly charger module based on Shelly stock firmware web API.
This charger works like the already existing pseudo chargers fritzdect, tasmota and tplink.
Only difference is the missing ChargedEnergy() interface, because stock firmware provides only a total energy meter value, but not a  daily sum.
Shelly devices will be detected by evcc.
Readme is extended. 