### PR TITLE
Apply configured phases for all modes

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1048,7 +1048,6 @@ func (lp *LoadPoint) setConfiguredPhases(phases int) {
 	defer lp.Unlock()
 
 	lp.ConfiguredPhases = phases
-	lp.phaseTimer = time.Time{}
 
 	// publish 1p3p capability and phase configuration
 	if _, ok := lp.charger.(api.PhaseSwitcher); ok {
@@ -1129,13 +1128,12 @@ func (lp *LoadPoint) pvScalePhases(availablePower, minCurrent, maxCurrent float6
 
 		lp.publishTimer(phaseTimer, lp.Disable.Delay, phaseScale1p)
 
-		elapsed := lp.clock.Since(lp.phaseTimer)
-		if elapsed >= lp.Disable.Delay {
+		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.Disable.Delay {
 			lp.log.DEBUG.Printf("phase %s timer elapsed", phaseScale1p)
 			if err := lp.scalePhases(1); err == nil {
 				lp.log.DEBUG.Printf("switched phases: 1p @ %.0fW", availablePower)
 			} else {
-				lp.log.ERROR.Printf("switch phases: %v", err)
+				lp.log.ERROR.Println(err)
 			}
 			return true
 		}
@@ -1158,13 +1156,12 @@ func (lp *LoadPoint) pvScalePhases(availablePower, minCurrent, maxCurrent float6
 
 		lp.publishTimer(phaseTimer, lp.Enable.Delay, phaseScale3p)
 
-		elapsed := lp.clock.Since(lp.phaseTimer)
-		if elapsed >= lp.Enable.Delay {
+		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.Enable.Delay {
 			lp.log.DEBUG.Printf("phase %s timer elapsed", phaseScale3p)
 			if err := lp.scalePhases(3); err == nil {
 				lp.log.DEBUG.Printf("switched phases: 3p @ %.0fW", availablePower)
 			} else {
-				lp.log.ERROR.Printf("switch phases: %v", err)
+				lp.log.ERROR.Println(err)
 			}
 			return true
 		}

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -124,6 +124,8 @@ func (lp *LoadPoint) SetPhases(phases int) error {
 		lp.setPhases(phases)
 	}
 
+	lp.requestUpdate()
+
 	return nil
 }
 


### PR DESCRIPTION
This PR:
- always scales to configured phases, not only in PV mode
- fixes phase scale timer reset when API called (it should not reset a running timer)
- makes switching quicker by requesting loadpoint update after api call
