### PR TITLE
Revert "Modbus: don't render rtu: false for Modbus TCP (#9915)"

### DIFF
--- a/charger/phoenix-em-eth.go
+++ b/charger/phoenix-em-eth.go
@@ -37,14 +37,15 @@ func init() {
 // NewPhoenixEMEthFromConfig creates a Phoenix charger from generic config
 func NewPhoenixEMEthFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		URI   string
-		ID    uint8
-		Meter struct {
+		modbus.TcpSettings `mapstructure:",squash"`
+		Meter              struct {
 			Power, Energy, Currents bool
 		}
 	}{
-		URI: "192.168.0.8:502", // default
-		ID:  180,               // default
+		TcpSettings: modbus.TcpSettings{
+			URI: "192.168.0.8:502", // default
+			ID:  180,               // default
+		},
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/util/templates/modbus.tpl
+++ b/util/templates/modbus.tpl
@@ -12,6 +12,7 @@ rtu: true
 {{- else if or (eq .modbus "tcpip") .tcpip }}
 # Modbus TCP
 uri: {{ .host }}:{{ .port }}
+rtu: false
 {{- else }}
 # configuration error - should not happen
 modbusConnectionTypeNotDefined: {{ .modbus }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/10045. This reverts commit fb617b000ba8cf6c87b84cc6ff94e0d1ce710316.

TODO

- [x] alle Modbus Config in .go von `host` auf `modbus.TcpSettings` umbauen wo https://github.com/evcc-io/evcc/pull/9729 von `host` auf `modbus` umgestellt hat.
- [ ] check why `phoenix-em-eth` default id has changed from 180 to 255