### PR TITLE
UI: handle missing smart cost limit

### DIFF
--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -182,7 +182,7 @@ export default {
 		phaseRemaining: Number,
 		pvRemaining: Number,
 		pvAction: String,
-		smartCostLimit: Number,
+		smartCostLimit: { type: Number, default: 0 },
 		smartCostType: String,
 		smartCostActive: Boolean,
 		tariffGrid: Number,

--- a/assets/js/components/Loadpoints.vue
+++ b/assets/js/components/Loadpoints.vue
@@ -63,9 +63,7 @@ export default {
 	props: {
 		loadpoints: Array,
 		vehicles: Array,
-		smartCostLimit: Number,
 		smartCostType: String,
-		smartCostActive: Boolean,
 		tariffGrid: Number,
 		tariffCo2: Number,
 		currency: String,

--- a/assets/js/components/Site.vue
+++ b/assets/js/components/Site.vue
@@ -21,9 +21,7 @@
 				class="mt-1 mt-sm-2 flex-grow-1"
 				:loadpoints="loadpoints"
 				:vehicles="vehicleList"
-				:smartCostLimit="smartCostLimit"
 				:smartCostType="smartCostType"
-				:smartCostActive="smartCostActive"
 				:tariffGrid="tariffGrid"
 				:tariffCo2="tariffCo2"
 				:currency="currency"
@@ -97,7 +95,6 @@ export default {
 		uploadProgress: Number,
 		sponsor: String,
 		sponsorTokenExpires: Number,
-		smartCostLimit: Number,
 		smartCostType: String,
 		smartCostActive: Boolean,
 	},

--- a/assets/js/components/SmartCostLimit.vue
+++ b/assets/js/components/SmartCostLimit.vue
@@ -85,7 +85,7 @@ export default {
 	components: { TariffChart },
 	mixins: [formatter],
 	props: {
-		smartCostLimit: { type: Number, default: 0 },
+		smartCostLimit: Number,
 		smartCostType: String,
 		tariffGrid: Number,
 		currency: String,


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/13828

Smart cost limit is not published on evcc startup if its empty (`0`).

- Adapt the UI to correctly deal with a missing limit.
- Cleanup of old site smartCost* properties

See https://github.com/evcc-io/evcc/issues/13828#issuecomment-2104638236