### PR TITLE
chore: optimize JS bundle size

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,7 +3,6 @@ import smoothscroll from "smoothscroll-polyfill";
 import "../css/app.css";
 import { createApp, h } from "vue";
 import { createMetaManager, plugin as metaPlugin } from "vue-meta";
-import Vue3linkify from "vue-3-linkify";
 import App from "./views/App.vue";
 import setupRouter from "./router";
 import setupI18n from "./i18n";
@@ -69,7 +68,6 @@ app.use(setupRouter(i18n));
 app.use(createMetaManager());
 app.use(metaPlugin);
 app.use(featureflags);
-app.use(Vue3linkify);
 window.app = app.mount("#app");
 
 watchThemeChanges();

--- a/assets/js/components/Config/FormRow.vue
+++ b/assets/js/components/Config/FormRow.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-v-html -->
 <template>
 	<div class="mb-3">
 		<label :for="id">
@@ -11,12 +12,14 @@
 		</div>
 		<div class="form-text">
 			<div v-if="example">{{ $t("config.form.example") }}: {{ example }}</div>
-			<div v-if="help" v-linkify:options="{ target: '_blank' }">{{ help }}</div>
+			<div v-if="help" v-html="helpHtml"></div>
 		</div>
 	</div>
 </template>
 
 <script>
+import linkify from "../../utils/linkify";
+
 export default {
 	name: "FormRow",
 	props: {
@@ -26,6 +29,11 @@ export default {
 		optional: Boolean,
 		smallValue: Boolean,
 		example: String,
+	},
+	computed: {
+		helpHtml() {
+			return linkify(this.help);
+		},
 	},
 };
 </script>

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -1,8 +1,6 @@
 import { createRouter, createWebHashHistory } from "vue-router";
 
 import Main from "./views/Main.vue";
-import ChargingSessions from "./views/ChargingSessions.vue";
-import Config from "./views/Config.vue";
 import { ensureCurrentLocaleMessages } from "./i18n";
 
 export default function setupRouter(i18n) {
@@ -10,10 +8,10 @@ export default function setupRouter(i18n) {
     history: createWebHashHistory(),
     routes: [
       { path: "/", component: Main, props: true },
-      { path: "/config", component: Config, props: true },
+      { path: "/config", component: () => import("./views/Config.vue"), props: true },
       {
         path: "/sessions",
-        component: ChargingSessions,
+        component: () => import("./views/ChargingSessions.vue"),
         props: (route) => {
           const { month, year, loadpoint, vehicle } = route.query;
           return {

--- a/assets/js/utils/linkify.js
+++ b/assets/js/utils/linkify.js
@@ -1,0 +1,7 @@
+export default function linkify(text) {
+  const urlRegex = /https?:\/\/[^\s]+/g;
+
+  return text.replace(urlRegex, function (url) {
+    return `<a href="${url}" target="_blank">${url}</a>`;
+  });
+}

--- a/assets/js/utils/linkify.test.js
+++ b/assets/js/utils/linkify.test.js
@@ -1,0 +1,25 @@
+import linkify from "./linkify";
+import { describe, expect, test } from "vitest";
+
+describe("linkify", () => {
+  test("should wrap links", () => {
+    expect(linkify("https://example.com")).eq(
+      `<a href="https://example.com" target="_blank">https://example.com</a>`
+    );
+  });
+  test("with surrounding text", () => {
+    expect(linkify("hello http://foo.bar/ world")).eq(
+      `hello <a href="http://foo.bar/" target="_blank">http://foo.bar/</a> world`
+    );
+  });
+  test("with query and hash", () => {
+    expect(linkify("a http://b.c/?d=e#f g")).eq(
+      `a <a href="http://b.c/?d=e#f" target="_blank">http://b.c/?d=e#f</a> g`
+    );
+  });
+  test("with multiple links", () => {
+    expect(linkify("hello http://foo.bar/ world https://bar.baz/ tadda!")).eq(
+      `hello <a href="http://foo.bar/" target="_blank">http://foo.bar/</a> world <a href="https://bar.baz/" target="_blank">https://bar.baz/</a> tadda!`
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "vite-plugin-toml": "^0.5.0",
         "vitest": "^0.33.0",
         "vue": "^3.2.29",
-        "vue-3-linkify": "^1.1.0",
         "vue-eslint-parser": "^9.1.0",
         "vue-hot-reload-api": "^2.3.4",
         "vue-i18n": "^9.2.2",
@@ -3058,11 +3057,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
-    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "license": "MIT"
@@ -5075,25 +5069,12 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/linkify-html": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/linkify-html/-/linkify-html-3.0.5.tgz",
-      "integrity": "sha512-3O7HEYjkugX+C/G2C2wyBmIt8Mt0pmeaHNIxRHodCFeQQeSxSoZHR+5hC1pi0WrmoEvfnSemyZyYTM8w3lo9cA==",
-      "peerDependencies": {
-        "linkifyjs": "^3.0.0"
-      }
-    },
     "node_modules/linkify-it": {
       "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
-    },
-    "node_modules/linkifyjs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-3.0.5.tgz",
-      "integrity": "sha512-1Y9XQH65eQKA9p2xtk+zxvnTeQBG7rdAXSkUG97DmuI/Xhji9uaUzaWxRj6rf9YC0v8KKHkxav7tnLX82Sz5Fg=="
     },
     "node_modules/local-pkg": {
       "version": "0.4.3",
@@ -7091,19 +7072,6 @@
         "@vue/shared": "3.3.4"
       }
     },
-    "node_modules/vue-3-linkify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vue-3-linkify/-/vue-3-linkify-1.1.0.tgz",
-      "integrity": "sha512-UXiG4rLS17ZKviAXBlCkuL015BgJsblyyq6CcQfxfiIT/s/RiFhd7FQ/MGAEF/fpwjwn+zllMJPmK/QdsXAb8Q==",
-      "dependencies": {
-        "linkify-html": "^3.0.5",
-        "linkifyjs": "^3.0.5",
-        "xss": "^1.0.11"
-      },
-      "peerDependencies": {
-        "vue": "^3.2.0"
-      }
-    },
     "node_modules/vue-component-type-helpers": {
       "version": "1.6.5",
       "license": "MIT"
@@ -7405,21 +7373,6 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "license": "MIT"
-    },
-    "node_modules/xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "vite-plugin-toml": "^0.5.0",
     "vitest": "^0.33.0",
     "vue": "^3.2.29",
-    "vue-3-linkify": "^1.1.0",
     "vue-eslint-parser": "^9.1.0",
     "vue-hot-reload-api": "^2.3.4",
     "vue-i18n": "^9.2.2",


### PR DESCRIPTION
🚀 reduced javascript bundle size

- replaced vue-3-linkify with much simpler implementation
- use code splitting for vue-router (load session/config code only when needed)
- `-100kb` JS (uncompressed) for initial load

before
```
../dist/assets/index-bc2fefeb.js                 557.74 kB │ gzip: 182.28 kB
```

after
```
../dist/assets/index-c6fb1d50.js                 457.45 kB │ gzip: 149.60 kB
../dist/assets/Config-e31e7f96.js                 15.98 kB │ gzip:   5.59 kB
../dist/assets/ChargingSessions-d8d5464b.js       22.07 kB │ gzip:   6.21 kB
```