### PR TITLE
Homewizard: Handle PV Usage

### DIFF
--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -27,6 +27,7 @@ func NewHomeWizardFromConfig(other map[string]interface{}) (api.Charger, error) 
 	cc := struct {
 		embed        `mapstructure:",squash"`
 		URI          string
+		Usage        string
 		StandbyPower float64
 		Cache        time.Duration
 	}{
@@ -37,12 +38,12 @@ func NewHomeWizardFromConfig(other map[string]interface{}) (api.Charger, error) 
 		return nil, err
 	}
 
-	return NewHomeWizard(cc.embed, cc.URI, cc.StandbyPower, cc.Cache)
+	return NewHomeWizard(cc.embed, cc.URI, cc.Usage, cc.StandbyPower, cc.Cache)
 }
 
 // NewHomeWizard creates HomeWizard charger
-func NewHomeWizard(embed embed, uri string, standbypower float64, cache time.Duration) (*HomeWizard, error) {
-	conn, err := homewizard.NewConnection(uri, cache)
+func NewHomeWizard(embed embed, uri string, usage string, standbypower float64, cache time.Duration) (*HomeWizard, error) {
+	conn, err := homewizard.NewConnection(uri, usage, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/homewizard.go
+++ b/meter/homewizard.go
@@ -22,6 +22,7 @@ func init() {
 func NewHomeWizardFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
 		URI   string
+		Usage string
 		Cache time.Duration
 	}{
 		Cache: time.Second,
@@ -31,12 +32,12 @@ func NewHomeWizardFromConfig(other map[string]interface{}) (api.Meter, error) {
 		return nil, err
 	}
 
-	return NewHomeWizard(cc.URI, cc.Cache)
+	return NewHomeWizard(cc.URI, cc.Usage, cc.Cache)
 }
 
 // NewHomeWizard creates HomeWizard meter
-func NewHomeWizard(uri string, cache time.Duration) (*HomeWizard, error) {
-	conn, err := homewizard.NewConnection(uri, cache)
+func NewHomeWizard(uri string, usage string, cache time.Duration) (*HomeWizard, error) {
+	conn, err := homewizard.NewConnection(uri, usage, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -103,7 +103,7 @@ func (c *Connection) Enabled() (bool, error) {
 func (c *Connection) CurrentPower() (float64, error) {
 	res, err := c.dataG.Get()
 	if c.usage == "pv" {
-		return res.ActivePowerW * -1, err
+		return -res.ActivePowerW, err
 	}
 	return res.ActivePowerW, err
 }

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -111,6 +111,9 @@ func (c *Connection) CurrentPower() (float64, error) {
 // TotalEnergy implements the api.MeterEnergy interface
 func (c *Connection) TotalEnergy() (float64, error) {
 	res, err := c.dataG.Get()
+	if c.usage == "pv" {
+		return res.TotalPowerExportT1kWh + res.TotalPowerExportT2kWh + res.TotalPowerExportT3kWh + res.TotalPowerExportT4kWh, err
+	}
 	return res.TotalPowerImportT1kWh + res.TotalPowerImportT2kWh + res.TotalPowerImportT3kWh + res.TotalPowerImportT4kWh, err
 }
 

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -121,7 +121,7 @@ func (c *Connection) TotalEnergy() (float64, error) {
 func (c *Connection) Currents() (float64, float64, float64, error) {
 	res, err := c.dataG.Get()
 	if c.usage == "pv" {
-		return res.ActiveCurrentL1A * -1, res.ActiveCurrentL2A * -1, res.ActiveCurrentL3A * -1, err
+		return -res.ActiveCurrentL1A, -res.ActiveCurrentL2A, -res.ActiveCurrentL3A, err
 	}
 	return res.ActiveCurrentL1A, res.ActiveCurrentL2A, res.ActiveCurrentL3A, err
 }

--- a/meter/homewizard/types.go
+++ b/meter/homewizard/types.go
@@ -21,6 +21,10 @@ type DataResponse struct {
 	TotalPowerImportT2kWh float64 `json:"total_power_import_t2_kwh"`
 	TotalPowerImportT3kWh float64 `json:"total_power_import_t3_kwh"`
 	TotalPowerImportT4kWh float64 `json:"total_power_import_t4_kwh"`
+	TotalPowerExportT1kWh float64 `json:"total_power_export_t1_kwh"`
+	TotalPowerExportT2kWh float64 `json:"total_power_export_t2_kwh"`
+	TotalPowerExportT3kWh float64 `json:"total_power_export_t3_kwh"`
+	TotalPowerExportT4kWh float64 `json:"total_power_export_t4_kwh"`
 	ActiveCurrentL1A      float64 `json:"active_current_l1_a"`
 	ActiveCurrentL2A      float64 `json:"active_current_l2_a"`
 	ActiveCurrentL3A      float64 `json:"active_current_l3_a"`

--- a/meter/homewizard/types_test.go
+++ b/meter/homewizard/types_test.go
@@ -42,6 +42,7 @@ func TestUnmarshalKwhDataResponse(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
 
 		assert.Equal(t, float64(30.511), res.TotalPowerImportT1kWh+res.TotalPowerImportT2kWh+res.TotalPowerImportT3kWh+res.TotalPowerImportT4kWh)
+		assert.Equal(t, float64(85.951), res.TotalPowerExportT1kWh+res.TotalPowerExportT2kWh+res.TotalPowerExportT3kWh+res.TotalPowerExportT4kWh)
 		assert.Equal(t, float64(543), res.ActivePowerW)
 		assert.Equal(t, float64(235.4), res.ActiveVoltageL1V)
 		assert.Equal(t, float64(235.8), res.ActiveVoltageL2V)
@@ -61,6 +62,7 @@ func TestUnmarshalP1DataResponse(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
 
 		assert.Equal(t, float64(18664.997), res.TotalPowerImportT1kWh+res.TotalPowerImportT2kWh+res.TotalPowerImportT3kWh+res.TotalPowerImportT4kWh)
+		assert.Equal(t, float64(13823.608), res.TotalPowerExportT1kWh+res.TotalPowerExportT2kWh+res.TotalPowerExportT3kWh+res.TotalPowerExportT4kWh)
 		assert.Equal(t, float64(203), res.ActivePowerW)
 		assert.Equal(t, float64(228), res.ActiveVoltageL1V)
 		assert.Equal(t, float64(226), res.ActiveVoltageL2V)

--- a/meter/homewizard/types_test.go
+++ b/meter/homewizard/types_test.go
@@ -33,11 +33,11 @@ func TestUnmarshalStateResponse(t *testing.T) {
 	}
 }
 
-// Test DataResponse
-func TestUnmarshalDataResponse(t *testing.T) {
+// Test homewizard kWh Meter 1-Phase response
+func TestUnmarshalKwhDataResponse(t *testing.T) {
 	{
 		var res DataResponse
-
+		// https://www.homewizard.com/shop/wi-fi-kwh-meter-1-phase/
 		jsonstr := `{"wifi_ssid": "My Wi-Fi","wifi_strength": 100,"total_power_import_t1_kwh": 30.511,"total_power_export_t1_kwh": 85.951,"active_power_w": 543,"active_power_l1_w": 28,"active_power_l2_w": 0,"active_power_l3_w": -181,"active_voltage_l1_v": 235.4,"active_voltage_l2_v": 235.8,"active_voltage_l3_v": 236.1,"active_current_l1_a": 1.19,"active_current_l2_a": 0.37,"active_current_l3_a": -0.93}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
 
@@ -49,5 +49,24 @@ func TestUnmarshalDataResponse(t *testing.T) {
 		assert.Equal(t, float64(1.19), res.ActiveCurrentL1A)
 		assert.Equal(t, float64(0.37), res.ActiveCurrentL2A)
 		assert.Equal(t, float64(-0.93), res.ActiveCurrentL3A)
+	}
+}
+
+// Test homewizard P1 Meter response
+func TestUnmarshalP1DataResponse(t *testing.T) {
+	{
+		var res DataResponse
+		// https://www.homewizard.com/shop/wi-fi-p1-meter-rj12-2/
+		jsonstr := `{"wifi_ssid":"redacted","wifi_strength":78,"smr_version":50,"meter_model":"Landis + Gyr","unique_id":"redacted","active_tariff":2,"total_power_import_kwh":18664.997,"total_power_import_t1_kwh":10909.724,"total_power_import_t2_kwh":7755.273,"total_power_export_kwh":13823.608,"total_power_export_t1_kwh":4243.981,"total_power_export_t2_kwh":9579.627,"active_power_w":203.000,"active_power_l1_w":-21.000,"active_power_l2_w":57.000,"active_power_l3_w":168.000,"active_voltage_l1_v":228.000,"active_voltage_l2_v":226.000,"active_voltage_l3_v":225.000,"active_current_a":1.091,"active_current_l1_a":-0.092,"active_current_l2_a":0.252,"active_current_l3_a":0.747,"voltage_sag_l1_count":12.000,"voltage_sag_l2_count":12.000,"voltage_sag_l3_count":19.000,"voltage_swell_l1_count":5055.000,"voltage_swell_l2_count":1950.000,"voltage_swell_l3_count":0.000,"any_power_fail_count":12.000,"long_power_fail_count":2.000,"total_gas_m3":5175.363,"gas_timestamp":241106093006,"gas_unique_id":"redacted","external":[{"unique_id":"redacted","type":"gas_meter","timestamp":241106093006,"value":5175.363,"unit":"m3"}]}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+
+		assert.Equal(t, float64(18664.997), res.TotalPowerImportT1kWh+res.TotalPowerImportT2kWh+res.TotalPowerImportT3kWh+res.TotalPowerImportT4kWh)
+		assert.Equal(t, float64(203), res.ActivePowerW)
+		assert.Equal(t, float64(228), res.ActiveVoltageL1V)
+		assert.Equal(t, float64(226), res.ActiveVoltageL2V)
+		assert.Equal(t, float64(225), res.ActiveVoltageL3V)
+		assert.Equal(t, float64(-0.092), res.ActiveCurrentL1A)
+		assert.Equal(t, float64(0.252), res.ActiveCurrentL2A)
+		assert.Equal(t, float64(0.747), res.ActiveCurrentL3A)
 	}
 }

--- a/templates/definition/meter/homewizard-kwh.yaml
+++ b/templates/definition/meter/homewizard-kwh.yaml
@@ -2,7 +2,7 @@ template: homewizard-kwh
 products:
   - brand: HomeWizard
     description:
-      generic: kWh Meter 1+3-Phase
+      generic: kWh Meter
 params:
   - name: usage
     choice: ["pv"]

--- a/templates/definition/meter/homewizard-kwh.yaml
+++ b/templates/definition/meter/homewizard-kwh.yaml
@@ -2,7 +2,7 @@ template: homewizard
 products:
   - brand: HomeWizard
     description:
-      generic: Wi-Fi HomeWizard Meter (P1+KWH)
+      generic: HomeWizard kWh Meter 1+3-Phase
 params:
   - name: usage
     choice: ["grid", "pv"]

--- a/templates/definition/meter/homewizard-kwh.yaml
+++ b/templates/definition/meter/homewizard-kwh.yaml
@@ -1,11 +1,11 @@
-template: homewizard
+template: homewizard-kwh
 products:
   - brand: HomeWizard
     description:
-      generic: HomeWizard kWh Meter 1+3-Phase
+      generic: kWh Meter 1+3-Phase
 params:
   - name: usage
-    choice: ["grid", "pv"]
+    choice: ["pv"]
   - name: host
 render: |
   type: homewizard

--- a/templates/definition/meter/homewizard-p1.yaml
+++ b/templates/definition/meter/homewizard-p1.yaml
@@ -2,8 +2,12 @@ template: homewizard
 products:
   - brand: HomeWizard
     description:
-      generic: Wi-Fi HomeWizard P1 Meter
+      generic: Wi-Fi P1 Meter
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: host
 render: |
   type: homewizard
   uri: http://{{ .host }}
-  usage: grid
+  usage: {{ .usage }}

--- a/templates/definition/meter/homewizard-p1.yaml
+++ b/templates/definition/meter/homewizard-p1.yaml
@@ -1,0 +1,9 @@
+template: homewizard
+products:
+  - brand: HomeWizard
+    description:
+      generic: Wi-Fi HomeWizard P1 Meter
+render: |
+  type: homewizard
+  uri: http://{{ .host }}
+  usage: grid

--- a/templates/definition/meter/homewizard.yaml
+++ b/templates/definition/meter/homewizard.yaml
@@ -2,7 +2,7 @@ template: homewizard
 products:
   - brand: HomeWizard
     description:
-      generic: Wi-Fi P1 Meter
+      generic: Wi-Fi HomeWizard Meter (P1+KWH)
 params:
   - name: usage
     choice: ["grid", "pv"]
@@ -10,3 +10,4 @@ params:
 render: |
   type: homewizard
   uri: http://{{ .host }}
+  usage: {{ .usage }}


### PR DESCRIPTION
In case the homewizard kwh meter is used as solar/pv meter, power and CurrentPower and Currents response values will be invested.
Refer to discussion #4882 .