### PR TITLE
tariffs: Improve Spotty Energie template

### DIFF
--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -1,0 +1,23 @@
+template: spottyenergy
+products:
+  - brand: Spotty Energie
+requirements:
+  description:
+    de: "Nur für Österreich verfügbar."
+    en: "Only available for Austria."
+group: price
+params:
+  - name: contractId
+    example: ffffffff-4444-6666-2222-aaaaaabbbbbb
+    required: true
+    help:
+      de: "Die Vertragsnummer bekommst du im Kundenportal https://i.spottyenergie.at/"
+      en: "You can get your contract id from the customer portal https://i.spottyenergie.at/"
+  - preset: tariff-base
+render: |
+  type: custom
+  {{ include "tariff-base" . }}
+  forecast:
+    source: http
+    uri: https://i.spottyenergy.at/api/prices/MARKET/{{ .contractId }}
+    jq: '[.[] | {start: .from, end: (.from | fromdate + 3600 | todate), price: (.price/100)}] | tostring'

--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -7,13 +7,13 @@ requirements:
     en: "Only available for Austria."
 group: price
 params:
-  - name: contractId
+  - name: contractid
     example: ffffffff-4444-6666-2222-aaaaaabbbbbb
     required: true
     help:
       de: "Die Vertragsnummer bekommst du im Kundenportal https://i.spottyenergie.at/"
       en: "You can get your contract id from the customer portal https://i.spottyenergie.at/"
-  - name: priceType
+  - name: pricetype
     example: CONSUMPTION
     validvalues: ["MARKET", "CONSUMPTION", "GENERATION"]
     required: true
@@ -26,5 +26,5 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://i.spottyenergie.at/api/prices/{{ .priceType }}/{{ .contractId }}
+    uri: https://i.spottyenergie.at/api/prices/{{ .pricetype }}/{{ .contractid }}
     jq: '[.[] | {start: .from, end: (.from | fromdate + 3600 | todate), price: (.price/100)}] | tostring'

--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -13,11 +13,18 @@ params:
     help:
       de: "Die Vertragsnummer bekommst du im Kundenportal https://i.spottyenergie.at/"
       en: "You can get your contract id from the customer portal https://i.spottyenergie.at/"
+  - name: priceType
+    example: CONSUMPTION
+    validvalues: ["MARKET", "CONSUMPTION", "GENERATION"]
+    required: true
+    help:
+      de: "Preistyp, entweder Börsenpreis, Verbrauchspreis oder Einspeisevergütunt (falls vereinbart), siehe https://www.spottyenergie.at/blog/energie-smart-produzieren"
+      en: "Price type, either spotmarket price, consumption price or generation compensation (if contractually agreed), more info at https://www.spottyenergie.at/blog/energie-smart-produzieren"
   - preset: tariff-base
 render: |
   type: custom
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://i.spottyenergie.at/api/prices/MARKET/{{ .contractId }}
+    uri: https://i.spottyenergie.at/api/prices/{{ .priceType }}/{{ .contractId }}
     jq: '[.[] | {start: .from, end: (.from | fromdate + 3600 | todate), price: (.price/100)}] | tostring'

--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -14,7 +14,7 @@ params:
       de: "Die Vertragsnummer bekommst du im Kundenportal https://i.spottyenergie.at/"
       en: "You can get your contract id from the customer portal https://i.spottyenergie.at/"
   - name: pricetype
-    example: CONSUMPTION
+    default: CONSUMPTION
     validvalues: ["MARKET", "CONSUMPTION", "GENERATION"]
     required: true
     help:

--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -18,7 +18,7 @@ params:
     validvalues: ["MARKET", "CONSUMPTION", "GENERATION"]
     required: true
     help:
-      de: "Preistyp, entweder Börsenpreis, Verbrauchspreis oder Einspeisevergütunt (falls vereinbart), siehe https://www.spottyenergie.at/blog/energie-smart-produzieren"
+      de: "Preistyp, entweder Börsenpreis, Verbrauchspreis oder Einspeisevergütung (falls vereinbart), siehe https://www.spottyenergie.at/blog/energie-smart-produzieren"
       en: "Price type, either spotmarket price, consumption price or generation compensation (if contractually agreed), more info at https://www.spottyenergie.at/blog/energie-smart-produzieren"
   - preset: tariff-base
 render: |

--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -19,5 +19,5 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://i.spottyenergy.at/api/prices/MARKET/{{ .contractId }}
+    uri: https://i.spottyenergie.at/api/prices/MARKET/{{ .contractId }}
     jq: '[.[] | {start: .from, end: (.from | fromdate + 3600 | todate), price: (.price/100)}] | tostring'


### PR DESCRIPTION
Adds a choice for the `priceType` value, see #16927 

As far as I understand:
- `MARKET`: raw market prices
- `CONSUMPTION`: price with any added charges by Spotty (excl. taxes)
- `GENERATION`: compensation for energy returned to the grid

The `GENERATION` price type would allow a dynamic feed-in tariff (is that possible already?)