### PR TITLE
Easee: adjust logic for opmode consistency

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -853,7 +853,7 @@ func (c *Easee) confirmStatusConsistency() {
 	powerFlowing := c.currentPower > 0
 	c.mux.Unlock()
 
-	if opCharging != powerFlowing || opCharging != pilotCharging {
+	if (!opCharging && powerFlowing) || opCharging != pilotCharging {
 		// poll opMode from charger as API can give outdated data after SignalR (re)connect
 		if time.Since(c.lastOpModePollTriggered) > time.Minute*3 { // api rate limit, max once in 3 minutes
 			uri := fmt.Sprintf("%s/chargers/%s/commands/poll_chargeropmode", easee.API, c.charger)


### PR DESCRIPTION
The logic for determining the need for an CHARGER_OP_MODE poll is over eager.
Currently it will also assume inconsistency when a charger is in mode C but no energy is flowing. However, this is a viable state.

The PR adjusts the logic, so that the relation between charger mode and energy flow is only considered invalid if the charger claims to be not charging (not mode C) and at the same time reports energy flow.