### PR TITLE
RCT: fix retrying recoverable errors

### DIFF
--- a/meter/rct.go
+++ b/meter/rct.go
@@ -83,8 +83,7 @@ func NewRCT(uri, usage string, cache time.Duration, capacity func() float64) (ap
 
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 10 * time.Millisecond
-	bo.MaxInterval = time.Second
-	bo.MaxElapsedTime = 10 * time.Second
+	bo.MaxElapsedTime = time.Second
 
 	m := &RCT{
 		usage: strings.ToLower(usage),

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -175,8 +175,8 @@ func (m *RCT) queryFloat(id rct.Identifier) (float64, error) {
 
 	res, err := backoff.RetryWithData(func() (float32, error) {
 		res, err := m.conn.QueryFloat32(id)
-		if err != nil && !errors.Is(err, rct.RecoverableError{}) {
-			err = &backoff.PermanentError{Err: err}
+		if !errors.Is(err, rct.RecoverableError{}) {
+			err = backoff.Permanent(err)
 		}
 		return res, err
 	}, m.bo)


### PR DESCRIPTION
Existing logic is broken since library returns plain error, not pointer. This PR should now retry for 1s with exponentional backoff.