### PR TITLE
Bluelink: persist tokens

### DIFF
--- a/vehicle/bluelink.go
+++ b/vehicle/bluelink.go
@@ -67,7 +67,7 @@ func newBluelinkFromConfig(brand string, factory store.Provider, other map[strin
 		return nil, err
 	}
 
-	store := factory("bluelink.tokens." + cc.User)
+	store := factory("bluelink." + brand + ".tokens." + cc.User)
 
 	log := util.NewLogger(brand).Redact(cc.User, cc.Password, cc.VIN)
 	identity := bluelink.NewIdentity(log, settings).WithStore(store)


### PR DESCRIPTION
This more or less depends on #4838 (The first commit copies some parts from it).

I don't know why #4838 went stale, but this is the variant for Bluelink.
For the Bluelinky API it may or may not help to prevent getting soft-banned if you persist the Access tokens to avoid a full login after a restart.