### PR TITLE
Remove battery power threshold in UI

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -193,15 +193,11 @@ export default {
 		pvProduction: function () {
 			return Math.abs(this.pvPower);
 		},
-		batteryPowerAdjusted: function () {
-			const batteryPowerThreshold = 50;
-			return Math.abs(this.batteryPower) < batteryPowerThreshold ? 0 : this.batteryPower;
-		},
 		batteryDischarge: function () {
-			return Math.abs(Math.max(0, this.batteryPowerAdjusted));
+			return Math.abs(Math.max(0, this.batteryPower));
 		},
 		batteryCharge: function () {
-			return Math.abs(Math.min(0, this.batteryPowerAdjusted) * -1);
+			return Math.abs(Math.min(0, this.batteryPower) * -1);
 		},
 		selfConsumption: function () {
 			const ownPower = this.batteryDischarge + this.pvProduction;


### PR DESCRIPTION
Low battery power (-50W to 50W) were shown as 0W because this is usually just standby power. This PR removes this threshold to avoid confusion with inconsistent in/out sums.

fixes #6421