### PR TITLE
Fix Siemens 7KT1665 template name

### DIFF
--- a/templates/definition/meter/siemens-7kt1665.yaml
+++ b/templates/definition/meter/siemens-7kt1665.yaml
@@ -1,4 +1,4 @@
-template: siemens
+template: siemens-7kt1665
 products:
   - brand: Siemens
     description:

--- a/templates/docs/meter/siemens-7kt1665_0.yaml
+++ b/templates/docs/meter/siemens-7kt1665_0.yaml
@@ -5,7 +5,7 @@ render:
   - usage: grid
     default: |
       type: template
-      template: siemens
+      template: siemens-7kt1665
       usage: grid      
 
       # RS485 via adapter (Modbus RTU)
@@ -29,7 +29,7 @@ render:
   - usage: pv
     default: |
       type: template
-      template: siemens
+      template: siemens-7kt1665
       usage: pv      
 
       # RS485 via adapter (Modbus RTU)
@@ -53,7 +53,7 @@ render:
   - usage: battery
     default: |
       type: template
-      template: siemens
+      template: siemens-7kt1665
       usage: battery      
 
       # RS485 via adapter (Modbus RTU)
@@ -77,7 +77,7 @@ render:
   - usage: charge
     default: |
       type: template
-      template: siemens
+      template: siemens-7kt1665
       usage: charge      
 
       # RS485 via adapter (Modbus RTU)


### PR DESCRIPTION
Das wäre jetzt analog zum `siemens-pac2200`