### PR TITLE
chore: standardise reading phase values

### DIFF
--- a/charger/abl-em4.go
+++ b/charger/abl-em4.go
@@ -205,14 +205,14 @@ func (wb *AblEm4) TotalEnergy() (float64, error) {
 
 // getPhaseValues returns 3 sequential register values
 func (wb *AblEm4) getPhaseValues(reg uint16) (float64, float64, float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(reg, 3*2)
+	b, err := wb.conn.ReadHoldingRegisters(reg, 6)
 	if err != nil {
 		return 0, 0, 0, err
 	}
 
 	var res [3]float64
 	for i := 0; i < 3; i++ {
-		res[i] = float64(binary.BigEndian.Uint32(b[4*i:])) * 0.1
+		res[i] = float64(binary.BigEndian.Uint32(b[4*i:])) / 10
 	}
 
 	return res[0], res[1], res[2], nil

--- a/charger/etrel.go
+++ b/charger/etrel.go
@@ -43,8 +43,8 @@ const (
 	etrelRegSWVersion     = 1015
 
 	// Always zero, see https://github.com/evcc-io/evcc/issues/5346
-	//etrelRegSessionEnergy = 30
-	//etrelRegChargeTime    = 32
+	// etrelRegSessionEnergy = 30
+	// etrelRegChargeTime    = 32
 
 	// holding, write-only!
 	etrelRegMaxCurrent = 8
@@ -211,12 +211,12 @@ func (wb *Etrel) Currents() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	var currents [3]float64
+	var res [3]float64
 	for i := 0; i < 3; i++ {
-		currents[i] = float64(encoding.Float32(b[4*i:]))
+		res[i] = float64(encoding.Float32(b[4*i:]))
 	}
 
-	return currents[0], currents[1], currents[2], nil
+	return res[0], res[1], res[2], nil
 }
 
 // var _ api.ChargeTimer = (*Etrel)(nil)

--- a/charger/hesotec.go
+++ b/charger/hesotec.go
@@ -185,12 +185,12 @@ func (wb *Hesotec) Currents() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	var curr [3]float64
-	for l := 0; l < 3; l++ {
-		curr[l] = float64(binary.BigEndian.Uint32(b[4*l:])) / 1e3
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = float64(binary.BigEndian.Uint32(b[4*i:])) / 1e3
 	}
 
-	return curr[0], curr[1], curr[2], nil
+	return res[0], res[1], res[2], nil
 }
 
 var _ api.PhaseVoltages = (*Hesotec)(nil)
@@ -202,12 +202,12 @@ func (wb *Hesotec) Voltages() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	var volt [3]float64
-	for l := 0; l < 3; l++ {
-		volt[l] = float64(binary.BigEndian.Uint16(b[2*l:]))
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = float64(binary.BigEndian.Uint16(b[2*i:]))
 	}
 
-	return volt[0], volt[1], volt[2], nil
+	return res[0], res[1], res[2], nil
 }
 
 var _ api.Diagnosis = (*Hesotec)(nil)

--- a/charger/innogy.go
+++ b/charger/innogy.go
@@ -29,18 +29,16 @@ import (
 )
 
 const (
-	igyRegID           = 0   // Input
-	igyRegSerial       = 25  // Input
-	igyRegProtocol     = 50  // Input
-	igyRegManufacturer = 100 // Input
-	igyRegFirmware     = 200 // Input
-	igyRegStatus       = 275 // Input
+	igyRegID           = 0    // Input
+	igyRegSerial       = 25   // Input
+	igyRegProtocol     = 50   // Input
+	igyRegManufacturer = 100  // Input
+	igyRegFirmware     = 200  // Input
+	igyRegStatus       = 275  // Input
+	igyRegCurrents     = 1006 // current readings per phase
 )
 
-var (
-	igyRegMaxCurrents = []uint16{1012, 1014, 1016} // max current per phase
-	igyRegCurrents    = []uint16{1006, 1008, 1010} // current readings per phase
-)
+var igyRegMaxCurrents = []uint16{1012, 1014, 1016} // max current per phase
 
 // https://www.innogy-emobility.com/content/dam/revu-global/emobility-solutions/neue-website-feb-2021/downloadcenter/digital-services/eld_instman_modbustcpde.pdf
 
