### PR TITLE
Visual indicator if plan can't be reached in time

### DIFF
--- a/assets/js/components/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlan.vue
@@ -7,17 +7,16 @@
 			data-testid="charging-plan"
 		>
 			<div class="value m-0 d-block align-items-baseline justify-content-center">
-				<button
-					class="value-button p-0"
-					:class="enabled ? 'evcc-default-text' : 'text-gray'"
-					@click="openModal"
-				>
+				<button class="value-button p-0" :class="buttonColor" @click="openModal">
 					<strong v-if="minSocEnabled" class="text-decoration-underline">
 						{{ minSocLabel }}
 					</strong>
 					<strong v-else-if="targetChargeEnabled">
 						<span class="text-decoration-underline"> {{ targetTimeLabel() }}</span>
-						<div class="extraValue text-nowrap">
+						<div
+							class="extraValue text-nowrap"
+							:class="{ 'text-warning': planOverrun }"
+						>
 							{{ targetSocLabel }}
 						</div>
 					</strong>
@@ -126,6 +125,7 @@ export default {
 		planActive: Boolean,
 		planEnergy: Number,
 		planTime: String,
+		planOverrun: Boolean,
 		rangePerSoc: Number,
 		smartCostLimit: Number,
 		smartCostType: String,
@@ -145,6 +145,15 @@ export default {
 		};
 	},
 	computed: {
+		buttonColor: function () {
+			if (this.planOverrun) {
+				return "text-warning";
+			}
+			if (!this.enabled) {
+				return "text-gray";
+			}
+			return "evcc-default-text";
+		},
 		minSoc: function () {
 			return this.vehicle?.minSoc;
 		},

--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -161,6 +161,7 @@ export default {
 		vehicles: Array,
 		planActive: Boolean,
 		planProjectedStart: String,
+		planOverrun: Boolean,
 		planEnergy: Number,
 		planTime: String,
 		effectivePlanTime: String,

--- a/assets/js/components/Vehicle.vue
+++ b/assets/js/components/Vehicle.vue
@@ -106,6 +106,7 @@ export default {
 		planEnergy: Number,
 		planProjectedStart: String,
 		planTime: String,
+		planOverrun: Boolean,
 		pvAction: String,
 		pvRemainingInterpolated: Number,
 		smartCostActive: Boolean,

--- a/assets/js/components/VehicleSoc.vue
+++ b/assets/js/components/VehicleSoc.vue
@@ -42,7 +42,10 @@
 				v-show="planMarkerAvailable"
 				class="plan-marker"
 				data-bs-toggle="tooltip"
-				:class="{ 'plan-marker--warn': planMarkerUnreachable }"
+				:class="{
+					'plan-marker--warning': planOverrun,
+					'plan-marker--error': planMarkerUnreachable,
+				}"
 				:style="{ left: `${planMarkerPosition}%` }"
 				data-testid="plan-marker"
 				@click="$emit('plan-clicked')"
@@ -88,6 +91,7 @@ export default {
 		effectiveLimitSoc: Number,
 		limitEnergy: Number,
 		planEnergy: Number,
+		planOverrun: Boolean,
 		chargedEnergy: Number,
 		socBasedCharging: Boolean,
 		socBasedPlanning: Boolean,
@@ -381,11 +385,17 @@ export default {
 	background-color: var(--evcc-darker-green);
 	transition: background-color var(--evcc-transition-fast) linear;
 }
-.plan-marker--warn {
+.plan-marker--warning {
+	color: var(--bs-warning);
+}
+.plan-marker--warning::before {
+	background-color: var(--bs-warning);
+}
+.plan-marker--error {
 	opacity: 1;
 	color: var(--bs-danger);
 }
-.plan-marker--warn::before {
+.plan-marker--error::before {
 	background-color: var(--bs-danger);
 }
 .energy-limit-marker {

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -53,6 +53,7 @@ const (
 	PlanSoc            = "planSoc"            // charge plan soc goal
 	PlanActive         = "planActive"         // charge plan has determined current slot to be an active slot
 	PlanProjectedStart = "planProjectedStart" // charge plan start time (earliest slot)
+	PlanOverrun        = "planOverrun"        // charge plan goal not reachable in time
 
 	// remote control
 	RemoteDisabled       = "remoteDisabled"       // remote disabled

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -88,8 +88,10 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	}()
 
 	var planStart time.Time
+	var planOverrun bool
 	defer func() {
 		lp.publish(keys.PlanProjectedStart, planStart)
+		lp.publish(keys.PlanOverrun, planOverrun)
 	}()
 
 	planTime := lp.EffectivePlanTime()
@@ -115,6 +117,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	var overrun string
 	if excessDuration := requiredDuration - lp.clock.Until(planTime); excessDuration > 0 {
 		overrun = fmt.Sprintf("overruns by %v, ", excessDuration.Round(time.Second))
+		planOverrun = true
 	}
 
 	planStart = planner.Start(plan)


### PR DESCRIPTION
Tinting marker and plan time/goal orange if plan can't be reached in time. Details are visible in plan modal after clicking one of the highlighted areas.

I opted against using a dedicated (and duplicate) text thats highlighting the time and amount of overrun since users would have to open the plan modal to fix this state anyway.

fixes #11327

**Loadpoint: Plan can't be reached**

![Bildschirmfoto 2024-01-17 um 17 09 04](https://github.com/evcc-io/evcc/assets/152287/fab6dc7f-5edf-4d56-9a67-504dae1d6188)

**Model: Plan can't be reached**

![Bildschirmfoto 2024-01-17 um 17 09 12](https://github.com/evcc-io/evcc/assets/152287/fae7afb5-3799-4771-a56e-ba533d81baca)

**Normal State**

![Bildschirmfoto 2024-01-17 um 17 08 46](https://github.com/evcc-io/evcc/assets/152287/13a1c5f8-fb12-47a2-a41a-825c633efdb7)
