### PR TITLE
Range values not gathered from the API

### DIFF
--- a/vehicle/mercedes/api.go
+++ b/vehicle/mercedes/api.go
@@ -48,6 +48,9 @@ func (v *API) SoC(vin string) (EVResponse, error) {
 
 	uri := fmt.Sprintf("%s/vehicles/%s/resources/soc", v.BaseURI(), vin)
 	err := v.GetJSON(uri, &res)
+	if err != nil {
+		res, err = v.allinOne(vin)
+	}
 
 	return res, err
 }
@@ -58,6 +61,33 @@ func (v *API) Range(vin string) (EVResponse, error) {
 
 	uri := fmt.Sprintf("%s/vehicles/%s/resources/rangeelectric", v.BaseURI(), vin)
 	err := v.GetJSON(uri, &res)
+	if err != nil {
+		res, err = v.allinOne(vin)
+	}
 
 	return res, err
+}
+
+// allinOne is a 'fallback' to gether both metrics range and soc.
+// It is used in case for any reason the single endpoints return an error - which happend in the past.
+func (v *API) allinOne(vin string) (EVResponse, error) {
+	var res []EVResponse
+
+	uri := fmt.Sprintf("%s/vehicles/%s/containers/electricvehicle", v.BaseURI(), vin)
+	err := v.GetJSON(uri, &res)
+
+	evres := EVResponse{}
+
+	for _, r := range res {
+		if r.SoC.Timestamp != 0 {
+			evres.SoC = r.SoC
+			continue
+		}
+
+		if r.RangeElectric.Timestamp != 0 {
+			evres.RangeElectric = r.RangeElectric
+		}
+	}
+
+	return evres, err
 }

--- a/vehicle/mercedes/api.go
+++ b/vehicle/mercedes/api.go
@@ -68,7 +68,7 @@ func (v *API) Range(vin string) (EVResponse, error) {
 	return res, err
 }
 
-// allinOne is a 'fallback' to gether both metrics range and soc.
+// allinOne is a 'fallback' to gather both metrics range and soc.
 // It is used in case for any reason the single endpoints return an error - which happend in the past.
 func (v *API) allinOne(vin string) (EVResponse, error) {
 	var res []EVResponse

--- a/vehicle/mercedes/provider.go
+++ b/vehicle/mercedes/provider.go
@@ -37,7 +37,7 @@ func (v *Provider) SoC() (float64, error) {
 
 // Range implements the api.VehicleRange interface
 func (v *Provider) Range() (rng int64, err error) {
-	res, err := v.chargerG()
+	res, err := v.rangeG()
 	if err == nil {
 		return int64(res.RangeElectric.Value), nil
 	}


### PR DESCRIPTION
This PR fixes the mercedes implementation to use the right cache provider. chargeG -> rangeG
Also it introduces the possibility in case of an error on the /soc or the /rangeelectic endpoint try to use the all-in one endpoint to fetch the necessary data. In the last weeks it happens to me that the /soc responded with an 401 (unauthorized) for what ever reason but the same token worked on the other endpoints.