### PR TITLE
Auth: add iframe hint

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -234,6 +234,8 @@ update = "Aktualisieren"
 [loginModal]
 cancel = "Abbrechen"
 error = "Login fehlgeschlagen: "
+iframeHint = "Öffne evcc in einem neuen Tab."
+iframeIssue = "Das Passwort ist korrekt, aber dein Browser hat das Authentifizierungscookie abgelehnt. Dies kann passieren, wenn du evcc in einem iframe über HTTP verwendest."
 invalid = "Passwort ist ungültig."
 login = "Anmelden"
 password = "Passwort"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -233,6 +233,8 @@ update = "Auto update"
 [loginModal]
 cancel = "Cancel"
 error = "Login failed: "
+iframeHint = "Open evcc in a new tab."
+iframeIssue = "Your password is correct, but your browser seems to have dropped the authentication cookie. This can happen if you run evcc in an iframe via HTTP."
 invalid = "Password is invalid."
 login = "Login"
 password = "Password"


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/13893#issuecomment-2126421142
replaces https://github.com/evcc-io/evcc/pull/14018

- ☝️ show hint when login was successful but auth cookie was dropped -> iframe + http
- ⛓️ show "open in dedicated tab" link


<img width="548" alt="Bildschirmfoto 2024-05-24 um 11 38 18" src="https://github.com/evcc-io/evcc/assets/152287/60c9527a-046b-408f-9c52-3d5e3f668351">


**Note:** this is not a proper solution but gives guidance to users that run into this problem. To solve this issue we could
- a) move auth handling from http-only cookie to js+localstorage (less secure, max compatibility)
- b) offer an option to go no-password (no security, credentials, code execution 🙀)
- c) add out-of the-box (self-signed) ssl support to evcc