### PR TITLE
Ask user for old service file

### DIFF
--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -33,25 +33,23 @@ if [ "$1" = "configure" ]; then
 	# this choice file will include that information
 	# and the user will no longer be asked if he wants to keep it
 	if [ -f "$USER_CHOICE_CONFIG" ]; then
-		source "$USER_CHOICE_CONFIG"
+		. "$USER_CHOICE_CONFIG"
 	fi
 
 	# If the user previously decided that he doesn't want to keep
 	# the files or if it's the first time, aks whether he want's to
 	# keep the file
-	if [ -f "$ETC_SERVICE" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+	if [ -f "$ETC_SERVICE" ] && [ "$KEEP_ETC_SERVICE" -eq 0 ]; then
 		echo "An alternate service file was detected under '$ETC_SERVICE'."
 		echo "This is probably due to a previous manual installation."
 		echo "You probably want to delete this file now. Your evcc configuration stays untouched!"
-		askUserKeepFile "$ETC_SERVICE"
-		KEEP_ETC_SERVICE=$?
+		askUserKeepFile "$ETC_SERVICE" || KEEP_ETC_SERVICE=$?
 	fi	
-	if [ -f "$USR_LOCAL_BIN" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+	if [ -f "$USR_LOCAL_BIN" ] && [ "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
 		echo "An alternate evcc binary was detected under '$USR_LOCAL_BIN'."
 		echo "This is probably due to a previous manual installation."
 		echo "You probably want to delete this file now. Your evcc configuration stays untouched!"
-		askUserKeepFile "$USR_LOCAL_BIN"
-		KEEP_USR_LOCAL_BIN=$?
+		askUserKeepFile "$USR_LOCAL_BIN" || KEEP_USR_LOCAL_BIN=$?
 	fi
 	# Save the user decision
 	cat > "$USER_CHOICE_CONFIG" <<EOF 
@@ -61,12 +59,12 @@ KEEP_USR_LOCAL_BIN=$KEEP_USR_LOCAL_BIN
 EOF
 
 	# Execute the user decision
-	if [ -f "$ETC_SERVICE" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+	if [ -f "$ETC_SERVICE" ] && [ "$KEEP_ETC_SERVICE" -eq 0 ]; then
 		echo "Deleting old service file '$ETC_SERVICE'"
 		rm -v "$ETC_SERVICE"
 	fi
 
-	if [ -f "$USR_LOCAL_BIN" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+	if [ -f "$USR_LOCAL_BIN" ] && [ "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
 		echo "Deleting old evcc binary '$USR_LOCAL_BIN'"
 		rm -v "$USR_LOCAL_BIN"
 	fi

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,6 +1,77 @@
 #!/bin/sh
 set -e
 
+USER_CHOICE_CONFIG="/etc/evcc-userchoices.sh"
+ETC_SERVICE="/etc/systemd/system/evcc.service"
+USR_LOCAL_BIN="/usr/local/bin/evcc"
+
+# Usage: askUserKeepFile <file>
+# Return: 1 = keep, 0 = delete
+askUserKeepFile() {
+	while true; do
+		echo "Shall '$1' be deleted? [Y/n]: "
+		read answer
+		case "$answer" in 
+			n*|N*)
+				echo "Ok. We will keep that file. Keep in mind that you may need to alter it if any changes are done upstream. Your answer is saved for the future."
+				return 1
+				;;
+			y*|Y*|"")
+				echo "The file will be deleted."
+				return 0
+				;;
+			*)
+				;;
+		esac
+	done
+}
+
+if [ "$1" = "configure" ]; then
+	KEEP_ETC_SERVICE=0
+	KEEP_USR_LOCAL_BIN=0
+	# If the user once said that he wants to keep the files
+	# this choice file will include that information
+	# and the user will no longer be asked if he wants to keep it
+	if [ -f "$USER_CHOICE_CONFIG" ]; then
+		source "$USER_CHOICE_CONFIG"
+	fi
+
+	# If the user previously decided that he doesn't want to keep
+	# the files or if it's the first time, aks whether he want's to
+	# keep the file
+	if [ -f "$ETC_SERVICE" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+		echo "An alternate service file was detected under '$ETC_SERVICE'."
+		echo "This is probably due to a previous manual installation."
+		echo "You probably want to delete this file now. Your evcc configuration stays untouched!"
+		askUserKeepFile "$ETC_SERVICE"
+		KEEP_ETC_SERVICE=$?
+	fi	
+	if [ -f "$USR_LOCAL_BIN" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+		echo "An alternate evcc binary was detected under '$USR_LOCAL_BIN'."
+		echo "This is probably due to a previous manual installation."
+		echo "You probably want to delete this file now. Your evcc configuration stays untouched!"
+		askUserKeepFile "$USR_LOCAL_BIN"
+		KEEP_USR_LOCAL_BIN=$?
+	fi
+	# Save the user decision
+	cat > "$USER_CHOICE_CONFIG" <<EOF 
+#!/bin/sh
+KEEP_ETC_SERVICE=$KEEP_ETC_SERVICE
+KEEP_USR_LOCAL_BIN=$KEEP_USR_LOCAL_BIN
+EOF
+
+	# Execute the user decision
+	if [ -f "$ETC_SERVICE" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+		echo "Deleting old service file '$ETC_SERVICE'"
+		rm -v "$ETC_SERVICE"
+	fi
+
+	if [ -f "$USR_LOCAL_BIN" -a "$KEEP_USR_LOCAL_BIN" -eq 0 ]; then
+		echo "Deleting old evcc binary '$USR_LOCAL_BIN'"
+		rm -v "$USR_LOCAL_BIN"
+	fi
+fi
+
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
 	# This will only remove masks created by d-s-h on package removal.
 	deb-systemd-helper unmask evcc.service >/dev/null || true


### PR DESCRIPTION
As discussed [here](https://github.com/evcc-io/evcc/discussions/2923) I've added questions to the postinst file to ask the user whether he wants to keep the service file under /etc/systemd/system/evcc.service and the binary under /usr/local/bin/evcc

For now I didn't have time to test this. If anyone can do so, feel free.