### PR TITLE
Reset MinSoC Before Vehicle Change

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -817,6 +817,11 @@ func (lp *LoadPoint) setActiveVehicle(vehicle api.Vehicle) {
 	}
 	lp.log.INFO.Printf("vehicle updated: %s -> %s", from, to)
 
+	// reset minSoC before change
+	lp.Unlock()
+	lp.SetMinSoC(0)
+	lp.Lock()
+
 	if lp.vehicle = vehicle; vehicle != nil {
 		lp.socUpdated = time.Time{}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -817,9 +817,10 @@ func (lp *LoadPoint) setActiveVehicle(vehicle api.Vehicle) {
 	}
 	lp.log.INFO.Printf("vehicle updated: %s -> %s", from, to)
 
-	// reset minSoC before change
+	// reset minSoC and targetSoC before change
 	lp.Unlock()
 	lp.SetMinSoC(0)
+	lp.setTargetSoC(100)
 	lp.Lock()
 
 	if lp.vehicle = vehicle; vehicle != nil {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -818,10 +818,8 @@ func (lp *LoadPoint) setActiveVehicle(vehicle api.Vehicle) {
 	lp.log.INFO.Printf("vehicle updated: %s -> %s", from, to)
 
 	// reset minSoC and targetSoC before change
-	lp.Unlock()
-	lp.SetMinSoC(0)
-	lp.setTargetSoC(100)
-	lp.Lock()
+	lp.setMinSoC(0)
+	lp.setTargetSoC(0)
 
 	if lp.vehicle = vehicle; vehicle != nil {
 		lp.socUpdated = time.Time{}

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -56,6 +56,7 @@ func (lp *LoadPoint) GetTargetSoC() int {
 	return lp.SoC.target
 }
 
+// setTargetSoC sets loadpoint charge target soc (no mutex)
 func (lp *LoadPoint) setTargetSoC(soc int) {
 	lp.SoC.target = soc
 	lp.socTimer.SoC = soc
@@ -83,6 +84,12 @@ func (lp *LoadPoint) GetMinSoC() int {
 	return lp.SoC.min
 }
 
+// setMinSoC sets loadpoint charge min soc (no mutex)
+func (lp *LoadPoint) setMinSoC(soc int) {
+	lp.SoC.min = soc
+	lp.publish("minSoC", soc)
+}
+
 // SetMinSoC sets loadpoint charge minimum soc
 func (lp *LoadPoint) SetMinSoC(soc int) {
 	lp.Lock()
@@ -92,8 +99,7 @@ func (lp *LoadPoint) SetMinSoC(soc int) {
 
 	// apply immediately
 	if lp.SoC.min != soc {
-		lp.SoC.min = soc
-		lp.publish("minSoC", soc)
+		lp.setMinSoC(soc)
 		lp.requestUpdate()
 	}
 }

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -59,7 +59,10 @@ func (lp *LoadPoint) GetTargetSoC() int {
 // setTargetSoC sets loadpoint charge target soc (no mutex)
 func (lp *LoadPoint) setTargetSoC(soc int) {
 	lp.SoC.target = soc
-	lp.socTimer.SoC = soc
+	// test guard
+	if lp.socTimer != nil {
+		lp.socTimer.SoC = soc
+	}
 	lp.publish("targetSoC", soc)
 }
 


### PR DESCRIPTION
Currently MinSoC is not reset when changing vehicles. If a MinSoC is active and you switch to an unknown vehicle or a known vehicle without MinSoC configured the previous MinSoC will remain active.

With this change the MinSoC is always reset before a vehicle change is performed.