### PR TITLE
Header-based auto-language detection

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -1,37 +1,39 @@
 <!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="evcc" />
-    <meta name="application-name" content="evcc" />
+<html lang="[[.DefaultLang]]">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
-    <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
-    <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
-    <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
-    <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
-    <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
-    <meta name="msapplication-TileColor" content="#1C2445" />
-    <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
-    <meta name="theme-color" content="#020318" />
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="apple-mobile-web-app-title" content="evcc" />
+  <meta name="application-name" content="evcc" />
 
-    <title>evcc</title>
-  </head>
+  <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
+  <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
+  <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
+  <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
+  <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
+  <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
+  <meta name="msapplication-TileColor" content="#1C2445" />
+  <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
+  <meta name="theme-color" content="#020318" />
 
-  <body>
-    <script>
-      window.evcc = {
-        version: "[[.Version]]",
-        configured: "[[.Configured]]",
-        commit: "[[.Commit]]",
-      };
-    </script>
+  <title>evcc</title>
+</head>
 
-    <div id="app"></div>
-    <script type="module" src="./js/app.js"></script>
-  </body>
+<body>
+  <script>
+    window.evcc = {
+      version: "[[.Version]]",
+      configured: "[[.Configured]]",
+      commit: "[[.Commit]]",
+    };
+  </script>
+
+  <div id="app"></div>
+  <script type="module" src="./js/app.js"></script>
+</body>
+
 </html>

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,39 +1,37 @@
 <!doctype html>
 <html lang="[[.DefaultLang]]">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="evcc" />
+    <meta name="application-name" content="evcc" />
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-  <meta name="apple-mobile-web-app-title" content="evcc" />
-  <meta name="application-name" content="evcc" />
+    <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
+    <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
+    <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
+    <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
+    <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
+    <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
+    <meta name="msapplication-TileColor" content="#1C2445" />
+    <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
+    <meta name="theme-color" content="#020318" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
-  <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
-  <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
-  <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
-  <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
-  <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
-  <meta name="msapplication-TileColor" content="#1C2445" />
-  <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
-  <meta name="theme-color" content="#020318" />
+    <title>evcc</title>
+  </head>
 
-  <title>evcc</title>
-</head>
+  <body>
+    <script>
+      window.evcc = {
+        version: "[[.Version]]",
+        configured: "[[.Configured]]",
+        commit: "[[.Commit]]",
+      };
+    </script>
 
-<body>
-  <script>
-    window.evcc = {
-      version: "[[.Version]]",
-      configured: "[[.Configured]]",
-      commit: "[[.Commit]]",
-    };
-  </script>
-
-  <div id="app"></div>
-  <script type="module" src="./js/app.js"></script>
-</body>
-
+    <div id="app"></div>
+    <script type="module" src="./js/app.js"></script>
+  </body>
 </html>

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -35,15 +35,7 @@ export const LOCALES = {
 };
 
 export const DEFAULT_LOCALE = "en";
-
-function getBrowserLocale() {
-  const navigatorLocale =
-    navigator.languages !== undefined ? navigator.languages[0] : navigator.language;
-  if (!navigatorLocale) {
-    return undefined;
-  }
-  return navigatorLocale.trim().split(/-|_/)[0];
-}
+const DEFAULT_BROWSER_LOCALE = document.querySelector("html").getAttribute("lang");
 
 export function getLocalePreference() {
   return settings.locale;
@@ -51,7 +43,7 @@ export function getLocalePreference() {
 
 export function removeLocalePreference(i18n) {
   settings.locale = null;
-  setI18nLanguage(i18n, getBrowserLocale());
+  setI18nLanguage(i18n, DEFAULT_BROWSER_LOCALE);
   ensureCurrentLocaleMessages(i18n);
 }
 
@@ -66,7 +58,7 @@ export function setLocalePreference(i18n, locale) {
 }
 
 function getLocale() {
-  return getLocalePreference() || getBrowserLocale();
+  return getLocalePreference() || DEFAULT_BROWSER_LOCALE;
 }
 
 export default function setupI18n() {


### PR DESCRIPTION
Fix #11789, fix #10459

Use `Accept-Language` header (Go) instead of `navigator.language(s)` (JS) for "Language: automatic" setting in UI.