### PR TITLE
Shelly Pro EM - 50 Support

### DIFF
--- a/meter/shelly/switch.go
+++ b/meter/shelly/switch.go
@@ -53,7 +53,7 @@ func (sh *Switch) CurrentPower() (float64, error) {
 		case 2:
 			power = res.Switch2.Apower
 		default:
-			power = res.Switch0.Apower
+			power = res.Switch0.Apower + res.Em0.Act_power + res.Em1.Act_power + res.Em2.Act_power
 		}
 	}
 
@@ -134,7 +134,7 @@ func (sh *Switch) TotalEnergy() (float64, error) {
 		case 2:
 			energy = res.Switch2.Aenergy.Total
 		default:
-			energy = res.Switch0.Aenergy.Total
+			energy = res.Switch0.Aenergy.Total + res.Em0.Total_act_energy + res.Em1.Total_act_energy + res.Em2.Total_act_energy
 		}
 	}
 

--- a/meter/shelly/types.go
+++ b/meter/shelly/types.go
@@ -25,8 +25,11 @@ type Gen2SwitchResponse struct {
 }
 
 type Gen2Switch struct {
-	Apower  float64
-	Aenergy struct {
+	Act_power            float64
+	Total_act_energy     float64
+	Total_act_ret_energy float64
+	Apower               float64
+	Aenergy              struct {
 		Total float64
 	}
 }
@@ -35,6 +38,12 @@ type Gen2StatusResponse struct {
 	Switch0 Gen2Switch `json:"switch:0"`
 	Switch1 Gen2Switch `json:"switch:1"`
 	Switch2 Gen2Switch `json:"switch:2"`
+	Em0     Gen2Switch `json:"em1:0"`
+	Em1     Gen2Switch `json:"em1:1"`
+	Em2     Gen2Switch `json:"em1:2"`
+	Data0   Gen2Switch `json:"em1data:0"`
+	Data1   Gen2Switch `json:"em1data:1"`
+	Data2   Gen2Switch `json:"em1data:2"`
 }
 
 type Gen2EmStatusResponse struct {

--- a/meter/shelly/types_test.go
+++ b/meter/shelly/types_test.go
@@ -46,12 +46,29 @@ func TestUnmarshalGen1StatusResponse(t *testing.T) {
 
 // Test Gen2StatusResponse response
 func TestUnmarshalGen2StatusResponse(t *testing.T) {
-	// Shelly Pro 1PM channel 0 (1)
-	var res Gen2StatusResponse
+	{
+		// Shelly Pro 1PM channel 0 (1)
+		var res Gen2StatusResponse
 
-	jsonstr := `{"ble":{},"cloud":{"connected":true},"eth":{"ip":null},"input:0":{"id":0,"state":false},"input:1":{"id":1,"state":false},"mqtt":{"connected":false},"switch:0":{"id":0, "source":"HTTP", "output":false, "apower":47.11, "voltage":232.0, "current":0.000, "pf":0.00, "aenergy":{"total":5.125,"by_minute":[0.000,0.000,0.000],"minute_ts":1675718520},"temperature":{"tC":25.3, "tF":77.5}},"sys":{"mac":"30C6F78BB4D8","restart_required":false,"time":"22:22","unixtime":1675718522,"uptime":45070,"ram_size":234204,"ram_free":137716,"fs_size":524288,"fs_free":172032,"cfg_rev":13,"kvs_rev":1,"schedule_rev":0,"webhook_rev":0,"available_updates":{"beta":{"version":"0.13.0-beta3"}}},"wifi":{"sta_ip":"192.168.178.64","status":"got ip","ssid":"***","rssi":-62},"ws":{"connected":false}}`
-	require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+		jsonstr := `{"ble":{},"cloud":{"connected":true},"eth":{"ip":null},"input:0":{"id":0,"state":false},"input:1":{"id":1,"state":false},"mqtt":{"connected":false},"switch:0":{"id":0, "source":"HTTP", "output":false, "apower":47.11, "voltage":232.0, "current":0.000, "pf":0.00, "aenergy":{"total":5.125,"by_minute":[0.000,0.000,0.000],"minute_ts":1675718520},"temperature":{"tC":25.3, "tF":77.5}},"sys":{"mac":"30C6F78BB4D8","restart_required":false,"time":"22:22","unixtime":1675718522,"uptime":45070,"ram_size":234204,"ram_free":137716,"fs_size":524288,"fs_free":172032,"cfg_rev":13,"kvs_rev":1,"schedule_rev":0,"webhook_rev":0,"available_updates":{"beta":{"version":"0.13.0-beta3"}}},"wifi":{"sta_ip":"192.168.178.64","status":"got ip","ssid":"***","rssi":-62},"ws":{"connected":false}}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
 
-	assert.Equal(t, 5.125, res.Switch0.Aenergy.Total)
-	assert.Equal(t, 47.11, res.Switch0.Apower)
+		assert.Equal(t, 5.125, res.Switch0.Aenergy.Total)
+		assert.Equal(t, 47.11, res.Switch0.Apower)
+	}
+
+	{
+		// Shelly Pro EM - 50 channel 0 (1)
+		var res Gen2StatusResponse
+
+		jsonstr := `{"ble":{},"cloud":{"connected":false},"em1:0":{"id":0,"current":0.020,"voltage":232.2,"act_power":1.2,"aprt_power":4.7,"pf":0.00, "freq":50.0,"calibration":"factory"},"em1:1":{"id":1,"current":0.025,"voltage":232.2,"act_power":2.2,"aprt_power":5.8,"pf":0.00, "freq":50.0,"calibration":"factory"},"em1data:0":{"id":0,"total_act_energy":8.88,"total_act_ret_energy":9.99},"em1data:1":{"id":1,"total_act_energy":6644.89,"total_act_ret_energy":2595.25},"eth":{"ip":null},"modbus":{},"mqtt":{"connected":true},"switch:0":{"id":0, "source":"HTTP_in", "output":true,"temperature":{"tC":29.5, "tF":85.0}},"sys":{"mac":"08F9E0E67204","restart_required":false,"time":"18:15","unixtime":1707930953,"uptime":28960,"ram_size":241936,"ram_free":117100,"fs_size":524288,"fs_free":208896,"cfg_rev":20,"kvs_rev":0,"schedule_rev":0,"webhook_rev":0,"available_updates":{"stable":{"version":"1.2.0"}},"reset_reason":3},"wifi":{"sta_ip":"192.168.8.9","status":"got ip","ssid":"K1","rssi":-59},"ws":{"connected":false}}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+
+		assert.Equal(t, 1.2, res.Em0.Act_power)
+		assert.Equal(t, 8.88, res.Data0.Total_act_energy)
+		assert.Equal(t, 9.99, res.Data0.Total_act_ret_energy)
+		assert.Equal(t, 2.2, res.Em1.Act_power)
+		assert.Equal(t, 6644.89, res.Data1.Total_act_energy)
+		assert.Equal(t, 2595.25, res.Data1.Total_act_ret_energy)
+	}
 }


### PR DESCRIPTION
Enable Shelly Pro EM - 50 energy meter channels for the shelly charger.

Device documentation: https://www.shelly.com/de/products/shop/shelly-pro-em-2x50-a

Refer to #12252 (no issue but feature request)

Change is adding EM 50 meter values in power and energy calculation. This device provides 2 energy meter channels and one phase switch. The meter values of the two em channels are summarized.
Do be prepared for future 3-phase meters a third set of meter values was added.