### PR TITLE
Nordpool day-ahead spot price API

### DIFF
--- a/tariff/nordpool.go
+++ b/tariff/nordpool.go
@@ -1,0 +1,143 @@
+package tariff
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/tariff/nordpool"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+)
+
+type Nordpool struct {
+	*embed
+	log      *util.Logger
+	area     string
+	currency string
+	data     *util.Monitor[api.Rates]
+}
+
+var _ api.Tariff = (*Nordpool)(nil)
+
+func init() {
+	registry.Add("nordpool", NewNordpoolFromConfig)
+}
+
+func NewNordpoolFromConfig(other map[string]interface{}) (api.Tariff, error) {
+	var cc struct {
+		embed    `mapstructure:",squash"`
+		Area     string
+		Currency string
+	}
+
+	err := util.DecodeOther(other, &cc)
+	if err != nil {
+		return nil, err
+	}
+
+	if cc.Area == "" {
+		return nil, errors.New("missing area")
+	}
+
+	if cc.Currency == "" {
+		return nil, errors.New("missing currency")
+	}
+
+	err = cc.init()
+	if err != nil {
+		return nil, err
+	}
+
+	t := &Nordpool{
+		embed:    &cc.embed,
+		log:      util.NewLogger("nordpool"),
+		area:     strings.ToUpper(cc.Area),
+		currency: strings.ToUpper(cc.Currency),
+		data:     util.NewMonitor[api.Rates](2 * time.Hour),
+	}
+	done := make(chan error)
+
+	t.log.DEBUG.Printf("downloading price data")
+	go t.run(done)
+	err = <-done
+	return t, err
+}
+
+func (t *Nordpool) run(done chan error) {
+	var once sync.Once
+	var n nordpool.NordpoolResponse
+	client := request.NewHelper(t.log)
+	t.log.TRACE.Printf("nordpool type: %#v\n", t)
+	tick := time.NewTicker(time.Hour)
+	for ; true; <-tick.C {
+		rd := time.Now().Local()
+		url, _ := nordpool.MakeURL(t.area, rd, t.currency)
+
+		if err := backoff.Retry(func() error {
+			return backoffPermanentError(client.GetJSON(url.String(), &n))
+		}, bo()); err != nil {
+			once.Do(func() { done <- err })
+
+			t.log.ERROR.Println(err)
+			continue
+		}
+		t.log.TRACE.Printf("Returned from url reader with n: %v\n", n)
+		rates := make(api.Rates, 0, len(n.AreaEntries))
+		for _, ae := range n.AreaEntries {
+			r := api.Rate{
+				Start: ae.Start.Local(),
+				End:   ae.Stop.Local(),
+				Price: t.totalPrice(float64(ae.Entry[t.area])/1000, ae.Start),
+			}
+			t.log.TRACE.Printf("api.Rate: %v\n", r)
+			rates = append(rates, r)
+		}
+		t.log.TRACE.Printf("Merging %v with %v\n", t.data, rates)
+		mergeRates(t.data, rates)
+
+		rd = time.Now().AddDate(0, 0, 1)
+		url, _ = nordpool.MakeURL(t.area, rd, t.currency)
+
+		if err := backoff.Retry(func() error {
+			return backoffPermanentError(client.GetJSON(url.String(), &n))
+		}, bo()); err != nil {
+			once.Do(func() { done <- err })
+
+			t.log.ERROR.Println(err)
+			continue
+		}
+		t.log.TRACE.Printf("Returned from url reader with n: &v\n", n)
+		rates = make(api.Rates, 0, len(n.AreaEntries))
+		for _, ae := range n.AreaEntries {
+			r := api.Rate{
+				Start: ae.Start.Local(),
+				End:   ae.Stop.Local(),
+				Price: t.totalPrice(float64(ae.Entry[t.area])/1000, ae.Start),
+			}
+			t.log.TRACE.Printf("api.Rate: %v\n", r)
+			rates = append(rates, r)
+		}
+		t.log.TRACE.Printf("Merging %v with %v\n", t.data, rates)
+		mergeRates(t.data, rates)
+		once.Do(func() { close(done) })
+
+	}
+
+}
+
+func (t *Nordpool) Rates() (api.Rates, error) {
+	var res api.Rates
+	err := t.data.GetFunc(func(val api.Rates) {
+		res = slices.Clone(val)
+	})
+	return res, err
+}
+
+func (t *Nordpool) Type() api.TariffType {
+	return api.TariffTypePriceForecast
+}

