### PR TITLE
Fix VAG login

### DIFF
--- a/vehicle/vag/vwidentity/forms.go
+++ b/vehicle/vag/vwidentity/forms.go
@@ -83,7 +83,7 @@ func ParseCredentialsPage(r io.ReadCloser) (CredentialParams, error) {
 	match := re.FindAllStringSubmatch(buf.String(), -1)
 
 	tmpl := strings.ReplaceAll(match[0][1], `'`, `"`)
-	for _, v := range []string{"templateModel", "currentLocale", "csrf_parameterName", "csrf_token"} {
+	for _, v := range []string{"templateModel", "currentLocale", "csrf_parameterName", "csrf_token", "userSession", "userId", "countryOfResidence"} {
 		tmpl = strings.Replace(tmpl, v, fmt.Sprintf(`"%s"`, v), 1)
 	}
 


### PR DESCRIPTION
New fields are in the returned HTML that have to be quoted
#5257 

```
{
	"templateModel": {...},
	"currentLocale": "en",
	"csrf_parameterName": "_csrf",
	"csrf_token": ",
	userSession: {
	  userId: "",
	  countryOfResidence: ""
	}
  }
```