### PR TITLE
Enforce checking of type assertions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 run:
   go: "1.21"
+linters:
+  enable:
+    - forcetypeassert
 issues:
   exclude:
     - .regActualCurrent. is unused
@@ -8,5 +11,3 @@ linters-settings:
   staticcheck:
     checks:
       - "-SA1019"
-  errcheck:
-    check-type-assertions: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,3 +8,5 @@ linters-settings:
   staticcheck:
     checks:
       - "-SA1019"
+  errcheck:
+    check-type-assertions: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   enable:
     - forcetypeassert
 issues:
+  max-same-issues: 0
   exclude:
     - .regActualCurrent. is unused
     - "`routeLogger` is unused"

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -285,29 +285,65 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 	case easee.USER_IDTOKEN:
 		c.rfid = res.Value
 	case easee.IS_ENABLED:
-		c.chargerEnabled = value.(bool)
+		boolVal, ok := value.(bool)
+		if ok {
+			c.chargerEnabled = boolVal
+		}
 	case easee.SMART_CHARGING:
-		c.smartCharging = value.(bool)
+		boolVal, ok := value.(bool)
+		if ok {
+			c.smartCharging = boolVal
+		}
 	case easee.TOTAL_POWER:
-		c.currentPower = 1e3 * value.(float64)
+		floatVal, ok := value.(float64)
+		if ok {
+			c.currentPower = 1e3 * floatVal
+		}
 	case easee.SESSION_ENERGY:
-		c.sessionEnergy = value.(float64)
+		floatVal, ok := value.(float64)
+		if ok {
+			c.sessionEnergy = floatVal
+		}
 	case easee.LIFETIME_ENERGY:
-		c.totalEnergy = value.(float64)
+		floatVal, ok := value.(float64)
+		if ok {
+			c.totalEnergy = floatVal
+		}
 	case easee.IN_CURRENT_T3:
-		c.currentL1 = value.(float64)
+		floatVal, ok := value.(float64)
+		if ok {
+			c.currentL1 = floatVal
+		}
 	case easee.IN_CURRENT_T4:
-		c.currentL2 = value.(float64)
+		floatVal, ok := value.(float64)
+		if ok {
+			c.currentL2 = floatVal
+		}
 	case easee.IN_CURRENT_T5:
-		c.currentL3 = value.(float64)
+		floatVal, ok := value.(float64)
+		if ok {
+			c.currentL3 = floatVal
+		}
 	case easee.PHASE_MODE:
-		c.phaseMode = value.(int)
+		intVal, ok := value.(int)
+		if ok {
+			c.phaseMode = intVal
+		}
 	case easee.DYNAMIC_CHARGER_CURRENT:
-		c.dynamicChargerCurrent = value.(float64)
+		floatVal, ok := value.(float64)
+		if ok {
+			c.dynamicChargerCurrent = floatVal
+		}
 	case easee.CHARGER_OP_MODE:
-		c.opMode = value.(int)
+		intVal, ok := value.(int)
+		if ok {
+			c.opMode = intVal
+		}
 	case easee.REASON_FOR_NO_CURRENT:
