### PR TITLE
Easee: obey current limits based on charger configuration

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -112,16 +112,15 @@ func NewEasee(user, password, charger string, timeout time.Duration, authorize b
 	done := make(chan struct{})
 
 	c := &Easee{
-		Helper:            request.NewHelper(log),
-		charger:           charger,
-		authorize:         authorize,
-		log:               log,
-		maxChargerCurrent: 6, // save default, will be overwritten by cloud config once fetched
-		current:           6, // default current
-		startDone:         sync.OnceFunc(func() { close(done) }),
-		cmdC:              make(chan easee.SignalRCommandResponse),
-		obsC:              make(chan easee.Observation),
-		obsTime:           make(map[easee.ObservationID]time.Time),
+		Helper:    request.NewHelper(log),
+		charger:   charger,
+		authorize: authorize,
+		log:       log,
+		current:   6, // default current
+		startDone: sync.OnceFunc(func() { close(done) }),
+		cmdC:      make(chan easee.SignalRCommandResponse),
+		obsC:      make(chan easee.Observation),
+		obsTime:   make(map[easee.ObservationID]time.Time),
 	}
 
 	c.Client.Timeout = timeout
@@ -652,7 +651,10 @@ func (c *Easee) waitForDynamicChargerCurrent(targetCurrent float64) error {
 
 // MaxCurrent implements the api.Charger interface
 func (c *Easee) MaxCurrent(current int64) error {
-	cur := min(float64(current), c.maxChargerCurrent)
+	cur := float64(current)
+	if c.maxChargerCurrent != 0 {
+		cur = min(cur, c.maxChargerCurrent)
+	}
 	data := easee.ChargerSettings{
 		DynamicChargerCurrent: &cur,
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -50,6 +50,7 @@ type Easee struct {
 	log                     *util.Logger
 	mux                     sync.RWMutex
 	lastEnergyPollMux       sync.Mutex
+	maxChargerCurrent       float64
 	dynamicChargerCurrent   float64
 	current                 float64
 	chargerEnabled          bool
@@ -314,6 +315,8 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 		c.phaseMode = value.(int)
 	case easee.OUTPUT_PHASE:
 		c.outputPhase = value.(int) / 10 // API gives 0,10,30 for 0,1,3p
+	case easee.MAX_CHARGER_CURRENT:
+		c.maxChargerCurrent = value.(float64)
 	case easee.DYNAMIC_CHARGER_CURRENT:
 		c.dynamicChargerCurrent = value.(float64)
 
@@ -648,7 +651,7 @@ func (c *Easee) waitForDynamicChargerCurrent(targetCurrent float64) error {
 
 // MaxCurrent implements the api.Charger interface
 func (c *Easee) MaxCurrent(current int64) error {
-	cur := float64(current)
+	cur := min(float64(current), c.maxChargerCurrent)
 	data := easee.ChargerSettings{
 		DynamicChargerCurrent: &cur,
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -112,15 +112,16 @@ func NewEasee(user, password, charger string, timeout time.Duration, authorize b
 	done := make(chan struct{})
 
 	c := &Easee{
-		Helper:    request.NewHelper(log),
-		charger:   charger,
-		authorize: authorize,
-		log:       log,
-		current:   6, // default current
-		startDone: sync.OnceFunc(func() { close(done) }),
-		cmdC:      make(chan easee.SignalRCommandResponse),
-		obsC:      make(chan easee.Observation),
-		obsTime:   make(map[easee.ObservationID]time.Time),
+		Helper:            request.NewHelper(log),
+		charger:           charger,
+		authorize:         authorize,
+		log:               log,
+		maxChargerCurrent: 6, // save default, will be overwritten by cloud config once fetched
+		current:           6, // default current
+		startDone:         sync.OnceFunc(func() { close(done) }),
+		cmdC:              make(chan easee.SignalRCommandResponse),
+		obsC:              make(chan easee.Observation),
+		obsTime:           make(map[easee.ObservationID]time.Time),
 	}
 
 	c.Client.Timeout = timeout


### PR DESCRIPTION
fix #15556

Note: This change serves the purpose of preventing evcc to request higher currents than allowed according to the site/circuit configuration on the Easee side. One would expect (hope?) that the charger simply ignores (or limits) requests above the configured amps allowed according to the installation. Based on the protocols shared in the linked case however, it seems that requests above the physical limits, cause erratic charger behavior (possibly resets). 

This change does not replace the limits configured in the loadpoint. It purely serves as a safe guard in case the loadpoint configuration's current range does not match with the charger's.