### PR TITLE
refactor: change effectiveMinCurrent logic

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -117,9 +117,10 @@ type Loadpoint struct {
 	Soc              SocConfig
 	Enable, Disable  ThresholdConfig
 
-	MinCurrent    float64       // PV mode: start current	Min+PV mode: min current
-	MaxCurrent    float64       // Max allowed current. Physically ensured by the charger
-	GuardDuration time.Duration // charger enable/disable minimum holding time
+	MinCurrent               float64       // PV mode: start current	Min+PV mode: min current
+	MaxCurrent               float64       // Max allowed current. Physically ensured by the charger
+	GuardDuration            time.Duration // charger enable/disable minimum holding time
+	hasUserDefinedMinCurrent bool          // hasUserDefinedMinCurrent is true if the user specified a minCurrent in their configuration
 
 	limitSoc    int     // Session limit for soc
 	limitEnergy float64 // Session limit for energy
@@ -186,6 +187,9 @@ func NewLoadpointFromConfig(log *util.Logger, settings *Settings, other map[stri
 	lp := NewLoadpoint(log, settings)
 	if err := util.DecodeOther(other, lp); err != nil {
 		return nil, err
+	}
+	if _, ok := other["mincurrent"]; ok {
+		lp.hasUserDefinedMinCurrent = true
 	}
 
 	// set vehicle polling mode

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -331,6 +331,7 @@ func (lp *Loadpoint) SetMinCurrent(current float64) {
 
 	if current != lp.MinCurrent {
 		lp.MinCurrent = current
+		lp.hasUserDefinedMinCurrent = true
 		lp.publish(keys.MinCurrent, lp.MinCurrent)
 	}
 }
@@ -363,6 +364,11 @@ func (lp *Loadpoint) GetMinPower() float64 {
 // GetMaxPower returns the max loadpoint power taking vehicle capabilities and phase scaling into account
 func (lp *Loadpoint) GetMaxPower() float64 {
 	return Voltage * lp.effectiveMaxCurrent() * float64(lp.maxActivePhases())
+}
+
+// HasUserDefinedMinCurrent returns true if the user has configured a minCurrent
+func (lp *Loadpoint) HasUserDefinedMinCurrent() bool {
+	return lp.hasUserDefinedMinCurrent
 }
 
 // GetPlanActive returns the active state of the planner


### PR DESCRIPTION
This change does the following:
1) Detect if a loadpoint has a non-default value for `minCurrent` configured
2) Handle the effective min current differently

```mermaid
graph TD
  A["getEffecticeMinCurrent"]-->B{"User changed lp minCurrent?"};
  B -- Yes --> C["Use maximum value of vehicle, lp and charger"];
  B -- "No (6A by default)" --> D{"Does the charger provide limits?"};
  D -- Yes --> E["Use the maximum value of charger and vehicle"]
  D -- No --> F["Use maximum value of vehicle and lp"];
```


see #11636