### PR TITLE
Huawei SUN2000: increase grid charge power

### DIFF
--- a/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
+++ b/templates/definition/meter/huawei-sun2000-dongle-powersensor.yaml
@@ -228,7 +228,7 @@ render: |
                 type: writesingle
                 encoding: uint16
           - source: const
-            value: 2500 # W
+            value: 10000 # W
             set: 
               source: modbus
               {{- include "modbus" . | indent 12 }}


### PR DESCRIPTION
Die maximal mögliche Ladeleistung des Huawei LUNA liegt bei 10000. Sollte der installierte Huawei LUNA weniger (2500, 5000 oder 7500) unterstützen, wird automatisch dieser maximale Wert gesetzt.

Entsprechende Tests siehe https://github.com/evcc-io/evcc/discussions/16331