### PR TITLE
chore: align battery control templates

### DIFF
--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -21,11 +21,11 @@ params:
   - name: capacity
     advanced: true
   - name: minsoc
-    default: 10
+    default: 20
     type: number
     advanced: true
   - name: maxsoc
-    default: 100
+    default: 95
     type: number
     advanced: true
 render: |
@@ -148,7 +148,6 @@ render: |
       type: holding
       decode: uint16
     scale: 0.1
-  capacity: {{ .capacity }} # kWh
   batterymode:
     source: switch
     switch:
@@ -207,4 +206,5 @@ render: |
               address: 2133 # 0x855 Charge Cut Soc
               type: writemultiple
               decode: uint16
+  capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -20,9 +20,11 @@ params:
     advanced: true
   - name: minsoc
     type: number
+    default: 20
     advanced: true
   - name: maxsoc
     type: number
+    default: 95
     advanced: true
 render: |
   type: custom
@@ -248,7 +250,5 @@ render: |
               address: 172 
               type: writemultiple
               decode: int32s  
-  minsoc: {{ .minsoc }}
-  maxsoc: {{ .maxsoc }}
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -254,7 +254,5 @@ render: |
               address: 172 
               type: writemultiple
               decode: int32s  
-  minsoc: {{ .minsoc }}
-  maxsoc: {{ .maxsoc }}
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -205,7 +205,5 @@ render: |
               address: 13832 # First_charge_power_time 
               type: writeholding
               decode: int16
-  minsoc: {{ .minsoc }}
-  maxsoc: {{ .maxsoc }}
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/storaxe.yaml
+++ b/templates/definition/meter/storaxe.yaml
@@ -9,6 +9,8 @@ params:
   - name: modbus
     choice: ["tcpip"]
     id: 2
+  - name: capacity
+    advanced: true
 render: |
   type: custom
   power:
@@ -77,3 +79,4 @@ render: |
       address: 126 # SXSSOC
       type: input
       decode: int16
+  capacity: {{ .capacity }} # kWh

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -35,13 +35,13 @@ params:
     help:
       en: optional product identifier of the energy site, use to override autodectction
       de: optionale Product ID dieser Energy Site, zum Übersteuern der automatischen Erkennung
-  - name: minSoc
+  - name: minsoc
     type: number
     advanced: true
     help:
       en: the battery reserve percentage to reset to when switching the Battery back to normal operations
       de: die Energyreserve auf die zurückgesetzt wird, wenn die Entladung wieder freigegeben wird
-  - name: maxSoc
+  - name: maxsoc
     type: number
     advanced: true
     help:
@@ -55,5 +55,5 @@ render: |
   password: {{ .password }} # for user 'customer'
   refreshToken: {{ .refreshToken }}
   siteId: {{ .siteId }}
-  minSoc: {{ .minSoc }}
-  maxSoc: {{ .maxSoc }}
+  minsoc: {{ .minsoc }}
+  maxsoc: {{ .maxsoc }}


### PR DESCRIPTION
`minsoc`/`maxsoc` are only part of the template if `limitsoc` is used.