### PR TITLE
Ocpp: split connection and runtime timeouts

### DIFF
--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -44,11 +44,12 @@ type CP struct {
 	connector int
 
 	connectC, statusC chan struct{}
-	updated           time.Time
 	status            *core.StatusNotificationRequest
 
-	timeout      time.Duration
+	updated      time.Time
 	meterUpdated time.Time
+	timeout      time.Duration
+
 	measurements map[string]types.SampledValue
 
 	txnCount int // change initial value to the last known global transaction. Needs persistence
@@ -184,7 +185,7 @@ func (cp *CP) CurrentPower() (float64, error) {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 
-	if cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
+	if cp.txnId != 0 && cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
 		return 0, api.ErrNotAvailable
 	}
 
@@ -202,7 +203,7 @@ func (cp *CP) TotalEnergy() (float64, error) {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 
-	if cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
+	if cp.txnId != 0 && cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
 		return 0, api.ErrNotAvailable
 	}
 
@@ -235,7 +236,7 @@ func (cp *CP) Currents() (float64, float64, float64, error) {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 
-	if cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
+	if cp.txnId != 0 && cp.timeout > 0 && time.Since(cp.meterUpdated) > cp.timeout {
 		return 0, 0, 0, api.ErrNotAvailable
 	}
 

--- a/templates/docs/charger/elvi_0.yaml
+++ b/templates/docs/charger/elvi_0.yaml
@@ -11,4 +11,5 @@ render:
       stationid: EVB-P12354 # Die Stations-ID der Wallbox (oder des Ladepunkts) # Optional
       connector: 1 # Ladepunkt, normalerweise 1 für den ersten Anschluss. # Optional
       idtag: '04E6B78921BBA0' # Token-ID welche für die Freischaltung der Ladevorgänge an den Ladepunkt zurückgesendet wird # Optional
-      timeout: 10m # Optional
+      connecttimeout: 5m # Optional
+      timeout: 2m # Optional

--- a/templates/docs/charger/ocpp_0.yaml
+++ b/templates/docs/charger/ocpp_0.yaml
@@ -26,6 +26,7 @@ render:
       stationid: EVB-P12354 # Die Stations-ID der Wallbox (oder des Ladepunkts) # Optional
       connector: 1 # Ladepunkt, normalerweise 1 für den ersten Anschluss. # Optional
       idtag: '04E6B78921BBA0' # Token-ID welche für die Freischaltung der Ladevorgänge an den Ladepunkt zurückgesendet wird # Optional
-      timeout: 10m # Optional
+      connecttimeout: 5m # Optional
+      timeout: 2m # Optional
       getconfiguration: true # Deaktivierung kann bei einigen Chargern hilfreich sein # Optional
       bootnotification: false # Aktivierung kann bei einigen Chargern hilfreich sein # Optional

--- a/templates/docs/charger/pulsarplus_0.yaml
+++ b/templates/docs/charger/pulsarplus_0.yaml
@@ -11,4 +11,5 @@ render:
       stationid: EVB-P12354 # Die Stations-ID der Wallbox (oder des Ladepunkts) # Optional
       connector: 1 # Ladepunkt, normalerweise 1 für den ersten Anschluss. # Optional
       idtag: '04E6B78921BBA0' # Token-ID welche für die Freischaltung der Ladevorgänge an den Ladepunkt zurückgesendet wird # Optional
-      timeout: 10m # Optional
+      connecttimeout: 5m # Optional
+      timeout: 2m # Optional

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -363,8 +363,15 @@ presets:
           de: Token-ID welche für die Freischaltung der Ladevorgänge an den Ladepunkt zurückgesendet wird
         advanced: true
         example: 04E6B78921BBA0
+      - name: connecttimeout
+        description:
+          de: Zeitlimit für Registrierung des Ladepunktes
+          en: Timeout for initial connection
+        advanced: true
+        type: duration
+        default: 5m
       - name: timeout
-        default: 10m
+        default: 2m
 
   mqtt:
     params:

--- a/util/templates/includes/ocpp.tpl
+++ b/util/templates/includes/ocpp.tpl
@@ -9,5 +9,6 @@ connector: {{ .connector }}
 {{- if ne .idtag "" }}
 idtag: {{ .idtag }}
 {{- end }}
+connecttimeout: {{ .connecttimeout }}
 timeout: {{ .timeout }}
 {{- end }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/6817

This PR adds a new `connecttimeout` setting and new default timeout values (2min for regular timeout, 5min for initial connection timeout).