### PR TITLE
Add fullscreen mode

### DIFF
--- a/assets/js/components/Config/UserInterfaceSettings.vue
+++ b/assets/js/components/Config/UserInterfaceSettings.vue
@@ -58,6 +58,22 @@
 				</div>
 			</div>
 		</FormRow>
+		<FormRow
+			v-if="fullscreenAvailable"
+			id="settingsFullscreen"
+			:label="$t('settings.fullscreen.label')"
+		>
+			<button
+				v-if="fullscreenActive"
+				class="btn btn-sm btn-outline-secondary"
+				@click="exitFullscreen"
+			>
+				{{ $t("settings.fullscreen.exit") }}
+			</button>
+			<button v-else class="btn btn-sm btn-outline-secondary" @click="enterFullscreen">
+				{{ $t("settings.fullscreen.enter") }}
+			</button>
+		</FormRow>
 	</div>
 </template>
 
@@ -75,6 +91,7 @@ import {
 import { getThemePreference, setThemePreference, THEMES } from "../../theme";
 import { getUnits, setUnits, UNITS } from "../../units";
 import { getHiddenFeatures, setHiddenFeatures } from "../../featureflags";
+import { isApp } from "../../utils/native";
 
 export default {
 	name: "UserInterfaceSettings",
@@ -89,9 +106,16 @@ export default {
 			language: getLocalePreference() || "",
 			unit: getUnits(),
 			hiddenFeatures: getHiddenFeatures(),
+			fullscreenActive: false,
 			THEMES,
 			UNITS,
 		};
+	},
+	mounted() {
+		document.addEventListener("fullscreenchange", this.fullscreenChange);
+	},
+	unmounted() {
+		document.removeEventListener("fullscreenchange", this.fullscreenChange);
 	},
 	computed: {
 		languageOptions: () => {
@@ -101,6 +125,12 @@ export default {
 			// sort by name
 			locales.sort((a, b) => (a.name < b.name ? -1 : 1));
 			return locales;
+		},
+		fullscreenAvailable: () => {
+			const isSupported = document.fullscreenEnabled;
+			const isPwa =
+				navigator.standalone || window.matchMedia("(display-mode: standalone)").matches;
+			return isSupported && !isPwa && !isApp();
 		},
 	},
 	watch: {
@@ -120,6 +150,17 @@ export default {
 			} else {
 				removeLocalePreference(i18n);
 			}
+		},
+	},
+	methods: {
+		enterFullscreen() {
+			document.documentElement.requestFullscreen();
+		},
+		exitFullscreen() {
+			document.exitFullscreen();
+		},
+		fullscreenChange() {
+			this.fullscreenActive = !!document.fullscreenElement;
 		},
 	},
 };

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -479,6 +479,11 @@ filter = "Filtern"
 [settings]
 title = "Darstellung"
 
+[settings.fullscreen]
+enter = "Vollbild starten"
+exit = "Vollbild beenden"
+label = "Vollbild"
+
 [settings.hiddenFeatures]
 label = "Experimentell"
 value = "Experimentelle UI-Funktionen zeigen."

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -478,6 +478,11 @@ filter = "Filter"
 [settings]
 title = "User Interface"
 
+[settings.fullscreen]
+enter = "Enter fullscreen"
+exit = "Exit fullscreen"
+label = "Fullscreen"
+
 [settings.hiddenFeatures]
 label = "Experimental"
 value = "Show experimental UI features."


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/13416

- 🪟 add fullscreen option to "user interface" dialog
- ☝️ option is only presented if not already in app/pwa-mode and system supports fullscreen (e.g. not in iOS Safari)

I've opted to not make "Enter/Exit fullscreen" a top level navigation entry since it's not an important feature for most use-cases.

![Bildschirmfoto 2024-04-17 um 11 31 31](https://github.com/evcc-io/evcc/assets/152287/b1a4c66d-a81e-401b-8b91-eb54ff8be325)
