### PR TITLE
tesla: workaround for north america single phase

### DIFF
--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"math"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/loadpoint"
@@ -16,6 +17,7 @@ import (
 // Twc3 is an api.Vehicle implementation for Twc3 cars
 type Twc3 struct {
 	*request.Helper
+	log     *util.Logger
 	lp      loadpoint.API
 	uri     string
 	vitalsG func() (Vitals, error)
@@ -74,6 +76,7 @@ func NewTwc3FromConfig(other map[string]interface{}) (api.Charger, error) {
 	c := &Twc3{
 		Helper: request.NewHelper(log),
 		uri:    util.DefaultScheme(strings.TrimSuffix(cc.URI, "/"), "http"),
+		log:    log,
 	}
 
 	c.vitalsG = provider.Cached(func() (Vitals, error) {
@@ -161,12 +164,30 @@ func (v *Twc3) ChargingTime() (time.Duration, error) {
 	return time.Duration(res.SessionS) * time.Second, err
 }
 
+// Use workaround if voltageC_v is approximately half of grid_v
+//   "voltageA_v": 241.5,
+//   "voltageB_v": 241.5,
+//   "voltageC_v": 118.7,
+// Default state is ~2V on all phases unless charging
+func IsSplitPhase(v *Twc3, res Vitals) (bool) {
+	if math.Abs(res.VoltageCV - res.GridV / 2) < 25 {
+		v.log.DEBUG.Println("Using split-phase workaround")
+		return true
+	} else {
+		return false
+	}
+}
+
 var _ api.PhaseCurrents = (*Twc3)(nil)
 
 // Currents implements the api.PhaseCurrents interface
 func (v *Twc3) Currents() (float64, float64, float64, error) {
 	res, err := v.vitalsG()
-	return res.CurrentAA, res.CurrentBA, res.CurrentCA, err
+	if IsSplitPhase(v, res) {
+		return res.CurrentAA + res.CurrentBA, 0, 0, err
+	} else {
+		return res.CurrentAA, res.CurrentBA, res.CurrentCA, err
+	}
 }
 
 var _ api.Meter = (*Twc3)(nil)
@@ -175,7 +196,11 @@ var _ api.Meter = (*Twc3)(nil)
 func (v *Twc3) CurrentPower() (float64, error) {
 	res, err := v.vitalsG()
 	if res.ContactorClosed {
-		return (res.CurrentAA + res.CurrentBA + res.CurrentCA) * res.GridV, err
+	        if IsSplitPhase(v, res) {
+			return (res.CurrentAA * res.VoltageAV) + (res.CurrentBA * res.VoltageBV), err
+		} else {
+			return (res.CurrentAA * res.VoltageAV) + (res.CurrentBA * res.VoltageBV) + (res.CurrentCA * res.VoltageCV), err
+		}
 	}
 	return 0, err
 }
@@ -185,7 +210,11 @@ var _ api.PhaseVoltages = (*Twc3)(nil)
 // Voltages implements the api.PhaseVoltages interface
 func (v *Twc3) Voltages() (float64, float64, float64, error) {
 	res, err := v.vitalsG()
-	return res.VoltageAV, res.VoltageBV, res.VoltageCV, err
+	if IsSplitPhase(v, res) {
+		return (res.VoltageAV + res.VoltageBV) / 2, 0, 0, err
+	} else {
+		return res.VoltageAV, res.VoltageBV, res.VoltageCV, err
+	}
 }
 
 var _ loadpoint.Controller = (*Twc3)(nil)


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/7599

Ignore incorrect values in TWC3 vitals API when `singlephase: true` is set in configuration, use only the A phase and total vehicle current and return values as a single phase charger. Hopefully my translation to the German is close enough.