### PR TITLE
Ocpp: allow specifying measurements to remove

### DIFF
--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/samber/lo"
 )
 
 const desiredMeasurands = "Power.Active.Import,Energy.Active.Import.Register,Current.Import,Voltage,Current.Offered,Power.Offered,SoC"
@@ -86,6 +87,11 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 		case KeyEvBoxSupportedMeasurands:
 			if meterValues == "" {
 				meterValues = *opt.Value
+			} else if remove, ok := strings.CutPrefix(meterValues, "-"); ok {
+				// remove a single offending measurand
+				meterValues = strings.Join(lo.Reject(strings.Split(*opt.Value, ","), func(v string, _ int) bool {
+					return v == remove
+				}), ",")
 			}
 		}
 	}

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -60,9 +60,7 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 			}
 			if remove, ok := strings.CutPrefix(meterValues, "-"); ok {
 				// remove a single offending measurand
-				cp.meterValuesSample = strings.Join(lo.Reject(strings.Split(*opt.Value, ","), func(v string, _ int) bool {
-					return v == remove
-				}), ",")
+				cp.meterValuesSample = strings.Join(lo.Without(strings.Split(*opt.Value, ","), strings.Split(remove, ",")...), ",")
 				meterValues = ""
 			} else {
 				cp.meterValuesSample = *opt.Value

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -58,7 +58,15 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 			if opt.Readonly {
 				meterValuesSampledDataMaxLength = 0
 			}
-			cp.meterValuesSample = *opt.Value
+			if remove, ok := strings.CutPrefix(meterValues, "-"); ok {
+				// remove a single offending measurand
+				cp.meterValuesSample = strings.Join(lo.Reject(strings.Split(*opt.Value, ","), func(v string, _ int) bool {
+					return v == remove
+				}), ",")
+				meterValues = ""
+			} else {
+				cp.meterValuesSample = *opt.Value
+			}
 
 		case KeyMeterValuesSampledDataMaxLength:
 			if val, err := strconv.Atoi(*opt.Value); err == nil {
@@ -87,11 +95,6 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 		case KeyEvBoxSupportedMeasurands:
 			if meterValues == "" {
 				meterValues = *opt.Value
-			} else if remove, ok := strings.CutPrefix(meterValues, "-"); ok {
-				// remove a single offending measurand
-				meterValues = strings.Join(lo.Reject(strings.Split(*opt.Value, ","), func(v string, _ int) bool {
-					return v == remove
-				}), ",")
 			}
 		}
 	}

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -59,7 +59,7 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 				meterValuesSampledDataMaxLength = 0
 			}
 			if remove, ok := strings.CutPrefix(meterValues, "-"); ok {
-				// remove a single offending measurand
+				// remove offending measurands
 				cp.meterValuesSample = strings.Join(lo.Without(strings.Split(*opt.Value, ","), strings.Split(remove, ",")...), ",")
 				meterValues = ""
 			} else {


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/discussions/15986#discussioncomment-10674428. Use like:

    metervalues: -Current.Offered

to keep all metervalues from auto configuration except `Current.Offered`.

Using `-` instead of `!` because it works better with yaml.