### PR TITLE
Senec: add optional schema definition

### DIFF
--- a/templates/definition/meter/senec-home.yaml
+++ b/templates/definition/meter/senec-home.yaml
@@ -9,6 +9,12 @@ params:
     allinone: true
   - name: host
   - name: capacity
+  - name: schema
+    type: choice
+    validvalues:
+      - http
+      - https
+    default: http
     advanced: true
 render: |
   type: custom
@@ -16,10 +22,11 @@ render: |
     source: http
     unpack: hex
     decode: float32
-    uri: http://{{ .host }}/lala.cgi
+    uri: {{ .schema }}://{{ .host }}/lala.cgi
     method: POST
     headers:
     - content-type: application/json
+    insecure: true
   {{- if eq .usage "grid" }}
     body: '{"ENERGY":{"GUI_GRID_POW":""}}'
     jq: .ENERGY.GUI_GRID_POW | sub("fl_"; "")
@@ -34,10 +41,11 @@ render: |
     scale: -1
   soc:
     source: http
-    uri: http://{{ .host }}/lala.cgi
+    uri: {{ .schema }}://{{ .host }}/lala.cgi
     method: POST
     headers:
     - content-type: application/json
+    insecure: true
     body: '{"ENERGY":{"GUI_BAT_DATA_FUEL_CHARGE":""}}'
     jq: .ENERGY.GUI_BAT_DATA_FUEL_CHARGE | sub("fl_"; "")
     unpack: hex

--- a/templates/docs/meter/senec-home_0.yaml
+++ b/templates/docs/meter/senec-home_0.yaml
@@ -13,6 +13,7 @@ render:
       template: senec-home
       usage: grid
       host: 192.0.2.2 # IP-Adresse oder Hostname
+      schema: http # Optional
   - usage: pv
     default: |
       type: template
@@ -24,15 +25,18 @@ render:
       template: senec-home
       usage: pv
       host: 192.0.2.2 # IP-Adresse oder Hostname
+      schema: http # Optional
   - usage: battery
     default: |
       type: template
       template: senec-home
       usage: battery
       host: 192.0.2.2 # IP-Adresse oder Hostname
+      capacity: 50 # Akkukapazität in kWh (Optional)
     advanced: |
       type: template
       template: senec-home
       usage: battery
       host: 192.0.2.2 # IP-Adresse oder Hostname
       capacity: 50 # Akkukapazität in kWh (Optional)
+      schema: http # Optional


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/9488. 

This PR leaves `http` as default. We should later change this to `https`. Senec should *REALLY* follow fest practices and implement the standard redirect.