### PR TITLE
Config UI: only reset form-data on manual template change

### DIFF
--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -41,6 +41,7 @@
 								<select
 									id="meterTemplate"
 									v-model="templateName"
+									@change="templateChanged"
 									:disabled="!isNew"
 									class="form-select w-100"
 								>
@@ -62,7 +63,6 @@
 										{{ option.name }}
 									</option>
 								</select>
-								{{ templateName }}
 							</FormRow>
 							<p v-if="loadingTemplate">Loading ...</p>
 							<Modbus
@@ -314,7 +314,6 @@ export default {
 		},
 		async loadTemplate() {
 			this.template = null;
-			this.reset();
 			this.loadingTemplate = true;
 			try {
 				const opts = {
@@ -404,6 +403,9 @@ export default {
 		},
 		selectType(type) {
 			this.selectedType = type;
+		},
+		templateChanged() {
+			this.reset();
 		},
 	},
 };

--- a/assets/js/components/Config/VehicleModal.vue
+++ b/assets/js/components/Config/VehicleModal.vue
@@ -29,6 +29,7 @@
 								<select
 									id="vehicleTemplate"
 									v-model="templateName"
+									@change="templateChanged"
 									:disabled="!isNew"
 									class="form-select w-100"
 								>
@@ -259,7 +260,6 @@ export default {
 		},
 		async loadTemplate() {
 			this.template = null;
-			this.reset();
 			try {
 				const opts = {
 					params: {
@@ -340,6 +340,9 @@ export default {
 		},
 		modalInvisible() {
 			this.isModalVisible = false;
+		},
+		templateChanged() {
+			this.reset();
 		},
 	},
 };


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/12015

Form was cleared on every template change. Now it's only done when user changes it manually via select.