### PR TITLE
Phoenix EM-ETH: add api.CurrentGetter

### DIFF
--- a/charger/phoenix-em-eth.go
+++ b/charger/phoenix-em-eth.go
@@ -183,7 +183,6 @@ func (wb *PhoenixEMEth) currents() (float64, float64, float64, error) {
 // GetMaxCurrent implements the api.CurrentGetter interface
 func (wb PhoenixEMEth) GetMaxCurrent() (float64, error) {
 	b, err := wb.conn.ReadHoldingRegisters(phxEMEthRegMaxCurrent, 1)
-
 	if err != nil {
 		return 0, err
 	}

--- a/charger/phoenix-em-eth.go
+++ b/charger/phoenix-em-eth.go
@@ -179,3 +179,14 @@ func (wb *PhoenixEMEth) currents() (float64, float64, float64, error) {
 
 	return currents[0], currents[1], currents[2], nil
 }
+
+// GetMaxCurrent implements the api.CurrentGetter interface
+func (wb PhoenixEMEth) GetMaxCurrent() (float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(phxEMEthRegMaxCurrent, 1)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return rs485.RTUUint16ToFloat64(b), err
+}


### PR DESCRIPTION
This implements the `api.currentGetter` interface from Phoenix EM-ETH controllers.
I hope it will fix #9826