### PR TITLE
Evbox Elvi: remove measurands preconfiguration

### DIFF
--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -82,6 +82,7 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration, timeout tim
 				case KeyAlfenPlugAndChargeIdentifier:
 					cp.IdTag = *opt.Value
 					cp.log.DEBUG.Printf("overriding default `idTag` with Alfen-specific value: %s", cp.IdTag)
+				}
 
 				if err != nil {
 					break

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -83,12 +83,6 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration, timeout tim
 					cp.IdTag = *opt.Value
 					cp.log.DEBUG.Printf("overriding default `idTag` with Alfen-specific value: %s", cp.IdTag)
 
-				case KeyEvBoxSupportedMeasurands:
-					if meterValues == "" {
-						meterValues = *opt.Value
-					}
-				}
-
 				if err != nil {
 					break
 				}


### PR DESCRIPTION
Alternative approach to #15876

- Removes vendor specific measurands preconfiguration
- Tries measurands autodetection as any other charger

May fix https://github.com/evcc-io/evcc/issues/14115 https://github.com/evcc-io/evcc/discussions/14138