### PR TITLE
mazda2mqtt Timeout

### DIFF
--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -21,7 +21,7 @@ params:
     default: car
     advanced: true
   - name: timeout
-    default: 1h
+    default: 720h
     advanced: true
   - preset: vehicle-identify
 render: |

--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -12,8 +12,8 @@ params:
   - name: vin
     required: true
     help:
-      de: Erforderlich, so wie im MQTT-Broker unter /mazda2mqtt angezeigt.
-      en: Required, as displayed in the MQTT broker under /mazda2mqtt..
+      de: Erforderlich
+      en: Required
   - name: capacity
   - name: phases
     advanced: true

--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -5,12 +5,15 @@ products:
 group: generic
 requirements:
   description:
-    en: Required MQTT broker configuration and a mazda2mqtt installation https://github.com/C64Axel/mazda2mqtt
-    de: Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation https://github.com/C64Axel/mazda2mqtt
+    en: Required MQTT broker configuration and a mazda2mqtt installation https://github.com/C64Axel/mazda2mqtt.
+    de: Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation https://github.com/C64Axel/mazda2mqtt.
 params:
   - name: title
   - name: vin
     required: true
+    help:
+      de: Erforderlich, so wie im MQTT-Broker unter /mazda2mqtt angezeigt.
+      en: Required, as displayed in the MQTT broker under /mazda2mqtt..
   - name: capacity
   - name: phases
     advanced: true

--- a/templates/docs/vehicle/mazda2mqtt_0.yaml
+++ b/templates/docs/vehicle/mazda2mqtt_0.yaml
@@ -18,7 +18,7 @@ render:
       capacity: 50 # Akkukapazität in kWh (Optional)
       phases: 3 # Die maximale Anzahl der Phasen welche genutzt werden können (Optional)
       icon: car # Icon in der Benutzeroberfläche (Optional)
-      timeout: 1h # Optional
+      timeout: 720h # Optional
       mode: # Möglich sind Off, Now, MinPV und PV, oder leer wenn keiner definiert werden soll (Optional)
       minSoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (Optional)
       targetSoc: 80 # Bis zu welchem Ladestand (Soc) soll das Fahrzeug geladen werden (Optional)

--- a/templates/docs/vehicle/mazda2mqtt_0.yaml
+++ b/templates/docs/vehicle/mazda2mqtt_0.yaml
@@ -2,19 +2,19 @@ product:
   description: mazda2mqtt
   group: Generische Unterstützung
 description: |
-  Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation https://github.com/C64Axel/mazda2mqtt
+  Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation https://github.com/C64Axel/mazda2mqtt.
 render:
   - default: |
       type: template
       template: mazda2mqtt
       title: # Wird in der Benutzeroberfläche angezeigt (Optional)
-      vin: W... # Erforderlich, wenn mehrere Fahrzeuge des Herstellers vorhanden sind
+      vin: W... # Erforderlich, so wie im MQTT-Broker unter /mazda2mqtt angezeigt.
       capacity: 50 # Akkukapazität in kWh (Optional)
     advanced: |
       type: template
       template: mazda2mqtt
       title: # Wird in der Benutzeroberfläche angezeigt (Optional)
-      vin: W... # Erforderlich, wenn mehrere Fahrzeuge des Herstellers vorhanden sind
+      vin: W... # Erforderlich, so wie im MQTT-Broker unter /mazda2mqtt angezeigt.
       capacity: 50 # Akkukapazität in kWh (Optional)
       phases: 3 # Die maximale Anzahl der Phasen welche genutzt werden können (Optional)
       icon: car # Icon in der Benutzeroberfläche (Optional)

--- a/templates/docs/vehicle/mazda2mqtt_0.yaml
+++ b/templates/docs/vehicle/mazda2mqtt_0.yaml
@@ -8,13 +8,13 @@ render:
       type: template
       template: mazda2mqtt
       title: # Wird in der Benutzeroberfläche angezeigt (Optional)
-      vin: W... # Erforderlich, so wie im MQTT-Broker unter /mazda2mqtt angezeigt.
+      vin: W... # Erforderlich
       capacity: 50 # Akkukapazität in kWh (Optional)
     advanced: |
       type: template
       template: mazda2mqtt
       title: # Wird in der Benutzeroberfläche angezeigt (Optional)
-      vin: W... # Erforderlich, so wie im MQTT-Broker unter /mazda2mqtt angezeigt.
+      vin: W... # Erforderlich
       capacity: 50 # Akkukapazität in kWh (Optional)
       phases: 3 # Die maximale Anzahl der Phasen welche genutzt werden können (Optional)
       icon: car # Icon in der Benutzeroberfläche (Optional)


### PR DESCRIPTION
Da der refresh nicht mehr zyklisch ausgeführt werden kann kommen die Daten nicht mehr regelmäßig. Aus diesem Grund der hohe Timeout wie bei Teslamate