### PR TITLE
Config UI: add advanced fields, add general vehicle properties

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -250,6 +250,10 @@ a:hover {
 	--bs-btn-hover-border-color: var(--bs-gray-medium);
 }
 
+.btn-link:hover {
+	color: var(--bs-primary);
+}
+
 .dark .btn-outline-secondary {
 	--bs-btn-color: var(--bs-gray-bright);
 	--bs-btn-border-color: var(--bs-gray-bright);

--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -171,6 +171,8 @@ function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const CUSTOM_FIELDS = ["usage", "modbus"];
+
 export default {
 	name: "MeterModal",
 	components: {
@@ -222,16 +224,14 @@ export default {
 			return this.products.filter((p) => p.group === "generic");
 		},
 		templateParams() {
-			const params = this.template?.Params || [];
-			return (
-				params
-					// remove usage option
-					.filter((p) => p.Name !== "usage")
-					// remove modbus, handles separately
-					.filter((p) => p.Name !== "modbus")
-					// capacity only for battery meters
-					.filter((p) => this.meterType === "battery" || p.Name !== "capacity")
-			);
+			return (this.template?.Params || [])
+				.filter((p) => !CUSTOM_FIELDS.includes(p.Name))
+				.map((p) => {
+					if (this.meterType === "battery" && p.Name === "capacity") {
+						p.Advanced = false;
+					}
+					return p;
+				});
 		},
 		normalParams() {
 			return this.templateParams.filter((p) => !p.Advanced);

--- a/assets/js/components/Config/PropertyCollapsible.vue
+++ b/assets/js/components/Config/PropertyCollapsible.vue
@@ -1,0 +1,60 @@
+<template>
+	<button
+		class="btn btn-link btn-sm text-gray px-0 border-0 d-flex align-items-center mb-2"
+		:class="open ? 'text-primary' : ''"
+		type="button"
+		@click="toggle"
+	>
+		<span v-if="open">Hide advanced settings</span>
+		<span v-else>Show advanced settings</span>
+		<DropdownIcon class="icon" :class="{ iconUp: open }" />
+	</button>
+
+	<Transition>
+		<div v-if="open" class="pt-2">
+			<slot name="advanced"></slot>
+			<hr v-if="$slots.advanced && $slots.more" class="my-5" />
+			<slot name="more"></slot>
+		</div>
+	</Transition>
+</template>
+
+<script>
+import DropdownIcon from "../MaterialIcon/Dropdown.vue";
+
+export default {
+	name: "PropertyCollapsible",
+	components: { DropdownIcon },
+	data() {
+		return { open: false };
+	},
+
+	methods: {
+		toggle() {
+			this.open = !this.open;
+		},
+	},
+};
+</script>
+<style scoped>
+.icon {
+	transform: rotate(0deg);
+	transition: transform var(--evcc-transition-medium) ease;
+}
+.iconUp {
+	transform: rotate(-180deg);
+}
+.v-enter-active,
+.v-leave-active {
+	transition:
+		transform var(--evcc-transition-medium) ease,
+		opacity var(--evcc-transition-medium) ease;
+	transform: translateY(0);
+}
+
+.v-enter-from,
+.v-leave-to {
+	opacity: 0;
+	transform: translateY(-0.5rem);
+}
+</style>

--- a/assets/js/components/Config/PropertyCollapsible.vue
+++ b/assets/js/components/Config/PropertyCollapsible.vue
@@ -1,22 +1,24 @@
 <template>
-	<button
-		class="btn btn-link btn-sm text-gray px-0 border-0 d-flex align-items-center mb-2"
-		:class="open ? 'text-primary' : ''"
-		type="button"
-		@click="toggle"
-	>
-		<span v-if="open">Hide advanced settings</span>
-		<span v-else>Show advanced settings</span>
-		<DropdownIcon class="icon" :class="{ iconUp: open }" />
-	</button>
+	<div v-if="$slots.advanced || $slots.more">
+		<button
+			class="btn btn-link btn-sm text-gray px-0 border-0 d-flex align-items-center mb-2"
+			:class="open ? 'text-primary' : ''"
+			type="button"
+			@click="toggle"
+		>
+			<span v-if="open">Hide advanced settings</span>
+			<span v-else>Show advanced settings</span>
+			<DropdownIcon class="icon" :class="{ iconUp: open }" />
+		</button>
 
-	<Transition>
-		<div v-if="open" class="pt-2">
-			<slot name="advanced"></slot>
-			<hr v-if="$slots.advanced && $slots.more" class="my-5" />
-			<slot name="more"></slot>
-		</div>
-	</Transition>
+		<Transition>
+			<div v-if="open" class="pt-2">
+				<slot name="advanced"></slot>
+				<hr v-if="$slots.advanced && $slots.more" class="my-5" />
+				<slot name="more"></slot>
+			</div>
+		</Transition>
+	</div>
 </template>
 
 <script>

--- a/assets/js/components/Config/PropertyEntry.vue
+++ b/assets/js/components/Config/PropertyEntry.vue
@@ -1,0 +1,53 @@
+<template>
+	<FormRow
+		:id="id"
+		:optional="!Required"
+		:label="Description || `[${Name}]`"
+		:help="Description === Help ? undefined : Help"
+		:example="Example"
+	>
+		<PropertyField
+			:id="id"
+			v-model="value"
+			:masked="Mask"
+			:property="Name"
+			:type="Type"
+			class="me-2"
+			:required="Required"
+			:validValues="ValidValues"
+		/>
+	</FormRow>
+</template>
+
+<script>
+import FormRow from "./FormRow.vue";
+import PropertyField from "./PropertyField.vue";
+
+export default {
+	name: "PropertyEntry",
+	components: { FormRow, PropertyField },
+	props: {
+		id: String,
+		Name: String,
+		Required: Boolean,
+		Description: String,
+		Help: String,
+		Example: String,
+		Type: String,
+		Mask: Boolean,
+		ValidValues: Array,
+		modelValue: [String, Number, Boolean, Object],
+	},
+	emits: ["update:modelValue"],
+	computed: {
+		value: {
+			get() {
+				return this.modelValue;
+			},
+			set(value) {
+				this.$emit("update:modelValue", value);
+			},
+		},
+	},
+};
+</script>

--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="unit" class="input-group" :class="short ? 'w-50' : ''">
+	<div v-if="unitValue" class="input-group" :class="sizeClass">
 		<input
 			:id="id"
 			v-model="value"
@@ -9,8 +9,9 @@
 			:required="required"
 			:aria-describedby="id + '_unit'"
 			class="form-control"
+			:class="{ 'text-end': endAlign }"
 		/>
-		<span :id="id + '_unit'" class="input-group-text">{{ unit }}</span>
+		<span :id="id + '_unit'" class="input-group-text">{{ unitValue }}</span>
 	</div>
 	<div v-else-if="icons" class="d-flex flex-wrap">
 		<div
@@ -34,24 +35,39 @@
 				:for="`icon_${key}`"
 				:aria-label="key"
 			>
-				<VehicleIcon :name="key" />
+				<VehicleIcon v-if="key" :name="key" />
+				<shopicon-regular-minus v-else></shopicon-regular-minus>
 			</label>
 		</div>
 		<div v-if="!selectMode" class="me-2 mb-2 d-flex align-items-end">
 			<a :id="id" class="text-muted" href="#" @click.prevent="toggleSelectMode">change</a>
 		</div>
 	</div>
-	<select v-else-if="select" :id="id" v-model="value" class="form-select">
+	<SelectGroup
+		v-else-if="boolean"
+		:id="id"
+		class="w-50"
+		v-model="value"
+		:options="[
+			{ value: false, name: $t('config.options.boolean.no') },
+			{ value: true, name: $t('config.options.boolean.yes') },
+		]"
+	/>
+	<select v-else-if="select" :id="id" v-model="value" class="form-select" :class="sizeClass">
 		<option v-if="!required" value="">---</option>
-		<option v-for="{ key, name } in selectOptions" :key="key" :value="key">
-			{{ name }}
-		</option>
+		<template v-for="({ key, name }, idx) in selectOptions">
+			<option v-if="key !== null && name !== null" :key="key" :value="key">
+				{{ name }}
+			</option>
+			<hr v-else :key="idx" />
+		</template>
 	</select>
 	<textarea
 		v-else-if="textarea"
 		:id="id"
 		v-model="value"
 		class="form-control"
+		:class="sizeClass"
 		:type="inputType"
 		:placeholder="placeholder"
 		:required="required"
@@ -62,7 +78,7 @@
 		:id="id"
 		v-model="value"
 		class="form-control"
-		:class="short ? 'w-50' : ''"
+		:class="sizeClass"
 		:type="inputType"
 		:step="step"
 		:placeholder="placeholder"
@@ -71,17 +87,22 @@
 </template>
 
 <script>
+import "@h2d2/shopicons/es/regular/minus";
 import VehicleIcon from "../VehicleIcon";
+import SelectGroup from "../SelectGroup.vue";
 
 export default {
 	name: "PropertyField",
-	components: { VehicleIcon },
+	components: { VehicleIcon, SelectGroup },
 	props: {
 		id: String,
 		property: String,
 		masked: Boolean,
 		placeholder: String,
 		type: String,
+		unit: String,
+		size: String,
+		scale: Number,
 		required: Boolean,
 		validValues: { type: Array, default: () => [] },
 		modelValue: [String, Number, Boolean, Object],
@@ -95,21 +116,33 @@ export default {
 			if (this.masked) {
 				return "password";
 			}
-			if (["Number", "Float"].includes(this.type)) {
+			if (["Number", "Float", "Duration"].includes(this.type)) {
 				return "number";
 			}
 			return "text";
 		},
-		short() {
+		sizeClass() {
+			if (this.size) {
+				return this.size;
+			}
+			if (["Number", "Float", "Duration"].includes(this.type)) {
+				return "w-50 w-min-200";
+			}
+			return "";
+		},
+		endAlign() {
 			return ["Number", "Float", "Duration"].includes(this.type);
 		},
 		step() {
-			if (this.type === "Float") {
+			if (this.type === "Float" || this.type === "Duration") {
 				return "any";
 			}
 			return null;
 		},
-		unit() {
+		unitValue() {
+			if (this.unit) {
+				return this.unit;
+			}
 			if (this.property === "capacity") {
 				return "kWh";
 			}
@@ -119,29 +152,68 @@ export default {
 			return this.property === "icon";
 		},
 		textarea() {
-			return ["accessToken", "refreshToken"].includes(this.property);
+			return ["accessToken", "refreshToken", "identifiers"].includes(this.property);
+		},
+		boolean() {
+			return this.type === "Bool";
+		},
+		array() {
+			return this.type === "StringList";
 		},
 		select() {
 			return this.validValues.length > 0;
 		},
 		selectOptions() {
 			// If the valid values are already in the correct format, return them
-			if (this.validValues[0].key && this.validValues[0].name) {
+			if (typeof this.validValues[0] === "object") {
 				return this.validValues;
 			}
 
+			let values = [...this.validValues];
+
+			if (this.icons && !this.required) {
+				values = ["", ...values];
+			}
+
 			// Otherwise, convert them to the correct format
-			return this.validValues.map((value) => ({
+			return values.map((value) => ({
 				key: value,
-				name: this.$t(`config.options.${this.property}.${value}`),
+				name: this.$t(`config.options.${this.property}.${value || "none"}`),
 			}));
 		},
 		value: {
 			get() {
+				// use first option if no value is set
+				if (this.selectOptions.length > 0 && !this.modelValue) {
+					return this.required ? this.selectOptions[0].key : "";
+				}
+
+				if (this.scale) {
+					return this.modelValue * this.scale;
+				}
+
+				if (this.boolean) {
+					return this.modelValue === true;
+				}
+
+				if (this.array) {
+					return Array.isArray(this.modelValue) ? this.modelValue.join("\n") : "";
+				}
+
 				return this.modelValue;
 			},
 			set(value) {
-				this.$emit("update:modelValue", value);
+				let newValue = value;
+
+				if (this.scale) {
+					newValue = value / this.scale;
+				}
+
+				if (this.array) {
+					newValue = value ? value.split("\n") : [];
+				}
+
+				this.$emit("update:modelValue", newValue);
 			},
 		},
 	},
@@ -163,5 +235,14 @@ input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {
 	-webkit-appearance: none;
 	margin: 0;
+}
+.w-min-100 {
+	min-width: min(100px, 100%);
+}
+.w-min-150 {
+	min-width: min(150px, 100%);
+}
+.w-min-200 {
+	min-width: min(200px, 100%);
 }
 </style>

--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -83,6 +83,7 @@
 		:step="step"
 		:placeholder="placeholder"
 		:required="required"
+		:autocomplete="masked ? 'off' : null"
 	/>
 </template>
 

--- a/assets/js/components/Config/VehicleModal.vue
+++ b/assets/js/components/Config/VehicleModal.vue
@@ -79,7 +79,6 @@
 								<template v-if="advancedParams.length" #advanced>
 									<PropertyEntry
 										v-for="param in advancedParams"
-										v-show="showAdvanced || !param.Advanced"
 										:key="param.Name"
 										:id="`vehicleParam${param.Name}`"
 										v-bind="param"

--- a/assets/js/components/Config/VehicleModal.vue
+++ b/assets/js/components/Config/VehicleModal.vue
@@ -307,15 +307,15 @@ export default {
 			};
 		},
 		templateParams() {
-			const params = this.template?.Params || [];
-			const filteredParams = params.filter((p) => !CUSTOM_FIELDS.includes(p.Name));
-			return filteredParams.map((p) => {
-				if (p.Name === "title" || p.Name === "icon") {
-					p.Required = true;
-					p.Advanced = false;
-				}
-				return p;
-			});
+			return (this.template?.Params || [])
+				.filter((p) => !CUSTOM_FIELDS.includes(p.Name))
+				.map((p) => {
+					if (p.Name === "title" || p.Name === "icon") {
+						p.Required = true;
+						p.Advanced = false;
+					}
+					return p;
+				});
 		},
 		normalParams() {
 			return this.templateParams.filter((p) => !p.Advanced);

--- a/assets/js/components/Config/VehicleModal.vue
+++ b/assets/js/components/Config/VehicleModal.vue
@@ -66,72 +66,27 @@
 									</optgroup>
 								</select>
 							</FormRow>
-							<FormRow
+
+							<PropertyEntry
 								v-for="param in normalParams"
 								:key="param.Name"
 								:id="`vehicleParam${param.Name}`"
-								:optional="!param.Required"
-								:label="param.Description || `[${param.Name}]`"
-								:help="param.Description === param.Help ? undefined : param.Help"
-								:example="param.Example"
-							>
-								<PropertyField
-									:id="`vehicleParam${param.Name}`"
-									v-model="values[param.Name]"
-									:masked="param.Mask"
-									:property="param.Name"
-									:type="param.Type"
-									class="me-2"
-									:required="param.Required"
-									:validValues="param.ValidValues"
-								/>
-							</FormRow>
-							<button
-								class="btn btn-link btn-sm text-gray px-0 border-0 d-flex align-items-center mb-2"
-								:class="showAdvanced ? 'text-primary' : ''"
-								type="button"
-								@click="toggleAdvanced"
-							>
-								<span v-if="showAdvanced">Hide advanced settings</span>
-								<span v-else>Show advanced settings</span>
-								<DropdownIcon
-									class="advancedIcon"
-									:class="{ advancedIconUp: showAdvanced }"
-								/>
-							</button>
+								v-bind="param"
+								v-model="values[param.Name]"
+							/>
 
-							<Transition>
-								<div v-if="showAdvanced" class="pt-2">
-									<!-- template specific fields -->
-									<FormRow
+							<PropertyCollapsible>
+								<template v-if="advancedParams.length" #advanced>
+									<PropertyEntry
 										v-for="param in advancedParams"
-										:key="param.Name"
 										v-show="showAdvanced || !param.Advanced"
+										:key="param.Name"
 										:id="`vehicleParam${param.Name}`"
-										:optional="!param.Required"
-										:label="param.Description || `[${param.Name}]`"
-										:help="
-											param.Description === param.Help
-												? undefined
-												: param.Help
-										"
-										:example="param.Example"
-									>
-										<PropertyField
-											:id="`vehicleParam${param.Name}`"
-											v-model="values[param.Name]"
-											:masked="param.Mask"
-											:property="param.Name"
-											:type="param.Type"
-											class="me-2"
-											:required="param.Required"
-											:validValues="param.ValidValues"
-										/>
-									</FormRow>
-
-									<hr v-if="advancedParams.length" class="my-5" />
-
-									<!-- standard vehicle fields -->
+										v-bind="param"
+										v-model="values[param.Name]"
+									/>
+								</template>
+								<template #more>
 									<h6 class="mt-3">Charging settings</h6>
 									<FormRow
 										id="vehicleParamMode"
@@ -242,8 +197,8 @@
 											class="me-2"
 										/>
 									</FormRow>
-								</div>
-							</Transition>
+								</template>
+							</PropertyCollapsible>
 
 							<TestResult
 								v-if="templateName"
@@ -301,13 +256,12 @@
 </template>
 
 <script>
-import "@h2d2/shopicons/es/regular/arrowdropup";
-import "@h2d2/shopicons/es/regular/arrowdropdown";
 import FormRow from "./FormRow.vue";
 import PropertyField from "./PropertyField.vue";
 import TestResult from "./TestResult.vue";
-import DropdownIcon from "../MaterialIcon/Dropdown.vue";
 import SelectGroup from "../SelectGroup.vue";
+import PropertyEntry from "./PropertyEntry.vue";
+import PropertyCollapsible from "./PropertyCollapsible.vue";
 import api from "../../api";
 import test from "./mixins/test";
 
@@ -321,7 +275,14 @@ const CUSTOM_FIELDS = ["minCurrent", "maxCurrent", "priority", "identifiers", "p
 
 export default {
 	name: "VehicleModal",
-	components: { FormRow, PropertyField, TestResult, SelectGroup, DropdownIcon },
+	components: {
+		FormRow,
+		PropertyField,
+		TestResult,
+		SelectGroup,
+		PropertyCollapsible,
+		PropertyEntry,
+	},
 	mixins: [test],
 	props: {
 		id: Number,
@@ -335,7 +296,6 @@ export default {
 			saving: false,
 			templateName: null,
 			template: null,
-			showAdvanced: false,
 			values: { ...initialValues },
 		};
 	},
@@ -418,9 +378,6 @@ export default {
 		reset() {
 			this.values = { ...initialValues };
 			this.resetTest();
-		},
-		toggleAdvanced() {
-			this.showAdvanced = !this.showAdvanced;
 		},
 		async loadConfiguration() {
 			try {
@@ -533,25 +490,5 @@ export default {
 	margin-left: calc(var(--bs-gutter-x) * -0.5);
 	margin-right: calc(var(--bs-gutter-x) * -0.5);
 	padding-right: 0;
-}
-.advancedIcon {
-	transform: rotate(0deg);
-	transition: transform var(--evcc-transition-medium) ease;
-}
-.advancedIconUp {
-	transform: rotate(-180deg);
-}
-.v-enter-active,
-.v-leave-active {
-	transition:
-		transform var(--evcc-transition-medium) ease,
-		opacity var(--evcc-transition-medium) ease;
-	transform: translateY(0);
-}
-
-.v-enter-from,
-.v-leave-to {
-	opacity: 0;
-	transform: translateY(-0.5rem);
 }
 </style>

--- a/assets/js/components/MaterialIcon/Dropdown.vue
+++ b/assets/js/components/MaterialIcon/Dropdown.vue
@@ -1,0 +1,17 @@
+<template>
+	<svg :style="svgStyle" viewBox="0 0 24 24">
+		<path
+			fill="currentColor"
+			d="M11.475 14.475L7.85 10.85q-.075-.075-.112-.162T7.7 10.5q0-.2.138-.35T8.2 10h7.6q.225 0 .363.15t.137.35q0 .05-.15.35l-3.625 3.625q-.125.125-.25.175T12 14.7t-.275-.05t-.25-.175"
+		/>
+	</svg>
+</template>
+
+<script>
+import icon from "../../mixins/icon";
+
+export default {
+	name: "Dropdown",
+	mixins: [icon],
+};
+</script>

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -170,6 +170,10 @@ title = "Network"
 
 [config.options]
 
+[config.options.boolean]
+no = "no"
+yes = "yes"
+
 [config.options.endianness]
 big = "big-endian"
 little = "little-endian"

--- a/tests/config-battery.spec.js
+++ b/tests/config-battery.spec.js
@@ -84,4 +84,21 @@ test.describe("battery meter", async () => {
 
     await expect(page.getByTestId("battery")).toHaveCount(0);
   });
+
+  test("advanced fields", async ({ page }) => {
+    await page.goto("/#/config");
+    await login(page);
+    await enableExperimental(page);
+
+    await page.getByRole("button", { name: "Add solar or battery" }).click();
+
+    const meterModal = page.getByTestId("meter-modal");
+    await meterModal.getByRole("button", { name: "Add battery meter" }).click();
+    await meterModal.getByLabel("Manufacturer").selectOption("OpenEMS");
+    await expect(meterModal.getByLabel("Password optional")).not.toBeVisible();
+    await page.getByRole("button", { name: "Show advanced settings" }).click();
+    await expect(meterModal.getByLabel("Password optional")).toBeVisible();
+    await page.getByRole("button", { name: "Hide advanced settings" }).click();
+    await expect(meterModal.getByLabel("Password optional")).not.toBeVisible();
+  });
 });

--- a/tests/config-vehicles.spec.js
+++ b/tests/config-vehicles.spec.js
@@ -136,7 +136,6 @@ test.describe("vehicles", async () => {
     await login(page);
     await enableExperimental(page);
 
-    await expect(page.getByTestId("vehicle")).toHaveCount(0);
     await page.getByTestId("add-vehicle").click();
     const vehicleModal = page.getByTestId("vehicle-modal");
 

--- a/tests/config-vehicles.spec.js
+++ b/tests/config-vehicles.spec.js
@@ -130,4 +130,42 @@ test.describe("vehicles", async () => {
     await expect(page.getByTestId("vehicle").nth(0)).toHaveText(/YAML Bike/);
     await expect(page.getByTestId("vehicle").nth(1)).toHaveText(/Green Car/);
   });
+
+  test("advanced fields", async ({ page }) => {
+    await page.goto("/#/config");
+    await login(page);
+    await enableExperimental(page);
+
+    await expect(page.getByTestId("vehicle")).toHaveCount(0);
+    await page.getByTestId("add-vehicle").click();
+    const vehicleModal = page.getByTestId("vehicle-modal");
+
+    // generic
+    await vehicleModal.getByLabel("Manufacturer").selectOption("Generic vehicle");
+    await expect(vehicleModal.getByLabel("Title")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Car")).toBeVisible(); // icon
+    await expect(vehicleModal.getByLabel("Battery capacity")).toBeVisible();
+
+    await page.getByRole("button", { name: "Show advanced settings" }).click();
+    await expect(vehicleModal.getByLabel("Default mode")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Maximum phases")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Minimum current")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Maximum current")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Priority")).toBeVisible();
+    await expect(vehicleModal.getByLabel("RFID identifiers")).toBeVisible();
+
+    await page.getByRole("button", { name: "Hide advanced settings" }).click();
+    await expect(vehicleModal.getByLabel("Default mode")).not.toBeVisible();
+
+    // polestar template
+    await vehicleModal.getByLabel("Manufacturer").selectOption("Polestar");
+    await expect(vehicleModal.getByLabel("Username")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Password")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Cache optional")).not.toBeVisible();
+    await expect(vehicleModal.getByLabel("Default mode")).not.toBeVisible();
+
+    await page.getByRole("button", { name: "Show advanced settings" }).click();
+    await expect(vehicleModal.getByLabel("Cache optional")).toBeVisible();
+    await expect(vehicleModal.getByLabel("Default mode")).toBeVisible();
+  });
 });


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/15000
fixes https://github.com/evcc-io/evcc/issues/12905

Added a "show more" link to the vehicles config ui screen.

- 🔭 show advanced template fields (vehicle & meter dialog)
- 🔌 show general charging/lp related fields (mode, current, phase, rfid, ...)
- ⇣ form order: normal fields, advanced fields, general charging/lp fields

**Todos**

- [x] add tests @naltatis 

---

Generic vehicle, charging/lp settings

[vehicle settings.webm](https://github.com/user-attachments/assets/df60c32c-a2ad-4642-8ac7-c0498c0ae0c3)

---

Vehicle template with additional advanced fields (Mini)

[advanced.webm](https://github.com/user-attachments/assets/bf75cfb9-831f-407a-bda6-952c3be567e7)