@@ -169,17 +167,17 @@ var _ api.PhaseCurrents = (*Innogy)(nil)
 
 // Currents implements the api.PhaseCurrents interface
 func (wb *Innogy) Currents() (float64, float64, float64, error) {
-	var currents []float64
-	for _, regCurrent := range igyRegCurrents {
-		b, err := wb.conn.ReadInputRegisters(regCurrent, 2)
-		if err != nil {
-			return 0, 0, 0, err
-		}
-
-		currents = append(currents, float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
+	b, err := wb.conn.ReadInputRegisters(igyRegCurrents, 6)
+	if err != nil {
+		return 0, 0, 0, err
 	}
 
-	return currents[0], currents[1], currents[2], nil
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = float64(math.Float32frombits(binary.BigEndian.Uint32(b[4*i:])))
+	}
+
+	return res[0], res[1], res[2], nil
 }
 
 var _ api.Diagnosis = (*Innogy)(nil)

--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -244,14 +244,14 @@ func (wb *Keba) totalEnergy() (float64, error) {
 
 // currents implements the api.PhaseCurrents interface
 func (wb *Keba) currents() (float64, float64, float64, error) {
-	var res [3]float64
-	for i := uint16(0); i < 3; i++ {
-		b, err := wb.conn.ReadHoldingRegisters(kebaRegCurrents+2*i, 2)
-		if err != nil {
-			return 0, 0, 0, err
-		}
+	b, err := wb.conn.ReadHoldingRegisters(kebaRegCurrents, 6)
+	if err != nil {
+		return 0, 0, 0, err
+	}
 
-		res[i] = float64(binary.BigEndian.Uint32(b)) / 1e3
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = float64(binary.BigEndian.Uint32(b[4*i:])) / 1e3
 	}
 
 	return res[0], res[1], res[2], nil

--- a/charger/kse.go
+++ b/charger/kse.go
@@ -194,12 +194,12 @@ func (wb *KSE) Currents() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	var curr [3]float64
-	for l := 0; l < 3; l++ {
-		curr[l] = float64(binary.BigEndian.Uint16(b[2*l:])) / 1e3
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = float64(binary.BigEndian.Uint16(b[2*i:])) / 1e3
 	}
 
-	return curr[0], curr[1], curr[2], nil
+	return res[0], res[1], res[2], nil
 }
 
 // var _ api.PhaseSwitcher = (*KSE)(nil)

--- a/charger/phoenix-charx.go
+++ b/charger/phoenix-charx.go
@@ -217,9 +217,12 @@ func (wb *PhoenixCharx) currents() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	return float64(encoding.Int32(b)) / 1e3,
-		float64(encoding.Int32(b[4:])) / 1e3,
-		float64(encoding.Int32(b[8:])) / 1e3, nil
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = float64(encoding.Int32(b[4*i:])) / 1e3
+	}
+
+	return res[0], res[1], res[2], nil
 }
 
 // voltages implements the api.PhaseVoltages interface
@@ -229,9 +232,12 @@ func (wb *PhoenixCharx) voltages() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	return float64(encoding.Int32(b)) / 1e3,
-		float64(encoding.Int32(b[4:])) / 1e3,
-		float64(encoding.Int32(b[8:])) / 1e3, nil
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = float64(encoding.Int32(b[4*i:])) / 1e3
+	}
+
+	return res[0], res[1], res[2], nil
 }
 
 var _ api.Identifier = (*PhoenixCharx)(nil)

--- a/charger/phoenix-em-eth.go
+++ b/charger/phoenix-em-eth.go
@@ -16,11 +16,10 @@ const (
 	phxEMEthRegMaxCurrent = 300 // Holding
 	phxEMEthRegEnable     = 400 // Coil
 
-	phxEMEthRegPower  = 120 // power reading
-	phxEMEthRegEnergy = 128 // energy reading
+	phxEMEthRegCurrents = 114 // currents
+	phxEMEthRegPower    = 120 // power reading
+	phxEMEthRegEnergy   = 128 // energy reading
 )
-
-var phxEMEthRegCurrents = []uint16{114, 116, 118} // current readings
 
 // PhoenixEMEth is an api.Charger implementation for Phoenix EM-CP-PP-ETH wallboxes.
 // It uses Modbus TCP to communicate with the wallbox at modbus client id 180.
