### PR TITLE
Add EcoHarmony/Viridian EV EPC 2.0 Plus (#14278)

### DIFF
--- a/templates/definition/charger/obo.yaml
+++ b/templates/definition/charger/obo.yaml
@@ -1,8 +1,14 @@
 template: obo
 products:
+  - brand: EcoHarmony
+    description:
+      generic: EVSE EPC 2.0 Plus
   - brand: OBO Bettermann
     description:
       generic: Ion
+  - brand: Viridian EV
+    description:
+      generic: EVSE EPC 2.0 Plus
 params:
   - name: modbus
     choice: ["rs485", "tcpip"]


### PR DESCRIPTION
The OBO Ion charger is based on the EcoHarmony (formerly Viridian EV) EVSE Protocol Controller (EPC) 2.0 Plus (EPC20P10). This is documented in an illustration in the documentation of the OBO Ion charger. The Modbus register documentation of both devices also matches.

The EPC 2.0 Plus charge controller is sold to manufacturers of chargers and might have been directly sold in chargers by EcoHarmony. Therefore, it is possible that other chargers with this charge controller exist and that the OBO Ion charger is just an example of a charger that uses this charge controller.

In order to ensure backwards compatibility, it seems best to continue to use the name "obo" internally. If there are notable other chargers with this charge controller, the driver could be added with additional names in the registry or it could be renamed internally.

Viridian EV seems to have changed its name to EcoHarmony. Therefore, it seems best to include both names to make it easier to find the charge controllers under both names.