### PR TITLE
Zuidwijk SlimmeLezer(+): Add new template for newer devices

### DIFF
--- a/templates/definition/meter/slimmelezer-v2.yaml
+++ b/templates/definition/meter/slimmelezer-v2.yaml
@@ -1,0 +1,100 @@
+template: slimmelezerV2
+products:
+  - brand: Zuidwijk
+    description:
+      generic: SlimmeLezer(+) V2
+      en: SlimmeLezer(+) V2 with new endpoints
+      de: SlimmeLezer(+) V2 mit neuen Endpunkten
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: host
+render: |
+  type: custom
+  power:
+    source: calc
+    add:
+    - source: http
+      uri: http://{{ .host }}/sensor/power_delivered
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: 1000
+    - source: http
+      uri: http://{{ .host }}/sensor/power_returned
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: -1000
+  energy:
+    source: calc
+    add:
+    - source: http
+      uri: http://{{ .host }}/sensor/energy_delivered_tariff1
+      headers:
+      - content-type: application/json
+      jq: .value
+    - source: http
+      uri: http://{{ .host }}/sensor/energy_delivered_tariff2
+      headers:
+      - content-type: application/json
+      jq: .value
+  currents:
+  - source: http
+    uri: http://{{ .host }}/sensor/current_l1
+    headers:
+    - content-type: application/json
+    jq: .value
+  - source: http
+    uri: http://{{ .host }}/sensor/current_l2
+    headers:
+    - content-type: application/json
+    jq: .value
+  - source: http
+    uri: http://{{ .host }}/sensor/current_l3
+    headers:
+    - content-type: application/json
+    jq: .value
+  powers:
+  - source: calc
+    add:
+    - source: http
+      uri: http://{{ .host }}/sensor/power_delivered_l1
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: 1000
+    - source: http
+      uri: http://{{ .host }}/sensor/power_returned_l1
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: -1000
+  - source: calc
+    add:
+    - source: http
+      uri: http://{{ .host }}/sensor/power_delivered_l2
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: 1000
+    - source: http
+      uri: http://{{ .host }}/sensor/power_returned_l2
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: -1000
+  - source: calc
+    add:
+    - source: http
+      uri: http://{{ .host }}/sensor/power_delivered_l3
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: 1000
+    - source: http
+      uri: http://{{ .host }}/sensor/power_returned_l3
+      headers:
+      - content-type: application/json
+      jq: .value
+      scale: -1000

--- a/templates/definition/meter/slimmelezer-v2.yaml
+++ b/templates/definition/meter/slimmelezer-v2.yaml
@@ -1,4 +1,4 @@
-template: slimmelezerV2
+template: slimmelezer-V2
 products:
   - brand: Zuidwijk
     description:

--- a/templates/definition/meter/slimmelezer-v2.yaml
+++ b/templates/definition/meter/slimmelezer-v2.yaml
@@ -15,13 +15,13 @@ render: |
     source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_delivered
+      uri: http://{{ .host }}/sensor/power_consumed
       headers:
       - content-type: application/json
       jq: .value
       scale: 1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_returned
+      uri: http://{{ .host }}/sensor/power_produced
       headers:
       - content-type: application/json
       jq: .value
@@ -30,28 +30,28 @@ render: |
     source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/energy_delivered_tariff1
+      uri: http://{{ .host }}/sensor/energy_produced_tariff_1
       headers:
       - content-type: application/json
       jq: .value
     - source: http
-      uri: http://{{ .host }}/sensor/energy_delivered_tariff2
+      uri: http://{{ .host }}/sensor/energy_produced_tariff_2
       headers:
       - content-type: application/json
       jq: .value
   currents:
   - source: http
-    uri: http://{{ .host }}/sensor/current_l1
+    uri: http://{{ .host }}/sensor/current_phase_1
     headers:
     - content-type: application/json
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/current_l2
+    uri: http://{{ .host }}/sensor/current_phase_2
     headers:
     - content-type: application/json
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/current_l3
+    uri: http://{{ .host }}/sensor/current_phase_3
     headers:
     - content-type: application/json
     jq: .value
@@ -59,13 +59,13 @@ render: |
   - source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_delivered_l1
+      uri: http://{{ .host }}/sensor/power_produced_phase_1
       headers:
       - content-type: application/json
       jq: .value
       scale: 1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_returned_l1
+      uri: http://{{ .host }}/sensor/power_consumed_phase_1
       headers:
       - content-type: application/json
       jq: .value
@@ -73,13 +73,13 @@ render: |
   - source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_delivered_l2
+      uri: http://{{ .host }}/sensor/power_produced_phase_2
       headers:
       - content-type: application/json
       jq: .value
       scale: 1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_returned_l2
+      uri: http://{{ .host }}/sensor/power_consumed_phase_2
       headers:
       - content-type: application/json
       jq: .value
@@ -87,13 +87,13 @@ render: |
   - source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_delivered_l3
+      uri: http://{{ .host }}/sensor/power_produced_phase_3
       headers:
       - content-type: application/json
       jq: .value
       scale: 1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_returned_l3
+      uri: http://{{ .host }}/sensor/power_consumed_phase_3
       headers:
       - content-type: application/json
       jq: .value

--- a/templates/definition/meter/slimmelezer-v2.yaml
+++ b/templates/definition/meter/slimmelezer-v2.yaml
@@ -3,8 +3,10 @@ products:
   - brand: Zuidwijk
     description:
       generic: SlimmeLezer(+) V2
-      en: SlimmeLezer(+) V2 with new endpoints
-      de: SlimmeLezer(+) V2 mit neuen Endpunkten
+requirements:
+  description:
+    de: Neuere Slimmelezer-Geräte verwenden eine andere Konfiguration. Probieren Sie diese Vorlage aus, wenn die andere fehlschlägt.
+    en: More recent slimmelezer devices use a different configuration. Try this template if the other one fails.
 params:
   - name: usage
     choice: ["grid"]


### PR DESCRIPTION
At some point the endpoints of the Zuidwijk SlimmeLezer devices have changed. So the existing template was not working anymore for recent devices. The PR Adds a new version of the template that uses the new endpoints.

Decided not to change the existing one to prevent braking existing installations with older devices.

fixes https://github.com/evcc-io/evcc/issues/10425