### PR TITLE
Vehicles: collect common properties in includable template

### DIFF
--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -36,13 +36,9 @@ params:
   - preset: vehicle-identify
 render: |
   type: citroen
-  title: {{ .title }}
-  icon: {{ .icon }}
+  {{ include "vehicle-common" . }}
   user: {{ .user }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
-  vin: {{ .vin }}
   {{ include "vehicle-identify" . }}

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -36,8 +36,8 @@ params:
   - preset: vehicle-identify
 render: |
   type: ds
-  user: {{ .user }}
   {{ include "vehicle-common" . }}
+  user: {{ .user }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -36,13 +36,9 @@ params:
   - preset: vehicle-identify
 render: |
   type: ds
-  title: {{ .title }}
-  icon: {{ .icon }}
   user: {{ .user }}
+  {{ include "vehicle-common" . }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
-  vin: {{ .vin }}
   {{ include "vehicle-identify" . }}

--- a/templates/definition/vehicle/ford-connect.yaml
+++ b/templates/definition/vehicle/ford-connect.yaml
@@ -41,13 +41,11 @@ params:
   - preset: vehicle-identify
 render: |
   type: ford-connect
+  {{ include "vehicle-common" . }}
   credentials:
     id: {{ .clientid }}
     secret: {{ .clientsecret }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
-  vin: {{ .vin }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
   {{ include "vehicle-identify" . }}

--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -38,13 +38,9 @@ params:
   - preset: vehicle-identify
 render: |
   type: mercedes
-  title: {{ .title }}
-  icon: {{ .icon }}
   user: {{ .user }}
+  {{ include "vehicle-common" . }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
-  vin: {{ .vin }}
   {{ include "vehicle-identify" . }}

--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -38,8 +38,8 @@ params:
   - preset: vehicle-identify
 render: |
   type: mercedes
-  user: {{ .user }}
   {{ include "vehicle-common" . }}
+  user: {{ .user }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -36,13 +36,9 @@ params:
   - preset: vehicle-identify
 render: |
   type: opel
-  title: {{ .title }}
-  icon: {{ .icon }}
+  {{ include "vehicle-common" . }}
   user: {{ .user }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
-  vin: {{ .vin }}
   {{ include "vehicle-identify" . }}

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -36,13 +36,9 @@ params:
   - preset: vehicle-identify
 render: |
   type: peugeot
-  title: {{ .title }}
-  icon: {{ .icon }}
+  {{ include "vehicle-common" . }}
   user: {{ .user }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
-  vin: {{ .vin }}
   {{ include "vehicle-identify" . }}

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -40,13 +40,9 @@ params:
   - preset: vehicle-identify
 render: |
   type: tesla
-  title: {{ .title }}
-  icon: {{ .icon }}
+  {{ include "vehicle-common" . }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
-  vin: {{ .vin }}
   {{ include "vehicle-identify" . }}
   features: ["coarsecurrent"]

--- a/templates/definition/vehicle/tronity.yaml
+++ b/templates/definition/vehicle/tronity.yaml
@@ -33,16 +33,8 @@ params:
   - preset: vehicle-identify
 render: |
   type: tronity
-  {{- if .title }}
-  title: {{ .title }}
-  {{- end }}
-  {{- if .icon }}
-  icon: {{ .icon }}
-  {{- end }}
+  {{ include "vehicle-common" . }}
   credentials:
     id: {{ .clientid }}
     secret: {{ .clientsecret }}
-  vin: {{ .vin }}
-  capacity: {{ .capacity }}
-  phases: {{ .phases }}
   {{ include "vehicle-identify" . }}

--- a/util/templates/includes/vehicle-base.tpl
+++ b/util/templates/includes/vehicle-base.tpl
@@ -1,22 +1,5 @@
 {{ define "vehicle-base" }}
-{{- if .title }}
-title: {{ .title }}
-{{- end }}
-{{- if .icon }}
-icon: {{ .icon }}
-{{- end }}
 user: {{ .user }}
 password: {{ .password }}
-{{- if .capacity }}
-capacity: {{ .capacity }}
-{{- end }}
-{{- if .vin }}
-vin: {{ .vin }}
-{{- end }}
-{{- if .phases }}
-phases: {{ .phases }}
-{{- end }}
-{{- if .cache }}
-cache: {{ .cache }}
-{{- end }}
+{{ template "vehicle-common" . }}
 {{- end }}

--- a/util/templates/includes/vehicle-common.tpl
+++ b/util/templates/includes/vehicle-common.tpl
@@ -1,0 +1,20 @@
+{{ define "vehicle-common" }}
+{{- if .title }}
+title: {{ .title }}
+{{- end }}
+{{- if .icon }}
+icon: {{ .icon }}
+{{- end }}
+{{- if .capacity }}
+capacity: {{ .capacity }}
+{{- end }}
+{{- if .vin }}
+vin: {{ .vin }}
+{{- end }}
+{{- if .phases }}
+phases: {{ .phases }}
+{{- end }}
+{{- if .cache }}
+cache: {{ .cache }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14203. Adding a template include makes it much easier to not forget any parameters ;)