### PR TITLE
E3DC: Fixed the problem that external sources or inverters are not displayed and used

### DIFF
--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -22,10 +22,8 @@ render: |
       address: 40073 # Hausverbrauchs-Leistung in Watt
   {{- end}}
   {{- if eq .usage "pv" }}
-      address: 40075 # Leistung aller zusätzlichen Einspeiser in Watt
-  {{- end}}
-  {{- if eq .usage "pv" }}
       address: 40067 # Photovoltaikleistung in Watt
+      address: 40075 # Leistung aller zusätzlichen Einspeiser in Watt
   {{- end}}
   {{- if eq .usage "battery" }}
       address: 40069 # Batterie-Leistung in Watt

--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -22,6 +22,9 @@ render: |
       address: 40073 # Hausverbrauchs-Leistung in Watt
   {{- end}}
   {{- if eq .usage "pv" }}
+      address: 40075 # Leistung aller zusätzlichen Einspeiser in Watt
+  {{- end}}
+  {{- if eq .usage "pv" }}
       address: 40067 # Photovoltaikleistung in Watt
   {{- end}}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -3,7 +3,7 @@ products:
   - brand: E3DC
 params:
   - name: usage
-    choice: ["grid", "pv", "battery"]
+    choice: ["grid", "pv", "battery", "external"]
     allinone: true
   - name: host
   - name: port
@@ -21,9 +21,11 @@ render: |
   {{- if eq .usage "grid" }}
       address: 40073 # Hausverbrauchs-Leistung in Watt
   {{- end}}
-  {{- if eq .usage "pv" }}
-      address: 40067 # Photovoltaikleistung in Watt
+  {{- if eq .usage "external" }}
       address: 40075 # Leistung aller zusätzlichen Einspeiser in Watt
+  {{- end}}
+  {{- if eq .usage "grid" }}
+      address: 40073 # Hausverbrauchs-Leistung in Watt
   {{- end}}
   {{- if eq .usage "battery" }}
       address: 40069 # Batterie-Leistung in Watt


### PR DESCRIPTION
The external power generators are now also recognized and can now be used.

[#6190](https://github.com/evcc-io/evcc/issues/6190)