### PR TITLE
Reset vehicle cache when charging stops for last soc update

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evcc-io/evcc/core/planner"
 	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/core/wrapper"
+	"github.com/evcc-io/evcc/provider"
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/util"
 
@@ -415,6 +416,7 @@ func (lp *Loadpoint) evChargeStopHandler() {
 	}
 
 	// soc update reset
+	provider.ResetCached()
 	lp.socUpdated = time.Time{}
 
 	// reset pv enable/disable timer


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/7032#issuecomment-1497599839

Note: this will reset all vehicles; but that seems acceptable at this stage.