### PR TITLE
Update sungrow-inverter.yaml PV Power register

### DIFF
--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -38,7 +38,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 5030 # Total Active Power
+      address: 5008 # Total apparent power
       type: input
       decode: uint32s
   energy:


### PR DESCRIPTION
Change from `Total Active Power` to `Total Apparent Power`. In the case of parallel inverters the power produced by the other inverters gets measured or calculated into `Total Active Power` on feedin and the numbers don't add up anymore.