### PR TITLE
Limit trace log level to physical communication

### DIFF
--- a/charger/nrgble_linux.go
+++ b/charger/nrgble_linux.go
@@ -248,7 +248,6 @@ func (nrg *NRGKickBLE) Status() (api.ChargeStatus, error) {
 func (nrg *NRGKickBLE) Enabled() (bool, error) {
 	res := nrgble.Info{}
 	if err := nrg.read(nrgble.InfoService, &res); err != nil {
-		nrg.log.TRACE.Println(err)
 		return false, err
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -258,7 +258,7 @@ func (site *Site) updateMeters() error {
 	if phaseMeter, ok := site.gridMeter.(api.MeterCurrent); err == nil && ok {
 		i1, i2, i3, err := phaseMeter.Currents()
 		if err == nil {
-			site.log.TRACE.Printf("grid currents: %.3gA", []float64{i1, i2, i3})
+			site.log.DEBUG.Printf("grid currents: %.3gA", []float64{i1, i2, i3})
 			site.publish("gridCurrents", []float64{i1, i2, i3})
 		}
 	}

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -119,7 +119,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 			if socDelta > 2 && energyDelta > 0 && s.prevSoC > 0 {
 				s.energyPerSocStep = energyDelta / socDelta
 				s.virtualCapacity = s.energyPerSocStep * 100
-				s.log.TRACE.Printf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualCapacity: %0.0fWh", s.energyPerSocStep, s.virtualCapacity)
+				s.log.DEBUG.Printf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualCapacity: %0.0fWh", s.energyPerSocStep, s.virtualCapacity)
 			}
 
 			// sample charged energy at soc change, reset energy delta
@@ -127,7 +127,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 			s.prevSoC = s.socCharge
 		} else {
 			s.socCharge = math.Min(f+energyDelta/s.energyPerSocStep, 100)
-			s.log.TRACE.Printf("soc estimated: %.2f%% (vehicle: %.2f%%)", s.socCharge, f)
+			s.log.DEBUG.Printf("soc estimated: %.2f%% (vehicle: %.2f%%)", s.socCharge, f)
 		}
 	}
 

--- a/detect/tasks/modbus.go
+++ b/detect/tasks/modbus.go
@@ -136,7 +136,7 @@ func (h *ModbusHandler) testSunSpec(log *util.Logger, conn meters.Connection, de
 			mr.Point = h.Point
 			mr.Value = res.Value()
 
-			log.TRACE.Printf("model %d point %s: %v", model, mr.Point, mr.Value)
+			log.DEBUG.Printf("model %d point %s: %v", model, mr.Point, mr.Value)
 
 			if len(h.Invalid) == 0 {
 				return true

--- a/hems/ocpp/ocpp.go
+++ b/hems/ocpp/ocpp.go
@@ -90,7 +90,7 @@ func (s *OCPP) Run() {
 				status = ocppcore.ChargePointStatusCharging
 			}
 
-			s.log.TRACE.Printf("send: lp-%d status: %+v", connector, status)
+			s.log.DEBUG.Printf("send: lp-%d status: %+v", connector, status)
 			if _, err := s.cp.StatusNotification(connector, ocppcore.NoError, status); err != nil {
 				s.log.ERROR.Printf("lp-%d: %v", connector, err)
 			}

--- a/provider/mqtt.go
+++ b/provider/mqtt.go
@@ -100,7 +100,7 @@ func (m *Mqtt) FloatGetter() func() (float64, error) {
 	h := &msgHandler{
 		topic: m.topic,
 		scale: m.scale,
-		mux:   util.NewWaiter(m.timeout, func() { m.log.TRACE.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
 		jq:    m.jq,
 	}
 
@@ -115,7 +115,7 @@ func (m *Mqtt) IntGetter() func() (int64, error) {
 	h := &msgHandler{
 		topic: m.topic,
 		scale: float64(m.scale),
-		mux:   util.NewWaiter(m.timeout, func() { m.log.TRACE.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
 		jq:    m.jq,
 	}
 
@@ -129,7 +129,7 @@ var _ StringProvider = (*Mqtt)(nil)
 func (m *Mqtt) StringGetter() func() (string, error) {
 	h := &msgHandler{
 		topic: m.topic,
-		mux:   util.NewWaiter(m.timeout, func() { m.log.TRACE.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
 		jq:    m.jq,
 	}
 
@@ -143,7 +143,7 @@ var _ BoolProvider = (*Mqtt)(nil)
 func (m *Mqtt) BoolGetter() func() (bool, error) {
 	h := &msgHandler{
 		topic: m.topic,
-		mux:   util.NewWaiter(m.timeout, func() { m.log.TRACE.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
 		jq:    m.jq,
 	}
 

--- a/provider/mqtt/client.go
+++ b/provider/mqtt/client.go
@@ -96,7 +96,7 @@ func (m *Client) ConnectionHandler(client paho.Client) {
 	defer m.mux.Unlock()
 
 	for topic := range m.listener {
-		m.log.TRACE.Printf("%s subscribe %s", m.broker, topic)
+		m.log.DEBUG.Printf("%s subscribe %s", m.broker, topic)
 		go m.listen(topic)
 	}
 }

--- a/provider/script.go
+++ b/provider/script.go
@@ -58,7 +58,7 @@ func NewScriptProvider(script string, timeout time.Duration, jq string, cache ti
 		timeout: timeout,
 		cache:   cache,
 	}
-	
+
 	if jq != "" {
 		op, err := gojq.Parse(jq)
 		if err != nil {
@@ -96,7 +96,7 @@ func (e *Script) exec(script string) (string, error) {
 		return "", err
 	}
 
-	e.log.TRACE.Printf("%s: %s", strings.Join(args, " "), s)
+	e.log.DEBUG.Printf("%s: %s", strings.Join(args, " "), s)
 
 	return s, nil
 }
@@ -115,7 +115,7 @@ func (e *Script) StringGetter() func() (string, error) {
 				}
 			}
 		}
-		
+
 		return e.val, e.err
 	}
 }

--- a/provider/sma/discover.go
+++ b/provider/sma/discover.go
@@ -65,7 +65,7 @@ func (d *Discoverer) createDevice(device *sunny.Device) *Device {
 	return &Device{
 		Device: device,
 		log:    d.log,
-		mux:    util.NewWaiter(udpTimeout, func() { d.log.TRACE.Println("wait for initial value") }),
+		mux:    util.NewWaiter(udpTimeout, func() { d.log.DEBUG.Println("wait for initial value") }),
 		values: make(map[sunny.ValueID]interface{}),
 	}
 }

--- a/provider/socket.go
+++ b/provider/socket.go
@@ -61,7 +61,7 @@ func NewSocketProviderFromConfig(other map[string]interface{}) (IntProvider, err
 	p := &Socket{
 		log:     log,
 		Helper:  request.NewHelper(log),
-		mux:     util.NewWaiter(cc.Timeout, func() { log.TRACE.Println("wait for initial value") }),
+		mux:     util.NewWaiter(cc.Timeout, func() { log.DEBUG.Println("wait for initial value") }),
 		url:     url,
 		headers: cc.Headers,
 		scale:   cc.Scale,

--- a/push/pushover.go
+++ b/push/pushover.go
@@ -38,7 +38,7 @@ func (m *PushOver) Send(title, msg string) {
 
 	for _, id := range m.recipients {
 		go func(id string) {
-			log.TRACE.Printf("pushover: sending to %s", id)
+			log.DEBUG.Printf("pushover: sending to %s", id)
 
 			recipient := pushover.NewRecipient(id)
 			if _, err := m.app.SendMessage(message, recipient); err != nil {

--- a/push/telegram.go
+++ b/push/telegram.go
@@ -70,7 +70,7 @@ func (m *Telegram) trackChats() {
 func (m *Telegram) Send(title, msg string) {
 	m.Lock()
 	for chat := range m.chats {
-		log.TRACE.Printf("telegram: sending to %d", chat)
+		log.DEBUG.Printf("telegram: sending to %d", chat)
 
 		msg := tgbotapi.NewMessage(chat, msg)
 		if _, err := m.bot.Send(msg); err != nil {

--- a/util/cache.go
+++ b/util/cache.go
@@ -23,7 +23,7 @@ func (c *Cache) Run(in <-chan Param) {
 	log := NewLogger("cache")
 
 	for p := range in {
-		log.TRACE.Printf("%s: %v", p.Key, p.Val)
+		log.DEBUG.Printf("%s: %v", p.Key, p.Val)
 		c.Add(p.UniqueID(), p)
 	}
 }

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -67,7 +67,7 @@ func min(a, b int) int {
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	r.log.TRACE.Printf("%s %s", req.Method, req.URL.String())
+	r.log.DEBUG.Printf("%s %s", req.Method, req.URL.String())
 
 	var bld strings.Builder
 	if body, err := httputil.DumpRequestOut(req, true); err == nil {

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -67,7 +67,7 @@ func min(a, b int) int {
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	r.log.DEBUG.Printf("%s %s", req.Method, req.URL.String())
+	r.log.TRACE.Printf("%s %s", req.Method, req.URL.String())
 
 	var bld strings.Builder
 	if body, err := httputil.DumpRequestOut(req, true); err == nil {


### PR DESCRIPTION
With this PR, meaningful logs with less detail should be available using the `debug` log level instead of `trace`.

A detailed logfile for analysis should hence be provided using:

```
log: debug
levels:
  cache: error # further reduce detail
```

This will also help reduce leaking sensitive information in log files.

/cc @naltatis 