### PR TITLE
Change Timeformat in logs to support debugging

### DIFF
--- a/util/log.go
+++ b/util/log.go
@@ -49,7 +49,7 @@ func NewLogger(area string) *Logger {
 
 	level := LogLevelForArea(area)
 	redactor := new(Redactor)
-	notepad := jww.NewNotepad(level, level, redactor, io.Discard, padded, log.Ldate|log.Ltime)
+	notepad := jww.NewNotepad(level, level, redactor, io.Discard, padded, log.Ldate|log.Lmicroseconds)
 
 	logger := &Logger{
 		Notepad:  notepad,


### PR DESCRIPTION
supports debugging when aligning externally collected information like network dumps with log entries, therefore add milliseconds to each log entry evcc writes