### PR TITLE
Add info about Sponsortoken for go-e phase switching

### DIFF
--- a/templates/definition/charger/goe-v3.yaml
+++ b/templates/definition/charger/goe-v3.yaml
@@ -9,11 +9,11 @@ requirements:
     de: |
       Benötigt mindestens Firmware 052.1 oder neuer. 
 
-      Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt. 💚
+      Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt.
     en: |
       Requires firmware 052.1 or later.
 
-      For 1P/3P-Phase switching the HTTP API v2 in the charger setup needs to be activated and a sponsor token is required. 💚
+      For 1P/3P-Phase switching the HTTP API v2 in the charger setup needs to be activated and a sponsor token is required.
   uri: https://docs.evcc.io/docs/devices/chargers#go-echarger-homeprov3
 params:
   - name: host

--- a/templates/definition/charger/goe-v3.yaml
+++ b/templates/definition/charger/goe-v3.yaml
@@ -9,11 +9,11 @@ requirements:
     de: |
       Benötigt mindestens Firmware 052.1 oder neuer. 
 
-      Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt.
+      Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt. 💚
     en: |
       Requires firmware 052.1 or later.
 
-      For 1P/3P-Phase switching the HTTP API v2 in the charger setup needs to be activated and a sponsor token is required.
+      For 1P/3P-Phase switching the HTTP API v2 in the charger setup needs to be activated and a sponsor token is required. 💚
   uri: https://docs.evcc.io/docs/devices/chargers#go-echarger-homeprov3
 params:
   - name: host

--- a/templates/definition/charger/goe-v3.yaml
+++ b/templates/definition/charger/goe-v3.yaml
@@ -9,11 +9,11 @@ requirements:
     de: |
       Benötigt mindestens Firmware 052.1 oder neuer. 
 
-      Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein.
+      Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt. 💚
     en: |
       Requires firmware 052.1 or later.
 
-      For 1P/3P-Phase switching the HTTP API v2 in the charger setup needs to be activated.
+      For 1P/3P-Phase switching the HTTP API v2 in the charger setup needs to be activated and a sponsor token is required. 💚
   uri: https://docs.evcc.io/docs/devices/chargers#go-echarger-homeprov3
 params:
   - name: host

--- a/templates/docs/charger/go-e-v3_0.yaml
+++ b/templates/docs/charger/go-e-v3_0.yaml
@@ -5,7 +5,7 @@ capabilities: ["1p3p"]
 description: |
   Benötigt mindestens Firmware 052.1 oder neuer. 
 
-  Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein.
+  Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt.
 
 render:
   - default: |

--- a/templates/docs/charger/go-e-v3_0.yaml
+++ b/templates/docs/charger/go-e-v3_0.yaml
@@ -5,7 +5,7 @@ capabilities: ["1p3p"]
 description: |
   Benötigt mindestens Firmware 052.1 oder neuer. 
 
-  Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt.
+  Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt. 💚
 
 render:
   - default: |

--- a/templates/docs/charger/tinkerforge-warp_0.yaml
+++ b/templates/docs/charger/tinkerforge-warp_0.yaml
@@ -9,5 +9,5 @@ render:
       template: tinkerforge-warp
       host: 192.0.2.2 # Die IP Adresse oder der Hostname des MQTT Brokers
       port: 1883 # Der Port des MQTT Brokers # Optional
-      topic: warp # Optional
+      topic: warp # Topic (ohne / am Anfang) # Optional
       timeout: 30s # Akzeptiere keine Daten die älter als dieser Wert sind # Optional

--- a/templates/docs/charger/tinkerforge-warp_1.yaml
+++ b/templates/docs/charger/tinkerforge-warp_1.yaml
@@ -9,5 +9,5 @@ render:
       template: tinkerforge-warp
       host: 192.0.2.2 # Die IP Adresse oder der Hostname des MQTT Brokers
       port: 1883 # Der Port des MQTT Brokers # Optional
-      topic: warp # Optional
+      topic: warp # Topic (ohne / am Anfang) # Optional
       timeout: 30s # Akzeptiere keine Daten die älter als dieser Wert sind # Optional


### PR DESCRIPTION
In evcc-io/evcc#3086 wurde aufgebracht dass die Info über den Sponsortoken fehlt

Ich hoffe das 💚 geht. Ich wollte es mit reinnehmen da es bei den anderen Themen mit Sponsortoken auch so ist.