### PR TITLE
SMA EV Charger Fixed Bug return currents negative

### DIFF
--- a/charger/smaevcharger.go
+++ b/charger/smaevcharger.go
@@ -255,7 +255,7 @@ func (wb *Smaevcharger) Currents() (float64, float64, float64, error) {
 			return 0, 0, 0, err
 		}
 
-		curr = append(curr, val)
+		curr = append(curr, val*-1)
 	}
 
 	return curr[0], curr[1], curr[2], nil

--- a/charger/smaevcharger.go
+++ b/charger/smaevcharger.go
@@ -255,7 +255,7 @@ func (wb *Smaevcharger) Currents() (float64, float64, float64, error) {
 			return 0, 0, 0, err
 		}
 
-		curr = append(curr, val*-1)
+		curr = append(curr, -val)
 	}
 
 	return curr[0], curr[1], curr[2], nil


### PR DESCRIPTION
This PR will multiply all currents with * -1 to invert SMA negative charge currents

[Fix for follwoing discussion ](https://github.com/evcc-io/evcc/discussions/3431#discussioncomment-2792041)

Please comment if we should consider using `Abs()` instead of `* -1`