### PR TITLE
Update versicharge.yaml wegen FW Update

### DIFF
--- a/templates/definition/charger/versicharge.yaml
+++ b/templates/definition/charger/versicharge.yaml
@@ -6,8 +6,8 @@ products:
 requirements:
   evcc: ["sponsorship"]
   description:
-    de: Erfordert Firmware >= 2.135, RFID und mA Steuerung nicht implementiert
-    en: Requires firmware >= 2.135, RFID and mA Control not implemented
+    de: Erfordert Firmware >= 2.135
+    en: Requires firmware >= 2.135
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/versicharge.yaml
+++ b/templates/definition/charger/versicharge.yaml
@@ -6,8 +6,8 @@ products:
 requirements:
   evcc: ["sponsorship"]
   description:
-    de: Erfordert Firmware >= 2.121.5
-    en: Requires firmware >= 2.121.5
+    de: Erfordert Firmware >= 2.135, RFID und mA Steuerung nicht implementiert
+    en: Requires firmware >= 2.135, RFID and mA Control not implemented
 params:
   - name: modbus
     choice: ["tcpip"]


### PR DESCRIPTION
Richtige Engergiewerte ab 2.135.
siehe auch Pull request 
https://github.com/evcc-io/evcc/commit/1515a67fc0e7446a076e9c0690bdb98c76d122e3