### PR TITLE
Tariff: better rate matching error

### DIFF
--- a/api/rates.go
+++ b/api/rates.go
@@ -37,7 +37,7 @@ func (r Rates) Current(now time.Time) (Rate, error) {
 	}
 
 	if len(r) == 0 {
-		return Rate{}, fmt.Errorf("no matching rate for: %s", now.Format(time.RFC3339))
+		return Rate{}, fmt.Errorf("no matching rate for: %s", now.Local().Format(time.RFC3339))
 	}
 	return Rate{}, fmt.Errorf("no matching rate for: %s, %d rates (%s to %s)",
 		now.Format(time.RFC3339), len(r), r[0].Start.Format(time.RFC3339), r[len(r)-1].End.Format(time.RFC3339))

--- a/api/rates.go
+++ b/api/rates.go
@@ -40,5 +40,5 @@ func (r Rates) Current(now time.Time) (Rate, error) {
 		return Rate{}, fmt.Errorf("no matching rate for: %s", now.Local().Format(time.RFC3339))
 	}
 	return Rate{}, fmt.Errorf("no matching rate for: %s, %d rates (%s to %s)",
-		now.Format(time.RFC3339), len(r), r[0].Start.Format(time.RFC3339), r[len(r)-1].End.Format(time.RFC3339))
+		now.Local().Format(time.RFC3339), len(r), r[0].Start.Local().Format(time.RFC3339), r[len(r)-1].End.Local().Format(time.RFC3339))
 }

--- a/api/rates.go
+++ b/api/rates.go
@@ -37,8 +37,8 @@ func (r Rates) Current(now time.Time) (Rate, error) {
 	}
 
 	if len(r) == 0 {
-		return Rate{}, fmt.Errorf("no matching rate: no rates available")
+		return Rate{}, fmt.Errorf("no matching rate for: %s", now.Format(time.RFC3339))
 	}
-	return Rate{}, fmt.Errorf("no matching rate: now %s, %d rates (%s to %s)",
+	return Rate{}, fmt.Errorf("no matching rate for: %s, %d rates (%s to %s)",
 		now.Format(time.RFC3339), len(r), r[0].Start.Format(time.RFC3339), r[len(r)-1].End.Format(time.RFC3339))
 }

--- a/api/rates.go
+++ b/api/rates.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"errors"
+	"fmt"
 	"slices"
 	"time"
 )
@@ -36,5 +36,9 @@ func (r Rates) Current(now time.Time) (Rate, error) {
 		}
 	}
 
-	return Rate{}, errors.New("no matching rate")
+	if len(r) == 0 {
+		return Rate{}, fmt.Errorf("no matching rate: no rates available")
+	}
+	return Rate{}, fmt.Errorf("no matching rate: now %s, %d rates (%s to %s)",
+		now.Format(time.RFC3339), len(r), r[0].Start.Format(time.RFC3339), r[len(r)-1].End.Format(time.RFC3339))
 }


### PR DESCRIPTION
Improve logging for cases like https://github.com/evcc-io/evcc/issues/17253

```
[site  ] WARN 2024/11/14 08:38:18 planner: no matching rate: now 2024-11-13T19:38:18+01:00, 24 rates (2024-11-13T23:00:00Z to 2024-11-14T23:00:00Z)
```