### PR TITLE
Cli: hide diagnose output behind --diagnose switch

### DIFF
--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -26,6 +26,8 @@ func init() {
 	chargerCmd.Flags().BoolP(flagEnable, "e", false, strings.Title(flagEnable))
 	//lint:ignore SA1019 as Title is safe on ascii
 	chargerCmd.Flags().BoolP(flagDisable, "d", false, strings.Title(flagDisable))
+	//lint:ignore SA1019 as Title is safe on ascii
+	chargerCmd.Flags().Bool(flagDiagnose, false, strings.Title(flagDiagnose))
 	chargerCmd.Flags().BoolP(flagWakeup, "w", false, flagWakeupDescription)
 	chargerCmd.Flags().IntP(flagPhases, "p", 0, flagPhasesDescription)
 }
@@ -131,8 +133,13 @@ func runCharger(cmd *cobra.Command, args []string) {
 
 	if !flagUsed {
 		d := dumper{len: len(chargers)}
+		flag := cmd.Flags().Lookup(flagDiagnose).Changed
+
 		for name, v := range chargers {
 			d.DumpWithHeader(name, v)
+			if flag {
+				d.DumpDiagnosis(v)
+			}
 		}
 	}
 

--- a/cmd/dumper.go
+++ b/cmd/dumper.go
@@ -200,6 +200,12 @@ func (d *dumper) Dump(name string, v interface{}) {
 		}
 	}
 
+	w.Flush()
+}
+
+func (d *dumper) DumpDiagnosis(v interface{}) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+
 	if v, ok := v.(api.Diagnosis); ok {
 		fmt.Fprintln(w, "Diagnostic dump:")
 		v.Diagnose()

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -23,8 +23,9 @@ const (
 	flagPhases            = "phases"
 	flagPhasesDescription = "Set usable phases (1 or 3)"
 
-	flagEnable  = "enable"
-	flagDisable = "disable"
+	flagEnable   = "enable"
+	flagDisable  = "disable"
+	flagDiagnose = "diagnose"
 
 	flagWakeup            = "wakeup"
 	flagWakeupDescription = "Wake up"

--- a/cmd/vehicle.go
+++ b/cmd/vehicle.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/spf13/cobra"
@@ -20,6 +21,8 @@ func init() {
 	vehicleCmd.Flags().BoolP(flagStart, "a", false, flagStartDescription)
 	vehicleCmd.Flags().BoolP(flagStop, "o", false, flagStopDescription)
 	vehicleCmd.Flags().BoolP(flagWakeup, "w", false, flagWakeupDescription)
+	//lint:ignore SA1019 as Title is safe on ascii
+	vehicleCmd.Flags().Bool(flagDiagnose, false, strings.Title(flagDiagnose))
 }
 
 func runVehicle(cmd *cobra.Command, args []string) {
@@ -51,8 +54,6 @@ func runVehicle(cmd *cobra.Command, args []string) {
 		}
 		vehicles = map[string]api.Vehicle{name: vehicle}
 	}
-
-	d := dumper{len: len(vehicles)}
 
 	var flagUsed bool
 	for _, v := range vehicles {
@@ -94,8 +95,14 @@ func runVehicle(cmd *cobra.Command, args []string) {
 	}
 
 	if !flagUsed {
+		d := dumper{len: len(vehicles)}
+		flag := cmd.Flags().Lookup(flagDiagnose).Changed
+
 		for name, v := range vehicles {
 			d.DumpWithHeader(name, v)
+			if flag {
+				d.DumpDiagnosis(v)
+			}
 		}
 	}
 

--- a/vehicle/vw/provider.go
+++ b/vehicle/vw/provider.go
@@ -182,10 +182,10 @@ func (v *Provider) StopCharge() error {
 	return v.action(ActionCharge, ActionChargeStop)
 }
 
-// var _ api.Diagnosis = (*Provider)(nil)
+var _ api.Diagnosis = (*Provider)(nil)
 
 // Diagnose implements the api.Diagnosis interface
-func (v *Provider) Diagnose2() {
+func (v *Provider) Diagnose() {
 	rr, err := v.rr()
 	if err != nil {
 		return


### PR DESCRIPTION
Idee: im Normalfall werden nur die relevanten Details angezeigt, wenn man mehr will per switch