### PR TITLE
Support for Enercab Smart ( ELEDIO / EVCC01 ) in OCPP mode

### DIFF
--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -33,20 +33,20 @@ type Connector struct {
 	txnId    int
 
 	resetAfterStop bool
-	needsReset bool
+	needsReset     bool
 }
 
-func NewConnector(log *util.Logger, id int, cp *CP, timeout time.Duration, resetAfterStop bool) (*Connector, error) {
+func NewConnector(log *util.Logger, id int, cp *CP, timeout time.Duration) (*Connector, error) {
 	conn := &Connector{
-		log:          log,
-		cp:           cp,
-		id:           id,
-		clock:        clock.New(),
-		statusC:      make(chan struct{}),
-		measurements: make(map[types.Measurand]types.SampledValue),
-		timeout:      timeout,
-		resetAfterStop: resetAfterStop,
-		needsReset:   true,
+		log:            log,
+		cp:             cp,
+		id:             id,
+		clock:          clock.New(),
+		statusC:        make(chan struct{}),
+		measurements:   make(map[types.Measurand]types.SampledValue),
+		timeout:        timeout,
+		resetAfterStop: false,
+		needsReset:     true,
 	}
 
 	err := cp.registerConnector(id, conn)
@@ -70,12 +70,16 @@ func (conn *Connector) ResetAfterStop() bool {
 	return conn.resetAfterStop
 }
 
+func (conn *Connector) SetResetAfterStop(val bool) {
+	conn.resetAfterStop = val
+}
+
 func (conn *Connector) NeedsReset() bool {
 	return conn.needsReset
 }
 
 func (conn *Connector) SetNeedsReset(val bool) {
-	conn.needsReset=val
+	conn.needsReset = val
 }
 
 func (conn *Connector) TriggerMessageRequest(feature remotetrigger.MessageTrigger, f ...func(request *remotetrigger.TriggerMessageRequest)) {

--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -31,9 +31,12 @@ type Connector struct {
 
 	txnCount int // change initial value to the last known global transaction. Needs persistence
 	txnId    int
+
+	resetAfterStop bool
+	needsReset bool
 }
 
-func NewConnector(log *util.Logger, id int, cp *CP, timeout time.Duration) (*Connector, error) {
+func NewConnector(log *util.Logger, id int, cp *CP, timeout time.Duration, resetAfterStop bool) (*Connector, error) {
 	conn := &Connector{
 		log:          log,
 		cp:           cp,
@@ -42,6 +45,8 @@ func NewConnector(log *util.Logger, id int, cp *CP, timeout time.Duration) (*Con
 		statusC:      make(chan struct{}),
 		measurements: make(map[types.Measurand]types.SampledValue),
 		timeout:      timeout,
+		resetAfterStop: resetAfterStop,
+		needsReset:   true,
 	}
 
 	err := cp.registerConnector(id, conn)
@@ -59,6 +64,18 @@ func (conn *Connector) ChargePoint() *CP {
 
 func (conn *Connector) ID() int {
 	return conn.id
+}
+
+func (conn *Connector) ResetAfterStop() bool {
+	return conn.resetAfterStop
+}
+
+func (conn *Connector) NeedsReset() bool {
+	return conn.needsReset
+}
+
+func (conn *Connector) SetNeedsReset(val bool) {
+	conn.needsReset=val
 }
 
 func (conn *Connector) TriggerMessageRequest(feature remotetrigger.MessageTrigger, f ...func(request *remotetrigger.TriggerMessageRequest)) {

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -1,8 +1,8 @@
 package ocpp
 
 import (
-	"time"
 	"strings"
+	"time"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
@@ -61,7 +61,7 @@ func (conn *Connector) MeterValues(request *core.MeterValuesRequest) (*core.Mete
 		// ignore old meter value requests
 		if meterValue.Timestamp.Time.After(conn.meterUpdated) {
 			for _, sample := range meterValue.SampledValue {
-				sample.Value=strings.TrimSpace(sample.Value)
+				sample.Value = strings.TrimSpace(sample.Value)
 				conn.measurements[getSampleKey(sample)] = sample
 				conn.meterUpdated = conn.clock.Now()
 			}

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -2,6 +2,7 @@ package ocpp
 
 import (
 	"time"
+	"strings"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
@@ -60,6 +61,7 @@ func (conn *Connector) MeterValues(request *core.MeterValuesRequest) (*core.Mete
 		// ignore old meter value requests
 		if meterValue.Timestamp.Time.After(conn.meterUpdated) {
 			for _, sample := range meterValue.SampledValue {
+				sample.Value=strings.TrimSpace(sample.Value)
 				conn.measurements[getSampleKey(sample)] = sample
 				conn.meterUpdated = conn.clock.Now()
 			}

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -98,17 +98,17 @@ func (cs *CS) OnStatusNotification(id string, request *core.StatusNotificationRe
 	}
 	conn := cp.connectorByID(request.ConnectorId)
 	if request.Status == core.ChargePointStatusPreparing && conn != nil && conn.ResetAfterStop() {
-		conn.log.TRACE.Printf("marking for later soft reset on chargepoint: %s %s",id,request.Status)
+		conn.log.TRACE.Printf("marking for later soft reset on chargepoint: %s %s", id, request.Status)
 		conn.SetNeedsReset(true)
 	}
 	if request.Status == core.ChargePointStatusAvailable && conn != nil && conn.ResetAfterStop() {
-		conn.log.TRACE.Printf("checking soft reset on free chargepoint: %s %s is %t",id,request.Status,conn.NeedsReset())
+		conn.log.TRACE.Printf("checking soft reset on free chargepoint: %s %s is %t", id, request.Status, conn.NeedsReset())
 		if conn.NeedsReset() {
-			conn.log.TRACE.Printf("actually performing soft reset on free chargepoint: %s",conn.ChargePoint().ID())
+			conn.log.TRACE.Printf("actually performing soft reset on free chargepoint: %s", conn.ChargePoint().ID())
 			conn.SetNeedsReset(false)
 			cs.TriggerResetRequest(conn.ChargePoint().ID(), core.ResetTypeSoft)
 		} else {
-			conn.log.TRACE.Printf("not performing soft reset on free chargepoint: %s",conn.ChargePoint().ID())
+			conn.log.TRACE.Printf("not performing soft reset on free chargepoint: %s", conn.ChargePoint().ID())
 		}
 	}
 

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -96,6 +96,21 @@ func (cs *CS) OnStatusNotification(id string, request *core.StatusNotificationRe
 	if err != nil {
 		return nil, err
 	}
+	conn := cp.connectorByID(request.ConnectorId)
+	if request.Status == core.ChargePointStatusPreparing && conn != nil && conn.ResetAfterStop() {
+		conn.log.TRACE.Printf("marking for later soft reset on chargepoint: %s %s",id,request.Status)
+		conn.SetNeedsReset(true)
+	}
+	if request.Status == core.ChargePointStatusAvailable && conn != nil && conn.ResetAfterStop() {
+		conn.log.TRACE.Printf("checking soft reset on free chargepoint: %s %s is %t",id,request.Status,conn.NeedsReset())
+		if conn.NeedsReset() {
+			conn.log.TRACE.Printf("actually performing soft reset on free chargepoint: %s",conn.ChargePoint().ID())
+			conn.SetNeedsReset(false)
+			cs.TriggerResetRequest(conn.ChargePoint().ID(), core.ResetTypeSoft)
+		} else {
+			conn.log.TRACE.Printf("not performing soft reset on free chargepoint: %s",conn.ChargePoint().ID())
+		}
+	}
 
 	return cp.StatusNotification(request)
 }

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -3,6 +3,7 @@ package ocpp
 import (
 	"sync"
 	"time"
+	"net/http"
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/lorenzodonini/ocpp-go/ocpp"
@@ -31,6 +32,7 @@ func Instance() *CS {
 
 		server := ws.NewServer()
 		server.SetTimeoutConfig(timeoutConfig)
+		server.SetCheckOriginHandler(func(r *http.Request) bool { return true })
 
 		dispatcher := ocppj.NewDefaultServerDispatcher(ocppj.NewFIFOQueueMap(0))
 		dispatcher.SetTimeout(time.Minute)

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -1,9 +1,9 @@
 package ocpp
 
 import (
+	"net/http"
 	"sync"
 	"time"
-	"net/http"
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/lorenzodonini/ocpp-go/ocpp"

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -76,6 +76,16 @@ params:
     description:
       de: Einheit, in der ChargingProfile-Werte gesetzt werden ("W" oder "A")
       en: Unit for setting ChargingProfile values ("W" or "A")
+  - name: resetafterstop
+    advanced: true
+    type: bool
+    default: false
+    description:
+      de: Charger Reset nach Transaktionsende um Laden ohne ocpp zu stoppen (free charge mode)
+      en: charger reset after end of transaction to prevent non ocpp loading (free charge mode)
+    help:
+      de: Enercab Smart laedt nach Aus sonst mit 6A weiter solange Fahrzeug verbunden ist
+      en: Enercab Smart would continue loading after Off with 6A as long as vehicle is connected
 render: |
   {{ include "ocpp" . }}
   {{- if ne .getconfiguration "true" }}
@@ -92,4 +102,7 @@ render: |
   {{- end }}
   {{- if .chargingrateunit }}
   chargingrateunit: {{ .chargingrateunit }}
+  {{- end }}
+  {{- if ne .resetafterstop "false" }}
+  resetafterstop: {{ .resetafterstop }}
   {{- end }}


### PR DESCRIPTION
Enercab Smart ( https://www.enercab.at/starkstrom-11kw-3x16a/1219-enercab-smart-3x16a-400cee-11kw-100m-starkstrom-intelligentes-ladekabel-9120099491495.html ) can be used in OCPP mode, however when switching to websocket it sends "file://" as source string which by deafault is rejected by lorenzodoninis library, so a handler has to be set to accept it.
The next problem is that the power value is sent as a space padded string which has to be trimmed.

With these 2 fixes loading will work, but pausing in PV mode will not. Or turning off, because it will start charging on its own shortly after. There is a "free charge mode" in the local wallbox gui which has to be disabled to prevent it from charging immediately when being plugged in, but this flag seems not to work once it has power and loaded already. However a soft reset can be performed after sending the disable command, or when the car has disconnected and reconnected later at night with no PV. So an optional ocpp parameter resetafterstop has been added to cover this. It will make the charger behave as if it had just been plugged to its power source and not start to load.

Example config:
chargers:
- type: template
  template: ocpp
  stationid: 30J-HZH-5R4
  connector: 1
  connecttimeout: 5m
  timeout: 2m
  getconfiguration: true
  bootnotification: true
  meterinterval: 1m
  chargingrateunit: A
  name: enercab
  resetafterstop: true

In the chargers webgui the url has to be set to ws://a.b.c.d:8887/ without stationid which is the chargers serial number. No ssl, no Authentication and set Free charge mode to OFF if you want to control pausing.

