### PR TITLE
Add offline vehicle template

### DIFF
--- a/templates/definition/vehicle/offline.yaml
+++ b/templates/definition/vehicle/offline.yaml
@@ -1,0 +1,50 @@
+template: offline
+products:
+  - description:
+      generic: Offline
+group: generic
+params:
+  - name: title
+  - name: capacity
+    valuetype: float
+  - name: phases
+    advanced: true
+  - name: mode
+    advanced: true
+  - name: minCurrent
+    advanced: true
+  - name: maxCurrent
+    advanced: true
+  - name: identifiers
+    advanced: true
+    valuetype: stringlist
+render: |
+  type: custom
+  {{- if ne .title "" }}
+  title: {{ .title }}
+  {{- end }}
+  capacity: {{ .capacity }} # kWh
+  {{- if ne .phases "" }}
+  phases: {{ .phases }}
+  {{- end }}
+  soc: # fixed - no SoC available
+    type: js
+    script: 0;
+  onIdentify:
+  {{- if (ne .mode "") }}
+    mode: {{ .mode }}
+  {{- end }}
+    minSoC: 0 # fixed - no SoC available
+    targetSoC: 100 # fixed - no SoC available
+  {{- if (ne .minCurrent "") }}
+    minCurrent: {{ .minCurrent }}
+  {{- end }}
+  {{- if (ne .maxCurrent "") }}
+    maxCurrent: {{ .maxCurrent }}
+  {{- end }}
+  {{- if ne (len .identifiers) 0 }}
+  identifiers:
+  {{-   range .identifiers }}
+  - {{ . }}
+  {{-   end }}
+  {{- end }}

--- a/templates/docs/vehicle/offline_0.yaml
+++ b/templates/docs/vehicle/offline_0.yaml
@@ -1,0 +1,19 @@
+product:
+  description: Offline
+  group: Generische Unterstützung
+render:
+  - default: |
+      type: template
+      template: offline
+      title: # Wird in der Benutzeroberfläche angezeigt # Optional
+      capacity: 50 # Akku-Kapazität in kWh # Optional
+    advanced: |
+      type: template
+      template: offline
+      title: # Wird in der Benutzeroberfläche angezeigt # Optional
+      capacity: 50 # Akku-Kapazität in kWh # Optional
+      phases: 3 # Die maximale Anzahl der Phasen welche genutzt werden können # Optional
+      mode: # Möglich sind Off, Now, MinPV und PV, oder leer wenn keiner definiert werden soll # Optional
+      minCurrent: 6 # Definiert die minimale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
+      maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
+      identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional


### PR DESCRIPTION
This adds a simple vehicle template for offline vehicles that do not provide any usable data connection.

These type of vehicles do not provide any sampled SoC values or other states.
So many of evcc's advanced charge control features are not available for this type of vehicle.

If there is still a demand to add such vehicles to evcc they need to be manually assigned to a loadpoint by UI or RFID tag.

Features **not** available:
- Anything around state of charge (SoC)
- minSoC (fixed to 0)
- targetSoC (fixed to 100)
- Automatic vehicle identification