### PR TITLE
Plan UI: faster loading

### DIFF
--- a/assets/js/components/ChargingPlanSettings.vue
+++ b/assets/js/components/ChargingPlanSettings.vue
@@ -23,7 +23,7 @@
 				{{ $t(`main.targetCharge.${isPreview ? "preview" : "currentPlan"}`) }}
 			</div>
 		</h5>
-		<ChargingPlanPreview v-if="chargingPlanPreviewProps" v-bind="chargingPlanPreviewProps" />
+		<ChargingPlanPreview v-bind="chargingPlanPreviewProps" />
 	</div>
 </template>
 
@@ -136,6 +136,10 @@ export default {
 			}
 		},
 		fetchPlanDebounced: async function (preview) {
+			if (!this.debounceTimer) {
+				await this.fetchPlan(preview);
+				return;
+			}
 			clearTimeout(this.debounceTimer);
 			this.debounceTimer = setTimeout(async () => await this.fetchPlan(preview), 1000);
 		},

--- a/assets/js/components/TariffChart.vue
+++ b/assets/js/components/TariffChart.vue
@@ -90,9 +90,9 @@ export default {
 		priceStyle(price) {
 			const value = price === undefined ? this.avgPrice : price;
 			const height =
-				value !== undefined
+				value !== undefined && !isNaN(value)
 					? `${10 + (90 / this.priceInfo.range) * (value - this.priceInfo.min)}%`
-					: "100%";
+					: "75%";
 			return { height };
 		},
 	},
@@ -116,7 +116,9 @@ export default {
 	flex-direction: column;
 	position: relative;
 	opacity: 1;
-	transition: opacity var(--evcc-transition-fast) linear;
+	transition-property: opacity, background, color;
+	transition-duration: var(--evcc-transition-fast);
+	transition-timing-function: ease-in;
 }
 @media (max-width: 991px) {
 	.chart {
@@ -148,6 +150,7 @@ export default {
 	display: flex;
 	justify-content: center;
 	color: var(--bs-white);
+	transition: height var(--evcc-transition-fast) ease-in;
 }
 .slot-label {
 	color: var(--bs-gray-light);


### PR DESCRIPTION
The added debounce (https://github.com/evcc-io/evcc/pull/12284) feature introduced a 1s delay on the plan modal. This PR removed the initial delay.

- ⏲️ remove plan delay when opening or changing plan
- 🦘 remove layout shift when data is not available yet (reserve space, show equal height bars)

**simulates very very slow loading**


https://github.com/evcc-io/evcc/assets/152287/0a10b817-c36a-4511-a4ba-d257888c7443


