### PR TITLE
Improved SoC handling provided by chargers

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -505,7 +505,7 @@ func (c *EEBus) SoC() (float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
 		c.log.TRACE.Printf("soc: no eebus data available yet")
-		return 0, api.ErrNotAvailable
+		return 0, api.ErrMustRetry
 	}
 
 	if !data.EVData.UCSoCAvailable || !data.EVData.SoCDataAvailable {

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -72,7 +72,7 @@ var eebusDevice spine.Device
 var once sync.Once
 
 func (c *EEBus) onConnect(ski string, conn ship.Conn) error {
-	c.log.TRACE.Println("onCconnect invoked on ski ", ski)
+	c.log.TRACE.Println("!! onCconnect invoked on ski ", ski)
 
 	once.Do(func() {
 		eebusDevice = app.HEMS(server.EEBusInstance.DeviceInfo())
@@ -89,7 +89,7 @@ func (c *EEBus) onConnect(ski string, conn ship.Conn) error {
 }
 
 func (c *EEBus) onDisconnect(ski string) {
-	c.log.TRACE.Println("onDisconnect invoked on ski ", ski)
+	c.log.TRACE.Println("!! onDisconnect invoked on ski ", ski)
 
 	c.connected = false
 	c.setDefaultValues()
@@ -135,19 +135,19 @@ func (c *EEBus) showCurrentChargingSetup() {
 	if prevComStandard != data.EVData.CommunicationStandard {
 		c.communicationStandard = data.EVData.CommunicationStandard
 		timestamp := time.Now()
-		c.log.WARN.Println(timestamp.Format("2006-01-02 15:04:05"), " ev-charger-communication changed from ", prevComStandard, " to ", data.EVData.CommunicationStandard)
+		c.log.WARN.Println("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-communication changed from ", prevComStandard, " to ", data.EVData.CommunicationStandard)
 	}
 
 	if prevSoCSupport != data.EVData.UCSoCAvailable {
 		c.socSupportAvailable = data.EVData.UCSoCAvailable
 		timestamp := time.Now()
-		c.log.WARN.Println(timestamp.Format("2006-01-02 15:04:05"), " ev-charger-soc support changed from ", prevSoCSupport, " to ", data.EVData.UCSoCAvailable)
+		c.log.WARN.Println("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-soc support changed from ", prevSoCSupport, " to ", data.EVData.UCSoCAvailable)
 	}
 
 	if prevSelfConsumptionSupport != data.EVData.UCSelfConsumptionAvailable {
 		c.selfConsumptionSupportAvailable = data.EVData.UCSelfConsumptionAvailable
 		timestamp := time.Now()
-		c.log.WARN.Println(timestamp.Format("2006-01-02 15:04:05"), " ev-charger-self-consumption-support support changed from ", prevSelfConsumptionSupport, " to ", data.EVData.UCSelfConsumptionAvailable)
+		c.log.WARN.Println("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-self-consumption-support support changed from ", prevSelfConsumptionSupport, " to ", data.EVData.UCSelfConsumptionAvailable)
 	}
 
 }
@@ -191,14 +191,14 @@ func (c *EEBus) dataUpdateHandler(dataType communication.EVDataElementUpdateType
 func (c *EEBus) Status() (api.ChargeStatus, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("status: no eebus data available yet")
+		c.log.TRACE.Printf("!! status: no eebus data available yet")
 		return api.StatusNone, err
 	}
 
 	currentState := data.EVData.ChargeState
 
 	if !c.connected {
-		c.log.TRACE.Printf("status: charger reported as disconnected")
+		c.log.TRACE.Printf("!! status: charger reported as disconnected")
 		return api.StatusNone, fmt.Errorf("charger reported as disconnected")
 	}
 
@@ -252,12 +252,12 @@ func (c *EEBus) Enabled() (bool, error) {
 func (c *EEBus) Enable(enable bool) error {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("enable: no eebus data available yet")
+		c.log.TRACE.Printf("!! enable: no eebus data available yet")
 		return err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("currents: ev reported as unplugged")
+		c.log.TRACE.Printf("!! currents: ev reported as unplugged")
 		// if the ev is unplugged, we do not need to disable charging by setting a current of 0 as it already is
 		if !enable {
 			return nil
@@ -269,7 +269,7 @@ func (c *EEBus) Enable(enable bool) error {
 	// if we disable charging with a potential but not yet known communication standard ISO15118
 	// this would set allowed A value to be 0. And this would trigger ISO connections to switch to IEC!
 	if data.EVData.CommunicationStandard == communication.EVCommunicationStandardEnumTypeUnknown {
-		c.log.TRACE.Printf("enable: cannot enable or disable as communication standard is not yet known")
+		c.log.TRACE.Printf("!! enable: cannot enable or disable as communication standard is not yet known")
 		return api.ErrMustRetry
 	}
 
@@ -356,26 +356,26 @@ var _ api.ChargerEx = (*EEBus)(nil)
 func (c *EEBus) MaxCurrentMillis(current float64) error {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("currents: no eebus data available yet")
+		c.log.TRACE.Printf("!! currents: no eebus data available yet")
 		return err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("currents: ev reported as unplugged")
+		c.log.TRACE.Printf("!! currents: ev reported as unplugged")
 		return errors.New("can't set new current as ev is unplugged")
 	}
 
 	if data.EVData.LimitsL1.Min == 0 {
-		c.log.TRACE.Println("we did not yet receive min and max currents to validate the call of MaxCurrent, use it as is")
+		c.log.TRACE.Println("!! we did not yet receive min and max currents to validate the call of MaxCurrent, use it as is")
 	}
 
 	if current < data.EVData.LimitsL1.Min {
-		c.log.TRACE.Printf("current value %f is lower than the allowed minimum value %f", current, data.EVData.LimitsL1.Min)
+		c.log.TRACE.Printf("!! current value %f is lower than the allowed minimum value %f", current, data.EVData.LimitsL1.Min)
 		current = data.EVData.LimitsL1.Min
 	}
 
 	if current > data.EVData.LimitsL1.Max {
-		c.log.TRACE.Printf("current value %f is higher than the allowed maximum value %f", current, data.EVData.LimitsL1.Max)
+		c.log.TRACE.Printf("!! current value %f is higher than the allowed maximum value %f", current, data.EVData.LimitsL1.Max)
 		current = data.EVData.LimitsL1.Max
 	}
 
@@ -383,7 +383,7 @@ func (c *EEBus) MaxCurrentMillis(current float64) error {
 
 	// TODO error handling
 
-	c.log.TRACE.Printf("currents: returning %f", current)
+	c.log.TRACE.Printf("!! currents: returning %f", current)
 
 	currents := []float64{current, current, current}
 	return c.writeCurrentLimitData(currents)
@@ -395,17 +395,17 @@ var _ api.Meter = (*EEBus)(nil)
 func (c *EEBus) CurrentPower() (float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("current power: no eebus data available yet")
+		c.log.TRACE.Printf("!! current power: no eebus data available yet")
 		return 0, err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("current power: ev reported as unplugged")
+		c.log.TRACE.Printf("!! current power: ev reported as unplugged")
 		return 0, nil
 	}
 
 	power := data.EVData.Measurements.PowerL1 + data.EVData.Measurements.PowerL2 + data.EVData.Measurements.PowerL3
-	c.log.TRACE.Printf("current power: returning %f", power)
+	c.log.TRACE.Printf("!! current power: returning %f", power)
 
 	return power, nil
 }
@@ -416,17 +416,17 @@ var _ api.ChargeRater = (*EEBus)(nil)
 func (c *EEBus) ChargedEnergy() (float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("charged energy: no eebus data available yet")
+		c.log.TRACE.Printf("!! charged energy: no eebus data available yet")
 		return 0, err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("charged energy: ev reported as unplugged")
+		c.log.TRACE.Printf("!! charged energy: ev reported as unplugged")
 		return 0, nil
 	}
 
 	energy := data.EVData.Measurements.ChargedEnergy / 1000
-	c.log.TRACE.Printf("charged energy: returning %f", energy)
+	c.log.TRACE.Printf("!! charged energy: returning %f", energy)
 
 	return energy, nil
 }
@@ -450,16 +450,16 @@ var _ api.MeterCurrent = (*EEBus)(nil)
 func (c *EEBus) Currents() (float64, float64, float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("currents: no eebus data available yet")
+		c.log.TRACE.Printf("!! currents: no eebus data available yet")
 		return 0, 0, 0, err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("currents: ev reported as unplugged")
+		c.log.TRACE.Printf("!! currents: ev reported as unplugged")
 		return 0, 0, 0, nil
 	}
 
-	c.log.TRACE.Printf("currents: returning %f, %f, %f, ", data.EVData.Measurements.CurrentL1, data.EVData.Measurements.CurrentL2, data.EVData.Measurements.CurrentL3)
+	c.log.TRACE.Printf("!! currents: returning %f, %f, %f, ", data.EVData.Measurements.CurrentL1, data.EVData.Measurements.CurrentL2, data.EVData.Measurements.CurrentL3)
 
 	return data.EVData.Measurements.CurrentL1, data.EVData.Measurements.CurrentL2, data.EVData.Measurements.CurrentL3, nil
 }
@@ -470,31 +470,31 @@ var _ api.Identifier = (*EEBus)(nil)
 func (c *EEBus) Identify() (string, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("identify: no eebus data available yet")
+		c.log.TRACE.Printf("!! identify: no eebus data available yet")
 		return "", err
 	}
 
 	if !c.connected {
-		c.log.TRACE.Printf("identify: charger reported as disconnected")
+		c.log.TRACE.Printf("!! identify: charger reported as disconnected")
 		return "", nil
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged || data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnknown {
-		c.log.TRACE.Printf("identify: ev reported as unplugged or unknown")
+		c.log.TRACE.Printf("!! identify: ev reported as unplugged or unknown")
 		return "", nil
 	}
 
 	if len(data.EVData.Identification) > 0 {
-		c.log.TRACE.Printf("identify: returning %s", data.EVData.Identification)
+		c.log.TRACE.Printf("!! identify: returning %s", data.EVData.Identification)
 		return data.EVData.Identification, nil
 	}
 
 	if data.EVData.CommunicationStandard == communication.EVCommunicationStandardEnumTypeIEC61851 {
-		c.log.TRACE.Printf("identify: ev communication is IEC61851 which does not support any identification")
+		c.log.TRACE.Printf("!! identify: ev communication is IEC61851 which does not support any identification")
 		return "", nil
 	}
 
-	c.log.TRACE.Printf("identify: returning nothing")
+	c.log.TRACE.Printf("!! identify: returning nothing")
 	return "", api.ErrMustRetry
 }
 
@@ -504,16 +504,16 @@ var _ api.Battery = (*EEBus)(nil)
 func (c *EEBus) SoC() (float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("soc: no eebus data available yet")
+		c.log.TRACE.Printf("!! soc: no eebus data available yet")
 		return 0, api.ErrMustRetry
 	}
 
 	if !data.EVData.UCSoCAvailable || !data.EVData.SoCDataAvailable {
-		c.log.TRACE.Printf("soc: feature not available")
+		c.log.TRACE.Printf("!! soc: feature not available")
 		return 0, api.ErrNotAvailable
 	}
 
-	c.log.TRACE.Printf("soc: returning %f", data.EVData.Measurements.SoC)
+	c.log.TRACE.Printf("!! soc: returning %f", data.EVData.Measurements.SoC)
 	return data.EVData.Measurements.SoC, nil
 }
 

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -119,7 +119,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 	if fetchedSoC == nil {
 		f, err := s.vehicle.SoC()
 		if err != nil {
-			// required for online APIs with refresh tokens
+			// required for online APIs with refreshkey
 			if errors.Is(err, api.ErrMustRetry) {
 				return 0, err
 			}

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -98,7 +98,23 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 	if charger, ok := s.charger.(api.Battery); ok {
 		f, err := charger.SoC()
 
-		if err == nil {
+		// if the charger does or could provide SoC, we always use it instead of using the vehicle API
+		if err == nil || !errors.Is(err, api.ErrNotAvailable) {
+			if err != nil {
+				if errors.Is(err, api.ErrMustRetry) {
+					return 0, err
+				}
+
+				// never received a soc value
+				if s.prevSoC == 0 {
+					return 0, err
+				}
+
+				// recover from temporary api errors
+				f = s.prevSoC
+				s.log.WARN.Printf("vehicle soc (charger): %v (ignored by estimator)", err)
+			}
+
 			s.vehicleSoc = f
 			fetchedSoC = &f
 		}

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -101,10 +101,6 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 		// if the charger does or could provide SoC, we always use it instead of using the vehicle API
 		if err == nil || !errors.Is(err, api.ErrNotAvailable) {
 			if err != nil {
-				if errors.Is(err, api.ErrMustRetry) {
-					return 0, err
-				}
-
 				// never received a soc value
 				if s.prevSoC == 0 {
 					return 0, err
@@ -123,6 +119,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 	if fetchedSoC == nil {
 		f, err := s.vehicle.SoC()
 		if err != nil {
+			// required for online APIs with refresh tokens
 			if errors.Is(err, api.ErrMustRetry) {
 				return 0, err
 			}

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -101,10 +101,6 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 		// if the charger does or could provide SoC, we always use it instead of using the vehicle API
 		if err == nil || !errors.Is(err, api.ErrNotAvailable) {
 			if err != nil {
-				if errors.Is(err, api.ErrMustRetry) {
-					return 0, err
-				}
-
 				// never received a soc value
 				if s.prevSoC == 0 {
 					return 0, err
@@ -123,10 +119,6 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 	if fetchedSoC == nil {
 		f, err := s.vehicle.SoC()
 		if err != nil {
-			if errors.Is(err, api.ErrMustRetry) {
-				return 0, err
-			}
-
 			// never received a soc value
 			if s.prevSoC == 0 {
 				return 0, err

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -101,6 +101,10 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 		// if the charger does or could provide SoC, we always use it instead of using the vehicle API
 		if err == nil || !errors.Is(err, api.ErrNotAvailable) {
 			if err != nil {
+				if errors.Is(err, api.ErrMustRetry) {
+					return 0, err
+				}
+
 				// never received a soc value
 				if s.prevSoC == 0 {
 					return 0, err
@@ -119,6 +123,10 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 	if fetchedSoC == nil {
 		f, err := s.vehicle.SoC()
 		if err != nil {
+			if errors.Is(err, api.ErrMustRetry) {
+				return 0, err
+			}
+
 			// never received a soc value
 			if s.prevSoC == 0 {
 				return 0, err

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -149,11 +149,11 @@ func TestSoCFromChargerAndVehicleWithErrors(t *testing.T) {
 	}{
 		// start with SoC from charger and errors
 		{0, 0.0, 0.0, 10000, false, errors.New("some error"), nil},
-		{10, 20.0, 20.0, 10000, false, api.ErrMustRetry, nil},
+		{10, 0.0, 20.0, 10000, false, api.ErrMustRetry, nil},
 		{10, 20.0, 20.0, 10000, false, nil, nil},
 		{0, 20.0, 20.0, 10000, false, nil, nil},
 		{123, 20.0, 21.23, 10000, false, nil, nil},
-		{123, 20.0, 21.23, 10000, false, errors.New("another error"), nil},
+		{123, 0.0, 21.23, 10000, false, errors.New("another error"), nil},
 		{1000, 20.0, 30.0, 10000, false, nil, nil},
 		{1100, 31.0, 31.0, 10000, false, nil, nil},
 		{1200, 32.0, 32.0, 10000, false, nil, nil},
@@ -164,11 +164,11 @@ func TestSoCFromChargerAndVehicleWithErrors(t *testing.T) {
 		{6500, 65.0, 65.0, 10000, false, nil, nil},
 		{7000, 65.0, 70.0, 10000, false, nil, nil},
 		// move to SoC from vehicle
-		{7000, 65.0, 70.0, 10000, true, api.ErrNotAvailable, errors.New("some error")},
-		{7100, 71.0, 71.0, 10000, true, api.ErrNotAvailable, api.ErrMustRetry},
+		{7000, 0.0, 70.0, 10000, true, api.ErrNotAvailable, errors.New("some error")},
+		{7100, 0.0, 71.0, 10000, true, api.ErrNotAvailable, api.ErrMustRetry},
 		{7100, 71.0, 71.0, 10000, true, api.ErrNotAvailable, nil},
 		{7300, 72.0, 72.0, 10000, true, api.ErrNotAvailable, nil},
-		{7400, 73.0, 73.0, 10000, true, api.ErrNotAvailable, errors.New("another error")},
+		{7400, 0.0, 73.0, 10000, true, api.ErrNotAvailable, errors.New("another error")},
 		{7400, 73.0, 73.0, 10000, true, api.ErrNotAvailable, nil},
 		{7700, 75.0, 75.0, 10000, true, api.ErrNotAvailable, nil},
 		{8200, 80.0, 80.0, 10000, true, api.ErrNotAvailable, nil},

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -136,7 +136,7 @@ func TestSoCFromChargerAndVehicleWithErrors(t *testing.T) {
 	vehicle.EXPECT().Capacity().Return(capacity)
 
 	ce := NewEstimator(util.NewLogger("foo"), charger, vehicle, true)
-	ce.socCharge = 20.0
+	ce.vehicleSoc = 20.0
 
 	tc := []struct {
 		chargedEnergy   float64

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -1,6 +1,7 @@
 package soc
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -116,6 +117,106 @@ func TestSoCEstimation(t *testing.T) {
 			if rm := ce.RemainingChargeDuration(chargePower, targetSoC); rm != remainingDuration {
 				t.Errorf("expected estimated duration: %v, got: %v", remainingDuration, rm)
 			}
+		}
+	}
+}
+
+func TestSoCFromChargerAndVehicleWithErrors(t *testing.T) {
+	type chargerStruct struct {
+		*mock.MockCharger
+		*mock.MockBattery
+	}
+
+	ctrl := gomock.NewController(t)
+	vehicle := mock.NewMockVehicle(ctrl)
+	charger := &chargerStruct{mock.NewMockCharger(ctrl), mock.NewMockBattery(ctrl)}
+
+	// 9 kWh user battery capacity is converted to initial value of 10 kWh virtual capacity
+	var capacity int64 = 9
+	vehicle.EXPECT().Capacity().Return(capacity)
+
+	ce := NewEstimator(util.NewLogger("foo"), charger, vehicle, true)
+	ce.socCharge = 20.0
+
+	tc := []struct {
+		chargedEnergy   float64
+		vehicleSoC      float64
+		estimatedSoC    float64
+		virtualCapacity float64
+		expectVehicle   bool
+		chargerError    error
+		vehicleError    error
+	}{
+		// start with SoC from charger and errors
+		{0, 0.0, 0.0, 10000, false, errors.New("some error"), nil},
+		{10, 20.0, 20.0, 10000, false, api.ErrMustRetry, nil},
+		{10, 20.0, 20.0, 10000, false, nil, nil},
+		{0, 20.0, 20.0, 10000, false, nil, nil},
+		{123, 20.0, 21.23, 10000, false, nil, nil},
+		{123, 20.0, 21.23, 10000, false, errors.New("another error"), nil},
+		{1000, 20.0, 30.0, 10000, false, nil, nil},
+		{1100, 31.0, 31.0, 10000, false, nil, nil},
+		{1200, 32.0, 32.0, 10000, false, nil, nil},
+		{1900, 39.0, 39.0, 10000, false, nil, nil},
+		{2000, 40.0, 40.0, 10000, false, nil, nil},
+		{4000, 50.0, 50.0, 20000, false, nil, nil}, // 2kWh add 10% -> 20kWh battery
+		{6000, 60.0, 60.0, 20000, false, nil, nil}, // 2kWh add 10% -> 20kWh battery
+		{6500, 65.0, 65.0, 10000, false, nil, nil},
+		{7000, 65.0, 70.0, 10000, false, nil, nil},
+		// move to SoC from vehicle
+		{7000, 65.0, 70.0, 10000, true, api.ErrNotAvailable, errors.New("some error")},
+		{7100, 71.0, 71.0, 10000, true, api.ErrNotAvailable, api.ErrMustRetry},
+		{7100, 71.0, 71.0, 10000, true, api.ErrNotAvailable, nil},
+		{7300, 72.0, 72.0, 10000, true, api.ErrNotAvailable, nil},
+		{7400, 73.0, 73.0, 10000, true, api.ErrNotAvailable, errors.New("another error")},
+		{7400, 73.0, 73.0, 10000, true, api.ErrNotAvailable, nil},
+		{7700, 75.0, 75.0, 10000, true, api.ErrNotAvailable, nil},
+		{8200, 80.0, 80.0, 10000, true, api.ErrNotAvailable, nil},
+		{0, 25.0, 25.0, 10000, true, api.ErrNotAvailable, nil},
+		{2500, 25.0, 50.0, 10000, true, api.ErrNotAvailable, nil},
+		{0, 50.0, 50.0, 10000, true, api.ErrNotAvailable, nil}, // -10000
+		{4990, 50.0, 99.9, 10000, true, api.ErrNotAvailable, nil},
+		{5000, 50.0, 100.0, 10000, true, api.ErrNotAvailable, nil},
+		// back to SoC from charger
+		{5001, 50.0, 100.0, 10000, false, nil, nil},
+		{0, 0.0, 0.0, 10000, false, nil, nil},
+		{1000, 0.0, 10.0, 10000, false, nil, nil},
+	}
+
+	for _, tc := range tc {
+		t.Logf("%+v", tc)
+		charger.MockBattery.EXPECT().SoC().Return(tc.vehicleSoC, tc.chargerError)
+		if tc.expectVehicle {
+			vehicle.EXPECT().SoC().Return(tc.vehicleSoC, tc.vehicleError)
+		}
+
+		soc, err := ce.SoC(tc.chargedEnergy)
+		if err != nil {
+			if (!tc.expectVehicle && err != tc.chargerError) || (tc.expectVehicle && err != tc.vehicleError) {
+				t.Error(err)
+			} else {
+				continue
+			}
+		}
+
+		// validate soc estimate
+		if tc.estimatedSoC != soc {
+			t.Errorf("expected estimated soc: %g, got: %g", tc.estimatedSoC, soc)
+		}
+
+		// validate capacity estimate
+		if tc.virtualCapacity != ce.virtualCapacity {
+			t.Errorf("expected virtual capacity: %v, got: %v", tc.virtualCapacity, ce.virtualCapacity)
+		}
+
+		// validate duration estimate
+		chargePower := 1e3
+		targetSoC := 100
+		remainingHours := (float64(targetSoC) - soc) / 100 * tc.virtualCapacity / chargePower
+		remainingDuration := time.Duration(float64(time.Hour) * remainingHours).Round(time.Second)
+
+		if rm := ce.RemainingChargeDuration(chargePower, targetSoC); rm != remainingDuration {
+			t.Errorf("expected estimated duration: %v, got: %v", remainingDuration, rm)
 		}
 	}
 }


### PR DESCRIPTION
- If the charger can not provide SoC with the current car connection, it has to return `api.ErrNotAvailable`
- If the charger does not know yet if it can provide SoC with the current car connection, it has to return `api.ErrMustRetry`
- If the charger does or could provide an SoC, the vehicle API will never be called, even in case of an error