### PR TITLE
Push: Add "msg" as encoding

### DIFF
--- a/push/push.go
+++ b/push/push.go
@@ -81,6 +81,8 @@ func (m *Push) Send(title, msg string) {
 		res = m.csv('\t', title, msg)
 	case "title":
 		res = title
+	case "msg":
+		res = msg
 	default:
 		res = msg
 	}


### PR DESCRIPTION
"msg" is the default encoding anyway, but for consistency's sake, we should add it as a possible option for the `encoding:` configuration field.
