### PR TITLE
VW ID switch from status endpoint to selectivestatus

### DIFF
--- a/vehicle/vw/id/api.go
+++ b/vehicle/vw/id/api.go
@@ -52,9 +52,6 @@ func (v *API) Vehicles() (res []string, err error) {
 	uri := fmt.Sprintf("%s/vehicles", BaseURL)
 
 	req, err := request.New(http.MethodGet, uri, nil, request.AcceptJSON)
-	if err != nil {
-		return nil, err
-	}
 
 	var vehicles struct {
 		Data []struct {
@@ -64,13 +61,12 @@ func (v *API) Vehicles() (res []string, err error) {
 		}
 	}
 
-	err = v.DoJSON(req, &vehicles)
-	if err != nil {
-		return nil, err
-	}
+	if err == nil {
+		err = v.DoJSON(req, &vehicles)
 
-	for _, v := range vehicles.Data {
-		res = append(res, v.VIN)
+		for _, v := range vehicles.Data {
+			res = append(res, v.VIN)
+		}
 	}
 
 	return res, err
@@ -83,11 +79,10 @@ func (v *API) Status(vin string) (res SelectiveSatus, err error) {
 
 	req, err := request.New(http.MethodGet, uri, nil, request.AcceptJSON)
 
-	if err != nil {
-		return res, err
+	if err == nil {
+		err = v.DoJSON(req, &res)
 	}
 
-	err = v.DoJSON(req, &res)
 	return res, err
 }
 
@@ -96,12 +91,13 @@ func (v *API) Action(vin, action, value string) error {
 	uri := fmt.Sprintf("%s/vehicles/%s/%s/%s", BaseURL, vin, action, value)
 
 	req, err := request.New(http.MethodPost, uri, nil, request.AcceptJSON)
-	if err != nil {
-		return err
+
+	if err == nil {
+		var res interface{}
+		err = v.DoJSON(req, &res)
 	}
 
-	var res interface{}
-	return v.DoJSON(req, &res)
+	return err
 }
 
 // Any implements any api response
@@ -111,11 +107,11 @@ func (v *API) Any(uri, vin string) (interface{}, error) {
 	}
 
 	req, err := request.New(http.MethodGet, uri, nil, request.AcceptJSON)
-	if err != nil {
-		return nil, err
-	}
 
 	var res interface{}
-	err = v.DoJSON(req, &res)
+	if err == nil {
+		err = v.DoJSON(req, &res)
+	}
+
 	return res, err
 }

--- a/vehicle/vw/id/provider.go
+++ b/vehicle/vw/id/provider.go
@@ -38,7 +38,7 @@ func (v *Provider) SoC() (float64, error) {
 		return float64(res.Charging.BatteryStatus.Value.CurrentSOCPct), nil
 	}
 
-	return 0, fmt.Errorf("SoC not avaliable")
+	return 0, fmt.Errorf("SoC not avaliable: %s", err)
 }
 
 var _ api.ChargeState = (*Provider)(nil)
@@ -58,7 +58,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		return status, nil
 	}
 
-	return "", fmt.Errorf("PlugStatus not avaliable")
+	return "", fmt.Errorf("PlugStatus not avaliable: %s", err)
 }
 
 var _ api.VehicleFinishTimer = (*Provider)(nil)
@@ -70,7 +70,7 @@ func (v *Provider) FinishTime() (time.Time, error) {
 		return res.Charging.ChargingStatus.Value.CarCapturedTimestamp.Add(time.Duration(res.Charging.ChargingStatus.Value.RemainingChargingTimeToCompleteMin) * time.Minute), err
 	}
 
-	return time.Time{}, fmt.Errorf("FinishTime not avaliable")
+	return time.Time{}, fmt.Errorf("FinishTime not avaliable: %s", err)
 }
 
 var _ api.VehicleRange = (*Provider)(nil)
@@ -82,7 +82,7 @@ func (v *Provider) Range() (int64, error) {
 		return int64(res.Charging.BatteryStatus.Value.CruisingRangeElectricKm), nil
 	}
 
-	return 0, fmt.Errorf("Range not avaliable")
+	return 0, fmt.Errorf("Range not avaliable: %s", err)
 }
 
 var _ api.VehicleOdometer = (*Provider)(nil)
@@ -112,7 +112,7 @@ func (v *Provider) Climater() (active bool, outsideTemp, targetTemp float64, err
 		return active, outsideTemp, targetTemp, nil
 	}
 
-	return false, 0, 0, fmt.Errorf("Climater not avaliable")
+	return false, 0, 0, fmt.Errorf("Climater not avaliable: %s", err)
 }
 
 var _ api.SocLimiter = (*Provider)(nil)
@@ -124,7 +124,7 @@ func (v *Provider) TargetSoC() (float64, error) {
 		return float64(res.Charging.ChargingSettings.Value.TargetSOCPct), nil
 	}
 
-	return 0, fmt.Errorf("Target SoC not avaliable")
+	return 0, fmt.Errorf("Target SoC not avaliable: %s", err)
 }
 
 var _ api.VehicleChargeController = (*Provider)(nil)

