### PR TITLE
Easee: fix hardcoded timeout while waiting for CommandResponses

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -574,7 +574,7 @@ func (c *Easee) waitForTickResponse(expectedTick int64) error {
 				}
 				return nil
 			}
-		case <-time.After(10 * time.Second):
+		case <-time.After(c.Client.Timeout):
 			return api.ErrTimeout
 		}
 	}


### PR DESCRIPTION
fix #10780 