### PR TITLE
Enable estimator by default

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -67,7 +67,7 @@ type PollConfig struct {
 // SoCConfig defines soc settings, estimation and update behaviour
 type SoCConfig struct {
 	Poll     PollConfig `mapstructure:"poll"`
-	Estimate bool       `mapstructure:"estimate"`
+	Estimate *bool      `mapstructure:"estimate"`
 	Min_     int        `mapstructure:"min"`    // TODO deprecated
 	Target_  int        `mapstructure:"target"` // TODO deprecated
 	min      int        // Default minimum SoC, guarded by mutex
@@ -820,7 +820,12 @@ func (lp *LoadPoint) setActiveVehicle(vehicle api.Vehicle) {
 	if lp.vehicle = vehicle; vehicle != nil {
 		lp.socUpdated = time.Time{}
 
-		lp.socEstimator = soc.NewEstimator(lp.log, lp.charger, vehicle, lp.SoC.Estimate)
+		// resolve optional config
+		var estimate bool
+		if lp.SoC.Estimate == nil || *lp.SoC.Estimate {
+			estimate = true
+		}
+		lp.socEstimator = soc.NewEstimator(lp.log, lp.charger, vehicle, estimate)
 
 		lp.publish("vehiclePresent", true)
 		lp.publish("vehicleTitle", lp.vehicle.Title())

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -100,7 +100,7 @@ loadpoints:
         interval: 60m
       min: 0 # immediately charge to 0% regardless of mode unless "off" (disabled)
       target: 100 # always charge to 100%
-      estimate: false # set true to interpolate between api updates
+      estimate: true # set false to disable interpolating between api updates (not recommended)
     phases: 3 # electrical connection (normal charger: default 3 for 3 phase, 1p3p charger: 0 for "auto" or 1/3 for fixed phases)
     enable: # pv mode enable behavior
       delay: 1m # threshold must be exceeded for this long


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/4220

Use

    soc:
      estimate: false

to override