### PR TITLE
Update error message with correct value

### DIFF
--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -193,7 +193,7 @@ func (c *GoE) Enable(enable bool) error {
 
 	status, err := c.apiUpdate(fmt.Sprintf("alw=%d", b))
 	if err == nil && isValid(status) && status.Alw != b {
-		return fmt.Errorf("alw update failed: %d", status.Amp)
+		return fmt.Errorf("alw update failed: %d", status.Alw)
 	}
 
 	return err


### PR DESCRIPTION
Most likely a copy and paste error. If "alw" could not be updated "Amp" was printed in the error message instead of "alw"