### PR TITLE
Increase EVSE DIN charge controller timeout

### DIFF
--- a/charger/evsedin.go
+++ b/charger/evsedin.go
@@ -52,7 +52,8 @@ func NewEvseDIN(uri, device, comset string, baudrate int, proto modbus.Protocol,
 	}
 
 	conn.Logger(log.TRACE)
-	conn.Delay(200 * time.Millisecond)
+	conn.Timeout(2000 * time.Millisecond)
+	conn.Delay(300 * time.Millisecond)
 
 	evse := &EvseDIN{
 		conn:    conn,


### PR DESCRIPTION
I hope this would fix intermittent error where EVSE DIN charge controller returns `charger: serial: timeout` error every few hours at random.
Logs show that request is sent but reply simply does not come.

Manufacturer's reply was that "if it just happens from time to time, it is normal. The PIC frequency is not set so high and it seems that other communication on the bus causes this"

Not sure what is the default timeout in evcc ?

```
	// set non-default timeout
	if cc.Timeout > 0 {
		conn.Timeout(cc.Timeout)

```