### PR TITLE
Align session month grouping in UI with CSV export

### DIFF
--- a/assets/js/views/ChargingSessions.vue
+++ b/assets/js/views/ChargingSessions.vue
@@ -184,7 +184,7 @@ export default {
 		},
 		groupByMonth(sessions) {
 			return sessions.reduce((groups, session) => {
-				const date = new Date(session.finished);
+				const date = new Date(session.created);
 				const month = `${date.getFullYear()}.${date.getMonth() + 1}`;
 				if (!groups[month]) groups[month] = [];
 				groups[month].push(session);


### PR DESCRIPTION
The CSV export for a month considers the `created` date to filter all sessions belonging to the specific month:

https://github.com/evcc-io/evcc/blob/59fca4580bafabf4e44fb34dc354baa7a3321971/server/http_session_handler.go#L64

The UI groups the month by `finished`date:

https://github.com/evcc-io/evcc/blob/59fca4580bafabf4e44fb34dc354baa7a3321971/assets/js/views/ChargingSessions.vue#L187

This is confusing, sine a download of a CSV does not yield the exact same result as the display in the UI, if there is a session started last month, which is finished in the next month.

While I don't care, if the grouping is done by `created` or `finished`, at least both UI and CSV should use the same. This PR changes the UI to behave the same as the CSV export, so that the export files stay compatible to previous versions.

Fixes #7766 