### PR TITLE
Fix inconsistent phases

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1100,7 +1100,12 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 	measuredPhases := lp.getMeasuredPhases()
 	if phases > 0 && phases < measuredPhases {
 		if lp.chargerUpdateCompleted() && lp.phaseSwitchCompleted() {
-			lp.log.WARN.Printf("ignoring inconsistent phases: %dp < %dp observed active", phases, measuredPhases)
+			lp.log.WARN.Printf("detected inconsistent phases: %dp < %dp observed active", phases, measuredPhases)
+			// sometimes the openwb hardware "forgets" to switch phases - fix by scaling phases up to enable recovery
+			if err := lp.scalePhases(3); err != nil {
+				lp.log.ERROR.Println(err)
+			}
+			return 3
 		}
 		lp.resetMeasuredPhases()
 	}


### PR DESCRIPTION
There is an error situation at least with OpenWB wallbox: Sometimes the charger hardware "forgets" to switch phases. 

Wallbox: 1p
Loadpoint: 1p
Measured Phases: > 1

This PR tries to recover from that situation by scaling phases to 3p.