### PR TITLE
Added wildcard __debug_bin* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-__debug_bin
+__debug_bin*
 .vscode
 .cache
 .DS_store


### PR DESCRIPTION
As mentioned in #13795, additional files `__debug_bin12345678` should be ignored by git.