### PR TITLE
mennekes-compact: add heartbeat interval property to configuration

### DIFF
--- a/templates/definition/charger/mennekes-compact.yaml
+++ b/templates/definition/charger/mennekes-compact.yaml
@@ -19,6 +19,11 @@ params:
     baudrate: 57600
     comset: 8N2
     id: 50
+  - name: heartbeat
+    default: 8s
+    description:
+      de: Der Intervall zwischen den Heartbeat-Nachrichten. Dieser muss kleiner als der Heartbeat-Timeout (10s) der Wallbox sein.
+      en: The interval between the heartbeat messages. This must be smaller than the heartbeat timeout (10s) of the charger.
 render: |
   type: mennekes-compact
   {{- include "modbus" . }}

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -248,6 +248,11 @@ func ProtocolFromRTU(rtu *bool) Protocol {
 	return Tcp
 }
 
+func NewConnectionFromSettings(settings *Settings) (*Connection, error) {
+	return NewConnection(settings.URI, settings.Device, settings.Comset,
+		settings.Baudrate, ProtocolFromRTU(settings.RTU), settings.ID)
+}
+
 // NewConnection creates physical modbus device from config
 func NewConnection(uri, device, comset string, baudrate int, proto Protocol, slaveID uint8) (*Connection, error) {
 	var conn meters.Connection


### PR DESCRIPTION
So users could react to local requirements. For example restarting evcc could lead to missing beats within the 10s time window. (Related #12171) Also I am able to sync the heartbeat with a modbus timeout (e.g. timeout 2s, heartbeat 4s) so we have at least the option to stay <10s on failure.

refactor: no inline config struct; use dedicated one