### PR TITLE
Easee: always adjust DCC after resuming charge

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -488,7 +488,7 @@ func (c *Easee) Enable(enable bool) (err error) {
 		return err
 	}
 
-	if c.authorize { // authenticating charger does not mingle with DCC, no need for below operations
+	if action == easee.ChargeStart { // ChargeStart does not mingle with DCC, no need for below operations
 		return nil
 	}
 


### PR DESCRIPTION
possibly fix #11988 (logs were not sufficient in the reported discussion)

I observed today a case in which my evcc installation did not use the `start_charge` but the `resume_charge` command, although my charger is setup to require authentication, and evcc is configured to perform this. (`authorize:true`)

I realized that this can happen every time a charge is paused, and then continued. As the vehicle is not disconnected, the initial authentication on the charger is still valid. This means the charger does not go into OP_MODE 7 again to re-request authentication. Evcc correctly uses the `resume_charge` command in this case.

The logic for DCC correction in `Enable()` however does not distinguish these two different situations, and just a assumes that if authentication is configured that `resume_charge` is never used. This is wrong.

This change adjusts the decision to do DCC correction based on the performed action instead.