### PR TITLE
EEbus: do not overwrite maxCurrent

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -167,21 +167,17 @@ func (c *EEBus) setLoadpointMinMaxLimits() {
 		return
 	}
 
-	minLimits, maxLimits, _, err := c.emobility.EVCurrentLimits()
-	if err != nil || len(minLimits) == 0 || len(maxLimits) == 0 {
+	minLimits, _, _, err := c.emobility.EVCurrentLimits()
+	if err != nil || len(minLimits) == 0 {
 		return
 	}
 
 	newMin := minLimits[0]
-	newMax := maxLimits[0]
 
 	vehicle := c.lp.GetVehicle()
 
 	if c.lp.GetMinCurrent() != newMin && newMin > 0 && (vehicle == nil || vehicle.OnIdentified().MinCurrent == nil) {
 		c.lp.SetMinCurrent(newMin)
-	}
-	if c.lp.GetMaxCurrent() != newMax && newMax > 0 && (vehicle == nil || vehicle.OnIdentified().MaxCurrent == nil) {
-		c.lp.SetMaxCurrent(newMax)
 	}
 }
 


### PR DESCRIPTION
The charger should not overwrite the max current with data provided by the charger and instead use what evcc defines.

The max current could in theory change, but practically stays the same, in PMC and ISO connection modes.

With this change it is also possible to use the API to change the loadpoints max current again and define a lower max current than what the charger allows.