### PR TITLE
Prevent building twice when pushing to a PR

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,6 +1,11 @@
 name: Default
 
-on: [push, pull_request, workflow_call]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_call:
 
 jobs:
 


### PR DESCRIPTION
Created PRs and commit pushes to PRs are all already handled by `pull_request`. Having `push` without limitations causes 2 build runs on every PR commit push.

Also the `push` scenario is only required for pushes (direct or merges) to the master branch.