### PR TITLE
Improve SunSpec config

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -24,9 +24,9 @@ render: |
   # reference: https://github.com/volkszaehler/mbmd/blob/master/meters/sunspec/models.go
   {{- if eq .usage "grid" }}
   type: modbus
-  model: sunspec
   uri: {{ .host }}:{{ .port }}
   id: 200
+  model: sunspec
   {{- if eq .integer "true" }}
   # sunspec model 203 (int+sf) meter
   power: 203:W
@@ -49,14 +49,14 @@ render: |
     source: calc
     add:
     - source: modbus
-      model: sunspec
       uri: {{ .host }}:{{ .port }}
       id: 1
+      model: sunspec
       value: 160:1:DCW # mppt 1
     - source: modbus
-      model: sunspec
       uri: {{ .host }}:{{ .port }}
       id: 1
+      model: sunspec
       value: 160:2:DCW # mppt 2
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -65,20 +65,20 @@ render: |
     source: calc
     add:
     - source: modbus
-      model: sunspec
       uri: {{ .host }}:{{ .port }}
       id: 1
+      model: sunspec
       value: 160:3:DCW # mppt 3 charge
       scale: -1
     - source: modbus
-      model: sunspec
       uri: {{ .host }}:{{ .port }}
       id: 1
+      model: sunspec
       value: 160:4:DCW # mppt 4 discharge
   soc:
     source: modbus
-    model: sunspec
     uri: {{ .host }}:{{ .port }}
     id: 1
+    model: sunspec
     value: ChargeState
   {{- end }}

--- a/templates/definition/meter/kostal-ksem.yaml
+++ b/templates/definition/meter/kostal-ksem.yaml
@@ -13,4 +13,4 @@ render: |
   type: modbus
   {{- include "modbus" . }}
   model: sunspec
-  value: Power
+  power: Power

--- a/templates/definition/meter/kostal-ksem.yaml
+++ b/templates/definition/meter/kostal-ksem.yaml
@@ -13,4 +13,3 @@ render: |
   type: modbus
   {{- include "modbus" . }}
   model: sunspec
-  power: Power

--- a/templates/definition/meter/kostal-ksem.yaml
+++ b/templates/definition/meter/kostal-ksem.yaml
@@ -11,5 +11,6 @@ params:
     id: 71
 render: |
   type: modbus
-  model: sunspec
   {{- include "modbus" . }}
+  model: sunspec
+  value: Power

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -25,12 +25,12 @@ render: |
     source: calc
     add: # The add plugin sums up both string values
     - source: modbus
+      {{- include "modbus" . | indent 4 }}
       model: sunspec
-  {{- include "modbus" . | indent 4 }}
       value: 160:1:DCW # string 1
     - source: modbus
+      {{- include "modbus" . | indent 4 }}
       model: sunspec
-  {{- include "modbus" . | indent 4 }}
       value: 160:2:DCW # string 2
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -24,11 +24,11 @@ render: |
   power:
   {{- if eq .usage "grid" }}
     source: modbus
-    model: sunspec
-    timeout: {{ .timeout }}
     uri: {{ .host }}:{{ .port }} # Port 502 (SetApp) or 1502 (LCD)
     id: 1
     subdevice: 1 # Metering device
+    timeout: {{ .timeout }}
+    model: sunspec
     value: 203:W
     scale: -1
   {{- end }}
@@ -36,15 +36,15 @@ render: |
     source: calc
     add:
     - source: modbus
-      model: sunspec
-      timeout: {{ .timeout }}
       uri: {{ .host }}:{{ .port }} # Port 502 (SetApp) or 1502 (LCD)
       id: 1
+      timeout: {{ .timeout }}
+      model: sunspec
       value: 103:DCW
     - source: modbus
-      timeout: {{ .timeout }}
       uri: {{ .host }}:{{ .port }} # Port 502 (SetApp) or 1502 (LCD)
       id: 1
+      timeout: {{ .timeout }}
       register:
         address: 62836 # Battery 1 Instantaneous Power
         type: holding

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -21,7 +21,9 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     model: sunspec
+  {{- if ne .usage "grid" }}
     value: Power
+  {{- end -}}
   {{- if eq .usage "grid" }}
     subdevice: 1
     value: 203:W # sunspec 3-phase meter power reading

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -18,9 +18,10 @@ render: |
   type: custom
   power:
     source: modbus
-    model: sunspec
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
+    model: sunspec
+    value: Power
   {{- if eq .usage "grid" }}
     subdevice: 1
     value: 203:W # sunspec 3-phase meter power reading

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -20,12 +20,12 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
-    model: sunspec
-  {{- if ne .usage "grid" }}
-    value: Power
-  {{- end -}}
   {{- if eq .usage "grid" }}
     subdevice: 1
+    model: sunspec
     value: 203:W # sunspec 3-phase meter power reading
     scale: -1
-  {{- end -}}
+  {{- else }}
+    model: sunspec
+    value: Power
+  {{- end }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -45,12 +45,12 @@ render: |
     source: calc
     add:
     - source: modbus
-      model: sunspec
       {{- include "modbus" . | indent 4 }}
+      model: sunspec
       value: 160:1:DCW # mppt 1
     - source: modbus
-      model: sunspec
       {{- include "modbus" . | indent 4 }}
+      model: sunspec
       value: 160:2:DCW # mppt 2
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -59,16 +59,17 @@ render: |
     source: calc
     add:
     - source: modbus
-      model: sunspec
       {{- include "modbus" . | indent 4 }}
+      model: sunspec
       value: 160:3:DCW # mppt 3 charge
       scale: -1
     - source: modbus
-      model: sunspec
       {{- include "modbus" . | indent 4 }}
+      model: sunspec
       value: 160:4:DCW # mppt 4 discharge
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    model: sunspec
     value: ChargeState
   {{- end }}

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -21,6 +21,7 @@ params:
 render: |
   type: modbus
   {{- include "modbus" . }}
+  model: sunspec
   {{- if eq .usage "grid" }}
   {{- if eq .integer "true" }}
   # sunspec model 203 (int+sf) meter

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -21,8 +21,8 @@ params:
 render: |
   type: modbus
   {{- include "modbus" . }}
-  model: sunspec
   {{- if eq .usage "grid" }}
+  model: sunspec
   {{- if eq .integer "true" }}
   # sunspec model 203 (int+sf) meter
   power: 203:W
@@ -38,4 +38,7 @@ render: |
     - 213:AphB
     - 213:AphC
   {{- end }}
+  {{- else }}
+  model: sunspec
+  power: Power
   {{- end }}


### PR DESCRIPTION
This PR contains two changes:

- more logical grouping of modbus properties in the templates (i.e. physical connection first, then logical properties)
- add default `Power` measurement to suppress warning