### PR TITLE
Chore: fail on lint warnings

### DIFF
--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -64,7 +64,7 @@ export default {
 		offline: function () {
 			updateAuthStatus();
 		},
-		startupErrors: function (now, prev) {
+		startupErrors: function (now) {
 			if (now) {
 				console.log("startup errors detected. redirecting to error page");
 				this.$router.push("/error");

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "vite build",
     "test": "TZ=Europe/Berlin vitest",
-    "lint": "prettier assets './**/*.{yml,yaml}' --write && eslint assets/**/*.js assets/**/*.vue --fix",
+    "lint": "prettier assets './**/*.{yml,yaml}' --write && eslint assets/**/*.js assets/**/*.vue --fix --max-warnings=0",
     "dev": "vite",
     "histoire": "histoire dev",
     "playwright": "playwright test --ui",


### PR DESCRIPTION
Don't allow eslint warnings in pipeline.

Currently, warnings are accepted and GitHub highlights them, which is annoying.

![Bildschirmfoto 2024-04-21 um 10 10 17](https://github.com/evcc-io/evcc/assets/152287/991b51b4-bf81-42a2-9ac9-bbf0e9364454)
