### PR TITLE
Updated deprecated GoReleaser tap use

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,7 +87,7 @@ nfpms:
       postremove: ./packaging/scripts/postremove.sh
 
 brews:
-  - tap:
+  - repository:
       owner: evcc-io
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
In the brews section of GoReleaser, an update has been made regarding the utilization of the "tap" functionality. As of June 13, 2023, "tap" has been marked as deprecated. It is important to note that this change does not impact the functionality or behavior of the release mechanism.