-		c.reasonForNoCurrent = value.(int)
+		intVal, ok := value.(int)
+		if ok {
+			c.reasonForNoCurrent = intVal
+		}
 	}
 
 	select {
@@ -566,7 +602,11 @@ func (c *Easee) waitForDynamicChargerCurrent(targetCurrent float64) error {
 			if err != nil {
 				continue
 			}
-			if value.(float64) == targetCurrent {
+			floatVal, ok := value.(float64)
+			if !ok {
+				continue
+			}
+			if floatVal == targetCurrent {
 				return nil
 			}
 		case <-timer.C: // time is up, bail after one final check

--- a/charger/fronius-wattpilot.go
+++ b/charger/fronius-wattpilot.go
@@ -60,7 +60,11 @@ func (c *Wattpilot) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
-	switch car.(float64) {
+	floatVal, ok := car.(float64)
+	if !ok {
+		return "", errors.New("car value is not a float64")
+	}
+	switch floatVal {
 	case 1.0:
 		return api.StatusA, nil
 	case 2.0, 5.0:
@@ -78,7 +82,11 @@ func (c *Wattpilot) Enabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return resp.(bool), nil
+	boolVal, ok := resp.(bool)
+	if !ok {
+		return false, errors.New("alw value is not a bool")
+	}
+	return boolVal, nil
 }
 
 // Enable implements the api.Charger interface
@@ -111,7 +119,11 @@ func (c *Wattpilot) ChargedEnergy() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return resp.(float64) / 1e3, err
+	floatVal, ok := resp.(float64)
+	if !ok {
+		return 0, errors.New("wh value is not a float64")
+	}
+	return floatVal / 1e3, err
 }
 
 var _ api.PhaseCurrents = (*Wattpilot)(nil)

--- a/cmd/configure/helper.go
+++ b/cmd/configure/helper.go
@@ -41,8 +41,9 @@ func (c *CmdConfigure) processDeviceValues(values map[string]interface{}, templa
 		if strings.ToLower(item) != "title" {
 			continue
 		}
-		if len(value.(string)) > 0 {
-			device.Title = value.(string)
+		title, ok := value.(string)
+		if ok && len(title) > 0 {
+			device.Title = title
 		}
 	}
 

--- a/cmd/configure/survey.go
+++ b/cmd/configure/survey.go
@@ -176,7 +176,10 @@ func (c *CmdConfigure) askValue(q question) string {
 	}
 
 	validate := func(val interface{}) error {
-		value := val.(string)
+		value, ok := val.(string)
+		if !ok {
+			return errors.New(c.localizedString("ValueError_Invalid"))
+		}
 		if q.invalidValues != nil && slices.Contains(q.invalidValues, value) {
 			return errors.New(c.localizedString("ValueError_Used"))
 		}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -122,7 +122,10 @@ func runDump(cmd *cobra.Command, args []string) {
 	}
 
 	for id, lpI := range site.Loadpoints() {
-		lp := lpI.(*core.Loadpoint)
+		lp, ok := lpI.(*core.Loadpoint)
+		if !ok {
+			continue
+		}
 
 		d.Header(fmt.Sprintf("loadpoint %d", id+1), "=")
 		fmt.Println("")

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -542,7 +542,11 @@ func (lp *Loadpoint) evChargeCurrentWrappedMeterHandler(current float64) {
 	}
 
 	// handler only called if charge meter was replaced by dummy
-	lp.chargeMeter.(*wrapper.ChargeMeter).SetPower(power)
+	wrapper, ok := lp.chargeMeter.(*wrapper.ChargeMeter)
+	if !ok {
+		panic("could not convert type to wrapper.ChargeMeter")
+	}
+	wrapper.SetPower(power)
 }
 
 // applyAction executes the action

--- a/core/session/session.go
+++ b/core/session/session.go
@@ -44,7 +44,7 @@ var _ api.CsvWriter = (*Sessions)(nil)
 
 func (t *Sessions) writeHeader(ctx context.Context, ww *csv.Writer) error {
 	localizer := locale.Localizer
-	if val := ctx.Value(locale.Locale).(string); val != "" {
+	if val, ok := ctx.Value(locale.Locale).(string); ok && val != "" {
 		localizer = i18n.NewLocalizer(locale.Bundle, val, locale.Language)
 	}
 

--- a/detect/tasks/modbus.go
+++ b/detect/tasks/modbus.go
@@ -30,9 +30,12 @@ type ModbusResult struct {
 }
 
 func (r *ModbusResult) Configuration(handler TaskHandler, res Result) map[string]interface{} {
-	port := handler.(*ModbusHandler).Port
+	modbusHandler, ok := handler.(*ModbusHandler)
+	if !ok {
+		return nil
+	}
 	cc := map[string]interface{}{
-		"uri":   net.JoinHostPort(res.ResultDetails.IP, strconv.Itoa(port)),
+		"uri":   net.JoinHostPort(res.ResultDetails.IP, strconv.Itoa(modbusHandler.Port)),
 		"model": "sunspec",
 		"id":    r.SlaveID,
 	}

--- a/meter/bosch_bpts5_hybrid.go
+++ b/meter/bosch_bpts5_hybrid.go
@@ -72,14 +72,18 @@ func NewBoschBpts5Hybrid(uri, usage string, cache time.Duration) (api.Meter, err
 	log := util.NewLogger("bosch-bpt")
 
 	instance, exists := bosch.Instances.LoadOrStore(uri, bosch.NewLocal(log, uri, cache))
+	boschApi, ok := instance.(*bosch.API)
+	if !ok {
+		return nil, errors.New("could not convert to bosch.API")
+	}
 	if !exists {
-		if err := instance.(*bosch.API).Login(); err != nil {
+		if err := boschApi.Login(); err != nil {
 			return nil, err
 		}
 	}
 
 	m := &BoschBpts5Hybrid{
-		api:   instance.(*bosch.API),
+		api:   boschApi,
 		usage: strings.ToLower(usage),
 	}
 

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -402,8 +402,12 @@ func GenerateRSAKeys() (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	rsaKey, ok := key.Public().(*rsa.PublicKey)
+	if !ok {
+		return nil, nil, errors.New("could not convert to rsa.PublicKey")
+	}
 
-	return key, key.Public().(*rsa.PublicKey), nil
+	return key, rsaKey, nil
 }
 
 func base64Decode(base64String string) (string, error) {

--- a/provider/prometheus.go
+++ b/provider/prometheus.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -97,7 +98,10 @@ func (p *Prometheus) FloatGetter() func() (float64, error) {
 			return 0, fmt.Errorf("query returned value of type %q, expected %q, consider wrapping query in scalar()", res.Type().String(), model.ValScalar.String())
 		}
 
-		scalarVal := res.(*model.Scalar)
+		scalarVal, ok := res.(*model.Scalar)
+		if !ok {
+			return 0, errors.New("value can not be converted to Scalar")
+		}
 		return float64(scalarVal.Value), nil
 	}
 }

--- a/provider/socket_test.go
+++ b/provider/socket_test.go
@@ -46,7 +46,11 @@ func TestSocketProvider(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	g := p.(IntProvider).IntGetter()
+	intProvider, ok := p.(IntProvider)
+	if !ok {
+		t.Fatal("could not convert to IntProvider")
+	}
+	g := intProvider.IntGetter()
 	i, err := g()
 	require.NoError(t, err)
 	require.Equal(t, int64(1), i)

--- a/provider/transformation.go
+++ b/provider/transformation.go
@@ -81,7 +81,11 @@ func configureOutputs(outConfig []transformationConfig) ([]outputTransformation,
 			}
 
 			f = func(v any) error {
-				return ff(v.(bool))
+				boolVal, ok := v.(bool)
+				if !ok {
+					return fmt.Errorf("could not convert %v to book", v)
+				}
+				return ff(boolVal)
 			}
 
 		case "int":
@@ -91,7 +95,11 @@ func configureOutputs(outConfig []transformationConfig) ([]outputTransformation,
 			}
 
 			f = func(v any) error {
-				return ff(v.(int64))
+				intVal, ok := v.(int64)
+				if !ok {
+					return fmt.Errorf("could not convert %v to int64", v)
+				}
+				return ff(intVal)
 			}
 
 		case "float":
@@ -101,7 +109,11 @@ func configureOutputs(outConfig []transformationConfig) ([]outputTransformation,
 			}
 
 			f = func(v any) error {
-				return ff(v.(float64))
+				floatVal, ok := v.(float64)
+				if !ok {
+					return fmt.Errorf("could not convert %v to float64", v)
+				}
+				return ff(floatVal)
 			}
 
 		case "string":
@@ -111,7 +123,11 @@ func configureOutputs(outConfig []transformationConfig) ([]outputTransformation,
 			}
 
 			f = func(v any) error {
-				return ff(v.(string))
+				stringVal, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("could not convert %v to string", v)
+				}
+				return ff(stringVal)
 			}
 
 		default:

--- a/server/http.go
+++ b/server/http.go
@@ -78,12 +78,19 @@ func NewHTTPd(addr string, hub *SocketHub) *HTTPd {
 
 // Router returns the main router
 func (s *HTTPd) Router() *mux.Router {
-	return s.Handler.(*mux.Router)
+	router, ok := s.Handler.(*mux.Router)
+	if !ok {
+		panic("handler can not be cast to Router")
+	}
+	return router
 }
 
 // RegisterSiteHandlers connects the http handlers to the site
 func (s *HTTPd) RegisterSiteHandlers(site site.API, cache *util.Cache) {
-	router := s.Server.Handler.(*mux.Router)
+	router, ok := s.Server.Handler.(*mux.Router)
+	if !ok {
+		panic("handler can not be cast to Router")
+	}
 
 	// api
 	api := router.PathPrefix("/api").Subrouter()
@@ -154,7 +161,10 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, cache *util.Cache) {
 
 // RegisterShutdownHandler connects the http handlers to the site
 func (s *HTTPd) RegisterShutdownHandler(callback func()) {
-	router := s.Server.Handler.(*mux.Router)
+	router, ok := s.Server.Handler.(*mux.Router)
+	if !ok {
+		panic("handler can not be cast to Router")
+	}
 
 	// api
 	api := router.PathPrefix("/api").Subrouter()

--- a/tariff/fixed_test.go
+++ b/tariff/fixed_test.go
@@ -48,7 +48,10 @@ func TestFixedSplitZones(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	tf := at.(*Fixed)
+	tf, ok := at.(*Fixed)
+	if !ok {
+		t.Fatal("failed type cast")
+	}
 	tf.clock = clock.NewMock()
 
 	var expect api.Rates

--- a/util/pipe/limiter_test.go
+++ b/util/pipe/limiter_test.go
@@ -10,7 +10,10 @@ import (
 )
 
 func TestLimiter(t *testing.T) {
-	l := NewLimiter(time.Hour).(*Limiter)
+	l, ok := NewLimiter(time.Hour).(*Limiter)
+	if !ok {
+		t.Fatal("failed type cast")
+	}
 	clck := clock.NewMock()
 	l.clock = clck
 
@@ -53,7 +56,10 @@ func TestLimiter(t *testing.T) {
 }
 
 func TestDeduplicator(t *testing.T) {
-	l := NewDeduplicator(time.Hour, "filtered").(*Deduplicator)
+	l, ok := NewDeduplicator(time.Hour, "filtered").(*Deduplicator)
+	if !ok {
+		t.Fatal("failed type cast")
+	}
 	clck := clock.NewMock()
 	l.clock = clck
 

--- a/util/templates/documentation.go
+++ b/util/templates/documentation.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"bytes"
 	_ "embed"
+	"errors"
 	"fmt"
 	"text/template"
 
@@ -27,7 +28,11 @@ func (t *Template) RenderDocumentation(product Product, lang string) ([]byte, er
 
 			switch p.Type {
 			case TypeStringList:
-				for _, e := range v.([]string) {
+				stringList, ok := v.([]string)
+				if !ok {
+					return nil, errors.New("could not convert to []string")
+				}
+				for _, e := range stringList {
 					t.Params[index].Values = append(p.Values, yamlQuote(e))
 				}
 			default:

--- a/util/templates/template_modbus.go
+++ b/util/templates/template_modbus.go
@@ -28,7 +28,11 @@ func (t *Template) ModbusParams(modbusType string, values map[string]interface{}
 		return
 	}
 
-	modbusParams := ConfigDefaults.Modbus.Types[values[ParamModbus].(string)].Params
+	stringVal, ok := values[ParamModbus].(string)
+	if !ok {
+		return
+	}
+	modbusParams := ConfigDefaults.Modbus.Types[stringVal].Params
 
 	// add the modbus params at the beginning
 	t.Params = append(modbusParams, t.Params...)


### PR DESCRIPTION
Since evcc makes heavy use of type assertions we should enforce that the error case is always handled to prevent unexpected runtime panics. This enables the [forcetypeassert](https://github.com/gostaticanalysis/forcetypeassert) linter to ensure that.