### PR TITLE
Porsche: use oauth2 library

### DIFF
--- a/vehicle/porsche.go
+++ b/vehicle/porsche.go
@@ -1,12 +1,14 @@
 package vehicle
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/vehicle/porsche"
+	"github.com/thoas/go-funk"
 )
 
 // Porsche is an api.Vehicle implementation for Porsche cars
@@ -45,26 +47,50 @@ func NewPorscheFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	}
 
 	api := porsche.NewAPI(log, identity.DefaultSource)
-	vin, err := api.FindVehicle(cc.VIN)
-	if err != nil {
-		return nil, err
+
+	if cc.VIN == "" {
+		vehicles, err := api.Vehicles()
+		if err == nil {
+			cc.VIN, err = findVehicle(funk.Map(vehicles, func(v porsche.Vehicle) string {
+				return v.VIN
+			}).([]string), nil)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		log.DEBUG.Printf("found vehicle: %v", cc.VIN)
 	}
+
+	// check if vehicle is paired
+	if res, err := api.PairingStatus(cc.VIN); err == nil && res.Status != porsche.PairingComplete {
+		return nil, errors.New("vehicle is not paired with the My Porsche account")
+	}
+
+	// check if vehicle provides status:
+	// some PHEVs do not provide any data
+	if _, err := api.Status(cc.VIN); err != nil {
+		return nil, errors.New("vehicle is not capable of providing data")
+	}
+
+	// get eMobility capabilities
 
 	// Note: As of 27.10.21 the capabilities API needs to be called AFTER a
 	//   call to status() as it otherwise returns an HTTP 502 error.
 	//   The reason is unknown, even when tested with 100% identical Headers.
 	//   It seems to be a new backend related issue.
-	if _, err := api.Status(vin); err != nil {
+	if _, err := api.Status(cc.VIN); err != nil {
 		return nil, err
 	}
 
 	emobility := porsche.NewEmobilityAPI(log, identity.EmobilitySource)
-	capabilities, err := emobility.Capabilities(vin)
+	capabilities, err := emobility.Capabilities(cc.VIN)
 	if err != nil {
 		return nil, err
 	}
 
-	provider := porsche.NewProvider(log, api, emobility, vin, capabilities.CarModel, cc.Cache)
+	provider := porsche.NewProvider(log, api, emobility, cc.VIN, capabilities.CarModel, cc.Cache)
 
 	v := &Porsche{
 		embed:    &cc.embed,

--- a/vehicle/porsche.go
+++ b/vehicle/porsche.go
@@ -50,11 +50,9 @@ func NewPorscheFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if cc.VIN == "" {
 		vehicles, err := api.Vehicles()
-		if err == nil {
-			cc.VIN, err = findVehicle(funk.Map(vehicles, func(v porsche.Vehicle) string {
-				return v.VIN
-			}).([]string), nil)
-		}
+		cc.VIN, err = findVehicle(funk.Map(vehicles, func(v porsche.Vehicle) string {
+			return v.VIN
+		}).([]string), err)
 
 		if err != nil {
 			return nil, err

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -41,6 +41,7 @@ func NewAPI(log *util.Logger, identity oauth2.TokenSource) *API {
 	return v
 }
 
+// Vehicles implements the vehicle list response
 func (v *API) Vehicles() ([]Vehicle, error) {
 	var res []Vehicle
 	uri := fmt.Sprintf("%s/core/api/v3/de/de_DE/vehicles", ApiURI)
@@ -48,7 +49,7 @@ func (v *API) Vehicles() ([]Vehicle, error) {
 	return res, err
 }
 
-// PairingStatus implements the vehicle status response
+// PairingStatus implements the vehicle pairing status response
 func (v *API) PairingStatus(vin string) (VehiclePairingResponse, error) {
 	var res VehiclePairingResponse
 	uri := fmt.Sprintf("%s/core/api/v3/de/de_DE/vehicles/%s/pairing", ApiURI, vin)

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -17,14 +17,12 @@ const (
 
 // API is an api.Vehicle implementation for Porsche PHEV cars
 type API struct {
-	log *util.Logger
 	*request.Helper
 }
 
 // NewAPI creates a new vehicle
 func NewAPI(log *util.Logger, identity oauth2.TokenSource) *API {
 	v := &API{
-		log:    log,
 		Helper: request.NewHelper(log),
 	}
 

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -1,0 +1,178 @@
+package porsche
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+)
+
+// API is an api.Vehicle implementation for Porsche PHEV cars
+type API struct {
+	log *util.Logger
+	*request.Helper
+	identity *Identity
+}
+
+// NewAPI creates a new vehicle
+func NewAPI(log *util.Logger, identity *Identity) *API {
+	impl := &API{
+		log:      log,
+		Helper:   request.NewHelper(log),
+		identity: identity,
+	}
+
+	return impl
+}
+
+func (v *API) request(emobility bool, uri string) (*http.Request, error) {
+	apiKey := OAuth2Config.ClientID
+	token, err := v.identity.DefaultSource.Token()
+	if emobility {
+		apiKey = EmobilityOAuth2Config.ClientID
+		token, err = v.identity.EmobilitySource.Token()
+	}
+
+	var req *http.Request
+	if err == nil {
+		req, err = request.New(http.MethodGet, uri, nil, map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", token.AccessToken),
+			"apikey":        apiKey,
+		})
+	}
+
+	return req, err
+}
+
+func (v *API) FindVehicle(vin string) (string, error) {
+	token, err := v.identity.DefaultSource.Token()
+	if err != nil {
+		return "", err
+	}
+
+	vehiclesURL := "https://api.porsche.com/core/api/v3/de/de_DE/vehicles"
+	req, err := request.New(http.MethodGet, vehiclesURL, nil, map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", token.AccessToken),
+		"apikey":        OAuth2Config.ClientID,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	var vehicles []VehicleResponse
+	if err = v.DoJSON(req, &vehicles); err != nil {
+		return "", err
+	}
+
+	var foundVehicle VehicleResponse
+
+	if vin == "" && len(vehicles) == 1 {
+		foundVehicle = vehicles[0]
+	} else {
+		for _, vehicleItem := range vehicles {
+			if vehicleItem.VIN == strings.ToUpper(vin) {
+				foundVehicle = vehicleItem
+			}
+		}
+	}
+	if foundVehicle.VIN == "" {
+		return "", errors.New("vin not found")
+	}
+
+	v.log.DEBUG.Printf("found vehicle: %v", foundVehicle.VIN)
+
+	// check if vehicle is paired
+	uri := fmt.Sprintf("%s/%s/pairing", vehiclesURL, foundVehicle.VIN)
+	req, err = request.New(http.MethodGet, uri, nil, map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", token.AccessToken),
+		"apikey":        OAuth2Config.ClientID,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	var pairing VehiclePairingResponse
+	if err = v.DoJSON(req, &pairing); err != nil {
+		return "", err
+	}
+
+	if pairing.Status != "PAIRINGCOMPLETE" {
+		return "", errors.New("vehicle is not paired with the My Porsche account")
+	}
+
+	// now check if we get any response at all for a status request
+	// there are PHEV which do not provide any data, even thought they are PHEV
+	uri = fmt.Sprintf("https://api.porsche.com/vehicle-data/de/de_DE/status/%s", foundVehicle.VIN)
+	req, err = request.New(http.MethodGet, uri, nil, map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", token.AccessToken),
+		"apikey":        OAuth2Config.ClientID,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	if _, err = v.DoBody(req); err != nil {
+		return "", errors.New("vehicle is not capable of providing data")
+	}
+
+	return foundVehicle.VIN, err
+}
+
+func (v *API) Capabilities(vin string) (CapabilitiesResponse, error) {
+	// Note: As of 27.10.21 the capabilities API needs to be called AFTER a
+	//   call to status() as it otherwise returns an HTTP 502 error.
+	//   The reason is unknown, even when tested with 100% identical Headers.
+	//   It seems to be a new backend related issue.
+
+	if _, err := v.Status(vin); err != nil {
+		return CapabilitiesResponse{}, err
+	}
+
+	uri := fmt.Sprintf("https://api.porsche.com/e-mobility/vcs/capabilities/%s", vin)
+
+	req, err := v.request(true, uri)
+	if err != nil {
+		return CapabilitiesResponse{}, err
+	}
+
+	var res CapabilitiesResponse
+	err = v.DoJSON(req, &res)
+	return res, err
+}
+
+// Status implements the vehicle status response
+func (v *API) Status(vin string) (StatusResponse, error) {
+	var res StatusResponse
+
+	uri := fmt.Sprintf("https://api.porsche.com/vehicle-data/de/de_DE/status/%s", vin)
+	req, err := v.request(false, uri)
+	if err == nil {
+		err = v.DoJSON(req, &res)
+	}
+
+	return res, err
+}
+
+// EmobilityStatus implements the vehicle status response
+func (v *API) EmobilityStatus(vin, model string) (EmobilityResponse, error) {
+	var res EmobilityResponse
+
+	uri := fmt.Sprintf("https://api.porsche.com/e-mobility/de/de_DE/%s/%s?timezone=Europe/Berlin", model, vin)
+	req, err := v.request(true, uri)
+	if err != nil {
+		return res, err
+	}
+
+	err = v.DoJSON(req, &res)
+	if err != nil && res.PcckErrorMessage != "" {
+		err = errors.New(res.PcckErrorMessage)
+	}
+
+	return res, err
+}

--- a/vehicle/porsche/api_emobility.go
+++ b/vehicle/porsche/api_emobility.go
@@ -12,14 +12,12 @@ import (
 
 // EmobilityAPI is the Porsche Emobility API
 type EmobilityAPI struct {
-	log *util.Logger
 	*request.Helper
 }
 
 // NewEmobilityAPI creates a new vehicle
 func NewEmobilityAPI(log *util.Logger, identity oauth2.TokenSource) *EmobilityAPI {
 	v := &EmobilityAPI{
-		log:    log,
 		Helper: request.NewHelper(log),
 	}
 
@@ -38,7 +36,6 @@ func NewEmobilityAPI(log *util.Logger, identity oauth2.TokenSource) *EmobilityAP
 
 func (v *EmobilityAPI) Capabilities(vin string) (CapabilitiesResponse, error) {
 	var res CapabilitiesResponse
-
 	uri := fmt.Sprintf("https://api.porsche.com/e-mobility/vcs/capabilities/%s", vin)
 	err := v.GetJSON(uri, &res)
 	return res, err

--- a/vehicle/porsche/api_emobility.go
+++ b/vehicle/porsche/api_emobility.go
@@ -1,0 +1,58 @@
+package porsche
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+	"golang.org/x/oauth2"
+)
+
+// EmobilityAPI is the Porsche Emobility API
+type EmobilityAPI struct {
+	log *util.Logger
+	*request.Helper
+}
+
+// NewEmobilityAPI creates a new vehicle
+func NewEmobilityAPI(log *util.Logger, identity oauth2.TokenSource) *EmobilityAPI {
+	v := &EmobilityAPI{
+		log:    log,
+		Helper: request.NewHelper(log),
+	}
+
+	v.Client.Transport = &transport.Decorator{
+		Base: &oauth2.Transport{
+			Source: identity,
+			Base:   v.Client.Transport,
+		},
+		Decorator: transport.DecorateHeaders(map[string]string{
+			"apikey": EmobilityOAuth2Config.ClientID,
+		}),
+	}
+
+	return v
+}
+
+func (v *EmobilityAPI) Capabilities(vin string) (CapabilitiesResponse, error) {
+	var res CapabilitiesResponse
+
+	uri := fmt.Sprintf("https://api.porsche.com/e-mobility/vcs/capabilities/%s", vin)
+	err := v.GetJSON(uri, &res)
+	return res, err
+}
+
+// Status implements the vehicle status response
+func (v *EmobilityAPI) Status(vin, model string) (EmobilityResponse, error) {
+	var res EmobilityResponse
+
+	uri := fmt.Sprintf("https://api.porsche.com/e-mobility/de/de_DE/%s/%s?timezone=Europe/Berlin", model, vin)
+	err := v.GetJSON(uri, &res)
+	if err != nil && res.PcckErrorMessage != "" {
+		err = errors.New(res.PcckErrorMessage)
+	}
+
+	return res, err
+}

--- a/vehicle/porsche/identity.go
+++ b/vehicle/porsche/identity.go
@@ -17,8 +17,27 @@ import (
 )
 
 const (
-	ClientID          = "4mPO3OE5Srjb1iaUGWsbqKBvvesya8oA"
-	EmobilityClientID = "NJOxLv4QQNrpZnYQbb7mCvdiMxQWkHDq"
+	OAuthURI = "https://login.porsche.com"
+)
+
+// https://login.porsche.com/.well-known/openid-configuration
+var (
+	OAuth2Config = &oauth2.Config{
+		ClientID:    "4mPO3OE5Srjb1iaUGWsbqKBvvesya8oA",
+		RedirectURL: "https://my.porsche.com/core/de/de_DE/",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  OAuthURI + "/as/authorization.oauth2",
+			TokenURL: OAuthURI + "/as/token.oauth2",
+		},
+		Scopes: []string{"openid"},
+	}
+
+	EmobilityOAuth2Config = &oauth2.Config{
+		ClientID:    "NJOxLv4QQNrpZnYQbb7mCvdiMxQWkHDq",
+		RedirectURL: "https://my.porsche.com/myservices/auth/auth.html",
+		Endpoint:    OAuth2Config.Endpoint,
+		Scopes:      OAuth2Config.Scopes,
+	}
 )
 
 type AccessTokens struct {
@@ -115,11 +134,11 @@ func (v *Identity) Login() (AccessTokens, error) {
 func (v *Identity) fetchToken(emobility bool) (oauth.Token, error) {
 	var pr oauth.Token
 
-	actualClientID := ClientID
+	actualClientID := OAuth2Config.ClientID
 	redirectURI := "https://my.porsche.com/core/de/de_DE/"
 
 	if emobility {
-		actualClientID = EmobilityClientID
+		actualClientID = EmobilityOAuth2Config.ClientID
 		redirectURI = "https://my.porsche.com/myservices/auth/auth.html"
 	}
 
@@ -188,7 +207,7 @@ func (v *Identity) FindVehicle(accessTokens AccessTokens, vin string) (string, e
 	vehiclesURL := "https://api.porsche.com/core/api/v3/de/de_DE/vehicles"
 	req, err := request.New(http.MethodGet, vehiclesURL, nil, map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", accessTokens.Token.AccessToken),
-		"apikey":        ClientID,
+		"apikey":        OAuth2Config.ClientID,
 	})
 
 	if err != nil {
@@ -221,7 +240,7 @@ func (v *Identity) FindVehicle(accessTokens AccessTokens, vin string) (string, e
 	uri := fmt.Sprintf("%s/%s/pairing", vehiclesURL, foundVehicle.VIN)
 	req, err = request.New(http.MethodGet, uri, nil, map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", accessTokens.Token.AccessToken),
-		"apikey":        ClientID,
+		"apikey":        OAuth2Config.ClientID,
 	})
 
 	if err != nil {
@@ -242,7 +261,7 @@ func (v *Identity) FindVehicle(accessTokens AccessTokens, vin string) (string, e
 	uri = fmt.Sprintf("https://api.porsche.com/vehicle-data/de/de_DE/status/%s", foundVehicle.VIN)
 	req, err = request.New(http.MethodGet, uri, nil, map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", accessTokens.Token.AccessToken),
-		"apikey":        ClientID,
+		"apikey":        OAuth2Config.ClientID,
 	})
 
 	if err != nil {

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -61,10 +61,10 @@ func (v *Provider) request(emobility bool, uri string) (*http.Request, error) {
 		v.accessTokens = newAccessTokens
 	}
 
-	apiKey := ClientID
+	apiKey := OAuth2Config.ClientID
 	apiAccessToken := v.accessTokens.Token.AccessToken
 	if emobility {
-		apiKey = EmobilityClientID
+		apiKey = EmobilityOAuth2Config.ClientID
 		apiAccessToken = v.accessTokens.EmobilityToken.AccessToken
 	}
 

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -1,144 +1,39 @@
 package porsche
 
 import (
-	"errors"
-	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/request"
 )
 
 // Provider is an api.Vehicle implementation for Porsche PHEV cars
 type Provider struct {
-	log *util.Logger
-	*request.Helper
-	accessTokens     AccessTokens
-	identity         *Identity
-	carModel         string
-	statusG          func() (interface{}, error)
-	statusEmobilityG func() (interface{}, error)
+	statusG    func() (interface{}, error)
+	emobilityG func() (interface{}, error)
 }
 
 // NewProvider creates a new vehicle
-func NewProvider(log *util.Logger, identity *Identity, accessTokens AccessTokens, vin string, cache time.Duration) *Provider {
+func NewProvider(log *util.Logger, api *API, vin, model string, cache time.Duration) *Provider {
 	impl := &Provider{
-		log:          log,
-		Helper:       request.NewHelper(log),
-		accessTokens: accessTokens,
-		identity:     identity,
+		statusG: provider.NewCached(func() (interface{}, error) {
+			return api.Status(vin)
+		}, cache).InterfaceGetter(),
+
+		emobilityG: provider.NewCached(func() (interface{}, error) {
+			return api.EmobilityStatus(vin, model)
+		}, cache).InterfaceGetter(),
 	}
-
-	impl.Client.Jar = identity.Client.Jar
-
-	impl.statusG = provider.NewCached(func() (interface{}, error) {
-		return impl.status(vin)
-	}, cache).InterfaceGetter()
-
-	impl.statusEmobilityG = provider.NewCached(func() (interface{}, error) {
-		return impl.statusEmobility(vin)
-	}, cache).InterfaceGetter()
 
 	return impl
-}
-
-func (v *Provider) request(emobility bool, uri string) (*http.Request, error) {
-	defaultToken := v.accessTokens.Token
-	emobilityToken := v.accessTokens.EmobilityToken
-
-	// if any of the two Tokens are empty or expired, login again
-	if defaultToken.AccessToken == "" ||
-		time.Since(defaultToken.Expiry) > 0 ||
-		emobilityToken.AccessToken == "" ||
-		time.Since(emobilityToken.Expiry) > 0 {
-		newAccessTokens, err := v.identity.Login()
-		if err != nil {
-			return nil, err
-		}
-		v.accessTokens = newAccessTokens
-	}
-
-	apiKey := OAuth2Config.ClientID
-	apiAccessToken := v.accessTokens.Token.AccessToken
-	if emobility {
-		apiKey = EmobilityOAuth2Config.ClientID
-		apiAccessToken = v.accessTokens.EmobilityToken.AccessToken
-	}
-
-	req, err := request.New(http.MethodGet, uri, nil, map[string]string{
-		"Authorization": fmt.Sprintf("Bearer %s", apiAccessToken),
-		"apikey":        apiKey,
-	})
-
-	return req, err
-}
-
-// Status implements the vehicle status response
-func (v *Provider) status(vin string) (StatusResponse, error) {
-	var res StatusResponse
-
-	uri := fmt.Sprintf("https://api.porsche.com/vehicle-data/de/de_DE/status/%s", vin)
-	req, err := v.request(false, uri)
-	if err != nil {
-		return res, err
-	}
-
-	err = v.DoJSON(req, &res)
-
-	return res, err
-}
-
-// Status implements the vehicle status response
-func (v *Provider) statusEmobility(vin string) (EmobilityResponse, error) {
-	var res EmobilityResponse
-
-	if v.carModel == "" {
-		// Note: As of 27.10.21 the capabilities API needs to be called AFTER a
-		//   call to status() as it otherwise returns an HTTP 502 error.
-		//   The reason is unknown, even when tested with 100% identical Headers.
-		//   It seems to be a new backend related issue.
-
-		if _, err := v.status(vin); err != nil {
-			return res, err
-		}
-
-		uri := fmt.Sprintf("https://api.porsche.com/e-mobility/vcs/capabilities/%s", vin)
-
-		req, err := v.request(true, uri)
-		if err != nil {
-			return res, err
-		}
-
-		var cr CapabilitiesResponse
-		err = v.DoJSON(req, &cr)
-		if err != nil {
-			return res, err
-		}
-		v.carModel = cr.CarModel
-	}
-
-	uri := fmt.Sprintf("https://api.porsche.com/e-mobility/de/de_DE/%s/%s?timezone=Europe/Berlin", v.carModel, vin)
-	req, err := v.request(true, uri)
-	if err != nil {
-		return res, err
-	}
-
-	err = v.DoJSON(req, &res)
-	if err != nil && res.PcckErrorMessage != "" {
-		err = errors.New(res.PcckErrorMessage)
-	}
-
-	return res, err
 }
 
 var _ api.Battery = (*Provider)(nil)
 
 // SoC implements the api.Vehicle interface
 func (v *Provider) SoC() (float64, error) {
-	res, err := v.statusEmobilityG()
+	res, err := v.emobilityG()
 	if res, ok := res.(EmobilityResponse); err == nil && ok {
 		return float64(res.BatteryChargeStatus.StateOfChargeInPercentage), nil
 	}
@@ -155,7 +50,7 @@ var _ api.VehicleRange = (*Provider)(nil)
 
 // Range implements the api.VehicleRange interface
 func (v *Provider) Range() (int64, error) {
-	res, err := v.statusEmobilityG()
+	res, err := v.emobilityG()
 	if res, ok := res.(EmobilityResponse); err == nil && ok {
 		return res.BatteryChargeStatus.RemainingERange.ValueInKilometers, nil
 	}
@@ -172,7 +67,7 @@ var _ api.VehicleFinishTimer = (*Provider)(nil)
 
 // FinishTime implements the api.VehicleFinishTimer interface
 func (v *Provider) FinishTime() (time.Time, error) {
-	res, err := v.statusEmobilityG()
+	res, err := v.emobilityG()
 	if res, ok := res.(EmobilityResponse); err == nil && ok {
 		return time.Now().Add(time.Duration(res.BatteryChargeStatus.RemainingChargeTimeUntil100PercentInMinutes) * time.Minute), err
 	}
@@ -184,7 +79,7 @@ var _ api.ChargeState = (*Provider)(nil)
 
 // Status implements the api.ChargeState interface
 func (v *Provider) Status() (api.ChargeStatus, error) {
-	res, err := v.statusEmobilityG()
+	res, err := v.emobilityG()
 	if res, ok := res.(EmobilityResponse); err == nil && ok {
 		switch res.BatteryChargeStatus.PlugState {
 		case "DISCONNECTED":
@@ -212,7 +107,7 @@ var _ api.VehicleClimater = (*Provider)(nil)
 
 // Climater implements the api.VehicleClimater interface
 func (v *Provider) Climater() (active bool, outsideTemp float64, targetTemp float64, err error) {
-	res, err := v.statusEmobilityG()
+	res, err := v.emobilityG()
 	if res, ok := res.(EmobilityResponse); err == nil && ok {
 		switch res.DirectClimatisation.ClimatisationState {
 		case "OFF":

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -15,14 +15,14 @@ type Provider struct {
 }
 
 // NewProvider creates a new vehicle
-func NewProvider(log *util.Logger, api *API, vin, model string, cache time.Duration) *Provider {
+func NewProvider(log *util.Logger, api *API, emobility *EmobilityAPI, vin, model string, cache time.Duration) *Provider {
 	impl := &Provider{
 		statusG: provider.NewCached(func() (interface{}, error) {
 			return api.Status(vin)
 		}, cache).InterfaceGetter(),
 
 		emobilityG: provider.NewCached(func() (interface{}, error) {
-			return api.EmobilityStatus(vin, model)
+			return emobility.Status(vin, model)
 		}, cache).InterfaceGetter(),
 	}
 

--- a/vehicle/porsche/types.go
+++ b/vehicle/porsche/types.go
@@ -1,6 +1,6 @@
 package porsche
 
-type VehicleResponse struct {
+type Vehicle struct {
 	VIN              string
 	ModelDescription string
 	Pictures         []struct {


### PR DESCRIPTION
This PR:

- uses oauth2 for code exchange and token refresh
- splits the standard and emobility apis
- aligns the implementation with other vehicle apis
- reduces internal dependencies and complexity of code