### PR TITLE
Add OAuth Bearer Token HTTP transport authentication type

### DIFF
--- a/provider/http.go
+++ b/provider/http.go
@@ -136,6 +136,8 @@ func (p *HTTP) WithAuth(typ, user, password string) (*HTTP, error) {
 		log.Redact(basicAuth)
 
 		p.Client.Transport = transport.BasicAuth(user, password, p.Client.Transport)
+	case "bearer":
+		p.Client.Transport = transport.BearerAuth(password, p.Client.Transport)
 	case "digest":
 		p.Client.Transport = digest.NewTransport(user, password, p.Client.Transport)
 	default:

--- a/util/transport/bearer.go
+++ b/util/transport/bearer.go
@@ -1,0 +1,15 @@
+package transport
+
+import (
+	"net/http"
+)
+
+// BearerAuth creates an HTTP transport performing HTTP authorization using an OAuth 2.0 Bearer Token
+func BearerAuth(token string, base http.RoundTripper) http.RoundTripper {
+	return &Decorator{
+		Decorator: DecorateHeaders(map[string]string{
+			"Authorization": "Bearer " + token,
+		}),
+		Base: base,
+	}
+}


### PR DESCRIPTION
This PR adds the `Bearer` authentication option for use with the HTTP provider plugin (and, indeed, elsewhere).

Manually supplying OAuth 2.0 bearer tokens is needed for services like the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest/) (useful for pulling things like grid demand metrics), though I'm sure there's plenty of other examples!