### PR TITLE
Disable charger when charging while disabled

### DIFF
--- a/charger/openwb.go
+++ b/charger/openwb.go
@@ -18,9 +18,8 @@ func init() {
 
 // OpenWB configures generic charger and charge meter for an openWB loadpoint
 type OpenWB struct {
-	current int64
-	enabled bool
-	// enabledG      func() (int64, error)
+	current       int64
+	enabled       bool
 	statusG       func() (string, error)
 	currentS      func(int64) error
 	currentPowerG func() (float64, error)
@@ -86,9 +85,6 @@ func NewOpenWB(log *util.Logger, mqttconf mqtt.Config, id int, topic string, p1p
 	chargingG := boolG(fmt.Sprintf("%s/lp/%d/%s", topic, id, openwb.ChargingTopic))
 	statusG := provider.NewOpenWBStatusProvider(pluggedG, chargingG).StringGetter
 
-	// getters
-	// enabledG := intG(fmt.Sprintf("%s/lp/%d/%s", topic, id, openwb.MaxCurrentTopic))
-
 	// setters
 	currentTopic := openwb.SlaveChargeCurrentTopic
 	if id == 2 {
@@ -120,8 +116,7 @@ func NewOpenWB(log *util.Logger, mqttconf mqtt.Config, id int, topic string, p1p
 	}
 
 	c := &OpenWB{
-		currentS: currentS,
-		// enabledG:      enabledG,
+		currentS:      currentS,
 		statusG:       statusG,
 		currentPowerG: currentPowerG,
 		totalEnergyG:  totalEnergyG,
@@ -182,7 +177,6 @@ func (m *OpenWB) Enable(enable bool) error {
 }
 
 func (m *OpenWB) Enabled() (bool, error) {
-	// current, err := m.enabledG()
 	return m.enabled, nil
 }
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -609,7 +609,10 @@ func (lp *Loadpoint) syncCharger() {
 		}
 
 		if !enabled && lp.charging() {
-			lp.log.WARN.Println("charger logic error: disabled but charging")
+			if time.Since(lp.guardUpdated) > guardGracePeriod {
+				lp.log.WARN.Println("charger logic error: disabled but charging")
+			}
+			err = lp.charger.Enable(false)
 		}
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/5544. 

Helps with chargers that are not able to provide "enabled" state. Also adds grace period to the warning.