### PR TITLE
Refactor green share calculation

### DIFF
--- a/core/savings_test.go
+++ b/core/savings_test.go
@@ -39,55 +39,6 @@ type StubPublisher struct{}
 
 func (p StubPublisher) publish(key string, val interface{}) {}
 
-func TestSavingsWithChangingEnergySources(t *testing.T) {
-	p := StubPublisher{}
-
-	clck := clock.NewMock()
-	s := &Savings{
-		clock:   clck,
-		started: clck.Now(),
-		updated: clck.Now(),
-	}
-
-	tc := []struct {
-		title                     string
-		grid, pv, battery, charge float64
-		total, self, percentage   float64
-	}{
-		{"half grid, half pv",
-			2500, 2500, 0, 5000,
-			5, 2.5, 50},
-		{"full pv",
-			0, 5000, 0, 5000,
-			10, 7.5, 75},
-		{"full grid",
-			5000, 0, 0, 5000,
-			15, 7.5, 50},
-		{"half grid, half battery",
-			2500, 0, 2500, 5000,
-			20, 10, 50},
-		{"full pv, pv export",
-			-5000, 10000, 0, 5000,
-			25, 15, 60},
-		{"full pv, pv export, battery charge",
-			-2500, 10000, -2500, 5000,
-			30, 20, 66},
-		{"double charge speed, full grid",
-			10000, 0, 0, 10000,
-			40, 20, 50},
-	}
-
-	s.Update(p, 0, 0, 0, 0)
-
-	for _, tc := range tc {
-		t.Logf("%+v", tc)
-
-		clck.Add(time.Hour)
-		s.Update(p, tc.grid, tc.pv, tc.battery, tc.charge)
-		assertEnergy(t, s, tc.total, tc.self, tc.percentage)
-	}
-}
-
 func TestSavingsWithDifferentTimespans(t *testing.T) {
 	p := StubPublisher{}
 
@@ -99,8 +50,8 @@ func TestSavingsWithDifferentTimespans(t *testing.T) {
 	}
 
 	type tcStep = struct {
-		dt                        time.Duration
-		grid, pv, battery, charge float64
+		dt                 time.Duration
+		greenShare, charge float64
 	}
 
 	tc := []struct {
@@ -110,54 +61,54 @@ func TestSavingsWithDifferentTimespans(t *testing.T) {
 	}{
 		{"10 second not charging, full grid",
 			[]tcStep{
-				{10 * time.Second, 1000, 0, 0, 0},
+				{10 * time.Second, 0, 0},
 			},
 			0, 0, 0, // 0Wh
 		},
 		{"10 second 11kW charging, full grid",
 			[]tcStep{
-				{10 * time.Second, 0, 0, 0, 11000},
+				{10 * time.Second, 0, 11000},
 			},
 			0.030556, 0, 0, // 30,555Wh
 		},
 		{"10 second 11kW charging, full grid",
 			[]tcStep{
-				{10 * time.Second, 0, 0, 0, 11000},
+				{10 * time.Second, 0, 11000},
 			},
 			0.061111, 0, 0, // 61,111Wh
 		},
 		{"5x 2 second 11kW charging, full grid",
 			[]tcStep{
-				{2 * time.Second, 0, 0, 0, 11000},
-				{2 * time.Second, 0, 0, 0, 11000},
-				{2 * time.Second, 0, 0, 0, 11000},
-				{2 * time.Second, 0, 0, 0, 11000},
-				{2 * time.Second, 0, 0, 0, 11000},
+				{2 * time.Second, 0, 11000},
+				{2 * time.Second, 0, 11000},
+				{2 * time.Second, 0, 11000},
+				{2 * time.Second, 0, 11000},
+				{2 * time.Second, 0, 11000},
 			},
 			0.092, 0, 0, // 91,666Wh
 		},
 		{"30 min 11kW charging, full grid",
 			[]tcStep{
-				{30 * time.Minute, 0, 0, 0, 11000},
+				{30 * time.Minute, 0, 11000},
 			},
 			5.592, 0, 0, // 5561,111Wh
 		},
 		{"4 hours 11kW charging, full pv",
 			[]tcStep{
-				{4 * time.Hour, 0, 11000, 0, 11000},
+				{4 * time.Hour, 1, 11000},
 			},
 			49.592, 44, 88,
 		},
 	}
 
-	s.Update(p, 0, 0, 0, 0)
+	s.Update(p, 0, 0)
 
 	for _, tc := range tc {
 		t.Logf("%+v", tc)
 
 		for _, tc := range tc.steps {
 			clck.Add(tc.dt)
-			s.Update(p, tc.grid, tc.pv, tc.battery, tc.charge)
+			s.Update(p, tc.charge, tc.greenShare)
 		}
 
 		assertEnergy(t, s, tc.total, tc.self, tc.percentage)
@@ -170,8 +121,8 @@ func TestEffectiveEnergyPriceAndSavingsAmount(t *testing.T) {
 	clck := clock.NewMock()
 
 	type tcStep = struct {
-		dt                        time.Duration
-		grid, pv, battery, charge float64
+		dt                 time.Duration
+		greenShare, charge float64
 	}
 
 	tc := []struct {
@@ -181,26 +132,26 @@ func TestEffectiveEnergyPriceAndSavingsAmount(t *testing.T) {
 	}{
 		{"1 hour, 10kW, full grid",
 			[]tcStep{
-				{time.Hour, 10000, 0, 0, 10000},
+				{time.Hour, 0, 10000},
 			},
 			0.3, 0,
 		},
 		{"1 hour, 10kW, full pv",
 			[]tcStep{
-				{time.Hour, 0, 10000, 0, 10000},
+				{time.Hour, 1, 10000},
 			},
 			0.08, 2.2,
 		},
 		{"1 hour, 10kW, full battery",
 			[]tcStep{
-				{time.Hour, 0, 0, 10000, 10000},
+				{time.Hour, 1, 10000},
 			},
 			0.08, 2.2,
 		},
 
 		{"1 hour, 10kW, half grid, half pv",
 			[]tcStep{
-				{time.Hour, 5000, 0, 5000, 10000},
+				{time.Hour, 0.5, 10000},
 			},
 			0.19, 1.1,
 		},
@@ -214,11 +165,11 @@ func TestEffectiveEnergyPriceAndSavingsAmount(t *testing.T) {
 			started: clck.Now(),
 			updated: clck.Now(),
 		}
-		s.Update(p, 0, 0, 0, 0)
+		s.Update(p, 0, 0)
 
 		for _, tc := range tc.steps {
 			clck.Add(tc.dt)
-			s.Update(p, tc.grid, tc.pv, tc.battery, tc.charge)
+			s.Update(p, tc.charge, tc.greenShare)
 		}
 
 		assertPrices(t, s, tc.effectivePrice, tc.savingsAmount)

--- a/core/site_test.go
+++ b/core/site_test.go
@@ -30,3 +30,48 @@ func TestSitePower(t *testing.T) {
 		}
 	}
 }
+
+func TestGreenShare(t *testing.T) {
+	tc := []struct {
+		title             string
+		grid, pv, battery float64
+		share             float64
+	}{
+		{"half grid, half pv",
+			2500, 2500, 0,
+			0.5},
+		{"full pv",
+			0, 5000, 0,
+			1},
+		{"full grid",
+			5000, 0, 0,
+			0},
+		{"half grid, half battery",
+			2500, 0, 2500,
+			0.5},
+		{"full pv, pv export",
+			-5000, 10000, 0,
+			1},
+		{"full pv, pv export, battery charge",
+			-2500, 10000, -2500,
+			1},
+		{"double charge speed, full grid",
+			10000, 0, 0,
+			0},
+	}
+
+	for _, tc := range tc {
+		t.Logf("%+v", tc)
+
+		s := &Site{
+			gridPower:    tc.grid,
+			pvPower:      tc.pv,
+			batteryPower: tc.battery,
+		}
+
+		share := s.greenShare()
+		if share != tc.share {
+			t.Errorf("greenShare wanted %.f, got %.f", tc.share, share)
+		}
+	}
+}

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -36,14 +36,15 @@ func Create(token, machineID string) error {
 	return nil
 }
 
-func UpdateChargeProgress(log *util.Logger, power, deltaCharged, deltaGreen float64) {
+func UpdateChargeProgress(log *util.Logger, power, deltaCharged, greenShare float64) {
+	deltaGreen := deltaCharged * greenShare
 	log.DEBUG.Printf("telemetry: charge: Δ%.0f/%.0fWh @ %.0fW", deltaGreen*1e3, deltaCharged*1e3, power)
 
 	data := InstanceChargeProgress{
 		InstanceID: instanceID,
 		ChargeProgress: ChargeProgress{
 			ChargePower:  power,
-			GreenPower:   power * deltaGreen / deltaCharged,
+			GreenPower:   power * greenShare,
 			ChargeEnergy: deltaCharged,
 			GreenEnergy:  deltaGreen,
 		},


### PR DESCRIPTION
- moved calculation from `savings.go` to `site.go` to make result reusable in savings, telemetry and sessions (later)
- simplified tests
- publish `greenShare` value
  - `0` means currently no self-produced energy used
  - `1` means all usage is covered by pv or battery