### PR TITLE
chore: return config error on invalid yaml template keys

### DIFF
--- a/util/decoder.go
+++ b/util/decoder.go
@@ -43,6 +43,10 @@ type ConfigError struct {
 	err error
 }
 
+func NewConfigError(err error) error {
+	return &ConfigError{err}
+}
+
 func (e *ConfigError) Error() string {
 	return e.err.Error()
 }

--- a/util/templates/render_instance.go
+++ b/util/templates/render_instance.go
@@ -32,7 +32,7 @@ func RenderInstance(class Class, other map[string]interface{}) (*Instance, error
 
 	b, _, err := tmpl.RenderResult(TemplateRenderModeInstance, other)
 	if err != nil {
-		return nil, err
+		return nil, util.NewConfigError(err)
 	}
 
 	var instance Instance


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/11386