### PR TITLE
Update EEBUS library to support Bender 1phase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ replace gopkg.in/yaml.v3 => github.com/andig/yaml v0.0.0-20240531135838-1ff5761a
 
 replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20240503125516-9fd99fe0e438
 
-replace github.com/enbility/eebus-go => github.com/enbility/eebus-go v0.0.0-20240805145658-631be103100a
+replace github.com/enbility/eebus-go => github.com/enbility/eebus-go v0.0.0-20240807063658-b851a17d9f25
 
 replace github.com/enbility/spine-go => github.com/enbility/spine-go v0.0.0-20240806132249-c994673d74e4
 

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/enbility/eebus-go v0.0.0-20240805145658-631be103100a h1:vwtPboVNSEMVsZ0O0qspNIki/AxTJFbJF/H1V5U69r0=
-github.com/enbility/eebus-go v0.0.0-20240805145658-631be103100a/go.mod h1:XulY17uTjq65MWG4LQh28C/D6ogXBUa1e8nNNKssPg4=
+github.com/enbility/eebus-go v0.0.0-20240807063658-b851a17d9f25 h1:FVgRp1riElkVOQNazirRcWp+st/lefSoxY1NuLc/CKE=
+github.com/enbility/eebus-go v0.0.0-20240807063658-b851a17d9f25/go.mod h1:XulY17uTjq65MWG4LQh28C/D6ogXBUa1e8nNNKssPg4=
 github.com/enbility/ship-go v0.0.0-20240806195332-a545a1063e94 h1:DKPRgPnl3PywWpJ5KfXIrpe92WF3qeZJ0ntnyirmPH4=
 github.com/enbility/ship-go v0.0.0-20240806195332-a545a1063e94/go.mod h1:jewJWYQ10jNhsnhS1C4jESx3CNmDa5HNWZjBhkTug5Y=
 github.com/enbility/spine-go v0.0.0-20240806132249-c994673d74e4 h1:cHXwGD/jkB740sPDKEU6DxRPeZt29MV50EmZY3Ovp6c=


### PR DESCRIPTION
The Bender controller doesn’t seem to follow the specs fully, so a workaround has been added to make it work.