### PR TITLE
Database: change persist interval to 1min instead of 30m

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -562,7 +562,7 @@ func configureDatabase(conf globalconfig.DB) error {
 
 	// persist unsaved settings every 30 minutes
 	go func() {
-		for range time.Tick(1 * time.Minute) {
+		for range time.Tick(time.Minute) {
 			persistSettings()
 		}
 	}()

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -562,7 +562,7 @@ func configureDatabase(conf globalconfig.DB) error {
 
 	// persist unsaved settings every 30 minutes
 	go func() {
-		for range time.Tick(30 * time.Minute) {
+		for range time.Tick(1 * time.Minute) {
 			persistSettings()
 		}
 	}()


### PR DESCRIPTION
Changed database persist to occur every minute instead of every 30m. I left the `1 * time.Minute` multiplier in for readability.

fixes #15135