### PR TITLE
Debian/Ubuntu: use non-root evcc user

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -73,6 +73,7 @@ nfpms:
         dst: /lib/systemd/system/evcc.service
 
     scripts:
+      preinstall: ./packaging/scripts/preinstall.sh
       postinstall: ./packaging/scripts/postinstall.sh
       preremove: ./packaging/scripts/preremove.sh
       postremove: ./packaging/scripts/postremove.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,7 @@ nfpms:
         dst: /lib/systemd/system/evcc.service
 
     scripts:
+      preinstall: ./packaging/scripts/preinstall.sh
       postinstall: ./packaging/scripts/postinstall.sh
       preremove: ./packaging/scripts/preremove.sh
       postremove: ./packaging/scripts/postremove.sh

--- a/packaging/init/evcc.service
+++ b/packaging/init/evcc.service
@@ -10,7 +10,7 @@ StartLimitIntervalSec=10
 StartLimitBurst=10
 
 [Service]
-ExecStart=/usr/bin/evcc
+ExecStart=/usr/bin/evcc --sqlite /var/lib/evcc/evcc.db
 Restart=always
 RestartSec=10
 

--- a/packaging/init/evcc.service
+++ b/packaging/init/evcc.service
@@ -14,5 +14,8 @@ ExecStart=/usr/bin/evcc
 Restart=always
 RestartSec=10
 
+User=evcc
+Group=evcc
+
 [Install]
 WantedBy=multi-user.target

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -4,6 +4,7 @@ set -e
 USER_CHOICE_CONFIG="/etc/evcc-userchoices.sh"
 ETC_SERVICE="/etc/systemd/system/evcc.service"
 USR_LOCAL_BIN="/usr/local/bin/evcc"
+RESTART_FLAG_FILE=/var/lib/evcc/.restartOnUpgrade
 
 # Usage: askUserKeepFile <file>
 # Return: 1 = keep, 0 = delete
@@ -88,7 +89,10 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
 	# Restart only if it was already started
 	if [ -d /run/systemd/system ]; then
 		systemctl --system daemon-reload >/dev/null || true
-		if [ -n "$2" ]; then
+		if [ -f $RESTART_FLAG_FILE ]; then
+			deb-systemd-invoke start evcc.service >/dev/null || true
+			rm $RESTART_FLAG_FILE
+		elif [ -n "$2" ]; then
 			deb-systemd-invoke try-restart evcc.service >/dev/null || true
 		else
 			deb-systemd-invoke start evcc.service >/dev/null || true

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -9,7 +9,7 @@ set -e
 
 EVCC_USER=evcc
 EVCC_GROUP=evcc
