### PR TITLE
Use smallGapDuration also for "requiredDuration < " where 30 minutes where hardcoded

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -143,7 +143,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 			// don't stop an already running slot if goal was not met
 			lp.log.DEBUG.Println("continuing until end of slot")
 			return true
-		case requiredDuration < 30*time.Minute:
+		case requiredDuration < smallGapDuration:
 			lp.log.DEBUG.Printf("continuing for remaining %v", requiredDuration.Round(time.Second))
 			return true
 		case lp.clock.Until(planStart) < smallGapDuration:


### PR DESCRIPTION
Sorry that I did not see that in the first step.

That means we continue if we have less then one slot of duration in front of us. So no hardcoded timings anymore in the switch statement.