### PR TITLE
Delay last soc update after charge stops

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -424,8 +424,10 @@ func (lp *Loadpoint) evChargeStopHandler() {
 	}
 
 	// soc update reset
-	provider.ResetCached()
-	lp.socUpdated = time.Time{}
+	time.AfterFunc(30*time.Second, func() { 
+		provider.ResetCached()
+		lp.socUpdated = time.Time{}
+	})
 
 	// reset pv enable/disable timer
 	// https://github.com/evcc-io/evcc/issues/2289

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -424,7 +424,7 @@ func (lp *Loadpoint) evChargeStopHandler() {
 	}
 
 	// soc update reset
-	time.AfterFunc(30*time.Second, func() { 
+	time.AfterFunc(30*time.Second, func() {
 		provider.ResetCached()
 		lp.socUpdated = time.Time{}
 	})

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -451,7 +451,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	lp.Update(-5000, false, false, false, 0, nil, nil)
 
-	time.Sleep(30*time.Second) // wait until soc update timer expires
+	time.Sleep(30 * time.Second) // wait until soc update timer expires
 
 	t.Log("soc has fallen below target - soc update timer expired")
 	clock.Add(pollInterval)

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -451,10 +451,9 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	lp.Update(-5000, false, false, false, 0, nil, nil)
 
-	time.Sleep(30 * time.Second) // wait until soc update timer expires
-
 	t.Log("soc has fallen below target - soc update timer expired")
 	clock.Add(pollInterval)
+	time.Sleep(45 * time.Second) // wait until soc update fuction runs
 	vehicle.EXPECT().Soc().Return(85.0, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -453,7 +453,6 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 
 	t.Log("soc has fallen below target - soc update timer expired")
 	clock.Add(pollInterval)
-	time.Sleep(45 * time.Second) // wait until soc update fuction runs
 	vehicle.EXPECT().Soc().Return(85.0, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -451,6 +451,8 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	lp.Update(-5000, false, false, false, 0, nil, nil)
 
+	time.Sleep(30*time.Second) // wait until soc update timer expires
+
 	t.Log("soc has fallen below target - soc update timer expired")
 	clock.Add(pollInterval)
 	vehicle.EXPECT().Soc().Return(85.0, nil)


### PR DESCRIPTION
Porsche API will not provide the correct value (100%) if charge stops due to full battery.