### PR TITLE
Remove didChargeOnLastSocUpdate

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1412,7 +1412,7 @@ func (lp *Loadpoint) stopWakeUpTimer() {
 	lp.wakeUpTimer.Stop()
 }
 
-// pvScalePhases switches phases if necessary and returns if switch occurred
+// guardGracePeriodElapsed checks if last guard update is within guard grace period
 func (lp *Loadpoint) guardGracePeriodElapsed() bool {
 	return time.Since(lp.guardUpdated) > guardGracePeriod
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -123,15 +123,15 @@ type Loadpoint struct {
 	MaxCurrent    float64       // Max allowed current. Physically ensured by the charger
 	GuardDuration time.Duration // charger enable/disable minimum holding time
 
-	enabled                  bool      // Charger enabled state
-	phases                   int       // Charger enabled phases, guarded by mutex
-	measuredPhases           int       // Charger physically measured phases
-	chargeCurrent            float64   // Charger current limit
-	guardUpdated             time.Time // Charger enabled/disabled timestamp
-	socUpdated               time.Time // Soc updated timestamp (poll: connected)
-	vehicleDetect            time.Time // Vehicle connected timestamp
-	vehicleDetectTicker      *clock.Ticker
-	vehicleIdentifier        string
+	enabled             bool      // Charger enabled state
+	phases              int       // Charger enabled phases, guarded by mutex
+	measuredPhases      int       // Charger physically measured phases
+	chargeCurrent       float64   // Charger current limit
+	guardUpdated        time.Time // Charger enabled/disabled timestamp
+	socUpdated          time.Time // Soc updated timestamp (poll: connected)
+	vehicleDetect       time.Time // Vehicle connected timestamp
+	vehicleDetectTicker *clock.Ticker
+	vehicleIdentifier   string
 
 	charger          api.Charger
 	chargeTimer      api.ChargeTimer

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -129,7 +129,6 @@ type Loadpoint struct {
 	chargeCurrent            float64   // Charger current limit
 	guardUpdated             time.Time // Charger enabled/disabled timestamp
 	socUpdated               time.Time // Soc updated timestamp (poll: connected)
-	didChargeOnLastSocUpdate bool      // There was a charge process when Soc was updated last
 	vehicleDetect            time.Time // Vehicle connected timestamp
 	vehicleDetectTicker      *clock.Ticker
 	vehicleIdentifier        string

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -680,7 +680,7 @@ func TestSocPoll(t *testing.T) {
 		{pollCharging, api.StatusC, -1, true},
 		{pollCharging, api.StatusC, 0, true},
 		{pollCharging, api.StatusC, tNoRefresh, true}, // cached by vehicle
-		{pollCharging, api.StatusC, tRefresh, true},
+		{pollCharging, api.StatusB, -1, true}, // fetch if car stopped charging
 		{pollCharging, api.StatusB, 0, false},        // no more polling
 		{pollCharging, api.StatusB, tRefresh, false}, // no more polling
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -680,9 +680,9 @@ func TestSocPoll(t *testing.T) {
 		{pollCharging, api.StatusC, -1, true},
 		{pollCharging, api.StatusC, 0, true},
 		{pollCharging, api.StatusC, tNoRefresh, true}, // cached by vehicle
-		{pollCharging, api.StatusB, -1, true}, // fetch if car stopped charging
-		{pollCharging, api.StatusB, 0, false},        // no more polling
-		{pollCharging, api.StatusB, tRefresh, false}, // no more polling
+		{pollCharging, api.StatusB, -1, true},         // fetch if car stopped charging
+		{pollCharging, api.StatusB, 0, false},         // no more polling
+		{pollCharging, api.StatusB, tRefresh, false},  // no more polling
 
 		// pollConnected
 		{pollConnected, api.StatusA, -1, false},

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -681,8 +681,8 @@ func TestSocPoll(t *testing.T) {
 		{pollCharging, api.StatusC, 0, true},
 		{pollCharging, api.StatusC, tNoRefresh, true}, // cached by vehicle
 		{pollCharging, api.StatusC, tRefresh, true},
-		{pollCharging, api.StatusB, 0, false},         // no more polling
-		{pollCharging, api.StatusB, tRefresh, false},  // no more polling
+		{pollCharging, api.StatusB, 0, false},        // no more polling
+		{pollCharging, api.StatusB, tRefresh, false}, // no more polling
 
 		// pollConnected
 		{pollConnected, api.StatusA, -1, false},

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -680,10 +680,9 @@ func TestSocPoll(t *testing.T) {
 		{pollCharging, api.StatusC, -1, true},
 		{pollCharging, api.StatusC, 0, true},
 		{pollCharging, api.StatusC, tNoRefresh, true}, // cached by vehicle
-		{pollCharging, api.StatusC, tRefresh, true},   // will set lp.didChargeOnLastSocUpdate
-		{pollCharging, api.StatusB, 0, false},         // last update must wait for interval
-		{pollCharging, api.StatusB, tRefresh, true},   // update once if connected and was charging
-		{pollCharging, api.StatusB, tRefresh, false},  // but only once
+		{pollCharging, api.StatusC, tRefresh, true},
+		{pollCharging, api.StatusB, 0, false},         // no more polling
+		{pollCharging, api.StatusB, tRefresh, false},  // no more polling
 
 		// pollConnected
 		{pollConnected, api.StatusA, -1, false},

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -330,7 +330,6 @@ func (lp *Loadpoint) vehicleClimatePollAllowed() bool {
 func (lp *Loadpoint) vehicleSocPollAllowed() bool {
 	// always update soc when charging
 	if lp.charging() {
-		lp.didChargeOnLastSocUpdate = true
 		return true
 	}
 
@@ -342,15 +341,12 @@ func (lp *Loadpoint) vehicleSocPollAllowed() bool {
 	remaining := lp.Soc.Poll.Interval - lp.clock.Since(lp.socUpdated)
 
 	honourUpdateInterval := lp.Soc.Poll.Mode == pollAlways ||
-		lp.connected() && (lp.Soc.Poll.Mode == pollConnected ||
-			// for mode charging allow one last soc update if did charge previously to not rely on soc estimator too much
-			lp.Soc.Poll.Mode == pollCharging && lp.didChargeOnLastSocUpdate)
+		lp.connected() && lp.Soc.Poll.Mode == pollConnected
 
 	if honourUpdateInterval {
 		if remaining > 0 {
 			lp.log.DEBUG.Printf("next soc poll remaining time: %v", remaining.Truncate(time.Second))
 		} else {
-			lp.didChargeOnLastSocUpdate = false
 			return true
 		}
 	}


### PR DESCRIPTION
didChargeOnLastSocUpdate is obsolete and can be safely removed thanks to https://github.com/evcc-io/evcc/pull/7238
