### PR TITLE
Add log api

### DIFF
--- a/server/log.go
+++ b/server/log.go
@@ -1,5 +1,0 @@
-package server
-
-import "github.com/evcc-io/evcc/util"
-
-var log = util.NewLogger("server")

--- a/server/socket.go
+++ b/server/socket.go
@@ -55,9 +55,9 @@ func (c *SocketClient) writePump() {
 func ServeWebsocket(hub *SocketHub, w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.ERROR.Println(err)
 		return
 	}
+
 	client := &SocketClient{hub: hub, conn: conn, send: make(chan []byte, 256)}
 	client.hub.register <- client
 

--- a/server/uds.go
+++ b/server/uds.go
@@ -9,23 +9,30 @@ import (
 
 	"github.com/evcc-io/evcc/cmd/shutdown"
 	"github.com/evcc-io/evcc/core/site"
+	"github.com/evcc-io/evcc/util"
 )
 
 // SocketPath is the unix domain socket path
 const SocketPath = "/tmp/evcc"
 
 // removeIfExists deletes file if it exists or fails
-func removeIfExists(file string) {
+func removeIfExists(file string) error {
 	if _, err := os.Stat(file); err == nil {
 		if err := os.RemoveAll(file); err != nil {
-			log.FATAL.Fatal(err)
+			return err
 		}
 	}
+	return nil
 }
 
 // HealthListener attaches listener to unix domain socket and runs listener
 func HealthListener(site site.API) {
-	removeIfExists(SocketPath)
+	log := util.NewLogger("main")
+
+	err := removeIfExists(SocketPath)
+	if err != nil {
+		log.FATAL.Fatal(err)
+	}
 
 	l, err := net.Listen("unix", SocketPath)
 	if err != nil {

--- a/server/uds.go
+++ b/server/uds.go
@@ -47,6 +47,6 @@ func HealthListener(site site.API) {
 
 	shutdown.Register(func() {
 		_ = l.Close()
-		removeIfExists(SocketPath) // cleanup
+		_ = removeIfExists(SocketPath) // cleanup
 	})
 }


### PR DESCRIPTION
This PR adds a `/log` endpoint for retrieving list of log messages.

@naltatis is that something we should add? Messages are redacted but may contain dynamic tokens (unavoidable). We would not live-push messages, only download on demand.