### PR TITLE
Sessions UI: improve solar year color palette

### DIFF
--- a/assets/js/colors.js
+++ b/assets/js/colors.js
@@ -18,7 +18,7 @@ const colors = reactive({
   price: "#FF912FFF",
   co2: "#00916EFF",
   background: null,
-  selfPalette: ["#0fde41ff", "#0ba631ff", "#076f20ff", "#054e18ff", "#043611ff", "#02230bff"],
+  selfPalette: ["#0FDE41FF", "#FFBD2FFF", "#FD6158FF", "#03C1EFFF", "#0F662DFF", "#FF922EFF"],
   palette: [
     "#03C1EFFF",
     "#FD6158FF",


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/17214

Improve color for solar year comparison chart.

before
![before](https://github.com/user-attachments/assets/e5fe5e27-37a3-4143-8269-89d516c9f9a2)

after
![after](https://github.com/user-attachments/assets/36d10102-6827-4345-a3e7-576bab7afd17)

new complete palette 
![palette](https://github.com/user-attachments/assets/9db953c9-18f4-432b-a1ae-c5a85a5ee616)