### PR TITLE
Automate Hassio releases #5

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,6 +60,7 @@ jobs:
           push: true
           tags: |
             andig/evcc:nightly
+            andig/evcc:nightly-$(date +'%Y-%m-%d')
 
   apt:
     name: Publish APT nightly
@@ -110,7 +111,7 @@ jobs:
 
       - name: Update version
         run: |
-          sed -i -e s#\"version.*#\"version\":\ \"nightly-$(date +'%Y%m%d%H%M%S')\",# ./hassio/evcc-nightly/config.json
+          sed -i -e s#\"version.*#\"version\":\ \"nightly-$(date +'%Y-%m-%d')\",# ./hassio/evcc-nightly/config.json
 
       - name: Push
         run: |


### PR DESCRIPTION
Updated the Version for nightly to date and 
add additinal tag for hub.docker nightly
format:
`nightly-$(date +'%Y-%m-%d')`
`nightly-2022-09-27`