### PR TITLE
make max offset current (diff of set and measured wallbox current) configurable

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -105,6 +105,7 @@ loadpoints:
   guardduration: 5m # switch charger contactor not more often than this (default 10m)
   mincurrent: 6 # minimum charge current (default 6A)
   maxcurrent: 16 # maximum charge current (default 16A)
+  maxoffsetcurrent: 2 # do not let wallbox's configured current be above measured current + maxoffsetcurrent + delta (default 2A)
 
 # tariffs are the fixed or variable tariffs
 # cheap can be used to define a tariff rate considered cheap enough for charging

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -105,7 +105,7 @@ loadpoints:
   guardduration: 5m # switch charger contactor not more often than this (default 10m)
   mincurrent: 6 # minimum charge current (default 6A)
   maxcurrent: 16 # maximum charge current (default 16A)
-  maxoffsetcurrent: 2 # do not let wallbox's configured current be above measured current + maxoffsetcurrent + delta (default 2A)
+  maxoffsetcurrent: 2 # do not let wallbox's next configured current be above measured current + delta + maxoffsetcurrent (default 2A)
 
 # tariffs are the fixed or variable tariffs
 # cheap can be used to define a tariff rate considered cheap enough for charging


### PR DESCRIPTION
explanation in evcc.yaml:
"maxoffsetcurrent: 2 # do not let wallbox's configured current be above measured current + maxoffsetcurrent + delta (default 2A)"