### PR TITLE
Improve EEBUS support for Elli Gen 1 (part 5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -196,3 +196,5 @@ require (
 )
 
 replace gopkg.in/yaml.v3 => github.com/andig/yaml v0.0.0-20240531135838-1ff5761ab467
+
+replace github.com/enbility/spine-go => github.com/enbility/spine-go v0.0.0-20240718190814-6580e13d0b35

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/enbility/eebus-go v0.6.1 h1:2xKf3+tuScfV0ZWK/spPzoc2ekix6oZdZ0mjmcS9r
 github.com/enbility/eebus-go v0.6.1/go.mod h1:XulY17uTjq65MWG4LQh28C/D6ogXBUa1e8nNNKssPg4=
 github.com/enbility/ship-go v0.5.2 h1:T9+YuP5ZpofKd463PLKq78fAaPAcGMnRAcv8c8aD5yU=
 github.com/enbility/ship-go v0.5.2/go.mod h1:jewJWYQ10jNhsnhS1C4jESx3CNmDa5HNWZjBhkTug5Y=
-github.com/enbility/spine-go v0.6.1 h1:6NAPE7PmCQsmfiZy/dLpnFZXEw8RK9H4USGniIw9r+Q=
-github.com/enbility/spine-go v0.6.1/go.mod h1:pRGS+C5rZ5rhxTAA1whU8fC9p7lH5ixyut++yEZe470=
+github.com/enbility/spine-go v0.0.0-20240718190814-6580e13d0b35 h1:QuzPIvtPzA7DHpwBVwsYOjuiKJtAtUzA2uPkhtTpyUI=
+github.com/enbility/spine-go v0.0.0-20240718190814-6580e13d0b35/go.mod h1:pRGS+C5rZ5rhxTAA1whU8fC9p7lH5ixyut++yEZe470=
 github.com/enbility/zeroconf/v2 v2.0.0-20240210101930-d0004078577b h1:sg3c6LJ4eWffwtt9SW0lgcIX4Oh274vwdJnNFNNrDco=
 github.com/enbility/zeroconf/v2 v2.0.0-20240210101930-d0004078577b/go.mod h1:BjzRRiYX6mWdOgku1xxDE+NsV8PijTby7Q7BkYVdfDU=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=


### PR DESCRIPTION
Update EEBUS spine-go library to send heartbeat messages 1s earlier than needed. Maybe the Elli sofware interprets the heartbeat not according to the spec and wrongly falls back into failsafe mode.

Maybe this also helps with Elli Gen 1 issues reported in https://github.com/evcc-io/evcc/issues/14839