### PR TITLE
Add Tesla using official vehicle command library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 BUILD_TAGS := -tags=release
 TESLA_CLIENT_ID := ${TESLA_CLIENT_ID}
-LD_FLAGS := -X github.com/evcc-io/evcc/server.Version=$(VERSION) -X github.com/evcc-io/evcc/server.Commit=$(COMMIT) -X github.com/evcc-io/evcc/vehicle.TeslaClientID=$(TESLA_CLIENT_ID) -s -w
+LD_FLAGS := -X github.com/evcc-io/evcc/server.Version=$(VERSION) -X github.com/evcc-io/evcc/server.Commit=$(COMMIT) -X github.com/evcc-io/evcc/vehicle/tesla-vehicle-command.OAuth2Config.ClientID=$(TESLA_CLIENT_ID) -s -w
 BUILD_ARGS := -trimpath -ldflags='$(LD_FLAGS)'
 
 # docker

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ endif
 VERSION := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 BUILD_TAGS := -tags=release
-LD_FLAGS := -X github.com/evcc-io/evcc/server.Version=$(VERSION) -X github.com/evcc-io/evcc/server.Commit=$(COMMIT) -s -w
+TESLA_CLIENT_ID := ${TESLA_CLIENT_ID}
+LD_FLAGS := -X github.com/evcc-io/evcc/server.Version=$(VERSION) -X github.com/evcc-io/evcc/server.Commit=$(COMMIT) -X github.com/evcc-io/evcc/vehicle.TeslaClientID=$(TESLA_CLIENT_ID) -s -w
 BUILD_ARGS := -trimpath -ldflags='$(LD_FLAGS)'
 
 # docker

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52
+	github.com/teslamotors/vehicle-command v0.0.2
 	github.com/traefik/yaegi v0.15.1
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c
 	github.com/volkszaehler/mbmd v0.0.0-20231215091549-af16b1f597b9

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/teslamotors/vehicle-command v0.0.1
+	github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52
 	github.com/traefik/yaegi v0.15.1
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c
 	github.com/volkszaehler/mbmd v0.0.0-20231215091549-af16b1f597b9

--- a/go.mod
+++ b/go.mod
@@ -181,6 +181,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/teivah/onecontext v1.3.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/teslamotors/vehicle-command v0.0.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
+	github.com/teslamotors/vehicle-command v0.0.1
 	github.com/traefik/yaegi v0.15.1
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c
 	github.com/volkszaehler/mbmd v0.0.0-20231215091549-af16b1f597b9
@@ -181,7 +182,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/teivah/onecontext v1.3.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
-	github.com/teslamotors/vehicle-command v0.0.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -671,6 +671,8 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/teivah/onecontext v1.3.0 h1:tbikMhAlo6VhAuEGCvhc8HlTnpX4xTNPTOseWuhO1J0=
 github.com/teivah/onecontext v1.3.0/go.mod h1:hoW1nmdPVK/0jrvGtcx8sCKYs2PiS4z0zzfdeuEVyb0=
+github.com/teslamotors/vehicle-command v0.0.1 h1:f430QXqCb065L2bBFUeMpvDym7wjpXzWy1GskNA1PY4=
+github.com/teslamotors/vehicle-command v0.0.1/go.mod h1:SydThpjTNvhUXBy1VyiD/A9scQSYcp+E6iElHa36Gk0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/traefik/yaegi v0.15.1 h1:YA5SbaL6HZA0Exh9T/oArRHqGN2HQ+zgmCY7dkoTXu4=
 github.com/traefik/yaegi v0.15.1/go.mod h1:AVRxhaI2G+nUsaM1zyktzwXn69G3t/AuTDrCiTds9p0=

--- a/go.sum
+++ b/go.sum
@@ -7,12 +7,8 @@ github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1r
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-<<<<<<< HEAD
-=======
-github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/JuulLabs-OSS/cbgo v0.0.1 h1:A5JdglvFot1J9qYR0POZ4qInttpsVPN9lqatjaPp2ro=
 github.com/JuulLabs-OSS/cbgo v0.0.1/go.mod h1:L4YtGP+gnyD84w7+jN66ncspFRfOYB5aj9QSXaFHmBA=
->>>>>>> 91ca91907 (wip)
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -170,14 +166,8 @@ github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9g
 github.com/glebarez/go-sqlite v1.21.2/go.mod h1:sfxdZyhQjTM2Wry3gVYWaW072Ri1WMdWJi0k6+3382k=
 github.com/glebarez/sqlite v1.10.0 h1:u4gt8y7OND/cCei/NMHmfbLxF6xP2wgKcT/BJf2pYkc=
 github.com/glebarez/sqlite v1.10.0/go.mod h1:IJ+lfSOmiekhQsFTJRx/lHtGYmCdtAiTaf5wI9u5uHA=
-<<<<<<< HEAD
-=======
 github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633 h1:ZrzoZQz1CF33SPHLkjRpnVuZwr9cO1lTEc4Js7SgBos=
 github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633/go.mod h1:fFJl/jD/uyILGBeD5iQ8tYHrPlJafyqCJzAyTHNJ1Uk=
-github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
-github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
->>>>>>> 91ca91907 (wip)
 github.com/go-http-utils/etag v0.0.0-20161124023236-513ea8f21eb1 h1:zga7zaRE8HCbWjcXMDlfvmQtH0/kMVLo7cQ48dy6kWg=
 github.com/go-http-utils/etag v0.0.0-20161124023236-513ea8f21eb1/go.mod h1:PumS+5d59wmAGsZo6IfRpVNaJUq+6xjC4Utt/k8GO6Q=
 github.com/go-http-utils/fresh v0.0.0-20161124030543-7231e26a4b27 h1:O6yi4xa9b2DMosGsXzlMe2E9qXgXCVkRLCoRX+5amxI=
@@ -689,8 +679,6 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/teivah/onecontext v1.3.0 h1:tbikMhAlo6VhAuEGCvhc8HlTnpX4xTNPTOseWuhO1J0=
 github.com/teivah/onecontext v1.3.0/go.mod h1:hoW1nmdPVK/0jrvGtcx8sCKYs2PiS4z0zzfdeuEVyb0=
-github.com/teslamotors/vehicle-command v0.0.1 h1:f430QXqCb065L2bBFUeMpvDym7wjpXzWy1GskNA1PY4=
-github.com/teslamotors/vehicle-command v0.0.1/go.mod h1:SydThpjTNvhUXBy1VyiD/A9scQSYcp+E6iElHa36Gk0=
 github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52 h1:IO9NoT4bqYsX1+dpolV8vVarZvS/2tYMqo+pCeO/kZQ=
 github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52/go.mod h1:SydThpjTNvhUXBy1VyiD/A9scQSYcp+E6iElHa36Gk0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,12 @@ github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1r
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+<<<<<<< HEAD
+=======
+github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/JuulLabs-OSS/cbgo v0.0.1 h1:A5JdglvFot1J9qYR0POZ4qInttpsVPN9lqatjaPp2ro=
+github.com/JuulLabs-OSS/cbgo v0.0.1/go.mod h1:L4YtGP+gnyD84w7+jN66ncspFRfOYB5aj9QSXaFHmBA=
+>>>>>>> 91ca91907 (wip)
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -164,6 +170,14 @@ github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9g
 github.com/glebarez/go-sqlite v1.21.2/go.mod h1:sfxdZyhQjTM2Wry3gVYWaW072Ri1WMdWJi0k6+3382k=
 github.com/glebarez/sqlite v1.10.0 h1:u4gt8y7OND/cCei/NMHmfbLxF6xP2wgKcT/BJf2pYkc=
 github.com/glebarez/sqlite v1.10.0/go.mod h1:IJ+lfSOmiekhQsFTJRx/lHtGYmCdtAiTaf5wI9u5uHA=
