### PR TITLE
Config UI: duration fields

### DIFF
--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -93,10 +93,14 @@
 import "@h2d2/shopicons/es/regular/minus";
 import VehicleIcon from "../VehicleIcon";
 import SelectGroup from "../SelectGroup.vue";
+import formatter from "../../mixins/formatter";
+
+const NS_PER_SECOND = 1000000000;
 
 export default {
 	name: "PropertyField",
 	components: { VehicleIcon, SelectGroup },
+	mixins: [formatter],
 	props: {
 		id: String,
 		property: String,
@@ -148,6 +152,9 @@ export default {
 			}
 			if (this.property === "capacity") {
 				return "kWh";
+			}
+			if (this.type === "Duration") {
+				return this.fmtSecondUnit(this.value);
 			}
 			return null;
 		},
@@ -203,6 +210,10 @@ export default {
 					return Array.isArray(this.modelValue) ? this.modelValue.join("\n") : "";
 				}
 
+				if (this.type === "Duration" && typeof this.modelValue === "number") {
+					return this.modelValue / NS_PER_SECOND;
+				}
+
 				return this.modelValue;
 			},
 			set(value) {
@@ -214,6 +225,10 @@ export default {
 
 				if (this.array) {
 					newValue = value ? value.split("\n") : [];
+				}
+
+				if (this.type === "Duration" && typeof newValue === "number") {
+					newValue = newValue * NS_PER_SECOND;
 				}
 
 				this.$emit("update:modelValue", newValue);

--- a/assets/js/mixins/formatter.js
+++ b/assets/js/mixins/formatter.js
@@ -246,6 +246,15 @@ export default {
         day: "numeric",
       }).format(date);
     },
+    fmtSecondUnit: function (seconds) {
+      return new Intl.NumberFormat(this.$i18n?.locale, {
+        style: "unit",
+        unit: "second",
+        unitDisplay: "long",
+      })
+        .formatToParts(seconds)
+        .find((part) => part.type === "unit").value;
+    },
     fmtMoney: function (amout = 0, currency = "EUR", decimals = true, withSymbol = false) {
       const currencyDisplay = withSymbol ? "narrowSymbol" : "code";
       const result = new Intl.NumberFormat(this.$i18n?.locale, {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/16385

- ⏰ add proper support for duration fields
- 🤌 durations are read, written and stored in nanoseconds (go default)

**german**
![Bildschirmfoto 2024-11-12 um 23 41 14](https://github.com/user-attachments/assets/25a42427-2716-440f-9b8a-68555a532c2d)

**english**
![Bildschirmfoto 2024-11-12 um 23 43 51](https://github.com/user-attachments/assets/dba6483e-d69f-42b8-bafd-13c8af3fda79)


**for later**
Provide option to select min or hrs unit. Currently, all durations are entered in seconds.