### PR TITLE
Add Sungrow SH Winet-S patch template

### DIFF
--- a/templates/definition/meter/sungrow-hybrid-winets.yaml
+++ b/templates/definition/meter/sungrow-hybrid-winets.yaml
@@ -1,0 +1,101 @@
+template: sungrow-hybrid-winets
+covers: ["sungrow"]
+products:
+  - brand: Sungrow
+    description:
+      generic: SH Series Hybrid Inverter
+requirements:
+  description:
+    de: Die Verbindung ist nur seriell (RS485) oder TCP (mit dem WiNet-S-Dongle) möglich.
+    en: Communication is either serial (RS485) or via TCP (WiNet-S-Dongle).
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+    allinone: true
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+    baudrate: 9600
+  - name: capacity
+    advanced: true
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      type: input
+      address: 13009 # Export power
+      decode: int32s
+    scale: -1
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 13036 # Total Import Energy, 0.1kWh
+      type: input
+      decode: uint32s
+    scale: 0.1
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 5016 # Total DC power
+      type: input
+      decode: uint32s
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 13002 # Total PV Generation, 0.1kWh
+      type: input
+      decode: uint32s
+    scale: 0.1
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 13007 # Load power
+        type: input
+        decode: uint32s
+    - source: calc
+      add:
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          type: input
+          address: 5016 # Total DC power
+          decode: uint32s
+        scale: -1
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          type: input
+          address: 13009 # Export power
+          decode: int32s
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 13026 # Total battery discharge energy, 0.1kWh
+      type: input
+      decode: uint32s
+    scale: 0.1
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 13022 # Battery level
+      type: input
+      decode: int16
+    scale: 0.1
+  {{- if .capacity }}
+  capacity: {{ .capacity }} # kWh
+  {{- end }}
+  {{- end }}

--- a/templates/docs/meter/sungrow-hybrid-winets_0.yaml
+++ b/templates/docs/meter/sungrow-hybrid-winets_0.yaml
@@ -1,0 +1,150 @@
+product:
+  brand: Sungrow
+  description: SH Series Hybrid Inverter
+description: |
+  Die Verbindung ist nur seriell (RS485) oder TCP (mit dem WiNet-S-Dongle) möglich.
+  Die Batterieleistung wird nicht ausgelesen sondern berechnet. Das kann möglicherweise
+  zu fehlerhaften Batteriewerten in Kombination mit weiteren Invertern/Batterien führen.
+render:
+  - usage: grid
+    default: |
+      type: template
+      template: sungrow-hybrid-winets
+      usage: grid
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+    advanced: |
+      type: template
+      template: sungrow-hybrid-winets
+      usage: grid
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+  - usage: pv
+    default: |
+      type: template
+      template: sungrow-hybrid-winets
+      usage: pv
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+    advanced: |
+      type: template
+      template: sungrow-hybrid-winets
+      usage: pv
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+  - usage: battery
+    default: |
+      type: template
+      template: sungrow-hybrid-winets
+      usage: battery
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+    advanced: |
+      type: template
+      template: sungrow-hybrid-winets
+      usage: battery
+
+      # RS485 via adapter (Modbus RTU)
+      modbus: rs485serial
+      id: 1
+      device: /dev/ttyUSB0 # USB-RS485 Adapter Adresse
+      baudrate: 9600 # Prüfe die Geräteeinstellungen, typische Werte sind 9600, 19200, 38400, 57600, 115200
+      comset: "8N1" # Kommunikationsparameter für den Adapter
+
+      # RS485 via TCP/IP (Modbus RTU)
+      modbus: rs485tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host: 192.0.2.2 # Hostname
+      port: 502 # Port
+      capacity: 50 # Akkukapazität in kWh (Optional)


### PR DESCRIPTION
This template can be used with Sungrow SH hybrid inverters without additional inverters/batteries on the same site.
The battery power is not read from (faulty) modbus register but calculated instead.
Incoming power = outgoing power: if pv, grid and consumer power is known the remaining power is the battery power (both directions).

Diese Vorlage kann für Sungrow SH Hybridwechselrichter ohne weitere Wechselrichter/Batterien im selben Netz verwendet werden.
Die Batterieleistung wird berechnet und nicht aus dem (fehlerhaften) Modbus Register ausgelesen.
Eingangsleistung = Ausgangsleistung: wenn PV, Netz und Verbrauch bekannt sind bleibt die Batterieleistung übrig (laden und entladen).