### PR TITLE
OCPP: phase switching

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -440,7 +440,7 @@ func (c *OCPP) currents() (float64, float64, float64, error) {
 	return c.cp.Currents()
 }
 
-// // TODO: Phases1p3p implements the api.PhaseSwitcher interface
+// Phases1p3p implements the api.PhaseSwitcher interface
 func (c *OCPP) Phases1p3p(phases int) error {
 	if !c.phaseSwitching {
 		return fmt.Errorf("phase switching is not supported by the charger")
@@ -453,6 +453,7 @@ func (c *OCPP) Phases1p3p(phases int) error {
 }
 
 // // Identify implements the api.Identifier interface
+// Unless charger uses vehicle ID as idTag in authorize.req it is not possible to implement this in ocpp1.6
 // func (c *OCPP) Identify() (string, error) {
 // 	return "", errors.New("not implemented")
 // }

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -217,6 +217,8 @@ func NewOCPP(id string, connector int, idtag string, meterValues string, meterIn
 		c.meterValuesSample = meterValues
 	}
 
+	c.log.DEBUG.Printf("currently sampled meter values: %s \r\n", c.meterValuesSample)
+
 	// get initial meter values and configure sample rate
 	if c.hasMeasurement("Power.Active.Import") || c.hasMeasurement("Energy.Active.Import.Register") {
 		ocpp.Instance().TriggerMessageRequest(cp.ID(), core.MeterValuesFeatureName)

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -117,14 +117,11 @@ func NewOCPP(id string, connector int, idtag string, meterValues string, meterIn
 
 	c.log.DEBUG.Printf("waiting for chargepoint: %v", timeout)
 
-
-
 	select {
 	case <-time.After(timeout):
 		return nil, api.ErrTimeout
 	case <-cp.HasConnected():
 	}
-
 
 	// see who's there
 	// ocpp.Instance().TriggerMessageRequest(cp.ID(), core.BootNotificationFeatureName)

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -313,9 +313,6 @@ func (c *OCPP) Enable(enable bool) error {
 			rc <- err
 		}, c.idtag, func(request *core.RemoteStartTransactionRequest) {
 			request.ConnectorId = &c.connector
-
-			// TODO remove log
-			c.log.TRACE.Printf("Setting current %d and phases %d at the start of remote transaction", c.current, c.phases)
 			request.ChargingProfile = getTxChargingProfile(c.current, c.phases)
 		})
 	} else {
@@ -419,13 +416,12 @@ func (c *OCPP) currents() (float64, float64, float64, error) {
 
 // Phases1p3p implements the api.PhaseSwitcher interface
 func (c *OCPP) phases1p3p(phases int) error {
+	c.phases = phases
+
 	enabled, err := c.Enabled()
 	if err == nil && enabled {
-		c.phases = phases
-
-		// TODO remove log
-		c.log.TRACE.Printf("sending request to set current %f @ %dp", c.current, c.phases)
-
+		// NOTE: this will currently _never_ happen since
+		// loadpoint disabled the charger before switching
 		err = c.setPeriod(c.current, c.phases)
 	}
 

--- a/charger/ocpp_decorators.go
+++ b/charger/ocpp_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error), phaseSwitcher func(int) (error)) api.Charger {
+func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error), phaseSwitcher func(int) error) api.Charger {
 	switch {
 	case meter == nil && meterCurrent == nil && meterEnergy == nil && phaseSwitcher == nil:
 		return base
@@ -273,9 +273,9 @@ func (impl *decorateOCPPMeterEnergyImpl) TotalEnergy() (float64, error) {
 }
 
 type decorateOCPPPhaseSwitcherImpl struct {
-	phaseSwitcher func(int) (error)
+	phaseSwitcher func(int) error
 }
 
-func (impl *decorateOCPPPhaseSwitcherImpl) Phases1p3p(phases int) (error) {
+func (impl *decorateOCPPPhaseSwitcherImpl) Phases1p3p(phases int) error {
 	return impl.phaseSwitcher(phases)
 }

--- a/charger/ocpp_decorators.go
+++ b/charger/ocpp_decorators.go
@@ -6,12 +6,12 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error)) api.Charger {
+func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() (float64, error), meterCurrent func() (float64, float64, float64, error), phaseSwitcher func(int) (error)) api.Charger {
 	switch {
-	case meter == nil && meterCurrent == nil && meterEnergy == nil:
+	case meter == nil && meterCurrent == nil && meterEnergy == nil && phaseSwitcher == nil:
 		return base
 
-	case meter != nil && meterCurrent == nil && meterEnergy == nil:
+	case meter != nil && meterCurrent == nil && meterEnergy == nil && phaseSwitcher == nil:
 		return &struct {
 			*OCPP
 			api.Meter
@@ -22,7 +22,7 @@ func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() 
 			},
 		}
 
-	case meter == nil && meterCurrent == nil && meterEnergy != nil:
+	case meter == nil && meterCurrent == nil && meterEnergy != nil && phaseSwitcher == nil:
 		return &struct {
 			*OCPP
 			api.MeterEnergy
@@ -33,7 +33,7 @@ func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() 
 			},
 		}
 
-	case meter != nil && meterCurrent == nil && meterEnergy != nil:
+	case meter != nil && meterCurrent == nil && meterEnergy != nil && phaseSwitcher == nil:
 		return &struct {
 			*OCPP
 			api.Meter
@@ -48,7 +48,7 @@ func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() 
 			},
 		}
 
-	case meter == nil && meterCurrent != nil && meterEnergy == nil:
+	case meter == nil && meterCurrent != nil && meterEnergy == nil && phaseSwitcher == nil:
 		return &struct {
 			*OCPP
 			api.MeterCurrent
@@ -59,7 +59,7 @@ func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() 
 			},
 		}
 
-	case meter != nil && meterCurrent != nil && meterEnergy == nil:
+	case meter != nil && meterCurrent != nil && meterEnergy == nil && phaseSwitcher == nil:
 		return &struct {
 			*OCPP
 			api.Meter
@@ -74,7 +74,7 @@ func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() 
 			},
 		}
 
