### PR TITLE
Ocpp: add autostart mode

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -350,13 +350,16 @@ func (c *OCPP) enableAutostart(enable bool) error {
 	return err
 }
 
-func (c *OCPP) Enable(enable bool) (err error) {
+func (c *OCPP) Enable(enable bool) error {
 	if c.autoStart {
 		return c.enableAutostart(enable)
 	}
 
 	rc := make(chan error, 1)
 	txn, err := c.conn.TransactionID()
+	if err != nil {
+		return err
+	}
 
 	defer func() {
 		if err == nil {

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -518,11 +518,10 @@ func (c *OCPP) phases1p3p(phases int) error {
 	return c.updatePeriod(c.current)
 }
 
-// // Identify implements the api.Identifier interface
-// Unless charger uses vehicle ID as idTag in authorize.req it is not possible to implement this in ocpp1.6
-// func (c *OCPP) Identify() (string, error) {
-// 	return "", errors.New("not implemented")
-// }
+// Identify implements the api.Identifier interface
+func (c *OCPP) Identify() (string, error) {
+	return c.conn.IdTag(), nil
+}
 
 var _ loadpoint.Controller = (*OCPP)(nil)
 

--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -31,6 +31,7 @@ type Connector struct {
 
 	txnCount int // change initial value to the last known global transaction. Needs persistence
 	txnId    int
+	idTag    string
 }
 
 func NewConnector(log *util.Logger, id int, cp *CP, timeout time.Duration) (*Connector, error) {
@@ -59,6 +60,12 @@ func (conn *Connector) ChargePoint() *CP {
 
 func (conn *Connector) ID() int {
 	return conn.id
+}
+
+func (conn *Connector) IdTag() string {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	return conn.idTag
 }
 
 func (conn *Connector) TriggerMessageRequest(feature remotetrigger.MessageTrigger, f ...func(request *remotetrigger.TriggerMessageRequest)) {

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -88,6 +88,7 @@ func (conn *Connector) StartTransaction(request *core.StartTransactionRequest) (
 
 	conn.txnCount++
 	conn.txnId = conn.txnCount
+	conn.idTag = request.IdTag
 
 	res := &core.StartTransactionConfirmation{
 		IdTagInfo: &types.IdTagInfo{

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -99,7 +99,7 @@ func (suite *ocppTestSuite) TestConnect() {
 	suite.Require().True(cp1.IsConnected())
 
 	// 1st charge point- local
-	c1, err := NewOCPP("test-1", 1, "", "", 0, false, false, ocppTestConnectTimeout, ocppTestTimeout, "A")
+	c1, err := NewOCPP("test-1", 1, "", "", 0, false, false, false, ocppTestConnectTimeout, ocppTestTimeout, "A")
 	suite.Require().NoError(err)
 
 	// status and meter values
@@ -158,7 +158,7 @@ func (suite *ocppTestSuite) TestConnect() {
 	suite.Require().True(cp2.IsConnected())
 
 	// 2nd charge point - local
-	c2, err := NewOCPP("test-2", 1, "", "", 0, false, false, ocppTestConnectTimeout, ocppTestTimeout, "A")
+	c2, err := NewOCPP("test-2", 1, "", "", 0, false, false, false, ocppTestConnectTimeout, ocppTestTimeout, "A")
 	suite.Require().NoError(err)
 
 	{

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -38,6 +38,9 @@ requirements:
       * Local network connection
 params:
   - preset: ocpp
+  - name: autostart
+    advanced: true
+    type: bool
   - name: getconfiguration
     advanced: true
     type: bool
@@ -78,6 +81,7 @@ params:
       en: Unit for setting ChargingProfile values ("W" or "A")
 render: |
   {{ include "ocpp" . }}
+  autostart: {{ .autostart }}
   {{- if ne .getconfiguration "true" }}
   getconfiguration: {{ .getconfiguration }}
   {{- end }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14348, replace https://github.com/evcc-io/evcc/pull/12861, fix https://github.com/evcc-io/evcc/issues/14579, fix https://github.com/evcc-io/evcc/issues/14673.

This PR adds an OCPP AutoStart mode. If `autostart: true`, evcc relies on the charger to start the transaction when a vehicle is connected. This transaction is then only ever updated (current, phases) but not stopped by evcc.
For time being, the old behaviour, using `RemoteStart/StopTransaction` remains the default. That might change at a later time.