### PR TITLE
Vehicle: remove cloud connection

### DIFF
--- a/templates/definition/defaults.yaml
+++ b/templates/definition/defaults.yaml
@@ -302,15 +302,6 @@ presets:
       language: {{ .language }}
       {{end}}
 
-  vehiclecloud:
-    params:
-      - name: cloud
-        advanced: true
-    render: |
-      {{define "vehicle-cloud"}}
-      cloud: {{ .cloud }}
-      {{end}}
-
 modbus:
   interfaces:
     rs485: ["rs485serial", "rs485tcpip"]

--- a/templates/definition/vehicle/audi-etron.yaml
+++ b/templates/definition/vehicle/audi-etron.yaml
@@ -8,9 +8,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WAUZZZ...
-  - preset: vehiclecloud
 render: |
   type: etron
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/audi.yaml
+++ b/templates/definition/vehicle/audi.yaml
@@ -9,9 +9,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WAUZZZ...
-  - preset: vehiclecloud
 render: |
   type: audi
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/bmw.yaml
+++ b/templates/definition/vehicle/bmw.yaml
@@ -6,9 +6,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WBMW...
-  - preset: vehiclecloud
 render: |
   type: bmw
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/carwings.yaml
+++ b/templates/definition/vehicle/carwings.yaml
@@ -6,9 +6,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: carwings
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -4,9 +4,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: citroen
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/dacia.yaml
+++ b/templates/definition/vehicle/dacia.yaml
@@ -6,9 +6,7 @@ params:
   - preset: vehicleidentify
   - name: capacity
     default: 27.4
-  - preset: vehiclecloud
 render: |
   type: dacia
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -4,9 +4,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: ds
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/evnotify.yaml
+++ b/templates/definition/vehicle/evnotify.yaml
@@ -14,7 +14,6 @@ params:
   - name: phases
     advanced: true
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: custom
   {{- if ne .title "" }}
@@ -29,4 +28,3 @@ render: |
     uri: https://app.evnotify.de/soc?akey={{ .akey }}&token={{ .token }} # evNotify Server + AKEY
     method: GET
     jq: .soc_display
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -8,7 +8,6 @@ params:
   - name: pin
     mask: true
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: fiat
   {{ include "vehicle-base" . }}
