### PR TITLE
Improve min/maxcurrent limit UI

### DIFF
--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -238,9 +238,9 @@ export default {
 		// other information
 		phases: Number,
 		phasesConfigured: Number,
+		phasesActive: Number,
 		minCurrent: Number,
 		maxCurrent: Number,
-		phasesActive: Number,
 		chargeCurrent: Number,
 		connectedDuration: Number,
 		chargeCurrents: Array,


### PR DESCRIPTION
- add lower min current options (0.125, 0.25, 0.5). No free form number input, they are messy on mobile. fixes #9595
- existing non-integer values (e.g. set via API) will now show correctly in settings modal. fixes #9595
- fixed phase-based min/max power estimation based on `phasesConfigured` and `phasesActive` fixes #6178

**Note:** 🧪 Feature remains experimental until we replace yaml config of this value with db persistance.

lower min current options
<img width="630" alt="lower options" src="https://github.com/evcc-io/evcc/assets/152287/f0e13df1-ad96-492e-bf1d-694723de202d">

add existing non-int values
<img width="581" alt="non int values" src="https://github.com/evcc-io/evcc/assets/152287/677c944b-77c4-41e1-85f4-c867c9ed3951">
