### PR TITLE
SDM120: add usage pv

### DIFF
--- a/templates/definition/meter/eastron-sdm120.yaml
+++ b/templates/definition/meter/eastron-sdm120.yaml
@@ -5,12 +5,29 @@ products:
       generic: SDM120-Modbus
 params:
   - name: usage
-    choice: ["grid", "charge"]
+    choice: ["grid", "charge", "pv"]
   - name: modbus
     choice: ["rs485"]
 render: |
-  type: mbmd
-  {{- include "modbus" . }}
-  model: sdm
-  power: Power
-  energy: Import
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0c # Active power
+      type: input
+      decode: float32
+    {{- if eq .usage "pv" }}
+    scale: -1
+    {{- end }}
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      {{- if eq .usage "pv" }}
+      address: 0x4c # Export active energy
+      {{- else }}
+      address: 0x48 # Import active energy
+      {{- end }}
+      type: input
+      decode: float32


### PR DESCRIPTION
Fixes #11868

Replaces mbmd by direct Modbus access and adds `usage: pv`.