### PR TITLE
Changed smallGapDuration from 30 to 60 minutes

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	smallSlotDuration = 10 * time.Minute // small planner slot duration we might ignore
-	smallGapDuration  = 30 * time.Minute // small gap duration between planner slots we might ignore
+	smallGapDuration  = 60 * time.Minute // small gap duration between planner slots we might ignore
 )
 
 // setPlanActive updates plan active flag


### PR DESCRIPTION
The reason is that we plan now everything in 60min slots. And with this change we only pause and skip complete slots. That will reduce too much pause events, if the estimator does not fit well to the current configured car.