### PR TITLE
Faster SMA device discovery

### DIFF
--- a/detect/tasks/sma.go
+++ b/detect/tasks/sma.go
@@ -68,11 +68,13 @@ func (h *SMAHandler) Test(log *util.Logger, in ResultDetails) (res []ResultDetai
 		return nil
 	}
 
-	devices, err := sunny.DiscoverDevices(h.Password)
+	connection, err := sunny.NewConnection("")
 	if err != nil {
 		log.ERROR.Println("sma:", err)
 		return nil
 	}
+
+	devices := connection.SimpleDiscoverDevices(h.Password)
 	h.handled = true
 	h.mux.Unlock()
 

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/thoas/go-funk v0.8.0
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c
 	github.com/volkszaehler/mbmd v0.0.0-20210117183837-59dcc46d62d4
-	gitlab.com/bboehmke/sunny v0.11.1
+	gitlab.com/bboehmke/sunny v0.12.0
 	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210508051633-16afe75a6701

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/thoas/go-funk v0.8.0
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c
 	github.com/volkszaehler/mbmd v0.0.0-20210117183837-59dcc46d62d4
-	gitlab.com/bboehmke/sunny v0.12.0
+	gitlab.com/bboehmke/sunny v0.12.1
 	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210508051633-16afe75a6701

--- a/go.sum
+++ b/go.sum
@@ -721,8 +721,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-gitlab.com/bboehmke/sunny v0.12.0 h1:ybklLvgfMOVpgOSuqi4j6CaiPCbKxyD+cOapbCc9rgI=
-gitlab.com/bboehmke/sunny v0.12.0/go.mod h1:o0e0jA5xTQ7JpQ2FO/C8N21gSV47g64EC+dRUQui+CM=
+gitlab.com/bboehmke/sunny v0.12.1 h1:SGFssDJNenC5csLHjtYsuFpOO+2Wd0woJyLBwfygr9g=
+gitlab.com/bboehmke/sunny v0.12.1/go.mod h1:o0e0jA5xTQ7JpQ2FO/C8N21gSV47g64EC+dRUQui+CM=
 go.coder.com/go-tools v0.0.0-20190317003359-0c6a35b74a16/go.mod h1:iKV5yK9t+J5nG9O3uF6KYdPEz3dyfMyB15MN1rbQ8Qw=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/go.sum
+++ b/go.sum
@@ -721,8 +721,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-gitlab.com/bboehmke/sunny v0.11.1 h1:AmGqCXAgDbQFwGjNQ/+K1jGDwAPDL4q6zGtW+ux7zlI=
-gitlab.com/bboehmke/sunny v0.11.1/go.mod h1:o0e0jA5xTQ7JpQ2FO/C8N21gSV47g64EC+dRUQui+CM=
+gitlab.com/bboehmke/sunny v0.12.0 h1:ybklLvgfMOVpgOSuqi4j6CaiPCbKxyD+cOapbCc9rgI=
+gitlab.com/bboehmke/sunny v0.12.0/go.mod h1:o0e0jA5xTQ7JpQ2FO/C8N21gSV47g64EC+dRUQui+CM=
 go.coder.com/go-tools v0.0.0-20190317003359-0c6a35b74a16/go.mod h1:iKV5yK9t+J5nG9O3uF6KYdPEz3dyfMyB15MN1rbQ8Qw=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -88,13 +88,13 @@ func NewSMA(uri, password, serial, iface, power, energy string, scale float64) (
 		scale:        scale,
 	}
 
-	connection, err := sunny.NewConnection(iface)
+	conn, err := sunny.NewConnection(iface)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get SMA connection: %w", err)
 	}
 
 	if uri != "" {
-		sm.device, err = connection.NewDevice(uri, password)
+		sm.device, err = conn.NewDevice(uri, password)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +116,7 @@ func NewSMA(uri, password, serial, iface, power, energy string, scale float64) (
 		}()
 
 		// discover devices and wait for results
-		connection.DiscoverDevices(ctx, devices, password)
+		conn.DiscoverDevices(ctx, devices, password)
 		close(devices)
 		wg.Wait()
 


### PR DESCRIPTION
Reworked SMA device discovery to stop waiting if requested device was found.
Also improved SOC detection by skipping this check for energy meters.

This should reduce the initialization time by 3-4 second per device.