### PR TITLE
chore: simplify templates

### DIFF
--- a/cmd/configure/configure.tpl
+++ b/cmd/configure/configure.tpl
@@ -12,7 +12,7 @@ levels:
 plant: {{ .Plant }}
 
 interval: 10s # control cycle interval
-{{- if ne (len .SponsorToken) 0 }}
+{{- if .SponsorToken }}
 
 sponsortoken: {{ .SponsorToken }}
 
@@ -20,28 +20,28 @@ sponsortoken: {{ .SponsorToken }}
 # see https://github.com/evcc-io/evcc/discussions/4554
 telemetry: {{ .Telemetry }}
 {{- end}}
-{{- if ne (len .Meters) 0 }}
+{{- if .Meters }}
 
 meters:
 {{-   range .Meters }}
 - {{ .Yaml | indent 2 | trim }}
 {{-   end }}
 {{- end }}
-{{- if ne (len .Chargers) 0 }}
+{{- if .Chargers }}
 
 chargers:
 {{-   range .Chargers }}
 - {{ .Yaml | indent 2 | trim }}
 {{-   end }}
 {{- end }}
-{{- if ne (len .Vehicles) 0 }}
+{{- if .Vehicles }}
 
 vehicles:
 {{-   range .Vehicles }}
 - {{ .Yaml | indent 2 | trim }}
 {{-   end }}
 {{- end }}
-{{- if ne (len .Chargers) 0 }}
+{{- if .Chargers }}
 
 loadpoints:
 {{-   range .Loadpoints }}
@@ -67,24 +67,24 @@ site:
 {{- if .Site.Grid }}
     grid: {{ .Site.Grid }}
 {{- end }}
-{{- if len .Site.PVs }}
+{{- if .Site.PVs }}
     pv:
 {{-   range .Site.PVs }}
     - {{ . }}
 {{-   end }}
 {{- end }}
-{{- if len .Site.Batteries }}
+{{- if .Site.Batteries }}
     battery:
 {{-   range .Site.Batteries }}
     - {{ . }}
 {{-   end }}
 {{- end }}
-{{- if ne (len .Hems) 0 }}
+{{- if .Hems }}
 
 hems:
 {{ .Hems | indent 2 }}
 {{- end }}
-{{- if ne (len .EEBUS) 0 }}
+{{- if .EEBUS }}
 
 eebus:
 {{ .EEBUS | indent 2 }}

--- a/cmd/configure/configure.tpl
+++ b/cmd/configure/configure.tpl
@@ -23,42 +23,42 @@ telemetry: {{ .Telemetry }}
 {{- if .Meters }}
 
 meters:
-{{-   range .Meters }}
+{{- range .Meters }}
 - {{ .Yaml | indent 2 | trim }}
-{{-   end }}
+{{- end }}
 {{- end }}
 {{- if .Chargers }}
 
 chargers:
-{{-   range .Chargers }}
+{{- range .Chargers }}
 - {{ .Yaml | indent 2 | trim }}
-{{-   end }}
+{{- end }}
 {{- end }}
 {{- if .Vehicles }}
 
 vehicles:
-{{-   range .Vehicles }}
+{{- range .Vehicles }}
 - {{ .Yaml | indent 2 | trim }}
-{{-   end }}
+{{- end }}
 {{- end }}
 {{- if .Chargers }}
 
 loadpoints:
-{{-   range .Loadpoints }}
+{{- range .Loadpoints }}
 - title: {{ .Title }}
   charger: {{ .Charger }}
-{{-     if .ChargeMeter }}
+{{- if .ChargeMeter }}
   meter: {{ .ChargeMeter }}
-{{-     end }}
-{{-     if .Vehicle }}
+{{- end }}
+{{- if .Vehicle }}
   vehicle: {{ .Vehicle }}
-{{-     end }}
+{{- end }}
   mode: {{ .Mode }}
   phases: {{ .Phases }}
   mincurrent: {{ .MinCurrent }}
   maxcurrent: {{ .MaxCurrent }}
   resetOnDisconnect: {{ .ResetOnDisconnect }}
-{{-   end }}
+{{- end }}
 {{- end }}
 
 site:
@@ -69,15 +69,15 @@ site:
 {{- end }}
 {{- if .Site.PVs }}
     pv:
