### PR TITLE
Adjustments to JLR API to new requirements

### DIFF
--- a/vehicle/jlr.go
+++ b/vehicle/jlr.go
@@ -106,6 +106,8 @@ func (v *JLR) RegisterDevice(log *util.Logger, user, device string, t jlr.Token)
 		"Accept":                  "application/json",
 		"X-Device-Id":             device,
 		"x-telematicsprogramtype": "jlrpy",
+		"x-App-Id":                "ICR_JAGUAR",
+		"x-App-Secret":            "018dd168-6271-707f-9fd4-aed2bf76905e",
 	})
 	if err == nil {
 		_, err = c.DoBody(req)

--- a/vehicle/jlr/api.go
+++ b/vehicle/jlr/api.go
@@ -36,6 +36,8 @@ func NewAPI(log *util.Logger, device string, ts oauth2.TokenSource) *API {
 					"Authorization":           fmt.Sprintf("Bearer %s", token.AccessToken),
 					"X-Device-Id":             device,
 					"x-telematicsprogramtype": "jlrpy",
+					"x-App-Id":                "ICR_JAGUAR",
+					"x-App-Secret":            "018dd168-6271-707f-9fd4-aed2bf76905e",
 				} {
 					req.Header.Set(k, v)
 				}

--- a/vehicle/jlr/identity.go
+++ b/vehicle/jlr/identity.go
@@ -38,6 +38,8 @@ func (v *Identity) login(data map[string]string) (Token, error) {
 		"Authorization": "Basic YXM6YXNwYXNz",
 		"Content-type":  request.JSONContent,
 		"X-Device-Id":   v.device,
+		"x-App-Id":      "ICR_JAGUAR",
+		"x-App-Secret":  "018dd168-6271-707f-9fd4-aed2bf76905e",
 	})
 
 	var token Token


### PR DESCRIPTION
This pull request addresses an issue encountered when using evcc due to changes in the Jaguar Land Rover API. Users were encountering the error message: "vehicle not available: cannot create vehicle type 'template': cannot create vehicle type 'jaguar': login failed: unexpected status: 407 (Proxy Authentication Required)".

To resolve this issue, this PR proposes adding additional HTTP headers to provide a workaround for the authentication problem. These headers should enable proper communication with the Jaguar Land Rover API, allowing evcc to function as intended.

 Tested with a Jaguar iPace and works as expected. 

Refs: https://github.com/ardevd/jlrpy/issues/116