### PR TITLE
Plan UI: dialog on unsaved changes

### DIFF
--- a/assets/js/components/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlan.vue
@@ -224,12 +224,22 @@ export default {
 		this.modal = Modal.getOrCreateInstance(this.$refs.modal);
 		this.$refs.modal.addEventListener("show.bs.modal", this.modalVisible);
 		this.$refs.modal.addEventListener("hidden.bs.modal", this.modalInvisible);
+		this.$refs.modal.addEventListener("hide.bs.modal", this.checkUnsavedOnClose);
 	},
 	unmounted() {
 		this.$refs.modal?.removeEventListener("show.bs.modal", this.modalVisible);
 		this.$refs.modal?.removeEventListener("hidden.bs.modal", this.modalInvisible);
+		this.$refs.modal?.removeEventListener("hide.bs.modal", this.checkUnsavedOnClose);
 	},
 	methods: {
+		checkUnsavedOnClose: function () {
+			const $applyButton = this.$refs.modal.querySelector("[data-testid=plan-apply]");
+			if ($applyButton) {
+				if (confirm(this.$t("main.chargingPlan.unsavedChanges"))) {
+					$applyButton.click();
+				}
+			}
+		},
 		modalVisible: function () {
 			this.isModalVisible = true;
 		},

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -208,6 +208,7 @@ time = "Zeit"
 title = "Plan"
 titleMinSoc = "Min. Ladung"
 titleTargetCharge = "Abfahrt"
+unsavedChanges = "Ungespeicherte Änderungen vorhanden. Jetzt anwenden?"
 update = "Anwenden"
 
 [main.energyflow]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -205,6 +205,7 @@ time = "Time"
 title = "Plan"
 titleMinSoc = "Min charge"
 titleTargetCharge = "Departure"
+unsavedChanges = "There are unsaved changes. Apply now?"
 update = "Apply"
 
 [main.energyflow]


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/12192

Show confirm dialog when closing plan modal with unsaved changes.

https://github.com/evcc-io/evcc/assets/152287/17d83f69-a228-455b-b499-cd44ea47a600

Note: This simple solution with system dialog can later be replaced by a styled one with proper option labeling.