### PR TITLE
Easee: only update smart charging if car connected

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -812,7 +812,7 @@ func (c *Easee) updateSmartCharging() {
 	isSmartCharging := mode == api.ModePV || mode == api.ModeMinPV
 
 	c.mux.Lock()
-	updateNeeded := isSmartCharging != c.smartCharging
+	updateNeeded := c.opMode != easee.ModeDisconnected && isSmartCharging != c.smartCharging
 	c.mux.Unlock()
 
 	if updateNeeded {


### PR DESCRIPTION
reduce chances for API errors by not updating smart charging if no car is connected. Was reported as part of #11492  