### PR TITLE
Enable cache option for http meters

### DIFF
--- a/meter/discovergy.go
+++ b/meter/discovergy.go
@@ -3,7 +3,6 @@ package meter
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider"
@@ -31,7 +30,6 @@ func NewDiscovergyFromConfig(other map[string]interface{}) (api.Meter, error) {
 		Password string
 		Meter    string
 		Scale    float64
-		Cache    time.Duration
 	}{
 		Scale: 1,
 	}

--- a/meter/discovergy.go
+++ b/meter/discovergy.go
@@ -3,6 +3,7 @@ package meter
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider"
@@ -30,8 +31,10 @@ func NewDiscovergyFromConfig(other map[string]interface{}) (api.Meter, error) {
 		Password string
 		Meter    string
 		Scale    float64
+		Cache    time.Duration
 	}{
 		Scale: 1,
+		Cache: 0,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -78,7 +81,7 @@ func NewDiscovergyFromConfig(other map[string]interface{}) (api.Meter, error) {
 	}
 
 	uri := fmt.Sprintf("%s/last_reading?meterId=%s", discovergyAPI, meterID)
-	power, err := provider.NewHTTP(log, http.MethodGet, uri, headers, "", false, "", ".values.power", 0.001*cc.Scale)
+	power, err := provider.NewHTTP(log, http.MethodGet, uri, headers, "", false, "", ".values.power", 0.001*cc.Scale, cc.Cache)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/discovergy.go
+++ b/meter/discovergy.go
@@ -34,7 +34,6 @@ func NewDiscovergyFromConfig(other map[string]interface{}) (api.Meter, error) {
 		Cache    time.Duration
 	}{
 		Scale: 1,
-		Cache: 0,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -81,7 +80,7 @@ func NewDiscovergyFromConfig(other map[string]interface{}) (api.Meter, error) {
 	}
 
 	uri := fmt.Sprintf("%s/last_reading?meterId=%s", discovergyAPI, meterID)
-	power, err := provider.NewHTTP(log, http.MethodGet, uri, headers, "", false, "", ".values.power", 0.001*cc.Scale, cc.Cache)
+	power, err := provider.NewHTTP(log, http.MethodGet, uri, headers, "", false, "", ".values.power", 0.001*cc.Scale, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/http.go
+++ b/provider/http.go
@@ -147,7 +147,7 @@ func NewHTTP(log *util.Logger, method, uri string, headers map[string]string, bo
 	return p, nil
 }
 
-// request executes the configured request or is returns the cached value
+// request executes the configured request or returns the cached value
 func (p *HTTP) request(body ...string) ([]byte, error) {
 
 	if time.Since(p.updated) > p.cache {

--- a/provider/http.go
+++ b/provider/http.go
@@ -199,23 +199,23 @@ func (p *HTTP) StringGetter() func() (string, error) {
 		if time.Since(p.updated) > p.cache {
 			p.val, p.err = p.request()
 			p.updated = time.Now()
+		}
 
-			if p.err != nil {
-				return string(p.val), p.err
-			}
+		if p.err != nil {
+			return string(p.val), p.err
+		}
 
-			if p.re != nil {
-				m := p.re.FindSubmatch(p.val)
-				if len(m) > 1 {
-					p.val = m[1] // first submatch
-				}
+		if p.re != nil {
+			m := p.re.FindSubmatch(p.val)
+			if len(m) > 1 {
+				p.val = m[1] // first submatch
 			}
+		}
 
-			if p.jq != nil {
-				v, err := jq.Query(p.jq, p.val)
-				p.err = err
-				return fmt.Sprintf("%v", v), p.err
-			}
+		if p.jq != nil {
+			v, err := jq.Query(p.jq, p.val)
+			p.err = err
+			return fmt.Sprintf("%v", v), p.err
 		}
 		return string(p.val), p.err
 	}

--- a/provider/http.go
+++ b/provider/http.go
@@ -149,7 +149,7 @@ func NewHTTP(log *util.Logger, method, uri string, headers map[string]string, bo
 
 // request executes the configured request or returns the cached value
 func (p *HTTP) request(body ...string) ([]byte, error) {
-	if time.Since(p.updated) > p.cache {
+	if time.Since(p.updated) >= p.cache {
 		var b io.Reader
 		if len(body) == 1 {
 			b = strings.NewReader(body[0])

--- a/provider/http.go
+++ b/provider/http.go
@@ -149,7 +149,6 @@ func NewHTTP(log *util.Logger, method, uri string, headers map[string]string, bo
 
 // request executes the configured request or returns the cached value
 func (p *HTTP) request(body ...string) ([]byte, error) {
-
 	if time.Since(p.updated) > p.cache {
 		var b io.Reader
 		if len(body) == 1 {


### PR DESCRIPTION
Enable cache option for http meters.
In case cache parameter is not set in evcc.yaml the module behaves like before.
PR was introduced to cope with a newly activated Web API limit for Solax inverters.

Solax support info:
![image](https://user-images.githubusercontent.com/77847348/134323125-f36bd213-6391-4a7f-bda7-90ddd2ccbaf3.png)
