### PR TITLE
Loadpoint: use measured phases/currents as fallback to api.PhaseGetter, api.GetMaxCurrent

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -704,8 +704,6 @@ func (lp *Loadpoint) syncCharger() error {
 	// #2: sync charger
 	switch {
 	case enabled && lp.enabled:
-		lp.GetMaxPhaseCurrent()
-
 		// sync max current
 		if charger, ok := lp.charger.(api.CurrentGetter); ok {
 			if current, err := charger.GetMaxCurrent(); err == nil {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -718,6 +718,15 @@ func (lp *Loadpoint) syncCharger() error {
 			} else if !errors.Is(err, api.ErrNotAvailable) {
 				return fmt.Errorf("charger get max current: %w", err)
 			}
+		} else {
+			// use measured phases as fallback, validate if current too high by at least 1A
+			if current := lp.GetMaxPhaseCurrent(); current > lp.chargeCurrent+1.0 {
+				if shouldBeConsistent {
+					lp.log.WARN.Printf("charger logic error: current mismatch (got %.3gA measured, expected %.3gA)", current, lp.chargeCurrent)
+				}
+				lp.chargeCurrent = current
+				lp.bus.Publish(evChargeCurrent, lp.chargeCurrent)
+			}
 		}
 
 		// sync phases

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -719,7 +719,7 @@ func (lp *Loadpoint) syncCharger() error {
 				return fmt.Errorf("charger get max current: %w", err)
 			}
 		} else {
-			// use measured phases as fallback, validate if current too high by at least 1A
+			// use measured phase currents as fallback, validate if current too high by at least 1A
 			if current := lp.GetMaxPhaseCurrent(); current > lp.chargeCurrent+1.0 {
 				if shouldBeConsistent {
 					lp.log.WARN.Printf("charger logic error: current mismatch (got %.3gA measured, expected %.3gA)", current, lp.chargeCurrent)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -703,9 +703,11 @@ func (lp *Loadpoint) syncCharger() error {
 
 	// #2: sync charger
 	switch {
-	case enabled == lp.enabled:
+	case enabled && lp.enabled:
+		lp.GetMaxPhaseCurrent()
+
 		// sync max current
-		if charger, ok := lp.charger.(api.CurrentGetter); ok && enabled {
+		if charger, ok := lp.charger.(api.CurrentGetter); ok {
 			if current, err := charger.GetMaxCurrent(); err == nil {
 				// smallest adjustment most PWM-Controllers can do is: 100%÷256×0,6A = 0.234A
 				if math.Abs(lp.chargeCurrent-current) > 0.23 {
@@ -722,14 +724,24 @@ func (lp *Loadpoint) syncCharger() error {
 
 		// sync phases
 		phases := lp.GetPhases()
-		if ps, ok := lp.charger.(api.PhaseGetter); ok && enabled && shouldBeConsistent && phases > 0 {
-			if chargerPhases, err := ps.GetPhases(); err == nil {
-				if chargerPhases != phases {
-					lp.log.WARN.Printf("charger logic error: phases mismatch (got %d, expected %d)", chargerPhases, phases)
-					lp.setPhases(chargerPhases)
+		if shouldBeConsistent && phases > 0 {
+			// fallback active phases from measured phases
+			chargerPhases := lp.measuredPhases
+			if chargerPhases == 2 {
+				chargerPhases = 3
+			}
+
+			if ps, ok := lp.charger.(api.PhaseGetter); ok {
+				if cp, err := ps.GetPhases(); err == nil {
+					chargerPhases = cp
+				} else if !errors.Is(err, api.ErrNotAvailable) {
+					return fmt.Errorf("charger get phases: %w", err)
 				}
-			} else if !errors.Is(err, api.ErrNotAvailable) {
-				return fmt.Errorf("charger get phases: %w", err)
+			}
+
+			if chargerPhases > 0 && chargerPhases != phases {
+				lp.log.WARN.Printf("charger logic error: phases mismatch (got %d, expected %d)", chargerPhases, phases)
+				lp.setPhases(chargerPhases)
 			}
 		}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -732,7 +732,10 @@ func (lp *Loadpoint) syncCharger() error {
 			if ps, ok := lp.charger.(api.PhaseGetter); ok {
 				if cp, err := ps.GetPhases(); err == nil {
 					chargerPhases = cp
-				} else if !errors.Is(err, api.ErrNotAvailable) {
+				} else {
+					if errors.Is(err, api.ErrNotAvailable) {
+						return nil
+					}
 					return fmt.Errorf("charger get phases: %w", err)
 				}
 			}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14443

@GrimmiMeloni the change is two-fold:

General:
- extract the common `&& enabled` condition to the switch (its obvious from the diff that this can be hoisted)

Phases:
- only evaluate if `shouldBeConsistent && phases > 0`
- use `measuredPhases` as go-in value, corrected for 2 active phases

Currents:
- use measured currents instead of set current as fallback

wdyt?

/cc @MarkusGH 