### PR TITLE
Use battery power values for zendure

### DIFF
--- a/meter/zendure.go
+++ b/meter/zendure.go
@@ -57,7 +57,7 @@ func (c *Zendure) CurrentPower() (float64, error) {
 	case "pv":
 		return float64(res.SolarInputPower), nil
 	case "battery":
-		return float64(res.GridInputPower) - float64(res.OutputHomePower), nil
+		return float64(res.packInputPower) - float64(res.outputPackPower), nil
 	default:
 		return 0, fmt.Errorf("invalid usage: %s", c.usage)
 	}

--- a/meter/zendure.go
+++ b/meter/zendure.go
@@ -57,7 +57,7 @@ func (c *Zendure) CurrentPower() (float64, error) {
 	case "pv":
 		return float64(res.SolarInputPower), nil
 	case "battery":
-		return float64(res.packInputPower) - float64(res.outputPackPower), nil
+		return float64(res.PackInputPower) - float64(res.OutputPackPower), nil
 	default:
 		return 0, fmt.Errorf("invalid usage: %s", c.usage)
 	}

--- a/meter/zendure/types.go
+++ b/meter/zendure/types.go
@@ -48,7 +48,7 @@ type Data struct {
 	MasterSwitch    bool   `json:"masterSwitch"`    // true,
 	OutputLimit     int    `json:"outputLimit"`     // 0,
 	OutputPackPower int    `json:"outputPackPower"` // 70,
-	PackInputPower  int    `json:"packInputPower"`   // 70,
+	PackInputPower  int    `json:"packInputPower"`  // 70,
 	OutputHomePower int    `json:"outputHomePower"` // 70,
 	PackNum         int    `json:"packNum"`         // 1,
 	PackState       int    `json:"packState"`       // 0,

--- a/meter/zendure/types.go
+++ b/meter/zendure/types.go
@@ -48,6 +48,7 @@ type Data struct {
 	MasterSwitch    bool   `json:"masterSwitch"`    // true,
 	OutputLimit     int    `json:"outputLimit"`     // 0,
 	OutputPackPower int    `json:"outputPackPower"` // 70,
+	PackInputPower  int    `json:"packInputPower"`   // 70,
 	OutputHomePower int    `json:"outputHomePower"` // 70,
 	PackNum         int    `json:"packNum"`         // 1,
 	PackState       int    `json:"packState"`       // 0,


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/pull/17149

The AC power values don't show the battery as charging when it uses its PV inputs etc.  With the battery pack power values everything shows as expected.