### PR TITLE
Improve Tibber Pulse Reconnect

### DIFF
--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -87,7 +87,7 @@ func NewTibberFromConfig(other map[string]interface{}) (api.Meter, error) {
 		WithConnectionParams(map[string]any{
 			"token": cc.Token,
 		}).
-		WithRetryTimeout(timeout).
+		WithRetryTimeout(0).
 		WithLog(t.log.TRACE.Println)
 
 	// run the client


### PR DESCRIPTION
Now we don't stop trying to reconnect to Tibber if connection is lost. The default of go-graphql-client (and our configured value) was to abort trying after 1min.

fixes #7314