### PR TITLE
Add tariff templates

### DIFF
--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -36,7 +36,6 @@ func NewTibberFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		embed  `mapstructure:",squash"`
 		Token  string
 		HomeID string
-		Unit   string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/templates/definition/embed.go
+++ b/templates/definition/embed.go
@@ -2,5 +2,5 @@ package definition
 
 import "embed"
 
-//go:embed charger/*.yaml meter/*.yaml vehicle/*.yaml
+//go:embed charger/*.yaml meter/*.yaml vehicle/*.yaml tariff/*.yaml
 var YamlTemplates embed.FS

--- a/templates/definition/tariff/awattar.yaml
+++ b/templates/definition/tariff/awattar.yaml
@@ -1,0 +1,10 @@
+template: awattar
+products:
+  - brand: Awattar
+params:
+  - preset: tariff-base
+  - name: region
+render: |
+  type: awattar
+  {{ include "tariff-base" . }}
+  region: {{ .region }}

--- a/templates/definition/tariff/fixed.yaml
+++ b/templates/definition/tariff/fixed.yaml
@@ -1,0 +1,12 @@
+template: fixed
+products:
+  - brand: Standard
+params:
+  - name: price
+    type: float
+    description:
+      en: "Price per kWh"
+      de: "Preis je kWh"
+render: |
+  type: fixed
+  price: {{ .price }}

--- a/templates/definition/tariff/gruenstromindex.yaml
+++ b/templates/definition/tariff/gruenstromindex.yaml
@@ -1,0 +1,8 @@
+template: grünstromindex
+products:
+  - brand: Grünstromindex
+params:
+  - name: zip
+render: |
+  type: grünstromindex
+  zip: {{ .zip }}

--- a/templates/definition/tariff/tibber.yaml
+++ b/templates/definition/tariff/tibber.yaml
@@ -1,0 +1,12 @@
+template: tibber
+products:
+  - brand: Tibber
+params:
+  - preset: tariff-base
+  - name: token
+  - name: homeid
+render: |
+  type: tibber
+  {{ include "tariff-base" . }}
+  token: {{ .token }}
+  homeid: {{ .homeid }}

--- a/util/templates/class.go
+++ b/util/templates/class.go
@@ -8,4 +8,5 @@ const (
 	Charger
 	Meter
 	Vehicle
+	Tariff
 )

--- a/util/templates/class_enumer.go
+++ b/util/templates/class_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _ClassName = "ChargerMeterVehicle"
+const _ClassName = "ChargerMeterVehicleTariff"
 
-var _ClassIndex = [...]uint8{0, 7, 12, 19}
+var _ClassIndex = [...]uint8{0, 7, 12, 19, 25}
 
-const _ClassLowerName = "chargermetervehicle"
+const _ClassLowerName = "chargermetervehicletariff"
 
 func (i Class) String() string {
 	i -= 1
@@ -28,9 +28,10 @@ func _ClassNoOp() {
 	_ = x[Charger-(1)]
 	_ = x[Meter-(2)]
 	_ = x[Vehicle-(3)]
+	_ = x[Tariff-(4)]
 }
 
-var _ClassValues = []Class{Charger, Meter, Vehicle}
+var _ClassValues = []Class{Charger, Meter, Vehicle, Tariff}
 
 var _ClassNameToValueMap = map[string]Class{
 	_ClassName[0:7]:        Charger,
@@ -39,12 +40,15 @@ var _ClassNameToValueMap = map[string]Class{
 	_ClassLowerName[7:12]:  Meter,
 	_ClassName[12:19]:      Vehicle,
 	_ClassLowerName[12:19]: Vehicle,
+	_ClassName[19:25]:      Tariff,
+	_ClassLowerName[19:25]: Tariff,
 }
 
 var _ClassNames = []string{
 	_ClassName[0:7],
 	_ClassName[7:12],
 	_ClassName[12:19],
+	_ClassName[19:25],
 }
 
 // ClassString retrieves an enum value from the enum constants string name.

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -320,6 +320,14 @@ presets:
   vehicle-language:
     params:
       - name: language
+  tariff-base:
+    params:
+      - name: costs
+        type: number
+        advanced: true
+      - name: tax
+        type: number
+        advanced: true
   eebus:
     params:
       - name: ski

--- a/util/templates/generate/main.go
+++ b/util/templates/generate/main.go
@@ -30,7 +30,7 @@ func main() {
 }
 
 func generateDocs(lang string) {
-	for _, class := range []templates.Class{templates.Meter, templates.Charger, templates.Vehicle} {
+	for _, class := range []templates.Class{templates.Meter, templates.Charger, templates.Vehicle, templates.Tariff} {
 		path := fmt.Sprintf("%s/%s/%s", docsPath, lang, strings.ToLower(class.String()))
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {

--- a/util/templates/generate/main.go
+++ b/util/templates/generate/main.go
@@ -30,7 +30,7 @@ func main() {
 }
 
 func generateDocs(lang string) {
-	for _, class := range []templates.Class{templates.Meter, templates.Charger, templates.Vehicle, templates.Tariff} {
+	for _, class := range templates.ClassValues() {
 		path := fmt.Sprintf("%s/%s/%s", docsPath, lang, strings.ToLower(class.String()))
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {

--- a/util/templates/includes/tariff-base.tpl
+++ b/util/templates/includes/tariff-base.tpl
@@ -1,0 +1,8 @@
+{{ define "tariff-base" }}
+{{- if .charges }}
+charges: {{ .charges }}
+{{- end }}
+{{- if .tax }}
+tax: {{ .tax }}
+{{- end }}
+{{- end }}

--- a/util/templates/init.go
+++ b/util/templates/init.go
@@ -32,9 +32,9 @@ func init() {
 
 	baseTmpl = template.Must(template.ParseFS(includeFS, "includes/*.tpl"))
 
-	loadTemplates(Charger)
-	loadTemplates(Meter)
-	loadTemplates(Vehicle)
+	for _, class := range ClassValues() {
+		loadTemplates(class)
+	}
 }
 
 func FromBytes(b []byte) (Template, error) {


### PR DESCRIPTION
In preparation for config UI, this PR adds config templates for tariffs. Can be merged as-is but currently not used.

TODO

- [x] generate docs
- [x] add `fixed`
- [ ] ~~add docs section~~
- [ ] ~~add to configure (think we can and should skip this)~~
- [ ] ~~add a usage type (cost, co2 -> later)~~