### PR TITLE
Option zum Setzen eines Timeouts für Skoda Enyaq

### DIFF
--- a/templates/definition/vehicle/skoda-enyaq.yaml
+++ b/templates/definition/vehicle/skoda-enyaq.yaml
@@ -6,7 +6,10 @@ products:
 params:
   - preset: vehicle-base
   - preset: vehicle-identify
+  - name: timeout
+    default: 10s
 render: |
   type: enyaq
   {{ include "vehicle-base" . }}
   {{ include "vehicle-identify" . }}
+  timeout: {{ .timeout }}

--- a/templates/docs/vehicle/enyaq_0.yaml
+++ b/templates/docs/vehicle/enyaq_0.yaml
@@ -28,3 +28,4 @@ render:
       maxCurrent: 16 # Definiert die maximale Stromstärke pro angeschlossener Phase mit welcher das Fahrzeug geladen werden soll # Optional
       identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/guides/vehicles/#erkennung-des-fahrzeugs-an-der-wallbox # Optional
       priority: # Priorität des Ladepunktes oder Fahrzeugs in Relation zu anderen Ladepunkten oder Fahrzeugen für die Zuweisung von PV-Energie # Optional
+      timeout: 10s # Optional

--- a/vehicle/skoda-enyaq.go
+++ b/vehicle/skoda-enyaq.go
@@ -57,6 +57,7 @@ func NewEnyaqFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	}
 
 	api := skoda.NewAPI(log, ts)
+	api.Client.Timeout = cc.Timeout
 
 	vehicle, err := ensureVehicleEx(
 		cc.VIN, api.Vehicles,


### PR DESCRIPTION
Moin!

Die Skoda API ist manchmal etwas langsam. Da reichen die standardmäßig eingestellten 10s manchmal nicht. Ich habe deshalb auch noch einen Parameter `timeout:` für den **Skoda Enyaq** implementiert. Der Timeout war in der Datei `skoda-enyaq.go` bereits vorhanden und wird mit `request.Timeout` initialisiert. Allerdings konnte man den noch nicht in der Konfiguration setzen, da er in der Template Definition noch fehlte. Die API wird zweimal mit `skoda.NewAPI()` initialisiert. Beim ersten Mal wird geprüft, ob das Fahrzeug existiert. Auch an dieser Stelle habe ich das Setzen des Timeout ergänzt. Im weiteren Verlauf ist das schon drin.

Ich hoffe, dass es euch gefällt. 

Danke und viele Grüße

Jens