### PR TITLE
Loadpoint: set internal current to 0 when disabling charger

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -862,6 +862,11 @@ func (lp *Loadpoint) setLimit(chargeCurrent float64) error {
 		lp.setAndPublishEnabled(enabled)
 		lp.chargerSwitched = lp.clock.Now()
 
+		// ensure we always re-set current when enabling charger
+		if !enabled {
+			lp.chargeCurrent = 0
+		}
+
 		lp.bus.Publish(evChargeCurrent, chargeCurrent)
 
 		// start/stop vehicle wake-up timer

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -448,7 +448,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	lp.Update(-5000, false, time.Time{}, false, false, 0, nil, nil)
 	ctrl.Finish()
 
-	t.Log("soc has fallen below target - soc update prevented by timer")
+	t.Log("soc has risen below target - soc update prevented by timer")
 	clock.Add(5 * time.Minute)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
@@ -460,6 +460,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	vehicle.EXPECT().Soc().Return(85.0, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
+	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
 	charger.EXPECT().Enable(true).Return(nil)
 	lp.Update(-5000, false, time.Time{}, false, false, 0, nil, nil)
 	ctrl.Finish()


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/15217

@premultiply das sollte auch mit den Boxen helfen, die sich ihren eingestellten Strom nicht merken können? Wir können das entweder so lösen oder dem Lastmanagement einen special case geben, beim Einschalten den ist-Strom korrekterweise als 0 zu betrachten. Ich bin unsicher, was besser wäre.