### PR TITLE
Update TargetSocSelect.vue

### DIFF
--- a/assets/js/components/TargetSocSelect.vue
+++ b/assets/js/components/TargetSocSelect.vue
@@ -61,7 +61,7 @@ export default {
 			return null;
 		},
 		formatSoc: function (value) {
-			return `${Math.round(value)}%`;
+			return `${Math.round(value)} %`;
 		},
 		formatKm: function (value) {
 			return `${Math.round(value)} ${distanceUnit()}`;


### PR DESCRIPTION
Zwischen Zahl und Prozentzeichen wird immer ein Leerraumzeichen (1 x Leerschritttaste) gesetzt (DIN 5008).