### PR TITLE
Expire timers whenever mode is changed

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1899,6 +1899,7 @@ func (lp *Loadpoint) Update(sitePower float64, batteryBuffered bool) {
 
 	case mode == api.ModeOff:
 		err = lp.setLimit(0, true)
+		lp.resetPhaseTimer()
 		lp.resetPVTimer()
 
 	// immediate charging

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1901,18 +1901,16 @@ func (lp *Loadpoint) Update(sitePower float64, batteryBuffered bool) {
 		err = lp.setLimit(0, true)
 		lp.resetPVTimer()
 
-	case lp.minSocNotReached():
-		err = lp.fastCharging()
-		lp.elapsePVTimer() // let PV mode disable immediately afterwards
-
 	// immediate charging
 	case mode == api.ModeNow:
 		err = lp.fastCharging()
+		lp.resetPhaseTimer()
 		lp.resetPVTimer()
 
-	// target charging
-	case lp.plannerActive():
+	// minimum or target charging
+	case lp.minSocNotReached() || lp.plannerActive():
 		err = lp.fastCharging()
+		lp.resetPhaseTimer()
 		lp.elapsePVTimer() // let PV mode disable immediately afterwards
 
 	case mode == api.ModeMinPV || mode == api.ModePV:


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/5182, fix https://github.com/evcc-io/evcc/issues/5242

This PR consistently resets the PV timer on any non-PV (or min+pv) mode. `plannerActive` is updated to behave like `minSocNotReached` i.e. pv mode will be allowed to immediately disable when plan is no longer active without waiting for pv timer.

/cc @Hofyyy 