### PR TITLE
Tibber Pulse: production power, better timeouts

### DIFF
--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -9,13 +9,14 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/tibber"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/request"
 	"github.com/hasura/go-graphql-client"
 )
 
 func init() {
 	registry.Add("tibber-pulse", NewTibberFromConfig)
 }
+
+var timeout = time.Minute
 
 type Tibber struct {
 	mu      sync.Mutex
@@ -57,6 +58,7 @@ func NewTibberFromConfig(other map[string]interface{}) (api.Meter, error) {
 		WithConnectionParams(map[string]any{
 			"token": cc.Token,
 		}).
+		WithRetryTimeout(timeout).
 		WithLog(t.log.TRACE.Println)
 
 	// run the client
@@ -117,7 +119,7 @@ func (t *Tibber) subscribe(client *graphql.SubscriptionClient, homeID string) er
 	if err == nil {
 		select {
 		case <-recv:
-		case <-time.After(request.Timeout):
+		case <-time.After(timeout):
 			err = api.ErrTimeout
 		case err = <-errC:
 		}
@@ -131,11 +133,16 @@ func (t *Tibber) CurrentPower() (float64, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if time.Since(t.updated) > request.Timeout {
+	if time.Since(t.updated) > timeout {
 		return 0, api.ErrTimeout
 	}
 
-	return t.live.Power, nil
+	power := t.live.Power
+	if t.live.PowerProduction > 0 {
+		power = -t.live.PowerProduction
+	}
+
+	return power, nil
 }
 
 var _ api.MeterCurrent = (*Tibber)(nil)
@@ -145,7 +152,7 @@ func (t *Tibber) Currents() (float64, float64, float64, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if time.Since(t.updated) > request.Timeout {
+	if time.Since(t.updated) > timeout {
 		return 0, 0, 0, api.ErrTimeout
 	}
 

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -137,12 +137,7 @@ func (t *Tibber) CurrentPower() (float64, error) {
 		return 0, api.ErrTimeout
 	}
 
-	power := t.live.Power
-	if t.live.PowerProduction > 0 {
-		power = -t.live.PowerProduction
-	}
-
-	return power, nil
+	return t.live.Power - t.live.PowerProduction, nil
 }
 
 var _ api.MeterCurrent = (*Tibber)(nil)

--- a/meter/tibber/types.go
+++ b/meter/tibber/types.go
@@ -40,6 +40,7 @@ type PriceInfo struct {
 type LiveMeasurement struct {
 	// Timestamp                       time.Time
 	Power                           float64
+	PowerProduction                 float64
 	LastMeterConsumption            float64
 	LastMeterProduction             float64
 	CurrentL1, CurrentL2, CurrentL3 float64


### PR DESCRIPTION
- support production power (negativ values for feed in)
- more liberal timeouts. The readings seem do come in bursts and not in well defined intervals 
- less aggressive reconnection behaviour