### PR TITLE
chore: use same number format for Power L1..L3 as for Power in dump

### DIFF
--- a/cmd/dumper.go
+++ b/cmd/dumper.go
@@ -74,7 +74,7 @@ func (d *dumper) Dump(name string, v interface{}) {
 		if p1, p2, p3, err := v.Powers(); err != nil {
 			fmt.Fprintf(w, "Power L1..L3:\t%v\n", err)
 		} else {
-			fmt.Fprintf(w, "Power L1..L3:\t%.3gW %.3gW %.3gW\n", p1, p2, p3)
+			fmt.Fprintf(w, "Power L1..L3:\t%.0fW %.0fW %.0fW\n", p1, p2, p3)
 		}
 	}
 


### PR DESCRIPTION
Zuvor

```
>go run main.go meter
grid
----
Power:          -5466W
Current L1..L3: 7.95A 7.35A 8.35A
Power L1..L3:   -1.84e+03W -1.7e+03W -1.92e+03W

```

danach

```
> go run main.go meter
grid
----
Power:          -5463W
Current L1..L3: 8.05A 7.28A 8.29A
Power L1..L3:   -1872W -1680W -1911W
```

Gleiches Format wie unter
https://github.com/evcc-io/evcc/blob/2cd08347167cda40edcdf3223d9afefb7a3188b0/cmd/dumper.go#L45