### PR TITLE
OpenWB: expose 1p3p config

### DIFF
--- a/templates/definition/charger/openwb.yaml
+++ b/templates/definition/charger/openwb.yaml
@@ -11,8 +11,21 @@ requirements:
 params:
   - name: host
   - name: loadpointid
+    description:
+      en: OpenWB Loadpoint Id
+      de: OpenWB Ladepunkt Id
     default: 1
+  - name: phases1p3p
+    valuetype: bool
+    description:
+      en: Charger is equipped with phase switching feature
+      de: Phasenumschaltung ist verbaut
+    advanced: true
+    default: false
 render: |
   type: openwb
   broker: {{ .host }}
   id: {{ .loadpointid }} # loadpoint id
+  {{- if ne .phases1p3p "false" }}
+  phases: true
+  {{- end }}

--- a/templates/definition/charger/openwb.yaml
+++ b/templates/definition/charger/openwb.yaml
@@ -15,7 +15,7 @@ params:
     valuetype: bool
     description:
       en: Charger is equipped with phase switching feature
-      de: Phasenumschaltung ist verbaut
+      de: Phasenumschaltung vorhanden
     advanced: true
     default: false
 render: |

--- a/templates/definition/charger/openwb.yaml
+++ b/templates/definition/charger/openwb.yaml
@@ -10,10 +10,11 @@ requirements:
   uri: https://docs.evcc.io/docs/devices/chargers#openwb
 params:
   - name: host
-  - name: loadpointid
+  - name: connector
     description:
       en: OpenWB Loadpoint Id
       de: OpenWB Ladepunkt Id
+    advanced: true
     default: 1
   - name: phases1p3p
     valuetype: bool
@@ -25,7 +26,12 @@ params:
 render: |
   type: openwb
   broker: {{ .host }}
+  {{- if ne .connector "1" }}
+  id: {{ .connector }} # loadpoint id
+  {{- end }}
+  {{- if ne .loadpointid "1" }}
   id: {{ .loadpointid }} # loadpoint id
+  {{- end }}
   {{- if ne .phases1p3p "false" }}
   phases: true
   {{- end }}

--- a/templates/definition/charger/openwb.yaml
+++ b/templates/definition/charger/openwb.yaml
@@ -11,11 +11,6 @@ requirements:
 params:
   - name: host
   - name: connector
-    description:
-      en: OpenWB Loadpoint Id
-      de: OpenWB Ladepunkt Id
-    advanced: true
-    default: 1
   - name: phases1p3p
     valuetype: bool
     description:

--- a/templates/definition/defaults.yaml
+++ b/templates/definition/defaults.yaml
@@ -77,7 +77,7 @@ params:
     mask: true
   - name: capacity
     description:
-      de: Akku-Kapazität in kWh
+      de: Akkukapazität in kWh
       en: Battery capacity in kWh
     help:
       de: Akku-Kapazität in kWh
@@ -101,13 +101,20 @@ params:
       en: The maximum number of phases which can be used
     example: 3
     valuetype: number
+  - name: connector
+    description:
+      de: Ladepunkt (falls >1 Ladepunkt)
+      en: Loadpoint (if >1 loadpoint)
+    advanced: true
+    default: 1
   - name: cache
     description:
       de: Cache
       en: Cache
     help:
-      de: Das zeitliche Interval, in welchem Daten vom Fahrzeug neu geladen werden soll
+      de: Zeitintervall, in dem Daten vom Fahrzeug neu geladen werden sollen
       en: Time interval with when data should be reloaded from the vehicle
+    advanced: true
     example: 5m
   - name: cloud
     description:

--- a/templates/docs/charger/openwb_0.yaml
+++ b/templates/docs/charger/openwb_0.yaml
@@ -9,3 +9,9 @@ render:
       template: openwb
       host: 192.0.2.2 # IP-Adresse oder Hostname
       loadpointid: 1 # Optional
+    advanced: |
+      type: template
+      template: openwb
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      loadpointid: 1 # Optional
+      phases1p3p: false # Optional

--- a/templates/docs/charger/openwb_0.yaml
+++ b/templates/docs/charger/openwb_0.yaml
@@ -8,10 +8,9 @@ render:
       type: template
       template: openwb
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      loadpointid: 1 # Optional
     advanced: |
       type: template
       template: openwb
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      loadpointid: 1 # Optional
+      connector: 1 # Optional
       phases1p3p: false # Optional

--- a/templates/docs/charger/openwb_0.yaml
+++ b/templates/docs/charger/openwb_0.yaml
@@ -8,6 +8,7 @@ render:
       type: template
       template: openwb
       host: 192.0.2.2 # IP-Adresse oder Hostname
+      connector: 1 # Optional
     advanced: |
       type: template
       template: openwb


### PR DESCRIPTION
- [x] align `loadpointid` parameter with other chargers

@premultiply wie wäre es wenn wir `loadpointid` konsistent überall als `connector` bezeichnen? Würde z.B. die Pracht betreffen (aktuell `vehicle`), ich bin noch nicht sicher welche Boxen sonst noch als "Dual" Version verfügbar sind (Ocpp etc)?