### PR TITLE
UI: fix header spacing

### DIFF
--- a/assets/js/components/Site.vue
+++ b/assets/js/components/Site.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="d-flex flex-column site safe-area-inset">
 		<div class="container px-4 top-area">
-			<div class="d-flex justify-content-between align-items-center mb-2">
+			<div class="d-flex justify-content-between align-items-center my-3 my-md-4">
 				<h1 class="d-block my-0">
 					{{ siteTitle || "evcc" }}
 				</h1>

--- a/assets/js/components/TopHeader.vue
+++ b/assets/js/components/TopHeader.vue
@@ -1,5 +1,5 @@
 <template>
-	<header class="d-flex justify-content-between align-items-center py-3">
+	<header class="d-flex justify-content-between align-items-center py-3 py-md-4">
 		<h1 class="mb-1 pt-1 d-flex text-nowrap text-truncate">
 			<router-link class="evcc-default-text" to="/" data-testid="home-link">
 				<shopicon-regular-home size="s" class="home"></shopicon-regular-home>


### PR DESCRIPTION
fixes #12968

⇅ consistent header spacing
💻 more space on larger devices

desktop small
<img width="708" alt="desktop safari small" src="https://github.com/evcc-io/evcc/assets/152287/8187087a-4970-4661-aadd-ff026c3e6a0f">

desktop large
<img width="949" alt="desktop safari large" src="https://github.com/evcc-io/evcc/assets/152287/473c2fdd-2338-4906-bb51-3b7ff35c5251">

ipad
<img width="1100" alt="ipad" src="https://github.com/evcc-io/evcc/assets/152287/d8e7aa75-11d4-4064-a96e-00d7ad32f720">

iphone (pwa)
<img width="469" alt="iphone" src="https://github.com/evcc-io/evcc/assets/152287/e804a857-513a-4041-b6b3-2cba568bd234">
