### PR TITLE
HTTP: add digest auth

### DIFF
--- a/provider/http.go
+++ b/provider/http.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"encoding/base64"
 	"fmt"
 	"io"
 	"math"
@@ -14,6 +13,7 @@ import (
 	"github.com/evcc-io/evcc/util/jq"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/itchyny/gojq"
+	"github.com/jpfielding/go-http-digest/pkg/digest"
 )
 
 // HTTP implements HTTP request provider
@@ -40,17 +40,6 @@ type Auth struct {
 	Type, User, Password string
 }
 
-// AuthHeaders creates authorization headers from config
-func AuthHeaders(log *util.Logger, auth Auth, headers map[string]string) error {
-	if strings.ToLower(auth.Type) != "basic" {
-		return fmt.Errorf("unsupported auth type: %s", auth.Type)
-	}
-
-	basicAuth := auth.User + ":" + auth.Password
-	headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(basicAuth))
-	return nil
-}
-
 // NewHTTPProviderFromConfig creates a HTTP provider
 func NewHTTPProviderFromConfig(other map[string]interface{}) (IntProvider, error) {
 	cc := struct {
@@ -75,13 +64,6 @@ func NewHTTPProviderFromConfig(other map[string]interface{}) (IntProvider, error
 
 	log := util.NewLogger("http")
 
-	// handle basic auth
-	if cc.Auth.Type != "" {
-		if err := AuthHeaders(log, cc.Auth, cc.Headers); err != nil {
-			return nil, fmt.Errorf("http auth: %w", err)
-		}
-	}
-
 	http, err := NewHTTP(log,
 		cc.Method,
 		cc.URI,
@@ -93,8 +75,9 @@ func NewHTTPProviderFromConfig(other map[string]interface{}) (IntProvider, error
 		cc.Scale,
 		cc.Cache,
 	)
-	if err != nil {
-		return nil, err
+
+	if err == nil && cc.Auth.Type != "" {
+		_, err = http.WithAuth(cc.Auth.Type, cc.Auth.User, cc.Auth.Password)
 	}
 
 	if err == nil {
@@ -142,6 +125,20 @@ func NewHTTP(log *util.Logger, method, uri string, headers map[string]string, bo
 		}
 
 		p.jq = op
+	}
+
+	return p, nil
+}
+
+// WithAuth adds authorized transport
+func (p *HTTP) WithAuth(typ, user, password string) (*HTTP, error) {
+	switch strings.ToLower(typ) {
+	case "basic":
+		p.Client.Transport = basicauth.NewTransport(user, password, p.Client.Transport)
+	case "digest":
+		p.Client.Transport = digest.NewTransport(user, password, p.Client.Transport)
+	default:
+		return nil, fmt.Errorf("unknown auth type '%s'", typ)
 	}
 
 	return p, nil

--- a/provider/http.go
+++ b/provider/http.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/basicauth"
 	"github.com/evcc-io/evcc/util/jq"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/itchyny/gojq"

--- a/provider/socket.go
+++ b/provider/socket.go
@@ -69,9 +69,7 @@ func NewSocketProviderFromConfig(other map[string]interface{}) (IntProvider, err
 
 	// handle basic auth
 	if cc.Auth.Type != "" {
-		if err := AuthHeaders(log, cc.Auth, p.headers); err != nil {
-			return nil, fmt.Errorf("socket auth: %w", err)
-		}
+		p.headers["Authorization"]= basicauth.Header(cc.Auth.User, cc.Auth.Password))
 	}
 
 	// ignore the self signed certificate

--- a/provider/socket.go
+++ b/provider/socket.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/basicauth"
 	"github.com/evcc-io/evcc/util/jq"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/gorilla/websocket"
@@ -69,7 +70,7 @@ func NewSocketProviderFromConfig(other map[string]interface{}) (IntProvider, err
 
 	// handle basic auth
 	if cc.Auth.Type != "" {
-		p.headers["Authorization"]= basicauth.Header(cc.Auth.User, cc.Auth.Password))
+		p.headers["Authorization"] = basicauth.Header(cc.Auth.User, cc.Auth.Password)
 	}
 
 	// ignore the self signed certificate

--- a/util/basicauth/transport.go
+++ b/util/basicauth/transport.go
@@ -10,14 +10,20 @@ type transport struct {
 	base   http.RoundTripper
 }
 
+// Header returns the basic auth header
+func Header(user, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+password))
+}
+
 // NewTransport creates an http transport performing basic auth
 func NewTransport(user, password string, base http.RoundTripper) http.RoundTripper {
 	return &transport{
-		header: "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+password)),
+		header: Header(user, password),
 		base:   base,
 	}
 }
 
+// RoundTrip implements the http.RoundTripper interface
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", t.header)
 	return t.base.RoundTrip(req)


### PR DESCRIPTION
This PR makes use of https://github.com/evcc-io/evcc/pull/1682 to reuse basic and digest auth for the http plugin