### PR TITLE
Telemetry: add upload cache and upload retry

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -107,6 +107,13 @@ func NewSiteFromConfig(
 		}
 	}
 
+	// upload telemetry on shutdown
+	if telemetry.Enabled() {
+		shutdown.Register(func() {
+			telemetry.Persist(log)
+		})
+	}
+
 	// give loadpoints access to vehicles and database
 	for _, lp := range loadpoints {
 		lp.coordinator = coordinator.NewAdapter(lp, site.coordinator)

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -59,8 +59,6 @@ func Create(machineID string) {
 // UpdateChargeProgress accumulates the charge delta and uploads at given interval.
 // This interval must be smaller that the apis expiry interval for treating power values as current.
 func UpdateChargeProgress(log *util.Logger, power, deltaCharged, deltaGreen float64) {
-	log.DEBUG.Printf("telemetry: charge: Δ%.0f/%.0fWh @ %.0fW", deltaGreen*1e3, deltaCharged*1e3, power)
-
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -94,6 +92,8 @@ func Persist(log *util.Logger) {
 // upload executes the actual upload.
 // Lock must be held when calling upload.
 func upload(log *util.Logger, chargePower, greenPower float64) error {
+	log.DEBUG.Printf("telemetry: charge: Δ%.0f/%.0fWh @ %.0fW", accGreenEnergy*1e3, accChargeEnergy*1e3, chargePower)
+
 	data := InstanceChargeProgress{
 		InstanceID: instanceID,
 		ChargeProgress: ChargeProgress{

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -114,12 +114,13 @@ func upload(log *util.Logger, chargePower, greenPower float64) error {
 	req = req.WithContext(ctx)
 	defer cancel()
 
-	var res struct {
-		Error string
-	}
-
 	if err == nil {
 		client := request.NewHelper(log)
+
+		var res struct {
+			Error string
+		}
+
 		if err = client.DoJSON(req, &res); err == nil && res.Error != "" {
 			err = errors.New(res.Error)
 		}

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -127,6 +127,8 @@ func upload(log *util.Logger, chargePower, greenPower float64) error {
 	}
 
 	if err == nil {
+		updated = time.Now()
+
 		accChargeEnergy = 0
 		accGreenEnergy = 0
 	}

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -56,7 +56,8 @@ func Create(machineID string) {
 	instanceID = machineID
 }
 
-// UpdateChargeProgress accumulates the charge delta and uploads at given interval
+// UpdateChargeProgress accumulates the charge delta and uploads at given interval.
+// This interval must be smaller that the apis expiry interval for treating power values as current.
 func UpdateChargeProgress(log *util.Logger, power, deltaCharged, deltaGreen float64) {
 	log.DEBUG.Printf("telemetry: charge: Δ%.0f/%.0fWh @ %.0fW", deltaGreen*1e3, deltaCharged*1e3, power)
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/4995

This PR reduces the frequency at which telemetry data is uploaded. This should reduce amount of internet traffic caused, server load and reduce error messages such as https://github.com/evcc-io/evcc/discussions/4554#discussioncomment-4127964.