### PR TITLE
Integration of an external BLE proxy into the Tesla template

### DIFF
--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -33,6 +33,11 @@ params:
   - name: vin
     example: W...
   - name: capacity
+  - name: bleHost
+    help:
+      en: "If Ble-Proxy should be used instead of Tesla Fleet Api."
+      de: "Wenn ein BLE-Proxy anstatt der Tesla Fleet Api verwendet werden soll."
+  - name: blePort
   - name: phases
     advanced: true
   - name: control
@@ -44,6 +49,9 @@ render: |
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
+  {{- if .bleHost }}
+  bleUri: http://{{ .bleHost }}:{{ .blePort }}
+  {{- end }}
   {{ include "vehicle-common" . }}
   {{ include "vehicle-identify" . }}
   features: ["coarsecurrent"]

--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -96,7 +96,7 @@ func NewTeslaFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	}
 
 	// proxy or ble proxy
-	var proxyVehicle *teslaclient.Vehicle = nil
+	var proxyVehicle *teslaclient.Vehicle
 	var ble bool
 	if cc.BleURI != "" {
 		bc := request.NewClient(log)

--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -32,7 +32,6 @@ func init() {
 	if tesla.OAuth2Config.ClientID != "" {
 		registry.Add("tesla", NewTeslaFromConfig)
 	}
-	registry.Add("tesla", NewTeslaFromConfig)
 }
 
 // NewTeslaFromConfig creates a new vehicle

--- a/vehicle/tesla/api_test.go
+++ b/vehicle/tesla/api_test.go
@@ -40,5 +40,5 @@ func TestCommandResponse(t *testing.T) {
 	v, err := client.Vehicle("abc")
 	require.NoError(t, err)
 
-	require.ErrorIs(t, NewController(v, v).ChargeEnable(true), api.ErrAsleep)
+	require.ErrorIs(t, NewController(v, v, false).ChargeEnable(true), api.ErrAsleep)
 }


### PR DESCRIPTION
Add the possibility to define ble proxy and use it instead of Tesla Fleet Api to control the vehicle.

```
vehicles:
  - name: tesla
    type: template
    template: tesla
    accessToken: TOKEN
    refreshToken: TOKEN
    bleHost: IP
    blePort: 8080
```

The BLE Proxy has to use the same API scheme like the Fleet Api.

- [x] Use BLE Proxy if defined
- [x] Don't fetch current when using BLE Proxy (because of API Limits)
- [x] Build locally and tested the control part
- [x] Updated Docs
- [ ] Maybe: Add more explanation in docs ?

Helps for https://github.com/evcc-io/evcc/discussions/14252 and https://github.com/evcc-io/evcc/issues/14226