### PR TITLE
Go plugin: add global imports (BC)

### DIFF
--- a/provider/golang/registry.go
+++ b/provider/golang/registry.go
@@ -8,6 +8,13 @@ import (
 	"github.com/traefik/yaegi/interp"
 )
 
+const Imports = `import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)`
+
 var (
 	mu       sync.Mutex
 	registry = make(map[string]*interp.Interpreter)
@@ -26,6 +33,10 @@ func RegisteredVM(name, init string) (*interp.Interpreter, error) {
 		vm = interp.New(interp.Options{})
 
 		if err := vm.Use(stdlib.Symbols); err != nil {
+			return nil, err
+		}
+
+		if _, err := vm.Eval(Imports); err != nil {
 			return nil, err
 		}
 

--- a/tariff/embed.go
+++ b/tariff/embed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/evcc-io/evcc/provider/golang"
 	"github.com/evcc-io/evcc/provider/golang/stdlib"
 	"github.com/traefik/yaegi/interp"
 )
@@ -33,18 +34,13 @@ func (t *embed) init() (err error) {
 		return err
 	}
 
-	if _, err := vm.Eval(fmt.Sprintf(`
-	import (
-		"math"
-		"time"
-	)
-	
+	if _, err := vm.Eval(fmt.Sprintf(`%s
 	var (
 		price float64
 		charges float64 = %f
 		tax float64 = %f
 		ts time.Time
-	)`, t.Charges, t.Tax)); err != nil {
+	)`, golang.Imports, t.Charges, t.Tax)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
By default, these modules are available:

	"fmt"
	"math"
	"strings"
	"time"

This might break scripts that add their own imports- just remove those.