### PR TITLE
E3DC: template brand

### DIFF
--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -1,7 +1,6 @@
 template: e3dc
 products:
-  - description:
-      generic: E3DC
+  - brand: E3DC
 guidedsetup:
   enable: true
 params:

--- a/templates/docs/meter/e3dc_0.yaml
+++ b/templates/docs/meter/e3dc_0.yaml
@@ -1,5 +1,5 @@
 product:
-  description: E3DC
+  brand: E3DC
 render:
   - usage: grid
     default: |

--- a/templates/evcc.io/brands.json
+++ b/templates/evcc.io/brands.json
@@ -50,6 +50,7 @@
   "Carlo Gavazzi",
   "cFos",
   "DSMR",
+  "E3DC",
   "Eastron",
   "FENECON",
   "Fronius",
@@ -78,6 +79,7 @@
  "PVBattery": [
   "AVM",
   "Carlo Gavazzi",
+  "E3DC",
   "Eastron",
   "FENECON",
   "Fronius",


### PR DESCRIPTION
- now E3DC should also appear as a supported brand on our website