### PR TITLE
Fiat: ignore HTTP 403 during deep refresh

### DIFF
--- a/vehicle/fiat/provider.go
+++ b/vehicle/fiat/provider.go
@@ -1,11 +1,14 @@
 package fiat
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/provider"
+	"github.com/evcc-io/evcc/util/request"
 )
 
 const refreshTimeout = 2 * time.Minute
@@ -48,6 +51,11 @@ func (v *Provider) deepRefresh() error {
 	res, err := v.action("ev", "DEEPREFRESH")
 	if err == nil && res.ResponseStatus != "pending" {
 		err = fmt.Errorf("invalid response status: %s", res.ResponseStatus)
+	} else {
+		var se request.StatusError
+		if errors.As(err, &se) && se.StatusCode() == http.StatusForbidden {
+			err = nil
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/pull/13223#issuecomment-2054064235