### PR TITLE
Sunspec: treat NaN as zero

### DIFF
--- a/provider/modbus_sunspec.go
+++ b/provider/modbus_sunspec.go
@@ -112,7 +112,7 @@ func (m *ModbusSunspec) floatGetter() (f float64, err error) {
 		m.op.Block,
 		m.op.Point,
 	)
-	if err != nil {
+	if err != nil && !errors.Is(err, meters.ErrNaN) {
 		return 0, fmt.Errorf("model %d block %d point %s: %w", m.op.Model, m.op.Block, m.op.Point, err)
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/11946

Looking at https://github.com/volkszaehler/mbmd/blob/af16b1f597b9fd402a1410e75a5b4bad5ffc78fc/meters/sunspec/sunspec.go#L209 (the previous codebase) it seems that we can safely treat NaN values as zero. In case of NaN we already know that the model/ block/ point actually exists