### PR TITLE
Mbmd: support predefined non-Sunspec meters using ModbusTCP

### DIFF
--- a/templates/definition/meter/cg-em24.yaml
+++ b/templates/definition/meter/cg-em24.yaml
@@ -7,10 +7,11 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery", "charge"]
   - name: modbus
-    choice: ["tcpip"]
+    choice: ["rs485", "tcpip"]
 render: |
   type: modbus
   model: cgem24
+  {{- include "modbus" . }}
   {{- if eq .usage "charge" }}
   energy: Import # only required for charge meter usage
   {{- end }}
@@ -20,4 +21,3 @@ render: |
     - CurrentL2
     - CurrentL3
   {{- end }}
-  {{- include "modbus" . }}

--- a/templates/definition/meter/siemens-pac2200.yaml
+++ b/templates/definition/meter/siemens-pac2200.yaml
@@ -7,12 +7,13 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery", "charge"]
   - name: modbus
-    choice: ["rs485"]
+    choice: ["rs485", "tcpip"]
 render: |
   type: modbus
   model: pac2200
+  {{- include "modbus" . }}
   {{- if eq .usage "charge" }}
-  energy: Sum # only required for charge meter usage
+  energy: Import # only required for charge meter usage
   {{- end }}
   {{- if or (eq .usage "charge") (eq .usage "grid") }}
   currents:
@@ -20,4 +21,3 @@ render: |
     - CurrentL2
     - CurrentL3
   {{- end }}
-  {{- include "modbus" . }}

--- a/templates/docs/meter/cg-em24_0.yaml
+++ b/templates/docs/meter/cg-em24_0.yaml
@@ -8,6 +8,19 @@ render:
       template: cg-em24
       usage: grid      
 
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
       # Modbus TCP
       modbus: tcpip
       id: 1
@@ -18,6 +31,19 @@ render:
       type: template
       template: cg-em24
       usage: pv      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
 
       # Modbus TCP
       modbus: tcpip
@@ -30,6 +56,19 @@ render:
       template: cg-em24
       usage: battery      
 
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
       # Modbus TCP
       modbus: tcpip
       id: 1
@@ -40,6 +79,19 @@ render:
       type: template
       template: cg-em24
       usage: charge      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
 
       # Modbus TCP
       modbus: tcpip

--- a/templates/docs/meter/siemens-pac2200_0.yaml
+++ b/templates/docs/meter/siemens-pac2200_0.yaml
@@ -20,6 +20,12 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
   - usage: pv
     default: |
       type: template
@@ -35,6 +41,12 @@ render:
 
       # RS485 via TCP/IP (Modbus RTU)
       modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
@@ -56,6 +68,12 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
   - usage: charge
     default: |
       type: template
@@ -71,6 +89,12 @@ render:
 
       # RS485 via TCP/IP (Modbus RTU)
       modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port

--- a/util/templates/modbus.tpl
+++ b/util/templates/modbus.tpl
@@ -14,5 +14,6 @@ rtu: true
 {{- if or (eq .modbus "tcpip") .tcpip }}
 # Modbus TCP
 uri: {{ .host }}:{{ .port }}
+rtu: false
 {{- end }}
 {{- end}}


### PR DESCRIPTION
This fixes `EM24` and `PAC2200` with Ethernet interface. Previously, when `rtu` was undefined and the meter `model` a recognized type from MBMD, `RTU` was assumed. Due to backwards compatibility we should not change this behaviour. We can still fix it by explicitly declaring `rtu: false` when using a meter with Ethernet interface.