### PR TITLE
Mobile UI: Active loadpoint indicator

### DIFF
--- a/assets/js/components/Loadpoints.vue
+++ b/assets/js/components/Loadpoints.vue
@@ -32,7 +32,11 @@
 				:class="{ 'indicator--selected': selected(index) }"
 				@click="scrollTo(index)"
 			>
-				<shopicon-filled-circle class="indicator-icon"></shopicon-filled-circle>
+				<shopicon-filled-lightning
+					v-if="isCharging(loadpoint)"
+					class="indicator-icon"
+				></shopicon-filled-lightning>
+				<shopicon-filled-circle v-else class="indicator-icon"></shopicon-filled-circle>
 			</button>
 		</div>
 	</div>
@@ -40,6 +44,7 @@
 
 <script>
 import "@h2d2/shopicons/es/filled/circle";
+import "@h2d2/shopicons/es/filled/lightning";
 
 import Loadpoint from "./Loadpoint.vue";
 
@@ -72,6 +77,9 @@ export default {
 			const { scrollLeft } = this.$refs.carousel;
 			const { offsetWidth } = this.$refs.carousel.children[0];
 			this.selectedIndex = Math.round((scrollLeft - 7.5) / offsetWidth);
+		},
+		isCharging(lp) {
+			return lp.charging && lp.chargePower > 0;
 		},
 		selected(index) {
 			return this.selectedIndex === index;
@@ -120,11 +128,19 @@ export default {
 		height: 32px;
 		opacity: 0.3;
 		transition: opacity var(--evcc-transition-fast) ease-in;
+		position: relative;
 	}
 	.indicator--selected {
 		opacity: 1;
 	}
 	.indicator-icon {
+		width: 18px;
+	}
+	.indicator-active {
+		position: absolute;
+		top: 0;
+		left: 0;
+		color: var(--evcc-background);
 		width: 18px;
 	}
 	.loadpoint {

--- a/assets/js/components/Loadpoints.vue
+++ b/assets/js/components/Loadpoints.vue
@@ -128,19 +128,11 @@ export default {
 		height: 32px;
 		opacity: 0.3;
 		transition: opacity var(--evcc-transition-fast) ease-in;
-		position: relative;
 	}
 	.indicator--selected {
 		opacity: 1;
 	}
 	.indicator-icon {
-		width: 18px;
-	}
-	.indicator-active {
-		position: absolute;
-		top: 0;
-		left: 0;
-		color: var(--evcc-background);
 		width: 18px;
 	}
 	.loadpoint {

--- a/assets/js/components/Loadpoints.vue
+++ b/assets/js/components/Loadpoints.vue
@@ -36,7 +36,11 @@
 					v-if="isCharging(loadpoint)"
 					class="indicator-icon"
 				></shopicon-filled-lightning>
-				<shopicon-filled-circle v-else class="indicator-icon"></shopicon-filled-circle>
+				<shopicon-filled-circle
+					v-else-if="loadpoint.connected"
+					class="indicator-icon"
+				></shopicon-filled-circle>
+				<shopicon-bold-circle v-else class="indicator-icon"></shopicon-bold-circle>
 			</button>
 		</div>
 	</div>
@@ -44,6 +48,7 @@
 
 <script>
 import "@h2d2/shopicons/es/filled/circle";
+import "@h2d2/shopicons/es/bold/circle";
 import "@h2d2/shopicons/es/filled/lightning";
 
 import Loadpoint from "./Loadpoint.vue";


### PR DESCRIPTION
fixes #12961

- shows lighting instead of dot for load points that are charging.
- distinguish between connected/not connected

⚡= charging
● = connected
○ = not connected

all connected, 2nd charging & selected
![Bildschirmfoto 2024-03-15 um 14 10 11](https://github.com/evcc-io/evcc/assets/152287/591a4812-65b1-4a18-a9bc-ffbb1411d11f)

all connected, 2nd charging, 1st selected
![Bildschirmfoto 2024-03-15 um 14 10 07](https://github.com/evcc-io/evcc/assets/152287/3875b340-cc3a-4478-99ac-70bd129a9293)

not connected, connected & selected, not connected, connected
![Bildschirmfoto 2024-03-15 um 15 10 54](https://github.com/evcc-io/evcc/assets/152287/6be1dc7a-d7dd-4a02-8252-f4d362282eca)

not connected, charging & selected, not connected, connected
![Bildschirmfoto 2024-03-15 um 15 11 55](https://github.com/evcc-io/evcc/assets/152287/e33ae22e-8abe-40e6-b155-0f30d9b44bcc)