### PR TITLE
Adding some guidance on how to get the huawei-sun2000-dongle-powersensor configured correctly

### DIFF
--- a/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
@@ -7,11 +7,11 @@ capabilities: ["battery-control"]
 requirements:
   description:
     de: |
-      Es kann notwendig sein, dass der Installateur mit Hilfe eines "Errichterzugangs" zunächst "Modbus/TCP" in den Kommunikationseinstellungen des Wechselrichters freischaltet. 
-      Eine Anleitung von Huawei ist hier zu finden: https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
+      Erfordert "Modbus/TCP". Freischaltung via "Errichterzugang" in den Kommunikationseinstellungen des Wechselrichters. 
+      Siehe https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
     en: |
-      It might be necessary to get "Modbus/TCP" activated within the communication settings of your inverter by your solar installer. 
-      A guide can be found here: https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
+      Needs "Modbus/TCP". Activation using "maintenance access" within the communication settings of the inverter.
+      See https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
@@ -4,6 +4,14 @@ products:
     description:
       generic: SUN2000 with SDongle & Power Sensor
 capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Es kann notwendig sein, dass der Installateur mit Hilfe eines "Errichterzugangs" zunächst "Modbus/TCP" in den Kommunikationseinstellungen des Wechselrichters freischaltet. 
+      Eine Anleitung von Huawei ist hier zu finden: https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
+    en: |
+      It might be necessary to get "Modbus/TCP" activated within the communication settings of your inverter by your solar installer. 
+      A guide can be found here: https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/huawei-sun2000-dongle.yaml
+++ b/templates/definition/meter/huawei-sun2000-dongle.yaml
@@ -3,6 +3,14 @@ products:
   - brand: Huawei
     description:
       generic: SUN2000 with SDongle
+requirements:
+  description:
+    de: |
+      Erfordert "Modbus/TCP". Freischaltung via "Errichterzugang" in den Kommunikationseinstellungen des Wechselrichters. 
+      Siehe https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
+    en: |
+      Needs "Modbus/TCP". Activation using "maintenance access" within the communication settings of the inverter.
+      See https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
 params:
   - name: usage
     choice: ["pv"]


### PR DESCRIPTION
adding information about how to activate modus/tcp within the inverter, since the default does not allow to connect via modes/tcp.