### PR TITLE
Solis Hybrid: split RHI and S series

### DIFF
--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -1,8 +1,8 @@
-template: solis-hybrid
+template: solis-hybrid-s
 products:
   - brand: Ginlong
     description:
-      generic: Solis Hybrid Inverter (RHI series)
+      generic: Solis Hybrid Inverter (S Series)
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -95,13 +95,25 @@ render: |
   {{- end }}
   {{- if eq .usage "battery" }}
   power:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      type: input
-      address: 33149 # Battery power
-      decode: int32
-    scale: -1
+    source: calc
+    mul:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        type: input
+        address: 33149 # Battery power
+        decode: uint32
+    - source: calc
+      add:
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          type: input
+          address: 33135 # Battery current direction
+          decode: uint16 # 0：charge, 1：discharge
+        scale: 2
+      - source: const
+        value: -1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14711 by splitting templates by series. The `S` series returns the "old" template with externally-determined power sign.