### PR TITLE
Fix porsche API

### DIFF
--- a/vehicle/porsche/api_emobility.go
+++ b/vehicle/porsche/api_emobility.go
@@ -36,7 +36,7 @@ func NewEmobilityAPI(log *util.Logger, identity oauth2.TokenSource) *EmobilityAP
 
 func (v *EmobilityAPI) Capabilities(vin string) (CapabilitiesResponse, error) {
 	var res CapabilitiesResponse
-	uri := fmt.Sprintf("%s/e-mobility/vcs/capabilities/%s", ApiURI, vin)
+	uri := fmt.Sprintf("%s/service-vehicle/vcs/capabilities/%s", ApiURI, vin)
 	err := v.GetJSON(uri, &res)
 	return res, err
 }


### PR DESCRIPTION
Change Capabilities URI from defunct e-mobility/vcs/capabilities to working service-vehicle/vcs/capabilities
Fix https://github.com/evcc-io/evcc/issues/12493 (hopefully)