### PR TITLE
Smartfox: add energy for aux + update description

### DIFF
--- a/templates/definition/meter/smartfox-em2.yaml
+++ b/templates/definition/meter/smartfox-em2.yaml
@@ -2,7 +2,7 @@ template: smartfox-em2
 products:
   - brand: Smartfox
     description:
-      generic: Pro, Pro 2, Pro Light, Pro Light 2, Light, Reg, Reg extended (EM2 firmware)
+      generic: Pro, Pro 2, Pro Light, Pro Light 2, Light (EM2 firmware)
 requirements:
   description:
     de: |

--- a/templates/definition/meter/smartfox.yaml
+++ b/templates/definition/meter/smartfox.yaml
@@ -2,7 +2,7 @@ template: smartfox
 products:
   - brand: Smartfox
     description:
-      generic: Pro, Pro 2, Pro Light, Pro Light 2, Light, Reg, Reg extended
+      generic: Box, Reg, Reg extended
 requirements:
   description:
     de: |
@@ -75,4 +75,9 @@ render: |
     source: http
     uri: {{ include "uri" . }}
     jq: .power_sf
+  energy:
+    source: http
+    uri: {{ include "uri" . }}
+    jq: .day_energy_sf
+    scale: 0.001
   {{- end }}


### PR DESCRIPTION
Hier gibt 2 Anpassungen:
* Doku angepasst: Smartfox hat mehrere Produkte und haben nicht alle die gleiche REST API...
* Add energy für "aux"

Energy funktioniert gut, obwohl mit `./evcc charger` ist der Output nicht vollständig, es fehlt Energy, Charged (und Soc sollte in `°C` sein)
```
boiler
------
Soc:           58%
Charge status: A
Enabled:       false
Features:      [IntegratedDevice Heating]

easee
-----
Power:          0W
Energy:         5794.3kWh
Current L1..L3: 0A 0A 0A
Charge status:  A
Enabled:        false
Charged:        3.0kWh
Identifier:     <none>
```

und so sieht mein Konfig aus:
```
loadpoints:
  - title: Boiler
    charger: boiler
    meter: boiler-smartfox
    mode: pv
    priority: 0
chargers:
  - name: boiler
    type: custom
    icon: waterheater
    status:  # charger status A..F https://evsim.gonium.net/#der-control-pilot-cp
      source: combined
      plugged:
        source: js
        script: |
          new Date().getHours() > 6 && new Date().getHours() < 21
      charging:
        source: http
        uri: http://192.168.1.61/all
        jq: .power_sf != 0
    enabled: # charger enabled state (true/false or 0/1)
      source: http
      uri: http://192.168.1.61/all
      jq: .power_sf != 0
    enable:
      source: js
      script: # do nothing
    maxcurrent:
      source: js
      script: '8.7' # 8.7 * 230 * 3 = 6kW
    soc:
      source: http
      uri: http://192.168.1.60/rpc/Temperature.GetStatus?id=100 # shelly plus addon https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Temperature
      jq: .tC
    features: [integrateddevice, heating]

meters:
  - name: boiler-smartfox
    type: template
    template: smartfox
    usage: aux
    host: 192.168.1.61
```    
![image](https://github.com/evcc-io/evcc/assets/14069254/f1ec3f4e-9e2c-4b0b-a202-662325ece173)

   