### PR TITLE
Add support for Amber Electric (AU)

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -183,6 +183,11 @@ tariffs:
     # charges: # optional, additional charges per kWh
     # tax: # optional, additional tax (0.1 for 10%)
 
+    # type: amber
+    # token: # api token from https://app.amber.com.au/developers/
+    # siteid: # site ID returned by the API
+    # channel: general
+
     # type: custom # price from a plugin source; see https://docs.evcc.io/docs/reference/plugins
     # price:
     #   source: http
@@ -197,6 +202,11 @@ tariffs:
     # type: octopusenergy
     # tariff: AGILE-FLEX-22-11-25 # Tariff code
     # region: A # optional
+
+    # type: amber
+    # token: # api token from https://app.amber.com.au/developers/
+    # siteid: # site ID returned by the API
+    # channel: feedIn
   co2:
     # co2 tariff provides co2 intensity forecast and is for co2-optimized target charging if no variable grid tariff is specified
     # type: grünstromindex # GrünStromIndex (Germany only)

--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -1,0 +1,136 @@
+package tariff
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/tariff/amber"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+	"golang.org/x/exp/slices"
+)
+
+type Amber struct {
+	*embed
+	*request.Helper
+	log     *util.Logger
+	uri     string
+	channel string
+	data    *util.Monitor[api.Rates]
+}
+
+var _ api.Tariff = (*Amber)(nil)
+
+func init() {
+	registry.Add("amber", NewAmberFromConfig)
+}
+
+func NewAmberFromConfig(other map[string]interface{}) (api.Tariff, error) {
+	var cc struct {
+		embed   `mapstructure:",squash"`
+		Token   string
+		SiteID  string
+		Channel string
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.Token == "" {
+		return nil, errors.New("missing token")
+	}
+
+	if cc.SiteID == "" {
+		return nil, errors.New("missing siteid")
+	}
+
+	if cc.Channel == "" {
+		return nil, errors.New("missing channel")
+	}
+
+	log := util.NewLogger("amber").Redact(cc.Token)
+
+	t := &Amber{
+		embed:   &cc.embed,
+		log:     log,
+		Helper:  request.NewHelper(log),
+		uri:     fmt.Sprintf(amber.URI, strings.ToUpper(cc.SiteID), time.Now().AddDate(0, 0, 1).Format("2006-01-02")),
+		channel: strings.ToLower(cc.Channel),
+		data:    util.NewMonitor[api.Rates](2 * time.Hour),
+	}
+
+	t.Client.Transport = &transport.Decorator{
+		Base: t.Client.Transport,
+		Decorator: transport.DecorateHeaders(map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", cc.Token),
+		}),
+	}
+
+	done := make(chan error)
+	go t.run(done)
+	err := <-done
+
+	return t, err
+}
+
+func (t *Amber) run(done chan error) {
+	var once sync.Once
+	bo := newBackoff()
+
+	for ; true; <-time.Tick(time.Minute) {
+		var res []amber.PriceInfo
+
+		if err := backoff.Retry(func() error {
+			return t.GetJSON(t.uri, &res)
+		}, bo); err != nil {
+			once.Do(func() { done <- err })
+
+			t.log.ERROR.Println(err)
+			continue
+		}
+
+		data := make(api.Rates, 0, len(res))
+
+		for _, r := range res {
+			if t.channel == strings.ToLower(r.ChannelType) {
+				startTime, _ := time.Parse("2006-01-02T15:04:05Z", r.StartTime)
+				endTime, _ := time.Parse("2006-01-02T15:04:05Z", r.EndTime)
+				ar := api.Rate{
+					Start: startTime.Local(),
+					End:   endTime.Local(),
+					Price: r.PerKwh / 1e2,
+				}
+				data = append(data, ar)
+			}
+		}
+		data.Sort()
+
+		t.data.Set(data)
+		once.Do(func() { close(done) })
+	}
+}
+
+// Rates implements the api.Tariff interface
+func (t *Amber) Rates() (api.Rates, error) {
+	var res api.Rates
+	err := t.data.GetFunc(func(val api.Rates) {
+		res = slices.Clone(val)
+	})
+	return res, err
+}
+
+func (t *Amber) Unit() string {
+	return "AUD"
+}
+
+// Type returns the tariff type
+func (t *Amber) Type() api.TariffType {
+	return api.TariffTypePriceForecast
+}

--- a/tariff/amber/types.go
+++ b/tariff/amber/types.go
@@ -1,0 +1,19 @@
+package amber
+
+const URI = "https://api.amber.com.au/v1/sites/%s/prices?endDate=%s&resolution=30"
+
+type PriceInfo struct {
+	Type        string  `json:"type"`
+	Date        string  `json:"date"`
+	Duration    int     `json:"duration"`
+	StartTime   string  `json:"startTime"`
+	EndTime     string  `json:"endTime"`
+	NemTime     string  `json:"nemTime"`
+	PerKwh      float64 `json:"perKwh"`
+	Renewables  float64 `json:"renewables"`
+	SpotPerKwh  float64 `json:"spotPerKwh"`
+	ChannelType string  `json:"channelType"`
+	SpikeStatus string  `json:"spikeStatus"`
+	Descriptor  string  `json:"descriptor"`
+	Estimate    bool    `json:"estimate"`
+}

--- a/templates/definition/tariff/amber.yaml
+++ b/templates/definition/tariff/amber.yaml
@@ -1,0 +1,14 @@
+template: amber
+products:
+  - brand: Amber Electric
+params:
+  - preset: tariff-base
+  - name: token
+  - name: siteid
+  - name: channel
+render: |
+  type: amber
+  {{ include "tariff-base" . }}
+  token: {{ .token }}
+  siteid: {{ .siteid }}
+  channel: {{ .channel }}


### PR DESCRIPTION
I'm fairly new to Golang so I'd appreciate any comments on how this code might be improved.

This adds support for [Amber Electric](https://www.amber.com.au/) (Australia) as a variable tarriff, for both grid imports and exports (feed-in.)

API documentation is available at https://app.amber.com.au/developers/ though unfortunately you need an account to obtain an API token.

The API returns both import and export pricing in the one call, so the result needs to be filtered by "channel", which can be `general`, `feedIn`, or another one for controlled loads (I don't have any, so I can't confirm what this looks like)

One striking difference to other variable tarriffs in evcc is that I have this updating every minute. [Most people using the Amber API tend to use this interval](https://github.com/amberelectric/public-api/discussions/146) (the official Home Assistant integration also polls every minute). The prices tend to fluctuate and can make sudden movements, so it's fairly important to keep this up to date. If 1 minute is not acceptable, 5 minutes is likely OK, but hourly would be too infrequent. As an example we had a swing from around $0.10 to around $19.00 (yes, really) last week due to a sudden fault causing spot prices to skyrocket. I'd have not wanted my charging to continue at full power for another hour until the next refresh, as this would have cost a bomb!

Screenshots attached of a local build, compared to what Amber's site is showing me presently:
<img width="1316" alt="Screenshot 2024-02-21 at 4 19 18 pm" src="https://github.com/evcc-io/evcc/assets/2508364/c3a4f6bc-fe68-40e6-9496-285efb835b79">


<img width="861" alt="Screenshot 2024-02-21 at 4 19 26 pm" src="https://github.com/evcc-io/evcc/assets/2508364/66774671-4a25-457a-a788-8cf267990787">
<img width="1623" alt="Screenshot 2024-02-21 at 4 20 05 pm" src="https://github.com/evcc-io/evcc/assets/2508364/b3902c70-62c0-4dfb-9d7d-dc32e00896d3">
