### PR TITLE
Shelly: Enable Gen3 Devices

### DIFF
--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -63,8 +63,8 @@ func NewConnection(uri, user, password string, channel int) (*Connection, error)
 			conn.Client.Transport = transport.BasicAuth(user, password, conn.Client.Transport)
 		}
 
-	case 2:
-		// Shelly GEN 2 API
+	case 2, 3:
+		// Shelly GEN 2+ API
 		// https://shelly-api-docs.shelly.cloud/gen2/
 		conn.uri = fmt.Sprintf("%s/rpc", util.DefaultScheme(uri, "http"))
 		if user != "" {


### PR DESCRIPTION
Enable Shelly Gen3 Devices like [Shelly 1 PM Mini](https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyMini1PMG3) using the same API like Gen2 devices.

Fix https://github.com/evcc-io/evcc/issues/13033