### PR TITLE
Go templates + sprig 4 messages

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -64,7 +64,7 @@ type typedConfig struct {
 }
 
 type messagingConfig struct {
-	Events   map[string]push.EventTemplate
+	Events   map[string]push.EventTemplateConfig
 	Services []typedConfig
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -172,7 +172,10 @@ func configureEEBus(conf map[string]interface{}) error {
 // setup messaging
 func configureMessengers(conf messagingConfig, cache *util.Cache) chan push.Event {
 	notificationChan := make(chan push.Event, 1)
-	notificationHub := push.NewHub(conf.Events, cache)
+	notificationHub, err := push.NewHub(conf.Events, cache)
+	if err != nil {
+		log.FATAL.Fatalf("failed configuring hems: %v", err)
+	}
 
 	for _, service := range conf.Services {
 		impl, err := push.NewMessengerFromConfig(service.Type, service.Other)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -174,7 +174,7 @@ func configureMessengers(conf messagingConfig, cache *util.Cache) chan push.Even
 	notificationChan := make(chan push.Event, 1)
 	notificationHub, err := push.NewHub(conf.Events, cache)
 	if err != nil {
-		log.FATAL.Fatalf("failed configuring hems: %v", err)
+		log.FATAL.Fatalf("failed configuring push services: %v", err)
 	}
 
 	for _, service := range conf.Services {

--- a/push/config.go
+++ b/push/config.go
@@ -12,11 +12,6 @@ type Sender interface {
 	Send(title, msg string)
 }
 
-// EventTemplate is the push message template for an event
-type EventTemplate struct {
-	Title, Msg string
-}
-
 var log = util.NewLogger("push")
 
 // NewMessengerFromConfig creates a new messenger

--- a/push/config.go
+++ b/push/config.go
@@ -3,6 +3,7 @@ package push
 import (
 	"fmt"
 	"strings"
+	"text/template"
 
 	"github.com/evcc-io/evcc/util"
 )
@@ -10,6 +11,10 @@ import (
 // Sender implements message sending
 type Sender interface {
 	Send(title, msg string)
+}
+
+type EventTemplate struct {
+	Title, Msg *template.Template
 }
 
 var log = util.NewLogger("push")

--- a/push/config.go
+++ b/push/config.go
@@ -3,7 +3,6 @@ package push
 import (
 	"fmt"
 	"strings"
-	"text/template"
 
 	"github.com/evcc-io/evcc/util"
 )
@@ -11,10 +10,6 @@ import (
 // Sender implements message sending
 type Sender interface {
 	Send(title, msg string)
-}
-
-type EventTemplate struct {
-	Title, Msg *template.Template
 }
 
 var log = util.NewLogger("push")

--- a/push/hub.go
+++ b/push/hub.go
@@ -39,15 +39,11 @@ func NewHub(cc map[string]EventTemplateConfig, cache *util.Cache) (*Hub, error) 
 	// instantiate all event templates
 	for k, v := range cc {
 		var def EventTemplate
+		var err error
 
-		t, err := template.New("out").Funcs(template.FuncMap(sprig.FuncMap())).Parse(v.Title)
+		def.Title, err = template.New("out").Funcs(template.FuncMap(sprig.FuncMap())).Parse(v.Title)
 		if err == nil {
-			def.Title = t
-
-			t, err = template.New("out").Funcs(template.FuncMap(sprig.FuncMap())).Parse(v.Msg)
-			if err == nil {
-				def.Msg = t
-			}
+			def.Msg, err = template.New("out").Funcs(template.FuncMap(sprig.FuncMap())).Parse(v.Msg)
 		}
 
 		if err != nil {

--- a/push/hub.go
+++ b/push/hub.go
@@ -15,11 +15,12 @@ type Event struct {
 	Event     string
 }
 
-// EventTemplateConfig is the push message template for an event
+// EventTemplateConfig is the push message configuration for an event
 type EventTemplateConfig struct {
 	Title, Msg string
 }
 
+// EventTemplate is the push message template for an event
 type EventTemplate struct {
 	Title, Msg *template.Template
 }

--- a/push/hub.go
+++ b/push/hub.go
@@ -20,6 +20,10 @@ type EventTemplateConfig struct {
 	Title, Msg string
 }
 
+type EventTemplate struct {
+	Title, Msg *template.Template
+}
+
 // Hub subscribes to event notifications and sends them to client devices
 type Hub struct {
 	definitions map[string]EventTemplate

--- a/util/format.go
+++ b/util/format.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/sprig/v3"
 )
 
 var re = regexp.MustCompile(`\${(\w+)(:([a-zA-Z0-9%.]+))?}`)
@@ -50,12 +52,10 @@ func FormatValue(format string, val interface{}) string {
 func ReplaceFormatted(s string, kv map[string]interface{}) (string, error) {
 	// New golang template logic
 	if strings.Contains(s, "{{") {
-		tmpl, err := template.New("evcc.tpl").Parse(s)
-		if err != nil {
-			return s, nil
-		}
+		tpl := template.Must(
+			template.New("base").Funcs(sprig.FuncMap()).Parse(s))
 		var rs bytes.Buffer
-		err = tmpl.Execute(&rs, kv)
+		err := tpl.Execute(&rs, kv)
 		return rs.String(), err
 	}
 

--- a/util/format.go
+++ b/util/format.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"bytes"
 	"fmt"
+	"html/template"
 	"regexp"
 	"strings"
 	"time"
@@ -46,6 +48,18 @@ func FormatValue(format string, val interface{}) string {
 
 // ReplaceFormatted replaces all occurrences of ${key} with formatted val from the kv map
 func ReplaceFormatted(s string, kv map[string]interface{}) (string, error) {
+	// New golang template logic
+	if strings.Contains(s, "{{") {
+		tmpl, err := template.New("evcc.tpl").Parse(s)
+		if err != nil {
+			return s, nil
+		}
+		var rs bytes.Buffer
+		err = tmpl.Execute(&rs, kv)
+		return rs.String(), err
+	}
+
+	// Deprecated regex logic
 	wanted := make([]string, 0)
 
 	for m := re.FindStringSubmatch(s); m != nil; m = re.FindStringSubmatch(s) {

--- a/util/format.go
+++ b/util/format.go
@@ -50,7 +50,7 @@ func FormatValue(format string, val interface{}) string {
 
 // ReplaceFormatted replaces all occurrences of ${key} with formatted val from the kv map
 func ReplaceFormatted(s string, kv map[string]interface{}) (string, error) {
-	// New golang template logic
+	// Enhanced golang template logic
 	if strings.Contains(s, "{{") {
 		tpl := template.Must(
 			template.New("base").Funcs(sprig.FuncMap()).Parse(s))
@@ -59,7 +59,7 @@ func ReplaceFormatted(s string, kv map[string]interface{}) (string, error) {
 		return rs.String(), err
 	}
 
-	// Deprecated regex logic
+	// Regex logic for backward compatibility
 	wanted := make([]string, 0)
 
 	for m := re.FindStringSubmatch(s); m != nil; m = re.FindStringSubmatch(s) {

--- a/util/format.go
+++ b/util/format.go
@@ -51,13 +51,17 @@ func FormatValue(format string, val interface{}) string {
 // ReplaceFormatted replaces all occurrences of ${key} with formatted val from the kv map
 func ReplaceFormatted(s string, kv map[string]interface{}) (string, error) {
 	// Enhanced golang template logic
-	if strings.Contains(s, "{{") {
-		tpl := template.Must(
-			template.New("base").Funcs(sprig.FuncMap()).Parse(s))
-		var rs bytes.Buffer
-		err := tpl.Execute(&rs, kv)
-		return rs.String(), err
+	tpl, err := template.New("base").Funcs(sprig.FuncMap()).Parse(s)
+	if err != nil {
+		return s, err
 	}
+
+	var rs bytes.Buffer
+	err = tpl.Execute(&rs, kv)
+	if err != nil {
+		return s, err
+	}
+	s = rs.String()
 
 	// Regex logic for backward compatibility
 	wanted := make([]string, 0)
@@ -79,7 +83,6 @@ func ReplaceFormatted(s string, kv map[string]interface{}) (string, error) {
 	}
 
 	// return missing keys
-	var err error
 	if len(wanted) > 0 {
 		got := make([]string, 0)
 		for k := range kv {

--- a/util/format_test.go
+++ b/util/format_test.go
@@ -71,7 +71,7 @@ func TestReplaceNoMatch(t *testing.T) {
 }
 
 func TestTemplateReplaceFormatted(t *testing.T) {
-	msg := "Wallbox {{.title}} started charging {{.vehicleTitle}} in {{.mode}} mode"
+	msg := "Wallbox {{.title}} started charging {{.vehicleTitle}} in {{.mode | upper }} mode"
 	s, err := ReplaceFormatted(msg, map[string]interface{}{
 		"title":        "go-e",
 		"vehicleTitle": "Zoe",

--- a/util/format_test.go
+++ b/util/format_test.go
@@ -33,9 +33,12 @@ func TestReplace(t *testing.T) {
 		v             interface{}
 		fmt, expected string
 	}{
+		// regex tests
 		{"foo", true, "${foo}", "true"},
 		{"foo", "1", "abc${foo}${foo}", "abc11"},
 		{"foo", math.Pi, "${foo:%.2f}", "3.14"},
+		// template + sprig func tests
+		{"foo", "lower2upper", "{{ .foo | upper }}", "LOWER2UPPER"},
 	}
 
 	for _, c := range cases {
@@ -66,19 +69,6 @@ func TestReplaceNoMatch(t *testing.T) {
 	})
 
 	if err == nil {
-		t.Error(s, err)
-	}
-}
-
-func TestTemplateReplaceFormatted(t *testing.T) {
-	msg := "Wallbox {{.title}} started charging {{.vehicleTitle}} in {{.mode | upper }} mode"
-	s, err := ReplaceFormatted(msg, map[string]interface{}{
-		"title":        "go-e",
-		"vehicleTitle": "Zoe",
-		"mode":         "pv",
-	})
-
-	if err != nil {
 		t.Error(s, err)
 	}
 }

--- a/util/format_test.go
+++ b/util/format_test.go
@@ -69,3 +69,16 @@ func TestReplaceNoMatch(t *testing.T) {
 		t.Error(s, err)
 	}
 }
+
+func TestTemplateReplaceFormatted(t *testing.T) {
+	msg := "Wallbox {{.title}} started charging {{.vehicleTitle}} in {{.mode}} mode"
+	s, err := ReplaceFormatted(msg, map[string]interface{}{
+		"title":        "go-e",
+		"vehicleTitle": "Zoe",
+		"mode":         "pv",
+	})
+
+	if err != nil {
+		t.Error(s, err)
+	}
+}

--- a/util/format_test.go
+++ b/util/format_test.go
@@ -37,8 +37,6 @@ func TestReplace(t *testing.T) {
 		{"foo", true, "${foo}", "true"},
 		{"foo", "1", "abc${foo}${foo}", "abc11"},
 		{"foo", math.Pi, "${foo:%.2f}", "3.14"},
-		// template + sprig func tests
-		{"foo", "lower2upper", "{{ .foo | upper }}", "LOWER2UPPER"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Alternative Nutzung von golang templates plus [sprig ](http://masterminds.github.io/sprig/)-Funktionen zum Rendern von Messages.