### PR TITLE
Fix requirements description for SolarEdge Hybrid battery control

### DIFF
--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -8,10 +8,10 @@ requirements:
   description:
     de: |
       Nur ein System kann und darf zeitgleich eine Modbus TCP-Verbindung zum Wechselrichter haben!
-      Für die optionale Batteriesteuerung muss StorageConf_CtrlMode (0xE004) auf 4 "Remote" stehen, das funktioniert am einfachsten wenn der Batteriemodus "Nutzungszeit" in der MySolarEdge-App aktiviert wurde.
+      Für die optionale Batteriesteuerung muss StorageConf_CtrlMode (0xE004) auf 4 "Remote" stehen.
     en: |
       Only one system can and may have a Modbus TCP connection to the inverter at the same time!
-      For optional battery control, StorageConf_CtrlMode (0xE004) must be set to 4 "Remote" that is most easily achieved by setting the battery mode to "Time of Use" e.g. in the MySolarEdge-App.
+      For optional battery control, StorageConf_CtrlMode (0xE004) must be set to 4 "Remote".
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]


### PR DESCRIPTION
Fix requirements description. 
"Time of Use" sets StorageConf_CtrlMode to 5, which does not work for evcc.

Refs https://github.com/evcc-io/evcc/discussions/12129#discussioncomment-11009567