### PR TITLE
daheimladen-mb: Fix Sessions & setCurrent

### DIFF
--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -177,6 +177,8 @@ func (wb *DaheimLadenMB) Status() (api.ChargeStatus, error) {
 			return api.StatusB, err
 		}
 		return api.StatusC, nil
+	case 5: // Start-UP Fail (B2)
+		return api.StatusB, nil
 	case 6: // Session Terminated by EVSE
 		return api.StatusB, nil
 	default: // Other

--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -105,6 +105,15 @@ func (wb *DaheimLadenMB) heartbeat(timeout time.Duration) {
 
 // Status implements the api.Charger interface
 func (wb *DaheimLadenMB) Status() (api.ChargeStatus, error) {
+	// work around firmware issue ignoring some current commands
+	c, err := wb.conn.ReadHoldingRegisters(dlRegCurrentLimit, 1)
+	if err == nil {
+		curr := binary.BigEndian.Uint16(c)
+		if curr > 0 && curr != wb.curr {
+			wb.setCurrent(wb.curr)
+		}
+	}
+
 	b, err := wb.conn.ReadHoldingRegisters(dlRegChargingState, 1)
 	if err != nil {
 		return api.StatusNone, err

--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -21,6 +21,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"time"
+	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -29,10 +31,9 @@ import (
 
 // DaheimLadenMB charger implementation
 type DaheimLadenMB struct {
-	log     *util.Logger
-	conn    *modbus.Connection
-	curr    uint16
-	enabled bool
+	log  *util.Logger
+	conn *modbus.Connection
+	curr uint16
 }
 
 const (
@@ -43,6 +44,8 @@ const (
 	dlRegTotalEnergy     = 28  // Uint32 RO 0.1KWh
 	dlRegEvseMaxCurrent  = 32  // Uint16 RO 0.1A
 	dlRegCableMaxCurrent = 36  // Uint16 RO 0.1A
+	dlRegStationId       = 38  // Chr[16] RO UTF16
+	dlRegCardId          = 54  // Chr[16] RO UTF16
 	dlRegChargedEnergy   = 72  // Uint16 RO 0.1kWh
 	dlRegChargingTime    = 78  // Uint32 RO 1s
 	dlRegSafeCurrent     = 87  // Uint16 WR 0.1A
@@ -81,10 +84,9 @@ func NewDaheimLadenMB(uri string, id uint8) (api.Charger, error) {
 	conn.Logger(log.TRACE)
 
 	wb := &DaheimLadenMB{
-		log:     log,
-		conn:    conn,
-		curr:    60, // assume min current
-		enabled: false,
+		log:  log,
+		conn: conn,
+		curr: 60, // assume min current
 	}
 
 	// get initial state from charger
@@ -92,7 +94,6 @@ func NewDaheimLadenMB(uri string, id uint8) (api.Charger, error) {
 	if err != nil {
 		return nil, fmt.Errorf("current limit: %w", err)
 	}
-	wb.enabled = curr > 0
 	if curr > wb.curr {
 		wb.curr = curr
 	}
@@ -133,30 +134,21 @@ func (wb *DaheimLadenMB) getCurrent() (uint16, error) {
 	return binary.BigEndian.Uint16(b), nil
 }
 
-// debug and work around potential firmware issue ignoring currentlimit register update
-func (wb *DaheimLadenMB) enforceState() error {
-	curr, err := wb.getCurrent()
-	if err == nil {
-		if wb.enabled {
-			if curr != wb.curr {
-				wb.log.DEBUG.Printf("current sync missmatch: actual value: %d, setpoint: %d\n", curr, wb.curr)
-				return wb.setCurrent(wb.curr)
-			}
-		} else {
-			if curr > 0 {
-				wb.log.DEBUG.Printf("enabled sync missmatch: actual value: %t, setpoint: %t\n", curr > 0, wb.enabled)
-				return wb.setCurrent(0)
-			}
-		}
+// utf16BytesToString converts UTF-16 encoded bytes, in big or little endian byte order,
+// to a UTF-8 encoded string.
+func utf16BytesToString(b []byte, o binary.ByteOrder) string {
+	utf := make([]uint16, (len(b)+(2-1))/2)
+	for i := 0; i+(2-1) < len(b); i += 2 {
+		utf[i/2] = o.Uint16(b[i:])
 	}
-
-	return err
+	if len(b)/2 < len(utf) {
+		utf[len(utf)-1] = utf8.RuneError
+	}
+	return string(utf16.Decode(utf))
 }
 
 // Status implements the api.Charger interface
 func (wb *DaheimLadenMB) Status() (api.ChargeStatus, error) {
-	_ = wb.enforceState() // debug
-
 	b, err := wb.conn.ReadHoldingRegisters(dlRegChargingState, 1)
 	if err != nil {
 		return api.StatusNone, err
@@ -199,7 +191,6 @@ func (wb *DaheimLadenMB) Enable(enable bool) error {
 	if enable {
 		current = wb.curr
 	}
-	wb.enabled = enable
 
 	return wb.setCurrent(current)
 }
@@ -268,6 +259,17 @@ func (wb *DaheimLadenMB) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(dlRegVoltages)
 }
 
+var _ api.Identifier = (*DaheimLadenMB)(nil)
+
+// Identify implements the api.Identifier interface
+func (wb *DaheimLadenMB) Identify() (string, error) {
+	b, err := wb.conn.ReadHoldingRegisters(dlRegCardId, 16)
+	if err != nil {
+		return "", err
+	}
+	return utf16BytesToString(b, binary.BigEndian), nil
+}
+
 var _ api.Diagnosis = (*DaheimLadenMB)(nil)
 
 // Diagnose implements the api.Diagnosis interface
@@ -283,6 +285,12 @@ func (wb *DaheimLadenMB) Diagnose() {
 	}
 	if b, err := wb.conn.ReadHoldingRegisters(dlRegCableMaxCurrent, 1); err == nil {
 		fmt.Printf("\tCable Max. Current:\t%.1fA\n", float64(binary.BigEndian.Uint16(b)/10))
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(dlRegStationId, 16); err == nil {
+		fmt.Printf("\tStation ID:\t%s\n", utf16BytesToString(b, binary.BigEndian))
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(dlRegCardId, 16); err == nil {
+		fmt.Printf("\tCard ID:\t%s\n", utf16BytesToString(b, binary.BigEndian))
 	}
 	if b, err := wb.conn.ReadHoldingRegisters(dlRegSafeCurrent, 1); err == nil {
 		fmt.Printf("\tSafe Current:\t%.1fA\n", float64(binary.BigEndian.Uint16(b)/10))

--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -110,7 +110,7 @@ func (wb *DaheimLadenMB) Status() (api.ChargeStatus, error) {
 	if err == nil {
 		curr := binary.BigEndian.Uint16(c)
 		if curr > 0 && curr != wb.curr {
-			wb.setCurrent(wb.curr)
+			_ = wb.setCurrent(wb.curr)
 		}
 	}
 

--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -94,7 +94,7 @@ func NewDaheimLadenMB(uri string, id uint8) (api.Charger, error) {
 	if err != nil {
 		return nil, fmt.Errorf("current limit: %w", err)
 	}
-	if curr > wb.curr {
+	if curr > 0 {
 		wb.curr = curr
 	}
 


### PR DESCRIPTION
Should fix issues discussed in #6963 and already mentioned in #5836

- Remove workaround of overlayed session start/stop
- Reads initial state from charger
- Supports RFID & App/OCPP (need manual session authorization first) and Plug&Charge-Mode (autostart of session) now