### PR TITLE
OCPP issues draft

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -124,7 +124,7 @@ func NewOCPP(id string, connector int, idtag string, meterValues string, meterIn
 		timeout:   timeout,
 	}
 
-	c.log.DEBUG.Printf("waiting for chargepoint: %v", timeout)
+	c.log.DEBUG.Printf("waiting for chargepoint connection: %v", timeout)
 
 	// wait for connection
 	select {
@@ -341,7 +341,7 @@ func (c *OCPP) Status() (api.ChargeStatus, error) {
 // Enabled implements the api.Charger interface
 func (c *OCPP) Enabled() (bool, error) {
 	c.log.TRACE.Printf("Enabled() called")
-	return (c.cp.HasTransaction() && c.cp.TransactionID() > 0), nil
+	return c.cp.Enabled()
 }
 
 // Enable implements the api.Charger interface

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -174,6 +174,10 @@ func (cp *CP) FinishTransaction() {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 
+	if cp.currentTransaction == nil {
+		return 
+	}
+
 	cp.currentTransaction.SetStatus(TransactionFinished)
 	cp.currentTransaction = nil
 }

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -152,7 +152,6 @@ func (cp *CP) Initialized(timeout time.Duration) bool {
 	// wait for status
 	select {
 	case <-cp.statusC:
-		cp.update()
 		return true
 	case <-time.After(timeout):
 		return false
@@ -209,6 +208,19 @@ func (cp *CP) GetTransactionStatus() TransactionState{
 		return TransactionUndefined
 	}
 	return cp.currentTransaction.Status()
+}
+
+func (cp *CP) Enabled() (bool, error) {
+	if !cp.HasTransaction() {
+		return false, nil
+	}
+
+	switch cp.GetTransactionStatus() {
+	case TransactionStarting, TransactionRunning, TransactionSuspended:
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 func (cp *CP) Status() (api.ChargeStatus, error) {

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -29,11 +29,16 @@ func (cp *CP) Authorize(request *core.AuthorizeRequest) (*core.AuthorizeConfirma
 func (cp *CP) BootNotification(request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
 	cp.log.TRACE.Printf("%T: %+v", request, request)
 
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
 	res := &core.BootNotificationConfirmation{
 		CurrentTime: types.NewDateTime(time.Now()),
 		Interval:    60, // TODO
 		Status:      core.RegistrationStatusAccepted,
 	}
+
+	close(cp.bootC)
 
 	return res, nil
 }

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	messageExpiry     = 30 * time.Second
+	// messageExpiry     = 30 * time.Second
 	transactionExpiry = time.Hour
 )
 
@@ -26,53 +26,10 @@ func (cp *CP) Authorize(request *core.AuthorizeRequest) (*core.AuthorizeConfirma
 	return res, nil
 }
 
-func (cp *CP) BootNotification(request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
-	cp.log.TRACE.Printf("%T: %+v", request, request)
-
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
-
-	// // required fields by spec
-	// cp.Details.Manufacturer = request.ChargePointVendor
-	// cp.Details.Model = request.ChargePointModel
-	//
-	// // optional fields by spec
-	// if request.ChargePointSerialNumber != "" {
-	// 	cp.Details.SerialNumber = request.ChargePointSerialNumber
-	// }
-	//
-	// if request.FirmwareVersion != "" {
-	// 	cp.Details.FirmwareVersion = request.FirmwareVersion
-	// }
-	// if request.Imsi != "" {
-	// 	cp.Details.Imsi = request.Imsi
-	// }
-	// if request.Iccid != "" {
-	// 	cp.Details.Iccid = request.Iccid
-	// }
-	//
-	// if request.MeterType != "" {
-	// 	cp.Details.MeterModel = request.MeterType
-	// }
-	// if request.MeterSerialNumber != "" {
-	// 	cp.Details.MeterSerialNumber = request.MeterSerialNumber
-	// }
-
-	res := &core.BootNotificationConfirmation{
-		CurrentTime: types.NewDateTime(time.Now()),
-		Interval:    60, // TODO
-		Status:      core.RegistrationStatusAccepted,
-	}
-
-	close(cp.bootC)
-
-	return res, nil
-}
-
 // timestampValid returns false if status timestamps are outdated
-func (cp *CP) timestampValid(t time.Time) bool {
+func (cp *CP) isStatusTimestampValid(t time.Time) bool {
 	// reject if expired
-	if time.Since(t) > messageExpiry {
+	if time.Since(t) > cp.timeout {
 		return false
 	}
 
@@ -85,78 +42,68 @@ func (cp *CP) timestampValid(t time.Time) bool {
 	return !t.Before(cp.status.Timestamp.Time)
 }
 
-func (cp *CP) StatusNotification(request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {
-	cp.log.TRACE.Printf("%T: %+v", request, request)
-
-	if request != nil {
-		cp.mu.Lock()
-		defer cp.mu.Unlock()
-
-		if cp.status == nil {
-			cp.status = request
-			close(cp.statusC) // signal initial status received
-		} else if request.Timestamp == nil || cp.timestampValid(request.Timestamp.Time) {
-			cp.status = request
-		} else {
-			cp.log.TRACE.Printf("ignoring status: %s < %s", request.Timestamp.Time, cp.status.Timestamp)
-		}
-	}
-
-	return new(core.StatusNotificationConfirmation), nil
-}
-
-func (cp *CP) DataTransfer(request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
-	cp.log.TRACE.Printf("%T: %+v", request, request)
-
-	res := &core.DataTransferConfirmation{
-		Status: core.DataTransferStatusRejected,
-	}
-
-	return res, nil
-}
-
 func (cp *CP) update() {
 	cp.mu.Lock()
 	cp.updated = time.Now()
 	cp.mu.Unlock()
 }
 
-func (cp *CP) Heartbeat(request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
-	cp.log.TRACE.Printf("%T: %+v", request, request)
-
-	cp.update()
-	res := &core.HeartbeatConfirmation{
-		CurrentTime: types.NewDateTime(time.Now()),
-	}
-
-	return res, nil
-}
-
-func (cp *CP) MeterValues(request *core.MeterValuesRequest) (*core.MeterValuesConfirmation, error) {
+func (cp *CP) BootNotification(request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
 	cp.log.TRACE.Printf("%T: %+v", request, request)
 
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 
-	for _, meterValue := range request.MeterValue {
-		// ignore old meter value requests
-		if meterValue.Timestamp.Time.After(cp.meterUpdated) {
-			for _, sample := range meterValue.SampledValue {
-				cp.measurements[getSampleKey(sample)] = sample
-				cp.meterUpdated = time.Now()
-			}
-		}
+	res := &core.BootNotificationConfirmation{
+		CurrentTime: types.NewDateTime(time.Now()),
+		Interval:    60, // TODO
+		Status:      core.RegistrationStatusAccepted,
 	}
 
-	return new(core.MeterValuesConfirmation), nil
+	// notify about boot event
+	close(cp.bootC)
+
+	return res, nil
 }
 
-func getSampleKey(s types.SampledValue) string {
-	if s.Phase != "" {
-		return string(s.Measurand) + "@" + string(s.Phase)
+func (cp *CP) StatusNotification(request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {
+	cp.log.TRACE.Printf("%T: %+v", request, request)
+
+	if request == nil { // is this really neccessary?
+		return nil, nil
 	}
 
-	return string(s.Measurand)
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	cp.updated = time.Now()
+
+ 	if request.Timestamp == nil || cp.isStatusTimestampValid(request.Timestamp.Time) {
+		if cp.status == nil {
+			close(cp.statusC) // signal initial status received
+		}
+
+		cp.status = request
+		cp.statusUpdated = time.Now()
+	} else {
+		cp.log.TRACE.Printf("ignoring status: %s < %s", request.Timestamp.Time, cp.status.Timestamp)
+	}
+
+	return new(core.StatusNotificationConfirmation), nil
+}
+
+func (cp *CP) Heartbeat(request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
+	cp.log.TRACE.Printf("%T: %+v", request, request)
+
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	cp.updated = time.Now()
+
+	res := &core.HeartbeatConfirmation{
+		CurrentTime: types.NewDateTime(time.Now()),
+	}
+
+	return res, nil
 }
 
 func (cp *CP) StartTransaction(request *core.StartTransactionRequest) (*core.StartTransactionConfirmation, error) {
@@ -169,6 +116,7 @@ func (cp *CP) StartTransaction(request *core.StartTransactionRequest) (*core.Sta
 		return nil, nil
 	}
 
+	// we have to respond to every CP request
 	res := &core.StartTransactionConfirmation{
 		IdTagInfo: &types.IdTagInfo{
 			Status: types.AuthorizationStatusAccepted, // accept
@@ -176,12 +124,22 @@ func (cp *CP) StartTransaction(request *core.StartTransactionRequest) (*core.Sta
 		TransactionId: 1, // default
 	}
 
-	if (time.Since(request.Timestamp.Time) < transactionExpiry) || // only respect transactions in the last hour, invalidate it
-	(cp.currentTransaction != nil && cp.GetTransactionStatus() != RequestedStart) { // we didnt start this transaction, invalidate it
-		cp.log.DEBUG.Printf("responded with authorization status blocked for unknown transaction")
-		res.IdTagInfo.Status = types.AuthorizationStatusConcurrentTx
-	} else { // create new transaction
-		res.TransactionId = cp.TransactionID()
+	// properly filling in transaction Id
+	if (cp.currentTransaction == nil) {
+		res.TransactionId = cp.lastTransactionId+1
+		cp.lastTransactionId = res.TransactionId
+	} else	{
+		res.TransactionId = cp.currentTransaction.Id
+		// no need to save lastTransactionId because NewTransaction always does that
+	}
+
+
+	if (time.Since(request.Timestamp.Time) < transactionExpiry) || // too old transaction request
+	(cp.currentTransaction != nil && cp.currentTransaction.Status() != TransactionStarting) { // we didnt start this transaction, invalidate it
+		cp.log.DEBUG.Printf("start transaction: defering transaction stop request and hope for the best")
+		defer Instance().RemoteStopTransaction(cp.ID(), func(resp *core.RemoteStopTransactionConfirmation, err error) {
+				cp.log.TRACE.Printf("%T: %+v", resp, resp)
+			}, res.TransactionId)
 	}
 
 	return res, nil
@@ -195,7 +153,7 @@ func (cp *CP) StopTransaction(request *core.StopTransactionRequest) (*core.StopT
 
 	// signal that transaction has ended
 	if cp.currentTransaction != nil {
-		if cp.currentTransaction.Status != Running || cp.currentTransaction.Status != Suspended {
+		if status := cp.currentTransaction.Status(); status != TransactionRunning || status != TransactionSuspended {
 			cp.log.ERROR.Printf("stop transaction: stopping not started transaction")
 		}
 
@@ -204,13 +162,27 @@ func (cp *CP) StopTransaction(request *core.StopTransactionRequest) (*core.StopT
 			cp.log.ERROR.Printf("stop transaction: mismatched id %d expected %d", request.TransactionId, cp.currentTransaction.Id)
 		}
 
-		cp.SetTransactionStatus(Finished)
+		cp.currentTransaction.SetStatus(TransactionFinished)
+	} else {
+		cp.log.WARN.Printf("stop transaction: stopping non existent transaction")
 	}
 
 	res := &core.StopTransactionConfirmation{
 		IdTagInfo: &types.IdTagInfo{
 			Status: types.AuthorizationStatusAccepted, // accept
 		},
+	}
+
+	return res, nil
+}
+
+// unsupported functions
+
+func (cp *CP) DataTransfer(request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
+	cp.log.TRACE.Printf("%T: %+v", request, request)
+
+	res := &core.DataTransferConfirmation{
+		Status: core.DataTransferStatusRejected,
 	}
 
 	return res, nil

--- a/charger/ocpp/cp_metering.go
+++ b/charger/ocpp/cp_metering.go
@@ -1,0 +1,143 @@
+package ocpp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	// "sync"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	// "github.com/evcc-io/evcc/util"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	// "github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
+)
+
+// core handlers used to handle metering
+
+func (cp *CP) MeterValues(request *core.MeterValuesRequest) (*core.MeterValuesConfirmation, error) {
+	cp.log.TRACE.Printf("%T: %+v", request, request)
+	// cp.log.TRACE.Printf("Meter Values TransactionId: %d", *request.TransactionId)
+
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	cp.updated = time.Now()
+
+	for _, meterValue := range request.MeterValue {
+		// ignore old meter value requests
+		if meterValue.Timestamp.Time.After(cp.meterUpdated) {
+			for _, sample := range meterValue.SampledValue {
+				cp.measurements[getSampleKey(sample)] = sample
+				cp.meterUpdated = time.Now()
+			}
+		}
+	}
+
+	return new(core.MeterValuesConfirmation), nil
+}
+
+func getSampleKey(s types.SampledValue) string {
+	if s.Phase != "" {
+		return string(s.Measurand) + "@" + string(s.Phase)
+	}
+
+	return string(s.Measurand)
+}
+
+// this watchdog routine triggers meter values messages if older than timeout.
+// Must be wrapped in a goroutine.
+func (cp *CP) MeteringWatchdog(timeout time.Duration) {
+	for ; true; <-time.NewTicker(timeout).C {
+		cp.mu.Lock()
+		update := cp.currentTransaction != nil && time.Since(cp.meterUpdated) > timeout
+		cp.mu.Unlock()
+
+		if update {
+			Instance().TriggerMessageRequest(cp.ID(), core.MeterValuesFeatureName)
+		}
+	}
+}
+
+// metering APIs implementations
+
+var _ api.Meter = (*CP)(nil)
+
+func (cp *CP) CurrentPower() (float64, error) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	if cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
+		return 0, api.ErrNotAvailable
+	}
+
+	if m, ok := cp.measurements[string(types.MeasurandPowerActiveImport)]; ok {
+		f, err := strconv.ParseFloat(m.Value, 64)
+		return scale(f, m.Unit), err
+	}
+
+	return 0, api.ErrNotAvailable
+}
+
+var _ api.MeterEnergy = (*CP)(nil)
+
+func (cp *CP) TotalEnergy() (float64, error) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	if cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
+		return 0, api.ErrNotAvailable
+	}
+
+	if m, ok := cp.measurements[string(types.MeasurandEnergyActiveImportRegister)]; ok {
+		f, err := strconv.ParseFloat(m.Value, 64)
+		return scale(f, m.Unit) / 1e3, err
+	}
+
+	return 0, api.ErrNotAvailable
+}
+
+func scale(f float64, scale types.UnitOfMeasure) float64 {
+	switch {
+	case strings.HasPrefix(string(scale), "k"):
+		return f * 1e3
+	case strings.HasPrefix(string(scale), "m"):
+		return f / 1e3
+	default:
+		return f
+	}
+}
+
+func getKeyCurrentPhase(phase int) string {
+	return string(types.MeasurandCurrentImport) + "@L" + strconv.Itoa(phase)
+}
+
+var _ api.MeterCurrent = (*CP)(nil)
+
+func (cp *CP) Currents() (float64, float64, float64, error) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	if cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
+		return 0, 0, 0, api.ErrNotAvailable
+	}
+
+	currents := make([]float64, 0, 3)
+
+	for phase := 1; phase <= 3; phase++ {
+		m, ok := cp.measurements[getKeyCurrentPhase(phase)]
+		if !ok {
+			return 0, 0, 0, api.ErrNotAvailable
+		}
+
+		f, err := strconv.ParseFloat(m.Value, 64)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("invalid current for phase %d: %w", phase, err)
+		}
+
+		currents = append(currents, scale(f, m.Unit))
+	}
+
+	return currents[0], currents[1], currents[2], nil
+}

--- a/charger/ocpp/cp_transactions.go
+++ b/charger/ocpp/cp_transactions.go
@@ -1,0 +1,76 @@
+package ocpp
+
+import (
+	// "fmt"
+	// "strconv"
+	// "strings"
+	"sync"
+	// "time"
+
+	// "github.com/evcc-io/evcc/api"
+	// "github.com/evcc-io/evcc/util"
+	// "github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	// "github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	// "github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
+)
+
+type TransactionState int
+
+const (
+	TransactionUndefined TransactionState = iota
+	TransactionStarting
+	TransactionRunning
+	TransactionSuspended
+	TransactionStopping
+	TransactionFinished
+)
+
+type Transaction struct {
+	Id int
+	status TransactionState
+	ConnectorId int
+
+	// state signalling
+	statusMu sync.Mutex
+	statusChanged chan struct{}
+	// StartedC chan struct{}
+	// StoppedC chan struct{}
+}
+
+func (tnx *Transaction) broadcastStatusChange() {
+	if tnx.statusChanged != nil {
+		close(tnx.statusChanged)
+	}
+	tnx.statusChanged = make(chan struct{})
+}
+
+func (tnx *Transaction) SetStatus(status TransactionState) {
+	tnx.statusMu.Lock()
+	defer tnx.statusMu.Unlock()
+
+	// preveting double status update
+	if tnx.status != status {
+		tnx.status = status
+		tnx.broadcastStatusChange()
+	}
+}
+
+func (tnx *Transaction) Status() TransactionState {
+	tnx.statusMu.Lock()
+	defer tnx.statusMu.Unlock()
+	return tnx.status
+}
+
+func (tnx *Transaction) HasStatusChanged() <-chan struct{} {
+	return tnx.statusChanged
+}
+
+func NewTransaction(id int) *Transaction {
+	return &Transaction {
+		Id: id,
+		ConnectorId: 1,
+		status: TransactionUndefined,
+		statusChanged: make(chan struct{}),
+	}
+}
+

--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -29,13 +29,6 @@ func (cs *CS) Register(id string, cp *CP) error {
 	return nil
 }
 
-// errorHandler logs error channel
-func (cs *CS) errorHandler(errC <-chan error) {
-	for err := range errC {
-		cs.log.ERROR.Println(err)
-	}
-}
-
 func (cs *CS) chargepointByID(id string) (*CP, error) {
 	cp, ok := cs.cps[id]
 	if !ok {
@@ -77,6 +70,13 @@ func (cs *CS) ChargePointDisconnected(chargePoint ocpp16.ChargePointConnection) 
 		cs.log.ERROR.Printf("chargepoint disconnected: %v", err)
 	} else {
 		cs.log.DEBUG.Printf("chargepoint disconnected: %s", chargePoint.ID())
+	}
+}
+
+// errorHandler logs error channel
+func (cs *CS) errorHandler(errC <-chan error) {
+	for err := range errC {
+		cs.log.ERROR.Println(err)
 	}
 }
 

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -44,7 +44,7 @@ func (cs *CS) TriggerMessageRequest(id string, requestedMessage remotetrigger.Me
 	}
 }
 
-// cp actions
+// core handlers are redirected to chargepoint object implementation
 
 func (cs *CS) OnAuthorize(id string, request *core.AuthorizeRequest) (*core.AuthorizeConfirmation, error) {
 	cp, err := cs.chargepointByID(id)


### PR DESCRIPTION
PR created based on #4977 and #5055 
**CAUTION** this doesn't exactly work, because it deadlocks, but I was able to make few observations

1. EVCC loadpoint doesn't try to enforce state in off state.

```
[site  ] DEBUG 2022/11/11 18:04:54 ----
[lp-1  ] DEBUG 2022/11/11 18:04:54 charge power: 0W
[site  ] DEBUG 2022/11/11 18:04:56 pv power: 0W
[site  ] DEBUG 2022/11/11 18:04:57 grid power: 4362W
[site  ] DEBUG 2022/11/11 18:04:59 grid currents: [2.65 16.2 1.11]A
[site  ] DEBUG 2022/11/11 18:05:00 site power: 3182W
[lp-1  ] ERROR 2022/11/11 18:05:09 vehicle odometer: 408 Request Timeout
[ocpp  ] TRACE 2022/11/11 18:05:09 Status() called
[lp-1  ] DEBUG 2022/11/11 18:05:09 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:05:09 next soc poll remaining time: 59m44s
[lp-1  ] DEBUG 2022/11/11 18:05:09 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:05:09 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:05:09 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:05:09 Enabled() called
[lp-1  ] WARN 2022/11/11 18:05:09 charger logic error: disabled but charging
[site  ] DEBUG 2022/11/11 18:05:09 ----
[lp-1  ] DEBUG 2022/11/11 18:05:09 charge power: 0W
[site  ] DEBUG 2022/11/11 18:05:11 pv power: 0W
[site  ] DEBUG 2022/11/11 18:05:12 grid power: 4329W
[site  ] DEBUG 2022/11/11 18:05:15 grid currents: [2.67 16.1 1.11]A
[site  ] DEBUG 2022/11/11 18:05:16 site power: 3149W
[ocpp  ] TRACE 2022/11/11 18:05:16 Status() called
[lp-1  ] DEBUG 2022/11/11 18:05:16 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:05:16 next soc poll remaining time: 59m53s
[lp-1  ] DEBUG 2022/11/11 18:05:16 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:05:16 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:05:16 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:05:16 Enabled() called
[lp-1  ] WARN 2022/11/11 18:05:16 charger logic error: disabled but charging
[site  ] DEBUG 2022/11/11 18:05:16 ----
[lp-1  ] DEBUG 2022/11/11 18:05:16 charge power: 0W
[site  ] DEBUG 2022/11/11 18:05:17 pv power: 0W
[ocpp  ] TRACE 2022/11/11 18:05:17 *core.MeterValuesRequest: &{ConnectorId:1 TransactionId:0xc000a4ecb8 MeterValue:[{Timestamp:2022-11-11 18:05:15 +0100 CET SampledValue:[{Value:251574.000 Context:Sample.Periodic Format: Measurand:Energy.Active.Import.Register Phase: Location:Outlet Unit:Wh} {Value:16.061 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L1 Location:Outlet Unit:A} {Value:0.000 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L2 Location:Outlet Unit:A} {Value:0.000 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L3 Location:Outlet Unit:A}]}]}
[site  ] DEBUG 2022/11/11 18:05:18 grid power: 4365W
[site  ] DEBUG 2022/11/11 18:05:21 grid currents: [2.67 16.1 1.11]A
[site  ] DEBUG 2022/11/11 18:05:22 site power: 3185W
[ocpp  ] TRACE 2022/11/11 18:05:22 Status() called
[lp-1  ] DEBUG 2022/11/11 18:05:22 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:05:22 next soc poll remaining time: 59m54s
[lp-1  ] DEBUG 2022/11/11 18:05:22 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:05:22 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:05:22 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:05:22 Enabled() called
[lp-1  ] WARN 2022/11/11 18:05:22 charger logic error: disabled but charging
[site  ] DEBUG 2022/11/11 18:05:22 ----
[lp-1  ] DEBUG 2022/11/11 18:05:22 charge power: 0W
[site  ] DEBUG 2022/11/11 18:05:22 pv power: 0W
[site  ] DEBUG 2022/11/11 18:05:24 grid power: 4341W
[site  ] DEBUG 2022/11/11 18:05:27 grid currents: [2.7 16.1 1.11]A
[site  ] DEBUG 2022/11/11 18:05:28 site power: 3161W
[ocpp  ] TRACE 2022/11/11 18:05:28 Status() called
[lp-1  ] DEBUG 2022/11/11 18:05:28 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:05:28 next soc poll remaining time: 59m53s
[lp-1  ] DEBUG 2022/11/11 18:05:28 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:05:28 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:05:28 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:05:28 Enabled() called
[lp-1  ] WARN 2022/11/11 18:05:28 charger logic error: disabled but charging
[site  ] DEBUG 2022/11/11 18:05:31 ----
[lp-1  ] DEBUG 2022/11/11 18:05:31 charge power: 0W
[site  ] DEBUG 2022/11/11 18:05:31 pv power: 0W
[site  ] DEBUG 2022/11/11 18:05:33 grid power: 4352W
[site  ] DEBUG 2022/11/11 18:05:35 grid currents: [2.68 16.1 1.1]A
[site  ] DEBUG 2022/11/11 18:05:36 site power: 3172W
[ocpp  ] TRACE 2022/11/11 18:05:36 Status() called
[lp-1  ] DEBUG 2022/11/11 18:05:36 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:05:36 next soc poll remaining time: 59m51s
[lp-1  ] DEBUG 2022/11/11 18:05:36 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:05:36 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:05:36 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:05:36 Enabled() called
[lp-1  ] WARN 2022/11/11 18:05:36 charger logic error: disabled but charging
[ocpp  ] TRACE 2022/11/11 18:05:38 *core.HeartbeatRequest: &{}
[site  ] DEBUG 2022/11/11 18:05:41 ----
[lp-1  ] DEBUG 2022/11/11 18:05:41 charge power: 0W
[site  ] DEBUG 2022/11/11 18:05:43 pv power: 0W
[site  ] DEBUG 2022/11/11 18:05:44 grid power: 4271W
[ocpp  ] TRACE 2022/11/11 18:05:47 *core.MeterValuesRequest: &{ConnectorId:1 TransactionId:0xc000a7bd08 MeterValue:[{Timestamp:2022-11-11 18:05:45 +0100 CET SampledValue:[{Value:251601.000 Context:Sample.Periodic Format: Measurand:Energy.Active.Import.Register Phase: Location:Outlet Unit:Wh} {Value:15.882 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L1 Location:Outlet Unit:A} {Value:0.000 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L2 Location:Outlet Unit:A} {Value:0.000 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L3 Location:Outlet Unit:A}]}]}
[site  ] DEBUG 2022/11/11 18:05:48 grid currents: [2.63 16 1.11]A
[site  ] DEBUG 2022/11/11 18:05:48 site power: 3091W
[ocpp  ] TRACE 2022/11/11 18:05:48 Status() called
[lp-1  ] DEBUG 2022/11/11 18:05:48 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:05:48 next soc poll remaining time: 59m47s
[lp-1  ] DEBUG 2022/11/11 18:05:48 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:05:48 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:05:48 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:05:48 Enabled() called
[lp-1  ] WARN 2022/11/11 18:05:48 charger logic error: disabled but charging
[site  ] DEBUG 2022/11/11 18:05:51 ----
[lp-1  ] DEBUG 2022/11/11 18:05:51 charge power: 0W
[site  ] DEBUG 2022/11/11 18:05:52 pv power: 0W
[site  ] DEBUG 2022/11/11 18:05:53 grid power: 4290W
[site  ] DEBUG 2022/11/11 18:05:55 grid currents: [2.64 16 1.11]A
[site  ] DEBUG 2022/11/11 18:05:56 site power: 3110W
[ocpp  ] TRACE 2022/11/11 18:05:56 Status() called
[lp-1  ] DEBUG 2022/11/11 18:05:56 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:05:56 next soc poll remaining time: 59m52s
[lp-1  ] DEBUG 2022/11/11 18:05:56 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:05:56 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:05:56 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:05:56 Enabled() called
[lp-1  ] WARN 2022/11/11 18:05:56 charger logic error: disabled but charging
[site  ] DEBUG 2022/11/11 18:06:01 ----
[lp-1  ] DEBUG 2022/11/11 18:06:01 charge power: 0W
[site  ] DEBUG 2022/11/11 18:06:02 pv power: 0W
[site  ] DEBUG 2022/11/11 18:06:03 grid power: 4280W
[site  ] DEBUG 2022/11/11 18:06:06 grid currents: [2.71 15.9 1.11]A
[site  ] DEBUG 2022/11/11 18:06:08 site power: 3100W
[ocpp  ] TRACE 2022/11/11 18:06:08 Status() called
[lp-1  ] DEBUG 2022/11/11 18:06:08 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:06:08 next soc poll remaining time: 59m48s
[lp-1  ] DEBUG 2022/11/11 18:06:08 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:06:08 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:06:08 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:06:08 Enabled() called
[lp-1  ] WARN 2022/11/11 18:06:08 charger logic error: disabled but charging
[site  ] DEBUG 2022/11/11 18:06:11 ----
[lp-1  ] DEBUG 2022/11/11 18:06:11 charge power: 0W
[site  ] DEBUG 2022/11/11 18:06:12 pv power: 0W
[site  ] DEBUG 2022/11/11 18:06:13 grid power: 4315W
[lp-1  ] DEBUG 2022/11/11 18:06:14 set charge mode: minpv
[lp-1  ] DEBUG 2022/11/11 18:06:14 pv timer elapse
[lp-1  ] DEBUG 2022/11/11 18:06:14 pv timer inactive
[site  ] DEBUG 2022/11/11 18:06:16 grid currents: [2.76 16.1 1.11]A
[site  ] DEBUG 2022/11/11 18:06:17 site power: 3135W
[ocpp  ] TRACE 2022/11/11 18:06:17 Status() called
[lp-1  ] DEBUG 2022/11/11 18:06:17 charger status: C
[lp-1  ] DEBUG 2022/11/11 18:06:17 next soc poll remaining time: 59m50s
[lp-1  ] DEBUG 2022/11/11 18:06:17 vehicle soc: 49%
[lp-1  ] DEBUG 2022/11/11 18:06:17 vehicle range: 235km
[lp-1  ] DEBUG 2022/11/11 18:06:17 vehicle target soc: 80%
[ocpp  ] TRACE 2022/11/11 18:06:17 Enabled() called
[lp-1  ] WARN 2022/11/11 18:06:17 charger logic error: disabled but charging
[lp-1  ] DEBUG 2022/11/11 18:06:17 available power -3135W < 4140W min 3p threshold
[lp-1  ] DEBUG 2022/11/11 18:06:17 start phase scale1p timer
[lp-1  ] DEBUG 2022/11/11 18:06:17 phase scale1p in 3m0s
[lp-1  ] DEBUG 2022/11/11 18:06:17 pv charge current: 0A = 0A + -4.54A (3135W @ 3p)
[ocpp  ] TRACE 2022/11/11 18:06:17 Enabled() called
[lp-1  ] DEBUG 2022/11/11 18:06:17 max charge current: 6A
[ocpp  ] TRACE 2022/11/11 18:06:17 Enable(true) called
[ocpp  ] TRACE 2022/11/11 18:06:17 *core.MeterValuesRequest: &{ConnectorId:1 TransactionId:0xc000adbb18 MeterValue:[{Timestamp:2022-11-11 18:06:15 +0100 CET SampledValue:[{Value:251629.000 Context:Sample.Periodic Format: Measurand:Energy.Active.Import.Register Phase: Location:Outlet Unit:Wh} {Value:16.027 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L1 Location:Outlet Unit:A} {Value:0.000 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L2 Location:Outlet Unit:A} {Value:0.000 Context:Sample.Periodic Format: Measurand:Current.Import Phase:L3 Location:Outlet Unit:A}]}]}
[ocpp  ] TRACE 2022/11/11 18:06:18 *core.RemoteStartTransactionConfirmation: &{Status:Rejected}
[lp-1  ] ERROR 2022/11/11 18:06:18 charger enable: Rejected
```

2. Any other response than Accepted for StartTransactionRequest, in case of my Alfen Eve results in Unavailable state. 

```
[ocpp  ] TRACE 2022/11/11 17:59:45 *core.ResetConfirmation: &{Status:Accepted}
[ocpp  ] TRACE 2022/11/11 17:59:46 *core.StatusNotificationRequest: &{ConnectorId:1 ErrorCode:NoError Info: Status:Available Timestamp:<nil> VendorId: VendorErrorCode:}
[ocpp  ] TRACE 2022/11/11 17:59:48 *core.MeterValuesRequest: &{ConnectorId:1 TransactionId:0xc0000445a0 MeterValue:[{Timestamp:2022-11-11 17:59:45 +0100 CET SampledValue:[{Value:251.500 Context:Transaction.End Format: Measurand: Phase: Location: Unit:kWh}]}]}
[ocpp  ] TRACE 2022/11/11 17:59:49 *core.StatusNotificationRequest: &{ConnectorId:1 ErrorCode:NoError Info: Status:Preparing Timestamp:<nil> VendorId: VendorErrorCode:}
[ocpp  ] TRACE 2022/11/11 17:59:49 *core.StopTransactionRequest: &{IdTag: MeterStop:251500 Timestamp:2022-11-11 17:59:45 +0100 CET TransactionId:1 Reason:SoftReset TransactionData:[{Timestamp:2022-11-11 17:52:55 +0100 CET SampledValue:[{Value:251.500 Context:Transaction.Begin Format: Measurand: Phase: Location: Unit:kWh}]} {Timestamp:2022-11-11 17:59:45 +0100 CET SampledValue:[{Value:251.500 Context:Transaction.End Format: Measurand: Phase: Location: Unit:kWh}]}]}
[ocpp  ] TRACE 2022/11/11 17:59:49 *core.HeartbeatRequest: &{}
[ocpp  ] TRACE 2022/11/11 17:59:52 *core.StatusNotificationRequest: &{ConnectorId:1 ErrorCode:NoError Info: Status:SuspendedEV Timestamp:<nil> VendorId: VendorErrorCode:}
[ocpp  ] TRACE 2022/11/11 17:59:53 *core.StatusNotificationRequest: &{ConnectorId:1 ErrorCode:NoError Info:Charging Status:Charging Timestamp:<nil> VendorId: VendorErrorCode:}
[ocpp  ] TRACE 2022/11/11 17:59:54 *core.StartTransactionRequest: &{ConnectorId:1 IdTag:ACExxxxxxx MeterStart:251500 ReservationId:<nil> Timestamp:2022-11-11 17:59:51 +0100 CET}
[ocpp  ] DEBUG 2022/11/11 17:59:54 responded with authorization status blocked for unknown transaction
[ocpp  ] TRACE 2022/11/11 17:59:54 *core.StatusNotificationRequest: &{ConnectorId:1 ErrorCode:NoError Info: Status:Unavailable Timestamp:<nil> VendorId: VendorErrorCode:}
```


