### PR TITLE
Generate and store instance ID if needed

### DIFF
--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -2,7 +2,6 @@ network:
   port: 7070
 
 log: debug
-plant: 683fd96cb7de8cf3080e1d79a12ffedd03d66d7c39be742350559817833ae6f7
 
 interval: 3s
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -93,9 +93,9 @@ func configureEnvironment(cmd *cobra.Command, conf config) (err error) {
 		err = configureDatabase(conf.Database)
 	}
 
-	// setup telemetry
 	if err == nil {
-		err = telemetry.Create(conf.Plant)
+		// setup telemetry
+		telemetry.Create(conf.Plant)
 	}
 
 	// deprecated: enable telemetry if its in the config

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -31,17 +31,25 @@ func Enable(enable bool) error {
 	return err
 }
 
-func Create(machineID string) error {
-	if machineID == "" {
-		var err error
-		if machineID, err = machine.ProtectedID("evcc-api"); err != nil {
-			return err
-		}
+func Create(machineID string) {
+	if machineID != "" {
+		instanceID = machineID
 	}
 
-	instanceID = machineID
+	// from settings
+	var err error
+	if instanceID, err = settings.String("telemetry.instanceId"); err == nil {
+		return
+	}
 
-	return nil
+	// from settings
+	if instanceID, err = machine.ProtectedID("evcc-api"); err == nil {
+		return
+	}
+
+	// generate and write to setting
+	instanceID = machine.RandomID()
+	settings.SetString("telemetry.instanceId", instanceID)
 }
 
 func UpdateChargeProgress(log *util.Logger, power, deltaCharged, deltaGreen float64) {

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -44,7 +44,7 @@ func Create(machineID string) {
 		return
 	}
 
-	// from settings
+	// from hardware
 	if instanceID, err = machine.ProtectedID("evcc-api"); err == nil {
 		return
 	}

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -32,6 +32,7 @@ func Enable(enable bool) error {
 }
 
 func Create(machineID string) {
+	// from config
 	if machineID != "" {
 		instanceID = machineID
 		return

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -34,6 +34,7 @@ func Enable(enable bool) error {
 func Create(machineID string) {
 	if machineID != "" {
 		instanceID = machineID
+		return
 	}
 
 	// from settings


### PR DESCRIPTION
Generate and persist an instance id if no hardware or config id is available.
Previously configured `plant` values will have priority.

fixes #5022