### PR TITLE
fix: wattpilot memory leak on broken connectivity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/libp2p/zeroconf/v2 v2.2.0
 	github.com/lorenzodonini/ocpp-go v0.16.1-0.20230416102136-782920b66533
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40
-	github.com/mabunixda/wattpilot v1.3.0
+	github.com/mabunixda/wattpilot v1.3.1
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mergermarket/go-pkcs7 v0.0.0-20170926155232-153b18ea13c9
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -750,8 +750,8 @@ github.com/lorenzodonini/ocpp-go v0.16.1-0.20230416102136-782920b66533/go.mod h1
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
-github.com/mabunixda/wattpilot v1.3.0 h1:GiK9b4xWwUgvwCwhk41tkYj3nHOrsDo0/UOLPDmERZQ=
-github.com/mabunixda/wattpilot v1.3.0/go.mod h1:h+EsQdE8PtdgoICydM7/2ki/Das1b/TAQWMXJTnKZLk=
+github.com/mabunixda/wattpilot v1.3.1 h1:SlPjgxtBzVGfqXRGy+88BvqTpqhVcVQY0nr2b7UI7k8=
+github.com/mabunixda/wattpilot v1.3.1/go.mod h1:h+EsQdE8PtdgoICydM7/2ki/Das1b/TAQWMXJTnKZLk=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=


### PR DESCRIPTION
fixxes #7299 with [wattpilot v1.3.1](https://github.com/mabunixda/wattpilot/releases/tag/v1.3.1)
