### PR TITLE
Enable tasmota SML grid meter

### DIFF
--- a/meter/tasmota.go
+++ b/meter/tasmota.go
@@ -7,6 +7,12 @@ import (
 )
 
 // Tasmota meter implementation
+type Tasmota struct {
+	conn  *tasmota.Connection
+	usage string
+}
+
+// Tasmota meter implementation
 func init() {
 	registry.Add("tasmota", NewTasmotaFromConfig)
 }
@@ -17,11 +23,47 @@ func NewTasmotaFromConfig(other map[string]interface{}) (api.Meter, error) {
 		URI      string
 		User     string
 		Password string
+		Usage    string
 	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return tasmota.NewConnection(cc.URI, cc.User, cc.Password)
+	return NewTasmota(cc.URI, cc.User, cc.Password, cc.Usage)
+}
+
+// NewTasmota creates Tasmota meter
+func NewTasmota(uri, user, password, usage string) (*Tasmota, error) {
+	conn, err := tasmota.NewConnection(uri, user, password)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Tasmota{
+		conn:  conn,
+		usage: usage,
+	}
+
+	return c, err
+}
+
+var _ api.Meter = (*Tasmota)(nil)
+
+// CurrentPower implements the api.Meter interface
+func (c *Tasmota) CurrentPower() (float64, error) {
+	if c.usage == "grid" {
+		return c.conn.GridCurrentPower()
+	}
+	return c.conn.CurrentPower()
+}
+
+var _ api.MeterEnergy = (*Tasmota)(nil)
+
+// TotalEnergy implements the api.MeterEnergy interface
+func (c *Tasmota) TotalEnergy() (float64, error) {
+	if c.usage == "grid" {
+		return c.conn.GridTotalEnergy()
+	}
+	return c.conn.TotalEnergy()
 }

--- a/meter/tasmota/connection.go
+++ b/meter/tasmota/connection.go
@@ -73,3 +73,25 @@ func (d *Connection) TotalEnergy() (float64, error) {
 
 	return float64(res.StatusSNS.Energy.Total), nil
 }
+
+// GridCurrentPower provides current power consumption
+func (d *Connection) GridCurrentPower() (float64, error) {
+	var res *StatusSNSResponse
+	err := d.ExecCmd("Status 8", &res)
+	if err != nil {
+		return 0, err
+	}
+
+	return float64(res.StatusSNS.SML.Power_curr), nil
+}
+
+// GridTotalEnergy implements the api.MeterEnergy interface
+func (d *Connection) GridTotalEnergy() (float64, error) {
+	var res *StatusSNSResponse
+	err := d.ExecCmd("Status 8", &res)
+	if err != nil {
+		return 0, err
+	}
+
+	return float64(res.StatusSNS.SML.Total_in), nil
+}

--- a/meter/tasmota/types.go
+++ b/meter/tasmota/types.go
@@ -73,5 +73,10 @@ type StatusSNSResponse struct {
 			Voltage        int
 			Current        float64
 		}
+		SML struct {
+			Total_in   float64
+			Total_out  float64
+			Power_curr int
+		}
 	}
 }

--- a/templates/definition/meter/tasmota.yaml
+++ b/templates/definition/meter/tasmota.yaml
@@ -19,5 +19,6 @@ params:
 render: |
   type: tasmota
   uri: http://{{ .host }}
+  usage: {{ .usage }}
   user: {{ .user }}
   password: {{ .password }}


### PR DESCRIPTION
Refer to #3636

Important: Tasmota meter template configs have to define new `usage` parameter (grid,pv,charger)!

Example grid meter config:
```yaml
- type: template
  template: tasmota 
  usage: grid  
  host: 192.168.xxx.xxx  
  name: grid1
```