--- a/vehicle/vw/id/provider.go
+++ b/vehicle/vw/id/provider.go
@@ -38,7 +38,7 @@ func (v *Provider) SoC() (float64, error) {
 		return float64(res.Charging.BatteryStatus.Value.CurrentSOCPct), nil
 	}
 
-	return 0, fmt.Errorf("SoC not avaliable: %s", err)
+	return 0, err
 }
 
 var _ api.ChargeState = (*Provider)(nil)
@@ -58,7 +58,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		return status, nil
 	}
 
-	return "", fmt.Errorf("PlugStatus not avaliable: %s", err)
+	return "", err
 }
 
 var _ api.VehicleFinishTimer = (*Provider)(nil)
@@ -70,7 +70,7 @@ func (v *Provider) FinishTime() (time.Time, error) {
 		return res.Charging.ChargingStatus.Value.CarCapturedTimestamp.Add(time.Duration(res.Charging.ChargingStatus.Value.RemainingChargingTimeToCompleteMin) * time.Minute), err
 	}
 
-	return time.Time{}, fmt.Errorf("FinishTime not avaliable: %s", err)
+	return time.Time{}, err
 }
 
 var _ api.VehicleRange = (*Provider)(nil)
@@ -82,7 +82,7 @@ func (v *Provider) Range() (int64, error) {
 		return int64(res.Charging.BatteryStatus.Value.CruisingRangeElectricKm), nil
 	}
 
-	return 0, fmt.Errorf("Range not avaliable: %s", err)
+	return 0, err
 }
 
 var _ api.VehicleOdometer = (*Provider)(nil)
@@ -112,7 +112,7 @@ func (v *Provider) Climater() (active bool, outsideTemp, targetTemp float64, err
 		return active, outsideTemp, targetTemp, nil
 	}
 
-	return false, 0, 0, fmt.Errorf("Climater not avaliable: %s", err)
+	return false, 0, 0, err
 }
 
 var _ api.SocLimiter = (*Provider)(nil)
@@ -124,7 +124,7 @@ func (v *Provider) TargetSoC() (float64, error) {
 		return float64(res.Charging.ChargingSettings.Value.TargetSOCPct), nil
 	}
 
-	return 0, fmt.Errorf("Target SoC not avaliable: %s", err)
+	return 0, err
 }
 
 var _ api.VehicleChargeController = (*Provider)(nil)

