### PR TITLE
Config: remove more ui-enabled settings (BC)

### DIFF
--- a/core/site_api.go
+++ b/core/site_api.go
@@ -153,24 +153,24 @@ func (site *Site) SetResidualPower(power float64) error {
 	return nil
 }
 
-// GetSmartCostLimit returns the SmartCostLimit
+// GetSmartCostLimit returns the smartCostLimit
 func (site *Site) GetSmartCostLimit() float64 {
 	site.RLock()
 	defer site.RUnlock()
-	return site.SmartCostLimit
+	return site.smartCostLimit
 }
 
-// SetSmartCostLimit sets the SmartCostLimit
+// SetSmartCostLimit sets the smartCostLimit
 func (site *Site) SetSmartCostLimit(val float64) error {
 	site.Lock()
 	defer site.Unlock()
 
 	site.log.DEBUG.Println("set smart cost limit:", val)
 
-	if site.SmartCostLimit != val {
-		site.SmartCostLimit = val
-		settings.SetFloat(keys.SmartCostLimit, site.SmartCostLimit)
-		site.publish(keys.SmartCostLimit, site.SmartCostLimit)
+	if site.smartCostLimit != val {
+		site.smartCostLimit = val
+		settings.SetFloat(keys.SmartCostLimit, site.smartCostLimit)
+		site.publish(keys.SmartCostLimit, site.smartCostLimit)
 	}
 
 	return nil
@@ -216,7 +216,7 @@ func (site *Site) GetTariff(tariff string) api.Tariff {
 func (site *Site) GetBatteryDischargeControl() bool {
 	site.Lock()
 	defer site.Unlock()
-	return site.BatteryDischargeControl
+	return site.batteryDischargeControl
 }
 
 // SetBatteryControl sets the battery control mode
@@ -234,7 +234,7 @@ func (site *Site) SetBatteryDischargeControl(val bool) error {
 		site.Lock()
 		defer site.Unlock()
 
-		site.BatteryDischargeControl = val
+		site.batteryDischargeControl = val
 		settings.SetBool(keys.BatteryDischargeControl, val)
 		site.publish(keys.BatteryDischargeControl, val)
 	}

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -110,20 +110,16 @@ site:
     aux:
       - aux # list of auxiliary meters for adjusting grid operating point
   residualPower: 0 # additional household usage margin
-  prioritySoc: 0 # give home battery priority up to this soc (empty to disable)
-  bufferSoc: 0 # continue charging on battery above soc (0 to disable)
-  bufferStartSoc: 0 # start charging on battery above soc (0 to disable)
   maxGridSupplyWhileBatteryCharging: 0 # ignore battery charging if AC consumption is above this value
   smartCostLimit: 0 # set cost limit for automatic charging in PV mode
+  batteryDischargeControl: false # disable home battery when charging vehicle and full power
 
 # loadpoint describes the charger, charge meter and connected vehicle
 loadpoints:
   - title: Garage # display name for UI
     charger: wallbe # charger
     meter: charge # charge meter
-    mode: "off" # set default charge mode, use "off" to disable by default if charger is publicly available
-    # vehicle: car1 # set default vehicle (disables vehicle detection)
-    resetOnDisconnect: true # set defaults when vehicle disconnects
+    mode: "off" # default charge mode to apply when vehicle is disconnected; use "off" to disable by default if charger is publicly available
     phases: 3 # electrical connection (normal charger: default 3 for 3 phase, 1p3p charger: 0 for "auto" or 1/3 for fixed phases)
     minCurrent: 6 # minimum charge current (default 6A)
     maxCurrent: 16 # maximum charge current (default 16A)

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -111,8 +111,6 @@ site:
       - aux # list of auxiliary meters for adjusting grid operating point
   residualPower: 0 # additional household usage margin
   maxGridSupplyWhileBatteryCharging: 0 # ignore battery charging if AC consumption is above this value
-  smartCostLimit: 0 # set cost limit for automatic charging in PV mode
-  batteryDischargeControl: false # disable home battery when charging vehicle and full power
 
 # loadpoint describes the charger, charge meter and connected vehicle
 loadpoints:

--- a/schema.json
+++ b/schema.json
@@ -208,9 +208,6 @@
           "mode": {
             "$ref": "#/definitions/mode"
           },
-          "resetOnDisconnect": {
-            "type": "boolean"
-          },
           "charger": {
             "type": "string"
           },

--- a/schema.json
+++ b/schema.json
@@ -180,8 +180,16 @@
               "minItems": 1,
               "uniqueItems": true
             },
-            "smart": {
-              "type": "string"
+            "aux": {
+              "description": "Auxiliary meters (0 or more)",
+              "type": [
+                "string",
+                "array"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
             }
           }
         },


### PR DESCRIPTION
Follow-up to https://github.com/evcc-io/evcc/pull/10335

Remove:

- smartCostLimit: 0 # set cost limit for automatic charging in PV mode
- batteryDischargeControl: false # disable home battery when charging vehicle and full power
