### PR TITLE
Fix patching go library asn1

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.18
-          cache: true
+          cache: false
         id: go
 
       - name: Patch ASN1
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.18
-          cache: true
+          cache: false
         id: go
 
       - name: Patch ASN1

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,7 +63,7 @@ jobs:
         id: go
 
       - name: Patch ASN1
-        run: make patch-asn1
+        run: sudo make patch-asn1
 
       - name: Test
         run: make test

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,7 +63,7 @@ jobs:
         id: go
 
       - name: Patch ASN1
-        run: sudo make patch-asn1
+        run: make patch-asn1
 
       - name: Test
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -137,4 +137,7 @@ patch-asn1:
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
-	ls $$(go env GOMODCACHE)/golang.org/x/
+	# also patch the downloaded mod
+CRYPTOMOD := $(sort $(dir $(wildcard $$(go env GOMODCACHE)/golang.org/x/crypto@*/)))
+	ls $(CRYPTOMOD)
+	cat $(CRYPTOMOD)/cryptobyte/asn1.go | grep -C 1 "out = true"

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,6 @@ soc:
 # patch asn1.go to allow Elli buggy certificates to be accepted with EEBUS
 patch-asn1:
 	# echo $$(go env GOROOT)
-	# cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
-	# patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
-	# cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
-	go mod vendor
-	cat vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
-	patch -N -t -d vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
-	cat vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
+	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
+	patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
+	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"

--- a/Makefile
+++ b/Makefile
@@ -132,12 +132,14 @@ soc:
 
 # patch asn1.go to allow Elli buggy certificates to be accepted with EEBUS
 patch-asn1:
-	# echo $$(go env GOROOT)
 	go mod download
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	# also patch the downloaded mod
-CRYPTOMOD := $(sort $(dir $(wildcard $$(go env GOMODCACHE)/golang.org/x/crypto@*/)))
-	ls $(CRYPTOMOD)
+	$(eval DIRS := $(shell ls -d $$(go env GOMODCACHE)/golang.org/x/crypto*))
+	# use the last directory as that should be the latest, there should be at least one
+	$(eval CRYPTOMOD := $(word $(words $(DIRS)), $(DIRS)))
+	cat $(CRYPTOMOD)/cryptobyte/asn1.go | grep -C 1 "out = true"
+	patch -N -t -d $(CRYPTOMOD)/cryptobyte -i $$(pwd)/patch/asn1.diff
 	cat $(CRYPTOMOD)/cryptobyte/asn1.go | grep -C 1 "out = true"

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,6 @@ patch-asn1:
 	echo $$DIRS ;\
 	CRYPTOMOD=$$DIRS ;\
 	cat $$CRYPTOMOD/cryptobyte/asn1.go | grep -C 1 "out = true" ;\
-	patch -N -t -d $$CRYPTOMOD/cryptobyte -i $$(pwd)/patch/asn1.diff ;\
+	sudo patch -N -t -d $$CRYPTOMOD/cryptobyte -i $$(pwd)/patch/asn1.diff ;\
 	cat $$CRYPTOMOD/cryptobyte/asn1.go | grep -C 1 "out = true" ;\
 	}

--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,4 @@ patch-asn1:
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
+	ls $$(go env GOMODCACHE)/golang.org/x/

--- a/Makefile
+++ b/Makefile
@@ -132,14 +132,15 @@ soc:
 
 # patch asn1.go to allow Elli buggy certificates to be accepted with EEBUS
 patch-asn1:
-	go mod download
-	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
-	patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
-	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
-	# also patch the downloaded mod
-	$(eval DIRS := $(shell ls -d $$(go env GOMODCACHE)/golang.org/x/crypto*))
-	# use the last directory as that should be the latest, there should be at least one
-	$(eval CRYPTOMOD := $(word $(words $(DIRS)), $(DIRS)))
-	cat $(CRYPTOMOD)/cryptobyte/asn1.go | grep -C 1 "out = true"
-	patch -N -t -d $(CRYPTOMOD)/cryptobyte -i $$(pwd)/patch/asn1.diff
-	cat $(CRYPTOMOD)/cryptobyte/asn1.go | grep -C 1 "out = true"
+	{ \
+	go mod download ;\
+	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true" ;\
+	patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff ;\
+	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true" ;\
+	DIRS=$$(ls -d $$(go env GOMODCACHE)/golang.org/x/crypto* | sort -r | head -n 1) ;\
+	echo $$DIRS ;\
+	CRYPTOMOD=$$DIRS ;\
+	cat $$CRYPTOMOD/cryptobyte/asn1.go | grep -C 1 "out = true" ;\
+	patch -N -t -d $$CRYPTOMOD/cryptobyte -i $$(pwd)/patch/asn1.diff ;\
+	cat $$CRYPTOMOD/cryptobyte/asn1.go | grep -C 1 "out = true" ;\
+	}

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ soc:
 # patch asn1.go to allow Elli buggy certificates to be accepted with EEBUS
 patch-asn1:
 	# echo $$(go env GOROOT)
+	go mod download
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	patch -N -t -d $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $$(pwd)/patch/asn1.diff
 	cat $$(go env GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"


### PR DESCRIPTION
- this hopefully fixes patching reliably
- don’t enable caching for `setup-go` actions in `build` and `test` jobs
- this makes sure that the env `GOMODCACHE` is not set and not available leaving only the default shipping code to be available and used
- tested by using the modified Makefile and test running it on the `test` job, which fails with the cache enabled and succeeds with the cache disabled