### PR TITLE
Feature - extend debug logging

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -825,7 +825,7 @@ func (lp *Loadpoint) minSocNotReached() bool {
 
 	if lp.vehicleSoc != 0 {
 		if lp.vehicleSoc < float64(lp.Soc.min) {
-			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc (%dp) < Minimum Soc (%dp)", lp.vehicleSoc, lp.Soc.min)
+			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc %.0f%% < Minimum Soc %d%%", lp.vehicleSoc, lp.Soc.min)
 		}
 		return lp.vehicleSoc < float64(lp.Soc.min)
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -825,7 +825,7 @@ func (lp *Loadpoint) minSocNotReached() bool {
 
 	if lp.vehicleSoc != 0 {
 		if lp.vehicleSoc < float64(lp.Soc.min) {
-			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc %.0f%% < Minimum Soc %.0f%%", lp.vehicleSoc, lp.Soc.min)
+			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc %.0f%% < Minimum Soc %.0f%%", lp.vehicleSoc, float64(lp.Soc.min))
 		}
 		return lp.vehicleSoc < float64(lp.Soc.min)
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -825,7 +825,7 @@ func (lp *Loadpoint) minSocNotReached() bool {
 
 	if lp.vehicleSoc != 0 {
 		if lp.vehicleSoc < float64(lp.Soc.min) {
-			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc %.0f%% < Minimum Soc %.0f%%", lp.vehicleSoc, float64(lp.Soc.min))
+			lp.log.DEBUG.Printf("forced charging at vehicle soc %.0f%% (< %.0f%% min soc)", lp.vehicleSoc, float64(lp.Soc.min))
 		}
 		return lp.vehicleSoc < float64(lp.Soc.min)
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -825,7 +825,7 @@ func (lp *Loadpoint) minSocNotReached() bool {
 
 	if lp.vehicleSoc != 0 {
 		if lp.vehicleSoc < float64(lp.Soc.min) {
-			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc %.0f%% < Minimum Soc %d%%", lp.vehicleSoc, lp.Soc.min)
+			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc %.0f%% < Minimum Soc %.0f%%", lp.vehicleSoc, lp.Soc.min)
 		}
 		return lp.vehicleSoc < float64(lp.Soc.min)
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -824,6 +824,9 @@ func (lp *Loadpoint) minSocNotReached() bool {
 	}
 
 	if lp.vehicleSoc != 0 {
+		if lp.vehicleSoc < float64(lp.Soc.min) {
+			lp.log.DEBUG.Printf("Minimum charging: vehicleSoc (%dp) < Minimum Soc (%dp)", lp.vehicleSoc, lp.Soc.min)
+		}
 		return lp.vehicleSoc < float64(lp.Soc.min)
 	}
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -768,6 +768,7 @@ func TestMinSoc(t *testing.T) {
 
 	for _, tc := range tc {
 		lp := &Loadpoint{
+			log: util.NewLogger("foo"),
 			Soc: SocConfig{
 				min: tc.min,
 			},

--- a/core/site.go
+++ b/core/site.go
@@ -613,7 +613,7 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 
 		// if battery is charging below prioritySoc give it priority
 		if site.batterySoc < site.PrioritySoc && batteryPower < 0 {
-			site.log.DEBUG.Printf("giving priority to battery charging at soc %.0f%% until %.0f%% reached", site.batterySoc, site.PrioritySoc)
+			site.log.DEBUG.Printf("giving priority to battery charging at soc %.0f%% until %.0f%% is reached", site.batterySoc, site.PrioritySoc)
 			batteryPower = 0
 		} else {
 			// if battery is above bufferSoc allow using it for charging

--- a/core/site.go
+++ b/core/site.go
@@ -613,7 +613,7 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 
 		// if battery is charging below prioritySoc give it priority
 		if site.batterySoc < site.PrioritySoc && batteryPower < 0 {
-			site.log.DEBUG.Printf("giving priority to battery charging at soc %.0f%% until %.0f%% is reached", site.batterySoc, site.PrioritySoc)
+			site.log.DEBUG.Printf("battery has priority at soc %.0f%% (< %.0f%%)", site.batterySoc, site.PrioritySoc)
 			batteryPower = 0
 		} else {
 			// if battery is above bufferSoc allow using it for charging

--- a/core/site.go
+++ b/core/site.go
@@ -613,7 +613,7 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 
 		// if battery is charging below prioritySoc give it priority
 		if site.batterySoc < site.PrioritySoc && batteryPower < 0 {
-			site.log.DEBUG.Printf("giving priority to battery charging at soc: %.0f%%", site.batterySoc)
+			site.log.DEBUG.Printf("giving priority to battery charging at soc %.0f%% until %.0f%% reached", site.batterySoc, site.PrioritySoc)
 			batteryPower = 0
 		} else {
 			// if battery is above bufferSoc allow using it for charging


### PR DESCRIPTION
Moin!

Ich habe gerade meine ersten Gehversuche mit dem Feature **Min Ladung** unternommen. Im UI wird das grafisch schön durch den roten Balken dargestellt. Im DEBUG Log des evcc Containers ist davon leider nichts zu sehen. Ich habe deshalb in der Funktion `minSocNotReached` mal eine DEBUG Meldung eingebaut, die anzeigt, dass der Ladevorgang im Modus *Schnell* erfolgt, obwohl als Modus *PV* ausgewählt ist. Das sieht dann so aus:
```
[lp-1  ] DEBUG 2023/10/15 12:00:42 Minimum charging: vehicleSoc 43% < Minimum Soc 50%
```

Als weitere Ergänzung habe ich die Meldung in `core/site.go`, die anzeigt, dass das Laden der Batterie Priorität vor dem Laden des Autos hat, so erweitert, dass nicht nur der aktuelle Ladezustand der Batterie, sondern auch der obere Grenzwert für diese Laden mit Priorität angezeigt wird:
```
evcc  | [site  ] DEBUG 2023/10/12 16:36:10 giving priority to battery charging at soc 37% until 60% is reached
```

Ich hoffe, dass es eure Zustimmung findet.

Danke und beste Grüße

Jens