### PR TITLE
Fix docs template warnings

### DIFF
--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -10,14 +10,14 @@
 {{- define "header" }}
   type: template
   template: {{ .Template }}
-  {{- if hasKey . "Usage" }}
+  {{- if . | hasKey  "Usage" }}
   usage: {{ .Usage }}
   {{- end }}
 {{- end }}
 
 {{- define "default" }}
   {{- include "header" . }}
-  {{- $usage := "" }}{{ if hasKey . "Usage" }}{{ $usage = .Usage }}{{ end }}
+  {{- $usage := "" }}{{ if . | hasKey "Usage" }}{{ $usage = .Usage }}{{ end }}
   {{- range .Params }}
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 }}
@@ -29,7 +29,7 @@
 
 {{- define "advanced" }}
   {{- include "header" . }}
-  {{- $usage := "" }}{{ if hasKey . "Usage" }}{{ $usage = .Usage }}{{ end }}
+  {{- $usage := "" }}{{ if . | hasKey  "Usage" }}{{ $usage = .Usage }}{{ end }}
   {{- range .Params }}
   {{- if eq .Name "modbus" }}
   {{- $.Modbus | indent 2 }}
@@ -63,7 +63,7 @@ render:
 {{- if .Usages -}}
 {{- $content := . }}
 {{- range $usage := .Usages }}
-{{- $_ := set $content "Usage" $usage }}
+{{- $_ := $content | set "Usage" $usage }}
   - usage: {{ $usage }}
     default: |
     {{- include "default" $content | indent 4 }}


### PR DESCRIPTION
Fixed warnings in go template files.

```
2024/10/03 02:27:59 WARN Template function `hasKey` is deprecated: The signature of `hasKey` has changed from `{{ hasKey dict key }}` to `{{ dict | hasKey key }}`, please update your code before next upgrade. This change will simplify the usage of the function and respect go/template conventions and allow usage of pipe (`|`). function=hasKey notice=deprecated
```