### PR TITLE
Added chargeEndTime field to Ford status response

### DIFF
--- a/vehicle/ford/provider.go
+++ b/vehicle/ford/provider.go
@@ -132,6 +132,14 @@ func (v *Provider) Position() (float64, float64, error) {
 	return res.VehicleStatus.Gps.Latitude, res.VehicleStatus.Gps.Longitude, err
 }
 
+var _ api.VehicleFinishTimer = (*Provider)(nil)
+
+// FinishTime implements the api.VehicleFinishTimer interface
+func (v *Provider) FinishTime() (time.Time, error) {
+	res, err := v.statusG()
+	return res.VehicleStatus.ChargeEndTime.Value.Time, err
+}
+
 var _ api.Resurrector = (*Provider)(nil)
 
 // WakeUp implements the api.Resurrector interface

--- a/vehicle/ford/types.go
+++ b/vehicle/ford/types.go
@@ -28,6 +28,10 @@ type StatusResponse struct {
 			Value     string
 			Timestamp Timestamp
 		}
+		ChargeEndTime struct {
+			Value     Timestamp
+			Timestamp Timestamp
+		}
 		PlugStatus struct {
 			Value     int
 			Timestamp Timestamp


### PR DESCRIPTION
Status response example

    {
        "status": 200,
        "vehiclestatus": {
            "PrmtAlarmEvent": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "NULL"
            },
            "TPMS": {
                "dualRearWheel": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": 1
                },
                "innerLeftRearTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "65535"
                },
                "innerLeftRearTireStatus": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Not_Supported"
                },
                "innerRightRearTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "65535"
                },
                "innerRightRearTireStatus": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Not_Supported"
                },
                "leftFrontTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "245"
                },
                "leftFrontTireStatus": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Normal"
                },
                "outerLeftRearTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "267"
                },
                "outerLeftRearTireStatus": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Normal"
                },
                "outerRightRearTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "274"
                },
                "outerRightRearTireStatus": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Normal"
                },
                "recommendedFrontTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": 36
                },
                "recommendedRearTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": 49
                },
                "rightFrontTirePressure": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "243"
                },
                "rightFrontTireStatus": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Normal"
                },
                "tirePressureByLocation": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": 1
                },
                "tirePressureSystemStatus": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Systm_Activ_Composite_Stat"
                }
            },
            "alarm": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "SET"
            },
            "authorization": "AUTHORIZED",
            "battTracLoSocDDsply": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "Null"
            },
            "battery": {
                "batteryHealth": {
                    "timestamp": "08-13-2022 22:02:39",
                    "value": "STATUS_GOOD"
                },
                "batteryStatusActual": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": 15
                }
            },
            "batteryChargeStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "NoReportRequest"
            },
            "batteryFillLevel": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": 51.5
            },
            "batteryPerfStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "Ok no message displayed"
            },
            "batteryTracLowChargeThreshold": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "Thres50mi80km"
            },
            "ccsSettings": {
                "contacts": 1,
                "drivingCharacteristics": 1,
                "location": 1,
                "timestamp": "03-29-2022 05:42:31",
                "vehicleConnectivity": 1,
                "vehicleData": 1
            },
            **_"chargeEndTime": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "08-25-2022 05:05:00"
            },_**
            "chargeStartTime": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "08-23-2022 22:28:00"
            },
            "chargerPowertype": null,
            "chargingStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "ChargingAC"
            },
            "dcFastChargeData": {
                "fstChrgBulkTEst": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "25"
                },
                "fstChrgCmpltTEst": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "73"
                }
            },
            "deepSleepInProgress": {
                "timestamp": "08-24-2022 06:25:29",
                "value": false
            },
            "dieselSystemStatus": {
                "exhaustFluidLevel": null,
                "filterRegenerationStatus": null,
                "filterSoot": null,
                "metricType": null,
                "ureaRange": null
            },
            "doorStatus": {
                "driverDoor": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Closed"
                },
                "hoodDoor": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Closed"
                },
                "innerTailgateDoor": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Closed"
                },
                "leftRearDoor": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Closed"
                },
                "passengerDoor": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Closed"
                },
                "rightRearDoor": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Closed"
                },
                "tailgateDoor": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:29:09",
                    "value": "Closed"
                }
            },
            "elVehDTE": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": 224
            },
            "firmwareUpgInProgress": {
                "timestamp": "09-03-2021 14:10:48",
                "value": false
            },
            "fuel": null,
            "gps": {
                "gpsState": "UNSHIFTED",
                "latitude": "XXX",
                "longitude": "XXX",
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09"
            },
            "hybridModeStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "Auto Charge Deplete Mode"
            },
            "ignitionStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "Off"
            },
            "lastModifiedDate": "08-24-2022 06:29:10",
            "lastRefresh": "08-24-2022 06:29:08",
            "lifeCycMode": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "NORMAL"
            },
            "lockStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "LOCKED"
            },
            "odometer": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": 18205
            },
            "oil": {
                "oilLife": "STATUS_GOOD",
                "oilLifeActual": 100,
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09"
            },
            "outandAbout": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "PwPckOffTqNotAvailable"
            },
            "plugStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": 1
            },
            "preCondStatusDsply": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": "Not Scheduled"
            },
            "remoteStart": {
                "remoteStartDuration": 10,
                "remoteStartTime": 0,
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09"
            },
            "remoteStartStatus": {
                "status": "CURRENT",
                "timestamp": "08-24-2022 06:29:09",
                "value": 0
            },
            "serverTime": "08-24-2022 06:31:06",
            "tirePressure": {
                "timestamp": "12-20-2021 07:56:32",
                "value": "STATUS_GOOD"
            },
            "vin": "XXX",
            "windowPosition": {
                "driverWindowPosition": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:25:29",
                    "value": "Fully closed position"
                },
                "passWindowPosition": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:25:29",
                    "value": "Fully closed position"
                },
                "rearDriverWindowPos": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:25:29",
                    "value": "Undefined window position"
                },
                "rearPassWindowPos": {
                    "status": "CURRENT",
                    "timestamp": "08-24-2022 06:25:29",
                    "value": "Fully closed position"
                }
            }
        },
        "version": "3.0.0"
    }