### PR TITLE
Etrel: remove api.CurrentGetter

### DIFF
--- a/charger/etrel.go
+++ b/charger/etrel.go
@@ -190,17 +190,8 @@ func (wb *Etrel) MaxCurrentMillis(current float64) error {
 	return err
 }
 
-var _ api.CurrentGetter = (*Etrel)(nil)
-
-// GetMaxCurrent implements the api.CurrentGetter interface
-func (wb *Etrel) GetMaxCurrent() (float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(wb.base+etrelRegMaxCurrent, 2)
-	if err != nil {
-		return 0, err
-	}
-
-	return float64(math.Float32frombits(binary.BigEndian.Uint32(b))), nil
-}
+// removed due to https://github.com/evcc-io/evcc/issues/14507
+// var _ api.CurrentGetter = (*Etrel)(nil)
 
 var _ api.Meter = (*Etrel)(nil)
 


### PR DESCRIPTION
Replaced by https://github.com/evcc-io/evcc/pull/14622, fix https://github.com/evcc-io/evcc/issues/14507