### PR TITLE
add template kostal-plenticore-gen1 to fix missing modbus reset functionality of Gen.1 hardware version

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen1.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen1.yaml
@@ -2,7 +2,7 @@ template: kostal-plenticore-gen1
 products:
   - brand: Kostal
     description:
-      generic: Plenticore Hybrid (Gen.1)
+      generic: Plenticore Hybrid (auch G1)
 capabilities: ["battery-control"]
 linked:
   - template: kostal-ksem-inverter
@@ -13,9 +13,9 @@ linked:
 requirements:
   description:
     de: |
-      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. Die Netzladung steht in diesem Template nicht zur Verfügung. Kompatibel mit Gen.1/2/3 Wechselrichtern.
+      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. Die Netzladung steht in diesem Template nicht zur Verfügung. Kompatibel auch mit Gen.1 Wechselrichtern.
     en: |
-      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access. The function for grid charging the battery is not possible with this template. Compatibilty with gen.1/2/3 inverters.
+      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access. The function for grid charging the battery is not possible with this template. Compatibilty also with gen.1 inverters.
 params:
   - name: usage
     choice: ["pv", "battery"]

--- a/templates/definition/meter/kostal-plenticore-gen1.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen1.yaml
@@ -40,10 +40,10 @@ params:
     advanced: true
   - name: maxsoc
     type: number
-    advanced: true  
+    advanced: true
   - name: watchdog
     type: duration
-    default: 60s	
+    default: 60s
     advanced: true
 render: |
   {{- if eq .usage "pv" }}
@@ -88,5 +88,5 @@ render: |
         encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
-  maxsoc: {{ .maxsoc }} # %  
+  maxsoc: {{ .maxsoc }} # %
   {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen1.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen1.yaml
@@ -13,9 +13,9 @@ linked:
 requirements:
   description:
     de: |
-      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. Die Netzladung steht in diesem Template nicht zur Verfügung.
+      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. Die Netzladung steht in diesem Template nicht zur Verfügung. Kompatibel mit Gen.1/2/3 Wechselrichtern.
     en: |
-      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access. The function for grid charging the battery is not possible with this template.
+      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access. The function for grid charging the battery is not possible with this template. Compatibilty with gen.1/2/3 inverters.
 params:
   - name: usage
     choice: ["pv", "battery"]

--- a/templates/definition/meter/kostal-plenticore-gen1.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen1.yaml
@@ -77,15 +77,15 @@ render: |
     {{- include "modbus" . | indent 2 }}
     value: 802:SoC # 802 battery control
   limitsoc:
-	source: watchdog
-	timeout: {{ .watchdog }} # re-write at timeout/2
-	set:
-	  source: modbus
-	  {{- include "modbus" . | indent 4 }}
-	  register:
-	    address: 1042 # limit soc
-	    type: writemultiple
-	    encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+    source: watchdog
+    timeout: {{ .watchdog }} # re-write at timeout/2
+    set:
+      source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 1042 # limit soc
+        type: writemultiple
+        encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %  

--- a/templates/definition/meter/kostal-plenticore-gen1.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen1.yaml
@@ -1,0 +1,92 @@
+template: kostal-plenticore-gen1
+products:
+  - brand: Kostal
+    description:
+      generic: Plenticore Hybrid (Gen.1)
+capabilities: ["battery-control"]
+deprecated: true
+linked:
+  - template: kostal-ksem-inverter
+    usage: grid
+  - template: kostal-ksem
+    usage: grid
+    excludetemplate: kostal-ksem-inverter
+requirements:
+  description:
+    de: |
+      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. Die Netzladung steht in diesem Template nicht zur Verfügung.
+    en: |
+      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access. The function for grid charging the battery is not possible with this template.
+params:
+  - name: usage
+    choice: ["pv", "battery"]
+    allinone: true
+  - name: modbus
+    choice: ["tcpip"]
+    id: 71
+    port: 1502
+  - name: endianness
+    description:
+      de: Byte-Reihenfolge (Little/Big)
+      en: Endianness (Little/Big)
+    validvalues: ["big", "little"]
+    default: little
+    advanced: true
+  - name: capacity
+    advanced: true
+  # battery control
+  - name: minsoc
+    type: number
+    advanced: true
+  - name: maxsoc
+    type: number
+    advanced: true  
+  - name: watchdog
+    type: duration
+    default: 60s	
+    advanced: true
+render: |
+  {{- if eq .usage "pv" }}
+  type: custom
+  power:
+    source: calc
+    add: # The add plugin sums up all string values
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      value: 160:1:DCW # string 1
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      value: 160:2:DCW # string 2
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      value: 160:3:DCW # string 3
+  energy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 103:WH # total yield
+    scale: 0.001
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  type: custom
+  power:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 802:W # 802 battery control
+  soc:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 802:SoC # 802 battery control
+  limitsoc:
+	source: watchdog
+	timeout: {{ .watchdog }} # re-write at timeout/2
+	set:
+	  source: modbus
+	  {{- include "modbus" . | indent 4 }}
+	  register:
+	    address: 1042 # limit soc
+	    type: writemultiple
+	    encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+  capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }} # %
+  maxsoc: {{ .maxsoc }} # %  
+  {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen1.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen1.yaml
@@ -4,7 +4,6 @@ products:
     description:
       generic: Plenticore Hybrid (Gen.1)
 capabilities: ["battery-control"]
-deprecated: true
 linked:
   - template: kostal-ksem-inverter
     usage: grid

--- a/templates/definition/meter/kostal-plenticore-nogridcharge.yaml
+++ b/templates/definition/meter/kostal-plenticore-nogridcharge.yaml
@@ -2,7 +2,7 @@ template: kostal-plenticore-nogridcharge
 products:
   - brand: Kostal
     description:
-      generic: Plenticore Hybrid (auch G1)
+      generic: Plenticore Hybrid (Gen.1+)
 capabilities: ["battery-control"]
 requirements:
   description:

--- a/templates/definition/meter/kostal-plenticore-nogridcharge.yaml
+++ b/templates/definition/meter/kostal-plenticore-nogridcharge.yaml
@@ -1,0 +1,62 @@
+template: kostal-plenticore-nogridcharge
+products:
+  - brand: Kostal
+    description:
+      generic: Plenticore Hybrid (auch G1)
+capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. Die Netzladung steht in diesem Template nicht zur Verfügung. Kompatibel auch mit Gen.1 Wechselrichtern.
+    en: |
+      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access. The function for grid charging the battery is not possible with this template. Compatibilty also with gen.1 inverters.
+params:
+  - name: usage
+    choice: ["battery"]
+  - name: modbus
+    choice: ["tcpip"]
+    id: 71
+    port: 1502
+  - name: endianness
+    description:
+      de: Byte-Reihenfolge (Little/Big)
+      en: Endianness (Little/Big)
+    validvalues: ["big", "little"]
+    default: little
+    advanced: true
+  - name: capacity
+    advanced: true
+  # battery control
+  - name: minsoc
+    type: number
+    advanced: true
+  - name: maxsoc
+    type: number
+    advanced: true
+  - name: watchdog
+    type: duration
+    default: 60s
+    advanced: true
+render: |
+  type: custom
+  power:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 802:W # 802 battery control
+  soc:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 802:SoC # 802 battery control
+  limitsoc:
+    source: watchdog
+    timeout: {{ .watchdog }} # re-write at timeout/2
+    set:
+      source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 1042 # limit soc
+        type: writemultiple
+        encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+  capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }} # %
+  maxsoc: {{ .maxsoc }} # %

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -13,9 +13,9 @@ linked:
 requirements:
   description:
     de: |
