### PR TITLE
Add Sonnenbatterie comfort, eco 5, eco 6, oem 6.5

### DIFF
--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -15,15 +15,9 @@ render: |
   type: custom
   {{- if eq .usage "grid" }}
   power:
-    source: calc
-    add:
-    - source: http
-      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
-      jq: .M39 # current purchase at the interconnection point
-    - source: http
-      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
-      jq: .M38 # current feed-in at the interconnection point
-      scale: -1
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    jq: .M39 - .M38 # current purchase - current feed-in at the interconnection point
   energy:
     source: http
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
@@ -41,20 +35,11 @@ render: |
   {{- end }}
   {{- if eq .usage "battery" }}
   power:
-    source: calc
-    add:
-    # The API is bugged and returns 65525 instead of 0 in some cases
-    - source: http
-      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
-      # M35 current charging power
-      # S65 max inverter power
-      jq: "if .M35 <= .S65 then .M35 else 0 end"
-      scale: -1
-    - source: http
-      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
-      # M34 current discharging power
-      # S65 max inverter power
-      jq: "if .M34 <= .S65 then .M34 else 0 end"
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    # M34 current discharging power, S65 max inverter power
+    # M35 current charging power, S65 max inverter power
+    jq: (if .M34 <= .S65 then .M34 else 0 end) - (if .M35 <= .S65 then .M35 else 0 end)
   energy:
     source: http
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
@@ -62,8 +47,7 @@ render: |
   soc:
     source: http
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
-    jq: .M30 # SOC relative to usable capacity
-    #jq: .M05 # display SOC
+    jq: .M30 # SOC relative to usable capacity (.M05 # display SOC)
   {{- if .capacity }}
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -1,0 +1,70 @@
+template: sonnenbatterie-eco56
+products:
+  - brand: Sonnenbatterie
+    description:
+      generic: comfort, eco 5, eco 6, oem 6.5
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+  - name: host
+  - name: port
+    default: 7979
+  - name: capacity
+    advanced: true
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: calc
+    add:
+    - source: http
+      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+      jq: .M39 # current purchase at the interconnection point
+    - source: http
+      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+      jq: .M38 # current feed-in at the interconnection point
+      scale: -1
+  energy:
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    jq: .M41 # cumulated purchase since installation
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    jq: .M03 # current pv power
+  energy:
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    jq: .M37 # cumulated pv production since installation of Sonnenbatterie
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: calc
+    add:
+    # The API is bugged and returns 65525 instead of 0 in some cases
+    - source: http
+      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+      # M35 current charging power
+      # S65 max inverter power
+      jq: "if .M35 <= .S65 then .M35 else 0 end"
+      scale: -1
+    - source: http
+      uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+      # M34 current discharging power
+      # S65 max inverter power
+      jq: "if .M34 <= .S65 then .M34 else 0 end"
+  energy:
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    jq: .M31 # total stored energy over lifetime
+  soc:
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    jq: .M30 # SOC relative to usable capacity
+    #jq: .M05 # display SOC
+  {{- if .capacity }}
+  capacity: {{ .capacity }} # kWh
+  {{- end }}
+  {{- end }}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -1,6 +1,6 @@
 template: sonnenbatterie-eco56
 products:
-  - brand: Sonnenbatterie
+  - brand: Sonnen
     description:
       generic: comfort, eco 5, eco 6, oem 6.5
 params:

--- a/templates/docs/meter/sonnenbatterie-eco56_0.yaml
+++ b/templates/docs/meter/sonnenbatterie-eco56_0.yaml
@@ -1,0 +1,44 @@
+product:
+  brand: Sonnen
+  description: comfort, eco 5, eco 6, oem 6.5
+render:
+  - usage: grid
+    default: |
+      type: template
+      template: sonnenbatterie-eco56
+      usage: grid
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      port: 7979 # Port (Optional)
+    advanced: |
+      type: template
+      template: sonnenbatterie-eco56
+      usage: grid
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      port: 7979 # Port (Optional)
+  - usage: pv
+    default: |
+      type: template
+      template: sonnenbatterie-eco56
+      usage: pv
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      port: 7979 # Port (Optional)
+    advanced: |
+      type: template
+      template: sonnenbatterie-eco56
+      usage: pv
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      port: 7979 # Port (Optional)
+  - usage: battery
+    default: |
+      type: template
+      template: sonnenbatterie-eco56
+      usage: battery
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      port: 7979 # Port (Optional)
+    advanced: |
+      type: template
+      template: sonnenbatterie-eco56
+      usage: battery
+      host: 192.0.2.2 # IP-Adresse oder Hostname
+      port: 7979 # Port (Optional)
+      capacity: 50 # Akkukapazität in kWh (Optional)


### PR DESCRIPTION
This adds support for the Sonnenbatterie API in the older comfort, eco 5, eco 6, oem 6.5 batteries(at least according to the API documentation. I am running this with an eco 6.