### PR TITLE
Solis-Hybrid: Add external battery power sign

### DIFF
--- a/templates/definition/meter/solis-hybrid.yaml
+++ b/templates/definition/meter/solis-hybrid.yaml
@@ -114,13 +114,6 @@ render: |
         scale: 2
       - source: const
         value: -1
-  power:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      type: input
-      address: 33149 # Battery power
-      decode: int32    
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/solis-hybrid.yaml
+++ b/templates/definition/meter/solis-hybrid.yaml
@@ -95,6 +95,26 @@ render: |
   {{- end }}
   {{- if eq .usage "battery" }}
   power:
+    source: calc
+    mul:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        type: input
+        address: 33149 # Battery power
+        decode: uint32
+    - source: calc
+      add:
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          type: input
+          address: 33135 # Battery current direction
+          decode: uint16 # 0：charge, 1：discharge
+        scale: 2
+      - source: const
+        value: -1
+  power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:


### PR DESCRIPTION
Hopefully fixes #11717

Signed battery power is missing the sign.
Ginlong documentation seems to be invalid.