### PR TITLE
Re-add Porsche pairing check

### DIFF
--- a/vehicle/porsche.go
+++ b/vehicle/porsche.go
@@ -69,9 +69,9 @@ func NewPorscheFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	}
 
 	// check if vehicle is paired
-	// if res, err := api.PairingStatus(cc.VIN); err == nil && res.Status != porsche.PairingComplete {
-	// 	return nil, errors.New("vehicle is not paired with the My Porsche account")
-	// }
+	if res, err := api.PairingStatus(cc.VIN); err == nil && res.Status != porsche.PairingComplete {
+		return nil, errors.New("vehicle is not paired with the My Porsche account")
+	}
 
 	// check if vehicle provides status:
 	// some PHEVs do not provide any data


### PR DESCRIPTION
The new API doesn't seem to have a replacement for this yet, and the "old" check works with cars needing the new API for getting SoC values.

So we just add the check back in for now.