### PR TITLE
docs: ensure help texts are not multiline

### DIFF
--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -128,16 +128,6 @@ params:
     advanced: true
     type: duration
     example: 5m
-  - name: cloud
-    description:
-      de: evcc Cloud
-      en: evcc Cloud
-    help:
-      de: "Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen, wird dies über die evcc Cloud gemacht. Die Zugangsdaten und VIN werden sicher und verschlüsselt übertragen und in der Cloud nicht gespeichert. Die Vorteile sind: - Falls sich etwas an der Online API des Fahrzeugherstellers ändert, können Updates für alle Benutzer viel schneller zur Verfügung gestellt werden - Man muss nicht auf eine neue Version von evcc warten und dann ein lokales Update von evcc durchführen"
-      en: "Instead of connecting to the vehicle manufacturers online API from your local installation, this will use the evcc Cloud instead. Your credentials and VIN will be transfered encrypted and securely and won't be stored in the cloud. The benefits are: - If the vehicles online API changes, we can update this for all users more quickly - No waiting for a new evcc version in this case and then requiring an update"
-    requirements:
-      evcc: ["sponsorship"]
-    type: bool
   - name: timeout
     description:
       de: Zeitüberschreitung

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -133,22 +133,8 @@ params:
       de: evcc Cloud
       en: evcc Cloud
     help:
-      de: |
-        Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen,
-        wird dies über die evcc Cloud gemacht. Die Zugangsdaten und VIN werden sicher und verschlüsselt
-        übertragen und in der Cloud nicht gespeichert.
-
-        Die Vorteile sind:
-        - Falls sich etwas an der Online API des Fahrzeugherstellers ändert, können Updates für alle Benutzer viel schneller zur Verfügung gestellt werden
-        - Man muss nicht auf eine neue Version von evcc warten und dann ein lokales Update von evcc durchführen
-      en: |
-        Instead of connecting to the vehicle manufacturers online API from your local installation,
-        this will use the evcc Cloud instead. Your credentials and VIN will be transfered encrypted and
-        securely and won't be stored in the cloud.
-
-        The benefits are:
-        - If the vehicles online API changes, we can update this for all users more quickly
-        - No waiting for a new evcc version in this case and then requiring an update
+      de: "Anstatt auf die Online API des Fahrzeugherstellers von der lokalen Installation zuzugreifen, wird dies über die evcc Cloud gemacht. Die Zugangsdaten und VIN werden sicher und verschlüsselt übertragen und in der Cloud nicht gespeichert. Die Vorteile sind: - Falls sich etwas an der Online API des Fahrzeugherstellers ändert, können Updates für alle Benutzer viel schneller zur Verfügung gestellt werden - Man muss nicht auf eine neue Version von evcc warten und dann ein lokales Update von evcc durchführen"
+      en: "Instead of connecting to the vehicle manufacturers online API from your local installation, this will use the evcc Cloud instead. Your credentials and VIN will be transfered encrypted and securely and won't be stored in the cloud. The benefits are: - If the vehicles online API changes, we can update this for all users more quickly - No waiting for a new evcc version in this case and then requiring an update"
     requirements:
       evcc: ["sponsorship"]
     type: bool
@@ -376,12 +362,8 @@ presets:
       - name: stationid
         type: string
         help:
-          en: |
-            Station ID of the charging point. Only required if multiple OCPP charging stations are set up to assign them correctly. A single OCPP charging station can also be automatically assigned.
-            Note: In exceptional cases, it may be necessary to manually append this ID to the OCPP URL of the charging station in the form ws://<evcc-address>:8887/<stationid>. Most charging stations automatically add the ID internally.
-          de: |
-            Station ID des Ladepunktes. Nur erforderlich wenn mehrere OCPP-Ladestationen eingerichtet sind um diese korrekt zuzuweisen. Eine einzelne OCPP-Ladestation kann auch automatisch zugeordnet werden.
-            Hinweis: In Ausnahmefällen kann es erforderlich sein, diese ID manuell an die OCPP-URL der Ladestation in der Form ws://<evcc-adresse>:8887/<stationid> anzuhängen. Die meisten Ladestationen fügen die ID intern automatisch hinzu.
+          en: "Station ID of the charging point. Only required if multiple OCPP charging stations are set up to assign them correctly. A single OCPP charging station can also be automatically assigned. Note: In exceptional cases, it may be necessary to manually append this ID to the OCPP URL of the charging station in the form ws://<evcc-address>:8887/<stationid>. Most charging stations automatically add the ID internally."
+          de: "Station ID des Ladepunktes. Nur erforderlich wenn mehrere OCPP-Ladestationen eingerichtet sind um diese korrekt zuzuweisen. Eine einzelne OCPP-Ladestation kann auch automatisch zugeordnet werden. Hinweis: In Ausnahmefällen kann es erforderlich sein, diese ID manuell an die OCPP-URL der Ladestation in der Form ws://<evcc-adresse>:8887/<stationid> anzuhängen. Die meisten Ladestationen fügen die ID intern automatisch hinzu."
         example: EVB-P12354
       - name: connector
         help:
