### PR TITLE
automatically switch session log energy unit

### DIFF
--- a/assets/js/components/ChargingSessionModal.vue
+++ b/assets/js/components/ChargingSessionModal.vue
@@ -67,7 +67,12 @@
 										{{ $t("sessions.energy") }}
 									</th>
 									<td>
-										{{ fmtKWh(session.chargedEnergy * 1e3) }}
+										{{
+											fmtKWh(
+												session.chargedEnergy * 1e3,
+												session.chargedEnergy >= 1
+											)
+										}}
 									</td>
 								</tr>
 								<tr v-if="session.solarPercentage != null">

--- a/assets/js/views/ChargingSessions.vue
+++ b/assets/js/views/ChargingSessions.vue
@@ -90,7 +90,12 @@
 											{{ session.vehicle }}
 										</td>
 										<td class="text-end">
-											{{ fmtKWh(session.chargedEnergy * 1e3) }}
+											{{
+												fmtKWh(
+													session.chargedEnergy * 1e3,
+													session.chargedEnergy >= 1
+												)
+											}}
 										</td>
 										<td class="text-end">
 											<span v-if="session.solarPercentage != null">


### PR DESCRIPTION
I use evcc to charge devices with small batteries (pedelecs, vacuum cleaner). Showing the charged energy only in kWh is too coarse for these devices, whose battery is usually smaller than 1 kWh.

This commit changes the session log and log detail views to show the charged energy in Wh for values below 1 kWh and in kWh for larger values.