### PR TITLE
Chore: add missing dependencies to DEB package definition

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -1,3 +1,5 @@
+version: 2
+
 dist: release
 release:
   disable: true
@@ -72,6 +74,9 @@ nfpms:
 
     formats:
       - deb
+
+    dependencies:
+      - adduser
 
     contents:
       - src: ./packaging/init/evcc.service

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,6 +81,9 @@ nfpms:
     formats:
       - deb
 
+    dependencies:
+      - adduser
+
     contents:
       - src: ./packaging/init/evcc.service
         dst: /lib/systemd/system/evcc.service


### PR DESCRIPTION
While fiddling with our deb package in an isolated environment, I realized that the dependency to the adduser package (via the pre/post install scripts) is not expressed.