### PR TITLE
Add support for sending events via MQTT

### DIFF
--- a/push/mqtt.go
+++ b/push/mqtt.go
@@ -1,0 +1,82 @@
+package push
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/evcc-io/evcc/provider/mqtt"
+	"github.com/evcc-io/evcc/util"
+)
+
+func init() {
+	registry.Add("mqtt", NewMqttFromConfig)
+}
+
+// Mqtt implements the MQTT messenger
+type Mqtt struct {
+	log    *util.Logger
+	client *mqtt.Client
+	topic  string
+}
+
+// NewMqttFromConfig creates a new Mqtt messenger with the MQTT endpoing configured properly
+func NewMqttFromConfig(other map[string]interface{}) (Messenger, error) {
+	var cc struct {
+		Topic string
+	}
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+	client := mqtt.Instance
+	if client == nil {
+		return nil, errors.New("no mqtt broker configured")
+	}
+	topic := cc.Topic
+	if topic == "" {
+		topic = "evcc/events"
+	}
+	m := &Mqtt{
+		log:    util.NewLogger("mqtt"),
+		client: client,
+		topic:  topic,
+	}
+
+	return m, nil
+}
+
+// Send sends the message via MQTT
+func (m *Mqtt) Send(title, msg string) {
+	jsonPayload, err := prepareJsonMessage(title, msg)
+	if err != nil {
+		m.log.ERROR.Println("error creating MQTT payload:", err)
+		return
+	}
+
+	m.log.DEBUG.Printf("sending MQTT event to %s: %s", m.topic, string(jsonPayload))
+	err = m.client.Publish(m.topic, false, jsonPayload)
+	if err != nil {
+		m.log.ERROR.Println("messenger mqtt publish:", err)
+	}
+}
+
+func prepareJsonMessage(title string, msg string) ([]byte, error) {
+	if json.Valid([]byte(msg)) {
+		var jsonPayload map[string]interface{}
+		// msg is JSON, parse it
+		if err := json.Unmarshal([]byte(msg), &jsonPayload); err != nil {
+			return nil, fmt.Errorf("json unmarshal: %w", err)
+		}
+		if title != "" {
+			jsonPayload["title"] = title
+		}
+		payload, err := json.Marshal(jsonPayload)
+		if err != nil {
+			return nil, fmt.Errorf("json marshal: %w", err)
+		}
+		return payload, nil
+	}
+
+	// msg is not JSON so take it literally. Ignore title in this case
+	return []byte(msg), nil
+}

--- a/push/mqtt_test.go
+++ b/push/mqtt_test.go
@@ -1,0 +1,83 @@
+package push
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareJsonMessage(t *testing.T) {
+	type test struct {
+		name           string
+		title          string
+		message        string
+		expectedResult string
+		expectJson     bool
+	}
+
+	tests := []test{
+		{
+			name:           "plain string message",
+			title:          "",
+			message:        "Hello, World!",
+			expectedResult: "Hello, World!",
+			expectJson:     false,
+		},
+		{
+			name:           "arbitrary non-JSON string, without title",
+			title:          "Alert", // will be ignored
+			message:        "Something went wrong.",
+			expectedResult: "Something went wrong.",
+			expectJson:     false,
+		},
+		{
+			name:           "valid JSON message",
+			title:          "",
+			message:        `{"key":"value"}`,
+			expectedResult: `{"key":"value"}`,
+			expectJson:     true,
+		},
+		{
+			name:           "valid JSON message with title",
+			title:          "Important",
+			message:        `{"key":"value"}`,
+			expectedResult: `{"key":"value","title":"Important"}`,
+			expectJson:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := prepareJsonMessage(tt.title, tt.message)
+			if err == nil {
+				var got, expected map[string]interface{}
+				if tt.expectJson {
+					if err := json.Unmarshal(result, &got); err != nil {
+						t.Fatalf("failed to unmarshal expectedResult: %v", err)
+					}
+					if err := json.Unmarshal([]byte(tt.expectedResult), &expected); err != nil {
+						t.Fatalf("failed to unmarshal expected JSON: %v", err)
+					}
+					if !equalMaps(got, expected) {
+						t.Errorf("expected: %v, got: %v", expected, got)
+					}
+				} else {
+					assert.Equal(t, tt.expectedResult, string(result))
+				}
+			}
+		})
+	}
+}
+
+func equalMaps(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if vb, found := b[k]; !found || v != vb {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
This PR adds a new type, `mqtt` for `services` defined in `messaging` as endpoints for receiving charging lifecycle events. 

It reuses a globally configured `mqtt` server to send out the events. 

These events help calculate your charging plan. True, one could also monitor boolean mqtt messages in topic `evcc.loadpoints[].charging` but one only gets to know about any state change after a delay (30s at worst), while monitoring a status change event is immediate, avoiding any delays for calculating the targettime for the charging plan.