### PR TITLE
Improve instructions for Victron EV charging station

### DIFF
--- a/templates/definition/charger/victron.yaml
+++ b/templates/definition/charger/victron.yaml
@@ -6,12 +6,12 @@ products:
 requirements:
   evcc: ["sponsorship"]
   description:
-    en: Charger has to be in manual mode and Modbus has to be configured for ID 100.
-    de: Wallbox muss sich im Modus "Manual" befinden und Modbus ID 100 konfiguriert sein.
+    en: The connection is established via Modbus TCP to the GX device (not to the EV Charging Station). Modbus TCP must be activated before use in the Settings menu under "services", where the Modbus ID of the EV Charging Station (e.g. 40) can then also be seen. The ev charger must also be in "Manual" mode.
+    de: Die Verbindung wird per Modbus-TCP zum GX-Gerät aufgebaut (nicht zur EV Charging Station). Modbus-TCP muss vor der Verwendung im Settings-Menü unter "services" aktiviert werden, dort ist anschließend auch die Modbus-ID der EV Charging Station (z.B. 40) ersichtlich. Die Wallbox muss sich zudem im Modus "Manual" befinden.
 params:
   - name: modbus
     choice: ["tcpip"]
-    id: 100
+    id: 40
 render: |
   type: victron
   {{- include "modbus" . }}


### PR DESCRIPTION
I tested the evcc today with a Victron Energy ESS and Victron Energy EV Charging Station and want to propose the following clearifications.

As both the GX device and the EV Charging Station have a Modbus server, initially it wasn't clear to me which of the devices had to be specified. With regard to the Modbus ID, I'm not sure where the limitation of ID 100 comes from – I have tested it successfully with the Modbus ID 40, displayed by the GX device. But I'm happy to be corrected.