### PR TITLE
Fix Loadpoint title being truncated on iPad devices in landscape mode

### DIFF
--- a/assets/js/components/Loadpoint.vue
+++ b/assets/js/components/Loadpoint.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="loadpoint d-flex flex-column pt-4 pb-2 px-3 px-sm-4 mx-2 mx-sm-0">
-		<div class="d-block d-sm-flex justify-content-between align-items-center mb-3">
+		<div class="d-block d-sm-flex d-lg-flex flex-lg-wrap justify-content-between align-items-center mb-3">
 			<div class="d-flex justify-content-between align-items-center mb-3 text-truncate">
 				<h3 class="me-2 mb-0 text-truncate d-flex">
 					<VehicleIcon


### PR DESCRIPTION
Fix #14167 

This Pull request fixes issue #14167 where a truncated loadpoint title on iPads in landscape orientation were reported.
The fix allows flexbox to break on a lg orientation, which results in the title being in a seperate line and no longer being truncated.