### PR TITLE
Smart Grid Charging: use ≤ instead of < for limits

### DIFF
--- a/assets/js/components/GridSettingsModal.vue
+++ b/assets/js/components/GridSettingsModal.vue
@@ -146,7 +146,7 @@ export default {
 			}
 			values.sort((a, b) => a - b);
 			return values.map((value) => {
-				const name = `< ${
+				const name = `≤ ${
 					this.isCo2
 						? this.fmtCo2Medium(value)
 						: this.fmtPricePerKWh(value, this.currency)
@@ -195,7 +195,7 @@ export default {
 				// TODO: handle multiple matching time slots
 				const price = this.findSlotInRange(start, end, rates)?.price;
 				const charging =
-					price < this.selectedSmartCostLimit && this.selectedSmartCostLimit !== 0;
+					price <= this.selectedSmartCostLimit && this.selectedSmartCostLimit !== 0;
 				const selectable = price !== undefined;
 				result.push({ day, price, startHour, endHour, charging, selectable });
 			}
@@ -321,7 +321,7 @@ export default {
 				this.selectedSmartCostLimit = 0;
 				return;
 			}
-			const nextOption = this.costOptions.find(({ value }) => value > limit);
+			const nextOption = this.costOptions.find(({ value }) => value >= limit);
 			if (nextOption) {
 				this.selectedSmartCostLimit = nextOption.value;
 			}

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -282,8 +282,8 @@ vehicleTarget = "Fahrzeuglimit: {soc}%"
 
 [main.vehicleStatus]
 charging = "Ladevorgang aktiv …"
-cheapEnergyCharging = "Lade günstige Energie: {price} (Grenze < {limit})"
-cleanEnergyCharging = "Lade saubere Energie: {co2} (Grenze < {limit})"
+cheapEnergyCharging = "Lade günstige Energie: {price} (Grenze {limit})"
+cleanEnergyCharging = "Lade saubere Energie: {co2} (Grenze {limit})"
 climating = "Vorklimatisierung erkannt."
 connected = "Verbunden."
 disconnected = "Nicht verbunden."

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -279,8 +279,8 @@ vehicleTarget = "Vehicle limit: {soc}%"
 
 [main.vehicleStatus]
 charging = "Charging…"
-cheapEnergyCharging = "Charging cheap energy: {price} (limit < {limit})"
-cleanEnergyCharging = "Charging clean energy: {co2} (limit < {limit})"
+cheapEnergyCharging = "Charging cheap energy: {price} (limit {limit})"
+cleanEnergyCharging = "Charging clean energy: {co2} (limit {limit})"
 climating = "Pre-conditioning detected."
 connected = "Connected."
 disconnected = "Disconnected."

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -286,8 +286,8 @@ vehicleTarget = "límite de vehículo: {soc}%"
 
 [main.vehicleStatus]
 charging = "Cargando ..."
-cheapEnergyCharging = "Cargando con energía barata: {price} (limit < {limit})"
-cleanEnergyCharging = "Cargando con energía limpia: {co2} (limit < {limit})"
+cheapEnergyCharging = "Cargando con energía barata: {price} (limit {limit})"
+cleanEnergyCharging = "Cargando con energía limpia: {co2} (limit {limit})"
 climating = "Preacondicionamiento detectado."
 connected = "Conectado."
 disconnected = "Desconectado."

--- a/i18n/lt.toml
+++ b/i18n/lt.toml
@@ -286,8 +286,8 @@ vehicleTarget = "Automobilyje nustatytas limitas: {soc}%"
 
 [main.vehicleStatus]
 charging = "Įkraunama..."
-cheapEnergyCharging = "Įkraunama pigia energija: {price} (limit < {limit})"
-cleanEnergyCharging = "Įkraunama švaria energija: {co2} (limit < {limit})"
+cheapEnergyCharging = "Įkraunama pigia energija: {price} (limit {limit})"
+cleanEnergyCharging = "Įkraunama švaria energija: {co2} (limit {limit})"
 climating = "Aptiktas išankstinis kondicionavimas."
 connected = "Prijungtas."
 disconnected = "Neprijungtas."

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -286,8 +286,8 @@ vehicleTarget = "Limite de veículo: {soc}%"
 
 [main.vehicleStatus]
 charging = "Carregando..."
-cheapEnergyCharging = "Carregando energia barata: {price} (limit < {limit})"
-cleanEnergyCharging = "Carregando energia limpa: {co2} (limit < {limit})"
+cheapEnergyCharging = "Carregando energia barata: {price} (limit {limit})"
+cleanEnergyCharging = "Carregando energia limpa: {co2} (limit {limit})"
 climating = "Pré-condicionamento detectado."
 connected = "Ligado."
 disconnected = "Não conectado."


### PR DESCRIPTION
Options, highlighting and select is updated to use lower then or equals logic.

![Bildschirmfoto 2023-10-18 um 09 32 34](https://github.com/evcc-io/evcc/assets/152287/5fbd9784-4999-4e74-a271-29f6e6c02150)

fixes #10348