### PR TITLE
Update handling of PV Systems in configure

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -119,6 +119,10 @@ Example Use Case: With SMA Home Manager, there can be a SMA Energy Meter used fo
 - `usage`: specifies a list of meter classes, the device can be used for. Possible values are `grid`, `pv`, `battery`, and `charger`
 - `modbus`: specifies that this device is accessed via modbus. It requires the `choice` property to have a list of possible interface values the device provides. These values can be `rs485` and `tcpip`. The command will use either to ask the appropriate questions and settings. The `render` section needs to include the string `{{include "modbus" .}}` in all places where the configuration needs modbus settings.
 
+#### Usage Options
+
+- `allineone`: Defines if the different usages are all available in a single device. Enables `guidedsetup` mode.
+
 #### Modbus Options
 
 - `id`: Device specific default for modbus ID

--- a/templates/definition/common-schema.json
+++ b/templates/definition/common-schema.json
@@ -68,6 +68,9 @@
             "type": "string",
             "enum": ["charge", "grid", "pv", "battery"]
           }
+        },
+        "allinone": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -4,6 +4,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -9,6 +9,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
 render: |
   type: custom

--- a/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
 render: |

--- a/templates/definition/meter/kostal-piko.yaml
+++ b/templates/definition/meter/kostal-piko.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
 render: |
   type: custom

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -12,6 +12,7 @@ linked:
 params:
   - name: usage
     choice: ["pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
     id: 71

--- a/templates/definition/meter/lg-ess-home-8-10.yaml
+++ b/templates/definition/meter/lg-ess-home-8-10.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: registration
     required: true

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -5,6 +5,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: password
     mask: true

--- a/templates/definition/meter/powerdog.yaml
+++ b/templates/definition/meter/powerdog.yaml
@@ -5,6 +5,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
 render: |

--- a/templates/definition/meter/rct-power.yaml
+++ b/templates/definition/meter/rct-power.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
 render: |
   type: rct

--- a/templates/definition/meter/senec-home.yaml
+++ b/templates/definition/meter/senec-home.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
 render: |
   type: custom

--- a/templates/definition/meter/sma-datamanager.yaml
+++ b/templates/definition/meter/sma-datamanager.yaml
@@ -12,6 +12,7 @@ requirements:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -7,6 +7,7 @@ products:
 params:
   - name: usage
     choice: ["pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
     port: 502

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -10,6 +10,7 @@ requirements:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -7,6 +7,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
     id: 1

--- a/templates/definition/meter/solarlog.yaml
+++ b/templates/definition/meter/solarlog.yaml
@@ -13,6 +13,7 @@ requirements:
 params:
   - name: usage
     choice: ["grid", "pv"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
     id: 1

--- a/templates/definition/meter/solarwatt-myreserve-matrix.yaml
+++ b/templates/definition/meter/solarwatt-myreserve-matrix.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 8080

--- a/templates/definition/meter/solarwatt.yaml
+++ b/templates/definition/meter/solarwatt.yaml
@@ -10,6 +10,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
 render: |
   type: custom

--- a/templates/definition/meter/solax-hybrid-cloud.yaml
+++ b/templates/definition/meter/solax-hybrid-cloud.yaml
@@ -17,6 +17,7 @@ requirements:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: tokenid
     required: true
     description:

--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -10,6 +10,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
     baudrate: 19200

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -7,6 +7,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 8080

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -11,6 +11,7 @@ requirements:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
     baudrate: 9600

--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -10,6 +10,7 @@ requirements:
 params:
   - name: usage
     choice: ["grid", "pv"]
+    allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
     baudrate: 9600

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -8,6 +8,7 @@ group: generic
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
   - name: integer

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -7,6 +7,7 @@ group: generic
 params:
   - name: usage
     choice: ["grid", "pv"]
+    allinone: true
   - name: modbus
     choice: ["tcpip"]
   - name: integer

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: password
     required: true

--- a/templates/definition/meter/varta-energiespeicher-battery-only.yaml
+++ b/templates/definition/meter/varta-energiespeicher-battery-only.yaml
@@ -7,6 +7,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/templates/definition/meter/varta-energiespeicher.yaml
+++ b/templates/definition/meter/varta-energiespeicher.yaml
@@ -7,6 +7,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/templates/definition/meter/victron-energy.yaml
+++ b/templates/definition/meter/victron-energy.yaml
@@ -6,6 +6,7 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: host
   - name: port
     default: 502

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -27,7 +27,7 @@ type Template struct {
 // GuidedSetupEnabled returns true if there are linked templates or >1 usage
 func (t *Template) GuidedSetupEnabled() bool {
 	_, p := t.ParamByName(ParamUsage)
-	return len(t.Linked) > 0 || len(p.Choice) > 1
+	return len(t.Linked) > 0 || (len(p.Choice) > 1 && p.AllInOne)
 }
 
 // UpdateParamWithDefaults adds default values to specific param name entries

--- a/util/templates/template_types.go
+++ b/util/templates/template_types.go
@@ -189,6 +189,7 @@ type Param struct {
 	ValueType     string       // string representation of the value type, "string" is default
 	ValidValues   []string     // list of valid values the user can provide
 	Choice        []string     // defines a set of choices, e.g. "grid", "pv", "battery", "charge" for "usage"
+	AllInOne      bool         // defines if the defined usages can all be present in a single device
 	Requirements  Requirements // requirements for this param to be usable, only supported via ValueType "bool"
 
 	Baudrate int    // device specific default for modbus RS485 baudrate


### PR DESCRIPTION
- The configure intents to present devices that implement multiple usages in a single device or have linked templates and provide an easier step by step configuration experience e.g. by not asking for the same data for different usages over and over again
- Commit 880557594fab024eabd0d86bd70baa8d28cce207 changes this behaviour and now presents all devices that have multiple usages, e.g. meters that could be used as battery or pv meter
- This change introduces a new property `allineone` that should be used with the `usage` `param` the identify a device that implements multiple usages in the same device
- The filter to present these devices is extended by checking for this property