### PR TITLE
TotalEnergy 4 goe-e Charger api v1

### DIFF
--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -41,7 +41,7 @@ func init() {
 	registry.Add("go-e", NewGoEFromConfig)
 }
 
-// go:generate go run ../cmd/tools/decorate.go -f decorateGoE -b *GoE -r api.Charger -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.PhaseSwitcher,Phases1p3p,func(int) (error)"
+// go:generate go run ../cmd/tools/decorate.go -f decorateGoE -b *GoE -r api.Charger -t "api.MeterEnergy,func() (float64, error)" -t "api.PhaseSwitcher,Phases1p3p,func(int) (error)"
 
 // NewGoEFromConfig creates a go-e charger from generic config
 func NewGoEFromConfig(other map[string]interface{}) (api.Charger, error) {
@@ -82,7 +82,7 @@ func NewGoE(uri, token string, cache time.Duration) (api.Charger, error) {
 	}
 
 	if c.api.IsV2() {
-		return decorateGoE(c, c.totalEnergy, c.phases1p3p), nil
+		return decorateGoE(c, c.phases1p3p), nil
 	}
 
 	return c, nil
@@ -187,19 +187,16 @@ func (c *GoE) Identify() (string, error) {
 	return resp.Identify(), nil
 }
 
+var _ api.MeterEnergy = (*GoE)(nil)
+
 // totalEnergy implements the api.MeterEnergy interface - v2 only
-func (c *GoE) totalEnergy() (float64, error) {
+func (c *GoE) TotalEnergy() (float64, error) {
 	resp, err := c.api.Status()
 	if err != nil {
 		return 0, err
 	}
 
-	var val float64
-	if res, ok := resp.(*goe.StatusResponse2); ok {
-		val = res.TotalEnergy()
-	}
-
-	return val, err
+	return resp.TotalEnergy(), err
 }
 
 // phases1p3p implements the api.PhaseSwitcher interface - v2 only

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -18,6 +18,7 @@ type Response interface {
 	Enabled() bool
 	CurrentPower() float64
 	ChargedEnergy() float64
+	TotalEnergy() float64
 	Currents() (float64, float64, float64)
 	Identify() string
 }

--- a/charger/go-e/types.go
+++ b/charger/go-e/types.go
@@ -15,6 +15,7 @@ type StatusResponse struct {
 	Alw int       `json:"alw,string"` // allow charging
 	Amp int       `json:"amp,string"` // current [A]
 	Err int       `json:"err,string"` // error
+	Eto int       `json:"eto,string"` // energy total Wh
 	Stp int       `json:"stp,string"` // stop state
 	Tmp int       `json:"tmp,string"` // temperature [°C]
 	Dws int       `json:"dws,string"` // energy [Ws]
@@ -49,6 +50,10 @@ func (g *StatusResponse) CurrentPower() float64 {
 
 func (g *StatusResponse) ChargedEnergy() float64 {
 	return float64(g.Dws) / 3.6e5 // Deka-Watt-Seconds to kWh (100.000 == 0,277kWh)
+}
+
+func (g *StatusResponse) TotalEnergy() float64 {
+	return float64(g.Eto) / 1e1 // 0.1kWh to kWh (130 == 13kWh)
 }
 
 func (g *StatusResponse) Currents() (float64, float64, float64) {

--- a/charger/go-e/types.go
+++ b/charger/go-e/types.go
@@ -15,7 +15,7 @@ type StatusResponse struct {
 	Alw int       `json:"alw,string"` // allow charging
 	Amp int       `json:"amp,string"` // current [A]
 	Err int       `json:"err,string"` // error
-	Eto int       `json:"eto,string"` // energy total Wh
+	Eto int       `json:"eto,string"` // energy total [0.1kWh]
 	Stp int       `json:"stp,string"` // stop state
 	Tmp int       `json:"tmp,string"` // temperature [°C]
 	Dws int       `json:"dws,string"` // energy [Ws]


### PR DESCRIPTION
Add TotalEnergy charge meter for api version 1 to support charge session log.

Session log export:
![image](https://user-images.githubusercontent.com/77847348/207442678-477660f3-892a-4400-9bd9-08cc7084b0dc.png)

go-e V1 charger test:
```bash
thierolm@accffmmt:~/evcc$ ./evcc -c ./evcc.yaml -l debug charger
[main  ] INFO 2022/12/13 21:40:05 evcc 0.109.2 (9927ea14)
[main  ] INFO 2022/12/13 21:40:05 using config file: ./evcc.yaml
[go-e  ] TRACE 2022/12/13 21:40:07 GET http://192.168.178.46/api/status?filter=alw
[go-e  ] TRACE 2022/12/13 21:40:07 Not found: /api/status

go-eCharger (Lokal)
-------------------
[go-e  ] TRACE 2022/12/13 21:40:07 GET http://192.168.178.46/status
[go-e  ] TRACE 2022/12/13 21:40:07 {"version":"B","tme":"1312222140","rbc":"14","rbt":"2259249302","car":"4","amp":"16","err":"0","ast":"0","alw":"0","stp":"0","cbl":"20","pha":"56","tmp":"12","tma":[8.63,7.88,8.13,7.75,-0.13,-0.13],"amt":"32","dws":"3899947","dwo":"0","adi":"0","uby":"0","eto":"53290","wst":"3","txi":"0","nrg":[224,223,223,1,0,0,0,0,0,0,0,0,0,0,0,0],"fwv":"041.0","sse":"011539","wss":"XXX-WLAN","wke":"*********","wen":"1","cdi":"0","tof":"101","tds":"1","lbr":"148","aho":"3","afi":"7","azo":"1","ama":"16","al1":"8","al2":"9","al3":"10","al4":"13","al5":"16","cid":"255","cch":"65535","cfi":"65280","lse":"1","ust":"0","wak":"eb53686bc4","r1x":"2","dto":"0","nmo":"0","sch":"AAAAAAAAAAAAAAAA","sdp":"0","eca":"0","ecr":"0","ecd":"0","ec4":"0","ec5":"0","ec6":"0","ec7":"0","ec8":"0","ec9":"0","ec1":"0","rca":"597DF3B8","rcr":"","rcd":"","rc4":"","rc5":"","rc6":"","rc7":"","rc8":"","rc9":"","rc1":"","rna":"","rnm":"","rne":"","rn4":"","rn5":"","rn6":"","rn7":"","rn8":"","rn9":"","rn1":"","loe":0,"lot":0,"lom":0,"lop":0,"log":"","lon":0,"lof":0,"loa":0,"lch":17319,"mce":0,"mcs":"test.mosquitto.org","mcp":1883,"mcu":"","mck":"","mcc":0}
Power:          0W
Energy:         5329.0kWh
Current L1..L3: 0A 0A 0A
Charge status:  B
Enabled:        false
Charged:        10.8kWh
Identifier:     <none>
```

- [x] Test API V1 version = B
- [x] Test API V1 version = B with missing eto tag
- [ ] Test API V1 version <> B
- [ ] Regressiontest API V2

Looking for testers of the last 2 open tests. :-)