### PR TITLE
Plan UI: color contrast in dark mode

### DIFF
--- a/assets/js/components/ChargingPlanSettings.vue
+++ b/assets/js/components/ChargingPlanSettings.vue
@@ -164,12 +164,12 @@ export default {
 h5 {
 	position: relative;
 	display: inline-block;
-	background-color: white;
+	background-color: var(--evcc-box);
 	top: -25px;
 	left: calc(50% - 50px);
 	padding: 0 0.5rem;
 	font-weight: normal;
-	color: var(--bs-gray);
+	color: var(--evcc-gray);
 	margin-bottom: -4rem;
 }
 </style>

--- a/assets/js/components/ChargingPlanSettingsEntry.vue
+++ b/assets/js/components/ChargingPlanSettingsEntry.vue
@@ -84,7 +84,7 @@
 			<div class="col-12 col-lg-2 d-flex justify-content-end align-items-baseline">
 				<button
 					type="button"
-					class="btn text-muted text-decoration-underline"
+					class="btn evcc-default-text text-decoration-underline"
 					@click="removePlan"
 				>
 					{{ $t("main.chargingPlan.remove") }}


### PR DESCRIPTION
fixes #10987

adjusted button and headline color

![Bildschirmfoto 2023-12-03 um 20 36 28](https://github.com/evcc-io/evcc/assets/152287/c1a25777-305d-4020-a7c9-2388c0576e2a)
