### PR TITLE
Sessions: locale-aware csv formatting

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -232,5 +232,5 @@ type FeatureDescriber interface {
 
 // CsvWriter converts to csv
 type CsvWriter interface {
-	WriteCsv(context.Context, io.Writer)
+	WriteCsv(context.Context, io.Writer) error
 }

--- a/core/db/session.go
+++ b/core/db/session.go
@@ -114,11 +114,10 @@ func (t *Sessions) WriteCsv(ctx context.Context, w io.Writer) error {
 		return err
 	}
 
+	// get context language
 	lang := locale.Language
-	if loc, ok := ctx.Value(locale.Locale).(string); ok && loc != "" {
-		if tags, _, err := language.ParseAcceptLanguage(loc); err == nil && len(tags) > 0 {
-			lang = tags[0].String()
-		}
+	if language, ok := ctx.Value(locale.Locale).(string); ok && language != "" {
+		lang = language
 	}
 
 	tag, err := language.Parse(lang)
@@ -127,6 +126,8 @@ func (t *Sessions) WriteCsv(ctx context.Context, w io.Writer) error {
 	}
 
 	ww := csv.NewWriter(w)
+
+	// set separator according to locale
 	if b, _ := tag.Base(); b.String() == language.German.String() {
 		ww.Comma = ';'
 	}

--- a/core/db/session.go
+++ b/core/db/session.go
@@ -110,13 +110,15 @@ func (t *Sessions) writeRow(ww *csv.Writer, mp *message.Printer, r Session) erro
 
 // WriteCsv implements the api.CsvWriter interface
 func (t *Sessions) WriteCsv(ctx context.Context, w io.Writer) error {
-	if _, err := w.Write([]byte{0xFE, 0xFF}); err != nil {
+	if _, err := w.Write([]byte{0xEF, 0xBB, 0xBF}); err != nil {
 		return err
 	}
 
 	lang := locale.Language
 	if loc, ok := ctx.Value(locale.Locale).(string); ok && loc != "" {
-		lang = loc
+		if tags, _, err := language.ParseAcceptLanguage(loc); err == nil && len(tags) > 0 {
+			lang = tags[0].String()
+		}
 	}
 
 	tag, err := language.Parse(lang)

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -75,7 +75,10 @@ func csvResult(ctx context.Context, w http.ResponseWriter, res any) {
 	w.Header().Set("Content-Disposition", `attachment; filename="sessions.csv"`)
 
 	if ww, ok := res.(api.CsvWriter); ok {
-		ww.WriteCsv(ctx, w)
+		println(1)
+		if err := ww.WriteCsv(ctx, w); err != nil {
+			fmt.Println(err)
+		}
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 	}

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -75,10 +75,7 @@ func csvResult(ctx context.Context, w http.ResponseWriter, res any) {
 	w.Header().Set("Content-Disposition", `attachment; filename="sessions.csv"`)
 
 	if ww, ok := res.(api.CsvWriter); ok {
-		println(1)
-		if err := ww.WriteCsv(ctx, w); err != nil {
-			fmt.Println(err)
-		}
+		_ = ww.WriteCsv(ctx, w)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 	}

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/locale"
 	"github.com/gorilla/mux"
+	"golang.org/x/text/language"
 )
 
 func indexHandler() http.HandlerFunc {
@@ -193,8 +194,13 @@ func sessionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.URL.Query().Get("format") == "csv" {
-		accept := r.Header.Get("Accept-Language")
-		ctx := context.WithValue(context.Background(), locale.Locale, accept)
+		// get request language
+		lang := r.Header.Get("Accept-Language")
+		if tags, _, err := language.ParseAcceptLanguage(lang); err == nil && len(tags) > 0 {
+			lang = tags[0].String()
+		}
+
+		ctx := context.WithValue(context.Background(), locale.Locale, lang)
 		csvResult(ctx, w, &res)
 		return
 	}

--- a/util/locale/locale.go
+++ b/util/locale/locale.go
@@ -36,10 +36,12 @@ func Init() error {
 		}
 	}
 
-	Language, err := jibber_jabber.DetectLanguage()
+	Language, err = jibber_jabber.DetectLanguage()
 	if err != nil {
-		Language = "de"
+		Language = language.German.String()
 	}
+
+	fmt.Println("Language", Language)
 
 	Localizer = i18n.NewLocalizer(Bundle, Language)
 

--- a/util/locale/locale.go
+++ b/util/locale/locale.go
@@ -41,8 +41,6 @@ func Init() error {
 		Language = language.German.String()
 	}
 
-	fmt.Println("Language", Language)
-
 	Localizer = i18n.NewLocalizer(Bundle, Language)
 
 	return nil


### PR DESCRIPTION
- Number formatting becomes locale-aware.
- Added BOM for proper UTF-8 encoding with Excel
- When German language is detected ("de"), CSV uses `;` instead of `,` as separator to ease import with Excel. 
