### PR TITLE
Add scale to SMA meter for usage as PV meter

### DIFF
--- a/meter/sma_test.go
+++ b/meter/sma_test.go
@@ -52,8 +52,9 @@ func TestSMAUpdateMeterValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sm := &SMA{
-				log: util.NewLogger("foo"),
-				mux: util.NewWaiter(udpTimeout, func() {}),
+				log:   util.NewLogger("foo"),
+				mux:   util.NewWaiter(udpTimeout, func() {}),
+				scale: 1,
 			}
 
 			sm.updateMeterValues(tt.message)


### PR DESCRIPTION
The SMA meters are and can be used as grid meter and PV meter. EVCC expects PV power to be positiv, but the meter would return it negativ as it is in export direction.

This is solved by adding an optional Scale property that is only used for the Power value. Default value for Scale is `1`