### PR TITLE
Attempt to make the asn1 patch work in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN go mod download
 
 # prepare
 COPY . .
-RUN make patch-asn1
+RUN make patch-asn1-docker
 RUN make assets
 
 # copy ui

--- a/Makefile
+++ b/Makefile
@@ -135,3 +135,9 @@ patch-asn1::
 	cat $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	sudo patch -N -t -d $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $(CURRDIR)/patch/asn1.diff
 	cat $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
+
+patch-asn1-docker::
+	# echo $(GOROOT)
+	cat $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
+	patch -N -t -d $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $(CURRDIR)/patch/asn1.diff
+	cat $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"


### PR DESCRIPTION
Assumption is that there is write access without sudo, as running `sudo patch …` causes the following error:
```
#26 0.112 sudo patch -N -t -d /usr/local/go/src/vendor/golang.org/x/crypto/cryptobyte -i /build/patch/asn1.diff
289
#26 0.112 make: sudo: No such file or directory
```