### PR TITLE
Ocpp: allow "disable" to override meter value sample

### DIFF
--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -123,12 +123,11 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 
 	// configure measurands
 	if meterValues != "" {
-		if meterValues != "disable" {
-			if err := cp.configure(KeyMeterValuesSampledData, meterValues); err != nil {
-				cp.log.WARN.Printf("failed configuring %s: %v", KeyMeterValuesSampledData, err)
-			}
+		if err := cp.configure(KeyMeterValuesSampledData, meterValues); err == nil || meterValues == "disable" {
+			cp.meterValuesSample = meterValues
+		} else {
+			cp.log.WARN.Printf("failed configuring %s: %v", KeyMeterValuesSampledData, err)
 		}
-		cp.meterValuesSample = meterValues
 	}
 
 	// trigger initial meter values


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/discussions/14138#discussioncomment-10568216

Die Idee hier ist, unabhängig von erfolgreicher Rekonfiguration der Box den String `disable` als override zu nutzen. Alternativ könnten die custom `metervalues` im Fehlerfall _immer_ aktiv wären.