### PR TITLE
feat: add soc limit for bluelink

### DIFF
--- a/vehicle/bluelink/provider.go
+++ b/vehicle/bluelink/provider.go
@@ -176,9 +176,9 @@ func (v *Provider) TargetSoC() (float64, error) {
 	res, err := v.statusG()
 
 	if err == nil {
-		for _, targetSOC := range res.EvStatus.ReservChargeInfos.TargetSOClist {
+		for _, targetSOC := range res.EvStatus.ReservChargeInfos.TargetSocList {
 			if targetSOC.PlugType == plugTypeAC {
-				return float64(targetSOC.TargetSOClevel), nil
+				return float64(targetSOC.TargetSocLevel), nil
 			}
 		}
 	}

--- a/vehicle/bluelink/provider.go
+++ b/vehicle/bluelink/provider.go
@@ -168,3 +168,20 @@ func (v *Provider) Odometer() (float64, error) {
 	res, err := v.statusLG()
 	return res.ResMsg.VehicleStatusInfo.Odometer.Value, err
 }
+
+var _ api.SocLimiter = (*Provider)(nil)
+
+// TargetSoC implements the api.SocLimiter interface
+func (v *Provider) TargetSoC() (float64, error) {
+	res, err := v.statusG()
+
+	if err == nil {
+		for _, targetSOC := range res.EvStatus.ReservChargeInfos.TargetSOClist {
+			if targetSOC.PlugType == plugTypeAC {
+				return float64(targetSOC.TargetSOClevel), nil
+			}
+		}
+	}
+
+	return 0, err
+}

--- a/vehicle/bluelink/types.go
+++ b/vehicle/bluelink/types.go
@@ -38,8 +38,8 @@ type VehicleStatus struct {
 				Value, Unit int
 			}
 		}
-		DrvDistance []DrivingDistance
-		ReservChargeInfos ReservCharge
+		DrvDistance       []DrivingDistance
+		ReservChargeInfos ReservChargeInfo
 	}
 	Vehicles []Vehicle
 }
@@ -75,11 +75,11 @@ type DrivingDistance struct {
 	}
 }
 
-type ReservCharge struct {
-	TargetSOClist []TargetSOC
+type ReservChargeInfo struct {
+	TargetSocList []TargetSoc
 }
 
-type TargetSOC struct {
-	TargetSOClevel int
-	PlugType int
+type TargetSoc struct {
+	TargetSocLevel int
+	PlugType       int
 }

--- a/vehicle/bluelink/types.go
+++ b/vehicle/bluelink/types.go
@@ -39,6 +39,7 @@ type VehicleStatus struct {
 			}
 		}
 		DrvDistance []DrivingDistance
+		ReservChargeInfos ReservCharge
 	}
 	Vehicles []Vehicle
 }
@@ -58,6 +59,8 @@ type Odometer struct {
 const (
 	timeFormat = "20060102150405 -0700" // Note: must add timeOffset
 	timeOffset = " +0100"
+
+	plugTypeAC = 1
 )
 
 func (d *VehicleStatus) Updated() (time.Time, error) {
@@ -70,4 +73,13 @@ type DrivingDistance struct {
 			Value int
 		}
 	}
+}
+
+type ReservCharge struct {
+	TargetSOClist []TargetSOC
+}
+
+type TargetSOC struct {
+	TargetSOClevel int
+	PlugType int
 }


### PR DESCRIPTION
SoC limit for visualization for Bluelink vehicles (Kia and Hyundai)

See #4245, which introduced this feature for Tesla vehicles only