### PR TITLE
Fix yaml meters added to dynamic config

### DIFF
--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -32,8 +32,9 @@ const (
 	Vehicles              = "vehicles"
 
 	// meters
+	AuxMeters     = "auxMeters"
 	BatteryMeters = "batteryMeters"
-	GridMeter     = "GridMeter"
+	GridMeter     = "gridMeter"
 	PvMeters      = "pvMeters"
 
 	// battery settings

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -32,10 +32,10 @@ const (
 	Vehicles              = "vehicles"
 
 	// meters
-	AuxMeters     = "auxMeters"
-	BatteryMeters = "batteryMeters"
 	GridMeter     = "gridMeter"
 	PvMeters      = "pvMeters"
+	BatteryMeters = "batteryMeters"
+	AuxMeters     = "auxMeters"
 
 	// battery settings
 	BatteryCapacity         = "batteryCapacity"

--- a/core/site.go
+++ b/core/site.go
@@ -247,6 +247,9 @@ func (site *Site) restoreMeters() {
 	if v, err := settings.String(keys.BatteryMeters); err == nil && v != "" {
 		site.Meters.BatteryMetersRef = append(site.Meters.BatteryMetersRef, strings.Split(v, ",")...)
 	}
+	if v, err := settings.String(keys.AuxMeters); err == nil && v != "" {
+		site.Meters.AuxMetersRef = append(site.Meters.AuxMetersRef, strings.Split(v, ",")...)
+	}
 }
 
 // restoreSettings restores site settings

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -121,7 +121,6 @@ func (site *Site) SetAuxMeterRefs(ref []string) {
 	defer site.Unlock()
 
 	site.Meters.AuxMetersRef = ref
-	// site.publish("siteGridMeterRef", meter)
 	settings.SetString(keys.AuxMeters, strings.Join(filterConfigurable(ref), ","))
 }
 

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -87,7 +87,6 @@ func (site *Site) SetPVMeterRefs(ref []string) {
 	defer site.Unlock()
 
 	site.Meters.PVMetersRef = ref
-	// site.publish("siteGridMeterRef", meter)
 	settings.SetString(keys.PvMeters, strings.Join(filterConfigurable(ref), ","))
 }
 

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -103,7 +103,6 @@ func (site *Site) SetBatteryMeterRefs(ref []string) {
 	defer site.Unlock()
 
 	site.Meters.BatteryMetersRef = ref
-	// site.publish("siteGridMeterRef", meter)
 	settings.SetString(keys.BatteryMeters, strings.Join(filterConfigurable(ref), ","))
 }
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/12026

This PR prevents yaml meters- expect for grid- being added to dynamic config. `yaml` meter references are always treated as present. If removed from yaml they are not removed from dynamic config, too.

Also added `aux` meters for completeness.