### PR TITLE
Update Energyflow.vue

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -236,7 +236,7 @@ export default {
 			});
 		},
 		batteryFmt() {
-			return (soc) => `${Math.round(soc)}%`;
+			return (soc) => `${Math.round(soc)} %`;
 		},
 	},
 	mounted() {


### PR DESCRIPTION
Zwischen Zahl und Prozentzeichen wird immer ein Leerraumzeichen (1 x Leerschritttaste) gesetzt (DIN 5008).