@@ -167,18 +166,20 @@ func (wb *PhoenixEMEth) totalEnergy() (float64, error) {
 
 // currents implements the api.PhaseCurrents interface
 func (wb *PhoenixEMEth) currents() (float64, float64, float64, error) {
-	var currents []float64
-	for _, regCurrent := range phxEMEthRegCurrents {
-		b, err := wb.conn.ReadInputRegisters(regCurrent, 2)
-		if err != nil {
-			return 0, 0, 0, err
-		}
-
-		currents = append(currents, rs485.RTUUint32ToFloat64Swapped(b)/1000)
+	b, err := wb.conn.ReadInputRegisters(phxEMEthRegCurrents, 6)
+	if err != nil {
+		return 0, 0, 0, err
 	}
 
-	return currents[0], currents[1], currents[2], nil
+	var res [3]float64
+	for i := 0; i < 3; i++ {
+		res[i] = rs485.RTUUint32ToFloat64Swapped(b[4*i:]) / 1e3
+	}
+
+	return res[0], res[1], res[2], nil
 }
+
+var _ api.CurrentGetter = (*PhoenixEMEth)(nil)
 
 // GetMaxCurrent implements the api.CurrentGetter interface
 func (wb PhoenixEMEth) GetMaxCurrent() (float64, error) {

--- a/charger/phoenix-ev-eth.go
+++ b/charger/phoenix-ev-eth.go
@@ -212,16 +212,16 @@ func (wb *PhoenixEVEth) totalEnergy() (float64, error) {
 
 // currents implements the api.PhaseCurrents interface
 func (wb *PhoenixEVEth) currents() (float64, float64, float64, error) {
-	return wb.getPhases(phxRegCurrents)
+	return wb.getPhaseValues(phxRegCurrents)
 }
 
 // voltages implements the api.PhaseVoltages interface
 func (wb *PhoenixEVEth) voltages() (float64, float64, float64, error) {
-	return wb.getPhases(phxRegVoltages)
+	return wb.getPhaseValues(phxRegVoltages)
 }
 
-// getPhases returns 3 sequential phase values
-func (wb *PhoenixEVEth) getPhases(reg uint16) (float64, float64, float64, error) {
+// getPhaseValues returns 3 sequential phase values
+func (wb *PhoenixEVEth) getPhaseValues(reg uint16) (float64, float64, float64, error) {
 	b, err := wb.conn.ReadInputRegisters(reg, 6)
 	if err != nil {
 		return 0, 0, 0, err

--- a/charger/schneider.go
+++ b/charger/schneider.go
@@ -200,31 +200,26 @@ var _ api.PhaseCurrents = (*Schneider)(nil)
 
 // Currents implements the api.PhaseCurrents interface
 func (wb *Schneider) Currents() (float64, float64, float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(schneiderRegCurrents, 6)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	var res []float64
-	for i := 0; i < 3; i++ {
-		res = append(res, float64(encoding.Float32LswFirst(b[4*i:])))
-	}
-
-	return res[0], res[1], res[2], nil
+	return wb.getPhaseValues(schneiderRegCurrents)
 }
 
 var _ api.PhaseVoltages = (*Schneider)(nil)
 
 // Voltages implements the api.PhaseVoltages interface
 func (wb *Schneider) Voltages() (float64, float64, float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(schneiderRegVoltages, 6)
+	return wb.getPhaseValues(schneiderRegVoltages)
+}
+
+// getPhaseValues returns 3 sequential phase values
+func (wb *Schneider) getPhaseValues(reg uint16) (float64, float64, float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(reg, 6)
 	if err != nil {
 		return 0, 0, 0, err
 	}
 
-	var res []float64
+	var res [3]float64
 	for i := 0; i < 3; i++ {
-		res = append(res, float64(encoding.Float32LswFirst(b[4*i:])))
+		res[i] = float64(encoding.Float32LswFirst(b[4*i:]))
 	}
 
 	return res[0], res[1], res[2], nil

--- a/charger/weidmüller.go
+++ b/charger/weidmüller.go
@@ -234,10 +234,3 @@ func (wb *Weidmüller) Phases1p3p(phases int) error {
 
 	return err
 }
-
-var _ api.Diagnosis = (*Weidmüller)(nil)
-
-// Diagnose implements the api.Diagnosis interface
-func (wb *Weidmüller) Diagnose() {
-
-}


### PR DESCRIPTION
Weniger round trips, überall identischer Code. Risiko: Boxen die einzelne Reads benötigen ohne dass wir das dokumentiert hätten.