+<<<<<<< HEAD
+=======
+github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633 h1:ZrzoZQz1CF33SPHLkjRpnVuZwr9cO1lTEc4Js7SgBos=
+github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633/go.mod h1:fFJl/jD/uyILGBeD5iQ8tYHrPlJafyqCJzAyTHNJ1Uk=
+github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+>>>>>>> 91ca91907 (wip)
 github.com/go-http-utils/etag v0.0.0-20161124023236-513ea8f21eb1 h1:zga7zaRE8HCbWjcXMDlfvmQtH0/kMVLo7cQ48dy6kWg=
 github.com/go-http-utils/etag v0.0.0-20161124023236-513ea8f21eb1/go.mod h1:PumS+5d59wmAGsZo6IfRpVNaJUq+6xjC4Utt/k8GO6Q=
 github.com/go-http-utils/fresh v0.0.0-20161124030543-7231e26a4b27 h1:O6yi4xa9b2DMosGsXzlMe2E9qXgXCVkRLCoRX+5amxI=
@@ -441,6 +455,8 @@ github.com/mergermarket/go-pkcs7 v0.0.0-20170926155232-153b18ea13c9/go.mod h1:GH
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab h1:n8cgpHzJ5+EDyDri2s/GC7a9+qK3/YEGnBsd0uS/8PY=
+github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab/go.mod h1:y1pL58r5z2VvAjeG1VLGc8zOQgSOzbKN7kMHPvFXJ+8=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
@@ -578,6 +594,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/raff/goble v0.0.0-20190909174656-72afc67d6a99 h1:JtoVdxWJ3tgyqtnPq3r4hJ9aULcIDDnPXBWxZsdmqWU=
+github.com/raff/goble v0.0.0-20190909174656-72afc67d6a99/go.mod h1:CxaUhijgLFX0AROtH5mluSY71VqpjQBw9JXE2UKZmc4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/relvacode/iso8601 v1.3.0 h1:HguUjsGpIMh/zsTczGN3DVJFxTU/GX+MMmzcKoMO7ko=
 github.com/relvacode/iso8601 v1.3.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=

--- a/go.sum
+++ b/go.sum
@@ -691,6 +691,8 @@ github.com/teivah/onecontext v1.3.0 h1:tbikMhAlo6VhAuEGCvhc8HlTnpX4xTNPTOseWuhO1
 github.com/teivah/onecontext v1.3.0/go.mod h1:hoW1nmdPVK/0jrvGtcx8sCKYs2PiS4z0zzfdeuEVyb0=
 github.com/teslamotors/vehicle-command v0.0.1 h1:f430QXqCb065L2bBFUeMpvDym7wjpXzWy1GskNA1PY4=
 github.com/teslamotors/vehicle-command v0.0.1/go.mod h1:SydThpjTNvhUXBy1VyiD/A9scQSYcp+E6iElHa36Gk0=
+github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52 h1:IO9NoT4bqYsX1+dpolV8vVarZvS/2tYMqo+pCeO/kZQ=
+github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52/go.mod h1:SydThpjTNvhUXBy1VyiD/A9scQSYcp+E6iElHa36Gk0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/traefik/yaegi v0.15.1 h1:YA5SbaL6HZA0Exh9T/oArRHqGN2HQ+zgmCY7dkoTXu4=
 github.com/traefik/yaegi v0.15.1/go.mod h1:AVRxhaI2G+nUsaM1zyktzwXn69G3t/AuTDrCiTds9p0=

--- a/go.sum
+++ b/go.sum
@@ -679,8 +679,8 @@ github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSW
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/teivah/onecontext v1.3.0 h1:tbikMhAlo6VhAuEGCvhc8HlTnpX4xTNPTOseWuhO1J0=
 github.com/teivah/onecontext v1.3.0/go.mod h1:hoW1nmdPVK/0jrvGtcx8sCKYs2PiS4z0zzfdeuEVyb0=
-github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52 h1:IO9NoT4bqYsX1+dpolV8vVarZvS/2tYMqo+pCeO/kZQ=
-github.com/teslamotors/vehicle-command v0.0.2-0.20231206234135-8e8fb14fba52/go.mod h1:SydThpjTNvhUXBy1VyiD/A9scQSYcp+E6iElHa36Gk0=
+github.com/teslamotors/vehicle-command v0.0.2 h1:NOoI7d5OVq+Yeaom7iv31sbUMPDhJ/2QRKT4HKHfTa8=
+github.com/teslamotors/vehicle-command v0.0.2/go.mod h1:SydThpjTNvhUXBy1VyiD/A9scQSYcp+E6iElHa36Gk0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/traefik/yaegi v0.15.1 h1:YA5SbaL6HZA0Exh9T/oArRHqGN2HQ+zgmCY7dkoTXu4=
 github.com/traefik/yaegi v0.15.1/go.mod h1:AVRxhaI2G+nUsaM1zyktzwXn69G3t/AuTDrCiTds9p0=

--- a/templates/definition/vehicle/tesla-command.yaml
+++ b/templates/definition/vehicle/tesla-command.yaml
@@ -1,0 +1,56 @@
+template: tesla-command
+products:
+  - brand: Tesla
+    description:
+      generic: Vehicle-Command API
+requirements:
+  description:
+    de: |
+      Es wird ein `access` und ein `refresh` Token für die Kommunikation mit der Tesla API erstellt werden.
+      Die Tokens werden unter https://tesla.evcc.io erstellt.
+    en: |
+      You need to generate an `access` and a `refresh` token for communicating with the Tesla API.
+      Tokens are generated using https://tesla.evcc.io.
+params:
+  - name: title
+  - name: icon
+    default: car
+    advanced: true
+  - name: accessToken
+    required: true
+    mask: true
+    help:
+      en: "See https://docs.evcc.io/en/docs/devices/vehicles#tesla-command"
+      de: "Siehe https://docs.evcc.io/docs/devices/vehicles#tesla-command"
+  - name: refreshToken
+    required: true
+    mask: true
+    help:
+      en: "See https://docs.evcc.io/en/docs/devices/vehicles#tesla-command"
+      de: "Siehe https://docs.evcc.io/docs/devices/vehicles#tesla-command"
+  - name: vin
+    example: W...
+  - name: capacity
+  - name: phases
+    advanced: true
+  - preset: vehicle-identify
+render: |
+  type: tesla-command
+  {{- if .title }}
+  title: {{ .title }}
+  {{- end }}
+  {{- if .icon }}
+  icon: {{ .icon }}
+  {{- end }}
+  tokens:
+    access: {{ .accessToken }}
+    refresh: {{ .refreshToken }}
+  capacity: {{ .capacity }}
+  {{- if .phases }}
+  phases: {{ .phases }}
+  {{- end }}
+  {{- if .vin }}
+  vin: {{ .vin }}
+  {{- end }}
+  {{ include "vehicle-identify" . }}
+  features: ["coarsecurrent"]

--- a/vehicle/tesla-command.go
+++ b/vehicle/tesla-command.go
@@ -53,7 +53,8 @@ func NewTeslaCommandFromConfig(other map[string]interface{}) (api.Vehicle, error
 		return nil, err
 	}
 
-	log := util.NewLogger("tesla-vc")
+	log := util.NewLogger("tesla-command").Redact(vc.OAuth2Config.ClientID, vc.OAuth2Config.ClientSecret)
+
 	client := request.NewClient(log)
 
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -46,7 +46,19 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		return nil, err
 	}
 
