### PR TITLE
Tariffs: make timestamp available for formulas

### DIFF
--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -86,7 +86,7 @@ func (t *Awattar) run(done chan error) {
 			ar := api.Rate{
 				Start: r.StartTimestamp.Local(),
 				End:   r.EndTimestamp.Local(),
-				Price: t.totalPrice(r.Marketprice / 1e3),
+				Price: t.totalPriceAt(r.Marketprice/1e3, r.StartTimestamp),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -86,7 +86,7 @@ func (t *Awattar) run(done chan error) {
 			ar := api.Rate{
 				Start: r.StartTimestamp.Local(),
 				End:   r.EndTimestamp.Local(),
-				Price: t.totalPriceAt(r.Marketprice/1e3, r.StartTimestamp),
+				Price: t.totalPrice(r.Marketprice/1e3, r.StartTimestamp),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/edf-tempo.go
+++ b/tariff/edf-tempo.go
@@ -141,7 +141,7 @@ func (t *EdfTempo) run(done chan error) {
 				ar := api.Rate{
 					Start: ts,
 					End:   ts.Add(time.Hour),
-					Price: t.totalPriceAt(t.prices[strings.ToLower(r.Value)], ts),
+					Price: t.totalPrice(t.prices[strings.ToLower(r.Value)], ts),
 				}
 				data = append(data, ar)
 			}

--- a/tariff/edf-tempo.go
+++ b/tariff/edf-tempo.go
@@ -141,7 +141,7 @@ func (t *EdfTempo) run(done chan error) {
 				ar := api.Rate{
 					Start: ts,
 					End:   ts.Add(time.Hour),
-					Price: t.totalPrice(t.prices[strings.ToLower(r.Value)]),
+					Price: t.totalPriceAt(t.prices[strings.ToLower(r.Value)], ts),
 				}
 				data = append(data, ar)
 			}

--- a/tariff/elering.go
+++ b/tariff/elering.go
@@ -90,7 +90,7 @@ func (t *Elering) run(done chan error) {
 			ar := api.Rate{
 				Start: ts.Local(),
 				End:   ts.Add(time.Hour).Local(),
-				Price: t.totalPrice(r.Price / 1e3),
+				Price: t.totalPriceAt(r.Price/1e3, ts),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/elering.go
+++ b/tariff/elering.go
@@ -85,12 +85,12 @@ func (t *Elering) run(done chan error) {
 
 		data := make(api.Rates, 0, len(res.Data[t.region]))
 		for _, r := range res.Data[t.region] {
-			ts := time.Unix(r.Timestamp, 0)
+			ts := time.Unix(r.Timestamp, 0).Local()
 
 			ar := api.Rate{
-				Start: ts.Local(),
-				End:   ts.Add(time.Hour).Local(),
-				Price: t.totalPriceAt(r.Price/1e3, ts),
+				Start: ts,
+				End:   ts.Add(time.Hour),
+				Price: t.totalPrice(r.Price/1e3, ts),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -57,7 +57,7 @@ func (t *embed) init() error {
 			return 0, err
 		}
 
-		if _, err := vm.Eval(fmt.Sprintf("ts = time.Unix(%d)", ts.Unix())); err != nil {
+		if _, err := vm.Eval(fmt.Sprintf("ts = time.Unix(%d, 0)", ts.Unix())); err != nil {
 			return 0, err
 		}
 

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -40,13 +40,11 @@ func (t *embed) init() (err error) {
 	)
 	
 	var (
-		price, charges, tax float64
+		price float64
+		charges float64 = %f
+		tax float64 = %f
 		ts time.Time
-	)
-
-	charges = %f
-	tax = %f
-	`, t.Charges, t.Tax)); err != nil {
+	)`, t.Charges, t.Tax)); err != nil {
 		return err
 	}
 

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -33,26 +33,20 @@ func (t *embed) init() (err error) {
 		return err
 	}
 
-	if _, err := vm.Eval(`import (
+	if _, err := vm.Eval(fmt.Sprintf(`
+	import (
 		"math"
 		"time"
-	)`); err != nil {
-		return err
-	}
+	)
+	
+	var (
+		price, charges, tax float64
+		ts time.Time
+	)
 
-	if _, err := vm.Eval("var price, charges, tax float64"); err != nil {
-		return err
-	}
-
-	if _, err := vm.Eval("var ts time.Time"); err != nil {
-		return err
-	}
-
-	if _, err := vm.Eval(fmt.Sprintf("charges = %f", t.Charges)); err != nil {
-		return err
-	}
-
-	if _, err := vm.Eval(fmt.Sprintf("tax = %f", t.Tax)); err != nil {
+	charges = %f
+	tax = %f
+	`, t.Charges, t.Tax)); err != nil {
 		return err
 	}
 
@@ -90,7 +84,7 @@ func (t *embed) init() (err error) {
 
 func (t *embed) totalPrice(price float64) float64 {
 	if t.calc != nil {
-		res, _ := t.calc(price, time.Now())
+		res, _ := t.calc(price, time.Time{})
 		return res
 	}
 	return (price + t.Charges) * (1 + t.Tax)

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -17,7 +17,13 @@ type embed struct {
 	calc func(float64, time.Time) (float64, error)
 }
 
-func (t *embed) init() error {
+func (t *embed) init() (err error) {
+	defer func() {
+		if r := recover(); r != nil && err == nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+
 	if t.Formula == "" {
 		return nil
 	}
@@ -27,7 +33,10 @@ func (t *embed) init() error {
 		return err
 	}
 
-	if _, err := vm.Eval(`import "math"`); err != nil {
+	if _, err := vm.Eval(`import (
+		"math"
+		"time"
+	)`); err != nil {
 		return err
 	}
 

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -82,15 +82,7 @@ func (t *embed) init() (err error) {
 	return err
 }
 
-// func (t *embed) totalPrice(price float64) float64 {
-// 	if t.calc != nil {
-// 		res, _ := t.calc(price, time.Time{})
-// 		return res
-// 	}
-// 	return (price + t.Charges) * (1 + t.Tax)
-// }
-
-func (t *embed) totalPriceAt(price float64, ts time.Time) float64 {
+func (t *embed) totalPrice(price float64, ts time.Time) float64 {
 	if t.calc != nil {
 		res, _ := t.calc(price, ts.Local())
 		return res

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -92,7 +92,7 @@ func (t *embed) totalPrice(price float64) float64 {
 
 func (t *embed) totalPriceAt(price float64, ts time.Time) float64 {
 	if t.calc != nil {
-		res, _ := t.calc(price, ts)
+		res, _ := t.calc(price, ts.Local())
 		return res
 	}
 	return (price + t.Charges) * (1 + t.Tax)

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -54,11 +54,10 @@ func (t *embed) init() (err error) {
 	}
 
 	t.calc = func(price float64, ts time.Time) (float64, error) {
-		if _, err := vm.Eval(fmt.Sprintf("price = %f", price)); err != nil {
-			return 0, err
-		}
-
-		if _, err := vm.Eval(fmt.Sprintf("ts = time.Unix(%d, 0)", ts.Unix())); err != nil {
+		if _, err := vm.Eval(fmt.Sprintf(`
+			price = %f
+			ts = time.Unix(%d, 0).Local()
+		`, price, ts.Unix())); err != nil {
 			return 0, err
 		}
 
@@ -82,7 +81,7 @@ func (t *embed) init() (err error) {
 
 func (t *embed) totalPrice(price float64, ts time.Time) float64 {
 	if t.calc != nil {
-		res, _ := t.calc(price, ts.Local())
+		res, _ := t.calc(price, ts)
 		return res
 	}
 	return (price + t.Charges) * (1 + t.Tax)

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -82,13 +82,13 @@ func (t *embed) init() (err error) {
 	return err
 }
 
-func (t *embed) totalPrice(price float64) float64 {
-	if t.calc != nil {
-		res, _ := t.calc(price, time.Time{})
-		return res
-	}
-	return (price + t.Charges) * (1 + t.Tax)
-}
+// func (t *embed) totalPrice(price float64) float64 {
+// 	if t.calc != nil {
+// 		res, _ := t.calc(price, time.Time{})
+// 		return res
+// 	}
+// 	return (price + t.Charges) * (1 + t.Tax)
+// }
 
 func (t *embed) totalPriceAt(price float64, ts time.Time) float64 {
 	if t.calc != nil {

--- a/tariff/energinet.go
+++ b/tariff/energinet.go
@@ -85,11 +85,11 @@ func (t *Energinet) run(done chan error) {
 
 		data := make(api.Rates, 0, len(res.Records))
 		for _, r := range res.Records {
-			date, _ := time.Parse("2006-01-02T15:04:05", r.HourUTC)
+			ts, _ := time.Parse("2006-01-02T15:04:05", r.HourUTC)
 			ar := api.Rate{
-				Start: date.Local(),
-				End:   date.Add(time.Hour).Local(),
-				Price: t.totalPrice(r.SpotPriceDKK / 1e3),
+				Start: ts.Local(),
+				End:   ts.Add(time.Hour).Local(),
+				Price: t.totalPriceAt(r.SpotPriceDKK/1e3, ts),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/energinet.go
+++ b/tariff/energinet.go
@@ -89,7 +89,7 @@ func (t *Energinet) run(done chan error) {
 			ar := api.Rate{
 				Start: ts.Local(),
 				End:   ts.Add(time.Hour).Local(),
-				Price: t.totalPriceAt(r.SpotPriceDKK/1e3, ts),
+				Price: t.totalPrice(r.SpotPriceDKK/1e3, ts),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -155,7 +155,7 @@ func (t *Entsoe) run(done chan error) {
 			ar := api.Rate{
 				Start: r.Start,
 				End:   r.End,
-				Price: t.totalPriceAt(r.Value, r.Start),
+				Price: t.totalPrice(r.Value, r.Start),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -153,8 +153,8 @@ func (t *Entsoe) run(done chan error) {
 		data := make(api.Rates, 0, len(res))
 		for _, r := range res {
 			ar := api.Rate{
-				Start: r.Start,
-				End:   r.End,
+				Start: r.Start.Local(),
+				End:   r.End.Local(),
 				Price: t.totalPrice(r.Value, r.Start),
 			}
 			data = append(data, ar)

--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -155,7 +155,7 @@ func (t *Entsoe) run(done chan error) {
 			ar := api.Rate{
 				Start: r.Start,
 				End:   r.End,
-				Price: t.totalPrice(r.Value),
+				Price: t.totalPriceAt(r.Value, r.Start),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -187,19 +187,16 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 			return nil, fmt.Errorf("load location: %w", err)
 		}
 
-		start := time.Date(date.Year(), date.Month(), date.Day(), hour-1, 0, 0, 0, location)
-		end := start.Add(time.Hour)
-
-		priceStr := strings.Replace(p.PUN, ",", ".", -1) // Ersetzen Sie Komma durch Punkt
-		price, err := strconv.ParseFloat(priceStr, 64)
+		price, err := strconv.ParseFloat(strings.ReplaceAll(p.PUN, ",", "."), 64)
 		if err != nil {
 			return nil, fmt.Errorf("parse price: %w", err)
 		}
 
+		ts := time.Date(date.Year(), date.Month(), date.Day(), hour-1, 0, 0, 0, location)
 		ar := api.Rate{
-			Start: start,
-			End:   end,
-			Price: t.totalPrice(price / 1e3),
+			Start: ts,
+			End:   ts.Add(time.Hour),
+			Price: t.totalPriceAt(price/1e3, ts),
 		}
 		data = append(data, ar)
 	}

--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -196,7 +196,7 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 		ar := api.Rate{
 			Start: ts,
 			End:   ts.Add(time.Hour),
-			Price: t.totalPriceAt(price/1e3, ts),
+			Price: t.totalPrice(price/1e3, ts),
 		}
 		data = append(data, ar)
 	}

--- a/tariff/smartenergy.go
+++ b/tariff/smartenergy.go
@@ -72,7 +72,7 @@ func (t *SmartEnergy) run(done chan error) {
 			ar := api.Rate{
 				Start: r.Date.Local(),
 				End:   r.Date.Add(15 * time.Minute).Local(),
-				Price: t.totalPriceAt(r.Value/100, r.Date),
+				Price: t.totalPrice(r.Value/100, r.Date),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/smartenergy.go
+++ b/tariff/smartenergy.go
@@ -72,7 +72,7 @@ func (t *SmartEnergy) run(done chan error) {
 			ar := api.Rate{
 				Start: r.Date.Local(),
 				End:   r.Date.Add(15 * time.Minute).Local(),
-				Price: t.totalPrice(r.Value / 100),
+				Price: t.totalPriceAt(r.Value/100, r.Date),
 			}
 			data = append(data, ar)
 		}

--- a/tariff/tariff.go
+++ b/tariff/tariff.go
@@ -103,7 +103,7 @@ func (t *Tariff) run(forecastG func() (string, error), done chan error) {
 				return backoff.Permanent(err)
 			}
 			for i, r := range data {
-				data[i].Price = t.totalPrice(r.Price)
+				data[i].Price = t.totalPriceAt(r.Price, r.Start)
 			}
 			return nil
 		}, bo()); err != nil {
@@ -140,7 +140,7 @@ func (t *Tariff) priceRates() (api.Rates, error) {
 		res[i] = api.Rate{
 			Start: slot,
 			End:   slot.Add(time.Hour),
-			Price: t.totalPrice(price),
+			Price: t.totalPriceAt(price, slot),
 		}
 	}
 

--- a/tariff/tariff.go
+++ b/tariff/tariff.go
@@ -103,7 +103,7 @@ func (t *Tariff) run(forecastG func() (string, error), done chan error) {
 				return backoff.Permanent(err)
 			}
 			for i, r := range data {
-				data[i].Price = t.totalPriceAt(r.Price, r.Start)
+				data[i].Price = t.totalPrice(r.Price, r.Start)
 			}
 			return nil
 		}, bo()); err != nil {
@@ -140,7 +140,7 @@ func (t *Tariff) priceRates() (api.Rates, error) {
 		res[i] = api.Rate{
 			Start: slot,
 			End:   slot.Add(time.Hour),
-			Price: t.totalPriceAt(price, slot),
+			Price: t.totalPrice(price, slot),
 		}
 	}
 

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -117,7 +117,7 @@ func (t *Tibber) rates(pi []tibber.Price) api.Rates {
 	for _, r := range pi {
 		price := r.Total
 		if t.Charges != 0 || t.Tax != 0 {
-			price = t.totalPrice(r.Energy)
+			price = t.totalPriceAt(r.Energy, r.StartsAt)
 		}
 		ar := api.Rate{
 			Start: r.StartsAt.Local(),

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -117,7 +117,7 @@ func (t *Tibber) rates(pi []tibber.Price) api.Rates {
 	for _, r := range pi {
 		price := r.Total
 		if t.Charges != 0 || t.Tax != 0 {
-			price = t.totalPriceAt(r.Energy, r.StartsAt)
+			price = t.totalPrice(r.Energy, r.StartsAt)
 		}
 		ar := api.Rate{
 			Start: r.StartsAt.Local(),


### PR DESCRIPTION
Follow-up to https://github.com/evcc-io/evcc/pull/17002, fix https://github.com/evcc-io/evcc/issues/12371. 

This PR adds a `ts` variable of type `time.Time` that contains the start of the current slot. The timestamp is in local timezone to allow immediate use of `ts.Hour()` for comparisons.

Could be nicer with https://github.com/traefik/yaegi/issues/1542.