@@ -395,16 +377,8 @@ presets:
           de: Immer eine Remote-Transaktion starten (RemoteStartTransaction) sobald ein Fahrzeug angeschlossen wird
           en: Always start a remote transaction (RemoteStartTransaction) as soon as a vehicle is connected
         help:
-          de: |
-            Diese Option nur aktivieren wenn keinerlei Möglichkeit besteht Transaktionen seitens des Ladepunktes zu initiieren!
-            Das ist nur der Fall wenn z. B. kein RFID-Lesegerät vorhanden ist und Ladevorgänge grundsätzlich einzeln per App freigeschaltet werden müssten.
-            Normalerweise sollte der Ladepunkt am Gerät immer so konfiguriert werden, dass entweder eine RFID-Karte zur Freischaltung verwendet wird oder der Ladepunkt auf "Autostart", "Freies Laden" o.ä. eingestellt ist.
-            Zunächst die Dokumentation und die Konfigurationsmöglichkeiten des Ladepunktes prüfen, ggf. beim Hersteller nachfragen!
-          en: |
-            Only enable this option if there is no way to initiate transactions from the charger side!
-            This is only the case if e.g. no RFID reader is available and charging processes would have to be released individually via app.
-            Normally, the charger should always be configured at the device so that either an RFID card is used for activation or the charger is set to "Autostart", "Free Charging" or similar.
-            First check the documentation and configuration possibilities of the charger, ask the manufacturer if necessary!
+          de: Diese Option nur aktivieren wenn keinerlei Möglichkeit besteht Transaktionen seitens des Ladepunktes zu initiieren! Das ist nur der Fall wenn z. B. kein RFID-Lesegerät vorhanden ist und Ladevorgänge grundsätzlich einzeln per App freigeschaltet werden müssten. Normalerweise sollte der Ladepunkt am Gerät immer so konfiguriert werden, dass entweder eine RFID-Karte zur Freischaltung verwendet wird oder der Ladepunkt auf "Autostart", "Freies Laden" o.ä. eingestellt ist. Zunächst die Dokumentation und die Konfigurationsmöglichkeiten des Ladepunktes prüfen, ggf. beim Hersteller nachfragen!
+          en: Only enable this option if there is no way to initiate transactions from the charger side! This is only the case if e.g. no RFID reader is available and charging processes would have to be released individually via app. Normally, the charger should always be configured at the device so that either an RFID card is used for activation or the charger is set to "Autostart", "Free Charging" or similar. First check the documentation and configuration possibilities of the charger, ask the manufacturer if necessary!
       - name: idtag
         advanced: true
         type: string
@@ -412,10 +386,8 @@ presets:
           en: Identifier used for authentication of external transactions (RemoteStartTransaction)
           de: Identifikator zur Authentifizierung von externen Transaktionen (RemoteStartTransaction)
         help:
-          de: |
-            Diese Option ist nur in Ausnahmefällen erforderlich wenn der Ladepunkt für die Annahme externer Transaktionen einen spezifischen Token erfordert.
-          en: |
-            This option is only required in exceptional cases if the charger requires a specific token for accepting external transactions.
+          de: Diese Option ist nur in Ausnahmefällen erforderlich wenn der Ladepunkt für die Annahme externer Transaktionen einen spezifischen Token erfordert.
+          en: This option is only required in exceptional cases if the charger requires a specific token for accepting external transactions.
         example: evcc
       - name: connecttimeout
         advanced: true


### PR DESCRIPTION
blocks https://github.com/evcc-io/docs/pull/598

similar to https://github.com/evcc-io/evcc/pull/15025

Currently help texts must be single line since the docs use them as a single line comment `# this is help` after each example line. We can change this once we dont need code samples in the docs any more.