### PR TITLE
Improve auth error handling

### DIFF
--- a/server/db/settings/setting.go
+++ b/server/db/settings/setting.go
@@ -47,6 +47,11 @@ func Init() error {
 	return err
 }
 
+// InitTest initializes the settings for testing only
+func InitTest() {
+	initialized = true
+}
+
 func Persist() error {
 	dirty := atomic.CompareAndSwapInt32(&dirty, 1, 0)
 	if !dirty || len(settings) == 0 {

--- a/server/db/settings/setting.go
+++ b/server/db/settings/setting.go
@@ -20,7 +20,7 @@ import (
 )
 
 var ErrNotFound = errors.New("not found")
-var ErrNotInitilized = errors.New("unable to read settings from database")
+var ErrNotInitialized = errors.New("unable to read settings from database")
 
 // setting is a settings entry
 type setting struct {
@@ -41,14 +41,12 @@ func Init() error {
 		err = db.Instance.Find(&settings).Error
 	}
 
-	if err == nil {
-		initialized = true
-	}
+	initialized = err == nil
 	return err
 }
 
-// InitTest initializes the settings for testing only
-func InitTest() {
+// initTest initializes the settings for testing only
+func initTest() {
 	initialized = true
 }
 
@@ -157,7 +155,7 @@ func String(key string) (string, error) {
 	defer mu.RUnlock()
 
 	if !initialized {
-		return "", ErrNotInitilized
+		return "", ErrNotInitialized
 	}
 
 	idx := slices.IndexFunc(settings, equal(key))

--- a/server/db/settings/settings_test.go
+++ b/server/db/settings/settings_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestString(t *testing.T) {
-	InitTest()
+	initTest()
 	v := "foo"
 	SetString("string", v)
 	res, err := String("string")
@@ -18,7 +18,7 @@ func TestString(t *testing.T) {
 }
 
 func TestInt(t *testing.T) {
-	InitTest()
+	initTest()
 	v := int64(math.MaxInt64)
 	SetInt("int64", v)
 	res, err := Int("int64")
@@ -27,7 +27,7 @@ func TestInt(t *testing.T) {
 }
 
 func TestFloat(t *testing.T) {
-	InitTest()
+	initTest()
 	v := 3.141
 	SetFloat("float64", v)
 	res, err := Float("float64")

--- a/server/db/settings/settings_test.go
+++ b/server/db/settings/settings_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestString(t *testing.T) {
+	InitTest()
 	v := "foo"
 	SetString("string", v)
 	res, err := String("string")
@@ -17,6 +18,7 @@ func TestString(t *testing.T) {
 }
 
 func TestInt(t *testing.T) {
+	InitTest()
 	v := int64(math.MaxInt64)
 	SetInt("int64", v)
 	res, err := Int("int64")
@@ -25,6 +27,7 @@ func TestInt(t *testing.T) {
 }
 
 func TestFloat(t *testing.T) {
+	InitTest()
 	v := 3.141
 	SetFloat("float64", v)
 	res, err := Float("float64")

--- a/util/auth/auth_test.go
+++ b/util/auth/auth_test.go
@@ -46,17 +46,23 @@ func TestIsAdminPasswordValid(t *testing.T) {
 
 	// password not set, reject
 	mock.EXPECT().String(keys.AdminPassword).Return("", nil).Times(1)
-	assert.False(t, auth.IsAdminPasswordValid(validPw))
+	valid, err := auth.IsAdminPasswordValid(validPw)
+	assert.NoError(t, err)
+	assert.False(t, valid)
 
 	// password set, accept
 	var storedHash string
 	mock.EXPECT().SetString(keys.AdminPassword, gomock.Not(gomock.Eq(""))).Do(func(_ string, hash string) { storedHash = hash })
 	auth.SetAdminPassword(validPw)
 	mock.EXPECT().String(keys.AdminPassword).Return(storedHash, nil).Times(2)
-	assert.True(t, auth.IsAdminPasswordValid(validPw))
+	valid, err = auth.IsAdminPasswordValid(validPw)
+	assert.NoError(t, err)
+	assert.True(t, valid)
 
 	// password set, wrong password
-	assert.False(t, auth.IsAdminPasswordValid(invalidPw))
+	valid, err = auth.IsAdminPasswordValid(invalidPw)
+	assert.NoError(t, err)
+	assert.False(t, valid)
 }
 
 func TestJwtToken(t *testing.T) {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/14373

settings api now return error when not initialized

- auth endpoints return status 500 when database isn't initialized
- better error communication to user
  - "server error" instead of "wrong password"
  - no "create admin password" when db isn't configured

For later: introduce same behavior for `SetString`