### PR TITLE
Add Weidmüller BasicLine energy meters

### DIFF
--- a/templates/definition/meter/eastron-sdm220_230.yaml
+++ b/templates/definition/meter/eastron-sdm220_230.yaml
@@ -3,6 +3,12 @@ products:
   - brand: Eastron
     description:
       generic: SDM220/230
+  - band: Weidmüller
+    description:
+      generic: EM110-RTU-2P
+  - band: Weidmüller
+    description:
+      generic: EM111-RTU-2P
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/eastron-sdm220_230.yaml
+++ b/templates/definition/meter/eastron-sdm220_230.yaml
@@ -3,10 +3,10 @@ products:
   - brand: Eastron
     description:
       generic: SDM220/230
-  - band: Weidmüller
+  - brand: Weidmüller
     description:
       generic: EM110-RTU-2P
-  - band: Weidmüller
+  - brand: Weidmüller
     description:
       generic: EM111-RTU-2P
 params:

--- a/templates/definition/meter/eastron-sdm72v2_630.yaml
+++ b/templates/definition/meter/eastron-sdm72v2_630.yaml
@@ -6,6 +6,12 @@ products:
   - brand: Eastron
     description:
       generic: SDM72DM-V2
+  - brand: Weidmüller
+    description:
+      generic: EM120-RTU-2P
+  - brand: Weidmüller
+    description:
+      generic: EM122-RTU-2P
 params:
   - name: usage
     choice: ["grid", "charge"]


### PR DESCRIPTION
Weidmüller BasicLine energy meters seem to be rebranded Eastron energy meters. Weidmüller is a popular brand for electrical installation material in Germany. So it seems much easier to convince a German eletrician to install a Weidmüller device with a German brand name and website than an Eastron device with a Chinese brand name and English website. Therefore, it seems to be a good idea to document that these Weidmüller devices are supported.