### PR TITLE
Ocpp: fix deadlock when client stops transaction

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -274,6 +274,11 @@ func NewOCPP(id string, connector int, idtag string,
 	return c, conn.Initialized()
 }
 
+// Connector returns the connector instance
+func (c *OCPP) Connector() *ocpp.Connector {
+	return c.conn
+}
+
 // hasMeasurement checks if meterValuesSample contains given measurement
 func (c *OCPP) hasMeasurement(val types.Measurand) bool {
 	return slices.Contains(strings.Split(c.meterValuesSample, ","), string(val))

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -11,7 +11,7 @@ import (
 // Since ocpp-go interfaces at charge point level, we need to manage multiple connector separately
 
 type CP struct {
-	mu   sync.Mutex
+	mu   sync.RWMutex
 	once sync.Once
 	log  *util.Logger
 
@@ -46,15 +46,15 @@ func (cp *CP) registerConnector(id int, conn *Connector) error {
 }
 
 func (cp *CP) connectorByID(id int) *Connector {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
 
 	return cp.connectors[id]
 }
 
 func (cp *CP) connectorByTransactionID(id int) *Connector {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
 
 	for _, conn := range cp.connectors {
 		if txn, err := conn.TransactionID(); err == nil && txn == id {
@@ -66,8 +66,8 @@ func (cp *CP) connectorByTransactionID(id int) *Connector {
 }
 
 func (cp *CP) ID() string {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
 
 	return cp.id
 }
@@ -97,8 +97,8 @@ func (cp *CP) connect(connect bool) {
 }
 
 func (cp *CP) Connected() bool {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
 
 	return cp.connected
 }

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -102,6 +102,7 @@ func (suite *ocppTestSuite) TestConnect() {
 	c1, err := NewOCPP("test-1", 1, "", "", 0, false, false, ocppTestConnectTimeout, ocppTestTimeout, "A")
 	suite.Require().NoError(err)
 
+	// status and meter values
 	{
 		suite.clock.Add(ocppTestTimeout)
 		c1.conn.TestClock(suite.clock)
@@ -119,6 +120,31 @@ func (suite *ocppTestSuite) TestConnect() {
 		f, err = c1.totalEnergy()
 		suite.NoError(err)
 		suite.Equal(1.2, f)
+
+	}
+
+	// takeover
+	{
+		expectedTxn := 99
+		_, err := cp1.MeterValues(1, []types.MeterValue{
+			{
+				Timestamp: types.NewDateTime(suite.clock.Now()),
+				SampledValue: []types.SampledValue{
+					{Measurand: types.MeasurandPowerActiveImport, Value: "1000"},
+				},
+			},
+		}, func(request *core.MeterValuesRequest) {
+			request.TransactionId = &expectedTxn
+		})
+		suite.NoError(err)
+
+		conn1 := c1.Connector()
+		txnId, err := conn1.TransactionID()
+		suite.NoError(err)
+		suite.Equal(expectedTxn, txnId)
+
+		_, err = cp1.StopTransaction(0, types.NewDateTime(suite.clock.Now()), expectedTxn)
+		suite.NoError(err)
 	}
 
 	// 2nd charge point - remote

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/korylprince/ipnetgen v1.0.1
 	github.com/kr/pretty v0.3.1
 	github.com/libp2p/zeroconf/v2 v2.2.0
-	github.com/lorenzodonini/ocpp-go v0.17.0
+	github.com/lorenzodonini/ocpp-go v0.17.1-0.20231009195058-5be50a50e6e9
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40
 	github.com/mabunixda/wattpilot v1.6.2
 	github.com/manifoldco/promptui v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,6 @@ github.com/libp2p/zeroconf/v2 v2.2.0 h1:Cup06Jv6u81HLhIj1KasuNM/RHHrJ8T7wOTS4+Tv
 github.com/libp2p/zeroconf/v2 v2.2.0/go.mod h1:fuJqLnUwZTshS3U/bMRJ3+ow/v9oid1n0DmyYyNO1Xs=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/lorenzodonini/ocpp-go v0.17.0 h1:dDukZNxtQhlDfai20P/jFbJCxinnqx44ml/mrcawfGQ=
-github.com/lorenzodonini/ocpp-go v0.17.0/go.mod h1:jVzgk5k3JVGltWMU/QGlU7chojlCd/bJYc4WYl8R2M4=
 github.com/lorenzodonini/ocpp-go v0.17.1-0.20231009195058-5be50a50e6e9 h1:vyxXHKvBUmBPpiFwcUEDDLo8pMpe0P1G7mnmLd202Ck=
 github.com/lorenzodonini/ocpp-go v0.17.1-0.20231009195058-5be50a50e6e9/go.mod h1:jVzgk5k3JVGltWMU/QGlU7chojlCd/bJYc4WYl8R2M4=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,8 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-b
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lorenzodonini/ocpp-go v0.17.0 h1:dDukZNxtQhlDfai20P/jFbJCxinnqx44ml/mrcawfGQ=
 github.com/lorenzodonini/ocpp-go v0.17.0/go.mod h1:jVzgk5k3JVGltWMU/QGlU7chojlCd/bJYc4WYl8R2M4=
+github.com/lorenzodonini/ocpp-go v0.17.1-0.20231009195058-5be50a50e6e9 h1:vyxXHKvBUmBPpiFwcUEDDLo8pMpe0P1G7mnmLd202Ck=
+github.com/lorenzodonini/ocpp-go v0.17.1-0.20231009195058-5be50a50e6e9/go.mod h1:jVzgk5k3JVGltWMU/QGlU7chojlCd/bJYc4WYl8R2M4=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/discussions/10305. Deadlock:

```
goroutine 70 [sync.Mutex.Lock]:
sync.runtime_SemacquireMutex(0xc000513b88?, 0x4c?, 0xc000513bb8?)
	/opt/homebrew/Cellar/go/1.21.3/libexec/src/runtime/sema.go:77 +0x28
sync.(*Mutex).lockSlow(0xc0005a7ae0)
	/opt/homebrew/Cellar/go/1.21.3/libexec/src/sync/mutex.go:171 +0x1e8
sync.(*Mutex).Lock(0xc0005a7ae0)
	/opt/homebrew/Cellar/go/1.21.3/libexec/src/sync/mutex.go:90 +0x60
github.com/evcc-io/evcc/charger/ocpp.(*CP).Connected(0xc0005a7ae0)
	/Users/andig/htdocs/evcc/charger/ocpp/cp.go:100 +0x34
github.com/evcc-io/evcc/charger/ocpp.(*Connector).TransactionID(0xc0005f6200)
	/Users/andig/htdocs/evcc/charger/ocpp/connector.go:107 +0x4c
github.com/evcc-io/evcc/charger/ocpp.(*CP).connectorByTransactionID(0xc0005a7ae0, 0x63)
	/Users/andig/htdocs/evcc/charger/ocpp/cp.go:60 +0x104
github.com/evcc-io/evcc/charger/ocpp.(*CP).StopTransaction(0xc0005d4d80?, 0xc0007f2370)
	/Users/andig/htdocs/evcc/charger/ocpp/cp_core.go:112 +0x50
github.com/evcc-io/evcc/charger/ocpp.(*CS).OnStopTransaction(0xc000213800?, {0xc0005c06c5, 0x6}, 0xc00017e700?)
	/Users/andig/htdocs/evcc/charger/ocpp/cs_core.go:118 +0x70
github.com/lorenzodonini/ocpp-go/ocpp1%2e6.(*centralSystem).handleIncomingRequest.func1()
	/Users/andig/go/pkg/mod/github.com/lorenzodonini/ocpp-go@v0.17.1-0.20231009195058-5be50a50e6e9/ocpp1.6/central_system.go:524 +0x5e4
created by github.com/lorenzodonini/ocpp-go/ocpp1%2e6.(*centralSystem).handleIncomingRequest in goroutine 30
	/Users/andig/go/pkg/mod/github.com/lorenzodonini/ocpp-go@v0.17.1-0.20231009195058-5be50a50e6e9/ocpp1.6/central_system.go:509 +0x69c
FAIL	github.com/evcc-io/evcc/charger	31.041s
FAIL
```