### PR TITLE
FoxESS H3: add grid

### DIFF
--- a/templates/definition/meter/fox-ess-h3-ethernet.yaml
+++ b/templates/definition/meter/fox-ess-h3-ethernet.yaml
@@ -35,6 +35,14 @@ render: |
         type: holding
         decode: int16
       scale: -1
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 31012 # Grid Consumption Total
+      type: holding
+      decode: uint32
+    scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/fox-ess-h3-ethernet.yaml
+++ b/templates/definition/meter/fox-ess-h3-ethernet.yaml
@@ -5,11 +5,37 @@ products:
       generic: H3 via Ethernet
 params:
   - name: usage
-    choice: ["pv", "battery"]
+    choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["tcpip"]
 render: |
   type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 31026 # Meter Power R
+        type: holding
+        decode: int16
+      scale: -1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 31027 # Meter Power S
+        type: holding
+        decode: int16
+      scale: -1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 31028 # Meter Power T
+        type: holding
+        decode: int16
+      scale: -1
+  {{- end }}
   {{- if eq .usage "pv" }}
   power:
     source: calc

--- a/templates/docs/meter/fox-ess-h3_0.yaml
+++ b/templates/docs/meter/fox-ess-h3_0.yaml
@@ -2,6 +2,17 @@ product:
   brand: FoxESS
   description: H3 via Ethernet
 render:
+  - usage: grid
+    default: |
+      type: template
+      template: fox-ess-h3
+      usage: grid
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
   - usage: pv
     default: |
       type: template


### PR DESCRIPTION
Es gab auch Meldungen, der H3 könne nur rs485. Im Moment haben die Templates einen komischen Zustand- es gibt h1, h3 und rs485. Wirkt inkonsistent, ich wüsste aber nicht, wie wir das sortieren sollten?