### PR TITLE
Teslamate: Add limitsoc

### DIFF
--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -47,4 +47,8 @@ render: |
     source: mqtt
     topic: teslamate/cars/{{ .id }}/odometer
     timeout: 720h # 30d
+  limitsoc:
+    source: mqtt
+    topic: teslamate/cars/{{ .id }}/charge_limit_soc
+    timeout: 720h
   features: ["coarsecurrent"]


### PR DESCRIPTION
Enables EVCC to read car built-in charge limit from Teslamate via MQTT.

This is supported since 2019:
[[1.4.3] - 2019-08-05](https://github.com/teslamate-org/teslamate/blob/master/CHANGELOG.md#143---2019-08-05)