### PR TITLE
Evse SmartWB support manual mode

### DIFF
--- a/charger/evse/types.go
+++ b/charger/evse/types.go
@@ -11,21 +11,21 @@ type ParameterResponse struct {
 // ListEntry is ParameterResponse.List
 type ListEntry struct {
 	VehicleState    int64   `json:"vehicleState"`
-	EvseState       bool    `json:"evseState"`
+	EvseState       bool    `json:"evseState"` // true when charing is enabled on the charger, regardless the car charges or not
 	MaxCurrent      int64   `json:"maxCurrent"`
 	ActualCurrent   int64   `json:"actualCurrent"`
 	ActualCurrentMA *int64  `json:"actualCurrentMA"` // 1/100 A
 	ActualPower     float64 `json:"actualPower"`
 	Duration        int64   `json:"duration"`
-	AlwaysActive    bool    `json:"alwaysActive"`
+	AlwaysActive    bool    `json:"alwaysActive"` // false for "normal" mode, true for "remote" and "always active"
 	UseMeter        bool    `json:"useMeter"`
-	LastActionUser  string  `json:"lastActionUser"`
-	LastActionUID   string  `json:"lastActionUID"`
+	LastActionUser  string  `json:"lastActionUser"` // one of API, GUI, Button, or the user name when using RFID
+	LastActionUID   string  `json:"lastActionUID"`  // RFID id when RFID us used, otherwise "API", "Button" or "GUI"
 	Energy          float64 `json:"energy"`
 	Mileage         float64 `json:"mileage"`
 	MeterReading    float64 `json:"meterReading"`
 	CurrentP1       float64 `json:"currentP1"`
 	CurrentP2       float64 `json:"currentP2"`
 	CurrentP3       float64 `json:"currentP3"`
-	RFIDUID         *string `json:"RFIDUID"`
+	RFIDUID         *string `json:"RFIDUID"` // RFID from current contact
 }

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -53,10 +53,6 @@ func NewEVSEWifiFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return wb, err
 	}
 
-	if !params.AlwaysActive {
-		return nil, errors.New("evse must be configured to remote mode")
-	}
-
 	if params.UseMeter {
 		cc.Meter.Energy = true
 		cc.Meter.Energy = true
@@ -157,6 +153,29 @@ func (wb *EVSEWifi) Status() (api.ChargeStatus, error) {
 	}
 }
 
+// check whether there is a manual intervention on the charger:
+// either by Button, GUI, RFID or Timer and "alwaysActive" is false
+// if so, dont allow changing the charger
+func (wb *EVSEWifi) controlAllowed() (bool, error) {
+	params, err := wb.getParameters()
+	if err != nil {
+		return false, err
+	}
+	if params.AlwaysActive == false {
+		wb.log.DEBUG.Println("charger in manual mode")
+		// in manual mode when active, check intervention on charger
+		if params.EvseState == true {
+			wb.log.DEBUG.Println(fmt.Sprintf("charger active with action: %s", params.LastActionUser))
+			if params.LastActionUser != "API" && params.LastActionUser != "" {
+				wb.log.INFO.Println(fmt.Sprintf("charger has manual intervention: %s (UID: %s)", params.LastActionUser, params.LastActionUID))
+				return false, errors.New(fmt.Sprintf("charger has manual intervention: %s (UID: %s)", params.LastActionUser, params.LastActionUID))
+			}
+		}
+	}
+	wb.log.DEBUG.Println("charger allowed for remote control")
+	return true, nil
+}
+
 // Enabled implements the api.Charger interface
 func (wb *EVSEWifi) Enabled() (bool, error) {
 	params, err := wb.getParameters()
@@ -174,6 +193,10 @@ func (wb *EVSEWifi) get(uri string) error {
 
 // Enable implements the api.Charger interface
 func (wb *EVSEWifi) Enable(enable bool) error {
+	ctrlAllowed, err := wb.controlAllowed()
+	if ctrlAllowed != true {
+		return err
+	}
 	uri := fmt.Sprintf("%s/setStatus?active=%v", wb.uri, enable)
 	if wb.alwaysActive {
 		var current int64
@@ -187,6 +210,10 @@ func (wb *EVSEWifi) Enable(enable bool) error {
 
 // MaxCurrent implements the api.Charger interface
 func (wb *EVSEWifi) MaxCurrent(current int64) error {
+	ctrlAllowed, err := wb.controlAllowed()
+	if ctrlAllowed != true {
+		return err
+	}
 	if wb.hires {
 		current = 100 * current
 	}
@@ -197,6 +224,10 @@ func (wb *EVSEWifi) MaxCurrent(current int64) error {
 
 // maxCurrentEx implements the api.ChargerEx interface
 func (wb *EVSEWifi) maxCurrentEx(current float64) error {
+	ctrlAllowed, err := wb.controlAllowed()
+	if ctrlAllowed != true {
+		return err
+	}
 	wb.current = int64(100 * current)
 	uri := fmt.Sprintf("%s/setCurrent?current=%d", wb.uri, wb.current)
 	return wb.get(uri)

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -19,6 +19,7 @@ type EVSEWifi struct {
 	alwaysActive bool
 	current      int64 // current will always be the physical value sent to the API
 	hires        bool
+	log          *util.Logger
 }
 
 func init() {
@@ -108,6 +109,7 @@ func NewEVSEWifi(uri string) (*EVSEWifi, error) {
 		Helper:  request.NewHelper(log),
 		uri:     strings.TrimRight(uri, "/"),
 		current: 6, // 6A defined value
+		log:     log,
 	}
 
 	return wb, nil


### PR DESCRIPTION
**tl;dr:** This change allows the charger also run in "normal" (manual) mode. EVCC will not change the charger state if it was activated by any action on the charger itself (via button, RFID, Timer or GUI on EVSE/SmartWB). This allows priority on manual decision taken, otherwise use EVCC management.

**Description:**
Without this change the EVSE will only work when in either "remote" or "alwaysActive" mode. If not, EVCC will even not start. Problems with this:
- the EVCC built in timer can not be used in this mode
- a user (WAF) cannot easily use the button or RFID to activate the charging at any time if immediate charging is required.

The EVSE API does not really return the mode and evse version. In both remote and alwaysActive mode the parameter "alwaysActive" is the same (which I consider as a problem or inconsistency with the EVSE API).

This change now does:
- accept evse also in "normal" mode (alwaysActive = false)
- when any charge activation on the charger is initiated, check whether the EVSE is activated by anything else than the API. If this is the case, dont change the EVSE status or current setting from EVCC. (EVSE will return to activated = false when charging has been stopped or the cable from vehicle has been removed).
- in evse mode "alwaysActive = true" the behavior is unchanged.