### PR TITLE
Fix nightly build - Change smart-cost test config

### DIFF
--- a/tests/smart-cost-only.evcc.yaml
+++ b/tests/smart-cost-only.evcc.yaml
@@ -40,5 +40,5 @@ tariffs:
     type: fixed
     price: 0.4 # EUR/kWh
     zones:
-      - hours: 1-6
+      - hours: 0-1
         price: 0.2


### PR DESCRIPTION
The nightly build is not working. The test case smart-cost is failing. 

The `tests/smart-cost-only.evcc.yaml` has a special setting that the price is different between 1-6am. I have changed this to 0-1 so that the nightly that runs at 2 have the right setup.

```
Error: Timed out 5000ms waiting for expect(locator).toHaveText(expected)

Locator: getByTestId('vehicle-status-smartcost')
Expected string: "40.0 ct ≤ 40.0 ct"
Received string: "20.0 ct ≤ 40.0 ct"
Call log:
  - expect.toHaveText with timeout 5000ms
  - waiting for getByTestId('vehicle-status-smartcost')
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"
  -   locator resolved to <button type="button" data-v-3e4eaa35="" data-bs-toggle=…>…</button>
  -   unexpected value "20.0 ct ≤ 40.0 ct"


  39 |     await expect(page.getByTestId("loadpoint-settings-modal")).not.toBeVisible();
  40 |     await expect(page.getByTestId("vehicle-status-charger")).toHaveText("Charging…");
> 41 |     await expect(page.getByTestId("vehicle-status-smartcost")).toHaveText("40.0 ct ≤ 40.0 ct");
     |                                                                ^
  42 |   });
  43 |   test("price above limit", async ({ page }) => {
  44 |     await page.goto("/");

    at /home/runner/work/evcc/evcc/tests/smart-cost.spec.js:41:64
```