### PR TITLE
Keba: fix enabled status of charger

### DIFF
--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -175,7 +175,8 @@ func (wb *Keba) Enabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return binary.BigEndian.Uint32(b) != 5, nil
+	status := binary.BigEndian.Uint32(b)
+	return !(status == 5 || status == 1), nil
 }
 
 // Enable implements the api.Charger interface


### PR DESCRIPTION
Die Keba Wallbox war bei mir als ich die EVCC auf Aus gestellt, wobei die WB im Status disabled war mit dem Wert 1 im Register 1000, wodurch ich immer den Fehler out-of-sync Fehler bekommen habe.

Laut Doku macht das auch Sinn, dass die WB nicht enabled ist im Status 1.
https://www.keba.com/download/x/dea7ae6b84/kecontactp30modbustcp_pgen.pdf (Siehe Seite 10).

Hab's bei mir auch lokal gebaut und da klappt das auch soweit.