### PR TITLE
BMW/Mini hcaptcha integration

### DIFF
--- a/templates/definition/vehicle/bmw.yaml
+++ b/templates/definition/vehicle/bmw.yaml
@@ -4,7 +4,7 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `hcaptcha` Token. Dieser muss einmalig unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
+      Benötigt `hcaptcha` Token. Dieses muss einmalig unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
     en: |
       Requires `hcaptcha` token. This must be generated once at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html. The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
 params:

--- a/templates/definition/vehicle/bmw.yaml
+++ b/templates/definition/vehicle/bmw.yaml
@@ -4,9 +4,9 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `hcaptcha` Token. Dieser kann unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden.
+      Benötigt `hcaptcha` Token. Dieser muss einmalig unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
     en: |
-      Requires `hcaptcha` token. This can be generated at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html
+      Requires `hcaptcha` token. This must be generated once at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html. The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
 params:
   - preset: vehicle-base
   - preset: vehicle-identify

--- a/templates/definition/vehicle/bmw.yaml
+++ b/templates/definition/vehicle/bmw.yaml
@@ -1,6 +1,12 @@
 template: bmw
 products:
   - brand: BMW
+requirements:
+  description:
+    de: |
+      Benötigt `hcaptcha` Token. Dieser kann unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden.
+    en: |
+      Requires `hcaptcha` token. This can be generated at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html
 params:
   - preset: vehicle-base
   - preset: vehicle-identify
@@ -19,6 +25,8 @@ params:
     advanced: true
   - name: welcomecharge
     advanced: true
+  - name: hcaptcha
+    required: true
 render: |
   type: bmw
   {{ include "vehicle-base" . }}
@@ -35,3 +43,4 @@ render: |
   - welcomecharge
   {{- end }}
   {{- end }}
+  hcaptcha: {{ .hcaptcha }}

--- a/templates/definition/vehicle/mini.yaml
+++ b/templates/definition/vehicle/mini.yaml
@@ -4,7 +4,7 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `hcaptcha` Token. Dieser muss einmalig unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
+      Benötigt `hcaptcha` Token. Dieses muss einmalig unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
     en: |
       Requires `hcaptcha` token. This must be generated once at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html. The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
 params:

--- a/templates/definition/vehicle/mini.yaml
+++ b/templates/definition/vehicle/mini.yaml
@@ -1,6 +1,12 @@
 template: mini
 products:
   - brand: Mini
+requirements:
+  description:
+    de: |
+      Benötigt `hcaptcha` Token. Dieser kann unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden.
+    en: |
+      Requires `hcaptcha` token. This can be generated at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html
 params:
   - preset: vehicle-base
   - preset: vehicle-identify
@@ -17,6 +23,8 @@ params:
     advanced: true
   - name: welcomecharge
     advanced: true
+  - name: hcaptcha
+    required: true
 render: |
   type: mini
   {{ include "vehicle-base" . }}
@@ -27,3 +35,4 @@ render: |
   {{- if eq .welcomecharge "true" }}
   features: ["welcomecharge"]
   {{- end }}
+  hcaptcha: {{ .hcaptcha }}

--- a/templates/definition/vehicle/mini.yaml
+++ b/templates/definition/vehicle/mini.yaml
@@ -4,9 +4,9 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `hcaptcha` Token. Dieser kann unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden.
+      Benötigt `hcaptcha` Token. Dieser muss einmalig unter https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
     en: |
-      Requires `hcaptcha` token. This can be generated at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html
+      Requires `hcaptcha` token. This must be generated once at https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html. The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
 params:
   - preset: vehicle-base
   - preset: vehicle-identify

