### PR TITLE
Improve EEBUS support for Elli Gen 1 (part 6)

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -398,9 +398,9 @@ func (c *EEBus) writeCurrentLimitData(currents []float64) error {
 	if recommendations, err := c.uc.OscEV.LoadControlLimits(evEntity); err == nil {
 		var writeNeeded bool
 
-		for _, item := range recommendations {
+		for index, item := range recommendations {
 			if item.IsActive {
-				item.IsActive = false
+				recommendations[index].IsActive = false
 				writeNeeded = true
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -197,4 +197,4 @@ require (
 
 replace gopkg.in/yaml.v3 => github.com/andig/yaml v0.0.0-20240531135838-1ff5761ab467
 
-replace github.com/enbility/spine-go => github.com/enbility/spine-go v0.0.0-20240718190814-6580e13d0b35
+replace github.com/enbility/spine-go => github.com/enbility/spine-go v0.0.0-20240726200332-a983de1e34b8

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/enbility/eebus-go v0.6.1 h1:2xKf3+tuScfV0ZWK/spPzoc2ekix6oZdZ0mjmcS9r
 github.com/enbility/eebus-go v0.6.1/go.mod h1:XulY17uTjq65MWG4LQh28C/D6ogXBUa1e8nNNKssPg4=
 github.com/enbility/ship-go v0.5.2 h1:T9+YuP5ZpofKd463PLKq78fAaPAcGMnRAcv8c8aD5yU=
 github.com/enbility/ship-go v0.5.2/go.mod h1:jewJWYQ10jNhsnhS1C4jESx3CNmDa5HNWZjBhkTug5Y=
-github.com/enbility/spine-go v0.0.0-20240718190814-6580e13d0b35 h1:QuzPIvtPzA7DHpwBVwsYOjuiKJtAtUzA2uPkhtTpyUI=
-github.com/enbility/spine-go v0.0.0-20240718190814-6580e13d0b35/go.mod h1:pRGS+C5rZ5rhxTAA1whU8fC9p7lH5ixyut++yEZe470=
+github.com/enbility/spine-go v0.0.0-20240726200332-a983de1e34b8 h1:hDJgZKbRE2b3wQmjr/5LG1C4YaU5Xy3hrZVxWKOeHIE=
+github.com/enbility/spine-go v0.0.0-20240726200332-a983de1e34b8/go.mod h1:pRGS+C5rZ5rhxTAA1whU8fC9p7lH5ixyut++yEZe470=
 github.com/enbility/zeroconf/v2 v2.0.0-20240210101930-d0004078577b h1:sg3c6LJ4eWffwtt9SW0lgcIX4Oh274vwdJnNFNNrDco=
 github.com/enbility/zeroconf/v2 v2.0.0-20240210101930-d0004078577b/go.mod h1:BjzRRiYX6mWdOgku1xxDE+NsV8PijTby7Q7BkYVdfDU=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -20,6 +20,7 @@ import (
 	"github.com/enbility/eebus-go/usecases/cem/opev"
 	"github.com/enbility/eebus-go/usecases/cem/oscev"
 	shipapi "github.com/enbility/ship-go/api"
+	"github.com/enbility/ship-go/mdns"
 	shiputil "github.com/enbility/ship-go/util"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -103,6 +104,9 @@ func NewServer(other Config) (*EEBus, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// use avahi if available, otherwise use go based zeroconf
+	configuration.SetMdnsProviderSelection(mdns.MdnsProviderSelectionAll)
 
 	// for backward compatibility
 	configuration.SetAlternateMdnsServiceName(DeviceCode)


### PR DESCRIPTION
- Check if sending the heartbeat even more often helps
- Use avahi as mDNS provider if available. this might help finding the Elli device after disconnections quicker and maybe even ones own mDNS entry better
- Fix a small bug with resetting recommendation limits to inactive when using VAS EVs