### PR TITLE
Easee: make retry for SignalR (re)connect more relaxed

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -205,6 +205,8 @@ func (c *Easee) chargerSite(charger string) (easee.Site, error) {
 func (c *Easee) connect(ts oauth2.TokenSource) func() (signalr.Connection, error) {
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxInterval = time.Minute
+	bo.InitialInterval = 2 * time.Second
+	bo.Multiplier = 2
 
 	return func() (conn signalr.Connection, err error) {
 		defer func() {


### PR DESCRIPTION
Adjust backoff timing to better fit refresh_token endpoint limits, reducing the chance for users getting throttled.