### PR TITLE
Homematic: Enhance Error Messages

### DIFF
--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -163,7 +163,7 @@ func ParseHmError(res MethodResponse) error {
 	}
 
 	if faultCode != 0 {
-		return fmt.Errorf("CCU error: %s (faultcode %v)", faultString, res.Fault[0].Value.CCUInt)
+		return fmt.Errorf("CCU error: %s (faultcode %v)", faultString, faultCode)
 	}
 
 	return nil

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -84,9 +84,9 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 		return hmr, err
 	}
 
-	if strings.Contains(string(res), "faultCode") {
-		return hmr, fmt.Errorf("ccu: %s", string(res))
-	}
+	// if strings.Contains(string(res), "faultCode") {
+	// 	return hmr, fmt.Errorf("ccu: %s", string(res))
+	// }
 
 	// correct Homematic IP Legacy API (CCU port 2010) method response encoding value
 	res = []byte(strings.Replace(string(res), "ISO-8859-1", "UTF-8", 1))
@@ -98,7 +98,7 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 		return hmr, err
 	}
 
-	return hmr, err
+	return hmr, CheckHmError(hmr)
 }
 
 // Initialze CCU methods via system.listMethods call
@@ -148,4 +148,15 @@ func (c *Connection) GridCurrentPower() (float64, error) {
 func (c *Connection) GridTotalEnergy() (float64, error) {
 	res, err := c.XmlCmd("getValue", c.MeterChannel, Param{CCUString: "IEC_ENERGY_COUNTER"})
 	return res.Value.CCUFloat, err
+}
+
+func CheckHmError(res MethodResponse) error {
+	if len(res.Fault) > 0 {
+
+		if res.Fault[0].Value.CCUInt != 0 {
+			return fmt.Errorf("ccu error: %v", res.Fault[0].Value.CCUInt)
+		}
+	}
+
+	return nil
 }

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -153,17 +153,17 @@ func ParseHmError(res MethodResponse) error {
 	var faultString string
 
 	faultCode = 0
-	for i := 0; i < len(res.Fault); i++ {
-		if res.Fault[i].Name == "faultCode" {
-			faultCode = res.Fault[i].Value.CCUInt
+	for _, f := range res.Fault {
+		if f.Name == "faultCode" {
+			faultCode = f.Value.CCUInt
 		}
-		if res.Fault[i].Name == "faultString" {
-			faultString = res.Fault[i].Value.CCUString
+		if f.Name == "faultString" {
+			faultString = f.Value.CCUString
 		}
 	}
 
 	if faultCode != 0 {
-		return fmt.Errorf("CCU error: %s (faultcode %v)", faultString, faultCode)
+		return fmt.Errorf("%s (%v)", faultString, faultCode)
 	}
 
 	return nil

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -94,7 +94,7 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 		return hmr, err
 	}
 
-	return hmr, ParseHmError(hmr)
+	return hmr, parseError(hmr)
 }
 
 // Initialze CCU methods via system.listMethods call

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -148,7 +148,7 @@ func (c *Connection) GridTotalEnergy() (float64, error) {
 
 // ParseHmError checks on Homematic CCU error codes
 // Refer to page 30 of https://homematic-ip.com/sites/default/files/downloads/HM_XmlRpc_API.pdf
-func ParseHmError(res MethodResponse) error {
+func parseError(res MethodResponse) error {
 	var faultCode int64
 	var faultString string
 

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -146,7 +146,7 @@ func (c *Connection) GridTotalEnergy() (float64, error) {
 	return res.Value.CCUFloat, err
 }
 
-// ParseHmError checks on Homematic CCU error codes
+// parseError checks on Homematic CCU error codes
 // Refer to page 30 of https://homematic-ip.com/sites/default/files/downloads/HM_XmlRpc_API.pdf
 func parseError(res MethodResponse) error {
 	var faultCode int64

--- a/meter/homematic/types.go
+++ b/meter/homematic/types.go
@@ -21,7 +21,19 @@ type MethodCall struct {
 	Params     []Param  `xml:"params>param,omitempty"`
 }
 
+type Member struct {
+	Name  string     `xml:"name,omitempty"`
+	Value FaultValue `xml:"value,omitempty"`
+}
+
+type FaultValue struct {
+	XMLName   xml.Name `xml:"value"`
+	CCUString string   `xml:",chardata"`
+	CCUInt    int64    `xml:"i4,omitempty"`
+}
+
 type MethodResponse struct {
 	XMLName xml.Name `xml:"methodResponse"`
 	Value   Param    `xml:"params>param,omitempty"`
+	Fault   []Member `xml:"fault>value>struct>member,omitempty"`
 }

--- a/meter/homematic/types_test.go
+++ b/meter/homematic/types_test.go
@@ -1,0 +1,37 @@
+package homematic
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test MethodResponse response
+func TestUnmarshalMethodResponse(t *testing.T) {
+
+	{
+		// Double test
+		var res MethodResponse
+
+		xmlstr := `<?xml version="1.0" encoding="ISO-8859-1"?><methodResponse><params><param><value><double>20698.0</double></value></param></params></methodResponse>`
+		assert.NoError(t, xml.Unmarshal([]byte(strings.Replace(string(xmlstr), "ISO-8859-1", "UTF-8", 1)), &res))
+
+		assert.Equal(t, float64(20698), res.Value.CCUFloat)
+	}
+
+	{
+		// Fault test
+		var res MethodResponse
+
+		xmlstr := `<?xml version="1.0" encoding="ISO-8859-1"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><i4>-2</i4></value></member><member><name>faultString</name><value>Invalid device</value></member></struct></value></fault></methodResponse>`
+		assert.NoError(t, xml.Unmarshal([]byte(strings.Replace(string(xmlstr), "ISO-8859-1", "UTF-8", 1)), &res))
+
+		assert.Equal(t, "faultCode", res.Fault[0].Name)
+		assert.Equal(t, int64(-2), res.Fault[0].Value.CCUInt)
+		assert.Equal(t, "faultString", res.Fault[1].Name)
+		assert.Equal(t, "Invalid device", res.Fault[1].Value.CCUString)
+	}
+
+}

--- a/meter/homematic/types_test.go
+++ b/meter/homematic/types_test.go
@@ -12,7 +12,7 @@ import (
 func TestUnmarshalMethodResponse(t *testing.T) {
 
 	{
-		// Double test
+		// Double response test
 		var res MethodResponse
 
 		xmlstr := `<?xml version="1.0" encoding="ISO-8859-1"?><methodResponse><params><param><value><double>20698.0</double></value></param></params></methodResponse>`
@@ -22,7 +22,7 @@ func TestUnmarshalMethodResponse(t *testing.T) {
 	}
 
 	{
-		// Fault test
+		// Faulty response test
 		var res MethodResponse
 
 		xmlstr := `<?xml version="1.0" encoding="ISO-8859-1"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><i4>-2</i4></value></member><member><name>faultString</name><value>Invalid device</value></member></struct></value></fault></methodResponse>`


### PR DESCRIPTION
Raise/Forward CCU fault codes and description

Refer to page 30 of https://homematic-ip.com/sites/default/files/downloads/HM_XmlRpc_API.pdf

CCU Error messages will be raised like this:
```bash
thierolm@LAPTOP-KQMMVN3H:~/git-repos/evcc$ ./evcc -c ./evcc_homematictest.yaml -l debug charger
[main  ] INFO 2023/03/15 13:25:47 evcc 0.114.1 (da3ae27d)
[main  ] INFO 2023/03/15 13:25:47 using config file: ./evcc_homematictest.yaml
[db    ] INFO 2023/03/15 13:25:47 using sqlite database: /home/thierolm/.evcc/evcc.db
Power:         Invalid device (-2)
Energy:        Invalid device (-2)
Charge status: Invalid device (-2)
Enabled:       Invalid device (-2)
Features:      []
``` 
