### PR TITLE
Add Weidmüller BasicLine energy meters

### DIFF
--- a/templates/definition/meter/eastron-sdm220.yaml
+++ b/templates/definition/meter/eastron-sdm220.yaml
@@ -1,8 +1,9 @@
-template: eastron-sdm220_230
+template: eastron-sdm220
+covers: ["eastron-sdm220_230"]
 products:
   - brand: Eastron
     description:
-      generic: SDM220/230
+      generic: SDM220
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/eastron-sdm230.yaml
+++ b/templates/definition/meter/eastron-sdm230.yaml
@@ -3,6 +3,12 @@ products:
   - brand: Eastron
     description:
       generic: SDM230
+  - band: Weidmüller
+    description:
+      generic: EM110-RTU-2P
+  - band: Weidmüller
+    description:
+      generic: EM111-RTU-2P
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/eastron-sdm230.yaml
+++ b/templates/definition/meter/eastron-sdm230.yaml
@@ -1,0 +1,16 @@
+template: eastron-sdm230
+products:
+  - brand: Eastron
+    description:
+      generic: SDM230
+params:
+  - name: usage
+    choice: ["grid", "charge"]
+  - name: modbus
+    choice: ["rs485"]
+render: |
+  type: mbmd
+  {{- include "modbus" . }}
+  model: sdm230
+  power: Power
+  energy: Import

--- a/templates/definition/meter/eastron-sdm72v2_630.yaml
+++ b/templates/definition/meter/eastron-sdm72v2_630.yaml
@@ -6,6 +6,12 @@ products:
   - brand: Eastron
     description:
       generic: SDM72DM-V2
+  - brand: Weidmüller
+    description:
+      generic: EM120-RTU-2P
+  - brand: Weidmüller
+    description:
+      generic: EM122-RTU-2P
 params:
   - name: usage
     choice: ["grid", "charge"]


### PR DESCRIPTION
Weidmüller BasicLine energy meters seem to be rebranded Eastron energy meters. Weidmüller is a popular brand for electrical installation material in Germany. So it seems much easier to convince a German eletrician to install a Weidmüller device with a German brand name and website than an Eastron device with a Chinese brand name and English website. Therefore, it seems to be a good idea to document that these Weidmüller devices are supported.