### PR TITLE
prevent screen from juddering when clicking on diagram

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -110,6 +110,7 @@ html.no-transitions * {
 body {
 	background-color: var(--evcc-background);
 	color: var(--evcc-default-text);
+	overflow-y: scroll;
 }
 
 h1,

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -110,6 +110,9 @@ html.no-transitions * {
 body {
 	background-color: var(--evcc-background);
 	color: var(--evcc-default-text);
+}
+
+body:not(.modal-open) {
 	overflow-y: scroll;
 }
 

--- a/assets/js/components/Footer.vue
+++ b/assets/js/components/Footer.vue
@@ -24,12 +24,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-@media (max-width: 30em) {
-	.footer .container > div:first-child {
-		justify-content: center !important;
-		flex-wrap: wrap;
-	}
-}
-</style>

--- a/assets/js/components/Footer.vue
+++ b/assets/js/components/Footer.vue
@@ -25,4 +25,11 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+@media (max-width: 30em) {
+	.footer .container > div:first-child {
+		justify-content: center !important;
+		flex-wrap: wrap;
+	}
+}
+</style>

--- a/assets/js/components/Version.vue
+++ b/assets/js/components/Version.vue
@@ -1,14 +1,16 @@
 <template>
-	<div>
+	<div class="text-truncate">
 		<a
 			v-if="commit"
 			:href="githubHashUrl"
 			target="_blank"
 			class="btn btn-link ps-0 text-decoration-none evcc-default-text text-nowrap d-flex align-items-end"
 		>
-			<Logo class="logo me-2" />
-			<span class="text-decoration-underline">v{{ installed }}</span>
-			<shopicon-regular-moonstars class="ms-2 text-gray-light"></shopicon-regular-moonstars>
+			<Logo class="logo me-2 flex-shrink-0" />
+			<span class="text-decoration-underline text-truncate">v{{ installed }}</span>
+			<shopicon-regular-moonstars
+				class="ms-2 text-gray-light flex-shrink-0"
+			></shopicon-regular-moonstars>
 		</a>
 		<button
 			v-else-if="newVersionAvailable"
@@ -17,7 +19,7 @@
 			@click="openModal"
 		>
 			<shopicon-regular-gift class="me-2"></shopicon-regular-gift>
-			<span class="text-decoration-underline">v{{ installed }}</span>
+			<span class="text-decoration-underline text-truncate">v{{ installed }}</span>
 			<span class="ms-2 d-none d-sm-block text-gray-medium text-decoration-underline">
 				{{ $t("footer.version.availableLong") }}
 			</span>
@@ -28,8 +30,8 @@
 			target="_blank"
 			class="btn btn-link evcc-default-text ps-0 text-decoration-none text-nowrap d-flex align-items-end"
 		>
-			<Logo class="logo me-2" />
-			<span class="text-decoration-underline">v{{ installed }}</span>
+			<Logo class="logo me-2 flex-shrink-0" />
+			<span class="text-decoration-underline text-truncate">v{{ installed }}</span>
 		</a>
 
 		<Teleport to="body">


### PR DESCRIPTION
Hi,
If you click on the `In-Out-diagram`, the screen jerks:

https://github.com/user-attachments/assets/79b26735-fac4-4840-b1b8-0f3ac452483a

Adding `overflow-y: scroll` to the `<body>`-tag prevents this:

https://github.com/user-attachments/assets/0de8fcf0-d003-4631-83d2-d0f87c15b016

