### PR TITLE
Config UI: fix typos in the warning text

### DIFF
--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -29,8 +29,8 @@
 				</div>
 
 				<div class="alert alert-danger my-4" role="alert">
-					<strong>Highly experimental!</strong> Only play around with this settings if you
-					know what your doing. Otherwise you might have to reset or manually repair you
+					<strong>Highly experimental!</strong> Only play around with these settings if you
+					know what you're doing. Otherwise you might have to reset or manually repair your
 					database.
 				</div>
 


### PR DESCRIPTION
Fixed three minor syntax errors in the warning text of the UI presented behind the menu option "Device Configuration".