### PR TITLE
Go-E: set default cache duration

### DIFF
--- a/charger/go-e.go
+++ b/charger/go-e.go
@@ -45,10 +45,12 @@ func init() {
 
 // NewGoEFromConfig creates a go-e charger from generic config
 func NewGoEFromConfig(other map[string]interface{}) (api.Charger, error) {
-	var cc struct {
+	cc := struct {
 		Token string
 		URI   string
 		Cache time.Duration
+	}{
+		Cache: time.Second,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/8703

Set cache default duration to 1s to relax go-e from multiple requests.

Refer to discussion #8694
