### PR TITLE
Fix Alfen OCPP Authorization Flow

### DIFF
--- a/charger/ocpp/const.go
+++ b/charger/ocpp/const.go
@@ -20,6 +20,7 @@ const (
 	KeyMaxChargingProfilesInstalled            = "MaxChargingProfilesInstalled"
 
 	// Vendor specific keys
+	KeyAlfenAuthorizationMethod     = "AuthorizationMethod"
 	KeyAlfenPlugAndChargeIdentifier = "PlugAndChargeIdentifier"
 	KeyEvBoxSupportedMeasurands     = "evb_SupportedMeasurands"
 )

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -21,6 +21,14 @@ func (cp *CP) Authorize(request *core.AuthorizeRequest) (*core.AuthorizeConfirma
 		},
 	}
 
+	// Set idTag for all connectors in available state
+	for _, conn := range cp.connectors {
+		if conn.status.Status == core.ChargePointStatusAvailable {
+			conn.log.INFO.Printf("Set idTag %v from Authorization request", request.IdTag)
+			conn.idTag = request.IdTag
+		}
+	}
+
 	return res, nil
 }
 

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -80,10 +80,10 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 
 		// vendor-specific keys
 		case KeyAlfenPlugAndChargeIdentifier:
-			authMethod, exists := getConfigurationValue(resp, KeyAlfenAuthorizationMethod)
+			authMethod, ok := getConfigurationValue(resp, KeyAlfenAuthorizationMethod)
 
 			// Override `idTag` with plug-and-charge id if PLUG_AND_CHARGE is configured
-			if exists && authMethod != "RFID" {
+			if ok && authMethod != "RFID" {
 				cp.IdTag = *opt.Value
 				cp.log.DEBUG.Printf("Alfen-specific: overriding `idTag` with PLUG_AND_CHARGE value: %s", cp.IdTag)
 			}


### PR DESCRIPTION
Hallo, erstmal Danke für all die Arbeit / Zeit die Ihr in evcc steckt. Ich habe selten solche gut maintainten Open Source Projekte gesehen 👍 

_Hier auch die Warnung bzw. der Hinweiss das ich wenig Erfahrung mit go habe und gerade deswegen äusserst Dankbar für jegliches Feedback / Änderungsvorschläge bin._

**Jetzt zum eigentlichen PR**

Ich habe versucht meine Alfen Wallbox über OCPP mit evcc zu verbinden und hatte hierbei einige Probleme die ich mit diesem PR beheben möchte.

**1. ID Tag - OCPP Authorize (Enhancement)**

Die Alfen Wallbox sendet leider nur den ID Tag beim `Authorize` request, hier gab es bereits ein [Issue](https://github.com/evcc-io/evcc/issues/14579) in dem besprochen wurde das man hierbei ja einfach den IdTag am Connector setzten könnte was zumindest im Fall von einem einzelnen Connector kein Problem darstellen sollte. Irgendwie scheint sich dieses Issue jedoch im Sand verlaufen zu haben bzw. wurde durch einen anderen [PR](https://github.com/evcc-io/evcc/pull/14733) geschlossen der aber an der `Authorize` function nichts veränderte.

Mein Gedanke war das es eigentlich kein Problem sein sollte für alle verfügbaren Connectors den idTag zu setzten. Hierdurch werden laufende Ladevorgänge nicht verändert. 

Vermutlich ist mit dem check auf `ChargePointStatusAvailable` nicht jeder Randfall abgedeckt, hier wäre euer Feedback also sehr wichtig. 
Alternativ könnte man auch einfach wie ursprünglich besprochen prüfen ob es nur einen Connector gibt und nur dann die ID setzten.

Zum Thema OCPP Auth hatte ich mich auch gefragt ob etwas gegen eine einfache "authorized_tags" Liste in der config sprechen würde? Ist nichts für diesen PR aber wenn das für euch gut klingt würde ich das implementieren.

**2. Alfen - Plug and Charge (Bugfix)**

Der Alfen `PlugAndChargeIdentifier` überschreibt immer den IdTag des Connectors. 
In nicht eichrechtskonformen Alfen Wallboxen lässt sich "Plug and Charge" aktivieren, hierzu muss man in der Wallbox eine ID hinterlegen die dann anstelle der RFID Tag ID gesetzt wird. Das Problem an der aktuellen Implementierung in evcc hierbei ist das immer die PlugAndCharge ID verwendet wird auch wenn das Feature nicht aktiv ist.

Die sauberste Lösung hierzu wäre vermutlich den `AuthorizationMethod` zu checken der in der selben OCPP Response vorhanden ist, im RFID Tag Fall wird hier "RFID" gesetzt. Den Plug and Change Fall konnte ich leider nicht testen da ich eine Eichrechtskonforme Wallbox habe und dort seit einigen Firmware Versionen Plug and Change nichtmehr zur Verfügung steht.

Danke für eurer Feedback!

VG,
Florian