### PR TITLE
Easee: async waits use configured timeout

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -523,7 +523,7 @@ func (c *Easee) waitForChargerEnabledState(expEnabled bool) error {
 		return nil
 	}
 
-	timer := time.NewTimer(10 * time.Second)
+	timer := time.NewTimer(c.Client.Timeout)
 	for {
 		select {
 		case obs := <-c.obsC:
@@ -552,7 +552,7 @@ func (c *Easee) waitForDynamicChargerCurrent(targetCurrent float64) error {
 	}
 	c.mux.Unlock()
 
-	timer := time.NewTimer(10 * time.Second)
+	timer := time.NewTimer(c.Client.Timeout)
 	for {
 		select {
 		case obs := <-c.obsC:


### PR DESCRIPTION
small fix that changes to hardcoded 10s timeout for async waits to the timeout value configured in the easee config