### PR TITLE
EM2GO Home: Workaround for V1.1 current and phase setting

### DIFF
--- a/charger/em2go.go
+++ b/charger/em2go.go
@@ -36,7 +36,6 @@ type Em2Go struct {
 	log     *util.Logger
 	conn    *modbus.Connection
 	current int64
-	phases  int
 	lp      loadpoint.API
 }
 
@@ -317,7 +316,6 @@ func (wb *Em2Go) phases1p3p(phases int) error {
 		if _, err := wb.conn.WriteMultipleRegisters(em2GoRegPhases, 1, b); err != nil {
 			return err
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
We would like to you to consider the following PR as a workaround for the EM2GO Home charger to address the following issues:

- Ignores 0A current when starting -> Set minimum of 6A when starting.
- Always starts charging with 3 phases even if evcc is set to auto or 1 phase -> Read phase setting from lp send start charging and phase setting in a row to avoid 3 phases when 1 phase is requested.
- Switch phases during charging -> stop charging, pause for 10 seconds, and start charging with changed phases.
This PR tries to fix issues mentioned in #12382, #14307, #14488 and #14643.