### PR TITLE
Tasmota: Enable Power Value Lists

### DIFF
--- a/meter/tasmota/connection.go
+++ b/meter/tasmota/connection.go
@@ -50,8 +50,19 @@ func (d *Connection) ExecCmd(cmd string, res interface{}) error {
 // CurrentPower implements the api.Meter interface
 func (d *Connection) CurrentPower() (float64, error) {
 	var res StatusSNSResponse
-	err := d.ExecCmd("Status 8", &res)
-	return float64(res.StatusSNS.Energy.Power), err
+	var err error
+	var power float64
+
+	if err = d.ExecCmd("Status 8", &res); err == nil {
+		switch v := res.StatusSNS.Energy.Power.(type) {
+		case float64:
+			power = res.StatusSNS.Energy.Power.(float64)
+		default:
+			fmt.Println("unkown type: ", v)
+		}
+	}
+
+	return power, err
 }
 
 // TotalEnergy implements the api.MeterEnergy interface

--- a/meter/tasmota/connection.go
+++ b/meter/tasmota/connection.go
@@ -57,8 +57,16 @@ func (d *Connection) CurrentPower() (float64, error) {
 		switch v := res.StatusSNS.Energy.Power.(type) {
 		case float64:
 			power = res.StatusSNS.Energy.Power.(float64)
-		default:
-			fmt.Println("unkown type: ", v)
+		case []interface{}:
+			// take first power meter value in case of a power meter list
+			for i, vl := range v {
+				switch vv := vl.(type) {
+				case float64:
+					if i == 0 {
+						power = vv
+					}
+				}
+			}
 		}
 	}
 

--- a/meter/tasmota/types.go
+++ b/meter/tasmota/types.go
@@ -85,7 +85,3 @@ type StatusSNSResponse struct {
 		}
 	}
 }
-
-// Helper structs to handle single and list response values
-type SingleInt struct{ intsingle int }
-type ListInt struct{ intlist []int }

--- a/meter/tasmota/types.go
+++ b/meter/tasmota/types.go
@@ -68,12 +68,13 @@ type StatusSNSResponse struct {
 			Total          float64
 			Yesterday      float64
 			Today          float64
-			Power          int
-			ApparentPower  int
-			ReactivePower  int
-			Factor         float64
+			Power          interface{}
+			ApparentPower  interface{}
+			ReactivePower  interface{}
+			Factor         interface{}
+			Frequency      int
 			Voltage        int
-			Current        float64
+			Current        interface{}
 		}
 
 		// SML sensor readings
@@ -84,3 +85,7 @@ type StatusSNSResponse struct {
 		}
 	}
 }
+
+// Helper structs to handle single and list response values
+type SingleInt struct{ intsingle int }
+type ListInt struct{ intlist []int }


### PR DESCRIPTION
Fixes #5732

In case a Tasmota device provides more than one power meter value, always the first one will be choosen.