### PR TITLE
Fix OpenWB 2.0 enabled state handling

### DIFF
--- a/charger/openwb-2.0.go
+++ b/charger/openwb-2.0.go
@@ -12,8 +12,9 @@ import (
 // OpenWB20 charger implementation
 type OpenWB20 struct {
 	conn *modbus.Connection
-	curr uint16
-	base uint16
+	enabled bool
+	curr    uint16
+	base    uint16
 }
 
 const (
@@ -106,12 +107,7 @@ func (wb *OpenWB20) Status() (api.ChargeStatus, error) {
 
 // Enabled implements the api.Charger interface
 func (wb *OpenWB20) Enabled() (bool, error) {
-	b, err := wb.conn.ReadInputRegisters(wb.base+openwbRegActualAmps, 1)
-	if err != nil {
-		return false, err
-	}
-
-	return binary.BigEndian.Uint16(b) == 1, nil
+	return verifyEnabled(wb, wb.enabled)
 }
 
 func (wb *OpenWB20) setCurrent(u uint16) error {
@@ -125,8 +121,11 @@ func (wb *OpenWB20) Enable(enable bool) error {
 	if enable {
 		u = wb.curr
 	}
-
-	return wb.setCurrent(u)
+	err := wb.setCurrent(u)
+	if err == nil {
+		wb.enabled = enable
+	}
+	return err
 }
 
 // MaxCurrent implements the api.Charger interface

--- a/charger/openwb-2.0.go
+++ b/charger/openwb-2.0.go
@@ -11,7 +11,7 @@ import (
 
 // OpenWB20 charger implementation
 type OpenWB20 struct {
-	conn *modbus.Connection
+	conn    *modbus.Connection
 	enabled bool
 	curr    uint16
 	base    uint16


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/11517

Enabled state handling was not implemented correctly for OpenWB 2.0.
Fixed (same handling as in OpenWB 1.x, as OpenWB 2.0 still lacks a "real" enabled state)