### PR TITLE
Clarification of Elli wallboxes are supported best

### DIFF
--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -26,6 +26,8 @@ requirements:
 
       Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+      Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+
       Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
     en: |
       The device has to have a fix IP address (manuall or via DHCP).
@@ -34,6 +36,8 @@ requirements:
 
       The support is in beta state and problems can occur!
 
+      Important: A mostly flawless functionality can only be provided with an external energy meter, due to sosftware bugs of the Wallbox.
+        
       Note: If you've added an energy meter to your charger please use the Pro or Connected+ integration.
 params:
   - preset: eebus

--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -37,7 +37,7 @@ requirements:
       The support is in beta state and problems can occur!
 
       Important: A mostly flawless functionality can only be provided with an external energy meter and no usage of CT coils, due to sosftware bugs of the Wallbox. Using a LAN connection is highly recommended.
-      
+
       Note: If you've added an energy meter to your charger please use the Pro or Connected+ integration.
 params:
   - preset: eebus

--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -24,8 +24,6 @@ requirements:
 
       Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-      Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
       Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
       Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
@@ -33,8 +31,6 @@ requirements:
       The device has to have a fix IP address (manuall or via DHCP).
 
       The identification of a vehicle using the RFID card is not possible.
-
-      The support is in beta state and problems can occur!
 
       Important: A mostly flawless functionality can only be provided with an external energy meter and no usage of CT coils, due to sosftware bugs of the Wallbox. Using a LAN connection is highly recommended.
 

--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -26,7 +26,7 @@ requirements:
 
       Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
-      Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+      Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
       Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
     en: |
@@ -36,8 +36,8 @@ requirements:
 
       The support is in beta state and problems can occur!
 
-      Important: A mostly flawless functionality can only be provided with an external energy meter, due to sosftware bugs of the Wallbox.
-        
+      Important: A mostly flawless functionality can only be provided with an external energy meter and no usage of CT coils, due to sosftware bugs of the Wallbox. Using a LAN connection is highly recommended.
+      
       Note: If you've added an energy meter to your charger please use the Pro or Connected+ integration.
 params:
   - preset: eebus

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -25,12 +25,16 @@ requirements:
       Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
       Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
+
+      Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
     en: |
       The device has to have a fix IP address (manuall or via DHCP).
 
       The identification of a vehicle using the RFID card is not possible.
 
       The support is in beta state and problems can occur!
+
+      Important: A mostly flawless functionality can only be provided with an external energy meter and no usage of CT coils, due to sosftware bugs of the Wallbox.  Using a LAN connection is highly recommended.
 params:
   - preset: eebus
   - name: ip

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -24,15 +24,11 @@ requirements:
 
       Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-      Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
       Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
     en: |
       The device has to have a fix IP address (manuall or via DHCP).
 
       The identification of a vehicle using the RFID card is not possible.
-
-      The support is in beta state and problems can occur!
 
       Important: A mostly flawless functionality can only be provided with an external energy meter and no usage of CT coils, due to sosftware bugs of the Wallbox.  Using a LAN connection is highly recommended.
 params:

--- a/templates/docs/charger/elliconnect_0.yaml
+++ b/templates/docs/charger/elliconnect_0.yaml
@@ -10,7 +10,7 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
-  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 

--- a/templates/docs/charger/elliconnect_0.yaml
+++ b/templates/docs/charger/elliconnect_0.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.

--- a/templates/docs/charger/elliconnect_0.yaml
+++ b/templates/docs/charger/elliconnect_0.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 
 render:

--- a/templates/docs/charger/elliconnect_1.yaml
+++ b/templates/docs/charger/elliconnect_1.yaml
@@ -10,7 +10,7 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
-  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 

--- a/templates/docs/charger/elliconnect_1.yaml
+++ b/templates/docs/charger/elliconnect_1.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.

--- a/templates/docs/charger/elliconnect_1.yaml
+++ b/templates/docs/charger/elliconnect_1.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 
 render:

--- a/templates/docs/charger/elliconnect_2.yaml
+++ b/templates/docs/charger/elliconnect_2.yaml
@@ -10,7 +10,7 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
-  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 

