### PR TITLE
Loadpoint: use measured power for calculation if available

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1185,6 +1185,13 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower float64, batter
 	// calculate target charge current from delta power and actual current
 	activePhases := lp.ActivePhases()
 	effectiveCurrent := lp.effectiveCurrent()
+
+	// use measured power if available
+	measuredPower, err := lp.chargeMeter.CurrentPower()
+	if err == nil {
+		effectiveCurrent = powerToCurrent(measuredPower, activePhases)
+	}
+
 	if scaledTo == 3 {
 		// if we did scale, adjust the effective current to the new phase count
 		effectiveCurrent /= 3.0


### PR DESCRIPTION
Instead of assuming the loadpoint is charging with `lp.effectiveCurrent` use `lp.chargeMeter.CurrentPower()` to calculate the actual charging current. If no power measurement is available, fall back to the old method.

This fixes [#13322](https://github.com/evcc-io/evcc/discussions/13322) where loads with long reaction times cause evcc to allow more current than available which results in oscillation.

Tested it on my installation without problems but may need some testing in other configurations.