### PR TITLE
sonnenBatterie: implement grid charging

### DIFF
--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -9,10 +9,10 @@ requirements:
   description:
     de: |
       Für die aktive Batteriesteuerung muss über das Webinterface der sonnenBatterie (unter Software-Integration) das "JSON Write API" aktiviert und das dort generierte API-Token in der Batteriekonfiguration unter `token` eingetragen werden.
-      Netzladen ist nicht implementiert.
+      Die Leistung für das Netzladen kann an die Wechselrichterleistung der sonnenBatterie über den Parameter `chargepower` angepasst werden.
     en: |
       For active battery control, the "JSON Write API" must be activated via the sonnenBatterie web interface (under Software-Integration) and the API token generated there must be entered in the battery configuration under `token`.
-      Grid charging is not implemented.
+      The power for grid charging can be adapted to the inverter power of the sonnenBatterie via the `chargepower` parameter.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -27,6 +27,14 @@ params:
     help:
       de: API Token (benötigt für aktive Batteriesteuerung)
       en: API Token (required for active battery control)
+    usages: ["battery"]
+  - name: chargepower
+    default: 3300
+    advanced: true
+    required: false
+    help:
+      de: Ladeleistung für Netzladen in W
+      en: Charging power for grid charging in W
     usages: ["battery"]
 render: |
   type: custom
@@ -88,14 +96,30 @@ render: |
           - Auth-Token: {{ .token }}
     - case: 3 # charge
       set:
-        source: http
-        uri: http://{{ .host }}/api/v2/configurations
-        insecure: true
-        method: PUT
-        headers:
-        - content-type: application/json
-        - Auth-Token: {{ .token }}
-        body: '{"EM_OperatingMode":"2"}'  # self consumption
+        source: sequence
+        set:
+        - source: http
+          uri: http://{{ .host }}/api/v2/configurations
+          insecure: true
+          method: PUT
+          headers:
+          - content-type: application/json
+          - Auth-Token: {{ .token }}
+          body: '{"EM_OperatingMode":"1"}'  # manual
+        - source: http
+          uri: http://{{ .host }}/api/v2/setpoint/discharge/0
+          insecure: true
+          method: POST
+          headers:
+          - content-type: application/json
+          - Auth-Token: {{ .token }}
+        - source: http
+          uri: http://{{ .host }}/api/v2/setpoint/charge/{{ .chargepower }}
+          insecure: true
+          method: POST
+          headers:
+          - content-type: application/json
+          - Auth-Token: {{ .token }}
   {{- end }}
   {{- if .capacity }}
   capacity: {{ .capacity }} # kWh

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -31,7 +31,6 @@ params:
   - name: chargepower
     default: 3300
     advanced: true
-    required: false
     help:
       de: Ladeleistung für Netzladen in W
       en: Charging power for grid charging in W


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/15926

This PR adds the grid charging capability to the existing battery control for sonnenBatterie via official sonnenBatterie JSON APIv2.

The power for grid charging can be adapted to the inverter power of the sonnenBatterie via the `chargepower` configuration parameter (default: 3300W).

This modification has been verified with my sonnenBatterie eco8.