### PR TITLE
Improve CSV Download Buttons Layout for Small Screens

### DIFF
--- a/assets/js/views/ChargingSessions.vue
+++ b/assets/js/views/ChargingSessions.vue
@@ -199,10 +199,10 @@
 						</tbody>
 					</table>
 				</div>
-				<div class="d-flex mb-5 my-4">
+				<div class="d-grid gap-2 d-sm-block mt-3 mb-5">
 					<a
 						v-if="currentSessions.length"
-						class="btn btn-outline-secondary text-nowrap me-3"
+						class="btn btn-outline-secondary text-nowrap me-sm-2"
 						:href="csvLink"
 						download
 					>


### PR DESCRIPTION
fixes #8482

large screen
<img width="405" alt="Bildschirmfoto 2023-06-16 um 23 34 23" src="https://github.com/evcc-io/evcc/assets/152287/f26bfb8c-c072-4eb5-9d50-723b6bc8e60a">

small screen
<img width="973" alt="Bildschirmfoto 2023-06-16 um 23 34 43" src="https://github.com/evcc-io/evcc/assets/152287/fe901a51-1d91-458b-b830-921e95d0793f">

