### PR TITLE
Battery control: hold battery while min soc not reached

### DIFF
--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -120,6 +120,8 @@ type API interface {
 	// charge progress
 	//
 
+	// GetMinSocNotReached returns the state of min soc is not reached
+	GetMinSocNotReached() bool
 	// GetPlanActive returns the active state of the planner
 	GetPlanActive() bool
 	// GetRemainingDuration is the estimated remaining charging duration

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -120,10 +120,8 @@ type API interface {
 	// charge progress
 	//
 
-	// GetMinSocNotReached returns the state of min soc is not reached
-	GetMinSocNotReached() bool
-	// GetPlanActive returns the active state of the planner
-	GetPlanActive() bool
+	// IsFastChargingActive indicates if fast charging with maximum power is active
+	IsFastChargingActive() bool
 	// GetRemainingDuration is the estimated remaining charging duration
 	GetRemainingDuration() time.Duration
 	// GetRemainingEnergy is the remaining charge energy in Wh

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -222,20 +222,6 @@ func (mr *MockAPIMockRecorder) GetMinCurrent() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinCurrent", reflect.TypeOf((*MockAPI)(nil).GetMinCurrent))
 }
 
-// GetMinSocNotReached mocks base method.
-func (m *MockAPI) GetMinSocNotReached() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMinSocNotReached")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// GetMinSocNotReached indicates an expected call of GetMinSocNotReached.
-func (mr *MockAPIMockRecorder) GetMinSocNotReached() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinSocNotReached", reflect.TypeOf((*MockAPI)(nil).GetMinSocNotReached))
-}
-
 // GetMode mocks base method.
 func (m *MockAPI) GetMode() api.ChargeMode {
 	m.ctrl.T.Helper()
@@ -277,20 +263,6 @@ func (m *MockAPI) GetPlan(arg0 time.Time, arg1 time.Duration) (api.Rates, error)
 func (mr *MockAPIMockRecorder) GetPlan(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), arg0, arg1)
-}
-
-// GetPlanActive mocks base method.
-func (m *MockAPI) GetPlanActive() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlanActive")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// GetPlanActive indicates an expected call of GetPlanActive.
-func (mr *MockAPIMockRecorder) GetPlanActive() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlanActive", reflect.TypeOf((*MockAPI)(nil).GetPlanActive))
 }
 
 // GetPlanEnergy mocks base method.
@@ -419,6 +391,20 @@ func (m *MockAPI) HasChargeMeter() bool {
 func (mr *MockAPIMockRecorder) HasChargeMeter() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasChargeMeter", reflect.TypeOf((*MockAPI)(nil).HasChargeMeter))
+}
+
+// IsFastChargingActive mocks base method.
+func (m *MockAPI) IsFastChargingActive() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsFastChargingActive")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsFastChargingActive indicates an expected call of IsFastChargingActive.
+func (mr *MockAPIMockRecorder) IsFastChargingActive() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFastChargingActive", reflect.TypeOf((*MockAPI)(nil).IsFastChargingActive))
 }
 
 // PublishEffectiveValues mocks base method.

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -266,6 +266,20 @@ func (mr *MockAPIMockRecorder) GetPlan(arg0, arg1 any) *gomock.Call {
 }
 
 // GetPlanActive mocks base method.
+func (m *MockAPI) GetMinSocNotReached() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMinSocNotReached")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetMinSocNotReached indicates an expected call of GetPlanActive.
+func (mr *MockAPIMockRecorder) GetMinSocNotReached() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinSocNotReached", reflect.TypeOf((*MockAPI)(nil).GetMinSocNotReached))
+}
+
+// GetPlanActive mocks base method.
 func (m *MockAPI) GetPlanActive() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPlanActive")

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -222,6 +222,20 @@ func (mr *MockAPIMockRecorder) GetMinCurrent() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinCurrent", reflect.TypeOf((*MockAPI)(nil).GetMinCurrent))
 }
 
