### PR TITLE
Restore vehicle onIdentify behavior for targetSoc from yaml

### DIFF
--- a/api/actionconfig.go
+++ b/api/actionconfig.go
@@ -15,7 +15,7 @@ type ActionConfig struct {
 	Mode       *ChargeMode `mapstructure:"mode,omitempty"`       // Charge Mode
 	MinCurrent *float64    `mapstructure:"minCurrent,omitempty"` // Minimum Current
 	MaxCurrent *float64    `mapstructure:"maxCurrent,omitempty"` // Maximum Current
-	MinSoc     *int        `mapstructure:"minSoc,omitempty"`     // Minimum Soc
+	MinSoc_    *int        `mapstructure:"minSoc,omitempty"`     // Minimum Soc (deprecated)
 	TargetSoc  *int        `mapstructure:"targetSoc,omitempty"`  // Target Soc
 	Priority   *int        `mapstructure:"priority,omitempty"`   // Priority
 }

--- a/api/actionconfig_test.go
+++ b/api/actionconfig_test.go
@@ -18,10 +18,8 @@ func TestMerge(t *testing.T) {
 
 	now := ModeNow
 	two := 2
-	three := 3
 	new := ActionConfig{
 		Mode:     &now,
-		MinSoc:   &three,
 		Priority: &two,
 	}
 
@@ -38,7 +36,6 @@ func TestMerge(t *testing.T) {
 	assert.Equal(t, dst, ActionConfig{
 		Mode:       &now,
 		MinCurrent: &six,
-		MinSoc:     &three,
 		Priority:   &two,
 	}, "new wrong")
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -321,8 +321,9 @@ func (lp *Loadpoint) collectDefaults() {
 	} else {
 		lp.log.ERROR.Printf("error allocating action config: %v", err)
 	}
-	// deprecated: do not reapply deprecated lp.targetSoc, use vehicle.targetSoc instead
+	// deprecated: do not reapply deprecated lp config values
 	actionCfg.TargetSoc = nil
+	actionCfg.MinSoc_ = nil
 }
 
 // requestUpdate requests site to update this loadpoint

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -317,8 +317,6 @@ func (lp *Loadpoint) collectDefaults() {
 		*actionCfg.Mode = lp.GetMode()
 		*actionCfg.MinCurrent = lp.GetMinCurrent()
 		*actionCfg.MaxCurrent = lp.GetMaxCurrent()
-		*actionCfg.MinSoc = lp.GetMinSoc()
-		*actionCfg.TargetSoc = lp.GetTargetSoc()
 		*actionCfg.Priority = lp.GetPriority()
 	} else {
 		lp.log.ERROR.Printf("error allocating action config: %v", err)
@@ -551,6 +549,12 @@ func (lp *Loadpoint) applyAction(actionCfg api.ActionConfig) {
 	}
 	if min := actionCfg.MinCurrent; min != nil && *min >= *lp.onDisconnect.MinCurrent {
 		lp.SetMinCurrent(*min)
+	}
+	if actionCfg.MinSoc != nil {
+		lp.SetMinSoc(*actionCfg.MinSoc)
+	}
+	if actionCfg.TargetSoc != nil {
+		lp.SetTargetSoc(*actionCfg.TargetSoc)
 	}
 	if max := actionCfg.MaxCurrent; max != nil && *max <= *lp.onDisconnect.MaxCurrent {
 		lp.SetMaxCurrent(*max)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -321,9 +321,8 @@ func (lp *Loadpoint) collectDefaults() {
 	} else {
 		lp.log.ERROR.Printf("error allocating action config: %v", err)
 	}
-	// do not reapply deprecated lp config values
+	// deprecated: do not reapply deprecated lp.targetSoc, use vehicle.targetSoc instead
 	actionCfg.TargetSoc = nil
-	actionCfg.MinSoc = nil
 }
 
 // requestUpdate requests site to update this loadpoint
@@ -552,9 +551,6 @@ func (lp *Loadpoint) applyAction(actionCfg api.ActionConfig) {
 	}
 	if min := actionCfg.MinCurrent; min != nil && *min >= *lp.onDisconnect.MinCurrent {
 		lp.SetMinCurrent(*min)
-	}
-	if actionCfg.MinSoc != nil {
-		lp.SetMinSoc(*actionCfg.MinSoc)
 	}
 	if actionCfg.TargetSoc != nil {
 		lp.SetTargetSoc(*actionCfg.TargetSoc)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -321,6 +321,9 @@ func (lp *Loadpoint) collectDefaults() {
 	} else {
 		lp.log.ERROR.Printf("error allocating action config: %v", err)
 	}
+	// do not reapply deprecated lp config values
+	actionCfg.TargetSoc = nil
+	actionCfg.MinSoc = nil
 }
 
 // requestUpdate requests site to update this loadpoint

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -227,7 +227,6 @@ func TestApplyVehicleDefaults(t *testing.T) {
 			Mode:       &mode,
 			MinCurrent: &minCurrent,
 			MaxCurrent: &maxCurrent,
-			MinSoc_:    nil,
 			TargetSoc:  targetSoc,
 		}
 	}

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -148,7 +148,6 @@ func TestDefaultVehicle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mode := api.ModePV
-	minsoc := 20
 	targetsoc := 80
 
 	dflt := mock.NewMockVehicle(ctrl)
@@ -158,7 +157,6 @@ func TestDefaultVehicle(t *testing.T) {
 	dflt.EXPECT().Phases().AnyTimes()
 	dflt.EXPECT().OnIdentified().Return(api.ActionConfig{
 		Mode:      &mode,
-		MinSoc:    &minsoc,
 		TargetSoc: &targetsoc,
 	}).AnyTimes()
 
@@ -224,12 +222,12 @@ func TestDefaultVehicle(t *testing.T) {
 func TestApplyVehicleDefaults(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	newConfig := func(mode api.ChargeMode, minCurrent, maxCurrent float64, minSoc, targetSoc *int) api.ActionConfig {
+	newConfig := func(mode api.ChargeMode, minCurrent, maxCurrent float64, targetSoc *int) api.ActionConfig {
 		return api.ActionConfig{
 			Mode:       &mode,
 			MinCurrent: &minCurrent,
 			MaxCurrent: &maxCurrent,
-			MinSoc:     minSoc,
+			MinSoc_:    nil,
 			TargetSoc:  targetSoc,
 		}
 	}
@@ -241,12 +239,11 @@ func TestApplyVehicleDefaults(t *testing.T) {
 	}
 
 	// onIdentified config
-	minSoc := 1
 	targetSoc := 99
-	oi := newConfig(api.ModePV, 7, 15, &minSoc, &targetSoc)
+	oi := newConfig(api.ModePV, 7, 15, &targetSoc)
 
 	// onDefault config
-	od := newConfig(api.ModeOff, 6, 16, nil, nil)
+	od := newConfig(api.ModeOff, 6, 16, nil)
 
 	vehicle := mock.NewMockVehicle(ctrl)
 	vehicle.EXPECT().Title().Return("it's me").AnyTimes()
@@ -265,7 +262,7 @@ func TestApplyVehicleDefaults(t *testing.T) {
 	lp.ResetOnDisconnect = true
 
 	// check loadpoint default currents can't be violated
-	lp.applyAction(newConfig(*od.Mode, 5, 17, od.MinSoc, od.TargetSoc))
+	lp.applyAction(newConfig(*od.Mode, 5, 17, od.TargetSoc))
 	assertConfig(lp, od)
 
 	// vehicle identified

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -175,13 +175,10 @@ func TestDefaultVehicle(t *testing.T) {
 	// ondisconnect
 	off := api.ModeOff
 	zero := 0
-	hundred := 100
 	onDisconnect := api.ActionConfig{
 		Mode:       &off,
 		MinCurrent: &lp.MinCurrent,
 		MaxCurrent: &lp.MaxCurrent,
-		MinSoc:     &zero,
-		TargetSoc:  &hundred,
 		Priority:   &zero,
 	}
 
@@ -227,13 +224,13 @@ func TestDefaultVehicle(t *testing.T) {
 func TestApplyVehicleDefaults(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	newConfig := func(mode api.ChargeMode, minCurrent, maxCurrent float64, minSoc, targetSoc int) api.ActionConfig {
+	newConfig := func(mode api.ChargeMode, minCurrent, maxCurrent float64, minSoc, targetSoc *int) api.ActionConfig {
 		return api.ActionConfig{
 			Mode:       &mode,
 			MinCurrent: &minCurrent,
 			MaxCurrent: &maxCurrent,
-			MinSoc:     &minSoc,
-			TargetSoc:  &targetSoc,
+			MinSoc:     minSoc,
+			TargetSoc:  targetSoc,
 		}
 	}
 
@@ -244,10 +241,12 @@ func TestApplyVehicleDefaults(t *testing.T) {
 	}
 
 	// onIdentified config
-	oi := newConfig(api.ModePV, 7, 15, 1, 99)
+	minSoc := 1
+	targetSoc := 99
+	oi := newConfig(api.ModePV, 7, 15, &minSoc, &targetSoc)
 
 	// onDefault config
-	od := newConfig(api.ModeOff, 6, 16, 2, 98)
+	od := newConfig(api.ModeOff, 6, 16, nil, nil)
 
 	vehicle := mock.NewMockVehicle(ctrl)
 	vehicle.EXPECT().Title().Return("it's me").AnyTimes()
@@ -266,7 +265,7 @@ func TestApplyVehicleDefaults(t *testing.T) {
 	lp.ResetOnDisconnect = true
 
 	// check loadpoint default currents can't be violated
-	lp.applyAction(newConfig(*od.Mode, 5, 17, *od.MinSoc, *od.TargetSoc))
+	lp.applyAction(newConfig(*od.Mode, 5, 17, od.MinSoc, od.TargetSoc))
 	assertConfig(lp, od)
 
 	// vehicle identified


### PR DESCRIPTION
Partly reverts https://github.com/evcc-io/evcc/pull/9370 so that vehicle values from yaml are respected again.

A proper fix with UI configuration and new API endpoints here #9684

Restored behavior: `vehicle.targetSoc` (onIdentify) will be used again
@VolkerK62 Magst du die Doku anpassen https://docs.evcc.io/docs/reference/configuration/vehicles/#onidentify

Refactoring: yaml based `minSoc` settings will not be used (as today). Structure is kept so that yaml files remain backwards compatible. Removed/clarified deprecation in the source code.