### PR TITLE
Translate In and Out on EnergyFlow Screen

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -46,7 +46,7 @@
 					class="col-12 col-md-6 pe-md-5 pb-4 d-flex flex-column justify-content-between"
 				>
 					<div class="d-flex justify-content-between align-items-end mb-4">
-						<h3 class="m-0">In</h3>
+						<h3 class="m-0">{{ $t("main.energyflow.input") }}</h3>
 						<span class="fw-bold">
 							<AnimatedNumber :to="inPower" :format="kw" />
 						</span>
@@ -88,7 +88,7 @@
 					class="col-12 col-md-6 ps-md-5 pb-4 d-flex flex-column justify-content-between"
 				>
 					<div class="d-flex justify-content-between align-items-end mb-4">
-						<h3 class="m-0">Out</h3>
+						<h3 class="m-0">{{ $t("main.energyflow.output") }}t</h3>
 						<span class="fw-bold">
 							<AnimatedNumber :to="outPower" :format="kw" />
 						</span>

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -129,6 +129,8 @@ titleMinSoc = "Min. Ladung"
 titleTargetCharge = "Abfahrt"
 
 [main.energyflow]
+input = "Eingang"
+output = "Ausgang"
 battery = "Batterie"
 batteryCharge = "Batterie laden"
 batteryDischarge = "Batterie entladen"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -129,6 +129,8 @@ titleMinSoc = "Min charge"
 titleTargetCharge = "Depature"
 
 [main.energyflow]
+input = "In"
+output = "Out"
 battery = "Battery"
 batteryCharge = "Battery charging"
 batteryDischarge = "Battery discharging"


### PR DESCRIPTION
Moin!

Das hier ist keine große Sache, aber ich dachte mir, dass man auch die Begriffe **In** und **Out** in die richtige Sprache übersetzen sollte. Habe das jetzt in den Code eingebaut und für DE und EN eingetragen. 

Erfolgt das für die übrigen Sprachen automatisch über Hosted weblate?

Danke und Gruß

Jens

PS: Habe das bewusst am oberen Balken so gelassen wie es ist.