+// GetMinSocNotReached mocks base method.
+func (m *MockAPI) GetMinSocNotReached() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMinSocNotReached")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetMinSocNotReached indicates an expected call of GetMinSocNotReached.
+func (mr *MockAPIMockRecorder) GetMinSocNotReached() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinSocNotReached", reflect.TypeOf((*MockAPI)(nil).GetMinSocNotReached))
+}
+
 // GetMode mocks base method.
 func (m *MockAPI) GetMode() api.ChargeMode {
 	m.ctrl.T.Helper()
@@ -263,20 +277,6 @@ func (m *MockAPI) GetPlan(arg0 time.Time, arg1 time.Duration) (api.Rates, error)
 func (mr *MockAPIMockRecorder) GetPlan(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), arg0, arg1)
-}
-
-// GetPlanActive mocks base method.
-func (m *MockAPI) GetMinSocNotReached() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMinSocNotReached")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// GetMinSocNotReached indicates an expected call of GetPlanActive.
-func (mr *MockAPIMockRecorder) GetMinSocNotReached() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinSocNotReached", reflect.TypeOf((*MockAPI)(nil).GetMinSocNotReached))
 }
 
 // GetPlanActive mocks base method.

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -397,8 +397,8 @@ func (lp *Loadpoint) GetMaxPower() float64 {
 
 // IsFastChargingActive indicates if fast charging with maximum power is active
 func (lp *Loadpoint) IsFastChargingActive() bool {
-	lp.Lock()
-	defer lp.Unlock()
+	lp.RLock()
+	defer lp.RUnlock()
 
 	return lp.mode == api.ModeNow || lp.planActive || lp.minSocNotReached()
 }

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -395,16 +395,12 @@ func (lp *Loadpoint) GetMaxPower() float64 {
 	return Voltage * lp.effectiveMaxCurrent() * float64(lp.maxActivePhases())
 }
 
-// GetMinSocNotReached returns the state of min soc is not reached
-func (lp *Loadpoint) GetMinSocNotReached() bool {
-	return lp.minSocNotReached()
-}
-
-// GetPlanActive returns the active state of the planner
-func (lp *Loadpoint) GetPlanActive() bool {
+// IsFastChargingActive indicates if fast charging with maximum power is active
+func (lp *Loadpoint) IsFastChargingActive() bool {
 	lp.Lock()
 	defer lp.Unlock()
-	return lp.planActive
+
+	return lp.mode == api.ModeNow || lp.planActive || lp.minSocNotReached()
 }
 
 // GetRemainingDuration is the estimated remaining charging duration

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -395,6 +395,11 @@ func (lp *Loadpoint) GetMaxPower() float64 {
 	return Voltage * lp.effectiveMaxCurrent() * float64(lp.maxActivePhases())
 }
 
+// GetMinSocNotReached returns the state of min soc is not reached
+func (lp *Loadpoint) GetMinSocNotReached() bool {
+	return lp.minSocNotReached()
+}
+
 // GetPlanActive returns the active state of the planner
 func (lp *Loadpoint) GetPlanActive() bool {
 	lp.Lock()

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -32,7 +32,7 @@ func (site *Site) SetBatteryMode(batMode api.BatteryMode) {
 
 func (site *Site) determineBatteryMode(loadpoints []loadpoint.API, smartCostActive bool) api.BatteryMode {
 	for _, lp := range loadpoints {
-		if lp.GetStatus() == api.StatusC && (smartCostActive || lp.GetMode() == api.ModeNow || lp.GetPlanActive() || lp.GetMinSocNotReached()) {
+		if lp.GetStatus() == api.StatusC && (smartCostActive || lp.IsFastChargingActive()) {
 			return api.BatteryHold
 		}
 	}

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -32,7 +32,7 @@ func (site *Site) SetBatteryMode(batMode api.BatteryMode) {
 
 func (site *Site) determineBatteryMode(loadpoints []loadpoint.API, smartCostActive bool) api.BatteryMode {
 	for _, lp := range loadpoints {
-		if lp.GetStatus() == api.StatusC && (smartCostActive || lp.GetMode() == api.ModeNow || lp.GetPlanActive()) {
+		if lp.GetStatus() == api.StatusC && (smartCostActive || lp.GetMode() == api.ModeNow || lp.GetPlanActive() || lp.GetMinSocNotReached()) {
 			return api.BatteryHold
 		}
 	}

--- a/core/site_battery_test.go
+++ b/core/site_battery_test.go
@@ -15,21 +15,19 @@ func TestDetermineBatteryMode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	tcs := []struct {
-		chargeStatus     api.ChargeStatus
-		planActive       bool
-		minSocNotReached bool
-		expBatMode       api.BatteryMode
-		mode             api.ChargeMode
+		chargeStatus       api.ChargeStatus
+		fastChargingActive bool
+		smartCostActive    bool
+		expBatMode         api.BatteryMode
 	}{
-		{api.StatusB, false, false, api.BatteryNormal, api.ModeOff},   // mode off -> bat normal
-		{api.StatusB, false, false, api.BatteryNormal, api.ModeNow},   // mode now, not charging -> bat normal
-		{api.StatusC, false, false, api.BatteryHold, api.ModeNow},     // mode now, charging -> bat hold
-		{api.StatusB, false, false, api.BatteryNormal, api.ModeMinPV}, // mode minPV, not charging -> bat normal
-		{api.StatusC, false, false, api.BatteryNormal, api.ModeMinPV}, // mode minPV, charging -> bat normal
-		{api.StatusB, false, false, api.BatteryNormal, api.ModePV},    // mode PV, not charging -> bat normal
-		{api.StatusC, false, false, api.BatteryNormal, api.ModePV},    // mode PV, charging, no planner, minSoc reached -> bat normal
-		{api.StatusC, true, false, api.BatteryHold, api.ModePV},       // mode PV, charging, planner active -> bat hold
-		{api.StatusC, false, true, api.BatteryHold, api.ModePV},       // mode PV, charging, no planner, minSoc not reached -> bat hold
+		{api.StatusB, false, false, api.BatteryNormal}, // not charging | fast charge not active | smart cost not active -> bat normal
+		{api.StatusB, true, false, api.BatteryNormal},  // not charging | fast charge active 	 | smart cost not active -> bat normal
+		{api.StatusC, false, false, api.BatteryNormal}, // charging 	| fast charge not active | smart cost not active -> bat normal
+		{api.StatusC, true, false, api.BatteryHold},    // charging 	| fast charge active 	 | smart cost not active -> bat hold
+		{api.StatusB, false, true, api.BatteryNormal},  // not charging | fast charge not active | smart cost active	 -> bat normal
+		{api.StatusB, true, true, api.BatteryNormal},   // not charging | fast charge active	 | smart cost active	 -> bat normal
+		{api.StatusC, false, true, api.BatteryHold},    // charging 	| fast charge not active | smart cost active	 -> bat hold
+		{api.StatusC, true, true, api.BatteryHold},     // charging 	| fast charge active	 | smart cost active	 -> bat hold
 	}
 
 	log := util.NewLogger("foo")
@@ -41,13 +39,11 @@ func TestDetermineBatteryMode(t *testing.T) {
 
 		lp := loadpoint.NewMockAPI(ctrl)
 		lp.EXPECT().GetStatus().Return(tc.chargeStatus).AnyTimes()
-		lp.EXPECT().GetMode().Return(tc.mode).AnyTimes()
-		lp.EXPECT().GetPlanActive().Return(tc.planActive).AnyTimes()
-		lp.EXPECT().GetMinSocNotReached().Return(tc.minSocNotReached).AnyTimes()
+		lp.EXPECT().IsFastChargingActive().Return(tc.fastChargingActive).AnyTimes()
 
 		loadpoints := []loadpoint.API{lp}
 
-		mode := s.determineBatteryMode(loadpoints, false)
+		mode := s.determineBatteryMode(loadpoints, tc.smartCostActive)
 		assert.Equal(t, tc.expBatMode, mode, tc)
 	}
 }


### PR DESCRIPTION
This PR extents the battery control mechanism to hold the battery also while `minSoc` is not reached, corresponding to #11511.

From my point of view this case should be treated in the same way as when `smartCostActive` or `api.ModeNow` is true.