### PR TITLE
Planner: always publish current plan

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -610,7 +610,8 @@ func (lp *Loadpoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 	lp.publish(vehiclePresent, false)
 	lp.publish(vehicleTitle, "")
 	lp.publish(vehicleIcon, "")
-	lp.publish(vehicleCapacity, 0)
+	lp.publish(vehicleCapacity, 0.0)
+	lp.publish(vehicleOdometer, 0.0)
 
 	// assign and publish default vehicle
 	if lp.defaultVehicle != nil {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -606,6 +606,12 @@ func (lp *Loadpoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 		lp.publish(chargerIcon, nil)
 	}
 
+	// vehicle
+	lp.publish(vehiclePresent, false)
+	lp.publish(vehicleTitle, "")
+	lp.publish(vehicleIcon, "")
+	lp.publish(vehicleCapacity, 0)
+
 	// assign and publish default vehicle
 	if lp.defaultVehicle != nil {
 		lp.setActiveVehicle(lp.defaultVehicle)
@@ -1561,6 +1567,9 @@ func (lp *Loadpoint) Update(sitePower float64, autoCharge, batteryBuffered, batt
 	mode := lp.GetMode()
 	lp.publish("mode", mode)
 
+	// update and publish plan without being short-circuited by modes etc.
+	plannerActive := lp.plannerActive()
+
 	// execute loading strategy
 	switch {
 	case !lp.connected():
@@ -1591,7 +1600,7 @@ func (lp *Loadpoint) Update(sitePower float64, autoCharge, batteryBuffered, batt
 		err = lp.fastCharging()
 
 	// minimum or target charging
-	case lp.minSocNotReached() || lp.plannerActive():
+	case lp.minSocNotReached() || plannerActive:
 		err = lp.fastCharging()
 		lp.resetPhaseTimer()
 		lp.elapsePVTimer() // let PV mode disable immediately afterwards

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -162,7 +162,7 @@ func (lp *Loadpoint) setActiveVehicle(vehicle api.Vehicle) {
 		lp.publish(vehiclePresent, false)
 		lp.publish(vehicleTitle, "")
 		lp.publish(vehicleIcon, "")
-		lp.publish(vehicleCapacity, int64(0))
+		lp.publish(vehicleCapacity, 0.0)
 		lp.publish(vehicleOdometer, 0.0)
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/10561

@naltatis das Problem hier war, dass die Planupdates- falls targetSoc schon erreicht- gar nicht mehr publiziert wurden. Passiert hiermit in jedem Durchlauf.