### PR TITLE
Create Solaranzeige-Mqtt

### DIFF
--- a/templates/definition/meter/Solaranzeige-Mqtt
+++ b/templates/definition/meter/Solaranzeige-Mqtt
@@ -1,0 +1,17 @@
+meters:
+  - name: pv
+    type: custom
+    power: # Leistung (W)
+      source: mqtt
+      topic: solaranzeige/box1/pv_leistung
+
+  - name: grid
+    type: custom
+    power: # Leistung (W)
+      source: mqtt
+      topic: solaranzeige/box1/einspeisung_bezug
+      scale: -1
+     
+mqtt:
+broker: ip:1883
+      


### PR DESCRIPTION
Anbindung Solaranzeige über Mqtt
meters:
  - name: pv
    type: custom
    power: # Leistung (W)
      source: mqtt
      topic: solaranzeige/box1/pv_leistung

  - name: grid
    type: custom
    power: # Leistung (W)
      source: mqtt
      topic: solaranzeige/box1/einspeisung_bezug
      scale: -1
     
mqtt:
broker: ip:1883
      