### PR TITLE
hecRegRemoteLock nicht auf 0 setzen

### DIFF
--- a/charger/heidelberg-ec.go
+++ b/charger/heidelberg-ec.go
@@ -273,13 +273,11 @@ var _ api.Resurrector = (*HeidelbergEC)(nil)
 // WakeUp implements the api.Resurrector interface
 func (wb *HeidelbergEC) WakeUp() error {
 	// force status F by locking
-	err := wb.set(hecRegRemoteLock, 0)
+	err := wb.set(hecRegRemoteLock, 1)
 	if err == nil {
 		// Always takes at least ~10 sec to return to normal operation
 		// after locking even if unlocking immediately.
 		wb.wakeup = true
-		// return to normal operation by unlocking after ~10 sec
-		err = wb.set(hecRegRemoteLock, 1)
 	}
 	return err
 }

--- a/charger/heidelberg-ec.go
+++ b/charger/heidelberg-ec.go
@@ -272,7 +272,7 @@ var _ api.Resurrector = (*HeidelbergEC)(nil)
 
 // WakeUp implements the api.Resurrector interface
 func (wb *HeidelbergEC) WakeUp() error {
-	// force status F by locking
+	// unlock the box to wakeUp
 	err := wb.set(hecRegRemoteLock, 1)
 	if err == nil {
 		// Always takes at least ~10 sec to return to normal operation


### PR DESCRIPTION
Um zu verhindern das ein eventuell gerade laufender Ladevorgang unterbrochen wird sollte das hecRegRemoteLock nie auf 0 (locked) gesetzt werden. Es ist jetzt auch schon mehrfach aufgetreten das wenn beim setzen ein Fehler auftritt die Box danach nie wieder in den 1 (unlocked) state zurückgesetzt wird, WakeUp scheint in diesem Fall nichtmehr aufgerufen zu werden (aber dazu kenn ich das Projekt zu wenig)