### PR TITLE
current correction for grid meters

### DIFF
--- a/templates/definition/meter/eastron-sdm630.yaml
+++ b/templates/definition/meter/eastron-sdm630.yaml
@@ -12,15 +12,78 @@ params:
   - name: modbus
     choice: ["rs485"]
 render: |
-  type: modbus
-  model: sdm
+  # reference: https://github.com/volkszaehler/mbmd/blob/master/meters/rs485/sdm.go
   {{- if eq .usage "charge" }}
+  type: modbus
+  {{- include "modbus" . }}
+  model: sdm
   energy: Sum # only required for charge meter usage
-  {{- end }}
-  {{- if or (eq .usage "charge") (eq .usage "grid") }}
+  power: Power
   currents:
     - CurrentL1
     - CurrentL2
     - CurrentL3
   {{- end }}
+  # custom for grid usage to adjust currents according power flow
+  {{- if eq .usage "grid" }}
+  type: custom
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2}}
+    model: sdm
+    value: Sum
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2}}
+    model: sdm
+    value: Power
+  currents:
+    - source: calc
+      mul:
+        - source: modbus
+          uri: {{ .host }}:{{ .port }}
+          id: {{ .id }}
+          model: sdm
+          value: CurrentL1
+        - source: calc
+          sign:
+            source: modbus
+            uri: {{ .host }}:{{ .port }}
+            id: {{ .id }}
+            model: sdm
+            value: PowerL1
+    - source: calc
+      mul:
+        - source: modbus
+          uri: {{ .host }}:{{ .port }}
+          id: {{ .id }}
+          model: sdm
+          value: CurrentL2
+        - source: calc
+          sign:
+            source: modbus
+            uri: {{ .host }}:{{ .port }}
+            id: {{ .id }}
+            model: sdm
+            value: PowerL2
+    - source: calc
+      mul:
+        - source: modbus
+          uri: {{ .host }}:{{ .port }}
+          id: {{ .id }}
+          model: sdm
+          value: CurrentL3
+        - source: calc
+          sign:
+            source: modbus
+            uri: {{ .host }}:{{ .port }}
+            id: {{ .id }}
+            model: sdm
+            value: PowerL3
+  {{- end }}
+  # battery / pv fallback
+  {{- if or (eq .usage "battery") (eq .usage "pv") }}
+  type: modbus
   {{- include "modbus" . }}
+  model: sdm
+  {{- end }}

--- a/templates/definition/meter/shelly-3em.yaml
+++ b/templates/definition/meter/shelly-3em.yaml
@@ -21,6 +21,18 @@ render: |
     scale: 0.001
   {{ end -}}
   {{if ne .usage "pv" -}}
+  {{if eq .usage "grid" -}}
+  currents:
+  - source: http
+    uri: http://{{ .host }}/emeter/0
+    jq: if .power < 0 then - .current else .current end
+  - source: http
+    uri: http://{{ .host }}/emeter/1
+    jq: if .power < 0 then - .current else .current end
+  - source: http
+    uri: http://{{ .host }}/emeter/2
+    jq: if .power < 0 then - .current else .current end
+  {{ else }}
   currents:
   - source: http
     uri: http://{{ .host }}/emeter/0
@@ -31,4 +43,5 @@ render: |
   - source: http
     uri: http://{{ .host }}/emeter/2
     jq: .current
+  {{ end -}}
   {{ end -}}


### PR DESCRIPTION
PR intended to provide corrections for phase currents based on consumption or production. Some meters only provide positive currents, regardless of power flow. It is expected that for grid meters a consumption form the grid has positive currents, while feeding into grid results in negative phase currents. This is in sync with the power value provided by the meters.
Table to be completed ... 
For entries marked with `to be tested`: if someone has such meter in use, pls support us with testing this branch with the meter and confirm its working (provides correct phase currents)

| Meter | Type | Currents correct | EVCC correction |
| ------- | ----- | ----------------- | ------------------ |
|Fronius Gen24|sunspec|x|
|SDM630|modbus|-|x (to be tested)|
|Shelly 3EM|http|-|x (to be tested)|

