### PR TITLE
Support waking up custom chargers/vehicles

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -39,6 +41,18 @@ const (
 	StatusE    ChargeStatus = "E" // Fzg. angeschlossen:   ja    Laden aktiv: nein    - Fehler (Kurzschluss)
 	StatusF    ChargeStatus = "F" // Fzg. angeschlossen:   ja    Laden aktiv: nein    - Fehler (Ausfall Wallbox)
 )
+
+// ChargeStatusString converts a string to ChargeStatus
+func ChargeStatusString(s string) (ChargeStatus, error) {
+	switch strings.ToUpper(s) {
+	case "A", "B", "C":
+		return ChargeStatus(s), nil
+	case "D", "E", "F":
+		return ChargeStatus(s), fmt.Errorf("invalid status: %s", s)
+	default:
+		return StatusNone, fmt.Errorf("invalid status: %s", s)
+	}
+}
 
 // String implements Stringer
 func (c ChargeStatus) String() string {

--- a/charger/charger.go
+++ b/charger/charger.go
@@ -66,14 +66,13 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Charger, error
 	// decorator phases
 	var phases1p3p func(int) error
 	if cc.Phases1p3p != nil {
-		var phases1p3pi64 func(int64) error
-		phases1p3pi64, err = provider.NewIntSetterFromConfig("phases", *cc.Phases1p3p)
+		phases1p3pS, err := provider.NewIntSetterFromConfig("phases", *cc.Phases1p3p)
 		if err != nil {
 			return nil, fmt.Errorf("phases: %w", err)
 		}
 
 		phases1p3p = func(phases int) error {
-			return phases1p3pi64(int64(phases))
+			return phases1p3pS(int64(phases))
 		}
 	}
 
@@ -84,20 +83,22 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Charger, error
 		if err != nil {
 			return nil, fmt.Errorf("identify: %w", err)
 		}
-
 	}
 
-	// decorate charger with wakeup
+	// decorate wakeup
 	var wakeup func() error
 	if cc.Wakeup != nil {
 		wakeupS, err := provider.NewBoolSetterFromConfig("wakeup", *cc.Wakeup)
 		if err != nil {
 			return nil, fmt.Errorf("wakeup: %w", err)
 		}
-		wakeup = func() error { return wakeupS(true) }
+
+		wakeup = func() error {
+			return wakeupS(true)
+		}
 	}
 
-	return decorateCustom(c, identify, phases1p3p, wakeup), err
+	return decorateCustom(c, identify, phases1p3p, wakeup), nil
 }
 
 // NewConfigurable creates a new charger

--- a/charger/charger.go
+++ b/charger/charger.go
@@ -57,14 +57,20 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Charger, error
 	}
 
 	c, err := NewConfigurable(status, enabled, enable, maxcurrent)
+	if err != nil {
+		return nil, err
+	}
 
 	c.embed = &cc.embed
 
 	// decorator phases
 	var phases1p3p func(int) error
