### PR TITLE
Fix smart cost type not published

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,7 +147,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	go socketHub.Run(pipe.NewDropper(ignoreEmpty).Pipe(tee.Attach()), cache)
 
 	// setup values channel
-	valueChan := make(chan util.Param, 1)
+	valueChan := make(chan util.Param, 16)
 	go tee.Run(valueChan)
 
 	// capture log messages for UI

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,7 +147,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	go socketHub.Run(pipe.NewDropper(ignoreEmpty).Pipe(tee.Attach()), cache)
 
 	// setup values channel
-	valueChan := make(chan util.Param, 16)
+	valueChan := make(chan util.Param, 64)
 	go tee.Run(valueChan)
 
 	// capture log messages for UI

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -592,52 +592,37 @@ func configureMessengers(conf messagingConfig, valueChan chan util.Param, cache 
 	return messageChan, nil
 }
 
-func configureTariffs(conf tariffConfig) (tariff.Tariffs, error) {
-	var grid, feedin, co2, planner api.Tariff
-	var currencyCode currency.Unit = currency.EUR
-	var err error
+func configureTariff(name string, conf config.Typed, t *api.Tariff, wg *sync.WaitGroup) {
+	defer wg.Done()
 
+	res, err := tariff.NewFromConfig(conf.Type, conf.Other)
+	if err != nil {
+		log.ERROR.Printf("failed configuring %s tariff: %v", name, err)
+		return
+	}
+
+	*t = res
+}
+
+func configureTariffs(conf tariffConfig) (*tariff.Tariffs, error) {
+	var grid, feedin, co2, planner api.Tariff
+
+	currencyCode := currency.EUR
 	if conf.Currency != "" {
 		currencyCode = currency.MustParseISO(conf.Currency)
 	}
 
-	if conf.Grid.Type != "" {
-		grid, err = tariff.NewFromConfig(conf.Grid.Type, conf.Grid.Other)
-		if err != nil {
-			grid = nil
-			log.ERROR.Printf("failed configuring grid tariff: %v", err)
-		}
-	}
+	var wg sync.WaitGroup
+	wg.Add(4)
 
-	if conf.FeedIn.Type != "" {
-		feedin, err = tariff.NewFromConfig(conf.FeedIn.Type, conf.FeedIn.Other)
-		if err != nil {
-			feedin = nil
-			log.ERROR.Printf("failed configuring feed-in tariff: %v", err)
-		}
-	}
+	go configureTariff("grid", conf.Grid, &grid, &wg)
+	go configureTariff("feedin", conf.FeedIn, &feedin, &wg)
+	go configureTariff("co2", conf.Co2, &co2, &wg)
+	go configureTariff("planner", conf.Planner, &planner, &wg)
 
-	if conf.Co2.Type != "" {
-		co2, err = tariff.NewFromConfig(conf.Co2.Type, conf.Co2.Other)
-		if err != nil {
-			co2 = nil
-			log.ERROR.Printf("failed configuring co2 tariff: %v", err)
-		}
-	}
+	wg.Wait()
 
-	if conf.Planner.Type != "" {
-		planner, err = tariff.NewFromConfig(conf.Planner.Type, conf.Planner.Other)
-		if err != nil {
-			planner = nil
-			log.ERROR.Printf("failed configuring planner tariff: %v", err)
-		} else if planner.Type() == api.TariffTypeCo2 {
-			log.WARN.Printf("tariff configuration changed, use co2 instead of planner for co2 tariff")
-		}
-	}
-
-	tariffs := tariff.NewTariffs(currencyCode, grid, feedin, co2, planner)
-
-	return *tariffs, nil
+	return tariff.NewTariffs(currencyCode, grid, feedin, co2, planner), nil
 }
 
 func configureDevices(conf globalConfig) error {
@@ -668,7 +653,7 @@ func configureSiteAndLoadpoints(conf globalConfig) (*core.Site, error) {
 	return configureSite(conf.Site, loadpoints, tariffs)
 }
 
-func configureSite(conf map[string]interface{}, loadpoints []*core.Loadpoint, tariffs tariff.Tariffs) (*core.Site, error) {
+func configureSite(conf map[string]interface{}, loadpoints []*core.Loadpoint, tariffs *tariff.Tariffs) (*core.Site, error) {
 	site, err := core.NewSiteFromConfig(log, conf, loadpoints, tariffs)
 	if err != nil {
 		return nil, fmt.Errorf("failed configuring site: %w", err)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -609,24 +609,25 @@ func configureTariff(name string, conf config.Typed, t *api.Tariff, wg *sync.Wai
 }
 
 func configureTariffs(conf tariffConfig) (*tariff.Tariffs, error) {
-	var grid, feedin, co2, planner api.Tariff
+	tariffs := tariff.Tariffs{
+		Currency: currency.EUR,
+	}
 
-	currencyCode := currency.EUR
 	if conf.Currency != "" {
-		currencyCode = currency.MustParseISO(conf.Currency)
+		tariffs.Currency = currency.MustParseISO(conf.Currency)
 	}
 
 	var wg sync.WaitGroup
 	wg.Add(4)
 
-	go configureTariff("grid", conf.Grid, &grid, &wg)
-	go configureTariff("feedin", conf.FeedIn, &feedin, &wg)
-	go configureTariff("co2", conf.Co2, &co2, &wg)
-	go configureTariff("planner", conf.Planner, &planner, &wg)
+	go configureTariff("grid", conf.Grid, &tariffs.Grid, &wg)
+	go configureTariff("feedin", conf.FeedIn, &tariffs.FeedIn, &wg)
+	go configureTariff("co2", conf.Co2, &tariffs.Co2, &wg)
+	go configureTariff("planner", conf.Planner, &tariffs.Planner, &wg)
 
 	wg.Wait()
 
-	return tariff.NewTariffs(currencyCode, grid, feedin, co2, planner), nil
+	return &tariffs, nil
 }
 
 func configureDevices(conf globalConfig) error {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -595,6 +595,10 @@ func configureMessengers(conf messagingConfig, valueChan chan util.Param, cache 
 func configureTariff(name string, conf config.Typed, t *api.Tariff, wg *sync.WaitGroup) {
 	defer wg.Done()
 
+	if conf.Type == "" {
+		return
+	}
+
 	res, err := tariff.NewFromConfig(conf.Type, conf.Other)
 	if err != nil {
 		log.ERROR.Printf("failed configuring %s tariff: %v", name, err)

--- a/core/site.go
+++ b/core/site.go
@@ -822,20 +822,16 @@ func (site *Site) prepare() {
 	site.publish(keys.GridConfigured, site.gridMeter != nil)
 	site.publish(keys.PvConfigured, len(site.pvMeters) > 0)
 	site.publish(keys.BatteryConfigured, len(site.batteryMeters) > 0)
-	site.publish(keys.BufferSoc, site.bufferSoc)
-	site.publish(keys.BufferStartSoc, site.bufferStartSoc)
-	site.publish(keys.PrioritySoc, site.prioritySoc)
+	site.publish(keys.BatteryMode, site.batteryMode)
 	site.publish(keys.ResidualPower, site.ResidualPower)
-	site.publish(keys.SmartCostLimit, site.smartCostLimit)
-	site.publish(keys.SmartCostType, nil)
+
+	site.publish(keys.Currency, site.tariffs.Currency)
 	site.publish(keys.SmartCostActive, false)
 	if tariff := site.GetTariff(PlannerTariff); tariff != nil {
 		site.publish(keys.SmartCostType, tariff.Type())
+	} else {
+		site.publish(keys.SmartCostType, nil)
 	}
-	site.publish(keys.Currency, site.tariffs.Currency)
-
-	site.publish(keys.BatteryDischargeControl, site.batteryDischargeControl)
-	site.publish(keys.BatteryMode, site.batteryMode)
 
 	if err := site.restoreSettings(); err != nil {
 		site.log.ERROR.Println(err)

--- a/core/site.go
+++ b/core/site.go
@@ -82,8 +82,8 @@ type Site struct {
 	bufferStartSoc          float64 // start charging on battery above this Soc
 	batteryDischargeControl bool    // prevent battery discharge for fast and planned charging
 
-	tariffs     tariff.Tariffs           // Tariff
 	loadpoints  []*Loadpoint             // Loadpoints
+	tariffs     *tariff.Tariffs          // Tariffs
 	coordinator *coordinator.Coordinator // Vehicles
 	prioritizer *prioritizer.Prioritizer // Power budgets
 	stats       *Stats                   // Stats
@@ -111,7 +111,7 @@ func NewSiteFromConfig(
 	log *util.Logger,
 	other map[string]interface{},
 	loadpoints []*Loadpoint,
-	tariffs tariff.Tariffs,
+	tariffs *tariff.Tariffs,
 ) (*Site, error) {
 	site := NewSite()
 	if err := util.DecodeOther(other, site); err != nil {

--- a/tariff/tariffs.go
+++ b/tariff/tariffs.go
@@ -12,16 +12,6 @@ type Tariffs struct {
 	Grid, FeedIn, Co2, Planner api.Tariff
 }
 
-func NewTariffs(currency currency.Unit, grid, feedin, co2 api.Tariff, planner api.Tariff) *Tariffs {
-	return &Tariffs{
-		Currency: currency,
-		Grid:     grid,
-		FeedIn:   feedin,
-		Co2:      co2,
-		Planner:  planner,
-	}
-}
-
 func currentPrice(t api.Tariff) (float64, error) {
 	if t != nil {
 		if rr, err := t.Rates(); err == nil {


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/11330

Root cause is indeterministic order of async publishing due to https://github.com/evcc-io/evcc/issues/11330#issuecomment-1873777695. This PR fixes that by publishing each value only once on startup and increasing the size of the send queue.

In addition, ui-based values are only published when their config has been read which reduces the number of startup messages and tariff setup is parallelised similar to vehicles.

A longer-time solution would be adding all messages sent to an unbounded global send queue.

/cc @StefanSchoof 