### PR TITLE
Go: fix encoding parameters to Go representation

### DIFF
--- a/provider/go.go
+++ b/provider/go.go
@@ -186,11 +186,7 @@ func (p *Go) evaluate() (res any, err error) {
 }
 
 func (p *Go) setParam(param string, val any) error {
-	if str, ok := val.(string); ok {
-		val = "\"" + str + "\""
-	}
-
-	_, err := p.vm.Eval(fmt.Sprintf("%s := %v;", param, val))
+	_, err := p.vm.Eval(fmt.Sprintf("%s := %#v;", param, val))
 	return err
 }
 


### PR DESCRIPTION
... or it will break with strings containing `"`.