### PR TITLE
Mercedes: fix configured vehicle cannot be modified

### DIFF
--- a/cmd/token_mercedes.go
+++ b/cmd/token_mercedes.go
@@ -43,7 +43,7 @@ func mercedesPinPrompt() (string, error) {
 }
 
 func mercedesToken() (*oauth2.Token, error) {
-	// Get username and region from user to initate the email process
+	// Get username and region from user to initiate the email process
 	username, region, err := mercedesUsernameAndRegionPrompt()
 	if err != nil {
 		return nil, err
@@ -55,17 +55,14 @@ func mercedesToken() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	if result {
-		pin, err := mercedesPinPrompt()
-		if err != nil {
-			return nil, err
-		}
-
-		token, err := api.RequestAccessToken(*nonce, pin)
-		if err == nil {
-			return token, nil
-		}
+	if !result {
+		return nil, errors.New("unknown PinResponse - 200, result empty")
 	}
 
-	return nil, errors.New("unknown PinResponse - 200, Email empty")
+	pin, err := mercedesPinPrompt()
+	if err != nil {
+		return nil, err
+	}
+
+	return api.RequestAccessToken(*nonce, pin)
 }

--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -4,56 +4,47 @@ products:
 requirements:
   description:
     de: |
-      Die Konfiguration der Mercedes-Benz Integration nur im yaml Modus möglich.
-      Ablauf:
-        1. Hinzufügen der Konfiguration in die evcc.yaml (ohne Token)
-          ```
-          vehicles:
-            - name: my_car
-              type: mercedes
-              account: # Mercedes Me Nutzer-Id (email)
-              region: # MB me Region (EMEA, APAC, NORAM)
-              vin: W... # Erforderlich, wenn mehr als ein Fahrzeug im Account registriert
-              capacity: 50 # Akkukapazität in kWh (optional)
-          ```
-        2. Token Generierung: Ausführen von `./evcc token mercedes` oder `evcc token [name]`, wenn name gesetzt ist.  
-        3. Einfügen der Tokens in die evcc.yaml
-          ```
-          vehicles:
-            - name: my_car
-              type: mercedes
-              account: # Mercedes Me Nutzer-Id (email)
-              region: # MB me Region (EMEA, APAC, NORAM)
-              vin: W... # , wenn mehr als ein Fahrzeug im Account registriert
-              capacity: 50 # Akkukapazität in kWh (optional)
-              tokens:
-                access: token...
-                refresh: token...
-          ```
+      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
     en: |
-      The configuration of the Mercedes-Benz integration is only possible in yaml mode.
-      Procedure:
-        1. add the configuration to evcc.yaml (without token)
-          ```
-          vehicles:
-            - name: my_car
-              type: mercedes
-              account: # Mercedes Me user-Id (email)
-              region: # MB me region (EMEA, APAC, NORAM)
-              vin: W... # Required, if more then one car is registered in this account
-              capacity: 50 # capacity in kWh (optional)
-          ```
-        2. Token generation: execute `./evcc token mercedes` or `evcc token [name]`, when name is defined
-        3. insert the tokens into evcc.yaml
-          ```
-          vehicles:
-            - name: my_car
-              type: mercedes
-              account: # Mercedes Me user-id (email)
-              region: # MB me region (EMEA, APAC, NORAM)
-              vin: W... # Required, if more then one car is registered in this account
-              capacity: 50 # capacity in kWh (optional)
-              tokens:
-                access: token...
-                refresh: token...
-          ```
+      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+params:
+  - name: title
+  - name: icon
+    default: car
+    advanced: true
+  - name: user
+    required: true
+  - name: region
+    required: true
+    validvalues: [EMEA, APAC, NORAM]
+    default: EMEA
+  - name: accessToken
+    required: true
+    mask: true
+    help:
+      en: "See https://docs.evcc.io/en/docs/devices/vehicles#mercedes"
+      de: "Siehe https://docs.evcc.io/docs/devices/vehicles#mercedes"
+  - name: refreshToken
+    required: true
+    mask: true
+    help:
+      en: "See https://docs.evcc.io/en/docs/devices/vehicles#mercedes"
+      de: "Siehe https://docs.evcc.io/docs/devices/vehicles#mercedes"
+  - name: vin
+    example: V...
+  - name: capacity
+  - name: phases
+    advanced: true
+  - preset: vehicle-identify
+render: |
+  type: mercedes
+  title: {{ .title }}
+  icon: {{ .icon }}
+  user: {{ .user }}
+  tokens:
+    access: {{ .accessToken }}
+    refresh: {{ .refreshToken }}
+  capacity: {{ .capacity }}
+  phases: {{ .phases }}
+  vin: {{ .vin }}
+  {{ include "vehicle-identify" . }}


### PR DESCRIPTION
Align Mercedes with PSA and other token-based vehicles.

Refs https://github.com/evcc-io/evcc/discussions/13758#discussioncomment-9337635

> Kannst du es übernehmen? Mein Problem war, dass ich zwei Schritte in der Konfiguration brauchte. Erst anlegen der minimalen Konfiguration damit "evcc token" funktioniert. In dem Schritt ist aber schon der testen-Link aktiv, was die UX natürlich deutlich schwieriger macht.
Dann einfügen des tokens.

Das Problem hier ist eigentlich, dass sich kein Token für einen beliebigen "Mercedes" oder "Opel" oder... anlegen lässt sondern erst nach einer Config geschaut wird. Dazu mache ich gleich noch einen Vorschlag.

/cc @ReneNulschDE 