### PR TITLE
change goreleaser from plist to service

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,24 +97,9 @@ brews:
     license: "MIT"
     test: |
       system "#{bin}/evcc --version"
-    plist: |
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{bin}/evcc</string>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>KeepAlive</key>
-          <true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/evcc.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/evcc.log</string>
-        </dict>
-      </plist>
+    service: |
+      run [opt_bin/"evcc"]
+      working_dir HOMEBREW_PREFIX
+      keep_alive true
+      log_path var/"log/evcc.log"
+      error_log_path var/"log/evcc.log"


### PR DESCRIPTION
According to the change https://github.com/evcc-io/homebrew-tap/pull/3, this probably also needs to be changed in order to keep the release for brew working