### PR TITLE
Fix Modbus Docs Templates

### DIFF
--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -25,7 +25,7 @@ render:
       template: {{ $.Template }}
       usage: {{ . }}
       {{- range $.Params }}
-      {{- if eq .Name "modbus" }}
+      {{- if eq .Name "modbus" -}}
 {{ $.Modbus | indent 6 -}}
       {{- else if ne .Advanced true }}
       {{ .Name }}:
@@ -44,7 +44,7 @@ render:
       template: {{ $.Template }}
       usage: {{ . }}
       {{- range $.Params }}
-      {{- if eq .Name "modbus" }}
+      {{- if eq .Name "modbus" -}}
 {{ $.Modbus | indent 6 -}}
       {{- else }}
       {{ .Name }}:
@@ -62,7 +62,7 @@ render:
       type: template
       template: {{ $.Template }}
       {{- range $.Params }}
-      {{- if eq .Name "modbus" }}
+      {{- if eq .Name "modbus" -}}
 {{ $.Modbus | indent 6 -}}
       {{- else if ne .Advanced true }}
       {{ .Name }}:
@@ -80,7 +80,7 @@ render:
       type: template
       template: {{ $.Template }}
       {{- range $.Params }}
-      {{- if eq .Name "modbus" }}
+      {{- if eq .Name "modbus" -}}
 {{ $.Modbus | indent 6 -}}
       {{- else }}
       {{ .Name }}:

--- a/util/templates/documentation_modbus.tpl
+++ b/util/templates/documentation_modbus.tpl
@@ -1,18 +1,26 @@
-id: {{ .id }}
 {{- if .rs485serial }}
+
 # Modbus: RS485 via adapter
+modbus: rs485serial
+id: {{ .id }}
 device: {{ .device }} # USB-RS485 Adapter Adresse
 baudrate: {{ .baudrate }} # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
 comset: "{{ .comset }}" # Kommunikationsparameter für den Adapter
 {{- end }}
 {{- if .rs485tcpip }}
+
 # Modbus: RS485 via TCPIP
+modbus: rs485tcpip
+id: {{ .id }}
 host: {{ .host }} # Hostname
 port: {{ .port }} # Port
 rtu: true
 {{- end }}
 {{- if .tcpip }}
+
 # Modbus: TCPIP
+modbus: tcpip
+id: {{ .id }}
 host: {{ .host }} # Hostname
 port: {{ .port }} # Port
 {{- end }}


### PR DESCRIPTION
Weiterführung von https://github.com/evcc-io/evcc/pull/3082

Das resultierende Codebeispiel sieht damit bspw. so aus:

```
      type: template
      template: sungrow-dongle
      usage: grid      

      # Modbus: RS485 via adapter
      modbus: rs485serial
      id: 1
      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
      comset: "8N1" # Kommunikationsparameter für den Adapter

      # Modbus: RS485 via TCPIP
      modbus: rs485tcpip
      id: 1
      host: 192.0.2.2 # Hostname
      port: 502 # Port
      rtu: true

      # Modbus: TCPIP
      modbus: tcpip
      id: 1
      host: 192.0.2.2 # Hostname
      port: 502 # Port
  ```
  
  Die Blöcke sind jeweils durch eine Leerzeile getrennt und die `id` ist in die Blöcke gewandert um den Kontext klarer zu machen (`id` == Modbus-ID). Optimierungen wie "keine Kommentare wenns nur eine Modbus-Option gibt" oder "Todbus-Art via UI wählbar" machen wir dann später mal.