### PR TITLE
Fix primarykey of sqlite session table

### DIFF
--- a/core/db/session.go
+++ b/core/db/session.go
@@ -19,10 +19,9 @@ import (
 
 // Session is a single charging session
 type Session struct {
-	ID            uint      `json:"-" csv:"-" gorm:"primarykey"`
-	Created       time.Time `json:"created"`
+	Created       time.Time `json:"created" gorm:"primarykey"`
+	Loadpoint     string    `json:"loadpoint" gorm:"primarykey"`
 	Finished      time.Time `json:"finished"`
-	Loadpoint     string    `json:"loadpoint"`
 	Identifier    string    `json:"identifier"`
 	Vehicle       string    `json:"vehicle"`
 	Odometer      float64   `json:"odometer" format:"int"`


### PR DESCRIPTION
Fix #5243

The primarykey (PK) of sessions table is currently defined as the standard gorm incremental id.
By changing it to the semantical correct composite PK, consisting out of

1. Created (timestamp) and
2. Loadpoint columns,

ensures the correct update of the session values. (Check the UPDATE WHERE clauses in the log below)

In context of this change, the ID column was deleted and the colums where reordered.

Backward compatibility was successfully tested. No migration of an existing database file is needed!

Testers are welcome! 

Test logs, without a vehicle having odometer, but MeterStart and MeterStop values, which where affected in #5243 as well, are updated correctly:

```bash
thierolm@accffmmt:~/evcc$ ./evcc -c ./evcc_homematictest.yaml -l debug --sqlite ./evcc_sessions.db
[main  ] INFO 2022/11/22 23:32:03 evcc 0.107.1 (c87df312)
[main  ] INFO 2022/11/22 23:32:03 using config file: ./evcc_homematictest.yaml
[main  ] INFO 2022/11/22 23:32:03 starting ui and api at :7070
[db    ] TRACE 2022/11/22 23:32:03 SELECT count(*) FROM sqlite_master WHERE type='table' AND name="settings" -1 <nil>
[db    ] TRACE 2022/11/22 23:32:03 SELECT sql FROM sqlite_master WHERE type IN ("table","index") AND tbl_name = "settings" AND sql IS NOT NULL order by type = "table" desc 1 <nil>
[db    ] TRACE 2022/11/22 23:32:03 SELECT * FROM `settings` LIMIT 1 -1 <nil>
[db    ] TRACE 2022/11/22 23:32:03 SELECT * FROM `settings` 6 <nil>
[db    ] TRACE 2022/11/22 23:32:03 SELECT count(*) FROM sqlite_master WHERE type='table' AND name="transactions" -1 <nil>
[db    ] TRACE 2022/11/22 23:32:03 SELECT count(*) FROM sqlite_master WHERE type='table' AND name="sessions" -1 <nil>
[db    ] TRACE 2022/11/22 23:32:03 SELECT sql FROM sqlite_master WHERE type IN ("table","index") AND tbl_name = "sessions" AND sql IS NOT NULL order by type = "table" desc 1 <nil>
[db    ] TRACE 2022/11/22 23:32:03 SELECT * FROM `sessions` LIMIT 1 -1 <nil>
[site  ] INFO 2022/11/22 23:32:04 site config:
[site  ] INFO 2022/11/22 23:32:04   meters:      grid ✓ pv ✗ battery ✗
[site  ] INFO 2022/11/22 23:32:04     grid:      power ✓ energy ✓ currents ✗
[site  ] INFO 2022/11/22 23:32:04   vehicles:
[site  ] INFO 2022/11/22 23:32:04     vehicle 1: range ✗ finish ✗ status ✗ climate ✗ wakeup ✗
[site  ] DEBUG 2022/11/22 23:32:04 ----
[site  ] DEBUG 2022/11/22 23:32:04 grid power: 826W
[site  ] DEBUG 2022/11/22 23:32:04 pv power: 0W
[site  ] DEBUG 2022/11/22 23:32:04 site power: 826W
[site  ] DEBUG 2022/11/22 23:32:19 ----
[site  ] DEBUG 2022/11/22 23:32:19 grid power: 826W
[site  ] DEBUG 2022/11/22 23:32:19 pv power: 0W
[site  ] DEBUG 2022/11/22 23:32:19 site power: 826W
[site  ] DEBUG 2022/11/22 23:32:34 ----
[site  ] DEBUG 2022/11/22 23:32:34 grid power: 826W
[site  ] DEBUG 2022/11/22 23:32:34 pv power: 0W
[site  ] DEBUG 2022/11/22 23:32:34 site power: 826W
[site  ] DEBUG 2022/11/22 23:32:35 ----
[site  ] DEBUG 2022/11/22 23:32:35 grid power: 826W
[site  ] DEBUG 2022/11/22 23:32:35 pv power: 0W
[site  ] DEBUG 2022/11/22 23:32:35 site power: 826W
[site  ] DEBUG 2022/11/22 23:32:49 ----
[site  ] DEBUG 2022/11/22 23:32:49 grid power: 826W
[site  ] DEBUG 2022/11/22 23:32:49 pv power: 0W
[site  ] DEBUG 2022/11/22 23:32:49 site power: 826W
[db    ] TRACE 2022/11/22 23:32:49 UPDATE `sessions` SET `finished`="0000-00-00 00:00:00",`identifier`="",`vehicle`="Zero S",`odometer`=0.000000,`meter_start_kwh`=0.001500,`meter_end_kwh`=0.000000,`charged_kwh`=0.000000 WHERE `created` = "2022-11-22 23:32:49.401" AND `loadpoint` = "Homematic" 0 <nil>
[db    ] TRACE 2022/11/22 23:32:49 SELECT * FROM `sessions` WHERE `created` = "2022-11-22 23:32:49.401" AND `loadpoint` = "Homematic" LIMIT 1 0 <nil>
[db    ] TRACE 2022/11/22 23:32:49 INSERT INTO `sessions` (`created`,`loadpoint`,`finished`,`identifier`,`vehicle`,`odometer`,`meter_start_kwh`,`meter_end_kwh`,`charged_kwh`) VALUES ("2022-11-22 23:32:49.401","Homematic","0000-00-00 00:00:00","","Zero S",0.000000,0.001500,0.000000,0.000000) 1 <nil>
[site  ] DEBUG 2022/11/22 23:33:04 ----
[site  ] DEBUG 2022/11/22 23:33:04 grid power: 826W
[site  ] DEBUG 2022/11/22 23:33:04 pv power: 0W
[site  ] DEBUG 2022/11/22 23:33:04 site power: 826W
[site  ] DEBUG 2022/11/22 23:33:19 ----
[site  ] DEBUG 2022/11/22 23:33:19 grid power: 826W
[site  ] DEBUG 2022/11/22 23:33:19 pv power: 0W
[site  ] DEBUG 2022/11/22 23:33:19 site power: 826W
[site  ] DEBUG 2022/11/22 23:33:34 ----
[site  ] DEBUG 2022/11/22 23:33:34 grid power: 826W
[site  ] DEBUG 2022/11/22 23:33:34 pv power: 0W
[site  ] DEBUG 2022/11/22 23:33:34 site power: 826W
[site  ] DEBUG 2022/11/22 23:33:49 ----
[site  ] DEBUG 2022/11/22 23:33:49 grid power: 826W
[site  ] DEBUG 2022/11/22 23:33:49 pv power: 0W
[site  ] DEBUG 2022/11/22 23:33:49 site power: 826W
[site  ] DEBUG 2022/11/22 23:34:03 ----
[site  ] DEBUG 2022/11/22 23:34:03 grid power: 826W
[site  ] DEBUG 2022/11/22 23:34:03 pv power: 0W
[site  ] DEBUG 2022/11/22 23:34:03 site power: 826W
[site  ] DEBUG 2022/11/22 23:34:04 ----
[site  ] DEBUG 2022/11/22 23:34:04 grid power: 826W
[site  ] DEBUG 2022/11/22 23:34:04 pv power: 0W
[site  ] DEBUG 2022/11/22 23:34:04 site power: 826W
[site  ] DEBUG 2022/11/22 23:34:19 ----
[site  ] DEBUG 2022/11/22 23:34:19 grid power: 826W
[site  ] DEBUG 2022/11/22 23:34:19 pv power: 0W
[site  ] DEBUG 2022/11/22 23:34:19 site power: 826W
[db    ] TRACE 2022/11/22 23:34:19 UPDATE `sessions` SET `finished`="2022-11-22 23:34:19.333",`identifier`="",`vehicle`="Zero S",`odometer`=0.000000,`meter_start_kwh`=0.001500,`meter_end_kwh`=0.001600,`charged_kwh`=0.000100 WHERE `created` = "2022-11-22 23:32:49.401" AND `loadpoint` = "Homematic" 1 <nil>
[site  ] DEBUG 2022/11/22 23:34:34 ----
[site  ] DEBUG 2022/11/22 23:34:34 grid power: 866W
[site  ] DEBUG 2022/11/22 23:34:34 pv power: 0W
[site  ] DEBUG 2022/11/22 23:34:34 site power: 866W
^C[db    ] TRACE 2022/11/22 23:34:37 INSERT INTO `settings` (`key`,`value`) VALUES ("savings.started","2022-11-22T23:16:53+01:00"),("savings.gridCharged","0.0003007924324291668"),("savings.gridCost","0.00009023772972874998"),("savings.gridSavedCost","0"),("savings.selfConsumptionCharged","0"),("savings.selfConsumptionCost","0") ON CONFLICT (`key`) DO UPDATE SET `value`=`excluded`.`value` 6 <nil>
[db    ] TRACE 2022/11/22 23:34:37 UPDATE `sessions` SET `finished`="2022-11-22 23:34:37.133",`identifier`="",`vehicle`="Zero S",`odometer`=0.000000,`meter_start_kwh`=0.001500,`meter_end_kwh`=0.001600,`charged_kwh`=0.000100 WHERE `created` = "2022-11-22 23:32:49.401" AND `loadpoint` = "Homematic" 1 <nil>
thierolm@accffmmt:~/evcc$ sqlite3 ./evcc_sessions.db 
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select * from sessions;
|2022-11-22 23:27:11.8987036+01:00|2022-11-22 23:29:24.0669159+01:00|Homematic||Zero S|0.0|0.0014|0.0015|0.0001
|2022-11-22 23:32:49.4011244+01:00|2022-11-22 23:34:37.133632+01:00|Homematic||Zero S|0.0|0.0015|0.0016|0.0001
sqlite> 
thierolm@accffmmt:~/evcc$ 
```