### PR TITLE
Energy meters solely for logging

### DIFF
--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -29,13 +29,13 @@ const (
 	TariffPriceLoadpoints = "tariffPriceLoadpoints"
 	Vehicles              = "vehicles"
 	Circuits              = "circuits"
-	Log                   = "logging"
+	Ext                   = "ext"
 
 	// meters
 	GridMeter     = "gridMeter"
 	PvMeters      = "pvMeters"
 	BatteryMeters = "batteryMeters"
-	LogMeters     = "logMeters"
+	ExtMeters     = "extMeters"
 	AuxMeters     = "auxMeters"
 
 	// battery settings

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -29,7 +29,7 @@ const (
 	TariffPriceLoadpoints = "tariffPriceLoadpoints"
 	Vehicles              = "vehicles"
 	Circuits              = "circuits"
-	Log                   = "Log"
+	Log                   = "logging"
 
 	// meters
 	GridMeter     = "gridMeter"

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -29,11 +29,13 @@ const (
 	TariffPriceLoadpoints = "tariffPriceLoadpoints"
 	Vehicles              = "vehicles"
 	Circuits              = "circuits"
+	Log                   = "Log"
 
 	// meters
 	GridMeter     = "gridMeter"
 	PvMeters      = "pvMeters"
 	BatteryMeters = "batteryMeters"
+	LogMeters     = "logMeters"
 	AuxMeters     = "auxMeters"
 
 	// battery settings

--- a/core/site.go
+++ b/core/site.go
@@ -78,7 +78,7 @@ type Site struct {
 	gridMeter     api.Meter   // Grid usage meter
 	pvMeters      []api.Meter // PV generation meters
 	batteryMeters []api.Meter // Battery charging meters
-	extMeters     []api.Meter // Meters used only for monitoring
+	extMeters     []api.Meter // External meters - for monitoring only
 	auxMeters     []api.Meter // Auxiliary meters
 
 	// battery settings
@@ -210,7 +210,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site), see https://docs.evcc.io/en/docs/reference/configuration/site#residualpower")
 	}
 
-	//Meters used only for monitoring
+	// Meters used only for monitoring
 	for _, ref := range site.Meters.ExtMetersRef {
 		dev, err := config.Meters().ByName(ref)
 		if err != nil {

--- a/core/site.go
+++ b/core/site.go
@@ -108,7 +108,7 @@ type MetersConfig struct {
 	GridMeterRef     string   `mapstructure:"grid"`    // Grid usage meter
 	PVMetersRef      []string `mapstructure:"pv"`      // PV meter
 	BatteryMetersRef []string `mapstructure:"battery"` // Battery charging meter
-	ExtMetersRef     []string `mapstructure:"ext"`     // Meters used only for logging
+	ExtMetersRef     []string `mapstructure:"ext"`     // Meters used only for monitoring
 	AuxMetersRef     []string `mapstructure:"aux"`     // Auxiliary meters
 }
 
@@ -210,7 +210,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 		site.log.WARN.Println("battery configured but residualPower is missing or <= 0 (add residualPower: 100 to site), see https://docs.evcc.io/en/docs/reference/configuration/site#residualpower")
 	}
 
-	//Meters used only for logging
+	//Meters used only for monitoring
 	for _, ref := range site.Meters.ExtMetersRef {
 		dev, err := config.Meters().ByName(ref)
 		if err != nil {
@@ -483,7 +483,7 @@ func (site *Site) updatePvMeters() {
 	site.publish(keys.Pv, mm)
 }
 
-// updateExtMeters updates log meters. All measurements are optional.
+// updateExtMeters updates ext meters. All measurements are optional.
 func (site *Site) updateExtMeters() {
 	if len(site.extMeters) == 0 {
 		return
@@ -492,18 +492,18 @@ func (site *Site) updateExtMeters() {
 	mm := make([]meterMeasurement, len(site.extMeters))
 
 	for i, meter := range site.extMeters {
-		// log power
+		// ext power
 		power, err := backoff.RetryWithData(meter.CurrentPower, bo())
 		if err != nil {
-			site.log.ERROR.Printf("log meter %d power: %v", i+1, err)
+			site.log.ERROR.Printf("ext meter %d power: %v", i+1, err)
 		}
 
-		// log energy
+		// ext energy
 		var energy float64
 		if m, ok := meter.(api.MeterEnergy); err == nil && ok {
 			energy, err = m.TotalEnergy()
 			if err != nil {
-				site.log.ERROR.Printf("log meter %d energy: %v", i+1, err)
+				site.log.ERROR.Printf("ext meter %d energy: %v", i+1, err)
 			}
 		}
 

--- a/core/site.go
+++ b/core/site.go
@@ -494,18 +494,16 @@ func (site *Site) updateLogMeters() {
 	for i, meter := range site.logMeters {
 		// log power
 		power, err := backoff.RetryWithData(meter.CurrentPower, bo())
-		if err == nil {
-		} else {
-			site.log.ERROR.Printf("logMeter %d power: %v", i+1, err)
+		if err != nil {
+			site.log.ERROR.Printf("log meter %d power: %v", i+1, err)
 		}
 
 		// log energy
 		var energy float64
 		if m, ok := meter.(api.MeterEnergy); err == nil && ok {
 			energy, err = m.TotalEnergy()
-			if err == nil {
-			} else {
-				site.log.ERROR.Printf("logMeter %d energy: %v", i+1, err)
+			if err != nil {
+				site.log.ERROR.Printf("log meter %d energy: %v", i+1, err)
 			}
 		}
 


### PR DESCRIPTION
Added the support for Energymeters that are solely used for logging purposes. Not supported to be shown in the UI for now, but gets published to e.g. MQTT