### PR TITLE
chore: fix vite build warning

### DIFF
--- a/assets/js/components/Energyflow/Visualization.vue
+++ b/assets/js/components/Energyflow/Visualization.vue
@@ -239,12 +239,12 @@ html.dark .grid-import {
 	white-space: nowrap;
 	overflow: hidden;
 }
-.visualization--ready ::v-deep(.label-bar) {
+.visualization--ready:deep(.label-bar) {
 	transition-property: width, opacity;
 	transition-duration: var(--evcc-transition-medium), var(--evcc-transition-fast);
 	transition-timing-function: linear, ease;
 }
-.visualization--ready ::v-deep(.label-bar-icon) {
+.visualization--ready:deep(.label-bar-icon) {
 	transition-duration: var(--evcc-transition-very-fast), 500ms;
 }
 </style>

--- a/assets/js/components/Energyflow/Visualization.vue
+++ b/assets/js/components/Energyflow/Visualization.vue
@@ -239,12 +239,12 @@ html.dark .grid-import {
 	white-space: nowrap;
 	overflow: hidden;
 }
-.visualization--ready:deep(.label-bar) {
+.visualization--ready :deep(.label-bar) {
 	transition-property: width, opacity;
 	transition-duration: var(--evcc-transition-medium), var(--evcc-transition-fast);
 	transition-timing-function: linear, ease;
 }
-.visualization--ready:deep(.label-bar-icon) {
+.visualization--ready :deep(.label-bar-icon) {
 	transition-duration: var(--evcc-transition-very-fast), 500ms;
 }
 </style>

--- a/assets/js/components/TelemetrySettings.vue
+++ b/assets/js/components/TelemetrySettings.vue
@@ -90,7 +90,7 @@ export default {
 .form-check-label {
 	max-width: 100%;
 }
-.errorMessage::v-deep pre {
+.errorMessage:deep(pre) {
 	text-overflow: ellipsis;
 	font-size: 1em;
 }

--- a/assets/js/components/TelemetrySettings.vue
+++ b/assets/js/components/TelemetrySettings.vue
@@ -90,7 +90,7 @@ export default {
 .form-check-label {
 	max-width: 100%;
 }
-.errorMessage:deep(pre) {
+.errorMessage :deep(pre) {
 	text-overflow: ellipsis;
 	font-size: 1em;
 }

--- a/assets/js/components/VehicleTitle.vue
+++ b/assets/js/components/VehicleTitle.vue
@@ -132,7 +132,7 @@ export default {
 .spin {
 	animation: rotation 1s infinite cubic-bezier(0.37, 0, 0.63, 1);
 }
-.spin ::v-deep(svg) {
+.spin :deep(svg) {
 	/* workaround to fix the not perfectly centered shopicon. Remove once its fixed in @h2d2/shopicons */
 	transform: translateY(-0.7px);
 }


### PR DESCRIPTION
```
vite v3.2.5 building for production...
transforming (287) js/components/MultiIcon/4.vue[@vue/compiler-sfc] ::v-deep usage as a combinator has been deprecated. Use :deep(<inner-selector>) instead.
```

I'm not sure if the fix is correct though, both selectors are different.