--- a/vehicle/vw/id/provider.go
+++ b/vehicle/vw/id/provider.go
@@ -33,15 +33,12 @@ var _ api.Battery = (*Provider)(nil)
 // SoC implements the api.Vehicle interface
 func (v *Provider) SoC() (float64, error) {
 	res, err := v.statusG()
-	if err != nil {
-		return 0, err
+
+	if err == nil && res.Charging != nil {
+		return float64(res.Charging.BatteryStatus.Value.CurrentSOCPct), nil
 	}
 
-	if res.Charging == nil {
-		return 0, fmt.Errorf("SoC not avaliable")
-	}
-
-	return float64(res.Charging.BatteryStatus.Value.CurrentSOCPct), nil
+	return 0, fmt.Errorf("SoC not avaliable")
 }
 
 var _ api.ChargeState = (*Provider)(nil)
@@ -51,22 +48,17 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	status := api.StatusA // disconnected
 
 	res, err := v.statusG()
-	if err != nil {
-		return "", err
+	if err == nil && res.Charging != nil {
+		if res.Charging.PlugStatus.Value.PlugConnectionState == "connected" {
+			status = api.StatusB
+		}
+		if res.Charging.ChargingStatus.Value.ChargingState == "charging" {
+			status = api.StatusC
+		}
+		return status, nil
 	}
 
-	if res.Charging == nil {
-		return "", fmt.Errorf("PlugStatus not avaliable")
-	}
-
-	if res.Charging.PlugStatus.Value.PlugConnectionState == "connected" {
-		status = api.StatusB
-	}
-	if res.Charging.ChargingStatus.Value.ChargingState == "charging" {
-		status = api.StatusC
-	}
-
-	return status, err
+	return "", fmt.Errorf("PlugStatus not avaliable")
 }
 
 var _ api.VehicleFinishTimer = (*Provider)(nil)
@@ -74,16 +66,11 @@ var _ api.VehicleFinishTimer = (*Provider)(nil)
 // FinishTime implements the api.VehicleFinishTimer interface
 func (v *Provider) FinishTime() (time.Time, error) {
 	res, err := v.statusG()
-	if err != nil {
-		return time.Time{}, err
+	if err == nil && res.Charging != nil {
+		return res.Charging.ChargingStatus.Value.CarCapturedTimestamp.Add(time.Duration(res.Charging.ChargingStatus.Value.RemainingChargingTimeToCompleteMin) * time.Minute), err
 	}
 
-	if res.Charging == nil {
-		return time.Time{}, fmt.Errorf("Finishtime not avaliable")
-	}
-
-	return res.Charging.ChargingStatus.Value.CarCapturedTimestamp.Add(time.Duration(res.Charging.ChargingStatus.Value.RemainingChargingTimeToCompleteMin) * time.Minute), err
-
+	return time.Time{}, fmt.Errorf("FinishTime not avaliable")
 }
 
 var _ api.VehicleRange = (*Provider)(nil)
@@ -91,16 +78,11 @@ var _ api.VehicleRange = (*Provider)(nil)
 // Range implements the api.VehicleRange interface
 func (v *Provider) Range() (int64, error) {
 	res, err := v.statusG()
-	if err != nil {
-		return 0, err
+	if err == nil && res.Charging != nil {
+		return int64(res.Charging.BatteryStatus.Value.CruisingRangeElectricKm), nil
 	}
 
-	if res.Charging == nil {
-		return 0, fmt.Errorf("Range not avaliable")
-	}
-
-	return int64(res.Charging.BatteryStatus.Value.CruisingRangeElectricKm), nil
-
+	return 0, fmt.Errorf("Range not avaliable")
 }
 
 var _ api.VehicleOdometer = (*Provider)(nil)
@@ -115,27 +97,22 @@ var _ api.VehicleClimater = (*Provider)(nil)
 // Climater implements the api.VehicleClimater interface
 func (v *Provider) Climater() (active bool, outsideTemp, targetTemp float64, err error) {
 	res, err := v.statusG()
-	if err != nil {
-		return active, outsideTemp, targetTemp, err
+	if err == nil && res.Climatisation != nil {
+		state := strings.ToLower(res.Climatisation.ClimatisationStatus.Value.ClimatisationState)
+
+		if state == "" {
+			return false, 0, 0, api.ErrNotAvailable
+		}
+
+		active = state != "off" && state != "invalid" && state != "error"
+		targetTemp = float64(res.Climatisation.ClimatisationSettings.Value.TargetTemperatureC)
+		// TODO not available; use target temp to avoid wrong heating/cooling display
+		outsideTemp = targetTemp
+
+		return active, outsideTemp, targetTemp, nil
 	}
 
-	if res.Climatisation == nil {
-		return false, 0, 0, fmt.Errorf("Climater not avaliable")
-	}
-
-	state := strings.ToLower(res.Climatisation.ClimatisationStatus.Value.ClimatisationState)
-
-	if state == "" {
-		return false, 0, 0, api.ErrNotAvailable
-	}
-
-	active = state != "off" && state != "invalid" && state != "error"
-	targetTemp = float64(res.Climatisation.ClimatisationSettings.Value.TargetTemperatureC)
-	// TODO not available; use target temp to avoid wrong heating/cooling display
-	outsideTemp = targetTemp
-
-	return active, outsideTemp, targetTemp, nil
-
+	return false, 0, 0, fmt.Errorf("Climater not avaliable")
 }
 
 var _ api.SocLimiter = (*Provider)(nil)
@@ -143,15 +120,11 @@ var _ api.SocLimiter = (*Provider)(nil)
 // TargetSoC implements the api.SocLimiter interface
 func (v *Provider) TargetSoC() (float64, error) {
 	res, err := v.statusG()
-	if err != nil {
-		return 0, err
+	if err == nil && res.Charging != nil {
+		return float64(res.Charging.ChargingSettings.Value.TargetSOCPct), nil
 	}
 
-	if res.Charging == nil {
-		return 0, fmt.Errorf("Target SoC not avaliable")
-	}
-
-	return float64(res.Charging.ChargingSettings.Value.TargetSOCPct), nil
+	return 0, fmt.Errorf("Target SoC not avaliable")
 }
 
 var _ api.VehicleChargeController = (*Provider)(nil)

--- a/vehicle/vw/id/provider.go
+++ b/vehicle/vw/id/provider.go
@@ -36,6 +36,11 @@ func (v *Provider) SoC() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	if res.Charging == nil {
+		return 0, fmt.Errorf("SoC not avaliable")
+	}
+
 	return float64(res.Charging.BatteryStatus.Value.CurrentSOCPct), nil
 }
 
@@ -48,6 +53,10 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	res, err := v.statusG()
 	if err != nil {
 		return "", err
+	}
+
+	if res.Charging == nil {
+		return "", fmt.Errorf("PlugStatus not avaliable")
 	}
 
 	if res.Charging.PlugStatus.Value.PlugConnectionState == "connected" {
@@ -69,6 +78,10 @@ func (v *Provider) FinishTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 
+	if res.Charging == nil {
+		return time.Time{}, fmt.Errorf("Finishtime not avaliable")
+	}
+
 	return res.Charging.ChargingStatus.Value.CarCapturedTimestamp.Add(time.Duration(res.Charging.ChargingStatus.Value.RemainingChargingTimeToCompleteMin) * time.Minute), err
 
 }
@@ -80,6 +93,10 @@ func (v *Provider) Range() (int64, error) {
 	res, err := v.statusG()
 	if err != nil {
 		return 0, err
+	}
+
+	if res.Charging == nil {
+		return 0, fmt.Errorf("Range not avaliable")
 	}
 
 	return int64(res.Charging.BatteryStatus.Value.CruisingRangeElectricKm), nil
@@ -100,6 +117,10 @@ func (v *Provider) Climater() (active bool, outsideTemp, targetTemp float64, err
 	res, err := v.statusG()
 	if err != nil {
 		return active, outsideTemp, targetTemp, err
+	}
+
+	if res.Climatisation == nil {
+		return false, 0, 0, fmt.Errorf("Climater not avaliable")
 	}
 
 	state := strings.ToLower(res.Climatisation.ClimatisationStatus.Value.ClimatisationState)
@@ -125,6 +146,11 @@ func (v *Provider) TargetSoC() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	if res.Charging == nil {
+		return 0, fmt.Errorf("Target SoC not avaliable")
+	}
+
 	return float64(res.Charging.ChargingSettings.Value.TargetSOCPct), nil
 }
 

--- a/vehicle/vw/id/samples/selectivestatus.json
+++ b/vehicle/vw/id/samples/selectivestatus.json
@@ -1,0 +1,289 @@
+{
+    "automation": {
+        "climatisationTimer": {
+            "value": {
+                "timers": [
+                    {
+                        "id": 1,
+                        "enabled": true,
+                        "recurringTimer": {
+                            "startTime": "04:55",
+                            "recurringOn": {
+                                "mondays": false,
+                                "tuesdays": true,
+                                "wednesdays": true,
+                                "thursdays": true,
+                                "fridays": true,
+                                "saturdays": false,
+                                "sundays": false
+                            }
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "enabled": false,
+                        "singleTimer": {
+                            "startDateTime": "2022-11-26T06:45:00Z"
+                        }
+                    }
+                ],
+                "carCapturedTimestamp": "2022-12-05T21:25:30.835Z",
+                "timeInCar": "2022-12-05T22:25:31+01:00"
+            }
+        },
+        "chargingProfiles": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T21:25:32.234Z",
+                "timeInCar": "2022-12-05T22:25:31+01:00",
+                "profiles": []
+            }
+        }
+    },
+    "userCapabilities": {
+        "capabilitiesStatus": {
+            "value": [
+                {
+                    "id": "webApp",
+                    "userDisablingAllowed": false
+                },
+                {
+                    "id": "automation",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "charging",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "chargingProfiles",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": false
+                },
+                {
+                    "id": "chargingStations",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "climatisation",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "climatisationTimers",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": false
+                },
+                {
+                    "id": "destinations",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "fuelStatus",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": false
+                },
+                {
+                    "id": "ignition",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": false
+                },
+                {
+                    "id": "mapUpdate",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "onlineSpeech",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "parkingInformation",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "readiness",
+                    "userDisablingAllowed": false
+                },
+                {
+                    "id": "routing",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "trafficInformation",
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                },
+                {
+                    "id": "webRadio",
+                    "status": [
+                        1004
+                    ],
+                    "expirationDate": "2025-02-12T23:59:59Z",
+                    "userDisablingAllowed": true
+                }
+            ]
+        }
+    },
+    "charging": {
+        "batteryStatus": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T22:28:06Z",
+                "currentSOC_pct": 76,
+                "cruisingRangeElectric_km": 206
+            }
+        },
+        "chargingStatus": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T22:28:06Z",
+                "remainingChargingTimeToComplete_min": 5,
+                "chargingState": "charging",
+                "chargeMode": "manual",
+                "chargePower_kW": 10,
+                "chargeRate_kmph": 52,
+                "chargeType": "ac",
+                "chargingSettings": "default"
+            }
+        },
+        "chargingSettings": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T21:25:36Z",
+                "maxChargeCurrentAC": "maximum",
+                "autoUnlockPlugWhenCharged": "permanent",
+                "autoUnlockPlugWhenChargedAC": "permanent",
+                "targetSOC_pct": 80
+            }
+        },
+        "plugStatus": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T21:41:13Z",
+                "plugConnectionState": "connected",
+                "plugLockState": "locked",
+                "externalPower": "active",
+                "ledColor": "green"
+            }
+        },
+        "chargeMode": {
+            "value": {
+                "preferredChargeMode": "manual",
+                "availableChargeModes": [
+                    "invalid"
+                ]
+            }
+        }
+    },
+    "climatisation": {
+        "climatisationStatus": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T21:25:34Z",
+                "remainingClimatisationTime_min": 0,
+                "climatisationState": "off"
+            }
+        },
+        "climatisationSettings": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T21:25:34Z",
+                "targetTemperature_C": 22,
+                "targetTemperature_F": 72,
+                "unitInCar": "celsius",
+                "climatizationAtUnlock": true,
+                "windowHeatingEnabled": true,
+                "zoneFrontLeftEnabled": true,
+                "zoneFrontRightEnabled": false
+            }
+        },
+        "windowHeatingStatus": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T21:25:34Z",
+                "windowHeatingStatus": [
+                    {
+                        "windowLocation": "front",
+                        "windowHeatingState": "off"
+                    },
+                    {
+                        "windowLocation": "rear",
+                        "windowHeatingState": "off"
+                    }
+                ]
+            }
+        }
+    },
+    "climatisationTimers": {
+        "climatisationTimersStatus": {
+            "value": {
+                "timers": [
+                    {
+                        "id": 1,
+                        "enabled": true,
+                        "recurringTimer": {
+                            "startTime": "04:55",
+                            "recurringOn": {
+                                "mondays": false,
+                                "tuesdays": true,
+                                "wednesdays": true,
+                                "thursdays": true,
+                                "fridays": true,
+                                "saturdays": false,
+                                "sundays": false
+                            }
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "enabled": false,
+                        "singleTimer": {
+                            "startDateTime": "2022-11-26T06:45:00Z"
+                        }
+                    }
+                ],
+                "carCapturedTimestamp": "2022-12-05T21:25:30.835Z",
+                "timeInCar": "2022-12-05T22:25:31+01:00"
+            }
+        }
+    },
+    "fuelStatus": {
+        "rangeStatus": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T22:28:06Z",
+                "carType": "electric",
+                "primaryEngine": {
+                    "type": "electric",
+                    "currentSOC_pct": 76,
+                    "remainingRange_km": 206
+                },
+                "totalRange_km": 206
+            }
+        }
+    },
+    "readiness": {
+        "readinessStatus": {
+            "value": {
+                "connectionState": {
+                    "isOnline": true,
+                    "isActive": false,
+                    "batteryPowerLevel": "comfort",
+                    "dailyPowerBudgetAvailable": true
+                },
+                "connectionWarning": {
+                    "insufficientBatteryLevelWarning": false,
+                    "dailyPowerBudgetWarning": false
+                }
+            }
+        }
+    },
+    "chargingProfiles": {
+        "chargingProfilesStatus": {
+            "value": {
+                "carCapturedTimestamp": "2022-12-05T21:25:32.234Z",
+                "timeInCar": "2022-12-05T22:25:31+01:00",
+                "profiles": []
+            }
+        }
+    }
+}

