### PR TITLE
Fix Vestel EVC04 charge status error

### DIFF
--- a/charger/vestel.go
+++ b/charger/vestel.go
@@ -29,20 +29,20 @@ import (
 )
 
 const (
-	vestelRegSerial           = 100 // 25
-	vestelRegBrand            = 190 // 10
-	vestelRegModel            = 210 // 5
-	vestelRegFirmware         = 230 // 50
-	vestelRegChargepointState = 1000
-	vestelRegChargeStatus     = 1001
-	vestelRegCableStatus      = 1004
-	vestelRegChargeTime       = 1508
-	vestelRegMaxCurrent       = 5004
-	vestelRegPower            = 1020
-	vestelRegTotalEnergy      = 1036
-	vestelRegSessionEnergy    = 1502
-	vestelRegFailsafeTimeout  = 2002
-	vestelRegAlive            = 6000
+	vestelRegSerial          = 100 // 25
+	vestelRegBrand           = 190 // 10
+	vestelRegModel           = 210 // 5
+	vestelRegFirmware        = 230 // 50
+	vestelRegChargeStatus    = 1001
+	vestelRegCableStatus     = 1004
+	vestelRegChargeTime      = 1508
+	vestelRegMaxCurrent      = 5004
+	vestelRegPower           = 1020
+	vestelRegTotalEnergy     = 1036
+	vestelRegSessionEnergy   = 1502
+	vestelRegFailsafeTimeout = 2002
+	vestelRegAlive           = 6000
+	//vestelRegChargepointState = 1000
 )
 
 var vestelRegCurrents = []uint16{1008, 1010, 1012} // non-continuous uint16 registers!

--- a/charger/vestel.go
+++ b/charger/vestel.go
@@ -232,7 +232,7 @@ func (wb *Vestel) Currents() (float64, float64, float64, error) {
 
 var _ api.PhaseVoltages = (*Vestel)(nil)
 
-// Currents implements the api.PhaseCurrents interface
+// Voltages implements the api.PhaseVoltages interface
 func (wb *Vestel) Voltages() (float64, float64, float64, error) {
 	var voltages []float64
 	for _, regVoltage := range vestelRegVoltages {

--- a/charger/vestel.go
+++ b/charger/vestel.go
@@ -116,11 +116,11 @@ func (wb *Vestel) Status() (api.ChargeStatus, error) {
 	res := api.StatusA
 
 	b, err := wb.conn.ReadInputRegisters(vestelRegCableStatus, 1)
-	if err == nil && binary.BigEndian.Uint16(b) > 0 {
+	if err == nil && binary.BigEndian.Uint16(b) >= 2 {
 		res = api.StatusB
 
 		b, err = wb.conn.ReadInputRegisters(vestelRegChargeStatus, 1)
-		if err == nil && binary.BigEndian.Uint16(b) > 0 {
+		if err == nil && binary.BigEndian.Uint16(b) == 1 {
 			res = api.StatusC
 		}
 	}


### PR DESCRIPTION
and add phase voltages api.

Ref #5604 

Charger still may refuse to set or reset MaxCurrent without connected vehicle / outside of session.
We will see...