### PR TITLE
Provide option to override SEMP VendorID

### DIFF
--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -335,6 +335,7 @@ func (s *SEMP) serialNumber(id int) string {
 	return fmt.Sprintf(sempSerialNumber, ser, id)
 }
 
+// uniqueDeviceID creates a 6-bytes base device id from machine id
 func uniqueDeviceID() ([]byte, error) {
 	bytes := 6
 
@@ -355,7 +356,7 @@ func uniqueDeviceID() ([]byte, error) {
 	return b[:bytes], nil
 }
 
-// deviceID creates a 6-bytes device id from machine id plus device number
+// deviceID combines base device id with device number
 func (s *SEMP) deviceID(id int) string {
 	// numerically add device number
 	did := append([]byte{0, 0}, s.did...)


### PR DESCRIPTION
This helps if someone wants to migrate e.g. from SAE to EVCC without the need to re-register the charger in the SMA backend