### PR TITLE
Smart Cost: higher precision limit via slot click

### DIFF
--- a/assets/js/components/SmartCostLimit.vue
+++ b/assets/js/components/SmartCostLimit.vue
@@ -288,17 +288,12 @@ export default {
 		slotHovered(index) {
 			this.activeIndex = index;
 		},
-		setSelectedSmartCostLimit(limit) {
-			const nextOption = this.costOptions.find(({ value }) => value >= limit);
-			if (nextOption) {
-				this.selectedSmartCostLimit = nextOption.value;
-			}
-		},
 		slotSelected(index) {
 			const price = this.slots[index].price;
 			if (price !== undefined) {
-				this.setSelectedSmartCostLimit(price);
-				this.saveSmartCostLimit(this.selectedSmartCostLimit);
+				// 3 decimal precision
+				const priceRounded = Math.ceil(price * 1000) / 1000;
+				this.saveSmartCostLimit(priceRounded);
 			}
 		},
 		changeSmartCostLimit($event) {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/17093

- 📊 use time slot value as limit (instead of next higher step)

[finer limits.webm](https://github.com/user-attachments/assets/bdd3e1bf-7c5e-44d1-a765-99e494278ea5)
