### PR TITLE
Fix using planner with Soc provided by charger

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1384,7 +1384,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 	soc, err := lp.chargerSoc()
 
 	// guard for socEstimator removed by api
-	if lp.socEstimator == nil || !lp.vehicleHasSoc() {
+	if lp.socEstimator == nil || (!lp.vehicleHasSoc() && err != nil) {
 		// This is a workaround for heaters. Without vehicle, the soc estimator is not initialized.
 		// We need to check if the charger can provide soc and use it if available.
 		if err == nil {


### PR DESCRIPTION
When the vehicles SoC is provided by the charger, the planner currently assumes that the EV is not charged at all. This can be reproduced by setting a target Soc to be identical to the current, and the planner will show a charge time that would be needed to reach the current Soc.

The reason is `s.vehicleSoc` in `estimator.go` not being set as `publichSocAndRange()` exits before setting it.