### PR TITLE
Pulsar Plus (v5.x): fix template

### DIFF
--- a/templates/definition/charger/ocpp-pulsarplus-fw5.yaml
+++ b/templates/definition/charger/ocpp-pulsarplus-fw5.yaml
@@ -23,7 +23,7 @@ requirements:
 params:
   - preset: ocpp
   - name: metervalues
-    default: -Current.Offered,-Power.Offered
+    default: -Current.Offered,Power.Offered
 render: |
   {{ include "ocpp" . }}
   remotestart: true 


### PR DESCRIPTION
Syntax for measurands removal was wrong, so Power.Offered was not removed as intended. Fixes #16768