### PR TITLE
UI: show real battery buffer start value

### DIFF
--- a/assets/js/components/BatterySettingsModal.vue
+++ b/assets/js/components/BatterySettingsModal.vue
@@ -160,7 +160,7 @@
 								@change="changeBufferStart"
 							>
 								<span class="text-decoration-underline">
-									{{ bufferStartOption.name }}
+									{{ selectedBufferStartName }}
 								</span>
 							</CustomSelect>
 						</small>
@@ -332,9 +332,7 @@ export default {
 			for (let i = 100; i >= this.bufferSoc; i -= 5) {
 				options.push({
 					value: i,
-					name: this.$t(`batterySettings.bufferStart.${i === 100 ? "full" : "above"}`, {
-						soc: this.fmtSoc(i),
-					}),
+					name: this.getBufferStartName(i),
 				});
 			}
 			options.push({
@@ -345,6 +343,9 @@ export default {
 		},
 		bufferStartOption() {
 			return this.bufferStartOptions.find((option) => this.bufferStartSoc >= option.value);
+		},
+		selectedBufferStartName() {
+			return this.getBufferStartName(this.selectedBufferStartSoc);
 		},
 		topHeight() {
 			return 100 - (this.bufferSoc || 100);
@@ -487,6 +488,11 @@ export default {
 			} catch (err) {
 				console.error(err);
 			}
+		},
+		getBufferStartName(soc) {
+			return this.$t(`batterySettings.bufferStart.${soc === 100 ? "full" : "above"}`, {
+				soc: this.fmtSoc(soc),
+			});
 		},
 	},
 };


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/16575

Shows actual `bufferStartSoc` even if the values is not present in the select range. Useful when setting values through API.

**98 %**

![Bildschirmfoto 2024-10-09 um 16 45 40](https://github.com/user-attachments/assets/d029d90f-6391-417f-a78f-8fd80fef888e)

available options

![Bildschirmfoto 2024-10-09 um 16 45 45](https://github.com/user-attachments/assets/84e2e68c-c303-43d5-8287-d0f2bbb57278)
