### PR TITLE
Reduce amount of sync messages

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -630,7 +630,8 @@ func (lp *Loadpoint) syncCharger() error {
 	}
 
 	if enabled != lp.enabled {
-		if lp.guardGracePeriodElapsed() {
+		// ignore disabled state if vehicle was disconnected ^(lp.enabled && ^lp.connected)
+		if lp.guardGracePeriodElapsed() && (!lp.enabled || lp.connected()) {
 			lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
 		}
 		return lp.charger.Enable(lp.enabled)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -625,24 +625,23 @@ func (lp *Loadpoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 // syncCharger updates charger status and synchronizes it with expectations
 func (lp *Loadpoint) syncCharger() {
 	enabled, err := lp.charger.Enabled()
-	if err == nil {
-		if enabled != lp.enabled {
-			if lp.guardGracePeriodElapsed() {
-				lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
-			}
-			err = lp.charger.Enable(lp.enabled)
-		}
-
-		if !enabled && lp.charging() {
-			if lp.guardGracePeriodElapsed() {
-				lp.log.WARN.Println("charger logic error: disabled but charging")
-			}
-			err = lp.charger.Enable(false)
-		}
-	}
-
 	if err != nil {
 		lp.log.ERROR.Printf("charger: %v", err)
+		return
+	}
+
+	if enabled != lp.enabled {
+		if lp.guardGracePeriodElapsed() {
+			lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
+		}
+		err = lp.charger.Enable(lp.enabled)
+	}
+
+	if !enabled && lp.charging() {
+		if lp.guardGracePeriodElapsed() {
+			lp.log.WARN.Println("charger logic error: disabled but charging")
+		}
+		err = lp.charger.Enable(false)
 	}
 }
 


### PR DESCRIPTION
It seems we're always creating guard messages when vehicle is disconnected since that happens after the guard timeout. This affects chargers that reset their enabled state when vehicle disconnects. In this case it doesn't help to re-enable and would not be possible anyway. Should figure out what to check fro to avoid that.

It's unclear what happens on connect- do we have chargers that consider themselves connected?

/cc @MarkusGH @DerAndereAndi 