### PR TITLE
Move single device configuration to advanced mode

### DIFF
--- a/cmd/configure/localization/de.toml
+++ b/cmd/configure/localization/de.toml
@@ -2,7 +2,7 @@ Intro = "Die nächsten Schritte führen durch die Einrichtung einer Konfiguratio
 
 Flow_Type = "Was möchtest du machen?"
 Flow_Type_NewConfiguration = "Eine neue evcc Konfigurationsdatei erstellen"
-Flow_Type_SingleDevice = "Ein einzelnes Gerät konfigurieren"
+Flow_Type_SingleDevice = "Ein einzelnes Gerät konfigurieren (muss manuell in eine Konfigurationsdatei eingetragen werden!)"
 
 Flow_NewConfiguration_Setup = "- Hausinstallation einrichten"
 Flow_NewConfiguration_Select = "Wähle eines der folgenden PV Komplettsysteme aus, oder '{{ .ItemNotPresent }}' falls keines dieser Geräte vorhanden ist"

--- a/cmd/configure/localization/en.toml
+++ b/cmd/configure/localization/en.toml
@@ -2,7 +2,7 @@ Intro = "The next steps will guide you through the creation of a configuration f
 
 Flow_Type = "What do you want to do?"
 Flow_Type_NewConfiguration = "Create a new evcc configuration file"
-Flow_Type_SingleDevice = "Configure a single device"
+Flow_Type_SingleDevice = "Configure a single device (has to be added manually to a configuration file!)"
 
 Flow_NewConfiguration_Setup = "- Setup meters (house installation)"
 Flow_NewConfiguration_Select = "Choose one of the following PV systems, or '{{ .ItemNotPresent }}' if you have none of them"

--- a/cmd/configure/main.go
+++ b/cmd/configure/main.go
@@ -65,6 +65,11 @@ func (c *CmdConfigure) Run(log *util.Logger, flagLang string, advancedMode, expa
 
 	c.setDefaultTexts()
 
+	if !c.advancedMode {
+		c.flowNewConfigFile()
+		return
+	}
+
 	fmt.Println()
 	fmt.Println(c.localizedString("Intro", nil))
 	flowChoices := []string{


### PR DESCRIPTION
- move the single device configuration to advanced mode only, as it is not a common use case
- clarify that single device configuration means the user has to add the output to a configuration file manually