### PR TITLE
Split SMA Sunny Boy Storage templates

### DIFF
--- a/templates/definition/meter/sma-sbs-modbus.yaml
+++ b/templates/definition/meter/sma-sbs-modbus.yaml
@@ -2,7 +2,7 @@ template: sma-sbs-modbus
 products:
   - brand: SMA
     description:
-      generic: Sunny Boy Storage (Modbus)
+      generic: Sunny Boy Storage 3.7/5.0/6.0 (Modbus)
 capabilities: ["battery-control"]
 params:
   - name: usage

--- a/templates/definition/meter/sma-si-modbus.yaml
+++ b/templates/definition/meter/sma-si-modbus.yaml
@@ -3,6 +3,9 @@ products:
   - brand: SMA
     description:
       generic: Sunny Island (Modbus)
+  - brand: SMA
+    description:
+      generic: Sunny Boy Storage 1.5/2.0/2.5 (Modbus)
 capabilities: ["battery-control"]
 params:
   - name: usage


### PR DESCRIPTION
The old, small SMA Sunny Boy Storage devices (<= 2.5) do not support the same features as the newer, more powerful devices (>= 3.7).
The small ones have the same register laylout like the Sunny Island inverter.