### PR TITLE
Battery control: graceful smart cost error handling

### DIFF
--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -74,7 +74,7 @@ func (site *Site) updateBatteryMode() {
 	for _, lp := range site.Loadpoints() {
 		smartCostActive, err := site.smartCostActive(lp)
 		if err != nil {
-			site.log.DEBUG.Println("smart cost:", err)
+			site.log.WARN.Println("smart cost:", err)
 		}
 
 		if lp.GetStatus() == api.StatusC && (smartCostActive || lp.IsFastChargingActive()) {

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -74,8 +74,7 @@ func (site *Site) updateBatteryMode() {
 	for _, lp := range site.Loadpoints() {
 		smartCostActive, err := site.smartCostActive(lp)
 		if err != nil {
-			site.log.ERROR.Println("smart cost:", err)
-			continue
+			site.log.DEBUG.Println("smart cost:", err)
 		}
 
 		if lp.GetStatus() == api.StatusC && (smartCostActive || lp.IsFastChargingActive()) {


### PR DESCRIPTION
Currently Tibber has API issues https://github.com/evcc-io/evcc/discussions/13160 and does not provide rates via their API.
Beside lots of errors in the UI this also leads to a disabled battery control.

- 🚨 converted error to debug logging -> we need something like device health
- 🪫 battery hold now also works when smart cost has errors (e.g. no rates)