### PR TITLE
BlueLink: extend TLS Handshake timeout

### DIFF
--- a/vehicle/bluelink/api.go
+++ b/vehicle/bluelink/api.go
@@ -43,6 +43,11 @@ func NewAPI(log *util.Logger, baseURI string, decorator func(*http.Request) erro
 	// api is unbelievably slow when retrieving status
 	v.Client.Timeout = 120 * time.Second
 
+	trans := transport.Default()
+	trans.TLSHandshakeTimeout = 30 * time.Second
+	tripper := request.NewTripper(log, trans)
+	v.Client.Transport = tripper
+
 	v.Client.Transport = &transport.Decorator{
 		Decorator: decorator,
 		Base:      v.Client.Transport,

--- a/vehicle/bluelink/api.go
+++ b/vehicle/bluelink/api.go
@@ -43,10 +43,9 @@ func NewAPI(log *util.Logger, baseURI string, decorator func(*http.Request) erro
 	// api is unbelievably slow when retrieving status
 	v.Client.Timeout = 120 * time.Second
 
-	trans := transport.Default()
-	trans.TLSHandshakeTimeout = 30 * time.Second
-	tripper := request.NewTripper(log, trans)
-	v.Client.Transport = tripper
+	if transport, ok := v.Client.Transport.(*http.Transport); ok {
+		transport.TLSHandshakeTimeout = 30 * time.Second
+	}
 
 	v.Client.Transport = &transport.Decorator{
 		Decorator: decorator,


### PR DESCRIPTION
possibly fix #17100 

@andig I am not too happy with this change, as I had to create a separate http transport.
I did so, because I did not see any way to access the Fields of the existing Transport in our http client. The http client does only expose its transport as a RoundTripper interface, which effectively hides the fields.
Alternatively I could downcast the RoundTripper to http.Transport explicitly, but I was not sure if this is really better. What do you think?