### PR TITLE
Docs: sort advanced params to the end

### DIFF
--- a/util/templates/documentation.go
+++ b/util/templates/documentation.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"bytes"
 	_ "embed"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -76,6 +77,17 @@ func (t *Template) RenderDocumentation(product Product, lang string) ([]byte, er
 
 		filteredParams = append(filteredParams, param)
 	}
+
+	// all advanced params should be sorted to the end
+	slices.SortStableFunc(filteredParams, func(i, j Param) int {
+		if i.IsAdvanced() && !j.IsAdvanced() {
+			return 1
+		}
+		if !i.IsAdvanced() && j.IsAdvanced() {
+			return -1
+		}
+		return 0
+	})
 
 	data := map[string]interface{}{
 		"Template":               t.Template,


### PR DESCRIPTION
see https://github.com/evcc-io/docs/pull/592 

Advanced params should be sorted to the end to make show/hide nicer in docs.

Currently:

https://github.com/user-attachments/assets/cef20884-85c4-456f-8281-178057b3a85e

