### PR TITLE
Templates: remove deprecated params from api

### DIFF
--- a/server/http_config_metadata_handler.go
+++ b/server/http_config_metadata_handler.go
@@ -33,7 +33,20 @@ func templatesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonResult(w, templates.ByClass(class))
+	// filter deprecated properties
+	res := make([]templates.Template, 0)
+	for _, t := range templates.ByClass(class) {
+		params := make([]templates.Param, 0, len(t.Params))
+		for _, p := range t.Params {
+			if p.Deprecated == nil || !*p.Deprecated {
+				params = append(params, p)
+			}
+		}
+		t.Params = params
+		res = append(res, t)
+	}
+
+	jsonResult(w, res)
 }
 
 // productsHandler returns the list of products by class


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/15000

TODO

- [x] hide deprecated properties

Out of scope 
- [ ] show advanced properties @naltatis 

@naltatis wenns einfacher wäre könnten wir auch das `advanced` per Filter raus nehmen- dann wird die Propertyliste aber ggf. sehr lang.