### PR TITLE
SMA Modbus: split templates

### DIFF
--- a/templates/definition/meter/sma-inverter-modbus.yaml
+++ b/templates/definition/meter/sma-inverter-modbus.yaml
@@ -2,14 +2,10 @@ template: sma-inverter-modbus
 products:
   - brand: SMA
     description:
-      generic: Sunny Island (Modbus)
-  - brand: SMA
-    description:
-      generic: Sunny Boy Storage (Modbus)
-capabilities: ["battery-control"]
+      generic: Wechselrichter (Modbus)
 params:
   - name: usage
-    choice: ["battery"]
+    choice: ["pv"]
   - name: modbus
     choice: ["tcpip"]
     port: 502
@@ -17,12 +13,6 @@ params:
     help:
       en: The Modbus TCP-Server needs to be enabled on this inverter
       de: Der Modbus TCP-Server muss an diesem Wechselrichter aktiviert sein
-  - name: capacity
-    advanced: true
-  - name: watchdog
-    type: duration
-    default: 60s
-    advanced: true
 render: |
   type: custom
   power:
@@ -40,55 +30,3 @@ render: |
       type: holding
       decode: uint64nan
     scale: 0.001
-  {{- if eq .usage "battery" }}
-  soc:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 30845 # SMA Modbus Profile: Bat.ChaStt
-      type: holding
-      decode: uint32nan
-  batterymode:
-    source: watchdog
-    timeout: {{ .watchdog }} # re-write at timeout/2
-    reset: 1 # reset watchdog on normal
-    set:
-      source: switch
-      switch:
-      - case: 1 # normal
-        set:
-          source: const
-          value: 10000 # Maximale Wirkleistung
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 44039 # SMA Modbus Profile: Inverter.WModCfg.WCtlComCfg.WSptMaxNom
-              type: writemultiple
-              decode: int32
-      - case: 2 # hold
-        set:
-          source: const
-          value: 0 # Maximale Wirkleistung
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 44039 # SMA Modbus Profile: Inverter.WModCfg.WCtlComCfg.WSptMaxNom
-              type: writemultiple
-              decode: int32
-      - case: 3 # charge
-        set:
-          source: const
-          value: -10000 # Maximale Wirkleistung
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 44039 # SMA Modbus Profile: Inverter.WModCfg.WCtlComCfg.WSptMaxNom
-              type: writemultiple
-              decode: int32
-  {{- if .capacity }}
-  capacity: {{ .capacity }} # kWh
-  {{- end }}
-  {{- end }}

--- a/templates/definition/meter/sma-sbs-modbus.yaml
+++ b/templates/definition/meter/sma-sbs-modbus.yaml
@@ -1,0 +1,89 @@
+template: sma-sbs-modbus
+products:
+  - brand: SMA
+    description:
+      generic: Sunny Boy Storage (Modbus)
+capabilities: ["battery-control"]
+params:
+  - name: usage
+    choice: ["battery"]
+  - name: modbus
+    choice: ["tcpip"]
+    port: 502
+    id: 3
+    help:
+      en: The Modbus TCP-Server needs to be enabled on this inverter
+      de: Der Modbus TCP-Server muss an diesem Wechselrichter aktiviert sein
+  - name: capacity
+    advanced: true
+  - name: watchdog
+    type: duration
+    default: 60s
+    advanced: true
+render: |
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 30775 # SMA Modbus Profile: GridMs.TotW
+      type: input
+      decode: int32nan
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 30513 # SMA Modbus Profile: Metering.TotWhOut
+      type: holding
+      decode: uint64nan
+    scale: 0.001
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 30845 # SMA Modbus Profile: Bat.ChaStt
+      type: holding
+      decode: uint32nan
+  batterymode:
+    source: watchdog
+    timeout: {{ .watchdog }}
+    reset: 1 # reset watchdog on normal
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: const
+          value: 10000 # Maximale Wirkleistung 100.00%
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44039 # SMA Modbus Profile: Inverter.WModCfg.WCtlComCfg.WSptMaxNom
+              type: writemultiple
+              decode: int32
+      - case: 2 # hold
+        set:
+          source: const
+          value: 0 # Maximale Wirkleistung 0.00%
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44039 # SMA Modbus Profile: Inverter.WModCfg.WCtlComCfg.WSptMaxNom
+              type: writemultiple
+              decode: int32
+      - case: 3 # charge
+        set:
+          source: const
+          value: -10000 # Maximale Wirkleistung -100.00%
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44039 # SMA Modbus Profile: Inverter.WModCfg.WCtlComCfg.WSptMaxNom
+              type: writemultiple
+              decode: int32
+  {{- if .capacity }}
+  capacity: {{ .capacity }} # kWh
+  {{- end }}

