### PR TITLE
Switchsockets: User/Password Check

### DIFF
--- a/api/actionconfig.go
+++ b/api/actionconfig.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/fatih/structs"
+	"github.com/imdario/mergo"
 )
 
 // ActionConfig defines an action to take on event
@@ -21,23 +22,8 @@ type ActionConfig struct {
 // Merge merges all non-nil properties of the additional config into the base config.
 // The receiver's config remains immutable.
 func (a ActionConfig) Merge(m ActionConfig) ActionConfig {
-	if m.Mode != nil {
-		a.Mode = m.Mode
-	}
-	if m.MinCurrent != nil {
-		a.MinCurrent = m.MinCurrent
-	}
-	if m.MaxCurrent != nil {
-		a.MaxCurrent = m.MaxCurrent
-	}
-	if m.MinSoc != nil {
-		a.MinSoc = m.MinSoc
-	}
-	if m.TargetSoc != nil {
-		a.TargetSoc = m.TargetSoc
-	}
-	if m.Priority != nil {
-		a.Priority = m.Priority
+	if err := mergo.MergeWithOverwrite(&a, m); err != nil {
+		panic(err)
 	}
 	return a
 }

--- a/api/actionconfig.go
+++ b/api/actionconfig.go
@@ -36,6 +36,9 @@ func (a ActionConfig) Merge(m ActionConfig) ActionConfig {
 	if m.TargetSoc != nil {
 		a.TargetSoc = m.TargetSoc
 	}
+	if m.Priority != nil {
+		a.Priority = m.Priority
+	}
 	return a
 }
 

--- a/api/actionconfig_test.go
+++ b/api/actionconfig_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMerge(t *testing.T) {
+	pv := ModePV
+	one := 1
+	six := 6.0
+	old := ActionConfig{
+		Mode:       &pv,
+		Priority:   &one,
+		MinCurrent: &six,
+	}
+
+	now := ModeNow
+	two := 2
+	three := 3
+	new := ActionConfig{
+		Mode:     &now,
+		MinSoc:   &three,
+		Priority: &two,
+	}
+
+	dst := old.Merge(new)
+
+	// unmodified
+	assert.Equal(t, old, ActionConfig{
+		Mode:       &pv,
+		Priority:   &one,
+		MinCurrent: &six,
+	}, "old modified")
+
+	// overwritten
+	assert.Equal(t, dst, ActionConfig{
+		Mode:       &now,
+		MinCurrent: &six,
+		MinSoc:     &three,
+		Priority:   &two,
+	}, "new wrong")
+}

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -34,11 +34,11 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
-	if cc.User == "" {
+	if cc.User == "" || cc.User == "<nil>" {
 		return nil, errors.New("missing user")
 	}
 
-	if cc.Password == "" {
+	if cc.Password == "" || cc.Password == "<nil>" {
 		return nil, errors.New("missing password")
 	}
 

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -104,6 +104,7 @@ func (c *FritzDECT) MaxCurrent(current int64) error {
 	return nil
 }
 
+var _ api.Meter = (*FritzDECT)(nil)
 var _ api.MeterEnergy = (*FritzDECT)(nil)
 
 // TotalEnergy implements the api.MeterEnergy interface

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -34,6 +34,14 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
+	if cc.User == "" {
+		return nil, errors.New("missing user")
+	}
+
+	if cc.Password == "" {
+		return nil, errors.New("missing password")
+	}
+
 	return NewFritzDECT(cc.embed, cc.URI, cc.AIN, cc.User, cc.Password, cc.StandbyPower)
 }
 

--- a/charger/homematic.go
+++ b/charger/homematic.go
@@ -35,11 +35,11 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
-	if cc.User == "" {
+	if cc.User == "" || cc.User == "<nil>" {
 		return nil, errors.New("missing user")
 	}
 
-	if cc.Password == "" {
+	if cc.Password == "" || cc.Password == "<nil>" {
 		return nil, errors.New("missing password")
 	}
 

--- a/charger/homematic.go
+++ b/charger/homematic.go
@@ -1,6 +1,8 @@
 package charger
 
 import (
+	"errors"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/homematic"
 	"github.com/evcc-io/evcc/util"
@@ -31,6 +33,14 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Charger, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
+	}
+
+	if cc.User == "" {
+		return nil, errors.New("missing user")
+	}
+
+	if cc.Password == "" {
+		return nil, errors.New("missing password")
 	}
 
 	return NewCCU(cc.embed, cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.StandbyPower)

--- a/charger/homematic.go
+++ b/charger/homematic.go
@@ -64,6 +64,7 @@ func (c *CCU) MaxCurrent(current int64) error {
 	return nil
 }
 
+var _ api.Meter = (*CCU)(nil)
 var _ api.MeterEnergy = (*CCU)(nil)
 
 // TotalEnergy implements the api.MeterEnergy interface

--- a/charger/mystrom.go
+++ b/charger/mystrom.go
@@ -67,3 +67,5 @@ func (c *MyStrom) Enable(enable bool) error {
 func (c *MyStrom) MaxCurrent(current int64) error {
 	return nil
 }
+
+var _ api.Meter = (*MyStrom)(nil)

--- a/charger/shelly.go
+++ b/charger/shelly.go
@@ -81,6 +81,7 @@ func (c *Shelly) MaxCurrent(current int64) error {
 	return nil
 }
 
+var _ api.Meter = (*Shelly)(nil)
 var _ api.MeterEnergy = (*Shelly)(nil)
 
 // TotalEnergy implements the api.MeterEnergy interface

--- a/charger/tapo.go
+++ b/charger/tapo.go
@@ -69,6 +69,7 @@ func (c *Tapo) MaxCurrent(current int64) error {
 	return nil
 }
 
+var _ api.Meter = (*Tapo)(nil)
 var _ api.ChargeRater = (*Tapo)(nil)
 
 // ChargedEnergy implements the api.ChargeRater interface

--- a/charger/tapo.go
+++ b/charger/tapo.go
@@ -1,6 +1,8 @@
 package charger
 
 import (
+	"errors"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/tapo"
 	"github.com/evcc-io/evcc/util"
@@ -28,6 +30,13 @@ func NewTapoFromConfig(other map[string]interface{}) (api.Charger, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
+	}
+	if cc.User == "" {
+		return nil, errors.New("missing user")
+	}
+
+	if cc.Password == "" {
+		return nil, errors.New("missing password")
 	}
 
 	return NewTapo(cc.embed, cc.URI, cc.User, cc.Password, cc.StandbyPower)

--- a/charger/tapo.go
+++ b/charger/tapo.go
@@ -31,11 +31,12 @@ func NewTapoFromConfig(other map[string]interface{}) (api.Charger, error) {
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
-	if cc.User == "" {
+
+	if cc.User == "" || cc.User == "<nil>" {
 		return nil, errors.New("missing user")
 	}
 
-	if cc.Password == "" {
+	if cc.Password == "" || cc.Password == "<nil>" {
 		return nil, errors.New("missing password")
 	}
 

--- a/charger/tasmota.go
+++ b/charger/tasmota.go
@@ -173,6 +173,7 @@ func (c *Tasmota) MaxCurrent(current int64) error {
 	return nil
 }
 
+var _ api.Meter = (*Tasmota)(nil)
 var _ api.MeterEnergy = (*Tasmota)(nil)
 
 // TotalEnergy implements the api.MeterEnergy interface

--- a/charger/tplink.go
+++ b/charger/tplink.go
@@ -97,6 +97,7 @@ func (c *TPLink) MaxCurrent(current int64) error {
 	return nil
 }
 
+var _ api.Meter = (*TPLink)(nil)
 var _ api.MeterEnergy = (*TPLink)(nil)
 
 // TotalEnergy implements the api.MeterEnergy interface

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -169,6 +169,22 @@ func (v *Twc3) Currents() (float64, float64, float64, error) {
 	return res.CurrentAA, res.CurrentBA, res.CurrentCA, err
 }
 
+var _ api.Meter = (*Twc3)(nil)
+
+// CurrentPower implements the api.Meter interface
+func (v *Twc3) CurrentPower() (float64, error) {
+	res, err := v.vitalsG()
+	return (res.CurrentAA + res.CurrentBA + res.CurrentCA) * res.GridV, err
+}
+
+var _ api.PhaseVoltages = (*Twc3)(nil)
+
+// Voltages implements the api.PhaseVoltages interface
+func (v *Twc3) Voltages() (float64, float64, float64, error) {
+	res, err := v.vitalsG()
+	return res.VoltageAV, res.VoltageBV, res.VoltageCV, err
+}
+
 var _ loadpoint.Controller = (*Twc3)(nil)
 
 // LoadpointControl implements loadpoint.Controller

--- a/meter/fritzdect.go
+++ b/meter/fritzdect.go
@@ -22,11 +22,11 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
-	if cc.User == "" {
+	if cc.User == "" || cc.User == "<nil>" {
 		return nil, errors.New("missing user")
 	}
 
-	if cc.Password == "" {
+	if cc.Password == "" || cc.Password == "<nil>" {
 		return nil, errors.New("missing password")
 	}
 

--- a/meter/fritzdect.go
+++ b/meter/fritzdect.go
@@ -1,6 +1,8 @@
 package meter
 
 import (
+	"errors"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/fritzdect"
 	"github.com/evcc-io/evcc/util"
@@ -18,6 +20,14 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Meter, error) {
 	var cc fritzdect.Settings
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
+	}
+
+	if cc.User == "" {
+		return nil, errors.New("missing user")
+	}
+
+	if cc.Password == "" {
+		return nil, errors.New("missing password")
 	}
 
 	return fritzdect.NewConnection(cc.URI, cc.AIN, cc.User, cc.Password)

--- a/meter/homematic.go
+++ b/meter/homematic.go
@@ -1,6 +1,8 @@
 package meter
 
 import (
+	"errors"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/homematic"
 	"github.com/evcc-io/evcc/util"
@@ -30,6 +32,14 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Meter, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
+	}
+
+	if cc.User == "" {
+		return nil, errors.New("missing user")
+	}
+
+	if cc.Password == "" {
+		return nil, errors.New("missing password")
 	}
 
 	return NewCCU(cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.Usage)

--- a/meter/homematic.go
+++ b/meter/homematic.go
@@ -34,11 +34,11 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
-	if cc.User == "" {
+	if cc.User == "" || cc.User == "<nil>" {
 		return nil, errors.New("missing user")
 	}
 
-	if cc.Password == "" {
+	if cc.Password == "" || cc.Password == "<nil>" {
 		return nil, errors.New("missing password")
 	}
 

--- a/meter/tapo.go
+++ b/meter/tapo.go
@@ -25,11 +25,11 @@ func NewTapoFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
-	if cc.User == "" {
+	if cc.User == "" || cc.User == "<nil>" {
 		return nil, errors.New("missing user")
 	}
 
-	if cc.Password == "" {
+	if cc.Password == "" || cc.Password == "<nil>" {
 		return nil, errors.New("missing password")
 	}
 

--- a/meter/tapo.go
+++ b/meter/tapo.go
@@ -1,6 +1,8 @@
 package meter
 
 import (
+	"errors"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/tapo"
 	"github.com/evcc-io/evcc/util"
@@ -21,6 +23,14 @@ func NewTapoFromConfig(other map[string]interface{}) (api.Meter, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
+	}
+
+	if cc.User == "" {
+		return nil, errors.New("missing user")
+	}
+
+	if cc.Password == "" {
+		return nil, errors.New("missing password")
 	}
 
 	return tapo.NewConnection(cc.URI, cc.User, cc.Password)

--- a/util/templates/includes/vehicle-identify.tpl
+++ b/util/templates/includes/vehicle-identify.tpl
@@ -17,7 +17,7 @@ onIdentify:
   maxCurrent: {{ .maxCurrent }}
 {{- end }}
 {{- if (ne .priority "") }}
-- priority: {{ .priority }}
+  priority: {{ .priority }}
 {{- end }}
 {{- end }}
 {{- if ne (len .identifiers) 0 }}


### PR DESCRIPTION
Add User/Password Check for Switchsocket devices for which user+password are mandatory:
- FritzDect
- Homematic
- Tapo 