### PR TITLE
Try staged vehicle wake-up first charger then vehicle api

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -135,14 +135,15 @@ type LoadPoint struct {
 	socTimer     *soc.Timer
 
 	// cached state
-	status         api.ChargeStatus       // Charger status
-	remoteDemand   loadpoint.RemoteDemand // External status demand
-	chargePower    float64                // Charging power
-	chargeCurrents []float64              // Phase currents
-	connectedTime  time.Time              // Time when vehicle was connected
-	pvTimer        time.Time              // PV enabled/disable timer
-	phaseTimer     time.Time              // 1p3p switch timer
-	wakeUpTimer    *Timer                 // Vehicle wake-up timeout
+	status           api.ChargeStatus       // Charger status
+	remoteDemand     loadpoint.RemoteDemand // External status demand
+	chargePower      float64                // Charging power
+	chargeCurrents   []float64              // Phase currents
+	connectedTime    time.Time              // Time when vehicle was connected
+	pvTimer          time.Time              // PV enabled/disable timer
+	phaseTimer       time.Time              // 1p3p switch timer
+	wakeUpTimer      *Timer                 // Vehicle wake-up timeout
+	wakeUpUseVehicle bool                   // Wake-up by vehicle API
 
 	// charge progress
 	vehicleSoc              float64       // Vehicle SoC
@@ -364,6 +365,10 @@ func (lp *LoadPoint) evChargeStartHandler() {
 	lp.log.INFO.Println("start charging ->")
 	lp.pushEvent(evChargeStart)
 
+	if lp.wakeUpUseVehicle && !lp.wakeUpTimer.Expired() {
+		// reset to use successful charger wake-up next time
+		lp.wakeUpUseVehicle = false
+	}
 	lp.wakeUpTimer.Stop()
 
 	// soc update reset
@@ -829,20 +834,29 @@ func (lp *LoadPoint) setActiveVehicle(vehicle api.Vehicle) {
 	lp.unpublishVehicle()
 }
 
+// wakeUpVehicle calls the next available wake-up method
 func (lp *LoadPoint) wakeUpVehicle() {
-	// charger
-	if c, ok := lp.charger.(api.AlarmClock); ok {
-		if err := c.WakeUp(); err != nil {
-			lp.log.ERROR.Printf("wake-up charger: %v", err)
+	if !lp.wakeUpUseVehicle {
+		// try the chargers explicit car wake-up method first
+		if c, ok := lp.charger.(api.AlarmClock); ok {
+			if err := c.WakeUp(); err != nil {
+				lp.log.ERROR.Printf("wake-up charger: %v", err)
+			}
 		}
-		return
-	}
+		// if not available, the charger may have an automatic
+		// internal car wake-up method that is already running
+		// in the background and has to be simply waited for.
 
-	// vehicle
-	if lp.vehicle != nil {
-		if vs, ok := lp.vehicle.(api.AlarmClock); ok {
-			if err := vs.WakeUp(); err != nil {
-				lp.log.ERROR.Printf("wake-up vehicle: %v", err)
+		// wait for vehicle wake-up again before trying the next wake-up method.
+		lp.wakeUpUseVehicle = true
+		lp.wakeUpTimer.Start()
+	} else {
+		// try vehicle remote wake-up
+		if lp.vehicle != nil {
+			if vs, ok := lp.vehicle.(api.AlarmClock); ok {
+				if err := vs.WakeUp(); err != nil {
+					lp.log.ERROR.Printf("wake-up vehicle: %v", err)
+				}
 			}
 		}
 	}

--- a/core/timer.go
+++ b/core/timer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/benbjohnson/clock"
 )
 
-const wakeupTimeout = 60 * time.Second
+const wakeupTimeout = 30 * time.Second
 
 // Timer measures active time between start and stop events
 type Timer struct {


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/4127

Versucht zunächst nach 30 Sekunden gezielt mittels Charger zu wecken (falls entsprechende Charger-API verfügbar).
Alternativ macht der Charger das intern selbst und man muss eben nur ausreichend lange abwarten.
Wenn das Fahrzeug nach weiteren 30 Sekunden (also nach insgesamt 60 Sekunden seit Ladefreigabe) immer noch nicht lädt wird versucht das Fahrzeug via Vehicle-API (sofern verfügbar) zu wecken.
Diese Einstellung bleibt dann bis zum Disconnect beibehalten. Sprich bei nachfolgenden Wakeups wird nach 30 Sekunden sofort die Vehicle-API zum Wakeup verwendet und nicht erst auf den Charger gewartet.

TODO:

- [ ] wir sollten den Timer nur starten (und loggen) falls es überhaupt entsprechende APIs gibt