### PR TITLE
Update daheimladen.yaml

### DIFF
--- a/templates/definition/charger/daheimladen.yaml
+++ b/templates/definition/charger/daheimladen.yaml
@@ -3,6 +3,10 @@ products:
   - brand: DaheimLaden
     description:
       generic: Wallbox
+requirements:
+  description:
+    de: Für die Nutzung mit evcc muss die Wallbox im RFID Modus betrieben werden.
+    en: For use with evcc, the wallbox must be operated in RFID mode.
 params:
   - name: token
     help:

--- a/templates/docs/charger/daheimladen_0.yaml
+++ b/templates/docs/charger/daheimladen_0.yaml
@@ -1,6 +1,8 @@
 product:
   brand: DaheimLaden
   description: Wallbox
+description: |
+  Für die Nutzung mit evcc muss die Wallbox im RFID Modus betrieben werden.
 render:
   - default: |
       type: template


### PR DESCRIPTION
Notwendigkeit RFID Modus zur Nutzung mit evcc. Wenn man von DaheimLaden keinen HInweis bekommt, kann man das nicht wissen.