### PR TITLE
Add grid cost guard for planner and minsoc charging

### DIFF
--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -28,9 +28,10 @@ const (
 	Charging  = "charging"  // charging
 
 	// smart charging
-	SmartCostActive    = "smartCostActive"    // smart cost active
-	SmartCostLimit     = "smartCostLimit"     // smart cost limit
-	SmartCostNextStart = "smartCostNextStart" // smart cost next start
+	SmartCostActive     = "smartCostActive"     // smart cost active
+	SmartCostLimit      = "smartCostLimit"      // smart cost limit
+	SmartCostNextStart  = "smartCostNextStart"  // smart cost next start
+	GridCostGuardActive = "gridCostGuardActive" // grid cost guard active
 
 	// effective values
 	EffectivePriority   = "effectivePriority"   // effective priority
@@ -60,7 +61,7 @@ const (
 	PlanSoc            = "planSoc"            // charge plan soc goal
 	PlanActive         = "planActive"         // charge plan has determined current slot to be an active slot
 	PlanProjectedStart = "planProjectedStart" // charge plan start time (earliest slot)
-	PlanProjectedEnd   = "planProjectedEnd"   //charge plan ends (end of last slot)
+	PlanProjectedEnd   = "planProjectedEnd"   // charge plan ends (end of last slot)
 	PlanOverrun        = "planOverrun"        // charge plan goal not reachable in time
 
 	// remote control

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -18,7 +18,6 @@ const (
 	PvPower               = "pvPower"
 	ResidualPower         = "residualPower"
 	SiteTitle             = "siteTitle"
-	SmartCostType         = "smartCostType"
 	Statistics            = "statistics"
 	TariffCo2             = "tariffCo2"
 	TariffCo2Home         = "tariffCo2Home"
@@ -29,6 +28,10 @@ const (
 	TariffPriceLoadpoints = "tariffPriceLoadpoints"
 	Vehicles              = "vehicles"
 	Circuits              = "circuits"
+
+	// costs
+	SmartCostType      = "smartCostType"
+	GridCostGuardLimit = "gridCostGuardLimit"
 
 	// meters
 	GridMeter     = "gridMeter"

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1614,8 +1614,8 @@ func (lp *Loadpoint) phaseSwitchCompleted() bool {
 	return time.Since(lp.phasesSwitched) > phaseSwitchDuration
 }
 
-// Update is the main control function. It reevaluates meters and charger state
-func (lp *Loadpoint) Update(sitePower float64, smartCostActive bool, smartCostNextStart time.Time, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+func (lp *Loadpoint) Update(sitePower float64, gridCostGuardActive, smartCostActive bool, smartCostNextStart time.Time, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+	lp.publish(keys.GridCostGuardActive, gridCostGuardActive)
 	lp.publish(keys.SmartCostActive, smartCostActive)
 	lp.publish(keys.SmartCostNextStart, smartCostNextStart)
 	lp.processTasks()
@@ -1694,7 +1694,7 @@ func (lp *Loadpoint) Update(sitePower float64, smartCostActive bool, smartCostNe
 		err = lp.setLimit(0)
 
 	// minimum or target charging
-	case lp.minSocNotReached() || plannerActive:
+	case !gridCostGuardActive && (lp.minSocNotReached() || plannerActive):
 		err = lp.fastCharging()
 		lp.resetPhaseTimer()
 		lp.elapsePVTimer() // let PV mode disable immediately afterwards

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -182,7 +182,7 @@ func TestUpdatePowerZero(t *testing.T) {
 		}
 
 		lp.mode = tc.mode
-		lp.Update(0, false, time.Time{}, false, false, 0, nil, nil) // false,sitePower false,0
+		lp.Update(0, false, false, time.Time{}, false, false, 0, nil, nil) // false,sitePower false,0
 
 		ctrl.Finish()
 	}
@@ -428,7 +428,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Status().Return(api.StatusC, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
-	lp.Update(500, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(500, false, false, time.Time{}, false, false, 0, nil, nil)
 	ctrl.Finish()
 
 	t.Log("charging above target - soc deactivates charger")
@@ -437,7 +437,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Status().Return(api.StatusC, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Enable(false).Return(nil)
-	lp.Update(500, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(500, false, false, time.Time{}, false, false, 0, nil, nil)
 	ctrl.Finish()
 
 	t.Log("deactivated charger changes status to B")
@@ -445,14 +445,14 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	vehicle.EXPECT().Soc().Return(95.0, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
-	lp.Update(-5000, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-5000, false, false, time.Time{}, false, false, 0, nil, nil)
 	ctrl.Finish()
 
 	t.Log("soc has fallen below target - soc update prevented by timer")
 	clock.Add(5 * time.Minute)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
-	lp.Update(-5000, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-5000, false, false, time.Time{}, false, false, 0, nil, nil)
 	ctrl.Finish()
 
 	t.Log("soc has fallen below target - soc update timer expired")
@@ -461,7 +461,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Enable(true).Return(nil)
-	lp.Update(-5000, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-5000, false, false, time.Time{}, false, false, 0, nil, nil)
 	ctrl.Finish()
 }
 
@@ -496,14 +496,14 @@ func TestSetModeAndSocAtDisconnect(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
 	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
-	lp.Update(500, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(500, false, false, time.Time{}, false, false, 0, nil, nil)
 
 	t.Log("switch off when disconnected")
 	clock.Add(5 * time.Minute)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusA, nil)
 	charger.EXPECT().Enable(false).Return(nil)
-	lp.Update(-3000, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-3000, false, false, time.Time{}, false, false, 0, nil, nil)
 
 	if mode := lp.GetMode(); mode != api.ModeOff {
 		t.Error("unexpected mode", mode)
@@ -566,14 +566,14 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(0.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-1, false, false, time.Time{}, false, false, 0, nil, nil)
 
 	t.Log("at 1:00h charging at 5 kWh")
 	clock.Add(time.Hour)
 	rater.EXPECT().ChargedEnergy().Return(5.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-1, false, false, time.Time{}, false, false, 0, nil, nil)
 	expectCache("chargedEnergy", 5000.0)
 
 	t.Log("at 1:00h stop charging at 5 kWh")
@@ -581,7 +581,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(5.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
-	lp.Update(-1, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-1, false, false, time.Time{}, false, false, 0, nil, nil)
 	expectCache("chargedEnergy", 5000.0)
 
 	t.Log("at 1:00h restart charging at 5 kWh")
@@ -589,7 +589,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(5.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-1, false, false, time.Time{}, false, false, 0, nil, nil)
 	expectCache("chargedEnergy", 5000.0)
 
 	t.Log("at 1:30h continue charging at 7.5 kWh")
@@ -597,7 +597,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(7.5, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-1, false, false, time.Time{}, false, false, 0, nil, nil)
 	expectCache("chargedEnergy", 7500.0)
 
 	t.Log("at 2:00h stop charging at 10 kWh")
@@ -605,7 +605,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(10.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
-	lp.Update(-1, false, time.Time{}, false, false, 0, nil, nil)
+	lp.Update(-1, false, false, time.Time{}, false, false, 0, nil, nil)
 	expectCache("chargedEnergy", 10000.0)
 
 	ctrl.Finish()

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -270,7 +270,7 @@ func TestReconnectVehicle(t *testing.T) {
 			// vehicle not updated yet
 			vehicle.MockChargeState.EXPECT().Status().Return(api.StatusA, nil)
 
-			lp.Update(0, false, time.Time{}, false, false, 0, nil, nil)
+			lp.Update(0, false, false, time.Time{}, false, false, 0, nil, nil)
 			ctrl.Finish()
 
 			// detection started
@@ -284,7 +284,7 @@ func TestReconnectVehicle(t *testing.T) {
 			// vehicle not updated yet
 			vehicle.MockChargeState.EXPECT().Status().Return(api.StatusB, nil)
 
-			lp.Update(0, false, time.Time{}, false, false, 0, nil, nil)
+			lp.Update(0, false, false, time.Time{}, false, false, 0, nil, nil)
 			ctrl.Finish()
 
 			// vehicle detected

--- a/core/site/api.go
+++ b/core/site/api.go
@@ -50,8 +50,9 @@ type API interface {
 	// tariffs and costs
 	//
 
-	// GetTariff returns the respective tariff
 	GetTariff(string) api.Tariff
+	GetGridCostGuardLimit() *float64
+	SetGridCostGuardLimit(*float64)
 
 	//
 	// battery control

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -153,6 +153,33 @@ func (site *Site) GetPrioritySoc() float64 {
 	return site.prioritySoc
 }
 
+// GetGridCostGuardLimit returns the grid cost guard limit
+func (site *Site) GetGridCostGuardLimit() *float64 {
+	site.RLock()
+	defer site.RUnlock()
+	return site.gridCostGuardLimit
+}
+
+// SetGridCostGuardLimit returns the PrioritySoc
+func (site *Site) SetGridCostGuardLimit(val *float64) {
+	site.Lock()
+	defer site.Unlock()
+
+	site.log.DEBUG.Println("set grid cost guard limit:", printFloatPtr("%.1f", val))
+
+	if site.gridCostGuardLimit != val {
+		site.gridCostGuardLimit = val
+
+		if val == nil {
+			settings.SetString(keys.MaxGridSupplyWhileBatteryCharging, "")
+			site.publish(keys.MaxGridSupplyWhileBatteryCharging, "")
+		} else {
+			settings.SetFloat(keys.MaxGridSupplyWhileBatteryCharging, *val)
+			site.publish(keys.MaxGridSupplyWhileBatteryCharging, *val)
+		}
+	}
+}
+
 // SetPrioritySoc sets the PrioritySoc
 func (site *Site) SetPrioritySoc(soc float64) error {
 	site.Lock()

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -171,11 +171,11 @@ func (site *Site) SetGridCostGuardLimit(val *float64) {
 		site.gridCostGuardLimit = val
 
 		if val == nil {
-			settings.SetString(keys.MaxGridSupplyWhileBatteryCharging, "")
-			site.publish(keys.MaxGridSupplyWhileBatteryCharging, "")
+			settings.SetString(keys.GridCostGuardLimit, "")
+			site.publish(keys.GridCostGuardLimit, "")
 		} else {
-			settings.SetFloat(keys.MaxGridSupplyWhileBatteryCharging, *val)
-			site.publish(keys.MaxGridSupplyWhileBatteryCharging, *val)
+			settings.SetFloat(keys.GridCostGuardLimit, *val)
+			site.publish(keys.GridCostGuardLimit, *val)
 		}
 	}
 }

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -78,6 +78,11 @@ func (site *Site) plannerRate() (*api.Rate, error) {
 	return &rate, nil
 }
 
+func (site *Site) gridCostGuardActive(rate *api.Rate) bool {
+	limit := site.GetGridCostGuardLimit()
+	return limit != nil && rate != nil && rate.Price <= *limit
+}
+
 func (site *Site) smartCostActive(lp loadpoint.API, rate *api.Rate) bool {
 	limit := lp.GetSmartCostLimit()
 	return limit != 0 && rate != nil && rate.Price <= limit


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/14887. Depends on https://github.com/evcc-io/evcc/pull/14855.

Add grid cost guard limit that is applied to minsoc and planner charging.

TODO

- [x] api
- [ ] cost ui
- [ ] status visualisation
- [ ] Integrate with planner @andig 
- [ ] check if planner issue can be visualised (@naltatis)

Out of scope
- Planner does not take up-front limits into account. A plan that includes slots with limits can never be fulfilled.