### PR TITLE
Easee: wait for pause/resume to be acknowledged

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
       ${{ needs.check_date.outputs.should_run != 'false' }}
       && startsWith(github.ref, 'refs/heads/master')
       && ! contains(github.head_ref, 'refs/heads/chore/')
-    uses: grimmimeloni/evcc/.github/workflows/default.yml@master
+    uses: evcc-io/evcc/.github/workflows/default.yml@master
 
   docker:
     name: Publish Docker :nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
       ${{ needs.check_date.outputs.should_run != 'false' }}
       && startsWith(github.ref, 'refs/heads/master')
       && ! contains(github.head_ref, 'refs/heads/chore/')
-    uses: evcc-io/evcc/.github/workflows/default.yml@master
+    uses: grimmimeloni/evcc/.github/workflows/default.yml@master
 
   docker:
     name: Publish Docker :nightly

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -482,7 +482,6 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 				return nil
 			}
 		case <-time.After(10 * time.Second):
-			c.log.TRACE.Printf("timeout, tick ID %d", expectedTick)
 			return os.ErrDeadlineExceeded
 		}
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -474,7 +474,6 @@ func decodeJSON(resp *http.Response, res interface{}) error {
 }
 
 func (c *Easee) waitForTickResponse(expectedTick int64) error {
-	c.log.TRACE.Printf("sent request, waiting for response, tick ID %d", expectedTick)
 	for {
 		select {
 		case cmdResp := <-c.respChan:

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -422,7 +422,7 @@ func (c *Easee) postJSONAndWait(uri string, data io.Reader) error {
 				return err
 			}
 
-			if cmd[0].Ticks == 0 { //Easee API ignored this call, retry
+			if len(cmd) == 0 || cmd[0].Ticks == 0 { //Easee API ignored this call, retry
 				continue
 			}
 			return c.waitForTickResponse(cmd[0].Ticks)

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -465,7 +465,7 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 				c.log.TRACE.Printf("received response, tick ID %d", cmdResp.Ticks)
 				return nil
 			}
-		case <-time.After(3 * time.Second):
+		case <-time.After(10 * time.Second):
 			return os.ErrDeadlineExceeded
 		}
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -327,7 +327,7 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 
 	select {
 	case c.respChan <- res:
-	default: //NoOp
+	default:
 	}
 }
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -327,8 +327,7 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 
 	select {
 	case c.respChan <- res:
-	default:
-		c.log.TRACE.Printf("CommandResponse %s arrived too late, ignoring: %+v", res.SerialNumber, res)
+	default: //NoOp
 	}
 }
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -482,7 +482,7 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 				return nil
 			}
 		case <-time.After(10 * time.Second):
-			return os.ErrDeadlineExceeded
+			return api.ErrTimeout
 		}
 	}
 }

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -448,7 +448,6 @@ func (c *Easee) postJSONAndWait(uri string, data io.ReadSeeker) error {
 			}
 
 			if cmd.Ticks == 0 { //Easee API ignored this call, retry
-				c.log.DEBUG.Printf("api call ignored, %d retries left", retriesLeft)
 				if _, err := data.Seek(0, io.SeekStart); err != nil {
 					return err
 				}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -463,7 +463,7 @@ func (c *Easee) postJSONAndWait(uri string, data io.ReadSeeker) error {
 	}
 
 	// retries exhausted
-	return errors.New("retries exhausted, API call failed")
+	return api.ErrTimeout
 }
 
 // decodeJSON reads HTTP response and decodes JSON body if error is nil

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -413,7 +413,7 @@ func (c *Easee) Enable(enable bool) error {
 }
 
 // posts JSON to the Easee API endpoint and waits for the async response
