### PR TITLE
i18n: energy format in subunit

### DIFF
--- a/assets/js/components/BatterySettingsModal.vue
+++ b/assets/js/components/BatterySettingsModal.vue
@@ -364,7 +364,6 @@ export default {
 		bufferStartOptionToSoc(option) {
 			const bufferSoc = this.selectedBufferSoc;
 			const bufferHeight = 100 - bufferSoc;
-			console.log("bufferStartOptionToSoc", { bufferSoc, bufferHeight, option });
 			switch (option) {
 				case "low":
 					return bufferSoc + bufferHeight * 0.2;

--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -23,20 +23,29 @@
 		<div class="details" :style="{ height: detailsHeight }">
 			<div ref="detailsInner" class="details-inner row">
 				<div class="col-12 d-flex justify-content-between pt-2 mb-4">
-					<div class="d-flex flex-nowrap align-items-center">
+					<div class="d-flex flex-nowrap align-items-center text-truncate">
 						<span class="color-self me-2"
 							><shopicon-filled-square></shopicon-filled-square
 						></span>
-						<span>{{ $t("main.energyflow.selfConsumption") }}</span>
+						<span class="text-nowrap text-truncate">
+							{{ $t("main.energyflow.selfConsumption") }}
+						</span>
 					</div>
-					<div v-if="gridImport > 0" class="d-flex flex-nowrap align-items-center">
-						<span>{{ $t("main.energyflow.gridImport") }}</span>
+					<div
+						v-if="gridImport > 0"
+						class="d-flex flex-nowrap align-items-center text-truncate"
+					>
+						<span class="text-nowrap text-truncate">
+							{{ $t("main.energyflow.gridImport") }}
+						</span>
 						<span class="color-grid ms-2"
 							><shopicon-filled-square></shopicon-filled-square
 						></span>
 					</div>
-					<div v-else class="d-flex flex-nowrap align-items-center">
-						<span>{{ $t("main.energyflow.pvExport") }}</span>
+					<div v-else class="d-flex flex-nowrap align-items-center text-truncate">
+						<span class="text-nowrap text-truncate">
+							{{ $t("main.energyflow.pvExport") }}
+						</span>
 						<span class="color-export ms-2"
 							><shopicon-filled-square></shopicon-filled-square
 						></span>

--- a/assets/js/components/Energyflow/EnergyflowEntry.vue
+++ b/assets/js/components/Energyflow/EnergyflowEntry.vue
@@ -5,7 +5,7 @@
 			<VehicleIcon v-else-if="isVehicle" :names="vehicleIcons" />
 			<component :is="`shopicon-regular-${icon}`" v-else></component>
 		</span>
-		<span class="text-nowrap flex-grow-1 ms-3">
+		<span class="text-nowrap flex-grow-1 ms-3 text-truncate">
 			{{ name }}
 		</span>
 		<span class="text-end text-nowrap ps-1 fw-bold d-flex">

--- a/assets/js/mixins/formatter.js
+++ b/assets/js/mixins/formatter.js
@@ -1,3 +1,19 @@
+// list of currencies where energy price should be displayed in subunits (factor 100)
+const ENERGY_PRICE_IN_SUBUNIT = {
+  AUD: "c", // Australian cent
+  BGN: "st", // Bulgarian stotinka
+  BRL: "¢", // Brazilian centavo
+  CAD: "¢", // Canadian cent
+  CHF: "rp", // Swiss Rappen
+  CNY: "f", // Chinese fen
+  EUR: "ct", // Euro cent
+  GBP: "p", // GB pence
+  ILS: "ag", // Israeli agora
+  NZD: "c", // New Zealand cent
+  PLN: "gr", // Polish grosz
+  USD: "¢", // US cent
+};
+
 export default {
   data: function () {
     return {
@@ -201,7 +217,7 @@ export default {
       let value = amout;
       let minimumFractionDigits = 1;
       let maximumFractionDigits = 3;
-      if (["EUR", "USD"].includes(currency)) {
+      if (ENERGY_PRICE_IN_SUBUNIT[currency]) {
         value *= 100;
         minimumFractionDigits = 1;
         maximumFractionDigits = 1;
@@ -217,10 +233,7 @@ export default {
       return price;
     },
     pricePerKWhUnit: function (currency = "EUR", short = false) {
-      let unit = currency;
-      if (["EUR", "USD"].includes(currency)) {
-        unit = "ct";
-      }
+      const unit = ENERGY_PRICE_IN_SUBUNIT[currency] || currency;
       return `${unit}${short ? "" : "/kWh"}`;
     },
     fmtTimeAgo: function (elapsed) {

--- a/assets/js/mixins/formatter.test.js
+++ b/assets/js/mixins/formatter.test.js
@@ -31,9 +31,10 @@ describe("fmtPricePerKWh", () => {
   test("should format with units", () => {
     expect(fmt.fmtPricePerKWh(0.2, "EUR")).eq("20,0 ct/kWh");
     expect(fmt.fmtPricePerKWh(0.2, "EUR", true)).eq("20,0 ct");
-    expect(fmt.fmtPricePerKWh(0.234, "USD")).eq("23,4 ct/kWh");
+    expect(fmt.fmtPricePerKWh(0.234, "USD")).eq("23,4 ¢/kWh");
     expect(fmt.fmtPricePerKWh(1234, "SEK")).eq("1.234,0 SEK/kWh");
     expect(fmt.fmtPricePerKWh(0.2, "EUR", false, false)).eq("20,0");
+    expect(fmt.fmtPricePerKWh(0.123, "CHF")).eq("12,3 rp/kWh");
   });
 });
 
@@ -41,8 +42,9 @@ describe("pricePerKWhUnit", () => {
   test("should return correct unit", () => {
     expect(fmt.pricePerKWhUnit("EUR")).eq("ct/kWh");
     expect(fmt.pricePerKWhUnit("EUR", true)).eq("ct");
-    expect(fmt.pricePerKWhUnit("USD")).eq("ct/kWh");
+    expect(fmt.pricePerKWhUnit("USD")).eq("¢/kWh");
     expect(fmt.pricePerKWhUnit("SEK")).eq("SEK/kWh");
     expect(fmt.pricePerKWhUnit("SEK", true)).eq("SEK");
+    expect(fmt.pricePerKWhUnit("CHF")).eq("rp/kWh");
   });
 });


### PR DESCRIPTION
- formatting energy price in currency submit where appropriate: `38 rp/kWh` instead of `0,38 CHF/kWh`
- minor layout fixes for long translation texts