### PR TITLE
Fix smartCostLimit mqtt topic

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -246,7 +246,7 @@ func (m *MQTT) Run(site site.API, in <-chan util.Param) {
 		return err
 	})
 
-	m.Handler.ListenSetter(m.root+"/site/smartcostlimit/set", func(payload string) error {
+	m.Handler.ListenSetter(m.root+"/site/smartCostLimit/set", func(payload string) error {
 		val, err := parseFloat(payload)
 		if err == nil {
 			err = site.SetSmartCostLimit(val)


### PR DESCRIPTION
the current mqtt topic for smartCostLimit is not `evcc/site/smartcostlimit` but `evcc/site/smartCostLimit`. 

this pr fixes the setter.

fix for documentation: https://github.com/evcc-io/docs/pull/394

fixes #8327 