### PR TITLE
Fix ChargerStatusReason not resetting

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1674,7 +1674,7 @@ func (lp *Loadpoint) Update(sitePower float64, rates api.Rates, batteryBuffered,
 	lp.publish(keys.Connected, lp.connected())
 	lp.publish(keys.Charging, lp.charging())
 
-	if sr, ok := lp.charger.(api.StatusReasoner); ok && lp.GetStatus() == api.StatusB {
+	if sr, ok := lp.charger.(api.StatusReasoner); ok {
 		if r, err := sr.StatusReason(); err == nil {
 			lp.publish(keys.ChargerStatusReason, r)
 		} else {


### PR DESCRIPTION
Mir ist beim testen zufällig aufgefallen, dass der `StatusReason()` via Icon "Kabel abstecken" dauerhaft in der UI angezeigt bleibt obwohl das Kabel definitiv abgezogen und dies auch mit "Nicht verbunden." korrekt signalisiert wurde.

Grund: `ChargerStatusReason` wird bisher nur in Status B aktualisiert. Sobald ein anderer Status vorliegt bzw. ein direkter Übergang erfolgt wird dies nicht mehr aktualisiert und somit nicht zurückgesetzt.