### PR TITLE
Remove url, uri, host, broker, id from redaction

### DIFF
--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -50,11 +50,11 @@ func unwrap(err error) (res []string) {
 // redact redacts a configuration string
 func redact(src string) string {
 	secrets := []string{
-		"url", "uri", "host", "broker", "mac", // infrastructure
+		"mac", // infrastructure
 		"sponsortoken", "plant", // global settings
 		"user", "password", "pin", // users
 		"token", "access", "refresh", // tokens
-		"ain", "id", "secret", "serial", "deviceid", "machineid", // devices
+		"ain", "secret", "serial", "deviceid", "machineid", // devices
 		"vin"} // vehicles
 	return regexp.
 		MustCompile(fmt.Sprintf(`\b(%s)\b.*?:.*`, strings.Join(secrets, "|"))).

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -50,7 +50,7 @@ func unwrap(err error) (res []string) {
 // redact redacts a configuration string
 func redact(src string) string {
 	secrets := []string{
-		"mac", // infrastructure
+		"mac",                   // infrastructure
 		"sponsortoken", "plant", // global settings
 		"user", "password", "pin", // users
 		"token", "access", "refresh", // tokens

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,8 +27,8 @@ func TestRedact(t *testing.T) {
 	token:
 		access: geheim
 		refresh: geheim
-	host: geheim
-	url: geheim
+	pin: geheim
+	mac: geheim
 	secret: geheim # comment
 	secret : geheim
 	`


### PR DESCRIPTION
This removes `url`, `uri`, `host`, `broker`, `id` from redaction
as it makes configs from users hard to read and otherwise does not seem to hide any sensible information.