### PR TITLE
chore: remove empty device type from devices api

### DIFF
--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -71,7 +71,9 @@ func deviceConfigMap[T any](class templates.Class, dev config.Device[T]) (map[st
 
 	dc := map[string]any{
 		"name": conf.Name,
-		"type": conf.Type,
+	}
+	if conf.Type != "" {
+		dc["type"] = conf.Type
 	}
 
 	if configurable, ok := dev.(config.ConfigurableDevice[T]); ok {


### PR DESCRIPTION
This prevents empty fields with circuits and loadpoints like in https://github.com/evcc-io/evcc/issues/15227#issuecomment-2267122145