### PR TITLE
Create qcells-hybrid-cloud

### DIFF
--- a/templates/definition/meter/qcells-hybrid-cloud
+++ b/templates/definition/meter/qcells-hybrid-cloud
@@ -1,0 +1,74 @@
+template: qcells-hybrid-cloud
+products:
+  - brand: QCells (based on Solax)
+    description:
+      de: Hybrid-Wechselrichter (Cloud)
+      en: Hybrid-Inverter (Cloud)
+requirements:
+  description:
+    de: |
+      Der QCells Hybrid-Wechselrichter muss in der QCellsCloud angemeldet sein.
+
+      **Achtung**: Die Werte können nur alle 150s abgerufen werden und dann auch 5 Minuten alt sein. Die Laderegelung nach PV kann hiermit nicht optimal gesteuert werden! Nur als Notfalloption nutzen wenn kein lokaler Zugriff möglich ist.
+    en: |
+      The QCells hybrid inverter has to be registered in the QCellsCloud.
+
+      **Attention**: Values can only be fetched every 150s and then also can be 5 minutes old. Charging by PV will not be optimal because of this! Only use as fallback if no local access is available.
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+    allinone: true
+  - name: tokenid
+    required: true
+    description:
+      generic: QCellsCloud TokenID
+    help:
+      de: Von https://qhome-ess-g3.q-cells.eu/#/api/ den Wert von "ObtaintokenID" hier eintragen.
+      en: Go to https://qhome-ess-g3.q-cells.eu/#/api/ and take the value of "ObtaintokenID".
+  - name: serial
+    required: true
+    description:
+      de: Seriennummer
+      en: Serial number
+    help:
+      de: Von https://qhome-ess-g3.q-cells.eu/blue/#/inverter die Registriernummer hier eintragen.
+      en: Go to https://qhome-ess-g3.q-cells.eu/blue/#/inverter and take the value of registration number.
+  - name: capacity
+    advanced: true
+render: |
+  type: custom
+  power:
+  {{- if eq .usage "grid" }}
+    source: http
+    uri: https://qhome-ess-g3.q-cells.eu/proxyApp/proxy/api/getRealtimeInfo.do?tokenId={{ urlEncode .tokenid }}&sn={{ urlEncode .serial }}
+    jq: .result.feedinpower
+    cache: 2m30s
+    scale: -1
+  {{- end }}
+  {{- if eq .usage "pv" }}
+    source: calc
+    add:
+    # Hybrid WR XXXXXXXXXXXXXX
+    # DC MPPT1 + MPPT2
+    - source: http
+      uri: https://qhome-ess-g3.q-cells.eu/proxyApp/proxy/api/getRealtimeInfo.do?tokenId={{ urlEncode .tokenid }}&sn={{ urlEncode .serial }}
+      jq: .result.powerdc1  # Solax API Inverter.DC.PV.power.MPPT1
+      cache: 2m30s
+    - source: http
+      uri: https://qhome-ess-g3.q-cells.eu/proxyApp/proxy/api/getRealtimeInfo.do?tokenId={{ urlEncode .tokenid }}&sn={{ urlEncode .serial }}
+      jq: .result.powerdc2  # Solax API Inverter.DC.PV.power.MPPT2
+      cache: 2m30s
+  {{- end }}
+  {{- if eq .usage "battery" }}
+    source: http
+    uri: https://qhome-ess-g3.q-cells.eu/proxyApp/proxy/api/getRealtimeInfo.do?tokenId={{ urlEncode .tokenid }}&sn={{ urlEncode .serial }}
+    jq: .result.batPower  # Solax API inverter.DC.battery.power.total
+    scale: -1
+    cache: 2m30s
+  soc:
+    source: http
+    uri: https://qhome-ess-g3.q-cells.eu/proxyApp/proxy/api/getRealtimeInfo.do?tokenId={{ urlEncode .tokenid }}&sn={{ urlEncode .serial }}
+    jq: .result.soc  # Solax API inverter.DC.battery.energy.SOC
+    cache: 2m30s
+  capacity: {{ .capacity }} # kWh
+  {{- end }}


### PR DESCRIPTION
Guten Abend, 

ich habe ohne Programmierkenntnisse den Template von Solax Cloud angepasst auf QCells. Ich hoffe alles passt und wie erwartet arbeitet die API genau wie bei Solax. Dann würde ich mal schauen, wie EVCC mit einer Latenz von zwei Minuten klarkommt. So schnell ändert sich doch das Wetter nicht. Hintergrund: mein Inverter ist fernab von allen LAN-Kabeln, für ne Modbus-Schnittstelle bräuchte ich ne eigenen WLAN-Brücke. Da nehme ich Präzisionsverluste in Kauf. 

Rückfragen und weitere Pull Requests gern.

Viele Grüße,
Kai

