### PR TITLE
Allow buffersoc = prioritysoc

### DIFF
--- a/core/site_api.go
+++ b/core/site_api.go
@@ -184,7 +184,7 @@ func (site *Site) SetBufferSoc(soc float64) error {
 	}
 
 	if soc != 0 && soc < site.prioritySoc {
-		return errors.New("buffer soc must be larger than priority soc")
+		return errors.New("buffer soc must not be smaller than priority soc")
 	}
 
 	if site.bufferStartSoc != 0 && soc > site.bufferStartSoc {

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -183,7 +183,7 @@ func (site *Site) SetBufferSoc(soc float64) error {
 		return ErrBatteryNotConfigured
 	}
 
-	if soc != 0 && soc <= site.prioritySoc {
+	if soc != 0 && soc < site.prioritySoc {
 		return errors.New("buffer soc must be larger than priority soc")
 	}
 


### PR DESCRIPTION
Allow buffersoc to be equal to prioritysoc. This is also allowed by the battery settings UI. Rejecting this state currently leads to strange out-of-sync behaviour in the UI.

@andig this check was introduced in https://github.com/evcc-io/evcc/pull/10335. Do you know if there was any reason why the check was added in this way? Or just an oversight while refactoring?