### PR TITLE
Fix energy readings deye hybrid 3p

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -40,7 +40,7 @@ render: |
     register:
       address: 522 # "Total_GridBuy_Power Wh"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   currents:
     - source: modbus
@@ -99,7 +99,7 @@ render: |
     register:
       address: 534 # "Total_PV_Power_Wh"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -251,6 +251,6 @@ render: |
     register:
       address: 518 # "Total discharge of the battery (Wh)"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   {{- end }}


### PR DESCRIPTION
Inverter is a Deye SUN-12K-SG04LP3-EU. 

Energy readings with current template: 
```
my_grid
-------
Power:          407W
Energy:         11481907.2kWh
Current L1..L3: 1.58A 0.85A 0.68A

my_pv
-----
Power:  0W
Energy: 42526310.4kWh

my_battery
----------
Power:        10W
Energy:       13074432.0kWh
Soc:          100%
Controllable: true
```

Energy readings with decode `uint32s`:
```
my_grid
-------
Power:          677W
Energy:         175.2kWh
Current L1..L3: 2.46A 0.58A 0.99A

my_pv
-----
Power:  0W
Energy: 648.9kWh

my_battery
----------
Power:  11W
Energy: 199.5kWh
Soc:    100%
```

See also https://github.com/tobiasfaust/SolaxModbusGateway/blob/development/docs/Deye-SUN%20Inverter-Modbus-en.pdf

@premultiply the only difference to the hp3 model is scaling of the pv and battery power. Maybe there is a option to merge the templates?
