### PR TITLE
chore: [Bug Template] make clear that the log need to show the issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -47,7 +47,7 @@ body:
       label: Log details
       render: text
       description: >
-        Show evcc log output by running with <code>evcc --log debug</code>. The evcc service **MUST** be stopped before running this command.
+        Show evcc log output of the issue, see https://docs.evcc.io/en/docs/faq#how-do-i-create-a-log-file-for-error-analysis for instructions.
 
   - type: dropdown
     validations:


### PR DESCRIPTION
Es passiert ja leider immer mal wieder, dass irgendeine Log und nicht eine die das Problem zeigt im Issue verwendet wird.

Auch wenn man eigentlich denkt, dass es offensichtlich ist, gibt es regelmäßig einfach irgendeine log.