### PR TITLE
feat: load config from env-var or also /etc/evcc

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,7 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set
 func initConfig() {
+	cfgFile = util.Getenv("CONFIG", cfgFile)
 	if cfgFile != "" {
 		// Use config file from the flag
 		viper.SetConfigFile(cfgFile)
@@ -110,7 +111,7 @@ func initConfig() {
 		// Search config in home directory with name "mbmd" (without extension).
 		viper.AddConfigPath(".")    // optionally look for config in the working directory
 		viper.AddConfigPath("/etc") // path to look for the config file in
-
+		viper.AddConfigPath("/etc/evcc") // path to look for the config file in
 		viper.SetConfigName("evcc")
 	}
 

--- a/docker/bin/entrypoint.sh
+++ b/docker/bin/entrypoint.sh
@@ -15,6 +15,9 @@ if [ -f ${HASSIO_OPTIONSFILE} ]; then
         echo "starting evcc: 'evcc --config ${CONFIG}'"
         exec evcc --config ${CONFIG}
     fi
+elif [ -f ${CONFIG} ]; then
+    echo "starting evcc: 'evcc --config ${CONFIG}'"
+    exec evcc --config ${CONFIG}
 else
     if [ "$1" == '"evcc"' ] || expr "$1" : '-*' > /dev/null; then
         exec evcc "$@"


### PR DESCRIPTION
* enable setting the configuration information also as env variable within the container. This environment variable is also used when running commands within the contianer
* add `/etc/evcc` as configuration directory as it is easier to mount stuff into a folder when using any orchestrator