### PR TITLE
chore: allocate yaml target objects

### DIFF
--- a/assets/js/components/Config/MessagingModal.vue
+++ b/assets/js/components/Config/MessagingModal.vue
@@ -6,6 +6,7 @@
 		docs="/docs/reference/configuration/messaging"
 		:defaultYaml="defaultYaml"
 		endpoint="/config/messaging"
+		data-testid="messaging-modal"
 		@changed="$emit('changed')"
 	/>
 </template>

--- a/server/http.go
+++ b/server/http.go
@@ -245,12 +245,12 @@ func (s *HTTPd) RegisterSystemHandler(valueChan chan<- util.Param, cache *util.C
 
 		// yaml handlers
 		for key, fun := range map[string]func() (any, any){
-			keys.EEBus:       func() (any, any) { return new(map[string]any), eebus.Config{} },
-			keys.Hems:        func() (any, any) { return new(map[string]any), config.Typed{} },
-			keys.Tariffs:     func() (any, any) { return new(map[string]any), globalconfig.Tariffs{} },
-			keys.Messaging:   func() (any, any) { return new(map[string]any), globalconfig.Messaging{} },       // has default
-			keys.ModbusProxy: func() (any, any) { return new([]map[string]any), []globalconfig.ModbusProxy{} }, // slice
-			keys.Circuits:    func() (any, any) { return new([]map[string]any), []config.Named{} },             // slice
+			keys.EEBus:       func() (any, any) { return map[string]any{}, eebus.Config{} },
+			keys.Hems:        func() (any, any) { return map[string]any{}, config.Typed{} },
+			keys.Tariffs:     func() (any, any) { return map[string]any{}, globalconfig.Tariffs{} },
+			keys.Messaging:   func() (any, any) { return map[string]any{}, globalconfig.Messaging{} },       // has default
+			keys.ModbusProxy: func() (any, any) { return []map[string]any{}, []globalconfig.ModbusProxy{} }, // slice
+			keys.Circuits:    func() (any, any) { return []map[string]any{}, []config.Named{} },             // slice
 		} {
 			other, struc := fun()
 			routes[key] = route{Method: "GET", Pattern: "/" + key, HandlerFunc: settingsGetStringHandler(key)}

--- a/tests/config-messaging.spec.js
+++ b/tests/config-messaging.spec.js
@@ -57,28 +57,4 @@ test.describe("messaging", async () => {
     await expect(modal).toBeVisible();
     await expect(modal).toContainText("# hello world");
   });
-
-  test("save real structure", async ({ page }) => {
-    await start(CONFIG_GRID_ONLY, "password.sql");
-    await goToConfig(page);
-
-    await page.getByTestId("messaging").getByRole("button", { name: "edit" }).click();
-    const modal = await page.getByTestId("messaging-modal");
-    await expect(modal).toBeVisible();
-
-    await modal.locator(".monaco-editor .view-line").nth(0).click();
-    for (let i = 0; i < 4; i++) {
-      await page.keyboard.press(SELECT_ALL);
-      await page.keyboard.press("Backspace");
-    }
-    await page.keyboard.type("# hello world");
-    await page.getByRole("button", { name: "Save" }).click();
-    await expect(modal).not.toBeVisible();
-
-    page.reload();
-
-    await page.getByTestId("messaging").getByRole("button", { name: "edit" }).click();
-    await expect(modal).toBeVisible();
-    await expect(modal).toContainText("# hello world");
-  });
 });

--- a/tests/config-messaging.spec.js
+++ b/tests/config-messaging.spec.js
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+
+const CONFIG_GRID_ONLY = "config-grid-only.evcc.yaml";
+
+test.use({ baseURL: baseUrl() });
+
+test.afterEach(async () => {
+  await stop();
+});
+
+const SELECT_ALL = "ControlOrMeta+KeyA";
+
+async function login(page) {
+  await page.locator("#loginPassword").fill("secret");
+  await page.getByRole("button", { name: "Login" }).click();
+  await expect(page.locator("#loginPassword")).not.toBeVisible();
+}
+
+async function enableExperimental(page) {
+  await page
+    .getByTestId("generalconfig-experimental")
+    .getByRole("button", { name: "edit" })
+    .click();
+  await page.getByLabel("Experimental 🧪").click();
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(page.locator(".modal-backdrop")).not.toBeVisible();
+}
+
+async function goToConfig(page) {
+  await page.goto("/#/config");
+  await login(page);
+  await enableExperimental(page);
+}
+
+test.describe("messaging", async () => {
+  test("save a comment", async ({ page }) => {
+    await start(CONFIG_GRID_ONLY, "password.sql");
+    await goToConfig(page);
+
+    await page.getByTestId("messaging").getByRole("button", { name: "edit" }).click();
+    const modal = await page.getByTestId("messaging-modal");
+    await expect(modal).toBeVisible();
+
+    await modal.locator(".monaco-editor .view-line").nth(0).click();
+    for (let i = 0; i < 4; i++) {
+      await page.keyboard.press(SELECT_ALL);
+      await page.keyboard.press("Backspace");
+    }
+    await page.keyboard.type("# hello world");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(modal).not.toBeVisible();
+
+    page.reload();
+
+    await page.getByTestId("messaging").getByRole("button", { name: "edit" }).click();
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("# hello world");
+  });
+
+  test("save real structure", async ({ page }) => {
+    await start(CONFIG_GRID_ONLY, "password.sql");
+    await goToConfig(page);
+
+    await page.getByTestId("messaging").getByRole("button", { name: "edit" }).click();
+    const modal = await page.getByTestId("messaging-modal");
+    await expect(modal).toBeVisible();
+
+    await modal.locator(".monaco-editor .view-line").nth(0).click();
+    for (let i = 0; i < 4; i++) {
+      await page.keyboard.press(SELECT_ALL);
+      await page.keyboard.press("Backspace");
+    }
+    await page.keyboard.type("# hello world");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(modal).not.toBeVisible();
+
+    page.reload();
+
+    await page.getByTestId("messaging").getByRole("button", { name: "edit" }).click();
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("# hello world");
+  });
+});


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14736

We need to return an allocated object instead of a new pointer to a typed nil (at least I think that's what's wrong here).

@naltatis könntest Du dafür einen Test hinzu fügen? Ich wundere mich, dass das jetzt erst auffällt.
Mich wundert auch, dass der Dialog nach dem (erfolgreichen) Speichern noch offen bleibt?

TODOs

- [x] add e2e test @naltatis 