### PR TITLE
Add carbonintensity.org.uk (National Grid ESO) CO2 forecasting

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -206,6 +206,11 @@ tariffs:
     # token: <token>
     # zone: DE
 
+    # type: ngeso # National Grid Electricity System Operator data (United Kingdom only) https://carbonintensity.org.uk/
+    # provides national data if both region and postcode are omitted - do not supply both at the same time!
+    # region: 1 # optional, coarser than using a postcode - see https://api.carbonintensity.org.uk/ for full list
+    # postcode: SW1A1AA # optional
+
 # mqtt message broker
 mqtt:
   # broker: localhost:1883

--- a/tariff/ngeso.go
+++ b/tariff/ngeso.go
@@ -1,0 +1,145 @@
+package tariff
+
+import (
+	"errors"
+	"github.com/cenkalti/backoff"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/tariff/ngeso"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"golang.org/x/exp/slices"
+)
+
+type Ngeso struct {
+	mux            sync.Mutex
+	log            *util.Logger
+	regionId       string
+	regionPostcode string
+	data           api.Rates
+	updated        time.Time
+}
+
+var _ api.Tariff = (*Ngeso)(nil)
+
+func init() {
+	registry.Add("ngeso", NewNgesoFromConfig)
+}
+
+func NewNgesoFromConfig(other map[string]interface{}) (api.Tariff, error) {
+	var cc struct {
+		Region   string
+		Postcode string
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.Region != "" && cc.Postcode != "" {
+		return nil, errors.New("region and postcode cannot be defined simultaneously - pick one")
+	}
+
+	t := &Ngeso{
+		log:            util.NewLogger("ngeso"),
+		regionId:       cc.Region,
+		regionPostcode: cc.Postcode,
+	}
+
+	done := make(chan error)
+	go t.run(done)
+	err := <-done
+
+	return t, err
+}
+
+func (t *Ngeso) run(done chan error) {
+	var once sync.Once
+	client := request.NewHelper(t.log)
+	bo := newBackoff()
+
+	// Use national results by default.
+	tUri := ngeso.ConstructForecastNationalAPI()
+	var apiDecodeAsRegional bool
+
+	// If a region is available, use that.
+	// These should never be set simultaneously (see NewNgesoFromConfig), but in the rare case that they are,
+	// use the postcode as the preferred method.
+	// Regional responses are subtly different, so we set a flag to let the loop know to decode them as such. FIXME?
+	if t.regionId != "" {
+		tUri = ngeso.ConstructForecastRegionalByIdAPI(t.regionId)
+		apiDecodeAsRegional = true
+	}
+	if t.regionPostcode != "" {
+		tUri = ngeso.ConstructForecastRegionalByPostcodeAPI(t.regionPostcode)
+		apiDecodeAsRegional = true
+	}
+
+	// Data updated by ESO every half hour, but we only need data every hour to stay current.
+	for ; true; <-time.Tick(time.Hour) {
+		// FIXME Eww, this is a sloppy way of handling this. Maybe we should move abstraction of this to the ngeso package?
+		var rgnlWrapper ngeso.RegionalIntensityResult
+		var res ngeso.IntensityRates
+
+		if err := backoff.Retry(func() error {
+			var wErr error
+			// (vomits internally)
+			if apiDecodeAsRegional {
+				wErr = client.GetJSON(tUri, &rgnlWrapper)
+				if wErr == nil {
+					res = rgnlWrapper.Results
+				}
+			} else {
+				wErr = client.GetJSON(tUri, &res)
+			}
+			if wErr != nil {
+				// Catch cases where we're sending completely incorrect data (usually the result of a bad region).
+				switch e := wErr.(type) {
+				case request.StatusError:
+					if e.StatusCode() == http.StatusBadRequest {
+						return backoff.Permanent(wErr)
+					}
+				}
+			}
+			return wErr
+		}, bo); err != nil {
+			once.Do(func() { done <- err })
+
+			t.log.ERROR.Println(err)
+			continue
+		}
+
+		once.Do(func() { close(done) })
+
+		t.mux.Lock()
+		t.updated = time.Now()
+
+		t.data = make(api.Rates, 0, len(res.Results))
+		for _, r := range res.Results {
+			ar := api.Rate{
+				Start: r.ValidityStart.Time,
+				End:   r.ValidityEnd.Time,
+				// Use the forecasted rate, as the actual rate is only available for historical data
+				Price: r.Intensity.Forecast,
+			}
+			t.data = append(t.data, ar)
+		}
+
+		t.mux.Unlock()
+	}
+}
+
+// Rates implements the api.Tariff interface
+func (t *Ngeso) Rates() (api.Rates, error) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	return slices.Clone(t.data), outdatedError(t.updated, time.Hour)
+}
+
+// Type implements the api.Tariff interface
+func (t *Ngeso) Type() api.TariffType {
+	return api.TariffTypeCo2
+}

