### PR TITLE
Always treat charger as enabled when charging 

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -640,8 +640,17 @@ func (lp *Loadpoint) syncCharger() error {
 		lp.publish("enabled", lp.enabled)
 	}()
 
+	if !enabled && lp.charging() {
+		if lp.guardGracePeriodElapsed() {
+			lp.log.WARN.Println("charger logic error: disabled but charging")
+		}
+		enabled = true // treat as enabled when charging
+		lp.elapseGuard()
+		return nil
+	}
+
 	// status in sync
-	if enabled && lp.enabled {
+	if enabled == lp.enabled {
 		// sync max current
 		if charger, ok := lp.charger.(api.CurrentGetter); ok && enabled {
 			current, err := charger.GetMaxCurrent()
@@ -667,15 +676,6 @@ func (lp *Loadpoint) syncCharger() error {
 		if lp.guardGracePeriodElapsed() && lp.phaseSwitchCompleted() && (enabled || lp.connected()) {
 			lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
 		}
-		lp.elapseGuard()
-		return nil
-	}
-
-	if !enabled && lp.charging() {
-		if lp.guardGracePeriodElapsed() {
-			lp.log.WARN.Println("charger logic error: disabled but charging")
-		}
-		enabled = true // treat as enabled when charging
 		lp.elapseGuard()
 		return nil
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -675,7 +675,7 @@ func (lp *Loadpoint) syncCharger() error {
 		if lp.guardGracePeriodElapsed() {
 			lp.log.WARN.Println("charger logic error: disabled but charging")
 		}
-		enabled = true //defer sets it on lp
+		enabled = true // treat as enabled when charging
 		lp.elapseGuard()
 		return nil
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -641,7 +641,7 @@ func (lp *Loadpoint) syncCharger() error {
 	}()
 
 	// status in sync
-	if enabled == lp.enabled {
+	if enabled && lp.enabled {
 		// sync max current
 		if charger, ok := lp.charger.(api.CurrentGetter); ok && enabled {
 			current, err := charger.GetMaxCurrent()
@@ -675,6 +675,7 @@ func (lp *Loadpoint) syncCharger() error {
 		if lp.guardGracePeriodElapsed() {
 			lp.log.WARN.Println("charger logic error: disabled but charging")
 		}
+		enabled = true //defer sets it on lp
 		lp.elapseGuard()
 		return nil
 	}

--- a/core/loadpoint_sync_test.go
+++ b/core/loadpoint_sync_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/mock"
+	"github.com/evcc-io/evcc/util"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncCharger(t *testing.T) {
+	tc := []struct {
+		expected, actual bool
+	}{
+		{false, false},
+		{false, true},
+		{true, false},
+		{true, true},
+	}
+
+	ctrl := gomock.NewController(t)
+
+	for _, tc := range tc {
+		charger := mock.NewMockCharger(ctrl)
+		charger.EXPECT().Enabled().Return(tc.actual, nil).AnyTimes()
+
+		lp := &Loadpoint{
+			log:     util.NewLogger("foo"),
+			clock:   clock.New(),
+			charger: charger,
+			enabled: tc.expected,
+		}
+
+		assert.NoError(t, lp.syncCharger())
+		assert.Equal(t, tc.actual, lp.enabled)
+	}
+}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/9540, https://github.com/evcc-io/evcc/issues/9586. Possibly fixes #9473.

- sync current only on enabled lp
- charger logic error detection now corrects enabled state of lp

/cc @DerAndereAndi hiermit werden die Logikfehler im Charger wieder vom Loadpoint abgefangen. Ich würde daher drauf verzichten, das im TWC zusätzlich zu korrigieren.