### PR TITLE
Easee: never stop session, only pause charge

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -406,9 +406,6 @@ func (c *Easee) Enable(enable bool) (err error) {
 
 	// resume/stop charger
 	action := easee.ChargePause
-	if c.authorize {
-		action = easee.ChargeStop
-	}
 	var targetCurrent float64
 	if enable {
 		action = easee.ChargeResume


### PR DESCRIPTION
User feedback on #9271  was given, that the change from pause to stop command is actually causing some annoyance. Background to this is, that stopping a charge, puts the charger back into the "unauthenticated" state. This has the side effect, that the LED strip on the charger starts blinking. Additionally when the charge is restarted later, the re-authentication is confirmed with an audible sound. When clouded weather is changing the charge status several times, this apparently becomes annoying to some.

This change simply removes the code path for the authenticated charger, that it uses stop command instead of pause. Using pause keeps the existing authentication, but this is OK, as it is sufficient to authenticate once on connection of a new vehicle. On disconnect the Easee de-authenticates anyways. For the charge (re)start this is also OK.

This change was tested already by me locally and is looking good to go.