-      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein.
+      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. Die Netzladung steht in diesem Template zur Verfügung, ist jedoch aktuell inkompatibel mit Gen.1-Wechselrichtern (z.B. HW Version 0100).
     en: |
-      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access.
+      Only a single system may access the inverter! For active battery control, the external battery control via Modbus must be activated using installer access. The function for grid charging the battery is possible with this template but actually incompatible with gen.1 inverters (e.g. HW version 0100).
 params:
   - name: usage
     choice: ["pv", "battery"]


### PR DESCRIPTION
Die Anpassungen für die Netzladungsfunktion (#15709) basieren auf anderen Registern als vor der Umstellung. Dies führt bei Geräten der ersten Generation (z.B. HW100) und aktueller Firmware (01.x.y) zu Problemen mit der Batteriesteuerung.

Die Ursache liegt in der Handhabung der schreibenden Register. Die externe Batteriesteuerung wird bei Gen.1-Geräten nicht erfolgreich zurückgesetzt.

Die vorherige Steuerung hat das Register 1042 beschrieben. Dieses führt bei Änderung am Wechselrichter nicht zur Umschaltung in die externe Steuerung. Der geschriebene Wert bleibt dauerhaft, bis zum Neustart (?) aktiv. Es ist nötig, die Einstellung mit der im Wechselrichter (WebAPI) identisch einzustellen.

Das Schreiben der Register 1028 oder 1036 aktiviert für die Wechselrichter der ersten und zweiten Generation nachweislich die externe Steuerung. Augenscheinlich wird nur bei der zweiten Generation erfolgreich nach dem Modbus-Timeout wieder in die interne Batteriesteuerung umgeschaltet.

Um die Batteriesperre für die Wechselrichter der ersten Generation wieder zu ermöglichen, müsste der alte Mechanismus (limitsoc) wiederhergestellt werden. 

Es wird eine Korrektur des Herstellers erwartet, die in entsprechender Diskussion (#16302) angefragt wurde.

Varianten zur Problemlösung:
1. PR umsetzen, altes Template parallel wiederherstellen
2. PR ändern, alten Mechanismus in das Template einbauen (z.B. per Parameter und Bedingung)
3. PR zurückweisen und auf eine mögliche Korrektur von Kostal warten