### PR TITLE
Easee: add shims for unknown SignalR methods

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -380,7 +380,7 @@ func (c *Easee) ChargerUpdate(i json.RawMessage) {
 	c.log.TRACE.Printf("ChargerUpdate: %s", i)
 }
 
-// ChargerUpdate implements the signalr receiver
+// SubscribeToMyProduct implements the signalr receiver
 func (c *Easee) SubscribeToMyProduct(i json.RawMessage) {
 	c.log.TRACE.Printf("SubscribeToMyProduct: %s", i)
 }

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -377,7 +377,12 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 
 // ChargerUpdate implements the signalr receiver
 func (c *Easee) ChargerUpdate(i json.RawMessage) {
-	// c.observe("ChargerUpdate", i)
+	c.log.TRACE.Printf("ChargerUpdate: %s", i)
+}
+
+// ChargerUpdate implements the signalr receiver
+func (c *Easee) SubscribeToMyProduct(i json.RawMessage) {
+	c.log.TRACE.Printf("SubscribeToMyProduct: %s", i)
 }
 
 // CommandResponse implements the signalr receiver


### PR DESCRIPTION
Fix #11486 

I am somewhat curious to observe what Easee may (or may not) be sending our way, so I have added a Trace level log. I did the same for ChargerUpdate (which was already present as a NoOp). It does not hurt to have these, and stabilizing the connection is always a good thing.