### PR TITLE
API: extend charger status mapping

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,12 +34,12 @@ type ChargeStatus string
 // Charging states
 const (
 	StatusNone ChargeStatus = ""
-	StatusA    ChargeStatus = "A" // Fzg. angeschlossen: nein    Laden aktiv: nein    - Kabel nicht angeschlossen
-	StatusB    ChargeStatus = "B" // Fzg. angeschlossen:   ja    Laden aktiv: nein    - Kabel angeschlossen
-	StatusC    ChargeStatus = "C" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    - Laden
-	StatusD    ChargeStatus = "D" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    - Laden mit Lüfter
-	StatusE    ChargeStatus = "E" // Fzg. angeschlossen:   ja    Laden aktiv: nein    - Fehler (Kurzschluss)
-	StatusF    ChargeStatus = "F" // Fzg. angeschlossen:   ja    Laden aktiv: nein    - Fehler (Ausfall Wallbox)
+	StatusA    ChargeStatus = "A" // Fzg. angeschlossen: nein    Laden aktiv: nein    Ladestation betriebsbereit, Fahrzeug getrennt
+	StatusB    ChargeStatus = "B" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fahrzeug verbunden, Netzspannung liegt nicht an
+	StatusC    ChargeStatus = "C" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt, Netzspannung liegt an
+	StatusD    ChargeStatus = "D" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt mit externer Belüfungsanforderung (für Blei-Säure-Batterien)
+	StatusE    ChargeStatus = "E" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler Fahrzeug / Kabel (CP-Kurzschluss, 0V)
+	StatusF    ChargeStatus = "F" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler EVSE oder Abstecken simulieren (CP-Wake-up, -12V)
 )
 
 // ChargeStatusString converts a string to ChargeStatus

--- a/api/api.go
+++ b/api/api.go
@@ -53,7 +53,7 @@ func ChargeStatusString(s string) (ChargeStatus, error) {
 		case "C1", "D1":
 			return StatusB, nil
 		default:
-			return ChargeStatus(s1), nil
+			return StatusC, nil
 		}
 	case "E", "F":
 		return ChargeStatus(s1), fmt.Errorf("invalid status: %s", status)

--- a/api/api.go
+++ b/api/api.go
@@ -44,11 +44,19 @@ const (
 
 // ChargeStatusString converts a string to ChargeStatus
 func ChargeStatusString(s string) (ChargeStatus, error) {
-	switch status := strings.ToUpper(s); status {
-	case "A", "B", "C":
-		return ChargeStatus(status), nil
-	case "D", "E", "F":
-		return ChargeStatus(status), fmt.Errorf("invalid status: %s", status)
+	status := strings.ToUpper(s)
+	switch s1 := status[:1]; s1 {
+	case "A", "B":
+		return ChargeStatus(s1), nil
+	case "C", "D":
+		switch status {
+		case "C1", "D1":
+			return StatusB, nil
+		default:
+			return ChargeStatus(s1), nil
+		}
+	case "E", "F":
+		return ChargeStatus(s1), fmt.Errorf("invalid status: %s", status)
 	default:
 		return StatusNone, fmt.Errorf("invalid status: %s", s)
 	}


### PR DESCRIPTION
This PR enhances `api.ChargeStatusString()` to accept extended charge status strings like A0, B2, C1 and automatically remap them to the correct internal StatusX charging state representation.

It also fixes the C1/D1 representation as StatusB (connected, not charging)

It keeps full compatibility with the short single character status strings (A-F).

This will help simplifying charger implementations.