### PR TITLE
UI: Support negative prices and smart cost limit

### DIFF
--- a/assets/js/components/GridSettingsModal.vue
+++ b/assets/js/components/GridSettingsModal.vue
@@ -305,7 +305,7 @@ export default {
 			const fmtMax = this.isCo2
 				? this.fmtCo2Short(max)
 				: this.fmtPricePerKWh(max, this.currency, true);
-			return `${fmtMin} - ${fmtMax}`;
+			return `${fmtMin} – ${fmtMax}`;
 		},
 		slotHovered(index) {
 			this.activeIndex = index;

--- a/assets/js/components/GridSettingsModal.vue
+++ b/assets/js/components/GridSettingsModal.vue
@@ -48,7 +48,7 @@
 									</option>
 								</select>
 							</div>
-							<small v-if="selectedSmartCostLimit > 0">
+							<small v-if="selectedSmartCostLimit !== 0">
 								{{ $t("gridSettings.costLimitDescription") }}
 							</small>
 						</div>
@@ -133,7 +133,10 @@ export default {
 			const values = [];
 			const stepSize = this.optionStepSize;
 			for (let i = 1; i <= 100; i++) {
-				values.push(stepSize * i);
+				const value = this.optionStartValue + stepSize * i;
+				if (value != 0) {
+					values.push(value);
+				}
 			}
 			// add special entry if currently selected value is not in the scale
 			const selected = this.selectedSmartCostLimit;
@@ -150,13 +153,22 @@ export default {
 				return { value, name };
 			});
 		},
+		optionStartValue() {
+			if (!this.tariff) {
+				return 0;
+			}
+			const { min } = this.costRange(this.totalSlots);
+			const minValue = Math.min(0, min);
+			const stepSize = this.optionStepSize;
+			return Math.ceil(minValue / stepSize) * stepSize;
+		},
 		optionStepSize() {
 			if (!this.tariff) {
 				return 1;
 			}
-			const { max } = this.costRange(this.totalSlots);
+			const { min, max } = this.costRange(this.totalSlots);
 			for (const scale of [0.1, 1, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]) {
-				if (max < scale) {
+				if (max - Math.min(0, min) < scale) {
 					return scale / 100;
 				}
 			}
@@ -181,7 +193,8 @@ export default {
 				const day = this.weekdayShort(start);
 				// TODO: handle multiple matching time slots
 				const price = this.findSlotInRange(start, end, rates)?.price;
-				const charging = price < this.selectedSmartCostLimit;
+				const charging =
+					price < this.selectedSmartCostLimit && this.selectedSmartCostLimit !== 0;
 				const selectable = price !== undefined;
 				result.push({ day, price, startHour, endHour, charging, selectable });
 			}

--- a/assets/js/components/TargetChargePlan.story.vue
+++ b/assets/js/components/TargetChargePlan.story.vue
@@ -31,7 +31,7 @@ const co2 = {
 	].map((price, i) => createRate(price, i)),
 	duration: 8695,
 	plan: [createRate(213, 4), createRate(336, 11), createRate(336, 12)],
-	unit: "gCO2eq",
+	smartCostType: "co2",
 	targetTime: createDate(14),
 };
 
@@ -39,7 +39,8 @@ const fixed = {
 	rates: [createRate(0.442, 0, 50)],
 	duration: 8695,
 	plan: [createRate(0.442, 12, 3)],
-	unit: "EUR",
+	smartCostType: "price",
+	currency: "EUR",
 	targetTime: createDate(14),
 };
 
@@ -53,7 +54,8 @@ const zoned = {
 	],
 	duration: 8695,
 	plan: [createRate(2.39, 13, 3)],
-	unit: "DKK",
+	smartCostType: "price",
+	currency: "DKK",
 	targetTime: createDate(17),
 };
 
@@ -61,8 +63,19 @@ const unknown = {
 	rates: co2.rates.slice(0, 16),
 	duration: 8695,
 	plan: [createRate(213, 4), createRate(336, 11), createRate(336, 12)],
-	unit: "gCO2eq",
+	smartCostType: "co2",
 	targetTime: createDate(14),
+};
+
+const dynamic = {
+	rates: [
+		0.12, 0.15, 0, -0.05, -0.11, -0.24, -0.08, 0.12, 0.25, 0.29, 0.22, 0.31, 0.31, 0.33,
+	].map((price, i) => createRate(price, i)),
+	duration: 8695,
+	plan: [createRate(0.23, 2, 5)],
+	smartCostType: "price",
+	currency: "EUR",
+	targetTime: createDate(13),
 };
 </script>
 
@@ -79,6 +92,9 @@ const unknown = {
 		</Variant>
 		<Variant title="unknown">
 			<TargetChargePlan v-bind="unknown" />
+		</Variant>
+		<Variant title="dynamic">
+			<TargetChargePlan v-bind="dynamic" />
 		</Variant>
 	</Story>
 </template>

--- a/assets/js/components/TariffChart.vue
+++ b/assets/js/components/TariffChart.vue
@@ -44,15 +44,17 @@ export default {
 		return { activeIndex: null, startTime: new Date() };
 	},
 	computed: {
-		maxPrice() {
-			let result = 0;
+		priceInfo() {
+			let max = Number.MIN_VALUE;
+			let min = 0;
 			this.slots
 				.map((s) => s.price)
 				.filter((price) => price !== undefined)
 				.forEach((price) => {
-					result = Math.max(result, price);
+					max = Math.max(max, price);
+					min = Math.min(min, price);
 				});
-			return result;
+			return { min, range: max - min };
 		},
 		avgPrice() {
 			let sum = 0;
@@ -89,7 +91,10 @@ export default {
 		},
 		priceStyle(price) {
 			const value = price === undefined ? this.avgPrice : price;
-			const height = value !== undefined ? `${5 + (95 / this.maxPrice) * value}%` : "100%";
+			const height =
+				value !== undefined
+					? `${10 + (90 / this.priceInfo.range) * (value - this.priceInfo.min)}%`
+					: "100%";
 			return { height };
 		},
 	},


### PR DESCRIPTION
fixes #8744

- ensure a minimum bar height even for negative prices
- show negative price filter options depending on the lowest price

Note: `0` currently has a special meaning (no limit). That's why `0` can't be selected as a limit.

<img width="1005" alt="Bildschirmfoto 2023-08-03 um 18 02 02" src="https://github.com/evcc-io/evcc/assets/152287/c6f688d5-41fa-467e-b6ee-87fd499820cc">

<img width="921" alt="Bildschirmfoto 2023-08-03 um 18 01 52" src="https://github.com/evcc-io/evcc/assets/152287/f29ca64a-8f2e-4094-9b28-80f847b423d1">
