### PR TITLE
Tesla: add wakeup api

### DIFF
--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -205,6 +205,13 @@ func (v *Tesla) MaxCurrent(current int64) error {
 	return v.vehicle.SetChargingAmps(int(current))
 }
 
+var _ api.Resurrector = (*Tesla)(nil)
+
+func (v *Tesla) WakeUp() error {
+	_, err := v.vehicle.Wakeup()
+	return err
+}
+
 var _ api.VehicleChargeController = (*Tesla)(nil)
 
 // StartCharge implements the api.VehicleChargeController interface


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/discussions/6422#discussioncomment-5520265.

@premultiply ergänzend: brauchen wir bzgl.

```go
// Wake-up checks
if lp.enabled && lp.status == api.StatusB &&
	int(lp.vehicleSoc) < lp.Soc.target && lp.wakeUpTimer.Expired() {
	lp.wakeUpVehicle()
}
```

noch eine bessere Logik? Was passiert wenn kein `targetSoc` gesetzt ist oder keiner vom Fahrzeug verfügbar?