### PR TITLE
Clarified phase setting for non 1p3p chargers

### DIFF
--- a/assets/js/components/LoadpointSettingsModal.vue
+++ b/assets/js/components/LoadpointSettingsModal.vue
@@ -34,6 +34,15 @@
 									{{ $t("main.loadpointSettings.phasesConfigured.label") }}
 								</label>
 								<div class="col-sm-8 pe-0">
+									<p v-if="!phases1p3p" class="mt-0 mb-2">
+										<small>
+											{{
+												$t(
+													"main.loadpointSettings.phasesConfigured.no1p3pSupport"
+												)
+											}}</small
+										>
+									</p>
 									<div
 										v-for="phases in phasesOptions"
 										:key="phases"
@@ -179,20 +188,24 @@ export default {
 			return [PHASES_3, PHASES_1];
 		},
 		maxPower: function () {
-			if (this.phasesConfigured === PHASES_AUTO) {
-				return this.maxPowerPhases(3);
-			}
-			if ([PHASES_3, PHASES_1].includes(this.phasesConfigured)) {
-				return this.maxPowerPhases(this.phasesConfigured);
+			if (this.phases1p3p) {
+				if (this.phasesConfigured === PHASES_AUTO) {
+					return this.maxPowerPhases(3);
+				}
+				if ([PHASES_3, PHASES_1].includes(this.phasesConfigured)) {
+					return this.maxPowerPhases(this.phasesConfigured);
+				}
 			}
 			return this.fmtKw(this.maxCurrent * V * this.phasesActive);
 		},
 		minPower: function () {
-			if (this.phasesConfigured === PHASES_AUTO) {
-				return this.minPowerPhases(1);
-			}
-			if ([PHASES_3, PHASES_1].includes(this.phasesConfigured)) {
-				return this.minPowerPhases(this.phasesConfigured);
+			if (this.phases1p3p) {
+				if (this.phasesConfigured === PHASES_AUTO) {
+					return this.minPowerPhases(1);
+				}
+				if ([PHASES_3, PHASES_1].includes(this.phasesConfigured)) {
+					return this.minPowerPhases(this.phasesConfigured);
+				}
 			}
 			return this.fmtKw(this.minCurrent * V * this.phasesActive);
 		},

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -233,6 +233,7 @@ label = "Min. Ladung %"
 
 [main.loadpointSettings.phasesConfigured]
 label = "Phasen"
+no1p3pSupport = "Wie ist deine Wallbox angeschlossen?"
 phases_0 = "automatischer Wechsel"
 phases_1 = "1-phasig"
 phases_1_hint = "({min} bis {max})"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -274,6 +274,7 @@ label = "Min. charge %"
 
 [main.loadpointSettings.phasesConfigured]
 label = "Phases"
+no1p3pSupport = "How is your charger connected?"
 phases_0 = "auto-switching"
 phases_1 = "1 phase"
 phases_1_hint = "({min} to {max})"


### PR DESCRIPTION
fixes #12013

- 🏷️ added expaination for non 1p3p chargers
- 🚥 calculate min/maxpower based on active phases if phase switching isnt supported


![Bildschirmfoto 2024-02-02 um 17 13 50](https://github.com/evcc-io/evcc/assets/152287/28bbc68b-2b13-4e50-a057-60523f760245)
