### PR TITLE
Fix phoenix-em-eth w/o meter broken in PR 10247

### DIFF
--- a/charger/phoenix-em-eth.go
+++ b/charger/phoenix-em-eth.go
@@ -56,7 +56,7 @@ func NewPhoenixEMEthFromConfig(other map[string]interface{}) (api.Charger, error
 	)
 
 	// check presence of meter by voltage on l1
-	if b, err := wb.conn.ReadInputRegisters(phxEMEthRegVoltages, 2); err == nil && encoding.Uint32LswFirst(b) > 0 {
+	if b, err := wb.conn.ReadInputRegisters(phxEMEthRegVoltages, 2); err == nil && encoding.Int32LswFirst(b) > 0 {
 		currentPower = wb.currentPower
 		totalEnergy = wb.totalEnergy
 		currents = wb.currents


### PR DESCRIPTION
In PR https://github.com/evcc-io/evcc/pull/10247 automatic detection of meter was implemented, however it broke the code for charge controllers without meter - it reports constant charging power of -10 W.

The problem is in the meter presence detection - the L1 voltage is tested, however it is improperly decoded as unsigned int and thus instead of -1 it reports 0xFFFF and detects presence of meter when the meter is not actually there.

The actual voltage/current reading on line 182 uses correct Int32LswFirst, only the detection of voltage used wrong Uint32LswFirst.