### PR TITLE
Add ignoreerror plugin

### DIFF
--- a/provider/ignoreerror.go
+++ b/provider/ignoreerror.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+
+	"github.com/evcc-io/evcc/util"
+)
+
+type ignoreerrorProvider struct {
+	ignoreerror    func() (float64, error)
+	log            *util.Logger
+	config         Config
+	errorstoignore []*regexp.Regexp
+}
+
+func init() {
+	registry.Add("ignoreerror", NewIgnoreerrorFromConfig)
+}
+
+// NewConstFromConfig creates const provider
+func NewIgnoreerrorFromConfig(other map[string]interface{}) (IntProvider, error) {
+	var cc struct {
+		Ignoreerror    Config
+		Errorstoignore []string
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	o := &ignoreerrorProvider{
+		config: cc.Ignoreerror,
+		log:    util.NewLogger("ignoreerror"),
+	}
+
+	for idx, errorstoignore := range cc.Errorstoignore {
+		r, err := regexp.Compile(errorstoignore)
+		if err != nil {
+			return nil, fmt.Errorf("errorstoignore[%d]: %w", idx, err)
+		}
+		o.errorstoignore = append(o.errorstoignore, r)
+	}
+
+	err := tryCreate(o)
+	if err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+func tryCreate(o *ignoreerrorProvider) error {
+	f, err := NewFloatGetterFromConfig(o.config)
+	if err != nil {
+		ignoreError := false
+		errortype := fmt.Sprintf("%s", reflect.TypeOf(err))
+		for idx, errorstoignore := range o.errorstoignore {
+			if errorstoignore.MatchString(errortype) {
+				ignoreError = true
+				o.log.DEBUG.Println(fmt.Sprintf("error match[%d]", idx), errortype, err)
+				break
+			}
+		}
+		if ignoreError {
+			o.log.WARN.Println("Ignore error:", errortype, err)
+		} else {
+			return fmt.Errorf("ignoreerror: %w", err)
+		}
+	} else {
+		o.ignoreerror = f
+	}
+	return nil
+}
+
+func (o *ignoreerrorProvider) IntGetter() func() (int64, error) {
+	return func() (int64, error) {
+		f, err := o.floatGetter()
+		return int64(f), err
+	}
+}
+
+func (o *ignoreerrorProvider) FloatGetter() func() (float64, error) {
+	return o.floatGetter
+}
+
+func (o *ignoreerrorProvider) floatGetter() (float64, error) {
+	if o.ignoreerror == nil {
+		tryCreate(o)
+	}
+	if o.ignoreerror != nil {
+		return o.ignoreerror()
+	}
+	o.log.WARN.Println("Source not yet created, use 0")
+	return 0, nil
+}

--- a/provider/ignoreerror.go
+++ b/provider/ignoreerror.go
@@ -55,7 +55,7 @@ func tryCreate(o *ignoreerrorProvider) error {
 	f, err := NewFloatGetterFromConfig(o.config)
 	if err != nil {
 		ignoreError := false
-		errortype := fmt.Sprintf("%s", reflect.TypeOf(err))
+		errortype := reflect.TypeOf(err).String()
 		for idx, errorstoignore := range o.errorstoignore {
 			if errorstoignore.MatchString(errortype) {
 				ignoreError = true
@@ -87,7 +87,7 @@ func (o *ignoreerrorProvider) FloatGetter() func() (float64, error) {
 
 func (o *ignoreerrorProvider) floatGetter() (float64, error) {
 	if o.ignoreerror == nil {
-		tryCreate(o)
+		_ = tryCreate(o)
 	}
 	if o.ignoreerror != nil {
 		return o.ignoreerror()


### PR DESCRIPTION
Ich habe genauso wie in https://github.com/evcc-io/evcc/discussions/6463 beschrieben, dass Problem das mein PV Wechselrichter sich nachts in einem Stomsparmodus wechselt und nicht im Netzwerk erreichbar ist. Da ich zusätzlich die Elli Wallbox habe, dessen Firmware es nicht mag neu gestartet zu werden, wenn ein Auto verbunden ist, ist es manchmal schwierig ein Zeitpunkt für Updates und andere neu starts zu finden-

n gibt es die Idee https://github.com/evcc-io/evcc/issues/4989#issuecomment-1446175305 das Problem mit einem `ignoreerror` plugin zu lösen. Ich habe mal mein Glück versucht und habe das schon ein paar Tage eingesetzt. 

Ist das eine mögliche Lösung für das Problem oder gibt es bessere?

Benutzen lässt sich das z.B. so:

```yaml
meters:
  - name: pv
    type: custom
    power:
      source: ignoreerror
      errorstoignore:
        - "net.*"
      ignoreerror:
        source: modbus
        model: sunspec
        uri: pv.fritz.box:502
        rtu: false
        id: 1
```