### PR TITLE
Api: let phases api configure default value for 1p3p charger

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1031,6 +1031,14 @@ func (lp *LoadPoint) scalePhasesIfAvailable(phases int) error {
 	return nil
 }
 
+// setDefaultPhases sets the default phase configuration
+func (lp *LoadPoint) setDefaultPhases(phases int) {
+	lp.Lock()
+	defer lp.Unlock()
+	lp.DefaultPhases = phases
+	lp.phaseTimer = time.Time{}
+}
+
 // setPhases sets the number of enabled phases without modifying the charger
 func (lp *LoadPoint) setPhases(phases int) {
 	if lp.GetPhases() != phases {

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -116,11 +116,14 @@ func (lp *LoadPoint) SetPhases(phases int) error {
 		return fmt.Errorf("invalid number of phases: %d", phases)
 	}
 
-	if _, ok := lp.charger.(api.ChargePhases); ok && phases > 0 {
-		return lp.scalePhases(phases)
+	// set new default
+	lp.setDefaultPhases(phases)
+
+	// apply immediately if not 1p3p
+	if _, ok := lp.charger.(api.ChargePhases); !ok {
+		lp.setPhases(phases)
 	}
 
-	lp.setPhases(phases)
 	return nil
 }
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/3908

In case of 1p3p charger: instead of directly (and slowly) switching to the target phases configuration, the `phases` api will now set the default configuration. During the next interval, phase configuration will we adjusted as necessary.
For non-1p3p charger nothing changes- the default configuration is updated and assumed to be active immediately.