### PR TITLE
mypv-wifi-meter correction energy scaling

### DIFF
--- a/templates/definition/meter/mypv-wifi-meter.yaml
+++ b/templates/definition/meter/mypv-wifi-meter.yaml
@@ -26,7 +26,7 @@ render: |
       address: 34 # 0x0022 sum of forward energy; unsigned, value=data/800, unit: kWh
       type: holding
       decode: uint32
-    scale: 0.08
+    scale: 0.00125
   currents:
   - source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
ref #17407 
data/800 ist nicht scale: 0.08 sondern scale: 0.00125