### PR TITLE
Honor advanced setting in templates defaults.yaml

### DIFF
--- a/cmd/configure/helper.go
+++ b/cmd/configure/helper.go
@@ -418,11 +418,11 @@ func (c *CmdConfigure) processParams(templateItem *templates.Template, deviceCat
 			}
 
 		default:
-			if param.Advanced && !c.advancedMode || param.Deprecated {
+			if param.IsAdvanced() && !c.advancedMode || param.IsDeprecated() {
 				continue
 			}
 
-			if param.Hidden && param.Default != "" {
+			if param.IsHidden() && param.Default != "" {
 				additionalConfig[param.Name] = param.Default
 				continue
 			}
@@ -495,8 +495,8 @@ func (c *CmdConfigure) processInputConfig(param templates.Param) string {
 		help:         help,
 		valueType:    param.ValueType,
 		validValues:  param.ValidValues,
-		mask:         param.Mask,
-		required:     param.Required,
+		mask:         param.IsMask(),
+		required:     param.IsRequired(),
 	})
 
 	if param.ValueType == templates.ParamValueTypeBool && value == "true" {

--- a/templates/definition/defaults.yaml
+++ b/templates/definition/defaults.yaml
@@ -359,7 +359,6 @@ presets:
     params:
       - name: ski
       - name: ip
-        required: false
     render: |
       {{define "eebus-meter"}}
       type: eebus
@@ -371,7 +370,6 @@ presets:
     params:
       - name: ski
       - name: ip
-        required: false
     render: |
       {{define "eebus-no-meter"}}
       type: eebus

--- a/templates/docs/charger/etrel-duo_0.yaml
+++ b/templates/docs/charger/etrel-duo_0.yaml
@@ -9,6 +9,11 @@ render:
   - default: |
       type: template
       template: etrel-duo
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      port: 502 # Port # Optional
+    advanced: |
+      type: template
+      template: etrel-duo
       connector: 1 # Optional
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional

--- a/templates/docs/charger/openwb_0.yaml
+++ b/templates/docs/charger/openwb_0.yaml
@@ -8,7 +8,6 @@ render:
       type: template
       template: openwb
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      connector: 1 # Optional
     advanced: |
       type: template
       template: openwb

--- a/templates/docs/charger/pracht-alpha_0.yaml
+++ b/templates/docs/charger/pracht-alpha_0.yaml
@@ -25,4 +25,26 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
+    advanced: |
+      type: template
+      template: pracht-alpha      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
       connector: 1 # Optional

--- a/templates/docs/meter/sma-energy-meter_0.yaml
+++ b/templates/docs/meter/sma-energy-meter_0.yaml
@@ -8,9 +8,19 @@ render:
       template: sma-energy-meter
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
+    advanced: |
+      type: template
+      template: sma-energy-meter
+      usage: grid
+      host: 192.0.2.2 # IP-Adresse oder Hostname
       interface: eth0 # Netzwerkinterface # Optional
   - usage: pv
     default: |
+      type: template
+      template: sma-energy-meter
+      usage: pv
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+    advanced: |
       type: template
       template: sma-energy-meter
       usage: pv

--- a/templates/docs/meter/sma-home-manager_0.yaml
+++ b/templates/docs/meter/sma-home-manager_0.yaml
@@ -9,4 +9,9 @@ render:
       template: sma-home-manager
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
+    advanced: |
+      type: template
+      template: sma-home-manager
+      usage: grid
+      host: 192.0.2.2 # IP-Adresse oder Hostname
       interface: eth0 # Netzwerkinterface # Optional

--- a/templates/docs/meter/solaredge-hybrid_0.yaml
+++ b/templates/docs/meter/solaredge-hybrid_0.yaml
@@ -28,7 +28,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 1502 # Port
-      timeout: 10s # Optional
     advanced: |
       type: template
       template: solaredge-hybrid
@@ -78,7 +77,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 1502 # Port
-      timeout: 10s # Optional
     advanced: |
       type: template
       template: solaredge-hybrid
@@ -128,7 +126,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 1502 # Port
-      timeout: 10s # Optional
     advanced: |
       type: template
       template: solaredge-hybrid

--- a/templates/docs/meter/solaredge-inverter_0.yaml
+++ b/templates/docs/meter/solaredge-inverter_0.yaml
@@ -28,9 +28,55 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 1502 # Port
+    advanced: |
+      type: template
+      template: solaredge-inverter
+      usage: grid      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 1502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 1502 # Port
       timeout: 10s # Optional
   - usage: pv
     default: |
+      type: template
+      template: solaredge-inverter
+      usage: pv      
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 1502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 1502 # Port
+    advanced: |
       type: template
       template: solaredge-inverter
       usage: pv      

--- a/util/templates/config.go
+++ b/util/templates/config.go
@@ -38,7 +38,7 @@ func (c *ConfigDefaults) LoadDefaults() {
 	for k := range c.Modbus.Types {
 		for i, p := range c.Modbus.Types[k].Params {
 			// if this is a reference, get the referenced values and then overwrite it with the values defined here
-			if p.Reference {
+			if p.IsReference() {
 				finalName := p.Name
 				referencedItemName := p.Name
 				if p.Referencename != "" {

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -28,7 +28,7 @@ render:
       {{- range $.Params }}
       {{- if eq .Name "modbus" -}}
 {{ $.Modbus | indent 6 -}}
-      {{- else if ne .Advanced true }}
+      {{- else if ne .IsAdvanced true }}
       {{ .Name }}:
       {{- if len .Value }} {{ .Value }} {{- end }}
       {{- if ne (len .Values) 0 }}
@@ -36,7 +36,7 @@ render:
         - {{ . }}
       {{ end }}
       {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .Required true }} # Optional{{ end }}
+      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if eq .IsRequired false }} # Optional{{ end }}
       {{- end -}}
       {{- end -}}
 {{- if $.AdvancedParams }}
@@ -55,7 +55,7 @@ render:
         - {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .Required true }} # Optional{{ end }}
+      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
       {{- end -}}
       {{- end -}}
 {{ end }}
@@ -67,7 +67,7 @@ render:
       {{- range $.Params }}
       {{- if eq .Name "modbus" -}}
 {{ $.Modbus | indent 6 -}}
-      {{- else if ne .Advanced true }}
+      {{- else if ne .IsAdvanced true }}
       {{ .Name }}:
       {{- if len .Value }} {{ .Value }} {{- end }}
       {{- if ne (len .Values) 0 }}
@@ -75,7 +75,7 @@ render:
         - {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .Required true }} # Optional{{ end }}
+      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
       {{- end -}}
       {{- end -}}
 {{- if $.AdvancedParams }}
@@ -93,7 +93,7 @@ render:
         - {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .Required true }} # Optional{{ end }}
+      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
       {{- end -}}
       {{- end -}}
 {{- end }}

--- a/util/templates/template_documentation.go
+++ b/util/templates/template_documentation.go
@@ -68,11 +68,11 @@ func (t *Template) RenderDocumentation(product Product, values map[string]interf
 	var hasAdvancedParam bool
 	var newParams []Param
 	for _, param := range t.Params {
-		if param.Deprecated || param.Name == ParamUsage {
+		if param.IsDeprecated() || param.Name == ParamUsage {
 			continue
 		}
 
-		if param.Advanced {
+		if param.IsAdvanced() {
 			hasAdvancedParam = true
 		}
 

--- a/util/templates/template_types.go
+++ b/util/templates/template_types.go
@@ -3,8 +3,9 @@ package templates
 import (
 	"bufio"
 	"fmt"
-	"reflect"
 	"strings"
+
+	"github.com/imdario/mergo"
 )
 
 const (
@@ -171,16 +172,16 @@ type LinkedTemplate struct {
 // 3. defaults.yaml modbus section
 // 4. template
 type Param struct {
-	Reference     bool         // if this is references another param definition
+	Reference     *bool        // if this is references another param definition
 	Referencename string       // name of the referenced param if it is not identical to the defined name
 	Preset        string       // Reference a predefined set of params
 	Name          string       // Param name which is used for assigning defaults properties and referencing in render
 	Description   TextLanguage // language specific titles (presented in UI instead of Name)
-	Required      bool         // cli if the user has to provide a non empty value
-	Mask          bool         // cli if the value should be masked, e.g. for passwords
-	Advanced      bool         // cli if the user does not need to be asked. Requires a "Default" to be defined.
-	Hidden        bool         // cli if the parameter should not be presented in the cli, the default value be assigned
-	Deprecated    bool         // if the parameter is deprecated and thus should not be presented in the cli or docs
+	Required      *bool        // cli if the user has to provide a non empty value
+	Mask          *bool        // cli if the value should be masked, e.g. for passwords
+	Advanced      *bool        // cli if the user does not need to be asked. Requires a "Default" to be defined.
+	Hidden        *bool        // cli if the parameter should not be presented in the cli, the default value be assigned
+	Deprecated    *bool        // if the parameter is deprecated and thus should not be presented in the cli or docs
 	Default       string       // default value if no user value is provided in the configuration
 	Example       string       // cli example value
 	Help          TextLanguage // cli configuration help
@@ -190,7 +191,7 @@ type Param struct {
 	ValueType     string       // string representation of the value type, "string" is default
 	ValidValues   []string     // list of valid values the user can provide
 	Choice        []string     // defines a set of choices, e.g. "grid", "pv", "battery", "charge" for "usage"
-	AllInOne      bool         // defines if the defined usages can all be present in a single device
+	AllInOne      *bool        // defines if the defined usages can all be present in a single device
 	Requirements  Requirements // requirements for this param to be usable, only supported via ValueType "bool"
 
 	Baudrate int    // device specific default for modbus RS485 baudrate
@@ -213,53 +214,39 @@ func (p *Param) DefaultValue(renderMode string) interface{} {
 	return p.Default
 }
 
-// overwrite specific properties by using values from another param
-//
-// always overwrites if not provided empty: description, valuetype, default, mask, required
-//
-// only overwrite if not provided empty and empty in param: help, example, requirements
+// OverwriteProperties merges properties from parameter definition
 func (p *Param) OverwriteProperties(withParam Param) {
-	// always overwrite if defined
-	p.Description.Update(withParam.Description, true)
-
-	if len(p.Usages) == 0 {
-		p.Usages = withParam.Usages
+	if err := mergo.Merge(p, &withParam); err != nil {
+		panic(err)
 	}
+}
 
-	if withParam.ValueType != "" {
-		p.ValueType = withParam.ValueType
-	}
+func (p *Param) IsReference() bool {
+	return p.Reference != nil && *p.Reference
+}
 
-	if withParam.Advanced {
-		p.Advanced = withParam.Advanced
-	}
+func (p *Param) IsAdvanced() bool {
+	return p.Advanced != nil && *p.Advanced
+}
 
-	if withParam.Required {
-		p.Required = withParam.Required
-	}
+func (p *Param) IsHidden() bool {
+	return p.Hidden != nil && *p.Hidden
+}
 
-	if withParam.Default != "" {
-		p.Default = withParam.Default
-	}
+func (p *Param) IsMask() bool {
+	return p.Mask != nil && *p.Mask
+}
 
-	if withParam.Mask {
-		p.Mask = withParam.Mask
-	}
+func (p *Param) IsRequired() bool {
+	return p.Required != nil && *p.Required
+}
 
-	// only set if empty
-	p.Help.Update(withParam.Help, false)
+func (p *Param) IsDeprecated() bool {
+	return p.Deprecated != nil && *p.Deprecated
+}
 
-	if p.Example == "" && withParam.Example != "" {
-		p.Example = withParam.Example
-	}
-
-	if p.ValidValues == nil && withParam.ValidValues != nil {
-		p.ValidValues = withParam.ValidValues
-	}
-
-	if reflect.DeepEqual(p.Requirements, Requirements{}) {
-		p.Requirements = withParam.Requirements
-	}
+func (p *Param) IsAllInOne() bool {
+	return p.AllInOne != nil && *p.AllInOne
 }
 
 // Product contains naming information about a product a template supports

--- a/util/templates/template_types.go
+++ b/util/templates/template_types.go
@@ -230,6 +230,10 @@ func (p *Param) OverwriteProperties(withParam Param) {
 		p.ValueType = withParam.ValueType
 	}
 
+	if withParam.Advanced {
+		p.Advanced = withParam.Advanced
+	}
+
 	if withParam.Required {
 		p.Required = withParam.Required
 	}


### PR DESCRIPTION
`evcc configure` currently asks values for params that have `advanced: true` set in `defaults.yaml` even when it runs in `standard` mode where it shouldn't ask for any param defined as advanced. This PR fixes this.

Also simplify code that overwrites param values with defaults as discussed in https://github.com/evcc-io/evcc/pull/5824