-	user, err := account.New(cc.Tokens.Access)
+	ts := OAuth2Config.TokenSource(context.Background(), &oauth2.Token{
+		AccessToken:  cc.Tokens.Access,
+		RefreshToken: cc.Tokens.Refresh,
+	})
+
+	token, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println(token)
+
+	user, err := account.New(token.AccessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -21,11 +21,14 @@ type TeslaVC struct {
 	dataG func() (*vc.VehicleData, error)
 }
 
-var TeslaClientID string
+var (
+	TeslaClientID     string
+	TeslaClientSecret string = os.Getenv("TESLA_CLIENT_SECRET")
+)
 
 func init() {
-	if TeslaClientID == "" {
-		TeslaClientID = os.Getenv("TESLA_CLIENT_ID")
+	if id := os.Getenv("TESLA_CLIENT_ID"); id != "" {
+		TeslaClientID = id
 	}
 	if TeslaClientID != "" {
 		vc.OAuth2Config.ClientID = TeslaClientID

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -3,8 +3,10 @@ package vehicle
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
+	"github.com/bogosj/tesla"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
@@ -46,7 +48,7 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		return nil, err
 	}
 
-	ts := OAuth2Config.TokenSource(context.Background(), &oauth2.Token{
+	ts := tesla.OAuth2Config.TokenSource(context.Background(), &oauth2.Token{
 		AccessToken:  cc.Tokens.Access,
 		RefreshToken: cc.Tokens.Refresh,
 	})
@@ -100,11 +102,12 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 // Soc implements the api.Vehicle interface
 func (v *TeslaVC) Soc() (float64, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return 0, err
-	}
-	return float64(res.Response.ChargeState.UsableBatteryLevel), nil
+	return 0, api.ErrAsleep
+	// res, err := v.dataG()
+	// if err != nil {
+	// 	return 0, err
+	// }
+	// return float64(res.Response.ChargeState.UsableBatteryLevel), nil
 }
 
 // var _ api.ChargeState = (*TeslaVC)(nil)

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -6,34 +6,27 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/provider"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	vc "github.com/evcc-io/evcc/vehicle/tesla-vehicle-command"
-	"github.com/teslamotors/vehicle-command/pkg/cache"
-	"github.com/teslamotors/vehicle-command/pkg/protocol"
 	"golang.org/x/oauth2"
 )
 
-// TeslaVC is an api.Vehicle implementation for Tesla cars.
-// It uses the official Tesla vehicle-command api.
-type TeslaVC struct {
+// TeslaCommand is an api.Vehicle implementation for Tesla cars using the official Tesla vehicle-command api.
+type TeslaCommand struct {
 	*embed
-	dataG func() (*vc.VehicleData, error)
+	*vc.Provider
 }
-
-var (
-	TeslaClientID     string
-	TeslaClientSecret string = os.Getenv("TESLA_CLIENT_SECRET")
-)
 
 func init() {
 	if id := os.Getenv("TESLA_CLIENT_ID"); id != "" {
-		TeslaClientID = id
+		vc.OAuth2Config.ClientID = id
 	}
-	if TeslaClientID != "" {
-		vc.OAuth2Config.ClientID = TeslaClientID
-		registry.Add("tesla-vehicle-command", NewTeslaVCFromConfig)
+	if secret := os.Getenv("TESLA_CLIENT_SECRET"); secret != "" {
+		vc.OAuth2Config.ClientSecret = secret
+	}
+	if vc.OAuth2Config.ClientID == "" {
+		registry.Add("tesla-command", NewTeslaCommandFromConfig)
 	}
 }
 
@@ -41,8 +34,8 @@ const (
 	privateKeyFile = "tesla-privatekey.pem"
 )
 
-// NewTeslaVCFromConfig creates a new vehicle
-func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
+// NewTeslaCommandFromConfig creates a new vehicle
+func NewTeslaCommandFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
 		embed   `mapstructure:",squash"`
 		Tokens  Tokens
@@ -77,10 +70,10 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		return nil, err
 	}
 
-	vcapi := vc.NewAPI(log, identity, cc.Timeout)
+	api := vc.NewAPI(log, identity, cc.Timeout)
 
 	vehicle, err := ensureVehicleEx(
-		cc.VIN, vcapi.Vehicles,
+		cc.VIN, api.Vehicles,
 		func(v *vc.Vehicle) string {
 			return v.Vin
 		},
@@ -89,143 +82,39 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		return nil, err
 	}
 
-	v := &TeslaVC{
-		embed: &cc.embed,
-		dataG: provider.Cached(func() (*vc.VehicleData, error) {
-			res, err := vcapi.VehicleData(vehicle.ID)
-			return res, vc.ApiError(err)
-		}, cc.Cache),
+	v := &TeslaCommand{
+		embed:    &cc.embed,
+		Provider: vc.NewProvider(api, vehicle.ID, cc.Cache),
 	}
 
 	if v.Title_ == "" {
 		v.Title_ = vehicle.DisplayName
 	}
+	/*
+		privKey, err := protocol.LoadPrivateKey(privateKeyFile)
+		if err != nil {
+			log.WARN.Println("private key not found, commands are disabled")
+			return v, nil
+		}
 
-	privKey, err := protocol.LoadPrivateKey(privateKeyFile)
-	if err != nil {
-		log.WARN.Println("private key not found, commands are disabled")
-		return v, nil
-	}
+		vv, err := identity.Account().GetVehicle(context.Background(), vehicle.Vin, privKey, cache.New(8))
+		if err != nil {
+			return nil, err
+		}
 
-	vv, err := identity.Account().GetVehicle(context.Background(), vehicle.Vin, privKey, cache.New(8))
-	if err != nil {
-		return nil, err
-	}
+		cs, err := vc.NewCommandSession(vv, cc.Timeout)
+		if err != nil {
+			return nil, err
+		}
 
-	cs, err := vc.NewCommandSession(vv, cc.Timeout)
-	if err != nil {
-		return nil, err
-	}
+		res := &struct {
+			*TeslaCommand
+			*vc.CommandSession
+		}{
+			TeslaCommand:   v,
+			CommandSession: cs,
+		}
+	*/
 
-	res := &struct {
-		*TeslaVC
-		*vc.CommandSession
-	}{
-		TeslaVC:        v,
-		CommandSession: cs,
-	}
-
-	return res, nil
-}
-
-// Soc implements the api.Vehicle interface
-func (v *TeslaVC) Soc() (float64, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return 0, err
-	}
-	return float64(res.Response.ChargeState.UsableBatteryLevel), nil
-}
-
-var _ api.ChargeState = (*TeslaVC)(nil)
-
-// Status implements the api.ChargeState interface
-func (v *TeslaVC) Status() (api.ChargeStatus, error) {
-	status := api.StatusA // disconnected
-	res, err := v.dataG()
-	if err != nil {
-		return status, err
-	}
-
-	switch res.Response.ChargeState.ChargingState {
-	case "Stopped", "NoPower", "Complete":
-		status = api.StatusB
-	case "Charging":
-		status = api.StatusC
-	}
-
-	return status, nil
-}
-
-var _ api.ChargeRater = (*TeslaVC)(nil)
-
-// ChargedEnergy implements the api.ChargeRater interface
-func (v *TeslaVC) ChargedEnergy() (float64, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return 0, err
-	}
-	return res.Response.ChargeState.ChargeEnergyAdded, nil
-}
-
-var _ api.VehicleRange = (*TeslaVC)(nil)
-
-// Range implements the api.VehicleRange interface
-func (v *TeslaVC) Range() (int64, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return 0, err
-	}
-	// miles to km
-	return int64(kmPerMile * res.Response.ChargeState.BatteryRange), nil
-}
-
-var _ api.VehicleOdometer = (*TeslaVC)(nil)
-
-// Odometer implements the api.VehicleOdometer interface
-func (v *TeslaVC) Odometer() (float64, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return 0, err
-	}
-	// miles to km
-	return kmPerMile * res.Response.VehicleState.Odometer, nil
-}
-
-var _ api.VehicleFinishTimer = (*TeslaVC)(nil)
-
-// FinishTime implements the api.VehicleFinishTimer interface
-func (v *TeslaVC) FinishTime() (time.Time, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Now().Add(time.Duration(res.Response.ChargeState.MinutesToFullCharge) * time.Minute), nil
-}
-
-// TODO api.Climater implementation has been removed as it drains battery. Re-check at a later time.
-
-// var _ api.VehiclePosition = (*TeslaVC)(nil)
-
-// // Position implements the api.VehiclePosition interface
-// func (v *TeslaVC) Position() (float64, float64, error) {
-// 	res, err := v.dataG()
-// 	if err != nil {
-// 		return 0, 0, err
-// 	}
-// 	if res.Response.DriveState.Latitude != 0 || res.Response.DriveState.Longitude != 0 {
-// 		return res.Response.DriveState.Latitude, res.Response.DriveState.Longitude, nil
-// 	}
-// 	return res.Response.DriveState.ActiveRouteLatitude, res.Response.DriveState.ActiveRouteLongitude, nil
-// }
-
-var _ api.SocLimiter = (*TeslaVC)(nil)
-
-// TargetSoc implements the api.SocLimiter interface
-func (v *TeslaVC) TargetSoc() (float64, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return 0, err
-	}
-	return float64(res.Response.ChargeState.ChargeLimitSoc), nil
+	return v, nil
 }

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -2,6 +2,7 @@ package vehicle
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
@@ -20,8 +21,16 @@ type TeslaVC struct {
 	dataG func() (*vc.VehicleData, error)
 }
 
