### PR TITLE
Arrival Tab: add soc based charging notice

### DIFF
--- a/assets/js/components/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlan.vue
@@ -128,6 +128,7 @@ export default {
 		smartCostLimit: Number,
 		smartCostType: String,
 		socBasedPlanning: Boolean,
+		socBasedCharging: Boolean,
 		socPerKwh: Number,
 		vehicle: Object,
 		vehicleCapacity: Number,

--- a/assets/js/components/ChargingPlanArrival.vue
+++ b/assets/js/components/ChargingPlanArrival.vue
@@ -1,4 +1,7 @@
 <template>
+	<div v-if="!socBasedCharging" class="alert alert-secondary my-4" role="alert">
+		{{ $t("main.loadpointSettings.onlyForSocBasedCharging") }}
+	</div>
 	<div class="mt-4 container">
 		<div class="row">
 			<div class="col-6 col-lg-3 col-form-label">
@@ -11,7 +14,7 @@
 					:id="formId('minsoc')"
 					v-model.number="selectedMinSoc"
 					class="form-select mb-2"
-					:disabled="!socBasedPlanning"
+					:disabled="!socBasedCharging"
 					@change="changeMinSoc"
 				>
 					<option v-for="soc in minSocOptions" :key="soc.value" :value="soc.value">
@@ -34,7 +37,7 @@
 					:id="formId('limitsoc')"
 					v-model.number="selectedLimitSoc"
 					class="form-select mb-2"
-					:disabled="!socBasedPlanning"
+					:disabled="!socBasedCharging"
 					@change="changeLimitSoc"
 				>
 					<option v-for="soc in limitSocOptions" :key="soc.value" :value="soc.value">
@@ -61,7 +64,7 @@ export default {
 		minSoc: { type: Number, default: 0 },
 		limitSoc: { type: Number, default: 0 },
 		vehicleName: String,
-		socBasedPlanning: Boolean,
+		socBasedCharging: Boolean,
 		rangePerSoc: Number,
 	},
 	emits: ["minsoc-updated", "limitsoc-updated"],

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -210,6 +210,7 @@ currents = "Ladestrom"
 default = "default"
 disclaimerHint = "Hinweis:"
 disclaimerText = "Änderungen gehen nach einem Neustart des Servers verloren."
+onlyForSocBasedCharging = "Diese Optionen sind nur für Fahrzeuge mit bekanntem Ladestand verfügbar."
 title = "Einstellungen {0}"
 vehicle = "Fahrzeug"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -207,6 +207,7 @@ currents = "Charging current"
 default = "default"
 disclaimerHint = "Note:"
 disclaimerText = "Changes will be lost after the server is restarted."
+onlyForSocBasedCharging = "These options are only available for vehicles with known charging level."
 title = "Settings {0}"
 vehicle = "Vehicle"
 


### PR DESCRIPTION
fixes #11130

- 💬 clarify why options are grayed out
- 🔋 allow minsoc / soc limit settings if capacity is unknown

![Bildschirmfoto 2023-12-18 um 20 58 30](https://github.com/evcc-io/evcc/assets/152287/c0e62b8e-188b-4bab-b753-75d6e2a0b506)

![Bildschirmfoto 2023-12-18 um 20 58 22](https://github.com/evcc-io/evcc/assets/152287/76168ac3-4d55-47c2-a6e7-2c98d9def693)

