### PR TITLE
OCPP: alfen idtag plug-charge conveniance setting

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -32,6 +32,8 @@ type OCPP struct {
 	phaseSwitching    bool
 }
 
+const defaultIdTag = "evcc"
+
 func init() {
 	registry.Add("ocpp", NewOCPPFromConfig)
 }
@@ -50,7 +52,7 @@ func NewOCPPFromConfig(other map[string]interface{}) (api.Charger, error) {
 		Timeout       time.Duration
 	}{
 		Connector: 1,
-		IdTag:     "evcc",
+		IdTag:     defaultIdTag,
 		Timeout:   time.Minute,
 	}
 
@@ -194,8 +196,8 @@ func NewOCPP(id string, connector int, idtag string, meterValues string, meterIn
 						}
 
 					case ocpp.KeyAlfenPlugAndChargeIdentifier:
-						if c.idtag == "evcc" {
-							c.log.TRACE.Printf("alfen-specific conveniance - detected default idtag evcc so setting plug&charge identifier to the one read from config")
+						if c.idtag == defaultIdTag {
+							c.log.TRACE.Printf("alfen-specific conveniance - detected default idtag %s, setting plug&charge identifier to the one read from config", defaultIdTag)
 							c.idtag = *opt.Value
 						}
 					}

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -197,8 +197,8 @@ func NewOCPP(id string, connector int, idtag string, meterValues string, meterIn
 
 					case ocpp.KeyAlfenPlugAndChargeIdentifier:
 						if c.idtag == defaultIdTag {
-							c.log.TRACE.Printf("alfen-specific conveniance - detected default idtag %s, setting plug&charge identifier to the one read from config", defaultIdTag)
 							c.idtag = *opt.Value
+							c.log.DEBUG.Printf("overriding default `idTag` with Alfen-specific value: %s", c.idtag)
 						}
 					}
 

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -192,6 +192,12 @@ func NewOCPP(id string, connector int, idtag string, meterValues string, meterIn
 						if val, err = strconv.ParseBool(*opt.Value); err == nil {
 							c.phaseSwitching = val
 						}
+
+					case ocpp.KeyAlfenPlugAndChargeIdentifier:
+						if c.idtag == "evcc" {
+							c.log.TRACE.Printf("alfen-specific conveniance - detected default idtag evcc so setting plug&charge identifier to the one read from config")
+							c.idtag = *opt.Value
+						}
 					}
 
 					if err != nil {

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -27,6 +27,9 @@ const (
 	KeyChargingScheduleMaxPeriods              = "ChargingScheduleMaxPeriods"
 	KeyConnectorSwitch3to1PhaseSupported       = "ConnectorSwitch3to1PhaseSupported"
 	KeyMaxChargingProfilesInstalled            = "MaxChargingProfilesInstalled"
+
+	// Alfen specific keys
+	KeyAlfenPlugAndChargeIdentifier = "PlugAndChargeIdentifier"
 )
 
 type CP struct {


### PR DESCRIPTION
Alfen EVE chargers require idtag to be exactly Plug&Charge identifier to be able to work in this mode. If not properly set they don't allow remote start etc. So I made this this quick conveniance.