### PR TITLE
Config UI: move generic meters to top

### DIFF
--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -45,6 +45,16 @@
 									class="form-select w-100"
 								>
 									<option
+										v-for="option in genericOptions"
+										:key="option.name"
+										:value="option.template"
+									>
+										{{ option.name }}
+									</option>
+									<option v-if="genericOptions.length" disabled>
+										──────────
+									</option>
+									<option
 										v-for="option in templateOptions"
 										:key="option.name"
 										:value="option.template"
@@ -52,6 +62,7 @@
 										{{ option.name }}
 									</option>
 								</select>
+								{{ templateName }}
 							</FormRow>
 							<p v-if="loadingTemplate">Loading ...</p>
 							<Modbus
@@ -198,7 +209,10 @@ export default {
 			return this.type || this.selectedType;
 		},
 		templateOptions() {
-			return this.products;
+			return this.products.filter((p) => p.group !== "generic");
+		},
+		genericOptions() {
+			return this.products.filter((p) => p.group === "generic");
 		},
 		templateParams() {
 			const params = this.template?.Params || [];

--- a/templates/definition/meter/sunspec-battery-control.yaml
+++ b/templates/definition/meter/sunspec-battery-control.yaml
@@ -1,8 +1,8 @@
 template: sunspec-battery-control
 products:
   - description:
-      de: Sunspec Batterie (Model 802)
-      en: Sunspec Battery (Model 802)
+      de: SunSpec Batterie (Model 802)
+      en: SunSpec Battery (Model 802)
 capabilities: ["battery-control"]
 group: generic
 params:

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -2,8 +2,8 @@ template: sunspec-hybrid
 covers: ["sunspec-hybrid-inverter"]
 products:
   - description:
-      de: Hybridwechselrichter
-      en: Hybrid Inverter
+      de: SunSpec Hybridwechselrichter
+      en: SunSpec Hybrid Inverter
 group: generic
 params:
   - name: usage

--- a/templates/definition/meter/sunspec-inverter-control.yaml
+++ b/templates/definition/meter/sunspec-inverter-control.yaml
@@ -1,8 +1,8 @@
 template: sunspec-inverter-control
 products:
   - description:
-      de: Sunspec Batterie (Model 124)
-      en: Sunspec Battery (Model 124)
+      de: SunSpec Batterie (Model 124)
+      en: SunSpec Battery (Model 124)
 capabilities: ["battery-control"]
 group: generic
 params:

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -1,8 +1,8 @@
 template: sunspec-inverter
 products:
   - description:
-      de: Wechselrichter
-      en: Inverter
+      de: SunSpec Wechselrichter
+      en: SunSpec Inverter
 group: generic
 params:
   - name: usage


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/12166

@premultiply Ist es richtig, dass der "normale" SunSpec Wechselrichter auch usage=battery hat?

<img width="933" alt="Bildschirmfoto 2024-02-15 um 20 26 33" src="https://github.com/evcc-io/evcc/assets/152287/aee1f3e1-a356-4735-9e98-47849f2a25cb">

<img width="784" alt="Bildschirmfoto 2024-02-15 um 20 26 43" src="https://github.com/evcc-io/evcc/assets/152287/0eae36e6-aa30-4a2c-af64-9b3de2a7147d">
