### PR TITLE
Fix vehicle data not removed from UI after disconnect

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -361,8 +361,10 @@ func (lp *LoadPoint) evVehicleConnectHandler() {
 	lp.log.DEBUG.Println("vehicle api refresh")
 	provider.ResetCached()
 
-	// identify active vehicle
-	lp.startVehicleDetection()
+	// start detection if we have multiple vehicles
+	if len(lp.vehicles) > 1 {
+		lp.startVehicleDetection()
+	}
 
 	// immediately allow pv mode activity
 	lp.elapsePVTimer()

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -380,9 +380,20 @@ func (lp *LoadPoint) evVehicleDisconnectHandler() {
 
 	lp.pushEvent(evVehicleDisconnect)
 
-	// remove active vehicle
+	// remove active vehicle if we have multiple vehicles
 	if len(lp.vehicles) > 1 {
 		lp.setActiveVehicle(nil)
+	}
+
+	// keep single vehicle to allow poll mode: always
+	if len(lp.vehicles) == 1 {
+		// if poll mode is connected/charging and not connected
+		if lp.SoC.Poll.Mode != pollAlways && !lp.connected() {
+			// reset published values
+			lp.publish("vehicleSoC", -1)
+			lp.publish("chargeRemainingDuration", time.Duration(-1))
+			lp.publish("vehicleRange", -1)
+		}
 	}
 
 	// set default mode on disconnect

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -389,12 +389,11 @@ func (lp *LoadPoint) evVehicleDisconnectHandler() {
 
 	// keep single vehicle to allow poll mode: always
 	if len(lp.vehicles) == 1 {
-		// if poll mode is connected/charging and not connected
-		if lp.SoC.Poll.Mode != pollAlways && !lp.connected() {
-			// reset published values
+		// but reset values if poll mode is not always (i.e. connected or charging)
+		if lp.SoC.Poll.Mode != pollAlways {
 			lp.publish("vehicleSoC", -1)
-			lp.publish("chargeRemainingDuration", time.Duration(-1))
 			lp.publish("vehicleRange", -1)
+			lp.setRemainingDuration(-1)
 		}
 	}
 


### PR DESCRIPTION
Proposal to fix #1934:

If there is a single vehicle configured per loadpoint and the poll mode is not always, reset following published values when vehicle is disconnected from charger:
  * vehicleSoC
  * chargeRemainingDuration
  * vehicleRange