-	case meter == nil && meterCurrent != nil && meterEnergy != nil:
+	case meter == nil && meterCurrent != nil && meterEnergy != nil && phaseSwitcher == nil:
 		return &struct {
 			*OCPP
 			api.MeterCurrent
@@ -89,7 +89,7 @@ func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() 
 			},
 		}
 
-	case meter != nil && meterCurrent != nil && meterEnergy != nil:
+	case meter != nil && meterCurrent != nil && meterEnergy != nil && phaseSwitcher == nil:
 		return &struct {
 			*OCPP
 			api.Meter
@@ -105,6 +105,142 @@ func decorateOCPP(base *OCPP, meter func() (float64, error), meterEnergy func() 
 			},
 			MeterEnergy: &decorateOCPPMeterEnergyImpl{
 				meterEnergy: meterEnergy,
+			},
+		}
+
+	case meter == nil && meterCurrent == nil && meterEnergy == nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
+			},
+		}
+
+	case meter != nil && meterCurrent == nil && meterEnergy == nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.Meter
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			Meter: &decorateOCPPMeterImpl{
+				meter: meter,
+			},
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
+			},
+		}
+
+	case meter == nil && meterCurrent == nil && meterEnergy != nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.MeterEnergy
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			MeterEnergy: &decorateOCPPMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
+			},
+		}
+
+	case meter != nil && meterCurrent == nil && meterEnergy != nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.Meter
+			api.MeterEnergy
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			Meter: &decorateOCPPMeterImpl{
+				meter: meter,
+			},
+			MeterEnergy: &decorateOCPPMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
+			},
+		}
+
+	case meter == nil && meterCurrent != nil && meterEnergy == nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.MeterCurrent
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			MeterCurrent: &decorateOCPPMeterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
+			},
+		}
+
+	case meter != nil && meterCurrent != nil && meterEnergy == nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.Meter
+			api.MeterCurrent
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			Meter: &decorateOCPPMeterImpl{
+				meter: meter,
+			},
+			MeterCurrent: &decorateOCPPMeterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
+			},
+		}
+
+	case meter == nil && meterCurrent != nil && meterEnergy != nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.MeterCurrent
+			api.MeterEnergy
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			MeterCurrent: &decorateOCPPMeterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+			MeterEnergy: &decorateOCPPMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
+			},
+		}
+
+	case meter != nil && meterCurrent != nil && meterEnergy != nil && phaseSwitcher != nil:
+		return &struct {
+			*OCPP
+			api.Meter
+			api.MeterCurrent
+			api.MeterEnergy
+			api.PhaseSwitcher
+		}{
+			OCPP: base,
+			Meter: &decorateOCPPMeterImpl{
+				meter: meter,
+			},
+			MeterCurrent: &decorateOCPPMeterCurrentImpl{
+				meterCurrent: meterCurrent,
+			},
+			MeterEnergy: &decorateOCPPMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseSwitcher: &decorateOCPPPhaseSwitcherImpl{
+				phaseSwitcher: phaseSwitcher,
 			},
 		}
 	}
@@ -134,4 +270,12 @@ type decorateOCPPMeterEnergyImpl struct {
 
 func (impl *decorateOCPPMeterEnergyImpl) TotalEnergy() (float64, error) {
 	return impl.meterEnergy()
+}
+
+type decorateOCPPPhaseSwitcherImpl struct {
+	phaseSwitcher func(int) (error)
+}
+
+func (impl *decorateOCPPPhaseSwitcherImpl) Phases1p3p(phases int) (error) {
+	return impl.phaseSwitcher(phases)
 }


### PR DESCRIPTION
According to standard ChargePointMaxProfile is intended to change sum of current used by whole charge point, so it is not surprising that setProfile message containing phase configuration, despite being accepted, does nothing. Since charging is restarted every time phase is changed, I implemented the feature by injecting properly adjusted transaction profile during remote start. Profiles are properly layered too. I think comments are more than sufficient to explain details.