### PR TITLE
UI: optimize for tall screens

### DIFF
--- a/assets/js/components/Loadpoints.vue
+++ b/assets/js/components/Loadpoints.vue
@@ -2,7 +2,11 @@
 	<div
 		class="container container--loadpoint px-0 mb-md-2 d-flex flex-column justify-content-center"
 	>
-		<div ref="carousel" class="carousel d-lg-flex flex-wrap">
+		<div
+			ref="carousel"
+			class="carousel d-lg-flex flex-wrap"
+			:class="`carousel--${loadpoints.length}`"
+		>
 			<div
 				v-for="(loadpoint, index) in loadpoints"
 				:key="index"
@@ -188,12 +192,28 @@ export default {
 	}
 }
 
-/* breakpoint lg */
+/* breakpoint lg, 2-col grid */
 @media (min-width: 992px) {
 	.carousel {
 		display: grid !important;
 		grid-gap: 2rem;
 		grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+	}
+}
+
+/* breakpoint lg, tall screen, 2 loadpoints rows */
+@media (min-width: 992px) and (min-height: 1450px) {
+	.carousel--2 {
+		grid-gap: 4rem;
+		grid-template-columns: 1fr;
+	}
+}
+
+/* breakpoint lg, taller screen, 3 loadpoints rows */
+@media (min-width: 992px) and (min-height: 1900px) {
+	.carousel--3 {
+		grid-gap: 4rem;
+		grid-template-columns: 1fr;
 	}
 }
 </style>


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/13505

added special layout for portrait screens (e.g. fridges)

2 loadpoints on tall screen -> 2-row layout

[2 lp responsive.webm](https://github.com/evcc-io/evcc/assets/152287/1ef5e8bc-395e-46e2-af8e-d63f6686c413)


2 loadpoints on taller screen -> 3-row layout

[3 lp responsive.webm](https://github.com/evcc-io/evcc/assets/152287/b8aee2d0-d94f-4827-af0c-dd929f0fa664)
