### PR TITLE
Fix Solax X3 modbus template battery power scale

### DIFF
--- a/templates/definition/meter/solax-x3.yaml
+++ b/templates/definition/meter/solax-x3.yaml
@@ -55,6 +55,7 @@ render: |
       address: 22 #(see Hybrid.X1.X3-G3.ModbusTCP.RTU.V3.21-.English.pdf)
       type: input
       decode: int16
+    scale: -1
   soc:
     source: modbus
     uri: {{ .host }}:{{ .port }}


### PR DESCRIPTION
By using the current Solax X3 battery template in config, battery power is provided with a wrong sign. This fix will correct this. 