### PR TITLE
Validate vehicle min/max currents against loadpoint defaults

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -477,11 +477,11 @@ func (lp *LoadPoint) applyAction(actionCfg api.ActionConfig) {
 	if actionCfg.Mode != nil {
 		lp.SetMode(*actionCfg.Mode)
 	}
-	if actionCfg.MinCurrent != nil {
-		lp.SetMinCurrent(*actionCfg.MinCurrent)
+	if min := actionCfg.MinCurrent; min != nil && *min >= *lp.onDisconnect.MinCurrent {
+		lp.SetMinCurrent(*min)
 	}
-	if actionCfg.MaxCurrent != nil {
-		lp.SetMaxCurrent(*actionCfg.MaxCurrent)
+	if max := actionCfg.MaxCurrent; max != nil && *max <= *lp.onDisconnect.MaxCurrent {
+		lp.SetMaxCurrent(*max)
 	}
 	if actionCfg.MinSoC != nil {
 		lp.SetMinSoC(*actionCfg.MinSoC)

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -172,8 +172,11 @@ func TestApplyVehicleDefaults(t *testing.T) {
 		}
 	}
 
-	oi := newConfig(api.ModePV, 7, 17, 1, 99)
-	od := newConfig(api.ModeOff, 5, 15, 2, 98)
+	// onIdentified config
+	oi := newConfig(api.ModePV, 7, 15, 1, 99)
+
+	// onDefault config
+	od := newConfig(api.ModeOff, 6, 16, 2, 98)
 
 	vehicle := mock.NewMockVehicle(ctrl)
 	vehicle.EXPECT().Title().Return("it's me").AnyTimes()
@@ -188,6 +191,10 @@ func TestApplyVehicleDefaults(t *testing.T) {
 
 	lp.onDisconnect = od
 	lp.ResetOnDisconnect = true
+
+	// check loadpoint default currents can't be violated
+	lp.applyAction(newConfig(*od.Mode, 5, 17, *od.MinSoC, *od.TargetSoC))
+	assertConfig(lp, od)
 
 	// vehicle identified
 	lp.setActiveVehicle(vehicle)


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/4113

`lp.onDisconnect` enthält die Defaults des Loadpoints.