### PR TITLE
OCPP: fix BootNotification trigger

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -261,7 +261,7 @@ func NewOCPP(id string, connector int, idtag string,
 
 	// see who's there
 	if c.hasRemoteTriggerFeature {
-		if err := conn.TriggerMessageRequest(core.BootNotificationFeatureName); err == nil {
+		if err := ocpp.Instance().TriggerMessageRequest(cp.ID(), core.BootNotificationFeatureName); err == nil {
 			select {
 			case <-time.After(timeout):
 				c.log.DEBUG.Printf("BootNotification timeout")


### PR DESCRIPTION
BootNotification does belong to the station, not the connector.