### PR TITLE
Add diffentiated log levels per area and simplify startup

### DIFF
--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -6,10 +6,7 @@ import (
 	"strings"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // chargerCmd represents the charger command
@@ -34,15 +31,10 @@ func init() {
 }
 
 func runCharger(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	// load config
 	if err := loadConfigFile(&conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	// setup environment
 	if err := configureEnvironment(cmd, conf); err != nil {

--- a/cmd/charger_ramp.go
+++ b/cmd/charger_ramp.go
@@ -7,10 +7,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // cmdEcho.AddCommand
@@ -68,15 +65,10 @@ func ramp(c api.Charger, digits int, delay time.Duration) {
 }
 
 func runChargerRamp(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	// load config
 	if err := loadConfigFile(&conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	// setup environment
 	if err := configureEnvironment(cmd, conf); err != nil {

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -9,10 +9,8 @@ import (
 	"text/template"
 
 	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // discussCmd represents the discuss command
@@ -37,12 +35,7 @@ func errorString(err error) string {
 }
 
 func runDiscuss(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	cfgErr := loadConfigFile(&conf)
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	file, pathErr := filepath.Abs(cfgFile)
 	if pathErr != nil {

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -11,9 +11,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/evcc-io/evcc/core"
 	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // dumpCmd represents the meter command
@@ -44,13 +42,8 @@ func handle(device any, err error) any {
 }
 
 func runDump(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	// load config
 	err := loadConfigFile(&conf)
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	// setup environment
 	if err == nil {

--- a/cmd/eebus.go
+++ b/cmd/eebus.go
@@ -8,9 +8,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	certhelper "github.com/evcc-io/eebus/cert"
 	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // teslaCmd represents the vehicle command
@@ -64,8 +62,5 @@ func generateEEBUSCert() {
 }
 
 func runEEBUSCert(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	generateEEBUSCert()
 }

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/tv42/httpunix"
 )
 
@@ -29,9 +27,6 @@ func init() {
 }
 
 func runHealth(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	u := &httpunix.Transport{
 		DialTimeout:           100 * time.Millisecond,
 		RequestTimeout:        1 * time.Second,

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -11,7 +11,26 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/cmd/shutdown"
+	"github.com/evcc-io/evcc/util"
+	"github.com/spf13/viper"
 )
+
+// logLevel parses --log area:level[,...] switch into levels per log area
+func logLevel() {
+	levels := viper.GetStringMapString("levels")
+
+	var level string
+	for _, kv := range strings.Split(viper.GetString("log"), ",") {
+		areaLevel := strings.SplitN(kv, ":", 2)
+		if len(areaLevel) == 1 {
+			level = areaLevel[0]
+		} else {
+			levels[areaLevel[0]] = areaLevel[1]
+		}
+	}
+
+	util.LogLevel(level, levels)
+}
 
 // unwrap converts a wrapped error into slice of strings
 func unwrap(err error) (res []string) {

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // meterCmd represents the meter command
@@ -23,15 +20,10 @@ func init() {
 }
 
 func runMeter(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	// load config
 	if err := loadConfigFile(&conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	// setup environment
 	if err := configureEnvironment(cmd, conf); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,10 @@ func initConfig() {
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
+
+	// print version
+	util.LogLevel("info", nil)
+	log.INFO.Printf("evcc %s", server.FormattedVersion())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -98,9 +102,6 @@ func publish(key string, val any) {
 }
 
 func runRoot(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
-
 	// load config and re-configure logging after reading config file
 	var err error
 	if cfgErr := loadConfigFile(&conf); errors.As(cfgErr, &viper.ConfigFileNotFoundError{}) {
@@ -109,8 +110,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 	} else {
 		err = cfgErr
 	}
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	// network config
 	if viper.GetString("uri") != "" {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -55,6 +55,10 @@ func loadConfigFile(conf *config) error {
 		}
 	}
 
+	if err == nil {
+		logLevel()
+	}
+
 	return err
 }
 

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 	"golang.org/x/oauth2"
 )
@@ -25,15 +22,11 @@ func init() {
 }
 
 func runToken(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
 
 	// load config
 	if err := loadConfigFile(&conf); err != nil {
 		log.FATAL.Fatal(err)
 	}
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	var vehicleConf qualifiedConfig
 	if len(conf.Vehicles) == 1 {

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -22,7 +22,6 @@ func init() {
 }
 
 func runToken(cmd *cobra.Command, args []string) {
-
 	// load config
 	if err := loadConfigFile(&conf); err != nil {
 		log.FATAL.Fatal(err)

--- a/cmd/vehicle.go
+++ b/cmd/vehicle.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/server"
-	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // vehicleCmd represents the vehicle command
@@ -26,15 +23,11 @@ func init() {
 }
 
 func runVehicle(cmd *cobra.Command, args []string) {
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
 
 	// load config
 	if err := loadConfigFile(&conf); err != nil {
 		fatal(err)
 	}
-
-	util.LogLevel(viper.GetString("log"), viper.GetStringMapString("levels"))
 
 	// setup environment
 	if err := configureEnvironment(cmd, conf); err != nil {

--- a/cmd/vehicle.go
+++ b/cmd/vehicle.go
@@ -23,7 +23,6 @@ func init() {
 }
 
 func runVehicle(cmd *cobra.Command, args []string) {
-
 	// load config
 	if err := loadConfigFile(&conf); err != nil {
 		fatal(err)


### PR DESCRIPTION
This PR allows specifying multiple log levels per area with a single command:

    --log trace,db:error