### PR TITLE
Templates: simplify handling of modbus default values

### DIFF
--- a/templates/definition/charger/abl.yaml
+++ b/templates/definition/charger/abl.yaml
@@ -12,8 +12,9 @@ requirements:
 params:
   - name: modbus
     choice: ["rs485"]
-    baudrate: 38400
-    comset: 8E1
+    modbus:
+      baudrate: 38400
+      comset: 8E1
 render: |
   type: abl
   {{- include "modbus" . }}

--- a/templates/definition/charger/alphatec.yaml
+++ b/templates/definition/charger/alphatec.yaml
@@ -8,8 +8,9 @@ requirements:
 params:
   - name: modbus
     choice: ["rs485"]
-    baudrate: 9600
-    comset: 8N1
+    modbus:
+      baudrate: 9600
+      comset: 8N1
 render: |
   type: alphatec
   {{- include "modbus" . }}

--- a/templates/definition/charger/amtron.yaml
+++ b/templates/definition/charger/amtron.yaml
@@ -8,7 +8,8 @@ requirements:
 params:
   - name: modbus
     choice: ["tcpip"]
-    id: 255
+    modbus:
+      id: 255
 render: |
   type: amtron
   {{- include "modbus" . }}

--- a/templates/definition/charger/dadapower.yaml
+++ b/templates/definition/charger/dadapower.yaml
@@ -7,7 +7,8 @@ capabilities: ["1p3p", "mA", "rfid"]
 params:
   - name: modbus
     choice: ["tcpip"]
-    id: 1
+    modbus:
+      id: 1
 render: |
   type: dadapower
   {{- include "modbus" . }}

--- a/templates/definition/charger/eon-vbox.yaml
+++ b/templates/definition/charger/eon-vbox.yaml
@@ -11,7 +11,8 @@ requirements:
 params:
   - name: modbus
     choice: ["tcpip"]
-    id: 255
+    modbus:
+      id: 255
 render: |
   type: vestel
   {{- include "modbus" . }}

--- a/templates/definition/charger/evse-din.yaml
+++ b/templates/definition/charger/evse-din.yaml
@@ -10,8 +10,9 @@ products:
 params:
   - name: modbus
     choice: ["rs485"]
-    baudrate: 9600
-    comset: 8N1
+    modbus:
+      baudrate: 9600
+      comset: 8N1
 render: |
   type: evsedin
   {{- include "modbus" . }}

--- a/templates/definition/charger/heidelberg.yaml
+++ b/templates/definition/charger/heidelberg.yaml
@@ -18,8 +18,9 @@ requirements:
 params:
   - name: modbus
     choice: ["rs485"]
-    baudrate: 19200
-    comset: 8E1
+    modbus:
+      baudrate: 19200
+      comset: 8E1
 render: |
   type: heidelberg
   {{- include "modbus" . }}

--- a/templates/definition/charger/kse.yaml
+++ b/templates/definition/charger/kse.yaml
@@ -9,9 +9,10 @@ requirements:
 params:
   - name: modbus
     choice: ["rs485"]
-    baudrate: 9600
-    comset: 8E1
-    id: 100
+    modbus:
+      baudrate: 9600
+      comset: 8E1
+      id: 100
 render: |
   type: kse
   {{- include "modbus" . }}

--- a/templates/definition/charger/pracht-alpha.yaml
+++ b/templates/definition/charger/pracht-alpha.yaml
@@ -8,9 +8,10 @@ requirements:
 params:
   - name: modbus
     choice: ["rs485", "tcpip"]
-    baudrate: 9600
-    comset: 8N1
-    id: 1
+    modbus:
+      baudrate: 9600
+      comset: 8N1
+      id: 1
   - name: connector
 render: |
   type: pracht-alpha

--- a/templates/definition/charger/vestel.yaml
+++ b/templates/definition/charger/vestel.yaml
@@ -11,7 +11,8 @@ requirements:
 params:
   - name: modbus
     choice: ["tcpip"]
-    id: 255
+    modbus:
+      id: 255
 render: |
   type: vestel
   {{- include "modbus" . }}

--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -9,8 +9,9 @@ params:
     allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
-    baudrate: 9600
-    id: 85
+    modbus:
+      baudrate: 9600
+      id: 85
   - name: capacity
     advanced: true
 render: |

--- a/templates/definition/meter/cfos.yaml
+++ b/templates/definition/meter/cfos.yaml
@@ -10,8 +10,9 @@ params:
     choice: ["charge"]
   - name: modbus
     choice: ["tcpip"]
-    port: 4702
-    id: 2
+    modbus:
+      port: 4702
+      id: 2
 render: |
   type: cfos
   {{- include "modbus" . }}

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -8,8 +8,9 @@ params:
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["rs485", "tcpip"]
-    baudrate: 9600
-    id: 247
+    modbus:
+      baudrate: 9600
+      id: 247
   - name: capacity
     advanced: true
 render: |

--- a/templates/definition/meter/growatt-hybrid.yaml
+++ b/templates/definition/meter/growatt-hybrid.yaml
@@ -8,8 +8,9 @@ params:
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["rs485", "tcpip"]
-    baudrate: 9600
-    id: 1
+    modbus:
+      baudrate: 9600
+      id: 1
   - name: capacity
     advanced: true
 render: |

