### PR TITLE
SolarEdge: add more grid values

### DIFF
--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -37,6 +37,66 @@ render: |
     subdevice: 1 # Metering device
     value: 203:W
     scale: -1
+  energy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
+    subdevice: 1 # Metering device
+    value: 203:TotWhImp
+  currents:
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:AphA
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:AphB
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:AphC
+      scale: -1
+  voltages:
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:PhVphA
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:PhVphB
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:PhVphC
+  powers:
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value:  203:WphA
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:WphB
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:WphC
+      scale: -1
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -49,19 +49,16 @@ render: |
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphA
-      scale: -1
     - source: sunspec
       {{- include "modbus" . | indent 4 }}
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphB
-      scale: -1
     - source: sunspec
       {{- include "modbus" . | indent 4 }}
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphC
-      scale: -1
   voltages:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}
@@ -106,8 +103,8 @@ render: |
         {{- include "modbus" . | indent 6 }}
         timeout: {{ .timeout }}
         value: 
-          - 101:W
-          - 103:W
+          - 101:DCW
+          - 103:DCW
       - source: modbus
         {{- include "modbus" . | indent 6 }}
         timeout: {{ .timeout }}

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -106,8 +106,8 @@ render: |
         {{- include "modbus" . | indent 6 }}
         timeout: {{ .timeout }}
         value: 
-          - 101:DCW
-          - 103:DCW
+          - 101:W
+          - 103:W
       - source: modbus
         {{- include "modbus" . | indent 6 }}
         timeout: {{ .timeout }}

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -39,19 +39,16 @@ render: |
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphA
-      scale: -1
     - source: sunspec
       {{- include "modbus" . | indent 4 }}
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphB
-      scale: -1
     - source: sunspec
       {{- include "modbus" . | indent 4 }}
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphC
-      scale: -1
   voltages:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -24,9 +24,69 @@ render: |
     source: sunspec
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
-    subdevice: 1
+    subdevice: 1 # Metering device
     value: 203:W # sunspec 3-phase meter power reading
     scale: -1
+  energy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
+    subdevice: 1 # Metering device
+    value: 203:TotWhImp
+  currents:
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:AphA
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:AphB
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:AphC
+      scale: -1
+  voltages:
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:PhVphA
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:PhVphB
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:PhVphC
+  powers:
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value:  203:WphA
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:WphB
+      scale: -1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      subdevice: 1 # Metering device
+      value: 203:WphC
+      scale: -1
   {{- end }}
   {{- if eq .usage "pv" }}
   power:


### PR DESCRIPTION
Values added:

- energy (grid only)
- currents (unsigned)
- voltages
- powers

Fixes #14160