### PR TITLE
Homematic: Error handling enhancement

### DIFF
--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -87,6 +87,8 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 			if err := xml.Unmarshal(res, &hmr); err != nil {
 				return hmr, err
 			}
+		} else {
+			return hmr, err
 		}
 	}
 

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -65,7 +65,7 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 	var hmr MethodResponse
 	body, err := xml.Marshal(hmc)
 	if err != nil {
-		return hmr, err
+		return MethodResponse{}, err
 	}
 
 	headers := map[string]string{
@@ -75,7 +75,7 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 	if req, err := request.New(http.MethodPost, c.URI, strings.NewReader(xml.Header+string(body)), headers); err == nil {
 		if res, err := c.DoBody(req); err == nil {
 			if strings.Contains(string(res), "faultCode") {
-				return hmr, fmt.Errorf("ccu: %s", string(res))
+				return MethodResponse{}, fmt.Errorf("ccu: %s", string(res))
 			}
 
 			// correct Homematic IP Legacy API (CCU port 2010) method response encoding value
@@ -85,10 +85,10 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 			res = []byte(strings.Replace(string(res), "iso-8859-1", "UTF-8", 1))
 
 			if err := xml.Unmarshal(res, &hmr); err != nil {
-				return hmr, err
+				return MethodResponse{}, err
 			}
 		} else {
-			return hmr, err
+			return MethodResponse{}, err
 		}
 	}
 


### PR DESCRIPTION
Raise homematic API errors.

In case of API errors, the corresponding response code will be returned (e-g. 401, 404 ...):
```bash
thierolm@LAPTOP-KQMMVN3H:~/git-repos/evcc$ ./evcc -c evcc_homematictest.yaml charger
[main  ] INFO 2023/03/01 17:34:45 evcc 0.113.2 (fb8cdf6a)
[main  ] INFO 2023/03/01 17:34:45 using config file: evcc_homematictest.yaml
[db    ] INFO 2023/03/01 17:34:45 using sqlite database: /home/thierolm/.evcc/evcc.db
Power:         unexpected status: 401
Energy:        unexpected status: 401
Charge status: unexpected status: 401
Enabled:       unexpected status: 401
```