### PR TITLE
Fronius Solar API: refine battery control

### DIFF
--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -12,7 +12,7 @@ params:
   - name: capacity
     advanced: true
   - name: user
-    required: false
+    default: customer
   - name: password
     required: false
 render: |
@@ -45,7 +45,7 @@ render: |
         - content-type: application/json
         auth:
           type: digest
-          user: {{- if .user }} {{ .user }}{{- else }} customer{{- end }}
+          user: {{ .user }}
           password: {{ .password }}
         body: '{"timeofuse":[]}'
     - case: 2 # hold
@@ -57,7 +57,7 @@ render: |
         - content-type: application/json
         auth:
           type: digest
-          user: {{- if .user }} {{ .user }}{{- else }} customer{{- end }}
+          user: {{ .user }}
           password: {{ .password }}
         body: '{"timeofuse":[{"Active":true,"Power":0,"ScheduleType":"DISCHARGE_MAX","TimeTable":{"Start":"00:00","End":"23:59"},"Weekdays":{"Mon":true,"Tue":true,"Wed":true,"Thu":true,"Fri":true,"Sat":true,"Sun":true}}]}'
     - case: 3 # charge
@@ -69,7 +69,7 @@ render: |
         - content-type: application/json
         auth:
           type: digest
-          user: {{- if .user }} {{ .user }}{{- else }} customer{{- end }}
+          user: {{ .user }}
           password: {{ .password }}
         body: '{"timeofuse":[]}'
   {{- end }}

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -32,6 +32,7 @@ render: |
     source: http
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi
     jq: .Body.Data.Inverters."1".SOC
+  {{- if .password }}
   batterymode:
     source: switch
     switch:
@@ -44,7 +45,7 @@ render: |
         - content-type: application/json
         auth:
           type: digest
-          user: {{ .user }}
+          user: {{- if .user }} {{ .user }}{{- else }} customer{{- end }}
           password: {{ .password }}
         body: '{"timeofuse":[]}'
     - case: 2 # hold
@@ -56,7 +57,7 @@ render: |
         - content-type: application/json
         auth:
           type: digest
-          user: {{ .user }}
+          user: {{- if .user }} {{ .user }}{{- else }} customer{{- end }}
           password: {{ .password }}
         body: '{"timeofuse":[{"Active":true,"Power":0,"ScheduleType":"DISCHARGE_MAX","TimeTable":{"Start":"00:00","End":"23:59"},"Weekdays":{"Mon":true,"Tue":true,"Wed":true,"Thu":true,"Fri":true,"Sat":true,"Sun":true}}]}'
     - case: 3 # charge
@@ -68,9 +69,10 @@ render: |
         - content-type: application/json
         auth:
           type: digest
-          user: {{ .user }}
+          user: {{- if .user }} {{ .user }}{{- else }} customer{{- end }}
           password: {{ .password }}
         body: '{"timeofuse":[]}'
+  {{- end }}
   {{- if .capacity }}
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
Two improvements:

* Only enable battery control if `password` is set (follow-up of <https://github.com/evcc-io/evcc/pull/11879#issuecomment-1920726133>)
* Use `customer` as default value for the username if `user` is not set - this is the Fronius default (see <https://github.com/evcc-io/evcc/discussions/11711#discussioncomment-8331423>)