### PR TITLE
UI: higher precision battery icon

### DIFF
--- a/assets/js/components/Energyflow/BatteryIcon.vue
+++ b/assets/js/components/Energyflow/BatteryIcon.vue
@@ -1,13 +1,15 @@
 <template>
-	<component :is="`shopicon-regular-${icon}`"></component>
+	<svg :style="svgStyle" viewBox="0 0 48 48">
+		<path d="M0-.004h48v48H0v-48z" fill="none" />
+		<path
+			d="M35 9.996h-3v-4a2 2 0 00-2-2H18a2 2 0 00-2 2v4h-3a2 2 0 00-2 2v30a2 2 0 002 2h22a2 2 0 002-2v-30a2 2 0 00-2-2zm-15-2h8v2h-8v-2zm13 32H15v-26h18v26z"
+		/>
+		<path :d="socRect" />
+	</svg>
 </template>
 
 <script>
-import "@h2d2/shopicons/es/regular/batteryfull";
-import "@h2d2/shopicons/es/regular/batterythreequarters";
-import "@h2d2/shopicons/es/regular/batteryhalf";
-import "@h2d2/shopicons/es/regular/batteryquarter";
-import "@h2d2/shopicons/es/regular/batteryempty";
+import icon from "../../mixins/icon";
 
 export default {
 	name: "BatteryIcon",
@@ -15,13 +17,11 @@ export default {
 		soc: { type: Number, default: 0 },
 	},
 	computed: {
-		icon: function () {
-			if (this.soc > 80) return "batteryfull";
-			if (this.soc > 60) return "batterythreequarters";
-			if (this.soc > 40) return "batteryhalf";
-			if (this.soc > 20) return "batteryquarter";
-			return "batteryempty";
+		socRect() {
+			const height = (this.soc / (100 / 22)).toFixed(2);
+			return `M30 38H17v-${height}h14v${height}z`;
 		},
 	},
+	mixins: [icon],
 };
 </script>

--- a/assets/js/components/Energyflow/BatteryIcon.vue
+++ b/assets/js/components/Energyflow/BatteryIcon.vue
@@ -19,7 +19,7 @@ export default {
 	computed: {
 		socRect() {
 			const height = (this.soc / (100 / 22)).toFixed(2);
-			return `M30 38H17v-${height}h14v${height}z`;
+			return `M30 38H18v-${height}h12v${height}z`;
 		},
 	},
 	mixins: [icon],


### PR DESCRIPTION
fixes #13901

- 🪫 changed battery icon from five-step (`empty`, `quarter`, `half`, `three-quarter`, `full`) to continuous levels based on `soc`.
- 🔎 slightly increased battery level area inside icon

**battery levels**

[battery-animation.webm](https://github.com/evcc-io/evcc/assets/152287/d5d74239-6934-4bfc-8f66-c48f73202ce5)

**increased height**

<img src="https://github.com/evcc-io/evcc/assets/152287/137e8a8c-0ce3-4a8a-b037-5712a78a557d" width="150" >
 