### PR TITLE
Shelly meter set default channel 0

### DIFF
--- a/templates/definition/meter/shelly-1pm.yaml
+++ b/templates/definition/meter/shelly-1pm.yaml
@@ -12,6 +12,7 @@ params:
   - name: user
   - name: password
   - name: channel
+    default: 0
 render: |
   type: shelly
   uri: http://{{ .host }}  # shelly device ip address (local)

--- a/templates/docs/meter/shelly-1pm_0.yaml
+++ b/templates/docs/meter/shelly-1pm_0.yaml
@@ -11,7 +11,7 @@ render:
       host: 192.0.2.2 # IP-Adresse oder Hostname
       user: # Benutzerkonto (bspw. E-Mail Adresse, User Id, etc.) (Optional)
       password: # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen) (Optional)
-      channel: # Optional
+      channel: 0 # Optional
   - usage: charge
     default: |
       type: template
@@ -20,4 +20,4 @@ render:
       host: 192.0.2.2 # IP-Adresse oder Hostname
       user: # Benutzerkonto (bspw. E-Mail Adresse, User Id, etc.) (Optional)
       password: # Passwort des Benutzerkontos (bei führenden Nullen bitte in einfache Hochkommata setzen) (Optional)
-      channel: # Optional
+      channel: 0 # Optional


### PR DESCRIPTION
beim Shelly EM sind die beiden Kanäle mit `0` und `1` abrufbar. Aktuell ist default channel =1. Das führt zu Verwirrung, weil man meinst, man müsste die Kanäle `1` und `2` aufrufen.

`make docs` fehlt noch (kann ich nicht)