### PR TITLE
Fix Websocket JSON; represent NaN as null

### DIFF
--- a/server/socket.go
+++ b/server/socket.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -100,7 +101,11 @@ func encode(v interface{}) (string, error) {
 		// must be before stringer to convert to seconds instead of string
 		s = fmt.Sprintf("%d", int64(val.Seconds()))
 	case float64:
-		s = fmt.Sprintf("%.5g", val)
+		if math.IsNaN(val) {
+			s = "null"
+		} else {
+			s = fmt.Sprintf("%.5g", val)
+		}
 	default:
 		if b, err := json.Marshal(v); err == nil {
 			s = string(b)

--- a/server/socket_test.go
+++ b/server/socket_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ func TestEncode(t *testing.T) {
 		in, out interface{}
 	}{
 		{int64(1), "1"},
+		{math.NaN(), "null"},
 		{float64(1.23456), "1.2346"},
 		{"1.2345", "\"1.2345\""},
 		{time.Hour, "3600"},


### PR DESCRIPTION
`NaN` is not a valid value in JSON. Changed the marshalling to prepresent NaN values as `null`.

Fixes #3215