### PR TITLE
Versicharge: Charger State 4 = Charging

### DIFF
--- a/charger/versicharge.go
+++ b/charger/versicharge.go
@@ -104,9 +104,9 @@ func (wb *Versicharge) Status() (api.ChargeStatus, error) {
 	switch s {
 	case 1: // Available
 		return api.StatusA, nil
-	case 2, 4, 5: // Preparing, Suspended EV, Suspended EVSE
+	case 2, 5: // Preparing, Suspended EV, Suspended EVSE
 		return api.StatusB, nil
-	case 3: // Charging
+	case 3, 4: // Charging
 		return api.StatusC, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", s)


### PR DESCRIPTION
Fehlerkorrektur Versicharge:
PV Laden startet nicht, da beim Charger Status (Register 1601) der Wert 4 -> Laden bedeutet. 
Daher Änderung: Charging (C) = Register Wert 3 +4 (anstelle nur 3)

In der Doku steht "Suspende EV", ist aber nicht korrekt
