### PR TITLE
Stats: prevent error when no sessions exist yet

### DIFF
--- a/core/stats.go
+++ b/core/stats.go
@@ -49,7 +49,7 @@ func (s *Stats) calculate(days int) map[string]float64 {
 
 	executeQuery := func(selectClause string, whereClause string, fromDate time.Time, dest interface{}) {
 		query := fmt.Sprintf(`
-		SELECT %s
+		SELECT COALESCE(%s, 0)
 		FROM sessions
 		WHERE finished >= ? 
 		AND charged_kwh > 0 


### PR DESCRIPTION
partly-fix https://github.com/evcc-io/evcc/issues/15618

Prevent `error executing query: sql: Scan error on column index 0, name \"SUM(charged_kwh * co2_per_kwh) / SUM(charged_kwh)\": converting NULL to float64 is unsupported` error, which happens when no matching sessions were found. Added fallback to 0.