### PR TITLE
chore: Disable blank issues and add link to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/evcc-io/evcc/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
Damit sieht https://github.com/evcc-io/evcc/issues/new/choose so aus: ![grafik](https://github.com/evcc-io/evcc/assets/4662023/5e01dbf9-b0c6-492a-861f-f8c2a372b8b8)
statt wie bisher so 
![grafik](https://github.com/evcc-io/evcc/assets/4662023/705fba69-0548-47cd-a0b4-7991d6f4be7a)

Ich hoffe, dass führt zu weniger Issues die eine discussion hätten sein sollen.

Documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser