### PR TITLE
chore: fix vehicle connected status when only the cable is connected to the charging station

### DIFF
--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -168,10 +168,10 @@ func (wb *Keba) Status() (api.ChargeStatus, error) {
 	}
 
 	switch status := binary.BigEndian.Uint32(b); status {
-	case 0, 3:
+	case 0, 1, 3:
 		return api.StatusA, nil
 
-	case 1, 5:
+	case 5:
 		return api.StatusB, nil
 
 	case 7:


### PR DESCRIPTION
According to the Keba modbus documentation status 1 means that only the  cable is connected to the EV Charger and not to the vehicle.
Therefore the status 1 should indicate an api.Status A instead of B, or does it have any other reason that it should be status B?