### PR TITLE
Homamtic charger: Allow custom metering and switching channel

### DIFF
--- a/templates/definition/charger/homematic.yaml
+++ b/templates/definition/charger/homematic.yaml
@@ -14,6 +14,20 @@ params:
     help:
       en: Homematic device id like shown in the CCU web user interface.
       de: Homematic Geräte Id, wie im CCU Webfrontend angezeigt.
+  - name: meterchannel
+    required: false
+    default: 6
+    example: 6
+    description:
+      en: Homematic channel number of the metering channel like shown in the CCU web user interface.
+      de: Kanalnummer des Messwertkanals, wie im CCU Webfrontend angezeigt.
+  - name: switchchannel
+    required: false
+    default: 3
+    example: 3
+    description:
+      en: Homematic channel number of the switching actor like shown in the CCU web user interface.
+      de: Kanalnummer des Schaltaktors, wie im CCU Webfrontend angezeigt.
   - name: standbypower
     default: 15
   - name: user
@@ -25,8 +39,8 @@ render: |
   type: homematic
   uri: {{ .host }}:2010
   device: {{ .device }}
-  meterchannel: 6
-  switchchannel: 3
+  meterchannel: {{ .meterchannel }}
+  switchchannel: {{ .switchchannel }}
   standbypower: {{ .standbypower }}
   {{ if ne .user "" }}
   user: {{ .user }}

--- a/templates/docs/charger/homematic_0.yaml
+++ b/templates/docs/charger/homematic_0.yaml
@@ -7,6 +7,8 @@ render:
       template: homematic
       host: 192.0.2.2 # IP-Adresse oder Hostname
       device: '0001EE89AAD848' # Homematic Geräte Id, wie im CCU Webfrontend angezeigt.
+      meterchannel: 6 # Optional
+      switchchannel: 3 # Optional
       standbypower: 15 # Leistung oberhalb des angegebenen Wertes wird als Ladeleistung gewertet # Optional
       user: # Benutzerkonto (bspw. E-Mail Adresse, User Id, etc.) # Optional
       password: # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen) # Optional


### PR DESCRIPTION
Kleine Anpassung, so dass im Template des Homematic-Chargers auch alternative Mess-/Aktor-Kanäle mit angegeben werden können. Das ermöglicht z.B. die Nutzung der Homematic-Geräte HmIP-FSM und HmIP-FSM16, dies sind Unterputz-Entsprechungen zu den Zwischensteckern. Hier ist z.B. der Schaltkanal=2 sowie der Messkanal=5. Mit diesem erfolgreich ausprobiert.