### PR TITLE
Easee: do not treat completed charge as disabled state

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -403,30 +403,27 @@ func (c *Easee) Enable(enable bool) (err error) {
 	if c.authorize {
 		action = easee.ChargeStop
 	}
-	var expectedEnabledState bool
 	var targetCurrent float64
 	if enable {
 		action = easee.ChargeResume
 		if opMode == easee.ModeAwaitingAuthentication && c.authorize {
 			action = easee.ChargeStart
 		}
-		expectedEnabledState = true
 		targetCurrent = 32
 	}
 
 	defer func() {
 		if err == nil {
-			c.enabled = expectedEnabledState
+			c.enabled = enable
 		}
 	}()
 
 	uri := fmt.Sprintf("%s/chargers/%s/commands/%s", easee.API, c.charger, action)
-	_, err = c.postJSONAndWait(uri, nil)
-	if err != nil {
+	if _, err := c.postJSONAndWait(uri, nil); err != nil {
 		return err
 	}
 
-	if err := c.waitForChargerEnabledState(expectedEnabledState); err != nil {
+	if err := c.waitForChargerEnabledState(enable); err != nil {
 		return err
 	}
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -374,7 +374,6 @@ func (c *Easee) Enabled() (bool, error) {
 	defer c.mux.Unlock()
 
 	disabled := c.opMode == easee.ModeDisconnected ||
-		c.opMode == easee.ModeCompleted ||
 		c.opMode == easee.ModeAwaitingAuthentication ||
 		(c.opMode == easee.ModeAwaitingStart && c.reasonForNoCurrent == 52)
 	return !disabled && c.dynamicChargerCurrent > 0, nil


### PR DESCRIPTION
Currently we consider a completed state a disable state.
This does not match the loadpoint, which considers this an enabled state.

The effect is that once charge is completed, loadpoint continuously reports charger out of sync (expected enabled, got disabled) and starts / resumes the charge permanently (which is a NoOp). This change prevents either from happening when the charge completes.