### PR TITLE
fix loadpoint effectiveCurrent (#3435)

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -474,7 +474,7 @@ func (lp *LoadPoint) evChargeCurrentHandler(current float64) {
 func (lp *LoadPoint) evChargeCurrentWrappedMeterHandler(current float64) {
 	power := current * float64(lp.activePhases()) * Voltage
 
-	if !lp.enabled || lp.GetStatus() != api.StatusC {
+	if !lp.enabled || lp.GetStatus() != api.StatusC || lp.GetStatus() != api.StatusD {
 		// if disabled we cannot be charging
 		power = 0
 	}
@@ -573,7 +573,7 @@ func (lp *LoadPoint) syncCharger() {
 			err = lp.charger.Enable(lp.enabled)
 		}
 
-		if !enabled && lp.GetStatus() == api.StatusC {
+		if !enabled && (lp.GetStatus() == api.StatusC || lp.GetStatus() == api.StatusD) {
 			lp.log.WARN.Println("charger logic error: disabled but charging")
 		}
 	}
@@ -655,12 +655,12 @@ func (lp *LoadPoint) setLimit(chargeCurrent float64, force bool) error {
 // connected returns the EVs connection state
 func (lp *LoadPoint) connected() bool {
 	status := lp.GetStatus()
-	return status == api.StatusB || status == api.StatusC
+	return status == api.StatusB || status == api.StatusC || status == api.StatusD
 }
 
 // charging returns the EVs charging state
 func (lp *LoadPoint) charging() bool {
-	return lp.GetStatus() == api.StatusC
+	return lp.GetStatus() == api.StatusC || lp.GetStatus() == api.StatusD
 }
 
 // charging returns the EVs charging state
@@ -926,7 +926,7 @@ func (lp *LoadPoint) updateChargerStatus() error {
 		// changed to C - start/stop charging cycle - handle before disconnect to update energy
 		if lp.charging() {
 			lp.bus.Publish(evChargeStart)
-		} else if prevStatus == api.StatusC {
+		} else if prevStatus == api.StatusC || prevStatus == api.StatusD {
 			lp.bus.Publish(evChargeStop)
 		}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -944,7 +944,7 @@ func (lp *LoadPoint) updateChargerStatus() error {
 
 // effectiveCurrent returns the currently effective charging current
 func (lp *LoadPoint) effectiveCurrent() float64 {
-	if lp.GetStatus() != api.StatusC {
+	if lp.GetStatus() != api.StatusC && lp.GetStatus() != api.StatusD {
 		return 0
 	}
 

--- a/core/soc/timer.go
+++ b/core/soc/timer.go
@@ -129,7 +129,7 @@ func (lp *Timer) DemandActive() bool {
 
 	// timer charging is already active- only deactivate once charging has stopped
 	if lp.active {
-		if time.Now().After(lp.Time) && lp.GetStatus() != api.StatusC {
+		if time.Now().After(lp.Time) && lp.GetStatus() != api.StatusC && lp.GetStatus() != api.StatusD {
 			lp.Stop()
 		}
 

--- a/hems/ocpp/ocpp.go
+++ b/hems/ocpp/ocpp.go
@@ -84,7 +84,7 @@ func (s *OCPP) Run() {
 			connector := id + 1
 
 			status := ocppcore.ChargePointStatusAvailable
-			if lp.GetStatus() == api.StatusC {
+			if lp.GetStatus() == api.StatusC || lp.GetStatus() == api.StatusD {
 				status = ocppcore.ChargePointStatusCharging
 			}
 

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -409,12 +409,11 @@ func (s *SEMP) deviceStatus(id int, lp loadpoint.API) DeviceStatus {
 	isPV := mode == api.ModeMinPV || mode == api.ModePV
 
 	deviceStatus := StatusOff
-	if status == api.StatusC {
+	if status == api.StatusC || status == api.StatusD {
 		deviceStatus = StatusOn
 	}
 
-	connected := status == api.StatusB || status == api.StatusC
-
+	connected := status == api.StatusB || status == api.StatusC || status == api.StatusD
 	res := DeviceStatus{
 		DeviceID:          s.deviceID(id),
 		EMSignalsAccepted: s.controllable && isPV && connected,
@@ -438,7 +437,7 @@ func (s *SEMP) allDeviceStatus() (res []DeviceStatus) {
 
 func (s *SEMP) planningRequest(id int, lp loadpoint.API) (res PlanningRequest) {
 	mode := lp.GetMode()
-	charging := lp.GetStatus() == api.StatusC
+	charging := lp.GetStatus() == api.StatusC || lp.GetStatus() == api.StatusD
 	connected := charging || lp.GetStatus() == api.StatusB
 
 	// remaining max demand duration in seconds


### PR DESCRIPTION
https://github.com/evcc-io/evcc/issues/3435

Fehlersituationen:

    StatusD = Laden mit Lüfter gibt immer 0 zurück
    falls ein Charger mit verdrehten Phasen angeschlossen ist (falsch oder rotierend bei mehreren), dann kann ein 3 phasiger Lader auch nur eine Phase benutzen, die nicht Phase 0 ist (zB im Klimatisierungsmodus). Oder ein 3 Phasen Charger hat ein 2Phasen Auto, wo das Ladekabel anders angeschlagen ist.
    Funktion sollte daher den Maximalwert der 3 Phasen liefern, und nicht nur den von Phase 0
