### PR TITLE
TotalEnergy 4 Shelly Charger

### DIFF
--- a/charger/shelly.go
+++ b/charger/shelly.go
@@ -79,3 +79,10 @@ func (c *Shelly) Enable(enable bool) error {
 func (c *Shelly) MaxCurrent(current int64) error {
 	return nil
 }
+
+var _ api.MeterEnergy = (*Shelly)(nil)
+
+// TotalEnergy implements the api.MeterEnergy interface
+func (c *Shelly) TotalEnergy() (float64, error) {
+	return c.conn.TotalEnergy()
+}

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -170,3 +170,42 @@ func (d *Connection) execGen2Cmd(method string, enable bool, res interface{}) er
 
 	return d.DoJSON(req, &res)
 }
+
+// TotalEnergy implements the api.Meter interface
+func (d *Connection) TotalEnergy() (float64, error) {
+	var energy float64
+	switch d.gen {
+	case 0, 1:
+		var res Gen1StatusResponse
+		uri := fmt.Sprintf("%s/status", d.uri)
+		if err := d.GetJSON(uri, &res); err != nil {
+			return 0, err
+		}
+
+		switch {
+		case d.channel < len(res.Meters):
+			energy = float64(res.Meters[d.channel].Total) / 60 / 1000
+		case d.channel < len(res.EMeters):
+			energy = float64(res.EMeters[d.channel].Total) / 60 / 1000
+		default:
+			return 0, errors.New("invalid channel, missing power meter")
+		}
+
+	default:
+		var res Gen2StatusResponse
+		if err := d.execGen2Cmd("Shelly.GetStatus", false, &res); err != nil {
+			return 0, err
+		}
+
+		switch d.channel {
+		case 1:
+			energy = res.Switch1.Aenergy.Total
+		case 2:
+			energy = res.Switch2.Aenergy.Total
+		default:
+			energy = res.Switch0.Aenergy.Total
+		}
+	}
+
+	return energy, nil
+}

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -184,9 +184,9 @@ func (d *Connection) TotalEnergy() (float64, error) {
 
 		switch {
 		case d.channel < len(res.Meters):
-			energy = float64(res.Meters[d.channel].Total) / 60 / 1000
+			energy = float64(res.Meters[d.channel].Total) / 60
 		case d.channel < len(res.EMeters):
-			energy = float64(res.EMeters[d.channel].Total) / 60 / 1000
+			energy = float64(res.EMeters[d.channel].Total) / 60
 		default:
 			return 0, errors.New("invalid channel, missing power meter")
 		}
@@ -207,5 +207,5 @@ func (d *Connection) TotalEnergy() (float64, error) {
 		}
 	}
 
-	return energy, nil
+	return energy / 1000, nil
 }

--- a/meter/shelly/types.go
+++ b/meter/shelly/types.go
@@ -25,7 +25,10 @@ type Gen2SwitchResponse struct {
 }
 
 type Gen2Switch struct {
-	Apower float64
+	Apower  float64
+	Aenergy struct {
+		Total float64
+	}
 }
 
 type Gen2StatusResponse struct {
@@ -41,9 +44,11 @@ type Gen1SwitchResponse struct {
 type Gen1StatusResponse struct {
 	Meters []struct {
 		Power float64
+		Total int64
 	}
 	// Shelly EM meter JSON response
 	EMeters []struct {
 		Power float64
+		Total int64
 	}
 }


### PR DESCRIPTION
Add TotalEnergy charge meter to support charge session log.

Shelly charger SQLite session log record before change:
`13|2022-12-04 19:30:40.150490948+01:00|2022-12-04 19:44:00.763250498+01:00|Homematic||Audi A3 Sportback TFSI e|33581.0|0.0|0.0|0.419973808697542`
Session log record before change:
`14|2022-12-04 21:43:18.301899014+01:00|2022-12-04 21:53:16.934146799+01:00|Homematic||Audi A3 Sportback TFSI e|33581.0|106.00695|106.3295|0.322549999999993`

Shelly charger test:
```bash
ierolm@accffmmt:~/evcc$ ./evcc -c ./evcc_homematictest.yaml -l debug charger
[main  ] INFO 2022/12/04 21:59:04 evcc 0.108.3 (c9ca1ff1)
[main  ] INFO 2022/12/04 21:59:04 using config file: ./evcc_homematictest.yaml
Power:         0W
Energy:        106.3kWh
Charge status: B
Enabled:       false
```

Hint:
A shelly firmware update will always set the Total Energy value back to zero, 