### PR TITLE
Feature/improve ovms

### DIFF
--- a/vehicle/ovms.go
+++ b/vehicle/ovms.go
@@ -36,6 +36,7 @@ type Ovms struct {
 	*embed
 	*request.Helper
 	user, password, vehicleId, server string
+	cache                             time.Duration
 	chargeG                           func() (interface{}, error)
 	statusG                           func() (interface{}, error)
 }
@@ -67,6 +68,7 @@ func NewOvmsFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		password:  cc.Password,
 		vehicleId: cc.VehicleID,
 		server:    cc.Server,
+		cache:     cc.Cache,
 	}
 
 	v.chargeG = provider.NewCached(v.batteryAPI, cc.Cache).InterfaceGetter()
@@ -137,7 +139,7 @@ func (v *Ovms) batteryAPI() (interface{}, error) {
 	}
 
 	messageAge := time.Duration(resp.MessageAgeServer) * time.Second
-	if err == nil && messageAge > time.Minute {
+	if err == nil && messageAge > v.cache {
 		err = api.ErrMustRetry
 	}
 

--- a/vehicle/ovms.go
+++ b/vehicle/ovms.go
@@ -70,7 +70,6 @@ func NewOvmsFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		vehicleId: cc.VehicleID,
 		server:    cc.Server,
 		cache:     cc.Cache,
-		isOnline:  false,
 	}
 
 	v.chargeG = provider.NewCached(v.batteryAPI, cc.Cache).InterfaceGetter()
@@ -122,7 +121,7 @@ func (v *Ovms) authFlow() error {
 	if err == nil {
 		resp, err = v.connectRequest()
 		if err == nil {
-			v.isOnline = (resp.NetConnected == 1)
+			v.isOnline = resp.NetConnected == 1
 		}
 	}
 	return err


### PR DESCRIPTION
1. Use configured or default vehicle cache time as max accepted message age.
2. Save connection status between OVMS module and OVMS server in vehicle and set MustRetry only if module is online. New values could only be requested if the module is connected to the used OVMS server.