### PR TITLE
adding 1p3p on wattpilot

### DIFF
--- a/charger/wattpilot.go
+++ b/charger/wattpilot.go
@@ -132,3 +132,15 @@ var _ api.Identifier = (*Wattpilot)(nil)
 func (c *Wattpilot) Identify() (string, error) {
 	return c.api.GetRFID()
 }
+
+var _ api.PhaseSwitcher = (*Wattpilot)(nil)
+
+// Phases1p3p implements the api.PhaseSwitcher interface
+func (c *Wattpilot) Phases1p3p(phases int) error {
+
+	if phases == 3 {
+		phases = 2
+	}
+
+	return c.api.SetProperty("psm", phases)
+}

--- a/charger/wattpilot.go
+++ b/charger/wattpilot.go
@@ -137,7 +137,6 @@ var _ api.PhaseSwitcher = (*Wattpilot)(nil)
 
 // Phases1p3p implements the api.PhaseSwitcher interface
 func (c *Wattpilot) Phases1p3p(phases int) error {
-
 	if phases == 3 {
 		phases = 2
 	}


### PR DESCRIPTION
implements #6095 

`phases = 0` = automatic on Wattpilot
`phases = 1` 1 phase
`phases =2` 3 phases 

So the simliaries on go-e and wattpilot continue ;-) 