### PR TITLE
Evbox Elvi: undeprecate meter-less configuration

### DIFF
--- a/templates/definition/charger/ocpp-elvi.yaml
+++ b/templates/definition/charger/ocpp-elvi.yaml
@@ -14,6 +14,6 @@ params:
     deprecated: true
 render: |
   {{ include "ocpp" . }}
-  {{- if .meter "false" }}
+  {{- if eq .meter "false" }}
   metervalues: Current.Offered
   {{- end }}

--- a/templates/definition/charger/ocpp-elvi.yaml
+++ b/templates/definition/charger/ocpp-elvi.yaml
@@ -8,8 +8,12 @@ requirements:
 params:
   - preset: ocpp
   - name: meter
-    deprecated: true
+    type: bool
+    default: true
   - name: meterinterval
     deprecated: true
 render: |
   {{ include "ocpp" . }}
+  {{- if .meter "false" }}
+  metervalues: Current.Offered
+  {{- end }}


### PR DESCRIPTION
Alternative approach to #15882

- Skip broken measurands decoration on Elvi chargers without internal meter if configured using `meter: false` template option.

May fix #14115 #14138