--- a/templates/docs/charger/elliconnect_2.yaml
+++ b/templates/docs/charger/elliconnect_2.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.

--- a/templates/docs/charger/elliconnect_2.yaml
+++ b/templates/docs/charger/elliconnect_2.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 
 render:

--- a/templates/docs/charger/elliconnect_3.yaml
+++ b/templates/docs/charger/elliconnect_3.yaml
@@ -10,7 +10,7 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
-  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 

--- a/templates/docs/charger/elliconnect_3.yaml
+++ b/templates/docs/charger/elliconnect_3.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.

--- a/templates/docs/charger/elliconnect_3.yaml
+++ b/templates/docs/charger/elliconnect_3.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 
 render:

--- a/templates/docs/charger/elliconnect_4.yaml
+++ b/templates/docs/charger/elliconnect_4.yaml
@@ -10,7 +10,7 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
-  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 

--- a/templates/docs/charger/elliconnect_4.yaml
+++ b/templates/docs/charger/elliconnect_4.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.

--- a/templates/docs/charger/elliconnect_4.yaml
+++ b/templates/docs/charger/elliconnect_4.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler möglich!
+
   Hinweis: Wenn du deiner Wallbox nachträglich einen Energiezähler hinzugefügt hast, nutze bitte die Pro bzw. Connected+ Integration.
 
 render:

--- a/templates/docs/charger/ellipro_0.yaml
+++ b/templates/docs/charger/ellipro_0.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
+
 render:
   - default: |
       type: template

--- a/templates/docs/charger/ellipro_0.yaml
+++ b/templates/docs/charger/ellipro_0.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
 render:

--- a/templates/docs/charger/ellipro_1.yaml
+++ b/templates/docs/charger/ellipro_1.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
+
 render:
   - default: |
       type: template

--- a/templates/docs/charger/ellipro_1.yaml
+++ b/templates/docs/charger/ellipro_1.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
 render:

--- a/templates/docs/charger/ellipro_2.yaml
+++ b/templates/docs/charger/ellipro_2.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
+
 render:
   - default: |
       type: template

--- a/templates/docs/charger/ellipro_2.yaml
+++ b/templates/docs/charger/ellipro_2.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
 render:

--- a/templates/docs/charger/ellipro_3.yaml
+++ b/templates/docs/charger/ellipro_3.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
+
 render:
   - default: |
       type: template

--- a/templates/docs/charger/ellipro_3.yaml
+++ b/templates/docs/charger/ellipro_3.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
 render:

--- a/templates/docs/charger/ellipro_4.yaml
+++ b/templates/docs/charger/ellipro_4.yaml
@@ -10,6 +10,8 @@ description: |
 
   Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
 
+  Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
+
 render:
   - default: |
       type: template

--- a/templates/docs/charger/ellipro_4.yaml
+++ b/templates/docs/charger/ellipro_4.yaml
@@ -8,8 +8,6 @@ description: |
 
   Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
 
-  Die Unterstützung ist im Beta Stadium und es kann noch zu Problemen kommen!
-
   Wichtig: Die möglichst reibungslose Funktionalität ist aufgrund von Software-Fehlern in der Wallbox nur mit einem externen Energiezähler und ohne Stromwandlerspulen möglich! Eine LAN Anbindung wird sehr empfohlen.
 
 render:


### PR DESCRIPTION
The current Elli wallboxes contain lots of software bugs, which make their usage and also support a nightmare.

Only the following two scenarios provide a somehow stable environment which can be “recommended”:

- Elli Pro: No CT coil usage, LAN connection. If a LAN connection is not possible, addition of an external meter
- Elli Pro: No CT coil usage, external meter usage.

A LAN connection is always highly recommended, as even the slightest network connection drop will allow charging of the car with minimal power until reconnection is establied.

There is no workaround for the wallbox software crashing often on connection attempts which can take a few minutes for the connection to work. During that time the EV is allowed to charge with minimal power.