### PR TITLE
Ocpp: handle nil timestamp

### DIFF
--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -60,11 +60,11 @@ type CP struct {
 	boot        *core.BootNotificationRequest
 	status      *core.StatusNotificationRequest
 
-	meterSupported      bool
-	meterUpdated        time.Time
-	measureDoneCh       chan struct{}
-	measurements        map[string]types.SampledValue
-	meterTrickerRunning bool
+	meterSupported     bool
+	measureDoneCh      chan struct{}
+	meterUpdated       time.Time
+	measurements       map[string]types.SampledValue
+	meterTickerRunning bool
 
 	supportedNumberOfConnectors int
 	smartChargingCapabilities   smartChargingProfile

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -44,7 +44,19 @@ func (cp *CP) BootNotification(request *core.BootNotificationRequest) (*core.Boo
 
 func (cp *CP) timestampValid(t time.Time) bool {
 	const statusExpiry = 30 * time.Second
-	return !t.Before(cp.status.Timestamp.Time) && time.Since(t) <= statusExpiry
+
+	// reject if expired
+	if time.Since(t) > statusExpiry {
+		return false
+	}
+
+	// assume having a timestamp is better than not
+	if cp.status.Timestamp == nil {
+		return true
+	}
+
+	// reject older values than we already have
+	return !t.Before(cp.status.Timestamp.Time)
 }
 
 func (cp *CP) StatusNotification(request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -104,7 +104,7 @@ func (cp *CP) Heartbeat(request *core.HeartbeatRequest) (*core.HeartbeatConfirma
 		CurrentTime: types.NewDateTime(time.Now()),
 	}
 
-	if !cp.meterTrickerRunning && cp.meterSupported {
+	if !cp.meterTickerRunning && cp.meterSupported {
 		Instance().TriggerMeterValueRequest(cp)
 	}
 
@@ -170,10 +170,10 @@ func (cp *CP) StartTransaction(request *core.StartTransactionRequest) (*core.Sta
 
 			res.TransactionId = cp.currentTransaction.ID
 
-			if request.Timestamp.After(time.Now().Add(-30*time.Second)) && cp.meterSupported && !cp.meterTrickerRunning {
+			if request.Timestamp.After(time.Now().Add(-30*time.Second)) && cp.meterSupported && !cp.meterTickerRunning {
 				go func() {
 					cp.log.TRACE.Printf("starting meter value ticker")
-					cp.meterTrickerRunning = true
+					cp.meterTickerRunning = true
 					cp.measureDoneCh = make(chan struct{})
 					ticker := time.NewTicker(15 * time.Second)
 
@@ -184,7 +184,7 @@ func (cp *CP) StartTransaction(request *core.StartTransactionRequest) (*core.Sta
 							Instance().TriggerMeterValueRequest(cp)
 						case <-cp.measureDoneCh:
 							cp.log.TRACE.Printf("returning from meter value requests")
-							cp.meterTrickerRunning = false
+							cp.meterTickerRunning = false
 							return
 						}
 					}
@@ -220,7 +220,7 @@ func (cp *CP) StopTransaction(request *core.StopTransactionRequest) (*core.StopT
 	}
 
 	if cp.meterSupported {
-		if cp.meterTrickerRunning {
+		if cp.meterTickerRunning {
 			cp.measureDoneCh <- struct{}{}
 		}
 

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -42,6 +42,7 @@ func (cp *CP) BootNotification(request *core.BootNotificationRequest) (*core.Boo
 	return res, nil
 }
 
+// timestampValid returns false if status timestamps are outdated
 func (cp *CP) timestampValid(t time.Time) bool {
 	const statusExpiry = 30 * time.Second
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/3929

Note: this will still panic if a `nil` ts is accepted and the next message contains a timestamp. Might be better to reject nil but that will break user's CP.

Why is the timestamp comparison required at all?