### PR TITLE
Add support for using validator struct tags

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -74,21 +74,16 @@ func init() {
 // NewEaseeFromConfig creates a go-e charger from generic config
 func NewEaseeFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		User      string
-		Password  string
-		Charger   string
-		Timeout   time.Duration
-		Authorize bool
+		User, Password string `validate:"required"`
+		Charger        string
+		Timeout        time.Duration
+		Authorize      bool
 	}{
 		Timeout: request.Timeout,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	return NewEasee(cc.User, cc.Password, cc.Charger, cc.Timeout, cc.Authorize)

--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -34,10 +34,6 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
-	}
-
 	return NewFritzDECT(cc.embed, cc.URI, cc.AIN, cc.User, cc.Password, cc.StandbyPower)
 }
 

--- a/charger/fronius-wattpilot.go
+++ b/charger/fronius-wattpilot.go
@@ -1,7 +1,6 @@
 package charger
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -22,8 +21,8 @@ func init() {
 // NewWattpilotFromConfig creates a wattpilot charger from generic config
 func NewWattpilotFromConfig(other map[string]interface{}) (api.Charger, error) {
 	var cc struct {
-		URI      string
-		Password string
+		URI      string `validate:"required"`
+		Password string `validate:"required"`
 		Cache    time.Duration
 	}
 
@@ -31,17 +30,11 @@ func NewWattpilotFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
-	if cc.URI == "" || cc.Password == "" {
-		return nil, errors.New("must have uri and password")
-	}
-
 	return NewWattpilot(cc.URI, cc.Password, cc.Cache)
-
 }
 
 // NewWattpilot creates Wattpilot charger
 func NewWattpilot(uri, password string, cache time.Duration) (api.Charger, error) {
-
 	c := &Wattpilot{
 		api: wattpilot.New(uri, password),
 	}

--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -55,7 +55,7 @@ func init() {
 // NewSaliaFromConfig creates a Salia cPH2 charger from generic config
 func NewSaliaFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		URI   string
+		URI   string `validate:"required"`
 		Cache time.Duration
 	}{
 		Cache: time.Second,

--- a/charger/homematic.go
+++ b/charger/homematic.go
@@ -21,15 +21,14 @@ func init() {
 // NewCCUFromConfig creates a Homematic charger from generic config
 func NewCCUFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		embed         `mapstructure:",squash"`
-		URI           string
-		Device        string
-		MeterChannel  string
-		SwitchChannel string
-		User          string
-		Password      string
-		StandbyPower  float64
-		Cache         time.Duration
+		embed          `mapstructure:",squash"`
+		URI            string `validate:"required"`
+		Device         string `validate:"required"`
+		MeterChannel   string
+		SwitchChannel  string
+		User, Password string
+		StandbyPower   float64
+		Cache          time.Duration
 	}{
 		Cache: time.Second,
 	}

--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -26,7 +26,7 @@ func init() {
 func NewHomeWizardFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
 		embed        `mapstructure:",squash"`
-		URI          string
+		URI          string `validate:"required"`
 		StandbyPower float64
 		Cache        time.Duration
 	}{

--- a/charger/openevse.go
+++ b/charger/openevse.go
@@ -1,7 +1,6 @@
 package charger
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -34,7 +33,7 @@ func init() {
 // NewOpenEVSEFromConfig creates an OpenEVSE charger from generic config
 func NewOpenEVSEFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		URI      string
+		URI      string `validate:"required"`
 		User     string
 		Password string
 		Cache    time.Duration
@@ -44,10 +43,6 @@ func NewOpenEVSEFromConfig(other map[string]interface{}) (api.Charger, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.URI == "" {
-		return nil, errors.New("missing uri")
 	}
 
 	return NewOpenEVSE(cc.URI, cc.User, cc.Password, cc.Cache)

--- a/charger/pantabox.go
+++ b/charger/pantabox.go
@@ -22,7 +22,7 @@ func init() {
 // NewPantaboxFromConfig creates a Pantabox charger from generic config
 func NewPantaboxFromConfig(other map[string]interface{}) (api.Charger, error) {
 	var cc struct {
-		URI string
+		URI string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/charger/pcelectric.go
+++ b/charger/pcelectric.go
@@ -35,7 +35,7 @@ func init() {
 // NewPCElectricFromConfig creates a PCElectric charger from generic config
 func NewPCElectricFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		URI        string
+		URI        string `validate:"required"`
 		SlaveIndex int
 		Meter      string
 	}{

--- a/charger/shelly.go
+++ b/charger/shelly.go
@@ -21,12 +21,11 @@ func init() {
 // NewShellyFromConfig creates a Shelly charger from generic config
 func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
 	var cc struct {
-		embed        `mapstructure:",squash"`
-		URI          string
-		User         string
-		Password     string
-		Channel      int
-		StandbyPower float64
+		embed          `mapstructure:",squash"`
+		URI            string `validate:"required"`
+		User, Password string
+		Channel        int
+		StandbyPower   float64
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/charger/smaevcharger.go
+++ b/charger/smaevcharger.go
@@ -52,20 +52,14 @@ func init() {
 // NewSmaevchargerFromConfig creates a SMA EV Charger from generic config
 func NewSmaevchargerFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		URI      string `validate:"required"`
-		User     string
-		Password string
-		Cache    time.Duration
+		URI, User, Password string `validate:"required"`
+		Cache               time.Duration
 	}{
 		Cache: 5 * time.Second,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	if cc.User == "admin" {

--- a/charger/smaevcharger.go
+++ b/charger/smaevcharger.go
@@ -52,7 +52,7 @@ func init() {
 // NewSmaevchargerFromConfig creates a SMA EV Charger from generic config
 func NewSmaevchargerFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		Uri      string
+		URI      string `validate:"required"`
 		User     string
 		Password string
 		Cache    time.Duration
@@ -64,10 +64,6 @@ func NewSmaevchargerFromConfig(other map[string]interface{}) (api.Charger, error
 		return nil, err
 	}
 
-	if cc.Uri == "" {
-		return nil, errors.New("missing uri")
-	}
-
 	if cc.User == "" || cc.Password == "" {
 		return nil, api.ErrMissingCredentials
 	}
@@ -76,7 +72,7 @@ func NewSmaevchargerFromConfig(other map[string]interface{}) (api.Charger, error
 		return nil, errors.New(`user "admin" not allowed, create new user`)
 	}
 
-	return NewSmaevcharger(cc.Uri, cc.User, cc.Password, cc.Cache)
+	return NewSmaevcharger(cc.URI, cc.User, cc.Password, cc.Cache)
 }
 
 // NewSmaevcharger creates an SMA EV Charger

--- a/charger/tapo.go
+++ b/charger/tapo.go
@@ -19,19 +19,13 @@ func init() {
 // NewTapoFromConfig creates a Tapo charger from generic config
 func NewTapoFromConfig(other map[string]interface{}) (api.Charger, error) {
 	var cc struct {
-		embed        `mapstructure:",squash"`
-		URI          string
-		User         string
-		Password     string
-		StandbyPower float64
+		embed               `mapstructure:",squash"`
+		URI, User, Password string `validate:"required"`
+		StandbyPower        float64
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	return NewTapo(cc.embed, cc.URI, cc.User, cc.Password, cc.StandbyPower)

--- a/charger/tasmota.go
+++ b/charger/tasmota.go
@@ -27,13 +27,11 @@ func init() {
 // NewTasmotaFromConfig creates a Tasmota charger from generic config
 func NewTasmotaFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		embed        `mapstructure:",squash"`
-		URI          string
-		User         string
-		Password     string
-		StandbyPower float64
-		Channel      int
-		Cache        time.Duration
+		embed               `mapstructure:",squash"`
+		URI, User, Password string `validate:"required"`
+		StandbyPower        float64
+		Channel             int
+		Cache               time.Duration
 	}{
 		Channel: 1,
 		Cache:   time.Second,

--- a/charger/template_test.go
+++ b/charger/template_test.go
@@ -26,8 +26,7 @@ var acceptable = []string{
 	"eebus not configured",
 	"context deadline exceeded",
 	"missing credentials",
-	"timeout",                    // ocpp
-	"must have uri and password", // Wattpilot
+	"timeout", // ocpp
 }
 
 func TestTemplates(t *testing.T) {

--- a/charger/tplink.go
+++ b/charger/tplink.go
@@ -24,16 +24,12 @@ func init() {
 func NewTPLinkFromConfig(other map[string]interface{}) (api.Charger, error) {
 	var cc struct {
 		embed        `mapstructure:",squash"`
-		URI          string
+		URI          string `validate:"required"`
 		StandbyPower float64
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.URI == "" {
-		return nil, errors.New("missing uri")
 	}
 
 	return NewTPLink(cc.embed, cc.URI, cc.StandbyPower)

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -56,7 +56,7 @@ func init() {
 // NewZaptecFromConfig creates a Zaptec Pro charger from generic config
 func NewZaptecFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		User, Password string
+		User, Password string `validate:"required"`
 		Id             string
 		Priority       bool
 		Cache          time.Duration
@@ -66,10 +66,6 @@ func NewZaptecFromConfig(other map[string]interface{}) (api.Charger, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	return NewZaptec(cc.User, cc.Password, cc.Id, cc.Priority, cc.Cache)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/glebarez/sqlite v1.9.0
 	github.com/go-http-utils/etag v0.0.0-20161124023236-513ea8f21eb1
+	github.com/go-playground/locales v0.14.1
+	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.15.4
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/godbus/dbus/v5 v5.1.0
@@ -128,8 +130,6 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.3.0 // indirect

--- a/meter/bosch_bpts5_hybrid.go
+++ b/meter/bosch_bpts5_hybrid.go
@@ -13,7 +13,6 @@ package meter
 // SOFTWARE.
 
 import (
-	"errors"
 	"strings"
 	"time"
 
@@ -52,16 +51,12 @@ func init() {
 func NewBoschBpts5HybridFromConfig(other map[string]interface{}) (api.Meter, error) {
 	var cc struct {
 		URI   string
-		Usage string
+		Usage string `validate:"required"`
 		Cache time.Duration
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Usage == "" {
-		return nil, errors.New("missing usage")
 	}
 
 	return NewBoschBpts5Hybrid(cc.URI, cc.Usage, cc.Cache)

--- a/meter/discovergy.go
+++ b/meter/discovergy.go
@@ -25,12 +25,10 @@ type Discovergy struct {
 // NewDiscovergyFromConfig creates a new configurable meter
 func NewDiscovergyFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		User     string
-		Password string
-		Meter    string
-		Scale    float64
-		Cache    time.Duration
-		Timeout  time.Duration
+		User, Password string `validate:"required"`
+		Meter          string
+		Scale          float64
+		Cache, Timeout time.Duration
 	}{
 		Scale:   1,
 		Cache:   time.Second,
@@ -39,10 +37,6 @@ func NewDiscovergyFromConfig(other map[string]interface{}) (api.Meter, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	basicAuth := transport.BasicAuthHeader(cc.User, cc.Password)

--- a/meter/fritzdect.go
+++ b/meter/fritzdect.go
@@ -20,9 +20,5 @@ func NewFritzDECTFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
-	}
-
 	return fritzdect.NewConnection(cc.URI, cc.AIN, cc.User, cc.Password)
 }

--- a/meter/fritzdect/fritzdect.go
+++ b/meter/fritzdect/fritzdect.go
@@ -24,7 +24,8 @@ import (
 
 // FritzDECT settings
 type Settings struct {
-	URI, AIN, User, Password string
+	URI                 string
+	AIN, User, Password string `validate:"required"`
 }
 
 // FritzDECT connection

--- a/meter/fritzdect/fritzdect.go
+++ b/meter/fritzdect/fritzdect.go
@@ -57,10 +57,6 @@ func NewConnection(uri, ain, user, password string) (*Connection, error) {
 		uri = "https://fritz.box"
 	}
 
-	if ain == "" {
-		return nil, errors.New("missing ain")
-	}
-
 	settings := &Settings{
 		URI:      strings.TrimRight(uri, "/"),
 		AIN:      ain,

--- a/meter/homematic.go
+++ b/meter/homematic.go
@@ -21,14 +21,13 @@ func init() {
 // NewCCUFromConfig creates a Homematic meter from generic config
 func NewCCUFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI           string
-		Device        string
-		MeterChannel  string
-		SwitchChannel string
-		User          string
-		Password      string
-		Usage         string
-		Cache         time.Duration
+		URI            string `validate:"required"`
+		Device         string `validate:"required"`
+		MeterChannel   string
+		SwitchChannel  string
+		User, Password string
+		Usage          string `validate:"required"`
+		Cache          time.Duration
 	}{
 		Cache: time.Second,
 	}

--- a/meter/homewizard.go
+++ b/meter/homewizard.go
@@ -21,7 +21,7 @@ func init() {
 // NewHomeWizardFromConfig creates a HomeWizard meter from generic config
 func NewHomeWizardFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI   string
+		URI   string `validate:"required"`
 		Cache time.Duration
 	}{
 		Cache: time.Second,

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -24,10 +24,6 @@ type Connection struct {
 
 // NewConnection creates a homewizard connection
 func NewConnection(uri string, cache time.Duration) (*Connection, error) {
-	if uri == "" {
-		return nil, errors.New("missing uri")
-	}
-
 	log := util.NewLogger("homewizard")
 	c := &Connection{
 		Helper: request.NewHelper(log),

--- a/meter/lgess.go
+++ b/meter/lgess.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -55,7 +54,8 @@ func init() {
 func NewLgEssFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
 		capacity               `mapstructure:",squash"`
-		URI, Usage             string
+		URI                    string
+		Usage                  string `validate:"required"`
 		Registration, Password string
 		Cache                  time.Duration
 	}{
@@ -64,10 +64,6 @@ func NewLgEssFromConfig(other map[string]interface{}) (api.Meter, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Usage == "" {
-		return nil, errors.New("missing usage")
 	}
 
 	return NewLgEss(cc.URI, cc.Usage, cc.Registration, cc.Password, cc.Cache, cc.capacity.Decorator())

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,22 +30,15 @@ func init() {
 // NewPowerWallFromConfig creates a PowerWall Powerwall Meter from generic config
 func NewPowerWallFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI, Usage, User, Password string
-		Cache                      time.Duration
+		URI, User       string
+		Usage, Password string `validate:"required"`
+		Cache           time.Duration
 	}{
 		Cache: time.Second,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Usage == "" {
-		return nil, errors.New("missing usage")
-	}
-
-	if cc.Password == "" {
-		return nil, errors.New("missing password")
 	}
 
 	// support default meter names

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -58,7 +58,7 @@ func init() {
 func NewRCTFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
 		capacity   `mapstructure:",squash"`
-		Uri, Usage string
+		URI, Usage string `validate:"required"`
 		Cache      time.Duration
 	}{
 		Cache: time.Second,
@@ -68,11 +68,7 @@ func NewRCTFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
-	if cc.Usage == "" {
-		return nil, errors.New("missing usage")
-	}
-
-	return NewRCT(cc.Uri, cc.Usage, cc.Cache, cc.capacity.Decorator())
+	return NewRCT(cc.URI, cc.Usage, cc.Cache, cc.capacity.Decorator())
 }
 
 // NewRCT creates an RCT meter

--- a/meter/shelly.go
+++ b/meter/shelly.go
@@ -14,10 +14,9 @@ func init() {
 // NewShellyFromConfig creates a Shelly charger from generic config
 func NewShellyFromConfig(other map[string]interface{}) (api.Meter, error) {
 	var cc struct {
-		URI      string
-		User     string
-		Password string
-		Channel  int
+		URI            string `validate:"required"`
+		User, Password string
+		Channel        int
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -1,7 +1,6 @@
 package shelly
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -23,10 +22,6 @@ type Connection struct {
 
 // NewConnection creates a new Shelly device connection.
 func NewConnection(uri, user, password string, channel int) (*Connection, error) {
-	if uri == "" {
-		return nil, errors.New("missing uri")
-	}
-
 	for _, suffix := range []string{"/", "/rcp", "/shelly"} {
 		uri = strings.TrimSuffix(uri, suffix)
 	}

--- a/meter/tapo.go
+++ b/meter/tapo.go
@@ -14,17 +14,11 @@ func init() {
 // NewTapoFromConfig creates a tapo meter from generic config
 func NewTapoFromConfig(other map[string]interface{}) (api.Meter, error) {
 	var cc struct {
-		URI      string
-		User     string
-		Password string
+		URI, User, Password string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	return tapo.NewConnection(cc.URI, cc.User, cc.Password)

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -52,14 +52,6 @@ type Connection struct {
 // User is encoded by using MessageDigest of SHA1 which is afterwards B64 encoded.
 // Password is directly B64 encoded.
 func NewConnection(uri, user, password string) (*Connection, error) {
-	if uri == "" {
-		return nil, errors.New("missing uri")
-	}
-
-	if user == "" || password == "" {
-		return nil, fmt.Errorf("missing user or password")
-	}
-
 	for _, suffix := range []string{"/", "/app"} {
 		uri = strings.TrimSuffix(uri, suffix)
 	}

--- a/meter/tasmota.go
+++ b/meter/tasmota.go
@@ -22,12 +22,11 @@ func init() {
 // NewTasmotaFromConfig creates a Tasmota meter from generic config
 func NewTasmotaFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI      string
-		User     string
-		Password string
-		Channel  int
-		Usage    string
-		Cache    time.Duration
+		URI            string `validate:"required"`
+		User, Password string
+		Channel        int
+		Usage          string `validate:"required"`
+		Cache          time.Duration
 	}{
 		Channel: 1,
 		Cache:   time.Second,

--- a/meter/tasmota.go
+++ b/meter/tasmota.go
@@ -22,11 +22,10 @@ func init() {
 // NewTasmotaFromConfig creates a Tasmota meter from generic config
 func NewTasmotaFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI            string `validate:"required"`
-		User, Password string
-		Channel        int
-		Usage          string `validate:"required"`
-		Cache          time.Duration
+		URI, User, Password string `validate:"required"`
+		Channel             int
+		Usage               string `validate:"required"`
+		Cache               time.Duration
 	}{
 		Channel: 1,
 		Cache:   time.Second,

--- a/meter/tasmota/connection.go
+++ b/meter/tasmota/connection.go
@@ -24,10 +24,6 @@ type Connection struct {
 
 // NewConnection creates a Tasmota connection
 func NewConnection(uri, user, password string, channel int, cache time.Duration) (*Connection, error) {
-	if uri == "" {
-		return nil, errors.New("missing uri")
-	}
-
 	log := util.NewLogger("tasmota")
 	c := &Connection{
 		Helper:   request.NewHelper(log),

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -3,7 +3,6 @@ package meter
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -32,16 +31,12 @@ type Tibber struct {
 
 func NewTibberFromConfig(other map[string]interface{}) (api.Meter, error) {
 	var cc struct {
-		Token  string
+		Token  string `validate:"required"`
 		HomeID string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Token == "" {
-		return nil, errors.New("missing token")
 	}
 
 	log := util.NewLogger("pulse").Redact(cc.Token, cc.HomeID)

--- a/meter/tplink.go
+++ b/meter/tplink.go
@@ -13,7 +13,7 @@ func init() {
 // NewTPLinkFromConfig creates a tapo meter from generic config
 func NewTPLinkFromConfig(other map[string]interface{}) (api.Meter, error) {
 	var cc struct {
-		URI string
+		URI string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/meter/tplink/connection.go
+++ b/meter/tplink/connection.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -20,10 +19,6 @@ type Connection struct {
 
 // NewConnection creates TP-Link charger
 func NewConnection(uri string) (*Connection, error) {
-	if uri == "" {
-		return nil, errors.New("missing uri")
-	}
-
 	c := &Connection{
 		log: util.NewLogger("tplink"),
 		uri: net.JoinHostPort(uri, "9999"),

--- a/meter/tq-em.go
+++ b/meter/tq-em.go
@@ -60,7 +60,7 @@ type TqEm struct {
 // NewTqEmFromConfig creates a new configurable meter
 func NewTqEmFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		URI      string
+		URI      string `validate:"required"`
 		Password string
 		Cache    time.Duration
 	}{

--- a/push/ntfy.go
+++ b/push/ntfy.go
@@ -1,7 +1,6 @@
 package push
 
 import (
-	"errors"
 	"net/http"
 	"strings"
 
@@ -24,17 +23,13 @@ type Ntfy struct {
 // NewNtfyFromConfig creates new Ntfy messenger
 func NewNtfyFromConfig(other map[string]interface{}) (Messenger, error) {
 	var cc struct {
-		URI      string
+		URI      string `validate:"required"`
 		Priority string
 		Tags     string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.URI == "" {
-		return nil, errors.New("missing uri")
 	}
 
 	log := util.NewLogger("ntfy")

--- a/push/pushover.go
+++ b/push/pushover.go
@@ -1,7 +1,6 @@
 package push
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/evcc-io/evcc/util"
@@ -23,17 +22,13 @@ type PushOver struct {
 // NewPushOverFromConfig creates new pushover messenger
 func NewPushOverFromConfig(other map[string]interface{}) (Messenger, error) {
 	var cc struct {
-		App        string
+		App        string `validate:"required"`
 		Recipients []string
 		Devices    []string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.App == "" {
-		return nil, errors.New("missing app name")
 	}
 
 	m := &PushOver{

--- a/push/script.go
+++ b/push/script.go
@@ -26,7 +26,7 @@ type Script struct {
 // NewScriptFromConfig creates a Script messenger. Script execution is aborted after given timeout.
 func NewScriptFromConfig(other map[string]interface{}) (Messenger, error) {
 	cc := struct {
-		CmdLine string
+		CmdLine string `validate:"required"`
 		Timeout time.Duration
 	}{
 		Timeout: request.Timeout,

--- a/push/shoutrrr.go
+++ b/push/shoutrrr.go
@@ -21,7 +21,7 @@ type Shoutrrr struct {
 // NewShoutrrrFromConfig creates new Shoutrrr messenger
 func NewShoutrrrFromConfig(other map[string]interface{}) (Messenger, error) {
 	var cc struct {
-		URI string
+		URI string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/push/telegram.go
+++ b/push/telegram.go
@@ -24,8 +24,8 @@ type Telegram struct {
 // NewTelegramFromConfig creates new pushover messenger
 func NewTelegramFromConfig(other map[string]interface{}) (Messenger, error) {
 	var cc struct {
-		Token string
-		Chats []int64
+		Token string  `validate:"required"`
+		Chats []int64 `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/tariff/electricitymaps.go
+++ b/tariff/electricitymaps.go
@@ -43,8 +43,8 @@ func init() {
 
 func NewElectricityMapsFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	cc := struct {
-		Uri   string
-		Token string
+		Uri   string `validate:"required"`
+		Token string `validate:"required"`
 		Zone  string
 	}{
 		Zone: "DE",

--- a/tariff/electricitymaps.go
+++ b/tariff/electricitymaps.go
@@ -43,9 +43,8 @@ func init() {
 
 func NewElectricityMapsFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	cc := struct {
-		Uri   string `validate:"required"`
-		Token string `validate:"required"`
-		Zone  string
+		URI, Token string `validate:"required"`
+		Zone       string
 	}{
 		Zone: "DE",
 	}
@@ -59,7 +58,7 @@ func NewElectricityMapsFromConfig(other map[string]interface{}) (api.Tariff, err
 	t := &ElectricityMaps{
 		log:    log,
 		Helper: request.NewHelper(log),
-		uri:    util.DefaultScheme(strings.TrimRight(cc.Uri, "/"), "https"),
+		uri:    util.DefaultScheme(strings.TrimRight(cc.URI, "/"), "https"),
 		zone:   strings.ToUpper(cc.Zone),
 	}
 

--- a/tariff/elering.go
+++ b/tariff/elering.go
@@ -1,7 +1,6 @@
 package tariff
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"slices"
@@ -34,15 +33,11 @@ func init() {
 func NewEleringFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
 		embed  `mapstructure:",squash"`
-		Region string
+		Region string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Region == "" {
-		return nil, errors.New("missing region")
 	}
 
 	t := &Elering{

--- a/tariff/energinet.go
+++ b/tariff/energinet.go
@@ -1,7 +1,6 @@
 package tariff
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -33,15 +32,11 @@ func init() {
 func NewEnerginetFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
 		embed  `mapstructure:",squash"`
-		Region string
+		Region string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Region == "" {
-		return nil, errors.New("missing region")
 	}
 
 	t := &Energinet{

--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -38,20 +38,12 @@ func init() {
 func NewEntsoeFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
 		embed         `mapstructure:",squash"`
-		Securitytoken string
-		Domain        string
+		Securitytoken string `validate:"required"`
+		Domain        string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Securitytoken == "" {
-		return nil, errors.New("missing securitytoken")
-	}
-
-	if cc.Domain == "" {
-		return nil, errors.New("missing domain")
 	}
 
 	domain, err := entsoe.Area(entsoe.BZN, strings.ToUpper(cc.Domain))

--- a/tariff/gruenstromindex.go
+++ b/tariff/gruenstromindex.go
@@ -66,7 +66,7 @@ func init() {
 
 func NewGrünStromIndexFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
-		Zip string
+		Zip string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -1,7 +1,6 @@
 package tariff
 
 import (
-	"errors"
 	"slices"
 	"sync"
 	"time"
@@ -30,19 +29,12 @@ func init() {
 
 func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
-		Region string
-		Tariff string
+		Region string `validate:"required"`
+		Tariff string `validate:"required"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Region == "" {
-		return nil, errors.New("missing region")
-	}
-	if cc.Tariff == "" {
-		return nil, errors.New("missing tariff code")
 	}
 
 	t := &Octopus{

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -2,7 +2,6 @@ package tariff
 
 import (
 	"context"
-	"errors"
 	"slices"
 	"sync"
 	"time"
@@ -34,16 +33,12 @@ func init() {
 func NewTibberFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
 		embed  `mapstructure:",squash"`
-		Token  string
+		Token  string `validate:"required"`
 		HomeID string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.Token == "" {
-		return nil, errors.New("missing token")
 	}
 
 	log := util.NewLogger("tibber").Redact(cc.Token, cc.HomeID)

--- a/util/decoder.go
+++ b/util/decoder.go
@@ -22,15 +22,17 @@ func init() {
 	uni := ut.New(en, en)
 
 	trans, _ = uni.GetTranslator("en")
-	en_translations.RegisterDefaultTranslations(validate, trans)
+	_ = en_translations.RegisterDefaultTranslations(validate, trans)
 
 	// simplify required field error
-	validate.RegisterTranslation("required", trans, func(ut ut.Translator) error {
+	if err := validate.RegisterTranslation("required", trans, func(ut ut.Translator) error {
 		return ut.Add("required", "missing {0}", true)
 	}, func(ut ut.Translator, fe validator.FieldError) string {
 		t, _ := ut.T("required", strings.ToLower(fe.Field()))
 		return t
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // DecodeOther uses mapstructure to decode into target structure. Unused keys cause errors.

--- a/vehicle/aiways.go
+++ b/vehicle/aiways.go
@@ -26,10 +26,11 @@ func init() {
 // NewAiwaysFromConfig creates a new vehicle
 func NewAiwaysFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -37,10 +38,6 @@ func NewAiwaysFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Aiways{

--- a/vehicle/audi.go
+++ b/vehicle/audi.go
@@ -31,10 +31,11 @@ func init() {
 // NewAudiFromConfig creates a new vehicle
 func NewAudiFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -42,10 +43,6 @@ func NewAudiFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Audi{

--- a/vehicle/bmw.go
+++ b/vehicle/bmw.go
@@ -32,10 +32,11 @@ func NewMiniFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 // NewBMWMiniFromConfig creates a new vehicle
 func NewBMWMiniFromConfig(brand string, other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Region              string
-		Cache               time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Region         string
+		Cache          time.Duration
 	}{
 		Region: "EU",
 		Cache:  interval,
@@ -43,10 +44,6 @@ func NewBMWMiniFromConfig(brand string, other map[string]interface{}) (api.Vehic
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &BMW{

--- a/vehicle/carwings.go
+++ b/vehicle/carwings.go
@@ -39,9 +39,10 @@ func init() {
 // NewCarWingsFromConfig creates a new vehicle
 func NewCarWingsFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed                       `mapstructure:",squash"`
-		User, Password, Region, VIN string
-		Cache                       time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		Region, VIN    string
+		Cache          time.Duration
 	}{
 		Region: carwings.RegionEurope,
 		Cache:  interval,
@@ -49,10 +50,6 @@ func NewCarWingsFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	log := util.NewLogger("carwings").Redact(cc.User, cc.Password, cc.VIN)

--- a/vehicle/fiat.go
+++ b/vehicle/fiat.go
@@ -24,10 +24,11 @@ func init() {
 // NewFiatFromConfig creates a new vehicle
 func NewFiatFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed                    `mapstructure:",squash"`
-		User, Password, VIN, PIN string
-		Expiry                   time.Duration
-		Cache                    time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN, PIN       string
+		Expiry         time.Duration
+		Cache          time.Duration
 	}{
 		Expiry: expiry,
 		Cache:  interval,
@@ -35,10 +36,6 @@ func NewFiatFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Fiat{

--- a/vehicle/ford.go
+++ b/vehicle/ford.go
@@ -26,10 +26,11 @@ func init() {
 // NewFordFromConfig creates a new vehicle
 func NewFordFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Expiry              time.Duration
-		Cache               time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Expiry         time.Duration
+		Cache          time.Duration
 	}{
 		Expiry: expiry,
 		Cache:  interval,
@@ -37,10 +38,6 @@ func NewFordFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Ford{

--- a/vehicle/jlr.go
+++ b/vehicle/jlr.go
@@ -29,11 +29,12 @@ func init() {
 // NewJLRFromConfig creates a new vehicle
 func NewJLRFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		DeviceID            string
-		Expiry              time.Duration
-		Cache               time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		DeviceID       string
+		Expiry         time.Duration
+		Cache          time.Duration
 	}{
 		Expiry: expiry,
 		Cache:  interval,
@@ -41,10 +42,6 @@ func NewJLRFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &JLR{

--- a/vehicle/nissan.go
+++ b/vehicle/nissan.go
@@ -30,10 +30,11 @@ func init() {
 // NewNissanFromConfig creates a new vehicle
 func NewNissanFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Expiry              time.Duration
-		Cache               time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Expiry         time.Duration
+		Cache          time.Duration
 	}{
 		Expiry: expiry,
 		Cache:  interval,
@@ -41,10 +42,6 @@ func NewNissanFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Nissan{

--- a/vehicle/niu.go
+++ b/vehicle/niu.go
@@ -33,19 +33,16 @@ func init() {
 // NewFordFromConfig creates a new vehicle
 func NewNiuFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed                  `mapstructure:",squash"`
-		User, Password, Serial string
-		Cache                  time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		Serial         string
+		Cache          time.Duration
 	}{
 		Cache: interval,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	if cc.Serial == "" {

--- a/vehicle/porsche.go
+++ b/vehicle/porsche.go
@@ -23,19 +23,16 @@ func init() {
 // NewPorscheFromConfig creates a new vehicle
 func NewPorscheFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
 	}{
 		Cache: interval,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	log := util.NewLogger("porsche").Redact(cc.User, cc.Password, cc.VIN)

--- a/vehicle/psa.go
+++ b/vehicle/psa.go
@@ -63,10 +63,11 @@ type PSA struct {
 // newPSA creates a new vehicle
 func newPSA(log *util.Logger, brand, realm, id, secret string, other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		Credentials         ClientCredentials
-		User, Password, VIN string
-		Cache               time.Duration
+		embed          `mapstructure:",squash"`
+		Credentials    ClientCredentials
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
 	}{
 		Credentials: ClientCredentials{
 			ID:     id,
@@ -77,10 +78,6 @@ func newPSA(log *util.Logger, brand, realm, id, secret string, other map[string]
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &PSA{
@@ -102,7 +99,6 @@ func newPSA(log *util.Logger, brand, realm, id, secret string, other map[string]
 			return v.VIN
 		},
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/renault.go
+++ b/vehicle/renault.go
@@ -37,10 +37,11 @@ func init() {
 // NewRenaultDaciaFromConfig creates a new Renault/Dacia vehicle
 func NewRenaultDaciaFromConfig(brand string, other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed                       `mapstructure:",squash"`
-		User, Password, Region, VIN string
-		Cache                       time.Duration
-		Timeout                     time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		Region, VIN    string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Region:  "de_DE",
 		Cache:   interval,
@@ -49,10 +50,6 @@ func NewRenaultDaciaFromConfig(brand string, other map[string]interface{}) (api.
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	log := util.NewLogger(brand).Redact(cc.User, cc.Password, cc.VIN)
@@ -75,7 +72,6 @@ func NewRenaultDaciaFromConfig(brand string, other map[string]interface{}) (api.
 	api.Client.Timeout = cc.Timeout
 
 	accountID, err := api.Person(identity.PersonID, brand)
-
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/seat-cupra.go
+++ b/vehicle/seat-cupra.go
@@ -27,10 +27,11 @@ func init() {
 // NewCupraFromConfig creates a new vehicle
 func NewCupraFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -38,10 +39,6 @@ func NewCupraFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Cupra{

--- a/vehicle/seat.go
+++ b/vehicle/seat.go
@@ -35,10 +35,11 @@ func init() {
 // NewSeatFromConfig creates a new vehicle
 func NewSeatFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -46,10 +47,6 @@ func NewSeatFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Seat{

--- a/vehicle/skoda-enyaq.go
+++ b/vehicle/skoda-enyaq.go
@@ -26,10 +26,11 @@ func init() {
 // NewEnyaqFromConfig creates a new vehicle
 func NewEnyaqFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -37,10 +38,6 @@ func NewEnyaqFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Enyaq{

--- a/vehicle/skoda.go
+++ b/vehicle/skoda.go
@@ -27,10 +27,11 @@ func init() {
 // NewSkodaFromConfig creates a new vehicle
 func NewSkodaFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -38,10 +39,6 @@ func NewSkodaFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &Skoda{

--- a/vehicle/smart.go
+++ b/vehicle/smart.go
@@ -24,7 +24,7 @@ func init() {
 func NewSmartFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
 		embed          `mapstructure:",squash"`
-		User, Password string
+		User, Password string `validate:"required"`
 		VIN            string
 		Expiry         time.Duration
 		Cache          time.Duration
@@ -35,10 +35,6 @@ func NewSmartFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	log := util.NewLogger("smart").Redact(cc.User, cc.Password, cc.VIN)

--- a/vehicle/volvo-connected.go
+++ b/vehicle/volvo-connected.go
@@ -22,22 +22,18 @@ func init() {
 func NewVolvoConnectedFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
 		embed          `mapstructure:",squash"`
-		User, Password string
+		User, Password string `validate:"required"`
 		VIN            string
+		VccApiKey      string `validate:"required"`
+		Cache          time.Duration
 		// ClientID, ClientSecret string
 		// Sandbox                bool
-		VccApiKey string
-		Cache     time.Duration
 	}{
 		Cache: interval,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	// if cc.ClientID == "" && cc.ClientSecret == "" {

--- a/vehicle/volvo.go
+++ b/vehicle/volvo.go
@@ -27,19 +27,16 @@ func init() {
 // NewVolvoFromConfig creates a new vehicle
 func NewVolvoFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
 	}{
 		Cache: interval,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	basicAuth := transport.BasicAuthHeader(cc.User, cc.Password)

--- a/vehicle/vw-id.go
+++ b/vehicle/vw-id.go
@@ -26,10 +26,11 @@ func init() {
 // NewIDFromConfig creates a new vehicle
 func NewIDFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -37,10 +38,6 @@ func NewIDFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &ID{

--- a/vehicle/vw.go
+++ b/vehicle/vw.go
@@ -26,10 +26,11 @@ func init() {
 // NewVWFromConfig creates a new vehicle
 func NewVWFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed               `mapstructure:",squash"`
-		User, Password, VIN string
-		Cache               time.Duration
-		Timeout             time.Duration
+		embed          `mapstructure:",squash"`
+		User, Password string `validate:"required"`
+		VIN            string
+		Cache          time.Duration
+		Timeout        time.Duration
 	}{
 		Cache:   interval,
 		Timeout: request.Timeout,
@@ -37,10 +38,6 @@ func NewVWFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
-	}
-
-	if cc.User == "" || cc.Password == "" {
-		return nil, api.ErrMissingCredentials
 	}
 
 	v := &VW{


### PR DESCRIPTION
This PR replaces validation code by struct tags. By design, validator tag errors can be translated. The PR utilises this capability to simplify the validator's error messages to match evcc standard ("missing ...").