### PR TITLE
Template updates

### DIFF
--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -11,9 +11,13 @@ requirements:
     de: |
       Dem Gerät muss eine feste IP Adresse zugewiesen sein (Manuell oder per DHCP).
 
+      Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
+
       Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
     en: |
       The device has to have a fix IP address (manuall or via DHCP).
+
+      The identification of a vehicle using the RFID card is not possible.
 
       The support is in beta state and problems can occur!
 params:

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -11,9 +11,13 @@ requirements:
     de: |
       Dem Gerät muss eine feste IP Adresse zugewiesen sein (Manuell oder per DHCP).
 
+      Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
+
       Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
     en: |
       The device has to have a fix IP address (manuall or via DHCP).
+
+      The identification of a vehicle using the RFID card is not possible.
 
       The support is in beta state and problems can occur!
 params:

--- a/templates/definition/devices-schema.json
+++ b/templates/definition/devices-schema.json
@@ -10,6 +10,12 @@
         "template": {
           "$": "#/definitions/Template"
         },
+        "covers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "products": {
           "type": "array",
           "items": {
@@ -19,8 +25,11 @@
         "group": {
           "$ref": "#/definitions/Groups"
         },
-        "guidedsetup": {
-          "$ref": "#/definitions/GuidedSetup"
+        "linked": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Linked"
+          }
         },
         "capabilities": {
           "type": "array",
@@ -58,7 +67,7 @@
       },
       "required": ["name"],
       "title": "Template"
-  },
+    },
     "Product": {
       "type": "object",
       "additionalProperties": false,
@@ -79,22 +88,6 @@
     "Groups": {
       "type": "string",
       "enum": ["generic", "switchsockets", "scooter", "sockets"]
-    },
-    "GuidedSetup": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "enable": {
-          "type": "boolean"
-        },
-        "linked": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Linked"
-          }
-        }
-      },
-      "required": ["enable"]
     },
     "Linked": {
       "type": "object",

--- a/templates/definition/meter/shelly-3em.yaml
+++ b/templates/definition/meter/shelly-3em.yaml
@@ -13,7 +13,7 @@ render: |
     source: http
     uri: http://{{ .host }}/status
     jq: .emeters | map(.power) | add
-  {{if eq .usage "grid" -}}
+  {{- if or (eq .usage "charge") (eq .usage "grid") }}
   energy:
     source: http
     uri: http://{{ .host }}/status

--- a/templates/definition/meter/siemens-7kt1665.yaml
+++ b/templates/definition/meter/siemens-7kt1665.yaml
@@ -1,0 +1,59 @@
+template: siemens
+products:
+  - brand: Siemens
+    description:
+      generic: 7KT1665
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery", "charge"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+render: |
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 57
+      type: input
+      decode: uint32
+    scale: 0.01
+    timeout: 5s
+  {{- if or (eq .usage "charge") (eq .usage "grid") }}
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 6687
+      type: input
+      decode: uint32
+    scale: 0.001
+    timeout: 5s
+  {{ end -}}
+  {{- if or (eq .usage "charge") (eq .usage "grid") }}
+  currents:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 7
+      type: input
+      decode: uint32
+    scale: 0.0001
+    timeout: 5s
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 9
+      type: input
+      decode: uint32
+    scale: 0.0001
+    timeout: 5s
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 11
+      type: input
+      decode: uint32
+    scale: 0.0001
+    timeout: 5s
+  {{ end -}}

--- a/templates/docs/charger/elliconnect_0.yaml
+++ b/templates/docs/charger/elliconnect_0.yaml
@@ -6,6 +6,8 @@ requirements: ["eebus"]
 description: |
   Dem Gerät muss eine feste IP Adresse zugewiesen sein (Manuell oder per DHCP).
 
+  Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
+
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
 render:

--- a/templates/docs/charger/ellipro_0.yaml
+++ b/templates/docs/charger/ellipro_0.yaml
@@ -6,6 +6,8 @@ requirements: ["eebus"]
 description: |
   Dem Gerät muss eine feste IP Adresse zugewiesen sein (Manuell oder per DHCP).
 
+  Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
+
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
 render:

--- a/templates/docs/meter/siemens_0.yaml
+++ b/templates/docs/meter/siemens_0.yaml
@@ -1,0 +1,100 @@
+product:
+  brand: Siemens
+  description: 7KT1665
+render:
+  - usage: grid
+    default: |
+      type: template
+      template: siemens
+      usage: grid      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+  - usage: pv
+    default: |
+      type: template
+      template: siemens
+      usage: pv      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+  - usage: battery
+    default: |
+      type: template
+      template: siemens
+      usage: battery      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+  - usage: charge
+    default: |
+      type: template
+      template: siemens
+      usage: charge      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port


### PR DESCRIPTION
- Updated Shelly 3EM template to provide energy when used as a charge meter
- Added Siemens 7KT1665 meter
  Details taken from https://github.com/evcc-io/evcc/discussions/4210#discussioncomment-3827786 and  https://github.com/evcc-io/evcc/discussions/4210#discussioncomment-3827841
  Output verified with `—expand` against example in first link
- Template schema updates
- Add info to Elli template that RFID cards can not be used to identify the vehicle