### PR TITLE
Feature/basic priority

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -150,6 +150,8 @@ type LoadPoint struct {
 	chargeRemainingDuration time.Duration // Remaining charge duration
 	chargeRemainingEnergy   float64       // Remaining charge energy in Wh
 	progress                *Progress     // Step-wise progress indicator
+
+	chargePriority int // charge Priority value
 }
 
 // NewLoadPointFromConfig creates a new loadpoint

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -59,7 +59,7 @@ func (lp *LoadPoint) GetMinPowerRequried() float64 {
 	if lp.minSocNotReached() || lp.Mode == api.ModeNow {
 		return lp.chargePower
 	}
-	if lp.Mode == api.ModeMinPV {
+	if lp.Mode == api.ModeMinPV && !lp.targetSocReached() && lp.vehicleSoc < 100 {
 		return lp.GetMinPower() * float64(lp.activePhases())
 	}
 	return 0
@@ -80,6 +80,9 @@ func (lp *LoadPoint) GetPriority() int {
 	}
 	if prio == -1 {
 		prio = 100 - int(lp.vehicleSoc)
+	}
+	if prio > 0 && lp.chargePower > 0 {
+		prio = prio * 2
 	}
 	lp.Lock()
 	defer lp.Unlock()

--- a/core/priority.go
+++ b/core/priority.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 )
 
-func (site *Site) priorityPowerDistribution(totalPriority int, availablePower float64, cheapRate bool, batteryBuffered bool) {
+func (site *Site) priorityPowerDistribution(totalPriority int, totalChargePower float64, availablePower float64, cheapRate bool, batteryBuffered bool) {
 	sort.Slice(site.loadpoints, func(i, j int) bool {
 		return site.loadpoints[i].chargePriority > site.loadpoints[j].chargePriority
 	})
@@ -12,43 +12,52 @@ func (site *Site) priorityPowerDistribution(totalPriority int, availablePower fl
 	var powerSliceNotUsed float64 = 0
 	for _, lp := range site.loadpoints {
 		if lp.chargePriority > 0 {
-			lp.log.DEBUG.Printf("priority of the loadpoint : %.0f%%", float64(lp.chargePriority)/float64(totalPriority)*100)
 			var powerSlice = availablePower*float64(lp.chargePriority)/float64(totalPriority) + powerSliceNotUsed
 			if powerRest > 0 {
 				powerRest = 0
 			}
 			if powerRest > powerSlice {
-				// then higer priority Loadpoint needed more power as the powerSlice was calculated for it
+				// then higer priority Loadpoint needed more power as the powerSlice was calculated for it to start charging
 				powerSlice = powerRest
 			}
+			lp.log.DEBUG.Printf("priority of the loadpoint: %.0f%% - Slice: %.2f - Rest: %.2f", float64(lp.chargePriority)/float64(totalPriority)*100, powerSlice, powerRest)
 			if powerSlice-lp.GetMinPowerRequried() > -lp.GetMinPower()*float64(lp.activePhases()) {
-				lp.log.DEBUG.Printf("priority not enoght for loadpoint : %.2f + %.2f > %.2f", powerSlice, -lp.GetMinPowerRequried(), -lp.GetMinPower()*float64(lp.activePhases()))
+				//lp.log.DEBUG.Printf("priority not enoght for loadpoint : %.2f + %.2f > %.2f", powerSlice, -lp.GetMinPowerRequried(), -lp.GetMinPower()*float64(lp.activePhases()))
 				if powerRest < -lp.GetMinPower()*float64(lp.activePhases()) {
-					lp.log.DEBUG.Printf("priority powerRest : %.2f : powerSlice :  %.2f ", powerRest, powerSlice)
-					lp.Update(powerRest+lp.GetChargePower(), cheapRate, batteryBuffered)
+					x := powerRest + lp.GetChargePower()
+					lp.log.DEBUG.Printf("priority rest update: %.2f", x)
+					lp.Update(x, cheapRate, batteryBuffered)
+					if totalChargePower > 0 && lp.GetChargePower() <= 0 {
+						lp.elapsePVTimer()
+					}
 					powerRest += lp.GetMaxPower()
 				} else {
 					// ToDo: powerRest don't fit for a start but could be added to an ealier Loadpoint
 					powerSliceNotUsed += powerSlice
-					lp.log.DEBUG.Printf("priority not enoght for loadpoint : %.2f < %.2f", powerRest, -lp.GetMinPower()*float64(lp.activePhases()))
-					if lp.chargePower > 0 {
+					lp.log.DEBUG.Printf("priority not enoght power - needed: %.2f", -lp.GetMinPower()*float64(lp.activePhases()))
+					if lp.GetChargePower() > 0 && powerRest == availablePower {
 						lp.elapsePVTimer()
 					}
 					lp.Update(lp.GetChargePower(), cheapRate, batteryBuffered)
 				}
 			} else {
-				lp.log.DEBUG.Printf("priority power for loadpoint : %.2f - %.2f > %.2f ", powerSlice, -lp.GetMinPowerRequried(), -lp.GetMinPower()*float64(lp.activePhases()))
-				lp.Update(powerSlice-lp.GetMinPowerRequried()+lp.GetChargePower(), cheapRate, batteryBuffered)
+				x := powerSlice - lp.GetMinPowerRequried() + lp.GetChargePower()
+				lp.log.DEBUG.Printf("priority power update: %.2f", x)
+				lp.Update(x, cheapRate, batteryBuffered)
+				if totalChargePower > 0 && lp.GetChargePower() <= 0 {
+					lp.elapsePVTimer()
+				}
 				powerRest -= powerSlice
 			}
 		} else {
-			lp.log.DEBUG.Printf("no priority for loadpoint : %.2f - %.2f", powerRest, -lp.GetMinPowerRequried())
-			lp.Update(powerRest-lp.GetMinPowerRequried()+lp.GetChargePower(), cheapRate, batteryBuffered)
+			x := powerRest - lp.GetMinPowerRequried() + lp.GetChargePower()
+			lp.log.DEBUG.Printf("no priority update : %.2f", x)
+			lp.Update(x, cheapRate, batteryBuffered)
 			powerRest = 0
 		}
 		if powerRest < 0 {
 			// ToDo: powerRest don't fit for a start but could be added to an ealier Loadpoint
-			site.log.DEBUG.Printf("power not provided to any loadpoint : %.2f", powerRest)
+			site.log.DEBUG.Printf("priority power not provided: %.2f", powerRest)
 		}
 	}
 }

--- a/core/priority.go
+++ b/core/priority.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"sort"
+)
+
+func (site *Site) priorityPowerDistribution(totalPriority int, availablePower float64, cheapRate bool, batteryBuffered bool) {
+	sort.Slice(site.loadpoints, func(i, j int) bool {
+		return site.loadpoints[i].chargePriority > site.loadpoints[j].chargePriority
+	})
+	var powerRest float64 = availablePower
+	var powerSliceNotUsed float64 = 0
+	for _, lp := range site.loadpoints {
+		if lp.chargePriority > 0 {
+			lp.log.DEBUG.Printf("priority of the loadpoint : %.0f%%", float64(lp.chargePriority)/float64(totalPriority)*100)
+			var powerSlice = availablePower*float64(lp.chargePriority)/float64(totalPriority) + powerSliceNotUsed
+			if powerRest > 0 {
+				powerRest = 0
+			}
+			if powerRest > powerSlice {
+				// then higer priority Loadpoint needed more power as the powerSlice was calculated for it
+				powerSlice = powerRest
+			}
+			if powerSlice-lp.GetMinPowerRequried() > -lp.GetMinPower()*float64(lp.activePhases()) {
+				lp.log.DEBUG.Printf("priority not enoght for loadpoint : %.2f + %.2f > %.2f", powerSlice, -lp.GetMinPowerRequried(), -lp.GetMinPower()*float64(lp.activePhases()))
+				if powerRest < -lp.GetMinPower()*float64(lp.activePhases()) {
+					lp.log.DEBUG.Printf("priority powerRest : %.2f : powerSlice :  %.2f ", powerRest, powerSlice)
+					lp.Update(powerRest+lp.GetChargePower(), cheapRate, batteryBuffered)
+					powerRest += lp.GetMaxPower()
+				} else {
+					// ToDo: powerRest don't fit for a start but could be added to an ealier Loadpoint
+					powerSliceNotUsed += powerSlice
+					lp.log.DEBUG.Printf("priority not enoght for loadpoint : %.2f < %.2f", powerRest, -lp.GetMinPower()*float64(lp.activePhases()))
+					if lp.chargePower > 0 {
+						lp.elapsePVTimer()
+					}
+					lp.Update(lp.GetChargePower(), cheapRate, batteryBuffered)
+				}
+			} else {
+				lp.log.DEBUG.Printf("priority power for loadpoint : %.2f - %.2f > %.2f ", powerSlice, -lp.GetMinPowerRequried(), -lp.GetMinPower()*float64(lp.activePhases()))
+				lp.Update(powerSlice-lp.GetMinPowerRequried()+lp.GetChargePower(), cheapRate, batteryBuffered)
+				powerRest -= powerSlice
+			}
+		} else {
+			lp.log.DEBUG.Printf("no priority for loadpoint : %.2f - %.2f", powerRest, -lp.GetMinPowerRequried())
+			lp.Update(powerRest-lp.GetMinPowerRequried()+lp.GetChargePower(), cheapRate, batteryBuffered)
+			powerRest = 0
+		}
+		if powerRest < 0 {
+			// ToDo: powerRest don't fit for a start but could be added to an ealier Loadpoint
+			site.log.DEBUG.Printf("power not provided to any loadpoint : %.2f", powerRest)
+		}
+	}
+}

--- a/core/site.go
+++ b/core/site.go
@@ -408,9 +408,12 @@ func (site *Site) update(lp Updater) {
 	}
 
 	if sitePower, err := site.sitePower(totalChargePower); err == nil {
-		// total available power = sitePower - totalChargePower + minPower
-
-		lp.Update(sitePower, cheap, site.batteryBuffered)
+		if sitePower-totalChargePower+minPower < 0 {
+			// total available power = sitePower - totalChargePower + minPower
+			site.priorityPowerDistribution(totalPriority, sitePower-totalChargePower+minPower, cheap, site.batteryBuffered)
+		} else {
+			lp.Update(sitePower, cheap, site.batteryBuffered)
+		}
 
 		// ignore negative pvPower values as that means it is not an energy source but consumption
 		homePower := site.gridPower + math.Max(0, site.pvPower) + site.batteryPower - totalChargePower

--- a/core/site.go
+++ b/core/site.go
@@ -410,7 +410,7 @@ func (site *Site) update(lp Updater) {
 	if sitePower, err := site.sitePower(totalChargePower); err == nil {
 		if sitePower-totalChargePower+minPower < 0 {
 			// total available power = sitePower - totalChargePower + minPower
-			site.priorityPowerDistribution(totalPriority, sitePower-totalChargePower+minPower, cheap, site.batteryBuffered)
+			site.priorityPowerDistribution(totalPriority, totalChargePower, sitePower-totalChargePower+minPower, cheap, site.batteryBuffered)
 		} else {
 			lp.Update(sitePower, cheap, site.batteryBuffered)
 		}

--- a/core/site.go
+++ b/core/site.go
@@ -398,12 +398,18 @@ func (site *Site) update(lp Updater) {
 
 	// update all loadpoint's charge power
 	var totalChargePower float64
+	var totalPriority int
+	var minPower float64
 	for _, lp := range site.loadpoints {
 		lp.UpdateChargePower()
 		totalChargePower += lp.GetChargePower()
+		totalPriority += lp.GetPriority()
+		minPower += lp.GetMinPowerRequried()
 	}
 
 	if sitePower, err := site.sitePower(totalChargePower); err == nil {
+		// total available power = sitePower - totalChargePower + minPower
+
 		lp.Update(sitePower, cheap, site.batteryBuffered)
 
 		// ignore negative pvPower values as that means it is not an energy source but consumption


### PR DESCRIPTION
Hallo hier mal ein kleiner versuch mit dem Thema Priority zu starten.
es gibt noch ein paar Probleme und es ist auch nicht konfigurierbar aber nur ein Anfang über den man diskutieren kann ob es so oder vielleicht auch ganz anders machbar ist.
hier kommen nahklar auch die ersten Probleme ans Licht die vorher noch behoben werden müssen.

- Wenn das Auto nicht lädt kann der Strom nicht von einem anderem Auto benutzt werden
- Wenn der Strom nicht für das Zweite Auto reicht bekommt das erste nicht die möglichkeit diesen zu nutzen

Aber hier die kurze Beschreibung wie ich es umgesetzt habe soweit.
Die Priorität ist der fehlende SoC zum target SoC aber wenn das Auto schon lädt wird die Priorität verdoppelt  damit es nicht hin und her flippt. (hier könnte man ganz einfach dann eine Konfigurierbaren Wert nutzen oder mit einbauen)
Die variable Power (also der teil der dynamisch dem Auto zu verfügung gestellt wurde oder generell übrig ist) wird zusammen gerechnet.
Die Prioritäten der LoadPoints werden auch zusammen gezählt. Dabei hat ein volles Auto nahklar keine Priorität mehr und auch ein Loadpoint der Aus ist oder auf Sofort steht denn diese Power ist ja nicht variabel.
danach wird diese Power aufgeteilt und auch umverteilt wenn ein LoadPoint mehr Power nutzt als ihm zusteht. In diesem fall schalte ich auch den PVtimer aus damit nicht ein LoadPoint 5 Minuten weiter lädt und der andere 1 Minute wartet bis er anfängt da es ja klar ist das Power da ist.
Die Verteilung (hab ich in die priotity.go file ausgelagert) war dann doch nicht so einfach wie gedacht und bestimmt gibt es hier ein paar Verbesserungen und die 2 Fehler müssen noch behoben werden.

Aber was haltet ihr davon - sollte man hier weiter machen oder ganz anders anfangen?