### PR TITLE
OCPP: Requires websocket port to be exposed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ COPY docker/bin/* /app/
 EXPOSE 7070/tcp
 # KEBA charger
 EXPOSE 7090/udp
+# OCPP charger
+EXPOSE 8887/tcp
 # SMA Energy Manager
 EXPOSE 9522/udp
 


### PR DESCRIPTION
https://docs.evcc.io/docs/devices/chargers#ocpp-16j-kompatible-wallbox-mit-smart-charging-profil

ws://< evcc-IP-Adresse >:8887/