### PR TITLE
Config UI: localized number input

### DIFF
--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -3,7 +3,8 @@
 		<input
 			:id="id"
 			v-model="value"
-			:type="type"
+			type="number"
+			step="any"
 			:placeholder="placeholder"
 			:required="required"
 			aria-label="unit"
@@ -124,3 +125,14 @@ export default {
 	},
 };
 </script>
+
+<style>
+input[type="number"] {
+	appearance: textfield;
+}
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+</style>


### PR DESCRIPTION
fixes: #9439

Das hier ist erstmal die einfache Lösung. Durch die Verwendung von `input[type=number]` wird die jeweilige Dezimalschreibweise des Browsers akzeptiert und ein bestehender Wert auch in dieser ausgegeben.

Leider ist hier das Locale des Browsers ausschlaggeben und es kann nicht bspw. durch die Sprachauswahl, übersteuert werden. Also keine perfekte Lösung, sollte aber in den meisten Fällen passen. Zudem gibts durch diesen Ansatz auch ordentliche Fehlermeldungen bei falscher Eingabe.

<img width="495" alt="Bildschirmfoto 2023-09-11 um 20 18 00" src="https://github.com/evcc-io/evcc/assets/152287/429f2dcd-1af8-4c07-a7f7-f6f7f93cf519">
