### PR TITLE
WIP: OCPP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Evcc is an extensible EV Charge Controller with PV integration implemented in [G
 - wide range of supported [chargers](https://docs.evcc.io/docs/devices/chargers):
   - ABL eMH1, Alfen (Eve), Bender (CC612/613), cFos (PowerBrain), Daheimladen, Ebee (Wallbox), Ensto (Chago Wallbox), [EVSEWifi/ smartWB](https://www.evse-wifi.de), Garo (GLB, GLB+, LS4), go-eCharger, HardyBarth (eCB1, cPH1, cPH2), Heidelberg (Energy Control), Innogy (eBox), Juice (Charger Me), KEBA/BMW, Menneckes (Amedio, Amtron Premium/Xtra, Amtron ChargeConrol), NRGkick, [openWB (includes Pro)](https://openwb.de/), Optec (Mobility One), PC Electric (includes Garo), TechniSat (Technivolt), Ubitricity (Heinz), Vestel, Wallbe, Webasto (Live), Mobile Charger Connect
   - experimental EEBus support (PMCC)
+  - experimental OCPP support
   - Build-your-own: Phoenix (includes ESL Walli), [EVSE DIN](https://www.evse-wifi.de/produkt-schlagwort/simple-evse-wb/)
   - Smart-Home outlets: FritzDECT, Shelly, Tasmota, TP-Link
 - wide range of supported [meters](https://docs.evcc.io/docs/devices/meters) for grid, pv, battery and charger:

--- a/templates/README.md
+++ b/templates/README.md
@@ -6,7 +6,7 @@
   - charger: all charger templates
   - meter: all meter templates
   - vehicle: all vehicle templates
-- docs: content is generated via `go generate ./..` using the above templates for the evcc documentation page to be used
+- docs: content is generated via `go generate ./...` using the above templates for the evcc documentation page to be used
 
 ## Template Documentation
 

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -4,34 +4,51 @@ products:
       de: OCPP v1.6 kompatible Wallbox
       en: OCPP v1.6 compatible Wallbox
 group: generic
-capabilities: []
+requirements:
+  description:
+    de: |
+      Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
+
+      // TODO
+
+    en: |
+      To connnect the wallbox with EVCC `ws://{evcc.ip}:8887/` as to be provided as a backend address.
+
+      // TODO
+
 params:
   - name: stationid
     required: true
     help:
-      en: The station ID of the wallbox
-      de: Die Stations ID der Wallbox
+      en: The chargepoint ID to uniquly identifiy the station (should work with a random string)
+      de: Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger string sollte funktioniern)
   - name: connector
     default: 1
     valuetype: int
     help:
-      en: The number of supported charge points
-      de: Die Anzahl der unterstützen Ladepunkte
+      en: Used chargepoint, usualy 1 for one connector.
+      de: Verwendeter Verbindungspunkt, normalerweise 1 bei einem Anschluss.
   - name: meterSupported
     default: false
     valuetype: bool
     help:
-      en: Use the wallboxes build in energie meter
-      de: Wenn der in der Wallbox verbaute Energiezähler genutzt werden soll
+      en: Use of the integrated meter (if present)
+      de: Verwendung des integrierten Zählers (falls vorhanden)
   - name: idtag
-    required: true
     valuetype: string
     help:
-      en: ID of the token used for transactions
-      de: ID des Tokens, welcher für Ladevorgänge genutzt werden soll
+      en: RFID token used for transactions (currently no authorization implemented)
+      de: ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt)
 render: |
   type: ocpp
   stationid: {{ .stationid }}
-  idtag: {{ .idtag }}
+  {{ if ne .idtag }}idtag: {{ .idtag }}{{ end }}
   connector: {{ .connector }}
   meterSupported: {{ .meterSupported }}
+  
+# TODO: switch to this config when implementation supports authorization
+# {{ if ne .rfid "" }}    
+# rfid:
+#   tag: {{ .rfid }}
+# {{ end }}
+

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -1,0 +1,37 @@
+template: ocpp
+products:
+  - description:
+      de: OCPP v1.6 kompatible Wallbox
+      en: OCPP v1.6 compatible Wallbox
+group: generic
+capabilities: []
+params:
+  - name: stationid
+    required: true
+    help:
+      en: The station ID of the wallbox
+      de: Die Stations ID der Wallbox
+  - name: connector
+    default: 1
+    valuetype: int
+    help:
+      en: The number of supported charge points
+      de: Die Anzahl der unterstützen Ladepunkte
+  - name: meterSupported
+    default: false
+    valuetype: bool
+    help:
+      en: Use the wallboxes build in energie meter
+      de: Wenn der in der Wallbox verbaute Energiezähler genutzt werden soll
+  - name: idtag
+    required: true
+    valuetype: string
+    help:
+      en: ID of the token used for transactions
+      de: ID des Tokens, welcher für Ladevorgänge genutzt werden soll
+render: |
+  type: ocpp
+  stationid: {{ .stationid }}
+  idtag: {{ .idtag }}
+  connector: {{ .connector }}
+  meterSupported: {{ .meterSupported }}

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -7,11 +7,17 @@ group: generic
 requirements:
   description:
     de: |
+      Vorraussetzungen vor der Verbindung mit EVCC:
+      * löschen von zu vor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
+      
       Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
 
       // TODO
 
     en: |
+      Requirements befor connecting to EVCC:
+      * delete prior configured load profiles (e.g. from another backend)
+      
       To connnect the wallbox with EVCC `ws://{evcc.ip}:8887/` as to be provided as a backend address.
 
       // TODO
@@ -20,8 +26,8 @@ params:
   - name: stationid
     required: true
     help:
-      en: The chargepoint ID to uniquly identifiy the station (should work with a random string)
-      de: Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger string sollte funktioniern)
+      en: The chargepoint ID to uniquly identifiy the station (a random value) e.g. EVB-P12354
+      de: Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger Wert) e.g. EVB-P12354
   - name: connector
     default: 1
     valuetype: int
@@ -37,15 +43,15 @@ params:
   - name: idtag
     valuetype: string
     help:
-      en: RFID token used for transactions (currently no authorization implemented)
-      de: ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt)
+      en: RFID token used for transactions (currently no authorization implemented) e.g. 04E6B78921BBA0
+      de: ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt) e.g 04E6B78921BBA0
 render: |
   type: ocpp
   stationid: {{ .stationid }}
   {{ if ne .idtag }}idtag: {{ .idtag }}{{ end }}
   connector: {{ .connector }}
   meterSupported: {{ .meterSupported }}
