### PR TITLE
Plan UI: clarify avg price

### DIFF
--- a/assets/js/components/ChargingPlanPreview.vue
+++ b/assets/js/components/ChargingPlanPreview.vue
@@ -92,7 +92,7 @@ export default {
 			return hourSum ? priceSum / hourSum : undefined;
 		},
 		fmtAvgPrice() {
-			if (!this.targetTime) {
+			if (!this.targetTime || this.duration === 0) {
 				return "—";
 			}
 			let price = this.activeSlot ? this.activeSlot.price : this.avgPrice;

--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -255,15 +255,10 @@ loadpoints:
 tariffs:
   currency: EUR # three letter ISO-4217 currency code (default EUR)
   grid:
-    type: fixed
-    price: 0.2 # EUR/kWh
-    zones:
-      - hours: 5-7
-        price: 0.6
-      - hours: 11-14
-        price: 0.05
-      - hours: 17-21
-        price: 0.5
+    type: template
+    template: energy-charts-api # epex spot market prices
+    bzn: DE-LU
+    charges: 0.15
   feedin:
     type: fixed
     price: 0.08 # EUR/kWh


### PR DESCRIPTION
fixed https://github.com/evcc-io/evcc/issues/15436

Replaced "still unknown" avg price by "—" if no charging is required.

**Plan SoC is below vehicle SoC: no charging required**

![no charge](https://github.com/user-attachments/assets/9aa76944-febf-4076-bcab-5ce2681efef3)

**Plan time outside of known price window**

![time in future](https://github.com/user-attachments/assets/33523db5-d850-4e0d-bc23-d28c14d0a6d5)

**Normal state, all infos available**

![normal](https://github.com/user-attachments/assets/7cb5476c-d1a1-4f8c-8d3d-aef3af592174)
