### PR TITLE
Wakeup vehicles during detection

### DIFF
--- a/core/coordinator/adapter.go
+++ b/core/coordinator/adapter.go
@@ -39,5 +39,11 @@ func (a *adapter) Release(v api.Vehicle) {
 
 func (a *adapter) IdentifyVehicleByStatus() api.Vehicle {
 	available := a.c.availableDetectibleVehicles(a.lp)
-	return a.c.identifyVehicleByStatus(available)
+	vehicle := a.c.identifyVehicleByStatus(available)
+	if vehicle == nil {
+		// No matching vehicle found.
+		// Make sure all detectible vehicles are awake
+		a.c.wakeupVehicles(available)
+	}
+	return vehicle
 }

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -114,13 +114,6 @@ func (c *Coordinator) identifyVehicleByStatus(available []api.Vehicle) api.Vehic
 			if err != nil {
 				c.log.ERROR.Println("vehicle status:", err)
 
-				if vr, ok := vs.(api.Resurrector); ok {
-					c.log.DEBUG.Println("wake-up vehicle")
-					if err := vr.WakeUp(); err != nil {
-						c.log.ERROR.Printf("wake-up vehicle: %v", err)
-					}
-				}
-
 				continue
 			}
 

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -113,7 +113,6 @@ func (c *Coordinator) identifyVehicleByStatus(available []api.Vehicle) api.Vehic
 			status, err := vs.Status()
 			if err != nil {
 				c.log.ERROR.Println("vehicle status:", err)
-
 				continue
 			}
 

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -113,6 +113,14 @@ func (c *Coordinator) identifyVehicleByStatus(available []api.Vehicle) api.Vehic
 			status, err := vs.Status()
 			if err != nil {
 				c.log.ERROR.Println("vehicle status:", err)
+
+				if vr, ok := vs.(api.Resurrector); ok {
+					c.log.DEBUG.Println("wake-up vehicle")
+					if err := vr.WakeUp(); err != nil {
+						c.log.ERROR.Printf("wake-up vehicle: %v", err)
+					}
+				}
+
 				continue
 			}
 
@@ -131,4 +139,15 @@ func (c *Coordinator) identifyVehicleByStatus(available []api.Vehicle) api.Vehic
 	}
 
 	return res
+}
+
+func (c *Coordinator) wakeupVehicles(available []api.Vehicle) {
+	for _, vehicle := range available {
+		if vr, ok := vehicle.(api.Resurrector); ok {
+			c.log.DEBUG.Println("wake-up vehicle")
+			if err := vr.WakeUp(); err != nil {
+				c.log.ERROR.Printf("wake-up vehicle: %v", err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
This is a proposed solution for #9956

The idea is to wakeup all detectible and resurrectible vehicles in the detection process if no suitable vehicle is found.
The idea is to check all vehicles in the hope to find a matching vehicle and wake up only if nothing was found.

In this implementation the wakeup will be repeated as long as the detection process goes on (a.k.a no matching vehicle is found)
That might put some strain on the vehicles but will ensure that possible delays in the status change of a vehicle (in its API) will be covered.
In my opinion that is acceptable, since the detection process is limited in time anyhow.
