### PR TITLE
SAX modbus port change

### DIFF
--- a/templates/definition/meter/sax.yaml
+++ b/templates/definition/meter/sax.yaml
@@ -3,12 +3,15 @@ products:
   - brand: SAX
     description:
       generic: Homespeicher
+requirements:
+  description:
+    de: Ältere Versionen nutzen Modbus-Port 3600.
+    en: Older versions use Modbus port 3600.
 params:
   - name: usage
     choice: ["grid", "battery"]
   - name: modbus
     choice: ["tcpip"]
-    port: 3600
     id: 64
 render: |
   type: custom


### PR DESCRIPTION
Newer devices use port 503 instead of 3600.

2022 manual: https://sax-power.net/wp-content/uploads/2022/03/SAX-Homespeicher-Handbuch.pdf

2024 manual: https://sax-power.net/download/Handbuch_SAX_Home_Plus_7,7_DE.pdf

The newer manual says both ports are available, but looks like the service hotline says that only 502 works. I don't know which HW or SW version introduced this change.