### PR TITLE
Messaging: Add ntfy (ntfy.sh) support

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -213,3 +213,7 @@ messaging:
   #   - # list of chat ids
   # - type: email
   #   uri: smtp://<user>:<password>@<host>:<port>/?fromAddress=<from>&toAddresses=<to>
+  # - type: ntfy
+  #   uri: https://<host>/<topics>
+  #   priority: <priority>
+  #   tags: <tags>

--- a/push/config.go
+++ b/push/config.go
@@ -37,6 +37,11 @@ func NewMessengerFromConfig(typ string, other map[string]interface{}) (res Sende
 		if err = util.DecodeOther(other, &cc); err == nil {
 			res, err = NewScriptMessenger(cc.CmdLine, cc.Timeout, cc.Scale, cc.Cache)
 		}
+	case "ntfy":
+		var cc ntfyConfig
+		if err = util.DecodeOther(other, &cc); err == nil {
+			res, err = NewNtfyMessenger(cc.URI, cc.Priority, cc.Tags)
+		}
 	default:
 		err = fmt.Errorf("unknown messenger type: %s", typ)
 	}

--- a/push/ntfy.go
+++ b/push/ntfy.go
@@ -1,0 +1,49 @@
+package push
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// Ntfy implements the ntfy messaging aggregator
+type Ntfy struct {
+	uri string
+	priority string
+	tags string
+}
+
+type ntfyConfig struct {
+	URI string
+	Priority string
+	Tags string
+}
+
+// NewNtfyMessenger creates new Ntfy messenger
+func NewNtfyMessenger(uri string, priority string, tags string) (*Ntfy, error) {
+	if uri == "" {
+	    return nil, errors.New("ntfy: missing uri")
+	}
+
+	m := &Ntfy{
+		uri: uri,
+		priority: priority,
+		tags: tags,
+	}
+
+	return m, nil
+}
+
+// Send sends to all receivers
+func (m *Ntfy) Send(title, msg string) {
+	req, err := http.NewRequest("POST", m.uri, strings.NewReader(msg))
+	if err != nil {
+		log.ERROR.Printf("ntfy: %v", err)
+	}
+	req.Header.Set("Title", title)
+	req.Header.Set("Priority", m.priority)
+	req.Header.Set("Tags", m.tags)
+	if _, err := http.DefaultClient.Do(req); err != nil {
+		log.ERROR.Printf("ntfy: %v", err)
+	}
+}

--- a/push/ntfy.go
+++ b/push/ntfy.go
@@ -4,31 +4,33 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+
+	"github.com/evcc-io/evcc/util/request"
 )
 
 // Ntfy implements the ntfy messaging aggregator
 type Ntfy struct {
-	uri string
+	uri      string
 	priority string
-	tags string
+	tags     string
 }
 
 type ntfyConfig struct {
-	URI string
+	URI      string
 	Priority string
-	Tags string
+	Tags     string
 }
 
 // NewNtfyMessenger creates new Ntfy messenger
 func NewNtfyMessenger(uri string, priority string, tags string) (*Ntfy, error) {
 	if uri == "" {
-	    return nil, errors.New("ntfy: missing uri")
+		return nil, errors.New("ntfy: missing uri")
 	}
 
 	m := &Ntfy{
-		uri: uri,
+		uri:      uri,
 		priority: priority,
-		tags: tags,
+		tags:     tags,
 	}
 
 	return m, nil
@@ -36,13 +38,15 @@ func NewNtfyMessenger(uri string, priority string, tags string) (*Ntfy, error) {
 
 // Send sends to all receivers
 func (m *Ntfy) Send(title, msg string) {
-	req, err := http.NewRequest("POST", m.uri, strings.NewReader(msg))
+	req, err := request.New("POST", m.uri, strings.NewReader(msg), map[string]string{
+		"Priority": m.priority,
+		"Title":    title,
+		"Tags":     m.tags,
+	})
 	if err != nil {
 		log.ERROR.Printf("ntfy: %v", err)
 	}
-	req.Header.Set("Title", title)
-	req.Header.Set("Priority", m.priority)
-	req.Header.Set("Tags", m.tags)
+
 	if _, err := http.DefaultClient.Do(req); err != nil {
 		log.ERROR.Printf("ntfy: %v", err)
 	}


### PR DESCRIPTION
Ntfy.sh sends push notifications to your phone or desktop via HTTP PUT/POST.
There is a free server at ntfy.sh, or you can run your own.

Configuration as a service is simple:

```
services:
    - type: ntfy
      priority: urgent
      uri: https://ntfy.sh/evcctestalerts
      tags: electric_plug,blue_car
```

Docs will be another PR.

![Screenshot_20221204-091852_ntfy](https://user-images.githubusercontent.com/30293195/205481077-0c1340de-35e7-4d05-a15f-ae0c79f310c5.jpg)

