### PR TITLE
Add shutdown handler

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -250,6 +250,10 @@ func runRoot(cmd *cobra.Command, args []string) {
 	// show main ui
 	if err == nil {
 		httpd.RegisterSiteHandlers(site, cache)
+		httpd.RegisterShutdownHandler(func() {
+			log.FATAL.Println("evcc was stopped by user. OS should restart the service. Or restart manually.")
+			once.Do(func() { close(stopC) }) // signal loop to end
+		})
 
 		// set channels
 		site.DumpConfig()


### PR DESCRIPTION
Complement https://github.com/evcc-io/evcc/pull/7671

```
[lp-2  ] DEBUG 2023/05/02 21:33:36 charger status: B
[main  ] FATAL 2023/05/02 21:33:39 evcc was stopped by user. OS should restart the service. Or restart manually.
```