### PR TITLE
Enphase: Add token-based authentication (firmware D7.x.xxx) and grid #8146

### DIFF
--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -8,9 +8,7 @@ params:
     choice: ["grid", "pv"]
   - name: host
     required: true
-  - name: timeout
-    default: 10s
-  - name: Token
+  - name: token
     help: 
       en: "Required if Envoy Firmware D7.x.xxx. Token is valid for one year. Instructions for obtaining a token via web UI: https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
       de: "Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
@@ -29,7 +27,6 @@ render: |
     {{- end }}
     jq: .consumption[] | select(.measurementType == "net-consumption").wNow
     scale: 1
-    timeout: {{ .timeout }}
   energy:
     source: http
     uri: http://{{ .host }}/production.json
@@ -42,7 +39,6 @@ render: |
     {{- end }}
     jq: .consumption[] | select(.measurementType == "net-consumption").whLifetime
     scale: 0.001
-    timeout: {{ .timeout }}
   {{- end }}
   {{- if eq .usage "pv" }}
   power:
@@ -57,7 +53,6 @@ render: |
     {{- end }}
     jq: .production[] | select(.measurementType == "production").wNow
     scale: 1
-    timeout: {{ .timeout }}
   energy:
     source: http
     uri: http://{{ .host }}/production.json
@@ -70,5 +65,4 @@ render: |
     {{- end }}
     jq: .production[] | select(.measurementType == "production").whLifetime
     scale: 0.001
-    timeout: {{ .timeout }}
   {{- end }}

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -9,6 +9,9 @@ params:
   - name: host
     required: true
   - name: token
+    help:
+      en: "Required if Envoy Firmware D7.x.xxx. Token is valid for one year. Instructions for obtaining a token via web UI: https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
+      de: "Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -9,7 +9,7 @@ params:
   - name: host
     required: true
   - name: token
-    help: 
+    help:
       en: "Required if Envoy Firmware D7.x.xxx. Token is valid for one year. Instructions for obtaining a token via web UI: https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
       de: "Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
 render: |

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -8,8 +8,10 @@ params:
     choice: ["grid", "pv"]
   - name: host
     required: true
-  - name: token
-    help:
+  - name: timeout
+    default: 10s
+  - name: Token
+    help: 
       en: "Required if Envoy Firmware D7.x.xxx. Token is valid for one year. Instructions for obtaining a token via web UI: https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
       de: "Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
 render: |
@@ -27,6 +29,20 @@ render: |
     {{- end }}
     jq: .consumption[] | select(.measurementType == "net-consumption").wNow
     scale: 1
+    timeout: {{ .timeout }}
+  energy:
+    source: http
+    uri: http://{{ .host }}/production.json
+    method: GET
+    {{- if .token }}
+    auth:
+      type: bearer
+      password: {{ .token }}
+    insecure: true
+    {{- end }}
+    jq: .consumption[] | select(.measurementType == "net-consumption").whLifetime
+    scale: 0.001
+    timeout: {{ .timeout }}
   {{- end }}
   {{- if eq .usage "pv" }}
   power:
@@ -41,4 +57,18 @@ render: |
     {{- end }}
     jq: .production[] | select(.measurementType == "production").wNow
     scale: 1
+    timeout: {{ .timeout }}
+  energy:
+    source: http
+    uri: http://{{ .host }}/production.json
+    method: GET
+    {{- if .token }}
+    auth:
+      type: bearer
+      password: {{ .token }}
+    insecure: true
+    {{- end }}
+    jq: .production[] | select(.measurementType == "production").whLifetime
+    scale: 0.001
+    timeout: {{ .timeout }}
   {{- end }}

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -5,19 +5,38 @@ products:
       generic: IQ Envoy
 params:
   - name: usage
-    choice: ["pv"]
+    choice: ["grid", "pv"]
   - name: host
+    required: true
+  - name: token
     required: true
 render: |
   type: custom
+  {{- if eq .usage "pv" }}
   power:
     source: http
     uri: http://{{ .host }}/production.json
     method: GET
-    jq: .production[0].wNow
-  energy:
+    {{- if .token }}
+    auth:
+      type: bearer
+      password: {{ .token }}
+    insecure: true
+    {{- end }}
+    jq: .production[] | select(.measurementType == "production").wNow
+    scale: 1
+  {{- end }}
+  {{- if eq .usage "grid" }}
+  power:
     source: http
     uri: http://{{ .host }}/production.json
     method: GET
