### PR TITLE
docs: document that NRGkick support only exists for older models

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ evcc is an extensible EV Charge Controller with PV integration implemented in [G
 
 - simple and clean user interface
 - wide range of supported [chargers](https://docs.evcc.io/docs/devices/chargers):
-  - ABL eMH1, Alfen (Eve), Bender (CC612/613), cFos (PowerBrain), Daheimladen, Ebee (Wallbox), Ensto (Chago Wallbox), [EVSEWifi/ smartWB](https://www.evse-wifi.de), Garo (GLB, GLB+, LS4), go-eCharger, HardyBarth (eCB1, cPH1, cPH2), Heidelberg (Energy Control), Innogy (eBox), Juice (Charger Me), KEBA/BMW, Menneckes (Amedio, Amtron Premium/Xtra, Amtron ChargeConrol), NRGkick, [openWB (includes Pro)](https://openwb.de/), Optec (Mobility One), PC Electric (includes Garo), Siemens, TechniSat (Technivolt), [Tinkerforge Warp Charger](https://www.warp-charger.com), Ubitricity (Heinz), Vestel, Wallbe, Webasto (Live), Mobile Charger Connect and many more
+  - ABL eMH1, Alfen (Eve), Bender (CC612/613), cFos (PowerBrain), Daheimladen, Ebee (Wallbox), Ensto (Chago Wallbox), [EVSEWifi/ smartWB](https://www.evse-wifi.de), Garo (GLB, GLB+, LS4), go-eCharger, HardyBarth (eCB1, cPH1, cPH2), Heidelberg (Energy Control), Innogy (eBox), Juice (Charger Me), KEBA/BMW, Menneckes (Amedio, Amtron Premium/Xtra, Amtron ChargeConrol), older NRGkicks (before 2022/2023), [openWB (includes Pro)](https://openwb.de/), Optec (Mobility One), PC Electric (includes Garo), Siemens, TechniSat (Technivolt), [Tinkerforge Warp Charger](https://www.warp-charger.com), Ubitricity (Heinz), Vestel, Wallbe, Webasto (Live), Mobile Charger Connect and many more
   - experimental EEBus support (Elli, PMCC)
   - experimental OCPP support
   - Build-your-own: Phoenix Contact (includes ESL Walli), [EVSE DIN](http://evracing.cz/simple-evse-wallbox)

--- a/templates/definition/charger/nrgkick-bluetooth.yaml
+++ b/templates/definition/charger/nrgkick-bluetooth.yaml
@@ -2,9 +2,11 @@ template: nrgkick-bluetooth
 products:
   - brand: NRGKick
     description:
-      de: NRGkick Lader via Bluetooth (älter als 2022/2023)
-      en: NRGkick charger via Bluetooth (older than 2022/2023)
       generic: Bluetooth
+requirements:
+  description:
+    de: NRGkick Lader via Bluetooth (älter als 2022/2023)
+    en: NRGkick charger via Bluetooth (older than 2022/2023)
 params:
   - name: mac
     required: true

--- a/templates/definition/charger/nrgkick-bluetooth.yaml
+++ b/templates/definition/charger/nrgkick-bluetooth.yaml
@@ -5,8 +5,8 @@ products:
       generic: Bluetooth
 requirements:
   description:
-    de: NRGkick Lader via Bluetooth (älter als 2022/2023)
-    en: NRGkick charger via Bluetooth (older than 2022/2023)
+    de: NRGkick Ladeeinheit via Bluetooth (älter als 2022/2023)
+    en: NRGkick charging unit via Bluetooth (older than 2022/2023)
 params:
   - name: mac
     required: true

--- a/templates/definition/charger/nrgkick-bluetooth.yaml
+++ b/templates/definition/charger/nrgkick-bluetooth.yaml
@@ -1,3 +1,4 @@
+# note: this only works for older NRGkicks (before 2022/2023)
 template: nrgkick-bluetooth
 products:
   - brand: NRGKick

--- a/templates/definition/charger/nrgkick-bluetooth.yaml
+++ b/templates/definition/charger/nrgkick-bluetooth.yaml
@@ -1,8 +1,9 @@
-# note: this only works for older NRGkicks (before 2022/2023)
 template: nrgkick-bluetooth
 products:
   - brand: NRGKick
     description:
+      de: NRGkick Lader via Bluetooth (älter als 2022/2023)
+      en: NRGkick charger via Bluetooth (older than 2022/2023)
       generic: Bluetooth
 params:
   - name: mac

--- a/templates/definition/charger/nrgkick-connect.yaml
+++ b/templates/definition/charger/nrgkick-connect.yaml
@@ -1,8 +1,9 @@
-# note: this only works for older NRGkicks (before 2022/2023)
 template: nrgkick-connect
 products:
   - brand: NRGKick
     description:
+      de: NRGkick Lader via HTTP (älter als 2022/2023)
+      en: NRGkick charger via HTTP (older than 2022/2023)
       generic: Connect
 params:
   - name: host

--- a/templates/definition/charger/nrgkick-connect.yaml
+++ b/templates/definition/charger/nrgkick-connect.yaml
@@ -1,3 +1,4 @@
+# note: this only works for older NRGkicks (before 2022/2023)
 template: nrgkick-connect
 products:
   - brand: NRGKick

--- a/templates/definition/charger/nrgkick-connect.yaml
+++ b/templates/definition/charger/nrgkick-connect.yaml
@@ -2,9 +2,11 @@ template: nrgkick-connect
 products:
   - brand: NRGKick
     description:
-      de: NRGkick Lader via HTTP (älter als 2022/2023)
-      en: NRGkick charger via HTTP (older than 2022/2023)
       generic: Connect
+requirements:
+  description:
+    de: NRGkick Lader via HTTP (älter als 2022/2023)
+    en: NRGkick charger via HTTP (older than 2022/2023)
 params:
   - name: host
   - name: mac

--- a/templates/definition/charger/nrgkick-connect.yaml
+++ b/templates/definition/charger/nrgkick-connect.yaml
@@ -5,8 +5,8 @@ products:
       generic: Connect
 requirements:
   description:
-    de: NRGkick Lader via HTTP (älter als 2022/2023)
-    en: NRGkick charger via HTTP (older than 2022/2023)
+    de: NRGkick Ladeeinheit via HTTP (älter als 2022/2023)
+    en: NRGkick charging unit via HTTP (older than 2022/2023)
 params:
   - name: host
   - name: mac


### PR DESCRIPTION
The list of supported charging cables has been updated to include only older NRGkick charging cables.

Currently, DiniTech GmbH refuses to publish the specification of the current communication protocol. According to discussions with NRGkick Support, it is also not guaranteed that a release is planned.

Further info:
- https://github.com/evcc-io/docs/pull/464
- https://github.com/evcc-io/evcc/discussions/4048