### PR TITLE
Ocpp: fix chargepoint registration and startup

### DIFF
--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -8,8 +8,8 @@ import (
 
 // cs actions
 
-func (cs *CS) TriggerResetRequest(cp *CP, resetType core.ResetType) {
-	if err := cs.Reset(cp.id, func(request *core.ResetConfirmation, err error) {
+func (cs *CS) TriggerResetRequest(id string, resetType core.ResetType) {
+	if err := cs.Reset(id, func(request *core.ResetConfirmation, err error) {
 		log := cs.log.TRACE
 		if err == nil && request != nil && request.Status != core.ResetStatusAccepted {
 			log = cs.log.ERROR
@@ -20,14 +20,14 @@ func (cs *CS) TriggerResetRequest(cp *CP, resetType core.ResetType) {
 			status = request.Status
 		}
 
-		log.Printf("TriggerReset for %s: %+v", cp.id, status)
+		log.Printf("TriggerReset for %s: %+v", id, status)
 	}, resetType); err != nil {
-		cs.log.ERROR.Printf("send TriggerReset for %s failed: %v", cp.id, err)
+		cs.log.ERROR.Printf("send TriggerReset for %s failed: %v", id, err)
 	}
 }
 
-func (cs *CS) TriggerMeterValuesRequest(cp *CP) {
-	if err := cs.TriggerMessage(cp.id, func(request *remotetrigger.TriggerMessageConfirmation, err error) {
+func (cs *CS) TriggerMessageRequest(id string, requestedMessage remotetrigger.MessageTrigger) {
+	if err := cs.TriggerMessage(id, func(request *remotetrigger.TriggerMessageConfirmation, err error) {
 		log := cs.log.TRACE
 		if err == nil && request != nil && request.Status != remotetrigger.TriggerMessageStatusAccepted {
 			log = cs.log.ERROR
@@ -38,16 +38,16 @@ func (cs *CS) TriggerMeterValuesRequest(cp *CP) {
 			status = request.Status
 		}
 
-		log.Printf("TriggerMessage %s for %s: %+v", core.MeterValuesFeatureName, cp.id, status)
-	}, core.MeterValuesFeatureName); err != nil {
-		cs.log.ERROR.Printf("send TriggerMessage for %s failed: %v", cp.id, err)
+		log.Printf("TriggerMessage %s for %s: %+v", requestedMessage, id, status)
+	}, requestedMessage); err != nil {
+		cs.log.ERROR.Printf("send TriggerMessage %s for %s failed: %v", requestedMessage, id, err)
 	}
 }
 
 // cp actions
 
-func (cs *CS) OnAuthorize(chargePointId string, request *core.AuthorizeRequest) (*core.AuthorizeConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnAuthorize(id string, request *core.AuthorizeRequest) (*core.AuthorizeConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +55,8 @@ func (cs *CS) OnAuthorize(chargePointId string, request *core.AuthorizeRequest) 
 	return cp.Authorize(request)
 }
 
-func (cs *CS) OnBootNotification(chargePointId string, request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnBootNotification(id string, request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +64,8 @@ func (cs *CS) OnBootNotification(chargePointId string, request *core.BootNotific
 	return cp.BootNotification(request)
 }
 
-func (cs *CS) OnDataTransfer(chargePointId string, request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnDataTransfer(id string, request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +73,8 @@ func (cs *CS) OnDataTransfer(chargePointId string, request *core.DataTransferReq
 	return cp.DataTransfer(request)
 }
 
-func (cs *CS) OnHeartbeat(chargePointId string, request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnHeartbeat(id string, request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (cs *CS) OnHeartbeat(chargePointId string, request *core.HeartbeatRequest) 
 	return cp.Heartbeat(request)
 }
 
-func (cs *CS) OnMeterValues(chargePointId string, request *core.MeterValuesRequest) (*core.MeterValuesConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnMeterValues(id string, request *core.MeterValuesRequest) (*core.MeterValuesConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +91,8 @@ func (cs *CS) OnMeterValues(chargePointId string, request *core.MeterValuesReque
 	return cp.MeterValues(request)
 }
 
-func (cs *CS) OnStatusNotification(chargePointId string, request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnStatusNotification(id string, request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +100,8 @@ func (cs *CS) OnStatusNotification(chargePointId string, request *core.StatusNot
 	return cp.StatusNotification(request)
 }
 
-func (cs *CS) OnStartTransaction(chargePointId string, request *core.StartTransactionRequest) (*core.StartTransactionConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnStartTransaction(id string, request *core.StartTransactionRequest) (*core.StartTransactionConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +109,8 @@ func (cs *CS) OnStartTransaction(chargePointId string, request *core.StartTransa
 	return cp.StartTransaction(request)
 }
 
-func (cs *CS) OnStopTransaction(chargePointId string, request *core.StopTransactionRequest) (*core.StopTransactionConfirmation, error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnStopTransaction(id string, request *core.StopTransactionRequest) (*core.StopTransactionConfirmation, error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -118,8 +118,8 @@ func (cs *CS) OnStopTransaction(chargePointId string, request *core.StopTransact
 	return cp.StopTransaction(request)
 }
 
-func (cs *CS) OnDiagnosticsStatusNotification(chargePointId string, request *firmware.DiagnosticsStatusNotificationRequest) (confirmation *firmware.DiagnosticsStatusNotificationConfirmation, err error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnDiagnosticsStatusNotification(id string, request *firmware.DiagnosticsStatusNotificationRequest) (confirmation *firmware.DiagnosticsStatusNotificationConfirmation, err error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +127,8 @@ func (cs *CS) OnDiagnosticsStatusNotification(chargePointId string, request *fir
 	return cp.DiagnosticStatusNotification(request)
 }
 
-func (cs *CS) OnFirmwareStatusNotification(chargePointId string, request *firmware.FirmwareStatusNotificationRequest) (confirmation *firmware.FirmwareStatusNotificationConfirmation, err error) {
-	cp, err := cs.chargepointByID(chargePointId)
+func (cs *CS) OnFirmwareStatusNotification(id string, request *firmware.FirmwareStatusNotificationRequest) (confirmation *firmware.FirmwareStatusNotificationConfirmation, err error) {
+	cp, err := cs.chargepointByID(id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ocpp/handler.go
+++ b/cmd/ocpp/handler.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+)
+
+type ChargePointHandler struct {
+	triggerC chan remotetrigger.MessageTrigger
+}
+
+func (handler *ChargePointHandler) OnChangeAvailability(request *core.ChangeAvailabilityRequest) (confirmation *core.ChangeAvailabilityConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewChangeAvailabilityConfirmation(core.AvailabilityStatusAccepted), nil
+}
+
+func (handler *ChargePointHandler) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusAccepted), nil
+}
+
+func (handler *ChargePointHandler) OnClearCache(request *core.ClearCacheRequest) (confirmation *core.ClearCacheConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewClearCacheConfirmation(core.ClearCacheStatusAccepted), nil
+}
+
+func (handler *ChargePointHandler) OnDataTransfer(request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewDataTransferConfirmation(core.DataTransferStatusAccepted), nil
+}
+
+func (handler *ChargePointHandler) OnGetConfiguration(request *core.GetConfigurationRequest) (confirmation *core.GetConfigurationConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	one := "1"
+	return core.NewGetConfigurationConfirmation([]core.ConfigurationKey{
+		{Key: "NumberOfConnectors", Value: &one},
+		{Key: "ChargeProfileMaxStackLevel", Value: &one},
+		{Key: "ChargingScheduleMaxPeriods", Value: &one},
+		{Key: "MaxChargingProfilesInstalled", Value: &one},
+		{Key: "ChargingScheduleAllowedChargingRateUnit", Value: &one},
+	}), nil
+}
+
+func (handler *ChargePointHandler) OnRemoteStartTransaction(request *core.RemoteStartTransactionRequest) (confirmation *core.RemoteStartTransactionConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewRemoteStartTransactionConfirmation(types.RemoteStartStopStatusAccepted), nil
+}
+
+func (handler *ChargePointHandler) OnRemoteStopTransaction(request *core.RemoteStopTransactionRequest) (confirmation *core.RemoteStopTransactionConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewRemoteStopTransactionConfirmation(types.RemoteStartStopStatusAccepted), nil
+}
+
+func (handler *ChargePointHandler) OnReset(request *core.ResetRequest) (confirmation *core.ResetConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewResetConfirmation(core.ResetStatusAccepted), nil
+}
+
+func (handler *ChargePointHandler) OnUnlockConnector(request *core.UnlockConnectorRequest) (confirmation *core.UnlockConnectorConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+	return core.NewUnlockConnectorConfirmation(core.UnlockStatusUnlocked), nil
+}
+
+func (handler *ChargePointHandler) OnTriggerMessage(request *remotetrigger.TriggerMessageRequest) (confirmation *remotetrigger.TriggerMessageConfirmation, err error) {
+	fmt.Printf("%T %+v\n", request, request)
+
+	if c := handler.triggerC; request != nil && c != nil {
+		select {
+		case c <- request.RequestedMessage:
+		default:
+		}
+	}
+
+	return remotetrigger.NewTriggerMessageConfirmation(remotetrigger.TriggerMessageStatusAccepted), nil
+}

--- a/cmd/ocpp/main.go
+++ b/cmd/ocpp/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	ocpp16 "github.com/lorenzodonini/ocpp-go/ocpp1.6"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+)
+
+const (
+	chargePointId = "cp0001"
+	url           = "ws://localhost:8887"
+)
+
+func main() {
+	chargePoint := ocpp16.NewChargePoint(chargePointId, nil, nil)
+
+	// Set a handler for all callback functions
+	handler := &ChargePointHandler{triggerC: make(chan remotetrigger.MessageTrigger, 1)}
+	chargePoint.SetCoreHandler(handler)
+	chargePoint.SetRemoteTriggerHandler(handler)
+
+	go func() {
+		for err := range chargePoint.Errors() {
+			fmt.Println(err)
+		}
+	}()
+
+	go func() {
+		for msg := range handler.triggerC {
+			fmt.Println("msg:", msg)
+			switch msg {
+			case core.StatusNotificationFeatureName:
+				if res, err := chargePoint.StatusNotification(1, core.NoError, core.ChargePointStatusAvailable); err != nil {
+					log.Println("StatusNotification:", err)
+				} else {
+					log.Println("StatusNotification:", res)
+				}
+
+			case core.MeterValuesFeatureName:
+				if _, err := chargePoint.MeterValues(1, []types.MeterValue{
+					{SampledValue: []types.SampledValue{
+						{Measurand: types.MeasurandPowerActiveImport, Value: "1000"},
+					}},
+				}); err != nil {
+					log.Println("MeterValues:", err)
+				}
+			}
+		}
+	}()
+
+	// Connects to central system
+	if err := chargePoint.Start(url); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("connected to central system at %v", url)
+	if res, err := chargePoint.BootNotification("model1", "vendor1"); err != nil {
+		log.Fatal("BootNotification", err)
+	} else {
+		log.Printf("status: %v, interval: %v", res.Status, res.Interval)
+	}
+
+	select {}
+}


### PR DESCRIPTION
This PR does:

- fix self-registering chargepoints (with empty `stationid`)
- requests initial status in case it's not sent by charging station
- move all log messages to either `ocpp` or `stationid` log areas
- replaces the problematic `sync.Cond` with simpler channels
- adds an ocpp test client