### PR TITLE
Read cfos meter: Wrong port and id

### DIFF
--- a/templates/definition/meter/cfos.yaml
+++ b/templates/definition/meter/cfos.yaml
@@ -10,8 +10,8 @@ params:
     choice: ["charge"]
   - name: modbus
     choice: ["tcpip"]
-    port: 4702
-    id: 2
+    port: 4701
+    id: 1
 render: |
   type: cfos
   {{- include "modbus" . }}


### PR DESCRIPTION
According to the [documentation](https://www.cfos-emobility.de/de/cfos-power-brain/modbus-registers.htm), the port has to be `4701` and ID `1`. 

See "angehefteter Zähler". 

https://github.com/evcc-io/evcc/discussions/14270#discussioncomment-10202476