### PR TITLE
fix: e2e test for battery grid charge

### DIFF
--- a/tests/battery-settings.evcc.yaml
+++ b/tests/battery-settings.evcc.yaml
@@ -64,7 +64,7 @@ tariffs:
     price: 0.2 # EUR/kWh
     zones:
       - hours: 5-7
-        price: 0.6
+        price: 0.45
       - hours: 11-14
         price: 0.05
       - hours: 17-21


### PR DESCRIPTION
Adjusted dyn. price test-data so that the test assumption (battery charge when <= 50ct) is always true.
Previously, tests failed between 5:00 and 7:00 🙈