### PR TITLE
Mqtt: add limitEnergy

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -273,6 +273,15 @@ func (m *MQTT) listenLoadpointSetters(topic string, site site.API, lp loadpoint.
 		})
 	}
 	if err == nil {
+		err = m.Handler.ListenSetter(topic+"/limitEnergy", func(payload string) error {
+			energy, err := strconv.ParseFloat(payload, 64)
+			if err == nil {
+				lp.SetLimitEnergy(energy)
+			}
+			return err
+		})
+	}
+	if err == nil {
 		err = m.Handler.ListenSetter(topic+"/planEnergy", func(payload string) error {
 			var plan struct {
 				Time  time.Time `json:"time"`


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/discussions/11780#discussioncomment-8327581

@naltatis mir fällt auf, dass weder `limitSoc` noch `limitEnergy` eine Fehlerbehandlung haben. Müssten wir hier nicht auf Verfügbarkeit des `soc` prüfen?