### PR TITLE
Add my-PV WiFi Meter

### DIFF
--- a/templates/definition/meter/mypv-wifi-meter.yaml
+++ b/templates/definition/meter/mypv-wifi-meter.yaml
@@ -1,0 +1,70 @@
+template: mypv-wifi-meter
+products:
+  - brand: my-PV
+    description:
+      generic: WiFi Meter
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: modbus
+    choice: ["tcpip"]
+    port: 502
+    id: 1
+render: |
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 32 # 0x0020 sum of power, signed, value=data, unit: W
+      type: holding
+      decode: int32
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 34 # 0x0022 sum of forward energy; unsigned, value=data/800, unit: kWh
+      type: holding
+      decode: uint32
+    scale: 0.08
+  currents:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 1 # 0x0001 Phase A current, unsigned, value=data/100, unit: A
+      type: holding
+      decode: uint16
+    scale: 0.01
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 11 # 0x000B Phase B current, unsigned, value=data/100, unit: A
+      type: holding
+      decode: uint16
+    scale: 0.01
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 21 # 0x0015 Phase C current, unsigned, value=data/100, unit: A
+      type: holding
+      decode: uint16
+    scale: 0.01
+  powers:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 2 # 0x0001 Phase A active power, signed, value=data, unit: "W"
+      type: holding
+      decode: int32
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 12 # 0x000C Phase B active power, signed, value=data, unit: "W"
+      type: holding
+      decode: int32
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 22 # 0x0016 Phase C active power, signed, value=data, unit: "W"
+      type: holding
+      decode: int32

--- a/templates/docs/meter/mypv-wifi-meter_0.yaml
+++ b/templates/docs/meter/mypv-wifi-meter_0.yaml
@@ -1,0 +1,15 @@
+product:
+  brand: my-PV
+  description: WiFi Meter
+render:
+  - usage: grid
+    default: |
+      type: template
+      template: mypv-wifi-meter
+      usage: grid      
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port

--- a/templates/evcc.io/brands.json
+++ b/templates/evcc.io/brands.json
@@ -83,6 +83,7 @@
   "Janitza",
   "Kostal",
   "LG",
+  "my-PV",
   "myStrom",
   "OpenEMS",
   "Orno",


### PR DESCRIPTION
Fixes #6801

`usage: grid`

- [x] power
- [x] energy
- [x] currents
- [x] powers

@mafde2023 Bitte testen. Insbesondere die Skalierung der Energie und der Ströme.
Ausgabe von `evcc meter` mit dem Webinterface des Meters vergleichen.