### PR TITLE
Do not use escaped template part of Query

### DIFF
--- a/util/net.go
+++ b/util/net.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -42,7 +43,18 @@ func DefaultScheme(uri, scheme string) string {
 		}
 	}
 
-	return u.String()
+	// do not use escaped Query for the template strings
+	retUrl := u.String()
+	if templateRegex, err := regexp.Compile(`%7B%7Bif.*?end%7D%7D`); err == nil {
+		matches := templateRegex.FindAllString(retUrl, -1)
+		for _, match := range matches {
+			if matchUnescaped, err := url.QueryUnescape(match); err == nil {
+				retUrl = strings.Replace(retUrl, match, matchUnescaped, 1)
+			}
+		}
+	}
+
+	return retUrl
 }
 
 // LocalIPs returns a slice of local IPv4 addresses


### PR DESCRIPTION
While using a custom http charger, I found that when doing templating on a url query it would be escaped and wouldn't work.
Example of what was the result:
`http://localhost:8080/api/1/vehicles/VIN/command/%7B%7Bif.enable%7D%7Dcharge_start%7B%7Belse%7D%7Dcharge_stop%7B%7Bend%7D%7D`
What should be:
`http://localhost:8080/api/1/vehicles/VIN/command/charge_start`

This solution overcomes the problems of https://github.com/evcc-io/evcc/pull/14146. And it resolves https://github.com/evcc-io/evcc/issues/14384.