### PR TITLE
Tesla: Use Same SoS as Car Display and App

### DIFF
--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -115,7 +115,7 @@ func (v *Tesla) SoC() (float64, error) {
 	res, err := v.chargeStateG()
 
 	if res, ok := res.(*tesla.ChargeState); err == nil && ok {
-		return float64(res.BatteryLevel), nil
+		return float64(res.UsableBatteryLevel), nil
 	}
 
 	return 0, err


### PR DESCRIPTION
The Tesla API has two SoC values (`BatteryLevel` and `UsableBatteryLevel`). The Tesla app and in-car display both show the second value. This one is usually a bit (1 or 2 points) lower. To be consistent we should use this value too.