### PR TITLE
added b+g e-tech ds100 / ws100 meters

### DIFF
--- a/templates/definition/meter/bge_tech_ds100.yaml
+++ b/templates/definition/meter/bge_tech_ds100.yaml
@@ -1,0 +1,107 @@
+template: bge_tech_ds100
+products:
+  - brand: BGEtech
+    description:
+      generic: DS100
+params:
+  - name: usage
+    choice: ["grid", "pv", "charge", "aux"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+    baudrate: 1200
+render: |
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0428 # Total active power
+      type: holding
+      decode: int32
+    {{- if eq .usage "pv" }}
+    scale: -1
+    {{- end }}
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      {{- if eq .usage "pv" }}
+      address: 0x0118 # Reversing active energy consumption
+      {{- else }}
+      address: 0x010E # Forward active energy consumption
+      {{- end }}
+      type: holding
+      decode: int32
+    scale: 0.01
+  currents:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0410 # Electricity of A phase
+      type: holding
+      decode: int32
+    scale: 0.1
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0412  # Electricity of B phase
+      type: holding
+      decode: int32
+    scale: 0.1
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0414 # Electricity of C phase
+      type: holding
+      decode: int32
+    scale: 0.1
+  voltages:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0400 # Voltage of A phase
+      type: holding
+      decode: int32
+    scale: 0.001
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0402 # Voltage of B phase
+      type: holding
+      decode: int32
+    scale: 0.001
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0404 # Voltage of C phase
+      type: holding
+      decode: int32
+    scale: 0.001
+  powers:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0410 # Active power of A phase
+      type: holding
+      decode: int32
+    {{- if eq .usage "pv" }}
+    scale: -1
+    {{- end }}
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0412 # Active power of B phase
+      type: holding
+      decode: int32
+    {{- if eq .usage "pv" }}
+    scale: -1
+    {{- end }}
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0414 # Active power of C phase
+      type: holding
+      decode: int32
+    {{- if eq .usage "pv" }}
+    scale: -1
+    {{- end }}

--- a/templates/definition/meter/bge_tech_ws100.yaml
+++ b/templates/definition/meter/bge_tech_ws100.yaml
@@ -1,0 +1,73 @@
+template: bge_tech_ws100
+products:
+  - brand: BGEtech
+    description:
+      generic: WS100
+params:
+  - name: usage
+    choice: ["grid", "pv", "charge", "aux"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+    baudrate: 1200
+render: |
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0104 # Total active power
+      type: holding
+      decode: int32
+    {{- if eq .usage "pv" }}
+    scale: -1
+    {{- end }}
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      {{- if eq .usage "pv" }}
+      address: 0x0118 # Reversing active energy consumption
+      {{- else }}
+      address: 0x010E # Forward active energy consumption
+      {{- end }}
+      type: holding
+      decode: int32
+    scale: 0.01
+  currents:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0102 # Electricity of A phase
+      type: holding
+      decode: int32
+    scale: 0.001
+  - source: const
+    value: 0  # since the device only a single phase, this value is set to 0
+  - source: const
+    value: 0  # since the device only a single phase, this value is set to 0
+  voltages:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0100 # Voltage of A phase
+      type: holding
+      decode: int32
+    scale: 0.001
+  - source: const
+    value: 0  # since the device only a single phase, this value is set to 0
+  - source: const
+    value: 0  # since the device only a single phase, this value is set to 0
+  powers:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x0104 # Active power of A phase
+      type: holding
+      decode: int32
+    {{- if eq .usage "pv" }}
+    scale: -1
+    {{- end }}
+  - source: const
+    value: 0  # since the device only a single phase, this value is set to 0
+  - source: const
+    value: 0  # since the device only a single phase, this value is set to 0


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/17105

Hi,

I added both meters mentioned in #17105 

Test on my site looks okay:

WS100 (1phase):
```
mfriedr7@dev:~/github/ev_test$ ./evcc -c ~/evcc.yaml meter

test_ws100
------
Power:          178W
Energy:         171.5kWh
Current L1..L3: 1.27A 0A 0A
Voltage L1..L3: 229V 0V 0V
Power L1..L3:   178W 0W 0W
```


DS100 (3phase):
```
mfriedr7@dev:~/github/ev_test$ ./evcc -c ~/evcc.yaml meter
test_ds100
------
Power:          0W
Energy:         66.0kWh
Current L1..L3: 0A 0A 0A
Voltage L1..L3: 227V 226V 229V
Power L1..L3:   0W 0W 0W
```
(It is correct that it currently shows 0 watts. The meter is connected to the heating element of the heat pump, which is currently not active)