### PR TITLE
Fronius Solar API: add battery control

### DIFF
--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Fronius
     description:
       generic: Solar API V1
+capabilities: ["battery-control"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -10,6 +11,10 @@ params:
   - name: host
   - name: capacity
     advanced: true
+  - name: user
+    required: false
+  - name: password
+    required: false
 render: |
   type: custom
   power:
@@ -27,6 +32,45 @@ render: |
     source: http
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi
     jq: .Body.Data.Inverters."1".SOC
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: http
+        uri: http://{{ .host }}/config/timeofuse
+        method: POST
+        headers:
+        - content-type: application/json
+        auth:
+          type: digest
+          user: {{ .user }}
+          password: {{ .password }}
+        body: '{"timeofuse":[]}'
+    - case: 2 # hold
+      set:
+        source: http
+        uri: http://{{ .host }}/config/timeofuse
+        method: POST
+        headers:
+        - content-type: application/json
+        auth:
+          type: digest
+          user: {{ .user }}
+          password: {{ .password }}
+        body: '{"timeofuse":[{"Active":true,"Power":0,"ScheduleType":"DISCHARGE_MAX","TimeTable":{"Start":"00:00","End":"23:59"},"Weekdays":{"Mon":true,"Tue":true,"Wed":true,"Thu":true,"Fri":true,"Sat":true,"Sun":true}}]}'
+    - case: 3 # charge
+      set:
+        source: http
+        uri: http://{{ .host }}/config/timeofuse
+        method: POST
+        headers:
+        - content-type: application/json
+        auth:
+          type: digest
+          user: {{ .user }}
+          password: {{ .password }}
+        body: '{"timeofuse":[]}'
   {{- if .capacity }}
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
As discussed in #11711. Review required, as I tried to mimic other inverters with battery control enabled. Ultimately, the contents of this PR works for me, but getting there required a bit of trial and error.

A couple of things to note:
* This adds `user` and `password` to the template as parameters. These are not required for `usage=grid` and `usage=pv`. And, they are not even required for `usage=battery` if battery control is not used. But making them `optional` is I think a good compromise.
* What I can't fully judge is if it's ok to add `batterymode` unconditionally to the template because there might be users that don't configure it, even for `usage=battery`. If users don't set `user` and `password`, the resulting URLs will be broken. But then, this might be ok as users will also have to actively switch on the functionality via the UI.
* I am not sure if there's a good way to reduce duplication. For example, `switch=1 # normal` and `switch=3 # charge` are identical, but I don't know if there's such a thing as `- case: 1, 3`. The same is true for most of the `set:` sections repeated three times.
* The way it is implemented now, resetting to `normal` or `charge` will remove all battery control rules stored in the inverter. Options to avoid this would be, as far as I can see:
  * Make the `body`s of the commands configurable. This way, users could add more sophisticated rules that are not overwritten. But this would come with the need for users to know the corresponding JSON syntax.
  * Try and read the existing configuration from the inverter first using a `sequence` and then trying to amend the existing configuration with the command to set maximum discharge to 0. While this approach would be best, I guess this isn't possible with just a template.
* Talking about `normal` and `charge`, I didn't fully understand the difference between the two, that's why they essentially do the same thing.
* And of course, as mentioned, the API used is undocumented, so it might change with new inverter firmware.

Once the above has been clarified, I'll also add the additional docs required. And, I can offer to do a separate PR detailing out authentication options in <https://docs.evcc.io/docs/reference/plugins#http-lesenschreiben>