### PR TITLE
Enable monthly min SoC values

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -904,6 +904,14 @@ func (lp *LoadPoint) initMinSoCs(minlst []int) {
 	lp.log.DEBUG.Printf("min soc: %d %%, month: %d ", lp.SoC.Min[lp.socMinMonth], lp.socMinMonth+1)
 }
 
+// setMinSoCMonth sets loadpoint soc min month
+func (lp *LoadPoint) setMinSoCMonth() {
+	lp.Lock()
+	defer lp.Unlock()
+	lp.socMinMonth = int(lp.clock.Now().Month()) - 1
+	lp.log.DEBUG.Printf("set soc: min month: %d", lp.socMinMonth+1)
+}
+
 // publish state of charge, remaining charge duration and range
 func (lp *LoadPoint) publishSoCAndRange() {
 	if lp.socEstimator == nil {
@@ -986,6 +994,7 @@ func (lp *LoadPoint) Update(sitePower float64) {
 	// update active vehicle and publish soc
 	// must be run after updating charger status to make sure
 	// initial update of connected state matches charger status
+	lp.setMinSoCMonth()
 	lp.findActiveVehicle()
 	lp.publishSoCAndRange()
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -199,7 +199,6 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 	}
 
 	// initialize monthly min soc parameters
-	lp.socMinMonth = int(lp.clock.Now().Month()) - 1
 	lp.initMinSoCs(lp.SoC.Min)
 
 	return lp, nil
@@ -398,7 +397,6 @@ func (lp *LoadPoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 	lp.lpChan = lpChan
 
 	// prepare monthly min soc elements
-	lp.socMinMonth = int(lp.clock.Now().Month()) - 1
 	lp.initMinSoCs(lp.SoC.Min)
 
 	// event handlers
@@ -886,7 +884,10 @@ func (lp *LoadPoint) socPollAllowed() bool {
 
 // initMinSoCs populates the loadpoints monthly min soc array
 func (lp *LoadPoint) initMinSoCs(minlst []int) {
-	if minlen := len(minlst); minlen < 12 {
+	lp.socMinMonth = int(lp.clock.Now().Month()) - 1
+
+	minlen := len(minlst)
+	if minlen < 12 {
 		for i := minlen; i < 12; i++ {
 			if minlen == 1 {
 				// use first soc min value for all 12 months
@@ -896,6 +897,11 @@ func (lp *LoadPoint) initMinSoCs(minlst []int) {
 			}
 		}
 	}
+
+	if minlen > 1 && minlen < 12 {
+		lp.log.WARN.Printf("monthly min soc list incomplete: %v", lp.SoC.Min)
+	}
+
 	lp.log.DEBUG.Printf("min soc: %d %%, month: %d ", lp.SoC.Min[lp.socMinMonth], lp.socMinMonth+1)
 }
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -202,7 +202,6 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 	lp.initMinSoCs(lp.SoC.Min)
 
 	return lp, nil
-
 }
 
 // NewLoadPoint creates a LoadPoint with sane defaults

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -898,7 +898,7 @@ func (lp *LoadPoint) initMinSoCs(minlst []int) {
 	}
 
 	if minlen > 1 && minlen < 12 {
-		lp.log.WARN.Printf("monthly min soc list incomplete: %v", lp.SoC.Min)
+		lp.log.WARN.Printf("soc: min format invalid: %v", lp.SoC.Min)
 	}
 
 	lp.log.DEBUG.Printf("min soc: %d %%, month: %d ", lp.SoC.Min[lp.socMinMonth], lp.socMinMonth+1)

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -92,7 +92,7 @@ func (lp *LoadPoint) SetTargetSoC(soc int) error {
 func (lp *LoadPoint) GetMinSoC() int {
 	lp.Lock()
 	defer lp.Unlock()
-	return lp.SoC.Min[int(time.Now().Month())-1]
+	return lp.SoC.Min[lp.socMinMonth]
 }
 
 // SetMinSoC sets loadpoint charge minimum soc
@@ -107,8 +107,8 @@ func (lp *LoadPoint) SetMinSoC(soc int) error {
 	lp.log.INFO.Println("set min soc:", soc)
 
 	// apply immediately
-	if lp.SoC.Min[int(time.Now().Month())-1] != soc {
-		lp.SoC.Min[int(time.Now().Month())-1] = soc
+	if lp.SoC.Min[lp.socMinMonth] != soc {
+		lp.SoC.Min[lp.socMinMonth] = soc
 		lp.publish("minSoC", soc)
 		lp.requestUpdate()
 	}

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -92,7 +92,7 @@ func (lp *LoadPoint) SetTargetSoC(soc int) error {
 func (lp *LoadPoint) GetMinSoC() int {
 	lp.Lock()
 	defer lp.Unlock()
-	return lp.SoC.Min
+	return lp.SoC.Min[int(time.Now().Month())-1]
 }
 
 // SetMinSoC sets loadpoint charge minimum soc
@@ -107,8 +107,8 @@ func (lp *LoadPoint) SetMinSoC(soc int) error {
 	lp.log.INFO.Println("set min soc:", soc)
 
 	// apply immediately
-	if lp.SoC.Min != soc {
-		lp.SoC.Min = soc
+	if lp.SoC.Min[int(time.Now().Month())-1] != soc {
+		lp.SoC.Min[int(time.Now().Month())-1] = soc
 		lp.publish("minSoC", soc)
 		lp.requestUpdate()
 	}

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -715,19 +715,19 @@ func TestMinSoC(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vhc := mock.NewMockVehicle(ctrl)
 
-	var min0 []int
+	var min0 [12]int
 	for i := 0; i < 12; i++ {
-		min0 = append(min0, 0)
+		min0[i] = 0
 	}
 
-	var min80 []int
+	var min80 [12]int
 	for i := 0; i < 12; i++ {
-		min80 = append(min80, 80)
+		min80[i] = 80
 	}
 
 	tc := []struct {
 		vehicle api.Vehicle
-		min     []int
+		min     [12]int
 		soc     float64
 		res     bool
 	}{

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -715,19 +715,19 @@ func TestMinSoC(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vhc := mock.NewMockVehicle(ctrl)
 
-	var min0 [12]int
+	var min0 []int
 	for i := 0; i < 12; i++ {
-		min0[i] = 0
+		min0 = append(min0, 0)
 	}
 
-	var min80 [12]int
+	var min80 []int
 	for i := 0; i < 12; i++ {
-		min80[i] = 80
+		min80 = append(min80, 80)
 	}
 
 	tc := []struct {
 		vehicle api.Vehicle
-		min     [12]int
+		min     []int
 		soc     float64
 		res     bool
 	}{

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -715,22 +715,32 @@ func TestMinSoC(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vhc := mock.NewMockVehicle(ctrl)
 
+	var min0 []int
+	for i := 0; i < 12; i++ {
+		min0 = append(min0, 0)
+	}
+
+	var min80 []int
+	for i := 0; i < 12; i++ {
+		min80 = append(min80, 80)
+	}
+
 	tc := []struct {
 		vehicle api.Vehicle
-		min     int
+		min     []int
 		soc     float64
 		res     bool
 	}{
-		{nil, 0, 0, false},    // never reached without vehicle
-		{nil, 0, 10, false},   // never reached without vehicle
-		{nil, 80, 0, false},   // never reached without vehicle
-		{nil, 80, 80, false},  // never reached without vehicle
-		{nil, 80, 100, false}, // never reached without vehicle
-		{vhc, 0, 0, false},    // min disabled
-		{vhc, 0, 10, false},   // min disabled
-		{vhc, 80, 0, true},    // min not reached
-		{vhc, 80, 80, false},  // min reached
-		{vhc, 80, 100, false}, // min reached
+		{nil, min0, 0, false},    // never reached without vehicle
+		{nil, min0, 10, false},   // never reached without vehicle
+		{nil, min80, 0, false},   // never reached without vehicle
+		{nil, min80, 80, false},  // never reached without vehicle
+		{nil, min80, 100, false}, // never reached without vehicle
+		{vhc, min0, 0, false},    // min disabled
+		{vhc, min0, 10, false},   // min disabled
+		{vhc, min80, 0, true},    // min not reached
+		{vhc, min80, 80, false},  // min reached
+		{vhc, min80, 100, false}, // min reached
 	}
 
 	for _, tc := range tc {


### PR DESCRIPTION
Following our slack discussion I changed the loadpoints min soc parameter to be optionally set by month.
The change is fully backwards compatible. 

In case only one value is set it will be taken for all months.
In case less the than 12 min month values are set, the missing ones will be set to 0.

The monthly min min values can be defined like this:
```yaml
  soc:
...
      mode: charging
      # poll interval defines how often the vehicle API may be polled if NOT charging
      interval: 60m
    min:  # 0  # immediately charge to 0% regardless of mode unless "off" (disabled) 
    - 70  # Jan
    - 60  # Feb
    - 50  # Mar
    - 40  # Apr
    - 40  # May
    - 30  # Jun
    - 30  # Jul
    - 30  # Aug
    - 40  # Sep
    - 50  # Oct
    - 60  # Nov
    - 70  # Dec
    target: 100 # always charge to 100%
...
```
 