### PR TITLE
Fix `plant` generation in configure process

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -6,7 +6,6 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/evcc-io/evcc/util/machine"
 	"github.com/evcc-io/evcc/util/templates"
 )
 
@@ -122,10 +121,6 @@ func (c *Configure) RenderConfiguration() ([]byte, error) {
 	if err != nil {
 		panic(err)
 	}
-
-	// Assign random plant id. Don't use actual machine-id as file might
-	// be copied around to a different machine.
-	c.config.Plant = machine.RandomID()
 
 	out := new(bytes.Buffer)
 	err = tmpl.Execute(out, c.config)

--- a/cmd/configure/main.go
+++ b/cmd/configure/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evcc-io/evcc/hems/semp"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/machine"
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"golang.org/x/exp/maps"
@@ -69,6 +70,14 @@ func (c *CmdConfigure) Run(log *util.Logger, flagLang string, advancedMode, expa
 	c.localizer = i18n.NewLocalizer(bundle, c.lang)
 
 	c.setDefaultTexts()
+
+	// Assign random plant id. Don't use actual machine-id as file might
+	// be copied around to a different machine.
+	c.configuration.config.Plant = machine.RandomID()
+
+	if err = machine.CustomID(c.configuration.config.Plant); err != nil {
+		panic(err)
+	}
 
 	fmt.Println()
 	fmt.Println(c.localizedString("Intro"))


### PR DESCRIPTION
The `plant` should be set at the beginning of the configuration proecss and used to set the machine `CustomID` as evcc does when starting up with a config file.

Fixes https://github.com/evcc-io/evcc/issues/8775