### PR TITLE
Docker: use non-root evcc user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,16 +68,18 @@ RUN RELEASE=${RELEASE} GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build
 # STEP 3 build a small image including module support
 FROM alpine:3.15
 
-WORKDIR /app
+ENV TZ=Europe/Berlin 
+ARG EVCC_HOME=/var/lib/evcc
 
-ENV TZ=Europe/Berlin
-
+# Create user
+RUN adduser -D -h $EVCC_HOME evcc
+    
 # Import from builder
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/evcc /usr/local/bin/evcc
 
-COPY docker/bin/* /app/
+COPY docker/bin/* /bin/
 
 # UI and /api
 EXPOSE 7070/tcp
@@ -90,5 +92,7 @@ EXPOSE 9522/udp
 
 HEALTHCHECK --interval=60s --start-period=60s --timeout=30s --retries=3 CMD [ "evcc", "health" ]
 
-ENTRYPOINT [ "/app/entrypoint.sh" ]
+USER evcc
+
+ENTRYPOINT [ "/bin/entrypoint.sh" ]
 CMD [ "evcc" ]

--- a/charger/nrgble_linux.go
+++ b/charger/nrgble_linux.go
@@ -69,7 +69,7 @@ func NewNRGKickBLE(device, mac string, pin int) (*NRGKickBLE, error) {
 	btmgmt := hw.NewBtMgmt(ainfo.AdapterID)
 
 	if len(os.Getenv("DOCKER")) > 0 {
-		btmgmt.BinPath = "./docker-btmgmt"
+		btmgmt.BinPath = "/bin/docker-btmgmt"
 	}
 
 	err = btmgmt.SetPowered(false)

--- a/docker/bin/entrypoint.sh
+++ b/docker/bin/entrypoint.sh
@@ -23,7 +23,7 @@ if [ -f ${HASSIO_OPTIONSFILE} ]; then
         fi
     fi
 else
-    if [ "$1" == '"evcc"' ] || expr "$1" : '-*' > /dev/null; then
+    if [ "$1" != 'evcc' ]; then
         exec evcc "$@"
     else
         exec "$@"


### PR DESCRIPTION
@andig fixes #4850 
Was wurde getan:

- ENV TZ removed (sollte mMn beim run übergeben werden)
- Runtime user default auf evcc geändert (adduser ...)
- /evcc Ordner als WORKDIR (kanm dann auch in der Doku als Mountpoint für persistierende Dateien übernommen werden)
- Entrypoint in /bin 
- Auch docker-btmgmt in /bin (konnte aber nicht finden wofür das gut ist?)
- entrypoint ein wenig aufgeräumt. Es sei denn, dass was ich gelöscht hab, macht noch Sinn. Konnte es mir aber nicht erklären und aus Git-Log bin ich auch nicht schlau geworden

Refs https://github.com/evcc-io/evcc/pull/4901