-{{-   range .Site.PVs }}
+    {{- range .Site.PVs }}
     - {{ . }}
-{{-   end }}
+    {{- end }}
 {{- end }}
 {{- if .Site.Batteries }}
     battery:
-{{-   range .Site.Batteries }}
+    {{- range .Site.Batteries }}
     - {{ . }}
-{{-   end }}
+    {{- end }}
 {{- end }}
 {{- if .Hems }}
 

--- a/templates/docs/meter/alpha-ess-smile_0.yaml
+++ b/templates/docs/meter/alpha-ess-smile_0.yaml
@@ -49,7 +49,6 @@ render:
       id: 85
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 85
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/e3dc_0.yaml
+++ b/templates/docs/meter/e3dc_0.yaml
@@ -14,7 +14,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -28,7 +27,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/fronius-gen24_0.yaml
+++ b/templates/docs/meter/fronius-gen24_0.yaml
@@ -15,7 +15,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -29,7 +28,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/fronius-gen24_1.yaml
+++ b/templates/docs/meter/fronius-gen24_1.yaml
@@ -15,7 +15,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -29,7 +28,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/fronius-solarapi-v1_0.yaml
+++ b/templates/docs/meter/fronius-solarapi-v1_0.yaml
@@ -13,7 +13,6 @@ render:
       template: fronius-solarapi-v1
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -25,7 +24,6 @@ render:
       template: fronius-solarapi-v1
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/goodwe-hybrid_0.yaml
+++ b/templates/docs/meter/goodwe-hybrid_0.yaml
@@ -49,7 +49,6 @@ render:
       id: 247
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 247
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/growatt-hybrid-tlxh_0.yaml
+++ b/templates/docs/meter/growatt-hybrid-tlxh_0.yaml
@@ -49,7 +49,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/growatt-hybrid_0.yaml
+++ b/templates/docs/meter/growatt-hybrid_0.yaml
@@ -49,7 +49,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/huawei-dongle-powersensor_0.yaml
+++ b/templates/docs/meter/huawei-dongle-powersensor_0.yaml
@@ -25,7 +25,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       timeout: 15s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -49,7 +48,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       timeout: 15s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/huawei-sun2000-rs485_0.yaml
+++ b/templates/docs/meter/huawei-sun2000-rs485_0.yaml
@@ -50,7 +50,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       storageunit: 1 # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -99,7 +98,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       storageunit: 1 # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/kostal-piko_0.yaml
+++ b/templates/docs/meter/kostal-piko_0.yaml
@@ -13,7 +13,6 @@ render:
       template: kostal-piko
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -25,7 +24,6 @@ render:
       template: kostal-piko
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/kostal-plenticore_0.yaml
+++ b/templates/docs/meter/kostal-plenticore_0.yaml
@@ -23,7 +23,6 @@ render:
       id: 71
       host: 192.0.2.2 # Hostname
       port: 1502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/lg-ess-home-8-10_0.yaml
