### PR TITLE
WARP Energy Manager: Fix phase switch for firmware v2.0

### DIFF
--- a/charger/warp2.go
+++ b/charger/warp2.go
@@ -145,12 +145,12 @@ func NewWarp2(mqttconf mqtt.Config, topic, emTopic string, timeout time.Duration
 		return nil, err
 	}
 
-	wb.emStateG, err = to.StringGetter(mq("%s/energy_manager/state", emTopic))
+	wb.emStateG, err = to.StringGetter(mq("%s/power_manager/state", emTopic))
 	if err != nil {
 		return nil, err
 	}
 	wb.phasesS, err = provider.NewMqtt(log, client,
-		fmt.Sprintf("%s/energy_manager/external_control_update", emTopic), 0).
+		fmt.Sprintf("%s/power_manager/external_control_update", emTopic), 0).
 		WithPayload(`{ "phases_wanted": ${phases} }`).
 		IntSetter("phases")
 	if err != nil {

--- a/templates/definition/charger/tinkerforge-warp.yaml
+++ b/templates/definition/charger/tinkerforge-warp.yaml
@@ -11,8 +11,8 @@ products:
 capabilities: ["mA", "1p3p", "rfid"]
 requirements:
   description:
-    en: Firmware v2 required. Automatic phase switching requires the additional WARP Energy Manager.
-    de: Firmware v2 erforderlich. Für automatische Phasenumschaltung wird zusätzlich der WARP Energy Manager benötigt.
+    en: WARP Firmware v2 required. Automatic phase switching requires the additional WARP Energy Manager.
+    de: WARP Firmware v2 erforderlich. Für automatische Phasenumschaltung wird zusätzlich der WARP Energy Manager benötigt.
   uri: https://docs.evcc.io/docs/devices/chargers#tinkerforge
 params:
   - preset: mqtt
@@ -20,8 +20,8 @@ params:
     default: warp
   - name: energymanager
     help:
-      de: EnergyManager MQTT Topic (falls installiert)
-      en: EnergyManager MQTT topic if installed
+      de: WEM Firmware v2 erforderlich. EnergyManager MQTT Topic (falls installiert)
+      en: WEM Firmware v2 required. EnergyManager MQTT topic (if installed)
 render: |
   type: warp2
   {{ include "mqtt" . }}


### PR DESCRIPTION
Mit WEM Firmware 2.0 wurden die MQTT-Topics "/energy_manager/state" und "/energy_manager/external_control_update" in "/power_manager/state" bzw. "/power_manager/external_control_update" umbenannt.