### PR TITLE
EEBUS: Monitor measurements after limit change

### DIFF
--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -1,0 +1,15 @@
+package eebus
+
+import (
+	"errors"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	"github.com/evcc-io/evcc/api"
+)
+
+func WrapError(err error) error {
+	if errors.Is(err, eebusapi.ErrDataNotAvailable) {
+		return api.ErrNotAvailable
+	}
+	return err
+}

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -36,3 +36,5 @@ params:
   - name: ip
 render: |
   {{ include "eebus" . }}
+  meter: true
+  chargedEnergy: false


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/15599#issuecomment-2321390023

If a limit has been set, a measurement is expected to provided within 15s. If this is not the case, then show a warning and return an error.

Also add support for the Elli Connect Pro internal meter again.

This should now lead to those EEBUS wallboxes not providing measurements, to fall back to the actual limit being assumed as being the current measurement. And the user is informed about non function metering in the wallbox.