### PR TITLE
Ocpp: use default transaction profile

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -375,7 +375,7 @@ func getTxChargingProfile(current float64, phases int) *types.ChargingProfile {
 	return &types.ChargingProfile{
 		ChargingProfileId:      1,
 		StackLevel:             0,
-		ChargingProfilePurpose: types.ChargingProfilePurposeTxProfile,
+		ChargingProfilePurpose: types.ChargingProfilePurposeTxDefaultProfile,
 		ChargingProfileKind:    types.ChargingProfileKindRelative,
 		ChargingSchedule: &types.ChargingSchedule{
 			ChargingRateUnit:       types.ChargingRateUnitAmperes,


### PR DESCRIPTION
/cc @premultiply 