### PR TITLE
correction costs vs charges

### DIFF
--- a/util/templates/includes/tariff-base.tpl
+++ b/util/templates/includes/tariff-base.tpl
@@ -1,6 +1,6 @@
 {{ define "tariff-base" }}
-{{- if .charges }}
-charges: {{ .charges }}
+{{- if .costs }}
+charges: {{ .costs }}
 {{- end }}
 {{- if .tax }}
 tax: {{ .tax }}


### PR DESCRIPTION
Im default-template werden `costs` abgefragt.
In tariff-base aber `charges` erwartet.