### PR TITLE
Various EEBUS improvements

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -154,11 +154,8 @@ func (c *EEBus) isCharging(evEntity spineapi.EntityRemoteInterface) bool {
 	} else {
 		limitsMin, _, _, err := c.uc.OpEV.CurrentLimits(evEntity)
 		if err != nil || len(limitsMin) == 0 {
-			// sometimes a min limit is not provided by the EVSE, so take the limit defined for the loadpoint
-			if c.lp == nil {
-				return false
-			}
-			limitsMin = []float64{c.lp.GetMinCurrent()}
+			// sometimes a min limit is not provided by the EVSE, and we can't take it from the loadpoint
+			return false
 		}
 		minPower = limitsMin[0] * voltage
 	}

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -137,31 +137,33 @@ func (c *EEBus) isCharging(evEntity spineapi.EntityRemoteInterface) bool {
 	// we only want this for configured meters and not for internal meters!
 	// right now it works as expected
 	if c.lp != nil && c.lp.HasChargeMeter() {
-		if c.lp.GetChargePower() > c.lp.EffectiveMinPower()*idleFactor {
-			return true
-		}
+		return c.lp.GetChargePower() > c.lp.EffectiveMinPower()*idleFactor
 	}
 
 	// The above doesn't (yet) work for built in meters, so check the EEBUS measurements also
-	currents, err := c.uc.EvCem.CurrentPerPhase(evEntity)
+
+	// use power data if available, otherwise the method will calculate the power from the current data
+	power, err := c.currentPower()
 	if err != nil {
 		return false
 	}
 
-	limitsMin, _, _, err := c.uc.OpEV.CurrentLimits(evEntity)
-	if err != nil || len(limitsMin) == 0 {
-		// sometimes a min limit is not provided by the EVSE, so take the limit defined for the loadpoint
-		if c.lp == nil {
-			return false
+	var minPower float64
+	if c.lp != nil {
+		minPower = c.lp.EffectiveMinPower()
+	} else {
+		limitsMin, _, _, err := c.uc.OpEV.CurrentLimits(evEntity)
+		if err != nil || len(limitsMin) == 0 {
+			// sometimes a min limit is not provided by the EVSE, so take the limit defined for the loadpoint
+			if c.lp == nil {
+				return false
+			}
+			limitsMin = []float64{c.lp.GetMinCurrent()}
 		}
-		limitsMin = []float64{c.lp.GetMinCurrent()}
+		minPower = limitsMin[0] * voltage
 	}
 
-	// require sum of all phase currents to be > 0.6 * a single phase minimum
-	// in some scenarios, e.g. Cayenne Hybrid, sometimes the meter of a PMCC device
-	// reported 600W, even tough the car was not charging
-	limitMin := limitsMin[0]
-	return lo.Sum(currents) > limitMin*idleFactor
+	return power > minPower*idleFactor
 }
 
 // Status implements the api.Charger interface
@@ -357,7 +359,8 @@ func (c *EEBus) hasActiveVASVW(evEntity spineapi.EntityRemoteInterface) bool {
 	}
 
 	// SoC has to be available, otherwise it is plain ISO15118-2
-	if _, err := c.Soc(); err != nil {
+	// SoC has to be >= 25%, because the Taycan can't be setup with a Min SoC below 25%, oherwise obligations have to be used
+	if soc, err := c.Soc(); err != nil || soc < 25 {
 		return false
 	}
 

--- a/charger/eebus_test.go
+++ b/charger/eebus_test.go
@@ -22,6 +22,7 @@ func TestEEBusIsCharging(t *testing.T) {
 	type testMeasurementStruct struct {
 		charging bool
 		currents []float64
+		powers   []float64
 	}
 
 	tests := []struct {
@@ -40,10 +41,12 @@ func TestEEBusIsCharging(t *testing.T) {
 				{
 					false,
 					[]float64{0, 3, 0},
+					[]float64{0, 690, 0},
 				},
 				{
 					true,
 					[]float64{6, 0, 1},
+					[]float64{1380, 0, 230},
 				},
 			},
 		},
@@ -56,10 +59,12 @@ func TestEEBusIsCharging(t *testing.T) {
 				{
 					false,
 					[]float64{2},
+					[]float64{460},
 				},
 				{
 					true,
 					[]float64{6},
+					[]float64{1380},
 				},
 			},
 		},
@@ -74,10 +79,12 @@ func TestEEBusIsCharging(t *testing.T) {
 				{
 					false,
 					[]float64{1, 0, 0},
+					[]float64{230, 0, 0},
 				},
 				{
 					true,
 					[]float64{1.8, 1, 3},
+					[]float64{414, 230, 690},
 				},
 			},
 		},
@@ -110,7 +117,9 @@ func TestEEBusIsCharging(t *testing.T) {
 					ev: evEntity,
 				}
 
-				evcem.EXPECT().CurrentPerPhase(evEntity).Return(m.currents, nil)
+				evcc.EXPECT().EVConnected(evEntity).Return(true)
+				evcem.EXPECT().IsScenarioAvailableAtEntity(evEntity, mock.Anything).Return(true)
+				evcem.EXPECT().PowerPerPhase(evEntity).Return(m.powers, nil)
 				opev.EXPECT().CurrentLimits(evEntity).Return(limitsMin, limitsMax, limitsDefault, nil)
 
 				require.Equal(t, m.charging, eebus.isCharging(evEntity))


### PR DESCRIPTION
- Make sure to use VWVAS feature only if the vehicle reported SoC is 25% or higher, as charging via this feature in a Taycan only works if the vehicle internal MinSoC is reached which can’t be lower than 25%
- For detecting if the EV is charging, use the reported power data first, and only use currents if no power data is available