### PR TITLE
MB - Add MaxSoc

### DIFF
--- a/vehicle/mercedes/api.go
+++ b/vehicle/mercedes/api.go
@@ -97,5 +97,15 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 		res.EvInfo.Battery.ChargingStatus = 3
 	}
 
+	if val, ok := message.Attributes["selectedChargeProgram"]; ok {
+		res.EvInfo.Battery.SelectedChargeProgram = int(val.GetIntValue())
+		val := message.Attributes["chargePrograms"].GetChargeProgramsValue()
+		res.EvInfo.Battery.SocLimit = int(val.ChargeProgramParameters[res.EvInfo.Battery.SelectedChargeProgram].GetMaxSoc())
+	} else {
+		if val, ok := message.Attributes["maxSoc"]; ok {
+			res.EvInfo.Battery.SocLimit = int(val.GetIntValue())
+		}
+	}
+
 	return res, err
 }

--- a/vehicle/mercedes/provider.go
+++ b/vehicle/mercedes/provider.go
@@ -42,6 +42,14 @@ func (v *Provider) Odometer() (float64, error) {
 	return float64(res.VehicleInfo.Odometer.Value), err
 }
 
+var _ api.SocLimiter = (*Provider)(nil)
+
+// GetLimitSoc implements the api.SocLimiter interface
+func (v *Provider) GetLimitSoc() (int64, error) {
+	res, err := v.dataG()
+	return int64(res.EvInfo.Battery.SocLimit), err
+}
+
 var _ api.ChargeState = (*Provider)(nil)
 
 // Status implements the api.ChargeState interface

--- a/vehicle/mercedes/types.go
+++ b/vehicle/mercedes/types.go
@@ -60,9 +60,11 @@ type StatusResponse struct {
 				Value int
 				Unit  string
 			}
-			StateOfCharge   float64 // 75
-			EndOfChargeTime int     // Minutes after midnight
-			TotalRange      int     // 17
+			StateOfCharge         float64 // 75
+			EndOfChargeTime       int     // Minutes after midnight
+			TotalRange            int     // 17
+			SocLimit              int     // 50-100
+			SelectedChargeProgram int
 		}
 		Timestamp time.Time
 	}


### PR DESCRIPTION
This PR adds the MaxSoc information to the MB vehicle implementation. 

MB has two modes:

1. Hybrids - Don't have charge programs and the value is stored in the attribute "maxSoc"
2. EQs - Have charge programs and the value out of the current selected charge program is used.