### PR TITLE
Startup Error: readded error message and config infos

### DIFF
--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -22,9 +22,9 @@ import HelpModal from "../components/HelpModal.vue";
 import collector from "../mixins/collector";
 import { updateAuthStatus } from "../auth";
 
-// assume offline if not data received for 60 seconds
+// assume offline if not data received for 5 minutes
 let lastDataReceived = new Date();
-const maxDataAge = 60 * 1000;
+const maxDataAge = 60 * 1000 * 5;
 setInterval(() => {
 	if (new Date() - lastDataReceived > maxDataAge) {
 		console.log("no data received, assume we are offline");

--- a/assets/js/views/StartupError.vue
+++ b/assets/js/views/StartupError.vue
@@ -77,20 +77,26 @@
 import "@h2d2/shopicons/es/regular/car1";
 import api from "../api";
 import collector from "../mixins/collector";
+import store from "../store";
 
 export default {
 	name: "StartupError",
 	mixins: [collector],
 	props: {
-		fatal: Array,
-		config: String,
-		file: String,
-		line: Number,
 		offline: Boolean,
 	},
 	computed: {
 		errors() {
-			return this.fatal || [];
+			return store.state.fatal || [];
+		},
+		config() {
+			return store.state.config;
+		},
+		file() {
+			return store.state.file;
+		},
+		line() {
+			return store.state.line;
 		},
 	},
 	methods: {


### PR DESCRIPTION
fixes regression from https://github.com/evcc-io/evcc/pull/13330

- 🧰 error message and config details are now shown again
- ⛈️ increased the "web socket is dead" detection period from 1m to 5m to not interfere with the current no-updates & auto-restart behavior in startup error state.