### PR TITLE
Remove `)` from Content-Disposition header in session

### DIFF
--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -69,7 +69,7 @@ func jsonError(w http.ResponseWriter, status int, err error) {
 }
 
 func csvResult(w http.ResponseWriter, res any) {
-	w.Header()["Content-Disposition"] = []string{`attachment; filename="sessions.csv")`}
+	w.Header()["Content-Disposition"] = []string{`attachment; filename="sessions.csv"`}
 
 	if ww, ok := res.(api.CsvWriter); ok {
 		ww.WriteCsv(w)


### PR DESCRIPTION
Da hat sich ein `)` in den http Header eingeschlichen, der zu einem komischen Dateinamen führt.
![grafik](https://user-images.githubusercontent.com/4662023/194352560-09abc1e4-86c6-4803-ba95-cfbc24fadd5a.png)
