### PR TITLE
Loadpoint: ignore charger our of sync if vehicle is disconnected

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -784,8 +784,8 @@ func (lp *Loadpoint) syncCharger() error {
 			return fmt.Errorf("charger enable: %w", err)
 		}
 
-	case shouldBeConsistent && (enabled || lp.connected()):
-		// ignore disabled state if vehicle was disconnected (!lp.enabled && !lp.connected)
+	case shouldBeConsistent && (!enabled || lp.connected()):
+		// ignore disabled state if vehicle was disconnected !(lp.enabled && !lp.connected)
 		lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
 	}
 


### PR DESCRIPTION
In https://github.com/evcc-io/evcc/pull/12876/files#diff-c456526d4bd9022a488ce32de208b40d86016e2c40b0c81a2dffe557c186377dL709-R723, syncCharger was cleaned up. Particularly, the desired logic of ignoring warnings when vehicle was disconnected like

    ^(lp.enabled && ^lp.connected)

was changed to 

    !lp.enabled && !lp.connected

which is NOT equivalent. Instead, this would be equivalent:

    !lp.enabled || lp.connected

This PR uses `enabled` as being the actual state of the charger: 

    !enabled || lp.connected
