### PR TITLE
UI: revert tabular nums

### DIFF
--- a/assets/js/components/AnimatedNumber.vue
+++ b/assets/js/components/AnimatedNumber.vue
@@ -48,9 +48,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-span {
-	font-variant-numeric: tabular-nums;
-}
-</style>

--- a/assets/js/components/LoadpointSessionInfo.vue
+++ b/assets/js/components/LoadpointSessionInfo.vue
@@ -155,7 +155,4 @@ export default {
 	user-select: none;
 	-webkit-user-select: none;
 }
-.value {
-	font-variant-numeric: tabular-nums;
-}
 </style>

--- a/assets/js/components/SavingsTile.vue
+++ b/assets/js/components/SavingsTile.vue
@@ -67,7 +67,4 @@ export default {
 .unit {
 	font-size: var(--bs-body-font-size);
 }
-.value {
-	font-variant-numeric: tabular-nums;
-}
 </style>


### PR DESCRIPTION
fixes #10522

Monserrat unterstützt Formatierung für tabellarische. Ändert dabei aber einige Zeichen so, dass es ein inkonsistentes Erscheinungsbild gibt. Durchgängiges Verwenden von tabular-nums (auch in nicht tabellarischen Anwendungen) wäre eine Option, sperrt aber die Schrift unnötig.

Daher reverte ich hier die Änderung wieder zugunsten einheitlicher Zeichen.

`1` im normalen Text
![90768572-37d52c80-e2ef-11ea-86e7-c5446e5eb5c9](https://github.com/evcc-io/evcc/assets/152287/17c8c898-4ff6-4e3f-8b27-e1239562eb74)

`1` in tabular
<img width="526" alt="Bildschirmfoto 2023-12-07 um 18 06 13" src="https://github.com/evcc-io/evcc/assets/152287/84cf17a0-9b7f-4080-835c-3ba4fa877883">
