### PR TITLE
sonnenCharger: Fix enabled check

### DIFF
--- a/charger/etrel.go
+++ b/charger/etrel.go
@@ -138,7 +138,7 @@ func (wb *Etrel) Enabled() (bool, error) {
 		return false, err
 	}
 	maxCurrent := encoding.Float32(b)
-	
+
 	currentPower, err := wb.CurrentPower()
 	if err != nil {
 		return false, err

--- a/charger/etrel.go
+++ b/charger/etrel.go
@@ -137,8 +137,14 @@ func (wb *Etrel) Enabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	maxCurrent := encoding.Float32(b)
+	
+	currentPower, err := wb.CurrentPower()
+	if err != nil {
+		return false, err
+	}
 
-	return encoding.Float32(b) > 0, nil
+	return maxCurrent > 0 || currentPower > 0, nil
 }
 
 // Enable implements the api.Charger interface


### PR DESCRIPTION
Der Test ob der sonnenCharger `Enabled` ist schlägt fehl, weil der sonnenCharger im `Power Mode` nach der Verbindung mit dem Fahrzeug nicht, wie vorher erwartet, den Ladestrom über das Register `etrelRegMaxCurrent` setzt, sondern über das Register `etrelRegPower`. Liest man jetzt nur `etrelRegMaxCurrent`, dann steht in diesem Anfangszustand 0 drin, der sonnenCharger lädt aber munter weiter.

Die Methode `Enabled` muss also beide Register abfragen um den Status zu ermitteln. Ist eines von beiden > 0, dann lädt der Charger.

Siehe https://github.com/evcc-io/evcc/discussions/2083