### PR TITLE
Australia: Amber use advanced price forecasts for tariffs

### DIFF
--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -19,11 +19,10 @@ import (
 type Amber struct {
 	*embed
 	*request.Helper
-	log              *util.Logger
-	uri              string
-	channel          string
-	data             *util.Monitor[api.Rates]
-	useAdvancedPrice bool
+	log     *util.Logger
+	uri     string
+	channel string
+	data    *util.Monitor[api.Rates]
 }
 
 var _ api.Tariff = (*Amber)(nil)
@@ -34,11 +33,10 @@ func init() {
 
 func NewAmberFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
-		embed            `mapstructure:",squash"`
-		Token            string
-		SiteID           string
-		Channel          string
-		UseAdvancedPrice bool
+		embed   `mapstructure:",squash"`
+		Token   string
+		SiteID  string
+		Channel string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -60,13 +58,12 @@ func NewAmberFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	log := util.NewLogger("amber").Redact(cc.Token)
 
 	t := &Amber{
-		embed:            &cc.embed,
-		log:              log,
-		Helper:           request.NewHelper(log),
-		uri:              fmt.Sprintf(amber.URI, strings.ToUpper(cc.SiteID)),
-		channel:          strings.ToLower(cc.Channel),
-		data:             util.NewMonitor[api.Rates](2 * time.Hour),
-		useAdvancedPrice: cc.UseAdvancedPrice,
+		embed:   &cc.embed,
+		log:     log,
+		Helper:  request.NewHelper(log),
+		uri:     fmt.Sprintf(amber.URI, strings.ToUpper(cc.SiteID)),
+		channel: strings.ToLower(cc.Channel),
+		data:    util.NewMonitor[api.Rates](2 * time.Hour),
 	}
 
 	t.Client.Transport = &transport.Decorator{
@@ -111,7 +108,7 @@ func (t *Amber) run(done chan error) {
 					End:   endTime.Local(),
 					Price: r.PerKwh / 1e2,
 				}
-				if t.useAdvancedPrice && r.AdvancedPrice != nil {
+				if r.AdvancedPrice != nil {
 					ar.Price = r.AdvancedPrice.Predicted / 1e2
 				}
 				data = append(data, ar)

--- a/tariff/amber/types.go
+++ b/tariff/amber/types.go
@@ -2,18 +2,25 @@ package amber
 
 const URI = "https://api.amber.com.au/v1/sites/%s/prices?resolution=30"
 
+type AdvancedPrice struct {
+	Low       float64 `json:"low"`
+	Predicted float64 `json:"predicted"`
+	High      float64 `json:"high"`
+}
+
 type PriceInfo struct {
-	Type        string  `json:"type"`
-	Date        string  `json:"date"`
-	Duration    int     `json:"duration"`
-	StartTime   string  `json:"startTime"`
-	EndTime     string  `json:"endTime"`
-	NemTime     string  `json:"nemTime"`
-	PerKwh      float64 `json:"perKwh"`
-	Renewables  float64 `json:"renewables"`
-	SpotPerKwh  float64 `json:"spotPerKwh"`
-	ChannelType string  `json:"channelType"`
-	SpikeStatus string  `json:"spikeStatus"`
-	Descriptor  string  `json:"descriptor"`
-	Estimate    bool    `json:"estimate"`
+	Type          string         `json:"type"`
+	Date          string         `json:"date"`
+	Duration      int            `json:"duration"`
+	StartTime     string         `json:"startTime"`
+	EndTime       string         `json:"endTime"`
+	NemTime       string         `json:"nemTime"`
+	PerKwh        float64        `json:"perKwh"`
+	Renewables    float64        `json:"renewables"`
+	SpotPerKwh    float64        `json:"spotPerKwh"`
+	ChannelType   string         `json:"channelType"`
+	SpikeStatus   string         `json:"spikeStatus"`
+	Descriptor    string         `json:"descriptor"`
+	Estimate      bool           `json:"estimate"`
+	AdvancedPrice *AdvancedPrice `json:"advancedPrice,omitempty"`
 }

--- a/templates/definition/tariff/amber.yaml
+++ b/templates/definition/tariff/amber.yaml
@@ -10,10 +10,12 @@ params:
   - name: token
   - name: siteid
   - name: channel
+  - name: useAdvancedPrice
   - preset: tariff-base
 render: |
   type: amber
   token: {{ .token }}
   siteid: {{ .siteid }}
   channel: {{ .channel }}
+  useAdvancedPrice: {{ .useAdvancedPrice }}
   {{ include "tariff-base" . }}

--- a/templates/definition/tariff/amber.yaml
+++ b/templates/definition/tariff/amber.yaml
@@ -10,12 +10,10 @@ params:
   - name: token
   - name: siteid
   - name: channel
-  - name: useAdvancedPrice
   - preset: tariff-base
 render: |
   type: amber
   token: {{ .token }}
   siteid: {{ .siteid }}
   channel: {{ .channel }}
-  useAdvancedPrice: {{ .useAdvancedPrice }}
   {{ include "tariff-base" . }}


### PR DESCRIPTION
Amber has an advanced price in the api for predicted prices, this pr adds a boolean configuration option `useAdvancedPrice` 

it's disabled by default but if enabled will allow the charge planner to pick better slots to charge.