### PR TITLE
Change to now token endpoint for Easee

### DIFF
--- a/charger/easee/identity.go
+++ b/charger/easee/identity.go
@@ -52,7 +52,7 @@ func TokenSource(log *util.Logger, user, password string) (oauth2.TokenSource, e
 		Password: password,
 	}
 
-	uri := fmt.Sprintf("%s/%s", API, "accounts/token")
+	uri := fmt.Sprintf("%s/%s", API, "accounts/login")
 	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
 
 	if err == nil {


### PR DESCRIPTION
the login endpoint will change like mentioned in the mail today from easee

<img width="534" alt="Bildschirmfoto 2022-05-27 um 11 21 09" src="https://user-images.githubusercontent.com/6056918/170670992-05287843-6d83-4f7d-b49f-9b2662024829.png">