### PR TITLE
fix tesla fleet api base url detection

### DIFF
--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -82,7 +82,13 @@ func NewTeslaFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 	// validate base url
 	region, err := tc.UserRegion()
 	if err != nil {
-		return nil, err
+		// Set the base URL to the European region and try again
+		// China region still not supported
+		tc.SetBaseUrl(teslaclient.FleetAudienceEU)
+		region, err = tc.UserRegion()
+		if err != nil {
+			return nil, err
+		}
 	}
 	tc.SetBaseUrl(region.FleetApiBaseUrl)
 


### PR DESCRIPTION
fix tesla fleet api base url when profile not in NA by making an extra request to EU if the first one failed (China region still not supported)

Currently it uses NA only and tries to get region from there but it will fail with following error when profile not in NA

```
[tesla ] TRACE 2024/09/20 11:34:00 GET https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/users/region
[tesla ] TRACE 2024/09/20 11:34:00 {"error":"Account *** must be registered in the current region https://fleet-api.prd.na.vn.cloud.tesla.com, please see https://developer.tesla.com/docs/fleet-api/endpoints/partner-endpoints#register"}
```

This is only needed when running a custom tesla http proxy server (not the centralized evcc one).
#16230 