### PR TITLE
Update evcc.dist.yaml: Remove OnIdentify, der nicht mehr ausgewertet wird.

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -93,8 +93,7 @@ vehicles:
     user: myuser # user
     password: mypassword # password
     vin: WREN...
-    onIdentify: # set defaults when vehicle is identified
-      mode: pv # enable PV-charging when vehicle is identified
+    mode: pv # enable PV-charging when vehicle is identified
 
 # site describes the EVU connection, PV and home battery
 site:


### PR DESCRIPTION
OnIdentify führt seit Release 0.123 dazu dass das vehicle nicht mehr erstellt wird.

`Dec 26 10:44:26 raspi evcc[3183535]: [main  ] ERROR 2023/12/26 10:44:26 creating vehicle IQ5 failed: cannot create vehicle 'template': invalid key: onidentify`
