### PR TITLE
Tariff: add relative smart cost limit

### DIFF
--- a/tariff/helper.go
+++ b/tariff/helper.go
@@ -34,13 +34,12 @@ func LevelRates(rates api.Rates, percent float64) []LeveledRate {
 	}
 
 	if totalDuration > 0 {
-		weighedCost /= float64(totalDuration)
+		weighedCost /= float64(totalDuration) * percent
 	}
 
-	cheap := weighedCost * percent
 	for i, r := range rates {
 		res[i].Rate = r
-		if r.Price <= cheap {
+		if r.Price <= weighedCost {
 			res[i].Cheap = true
 		}
 	}

--- a/tariff/helper.go
+++ b/tariff/helper.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/evcc-io/evcc/api"
 )
 
 func newBackoff() backoff.BackOff {
@@ -11,4 +12,38 @@ func newBackoff() backoff.BackOff {
 	bo.InitialInterval = time.Second
 	bo.MaxElapsedTime = time.Minute
 	return bo
+}
+
+type LeveledRate struct {
+	api.Rate
+	Cheap bool `json:"cheap"`
+}
+
+func LevelRates(rates api.Rates, percent float64) []LeveledRate {
+	res := make([]LeveledRate, len(rates))
+
+	var (
+		totalDuration time.Duration
+		weighedCost   float64
+	)
+
+	for _, r := range rates {
+		d := r.End.Sub(r.Start)
+		totalDuration += d
+		weighedCost += r.Price * float64(d)
+	}
+
+	if totalDuration > 0 {
+		weighedCost /= float64(totalDuration)
+	}
+
+	cheap := weighedCost * percent
+	for i, r := range rates {
+		res[i].Rate = r
+		if r.Price < cheap {
+			res[i].Cheap = true
+		}
+	}
+
+	return res
 }

--- a/tariff/helper.go
+++ b/tariff/helper.go
@@ -40,7 +40,7 @@ func LevelRates(rates api.Rates, percent float64) []LeveledRate {
 	cheap := weighedCost * percent
 	for i, r := range rates {
 		res[i].Rate = r
-		if r.Price < cheap {
+		if r.Price <= cheap {
 			res[i].Cheap = true
 		}
 	}

--- a/tariff/helper_test.go
+++ b/tariff/helper_test.go
@@ -1,0 +1,24 @@
+package tariff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/jinzhu/now"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevel(t *testing.T) {
+	var r api.Rates
+
+	for i := 0; i < 24; i++ {
+		r = append(r, api.Rate{
+			Start: now.BeginningOfHour().Add(time.Duration(i) * time.Hour),
+			End:   now.BeginningOfHour().Add(time.Duration(i+1) * time.Hour),
+			Price: float64(i),
+		})
+	}
+
+	assert.Len(t, LevelRates(r, 0.6), 24)
+}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/10848

TODO

- [ ] config setting for smart cost type
- [ ] wire to site
- [ ] ui

API suggestion:

    /smartcostlimit/{type:[a-z]}/{value:[-0-9.]+}

valid types `absolute`/`relative`.
