### PR TITLE
Guard soc against invalid values

### DIFF
--- a/core/loadpoint_charger.go
+++ b/core/loadpoint_charger.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/soc"
 )
 
 // chargerHasFeature checks availability of charger feature
@@ -27,7 +28,7 @@ func (lp *Loadpoint) publishChargerFeature(f api.Feature) {
 // chargerSoc returns charger soc if available
 func (lp *Loadpoint) chargerSoc() (float64, error) {
 	if c, ok := lp.charger.(api.Battery); ok {
-		return c.Soc()
+		return soc.Guard(c.Soc())
 	}
 	return 0, api.ErrNotAvailable
 }

--- a/core/site.go
+++ b/core/site.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evcc-io/evcc/core/planner"
 	"github.com/evcc-io/evcc/core/prioritizer"
 	"github.com/evcc-io/evcc/core/session"
+	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server/db"
 	"github.com/evcc-io/evcc/server/db/settings"
@@ -483,7 +484,7 @@ func (site *Site) updateMeters() error {
 
 			// battery soc and capacity
 			var capacity float64
-			soc, err := meter.(api.Battery).Soc()
+			soc, err := soc.Guard(meter.(api.Battery).Soc())
 
 			if err == nil {
 				// weigh soc by capacity and accumulate total capacity

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -107,7 +107,7 @@ func (s *Estimator) Soc(chargedEnergy float64) (float64, error) {
 	var fetchedSoc *float64
 
 	if charger, ok := s.charger.(api.Battery); ok {
-		f, err := charger.Soc()
+		f, err := Guard(charger.Soc())
 
 		// if the charger does or could provide Soc, we always use it instead of using the vehicle API
 		if err == nil || !errors.Is(err, api.ErrNotAvailable) {
@@ -128,7 +128,7 @@ func (s *Estimator) Soc(chargedEnergy float64) (float64, error) {
 	}
 
 	if fetchedSoc == nil {
-		f, err := s.vehicle.Soc()
+		f, err := Guard(s.vehicle.Soc())
 		if err != nil {
 			// required for online APIs with refreshkey
 			if errors.Is(err, api.ErrMustRetry) {

--- a/core/soc/helper.go
+++ b/core/soc/helper.go
@@ -1,0 +1,20 @@
+package soc
+
+import "fmt"
+
+// Guard checks soc value for validity
+func Guard(soc float64, err error) (float64, error) {
+	switch {
+	case err != nil:
+		return soc, err
+
+	case soc < 0:
+		return 0, fmt.Errorf("invalid soc: %.1f", soc)
+
+	case soc > 100:
+		return 100, fmt.Errorf("invalid soc: %.1f", soc)
+
+	default:
+		return soc, nil
+	}
+}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/9504

@premultiply liefert der Estimator immer <100%? Sonst gäbe das Ärger :)