### PR TITLE
Add energy and currents to solaredge-inverter

### DIFF
--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -94,4 +94,25 @@ render: |
     value:
       - 101:W
       - 103:W
+  energy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
+    value:
+      - 101:WH
+      - 103:WH
+    scale: 0.001
+  currents:
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      value: 103:AphA
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      value: 103:AphB
+    - source: sunspec
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      value: 103:AphC
   {{- end }}


### PR DESCRIPTION
Adding read outs of currents and produced energy for Solaredge inverters for a use case where they are not equiped with CTs.