+var TeslaClientID string
+
 func init() {
-	registry.Add("tesla-vehicle-command", NewTeslaVCFromConfig)
+	if TeslaClientID == "" {
+		TeslaClientID = os.Getenv("TESLA_CLIENT_ID")
+	}
+	if TeslaClientID != "" {
+		vc.OAuth2Config.ClientID = TeslaClientID
+		registry.Add("tesla-vehicle-command", NewTeslaVCFromConfig)
+	}
 }
 
 // NewTeslaVCFromConfig creates a new vehicle

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -123,10 +123,10 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	}
 
 	res := &struct {
-		api.Vehicle
+		*TeslaVC
 		*vc.CommandSession
 	}{
-		Vehicle:        v,
+		TeslaVC:        v,
 		CommandSession: cs,
 	}
 

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -63,7 +63,7 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		return nil, err
 	}
 
-	api := vc.NewAPI(identity)
+	api := vc.NewAPI(log, identity)
 
 	v := &TeslaVC{
 		embed: &cc.embed,
@@ -109,7 +109,7 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 // apiError converts HTTP 408 error to ErrTimeout
 func (v *TeslaVC) apiError(err error) error {
-	if err != nil && strings.HasSuffix(err.Error(), "408 Request Timeout") {
+	if err != nil && (strings.HasSuffix(err.Error(), "408 Request Timeout") || strings.HasSuffix(err.Error(), "408 (Request Timeout)")) {
 		err = api.ErrAsleep
 	}
 	return err

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -29,6 +29,8 @@ func init() {
 	registry.Add("tesla-vehicle-command", NewTeslaVCFromConfig)
 }
 
+// https://auth.tesla.com/oauth2/v3/.well-known/openid-configuration
+
 // NewTeslaVCFromConfig creates a new vehicle
 func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -1,0 +1,225 @@
+package vehicle
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/teslamotors/vehicle-command/pkg/account"
+	"github.com/teslamotors/vehicle-command/pkg/cache"
+	"github.com/teslamotors/vehicle-command/pkg/protocol"
+	"github.com/teslamotors/vehicle-command/pkg/vehicle"
+	"golang.org/x/oauth2"
+)
+
+// TeslaVC is an api.Vehicle implementation for Tesla cars.
+// It uses the official Tesla vehicle-command api.
+type TeslaVC struct {
+	*embed
+	vehicle *vehicle.Vehicle
+	// dataG   func() (*tesla.VehicleData, error)
+}
+
+func init() {
+	registry.Add("tesla-vehicle-command", NewTeslaVCFromConfig)
+}
+
+// NewTeslaVCFromConfig creates a new vehicle
+func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
+	cc := struct {
+		embed  `mapstructure:",squash"`
+		Tokens Tokens
+		VIN    string
+		Cache  time.Duration
+	}{
+		Cache: interval,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if err := cc.Tokens.Error(); err != nil {
+		return nil, err
+	}
+
+	user, err := account.New(cc.Tokens.Access)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &TeslaVC{
+		embed: &cc.embed,
+	}
+
+	// authenticated http client with logging injected to the TeslaVC client
+	log := util.NewLogger("tesla").Redact(cc.Tokens.Access, cc.Tokens.Refresh)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, request.NewClient(log))
+
+	// privKey, err := protocol.UnmarshalECDHPrivateKey(nil)
+	// if err != nil {
+	// 	logger.Printf("Failed to load private key: %s", err)
+	// 	return
+	// }
+	privKey := protocol.UnmarshalECDHPrivateKey(nil)
+	if privKey == nil {
+		return nil, errors.New("failed to load private key")
+	}
+
+	v.vehicle, err = user.GetVehicle(ctx, cc.VIN, privKey, cache.New(8))
+	if err != nil {
+		return nil, err
+	}
+
+	// if v.Title_ == "" {
+	// 	v.Title_ = v.vehicle.DisplayName
+	// }
+
+	// v.dataG = provider.Cached(func() (*tesla.VehicleData, error) {
+	// 	res, err := v.vehicle.Data()
+	// 	return res, v.apiError(err)
+	// }, cc.Cache)
+
+	return v, nil
+}
+
+// Soc implements the api.Vehicle interface
+func (v *TeslaVC) Soc() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	return float64(res.Response.ChargeState.UsableBatteryLevel), nil
+}
+
+// var _ api.ChargeState = (*TeslaVC)(nil)
+
+// // Status implements the api.ChargeState interface
+// func (v *TeslaVC) Status() (api.ChargeStatus, error) {
+// 	status := api.StatusA // disconnected
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return status, err
+// 	}
+
+// 	switch res.Response.ChargeState.ChargingState {
+// 	case "Stopped", "NoPower", "Complete":
+// 		status = api.StatusB
+// 	case "Charging":
+// 		status = api.StatusC
+// 	}
+
+// 	return status, nil
+// }
+
+// var _ api.ChargeRater = (*TeslaVC)(nil)
+
+// // ChargedEnergy implements the api.ChargeRater interface
+// func (v *TeslaVC) ChargedEnergy() (float64, error) {
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return 0, err
+// 	}
+// 	return res.Response.ChargeState.ChargeEnergyAdded, nil
+// }
+
+// const kmPerMile = 1.609344
+
+// var _ api.VehicleRange = (*TeslaVC)(nil)
+
+// // Range implements the api.VehicleRange interface
+// func (v *TeslaVC) Range() (int64, error) {
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return 0, err
+// 	}
+// 	// miles to km
+// 	return int64(kmPerMile * res.Response.ChargeState.BatteryRange), nil
+// }
+
+// var _ api.VehicleOdometer = (*TeslaVC)(nil)
+
+// // Odometer implements the api.VehicleOdometer interface
+// func (v *TeslaVC) Odometer() (float64, error) {
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return 0, err
+// 	}
+// 	// miles to km
+// 	return kmPerMile * res.Response.VehicleState.Odometer, nil
+// }
+
+// var _ api.VehicleFinishTimer = (*TeslaVC)(nil)
+
+// // FinishTime implements the api.VehicleFinishTimer interface
+// func (v *TeslaVC) FinishTime() (time.Time, error) {
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return time.Time{}, err
+// 	}
+// 	return time.Now().Add(time.Duration(res.Response.ChargeState.MinutesToFullCharge) * time.Minute), nil
+// }
+
+// // TODO api.Climater implementation has been removed as it drains battery. Re-check at a later time.
+
+// var _ api.VehiclePosition = (*TeslaVC)(nil)
+
+// // Position implements the api.VehiclePosition interface
+// func (v *TeslaVC) Position() (float64, float64, error) {
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return 0, 0, err
+// 	}
+// 	return res.Response.DriveState.Latitude, res.Response.DriveState.Longitude, nil
+// }
+
+// var _ api.SocLimiter = (*TeslaVC)(nil)
+
+// // TargetSoc implements the api.SocLimiter interface
+// func (v *TeslaVC) TargetSoc() (float64, error) {
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return 0, err
+// 	}
+// 	return float64(res.Response.ChargeState.ChargeLimitSoc), nil
+// }
+
+// var _ api.CurrentLimiter = (*TeslaVC)(nil)
+
+// // StartCharge implements the api.VehicleChargeController interface
+// func (v *TeslaVC) MaxCurrent(current int64) error {
+// 	return v.apiError(v.vehicle.SetChargingAmps(int(current)))
+// }
+
+// var _ api.Resurrector = (*TeslaVC)(nil)
+
+// func (v *TeslaVC) WakeUp() error {
+// 	_, err := v.vehicle.Wakeup()
+// 	return v.apiError(err)
+// }
+
+// var _ api.VehicleChargeController = (*TeslaVC)(nil)
+
+// // StartCharge implements the api.VehicleChargeController interface
+// func (v *TeslaVC) StartCharge() error {
+// 	err := v.apiError(v.vehicle.StartCharging())
+// 	if err != nil && slices.Contains([]string{"complete", "is_charging"}, err.Error()) {
+// 		return nil
+// 	}
+// 	return err
+// }
+
+// // StopCharge implements the api.VehicleChargeController interface
+// func (v *TeslaVC) StopCharge() error {
+// 	err := v.apiError(v.vehicle.StopCharging())
+
+// 	// ignore sleeping vehicle
+// 	if errors.Is(err, api.ErrAsleep) {
+// 		err = nil
+// 	}
+
+// 	return err
+// }

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -30,9 +30,7 @@ func init() {
 	}
 }
 
