### PR TITLE
Fix negative PvPower Calcualtion if not Meter is installed.

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -353,6 +353,9 @@ func (site *Site) sitePower(totalChargePower float64) (float64, error) {
 	// allow using Grid and charge as estimate for pv power
 	if site.pvMeters == nil {
 		site.pvPower = totalChargePower - site.gridPower + site.ResidualPower
+		if site.pvPower < 0 {
+			site.pvPower = 0
+		}
 		site.log.DEBUG.Printf("pv power: %.0fW", site.pvPower)
 		site.publish("pvPower", site.pvPower)
 	}


### PR DESCRIPTION
Since https://github.com/evcc-io/evcc/pull/3705 the calculated PvPower can get negative. Here is the fix.