### PR TITLE
Added Homematic and Homematic Wired support for charger

### DIFF
--- a/templates/definition/charger/homematic.yaml
+++ b/templates/definition/charger/homematic.yaml
@@ -15,7 +15,7 @@ params:
       en: Device address/Serial number
     required: true
     mask: false
-    example: "TEQ0000549" or "0001EE89AAD848"
+    example: "0001EE89AAD848"
     help:
       en: Homematic device id like shown in the CCU web user interface.
       de: Homematic Geräte Id, wie im CCU Webfrontend angezeigt.

--- a/templates/definition/charger/homematic.yaml
+++ b/templates/definition/charger/homematic.yaml
@@ -1,16 +1,21 @@
 template: homematic
 products:
-  - brand: Homematic IP
+  - brand: Homematic / Homematic IP
 group: switchsockets
 params:
   - name: host
+  - name: port
+    default: 2010
+    description:
+      en: XML-RPC server port number (BidCos-Wired=2000, BidCos-RF=2001, HmIP=2010)
+      de: XML-RPC-Server Port-Nummer (BidCos-Wired=2000, BidCos-RF=2001, HmIP=2010)
   - name: device
     description:
       de: Geräteadresse/Seriennummer
       en: Device address/Serial number
     required: true
     mask: false
-    example: "0001EE89AAD848"
+    example: "TEQ0000549" or "0001EE89AAD848"
     help:
       en: Homematic device id like shown in the CCU web user interface.
       de: Homematic Geräte Id, wie im CCU Webfrontend angezeigt.
@@ -27,8 +32,8 @@ params:
     required: true
     advanced: true
     description:
-      en: Meter channel number (HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5)
-      de: Kanalnummer des Power-Meters (HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5)
+      en: Meter channel number (HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5, HM=2)
+      de: Kanalnummer des Power-Meters (HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5, HM=2)
     help:
       en: Homematic meter channel number like shown in the CCU web user interface.
       de: Kanalnummer des Messwertkanals, wie im CCU Webfrontend angezeigt.
@@ -38,14 +43,14 @@ params:
     required: true
     advanced: true
     description:
-      en: Switch/Actor channel number (HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2)
-      de: Kanalnummer der schaltbaren Steckdose (HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2)
+      en: Switch/Actor channel number (HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2, HM=1)
+      de: Kanalnummer der schaltbaren Steckdose (HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2, HM=1)
     help:
       en: Homematic switch actor channel number like shown in the CCU web user interface.
       de: Kanalnummer der schaltbaren Steckdose, wie im CCU Webfrontend angezeigt.
 render: |
   type: homematic
-  uri: {{ .host }}:2010
+  uri: {{ .host }}:{{ .port }}
   device: {{ .device }}
   meterchannel: {{ .meterchannel }}
   switchchannel: {{ .switchchannel }}


### PR DESCRIPTION
This change adds Homematic (BidCos-RF) and Homematic Wired (BidCos-Wired) support to the existing Homematic IP support.

Sample definition for a HM-ES-PMSw1-DR device:

- name: heaterL1
  type: template
  template: homematic
  host: ccu
  port: 2001
  device: TEQ0000529
  switchchannel: 1
  meterchannel: 2

If port/switchchannel/meterchannel is not specified, it defaults to 2010/3/6 so it's backwards compatible to Homematic IP.