### PR TITLE
Prevent starting pv disable timer when phase scaling is pending

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1167,7 +1167,7 @@ func (lp *LoadPoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64, batter
 
 	if mode == api.ModePV && lp.enabled && targetCurrent < minCurrent {
 		// kick off disable sequence
-		if sitePower >= lp.Disable.Threshold {
+		if sitePower >= lp.Disable.Threshold && lp.phaseTimer.IsZero() {
 			lp.log.DEBUG.Printf("site power %.0fW >= %.0fW disable threshold", sitePower, lp.Disable.Threshold)
 
 			if lp.pvTimer.IsZero() {


### PR DESCRIPTION
Benefit: amount of logging is reduced:

```
[lp-1  ] DEBUG 2022/03/03 10:19:04 start phase scale1p timer
[lp-1  ] DEBUG 2022/03/03 10:19:04 phase scale1p in 1m0s
[lp-1  ] DEBUG 2022/03/03 10:19:04 pv charge current: 4.74A = 8.99A + -4.26A (1959W @ 2p)
-> the following logic is short-circuited
[lp-1  ] DEBUG 2022/03/03 10:19:04 site power 1959W >= 250W disable threshold
[lp-1  ] DEBUG 2022/03/03 10:19:04 pv disable timer start: 1m0s
[lp-1  ] DEBUG 2022/03/03 10:19:04 pv disable in 1m0s
```

Impact: if power is below 1p, the phase scale and pv disable timers are executed sequentially.
