### PR TITLE
Allow setting a timeout for easee wallbox

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -99,6 +99,15 @@ func NewEasee(user, password, charger string) (*Easee, error) {
 		current: 6, // default current
 	}
 
+	// log timeout with DEBUG level
+	c.log.DEBUG.Printf("Current API.Timeout to %v", c.API.Timeout)
+
+	// log timeout with DEBUG level
+	c.log.DEBUG.Printf("Setting Client.Timeout to %v", timeout)
+
+	// Set the HTTP Client Timeout to <timeout>
+	c.Client.Timeout = timeout
+
 	ts, err := easee.TokenSource(log, user, password)
 	if err != nil {
 		return c, err
@@ -156,7 +165,7 @@ func NewEasee(user, password, charger string) (*Easee, error) {
 
 		client.Start()
 
-		ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), c.Client.Timeout)
 		defer cancel()
 		err = <-client.WaitForState(ctx, signalr.ClientConnected)
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -79,6 +79,10 @@ func NewEaseeFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
 	return NewEasee(cc.User, cc.Password, cc.Charger, cc.Timeout)
 }
 
@@ -98,10 +102,6 @@ func NewEasee(user, password, charger string, timeout time.Duration) (*Easee, er
 		current: 6, // default current
 	}
 
-	// log timeout with DEBUG level
-	c.log.DEBUG.Printf("Setting Client.Timeout to %v", timeout)
-
-	// Set the HTTP Client Timeout to <timeout>
 	c.Client.Timeout = timeout
 
 	ts, err := easee.TokenSource(log, user, password)

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -161,7 +161,7 @@ func NewEasee(user, password, charger string, timeout time.Duration) (*Easee, er
 
 		client.Start()
 
-		ctx, cancel := context.WithTimeout(context.Background(), c.Client.Timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
 		defer cancel()
 		err = <-client.WaitForState(ctx, signalr.ClientConnected)
 	}
@@ -172,7 +172,7 @@ func NewEasee(user, password, charger string, timeout time.Duration) (*Easee, er
 
 	select {
 	case <-done:
-	case <-time.After(c.Client.Timeout):
+	case <-time.After(request.Timeout):
 		err = os.ErrDeadlineExceeded
 	}
 

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -16,6 +16,7 @@ params:
     required: true
     example: EH______
   - name: timeout
+    default: 10s
 render: |
   type: easee
   user: {{ .user }}

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -16,8 +16,6 @@ params:
     required: true
     example: EH______
   - name: timeout
-    required: false
-    example: 20
 render: |
   type: easee
   user: {{ .user }}

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -15,8 +15,12 @@ params:
   - name: charger
     required: true
     example: EH______
+  - name: timeout
+    required: false
+    example: 20
 render: |
   type: easee
   user: {{ .user }}
   password: {{ .password }}
   charger: {{ .charger }}
+  timeout: {{ .timeout }}

--- a/templates/docs/charger/easee_0.yaml
+++ b/templates/docs/charger/easee_0.yaml
@@ -10,3 +10,4 @@ render:
       user: # Benutzerkonto (bspw. E-Mail Adresse, User Id, etc.)
       password: # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen)
       charger: EH______
+      timeout: # Timeout für Requests # Optional

--- a/templates/docs/charger/easee_0.yaml
+++ b/templates/docs/charger/easee_0.yaml
@@ -10,4 +10,10 @@ render:
       user: # Benutzerkonto (bspw. E-Mail Adresse, User Id, etc.)
       password: # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen)
       charger: EH______
-      timeout: # Timeout für Requests # Optional
+    advanced: |
+      type: template
+      template: easee
+      user: # Benutzerkonto (bspw. E-Mail Adresse, User Id, etc.)
+      password: # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen)
+      charger: EH______
+      timeout: 10s # Optional


### PR DESCRIPTION
Moin!

es kommt immer mal wieder vor, dass die Easee Wallbox nicht innerhalb des Standard Timeouts von `10s` antwortet. Dann gibt es unter anderem Fehlermeldungen wie diese hier:

```
[easee ] ERROR 2022/09/21 14:11:25 Post "https://api.easee.cloud/api/chargers/EHXXXXXX/settings": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```
oder
```
[main  ] FATAL 2023/03/12 11:25:32 cannot create charger 'wallbox4': cannot create charger 'template': cannot create charger 'easee': i/o timeout
```

Um das zu umgehen, habe ich eine Möglichkeit eingebaut mit der man einen weiteren Parameter `timeout:` in die Konfiguration der Wallbox einbauen kann. Zum Beispiel so um ein Timeout von `20s` zu setzen:
```
chargers:
- type: template
  template: easee
  user: username@example.com
  password: <*******>
  timeout: 30s
  charger: EH______
  name: wallbox4
```

Ich hoffe, dass es eure Zustimmung findet.

Danke und viele Grüße

Jens

PS: Sorry für meine missglückten Versuche von letzter Woche. Hatte versucht die Workflows in meinem Fork zum Laufen zu bringen ..... Kommt nicht wieder vor ... :-)

 