### PR TITLE
Rename patch targets

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -44,7 +44,7 @@ jobs:
         id: go
 
       - name: Patch ASN1
-        run: make patch-asn1
+        run: make patch-asn1-sudo
 
       - name: Build
         run: make build
@@ -63,7 +63,7 @@ jobs:
         id: go
 
       - name: Patch ASN1
-        run: make patch-asn1
+        run: make patch-asn1-sudo
 
       - name: Test
         run: make test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
         run: pip install --upgrade cloudsmith-cli
 
       - name: Patch ASN1
-        run: make patch-asn1
+        run: make patch-asn1-sudo
 
       - name: Create nightly build
         uses: goreleaser/goreleaser-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN go mod download
 
 # prepare
 COPY . .
-RUN make patch-asn1-docker
+RUN make patch-asn1
 RUN make assets
 
 # copy ui

--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,13 @@ soc::
 	go build $(BUILD_TAGS) $(BUILD_ARGS) github.com/evcc-io/evcc/cmd/soc
 
 # patch asn1.go to allow Elli buggy certificates to be accepted with EEBUS
-patch-asn1::
+patch-asn1-sudo::
 	# echo $(GOROOT)
 	cat $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	sudo patch -N -t -d $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $(CURRDIR)/patch/asn1.diff
 	cat $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 
-patch-asn1-docker::
+patch-asn1::
 	# echo $(GOROOT)
 	cat $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte/asn1.go | grep -C 1 "out = true"
 	patch -N -t -d $(GOROOT)/src/vendor/golang.org/x/crypto/cryptobyte -i $(CURRDIR)/patch/asn1.diff


### PR DESCRIPTION
Make the names more generic

- `patch-asn1` into `patch-asn1-sudo`
- `patch-asn1-docker` into `patch-asn`