### PR TITLE
fix: allow set float for http plugin

### DIFF
--- a/provider/http.go
+++ b/provider/http.go
@@ -251,6 +251,15 @@ func (p *HTTP) IntSetter(param string) func(int64) error {
 	}
 }
 
+var _ SetFloatProvider = (*HTTP)(nil)
+
+// FloatSetter sends int request
+func (p *HTTP) FloatSetter(param string) func(float64) error {
+	return func(val float64) error {
+		return p.set(param, val)
+	}
+}
+
 var _ SetStringProvider = (*HTTP)(nil)
 
 // StringSetter sends string request


### PR DESCRIPTION
added float capability to http plugin provider. this is required to support `maxcurrentmillis` for custom chargers.