### PR TITLE
eebus: fixed duplicate template names

### DIFF
--- a/templates/definition/charger/elli-2.yaml
+++ b/templates/definition/charger/elli-2.yaml
@@ -1,4 +1,4 @@
-template: eebus
+template: elli-2
 products:
   - brand: Elli
     description:

--- a/templates/definition/charger/ghost.yaml
+++ b/templates/definition/charger/ghost.yaml
@@ -1,4 +1,4 @@
-template: eebus
+template: ghost
 products:
   - brand: eSystems
     description:

--- a/templates/definition/charger/porsche-wallbox.yaml
+++ b/templates/definition/charger/porsche-wallbox.yaml
@@ -1,4 +1,4 @@
-template: eebus
+template: porsche-wallbox
 products:
   - brand: Porsche
     description:

--- a/util/templates/init.go
+++ b/util/templates/init.go
@@ -84,6 +84,10 @@ func load(class Class) (res []Template) {
 			return fmt.Errorf("processing template '%s' failed: %w", filepath, err)
 		}
 
+		if slices.ContainsFunc(res, func(t Template) bool { return t.Template == tmpl.Template }) {
+			return fmt.Errorf("duplicate template name '%s' found in file '%s'", tmpl.Template, filepath)
+		}
+
 		res = append(res, tmpl)
 
 		return nil


### PR DESCRIPTION
> [via Slack] @DerAndereAndi: Auf https://docs.evcc.io/docs/devices/chargers werden die Elli “Charger Pro 2” und “Charger Connect 2" nicht aufgeführt, obwohl sie im Template vorhanden sind. Ne Idee warum? 

The new templates all used `template: eebus` as name. In documentation this leads to doc-templates overwriting each other. In software, the first one won. Which was not a big issue because the templates are quite similar in signature.

- 👮 implemented a name-uniquenes check for templates
- 🏷️ renamed Elli 2 and Ghost template names