-    jq: .production[0].whLifetime
-    scale: 0.001
+    {{- if .token }}
+    auth:
+      type: bearer
+      password: {{ .token }}
+    insecure: true
+    {{- end }}
+    jq: .consumption[] | select(.measurementType == "net-consumption").wNow
+    scale: 1
+  {{- end }}

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -9,23 +9,8 @@ params:
   - name: host
     required: true
   - name: token
-    required: true
 render: |
   type: custom
-  {{- if eq .usage "pv" }}
-  power:
-    source: http
-    uri: http://{{ .host }}/production.json
-    method: GET
-    {{- if .token }}
-    auth:
-      type: bearer
-      password: {{ .token }}
-    insecure: true
-    {{- end }}
-    jq: .production[] | select(.measurementType == "production").wNow
-    scale: 1
-  {{- end }}
   {{- if eq .usage "grid" }}
   power:
     source: http
@@ -38,5 +23,19 @@ render: |
     insecure: true
     {{- end }}
     jq: .consumption[] | select(.measurementType == "net-consumption").wNow
+    scale: 1
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: http
+    uri: http://{{ .host }}/production.json
+    method: GET
+    {{- if .token }}
+    auth:
+      type: bearer
+      password: {{ .token }}
+    insecure: true
+    {{- end }}
+    jq: .production[] | select(.measurementType == "production").wNow
     scale: 1
   {{- end }}

--- a/templates/docs/meter/enphase_0.yaml
+++ b/templates/docs/meter/enphase_0.yaml
@@ -8,25 +8,25 @@ render:
       template: enphase
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
     advanced: |
       type: template
       template: enphase
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       timeout: 10s # Optional
-      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
   - usage: pv
     default: |
       type: template
       template: enphase
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
     advanced: |
       type: template
       template: enphase
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
       timeout: 10s # Optional
-      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)

--- a/templates/docs/meter/enphase_0.yaml
+++ b/templates/docs/meter/enphase_0.yaml
@@ -6,13 +6,13 @@ render:
     default: |
       type: template
       template: enphase
-      usage: pv
+      usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
   - usage: pv
     default: |
       type: template
       template: enphase
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)

--- a/templates/docs/meter/enphase_0.yaml
+++ b/templates/docs/meter/enphase_0.yaml
@@ -2,9 +2,17 @@ product:
   brand: Enphase
   description: IQ Envoy
 render:
+  - usage: grid
+    default: |
+      type: template
+      template: enphase
+      usage: pv
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication
   - usage: pv
     default: |
       type: template
       template: enphase
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
+      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication

--- a/templates/docs/meter/enphase_0.yaml
+++ b/templates/docs/meter/enphase_0.yaml
@@ -9,24 +9,10 @@ render:
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
       token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
-    advanced: |
-      type: template
-      template: enphase
-      usage: grid
-      host: 192.0.2.2 # IP-Adresse oder Hostname
-      timeout: 10s # Optional
-      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
   - usage: pv
     default: |
       type: template
       template: enphase
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
-    advanced: |
-      type: template
-      template: enphase
-      usage: pv
-      host: 192.0.2.2 # IP-Adresse oder Hostname
-      timeout: 10s # Optional
       token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)

--- a/templates/docs/meter/enphase_0.yaml
+++ b/templates/docs/meter/enphase_0.yaml
@@ -8,11 +8,25 @@ render:
       template: enphase
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+    advanced: |
+      type: template
+      template: enphase
+      usage: grid
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      timeout: 10s # Optional
+      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
   - usage: pv
     default: |
       type: template
       template: enphase
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
-      token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)
+    advanced: |
+      type: template
+      template: enphase
+      usage: pv
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      timeout: 10s # Optional
+      Token: # Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication (Optional)

--- a/templates/evcc.io/brands.json
+++ b/templates/evcc.io/brands.json
@@ -83,6 +83,7 @@
   "DZG",
   "E3/DC",
   "Eastron",
+  "Enphase",
   "FENECON",
   "FoxESS",
   "Fronius",


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/8146

Ab Firmware `D7.x.xxx` braucht man einen Token um auf die lokale API vom Enphase Envoy zuzugreifen. Da es vorher auch ohne Token geht, habe ich den Parameter optional gemacht.

Erfolgreich getestet mit Firmware `D7.6.125`. Bei Problemen mit früheren D7-Firmwares sollte am besten der Installateur oder Enphase erstmal ein aktuelles Update in den Envoy-S einspielen. 

Zusätzlich habe ich auch noch den `grid` hinzugefügt. `battery` kann ich leider mangels eigener Batterie nicht implementieren.