### PR TITLE
fix to remove standard port numbers

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,7 +53,12 @@ type networkConfig struct {
 }
 
 func (c networkConfig) HostPort() string {
-	return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+        if ((c.Schema == "http" && c.Port == 80) ||
+                (c.Schema == "https" && c.Port == 443)) {
+                return c.Host;
+	} else {
+		return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+	}
 }
 
 func (c networkConfig) URI() string {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,12 +53,10 @@ type networkConfig struct {
 }
 
 func (c networkConfig) HostPort() string {
-        if ((c.Schema == "http" && c.Port == 80) ||
-                (c.Schema == "https" && c.Port == 443)) {
-                return c.Host;
-	} else {
-		return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+	if c.Schema == "http" && c.Port == 80 || c.Schema == "https" && c.Port == 443 {
+		return c.Host
 	}
+	return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
 }
 
 func (c networkConfig) URI() string {


### PR DESCRIPTION
Hi,

i'm using evcc behind a reverse proxy (kubernetes ingress). callback urls for oauth gets malformed, due adding default port numbers, e.g. https://evcc.localdomain:443. 

In my case, mercedes-benz developer portal doesn't accept default port numbers like 443 for https which results in invalid callback urls.

Maybe this PR could help others, but it's not perfect. An configurable external base uri for callbacks could be the better approach.

Kind regards,
Simon