### PR TITLE
Publish phasesEnabled

### DIFF
--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -28,6 +28,9 @@ func (lp *Loadpoint) setPhases(phases int) {
 		lp.phases = phases
 		lp.Unlock()
 
+		// publish updated phase configuration
+		lp.publish(phasesEnabled, lp.phases)
+
 		// reset timer to disabled state
 		lp.resetPhaseTimer()
 


### PR DESCRIPTION
Publish `phasesEnabled` on phase reconfiguration to reflect the enabled phases seen on the charge connector.

Replaces #6814
May fix #6178