### PR TITLE
Add armv7 architecture go get armhf deb packages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,6 +106,13 @@ jobs:
         CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       run: |
         for filename in release/*.deb; do
+          # goreleaser creates armel packages for armv6, which is wrong
+          # until this is fixed, ignore armv6 
+          if [[ "$filename" == *"armv6"* ]]; then
+            echo "Skipping $filename"
+            continue
+          fi
+
           echo "Pushing $filename to 'unstable'"
           cloudsmith push deb evcc/unstable/any-distro/any-version $filename
         done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,13 @@ jobs:
         CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       run: |
         for filename in release/*.deb; do
+          # goreleaser creates armel packages for armv6, which is wrong
+          # until this is fixed, ignore armv6 
+          if [[ "$filename" == *"armv6"* ]]; then
+            echo "Skipping $filename"
+            continue
+          fi
+
           echo "Pushing $filename to 'stable'"
           cloudsmith push deb evcc/stable/any-distro/any-version $filename
         done

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -20,6 +20,7 @@ builds:
   - arm64
   goarm:
   - "6"
+  - "7"
 archives:
 - builds:
   - evcc

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -32,7 +32,7 @@ archives:
     format: zip
   files:
   - evcc.dist.yaml
-  name_template: "{{.ProjectName}}_{{ .Version }}.{{.Timestamp}}_{{.Os}}-{{.Arch}}"
+  name_template: "{{.ProjectName}}_{{ .Version }}.{{.Timestamp}}_{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 universal_binaries:
 - replace: true
 checksum:
@@ -42,7 +42,7 @@ snapshot:
 nfpms:
   - id: default
     package_name: evcc
-    file_name_template: "{{.ProjectName}}_{{ .Version }}.{{.Timestamp}}_{{.Os}}-{{.Arch}}"
+    file_name_template: "{{.ProjectName}}_{{ .Version }}.{{.Timestamp}}_{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
     homepage:  https://evcc.io
     description: EV Charge Controller

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
   - arm64
   goarm:
   - "6"
+  - "7"
 archives:
 - builds:
   - evcc


### PR DESCRIPTION
- Don't push armv6 deb packages, as goreleaser right now incorrectly makes `armel` instead of `armhf` packages
- Add armv7 builds and use that for debian packages