### PR TITLE
Persist language preference

### DIFF
--- a/assets/js/components/GlobalSettingsModal.vue
+++ b/assets/js/components/GlobalSettingsModal.vue
@@ -41,7 +41,7 @@
 									v-model="language"
 									class="form-select form-select-sm w-75"
 								>
-									<option value="">{{ $t("settings.language.auto") }}</option>
+									<option value="auto">{{ $t("settings.language.auto") }}</option>
 									<option
 										v-for="option in languageOptions"
 										:key="option"
@@ -99,10 +99,11 @@ import TelemetrySettings from "./TelemetrySettings.vue";
 import SponsorTokenExpires from "./SponsorTokenExpires.vue";
 import FormRow from "./FormRow.vue";
 import SelectGroup from "./SelectGroup.vue";
-import { getLocalePreference, setLocalePreference, LOCALES, removeLocalePreference } from "../i18n";
+import { getLocalePreference, LOCALES } from "../i18n";
 import { getThemePreference, setThemePreference, THEMES } from "../theme";
 import { getUnits, setUnits, UNITS } from "../units";
 import { getHiddenFeatures, setHiddenFeatures } from "../featureflags";
+import api from "../api";
 
 export default {
 	name: "GlobalSettingsModal",
@@ -114,7 +115,7 @@ export default {
 	data: function () {
 		return {
 			theme: getThemePreference(),
-			language: getLocalePreference() || "",
+			language: getLocalePreference() || "auto",
 			unit: getUnits(),
 			hiddenFeatures: getHiddenFeatures(),
 			THEMES,
@@ -142,12 +143,7 @@ export default {
 			setHiddenFeatures(value);
 		},
 		language(value) {
-			const i18n = this.$root.$i18n;
-			if (value) {
-				setLocalePreference(i18n, value);
-			} else {
-				removeLocalePreference(i18n);
-			}
+			api.post(`/settings/language/${value}`);
 		},
 	},
 };

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -8,9 +8,8 @@ import settings from "./settings";
 // https://github.com/joker-x/languages.js/blob/master/languages.json
 export const LOCALES = {
   ar: ["Arabic", "العربية"],
-  bh: ["Bihari", "भोजपुरी"],
+  bg: ["Bulgarian", "Български"],
   ca: ["Catalan", "Català"],
-  "zh-Hans": ["Chinese (Simplified)", "简体中文"],
   cs: ["Czech", "Česky"],
   da: ["Danish", "Dansk"],
   de: ["German", "Deutsch"],
@@ -30,7 +29,9 @@ export const LOCALES = {
   ru: ["Russian", "Русский"],
   sl: ["Slovenian", "Slovenščina"],
   sv: ["Swedish", "Svenska"],
+  tr: ["Turkish", "Türkçe"],
   uk: ["Ukrainian", "Українська"],
+  "zh-Hans": ["Chinese (Simplified)", "简体中文"],
 };
 
 function getBrowserLocale() {

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script>
+import { setLocalePreference, removeLocalePreference } from "../i18n";
 import store from "../store";
 
 export default {
@@ -19,6 +20,21 @@ export default {
 	head() {
 		const siteTitle = store.state.siteTitle;
 		return { title: siteTitle ? `${siteTitle} | evcc` : "evcc" };
+	},
+	computed: {
+		language() {
+			return store.state.language;
+		},
+	},
+	watch: {
+		language(value) {
+			const i18n = this.$root.$i18n;
+			if (!value || value == "auto") {
+				removeLocalePreference(i18n);
+			} else {
+				setLocalePreference(i18n, value);
+			}
+		},
 	},
 	mounted: function () {
 		this.connect();

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -30,6 +30,7 @@ const (
 	TariffPriceHome       = "tariffPriceHome"
 	TariffPriceLoadpoints = "tariffPriceLoadpoints"
 	Vehicles              = "vehicles"
+	Language              = "language"
 
 	// battery settings
 	BatteryCapacity         = "batteryCapacity"

--- a/core/site.go
+++ b/core/site.go
@@ -95,6 +95,9 @@ type Site struct {
 	batterySoc   float64         // Battery soc
 	batteryMode  api.BatteryMode // Battery mode
 
+	// user settings
+	language string // Language
+
 	publishCache map[string]any // store last published values to avoid unnecessary republishing
 }
 
@@ -250,6 +253,12 @@ func (site *Site) restoreSettings() error {
 	}
 	if v, err := settings.Bool(keys.BatteryDischargeControl); err == nil {
 		if err := site.SetBatteryDischargeControl(v); err != nil {
+			return err
+		}
+	}
+
+	if v, err := settings.String(keys.Language); err == nil {
+		if err := site.SetLanguage(v); err != nil {
 			return err
 		}
 	}

--- a/core/site/api.go
+++ b/core/site/api.go
@@ -41,7 +41,12 @@ type API interface {
 	//
 	// battery control
 	//
-
 	GetBatteryDischargeControl() bool
 	SetBatteryDischargeControl(bool) error
+
+	//
+	// ui language
+	//
+	GetLanguage() string
+	SetLanguage(string) error
 }

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/util/locale"
 )
 
 var _ site.API = (*Site)(nil)
@@ -171,6 +172,33 @@ func (site *Site) SetSmartCostLimit(val float64) error {
 		site.smartCostLimit = val
 		settings.SetFloat(keys.SmartCostLimit, site.smartCostLimit)
 		site.publish(keys.SmartCostLimit, site.smartCostLimit)
+	}
+
+	return nil
+}
+
+// GetLanguage returns the language
+func (site *Site) GetLanguage() string {
+	site.RLock()
+	defer site.RUnlock()
+	return site.language
+}
+
+// SetLanguage sets the language
+func (site *Site) SetLanguage(lang string) error {
+	site.Lock()
+	defer site.Unlock()
+
+	if lang != "auto" && !locale.LanguageExists(lang) {
+		return errors.New("language not supported")
+	}
+
+	site.log.DEBUG.Println("set language:", lang)
+
+	if site.language != lang {
+		site.language = lang
+		settings.SetString(keys.Language, site.language)
+		site.publish(keys.Language, site.language)
 	}
 
 	return nil

--- a/server/http.go
+++ b/server/http.go
@@ -118,6 +118,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, cache *util.Cache) {
 		"session2":                {[]string{"DELETE", "OPTIONS"}, "/session/{id:[0-9]+}", deleteSessionHandler},
 		"telemetry":               {[]string{"GET"}, "/settings/telemetry", boolGetHandler(telemetry.Enabled)},
 		"telemetry2":              {[]string{"POST", "OPTIONS"}, "/settings/telemetry/{value:[a-z]+}", boolHandler(telemetry.Enable, telemetry.Enabled)},
+		"language":                {[]string{"POST", "OPTIONS"}, "/settings/language/{value:[a-zA-Z-]+}", stringHandler(site.SetLanguage, site.GetLanguage)},
 	}
 
 	for _, r := range routes {

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -136,6 +136,21 @@ func boolHandler(set func(bool) error, get func() bool) http.HandlerFunc {
 	}
 }
 
+// stringHandler updates string-param api
+func stringHandler(set func(string) error, get func() string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		val := vars["value"]
+		if err := set(val); err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		jsonResult(w, get())
+	}
+}
+
 // boolGetHandler retrieves bool api values
 func boolGetHandler(get func() bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/tests/basics.spec.js
+++ b/tests/basics.spec.js
@@ -78,7 +78,6 @@ test.describe("language", async () => {
 
     // survive restart
     await restart(CONFIG);
-    console.log("restarted>>>>");
     await page.goto("/");
     await expect(page.getByTestId("vehicle-status")).toHaveText("Ladevorgang aktiv …");
 

--- a/tests/evcc.js
+++ b/tests/evcc.js
@@ -48,12 +48,15 @@ async function _start(config) {
       throw new Error("evcc terminated", code);
     }
   });
+  // ensure evcc responds
   await waitOn({ resources: [BASE_URL] });
 }
 
 async function _stop() {
   console.log("shutting down evcc");
   await axios.post(BASE_URL + "/api/shutdown");
+  // ensure evcc is down
+  await waitOn({ resources: [BASE_URL], reverse: true });
 }
 
 async function _clean() {

--- a/util/locale/locale.go
+++ b/util/locale/locale.go
@@ -60,3 +60,13 @@ func LocalizeID(id string) string {
 		MessageID: id,
 	})
 }
+
+func LanguageExists(lang string) bool {
+	langTag := language.Make(lang)
+	for _, tag := range Bundle.LanguageTags() {
+		if tag == langTag {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/10459

- 💽 language selection is persisted to database (before browser storage)
- 🔄 new behaviour: language syncs to all clients
- 🪄 automatic mode still exists -> preferred language per browser (accept header)
- 🫧 removed unused `bh` lang. added `bg` 🇧🇪 and `tr` 🇹🇷 


Video: Firefox (en) <> Safari (de)

https://github.com/evcc-io/evcc/assets/152287/216c061f-a281-4a73-8096-4c36b4d4e8ff

