### PR TITLE
Cost limit: show negative price options, add 0.5ct steps

### DIFF
--- a/assets/js/components/SmartCostLimit.vue
+++ b/assets/js/components/SmartCostLimit.vue
@@ -111,12 +111,12 @@ export default {
 			for (let i = 1; i <= 100; i++) {
 				const value = this.optionStartValue + stepSize * i;
 				if (value != 0) {
-					values.push(value.toFixed(2));
+					values.push(this.roundLimit(value));
 				}
 			}
 			// add special entry if currently selected value is not in the scale
 			const selected = this.selectedSmartCostLimit;
-			if (selected !== undefined && !values.includes(selected)) {
+			if (selected && !values.includes(selected)) {
 				values.push(selected);
 			}
 			values.sort((a, b) => a - b);
@@ -134,16 +134,18 @@ export default {
 				return 0;
 			}
 			const { min } = this.costRange(this.totalSlots);
-			const minValue = Math.min(0, min);
 			const stepSize = this.optionStepSize;
-			return Math.ceil(minValue / stepSize) * stepSize;
+			// always show some negative values for price
+			const start = this.isCo2 ? 0 : stepSize * -11;
+			const minValue = Math.min(start, min);
+			return Math.floor(minValue / stepSize) * stepSize;
 		},
 		optionStepSize() {
 			if (!this.tariff) {
 				return 1;
 			}
 			const { min, max } = this.costRange(this.totalSlots);
-			for (const scale of [0.1, 1, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]) {
+			for (const scale of [0.1, 0.5, 1, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]) {
 				if (max - Math.min(0, min) < scale) {
 					return scale / 100;
 				}
@@ -225,14 +227,17 @@ export default {
 			this.updateTariff();
 		},
 		smartCostLimit(limit) {
-			this.selectedSmartCostLimit = limit?.toFixed(2);
+			this.selectedSmartCostLimit = this.roundLimit(limit);
 		},
 	},
 	mounted() {
 		this.updateTariff();
-		this.selectedSmartCostLimit = this.smartCostLimit?.toFixed(2);
+		this.selectedSmartCostLimit = this.roundLimit(this.smartCostLimit);
 	},
 	methods: {
+		roundLimit(limit) {
+			return limit ? Math.round(limit * 1000) / 1000 : 0;
+		},
 		updateTariff: async function () {
 			try {
 				this.tariff = (await api.get(`tariff/planner`)).data.result;

--- a/tests/smart-cost.spec.js
+++ b/tests/smart-cost.spec.js
@@ -34,11 +34,11 @@ test.describe("smart cost limit", async () => {
     await page
       .getByTestId("loadpoint-settings-modal")
       .getByLabel("Price limit")
-      .selectOption("≤ 50.0 ct/kWh");
+      .selectOption("≤ 20.0 ct/kWh");
     await page.getByTestId("loadpoint-settings-modal").getByLabel("Close").click();
     await expect(page.getByTestId("loadpoint-settings-modal")).not.toBeVisible();
     await expect(page.getByTestId("vehicle-status")).toContainText("Charging cheap energy");
-    await expect(page.getByTestId("vehicle-status")).toContainText("(limit 50.0 ct)");
+    await expect(page.getByTestId("vehicle-status")).toContainText("(limit 20.0 ct)");
   });
   test("price above limit", async ({ page }) => {
     await page.goto("/");

--- a/tests/smart-cost.spec.js
+++ b/tests/smart-cost.spec.js
@@ -34,11 +34,11 @@ test.describe("smart cost limit", async () => {
     await page
       .getByTestId("loadpoint-settings-modal")
       .getByLabel("Price limit")
-      .selectOption("≤ 20.0 ct/kWh");
+      .selectOption("≤ 40.0 ct/kWh");
     await page.getByTestId("loadpoint-settings-modal").getByLabel("Close").click();
     await expect(page.getByTestId("loadpoint-settings-modal")).not.toBeVisible();
     await expect(page.getByTestId("vehicle-status")).toContainText("Charging cheap energy");
-    await expect(page.getByTestId("vehicle-status")).toContainText("(limit 20.0 ct)");
+    await expect(page.getByTestId("vehicle-status")).toContainText("(limit 40.0 ct)");
   });
   test("price above limit", async ({ page }) => {
     await page.goto("/");


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/14020

- 🪲 use floor (instead of ceil) to determin the lowes limit option based on current tariffs ([see here](https://github.com/evcc-io/evcc/discussions/13968#discussioncomment-9496435))
- 0️⃣ fix issue where both `none` and `<= 0` options appeared (type mismatch)
- 📉 always show at least 10 negative limit options (only for price, not for co2)
- 🤏 add finer steps (e.g. 0.05ct) when they make sense

![Bildschirmfoto 2024-05-22 um 11 56 42](https://github.com/evcc-io/evcc/assets/152287/1fae79b3-e894-40e9-b3b8-61c5055b1940)
