### PR TITLE
Versicharge: fix TotalEnergy() being low by factor 10 on firmware 2.135

### DIFF
--- a/charger/versicharge.go
+++ b/charger/versicharge.go
@@ -164,7 +164,7 @@ func (wb *Versicharge) TotalEnergy() (float64, error) {
 		return 0, err
 	}
 
-	return float64(binary.BigEndian.Uint32(b)) / 1e4, err
+	return float64(binary.BigEndian.Uint32(b)) / 1e3, err
 }
 
 // getPhaseValues returns 3 sequential register values


### PR DESCRIPTION
fixes #15048

No differentiating between firmware versions, as they update automatically according to [this comment](https://github.com/evcc-io/evcc/pull/9268#issuecomment-1666780948)