--- a/vehicle/vw/id/types.go
+++ b/vehicle/vw/id/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SelectiveSatus struct {
-	Automation struct {
+	Automation *struct {
 		ClimatisationTimer struct {
 			Value struct {
 				Timers []struct {
@@ -33,7 +33,7 @@ type SelectiveSatus struct {
 				TimeInCar            Timestamp `json:"timeInCar"`
 			} `json:"value"`
 		} `json:"climatisationTimer"`
-		ChargingProfiles struct {
+		ChargingProfiles *struct {
 			Value struct {
 				CarCapturedTimestamp Timestamp     `json:"carCapturedTimestamp"`
 				TimeInCar            Timestamp     `json:"timeInCar"`
@@ -41,7 +41,7 @@ type SelectiveSatus struct {
 			} `json:"value"`
 		} `json:"chargingProfiles"`
 	} `json:"automation"`
-	UserCapabilities struct {
+	UserCapabilities *struct {
 		CapabilitiesStatus struct {
 			Value []struct {
 				ID                   string    `json:"id"`
@@ -51,7 +51,7 @@ type SelectiveSatus struct {
 			} `json:"value"`
 		} `json:"capabilitiesStatus"`
 	} `json:"userCapabilities"`
-	Charging struct {
+	Charging *struct {
 		BatteryStatus struct {
 			Value struct {
 				CarCapturedTimestamp    Timestamp `json:"carCapturedTimestamp"`
@@ -96,7 +96,7 @@ type SelectiveSatus struct {
 			} `json:"value"`
 		} `json:"chargeMode"`
 	} `json:"charging"`
-	Climatisation struct {
+	Climatisation *struct {
 		ClimatisationStatus struct {
 			Value struct {
 				CarCapturedTimestamp          Timestamp `json:"carCapturedTimestamp"`
@@ -126,7 +126,7 @@ type SelectiveSatus struct {
 			} `json:"value"`
 		} `json:"windowHeatingStatus"`
 	} `json:"climatisation"`
-	ClimatisationTimers struct {
+	ClimatisationTimers *struct {
 		ClimatisationTimersStatus struct {
 			Value struct {
 				Timers []struct {
@@ -153,7 +153,7 @@ type SelectiveSatus struct {
 			} `json:"value"`
 		} `json:"climatisationTimersStatus"`
 	} `json:"climatisationTimers"`
-	FuelStatus struct {
+	FuelStatus *struct {
 		RangeStatus struct {
 			Value struct {
 				CarCapturedTimestamp Timestamp `json:"carCapturedTimestamp"`
@@ -167,7 +167,7 @@ type SelectiveSatus struct {
 			} `json:"value"`
 		} `json:"rangeStatus"`
 	} `json:"fuelStatus"`
-	Readiness struct {
+	Readiness *struct {
 		ReadinessStatus struct {
 			Value struct {
 				ConnectionState struct {
@@ -183,7 +183,7 @@ type SelectiveSatus struct {
 			} `json:"value"`
 		} `json:"readinessStatus"`
 	} `json:"readiness"`
-	ChargingProfiles struct {
+	ChargingProfiles *struct {
 		ChargingProfilesStatus struct {
 			Value struct {
 				CarCapturedTimestamp Timestamp     `json:"carCapturedTimestamp"`

--- a/vehicle/vw/id/types.go
+++ b/vehicle/vw/id/types.go
@@ -6,18 +6,192 @@ import (
 	"time"
 )
 
-// Status is the /status api
-type Status struct {
-	Data struct {
-		BatteryStatus         `json:"batteryStatus"`
-		ChargingStatus        `json:"chargingStatus"`
-		ChargingSettings      `json:"chargingSettings"`
-		PlugStatus            `json:"plugStatus"`
-		RangeStatus           `json:"rangeStatus"`
-		ClimatisationSettings `json:"climatisationSettings"`
-		ClimatisationStatus   `json:"climatisationStatus"` // may be temporarily not available
-		*MaintenanceStatus    `json:"maintenanceStatus"`   // optional
-	}
+type SelectiveSatus struct {
+	Automation struct {
+		ClimatisationTimer struct {
+			Value struct {
+				Timers []struct {
+					ID             int  `json:"id"`
+					Enabled        bool `json:"enabled"`
+					RecurringTimer struct {
+						StartTime   string `json:"startTime"`
+						RecurringOn struct {
+							Mondays    bool `json:"mondays"`
+							Tuesdays   bool `json:"tuesdays"`
+							Wednesdays bool `json:"wednesdays"`
+							Thursdays  bool `json:"thursdays"`
+							Fridays    bool `json:"fridays"`
+							Saturdays  bool `json:"saturdays"`
+							Sundays    bool `json:"sundays"`
+						} `json:"recurringOn"`
+					} `json:"recurringTimer,omitempty"`
+					SingleTimer struct {
+						StartDateTime Timestamp `json:"startDateTime"`
+					} `json:"singleTimer,omitempty"`
+				} `json:"timers"`
+				CarCapturedTimestamp Timestamp `json:"carCapturedTimestamp"`
+				TimeInCar            Timestamp `json:"timeInCar"`
+			} `json:"value"`
+		} `json:"climatisationTimer"`
+		ChargingProfiles struct {
+			Value struct {
+				CarCapturedTimestamp Timestamp     `json:"carCapturedTimestamp"`
+				TimeInCar            Timestamp     `json:"timeInCar"`
+				Profiles             []interface{} `json:"profiles"`
+			} `json:"value"`
+		} `json:"chargingProfiles"`
+	} `json:"automation"`
+	UserCapabilities struct {
+		CapabilitiesStatus struct {
+			Value []struct {
+				ID                   string    `json:"id"`
+				UserDisablingAllowed bool      `json:"userDisablingAllowed"`
+				ExpirationDate       Timestamp `json:"expirationDate,omitempty"`
+				Status               []int     `json:"status,omitempty"`
+			} `json:"value"`
+		} `json:"capabilitiesStatus"`
+	} `json:"userCapabilities"`
+	Charging struct {
+		BatteryStatus struct {
+			Value struct {
+				CarCapturedTimestamp    Timestamp `json:"carCapturedTimestamp"`
+				CurrentSOCPct           int       `json:"currentSOC_pct"`
+				CruisingRangeElectricKm int       `json:"cruisingRangeElectric_km"`
+			} `json:"value"`
+		} `json:"batteryStatus"`
+		ChargingStatus struct {
+			Value struct {
+				CarCapturedTimestamp               Timestamp `json:"carCapturedTimestamp"`
+				RemainingChargingTimeToCompleteMin int       `json:"remainingChargingTimeToComplete_min"`
+				ChargingState                      string    `json:"chargingState"` // readyForCharging/off
+				ChargeMode                         string    `json:"chargeMode"`    // invalid
+				ChargePowerKW                      int       `json:"chargePower_kW"`
+				ChargeRateKmph                     int       `json:"chargeRate_kmph"`
+				ChargeType                         string    `json:"chargeType"`
+				ChargingSettings                   string    `json:"chargingSettings"`
+			} `json:"value"`
+		} `json:"chargingStatus"`
+		ChargingSettings struct {
+			Value struct {
+				CarCapturedTimestamp        Timestamp `json:"carCapturedTimestamp"`
+				MaxChargeCurrentAC          string    `json:"maxChargeCurrentAC"` // reduced, maximum
+				AutoUnlockPlugWhenCharged   string    `json:"autoUnlockPlugWhenCharged"`
+				AutoUnlockPlugWhenChargedAC string    `json:"autoUnlockPlugWhenChargedAC"`
+				TargetSOCPct                int       `json:"targetSOC_pct"`
+			} `json:"value"`
+		} `json:"chargingSettings"`
+		PlugStatus struct {
+			Value struct {
+				CarCapturedTimestamp Timestamp `json:"carCapturedTimestamp"`
+				PlugConnectionState  string    `json:"plugConnectionState"` // connected, disconnected
+				PlugLockState        string    `json:"plugLockState"`       // locked, unlocked
+				ExternalPower        string    `json:"externalPower"`
+				LedColor             string    `json:"ledColor"`
+			} `json:"value"`
+		} `json:"plugStatus"`
+		ChargeMode struct {
+			Value struct {
+				PreferredChargeMode  string   `json:"preferredChargeMode"`
+				AvailableChargeModes []string `json:"availableChargeModes"`
+			} `json:"value"`
+		} `json:"chargeMode"`
+	} `json:"charging"`
+	Climatisation struct {
+		ClimatisationStatus struct {
+			Value struct {
+				CarCapturedTimestamp          Timestamp `json:"carCapturedTimestamp"`
+				RemainingClimatisationTimeMin int       `json:"remainingClimatisationTime_min"`
+				ClimatisationState            string    `json:"climatisationState"` // off
+			} `json:"value"`
+		} `json:"climatisationStatus"` // may be temporarily not available
+		ClimatisationSettings struct {
+			Value struct {
+				CarCapturedTimestamp  Timestamp `json:"carCapturedTimestamp"`
+				TargetTemperatureC    int       `json:"targetTemperature_C"`
+				TargetTemperatureF    int       `json:"targetTemperature_F"`
+				UnitInCar             string    `json:"unitInCar"`
+				ClimatizationAtUnlock bool      `json:"climatizationAtUnlock"` // ClimatizationAtUnlock?
+				WindowHeatingEnabled  bool      `json:"windowHeatingEnabled"`
+				ZoneFrontLeftEnabled  bool      `json:"zoneFrontLeftEnabled"`
+				ZoneFrontRightEnabled bool      `json:"zoneFrontRightEnabled"`
+			} `json:"value"`
+		} `json:"climatisationSettings"`
+		WindowHeatingStatus struct {
+			Value struct {
+				CarCapturedTimestamp Timestamp `json:"carCapturedTimestamp"`
+				WindowHeatingStatus  []struct {
+					WindowLocation     string `json:"windowLocation"`
+					WindowHeatingState string `json:"windowHeatingState"`
+				} `json:"windowHeatingStatus"`
+			} `json:"value"`
+		} `json:"windowHeatingStatus"`
+	} `json:"climatisation"`
+	ClimatisationTimers struct {
+		ClimatisationTimersStatus struct {
+			Value struct {
+				Timers []struct {
+					ID             int  `json:"id"`
+					Enabled        bool `json:"enabled"`
+					RecurringTimer struct {
+						StartTime   string `json:"startTime"`
+						RecurringOn struct {
+							Mondays    bool `json:"mondays"`
+							Tuesdays   bool `json:"tuesdays"`
+							Wednesdays bool `json:"wednesdays"`
+							Thursdays  bool `json:"thursdays"`
+							Fridays    bool `json:"fridays"`
+							Saturdays  bool `json:"saturdays"`
+							Sundays    bool `json:"sundays"`
+						} `json:"recurringOn"`
+					} `json:"recurringTimer,omitempty"`
+					SingleTimer struct {
+						StartDateTime Timestamp `json:"startDateTime"`
+					} `json:"singleTimer,omitempty"`
+				} `json:"timers"`
+				CarCapturedTimestamp Timestamp `json:"carCapturedTimestamp"`
+				TimeInCar            Timestamp `json:"timeInCar"`
+			} `json:"value"`
+		} `json:"climatisationTimersStatus"`
+	} `json:"climatisationTimers"`
+	FuelStatus struct {
+		RangeStatus struct {
+			Value struct {
+				CarCapturedTimestamp Timestamp `json:"carCapturedTimestamp"`
+				CarType              string    `json:"carType"`
+				PrimaryEngine        struct {
+					Type             string `json:"type"`
+					CurrentSOCPct    int    `json:"currentSOC_pct"`
+					RemainingRangeKm int    `json:"remainingRange_km"`
+				} `json:"primaryEngine"`
+				TotalRangeKm int `json:"totalRange_km"`
+			} `json:"value"`
+		} `json:"rangeStatus"`
+	} `json:"fuelStatus"`
+	Readiness struct {
+		ReadinessStatus struct {
+			Value struct {
+				ConnectionState struct {
+					IsOnline                  bool   `json:"isOnline"`
+					IsActive                  bool   `json:"isActive"`
+					BatteryPowerLevel         string `json:"batteryPowerLevel"`
+					DailyPowerBudgetAvailable bool   `json:"dailyPowerBudgetAvailable"`
+				} `json:"connectionState"`
+				ConnectionWarning struct {
+					InsufficientBatteryLevelWarning bool `json:"insufficientBatteryLevelWarning"`
+					DailyPowerBudgetWarning         bool `json:"dailyPowerBudgetWarning"`
+				} `json:"connectionWarning"`
+			} `json:"value"`
+		} `json:"readinessStatus"`
+	} `json:"readiness"`
+	ChargingProfiles struct {
+		ChargingProfilesStatus struct {
+			Value struct {
+				CarCapturedTimestamp Timestamp     `json:"carCapturedTimestamp"`
+				TimeInCar            Timestamp     `json:"timeInCar"`
+				Profiles             []interface{} `json:"profiles"`
+			} `json:"value"`
+		} `json:"chargingProfilesStatus"`
+	} `json:"chargingProfiles"`
 	Error ErrorMap
 }
 
@@ -37,81 +211,6 @@ func (e ErrorMap) Extract(key string) error {
 type Error struct {
 	Code          int
 	Message, Info string
-}
-
-// BatteryStatus is the /status.batteryStatus api
-type BatteryStatus struct {
-	CarCapturedTimestamp    Timestamp
-	CurrentSOCPercent       int `json:"currentSOC_pct"`
-	CruisingRangeElectricKm int `json:"cruisingRangeElectric_km"`
-}
-
-// ChargingStatus is the /status.chargingStatus api
-type ChargingStatus struct {
-	CarCapturedTimestamp               Timestamp
-	ChargingState                      string  // readyForCharging/off
-	ChargeMode                         string  // invalid
-	RemainingChargingTimeToCompleteMin int     `json:"remainingChargingTimeToComplete_min"`
-	ChargePowerKW                      float64 `json:"chargePower_kW"`
-	ChargeRateKmph                     float64 `json:"chargeRate_kmph"`
-}
-
-// ChargingSettings is the /status.chargingSettings api
-type ChargingSettings struct {
-	CarCapturedTimestamp      Timestamp
-	MaxChargeCurrentAC        string // reduced, maximum
-	AutoUnlockPlugWhenCharged string
-	TargetSOCPercent          int `json:"targetSOC_pct"`
-}
-
-// PlugStatus is the /status.plugStatus api
-type PlugStatus struct {
-	CarCapturedTimestamp Timestamp
-	PlugConnectionState  string // connected, disconnected
-	PlugLockState        string // locked, unlocked
-}
-
-// ClimatisationStatus is the /status.climatisationStatus api
-type ClimatisationStatus struct {
-	CarCapturedTimestamp          Timestamp
-	RemainingClimatisationTimeMin int    `json:"remainingClimatisationTime_min"`
-	ClimatisationState            string // off
-}
-
-// ClimatisationSettings is the /status.climatisationSettings api
-type ClimatisationSettings struct {
-	CarCapturedTimestamp              Timestamp
-	TargetTemperatureK                float64 `json:"targetTemperature_K"`
-	TargetTemperatureC                float64 `json:"targetTemperature_C"`
-	ClimatisationWithoutExternalPower bool
-	ClimatisationAtUnlock             bool // ClimatizationAtUnlock?
-	WindowHeatingEnabled              bool
-	ZoneFrontLeftEnabled              bool
-	ZoneFrontRightEnabled             bool
-	ZoneRearLeftEnabled               bool
-	ZoneRearRightEnabled              bool
-}
-
-// RangeStatus is the /status.rangeStatus api
-type RangeStatus struct {
-	CarCapturedTimestamp Timestamp
-	CarType              string
-	PrimaryEngine        struct {
-		Type              string
-		CurrentSOCPercent int `json:"currentSOC_pct"`
-		RemainingRangeKm  int `json:"remainingRange_km"`
-	}
-	TotalRangeKm int `json:"totalRange_km"`
-}
-
-// MaintenanceStatus is the /status.maintenanceStatus api
-type MaintenanceStatus struct {
-	CarCapturedTimestamp Timestamp // "2021-09-04T14:59:10Z",
-	InspectionDueDays    int       `json:"inspectionDue_days"`
-	InspectionDueKm      int       `json:"inspectionDue_km"`
-	MileageKm            int       `json:"mileage_km"`
-	OilServiceDueDays    int       `json:"oilServiceDue_days"`
-	OilServiceDueKm      int       `json:"oilServiceDue_km"`
 }
 
 // Timestamp implements JSON unmarshal

--- a/vehicle/vw/id/types_test.go
+++ b/vehicle/vw/id/types_test.go
@@ -6,34 +6,17 @@ import (
 	"testing"
 )
 
-//go:embed samples/status.json
+//go:embed samples/selectivestatus.json
 var data []byte
 
 func TestStatus(t *testing.T) {
-	var status Status
+	var status SelectiveSatus
 	if err := json.Unmarshal(data, &status); err != nil {
 		t.Error(err)
 	}
 
-	if v := status.Data.ChargingStatus.RemainingChargingTimeToCompleteMin; v != 120 {
+	if v := status.Charging.ChargingStatus.Value.RemainingChargingTimeToCompleteMin; v != 5 {
 		t.Error("invalid RemainingChargingTimeToCompleteMin", v)
 	}
 
-	if status.Data.MaintenanceStatus != nil {
-		t.Error("unexpected MaintenanceStatus")
-	}
-}
-
-//go:embed samples/status2.json
-var data2 []byte
-
-func TestStatus2(t *testing.T) {
-	var status Status
-	if err := json.Unmarshal(data2, &status); err != nil {
-		t.Error(err)
-	}
-
-	if status.Data.MaintenanceStatus == nil || status.Data.MaintenanceStatus.MileageKm == 0 {
-		t.Error("invalid MaintenanceStatus.MileageKm")
-	}
 }


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/5388

As mentioned in #5388 the `/status` endpoint doesn't return information anymore.

The `/selectivestatus` is an alternative. 

The returned JSON is different but I didn't want to change the used Status model so I made a small workaround by transforming the data to fit the current `Status` struct again. 

I am open for a different approach but this way we could switch back if needed to the `/status` endpoint without bigger issues.

`gjson` is convenience lib and could be replaces by `map[]interface{}` casting and usage, but I could image `gjson` being helpful in other parts as well. 

Looking foward to feedback on this one @andig 