### PR TITLE
Fronius Solar API: Explain limitations of active battery control

### DIFF
--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -6,8 +6,14 @@ products:
 capabilities: ["battery-control"]
 requirements:
   description:
-    de: Benutzername und Passwort werden nur für die aktive Batteriesteuerung benötigt.
-    en: Username and password are only required for battery control.
+    de: |
+      Benutzername und Passwort werden nur für die aktive Batteriesteuerung benötigt.
+
+      **Achtung**: Die aktive Batteriesteuerung sollte nur verwendet werden, wenn keine weiteren Einstellungen für die zeitabhängige Batteriesteuerung in der Wechselrichter-Konfiguration unter "Energiemanagement" - "Batteriemanagement" getätigt wurden, denn bestehende Einstellungen werden überschrieben.
+    en: |
+      Username and password are only required for active battery control.
+
+      **Attention**: Active battery control should only be used if no other settings for time-dependent battery control were made in the inverter configuration under "Energy Management" - "Battery Management", as existing settings will be overwritten.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -19,12 +25,12 @@ params:
     default: customer
     description:
       de: Benutzername (für aktive Batteriesteuerung)
-      en: Username (for battery control)
+      en: Username (for active battery control)
   - name: password
     required: false
     description:
       de: Passwort (für aktive Batteriesteuerung)
-      en: Password (for battery control)
+      en: Password (for active battery control)
 render: |
   type: custom
   power:


### PR DESCRIPTION
Follow-up of #12303. Used pre-existing formatting from <https://github.com/evcc-io/evcc/blob/master/templates/definition/meter/solax-hybrid-cloud.yaml>.