### PR TITLE
Add stop current flag to ramp function

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -28,8 +28,9 @@ const (
 	flagStop            = "stop"
 	flagStopDescription = "Stop charging"
 
-	flagDigits = "digits"
-	flagDelay  = "delay"
+	flagDigits      = "digits"
+	flagDelay       = "delay"
+	flagStopcurrent = "stopcurrent"
 )
 
 func selectByName(cmd *cobra.Command, conf *[]qualifiedConfig) error {


### PR DESCRIPTION
1Phase cars need up to 20A for full ramp cycle - default is 16

[This commit](https://github.com/evcc-io/evcc/commit/3db8e4071e909775f77ccee6e8f57b6c293d18ea) broke the functionality to be able to test 1P Cars in the full range. I do not want to revert the limit, just be able to have the additional option.

Default 6-16A ramp range.
Optional stop current 6-20A