### PR TITLE
Fix ISO15118 vehicle

### DIFF
--- a/templates/definition/vehicle/iso15118.yaml
+++ b/templates/definition/vehicle/iso15118.yaml
@@ -29,4 +29,7 @@ render: |
   {{- if .phases }}
   phases: {{ .phases }}
   {{- end }}
+  soc: # fixed - Soc fetched via charger available
+    source: js
+    script: 0;
   {{ include "vehicle-identify" . }}


### PR DESCRIPTION
Such vehicles would be reported as `(Offline)` previously, as no Soc can be fetched and thus needs to behave as the `offline` template.

The SoC is fetched via the charger, so hardcode it to 0 in here