### PR TITLE
Support multiple batteries

### DIFF
--- a/core/site_api.go
+++ b/core/site_api.go
@@ -3,7 +3,6 @@ package core
 import (
 	"errors"
 
-	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/site"
 )
 
@@ -21,7 +20,7 @@ func (site *Site) SetPrioritySoC(soc float64) error {
 	site.Lock()
 	defer site.Unlock()
 
-	if _, ok := site.batteryMeter.(api.Battery); !ok {
+	if len(site.batteryMeters) == 0 {
 		return errors.New("battery not configured")
 	}
 


### PR DESCRIPTION
- Leistungen werden summiert
- SoCs werden gemittelt

Aus den einzelnen SoCs der Batterien wird ein Mittelwert gebildet. Das ist mangels anderen Daten erstmal die einzige Möglichkeit. Diese Berechnung ist unter der Annahme dass jede Batterie im Verbund die gleiche Kapazität aufweist mathematisch korrekt entsprechend der ingesamt eingespeicherten Energie.

Sollte bei (stark) unterschiedlichen Batteriegrößen eine korrekte Angabe erfolgen sollen müsste man die Kapazitäten in der Konfiguration hinterlegen können um diese dann anteilig in den Gesamt-SoC einfließen zu lassen, da die Speicher diese regelmäßig leider nicht per Schnittstelle bereitstellen.