### PR TITLE
Config UI: support name with whitespace in status endpoint

### DIFF
--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -424,7 +424,8 @@ export default {
 		},
 		async updateDeviceValue(type, name) {
 			try {
-				const response = await api.get(`/config/devices/${type}/${name}/status`);
+				const url = `/config/devices/${encodeURIComponent(type)}/${encodeURIComponent(name)}/status`;
+				const response = await api.get(url);
 				if (!this.deviceValues[type]) this.deviceValues[type] = {};
 				this.deviceValues[type][name] = response.data.result;
 			} catch (error) {

--- a/server/http.go
+++ b/server/http.go
@@ -95,7 +95,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, cache *util.Cache) {
 		"products":                {[]string{"GET"}, "/config/products/{class:[a-z]+}", productsHandler},
 		"devices":                 {[]string{"GET"}, "/config/devices/{class:[a-z]+}", devicesHandler},
 		"device":                  {[]string{"GET"}, "/config/devices/{class:[a-z]+}/{id:[0-9.]+}", deviceConfigHandler},
-		"devicestatus":            {[]string{"GET"}, "/config/devices/{class:[a-z]+}/{name:[a-zA-Z0-9_.:-]+}/status", deviceStatusHandler},
+		"devicestatus":            {[]string{"GET"}, "/config/devices/{class:[a-z]+}/{name:[a-zA-Z0-9 _.:-]+}/status", deviceStatusHandler},
 		"site":                    {[]string{"GET"}, "/config/site", siteHandler(site)},
 		"dirty":                   {[]string{"GET"}, "/config/dirty", boolGetHandler(ConfigDirty)},
 		"updatesite":              {[]string{"PUT", "OPTIONS"}, "/config/site", updateSiteHandler(site)},

--- a/server/http.go
+++ b/server/http.go
@@ -124,10 +124,10 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, cache *util.Cache) {
 
 	// vehicle api
 	vehicles := map[string]route{
-		"minsoc":   {[]string{"POST", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
-		"limitsoc": {[]string{"POST", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
-		"plan":     {[]string{"POST", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.-]+}", planSocHandler(site)},
-		"plan2":    {[]string{"DELETE", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
+		"minsoc":   {[]string{"POST", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9 _.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
+		"limitsoc": {[]string{"POST", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9 _.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
+		"plan":     {[]string{"POST", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9 _.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.-]+}", planSocHandler(site)},
+		"plan2":    {[]string{"DELETE", "OPTIONS"}, "/vehicles/{name:[a-zA-Z0-9 _.:-]+}/plan/soc", planSocRemoveHandler(site)},
 
 		// config ui
 		// "mode":     {[]string{"POST", "OPTIONS"}, "/mode/{value:[a-z]+}", chargeModeHandler(v)},
@@ -155,7 +155,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, cache *util.Cache) {
 			"planpreview":      {[]string{"GET"}, "/plan/preview/{type:(?:soc|energy)}/{value:[0-9.]+}/{time:[0-9TZ:.-]+}", planPreviewHandler(lp)},
 			"planenergy":       {[]string{"POST", "OPTIONS"}, "/plan/energy/{value:[0-9.]+}/{time:[0-9TZ:.-]+}", planEnergyHandler(lp)},
 			"planenergy2":      {[]string{"DELETE", "OPTIONS"}, "/plan/energy", planRemoveHandler(lp)},
-			"vehicle":          {[]string{"POST", "OPTIONS"}, "/vehicle/{name:[a-zA-Z0-9_.:-]+}", vehicleSelectHandler(site, lp)},
+			"vehicle":          {[]string{"POST", "OPTIONS"}, "/vehicle/{name:[a-zA-Z0-9 _.:-]+}", vehicleSelectHandler(site, lp)},
 			"vehicle2":         {[]string{"DELETE", "OPTIONS"}, "/vehicle", vehicleRemoveHandler(lp)},
 			"vehicleDetect":    {[]string{"PATCH", "OPTIONS"}, "/vehicle", vehicleDetectHandler(lp)},
 			"remotedemand":     {[]string{"POST", "OPTIONS"}, "/remotedemand/{demand:[a-z]+}/{source:[0-9a-zA-Z_-]+}", remoteDemandHandler(lp)},


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/12723

The status api breaks when device names (yaml) contain a whitespace. I would argue that whitespace should not be used there anyway, but since this currently works everywhere else and we don't prevent it i've added support in the status endpoint mapping and additionally ensured that we do proper URL escaping.

example mentioned in the issue:
```
meters:
- name: elgris meter
```