--- a/templates/definition/meter/huawei-sun2000-rs485.yaml
+++ b/templates/definition/meter/huawei-sun2000-rs485.yaml
@@ -10,7 +10,8 @@ params:
     choice: ["pv"]
   - name: modbus
     choice: ["rs485"]
-    baudrate: 9600
+    modbus:
+      baudrate: 9600
 render: |
   type: custom
   power:

--- a/templates/definition/meter/kostal-ksem-inverter.yaml
+++ b/templates/definition/meter/kostal-ksem-inverter.yaml
@@ -13,8 +13,9 @@ params:
     choice: ["grid"]
   - name: modbus
     choice: ["tcpip"]
-    port: 1502
-    id: 71
+    modbus:
+      port: 1502
+      id: 71
 render: |
   type: custom
   power:

--- a/templates/definition/meter/kostal-ksem.yaml
+++ b/templates/definition/meter/kostal-ksem.yaml
@@ -8,7 +8,8 @@ params:
     choice: ["grid"]
   - name: modbus
     choice: ["tcpip"]
-    id: 71
+    modbus:
+      id: 71
 render: |
   type: modbus
   {{- include "modbus" . }}

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -15,8 +15,9 @@ params:
     allinone: true
   - name: modbus
     choice: ["tcpip"]
-    id: 71
-    port: 1502
+    modbus:
+      id: 71
+      port: 1502
   - name: capacity
     advanced: true
 render: |

--- a/templates/definition/meter/senergy.yaml
+++ b/templates/definition/meter/senergy.yaml
@@ -11,7 +11,8 @@ params:
     choice: ["pv"]
   - name: modbus
     choice: ["tcpip"]
-    id: 1
+    modbus:
+      id: 1
 render: |
   type: custom
   {{- if eq .usage "pv" }}

--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -10,8 +10,9 @@ params:
     allinone: true
   - name: modbus
     choice: ["tcpip"]
-    port: 502
-    id: 3
+    modbus:
+      port: 502
+      id: 3
     help:
       en: The Modbus TCP-Server needs to be enabled on this Smart Energy inverter
       de: Der Modbus TCP-Server muss an diesem Smart Energy Wechselrichter aktiviert sein

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -13,8 +13,9 @@ params:
     allinone: true
   - name: modbus
     choice: ["tcpip", "rs485"]
-    id: 1
-    port: 1502
+    modbus:
+      id: 1
+      port: 1502
   - name: timeout
     valuetype: duration
   - name: capacity

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -14,8 +14,9 @@ params:
     allinone: true
   - name: modbus
     choice: ["tcpip", "rs485"]
-    id: 1
-    port: 1502
+    modbus:
+      id: 1
+      port: 1502
   - name: timeout
     valuetype: duration
 render: |

--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -9,7 +9,8 @@ params:
     allinone: true
   - name: modbus
     choice: ["tcpip"]
-    id: 1
+    modbus:
+      id: 1
   - name: capacity
     advanced: true
 render: |

--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -13,7 +13,8 @@ params:
     allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
-    baudrate: 19200
+    modbus:
+      baudrate: 19200
   - name: capacity
     advanced: true
 render: |

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -14,7 +14,8 @@ params:
     allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
-    baudrate: 9600
+    modbus:
+      baudrate: 9600
   - name: capacity
     advanced: true
 render: |

--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -13,7 +13,8 @@ params:
     allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
-    baudrate: 9600
+    modbus:
+      baudrate: 9600
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/util/templates/template_modbus.go
+++ b/util/templates/template_modbus.go
@@ -70,35 +70,14 @@ func (t *Template) ModbusValues(renderMode string, values map[string]interface{}
 
 			values[p.Name] = p.DefaultValue(renderMode)
 
-			var defaultValue string
-
-			switch p.Name {
-			case ModbusParamNameId:
-				if modbusParam.ID != 0 {
-					defaultValue = fmt.Sprintf("%d", modbusParam.ID)
-				}
-			case ModbusParamNamePort:
-				if modbusParam.Port != 0 {
-					defaultValue = fmt.Sprintf("%d", modbusParam.Port)
-				}
-			case ModbusParamNameBaudrate:
-				if modbusParam.Baudrate != 0 {
-					defaultValue = fmt.Sprintf("%d", modbusParam.Baudrate)
-				}
-			case ModbusParamNameComset:
-				if modbusParam.Comset != "" {
-					defaultValue = modbusParam.Comset
-				}
-			}
-
-			if defaultValue != "" {
+			if override := modbusParam.Modbus.Value(p.Name); override != "" {
 				// for modbus params the default value is carried
 				// using the parameter default, not the value
 				// TODO figure out why that's necessary
 				if renderMode == TemplateRenderModeInstance {
-					t.SetParamDefault(p.Name, defaultValue)
+					t.SetParamDefault(p.Name, override)
 				} else {
-					values[p.Name] = defaultValue
+					values[p.Name] = override
 				}
 			}
 		}


### PR DESCRIPTION
@DerAndereAndi this PR should move the specific modbus properties to a separate struct. This might prepare for further refactoring. Downside is that the default values need be indented in the templates.

@premultiply kannst Du mit der Einrückung leben?