### PR TITLE
Change Discharge-Mode for goodwe-hybrid

### DIFF
--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -135,7 +135,7 @@ render: |
           source: sequence
           set:
           - source: const
-            value: 8 # EMSPowerMode 8 disables discharge. Charging possible. Charge from PV+AC according to the EMSPowerSet below
+            value: 2 # EMSPowerMode 2 "Charge-PV"-Mode. If EMSPowerSet=0 only PV is used to charge. Value 6 "Conserve"-Mode can be alternatively used.
             set: 
               source: modbus
               {{- include "modbus" . | indent 12 }}
@@ -157,7 +157,7 @@ render: |
           source: sequence
           set:
           - source: const
-            value: 2 # Charge from PV+AC according to the EMSPowerSet below
+            value: 2 # Charge from PV+AC according to the EMSPowerSet below. PV-Preferred. "Import-AC"-Mode (Value: 4) would prefer Grid-Power and reduce PV-Power generated.
             set: 
               source: modbus
               {{- include "modbus" . | indent 12 }}


### PR DESCRIPTION
Previously used Mode 8 is putting battery into standby where it would not charge or discharge. Mode 2 uses all PV-Power to charge Battery and uses Grid-Power to power AC side. Discharging is prevented.