### PR TITLE
Add persistent settings

### DIFF
--- a/api/store/types.go
+++ b/api/store/types.go
@@ -1,0 +1,10 @@
+package store
+
+// Provider creates a Persister for given string key
+type Provider func(string) Store
+
+// Store can load and store data
+type Store interface {
+	Load(any) error
+	Save(any) error
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -75,7 +75,7 @@ func configureEnvironment(cmd *cobra.Command, conf config) (err error) {
 	}
 
 	// setup sponsorship
-	if conf.SponsorToken != "" {
+	if err == nil && conf.SponsorToken != "" {
 		err = sponsor.ConfigureSponsorship(conf.SponsorToken)
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/locale"
@@ -113,7 +114,17 @@ func configureEnvironment(cmd *cobra.Command, conf config) (err error) {
 
 // configureDatabase configures session database
 func configureDatabase(conf dbConfig) error {
-	return db.NewInstance(conf.Type, conf.Dsn)
+	err := db.NewInstance(conf.Type, conf.Dsn)
+	if err == nil {
+		if err = settings.Init(); err == nil {
+			shutdown.Register(func() {
+				if err := settings.Persist(); err != nil {
+					log.ERROR.Println("cannot save settings:", err)
+				}
+			})
+		}
+	}
+	return err
 }
 
 // configureInflux configures influx database

--- a/server/db/settings/setting.go
+++ b/server/db/settings/setting.go
@@ -1,0 +1,81 @@
+package settings
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/evcc-io/evcc/server/db"
+	"golang.org/x/exp/slices"
+)
+
+var ErrNotFound = errors.New("not found")
+
+// setting is a settings entry
+type setting struct {
+	Key   string `json:"key" gorm:"primarykey"`
+	Value string `json:"value"`
+}
+
+var settings []setting
+
+func Init() error {
+	err := db.Instance.AutoMigrate(new(setting))
+	if err == nil {
+		err = db.Instance.Find(&settings).Error
+	}
+	return err
+}
+
+func Persist() error {
+	if len(settings) == 0 {
+		// avoid "empty slice found"
+		return nil
+	}
+	return db.Instance.Save(settings).Error
+}
+
+func SetString(key string, val string) {
+	idx := slices.IndexFunc(settings, func(s setting) bool {
+		return s.Key == key
+	})
+
+	if idx < 0 {
+		settings = append(settings, setting{key, val})
+	} else {
+		settings[idx].Value = val
+	}
+}
+
+func SetInt(key string, val int64) {
+	SetString(key, strconv.FormatInt(val, 10))
+}
+
+func SetFloat(key string, val float64) {
+	SetString(key, strconv.FormatFloat(val, 'f', -1, 64))
+}
+
+func String(key string) (string, error) {
+	idx := slices.IndexFunc(settings, func(s setting) bool {
+		return s.Key == key
+	})
+	if idx < 0 {
+		return "", ErrNotFound
+	}
+	return settings[idx].Value, nil
+}
+
+func Int(key string) (int64, error) {
+	s, err := String(key)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
+func Float(key string) (float64, error) {
+	s, err := String(key)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseFloat(s, 64)
+}

--- a/server/db/settings/settings_test.go
+++ b/server/db/settings/settings_test.go
@@ -1,0 +1,32 @@
+package settings
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestString(t *testing.T) {
+	v := "foo"
+	SetString("string", v)
+	res, err := String("string")
+	assert.Nil(t, err)
+	assert.Equal(t, v, res)
+}
+
+func TestInt(t *testing.T) {
+	v := int64(math.MaxInt64)
+	SetInt("int64", v)
+	res, err := Int("int64")
+	assert.Nil(t, err)
+	assert.Equal(t, v, res)
+}
+
+func TestFloat(t *testing.T) {
+	v := 3.141
+	SetFloat("float64", v)
+	res, err := Float("float64")
+	assert.Nil(t, err)
+	assert.Equal(t, v, res)
+}

--- a/server/db/settings/store.go
+++ b/server/db/settings/store.go
@@ -1,0 +1,21 @@
+package settings
+
+import "github.com/evcc-io/evcc/api/store"
+
+type storer struct {
+	key string
+}
+
+var _ store.Store = (*storer)(nil)
+
+func NewStore(key string) store.Store {
+	return &storer{key: key}
+}
+
+func (s *storer) Load(res any) error {
+	return Json(s.key, &res)
+}
+
+func (s *storer) Save(val any) error {
+	return SetJson(s.key, val)
+}


### PR DESCRIPTION
This PR adds a simple interface for storing/retrieving settings from database. Settings provide additional abstractor over the plain `db.Instance`.

Settings are only saved when `settings.Persist()` is called. A corresponding shutdown hook is registered during setup.

`store.Provider` and `store.Store` provide abstraction for creating a store for a single value and load/save against that store. Using these, individual devices do not need to depend on the settings implementation. See https://github.com/evcc-io/evcc/pull/4838 for example usage.