### PR TITLE
Only send updates to homematic chargers if changed

### DIFF
--- a/meter/homematic/connection.go
+++ b/meter/homematic/connection.go
@@ -70,8 +70,12 @@ func NewConnection(uri, device, meterchannel, switchchannel, user, password stri
 
 // Enable sets the homematic HMIP-PSM switchchannel state to true=on/false=off
 func (c *Connection) Enable(enable bool) error {
+	current, err := c.Enabled()
+	if err == nil && current == enable {
+		return nil
+	}
 	onoff := map[bool]string{true: "1", false: "0"}
-	_, err := c.XmlCmd("setValue", c.SwitchChannel, Param{CCUString: "STATE"}, Param{CCUBool: onoff[enable]})
+	_, err = c.XmlCmd("setValue", c.SwitchChannel, Param{CCUString: "STATE"}, Param{CCUBool: onoff[enable]})
 	if err == nil {
 		c.switchCache.Reset()
 		c.meterCache.Reset()


### PR DESCRIPTION
This prevents unnecessary radio comm and keeps the duty cycle down.

At least plain Homematic devices (non IP), the handling is rather stupid. Every set request is pushed directly to the target device, without checking whether this is really necessary. Thus the duty cycle limit is reached really fast.

This PR simply checks whether the last (cached) is identical to the target state. In that case, nothing is sent.

Even if somehow the state is no longer in sync, next time the cache is updated by periodic read, everything should match again.

refs: #7483, #7430