### PR TITLE
Battery UI: fix buffer start 0

### DIFF
--- a/assets/js/components/BatterySettingsModal.vue
+++ b/assets/js/components/BatterySettingsModal.vue
@@ -337,7 +337,7 @@ export default {
 			}
 			options.push({
 				value: 0,
-				name: this.$t("batterySettings.bufferStart.never"),
+				name: this.getBufferStartName(0),
 			});
 			return options;
 		},
@@ -489,10 +489,10 @@ export default {
 				console.error(err);
 			}
 		},
-		getBufferStartName(soc) {
-			return this.$t(`batterySettings.bufferStart.${soc === 100 ? "full" : "above"}`, {
-				soc: this.fmtSoc(soc),
-			});
+		getBufferStartName(value) {
+			const key = value === 0 ? "never" : value === 100 ? "full" : "above";
+			const soc = this.fmtSoc(value);
+			return this.$t(`batterySettings.bufferStart.${key}`, { soc });
 		},
 	},
 };


### PR DESCRIPTION
fixed regression from https://github.com/evcc-io/evcc/pull/16582 when value is `0`

\\cc @VolkerK62 

![Bildschirmfoto 2024-10-16 um 14 16 59](https://github.com/user-attachments/assets/1eeab338-e240-49bd-b3fe-0e437ee68896)

![Bildschirmfoto 2024-10-16 um 14 16 56](https://github.com/user-attachments/assets/d276657a-cbb7-4a14-beb6-935780744048)
