### PR TITLE
Plan: only keep expired plans when vehicle stays connected

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -100,7 +100,9 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	if planTime.IsZero() {
 		return false
 	}
-	if lp.clock.Until(planTime) < 0 && !lp.planActive {
+	// keep overrunning plans as long as a vehicle is connected
+	if lp.clock.Until(planTime) < 0 && (!lp.planActive || !lp.connected()) {
+		lp.log.DEBUG.Println("plan: deleting expired plan")
 		lp.deletePlan()
 		return false
 	}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/15027

Before, an unfulfilled plan remained active even if the vehicle was disconnected.
Now the plan gets deleted if the plan time passes and no vehicle is present.