### PR TITLE
SHM: expose device types other than EVCharger

### DIFF
--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -118,6 +118,8 @@ type API interface {
 	// power and energy
 	//
 
+	// GetCharger gets the charger
+	GetCharger() api.Charger
 	// HasChargeMeter determines if a physical charge meter is attached
 	HasChargeMeter() bool
 	// GetChargePower returns the current charging power

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -138,6 +138,20 @@ func (mr *MockAPIMockRecorder) GetChargePowerFlexibility() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChargePowerFlexibility", reflect.TypeOf((*MockAPI)(nil).GetChargePowerFlexibility))
 }
 
+// GetCharger mocks base method.
+func (m *MockAPI) GetCharger() api.Charger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCharger")
+	ret0, _ := ret[0].(api.Charger)
+	return ret0
+}
+
+// GetCharger indicates an expected call of GetCharger.
+func (mr *MockAPIMockRecorder) GetCharger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharger", reflect.TypeOf((*MockAPI)(nil).GetCharger))
+}
+
 // GetCircuit mocks base method.
 func (m *MockAPI) GetCircuit() api.Circuit {
 	m.ctrl.T.Helper()

--- a/core/loadpoint_charger.go
+++ b/core/loadpoint_charger.go
@@ -8,6 +8,13 @@ import (
 	"github.com/evcc-io/evcc/core/soc"
 )
 
+// GetCharger gets the charger
+func (lp *Loadpoint) GetCharger() api.Charger {
+	lp.Lock()
+	defer lp.Unlock()
+	return lp.charger
+}
+
 // chargerHasFeature checks availability of charger feature
 func (lp *Loadpoint) chargerHasFeature(f api.Feature) bool {
 	c, ok := lp.charger.(api.FeatureDescriber)

--- a/hems/semp/const.go
+++ b/hems/semp/const.go
@@ -1,0 +1,18 @@
+package semp
+
+const (
+	AirConditioning = "AirConditioning"
+	Charger         = "Charger"
+	DishWasher      = "DishWasher"
+	Dryer           = "Dryer"
+	ElectricVehicle = "ElectricVehicle"
+	EVCharger       = "EVCharger"
+	Freezer         = "Freezer"
+	Fridge          = "Fridge"
+	Heater          = "Heater"
+	HeatPump        = "HeatPump"
+	Motor           = "Motor"
+	Pump            = "Pump"
+	WashingMachine  = "WashingMachine"
+	Other           = "Other"
+)

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +31,7 @@ const (
 	sempDeviceId     = "F-%s-%.12x-00" // 6 bytes
 	sempSerialNumber = "%s-%d"
 	sempCharger      = "EVCharger"
+	sempHeatPump     = "HeatPump"
 	basePath         = "/semp"
 	maxAge           = 1800
 )
@@ -366,6 +368,14 @@ func (s *SEMP) deviceID(id int) string {
 	// numerically add device number
 	did := append([]byte{0, 0}, s.did...)
 	return fmt.Sprintf(sempDeviceId, s.vid, ^uint64(0xffff<<48)&(binary.BigEndian.Uint64(did)+uint64(id)))
+}
+
+func (s *SEMP) deviceType(lp loadpoint.API) string {
+	charger := lp.GetCharger()
+	if charger != nil && slices.Contains(charger.Features(), api.Heating) {
+		return sempHeatPump
+	}
+	return sempCharger
 }
 
 func (s *SEMP) deviceInfo(id int, lp loadpoint.API) DeviceInfo {

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -371,9 +371,10 @@ func (s *SEMP) deviceID(id int) string {
 }
 
 func (s *SEMP) deviceType(lp loadpoint.API) string {
-	charger := lp.GetCharger()
-	if charger != nil && slices.Contains(charger.Features(), api.Heating) {
-		return sempHeatPump
+	if c, ok := lp.GetCharger().(api.FeatureDescriber); ok {
+		if slices.Contains(c.Features(), api.Heating) {
+			return sempHeatPump
+		}
 	}
 	return sempCharger
 }

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -30,8 +30,6 @@ const (
 	sempGateway      = "urn:schemas-simple-energy-management-protocol:device:Gateway:1"
 	sempDeviceId     = "F-%s-%.12x-00" // 6 bytes
 	sempSerialNumber = "%s-%d"
-	sempCharger      = "EVCharger"
-	sempHeatPump     = "HeatPump"
 	basePath         = "/semp"
 	maxAge           = 1800
 )
@@ -373,10 +371,10 @@ func (s *SEMP) deviceID(id int) string {
 func (s *SEMP) deviceType(lp loadpoint.API) string {
 	if c, ok := lp.GetCharger().(api.FeatureDescriber); ok {
 		if slices.Contains(c.Features(), api.Heating) {
-			return sempHeatPump
+			return HeatPump
 		}
 	}
-	return sempCharger
+	return EVCharger
 }
 
 func (s *SEMP) deviceInfo(id int, lp loadpoint.API) DeviceInfo {
@@ -389,7 +387,7 @@ func (s *SEMP) deviceInfo(id int, lp loadpoint.API) DeviceInfo {
 		Identification: Identification{
 			DeviceID:     s.deviceID(id),
 			DeviceName:   lp.Title(),
-			DeviceType:   sempCharger,
+			DeviceType:   s.deviceType(lp),
 			DeviceSerial: s.serialNumber(id),
 			DeviceVendor: "github.com/evcc-io/evcc",
 		},


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14074

@naltatis wir könnten auch die Icons heran ziehen? Die werden aber nur für "Fahrzeuge" vergeben, oder? Hier müsste der Charger "exposed" werden. Ggf. müssten wir nochmal überlegen, welche Objekte eigentlich über "Features" verfügen können. Im Moment wäre das ausschließlich beim custom Charger möglich.