### PR TITLE
Tariffs: formula, charges, tax > advanced fields

### DIFF
--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -333,16 +333,19 @@ presets:
     params:
       - name: charges
         type: number
+        advanced: true
         help:
           de: Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent)
           en: Additional fixed charge per kWh (e.g. 0.05 for 5 cents)
       - name: tax
         type: number
+        advanced: true
         help:
           de: Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%)
           en: Additional percentage charge (e.g. 0.2 for 20%)
       - name: formula
         type: string
+        advanced: true
         help:
           de: Individuelle Formel zur Berechnung des Preises
           en: Individual formula for calculating the price


### PR DESCRIPTION
Mark price calculation fields as advanced, so that they are not part of the standard copy&paste sample-code in the docs on all tariffs.

![Bildschirmfoto 2024-11-17 um 12 20 14](https://github.com/user-attachments/assets/30617889-8ca5-4c9c-8ceb-b9ad836492f4)
