### PR TITLE
Kostal Plenticore add grid charge feature

### DIFF
--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -75,16 +75,57 @@ render: |
     source: sunspec
     {{- include "modbus" . | indent 2 }}
     value: 802:SoC # 802 battery control
-  limitsoc:
+  batterymode:
     source: watchdog
-    timeout: {{ .watchdog }} # re-write at timeout/2
+    timeout: {{ .watchdog }}
+    reset: 1 # reset watchdog on normal
     set:
-      source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 1042 # limit soc
-        type: writemultiple
-        encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: const
+          value: {{ .minsoc }}  # % (dummy operation, reset minSoC)
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1042 # # limit soc (min)
+              type: writemultiple
+              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+      - case: 2 # hold
+        set:
+          source: const
+          value: 0 # %
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1028 # Battery charge current (DC) setpoint, relative
+              type: writemultiple
+              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+      - case: 3 # charge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: -100 # % 
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1028 # Battery charge current (DC) setpoint, relative
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          - source: const
+            value: {{ .maxsoc }} 
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1044 # Maximum soc
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %


### PR DESCRIPTION
Sollte das Netzladen mit einem Kostal Plenticore ermöglichen.

Ich bin mir hier noch nicht ganz sicher, ob `case 1` für normal funktioniert: Der WR fällt nur dann in die interne Steuerung zurück, wenn Befehle via Modbus nach einer eingestellen Zeit ausbleiben. 
![grafik](https://github.com/user-attachments/assets/b4f8442f-8996-44de-b305-806236c2b234)

Es wird hier aber der `minsoc` als dummy Befehl geschrieben, was, soweit ich weiß, dazu führt, dass der WR _nicht_ in den internen Modus zurückfällt. 