### PR TITLE
Improve EEBUS support for Elli Gen 1 (part 4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -197,6 +197,6 @@ require (
 
 replace gopkg.in/yaml.v3 => github.com/andig/yaml v0.0.0-20240531135838-1ff5761ab467
 
-replace github.com/enbility/eebus-go => github.com/enbility/eebus-go v0.0.0-20240705140947-e13aec8af1ba
+replace github.com/enbility/eebus-go => github.com/enbility/eebus-go v0.0.0-20240711202230-38f7be54ae45
 
 replace github.com/enbility/spine-go => github.com/enbility/spine-go v0.0.0-20240705075417-fb2969d753c1

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/enbility/eebus-go v0.0.0-20240705140947-e13aec8af1ba h1:wlfFa9joFrll4u3nqPc25q3QyNUxiYSa0l8sPiYMOCA=
-github.com/enbility/eebus-go v0.0.0-20240705140947-e13aec8af1ba/go.mod h1:6ka3OsfqJDiXAWMMYO1LkKQa7xSIgqrhwOeP5kO/yao=
+github.com/enbility/eebus-go v0.0.0-20240711202230-38f7be54ae45 h1:k8g24cFlbQbjxeZ1Xqiu+YpTPQh8iocCAtH5z7rwESg=
+github.com/enbility/eebus-go v0.0.0-20240711202230-38f7be54ae45/go.mod h1:6ka3OsfqJDiXAWMMYO1LkKQa7xSIgqrhwOeP5kO/yao=
 github.com/enbility/ship-go v0.5.1 h1:8Vax1MpyI/C+kQlMFAzQ7/h/xJ7fuumSLJy9FYgEkcE=
 github.com/enbility/ship-go v0.5.1/go.mod h1:jewJWYQ10jNhsnhS1C4jESx3CNmDa5HNWZjBhkTug5Y=
 github.com/enbility/spine-go v0.0.0-20240705075417-fb2969d753c1 h1:H7Jvd7QOmA3IJtfswnoXY37WFSxYeMCIQemtmrN1pS8=


### PR DESCRIPTION
Update EEBUS library to not actively send read messages if measurement values provide no or an “old” timestamp.

Maybe this also helps with Elli Gen 1 issues reported in https://github.com/evcc-io/evcc/issues/14839