### PR TITLE
Vestel EVC04 - failsafe timeout = 20sec

### DIFF
--- a/charger/vestel.go
+++ b/charger/vestel.go
@@ -93,8 +93,8 @@ func NewVestel(uri string, id uint8) (*Vestel, error) {
 		current: 6,
 	}
 
-	// 5min failsafe timeout
-	if _, err := wb.conn.WriteSingleRegister(vestelRegFailsafeTimeout, 5*60); err != nil {
+	// 20 sec failsafe timeout
+	if _, err := wb.conn.WriteSingleRegister(vestelRegFailsafeTimeout, 20); err != nil {
 		return nil, fmt.Errorf("could not set failsafe timeout: %v", err)
 	}
 


### PR DESCRIPTION
Gemäß Vestel Modbus Doku ist standarmäßig der Failsafe Timeout = 20s. Der Failsafe Timeout ist bei Vestel ein Zeitfenster, in welchem die Box erst wieder eine neue Verbindung zulässt.