### PR TITLE
Fix EEBUS setup timing issue

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -198,7 +198,7 @@ func configureEEBus(conf map[string]interface{}) error {
 		return fmt.Errorf("failed configuring eebus: %w", err)
 	}
 
-	go server.EEBusInstance.Run()
+	server.EEBusInstance.Run()
 	shutdown.Register(server.EEBusInstance.Shutdown)
 
 	return nil


### PR DESCRIPTION
The EBBUS server should not be started in a go-routine. If avahi connection takes too long, it can happen that devices are registered and thus searched for, before mDNS setup is complete.

This change results in a slower startup, roughly 1s, as checking if avahi is available is now blocking.

I’ll check if I can change the setup code to be non blocking and device registrations not to cause issues when the mDNS server is not ready. See https://github.com/enbility/eebus-go/issues/44