### PR TITLE
OCPP: minor compatibility enhancements

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -42,7 +42,7 @@ type OCPP struct {
 
 const (
 	defaultIdTag      = "evcc" // RemoteStartTransaction only
-	desiredMeasurands = "Energy.Active.Import.Register,Power.Active.Import,SoC,Current.Offered,Power.Offered,Current.Import,Voltage"
+	desiredMeasurands = "Power.Active.Import,Energy.Active.Import.Register,SoC,Current.Offered,Power.Offered,Current.Import,Voltage"
 )
 
 func init() {
@@ -214,6 +214,11 @@ func NewOCPP(id string, connector int, idtag string,
 				case ocpp.KeyMaxChargingProfilesInstalled:
 					if val, err := strconv.Atoi(*opt.Value); err == nil {
 						c.chargingProfileId = val
+					}
+
+				case ocpp.KeyMeterValuesSampledData:
+					if opt.Readonly {
+						meterValuesSampledDataMaxLength = 0
 					}
 
 				case ocpp.KeyMeterValuesSampledDataMaxLength:

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -232,7 +232,7 @@ func NewOCPP(id string, connector int, idtag string,
 
 				case ocpp.KeySupportedFeatureProfiles:
 					if !c.hasProperty(*opt.Value, smartcharging.ProfileName) {
-						err = fmt.Errorf("the mandatory SmartCharging profile is not supported")
+						c.log.WARN.Printf("the required SmartCharging feature profile is not indicated as supported")
 					}
 					c.hasRemoteTriggerFeature = c.hasProperty(*opt.Value, remotetrigger.ProfileName)
 


### PR DESCRIPTION
Improves compatibility with some spec-violating chargers

- [x] assume unlimited MaxLength if not indicated (Ref https://github.com/evcc-io/evcc/issues/15022 and other)
- [x] log error only on feature profiles mismatch (Fixes https://github.com/evcc-io/evcc/issues/15474)
- [x] never abort on rejected configuration
- [x] refine desired measurands priority (active power has highest priority now)
- [x] do not attempt to change read-only sample configuration key

