### PR TITLE
More configure flow improvements

### DIFF
--- a/cmd/configure/devicetest.go
+++ b/cmd/configure/devicetest.go
@@ -84,7 +84,7 @@ func (d *DeviceTest) testCharger(v interface{}) (DeviceTestResult, error) {
 			return DeviceTestResultInvalid, err
 		}
 	} else {
-		return DeviceTestResultInvalid, errors.New("Selected device is not a wallbox!")
+		return DeviceTestResultInvalid, errors.New("selected device is not a wallbox!")
 	}
 
 	if v, ok := v.(api.Meter); ok {
@@ -116,11 +116,11 @@ func (d *DeviceTest) testMeter(deviceCategory DeviceCategory, v interface{}) (De
 					return DeviceTestResultInvalid, err
 				}
 			} else {
-				return DeviceTestResultInvalid, errors.New("Selected device is not a battery meter!")
+				return DeviceTestResultInvalid, errors.New("selected device is not a battery meter!")
 			}
 		}
 	} else {
-		return DeviceTestResultInvalid, errors.New("Selected device is not a meter!")
+		return DeviceTestResultInvalid, errors.New("selected device is not a meter!")
 	}
 
 	return DeviceTestResultValid, nil
@@ -135,7 +135,7 @@ func (d *DeviceTest) testVehicle(v interface{}) (DeviceTestResult, error) {
 			}
 		}
 	} else {
-		return DeviceTestResultInvalid, errors.New("Selected device is not a vehicle!")
+		return DeviceTestResultInvalid, errors.New("selected device is not a vehicle!")
 	}
 
 	return DeviceTestResultValid, nil

