### PR TITLE
PSA: delete token from settings db if invalid

### DIFF
--- a/vehicle/psa/identity.go
+++ b/vehicle/psa/identity.go
@@ -71,6 +71,9 @@ func (v *Identity) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 
 	tok, err := v.oc.TokenSource(ctx, token).Token()
 	if err != nil {
+		if strings.Contains(err.Error(), "invalid_grant") {
+			settings.Delete(v.subject)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
If there is already a token stored in the settings DB, it is always prioritized over the token in the config.
So, if the token in the DB got invalid for some reason, it is necessary to manually delete it from the settings DB before a new token can be set via the config.
This isn't a easy task and many users struggle with it, see: https://github.com/evcc-io/evcc/discussions/13685
Probably sometimes it is actually impossible if there is no CLI access available (HA installations?).

This simple change automatically deletes the token from the settings DB if it is invalid (token refresh results in error: 'oauth2: "invalid_grant" "grant is invalid"').
So, at the next try it will use the token from the config again.