### PR TITLE
Update TargetEnergySelect.vue

### DIFF
--- a/assets/js/components/TargetEnergySelect.vue
+++ b/assets/js/components/TargetEnergySelect.vue
@@ -93,7 +93,7 @@ export default {
 			return this.fmtKWh(value * 1e3, inKWh, true, digits);
 		},
 		fmtSoc: function (value) {
-			return `+${Math.round(value)}%`;
+			return `+${Math.round(value)} %`;
 		},
 	},
 };


### PR DESCRIPTION
Zwischen Zahl und Prozentzeichen wird immer ein Leerraumzeichen (1 x Leerschritttaste) gesetzt (DIN 5008).