### PR TITLE
Various EEBUS updates

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -252,6 +252,9 @@ func (c *EEBus) updateState() (api.ChargeStatus, error) {
 
 // Status implements the api.Charger interface
 func (c *EEBus) Status() (api.ChargeStatus, error) {
+	// check the current limits and update if necesarry
+	c.setLoadpointMinMaxLimits()
+
 	return c.updateState()
 }
 

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -98,7 +98,7 @@ func NewEEBus(ski, ip string, hasMeter, hasChargedEnergy bool) (api.Charger, err
 
 // waitForConnection wait for initial connection and returns an error on failure
 func (c *EEBus) waitForConnection() error {
-	timeout := time.After(30 * time.Second)
+	timeout := time.After(90 * time.Second)
 	for {
 		select {
 		case <-timeout:

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -227,7 +227,7 @@ func (c *EEBus) updateState() (api.ChargeStatus, error) {
 	}
 
 	if !c.isConnected() {
-		return api.StatusNone, fmt.Errorf("%s charger reported as disconnected", c.ski)
+		return api.StatusNone, fmt.Errorf("%s disconnected", c.ski)
 	}
 
 	switch currentState {

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/dylanmei/iso8601 v0.1.0
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/enbility/cemd v0.1.6
-	github.com/enbility/eebus-go v0.1.6
+	github.com/enbility/cemd v0.0.0-20230321102214-8c65610b2275
+	github.com/enbility/eebus-go v0.0.0-20230321101701-4e981696a8ac
 	github.com/fatih/structs v1.1.0
 	github.com/foogod/go-powerwall v0.2.0
 	github.com/glebarez/sqlite v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/dylanmei/iso8601 v0.1.0
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/enbility/cemd v0.0.0-20230321102214-8c65610b2275
-	github.com/enbility/eebus-go v0.0.0-20230321101701-4e981696a8ac
+	github.com/enbility/cemd v0.1.7
+	github.com/enbility/eebus-go v0.1.7
 	github.com/fatih/structs v1.1.0
 	github.com/foogod/go-powerwall v0.2.0
 	github.com/glebarez/sqlite v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -346,10 +346,10 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/enbility/cemd v0.1.6 h1:tXpFeU1XlRTeSA1JiQkoySdlwnOvO9nq77u00JRrBY0=
-github.com/enbility/cemd v0.1.6/go.mod h1:rSIgtHrPfJdGE3jS9wFe6UvVohfVnODy/8HgiY3mvHs=
-github.com/enbility/eebus-go v0.1.6 h1:T+yxpOhdfakJFd5SBon44lXkjBUyaUITS093qIpMo3Q=
-github.com/enbility/eebus-go v0.1.6/go.mod h1:BaXy+yk3pAURDqjaaPkxqJ6nlPDcEOT7ARs85U9T6YI=
+github.com/enbility/cemd v0.0.0-20230321102214-8c65610b2275 h1:2ltcpzAhPQvNaFu1AQIQEEpQ5vj9pD/CKwh+gUOk0Ec=
+github.com/enbility/cemd v0.0.0-20230321102214-8c65610b2275/go.mod h1:3wJRxyeD3wryvpFZgKk+0kU93sfepBABzOCOuAvI+7E=
+github.com/enbility/eebus-go v0.0.0-20230321101701-4e981696a8ac h1:QzNgPVZBdkidrJ8InqCrIKjqA/bbn8SO72UXRr47Moo=
+github.com/enbility/eebus-go v0.0.0-20230321101701-4e981696a8ac/go.mod h1:Ozg1eDUfSbHfQ1dWfyAUa3h8dMtgM/01eO30kHca5zk=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -346,10 +346,10 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/enbility/cemd v0.0.0-20230321102214-8c65610b2275 h1:2ltcpzAhPQvNaFu1AQIQEEpQ5vj9pD/CKwh+gUOk0Ec=
-github.com/enbility/cemd v0.0.0-20230321102214-8c65610b2275/go.mod h1:3wJRxyeD3wryvpFZgKk+0kU93sfepBABzOCOuAvI+7E=
-github.com/enbility/eebus-go v0.0.0-20230321101701-4e981696a8ac h1:QzNgPVZBdkidrJ8InqCrIKjqA/bbn8SO72UXRr47Moo=
-github.com/enbility/eebus-go v0.0.0-20230321101701-4e981696a8ac/go.mod h1:Ozg1eDUfSbHfQ1dWfyAUa3h8dMtgM/01eO30kHca5zk=
+github.com/enbility/cemd v0.1.7 h1:PuofIXdILw3rXe1JMWHW7bA2ritaGp/3wy8rBRC8png=
+github.com/enbility/cemd v0.1.7/go.mod h1:yjDruIQ9LkQI9dEvmYcp6y0QeVRPC9P8tli3Ehp8Ecs=
+github.com/enbility/eebus-go v0.1.7 h1:iPOp3oJ12cExOfS9tcBbsHRSOyr+uKGypjAjRP8SdaE=
+github.com/enbility/eebus-go v0.1.7/go.mod h1:Ozg1eDUfSbHfQ1dWfyAUa3h8dMtgM/01eO30kHca5zk=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
- Fix crash when removing non existing entities (occurs when a wallbox sends a message to remove an EV multiple times)
- Initiate connection via IP addresses before using hostname
- Update the charging limits as provided by the EVSE
- Update randomizer seed usage which fixes linter warning and still providing 1.18 compatibility
- Change log level for ev (dis)connect states
- Update timeout to 90s (from 30s) to improve handling of Elli Wallboxes EEBUS daemon crashing on first connection often
- Update an error message to be more compact