### PR TITLE
Properly shut down EEBUS mdns entry

### DIFF
--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/cmd/shutdown"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/shutdown"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -4,6 +4,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/shutdown"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -38,6 +39,9 @@ func runCharger(cmd *cobra.Command, args []string) {
 		log.FATAL.Fatal(err)
 	}
 
+	stopC := make(chan struct{})
+	go shutdown.Run(stopC)
+
 	chargers := cp.chargers
 	if len(args) == 1 {
 		arg := args[0]
@@ -48,4 +52,7 @@ func runCharger(cmd *cobra.Command, args []string) {
 	for name, v := range chargers {
 		d.DumpWithHeader(name, v)
 	}
+
+	close(stopC)
+	<-shutdown.Done()
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evcc-io/evcc/cmd/configure"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/shutdown"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -43,5 +44,11 @@ func runConfigure(cmd *cobra.Command, args []string) {
 
 	util.LogLevel(viper.GetString("log"), nil)
 
+	stopC := make(chan struct{})
+	go shutdown.Run(stopC)
+
 	impl.Run(log, lang, advanced, expand)
+
+	close(stopC)
+	<-shutdown.Done()
 }

--- a/cmd/configure/eebus.go
+++ b/cmd/configure/eebus.go
@@ -13,9 +13,8 @@ import (
 func (c *CmdConfigure) configureEEBus(conf map[string]interface{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
-		stopC := make(chan struct{})
-		shutdown.Register(func() { close(stopC) })
-		go server.EEBusInstance.Run(stopC)
+		go server.EEBusInstance.Run()
+		shutdown.Register(func() { server.EEBusInstance.Shutdown() })
 	}
 
 	return nil

--- a/cmd/configure/eebus.go
+++ b/cmd/configure/eebus.go
@@ -14,7 +14,7 @@ func (c *CmdConfigure) configureEEBus(conf map[string]interface{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
 		go server.EEBusInstance.Run()
-		shutdown.Register(func() { server.EEBusInstance.Shutdown() })
+		shutdown.Register(server.EEBusInstance.Shutdown)
 	}
 
 	return nil

--- a/cmd/configure/eebus.go
+++ b/cmd/configure/eebus.go
@@ -20,8 +20,7 @@ func (c *CmdConfigure) configureEEBus(conf map[string]interface{}) error {
 	return nil
 }
 
-// eebusCertificate setup EEBUS certificate
-// returns privagte key, public key and error
+// eebusCertificate creates EEBUS certificate and returns private/public key
 func (c *CmdConfigure) eebusCertificate() (map[string]interface{}, error) {
 	details := server.EEBUSDetails
 

--- a/cmd/configure/eebus.go
+++ b/cmd/configure/eebus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	certhelper "github.com/evcc-io/eebus/cert"
+	"github.com/evcc-io/evcc/cmd/shutdown"
 	"github.com/evcc-io/evcc/server"
 )
 
@@ -12,7 +13,9 @@ import (
 func (c *CmdConfigure) configureEEBus(conf map[string]interface{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
-		go server.EEBusInstance.Run()
+		stopC := make(chan struct{})
+		shutdown.Register(func() { close(stopC) })
+		go server.EEBusInstance.Run(stopC)
 	}
 
 	return nil

--- a/cmd/configure/helper.go
+++ b/cmd/configure/helper.go
@@ -161,8 +161,7 @@ func (c *CmdConfigure) processDeviceRequirements(templateItem templates.Template
 				return fmt.Errorf("%s: %s", c.localizedString("Requirements_EEBUS_Cert_Error", nil), err)
 			}
 
-			err = c.configureEEBus(eebusConfig)
-			if err != nil {
+			if err := c.configureEEBus(eebusConfig); err != nil {
 				return err
 			}
 
@@ -170,6 +169,7 @@ func (c *CmdConfigure) processDeviceRequirements(templateItem templates.Template
 			if err != nil {
 				return err
 			}
+
 			c.configuration.config.EEBUS = string(eebusYaml)
 			fmt.Println()
 			fmt.Println("--------------------------------------------")

--- a/cmd/configure/survey.go
+++ b/cmd/configure/survey.go
@@ -38,16 +38,15 @@ func (c *CmdConfigure) askConfigFailureNextStep() bool {
 }
 
 // select item from list
-func (c *CmdConfigure) askSelection(message string, items []string) (error, string, int) {
+func (c *CmdConfigure) askSelection(message string, items []string) (string, int, error) {
 	selection := ""
 	prompt := &survey.Select{
 		Message: message,
 		Options: items,
 	}
 
-	err := c.surveyAskOne(prompt, &selection)
-	if err != nil {
-		return err, "", 0
+	if err := c.surveyAskOne(prompt, &selection); err != nil {
+		return "", 0, err
 	}
 
 	var selectedIndex int
@@ -58,7 +57,7 @@ func (c *CmdConfigure) askSelection(message string, items []string) (error, stri
 		}
 	}
 
-	return err, selection, selectedIndex
+	return selection, selectedIndex, nil
 }
 
 // selectItem selects item from list
@@ -77,7 +76,7 @@ func (c *CmdConfigure) selectItem(deviceCategory DeviceCategory) templates.Templ
 	}
 
 	text := fmt.Sprintf("%s %s %s:", c.localizedString("Choose", nil), DeviceCategories[deviceCategory].article, DeviceCategories[deviceCategory].title)
-	err, _, selected := c.askSelection(text, items)
+	_, selected, err := c.askSelection(text, items)
 	if err != nil {
 		c.log.FATAL.Fatal(err)
 	}
@@ -87,7 +86,7 @@ func (c *CmdConfigure) selectItem(deviceCategory DeviceCategory) templates.Templ
 
 // askChoice selects item from list
 func (c *CmdConfigure) askChoice(label string, choices []string) (int, string) {
-	err, selection, index := c.askSelection(label, choices)
+	selection, index, err := c.askSelection(label, choices)
 	if err != nil {
 		c.log.FATAL.Fatal(err)
 	}

--- a/cmd/configure/survey.go
+++ b/cmd/configure/survey.go
@@ -45,19 +45,12 @@ func (c *CmdConfigure) askSelection(message string, items []string) (string, int
 		Options: items,
 	}
 
-	if err := c.surveyAskOne(prompt, &selection); err != nil {
-		return "", 0, err
+	err := c.surveyAskOne(prompt, &selection)
+	if err == nil {
+		return selection, funk.IndexOf(items, selection), nil
 	}
 
-	var selectedIndex int
-	for index, item := range items {
-		if item == selection {
-			selectedIndex = index
-			break
-		}
-	}
-
-	return selection, selectedIndex, nil
+	return "", 0, err
 }
 
 // selectItem selects item from list

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,6 +237,9 @@ func run(cmd *cobra.Command, args []string) {
 
 	go func() {
 		site.Run(stopC, conf.Interval)
+		if server.EEBusInstance != nil {
+			server.EEBusInstance.Shutdown()
+		}
 		close(exitC)
 	}()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	_ "net/http/pprof" // pprof handler
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -234,18 +235,16 @@ func run(cmd *cobra.Command, args []string) {
 	site.Prepare(valueChan, pushChan)
 
 	stopC := make(chan struct{})
-	exitC := make(chan struct{})
-
-	// TODO join waiting for shutdown handler
 	go shutdown.Run(stopC)
 
+	siteC := make(chan struct{})
 	go func() {
 		site.Run(stopC, conf.Interval)
-		close(exitC)
+		close(siteC)
 	}()
 
 	// uds health check listener
-	go server.HealthListener(site, exitC)
+	go server.HealthListener(site, siteC)
 
 	// catch signals
 	go func() {
@@ -254,6 +253,15 @@ func run(cmd *cobra.Command, args []string) {
 
 		<-signalC    // wait for signal
 		close(stopC) // signal loop to end
+
+		exitC := make(chan struct{})
+		wg := new(sync.WaitGroup)
+		wg.Add(2)
+
+		// wait for main loop and shutdown functions to finish
+		go func() { <-shutdown.Done(conf.Interval); wg.Done() }()
+		go func() { <-siteC; wg.Done() }()
+		go func() { wg.Wait(); close(exitC) }()
 
 		select {
 		case <-exitC: // wait for loop to end

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,7 +154,9 @@ func run(cmd *cobra.Command, args []string) {
 	log.INFO.Println("listening at", uri)
 
 	// setup environment
-	if err := configureEnvironment(conf); err != nil {
+	stopC := make(chan struct{})
+
+	if err := configureEnvironment(conf, stopC); err != nil {
 		log.FATAL.Fatal(err)
 	}
 
@@ -232,14 +234,10 @@ func run(cmd *cobra.Command, args []string) {
 	site.DumpConfig()
 	site.Prepare(valueChan, pushChan)
 
-	stopC := make(chan struct{})
 	exitC := make(chan struct{})
 
 	go func() {
 		site.Run(stopC, conf.Interval)
-		if server.EEBusInstance != nil {
-			server.EEBusInstance.Shutdown()
-		}
 		close(exitC)
 	}()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,11 +9,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/evcc-io/evcc/cmd/shutdown"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/server/updater"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/pipe"
-	"github.com/evcc-io/evcc/util/shutdown"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -11,6 +11,7 @@ import (
 	paho "github.com/eclipse/paho.mqtt.golang"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/proto/pb"
+	"github.com/evcc-io/evcc/cmd/shutdown"
 	"github.com/evcc-io/evcc/core"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/hems"
@@ -163,7 +164,9 @@ func configureHEMS(conf typedConfig, site *core.Site, httpd *server.HTTPd) hems.
 func configureEEBus(conf map[string]interface{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
-		go server.EEBusInstance.Run()
+		stopC := make(chan struct{})
+		shutdown.Register(func() { close(stopC) })
+		go server.EEBusInstance.Run(stopC)
 	}
 
 	return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -48,7 +48,7 @@ func loadConfigFile(cfgFile string) (conf config, err error) {
 	return conf, err
 }
 
-func configureEnvironment(conf config) (err error) {
+func configureEnvironment(conf config, stopC chan struct{}) (err error) {
 	// setup sponsorship
 	if conf.SponsorToken != "" {
 		err = configureSponsorship(conf.SponsorToken)
@@ -66,7 +66,7 @@ func configureEnvironment(conf config) (err error) {
 
 	// setup EEBus server
 	if err == nil && conf.EEBus != nil {
-		err = configureEEBus(conf.EEBus)
+		err = configureEEBus(conf.EEBus, stopC)
 	}
 
 	return
@@ -160,10 +160,10 @@ func configureHEMS(conf typedConfig, site *core.Site, httpd *server.HTTPd) hems.
 }
 
 // setup EEBus
-func configureEEBus(conf map[string]interface{}) error {
+func configureEEBus(conf map[string]interface{}, stopC <-chan struct{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
-		go server.EEBusInstance.Run()
+		go server.EEBusInstance.Run(stopC)
 	}
 
 	return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -164,9 +164,8 @@ func configureHEMS(conf typedConfig, site *core.Site, httpd *server.HTTPd) hems.
 func configureEEBus(conf map[string]interface{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
-		stopC := make(chan struct{})
-		shutdown.Register(func() { close(stopC) })
-		go server.EEBusInstance.Run(stopC)
+		go server.EEBusInstance.Run()
+		shutdown.Register(func() { server.EEBusInstance.Shutdown() })
 	}
 
 	return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -165,7 +165,7 @@ func configureEEBus(conf map[string]interface{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
 		go server.EEBusInstance.Run()
-		shutdown.Register(func() { server.EEBusInstance.Shutdown() })
+		shutdown.Register(server.EEBusInstance.Shutdown)
 	}
 
 	return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -48,7 +48,7 @@ func loadConfigFile(cfgFile string) (conf config, err error) {
 	return conf, err
 }
 
-func configureEnvironment(conf config, stopC chan struct{}) (err error) {
+func configureEnvironment(conf config) (err error) {
 	// setup sponsorship
 	if conf.SponsorToken != "" {
 		err = configureSponsorship(conf.SponsorToken)
@@ -66,7 +66,7 @@ func configureEnvironment(conf config, stopC chan struct{}) (err error) {
 
 	// setup EEBus server
 	if err == nil && conf.EEBus != nil {
-		err = configureEEBus(conf.EEBus, stopC)
+		err = configureEEBus(conf.EEBus)
 	}
 
 	return
@@ -160,10 +160,10 @@ func configureHEMS(conf typedConfig, site *core.Site, httpd *server.HTTPd) hems.
 }
 
 // setup EEBus
-func configureEEBus(conf map[string]interface{}, stopC <-chan struct{}) error {
+func configureEEBus(conf map[string]interface{}) error {
 	var err error
 	if server.EEBusInstance, err = server.NewEEBus(conf); err == nil {
-		go server.EEBusInstance.Run(stopC)
+		go server.EEBusInstance.Run()
 	}
 
 	return nil

--- a/cmd/shutdown/shutdown.go
+++ b/cmd/shutdown/shutdown.go
@@ -35,13 +35,9 @@ func Run(stopC <-chan struct{}) {
 
 	wg.Wait()
 	close(exitC)
-
-	println("Run wg.Wait exitC")
 }
 
 func Done(timeout ...time.Duration) <-chan struct{} {
-	println("Done")
-
 	to := time.Second
 	if len(timeout) == 1 {
 		to = timeout[0]
@@ -49,10 +45,8 @@ func Done(timeout ...time.Duration) <-chan struct{} {
 
 	select {
 	case <-exitC:
-		println("Done exitC closed")
 		return exitC
 	case <-time.After(to):
-		println("Done timeout")
 		exitC := make(chan struct{})
 		close(exitC)
 		return exitC

--- a/cmd/shutdown/shutdown.go
+++ b/cmd/shutdown/shutdown.go
@@ -35,9 +35,13 @@ func Run(stopC <-chan struct{}) {
 
 	wg.Wait()
 	close(exitC)
+
+	println("Run wg.Wait exitC")
 }
 
 func Done(timeout ...time.Duration) <-chan struct{} {
+	println("Done")
+
 	to := time.Second
 	if len(timeout) == 1 {
 		to = timeout[0]
@@ -45,8 +49,10 @@ func Done(timeout ...time.Duration) <-chan struct{} {
 
 	select {
 	case <-exitC:
+		println("Done exitC closed")
 		return exitC
 	case <-time.After(to):
+		println("Done timeout")
 		exitC := make(chan struct{})
 		close(exitC)
 		return exitC

--- a/cmd/shutdown/shutdown.go
+++ b/cmd/shutdown/shutdown.go
@@ -18,12 +18,10 @@ func Register(cb func()) {
 }
 
 func Run(stopC <-chan struct{}) {
-	mu.Lock()
-	defer mu.Unlock()
-
 	<-stopC
 	wg := new(sync.WaitGroup)
 
+	mu.Lock()
 	for _, cb := range handlers {
 		wg.Add(1)
 
@@ -32,6 +30,7 @@ func Run(stopC <-chan struct{}) {
 			wg.Done()
 		}(cb)
 	}
+	mu.Unlock()
 
 	wg.Wait()
 	close(exitC)

--- a/server/eebus.go
+++ b/server/eebus.go
@@ -37,6 +37,7 @@ type EEBus struct {
 	log               *util.Logger
 	srv               *server.Server
 	id                string
+	zc                *zeroconf.Server
 	clients           map[string]EEBusClientCBs
 	connectedClients  map[string]ship.Conn
 	discoveredClients map[string]*zeroconf.ServiceEntry
@@ -90,11 +91,13 @@ func NewEEBus(other map[string]interface{}) (*EEBus, error) {
 		Register:    true,
 	}
 
-	if _, err = srv.Announce(); err != nil {
+	zc, err := srv.Announce()
+	if err != nil {
 		return nil, err
 	}
 
 	c := &EEBus{
+		zc:                zc,
 		log:               log,
 		srv:               srv,
 		id:                id,
@@ -149,6 +152,12 @@ func (c *EEBus) Run() {
 
 	if err := c.srv.Listen(ln, c.certificateHandler); err != nil {
 		c.log.ERROR.Println("eebus listen:", err)
+	}
+}
+
+func (c *EEBus) Shutdown() {
+	if c.zc != nil {
+		c.zc.Shutdown()
 	}
 }
 

--- a/server/eebus.go
+++ b/server/eebus.go
@@ -125,7 +125,7 @@ func (c *EEBus) Register(ski string, shipConnectHandler func(string, ship.Conn) 
 	c.handleDiscoveredSKI(ski)
 }
 
-func (c *EEBus) Run() {
+func (c *EEBus) Run(stopC <-chan struct{}) {
 	entries := make(chan *zeroconf.ServiceEntry)
 	go c.discoverDNS(entries, func(entry *zeroconf.ServiceEntry) {
 		c.addDisoveredEntry(entry)
@@ -144,6 +144,12 @@ func (c *EEBus) Run() {
 		panic(fmt.Errorf("failed to browse: %w", err))
 	}
 
+	// unpublish mDNS on exit
+	go func() {
+		<-stopC
+		c.zc.Shutdown()
+	}()
+
 	ln := &server.Listener{
 		Log:          c.log.TRACE,
 		AccessMethod: c.id,
@@ -152,12 +158,6 @@ func (c *EEBus) Run() {
 
 	if err := c.srv.Listen(ln, c.certificateHandler); err != nil {
 		c.log.ERROR.Println("eebus listen:", err)
-	}
-}
-
-func (c *EEBus) Shutdown() {
-	if c.zc != nil {
-		c.zc.Shutdown()
 	}
 }
 

--- a/util/shutdown/shutdown.go
+++ b/util/shutdown/shutdown.go
@@ -47,6 +47,8 @@ func Done(timeout ...time.Duration) <-chan struct{} {
 	case <-exitC:
 		return exitC
 	case <-time.After(to):
-		return nil
+		exitC := make(chan struct{})
+		close(exitC)
+		return exitC
 	}
 }

--- a/util/shutdown/shutdown.go
+++ b/util/shutdown/shutdown.go
@@ -1,0 +1,52 @@
+package shutdown
+
+import (
+	"sync"
+	"time"
+)
+
+var (
+	mu       sync.Mutex
+	handlers = make([]func(), 0)
+	exitC    = make(chan struct{})
+)
+
+func Register(cb func()) {
+	mu.Lock()
+	handlers = append(handlers, cb)
+	mu.Unlock()
+}
+
+func Run(stopC <-chan struct{}) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	<-stopC
+	wg := new(sync.WaitGroup)
+
+	for _, cb := range handlers {
+		wg.Add(1)
+
+		go func(cb func()) {
+			cb()
+			wg.Done()
+		}(cb)
+	}
+
+	wg.Wait()
+	close(exitC)
+}
+
+func Done(timeout ...time.Duration) <-chan struct{} {
+	to := time.Second
+	if len(timeout) == 1 {
+		to = timeout[0]
+	}
+
+	select {
+	case <-exitC:
+		return exitC
+	case <-time.After(to):
+		return nil
+	}
+}


### PR DESCRIPTION
Without this code, the mDNS entry would stay alive for a longer time after evcc stopped running.

This will still happen if it quits early in the startup process.