### PR TITLE
UI: reload on upgrade and startup error fix

### DIFF
--- a/assets/js/components/LoadpointSettingsModal.vue
+++ b/assets/js/components/LoadpointSettingsModal.vue
@@ -35,7 +35,7 @@
 							</h4>
 							<div v-if="phasesOptions.length" class="mb-3 row">
 								<label
-									:for="formId('phases_0')"
+									:for="formId(`phases_${phasesOptions[0]}`)"
 									class="col-sm-4 col-form-label pt-0"
 								>
 									{{ $t("main.loadpointSettings.phasesConfigured.label") }}

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -40,7 +40,18 @@ export default {
 		const siteTitle = store.state.siteTitle;
 		return { title: siteTitle ? `${siteTitle} | evcc` : "evcc" };
 	},
+	watch: {
+		version: function (prev, now) {
+			if (!!prev && !!now) {
+				console.log("new version detected. reloading browser", { now, prev });
+				this.reload();
+			}
+		},
+	},
 	computed: {
+		version: function () {
+			return store.state.version;
+		},
 		batteryModalAvailabe: function () {
 			return store.state.batteryConfigured;
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -264,6 +264,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 			go updater.Run(log, httpd, valueChan)
 		}
 
+		// remove previous fatal startup errors
+		valueChan <- util.Param{Key: "fatal", Val: nil}
+
 		// expose sponsor to UI
 		if sponsor.Subject != "" {
 			valueChan <- util.Param{Key: "sponsor", Val: sponsor.Subject}


### PR DESCRIPTION
- 👹 switch from startup error screen to main ui, when yaml error was resolved after restart
- 💫 reload UI when evcc version changes -> no need for manual refresh in open browsers
- 🚨 html validator fix: broken label/id ref when loadpoint has no 1p3p