### PR TITLE
Add rudimentary battery controls to Growatt Hybrid

### DIFF
--- a/templates/definition/meter/growatt-hybrid.yaml
+++ b/templates/definition/meter/growatt-hybrid.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Growatt
     description:
       generic: Hybrid Inverter
+capabilities: ["battery-control"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -94,3 +95,74 @@ render: |
       decode: uint32
     scale: 0.1
   {{- end }}
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal -> disable "battery first" and "ac charge enabled"
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1102
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1092
+              type: writemultiple
+              decode: uint16
+
+    - case: 2 # hold -> enable "battery first" and disable "ac charge enabled"
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1102
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1092
+              type: writemultiple
+              decode: uint16
+
+    - case: 3 # charge -> enable "battery first" and "ac charge enabled"
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1102
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1092
+              type: writemultiple
+              decode: uint16

--- a/templates/definition/meter/growatt-hybrid.yaml
+++ b/templates/definition/meter/growatt-hybrid.yaml
@@ -4,6 +4,18 @@ products:
     description:
       generic: Hybrid Inverter
 capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Um die aktive Ladesteuerung nutzen zu können ist eine einmalige manuelle Einrichtung notwendig.
+      Es müssen die Modbusregister `1100, 1101, 1102` gleichzeitig (via "write multiple", FC 16) auf die Werte `0, 5947, 0` gesetzt werden.
+      Das kann zB. mit der [Modbus CLI](https://github.com/favalex/modbus-cli) gemacht werden: `modbus [...] H@1100=0 H@1101=5947 H@1102=0`.
+      Die aktive Ladesteuerung nutzt den ersten Zeitslot für den "Battery first" modus, d.h. dieser kann nicht anderweitig genutzt werden.
+    en: |
+      To use the active battery control, a one-time manual setup is necessary.
+      The modbus registers `1100, 1101, 1102` need to be set to the values `0, 5947, 0` at the same time (via "write multiple", FC 16).
+      This can be done by e.g. using the [Modbus CLI](https://github.com/favalex/modbus-cli): `modbus [...] H@1100=0 H@1101=5947 H@1102=0`.
+      The active battery control uses the first "Battery first" timeslot, so it cannot be used otherwise.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -98,7 +110,7 @@ render: |
   batterymode:
     source: switch
     switch:
-    - case: 1 # normal -> disable "battery first" and "ac charge enabled"
+    - case: 1 # normal -> disable "battery first" and "ac charge"
       set:
         source: sequence
         set:
@@ -120,8 +132,7 @@ render: |
               address: 1092
               type: writemultiple
               decode: uint16
-
-    - case: 2 # hold -> enable "battery first" and disable "ac charge enabled"
+    - case: 2 # hold -> enable "battery first" and disable "ac charge"
       set:
         source: sequence
         set:
@@ -143,8 +154,7 @@ render: |
               address: 1092
               type: writemultiple
               decode: uint16
-
-    - case: 3 # charge -> enable "battery first" and "ac charge enabled"
+    - case: 3 # charge -> enable "battery first" and "ac charge"
       set:
         source: sequence
         set:


### PR DESCRIPTION
This adds rudimentary battery controls to the growatt hybrid battery. (https://github.com/evcc-io/evcc/issues/12858)

The growatt hybrid inverter supports three operating modes: Load first (default), Battery first and Grid first.
* In "Load first", the inverter behaves as you'd expect from a hybrid inverter; charging excess PV production and discharging when production is insufficient for the load.
* In "Battery first", it will only charge excess production but will not discharge the battery. Additionally, in this mode we can enable another property called "AC charging", that will charge the battery even if there is not enough production, importing additional energy from the grid.
* "Grid first" will discharge the battery into the grid until empty.

The operating mode of the growatt hybrid inverter cannot be set directly. Instead, timeslots can be configured to change the mode for specific times of the day. There are 3 timeslots for each operating mode. Each timeslot is defined by a start time, end time and enable flag.

This implementation uses the first "Battery first" timeslot. It is set to start at 0:00 and end at 23:59. The mode is then switched from "Load first" to "Battery first" by using the enable flag on this timeslot.

Another quirk of this inverter is that the registers to set the start, end and enable registers all need to be set in one write operation, otherwise it will not accept the new values. Once the timeslot is set, it is possible to just change the enable value though.

Unfortunately, I did not find a solution to write to exactly three registers (1100-1102) at once. I would like to add this if someone can give me a hint on how to achieve this. Until then, it is required to setup the timeslot manually by writing the values `0, 5947, 0` to the registers (e.g. using https://github.com/favalex/modbus-cli: `modbus [...] H@1100=0 H@1101=5947 H@1102=0`).

The operating mode can be observed by querying the input register 118 and AC charge power can be monitored with input registers 116 and 117 (uint32, 0.1kw). I am using this on my Growatt SPH8000TL3 BH-UP and its working fine so far.