### PR TITLE
Enabling getConfiguration for Elvi EVBox

### DIFF
--- a/templates/definition/charger/ocpp-elvi.yaml
+++ b/templates/definition/charger/ocpp-elvi.yaml
@@ -27,4 +27,4 @@ render: |
   metervalues: Current.Import.L1,Current.Import.L2,Current.Import.L3,Energy.Active.Import.Register,Power.Active.Import,Voltage.L1,Voltage.L2,Voltage.L3
   meterinterval: {{ .meterinterval }}
   {{- end }}
-  getconfiguration: false
+  getconfiguration: true


### PR DESCRIPTION
Enabling getConfiguration call for Elvi EVBox as the underlying problem was mitigated by https://github.com/evcc-io/evcc/pull/12856