### PR TITLE
Fronius-Gen24: add phase currents for grid meter

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -27,6 +27,10 @@ render: |
   uri: {{ .host }}:{{ .port }}
   id: 200
   power: {{ if eq .integer "true" }}203{{ else }}213{{ end }}:W # sunspec model 203/213 meter
+  currents:
+    - {{ if eq .integer "true" }}203{{ else }}213{{ end }}:AphA # sunspec 203/213 current
+    - {{ if eq .integer "true" }}203{{ else }}213{{ end }}:AphB # sunspec 203/213 current
+    - {{ if eq .integer "true" }}203{{ else }}213{{ end }}:AphC # sunspec 203/213 current
   {{- end }}
   {{- if eq .usage "pv" }}
   type: custom

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -26,11 +26,21 @@ render: |
   model: sunspec
   uri: {{ .host }}:{{ .port }}
   id: 200
-  power: {{ if eq .integer "true" }}203{{ else }}213{{ end }}:W # sunspec model 203/213 meter
+  {{ if eq .integer "true" }}
+  # sunspec model 203 (int+sf) meter
+  power: 203:W
   currents:
-    - {{ if eq .integer "true" }}203{{ else }}213{{ end }}:AphA # sunspec 203/213 current
-    - {{ if eq .integer "true" }}203{{ else }}213{{ end }}:AphB # sunspec 203/213 current
-    - {{ if eq .integer "true" }}203{{ else }}213{{ end }}:AphC # sunspec 203/213 current
+    - 203:AphA
+    - 203:AphB
+    - 203:AphC
+  {{ else }}
+  # sunspec model 213 (float) meter
+  power: 213:W
+  currents:
+    - 213:AphA
+    - 213:AphB
+    - 213:AphC
+  {{- end }}
   {{- end }}
   {{- if eq .usage "pv" }}
   type: custom

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -21,6 +21,7 @@ params:
     advanced: true
     valuetype: bool
 render: |
+  # reference: https://github.com/volkszaehler/mbmd/blob/master/meters/sunspec/models.go
   {{- if eq .usage "grid" }}
   type: modbus
   model: sunspec


### PR DESCRIPTION
Template extension to read phase currents from Fronius-Gen24 according sunspec.