### PR TITLE
Improve session info discoverability

### DIFF
--- a/assets/js/components/LabelAndValue.vue
+++ b/assets/js/components/LabelAndValue.vue
@@ -1,13 +1,17 @@
 <template>
 	<div class="root">
-		<div class="mb-2 label" :class="labelClass">{{ label }}</div>
+		<div class="mb-2 label" :class="labelClass">
+			<slot name="label">{{ label }}</slot>
+		</div>
 		<slot>
 			<h3 class="value m-0 d-block d-sm-flex align-items-baseline" :class="valueClass">
-				<AnimatedNumber v-if="valueFmt" :to="value" :format="valueFmt" />
-				<span v-else>{{ value }}</span>
-				<div v-if="extraValue" class="extraValue ms-0 ms-sm-1 text-nowrap">
-					{{ extraValue }}
-				</div>
+				<slot name="value">
+					<AnimatedNumber v-if="valueFmt" :to="value" :format="valueFmt" />
+					<span v-else>{{ value }}</span>
+					<div v-if="extraValue" class="extraValue ms-0 ms-sm-1 text-nowrap">
+						{{ extraValue }}
+					</div>
+				</slot>
 			</h3>
 		</slot>
 	</div>

--- a/assets/js/components/LoadpointSessionInfo.vue
+++ b/assets/js/components/LoadpointSessionInfo.vue
@@ -1,0 +1,158 @@
+<template>
+	<div class="sessionInfo">
+		<LabelAndValue class="d-block" align="end">
+			<template #label>
+				<CustomSelect
+					:selected="selectedKey"
+					:options="selectOptions"
+					data-testid="sessionInfoSelect"
+					@change="selectOption($event.target.value)"
+				>
+					<span class="text-decoration-underline" data-testid="sessionInfoLabel">
+						{{ label }}
+					</span>
+				</CustomSelect>
+			</template>
+			<template #value>
+				<div data-testid="sessionInfoValue" @click="nextSessionInfo">
+					<div :class="{ 'd-none d-sm-block': showSm }">{{ value }}</div>
+					<div v-if="showSm" class="d-block d-sm-none">{{ valueSm }}</div>
+				</div>
+			</template>
+		</LabelAndValue>
+	</div>
+</template>
+
+<script>
+import LabelAndValue from "./LabelAndValue.vue";
+import formatter from "../mixins/formatter";
+import CustomSelect from "./CustomSelect.vue";
+import { getSessionInfo, setSessionInfo } from "../sessionInfo";
+
+export default {
+	name: "LoadpointSessionInfo",
+	components: {
+		LabelAndValue,
+		CustomSelect,
+	},
+	mixins: [formatter],
+	props: {
+		id: Number,
+		sessionEnergy: Number,
+		sessionCo2PerKWh: Number,
+		sessionPricePerKWh: Number,
+		sessionPrice: Number,
+		currency: String,
+		sessionSolarPercentage: Number,
+		chargeRemainingDurationInterpolated: Number,
+		chargeDurationInterpolated: Number,
+		tariffCo2: Number,
+		tariffGrid: Number,
+	},
+	data() {
+		return {
+			selectedKey: getSessionInfo(this.id),
+		};
+	},
+	computed: {
+		options: function () {
+			const result = [
+				{
+					key: "remaining",
+					value: this.fmtDuration(this.chargeRemainingDurationInterpolated),
+					available: this.chargeRemainingDurationInterpolated > 0,
+				},
+				{
+					key: "duration",
+					value: this.fmtDuration(this.chargeDurationInterpolated),
+				},
+				{
+					key: "solar",
+					value: this.solarFormatted,
+				},
+				{
+					key: "avgPrice",
+					value: this.fmtAvgPrice(this.sessionPricePerKWh),
+					valueSm: this.fmtAvgPriceShort(this.sessionPricePerKWh),
+					available: this.tariffGrid !== undefined,
+				},
+				{
+					key: "price",
+					value: this.priceFormatted,
+					available: this.tariffGrid !== undefined,
+				},
+				{
+					key: "co2",
+					value: this.fmtCo2Medium(this.sessionCo2PerKWh),
+					valueSm: this.fmtCo2Short(this.sessionCo2PerKWh),
+					available: this.tariffCo2 !== undefined,
+				},
+			];
+			// only show options that are available
+			return result.filter(({ available }) => available === undefined || available);
+		},
+		optionKeys() {
+			return this.options.map((option) => option.key);
+		},
+		selectOptions() {
+			return this.optionKeys.map((key) => ({
+				name: this.$t(`main.loadpoint.${key}`),
+				value: key,
+			}));
+		},
+		selectedOption() {
+			return (
+				this.options.find((option) => option.key === this.selectedKey) || this.options[0]
+			);
+		},
+		label() {
+			return this.$t(`main.loadpoint.${this.selectedOption.key}`);
+		},
+		value() {
+			return this.selectedOption.value;
+		},
+		valueSm() {
+			return this.selectedOption.valueSm;
+		},
+		showSm() {
+			return this.valueSm !== undefined;
+		},
+		solarFormatted() {
+			return `${this.fmtNumber(this.sessionSolarPercentage, 1)}%`;
+		},
+		priceFormatted() {
+			return `${this.fmtMoney(this.sessionPrice, this.currency)} ${this.fmtCurrencySymbol(
+				this.currency
+			)}`;
+		},
+	},
+	methods: {
+		fmtAvgPrice(value) {
+			return this.fmtPricePerKWh(value, this.currency, false);
+		},
+		fmtAvgPriceShort(value) {
+			return this.fmtPricePerKWh(value, this.currency, true);
+		},
+		nextSessionInfo() {
+			const index = this.optionKeys.indexOf(this.selectedKey);
+			this.selectedKey = this.optionKeys[index + 1] || this.optionKeys[0];
+			this.presist();
+		},
+		selectOption(value) {
+			this.selectedKey = value;
+			this.presist();
+		},
+		presist() {
+			setSessionInfo(this.id, this.selectedKey);
+		},
+	},
+};
+</script>
+
+<style scoped>
+.sessionInfo * {
+	cursor: pointer;
+	user-select: none;
+	-webkit-user-select: none;
+}
+</style>

