### PR TITLE
Replace "folder" with "directory" in Brews

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,7 +96,7 @@ brews:
     commit_author:
       name: andig
       email: cpuidle@gmx.de
-    folder: Formula
+    directory: Formula
     homepage: "https://evcc.io"
     description: "Sonne tanken ☀️🚘"
     license: "MIT"


### PR DESCRIPTION
This pull request updates the codebase to replace instances of "folder" with "directory" in Brews. The term "folder" is deprecated, and "directory" is the preferred terminology. 

https://goreleaser.com/deprecations/#__tabbed_3_2