### PR TITLE
Implement api resurrector for porsche, always use charger + vehicle for wake-up

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -179,7 +179,6 @@ func (lp *Loadpoint) wakeUpVehicle() {
 		if err := c.WakeUp(); err != nil {
 			lp.log.ERROR.Printf("wake-up charger: %v", err)
 		}
-		return
 	}
 
 	// vehicle

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -68,3 +68,10 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 	err := v.GetJSON(uri, &res)
 	return res, err
 }
+
+// WakeUp performs a wakeup request
+func (v *API) WakeUp(vin string) error {
+	// try to request status and hope this will wake up the car from sleep
+	res, err := Status(vin)
+	return err
+}

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -68,4 +68,3 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 	err := v.GetJSON(uri, &res)
 	return res, err
 }
-

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -72,6 +72,6 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 // WakeUp performs a wakeup request
 func (v *API) WakeUp(vin string) error {
 	// try to request status and hope this will wake up the car from sleep
-	res, err := v.Status(vin)
+	_, err := v.Status(vin)
 	return err
 }

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -69,9 +69,3 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 	return res, err
 }
 
-// WakeUp performs a wakeup request
-func (v *API) WakeUp(vin string) error {
-	// try to request status and hope this will wake up the car from sleep
-	_, err := v.Status(vin)
-	return err
-}

--- a/vehicle/porsche/api.go
+++ b/vehicle/porsche/api.go
@@ -72,6 +72,6 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 // WakeUp performs a wakeup request
 func (v *API) WakeUp(vin string) error {
 	// try to request status and hope this will wake up the car from sleep
-	res, err := Status(vin)
+	res, err := v.Status(vin)
 	return err
 }

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -14,7 +14,6 @@ type Provider struct {
 	statusG    func() (StatusResponse, error)
 	emobilityG func() (EmobilityResponse, error)
 	mobileG    func() (StatusResponseMobile, error)
-	wakeup     func() error
 }
 
 // NewProvider creates a vehicle api provider
@@ -34,14 +33,6 @@ func NewProvider(log *util.Logger, api *API, emobility *EmobilityAPI, mobile *Mo
 		mobileG: provider.Cached(func() (StatusResponseMobile, error) {
 			return mobile.Status(vin, []string{BATTERY_LEVEL, BATTERY_CHARGING_STATE, CLIMATIZER_STATE, E_RANGE, HEATING_STATE, MILEAGE})
 		}, cache),
-
-		wakeup: func() error {
-			_ := api.Status(vin)
-			if carModel != "" {
-				_ := emobility.Status(vin, carModel)
-			}
-			_ := mobile.Status(vin, []string{BATTERY_LEVEL})
-		},
 	}
 
 	return impl
@@ -244,5 +235,10 @@ var _ api.Resurrector = (*Provider)(nil)
 
 // WakeUp implements the api.Resurrector interface
 func (v *Provider) WakeUp() error {
-	return v.wakeup()
+	_ := api.Status(vin)
+	if carModel != "" {
+		_ := emobility.Status(vin, carModel)
+	}
+	_ := mobile.Status(vin, []string{BATTERY_LEVEL})
+	return nil
 }

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -35,7 +35,13 @@ func NewProvider(log *util.Logger, api *API, emobility *EmobilityAPI, mobile *Mo
 			return mobile.Status(vin, []string{BATTERY_LEVEL, BATTERY_CHARGING_STATE, CLIMATIZER_STATE, E_RANGE, HEATING_STATE, MILEAGE})
 		}, cache),
 
-		wakeup: func() error { return api.WakeUp(vin) },
+		wakeup: func() error {
+			_ := api.Status(vin)
+			if carModel != "" {
+				_ := emobility.Status(vin, carModel)
+			}
+			_ := mobile.Status(vin, []string{BATTERY_LEVEL})
+		},
 	}
 
 	return impl

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -36,11 +36,11 @@ func NewProvider(log *util.Logger, api *API, emobility *EmobilityAPI, mobile *Mo
 		}, cache),
 
 		wakeup: func() error {
-			_ := api.Status(vin)
+			_, _ = api.Status(vin)
 			if carModel != "" {
-				_ := emobility.Status(vin, carModel)
+				_, _ = emobility.Status(vin, carModel)
 			}
-			_ := mobile.Status(vin, []string{BATTERY_LEVEL})
+			_, _ = mobile.Status(vin, []string{BATTERY_LEVEL})
 			return nil
 		},
 	}

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -35,7 +35,7 @@ func NewProvider(log *util.Logger, api *API, emobility *EmobilityAPI, mobile *Mo
 			return mobile.Status(vin, []string{BATTERY_LEVEL, BATTERY_CHARGING_STATE, CLIMATIZER_STATE, E_RANGE, HEATING_STATE, MILEAGE})
 		}, cache),
 
-		wakeup = func() error { return api.WakeUp(vin) }
+		wakeup: func() error { return api.WakeUp(vin) },
 	}
 
 	return impl

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -14,6 +14,7 @@ type Provider struct {
 	statusG    func() (StatusResponse, error)
 	emobilityG func() (EmobilityResponse, error)
 	mobileG    func() (StatusResponseMobile, error)
+	wakeup     func() error
 }
 
 // NewProvider creates a vehicle api provider
@@ -33,6 +34,15 @@ func NewProvider(log *util.Logger, api *API, emobility *EmobilityAPI, mobile *Mo
 		mobileG: provider.Cached(func() (StatusResponseMobile, error) {
 			return mobile.Status(vin, []string{BATTERY_LEVEL, BATTERY_CHARGING_STATE, CLIMATIZER_STATE, E_RANGE, HEATING_STATE, MILEAGE})
 		}, cache),
+
+		wakeup: func() error {
+			_ := api.Status(vin)
+			if carModel != "" {
+				_ := emobility.Status(vin, carModel)
+			}
+			_ := mobile.Status(vin, []string{BATTERY_LEVEL})
+			return nil
+		},
 	}
 
 	return impl
@@ -235,8 +245,5 @@ var _ api.Resurrector = (*Provider)(nil)
 
 // WakeUp implements the api.Resurrector interface
 func (v *Provider) WakeUp() error {
-	_, _ := v.statusG()
-	_, _ := v.emobilityG()
-	_, _ := v.mobileG()
-	return nil
+	return v.wakeup()
 }

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -235,10 +235,8 @@ var _ api.Resurrector = (*Provider)(nil)
 
 // WakeUp implements the api.Resurrector interface
 func (v *Provider) WakeUp() error {
-	_ := api.Status(vin)
-	if carModel != "" {
-		_ := emobility.Status(vin, carModel)
-	}
-	_ := mobile.Status(vin, []string{BATTERY_LEVEL})
+	_, _ := v.statusG()
+	_, _ := v.emobilityG()
+	_, _ := v.mobileG()
 	return nil
 }


### PR DESCRIPTION
Versuch Porsche Fahrzeugen über die Porsche APIs aufzuwecken.
Notwendig, da mindestens einige Porsche Fahrzeuge nach 5 vergeblichen Ladeversuchen einschlafen und dann nicht mehr auf CP Unterbrechung reagieren.
Sollte parallel zu CP Unterbrechung verwendet werden.