### PR TITLE
Vehicles: add hidden feature

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -186,6 +186,7 @@ type Authorizer interface {
 type Vehicle interface {
 	Battery
 	BatteryCapacity
+	FeatureDescriber
 	IconDescriber
 	Title() string
 	SetTitle(string)

--- a/api/feature.go
+++ b/api/feature.go
@@ -13,8 +13,10 @@ func (f *Feature) UnmarshalText(text []byte) error {
 //go:generate enumer -type Feature
 const (
 	_ Feature = iota
-	Offline
-	CoarseCurrent
-	IntegratedDevice
-	Heating
+
+	Hidden           // vehicle: hidden from api
+	Offline          // vehicle: no capacity/soc
+	CoarseCurrent    // vehicle: 1A resolution
+	IntegratedDevice // charger: no separate vehicle
+	Heating          // charger: heating device
 )

--- a/api/feature_enumer.go
+++ b/api/feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "OfflineCoarseCurrentIntegratedDeviceHeating"
+const _FeatureName = "HiddenOfflineCoarseCurrentIntegratedDeviceHeating"
 
-var _FeatureIndex = [...]uint8{0, 7, 20, 36, 43}
+var _FeatureIndex = [...]uint8{0, 6, 13, 26, 42, 49}
 
-const _FeatureLowerName = "offlinecoarsecurrentintegrateddeviceheating"
+const _FeatureLowerName = "hiddenofflinecoarsecurrentintegrateddeviceheating"
 
 func (i Feature) String() string {
 	i -= 1
@@ -25,30 +25,34 @@ func (i Feature) String() string {
 // Re-run the stringer command to generate them again.
 func _FeatureNoOp() {
 	var x [1]struct{}
-	_ = x[Offline-(1)]
-	_ = x[CoarseCurrent-(2)]
-	_ = x[IntegratedDevice-(3)]
-	_ = x[Heating-(4)]
+	_ = x[Hidden-(1)]
+	_ = x[Offline-(2)]
+	_ = x[CoarseCurrent-(3)]
+	_ = x[IntegratedDevice-(4)]
+	_ = x[Heating-(5)]
 }
 
-var _FeatureValues = []Feature{Offline, CoarseCurrent, IntegratedDevice, Heating}
+var _FeatureValues = []Feature{Hidden, Offline, CoarseCurrent, IntegratedDevice, Heating}
 
 var _FeatureNameToValueMap = map[string]Feature{
-	_FeatureName[0:7]:        Offline,
-	_FeatureLowerName[0:7]:   Offline,
-	_FeatureName[7:20]:       CoarseCurrent,
-	_FeatureLowerName[7:20]:  CoarseCurrent,
-	_FeatureName[20:36]:      IntegratedDevice,
-	_FeatureLowerName[20:36]: IntegratedDevice,
-	_FeatureName[36:43]:      Heating,
-	_FeatureLowerName[36:43]: Heating,
+	_FeatureName[0:6]:        Hidden,
+	_FeatureLowerName[0:6]:   Hidden,
+	_FeatureName[6:13]:       Offline,
+	_FeatureLowerName[6:13]:  Offline,
+	_FeatureName[13:26]:      CoarseCurrent,
+	_FeatureLowerName[13:26]: CoarseCurrent,
+	_FeatureName[26:42]:      IntegratedDevice,
+	_FeatureLowerName[26:42]: IntegratedDevice,
+	_FeatureName[42:49]:      Heating,
+	_FeatureLowerName[42:49]: Heating,
 }
 
 var _FeatureNames = []string{
-	_FeatureName[0:7],
-	_FeatureName[7:20],
-	_FeatureName[20:36],
-	_FeatureName[36:43],
+	_FeatureName[0:6],
+	_FeatureName[6:13],
+	_FeatureName[13:26],
+	_FeatureName[26:42],
+	_FeatureName[42:49],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/api/mock.go
+++ b/api/mock.go
@@ -317,6 +317,20 @@ func (mr *MockVehicleMockRecorder) Capacity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capacity", reflect.TypeOf((*MockVehicle)(nil).Capacity))
 }
 
+// Features mocks base method.
+func (m *MockVehicle) Features() []Feature {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Features")
+	ret0, _ := ret[0].([]Feature)
+	return ret0
+}
+
+// Features indicates an expected call of Features.
+func (mr *MockVehicleMockRecorder) Features() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Features", reflect.TypeOf((*MockVehicle)(nil).Features))
+}
+
 // Icon mocks base method.
 func (m *MockVehicle) Icon() string {
 	m.ctrl.T.Helper()

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -390,8 +390,9 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 
 	// wrap vehicle with estimator
 	vehicle.EXPECT().Capacity().Return(float64(10)).AnyTimes()
-	vehicle.EXPECT().Phases().Return(0).AnyTimes()
-	vehicle.EXPECT().Title().Return("foo").AnyTimes() // TODO remove when settings always available for vehicle
+	vehicle.EXPECT().Phases().AnyTimes()
+	vehicle.EXPECT().Title().AnyTimes()
+	vehicle.EXPECT().Features().AnyTimes()
 	vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
 
 	socEstimator := soc.NewEstimator(util.NewLogger("foo"), charger, vehicle, false)

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -201,8 +201,6 @@ func (lp *Loadpoint) unpublishVehicle() {
 
 	lp.setRemainingEnergy(0)
 	lp.setRemainingDuration(0)
-
-	lp.publishVehicleFeature(api.Offline)
 }
 
 // vehicleHasFeature checks availability of vehicle feature
@@ -212,11 +210,6 @@ func (lp *Loadpoint) vehicleHasFeature(f api.Feature) bool {
 		ok = slices.Contains(v.Features(), f)
 	}
 	return ok
-}
-
-// publishVehicleFeature availability of vehicle features
-func (lp *Loadpoint) publishVehicleFeature(f api.Feature) {
-	lp.publish("vehicleFeature"+f.String(), lp.vehicleHasFeature(f))
 }
 
 // vehicleUnidentified returns true if there are associated vehicles and detection is running.

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -27,6 +27,7 @@ func TestPublishSocAndRange(t *testing.T) {
 	vehicle.EXPECT().Title().Return("target").AnyTimes()
 	vehicle.EXPECT().Capacity().AnyTimes()
 	vehicle.EXPECT().Phases().AnyTimes()
+	vehicle.EXPECT().Features().AnyTimes()
 	vehicle.EXPECT().OnIdentified().AnyTimes()
 
 	log := util.NewLogger("foo")
@@ -228,10 +229,11 @@ func TestReconnectVehicle(t *testing.T) {
 			}
 
 			vehicle := &vehicleT{api.NewMockVehicle(ctrl), api.NewMockChargeState(ctrl)}
-			vehicle.MockVehicle.EXPECT().Title().Return("vehicle").AnyTimes()
-			vehicle.MockVehicle.EXPECT().Icon().Return("").AnyTimes()
+			vehicle.MockVehicle.EXPECT().Title().AnyTimes()
+			vehicle.MockVehicle.EXPECT().Icon().AnyTimes()
 			vehicle.MockVehicle.EXPECT().Capacity().AnyTimes()
 			vehicle.MockVehicle.EXPECT().Phases().AnyTimes()
+			vehicle.MockVehicle.EXPECT().Features().AnyTimes()
 			vehicle.MockVehicle.EXPECT().OnIdentified().AnyTimes()
 			vehicle.MockVehicle.EXPECT().Identifiers().AnyTimes().Return(tc.vehicleId)
 			vehicle.MockVehicle.EXPECT().Soc().Return(0.0, nil).AnyTimes()

--- a/vehicle/embed.go
+++ b/vehicle/embed.go
@@ -4,7 +4,6 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-// TODO align phases with OnIdentify
 // TODO remove vehicle settings
 type embed struct {
 	Title_       string           `mapstructure:"title"`


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/11023

@naltatis damit verschwindet im UI auch

     "vehicleFeatureOffline": false,

brauchst Du das oder kannst Du Dir das konsequenterweise aus /vehicles holen? Perspektivisch sollten wir auch den soc dorthin verlagern.