--- a/assets/js/components/Savings.vue
+++ b/assets/js/components/Savings.vue
@@ -4,10 +4,10 @@
 			class="btn btn-link pe-0 text-decoration-none evcc-default-text text-nowrap d-flex align-items-end"
 			@click="openModal"
 		>
-			<span class="d-inline d-sm-none">{{
+			<span class="d-inline d-sm-none text-decoration-underline">{{
 				$t("footer.savings.footerShort", { percent })
 			}}</span
-			><span class="d-none d-sm-inline">{{
+			><span class="d-none d-sm-inline text-decoration-underline">{{
 				$t("footer.savings.footerLong", { percent })
 			}}</span>
 			<shopicon-regular-sun class="ms-2 text-evcc"></shopicon-regular-sun>

--- a/assets/js/components/Version.vue
+++ b/assets/js/components/Version.vue
@@ -7,7 +7,7 @@
 			class="btn btn-link ps-0 text-decoration-none evcc-default-text text-nowrap d-flex align-items-end"
 		>
 			<Logo class="logo me-2" />
-			v{{ installed }}
+			<span class="text-decoration-underline">v{{ installed }}</span>
 			<shopicon-regular-moonstars class="ms-2 text-gray-light"></shopicon-regular-moonstars>
 		</a>
 		<button
@@ -17,7 +17,7 @@
 			@click="openModal"
 		>
 			<shopicon-regular-gift class="me-2"></shopicon-regular-gift>
-			v{{ installed }}
+			<span class="text-decoration-underline">v{{ installed }}</span>
 			<span class="ms-2 d-none d-sm-block text-gray-medium text-decoration-underline">
 				{{ $t("footer.version.availableLong") }}
 			</span>
@@ -29,7 +29,7 @@
 			class="btn btn-link evcc-default-text ps-0 text-decoration-none text-nowrap d-flex align-items-end"
 		>
 			<Logo class="logo me-2" />
-			v{{ installed }}
+			<span class="text-decoration-underline">v{{ installed }}</span>
 		</a>
 
 		<Teleport to="body">

--- a/assets/js/sessionInfo.js
+++ b/assets/js/sessionInfo.js
@@ -1,20 +1,7 @@
 import settings from "./settings";
 
-const TIME = "time";
-const CO2 = "co2";
-const PRICE = "price";
-const AVG_PRICE = "avgPrice";
-const SOLAR = "solar";
-export const SESSION = {
-  TIME,
-  AVG_PRICE,
-  PRICE,
-  SOLAR,
-  CO2,
-};
-
-export function getSessionInfo(index) {
-  return settings.sessionInfo[index - 1] || TIME;
+export function getSessionInfo(index, fallback) {
+  return settings.sessionInfo[index - 1] || fallback;
 }
 
 export function setSessionInfo(index, value) {

--- a/tests/basics.evcc.yaml
+++ b/tests/basics.evcc.yaml
@@ -1,3 +1,5 @@
+interval: 0.1s
+
 site:
   title: Hello World
   meters:
@@ -10,10 +12,18 @@ meters:
       source: js
       script: |
         1000
+  - name: charger_meter
+    type: custom
+    power:
+      source: js
+      script: |
+        500
 
 loadpoints:
   - title: Carport
     charger: charger
+    meter: charger_meter
+    mode: now
 
 chargers:
   - name: charger
@@ -24,11 +34,12 @@ chargers:
     enabled:
       source: js
       script: |
-        false
+        true
     status:
       source: js
       script: |
-        "B"
+        "C"
     maxcurrent:
       source: js
-      script:
+      script: |
+        16

--- a/tests/basics.spec.js
+++ b/tests/basics.spec.js
@@ -35,3 +35,24 @@ test.describe("main screen", async () => {
     await expect(page.getByRole("heading", { name: "Guest vehicle" })).toBeVisible();
   });
 });
+
+test.describe("session info", async () => {
+  test("default", async ({ page }) => {
+    await expect(page.getByTestId("sessionInfoLabel").first()).toContainText("Duration");
+  });
+  test("change value", async ({ page }) => {
+    // by select
+    await page.getByTestId("sessionInfoSelect").first().selectOption({ label: "Solar" });
+    await expect(page.getByTestId("sessionInfoLabel").first()).toContainText("Solar");
+    // by click on value
+    await page.getByTestId("sessionInfoValue").first().click();
+    await expect(page.getByTestId("sessionInfoLabel").first()).toContainText("Duration");
+  });
+  test("keep selection on reload", async ({ page }) => {
+    await expect(page.getByTestId("sessionInfoLabel").first()).toContainText("Duration");
+    await page.getByTestId("sessionInfoSelect").first().selectOption({ label: "Solar" });
+    await expect(page.getByTestId("sessionInfoLabel").first()).toContainText("Solar");
+    await page.reload();
+    await expect(page.getByTestId("sessionInfoLabel").first()).toContainText("Solar");
+  });
+});


### PR DESCRIPTION
fixes #9750

- add underline to indicate interaction
- open dropdown by clicking on the label
  - show all options, better overview
  - same pattern as in session table (table headers)
- clicking on the value still toggles to next option (quick change)
  - disable unwanted browser text select when clicking faster
- add underline to footer links
- "duration" and "remaining" now don't exclude each other
- some fields are only shown if data exists (tariff.grid, tariff.co2, ...)

<img width="949" alt="underline" src="https://github.com/evcc-io/evcc/assets/152287/11118421-f8f9-4c3a-9de0-e7855f2dc9bb">
<img width="333" alt="select" src="https://github.com/evcc-io/evcc/assets/152287/5cf1d660-50b2-4bc9-8b63-7e6136c33cdc">

video of toggling by click or select

https://github.com/evcc-io/evcc/assets/152287/82e7c808-c64f-4ec4-8095-fc99cab1214f

