### PR TITLE
Mercedes: Fix HTTP502 when VIN is present and not equal to FIN

### DIFF
--- a/vehicle/mercedes/api.go
+++ b/vehicle/mercedes/api.go
@@ -48,7 +48,11 @@ func (v *API) Vehicles() ([]string, error) {
 
 	var vehicles []string
 	for _, v := range res.AssignedVehicles {
-		vehicles = append(vehicles, v.Fin)
+		if len(v.Vin) > 0 {
+			vehicles = append(vehicles, v.Vin)
+		} else {
+			vehicles = append(vehicles, v.Fin)
+		}
 	}
 
 	return vehicles, err

--- a/vehicle/mercedes/types.go
+++ b/vehicle/mercedes/types.go
@@ -42,6 +42,7 @@ type VehiclesResponse struct {
 
 type Vehicle struct {
 	Fin string
+	Vin string
 }
 
 type StatusResponse struct {


### PR DESCRIPTION
Goal of the PR: Handling the scenario when a vehicle has a VIN in the master data that differs from the FIN
Fixes: #12533


Whenever this happens the VIN has to be used for the communication with the MB API.
Sorry, missed this when converting the code from HA to evcc.