### PR TITLE
Fronius Wattpilot: deprecate

### DIFF
--- a/templates/definition/charger/fronius-wattpilot.yaml
+++ b/templates/definition/charger/fronius-wattpilot.yaml
@@ -1,4 +1,5 @@
 template: fronius-wattpilot
+deprecated: true
 products:
   - brand: Fronius
     description:

--- a/templates/definition/charger/ocpp-fronius-wattpilot.yaml
+++ b/templates/definition/charger/ocpp-fronius-wattpilot.yaml
@@ -1,0 +1,9 @@
+template: ocpp-fronius-wattpilot
+products:
+  - brand: Fronius
+    description:
+      generic: Wattpilot (OCPP)
+params:
+  - preset: ocpp
+render: |
+  {{ include "ocpp" . }}


### PR DESCRIPTION
Die reverse-engineerte API macht immer wieder Probleme; die Implementierungist nicht fehlerfrei: https://github.com/search?q=repo%3Aevcc-io%2Fevcc+wattpilot&type=issues

Da Fronius auch OCPP unterstützt wird diese hiermit deprecated: https://www.fronius.com/de/solarenergie/installateure-partner/technische-daten/alle-produkte/anlagen-monitoring/offene-schnittstellen/wattpilot-ocpp-1-6-j

TODO

- [x] add OCPP template

/cc @mabunixda @premultiply 