### PR TITLE
Update types.go to match new API url for Discovergy meters

### DIFF
--- a/meter/discovergy/types.go
+++ b/meter/discovergy/types.go
@@ -1,6 +1,6 @@
 package discovergy
 
-const API = "https://api.discovergy.com/public/v1"
+const API = "https://api.inexogy.com/public/v1"
 
 type Meter struct {
 	MeterID          string `json:"meterId"`


### PR DESCRIPTION
The API url has changed from api.discovery.com to api.inexogy.com. This change needs to be applied to the EVCC type.