### PR TITLE
Add publishing of auxiliary meters

### DIFF
--- a/server/influxdb.go
+++ b/server/influxdb.go
@@ -107,6 +107,8 @@ func (m *Influx) Run(loadPoints []loadpoint.API, in <-chan util.Param) {
 		if param.LoadPoint != nil {
 			tags["loadpoint"] = loadPoints[*param.LoadPoint].Name()
 			tags["vehicle"] = vehicles[*param.LoadPoint]
+		} else if len(param.Meter) > 0 {
+			tags["meter"] = param.Meter
 		}
 
 		fields := map[string]interface{}{}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -137,6 +137,9 @@ func (m *MQTT) Run(site site.API, in <-chan util.Param) {
 		if p.LoadPoint != nil {
 			id := *p.LoadPoint + 1
 			topic = fmt.Sprintf("%s/loadpoints/%d", m.root, id)
+		} else if len(p.Meter) > 0 {
+			name := p.Meter
+			topic = fmt.Sprintf("%s/meters/%s", m.root, name)
 		}
 
 		// alive indicator

--- a/server/socket.go
+++ b/server/socket.go
@@ -124,6 +124,8 @@ func kv(p util.Param) string {
 	msg.WriteString("\"")
 	if p.LoadPoint != nil {
 		msg.WriteString(fmt.Sprintf("loadpoints.%d.", *p.LoadPoint))
+	} else if len(p.Meter) > 0 {
+		msg.WriteString(fmt.Sprintf("meters.%s.", p.Meter))
 	}
 	msg.WriteString(p.Key)
 	msg.WriteString("\":")

--- a/util/param.go
+++ b/util/param.go
@@ -5,6 +5,7 @@ import "strconv"
 // Param is the broadcast channel data type
 type Param struct {
 	LoadPoint *int
+	Meter     string
 	Key       string
 	Val       interface{}
 }
@@ -14,6 +15,8 @@ func (p Param) UniqueID() string {
 	key := p.Key
 	if p.LoadPoint != nil {
 		key = strconv.Itoa(*p.LoadPoint) + "." + key
+	} else if len(p.Meter) > 0 {
+		key = p.Meter + "." + key
 	}
 	return key
 }


### PR DESCRIPTION
This PR enables publishing of meter data for auxiliary meters (e.g. string data of multiple inverter/mpp configurations).

See this example config:

```
#...
meters:
- type: template
  template: sma-home-manager 
  usage: grid  
#...
  name: grid1
- type: template
  template: sma-inverter 
  usage: pv  
#...
  name: pv1
- type: template
  template: sma-inverter 
  usage: pv  
#...
  name: pv2
- type: modbus
  model: sunspec
  uri: 192.168.0.201:502
  power: 160:1:DCW # SunSpec Model 160 MPP string 1 DCW
  id: 126
  name: pv1mpp1
- type: modbus
  model: sunspec
  uri: 192.168.0.201:502
  power: 160:2:DCW # SunSpec Model 160 MPP string 2 DCW
  id: 126
  name: pv1mpp2
#...

site:
  title: MySite
  meters:
    grid: grid1
    pvs:
    - pv1
    - pv2
    aux:
    - pv1mpp1
    - pv1mpp2
    - pv2mpp1
    - pv2mpp2
```

I would like to upstream this change to not keep my fork for a lifetime :)

Refs https://github.com/evcc-io/evcc/issues/3198