### PR TITLE
Add Kostal Enector and Energy Meters (KEM-C/KEM-P)

### DIFF
--- a/templates/definition/charger/mennekes-compact.yaml
+++ b/templates/definition/charger/mennekes-compact.yaml
@@ -7,11 +7,14 @@ products:
   - brand: Mennekes
     description:
       generic: Amtron Start 2.0s
+  - brand: Kostal
+    description:
+      generic: Enector
 capabilities: ["1p3p", "mA"]
 requirements:
   description:
-    de: Die Wallbox muss mit Hilfe der DIP-Schalter auf der Hauptplatine als Satellit konfiguriert werden.
-    en: The charger needs to be configured as Satellite with help of the DIP-Switches on the baseboard.
+    de: "Die Wallbox muss mit Hilfe der DIP-Schalter auf der Hauptplatine als Satellit/Slave konfiguriert werden und Modbus RTU aktiviert sein (Bank S1: 4=ON, 5=ON, 7=OFF). Es sollte kein externes Meter direkt mit der Wallbox verbunden sein, da die Steuerung aller Funktionen direkt durch evcc erfolgt. Es ist keine Zusatzlizenz für das Kostal KSEM erforderlich."
+    en: "The charger needs to be configured as Satellite/Slave with help of the DIP-Switches on the baseboard (Bank S1: 4=ON, 5=ON, 7=OFF) and Modbus RTU enabled. No external meter should be connected directly to the charger as all control functions are managed by evcc. No additional license for Kostal KSEM is required."
   evcc: ["sponsorship"]
 params:
   - name: modbus

--- a/templates/definition/charger/mennekes-compact.yaml
+++ b/templates/definition/charger/mennekes-compact.yaml
@@ -13,8 +13,14 @@ products:
 capabilities: ["1p3p", "mA"]
 requirements:
   description:
-    de: "Die Wallbox muss mit Hilfe der DIP-Schalter auf der Hauptplatine als Satellit/Slave konfiguriert werden und Modbus RTU aktiviert sein (Bank S1: 4=ON, 5=ON, 7=OFF). Es sollte kein externes Meter direkt mit der Wallbox verbunden sein, da die Steuerung aller Funktionen direkt durch evcc erfolgt. Es ist keine Zusatzlizenz für das Kostal KSEM erforderlich."
-    en: "The charger needs to be configured as Satellite/Slave with help of the DIP-Switches on the baseboard (Bank S1: 4=ON, 5=ON, 7=OFF) and Modbus RTU enabled. No external meter should be connected directly to the charger as all control functions are managed by evcc. No additional license for Kostal KSEM is required."
+    de: |
+      Die Wallbox muss mit Hilfe der DIP-Schalter auf der Hauptplatine als Satellit/Slave konfiguriert werden und Modbus RTU aktiviert sein (Bank S1: 4=ON, 5=ON, 7=OFF).
+      Es sollte kein externes Meter direkt mit der Wallbox verbunden sein, da die Steuerung aller Funktionen direkt durch evcc erfolgt.
+      Bei Kostal-Systemen mit Smart Energy Meter (KSEM) ist der zusätzliche Aktivierungscode (Solar Pure Mode / Solar Plus Mode) für das KSEM *nicht* erforderlich.
+    en: |
+      The wallbox must be configured as satellite/slave using the DIP switches on the mainboard and Modbus RTU must be enabled (bank S1: 4=ON, 5=ON, 7=OFF).
+      No external meter should be connected directly to the wallbox, as all functions are controlled directly by evcc.
+      For Kostal systems with Smart Energy Meter (KSEM), the additional activation code (Solar Pure Mode / Solar Plus Mode) for the KSEM is *not* required.
   evcc: ["sponsorship"]
 params:
   - name: modbus

--- a/templates/definition/meter/cg-em24.yaml
+++ b/templates/definition/meter/cg-em24.yaml
@@ -3,6 +3,9 @@ products:
   - brand: Carlo Gavazzi
     description:
       generic: EM24
+  - brand: Victron
+    description:
+      generic: EM24
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/cg-emt3xx.yaml
+++ b/templates/definition/meter/cg-emt3xx.yaml
@@ -2,7 +2,22 @@ template: cg-emt3xx
 products:
   - brand: Carlo Gavazzi
     description:
-      generic: EM/ET 330/340
+      generic: ET330/ET340
+  - brand: Carlo Gavazzi
+    description:
+      generic: EM330/EM340
+  - brand: Carlo Gavazzi
+    description:
+      generic: EM530/EM540
+  - brand: Victron
+    description:
+      generic: ET340
+  - brand: Victron
+    description:
+      generic: EM530/EM540
+  - brand: Kostal
+    description:
+      generic: Energy Meter C (KEM-C)
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/eastron-sdm72v2_630.yaml
+++ b/templates/definition/meter/eastron-sdm72v2_630.yaml
@@ -12,6 +12,9 @@ products:
   - brand: Weidmüller
     description:
       generic: EM122-RTU-2P
+  - brand: Kostal
+    description:
+      generic: Energy Meter P (KEM-P)
 params:
   - name: usage
     choice: ["grid", "charge"]


### PR DESCRIPTION
This charger is an unmodified brand of Mennekes Amtron Compact 2.0s.
It _does not_ require any other Kostal devices or licenses like KSEM.

/cc @unikinCK