### PR TITLE
Template naming cleanup

### DIFF
--- a/templates/definition/charger/alphatec.yaml
+++ b/templates/definition/charger/alphatec.yaml
@@ -2,7 +2,7 @@ template: alphatec
 products:
   - brand: Alphatec
     description:
-      generic: Wallbox Mini/Power
+      generic: Wallbox Mini, Power
   - brand: Alphatec
     description:
       generic: Ladesäule Twin

--- a/templates/definition/charger/em2go.yaml
+++ b/templates/definition/charger/em2go.yaml
@@ -2,7 +2,7 @@ template: em2go
 products:
   - brand: EM2GO
     description:
-      generic: Pro Power/OCPP/ONC
+      generic: Pro Power, OCPP/ONC
 capabilities: ["mA"]
 requirements:
   description:

--- a/templates/definition/charger/homematic.yaml
+++ b/templates/definition/charger/homematic.yaml
@@ -1,6 +1,6 @@
 template: homematic
 products:
-  - brand: Homematic / Homematic IP
+  - brand: Homematic IP
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/ocpp-pulsarplus.yaml
+++ b/templates/definition/charger/ocpp-pulsarplus.yaml
@@ -2,7 +2,7 @@ template: pulsarplus
 products:
   - brand: wallbox
     description:
-      generic: Pulsar Plus / Commander 2 / Copper SB
+      generic: Pulsar Plus, Commander 2, Copper SB
 requirements:
   description:
     de: |

--- a/templates/definition/charger/phoenix-charx.yaml
+++ b/templates/definition/charger/phoenix-charx.yaml
@@ -5,7 +5,7 @@ products:
       generic: CHARX
   - brand: LadeFoxx
     description:
-      generic: EvLoad/ Mikro 2.0
+      generic: EvLoad, Mikro 2.0
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/tasmota.yaml
+++ b/templates/definition/charger/tasmota.yaml
@@ -1,6 +1,9 @@
 template: tasmota
 products:
-  - brand: Tasmota (1 Phase Charger)
+  - brand: Tasmota
+    description:
+      de: einphasig
+      en: single phase
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/vestel.yaml
+++ b/templates/definition/charger/vestel.yaml
@@ -3,7 +3,7 @@ covers: ["eon-vbox"]
 products:
   - brand: Vestel
     description:
-      generic: EVC04 Home Smart/Connect Plus
+      generic: EVC04 Home Smart, Connect Plus
   - brand: Webasto
     description:
       generic: Unite

--- a/templates/definition/charger/victron.yaml
+++ b/templates/definition/charger/victron.yaml
@@ -2,7 +2,7 @@ template: victron
 products:
   - brand: Victron
     description:
-      generic: EV charging station
+      generic: EV Charging Station
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/zaptec.yaml
+++ b/templates/definition/charger/zaptec.yaml
@@ -2,7 +2,7 @@ template: zaptec
 products:
   - brand: Zaptec
     description:
-      generic: Go/Pro
+      generic: Go, Pro
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/meter/smartfox.yaml
+++ b/templates/definition/meter/smartfox.yaml
@@ -2,15 +2,15 @@ template: smartfox
 products:
   - brand: Smartfox
     description:
-      generic: Smartfox Reg/Reg extended/Pro/Pro 2/Pro Light/Pro Light 2/Light
+      generic: Pro, Pro 2, Pro Light, Pro Light 2, Light, Reg, Reg extended
 requirements:
   description:
     de: |
-      Kann verwendet werden, um Daten für 'grid', 'pv' und 'aux' zu erhalten. 
-      Wenn "usage" nicht definiert ist, wird die Leistung für die Warmwasserbereitung zurückgegeben (als "aux" zu verwenden).
+      Kann verwendet werden, um Daten für `grid`, `pv` und `aux` zu erhalten. 
+      Wenn `usage` nicht definiert ist, wird die Leistung für die Warmwasserbereitung zurückgegeben (als `aux` zu verwenden).
     en: |
-      Can be used to get 'grid', 'pv' and 'aux' data. 
-      If 'usage' is not defined, then return the power for the water heating (to be used as 'aux').
+      Can be used to get `grid`, `pv` and `aux` data. 
+      If `usage` is not defined, then return the power for the water heating (to be used as `aux`).
 params:
   - name: usage
     choice: ["grid", "pv"]

--- a/templates/definition/meter/sofarsolar.yaml
+++ b/templates/definition/meter/sofarsolar.yaml
@@ -2,10 +2,10 @@ template: sofarsolar
 products:
   - brand: SofarSolar
     description:
-      generic: Inverter / Hybrid Inverter
+      generic: Inverter, Hybrid Inverter
   - brand: ZCS Azzurro
     description:
-      generic: Inverter / Hybrid Inverter
+      generic: Inverter, Hybrid Inverter
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/tasmota-3p.yaml
+++ b/templates/definition/meter/tasmota-3p.yaml
@@ -1,7 +1,13 @@
 template: tasmota-3p
 products:
-  - description:
-      generic: Tasmota (3 Phase Meter - meter channels 1,2+3 must be used)
+  - brand: Tasmota
+    description:
+      de: dreiphasig
+      en: three phase
+requirements:
+  description:
+    de: Kanäle 1,2,3 müssen verwendet werden.
+    en: Meter channels 1,2,3 must be used.
 group: switchsockets
 params:
   - name: usage

--- a/templates/definition/meter/varta.yaml
+++ b/templates/definition/meter/varta.yaml
@@ -3,8 +3,11 @@ covers: ["varta-energiespeicher", "varta-energiespeicher-battery-only"]
 products:
   - brand: VARTA
     description:
-      de: pulse/ pulse neo/ element (PV nur verfügbar mit PV-Sensor)
-      en: pulse/ pulse neo/ element (PV only available with PV sensor)
+      generic: pulse, pulse neo, element
+requirements:
+  description:
+    de: PV nur verfügbar mit PV-Sensor
+    en: PV only available with PV sensor
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/evcc.io/brands.json
+++ b/templates/evcc.io/brands.json
@@ -74,11 +74,11 @@
  ],
  "SmartPlugs": [
   "AVM",
-  "Homematic / Homematic IP",
+  "Homematic IP",
   "HomeWizard",
   "myStrom",
   "Shelly",
-  "Tasmota (1 Phase Charger)",
+  "Tasmota",
   "TP-Link"
  ],
  "Meters": [
@@ -137,6 +137,7 @@
   "Sonnen",
   "Sungrow",
   "Sunsynk",
+  "Tasmota",
   "Tesla",
   "Tibber",
   "TQ",
@@ -195,6 +196,7 @@
   "Steca",
   "Sungrow",
   "Sunsynk",
+  "Tasmota",
   "Tesla",
   "TP-Link",
   "VARTA",


### PR DESCRIPTION
- Always separate products with `, ` inside `description`
- Consistently use `brand` field