### PR TITLE
EEBUS: Make sure disabling charging will save current

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -350,7 +350,7 @@ func (c *EEBus) Enable(enable bool) error {
 		current = c.current
 	}
 
-	return c.writeCurrentLimitData([]float64{current, current, current})
+	return c.MaxCurrentMillis(current)
 }
 
 // send current charging power limits to the EV


### PR DESCRIPTION
When disabling charging, and setting the limit on the next reconnect didn’t stop charging right away if that was the previous state.