### PR TITLE
Keba: fixes to api.PhaseGetter

### DIFF
--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -287,12 +287,14 @@ func (wb *Keba) phases1p3p(phases int) error {
 
 // getPhases implements the api.PhaseGetter interface
 func (wb *Keba) getPhases() (int, error) {
-	b, err := wb.conn.ReadHoldingRegisters(kebaRegPhaseState, 1)
+	b, err := wb.conn.ReadHoldingRegisters(kebaRegPhaseState, 2)
 	if err != nil {
 		return 0, err
 	}
-
-	return int(binary.BigEndian.Uint16(b)), nil
+	if binary.BigEndian.Uint32(b) == 0 {
+		return 1, nil
+	}
+	return 3, nil
 }
 
 var _ api.Diagnosis = (*Keba)(nil)


### PR DESCRIPTION
- Fixes register read length of kebaRegPhaseState to 32 bits.
- This register holds the state of the external contactor ( 2 x normally open), which is used to switch between 1 phase and 3 phases. If this register holds a zero, only one phase is active. If it holds a one, three phases are active.