### PR TITLE
Running "make docker" fails on task patch-asn1 due to missing patch utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # STEP 1 build ui
 FROM --platform=$BUILDPLATFORM node:18-alpine as node
 
-RUN apk update && apk add --no-cache make
+RUN apk update && apk add --no-cache make patch
 
 WORKDIR /build
 
@@ -25,7 +25,7 @@ FROM --platform=$BUILDPLATFORM golang:1.20-alpine as builder
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.
 # Ca-certificates is required to call HTTPS endpoints.
-RUN apk update && apk add --no-cache git make tzdata ca-certificates && update-ca-certificates
+RUN apk update && apk add --no-cache git make patch tzdata ca-certificates && update-ca-certificates
 
 # define RELEASE=1 to hide commit hash
 ARG RELEASE=0


### PR DESCRIPTION
Hello,

I tried to build the docker image locally, but the build process fails now. It worked well yesterday. I figured out that the removal of the package `alpine-sdk` from the Dockerfile is causing this issue. this PR does not add the package `alpine-sdk`, but only the package `patch`. The build process works fine with that.

Thanks and kind regards

Jens