### PR TITLE
Set Shelly gen2 default scheme to http

### DIFF
--- a/charger/shelly.go
+++ b/charger/shelly.go
@@ -94,7 +94,7 @@ func NewShelly(uri, user, password string, channel int, standbypower float64) (*
 	case 2:
 		// Shelly GEN 2 API
 		// https://shelly-api-docs.shelly.cloud/gen2/
-		c.uri = fmt.Sprintf("%s/rpc", util.DefaultScheme(uri, "https"))
+		c.uri = fmt.Sprintf("%s/rpc", util.DefaultScheme(uri, "http"))
 		if user != "" {
 			c.Client.Transport = digest.NewTransport(user, password, c.Client.Transport)
 		}


### PR DESCRIPTION
Current Shelly NG web server is not providing https.
Set default gen2 default scheme to http.
Refer to: https://www.shelly-support.eu/forum/index.php?thread/11372-ssl-support-aktivieren/&postID=120881#post120893