### PR TITLE
Change from html/template to text/template for ReplaceFormatted()

### DIFF
--- a/util/format.go
+++ b/util/format.go
@@ -3,11 +3,11 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"maps"
 	"regexp"
 	"slices"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/Masterminds/sprig/v3"
@@ -50,7 +50,7 @@ func FormatValue(format string, val interface{}) string {
 func ReplaceFormatted(s string, kv map[string]interface{}) (string, error) {
 	// Enhanced golang template logic
 	tpl, err := template.New("base").
-		Funcs(sprig.FuncMap()).
+		Funcs(sprig.TxtFuncMap()).
 		Funcs(map[string]any{
 			"timeRound": timeRound,
 		}).Parse(s)


### PR DESCRIPTION
In format.go, probably accidentally, html/template is used instead of text/template for allowing parameterization of various backend configuration. 
While the differences are subtle, it can hurt when characters like '<' or '>' are used in the configuration for inline templates (like when sending XML payload for messaging events).

In this scenario it shoudl be more robust to use text/template, as the HTML escaping is not really needed here.
