### PR TITLE
Fix dumping ActionConfig structure

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -60,8 +60,9 @@ type ActionConfig struct {
 func (a ActionConfig) String() string {
 	var s []string
 	for k, v := range structs.Map(a) {
-		if v != nil && !reflect.ValueOf(v).IsNil() {
-			s = append(s, fmt.Sprintf("%s:%v", k, v))
+		val := reflect.ValueOf(v)
+		if v != nil && !val.IsNil() {
+			s = append(s, fmt.Sprintf("%s:%v", k, val.Elem()))
 		}
 	}
 	return strings.Join(s, ", ")

--- a/api/api.go
+++ b/api/api.go
@@ -60,8 +60,8 @@ type ActionConfig struct {
 func (a ActionConfig) String() string {
 	var s []string
 	for k, v := range structs.Map(a) {
-		val := reflect.ValueOf(v)
 		if v != nil && !val.IsNil() {
+			val := reflect.ValueOf(v)
 			s = append(s, fmt.Sprintf("%s:%v", k, val.Elem()))
 		}
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -60,8 +60,8 @@ type ActionConfig struct {
 func (a ActionConfig) String() string {
 	var s []string
 	for k, v := range structs.Map(a) {
+		val := reflect.ValueOf(v)
 		if v != nil && !val.IsNil() {
-			val := reflect.ValueOf(v)
 			s = append(s, fmt.Sprintf("%s:%v", k, val.Elem()))
 		}
 	}

--- a/cmd/dumper.go
+++ b/cmd/dumper.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/fatih/structs"
 )
 
 var truefalse = map[bool]string{false: "false", true: "true"}
@@ -174,6 +175,8 @@ func (d *dumper) Dump(name string, v interface{}) {
 		fmt.Fprintf(w, "Capacity:\t%dkWh\n", v.Capacity())
 		if len(v.Identifiers()) > 0 {
 			fmt.Fprintf(w, "Identifiers:\t%v\n", v.Identifiers())
+		}
+		if !structs.IsZero(v.OnIdentified()) {
 			fmt.Fprintf(w, "OnIdentified:\t%s\n", v.OnIdentified())
 		}
 	}


### PR DESCRIPTION
* print value instead of address in `ActionConfig` stringer function
* dump `OnIdentified` structure when its not empty and independent from `identifiers` presence