### PR TITLE
Update EEBUS SHIP library to improve reconnects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,4 +199,6 @@ replace gopkg.in/yaml.v3 => github.com/andig/yaml v0.0.0-20240531135838-1ff5761a
 
 replace github.com/enbility/spine-go => github.com/enbility/spine-go v0.0.0-20240726200332-a983de1e34b8
 
+replace github.com/enbility/ship-go => github.com/enbility/ship-go v0.0.0-20240731093131-37b1302bca66
+
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20240730071053-d69e53b0fce9

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/enbility/eebus-go v0.6.1 h1:2xKf3+tuScfV0ZWK/spPzoc2ekix6oZdZ0mjmcS9rdQ=
 github.com/enbility/eebus-go v0.6.1/go.mod h1:XulY17uTjq65MWG4LQh28C/D6ogXBUa1e8nNNKssPg4=
-github.com/enbility/ship-go v0.5.2 h1:T9+YuP5ZpofKd463PLKq78fAaPAcGMnRAcv8c8aD5yU=
-github.com/enbility/ship-go v0.5.2/go.mod h1:jewJWYQ10jNhsnhS1C4jESx3CNmDa5HNWZjBhkTug5Y=
+github.com/enbility/ship-go v0.0.0-20240731093131-37b1302bca66 h1:xyyTo5DD8RMegL1ztiCZ93TVG1hogrKMVh1bvbayY6g=
+github.com/enbility/ship-go v0.0.0-20240731093131-37b1302bca66/go.mod h1:jewJWYQ10jNhsnhS1C4jESx3CNmDa5HNWZjBhkTug5Y=
 github.com/enbility/spine-go v0.0.0-20240726200332-a983de1e34b8 h1:hDJgZKbRE2b3wQmjr/5LG1C4YaU5Xy3hrZVxWKOeHIE=
 github.com/enbility/spine-go v0.0.0-20240726200332-a983de1e34b8/go.mod h1:pRGS+C5rZ5rhxTAA1whU8fC9p7lH5ixyut++yEZe470=
 github.com/enbility/zeroconf/v2 v2.0.0-20240210101930-d0004078577b h1:sg3c6LJ4eWffwtt9SW0lgcIX4Oh274vwdJnNFNNrDco=


### PR DESCRIPTION
If a websocket connection was closed, e.g. due to i/o timeout error or remotely denied connection attempt, then a reconnect was only initiated if the remote service announced its mDNS entry again and the code relied on the remote service to initiate the connection. Especially the Elli Connect/Pro devices do not do that, and this situation can appear if the device is connected via WLAN.

This update now uses to currently known mDNS entries upon a disconnect to initiate a connection itself.