### PR TITLE
Ocpp: deduplicate event handlers

### DIFF
--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
@@ -13,16 +12,6 @@ var (
 	ErrInvalidConnector   = errors.New("invalid connector")
 	ErrInvalidTransaction = errors.New("invalid transaction")
 )
-
-func (cp *CP) OnAuthorize(request *core.AuthorizeRequest) (*core.AuthorizeConfirmation, error) {
-	res := &core.AuthorizeConfirmation{
-		IdTagInfo: &types.IdTagInfo{
-			Status: types.AuthorizationStatusAccepted,
-		},
-	}
-
-	return res, nil
-}
 
 func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
 	res := &core.BootNotificationConfirmation{
@@ -38,14 +27,6 @@ func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.B
 	return res, nil
 }
 
-func (cp *CP) OnDiagnosticStatusNotification(request *firmware.DiagnosticsStatusNotificationRequest) (*firmware.DiagnosticsStatusNotificationConfirmation, error) {
-	return new(firmware.DiagnosticsStatusNotificationConfirmation), nil
-}
-
-func (cp *CP) OnFirmwareStatusNotification(request *firmware.FirmwareStatusNotificationRequest) (*firmware.FirmwareStatusNotificationConfirmation, error) {
-	return new(firmware.FirmwareStatusNotificationConfirmation), nil
-}
-
 func (cp *CP) OnStatusNotification(request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {
 	if request == nil {
 		return nil, ErrInvalidRequest
@@ -56,22 +37,6 @@ func (cp *CP) OnStatusNotification(request *core.StatusNotificationRequest) (*co
 	}
 
 	return new(core.StatusNotificationConfirmation), nil
-}
-
-func (cp *CP) OnDataTransfer(request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
-	res := &core.DataTransferConfirmation{
-		Status: core.DataTransferStatusAccepted,
-	}
-
-	return res, nil
-}
-
-func (cp *CP) OnHeartbeat(request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
-	res := &core.HeartbeatConfirmation{
-		CurrentTime: types.Now(),
-	}
-
-	return res, nil
 }
 
 func (cp *CP) OnMeterValues(request *core.MeterValuesRequest) (*core.MeterValuesConfirmation, error) {

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -2,7 +2,6 @@ package ocpp
 
 import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
@@ -32,14 +31,6 @@ func (cs *CS) OnHeartbeat(id string, request *core.HeartbeatRequest) (*core.Hear
 	}
 
 	return res, nil
-}
-
-func (cs *CS) OnDiagnosticsStatusNotification(id string, request *firmware.DiagnosticsStatusNotificationRequest) (confirmation *firmware.DiagnosticsStatusNotificationConfirmation, err error) {
-	return new(firmware.DiagnosticsStatusNotificationConfirmation), nil
-}
-
-func (cs *CS) OnFirmwareStatusNotification(id string, request *firmware.FirmwareStatusNotificationRequest) (confirmation *firmware.FirmwareStatusNotificationConfirmation, err error) {
-	return new(firmware.FirmwareStatusNotificationConfirmation), nil
 }
 
 // cp actions - local handlers

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -5,13 +5,27 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
-// cp actions - global handlers
+// cp actions
 
 func (cs *CS) OnAuthorize(id string, request *core.AuthorizeRequest) (*core.AuthorizeConfirmation, error) {
 	res := &core.AuthorizeConfirmation{
 		IdTagInfo: &types.IdTagInfo{
 			Status: types.AuthorizationStatusAccepted,
 		},
+	}
+
+	return res, nil
+}
+
+func (cs *CS) OnBootNotification(id string, request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
+	if cp, err := cs.ChargepointByID(id); err == nil {
+		return cp.OnBootNotification(request)
+	}
+
+	res := &core.BootNotificationConfirmation{
+		CurrentTime: types.Now(),
+		Interval:    60,
+		Status:      core.RegistrationStatusPending, // not accepted during startup
 	}
 
 	return res, nil
@@ -28,22 +42,6 @@ func (cs *CS) OnDataTransfer(id string, request *core.DataTransferRequest) (*cor
 func (cs *CS) OnHeartbeat(id string, request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
 	res := &core.HeartbeatConfirmation{
 		CurrentTime: types.Now(),
-	}
-
-	return res, nil
-}
-
-// cp actions - local handlers
-
-func (cs *CS) OnBootNotification(id string, request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
-	if cp, err := cs.ChargepointByID(id); err == nil {
-		return cp.OnBootNotification(request)
-	}
-
-	res := &core.BootNotificationConfirmation{
-		CurrentTime: types.Now(),
-		Interval:    60,
-		Status:      core.RegistrationStatusPending, // not accepted during startup
 	}
 
 	return res, nil

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -3,18 +3,46 @@ package ocpp
 import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
-// cp actions
+// cp actions - global handlers
 
 func (cs *CS) OnAuthorize(id string, request *core.AuthorizeRequest) (*core.AuthorizeConfirmation, error) {
-	cp, err := cs.ChargepointByID(id)
-	if err != nil {
-		return nil, err
+	res := &core.AuthorizeConfirmation{
+		IdTagInfo: &types.IdTagInfo{
+			Status: types.AuthorizationStatusAccepted,
+		},
 	}
 
-	return cp.OnAuthorize(request)
+	return res, nil
 }
+
+func (cs *CS) OnDataTransfer(id string, request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
+	res := &core.DataTransferConfirmation{
+		Status: core.DataTransferStatusAccepted,
+	}
+
+	return res, nil
+}
+
+func (cs *CS) OnHeartbeat(id string, request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
+	res := &core.HeartbeatConfirmation{
+		CurrentTime: types.Now(),
+	}
+
+	return res, nil
+}
+
+func (cs *CS) OnDiagnosticsStatusNotification(id string, request *firmware.DiagnosticsStatusNotificationRequest) (confirmation *firmware.DiagnosticsStatusNotificationConfirmation, err error) {
+	return new(firmware.DiagnosticsStatusNotificationConfirmation), nil
+}
+
+func (cs *CS) OnFirmwareStatusNotification(id string, request *firmware.FirmwareStatusNotificationRequest) (confirmation *firmware.FirmwareStatusNotificationConfirmation, err error) {
+	return new(firmware.FirmwareStatusNotificationConfirmation), nil
+}
+
+// cp actions - local handlers
 
 func (cs *CS) OnBootNotification(id string, request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
 	cp, err := cs.ChargepointByID(id)
@@ -23,24 +51,6 @@ func (cs *CS) OnBootNotification(id string, request *core.BootNotificationReques
 	}
 
 	return cp.OnBootNotification(request)
-}
-
-func (cs *CS) OnDataTransfer(id string, request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
-	cp, err := cs.ChargepointByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	return cp.OnDataTransfer(request)
-}
-
-func (cs *CS) OnHeartbeat(id string, request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
-	cp, err := cs.ChargepointByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	return cp.OnHeartbeat(request)
 }
 
 func (cs *CS) OnMeterValues(id string, request *core.MeterValuesRequest) (*core.MeterValuesConfirmation, error) {
@@ -77,22 +87,4 @@ func (cs *CS) OnStopTransaction(id string, request *core.StopTransactionRequest)
 	}
 
 	return cp.OnStopTransaction(request)
-}
-
-func (cs *CS) OnDiagnosticsStatusNotification(id string, request *firmware.DiagnosticsStatusNotificationRequest) (confirmation *firmware.DiagnosticsStatusNotificationConfirmation, err error) {
-	cp, err := cs.ChargepointByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	return cp.OnDiagnosticStatusNotification(request)
-}
-
-func (cs *CS) OnFirmwareStatusNotification(id string, request *firmware.FirmwareStatusNotificationRequest) (confirmation *firmware.FirmwareStatusNotificationConfirmation, err error) {
-	cp, err := cs.ChargepointByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	return cp.OnFirmwareStatusNotification(request)
 }

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -8,6 +8,8 @@ import (
 // cp actions
 
 func (cs *CS) OnAuthorize(id string, request *core.AuthorizeRequest) (*core.AuthorizeConfirmation, error) {
+	// no cp handler
+
 	res := &core.AuthorizeConfirmation{
 		IdTagInfo: &types.IdTagInfo{
 			Status: types.AuthorizationStatusAccepted,
@@ -32,6 +34,8 @@ func (cs *CS) OnBootNotification(id string, request *core.BootNotificationReques
 }
 
 func (cs *CS) OnDataTransfer(id string, request *core.DataTransferRequest) (*core.DataTransferConfirmation, error) {
+	// no cp handler
+
 	res := &core.DataTransferConfirmation{
 		Status: core.DataTransferStatusAccepted,
 	}
@@ -40,6 +44,8 @@ func (cs *CS) OnDataTransfer(id string, request *core.DataTransferRequest) (*cor
 }
 
 func (cs *CS) OnHeartbeat(id string, request *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
+	// no cp handler
+
 	res := &core.HeartbeatConfirmation{
 		CurrentTime: types.Now(),
 	}


### PR DESCRIPTION
This PR moves all cp event handlers to cs where logic is globally handled