--- a/tariff/nordpool/api.go
+++ b/tariff/nordpool/api.go
@@ -1,0 +1,64 @@
+package nordpool
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+func MakeURL(area string, date time.Time, currency string) (u *url.URL, err error) {
+	u, err = url.Parse(BaseURL)
+	q := u.Query()
+	q.Add("market", "DayAhead")
+	q.Add("deliveryArea", area)
+	q.Add("currency", currency)
+	q.Add("date", date.Format("2006-01-02"))
+	u.RawQuery = q.Encode()
+	return u, err
+}
+
+func (d *Date) UnmarshalJSON(b []byte) (err error) {
+	loc, err := time.LoadLocation("CET")
+	if err != nil {
+		return err
+	}
+
+	date, err := time.ParseInLocation(`"2006-01-02"`, string(b), loc)
+	if err != nil {
+		return err
+	}
+
+	d.Date = date
+	return nil
+}
+
+func GetDayAheadData(area string, date time.Time, currency string) (rc int, n *NordpoolResponse, err error) {
+	url, err := MakeURL(area, date, currency)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	resp, err := http.Get(url.String())
+
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+
+	if resp.StatusCode == 204 {
+		//fmt.Println("No data yet")
+		return 204, nil, nil
+	}
+
+	b, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+
+	var m NordpoolResponse
+	err = json.Unmarshal(b, &m)
+	return resp.StatusCode, &m, err
+}

--- a/tariff/nordpool/api.go
+++ b/tariff/nordpool/api.go
@@ -8,15 +8,15 @@ import (
 	"time"
 )
 
