### PR TITLE
Vehicles: move more properties to /vehicles (BC)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,87 +2,12 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 )
 
 //go:generate mockgen -package api -destination mock.go github.com/evcc-io/evcc/api Charger,ChargeState,CurrentLimiter,PhaseSwitcher,Identifier,Meter,MeterEnergy,Vehicle,ChargeRater,Battery,Tariff,BatteryController
-
-// ChargeMode is the charge operation mode. Valid values are off, now, minpv and pv
-type ChargeMode string
-
-// Charge modes
-const (
-	ModeEmpty ChargeMode = ""
-	ModeOff   ChargeMode = "off"
-	ModeNow   ChargeMode = "now"
-	ModeMinPV ChargeMode = "minpv"
-	ModePV    ChargeMode = "pv"
-)
-
-// String implements Stringer
-func (c ChargeMode) String() string {
-	return string(c)
-}
-
-// ChargeStatus is the EV's charging status from A to F
-type ChargeStatus string
-
-// Charging states
-const (
-	StatusNone ChargeStatus = ""
-	StatusA    ChargeStatus = "A" // Fzg. angeschlossen: nein    Laden aktiv: nein    Ladestation betriebsbereit, Fahrzeug getrennt
-	StatusB    ChargeStatus = "B" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fahrzeug verbunden, Netzspannung liegt nicht an
-	StatusC    ChargeStatus = "C" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt, Netzspannung liegt an
-	StatusD    ChargeStatus = "D" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt mit externer Belüfungsanforderung (für Blei-Säure-Batterien)
-	StatusE    ChargeStatus = "E" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler Fahrzeug / Kabel (CP-Kurzschluss, 0V)
-	StatusF    ChargeStatus = "F" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler EVSE oder Abstecken simulieren (CP-Wake-up, -12V)
-)
-
-var StatusEasA = map[ChargeStatus]ChargeStatus{StatusE: StatusA}
-
-// ChargeStatusString converts a string to ChargeStatus
-func ChargeStatusString(status string) (ChargeStatus, error) {
-	s := strings.ToUpper(strings.Trim(status, "\x00 "))
-
-	if len(s) == 0 {
-		return StatusNone, fmt.Errorf("invalid status: %s", status)
-	}
-
-	switch s1 := s[:1]; s1 {
-	case "A", "B":
-		return ChargeStatus(s1), nil
-
-	case "C", "D":
-		if s == "C1" || s == "D1" {
-			return StatusB, nil
-		}
-		return StatusC, nil
-
-	case "E", "F":
-		return ChargeStatus(s1), fmt.Errorf("invalid status: %s", s)
-
-	default:
-		return StatusNone, fmt.Errorf("invalid status: %s", status)
-	}
-}
-
-// ChargeStatusStringWithMapping converts a string to ChargeStatus. In case of error, mapping is applied.
-func ChargeStatusStringWithMapping(s string, m map[ChargeStatus]ChargeStatus) (ChargeStatus, error) {
-	status, err := ChargeStatusString(s)
-	if mappedStatus, ok := m[status]; ok && err != nil {
-		return mappedStatus, nil
-	}
-	return status, err
-}
-
-// String implements Stringer
-func (c ChargeStatus) String() string {
-	return string(c)
-}
 
 // Meter provides total active power in W
 type Meter interface {
@@ -187,6 +112,8 @@ type Vehicle interface {
 	Battery
 	BatteryCapacity
 	IconDescriber
+	ConnectorDescriber
+	FeatureDescriber
 	Title() string
 	SetTitle(string)
 	Phases() int
@@ -258,6 +185,11 @@ type AuthProvider interface {
 // IconDescriber optionally provides an icon
 type IconDescriber interface {
 	Icon() string
+}
+
+// ConnectorDescriber optionally provides an connector
+type ConnectorDescriber interface {
+	Connector() string
 }
 
 // FeatureDescriber optionally provides a list of supported non-api features

--- a/api/api.go
+++ b/api/api.go
@@ -187,11 +187,6 @@ type IconDescriber interface {
 	Icon() string
 }
 
-// ConnectorDescriber optionally provides an connector
-type ConnectorDescriber interface {
-	Connector() string
-}
-
 // FeatureDescriber optionally provides a list of supported non-api features
 type FeatureDescriber interface {
 	Features() []Feature

--- a/api/api.go
+++ b/api/api.go
@@ -112,7 +112,6 @@ type Vehicle interface {
 	Battery
 	BatteryCapacity
 	IconDescriber
-	ConnectorDescriber
 	FeatureDescriber
 	Title() string
 	SetTitle(string)

--- a/api/chargemodestatus.go
+++ b/api/chargemodestatus.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ChargeMode is the charge operation mode. Valid values are off, now, minpv and pv
+type ChargeMode string
+
+// Charge modes
+const (
+	ModeEmpty ChargeMode = ""
+	ModeOff   ChargeMode = "off"
+	ModeNow   ChargeMode = "now"
+	ModeMinPV ChargeMode = "minpv"
+	ModePV    ChargeMode = "pv"
+)
+
+// String implements Stringer
+func (c ChargeMode) String() string {
+	return string(c)
+}
+
+// ChargeStatus is the EV's charging status from A to F
+type ChargeStatus string
+
+// Charging states
+const (
+	StatusNone ChargeStatus = ""
+	StatusA    ChargeStatus = "A" // Fzg. angeschlossen: nein    Laden aktiv: nein    Ladestation betriebsbereit, Fahrzeug getrennt
+	StatusB    ChargeStatus = "B" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fahrzeug verbunden, Netzspannung liegt nicht an
+	StatusC    ChargeStatus = "C" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt, Netzspannung liegt an
+	StatusD    ChargeStatus = "D" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt mit externer Belüfungsanforderung (für Blei-Säure-Batterien)
+	StatusE    ChargeStatus = "E" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler Fahrzeug / Kabel (CP-Kurzschluss, 0V)
+	StatusF    ChargeStatus = "F" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler EVSE oder Abstecken simulieren (CP-Wake-up, -12V)
+)
+
+var StatusEasA = map[ChargeStatus]ChargeStatus{StatusE: StatusA}
+
+// ChargeStatusString converts a string to ChargeStatus
+func ChargeStatusString(status string) (ChargeStatus, error) {
+	s := strings.ToUpper(strings.Trim(status, "\x00 "))
+
+	if len(s) == 0 {
+		return StatusNone, fmt.Errorf("invalid status: %s", status)
+	}
+
+	switch s1 := s[:1]; s1 {
+	case "A", "B":
+		return ChargeStatus(s1), nil
+
+	case "C", "D":
+		if s == "C1" || s == "D1" {
+			return StatusB, nil
+		}
+		return StatusC, nil
+
+	case "E", "F":
+		return ChargeStatus(s1), fmt.Errorf("invalid status: %s", s)
+
+	default:
+		return StatusNone, fmt.Errorf("invalid status: %s", status)
+	}
+}
+
+// ChargeStatusStringWithMapping converts a string to ChargeStatus. In case of error, mapping is applied.
+func ChargeStatusStringWithMapping(s string, m map[ChargeStatus]ChargeStatus) (ChargeStatus, error) {
+	status, err := ChargeStatusString(s)
+	if mappedStatus, ok := m[status]; ok && err != nil {
+		return mappedStatus, nil
+	}
+	return status, err
+}
+
+// String implements Stringer
+func (c ChargeStatus) String() string {
+	return string(c)
+}

--- a/api/mock.go
+++ b/api/mock.go
@@ -361,20 +361,6 @@ func (mr *MockVehicleMockRecorder) Capacity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capacity", reflect.TypeOf((*MockVehicle)(nil).Capacity))
 }
 
-// Connector mocks base method.
-func (m *MockVehicle) Connector() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Connector")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Connector indicates an expected call of Connector.
-func (mr *MockVehicleMockRecorder) Connector() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connector", reflect.TypeOf((*MockVehicle)(nil).Connector))
-}
-
 // Features mocks base method.
 func (m *MockVehicle) Features() []Feature {
 	m.ctrl.T.Helper()

--- a/api/mock.go
+++ b/api/mock.go
@@ -361,6 +361,34 @@ func (mr *MockVehicleMockRecorder) Capacity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capacity", reflect.TypeOf((*MockVehicle)(nil).Capacity))
 }
 
+// Connector mocks base method.
+func (m *MockVehicle) Connector() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Connector")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Connector indicates an expected call of Connector.
+func (mr *MockVehicleMockRecorder) Connector() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connector", reflect.TypeOf((*MockVehicle)(nil).Connector))
+}
+
+// Features mocks base method.
+func (m *MockVehicle) Features() []Feature {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Features")
+	ret0, _ := ret[0].([]Feature)
+	return ret0
+}
+
+// Features indicates an expected call of Features.
+func (mr *MockVehicleMockRecorder) Features() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Features", reflect.TypeOf((*MockVehicle)(nil).Features))
+}
+
 // Icon mocks base method.
 func (m *MockVehicle) Icon() string {
 	m.ctrl.T.Helper()

--- a/assets/js/components/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlan.vue
@@ -133,7 +133,7 @@ export default {
 		socBasedCharging: Boolean,
 		socPerKwh: Number,
 		vehicle: Object,
-		vehicleCapacity: Number,
+		capacity: Number,
 		vehicleSoc: Number,
 		vehicleTargetSoc: Number,
 	},
@@ -208,7 +208,7 @@ export default {
 			}
 			return fmtEnergy(
 				this.planEnergy,
-				optionStep(this.vehicleCapacity || 100),
+				optionStep(this.capacity || 100),
 				this.fmtKWh,
 				this.$t("main.targetEnergy.noLimit")
 			);

--- a/assets/js/components/ChargingPlanSettings.vue
+++ b/assets/js/components/ChargingPlanSettings.vue
@@ -6,7 +6,7 @@
 					:id="`${id}_0`"
 					class="mb-2"
 					v-bind="plans[0] || {}"
-					:vehicle-capacity="vehicleCapacity"
+					:capacity="capacity"
 					:range-per-soc="rangePerSoc"
 					:soc-per-kwh="socPerKwh"
 					:soc-based-planning="socBasedPlanning"
@@ -58,7 +58,7 @@ export default {
 		smartCostType: String,
 		currency: String,
 		mode: String,
-		vehicleCapacity: Number,
+		capacity: Number,
 		vehicle: Object,
 		vehicleTargetSoc: Number,
 	},
@@ -161,7 +161,7 @@ export default {
 			this.$emit("plan-updated", {
 				time: this.defaultDate(),
 				soc: 100,
-				energy: this.vehicleCapacity || 10,
+				energy: this.capacity || 10,
 			});
 		},
 		removePlan: function (index) {

--- a/assets/js/components/ChargingPlanSettingsEntry.vue
+++ b/assets/js/components/ChargingPlanSettingsEntry.vue
@@ -147,7 +147,7 @@ export default {
 		time: String,
 		rangePerSoc: Number,
 		socPerKwh: Number,
-		vehicleCapacity: Number,
+		capacity: Number,
 		socBasedPlanning: Boolean,
 	},
 	emits: ["plan-updated", "plan-removed", "plan-preview"],
@@ -173,7 +173,7 @@ export default {
 		energyOptions: function () {
 			const options = energyOptions(
 				0,
-				this.vehicleCapacity || 100,
+				this.capacity || 100,
 				this.socPerKwh,
 				this.fmtKWh,
 				"-"
@@ -241,7 +241,7 @@ export default {
 			}
 			if (!this.selectedEnergy) {
 				this.selectedEnergy =
-					window.localStorage[LAST_ENERGY_GOAL_KEY] || this.vehicleCapacity || 10;
+					window.localStorage[LAST_ENERGY_GOAL_KEY] || this.capacity || 10;
 			}
 
 			let time = this.time;

--- a/assets/js/components/ChargingSessionModal.vue
+++ b/assets/js/components/ChargingSessionModal.vue
@@ -38,7 +38,6 @@
 											:id="session.vehicle"
 											class="options"
 											:vehicles="vehicles"
-											:is-unknown="false"
 											connected
 											@change-vehicle="changeVehicle"
 											@remove-vehicle="removeVehicle"

--- a/assets/js/components/LimitEnergySelect.vue
+++ b/assets/js/components/LimitEnergySelect.vue
@@ -47,21 +47,21 @@ export default {
 		limitEnergy: Number,
 		socPerKwh: Number,
 		chargedEnergy: Number,
-		vehicleCapacity: Number,
+		capacity: Number,
 	},
 	emits: ["limit-energy-updated"],
 	computed: {
 		options: function () {
 			return energyOptions(
 				this.chargedEnergy,
-				this.vehicleCapacity || 100,
+				this.capacity || 100,
 				this.socPerKwh,
 				this.fmtKWh,
 				this.$t("main.targetEnergy.noLimit")
 			);
 		},
 		step() {
-			return optionStep(this.vehicleCapacity || 100);
+			return optionStep(this.capacity || 100);
 		},
 		estimated: function () {
 			return estimatedSoc(this.limitEnergy, this.socPerKwh);

--- a/assets/js/components/Loadpoint.story.vue
+++ b/assets/js/components/Loadpoint.story.vue
@@ -8,8 +8,8 @@ const state = reactive({
 	chargePower: 2800,
 	chargedEnergy: 11e3,
 	chargeDuration: 95 * 60,
-	vehiclePresent: true,
 	vehicleTitle: "Mein Auto",
+	vehicleName: "meinauto",
 	enabled: true,
 	connected: true,
 	mode: "pv",
@@ -29,14 +29,14 @@ const state = reactive({
 			<Loadpoint v-bind="state" />
 		</Variant>
 		<Variant title="without soc">
-			<Loadpoint v-bind="state" vehicleTitle="" :vehiclePresent="false" />
+			<Loadpoint v-bind="state" vehicleTitle="" vehicleName="" />
 		</Variant>
 		<Variant title="idle">
 			<Loadpoint
 				v-bind="state"
 				:enabled="false"
 				:connected="false"
-				:vehiclePresent="false"
+				vehicleName=""
 				mode="off"
 				:charging="false"
 				:chargeCurrent="0"

--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -156,7 +156,6 @@ export default {
 		vehicleName: String,
 		vehicleIcon: String,
 		vehicleTargetSoc: Number,
-		vehicleCapacity: Number,
 		vehicleFeatureOffline: Boolean,
 		vehicles: Array,
 		planActive: Boolean,
@@ -247,13 +246,13 @@ export default {
 			return !!this.vehicleName;
 		},
 		vehicleHasSoc: function () {
-			return this.vehicleKnown && !this.vehicleFeatureOffline;
+			return this.vehicleKnown && !this.vehicle?.features?.includes("Offline");
 		},
 		socBasedCharging: function () {
 			return this.vehicleHasSoc || this.vehicleSoc > 0;
 		},
 		socBasedPlanning: function () {
-			return this.socBasedCharging && this.vehicleCapacity > 0;
+			return this.socBasedCharging && this.vehicle?.capacity > 0;
 		},
 	},
 	watch: {

--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -156,7 +156,6 @@ export default {
 		vehicleName: String,
 		vehicleIcon: String,
 		vehicleTargetSoc: Number,
-		vehicleFeatureOffline: Boolean,
 		vehicles: Array,
 		planActive: Boolean,
 		planProjectedStart: String,

--- a/assets/js/components/Loadpoints.story.vue
+++ b/assets/js/components/Loadpoints.story.vue
@@ -9,7 +9,7 @@ function loadpoint(opts) {
 		chargePower: 2800,
 		chargedEnergy: 11e3,
 		chargeDuration: 95 * 60,
-		vehiclePresent: true,
+		vehicleName: "tesla",
 		vehicleTitle: "Tesla Model 3",
 		enabled: true,
 		connected: true,

--- a/assets/js/components/Site.vue
+++ b/assets/js/components/Site.vue
@@ -111,7 +111,8 @@ export default {
 		},
 		loadpointsCompact: function () {
 			return this.loadpoints.map((lp) => {
-				const icon = lp.chargerIcon || lp.vehicleIcon || "car";
+				const vehicleIcon = this.vehicles?.[lp.vehicleName]?.icon;
+				const icon = lp.chargerIcon || vehicleIcon || "car";
 				const charging = lp.charging;
 				const power = lp.chargePower || 0;
 				return { icon, charging, power };

--- a/assets/js/components/Vehicle.story.vue
+++ b/assets/js/components/Vehicle.story.vue
@@ -3,14 +3,13 @@ import { reactive } from "vue";
 import Vehicle from "./Vehicle.vue";
 
 const state = reactive({
-	vehicleTitle: "Mein Auto",
+	vehicle: { title: "Mein Auto", icon: "car", capacity: 72, features: [] },
 	enabled: false,
 	connected: true,
-	vehiclePresent: true,
+	vehicleName: "meinauto",
 	vehicleSoc: 42.742,
 	vehicleRange: 231,
 	limitSoc: 90,
-	vehicleCapacity: 72,
 	chargedEnergy: 14123,
 	socBasedCharging: true,
 	id: 0,
@@ -45,9 +44,9 @@ const hoursFromNow = function (hours) {
 				v-bind="state"
 				enabled
 				charging
-				:vehiclePresent="false"
+				vehicleName=""
 				:socBasedCharging="false"
-				:vehicleCapacity="null"
+				:vehicle="{ ...state.vehicle, capacity: null }"
 				mode="pv"
 			/>
 		</Variant>
@@ -56,10 +55,13 @@ const hoursFromNow = function (hours) {
 				v-bind="state"
 				enabled
 				charging
-				vehicleTitle="Opel Corsa-e"
 				:socBasedCharging="false"
-				:vehicleCapacity="72"
-				vehicleFeatureOffline
+				:vehicle="{
+					...state.vehicle,
+					title: 'Opel Corsa-e',
+					capacity: 72,
+					features: ['Offline'],
+				}"
 				mode="pv"
 			/>
 		</Variant>
@@ -68,11 +70,14 @@ const hoursFromNow = function (hours) {
 				v-bind="state"
 				enabled
 				charging
-				vehicleTitle="Opel Corsa-e"
 				:socBasedCharging="false"
-				:vehicleCapacity="72"
+				:vehicle="{
+					...state.vehicle,
+					title: 'Opel Corsa-e',
+					capacity: 72,
+					features: ['Offline'],
+				}"
 				:targetEnergy="30"
-				vehicleFeatureOffline
 				mode="pv"
 			/>
 		</Variant>

--- a/assets/js/components/Vehicle.vue
+++ b/assets/js/components/Vehicle.vue
@@ -52,7 +52,7 @@
 				:limit-energy="limitEnergy"
 				:soc-per-kwh="socPerKwh"
 				:charged-energy="chargedEnergy"
-				:vehicle-capacity="vehicleCapacity"
+				:capacity="capacity"
 				@limit-energy-updated="limitEnergyUpdated"
 			/>
 		</div>
@@ -117,16 +117,13 @@ export default {
 		tariffCo2: Number,
 		tariffGrid: Number,
 		vehicle: Object,
-		vehicleCapacity: Number,
 		vehicleDetectionActive: Boolean,
-		vehicleIcon: String,
 		vehicleName: String,
 		vehiclePresent: Boolean,
 		vehicleRange: Number,
 		vehicles: Array,
 		vehicleSoc: Number,
 		vehicleTargetSoc: Number,
-		vehicleTitle: String,
 	},
 	emits: ["limit-soc-updated", "limit-energy-updated", "change-vehicle", "remove-vehicle"],
 	data() {
@@ -135,6 +132,15 @@ export default {
 		};
 	},
 	computed: {
+		title: function () {
+			return this.vehicle?.title || "";
+		},
+		capacity: function () {
+			return this.vehicle?.capacity || 0;
+		},
+		icon: function () {
+			return this.vehicle?.icon || "";
+		},
 		minSoc: function () {
 			return this.vehicle?.minSoc || 0;
 		},
@@ -178,8 +184,8 @@ export default {
 			return null;
 		},
 		socPerKwh: function () {
-			if (this.vehicleCapacity > 0) {
-				return 100 / this.vehicleCapacity;
+			if (this.capacity > 0) {
+				return 100 / this.capacity;
 			}
 			return null;
 		},

--- a/assets/js/components/Vehicle.vue
+++ b/assets/js/components/Vehicle.vue
@@ -119,7 +119,6 @@ export default {
 		vehicle: Object,
 		vehicleDetectionActive: Boolean,
 		vehicleName: String,
-		vehiclePresent: Boolean,
 		vehicleRange: Number,
 		vehicles: Array,
 		vehicleSoc: Number,

--- a/assets/js/components/VehicleOptions.vue
+++ b/assets/js/components/VehicleOptions.vue
@@ -19,7 +19,7 @@
 					{{ vehicle.title }}
 				</button>
 			</li>
-			<li v-if="!isUnknown">
+			<li>
 				<button type="button" class="dropdown-item" @click="removeVehicle()">
 					<span v-if="connected">{{ $t("main.vehicle.unknown") }}</span>
 					<span v-else>{{ $t("main.vehicle.none") }}</span>
@@ -39,7 +39,6 @@ export default {
 		connected: Boolean,
 		id: [String, Number],
 		vehicles: Array,
-		isUnknown: Boolean,
 	},
 	emits: ["change-vehicle", "remove-vehicle"],
 	computed: {

--- a/assets/js/components/VehicleSoc.vue
+++ b/assets/js/components/VehicleSoc.vue
@@ -81,7 +81,6 @@ export default {
 	name: "VehicleSoc",
 	props: {
 		connected: Boolean,
-		vehiclePresent: Boolean,
 		vehicleSoc: Number,
 		vehicleTargetSoc: Number,
 		enabled: Boolean,

--- a/assets/js/components/VehicleTitle.vue
+++ b/assets/js/components/VehicleTitle.vue
@@ -2,15 +2,15 @@
 	<div class="d-flex justify-content-between mb-3 align-items-center" data-testid="vehicle-title">
 		<h4 class="d-flex align-items-center m-0 flex-grow-1 overflow-hidden">
 			<shopicon-regular-refresh
-				v-if="icon === 'refresh'"
+				v-if="iconType === 'refresh'"
 				ref="refresh"
 				data-bs-toggle="tooltip"
 				:title="$t('main.vehicle.detectionActive')"
 				class="me-2 flex-shrink-0 spin"
 			></shopicon-regular-refresh>
 			<VehicleIcon
-				v-else-if="icon === 'vehicle'"
-				:name="vehicleIcon"
+				v-else-if="iconType === 'vehicle'"
+				:name="icon"
 				class="me-2 flex-shrink-0"
 			/>
 			<shopicon-regular-cablecharge
@@ -23,7 +23,6 @@
 				:id="id"
 				class="options"
 				:vehicles="otherVehicles"
-				:is-unknown="isUnknown"
 				@change-vehicle="changeVehicle"
 				@remove-vehicle="removeVehicle"
 			>
@@ -54,14 +53,14 @@ export default {
 		connected: Boolean,
 		id: [String, Number],
 		vehicleDetectionActive: Boolean,
-		vehicleIcon: String,
+		icon: String,
 		vehicleName: String,
 		vehicles: { type: Array, default: () => [] },
-		vehicleTitle: String,
+		title: String,
 	},
 	emits: ["change-vehicle", "remove-vehicle"],
 	computed: {
-		icon() {
+		iconType() {
 			if (this.vehicleDetectionActive) {
 				return "refresh";
 			}
@@ -71,8 +70,8 @@ export default {
 			return null;
 		},
 		name() {
-			if (this.vehicleTitle) {
-				return this.vehicleTitle;
+			if (this.title) {
+				return this.title;
 			}
 			if (this.connected) {
 				return this.$t("main.vehicle.unknown");
@@ -93,7 +92,7 @@ export default {
 		},
 	},
 	watch: {
-		icon: function () {
+		iconType: function () {
 			this.tooltip();
 		},
 	},

--- a/charger/embed.go
+++ b/charger/embed.go
@@ -5,9 +5,8 @@ import (
 )
 
 type embed struct {
-	Icon_      string        `mapstructure:"icon"`
-	Connector_ string        `mapstructure:"connector"`
-	Features_  []api.Feature `mapstructure:"features"`
+	Icon_     string        `mapstructure:"icon"`
+	Features_ []api.Feature `mapstructure:"features"`
 }
 
 var _ api.IconDescriber = (*embed)(nil)
@@ -15,13 +14,6 @@ var _ api.IconDescriber = (*embed)(nil)
 // Icon implements the api.IconDescriber interface
 func (v *embed) Icon() string {
 	return v.Icon_
-}
-
-var _ api.ConnectorDescriber = (*embed)(nil)
-
-// Connector implements the api.ConnectorDescriber interface
-func (v *embed) Connector() string {
-	return v.Connector_
 }
 
 var _ api.FeatureDescriber = (*embed)(nil)

--- a/charger/embed.go
+++ b/charger/embed.go
@@ -5,8 +5,9 @@ import (
 )
 
 type embed struct {
-	Icon_     string        `mapstructure:"icon"`
-	Features_ []api.Feature `mapstructure:"features"`
+	Icon_      string        `mapstructure:"icon"`
+	Connector_ string        `mapstructure:"connector"`
+	Features_  []api.Feature `mapstructure:"features"`
 }
 
 var _ api.IconDescriber = (*embed)(nil)
@@ -14,6 +15,13 @@ var _ api.IconDescriber = (*embed)(nil)
 // Icon implements the api.IconDescriber interface
 func (v *embed) Icon() string {
 	return v.Icon_
+}
+
+var _ api.ConnectorDescriber = (*embed)(nil)
+
+// Connector implements the api.ConnectorDescriber interface
+func (v *embed) Connector() string {
+	return v.Connector_
 }
 
 var _ api.FeatureDescriber = (*embed)(nil)

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -60,12 +60,9 @@ const (
 	RemoteDisabledSource = "remoteDisabledSource" // remote disabled source
 
 	// vehicle
-	VehicleTitle           = "vehicleTitle"           // vehicle title
 	VehicleName            = "vehicleName"            // vehicle name
 	VehicleIdentity        = "vehicleIdentity"        // vehicle identity
-	VehicleCapacity        = "vehicleCapacity"        // vehicle battery capacity
 	VehicleDetectionActive = "vehicleDetectionActive" // vehicle detection active
-	VehicleIcon            = "vehicleIcon"            // vehicle icon for ui
 	VehicleOdometer        = "vehicleOdometer"        // vehicle odometer
 	VehicleRange           = "vehicleRange"           // vehicle range
 	VehicleSoc             = "vehicleSoc"             // vehicle soc

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -66,6 +66,6 @@ const (
 	VehicleOdometer        = "vehicleOdometer"        // vehicle odometer
 	VehicleRange           = "vehicleRange"           // vehicle range
 	VehicleSoc             = "vehicleSoc"             // vehicle soc
-	VehicleTargetSoc       = "vehicleTargetSoc"       // vehicle soc limit
+	VehicleTargetSoc       = "vehicleTargetSoc"       // vehicle api soc limit
 	VehicleClimaterActive  = "vehicleClimaterActive"  // vehicle climater active
 )

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -591,9 +591,7 @@ func (lp *Loadpoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 	}
 
 	// vehicle
-	lp.publish(keys.VehicleIcon, "")
 	lp.publish(keys.VehicleName, "")
-	lp.publish(keys.VehicleCapacity, 0.0)
 	lp.publish(keys.VehicleOdometer, 0.0)
 
 	// assign and publish default vehicle

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -386,10 +386,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	vehicle := api.NewMockVehicle(ctrl)
 
 	// wrap vehicle with estimator
-	vehicle.EXPECT().Capacity().Return(float64(10)).AnyTimes()
-	vehicle.EXPECT().Phases().Return(0).AnyTimes()
-	vehicle.EXPECT().Title().Return("foo").AnyTimes() // TODO remove when settings always available for vehicle
-	vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
+	expectVehiclePublish(vehicle)
 
 	socEstimator := soc.NewEstimator(util.NewLogger("foo"), charger, vehicle, false)
 

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -132,8 +132,6 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 		lp.socEstimator = soc.NewEstimator(lp.log, lp.charger, v, estimate)
 
 		lp.publish(keys.VehicleName, vehicle.Settings(lp.log, v).Name())
-		lp.publish(keys.VehicleIcon, v.Icon())
-		lp.publish(keys.VehicleCapacity, v.Capacity())
 
 		if mode, ok := v.OnIdentified().GetMode(); ok {
 			lp.SetMode(mode)
@@ -146,8 +144,6 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 		lp.socEstimator = nil
 		lp.publish(keys.VehicleSoc, 0)
 		lp.publish(keys.VehicleName, "")
-		lp.publish(keys.VehicleIcon, "")
-		lp.publish(keys.VehicleCapacity, 0.0)
 		lp.publish(keys.VehicleOdometer, 0.0)
 	}
 
@@ -197,8 +193,6 @@ func (lp *Loadpoint) unpublishVehicle() {
 
 	lp.setRemainingEnergy(0)
 	lp.setRemainingDuration(0)
-
-	lp.publishVehicleFeature(api.Offline)
 }
 
 // vehicleHasFeature checks availability of vehicle feature
@@ -208,11 +202,6 @@ func (lp *Loadpoint) vehicleHasFeature(f api.Feature) bool {
 		ok = slices.Contains(v.Features(), f)
 	}
 	return ok
-}
-
-// publishVehicleFeature availability of vehicle features
-func (lp *Loadpoint) publishVehicleFeature(f api.Feature) {
-	lp.publish("vehicleFeature"+f.String(), lp.vehicleHasFeature(f))
 }
 
 // vehicleUnidentified returns true if there are associated vehicles and detection is running.

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -15,6 +15,15 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func expectVehiclePublish(vehicle *api.MockVehicle) {
+	vehicle.EXPECT().Title().Return("target").AnyTimes()
+	vehicle.EXPECT().Capacity().AnyTimes()
+	vehicle.EXPECT().Icon().AnyTimes()
+	vehicle.EXPECT().Features().AnyTimes()
+	vehicle.EXPECT().Phases().AnyTimes()
+	vehicle.EXPECT().OnIdentified().AnyTimes()
+}
+
 func TestPublishSocAndRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	clck := clock.NewMock()
@@ -24,10 +33,7 @@ func TestPublishSocAndRange(t *testing.T) {
 	charger.EXPECT().Enabled().Return(true, nil).AnyTimes()
 
 	vehicle := api.NewMockVehicle(ctrl)
-	vehicle.EXPECT().Title().Return("target").AnyTimes()
-	vehicle.EXPECT().Capacity().AnyTimes()
-	vehicle.EXPECT().Phases().AnyTimes()
-	vehicle.EXPECT().OnIdentified().AnyTimes()
+	expectVehiclePublish(vehicle)
 
 	log := util.NewLogger("foo")
 	lp := &Loadpoint{
@@ -227,12 +233,9 @@ func TestReconnectVehicle(t *testing.T) {
 				*api.MockChargeState
 			}
 
-			vehicle := &vehicleT{api.NewMockVehicle(ctrl), api.NewMockChargeState(ctrl)}
-			vehicle.MockVehicle.EXPECT().Title().Return("vehicle").AnyTimes()
-			vehicle.MockVehicle.EXPECT().Icon().Return("").AnyTimes()
-			vehicle.MockVehicle.EXPECT().Capacity().AnyTimes()
-			vehicle.MockVehicle.EXPECT().Phases().AnyTimes()
-			vehicle.MockVehicle.EXPECT().OnIdentified().AnyTimes()
+			v := api.NewMockVehicle(ctrl)
+			vehicle := &vehicleT{v, api.NewMockChargeState(ctrl)}
+			expectVehiclePublish(v)
 			vehicle.MockVehicle.EXPECT().Identifiers().AnyTimes().Return(tc.vehicleId)
 			vehicle.MockVehicle.EXPECT().Soc().Return(0.0, nil).AnyTimes()
 

--- a/core/site_vehicles.go
+++ b/core/site_vehicles.go
@@ -18,14 +18,13 @@ type planStruct struct {
 }
 
 type vehicleStruct struct {
-	Title     string       `json:"title"`
-	Icon      string       `json:"icon,omitempty"`
-	Capacity  float64      `json:"capacity,omitempty"`
-	MinSoc    int          `json:"minSoc,omitempty"`
-	LimitSoc  int          `json:"limitSoc,omitempty"`
-	Connector string       `json:"connector,omitempty"`
-	Features  []string     `json:"features,omitempty"`
-	Plans     []planStruct `json:"plans,omitempty"`
+	Title    string       `json:"title"`
+	Icon     string       `json:"icon,omitempty"`
+	Capacity float64      `json:"capacity,omitempty"`
+	MinSoc   int          `json:"minSoc,omitempty"`
+	LimitSoc int          `json:"limitSoc,omitempty"`
+	Features []string     `json:"features,omitempty"`
+	Plans    []planStruct `json:"plans,omitempty"`
 }
 
 // publishVehicles returns a list of vehicle titles
@@ -47,14 +46,13 @@ func (site *Site) publishVehicles() {
 		})
 
 		res[v.Name()] = vehicleStruct{
-			Title:     instance.Title(),
-			Connector: instance.Connector(),
-			Icon:      instance.Icon(),
-			Capacity:  instance.Capacity(),
-			MinSoc:    v.GetMinSoc(),
-			LimitSoc:  v.GetLimitSoc(),
-			Features:  features,
-			Plans:     plans,
+			Title:    instance.Title(),
+			Icon:     instance.Icon(),
+			Capacity: instance.Capacity(),
+			MinSoc:   v.GetMinSoc(),
+			LimitSoc: v.GetLimitSoc(),
+			Features: features,
+			Plans:    plans,
 		}
 
 		if lp := site.coordinator.Owner(instance); lp != nil {

--- a/core/site_vehicles.go
+++ b/core/site_vehicles.go
@@ -41,9 +41,6 @@ func (site *Site) publishVehicles() {
 		}
 
 		instance := v.Instance()
-		features := lo.Map(instance.Features(), func(f api.Feature, _ int) string {
-			return f.String()
-		})
 
 		res[v.Name()] = vehicleStruct{
 			Title:    instance.Title(),
@@ -51,7 +48,7 @@ func (site *Site) publishVehicles() {
 			Capacity: instance.Capacity(),
 			MinSoc:   v.GetMinSoc(),
 			LimitSoc: v.GetLimitSoc(),
-			Features: features,
+			Features: lo.Map(instance.Features(), func(f api.Feature, _ int) string { return f.String() }),
 			Plans:    plans,
 		}
 

--- a/push/hub.go
+++ b/push/hub.go
@@ -79,7 +79,10 @@ func (h *Hub) apply(ev Event, tmpl string) (string, error) {
 	// add missing attributes
 	if name, ok := attr["vehicleName"].(string); ok {
 		if v, err := h.vehicles.ByName(name); err == nil {
-			attr["vehicleTitle"] = v.Instance().Title()
+			instance := v.Instance()
+			attr["vehicleTitle"] = instance.Title()
+			attr["vehicleIcon"] = instance.Icon()
+			attr["vehicleCapacity"] = instance.Capacity()
 		}
 	}
 

--- a/vehicle/embed.go
+++ b/vehicle/embed.go
@@ -5,10 +5,10 @@ import (
 )
 
 // TODO align phases with OnIdentify
-// TODO remove vehicle settings
 type embed struct {
 	Title_       string           `mapstructure:"title"`
 	Icon_        string           `mapstructure:"icon"`
+	Connector_   string           `mapstructure:"connector"`
 	Capacity_    float64          `mapstructure:"capacity"`
 	Phases_      int              `mapstructure:"phases"`
 	Identifiers_ []string         `mapstructure:"identifiers"`
@@ -61,6 +61,13 @@ var _ api.IconDescriber = (*embed)(nil)
 // Icon implements the api.IconDescriber interface
 func (v *embed) Icon() string {
 	return v.Icon_
+}
+
+var _ api.ConnectorDescriber = (*embed)(nil)
+
+// Connector implements the api.ConnectorDescriber interface
+func (v *embed) Connector() string {
+	return v.Connector_
 }
 
 var _ api.FeatureDescriber = (*embed)(nil)

--- a/vehicle/embed.go
+++ b/vehicle/embed.go
@@ -8,7 +8,6 @@ import (
 type embed struct {
 	Title_       string           `mapstructure:"title"`
 	Icon_        string           `mapstructure:"icon"`
-	Connector_   string           `mapstructure:"connector"`
 	Capacity_    float64          `mapstructure:"capacity"`
 	Phases_      int              `mapstructure:"phases"`
 	Identifiers_ []string         `mapstructure:"identifiers"`
@@ -61,13 +60,6 @@ var _ api.IconDescriber = (*embed)(nil)
 // Icon implements the api.IconDescriber interface
 func (v *embed) Icon() string {
 	return v.Icon_
-}
-
-var _ api.ConnectorDescriber = (*embed)(nil)
-
-// Connector implements the api.ConnectorDescriber interface
-func (v *embed) Connector() string {
-	return v.Connector_
 }
 
 var _ api.FeatureDescriber = (*embed)(nil)

--- a/vehicle/wrapper/wrapper.go
+++ b/vehicle/wrapper/wrapper.go
@@ -13,7 +13,6 @@ type Wrapper struct {
 	err       error
 	title     string
 	icon      string
-	connector string
 	phases    int
 	capacity  float64
 	Features_ []api.Feature
@@ -23,12 +22,11 @@ type Wrapper struct {
 func New(name string, other map[string]interface{}, err error) api.Vehicle {
 	var cc struct {
 		// add manuelly since embed is not available here
-		Title     string
-		Icon      string
-		Connector string
-		Phases    int
-		Capacity  float64
-		Other     map[string]interface{} `mapstructure:",remain"`
+		Title    string
+		Icon     string
+		Phases   int
+		Capacity float64
+		Other    map[string]interface{} `mapstructure:",remain"`
 	}
 
 	// try to decode vehicle-specific config and look for title attribute
@@ -43,7 +41,6 @@ func New(name string, other map[string]interface{}, err error) api.Vehicle {
 		err:       fmt.Errorf("vehicle not available: %w", err),
 		title:     fmt.Sprintf("%s (offline)", cc.Title),
 		icon:      cc.Icon,
-		connector: cc.Connector,
 		phases:    cc.Phases,
 		capacity:  cc.Capacity,
 		Features_: []api.Feature{api.Offline},
@@ -72,11 +69,6 @@ func (v *Wrapper) SetTitle(title string) {
 // Icon implements the api.IconDescriber interface
 func (v *Wrapper) Icon() string {
 	return v.icon
-}
-
-// Connector implements the api.ConnectorDescriber interface
-func (v *Wrapper) Connector() string {
-	return v.connector
 }
 
 // Capacity implements the api.Vehicle interface

--- a/vehicle/wrapper/wrapper.go
+++ b/vehicle/wrapper/wrapper.go
@@ -13,6 +13,7 @@ type Wrapper struct {
 	err       error
 	title     string
 	icon      string
+	connector string
 	phases    int
 	capacity  float64
 	Features_ []api.Feature
@@ -21,11 +22,13 @@ type Wrapper struct {
 // New creates a new Vehicle
 func New(name string, other map[string]interface{}, err error) api.Vehicle {
 	var cc struct {
-		Title    string
-		Icon     string
-		Phases   int
-		Capacity float64
-		Other    map[string]interface{} `mapstructure:",remain"`
+		// add manuelly since embed is not available here
+		Title     string
+		Icon      string
+		Connector string
+		Phases    int
+		Capacity  float64
+		Other     map[string]interface{} `mapstructure:",remain"`
 	}
 
 	// try to decode vehicle-specific config and look for title attribute
@@ -40,6 +43,7 @@ func New(name string, other map[string]interface{}, err error) api.Vehicle {
 		err:       fmt.Errorf("vehicle not available: %w", err),
 		title:     fmt.Sprintf("%s (offline)", cc.Title),
 		icon:      cc.Icon,
+		connector: cc.Connector,
 		phases:    cc.Phases,
 		capacity:  cc.Capacity,
 		Features_: []api.Feature{api.Offline},
@@ -68,6 +72,11 @@ func (v *Wrapper) SetTitle(title string) {
 // Icon implements the api.IconDescriber interface
 func (v *Wrapper) Icon() string {
 	return v.icon
+}
+
+// Connector implements the api.ConnectorDescriber interface
+func (v *Wrapper) Connector() string {
+	return v.connector
 }
 
 // Capacity implements the api.Vehicle interface

--- a/vehicle/wrapper/wrapper.go
+++ b/vehicle/wrapper/wrapper.go
@@ -21,7 +21,7 @@ type Wrapper struct {
 // New creates a new Vehicle
 func New(name string, other map[string]interface{}, err error) api.Vehicle {
 	var cc struct {
-		// add manuelly since embed is not available here
+		// add manually since embed is not available here
 		Title    string
 		Icon     string
 		Phases   int


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/11023

This PR moves all vehicle settings output from `loadpoint` to `vehicles`. This affects `icon`, `capacity` and `features`.

TODO

- [x] revert connector @andig
- [x] add fake vehicle attributes for push (similar to https://github.com/evcc-io/evcc/issues/11705)
- [x] refactor ui @naltatis 

Out of scope:

- [ ] decide `connector` or `group` or drop this feature altogether
- [ ] implement connector/group if desired
- [ ] move vehicle state from `loadpoint` to `vehicles`