### PR TITLE
Session: don't use meter totals for overriding session energy

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1274,7 +1274,7 @@ func (lp *Loadpoint) publishChargeProgress() {
 	if f, err := lp.chargeRater.ChargedEnergy(); err == nil {
 		// workaround for Go-E resetting during disconnect, see
 		// https://github.com/evcc-io/evcc/issues/5092
-		if f > 0 {
+		if f > lp.chargedAtStartup {
 			lp.setChargedEnergy(1e3 * (f - lp.chargedAtStartup)) // convert to Wh
 		}
 	} else {

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -58,12 +58,7 @@ func (lp *Loadpoint) stopSession() {
 	lp.session.Finished = lp.clock.Now()
 	lp.session.MeterStop = lp.chargeMeterTotal()
 
-	chargedEnergy := lp.getChargedEnergy() / 1e3
-	if delta := lp.session.MeterStop - lp.session.MeterStart; delta < chargedEnergy && lp.session.MeterStart*lp.session.MeterStop > 0 {
-		chargedEnergy = delta
-	}
-
-	if chargedEnergy > lp.session.ChargedEnergy {
+	if chargedEnergy := lp.getChargedEnergy() / 1e3; chargedEnergy > lp.session.ChargedEnergy {
 		lp.session.ChargedEnergy = chargedEnergy
 	}
 

--- a/core/loadpoint_session_test.go
+++ b/core/loadpoint_session_test.go
@@ -70,7 +70,7 @@ func TestSession(t *testing.T) {
 	s, err := db.Sessions()
 	assert.NoError(t, err)
 	assert.Len(t, s, 1)
-	t.Log(s)
+	t.Logf("session: %+v", s)
 
 	// stop charging - 2nd leg
 	clock.Add(time.Hour)
@@ -79,11 +79,10 @@ func TestSession(t *testing.T) {
 
 	lp.stopSession()
 	assert.NotNil(t, lp.session)
-	assert.Equal(t, 3.0-1.0, lp.session.ChargedEnergy) // expect actual meter energy delta
 	assert.Equal(t, clock.Now(), lp.session.Finished)
 
 	s, err = db.Sessions()
 	assert.NoError(t, err)
 	assert.Len(t, s, 1)
-	t.Log(s)
+	t.Logf("session: %+v", s)
 }


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/7214