### PR TITLE
wattpilot: correction,  1p3p function

### DIFF
--- a/templates/definition/charger/wattpilot.yaml
+++ b/templates/definition/charger/wattpilot.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Fronius
     description:
       generic: Wattpilot
-capabilities: ["1p3p", "rfid"]
+capabilities: ["rfid"]
 requirements:
   description:
     de: |


### PR DESCRIPTION
Die 1p3p Funktion wird derzeit noch nicht unterstützt und der Doku Hinweis führt immer wieder zu Verwirrung. https://github.com/evcc-io/evcc/discussions/6056#discussioncomment-4872900

Bitte `make docs` noch ausführen.