### PR TITLE
tariff/octopusenergy: Fix parsing of Tariff variable

### DIFF
--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -48,7 +48,7 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		if cc.Region == "" {
 			return nil, errors.New("missing region")
 		}
-		if cc.Tariff == "" {
+		if cc.Tariff != "" {
 			// deprecated - copy to correct slot and WARN
 			logger.WARN.Print("'tariff' is deprecated and will break in a future version - use 'productCode' instead")
 			cc.ProductCode = cc.Tariff

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -1,0 +1,35 @@
+package tariff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOctopusConfigParse(t *testing.T) {
+	// This test will start failing if you remove the deprecated "tariff" config var.
+	validTariffConfig := map[string]interface{}{
+		"region": "H",
+		"tariff": "GO-22-03-29",
+	}
+
+	_, err := NewOctopusFromConfig(validTariffConfig)
+	require.NoError(t, err)
+
+	validProductCodeConfig := map[string]interface{}{
+		"region":      "H",
+		"productcode": "GO-22-03-29",
+	}
+
+	_, err = NewOctopusFromConfig(validProductCodeConfig)
+	require.NoError(t, err)
+
+	invalidApiAndProductCodeConfig := map[string]interface{}{
+		"region":      "H",
+		"productcode": "GO-22-03-29",
+		"apikey":      "nope",
+	}
+	_, err = NewOctopusFromConfig(invalidApiAndProductCodeConfig)
+	require.Error(t, err)
+
+}

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -31,5 +31,4 @@ func TestOctopusConfigParse(t *testing.T) {
 	}
 	_, err = NewOctopusFromConfig(invalidApiAndProductCodeConfig)
 	require.Error(t, err)
-
 }


### PR DESCRIPTION
This PR resolves a silly typo I made that causes usage of the old `tariff` configuration variable to fail hard instead of with a deprecation warning.

Also includes a test for parsing (feel free to expand, I kinda ran out of time implementing)

Closes #13786