### PR TITLE
sonnenBatterie: add battery control (APIv2)

### DIFF
--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -1,5 +1,5 @@
 template: sonnenbatterie
-covers: ["sonnenbatterie-eco8", "sonnenbatterie-eco10"]
+covers: ["sonnenbatterie-eco10"]
 products:
   - brand: Sonnen
     description:

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -1,9 +1,16 @@
 template: sonnenbatterie
-covers: ["sonnenbatterie-eco10"]
+covers: ["sonnenbatterie-eco8", "sonnenbatterie-eco10"]
 products:
   - brand: Sonnen
     description:
       generic: sonnenBatterie
+capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Für die aktive Batteriesteuerung muss das "JSON Write API" über das Webinterface der sonnenBatterie aktiviert werden (unter Software-Integration).
+    en: |
+      For active battery control, the "JSON Write API" must be activated via the sonnenBatterie web interface (under Software-Integration).
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -13,6 +20,13 @@ params:
     default: 8080
   - name: capacity
     advanced: true
+  - name: token
+    advanced: true
+    required: false
+    help:
+      de: API Token (benötigt für aktive Batteriesteuerung)
+      en: API Token (required for active battery control)
+    usages: ["battery"]
 render: |
   type: custom
   power:
@@ -31,6 +45,57 @@ render: |
     source: http
     uri: http://{{ .host }}:{{ .port }}/api/v1/status
     jq: .USOC
+  {{- if .token }}
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: http
+        uri: http://{{ .host }}/api/v2/configurations
+        insecure: true
+        method: PUT
+        headers:
+        - content-type: application/json
+        - Auth-Token: {{ .token }}
+        body: '{"EM_OperatingMode":"2"}'  # self consumption
+    - case: 2 # hold
+      set:
+        source: sequence
+        set:
+        - source: http
+          uri: http://{{ .host }}/api/v2/configurations
+          insecure: true
+          method: PUT
+          headers:
+          - content-type: application/json
+          - Auth-Token: {{ .token }}
+          body: '{"EM_OperatingMode":"1"}'  # manual
+        - source: http
+          uri: http://{{ .host }}/api/v2/setpoint/discharge/0
+          insecure: true
+          method: POST
+          headers:
+          - content-type: application/json
+          - Auth-Token: {{ .token }}
+        - source: http
+          uri: http://{{ .host }}/api/v2/setpoint/charge/0
+          insecure: true
+          method: POST
+          headers:
+          - content-type: application/json
+          - Auth-Token: {{ .token }}
+    - case: 3 # charge
+      set:
+        source: http
+        uri: http://{{ .host }}/api/v2/configurations
+        insecure: true
+        method: PUT
+        headers:
+        - content-type: application/json
+        - Auth-Token: {{ .token }}
+        body: '{"EM_OperatingMode":"2"}'  # self consumption
+  {{- end }}
   {{- if .capacity }}
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
This PR introduces active battery control for sonnenBatterie via official sonnenBatterie JSON APIv2.

To use active battery control, the "JSON Write API" must be activated via the sonnenBatterie web interface (under Software-Integration).

This modification has been tested with my sonnenBatterie eco8.

Notes on my implementation:
* This adds a new `token` parameter to the battery template as parameter. It is classified as optional and is only required if active battery control shall be used. This API token can be retrieved from the sonnenBatterie web interface (under Software-Integration)
* Following `batterymode` is only rendered when the `token` parameter is set
* For now `case: 3 (charge)` has the same behavior as `case: 1 (normal)`, as this mode is currently not used.
