### PR TITLE
feat: add phases configuration option to shelly switch

### DIFF
--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -49,7 +49,7 @@ func NewFritzDECT(embed embed, uri, ain, user, password string, standbypower flo
 		conn: conn,
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, 1, standbypower)
 
 	return c, err
 }

--- a/charger/homematic.go
+++ b/charger/homematic.go
@@ -49,7 +49,7 @@ func NewCCU(embed embed, uri, deviceid, meterid, switchid, user, password string
 		conn: conn,
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, 1, standbypower)
 
 	return c, err
 }

--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -56,7 +56,7 @@ func NewHomeWizard(embed embed, uri string, standbypower float64, cache time.Dur
 		return nil, errors.New("unsupported product type: " + c.conn.ProductType)
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, 1, standbypower)
 
 	return c, nil
 }

--- a/charger/mystrom.go
+++ b/charger/mystrom.go
@@ -43,7 +43,7 @@ func NewMyStromFromConfig(other map[string]interface{}) (api.Charger, error) {
 		conn: mystrom.NewConnection(cc.URI),
 	}
 
-	c.switchSocket = NewSwitchSocket(&cc.embed, c.Enabled, c.conn.CurrentPower, cc.StandbyPower)
+	c.switchSocket = NewSwitchSocket(&cc.embed, c.Enabled, c.conn.CurrentPower, 1, cc.StandbyPower)
 	c.reportG = provider.ResettableCached(c.conn.Report, cc.Cache)
 
 	return c, nil

--- a/charger/shelly.go
+++ b/charger/shelly.go
@@ -26,6 +26,7 @@ func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
 		User         string
 		Password     string
 		Channel      int
+		Phases       int
 		StandbyPower float64
 	}
 
@@ -33,11 +34,11 @@ func NewShellyFromConfig(other map[string]interface{}) (api.Charger, error) {
 		return nil, err
 	}
 
-	return NewShelly(cc.embed, cc.URI, cc.User, cc.Password, cc.Channel, cc.StandbyPower)
+	return NewShelly(cc.embed, cc.URI, cc.User, cc.Password, cc.Channel, cc.Phases, cc.StandbyPower)
 }
 
 // NewShelly creates Shelly charger
