### PR TITLE
Go plugin

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -62,6 +62,7 @@ type config struct {
 	Mqtt         mqttConfig
 	ModbusProxy  []proxyConfig
 	Javascript   []javascriptConfig
+	Go           []goConfig
 	Influx       server.InfluxConfig
 	EEBus        map[string]interface{}
 	HEMS         typedConfig
@@ -80,6 +81,11 @@ type mqttConfig struct {
 }
 
 type javascriptConfig struct {
+	VM     string
+	Script string
+}
+
+type goConfig struct {
 	VM     string
 	Script string
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/evcc-io/evcc/provider/golang"
 	"strconv"
 	"strings"
 	"time"
@@ -96,6 +97,11 @@ func configureEnvironment(cmd *cobra.Command, conf config) (err error) {
 		err = configureJavascript(conf.Javascript)
 	}
 
+	// setup go VMs
+	if err == nil {
+		err = configureGo(conf.Go)
+	}
+
 	// setup EEBus server
 	if err == nil && conf.EEBus != nil {
 		err = configureEEBus(conf.EEBus)
@@ -158,6 +164,16 @@ func configureJavascript(conf []javascriptConfig) error {
 	for _, cc := range conf {
 		if _, err := javascript.RegisteredVM(cc.VM, cc.Script); err != nil {
 			return fmt.Errorf("failed configuring javascript: %w", err)
+		}
+	}
+	return nil
+}
+
+// setup go
+func configureGo(conf []goConfig) error {
+	for _, cc := range conf {
+		if _, err := golang.RegisteredVM(cc.VM, cc.Script); err != nil {
+			return fmt.Errorf("failed configuring go: %w", err)
 		}
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
+	github.com/traefik/yaegi v0.14.3
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c
 	github.com/volkszaehler/mbmd v0.0.0-20230312113724-f6764040a78e
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1045,6 +1045,8 @@ github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cb
 github.com/teivah/onecontext v1.3.0 h1:tbikMhAlo6VhAuEGCvhc8HlTnpX4xTNPTOseWuhO1J0=
 github.com/teivah/onecontext v1.3.0/go.mod h1:hoW1nmdPVK/0jrvGtcx8sCKYs2PiS4z0zzfdeuEVyb0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/traefik/yaegi v0.14.3 h1:LqA0k8DKwvRMc+msfQjNusphHJc+r6WC5tZU5TmUFOM=
+github.com/traefik/yaegi v0.14.3/go.mod h1:AVRxhaI2G+nUsaM1zyktzwXn69G3t/AuTDrCiTds9p0=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=

--- a/provider/go.go
+++ b/provider/go.go
@@ -2,10 +2,11 @@ package provider
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/evcc-io/evcc/provider/golang"
 	"github.com/evcc-io/evcc/util"
 	"github.com/traefik/yaegi/interp"
-	"reflect"
 )
 
 // Go implements Go request provider
@@ -49,8 +50,8 @@ func (p *Go) FloatGetter() func() (float64, error) {
 			var v reflect.Value
 			v, err = p.vm.Eval(p.script)
 			if err == nil {
-				if v.CanConvert(reflect.TypeOf(0.0)) {
-					res = v.Convert(reflect.TypeOf(0.0)).Float()
+				if typ := reflect.TypeOf(res); v.CanConvert(typ) {
+					res = v.Convert(typ).Float()
 				} else {
 					err = fmt.Errorf("not a float: %v", v)
 				}
@@ -66,8 +67,8 @@ func (p *Go) IntGetter() func() (int64, error) {
 		var v reflect.Value
 		v, err = p.vm.Eval(p.script)
 		if err == nil {
-			if v.CanConvert(reflect.TypeOf(0)) {
-				res = v.Convert(reflect.TypeOf(0)).Int()
+			if typ := reflect.TypeOf(res); v.CanConvert(typ) {
+				res = v.Convert(typ).Int()
 			} else {
 				err = fmt.Errorf("not an int: %v", v)
 			}
@@ -83,8 +84,8 @@ func (p *Go) StringGetter() func() (string, error) {
 		var v reflect.Value
 		v, err = p.vm.Eval(p.script)
 		if err == nil {
-			if v.CanConvert(reflect.TypeOf("")) {
-				res = v.Convert(reflect.TypeOf("")).String()
+			if typ := reflect.TypeOf(res); v.CanConvert(typ) {
+				res = v.Convert(typ).String()
 			} else {
 				err = fmt.Errorf("not a string: %v", v)
 			}
@@ -100,8 +101,8 @@ func (p *Go) BoolGetter() func() (bool, error) {
 		var v reflect.Value
 		v, err = p.vm.Eval(p.script)
 		if err == nil {
-			if v.CanConvert(reflect.TypeOf(true)) {
-				res = v.Convert(reflect.TypeOf(true)).Bool()
+			if typ := reflect.TypeOf(res); v.CanConvert(typ) {
+				res = v.Convert(typ).Bool()
 			} else {
 				err = fmt.Errorf("not a boolean: %v", v)
 			}

--- a/provider/go.go
+++ b/provider/go.go
@@ -46,17 +46,15 @@ func NewGoProviderFromConfig(other map[string]interface{}) (IntProvider, error) 
 // FloatGetter parses float from request
 func (p *Go) FloatGetter() func() (float64, error) {
 	return func() (res float64, err error) {
+		v, err := p.vm.Eval(p.script)
 		if err == nil {
-			var v reflect.Value
-			v, err = p.vm.Eval(p.script)
-			if err == nil {
-				if typ := reflect.TypeOf(res); v.CanConvert(typ) {
-					res = v.Convert(typ).Float()
-				} else {
-					err = fmt.Errorf("not a float: %v", v)
-				}
+			if typ := reflect.TypeOf(res); v.CanConvert(typ) {
+				res = v.Convert(typ).Float()
+			} else {
+				err = fmt.Errorf("not a float: %v", v)
 			}
 		}
+
 		return res, err
 	}
 }
@@ -64,8 +62,7 @@ func (p *Go) FloatGetter() func() (float64, error) {
 // IntGetter parses int64 from request
 func (p *Go) IntGetter() func() (int64, error) {
 	return func() (res int64, err error) {
-		var v reflect.Value
-		v, err = p.vm.Eval(p.script)
+		v, err := p.vm.Eval(p.script)
 		if err == nil {
 			if typ := reflect.TypeOf(res); v.CanConvert(typ) {
 				res = v.Convert(typ).Int()
@@ -81,8 +78,7 @@ func (p *Go) IntGetter() func() (int64, error) {
 // StringGetter sends string request
 func (p *Go) StringGetter() func() (string, error) {
 	return func() (res string, err error) {
-		var v reflect.Value
-		v, err = p.vm.Eval(p.script)
+		v, err := p.vm.Eval(p.script)
 		if err == nil {
 			if typ := reflect.TypeOf(res); v.CanConvert(typ) {
 				res = v.Convert(typ).String()

--- a/provider/go.go
+++ b/provider/go.go
@@ -114,35 +114,30 @@ func (p *Go) setParam(param string, val interface{}) error {
 	return err
 }
 
-// IntSetter sends int request
+func (p *Go) paramAndEval(param string, val any) error {
+	err := p.setParam(param, val)
+	if err == nil {
+		_, err = p.vm.Eval(p.script)
+	}
+	return err
+}
+
 func (p *Go) IntSetter(param string) func(int64) error {
 	return func(val int64) error {
-		err := p.setParam(param, val)
-		if err == nil {
-			_, err = p.vm.Eval(p.script)
-		}
-		return err
+		return p.paramAndEval(param, val)
 	}
 }
 
 // StringSetter sends string request
 func (p *Go) StringSetter(param string) func(string) error {
 	return func(val string) error {
-		err := p.setParam(param, val)
-		if err == nil {
-			_, err = p.vm.Eval(p.script)
-		}
-		return err
+		return p.paramAndEval(param, val)
 	}
 }
 
 // BoolSetter sends bool request
 func (p *Go) BoolSetter(param string) func(bool) error {
 	return func(val bool) error {
-		err := p.setParam(param, val)
-		if err == nil {
-			_, err = p.vm.Eval(p.script)
-		}
-		return err
+		return p.paramAndEval(param, val)
 	}
 }

--- a/provider/go.go
+++ b/provider/go.go
@@ -75,7 +75,7 @@ func (p *Go) IntGetter() func() (int64, error) {
 	}
 }
 
-// StringGetter sends string request
+// StringGetter parses string from request
 func (p *Go) StringGetter() func() (string, error) {
 	return func() (res string, err error) {
 		v, err := p.vm.Eval(p.script)
@@ -107,14 +107,8 @@ func (p *Go) BoolGetter() func() (bool, error) {
 	}
 }
 
-func (p *Go) setParam(param string, val interface{}) error {
-	log.DEBUG.Printf("Setting param %s := %v;", param, val)
-	_, err := p.vm.Eval(fmt.Sprintf("%s := %v;", param, val))
-	return err
-}
-
 func (p *Go) paramAndEval(param string, val any) error {
-	err := p.setParam(param, val)
+	_, err := p.vm.Eval(fmt.Sprintf("%s := %v;", param, val))
 	if err == nil {
 		_, err = p.vm.Eval(p.script)
 	}

--- a/provider/go.go
+++ b/provider/go.go
@@ -94,8 +94,7 @@ func (p *Go) StringGetter() func() (string, error) {
 // BoolGetter parses bool from request
 func (p *Go) BoolGetter() func() (bool, error) {
 	return func() (res bool, err error) {
-		var v reflect.Value
-		v, err = p.vm.Eval(p.script)
+		v, err := p.vm.Eval(p.script)
 		if err == nil {
 			if typ := reflect.TypeOf(res); v.CanConvert(typ) {
 				res = v.Convert(typ).Bool()

--- a/provider/golang/registry.go
+++ b/provider/golang/registry.go
@@ -1,0 +1,43 @@
+package golang
+
+import (
+	"github.com/traefik/yaegi/interp"
+	"github.com/traefik/yaegi/stdlib"
+	"strings"
+	"sync"
+)
+
+var (
+	mu       sync.Mutex
+	registry = make(map[string]*interp.Interpreter)
+)
+
+// RegisteredVM returns a JS VM. If name is not empty, it will return a shared instance.
+func RegisteredVM(name, init string) (*interp.Interpreter, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	name = strings.ToLower(name)
+	vm, ok := registry[name]
+
+	// create new VM
+	if !ok {
+		vm = interp.New(interp.Options{})
+
+		if err := vm.Use(stdlib.Symbols); err != nil {
+			return nil, err
+		}
+
+		if init != "" {
+			if _, err := vm.Eval(init); err != nil {
+				return nil, err
+			}
+		}
+
+		if name != "" {
+			registry[name] = vm
+		}
+	}
+
+	return vm, nil
+}


### PR DESCRIPTION
Implementierung eines Go Plugins, so nah wie möglich am Javascript Plugin.

Der 1. commit ist die eigentliche Implementierung. Im Prinzip alles vom javascript Plugin kopiert. Hauptunterschied: im Javascript wird `val`genutzt um einen Parameterwert zu lesen, im Go Plugin wird der Name des Parameters als Variablenname genutzt.

Der 2. commit enthält eine demo.yaml, in der das javascript durch go ersetzt wurde. Sollte sich hoffentlich genauso verhalten, wie vorher. Das könnte man dort vermutlich auch alles noch schöner machen, ich habe versucht es möglichst nah am javascript original zu lassen.

(Basiert auf dem Prototypen, der in #5730 enthalten war. An dem Transformation Kram arbeite ich auch noch, dauert aber noch ein bisschen 😄)