### PR TITLE
Add option to limit network interfaces for eebus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dylanmei/iso8601 v0.1.0
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/evcc-io/config v0.0.0-20210930111050-37df6f7e52b8
-	github.com/evcc-io/eebus v0.0.0-20210928080925-1829ea71928f
+	github.com/evcc-io/eebus v0.0.0-20211002143419-1336d099b84c
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/fatih/structs v1.1.0
 	github.com/go-ping/ping v0.0.0-20210506233800-ff8be3320020

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evcc-io/config v0.0.0-20210930111050-37df6f7e52b8 h1:kfrzL89jpU+1fQ8Kyd3r9UI6wJ1KAABsFI0DrIR++/Q=
 github.com/evcc-io/config v0.0.0-20210930111050-37df6f7e52b8/go.mod h1:aN5D6PVnoFvfZSMScvAQAIYRXwWOZ9lde3J0lsNRIOM=
-github.com/evcc-io/eebus v0.0.0-20210928080925-1829ea71928f h1:jORYK0uKT+jJtpUxOZ8+cVLXKPASXioUPS9bnHNQfoA=
-github.com/evcc-io/eebus v0.0.0-20210928080925-1829ea71928f/go.mod h1:2fJZDu2dSe7M6m+KIYkG5XPdk+Ws1ckuRyklZRvFzWE=
+github.com/evcc-io/eebus v0.0.0-20211002143419-1336d099b84c h1:8G209dbZPMz79/A0oocEXqIqx9IN3VwE9oHCKUEJ2Rw=
+github.com/evcc-io/eebus v0.0.0-20211002143419-1336d099b84c/go.mod h1:2fJZDu2dSe7M6m+KIYkG5XPdk+Ws1ckuRyklZRvFzWE=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/server/eebus.go
+++ b/server/eebus.go
@@ -41,6 +41,7 @@ func NewEEBus(other map[string]interface{}) (*EEBus, error) {
 	cc := struct {
 		Uri         string
 		ShipID      string
+		Interfaces  []string
 		Certificate struct {
 			Public, Private []byte
 		}
@@ -75,6 +76,7 @@ func NewEEBus(other map[string]interface{}) (*EEBus, error) {
 		Path:        "/ship/",
 		Certificate: cert,
 		ID:          id,
+		Interfaces:  cc.Interfaces,
 		Brand:       details.BrandName,
 		Model:       details.DeviceCode,
 		Type:        string(model.DeviceTypeEnumTypeEnergyManagementSystem),


### PR DESCRIPTION
The `eebus` configuration now has an option `interfaces` which expects a list of network interface names. The EEBUS Server will then only use this network interface for connections to clients