### PR TITLE
Update huawei-dongle-powersensor.yaml

### DIFF
--- a/templates/definition/meter/huawei-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-dongle-powersensor.yaml
@@ -17,9 +17,8 @@ render: |
     source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
-    timeout: 30s
-    connectdelay: 5
-    delay: 2s
+    timeout: 10s
+    connectdelay: 1s
     register:
       address: 37113 # Grid import export power
       type: holding
@@ -29,11 +28,9 @@ render: |
     source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
-    timeout: 30s
-    connectdelay: 5
-    delay: 2s
+    timeout: 10s
     register:
-      address: 37121 # Grid active energy
+      address: 37121 # Grid active energy import from the grid
       type: holding
       decode: int32
     scale: 0.01
@@ -41,6 +38,7 @@ render: |
   - source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
+    timeout: 10s
     register:
       address: 37107 # Huawei phase A grid current
       type: holding
@@ -49,6 +47,7 @@ render: |
   - source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
+    timeout: 10s
     register:
       address: 37109 # Huawei phase B grid current
       type: holding
@@ -57,6 +56,7 @@ render: |
   - source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
+    timeout: 10s
     register:
       address: 37111 # Huawei phase C grid current
       type: holding
@@ -68,9 +68,8 @@ render: |
     source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
-    timeout: 30s
-    connectdelay: 5
-    delay: 2s
+    timeout: 10s
+    connectdelay: 1s
     register:
       address: 32080 # Active generation power
       type: holding
@@ -81,9 +80,8 @@ render: |
     source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
-    timeout: 30s
-    connectdelay: 5
-    delay: 2s
+    timeout: 10s
+    connectdelay: 1s
     register:
       address: 37001
       type: holding
@@ -92,9 +90,7 @@ render: |
     source: modbus
     {{include "modbus" . | indent 2}}
     model: huawei
-    timeout: 30s
-    connectdelay: 5
-    delay: 2s
+    timeout: 10s
     register:
       address: 37004
       type: holding

--- a/templates/definition/meter/huawei-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-dongle-powersensor.yaml
@@ -30,7 +30,7 @@ render: |
     model: huawei
     timeout: 10s
     register:
-      address: 37121 # Grid active energy import from the grid
+      address: 37121 # Active energy import from the grid
       type: holding
       decode: int32
     scale: 0.01


### PR DESCRIPTION
Add missing "s" to `connectdelay`
Reduce `timeout` time, remove `connectdelay` where not needed, remove `delay` as it does not seem needed at all. Speed things up.
Add `timeout` where it was missing and needed.