### PR TITLE
Kostal: fix setting battery limit

### DIFF
--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -80,13 +80,8 @@ func NewModbusFromConfig(other map[string]interface{}) (Provider, error) {
 	var device meters.Device
 	var op modbus.Operation
 
-	if cc.Value != "" && cc.Register.Decode != "" {
-		return nil, errors.New("modbus cannot have value and register both")
-	}
-
-	if cc.Value == "" && cc.Register.Decode == "" {
-		log.WARN.Println("missing modbus value or register - assuming Power")
-		cc.Value = "Power"
+	if (cc.Value == "") == (cc.Register.Decode == "") {
+		return nil, errors.New("either value or register required")
 	}
 
 	if cc.Model == "" && cc.Value != "" {
@@ -338,7 +333,12 @@ func (m *Modbus) IntSetter(_ string) (func(int64) error, error) {
 
 			case 2:
 				var b [4]byte
-				binary.BigEndian.PutUint32(b[:], uint32(ival))
+
+				// TODO preserve encoding
+				uval := uint32(ival)
+				uval = uval&0xFFFF<<16 | uval>>16
+
+				binary.BigEndian.PutUint32(b[:], uval)
 				_, err = m.conn.WriteMultipleRegisters(op.OpCode, 2, b[:])
 
 			case 4:

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -290,12 +290,7 @@ func (m *Modbus) FloatSetter(_ string) (func(float64) error, error) {
 		switch op.ReadLen {
 		case 2:
 			var b [4]byte
-
-			// TODO preserve encoding
-			uval := math.Float32bits(float32(val))
-			uval = uval&0xFFFF<<16 | uval>>16
-
-			binary.BigEndian.PutUint32(b[:], uval)
+			binary.BigEndian.PutUint32(b[:], math.Float32bits(float32(val)))
 			_, err = m.conn.WriteMultipleRegisters(op.OpCode, 2, b[:])
 
 		case 4:

--- a/provider/modbus.go
+++ b/provider/modbus.go
@@ -290,7 +290,12 @@ func (m *Modbus) FloatSetter(_ string) (func(float64) error, error) {
 		switch op.ReadLen {
 		case 2:
 			var b [4]byte
-			binary.BigEndian.PutUint32(b[:], math.Float32bits(float32(val)))
+
+			// TODO preserve encoding
+			uval := math.Float32bits(float32(val))
+			uval = uval&0xFFFF<<16 | uval>>16
+
+			binary.BigEndian.PutUint32(b[:], uval)
 			_, err = m.conn.WriteMultipleRegisters(op.OpCode, 2, b[:])
 
 		case 4:
@@ -333,12 +338,7 @@ func (m *Modbus) IntSetter(_ string) (func(int64) error, error) {
 
 			case 2:
 				var b [4]byte
-
-				// TODO preserve encoding
-				uval := uint32(ival)
-				uval = uval&0xFFFF<<16 | uval>>16
-
-				binary.BigEndian.PutUint32(b[:], uval)
+				binary.BigEndian.PutUint32(b[:], uint32(ival))
 				_, err = m.conn.WriteMultipleRegisters(op.OpCode, 2, b[:])
 
 			case 4:

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -9,6 +9,14 @@ linked:
   - template: kostal-ksem
     usage: grid
     excludetemplate: kostal-ksem-inverter
+requirements:
+  description:
+    de: |
+      Nur ein System kann und darf auf den Wechselrichter zugreifen!
+      Für die optionale Batteriesteuerung muss Modbus Bytereihenfolge auf BigEndian (Sunspec) konfiguriert sein.
+    en: |
+      Only one system may access the inverter!
+      For optional battery control, Modbus byte order must be set to BigEndian (Sunspec).
 params:
   - name: usage
     choice: ["pv", "battery"]
@@ -25,6 +33,10 @@ params:
     advanced: true
   - name: maxsoc
     type: number
+    advanced: true
+  - name: watchdog
+    type: duration
+    default: 60s
     advanced: true
 render: |
   {{- if eq .usage "pv" }}
@@ -58,12 +70,15 @@ render: |
     model: sunspec
     value: 802:SoC # 802 battery control
   limitsoc:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 1042 # limit soc
-      type: writemultiple
-      decode: float32
+    source: watchdog
+    timeout: {{ .watchdog }} # re-write at timeout/2
+    set:
+      source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 1042 # limit soc
+        type: writemultiple
+        decode: float32
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -58,14 +58,12 @@ render: |
     model: sunspec
     value: 802:SoC # 802 battery control
   limitsoc:
-    source: float2int
-    set:
-      source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 1042 # limit soc
-        type: writesingle
-        decode: uint16
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 1042 # limit soc
+      type: writemultiple
+      decode: float32
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %

--- a/util/templates/render_instance.go
+++ b/util/templates/render_instance.go
@@ -2,7 +2,6 @@ package templates
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/evcc-io/evcc/util"
 	"gopkg.in/yaml.v3"
@@ -35,7 +34,6 @@ func RenderInstance(class Class, other map[string]interface{}) (*Instance, error
 		return nil, err
 	}
 
-	fmt.Println(string(b))
 	var instance Instance
 	if err = yaml.Unmarshal(b, &instance); err == nil && instance.Type == "" {
 		err = errors.New("empty instance type- check for missing usage")


### PR DESCRIPTION
TODO

- [ ] timeout (max 60s)

/cc @premultiply das ist ein hässlicher Hack für float32lswfirst. Eigentlich müssten wir die ganze Modbus Integration umbiegen und das Bestimmen der eigentlichen Operation bis zum Schluss lassen oder auch für Writes die entsprechenden Transformationen einführen.