### PR TITLE
Remove built in meter support for Elli Pro (BC)

### DIFF
--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -35,5 +35,3 @@ params:
   - preset: eebus
 render: |
   {{ include "eebus" . }}
-  meter: true
-  chargedEnergy: false


### PR DESCRIPTION
The meter values are not provided reliably and evcc would have to add logic to invalidate old meter values. The better solution is to always use an external meter for these wallboxes.