### PR TITLE
Skip sending empty push message after go template rendering

### DIFF
--- a/push/hub.go
+++ b/push/hub.go
@@ -114,7 +114,11 @@ func (h *Hub) Run(events <-chan Event) {
 		}
 
 		for _, sender := range h.sender {
-			go sender.Send(title, msg)
+			if strings.TrimSpace(msg) != "" {
+				go sender.Send(title, msg)
+			} else {
+				log.DEBUG.Printf("did not send empty message template for %s: %v", ev.Event, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Skip sending empty push messages after go template rendering.

Refer to discussion #2714