### PR TITLE
Easee: use start_charge when authentication required

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -77,7 +77,7 @@ func NewEaseeFromConfig(other map[string]interface{}) (api.Charger, error) {
 		Password  string
 		Charger   string
 		Timeout   time.Duration
-		authorize bool
+		Authorize bool
 	}{
 		Timeout: request.Timeout,
 	}
@@ -90,7 +90,7 @@ func NewEaseeFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, api.ErrMissingCredentials
 	}
 
-	return NewEasee(cc.User, cc.Password, cc.Charger, cc.Timeout, cc.authorize)
+	return NewEasee(cc.User, cc.Password, cc.Charger, cc.Timeout, cc.Authorize)
 }
 
 // NewEasee creates Easee charger

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -388,6 +388,7 @@ func (c *Easee) Enabled() (bool, error) {
 
 	disabled := c.opMode == easee.ModeDisconnected ||
 		c.opMode == easee.ModeCompleted ||
+		c.opMode == easee.ModeAwaitingAuthentication ||
 		(c.opMode == easee.ModeAwaitingStart && c.reasonForNoCurrent == 52)
 	return !disabled && c.dynamicChargerCurrent > 0, nil
 }

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -441,13 +441,16 @@ func (c *Easee) Enable(enable bool) error {
 	if err := c.waitForChargerEnabledState(expectedEnabledState); err != nil {
 		return err
 	}
-	if err := c.waitForDynamicChargerCurrent(targetCurrent); err != nil {
-		return err
-	}
 
-	if enable {
-		// reset currents after enable, as easee automatically resets to maxA
-		return c.MaxCurrent(int64(c.current))
+	if !c.authorize { // authenticating charger does not mingle with DCC, no need for waiting
+		if err := c.waitForDynamicChargerCurrent(targetCurrent); err != nil {
+			return err
+		}
+
+		if enable {
+			// reset currents after enable, as easee automatically resets to maxA
+			return c.MaxCurrent(int64(c.current))
+		}
 	}
 
 	return nil

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -418,6 +418,9 @@ func (c *Easee) Enable(enable bool) error {
 
 	// resume/stop charger
 	action := easee.ChargePause
+	if c.authorize {
+		action = easee.ChargeStop
+	}
 	var expectedEnabledState bool
 	var targetCurrent float64
 	if enable {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -408,7 +408,7 @@ func (c *Easee) Enable(enable bool) error {
 	}
 
 	// do not send pause/resume if disconnected or unauthenticated
-	if c.opMode == easee.ModeDisconnected || c.opMode == easee.ModeAwaitingAuthentication {
+	if c.opMode == easee.ModeDisconnected || (c.opMode == easee.ModeAwaitingAuthentication && !enable) {
 		return nil
 	}
 
@@ -418,6 +418,9 @@ func (c *Easee) Enable(enable bool) error {
 	var targetCurrent float64
 	if enable {
 		action = easee.ChargeResume
+		if c.opMode == easee.ModeAwaitingAuthentication {
+			action = easee.ChargeStart
+		}
 		expectedEnabledState = true
 		targetCurrent = 32
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -397,6 +397,7 @@ func (c *Easee) Enabled() (bool, error) {
 func (c *Easee) Enable(enable bool) error {
 	c.mux.Lock()
 	enablingRequired := enable && !c.chargerEnabled
+	opMode := c.opMode
 	c.mux.Unlock()
 
 	// enable charger once if it's switched off
@@ -411,9 +412,6 @@ func (c *Easee) Enable(enable bool) error {
 		}
 	}
 
-	c.mux.Lock()
-	opMode := c.opMode
-	c.mux.Unlock()
 	// do not send pause/resume if disconnected or unauthenticated without automatic authorization
 	if opMode == easee.ModeDisconnected || (opMode == easee.ModeAwaitingAuthentication && !(enable && c.authorize)) {
 		return nil

--- a/charger/easee/types.go
+++ b/charger/easee/types.go
@@ -5,6 +5,7 @@ const API = "https://api.easee.com/api"
 
 const (
 	ChargeStart  = "start_charging"
+	ChargeStop   = "stop_charging"
 	ChargePause  = "pause_charging"
 	ChargeResume = "resume_charging"
 )

--- a/charger/easee/types.go
+++ b/charger/easee/types.go
@@ -4,6 +4,7 @@ package easee
 const API = "https://api.easee.com/api"
 
 const (
+	ChargeStart  = "start_charging"
 	ChargePause  = "pause_charging"
 	ChargeResume = "resume_charging"
 )

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -23,9 +23,12 @@ params:
     example: EH______
   - name: timeout
     default: 10s
+  - name: authorize
+    default: false
 render: |
   type: easee
   user: {{ .user }}
   password: {{ .password }}
   charger: {{ .charger }}
   timeout: {{ .timeout }}
+  authorize: {{ .authorize }}

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -25,6 +25,9 @@ params:
     default: 10s
   - name: authorize
     default: false
+    help:
+      de: Steuert ob evcc die Authentifizierung am Charger vornimmt. Vorteil ist ein kontrollierter Ladestart. Nicht kompatibel mit RFID Identifikation von Fahrzeugen.
+      en: Controls wether evcc shall perform authentication against charger. Benefit is a contolled start of charging. Not compatible with RFID identification of vehicles.
 render: |
   type: easee
   user: {{ .user }}

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -24,7 +24,6 @@ params:
   - name: timeout
     default: 10s
   - name: authorize
-    default: false
     help:
       de: Steuert ob evcc die Authentifizierung am Charger vornimmt. Vorteil ist ein kontrollierter Ladestart. Nicht kompatibel mit RFID Identifikation von Fahrzeugen.
       en: Controls wether evcc shall perform authentication against charger. Benefit is a contolled start of charging. Not compatible with RFID identification of vehicles.


### PR DESCRIPTION
See discussion in #9228

Note: this change is breaking with previous behavior, as it allows evcc to perform any needed authorization on behalf of the user. If users want to keep manual control of the charge start, they can do so by setting the default mode in evcc to off.

The upside of this change is, that the charger won't autostart when connecting a vehicle, giving evcc better control over the starting phase of the charge, and eliminating any maxA charging between connecting the car and the first evcc interval.