### PR TITLE
Enable soc ui functions when soc is provided by charger

### DIFF
--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -294,7 +294,7 @@ export default {
 			return this.charging && this.chargePower > 0;
 		},
 		socBasedCharging: function () {
-			return !this.vehicleFeatureOffline && this.vehiclePresent;
+			return (!this.vehicleFeatureOffline && this.vehiclePresent) || this.vehicleSoc > 0;
 		},
 		sessionOptions: function () {
 			const result = [SESSION.TIME, SESSION.SOLAR];


### PR DESCRIPTION
fixes #7209 

Note: vehicleSoc has to be removed (= 0) on disconnect.

- [x] set `vehicleSoc` accordingly @andig 