+++ b/templates/docs/meter/lg-ess-home-8-10_0.yaml
@@ -15,7 +15,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       registration: DE200... # Registriernummer des LG ESS HOME Wechselrichters.
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -29,7 +28,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       registration: DE200... # Registriernummer des LG ESS HOME Wechselrichters.
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/openems_0.yaml
+++ b/templates/docs/meter/openems_0.yaml
@@ -13,7 +13,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       password: user # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen) # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -26,7 +25,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       password: user # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen) # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/openems_1.yaml
+++ b/templates/docs/meter/openems_1.yaml
@@ -13,7 +13,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       password: user # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen) # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -26,7 +25,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       password: user # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen) # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/rct-power_0.yaml
+++ b/templates/docs/meter/rct-power_0.yaml
@@ -13,7 +13,6 @@ render:
       template: rct-power
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -25,7 +24,6 @@ render:
       template: rct-power
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/senec-home_0.yaml
+++ b/templates/docs/meter/senec-home_0.yaml
@@ -13,7 +13,6 @@ render:
       template: senec-home
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -25,7 +24,6 @@ render:
       template: senec-home
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sma-data-manager_0.yaml
+++ b/templates/docs/meter/sma-data-manager_0.yaml
@@ -17,7 +17,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -31,7 +30,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sma-hybrid_0.yaml
+++ b/templates/docs/meter/sma-hybrid_0.yaml
@@ -23,7 +23,6 @@ render:
       id: 3
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sma-inverter_0.yaml
+++ b/templates/docs/meter/sma-inverter_0.yaml
@@ -15,7 +15,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       password: # Passwort für Benutzergruppe Benutzer # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sofarsolar-g3_0.yaml
+++ b/templates/docs/meter/sofarsolar-g3_0.yaml
@@ -51,7 +51,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -101,7 +100,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sofarsolar-g3_1.yaml
+++ b/templates/docs/meter/sofarsolar-g3_1.yaml
@@ -51,7 +51,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -101,7 +100,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sofarsolar-g3_2.yaml
+++ b/templates/docs/meter/sofarsolar-g3_2.yaml
@@ -51,7 +51,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -101,7 +100,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sofarsolar-g3_3.yaml
+++ b/templates/docs/meter/sofarsolar-g3_3.yaml
@@ -51,7 +51,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -101,7 +100,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       delay: 1s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sofarsolar_0.yaml
+++ b/templates/docs/meter/sofarsolar_0.yaml
@@ -49,7 +49,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sofarsolar_1.yaml
+++ b/templates/docs/meter/sofarsolar_1.yaml
@@ -49,7 +49,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solaredge-hybrid_0.yaml
+++ b/templates/docs/meter/solaredge-hybrid_0.yaml
@@ -52,7 +52,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 1502 # Port
       timeout: 10s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -101,7 +100,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 1502 # Port
       timeout: 10s # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solarmax-maxstorage_0.yaml
+++ b/templates/docs/meter/solarmax-maxstorage_0.yaml
@@ -23,7 +23,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -45,7 +44,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solarwatt-myreserve-matrix_0.yaml
+++ b/templates/docs/meter/solarwatt-myreserve-matrix_0.yaml
@@ -15,7 +15,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 8080 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -29,7 +28,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 8080 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solarwatt_0.yaml
+++ b/templates/docs/meter/solarwatt_0.yaml
@@ -13,7 +13,6 @@ render:
       template: solarwatt
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -25,7 +24,6 @@ render:
       template: solarwatt
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solarwatt_1.yaml
+++ b/templates/docs/meter/solarwatt_1.yaml
@@ -13,7 +13,6 @@ render:
       template: solarwatt
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -25,7 +24,6 @@ render:
       template: solarwatt
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solax-hybrid-cloud_0.yaml
+++ b/templates/docs/meter/solax-hybrid-cloud_0.yaml
@@ -20,7 +20,6 @@ render:
       usage: grid
       tokenid: # Auf https://www.solaxcloud.com/#/api den Wert von "ObtaintokenID" hier eintragen.
       serial: # Auf https://www.solaxcloud.com/#/inverter die Registriernummer hier eintragen.
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -34,7 +33,6 @@ render:
       usage: pv
       tokenid: # Auf https://www.solaxcloud.com/#/api den Wert von "ObtaintokenID" hier eintragen.
       serial: # Auf https://www.solaxcloud.com/#/inverter die Registriernummer hier eintragen.
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solax_0.yaml
+++ b/templates/docs/meter/solax_0.yaml
@@ -49,7 +49,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/solax_1.yaml
+++ b/templates/docs/meter/solax_1.yaml
@@ -49,7 +49,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -97,7 +96,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sonnenbatterie_0.yaml
+++ b/templates/docs/meter/sonnenbatterie_0.yaml
@@ -15,7 +15,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 8080 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -29,7 +28,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 8080 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sungrow-hybrid_0.yaml
+++ b/templates/docs/meter/sungrow-hybrid_0.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -99,7 +98,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/sunspec-hybrid_0.yaml
+++ b/templates/docs/meter/sunspec-hybrid_0.yaml
@@ -24,7 +24,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       integer: # Einstellung Float/Integer im Wechselrichter überprüfen # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -47,7 +46,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       integer: # Einstellung Float/Integer im Wechselrichter überprüfen # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/varta_0.yaml
+++ b/templates/docs/meter/varta_0.yaml
@@ -15,7 +15,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -29,7 +28,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/templates/docs/meter/victron-energy_0.yaml
+++ b/templates/docs/meter/victron-energy_0.yaml
@@ -15,7 +15,6 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: pv
     default: |
       type: template
