### PR TITLE
Fix: singleline help test for welcomecharge

### DIFF
--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -295,12 +295,8 @@ params:
       en: Charge on connection
       de: Laden bei Verbindung
     help:
-      en: |
-        Charger will enable charging for short time when vehicle is connected, irrespective of configured charge mode. 
-        This is useful for vehicles that require power supply when connecting.
-      de: |
-        Wallbox gibt kurzzeitige Ladefreigabe bei Fahrzeugverbindung. Das ermöglicht es Fahrzeugen, die eine Stromversorgung beim Anschließen benötigen, 
-        einen Fehlerzustand zu vermeiden.
+      en: Charger will enable charging for short time when vehicle is connected, irrespective of configured charge mode. This is useful for vehicles that require power supply when connecting.
+      de: Wallbox gibt kurzzeitige Ladefreigabe bei Fahrzeugverbindung. Das ermöglicht es Fahrzeugen, die eine Stromversorgung beim Anschließen benötigen, einen Fehlerzustand zu vermeiden.
 
 presets:
   vehicle-base:


### PR DESCRIPTION
Since help-texts are used as yaml comments in documentation right now its important that they are dont include linebreaks. Otherwise docs will fail building https://github.com/evcc-io/docs/actions/runs/10073941116/job/27849002976