### PR TITLE
Mercedes: Update doc - Token command when multiple vehicles in config

### DIFF
--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -16,7 +16,7 @@ requirements:
               vin: W... # Erforderlich, wenn mehr als ein Fahrzeug im Account registriert
               capacity: 50 # Akkukapazität in kWh (optional)
           ```
-        2. Ausführen von "./evcc token mercedes" zur Token Generierung
+        2. Token Generierung: Ausführen von "./evcc token mercedes" oder "evcc token [name]", wenn name gesetzt ist.  
         3. Einfügen der Tokens in die evcc.yaml
           ```
           vehicles:
@@ -43,7 +43,7 @@ requirements:
               vin: W... # Required, if more then one car is registered in this account
               capacity: 50 # capacity in kWh (optional)
           ```
-        2. execute "./evcc token mercedes" for token generation
+        2. Token generation: execute "./evcc token mercedes" or "evcc token [name]", when name is defined
         3. insert the tokens into evcc.yaml
           ```
           vehicles:


### PR DESCRIPTION
This small PR updates the doc. Add the evcc token [name] when multiple vehicles and defined or the config entry has a name configured.

