### PR TITLE
Select network interface for listening to SMA multicasts

### DIFF
--- a/detect/tasks/sma.go
+++ b/detect/tasks/sma.go
@@ -66,7 +66,7 @@ func (h *SMAHandler) Test(log *util.Logger, in ResultDetails) (res []ResultDetai
 	}
 
 	var err error
-	if h.listener, err = sma.New(log); err != nil {
+	if h.listener, err = sma.New("", log); err != nil {
 		log.ERROR.Println("shm:", err)
 		return nil
 	}

--- a/detect/tasks/sma.go
+++ b/detect/tasks/sma.go
@@ -66,7 +66,7 @@ func (h *SMAHandler) Test(log *util.Logger, in ResultDetails) (res []ResultDetai
 	}
 
 	var err error
-	if h.listener, err = sma.New("", log); err != nil {
+	if h.listener, err = sma.New(log, ""); err != nil {
 		log.ERROR.Println("shm:", err)
 		return nil
 	}

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -27,6 +27,7 @@ type SMA struct {
 	mux     *util.Waiter
 	uri     string
 	serial  string
+	network string
 	values  values
 	powerO  sma.Obis
 	energyO sma.Obis
@@ -42,18 +43,18 @@ func init() {
 // NewSMAFromConfig creates a SMA Meter from generic config
 func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI, Serial, Power, Energy string
+		URI, Serial, Network, Power, Energy string
 	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewSMA(cc.URI, cc.Serial, cc.Power, cc.Energy)
+	return NewSMA(cc.URI, cc.Serial, cc.Network, cc.Power, cc.Energy)
 }
 
 // NewSMA creates a SMA Meter
-func NewSMA(uri, serial, power, energy string) (api.Meter, error) {
+func NewSMA(uri, serial, network, power, energy string) (api.Meter, error) {
 	log := util.NewLogger("sma")
 
 	sm := &SMA{
@@ -61,13 +62,14 @@ func NewSMA(uri, serial, power, energy string) (api.Meter, error) {
 		log:     log,
 		uri:     uri,
 		serial:  serial,
+		network: network,
 		powerO:  sma.Obis(power),
 		energyO: sma.Obis(energy),
 		recv:    make(chan sma.Telegram),
 	}
 
 	if sma.Instance == nil {
-		instance, err := sma.New(log)
+		instance, err := sma.New(network, log)
 		if err != nil {
 			return nil, err
 		}

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -69,7 +69,7 @@ func NewSMA(uri, serial, network, power, energy string) (api.Meter, error) {
 	}
 
 	if sma.Instance == nil {
-		instance, err := sma.New(network, log)
+		instance, err := sma.New(log, network)
 		if err != nil {
 			return nil, err
 		}

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -27,7 +27,7 @@ type SMA struct {
 	mux     *util.Waiter
 	uri     string
 	serial  string
-	network string
+	iface 	string
 	values  values
 	powerO  sma.Obis
 	energyO sma.Obis
@@ -43,18 +43,18 @@ func init() {
 // NewSMAFromConfig creates a SMA Meter from generic config
 func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI, Serial, Network, Power, Energy string
+		URI, Serial, Interface, Power, Energy string
 	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewSMA(cc.URI, cc.Serial, cc.Network, cc.Power, cc.Energy)
+	return NewSMA(cc.URI, cc.Serial, cc.Interface, cc.Power, cc.Energy)
 }
 
 // NewSMA creates a SMA Meter
-func NewSMA(uri, serial, network, power, energy string) (api.Meter, error) {
+func NewSMA(uri, serial, iface, power, energy string) (api.Meter, error) {
 	log := util.NewLogger("sma")
 
 	sm := &SMA{
@@ -62,14 +62,14 @@ func NewSMA(uri, serial, network, power, energy string) (api.Meter, error) {
 		log:     log,
 		uri:     uri,
 		serial:  serial,
-		network: network,
+		iface: iface,
 		powerO:  sma.Obis(power),
 		energyO: sma.Obis(energy),
 		recv:    make(chan sma.Telegram),
 	}
 
 	if sma.Instance == nil {
-		instance, err := sma.New(log, network)
+		instance, err := sma.New(log, iface)
 		if err != nil {
 			return nil, err
 		}

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -116,7 +116,7 @@ func New(log *util.Logger, network string) (*Listener, error) {
 		for i := range interfaces {
 			addresses, err := interfaces[i].Addrs()
 			if err != nil {
-				log.WARN.Printf("error resolving IP addresses network interface %s: %w", interfaces[i].Name, err)
+				log.WARN.Printf("error resolving IP addresses network interface %s: %s", interfaces[i].Name, err)
 			} else {
 				for n := range addresses {
 					ipNet, success := addresses[n].(*net.IPNet)

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -139,6 +139,7 @@ func New(log *util.Logger, network string) (*Listener, error) {
 	}
 
 	// Open up a connection
+	log.DEBUG.Printf("listening on iface: %s", iface.Name)
 	conn, err := net.ListenMulticastUDP("udp4", iface, gaddr)
 	if err != nil {
 		return nil, fmt.Errorf("error opening connecting: %w", err)

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -130,6 +130,8 @@ func New(log *util.Logger, network string) (*Listener, error) {
 		if iface == nil {
 			return nil, fmt.Errorf("network %s cannot be found in local network interfaces", network)
 		}
+
+		log.DEBUG.Printf("listening on iface %s for multicasts", iface.Name)
 	}
 
 
@@ -140,11 +142,6 @@ func New(log *util.Logger, network string) (*Listener, error) {
 	}
 
 	// Open up a connection
-	if iface != nil {
-		log.DEBUG.Printf("listening on iface: %s", iface.Name)
-	} else {
-		log.DEBUG.Printf("listening on default iface")
-	}
 	conn, err := net.ListenMulticastUDP("udp4", iface, gaddr)
 	if err != nil {
 		return nil, fmt.Errorf("error opening connecting: %w", err)

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -104,34 +104,17 @@ type Listener struct {
 }
 
 // New creates a Listener
-func New(log *util.Logger, network string) (*Listener, error) {
+func New(log *util.Logger, ifaceName string) (*Listener, error) {
 	//Select local network interface
-	var iface *net.Interface
-	if network != "" {
-		interfaces, err := net.Interfaces()
+	var iface *net.Interface //Default is nil = System Default
+	if ifaceName != "" {
+		foundInterface, err := net.InterfaceByName(ifaceName)
 		if err != nil {
-			return nil, fmt.Errorf("error resolving network interfaces: %w", err)
+			return nil, fmt.Errorf("error resolving network interface '%s': %w", ifaceName, err)
 		}
 
-		for i := range interfaces {
-			addresses, err := interfaces[i].Addrs()
-			if err != nil {
-				log.WARN.Printf("error resolving IP addresses network interface %s: %s", interfaces[i].Name, err)
-			} else {
-				for n := range addresses {
-					ipNet, success := addresses[n].(*net.IPNet)
-					if success && ipNet.Contains(net.ParseIP(network)) && iface == nil {
-						iface = &interfaces[i]
-					}
-				}
-			}
-		}
-
-		if iface == nil {
-			return nil, fmt.Errorf("network %s cannot be found in local network interfaces", network)
-		}
-
-		log.DEBUG.Printf("listening on iface %s for multicasts", iface.Name)
+		iface = foundInterface
+		log.DEBUG.Printf("listening on network interface %s for multicasts", iface.Name)
 	}
 
 

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/andig/evcc/util"
@@ -119,8 +118,9 @@ func New(network string, log *util.Logger) (*Listener, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error resolving IP addresses network interface %s: %w", interfaces[i].Name, err)
 			}
+
 			for n := range addresses {
-				if strings.HasPrefix(addresses[n].(*net.IPNet).String(), network) {
+				if addresses[n].(*net.IPNet).Contains(net.ParseIP(network)) && iface == nil {
 					iface = &interfaces[i]
 				}
 			}

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -105,26 +105,23 @@ type Listener struct {
 
 // New creates a Listener
 func New(log *util.Logger, ifaceName string) (*Listener, error) {
-	//Select local network interface
-	var iface *net.Interface //Default is nil = System Default
+	var iface *net.Interface
 	if ifaceName != "" {
-		foundInterface, err := net.InterfaceByName(ifaceName)
-		if err != nil {
+		var err error
+		if iface, err = net.InterfaceByName(ifaceName); err != nil {
 			return nil, fmt.Errorf("error resolving network interface '%s': %w", ifaceName, err)
 		}
 
-		iface = foundInterface
 		log.DEBUG.Printf("listening on network interface %s for multicasts", iface.Name)
 	}
 
-
-	// Parse the string address
+	// parse address
 	gaddr, err := net.ResolveUDPAddr("udp4", multicastAddr)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving udp address: %w", err)
 	}
 
-	// Open up a connection
+	// open connection
 	conn, err := net.ListenMulticastUDP("udp4", iface, gaddr)
 	if err != nil {
 		return nil, fmt.Errorf("error opening connecting: %w", err)

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -139,7 +139,11 @@ func New(log *util.Logger, network string) (*Listener, error) {
 	}
 
 	// Open up a connection
-	log.DEBUG.Printf("listening on iface: %s", iface.Name)
+	if iface != nil {
+		log.DEBUG.Printf("listening on iface: %s", iface.Name)
+	} else {
+		log.DEBUG.Printf("listening on default iface")
+	}
 	conn, err := net.ListenMulticastUDP("udp4", iface, gaddr)
 	if err != nil {
 		return nil, fmt.Errorf("error opening connecting: %w", err)

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -106,7 +106,7 @@ type Listener struct {
 // New creates a Listener
 func New(log *util.Logger, network string) (*Listener, error) {
 	//Select local network interface
-	var iface *net.Interface = nil
+	var iface *net.Interface
 	if network != "" {
 		interfaces, err := net.Interfaces()
 		if err != nil {
@@ -116,12 +116,13 @@ func New(log *util.Logger, network string) (*Listener, error) {
 		for i := range interfaces {
 			addresses, err := interfaces[i].Addrs()
 			if err != nil {
-				return nil, fmt.Errorf("error resolving IP addresses network interface %s: %w", interfaces[i].Name, err)
-			}
-
-			for n := range addresses {
-				if addresses[n].(*net.IPNet).Contains(net.ParseIP(network)) && iface == nil {
-					iface = &interfaces[i]
+				log.WARN.Printf("error resolving IP addresses network interface %s: %w", interfaces[i].Name, err)
+			} else {
+				for n := range addresses {
+					ipNet, success := addresses[n].(*net.IPNet)
+					if success && ipNet.Contains(net.ParseIP(network)) && iface == nil {
+						iface = &interfaces[i]
+					}
 				}
 			}
 		}

--- a/meter/sma/listener.go
+++ b/meter/sma/listener.go
@@ -104,7 +104,7 @@ type Listener struct {
 }
 
 // New creates a Listener
-func New(network string, log *util.Logger) (*Listener, error) {
+func New(log *util.Logger, network string) (*Listener, error) {
 	//Select local network interface
 	var iface *net.Interface = nil
 	if network != "" {


### PR DESCRIPTION
Optional kann bei SMA ein Parameter 'network: <IP>' gesetzt werden mit dem die SMA Multicasts nur auf einem bestimmten Netzwerkinterface empfangen werden sollen.
<IP> kann jede gültige IP aus dem IP-Netzwerk sein. Am besten aber die Netzwerk-ID (z.B. 192.168.90.0).

Falls die der Parameter  nicht gesetzt ist verhält sich der Meter wie bisher (es wird auf dem Default-Interface gelauscht).