### PR TITLE
Plugins: allow setters to return nil

### DIFF
--- a/provider/go.go
+++ b/provider/go.go
@@ -167,6 +167,10 @@ func (p *Go) evaluate() (res any, err error) {
 		return nil, err
 	}
 
+	if v.IsNil() {
+		return nil, nil
+	}
+
 	return normalizeValue(v.Interface())
 }
 

--- a/provider/javascript.go
+++ b/provider/javascript.go
@@ -145,6 +145,10 @@ func (p *Javascript) evaluate() (any, error) {
 		return nil, err
 	}
 
+	if vv == nil {
+		return nil, nil
+	}
+
 	return normalizeValue(vv)
 }
 

--- a/provider/transformation.go
+++ b/provider/transformation.go
@@ -145,6 +145,10 @@ func transformInputs(in []inputTransformation, set func(string, any) error) erro
 
 func transformOutputs(out []outputTransformation, v any) error {
 	for _, cc := range out {
+		if v == nil {
+			return fmt.Errorf("no value to transform")
+		}
+
 		if err := cc.function(v); err != nil {
 			return fmt.Errorf("%s: %w", cc.name, err)
 		}


### PR DESCRIPTION
This is useful when a setter has no downstream transformation that depends on the returned value, e.g. consider extending demo.yaml like this:

```yaml
    batterymode:
      source: js
      vm: shared
      script: |
        console.log("batteryMode", batteryMode);
```

This would previously error while being perfectly legal.