### PR TITLE
Tariff: add dynamic/zones charges to ENTSO-e

### DIFF
--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"fmt"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/evcc-io/evcc/api"
@@ -24,6 +25,10 @@ type Entsoe struct {
 	token  string
 	domain string
 	data   *util.Monitor[api.Rates]
+	zones []struct {
+			Price       float64
+			Days, Hours string
+		}
 }
 
 var _ api.Tariff = (*Entsoe)(nil)
@@ -37,6 +42,10 @@ func NewEntsoeFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		embed         `mapstructure:",squash"`
 		Securitytoken string
 		Domain        string
+		Zones []struct {
+			Price       float64
+			Days, Hours string
+		}
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -69,6 +78,7 @@ func NewEntsoeFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		token:  cc.Securitytoken,
 		domain: domain,
 		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		zones: cc.Zones,
 	}
 
 	// Wrap the client with a decorator that adds the security token to each request.
@@ -152,11 +162,83 @@ func (t *Entsoe) run(done chan error) {
 
 		data := make(api.Rates, 0, len(res))
 		for _, r := range res {
+			var zonePrice float64 = 0.0
+
+			weekDays := map[string]int{"Sun": 0, "Mon": 1, "Tue": 2, "Wed": 3, "Thu": 4, "Fri": 5, "Sat": 6}
+
+			for _, zone := range t.zones{
+				var dayStart, dayEnd string
+				parsed, _ := fmt.Sscanf(strings.ReplaceAll(zone.Days,"-"," "), "%s %s", &dayStart, &dayEnd)
+
+				// verify weekday parse process
+				if parsed == 1 || parsed == 2 {
+					// allow to specify single weekday
+					if parsed == 1 {
+						dayEnd = dayStart
+					}
+
+					if _, ok := weekDays[dayStart]; !ok {
+						t.log.ERROR.Printf("Invalid weekday found: %s", dayStart)
+						continue
+					}
+
+					if _, ok := weekDays[dayEnd]; !ok {
+						t.log.ERROR.Printf("Invalid weekday found: %s", dayEnd)
+						continue
+					}
+				} else {
+					t.log.ERROR.Println("Invalid zone days: %s", zone.Days)
+					continue
+				}
+
+				// skip zone if not part of weekday range
+				if !(int(r.Start.Weekday()) >= weekDays[dayStart] && int(r.Start.Weekday()) <= weekDays[dayEnd]){
+					continue
+				}
+
+				var hourStart, hourEnd int
+				parsed, _ = fmt.Sscanf(zone.Hours, "%d-%d", &hourStart, &hourEnd)
+
+				// verify hour parse process
+				if parsed == 1 || parsed == 2 {
+					// allow to specify single hour
+					if parsed == 1 {
+						hourEnd = hourStart
+					}
+
+					if (hourStart < 0 || hourStart > 23 || hourEnd < 0 || hourEnd > 23){
+						t.log.ERROR.Printf("Invalid hour range found, hourStart or hourEnd must be within 0-23 range: %d-%d", hourStart, hourEnd)
+						continue
+					}
+
+					if (hourStart > hourEnd){
+						t.log.ERROR.Printf("Invalid hour range found, hourStart cannot be higher than hourEnd: %d-%d", hourStart, hourEnd)
+						continue
+					}
+
+				} else {
+					t.log.ERROR.Println("Invalid zone hours: %s", zone.Hours)
+					continue
+				}
+
+
+				// skip zone if not part of hour range
+				if !(int(r.Start.Hour()) >= hourStart && int(r.Start.Hour()) <= hourEnd){
+					continue
+				}
+
+				t.log.DEBUG.Printf("Found maching zone %s for %s with currentPrice: %f", zone, r.Start, t.totalPrice(r.Value))
+
+				zonePrice = zone.Price
+				break
+			}
+
 			ar := api.Rate{
 				Start: r.Start,
 				End:   r.End,
-				Price: t.totalPrice(r.Value),
+				Price: t.totalPrice(r.Value) + zonePrice,
 			}
+
 			data = append(data, ar)
 		}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/12371

Example for BZN|PT domain with feedin and grid:
```
tariffs:
  feedin:
    type: entsoe
    domain: BZN|PT
    securitytoken: xxxxxx
    charges: 0
    tax: 0
  grid:
    type: entsoe
    domain: BZN|PT
    securitytoken: xxxxxx
    charges: 0
    tax: 0
    formula: (price + 0.004 + 0.0028930 + 0.010)*(1 + 0.16) + 0.005
    zones:
      - days: Sun-Sat
        hours: 0-7
        price: 0.0157
      - days: Sun-Sat
        hours: 8-21
        price: 0.0860
      - days: Sun-Sat
        hours: 22-23
        price: 0.0157
```

Same code can be added to other tariffs. Once it reaches final version. 