### PR TITLE
Split min/max current into 3p (default) and 1p settings

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -51,11 +51,13 @@ func (c ChargeStatus) String() string {
 
 // ActionConfig defines an action to take on event
 type ActionConfig struct {
-	Mode       *ChargeMode `mapstructure:"mode,omitempty"`       // Charge Mode
-	MinCurrent *float64    `mapstructure:"minCurrent,omitempty"` // Minimum Current
-	MaxCurrent *float64    `mapstructure:"maxCurrent,omitempty"` // Maximum Current
-	MinSoC     *int        `mapstructure:"minSoC,omitempty"`     // Minimum SoC
-	TargetSoC  *int        `mapstructure:"targetSoC,omitempty"`  // Target SoC
+	Mode         *ChargeMode `mapstructure:"mode,omitempty"`         // Charge Mode
+	MinCurrent   *float64    `mapstructure:"minCurrent,omitempty"`   // Minimum Current
+	MaxCurrent   *float64    `mapstructure:"maxCurrent,omitempty"`   // Maximum Current
+	MinCurrent1p *float64    `mapstructure:"minCurrent1p,omitempty"` // Minimum Current 1p
+	MaxCurrent1p *float64    `mapstructure:"maxCurrent1p,omitempty"` // Maximum Current 1p
+	MinSoC       *int        `mapstructure:"minSoC,omitempty"`       // Minimum SoC
+	TargetSoC    *int        `mapstructure:"targetSoC,omitempty"`    // Target SoC
 }
 
 // String implements Stringer and returns the ActionConfig as comma-separated key:value string

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -113,6 +113,8 @@ type LoadPoint struct {
 
 	MinCurrent    float64       // PV mode: start current	Min+PV mode: min current
 	MaxCurrent    float64       // Max allowed current. Physically ensured by the charger
+	MinCurrent1p  float64       // Min current for 1p
+	MaxCurrent1p  float64       // Max current for 1p
 	GuardDuration time.Duration // charger enable/disable minimum holding time
 
 	enabled             bool      // Charger enabled state
@@ -295,6 +297,8 @@ func (lp *LoadPoint) collectDefaults() {
 		*actionCfg.Mode = lp.GetMode()
 		*actionCfg.MinCurrent = lp.GetMinCurrent()
 		*actionCfg.MaxCurrent = lp.GetMaxCurrent()
+		*actionCfg.MinCurrent1p = lp.MinCurrent1p // TODO add api
+		*actionCfg.MaxCurrent1p = lp.MaxCurrent1p // TODO add api
 		*actionCfg.MinSoC = lp.GetMinSoC()
 		*actionCfg.TargetSoC = lp.GetTargetSoC()
 	} else {
@@ -497,8 +501,14 @@ func (lp *LoadPoint) applyAction(actionCfg api.ActionConfig) {
 	if actionCfg.MinCurrent != nil {
 		lp.SetMinCurrent(*actionCfg.MinCurrent)
 	}
+	if actionCfg.MinCurrent1p != nil {
+		lp.MinCurrent1p = *actionCfg.MinCurrent1p // TODO add api
+	}
 	if actionCfg.MaxCurrent != nil {
 		lp.SetMaxCurrent(*actionCfg.MaxCurrent)
+	}
+	if actionCfg.MaxCurrent1p != nil {
+		lp.MaxCurrent1p = *actionCfg.MaxCurrent1p // TODO add api
 	}
 	if actionCfg.MinSoC != nil {
 		lp.SetMinSoC(*actionCfg.MinSoC)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -295,10 +295,10 @@ func (lp *LoadPoint) collectDefaults() {
 	if err := allocate.Zero(actionCfg); err == nil {
 		// initialize with default values
 		*actionCfg.Mode = lp.GetMode()
-		*actionCfg.MinCurrent = lp.GetMinCurrent()
-		*actionCfg.MaxCurrent = lp.GetMaxCurrent()
-		*actionCfg.MinCurrent1p = lp.MinCurrent1p // TODO add api
-		*actionCfg.MaxCurrent1p = lp.MaxCurrent1p // TODO add api
+		*actionCfg.MinCurrent = lp.MinCurrent     // TODO
+		*actionCfg.MaxCurrent = lp.MaxCurrent     // TODO
+		*actionCfg.MinCurrent1p = lp.MinCurrent1p // TODO
+		*actionCfg.MaxCurrent1p = lp.MaxCurrent1p // TODO
 		*actionCfg.MinSoC = lp.GetMinSoC()
 		*actionCfg.TargetSoC = lp.GetTargetSoC()
 	} else {
@@ -539,7 +539,7 @@ func (lp *LoadPoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 
 	// publish initial values
 	lp.publish("title", lp.Title)
-	lp.publish("minCurrent", lp.MinCurrent)
+	lp.publish("minCurrent", lp.MinCurrent) // TODO
 	lp.publish("maxCurrent", lp.MaxCurrent)
 	lp.publish("phases", lp.phases)
 	lp.publish("activePhases", lp.activePhases())

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -184,7 +184,7 @@ func (lp *LoadPoint) GetMinCurrent() float64 {
 	return lp.MinCurrent
 }
 
-// SetMinCurrent returns the min loadpoint current
+// SetMinCurrent sets the min loadpoint current
 func (lp *LoadPoint) SetMinCurrent(current float64) {
 	lp.Lock()
 	defer lp.Unlock()


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/3528

Approach:

- `min/maxCurrent` are the 3p defaults
- `min/maxCurrent1p` are additional 1p defaults; if omitted 3p values apply

Todo:

- [ ] clarify api
- [ ] fix logic