--- a/templates/definition/meter/sma-si-modbus.yaml
+++ b/templates/definition/meter/sma-si-modbus.yaml
@@ -1,76 +1,39 @@
-template: sma-hybrid
+template: sma-si-modbus
 products:
   - brand: SMA
     description:
-      de: Smart Energy Hybrid-Wechselrichter
-      en: Smart Energy Hybrid Inverter
+      generic: Sunny Island (Modbus)
 capabilities: ["battery-control"]
 params:
   - name: usage
-    choice: ["pv", "battery"]
-    allinone: true
+    choice: ["battery"]
   - name: modbus
     choice: ["tcpip"]
     port: 502
     id: 3
     help:
-      en: The Modbus TCP-Server needs to be enabled on this Smart Energy inverter
-      de: Der Modbus TCP-Server muss an diesem Smart Energy Wechselrichter aktiviert sein
+      en: The Modbus TCP-Server needs to be enabled on this inverter
+      de: Der Modbus TCP-Server muss an diesem Wechselrichter aktiviert sein
   - name: capacity
     advanced: true
   - name: watchdog
     type: duration
-    default: 30s
+    default: 60s
     advanced: true
 render: |
   type: custom
-  {{- if eq .usage "pv" }}
   power:
-    source: calc
-    add:
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 30773 # SMA Modbus Profile: DcMs.Watt [1]
-          type: holding
-          decode: int32nan
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 30961 # SMA Modbus Profile: DcMs.Watt [2]
-          type: holding
-          decode: int32nan
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 30775 # SMA Modbus Profile: GridMs.TotW
+      type: input
+      decode: int32nan
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
       address: 30513 # SMA Modbus Profile: Metering.TotWhOut
-      type: holding
-      decode: uint64nan
-    scale: 0.001
-  {{- end }}
-  {{- if eq .usage "battery" }}
-  power:
-    source: calc
-    add:
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 31395 # SMA Modbus Profile: BatDsch.CurBatDsch
-          type: input
-          decode: uint32nan
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 31393 # SMA Modbus Profile: BatChrg.CurBatCha
-          type: input
-          decode: uint32nan
-        scale: -1
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 31401 # SMA Modbus Profile: CmpBMS.GetBatDschWh
       type: holding
       decode: uint64nan
     scale: 0.001
@@ -145,44 +108,4 @@ render: |
                 decode: uint32
   {{- if .capacity }}
   capacity: {{ .capacity }} # kWh
-  {{- end }}
-  {{- end }}
-  {{- if eq .usage "grid" }}
-  power:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 30865 # SMA Modbus Profile: Metering.GridMs.TotWIn
-      type: input
-      decode: int32nan
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 30581 # SMA Modbus Profile: Metering.GridMs.TotWhIn
-      type: holding
-      decode: int32nan
-    scale: 0.001
-  currents:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 31435 # SMA Modbus Profile: Metering.GridMs.A.phsA
-        type: input
-        decode: int32nan
-      scale: 0.001
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 31437 # SMA Modbus Profile: Metering.GridMs.A.phsB
-        type: input
-        decode: int32nan
-      scale: 0.001
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 31439 # SMA Modbus Profile: Metering.GridMs.A.phsC
-        type: input
-        decode: int32nan
-      scale: 0.001
   {{- end }}


### PR DESCRIPTION
Fixes #11812

There may be other Modbus registers to control SI in a smarter way, but that would require testing on a real device.