### PR TITLE
Easee: update smartCharging state only if API call is OK

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -559,6 +559,7 @@ func (c *Easee) updateSmartCharging() {
 		}
 		if err != nil {
 			c.log.WARN.Printf("smart charging: %v", err)
+			return
 		}
 
 		c.mux.Lock()


### PR DESCRIPTION
In case of failed settings calls for the smart charging state, the internal state gets updated nevertheless. This change prevents the update, so evcc will retry on the next interval.

cc: @naltatis 