### PR TITLE
Temporary fix for PUN tariff

### DIFF
--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -129,7 +129,7 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 	client.Jar, _ = cookiejar.New(nil)
 
 	// Erster Request
-	uri := "https://www.mercatoelettrico.org/It/WebServerDataStore/MGP_Prezzi/" + day.Format("20060102") + "MGPPrezzi.xml"
+	uri := "https://storico.mercatoelettrico.org/It/WebServerDataStore/MGP_Prezzi/" + day.Format("20060102") + "MGPPrezzi.xml"
 	resp, err := client.Get(uri)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Temporary fix for #17174 . Changed endpoint from www.mercatoelettrico.org to storico.mercatoelettrico.org . It should work until december 31 2024; after that, it is necessary to pull data with the new api from the updated site.