### PR TITLE
Remove grid and battery and pv voltages and currents

### DIFF
--- a/templates/definition/meter/smartfox-em2.yaml
+++ b/templates/definition/meter/smartfox-em2.yaml
@@ -28,16 +28,6 @@ render: |
     source: http
     uri: {{ include "uri" . }}
     jq: .values.value[] | select(.attrid=="energyValue")."#content" | rtrimstr(" kWh")
-  voltages: # grid voltages in V
-  - source: http
-    uri: {{ include "uri" . }}
-    jq: .values.value[] | select(.attrid=="voltageL1Value")."#content" | rtrimstr(" V")
-  - source: http
-    uri: {{ include "uri" . }}
-    jq: .values.value[] | select(.attrid=="voltageL2Value")."#content" | rtrimstr(" V")
-  - source: http
-    uri: {{ include "uri" . }}
-    jq: .values.value[] | select(.attrid=="voltageL3Value")."#content" | rtrimstr(" V")
   currents: # grid currents in A
   - source: http
     uri: {{ include "uri" . }}

--- a/templates/definition/meter/smartfox.yaml
+++ b/templates/definition/meter/smartfox.yaml
@@ -28,16 +28,6 @@ render: |
     uri: {{ include "uri" . }}
     jq: .energy_in
     scale: 0.001  
-  voltages:
-  - source: http
-    uri: {{ include "uri" . }}
-    jq: .voltages[0]
-  - source: http
-    uri: {{ include "uri" . }}
-    jq: .voltages[1]
-  - source: http
-    uri: {{ include "uri" . }}
-    jq: .voltages[2]
   currents:
   - source: http
     uri: {{ include "uri" . }}

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -61,22 +61,6 @@ render: |
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphC
-  voltages:
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      timeout: {{ .timeout }}
-      subdevice: 1 # Metering device
-      value: 203:PhVphA
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      timeout: {{ .timeout }}
-      subdevice: 1 # Metering device
-      value: 203:PhVphB
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      timeout: {{ .timeout }}
-      subdevice: 1 # Metering device
-      value: 203:PhVphC
   powers:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -50,22 +50,6 @@ render: |
       timeout: {{ .timeout }}
       subdevice: 1 # Metering device
       value: 203:AphC
-  voltages:
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      timeout: {{ .timeout }}
-      subdevice: 1 # Metering device
-      value: 203:PhVphA
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      timeout: {{ .timeout }}
-      subdevice: 1 # Metering device
-      value: 203:PhVphB
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      timeout: {{ .timeout }}
-      subdevice: 1 # Metering device
-      value: 203:PhVphC
   powers:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/storaxe.yaml
+++ b/templates/definition/meter/storaxe.yaml
@@ -28,50 +28,6 @@ render: |
       address: 115 # EnergyExportedAC
       type: input
       decode: uint32
-  voltages:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 7 # ACVoltageL1
-        type: input
-        decode: int16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 8 # ACVoltageL2
-        type: input
-        decode: int16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 9 # ACVoltageL3
-        type: input
-        decode: int16
-      scale: 0.1  
-  currents:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 10 # ACCurrentL1
-        type: input
-        decode: int16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 11 # ACCurrentL2
-        type: input
-        decode: int16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 12 # ACCurrentL3
-        type: input
-        decode: int16
-      scale: 0.1
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -47,22 +47,6 @@ render: |
       value: 
         - 203:AphC
         - 213:AphC
-  voltages:
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      value: 
-        - 203:PhVphA
-        - 213:PhVphA
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      value: 
-        - 203:PhVphB
-        - 213:PhVphB
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      value: 
-        - 203:PhVphC
-        - 213:PhVphC
   powers:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -50,24 +50,6 @@ render: |
       value: 
         - 203:AphC
         - 213:AphC
-  voltages:
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      value:
-        - 201:PhVphA
-        - 211:PhVphA
-        - 203:PhVphA
-        - 213:PhVphA
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      value:
-        - 203:PhVphB
-        - 213:PhVphB
-    - source: sunspec
-      {{- include "modbus" . | indent 4 }}
-      value: 
-        - 203:PhVphC
-        - 213:PhVphC
   powers:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}


### PR DESCRIPTION
Refs https://github.com/evcc-io/docs/issues/650

Cleanup device measurements according to usage. Battery and inverter currents and voltages are not used. Don't implement them.

/cc @premultiply @MarkusGH this partially reverts PRs or yours. Please kindly review.