### PR TITLE
Adjustment to new JLR API requirements

### DIFF
--- a/vehicle/jlr.go
+++ b/vehicle/jlr.go
@@ -106,6 +106,8 @@ func (v *JLR) RegisterDevice(log *util.Logger, user, device string, t jlr.Token)
 		"Accept":                  "application/json",
 		"X-Device-Id":             device,
 		"x-telematicsprogramtype": "jlrpy",
+		"x-App-Id": "ICR_JAGUAR",
+		"x-App-Secret": "018dd168-6271-707f-9fd4-aed2bf76905e",
 	})
 	if err == nil {
 		_, err = c.DoBody(req)


### PR DESCRIPTION
This pull request addresses an issue encountered when using evcc due to changes in the Jaguar Land Rover API. Users were encountering the error message: "vehicle not available: cannot create vehicle type 'template': cannot create vehicle type 'jaguar': login failed: unexpected status: 407 (Proxy Authentication Required)".

To resolve this issue, this PR proposes adding additional HTTP headers to provide a workaround for the authentication problem. These headers should enable proper communication with the Jaguar Land Rover API, allowing evcc to function as intended.

Refs: https://github.com/ardevd/jlrpy/issues/116