### PR TITLE
E3/DC: make credentials required

### DIFF
--- a/templates/definition/meter/e3dc-rscp.yaml
+++ b/templates/definition/meter/e3dc-rscp.yaml
@@ -20,8 +20,11 @@ params:
   - name: port
     default: 5033
   - name: user
+    required: true
   - name: password
+    required: true
   - name: key
+    required: true
   - name: battery
     deprecated: true
   - name: dischargelimit


### PR DESCRIPTION
Credentials are always required when trying to access the E3/DC via RSCP. This PR should remove the `(optional)` in the docs, but please correct me if I'm wrong.