### PR TITLE
Kostal-Piko: Consider charger indicator in battery meter

### DIFF
--- a/templates/definition/meter/kostal-piko.yaml
+++ b/templates/definition/meter/kostal-piko.yaml
@@ -36,7 +36,7 @@ render: |
   {{- if eq .usage "battery" }}
     # Battery
     source: http
-    uri: http://{{ .host }}/api/dxs.json?dxsEntries=33556226,33556238,33556230 # Battery Voltage * Energy * Charging Indicator
+    uri: http://{{ .host }}/api/dxs.json?dxsEntries=33556226&dxsEntries=33556238&dxsEntries=33556230 # Battery Voltage * Energy * Charging Indicator
     jq: (.dxsEntries[] | select(.dxsId==33556226) | .value) * (.dxsEntries[] | select(.dxsId==33556238) | .value) * (if (.dxsEntries[] | select(.dxsId==33556230) | .value) == 1 then -1 else 1 end) | if . == null then 0 else . end
   soc:
     source: http

--- a/templates/definition/meter/kostal-piko.yaml
+++ b/templates/definition/meter/kostal-piko.yaml
@@ -37,7 +37,7 @@ render: |
     # Battery
     source: http
     uri: http://{{ .host }}/api/dxs.json?dxsEntries=33556226&dxsEntries=33556238&dxsEntries=33556230 # Battery Voltage * Energy * Charging Indicator
-    jq: (.dxsEntries[] | select(.dxsId==33556226) | .value) * (.dxsEntries[] | select(.dxsId==33556238) | .value) * (if (.dxsEntries[] | select(.dxsId==33556230) | .value) == 1 then -1 else 1 end) | if . == null then 0 else . end
+    jq: (.dxsEntries[] | select(.dxsId==33556226) | .value) * (.dxsEntries[] | select(.dxsId==33556238) | .value) * (if (.dxsEntries[] | select(.dxsId==33556230) | .value) == 0 then -1 else 1 end) | if . == null then 0 else . end
   soc:
     source: http
     uri: http://{{ .host }}/api/dxs.json?dxsEntries=33556229 # Battery SOC

--- a/templates/definition/meter/kostal-piko.yaml
+++ b/templates/definition/meter/kostal-piko.yaml
@@ -36,8 +36,8 @@ render: |
   {{- if eq .usage "battery" }}
     # Battery
     source: http
-    uri: http://{{ .host }}/api/dxs.json?dxsEntries=33556226,33556238 # Battery Voltage * Energy
-    jq: (.dxsEntries[] | select(.dxsId==33556226) | .value) * (.dxsEntries[] | select(.dxsId==33556238) | .value) | if . == null then 0 else . end
+    uri: http://{{ .host }}/api/dxs.json?dxsEntries=33556226,33556238,33556230 # Battery Voltage * Energy * Charging Indicator
+    jq: (.dxsEntries[] | select(.dxsId==33556226) | .value) * (.dxsEntries[] | select(.dxsId==33556238) | .value) * (if (.dxsEntries[] | select(.dxsId==33556230) | .value) == 1 then -1 else 1 end) | if . == null then 0 else . end
   soc:
     source: http
     uri: http://{{ .host }}/api/dxs.json?dxsEntries=33556229 # Battery SOC


### PR DESCRIPTION
Refer to #3340
Template enhancement will render the following Kostal Piko battery meter config:
```yaml
- name: battery
  type: custom
  power:
    # Battery
    source: http
    uri: http://<kostal-ip>/api/dxs.json?dxsEntries=33556226&dxsEntries=33556238&dxsEntries=33556230 # Battery Voltage * Energy * Charging Indicator
    jq: (.dxsEntries[] | select(.dxsId==33556226) | .value) * (.dxsEntries[] | select(.dxsId==33556238) | .value) * (if (.dxsEntries[] | select(.dxsId==33556230) | .value) == 0 then -1 else 1 end) | if . == null then 0 else . end
  soc:
    source: http
    uri: http://<kostal-ip>/api/dxs.json?dxsEntries=33556229 # Battery SOC
    jq: .dxsEntries[0].value | if . == null then 0 else . end
``` 