### PR TITLE
Rename smart loads to aux meter

### DIFF
--- a/cmd/configure/configure.tpl
+++ b/cmd/configure/configure.tpl
@@ -68,13 +68,13 @@ site:
     grid: {{ .Site.Grid }}
 {{- end }}
 {{- if len .Site.PVs }}
-    pvs:
+    pv:
 {{-   range .Site.PVs }}
     - {{ . }}
 {{-   end }}
 {{- end }}
 {{- if len .Site.Batteries }}
-    batteries:
+    battery:
 {{-   range .Site.Batteries }}
     - {{ . }}
 {{-   end }}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -97,27 +97,21 @@ func runDump(cmd *cobra.Command, args []string) {
 		d.DumpWithHeader(fmt.Sprintf("grid: %s", name), handle(cp.Meter(name)))
 	}
 
-	if len(site.Meters.PVMetersRef) == 0 {
-		if name := site.Meters.PVMeterRef; name != "" {
-			d.DumpWithHeader(fmt.Sprintf("pv: %s", name), handle(cp.Meter(name)))
-		}
-	} else {
-		for id, name := range site.Meters.PVMetersRef {
-			if name != "" {
-				d.DumpWithHeader(fmt.Sprintf("pv %d: %s", id, name), handle(cp.Meter(name)))
-			}
+	for id, name := range append(site.Meters.PVMetersRef, site.Meters.PVMetersRef_...) {
+		if name != "" {
+			d.DumpWithHeader(fmt.Sprintf("pv %d: %s", id+1, name), handle(cp.Meter(name)))
 		}
 	}
 
-	if len(site.Meters.BatteryMetersRef) == 0 {
-		if name := site.Meters.BatteryMeterRef; name != "" {
-			d.DumpWithHeader(fmt.Sprintf("battery: %s", name), handle(cp.Meter(name)))
+	for id, name := range append(site.Meters.BatteryMetersRef, site.Meters.BatteryMetersRef_...) {
+		if name != "" {
+			d.DumpWithHeader(fmt.Sprintf("battery %d: %s", id+1, name), handle(cp.Meter(name)))
 		}
-	} else {
-		for id, name := range site.Meters.BatteryMetersRef {
-			if name != "" {
-				d.DumpWithHeader(fmt.Sprintf("battery %d: %s", id, name), handle(cp.Meter(name)))
-			}
+	}
+
+	for id, name := range site.Meters.AuxMetersRef {
+		if name != "" {
+			d.DumpWithHeader(fmt.Sprintf("aux %d: %s", id+1, name), handle(cp.Meter(name)))
 		}
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -63,7 +63,7 @@ type Site struct {
 	gridMeter     api.Meter   // Grid usage meter
 	pvMeters      []api.Meter // PV generation meters
 	batteryMeters []api.Meter // Battery charging meters
-	loadMeter     api.Meter   // Smart load meter
+	auxMeters     []api.Meter // Auxiliary meters
 
 	tariffs     tariff.Tariffs           // Tariff
 	loadpoints  []*Loadpoint             // Loadpoints
@@ -82,12 +82,12 @@ type Site struct {
 
 // MetersConfig contains the loadpoint's meter configuration
 type MetersConfig struct {
-	GridMeterRef     string   `mapstructure:"grid"`      // Grid usage meter
-	PVMeterRef       string   `mapstructure:"pv"`        // PV meter
-	PVMetersRef      []string `mapstructure:"pvs"`       // Multiple PV meters
-	BatteryMeterRef  string   `mapstructure:"battery"`   // Battery charging meter
-	BatteryMetersRef []string `mapstructure:"batteries"` // Multiple Battery charging meters
-	SmartLoadRef     string   `mapstructure:"smart"`     // Smart loads meter
+	GridMeterRef      string   `mapstructure:"grid"`      // Grid usage meter
+	PVMetersRef       []string `mapstructure:"pv"`        // PV meter
+	PVMetersRef_      []string `mapstructure:"pvs"`       // TODO deprecated
+	BatteryMetersRef  []string `mapstructure:"battery"`   // Battery charging meter
+	BatteryMetersRef_ []string `mapstructure:"batteries"` // TODO deprecated
+	AuxMetersRef      []string `mapstructure:"aux"`       // Auxiliary meters
 }
 
 // NewSiteFromConfig creates a new site
@@ -159,7 +159,7 @@ func NewSiteFromConfig(
 	}
 
 	// multiple pv
-	for _, ref := range site.Meters.PVMetersRef {
+	for _, ref := range append(site.Meters.PVMetersRef, site.Meters.PVMetersRef_...) {
 		pv, err := cp.Meter(ref)
 		if err != nil {
 			return nil, err
@@ -167,20 +167,8 @@ func NewSiteFromConfig(
 		site.pvMeters = append(site.pvMeters, pv)
 	}
 
-	// single pv
-	if site.Meters.PVMeterRef != "" {
-		if len(site.pvMeters) > 0 {
-			return nil, errors.New("cannot have pv and pvs both")
-		}
-		pv, err := cp.Meter(site.Meters.PVMeterRef)
-		if err != nil {
-			return nil, err
-		}
-		site.pvMeters = append(site.pvMeters, pv)
-	}
-
 	// multiple batteries
-	for _, ref := range site.Meters.BatteryMetersRef {
+	for _, ref := range append(site.Meters.BatteryMetersRef, site.Meters.BatteryMetersRef_...) {
 		battery, err := cp.Meter(ref)
 		if err != nil {
 			return nil, err
@@ -188,24 +176,13 @@ func NewSiteFromConfig(
 		site.batteryMeters = append(site.batteryMeters, battery)
 	}
 
-	// single battery
-	if site.Meters.BatteryMeterRef != "" {
-		if len(site.batteryMeters) > 0 {
-			return nil, errors.New("cannot have battery and batteries both")
-		}
-		battery, err := cp.Meter(site.Meters.BatteryMeterRef)
+	// auxiliary meters
+	for _, ref := range site.Meters.AuxMetersRef {
+		meter, err := cp.Meter(ref)
 		if err != nil {
 			return nil, err
 		}
-		site.batteryMeters = append(site.batteryMeters, battery)
-	}
-
-	// smart load meter
-	if site.Meters.SmartLoadRef != "" {
-		var err error
-		if site.loadMeter, err = cp.Meter(site.Meters.SmartLoadRef); err != nil {
-			return nil, err
-		}
+		site.auxMeters = append(site.auxMeters, meter)
 	}
 
 	// configure meter from references
@@ -563,15 +540,17 @@ func (site *Site) sitePower(totalChargePower float64) (float64, error) {
 	sitePower := sitePower(site.log, site.MaxGridSupplyWhileBatteryCharging, site.gridPower, batteryPower, site.ResidualPower)
 
 	// deduct smart loads
-	if site.loadMeter != nil {
-		if power, err := site.loadMeter.CurrentPower(); err != nil {
-			site.log.ERROR.Printf("smart load meter: %v", err)
+	var auxPower float64
+	for i, meter := range site.auxMeters {
+		if power, err := meter.CurrentPower(); err != nil {
+			site.log.ERROR.Printf("aux meter %d: %v", i, err)
 		} else {
-			site.log.DEBUG.Printf("smart load power: %.0fW", power)
-			site.publish("smartLoadPower", power)
-			sitePower -= power
+			auxPower += power
+			site.log.DEBUG.Printf("aux power %d: %.0fW", i, power)
 		}
 	}
+	site.publish("auxPower", auxPower)
+	sitePower -= auxPower
 
 	site.log.DEBUG.Printf("site power: %.0fW", sitePower)
 

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -69,7 +69,7 @@ meters:
     type: ...
   - name: charge
     type: ...
-  - name: smart
+  - name: aux
     type: ...
 
 # charger definitions
@@ -103,11 +103,11 @@ site:
   title: Home # display name for UI
   meters:
     grid: grid # grid meter
-    pvs:
+    pv:
       - pv # list of pv inverters/ meters
-    batteries:
+    battery:
       - battery # list of battery meters
-    smart: smart # additional smart loads meter
+    aux: aux # auxiliary meters for adjusting grid operating point
   prioritySoc: # give home battery priority up to this soc (empty to disable)
   bufferSoc: # ignore home battery discharge above soc (empty to disable)
 

--- a/schema.json
+++ b/schema.json
@@ -154,10 +154,19 @@
               "type": "string"
             },
             "pv": {
-              "type": "string"
+              "description": "PV inverter/meter (1 or more)",
+              "type": [
+                "string",
+                "array"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
             },
             "pvs": {
-              "description": "List of pv inverters/meters",
+              "description": "PV inverters/meters",
               "type": "array",
               "items": {
                 "type": "string"
@@ -166,10 +175,19 @@
               "uniqueItems": true
             },
             "battery": {
-              "type": "string"
+              "description": "Home battery (1 or more)",
+              "type": [
+                "string",
+                "array"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
             },
             "batteries": {
-              "description": "List of home batteries",
+              "description": "Home batteries",
               "type": "array",
               "items": {
                 "type": "string"


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/6106

This also makes the `pv` and `battery` settings single- or multivalued. No more ugly `pvs`.

I'm not sure this is allowed for json schema?