### PR TITLE
Remove deprecated chargedEnergy from ui

### DIFF
--- a/assets/js/components/Loadpoint.story.vue
+++ b/assets/js/components/Loadpoint.story.vue
@@ -6,7 +6,7 @@ const state = reactive({
 	id: 0,
 	pvConfigured: true,
 	chargePower: 2800,
-	chargedEnergy: 11e3,
+	sessionEnergy: 11e3,
 	chargeDuration: 95 * 60,
 	vehiclePresent: true,
 	vehicleTitle: "Mein Auto",

--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -75,7 +75,7 @@
 			<LabelAndValue
 				v-show="socBasedCharging"
 				:label="$t('main.loadpoint.charged')"
-				:value="fmtEnergy(chargedEnergy)"
+				:value="fmtEnergy(sessionEnergy)"
 				align="center"
 			/>
 			<LoadpointSessionInfo v-bind="sessionInfoProps" />
@@ -173,7 +173,6 @@ export default {
 
 		// details
 		chargePower: Number,
-		chargedEnergy: Number,
 		climaterActive: Boolean,
 		chargeRemainingDuration: Number,
 

--- a/assets/js/components/Loadpoints.story.vue
+++ b/assets/js/components/Loadpoints.story.vue
@@ -7,7 +7,7 @@ function loadpoint(opts) {
 		id: 0,
 		pvConfigured: true,
 		chargePower: 2800,
-		chargedEnergy: 11e3,
+		sessionEnergy: 11e3,
 		chargeDuration: 95 * 60,
 		vehiclePresent: true,
 		vehicleTitle: "Tesla Model 3",

--- a/assets/js/components/TargetEnergySelect.vue
+++ b/assets/js/components/TargetEnergySelect.vue
@@ -45,7 +45,7 @@ export default {
 	props: {
 		targetEnergy: Number,
 		socPerKwh: Number,
-		chargedEnergy: Number,
+		sessionEnergy: Number,
 		vehicleCapacity: Number,
 	},
 	emits: ["target-energy-updated"],
@@ -66,7 +66,7 @@ export default {
 			const result = [];
 			for (let energy = 0; energy <= this.maxEnergy; energy += this.steps) {
 				let text = this.fmtEnergy(energy);
-				const disabled = energy < this.chargedEnergy / 1e3 && energy !== 0;
+				const disabled = energy < this.sessionEnergy / 1e3 && energy !== 0;
 				const soc = this.estimatedSoc(energy);
 				if (soc) {
 					text += ` (${this.fmtSoc(soc)})`;

--- a/assets/js/components/Vehicle.story.vue
+++ b/assets/js/components/Vehicle.story.vue
@@ -11,7 +11,7 @@ const state = reactive({
 	vehicleRange: 231,
 	targetSoc: 90,
 	vehicleCapacity: 72,
-	chargedEnergy: 14123,
+	sessionEnergy: 14123,
 	socBasedCharging: true,
 	id: 0,
 });

--- a/assets/js/components/Vehicle.vue
+++ b/assets/js/components/Vehicle.vue
@@ -27,7 +27,7 @@
 				v-else
 				class="flex-grow-1"
 				:label="$t('main.loadpoint.charged')"
-				:value="fmtEnergy(chargedEnergy)"
+				:value="fmtEnergy(sessionEnergy)"
 				:extraValue="chargedSoc"
 				align="start"
 			/>
@@ -53,7 +53,7 @@
 				class="flex-grow-1 text-end"
 				:target-energy="targetEnergy"
 				:soc-per-kwh="socPerKwh"
-				:charged-energy="chargedEnergy"
+				:session-energy="sessionEnergy"
 				:vehicle-capacity="vehicleCapacity"
 				@target-energy-updated="targetEnergyUpdated"
 			/>
@@ -107,7 +107,7 @@ export default {
 		targetTime: String,
 		targetSoc: Number,
 		targetEnergy: Number,
-		chargedEnergy: Number,
+		sessionEnergy: Number,
 		mode: String,
 		phaseAction: String,
 		phaseRemainingInterpolated: Number,
@@ -186,7 +186,7 @@ export default {
 			return null;
 		},
 		chargedSoc: function () {
-			const value = this.socPerKwh * (this.chargedEnergy / 1e3);
+			const value = this.socPerKwh * (this.sessionEnergy / 1e3);
 			return value > 1 ? `+${Math.round(value)}%` : null;
 		},
 		chargingPlanDisabled: function () {

--- a/assets/js/components/VehicleSoc.vue
+++ b/assets/js/components/VehicleSoc.vue
@@ -64,7 +64,7 @@ export default {
 		minSoc: Number,
 		targetSoc: Number,
 		targetEnergy: Number,
-		chargedEnergy: Number,
+		sessionEnergy: Number,
 		socBasedCharging: Boolean,
 	},
 	emits: ["target-soc-drag", "target-soc-updated"],
@@ -84,7 +84,7 @@ export default {
 				return 100;
 			} else {
 				if (this.targetEnergy) {
-					return (100 / this.targetEnergy) * (this.chargedEnergy / 1e3);
+					return (100 / this.targetEnergy) * (this.sessionEnergy / 1e3);
 				}
 				return 100;
 			}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -445,7 +445,6 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 	// energy
 	lp.sessionEnergy.Reset()
 	lp.sessionEnergy.Publish("session", lp)
-	lp.publish("chargedEnergy", lp.getChargedEnergy())
 
 	// duration
 	lp.connectedTime = lp.clock.Now()
@@ -483,7 +482,6 @@ func (lp *Loadpoint) evVehicleDisconnectHandler() {
 
 	// energy and duration
 	lp.sessionEnergy.Publish("session", lp)
-	lp.publish("chargedEnergy", lp.getChargedEnergy())
 	lp.publish("connectedDuration", lp.clock.Since(lp.connectedTime).Round(time.Second))
 
 	// forget startup energy offset
@@ -1364,8 +1362,6 @@ func (lp *Loadpoint) publishChargeProgress() {
 	}
 
 	lp.sessionEnergy.Publish("session", lp)
-	// deprecated: use sessionEnergy instead
-	lp.publish("chargedEnergy", lp.getChargedEnergy())
 	lp.publish("chargeDuration", lp.chargeDuration)
 	if _, ok := lp.chargeMeter.(api.MeterEnergy); ok {
 		lp.publish("chargeTotalImport", lp.chargeMeterTotal())

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -62,10 +62,6 @@ func (lp *Loadpoint) stopSession() {
 		s.MeterStop = &meterStop
 	}
 
-	if chargedEnergy := lp.getChargedEnergy() / 1e3; chargedEnergy > s.ChargedEnergy {
-		lp.sessionEnergy.Update(chargedEnergy)
-	}
-
 	solarPerc := lp.sessionEnergy.SolarPercentage()
 	s.SolarPercentage = &solarPerc
 	s.Price = lp.sessionEnergy.Price()


### PR DESCRIPTION
- Use `sessionEnergy` in the UI instead of the deprecated `chargedEnergy`.
- Dont publish redundant `chargedEnergy` any more.