### PR TITLE
chore: remove invalid host defaults

### DIFF
--- a/templates/definition/charger/bender.yaml
+++ b/templates/definition/charger/bender.yaml
@@ -38,8 +38,6 @@ requirements:
   evcc: ["sponsorship"]
 params:
   - name: host
-    required: true
-    example: 192.0.2.2
   - name: port
     default: 502
 render: |

--- a/templates/definition/charger/daheimladen-mb.yaml
+++ b/templates/definition/charger/daheimladen-mb.yaml
@@ -9,8 +9,6 @@ requirements:
     en: Wallbox must be operated with a recent firmware including Modbus support. Furthermore, “Nachladen” (Smart) or “RSDA” (Touch) must be activated in settings.
 params:
   - name: host
-    required: true
-    example: 192.0.2.2
   - name: port
     default: 502
 render: |

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -14,7 +14,6 @@ params:
       en: Email address
   - name: password
     required: true
-    mask: true
     help:
       de: wie Login für Easee App oder Web Portal (https://easee.cloud)
       en: same as Easee app or the web portal (https://easee.cloud)

--- a/templates/definition/charger/etrel-duo.yaml
+++ b/templates/definition/charger/etrel-duo.yaml
@@ -12,7 +12,6 @@ requirements:
 params:
   - name: connector
   - name: host
-    required: true
   - name: port
     default: 502
 render: |

--- a/templates/definition/charger/etrel.yaml
+++ b/templates/definition/charger/etrel.yaml
@@ -14,7 +14,6 @@ requirements:
     en: The charger must be switched to "Power" charging mode.
 params:
   - name: host
-    required: true
   - name: port
     default: 502
 render: |

--- a/templates/definition/charger/fritzdect.yaml
+++ b/templates/definition/charger/fritzdect.yaml
@@ -11,7 +11,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
   - name: ain
     required: true
   - preset: switchsocket

--- a/templates/definition/charger/nrgkick-connect.yaml
+++ b/templates/definition/charger/nrgkick-connect.yaml
@@ -9,7 +9,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
 render: |
   type: nrgkick-connect
   uri: http://{{ .host }}

--- a/templates/definition/charger/openevse.yaml
+++ b/templates/definition/charger/openevse.yaml
@@ -7,7 +7,6 @@ requirements:
     de: Benötigt mindestens Firmware 7.0 oder neuer.
 params:
   - name: host
-    required: true
   - name: user
     required: false
   - name: password

--- a/templates/definition/charger/smaevcharger.yaml
+++ b/templates/definition/charger/smaevcharger.yaml
@@ -15,7 +15,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
 render: |
   type: smaevcharger
   uri: http://{{ .host }}

--- a/templates/definition/charger/smaevcharger.yaml
+++ b/templates/definition/charger/smaevcharger.yaml
@@ -11,7 +11,6 @@ requirements:
     en: The charger must be switched to "Fast" charging mode and the user must have "Administrator" rights.
 params:
   - name: host
-    required: true
   - name: user
     required: true
   - name: password

--- a/templates/definition/charger/tapo.yaml
+++ b/templates/definition/charger/tapo.yaml
@@ -10,7 +10,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
   - preset: switchsocket
 render: |
   type: tapo

--- a/templates/definition/charger/webasto-next.yaml
+++ b/templates/definition/charger/webasto-next.yaml
@@ -11,8 +11,6 @@ requirements:
   evcc: ["sponsorship"]
 params:
   - name: host
-    required: true
-    example: 192.0.2.2
   - name: port
     default: 502
 render: |

--- a/templates/definition/meter/discovergy.yaml
+++ b/templates/definition/meter/discovergy.yaml
@@ -9,7 +9,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
   - name: meter
     required: true
     example: 1ESY1161229886

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -11,7 +11,6 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: host
-    required: true
   - name: token
     help:
       en: "Required if Envoy Firmware D7.x.xxx. Token is valid for one year. Instructions for obtaining a token via web UI: https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"

--- a/templates/definition/meter/fritzdect.yaml
+++ b/templates/definition/meter/fritzdect.yaml
@@ -13,7 +13,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
   - name: ain
     required: true
 render: |

--- a/templates/definition/meter/homewizard.yaml
+++ b/templates/definition/meter/homewizard.yaml
@@ -7,7 +7,6 @@ params:
   - name: usage
     choice: ["grid", "pv"]
   - name: host
-    required: true
 render: |
   type: homewizard
   uri: http://{{ .host }}

--- a/templates/definition/meter/hoymiles-opendtu.yaml
+++ b/templates/definition/meter/hoymiles-opendtu.yaml
@@ -7,7 +7,6 @@ params:
   - name: usage
     choice: ["pv"]
   - name: host
-    required: true
 render: |
   type: custom
   power:

--- a/templates/definition/meter/huawei-smartlogger.yaml
+++ b/templates/definition/meter/huawei-smartlogger.yaml
@@ -7,8 +7,6 @@ params:
   - name: usage
     choice: ["pv"]
   - name: host
-    required: true
-    example: 192.0.2.2
   - name: port
     default: 502
 render: |

--- a/templates/definition/meter/powerfox-poweropti.yaml
+++ b/templates/definition/meter/powerfox-poweropti.yaml
@@ -10,7 +10,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
   - name: id
     default: main
     required: true

--- a/templates/definition/meter/shelly-1pm.yaml
+++ b/templates/definition/meter/shelly-1pm.yaml
@@ -8,7 +8,6 @@ params:
   - name: usage
     choice: ["pv", "charge"]
   - name: host
-    default: 192.0.2.2
   - name: user
   - name: password
   - name: channel

--- a/templates/definition/meter/shelly-pro-3em.yaml
+++ b/templates/definition/meter/shelly-pro-3em.yaml
@@ -7,7 +7,6 @@ params:
   - name: usage
     choice: ["grid", "pv", "charge"]
   - name: host
-    default: 192.0.2.2
   - name: user
   - name: password
 render: |

--- a/templates/definition/meter/slimmelezer.yaml
+++ b/templates/definition/meter/slimmelezer.yaml
@@ -10,7 +10,6 @@ params:
   - name: usage
     choice: ["grid"]
   - name: host
-    required: true
 render: |
   type: custom
   power:

--- a/templates/definition/meter/tapo.yaml
+++ b/templates/definition/meter/tapo.yaml
@@ -12,7 +12,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
 render: |
   type: tapo
   uri: http://{{ .host }}

--- a/templates/definition/meter/tasmota.yaml
+++ b/templates/definition/meter/tasmota.yaml
@@ -7,7 +7,6 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: host
-    default: 192.0.2.2
   - name: user
     required: false
     help:

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -10,7 +10,6 @@ params:
   - name: host
   - name: password
     required: true
-    mask: true
     help:
       en: Password of the user "customer"
       de: Passwort des Benutzers "Kunde"

--- a/templates/definition/meter/tplink.yaml
+++ b/templates/definition/meter/tplink.yaml
@@ -8,7 +8,6 @@ params:
   - name: usage
     choice: ["pv"]
   - name: host
-    default: 192.0.2.2
 render: |
   type: tplink
   uri: {{ .host }}

--- a/templates/definition/meter/youless.yaml
+++ b/templates/definition/meter/youless.yaml
@@ -13,7 +13,6 @@ params:
   - name: usage
     choice: ["grid", "pv"]
   - name: host
-    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/vehicle/niu-e-scooter.yaml
+++ b/templates/definition/vehicle/niu-e-scooter.yaml
@@ -12,7 +12,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
   - name: serial
     description:
       de: Scooter Seriennummer, wie in der NIU app angegeben

--- a/templates/definition/vehicle/ovms.yaml
+++ b/templates/definition/vehicle/ovms.yaml
@@ -16,7 +16,6 @@ params:
     required: true
   - name: password
     required: true
-    mask: true
   - name: vehicleid
     required: true
   - name: capacity


### PR DESCRIPTION
@premultiply tempaltes aufgeräumt. Host ist immer required, defaults sollten nur gesetzt sein wenn es tatsächlich welches sind.