### PR TITLE
allow one last soc update if stopped charging

### DIFF
--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -680,7 +680,10 @@ func TestSocPoll(t *testing.T) {
 		{pollCharging, api.StatusC, -1, true},
 		{pollCharging, api.StatusC, 0, true},
 		{pollCharging, api.StatusC, tNoRefresh, true}, // cached by vehicle
-		{pollCharging, api.StatusC, tRefresh, true},
+		{pollCharging, api.StatusC, tRefresh, true},   // will set lp.didChargeOnLastSocUpdate
+		{pollCharging, api.StatusB, 0, false},         // last update must wait for interval
+		{pollCharging, api.StatusB, tRefresh, true},   // update once if connected and was charging
+		{pollCharging, api.StatusB, tRefresh, false},  // but only once
 
 		// pollConnected
 		{pollConnected, api.StatusA, -1, false},


### PR DESCRIPTION
Siehe: https://github.com/evcc-io/evcc/pull/6238#discussion_r1106395670

Das Ganze erlaubt jetzt ein weiteren Soc Update, wenn vorher geladen wurde und das Auto noch verbunden ist und der TargetSoc noch nicht erreicht ist laut letztem Update.
Dieses Update muss aber auch wieder `soc.poll.interval` warten.

Ich habe die Funktion jetzt auch zu mehreren Returns gerefactored um das ganze transparenter zu machen.
 Das hat auch den Vorteil das beim Laden nicht jedes mal das gleiche `60m` (`soc.poll.interval`) - `10s` (control `interval`) ausgegeben wird:
```
next soc poll remaining time: 59m50s
```
(wie [hier](https://github.com/evcc-io/evcc/discussions/6173#discussioncomment-4953818))