### PR TITLE
Visualization: fix label width on mobile

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.story.vue
+++ b/assets/js/components/Energyflow/Energyflow.story.vue
@@ -115,7 +115,12 @@ import Energyflow from "./Energyflow.vue";
 				:pvPower="0"
 				:gridPower="6500"
 				:homePower="1000"
-				:loadpointsCompact="[{ power: 5500, icon: 'car', charging: true }]"
+				:loadpointsCompact="[
+					{ power: 5500, icon: 'car', charging: true },
+					{ power: 0, icon: 'car', charging: false },
+					{ power: 0, icon: 'car', charging: false },
+					{ power: 0, icon: 'car', charging: false },
+				]"
 				:batteryPower="0"
 				:batterySoc="0"
 				siteTitle="Home"

--- a/assets/js/components/Energyflow/Visualization.vue
+++ b/assets/js/components/Energyflow/Visualization.vue
@@ -146,7 +146,7 @@ export default {
 	},
 	methods: {
 		widthTotal: function (power) {
-			if (this.totalAdjusted === 0) return "0%";
+			if (this.totalAdjusted === 0 || power === 0) return "0";
 			return (100 / this.totalAdjusted) * power + "%";
 		},
 		fmtBarValue: function (watt) {


### PR DESCRIPTION
Fixes a bug where the visualization labels extend beyond screen width on small screens.
Side-effect of the added labels by #9730 

before
![before](https://github.com/evcc-io/evcc/assets/152287/2ed123ea-fa6e-4ad9-8094-8b08716d09a4)

after
![after](https://github.com/evcc-io/evcc/assets/152287/0da602fb-f267-474e-9cbb-7b718197be42)

