### PR TITLE
Scale to 2p/3p only if 1p maxcurrent is exceeded

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1048,10 +1048,9 @@ func (lp *LoadPoint) pvScalePhases(availablePower, minCurrent, maxCurrent float6
 
 	var waiting bool
 	activePhases := lp.activePhases()
-	targetCurrent := powerToCurrent(availablePower, activePhases)
 
 	// scale down phases
-	if targetCurrent < minCurrent && activePhases > 1 {
+	if targetCurrent := powerToCurrent(availablePower, activePhases); targetCurrent < minCurrent && activePhases > 1 {
 		lp.log.DEBUG.Printf("available power %.0fW < %.0fW min %dp threshold", availablePower, float64(activePhases)*Voltage*minCurrent, activePhases)
 
 		if lp.phaseTimer.IsZero() {
@@ -1076,10 +1075,11 @@ func (lp *LoadPoint) pvScalePhases(availablePower, minCurrent, maxCurrent float6
 	}
 
 	maxPhases := lp.maxActivePhases()
-	scalable := maxPhases > 1 && phases < maxPhases
+	target1pCurrent := powerToCurrent(availablePower, 1)
+	scalable := maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent
 
 	// scale up phases
-	if min3pCurrent := powerToCurrent(availablePower, maxPhases); min3pCurrent >= minCurrent && scalable {
+	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {
 		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, 3*Voltage*minCurrent, maxPhases)
 
 		if lp.phaseTimer.IsZero() {

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -81,6 +81,7 @@ func testScale(t *testing.T, lp *LoadPoint, power float64, direction string, tc 
 				t.Errorf("%v act=%d max=%d missing scale %s at reduced max current %.1fA", tc, act, max, direction, maxAmp)
 			}
 
+			// we've verified scale-up here- next test should not scale
 			testExpectation = strings.ReplaceAll(testExpectation, "u", "")
 		}
 	}

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -68,9 +68,26 @@ var (
 func testScale(t *testing.T, lp *LoadPoint, power float64, direction string, tc testCase) {
 	act := lp.activePhases()
 	max := lp.maxActivePhases()
+
+	testDirection := direction[0:1] // (d)own or (u)p
+	testExpectation := tc.scale
+
+	// up-scale expected
+	if testDirection == "u" && strings.Contains(testExpectation, testDirection) {
+		// scale-up should only execute when the 1p max current is exceeded
+		// we're testing this here and remove the upscale exception for the following test below 1p max current
+		if maxAmp := power / Voltage; maxAmp < maxA {
+			if scaled := lp.pvScalePhases(power, minA, maxAmp-0.0001); !scaled {
+				t.Errorf("%v act=%d max=%d missing scale %s at reduced max current %.1fA", tc, act, max, direction, maxAmp)
+			}
+
+			testExpectation = strings.ReplaceAll(testExpectation, "u", "")
+		}
+	}
+
 	scaled := lp.pvScalePhases(power, minA, maxA)
 
-	if strings.Contains(tc.scale, direction[0:1]) {
+	if strings.Contains(testExpectation, testDirection) {
 		if !scaled {
 			t.Errorf("%v act=%d max=%d missing scale %s", tc, act, max, direction)
 		}

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -75,7 +75,7 @@ func testScale(t *testing.T, lp *LoadPoint, power float64, direction string, tc 
 	// up-scale expected
 	if testDirection == "u" && strings.Contains(testExpectation, testDirection) {
 		// scale-up should only execute when the 1p max current is exceeded
-		// we're testing this here and remove the upscale exception for the following test below 1p max current
+		// we're testing this here and remove the upscale expectation for the following test below 1p max current
 		if maxAmp := power / Voltage; maxAmp < maxA {
 			if scaled := lp.pvScalePhases(power, minA, maxAmp-0.0001); !scaled {
 				t.Errorf("%v act=%d max=%d missing scale %s at reduced max current %.1fA", tc, act, max, direction, maxAmp)

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -81,8 +81,8 @@ func testScale(t *testing.T, lp *LoadPoint, power float64, direction string, tc 
 				t.Errorf("%v act=%d max=%d missing scale %s at reduced max current %.1fA", tc, act, max, direction, maxAmp)
 			}
 
-			// we've verified scale-up here- next test should not scale
-			testExpectation = strings.ReplaceAll(testExpectation, "u", "")
+			// we've verified scale-up here so next test should not scale
+			testExpectation = strings.ReplaceAll(testExpectation, testDirection, "")
 		}
 	}
 


### PR DESCRIPTION
Dieser PR verhindert das frühe Hochschalten auf 2p/3p, solange der Maximalstrom für 1p noch nicht überschritten ist.

@premultiply wie besprochen. Der Test sieht etwas komisch aus weil er jetzt für upscaling doppelt ausgeführt wird: einmal mit reduziertem Maximalstrom so dass skaliert werden muss und einmal mit 16A Maximalstrom so dass die 2p/3p Leistung noch innerhalb der Reichweite von 1p liegt und daher nicht skaliert werden darf.

Mit diesem Ansatz haben wir eine Hysterese- hoch- und runter schalten so spät wie möglich. Dafür auf Kosten der abnehmenden Ladeeffizienz an der Untergrenze der 3p Ladung. Das wäre in einem separaten PR nochmal zu überlegen.