### PR TITLE
Frauenhofer ISE energy-charts-api | masked &end parameter for runtime readout

### DIFF
--- a/templates/definition/tariff/energy-charts-api.yaml
+++ b/templates/definition/tariff/energy-charts-api.yaml
@@ -37,5 +37,5 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://api.energy-charts.info/price?bzn={{ .bzn }}&end={{ now | dateModify "+24h" | date "2006-01-02" }}
+    uri: https://api.energy-charts.info/price?bzn={{ .bzn }}&end={{"{{"}} now | dateModify "+24h" | date "2006-01-02" {{"}}"}}
     jq: '[.unix_seconds, .price] | transpose | map({ "start": (.[0] | todate), "end": ((.[0]+3600) | todate), "price": (.[1]/1000)}) | tostring'


### PR DESCRIPTION
> läuft nun.. aber noch nicht getestet, ob das "verstecken" der Klammern notwendig ist.
> 
> `{{"{{"}} now {{"}}"}}`

> Doch, müssen sein- sonst würden die Funktionen direkt beim Template einlesen ausgeführt anstatt erst zur Laufzeit der Abfrage. Läuft bei mir auch- sehr schön 👍🏻

War nur noch nicht eingebaut ;) - wollte es ja noch testen.. mit "Maskierung" funktioniert es aber weiterhin.

`&end={{"{{"}} now | dateModify "+24h" | date "2006-01-02" {{"}}"}}`