### PR TITLE
Docs: add support for multiline help text in templates

### DIFF
--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -3,7 +3,7 @@
   {{- range .Values }}
   - {{ . }}
   {{- end }}
-  {{- $help := localize .Help -}}
+  {{- $help := localize .Help | replace "\n" " " -}}
   {{- if $help }} # {{ $help }}{{- end }}{{- if not .IsRequired }}{{ if not $help }} # {{ else }} ({{ end }}optional{{ if $help }}){{ end }}{{ end }}
 {{- end }}
 


### PR DESCRIPTION
This is now possible and does not break the documentation.

```
  - name: greeting
    example: Hallo
    help:
      de |
        Sage
        Hallo!
      en |
        Day
        Hello!
```

In docs.evcc.io code snippets, this text will be single-lined:

```
   greeting: Hallo # Sage Hallo!
```