### PR TITLE
Support dynamic retrieval of battery capacity

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-//go:generate mockgen -package mock -destination ../mock/mock_api.go github.com/evcc-io/evcc/api Charger,ChargeState,PhaseSwitcher,Identifier,Meter,MeterEnergy,Vehicle,ChargeRater,Battery,Tariff
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -package mock -destination ../mock/mock_api.go github.com/evcc-io/evcc/api Charger,ChargeState,PhaseSwitcher,Identifier,Meter,MeterEnergy,Vehicle,ChargeRater,Battery,Tariff
 
 // ChargeMode is the charge operation mode. Valid values are off, now, minpv and pv
 type ChargeMode string

--- a/api/api.go
+++ b/api/api.go
@@ -116,7 +116,7 @@ type Battery interface {
 
 // BatteryCapacity provides a capacity in kWh
 type BatteryCapacity interface {
-	Capacity() float64
+	Capacity() (float64, error)
 }
 
 // ChargeState provides current charging status

--- a/api/feature.go
+++ b/api/feature.go
@@ -10,7 +10,7 @@ func (f *Feature) UnmarshalText(text []byte) error {
 	return err
 }
 
-//go:generate enumer -type Feature
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type Feature
 const (
 	_ Feature = iota
 	Offline

--- a/api/tariff.go
+++ b/api/tariff.go
@@ -1,6 +1,6 @@
 package api
 
-//go:generate enumer -type TariffType -trimprefix TariffType -transform=lower
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type TariffType -trimprefix TariffType -transform=lower
 
 type TariffType int
 

--- a/charger/easee/signalr.go
+++ b/charger/easee/signalr.go
@@ -62,7 +62,7 @@ const (
 // https://www.notion.so/Charger-template-c6a20ff7cfea41e2b5f80b00afb34af5
 type ObservationID int
 
-//go:generate enumer -type ObservationID
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type ObservationID
 const (
 	SELF_TEST_RESULT                                   ObservationID = 1   // PASSED or error codes [String]
 	SELF_TEST_DETAILS                                  ObservationID = 2   // JSON with details from self-test [String]

--- a/charger/warp/types.go
+++ b/charger/warp/types.go
@@ -86,7 +86,7 @@ type EmConfig struct {
 	PhaseSwitchingMode int  `json:"phase_switching_mode"`
 }
 
-//go:generate enumer -type ExternalControl -trimprefix ExternalControl -transform whitespace
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type ExternalControl -trimprefix ExternalControl -transform whitespace
 type ExternalControl int
 
 const (

--- a/charger/zaptec/const.go
+++ b/charger/zaptec/const.go
@@ -4,7 +4,7 @@ const ApiURL = "https://api.zaptec.com"
 
 type ObservationID int
 
-//go:generate enumer -type ObservationID
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type ObservationID
 
 // Commands
 const (

--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -71,7 +71,9 @@ meters:
         if (state.batterySoc < 10) state.batterySoc = 90;
         if (state.batterySoc > 90) state.batterySoc = 10;
         state.batterySoc;
-    capacity: 13.4
+    capacity:
+      source: const
+      value: 13.4
 
   - name: meter_charger_1
     type: custom

--- a/cmd/dumper.go
+++ b/cmd/dumper.go
@@ -103,7 +103,12 @@ func (d *dumper) Dump(name string, v interface{}) {
 	}
 
 	if v, ok := v.(api.BatteryCapacity); ok {
-		fmt.Fprintf(w, "Capacity:\t%.1fkWh\n", v.Capacity())
+		capcacity, err := v.Capacity()
+		if err != nil {
+			fmt.Fprintf(w, "Capacity:\t%v\n", err)
+		} else {
+			fmt.Fprintf(w, "Capacity:\t%.1fkWh\n", capcacity)
+		}
 	}
 
 	// charger

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -817,8 +817,12 @@ func (lp *Loadpoint) minSocNotReached() bool {
 	if lp.vehicleSoc != 0 {
 		return lp.vehicleSoc < float64(lp.Soc.min)
 	}
+	capacity, capacityErr := vehicle.Capacity()
+	if capacityErr != nil {
+		return false
+	}
 
-	minEnergy := vehicle.Capacity() * float64(lp.Soc.min) / 100 / soc.ChargeEfficiency
+	minEnergy := capacity * float64(lp.Soc.min) / 100 / soc.ChargeEfficiency
 	return minEnergy > 0 && lp.getChargedEnergy() < minEnergy
 }
 

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-//go:generate mockgen -package loadpoint -destination mock.go -mock_names API=MockAPI github.com/evcc-io/evcc/core/loadpoint API
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -package loadpoint -destination mock.go -mock_names API=MockAPI github.com/evcc-io/evcc/core/loadpoint API
 
 // Controller gives access to loadpoint
 type Controller interface {

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -387,7 +387,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	vehicle := mock.NewMockVehicle(ctrl)
 
 	// wrap vehicle with estimator
-	vehicle.EXPECT().Capacity().Return(float64(10))
+	vehicle.EXPECT().Capacity().Return(float64(10), nil)
 	vehicle.EXPECT().Phases().Return(0).AnyTimes()
 	socEstimator := soc.NewEstimator(util.NewLogger("foo"), charger, vehicle, false)
 
@@ -778,7 +778,7 @@ func TestMinSoc(t *testing.T) {
 
 		if v := tc.vehicle; v != nil {
 			lp.vehicle = tc.vehicle // avoid assigning nil to interface
-			v.EXPECT().Capacity().Return(10.0).MaxTimes(1)
+			v.EXPECT().Capacity().Return(10., nil).MaxTimes(1)
 		}
 
 		assert.Equal(t, tc.res, lp.minSocNotReached(), tc)

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -149,7 +149,12 @@ func (lp *Loadpoint) setActiveVehicle(vehicle api.Vehicle) {
 		lp.publish(vehiclePresent, true)
 		lp.publish(vehicleTitle, vehicle.Title())
 		lp.publish(vehicleIcon, vehicle.Icon())
-		lp.publish(vehicleCapacity, vehicle.Capacity())
+		capacity, capacityErr := vehicle.Capacity()
+		if capacityErr == nil {
+			lp.publish(vehicleCapacity, capacity)
+		} else {
+			lp.publish(vehicleCapacity, int64(0))
+		}
 		lp.restoreVehicleSettings()
 
 		lp.applyAction(vehicle.OnIdentified())

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -50,7 +50,10 @@ func (s *Estimator) Reset() {
 	s.prevSoc = 0
 	s.prevChargedEnergy = 0
 	s.initialSoc = 0
-	s.capacity = float64(s.vehicle.Capacity()) * 1e3  // cache to simplify debugging
+	capacity, err := s.vehicle.Capacity()
+	if err == nil {
+		s.capacity = float64(capacity) * 1e3 // cache to simplify debugging
+	}
 	s.virtualCapacity = s.capacity / ChargeEfficiency // initial capacity taking efficiency into account
 	s.energyPerSocStep = s.virtualCapacity / 100
 	s.minChargePower = 1000  // default 1 kW

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -17,7 +17,7 @@ func TestRemainingChargeDuration(t *testing.T) {
 	charger := mock.NewMockCharger(ctrl)
 	vehicle := mock.NewMockVehicle(ctrl)
 	// 9 kWh userBatCap => 10 kWh virtualBatCap
-	vehicle.EXPECT().Capacity().Return(float64(9))
+	vehicle.EXPECT().Capacity().Return(float64(9), nil)
 
 	ce := NewEstimator(util.NewLogger("foo"), charger, vehicle, false)
 	ce.vehicleSoc = 20.0
@@ -42,7 +42,7 @@ func TestSocEstimation(t *testing.T) {
 
 	// 9 kWh user battery capacity is converted to initial value of 10 kWh virtual capacity
 	var capacity float64 = 9
-	vehicle.EXPECT().Capacity().Return(capacity)
+	vehicle.EXPECT().Capacity().Return(capacity, nil)
 
 	ce := NewEstimator(util.NewLogger("foo"), charger, vehicle, true)
 	ce.vehicleSoc = 0.0
@@ -126,7 +126,7 @@ func TestSocFromChargerAndVehicleWithErrors(t *testing.T) {
 
 	// 9 kWh user battery capacity is converted to initial value of 10 kWh virtual capacity
 	var capacity float64 = 9
-	vehicle.EXPECT().Capacity().Return(capacity)
+	vehicle.EXPECT().Capacity().Return(capacity, nil)
 
 	ce := NewEstimator(util.NewLogger("foo"), charger, vehicle, true)
 	ce.vehicleSoc = 20.0
@@ -235,7 +235,7 @@ func TestImprovedEstimatorRemainingChargeDuration(t *testing.T) {
 	for _, tc := range tc {
 		t.Log(tc)
 
-		vehicle.EXPECT().Capacity().Return(tc.capacity)
+		vehicle.EXPECT().Capacity().Return(tc.capacity, nil)
 
 		ce := NewEstimator(util.NewLogger("foo"), charger, vehicle, false)
 		ce.vehicleSoc = tc.soc

--- a/meter/capacity.go
+++ b/meter/capacity.go
@@ -7,11 +7,11 @@ type capacity struct {
 // var _ api.BatteryCapacity = (*capacity)(nil)
 
 // Decorator returns the capacity decorator if capacity is specified or nil otherwise
-func (m *capacity) Decorator() func() float64 {
+func (m *capacity) Decorator() func() (float64, error) {
 	if m.Capacity == 0 {
 		return nil
 	}
-	return func() float64 {
-		return m.Capacity
+	return func() (float64, error) {
+		return m.Capacity, nil
 	}
 }

--- a/meter/lgess.go
+++ b/meter/lgess.go
@@ -49,7 +49,7 @@ func init() {
 	registry.Add("lgess", NewLgEssFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -f decorateLgEss -b *LgEss -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64"
+//go:generate go run ../cmd/tools/decorate.go -f decorateLgEss -b *LgEss -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() (float64, error)"
 
 // NewLgEssFromConfig creates an LgEss Meter from generic config
 func NewLgEssFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -73,7 +73,7 @@ func NewLgEssFromConfig(other map[string]interface{}) (api.Meter, error) {
 }
 
 // NewLgEss creates an LgEss Meter
-func NewLgEss(uri, usage, password string, cache time.Duration, capacity func() float64) (api.Meter, error) {
+func NewLgEss(uri, usage, password string, cache time.Duration, capacity func() (float64, error)) (api.Meter, error) {
 	lp, err := lgpcs.GetInstance(uri, password, cache)
 	if err != nil {
 		return nil, err

--- a/meter/lgess_decorators.go
+++ b/meter/lgess_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateLgEss(base *LgEss, meterEnergy func() (float64, error), battery func() (float64, error), batteryCapacity func() float64) api.Meter {
+func decorateLgEss(base *LgEss, meterEnergy func() (float64, error), battery func() (float64, error), batteryCapacity func() (float64, error)) api.Meter {
 	switch {
 	case battery == nil && batteryCapacity == nil && meterEnergy == nil:
 		return base
@@ -121,10 +121,10 @@ func (impl *decorateLgEssBatteryImpl) Soc() (float64, error) {
 }
 
 type decorateLgEssBatteryCapacityImpl struct {
-	batteryCapacity func() float64
+	batteryCapacity func() (float64, error)
 }
 
-func (impl *decorateLgEssBatteryCapacityImpl) Capacity() float64 {
+func (impl *decorateLgEssBatteryCapacityImpl) Capacity() (float64, error) {
 	return impl.batteryCapacity()
 }
 

--- a/meter/meter_average.go
+++ b/meter/meter_average.go
@@ -14,9 +14,8 @@ func NewMovingAverageFromConfig(other map[string]interface{}) (api.Meter, error)
 	cc := struct {
 		Decay float64
 		Meter struct {
-			capacity `mapstructure:",squash"`
-			Type     string
-			Other    map[string]interface{} `mapstructure:",remain"`
+			Type  string
+			Other map[string]interface{} `mapstructure:",remain"`
 		}
 	}{
 		Decay: 0.1,
@@ -50,6 +49,12 @@ func NewMovingAverageFromConfig(other map[string]interface{}) (api.Meter, error)
 		batterySoc = m.Soc
 	}
 
+	// decorate battery reading
+	var batteryCapacity func() (float64, error)
+	if m, ok := m.(api.BatteryCapacity); ok {
+		batteryCapacity = m.Capacity
+	}
+
 	// decorate currents reading
 	var currents func() (float64, float64, float64, error)
 	if m, ok := m.(api.PhaseCurrents); ok {
@@ -68,7 +73,7 @@ func NewMovingAverageFromConfig(other map[string]interface{}) (api.Meter, error)
 		powers = m.Powers
 	}
 
-	return meter.Decorate(totalEnergy, currents, voltages, powers, batterySoc, cc.Meter.capacity.Decorator()), nil
+	return meter.Decorate(totalEnergy, currents, voltages, powers, batterySoc, batteryCapacity), nil
 }
 
 type MovingAverage struct {

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error), battery func() (float64, error), batteryCapacity func() float64) api.Meter {
+func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error), battery func() (float64, error), batteryCapacity func() (float64, error)) api.Meter {
 	switch {
 	case battery == nil && batteryCapacity == nil && meterEnergy == nil && phaseCurrents == nil && phasePowers == nil && phaseVoltages == nil:
 		return base
@@ -1233,10 +1233,10 @@ func (impl *decorateMeterBatteryImpl) Soc() (float64, error) {
 }
 
 type decorateMeterBatteryCapacityImpl struct {
-	batteryCapacity func() float64
+	batteryCapacity func() (float64, error)
 }
 
-func (impl *decorateMeterBatteryCapacityImpl) Capacity() float64 {
+func (impl *decorateMeterBatteryCapacityImpl) Capacity() (float64, error) {
 	return impl.batteryCapacity()
 }
 

--- a/meter/modbus.go
+++ b/meter/modbus.go
@@ -26,7 +26,7 @@ func init() {
 	registry.Add("modbus", NewModbusFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -f decorateModbus -b api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.PhaseCurrents,Currents,func() (float64, float64, float64, error)" -t "api.PhaseVoltages,Voltages,func() (float64, float64, float64, error)" -t "api.PhasePowers,Powers,func() (float64, float64, float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64"
+//go:generate go run ../cmd/tools/decorate.go -f decorateModbus -b api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.PhaseCurrents,Currents,func() (float64, float64, float64, error)" -t "api.PhaseVoltages,Voltages,func() (float64, float64, float64, error)" -t "api.PhasePowers,Powers,func() (float64, float64, float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() (float64, error)"
 
 // NewModbusFromConfig creates api.Meter from config
 func NewModbusFromConfig(other map[string]interface{}) (api.Meter, error) {

--- a/meter/modbus_decorators.go
+++ b/meter/modbus_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateModbus(base api.Meter, meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error), battery func() (float64, error), batteryCapacity func() float64) api.Meter {
+func decorateModbus(base api.Meter, meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error), battery func() (float64, error), batteryCapacity func() (float64, error)) api.Meter {
 	switch {
 	case battery == nil && batteryCapacity == nil && meterEnergy == nil && phaseCurrents == nil && phasePowers == nil && phaseVoltages == nil:
 		return base
@@ -1233,10 +1233,10 @@ func (impl *decorateModbusBatteryImpl) Soc() (float64, error) {
 }
 
 type decorateModbusBatteryCapacityImpl struct {
-	batteryCapacity func() float64
+	batteryCapacity func() (float64, error)
 }
 
-func (impl *decorateModbusBatteryCapacityImpl) Capacity() float64 {
+func (impl *decorateModbusBatteryCapacityImpl) Capacity() (float64, error) {
 	return impl.batteryCapacity()
 }
 

--- a/meter/openwb.go
+++ b/meter/openwb.go
@@ -59,7 +59,7 @@ func NewOpenWBFromConfig(other map[string]interface{}) (api.Meter, error) {
 	var power func() (float64, error)
 	var currents func() (float64, float64, float64, error)
 	var soc func() (float64, error)
-	var capacity func() float64
+	var capacity func() (float64, error)
 
 	switch strings.ToLower(cc.Usage) {
 	case "grid":

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -26,7 +26,7 @@ func init() {
 	registry.Add("powerwall", NewPowerWallFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -f decoratePowerWall -b *PowerWall -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64"
+//go:generate go run ../cmd/tools/decorate.go -f decoratePowerWall -b *PowerWall -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() (float64, error)"
 
 // NewPowerWallFromConfig creates a PowerWall Powerwall Meter from generic config
 func NewPowerWallFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -88,7 +88,7 @@ func NewPowerWall(uri, usage, user, password string, cache time.Duration) (api.M
 
 	// decorate api.BatterySoc
 	var batterySoc func() (float64, error)
-	var batteryCapacity func() float64
+	var batteryCapacity func() (float64, error)
 	if usage == "battery" {
 		batterySoc = m.batterySoc
 
@@ -97,8 +97,8 @@ func NewPowerWall(uri, usage, user, password string, cache time.Duration) (api.M
 			return nil, err
 		}
 
-		batteryCapacity = func() float64 {
-			return float64(res.NominalFullPackEnergy) / 1e3
+		batteryCapacity = func() (float64, error) {
+			return float64(res.NominalFullPackEnergy) / 1e3, nil
 		}
 	}
 

--- a/meter/powerwall_decorators.go
+++ b/meter/powerwall_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decoratePowerWall(base *PowerWall, meterEnergy func() (float64, error), battery func() (float64, error), batteryCapacity func() float64) api.Meter {
+func decoratePowerWall(base *PowerWall, meterEnergy func() (float64, error), battery func() (float64, error), batteryCapacity func() (float64, error)) api.Meter {
 	switch {
 	case battery == nil && batteryCapacity == nil && meterEnergy == nil:
 		return base
@@ -121,10 +121,10 @@ func (impl *decoratePowerWallBatteryImpl) Soc() (float64, error) {
 }
 
 type decoratePowerWallBatteryCapacityImpl struct {
-	batteryCapacity func() float64
+	batteryCapacity func() (float64, error)
 }
 
-func (impl *decoratePowerWallBatteryCapacityImpl) Capacity() float64 {
+func (impl *decoratePowerWallBatteryCapacityImpl) Capacity() (float64, error) {
 	return impl.batteryCapacity()
 }
 

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -52,7 +52,7 @@ func init() {
 	registry.Add("rct", NewRCTFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -f decorateRCT -b *RCT -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64"
+//go:generate go run ../cmd/tools/decorate.go -f decorateRCT -b *RCT -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() (float64, error)"
 
 // NewRCTFromConfig creates an RCT from generic config
 func NewRCTFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -76,7 +76,7 @@ func NewRCTFromConfig(other map[string]interface{}) (api.Meter, error) {
 }
 
 // NewRCT creates an RCT meter
-func NewRCT(uri, usage string, cache time.Duration, capacity func() float64) (api.Meter, error) {
+func NewRCT(uri, usage string, cache time.Duration, capacity func() (float64, error)) (api.Meter, error) {
 	conn, err := rct.NewConnection(uri, cache)
 	if err != nil {
 		return nil, err

--- a/meter/rct_decorators.go
+++ b/meter/rct_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateRCT(base *RCT, meterEnergy func() (float64, error), battery func() (float64, error), batteryCapacity func() float64) api.Meter {
+func decorateRCT(base *RCT, meterEnergy func() (float64, error), battery func() (float64, error), batteryCapacity func() (float64, error)) api.Meter {
 	switch {
 	case battery == nil && batteryCapacity == nil && meterEnergy == nil:
 		return base
@@ -121,10 +121,10 @@ func (impl *decorateRCTBatteryImpl) Soc() (float64, error) {
 }
 
 type decorateRCTBatteryCapacityImpl struct {
-	batteryCapacity func() float64
+	batteryCapacity func() (float64, error)
 }
 
-func (impl *decorateRCTBatteryCapacityImpl) Capacity() float64 {
+func (impl *decorateRCTBatteryCapacityImpl) Capacity() (float64, error) {
 	return impl.batteryCapacity()
 }
 

--- a/meter/sma.go
+++ b/meter/sma.go
@@ -24,7 +24,7 @@ func init() {
 	registry.Add("sma", NewSMAFromConfig)
 }
 
-//go:generate go run ../cmd/tools/decorate.go -f decorateSMA -b *SMA -r api.Meter -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64"
+//go:generate go run ../cmd/tools/decorate.go -f decorateSMA -b *SMA -r api.Meter -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() (float64, error)"
 
 // NewSMAFromConfig creates an SMA meter from generic config
 func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
@@ -46,7 +46,7 @@ func NewSMAFromConfig(other map[string]interface{}) (api.Meter, error) {
 }
 
 // NewSMA creates an SMA meter
-func NewSMA(uri, password, iface string, serial uint32, scale float64, capacity func() float64) (api.Meter, error) {
+func NewSMA(uri, password, iface string, serial uint32, scale float64, capacity func() (float64, error)) (api.Meter, error) {
 	sm := &SMA{
 		uri:   uri,
 		scale: scale,

--- a/meter/sma_decorators.go
+++ b/meter/sma_decorators.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateSMA(base *SMA, battery func() (float64, error), batteryCapacity func() float64) api.Meter {
+func decorateSMA(base *SMA, battery func() (float64, error), batteryCapacity func() (float64, error)) api.Meter {
 	switch {
 	case battery == nil && batteryCapacity == nil:
 		return base
@@ -61,9 +61,9 @@ func (impl *decorateSMABatteryImpl) Soc() (float64, error) {
 }
 
 type decorateSMABatteryCapacityImpl struct {
-	batteryCapacity func() float64
+	batteryCapacity func() (float64, error)
 }
 
-func (impl *decorateSMABatteryCapacityImpl) Capacity() float64 {
+func (impl *decorateSMABatteryCapacityImpl) Capacity() (float64, error) {
 	return impl.batteryCapacity()
 }

--- a/mock/mock_api.go
+++ b/mock/mock_api.go
@@ -305,11 +305,12 @@ func (m *MockVehicle) EXPECT() *MockVehicleMockRecorder {
 }
 
 // Capacity mocks base method.
-func (m *MockVehicle) Capacity() float64 {
+func (m *MockVehicle) Capacity() (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Capacity")
 	ret0, _ := ret[0].(float64)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Capacity indicates an expected call of Capacity.

--- a/tariff/fixed/day.go
+++ b/tariff/fixed/day.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-//go:generate enumer -type Day
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type Day
 type Day int
 
 const (

--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -134,6 +134,8 @@ render: |
       decode: uint16
     scale: 0.1
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/deye-hybrid.yaml
+++ b/templates/definition/meter/deye-hybrid.yaml
@@ -110,7 +110,9 @@ render: |
       type: holding
       decode: int16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -56,6 +56,8 @@ render: |
       type: holding
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -82,6 +82,8 @@ render: |
     {{- end }}
     jq: .[].devices | map(.percentFull) | add / length
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -76,6 +76,8 @@ render: |
     model: sunspec
     value: ChargeState
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -28,6 +28,8 @@ render: |
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi
     jq: .Body.Data.Inverters."1".SOC
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -85,7 +85,9 @@ render: |
       type: holding
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/growatt-hybrid-tlxh.yaml
+++ b/templates/definition/meter/growatt-hybrid-tlxh.yaml
@@ -85,7 +85,9 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/growatt-hybrid.yaml
+++ b/templates/definition/meter/growatt-hybrid.yaml
@@ -83,7 +83,9 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
@@ -140,6 +140,8 @@ render: |
       decode: uint32
     scale: 0.01
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000-rs485.yaml
+++ b/templates/definition/meter/huawei-sun2000-rs485.yaml
@@ -117,6 +117,8 @@ render: |
       decode: uint32
     scale: 0.01
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/kostal-piko-hybrid.yaml
+++ b/templates/definition/meter/kostal-piko-hybrid.yaml
@@ -40,6 +40,8 @@ render: |
     #   | ----------------------------- Bat SOC% --------- |
     jq: (.dxsEntries[] | select(.dxsId==33556229) | .value )
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end -}}

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -41,6 +41,8 @@ render: |
       password: {{ .password }}
     jq: .value
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/senec-home.yaml
+++ b/templates/definition/meter/senec-home.yaml
@@ -53,6 +53,8 @@ render: |
     unpack: hex
     decode: float32
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/slimmelezer.yaml
+++ b/templates/definition/meter/slimmelezer.yaml
@@ -14,7 +14,7 @@ params:
 render: |
   type: custom
   power:
-  - source: calc
+    source: calc
     add:
     - source: http
       uri: http://{{ .host }}/sensor/power_delivered

--- a/templates/definition/meter/sma-datamanager.yaml
+++ b/templates/definition/meter/sma-datamanager.yaml
@@ -102,6 +102,8 @@ render: |
       type: holding
       decode: uint32nan
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -61,6 +61,8 @@ render: |
       type: holding
       decode: uint32nan
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -145,6 +145,8 @@ render: |
       decode: uint32
     scale: 0.1
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sofarsolar.yaml
+++ b/templates/definition/meter/sofarsolar.yaml
@@ -92,6 +92,8 @@ render: |
       type: holding
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -64,6 +64,8 @@ render: |
       type: holding
       decode: float32s
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -48,6 +48,8 @@ render: |
       type: input
       decode: int16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solarwatt-myreserve-matrix.yaml
+++ b/templates/definition/meter/solarwatt-myreserve-matrix.yaml
@@ -30,6 +30,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/
     jq: .SData.SoC
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solarwatt.yaml
+++ b/templates/definition/meter/solarwatt.yaml
@@ -50,6 +50,8 @@ render: |
     uri: http://{{ .host }}/rest/kiwigrid/wizard/devices # EnergyManager
     jq: .result.items[] | select(.deviceModel[].deviceClass == "com.kiwigrid.devices.location.Location" ) | .tagValues.WorkReleased.value / 1000
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solax-hybrid-cloud.yaml
+++ b/templates/definition/meter/solax-hybrid-cloud.yaml
@@ -71,6 +71,8 @@ render: |
     jq: .result.soc  # Solax API inverter.DC.battery.energy.SOC
     cache: 2m30s
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -76,6 +76,8 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -32,6 +32,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/api/v1/status
     jq: .USOC
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -49,6 +49,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
     jq: .M30 # SOC relative to usable capacity (.M05 # display SOC)
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -9,8 +9,6 @@ params:
   - name: host
   - name: port
     default: 7979
-  - name: capacity
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -48,9 +46,10 @@ render: |
     source: http
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
     jq: .M30 # SOC relative to usable capacity (.M05 # display SOC)
-  {{- if .capacity }}
   capacity:
-    source: const
-    value: {{ .capacity }} # kWh
-  {{- end }}
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    # S01 gross capacity in 100Wh e.g 82 for 8.2kWh
+    # S08 minimum SOC
+    jq: (.S01/10)*(1-(.S08/100))
   {{- end }}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -98,6 +98,8 @@ render: |
       decode: int16
     scale: 0.1
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -110,6 +110,8 @@ render: |
     model: sunspec
     value: ChargeState
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/varta.yaml
+++ b/templates/definition/meter/varta.yaml
@@ -50,6 +50,8 @@ render: |
       type: holding
       decode: int16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/victron-energy.yaml
+++ b/templates/definition/meter/victron-energy.yaml
@@ -111,6 +111,8 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/util/templates/class.go
+++ b/util/templates/class.go
@@ -2,7 +2,7 @@ package templates
 
 type Class int
 
-//go:generate enumer -type Class
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type Class
 const (
 	_ Class = iota
 	Charger

--- a/util/templates/paramtype.go
+++ b/util/templates/paramtype.go
@@ -10,7 +10,7 @@ func (c *ParamType) UnmarshalText(text []byte) error {
 	return err
 }
 
-//go:generate enumer -type ParamType -trimprefix Type
+//go:generate go run github.com/dmarkham/enumer@v1.5.8 -type ParamType -trimprefix Type
 const (
 	TypeString ParamType = iota // default type string
 	TypeBool

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -160,7 +160,7 @@ type LinkedTemplate struct {
 // Param is a proxy template parameter
 // Params can be defined:
 // 1. in the template: uses entries in 4. for default properties and values, can be overwritten here
-// 2. in defaults.yaml presets: can ne referenced in 1 and some values set here can be overwritten in 1. See OverwriteProperties method
+// 2. in defaults.yaml presets: can be referenced in 1 and some values set here can be overwritten in 1. See OverwriteProperties method
 // 3. in defaults.yaml modbus section: are referenced in 1 by a `name:modbus` param entry. Some values here can be overwritten in 1.
 // 4. in defaults.yaml param section: defaults for some params
 // Generelle Reihenfolge der Werte (außer Description, Default, Type):

--- a/vehicle/embed.go
+++ b/vehicle/embed.go
@@ -35,8 +35,8 @@ func (v *embed) SetTitle(title string) {
 }
 
 // Capacity implements the api.Vehicle interface
-func (v *embed) Capacity() float64 {
-	return v.Capacity_
+func (v *embed) Capacity() (float64, error) {
+	return v.Capacity_, nil
 }
 
 // Phases returns the phases used by the vehicle

--- a/vehicle/wrapper/wrapper.go
+++ b/vehicle/wrapper/wrapper.go
@@ -71,8 +71,8 @@ func (v *Wrapper) Icon() string {
 }
 
 // Capacity implements the api.Vehicle interface
-func (v *Wrapper) Capacity() float64 {
-	return v.capacity
+func (v *Wrapper) Capacity() (float64, error) {
+	return v.capacity, nil
 }
 
 // Phases implements the api.Vehicle interface


### PR DESCRIPTION
This is a follow-up of #8679 to support the dynamic retrieval of the battery capacity. This has been implemented initially for `sonnenbatterie-eco56` but can be extended to other storage systems.