### PR TITLE
Fix network timeouts in template tests

### DIFF
--- a/charger/openwb.go
+++ b/charger/openwb.go
@@ -77,7 +77,7 @@ func NewOpenWB(log *util.Logger, mqttconf mqtt.Config, id int, topic string, p1p
 	// check if loadpoint configured
 	configured := boolG(fmt.Sprintf("%s/lp/%d/%s", topic, id, openwb.ConfiguredTopic))
 	if isConfigured, err := configured(); err != nil || !isConfigured {
-		return nil, fmt.Errorf("openWB loadpoint %d is not configured", id)
+		return nil, fmt.Errorf("loadpoint %d is not configured", id)
 	}
 
 	// adapt plugged/charging to status

--- a/charger/template_test.go
+++ b/charger/template_test.go
@@ -17,8 +17,10 @@ var acceptable = []string{
 	"hciconfig provided no response",
 	"connect: no route to host",
 	"connect: connection refused",
+	"connector already registered: 1", // ocpp
 	"error connecting: Network Error",
 	"i/o timeout",
+	"loadpoint 1 is not configured", // openWB
 	"recv timeout",
 	"(Client.Timeout exceeded while awaiting headers)",
 	"can only have either uri or device", // modbus

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -44,7 +44,8 @@ params:
     help:
       de: IP-Adresse oder Hostname
       en: IP address or hostname
-    example: localhost
+    default: localhost
+    example: 192.0.2.2
   - name: ip
     description:
       de: IP-Adresse
@@ -52,7 +53,8 @@ params:
     help:
       de: IP-Adresse
       en: IP address
-    example: 127.0.0.1
+    default: 127.0.0.1
+    example: 192.0.2.2
   - name: port
     description:
       de: Port

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -44,7 +44,7 @@ params:
     help:
       de: IP-Adresse oder Hostname
       en: IP address or hostname
-    example: 192.0.2.2
+    example: localhost
   - name: ip
     description:
       de: IP-Adresse
@@ -52,7 +52,7 @@ params:
     help:
       de: IP-Adresse
       en: IP address
-    example: 192.0.2.2
+    example: 127.0.0.1
   - name: port
     description:
       de: Port

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -44,7 +44,6 @@ params:
     help:
       de: IP-Adresse oder Hostname
       en: IP address or hostname
-    default: localhost
     example: 192.0.2.2
   - name: ip
     description:
@@ -53,7 +52,6 @@ params:
     help:
       de: IP-Adresse
       en: IP address
-    default: 127.0.0.1
     example: 192.0.2.2
   - name: port
     description:

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -54,6 +54,9 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 				tmpl.ModbusValues(TemplateRenderModeUnitTest, values)
 			}
 
+			// https://github.com/evcc-io/evcc/pull/10272 - override example IP (192.0.2.2)
+			values["host"] = "localhost"
+
 			usages := tmpl.Usages()
 			if len(usages) == 0 {
 				test(t, tmpl, values, func(values map[string]interface{}) {

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -38,9 +38,6 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 		// set default values for all params
 		values := tmpl.Defaults(TemplateRenderModeUnitTest)
 
-		// set the template value which is needed for rendering
-		values["template"] = tmpl.Template
-
 		// set modbus default test values
 		if values[ParamModbus] != nil {
 			modbusChoices := tmpl.ModbusChoices()
@@ -53,6 +50,8 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 			tmpl.ModbusValues(TemplateRenderModeUnitTest, values)
 		}
 
+		// set the template value which is needed for rendering
+		values["template"] = tmpl.Template
 		// https://github.com/evcc-io/evcc/pull/10272 - override example IP (192.0.2.2)
 		values["host"] = "localhost"
 

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -56,6 +56,8 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 
 			usages := tmpl.Usages()
 			if len(usages) == 0 {
+				t.Parallel()
+
 				test(t, tmpl, values, func(values map[string]interface{}) {
 					instantiate(t, values)
 				})

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -35,54 +35,56 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 	for _, tmpl := range ByClass(class) {
 		tmpl := tmpl
 
-		t.Run(tmpl.Template, func(t *testing.T) {
-			// set default values for all params
-			values := tmpl.Defaults(TemplateRenderModeUnitTest)
+		// set default values for all params
+		values := tmpl.Defaults(TemplateRenderModeUnitTest)
 
-			// set the template value which is needed for rendering
-			values["template"] = tmpl.Template
+		// set the template value which is needed for rendering
+		values["template"] = tmpl.Template
 
-			// set modbus default test values
-			if values[ParamModbus] != nil {
-				modbusChoices := tmpl.ModbusChoices()
-				// we only test one modbus setup
-				if slices.Contains(modbusChoices, ModbusChoiceTCPIP) {
-					values[ModbusKeyTCPIP] = true
-				} else {
-					values[ModbusKeyRS485TCPIP] = true
-				}
-				tmpl.ModbusValues(TemplateRenderModeUnitTest, values)
+		// set modbus default test values
+		if values[ParamModbus] != nil {
+			modbusChoices := tmpl.ModbusChoices()
+			// we only test one modbus setup
+			if slices.Contains(modbusChoices, ModbusChoiceTCPIP) {
+				values[ModbusKeyTCPIP] = true
+			} else {
+				values[ModbusKeyRS485TCPIP] = true
 			}
+			tmpl.ModbusValues(TemplateRenderModeUnitTest, values)
+		}
 
-			// https://github.com/evcc-io/evcc/pull/10272 - override example IP (192.0.2.2)
-			values["host"] = "localhost"
+		// https://github.com/evcc-io/evcc/pull/10272 - override example IP (192.0.2.2)
+		values["host"] = "localhost"
 
-			usages := tmpl.Usages()
-			if len(usages) == 0 {
+		usages := tmpl.Usages()
+		if len(usages) == 0 {
+			t.Run(tmpl.Template, func(t *testing.T) {
+				t.Parallel()
+
 				test(t, tmpl, values, func(values map[string]interface{}) {
 					instantiate(t, values)
 				})
+			})
 
-				return
+			return
+		}
+
+		for _, u := range usages {
+			// create a copy of the map for parallel execution
+			usageValues := make(map[string]interface{}, len(values)+1)
+			if err := copier.Copy(&usageValues, values); err != nil {
+				panic(err)
 			}
+			usageValues[ParamUsage] = u
 
-			for _, u := range usages {
-				// create a copy of the map for parallel execution
-				usageValues := make(map[string]interface{}, len(values)+1)
-				if err := copier.Copy(&usageValues, values); err != nil {
-					panic(err)
-				}
-				usageValues[ParamUsage] = u
+			// subtest for each usage
+			t.Run(u, func(t *testing.T) {
+				t.Parallel()
 
-				// subtest for each usage
-				t.Run(u, func(t *testing.T) {
-					t.Parallel()
-
-					test(t, tmpl, usageValues, func(values map[string]interface{}) {
-						instantiate(t, values)
-					})
+				test(t, tmpl, usageValues, func(values map[string]interface{}) {
+					instantiate(t, values)
 				})
-			}
-		})
+			})
+		}
 	}
 }

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -56,8 +56,6 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 
 			usages := tmpl.Usages()
 			if len(usages) == 0 {
-				t.Parallel()
-
 				test(t, tmpl, values, func(values map[string]interface{}) {
 					instantiate(t, values)
 				})


### PR DESCRIPTION
Make test suite complete fast again.
Fixes issue introduced in 31ab90e6381b30278731bd01effa62bdfb884ebc

As a side effect, the problem regarding the 192.0.2.x network being unreachable also disappear, giving me 100% success rate for the test suite locally. My (unconfirmed) theory is, that the tests running in sequence gives some of the heartbeats for different templates enough runtime to actually bump into that issue. By running in parallel the overall test suite is already done by the time the first heartbeat would trigger, so the problems disappear.
We might want to keep this theory in mind, in case we ever see these kinds of heartbeat problems appear as the test suite and its runtime grows.