### PR TITLE
Log UI: fixed button layout

### DIFF
--- a/assets/js/views/Log.vue
+++ b/assets/js/views/Log.vue
@@ -5,10 +5,10 @@
 			<div class="logs d-flex flex-column overflow-hidden flex-grow-1 px-4 mx-2 mx-sm-4">
 				<div class="flex-grow-0 row py-4">
 					<div class="col-6 col-lg-3 mb-4 mb-lg-0 d-flex gap-2">
-						<div class="btn-group">
+						<div class="btn-group w-100 w-lg-auto d-flex">
 							<button
 								type="button"
-								class="btn text-nowrap d-flex w-100 w-lg-auto justify-content-between"
+								class="btn text-nowrap d-flex gap-2 flex-grow-1 text-nowrap text-truncate"
 								:class="autoFollow ? 'btn-secondary' : 'btn-outline-secondary'"
 								@click="toggleAutoFollow"
 							>
@@ -18,13 +18,13 @@
 								<Record
 									v-if="autoFollow"
 									ref="spin"
-									class="ms-1 spin flex-shrink-0"
+									class="spin flex-shrink-0"
 									:style="{ animationDuration: `${updateInterval}ms` }"
 								/>
-								<Play v-else class="ms-1 flex-shrink-0 play" />
+								<Play v-else class="flex-shrink-0 play" />
 							</button>
 							<a
-								class="btn btn-outline-secondary"
+								class="btn btn-outline-secondary flex-grow-0"
 								:aria-label="$t('log.download')"
 								:href="downloadUrl"
 								download


### PR DESCRIPTION
fixes #13437

- Better alignment for buttons and filter
- Truncate long translations if needed

<img width="751" alt="Bildschirmfoto 2024-04-15 um 14 56 17" src="https://github.com/evcc-io/evcc/assets/152287/794e09aa-7e88-40c9-8b1e-a916583912a5">

<img width="477" alt="Bildschirmfoto 2024-04-15 um 14 56 08" src="https://github.com/evcc-io/evcc/assets/152287/99c97eb5-06e3-454d-be3f-7fce9b582932">
