### PR TITLE
Fix power map for slimmelezer DSMR

### DIFF
--- a/templates/definition/meter/slimmelezer.yaml
+++ b/templates/definition/meter/slimmelezer.yaml
@@ -14,7 +14,7 @@ params:
 render: |
   type: custom
   power:
-  - source: calc
+    source: calc
     add:
     - source: http
       uri: http://{{ .host }}/sensor/power_delivered


### PR DESCRIPTION
This PR fixes issue https://github.com/evcc-io/evcc/issues/9907

### Before
```
[main  ] FATAL 2023/09/16 15:08:51 cannot create meter 'grid': cannot create meter 'custom': 1 error(s) decoding:

* 'Power' expected a map, got 'slice'
```

### After
```
(...)
[site  ] INFO 2023/09/16 15:09:26   meters:      grid ✓ pv ✓ battery ✗
[site  ] INFO 2023/09/16 15:09:26     grid:      power ✓ energy ✓ currents ✓
[site  ] INFO 2023/09/16 15:09:26     pv 1:      power ✓ energy ✓ currents ✗
[site  ] INFO 2023/09/16 15:09:26     pv 2:      power ✓ energy ✓ currents ✗
(...)
```