### PR TITLE
Bluelink: add wakeup using forced update

### DIFF
--- a/vehicle/bluelink/provider.go
+++ b/vehicle/bluelink/provider.go
@@ -194,3 +194,12 @@ func (v *Provider) Position() (float64, float64, error) {
 	coord := res.ResMsg.VehicleStatusInfo.VehicleLocation.Coord
 	return coord.Lat, coord.Lon, err
 }
+
+var _ api.Resurrector = (*Provider)(nil)
+
+// WakeUp implements the api.Resurrector interface
+func (v *Provider) WakeUp() error {
+	// forcing an update will usually make the car start charging even if the (first) resulting status still says it does not charge...
+	_, err := v.refreshG()
+	return err
+}


### PR DESCRIPTION
I added the Wakeup/Resurrector interface to Bluelink as I noticed, that forcing the update will wake my Kona up (faster). The Kona usually also starts charging 10-20 min after enabling the wallbox, but this should make it a bit quicker.