### PR TITLE
fixed race condition in sma trace logger initialization

### DIFF
--- a/meter/sma.go
+++ b/meter/sma.go
@@ -116,10 +116,15 @@ func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
 // map of created discover instances
 var discoverers = make(map[string]*smaDiscoverer)
 
+// initialize sunny logger only once
+var logInitOnce sync.Once
+
 // NewSMA creates a SMA Meter
 func NewSMA(uri, password, iface string, serial uint32, scale float64) (api.Meter, error) {
 	log := util.NewLogger("sma")
-	sunny.Log = log.TRACE
+	logInitOnce.Do(func() {
+		sunny.Log = log.TRACE
+	})
 
 	sm := &SMA{
 		mux:    util.NewWaiter(udpTimeout, func() { log.TRACE.Println("wait for initial value") }),

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -117,12 +117,12 @@ func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
 var discoverers = make(map[string]*smaDiscoverer)
 
 // initialize sunny logger only once
-var logInitOnce sync.Once
+var once sync.Once
 
 // NewSMA creates a SMA Meter
 func NewSMA(uri, password, iface string, serial uint32, scale float64) (api.Meter, error) {
 	log := util.NewLogger("sma")
-	logInitOnce.Do(func() {
+	once.Do(func() {
 		sunny.Log = log.TRACE
 	})
 


### PR DESCRIPTION
Because of the simple implementation of the logger in the SMA library a modification of the logger instance after the first communication causes a race condition.

This change ensure that the logger is only initialized once before the first device communication.