-func (c *Easee) postJSONAndWait(uri string, data io.ReadSeeker) error {
+func (c *Easee) postJSONAndWait(uri string, data any) error {
 	isCommand := strings.Contains(uri, "/commands/")
 
 	for retriesLeft := 2; retriesLeft >= 0; retriesLeft-- {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -417,15 +417,15 @@ func (c *Easee) postJSONAndWait(uri string, data io.Reader) error {
 		}
 
 		if resp.StatusCode == 202 { //async call, wait for response
-			var cmd easee.RestCommandResponse
+			var cmd []easee.RestCommandResponse
 			if err := decodeJSON(resp, &cmd); err != nil {
 				return err
 			}
 
-			if cmd.Ticks == 0 { //Easee API ignored this call, retry
+			if cmd[0].Ticks == 0 { //Easee API ignored this call, retry
 				continue
 			}
-			return c.waitForTickResponse(cmd.Ticks)
+			return c.waitForTickResponse(cmd[0].Ticks)
 		}
 
 		// all other response codes lead to an error

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -478,7 +478,6 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 		select {
 		case cmdResp := <-c.respChan:
 			if cmdResp.Ticks != expectedTick {
-				c.log.TRACE.Printf("unexpected response tickId, waiting for %d, but got ID %d", expectedTick, cmdResp.Ticks)
 			} else if !cmdResp.WasAccepted {
 				return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
 			} else {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -412,7 +412,7 @@ func (c *Easee) Enable(enable bool) error {
 // posts JSON to the Easee API endpoint and waits for the async response
 func (c *Easee) postJSONAndWait(uri string, isCommand bool, data io.ReadSeeker) error {
 
-	for retriesLeft := 2; retriesLeft > 0; retriesLeft-- {
+	for retriesLeft := 2; retriesLeft >= 0; retriesLeft-- {
 
 		resp, err := c.Post(uri, request.JSONContent, data)
 		if err != nil {
@@ -444,6 +444,7 @@ func (c *Easee) postJSONAndWait(uri string, isCommand bool, data io.ReadSeeker) 
 			}
 
 			if cmd.Ticks == 0 { //Easee API ignored this call, retry
+				c.log.DEBUG.Printf("Easee ignored API call, %d retries left", retriesLeft)
 				if _, err := data.Seek(0, io.SeekStart); err != nil {
 					return err
 				}
@@ -457,7 +458,7 @@ func (c *Easee) postJSONAndWait(uri string, isCommand bool, data io.ReadSeeker) 
 	}
 
 	//retries exhausted
-	return api.ErrMustRetry
+	return errors.New("retries exhausted, API call failed")
 }
 
 func (c *Easee) waitForTickResponse(expectedTick int64) error {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -414,7 +414,6 @@ func (c *Easee) Enable(enable bool) error {
 
 // posts JSON to the Easee API endpoint and waits for the async response
 func (c *Easee) postJSONAndWait(uri string, data io.ReadSeeker) error {
-
 	isCommand := strings.Contains(uri, "/commands/")
 
 	for retriesLeft := 2; retriesLeft >= 0; retriesLeft-- {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -388,7 +387,7 @@ func (c *Easee) Enable(enable bool) error {
 		}
 
 		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
-		if err := c.postJSONAndWait(uri, request.MarshalJSON(data)); err != nil {
+		if err := c.postJSONAndWait(uri, data); err != nil {
 			return err
 		}
 	}
@@ -417,7 +416,7 @@ func (c *Easee) postJSONAndWait(uri string, data any) error {
 	isCommand := strings.Contains(uri, "/commands/")
 
 	for retriesLeft := 2; retriesLeft >= 0; retriesLeft-- {
-		resp, err := c.Post(uri, request.JSONContent, data)
+		resp, err := c.Post(uri, request.JSONContent, request.MarshalJSON(data))
 		if err != nil {
 			return err
 		}
@@ -446,9 +445,6 @@ func (c *Easee) postJSONAndWait(uri string, data any) error {
 			}
 
 			if cmd.Ticks == 0 { //Easee API ignored this call, retry
-				if _, err := data.Seek(0, io.SeekStart); err != nil {
-					return err
-				}
 				time.Sleep(time.Second)
 				continue
 			}
@@ -497,7 +493,7 @@ func (c *Easee) MaxCurrent(current int64) error {
 	}
 
 	uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
-	if err := c.postJSONAndWait(uri, request.MarshalJSON(data)); err != nil {
+	if err := c.postJSONAndWait(uri, data); err != nil {
 		return err
 	}
 
@@ -543,7 +539,7 @@ func (c *Easee) Phases1p3p(phases int) error {
 			data.DynamicCircuitCurrentP3 = &max3
 		}
 
-		err = c.postJSONAndWait(uri, request.MarshalJSON(data))
+		err = c.postJSONAndWait(uri, data)
 	} else {
 		// charger level
 		if phases == 3 {
@@ -558,7 +554,7 @@ func (c *Easee) Phases1p3p(phases int) error {
 
 			uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
 
-			err = c.postJSONAndWait(uri, request.MarshalJSON(data))
+			err = c.postJSONAndWait(uri, data)
 		}
 	}
 
@@ -635,7 +631,7 @@ func (c *Easee) updateSmartCharging() {
 
 		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
 
-		err := c.postJSONAndWait(uri, request.MarshalJSON(data))
+		err := c.postJSONAndWait(uri, data)
 		if err != nil {
 			c.log.WARN.Printf("smart charging: %v", err)
 		}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -477,7 +477,6 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 				if !cmdResp.WasAccepted {
 					return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
 				}
-
 				return nil
 			}
 		case <-time.After(10 * time.Second):

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -476,7 +476,7 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 			if cmdResp.Ticks != expectedTick {
 				c.log.WARN.Printf("unexpected response tickId, waiting for %d, but got ID %d", expectedTick, cmdResp.Ticks)
 			} else if !cmdResp.WasAccepted {
-				return fmt.Errorf("easee rejected command, tick ID %d", cmdResp.Ticks)
+				return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
 			} else {
 				c.log.TRACE.Printf("received response, tick ID %d", cmdResp.Ticks)
 				return nil

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -473,10 +473,11 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 	for {
 		select {
 		case cmdResp := <-c.respChan:
-			if cmdResp.Ticks != expectedTick {
-			} else if !cmdResp.WasAccepted {
-				return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
-			} else {
+			if cmdResp.Ticks == expectedTick {
+				if !cmdResp.WasAccepted {
+					return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
+				}
+
 				return nil
 			}
 		case <-time.After(10 * time.Second):

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -484,7 +484,6 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 			} else if !cmdResp.WasAccepted {
 				return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
 			} else {
-				c.log.TRACE.Printf("received response: %d", cmdResp.Ticks)
 				return nil
 			}
 		case <-time.After(10 * time.Second):

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -451,7 +451,7 @@ func (c *Easee) postJSONAndWait(uri string, isCommand bool, data io.ReadSeeker) 
 		}
 
 		// all other response codes lead to an error
-		return fmt.Errorf("unexpected HTTP result code %d, response: %v", resp.StatusCode, resp)
+		return fmt.Errorf("invalid status: %d", resp.StatusCode)
 	}
 
 	// retries exhausted

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -448,6 +448,7 @@ func (c *Easee) postJSONAndWait(uri string, isCommand bool, data io.ReadSeeker) 
 				if _, err := data.Seek(0, io.SeekStart); err != nil {
 					return err
 				}
+				time.Sleep(time.Second)
 				continue
 			}
 			return c.waitForTickResponse(cmd.Ticks)

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -436,7 +436,9 @@ func (c *Easee) postJSONAndWait(uri string, isCommand bool, data io.ReadSeeker) 
 			}
 
 			if cmd.Ticks == 0 { //Easee API ignored this call, retry
-				data.Seek(0, io.SeekStart)
+				if _, err := data.Seek(0, io.SeekStart); err != nil {
+					return err
+				}
 				continue
 			}
 			return c.waitForTickResponse(cmd.Ticks)

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -408,7 +409,7 @@ func (c *Easee) Enable(enable bool) error {
 
 	var cmd easee.RestCommandResponse
 
-	err := c.PostJSON(uri, &cmd)
+	err := c.postJSON(uri, nil, &cmd)
 	if err == nil {
 		c.mux.Lock()
 		c.pauseResumeTicks = cmd.Ticks
@@ -616,8 +617,8 @@ func (c *Easee) LoadpointControl(lp loadpoint.API) {
 
 // PostJSON executes HTTP POST request and decodes JSON response.
 // It returns a StatusError on response codes other than HTTP 2xx.
-func (c *Easee) PostJSON(url string, res interface{}) error {
-	req, err := request.New(http.MethodPost, url, nil, request.AcceptJSON)
+func (c *Easee) postJSON(url string, data io.Reader, res interface{}) error {
+	req, err := request.New(http.MethodPost, url, data, request.AcceptJSON)
 	if err == nil {
 		err = c.Helper.DoJSON(req, &res)
 	}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/8398

I felt the need to address the parallel pause/resume situation described in https://github.com/evcc-io/evcc/discussions/7366#discussioncomment-6070713. 

I have taken the initial change which @naltatis implemented in https://github.com/evcc-io/evcc/pull/7597 to capture the ticks when sending pause/resume commands to the Easee cloud.
I have now added enforcement into Enable() to check if a reply for a previous pause or resume command is still outstanding. If so, Enable() returns an error, so that the operation will be retried on the next interval.
I decided to wait for a max of 30s, otherwise I consider the outstanding reply lost. This is a compromise to ensure we don't get stuck forever waiting, in case Easee decides to ignore/drop requests completely.

Did my best to do proper locking in case replies come in in parallel. I'd appreciate reviewer(s) to double check this, though.

@andig I have NOT tested this yet (car is charged up right now). Can you help me mark this as WIP, or is it sufficient to leave the PR in draft state until tested?