### PR TITLE
Homewizard: add cache

### DIFF
--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -53,7 +53,7 @@ func NewHomeWizard(embed embed, uri string, standbypower float64, cache time.Dur
 
 	// Check compatible product type
 	if c.conn.ProductType != "HWE-SKT" {
-		return nil, errors.New("not supported product type: " + c.conn.ProductType)
+		return nil, errors.New("unsupported product type: " + c.conn.ProductType)
 	}
 
 	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)

--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -2,13 +2,11 @@ package charger
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
+	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/homewizard"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/request"
 )
 
 // HomeWizard project homepage
@@ -26,22 +24,25 @@ func init() {
 
 // NewHomeWizardFromConfig creates a HomeWizard charger from generic config
 func NewHomeWizardFromConfig(other map[string]interface{}) (api.Charger, error) {
-	var cc = struct {
+	cc := struct {
 		embed        `mapstructure:",squash"`
 		URI          string
 		StandbyPower float64
-	}{}
+		Cache        time.Duration
+	}{
+		Cache: time.Second,
+	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewHomeWizard(cc.embed, cc.URI, cc.StandbyPower)
+	return NewHomeWizard(cc.embed, cc.URI, cc.StandbyPower, cc.Cache)
 }
 
 // NewHomeWizard creates HomeWizard charger
-func NewHomeWizard(embed embed, uri string, standbypower float64) (*HomeWizard, error) {
-	conn, err := homewizard.NewConnection(uri)
+func NewHomeWizard(embed embed, uri string, standbypower float64, cache time.Duration) (*HomeWizard, error) {
+	conn, err := homewizard.NewConnection(uri, cache)
 	if err != nil {
 		return nil, err
 	}
@@ -62,34 +63,12 @@ func NewHomeWizard(embed embed, uri string, standbypower float64) (*HomeWizard, 
 
 // Enabled implements the api.Charger interface
 func (c *HomeWizard) Enabled() (bool, error) {
-	var res homewizard.StateResponse
-	err := c.conn.GetJSON(fmt.Sprintf("%s/data", c.conn.URI), &res)
-	return res.PowerOn, err
+	return c.conn.Enabled()
 }
 
 // Enable implements the api.Charger interface
 func (c *HomeWizard) Enable(enable bool) error {
-	var res homewizard.StateResponse
-	data := map[string]interface{}{
-		"power_on": enable,
-	}
-
-	req, err := request.New(http.MethodPut, fmt.Sprintf("%s/state", c.conn.URI), request.MarshalJSON(data), request.JSONEncoding)
-	if err != nil {
-		return err
-	}
-	if err := c.conn.DoJSON(req, &res); err != nil {
-		return err
-	}
-
-	switch {
-	case enable && !res.PowerOn:
-		return errors.New("switchOn failed")
-	case !enable && res.PowerOn:
-		return errors.New("switchOff failed")
-	default:
-		return nil
-	}
+	return c.conn.Enable(enable)
 }
 
 var _ api.MeterEnergy = (*HomeWizard)(nil)

--- a/meter/homewizard.go
+++ b/meter/homewizard.go
@@ -1,6 +1,8 @@
 package meter
 
 import (
+	"time"
+
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/homewizard"
 	"github.com/evcc-io/evcc/util"
@@ -19,19 +21,22 @@ func init() {
 // NewHomeWizardFromConfig creates a HomeWizard meter from generic config
 func NewHomeWizardFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI string
-	}{}
+		URI   string
+		Cache time.Duration
+	}{
+		Cache: time.Second,
+	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewHomeWizard(cc.URI)
+	return NewHomeWizard(cc.URI, cc.Cache)
 }
 
 // NewHomeWizard creates HomeWizard meter
-func NewHomeWizard(uri string) (*HomeWizard, error) {
-	conn, err := homewizard.NewConnection(uri)
+func NewHomeWizard(uri string, cache time.Duration) (*HomeWizard, error) {
+	conn, err := homewizard.NewConnection(uri, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/homewizard.go
+++ b/meter/homewizard.go
@@ -45,7 +45,7 @@ func NewHomeWizard(uri string, cache time.Duration) (*HomeWizard, error) {
 		conn: conn,
 	}
 
-	return c, err
+	return c, nil
 }
 
 var _ api.Meter = (*HomeWizard)(nil)

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -3,6 +3,7 @@ package homewizard
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -19,6 +20,7 @@ type Connection struct {
 	ProductType string
 	Cache       time.Duration
 	dataCache   provider.Cacheable[DataResponse]
+	stateCache  provider.Cacheable[StateResponse]
 }
 
 // NewConnection creates a homewizard connection
@@ -54,12 +56,57 @@ func NewConnection(uri string, cache time.Duration) (*Connection, error) {
 		return res, err
 	}, c.Cache)
 
+	c.stateCache = provider.ResettableCached(func() (StateResponse, error) {
+		var res StateResponse
+		err := c.GetJSON(fmt.Sprintf("%s/state", c.URI), &res)
+		return res, err
+	}, c.Cache)
+
 	return c, nil
 }
 
+// Enable implements the api.Charger interface
+func (c *Connection) Enable(enable bool) error {
+	var res StateResponse
+	data := map[string]interface{}{
+		"power_on": enable,
+	}
+
+	req, err := request.New(http.MethodPut, fmt.Sprintf("%s/state", c.URI), request.MarshalJSON(data), request.JSONEncoding)
+	if err != nil {
+		return err
+	}
+	if err := c.DoJSON(req, &res); err != nil {
+		return err
+	}
+
+	if err == nil {
+		c.stateCache.Reset()
+		c.dataCache.Reset()
+	}
+
+	switch {
+	case enable && !res.PowerOn:
+		return errors.New("switchOn failed")
+	case !enable && res.PowerOn:
+		return errors.New("switchOff failed")
+	default:
+		return nil
+	}
+}
+
+// Enabled reads the homewizard switch state true=on/false=off
+func (c *Connection) Enabled() (bool, error) {
+	res, err := c.stateCache.Get()
+	if err != nil {
+		return false, err
+	}
+	return res.PowerOn, err
+}
+
 // CurrentPower implements the api.Meter interface
-func (d *Connection) CurrentPower() (float64, error) {
-	res, err := d.dataCache.Get()
+func (c *Connection) CurrentPower() (float64, error) {
+	res, err := c.dataCache.Get()
 	if err != nil {
 		return 0, err
 	}
@@ -67,8 +114,8 @@ func (d *Connection) CurrentPower() (float64, error) {
 }
 
 // TotalEnergy implements the api.MeterEnergy interface
-func (d *Connection) TotalEnergy() (float64, error) {
-	res, err := d.dataCache.Get()
+func (c *Connection) TotalEnergy() (float64, error) {
+	res, err := c.dataCache.Get()
 	if err != nil {
 		return 0, err
 	}

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -36,13 +36,13 @@ func NewConnection(uri string, cache time.Duration) (*Connection, error) {
 
 	c.Client.Transport = request.NewTripper(log, transport.Insecure())
 
-	// Check and set API version + product type
+	// check and set API version + product type
 	var res ApiResponse
 	if err := c.GetJSON(c.uri, &res); err != nil {
 		return c, err
 	}
 	if res.ApiVersion != "v1" {
-		return nil, errors.New("not supported api version: " + res.ApiVersion)
+		return nil, errors.New("unsupported api version: " + res.ApiVersion)
 	}
 
 	c.uri = c.uri + "/" + res.ApiVersion


### PR DESCRIPTION
Based on the first nightly logs I realised a lot of device timeouts. Therefore I added cache mechanism (1s). I also had to correct the api endpoint (data->state) in enabled function.