### PR TITLE
Vehicle status icons only when connected, tooltips, logs

### DIFF
--- a/assets/js/components/VehicleStatus.vue
+++ b/assets/js/components/VehicleStatus.vue
@@ -270,7 +270,7 @@ export default {
 		},
 		vehicleLimitVisible() {
 			const limit = this.effectiveLimitSoc || 100;
-			return this.vehicleLimitSoc > 0 && this.vehicleLimitSoc < limit;
+			return this.connected && this.vehicleLimitSoc > 0 && this.vehicleLimitSoc < limit;
 		},
 		vehicleLimitTooltipContent() {
 			if (!this.vehicleLimitVisible) {
@@ -285,7 +285,7 @@ export default {
 			return this.$t("main.vehicleStatus.vehicleLimit");
 		},
 		minSocVisible() {
-			return this.minSoc > 0 && this.vehicleSoc < this.minSoc;
+			return this.connected && this.minSoc > 0 && this.vehicleSoc < this.minSoc;
 		},
 		minSocTooltipContent() {
 			if (!this.minSocVisible) {
@@ -539,8 +539,8 @@ export default {
 			}
 		},
 		smartCostClicked() {
-			this.smartCostTooltip?.hide();
 			this.openLoadpointSettings();
+			this.smartCostTooltip?.hide();
 		},
 		updatePvTooltip() {
 			this.pvTooltip = this.updateTooltip(

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -66,7 +66,7 @@ func (site *Site) plannerRates() (api.Rates, error) {
 
 func (site *Site) plannerRate() (*api.Rate, error) {
 	rates, err := site.plannerRates()
-	if err != nil {
+	if rates == nil || err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/14782
small reworks for https://github.com/evcc-io/evcc/pull/14581

- 🧹 remove smart cost log warning
- 🚗 vehicle icons (limit/minsoc) only when connected
- 🏷️ close tooltip when opening dialog