### PR TITLE
Update pvtimer handling

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -880,6 +880,12 @@ func (lp *LoadPoint) elapsePVTimer() {
 	lp.publishTimer(pvTimer, 0, timerInactive)
 }
 
+// resetPVTimer resets the pv enable/disable timer to disabled state
+func (lp *LoadPoint) resetPVTimer() {
+	lp.pvTimer = time.Time{}
+	lp.publishTimer(pvTimer, 0, timerInactive)
+}
+
 // scalePhasesIfAvailable scales if api.ChargePhases is available
 func (lp *LoadPoint) scalePhasesIfAvailable(phases int) error {
 	err := lp.scalePhases(phases)
@@ -1100,10 +1106,10 @@ func (lp *LoadPoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64, batter
 			}
 		} else {
 			// reset timer
-			lp.log.DEBUG.Printf("pv disable timer reset: %v", lp.Disable.Delay)
-			lp.pvTimer = lp.clock.Now()
-
-			lp.publishTimer(pvTimer, 0, timerInactive)
+			if !lp.pvTimer.IsZero() {
+				lp.log.DEBUG.Printf("pv disable timer reset")
+				lp.resetPVTimer()
+			}
 		}
 
 		// lp.log.DEBUG.Println("pv disable timer: keep enabled")
@@ -1135,10 +1141,10 @@ func (lp *LoadPoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64, batter
 			}
 		} else {
 			// reset timer
-			lp.log.DEBUG.Printf("pv enable timer reset: %v", lp.Enable.Delay)
-			lp.pvTimer = lp.clock.Now()
-
-			lp.publishTimer(pvTimer, 0, timerInactive)
+			if !lp.pvTimer.IsZero() {
+				lp.log.DEBUG.Printf("pv enable timer reset")
+				lp.resetPVTimer()
+			}
 		}
 
 		// lp.log.DEBUG.Println("pv enable timer: keep disabled")
@@ -1148,9 +1154,7 @@ func (lp *LoadPoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64, batter
 	// reset timer to disabled state
 	if !lp.pvTimer.IsZero() {
 		lp.log.DEBUG.Printf("pv timer reset")
-		lp.pvTimer = time.Time{}
-
-		lp.publishTimer(pvTimer, 0, timerInactive)
+		lp.resetPVTimer()
 	}
 
 	// cap at maximum current

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -347,6 +347,10 @@ func (lp *LoadPoint) evChargeStopHandler() {
 
 	// soc update reset
 	lp.socUpdated = time.Time{}
+
+	// reset pv enable/disable timer
+	lp.log.DEBUG.Printf("pv timer reset")
+	lp.resetPVTimer()
 }
 
 // evVehicleConnectHandler sends external start event

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1044,7 +1044,7 @@ func (lp *LoadPoint) publishTimer(name string, delay time.Duration, action strin
 	if action == timerInactive {
 		lp.log.DEBUG.Printf("%s action: %s", name, action)
 	} else {
-		lp.log.DEBUG.Printf("%s action: %s in %v", name, action, remaining)
+		lp.log.DEBUG.Printf("%s action: %s in %v", name, action, remaining.Round(time.Second))
 	}
 }
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -262,8 +262,8 @@ func TestPVHysteresis(t *testing.T) {
 			{-500, 1, 0},
 			{-499, dt - 1, 0}, // should reset timer
 			{-500, dt + 1, 0}, // new begin of timer
-			{-500, 2*dt - 2, 0},
-			{-500, 2*dt - 1, minA},
+			{-500, 2 * dt, 0},
+			{-500, 2*dt + 1, minA},
 		}},
 		// reset enable timer when threshold not met while timer active and threshold not configured
 		{false, 0, 0, []se{
@@ -271,16 +271,16 @@ func TestPVHysteresis(t *testing.T) {
 			{-6 * 100 * 10, dt + 1, 0},
 			{-6 * 100 * 10, dt + 2, 0},
 			{-6 * 100 * 10, 2 * dt, 0},
-			{-6 * 100 * 10, 2*dt + 2, minA},
+			{-6 * 100 * 10, 2*dt + 1, minA},
 		}},
 		// reset disable timer when threshold not met while timer active
 		{true, 0, 500, []se{
 			{500, 0, minA},
 			{500, 1, minA},
-			{499, dt - 1, minA},   // reset timer
-			{500, dt + 1, minA},   // within reset timer duration
-			{500, 2*dt - 2, minA}, // still within reset timer duration
-			{500, 2*dt - 1, 0},    // reset timer elapsed
+			{499, dt - 1, minA}, // reset timer
+			{500, dt + 1, minA}, // within reset timer duration
+			{500, 2 * dt, minA}, // still within reset timer duration
+			{500, 2*dt + 1, 0},  // reset timer elapsed
 		}},
 	}
 


### PR DESCRIPTION
1. Fix running PV timer when charging has been stopped

![Screenshot_20211222-140018_Ungoogled Chromium_small](https://user-images.githubusercontent.com/75251226/147389985-d4a87479-a8fb-493a-85da-2b4f1d663325.jpg)

2. Round remaining time to seconds for published timer (debug log)

  Old: `[lp-1  ] DEBUG 2021/12/25 17:43:32 pv action: disable in 8m39.995363443s`
  New: `[lp-1  ] DEBUG 2021/12/25 17:48:01 pv action: disable in 9m40s`

3.  add resetPVTimer function, reset enable and disable timers only when running