### PR TITLE
Consistent formatting for live community and savings data

### DIFF
--- a/assets/js/components/LiveCommunity.vue
+++ b/assets/js/components/LiveCommunity.vue
@@ -4,9 +4,9 @@
 			class="text-accent2"
 			icon="car"
 			:title="$t('footer.community.power')"
-			:value="chargePower"
+			:value="chargePower.value"
 			:valueFmt="fmtAnimation"
-			unit="kW"
+			:unit="chargePower.unit"
 			:sub1="$t('footer.community.powerSub1', { totalClients, activeClients })"
 			:sub2="$t('footer.community.powerSub2')"
 		/>
@@ -16,7 +16,7 @@
 			icon="sun"
 			:title="$t('footer.community.greenShare')"
 			:value="greenShare"
-			:valueFmt="fmtAnimationDecimal"
+			:valueFmt="fmtAnimation"
 			unit="%"
 			:sub1="$t('footer.community.greenShareSub1')"
 			:sub2="$t('footer.community.greenShareSub2')"
@@ -26,9 +26,9 @@
 			class="text-accent3"
 			icon="eco"
 			:title="$t('footer.community.greenEnergy')"
-			:value="greenEnergyMWh"
-			:valueFmt="fmtAnimationDecimal"
-			unit="MWh"
+			:value="greenEnergy.value"
+			:valueFmt="fmtAnimation"
+			:unit="greenEnergy.unit"
 			:sub1="$t('footer.community.greenEnergySub1')"
 			:sub2="$t('footer.community.greenEnergySub2')"
 		/>
@@ -62,8 +62,11 @@ export default {
 			return this.result.activeClients;
 		},
 		chargePower() {
-			const { chargePower = 0 } = this.result;
-			return chargePower / 1e3;
+			let { chargePower = 0 } = this.result;
+			if (chargePower < 1e6) return { value: chargePower / 1e3, unit: "kW" };
+			if (chargePower < 1e9) return { value: chargePower / 1e6, unit: "MW" };
+			if (chargePower < 1e12) return { value: chargePower / 1e9, unit: "GW" };
+			return { value: chargePower / 1e12, unit: "TW" };
 		},
 		greenShare() {
 			const { chargePower, greenPower } = this.result;
@@ -72,9 +75,12 @@ export default {
 			}
 			return (100 / chargePower) * greenPower;
 		},
-		greenEnergyMWh() {
+		greenEnergy() {
 			const { greenEnergy = 0 } = this.result;
-			return greenEnergy / 1e3;
+			if (greenEnergy < 1e3) return { value: greenEnergy, unit: "kWh" };
+			if (greenEnergy < 1e6) return { value: greenEnergy / 1e3, unit: "MWh" };
+			if (greenEnergy < 1e9) return { value: greenEnergy / 1e6, unit: "GWh" };
+			return { value: greenEnergy / 1e9, unit: "TWh" };
 		},
 	},
 	async mounted() {
@@ -94,10 +100,10 @@ export default {
 			}
 		},
 		fmtAnimation(number) {
-			return this.fmtNumber(number, 0);
-		},
-		fmtAnimationDecimal(number) {
-			return this.fmtNumber(number, 1);
+			let decimals = 0;
+			if (number < 100) decimals = 1;
+			if (number < 10) decimals = 2;
+			return this.fmtNumber(number, decimals);
 		},
 	},
 };

--- a/assets/js/components/Savings.vue
+++ b/assets/js/components/Savings.vue
@@ -74,13 +74,14 @@
 												self: fmtKw(
 													selfConsumptionCharged * 1000,
 													true,
-													false
+													false,
+													0
 												),
 											})
 										"
 										:sub2="
 											$t('footer.savings.percentGrid', {
-												grid: fmtKw(gridCharged * 1000, true, false),
+												grid: fmtKw(gridCharged * 1000, true, false, 0),
 											})
 										"
 									/>
@@ -112,7 +113,7 @@
 										:sub1="$t('footer.savings.savingsComparedToGrid')"
 										:sub2="
 											$t('footer.savings.savingsTotalEnergy', {
-												total: fmtKw(totalCharged * 1000, true, false),
+												total: fmtKw(totalCharged * 1000, true, false, 0),
 											})
 										"
 									/>

--- a/assets/js/components/Savings.vue
+++ b/assets/js/components/Savings.vue
@@ -66,7 +66,8 @@
 										class="text-accent1"
 										icon="sun"
 										:title="$t('footer.savings.percentTitle')"
-										:value="percent"
+										:value="selfConsumptionPercent"
+										:valueFmt="fmtAnimation"
 										unit="%"
 										:sub1="
 											$t('footer.savings.percentSelf', {
@@ -106,7 +107,7 @@
 										class="text-accent3"
 										icon="coinjar"
 										:title="$t('footer.savings.savingsTitle')"
-										:value="fmtMoney(amount, currency)"
+										:value="fmtMoney(amount, currency, amount < 100)"
 										:unit="fmtCurrencySymbol(currency)"
 										:sub1="$t('footer.savings.savingsComparedToGrid')"
 										:sub2="
@@ -195,6 +196,12 @@ export default {
 		openModal() {
 			const modal = Modal.getOrCreateInstance(document.getElementById("savingsModal"));
 			modal.show();
+		},
+		fmtAnimation(number) {
+			let decimals = 0;
+			if (number < 100) decimals = 1;
+			if (number < 10) decimals = 2;
+			return this.fmtNumber(number, decimals);
 		},
 	},
 };

--- a/assets/js/mixins/formatter.js
+++ b/assets/js/mixins/formatter.js
@@ -177,11 +177,12 @@ export default {
         year: "numeric",
       }).format(date);
     },
-    fmtMoney: function (amout = 0, currency = "EUR") {
+    fmtMoney: function (amout = 0, currency = "EUR", decimals = true) {
       return new Intl.NumberFormat(this.$i18n.locale, {
         style: "currency",
         currency,
         currencyDisplay: "code",
+        maximumFractionDigits: decimals ? undefined : 0,
       })
         .format(amout)
         .replace(currency, "")


### PR DESCRIPTION
- Choose energy/power unit based on value (kW, MW, GW, ...)
- Adjust rounding so that we always get 3 digits (if possible)

<img width="888" alt="Bildschirmfoto 2023-05-03 um 12 57 14" src="https://user-images.githubusercontent.com/152287/235897783-7e42450d-2d59-47f6-9f04-444ed0c20438.png">

<img width="888" alt="Bildschirmfoto 2023-05-03 um 12 57 08" src="https://user-images.githubusercontent.com/152287/235897790-81b192d6-044a-4471-b923-29753af07214.png">

- [x] apply formatting rules to values in subline

fixes #7795 