### PR TITLE
Layout: no vertical scrolling

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -484,8 +484,22 @@ html.app .hide-in-app {
 }
 
 .safe-area-inset {
-	padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
-		env(safe-area-inset-left);
+	padding: max(1rem, env(safe-area-inset-top)) env(safe-area-inset-right)
+		calc(0.5 * env(safe-area-inset-bottom)) env(safe-area-inset-left);
+	position: relative;
+}
+
+.safe-area-inset::before {
+	content: "";
+	display: block;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: env(safe-area-inset-top);
+	z-index: 1000;
+	opacity: 0.9;
+	background-color: var(--evcc-background);
 }
 
 .modal-dialog {

--- a/assets/js/components/Site.vue
+++ b/assets/js/components/Site.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="d-flex flex-column site safe-area-inset">
 		<div class="container px-4 top-area">
-			<div class="d-flex justify-content-between align-items-center my-3">
+			<div class="d-flex justify-content-between align-items-center mb-2">
 				<h1 class="d-block my-0">
 					{{ siteTitle || "evcc" }}
 				</h1>


### PR DESCRIPTION
fixes https://github.com/evcc-io/app/issues/6

- 🤏 decrease height to fit on phone screens without scrolling (tested in std iphone devices)
- 🚥 add backdrop to menu bar when integrated in ios app

<img width="443" alt="Bildschirmfoto 2024-03-04 um 22 16 02" src="https://github.com/evcc-io/evcc/assets/152287/c183fbbc-be36-4a9f-92f5-3a6e62606c9b">
