### PR TITLE
Telemetry: add plant id

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,6 +29,7 @@ type config struct {
 	Log          string
 	SponsorToken string
 	Telemetry    bool
+	Plant        string // telemetry plant id
 	Metrics      bool
 	Profile      bool
 	Levels       map[string]string

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -61,7 +61,7 @@ func configureEnvironment(conf config) (err error) {
 
 	// setup telemetry
 	if err == nil && conf.Telemetry {
-		err = telemetry.Create(sponsor.Token)
+		err = telemetry.Create(sponsor.Token, conf.Plant)
 	}
 
 	// setup mqtt client listener

--- a/util/telemetry/charging.go
+++ b/util/telemetry/charging.go
@@ -8,30 +8,42 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/evcc-io/evcc/util/sponsor"
+	"github.com/panta/machineid"
 )
+
+const api = "https://api.evcc.io"
 
 var (
-	api     = "https://api.evcc.io"
-	Enabled bool
+	Enabled    bool
+	instanceID string
 )
 
-func Create(token string) error {
+func Create(token, instance string) error {
 	if token == "" {
 		return errors.New("telemetry requires sponsorship")
 	}
 
 	Enabled = true
+	instanceID = instance
+
+	if mid, err := machineid.ProtectedID("evcc-api"); err == nil && instanceID == "" {
+		instanceID = mid
+	}
+
 	return nil
 }
 
 func UpdateChargeProgress(log *util.Logger, power, deltaCharged, deltaGreen float64) {
 	log.DEBUG.Printf("telemetry: charge: Δ%.0f/%.0fWh @ %.0fW", deltaGreen*1e3, deltaCharged*1e3, power)
 
-	data := ChargeProgress{
-		ChargePower:  power,
-		GreenPower:   power * deltaGreen / deltaCharged,
-		ChargeEnergy: deltaCharged,
-		GreenEnergy:  deltaGreen,
+	data := InstanceChargeProgress{
+		InstanceID: instanceID,
+		ChargeProgress: ChargeProgress{
+			ChargePower:  power,
+			GreenPower:   power * deltaGreen / deltaCharged,
+			ChargeEnergy: deltaCharged,
+			GreenEnergy:  deltaGreen,
+		},
 	}
 
 	uri := fmt.Sprintf("%s/v1/charge", api)

--- a/util/telemetry/types.go
+++ b/util/telemetry/types.go
@@ -1,5 +1,10 @@
 package telemetry
 
+type InstanceChargeProgress struct {
+	InstanceID string `json:"instanceId"`
+	ChargeProgress
+}
+
 type ChargeProgress struct {
 	ChargePower  float64 `json:"chargePower"`
 	GreenPower   float64 `json:"greenPower"`


### PR DESCRIPTION
This PR adds an instance id generated from machine-id. Can be overridden using:

    plant: your-unique-name-here

Refs https://github.com/evcc-io/evcc/discussions/4554#discussioncomment-3726901