### PR TITLE
Fix grid energy scale for Solaredge Hybrid meter

### DIFF
--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -43,6 +43,7 @@ render: |
     timeout: {{ .timeout }}
     subdevice: 1 # Metering device
     value: 203:TotWhImp
+    scale: 0.001
   currents:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}


### PR DESCRIPTION
Name says it all - meter reading was not scaled properly.