### PR TITLE
Update default Value capacity

### DIFF
--- a/templates/definition/vehicle/dacia.yaml
+++ b/templates/definition/vehicle/dacia.yaml
@@ -4,7 +4,7 @@ params:
 - base: vehiclebase
 - base: vehicleidentify
 - name: capacity
-  default: 27,4
+  default: 27.4
 render: |
   type: renault
   {{include "vehicle-base" .}}


### PR DESCRIPTION
HIer wurde ein komma verwendet was beim übernehmen in der Konfiguration zum Fehler führt. Es muss ein Punkt sein.