### PR TITLE
Warp3: require automatic 1p phase switching to be disabled

### DIFF
--- a/templates/definition/charger/tinkerforge-warp3.yaml
+++ b/templates/definition/charger/tinkerforge-warp3.yaml
@@ -8,6 +8,9 @@ products:
       generic: WARP3 Charger Pro
 capabilities: ["mA", "1p3p", "rfid"]
 requirements:
+  description:
+    de: Die automatische Phasenumschaltung bei 1p Fahrzeugen muss deaktiviert sein. Siehe https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3.
+    en: The automatic phase switching for 1p vehicles must be deactivated. Siehe https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3.
   uri: https://docs.evcc.io/docs/devices/chargers#tinkerforge
 params:
   - preset: mqtt


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14403