### PR TITLE
Add current (I), (e)nable, (d)isable and (w)akeup options to charger command

### DIFF
--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/cmd/shutdown"
 	"github.com/evcc-io/evcc/server"
@@ -19,6 +22,9 @@ var chargerCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(chargerCmd)
 	chargerCmd.PersistentFlags().StringP("name", "n", "", "select charger by name")
+	chargerCmd.PersistentFlags().IntP("current", "I", -1, "set current")
+	chargerCmd.PersistentFlags().BoolP("enable", "e", false, "enable")
+	chargerCmd.PersistentFlags().BoolP("disable", "d", false, "disable")
 }
 
 func runCharger(cmd *cobra.Command, args []string) {
@@ -61,6 +67,30 @@ func runCharger(cmd *cobra.Command, args []string) {
 
 	d := dumper{len: len(chargers)}
 	for name, v := range chargers {
+		if flag := cmd.PersistentFlags().Lookup("current").Value.String(); flag != "-1" {
+			val, err := strconv.ParseInt(flag, 10, 64)
+			if err != nil {
+				log.ERROR.Println(err)
+			} else {
+				fmt.Println("Set current:", val)
+				if err := v.MaxCurrent(val); err != nil {
+					log.ERROR.Println(err)
+				}
+			}
+		}
+		if flag := cmd.PersistentFlags().Lookup("enable").Value.String(); flag == "true" {
+			fmt.Println("Enable(true)")
+			if err := v.Enable(true); err != nil {
+				log.ERROR.Println(err)
+			}
+		}
+		if flag := cmd.PersistentFlags().Lookup("disable").Value.String(); flag == "true" {
+			fmt.Println("Enable(false)")
+			if err := v.Enable(false); err != nil {
+				log.ERROR.Println(err)
+			}
+		}
+
 		d.DumpWithHeader(name, v)
 	}
 

--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -65,25 +65,31 @@ func runCharger(cmd *cobra.Command, args []string) {
 		chargers = map[string]api.Charger{arg: cp.Charger(arg)}
 	}
 
+	var current int64
+	if flag := cmd.PersistentFlags().Lookup("current").Value.String(); flag != "-1" {
+		var err error
+		current, err = strconv.ParseInt(flag, 10, 64)
+		if err != nil {
+			log.ERROR.Fatalln(err)
+		}
+	}
+
 	d := dumper{len: len(chargers)}
 	for name, v := range chargers {
-		if flag := cmd.PersistentFlags().Lookup("current").Value.String(); flag != "-1" {
-			val, err := strconv.ParseInt(flag, 10, 64)
-			if err != nil {
+		if current >= 0 {
+			fmt.Println("Set current:", current)
+			if err := v.MaxCurrent(current); err != nil {
 				log.ERROR.Println(err)
-			} else {
-				fmt.Println("Set current:", val)
-				if err := v.MaxCurrent(val); err != nil {
-					log.ERROR.Println(err)
-				}
 			}
 		}
+
 		if flag := cmd.PersistentFlags().Lookup("enable").Value.String(); flag == "true" {
 			fmt.Println("Enable(true)")
 			if err := v.Enable(true); err != nil {
 				log.ERROR.Println(err)
 			}
 		}
+
 		if flag := cmd.PersistentFlags().Lookup("disable").Value.String(); flag == "true" {
 			fmt.Println("Enable(false)")
 			if err := v.Enable(false); err != nil {

--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -84,14 +84,14 @@ func runCharger(cmd *cobra.Command, args []string) {
 		}
 
 		if flag := cmd.PersistentFlags().Lookup("enable").Value.String(); flag == "true" {
-			fmt.Println("Enable(true)")
+			fmt.Println("Set enabled")
 			if err := v.Enable(true); err != nil {
 				log.ERROR.Println(err)
 			}
 		}
 
 		if flag := cmd.PersistentFlags().Lookup("disable").Value.String(); flag == "true" {
-			fmt.Println("Enable(false)")
+			fmt.Println("Set disabled")
 			if err := v.Enable(false); err != nil {
 				log.ERROR.Println(err)
 			}


### PR DESCRIPTION
/cc @premultiply weitere Debughelfer:

```
❯ gor main.go charger --help
Query configured chargers

Usage:
  evcc charger [name] [flags]

Flags:
  -I, --current int   set current (default -1)
  -d, --disable       disable
  -e, --enable        enable

Global Flags: ...
```