### PR TITLE
Updated target charge factors which are used for greater 80%

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -30,7 +30,7 @@ func (lp *Loadpoint) planRequiredDuration(maxPower float64) time.Duration {
 	if energy, ok := lp.remainingChargeEnergy(); ok {
 		requiredDuration = time.Duration(energy * 1e3 / maxPower * float64(time.Hour))
 
-		// Multiply with e.g. 90% charge efficiency which is normaly done internaly in the Estimator
+		// Consider charge efficiency manually because we calulate outside the estimator
 		requiredDuration = time.Duration(float64(requiredDuration) / soc.ChargeEfficiency)
 	} else if lp.socEstimator != nil {
 		// TODO vehicle soc limit

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -24,37 +24,37 @@ func (lp *Loadpoint) setPlanActive(active bool) {
 
 // planRequiredDuration is the estimated total charging duration
 func (lp *Loadpoint) planRequiredDuration(maxPower float64) time.Duration {
-	var requiredDuration time.Duration
-
 	if energy, ok := lp.remainingChargeEnergy(); ok {
-		requiredDuration = time.Duration(energy * 1e3 / maxPower * float64(time.Hour))
-	} else if lp.socEstimator != nil {
-		// TODO vehicle soc limit
-		targetSoc := lp.Soc.target
-		if targetSoc == 0 {
-			targetSoc = 100
-		}
-
-		requiredDuration = lp.socEstimator.RemainingChargeDuration(targetSoc, maxPower)
-		if requiredDuration <= 0 {
-			return 0
-		}
-
-		// anticipate lower charge rates at end of charging curve
-		var additionalDuration time.Duration
-
-		if targetSoc > 80 && maxPower > 15000 {
-			additionalDuration = time.Duration(float64(targetSoc-80) / (float64(targetSoc) - lp.vehicleSoc) * float64(requiredDuration))
-			lp.log.DEBUG.Printf("add additional charging time %v for soc > 80%%", additionalDuration.Round(time.Minute))
-		} else if targetSoc > 90 && maxPower > 4000 {
-			additionalDuration = time.Duration(float64(targetSoc-90) / (float64(targetSoc) - lp.vehicleSoc) * float64(requiredDuration))
-			lp.log.DEBUG.Printf("add additional charging time %v for soc > 90%%", additionalDuration.Round(time.Minute))
-		}
-
-		requiredDuration += additionalDuration
+		return time.Duration(energy * 1e3 / maxPower * float64(time.Hour))
 	}
 
-	return requiredDuration
+	if lp.socEstimator == nil {
+		return 0
+	}
+
+	// TODO vehicle soc limit
+	targetSoc := lp.Soc.target
+	if targetSoc == 0 {
+		targetSoc = 100
+	}
+
+	requiredDuration := lp.socEstimator.RemainingChargeDuration(targetSoc, maxPower)
+	if requiredDuration <= 0 {
+		return 0
+	}
+
+	// anticipate lower charge rates at end of charging curve
+	var additionalDuration time.Duration
+
+	if targetSoc > 80 && maxPower > 15000 {
+		additionalDuration = time.Duration(float64(targetSoc-80) / (float64(targetSoc) - lp.vehicleSoc) * float64(requiredDuration))
+		lp.log.DEBUG.Printf("add additional charging time %v for soc > 80%%", additionalDuration.Round(time.Minute))
+	} else if targetSoc > 90 && maxPower > 4000 {
+		additionalDuration = time.Duration(float64(targetSoc-90) / (float64(targetSoc) - lp.vehicleSoc) * float64(requiredDuration))
+		lp.log.DEBUG.Printf("add additional charging time %v for soc > 90%%", additionalDuration.Round(time.Minute))
+	}
+
+	return requiredDuration + additionalDuration
 }
 
 func (lp *Loadpoint) GetPlannerUnit() string {


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/7379

- moved charge efficiency line into if with own calculation, because the socEstimator use it internaly already.
- Set Factor to one for both usecases, because it double the timing for this period which seems to be ok.
-  See excelsheet in https://github.com/evcc-io/evcc/issues/7379