@@ -16,4 +15,3 @@ render: |
   pin: {{ .pin }} # mandatory to deep refresh SoC
   {{- end }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/ford.yaml
+++ b/templates/definition/vehicle/ford.yaml
@@ -6,9 +6,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WF0FXX...
-  - preset: vehiclecloud
 render: |
   type: ford
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/hyundai.yaml
+++ b/templates/definition/vehicle/hyundai.yaml
@@ -7,10 +7,8 @@ params:
   - preset: vehiclebase
   - preset: vehiclelanguage
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: hyundai
   {{ include "vehicle-base" . }}
   {{ include "vehicle-language" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/jaguar-landrover.yaml
+++ b/templates/definition/vehicle/jaguar-landrover.yaml
@@ -5,9 +5,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: jaguar
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -7,10 +7,8 @@ params:
   - preset: vehiclebase
   - preset: vehiclelanguage
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: kia
   {{ include "vehicle-base" . }}
   {{ include "vehicle-language" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/mini.yaml
+++ b/templates/definition/vehicle/mini.yaml
@@ -6,9 +6,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WBMW...
-  - preset: vehiclecloud
 render: |
   type: mini
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/nissan.yaml
+++ b/templates/definition/vehicle/nissan.yaml
@@ -6,9 +6,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: nissan
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -6,9 +6,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WP0...
-  - preset: vehiclecloud
 render: |
   type: opel
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -4,9 +4,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: peugeot
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/porsche.yaml
+++ b/templates/definition/vehicle/porsche.yaml
@@ -4,9 +4,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: porsche
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/renault.yaml
+++ b/templates/definition/vehicle/renault.yaml
@@ -6,9 +6,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WREN...
-  - preset: vehiclecloud
 render: |
   type: renault
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/seat-cupra.yaml
+++ b/templates/definition/vehicle/seat-cupra.yaml
@@ -6,9 +6,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: cupra
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/seat.yaml
+++ b/templates/definition/vehicle/seat.yaml
@@ -7,9 +7,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: seat
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/silence.yaml
+++ b/templates/definition/vehicle/silence.yaml
@@ -11,8 +11,6 @@ params:
   - preset: vehiclebase
   - name: vin
     example: W...
-  - preset: vehiclecloud
 render: |
   type: silence
   {{ include "vehicle-base" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/skoda-enyaq.yaml
+++ b/templates/definition/vehicle/skoda-enyaq.yaml
@@ -6,9 +6,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: enyaq
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/skoda.yaml
+++ b/templates/definition/vehicle/skoda.yaml
@@ -7,9 +7,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: skoda
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/smart.yaml
+++ b/templates/definition/vehicle/smart.yaml
@@ -8,9 +8,7 @@ params:
   - preset: vehicleidentify
   - name: capacity
     default: 17.6
-  - preset: vehiclecloud
 render: |
   type: smart
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -35,7 +35,6 @@ params:
   - name: phases
     advanced: true
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: tesla
   {{- if ne .title "" }}
@@ -52,4 +51,3 @@ render: |
   vin: {{ .vin }}
   {{- end }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/volvo.yaml
+++ b/templates/definition/vehicle/volvo.yaml
@@ -4,9 +4,7 @@ products:
 params:
   - preset: vehiclebase
   - preset: vehicleidentify
-  - preset: vehiclecloud
 render: |
   type: volvo
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/vw-id.yaml
+++ b/templates/definition/vehicle/vw-id.yaml
@@ -12,9 +12,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WVWZZZ...
-  - preset: vehiclecloud
 render: |
   type: id
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/definition/vehicle/vw.yaml
+++ b/templates/definition/vehicle/vw.yaml
@@ -12,9 +12,7 @@ params:
   - preset: vehicleidentify
   - name: vin
     example: WVWZZZ...
-  - preset: vehiclecloud
 render: |
   type: vw
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
-  {{ include "vehicle-cloud" . }}

--- a/templates/docs/vehicle/audi_0.yaml
+++ b/templates/docs/vehicle/audi_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/bmw_0.yaml
+++ b/templates/docs/vehicle/bmw_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/carwings_0.yaml
+++ b/templates/docs/vehicle/carwings_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/citroen_0.yaml
+++ b/templates/docs/vehicle/citroen_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/cupra_0.yaml
+++ b/templates/docs/vehicle/cupra_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/dacia_0.yaml
+++ b/templates/docs/vehicle/dacia_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/ds_0.yaml
+++ b/templates/docs/vehicle/ds_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/enyaq_0.yaml
+++ b/templates/docs/vehicle/enyaq_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/etron_0.yaml
+++ b/templates/docs/vehicle/etron_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/evnotify_0.yaml
+++ b/templates/docs/vehicle/evnotify_0.yaml
@@ -23,4 +23,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/fiat_0.yaml
+++ b/templates/docs/vehicle/fiat_0.yaml
@@ -26,4 +26,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/ford_0.yaml
+++ b/templates/docs/vehicle/ford_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/hyundai_0.yaml
+++ b/templates/docs/vehicle/hyundai_0.yaml
@@ -27,4 +27,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/id_0.yaml
+++ b/templates/docs/vehicle/id_0.yaml
@@ -27,4 +27,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/jaguar-landrover_0.yaml
+++ b/templates/docs/vehicle/jaguar-landrover_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/jaguar-landrover_1.yaml
+++ b/templates/docs/vehicle/jaguar-landrover_1.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/kia_0.yaml
+++ b/templates/docs/vehicle/kia_0.yaml
@@ -27,4 +27,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/mini_0.yaml
+++ b/templates/docs/vehicle/mini_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/nissan_0.yaml
+++ b/templates/docs/vehicle/nissan_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/opel_0.yaml
+++ b/templates/docs/vehicle/opel_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/peugeot_0.yaml
+++ b/templates/docs/vehicle/peugeot_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/porsche_0.yaml
+++ b/templates/docs/vehicle/porsche_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/renault_0.yaml
+++ b/templates/docs/vehicle/renault_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/seat_0.yaml
+++ b/templates/docs/vehicle/seat_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/silence_0.yaml
+++ b/templates/docs/vehicle/silence_0.yaml
@@ -20,4 +20,3 @@ render:
       vin: W... # Erforderlich, wenn mehrere Fahrzeuge des Herstellers vorhanden sind # Optional
       capacity: 50 # Akku-Kapazität in kWh # Optional
       phases: 3 # Die maximale Anzahl der Phasen welche genutzt werden können # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/silence_1.yaml
+++ b/templates/docs/vehicle/silence_1.yaml
@@ -20,4 +20,3 @@ render:
       vin: W... # Erforderlich, wenn mehrere Fahrzeuge des Herstellers vorhanden sind # Optional
       capacity: 50 # Akku-Kapazität in kWh # Optional
       phases: 3 # Die maximale Anzahl der Phasen welche genutzt werden können # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/skoda_0.yaml
+++ b/templates/docs/vehicle/skoda_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/smart_0.yaml
+++ b/templates/docs/vehicle/smart_0.yaml
@@ -25,4 +25,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/tesla_0.yaml
+++ b/templates/docs/vehicle/tesla_0.yaml
@@ -32,4 +32,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/volvo_0.yaml
+++ b/templates/docs/vehicle/volvo_0.yaml
@@ -24,4 +24,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional

--- a/templates/docs/vehicle/vw_0.yaml
+++ b/templates/docs/vehicle/vw_0.yaml
@@ -27,4 +27,3 @@ render:
       minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
-      cloud: # Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,... # Optional


### PR DESCRIPTION
The `cloud` access can only supply soc but not status. Vehicle detection does not work. For time being, cloud should not be used.

/cc @VolkerK62 