### PR TITLE
add maskable icon for android

### DIFF
--- a/assets/public/meta/site.webmanifest
+++ b/assets/public/meta/site.webmanifest
@@ -15,6 +15,12 @@
 			"src": "android-chrome-512x512.png",
 			"sizes": "512x512",
 			"type": "image/png"
+		},
+		{
+			"src": "android-chrome-512x512.png",
+			"sizes": "512x512",
+			"type": "image/png",
+			"purpose": "maskable"
 		}
 	]
 }


### PR DESCRIPTION
Erlaube es android das evcc icon als maskable zu verwenden.
Zuvor
![signal-2023-10-27-111650](https://github.com/evcc-io/evcc/assets/4662023/795cd564-22f4-4c14-94db-c3d18a8680f0)

Danach
![signal-2023-10-27-134809](https://github.com/evcc-io/evcc/assets/4662023/bc13639d-1188-4a84-a654-ccd3245bc031)

Ein der default `any` typ scheint dafür nicht zu reichen, siehe auch https://developer.mozilla.org/en-US/docs/Web/Manifest/icons#values

Damit das funktioniert muss man sein evcc per dritt Software über https verfügbar haben und der `/meta` ohne auth haben. Mit [traefik-forward-auth](https://github.com/thomseddon/traefik-forward-auth) geht das mit so etwas wie:

```
      - "--rule.manifest.action=allow"
      - "--rule.manifest.rule=PathPrefix(`/meta`)"
```

Sonst wird das nicht als WebApk sondern als Chrome Link installiert.