### PR TITLE
Simplify vehicle identification

### DIFF
--- a/core/coordinator/adapter.go
+++ b/core/coordinator/adapter.go
@@ -31,7 +31,7 @@ func (a *adapter) Release(v api.Vehicle) {
 	a.c.release(v)
 }
 
-func (a *adapter) IdentifyVehicleByStatus(includeIdCapable bool) api.Vehicle {
-	available := a.c.availableDetectibleVehicles(a.lp, includeIdCapable)
+func (a *adapter) IdentifyVehicleByStatus() api.Vehicle {
+	available := a.c.availableDetectibleVehicles(a.lp)
 	return a.c.identifyVehicleByStatus(available)
 }

--- a/core/coordinator/api.go
+++ b/core/coordinator/api.go
@@ -7,5 +7,5 @@ type API interface {
 	GetVehicles() []api.Vehicle
 	Acquire(api.Vehicle)
 	Release(api.Vehicle)
-	IdentifyVehicleByStatus(includeIdCapable bool) api.Vehicle
+	IdentifyVehicleByStatus() api.Vehicle
 }

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -39,7 +39,7 @@ func (c *Coordinator) release(vehicle api.Vehicle) {
 
 // availableDetectibleVehicles is the list of vehicles that are currently not
 // associated to another loadpoint and have a status api that allows for detection
-func (c *Coordinator) availableDetectibleVehicles(owner loadpoint.API, includeIdCapable bool) []api.Vehicle {
+func (c *Coordinator) availableDetectibleVehicles(owner loadpoint.API) []api.Vehicle {
 	var res []api.Vehicle
 
 	for _, vv := range c.vehicles {
@@ -47,10 +47,7 @@ func (c *Coordinator) availableDetectibleVehicles(owner loadpoint.API, includeId
 		if _, ok := vv.(api.ChargeState); ok {
 			// available or associated to current loadpoint
 			if o, ok := c.tracked[vv]; o == owner || !ok {
-				// no identifiers configured or identifiers ignored
-				if includeIdCapable || len(vv.Identifiers()) == 0 {
-					res = append(res, vv)
-				}
+				res = append(res, vv)
 			}
 		}
 	}

--- a/core/coordinator/coordinator_test.go
+++ b/core/coordinator/coordinator_test.go
@@ -52,7 +52,7 @@ func TestVehicleDetectByStatus(t *testing.T) {
 		v1.MockChargeState.EXPECT().Status().Return(tc.v1, nil)
 		v2.MockChargeState.EXPECT().Status().Return(tc.v2, nil)
 
-		available := c.availableDetectibleVehicles(lp, true) // include id-able vehicles
+		available := c.availableDetectibleVehicles(lp) // include id-able vehicles
 		res := c.identifyVehicleByStatus(available)
 		if tc.res != res {
 			t.Errorf("expected %v, got %v", tc.res, res)

--- a/core/coordinator/dummy.go
+++ b/core/coordinator/dummy.go
@@ -19,6 +19,6 @@ func (a *dummy) Acquire(v api.Vehicle) {}
 
 func (a *dummy) Release(v api.Vehicle) {}
 
-func (a *dummy) IdentifyVehicleByStatus(includeIdCapable bool) api.Vehicle {
+func (a *dummy) IdentifyVehicleByStatus() api.Vehicle {
 	return nil
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1036,17 +1036,7 @@ func (lp *LoadPoint) identifyVehicleByStatus() {
 		return
 	}
 
-	// decide if id-able vehicles should be included https://github.com/evcc-io/evcc/pull/5469
-	var ignoreIdCapable bool
-	if identifier, ok := lp.charger.(api.Identifier); ok {
-		id, err := identifier.Identify()
-		if err != nil {
-			lp.log.ERROR.Println("charger vehicle id:", err)
-		}
-		ignoreIdCapable = id != ""
-	}
-
-	if vehicle := lp.coordinator.IdentifyVehicleByStatus(!ignoreIdCapable); vehicle != nil {
+	if vehicle := lp.coordinator.IdentifyVehicleByStatus(); vehicle != nil {
 		lp.stopVehicleDetection()
 		lp.setActiveVehicle(vehicle)
 		return


### PR DESCRIPTION
In https://github.com/evcc-io/evcc/pull/5469, we fixed an issue where an id-capable vehicle was excluded from detection by status when the charger did not return the vehicles id. The logic added is complex and error-prone. This PR changes that by always including all vehicles in the detection, if they are tagged with an id or not. This approach should not introduce side effects since identification-by-status is always only executed when identification-by-id has failed.

/cc @DerAndereAndi ok?