### PR TITLE
Fix startup on gokrazy

### DIFF
--- a/cmd/gokrazy.go
+++ b/cmd/gokrazy.go
@@ -1,7 +1,0 @@
-//go:build gokrazy
-
-package cmd
-
-func init() {
-	viper.AddConfigPath("/perm") // path to look for the config file in
-}


### PR DESCRIPTION
Fixes panic: runtime error: invalid memory address or nil pointer dereference.

viper is uninitialized in init.

Secondly gokrazy process interface defaults HOME to /perm so config already
is looked up from /perm filesystem so this is
not even required.

https://gokrazy.org/development/process-interface/

[db    ] INFO 2024/08/13 22:26:28 using sqlite database: /perm/home/evcc/.evcc/evcc.db

Related to #15375.