### PR TITLE
Support dynamic retrieval of battery capacity V2

### DIFF
--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -71,7 +71,9 @@ meters:
         if (state.batterySoc < 10) state.batterySoc = 90;
         if (state.batterySoc > 90) state.batterySoc = 10;
         state.batterySoc;
-    capacity: 13.4
+    capacity:
+      source: const
+      value: 13.4
 
   - name: meter_charger_1
     type: custom

--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -134,6 +134,8 @@ render: |
       decode: uint16
     scale: 0.1
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/deye-hybrid.yaml
+++ b/templates/definition/meter/deye-hybrid.yaml
@@ -110,7 +110,9 @@ render: |
       type: holding
       decode: int16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/e3dc.yaml
+++ b/templates/definition/meter/e3dc.yaml
@@ -56,6 +56,8 @@ render: |
       type: holding
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -81,6 +81,8 @@ render: |
     {{- end }}
     jq: .[].devices | map(.percentFull) | add / length
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -76,6 +76,8 @@ render: |
     model: sunspec
     value: ChargeState
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -28,6 +28,8 @@ render: |
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi
     jq: .Body.Data.Inverters."1".SOC
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -85,7 +85,9 @@ render: |
       type: holding
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/growatt-hybrid-tlxh.yaml
+++ b/templates/definition/meter/growatt-hybrid-tlxh.yaml
@@ -85,7 +85,9 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/growatt-hybrid.yaml
+++ b/templates/definition/meter/growatt-hybrid.yaml
@@ -83,7 +83,9 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   energy:
     source: modbus

--- a/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
@@ -140,6 +140,8 @@ render: |
       decode: uint32nan
     scale: 0.01
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000-rs485.yaml
+++ b/templates/definition/meter/huawei-sun2000-rs485.yaml
@@ -117,6 +117,8 @@ render: |
       decode: uint32
     scale: 0.01
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/kostal-piko-hybrid.yaml
+++ b/templates/definition/meter/kostal-piko-hybrid.yaml
@@ -40,6 +40,8 @@ render: |
     #   | ----------------------------- Bat SOC% --------- |
     jq: (.dxsEntries[] | select(.dxsId==33556229) | .value )
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end -}}

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -41,6 +41,8 @@ render: |
       password: {{ .password }}
     jq: .value
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/senec-home.yaml
+++ b/templates/definition/meter/senec-home.yaml
@@ -53,6 +53,8 @@ render: |
     unpack: hex
     decode: float32
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sma-datamanager.yaml
+++ b/templates/definition/meter/sma-datamanager.yaml
@@ -102,6 +102,8 @@ render: |
       type: holding
       decode: uint32nan
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -61,6 +61,8 @@ render: |
       type: holding
       decode: uint32nan
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -145,6 +145,8 @@ render: |
       decode: uint32
     scale: 0.1
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sofarsolar.yaml
+++ b/templates/definition/meter/sofarsolar.yaml
@@ -92,6 +92,8 @@ render: |
       type: holding
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -64,6 +64,8 @@ render: |
       type: holding
       decode: float32s
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -48,6 +48,8 @@ render: |
       type: input
       decode: int16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solarwatt-myreserve-matrix.yaml
+++ b/templates/definition/meter/solarwatt-myreserve-matrix.yaml
@@ -30,6 +30,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/
     jq: .SData.SoC
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solarwatt.yaml
+++ b/templates/definition/meter/solarwatt.yaml
@@ -50,6 +50,8 @@ render: |
     uri: http://{{ .host }}/rest/kiwigrid/wizard/devices # EnergyManager
     jq: .result.items[] | select(.deviceModel[].deviceClass == "com.kiwigrid.devices.location.Location" ) | .tagValues.WorkReleased.value / 1000
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solax-hybrid-cloud.yaml
+++ b/templates/definition/meter/solax-hybrid-cloud.yaml
@@ -71,6 +71,8 @@ render: |
     jq: .result.soc  # Solax API inverter.DC.battery.energy.SOC
     cache: 2m30s
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -76,6 +76,8 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -32,6 +32,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/api/v1/status
     jq: .USOC
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -49,6 +49,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
     jq: .M30 # SOC relative to usable capacity (.M05 # display SOC)
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -9,8 +9,6 @@ params:
   - name: host
   - name: port
     default: 7979
-  - name: capacity
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -48,9 +46,10 @@ render: |
     source: http
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
     jq: .M30 # SOC relative to usable capacity (.M05 # display SOC)
-  {{- if .capacity }}
   capacity:
-    source: const
-    value: {{ .capacity }} # kWh
-  {{- end }}
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
+    # S01 gross capacity in 100Wh e.g 82 for 8.2kWh
+    # S08 minimum SOC
+    jq: (.S01/10)*(1-(.S08/100))
   {{- end }}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -98,6 +98,8 @@ render: |
       decode: int16
     scale: 0.1
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -110,6 +110,8 @@ render: |
     model: sunspec
     value: ChargeState
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/varta.yaml
+++ b/templates/definition/meter/varta.yaml
@@ -50,6 +50,8 @@ render: |
       type: holding
       decode: int16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/victron-energy.yaml
+++ b/templates/definition/meter/victron-energy.yaml
@@ -111,6 +111,8 @@ render: |
       type: input
       decode: uint16
   {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
+  capacity:
+    source: const
+    value: {{ .capacity }} # kWh
   {{- end }}
   {{- end }}

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -160,7 +160,7 @@ type LinkedTemplate struct {
 // Param is a proxy template parameter
 // Params can be defined:
 // 1. in the template: uses entries in 4. for default properties and values, can be overwritten here
-// 2. in defaults.yaml presets: can ne referenced in 1 and some values set here can be overwritten in 1. See OverwriteProperties method
+// 2. in defaults.yaml presets: can be referenced in 1 and some values set here can be overwritten in 1. See OverwriteProperties method
 // 3. in defaults.yaml modbus section: are referenced in 1 by a `name:modbus` param entry. Some values here can be overwritten in 1.
 // 4. in defaults.yaml param section: defaults for some params
 // Generelle Reihenfolge der Werte (außer Description, Default, Type):


### PR DESCRIPTION
This is a rework of #9816 that allows reading the capacity of batteries defined by templates. The capacity is now only read once during meter initialization.