### PR TITLE
Tronity: update api endpoints and oauth scopes

### DIFF
--- a/vehicle/tronity.go
+++ b/vehicle/tronity.go
@@ -165,7 +165,7 @@ func (v *Tronity) RefreshToken(_ *oauth2.Token) (*oauth2.Token, error) {
 
 // vehicles implements the vehicles api
 func (v *Tronity) vehicles() ([]tronity.Vehicle, error) {
-	uri := fmt.Sprintf("%s/v1/vehicles", tronity.URI)
+	uri := fmt.Sprintf("%s/tronity/vehicles", tronity.URI)
 
 	var res tronity.Vehicles
 	err := v.GetJSON(uri, &res)
@@ -175,7 +175,7 @@ func (v *Tronity) vehicles() ([]tronity.Vehicle, error) {
 
 // bulk implements the bulk api
 func (v *Tronity) bulk() (tronity.Bulk, error) {
-	uri := fmt.Sprintf("%s/v1/vehicles/%s/bulk", tronity.URI, v.vid)
+	uri := fmt.Sprintf("%s/tronity/vehicles/%s/last_record", tronity.URI, v.vid)
 
 	var res tronity.Bulk
 	err := v.GetJSON(uri, &res)
@@ -235,12 +235,12 @@ func (v *Tronity) post(uri string) error {
 
 // startCharge implements the api.VehicleChargeController interface
 func (v *Tronity) startCharge() error {
-	uri := fmt.Sprintf("%s/v1/vehicles/%s/charge_start", tronity.URI, v.vid)
+	uri := fmt.Sprintf("%s/tronity/vehicles/%s/start_charging", tronity.URI, v.vid)
 	return v.post(uri)
 }
 
 // stopCharge implements the api.VehicleChargeController interface
 func (v *Tronity) stopCharge() error {
-	uri := fmt.Sprintf("%s/v1/vehicles/%s/charge_stop", tronity.URI, v.vid)
+	uri := fmt.Sprintf("%s/tronity/vehicles/%s/stop_charging", tronity.URI, v.vid)
 	return v.post(uri)
 }

--- a/vehicle/tronity/auth.go
+++ b/vehicle/tronity/auth.go
@@ -4,15 +4,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const URI = "https://api-eu.tronity.io"
+const URI = "https://api.tronity.tech"
 
 func OAuth2Config(id, secret string) (*oauth2.Config, error) {
 	return &oauth2.Config{
 		ClientID:     id,
 		ClientSecret: secret,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  "https://api-eu.tronity.io/oauth/authorize",
-			TokenURL: "https://api-eu.tronity.io/oauth/authentication",
+			AuthURL:  "https://auth.tronity.io/oauth/v2/authorize",
+			TokenURL: "https://api.tronity.tech/authentication",
 		},
 		Scopes: []string{"read_vin", "read_vehicle_info", "read_odometer", "read_charge", "read_charge", "read_battery", "read_location", "write_charge_start_stop", "write_wake_up"},
 	}, nil

--- a/vehicle/tronity/types.go
+++ b/vehicle/tronity/types.go
@@ -1,16 +1,11 @@
 package tronity
 
-// https://app.platform.tronity.io/docs#operation
+// https://app.tronity.tech/docs#section/Authentication-Flow
 
 const (
-	ReadBattery          = "read_battery"            // Read EV battery's capacity and state of charge
-	ReadCharge           = "read_charge"             // Know whether vehicle is charging
-	ReadLocation         = "read_location"           // Access location
-	ReadOdometer         = "read_odometer"           // Retrieve total distance traveled
-	ReadVehicleInfo      = "read_vehicle_info"       // Know make, model, and year
-	ReadVIN              = "read_vin"                // Read VIN
-	WriteChargeStartStop = "write_charge_start_stop" // Start or stop your vehicle's charging
-	WriteWakeUp          = "write_wake_up"           // Wake up car. Only valid for Tesla
+	ReadCharge           = "tronity_charging" // Know whether vehicle is charging
+	ReadOdometer         = "tronity_odometer" // Retrieve total distance traveled
+	WriteChargeStartStop = "tronity_control_charging"
 )
 
 type Vehicles struct {
@@ -26,7 +21,6 @@ type Vehicle struct {
 }
 
 type Bulk struct {
-	VIN      string
 	Odometer float64
 	Range    float64
 	Level    float64


### PR DESCRIPTION
The tronity api endpoints and the oauth scopes have changed.

### Endpoint

Set api endpoints to https://api.tronity.tech

### OAuth Scopes

Updated to the scope names documented here: https://app.tronity.tech/docs#section/Scopes