### PR TITLE
Fix: render testing skips tests after first usage == 0

### DIFF
--- a/tariff/template_test.go
+++ b/tariff/template_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 var acceptable = []string{
-	"missing token",         //amber, tibber
-	"invalid zipcode",       //grünstromindex
-	"invalid apikey format", //octopusenergy
-	"missing region",        //octopusenergy
+	"missing token",         // amber, tibber
+	"invalid zipcode",       // grünstromindex
+	"invalid apikey format", // octopusenergy
+	"missing region",        // octopusenergy
 }
 
 func TestTemplates(t *testing.T) {

--- a/tariff/template_test.go
+++ b/tariff/template_test.go
@@ -7,7 +7,12 @@ import (
 	"github.com/evcc-io/evcc/util/test"
 )
 
-var acceptable = []string{}
+var acceptable = []string{
+	"missing token",         //amber, tibber
+	"invalid zipcode",       //grünstromindex
+	"invalid apikey format", //octopusenergy
+	"missing region",        //octopusenergy
+}
 
 func TestTemplates(t *testing.T) {
 	templates.TestClass(t, templates.Tariff, func(t *testing.T, values map[string]any) {

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -68,8 +68,6 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 					instantiate(t, values)
 				})
 			})
-
-			return
 		}
 
 		for _, u := range usages {

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -68,6 +68,8 @@ func TestClass(t *testing.T, class Class, instantiate func(t *testing.T, values 
 					instantiate(t, values)
 				})
 			})
+
+			continue
 		}
 
 		for _, u := range usages {

--- a/vehicle/template_test.go
+++ b/vehicle/template_test.go
@@ -22,6 +22,9 @@ var acceptable = []string{
 	"missing credentials",    // Tesla
 	"missing credentials id", // Tronity
 	"missing access and/or refresh token, use `evcc token` to create", // Tesla
+	"login failed: code not found",                                    //Polestar
+	"empty instance type- check for missing usage",                    // Merces
+	"invalid vehicle type: tesla",                                     //Tesla
 }
 
 func TestTemplates(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug originally introduced as part of #10272.
The return I am getting rid off here now would have had to become a continue when I changed the logic back last year.
That said, removing it simply also is OK, is the range over usages will not even start the loop if the usage count is 0.

Additionally, and why I am marking as draft @andig, is that now that more tests are running again, some of the recent changes now started to show failures when running locally.
I assume some errors are OK, while others might actually indicate we have a real issue with some of the default data + template combinations. I am frankly unsure how to confirm if these errors are real or not, so I could use some help with sorting these.