### PR TITLE
Elli (Volkswagen) in overview page

### DIFF
--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -1,6 +1,6 @@
 template: elliconnect
 products:
-  - brand: Elli
+  - brand: Elli (Volkswagen)
     description:
       de: Charger Connect (ohne Meter) (Beta)
       en: Charger Connect (without Meter) (Beta)

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -1,6 +1,6 @@
 template: ellipro
 products:
-  - brand: Elli
+  - brand: Elli (Volkswagen)
     description:
       de: Charger Connect (mit Meter)/Pro (Beta)
       en: Charger Connect (with Meter)/Pro (Beta)

--- a/templates/docs/charger/elliconnect_0.yaml
+++ b/templates/docs/charger/elliconnect_0.yaml
@@ -1,5 +1,5 @@
 product:
-  brand: Elli
+  brand: Elli (Volkswagen)
   description: Charger Connect (ohne Meter) (Beta)
 capabilities: ["mA"]
 requirements: ["eebus"]

--- a/templates/docs/charger/ellipro_0.yaml
+++ b/templates/docs/charger/ellipro_0.yaml
@@ -1,5 +1,5 @@
 product:
-  brand: Elli
+  brand: Elli (Volkswagen)
   description: Charger Connect (mit Meter)/Pro (Beta)
 capabilities: ["mA"]
 requirements: ["eebus"]

--- a/templates/evcc.io/brands.json
+++ b/templates/evcc.io/brands.json
@@ -14,7 +14,7 @@
   "Easee",
   "Ebee",
   "echarge",
-  "Elli",
+  "Elli (Volkswagen)",
   "EM2GO",
   "Ensto",
   "Etrel",


### PR DESCRIPTION
My suggestion: when I first read about the project and had a glimpse on the overview I did not recognise the Volkswagen Wallbox in your list of supported devices. I propose to say "Elli (Volkswagen)" there in the Overview. Also because there is a large "VW" logo printed on the front plate of the Wallbox, but no "Elli" logo.

Thx for this nice project and your work. It works like a charm on my site with Elli (Volkswagen) ID. Charger Pro + Sungrow SH8. I use 1-phase loading with 6-16 Ampere. The configuration dialog on the commandline is comfortable. With your fresh release yesterday v0.116.6 also the connect status is fixed and works. Thanks for all that.

Learned from https://github.com/evcc-io/evcc.io/pull/16 that this would require changes in the main project. For this reason, creating this PR