### PR TITLE
EEBUS: Only disable recommendations if available

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -334,8 +334,13 @@ func (c *EEBus) writeCurrentLimitData(evEntity spineapi.EntityRemoteInterface, c
 	}
 
 	// make sure the recommendations are inactive, otherwise the EV won't go to sleep
-	if err := c.disableLimits(evEntity, c.uc.OscEV); err != nil {
-		return err
+	// but only if it supports OSCEV and has required data!
+	if c.uc.OscEV.IsScenarioAvailableAtEntity(evEntity, 1) {
+		if _, err := c.uc.OscEV.LoadControlLimits(evEntity); err == nil {
+			if err := c.disableLimits(evEntity, c.uc.OscEV); err != nil {
+				return err
+			}
+		}
 	}
 
 	// set overload protection limits
@@ -404,6 +409,11 @@ func (c *EEBus) writeLoadControlLimitsVASVW(evEntity spineapi.EntityRemoteInterf
 
 	// check if the EVSE supports optimization of self consumption limits
 	if !c.uc.OscEV.IsScenarioAvailableAtEntity(evEntity, 1) {
+		return false
+	}
+
+	// OSCEV requires recommendation limits to be available
+	if _, err := c.uc.OscEV.LoadControlLimits(evEntity); err != nil {
 		return false
 	}
 


### PR DESCRIPTION
Some EEBUS wallboxes like the PCMP do report the OSCEV usecase to be available, but it doesn’t provide the necessary recommendation limit data.

This change adds checks for this case.