### PR TITLE
PR build artifact

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: evcc
+          path: ./evcc
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ich habe öfter mitbekommen, dass ein PR getestet werden sollte, aber da die Personen die testen sollten selbst keinen Build erstellen konnte, Dinge germergt wurden, damit sie dann im nightly getestet werden können.

Eine Alternative wäre den PR build als artifact bereit zu stellen. Das wäre im Moment nur ein linux amd64 binary, das recht versteckt in der Build Action ist. Es ist denkbar, auch arm oder windows zu erstellen oder auch ein Kommentar in dem PR mit einem Link zu platzieren.

Ist das eine Idee die Vorteile bringt oder lieber nichts an dem bekannten merge und dann nightly Prozess ändern?

![grafik](https://github.com/evcc-io/evcc/assets/4662023/e9883805-257c-46ca-922a-2bec45518593)
