### PR TITLE
Elli branded: Cupra Charger Connect

### DIFF
--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -8,7 +8,7 @@ products:
       generic: ID. Charger Connect (Beta)
   - brand: Skoda
     description:
-      generic: iV Charger Connect (Beta)      
+      generic: iV Charger Connect (Beta)
   - brand: Cupra
     description:
       generic: Charger Connect (Beta)

--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -8,8 +8,8 @@ products:
       generic: ID. Charger Connect (Beta)
   - brand: Skoda
     description:
-      generic: iV Charger Connect (Beta)
-  - brand: Elli
+      generic: iV Charger Connect (Beta)      
+  - brand: Cupra
     description:
       generic: Charger Connect (Beta)
   - brand: Audi

--- a/templates/docs/charger/elliconnect_3.yaml
+++ b/templates/docs/charger/elliconnect_3.yaml
@@ -1,5 +1,5 @@
 product:
-  brand: Elli
+  brand: Cupra
   description: Charger Connect (Beta)
 capabilities: ["mA"]
 requirements: ["eebus"]


### PR DESCRIPTION
Corrected typo 

Currently the docu on https://docs.evcc.io/docs/devices/chargers#cupra-charger-pro-beta shows Elli Charger Connect twice but misses the Cupra branded one :-)

Thx @naltatis for your nice table overview on https://github.com/evcc-io/evcc/pull/7757#issuecomment-1529477695