### PR TITLE
Do not use escaped Query, because it will break templating.

### DIFF
--- a/util/net.go
+++ b/util/net.go
@@ -42,7 +42,12 @@ func DefaultScheme(uri, scheme string) string {
 		}
 	}
 
-	return u.String()
+	// do not use escaped Query, because it will break templating
+	newUrl, err := url.QueryUnescape(u.String())
+	if err != nil {
+		return uri
+	}
+	return newUrl
 }
 
 // LocalIPs returns a slice of local IPv4 addresses

--- a/util/net.go
+++ b/util/net.go
@@ -43,11 +43,8 @@ func DefaultScheme(uri, scheme string) string {
 	}
 
 	// do not use escaped Query, because it will break templating
-	newUrl, err := url.QueryUnescape(u.String())
-	if err != nil {
-		return uri
-	}
-	return newUrl
+	res, _ := url.QueryUnescape(u.String())
+	return res
 }
 
 // LocalIPs returns a slice of local IPv4 addresses

--- a/util/net_test.go
+++ b/util/net_test.go
@@ -18,23 +18,23 @@ func TestDefaultPort(t *testing.T) {
 }
 
 func TestDefaultScheme(t *testing.T) {
-	expect := "http://localhost"
+	expect := "http://localhost/a={{b}}?a={{b}}"
 
-	if uri := DefaultScheme("localhost", "http"); uri != expect {
+	if uri := DefaultScheme("localhost/a={{b}}?a={{b}}", "http"); uri != expect {
 		t.Errorf("expected %s, got %s", expect, uri)
 	}
 
-	if uri := DefaultScheme("http://localhost", "http"); uri != expect {
+	if uri := DefaultScheme("http://localhost/a={{b}}?a={{b}}", "http"); uri != expect {
 		t.Errorf("expected %s, got %s", expect, uri)
 	}
 
-	if uri := DefaultScheme("http://localhost", "https"); uri != expect {
+	if uri := DefaultScheme("http://localhost/a={{b}}?a={{b}}", "https"); uri != expect {
 		t.Errorf("expected %s, got %s", expect, uri)
 	}
 
-	expect = "ws://localhost:8080"
+	expect = "ws://localhost:8080/a={{b}}?a={{b}}"
 
-	if uri := DefaultScheme("localhost:8080", "ws"); uri != expect {
+	if uri := DefaultScheme("localhost:8080/a={{b}}?a={{b}}", "ws"); uri != expect {
 		t.Errorf("expected %s, got %s", expect, uri)
 	}
 }


### PR DESCRIPTION
While writing a custom http charger, I found that when doing templating on a url query it would be escaped and wouldn't work.
Example of what was the result:
`/write/Paused=%7B%7Bif%20.enable%7D%7D0%7B%7Belse%7D%7D1%7B%7Bend%7D%7D`
What should be:
`/write/Paused=1`
