### PR TITLE
Charger Delta AC Max: fix AC Max Basic Charger Status mapping

### DIFF
--- a/charger/delta.go
+++ b/charger/delta.go
@@ -162,11 +162,11 @@ func (wb *Delta) statusDelta() (api.ChargeStatus, error) {
 	// 7: Charging ended with error (vehicle still connected)
 
 	switch s := encoding.Uint16(b); s {
-	case 0, 1, 2:
+	case 0:
 		return api.StatusA, nil
 	case 3:
 		return api.StatusC, nil
-	case 4, 5, 6, 7:
+	case 1, 2, 4, 5, 6, 7:
 		return api.StatusB, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %0x", s)


### PR DESCRIPTION
Fix Status mapping for AC Max basic (func statusDelta) based on 0.128.4. Value 1 and 2 mapped to Charger Status B instead of A based on official Modbus documentation from Delta and old status mapping used in evcc up to 0.128.4 which is confirmed to work correctly.