### PR TITLE
Standard sh shell uses single '=' not '==' for comparison

### DIFF
--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -23,7 +23,7 @@ if [ -f ${HASSIO_OPTIONSFILE} ]; then
         fi
     fi
 else
-    if [ "$1" == '"evcc"' ] || expr "$1" : '-*' > /dev/null; then
+    if [ "$1" = '"evcc"' ] || expr "$1" : '-*' > /dev/null; then
         exec evcc "$@"
     else
         exec "$@"


### PR DESCRIPTION
See issue: https://github.com/evcc-io/evcc/issues/14830