-  
+
 # TODO: switch to this config when implementation supports authorization
 # {{ if ne .rfid "" }}    
 # rfid:

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -8,8 +8,8 @@ requirements:
   description:
     de: |
       Vorraussetzungen vor der Verbindung mit EVCC:
-      * löschen von zu vor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
-      
+      * löschen von zuvor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
+
       Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
 
       // TODO
@@ -48,7 +48,7 @@ params:
 render: |
   type: ocpp
   stationid: {{ .stationid }}
-  {{ if ne .idtag }}idtag: {{ .idtag }}{{ end }}
+  {{ if ne .idtag "" }}idtag: {{ .idtag }}{{ end }}
   connector: {{ .connector }}
   meterSupported: {{ .meterSupported }}
 

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -1,13 +1,13 @@
 template: ocpp
 products:
   - description:
-      de: OCPP v1.6 kompatible Wallbox
-      en: OCPP v1.6 compatible Wallbox
+      de: OCPP v1.6 kompatible Wallbox mit Smart Charging Profile
+      en: OCPP v1.6 compatible charger with smart charging profile
 group: generic
 requirements:
   description:
     de: |
-      Vorraussetzungen:
+      Voraussetzungen:
       * Löschen zuvor konfigurierter Ladeprofile (z.B. durch ein anderes Backend)
       * Konfiguration des Backends der Wallbox: `ws://evcc.local:8887/`
     en: |

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -7,34 +7,28 @@ group: generic
 requirements:
   description:
     de: |
-      Vorraussetzungen vor der Verbindung mit EVCC:
-      * löschen von zuvor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
-
-      Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
-
-      // TODO
-
+      Vorraussetzungen:
+      * Löschen zuvor konfigurierter Ladeprofile (z.B. durch ein anderes Backend)
+      * Konfiguration des Backends der Wallbox: `ws://evcc.local:8887/`
     en: |
-      Requirements befor connecting to EVCC:
-      * delete prior configured load profiles (e.g. from another backend)
-      
-      To connnect the wallbox with EVCC `ws://{evcc.ip}:8887/` as to be provided as a backend address.
-
-      // TODO
-
+      Requirements:
+      * Deletion prior configured load profiles (e.g. from another backend)
+      * Backend configuration of the charger: `ws://evcc.local:8887/`
 params:
   - name: stationid
     required: true
     help:
-      en: The chargepoint ID to uniquly identifiy the station (a random value) e.g. EVB-P12354
-      de: Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger Wert) e.g. EVB-P12354
+      en: The charger's unique station id
+      de: Die Stations-ID der Wallbox
+    example: EVB-P12354
   - name: connector
     default: 1
     valuetype: int
+    advanced: true
     help:
-      en: Used chargepoint, usualy 1 for one connector.
-      de: Verwendeter Verbindungspunkt, normalerweise 1 bei einem Anschluss.
-  - name: meterSupported
+      en: Connector number, usually 1 for first connector.
+      de: Verwendeter Ladepunkt, normalerweise 1 für den ersten Anschluss.
+  - name: meter
     default: false
     valuetype: bool
     help:
@@ -42,19 +36,20 @@ params:
       de: Verwendung des integrierten Zählers (falls vorhanden)
   - name: idtag
     valuetype: string
+    advanced: true
     help:
-      en: RFID token used for transactions (currently no authorization implemented) e.g. 04E6B78921BBA0
-      de: ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt) e.g 04E6B78921BBA0
+      en: RFID token used for transactions (currently no authorization implemented)
+      de: ID des Tokens, welcher für Ladevorgänge genutzt werden soll, (aktuell nicht für Autorisierung verwendet) e.g
+    example: 04E6B78921BBA0
 render: |
   type: ocpp
   stationid: {{ .stationid }}
-  {{ if ne .idtag "" }}idtag: {{ .idtag }}{{ end }}
+  {{- if ne .connector "1 "}}
   connector: {{ .connector }}
-  meterSupported: {{ .meterSupported }}
-
-# TODO: switch to this config when implementation supports authorization
-# {{ if ne .rfid "" }}    
-# rfid:
-#   tag: {{ .rfid }}
-# {{ end }}
-
+  {{- end }}
+  {{- if ne .idtag "" }}
+  idtag: {{ .idtag }}
+  {{- end }}
+  {{- if ne .meter "false" }}
+  meter: {{ .meter }}
+  {{- end }}

--- a/templates/docs/charger/ocpp_0.yaml
+++ b/templates/docs/charger/ocpp_0.yaml
@@ -1,8 +1,8 @@
 product:
-  description: OCPP v1.6 kompatible Wallbox
+  description: OCPP v1.6 kompatible Wallbox mit Smart Charging Profile
   group: Generische Unterstützung
 description: |
-  Vorraussetzungen:
+  Voraussetzungen:
   * Löschen zuvor konfigurierter Ladeprofile (z.B. durch ein anderes Backend)
   * Konfiguration des Backends der Wallbox: `ws://evcc.local:8887/`
 

--- a/templates/docs/charger/ocpp_0.yaml
+++ b/templates/docs/charger/ocpp_0.yaml
@@ -1,0 +1,11 @@
+product:
+  description: OCPP v1.6 kompatible Wallbox
+  group: Generische Unterstützung
+render:
+  - default: |
+      type: template
+      template: ocpp
+      stationid: # Die Stations ID der Wallbox
+      connector: 1 # Die Anzahl der unterstützen Ladepunkte # Optional
+      meterSupported: false # Wenn der in der Wallbox verbaute Energiezähler genutzt werden soll # Optional
+      idtag: # ID des Tokens, welcher für Ladevorgänge genutzt werden soll

--- a/templates/docs/charger/ocpp_0.yaml
+++ b/templates/docs/charger/ocpp_0.yaml
@@ -2,18 +2,20 @@ product:
   description: OCPP v1.6 kompatible Wallbox
   group: Generische Unterstützung
 description: |