--- a/cmd/configure/flow.go
+++ b/cmd/configure/flow.go
@@ -121,7 +121,7 @@ func (c *CmdConfigure) configureLinkedTypes(templateItem templates.Template) {
 
 		fmt.Println()
 		if !c.askYesNo(c.localizedString("AddLinkedDeviceInCategory", localizeMap)) {
-			break
+			continue
 		}
 
 		for ok := true; ok; {

--- a/cmd/configure/flow.go
+++ b/cmd/configure/flow.go
@@ -139,6 +139,7 @@ func (c *CmdConfigure) configureLinkedTypes(templateItem templates.Template) {
 	}
 }
 
+// configureLinkedTemplate lets the user configure a device that is marked as being linked to a guided device
 func (c *CmdConfigure) configureLinkedTemplate(template templates.Template, category DeviceCategory) {
 	for ok := true; ok; {
 		deviceItem := device{}

--- a/cmd/configure/localization/de.toml
+++ b/cmd/configure/localization/de.toml
@@ -15,7 +15,8 @@ ItemNotPresent = "Mein Gerät ist nicht in der Liste"
 
 AddDeviceInCategory = "Möchtest du {{ .Article }} {{ .Category }} hinzufügen?"
 AddAnotherDeviceInCategory = "Möchtest du noch {{ .Additional }} {{ .Category }} hinzufügen?"
-AddLinkedDeviceInCategory = "Möchtest du '{{ .Linked }}' als {{ .Article }} {{ .Category }} hinzufügen?"
+AddLinkedDeviceInCategory = "Möchtest du ein '{{ .Linked }}' Gerät als {{ .Article }} {{ .Category }} hinzufügen?"
+AddAnotherLinkedDeviceInCategory = "Möchtest du noch ein '{{ .Linked }}' Gerät als {{ .Article }} {{ .Category }} hinzufügen?"
 
 Error = "Fehler: {{ .Error }}"
 Error_ItemNotPresent = "Gerät nicht vorhanden"

--- a/cmd/configure/localization/en.toml
+++ b/cmd/configure/localization/en.toml
@@ -15,7 +15,8 @@ ItemNotPresent = "My device is not in this list"
 
 AddDeviceInCategory = "Do you want to add {{ .Article }} {{ .Category }}?"
 AddAnotherDeviceInCategory = "Do you want to add {{ .Additional }} {{ .Category }}?"
-AddLinkedDeviceInCategory = "Do you want to add '{{ .Linked }}' as {{ .Article }} {{ .Category }}?"
+AddLinkedDeviceInCategory = "Do you want to add a '{{ .Linked }}' device as {{ .Article }} {{ .Category }}?"
+AddAnotherLinkedDeviceInCategory = "Do you want to add another '{{ .Linked }}' device as {{ .Article }} {{ .Category }}?"
 
 Error = "Error: {{ .Error }}"
 Error_ItemNotPresent = "Device not present"

--- a/templates/README.md
+++ b/templates/README.md
@@ -54,6 +54,12 @@ Allows to define a list of meter devices that are typically installed with this 
 
 `multiple:true` to define that multiple devices of this template can be added
 
+#### `excludetemplate`
+
+`excludetemplate` defines a linked device `template` value. If defined and a device of the linked template is added, then this linked template won't be considered in the flow
+
+Example Use Case: With SMA Home Manager, there can be a SMA Energy Meter used for getting the PV generation or multiple SMA PV inverters. But never both together. So if the used added an SMA Energy Meter, then the flow shoudn't ask for SMA PV inverters.
+
 ## `requirements`
 
 `requirements` provides an option to define various requirements / dependencies that need to be setup

--- a/templates/README.md
+++ b/templates/README.md
@@ -50,6 +50,10 @@ Allows to define a list of meter devices that are typically installed with this 
 - `pv`:  for pv inverter/meter
 - `battery`: for battery inverter/meter
 
+#### `multiple`
+
+`multiple:true` to define that multiple devices of this template can be added
+
 ## `requirements`
 
 `requirements` provides an option to define various requirements / dependencies that need to be setup

--- a/templates/definition/charger/nrgkick-bluetooth.yaml
+++ b/templates/definition/charger/nrgkick-bluetooth.yaml
@@ -5,6 +5,7 @@ params:
   required: true
 - name: pin
   required: true
+  mask: true
 render: |
   type: nrgkick-bluetooth
   mac: {{ .mac }}

--- a/templates/definition/charger/tinkerforge-warp-pro.yaml
+++ b/templates/definition/charger/tinkerforge-warp-pro.yaml
@@ -9,8 +9,14 @@ params:
 - name: host
   required: true
   example: 192.0.2.2
+  help:
+    de: Die IP Adresse oder der Hostname des MQTT Brokers
+    en: The IP address or hostname of the MQTT broker
 - name: port
   default: 1883
+  help:
+    de: Der Port des MQTT Brokers
+    en: The port of the MQTT broker
 - name: topic
   default: warp
 - name: timeout

--- a/templates/definition/charger/tinkerforge-warp.yaml
+++ b/templates/definition/charger/tinkerforge-warp.yaml
@@ -9,8 +9,14 @@ params:
 - name: host
   required: true
   example: 192.0.2.2
+  help:
+    de: Die IP Adresse oder der Hostname des MQTT Brokers
+    en: The IP address or hostname of the MQTT broker
 - name: port
   default: 1883
+  help:
+    de: Der Port des MQTT Brokers
+    en: The port of the MQTT broker
 - name: topic
   default: warp
 - name: timeout

--- a/templates/definition/meter/powerfox-poweropti.yaml
+++ b/templates/definition/meter/powerfox-poweropti.yaml
@@ -7,6 +7,7 @@ params:
   required: true
 - name: password
   required: true
+  mask: true
 render: |
   type: custom
   power:

--- a/templates/definition/meter/sma-homemanager.yaml
+++ b/templates/definition/meter/sma-homemanager.yaml
@@ -9,8 +9,10 @@ guidedsetup:
     usage: pv
   - template: sma-inverter
     usage: pv
+    multiple: true
   - template: sma-inverter
     usage: battery
+    multiple: true
 params:
 - name: usage
   choice: ["grid"]

--- a/templates/definition/meter/sma-homemanager.yaml
+++ b/templates/definition/meter/sma-homemanager.yaml
@@ -10,6 +10,7 @@ guidedsetup:
   - template: sma-inverter
     usage: pv
     multiple: true
+    excludetemplate: sma-energy-meter
   - template: sma-inverter
     usage: battery
     multiple: true

--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -3,6 +3,7 @@ description: Fiat
 paramsbase: vehicle
 params:
 - name: pin
+  mask: true
 - name: vin
   example: ZFAE...
 - name: capacity

--- a/templates/docs/charger/tinkerforge-warp-pro.yaml
+++ b/templates/docs/charger/tinkerforge-warp-pro.yaml
@@ -1,7 +1,7 @@
 type: template
 template: tinkerforge-warp-pro
 description: TinkerForge WARP Charger Pro
-host: 192.0.2.2 
-port: 1883 
+host: 192.0.2.2  # Die IP Adresse oder der Hostname des MQTT Brokers
+port: 1883  # Der Port des MQTT Brokers
 topic: warp 
 timeout: 30s

--- a/templates/docs/charger/tinkerforge-warp.yaml
+++ b/templates/docs/charger/tinkerforge-warp.yaml
@@ -1,7 +1,7 @@
 type: template
 template: tinkerforge-warp
 description: TinkerForge WARP Charger
-host: 192.0.2.2 
-port: 1883 
+host: 192.0.2.2  # Die IP Adresse oder der Hostname des MQTT Brokers
+port: 1883  # Der Port des MQTT Brokers
 topic: warp 
 timeout: 30s

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -100,9 +100,10 @@ type GuidedSetup struct {
 
 // Linked Template
 type LinkedTemplate struct {
-	Template string
-	Usage    string // usage: "grid", "pv", "battery"
-	Multiple bool   // if true, multiple instances of this template can be added
+	Template        string
+	Usage           string // usage: "grid", "pv", "battery"
+	Multiple        bool   // if true, multiple instances of this template can be added
+	ExcludeTemplate string // only consider this if no device of the named linked template was added
 }
 
 // Param is a proxy template parameter

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -102,6 +102,7 @@ type GuidedSetup struct {
 type LinkedTemplate struct {
 	Template string
 	Usage    string // usage: "grid", "pv", "battery"
+	Multiple bool   // if true, multiple instances of this template can be added
 }
 
 // Param is a proxy template parameter


### PR DESCRIPTION
- Added Tinkerforge Warp help texts to make it clear that the MQTT host and port need to be added
- Allow to define linked templates in guided setup to be added multiple times, e.g. multiple SMA PV or Battery inverters with an SMA Home Manager setup
- Allow to exclude a linked template, if devices are added of another linked template, e.g. don't ask for SMA PV inverters if an SMA Energy Meter is added
- Various other changes