### PR TITLE
Add javascript support to the http plugin

### DIFF
--- a/provider/http.go
+++ b/provider/http.go
@@ -353,8 +353,7 @@ func (p *HTTP) StringGetter() func() (string, error) {
 				return string(b), err
 			}
 
-			s, err := v.ToString()
-			return string(s), err
+			return v.ToString()
 		}
 
 		return string(b), err

--- a/provider/http.go
+++ b/provider/http.go
@@ -318,7 +318,6 @@ func (p *HTTP) StringGetter() func() (string, error) {
 		}
 
 		if p.jq != nil {
-			b = []byte("{\"ENERGY\":{\"GUI_GRID_POW\":\"fl_42C80000\"}}")
 			v, err := jq.Query(p.jq, b)
 			if err != nil {
 				return string(b), err

--- a/provider/http.go
+++ b/provider/http.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math"
@@ -218,28 +219,34 @@ func (p *HTTP) request(body ...string) ([]byte, error) {
 	return p.val, p.err
 }
 
-func (p *HTTP) decodeValue(value []byte) (interface{}, error) {
+// decode a hex string to a proper value
+func (p *HTTP) decodeValue(value string) (interface{}, error) {
+	b, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, err
+	}
+
 	switch p.decode {
 	case "float32", "ieee754":
-		return rs485.RTUIeee754ToFloat64(value), nil
+		return rs485.RTUIeee754ToFloat64(b), nil
 	case "float32s", "ieee754s":
-		return rs485.RTUIeee754ToFloat64Swapped(value), nil
+		return rs485.RTUIeee754ToFloat64Swapped(b), nil
 	case "float64":
-		return rs485.RTUUint64ToFloat64(value), nil
+		return rs485.RTUUint64ToFloat64(b), nil
 	case "uint16":
-		return rs485.RTUUint16ToFloat64(value), nil
+		return rs485.RTUUint16ToFloat64(b), nil
 	case "uint32":
-		return rs485.RTUUint32ToFloat64(value), nil
+		return rs485.RTUUint32ToFloat64(b), nil
 	case "uint32s":
-		return rs485.RTUUint32ToFloat64Swapped(value), nil
+		return rs485.RTUUint32ToFloat64Swapped(b), nil
 	case "uint64":
-		return rs485.RTUUint64ToFloat64(value), nil
+		return rs485.RTUUint64ToFloat64(b), nil
 	case "int16":
-		return rs485.RTUInt16ToFloat64(value), nil
+		return rs485.RTUInt16ToFloat64(b), nil
 	case "int32":
-		return rs485.RTUInt32ToFloat64(value), nil
+		return rs485.RTUInt32ToFloat64(b), nil
 	case "int32s":
-		return rs485.RTUInt32ToFloat64Swapped(value), nil
+		return rs485.RTUInt32ToFloat64Swapped(b), nil
 	}
 
 	return nil, fmt.Errorf("invalid decoding: %s", p.decode)
@@ -298,7 +305,7 @@ func (p *HTTP) StringGetter() func() (string, error) {
 		}
 
 		if p.decode != "" {
-			v, err := p.decodeValue(b)
+			v, err := p.decodeValue(string(b))
 			if err != nil {
 				return string(b), err
 			}

--- a/provider/http.go
+++ b/provider/http.go
@@ -251,7 +251,6 @@ func (p *HTTP) StringGetter() func() (string, error) {
 		if p.jq != nil {
 			v, err := jq.Query(p.jq, b)
 			if err != nil {
-				fmt.Println(err)
 				return string(b), err
 			}
 			b = []byte(fmt.Sprintf("%v", v))

--- a/provider/http.go
+++ b/provider/http.go
@@ -343,7 +343,11 @@ func (p *HTTP) StringGetter() func() (string, error) {
 		}
 
 		if p.vm != nil {
-			p.vm.Set("val", string(b))
+			err := p.vm.Set("val", string(b))
+			if err != nil {
+				return string(b), err
+			}
+
 			v, err := p.vm.Eval(p.script)
 			if err != nil {
 				return string(b), err

--- a/provider/http.go
+++ b/provider/http.go
@@ -249,7 +249,6 @@ func (p *HTTP) StringGetter() func() (string, error) {
 		}
 
 		if p.jq != nil {
-			b = []byte("{\"ENERGY\":{\"GUI_GRID_POW\":\"fl_C137BE76\"}}")
 			v, err := jq.Query(p.jq, b)
 			if err != nil {
 				fmt.Println(err)

--- a/provider/http.go
+++ b/provider/http.go
@@ -246,6 +246,7 @@ func (p *HTTP) unpackValue(value []byte) (string, error) {
 }
 
 // decode a hex string to a proper value
+// TODO reuse similar code from Modbus
 func (p *HTTP) decodeValue(value []byte) (interface{}, error) {
 	switch p.decode {
 	case "float32", "ieee754":
@@ -342,16 +343,13 @@ func (p *HTTP) StringGetter() func() (string, error) {
 		}
 
 		if p.vm != nil {
-			inputScript := fmt.Sprintf("var input = '" + string(b) + "';\n")
-			script := inputScript + p.script
-			v, err := p.vm.Eval(script)
+			p.vm.Set("val", string(b))
+			v, err := p.vm.Eval(p.script)
 			if err != nil {
-				fmt.Println(err)
 				return string(b), err
 			}
 
 			s, err := v.ToString()
-			fmt.Println(err)
 			return string(s), err
 		}
 


### PR DESCRIPTION
This allows to run javascript code on the data returned by the HTTP call and optionally processed via jq

This allows e.g. the senec device to be configured without using external scripts that runs curl and python

The data is provided to the script env via an input variable