### PR TITLE
fix: calculate end date at time of request, rather than process start

### DIFF
--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -61,7 +61,7 @@ func NewAmberFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		embed:   &cc.embed,
 		log:     log,
 		Helper:  request.NewHelper(log),
-		uri:     fmt.Sprintf(amber.URI, strings.ToUpper(cc.SiteID), time.Now().AddDate(0, 0, 1).Format("2006-01-02")),
+		uri:     fmt.Sprintf(amber.URI, strings.ToUpper(cc.SiteID)),
 		channel: strings.ToLower(cc.Channel),
 		data:    util.NewMonitor[api.Rates](2 * time.Hour),
 	}
@@ -87,9 +87,10 @@ func (t *Amber) run(done chan error) {
 	tick := time.NewTicker(time.Minute)
 	for ; true; <-tick.C {
 		var res []amber.PriceInfo
-
+		uri := fmt.Sprintf("%s&endDate=%s", t.uri,
+			time.Now().AddDate(0, 0, 2).Format("2006-01-02"))
 		if err := backoff.Retry(func() error {
-			return t.GetJSON(t.uri, &res)
+			return t.GetJSON(uri, &res)
 		}, bo); err != nil {
 			once.Do(func() { done <- err })
 

--- a/tariff/amber/types.go
+++ b/tariff/amber/types.go
@@ -1,6 +1,6 @@
 package amber
 
-const URI = "https://api.amber.com.au/v1/sites/%s/prices?endDate=%s&resolution=30"
+const URI = "https://api.amber.com.au/v1/sites/%s/prices?resolution=30"
 
 type PriceInfo struct {
 	Type        string  `json:"type"`


### PR DESCRIPTION
Regrettably, my [last PR](https://github.com/evcc-io/evcc/pull/12381) had a bug where the `endDate` sent to the API was calculated only once (at process start.) This meant that if the process was still running when the next day rolled around, the API would no longer receive the correct end date, and not return the correct data. As I had been restarting the `evcc` process regularly, I hadn't noticed.

This PR is to move the date calculation into the loop, similar to how the `elering` tariff works.