### PR TITLE
Odometer number format

### DIFF
--- a/assets/js/components/ChargingSessionModal.vue
+++ b/assets/js/components/ChargingSessionModal.vue
@@ -207,7 +207,7 @@ export default {
 			modal.show();
 		},
 		formatKm: function (value) {
-			return `${distanceValue(value)} ${distanceUnit()}`;
+			return `${this.fmtNumber(distanceValue(value), 0)} ${distanceUnit()}`;
 		},
 		async changeVehicle(index) {
 			await this.updateSession({

--- a/assets/js/components/TargetSocSelect.vue
+++ b/assets/js/components/TargetSocSelect.vue
@@ -28,10 +28,12 @@
 import LabelAndValue from "./LabelAndValue.vue";
 import AnimatedNumber from "./AnimatedNumber.vue";
 import { distanceUnit } from "../units";
+import formatter from "../mixins/formatter";
 
 export default {
 	name: "TargetSocSelect",
 	components: { LabelAndValue, AnimatedNumber },
+	mixins: [formatter],
 	props: {
 		targetSoc: Number,
 		rangePerSoc: Number,
@@ -69,7 +71,7 @@ export default {
 			return `${Math.round(value)}%`;
 		},
 		formatKm: function (value) {
-			return `${Math.round(value)} ${distanceUnit()}`;
+			return `${this.fmtNumber(value, 0)} ${distanceUnit()}`;
 		},
 	},
 };

--- a/assets/js/components/Vehicle.vue
+++ b/assets/js/components/Vehicle.vue
@@ -20,7 +20,7 @@
 				class="flex-grow-1"
 				:label="$t('main.vehicle.vehicleSoc')"
 				:value="vehicleSoc ? `${Math.round(vehicleSoc)}%` : '--'"
-				:extraValue="range ? `${Math.round(range)} ${rangeUnit}` : null"
+				:extraValue="range ? `${fmtNumber(range, 0)} ${rangeUnit}` : null"
 				align="start"
 			/>
 			<LabelAndValue


### PR DESCRIPTION
Proper odometer formatting.
Also applied this formatting to range values in case someone has a >1k [unit] range vehicle.

fixes #9335


<img width="613" alt="Bildschirmfoto 2023-08-11 um 19 39 35" src="https://github.com/evcc-io/evcc/assets/152287/4eee670b-03a6-4afd-9aa5-b0ce4bbecc85">

<img width="609" alt="Bildschirmfoto 2023-08-11 um 19 39 51" src="https://github.com/evcc-io/evcc/assets/152287/e32490ad-91f4-4a35-9e34-78101cbee867">
