### PR TITLE
template/ac-elwa-e: Correct soc and rename file and description

### DIFF
--- a/templates/definition/meter/ac-elwa-e.yaml
+++ b/templates/definition/meter/ac-elwa-e.yaml
@@ -17,3 +17,4 @@ render: |
     source: http
     uri: http://{{ .host }}/data.jsn
     jq: .temp1
+    scale: 0.1

--- a/templates/definition/meter/ac-elwa-e.yaml
+++ b/templates/definition/meter/ac-elwa-e.yaml
@@ -1,4 +1,5 @@
 template: ac-elwa-e
+covers: ["elwa-e"]
 products:
   - brand: my-PV
     description:

--- a/templates/definition/meter/elwa-e.yaml
+++ b/templates/definition/meter/elwa-e.yaml
@@ -1,8 +1,8 @@
-template: elwa-e
+template: ac-elwa-e
 products:
   - brand: my-PV
     description:
-      generic: AC ELWA
+      generic: AC ELWA-E
 params:
   - name: usage
     choice: ["aux"]
@@ -16,4 +16,4 @@ render: |
   soc:
     source: http
     uri: http://{{ .host }}/data.jsn
-    jq: .temp
+    jq: .temp1


### PR DESCRIPTION
My-PV has various products (https://www.my-pv.com/de/produkte/ ), I can only test and verify the old AC ELWA-E.

evcc trace output:
```
[http  ] TRACE 2024/03/02 17:28:34 GET http://192.168.178.23/data.jsn
[http  ] TRACE 2024/03/02 17:28:34 {
"device":"AC ELWA-E",
"fwversion":"00206.02",
"status":3,
"power":0,
"boostpower":0,
"temp1":185,
"ww1target":597,
"boostactive":0,
"legboostnext":"off",
"loctime":"17:28:11",
"unixtime":1709396891,
"ctrlstate":"Conn. to Fronius. P Grid=689",
"blockactive":0,
"meter1_id":null,
"meter1_ip":"null",
"meter2_id":null,
"meter2_ip":"null",
"meter3_id":null,
"meter3_ip":"null",
"meter4_id":null,
"meter4_ip":"null",
"meter5_id":null,
"meter5_ip":"null",
"meter6_id":null,
"meter6_ip":"null",
"meter_ss":null,
"meter_ssid":"null",
"surplus":-689,
"m0sum":-689,
"m0l1":null,
"m0l2":null,
"m0l3":null,
"m0bat":0,
"m1sum":152,
"m1l1":null,
"m1l2":null,
"m1l3":null,
"m1devstate":0,
"m2sum":null,
"m2l1":null,
"m2l2":null,
"m2l3":null,
"m2soc":null,
"m2state":null,
"m2devstate":null,
"m3sum":null,
"m3l1":null,
"m3l2":null,
"m3l3":null,
"m3soc":null,
"m3devstate":3,
"m4sum":null,
"m4l1":null,
"m4l2":null,
"m4l3":null,
"m4devstate":null,
"ecarstate":"null",
"ecarboostctr":null,
"mss2":"null",
"mss3":"null",
"mss4":"null",
"mss5":"null",
"mss6":"null",
"mss7":"null",
"mss8":"null",
"mss9":"null",
"mss10":"null",
"mss11":"null",
"tempchip":30,
"cur_ip":"192.168.178.23",
"cur_sn":"255.255.255.0",
"cur_gw":"192.168.178.1",
"cur_dns":"192.168.178.1",
"cloudstate":4,
"debug_ip":"0.0.0.0"
}

temp1 is the measured temperature in Celcius with a factor of 0.1.

I would really use the name shown from the website and in the status json.

```