@@ -29,7 +28,6 @@ render:
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       port: 502 # Port # Optional
-      capacity: 50 # Akkukapazität in kWh # Optional
   - usage: battery
     default: |
       type: template

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -17,10 +17,11 @@
 
 {{- define "default" }}
   {{- include "header" . }}
+  {{- $usage := "" }}{{- if hasKey . "Usage" }}{{ $usage = .Usage }}{{ end }}
   {{- range $.Params }}
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 -}}
-  {{- else if ne .IsAdvanced true }}
+  {{- else if and (not .IsAdvanced) (or (or (not $usage) (not .Usages)) (and $usage .Usages (has $usage .Usages))) }}
   {{- template "param" . }}
   {{- end }}
   {{- end }}
@@ -28,10 +29,11 @@
 
 {{- define "advanced" }}
   {{- include "header" . }}
+  {{- $usage := "" }}{{- if hasKey . "Usage" }}{{ $usage = .Usage }}{{ end }}
   {{- range $.Params }}
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 -}}
-  {{- else }}
+  {{- else if or (or (not $usage) (not .Usages)) (and $usage .Usages (has $usage .Usages)) }}
   {{- template "param" . }}
   {{- end -}}
   {{- end -}}

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -1,11 +1,26 @@
-{{- define "default" }}
+{{- define "param" }}
+  {{ .Name }}:
+  {{- if .Value }} {{ .Value }} {{- end }}
+  {{- if .Values }}
+  {{ range .Values }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}
+>{{ printf "%+v" . }}
+  {{/* {{- if ne .IsRequired true }} # Optional{{ end }} */}}
+{{- end }}
+
+{{- define "header" }}
   type: template
   template: {{ $.Template }}
   {{- if hasKey . "Usage" }}
   usage: {{ .Usage }}
   {{- end }}
-  {{- if .Name }}
-  {{- end }}
+{{- end }}
+
+{{- define "default" }}
+  {{- include "header" . }}
   {{- range $.Params }}
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 -}}
@@ -23,11 +38,7 @@
 {{- end }}
 
 {{- define "advanced" }}
