### PR TITLE
Reduce api calls for OVMS vehicle

### DIFF
--- a/vehicle/ovms.go
+++ b/vehicle/ovms.go
@@ -145,8 +145,8 @@ func (v *Ovms) batteryAPI() (interface{}, error) {
 			err = v.disconnect()
 		}
 
-		messageAge := time.Duration(resp.MessageAgeServer * int(time.Second))
-		if err == nil && messageAge > (v.interval+time.Minute) && ovmsConnected {
+		messageAge := time.Duration(resp.MessageAgeServer) * time.Second
+		if err == nil && messageAge > v.interval+time.Minute && ovmsConnected {
 			err = api.ErrMustRetry
 		}
 	}

--- a/vehicle/ovms.go
+++ b/vehicle/ovms.go
@@ -32,6 +32,7 @@ type Ovms struct {
 	*embed
 	*request.Helper
 	user, password, vehicleId, server string
+	interval                          time.Duration
 	chargeG                           func() (interface{}, error)
 }
 
@@ -62,6 +63,7 @@ func NewOvmsFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		password:  cc.Password,
 		vehicleId: cc.VehicleID,
 		server:    cc.Server,
+		interval:  cc.Cache,
 	}
 
 	v.chargeG = provider.NewCached(v.batteryAPI, cc.Cache).InterfaceGetter()
@@ -143,7 +145,8 @@ func (v *Ovms) batteryAPI() (interface{}, error) {
 			err = v.disconnect()
 		}
 
-		if err == nil && resp.MessageAgeServer > 59 && ovmsConnected {
+		messageAge := time.Duration(resp.MessageAgeServer * int(time.Second))
+		if err == nil && messageAge > (v.interval+time.Minute) && ovmsConnected {
 			err = api.ErrMustRetry
 		}
 	}


### PR DESCRIPTION
Die aktuelle Implementierung hatte dazu geführt, dass für jeden Durchlauf immer zwei Abfragen ausgeführt wurden.

OVMS verwendet ein Backend (dexters-web.de), an den das Modul seine Daten sendet. Dies geschieht per Default nur alle 10min. Die verwendete API ruft an sich nur die Daten vom Backend ab. Mit dem vehicle Connect wird dem Modul gesagt, dass es neue Daten senden soll. Dies geschieht aber asynchron, so dass die Daten erst mit 1-2 Sekunden Verzögerung ankommen. Dies führt dazu, dass im evcc Prozess immer die Daten des letzten Connect abgerufen werden.

Mit der Änderung wird jetzt das Cache Interval (damit auch Abfrageinterval) beachtet und eine Karenz von 1 Minute eingeräumt. D.h. es ist OK, wenn die Daten maximal Interval + 1 Minute alt sind.