--- a/tariff/ngeso.go
+++ b/tariff/ngeso.go
@@ -11,7 +11,7 @@ import (
 	"github.com/evcc-io/evcc/tariff/ngeso"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 type Ngeso struct {

--- a/tariff/ngeso.go
+++ b/tariff/ngeso.go
@@ -82,10 +82,10 @@ func (t *Ngeso) run(done chan error) {
 			var err error
 			carbonResponse, err = tReq.DoRequest(client)
 
-			var statusError *request.StatusError
-			if errors.As(err, &statusError) && statusError.HasStatus(http.StatusBadRequest) {
+			// Consider whether errors.As would be more appropriate if this needs to start dealing with wrapped errors.
+			if se, ok := err.(request.StatusError); ok && se.HasStatus(http.StatusBadRequest) {
 				// Catch cases where we're sending completely incorrect data (usually the result of a bad region).
-				return backoff.Permanent(err)
+				return backoff.Permanent(se)
 			}
 			return err
 		}, bo); err != nil {

--- a/tariff/ngeso.go
+++ b/tariff/ngeso.go
@@ -2,11 +2,11 @@ package tariff
 
 import (
 	"errors"
-	"github.com/cenkalti/backoff"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/tariff/ngeso"
 	"github.com/evcc-io/evcc/util"

--- a/tariff/ngeso/api.go
+++ b/tariff/ngeso/api.go
@@ -46,7 +46,7 @@ type CarbonForecastRequest interface {
 
 type CarbonForecastNationalRequest struct{}
 
-func (r CarbonForecastNationalRequest) URI() (string, error) {
+func (r *CarbonForecastNationalRequest) URI() (string, error) {
 	currentTs := time.Now().UTC()
 	t := currentTs.Format(time.RFC3339)
 	return fmt.Sprintf(ForecastNationalURI, t), nil
@@ -136,4 +136,4 @@ type CarbonIntensity struct {
 	Index string `json:"index"`
 }
 
-var ErrRegionalRequestInvalidFormat error = errors.New("regional request object missing region")
+var ErrRegionalRequestInvalidFormat = errors.New("regional request object missing region")

--- a/tariff/ngeso/api.go
+++ b/tariff/ngeso/api.go
@@ -1,0 +1,69 @@
+// Package ngeso implements the carbonintensity.org.uk Grid CO2 tracking service, which provides CO2 forecasting for the UK at a national and regional level.
+// This service is provided by the National Grid Electricity System Operator (NGESO).
+package ngeso
+
+import (
+	"fmt"
+	"time"
+)
+
+// BaseURI is the root path that the API is accessed from.
+const BaseURI = "https://api.carbonintensity.org.uk/"
+
+// ForecastNationalURI defines the location of the national forecast.
+// Replace the first %s with the RFC3339 timestamp to fetch from.
+const ForecastNationalURI = BaseURI + "intensity/%s/fw48h"
+
+// ForecastRegionalByIdURI defines the location of the regional forecast determined by Region ID.
+// Replace the first %s with the RFC3339 timestamp to fetch from, and the second with the appropriate Region ID.
+const ForecastRegionalByIdURI = BaseURI + "regional/intensity/%s/fw48h/regionid/%s"
+
+// ForecastRegionalByPostcodeURI defines the location of the regional forecast determined by a given postcode.
+// Replace the first %s with the RFC3339 timestamp to fetch from, and the second with the appropriate postcode.
+const ForecastRegionalByPostcodeURI = BaseURI + "regional/intensity/%s/fw48h/postcode/%s"
+
+// ConstructForecastNationalAPI returns a validly formatted, fully qualified URI to the national forecast.
+func ConstructForecastNationalAPI() string {
+	currentTs := time.Now().UTC()
+	t := currentTs.Format(time.RFC3339)
+	return fmt.Sprintf(ForecastNationalURI, t)
+}
+
+// ConstructForecastRegionalByIdAPI returns a validly formatted, fully qualified URI to the forecast valid for the given region.
+func ConstructForecastRegionalByIdAPI(r string) string {
+	currentTs := time.Now().UTC()
+	t := currentTs.Format(time.RFC3339)
+	return fmt.Sprintf(ForecastRegionalByIdURI, t, r)
+}
+
+// ConstructForecastRegionalByPostcodeAPI returns a validly formatted, fully qualified URI to the forecast valid for the given postcode.
+func ConstructForecastRegionalByPostcodeAPI(p string) string {
+	currentTs := time.Now().UTC()
+	t := currentTs.Format(time.RFC3339)
+	return fmt.Sprintf(ForecastRegionalByPostcodeURI, t, p)
+}
+
+type RegionalIntensityResult struct {
+	RegionId  int            `json:"regionid"`
+	DNORegion string         `json:"dnoregion"`
+	ShortName string         `json:"shortname"`
+	Results   IntensityRates `json:"data"`
+}
+type IntensityRates struct {
+	Results []CarbonIntensityForecastEntry `json:"data"`
+}
+
+type CarbonIntensityForecastEntry struct {
+	ValidityStart shortRFC3339Timestamp `json:"from"`
+	ValidityEnd   shortRFC3339Timestamp `json:"to"`
+	Intensity     CarbonIntensity       `json:"intensity"`
+}
+
+type CarbonIntensity struct {
+	// The forecasted rate in gCO2/kWh
+	Forecast float64 `json:"forecast"`
+	// The rate recorded when this slot occurred - only available historically, otherwise nil
+	Actual float64 `json:"actual"`
+	// A human-readable representation of the level of emissions (e.g "low", "moderate")
+	Index string `json:"index"`
+}

--- a/tariff/ngeso/shortrfc3339.go
+++ b/tariff/ngeso/shortrfc3339.go
@@ -1,0 +1,36 @@
+package ngeso
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// shortRFC3339Timestamp is a custom JSON encoder / decoder for shortened RFC3339-compliant timestamps (those without seconds).
+// Please don't ask why NGESO uses this format instead of standards-compliant RFC3339. 🇬🇧
+type shortRFC3339Timestamp struct {
+	time.Time
+}
+
+const s3339Layout = "2006-01-02T15:04Z"
+
+func (ct *shortRFC3339Timestamp) UnmarshalJSON(b []byte) (err error) {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		ct.Time = time.Time{}
+		return
+	}
+	ct.Time, err = time.Parse(s3339Layout, s)
+	return
+}
+
+func (ct *shortRFC3339Timestamp) MarshalJSON() ([]byte, error) {
+	if ct.Time.IsZero() {
+		return []byte("null"), nil
+	}
+	return []byte(fmt.Sprintf("\"%s\"", ct.Time.Format(s3339Layout))), nil
+}
+
+func (ct *shortRFC3339Timestamp) IsSet() bool {
+	return !ct.IsZero()
+}

--- a/tariff/ngeso/shortrfc3339.go
+++ b/tariff/ngeso/shortrfc3339.go
@@ -1,7 +1,6 @@
 package ngeso
 
 import (
-	"fmt"
 	"strings"
 	"time"
 )
@@ -28,7 +27,7 @@ func (ct *shortRFC3339Timestamp) MarshalJSON() ([]byte, error) {
 	if ct.Time.IsZero() {
 		return []byte("null"), nil
 	}
-	return []byte(fmt.Sprintf("%s", ct.Time.Format(s3339Layout))), nil
+	return []byte(ct.Time.Format(s3339Layout)), nil
 }
 
 func (ct *shortRFC3339Timestamp) IsSet() bool {

--- a/tariff/ngeso/shortrfc3339.go
+++ b/tariff/ngeso/shortrfc3339.go
@@ -28,7 +28,7 @@ func (ct *shortRFC3339Timestamp) MarshalJSON() ([]byte, error) {
 	if ct.Time.IsZero() {
 		return []byte("null"), nil
 	}
-	return []byte(fmt.Sprintf("\"%s\"", ct.Time.Format(s3339Layout))), nil
+	return []byte(fmt.Sprintf("%s", ct.Time.Format(s3339Layout))), nil
 }
 
 func (ct *shortRFC3339Timestamp) IsSet() bool {

--- a/tariff/ngeso/shortrfc3339_test.go
+++ b/tariff/ngeso/shortrfc3339_test.go
@@ -12,8 +12,7 @@ var (
 func TestMarshalling(t *testing.T) {
 	// Firstly, test that we can unmarshal into a struct.
 	ct := shortRFC3339Timestamp{}
-    if err := ct.UnmarshalJSON(tTsBytes); err!=nil {
-	if err != nil {
+	if err := ct.UnmarshalJSON(tTsBytes); err != nil {
 		t.Fatal(err)
 	}
 	if ct.Time.String() != tTsStringRepr {

--- a/tariff/ngeso/shortrfc3339_test.go
+++ b/tariff/ngeso/shortrfc3339_test.go
@@ -1,0 +1,31 @@
+package ngeso
+
+import (
+	"testing"
+)
+
+var (
+	tTsBytes      = []byte("2023-04-20T14:30Z")
+	tTsStringRepr = "2023-04-20 14:30:00 +0000 UTC"
+)
+
+func TestMarshalling(t *testing.T) {
+	// Firstly, test that we can unmarshal into a struct.
+	ct := shortRFC3339Timestamp{}
+	err := ct.UnmarshalJSON(tTsBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ct.Time.String() != tTsStringRepr {
+		t.Errorf("time did not unmarshal successfully: got %s, expected %s", ct.Time.String(), tTsStringRepr)
+	}
+
+	// Now test remarshalling.
+	res, err := ct.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(res) != string(tTsBytes) {
+		t.Errorf("time did not marshal successfully: got %s, expected %s", res, tTsBytes)
+	}
+}

--- a/tariff/ngeso/shortrfc3339_test.go
+++ b/tariff/ngeso/shortrfc3339_test.go
@@ -12,7 +12,7 @@ var (
 func TestMarshalling(t *testing.T) {
 	// Firstly, test that we can unmarshal into a struct.
 	ct := shortRFC3339Timestamp{}
-	err := ct.UnmarshalJSON(tTsBytes)
+    if err := ct.UnmarshalJSON(tTsBytes); err!=nil {
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This supports the National Grid Electricity System Operator's carbonintensity.org.uk service, supplying information on forecast CO2 per kWh.

Extremely sloppy first commit, just wanted to get something out the door - tests and a bit more refinement to come.

(oh my goodness is their API a mess, what have I gotten myself into?)