### PR TITLE
chore: reduce log spam from planner, if no plan active

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -95,6 +95,9 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	}()
 
 	planTime := lp.EffectivePlanTime()
+	if planTime.IsZero() {
+		return false
+	}
 	if lp.clock.Until(planTime) < 0 && !lp.planActive {
 		lp.deletePlan()
 		return false


### PR DESCRIPTION
The planner regularly spams the debug logs on every interval logging the so called "zero time".

```
[site  ] DEBUG 2024/01/25 22:19:49 set vehicle_2 plan soc: 0 @ 0001-01-01 00:53:28 +0053 LMT
```

Zero time is what the plantime is set to initially or when removing a plan.
Currently the logic checks if the planTime is in the past and the plan is inactive.
In this case it resets the plantime to zero time.
As zero time is always in the past, every interval also resets the timer, leading to the above repeated messages.

The change here simply short circuits Loadpoint.plannerActive() to return false in case the planner time is zero time. 