-func NewShelly(embed embed, uri, user, password string, channel int, standbypower float64) (*Shelly, error) {
+func NewShelly(embed embed, uri, user, password string, channel int, phases int, standbypower float64) (*Shelly, error) {
 	conn, err := shelly.NewConnection(uri, user, password, channel)
 	if err != nil {
 		return nil, err
@@ -47,7 +48,7 @@ func NewShelly(embed embed, uri, user, password string, channel int, standbypowe
 		conn: shelly.NewSwitch(conn),
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, phases, standbypower)
 
 	return c, nil
 }

--- a/charger/switchsocket.go
+++ b/charger/switchsocket.go
@@ -11,6 +11,7 @@ type switchSocket struct {
 	*embed
 	enabled      func() (bool, error)
 	currentPower func() (float64, error)
+	phases       int
 	standbypower float64
 	lp           loadpoint.API
 }
@@ -19,12 +20,14 @@ func NewSwitchSocket(
 	embed *embed,
 	enabled func() (bool, error),
 	currentPower func() (float64, error),
+	phases int,
 	standbypower float64,
 ) *switchSocket {
 	return &switchSocket{
 		embed:        embed,
 		enabled:      enabled,
 		currentPower: currentPower,
+		phases:       phases,
 		standbypower: standbypower,
 	}
 }
@@ -103,5 +106,5 @@ var _ api.PhaseDescriber = (*switchSocket)(nil)
 
 // Phases implements the api.PhasesDescriber interface
 func (v *switchSocket) Phases() int {
-	return 1
+	return v.phases
 }

--- a/charger/tapo.go
+++ b/charger/tapo.go
@@ -48,7 +48,7 @@ func NewTapo(embed embed, uri, user, password string, standbypower float64) (*Ta
 		conn: conn,
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, 1, standbypower)
 
 	return c, nil
 }

--- a/charger/tasmota.go
+++ b/charger/tasmota.go
@@ -62,7 +62,7 @@ func NewTasmota(embed embed, uri, user, password string, channels []int, standby
 		conn: conn,
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, 1, standbypower)
 
 	var currents, voltages func() (float64, float64, float64, error)
 	if len(channels) == 3 {

--- a/charger/tplink.go
+++ b/charger/tplink.go
@@ -50,7 +50,7 @@ func NewTPLink(embed embed, uri string, standbypower float64) (*TPLink, error) {
 		conn: conn,
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, standbypower)
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.conn.CurrentPower, 1, standbypower)
 
 	return c, nil
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1219,7 +1219,11 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64, batter
 		// kick off enable sequence
 		if (lp.Enable.Threshold == 0 && targetCurrent >= minCurrent) ||
 			(lp.Enable.Threshold != 0 && sitePower <= lp.Enable.Threshold) {
-			lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, lp.Enable.Threshold)
+			if lp.Enable.Threshold == 0 {
+				lp.log.DEBUG.Printf("targetCurrent %.0fA >= %.0fA minCurrent", targetCurrent, minCurrent)
+			} else {
+				lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, lp.Enable.Threshold)
+			}
 
 			if lp.pvTimer.IsZero() {
 				lp.log.DEBUG.Printf("pv enable timer start: %v", lp.Enable.Delay)

--- a/templates/definition/charger/shelly.yaml
+++ b/templates/definition/charger/shelly.yaml
@@ -9,6 +9,8 @@ params:
     mask: true
   - name: channel
     default: 0
+  - name: phases
+    default: 1
   - preset: switchsocket
 render: |
   type: shelly

--- a/util/templates/includes/switchsocket.tpl
+++ b/util/templates/includes/switchsocket.tpl
@@ -1,4 +1,5 @@
 {{ define "switchsocket" }}
+phases: {{ .phases }}
 standbypower: {{ .standbypower }}
 features:
 {{- if .integrateddevice }}


### PR DESCRIPTION
In the MR #12052 a functionality was introduced that limits the active phases based on phases configured for a charger. For shelly chargers, this value is hardcoded to 1 (since it is a switchsocket).

This configuration breaks if the shelly controls a switch contact of a "dumb" wallbox. If the shelly is turned on the vehicle connected to the wallbox starts drawing current on 2/3 phases (dependent on the vehicle). If the shelly is configured with only one phase the calculation of the "targetCurrent" is incorrect and the switch is turned on with insufficient "PV Überschuss". Then it draws too much power and is turned off again and the cycle continues… The intended behaviour is that the wallbox only turns on if there is sufficient PV Überschuss available to charge the vehicle at max power. This is achieved by setting minCurrent to 16A (same value as maxCurrent). 

This PR makes the phase count configurable while keeping the default value of single phase. I realize this may be a rare and quite special setup and if there are any other options how to solve this problem, please let me know. Also, this is my first contribution to this project, so please let me know if I have missed anything and need to update the PR to match some guidelines.

My configuration as reference:

```
meters:
  - name: shelly-wb-meter
    type: template
    template: shelly-3em
    usage: charge
    host: 192.168.0.69 # IP-Adresse oder Hostname

chargers:
  - name: shelly
    type: template
    template: shelly
    standbypower: 4
    host: 192.168.0.69 # IP-Adresse oder Hostname
    phases: 3 # New parameter as part of this PR

loadpoints:
  - title: Garage
    charger: shelly
    phases: 3
    minCurrent: 16
    maxCurrent: 16
    meter: shelly-wb-meter
```

<img width="1125" alt="image" src="https://github.com/evcc-io/evcc/assets/3419838/5e6f421a-3061-4542-90f8-d1af42d443d9">