-const (
-	privateKeyFile = "tesla-privatekey.pem"
-)
+// const privateKeyFile = "tesla-privatekey.pem"
 
 // NewTeslaCommandFromConfig creates a new vehicle
 func NewTeslaCommandFromConfig(other map[string]interface{}) (api.Vehicle, error) {

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -44,12 +44,11 @@ const (
 // NewTeslaVCFromConfig creates a new vehicle
 func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	cc := struct {
-		embed    `mapstructure:",squash"`
-		ClientID string
-		Tokens   Tokens
-		VIN      string
-		Timeout  time.Duration
-		Cache    time.Duration
+		embed   `mapstructure:",squash"`
+		Tokens  Tokens
+		VIN     string
+		Timeout time.Duration
+		Cache   time.Duration
 	}{
 		Timeout: 10 * time.Second,
 		Cache:   interval,
@@ -61,10 +60,6 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err := cc.Tokens.Error(); err != nil {
 		return nil, err
-	}
-
-	if cc.ClientID != "" {
-		vc.OAuth2Config.ClientID = cc.ClientID
 	}
 
 	log := util.NewLogger("tesla-vc")

--- a/vehicle/tesla-vehicle-command.go
+++ b/vehicle/tesla-vehicle-command.go
@@ -83,8 +83,16 @@ func NewTeslaVCFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		embed: &cc.embed,
 	}
 
-	if _, err := account.Get(ctx, "api/1/vehicles"); err != nil {
+	if b, err := account.Get(ctx, "api/1/users/region"); err != nil {
 		return nil, err
+	} else {
+		fmt.Println(string(b))
+	}
+
+	if b, err := account.Get(ctx, "api/1/vehicles"); err != nil {
+		return nil, err
+	} else {
+		fmt.Println(string(b))
 	}
 
 	// privKey, err := protocol.UnmarshalECDHPrivateKey(nil)

--- a/vehicle/tesla-vehicle-command/api.go
+++ b/vehicle/tesla-vehicle-command/api.go
@@ -1,9 +1,8 @@
 package vc
 
 import (
-	"errors"
 	"fmt"
-	"net/http"
+	"time"
 
 	"github.com/bogosj/tesla"
 	"github.com/evcc-io/evcc/util"
@@ -20,8 +19,9 @@ type API struct {
 	identity *Identity
 }
 
-func NewAPI(log *util.Logger, identity *Identity) *API {
+func NewAPI(log *util.Logger, identity *Identity, timeout time.Duration) *API {
 	client := request.NewHelper(log)
+	client.Client.Timeout = timeout
 	client.Transport = &oauth2.Transport{
 		Source: identity,
 		Base:   client.Transport,
@@ -34,7 +34,7 @@ func NewAPI(log *util.Logger, identity *Identity) *API {
 }
 
 func (v *API) Vehicles() ([]*Vehicle, error) {
-	// ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	// ctx, cancel := context.WithTimeout(context.Background(), v.Timeout)
 	// defer cancel()
 
 	// b, err := v.identity.Account().Get(ctx, "api/1/vehicles")
@@ -71,40 +71,4 @@ func (v *API) VehicleData(id int64) (*VehicleData, error) {
 	err := v.GetJSON(fmt.Sprintf("%sapi/1/vehicles/%d/vehicle_data", FleetAudienceEU, id), &res)
 
 	return &res, err
-}
-
-func (v *API) commandPath(command string, id int64) string {
-	return FleetAudienceEU + fmt.Sprintf("api/1/vehicles/%d/command/%s", id, command)
-}
-
-func (v *API) sendCommand(uri string) error {
-	req, _ := request.New(http.MethodPost, uri, nil)
-
-	var resp CommandResponse
-	if err := v.DoJSON(req, &resp); err != nil {
-		return err
-	}
-
-	if !resp.Response.Result && resp.Response.Reason != "" {
-		return errors.New(resp.Response.Reason)
-	}
-
-	return nil
-}
-
-// StartCharging starts the charging of the vehicle after you have inserted the charging cable.
-func (v *API) StartCharging(id int64) error {
-	uri := v.commandPath("charge_start", id)
-	return v.sendCommand(uri)
-}
-
-// StopCharging stops the charging of the vehicle.
-func (v *API) StopCharging(id int64) error {
-	uri := v.commandPath("charge_stop", id)
-	return v.sendCommand(uri)
-}
-
-func (v *API) WakeUp(id int64) error {
-	uri := FleetAudienceEU + fmt.Sprintf("api/1/vehicles/%d/wake_up", id)
-	return v.sendCommand(uri)
 }

--- a/vehicle/tesla-vehicle-command/api.go
+++ b/vehicle/tesla-vehicle-command/api.go
@@ -1,54 +1,110 @@
 package vc
 
 import (
-	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/bogosj/tesla"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
+	"golang.org/x/oauth2"
+)
+
+const (
+	FleetAudienceEU = "https://fleet-api.prd.eu.vn.cloud.tesla.com/"
 )
 
 type API struct {
+	*request.Helper
 	identity *Identity
 }
 
-func NewAPI(identity *Identity) *API {
+func NewAPI(log *util.Logger, identity *Identity) *API {
+	client := request.NewHelper(log)
+	client.Transport = &oauth2.Transport{
+		Source: identity,
+		Base:   client.Transport,
+	}
+
 	return &API{
+		Helper:   client,
 		identity: identity,
 	}
 }
 
 func (v *API) Vehicles() ([]*Vehicle, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
-	defer cancel()
+	// ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	// defer cancel()
 
-	b, err := v.identity.Account().Get(ctx, "api/1/vehicles")
-	if err != nil {
-		return nil, err
-	}
+	// b, err := v.identity.Account().Get(ctx, "api/1/vehicles")
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// var res tesla.VehiclesResponse
+	// if err := json.Unmarshal(b, &res); err != nil {
+	// 	return nil, err
+	// }
 
 	var res tesla.VehiclesResponse
-	if err := json.Unmarshal(b, &res); err != nil {
-		return nil, err
-	}
+	err := v.GetJSON(fmt.Sprintf("%sapi/1/vehicles", FleetAudienceEU), &res)
 
-	return res.Response, nil
+	return res.Response, err
 }
 
 func (v *API) VehicleData(id int64) (*VehicleData, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
-	defer cancel()
+	// ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	// defer cancel()
 
-	b, err := v.identity.Account().Get(ctx, fmt.Sprintf("api/1/vehicles/%d/vehicle_data", id))
-	if err != nil {
-		return nil, err
-	}
+	// b, err := v.identity.Account().Get(ctx, fmt.Sprintf("api/1/vehicles/%d/vehicle_data", id))
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// var res tesla.VehicleData
+	// if err := json.Unmarshal(b, &res); err != nil {
+	// 	return nil, err
+	// }
 
 	var res tesla.VehicleData
-	if err := json.Unmarshal(b, &res); err != nil {
-		return nil, err
+	err := v.GetJSON(fmt.Sprintf("%sapi/1/vehicles/%d/vehicle_data", FleetAudienceEU, id), &res)
+
+	return &res, err
+}
+
+func (v *API) commandPath(command string, id int64) string {
+	return FleetAudienceEU + fmt.Sprintf("api/1/vehicles/%d/command/%s", id, command)
+}
+
+func (v *API) sendCommand(uri string) error {
+	req, _ := request.New(http.MethodPost, uri, nil)
+
+	var resp CommandResponse
+	if err := v.DoJSON(req, &resp); err != nil {
+		return err
 	}
 
-	return &res, nil
+	if !resp.Response.Result && resp.Response.Reason != "" {
+		return errors.New(resp.Response.Reason)
+	}
+
+	return nil
+}
+
+// StartCharging starts the charging of the vehicle after you have inserted the charging cable.
+func (v *API) StartCharging(id int64) error {
+	uri := v.commandPath("charge_start", id)
+	return v.sendCommand(uri)
+}
+
+// StopCharging stops the charging of the vehicle.
+func (v *API) StopCharging(id int64) error {
+	uri := v.commandPath("charge_stop", id)
+	return v.sendCommand(uri)
+}
+
+func (v *API) WakeUp(id int64) error {
+	uri := FleetAudienceEU + fmt.Sprintf("api/1/vehicles/%d/wake_up", id)
+	return v.sendCommand(uri)
 }

--- a/vehicle/tesla-vehicle-command/api.go
+++ b/vehicle/tesla-vehicle-command/api.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	FleetAudienceEU = "https://fleet-api.prd.eu.vn.cloud.tesla.com/"
+	FleetAudienceEU = "https://fleet-api.prd.eu.vn.cloud.tesla.com"
 )
 
 type API struct {
@@ -48,7 +48,7 @@ func (v *API) Vehicles() ([]*Vehicle, error) {
 	// }
 
 	var res tesla.VehiclesResponse
-	err := v.GetJSON(fmt.Sprintf("%sapi/1/vehicles", FleetAudienceEU), &res)
+	err := v.GetJSON(fmt.Sprintf("%s/api/1/vehicles", FleetAudienceEU), &res)
 
 	return res.Response, err
 }
@@ -68,7 +68,7 @@ func (v *API) VehicleData(id int64) (*VehicleData, error) {
 	// }
 
 	var res tesla.VehicleData
-	err := v.GetJSON(fmt.Sprintf("%sapi/1/vehicles/%d/vehicle_data", FleetAudienceEU, id), &res)
+	err := v.GetJSON(fmt.Sprintf("%s/api/1/vehicles/%d/vehicle_data", FleetAudienceEU, id), &res)
 
 	return &res, err
 }

--- a/vehicle/tesla-vehicle-command/api.go
+++ b/vehicle/tesla-vehicle-command/api.go
@@ -1,0 +1,55 @@
+package vc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bogosj/tesla"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/teslamotors/vehicle-command/pkg/account"
+)
+
+type API struct {
+	user *account.Account
+}
+
+func NewAPI(user *account.Account) *API {
+	return &API{
+		user: user,
+	}
+}
+
+func (v *API) Vehicles() ([]*tesla.Vehicle, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	defer cancel()
+
+	b, err := v.user.Get(ctx, "api/1/vehicles")
+	if err != nil {
+		return nil, err
+	}
+
+	var res tesla.VehiclesResponse
+	if err := json.Unmarshal(b, &res); err != nil {
+		return nil, err
+	}
+
+	return res.Response, nil
+}
+
+func (v *API) VehicleData(id int64) (*tesla.VehicleData, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	defer cancel()
+
+	b, err := v.user.Get(ctx, fmt.Sprintf("api/1/vehicles/%d/vehicle_data", id))
+	if err != nil {
+		return nil, err
+	}
+
+	var res tesla.VehicleData
+	if err := json.Unmarshal(b, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/vehicle/tesla-vehicle-command/api.go
+++ b/vehicle/tesla-vehicle-command/api.go
@@ -7,24 +7,23 @@ import (
 
 	"github.com/bogosj/tesla"
 	"github.com/evcc-io/evcc/util/request"
-	"github.com/teslamotors/vehicle-command/pkg/account"
 )
 
 type API struct {
-	user *account.Account
+	identity *Identity
 }
 
-func NewAPI(user *account.Account) *API {
+func NewAPI(identity *Identity) *API {
 	return &API{
-		user: user,
+		identity: identity,
 	}
 }
 
-func (v *API) Vehicles() ([]*tesla.Vehicle, error) {
+func (v *API) Vehicles() ([]*Vehicle, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
 	defer cancel()
 
-	b, err := v.user.Get(ctx, "api/1/vehicles")
+	b, err := v.identity.Account().Get(ctx, "api/1/vehicles")
 	if err != nil {
 		return nil, err
 	}
@@ -37,11 +36,11 @@ func (v *API) Vehicles() ([]*tesla.Vehicle, error) {
 	return res.Response, nil
 }
 
-func (v *API) VehicleData(id int64) (*tesla.VehicleData, error) {
+func (v *API) VehicleData(id int64) (*VehicleData, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
 	defer cancel()
 
-	b, err := v.user.Get(ctx, fmt.Sprintf("api/1/vehicles/%d/vehicle_data", id))
+	b, err := v.identity.Account().Get(ctx, fmt.Sprintf("api/1/vehicles/%d/vehicle_data", id))
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/tesla-vehicle-command/helper.go
+++ b/vehicle/tesla-vehicle-command/helper.go
@@ -1,0 +1,15 @@
+package vc
+
+import (
+	"strings"
+
+	"github.com/evcc-io/evcc/api"
+)
+
+// ApiError converts HTTP 408 error to ErrTimeout
+func ApiError(err error) error {
+	if err != nil && (strings.HasSuffix(err.Error(), "408 Request Timeout") || strings.HasSuffix(err.Error(), "408 (Request Timeout)")) {
+		err = api.ErrAsleep
+	}
+	return err
+}

--- a/vehicle/tesla-vehicle-command/helper.go
+++ b/vehicle/tesla-vehicle-command/helper.go
@@ -1,14 +1,17 @@
 package vc
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/teslamotors/vehicle-command/pkg/connector/inet"
 )
 
 // ApiError converts HTTP 408 error to ErrTimeout
 func ApiError(err error) error {
-	if err != nil && (strings.HasSuffix(err.Error(), "408 Request Timeout") || strings.HasSuffix(err.Error(), "408 (Request Timeout)")) {
+	if err != nil && (errors.Is(err, inet.ErrVehicleNotAwake) ||
+		strings.HasSuffix(err.Error(), "408 Request Timeout") || strings.HasSuffix(err.Error(), "408 (Request Timeout)")) {
 		err = api.ErrAsleep
 	}
 	return err

--- a/vehicle/tesla-vehicle-command/identity.go
+++ b/vehicle/tesla-vehicle-command/identity.go
@@ -1,8 +1,6 @@
 package vc
 
 import (
-	"os"
-
 	"github.com/evcc-io/evcc/util"
 	"github.com/teslamotors/vehicle-command/pkg/account"
 	"golang.org/x/oauth2"
@@ -12,7 +10,6 @@ import (
 
 // OAuth2Config is the OAuth2 configuration for authenticating with the Tesla API.
 var OAuth2Config = &oauth2.Config{
-	ClientID:    os.Getenv("TESLA_CLIENT_ID"),
 	RedirectURL: "https://auth.tesla.com/void/callback",
 	Endpoint: oauth2.Endpoint{
 		AuthURL:   "https://auth.tesla.com/en_us/oauth2/v3/authorize",

--- a/vehicle/tesla-vehicle-command/identity.go
+++ b/vehicle/tesla-vehicle-command/identity.go
@@ -19,6 +19,8 @@ var OAuth2Config = &oauth2.Config{
 	Scopes: []string{"openid", "email", "offline_access"},
 }
 
+const userAgent = "evcc/evcc-io"
+
 type Identity struct {
 	oauth2.TokenSource
 	log   *util.Logger
@@ -32,7 +34,7 @@ func NewIdentity(log *util.Logger, ts oauth2.TokenSource) (*Identity, error) {
 		return nil, err
 	}
 
-	acct, err := account.New(token.AccessToken)
+	acct, err := account.New(token.AccessToken, userAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +54,7 @@ func (v *Identity) Account() *account.Account {
 	}
 
 	if token.AccessToken != v.token.AccessToken {
-		acct, err := account.New(token.AccessToken)
+		acct, err := account.New(token.AccessToken, userAgent)
 		if err != nil {
 			v.log.ERROR.Println(err)
 			return v.acct

--- a/vehicle/tesla-vehicle-command/identity.go
+++ b/vehicle/tesla-vehicle-command/identity.go
@@ -23,8 +23,8 @@ var OAuth2Config = &oauth2.Config{
 }
 
 type Identity struct {
+	oauth2.TokenSource
 	log   *util.Logger
-	ts    oauth2.TokenSource
 	token *oauth2.Token
 	acct  *account.Account
 }
@@ -41,14 +41,14 @@ func NewIdentity(log *util.Logger, ts oauth2.TokenSource) (*Identity, error) {
 	}
 
 	return &Identity{
-		ts:    ts,
-		token: token,
-		acct:  acct,
+		TokenSource: ts,
+		token:       token,
+		acct:        acct,
 	}, nil
 }
 
 func (v *Identity) Account() *account.Account {
-	token, err := v.ts.Token()
+	token, err := v.Token()
 	if err != nil {
 		v.log.ERROR.Println(err)
 		return v.acct

--- a/vehicle/tesla-vehicle-command/identity.go
+++ b/vehicle/tesla-vehicle-command/identity.go
@@ -1,0 +1,68 @@
+package vc
+
+import (
+	"os"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/teslamotors/vehicle-command/pkg/account"
+	"golang.org/x/oauth2"
+)
+
+// https://auth.tesla.com/oauth2/v3/.well-known/openid-configuration
+
+// OAuth2Config is the OAuth2 configuration for authenticating with the Tesla API.
+var OAuth2Config = &oauth2.Config{
+	ClientID:    os.Getenv("TESLA_CLIENT_ID"),
+	RedirectURL: "https://auth.tesla.com/void/callback",
+	Endpoint: oauth2.Endpoint{
+		AuthURL:   "https://auth.tesla.com/en_us/oauth2/v3/authorize",
+		TokenURL:  "https://auth.tesla.com/oauth2/v3/token",
+		AuthStyle: oauth2.AuthStyleInParams,
+	},
+	Scopes: []string{"openid", "email", "offline_access"},
+}
+
+type Identity struct {
+	log   *util.Logger
+	ts    oauth2.TokenSource
+	token *oauth2.Token
+	acct  *account.Account
+}
+
+func NewIdentity(log *util.Logger, ts oauth2.TokenSource) (*Identity, error) {
+	token, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	acct, err := account.New(token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Identity{
+		ts:    ts,
+		token: token,
+		acct:  acct,
+	}, nil
+}
+
+func (v *Identity) Account() *account.Account {
+	token, err := v.ts.Token()
+	if err != nil {
+		v.log.ERROR.Println(err)
+		return v.acct
+	}
+
+	if token.AccessToken != v.token.AccessToken {
+		acct, err := account.New(token.AccessToken)
+		if err != nil {
+			v.log.ERROR.Println(err)
+			return v.acct
+		}
+
+		v.acct = acct
+	}
+
+	return v.acct
+}

--- a/vehicle/tesla-vehicle-command/provider.go
+++ b/vehicle/tesla-vehicle-command/provider.go
@@ -1,0 +1,125 @@
+package vc
+
+import (
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/provider"
+)
+
+type Provider struct {
+	dataG func() (*VehicleData, error)
+}
+
+func NewProvider(api *API, vid int64, cache time.Duration) *Provider {
+	impl := &Provider{
+		dataG: provider.Cached(func() (*VehicleData, error) {
+			return api.VehicleData(vid)
+		}, cache),
+	}
+	return impl
+}
+
+// Soc implements the api.Vehicle interface
+func (v *Provider) Soc() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	return float64(res.Response.ChargeState.UsableBatteryLevel), nil
+}
+
+var _ api.ChargeState = (*Provider)(nil)
+
+// Status implements the api.ChargeState interface
+func (v *Provider) Status() (api.ChargeStatus, error) {
+	status := api.StatusA // disconnected
+	res, err := v.dataG()
+	if err != nil {
+		return status, err
+	}
+
+	switch res.Response.ChargeState.ChargingState {
+	case "Stopped", "NoPower", "Complete":
+		status = api.StatusB
+	case "Charging":
+		status = api.StatusC
+	}
+
+	return status, nil
+}
+
+var _ api.ChargeRater = (*Provider)(nil)
+
+// ChargedEnergy implements the api.ChargeRater interface
+func (v *Provider) ChargedEnergy() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	return res.Response.ChargeState.ChargeEnergyAdded, nil
+}
+
+var _ api.VehicleRange = (*Provider)(nil)
+
+// Range implements the api.VehicleRange interface
+func (v *Provider) Range() (int64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	// miles to km
+	return int64(kmPerMile * res.Response.ChargeState.BatteryRange), nil
+}
+
+var _ api.VehicleOdometer = (*Provider)(nil)
+
+const kmPerMile = 1.609344
+
+// Odometer implements the api.VehicleOdometer interface
+func (v *Provider) Odometer() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	// miles to km
+	return kmPerMile * res.Response.VehicleState.Odometer, nil
+}
+
+var _ api.VehicleFinishTimer = (*Provider)(nil)
+
+// FinishTime implements the api.VehicleFinishTimer interface
+func (v *Provider) FinishTime() (time.Time, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Now().Add(time.Duration(res.Response.ChargeState.MinutesToFullCharge) * time.Minute), nil
+}
+
+// TODO api.Climater implementation has been removed as it drains battery. Re-check at a later time.
+
+// var _ api.VehiclePosition = (*Provider)(nil)
+
+// // Position implements the api.VehiclePosition interface
+// func (v *Provider) Position() (float64, float64, error) {
+// 	res, err := v.dataG()
+// 	if err != nil {
+// 		return 0, 0, err
+// 	}
+// 	if res.Response.DriveState.Latitude != 0 || res.Response.DriveState.Longitude != 0 {
+// 		return res.Response.DriveState.Latitude, res.Response.DriveState.Longitude, nil
+// 	}
+// 	return res.Response.DriveState.ActiveRouteLatitude, res.Response.DriveState.ActiveRouteLongitude, nil
+// }
+
+var _ api.SocLimiter = (*Provider)(nil)
+
+// TargetSoc implements the api.SocLimiter interface
+func (v *Provider) TargetSoc() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	return float64(res.Response.ChargeState.ChargeLimitSoc), nil
+}

--- a/vehicle/tesla-vehicle-command/session.go
+++ b/vehicle/tesla-vehicle-command/session.go
@@ -1,0 +1,85 @@
+package vc
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/teslamotors/vehicle-command/pkg/vehicle"
+)
+
+type CommandSession struct {
+	vehicle *vehicle.Vehicle
+	timeout time.Duration
+}
+
+func NewCommandSession(vv *vehicle.Vehicle, timeout time.Duration) (*CommandSession, error) {
+	if err := vv.Connect(context.Background()); err != nil {
+		return nil, err
+	}
+
+	if err := vv.StartSession(context.Background(), nil); err != nil {
+		return nil, err
+	}
+
+	v := &CommandSession{
+		vehicle: vv,
+		timeout: timeout,
+	}
+
+	return v, nil
+}
+
+var _ api.CurrentLimiter = (*CommandSession)(nil)
+
+// MaxCurrent implements the api.CurrentController interface
+func (v *CommandSession) MaxCurrent(current int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), v.timeout)
+	defer cancel()
+
+	return ApiError(v.vehicle.SetChargingAmps(ctx, int32(current)))
+}
+
+var _ api.Resurrector = (*CommandSession)(nil)
+
+// WakeUp implements the api.Resurrector interface
+func (v *CommandSession) WakeUp() error {
+	ctx, cancel := context.WithTimeout(context.Background(), v.timeout)
+	defer cancel()
+
+	return ApiError(v.vehicle.Wakeup(ctx))
+}
+
+var _ api.VehicleChargeController = (*CommandSession)(nil)
+
+// StartCharge implements the api.VehicleChargeController interface
+func (v *CommandSession) StartCharge() error {
+	ctx, cancel := context.WithTimeout(context.Background(), v.timeout)
+	defer cancel()
+
+	err := ApiError(v.vehicle.ChargeStart(ctx))
+
+	// ignore charging or complete
+	if err != nil && slices.Contains([]string{"complete", "is_charging"}, err.Error()) {
+		err = nil
+	}
+
+	return err
+}
+
+// StopCharge implements the api.VehicleChargeController interface
+func (v *CommandSession) StopCharge() error {
+	ctx, cancel := context.WithTimeout(context.Background(), v.timeout)
+	defer cancel()
+
+	err := ApiError(v.vehicle.ChargeStop(ctx))
+
+	// ignore sleeping vehicle
+	if errors.Is(err, api.ErrAsleep) {
+		err = nil
+	}
+
+	return err
+}

--- a/vehicle/tesla-vehicle-command/session.go
+++ b/vehicle/tesla-vehicle-command/session.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/teslamotors/vehicle-command/pkg/protocol/protobuf/universalmessage"
 	"github.com/teslamotors/vehicle-command/pkg/vehicle"
 )
 
@@ -20,7 +21,7 @@ func NewCommandSession(vv *vehicle.Vehicle, timeout time.Duration) (*CommandSess
 		return nil, err
 	}
 
-	if err := vv.StartSession(context.Background(), nil); err != nil {
+	if err := vv.StartSession(context.Background(), []universalmessage.Domain{universalmessage.Domain_DOMAIN_INFOTAINMENT}); err != nil {
 		return nil, err
 	}
 

--- a/vehicle/tesla-vehicle-command/session.go
+++ b/vehicle/tesla-vehicle-command/session.go
@@ -33,7 +33,7 @@ func NewCommandSession(vv *vehicle.Vehicle, timeout time.Duration) (*CommandSess
 	return v, nil
 }
 
-var _ api.CurrentLimiter = (*CommandSession)(nil)
+var _ api.CurrentController = (*CommandSession)(nil)
 
 // MaxCurrent implements the api.CurrentController interface
 func (v *CommandSession) MaxCurrent(current int64) error {

--- a/vehicle/tesla-vehicle-command/types.go
+++ b/vehicle/tesla-vehicle-command/types.go
@@ -3,6 +3,7 @@ package vc
 import "github.com/bogosj/tesla"
 
 type (
-	Vehicle     = tesla.Vehicle
-	VehicleData = tesla.VehicleData
+	Vehicle         = tesla.Vehicle
+	VehicleData     = tesla.VehicleData
+	CommandResponse = tesla.CommandResponse
 )

--- a/vehicle/tesla-vehicle-command/types.go
+++ b/vehicle/tesla-vehicle-command/types.go
@@ -1,0 +1,8 @@
+package vc
+
+import "github.com/bogosj/tesla"
+
+type (
+	Vehicle     = tesla.Vehicle
+	VehicleData = tesla.VehicleData
+)

--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -197,13 +197,14 @@ func (v *Tesla) TargetSoc() (float64, error) {
 
 var _ api.CurrentController = (*Tesla)(nil)
 
-// StartCharge implements the api.VehicleChargeController interface
+// MaxCurrent implements the api.CurrentLimiter interface
 func (v *Tesla) MaxCurrent(current int64) error {
 	return v.apiError(v.vehicle.SetChargingAmps(int(current)))
 }
 
 var _ api.Resurrector = (*Tesla)(nil)
 
+// WakeUp implements the api.Resurrector interface
 func (v *Tesla) WakeUp() error {
 	_, err := v.vehicle.Wakeup()
 	return v.apiError(err)

--- a/vehicle/types.go
+++ b/vehicle/types.go
@@ -27,7 +27,7 @@ type Tokens struct {
 
 // Error validates the token and returns an error if they are incomplete
 func (t *Tokens) Error() error {
-	if t.Access == "" || t.Refresh == "" {
+	if t.Access == "" && t.Refresh == "" {
 		return errors.New("missing access and/or refresh token, use `evcc token` to create")
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/10460, refs https://github.com/evcc-io/evcc/issues/10789

- [x] depends on https://github.com/teslamotors/vehicle-command/issues/28 (or patch Tesla Library)
- [x] add template
- [x] use client id during build, replaceable by ENV
- [x] fix token handling
- [x] depends on https://github.com/evcc-io/tesla/issues/3 (@naltatis)

## How to get Tesla Integration working?

1. generate a new pair of API tokens here https://tesla.evcc.io
2. switch to the latest **nightly build** of evcc
3. change your `template` from `tesla` to `tesla-command`.

```diff
vehicles:
 - name: mytesla
   type: template
-  template: tesla
+  template: tesla-command
   accessToken: [...] # generetad by tesla.evcc.io
   refreshToken:  [...] # generetad by tesla.evcc.io
   ...
```

⚠️ The template name `tesla-command` might change before the next stable release. But for now, this is the working version.

Using local builds is still possible, but now requires a Tesla Developer account. Use the `TESLA_CLIENT_ID` env.

Optional:

- [ ] implement commands via API server