### PR TITLE
Planner: show planned slots without tariff

### DIFF
--- a/assets/js/components/TargetCharge.vue
+++ b/assets/js/components/TargetCharge.vue
@@ -201,13 +201,18 @@ export default {
 				!isNaN(this.selectedTargetTime)
 			) {
 				try {
-					const opts = {
-						params: { targetTime: this.selectedTargetTime },
-					};
 					this.plan = (
-						await api.get(`loadpoints/${this.id}/target/plan`, opts)
+						await api.get(`loadpoints/${this.id}/target/plan`, {
+							params: { targetTime: this.selectedTargetTime },
+						})
 					).data.result;
-					this.tariff = (await api.get(`tariff/planner`)).data.result;
+
+					const tariffRes = await api.get(`tariff/planner`, {
+						validateStatus: function (status) {
+							return status >= 200 && status < 500;
+						},
+					});
+					this.tariff = tariffRes.status === 404 ? { rates: [] } : tariffRes.data.result;
 				} catch (e) {
 					console.error(e);
 				}

--- a/assets/js/components/TargetCharge.vue
+++ b/assets/js/components/TargetCharge.vue
@@ -128,7 +128,7 @@ export default {
 		timeTooFarInTheFuture: function () {
 			if (this.tariff?.rates) {
 				const lastRate = this.tariff.rates[this.tariff.rates.length - 1];
-				if (lastRate.end) {
+				if (lastRate?.end) {
 					const end = new Date(lastRate.end);
 					return this.selectedTargetTime >= end;
 				}

--- a/assets/js/components/TargetChargePlan.vue
+++ b/assets/js/components/TargetChargePlan.vue
@@ -5,7 +5,7 @@
 				<div class="label">{{ $t("main.targetChargePlan.chargeDuration") }}</div>
 				<div class="value text-primary">{{ planDuration }}</div>
 			</div>
-			<div class="text-end">
+			<div v-if="hasTariff" class="text-end">
 				<div class="label">
 					<span v-if="activeSlot">{{ activeSlotName }}</span>
 					<span v-else-if="isCo2">{{ $t("main.targetChargePlan.co2Label") }}</span>
@@ -45,6 +45,9 @@ export default {
 		},
 		isCo2() {
 			return this.unit === CO2_UNIT;
+		},
+		hasTariff() {
+			return this.rates?.length > 1;
 		},
 		avgPrice() {
 			let hourSum = 0;

--- a/assets/js/components/TariffChart.vue
+++ b/assets/js/components/TariffChart.vue
@@ -89,9 +89,8 @@ export default {
 		},
 		priceStyle(price) {
 			const value = price === undefined ? this.avgPrice : price;
-			return {
-				height: `${(100 / this.maxPrice) * value}%`,
-			};
+			const height = value ? `${(100 / this.maxPrice) * value}%` : "100%";
+			return { height };
 		},
 	},
 };

--- a/assets/js/components/TariffChart.vue
+++ b/assets/js/components/TariffChart.vue
@@ -18,7 +18,7 @@
 			@click="selectSlot(index)"
 		>
 			<div class="slot-bar" :style="priceStyle(slot.price)">
-				<span v-if="slot.price === undefined" class="unknown">?</span>
+				<span v-if="slot.price === undefined && avgPrice" class="unknown">?</span>
 			</div>
 			<div class="slot-label">
 				{{ slot.startHour }}

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"math"
@@ -186,19 +187,17 @@ func tariffHandler(site site.API) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		tariff := vars["tariff"]
-		var rates api.Rates
-		var err error
 
 		t := site.GetTariff(tariff)
 		if t == nil {
-			// to tariff, empty list
-			rates = make(api.Rates, 0)
-		} else {
-			rates, err = t.Rates()
-			if err != nil {
-				jsonError(w, http.StatusBadRequest, err)
-				return
-			}
+			jsonError(w, http.StatusNotFound, errors.New("tariff not available"))
+			return
+		}
+
+		rates, err := t.Rates()
+		if err != nil {
+			jsonError(w, http.StatusNotFound, err)
+			return
 		}
 
 		res := struct {

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"math"
@@ -187,17 +186,19 @@ func tariffHandler(site site.API) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		tariff := vars["tariff"]
+		var rates api.Rates
+		var err error
 
 		t := site.GetTariff(tariff)
 		if t == nil {
-			jsonError(w, http.StatusBadRequest, errors.New("tariff not available"))
-			return
-		}
-
-		rates, err := t.Rates()
-		if err != nil {
-			jsonError(w, http.StatusBadRequest, err)
-			return
+			// to tariff, empty list
+			rates = make(api.Rates, 0)
+		} else {
+			rates, err = t.Rates()
+			if err != nil {
+				jsonError(w, http.StatusBadRequest, err)
+				return
+			}
 		}
 
 		res := struct {


### PR DESCRIPTION
fix #7817

- return empty list instead of error when no tariff is defined
- adjust bar heights if no price is known

- [x] remove `?` and `unknown price`

![Bildschirmfoto 2023-05-05 um 22 03 10](https://user-images.githubusercontent.com/152287/236558867-e2be3ec9-ab60-46a4-92d4-01a3a250e08b.png)
