### PR TITLE
Optimize modal scrolling

### DIFF
--- a/assets/js/components/ChargingSessionModal.vue
+++ b/assets/js/components/ChargingSessionModal.vue
@@ -7,7 +7,7 @@
 			role="dialog"
 			aria-hidden="true"
 		>
-			<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" role="document">
+			<div class="modal-dialog modal-dialog-centered" role="document">
 				<div v-if="session" class="modal-content">
 					<div class="modal-header">
 						<h5>{{ $t("session.title") }}</h5>
@@ -125,7 +125,7 @@
 			role="dialog"
 			aria-hidden="true"
 		>
-			<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" role="document">
+			<div class="modal-dialog modal-dialog-centered" role="document">
 				<div v-if="session" class="modal-content">
 					<div class="modal-header">
 						<h5>{{ $t("sessions.reallyDelete") }}</h5>

--- a/assets/js/components/GlobalSettingsModal.vue
+++ b/assets/js/components/GlobalSettingsModal.vue
@@ -8,7 +8,7 @@
 			role="dialog"
 			aria-hidden="true"
 		>
-			<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" role="document">
+			<div class="modal-dialog modal-dialog-centered" role="document">
 				<div class="modal-content">
 					<div class="modal-header">
 						<h5 class="modal-title">{{ $t("settings.title") }}</h5>

--- a/assets/js/components/LoadpointSettingsModal.vue
+++ b/assets/js/components/LoadpointSettingsModal.vue
@@ -8,7 +8,7 @@
 			role="dialog"
 			aria-hidden="true"
 		>
-			<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" role="document">
+			<div class="modal-dialog modal-dialog-centered" role="document">
 				<div class="modal-content">
 					<div class="modal-header">
 						<h5 class="modal-title">

--- a/assets/js/components/Savings.vue
+++ b/assets/js/components/Savings.vue
@@ -23,10 +23,7 @@
 				role="dialog"
 				aria-hidden="true"
 			>
-				<div
-					class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable"
-					role="document"
-				>
+				<div class="modal-dialog modal-lg modal-dialog-centered" role="document">
 					<div class="modal-content">
 						<div class="modal-header">
 							<h5 class="modal-title">

--- a/assets/js/components/TargetCharge.vue
+++ b/assets/js/components/TargetCharge.vue
@@ -26,10 +26,7 @@
 				role="dialog"
 				aria-hidden="true"
 			>
-				<div
-					class="modal-dialog modal-dialog-centered modal-dialog-scrollable"
-					role="document"
-				>
+				<div class="modal-dialog modal-dialog-centered" role="document">
 					<div class="modal-content">
 						<div class="modal-header">
 							<h5 class="modal-title">

--- a/assets/js/components/TargetChargePlan.vue
+++ b/assets/js/components/TargetChargePlan.vue
@@ -25,7 +25,6 @@
 				:class="{ active: isActive(index), toLate: slot.toLate }"
 				@touchstart="activeIndex = index"
 				@mouseenter="activeIndex = index"
-				@touchmove="touchmove"
 				@touchend="activeIndex = null"
 				@mouseleave="activeIndex = null"
 				@mouseup="activeIndex = null"
@@ -159,17 +158,6 @@ export default {
 			return {
 				height: price === undefined ? "100%" : `${(100 / this.maxPrice) * price}%`,
 			};
-		},
-		touchmove(e) {
-			let $el = document.elementFromPoint(e.touches[0].clientX, e.touches[0].clientY);
-			if (!$el) return;
-			if (!$el.classList.contains("slot")) {
-				$el = $el.parent;
-			}
-			if (!$el) return;
-			const index = $el.getAttribute("data-index");
-			if (!index) return;
-			this.activeIndex = index * 1;
 		},
 		convertDates(list) {
 			if (!list?.length) {

--- a/assets/js/components/Version.vue
+++ b/assets/js/components/Version.vue
@@ -40,10 +40,7 @@
 				role="dialog"
 				aria-hidden="true"
 			>
-				<div
-					class="modal-dialog modal-dialog-centered modal-dialog-scrollable"
-					role="document"
-				>
+				<div class="modal-dialog modal-dialog-centered" role="document">
 					<div class="modal-content">
 						<div class="modal-header">
 							<h5 class="modal-title">{{ $t("footer.version.modalTitle") }}</h5>


### PR DESCRIPTION
- Changed scrolling behaviour for modals. Switched from in-modal-scrolling to scrolling the complete page.
- Improved horizontal scrolling of the charging plan on mobile. Avoid times lot highlight changes when scrolling.


![IMG_47E95C9BF39F-1](https://user-images.githubusercontent.com/152287/215799814-f0de6929-db8c-4de7-80a9-846561b11885.jpeg)

\\cc @VolkerK62