### PR TITLE
Saic: improve response handling

### DIFF
--- a/vehicle/saic/provider.go
+++ b/vehicle/saic/provider.go
@@ -54,7 +54,7 @@ func (v *Provider) Soc() (float64, error) {
 
 	val := res.ChrgMgmtData.BmsPackSOCDsp
 	if val > 1000 {
-		v.status.Reset()
+		//v.status.Reset()
 		return float64(val), fmt.Errorf("invalid raw soc value: %d: %w", val, api.ErrMustRetry)
 	}
 

--- a/vehicle/saic/requests/sendRequest.go
+++ b/vehicle/saic/requests/sendRequest.go
@@ -45,6 +45,7 @@ func CreateRequest(
 		return nil, err
 	}
 
+	Decorate(req)
 	req.Header.Set("app-send-date", strconv.FormatInt(appSendDate, 10))
 	req.Header.Set("original-content-type", contentType)
 


### PR DESCRIPTION
Since the UI queries the car's status it might happen that this query is triggered over and over again if the value cache is invalidated if suspicous data is received.
I removed the "reset" call there.

Furthermore I noticed that the headers are not complete. I therefore call `Decorate` now when creating a request.