### PR TITLE
Correct unit for fixed tariffs

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -253,7 +253,7 @@ func configureTariffs(conf tariffConfig) (tariff.Tariffs, error) {
 	}
 
 	if conf.Grid.Type != "" {
-		grid, err = tariff.NewFromConfig(conf.Grid.Type, conf.Grid.Other)
+		grid, err = tariff.NewFromConfig(conf.Grid.Type, conf.Grid.Other, conf.Currency)
 		if err != nil {
 			grid = nil
 			log.ERROR.Printf("failed configuring grid tariff: %v", err)
@@ -261,7 +261,7 @@ func configureTariffs(conf tariffConfig) (tariff.Tariffs, error) {
 	}
 
 	if conf.FeedIn.Type != "" {
-		feedin, err = tariff.NewFromConfig(conf.FeedIn.Type, conf.FeedIn.Other)
+		feedin, err = tariff.NewFromConfig(conf.FeedIn.Type, conf.FeedIn.Other, conf.Currency)
 		if err != nil {
 			feedin = nil
 			log.ERROR.Printf("failed configuring feed-in tariff: %v", err)
@@ -269,7 +269,7 @@ func configureTariffs(conf tariffConfig) (tariff.Tariffs, error) {
 	}
 
 	if conf.Planner.Type != "" {
-		planner, err = tariff.NewFromConfig(conf.Planner.Type, conf.Planner.Other)
+		planner, err = tariff.NewFromConfig(conf.Planner.Type, conf.Planner.Other, conf.Currency)
 		if err != nil {
 			planner = nil
 			log.ERROR.Printf("failed configuring planner tariff: %v", err)

--- a/cmd/tariff.go
+++ b/cmd/tariff.go
@@ -47,7 +47,7 @@ func runTariff(cmd *cobra.Command, args []string) {
 			fmt.Println(key + ":")
 		}
 
-		tf, err := tariff.NewFromConfig(cc.Type, cc.Other)
+		tf, err := tariff.NewFromConfig(cc.Type, cc.Other, conf.Tariffs.Currency)
 		if err != nil {
 			fatal(err)
 		}

--- a/tariff/config.go
+++ b/tariff/config.go
@@ -27,9 +27,13 @@ func (r tariffRegistry) Get(name string) (func(map[string]interface{}) (api.Tari
 var registry tariffRegistry = make(map[string]func(map[string]interface{}) (api.Tariff, error))
 
 // NewFromConfig creates tariff from configuration
-func NewFromConfig(typ string, other map[string]interface{}) (v api.Tariff, err error) {
-	factory, err := registry.Get(strings.ToLower(typ))
+func NewFromConfig(typ string, other map[string]interface{}, currency string) (v api.Tariff, err error) {
+	lowerType := strings.ToLower(typ)
+	factory, err := registry.Get(lowerType)
 	if err == nil {
+		if lowerType == "fixed" {
+			other["currency"] = currency
+		}
 		if v, err = factory(other); err != nil {
 			err = fmt.Errorf("cannot create tariff '%s': %w", typ, err)
 		}


### PR DESCRIPTION
adresses #8012

Fix https://github.com/evcc-io/evcc/issues/8012

Currency is shown in the correct unit (CHF/kWh instead of ct/kWh). Correctly showing sub-units (rap, ore, ...) for more currencies than USD/EUR will be done in a following step.