### PR TITLE
Enable configure for running evcc in docker

### DIFF
--- a/docker/bin/entrypoint.sh
+++ b/docker/bin/entrypoint.sh
@@ -25,7 +25,15 @@ if [ -f ${HASSIO_OPTIONSFILE} ]; then
 else
     if [ "$1" == '"evcc"' ] || expr "$1" : '-*' > /dev/null; then
         exec evcc "$@"
+    elif [ "$1" == 'configure' ]; then
+        evcc configure
+        cat evcc.yaml && echo
+        test -d /etc/evcc && mv evcc.yaml /etc/evcc
     else
-        exec "$@"
+        EVCC_CONFIG="/etc/evcc.yaml"
+        if [ -f /etc/evcc/evcc.yaml ]; then
+            EVCC_CONFIG="/etc/evcc/evcc.yaml"
+        fi
+        exec "$@ -c ${EVCC_CONFIG}"
     fi
 fi


### PR DESCRIPTION
Added an "configure" option to the entrypoint.sh which can write a evcc.yaml into a volume and prints it to system out.

Running:
```
   docker run -it --rm -p 7070:7070 -p 8887:8887 -p 7090:7090/udp -p 9522:9522/udp \
                     -v evcc:/etc/evcc evcc/evcc configure
```
should generate now a `evcc.yaml` within the docker-volume `evcc`

In order to take this new config the volume has to be mounted at evcc-start as well.
