### PR TITLE
Dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "evcc-devenv",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "make install-ui && make install && make",
+	"postCreateCommand": "make install",
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "evcc-devenv",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+			"ghcr.io/devcontainers-contrib/features/npm-package:1": {},
+			"ghcr.io/devcontainers/features/node:1":{}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"esbenp.prettier-vscode",
+				"octref.vetur",
+				"yy0931.vscode-sqlite3-editor"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [9000],
+
+	// Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// More info: https://containers.dev/implementors/json_reference/#port-attributes
+	"portsAttributes": {
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "make install-ui && make install && make",
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "root"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# configure automatic crlf conversion to ensure Windows <-> DevEnv compatibility
+* text eol=lf
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.woff binary
+*.woff2 binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@
 
 Developing evcc requires [Go][1] 1.22 and [Node][2] 18. We recommend VSCode with the [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go), [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extensions.
 
+Alternatively the extension [dev-containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) together with [Docker](https://www.docker.com/) can be used. To open your dev-container Press CTRL + P and type "Open folder in container" and choose the folder of the repository. The recommended extensions are already installed and the container is ready to debug.
+
 We use linters (golangci-lint, Prettier) to keep a coherent source code formatting. It's recommended to use the format-on-save feature of your editor. You can manually reformat your code by running:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 Developing evcc requires [Go][1] 1.22 and [Node][2] 18. We recommend VSCode with the [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go), [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extensions.
 
-Alternatively the extension [dev-containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) together with [Docker](https://www.docker.com/) can be used. To open your dev-container Press CTRL + P and type "Open folder in container" and choose the folder of the repository. The recommended extensions are already installed and the container is ready to debug.
+Alternatively the extension [dev-containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) together with [Docker](https://www.docker.com/) can be used. To open your dev-container Press CTRL + Shift + P and type "Open folder in container" and choose the folder of the repository. The recommended extensions are already installed and the container is ready to debug.
 
 We use linters (golangci-lint, Prettier) to keep a coherent source code formatting. It's recommended to use the format-on-save feature of your editor. You can manually reformat your code by running:
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ docs::
 	go generate github.com/evcc-io/evcc/util/templates/...
 
 lint::
-	golangci-lint run --timeout 1200s
+	golangci-lint run --timeout 400s
 
 lint-ui::
 	npm run lint

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ docs::
 	go generate github.com/evcc-io/evcc/util/templates/...
 
 lint::
-	golangci-lint run
+	golangci-lint run --timeout 1200s
 
 lint-ui::
 	npm run lint


### PR DESCRIPTION
Möglichkeit hinzugefügt einen Devcontainer zu starten der die Entwicklung von EVCC auf Windows Systemen erleichtert. Die gitattributes ermöglichen die Nutzung von Git innerhalb des Containers.