### PR TITLE
Allow negative Disable.Threshold values

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1101,7 +1101,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64, batter
 		return minCurrent
 	}
 
-	if mode == api.ModePV && lp.enabled && targetCurrent < minCurrent {
+	if mode == api.ModePV && lp.enabled && (targetCurrent < minCurrent || lp.Disable.Threshold < 0) {
 		// kick off disable sequence
 		if sitePower >= lp.Disable.Threshold && lp.phaseTimer.IsZero() {
 			lp.log.DEBUG.Printf("site power %.0fW >= %.0fW disable threshold", sitePower, lp.Disable.Threshold)


### PR DESCRIPTION
Use case: cooler should only run on "huge" pv surplus.
The cooler should be disabled on a negative threshold value (an not as usual on positive or zero threshold value).

Anwendung: Die Klimaanlage soll nur bei "großem" PV Überschuss laufen.
Die Klimaanlage soll bei einer negativen Schwelle bereits wieder ausgeschalten werden (und nicht wie üblich bei einer positiven Schwelle oder 0).