### PR TITLE
UI configurable vehicle settings (onIdentify replacement)

### DIFF
--- a/api/actionconfig.go
+++ b/api/actionconfig.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/fatih/structs"
-	"github.com/imdario/mergo"
-	"github.com/jinzhu/copier"
 )
 
 // ActionConfig defines an action to take on event
@@ -15,22 +13,9 @@ type ActionConfig struct {
 	Mode       *ChargeMode `mapstructure:"mode,omitempty"`       // Charge Mode
 	MinCurrent *float64    `mapstructure:"minCurrent,omitempty"` // Minimum Current
 	MaxCurrent *float64    `mapstructure:"maxCurrent,omitempty"` // Maximum Current
-	MinSoc     *int        `mapstructure:"minSoc,omitempty"`     // Minimum Soc
-	TargetSoc  *int        `mapstructure:"targetSoc,omitempty"`  // Target Soc
+	MinSoc_    *int        `mapstructure:"minSoc,omitempty"`     // Minimum Soc (deprecated)
+	TargetSoc_ *int        `mapstructure:"targetSoc,omitempty"`  // Target Soc (deprecated)
 	Priority   *int        `mapstructure:"priority,omitempty"`   // Priority
-}
-
-// Merge merges all non-nil properties of the additional config into the base config.
-// The receiver's config remains immutable.
-func (a ActionConfig) Merge(m ActionConfig) ActionConfig {
-	var res ActionConfig
-	if err := copier.Copy(&res, a); err != nil {
-		panic(err)
-	}
-	if err := mergo.MergeWithOverwrite(&res, m); err != nil {
-		panic(err)
-	}
-	return res
 }
 
 // String implements Stringer and returns the ActionConfig as comma-separated key:value string

