### PR TITLE
Shelly 3EM Gen2: TotalEnergy Unit Fix

### DIFF
--- a/meter/shelly/energymeter.go
+++ b/meter/shelly/energymeter.go
@@ -31,7 +31,7 @@ func (sh *EnergyMeter) TotalEnergy() (float64, error) {
 		return 0, err
 	}
 
-	return res.TotalEnergy, nil
+	return res.TotalEnergy / 1000, nil
 }
 
 var _ api.PhaseCurrents = (*EnergyMeter)(nil)


### PR DESCRIPTION
Fixes #7263

Shelly 3EM Gen2 devices are providing total active energy on all phases in Wh!

Refer to https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/EMData#status