### PR TITLE
Daheimladen: Charging station is enabled only when in 'Charging' state

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -64,7 +64,7 @@ func NewDaheimLaden(token string, stationID string) (*DaheimLaden, error) {
 func (c *DaheimLaden) Enabled() (bool, error) {
 	var res daheimladen.GetLatestStatus
 	err := c.GetJSON(fmt.Sprintf("%s/cs/%s/status", daheimladen.BASE_URL, c.stationID), &res)
-	return res.Status == string(daheimladen.CHARGING) || res.Status == string(daheimladen.PREPARING), err
+	return res.Status == string(daheimladen.CHARGING), err
 }
 
 // Enable implements the api.Charger interface


### PR DESCRIPTION
Fixes: #2273

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## Description:
DaheimLaden charging station needs to return true for `Enabled` function only when the station is in "Charging" state.
This will get rid of "charger out of sync" errors before starting the charging and after the charging is completed.