### PR TITLE
Smart: fix status response mapping

### DIFF
--- a/vehicle/smart/provider.go
+++ b/vehicle/smart/provider.go
@@ -56,7 +56,7 @@ var _ api.ChargeState = (*Provider)(nil)
 func (v *Provider) Status() (api.ChargeStatus, error) {
 	res, err := v.statusG()
 
-	switch v := res.PreCond.Data.ChargingStatus.Value; v {
+	switch v := res.PreCond.Data.ChargingStatus.Status; v {
 	case 0:
 		return api.StatusC, err
 	case 1, 2:

--- a/vehicle/smart/provider.go
+++ b/vehicle/smart/provider.go
@@ -58,9 +58,11 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 
 	switch v := res.PreCond.Data.ChargingStatus.Status; v {
 	case 0:
-		return api.StatusC, err
-	case 1, 2:
-		return api.StatusB, err
+		if res.PreCond.Data.ChargingStatus.Value == 0 {
+			return api.StatusC, err
+		} else {
+			return api.StatusB, err
+		}
 	case 3:
 		return api.StatusA, err
 	default:

--- a/vehicle/smart/provider.go
+++ b/vehicle/smart/provider.go
@@ -58,11 +58,10 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 
 	switch v := res.PreCond.Data.ChargingStatus.Status; v {
 	case 0:
-		if res.PreCond.Data.ChargingStatus.Value == 0 {
+		if res.PreCond.Data.ChargingActive.Value {
 			return api.StatusC, err
-		} else {
-			return api.StatusB, err
 		}
+		return api.StatusB, err
 	case 3:
 		return api.StatusA, err
 	default:

--- a/vehicle/smart/types.go
+++ b/vehicle/smart/types.go
@@ -9,8 +9,8 @@ type StatusResponse struct {
 	PreCond struct {
 		Data struct {
 			ChargingPower  IntValue
-			ChargingActive ChargeValue
-			ChargingStatus ChargeValue
+			ChargingActive BoolValue
+			ChargingStatus IntValue
 		} `json:"data"`
 	}
 	ChargeOpt struct{}
@@ -26,8 +26,9 @@ type StatusResponse struct {
 	ErrorDescription string `json:"error_description"`
 }
 
-type ChargeValue struct {
+type BoolValue struct {
 	Status int
+	Value  bool
 	Ts     TimeSecs
 }
 

--- a/vehicle/smart/types.go
+++ b/vehicle/smart/types.go
@@ -8,8 +8,9 @@ import (
 type StatusResponse struct {
 	PreCond struct {
 		Data struct {
-			ChargingActive BoolValue
-			ChargingStatus IntValue
+			ChargingPower IntValue
+			ChargingActive ChargeValue
+			ChargingStatus ChargeValue
 		} `json:"data"`
 	}
 	ChargeOpt struct{}
@@ -25,9 +26,8 @@ type StatusResponse struct {
 	ErrorDescription string `json:"error_description"`
 }
 
-type BoolValue struct {
+type ChargeValue struct {
 	Status int
-	Value  bool
 	Ts     TimeSecs
 }
 

--- a/vehicle/smart/types.go
+++ b/vehicle/smart/types.go
@@ -8,7 +8,7 @@ import (
 type StatusResponse struct {
 	PreCond struct {
 		Data struct {
-			ChargingPower IntValue
+			ChargingPower  IntValue
 			ChargingActive ChargeValue
 			ChargingStatus ChargeValue
 		} `json:"data"`


### PR DESCRIPTION
Here is a part of status response for Smart cars 

```
"precond": {
            "data": {
                "chargingPower": {
                    "status": 0,
                    "ts": 1658560932,
                    "value": 0
                },
                "chargingactive": {
                    "status": 3,
                    "ts": 1658515516
                },
                "chargingstatus": {
                    "status": 3,
                    "ts": 1658863524
                },
            }
        },

```        
        PreCond.Data.ChargingStatus and ChargingActive have no Value field, so switch case in Status Provider call should be dependent on PreCond.Data.ChargingStatus.Status value
