### PR TITLE
Fix: E3DC external power source now added to the main power

### DIFF
--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -37,6 +37,7 @@ render: |
         type: holding
         decode: int32s
         address: 40075 # Leistung zusätzlicher Einspeiser in Watt
+      scale: -1 # Invert the value to add it to the other value
   {{- end}}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -37,7 +37,7 @@ render: |
         type: holding
         decode: int32s
         address: 40075 # Leistung zusätzlicher Einspeiser in Watt
-    calc: sum
+      scale: -1 # Invert the value to add it to the other value
   {{- end}}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -37,7 +37,7 @@ render: |
         type: holding
         decode: int32s
         address: 40075 # Leistung zusätzlicher Einspeiser in Watt
-      scale: -1 # Invert the value to add it to the other value
+    calc: sum
   {{- end}}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
A condition is used in the render field to retrieve either grid power, photovoltaic power, or battery power, depending on the intended use of the E3DC system. When purpose is "pv", two power values have been subtracted instead of added. To change this, the add field in the power section has been edited to invert the value of 40075 before adding it to the other value, turning the subtraction into an addition.