### PR TITLE
Tariffs: add formulas

### DIFF
--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -197,6 +197,13 @@ tariffs:
     #   uri: https://example.org/price.json
     #   jq: .price.current
 
+    # type: template
+    # template: energy-charts-api # epex spot market prices
+    # bzn: DE-LU
+    # charges: 0.15
+    # tax: 0.1
+    # formula: math.Min((price + charges) * (1 + tax), 0.5)
+
   feedin:
     # rate for feeding excess (pv) energy to the grid
     type: fixed

--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -39,6 +39,10 @@ func NewAwattarFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		return nil, err
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	t := &Awattar{
 		embed: &cc.embed,
 		log:   util.NewLogger("awattar"),

--- a/tariff/edf-tempo.go
+++ b/tariff/edf-tempo.go
@@ -53,6 +53,10 @@ func NewEdfTempoFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		return nil, errors.New("missing credentials")
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	basic := transport.BasicAuthHeader(cc.ClientID, cc.ClientSecret)
 	log := util.NewLogger("edf-tempo").Redact(basic)
 

--- a/tariff/elering.go
+++ b/tariff/elering.go
@@ -43,6 +43,10 @@ func NewEleringFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		return nil, errors.New("missing region")
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	t := &Elering{
 		embed:  &cc.embed,
 		log:    util.NewLogger("elering"),

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -26,6 +26,10 @@ func (t *embed) init() error {
 		return err
 	}
 
+	if _, err := vm.Eval(`import "math"`); err != nil {
+		return err
+	}
+
 	if _, err := vm.Eval("var price, charges, tax float64"); err != nil {
 		return err
 	}

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -1,12 +1,67 @@
 package tariff
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/traefik/yaegi/interp"
+	"github.com/traefik/yaegi/stdlib"
+)
+
 type embed struct {
-	Margin  float64 `mapstructure:"margin"`
 	Charges float64 `mapstructure:"charges"`
 	Tax     float64 `mapstructure:"tax"`
-	Uplifts float64 `mapstructure:"uplifts"`
+	Formula string  `mapstructure:"formula"`
+
+	calc func(float64) (float64, error)
+}
+
+func (t *embed) init() error {
+	if t.Formula == "" {
+		return nil
+	}
+
+	vm := interp.New(interp.Options{})
+	if err := vm.Use(stdlib.Symbols); err != nil {
+		return err
+	}
+
+	if _, err := vm.Eval("var price, charges, tax float64"); err != nil {
+		return err
+	}
+
+	prg, err := vm.Compile(t.Formula)
+	if err != nil {
+		return err
+	}
+
+	t.calc = func(price float64) (float64, error) {
+		if _, err := vm.Eval(fmt.Sprintf("price = %f", price)); err != nil {
+			return 0, err
+		}
+
+		res, err := vm.Execute(prg)
+		if err != nil {
+			return 0, err
+		}
+
+		if !res.CanFloat() {
+			return 0, errors.New("formula did not return a float value")
+		}
+
+		return res.Float(), nil
+	}
+
+	// test the formula
+	_, err = t.calc(0)
+
+	return err
 }
 
 func (t *embed) totalPrice(price float64) float64 {
-	return (price*(1+t.Margin)+t.Charges)*(1+t.Tax) + t.Uplifts
+	if t.calc == nil {
+		res, _ := t.calc(price)
+		return res
+	}
+	return (price + t.Charges) * (1 + t.Tax)
 }

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -59,7 +59,7 @@ func (t *embed) init() error {
 }
 
 func (t *embed) totalPrice(price float64) float64 {
-	if t.calc == nil {
+	if t.calc != nil {
 		res, _ := t.calc(price)
 		return res
 	}

--- a/tariff/energinet.go
+++ b/tariff/energinet.go
@@ -42,6 +42,10 @@ func NewEnerginetFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		return nil, errors.New("missing region")
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	t := &Energinet{
 		embed:  &cc.embed,
 		log:    util.NewLogger("energinet"),

--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -51,6 +51,10 @@ func NewEntsoeFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		return nil, errors.New("missing domain")
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	domain, err := entsoe.Area(entsoe.BZN, strings.ToUpper(cc.Domain))
 	if err != nil {
 		return nil, err

--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -55,6 +55,10 @@ func NewPunFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		return nil, err
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	t := &Pun{
 		log:   util.NewLogger("pun"),
 		embed: &cc,

--- a/tariff/smartenergy.go
+++ b/tariff/smartenergy.go
@@ -33,6 +33,10 @@ func NewSmartEnergyFromConfig(other map[string]interface{}) (api.Tariff, error) 
 		return nil, err
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	t := &SmartEnergy{
 		embed: &cc.embed,
 		log:   util.NewLogger("smartenergy"),

--- a/tariff/tariff.go
+++ b/tariff/tariff.go
@@ -46,6 +46,10 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]interface{}
 		return nil, fmt.Errorf("must have either price or forecast")
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	var (
 		err       error
 		priceG    func() (float64, error)

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -44,6 +44,10 @@ func NewTibberFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		return nil, errors.New("missing token")
 	}
 
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
 	log := util.NewLogger("tibber").Redact(cc.Token, cc.HomeID)
 
 	t := &Tibber{

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -333,6 +333,12 @@ presets:
         help:
           de: Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%)
           en: Additional percentage charge (e.g. 0.2 for 20%)
+      - name: formula
+        type: string
+        help:
+          de: Individuelle Formel zur Berechnung des Preises
+          en: Individual formula for calculating the price
+        example: "math.Max((price + charges) * (1 + tax), 0.0)"
   eebus:
     params:
       - name: ski

--- a/util/templates/includes/tariff-base.tpl
+++ b/util/templates/includes/tariff-base.tpl
@@ -5,4 +5,7 @@ charges: {{ .charges }}
 {{- if .tax }}
 tax: {{ .tax }}
 {{- end }}
+{{- if .formula }}
+formula: {{ .formula }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/16977

Available Variables: `price`, `charges`, `tax`, [`math`](https://pkg.go.dev/math) (go package)

Examples: Raw spot price with 0ct lower cap and 50ct upper cap
```
  grid:
    type: template
    template: energy-charts-api
    bzn: DE-LU
    formula: Math.Min(math.Max(price, 0), 0.5)
```

TODO

- [x] add to templates