### PR TITLE
Solax Cloud Meters: Set Tokenid String Type

### DIFF
--- a/templates/definition/meter/solax-hybrid-cloud.yaml
+++ b/templates/definition/meter/solax-hybrid-cloud.yaml
@@ -20,6 +20,7 @@ params:
     allinone: true
   - name: tokenid
     required: true
+    type: string
     description:
       generic: SolaxCloud TokenID
     help:

--- a/templates/definition/meter/solax-inverter-cloud.yaml
+++ b/templates/definition/meter/solax-inverter-cloud.yaml
@@ -19,6 +19,7 @@ params:
     choice: ["pv"]
   - name: tokenid
     required: true
+    type: string
     description:
       generic: SolaxCloud TokenID
     help:


### PR DESCRIPTION
Always treat template tokenid parameter as to be a string.
Refer to discussion #7889 