### PR TITLE
Allow fixed phase configuration

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -977,9 +977,11 @@ func (lp *LoadPoint) resetPVTimerIfRunning(typ ...string) {
 
 // scalePhasesIfAvailable scales if api.ChargePhases is available
 func (lp *LoadPoint) scalePhasesIfAvailable(phases int) error {
-	mustNotChange := lp.DefaultPhases != 0 && lp.GetPhases() == lp.DefaultPhases
+	if lp.DefaultPhases != 0 {
+		phases = lp.DefaultPhases
+	}
 
-	if _, ok := lp.charger.(api.ChargePhases); ok && !mustNotChange {
+	if _, ok := lp.charger.(api.ChargePhases); ok {
 		return lp.scalePhases(phases)
 	}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1076,7 +1076,7 @@ func (lp *LoadPoint) pvScalePhases(availablePower, minCurrent, maxCurrent float6
 	scalable := maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent
 
 	// scale up phases
-	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable && lp.DefaultPhases != 1 {
+	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {
 		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, 3*Voltage*minCurrent, maxPhases)
 
 		if lp.phaseTimer.IsZero() {

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -102,16 +102,21 @@ func (lp *LoadPoint) SetMinSoC(soc int) {
 func (lp *LoadPoint) GetPhases() int {
 	lp.Lock()
 	defer lp.Unlock()
-	return lp.Phases
+	return lp.phases
 }
 
 // SetPhases sets loadpoint enabled phases
 func (lp *LoadPoint) SetPhases(phases int) error {
-	if phases != 1 && phases != 3 {
+	// limit auto mode (phases=0) to scalable charger
+	if _, ok := lp.charger.(api.ChargePhases); !ok && phases == 0 {
 		return fmt.Errorf("invalid number of phases: %d", phases)
 	}
 
-	if _, ok := lp.charger.(api.ChargePhases); ok {
+	if phases != 0 && phases != 1 && phases != 3 {
+		return fmt.Errorf("invalid number of phases: %d", phases)
+	}
+
+	if _, ok := lp.charger.(api.ChargePhases); ok && phases > 0 {
 		return lp.scalePhases(phases)
 	}
 

--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -63,9 +63,12 @@ func (lp *LoadPoint) maxActivePhases() int {
 		measured = 0
 	}
 
-	// if 1p3p supported then assume 3p
+	// if 1p3p supported then assume configured limit or 3p
 	if _, ok := lp.charger.(api.ChargePhases); ok {
-		physical = 3
+		physical = lp.DefaultPhases
+		if physical == 0 {
+			physical = 3
+		}
 	}
 
 	return min(expect(vehicle), expect(physical), expect(measured))

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -130,7 +130,7 @@ func TestPvScalePhases(t *testing.T) {
 			MinCurrent:  minA,
 			MaxCurrent:  maxA,
 			vehicle:     vehicle,
-			Phases:      tc.physical,
+			phases:      tc.physical,
 		}
 
 		if phaseCharger != nil {
@@ -155,8 +155,8 @@ func TestPvScalePhases(t *testing.T) {
 			t.Fatalf("%v invalid test case", tc)
 		}
 
-		if lp.Phases != tc.physical {
-			t.Error("wrong phases", lp.Phases, tc.physical)
+		if lp.phases != tc.physical {
+			t.Error("wrong phases", lp.phases, tc.physical)
 		}
 
 		if phs := lp.activePhases(); phs != tc.actExpected {
@@ -184,7 +184,7 @@ func TestPvScalePhases(t *testing.T) {
 			lp.phaseTimer = time.Time{}
 
 			// reset to initial state
-			lp.Phases = tc.physical
+			lp.phases = tc.physical
 			lp.measuredPhases = tc.measuredPhases
 
 			plainCharger.EXPECT().Enable(false).Return(nil).MaxTimes(1)
@@ -289,7 +289,7 @@ func TestPvScalePhasesTimer(t *testing.T) {
 			charger:        charger,
 			MinCurrent:     minA,
 			MaxCurrent:     maxA,
-			Phases:         tc.phases,
+			phases:         tc.phases,
 			measuredPhases: tc.measuredPhases,
 			Enable: ThresholdConfig{
 				Delay: dt,
@@ -312,8 +312,8 @@ func TestPvScalePhasesTimer(t *testing.T) {
 		switch {
 		case tc.res != res:
 			t.Errorf("expected %v, got %v", tc.res, res)
-		case lp.Phases != tc.toPhases:
-			t.Errorf("expected %dp, got %dp", tc.toPhases, lp.Phases)
+		case lp.phases != tc.toPhases:
+			t.Errorf("expected %dp, got %dp", tc.toPhases, lp.phases)
 		}
 	}
 }

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -71,8 +71,8 @@ func attachListeners(t *testing.T, lp *LoadPoint) {
 func TestNew(t *testing.T) {
 	lp := NewLoadPoint(util.NewLogger("foo"))
 
-	if lp.Phases != 3 {
-		t.Errorf("Phases %v", lp.Phases)
+	if lp.phases != 3 {
+		t.Errorf("Phases %v", lp.phases)
 	}
 	if lp.MinCurrent != minA {
 		t.Errorf("MinCurrent %v", lp.MinCurrent)
@@ -154,7 +154,7 @@ func TestUpdatePowerZero(t *testing.T) {
 			wakeUpTimer: NewTimer(),
 			MinCurrent:  minA,
 			MaxCurrent:  maxA,
-			Phases:      1,
+			phases:      1,
 			status:      tc.status, // no status change
 		}
 
@@ -302,7 +302,7 @@ func TestPVHysteresis(t *testing.T) {
 				charger:        charger,
 				MinCurrent:     minA,
 				MaxCurrent:     maxA,
-				Phases:         phases,
+				phases:         phases,
 				measuredPhases: phases,
 				Enable: ThresholdConfig{
 					Threshold: tc.enable,
@@ -350,7 +350,7 @@ func TestPVHysteresisForStatusOtherThanC(t *testing.T) {
 		clock:          clck,
 		MinCurrent:     minA,
 		MaxCurrent:     maxA,
-		Phases:         phases,
+		phases:         phases,
 		measuredPhases: phases,
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/3482

This PR allows configuring fixed phases for switchable chargers. Using

    phases: 1/3

will fix the charger's phases. Phase switching is disabled in this mode. evcc will try to establish this setting once in case it has been modified externally. 

    phases: 0 # or omitted

will put a switchable charger in "auto" which is today's default. The `/api/phases` allows to specify all three values now:

    phases: 0/1/3

where `0` will release the lock and switch back to `auto` mode. If `1/3` are specified, phases are immediately switched and lock established.

**Note:** The phase lock is also maintained for any "fast" charging modes, i.e. "Now" will stick to 1p if fixed by config or api.

Todo:

- [x] check configure (Phasen werden aktuell nicht abgefragt)
- [x] add more tests