### PR TITLE
Fix EEBUS enable detection

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -274,6 +274,11 @@ func (c *EEBus) Enabled() (bool, error) {
 		return c.expectedEnableUnpluggedState, nil
 	}
 
+	// if the EV is charging
+	if state == api.StatusC {
+		return true, nil
+	}
+
 	limits, err := c.emobility.EVLoadControlObligationLimits()
 	if err != nil {
 		// there are no overload protection limits available, e.g. because the data was not received yet


### PR DESCRIPTION
- If the EV is charging, make sure to report as being enabled
- Fixes https://github.com/evcc-io/evcc/issues/9473