### PR TITLE
Convert structured logger usage to interfaces

### DIFF
--- a/api/log.go
+++ b/api/log.go
@@ -1,0 +1,16 @@
+package api
+
+type Logger interface {
+	Tracef(format string, v ...interface{})
+	Traceln(v ...interface{})
+	Debugf(format string, v ...interface{})
+	Debugln(v ...interface{})
+	Infof(format string, v ...interface{})
+	Infoln(v ...interface{})
+	Warnf(format string, v ...interface{})
+	Warnln(v ...interface{})
+	Errorf(format string, v ...interface{})
+	Errorln(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Fatalln(v ...interface{})
+}

--- a/charger/abl.go
+++ b/charger/abl.go
@@ -29,7 +29,7 @@ import (
 
 // ABLeMH charger implementation
 type ABLeMH struct {
-	log  *util.Logger
+	log  api.Logger
 	conn *modbus.Connection
 }
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -43,7 +43,7 @@ type Easee struct {
 	lp            loadpoint.API
 	//lastSmartCharging bool
 	//lastChargeMode api.ChargeMode
-	log     *util.Logger
+	log     api.Logger
 	phases  int
 	current float64
 }

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -162,7 +162,7 @@ func (c *Easee) syncSmartCharging() error {
 	}
 
 	if c.lp.GetMode() != c.lastChargeMode {
-		c.log.DEBUG.Printf("charge mode changed by loadpoint: %v -> %v", c.lastChargeMode, c.lp.GetMode())
+		c.log.Debugf("charge mode changed by loadpoint: %v -> %v", c.lastChargeMode, c.lp.GetMode())
 		newSmartCharging := false
 		if c.lp.GetMode() == api.ModePV {
 			newSmartCharging = true
@@ -187,7 +187,7 @@ func (c *Easee) syncSmartCharging() error {
 	}
 
 	if c.lastSmartCharging != c.status.SmartCharging {
-		c.log.DEBUG.Printf("smart status changed by charger: %v -> %v", c.lastSmartCharging, c.status.SmartCharging)
+		c.log.Debugf("smart status changed by charger: %v -> %v", c.lastSmartCharging, c.status.SmartCharging)
 		if c.status.SmartCharging {
 			c.lp.SetMode(api.ModePV)
 		} else {

--- a/charger/easee/identity.go
+++ b/charger/easee/identity.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
@@ -39,7 +39,7 @@ type tokenSource struct {
 }
 
 // TokenSource creates an Easee token source
-func TokenSource(log *util.Logger, user, password string) (oauth2.TokenSource, error) {
+func TokenSource(log api.Logger, user, password string) (oauth2.TokenSource, error) {
 	c := &tokenSource{
 		Helper: request.NewHelper(log),
 	}

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -72,7 +72,7 @@ var eebusDevice spine.Device
 var once sync.Once
 
 func (c *EEBus) onConnect(ski string, conn ship.Conn) error {
-	c.log.TRACE.Println("!! onCconnect invoked on ski ", ski)
+	c.log.Traceln("!! onCconnect invoked on ski ", ski)
 
 	once.Do(func() {
 		eebusDevice = app.HEMS(server.EEBusInstance.DeviceInfo())
@@ -89,7 +89,7 @@ func (c *EEBus) onConnect(ski string, conn ship.Conn) error {
 }
 
 func (c *EEBus) onDisconnect(ski string) {
-	c.log.TRACE.Println("!! onDisconnect invoked on ski ", ski)
+	c.log.Traceln("!! onDisconnect invoked on ski ", ski)
 
 	c.connected = false
 	c.setDefaultValues()
@@ -163,7 +163,7 @@ func (c *EEBus) dataUpdateHandler(dataType communication.EVDataElementUpdateType
 		// if availability of self consumption use case changes, resend the current charging limit
 		err := c.writeCurrentLimitData([]float64{c.maxCurrent, c.maxCurrent, c.maxCurrent})
 		if err != nil {
-			c.log.ERROR.Println("failed to send current limit data: ", err)
+			c.log.Errorln("failed to send current limit data: ", err)
 		}
 	// case communication.EVDataElementUpdateUseCaseSoC:
 	case communication.EVDataElementUpdateEVConnectionState:
@@ -191,14 +191,14 @@ func (c *EEBus) dataUpdateHandler(dataType communication.EVDataElementUpdateType
 func (c *EEBus) Status() (api.ChargeStatus, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! status: no eebus data available yet")
+		c.log.Tracef("!! status: no eebus data available yet")
 		return api.StatusNone, err
 	}
 
 	currentState := data.EVData.ChargeState
 
 	if !c.connected {
-		c.log.TRACE.Printf("!! status: charger reported as disconnected")
+		c.log.Tracef("!! status: charger reported as disconnected")
 		return api.StatusNone, fmt.Errorf("charger reported as disconnected")
 	}
 
@@ -252,12 +252,12 @@ func (c *EEBus) Enabled() (bool, error) {
 func (c *EEBus) Enable(enable bool) error {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! enable: no eebus data available yet")
+		c.log.Tracef("!! enable: no eebus data available yet")
 		return err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("!! currents: ev reported as unplugged")
+		c.log.Tracef("!! currents: ev reported as unplugged")
 		// if the ev is unplugged, we do not need to disable charging by setting a current of 0 as it already is
 		if !enable {
 			return nil
@@ -269,7 +269,7 @@ func (c *EEBus) Enable(enable bool) error {
 	// if we disable charging with a potential but not yet known communication standard ISO15118
 	// this would set allowed A value to be 0. And this would trigger ISO connections to switch to IEC!
 	if data.EVData.CommunicationStandard == communication.EVCommunicationStandardEnumTypeUnknown {
-		c.log.TRACE.Printf("!! enable: cannot enable or disable as communication standard is not yet known")
+		c.log.Tracef("!! enable: cannot enable or disable as communication standard is not yet known")
 		return api.ErrMustRetry
 	}
 
@@ -356,26 +356,26 @@ var _ api.ChargerEx = (*EEBus)(nil)
 func (c *EEBus) MaxCurrentMillis(current float64) error {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! currents: no eebus data available yet")
+		c.log.Tracef("!! currents: no eebus data available yet")
 		return err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("!! currents: ev reported as unplugged")
+		c.log.Tracef("!! currents: ev reported as unplugged")
 		return errors.New("can't set new current as ev is unplugged")
 	}
 
 	if data.EVData.LimitsL1.Min == 0 {
-		c.log.TRACE.Println("!! we did not yet receive min and max currents to validate the call of MaxCurrent, use it as is")
+		c.log.Traceln("!! we did not yet receive min and max currents to validate the call of MaxCurrent, use it as is")
 	}
 
 	if current < data.EVData.LimitsL1.Min {
-		c.log.TRACE.Printf("!! current value %f is lower than the allowed minimum value %f", current, data.EVData.LimitsL1.Min)
+		c.log.Tracef("!! current value %f is lower than the allowed minimum value %f", current, data.EVData.LimitsL1.Min)
 		current = data.EVData.LimitsL1.Min
 	}
 
 	if current > data.EVData.LimitsL1.Max {
-		c.log.TRACE.Printf("!! current value %f is higher than the allowed maximum value %f", current, data.EVData.LimitsL1.Max)
+		c.log.Tracef("!! current value %f is higher than the allowed maximum value %f", current, data.EVData.LimitsL1.Max)
 		current = data.EVData.LimitsL1.Max
 	}
 
@@ -383,7 +383,7 @@ func (c *EEBus) MaxCurrentMillis(current float64) error {
 
 	// TODO error handling
 
-	c.log.TRACE.Printf("!! currents: returning %f", current)
+	c.log.Tracef("!! currents: returning %f", current)
 
 	currents := []float64{current, current, current}
 	return c.writeCurrentLimitData(currents)
@@ -395,17 +395,17 @@ var _ api.Meter = (*EEBus)(nil)
 func (c *EEBus) CurrentPower() (float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! current power: no eebus data available yet")
+		c.log.Tracef("!! current power: no eebus data available yet")
 		return 0, err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("!! current power: ev reported as unplugged")
+		c.log.Tracef("!! current power: ev reported as unplugged")
 		return 0, nil
 	}
 
 	power := data.EVData.Measurements.PowerL1 + data.EVData.Measurements.PowerL2 + data.EVData.Measurements.PowerL3
-	c.log.TRACE.Printf("!! current power: returning %f", power)
+	c.log.Tracef("!! current power: returning %f", power)
 
 	return power, nil
 }
@@ -416,17 +416,17 @@ var _ api.ChargeRater = (*EEBus)(nil)
 func (c *EEBus) ChargedEnergy() (float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! charged energy: no eebus data available yet")
+		c.log.Tracef("!! charged energy: no eebus data available yet")
 		return 0, err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("!! charged energy: ev reported as unplugged")
+		c.log.Tracef("!! charged energy: ev reported as unplugged")
 		return 0, nil
 	}
 
 	energy := data.EVData.Measurements.ChargedEnergy / 1000
-	c.log.TRACE.Printf("!! charged energy: returning %f", energy)
+	c.log.Tracef("!! charged energy: returning %f", energy)
 
 	return energy, nil
 }
@@ -450,16 +450,16 @@ var _ api.MeterCurrent = (*EEBus)(nil)
 func (c *EEBus) Currents() (float64, float64, float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! currents: no eebus data available yet")
+		c.log.Tracef("!! currents: no eebus data available yet")
 		return 0, 0, 0, err
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged {
-		c.log.TRACE.Printf("!! currents: ev reported as unplugged")
+		c.log.Tracef("!! currents: ev reported as unplugged")
 		return 0, 0, 0, nil
 	}
 
-	c.log.TRACE.Printf("!! currents: returning %f, %f, %f, ", data.EVData.Measurements.CurrentL1, data.EVData.Measurements.CurrentL2, data.EVData.Measurements.CurrentL3)
+	c.log.Tracef("!! currents: returning %f, %f, %f, ", data.EVData.Measurements.CurrentL1, data.EVData.Measurements.CurrentL2, data.EVData.Measurements.CurrentL3)
 
 	return data.EVData.Measurements.CurrentL1, data.EVData.Measurements.CurrentL2, data.EVData.Measurements.CurrentL3, nil
 }
@@ -470,31 +470,31 @@ var _ api.Identifier = (*EEBus)(nil)
 func (c *EEBus) Identify() (string, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! identify: no eebus data available yet")
+		c.log.Tracef("!! identify: no eebus data available yet")
 		return "", err
 	}
 
 	if !c.connected {
-		c.log.TRACE.Printf("!! identify: charger reported as disconnected")
+		c.log.Tracef("!! identify: charger reported as disconnected")
 		return "", nil
 	}
 
 	if data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnplugged || data.EVData.ChargeState == communication.EVChargeStateEnumTypeUnknown {
-		c.log.TRACE.Printf("!! identify: ev reported as unplugged or unknown")
+		c.log.Tracef("!! identify: ev reported as unplugged or unknown")
 		return "", nil
 	}
 
 	if len(data.EVData.Identification) > 0 {
-		c.log.TRACE.Printf("!! identify: returning %s", data.EVData.Identification)
+		c.log.Tracef("!! identify: returning %s", data.EVData.Identification)
 		return data.EVData.Identification, nil
 	}
 
 	if data.EVData.CommunicationStandard == communication.EVCommunicationStandardEnumTypeIEC61851 {
-		c.log.TRACE.Printf("!! identify: ev communication is IEC61851 which does not support any identification")
+		c.log.Tracef("!! identify: ev communication is IEC61851 which does not support any identification")
 		return "", nil
 	}
 
-	c.log.TRACE.Printf("!! identify: returning nothing")
+	c.log.Tracef("!! identify: returning nothing")
 	return "", api.ErrMustRetry
 }
 
@@ -504,16 +504,16 @@ var _ api.Battery = (*EEBus)(nil)
 func (c *EEBus) SoC() (float64, error) {
 	data, err := c.cc.GetData()
 	if err != nil {
-		c.log.TRACE.Printf("!! soc: no eebus data available yet")
+		c.log.Tracef("!! soc: no eebus data available yet")
 		return 0, api.ErrMustRetry
 	}
 
 	if !data.EVData.UCSoCAvailable || !data.EVData.SoCDataAvailable {
-		c.log.TRACE.Printf("!! soc: feature not available")
+		c.log.Tracef("!! soc: feature not available")
 		return 0, api.ErrNotAvailable
 	}
 
-	c.log.TRACE.Printf("!! soc: returning %f", data.EVData.Measurements.SoC)
+	c.log.Tracef("!! soc: returning %f", data.EVData.Measurements.SoC)
 	return data.EVData.Measurements.SoC, nil
 }
 

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -135,19 +135,19 @@ func (c *EEBus) showCurrentChargingSetup() {
 	if prevComStandard != data.EVData.CommunicationStandard {
 		c.communicationStandard = data.EVData.CommunicationStandard
 		timestamp := time.Now()
-		c.log.WARN.Println("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-communication changed from ", prevComStandard, " to ", data.EVData.CommunicationStandard)
+		c.log.Warnln("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-communication changed from ", prevComStandard, " to ", data.EVData.CommunicationStandard)
 	}
 
 	if prevSoCSupport != data.EVData.UCSoCAvailable {
 		c.socSupportAvailable = data.EVData.UCSoCAvailable
 		timestamp := time.Now()
-		c.log.WARN.Println("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-soc support changed from ", prevSoCSupport, " to ", data.EVData.UCSoCAvailable)
+		c.log.Warnln("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-soc support changed from ", prevSoCSupport, " to ", data.EVData.UCSoCAvailable)
 	}
 
 	if prevSelfConsumptionSupport != data.EVData.UCSelfConsumptionAvailable {
 		c.selfConsumptionSupportAvailable = data.EVData.UCSelfConsumptionAvailable
 		timestamp := time.Now()
-		c.log.WARN.Println("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-self-consumption-support support changed from ", prevSelfConsumptionSupport, " to ", data.EVData.UCSelfConsumptionAvailable)
+		c.log.Warnln("!! ", timestamp.Format("2006-01-02 15:04:05"), " ev-charger-self-consumption-support support changed from ", prevSelfConsumptionSupport, " to ", data.EVData.UCSelfConsumptionAvailable)
 	}
 
 }

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -50,7 +50,7 @@ type EVSEListEntry struct {
 // EVSEWifi charger implementation
 type EVSEWifi struct {
 	*request.Helper
-	log          *util.Logger
+	log          api.Logger
 	uri          string
 	alwaysActive bool
 	current      int64 // current will always be the physical value sent to the API

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -164,7 +164,7 @@ func (evse *EVSEWifi) getParameters() (EVSEListEntry, error) {
 
 	params := res.List[0]
 	if !params.AlwaysActive {
-		evse.log.WARN.Println("evse should be configured to remote mode")
+		evse.log.Warnln("evse should be configured to remote mode")
 	}
 
 	evse.alwaysActive = params.AlwaysActive

--- a/charger/heidelberg-ec.go
+++ b/charger/heidelberg-ec.go
@@ -29,7 +29,7 @@ import (
 
 // HeidelbergEC charger implementation
 type HeidelbergEC struct {
-	log     *util.Logger
+	log     api.Logger
 	conn    *modbus.Connection
 	current uint16
 }

--- a/charger/keba.go
+++ b/charger/keba.go
@@ -25,7 +25,7 @@ type RFID struct {
 
 // Keba is an api.Charger implementation with configurable getters and setters.
 type Keba struct {
-	log     *util.Logger
+	log     api.Logger
 	conn    string
 	rfid    RFID
 	timeout time.Duration

--- a/charger/keba.go
+++ b/charger/keba.go
@@ -166,7 +166,7 @@ func (c *Keba) Status() (api.ChargeStatus, error) {
 	}
 
 	if kr.AuthON == 1 && c.rfid.Tag == "" {
-		c.log.WARN.Println("missing credentials for RFID authorization")
+		c.log.Warnln("missing credentials for RFID authorization")
 	}
 
 	if kr.Plug < 5 {

--- a/charger/keba/listener.go
+++ b/charger/keba/listener.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 )
 
 const (
@@ -37,14 +37,14 @@ type UDPMsg struct {
 // Listener singleton listens for KEBA UDP messages
 type Listener struct {
 	mux     sync.Mutex
-	log     *util.Logger
+	log     api.Logger
 	conn    *net.UDPConn
 	clients map[string]chan<- UDPMsg
 	cache   map[string]string
 }
 
 // New creates a UDP listener that clients can subscribe to
-func New(log *util.Logger) (*Listener, error) {
+func New(log api.Logger) (*Listener, error) {
 	laddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", Port))
 	if err != nil {
 		return nil, err

--- a/charger/keba/listener.go
+++ b/charger/keba/listener.go
@@ -81,12 +81,12 @@ func (l *Listener) listen() {
 	for {
 		read, addr, err := l.conn.ReadFrom(b)
 		if err != nil {
-			l.log.TRACE.Printf("listener: %v", err)
+			l.log.Tracef("listener: %v", err)
 			continue
 		}
 
 		body := strings.TrimSpace(string(b[:read]))
-		l.log.TRACE.Printf("recv from %s %v", addr.String(), body)
+		l.log.Tracef("recv from %s %v", addr.String(), body)
 
 		msg := UDPMsg{
 			Addr:    addr.String(),
@@ -143,7 +143,7 @@ func (l *Listener) send(msg UDPMsg) {
 			select {
 			case client <- msg:
 			default:
-				l.log.TRACE.Println("recv: listener blocked")
+				l.log.Traceln("recv: listener blocked")
 			}
 			break
 		}

--- a/charger/keba/listener.go
+++ b/charger/keba/listener.go
@@ -98,7 +98,7 @@ func (l *Listener) listen() {
 			if err := json.Unmarshal([]byte(body), &report); err != nil {
 				// ignore error during detection when sending report request to localhost
 				if body != "report 1" {
-					l.log.WARN.Printf("recv: invalid message: %v", err)
+					l.log.Warnf("recv: invalid message: %v", err)
 				}
 				continue
 			}

--- a/charger/keba/sender.go
+++ b/charger/keba/sender.go
@@ -5,18 +5,19 @@ import (
 	"net"
 	"strings"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 )
 
 // Sender is a KEBA UDP sender
 type Sender struct {
-	log  *util.Logger
+	log  api.Logger
 	addr string
 	conn *net.UDPConn
 }
 
 // NewSender creates KEBA UDP sender
-func NewSender(log *util.Logger, addr string) (*Sender, error) {
+func NewSender(log api.Logger, addr string) (*Sender, error) {
 	addr = util.DefaultPort(addr, Port)
 	raddr, err := net.ResolveUDPAddr("udp", addr)
 

--- a/charger/keba/sender.go
+++ b/charger/keba/sender.go
@@ -36,7 +36,7 @@ func NewSender(log *util.Logger, addr string) (*Sender, error) {
 
 // Send msg to receiver
 func (c *Sender) Send(msg string) error {
-	c.log.TRACE.Printf("send to %s %v", c.addr, msg)
+	c.log.Tracef("send to %s %v", c.addr, msg)
 	_, err := io.Copy(c.conn, strings.NewReader(msg))
 	return err
 }

--- a/charger/nrgble_linux.go
+++ b/charger/nrgble_linux.go
@@ -173,7 +173,7 @@ func (nrg *NRGKickBLE) read(service string, res interface{}) error {
 		nrg.close()
 		return err
 	}
-	nrg.log.TRACE.Printf("read %s %0x", service, b)
+	nrg.log.Tracef("read %s %0x", service, b)
 
 	return struc.Unpack(bytes.NewReader(b), res)
 }
@@ -183,7 +183,7 @@ func (nrg *NRGKickBLE) write(service string, val interface{}) error {
 	if err := struc.Pack(&out, val); err != nil {
 		return err
 	}
-	nrg.log.TRACE.Printf("write %s %0x", service, out.Bytes())
+	nrg.log.Tracef("write %s %0x", service, out.Bytes())
 
 	nrg.waitTimer()
 	defer nrg.setTimer()
@@ -230,7 +230,7 @@ func (nrg *NRGKickBLE) Status() (api.ChargeStatus, error) {
 		return api.StatusF, err
 	}
 
-	nrg.log.TRACE.Printf("read power: %+v", res)
+	nrg.log.Tracef("read power: %+v", res)
 
 	switch res.CPSignal {
 	case 3:
@@ -251,7 +251,7 @@ func (nrg *NRGKickBLE) Enabled() (bool, error) {
 		return false, err
 	}
 
-	nrg.log.TRACE.Printf("read info: %+v", res)
+	nrg.log.Tracef("read info: %+v", res)
 
 	// workaround internal NRGkick state change after connecting
 	// https://github.com/evcc-io/evcc/pull/274
@@ -271,7 +271,7 @@ func (nrg *NRGKickBLE) Enable(enable bool) error {
 		nrg.pauseCharging = false
 		settings := nrg.mergeSettings(res)
 
-		nrg.log.TRACE.Printf("write settings (workaround): %+v", settings)
+		nrg.log.Tracef("write settings (workaround): %+v", settings)
 		if err := nrg.write(nrgble.SettingsService, &settings); err != nil {
 			return err
 		}
@@ -280,7 +280,7 @@ func (nrg *NRGKickBLE) Enable(enable bool) error {
 	nrg.pauseCharging = !enable // use cached value to work around API roundtrip delay
 	settings := nrg.mergeSettings(res)
 
-	nrg.log.TRACE.Printf("write settings: %+v", settings)
+	nrg.log.Tracef("write settings: %+v", settings)
 
 	return nrg.write(nrgble.SettingsService, &settings)
 }
@@ -295,7 +295,7 @@ func (nrg *NRGKickBLE) MaxCurrent(current int64) error {
 	nrg.current = int(current) // use cached value to work around API roundtrip delay
 	settings := nrg.mergeSettings(res)
 
-	nrg.log.TRACE.Printf("write settings: %+v", settings)
+	nrg.log.Tracef("write settings: %+v", settings)
 
 	return nrg.write(nrgble.SettingsService, &settings)
 }
@@ -309,7 +309,7 @@ func (nrg *NRGKickBLE) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
-	nrg.log.TRACE.Printf("read power: %+v", res)
+	nrg.log.Tracef("read power: %+v", res)
 
 	return float64(res.TotalPower) * 10, nil
 }
@@ -323,7 +323,7 @@ func (nrg *NRGKickBLE) TotalEnergy() (float64, error) {
 		return 0, err
 	}
 
-	nrg.log.TRACE.Printf("read energy: %+v", res)
+	nrg.log.Tracef("read energy: %+v", res)
 
 	return float64(res.TotalEnergy) / 1000, nil
 }
@@ -337,7 +337,7 @@ func (nrg *NRGKickBLE) Currents() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	nrg.log.TRACE.Printf("read voltage/current: %+v", res)
+	nrg.log.Tracef("read voltage/current: %+v", res)
 
 	return float64(res.CurrentL1) / 100,
 		float64(res.CurrentL2) / 100,
@@ -352,6 +352,6 @@ func (nrg *NRGKickBLE) Currents() (float64, float64, float64, error) {
 // 	if err := nrg.read(nrgble.EnergyService, &res); err != nil {
 // 		return 0, err
 // 	}
-// 	nrg.log.TRACE.Printf("energy: %+v", res)
+// 	nrg.log.Tracef("energy: %+v", res)
 // 	return float64(res.EnergyLastCharge) / 1000, nil
 // }

--- a/charger/nrgble_linux.go
+++ b/charger/nrgble_linux.go
@@ -22,7 +22,7 @@ const nrgTimeout = 10 * time.Second
 
 // NRGKickBLE charger implementation
 type NRGKickBLE struct {
-	log           *util.Logger
+	log           api.Logger
 	timer         *time.Timer
 	adapter       *adapter.Adapter1
 	agent         *agent.SimpleAgent

--- a/charger/nrgconnect.go
+++ b/charger/nrgconnect.go
@@ -96,7 +96,7 @@ func NewNRGKickConnect(uri, mac, password string) (*NRGKickConnect, error) {
 		password: password,
 	}
 
-	nrg.log.WARN.Println("-- experimental --")
+	nrg.log.Warnln("-- experimental --")
 
 	return nrg, nil
 }

--- a/charger/nrgconnect.go
+++ b/charger/nrgconnect.go
@@ -65,7 +65,7 @@ type NRGDeviceMetadata struct {
 // NRGKickConnect charger implementation
 type NRGKickConnect struct {
 	*request.Helper
-	log      *util.Logger
+	log      api.Logger
 	uri      string
 	mac      string
 	password string

--- a/charger/openwb.go
+++ b/charger/openwb.go
@@ -50,7 +50,7 @@ func NewOpenWBFromConfig(other map[string]interface{}) (api.Charger, error) {
 }
 
 // NewOpenWB creates a new configurable charger
-func NewOpenWB(log *util.Logger, mqttconf mqtt.Config, id int, topic string, p1p3 bool, timeout time.Duration) (api.Charger, error) {
+func NewOpenWB(log api.Logger, mqttconf mqtt.Config, id int, topic string, p1p3 bool, timeout time.Duration) (api.Charger, error) {
 	client, err := mqtt.RegisteredClientOrDefault(log, mqttconf)
 	if err != nil {
 		return nil, err

--- a/charger/simpleevse.go
+++ b/charger/simpleevse.go
@@ -11,7 +11,7 @@ import (
 
 // SimpleEVSE charger implementation
 type SimpleEVSE struct {
-	log     *util.Logger
+	log     api.Logger
 	conn    *modbus.Connection
 	current int64
 }

--- a/charger/tplink.go
+++ b/charger/tplink.go
@@ -17,7 +17,7 @@ import (
 
 // TPLink charger implementation
 type TPLink struct {
-	log          *util.Logger
+	log          api.Logger
 	uri          string
 	standbypower float64
 }

--- a/charger/tplink.go
+++ b/charger/tplink.go
@@ -196,7 +196,7 @@ func (c *TPLink) execCmd(cmd string, res interface{}) error {
 		key = resp[i]
 		_ = buf.WriteByte(dec)
 	}
-	c.log.TRACE.Printf("recv: %s", buf.String())
+	c.log.Tracef("recv: %s", buf.String())
 
 	return json.Unmarshal(buf.Bytes(), res)
 }

--- a/charger/warp.go
+++ b/charger/warp.go
@@ -53,7 +53,7 @@ func NewWarpFromConfig(other map[string]interface{}) (api.Charger, error) {
 
 // Warp configures generic charger and charge meter for an Warp loadpoint
 type Warp struct {
-	log         *util.Logger
+	log         api.Logger
 	root        string
 	client      *mqtt.Client
 	enabledG    func() (string, error)

--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -26,16 +26,16 @@ func runCharger(cmd *cobra.Command, args []string) {
 	// load config
 	conf, err := loadConfigFile(cfgFile)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	// setup environment
 	if err := configureEnvironment(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	if err := cp.configureChargers(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	chargers := cp.chargers

--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -21,7 +21,7 @@ func init() {
 
 func runCharger(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	// load config
 	conf, err := loadConfigFile(cfgFile)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -79,7 +79,7 @@ func (cp *ConfigProvider) Meter(name string) api.Meter {
 	if meter, ok := cp.meters[name]; ok {
 		return meter
 	}
-	log.FATAL.Fatalf("invalid meter: %s", name)
+	log.Fatalf("invalid meter: %s", name)
 	return nil
 }
 
@@ -88,7 +88,7 @@ func (cp *ConfigProvider) Charger(name string) api.Charger {
 	if charger, ok := cp.chargers[name]; ok {
 		return charger
 	}
-	log.FATAL.Fatalf("invalid charger: %s", name)
+	log.Fatalf("invalid charger: %s", name)
 	return nil
 }
 
@@ -97,7 +97,7 @@ func (cp *ConfigProvider) Vehicle(name string) api.Vehicle {
 	if vehicle, ok := cp.vehicles[name]; ok {
 		return vehicle
 	}
-	log.FATAL.Fatalf("invalid vehicle: %s", name)
+	log.Fatalf("invalid vehicle: %s", name)
 	return nil
 }
 

--- a/cmd/demo.go
+++ b/cmd/demo.go
@@ -15,7 +15,7 @@ func demoConfig() (conf config) {
 	demo := map[string]interface{}{}
 
 	if err := yaml.Unmarshal([]byte(demoYaml), &demo); err != nil {
-		log.FATAL.Fatalf("failed decoding demo config: %+v", err)
+		log.Fatalf("failed decoding demo config: %+v", err)
 	}
 
 	for k, v := range demo {
@@ -26,7 +26,7 @@ func demoConfig() (conf config) {
 	viper.Set("uri", fmt.Sprintf("0.0.0.0:%d", defaultPort))
 
 	if err := viper.UnmarshalExact(&conf); err != nil {
-		log.FATAL.Fatalf("failed loading demo config: %v", err)
+		log.Fatalf("failed loading demo config: %v", err)
 	}
 
 	return conf

--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -61,7 +61,7 @@ func ParseHostIPNet(arg string) (res []string) {
 
 	// check subnet size
 	if bits, _ := ipnet.Mask.Size(); bits < 24 {
-		log.INFO.Println("skipping large subnet:", ipnet)
+		log.Infoln("skipping large subnet:", ipnet)
 		return
 	}
 
@@ -128,7 +128,7 @@ configuring EVCC but are probably not sufficient for fully automatic configurati
 		}
 
 		myIP := ips[0]
-		log.INFO.Println("my ip:", myIP.IP)
+		log.Infoln("my ip:", myIP.IP)
 
 		hosts = append(hosts, "127.0.0.1")
 		hosts = append(hosts, IPsFromSubnet(myIP.String())...)

--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -36,7 +36,7 @@ func init() {
 func IPsFromSubnet(arg string) (res []string) {
 	gen, err := ipnetgen.New(arg)
 	if err != nil {
-		log.FATAL.Fatal("could not create iterator")
+		log.Fatalln("could not create iterator")
 	}
 
 	for ip := gen.Next(); ip != nil; ip = gen.Next() {
@@ -124,7 +124,7 @@ configuring EVCC but are probably not sufficient for fully automatic configurati
 	if len(hosts) == 0 {
 		ips := util.LocalIPs()
 		if len(ips) == 0 {
-			log.FATAL.Fatal("could not find ip")
+			log.Fatalln("could not find ip")
 		}
 
 		myIP := ips[0]

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -28,17 +28,17 @@ func runDump(cmd *cobra.Command, args []string) {
 	// load config
 	conf, err := loadConfigFile(cfgFile)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	// setup environment
 	if err := configureEnvironment(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	site, err := configureSiteAndLoadpoints(conf)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	d := dumper{len: 2}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -23,7 +23,7 @@ func init() {
 
 func runDump(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	// load config
 	conf, err := loadConfigFile(cfgFile)

--- a/cmd/eebus.go
+++ b/cmd/eebus.go
@@ -71,7 +71,7 @@ func generateEEBUSCert() {
 
 func runEEBUSCert(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	generateEEBUSCert()
 }

--- a/cmd/eebus.go
+++ b/cmd/eebus.go
@@ -52,12 +52,12 @@ func generateEEBUSCert() {
 
 	cert, err := certhelper.CreateCertificate(true, subject)
 	if err != nil {
-		log.FATAL.Fatal("could not create certificate")
+		log.Fatalln("could not create certificate")
 	}
 
 	pubKey, privKey, err := certhelper.GetX509KeyPair(cert)
 	if err != nil {
-		log.FATAL.Fatal("could not process generated certificate")
+		log.Fatalln("could not process generated certificate")
 	}
 
 	t := template.Must(template.New("out").Funcs(template.FuncMap(sprig.FuncMap())).Parse(tmpl))
@@ -65,7 +65,7 @@ func generateEEBUSCert() {
 		"public":  pubKey,
 		"private": privKey,
 	}); err != nil {
-		log.FATAL.Fatal("rendering failed", err)
+		log.Fatalln("rendering failed", err)
 	}
 }
 

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cmd
@@ -30,7 +31,7 @@ func init() {
 
 func runHealth(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	u := &httpunix.Transport{
 		DialTimeout:           100 * time.Millisecond,
@@ -51,13 +52,13 @@ func runHealth(cmd *cobra.Command, args []string) {
 		resp.Body.Close()
 
 		if resp.StatusCode == http.StatusOK {
-			log.INFO.Printf("health check ok")
+			log.Infof("health check ok")
 			ok = true
 		}
 	}
 
 	if !ok {
-		log.ERROR.Printf("health check failed")
+		log.Errorf("health check failed")
 		os.Exit(1)
 	}
 }

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -21,7 +21,7 @@ func init() {
 
 func runMeter(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	// load config
 	conf, err := loadConfigFile(cfgFile)

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -26,16 +26,16 @@ func runMeter(cmd *cobra.Command, args []string) {
 	// load config
 	conf, err := loadConfigFile(cfgFile)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	// setup environment
 	if err := configureEnvironment(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	if err := cp.configureMeters(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	meters := cp.meters

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,19 +139,19 @@ func Execute() {
 
 func run(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	// load config and re-configure logging after reading config file
 	conf, err := loadConfigFile(cfgFile)
 	if err != nil {
-		log.ERROR.Println("missing evcc config - switching into demo mode")
+		log.Errorln("missing evcc config - switching into demo mode")
 		conf = demoConfig()
 	}
 
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	uri := viper.GetString("uri")
-	log.INFO.Println("listening at", uri)
+	log.Infoln("listening at", uri)
 
 	// setup environment
 	if err := configureEnvironment(conf); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -155,13 +155,13 @@ func run(cmd *cobra.Command, args []string) {
 
 	// setup environment
 	if err := configureEnvironment(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	// setup loadpoints
 	site, err := configureSiteAndLoadpoints(conf)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	// start broadcasting values

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -172,7 +172,6 @@ func configureMessengers(conf messagingConfig, cache *util.Cache) chan push.Even
 	for _, service := range conf.Services {
 		impl, err := push.NewMessengerFromConfig(service.Type, service.Other)
 		if err != nil {
-			log.FATAL.Fatal(err)
 			log.Fatalf("failed configuring messenger %s: %v", service.Type, err)
 		}
 		notificationHub.Add(impl)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -34,9 +34,9 @@ var cp = &ConfigProvider{}
 
 func loadConfigFile(cfgFile string) (conf config, err error) {
 	if cfgFile != "" {
-		log.INFO.Println("using config file", cfgFile)
+		log.Infoln("using config file", cfgFile)
 		if err := viper.UnmarshalExact(&conf); err != nil {
-			log.FATAL.Fatalf("failed parsing config file %s: %v", cfgFile, err)
+			log.Fatalf("failed parsing config file %s: %v", cfgFile, err)
 		}
 	} else {
 		err = errors.New("missing evcc config")
@@ -149,7 +149,7 @@ func configureJavascript(conf map[string]interface{}) error {
 func configureHEMS(conf typedConfig, site *core.Site, cache *util.Cache, httpd *server.HTTPd) hems.HEMS {
 	hems, err := hems.NewFromConfig(conf.Type, conf.Other, site, cache, httpd)
 	if err != nil {
-		log.FATAL.Fatalf("failed configuring hems: %v", err)
+		log.Fatalf("failed configuring hems: %v", err)
 	}
 	return hems
 }
@@ -173,7 +173,7 @@ func configureMessengers(conf messagingConfig, cache *util.Cache) chan push.Even
 		impl, err := push.NewMessengerFromConfig(service.Type, service.Other)
 		if err != nil {
 			log.FATAL.Fatal(err)
-			log.FATAL.Fatalf("failed configuring messenger %s: %v", service.Type, err)
+			log.Fatalf("failed configuring messenger %s: %v", service.Type, err)
 		}
 		notificationHub.Add(impl)
 	}

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -25,7 +25,7 @@ func init() {
 
 func runToken(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	// load config
 	conf, err := loadConfigFile(cfgFile)
@@ -54,7 +54,7 @@ func runToken(cmd *cobra.Command, args []string) {
 	case "tronity":
 		token, err = tronityToken(conf, vehicleConf)
 	default:
-		log.FATAL.Fatalf("vehicle type '%s' does not support token authentication", vehicleConf.Type)
+		log.Fatalf("vehicle type '%s' does not support token authentication", vehicleConf.Type)
 	}
 
 	if err != nil {

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -30,7 +30,7 @@ func runToken(cmd *cobra.Command, args []string) {
 	// load config
 	conf, err := loadConfigFile(cfgFile)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	var vehicleConf qualifiedConfig
@@ -43,7 +43,7 @@ func runToken(cmd *cobra.Command, args []string) {
 	}
 
 	if vehicleConf.Name == "" {
-		log.FATAL.Fatal("vehicle not found")
+		log.Fatalln("vehicle not found")
 	}
 
 	var token *oauth2.Token
@@ -58,7 +58,7 @@ func runToken(cmd *cobra.Command, args []string) {
 	}
 
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	fmt.Println()

--- a/cmd/token_tronity.go
+++ b/cmd/token_tronity.go
@@ -85,7 +85,7 @@ func tronityAuthorize(addr string, oc *oauth2.Config) (*oauth2.Token, error) {
 	wg.Add(1)
 	go func() {
 		if err := s.ListenAndServe(); err != http.ErrServerClosed {
-			log.FATAL.Fatal(err)
+			log.Fatalln(err)
 		}
 		wg.Done()
 	}()

--- a/cmd/vehicle.go
+++ b/cmd/vehicle.go
@@ -25,7 +25,7 @@ func init() {
 
 func runVehicle(cmd *cobra.Command, args []string) {
 	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s (%s)", server.Version, server.Commit)
+	log.Infof("evcc %s (%s)", server.Version, server.Commit)
 
 	// load config
 	conf, err := loadConfigFile(cfgFile)
@@ -57,7 +57,7 @@ NEXT:
 		// wait up to 1m for the vehicle to wakeup
 		for {
 			if time.Since(start) > time.Minute {
-				log.ERROR.Println(api.ErrTimeout)
+				log.Errorln(api.ErrTimeout)
 				continue NEXT
 			}
 
@@ -68,7 +68,7 @@ NEXT:
 					continue WAIT
 				}
 
-				log.ERROR.Println(err)
+				log.Errorln(err)
 				continue NEXT
 			}
 

--- a/cmd/vehicle.go
+++ b/cmd/vehicle.go
@@ -30,16 +30,16 @@ func runVehicle(cmd *cobra.Command, args []string) {
 	// load config
 	conf, err := loadConfigFile(cfgFile)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	// setup environment
 	if err := configureEnvironment(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	if err := cp.configureVehicles(conf); err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 
 	vehicles := cp.vehicles

--- a/core/coordinator.go
+++ b/core/coordinator.go
@@ -49,16 +49,16 @@ func (lp *vehicleCoordinator) identifyVehicleByStatus(log *util.Logger, owner in
 			status, err := vs.Status()
 
 			if err != nil {
-				log.ERROR.Println("vehicle status:", err)
+				log.Errorln("vehicle status:", err)
 				continue
 			}
 
-			log.DEBUG.Printf("vehicle status: %s (%s)", status, vehicle.Title())
+			log.Debugf("vehicle status: %s (%s)", status, vehicle.Title())
 
 			// vehicle is plugged or charging, so it should be the right one
 			if status == api.StatusB || status == api.StatusC {
 				if res != nil {
-					log.DEBUG.Printf("vehicle status: >1 matches, giving up")
+					log.Debugf("vehicle status: >1 matches, giving up")
 					return nil
 				}
 

--- a/core/coordinator.go
+++ b/core/coordinator.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/util"
 )
 
 type vehicleCoordinator struct {
@@ -40,7 +39,7 @@ func (lp *vehicleCoordinator) availableVehicles(owner interface{}, vehicles []ap
 }
 
 // find active vehicle by charge state
-func (lp *vehicleCoordinator) identifyVehicleByStatus(log *util.Logger, owner interface{}, vehicles []api.Vehicle) api.Vehicle {
+func (lp *vehicleCoordinator) identifyVehicleByStatus(log api.Logger, owner interface{}, vehicles []api.Vehicle) api.Vehicle {
 	available := lp.availableVehicles(owner, vehicles)
 
 	var res api.Vehicle

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -78,7 +78,7 @@ type LoadPoint struct {
 	pushChan chan<- push.Event // notifications
 	uiChan   chan<- util.Param // client push messages
 	lpChan   chan<- *LoadPoint // update requests
-	log      *util.Logger
+	log      api.Logger
 
 	// exposed public configuration
 	sync.Mutex                // guard status
@@ -140,7 +140,7 @@ type LoadPoint struct {
 }
 
 // NewLoadPointFromConfig creates a new loadpoint
-func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[string]interface{}) (*LoadPoint, error) {
+func NewLoadPointFromConfig(log api.Logger, cp configProvider, other map[string]interface{}) (*LoadPoint, error) {
 	lp := NewLoadPoint(log)
 	if err := util.DecodeOther(other, &lp); err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 }
 
 // NewLoadPoint creates a LoadPoint with sane defaults
-func NewLoadPoint(log *util.Logger) *LoadPoint {
+func NewLoadPoint(log api.Logger) *LoadPoint {
 	clock := clock.New()
 	bus := evbus.New()
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -150,10 +150,10 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 	switch lp.SoC.Poll.Mode = strings.ToLower(lp.SoC.Poll.Mode); lp.SoC.Poll.Mode {
 	case pollCharging:
 	case pollConnected, pollAlways:
-		log.WARN.Printf("poll mode '%s' may deplete your battery or lead to API misuse. USE AT YOUR OWN RISK.", lp.SoC.Poll)
+		log.Warnf("poll mode '%s' may deplete your battery or lead to API misuse. USE AT YOUR OWN RISK.", lp.SoC.Poll)
 	default:
 		if lp.SoC.Poll.Mode != "" {
-			log.WARN.Printf("invalid poll mode: %s", lp.SoC.Poll.Mode)
+			log.Warnf("invalid poll mode: %s", lp.SoC.Poll.Mode)
 		}
 		lp.SoC.Poll.Mode = pollConnected
 	}
@@ -163,7 +163,7 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 		if lp.SoC.Poll.Interval == 0 {
 			lp.SoC.Poll.Interval = pollInterval
 		} else {
-			log.WARN.Printf("poll interval '%v' is lower than %v and may deplete your battery or lead to API misuse. USE AT YOUR OWN RISK.", lp.SoC.Poll.Interval, pollInterval)
+			log.Warnf("poll interval '%v' is lower than %v and may deplete your battery or lead to API misuse. USE AT YOUR OWN RISK.", lp.SoC.Poll.Interval, pollInterval)
 		}
 	}
 
@@ -175,11 +175,11 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 	}
 
 	if lp.MinCurrent == 0 {
-		log.WARN.Println("minCurrent must not be zero")
+		log.Warnln("minCurrent must not be zero")
 	}
 
 	if lp.MaxCurrent <= lp.MinCurrent {
-		log.WARN.Println("maxCurrent must be larger than minCurrent")
+		log.Warnln("maxCurrent must be larger than minCurrent")
 	}
 
 	if lp.Meters.ChargeMeterRef != "" {
@@ -207,9 +207,9 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 	// allow target charge handler to access loadpoint
 	lp.socTimer = soc.NewTimer(lp.log, &adapter{LoadPoint: lp})
 	if lp.Enable.Threshold > lp.Disable.Threshold {
-		log.WARN.Printf("PV mode enable threshold (%.0fW) is larger than disable threshold (%.0fW)", lp.Enable.Threshold, lp.Disable.Threshold)
+		log.Warnf("PV mode enable threshold (%.0fW) is larger than disable threshold (%.0fW)", lp.Enable.Threshold, lp.Disable.Threshold)
 	} else if lp.Enable.Threshold > 0 {
-		log.WARN.Printf("PV mode enable threshold %.0fW > 0 will start PV charging on grid power consumption. Did you mean -%.0f?", lp.Enable.Threshold, lp.Enable.Threshold)
+		log.Warnf("PV mode enable threshold %.0fW > 0 will start PV charging on grid power consumption. Did you mean -%.0f?", lp.Enable.Threshold, lp.Enable.Threshold)
 	}
 
 	return lp, nil
@@ -468,12 +468,12 @@ func (lp *LoadPoint) syncCharger() {
 	enabled, err := lp.charger.Enabled()
 	if err == nil {
 		if enabled != lp.enabled {
-			lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
+			lp.log.Warnf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
 			err = lp.charger.Enable(lp.enabled)
 		}
 
 		if !enabled && lp.GetStatus() == api.StatusC {
-			lp.log.WARN.Println("charger logic error: disabled but charging")
+			lp.log.Warnln("charger logic error: disabled but charging")
 		}
 	}
 
@@ -872,7 +872,7 @@ func (lp *LoadPoint) pvScalePhases(availablePower, minCurrent, maxCurrent float6
 	targetCurrent := availablePower / Voltage / float64(lp.activePhases)
 
 	if phases < lp.activePhases {
-		lp.log.WARN.Printf("invalid status: %dp active @ %dp configured", lp.activePhases, phases)
+		lp.log.Warnf("invalid status: %dp active @ %dp configured", lp.activePhases, phases)
 	}
 
 	lp.log.Debugf("!!pvScalePhases available power %.0f for target current %.1f @ %dp/%dp", availablePower, targetCurrent, lp.activePhases, phases)

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -29,7 +29,7 @@ func (lp *LoadPoint) SetMode(mode api.ChargeMode) {
 	lp.Lock()
 	defer lp.Unlock()
 
-	lp.log.INFO.Printf("set charge mode: %s", string(mode))
+	lp.log.Infof("set charge mode: %s", string(mode))
 
 	// apply immediately
 	if lp.Mode != mode {
@@ -59,7 +59,7 @@ func (lp *LoadPoint) SetTargetSoC(soc int) error {
 	lp.Lock()
 	defer lp.Unlock()
 
-	lp.log.INFO.Println("set target soc:", soc)
+	lp.log.Infoln("set target soc:", soc)
 
 	// apply immediately
 	if lp.SoC.Target != soc {
@@ -87,7 +87,7 @@ func (lp *LoadPoint) SetMinSoC(soc int) error {
 	lp.Lock()
 	defer lp.Unlock()
 
-	lp.log.INFO.Println("set min soc:", soc)
+	lp.log.Infoln("set min soc:", soc)
 
 	// apply immediately
 	if lp.SoC.Min != soc {
@@ -117,7 +117,7 @@ func (lp *LoadPoint) SetTargetCharge(finishAt time.Time, targetSoC int) {
 	lp.Lock()
 	defer lp.Unlock()
 
-	lp.log.INFO.Printf("set target charge: %d @ %v", targetSoC, finishAt)
+	lp.log.Infof("set target charge: %d @ %v", targetSoC, finishAt)
 
 	// apply immediately
 	// TODO check reset of targetSoC
@@ -135,7 +135,7 @@ func (lp *LoadPoint) RemoteControl(source string, demand loadpoint.RemoteDemand)
 	lp.Lock()
 	defer lp.Unlock()
 
-	lp.log.INFO.Println("remote demand:", demand)
+	lp.log.Infoln("remote demand:", demand)
 
 	// apply immediately
 	if lp.remoteDemand != demand {

--- a/core/loadpoint_task.go
+++ b/core/loadpoint_task.go
@@ -35,7 +35,7 @@ func (lp *LoadPoint) odometer() error {
 		lp.publish("vehicleOdometer", odo)
 	case api.ErrMustRetry:
 	default:
-		lp.log.ERROR.Printf("vehicle odometer: %v", err)
+		lp.log.Errorf("vehicle odometer: %v", err)
 	}
 	return err
 }

--- a/core/site.go
+++ b/core/site.go
@@ -29,7 +29,7 @@ type Site struct {
 	*Health
 
 	sync.Mutex
-	log *util.Logger
+	log api.Logger
 
 	// configuration
 	Title         string       `mapstructure:"title"`         // UI title
@@ -61,7 +61,7 @@ type MetersConfig struct {
 
 // NewSiteFromConfig creates a new site
 func NewSiteFromConfig(
-	log *util.Logger,
+	log api.Logger,
 	cp configProvider,
 	other map[string]interface{},
 	loadpoints []*LoadPoint,

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -148,7 +148,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 			if socDelta > 2 && energyDelta > 0 && s.prevSoC > 0 {
 				s.energyPerSocStep = energyDelta / socDelta
 				s.virtualCapacity = s.energyPerSocStep * 100
-				s.log.DEBUG.Printf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualCapacity: %0.0fWh", s.energyPerSocStep, s.virtualCapacity)
+				s.log.Debugf("soc gradient updated: energyPerSocStep: %0.0fWh, virtualCapacity: %0.0fWh", s.energyPerSocStep, s.virtualCapacity)
 			}
 
 			// sample charged energy at soc change, reset energy delta
@@ -156,7 +156,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 			s.prevSoC = s.vehicleSoc
 		} else {
 			s.vehicleSoc = math.Min(*fetchedSoC+energyDelta/s.energyPerSocStep, 100)
-			s.log.DEBUG.Printf("soc estimated: %.2f%% (vehicle: %.2f%%)", s.vehicleSoc, *fetchedSoC)
+			s.log.Debugf("soc estimated: %.2f%% (vehicle: %.2f%%)", s.vehicleSoc, *fetchedSoC)
 		}
 	}
 

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/util"
 )
 
 const chargeEfficiency = 0.9 // assume charge 90% efficiency
@@ -14,7 +13,7 @@ const chargeEfficiency = 0.9 // assume charge 90% efficiency
 // Estimator provides vehicle soc and charge duration
 // Vehicle SoC can be estimated to provide more granularity
 type Estimator struct {
-	log      *util.Logger
+	log      api.Logger
 	charger  api.Charger
 	vehicle  api.Vehicle
 	estimate bool
@@ -28,7 +27,7 @@ type Estimator struct {
 }
 
 // NewEstimator creates new estimator
-func NewEstimator(log *util.Logger, charger api.Charger, vehicle api.Vehicle, estimate bool) *Estimator {
+func NewEstimator(log api.Logger, charger api.Charger, vehicle api.Vehicle, estimate bool) *Estimator {
 	s := &Estimator{
 		log:      log,
 		charger:  charger,

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -67,7 +67,7 @@ func (s *Estimator) RemainingChargeDuration(chargePower float64, targetSoC int) 
 			}
 
 			if !errors.Is(err, api.ErrNotAvailable) {
-				s.log.WARN.Printf("updating remaining time failed: %v", err)
+				s.log.Warnf("updating remaining time failed: %v", err)
 			}
 		}
 
@@ -108,7 +108,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 
 				// recover from temporary api errors
 				f = s.prevSoC
-				s.log.WARN.Printf("vehicle soc (charger): %v (ignored by estimator)", err)
+				s.log.Warnf("vehicle soc (charger): %v (ignored by estimator)", err)
 			}
 
 			s.vehicleSoc = f
@@ -131,7 +131,7 @@ func (s *Estimator) SoC(chargedEnergy float64) (float64, error) {
 
 			// recover from temporary api errors
 			f = s.prevSoC
-			s.log.WARN.Printf("vehicle soc: %v (ignored by estimator)", err)
+			s.log.Warnf("vehicle soc: %v (ignored by estimator)", err)
 		}
 
 		fetchedSoC = &f

--- a/core/soc/timer.go
+++ b/core/soc/timer.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/util"
 )
 
 const (
@@ -15,7 +14,7 @@ const (
 // Timer is the target charging handler
 type Timer struct {
 	Adapter
-	log      *util.Logger
+	log      api.Logger
 	current  float64
 	SoC      int
 	Time     time.Time
@@ -24,7 +23,7 @@ type Timer struct {
 }
 
 // NewTimer creates a Timer
-func NewTimer(log *util.Logger, api Adapter) *Timer {
+func NewTimer(log api.Logger, api Adapter) *Timer {
 	lp := &Timer{
 		log:     log,
 		Adapter: api,

--- a/core/soc/timer.go
+++ b/core/soc/timer.go
@@ -52,7 +52,7 @@ func (lp *Timer) DemandActive() bool {
 
 	se := lp.SocEstimator()
 	if se == nil {
-		lp.log.WARN.Printf("target charging: not possible")
+		lp.log.Warnf("target charging: not possible")
 		return false
 	}
 

--- a/core/soc/timer.go
+++ b/core/soc/timer.go
@@ -75,7 +75,7 @@ func (lp *Timer) DemandActive() bool {
 	// timer charging is already active- only deactivate once charging has stopped
 	if lp.active {
 		if time.Now().After(lp.Time) && lp.GetStatus() != api.StatusC {
-			lp.log.TRACE.Printf("target charging: deactivating")
+			lp.log.Tracef("target charging: deactivating")
 			lp.active = false
 		}
 
@@ -85,7 +85,7 @@ func (lp *Timer) DemandActive() bool {
 	// check if charging need be activated
 	if lp.active = lp.finishAt.After(lp.Time); lp.active {
 		lp.current = lp.GetMaxCurrent()
-		lp.log.DEBUG.Printf("target charging active for %v: projected %v (%v remaining)", lp.Time, lp.finishAt, remainingDuration.Round(time.Minute))
+		lp.log.Debugf("target charging active for %v: projected %v (%v remaining)", lp.Time, lp.finishAt, remainingDuration.Round(time.Minute))
 	}
 
 	return lp.active
@@ -106,7 +106,7 @@ func (lp *Timer) Handle() float64 {
 	}
 
 	lp.current = math.Max(math.Min(lp.current, lp.GetMaxCurrent()), lp.GetMinCurrent())
-	lp.log.DEBUG.Printf("target charging: %s (%.3gA)", action, lp.current)
+	lp.log.Debugf("target charging: %s (%.3gA)", action, lp.current)
 
 	return lp.current
 }

--- a/core/wrapper/chargerater.go
+++ b/core/wrapper/chargerater.go
@@ -47,9 +47,9 @@ func (cr *ChargeRater) StartCharge(continued bool) {
 	if m, ok := cr.meter.(api.MeterEnergy); ok {
 		if f, err := m.TotalEnergy(); err == nil {
 			cr.startEnergy = f
-			cr.log.DEBUG.Printf("charge start energy: %.3gkWh", f)
+			cr.log.Debugf("charge start energy: %.3gkWh", f)
 		} else {
-			cr.log.ERROR.Printf("charge meter error %v", err)
+			cr.log.Errorf("charge meter error %v", err)
 		}
 	}
 
@@ -70,9 +70,9 @@ func (cr *ChargeRater) StopCharge() {
 	if m, ok := cr.meter.(api.MeterEnergy); ok {
 		if f, err := m.TotalEnergy(); err == nil {
 			cr.chargedEnergy += f - cr.startEnergy
-			cr.log.DEBUG.Printf("final charge energy: %.3gkWh", cr.chargedEnergy)
+			cr.log.Debugf("final charge energy: %.3gkWh", cr.chargedEnergy)
 		} else {
-			cr.log.ERROR.Printf("charge meter error %v", err)
+			cr.log.Errorf("charge meter error %v", err)
 		}
 	}
 }

--- a/core/wrapper/chargerater.go
+++ b/core/wrapper/chargerater.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/util"
 )
 
 // ChargeRater is responsible for providing charged energy amount
@@ -15,7 +14,7 @@ import (
 // keeps track of consumed energy by regularly updating consumed power.
 type ChargeRater struct {
 	sync.Mutex
-	log           *util.Logger
+	log           api.Logger
 	clck          clock.Clock
 	meter         api.Meter
 	charging      bool
@@ -25,7 +24,7 @@ type ChargeRater struct {
 }
 
 // NewChargeRater creates charge rater and initializes realtime clock
-func NewChargeRater(log *util.Logger, meter api.Meter) *ChargeRater {
+func NewChargeRater(log api.Logger, meter api.Meter) *ChargeRater {
 	return &ChargeRater{
 		log:   log,
 		clck:  clock.New(),

--- a/detect/tasklist.go
+++ b/detect/tasklist.go
@@ -100,7 +100,7 @@ func (l *TaskList) Test(log *util.Logger, id string, input tasks.ResultDetails) 
 
 		inputs = task.Test(log, input)
 		success := len(inputs) > 0
-		log.DEBUG.Printf("task: %s %v -> %v", id, input, success)
+		log.Debugf("task: %s %v -> %v", id, input, success)
 
 		for _, detail := range inputs {
 			all = append(all, tasks.Result{

--- a/detect/tasks/keba.go
+++ b/detect/tasks/keba.go
@@ -40,7 +40,7 @@ func (h *KEBAHandler) Test(log *util.Logger, in ResultDetails) []ResultDetails {
 	if h.listener == nil {
 		var err error
 		if h.listener, err = keba.New(log); err != nil {
-			log.ERROR.Println("keba:", err)
+			log.Errorln("keba:", err)
 		}
 
 		h.mux.Unlock()
@@ -54,7 +54,7 @@ func (h *KEBAHandler) Test(log *util.Logger, in ResultDetails) []ResultDetails {
 
 	sender, err := keba.NewSender(log, in.IP)
 	if err != nil {
-		log.ERROR.Println("keba:", err)
+		log.Errorln("keba:", err)
 		return nil
 	}
 
@@ -67,7 +67,7 @@ func (h *KEBAHandler) Test(log *util.Logger, in ResultDetails) []ResultDetails {
 
 		select {
 		case t := <-resC:
-			log.INFO.Println(t)
+			log.Infoln(t)
 			if t.Report == nil {
 				continue
 			}

--- a/detect/tasks/modbus.go
+++ b/detect/tasks/modbus.go
@@ -136,7 +136,7 @@ func (h *ModbusHandler) testSunSpec(log *util.Logger, conn meters.Connection, de
 			mr.Point = h.Point
 			mr.Value = res.Value()
 
-			log.DEBUG.Printf("model %d point %s: %v", model, mr.Point, mr.Value)
+			log.Debugf("model %d point %s: %v", model, mr.Point, mr.Value)
 
 			if len(h.Invalid) == 0 {
 				return true
@@ -162,7 +162,7 @@ func (h *ModbusHandler) testSunSpec(log *util.Logger, conn meters.Connection, de
 				}
 			}
 		} else {
-			log.DEBUG.Printf("model %d: %v", model, err)
+			log.Debugf("model %d: %v", model, err)
 		}
 	}
 
@@ -199,10 +199,10 @@ func (h *ModbusHandler) Test(log *util.Logger, in ResultDetails) (res []ResultDe
 
 		var ok bool
 		if h.op.OpCode > 0 {
-			// log.DEBUG.Printf("slave id: %d op: %v", slaveID, h.op)
+			// log.Debugf("slave id: %d op: %v", slaveID, h.op)
 			ok = h.testRegister(log, conn.ModbusClient())
 		} else {
-			// log.DEBUG.Printf("slave id: %d models: %v", slaveID, h.Models)
+			// log.Debugf("slave id: %d models: %v", slaveID, h.Models)
 			ok = h.testSunSpec(log, conn, dev, &mr)
 		}
 

--- a/detect/tasks/ping.go
+++ b/detect/tasks/ping.go
@@ -53,7 +53,7 @@ func (h *PingHandler) Test(log *util.Logger, in ResultDetails) []ResultDetails {
 			log.FATAL.Println("	sudo sysctl -w net.ipv4.ping_group_range=\"0 2147483647\"")
 		}
 
-		log.FATAL.Fatalln("")
+		log.Fatalln("")
 	}
 
 	stat := pinger.Statistics()

--- a/detect/tasks/ping.go
+++ b/detect/tasks/ping.go
@@ -44,13 +44,13 @@ func (h *PingHandler) Test(log *util.Logger, in ResultDetails) []ResultDetails {
 	pinger.Timeout = h.Timeout
 
 	if err = pinger.Run(); err != nil {
-		log.FATAL.Println("ping:", err)
+		log.Errorln("ping:", err)
 
 		if runtime.GOOS != "windows" {
-			log.FATAL.Println("")
-			log.FATAL.Println("In order to run evcc in discovery mode, make sure to allow ping:")
-			log.FATAL.Println("")
-			log.FATAL.Println("	sudo sysctl -w net.ipv4.ping_group_range=\"0 2147483647\"")
+			log.Errorln("")
+			log.Errorln("In order to run evcc in discovery mode, make sure to allow ping:")
+			log.Errorln("")
+			log.Errorln("	sudo sysctl -w net.ipv4.ping_group_range=\"0 2147483647\"")
 		}
 
 		log.Fatalln("")

--- a/detect/tasks/sma.go
+++ b/detect/tasks/sma.go
@@ -70,7 +70,7 @@ func (h *SMAHandler) Test(log *util.Logger, in ResultDetails) (res []ResultDetai
 
 	connection, err := sunny.NewConnection("")
 	if err != nil {
-		log.ERROR.Println("sma:", err)
+		log.Errorln("sma:", err)
 		return nil
 	}
 

--- a/detect/work.go
+++ b/detect/work.go
@@ -36,7 +36,7 @@ func Work(log *util.Logger, num int, hosts []string) []tasks.Result {
 	hits := make(chan []tasks.Result)
 	done := make(chan struct{})
 
-	// log.INFO.Println(
+	// log.Infoln(
 	// 	"\n" +
 	// 		strings.Join(
 	// 			funk.Map(taskList.tasks, func(t tasks.Task) string {

--- a/hems/ocpp/ocpp.go
+++ b/hems/ocpp/ocpp.go
@@ -47,7 +47,7 @@ func New(conf map[string]interface{}, site site.API, cache *util.Cache) (*OCPP, 
 		} else {
 			cc.StationID = fmt.Sprintf("evcc-%d", rand.Int31())
 		}
-		log.DEBUG.Println("station id:", cc.StationID)
+		log.Debugln("station id:", cc.StationID)
 	}
 
 	ws := ws.NewClient()
@@ -75,7 +75,7 @@ func New(conf map[string]interface{}, site site.API, cache *util.Cache) (*OCPP, 
 // errorHandler logs error channel
 func (s *OCPP) errorHandler(errC <-chan error) {
 	for err := range errC {
-		s.log.ERROR.Println(err)
+		s.log.Errorln(err)
 	}
 }
 
@@ -90,9 +90,9 @@ func (s *OCPP) Run() {
 				status = ocppcore.ChargePointStatusCharging
 			}
 
-			s.log.DEBUG.Printf("send: lp-%d status: %+v", connector, status)
+			s.log.Debugf("send: lp-%d status: %+v", connector, status)
 			if _, err := s.cp.StatusNotification(connector, ocppcore.NoError, status); err != nil {
-				s.log.ERROR.Printf("lp-%d: %v", connector, err)
+				s.log.Errorf("lp-%d: %v", connector, err)
 			}
 		}
 

--- a/hems/ocpp/ocpp.go
+++ b/hems/ocpp/ocpp.go
@@ -19,7 +19,7 @@ import (
 
 // OCPP is an OCPP client
 type OCPP struct {
-	log   *util.Logger
+	log   api.Logger
 	cache *util.Cache
 	site  site.API
 	cp    ocpp16.ChargePoint

--- a/hems/ocpp/profile/core.go
+++ b/hems/ocpp/profile/core.go
@@ -1,17 +1,17 @@
 package profile
 
 import (
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
 type Core struct {
-	log           *util.Logger
+	log           api.Logger
 	configuration ConfigMap
 }
 
-func NewCore(log *util.Logger, config ConfigMap) *Core {
+func NewCore(log api.Logger, config ConfigMap) *Core {
 	return &Core{
 		log:           log,
 		configuration: config,

--- a/hems/ocpp/profile/core.go
+++ b/hems/ocpp/profile/core.go
@@ -20,24 +20,24 @@ func NewCore(log *util.Logger, config ConfigMap) *Core {
 
 // OnChangeAvailability handles the CS message
 func (s *Core) OnChangeAvailability(request *core.ChangeAvailabilityRequest) (confirmation *core.ChangeAvailabilityConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return core.NewChangeAvailabilityConfirmation(core.AvailabilityStatusRejected), nil
 }
 
 // OnUnlockConnector handles the CS message
 func (s *Core) OnUnlockConnector(request *core.UnlockConnectorRequest) (confirmation *core.UnlockConnectorConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return core.NewUnlockConnectorConfirmation(core.UnlockStatusUnlocked), nil
 }
 
 // OnRemoteStartTransaction handles the CS message
 func (s *Core) OnRemoteStartTransaction(request *core.RemoteStartTransactionRequest) (confirmation *core.RemoteStartTransactionConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return core.NewRemoteStartTransactionConfirmation(types.RemoteStartStopStatusRejected), nil
 }
 
 // OnRemoteStopTransaction handles the CS message
 func (s *Core) OnRemoteStopTransaction(request *core.RemoteStopTransactionRequest) (confirmation *core.RemoteStopTransactionConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return core.NewRemoteStopTransactionConfirmation(types.RemoteStartStopStatusRejected), nil
 }

--- a/hems/ocpp/profile/core_configuration.go
+++ b/hems/ocpp/profile/core_configuration.go
@@ -4,7 +4,7 @@ import "github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 
 // OnGetConfiguration handles the CS message
 func (s *Core) OnGetConfiguration(request *core.GetConfigurationRequest) (confirmation *core.GetConfigurationConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 
 	var resultKeys []core.ConfigurationKey
 	var unknownKeys []string
@@ -25,7 +25,7 @@ func (s *Core) OnGetConfiguration(request *core.GetConfigurationRequest) (confir
 		}
 	}
 
-	s.log.TRACE.Printf("%s: configuration for requested keys: %v", request.GetFeatureName(), request.Key)
+	s.log.Tracef("%s: configuration for requested keys: %v", request.GetFeatureName(), request.Key)
 
 	conf := core.NewGetConfigurationConfirmation(resultKeys)
 	conf.UnknownKey = unknownKeys
@@ -35,6 +35,6 @@ func (s *Core) OnGetConfiguration(request *core.GetConfigurationRequest) (confir
 
 // OnChangeConfiguration handles the CS message
 func (s *Core) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusAccepted), nil
 }

--- a/hems/ocpp/profile/core_other.go
+++ b/hems/ocpp/profile/core_other.go
@@ -6,18 +6,18 @@ import (
 
 // OnClearCache handles the CS message
 func (s *Core) OnClearCache(request *core.ClearCacheRequest) (confirmation *core.ClearCacheConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s", request.GetFeatureName())
+	s.log.Tracef("recv: %s", request.GetFeatureName())
 	return core.NewClearCacheConfirmation(core.ClearCacheStatusAccepted), nil
 }
 
 // OnDataTransfer handles the CS message
 func (s *Core) OnDataTransfer(request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return core.NewDataTransferConfirmation(core.DataTransferStatusAccepted), nil
 }
 
 // OnReset handles the CS message
 func (s *Core) OnReset(request *core.ResetRequest) (confirmation *core.ResetConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return core.NewResetConfirmation(core.ResetStatusAccepted), nil
 }

--- a/hems/ocpp/profile/smartcharging.go
+++ b/hems/ocpp/profile/smartcharging.go
@@ -17,18 +17,18 @@ func NewSmartCharging(log *util.Logger) *SmartCharging {
 
 // OnSetChargingProfile handles the CS message
 func (s *SmartCharging) OnSetChargingProfile(request *sc.SetChargingProfileRequest) (confirmation *sc.SetChargingProfileConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return sc.NewSetChargingProfileConfirmation(sc.ChargingProfileStatusRejected), nil
 }
 
 // OnClearChargingProfile handles the CS message
 func (s *SmartCharging) OnClearChargingProfile(request *sc.ClearChargingProfileRequest) (confirmation *sc.ClearChargingProfileConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return sc.NewClearChargingProfileConfirmation(sc.ClearChargingProfileStatusUnknown), nil
 }
 
 // OnGetCompositeSchedule handles the CS message
 func (s *SmartCharging) OnGetCompositeSchedule(request *sc.GetCompositeScheduleRequest) (confirmation *sc.GetCompositeScheduleConfirmation, err error) {
-	s.log.TRACE.Printf("recv: %s %+v", request.GetFeatureName(), request)
+	s.log.Tracef("recv: %s %+v", request.GetFeatureName(), request)
 	return sc.NewGetCompositeScheduleConfirmation(sc.GetCompositeScheduleStatusRejected), nil
 }

--- a/hems/ocpp/profile/smartcharging.go
+++ b/hems/ocpp/profile/smartcharging.go
@@ -1,15 +1,15 @@
 package profile
 
 import (
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	sc "github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
 )
 
 type SmartCharging struct {
-	log *util.Logger
+	log api.Logger
 }
 
-func NewSmartCharging(log *util.Logger) *SmartCharging {
+func NewSmartCharging(log api.Logger) *SmartCharging {
 	return &SmartCharging{
 		log: log,
 	}

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -187,7 +187,7 @@ func (s *SEMP) callbackURI() string {
 	}
 
 	uri := fmt.Sprintf("http://%s:%d", ip, s.port)
-	s.log.WARN.Printf("%s unspecified, using %s instead", sempBaseURLEnv, uri)
+	s.log.Warnf("%s unspecified, using %s instead", sempBaseURLEnv, uri)
 
 	return uri
 }

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -116,7 +116,7 @@ func (s *SEMP) advertise(st, usn string) *ssdp.Advertiser {
 	descriptor := s.hostURI + basePath + "/description.xml"
 	ad, err := ssdp.Advertise(st, usn, descriptor, serverName, maxAge)
 	if err != nil {
-		s.log.ERROR.Println(err)
+		s.log.Errorln(err)
 	}
 	return ad
 }
@@ -143,7 +143,7 @@ ANNOUNCE:
 		case <-ticker.C:
 			for _, ad := range ads {
 				if err := ad.Alive(); err != nil {
-					s.log.ERROR.Println(err)
+					s.log.Errorln(err)
 				}
 			}
 		case <-s.closeC:
@@ -153,7 +153,7 @@ ANNOUNCE:
 
 	for _, ad := range ads {
 		if err := ad.Bye(); err != nil {
-			s.log.ERROR.Println(err)
+			s.log.Errorln(err)
 		}
 	}
 
@@ -183,7 +183,7 @@ func (s *SEMP) callbackURI() string {
 	if len(ips) > 0 {
 		ip = ips[0].IP.String()
 	} else {
-		s.log.ERROR.Printf("couldn't determine ip address- specify %s to override", sempBaseURLEnv)
+		s.log.Errorf("couldn't determine ip address- specify %s to override", sempBaseURLEnv)
 	}
 
 	uri := fmt.Sprintf("http://%s:%d", ip, s.port)
@@ -209,7 +209,7 @@ func (s *SEMP) handlers(router *mux.Router) {
 }
 
 func (s *SEMP) writeXML(w http.ResponseWriter, msg interface{}) {
-	s.log.TRACE.Printf("send: %+v", msg)
+	s.log.Tracef("send: %+v", msg)
 
 	b, err := xml.MarshalIndent(msg, "", "  ")
 	if err != nil {
@@ -498,7 +498,7 @@ func (s *SEMP) deviceControlHandler(w http.ResponseWriter, r *http.Request) {
 	var msg EM2Device
 
 	err := xml.NewDecoder(r.Body).Decode(&msg)
-	s.log.TRACE.Printf("recv: %+v", msg)
+	s.log.Tracef("recv: %+v", msg)
 
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -40,7 +40,7 @@ var (
 
 // SEMP is the SMA SEMP server
 type SEMP struct {
-	log          *util.Logger
+	log          api.Logger
 	cache        *util.Cache
 	closeC       chan struct{}
 	doneC        chan struct{}

--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -15,7 +15,7 @@ import (
 
 // Modbus is an api.Meter implementation with configurable getters and setters.
 type Modbus struct {
-	log      *util.Logger
+	log      api.Logger
 	conn     *modbus.Connection
 	device   meters.Device
 	opPower  modbus.Operation

--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -152,7 +152,7 @@ func (m *Modbus) floatGetter(op modbus.Operation) (float64, error) {
 	}
 
 	if err == nil {
-		m.log.TRACE.Printf("%+v", res)
+		m.log.Tracef("%+v", res)
 	}
 
 	return res.Value, err

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -15,7 +15,7 @@ import (
 
 // SMA supporting SMA Home Manager 2.0, SMA Energy Meter 30 and SMA inverter
 type SMA struct {
-	log    *util.Logger
+	log    api.Logger
 	uri    string
 	scale  float64
 	device *sma.Device

--- a/provider/cache.go
+++ b/provider/cache.go
@@ -60,7 +60,7 @@ func (c *Cached) mustUpdate() bool {
 func (c *Cached) FloatGetter() func() (float64, error) {
 	g, ok := c.getter.(func() (float64, error))
 	if !ok {
-		log.FATAL.Fatalf("invalid type: %T", c.getter)
+		log.Fatalf("invalid type: %T", c.getter)
 	}
 
 	return func() (float64, error) {
@@ -80,7 +80,7 @@ func (c *Cached) FloatGetter() func() (float64, error) {
 func (c *Cached) IntGetter() func() (int64, error) {
 	g, ok := c.getter.(func() (int64, error))
 	if !ok {
-		log.FATAL.Fatalf("invalid type: %T", c.getter)
+		log.Fatalf("invalid type: %T", c.getter)
 	}
 
 	return func() (int64, error) {
@@ -100,7 +100,7 @@ func (c *Cached) IntGetter() func() (int64, error) {
 func (c *Cached) StringGetter() func() (string, error) {
 	g, ok := c.getter.(func() (string, error))
 	if !ok {
-		log.FATAL.Fatalf("invalid type: %T", c.getter)
+		log.Fatalf("invalid type: %T", c.getter)
 	}
 
 	return func() (string, error) {
@@ -120,7 +120,7 @@ func (c *Cached) StringGetter() func() (string, error) {
 func (c *Cached) BoolGetter() func() (bool, error) {
 	g, ok := c.getter.(func() (bool, error))
 	if !ok {
-		log.FATAL.Fatalf("invalid type: %T", c.getter)
+		log.Fatalf("invalid type: %T", c.getter)
 	}
 
 	return func() (bool, error) {
@@ -140,7 +140,7 @@ func (c *Cached) BoolGetter() func() (bool, error) {
 func (c *Cached) DurationGetter() func() (time.Duration, error) {
 	g, ok := c.getter.(func() (time.Duration, error))
 	if !ok {
-		log.FATAL.Fatalf("invalid type: %T", c.getter)
+		log.Fatalf("invalid type: %T", c.getter)
 	}
 
 	return func() (time.Duration, error) {
@@ -160,7 +160,7 @@ func (c *Cached) DurationGetter() func() (time.Duration, error) {
 func (c *Cached) TimeGetter() func() (time.Time, error) {
 	g, ok := c.getter.(func() (time.Time, error))
 	if !ok {
-		log.FATAL.Fatalf("invalid type: %T", c.getter)
+		log.Fatalf("invalid type: %T", c.getter)
 	}
 
 	return func() (time.Time, error) {
@@ -180,7 +180,7 @@ func (c *Cached) TimeGetter() func() (time.Time, error) {
 func (c *Cached) InterfaceGetter() func() (interface{}, error) {
 	g, ok := c.getter.(func() (interface{}, error))
 	if !ok {
-		log.FATAL.Fatalf("invalid type: %T", c.getter)
+		log.Fatalf("invalid type: %T", c.getter)
 	}
 
 	return func() (interface{}, error) {

--- a/provider/http.go
+++ b/provider/http.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/jq"
 	"github.com/evcc-io/evcc/util/request"
@@ -37,7 +38,7 @@ type Auth struct {
 }
 
 // AuthHeaders creates authorization headers from config
-func AuthHeaders(log *util.Logger, auth Auth, headers map[string]string) error {
+func AuthHeaders(log api.Logger, auth Auth, headers map[string]string) error {
 	if strings.ToLower(auth.Type) != "basic" {
 		return fmt.Errorf("unsupported auth type: %s", auth.Type)
 	}
@@ -99,7 +100,7 @@ func NewHTTPProviderFromConfig(other map[string]interface{}) (IntProvider, error
 }
 
 // NewHTTP create HTTP provider
-func NewHTTP(log *util.Logger, method, uri string, headers map[string]string, body string, insecure bool, regex, jq string, scale float64) (*HTTP, error) {
+func NewHTTP(log api.Logger, method, uri string, headers map[string]string, body string, insecure bool, regex, jq string, scale float64) (*HTTP, error) {
 	url := util.DefaultScheme(uri, "http")
 	if url != uri {
 		log.Warnf("missing scheme for %s, assuming http", uri)

--- a/provider/http.go
+++ b/provider/http.go
@@ -102,7 +102,7 @@ func NewHTTPProviderFromConfig(other map[string]interface{}) (IntProvider, error
 func NewHTTP(log *util.Logger, method, uri string, headers map[string]string, body string, insecure bool, regex, jq string, scale float64) (*HTTP, error) {
 	url := util.DefaultScheme(uri, "http")
 	if url != uri {
-		log.WARN.Printf("missing scheme for %s, assuming http", uri)
+		log.Warnf("missing scheme for %s, assuming http", uri)
 	}
 
 	p := &HTTP{

--- a/provider/javascript.go
+++ b/provider/javascript.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"strings"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider/javascript"
 	"github.com/evcc-io/evcc/util"
 	"github.com/robertkrimen/otto"
@@ -10,7 +11,7 @@ import (
 
 // Javascript implements Javascript request provider
 type Javascript struct {
-	log    *util.Logger
+	log    api.Logger
 	vm     *otto.Otto
 	script string
 }

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/modbus"
 	"github.com/volkszaehler/mbmd/meters"
@@ -16,7 +17,7 @@ import (
 
 // Modbus implements modbus RTU and TCP access
 type Modbus struct {
-	log    *util.Logger
+	log    api.Logger
 	conn   *modbus.Connection
 	device meters.Device
 	op     modbus.Operation

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -174,9 +174,9 @@ func (m *Modbus) floatGetter() (float64, error) {
 
 	if err == nil {
 		if m.op.MBMD.IEC61850 != 0 {
-			m.log.TRACE.Printf("%s: %v", m.op.MBMD.IEC61850, res.Value)
+			m.log.Tracef("%s: %v", m.op.MBMD.IEC61850, res.Value)
 		} else {
-			m.log.TRACE.Printf("%d:%d:%s: %v", m.op.SunSpec.Model, m.op.SunSpec.Block, m.op.SunSpec.Point, res.Value)
+			m.log.Tracef("%d:%d:%s: %v", m.op.SunSpec.Model, m.op.SunSpec.Block, m.op.SunSpec.Point, res.Value)
 		}
 	}
 

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -70,7 +70,7 @@ func NewModbusFromConfig(other map[string]interface{}) (IntProvider, error) {
 	}
 
 	if cc.Value == "" && cc.Register.Decode == "" {
-		log.WARN.Println("missing modbus value or register - assuming Power")
+		log.Warnln("missing modbus value or register - assuming Power")
 		cc.Value = "Power"
 	}
 

--- a/provider/mqtt.go
+++ b/provider/mqtt.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider/mqtt"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/jq"
@@ -15,7 +16,7 @@ import (
 
 // Mqtt provider
 type Mqtt struct {
-	log     *util.Logger
+	log     api.Logger
 	client  *mqtt.Client
 	topic   string
 	payload string
@@ -73,7 +74,7 @@ func NewMqttFromConfig(other map[string]interface{}) (IntProvider, error) {
 }
 
 // NewMqtt creates mqtt provider for given topic
-func NewMqtt(log *util.Logger, client *mqtt.Client, topic string, scale float64, timeout time.Duration) *Mqtt {
+func NewMqtt(log api.Logger, client *mqtt.Client, topic string, scale float64, timeout time.Duration) *Mqtt {
 	m := &Mqtt{
 		log:     log,
 		client:  client,

--- a/provider/mqtt.go
+++ b/provider/mqtt.go
@@ -122,7 +122,7 @@ func (m *Mqtt) FloatGetter() func() (float64, error) {
 	h := &msgHandler{
 		topic: m.topic,
 		scale: m.scale,
-		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.Debugf("%s wait for initial value", m.topic) }),
 		re:    m.re,
 		jq:    m.jq,
 	}
@@ -138,7 +138,7 @@ func (m *Mqtt) IntGetter() func() (int64, error) {
 	h := &msgHandler{
 		topic: m.topic,
 		scale: float64(m.scale),
-		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.Debugf("%s wait for initial value", m.topic) }),
 		re:    m.re,
 		jq:    m.jq,
 	}
@@ -153,7 +153,7 @@ var _ StringProvider = (*Mqtt)(nil)
 func (m *Mqtt) StringGetter() func() (string, error) {
 	h := &msgHandler{
 		topic: m.topic,
-		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.Debugf("%s wait for initial value", m.topic) }),
 		re:    m.re,
 		jq:    m.jq,
 	}
@@ -168,7 +168,7 @@ var _ BoolProvider = (*Mqtt)(nil)
 func (m *Mqtt) BoolGetter() func() (bool, error) {
 	h := &msgHandler{
 		topic: m.topic,
-		mux:   util.NewWaiter(m.timeout, func() { m.log.DEBUG.Printf("%s wait for initial value", m.topic) }),
+		mux:   util.NewWaiter(m.timeout, func() { m.log.Debugf("%s wait for initial value", m.topic) }),
 		re:    m.re,
 		jq:    m.jq,
 	}

--- a/provider/mqtt/client.go
+++ b/provider/mqtt/client.go
@@ -48,7 +48,7 @@ type Option func(*paho.ClientOptions)
 // NewClient creates new Mqtt publisher
 func NewClient(log *util.Logger, broker, user, password, clientID string, qos byte, opts ...Option) (*Client, error) {
 	broker = util.DefaultPort(broker, 1883)
-	log.INFO.Printf("connecting %s at %s", clientID, broker)
+	log.Infof("connecting %s at %s", clientID, broker)
 
 	mc := &Client{
 		log:      log,
@@ -85,25 +85,25 @@ func NewClient(log *util.Logger, broker, user, password, clientID string, qos by
 
 // ConnectionLostHandler logs cause of connection loss as warning
 func (m *Client) ConnectionLostHandler(client paho.Client, reason error) {
-	m.log.ERROR.Printf("%s connection lost: %v", m.broker, reason.Error())
+	m.log.Errorf("%s connection lost: %v", m.broker, reason.Error())
 }
 
 // ConnectionHandler restores listeners
 func (m *Client) ConnectionHandler(client paho.Client) {
-	m.log.DEBUG.Printf("%s connected", m.broker)
+	m.log.Debugf("%s connected", m.broker)
 
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
 	for topic := range m.listener {
-		m.log.DEBUG.Printf("%s subscribe %s", m.broker, topic)
+		m.log.Debugf("%s subscribe %s", m.broker, topic)
 		go m.listen(topic)
 	}
 }
 
 // Publish synchronously publishes payload using client qos
 func (m *Client) Publish(topic string, retained bool, payload interface{}) error {
-	m.log.TRACE.Printf("send %s: '%v'", topic, payload)
+	m.log.Tracef("send %s: '%v'", topic, payload)
 	token := m.Client.Publish(topic, m.Qos, retained, payload)
 	if token.WaitTimeout(publishTimeout) {
 		return token.Error()
@@ -124,7 +124,7 @@ func (m *Client) Listen(topic string, callback func(string)) {
 func (m *Client) listen(topic string) {
 	token := m.Client.Subscribe(topic, m.Qos, func(c paho.Client, msg paho.Message) {
 		payload := string(msg.Payload())
-		m.log.TRACE.Printf("recv %s: '%v'", topic, payload)
+		m.log.Tracef("recv %s: '%v'", topic, payload)
 		if len(payload) > 0 {
 			m.mux.Lock()
 			callbacks := m.listener[topic]
@@ -142,9 +142,9 @@ func (m *Client) listen(topic string) {
 func (m *Client) WaitForToken(token paho.Token) {
 	if token.WaitTimeout(publishTimeout) {
 		if token.Error() != nil {
-			m.log.ERROR.Printf("error: %s", token.Error())
+			m.log.Errorf("error: %s", token.Error())
 		}
 	} else {
-		m.log.DEBUG.Println("timeout")
+		m.log.Debugln("timeout")
 	}
 }

--- a/provider/mqtt/client.go
+++ b/provider/mqtt/client.go
@@ -35,7 +35,7 @@ type Config struct {
 
 // Client encapsulates mqtt publish/subscribe functions
 type Client struct {
-	log      *util.Logger
+	log      api.Logger
 	mux      sync.Mutex
 	Client   paho.Client
 	broker   string
@@ -46,7 +46,7 @@ type Client struct {
 type Option func(*paho.ClientOptions)
 
 // NewClient creates new Mqtt publisher
-func NewClient(log *util.Logger, broker, user, password, clientID string, qos byte, opts ...Option) (*Client, error) {
+func NewClient(log api.Logger, broker, user, password, clientID string, qos byte, opts ...Option) (*Client, error) {
 	broker = util.DefaultPort(broker, 1883)
 	log.Infof("connecting %s at %s", clientID, broker)
 

--- a/provider/mqtt/registry.go
+++ b/provider/mqtt/registry.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 )
 
 type clientRegistry map[string]*Client
@@ -28,8 +28,8 @@ func (r clientRegistry) Get(broker string) (*Client, error) {
 var registry clientRegistry = make(map[string]*Client)
 
 // RegisteredClient reuses an registered Mqtt publisher or creates a new one
-func RegisteredClient(log *util.Logger, broker, user, password, clientID string, qos byte, opts ...Option) (*Client, error) {
-	key := fmt.Sprintf("%s.%s", broker, log.Name())
+func RegisteredClient(log api.Logger, broker, user, password, clientID string, qos byte, opts ...Option) (*Client, error) {
+	key := fmt.Sprintf("%s.%s", broker, user)
 	client, err := registry.Get(key)
 
 	if err != nil {
@@ -43,7 +43,7 @@ func RegisteredClient(log *util.Logger, broker, user, password, clientID string,
 
 // RegisteredClientOrDefault reuses an registered Mqtt publisher or creates a new one.
 // If no publisher is configured, it uses the default instance.
-func RegisteredClientOrDefault(log *util.Logger, cc Config) (*Client, error) {
+func RegisteredClientOrDefault(log api.Logger, cc Config) (*Client, error) {
 	var err error
 	client := Instance
 

--- a/provider/script.go
+++ b/provider/script.go
@@ -104,11 +104,11 @@ func (e *Script) exec(script string) (string, error) {
 			s = strings.TrimSpace(string(ee.Stderr))
 		}
 
-		e.log.ERROR.Printf("%s: %s", strings.Join(args, " "), s)
+		e.log.Errorf("%s: %s", strings.Join(args, " "), s)
 		return "", err
 	}
 
-	e.log.DEBUG.Printf("%s: %s", strings.Join(args, " "), s)
+	e.log.Debugf("%s: %s", strings.Join(args, " "), s)
 
 	return s, nil
 }

--- a/provider/script.go
+++ b/provider/script.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/jq"
 	"github.com/itchyny/gojq"
@@ -18,7 +19,7 @@ import (
 
 // Script implements shell script-based providers and setters
 type Script struct {
-	log     *util.Logger
+	log     api.Logger
 	script  string
 	timeout time.Duration
 	cache   time.Duration

--- a/provider/sma/device.go
+++ b/provider/sma/device.go
@@ -81,7 +81,7 @@ func AsFloat(value interface{}) float64 {
 	case nil:
 		return 0
 	default:
-		util.NewLogger("sma").WARN.Printf("unknown value type: %T", value)
+		util.NewLogger("sma").Warnf("unknown value type: %T", value)
 		return 0
 	}
 }

--- a/provider/sma/device.go
+++ b/provider/sma/device.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/imdario/mergo"
 	"gitlab.com/bboehmke/sunny"
@@ -14,7 +15,7 @@ import (
 type Device struct {
 	*sunny.Device
 
-	log    *util.Logger
+	log    api.Logger
 	mux    *util.Waiter
 	values map[sunny.ValueID]interface{}
 	once   sync.Once

--- a/provider/sma/device.go
+++ b/provider/sma/device.go
@@ -43,7 +43,7 @@ func (d *Device) updateValues() {
 	}
 
 	if err != nil {
-		d.log.ERROR.Println(err)
+		d.log.Errorln(err)
 	}
 }
 

--- a/provider/sma/discover.go
+++ b/provider/sma/discover.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"gitlab.com/bboehmke/sunny"
 )
@@ -54,7 +55,7 @@ func GetDiscoverer(iface string) (*Discoverer, error) {
 
 // Discoverer discovers SMA devicesBySerial in background while providing already found devicesBySerial
 type Discoverer struct {
-	log     *util.Logger
+	log     api.Logger
 	conn    *sunny.Connection
 	devices map[uint32]*Device
 	mux     sync.RWMutex

--- a/provider/sma/discover.go
+++ b/provider/sma/discover.go
@@ -65,7 +65,7 @@ func (d *Discoverer) createDevice(device *sunny.Device) *Device {
 	return &Device{
 		Device: device,
 		log:    d.log,
-		mux:    util.NewWaiter(udpTimeout, func() { d.log.DEBUG.Println("wait for initial value") }),
+		mux:    util.NewWaiter(udpTimeout, func() { d.log.Debugln("wait for initial value") }),
 		values: make(map[sunny.ValueID]interface{}),
 	}
 }

--- a/provider/socket.go
+++ b/provider/socket.go
@@ -61,7 +61,7 @@ func NewSocketProviderFromConfig(other map[string]interface{}) (IntProvider, err
 	p := &Socket{
 		log:     log,
 		Helper:  request.NewHelper(log),
-		mux:     util.NewWaiter(cc.Timeout, func() { log.DEBUG.Println("wait for initial value") }),
+		mux:     util.NewWaiter(cc.Timeout, func() { log.Debugln("wait for initial value") }),
 		url:     url,
 		headers: cc.Headers,
 		scale:   cc.Scale,
@@ -102,7 +102,7 @@ func (p *Socket) listen() {
 	for {
 		client, _, err := websocket.DefaultDialer.Dial(p.url, headers)
 		if err != nil {
-			p.log.ERROR.Println(err)
+			p.log.Errorln(err)
 			time.Sleep(retryDelay)
 			continue
 		}
@@ -110,12 +110,12 @@ func (p *Socket) listen() {
 		for {
 			_, b, err := client.ReadMessage()
 			if err != nil {
-				p.log.TRACE.Println("read:", err)
+				p.log.Traceln("read:", err)
 				_ = client.Close()
 				break
 			}
 
-			p.log.TRACE.Printf("recv: %s", b)
+			p.log.Tracef("recv: %s", b)
 
 			p.mux.Lock()
 			if p.jq != nil {

--- a/provider/socket.go
+++ b/provider/socket.go
@@ -55,7 +55,7 @@ func NewSocketProviderFromConfig(other map[string]interface{}) (IntProvider, err
 
 	url := util.DefaultScheme(cc.URI, "ws")
 	if url != cc.URI {
-		log.WARN.Printf("missing scheme for %s, assuming ws", cc.URI)
+		log.Warnf("missing scheme for %s, assuming ws", cc.URI)
 	}
 
 	p := &Socket{

--- a/provider/socket.go
+++ b/provider/socket.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/jq"
 	"github.com/evcc-io/evcc/util/request"
@@ -19,7 +20,7 @@ const retryDelay = 5 * time.Second
 // Socket implements websocket request provider
 type Socket struct {
 	*request.Helper
-	log     *util.Logger
+	log     api.Logger
 	mux     *util.Waiter
 	url     string
 	headers map[string]string

--- a/push/hub.go
+++ b/push/hub.go
@@ -64,13 +64,13 @@ func (h *Hub) Run(events <-chan Event) {
 
 		title, err := h.apply(ev, definition.Title)
 		if err != nil {
-			log.ERROR.Printf("invalid title template for %s: %v", ev.Event, err)
+			log.Errorf("invalid title template for %s: %v", ev.Event, err)
 			continue
 		}
 
 		msg, err := h.apply(ev, definition.Msg)
 		if err != nil {
-			log.ERROR.Printf("invalid message template for %s: %v", ev.Event, err)
+			log.Errorf("invalid message template for %s: %v", ev.Event, err)
 			continue
 		}
 

--- a/push/pushover.go
+++ b/push/pushover.go
@@ -38,7 +38,7 @@ func (m *PushOver) Send(title, msg string) {
 
 	for _, id := range m.recipients {
 		go func(id string) {
-			log.DEBUG.Printf("pushover: sending to %s", id)
+			log.Debugf("pushover: sending to %s", id)
 
 			recipient := pushover.NewRecipient(id)
 			if _, err := m.app.SendMessage(message, recipient); err != nil {

--- a/push/pushover.go
+++ b/push/pushover.go
@@ -42,7 +42,7 @@ func (m *PushOver) Send(title, msg string) {
 
 			recipient := pushover.NewRecipient(id)
 			if _, err := m.app.SendMessage(message, recipient); err != nil {
-				log.ERROR.Print(err)
+				log.Errorln(err)
 			}
 		}(id)
 	}

--- a/push/shoutrrr.go
+++ b/push/shoutrrr.go
@@ -40,7 +40,7 @@ func (m *Shoutrrr) Send(title, msg string) {
 
 	for _, err := range m.app.Send(msg, params) {
 		if err != nil {
-			log.ERROR.Printf("shoutrrr: %v", err)
+			log.Errorf("shoutrrr: %v", err)
 		}
 	}
 }

--- a/push/telegram.go
+++ b/push/telegram.go
@@ -69,7 +69,7 @@ func (m *Telegram) Send(title, msg string) {
 
 		msg := tgbotapi.NewMessage(chat, msg)
 		if _, err := m.bot.Send(msg); err != nil {
-			log.ERROR.Print(err)
+			log.Errorln(err)
 		}
 	}
 	m.Unlock()

--- a/push/telegram.go
+++ b/push/telegram.go
@@ -21,7 +21,7 @@ type telegramConfig struct {
 
 func init() {
 	if err := tgbotapi.SetLogger(log.ERROR); err != nil {
-		log.ERROR.Printf("telegram: %v", err)
+		log.Errorf("telegram: %v", err)
 	}
 }
 
@@ -54,7 +54,7 @@ func (m *Telegram) trackChats() {
 	for update := range m.bot.GetUpdatesChan(conf) {
 		m.Lock()
 		if _, ok := m.chats[update.Message.Chat.ID]; !ok {
-			log.INFO.Printf("telegram: new chat id: %d", update.Message.Chat.ID)
+			log.Infof("telegram: new chat id: %d", update.Message.Chat.ID)
 			// m.chats[update.Message.Chat.ID] = struct{}{}
 		}
 		m.Unlock()
@@ -65,7 +65,7 @@ func (m *Telegram) trackChats() {
 func (m *Telegram) Send(title, msg string) {
 	m.Lock()
 	for chat := range m.chats {
-		log.DEBUG.Printf("telegram: sending to %d", chat)
+		log.Debugf("telegram: sending to %d", chat)
 
 		msg := tgbotapi.NewMessage(chat, msg)
 		if _, err := m.bot.Send(msg); err != nil {

--- a/server/http.go
+++ b/server/http.go
@@ -53,7 +53,7 @@ func routeLogger(inner http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		inner.ServeHTTP(w, r)
-		log.TRACE.Printf(
+		log.Tracef(
 			"%s\t%s\t%s",
 			r.Method,
 			r.RequestURI,
@@ -82,7 +82,7 @@ func indexHandler(site site.API) http.HandlerFunc {
 			"Commit":     Commit,
 			"Configured": len(site.LoadPoints()),
 		}); err != nil {
-			log.ERROR.Println("httpd: failed to render main page:", err.Error())
+			log.Errorln("httpd: failed to render main page:", err.Error())
 		}
 	})
 }
@@ -98,7 +98,7 @@ func jsonHandler(h http.Handler) http.Handler {
 func jsonResponse(w http.ResponseWriter, r *http.Request, content interface{}) {
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(content); err != nil {
-		log.ERROR.Printf("httpd: failed to encode JSON: %v", err)
+		log.Errorf("httpd: failed to encode JSON: %v", err)
 	}
 }
 

--- a/server/http.go
+++ b/server/http.go
@@ -68,13 +68,13 @@ func indexHandler(site site.API) http.HandlerFunc {
 
 		indexTemplate, err := fs.ReadFile(Assets, "index.html")
 		if err != nil {
-			log.FATAL.Print("httpd: failed to load embedded template:", err.Error())
-			log.FATAL.Fatal("Make sure templates are included using the `release` build tag or use `make build`")
+			log.Errorln("httpd: failed to load embedded template:", err.Error())
+			log.Fatalln("Make sure templates are included using the `release` build tag or use `make build`")
 		}
 
 		t, err := template.New("evcc").Delims("[[", "]]").Parse(string(indexTemplate))
 		if err != nil {
-			log.FATAL.Fatal("httpd: failed to create main page template:", err.Error())
+			log.Fatalln("httpd: failed to create main page template:", err.Error())
 		}
 
 		if err := t.Execute(w, map[string]interface{}{

--- a/server/influxdb.go
+++ b/server/influxdb.go
@@ -79,7 +79,7 @@ func (m *Influx) Run(loadPoints []loadpoint.API, in <-chan util.Param) {
 	// log errors
 	go func() {
 		for err := range writer.Errors() {
-			m.log.ERROR.Println(err)
+			m.log.Errorln(err)
 		}
 	}()
 
@@ -129,7 +129,7 @@ func (m *Influx) Run(loadPoints []loadpoint.API, in <-chan util.Param) {
 		fields["value"] = val
 
 		// write asynchronously
-		m.log.TRACE.Printf("write %s=%v (%v)", param.Key, param.Val, tags)
+		m.log.Tracef("write %s=%v (%v)", param.Key, param.Val, tags)
 		p := influxdb2.NewPoint(param.Key, tags, fields, time.Now())
 		writer.WritePoint(p)
 	}

--- a/server/influxdb.go
+++ b/server/influxdb.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -25,7 +26,7 @@ type InfluxConfig struct {
 // Influx is a influx publisher
 type Influx struct {
 	sync.Mutex
-	log      *util.Logger
+	log      api.Logger
 	client   influxdb2.Client
 	org      string
 	database string

--- a/server/socket.go
+++ b/server/socket.go
@@ -54,7 +54,7 @@ func (c *SocketClient) writePump() {
 func ServeWebsocket(hub *SocketHub, w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.ERROR.Println(err)
+		log.Errorln(err)
 		return
 	}
 	client := &SocketClient{hub: hub, conn: conn, send: make(chan []byte, 256)}

--- a/server/uds.go
+++ b/server/uds.go
@@ -22,7 +22,7 @@ func remoteIfExists(file string) {
 	}
 
 	if err != nil && !os.IsNotExist(err) {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 }
 
@@ -32,7 +32,7 @@ func HealthListener(site site.API) {
 
 	l, err := net.Listen("unix", SocketPath)
 	if err != nil {
-		log.FATAL.Fatal(err)
+		log.Fatalln(err)
 	}
 	defer l.Close()
 

--- a/server/updater/run.go
+++ b/server/updater/run.go
@@ -1,3 +1,4 @@
+//go:build !gokrazy
 // +build !gokrazy
 
 package updater

--- a/server/updater/run.go
+++ b/server/updater/run.go
@@ -4,13 +4,14 @@
 package updater
 
 import (
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/util"
 	"github.com/google/go-github/v32/github"
 )
 
 // Run regularly checks version
-func Run(log *util.Logger, httpd webServer, tee util.TeeAttacher, outChan chan<- util.Param) {
+func Run(log api.Logger, httpd webServer, tee util.TeeAttacher, outChan chan<- util.Param) {
 	u := &watch{
 		log:     log,
 		outChan: outChan,

--- a/server/updater/run_gokrazy.go
+++ b/server/updater/run_gokrazy.go
@@ -1,3 +1,4 @@
+//go:build gokrazy
 // +build gokrazy
 
 package updater
@@ -54,7 +55,7 @@ func (u *watch) updateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := u.execute(assetID, size); err != nil {
-		u.log.ERROR.Printf("could not find release image: %v", err)
+		u.log.Errorf("could not find release image: %v", err)
 
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "update failed: %v", err)

--- a/server/updater/run_gokrazy.go
+++ b/server/updater/run_gokrazy.go
@@ -17,7 +17,7 @@ var (
 )
 
 // Run regularly checks version
-func Run(log *util.Logger, httpd webServer, tee util.TeeAttacher, outChan chan<- util.Param) {
+func Run(log api.Logger, httpd webServer, tee util.TeeAttacher, outChan chan<- util.Param) {
 	u := &watch{
 		log:     log,
 		outChan: outChan,

--- a/server/updater/watch.go
+++ b/server/updater/watch.go
@@ -31,12 +31,12 @@ func (u *watch) watchReleases(installed string, out chan *github.RepositoryRelea
 	for range time.NewTicker(6 * time.Hour).C {
 		rel, err := u.findReleaseUpdate(installed)
 		if err != nil {
-			u.log.ERROR.Printf("version check failed: %v", err)
+			u.log.Errorf("version check failed: %v", err)
 			continue
 		}
 
 		if rel != nil {
-			u.log.INFO.Printf("new version available: %s", *rel.TagName)
+			u.log.Infof("new version available: %s", *rel.TagName)
 			out <- rel
 		}
 	}

--- a/server/updater/watch.go
+++ b/server/updater/watch.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/google/go-github/v32/github"
 	"github.com/gorilla/mux"
@@ -15,7 +16,7 @@ type webServer interface {
 }
 
 type watch struct {
-	log     *util.Logger
+	log     api.Logger
 	outChan chan<- util.Param
 	repo    *Repo
 }

--- a/server/updater/watch.go
+++ b/server/updater/watch.go
@@ -80,6 +80,6 @@ func (u *watch) fetchReleaseNotes(installed string) {
 			Val: notes,
 		}
 	} else {
-		u.log.WARN.Printf("couldn't download release notes: %v", err)
+		u.log.Warnf("couldn't download release notes: %v", err)
 	}
 }

--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -14,7 +14,7 @@ import (
 
 type Awattar struct {
 	mux   sync.Mutex
-	log   *util.Logger
+	log   api.Logger
 	uri   string
 	cheap float64
 	data  []awattar.PriceInfo

--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -51,7 +51,7 @@ func (t *Awattar) Run() {
 	for ; true; <-time.NewTicker(time.Hour).C {
 		var res awattar.Prices
 		if err := client.GetJSON(t.uri, &res); err != nil {
-			t.log.ERROR.Println(err)
+			t.log.Errorln(err)
 			continue
 		}
 

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -87,7 +87,7 @@ func (t *Tibber) Run() {
 		}
 
 		if err := t.client.Query(context.Background(), &res, v); err != nil {
-			t.log.ERROR.Println(err)
+			t.log.Errorln(err)
 			continue
 		}
 

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -16,7 +16,7 @@ import (
 
 type Tibber struct {
 	mux    sync.Mutex
-	log    *util.Logger
+	log    api.Logger
 	Token  string
 	HomeID string
 	Cheap  float64

--- a/util/cache.go
+++ b/util/cache.go
@@ -22,7 +22,7 @@ func (c *Cache) Run(in <-chan Param) {
 	log := NewLogger("cache")
 
 	for p := range in {
-		log.DEBUG.Printf("%s: %v", p.Key, p.Val)
+		log.Debugf("%s: %v", p.Key, p.Val)
 		c.Add(p.UniqueID(), p)
 	}
 }

--- a/util/log.go
+++ b/util/log.go
@@ -32,7 +32,6 @@ var LogAreaPadding = 6
 // Logger wraps a jww notepad to avoid leaking implementation detail
 type Logger struct {
 	*jww.Notepad
-	name string
 }
 
 // NewLogger creates a logger with the given log area and adds it to the registry
@@ -54,7 +53,6 @@ func NewLogger(area string) *Logger {
 
 	logger := &Logger{
 		Notepad: notepad,
-		name:    area,
 	}
 	loggers[area] = logger
 	return logger
@@ -109,11 +107,6 @@ func (l *Logger) Fatalf(format string, v ...interface{}) {
 
 func (l *Logger) Fatalln(v ...interface{}) {
 	l.FATAL.Fatalln(v...)
-}
-
-// Name returns the loggers name
-func (l *Logger) Name() string {
-	return l.name
 }
 
 // Loggers invokes callback for each configured logger

--- a/util/log.go
+++ b/util/log.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/evcc-io/evcc/api"
 	jww "github.com/spf13/jwalterweatherman"
 )
 
@@ -59,6 +60,9 @@ func NewLogger(area string) *Logger {
 	return logger
 }
 
+// implement api.Logger
+var _ api.Logger = (*Logger)(nil)
+
 func (l *Logger) Tracef(format string, v ...interface{}) {
 	l.TRACE.Printf(format, v...)
 }
@@ -81,6 +85,14 @@ func (l *Logger) Infof(format string, v ...interface{}) {
 
 func (l *Logger) Infoln(v ...interface{}) {
 	l.INFO.Println(v...)
+}
+
+func (l *Logger) Warnf(format string, v ...interface{}) {
+	l.WARN.Printf(format, v...)
+}
+
+func (l *Logger) Warnln(v ...interface{}) {
+	l.WARN.Println(v...)
 }
 
 func (l *Logger) Errorf(format string, v ...interface{}) {

--- a/util/log.go
+++ b/util/log.go
@@ -59,6 +59,46 @@ func NewLogger(area string) *Logger {
 	return logger
 }
 
+func (l *Logger) Tracef(format string, v ...interface{}) {
+	l.TRACE.Printf(format, v...)
+}
+
+func (l *Logger) Traceln(v ...interface{}) {
+	l.TRACE.Println(v...)
+}
+
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	l.DEBUG.Printf(format, v...)
+}
+
+func (l *Logger) Debugln(v ...interface{}) {
+	l.DEBUG.Println(v...)
+}
+
+func (l *Logger) Infof(format string, v ...interface{}) {
+	l.INFO.Printf(format, v...)
+}
+
+func (l *Logger) Infoln(v ...interface{}) {
+	l.INFO.Println(v...)
+}
+
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	l.ERROR.Printf(format, v...)
+}
+
+func (l *Logger) Errorln(v ...interface{}) {
+	l.ERROR.Println(v...)
+}
+
+func (l *Logger) Fatalf(format string, v ...interface{}) {
+	l.FATAL.Fatalf(format, v...)
+}
+
+func (l *Logger) Fatalln(v ...interface{}) {
+	l.FATAL.Fatalln(v...)
+}
+
 // Name returns the loggers name
 func (l *Logger) Name() string {
 	return l.name

--- a/util/request/helper.go
+++ b/util/request/helper.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 )
 
 // Timeout is the default request timeout used by the Helper
@@ -17,7 +17,7 @@ type Helper struct {
 }
 
 // NewHelper creates http helper for simplified PUT GET logic
-func NewHelper(log *util.Logger) *Helper {
+func NewHelper(log api.Logger) *Helper {
 	r := &Helper{
 		Client: &http.Client{
 			Timeout:   Timeout,

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type roundTripper struct {
-	log  *util.Logger
+	log  api.Logger
 	base http.RoundTripper
 }
 
@@ -50,7 +50,7 @@ func init() {
 }
 
 // NewTripper creates a logging roundtrip handler
-func NewTripper(log *util.Logger, base http.RoundTripper) http.RoundTripper {
+func NewTripper(log api.Logger, base http.RoundTripper) http.RoundTripper {
 	tripper := &roundTripper{
 		log:  log,
 		base: base,

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -67,7 +67,7 @@ func min(a, b int) int {
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	r.log.TRACE.Printf("%s %s", req.Method, req.URL.String())
+	r.log.Tracef("%s %s", req.Method, req.URL.String())
 
 	var bld strings.Builder
 	if body, err := httputil.DumpRequestOut(req, true); err == nil {
@@ -92,7 +92,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if bld.Len() > 0 {
-		r.log.TRACE.Println(bld.String())
+		r.log.Traceln(bld.String())
 	}
 
 	return resp, err

--- a/vehicle/audi.go
+++ b/vehicle/audi.go
@@ -70,7 +70,7 @@ func NewAudiFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/audi/api.go
+++ b/vehicle/audi/api.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -22,7 +22,7 @@ type API struct {
 }
 
 // NewAPI creates a new api client
-func NewAPI(log *util.Logger, identity oauth2.TokenSource, brand, country string) *API {
+func NewAPI(log api.Logger, identity oauth2.TokenSource, brand, country string) *API {
 	v := &API{
 		Helper:  request.NewHelper(log),
 		brand:   brand,

--- a/vehicle/bluelink/api.go
+++ b/vehicle/bluelink/api.go
@@ -170,7 +170,7 @@ func (v *API) refreshRequest(vid string) error {
 		go func() {
 			var resp StatusResponse
 			if err := v.DoJSON(req, &resp); err == nil && resp.RetCode != resOK {
-				v.log.ERROR.Printf("unexpected response: %s", resp.RetCode)
+				v.log.Errorf("unexpected response: %s", resp.RetCode)
 			}
 		}()
 	}

--- a/vehicle/bluelink/api.go
+++ b/vehicle/bluelink/api.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 )
 
@@ -32,14 +31,14 @@ var ErrAuthFail = errors.New("authorization failed")
 // Based on https://github.com/Hacksore/bluelinky.
 type API struct {
 	*request.Helper
-	log         *util.Logger
+	log         api.Logger
 	identity    *Identity
 	refresh     bool
 	refreshTime time.Time
 }
 
 // New creates a new BlueLink API
-func NewAPI(log *util.Logger, identity *Identity, cache time.Duration) *API {
+func NewAPI(log api.Logger, identity *Identity, cache time.Duration) *API {
 	v := &API{
 		log:      log,
 		identity: identity,

--- a/vehicle/bluelink/identity.go
+++ b/vehicle/bluelink/identity.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/google/uuid"
@@ -39,14 +39,14 @@ type Config struct {
 // Based on https://github.com/Hacksore/bluelinky.
 type Identity struct {
 	*request.Helper
-	log      *util.Logger
+	log      api.Logger
 	config   Config
 	deviceID string
 	oauth2.TokenSource
 }
 
 // NewIdentity creates BlueLink Identity
-func NewIdentity(log *util.Logger, config Config) (*Identity, error) {
+func NewIdentity(log api.Logger, config Config) (*Identity, error) {
 	v := &Identity{
 		log:    log,
 		Helper: request.NewHelper(log),

--- a/vehicle/bluelink/stamps.go
+++ b/vehicle/bluelink/stamps.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 )
@@ -38,7 +39,7 @@ var (
 	}
 )
 
-func download(log *util.Logger, id, brand string) {
+func download(log api.Logger, id, brand string) {
 	var res []string
 	uri := fmt.Sprintf("https://raw.githubusercontent.com/neoPix/bluelinky-stamps/master/%s.json", brand)
 
@@ -58,7 +59,7 @@ func download(log *util.Logger, id, brand string) {
 }
 
 // updateStamps updates stamps according to https://github.com/Hacksore/bluelinky/pull/144
-func updateStamps(log *util.Logger, id string) {
+func updateStamps(log api.Logger, id string) {
 	if _, ok := updater[id]; ok {
 		return
 	}

--- a/vehicle/bluelink/stamps.go
+++ b/vehicle/bluelink/stamps.go
@@ -44,7 +44,7 @@ func download(log *util.Logger, id, brand string) {
 
 	err := client.GetJSON(uri, &res)
 	if err != nil {
-		log.ERROR.Println(err)
+		log.Errorln(err)
 		return
 	}
 

--- a/vehicle/bmw.go
+++ b/vehicle/bmw.go
@@ -51,7 +51,7 @@ func NewBMWFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/bmw/api.go
+++ b/vehicle/bmw/api.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -39,7 +39,7 @@ type API struct {
 }
 
 // NewAPI creates a new vehicle
-func NewAPI(log *util.Logger, identity oauth2.TokenSource) *API {
+func NewAPI(log api.Logger, identity oauth2.TokenSource) *API {
 	v := &API{
 		Helper: request.NewHelper(log),
 	}

--- a/vehicle/bmw/identity.go
+++ b/vehicle/bmw/identity.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
@@ -18,13 +18,13 @@ const AuthURI = "https://customer.bmwgroup.com/gcdm/oauth/authenticate"
 
 type Identity struct {
 	*request.Helper
-	log *util.Logger
+	log api.Logger
 	oauth2.TokenSource
 	user, password string
 }
 
 // NewIdentity creates BMW identity
-func NewIdentity(log *util.Logger) *Identity {
+func NewIdentity(log api.Logger) *Identity {
 	v := &Identity{
 		log:    log,
 		Helper: request.NewHelper(log),

--- a/vehicle/carwings.go
+++ b/vehicle/carwings.go
@@ -91,7 +91,7 @@ func NewCarWingsFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	v.wg.Add(1)
 	go func() {
 		if err := v.session.Connect(v.user, v.password); err != nil {
-			log.ERROR.Println("login failed:", err)
+			log.Errorln("login failed:", err)
 		}
 		v.wg.Done()
 	}()

--- a/vehicle/enyaq.go
+++ b/vehicle/enyaq.go
@@ -69,7 +69,7 @@ func NewEnyaqFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/fiat.go
+++ b/vehicle/fiat.go
@@ -60,7 +60,7 @@ func NewFiatFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/fiat/api.go
+++ b/vehicle/fiat/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 )
@@ -26,7 +27,7 @@ type API struct {
 	*request.Helper
 }
 
-func NewAPI(log *util.Logger, identity *Identity) *API {
+func NewAPI(log api.Logger, identity *Identity) *API {
 	api := &API{
 		identity: identity,
 		Helper:   request.NewHelper(log),

--- a/vehicle/fiat/identity.go
+++ b/vehicle/fiat/identity.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 )
@@ -33,7 +34,7 @@ type Identity struct {
 }
 
 // NewIdentity creates Fiat identity
-func NewIdentity(log *util.Logger, user, password string) *Identity {
+func NewIdentity(log api.Logger, user, password string) *Identity {
 	return &Identity{
 		Helper:   request.NewHelper(log),
 		user:     user,

--- a/vehicle/ford.go
+++ b/vehicle/ford.go
@@ -82,7 +82,7 @@ func NewFordFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if err == nil && cc.VIN == "" {
 		v.vin, err = findVehicle(v.vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", v.vin)
+			log.Debugf("found vehicle: %v", v.vin)
 		}
 	}
 
@@ -218,7 +218,7 @@ func (v *Ford) status() (res fordVehicleStatus, err error) {
 		lastUpdate, err = time.Parse(fordTimeFormat, res.VehicleStatus.LastRefresh)
 
 		if elapsed := time.Since(lastUpdate); err == nil && elapsed > fordStatusExpiry {
-			v.log.DEBUG.Printf("vehicle status is outdated (age %v > %v), requesting refresh", elapsed, fordStatusExpiry)
+			v.log.Debugf("vehicle status is outdated (age %v > %v), requesting refresh", elapsed, fordStatusExpiry)
 
 			if err = v.refreshRequest(); err == nil {
 				err = api.ErrMustRetry

--- a/vehicle/ford.go
+++ b/vehicle/ford.go
@@ -29,7 +29,7 @@ const (
 type Ford struct {
 	*embed
 	*request.Helper
-	log                 *util.Logger
+	log                 api.Logger
 	user, password, vin string
 	tokenSource         oauth2.TokenSource
 	statusG             func() (interface{}, error)

--- a/vehicle/hyundai.go
+++ b/vehicle/hyundai.go
@@ -68,7 +68,7 @@ func NewHyundaiFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	var vehicle bluelink.Vehicle
 	if cc.VIN == "" && len(vehicles) == 1 {
 		vehicle = vehicles[0]
-		log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+		log.Debugf("found vehicle: %v", cc.VIN)
 	} else {
 		for _, v := range vehicles {
 			if v.VIN == strings.ToUpper(cc.VIN) {

--- a/vehicle/id.go
+++ b/vehicle/id.go
@@ -66,7 +66,7 @@ func NewIDFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/id/api.go
+++ b/vehicle/id/api.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -34,7 +34,7 @@ const (
 )
 
 // NewAPI creates a new vehicle
-func NewAPI(log *util.Logger, identity oauth2.TokenSource) *API {
+func NewAPI(log api.Logger, identity oauth2.TokenSource) *API {
 	v := &API{
 		Helper: request.NewHelper(log),
 	}

--- a/vehicle/id/refresh.go
+++ b/vehicle/id/refresh.go
@@ -3,7 +3,7 @@ package id
 import (
 	"net/http"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
@@ -14,7 +14,7 @@ type tokenRefresher struct {
 	login func() (Token, error)
 }
 
-func Refresher(log *util.Logger, login func() (Token, error)) oauth.TokenRefresher {
+func Refresher(log api.Logger, login func() (Token, error)) oauth.TokenRefresher {
 	return &tokenRefresher{
 		Helper: request.NewHelper(log),
 		login:  login,

--- a/vehicle/kia.go
+++ b/vehicle/kia.go
@@ -68,7 +68,7 @@ func NewKiaFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	var vehicle bluelink.Vehicle
 	if cc.VIN == "" && len(vehicles) == 1 {
 		vehicle = vehicles[0]
-		log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+		log.Debugf("found vehicle: %v", cc.VIN)
 	} else {
 		for _, v := range vehicles {
 			if v.VIN == strings.ToUpper(cc.VIN) {

--- a/vehicle/nissan.go
+++ b/vehicle/nissan.go
@@ -59,7 +59,7 @@ func NewNissanFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		api.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", api.VIN)
+			log.Debugf("found vehicle: %v", api.VIN)
 		}
 	}
 

--- a/vehicle/nissan/api.go
+++ b/vehicle/nissan/api.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -24,7 +23,7 @@ type API struct {
 	refreshTime time.Time
 }
 
-func NewAPI(log *util.Logger, identity oauth2.TokenSource, vin string) *API {
+func NewAPI(log api.Logger, identity oauth2.TokenSource, vin string) *API {
 	v := &API{
 		Helper: request.NewHelper(log),
 		VIN:    vin,

--- a/vehicle/nissan/identity.go
+++ b/vehicle/nissan/identity.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/avast/retry-go/v3"
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
@@ -19,7 +19,7 @@ type Identity struct {
 }
 
 // NewIdentity creates Nissan identity
-func NewIdentity(log *util.Logger) *Identity {
+func NewIdentity(log api.Logger) *Identity {
 	return &Identity{
 		Helper: request.NewHelper(log),
 	}

--- a/vehicle/porsche/identity.go
+++ b/vehicle/porsche/identity.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	cv "github.com/nirasan/go-oauth-pkce-code-verifier"
 	"golang.org/x/net/publicsuffix"
@@ -34,13 +34,13 @@ type AccessTokens struct {
 
 // Identity is the Porsche Identity client
 type Identity struct {
-	log *util.Logger
+	log api.Logger
 	*request.Helper
 	user, password string
 }
 
 // NewIdentity creates Porsche identity
-func NewIdentity(log *util.Logger, user, password string) *Identity {
+func NewIdentity(log api.Logger, user, password string) *Identity {
 	v := &Identity{
 		log:      log,
 		Helper:   request.NewHelper(log),

--- a/vehicle/porsche/identity.go
+++ b/vehicle/porsche/identity.go
@@ -235,7 +235,7 @@ func (v *Identity) FindVehicle(accessTokens AccessTokens, vin string) (Vehicle, 
 		}
 
 		if foundVehicle.VIN != "" {
-			v.log.DEBUG.Printf("found vehicle: %v", foundVehicle.VIN)
+			v.log.Debugf("found vehicle: %v", foundVehicle.VIN)
 
 			if accessTokens.EmobilityToken.AccessToken != "" {
 				foundEmobilityVehicle = true

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider"
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -35,7 +34,7 @@ type StatusResponse struct {
 
 // Provider is an api.Vehicle implementation for Porsche PHEV cars
 type Provider struct {
-	log *util.Logger
+	log api.Logger
 	*request.Helper
 	token    oauth2.Token
 	identity *Identity
@@ -43,7 +42,7 @@ type Provider struct {
 }
 
 // NewProvider creates a new vehicle
-func NewProvider(log *util.Logger, identity *Identity, token oauth2.Token, vin string, cache time.Duration) *Provider {
+func NewProvider(log api.Logger, identity *Identity, token oauth2.Token, vin string, cache time.Duration) *Provider {
 	impl := &Provider{
 		log:      log,
 		Helper:   request.NewHelper(log),

--- a/vehicle/porsche/provider_emobility.go
+++ b/vehicle/porsche/provider_emobility.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider"
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -68,7 +67,7 @@ type EmobilityResponse struct {
 
 // EMobilityProvider is an api.Vehicle implementation for Porsche Taycan cars
 type EMobilityProvider struct {
-	log *util.Logger
+	log api.Logger
 	*request.Helper
 	token    oauth2.Token
 	identity *Identity
@@ -77,7 +76,7 @@ type EMobilityProvider struct {
 }
 
 // NewEMobilityProvider creates a new vehicle
-func NewEMobilityProvider(log *util.Logger, identity *Identity, token oauth2.Token, vin string, cache time.Duration) *EMobilityProvider {
+func NewEMobilityProvider(log api.Logger, identity *Identity, token oauth2.Token, vin string, cache time.Duration) *EMobilityProvider {
 	impl := &EMobilityProvider{
 		log:      log,
 		token:    token,

--- a/vehicle/psa.go
+++ b/vehicle/psa.go
@@ -63,7 +63,7 @@ type PSA struct {
 }
 
 // newPSA creates a new vehicle
-func newPSA(log *util.Logger, brand, realm, id, secret string, other map[string]interface{}) (api.Vehicle, error) {
+func newPSA(log api.Logger, brand, realm, id, secret string, other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
 		embed               `mapstructure:",squash"`
 		Credentials         ClientCredentials

--- a/vehicle/psa/api.go
+++ b/vehicle/psa/api.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -24,7 +24,7 @@ type API struct {
 }
 
 // NewAPI creates a new vehicle
-func NewAPI(log *util.Logger, identity oauth2.TokenSource, realm, id string) *API {
+func NewAPI(log api.Logger, identity oauth2.TokenSource, realm, id string) *API {
 	v := &API{
 		Helper: request.NewHelper(log),
 		realm:  realm,

--- a/vehicle/psa/identity.go
+++ b/vehicle/psa/identity.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -16,7 +16,7 @@ type Identity struct {
 }
 
 // NewIdentity creates PSA identity
-func NewIdentity(log *util.Logger, brand, id, secret string) *Identity {
+func NewIdentity(log api.Logger, brand, id, secret string) *Identity {
 	return &Identity{
 		Helper: request.NewHelper(log),
 		oc: &oauth2.Config{

--- a/vehicle/renault.go
+++ b/vehicle/renault.go
@@ -146,7 +146,7 @@ func NewRenaultFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if err == nil && cc.VIN == "" {
 		v.vin, err = findVehicle(v.kamereonVehicles(v.accountID))
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", v.vin)
+			log.Debugf("found vehicle: %v", v.vin)
 		}
 	}
 

--- a/vehicle/seat.go
+++ b/vehicle/seat.go
@@ -66,7 +66,7 @@ func NewSeatFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/skoda.go
+++ b/vehicle/skoda.go
@@ -66,7 +66,7 @@ func NewSkodaFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/skoda/api.go
+++ b/vehicle/skoda/api.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -17,7 +17,7 @@ type API struct {
 }
 
 // NewAPI creates a new api client
-func NewAPI(log *util.Logger, identity oauth2.TokenSource) *API {
+func NewAPI(log api.Logger, identity oauth2.TokenSource) *API {
 	v := &API{
 		Helper: request.NewHelper(log),
 	}

--- a/vehicle/skoda/refresh.go
+++ b/vehicle/skoda/refresh.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
@@ -16,7 +16,7 @@ type tokenRefresher struct {
 	login func() (oauth.Token, error)
 }
 
-func Refresher(log *util.Logger, login func() (oauth.Token, error)) oauth.TokenRefresher {
+func Refresher(log api.Logger, login func() (oauth.Token, error)) oauth.TokenRefresher {
 	return &tokenRefresher{
 		Helper: request.NewHelper(log),
 		login:  login,

--- a/vehicle/tronity.go
+++ b/vehicle/tronity.go
@@ -39,7 +39,7 @@ import (
 type Tronity struct {
 	*embed
 	*request.Helper
-	log   *util.Logger
+	log   api.Logger
 	oc    *oauth2.Config
 	vid   string
 	bulkG func() (interface{}, error)

--- a/vehicle/volvo.go
+++ b/vehicle/volvo.go
@@ -124,7 +124,7 @@ func NewVolvoFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		v.vin, err = findVehicle(v.vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", v.vin)
+			log.Debugf("found vehicle: %v", v.vin)
 		}
 	}
 

--- a/vehicle/vw.go
+++ b/vehicle/vw.go
@@ -66,7 +66,7 @@ func NewVWFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	if cc.VIN == "" {
 		cc.VIN, err = findVehicle(api.Vehicles())
 		if err == nil {
-			log.DEBUG.Printf("found vehicle: %v", cc.VIN)
+			log.Debugf("found vehicle: %v", cc.VIN)
 		}
 	}
 

--- a/vehicle/vw/api.go
+++ b/vehicle/vw/api.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -25,7 +25,7 @@ type API struct {
 }
 
 // NewAPI creates a new api client
-func NewAPI(log *util.Logger, identity oauth2.TokenSource, brand, country string) *API {
+func NewAPI(log api.Logger, identity oauth2.TokenSource, brand, country string) *API {
 	v := &API{
 		Helper:  request.NewHelper(log),
 		brand:   brand,

--- a/vehicle/vw/identity.go
+++ b/vehicle/vw/identity.go
@@ -119,7 +119,7 @@ func (v *Identity) login(uri, user, password string) (url.Values, error) {
 			}
 
 			if u := resp.Request.URL.Query().Get("updated"); err == nil && u != "" {
-				v.log.WARN.Println("accepting updated", u)
+				v.log.Warnln("accepting updated", u)
 				if resp, err = v.postTos(resp.Request.URL.String()); err == nil {
 					resp.Body.Close()
 				}

--- a/vehicle/vw/identity.go
+++ b/vehicle/vw/identity.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
@@ -36,13 +37,13 @@ const (
 
 // Identity provides the identity.vwgroup.io login token source
 type Identity struct {
-	log *util.Logger
+	log api.Logger
 	*request.Helper
 	oauth2.TokenSource
 }
 
 // NewIdentity creates VW identity
-func NewIdentity(log *util.Logger) *Identity {
+func NewIdentity(log api.Logger) *Identity {
 	v := &Identity{
 		log:    log,
 		Helper: request.NewHelper(log),

--- a/vehicle/vw/refresh.go
+++ b/vehicle/vw/refresh.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
@@ -17,7 +17,7 @@ type tokenRefresher struct {
 	clientID string
 }
 
-func Refresher(log *util.Logger, login func() (oauth.Token, error), clientID string) oauth.TokenRefresher {
+func Refresher(log api.Logger, login func() (oauth.Token, error), clientID string) oauth.TokenRefresher {
 	return &tokenRefresher{
 		Helper:   request.NewHelper(log),
 		login:    login,


### PR DESCRIPTION
Refs #1492, #1493 

Remaining points:
- [ ] finalize method naming (`ln` vs `f`)
- [ ] change structured logger params to interfaces
- [ ] add simple logger
- [ ] replace structured with simple logger where sufficient as param and when creating logger