### PR TITLE
Plugins: make javascript return values more permissive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/samber/lo v1.38.1
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
+	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/pflag v1.0.5
@@ -171,7 +172,6 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
-	github.com/spf13/cast v1.5.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/teivah/onecontext v1.3.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect

--- a/provider/go.go
+++ b/provider/go.go
@@ -68,7 +68,7 @@ func (p *Go) FloatGetter() func() (float64, error) {
 
 		vv, ok := v.(float64)
 		if !ok {
-			return 0, fmt.Errorf("not a float: %s", v)
+			return 0, fmt.Errorf("not a float: %v", v)
 		}
 
 		return vv, nil
@@ -85,7 +85,7 @@ func (p *Go) IntGetter() func() (int64, error) {
 
 		vv, ok := v.(int64)
 		if !ok {
-			return 0, fmt.Errorf("not a int: %s", v)
+			return 0, fmt.Errorf("not a int: %v", v)
 		}
 
 		return vv, nil
@@ -102,7 +102,7 @@ func (p *Go) StringGetter() func() (string, error) {
 
 		vv, ok := v.(string)
 		if !ok {
-			return "", fmt.Errorf("not a string: %s", v)
+			return "", fmt.Errorf("not a string: %v", v)
 		}
 
 		return vv, nil
@@ -119,7 +119,7 @@ func (p *Go) BoolGetter() func() (bool, error) {
 
 		vv, ok := v.(bool)
 		if !ok {
-			return false, fmt.Errorf("not a bool: %s", v)
+			return false, fmt.Errorf("not a bool: %v", v)
 		}
 
 		return vv, nil

--- a/provider/javascript.go
+++ b/provider/javascript.go
@@ -1,11 +1,10 @@
 package provider
 
 import (
-	"fmt"
-
 	"github.com/evcc-io/evcc/provider/javascript"
 	"github.com/evcc-io/evcc/util"
 	"github.com/robertkrimen/otto"
+	"github.com/spf13/cast"
 )
 
 // Javascript implements Javascript request provider
@@ -66,12 +65,7 @@ func (p *Javascript) FloatGetter() func() (float64, error) {
 			return 0, err
 		}
 
-		vv, ok := v.(float64)
-		if !ok {
-			return 0, fmt.Errorf("not a float: %s", v)
-		}
-
-		return vv, nil
+		return cast.ToFloat64E(v)
 	}
 }
 
@@ -83,12 +77,7 @@ func (p *Javascript) IntGetter() func() (int64, error) {
 			return 0, err
 		}
 
-		vv, ok := v.(int64)
-		if !ok {
-			return 0, fmt.Errorf("not a int: %s", v)
-		}
-
-		return vv, nil
+		return cast.ToInt64E(v)
 	}
 }
 
@@ -100,12 +89,7 @@ func (p *Javascript) StringGetter() func() (string, error) {
 			return "", err
 		}
 
-		vv, ok := v.(string)
-		if !ok {
-			return "", fmt.Errorf("not a string: %s", v)
-		}
-
-		return vv, nil
+		return cast.ToStringE(v)
 	}
 }
 
@@ -117,12 +101,7 @@ func (p *Javascript) BoolGetter() func() (bool, error) {
 			return false, err
 		}
 
-		vv, ok := v.(bool)
-		if !ok {
-			return false, fmt.Errorf("not a bool: %s", v)
-		}
-
-		return vv, nil
+		return cast.ToBoolE(v)
 	}
 }
 
@@ -131,12 +110,7 @@ func (p *Javascript) handleGetter() (any, error) {
 		return nil, err
 	}
 
-	v, err := p.evaluate()
-	if err != nil {
-		return nil, err
-	}
-
-	return v, nil
+	return p.evaluate()
 }
 
 func (p *Javascript) handleSetter(param string, val any) error {


### PR DESCRIPTION
Fix js plugin issue introduced by https://github.com/evcc-io/evcc/pull/7836.

/cc @tisoft Fehler in Master: die vordefinierten Werte in State kommen als `int64`, by JS müssen wir also explizit auf Zielwert konvertieren, das machen wir hier mit Hilfe von `cast`.