### PR TITLE
Guard against expiring tokens due to wrong database

### DIFF
--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -31,7 +31,7 @@ func init() {
 
 func runCharger(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/charger_ramp.go
+++ b/cmd/charger_ramp.go
@@ -66,7 +66,7 @@ func ramp(c api.Charger, digits int, delay time.Duration) {
 
 func runChargerRamp(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/check_config.go
+++ b/cmd/check_config.go
@@ -19,7 +19,7 @@ func init() {
 }
 
 func runConfigCheck(cmd *cobra.Command, args []string) {
-	err := loadConfigFile(&conf)
+	err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed)
 
 	if err != nil {
 		log.FATAL.Println("config invalid:", err)

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -24,7 +24,7 @@ func init() {
 
 func runDevice(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -35,7 +35,7 @@ func errorString(err error) string {
 }
 
 func runDiscuss(cmd *cobra.Command, args []string) {
-	cfgErr := loadConfigFile(&conf)
+	cfgErr := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed)
 
 	file, pathErr := filepath.Abs(cfgFile)
 	if pathErr != nil {

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -45,7 +45,7 @@ func handle[T any](name string, h config.Handler[T]) config.Device[T] {
 
 func runDump(cmd *cobra.Command, args []string) {
 	// load config
-	err := loadConfigFile(&conf)
+	err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed)
 
 	// setup environment
 	if err == nil {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,6 +9,9 @@ const (
 	flagHeaders            = "log-headers"
 	flagHeadersDescription = "Log headers"
 
+	flagIgnoreDatabase            = "ignore-db"
+	flagIgnoreDatabaseDescription = "Run command ignoring service database"
+
 	flagBatteryMode                = "battery-mode"
 	flagBatteryModeDescription     = "Set battery mode (normal, hold, charge)"
 	flagBatteryModeWait            = "battery-mode-wait"

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -25,7 +25,7 @@ func init() {
 
 func runMeter(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/password_reset.go
+++ b/cmd/password_reset.go
@@ -19,7 +19,7 @@ func init() {
 
 func runPasswordReset(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/password_set.go
+++ b/cmd/password_set.go
@@ -19,7 +19,7 @@ func init() {
 
 func runPasswordSet(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/settings-get.go
+++ b/cmd/settings-get.go
@@ -24,7 +24,7 @@ func init() {
 
 func runSettingsGet(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/settings-set.go
+++ b/cmd/settings-set.go
@@ -23,7 +23,7 @@ func init() {
 
 func runSettingsSet(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -203,7 +203,7 @@ Running evcc with vehicles configured in evcc.yaml may lead to expiring the yaml
 This is due to the fact, that the token refresh will be saved to the local instead of the service's database.
 If you have vehicles with touchy tokens like PSA or Tesla, make sure to remove vehicle configuration from the yaml file.
 
-If you now what you're doing, you can run evcc ignoring the service database with the --ignore-db flag.
+If you know what you're doing, you can run evcc ignoring the service database with the --ignore-db flag.
 `)
 	}
 

--- a/cmd/tariff.go
+++ b/cmd/tariff.go
@@ -24,7 +24,7 @@ func init() {
 
 func runTariff(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		fatal(err)
 	}
 

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -24,7 +24,7 @@ func init() {
 
 func runToken(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		log.FATAL.Fatal(err)
 	}
 

--- a/cmd/vehicle.go
+++ b/cmd/vehicle.go
@@ -28,7 +28,7 @@ func init() {
 
 func runVehicle(cmd *cobra.Command, args []string) {
 	// load config
-	if err := loadConfigFile(&conf); err != nil {
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
 		fatal(err)
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/13479

This PR will prevent evcc from starting if a secondary service database is detected.