### PR TITLE
Make the underscore javascript lib available

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ All possible values can be found as const [here](https://gitlab.com/bboehmke/sun
 
 ### Javascript (read/write)
 
-EVCC includes a bundled Javascript interpreter with Underscore.js library installed. The `js` plugin is able to execute Javascript code from the `script` tag. Useful for quick prototyping:
+EVCC includes a bundled Javascript interpreter with Underscore.js library installed, which is directly accessible via `_.` e.g. `_.random(0,5)`. The `js` plugin is able to execute Javascript code from the `script` tag. Useful for quick prototyping:
 
 ```yaml
 source: js

--- a/provider/javascript/init.go
+++ b/provider/javascript/init.go
@@ -3,6 +3,7 @@ package javascript
 import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/robertkrimen/otto"
+	_ "github.com/robertkrimen/otto/underscore"
 )
 
 // Configure initializes JS VMs


### PR DESCRIPTION
This change is required to actually use the underscore javascript library, as documented here: https://github.com/robertkrimen/otto#underscore