### PR TITLE
Fix using multiple eebus chargers

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -3,13 +3,11 @@ package charger
 import (
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/evcc-io/eebus/app"
 	"github.com/evcc-io/eebus/communication"
 	"github.com/evcc-io/eebus/ship"
-	"github.com/evcc-io/eebus/spine"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/server"
@@ -72,15 +70,10 @@ func NewEEBus(ski string, forcePVLimits bool) (*EEBus, error) {
 	return c, nil
 }
 
-var eebusDevice spine.Device
-var once sync.Once
-
 func (c *EEBus) onConnect(ski string, conn ship.Conn) error {
 	c.log.TRACE.Println("!! onCconnect invoked on ski ", ski)
 
-	once.Do(func() {
-		eebusDevice = app.HEMS(server.EEBusInstance.DeviceInfo())
-	})
+	eebusDevice := app.HEMS(server.EEBusInstance.DeviceInfo())
 	c.cc = communication.NewConnectionController(c.log.TRACE, conn, eebusDevice)
 	c.cc.SetDataUpdateHandler(c.dataUpdateHandler)
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dylanmei/iso8601 v0.1.0
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/evcc-io/config v0.0.0-20210930111050-37df6f7e52b8
-	github.com/evcc-io/eebus v0.0.0-20211002143419-1336d099b84c
+	github.com/evcc-io/eebus v0.0.0-20211004203943-949a5847f2ea
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/fatih/structs v1.1.0
 	github.com/go-ping/ping v0.0.0-20210506233800-ff8be3320020

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evcc-io/config v0.0.0-20210930111050-37df6f7e52b8 h1:kfrzL89jpU+1fQ8Kyd3r9UI6wJ1KAABsFI0DrIR++/Q=
 github.com/evcc-io/config v0.0.0-20210930111050-37df6f7e52b8/go.mod h1:aN5D6PVnoFvfZSMScvAQAIYRXwWOZ9lde3J0lsNRIOM=
-github.com/evcc-io/eebus v0.0.0-20211002143419-1336d099b84c h1:8G209dbZPMz79/A0oocEXqIqx9IN3VwE9oHCKUEJ2Rw=
-github.com/evcc-io/eebus v0.0.0-20211002143419-1336d099b84c/go.mod h1:2fJZDu2dSe7M6m+KIYkG5XPdk+Ws1ckuRyklZRvFzWE=
+github.com/evcc-io/eebus v0.0.0-20211004203943-949a5847f2ea h1:5jS7Gp84BUOTWRn7VWdeWxH/72QgMSt2U6JPclYOoqQ=
+github.com/evcc-io/eebus v0.0.0-20211004203943-949a5847f2ea/go.mod h1:2fJZDu2dSe7M6m+KIYkG5XPdk+Ws1ckuRyklZRvFzWE=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION
Right now the eebus server implementation doesn't act as one server device, that`s why we need create one for each connection.

Otherwise the server device assigns all data to the latest created charger