### PR TITLE
Update .gitignore for Gitpod development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ asset-stats.html
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.gitpod.yml


### PR DESCRIPTION
Developing in Gitpod adds a file ".gitpod.yml" which should be ignored by Git.