-	if err == nil && cc.Phases1p3p != nil {
+	if cc.Phases1p3p != nil {
 		var phases1p3pi64 func(int64) error
 		phases1p3pi64, err = provider.NewIntSetterFromConfig("phases", *cc.Phases1p3p)
+		if err != nil {
+			return nil, fmt.Errorf("phases: %w", err)
+		}
 
 		phases1p3p = func(phases int) error {
 			return phases1p3pi64(int64(phases))
@@ -73,8 +79,12 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Charger, error
 
 	// decorator identifier
 	var identify func() (string, error)
-	if err == nil && cc.Identify != nil {
+	if cc.Identify != nil {
 		identify, err = provider.NewStringGetterFromConfig(*cc.Identify)
+		if err != nil {
+			return nil, fmt.Errorf("identify: %w", err)
+		}
+
 	}
 
 	// decorate charger with wakeup

--- a/vehicle/vehicle.go
+++ b/vehicle/vehicle.go
@@ -99,12 +99,12 @@ func NewConfigurableFromConfig(other map[string]interface{}) (api.Vehicle, error
 		if err != nil {
 			return nil, fmt.Errorf("wakeup: %w", err)
 		}
-		wakeup = func() error { return wakeupS(true) }
+		wakeup = func() error {
+			return wakeupS(true)
+		}
 	}
 
-	res := decorateVehicle(v, status, rng, odo, climater, wakeup)
-
-	return res, nil
+	return decorateVehicle(v, status, rng, odo, climater, wakeup), nil
 }
 
 // Soc implements the api.Vehicle interface

--- a/vehicle/vehicle_decorators.go
+++ b/vehicle/vehicle_decorators.go
@@ -6,12 +6,12 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, error), vehicleRange func() (int64, error), vehicleOdometer func() (float64, error), vehicleClimater func() (bool, error)) api.Vehicle {
+func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, error), vehicleRange func() (int64, error), vehicleOdometer func() (float64, error), vehicleClimater func() (bool, error), resurrector func() error) api.Vehicle {
 	switch {
-	case chargeState == nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange == nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange == nil:
 		return base
 
-	case chargeState != nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange == nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange == nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -22,7 +22,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState == nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange != nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.VehicleRange
@@ -33,7 +33,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState != nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange != nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -48,7 +48,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState == nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange == nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange == nil:
 		return &struct {
 			api.Vehicle
 			api.VehicleOdometer
@@ -59,7 +59,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState != nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange == nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange == nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -74,7 +74,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState == nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange != nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.VehicleOdometer
@@ -89,7 +89,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState != nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange != nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -108,7 +108,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState == nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange == nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange == nil:
 		return &struct {
 			api.Vehicle
 			api.VehicleClimater
@@ -119,7 +119,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState != nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange == nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange == nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -134,7 +134,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState == nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange != nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.VehicleClimater
@@ -149,7 +149,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState != nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange != nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -168,7 +168,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState == nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange == nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange == nil:
 		return &struct {
 			api.Vehicle
 			api.VehicleClimater
@@ -183,7 +183,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState != nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange == nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange == nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -202,7 +202,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState == nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange != nil:
+	case chargeState == nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.VehicleClimater
@@ -221,7 +221,7 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			},
 		}
 
-	case chargeState != nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange != nil:
+	case chargeState != nil && resurrector == nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange != nil:
 		return &struct {
 			api.Vehicle
 			api.ChargeState
@@ -232,6 +232,310 @@ func decorateVehicle(base api.Vehicle, chargeState func() (api.ChargeStatus, err
 			Vehicle: base,
 			ChargeState: &decorateVehicleChargeStateImpl{
 				chargeState: chargeState,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer == nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+			api.VehicleOdometer
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+			api.VehicleOdometer
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+			api.VehicleOdometer
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater == nil && vehicleOdometer != nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+			api.VehicleOdometer
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+			api.VehicleClimater
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+			api.VehicleClimater
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+			api.VehicleClimater
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer == nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+			api.VehicleClimater
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+			api.VehicleClimater
+			api.VehicleOdometer
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange == nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+			api.VehicleClimater
+			api.VehicleOdometer
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+		}
+
+	case chargeState == nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.Resurrector
+			api.VehicleClimater
+			api.VehicleOdometer
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
+			},
+			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
+				vehicleClimater: vehicleClimater,
+			},
+			VehicleOdometer: &decorateVehicleVehicleOdometerImpl{
+				vehicleOdometer: vehicleOdometer,
+			},
+			VehicleRange: &decorateVehicleVehicleRangeImpl{
+				vehicleRange: vehicleRange,
+			},
+		}
+
+	case chargeState != nil && resurrector != nil && vehicleClimater != nil && vehicleOdometer != nil && vehicleRange != nil:
+		return &struct {
+			api.Vehicle
+			api.ChargeState
+			api.Resurrector
+			api.VehicleClimater
+			api.VehicleOdometer
+			api.VehicleRange
+		}{
+			Vehicle: base,
+			ChargeState: &decorateVehicleChargeStateImpl{
+				chargeState: chargeState,
+			},
+			Resurrector: &decorateVehicleResurrectorImpl{
+				resurrector: resurrector,
 			},
 			VehicleClimater: &decorateVehicleVehicleClimaterImpl{
 				vehicleClimater: vehicleClimater,
@@ -254,6 +558,14 @@ type decorateVehicleChargeStateImpl struct {
 
 func (impl *decorateVehicleChargeStateImpl) Status() (api.ChargeStatus, error) {
 	return impl.chargeState()
+}
+
+type decorateVehicleResurrectorImpl struct {
+	resurrector func() error
+}
+
+func (impl *decorateVehicleResurrectorImpl) WakeUp() error {
+	return impl.resurrector()
 }
 
 type decorateVehicleVehicleClimaterImpl struct {


### PR DESCRIPTION
Allows adding`wakeup` to custom chargers and vehicles.

The wakeup call itself has no parameter, but we need to use one of the `NewXXXSetterFromConfig` functions to initialize it. This is done by using the `NewBoolSetterFromConfig` function and always sending `true` as the `wakeup` parameter value.

If some other value is needed, this would be something that could be done with #7836, when that is implemented.