### PR TITLE
fix warning residualpower in combination with battery

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -182,7 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site), see https://https://docs.evcc.io/docs/reference/configuration/site#residualpower ")
+		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site), see https://docs.evcc.io/docs/reference/configuration/site#residualpower ")
 	}
 
 	// auxiliary meters

--- a/core/site.go
+++ b/core/site.go
@@ -182,8 +182,15 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or <= 0.")
-		site.ResidualPower = 100
+	if len(site.batteryMeters) > 0 {
+		if site.ResidualPower == 0 {
+			site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or = 0.")
+			site.ResidualPower = 100
+		}
+
+		if site.ResidualPower < 0 {
+			site.log.WARN.Println("battery configured but residualPower is < 0 (add residualPower: 100 to site), see https://https://docs.evcc.io/docs/reference/configuration/site#residualpower")
+		}
 	}
 
 	// auxiliary meters

--- a/core/site.go
+++ b/core/site.go
@@ -182,6 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
+		site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or <= 0.")   
 		site.ResidualPower = 100
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -182,7 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or <= 0.")   
+		site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or <= 0."),   
 		site.ResidualPower = 100
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -182,7 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site)")
+		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site), see https://https://docs.evcc.io/docs/reference/configuration/site#residualpower ")
 	}
 
 	// auxiliary meters

--- a/core/site.go
+++ b/core/site.go
@@ -182,7 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site), see https://docs.evcc.io/docs/reference/configuration/site#residualpower ")
+		site.ResidualPower = 100
 	}
 
 	// auxiliary meters

--- a/core/site.go
+++ b/core/site.go
@@ -182,7 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or <= 0."),   
+		site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or <= 0.")
 		site.ResidualPower = 100
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -182,7 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		site.log.WARN.Println("battery configured but residualPower is missing (add residualPower: 100 to site)")
+		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site)")
 	}
 
 	// auxiliary meters

--- a/core/site.go
+++ b/core/site.go
@@ -182,7 +182,6 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-	if len(site.batteryMeters) > 0 {
 		if site.ResidualPower == 0 {
 			site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or = 0.")
 			site.ResidualPower = 100

--- a/core/site.go
+++ b/core/site.go
@@ -182,14 +182,7 @@ func NewSiteFromConfig(
 	}
 
 	if len(site.batteryMeters) > 0 && site.ResidualPower <= 0 {
-		if site.ResidualPower == 0 {
-			site.log.WARN.Println("ResidualPower is set to 100, because battery is configured and residualPower is missing or = 0.")
-			site.ResidualPower = 100
-		}
-
-		if site.ResidualPower < 0 {
-			site.log.WARN.Println("battery configured but residualPower is < 0 (add residualPower: 100 to site), see https://https://docs.evcc.io/docs/reference/configuration/site#residualpower")
-		}
+		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site), see https://https://docs.evcc.io/docs/reference/configuration/site#residualpower")
 	}
 
 	// auxiliary meters


### PR DESCRIPTION
da auch bei negativen Werten eine Warnung kommt ist der alleinige Hnweis "is missing" missverständlich