### PR TITLE
Tesla: use larger battery range value similar to Tesla app

### DIFF
--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -163,7 +163,7 @@ func (v *Tesla) Range() (int64, error) {
 
 	if res, ok := res.(*tesla.ChargeState); err == nil && ok {
 		// miles to km
-		return int64(kmPerMile * res.EstBatteryRange), nil
+		return int64(kmPerMile * res.BatteryRange), nil
 	}
 
 	return 0, err


### PR DESCRIPTION
<img width="227" alt="Bildschirmfoto 2021-12-22 um 11 58 28" src="https://user-images.githubusercontent.com/184815/147082453-c913284f-6658-4eba-b32a-51d2fb6e76bb.png">

This change will display the same value as the app instead of the lower (though possibly more correct) value of the Tesla's onboard energy display.

/cc @naltatis @pacemaker