### PR TITLE
Easee: Update Smart Charging LED

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -528,7 +528,9 @@ func (c *Easee) updateSmartCharging() {
 		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
 		resp, err := c.Post(uri, request.JSONContent, request.MarshalJSON(data))
 		if err != nil {
-			c.log.WARN.Println("failed to update smart charging status", err)
+			c.log.WARN.Println("smart charging update request failed with error", err)
+		} else if resp.StatusCode != http.StatusAccepted {
+			c.log.WARN.Println("smart charging update request failed with http status", resp.StatusCode, resp.Status)
 		}
 		resp.Body.Close()
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -528,11 +528,11 @@ func (c *Easee) updateSmartCharging() {
 		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
 		resp, err := c.Post(uri, request.JSONContent, request.MarshalJSON(data))
 		if err != nil {
-			c.log.WARN.Println("smart charging update request failed with error", err)
+			c.log.WARN.Println("smart charging update failed:", err)
 		} else if resp.StatusCode != http.StatusAccepted {
-			c.log.WARN.Println("smart charging update request failed with http status", resp.StatusCode, resp.Status)
+			resp.Body.Close()
+			c.log.WARN.Println("smart charging update failed:", resp.StatusCode, resp.Status)
 		}
-		resp.Body.Close()
 
 		c.mux.L.Lock()
 		c.smartCharging = isSmartCharging

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -522,15 +522,13 @@ func (c *Easee) updateSmartCharging() {
 	c.mux.L.Unlock()
 
 	if updateNeeded {
-		c.log.DEBUG.Printf("update smart charging status: %v", isSmartCharging)
-
 		data := easee.ChargerSettings{
 			SmartCharging: &isSmartCharging,
 		}
 		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
 		resp, err := c.Post(uri, request.JSONContent, request.MarshalJSON(data))
 		if err != nil {
-			c.log.WARN.Printf("failed to update smart charging status")
+			c.log.WARN.Println("failed to update smart charging status", err)
 		}
 		resp.Body.Close()
 


### PR DESCRIPTION
This change reports the evcc charging mode to the easee API which then indicates via white/blue LEDs if the current charging session is **normal** or **smart**.

`now` mode leads to white LEDs ⚪️⚪️⚪️
`pv` and `minpv` mode are reported as smart and show blue LEDs 🔵🔵🔵
`off` is also reported as non-smart, but the charger doesn't show the LED wave in this mode anyway.

https://developer.easee.cloud/docs/api-smart-charging#time-of-use