### PR TITLE
Enphase multiple batteries - jq: too many results #17254

### DIFF
--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -74,6 +74,6 @@ render: |
       password: {{ .token }}
     insecure: true
     {{- end }}
-    jq: .[].devices | map(.percentFull) | add / length
+    jq: '[.[].devices[] | select(.percentFull != null) | .percentFull] | add / length'
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
updated SOC jq to resolve “too many results” error where multiple enphase batteries are installed.