### PR TITLE
Prevent premature guard elapse in "charger out of sync" situation

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -685,8 +685,8 @@ func (lp *Loadpoint) syncCharger() error {
 		// ignore disabled state if vehicle was disconnected ^(lp.enabled && ^lp.connected)
 		if lp.guardGracePeriodElapsed() && lp.phaseSwitchCompleted() && (enabled || lp.connected()) {
 			lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
+			lp.elapseGuard()
 		}
-		lp.elapseGuard()
 		return nil
 	}
 


### PR DESCRIPTION
Follow-up to #9959, there was still one situation where the guard timer was elapsed too soon