### PR TITLE
Battery control not experimental

### DIFF
--- a/assets/js/components/BatterySettingsModal.vue
+++ b/assets/js/components/BatterySettingsModal.vue
@@ -224,33 +224,27 @@
 								</p>
 							</div>
 						</div>
-						<div v-if="$hiddenFeatures()">
-							<FormRow
-								v-if="controllable"
-								id="batteryDischargeControl"
-								:label="`${$t('batterySettings.control')}`"
-							>
-								<div class="form-check form-switch col-form-label">
-									<input
-										id="batteryDischargeControl"
-										:checked="batteryDischargeControl"
-										class="form-check-input"
-										type="checkbox"
-										role="switch"
-										@change="changeDischargeControl"
-									/>
-									<div class="form-check-label">
-										<label for="batteryDischargeControl">
-											{{ $t("batterySettings.discharge") }}
-											<span title="experimental">🧪</span>
-										</label>
-									</div>
+						<FormRow
+							v-if="controllable"
+							id="batteryDischargeControl"
+							:label="`${$t('batterySettings.control')}`"
+						>
+							<div class="form-check form-switch col-form-label">
+								<input
+									id="batteryDischargeControl"
+									:checked="batteryDischargeControl"
+									class="form-check-input"
+									type="checkbox"
+									role="switch"
+									@change="changeDischargeControl"
+								/>
+								<div class="form-check-label">
+									<label for="batteryDischargeControl">
+										{{ $t("batterySettings.discharge") }}
+									</label>
 								</div>
-							</FormRow>
-							<p v-else>
-								<small>{{ $t("batterySettings.notControllable") }}</small>
-							</p>
-						</div>
+							</div>
+						</FormRow>
 					</div>
 				</div>
 			</div>

--- a/i18n/da.toml
+++ b/i18n/da.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "starter automatisk"
 legendTopName = "batteri understøttet opladning"
 legendTopSubline = "uden afbrydelser"
 modalTitle = "batteri indstillinger"
-notControllable = "Indstilling af batteriet er ikke mulig for dette batteri"
 
 [batterySettings.bufferStart]
 full = "næsten fyldt"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "startet automatisch"
 legendTopName = "Batterieunterstütztes Laden"
 legendTopSubline = "ohne Unterbrechungen"
 modalTitle = "Batterieeinstellungen"
-notControllable = "Batteriesteuerung ist für diesen Speicher nicht verfügbar."
 
 [batterySettings.bufferStart]
 full = "wenn fast voll"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "starts automatically"
 legendTopName = "battery supported charging"
 legendTopSubline = "without interruptions"
 modalTitle = "Battery settings"
-notControllable = "Battery control is not available for this battery."
 
 [batterySettings.bufferStart]
 full = "when nearly full"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "inicio automático"
 legendTopName = "carga soportada por bateria"
 legendTopSubline = "sin interrupciones"
 modalTitle = "Configuración de batería"
-notControllable = "El control de la batería no está disponible para esta batería"
 
 [batterySettings.bufferStart]
 full = "cuando está casi llena"

--- a/i18n/lt.toml
+++ b/i18n/lt.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "startuoja automatiškai"
 legendTopName = "kaupiklis padeda įkrauti"
 legendTopSubline = "be pertraukų"
 modalTitle = "Kaupiklio nustatymai"
-notControllable = "Šiam kaupikliui valdymo nėra."
 
 [batterySettings.bufferStart]
 full = "kai beveik pilnas"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "inicio automatico"
 legendTopName = "carregamento suportado por bateria"
 legendTopSubline = "sem interrupções"
 modalTitle = "Configuraçao da bateria"
-notControllable = "O controle de bateria não está disponível para esta bateria."
 
 [batterySettings.bufferStart]
 full = "quando quase cheio"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "запускается автоматически"
 legendTopName = "зарядка с поддержкой от аккумулятора"
 legendTopSubline = "без перебоев"
 modalTitle = "Настройки батареи"
-notControllable = "Управление батарей недоступно для этой батареи"
 
 [batterySettings.bufferStart]
 full = "когда почти полная"

--- a/i18n/sl.toml
+++ b/i18n/sl.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "samodejno se zažene"
 legendTopName = "polnjenje, ki ga podpira baterija"
 legendTopSubline = "brez prekinitev"
 modalTitle = "Nastavitve baterije"
-notControllable = "Nadzor baterije ni na voljo za to baterijo."
 
 [batterySettings.bufferStart]
 full = "ko je skoraj poln"

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -14,7 +14,6 @@ legendTopAutostart = "startar automatiskt"
 legendTopName = "laddning med batteristöd"
 legendTopSubline = "utan avbrott"
 modalTitle = "Batteriinställningar"
-notControllable = "Inställning ej möjligt för detta batteri"
 
 [batterySettings.bufferStart]
 full = "när det är nästan fullt"


### PR DESCRIPTION
- 🧪 removed battery control experimental flag
-  🗒️ removed confusing "battery control not supported" message (fixes https://github.com/evcc-io/evcc/issues/11306)