### PR TITLE
Auth: improve iframe support

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -10,6 +10,7 @@ const api = axios.create({
   headers: {
     Accept: "application/json",
   },
+  withCredentials: true,
 });
 
 // global error handling

--- a/server/http_auth.go
+++ b/server/http_auth.go
@@ -124,7 +124,6 @@ func setCookie(w http.ResponseWriter, name, value string, expires time.Time) {
 		HttpOnly: true,
 		Expires:  expires,
 		SameSite: http.SameSiteNoneMode,
-		Secure:   true,
 	}).String()
 
 	// implement CHIPS to allow cookies in iframe context https://developers.google.com/privacy-sandbox/3pcd


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/13893

- switched to `SameSite: None` do allow cookies to be set from inside an iframe
- added `partitioned` attribute to comply with anti-tracking measures of major browsers. see https://developers.google.com/privacy-sandbox/3pcd/chips

General note: when using evcc in an iframe (e.g. in another HA system)  it's recommended to use https since browsers are quite strict with security features like cookies. 