### PR TITLE
http provider enable templates in uri

### DIFF
--- a/provider/http.go
+++ b/provider/http.go
@@ -180,7 +180,7 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 		//Escape URL
 		var u string
 		if tu, err := neturl.Parse(builder.String()); err == nil {
-			u = tu.String()
+			u = fmt.Sprintf("%s://%s%s?%s", tu.Scheme, tu.Host, tu.Path, neturl.PathEscape(tu.RawQuery))
 		} else {
 			u = builder.String()
 		}

--- a/provider/http_test.go
+++ b/provider/http_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -59,4 +60,44 @@ func TestHttpSet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uriUrl.Path, h.req.URL.Path)
 	assert.Equal(t, "baz=4711", h.req.URL.RawQuery)
+}
+
+// templating in url path
+func TestHttpSetTemplating(t *testing.T) {
+	h := new(httpHandler)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	uri := srv.URL + "/foo/bar/{{.baz}}"
+	p := NewHTTP(util.NewLogger("foo"), http.MethodGet, uri, false, 1, 0)
+
+	s, err := p.StringSetter("baz")
+	require.NoError(t, err)
+
+	err = s("charge_start")
+	require.NoError(t, err)
+
+	fmt.Printf("Path: %s\n", h.req.URL.Path)
+
+	assert.Equal(t, "/foo/bar/charge_start", h.req.URL.Path)
+}
+
+// test escaping in url path
+func TestHttpGetEscaping(t *testing.T) {
+	h := new(httpHandler)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	uri := srv.URL + "/foo/bar/cm?cmd=Status%208"
+	p := NewHTTP(util.NewLogger("foo"), http.MethodGet, uri, false, 1, 0)
+
+	g, err := p.StringGetter()
+	require.NoError(t, err)
+
+	res, err := g()
+	require.NoError(t, err)
+
+	assert.Equal(t, "/foo/bar/cm", h.req.URL.Path)
+	assert.Equal(t, "cmd=Status%208", h.req.URL.RawQuery)
+	assert.Equal(t, h.val, res)
 }

--- a/util/net.go
+++ b/util/net.go
@@ -19,6 +19,10 @@ func DefaultPort(conn string, port int) string {
 
 // DefaultScheme prepends given scheme to uri if not specified
 func DefaultScheme(uri, scheme string) string {
+	return DefaultSchemeEscaped(uri, scheme, true)
+}
+
+func DefaultSchemeEscaped(uri, scheme string, escaped bool) string {
 	u, err := url.Parse(uri)
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "first path segment in URL cannot contain colon") {
@@ -42,7 +46,12 @@ func DefaultScheme(uri, scheme string) string {
 		}
 	}
 
-	return u.String()
+	if escaped {
+		return u.String()
+	} else {
+		res, _ := url.QueryUnescape(u.String())
+		return res
+	}
 }
 
 // LocalIPs returns a slice of local IPv4 addresses


### PR DESCRIPTION
While using a custom http charger, I found that when doing templating on a url query it would be escaped and wouldn't work.
Example of what was the result:
`http://localhost:8080/api/1/vehicles/VIN/command/%7B%7Bif.enable%7D%7Dcharge_start%7B%7Belse%7D%7Dcharge_stop%7B%7Bend%7D%7D`
What should be:
`http://localhost:8080/api/1/vehicles/VIN/command/charge_start`

This solution overcomes the problems of https://github.com/evcc-io/evcc/pull/14146. And it resolves https://github.com/evcc-io/evcc/issues/14384.