### PR TITLE
Sync charger if measured phases and charger logical state are different

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -768,6 +768,11 @@ func (lp *Loadpoint) syncCharger() error {
 				if chargerPhases > phases {
 					lp.log.WARN.Printf("charger logic error: phases mismatch (got %d measured, expected %d)", chargerPhases, phases)
 					lp.setPhases(chargerPhases)
+					// switch charger phases according to charger's physical state
+					// this is necessary if charger hardware sometimes "forgets" to switch phases i.E. openWB
+					if err := lp.scalePhases(chargerPhases); err != nil {
+						lp.log.ERROR.Println(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Follow up to https://github.com/evcc-io/evcc/pull/14690

Reason is that i.E. openWB sometimes "forgets" to actually switch phases.

In that case fixing loadpoint's state alone does not help, because openWB will ignore the following phase switch as it believes to be already in the desired state.