### PR TITLE
Adding TLS and mTLS

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -34,9 +34,12 @@ var conf = config{
 	Interval: 10 * time.Second,
 	Log:      "info",
 	Network: networkConfig{
-		Schema: "http",
-		Host:   "evcc.local",
-		Port:   7070,
+		Schema:   "http",
+		Host:     "evcc.local",
+		Port:     7070,
+		PathCert: "",
+		PathKey:  "",
+		UserAuth: false,
 	},
 	Mqtt: mqttConfig{
 		Topic: "evcc",
@@ -118,9 +121,12 @@ type tariffConfig struct {
 }
 
 type networkConfig struct {
-	Schema string
-	Host   string
-	Port   int
+	Schema   string
+	Host     string
+	Port     int
+	PathCert string
+	PathKey  string
+	UserAuth bool
 }
 
 func (c networkConfig) HostPort() string {


### PR DESCRIPTION
This adds the option to provide a (self-signed) certificate for HTTPS support.
By additionally adding a option for mTLS, the EVCC webserver could be securely published to internet and still only accessible bu the user holding the certificate.

This is my first contribution and if I did not follow any coding guidelines feel free to give me some hints. Actually its my first time writing go code at all.
I did test it locally on my computer.

Currently missing:
- Adding documentation on the website
- Add this to evcc configure