### PR TITLE
Update loadpoint.go

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -935,6 +935,9 @@ func (lp *Loadpoint) scalePhases(phases int) error {
 			return err
 		}
 
+		// reset measured phases
+		lp.resetMeasuredPhases()
+
 		// switch phases
 		if err := cp.Phases1p3p(phases); err != nil {
 			return fmt.Errorf("switch phases: %w", err)


### PR DESCRIPTION
Reset measured phases before switching phases to avoid error messages