### PR TITLE
Loadpoint: add welcomecharge feature

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -10,4 +10,5 @@ const (
 	IntegratedDevice
 	Heating
 	Retryable
+	KickCharge
 )

--- a/api/feature.go
+++ b/api/feature.go
@@ -10,5 +10,5 @@ const (
 	IntegratedDevice
 	Heating
 	Retryable
-	KickCharge
+	WelcomeCharge
 )

--- a/api/feature_enumer.go
+++ b/api/feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "OfflineCoarseCurrentIntegratedDeviceHeatingRetryableKickCharge"
+const _FeatureName = "OfflineCoarseCurrentIntegratedDeviceHeatingRetryableWelcomeCharge"
 
-var _FeatureIndex = [...]uint8{0, 7, 20, 36, 43, 52, 62}
+var _FeatureIndex = [...]uint8{0, 7, 20, 36, 43, 52, 65}
 
-const _FeatureLowerName = "offlinecoarsecurrentintegrateddeviceheatingretryablekickcharge"
+const _FeatureLowerName = "offlinecoarsecurrentintegrateddeviceheatingretryablewelcomecharge"
 
 func (i Feature) String() string {
 	i -= 1
@@ -30,10 +30,10 @@ func _FeatureNoOp() {
 	_ = x[IntegratedDevice-(3)]
 	_ = x[Heating-(4)]
 	_ = x[Retryable-(5)]
-	_ = x[KickCharge-(6)]
+	_ = x[WelcomeCharge-(6)]
 }
 
-var _FeatureValues = []Feature{Offline, CoarseCurrent, IntegratedDevice, Heating, Retryable, KickCharge}
+var _FeatureValues = []Feature{Offline, CoarseCurrent, IntegratedDevice, Heating, Retryable, WelcomeCharge}
 
 var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureName[0:7]:        Offline,
@@ -46,8 +46,8 @@ var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureLowerName[36:43]: Heating,
 	_FeatureName[43:52]:      Retryable,
 	_FeatureLowerName[43:52]: Retryable,
-	_FeatureName[52:62]:      KickCharge,
-	_FeatureLowerName[52:62]: KickCharge,
+	_FeatureName[52:65]:      WelcomeCharge,
+	_FeatureLowerName[52:65]: WelcomeCharge,
 }
 
 var _FeatureNames = []string{
@@ -56,7 +56,7 @@ var _FeatureNames = []string{
 	_FeatureName[20:36],
 	_FeatureName[36:43],
 	_FeatureName[43:52],
-	_FeatureName[52:62],
+	_FeatureName[52:65],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/api/feature_enumer.go
+++ b/api/feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "OfflineCoarseCurrentIntegratedDeviceHeatingRetryable"
+const _FeatureName = "OfflineCoarseCurrentIntegratedDeviceHeatingRetryableKickCharge"
 
-var _FeatureIndex = [...]uint8{0, 7, 20, 36, 43, 52}
+var _FeatureIndex = [...]uint8{0, 7, 20, 36, 43, 52, 62}
 
-const _FeatureLowerName = "offlinecoarsecurrentintegrateddeviceheatingretryable"
+const _FeatureLowerName = "offlinecoarsecurrentintegrateddeviceheatingretryablekickcharge"
 
 func (i Feature) String() string {
 	i -= 1
@@ -30,9 +30,10 @@ func _FeatureNoOp() {
 	_ = x[IntegratedDevice-(3)]
 	_ = x[Heating-(4)]
 	_ = x[Retryable-(5)]
+	_ = x[KickCharge-(6)]
 }
 
-var _FeatureValues = []Feature{Offline, CoarseCurrent, IntegratedDevice, Heating, Retryable}
+var _FeatureValues = []Feature{Offline, CoarseCurrent, IntegratedDevice, Heating, Retryable, KickCharge}
 
 var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureName[0:7]:        Offline,
@@ -45,6 +46,8 @@ var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureLowerName[36:43]: Heating,
 	_FeatureName[43:52]:      Retryable,
 	_FeatureLowerName[43:52]: Retryable,
+	_FeatureName[52:62]:      KickCharge,
+	_FeatureLowerName[52:62]: KickCharge,
 }
 
 var _FeatureNames = []string{
@@ -53,6 +56,7 @@ var _FeatureNames = []string{
 	_FeatureName[20:36],
 	_FeatureName[36:43],
 	_FeatureName[43:52],
+	_FeatureName[52:62],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/core/coordinator/adapter.go
+++ b/core/coordinator/adapter.go
@@ -19,8 +19,8 @@ func NewAdapter(lp loadpoint.API, c *Coordinator) API {
 	}
 }
 
-func (a *adapter) GetVehicles() []api.Vehicle {
-	return a.c.GetVehicles()
+func (a *adapter) GetVehicles(availableOnly bool) []api.Vehicle {
+	return a.c.GetVehicles(availableOnly)
 }
 
 func (a *adapter) Owner(v api.Vehicle) loadpoint.API {

--- a/core/coordinator/api.go
+++ b/core/coordinator/api.go
@@ -7,8 +7,8 @@ import (
 
 // API is the coordinator API
 type API interface {
-	// GetVehicles returns the list of all vehicles
-	GetVehicles() []api.Vehicle
+	// GetVehicles returns the list of all vehicles, filtered by availability
+	GetVehicles(availableOnly bool) []api.Vehicle
 
 	// Owner returns the loadpoint that currently owns the vehicle
 	Owner(api.Vehicle) loadpoint.API

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -30,7 +30,7 @@ func (c *Coordinator) GetVehicles(availableOnly bool) []api.Vehicle {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	var res []api.Vehicle
+	res := make([]api.Vehicle, 0, len(c.vehicles))
 	for _, v := range c.vehicles {
 		if _, tracked := c.tracked[v]; !availableOnly || availableOnly && !tracked {
 			res = append(res, v)

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -1,7 +1,6 @@
 package coordinator
 
 import (
-	"slices"
 	"sync"
 
 	"github.com/evcc-io/evcc/api"
@@ -27,11 +26,18 @@ func New(log *util.Logger, vehicles []api.Vehicle) *Coordinator {
 }
 
 // GetVehicles returns the list of all vehicles
-func (c *Coordinator) GetVehicles() []api.Vehicle {
+func (c *Coordinator) GetVehicles(availableOnly bool) []api.Vehicle {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return slices.Clone(c.vehicles)
+	var res []api.Vehicle
+	for _, v := range c.vehicles {
+		if _, tracked := c.tracked[v]; !availableOnly || availableOnly && !tracked {
+			res = append(res, v)
+		}
+	}
+
+	return res
 }
 
 // Owner returns the loadpoint that currently owns the vehicle

--- a/core/coordinator/dummy.go
+++ b/core/coordinator/dummy.go
@@ -12,7 +12,7 @@ func NewDummy() API {
 	return new(dummy)
 }
 
-func (a *dummy) GetVehicles() []api.Vehicle {
+func (a *dummy) GetVehicles(_ bool) []api.Vehicle {
 	return nil
 }
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -485,8 +485,8 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 	// Enable charging on connect if any available vehicle requires it. We're using the PV timer
 	// to disable after the welcome, hence this must be placed after elapsePVTimer.
 	// TODO check is this doesn't conflict with vehicle defaults like mode: off
-	if vv := lp.availableVehicles(); pvMode {
-		for _, v := range vv {
+	if pvMode {
+		for _, v := range lp.availableVehicles() {
 			if slices.Contains(v.Features(), api.WelcomeCharge) {
 				lp.setLimit(lp.effectiveMinCurrent())
 				break

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -482,12 +482,12 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 	// immediately allow pv mode activity
 	lp.elapsePVTimer()
 
-	// kick-charge if any available vehicle requires it
-	// since kickCharge uses the PV timer it must be placed after elapsePVTimer
+	// Enable charging on connect if any available vehicle requires it. We're using the PV timer
+	// to disable after the welcome, hence this must be placed after elapsePVTimer.
 	// TODO check is this doesn't conflict with vehicle defaults like mode: off
 	if vv := lp.availableVehicles(); pvMode {
 		for _, v := range vv {
-			if slices.Contains(v.Features(), api.KickCharge) {
+			if slices.Contains(v.Features(), api.WelcomeCharge) {
 				lp.setLimit(lp.effectiveMinCurrent())
 				break
 			}

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -20,12 +20,20 @@ const (
 	vehicleDetectDuration = 10 * time.Minute
 )
 
+// availableVehicles is the slice of vehicles from the coordinator that are available
+func (lp *Loadpoint) availableVehicles() []api.Vehicle {
+	if lp.coordinator == nil {
+		return nil
+	}
+	return lp.coordinator.GetVehicles(true)
+}
+
 // coordinatedVehicles is the slice of vehicles from the coordinator
 func (lp *Loadpoint) coordinatedVehicles() []api.Vehicle {
 	if lp.coordinator == nil {
 		return nil
 	}
-	return lp.coordinator.GetVehicles()
+	return lp.coordinator.GetVehicles(false)
 }
 
 // setVehicleIdentifier updated the vehicle id as read from the charger


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/13423

This PR adds a `kickcharge` feature (are there better names)? When a vehicle connection is detected, and any of the vehicles that are currently _not_ connected to any charger has this feature, then charging will start immediately if in PV mode.

This works such that vehicle defaults (like resetting mode) are only applied after starting the charging session.