### PR TITLE
Homematic: Reduce API requests to relax CCU duty cycle

### DIFF
--- a/charger/homematic.go
+++ b/charger/homematic.go
@@ -1,6 +1,8 @@
 package charger
 
 import (
+	"time"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/homematic"
 	"github.com/evcc-io/evcc/util"
@@ -18,7 +20,7 @@ func init() {
 
 // NewCCUFromConfig creates a Homematic charger from generic config
 func NewCCUFromConfig(other map[string]interface{}) (api.Charger, error) {
-	var cc struct {
+	cc := struct {
 		embed         `mapstructure:",squash"`
 		URI           string
 		Device        string
@@ -27,18 +29,21 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Charger, error) {
 		User          string
 		Password      string
 		StandbyPower  float64
+		Cache         time.Duration
+	}{
+		Cache: time.Second,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewCCU(cc.embed, cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.StandbyPower)
+	return NewCCU(cc.embed, cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.StandbyPower, cc.Cache)
 }
 
 // NewCCU creates a new connection with standbypower for charger
-func NewCCU(embed embed, uri, deviceid, meterid, switchid, user, password string, standbypower float64) (*CCU, error) {
-	conn, err := homematic.NewConnection(uri, deviceid, meterid, switchid, user, password)
+func NewCCU(embed embed, uri, deviceid, meterid, switchid, user, password string, standbypower float64, cache time.Duration) (*CCU, error) {
+	conn, err := homematic.NewConnection(uri, deviceid, meterid, switchid, user, password, cache)
 
 	c := &CCU{
 		conn: conn,

--- a/meter/homematic.go
+++ b/meter/homematic.go
@@ -1,6 +1,8 @@
 package meter
 
 import (
+	"time"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/homematic"
 	"github.com/evcc-io/evcc/util"
@@ -18,7 +20,7 @@ func init() {
 
 // NewCCUFromConfig creates a Homematic meter from generic config
 func NewCCUFromConfig(other map[string]interface{}) (api.Meter, error) {
-	var cc struct {
+	cc := struct {
 		URI           string
 		Device        string
 		MeterChannel  string
@@ -26,18 +28,21 @@ func NewCCUFromConfig(other map[string]interface{}) (api.Meter, error) {
 		User          string
 		Password      string
 		Usage         string
+		Cache         time.Duration
+	}{
+		Cache: time.Second,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewCCU(cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.Usage)
+	return NewCCU(cc.URI, cc.Device, cc.MeterChannel, cc.SwitchChannel, cc.User, cc.Password, cc.Usage, cc.Cache)
 }
 
 // NewCCU creates a new connection with usage for meter
-func NewCCU(uri, deviceid, meterid, switchid, user, password, usage string) (*CCU, error) {
-	conn, err := homematic.NewConnection(uri, deviceid, meterid, switchid, user, password)
+func NewCCU(uri, deviceid, meterid, switchid, user, password, usage string, cache time.Duration) (*CCU, error) {
+	conn, err := homematic.NewConnection(uri, deviceid, meterid, switchid, user, password, cache)
 
 	m := &CCU{
 		conn:  conn,

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -58,17 +58,11 @@ func NewConnection(uri, device, meterchannel, switchchannel, user, password stri
 	}
 
 	conn.switchCache = provider.ResettableCached(func() (MethodResponse, error) {
-		var res MethodResponse
-		var err error
-		res, err = conn.XmlCmd("getParamset", conn.SwitchChannel, Param{CCUString: "VALUES"})
-		return res, err
+		return conn.XmlCmd("getParamset", conn.SwitchChannel, Param{CCUString: "VALUES"})
 	}, conn.Cache)
 
 	conn.meterCache = provider.ResettableCached(func() (MethodResponse, error) {
-		var res MethodResponse
-		var err error
-		res, err = conn.XmlCmd("getParamset", conn.MeterChannel, Param{CCUString: "VALUES"})
-		return res, err
+		return conn.XmlCmd("getParamset", conn.MeterChannel, Param{CCUString: "VALUES"})
 	}, conn.Cache)
 
 	return conn, nil

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -28,10 +28,8 @@ type Connection struct {
 	log *util.Logger
 	*request.Helper
 	*Settings
-	meterCache    provider.Cacheable[MethodResponse]
-	meterUpdated  time.Time
-	switchCache   provider.Cacheable[MethodResponse]
-	switchUpdated time.Time
+	meterCache  provider.Cacheable[MethodResponse]
+	switchCache provider.Cacheable[MethodResponse]
 }
 
 // NewConnection creates a new Homematic device connection.
@@ -77,10 +75,10 @@ func NewConnection(uri, device, meterchannel, switchchannel, user, password stri
 }
 
 // reset caches
-func (c *Connection) reset() {
-	c.switchCache.Reset()
-	c.meterCache.Reset()
-}
+// func (c *Connection) reset() {
+// 	c.switchCache.Reset()
+// 	c.meterCache.Reset()
+// }
 
 // Enable sets the homematic HMIP-PSM switchchannel state to true=on/false=off
 func (c *Connection) Enable(enable bool) error {

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -106,7 +106,7 @@ func (c *Connection) Init() error {
 // Enabled reads the homematic HMIP-PSM switchchannel state true=on/false=off
 func (c *Connection) Enabled() (bool, error) {
 	res, err := c.XmlCmd("getValue", c.SwitchChannel, Param{CCUString: "STATE"})
-	return res.Value.CCUBool == "1", err
+	return res.CCUBool == "1", err
 }
 
 // Enable sets the homematic HMIP-PSM switchchannel state to true=on/false=off
@@ -119,31 +119,31 @@ func (c *Connection) Enable(enable bool) error {
 // CurrentPower reads the homematic HMIP-PSM meterchannel power in W
 func (c *Connection) CurrentPower() (float64, error) {
 	res, err := c.XmlCmd("getValue", c.MeterChannel, Param{CCUString: "POWER"})
-	return res.Value.CCUFloat, err
+	return res.CCUFloat, err
 }
 
 // TotalEnergy reads the homematic HMIP-PSM meterchannel energy in Wh
 func (c *Connection) TotalEnergy() (float64, error) {
 	res, err := c.XmlCmd("getValue", c.MeterChannel, Param{CCUString: "ENERGY_COUNTER"})
-	return res.Value.CCUFloat / 1000, err
+	return res.CCUFloat / 1000, err
 }
 
 // Currents reads the homematic HMIP-PSM meterchannel L1 current in A
 func (c *Connection) Currents() (float64, float64, float64, error) {
 	res, err := c.XmlCmd("getValue", c.MeterChannel, Param{CCUString: "CURRENT"})
-	return res.Value.CCUFloat / 1000, 0, 0, err
+	return res.CCUFloat / 1000, 0, 0, err
 }
 
 // GridCurrentPower reads the homematic HM-ES-TX-WM grid meterchannel power in W
 func (c *Connection) GridCurrentPower() (float64, error) {
 	res, err := c.XmlCmd("getValue", c.MeterChannel, Param{CCUString: "IEC_POWER"})
-	return res.Value.CCUFloat, err
+	return res.CCUFloat, err
 }
 
 // GridTotalEnergy reads the homematic HM-ES-TX-WM grid meterchannel energy in Wh
 func (c *Connection) GridTotalEnergy() (float64, error) {
 	res, err := c.XmlCmd("getValue", c.MeterChannel, Param{CCUString: "IEC_ENERGY_COUNTER"})
-	return res.Value.CCUFloat, err
+	return res.CCUFloat, err
 }
 
 // parseError checks on Homematic CCU error codes

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -80,37 +80,37 @@ func (c *Connection) Enable(enable bool) error {
 
 // Enabled reads the homematic HMIP-PSM switchchannel state true=on/false=off
 func (c *Connection) Enabled() (bool, error) {
-	_, ccuBool, err := c.getParamsetValue(c.SwitchChannel, "STATE")
+	_, ccuBool, err := c.getParamsetValue("STATE")
 	return ccuBool, err
 }
 
 // CurrentPower reads the homematic HMIP-PSM meterchannel power in W
 func (c *Connection) CurrentPower() (float64, error) {
-	ccuFloat, _, err := c.getParamsetValue(c.MeterChannel, "POWER")
+	ccuFloat, _, err := c.getParamsetValue("POWER")
 	return ccuFloat, err
 }
 
 // TotalEnergy reads the homematic HMIP-PSM meterchannel energy in Wh
 func (c *Connection) TotalEnergy() (float64, error) {
-	ccuFloat, _, err := c.getParamsetValue(c.MeterChannel, "ENERGY_COUNTER")
+	ccuFloat, _, err := c.getParamsetValue("ENERGY_COUNTER")
 	return ccuFloat / 1000, err
 }
 
 // Currents reads the homematic HMIP-PSM meterchannel L1 current in A
 func (c *Connection) Currents() (float64, float64, float64, error) {
-	ccuFloat, _, err := c.getParamsetValue(c.MeterChannel, "CURRENT")
+	ccuFloat, _, err := c.getParamsetValue("CURRENT")
 	return ccuFloat / 1000, 0, 0, err
 }
 
 // GridCurrentPower reads the homematic HM-ES-TX-WM grid meterchannel power in W
 func (c *Connection) GridCurrentPower() (float64, error) {
-	ccuFloat, _, err := c.getParamsetValue(c.MeterChannel, "IEC_POWER")
+	ccuFloat, _, err := c.getParamsetValue("IEC_POWER")
 	return ccuFloat, err
 }
 
 // GridTotalEnergy reads the homematic HM-ES-TX-WM grid meterchannel energy in Wh
 func (c *Connection) GridTotalEnergy() (float64, error) {
-	ccuFloat, _, err := c.getParamsetValue(c.MeterChannel, "IEC_ENERGY_COUNTER")
+	ccuFloat, _, err := c.getParamsetValue("IEC_ENERGY_COUNTER")
 	return ccuFloat, err
 }
 
@@ -154,7 +154,7 @@ func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResp
 }
 
 // getParamsetValue reads all parameter values of a device channel
-func (c *Connection) getParamsetValue(channel, valueName string) (float64, bool, error) {
+func (c *Connection) getParamsetValue(valueName string) (float64, bool, error) {
 	var res MethodResponse
 	var err error
 
@@ -163,7 +163,7 @@ func (c *Connection) getParamsetValue(channel, valueName string) (float64, bool,
 		if time.Since(c.switchUpdated) <= cacheTimeout {
 			res = c.switchCache
 		} else {
-			res, err = c.XmlCmd("getParamset", channel, Param{CCUString: "VALUES"})
+			res, err = c.XmlCmd("getParamset", c.SwitchChannel, Param{CCUString: "VALUES"})
 			c.switchCache = res
 			// update switchUpdated timestamp
 			c.switchUpdated = time.Now()
@@ -173,7 +173,7 @@ func (c *Connection) getParamsetValue(channel, valueName string) (float64, bool,
 		if time.Since(c.meterUpdated) <= cacheTimeout {
 			res = c.meterCache
 		} else {
-			res, err = c.XmlCmd("getParamset", channel, Param{CCUString: "VALUES"})
+			res, err = c.XmlCmd("getParamset", c.MeterChannel, Param{CCUString: "VALUES"})
 			c.meterCache = res
 			// update meterUpdated timestamp
 			c.meterUpdated = time.Now()

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -121,7 +121,7 @@ func (c *Connection) GridCurrentPower() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return getFloatValue(res, "IEC_POWER") / 1e3, nil
+	return getFloatValue(res, "IEC_POWER"), nil
 }
 
 // GridTotalEnergy reads the homematic HM-ES-TX-WM grid meterchannel energy in Wh
@@ -130,7 +130,7 @@ func (c *Connection) GridTotalEnergy() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return getFloatValue(res, "IEC_ENERGY_COUNTER") / 1e3, nil
+	return getFloatValue(res, "IEC_ENERGY_COUNTER"), nil
 }
 
 func (c *Connection) XmlCmd(method, channel string, values ...Param) (MethodResponse, error) {

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -124,7 +124,7 @@ func (c *Connection) GridCurrentPower() (float64, error) {
 	return getFloatValue(res, "IEC_POWER"), nil
 }
 
-// GridTotalEnergy reads the homematic HM-ES-TX-WM grid meterchannel energy in Wh
+// GridTotalEnergy reads the homematic HM-ES-TX-WM grid meterchannel energy in kWh
 func (c *Connection) GridTotalEnergy() (float64, error) {
 	res, err := c.meterCache.Get()
 	if err != nil {

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -58,17 +58,7 @@ func NewConnection(uri, device, meterchannel, switchchannel, user, password stri
 		conn.Client.Transport = transport.BasicAuth(user, password, conn.Client.Transport)
 	}
 
-	if err := conn.Init(); err != nil {
-		return conn, err
-	}
-
 	return conn, nil
-}
-
-// Initialze CCU methods via system.listMethods call
-func (c *Connection) Init() error {
-	_, err := c.XmlCmd("system.listMethods", c.SwitchChannel)
-	return err
 }
 
 // Enable sets the homematic HMIP-PSM switchchannel state to true=on/false=off

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -75,13 +75,14 @@ func NewConnection(uri, device, meterchannel, switchchannel, user, password stri
 }
 
 // reset caches
-// func (c *Connection) reset() {
-// 	c.switchCache.Reset()
-// 	c.meterCache.Reset()
-// }
+func (c *Connection) reset() {
+	c.switchCache.Reset()
+	c.meterCache.Reset()
+}
 
 // Enable sets the homematic HMIP-PSM switchchannel state to true=on/false=off
 func (c *Connection) Enable(enable bool) error {
+	c.reset()
 	onoff := map[bool]string{true: "1", false: "0"}
 	_, err := c.XmlCmd("setValue", c.SwitchChannel, Param{CCUString: "STATE"}, Param{CCUBool: onoff[enable]})
 	return err

--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -68,18 +68,13 @@ func NewConnection(uri, device, meterchannel, switchchannel, user, password stri
 	return conn, nil
 }
 
-// reset caches
-func (c *Connection) reset() {
-	c.switchCache.Reset()
-	c.meterCache.Reset()
-}
-
 // Enable sets the homematic HMIP-PSM switchchannel state to true=on/false=off
 func (c *Connection) Enable(enable bool) error {
 	onoff := map[bool]string{true: "1", false: "0"}
 	_, err := c.XmlCmd("setValue", c.SwitchChannel, Param{CCUString: "STATE"}, Param{CCUBool: onoff[enable]})
 	if err == nil {
-		c.reset()
+		c.switchCache.Reset()
+		c.meterCache.Reset()
 	}
 	return err
 }

--- a/meter/homematic/types.go
+++ b/meter/homematic/types.go
@@ -26,10 +26,13 @@ type Member struct {
 }
 
 type MethodResponse struct {
-	XMLName xml.Name `xml:"methodResponse"`
-	Value   Param    `xml:"params>param>xxxx,omitempty"`
-	Member  []Member `xml:"params>param>value>struct>member,omitempty"`
-	Fault   []Member `xml:"fault>value>struct>member,omitempty"`
+	XMLName   xml.Name `xml:"methodResponse"`
+	CCUBool   string   `xml:"params>param>value>boolean,omitempty"`
+	CCUFloat  float64  `xml:"params>param>value>double,omitempty"`
+	CCUInt    int64    `xml:"params>param>value>i4,omitempty"`
+	CCUString string   `xml:"params>param>value>string,omitempty"`
+	Member    []Member `xml:"params>param>value>struct>member,omitempty"`
+	Fault     []Member `xml:"fault>value>struct>member,omitempty"`
 }
 type Value struct {
 	XMLName   xml.Name `xml:"value"`

--- a/meter/homematic/types.go
+++ b/meter/homematic/types.go
@@ -8,32 +8,33 @@ import (
 // https://homematic-ip.com/sites/default/files/downloads/HM_XmlRpc_API.pdf
 // https://homematic-ip.com/sites/default/files/downloads/HMIP_XmlRpc_API_Addendum.pdf
 
-type Param struct {
-	CCUBool   string  `xml:"value>boolean,omitempty"`
-	CCUFloat  float64 `xml:"value>double,omitempty"`
-	CCUInt    int64   `xml:"value>i4,omitempty"`
-	CCUString string  `xml:"value>string,omitempty"`
-}
-
 type MethodCall struct {
 	XMLName    xml.Name `xml:"methodCall"`
 	MethodName string   `xml:"methodName"`
 	Params     []Param  `xml:"params>param,omitempty"`
 }
 
-type Member struct {
-	Name  string     `xml:"name,omitempty"`
-	Value FaultValue `xml:"value,omitempty"`
+type Param struct {
+	CCUBool   string  `xml:"value>boolean,omitempty"`
+	CCUFloat  float64 `xml:"value>double,omitempty"`
+	CCUInt    int64   `xml:"value>i4,omitempty"`
+	CCUString string  `xml:"value>string,omitempty"`
 }
-
-type FaultValue struct {
-	XMLName   xml.Name `xml:"value"`
-	CCUString string   `xml:",chardata"`
-	CCUInt    int64    `xml:"i4,omitempty"`
+type Member struct {
+	Name  string `xml:"name,omitempty"`
+	Value Value  `xml:"value,omitempty"`
 }
 
 type MethodResponse struct {
 	XMLName xml.Name `xml:"methodResponse"`
-	Value   Param    `xml:"params>param,omitempty"`
+	Value   Param    `xml:"params>param>xxxx,omitempty"`
+	Member  []Member `xml:"params>param>value>struct>member,omitempty"`
 	Fault   []Member `xml:"fault>value>struct>member,omitempty"`
+}
+type Value struct {
+	XMLName   xml.Name `xml:"value"`
+	CCUString string   `xml:",chardata"`
+	CCUInt    int64    `xml:"i4,omitempty"`
+	CCUBool   bool     `xml:"boolean,omitempty"`
+	CCUFloat  float64  `xml:"double,omitempty"`
 }

--- a/meter/homematic/types_test.go
+++ b/meter/homematic/types_test.go
@@ -12,13 +12,38 @@ import (
 func TestUnmarshalMethodResponse(t *testing.T) {
 
 	{
-		// Double response test
+		// BidCos-RF (Port 2001) getParamset measure-channel response test
 		var res MethodResponse
 
-		xmlstr := `<?xml version="1.0" encoding="ISO-8859-1"?><methodResponse><params><param><value><double>20698.0</double></value></param></params></methodResponse>`
+		xmlstr := `<?xml version="1.0" encoding="iso-8859-1"?><methodResponse><params><param><value><struct><member><name>IEC_ENERGY_COUNTER</name><value><double>689.586500</double></value></member><member><name>IEC_POWER</name><value><double>166.390000</double></value></member></struct></value></param></params></methodResponse>`
+		assert.NoError(t, xml.Unmarshal([]byte(strings.Replace(string(xmlstr), "iso-8859-1", "UTF-8", 1)), &res))
+
+		assert.Equal(t, "IEC_ENERGY_COUNTER", res.Member[0].Name)
+		assert.Equal(t, float64(689.586500), res.Member[0].Value.CCUFloat)
+	}
+
+	{
+		// BidCos-IP (Port 2010) getParamset measure-channel response test
+		var res MethodResponse
+
+		xmlstr := `<?xml version="1.0" encoding="ISO-8859-1"?><methodResponse><params><param><value><struct><member><name>VOLTAGE</name><value><double>230.6</double></value></member><member><name>POWER_STATUS</name><value><i4>0</i4></value></member><member><name>ENERGY_COUNTER</name><value><double>10888.7</double></value></member><member><name>CURRENT_STATUS</name><value><i4>0</i4></value></member><member><name>FREQUENCY</name><value><double>49.97</double></value></member><member><name>ENERGY_COUNTER_OVERFLOW</name><value><boolean>0</boolean></value></member><member><name>POWER</name><value><double>0.05</double></value></member><member><name>VOLTAGE_STATUS</name><value><i4>0</i4></value></member><member><name>CURRENT</name><value><double>0.0</double></value></member><member><name>FREQUENCY_STATUS</name><value><i4>0</i4></value></member></struct></value></param></params></methodResponse>`
 		assert.NoError(t, xml.Unmarshal([]byte(strings.Replace(string(xmlstr), "ISO-8859-1", "UTF-8", 1)), &res))
 
-		assert.Equal(t, float64(20698), res.Value.CCUFloat)
+		assert.Equal(t, "ENERGY_COUNTER", res.Member[2].Name)
+		assert.Equal(t, float64(10888.7), res.Member[2].Value.CCUFloat)
+		assert.Equal(t, "POWER", res.Member[6].Name)
+		assert.Equal(t, float64(0.05), res.Member[6].Value.CCUFloat)
+	}
+
+	{
+		// BidCos-IP (Port 2010) getParamset switch-channel response test
+		var res MethodResponse
+
+		xmlstr := `<?xml version="1.0" encoding="ISO-8859-1"?><methodResponse><params><param><value><struct><member><name>SECTION_STATUS</name><value><i4>0</i4></value></member><member><name>PROCESS</name><value><i4>0</i4></value></member><member><name>STATE</name><value><boolean>1</boolean></value></member><member><name>SECTION</name><value><i4>2</i4></value></member></struct></value></param></params></methodResponse>`
+		assert.NoError(t, xml.Unmarshal([]byte(strings.Replace(string(xmlstr), "ISO-8859-1", "UTF-8", 1)), &res))
+
+		assert.Equal(t, "STATE", res.Member[2].Name)
+		assert.Equal(t, true, res.Member[2].Value.CCUBool)
 	}
 
 	{


### PR DESCRIPTION
Enhancement of CCU access logic:

- Switch reading single device channel values (getValue) to multiple values (getParamset)
- Introduction of caching to avoid multiple CCU accesses, causing CCU duty cycle problems
- Code simplification and refactoring

Refer to #7430