### PR TITLE
Various template improvements

### DIFF
--- a/cmd/configure/survey.go
+++ b/cmd/configure/survey.go
@@ -171,6 +171,9 @@ func (c *CmdConfigure) askValue(q question) string {
 		}
 
 		if q.valueType == templates.ParamValueTypeFloat {
+			if value == "" && !q.required {
+				return nil
+			}
 			_, err := strconv.ParseFloat(value, 64)
 			if err != nil {
 				return errors.New(c.localizedString("ValueError_Float", nil))
@@ -178,6 +181,10 @@ func (c *CmdConfigure) askValue(q question) string {
 		}
 
 		if q.valueType == templates.ParamValueTypeNumber {
+			if value == "" && !q.required {
+				return nil
+			}
+
 			intValue, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
 				return errors.New(c.localizedString("ValueError_Number", nil))

--- a/templates/README.md
+++ b/templates/README.md
@@ -76,17 +76,13 @@ Example Use Case: With SMA Home Manager, there can be a SMA Energy Meter used fo
 
 `loglevel` defindes the name that can be used in the `levels` configuration for adjusting the log level of individual devices/components/...
 
-## `paramsbase`
-
-`paramsbase` allows to use a predefined set of params, so they don't need to be redefined in each template. The `example` and `default` values for each predefined value can be overwritten.
-
-**Possible values**:
-
-- `vehicle`: Provides a set of params that are used in most vehicles
-
 ## `params`
 
 `params` describes the set of parameters the user needs to provide a value for.
+
+## `base`
+
+`base` reference value of a predefined params set defined in `parambaselist.yaml`, so these params don't need to be redefined in each template. The `example` and `default` values for each predefined value can be overwritten.
 
 ### `name`
 

--- a/templates/definition/meter/senec-home.yaml
+++ b/templates/definition/meter/senec-home.yaml
@@ -8,8 +8,6 @@ params:
 - name: host
   required: true
   example: 192.0.2.2
-- name: port
-  default: 8080
 render: |
   type: custom
   power:

--- a/templates/definition/parambaselist.yaml
+++ b/templates/definition/parambaselist.yaml
@@ -1,4 +1,4 @@
-vehicle:
+vehiclebase:
   params:
   - name: title
   - name: user
@@ -12,21 +12,8 @@ vehicle:
     default: '50'
   - name: cache
     advanced: true
-  - name: mode
-    advanced: true
-  - name: minSoC
-    advanced: true
-  - name: targetSoC
-    advanced: true
-  - name: minCurrent
-    advanced: true
-  - name: maxCurrent
-    advanced: true
-  - name: identifiers
-    advanced: true
-    valueType: stringlist
   render: |
-    {{define "vehicle-common"}}
+    {{define "vehicle-base"}}
     {{- if ne .title "" }}
     title: {{ .title }}
     {{- end }}
@@ -41,6 +28,24 @@ vehicle:
     {{- if ne .cache "" }}
     cache: {{ .cache }}
     {{- end }}
+    {{end}}
+vehicleidentify:
+  params:
+  - name: mode
+    advanced: true
+  - name: minSoC
+    advanced: true
+  - name: targetSoC
+    advanced: true
+  - name: minCurrent
+    advanced: true
+  - name: maxCurrent
+    advanced: true
+  - name: identifiers
+    advanced: true
+    valueType: stringlist
+  render: |
+    {{define "vehicle-identify"}}
     {{- if or (ne .mode "") (ne .minSoC "") (ne .targetSoC "") (ne .minCurrent "") (ne .maxCurrent "") }}
     onIdentify:
     {{- if (ne .mode "") }}

--- a/templates/definition/vehicle/audi.yaml
+++ b/templates/definition/vehicle/audi.yaml
@@ -1,11 +1,13 @@
 template: audi
 description: Audi
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WAUZZZ...
 - name: capacity
   default: 60
 render: |
   type: audi
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/bmw.yaml
+++ b/templates/definition/vehicle/bmw.yaml
@@ -1,11 +1,13 @@
 template: bmw
 description: BMW
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WBMW...
 - name: capacity
   default: 65
 render: |
   type: bmw
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/carwings.yaml
+++ b/templates/definition/vehicle/carwings.yaml
@@ -1,9 +1,11 @@
 template: carwings
 description: Nissan Leaf (pre 2019)
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 50
 render: |
   type: carwings
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -1,9 +1,11 @@
 template: citroen
 description: Citroen
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 50
 render: |
   type: citroen
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/dacia.yaml
+++ b/templates/definition/vehicle/dacia.yaml
@@ -1,0 +1,11 @@
+template: dacia
+description: Dacia
+params:
+- base: vehiclebase
+- base: vehicleidentify
+- name: capacity
+  default: 27,4
+render: |
+  type: renault
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -1,9 +1,11 @@
 template: ds
 description: DS
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 50
 render: |
   type: ds
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/evnotify.yaml
+++ b/templates/definition/vehicle/evnotify.yaml
@@ -9,6 +9,7 @@ params:
 - name: capacity
   default: 64
   valuetype: float
+- base: vehicleidentify
 render: |
   type: custom
   {{- if ne .title "" }}

--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -1,16 +1,18 @@
 template: fiat
 description: Fiat
-paramsbase: vehicle
 params:
-- name: pin
-  mask: true
+- base: vehiclebase
 - name: vin
   example: ZFAE...
 - name: capacity
   default: 42
+- name: pin
+  mask: true
+- base: vehicleidentify
 render: |
   type: fiat
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
   {{- if ne .pin "" }}
   pin: {{ .pin }} #mandatory to deep refresh SoC
   {{- end }}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/ford.yaml
+++ b/templates/definition/vehicle/ford.yaml
@@ -1,11 +1,13 @@
 template: ford
 description: Ford
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WF0FXX...
 - name: capacity
   default: 10
 render: |
   type: ford
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/hyundai.yaml
+++ b/templates/definition/vehicle/hyundai.yaml
@@ -1,9 +1,11 @@
 template: hyundai
 description: Hyundai
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 64
 render: |
   type: hyundai
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -1,9 +1,11 @@
 template: kia
 description: Kia
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 64
 render: |
   type: kia
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/mini.yaml
+++ b/templates/definition/vehicle/mini.yaml
@@ -1,11 +1,13 @@
 template: mini
 description: Mini
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WBMW...
 - name: capacity
   default: 32
 render: |
   type: mini
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/nissan.yaml
+++ b/templates/definition/vehicle/nissan.yaml
@@ -1,9 +1,11 @@
 template: nissan
 description: Nissan
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 60
 render: |
   type: nissan
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/niu-e-scooter.yaml
+++ b/templates/definition/vehicle/niu-e-scooter.yaml
@@ -9,6 +9,7 @@ params:
   mask: true
 - name: serial
   required: true
+- base: vehicleidentify
 render: |
   type: niu
   {{- if ne .title "" }}

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -1,11 +1,13 @@
 template: opel
 description: Opel
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WP0...
 - name: capacity
   default: 50
 render: |
   type: opel
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/ovms.yaml
+++ b/templates/definition/vehicle/ovms.yaml
@@ -11,6 +11,7 @@ params:
   required: true
 - name: capacity
   default: 12
+- base: vehicleidentify
 render: |
   type: ovms
   {{- if ne .title "" }}

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -1,9 +1,11 @@
 template: peugeot
 description: Peugeot
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 50
 render: |
   type: peugeot
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/porsche.yaml
+++ b/templates/definition/vehicle/porsche.yaml
@@ -1,9 +1,11 @@
 template: porsche
 description: Porsche
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 83.4
 render: |
   type: porsche
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/renault.yaml
+++ b/templates/definition/vehicle/renault.yaml
@@ -1,11 +1,13 @@
 template: renault
 description: Renault
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WREN...
 - name: capacity
   default: 60
 render: |
   type: renault
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/seat.yaml
+++ b/templates/definition/vehicle/seat.yaml
@@ -1,9 +1,11 @@
 template: seat
 description: Seat (Cupra, Mii)
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 10
 render: |
   type: seat
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/skoda.yaml
+++ b/templates/definition/vehicle/skoda.yaml
@@ -1,9 +1,11 @@
 template: skoda
 description: Skoda (Citigo)
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 10
 render: |
   type: skoda
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/skodaenyaq.yaml
+++ b/templates/definition/vehicle/skodaenyaq.yaml
@@ -1,9 +1,11 @@
 template: enyaq
 description: Skoda (Enyaq)
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 50
 render: |
   type: enyaq
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -16,6 +16,7 @@ params:
   example: W...
 - name: capacity
   default: 90
+- base: vehicleidentify
 render: |
   type: tesla
   {{- if ne .title "" }}
@@ -28,3 +29,4 @@ render: |
   {{- if ne .vin "" }}
   vin: {{ .vin }}
   {{- end }}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/tronity.yaml
+++ b/templates/definition/vehicle/tronity.yaml
@@ -16,6 +16,7 @@ params:
   example: W...
 - name: capacity
   default: 10
+- base: vehicleidentify
 render: |
   type: tronity
   {{- if ne .title "" }}

--- a/templates/definition/vehicle/volvo.yaml
+++ b/templates/definition/vehicle/volvo.yaml
@@ -1,9 +1,11 @@
 template: volvo
 description: Volvo
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: capacity
   default: 50
 render: |
   type: volvo
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/vw.yaml
+++ b/templates/definition/vehicle/vw.yaml
@@ -1,11 +1,13 @@
 template: vw
 description: Volkswagen (We Connect)
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WVWZZZ...
 - name: capacity
   default: 10
 render: |
   type: vw
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/definition/vehicle/vwid.yaml
+++ b/templates/definition/vehicle/vwid.yaml
@@ -1,11 +1,13 @@
 template: id
 description: Volkswagen (We Connect ID)
-paramsbase: vehicle
 params:
+- base: vehiclebase
+- base: vehicleidentify
 - name: vin
   example: WVWZZZ...
 - name: capacity
   default: 50
 render: |
   type: id
-  {{include "vehicle-common" .}}
+  {{include "vehicle-base" .}}
+  {{include "vehicle-identify" .}}

--- a/templates/docs/meter/senec-home-battery.yaml
+++ b/templates/docs/meter/senec-home-battery.yaml
@@ -2,5 +2,4 @@ type: template
 template: senec-home
 description: SENEC.Home
 usage: battery 
-host: 192.0.2.2 
-port: 8080
+host: 192.0.2.2

--- a/templates/docs/meter/senec-home-grid.yaml
+++ b/templates/docs/meter/senec-home-grid.yaml
@@ -2,5 +2,4 @@ type: template
 template: senec-home
 description: SENEC.Home
 usage: grid 
-host: 192.0.2.2 
-port: 8080
+host: 192.0.2.2

--- a/templates/docs/meter/senec-home-pv.yaml
+++ b/templates/docs/meter/senec-home-pv.yaml
@@ -2,5 +2,4 @@ type: template
 template: senec-home
 description: SENEC.Home
 usage: pv 
-host: 192.0.2.2 
-port: 8080
+host: 192.0.2.2

--- a/templates/docs/vehicle/dacia.yaml
+++ b/templates/docs/vehicle/dacia.yaml
@@ -1,0 +1,7 @@
+type: template
+template: dacia
+description: Dacia
+user:
+password:
+vin: W... 
+capacity: 27,4

--- a/util/templates/init.go
+++ b/util/templates/init.go
@@ -41,7 +41,9 @@ func loadTemplates(class string) {
 		if err = yaml.Unmarshal(b, &tmpl); err != nil {
 			return fmt.Errorf("reading template '%s' failed: %w", filepath, err)
 		}
-		tmpl.ResolveParamBase()
+		if err = tmpl.ResolveParamBases(); err != nil {
+			return err
+		}
 		if err = tmpl.Validate(); err != nil {
 			return err
 		}


### PR DESCRIPTION
- Remove unused port param in senec-home template
- Support for multiple predefined param sets, also adds identifier params to Tesla, Tronity, OVMS, ...
- Properly handle optional number/float checks
- Add Dacia vehicle template