--- a/vehicle/bmw.go
+++ b/vehicle/bmw.go
@@ -34,6 +34,7 @@ func NewBMWMiniFromConfig(brand string, other map[string]interface{}) (api.Vehic
 	cc := struct {
 		embed               `mapstructure:",squash"`
 		User, Password, VIN string
+		Hcaptcha            string
 		Region              string
 		Cache               time.Duration
 	}{
@@ -45,7 +46,7 @@ func NewBMWMiniFromConfig(brand string, other map[string]interface{}) (api.Vehic
 		return nil, err
 	}
 
-	if cc.User == "" || cc.Password == "" {
+	if cc.User == "" || cc.Password == "" || cc.Hcaptcha == "" {
 		return nil, api.ErrMissingCredentials
 	}
 
@@ -56,7 +57,7 @@ func NewBMWMiniFromConfig(brand string, other map[string]interface{}) (api.Vehic
 	log := util.NewLogger(brand).Redact(cc.User, cc.Password, cc.VIN)
 	identity := bmw.NewIdentity(log, cc.Region)
 
-	ts, err := identity.Login(cc.User, cc.Password)
+	ts, err := identity.Login(cc.User, cc.Password, cc.Hcaptcha)
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/bmw/identity.go
+++ b/vehicle/bmw/identity.go
@@ -165,10 +165,9 @@ func (v *Identity) retrieveToken(data url.Values) (*oauth2.Token, error) {
 	var tok oauth2.Token
 	if err == nil {
 		err = v.DoJSON(req, &tok)
+	} else {
+		return nil, err
 	}
-        if err != nil {
-                return nil, err
-        }
 
 	tokex := util.TokenWithExpiry(&tok)
 

--- a/vehicle/bmw/identity.go
+++ b/vehicle/bmw/identity.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
@@ -23,6 +24,8 @@ const (
 type Identity struct {
 	*request.Helper
 	region Region
+	log *util.Logger
+	user string
 }
 
 // NewIdentity creates BMW identity
@@ -30,14 +33,31 @@ func NewIdentity(log *util.Logger, region string) *Identity {
 	v := &Identity{
 		Helper: request.NewHelper(log),
 		region: regions[strings.ToUpper(region)],
+		log: log,
 	}
 
 	return v
 }
 
-func (v *Identity) Login(user, password string) (oauth2.TokenSource, error) {
+func (v *Identity) Login(user, password, hcaptcha string) (oauth2.TokenSource, error) {
 	v.Client.CheckRedirect = request.DontFollow
 	defer func() { v.Client.CheckRedirect = nil }()
+
+	v.user = user
+
+	// database token
+	var tok oauth2.Token
+	if err := settings.Json(v.settingsKey(), &tok); err == nil {
+		v.log.DEBUG.Println("identity.Login - database token found")
+		tok, err := v.RefreshToken(&tok)
+		if err == nil {
+			ts := oauth2.ReuseTokenSourceWithExpiry(tok, oauth.RefreshTokenSource(tok, v), 15*time.Minute)
+			return ts, nil
+		}
+		v.log.DEBUG.Println("identity.Login - database token invalid. Proceeding to login via user, password and captcha.")
+	} else {
+		v.log.DEBUG.Println("identity.Login - no database token found. Proceeding to login via user, password and captcha.")
+	}
 
 	cv := oauth2.GenerateVerifier()
 
@@ -60,7 +80,11 @@ func (v *Identity) Login(user, password string) (oauth2.TokenSource, error) {
 	}
 
 	uri := fmt.Sprintf("%s/oauth/authenticate", v.region.AuthURI)
-	req, err := request.New(http.MethodPost, uri, strings.NewReader(data.Encode()), request.URLEncoding)
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+		"hcaptchatoken": hcaptcha,
+	}
+	req, err := request.New(http.MethodPost, uri, strings.NewReader(data.Encode()), headers)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +166,15 @@ func (v *Identity) retrieveToken(data url.Values) (*oauth2.Token, error) {
 	if err == nil {
 		err = v.DoJSON(req, &tok)
 	}
+        if err != nil {
+                return nil, err
+        }
 
-	return util.TokenWithExpiry(&tok), err
+	tokex := util.TokenWithExpiry(&tok)
+
+	err = settings.SetJson(v.settingsKey(), tokex)
+
+	return tokex, err
 }
 
 func (v *Identity) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
@@ -154,4 +185,8 @@ func (v *Identity) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 	}
 
 	return v.retrieveToken(data)
+}
+
+func (v *Identity) settingsKey() string {
+	return fmt.Sprintf("bmw.%s", v.user)
 }


### PR DESCRIPTION
Minimally invasive fix for broken BMW/Mini API #17332 
hcaptcha must be generated once using https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html and copied to evcc.yaml
Refresh tokens received after first login are persisted in the database and get refreshed every time the token is refreshed.