### PR TITLE
add: preliminary support for VW ID vehicle charge rate control

### DIFF
--- a/vehicle/vw/id/api.go
+++ b/vehicle/vw/id/api.go
@@ -75,6 +75,19 @@ func (v *API) Status(vin string) (res Status, err error) {
 	return res, err
 }
 
+func (v *API) MaxChargeLevel(vin, level string) error {
+	uri := fmt.Sprintf("%s/vehicles/%s/charging/settings", BaseURL, vin)
+	data := map[string]string{"maxChargeCurrentAC": level}
+	req, err := request.New(http.MethodPut, uri, request.MarshalJSON(data), request.JSONEncoding)
+
+	if err == nil {
+		var res interface{}
+		err = v.DoJSON(req, &res)
+	}
+
+	return err
+}
+
 // Action implements vehicle actions
 func (v *API) Action(vin, action, value string) error {
 	uri := fmt.Sprintf("%s/vehicles/%s/%s/%s", BaseURL, vin, action, value)

--- a/vehicle/vw/id/provider.go
+++ b/vehicle/vw/id/provider.go
@@ -2,10 +2,12 @@ package id
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/provider"
 )
 
@@ -14,6 +16,7 @@ type Provider struct {
 	statusG        func() (Status, error)
 	action         func(action, value string) error
 	maxChargeLevel func(value string) error
+	lp             loadpoint.API
 }
 
 // NewProvider creates a vehicle api provider
@@ -185,12 +188,25 @@ func (v *Provider) WakeUp() error {
 
 // MaxCurrent implements the api.Charger interface
 func (v *Provider) MaxCurrent(current int64) error {
+	fmt.Printf("current: %d\n", current)
+	fmt.Printf("lp: %+v\n", v.lp)
+
+	// commented out to avoid spamming API calls during development
+
 	// e-up: there are only two possible levels
 	// "reduced" or "maximum"; reduced is 5A
-	level := "maximum"
-	if current <= 5 {
-		level = "reduced"
-	}
+	// level := "maximum"
+	// if current <= 5 {
+	// 	level = "reduced"
+	// }
 
-	return v.maxChargeLevel(level)
+	//return v.maxChargeLevel(level)
+	return nil
+}
+
+var _ loadpoint.Controller = (*Provider)(nil)
+
+// LoadpointControl implements loadpoint.Controller
+func (v *Provider) LoadpointControl(lp loadpoint.API) {
+	v.lp = lp
 }


### PR DESCRIPTION
Hello,

This PR adds preliminary support for vehicle-based charge rate control with VW ID.
It has a few caveats that I'd like to discuss:
- the API, at least for the VW e-up, only supports two values for charge rate: `maximum` or `reduced`, being that reduced is 5A, and `maximum` is whatever maximum the charger supports. The logic I've added only changes the rate to `reduced` if current control is below or equal to 5A, otherwise it sets it to `maximum`. I'd be happier with something smarter!
- the API has a limit on number of requests that can be done before throttling with an HTTP 429. This means that, due to the way evcc works, we run the risk of exhausting HTTP API calls to set charge rate quickly; once again, something smarter would be appreciated
- I understand some vehicles, like the e-golf, support more granular charge rates, but I'm not aware of how to detect specific vehicles and change logic accordingly

This PR suits my specific use case, since I have a TWC3 and charge rate control has to be done via the vehicle API.

I'd like to start a discussion, gather ideas, and hopefully improvements to this PR. Cheers!