### PR TITLE
Ocpp: fix duplicate init

### DIFF
--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -80,12 +80,13 @@ func (cs *CS) RegisterChargepoint(id string, newfun func() *CP, init func(*CP) e
 	cpmu.Lock()
 	defer cpmu.Unlock()
 
-	cp, err := cs.ChargepointByID(id)
-	if err != nil {
-		cp = newfun()
+	// already registered?
+	if cp, err := cs.ChargepointByID(id); err == nil {
+		return cp, nil
 	}
 
-	// should not error
+	// first time- registration should not error
+	cp := newfun()
 	if err := cs.register(id, cp); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Follow-up to https://github.com/evcc-io/evcc/pull/16262. That PR accidentally setup the loadpoint multiple times, once for each connector.