### PR TITLE
Tapo plug: add description for error 9999

### DIFF
--- a/charger/tapo/connection.go
+++ b/charger/tapo/connection.go
@@ -267,6 +267,7 @@ func (d *Connection) DoSecureRequest(uri string, taporequest map[string]interfac
 func (d *Connection) CheckErrorCode(errorCode int) error {
 	errorDesc := map[int]string{
 		0:     "Success",
+		9999:  "Login failed, invalid user or password",
 		-1002: "Incorrect Request/Method",
 		-1003: "JSON formatting error ",
 		-1010: "Invalid Public Key Length",


### PR DESCRIPTION
Add description of error 9999:

```bash
xxx@xxxffmmt:~/evcc$ ./evcc -c ./evcc_tapotest.yaml -l debug charger
[main  ] INFO 2022/04/09 15:03:17 evcc 0.89 (68db9b27)
[main  ] INFO 2022/04/09 15:03:17 using config file ./evcc_tapotest.yaml
Power:         Tapo error 9999: Login failed, invalid user or password
Charge status: Tapo error 9999: Login failed, invalid user or password
Enabled:       Tapo error 9999: Login failed, invalid user or password
Charged:       Tapo error 9999: Login failed, invalid user or password
```

Refer to #2935