### PR TITLE
Update kostal-ksem-inverter.yaml

### DIFF
--- a/templates/definition/meter/kostal-ksem-inverter.yaml
+++ b/templates/definition/meter/kostal-ksem-inverter.yaml
@@ -15,6 +15,13 @@ params:
     choice: ["tcpip"]
     port: 1502
     id: 71
+  - name: endianness
+    description:
+      de: Byte-Reihenfolge (Little/Big)
+      en: Endianness (Little/Big)
+    validvalues: ["big", "little"]
+    default: little
+    advanced: true
 render: |
   type: custom
   power:
@@ -23,4 +30,4 @@ render: |
     register: # manual non-sunspec register configuration
       address: 252 # (see ba_kostal_interface_modbus-tcp_sunspec.pdf)
       type: holding
-      decode: float32s # may be float32 on specific firmware/devices
+      decode: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}


### PR DESCRIPTION
Support setting endianness when reading enery meters from a kostal inverter.

Currently, the endianness is set to little endian, however the sunspec standard expects big endian.

Note that this change does not change the default, so it is backwards compatible.