### PR TITLE
Ocpp: add support for ChargeRateUnit (#9838)

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -399,10 +399,10 @@ func getTxChargingProfile(current float64, phases int, unit types.ChargingRateUn
 
 	period := types.NewChargingSchedulePeriod(0, value)
 
-	// TODO add phases support
-	// if phases != 0 {
-	// 	period.NumberPhases = &phases
-	// }
+	// OCPP will assume 3 phases if not specified
+	if phases != 0 {
+		period.NumberPhases = &phases
+	}
 
 	return &types.ChargingProfile{
 		ChargingProfileId:      1,

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -154,11 +154,7 @@ func NewOCPP(id string, connector int, idtag string,
 	}
 	_ = keys
 
-	if chargingRateUnit == "W" {
-		c.chargingRateUnit = types.ChargingRateUnitWatts
-	} else {
-		c.chargingRateUnit = types.ChargingRateUnitAmperes
-	}
+	c.chargingRateUnit = types.ChargingRateUnitType(chargingRateUnit)
 
 	// noConfig mode disables GetConfiguration
 	if noConfig {
@@ -219,8 +215,6 @@ func NewOCPP(id string, connector int, idtag string,
 					case ocpp.KeyChargingScheduleAllowedChargingRateUnit:
 						if *opt.Value == "W" {
 							c.chargingRateUnit = types.ChargingRateUnitWatts
-						} else {
-							c.chargingRateUnit = types.ChargingRateUnitAmperes
 						}
 					}
 

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -95,7 +95,7 @@ func (suite *ocppTestSuite) TestConnect() {
 	suite.True(suite.cp.IsConnected())
 
 	// start cp server
-	c, err := NewOCPP("test", ocppTestConnector, "", "", 0, false, false, ocppTestConnectTimeout, ocppTestTimeout)
+	c, err := NewOCPP("test", ocppTestConnector, "", "", 0, false, false, ocppTestConnectTimeout, ocppTestTimeout, "A")
 	suite.NoError(err)
 
 	if err != nil {

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -70,6 +70,12 @@ params:
     description:
       de: Liste der Zählerwerte
       en: List of meter values
+  - name: chargingrateunit
+    advanced: true
+    type: string
+    description:
+      de: Einheit, in der ChargingProfile-Werte gesetzt werden ("W" oder "A")
+      en: Unit for setting ChargingProfile values ("W" or "A")
 render: |
   {{ include "ocpp" . }}
   {{- if ne .getconfiguration "true" }}
@@ -83,4 +89,7 @@ render: |
   {{- end }}
   {{- if .metervalues }}
   metervalues: {{ .metervalues }}
+  {{- end }}
+  {{- if .chargingrateunit }}
+  chargingrateunit: {{ .chargingrateunit }}
   {{- end }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/9838

My OCPP charger requires a ChargeRateUnit of W. 
