### PR TITLE
Fix nightly build - Smart-cost test

### DIFF
--- a/tests/smart-cost-only.evcc.yaml
+++ b/tests/smart-cost-only.evcc.yaml
@@ -40,5 +40,5 @@ tariffs:
     type: fixed
     price: 0.4 # EUR/kWh
     zones:
-      - hours: 0-1
+      - hours: 1-6
         price: 0.2

--- a/tests/smart-cost.spec.js
+++ b/tests/smart-cost.spec.js
@@ -38,7 +38,7 @@ test.describe("smart cost limit", async () => {
     await page.getByTestId("loadpoint-settings-modal").getByLabel("Close").click();
     await expect(page.getByTestId("loadpoint-settings-modal")).not.toBeVisible();
     await expect(page.getByTestId("vehicle-status-charger")).toHaveText("Charging…");
-    await expect(page.getByTestId("vehicle-status-smartcost")).toHaveText(/(20\.0 ct ≤ 40\.0 ct|40\.0 ct ≤ 40\.0 ct)/);
+    await expect(page.getByTestId("vehicle-status-smartcost")).toHaveText(/[24]0\.0 ct ≤ 40\.0 ct/);
   });
   test("price above limit", async ({ page }) => {
     await page.goto("/");

--- a/tests/smart-cost.spec.js
+++ b/tests/smart-cost.spec.js
@@ -38,7 +38,7 @@ test.describe("smart cost limit", async () => {
     await page.getByTestId("loadpoint-settings-modal").getByLabel("Close").click();
     await expect(page.getByTestId("loadpoint-settings-modal")).not.toBeVisible();
     await expect(page.getByTestId("vehicle-status-charger")).toHaveText("Charging…");
-    await expect(page.getByTestId("vehicle-status-smartcost")).toHaveText("40.0 ct ≤ 40.0 ct");
+    await expect(page.getByTestId("vehicle-status-smartcost")).toHaveText(/(20\.0 ct ≤ 40\.0 ct|40\.0 ct ≤ 40\.0 ct)/);
   });
   test("price above limit", async ({ page }) => {
     await page.goto("/");


### PR DESCRIPTION
As proposed in #15031, I have changed the test to check for  `40.0 ct ≤ 40.0 ct` OR  `20.0 ct ≤ 40.0 ct`