### PR TITLE
Cleanup template meta data

### DIFF
--- a/templates/definition/vehicle/audi.yaml
+++ b/templates/definition/vehicle/audi.yaml
@@ -2,8 +2,7 @@ template: audi
 products:
   - brand: Audi
     description:
-      de: Andere
-      en: Others
+      generic: legacy
 params:
   - preset: vehicle-base
   - preset: vehicle-identify

--- a/templates/definition/vehicle/flobz.yaml
+++ b/templates/definition/vehicle/flobz.yaml
@@ -1,8 +1,11 @@
 template: flobz
 products:
-  - brand: PSA
-    description:
-      generic: PSA Car Controller (flobz)
+  - description:
+      generic: PSA Car Controller
+group: generic
+requirements:
+  description:
+    generic: Remote Control of PSA car https://github.com/flobz/psa_car_controller
 params:
   - name: title
   - name: url

--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -1,12 +1,12 @@
 template: mazda2mqtt
 products:
-  - brand: Mazda
-    description:
-      generic: Publish all myMazda Car Data to MQTT (mazda2mqtt)
+  - description:
+      generic: mazda2mqtt
+group: generic
 requirements:
   description:
-    en: Required MQTT broker configuration
-    de: Voraussetzung ist ein konfigurierter MQTT Broker
+    en: MQTT broker configuration required.
+    de: Voraussetzung ist ein konfigurierter MQTT Broker.
 params:
   - name: title
   - name: vin

--- a/templates/definition/vehicle/mg2mqtt.yaml
+++ b/templates/definition/vehicle/mg2mqtt.yaml
@@ -1,8 +1,8 @@
 template: mg2mqtt
 products:
-  - brand: MG
-    description:
-      generic: Publish all MG iSmart Car Data to MQTT (mg2mqtt)
+  - description:
+      generic: mg2mqtt
+group: generic
 requirements:
   description:
     en: Required MQTT broker configuration and a SAIC/MQTT Gateway (https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway or https://github.com/SAIC-iSmart-API/saic-java-client)

--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -5,7 +5,7 @@ products:
 group: generic
 requirements:
   description:
-    en: Open source Tesla data logger https://github.com/adriankumpf/teslamate. MQTT broker configuration required.
+    en: Open source Tesla data logger https://github.com/adriankumpf/teslamate. MQTT broker required.
     de: Open Source Tesla Datenlogger https://github.com/adriankumpf/teslamate. Voraussetzung ist konfigurierter MQTT Broker.
 params:
   - name: title

--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -1,12 +1,12 @@
 template: teslamate
 products:
-  - brand: Tesla
-    description:
-      generic: A self-hosted data logger for your Tesla (teslamate)
+  - description:
+      generic: TeslaMate
+group: generic
 requirements:
   description:
-    en: Required MQTT broker configuration
-    de: Voraussetzung ist konfigurierter MQTT Broker
+    en: Open source Tesla data logger https://github.com/adriankumpf/teslamate. MQTT broker configuration required.
+    de: Open Source Tesla Datenlogger https://github.com/adriankumpf/teslamate. Voraussetzung ist konfigurierter MQTT Broker.
 params:
   - name: title
   - name: id

--- a/templates/definition/vehicle/volvo.yaml
+++ b/templates/definition/vehicle/volvo.yaml
@@ -1,6 +1,8 @@
 template: volvo
 products:
-  - brand: Volvo (legacy)
+  - brand: Volvo
+    description:
+      generic: legacy
 params:
   - preset: vehicle-base
   - preset: vehicle-identify

--- a/templates/docs/vehicle/audi_0.yaml
+++ b/templates/docs/vehicle/audi_0.yaml
@@ -1,6 +1,6 @@
 product:
   brand: Audi
-  description: Andere
+  description: legacy
 render:
   - default: |
       type: template

--- a/templates/docs/vehicle/flobz_0.yaml
+++ b/templates/docs/vehicle/flobz_0.yaml
@@ -1,6 +1,8 @@
 product:
-  brand: PSA
-  description: PSA Car Controller (flobz)
+  description: PSA Car Controller
+  group: Generische Unterstützung
+description: |
+  Remote Control of PSA car https://github.com/flobz/psa_car_controller
 render:
   - default: |
       type: template

--- a/templates/docs/vehicle/mazda2mqtt_0.yaml
+++ b/templates/docs/vehicle/mazda2mqtt_0.yaml
@@ -1,8 +1,8 @@
 product:
-  brand: Mazda
-  description: Publish all myMazda Car Data to MQTT (mazda2mqtt)
+  description: mazda2mqtt
+  group: Generische Unterstützung
 description: |
-  Voraussetzung ist ein konfigurierter MQTT Broker
+  Voraussetzung ist ein konfigurierter MQTT Broker.
 render:
   - default: |
       type: template

--- a/templates/docs/vehicle/mg2mqtt_0.yaml
+++ b/templates/docs/vehicle/mg2mqtt_0.yaml
@@ -1,6 +1,6 @@
 product:
-  brand: MG
-  description: Publish all MG iSmart Car Data to MQTT (mg2mqtt)
+  description: mg2mqtt
+  group: Generische Unterstützung
 description: |
   Voraussetzung ist ein konfigurierter MQTT Broker und ein SAIC/MQTT Gateway (https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway oder https://github.com/SAIC-iSmart-API/saic-java-client)
 render:

--- a/templates/docs/vehicle/teslamate_0.yaml
+++ b/templates/docs/vehicle/teslamate_0.yaml
@@ -1,8 +1,8 @@
 product:
-  brand: Tesla
-  description: A self-hosted data logger for your Tesla (teslamate)
+  description: TeslaMate
+  group: Generische Unterstützung
 description: |
-  Voraussetzung ist konfigurierter MQTT Broker
+  Open Source Tesla Datenlogger https://github.com/adriankumpf/teslamate. Voraussetzung ist konfigurierter MQTT Broker.
 render:
   - default: |
       type: template

--- a/templates/docs/vehicle/volvo_0.yaml
+++ b/templates/docs/vehicle/volvo_0.yaml
@@ -1,5 +1,6 @@
 product:
-  brand: Volvo (legacy)
+  brand: Volvo
+  description: legacy
 render:
   - default: |
       type: template

--- a/templates/evcc.io/brands.json
+++ b/templates/evcc.io/brands.json
@@ -179,22 +179,18 @@
   "Jaguar",
   "Kia",
   "Land Rover",
-  "Mazda",
-  "MG",
   "Mini",
   "Nissan",
   "NIU",
   "Opel",
   "Peugeot",
   "Porsche",
-  "PSA",
   "Renault",
   "Seat",
   "Skoda",
   "Smart",
   "Tesla",
   "Volkswagen",
-  "Volvo",
-  "Volvo (legacy)"
+  "Volvo"
  ]
 }


### PR DESCRIPTION
- moved `PSA Car Controller`, `mg2mqtt`, `mazda2mqtt` and `teslamate` to the generic section since they require a third party system to be configured (similar to Tronity).
- added teslamate link
- Volvo legacy fix

@andig @C64Axel we should add details (e.g. a link) on what's required to get `mazda2mqtt` working.