### PR TITLE
fix build with -tags gokrazy

### DIFF
--- a/server/updater/run_gokrazy.go
+++ b/server/updater/run_gokrazy.go
@@ -18,7 +18,7 @@ func Run(log *util.Logger, httpd webServer, outChan chan<- util.Param) {
 	u := &watch{
 		log:     log,
 		outChan: outChan,
-		repo:    NewRepo(owner, repository),
+		repo:    NewRepo(log, owner, repository),
 	}
 
 	httpd.Router().PathPrefix("/api/update").HandlerFunc(u.updateHandler)


### PR DESCRIPTION
Before this commit, go build -tags gokrazy ./... would fail with:

github.com/evcc-io/evcc/server/updater
server/updater/run_gokrazy.go:21:27: not enough arguments in call to NewRepo
	have (string, string)
	want (*util.Logger, string, string)