### PR TITLE
Configure MQTT bugfixes

### DIFF
--- a/cmd/configure/helper.go
+++ b/cmd/configure/helper.go
@@ -136,7 +136,7 @@ func (c *CmdConfigure) processDeviceRequirements(templateItem templates.Template
 	// check if we need to setup an MQTT broker
 	if funk.ContainsString(templateItem.Requirements.EVCC, templates.RequirementMQTT) {
 		if c.configuration.config.MQTT == "" {
-			mqttConfig, err := c.configureMQTT()
+			mqttConfig, err := c.configureMQTT(templateItem)
 			if err != nil {
 				return err
 			}
@@ -209,7 +209,7 @@ func (c *CmdConfigure) askSponsortoken(required bool) error {
 	return nil
 }
 
-func (c *CmdConfigure) configureMQTT() (map[string]interface{}, error) {
+func (c *CmdConfigure) configureMQTT(templateItem templates.Template) (map[string]interface{}, error) {
 	fmt.Println()
 	fmt.Println("-- MQTT Broker ----------------------------")
 
@@ -217,23 +217,27 @@ func (c *CmdConfigure) configureMQTT() (map[string]interface{}, error) {
 
 	for ok := true; ok; {
 		fmt.Println()
+		_, paramHost := templateItem.ConfigDefaults.ParamByName("host")
+		_, paramPort := templateItem.ConfigDefaults.ParamByName("port")
+		_, paramUser := templateItem.ConfigDefaults.ParamByName("user")
+		_, paramPassword := templateItem.ConfigDefaults.ParamByName("password")
 		host := c.askValue(question{
-			label:    c.localizedString("UserFriendly_Host_Name", nil),
+			label:    paramHost.Description.String(c.lang),
 			mask:     false,
 			required: true})
 
 		port := c.askValue(question{
-			label:    c.localizedString("UserFriendly_Port_Name", nil),
+			label:    paramPort.Description.String(c.lang),
 			mask:     false,
 			required: true})
 
 		user := c.askValue(question{
-			label:    c.localizedString("UserFriendly_User_Name", nil),
+			label:    paramUser.Description.String(c.lang),
 			mask:     false,
 			required: false})
 
 		password := c.askValue(question{
-			label:    c.localizedString("UserFriendly_Password_Name", nil),
+			label:    paramPassword.Description.String(c.lang),
 			mask:     true,
 			required: false})
 

--- a/cmd/configure/localization/de.toml
+++ b/cmd/configure/localization/de.toml
@@ -99,6 +99,7 @@ ValueError_Float = "Der Wert muss eine Zahl sein. Nachkommastellen mit . anstatt
 ValueError_Number = "Der Wert muss eine ganzzahlige Zahl sein."
 ValueError_NumberLowerThanMin = "Der Wert muss größer oder gleich {{ .Min }} sein."
 ValueError_NumberBiggerThanMax = "Der Wert muss kleiner oder gleich {{ .Max }} sein."
+ValueError_Duration = "Der Wert muss eine Zeitdauer angeben. Zum Beispiel: 1s, 1m, 1h"
 
 Device_Configure = "Konfiguration"
 Device_Added = "wurde erfolgreich hinzugefügt."

--- a/cmd/configure/localization/en.toml
+++ b/cmd/configure/localization/en.toml
@@ -99,6 +99,7 @@ ValueError_Float = "The value has to be a number."
 ValueError_Number = "The value has to be an integer."
 ValueError_NumberLowerThanMin = "The value must be bigger or equal to {{ .Min }}."
 ValueError_NumberBiggerThanMax = "The value must be smaller or equal to {{ .Max }}."
+ValueError_Duration = "The value has to provide a duration. For example: 1s, 1m, 1h"
 
 Device_Configure = "Configuration"
 Device_Added = "was successfully added."

--- a/cmd/configure/survey.go
+++ b/cmd/configure/survey.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -170,10 +171,11 @@ func (c *CmdConfigure) askValue(q question) string {
 			return errors.New(c.localizedString("ValueError_Empty", nil))
 		}
 
+		if !q.required && len(value) == 0 {
+			return nil
+		}
+
 		if q.valueType == templates.ParamValueTypeFloat {
-			if value == "" && !q.required {
-				return nil
-			}
 			_, err := strconv.ParseFloat(value, 64)
 			if err != nil {
 				return errors.New(c.localizedString("ValueError_Float", nil))
@@ -181,10 +183,6 @@ func (c *CmdConfigure) askValue(q question) string {
 		}
 
 		if q.valueType == templates.ParamValueTypeNumber {
-			if value == "" && !q.required {
-				return nil
-			}
-
 			intValue, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
 				return errors.New(c.localizedString("ValueError_Number", nil))
@@ -194,6 +192,13 @@ func (c *CmdConfigure) askValue(q question) string {
 			}
 			if q.maxNumberValue != 0 && intValue > q.maxNumberValue {
 				return errors.New(c.localizedString("ValueError_NumberBiggerThanMax", localizeMap{"Max": q.maxNumberValue}))
+			}
+		}
+
+		if q.valueType == templates.ParamValueTypeDuration {
+			_, err := time.ParseDuration(value)
+			if err != nil {
+				return errors.New(c.localizedString("ValueError_Duration", nil))
 			}
 		}
 

--- a/templates/definition/defaults.yaml
+++ b/templates/definition/defaults.yaml
@@ -101,6 +101,15 @@ params:
     de: Das zeitliche Interval, in welchem Daten vom Fahrzeug neu geladen werden soll
     en: Time interval with when data should be reloaded from the vehicle
   example: 5m
+- name: timeout
+  description:
+    de: Zeitüberschreitung
+    en: Timeout
+  help:
+    de: Akzeptiere keine Daten die älter als dieser Wert ist
+    en: Don't accept values older than this value in seconds
+  example: 30s
+  valuetype: duration
 - name: mode
   description:
     de: Standard-Lademodus, wenn ein Fahrzeug angeschlossen ist

--- a/templates/definition/meter/mqtt-meter.yaml
+++ b/templates/definition/meter/mqtt-meter.yaml
@@ -64,10 +64,7 @@ params:
     - name: currentp1
       check: notempty
 - name: timeout
-  default: 30
-  help:
-    de: Akzeptiere keine Daten die älter als dieser Wert in Sekunden ist 
-    en: Don't accept values older than this value in seconds
+  default: 30s
 render: |
   type: custom
   power:

--- a/templates/definition/meter/mqtt-meter.yaml
+++ b/templates/definition/meter/mqtt-meter.yaml
@@ -75,7 +75,7 @@ render: |
     topic: {{ .power }}
     scale: {{ .scalepower }}
     timeout: {{ .timeout }}
-  {{- if ne .energy1 "" }}
+  {{- if ne .energy "" }}
   energy:
     source: mqtt
     topic: {{ .energy }}

--- a/templates/docs/charger/tinkerforge-warp-pro_0.yaml
+++ b/templates/docs/charger/tinkerforge-warp-pro_0.yaml
@@ -11,4 +11,4 @@ render:
     host: 192.0.2.2  # Die IP Adresse oder der Hostname des MQTT Brokers 
     port: 1883  # Der Port des MQTT Brokers  # Optional 
     topic: warp  # Optional 
-    timeout: 30s  # Optional
+    timeout: 30s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional

--- a/templates/docs/charger/tinkerforge-warp_0.yaml
+++ b/templates/docs/charger/tinkerforge-warp_0.yaml
@@ -11,4 +11,4 @@ render:
     host: 192.0.2.2  # Die IP Adresse oder der Hostname des MQTT Brokers 
     port: 1883  # Der Port des MQTT Brokers  # Optional 
     topic: warp  # Optional 
-    timeout: 30s  # Optional
+    timeout: 30s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional

--- a/templates/docs/meter/mqtt-meter_0.yaml
+++ b/templates/docs/meter/mqtt-meter_0.yaml
@@ -17,7 +17,7 @@ render:
     currentp1: # Optional 
     currentp2: # Optional 
     currentp3: # Optional 
-    timeout: 30  # Akzeptiere keine Daten die älter als dieser Wert in Sekunden ist  # Optional 
+    timeout: 30s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional 
 - usage: pv
   default: |
     type: template
@@ -31,7 +31,7 @@ render:
     currentp1: # Optional 
     currentp2: # Optional 
     currentp3: # Optional 
-    timeout: 30  # Akzeptiere keine Daten die älter als dieser Wert in Sekunden ist  # Optional 
+    timeout: 30s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional 
 - usage: charge
   default: |
     type: template
@@ -45,7 +45,7 @@ render:
     currentp1: # Optional 
     currentp2: # Optional 
     currentp3: # Optional 
-    timeout: 30  # Akzeptiere keine Daten die älter als dieser Wert in Sekunden ist  # Optional 
+    timeout: 30s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional 
 - usage: battery
   default: |
     type: template
@@ -59,4 +59,4 @@ render:
     currentp1: # Optional 
     currentp2: # Optional 
     currentp3: # Optional 
-    timeout: 30  # Akzeptiere keine Daten die älter als dieser Wert in Sekunden ist  # Optional
+    timeout: 30s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional

--- a/templates/docs/meter/solaredge-hybrid_0.yaml
+++ b/templates/docs/meter/solaredge-hybrid_0.yaml
@@ -12,7 +12,7 @@ render:
     usage: grid
     host: 192.0.2.2  # IP-Adresse oder Hostname 
     port: 502  # Port 502 (SetApp) oder 1502 (LCD)  # Optional 
-    timeout: 3s  # Optional 
+    timeout: 3s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional 
 - usage: pv
   default: |
     type: template
@@ -20,7 +20,7 @@ render:
     usage: pv
     host: 192.0.2.2  # IP-Adresse oder Hostname 
     port: 502  # Port 502 (SetApp) oder 1502 (LCD)  # Optional 
-    timeout: 3s  # Optional 
+    timeout: 3s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional 
 - usage: battery
   default: |
     type: template
@@ -28,4 +28,4 @@ render:
     usage: battery
     host: 192.0.2.2  # IP-Adresse oder Hostname 
     port: 502  # Port 502 (SetApp) oder 1502 (LCD)  # Optional 
-    timeout: 3s  # Optional
+    timeout: 3s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional

--- a/templates/docs/meter/solaredge-inverter_0.yaml
+++ b/templates/docs/meter/solaredge-inverter_0.yaml
@@ -13,7 +13,7 @@ render:
     # TCPIP
     uri: 192.0.2.2:1502 # IP-Adresse oder Hostname: Port
     # Modbus End
-    timeout: 3s  # Optional 
+    timeout: 3s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional 
 - usage: pv
   default: |
     type: template
@@ -24,4 +24,4 @@ render:
     # TCPIP
     uri: 192.0.2.2:1502 # IP-Adresse oder Hostname: Port
     # Modbus End
-    timeout: 3s  # Optional
+    timeout: 3s  # Akzeptiere keine Daten die älter als dieser Wert ist  # Optional

--- a/util/templates/template_types.go
+++ b/util/templates/template_types.go
@@ -38,9 +38,10 @@ const (
 	ParamValueTypeBool        = "bool"
 	ParamValueTypeStringList  = "stringlist"
 	ParamValueTypeChargeModes = "chargemodes"
+	ParamValueTypeDuration    = "duration"
 )
 
-var ValidParamValueTypes = []string{ParamValueTypeString, ParamValueTypeNumber, ParamValueTypeFloat, ParamValueTypeBool, ParamValueTypeStringList, ParamValueTypeChargeModes}
+var ValidParamValueTypes = []string{ParamValueTypeString, ParamValueTypeNumber, ParamValueTypeFloat, ParamValueTypeBool, ParamValueTypeStringList, ParamValueTypeChargeModes, ParamValueTypeDuration}
 
 var ValidModbusChoices = []string{ModbusChoiceRS485, ModbusChoiceTCPIP}
 var ValidUsageChoices = []string{UsageChoiceGrid, UsageChoicePV, UsageChoiceBattery, UsageChoiceCharge}


### PR DESCRIPTION
- Fix MQTT configure process crashing: This happened because it used the old language file definitions instead of the new templates defaultConfig data
- Fix MQTT meter template
- Add new valuetype `duration` to templates