-func MakeURL(area string, date time.Time, currency string) (u *url.URL, err error) {
-	u, err = url.Parse(BaseURL)
-	q := u.Query()
-	q.Add("market", "DayAhead")
-	q.Add("deliveryArea", area)
-	q.Add("currency", currency)
-	q.Add("date", date.Format("2006-01-02"))
-	u.RawQuery = q.Encode()
-	return u, err
+func MakeURL(area string, date time.Time, currency string) string {
+	data := url.Values{
+		"market":       {"DayAhead"},
+		"deliveryArea": {area},
+		"currency":     {currency},
+		"date":         {date.Format("2006-01-02")},
+	}
+
+	return BaseURL + "?" + data.Encode()
 }
 
 func (d *Date) UnmarshalJSON(b []byte) (err error) {
@@ -35,24 +35,19 @@ func (d *Date) UnmarshalJSON(b []byte) (err error) {
 }
 
 func GetDayAheadData(area string, date time.Time, currency string) (rc int, n *NordpoolResponse, err error) {
-	url, err := MakeURL(area, date, currency)
-	if err != nil {
-		return 0, nil, err
-	}
+	uri := MakeURL(area, date, currency)
 
-	resp, err := http.Get(url.String())
-
+	resp, err := http.Get(uri)
 	if err != nil {
 		return resp.StatusCode, nil, err
 	}
 
 	if resp.StatusCode == 204 {
-		//fmt.Println("No data yet")
+		// fmt.Println("No data yet")
 		return 204, nil, nil
 	}
 
 	b, err := io.ReadAll(resp.Body)
-
 	if err != nil {
 		return 0, nil, err
 	}

--- a/tariff/nordpool/types.go
+++ b/tariff/nordpool/types.go
@@ -1,0 +1,71 @@
+package nordpool
+
+import (
+	"time"
+)
+
+const (
+	BaseURL    string = "https://dataportal-api.nordpoolgroup.com/api/DayAheadPrices"
+	TimeFormat string = "2006-01-02T15:04" // RFC3339 short
+)
+
+// TODO: Needed?
+type Prices struct {
+	Records []PriceInfo `json:"records"`
+}
+
+// TODO: Needed?
+type PriceInfo struct {
+	HourUTC  string
+	HourCET  string
+	Area     string
+	Currency string
+	Price    float64
+}
+
+type Date struct {
+	Date time.Time
+}
+
+type AreaEntry struct {
+	Start time.Time          `json:"deliveryStart"`
+	Stop  time.Time          `json:"deliveryEnd"`
+	Entry map[string]float32 `json:"entryPerArea"`
+}
+
+type AreaState struct {
+	State string   `json:"state"`
+	Areas []string `json:"areas"`
+}
+
+type AreaAverage struct {
+	AreaCode string  `json:"areaCode"`
+	Price    float32 `json:"price"`
+}
+
+type AveragePrice struct {
+	Average float32 `json:"average"`
+	Min     float32 `json:"min"`
+	Max     float32 `json:"max"`
+}
+
+type PriceAggregate struct {
+	BlockName     string                  `json:"blockName"`
+	Start         time.Time               `json:"deliveryStart"`
+	Stop          time.Time               `json:"deliveryEnd"`
+	AveragePrices map[string]AveragePrice `json:"averagePricePerArea"`
+}
+
+type NordpoolResponse struct {
+	RequestDay      Date             `json:"deliveryDateCET"`
+	APIVersion      int32            `json:"version"`
+	UpdatedAt       time.Time        `json:"updatedAt"`
+	DeliveredAreas  []string         `json:"deliveryAreas"`
+	Market          string           `json:"market"`
+	AreaEntries     []AreaEntry      `json:"multiAreaEntries"`
+	PriceAggregates []PriceAggregate `json:"blockPriceAggregates"`
+	Currency        string           `json:"currency"`
+	ExchangeRate    float32          `json:"exchangeRate"`
+	AreaStates      []AreaState      `json:"areaStates"`
+	AreaAverages    []AreaAverage    `json:"areaAverages"`
+}

--- a/templates/definition/tariff/nordpool.yaml
+++ b/templates/definition/tariff/nordpool.yaml
@@ -3,8 +3,8 @@ products:
   - brand: Nordpool spot prices
 requirements:
   description:
-    de: "Nur für Nordics verfügbar."
-    en: "Only available for Nordics."
+    de: ""
+    en: "Fetch Nordpool spot prices in day-ahead market for all markets in the Nordpool region."
   evcc: ["skiptest"]
 group: price
 params:

--- a/templates/definition/tariff/nordpool.yaml
+++ b/templates/definition/tariff/nordpool.yaml
@@ -1,0 +1,22 @@
+template: nordpool
+products:
+  - brand: Nordpool spot prices
+requirements:
+  description:
+    de: "Nur für Nordics verfügbar."
+    en: "Only available for Nordics."
+  evcc: ["skiptest"]
+group: price
+params:
+  - name: region
+    example: SE4
+    validvalues: ["EE","LT","LV","AT","BE","FR","GER","NL","PL","DK1","DK2","FI","NO1","NO2","NO3","NO4","NO5","SE1", "SE2","SE3","SE4","TEL","SYS"]
+  - name: currency
+    example: SEK
+    validvalues: ["DKK","EUR","NOK","PLN","RON","SEK"]
+  - preset: tariff-base
+render: |
+  type: nordpool
+  region: {{ .region }}
+  currency: {{ .currency }}
+  {{ include "tariff-base" . }}


### PR DESCRIPTION
This PR adds support for using the Nordpool api which provides price data for 14 countries, and 22 areas with local currencies and EUR.

Would fix
#17464
#17479
#17580

May replace or supersede tariffs from
energinet
elering

Related to:
#17582
#17493

