### PR TITLE
Docs: show timeout param

### DIFF
--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -22,7 +22,6 @@ params:
     advanced: true
   - name: timeout
     default: 720h
-    advanced: true
   - preset: vehicle-identify
 render: |
   type: custom

--- a/templates/definition/vehicle/mg2mqtt.yaml
+++ b/templates/definition/vehicle/mg2mqtt.yaml
@@ -21,7 +21,6 @@ params:
     advanced: true
   - name: timeout
     default: 1h
-    advanced: true
   - preset: vehicle-identify
 render: |
   type: custom

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -156,7 +156,6 @@ params:
     description:
       de: Zeitüberschreitung
       en: Timeout
-    advanced: true
     example: 10s
     type: duration
   - name: mode


### PR DESCRIPTION
The timeout param was marked as advanced. Now the option will be shown in docs.evcc.io if available.

This change effects the documentation of these devices:
<img width="473" alt="Bildschirmfoto 2023-10-24 um 19 34 18" src="https://github.com/evcc-io/evcc/assets/152287/42fa7941-53d0-4c24-8f06-0a006d9d8424">
