### PR TITLE
Modbus meters: remove battery usage

### DIFF
--- a/templates/definition/meter/cg-em24.yaml
+++ b/templates/definition/meter/cg-em24.yaml
@@ -5,7 +5,7 @@ products:
       generic: EM24/ET340
 params:
   - name: usage
-    choice: ["grid", "pv", "battery", "charge"]
+    choice: ["grid", "pv", "charge"]
   - name: modbus
     choice: ["rs485", "tcpip"]
 render: |

--- a/templates/definition/meter/eastron-sdm72_220_230.yaml
+++ b/templates/definition/meter/eastron-sdm72_220_230.yaml
@@ -5,7 +5,7 @@ products:
       generic: SDM 72/220/230
 params:
   - name: usage
-    choice: ["grid", "pv", "battery", "charge"]
+    choice: ["grid", "pv", "charge"]
   - name: modbus
     choice: ["rs485"]
 render: |

--- a/templates/definition/meter/janitza-b23.yaml
+++ b/templates/definition/meter/janitza-b23.yaml
@@ -5,7 +5,7 @@ products:
       generic: B23
 params:
   - name: usage
-    choice: ["grid", "pv", "battery", "charge"]
+    choice: ["grid", "pv", "charge"]
   - name: modbus
     choice: ["rs485", "tcpip"]
 render: |

--- a/templates/definition/meter/siemens-pac2200.yaml
+++ b/templates/definition/meter/siemens-pac2200.yaml
@@ -5,7 +5,7 @@ products:
       generic: PAC 2200
 params:
   - name: usage
-    choice: ["grid", "pv", "battery", "charge"]
+    choice: ["grid", "pv", "charge"]
   - name: modbus
     choice: ["rs485", "tcpip"]
 render: |

--- a/templates/docs/meter/cg-em24_0.yaml
+++ b/templates/docs/meter/cg-em24_0.yaml
@@ -50,30 +50,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-  - usage: battery
-    default: |
-      type: template
-      template: cg-em24
-      usage: battery      
-
-      # RS485 via adapter (Modbus RTU)
-      modbus: rs485serial
-      id: 1
-      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
-      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
-      comset: "8N1" # Kommunikationsparameter für den Adapter
-
-      # RS485 via TCP/IP (Modbus RTU)
-      modbus: rs485tcpip
-      id: 1
-      host: 192.0.2.2 # Hostname
-      port: 502 # Port
-
-      # Modbus TCP
-      modbus: tcpip
-      id: 1
-      host: 192.0.2.2 # Hostname
-      port: 502 # Port
   - usage: charge
     default: |
       type: template

--- a/templates/docs/meter/eastron-sdm72_220_230_0.yaml
+++ b/templates/docs/meter/eastron-sdm72_220_230_0.yaml
@@ -38,24 +38,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-  - usage: battery
-    default: |
-      type: template
-      template: eastron-sdm72_220_230
-      usage: battery      
-
-      # RS485 via adapter (Modbus RTU)
-      modbus: rs485serial
-      id: 1
-      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
-      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
-      comset: "8N1" # Kommunikationsparameter für den Adapter
-
-      # RS485 via TCP/IP (Modbus RTU)
-      modbus: rs485tcpip
-      id: 1
-      host: 192.0.2.2 # Hostname
-      port: 502 # Port
   - usage: charge
     default: |
       type: template

--- a/templates/docs/meter/janitza-b23_0.yaml
+++ b/templates/docs/meter/janitza-b23_0.yaml
@@ -50,30 +50,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-  - usage: battery
-    default: |
-      type: template
-      template: janitza-b23
-      usage: battery      
-
-      # RS485 via adapter (Modbus RTU)
-      modbus: rs485serial
-      id: 1
-      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
-      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
-      comset: "8N1" # Kommunikationsparameter für den Adapter
-
-      # RS485 via TCP/IP (Modbus RTU)
-      modbus: rs485tcpip
-      id: 1
-      host: 192.0.2.2 # Hostname
-      port: 502 # Port
-
-      # Modbus TCP
-      modbus: tcpip
-      id: 1
-      host: 192.0.2.2 # Hostname
-      port: 502 # Port
   - usage: charge
     default: |
       type: template

--- a/templates/docs/meter/siemens-pac2200_0.yaml
+++ b/templates/docs/meter/siemens-pac2200_0.yaml
@@ -50,30 +50,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-  - usage: battery
-    default: |
-      type: template
-      template: siemens-pac2200
-      usage: battery      
-
-      # RS485 via adapter (Modbus RTU)
-      modbus: rs485serial
-      id: 1
-      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
-      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
-      comset: "8N1" # Kommunikationsparameter für den Adapter
-
-      # RS485 via TCP/IP (Modbus RTU)
-      modbus: rs485tcpip
-      id: 1
-      host: 192.0.2.2 # Hostname
-      port: 502 # Port
-
-      # Modbus TCP
-      modbus: tcpip
-      id: 1
-      host: 192.0.2.2 # Hostname
-      port: 502 # Port
   - usage: charge
     default: |
       type: template


### PR DESCRIPTION
@premultiply die Logik wäre, dass bei Batterie eigentlich immer ein intelligenter WR mit Meßequipment im Spiel ist, aber niemals ein Standardzähler dazwischen gedübelt wird.