### PR TITLE
Upgrade infrastructure to Go 1.18 without requiring it

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ^1.18
       id: go
 
     - name: Set up Node

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ^1.18
       id: go
 
     - name: Set up Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ^1.18
       id: go
 
     - name: Setup Node

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  go: 1.18
 issues:
   exclude:
   - .regActualCurrent. is unused

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN make clean ui
 
 
 # STEP 2 build executable binary
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -1,10 +1,8 @@
 # executes binary build excluding UI
 
-# STEP 2 build executable binary
-FROM golang:1.17-alpine as builder
-
 # define RELEASE=1 to hide commit hash
 ARG RELEASE={{ env "RELEASE" }}
+FROM golang:1.18-alpine as builder
 
 WORKDIR /build
 

--- a/docker/tmpl.Dockerfile
+++ b/docker/tmpl.Dockerfile
@@ -20,10 +20,10 @@ RUN make clean ui
 
 
 # STEP 2 build executable binary
-FROM golang:1.17-alpine as builder
 
 # define RELEASE=1 to hide commit hash
 ARG RELEASE={{ env "RELEASE" }}
+FROM golang:1.18-alpine as builder
 
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.


### PR DESCRIPTION
This will help to issue in the build infrastructure before we switch to requiring 1.18.