### PR TITLE
tariffs: add custom template for spottyenergy

### DIFF
--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -1,0 +1,23 @@
+template: spottyenergy
+products:
+  - brand: Spotty Energie
+requirements:
+  description:
+    de: "Nur für Österreich verfügbar."
+    en: "Only available for Austria."
+group: price
+params:
+  - name: contractId
+    example: ffffffff-4444-6666-2222-aaaaaabbbbbb
+    required: true
+    help:
+      de: "Die Vertragsnummer bekommst du im Kundenportal https://i.spottyenergie.at/"
+      en: "You can get your contract id from the customer portal https://i.spottyenergie.at/"
+  - preset: tariff-base
+render: |
+  type: custom
+  {{ include "tariff-base" . }}
+  forecast:
+    source: http
+    uri: https://i.spottyenergy.at/api/prices/MARKET/{{ .contractId }}
+    jq: '[.[] | {start: .from, end: (.from | fromdate + 3600 | todate), price: (.price/100)}] | tostring'

--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -19,5 +19,5 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://i.spottyenergy.at/api/prices/MARKET/{{ .contractId }}
+    uri: https://i.spottyenergie.at/api/prices/MARKET/{{ .contractId }}
     jq: '[.[] | {start: .from, end: (.from | fromdate + 3600 | todate), price: (.price/100)}] | tostring'


### PR DESCRIPTION
Fix #16816 

Can't test since I'm not a customer, but based on the example data it should work. Sadly there is little documentation.

The example data is in localtime with timestamps like `2024-08-19T03:00:00+02:00`. Documentation at https://www.spottyenergie.at/blog/energie-smart-produzieren mentions that it defaults to UTC when you leave out the URL parameter `timezone=at`, so I figured the timestamps would be like `2024-08-19T01:00:00Z`. 

Prices look like they're in cents/kWh, so I convert them to €/kWh in the jq expression. 

Someone who is getting power from Spotty should test this template first