### PR TITLE
Limit requesting EV identification

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -32,7 +32,7 @@ type EEBus struct {
 	connected           bool
 	expectedEnableState bool
 
-	timestampEVConnected time.Time
+	evConnectedTime time.Time
 }
 
 func init() {
@@ -208,10 +208,10 @@ func (c *EEBus) Status() (api.ChargeStatus, error) {
 
 	switch currentState {
 	case communication.EVChargeStateEnumTypeUnknown:
-		c.timestampEVConnected = time.Now()
+		c.evConnectedTime = time.Now()
 		return api.StatusA, nil
 	case communication.EVChargeStateEnumTypeUnplugged: // Unplugged
-		c.timestampEVConnected = time.Now()
+		c.evConnectedTime = time.Now()
 		return api.StatusA, nil
 	case communication.EVChargeStateEnumTypeFinished, communication.EVChargeStateEnumTypePaused: // Finished, Paused
 		return api.StatusB, nil
@@ -500,7 +500,7 @@ func (c *EEBus) Identify() (string, error) {
 		return "", nil
 	}
 
-	if time.Since(c.timestampEVConnected) < maxIdRequestTimespan {
+	if time.Since(c.evConnectedTime) < maxIdRequestTimespan {
 		c.log.TRACE.Printf("!! identify: returning nothing, retry")
 		return "", api.ErrMustRetry
 	}

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -16,7 +16,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 )
 
-const maxIdRequestAttempts = 20
+const maxIdRequestAttempts = 10
 
 type EEBus struct {
 	log           *util.Logger


### PR DESCRIPTION
If the EEBUS EVSE doesn't provide an identification we retry endlessly. The problem is that getting the identification from the EV is not instant and could take 1-2 minutes after it is connected. Also if there are network issues, the EVSE doesn't provide the identification it previously had.

So instead of requesting the identification value endlessly, we limit it to a maximum count.