### PR TITLE
Extend victron energy meter template to retrieve currents for grid meter

### DIFF
--- a/templates/definition/meter/victron-energy.yaml
+++ b/templates/definition/meter/victron-energy.yaml
@@ -47,6 +47,40 @@ render: |
         address: 822 # L3 grid power
         type: input
         decode: int16
+  currents:
+    - source: calc
+      div: # values in modbus registers are multiplied by 10 
+      - source: modbus
+        uri: {{ .host }}:{{ .port }}
+        id: 30
+        register:
+          address: 2617 # L1 grid current
+          type: input
+          decode: int16
+      - source: const
+        value: 10
+    - source: calc
+      div:
+      - source: modbus
+        uri: {{ .host }}:{{ .port }}
+        id: 30
+        register:
+          address: 2619 # L2 grid current
+          type: input
+          decode: int16
+      - source: const
+        value: 10
+    - source: calc
+      div:
+      - source: modbus
+        uri: {{ .host }}:{{ .port }}
+        id: 30
+        register:
+          address: 2621 # L3 grid current
+          type: input
+          decode: int16
+      - source: const
+        value: 10
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/victron-energy.yaml
+++ b/templates/definition/meter/victron-energy.yaml
@@ -48,39 +48,30 @@ render: |
         type: input
         decode: int16
   currents:
-    - source: calc
-      div: # values in modbus registers are multiplied by 10 
-      - source: modbus
-        uri: {{ .host }}:{{ .port }}
-        id: 30
-        register:
-          address: 2617 # L1 grid current
-          type: input
-          decode: int16
-      - source: const
-        value: 10
-    - source: calc
-      div:
-      - source: modbus
-        uri: {{ .host }}:{{ .port }}
-        id: 30
-        register:
-          address: 2619 # L2 grid current
-          type: input
-          decode: int16
-      - source: const
-        value: 10
-    - source: calc
-      div:
-      - source: modbus
-        uri: {{ .host }}:{{ .port }}
-        id: 30
-        register:
-          address: 2621 # L3 grid current
-          type: input
-          decode: int16
-      - source: const
-        value: 10
+    - source: modbus
+      uri: {{ .host }}:{{ .port }}
+      id: 30
+      register:
+        address: 2617 # L1 grid current
+        type: input
+        decode: int16
+      scale: 0.1
+    - source: modbus
+      uri: {{ .host }}:{{ .port }}
+      id: 30
+      register:
+        address: 2619 # L2 grid current
+        type: input
+        decode: int16
+      scale: 0.1
+    - source: modbus
+      uri: {{ .host }}:{{ .port }}
+      id: 30
+      register:
+        address: 2621 # L3 grid current
+        type: input
+        decode: int16
+      scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
   power:


### PR DESCRIPTION
Using the victron energy grid meter for circuits gets refused because of missing current information. This modification fixes this and allowes one to use the victron grid meter data for circuits. 