### PR TITLE
Keba: fix charger status mismatch

### DIFF
--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -131,10 +131,10 @@ func (wb *Keba) Status() (api.ChargeStatus, error) {
 	}
 
 	switch status := binary.BigEndian.Uint32(b); status {
-	case 0:
+	case 0, 3:
 		return api.StatusA, nil
 
-	case 1, 3, 5:
+	case 1, 5:
 		return api.StatusB, nil
 
 	case 7:


### PR DESCRIPTION
Fix an issue with that the charger is always connected to the vehicle