### PR TITLE
Add TapoP100 login retry on login error

### DIFF
--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -294,7 +294,10 @@ func (d *Connection) DoSecureRequest(uri string, taporequest map[string]interfac
 
 	// Login atempt in case of tapo switch connection hicups
 	if res.ErrorCode == 9999 {
-		d.Login()
+		if err := d.Login(); err != nil {
+			return nil, err
+		}
+
 		if err := d.DoJSON(req, &res); err != nil {
 			return nil, err
 		}

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -327,6 +327,10 @@ func (d *Connection) CheckErrorCode(errorCode int) error {
 		-1501: "Invalid Request or Credentials",
 	}
 
+	if errorCode == 9999 {
+		d.Login()
+	}
+
 	if errorCode != 0 {
 		return fmt.Errorf("tapo error %d: %s", errorCode, errorDesc[errorCode])
 	}

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -292,6 +292,14 @@ func (d *Connection) DoSecureRequest(uri string, taporequest map[string]interfac
 		return nil, err
 	}
 
+	// Login atempt in case of tapo switch connection hicups
+	if res.ErrorCode == 9999 {
+		d.Login()
+		if err := d.DoJSON(req, &res); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := d.CheckErrorCode(res.ErrorCode); err != nil {
 		return nil, err
 	}
@@ -325,10 +333,6 @@ func (d *Connection) CheckErrorCode(errorCode int) error {
 		-1010: "Invalid Public Key Length",
 		-1012: "Invalid terminalUUID",
 		-1501: "Invalid Request or Credentials",
-	}
-
-	if errorCode == 9999 {
-		d.Login()
 	}
 
 	if errorCode != 0 {


### PR DESCRIPTION
When disconnecting/connecting Tapo P110 switches sometimes the "Login failed, invalid user or password" error occurs (in my case endlessly).
In that case only restarting evcc would fix that issue.
Calling the login function will fix that issue (if user and password are correct of course) without restarting evcc.

Wenn man Tapo P110 Steckdosen kurz aus und wieder einsteckt kommt manchmal der Fehler "Login failed, invalid user or password" (in meinem Fall kommt diese Fehlermeldung dann endlos immer wieder).
Ein Aufruf der login Funktion behebt den Fehler (natürlich nur wenn user und password stimmen) ohne evcc neu starten zu müssen.