### PR TITLE
call actions right on set vehicle with vehicle identifier

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -714,6 +714,11 @@ func (lp *LoadPoint) setActiveVehicle(vehicle api.Vehicle) {
 		lp.publish("hasVehicle", true)
 		lp.publish("socTitle", lp.vehicle.Title())
 		lp.publish("socCapacity", lp.vehicle.Capacity())
+
+		if action, ok := lp.OnIdentify[lp.vehicle.Identify()]; ok {
+			lp.log.DEBUG.Println("running vehicle action:", action)
+			lp.applyAction(action)
+		}
 	} else {
 		lp.socEstimator = nil
 


### PR DESCRIPTION
Wird der Branch feature/actions noch weiterentwickelt? Finde die Idee sehr gut.

Im aktuellen Stand werden die Actions nur ausgeführt, wenn per Charger das Vehicle über ein RFID gesetzt wird.

Fände es aber auch interessant, wenn die Actions beim setActiveVehicle mit der erkannten Vehicle Identity ausgeführt werden.

Für mich sind das Setzen des maximalen Stroms und des TargetSoC interessant. Der zweite Wert ist durch die Fahrzeuge (ZOE und Smart ED) interessant, da der Smart ED durch das nicht "perfekte" BMS eher auf 100% geladen werden sollte. Wenn bei <40% nur eine Teilladung gemacht wird, dann kommt das BMS durcheinander.