### PR TITLE
Sockets: Mandatory Credentials Check

### DIFF
--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -34,6 +34,10 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
 	return NewFritzDECT(cc.embed, cc.URI, cc.AIN, cc.User, cc.Password, cc.StandbyPower)
 }
 

--- a/charger/homematic.go
+++ b/charger/homematic.go
@@ -33,6 +33,10 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
 	return NewCCU(cc.embed, cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.StandbyPower)
 }
 

--- a/charger/tapo.go
+++ b/charger/tapo.go
@@ -30,6 +30,10 @@ func NewTapoFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
 	return NewTapo(cc.embed, cc.URI, cc.User, cc.Password, cc.StandbyPower)
 }
 

--- a/meter/fritzdect.go
+++ b/meter/fritzdect.go
@@ -20,5 +20,9 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
 	return fritzdect.NewConnection(cc.URI, cc.AIN, cc.User, cc.Password)
 }

--- a/meter/homematic.go
+++ b/meter/homematic.go
@@ -32,6 +32,10 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
 	return NewCCU(cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.Usage)
 }
 

--- a/meter/tapo.go
+++ b/meter/tapo.go
@@ -23,5 +23,9 @@ func NewTapoFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
 	return tapo.NewConnection(cc.URI, cc.User, cc.Password)
 }

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -323,6 +323,7 @@ func (t *Template) RenderResult(renderMode string, other map[string]interface{})
 
 		default:
 			if res[out] == nil || res[out].(string) == "" {
+				// prevent rendering nil interfaces as "<nil>" string
 				var s string
 				if val != nil {
 					s = yamlQuote(fmt.Sprintf("%v", val))

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -323,7 +323,11 @@ func (t *Template) RenderResult(renderMode string, other map[string]interface{})
 
 		default:
 			if res[out] == nil || res[out].(string) == "" {
-				res[out] = yamlQuote(fmt.Sprintf("%v", val))
+				var s string
+				if val != nil {
+					s = yamlQuote(fmt.Sprintf("%v", val))
+				}
+				res[out] = s
 			}
 		}
 	}


### PR DESCRIPTION
Add User/Password Check for Switchsocket devices for which user+password are mandatory:

- FritzDect
- Homematic
- Tapo