### PR TITLE
Add description and battery control for E3/DC RSCP template

### DIFF
--- a/templates/definition/meter/e3dc-rscp.yaml
+++ b/templates/definition/meter/e3dc-rscp.yaml
@@ -5,15 +5,13 @@ capabilities: ["battery-control"]
 requirements:
   description:
     de: |
-      Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key bzw. RSCP-Passwort wird im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt.
-      Bei aktiver Batteriesteuerung kann nicht nur eine Entladesperre gesetzt, sondern eine Leistung definiert werden, welche die Batterie im 'Halten' Batteriemodus dennoch liefert, z.B. um wenigstens noch den Hausverbrauch zu bedienen. So wird die Batterie weiterhin moderat entladen und hat damit die Möglichkeit am nächsten Tag mehr PV-Überschuß aufzunehmen.
+      Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key (=RSCP-Passwort) muss im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt werden.
 
-      **Achtung**: Die aktive Batteriesteuerung sollte nur verwendet werden, wenn keine weiteren Einstellungen im Smart-Power/Betriebsbereich getätigt wurden, denn bestehende Einstellungen werden überschrieben.
+      **Achtung**: Die aktive Batteriesteuerung überschreibt Einstellungen im Smart-Power/Betriebsbereich.
     en: |
-      Username and password are identical to Web Portal or My E3/DC App access. Key resp. RSCP-Password must be set in the E3/DC System at Personalize/User Profile.
-      With active battery control, not only can a discharge lock be set, but a power can be defined that the battery still delivers in 'hold' battery mode, e.g. to at least meet household consumption. This will continue to moderately discharge the battery, potentially allowing it to store more PV surplus the next day.
+      Username and password are identical to Web Portal or My E3/DC App access. Key (=RSCP-Password) must be set in the E3/DC System at Personalize/User Profile.
 
-      **Attention**: Active battery control should only be used if no other settings in Smart-Power/Operating Range have been set, as existing settings will be overwritten.
+      **Note**: Active battery control will override Smart-Power/Operating Range settings.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/e3dc-rscp.yaml
+++ b/templates/definition/meter/e3dc-rscp.yaml
@@ -27,8 +27,8 @@ params:
     advanced: true
   - name: dischargelimit
     description:
-      de: Entladelimit in W (0=Entladesperre)
-      en: Discharge limit in W (0=Discharge lock)
+      de: Entladelimit in W
+      en: Discharge limit in W
     help:
       de: Limitiert die Entladeleistung im 'Halten' Batteriemodus
       en: Limits discharge power in 'Hold' battery mode

--- a/templates/definition/meter/e3dc-rscp.yaml
+++ b/templates/definition/meter/e3dc-rscp.yaml
@@ -1,6 +1,19 @@
 template: e3dc-rscp
 products:
   - brand: E3/DC
+capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key bzw. RSCP-Passwort wird im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt.
+      Bei aktiver Batteriesteuerung kann nicht nur eine Entladesperre gesetzt, sondern eine Leistung definiert werden, welche die Batterie im 'Halten' Batteriemodus dennoch liefert, z.B. um wenigstens noch den Hausverbrauch zu bedienen. So wird die Batterie weiterhin moderat entladen und hat damit die Möglichkeit am nächsten Tag mehr PV-Überschuß aufzunehmen.
+
+      **Achtung**: Die aktive Batteriesteuerung sollte nur verwendet werden, wenn keine weiteren Einstellungen im Smart-Power/Betriebsbereich getätigt wurden, denn bestehende Einstellungen werden überschrieben.
+    en: |
+      Username and password are identical to Web Portal or My E3/DC App access. Key resp. RSCP-Password must be set in the E3/DC System at Personalize/User Profile.
+      With active battery control, not only can a discharge lock be set, but a power can be defined that the battery still delivers in 'hold' battery mode, e.g. to at least meet household consumption. This will continue to moderately discharge the battery, potentially allowing it to store more PV surplus the next day.
+
+      **Attention**: Active battery control should only be used if no other settings in Smart-Power/Operating Range have been set, as existing settings will be overwritten.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -16,8 +29,8 @@ params:
     advanced: true
   - name: dischargelimit
     description:
-      de: Entladelimit in W
-      en: Discharge limit in W
+      de: Entladelimit in W (0=Entladesperre)
+      en: Discharge limit in W (0=Discharge lock)
     help:
       de: Limitiert die Entladeleistung im 'Halten' Batteriemodus
       en: Limits discharge power in 'Hold' battery mode


### PR DESCRIPTION
I've added some more description for setup, the `battery-control` flag and a hint how to get a discharge lock.

We should add some hint about the number that should be used for `battery` parameter. This is normally "0" at single battery storage setups and is mandatory to get battery capacity from the system.

```
de: Index des Batteriespeichers im System (bei Systemen mit 1 Batteriespeicher ist dieser normalerweise 0)
en: Index of battery storage in the system (for systems with 1 battery storage this is usually 0)
```