### PR TITLE
UI: better handle api errors when offline

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,6 +28,7 @@ const app = createApp({
   },
   methods: {
     raise: function (msg) {
+      if (this.offline) return;
       if (!msg.level) msg.level = "error";
       const now = new Date();
       const latestMsg = this.notifications[0];

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -4,14 +4,14 @@ import Modal from "bootstrap/js/dist/modal";
 
 const auth = reactive({
   configured: true,
-  loggedIn: false,
+  loggedIn: null, // true / false / null (unknown)
   nextUrl: null,
 });
 
 export async function updateAuthStatus() {
   try {
     const res = await api.get("/auth/status", {
-      validateStatus: (code) => [200, 501].includes(code),
+      validateStatus: (code) => [200, 501, 500].includes(code),
     });
     if (res.status === 501) {
       auth.configured = false;
@@ -19,6 +19,10 @@ export async function updateAuthStatus() {
     if (res.status === 200) {
       auth.configured = true;
       auth.loggedIn = res.data === true;
+    }
+    if (res.status === 500) {
+      auth.loggedIn = null;
+      console.log("unable to fetch auth status", res);
     }
   } catch (e) {
     console.log("unable to fetch auth status", e);
@@ -36,7 +40,11 @@ export async function logout() {
 }
 
 export function isLoggedIn() {
-  return auth.loggedIn;
+  return auth.loggedIn === true;
+}
+
+export function statusUnknown() {
+  return auth.loggedIn === null;
 }
 
 export function isConfigured() {

--- a/assets/js/components/TelemetrySettings.vue
+++ b/assets/js/components/TelemetrySettings.vue
@@ -75,9 +75,12 @@ export default {
 				return;
 			}
 			try {
-				const response = await api.get("settings/telemetry");
-				console.log("update in settings", response.data.result);
-				settings.telemetry = response.data.result;
+				const response = await api.get("settings/telemetry", {
+					validateStatus: () => true,
+				});
+				if (response.status === 200) {
+					settings.telemetry = response.data.result;
+				}
 			} catch (err) {
 				console.error(err);
 			}

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -2,7 +2,7 @@ import { createRouter, createWebHashHistory } from "vue-router";
 import Modal from "bootstrap/js/dist/modal";
 import Main from "./views/Main.vue";
 import { ensureCurrentLocaleMessages } from "./i18n";
-import { openLoginModal, updateAuthStatus, isLoggedIn } from "./auth";
+import { openLoginModal, statusUnknown, updateAuthStatus, isLoggedIn } from "./auth";
 
 function hideAllModals() {
   [...document.querySelectorAll(".modal.show")].forEach((modal) => {
@@ -18,7 +18,7 @@ function hideAllModals() {
 
 async function ensureAuth(to) {
   await updateAuthStatus();
-  if (!isLoggedIn()) {
+  if (!isLoggedIn() && !statusUnknown()) {
     openLoginModal(to.path);
     return false;
   }

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -466,14 +466,16 @@ export default {
 		},
 		async updateValues() {
 			clearTimeout(this.deviceValueTimeout);
+			if (!this.offline) {
+				const promises = [
+					...this.meters.map((meter) => this.updateDeviceValue("meter", meter.name)),
+					...this.vehicles.map((vehicle) =>
+						this.updateDeviceValue("vehicle", vehicle.name)
+					),
+				];
 
-			const promises = [
-				...this.meters.map((meter) => this.updateDeviceValue("meter", meter.name)),
-				...this.vehicles.map((vehicle) => this.updateDeviceValue("vehicle", vehicle.name)),
-			];
-
-			await Promise.all(promises);
-
+				await Promise.all(promises);
+			}
 			this.deviceValueTimeout = setTimeout(this.updateValues, 10000);
 		},
 		deviceTags(type, id) {


### PR DESCRIPTION
fixes #13570

- 🍋 don't refresh device status (config) when offline
- 🔺 don't show rest api errors when offline
- 🔑 don't show passwort prompt when endpoint couldn't be reached (added unknown state)

subset of https://github.com/evcc-io/evcc/pull/13319 which also includes some other major improvements when offline or while restarting.