### PR TITLE
FritzDect static mode to provide B (disabled) & C (enabled) status by switch state

### DIFF
--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -153,7 +153,7 @@ var _ api.Meter = (*FritzDECT)(nil)
 // CurrentPower implements the api.Meter interface
 func (c *FritzDECT) CurrentPower() (float64, error) {
 	power, err := c.fritzdect.CurrentPower()
-	if power < c.standbypower {
+	if power < c.standbypower || c.powerless {
 		power = 0
 	}
 

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -152,7 +152,7 @@ var _ api.Meter = (*FritzDECT)(nil)
 // CurrentPower implements the api.Meter interface
 func (c *FritzDECT) CurrentPower() (float64, error) {
 	power, err := c.fritzdect.CurrentPower()
-	if power < c.standbypower || c.staticmode {
+	if power < c.standbypower && !c.staticmode {
 		power = 0
 	}
 

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -59,7 +59,7 @@ func NewFritzDECT(uri, ain, user, password string, standbypower float64, powerle
 func (c *FritzDECT) Status() (api.ChargeStatus, error) {
 	// present 0/1 - DECT Switch connected to fritzbox (no/yes)
 	var present bool
-	var on bool
+	var Ison bool
 	var power float64
 
 	resp, err := c.fritzdect.ExecCmd("getswitchpresent")
@@ -74,7 +74,7 @@ func (c *FritzDECT) Status() (api.ChargeStatus, error) {
 	}
 
 	if c.powerless {
-		on, err = c.Enabled()
+		Ison, err = c.Enabled()
 		if err != nil {
 			return api.StatusNone, err
 		}
@@ -92,9 +92,9 @@ func (c *FritzDECT) Status() (api.ChargeStatus, error) {
 	case !c.powerless && power > c.standbypower:
 		return api.StatusC, err
 	// Simple powerless switch status rules
-	case c.powerless && !on:
+	case c.powerless && !Ison:
 		return api.StatusB, err
-	case c.powerless && on:
+	case c.powerless && Ison:
 		return api.StatusC, err
 	default:
 		return api.StatusNone, api.ErrNotAvailable
@@ -126,17 +126,17 @@ func (c *FritzDECT) Enable(enable bool) error {
 	// on 0/1 - DECT Switch state off/on (empty if unknown or error)
 	resp, err := c.fritzdect.ExecCmd(cmd)
 
-	var on bool
+	var Ison bool
 	if err == nil {
-		on, err = strconv.ParseBool(resp)
+		Ison, err = strconv.ParseBool(resp)
 	}
 
 	switch {
 	case err != nil:
 		return err
-	case enable && !on:
+	case enable && !Ison:
 		return errors.New("switchOn failed")
-	case !enable && on:
+	case !enable && Ison:
 		return errors.New("switchOff failed")
 	default:
 		return nil

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -164,6 +164,11 @@ var _ api.ChargeRater = (*FritzDECT)(nil)
 
 // ChargedEnergy implements the api.ChargeRater interface
 func (c *FritzDECT) ChargedEnergy() (float64, error) {
+	// no charge in case of powerless use
+	if c.powerless {
+		return 0, nil
+	}
+
 	// fetch basicdevicestats
 	resp, err := c.fritzdect.ExecCmd("getbasicdevicestats")
 	if err != nil {

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -58,7 +58,7 @@ func NewFritzDECT(uri, ain, user, password string, standbypower float64) (*Fritz
 func (c *FritzDECT) Status() (api.ChargeStatus, error) {
 	// present 0/1 - DECT Switch connected to fritzbox (no/yes)
 	var present bool
-	var isOn bool
+	var on bool
 	var power float64
 
 	resp, err := c.fritzdect.ExecCmd("getswitchpresent")
@@ -73,15 +73,15 @@ func (c *FritzDECT) Status() (api.ChargeStatus, error) {
 	}
 
 	if c.staticmode {
-		isOn, err = c.Enabled()
+		on, err = c.Enabled()
 		if err != nil {
 			return api.StatusNone, err
 		}
 		switch {
 		// Simple staticmode switch status rules
-		case !isOn:
+		case !on:
 			return api.StatusB, err
-		case isOn:
+		case on:
 			return api.StatusC, err
 		}
 	} else {
@@ -126,17 +126,17 @@ func (c *FritzDECT) Enable(enable bool) error {
 	// on 0/1 - DECT Switch state off/on (empty if unknown or error)
 	resp, err := c.fritzdect.ExecCmd(cmd)
 
-	var isOn bool
+	var on bool
 	if err == nil {
-		isOn, err = strconv.ParseBool(resp)
+		on, err = strconv.ParseBool(resp)
 	}
 
 	switch {
 	case err != nil:
 		return err
-	case enable && !isOn:
+	case enable && !on:
 		return errors.New("switchOn failed")
-	case !enable && isOn:
+	case !enable && on:
 		return errors.New("switchOff failed")
 	default:
 		return nil


### PR DESCRIPTION
First implementation of `powerless` parameter for FritzDect charger in order to support simple heat pump control use cases without metering the power and charged energy.

Other switches (shelly, tasmota,tp-link) will follow, as soon as parameter and behaviour are finally aligned/approved by evcc team.

Fix #2408