### PR TITLE
Use currency style in fmtPricePerKWh (fixes #7892)

### DIFF
--- a/assets/js/mixins/formatter.js
+++ b/assets/js/mixins/formatter.js
@@ -195,19 +195,10 @@ export default {
     fmtPricePerKWh: function (amout = 0, currency = "EUR", short = false) {
       let unit = currency;
       let value = amout;
-      let minimumFractionDigits = "auto";
-      let maximumFractionDigits = 3;
-      if (["EUR", "USD"].includes(currency)) {
-        value *= 100;
-        unit = "ct";
-        minimumFractionDigits = 1;
-        maximumFractionDigits = 1;
-      }
       return `${new Intl.NumberFormat(this.$i18n.locale, {
-        style: "decimal",
-        minimumFractionDigits,
-        maximumFractionDigits,
-      }).format(value)} ${unit}${short ? "" : "/kWh"}`;
+        style: "currency",
+        currency: currency
+      }).format(value)}${short ? "" : "/kWh"}`;
     },
     fmtTimeAgo: function (elapsed) {
       const units = {

--- a/assets/js/mixins/formatter.js
+++ b/assets/js/mixins/formatter.js
@@ -197,7 +197,7 @@ export default {
       let value = amout;
       return `${new Intl.NumberFormat(this.$i18n.locale, {
         style: "currency",
-        currency: currency
+        currency: currency,
       }).format(value)}${short ? "" : "/kWh"}`;
     },
     fmtTimeAgo: function (elapsed) {

--- a/assets/js/mixins/formatter.js
+++ b/assets/js/mixins/formatter.js
@@ -195,10 +195,22 @@ export default {
     fmtPricePerKWh: function (amout = 0, currency = "EUR", short = false) {
       let unit = currency;
       let value = amout;
-      return `${new Intl.NumberFormat(this.$i18n.locale, {
-        style: "currency",
-        currency: currency,
-      }).format(value)}${short ? "" : "/kWh"}`;
+      if (["EUR", "USD"].includes(currency)) {
+        value *= 100;
+        unit = "ct";
+        let minimumFractionDigits = 1;
+        let maximumFractionDigits = 1;
+        return `${new Intl.NumberFormat(this.$i18n.locale, {
+          style: "decimal",
+          minimumFractionDigits,
+          maximumFractionDigits,
+        }).format(value)} ${unit}${short ? "" : "/kWh"}`;
+      } else {
+        return `${new Intl.NumberFormat(this.$i18n.locale, {
+          style: "currency",
+          currency: currency,
+        }).format(value)}${short ? "" : "/kWh"}`;
+      }
     },
     fmtTimeAgo: function (elapsed) {
       const units = {


### PR DESCRIPTION
Didn't actually test it, but this should fix #7892 

Implications would be, that two instead of 1 digit would be shown for EUR and USD.

As currency formatting uses the values from here:
https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml
