### PR TITLE
Synchronise cache before publishing events

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -539,7 +539,7 @@ func configureEEBus(conf map[string]interface{}) error {
 }
 
 // setup messaging
-func configureMessengers(conf messagingConfig, valueChan chan util.Param, cache *util.Cache) (chan push.Event, error) {
+func configureMessengers(conf messagingConfig, cache *util.Cache) (chan<- push.Event, error) {
 	messageChan := make(chan push.Event, 1)
 
 	messageHub, err := push.NewHub(conf.Events, cache)
@@ -555,7 +555,7 @@ func configureMessengers(conf messagingConfig, valueChan chan util.Param, cache 
 		messageHub.Add(impl)
 	}
 
-	go messageHub.Run(messageChan, valueChan)
+	go messageHub.Run(messageChan, cache.Attach())
 
 	return messageChan, nil
 }

--- a/push/hub.go
+++ b/push/hub.go
@@ -72,7 +72,7 @@ func (h *Hub) apply(ev Event, tmpl string) (string, error) {
 }
 
 // Run is the Hub's main publishing loop
-func (h *Hub) Run(events <-chan Event, valueChan chan util.Param) {
+func (h *Hub) Run(events <-chan Event, valueChan <-chan util.Param) {
 	log := util.NewLogger("push")
 
 	for ev := range events {
@@ -84,11 +84,6 @@ func (h *Hub) Run(events <-chan Event, valueChan chan util.Param) {
 		if !ok {
 			continue
 		}
-
-		// let cache catch up, refs https://github.com/evcc-io/evcc/pull/445
-		flushC := util.Flusher()
-		valueChan <- util.Param{Val: flushC}
-		<-flushC
 
 		title, err := h.apply(ev, definition.Title)
 		if err != nil {

--- a/push/hub.go
+++ b/push/hub.go
@@ -76,6 +76,8 @@ func (h *Hub) Run(events <-chan Event, valueChan <-chan util.Param) {
 	log := util.NewLogger("push")
 
 	for ev := range events {
+		fmt.Println("event", ev)
+
 		if len(h.sender) == 0 {
 			continue
 		}
@@ -97,12 +99,12 @@ func (h *Hub) Run(events <-chan Event, valueChan <-chan util.Param) {
 			continue
 		}
 
-		for _, sender := range h.sender {
-			if strings.TrimSpace(msg) != "" {
+		if strings.TrimSpace(msg) != "" {
+			for _, sender := range h.sender {
 				go sender.Send(title, msg)
-			} else {
-				log.DEBUG.Printf("did not send empty message template for %s: %v", ev.Event, err)
 			}
+		} else {
+			log.DEBUG.Printf("did not send empty message template for %s: %v", ev.Event, err)
 		}
 	}
 }

--- a/util/cache.go
+++ b/util/cache.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
 // Cache is a data store
@@ -45,10 +46,9 @@ func (c *Cache) Run(in <-chan Param) {
 		// send downstream after adding to cache
 		if c.recv != nil {
 			select {
-
 			case c.recv <- p:
-			default:
-				println("cache blocked")
+			case <-time.After(time.Second):
+				fmt.Println("blocked: cache", p)
 			}
 		}
 	}

--- a/util/tee.go
+++ b/util/tee.go
@@ -1,14 +1,10 @@
 package util
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 )
-
-// TeeAttacher allows attaching a listener to a tee
-type TeeAttacher interface {
-	Attach() <-chan Param
-}
 
 // Tee distributes parameters to subscribers
 type Tee struct {
@@ -42,8 +38,13 @@ func (t *Tee) Run(in <-chan Param) {
 		}
 
 		t.mu.Lock()
-		for _, recv := range t.recv {
-			recv <- msg
+		for i, recv := range t.recv {
+			select {
+
+			case recv <- msg:
+			default:
+				fmt.Println("tee blocked", i)
+			}
 		}
 		t.mu.Unlock()
 	}

--- a/util/tee.go
+++ b/util/tee.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 )
 
 // Tee distributes parameters to subscribers
@@ -37,15 +38,14 @@ func (t *Tee) Run(in <-chan Param) {
 			}
 		}
 
-		t.mu.Lock()
 		for i, recv := range t.recv {
+			t.mu.Lock()
 			select {
-
 			case recv <- msg:
-			default:
-				fmt.Println("tee blocked", i)
+			case <-time.After(time.Second):
+				fmt.Println("blocked: tee", i, msg)
 			}
+			t.mu.Unlock()
 		}
-		t.mu.Unlock()
 	}
 }


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/7193

This PR attaches the event hub to the cache as downstream consumer. Hence event hub always has access to synchronised cache.