### PR TITLE
Remove deprecated configuration options

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -65,29 +65,17 @@ func NewEaseeFromConfig(other map[string]interface{}) (api.Charger, error) {
 		User     string
 		Password string
 		Charger  string
-		Circuit  int           // deprecated
-		Cache    time.Duration // deprecated
 	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	log := util.NewLogger("easee")
-
-	if cc.Circuit > 0 {
-		log.WARN.Println("circuit is deprecated and will be removed in a future release")
-	}
-
-	if cc.Cache > 0 {
-		log.WARN.Println("cache is deprecated and will be removed in a future release")
-	}
-
-	return NewEasee(cc.User, cc.Password, cc.Charger, cc.Cache)
+	return NewEasee(cc.User, cc.Password, cc.Charger)
 }
 
 // NewEasee creates Easee charger
-func NewEasee(user, password, charger string, cache time.Duration) (*Easee, error) {
+func NewEasee(user, password, charger string) (*Easee, error) {
 	log := util.NewLogger("easee").Redact(user, password)
 
 	if !sponsor.IsAuthorized() {

--- a/charger/wallbe.go
+++ b/charger/wallbe.go
@@ -50,7 +50,6 @@ func NewWallbeFromConfig(other map[string]interface{}) (api.Charger, error) {
 		Legacy bool
 		Meter  struct {
 			Power, Energy, Currents bool
-			Encoding                interface{}
 		}
 	}{
 		URI: "192.168.0.8:502",
@@ -63,10 +62,6 @@ func NewWallbeFromConfig(other map[string]interface{}) (api.Charger, error) {
 	wb, err := NewWallbe(cc.URI)
 	if err != nil {
 		return nil, err
-	}
-
-	if cc.Meter.Encoding != nil {
-		util.NewLogger("wallbe").WARN.Printf("encoding is deprecated and will be removed in a future release. Use firmware 01.04.21 instead.")
 	}
 
 	if cc.Legacy {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -104,8 +104,6 @@ type LoadPoint struct {
 		ChargeMeterRef string `mapstructure:"charge"` // deprecated
 	}
 	SoC               SoCConfig
-	OnDisconnect_     interface{} `mapstructure:"onDisconnect"`
-	OnIdentify_       interface{} `mapstructure:"onIdentify"`
 	Enable, Disable   ThresholdConfig
 	ResetOnDisconnect bool `mapstructure:"resetOnDisconnect"`
 	onDisconnect      api.ActionConfig
@@ -169,14 +167,6 @@ func NewLoadPointFromConfig(log *util.Logger, cp configProvider, other map[strin
 			lp.log.WARN.Printf("invalid poll mode: %s", lp.SoC.Poll.Mode)
 		}
 		lp.SoC.Poll.Mode = pollConnected
-	}
-
-	if lp.OnIdentify_ != nil {
-		lp.log.WARN.Printf("loadpoint.onIdentify is deprecated and will be removed in a future release. Use vehicle.onIdentify instead.")
-	}
-
-	if lp.OnDisconnect_ != nil {
-		lp.log.WARN.Printf("loadpoint.onDisconnect is deprecated and will be removed in a future release. Use loadpoint.resetOnDisconnect instead.")
 	}
 
 	// set vehicle polling interval

--- a/vehicle/vehicle.go
+++ b/vehicle/vehicle.go
@@ -29,7 +29,6 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Vehicle, error
 		Status   *provider.Config
 		Range    *provider.Config
 		Odometer *provider.Config
-		Cache    interface{}
 	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -42,10 +41,6 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Vehicle, error
 	cc.Status.Deprecate(log)
 	cc.Range.Deprecate(log)
 	cc.Odometer.Deprecate(log)
-
-	if cc.Cache != nil {
-		util.NewLogger("vehicle").WARN.Println("cache is deprecated and will be removed in a future release")
-	}
 
 	socG, err := provider.NewFloatGetterFromConfig(cc.Soc)
 	if err != nil {


### PR DESCRIPTION
Breaking change: the following config options have been removed.
- Loadpoint: `onDisconnect`, `onIdentify`
- Easee and custom vehicle: `cache`
- Warp: `useMeter`