### PR TITLE
Chrome CORS fix for private http ressources

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -40,6 +40,15 @@ func NewHTTPd(addr string, hub *SocketHub) *HTTPd {
 		return etag.Handler(h, false)
 	})
 
+	// allow requesting http assets from a non-private host. see https://developer.chrome.com/blog/cors-rfc1918-feedback?hl=de#step-2:-sending-preflight-requests-with-a-special-header
+	static.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Private-Network", "true")
+			next.ServeHTTP(w, r)
+		})
+	})
+
 	static.HandleFunc("/", indexHandler())
 	for _, dir := range []string{"assets", "meta"} {
 		static.PathPrefix("/" + dir).Handler(http.FileServer(http.FS(assets.Web)))


### PR DESCRIPTION
fixes #12534

This is not a pretty solution since it disables chromes new CORS check to prevent CSRF measures. This PR only adds exceptions for static assets. So it's not critical and hopefully sufficient for fixing the issue.

For a proper and secure solution, we need to think about switching to HTTPS (self-signed) by default and/or adding authentication (WIP).