### PR TITLE
Add action to deploy generated template docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,32 @@
+name: Deploy updated templates
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  docupdate:
+    name: Deploy updated templates
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Clean git
+      run: |
+        git checkout go.*
+        rm -rf flags buildflags
+
+    - name: Deploy to docs repo
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        deploy_key: ${{ secrets.GH_API_TOKEN }}
+        publish_dir: ./templates/docs
+        external_repository: evcc-io/docs
+        publish_branch: master
+        destination_dir: templates
+        allow_empty_commit: false
+        commit_message: Templates update
+      if: ${{ success() }}


### PR DESCRIPTION
This deploys the current content of `/templates/docs` to the `templates` folder in the docs repo