### PR TITLE
Fix broken plan view for disconnected soc vehicles

### DIFF
--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -245,7 +245,15 @@ export default {
 			return (!this.vehicleFeatureOffline && this.vehiclePresent) || this.vehicleSoc > 0;
 		},
 		socBasedPlanning: function () {
-			return this.vehicleSoc > 0 && this.vehicleCapacity > 0;
+			// TODO: deduplicate business logic. see also: socBasedPlanning() in loadpoint.go
+			return (
+				this.vehicleName &&
+				this.vehicleCapacity > 0 &&
+				(this.vehicleHasSoc || this.vehicleSoc > 0)
+			);
+		},
+		vehicleHasSoc: function () {
+			return this.vehicleName && !this.vehicleFeatureOffline;
 		},
 	},
 	watch: {

--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -244,16 +244,19 @@ export default {
 		socBasedCharging: function () {
 			return (!this.vehicleFeatureOffline && this.vehiclePresent) || this.vehicleSoc > 0;
 		},
+		knownVehicle: function () {
+			return !!this.vehicleName;
+		},
+		vehicleHasSoc: function () {
+			return this.knownVehicle && !this.vehicleFeatureOffline;
+		},
 		socBasedPlanning: function () {
 			// TODO: deduplicate business logic. see also: socBasedPlanning() in loadpoint.go
 			return (
-				this.vehicleName &&
+				this.knownVehicle &&
 				this.vehicleCapacity > 0 &&
 				(this.vehicleHasSoc || this.vehicleSoc > 0)
 			);
-		},
-		vehicleHasSoc: function () {
-			return this.vehicleName && !this.vehicleFeatureOffline;
 		},
 	},
 	watch: {


### PR DESCRIPTION
fixes #11278 

Align `socBasedPlanning` Implementation in UI with the Go logic.

This is redundant logic. But currently this is the easiest solution without aggressively publishing plan mode every cycle.