### PR TITLE
MySkoda: fix error upon vehicle wake up

### DIFF
--- a/vehicle/skoda/myskoda/api.go
+++ b/vehicle/skoda/myskoda/api.go
@@ -107,7 +107,7 @@ func (v *API) WakeUp(vin string) error {
 
 	req, err := request.New(http.MethodPost, uri, nil, request.JSONEncoding)
 	if err == nil {
-		err = v.DoJSON(req, nil)
+		_, err = v.DoBody(req) // this returns 202 and a empty reponse body
 	}
 	return err
 }

--- a/vehicle/skoda/myskoda/api.go
+++ b/vehicle/skoda/myskoda/api.go
@@ -107,7 +107,7 @@ func (v *API) WakeUp(vin string) error {
 
 	req, err := request.New(http.MethodPost, uri, nil, request.JSONEncoding)
 	if err == nil {
-		_, err = v.DoBody(req) // this returns 202 and a empty reponse body
+		_, err = v.DoBody(req) // this returns 202 and a empty response body
 	}
 	return err
 }


### PR DESCRIPTION
I added the vehicle wake up to our skoda implementation in #14349.
During usage I noticed that the wake up causes an EOF error in the loadpoint.
I checked the API response and it seems the wake up call only replies with a 202 and an empty body.
The EOF error is caused, as we are trying to read a JSON body out said 0-byte response.

This PR simply skips the JSON wrangling.