### PR TITLE
Fronius Solar API: don't set mask here as it is the default

### DIFF
--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -22,7 +22,6 @@ params:
       en: Username (for battery control)
   - name: password
     required: false
-    mask: true
     description:
       de: Passwort (für aktive Batteriesteuerung)
       en: Password (for battery control)


### PR DESCRIPTION
Follow-up of #12310.