### PR TITLE
Easee: enumerate chargers for logger

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -102,7 +103,8 @@ func NewEaseeFromConfig(other map[string]interface{}) (api.Charger, error) {
 
 // NewEasee creates Easee charger
 func NewEasee(user, password, charger string, timeout time.Duration, authorize bool) (*Easee, error) {
-	log := util.NewLogger("easee").Redact(user, password)
+	easee.InstanceCount++
+	log := util.NewLogger("easee-"+strconv.Itoa(easee.InstanceCount)).Redact(user, password)
 
 	if !sponsor.IsAuthorized() {
 		return nil, api.ErrSponsorRequired

--- a/charger/easee/log.go
+++ b/charger/easee/log.go
@@ -8,6 +8,9 @@ import (
 	"github.com/philippseith/signalr"
 )
 
+// enumerate instances
+var InstanceCount = 0
+
 // Logger is a simple logger interface
 type Logger interface {
 	Println(v ...interface{})


### PR DESCRIPTION
Small change to have proper separation of log messages for installations with more than a single Easee charger. Will help with debugging issues in such installations.