### PR TITLE
Tasmota: set fix power in static mode

### DIFF
--- a/charger/tasmota.go
+++ b/charger/tasmota.go
@@ -134,6 +134,19 @@ func (c *Tasmota) CurrentPower() (float64, error) {
 		power = 0
 	}
 
+	// set fix static power in static mode
+	if c.standbypower < 0 {
+		on, err := c.Enabled()
+		if err != nil {
+			return 0, err
+		}
+		if on {
+			power = c.standbypower * -1
+		} else {
+			power = 0
+		}
+	}
+
 	return power, err
 }
 

--- a/charger/tasmota.go
+++ b/charger/tasmota.go
@@ -145,7 +145,7 @@ func (c *Tasmota) CurrentPower() (float64, error) {
 		if err != nil {
 			return 0, err
 		}
-		power := float64(resp.StatusSNS.Energy.Power)
+		power = float64(resp.StatusSNS.Energy.Power)
 		// ignore standby power
 		if power < c.standbypower {
 			power = 0


### PR DESCRIPTION
Set fix power in static mode

```yaml
chargers:
- type: template
  template: tasmota 
  host: 192.168.178.xxx
  # user: XXX
  # password: XXX
  standbypower: -1500
  name: wallbox1
```

Tasmota plug on:
```bash
[main  ] INFO 2022/04/17 14:21:53 evcc 0.90 (fe7b4ff0)
[main  ] INFO 2022/04/17 14:21:53 using config file ./evcc_tasmotatest.yaml
Power:         1500W
Energy:        118.9kWh
Charge status: C
Enabled:       true
```

Tasmota plug off:
```bash
[main  ] INFO 2022/04/17 14:23:57 evcc 0.90 (fe7b4ff0)
[main  ] INFO 2022/04/17 14:23:57 using config file ./evcc_tasmotatest.yaml
Power:         0W
Energy:        118.9kWh
Charge status: B
Enabled:       false
```
