### PR TITLE
Tapo Switch Sockets: Add missing login errorcheck

### DIFF
--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -104,6 +104,10 @@ func (d *Connection) Login() error {
 		return err
 	}
 
+	if err := d.CheckErrorCode(res.ErrorCode); err != nil {
+		return err
+	}
+
 	d.Token = res.Result.Token
 
 	deviceResponse, err := d.ExecMethod("get_device_info", false)


### PR DESCRIPTION
Handles #9050

Invalid login credentials will now be recognized and raised as an error:

```
thierolm@LAPTOP-KQMMVN3H:~/git-repos/evcc$ ./evcc -c ./evcc_tapotest.yaml -l debug charger
[main  ] INFO 2023/07/22 00:25:01 evcc 0.118.9 (35c55f66)
[main  ] INFO 2023/07/22 00:25:01 using config file: ./evcc_tapotest.yaml
[db    ] INFO 2023/07/22 00:25:02 using sqlite database: /home/thierolm/.evcc/evcc.db
Power:         tapo error -1501: Invalid Request or Credentials
Charge status: tapo error -1501: Invalid Request or Credentials
Enabled:       tapo error -1501: Invalid Request or Credentials
Charged:       tapo error -1501: Invalid Request or Credentials
Features:      [] 
```