### PR TITLE
Easee: stop ticker for LIFETIME_ENERGY update only after disconnecting the vehicle

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -356,8 +356,9 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 			}
 		}
 
-		// OpMode changed FROM charging to something else - stop ticker if channel exists
-		if c.opMode == easee.ModeCharging && opMode != easee.ModeCharging && c.stopTicker != nil {
+		// OpMode changed FROM >1 ("car connected") TO  1/disconnected  - stop ticker if channel exists
+		//channel may not exist if car was connected but charging never started
+		if c.opMode != easee.ModeDisconnected && opMode == easee.ModeDisconnected && c.stopTicker != nil {
 			close(c.stopTicker)
 			c.stopTicker = nil
 		}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -357,7 +357,7 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 		}
 
 		// OpMode changed FROM >1 ("car connected") TO  1/disconnected  - stop ticker if channel exists
-		//channel may not exist if car was connected but charging never started
+		// channel may not exist regulary if the car was connected but charging never started
 		if c.opMode != easee.ModeDisconnected && opMode == easee.ModeDisconnected && c.stopTicker != nil {
 			close(c.stopTicker)
 			c.stopTicker = nil


### PR DESCRIPTION
As discussed in #10428, continue to call the API periodically after pause_charging (or some other event) to make the Easee Cloud retrieve the LIFTIME_ENERGY value from the charger until the vehicle is unplugged.