### PR TITLE
Update evcc.dist.yaml

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -114,7 +114,7 @@ site:
 loadpoints:
   - title: Garage # display name for UI
     charger: wallbe # charger
-    meter: charge # charge meter
+    meter: charge # external charge meter (if charger has no meter included). NOT grid or pv meter.
     mode: "off" # default charge mode to apply when vehicle is disconnected; use "off" to disable by default if charger is publicly available
 
     # remaining settings are experts-only and best left at default values


### PR DESCRIPTION
Klarstellung, weil es immer wieder vorkommt, dass dort ein Verweis auf das Grid Meter eingetragen wird, was dann zu unplausiblen Ladeleistungen führt.
Z.B.  https://github.com/evcc-io/evcc/discussions/16138