-  Vorraussetzungen vor der Verbindung mit EVCC:
-  * löschen von zuvor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
-
-  Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
-
-  // TODO
+  Vorraussetzungen:
+  * Löschen zuvor konfigurierter Ladeprofile (z.B. durch ein anderes Backend)
+  * Konfiguration des Backends der Wallbox: `ws://evcc.local:8887/`
 
 render:
   - default: |
       type: template
       template: ocpp
-      stationid: # Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger Wert) e.g. EVB-P12354
-      connector: 1 # Verwendeter Verbindungspunkt, normalerweise 1 bei einem Anschluss. # Optional
-      meterSupported: false # Verwendung des integrierten Zählers (falls vorhanden) # Optional
-      idtag: # ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt) e.g 04E6B78921BBA0 # Optional
+      stationid: EVB-P12354 # Die Stations-ID der Wallbox
+      meter: false # Verwendung des integrierten Zählers (falls vorhanden) # Optional
+    advanced: |
+      type: template
+      template: ocpp
+      stationid: EVB-P12354 # Die Stations-ID der Wallbox
+      connector: 1 # Verwendeter Ladepunkt, normalerweise 1 für den ersten Anschluss. # Optional
+      meter: false # Verwendung des integrierten Zählers (falls vorhanden) # Optional
+      idtag: 04E6B78921BBA0 # ID des Tokens, welcher für Ladevorgänge genutzt werden soll, (aktuell nicht für Autorisierung verwendet) e.g # Optional

--- a/templates/docs/charger/ocpp_0.yaml
+++ b/templates/docs/charger/ocpp_0.yaml
@@ -3,7 +3,7 @@ product:
   group: Generische Unterstützung
 description: |
   Vorraussetzungen vor der Verbindung mit EVCC:
-  * löschen von zu vor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
+  * löschen von zuvor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
 
   Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
 

--- a/templates/docs/charger/ocpp_0.yaml
+++ b/templates/docs/charger/ocpp_0.yaml
@@ -2,6 +2,9 @@ product:
   description: OCPP v1.6 kompatible Wallbox
   group: Generische Unterstützung
 description: |
+  Vorraussetzungen vor der Verbindung mit EVCC:
+  * löschen von zu vor konfigurierte Ladeprofile (z.B. durch ein anderes Backend)
+
   Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
 
   // TODO
@@ -10,7 +13,7 @@ render:
   - default: |
       type: template
       template: ocpp
-      stationid: # Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger string sollte funktioniern)
+      stationid: # Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger Wert) e.g. EVB-P12354
       connector: 1 # Verwendeter Verbindungspunkt, normalerweise 1 bei einem Anschluss. # Optional
       meterSupported: false # Verwendung des integrierten Zählers (falls vorhanden) # Optional
-      idtag: # ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt) # Optional
+      idtag: # ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt) e.g 04E6B78921BBA0 # Optional

--- a/templates/docs/charger/ocpp_0.yaml
+++ b/templates/docs/charger/ocpp_0.yaml
@@ -1,11 +1,16 @@
 product:
   description: OCPP v1.6 kompatible Wallbox
   group: Generische Unterstützung
+description: |
+  Zur Verbindung mit EVCC muss in der Wallbox `ws://{evcc.ip}:8887/` als Backend eingetragen werden. 
+
+  // TODO
+
 render:
   - default: |
       type: template
       template: ocpp
-      stationid: # Die Stations ID der Wallbox
-      connector: 1 # Die Anzahl der unterstützen Ladepunkte # Optional
-      meterSupported: false # Wenn der in der Wallbox verbaute Energiezähler genutzt werden soll # Optional
-      idtag: # ID des Tokens, welcher für Ladevorgänge genutzt werden soll
+      stationid: # Die Ladepunkt ID für die eindeutige identifizierung der Wallbox (ein belibiger string sollte funktioniern)
+      connector: 1 # Verwendeter Verbindungspunkt, normalerweise 1 bei einem Anschluss. # Optional
+      meterSupported: false # Verwendung des integrierten Zählers (falls vorhanden) # Optional
+      idtag: # ID des Tokens, welcher für Ladevorgänge genutzt werden soll (aktuell keine Authorizierung umgesetzt) # Optional


### PR DESCRIPTION
Documentation for OCPP compatible chargers.

Breaking change: renamed `metersupported` to `meter`.