### PR TITLE
Fix crash PMCC 1 phase setup charging Taycan

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -413,10 +413,14 @@ func (c *EEBus) writeLoadControlLimitsVASVW(evEntity spineapi.EntityRemoteInterf
 	}
 
 	for index, item := range limits {
-		limits[index].IsActive = item.Value >= minLimits[index]
+		// if the limit is equal or bigger than the min allowed, then the recommendation limit is active, otherwise it is not
+		limits[index].IsActive = false
+		if index < len(minLimits) {
+			limits[index].IsActive = item.Value >= minLimits[index]
+		}
 	}
 
-	// set overload protection limits
+	// set recommendation limits
 	if _, err := c.uc.OscEV.WriteLoadControlLimits(evEntity, limits, nil); err != nil {
 		c.log.ERROR.Println("!! OscEV.WriteLoadControlLimits:", err)
 		return false


### PR DESCRIPTION
If a PMCC charger is connected with 1 phase only, and a Taycan is charging via VWVAS services, the following crash occurred:

```
[site  ] DEBUG 2024/08/21 21:25:28 site power: 368W
[lp-1  ] DEBUG 2024/08/21 21:25:28 !! session: chargeRater.chargedEnergy=0.7 - chargedAtStartup=0.0
panic: runtime error: index out of range [1] with length 1

goroutine 96 [running]:
github.com/evcc-io/evcc/charger.(*EEBus).writeLoadControlLimitsVASVW(0xc0005f8850, {0x37f8e58, 0xc001456f80}, {0xc0021a6380, 0x3, 0x4})
	github.com/evcc-io/evcc/charger/eebus.go:416 +0x310
github.com/evcc-io/evcc/charger.(*EEBus).writeCurrentLimitData(0xc0005f8850, {0x37f8e58, 0xc001456f80}, 0x0)
	github.com/evcc-io/evcc/charger/eebus.go:331 +0x2a5
github.com/evcc-io/evcc/charger.(*EEBus).Status.func1()
	github.com/evcc-io/evcc/charger/eebus.go:194 +0xd0
```

This change fixes this issue.