### PR TITLE
Template ocpp-abb: set increased connecttimeout

### DIFF
--- a/templates/definition/charger/ocpp-abb.yaml
+++ b/templates/definition/charger/ocpp-abb.yaml
@@ -9,4 +9,5 @@ params:
   - preset: ocpp
 render: |
   {{ include "ocpp" . }}
+  connecttimeout: 30m
   stacklevelzero: true


### PR DESCRIPTION
Meine TerraAC braucht teilweise >20 Minuten um sich nach einem evcc Neustart neu zu verbinden (die Varianz ist da zwischen 30 Sekunden wenn man Glück hat und >20 Minuten).
Ich halte es für sinnvoll diesen Umstand im zugehörgen Template zu beachten.

Ich weiß dass 30 Minuten enorm lang sind, aber mit 20 hatte ich dieses Problem in der Vergangenheit (wenn auch nur 1-2x) trotzdem.