### PR TITLE
bugfix: segfault when dereferencing null pointer in OpenEVSE implementation

### DIFF
--- a/charger/openevse.go
+++ b/charger/openevse.go
@@ -195,7 +195,7 @@ func (c *OpenEVSE) Enabled() (bool, error) {
 		}
 	}
 
-	return false, fmt.Errorf("unknown EVSE state: %s", *overrideResp.JSON200.State)
+	return false, fmt.Errorf("unknown EVSE state")
 }
 
 // Enable implements the api.Charger interface

--- a/charger/openevse.go
+++ b/charger/openevse.go
@@ -187,15 +187,17 @@ func (c *OpenEVSE) Enabled() (bool, error) {
 	}
 
 	if overrideResp.JSON200 != nil && overrideResp.JSON200.State != nil {
-		switch *overrideResp.JSON200.State {
+		switch state := *overrideResp.JSON200.State; state {
 		case "disabled":
 			return false, nil
 		case "enabled", "active":
 			return true, nil
+		default:
+			return false, fmt.Errorf("unknown EVSE state: %s", state)
 		}
 	}
 
-	return false, fmt.Errorf("unknown EVSE state")
+	return false, errors.New("invalid EVSE state")
 }
 
 // Enable implements the api.Charger interface


### PR DESCRIPTION
Only happens if the EVSE is not under manual override mode but it leads to a crash under that circumstance.