### PR TITLE
Ocpp: add quirks mode

### DIFF
--- a/core/wrapper/chargerater.go
+++ b/core/wrapper/chargerater.go
@@ -49,7 +49,7 @@ func (cr *ChargeRater) StartCharge(continued bool) {
 			cr.startEnergy = f
 			cr.log.DEBUG.Printf("charge start energy: %.3gkWh", f)
 		} else {
-			cr.log.ERROR.Printf("charge meter error %v", err)
+			cr.log.ERROR.Printf("charge meter: %v", err)
 		}
 	}
 


### PR DESCRIPTION
In quirks mode, we will **not** use `GetConfigurationKeys` which seems broken on many chargers according to https://github.com/evcc-io/evcc/discussions/3806#discussioncomment-3884592:

Instead, you can:

    type: ocpp
    quirks: true
    metervalues: Energy.Active.Import.Register,Power.Active.Import,Current.Import.L1,Current.Import.L2,Current.Import.L3

If `metervalues` is specified, we will assume a meter with given values is present.