--- a/api/api.go
+++ b/api/api.go
@@ -184,6 +184,10 @@ type Vehicle interface {
 	IconDescriber
 	Title() string
 	SetTitle(string)
+	DefaultTargetSoc() int
+	SetDefaultTargetSoc(int)
+	MinSoc() int
+	SetMinSoc(int)
 	Phases() int
 	Identifiers() []string
 	OnIdentified() ActionConfig

--- a/assets/js/components/ChargingPlanArrival.vue
+++ b/assets/js/components/ChargingPlanArrival.vue
@@ -16,17 +16,46 @@
 						@change="changeMinSoc"
 					>
 						<option
-							v-for="soc in [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50]"
-							:key="soc"
-							:value="soc"
+							v-for="{ value, label } in minSocOptions"
+							:key="value"
+							:value="value"
 						>
-							{{ soc ? `${soc}%` : "--" }}
+							{{ label }}
 						</option>
 					</select>
 				</div>
 			</div>
 			<small class="col-12 col-md-6 ps-md-4">
 				{{ $t("main.loadpointSettings.minSoc.description", [selectedMinSoc || "x"]) }}
+			</small>
+		</div>
+		<div class="row">
+			<div class="col-12 col-md-6">
+				<div
+					class="defaulttargetsoc d-flex justify-content-between align-items-baseline mb-2 me-sm-4"
+				>
+					<label :for="formId('defaulttargetsoc')" class="pt-1">
+						{{ $t("main.loadpointSettings.defaultTargetSoc.label") }}
+					</label>
+					<select
+						:id="formId('defaulttargetsoc')"
+						v-model.number="selectedDefaultTargetSoc"
+						class="minSocSelect form-select mb-2"
+						:disabled="!socBasedCharging"
+						@change="changeDefaultTargetSoc"
+					>
+						<option
+							v-for="{ value, label } in defaultTargetSocOptions"
+							:key="value"
+							:value="value"
+						>
+							{{ label }}
+						</option>
+					</select>
+				</div>
+			</div>
+			<small class="col-12 col-md-6 ps-md-4">
+				{{ $t("main.loadpointSettings.defaultTargetSoc.description") }}
 			</small>
 		</div>
 	</div>
@@ -41,13 +70,37 @@ export default {
 		vehicleName: String,
 		socBasedCharging: Boolean,
 	},
-	emits: ["minsoc-updated"],
+	emits: ["minsoc-updated", "defaulttargetsoc-updated"],
 	data: function () {
-		return { selectedMinSoc: this.minSoc };
+		return {
+			selectedMinSoc: this.minSoc,
+			selectedDefaultTargetSoc: this.defaultTargetSoc,
+		};
+	},
+	computed: {
+		minSocOptions() {
+			const options = [{ value: 0, label: "--" }];
+			for (let i = 5; i <= 50; i += 5) {
+				options.push({ value: i, label: `${i}%` });
+			}
+			return options;
+		},
+		defaultTargetSocOptions() {
+			const options = [
+				{ value: 0, label: this.$t("main.loadpointSettings.defaultTargetSoc.none") },
+			];
+			for (let i = 20; i <= 100; i += 5) {
+				options.push({ value: i, label: `${i}%` });
+			}
+			return options;
+		},
 	},
 	watch: {
 		minSoc: function (value) {
 			this.selectedMinSoc = value;
+		},
+		defaultTargetSoc: function (value) {
+			this.selectedDefaultTargetSoc = value;
 		},
 	},
 	methods: {
@@ -56,6 +109,9 @@ export default {
 		},
 		changeMinSoc: function () {
 			this.$emit("minsoc-updated", this.selectedMinSoc);
+		},
+		changeDefaultTargetSoc: function () {
+			this.$emit("defaulttargetsoc-updated", this.selectedDefaultTargetSoc);
 		},
 	},
 };

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -59,6 +59,10 @@ type API interface {
 	GetTargetSoc() int
 	// SetTargetSoc sets the charge target soc
 	SetTargetSoc(int)
+	// GetDefaultTargetSoc returns the vehicles default target soc
+	GetDefaultTargetSoc() int
+	// SetDefaultTargetSoc sets the vehicles default target soc
+	SetDefaultTargetSoc(int)
 	// GetPlan creates a charging plan
 	GetPlan(targetTime time.Time, maxPower float64) (time.Duration, api.Rates, error)
 	// GetEnableThreshold gets the loadpoint enable threshold

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -34,7 +34,7 @@ func (lp *Loadpoint) planRequiredDuration(maxPower float64) time.Duration {
 	}
 
 	// TODO vehicle soc limit
-	targetSoc := lp.Soc.target
+	targetSoc := lp.GetTargetSoc()
 	if targetSoc == 0 {
 		targetSoc = 100
 	}

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -126,10 +126,6 @@ func (lp *Loadpoint) setActiveVehicle(vehicle api.Vehicle) {
 	// lock api
 	lp.Lock()
 
-	// reset minSoc and targetSoc before change
-	lp.setMinSoc(0)
-	lp.setTargetSoc(100)
-
 	// reset target energy
 	lp.setTargetEnergy(0)
 
@@ -228,13 +224,14 @@ func (lp *Loadpoint) publishVehicleFeature(f api.Feature) {
 
 // persistVehicleSettings stores user configuration (via UI/API) for the current vehicle
 func (lp *Loadpoint) persistVehicleSettings() {
-	idx := lp.coordinator.GetVehicleIndex(lp.GetVehicle())
+	v := lp.GetVehicle()
+	idx := lp.coordinator.GetVehicleIndex(v)
 	if idx == -1 {
 		return
 	}
-	settings.SetInt(fmt.Sprintf("vehicle.%d.targetSoc", idx), int64(lp.Soc.target))
 	settings.SetFloat(fmt.Sprintf("vehicle.%d.targetEnergy", idx), lp.targetEnergy)
-	settings.SetInt(fmt.Sprintf("vehicle.%d.minSoc", idx), int64(lp.Soc.min))
+	settings.SetInt(fmt.Sprintf("vehicle.%d.minSoc", idx), int64(v.MinSoc()))
+	settings.SetInt(fmt.Sprintf("vehicle.%d.defaultTargetSoc", idx), int64(v.DefaultTargetSoc()))
 	settings.SetTime(fmt.Sprintf("vehicle.%d.targetTime", idx), lp.targetTime)
 }
 
@@ -244,15 +241,19 @@ func (lp *Loadpoint) restoreVehicleSettings() {
 	if idx == -1 {
 		return
 	}
+	/* TODO
 	if v, err := settings.Int(fmt.Sprintf("vehicle.%d.targetSoc", idx)); err == nil {
 		lp.setTargetSoc(int(v))
 	}
+	*/
 	if v, err := settings.Float(fmt.Sprintf("vehicle.%d.targetEnergy", idx)); err == nil {
 		lp.setTargetEnergy(v)
 	}
+	/* TODO
 	if v, err := settings.Int(fmt.Sprintf("vehicle.%d.minSoc", idx)); err == nil {
 		lp.setMinSoc(int(v))
 	}
+	*/
 	if v, err := settings.Time(fmt.Sprintf("vehicle.%d.targetTime", idx)); err == nil {
 		if v.After(time.Now()) {
 			lp.setTargetTime(v)

--- a/core/site.go
+++ b/core/site.go
@@ -245,6 +245,20 @@ func (site *Site) restoreSettings() {
 	if v, err := settings.Float("site.smartCostLimit"); err == nil {
 		site.SmartCostLimit = v
 	}
+
+	site.restoreSettings()
+}
+
+// restoreVehicleSettings restores vehicle settings from database
+func restoreVehicleSettings(site *Site) {
+	for idx, v := range site.coordinator.GetVehicles() {
+		if soc, err := settings.Int(fmt.Sprintf("vehicle.%d.defaultTargetSoc", idx)); err == nil {
+			v.SetDefaultTargetSoc(int(soc))
+		}
+		if soc, err := settings.Int(fmt.Sprintf("vehicle.%d.minSoc", idx)); err == nil {
+			v.SetMinSoc(int(soc))
+		}
+	}
 }
 
 func meterCapabilities(name string, meter interface{}) string {

--- a/server/http.go
+++ b/server/http.go
@@ -135,6 +135,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, cache *util.Cache) {
 			"phases":           {[]string{"POST", "OPTIONS"}, "/phases/{value:[0-9]+}", phasesHandler(lp)},
 			"targetenergy":     {[]string{"POST", "OPTIONS"}, "/target/energy/{value:[0-9.]+}", floatHandler(pass(lp.SetTargetEnergy), lp.GetTargetEnergy)},
 			"targetsoc":        {[]string{"POST", "OPTIONS"}, "/target/soc/{value:[0-9]+}", intHandler(pass(lp.SetTargetSoc), lp.GetTargetSoc)},
+			"defaulttargetsoc": {[]string{"POST", "OPTIONS"}, "/target/defaultsoc/{value:[0-9]+}", intHandler(pass(lp.SetDefaultTargetSoc), lp.GetDefaultTargetSoc)},
 			"targettime":       {[]string{"POST", "OPTIONS"}, "/target/time/{time:[0-9TZ:.-]+}", targetTimeHandler(lp)},
 			"targettime2":      {[]string{"DELETE", "OPTIONS"}, "/target/time", targetTimeRemoveHandler(lp)},
 			"plan":             {[]string{"GET"}, "/target/plan", planHandler(lp)},

--- a/vehicle/embed.go
+++ b/vehicle/embed.go
@@ -5,13 +5,15 @@ import (
 )
 
 type embed struct {
-	Title_       string           `mapstructure:"title"`
-	Icon_        string           `mapstructure:"icon"`
-	Capacity_    float64          `mapstructure:"capacity"`
-	Phases_      int              `mapstructure:"phases"`
-	Identifiers_ []string         `mapstructure:"identifiers"`
-	Features_    []api.Feature    `mapstructure:"features"`
-	OnIdentify   api.ActionConfig `mapstructure:"onIdentify"`
+	Title_            string           `mapstructure:"title"`
+	Icon_             string           `mapstructure:"icon"`
+	Capacity_         float64          `mapstructure:"capacity"`
+	Phases_           int              `mapstructure:"phases"`
+	DefaultTargetSoc_ int              `mapstructure:"targetSoc"`
+	MinSoc_           int              `mapstructure:"minSoc"`
+	Identifiers_      []string         `mapstructure:"identifiers"`
+	Features_         []api.Feature    `mapstructure:"features"`
+	OnIdentify        api.ActionConfig `mapstructure:"onIdentify"`
 }
 
 // Title implements the api.Vehicle interface
@@ -32,6 +34,26 @@ func (v *embed) Capacity() float64 {
 // Phases returns the phases used by the vehicle
 func (v *embed) Phases() int {
 	return v.Phases_
+}
+
+// DefaultTargetSoc implements the api.Vehicle interface
+func (v *embed) DefaultTargetSoc() int {
+	return v.DefaultTargetSoc_
+}
+
+// SetDefaultTargetSoc implements the api.Vehicle interface
+func (v *embed) SetDefaultTargetSoc(soc int) {
+	v.DefaultTargetSoc_ = soc
+}
+
+// MinSoc implements the api.Vehicle interface
+func (v *embed) MinSoc() int {
+	return v.MinSoc_
+}
+
+// SetMinSoc implements the api.Vehicle interface
+func (v *embed) SetMinSoc(soc int) {
+	v.MinSoc_ = soc
 }
 
 // Identifiers implements the api.Identifier interface


### PR DESCRIPTION
Determine minSoc and targetSoc based on system state (check vehicle, check loadpoint, use defaults) instead of event-based copying of values.

fixes #9641