### PR TITLE
Ocpp: getConfiguration delay for Elvi bug

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -175,7 +175,7 @@ func NewOCPP(id string, connector int, idtag string,
 		}
 	} else {
 		// fix timing issue in EVBox when switching OCPP protocol version
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Second)
 
 		err := ocpp.Instance().GetConfiguration(cp.ID(), func(resp *core.GetConfigurationConfirmation, err error) {
 			if err == nil {

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -174,7 +174,7 @@ func NewOCPP(id string, connector int, idtag string,
 			meterInterval = 10 * time.Second
 		}
 	} else {
-		// Wait 1 second before querying getConfiguration, as there seems to be a timing issue in EVBox when switching OCPP protocol version
+		// fix timing issue in EVBox when switching OCPP protocol version
 		time.Sleep(1 * time.Second)
 
 		err := ocpp.Instance().GetConfiguration(cp.ID(), func(resp *core.GetConfigurationConfirmation, err error) {

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -175,7 +175,6 @@ func NewOCPP(id string, connector int, idtag string,
 		}
 	} else {
 		// Wait 1 second before querying getConfiguration, as there seems to be a timing issue in EVBox when switching OCPP protocol version
-		c.log.DEBUG.Printf("waiting 1 second before getConfiguration call")
 		time.Sleep(1 * time.Second)
 
 		err := ocpp.Instance().GetConfiguration(cp.ID(), func(resp *core.GetConfigurationConfirmation, err error) {

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -174,6 +174,10 @@ func NewOCPP(id string, connector int, idtag string,
 			meterInterval = 10 * time.Second
 		}
 	} else {
+		// Wait 1 second before querying getConfiguration, as there seems to be a timing issue in EVBox when switching OCPP protocol version
+		c.log.DEBUG.Printf("waiting 1 second before getConfiguration call")
+		time.Sleep(1 * time.Second)
+
 		err := ocpp.Instance().GetConfiguration(cp.ID(), func(resp *core.GetConfigurationConfirmation, err error) {
 			if err == nil {
 				// log unsupported configuration keys

--- a/templates/definition/charger/ocpp-elvi.yaml
+++ b/templates/definition/charger/ocpp-elvi.yaml
@@ -27,4 +27,3 @@ render: |
   metervalues: Current.Import.L1,Current.Import.L2,Current.Import.L3,Energy.Active.Import.Register,Power.Active.Import,Voltage.L1,Voltage.L2,Voltage.L3
   meterinterval: {{ .meterinterval }}
   {{- end }}
-  getconfiguration: false


### PR DESCRIPTION
Elvi EVBox has a timing issue after protocol version change, therefore we'll wait 1 second before sending the getConfiguration call