-  type: template
-  template: {{ $.Template }}
-  {{- if hasKey . "Usage" }}
-  usage: {{ .Usage }}
-  {{- end }}
+  {{- include "header" . }}
   {{- range $.Params }}
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 -}}

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -1,3 +1,49 @@
+{{- define "default" }}
+  type: template
+  template: {{ $.Template }}
+  {{- if hasKey . "Usage" }}
+  usage: {{ .Usage }}
+  {{- end }}
+  {{- if .Name }}
+  {{- end }}
+  {{- range $.Params }}
+  {{- if eq .Name "modbus" }}
+  {{- $.Modbus | indent 2 -}}
+  {{- else if ne .IsAdvanced true }}
+  {{ .Name }}:
+  {{- if .Value }} {{ .Value }} {{- end }}
+  {{- if .Values }}
+  {{ range .Values }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
+  {{- end -}}
+  {{- end -}}
+{{- end }}
+
+{{- define "advanced" }}
+  type: template
+  template: {{ $.Template }}
+  {{- if hasKey . "Usage" }}
+  usage: {{ .Usage }}
+  {{- end }}
+  {{- range $.Params }}
+  {{- if eq .Name "modbus" }}
+  {{- $.Modbus | indent 2 -}}
+  {{- else }}
+  {{ .Name }}:
+  {{- if .Value }} {{ .Value }} {{- end }}
+  {{- if .Values }}
+  {{ range .Values }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
+  {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 product:
 {{- if .ProductBrand }}
   brand: {{ .ProductBrand }}
@@ -19,82 +65,23 @@ description: |
 {{ .RequirementDescription | indent 2 }}
 {{- end }}
 render:
-{{- if .Usages -}}{{ range .Usages }}
-  - usage: {{ . }}
+{{- if .Usages -}}
+{{- $content := . }}
+{{- range $usage := .Usages }}
+{{- $_ := set $content "Usage" $usage }}
+  - usage: {{ $usage }}
     default: |
-      type: template
-      template: {{ $.Template }}
-      usage: {{ . }}
-      {{- range $.Params }}
-      {{- if eq .Name "modbus" -}}
-{{ $.Modbus | indent 6 -}}
-      {{- else if ne .IsAdvanced true }}
-      {{ .Name }}:
-      {{- if len .Value }} {{ .Value }} {{- end }}
-      {{- if ne (len .Values) 0 }}
-      {{ range .Values }}
-        - {{ . }}
-      {{ end }}
-      {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if eq .IsRequired false }} # Optional{{ end }}
-      {{- end -}}
-      {{- end -}}
-{{- if $.AdvancedParams }}
+	{{- include "default" $content | indent 4 }}
+    {{- if $.AdvancedParams }}
     advanced: |
-      type: template
-      template: {{ $.Template }}
-      usage: {{ . }}
-      {{- range $.Params }}
-      {{- if eq .Name "modbus" -}}
-{{ $.Modbus | indent 6 -}}
-      {{- else }}
-      {{ .Name }}:
-      {{- if len .Value }} {{ .Value }} {{- end }}
-      {{- if ne (len .Values) 0 }}
-      {{ range .Values }}
-        - {{ . }}
-      {{- end }}
-      {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
-      {{- end -}}
-      {{- end -}}
-{{ end }}
+	{{- include "advanced" $content | indent 4 }}
+    {{- end }}
 {{- end }}
 {{- else }}
   - default: |
-      type: template
-      template: {{ $.Template }}
-      {{- range $.Params }}
-      {{- if eq .Name "modbus" -}}
-{{ $.Modbus | indent 6 -}}
-      {{- else if ne .IsAdvanced true }}
-      {{ .Name }}:
-      {{- if len .Value }} {{ .Value }} {{- end }}
-      {{- if ne (len .Values) 0 }}
-      {{ range .Values }}
-        - {{ . }}
-      {{- end }}
-      {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
-      {{- end -}}
-      {{- end -}}
-{{- if $.AdvancedParams }}
+    {{- include "default" . | indent 4 }}
+    {{- if $.AdvancedParams }}
     advanced: |
-      type: template
-      template: {{ $.Template }}
-      {{- range $.Params }}
-      {{- if eq .Name "modbus" -}}
-{{ $.Modbus | indent 6 -}}
-      {{- else }}
-      {{ .Name }}:
-      {{- if len .Value }} {{ .Value }} {{- end }}
-      {{- if ne (len .Values) 0 }}
-      {{ range .Values }}
-        - {{ . }}
-      {{- end }}
-      {{- end }}
-      {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
-      {{- end -}}
-      {{- end -}}
-{{- end }}
+    {{- include "advanced" . | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -1,14 +1,10 @@
 {{- define "param" }}
   {{ .Name }}:
   {{- if .Value }} {{ .Value }} {{- end }}
-  {{- if .Values }}
-  {{ range .Values }}
+  {{- range .Values }}
   - {{ . }}
   {{- end }}
-  {{- end }}
-  {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}
->{{ printf "%+v" . }}
-  {{/* {{- if ne .IsRequired true }} # Optional{{ end }} */}}
+  {{- if .Help.DE }} # {{ .Help.DE }}{{- end }}{{- if not .IsRequired }} # Optional{{- end }}
 {{- end }}
 
 {{- define "header" }}
@@ -25,16 +21,9 @@
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 -}}
   {{- else if ne .IsAdvanced true }}
-  {{ .Name }}:
-  {{- if .Value }} {{ .Value }} {{- end }}
-  {{- if .Values }}
-  {{ range .Values }}
-  - {{ . }}
+  {{- template "param" . }}
   {{- end }}
   {{- end }}
-  {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
-  {{- end -}}
-  {{- end -}}
 {{- end }}
 
 {{- define "advanced" }}
@@ -43,14 +32,7 @@
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 -}}
   {{- else }}
-  {{ .Name }}:
-  {{- if .Value }} {{ .Value }} {{- end }}
-  {{- if .Values }}
-  {{ range .Values }}
-  - {{ . }}
-  {{- end }}
-  {{- end }}
-  {{- if .Help.DE }} # {{ .Help.DE }}{{ end }}{{ if ne .IsRequired true }} # Optional{{ end }}
+  {{- template "param" . }}
   {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/util/templates/includes/eebus-meter.tpl
+++ b/util/templates/includes/eebus-meter.tpl
@@ -1,6 +1,6 @@
 {{ define "eebus-meter" }}
 type: eebus
 ski: {{ .ski }}
-{{ if ne .ip "" }}ip: {{ .ip }}{{ end }}
+{{ if .ip }}ip: {{ .ip }}{{ end }}
 meter: true
 {{- end }}

--- a/util/templates/includes/eebus-no-meter.tpl
+++ b/util/templates/includes/eebus-no-meter.tpl
@@ -1,5 +1,5 @@
 {{ define "eebus-no-meter" }}
 type: eebus
 ski: {{ .ski }}
-{{ if ne .ip "" }}ip: {{ .ip }}{{ end }}
+{{ if .ip }}ip: {{ .ip }}{{ end }}
 {{- end}}

--- a/util/templates/includes/ocpp.tpl
+++ b/util/templates/includes/ocpp.tpl
@@ -1,12 +1,12 @@
 {{ define "ocpp" }}
 type: ocpp
-{{- if ne .stationid "" }}
+{{- if .stationid }}
 stationid: {{ .stationid }}
 {{- end }}
 {{- if ne .connector "1" }}
 connector: {{ .connector }}
 {{- end }}
-{{- if ne .idtag "" }}
+{{- if .idtag }}
 idtag: {{ .idtag }}
 {{- end }}
 connecttimeout: {{ .connecttimeout }}

--- a/util/templates/includes/switchsocket.tpl
+++ b/util/templates/includes/switchsocket.tpl
@@ -1,5 +1,5 @@
 {{ define "switchsocket" }}
 standbypower: {{ .standbypower }}
 {{ if eq .integrateddevice "true" }}features: ["integrateddevice"]{{ end }}
-{{ if ne .icon "" }}icon: {{ .icon }}{{ end }}
+{{ if .icon }}icon: {{ .icon }}{{ end }}
 {{ end -}}

--- a/util/templates/includes/vehicle-base.tpl
+++ b/util/templates/includes/vehicle-base.tpl
@@ -1,22 +1,22 @@
 {{ define "vehicle-base" }}
-{{- if ne .title "" }}
+{{- if .title }}
 title: {{ .title }}
 {{- end }}
-{{- if ne .icon "" }}
+{{- if .icon }}
 icon: {{ .icon }}
 {{- end }}
 user: {{ .user }}
 password: {{ .password }}
-{{- if ne .capacity "" }}
+{{- if .capacity }}
 capacity: {{ .capacity }}
 {{- end }}
-{{- if ne .vin "" }}
+{{- if .vin }}
 vin: {{ .vin }}
 {{- end }}
-{{- if ne .phases "" }}
+{{- if .phases }}
 phases: {{ .phases }}
 {{- end }}
-{{- if ne .cache "" }}
+{{- if .cache }}
 cache: {{ .cache }}
 {{- end }}
 {{- end }}

--- a/util/templates/includes/vehicle-identify.tpl
+++ b/util/templates/includes/vehicle-identify.tpl
@@ -1,26 +1,26 @@
 {{ define "vehicle-identify" }}
-{{- if or (ne .mode "") (ne .minSoc "") (ne .targetSoc "") (ne .minCurrent "") (ne .maxCurrent "") (ne .priority "") }}
+{{- if or .mode .minSoc .targetSoc .minCurrent .maxCurrent .priority }}
 onIdentify:
-{{- if (ne .mode "") }}
+{{- if .mode }}
   mode: {{ .mode }}
 {{- end }}
-{{- if (ne .minSoc "") }}
+{{- if .minSoc }}
   minSoc: {{ .minSoc }}
 {{- end }}
-{{- if (ne .targetSoc "") }}
+{{- if .targetSoc }}
   targetSoc: {{ .targetSoc }}
 {{- end }}
-{{- if (ne .minCurrent "") }}
+{{- if .minCurrent }}
   minCurrent: {{ .minCurrent }}
 {{- end }}
-{{- if (ne .maxCurrent "") }}
+{{- if .maxCurrent }}
   maxCurrent: {{ .maxCurrent }}
 {{- end }}
-{{- if (ne .priority "") }}
+{{- if .priority }}
   priority: {{ .priority }}
 {{- end }}
 {{- end }}
-{{- if ne (len .identifiers) 0 }}
+{{- if len .identifiers }}
 identifiers:
 {{-   range .identifiers }}
 - {{ . }}


### PR DESCRIPTION
PR simplifies rending docs by reducing amount of duplicated template code.
It also removed parameters bounded by `usages` if `usage` doesn't match.