### PR TITLE
Awattar: fetch more than 24h price data

### DIFF
--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -64,8 +64,8 @@ func (t *Awattar) run(done chan error) {
 
 		// Awattar publishes prices for next day around 13:00 CET/CEST, so up to 35h of price data are available
 		// To be on the safe side request a window of -2h and +48h, the API doesn't mind requesting more than available
-		start := time.Now().Add(-time.Hour * 2).UnixMilli()
-		end := time.Now().Add(time.Hour * 48).UnixMilli()
+		start := time.Now().Add(-2 * time.Hour).UnixMilli()
+		end := time.Now().Add(48 * time.Hour).UnixMilli()
 		uri := fmt.Sprintf("%s?start=%d&end=%d", t.uri, start, end)
 
 		if err := backoff.Retry(func() error {

--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -62,8 +62,14 @@ func (t *Awattar) run(done chan error) {
 	for ; true; <-tick.C {
 		var res awattar.Prices
 
+		// Awattar publishes prices for next day around 13:00 CET/CEST, so up to 35h of price data are available
+		// To be on the safe side request a window of -2h and +48h, the API doesn't mind requesting more than available
+		start := time.Now().Add(-time.Hour * 2).UnixMilli()
+		end := time.Now().Add(time.Hour * 48).UnixMilli()
+		uri := fmt.Sprintf("%s?start=%d&end=%d", t.uri, start, end)
+
 		if err := backoff.Retry(func() error {
-			return backoffPermanentError(client.GetJSON(t.uri, &res))
+			return backoffPermanentError(client.GetJSON(uri, &res))
 		}, bo()); err != nil {
 			once.Do(func() { done <- err })
 


### PR DESCRIPTION
Currently the Awattar API call is unparametrized, which fetches the price for the next 24 hours.

Awattar publishes the prices for the next day around noon, so up to 35 hours of price data can be availible. The Awattar API also supports fetching more than 24 hours by parametrizing the API call with `start` and `end` timestamps.

This change makes all future price data available to evcc. This is important if you plan a charge to finish on the next day in the evening.

---

before:
![grafik](https://github.com/user-attachments/assets/7a9e4e4a-4ddf-4e6d-ba5b-f153f0252405)

after:
![grafik](https://github.com/user-attachments/assets/165b52ed-5e38-460a-b246-991a29177f70)
