### PR TITLE
Charger: add ramp command for testing vehicle response

### DIFF
--- a/cmd/charger_ramp.go
+++ b/cmd/charger_ramp.go
@@ -37,6 +37,9 @@ func ramp(c api.Charger, digits int) {
 
 	fmt.Printf("%6s\t%6s\n", "I (A)", "P (W)")
 
+	c.Enable(true)
+	defer c.Enable(false)
+
 	var i float64 = 6.0
 	for {
 		var err error

--- a/cmd/charger_ramp.go
+++ b/cmd/charger_ramp.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/cmd/shutdown"
+	"github.com/evcc-io/evcc/server"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// cmdEcho.AddCommand
+
+// chargerRampCmd represents the charger command
+var chargerRampCmd = &cobra.Command{
+	Use:   "ramp [name]",
+	Short: "Ramp current from 6..16A in configurtable steps",
+	Run:   runChargerRamp,
+}
+
+func init() {
+	chargerCmd.AddCommand(chargerRampCmd)
+	chargerRampCmd.PersistentFlags().StringP(flagName, "n", "", fmt.Sprintf(flagNameDescription, "charger"))
+	chargerRampCmd.PersistentFlags().Bool(flagHeaders, false, flagHeadersDescription)
+	chargerRampCmd.PersistentFlags().StringP(flagDigits, "", "0", "fractional digits (0..2)")
+}
+
+func ramp(c api.Charger, digits int) {
+	steps := math.Pow10(digits)
+	delta := 1 / steps
+
+	fmt.Printf("%6s\t%6s\n", "I (A)", "P (W)")
+
+	var i float64 = 6.0
+	for {
+		var err error
+
+		if cc, ok := c.(api.ChargerEx); ok {
+			err = cc.MaxCurrentMillis(i)
+		} else {
+			err = c.MaxCurrent(int64(i))
+		}
+
+		time.Sleep(time.Second)
+
+		var p float64
+		if cc, ok := c.(api.Meter); err == nil && ok {
+			p, err = cc.CurrentPower()
+		}
+
+		if err != nil {
+			log.ERROR.Fatalln(err)
+		}
+
+		fmt.Printf("%6.3f\t%6.0f\n", i, p)
+
+		i += delta
+	}
+}
+
+func runChargerRamp(cmd *cobra.Command, args []string) {
+	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
+	log.INFO.Printf("evcc %s", server.FormattedVersion())
+
+	// load config
+	if err := loadConfigFile(cfgFile, &conf); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	// setup environment
+	if err := configureEnvironment(conf); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	// full http request log
+	if cmd.PersistentFlags().Lookup(flagHeaders).Changed {
+		request.LogHeaders = true
+	}
+
+	// select single charger
+	if err := selectByName(cmd, &conf.Chargers); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	if err := cp.configureChargers(conf); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	stopC := make(chan struct{})
+	go shutdown.Run(stopC)
+
+	chargers := cp.chargers
+	if len(args) == 1 {
+		arg := args[0]
+		chargers = map[string]api.Charger{arg: cp.Charger(arg)}
+	}
+
+	flag := cmd.PersistentFlags().Lookup(flagDigits)
+	digits, err := strconv.Atoi(flag.Value.String())
+	if err != nil {
+		log.ERROR.Fatalln(err)
+	}
+
+	for _, c := range chargers {
+		if _, ok := c.(api.ChargerEx); digits > 0 && !ok {
+			log.ERROR.Fatalln("charger does not support mA control")
+		}
+		ramp(c, digits)
+	}
+
+	close(stopC)
+	<-shutdown.Done()
+}

--- a/cmd/charger_ramp.go
+++ b/cmd/charger_ramp.go
@@ -47,8 +47,10 @@ func ramp(c api.Charger, digits int, delay time.Duration) {
 	fmt.Printf("delay:\t%s\n", delay)
 	fmt.Printf("\n%6s\t%6s\n", "I (A)", "P (W)")
 
-	c.Enable(true)
-	defer c.Enable(false)
+	if err := c.Enable(true); err != nil {
+		log.ERROR.Fatalln(err)
+	}
+	defer func() { _ = c.Enable(false) }()
 
 	var i float64 = 6.0
 	for {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -27,6 +27,8 @@ const (
 
 	flagStop            = "stop"
 	flagStopDescription = "Stop charging"
+
+	flagDigits = "digits"
 )
 
 func selectByName(cmd *cobra.Command, conf *[]qualifiedConfig) error {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -29,6 +29,7 @@ const (
 	flagStopDescription = "Stop charging"
 
 	flagDigits = "digits"
+	flagDelay  = "delay"
 )
 
 func selectByName(cmd *cobra.Command, conf *[]qualifiedConfig) error {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -31,7 +31,7 @@ func init() {
 
 var cp = new(ConfigProvider)
 
-func loadConfigFile(cfgFile string, conf any) (err error) {
+func loadConfigFile(cfgFile string, conf *config) (err error) {
 	if cfgFile != "" {
 		log.INFO.Println("using config file", cfgFile)
 		if err := viper.UnmarshalExact(&conf); err != nil {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -31,7 +31,7 @@ func init() {
 
 var cp = new(ConfigProvider)
 
-func loadConfigFile(cfgFile string, conf *config) (err error) {
+func loadConfigFile(cfgFile string, conf any) (err error) {
 	if cfgFile != "" {
 		log.INFO.Println("using config file", cfgFile)
 		if err := viper.UnmarshalExact(&conf); err != nil {


### PR DESCRIPTION
Allows  testing vehicle response:

```
❯ evcc charger ramp -c cfg/prod.yaml --log error --digits 1 --delay 20s

delay:	20s

 I (A)	 P (W)
 6.000	  2740
 6.100	  2740
 6.200	  2740
 6.300	  2740
 6.400	  2740
 6.500	  2821
 6.600	  2858
 6.700	  2903
 6.800	  2934
 6.900	  3025
 7.000	  3066
 7.100	  3067
 7.200	  3148
 7.300	  3149
 7.400	  3230
 7.500	  3230
 7.600	  3309
```