### PR TITLE
Loadpoint: sync currents only if off by more than 1A

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -729,8 +729,8 @@ func (lp *Loadpoint) syncCharger() error {
 
 		// use measured phase currents as fallback if charger does not provide max current or does not currently relay from vehicle (TWC3)
 		if !isCg || errors.Is(err, api.ErrNotAvailable) {
-			// validate if current too high by at least 1A
-			if current := lp.GetMaxPhaseCurrent(); current >= lp.chargeCurrent+1.0 {
+			// validate if current too high by more than 1A (https://github.com/evcc-io/evcc/issues/14731)
+			if current := lp.GetMaxPhaseCurrent(); current > lp.chargeCurrent+1.0 {
 				if shouldBeConsistent {
 					lp.log.WARN.Printf("charger logic error: current mismatch (got %.3gA measured, expected %.3gA)", current, lp.chargeCurrent)
 				}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14731