-EVCC_HOME=/var/lib/$EVCC_USER
+EVCC_HOME="/var/lib/$EVCC_USER"
 RESTART_FLAG_FILE=/var/lib/evcc/.restartOnUpgrade
 
 copyDbToUserDir() {
@@ -20,7 +20,8 @@ copyDbToUserDir() {
       deb-systemd-invoke stop evcc.service >/dev/null || true
       touch ${RESTART_FLAG_FILE}
     fi
-    /bin/cp -Rp /root/.evcc/evcc.db /var/lib/evcc/
+    /bin/cp -Rp /root/.evcc/evcc.db "$EVCC_HOME"
+    chown "$EVCC_USER:$EVCC_GROUP" "$EVCC_HOME/evcc.db"
   fi
   return 0
 }

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -31,7 +31,7 @@ if [ "$1" = "install" ] || [ "$1" = "upgrade" ]; then
       addgroup --system "$EVCC_GROUP" --quiet
     fi
     if ! getent passwd "$EVCC_USER" > /dev/null 2>&1 ; then
-      adduser --quiet --system --ingroup "$EVCC_GROUP" --no-create-home \
+      adduser --quiet --system --ingroup "$EVCC_GROUP" \
       --disabled-password --shell /bin/false \
       --gecos "evcc runtime user" --home "$EVCC_HOME" "$EVCC_USER"
     else

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -11,17 +11,17 @@ EVCC_USER=evcc
 EVCC_GROUP=evcc
 EVCC_HOME="/var/lib/$EVCC_USER"
 RESTART_FLAG_FILE=/var/lib/evcc/.restartOnUpgrade
+COPIED_FLAG=/root/.evcc/.copiedToEvccUser
 
 copyDbToUserDir() {
-  if [ -d /root/.evcc ] && [ ! -f /root/.evcc/.copiedToEvccUser ]; then
-    touch /var/lib/openhab2/.copiedToEvccUser
-
+  if [ -d /root/.evcc ] && [ ! -f $COPIED_FLAG ]; then
     if [ -d /run/systemd/system ] && /bin/systemctl status evcc.service > /dev/null 2>&1; then
       deb-systemd-invoke stop evcc.service >/dev/null || true
       touch ${RESTART_FLAG_FILE}
     fi
     /bin/cp -Rp /root/.evcc/evcc.db "$EVCC_HOME"
     chown "$EVCC_USER:$EVCC_GROUP" "$EVCC_HOME/evcc.db"
+    touch "$COPIED_FLAG"
   fi
   return 0
 }

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Executed before the installation of the new package
+#
+#   $1=install              : On installation
+#   $1=upgrade              : On upgrade
+
+set -e
+
+EVCC_USER=evcc
+EVCC_GROUP=evcc
+EVCC_HOME=/var/lib/$EVCC_USER
+RESTART_FLAG_FILE=/var/lib/evcc/.restartOnUpgrade
+
+copyDbToUserDir() {
+  if [ -d /root/.evcc ] && [ ! -f /root/.evcc/.copiedToEvccUser ]; then
+    touch /var/lib/openhab2/.copiedToEvccUser
+
+    if [ -d /run/systemd/system ] && /bin/systemctl status evcc.service > /dev/null 2>&1; then
+      deb-systemd-invoke stop evcc.service >/dev/null || true
+      touch ${RESTART_FLAG_FILE}
+    fi
+    /bin/cp -Rp /root/.evcc/evcc.db /var/lib/evcc/
+  fi
+  return 0
+}
+
+if [ "$1" = "install" ] || [ "$1" = "upgrade" ]; then
+    if ! getent group "$EVCC_GROUP" > /dev/null 2>&1 ; then
+      addgroup --system "$EVCC_GROUP" --quiet
+    fi
+    if ! getent passwd "$EVCC_USER" > /dev/null 2>&1 ; then
+      adduser --quiet --system --ingroup "$EVCC_GROUP" --no-create-home \
+      --disabled-password --shell /bin/false \
+      --gecos "evcc runtime user" --home "$EVCC_HOME" "$EVCC_USER"
+    else
+      homedir=$(getent passwd "$EVCC_USER" | cut -d: -f4)
+      if [ "$homedir" != "$EVCC_HOME" ]; then
+        process=$(pgrep -u "$EVCC_USER") || true
+        if [ -z "$process" ]; then
+          usermod -d "$EVCC_HOME" "$EVCC_USER"
+        else 
+          echo "Warning: evcc's home directory is incorrect ($homedir)"
+          echo "but can't be changed because another process ($process) is using it."
+        fi
+      fi
+    fi
+fi
+
+if [ "$1" = "upgrade" ]; then
+    copyDbToUserDir
+fi
+
+exit 0

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -10,18 +10,41 @@ set -e
 EVCC_USER=evcc
 EVCC_GROUP=evcc
 EVCC_HOME="/var/lib/$EVCC_USER"
-RESTART_FLAG_FILE=/var/lib/evcc/.restartOnUpgrade
-COPIED_FLAG=/root/.evcc/.copiedToEvccUser
+RESTART_FLAG_FILE=$EVCC_HOME/.restartOnUpgrade
 
 copyDbToUserDir() {
-  if [ -d /root/.evcc ] && [ ! -f $COPIED_FLAG ]; then
+  CURRENT_USER=$(systemctl show -pUser evcc | cut -d= -f2)
+  if [ -z "$CURRENT_USER" ]; then
+  	CURRENT_USER=root
+  fi
+  CURRENT_HOME=$(getent passwd "$CURRENT_USER" | cut -d: -f6)
+  COPIED_FLAG="$CURRENT_HOME/.evcc/.copiedToEvccUser"
+  if [ -f "$CURRENT_HOME/.evcc/evcc.db" ] && [ ! -f "$COPIED_FLAG" ]; then
     if [ -d /run/systemd/system ] && /bin/systemctl status evcc.service > /dev/null 2>&1; then
       deb-systemd-invoke stop evcc.service >/dev/null || true
-      touch ${RESTART_FLAG_FILE}
+      touch "$RESTART_FLAG_FILE"
     fi
-    /bin/cp -Rp /root/.evcc/evcc.db "$EVCC_HOME"
+    if [ -f "$EVCC_HOME/evcc.db" ]; then
+      echo "Not copying $CURRENT_HOME/.evcc/evcc.db to $EVCC_HOME/evcc.db, since there is already a database there"
+      echo "Either delete one of the databases or run 'touch $COPIED_FLAG' to keep both."
+      echo "then restart installation."
+      exit 1
+    else
+      cp -Rp "$CURRENT_HOME"/.evcc/evcc.db "$EVCC_HOME"
+    fi
     chown "$EVCC_USER:$EVCC_GROUP" "$EVCC_HOME/evcc.db"
     touch "$COPIED_FLAG"
+    if [ -n "$(ls -A /etc/systemd/system/evcc.service.d 2>/dev/null)" ]; then
+		echo "You have overrides defined in /etc/systemd/system/evcc.service.d."
+		echo "This update changes the evcc user to 'evcc' (from root) and the database file to '/var/lib/evcc/evcc.db"
+		echo "Make sure that you neither override 'User' nor 'ExecStart'"
+		echo "Hint: you can delete all overrides with 'systemctl revert evcc'"
+		echo "As a precaution, evcc is not started even if it was previously started."
+		rm -f "$RESTART_FLAG_FILE"
+	else
+		echo "NOTE: evcc user has changed from $CURRENT_USER to $EVCC_USER, db has been copied to new"
+		echo "directory $EVCC_HOME/evcc.db, old db in $CURRENT_USER/.evcc has been retained."
+    fi
   fi
   return 0
 }
@@ -37,12 +60,19 @@ if [ "$1" = "install" ] || [ "$1" = "upgrade" ]; then
     else
       homedir=$(getent passwd "$EVCC_USER" | cut -d: -f4)
       if [ "$homedir" != "$EVCC_HOME" ]; then
+      	mkdir -p "$EVCC_HOME"
+      	chown "$EVCC_USER:$EVCC_GROUP" "$EVCC_HOME"
         process=$(pgrep -u "$EVCC_USER") || true
         if [ -z "$process" ]; then
           usermod -d "$EVCC_HOME" "$EVCC_USER"
-        else 
+          if [ -f "$homedir/.evcc/evcc.db" ]; then
+          	cp "$homedir/.evcc/evcc.db" "$EVCC_HOME" && touch "$homedir/.evcc/.copiedToEvccUser"
+          fi
+        else
           echo "Warning: evcc's home directory is incorrect ($homedir)"
           echo "but can't be changed because another process ($process) is using it."
+          echo "Stop offending process(es), then restart installation"
+          exit 1
         fi
       fi
     fi


### PR DESCRIPTION
- include preinstall script that stops the service (with flag) and
  copies  over the database
- postinstall also recognizes restart flag in above case
- unit file uses evcc user

Fixes #4900

Refs https://github.com/evcc-io/evcc/pull/4878