### PR TITLE
fix: Title as func cases error on json marshal

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -108,7 +108,7 @@ type Loadpoint struct {
 	sync.Mutex                // guard status
 	Mode       api.ChargeMode `mapstructure:"mode"` // Charge mode, guarded by mutex
 
-	Title_            string   `mapstructure:"title"`    // UI title
+	Title            string   `mapstructure:"title"`    // UI title
 	ConfiguredPhases  int      `mapstructure:"phases"`   // Charger configured phase mode 0/1/3
 	ChargerRef        string   `mapstructure:"charger"`  // Charger reference
 	VehicleRef        string   `mapstructure:"vehicle"`  // Vehicle reference

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -14,7 +14,7 @@ type Controller interface {
 // API is the external loadpoint API
 type API interface {
 	// Title returns the defined loadpoint title
-	Title() string
+	GetTitle() string
 
 	//
 	// status

--- a/core/site.go
+++ b/core/site.go
@@ -137,7 +137,7 @@ func NewSiteFromConfig(
 
 		if serverdb.Instance != nil {
 			var err error
-			if lp.db, err = db.New(lp.Title()); err != nil {
+			if lp.db, err = db.New(lp.GetTitle()); err != nil {
 				return nil, err
 			}
 

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -377,7 +377,7 @@ func (s *SEMP) deviceInfo(id int, lp loadpoint.API) DeviceInfo {
 	res := DeviceInfo{
 		Identification: Identification{
 			DeviceID:     s.deviceID(id),
-			DeviceName:   lp.Title(),
+			DeviceName:   lp.GetTitle(),
 			DeviceType:   sempCharger,
 			DeviceSerial: s.serialNumber(id),
 			DeviceVendor: "github.com/evcc-io/evcc",

--- a/server/influxdb.go
+++ b/server/influxdb.go
@@ -150,7 +150,7 @@ func (m *Influx) Run(site site.API, in <-chan util.Param) {
 		if param.Loadpoint != nil {
 			lp := site.Loadpoints()[*param.Loadpoint]
 
-			tags["loadpoint"] = lp.Title()
+			tags["loadpoint"] = lp.GetTitle()
 			if v := lp.GetVehicle(); v != nil {
 				tags["vehicle"] = v.Title()
 			}


### PR DESCRIPTION
Fix json marshal error due to Title being a func now. 

```

httpd: failed to encode JSON: json: unsupported type: func() string
3


Failed to parse web socket data: Unexpected token ',', ...".1.title":,"loadpoin"... is not valid JSON [{"loadpoints.0.chargedEnergy":0,"savingsEffectivePrice":0.3037,"loadpoints.0.mode":"pv","loadpoints.

```