### PR TITLE
Huawei SUN2000-RS485: Add battery-control

### DIFF
--- a/templates/definition/meter/huawei-sun2000-rs485.yaml
+++ b/templates/definition/meter/huawei-sun2000-rs485.yaml
@@ -5,9 +5,11 @@ products:
   - brand: Huawei
     description:
       generic: SUN2000 via RS485 Modbus
+capabilities: ["battery-control"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
+    allinone: true
   - name: modbus
     choice: ["rs485", "tcpip"]
     baudrate: 9600
@@ -26,7 +28,7 @@ render: |
     register:
       address: 37113 # Grid import export power
       type: holding
-      decode: int32
+      decode: int32nan
     scale: -1
   energy:
     source: modbus
@@ -34,7 +36,7 @@ render: |
     register:
       address: 37121 # Active energy import from the grid
       type: holding
-      decode: uint32
+      decode: uint32nan
     scale: 0.01
   currents:
   - source: modbus
@@ -42,21 +44,21 @@ render: |
     register:
       address: 37107 # Huawei phase A grid current
       type: holding
-      decode: int32
+      decode: int32nan
     scale: -0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
       address: 37109 # Huawei phase B grid current
       type: holding
-      decode: int32
+      decode: int32nan
     scale: -0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
       address: 37111 # Huawei phase C grid current
       type: holding
-      decode: int32
+      decode: int32nan
     scale: -0.01
   {{- end }}
   {{- if eq .usage "pv" }}
@@ -66,16 +68,16 @@ render: |
     register:
       address: 32064 # Input power DC (if no battery in your system - for more precise readings use 32080 # Active generation power AC)
       type: holding
-      decode: int32
+      decode: int32nan
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
       address: 32106 # Accumulated energy yield
       type: holding
-      decode: uint32
+      decode: uint32nan
     scale: 0.01
-    {{- end }}
+  {{- end }}
   {{- if eq .usage "battery" }}
   power:
     source: modbus
@@ -114,7 +116,114 @@ render: |
       address: 37755 # [Energy storage unit 2] Total discharge
       {{- end }}
       type: holding
-      decode: uint32
+      decode: uint32nan
     scale: 0.01
+  batterymode:
+    source: watchdog
+    timeout: 30s
+    reset: 1 # reset watchdog on normal
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: const
+          value: 0 # stop
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47100 # Forcible charge/discharge
+              type: writesingle
+              encoding: uint16
+      - case: 2 # hold
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 2 # discharge
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47100 # Forcible charge/discharge
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # duration
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47246 # Forcible charge/discharge setting mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Minute
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47083 # Forced charging and discharging period
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47249 # Forcible discharge power
+                type: writemultiple
+                encoding: uint32
+      - case: 3 # charge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 1 # charge
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47100 # Forcible charge/discharge
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # duration
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47246 # Forcible charge/discharge setting mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Minute
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47083 # Forced charging and discharging period
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 10000 # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47247 # Forcible charge power
+                type: writemultiple
+                encoding: uint32
+          - source: const
+            value: 1 # Enable
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47087 # Charge from grid
+                type: writesingle
+                encoding: uint16
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
* Take over changes from huawei-sun2000-dongle-powersensor.yaml to support battery-control.
* Use same register type as used in huawei-sun2000-dongle-powersensor.yaml