### PR TITLE
Fix weekday i18n for target charge dialog

### DIFF
--- a/assets/js/components/TargetCharge.vue
+++ b/assets/js/components/TargetCharge.vue
@@ -302,12 +302,12 @@ export default {
 				this.$t("main.targetCharge.tomorrow"),
 			];
 			for (let i = 0; i < 7; i++) {
-				const dayNumber = date.toLocaleDateString("default", {
+				const dayNumber = date.toLocaleDateString(this.$i18n.locale, {
 					month: "short",
 					day: "numeric",
 				});
 				const dayName =
-					labels[i] || date.toLocaleDateString("default", { weekday: "long" });
+					labels[i] || date.toLocaleDateString(this.$i18n.locale, { weekday: "long" });
 				options.push({
 					value: this.fmtDayString(date),
 					name: `${dayNumber} (${dayName})`,


### PR DESCRIPTION
fixes #6546

This was an easy one. We had proper internationalization there, but always used the browser default and not the user configured locale.

![Bildschirm­foto 2023-03-01 um 15 42 00](https://user-images.githubusercontent.com/152287/222173142-8fc5b524-4cf0-4270-98e8-0d12ca164d7b.png)
![Bildschirm­foto 2023-03-01 um 15 41 41](https://user-images.githubusercontent.com/152287/222173152-662864f1-a755-41cc-96af-5b1ffa6365fb.png)

\\cc @kfussmann thanks for finding this