### PR TITLE
Improve network configuration

### DIFF
--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -38,8 +38,7 @@ func runCharger(cmd *cobra.Command, args []string) {
 	log.INFO.Printf("evcc %s", server.FormattedVersion())
 
 	// load config
-	conf, err := loadConfigFile(cfgFile)
-	if err != nil {
+	if err := loadConfigFile(cfgFile, &conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,7 +23,8 @@ import (
 )
 
 type config struct {
-	URI          string
+	URI          interface{} // deprecated
+	Network      networkConfig
 	Log          string
 	SponsorToken string
 	Metrics      bool
@@ -40,6 +43,20 @@ type config struct {
 	Tariffs      tariffConfig
 	Site         map[string]interface{}
 	LoadPoints   []map[string]interface{}
+}
+
+type networkConfig struct {
+	Schema string
+	Host   string
+	Port   int
+}
+
+func (c networkConfig) HostPort() string {
+	return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+}
+
+func (c networkConfig) URI() string {
+	return fmt.Sprintf("%s://%s", c.Schema, c.HostPort())
 }
 
 type mqttConfig struct {

--- a/cmd/demo.go
+++ b/cmd/demo.go
@@ -10,7 +10,7 @@ import (
 //go:embed demo.yaml
 var demoYaml string
 
-func demoConfig() (conf config) {
+func demoConfig(conf *config) {
 	demo := map[string]interface{}{}
 
 	if err := yaml.Unmarshal([]byte(demoYaml), &demo); err != nil {
@@ -24,6 +24,4 @@ func demoConfig() (conf config) {
 	if err := viper.UnmarshalExact(&conf); err != nil {
 		log.FATAL.Fatalf("failed loading demo config: %v", err)
 	}
-
-	return conf
 }

--- a/cmd/demo.go
+++ b/cmd/demo.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	_ "embed" // for yaml
-	"fmt"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -21,9 +20,6 @@ func demoConfig() (conf config) {
 	for k, v := range demo {
 		viper.Set(k, v)
 	}
-
-	// demo port
-	viper.Set("uri", fmt.Sprintf("0.0.0.0:%d", defaultPort))
 
 	if err := viper.UnmarshalExact(&conf); err != nil {
 		log.FATAL.Fatalf("failed loading demo config: %v", err)

--- a/cmd/demo.go
+++ b/cmd/demo.go
@@ -24,4 +24,6 @@ func demoConfig(conf *config) {
 	if err := viper.UnmarshalExact(&conf); err != nil {
 		log.FATAL.Fatalf("failed loading demo config: %v", err)
 	}
+
+	conf.Network.Port = defaultPort
 }

--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -1,3 +1,6 @@
+network:
+  port: 7070
+
 log: info
 
 interval: 3s

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -26,8 +26,7 @@ func runDump(cmd *cobra.Command, args []string) {
 	log.INFO.Printf("evcc %s", server.FormattedVersion())
 
 	// load config
-	conf, err := loadConfigFile(cfgFile)
-	if err != nil {
+	if err := loadConfigFile(cfgFile, &conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -29,8 +29,7 @@ func runMeter(cmd *cobra.Command, args []string) {
 	log.INFO.Printf("evcc %s", server.FormattedVersion())
 
 	// load config
-	conf, err := loadConfigFile(cfgFile)
-	if err != nil {
+	if err := loadConfigFile(cfgFile, &conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -31,7 +31,7 @@ func init() {
 
 var cp = new(ConfigProvider)
 
-func loadConfigFile(cfgFile string) (conf config, err error) {
+func loadConfigFile(cfgFile string, conf *config) (err error) {
 	if cfgFile != "" {
 		log.INFO.Println("using config file", cfgFile)
 		if err := viper.UnmarshalExact(&conf); err != nil {
@@ -41,7 +41,7 @@ func loadConfigFile(cfgFile string) (conf config, err error) {
 		err = errors.New("missing evcc config")
 	}
 
-	return conf, err
+	return err
 }
 
 func configureEnvironment(conf config) (err error) {

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -29,8 +29,7 @@ func runToken(cmd *cobra.Command, args []string) {
 	log.INFO.Printf("evcc %s", server.FormattedVersion())
 
 	// load config
-	conf, err := loadConfigFile(cfgFile)
-	if err != nil {
+	if err := loadConfigFile(cfgFile, &conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
 
@@ -55,6 +54,7 @@ func runToken(cmd *cobra.Command, args []string) {
 	}
 
 	var token *oauth2.Token
+	var err error
 
 	switch strings.ToLower(vehicleConf.Type) {
 	case "tesla":

--- a/cmd/token_tronity.go
+++ b/cmd/token_tronity.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -133,13 +132,8 @@ func tronityToken(conf config, vehicleConf qualifiedConfig) (*oauth2.Token, erro
 	}
 
 	if oc.RedirectURL = cc.RedirectURI; oc.RedirectURL == "" {
-		_, port, err := net.SplitHostPort(conf.URI)
-		if err != nil {
-			return nil, err
-		}
-
-		oc.RedirectURL = fmt.Sprintf("http://%s/auth/tronity", net.JoinHostPort("localhost", port))
+		oc.RedirectURL = fmt.Sprintf("%s/auth/tronity", conf.Network.URI())
 	}
 
-	return tronityAuthorize(conf.URI, oc)
+	return tronityAuthorize(conf.Network.HostPort(), oc)
 }

--- a/cmd/vehicle.go
+++ b/cmd/vehicle.go
@@ -32,8 +32,7 @@ func runVehicle(cmd *cobra.Command, args []string) {
 	log.INFO.Printf("evcc %s", server.FormattedVersion())
 
 	// load config
-	conf, err := loadConfigFile(cfgFile)
-	if err != nil {
+	if err := loadConfigFile(cfgFile, &conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -172,7 +172,7 @@ func (site *Site) DumpConfig() {
 
 	if len(site.pvMeters) > 0 {
 		for i, pv := range site.pvMeters {
-			site.log.INFO.Println(meterCapabilities(fmt.Sprintf("pv %d", i), pv))
+			site.log.INFO.Println(meterCapabilities(fmt.Sprintf("pv %d", i+1), pv))
 		}
 	}
 
@@ -180,7 +180,7 @@ func (site *Site) DumpConfig() {
 		for i, battery := range site.batteryMeters {
 			_, ok := battery.(api.Battery)
 			site.log.INFO.Println(
-				meterCapabilities(fmt.Sprintf("battery %d", i), battery),
+				meterCapabilities(fmt.Sprintf("battery %d", i+1), battery),
 				fmt.Sprintf("soc %s", presence[ok]),
 			)
 		}
@@ -217,7 +217,7 @@ func (site *Site) DumpConfig() {
 			_, status := v.(api.ChargeState)
 			_, climate := v.(api.VehicleClimater)
 			lp.log.INFO.Printf("    vehicle %d: range %s finish %s status %s climate %s",
-				i, presence[rng], presence[finish], presence[status], presence[climate],
+				i+1, presence[rng], presence[finish], presence[status], presence[climate],
 			)
 		}
 	}

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -1,4 +1,8 @@
-uri: 0.0.0.0:7070 # uri for ui
+network:
+  schema: http
+  host: evcc.local
+  port: 7070
+
 interval: 10s # control cycle interval
 
 # sponsor token enables optional features (request at https://cloud.evcc.io)

--- a/server/http.go
+++ b/server/http.go
@@ -41,7 +41,7 @@ type HTTPd struct {
 }
 
 // NewHTTPd creates HTTP server with configured routes for loadpoint
-func NewHTTPd(url string, site site.API, hub *SocketHub, cache *util.Cache) *HTTPd {
+func NewHTTPd(addr string, site site.API, hub *SocketHub, cache *util.Cache) *HTTPd {
 	routes := map[string]route{
 		"health": {[]string{"GET"}, "/health", healthHandler(site)},
 		"state":  {[]string{"GET"}, "/state", stateHandler(cache)},
@@ -98,7 +98,7 @@ func NewHTTPd(url string, site site.API, hub *SocketHub, cache *util.Cache) *HTT
 
 	srv := &HTTPd{
 		Server: &http.Server{
-			Addr:         url,
+			Addr:         addr,
 			Handler:      router,
 			ReadTimeout:  5 * time.Second,
 			WriteTimeout: 10 * time.Second,

--- a/vehicle/mercedes.go
+++ b/vehicle/mercedes.go
@@ -13,6 +13,7 @@ import (
 // Mercedes is an api.Vehicle implementation for Mercedes cars
 type Mercedes struct {
 	*embed
+	api.ProviderLogin
 	*mercedes.Provider
 }
 
@@ -63,8 +64,9 @@ func NewMercedesFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	api := mercedes.NewAPI(log, identity, cc.Sandbox)
 
 	v := &Mercedes{
-		embed:    &cc.embed,
-		Provider: mercedes.NewProvider(api, strings.ToUpper(cc.VIN), cc.Cache),
+		embed:         &cc.embed,
+		Provider:      mercedes.NewProvider(api, strings.ToUpper(cc.VIN), cc.Cache),
+		ProviderLogin: identity, // expose the OAuth2 login
 	}
 
 	return v, nil


### PR DESCRIPTION
This PR replaces `uri` with more detailed network configuration:

```
network:
  # schema is the HTTP schema
  # setting to `https` does not enable https, it only changes the way URLs are generated
  schema: http

  # host is the hostname or IP address
  # if the host name contains a `.local` suffix, the name will be announced on MDNS
  # docker: MDNS announcements don't not work. Host must be set to the docker host's name
  host: evcc.local

  # port is the listening port for UI and api
  # evcc will listen on all available interfaces
  port: 7070

  # per default, evcc should be available at http://evcc.local:7070
```

`uri` is deprecated and will be ignored (but currently not error).

Changing this config allows to fix the outstanding issues with the Mercedes Benz OAuth2 configuration.