### PR TITLE
Golang/ Javascript plugins: make errors permanent

### DIFF
--- a/provider/go.go
+++ b/provider/go.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/evcc-io/evcc/provider/golang"
 	"github.com/evcc-io/evcc/util"
 	"github.com/traefik/yaegi/interp"
@@ -167,6 +168,7 @@ func (p *Go) evaluate() (res any, err error) {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: %v", r)
 		}
+		err = backoff.Permanent(err)
 	}()
 
 	v, err := p.vm.Eval(p.script)

--- a/provider/pipeline/pipeline.go
+++ b/provider/pipeline/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	xj "github.com/basgys/goxml2json"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/jq"
 	"github.com/itchyny/gojq"
@@ -185,7 +186,7 @@ func (p *Pipeline) Process(in []byte) ([]byte, error) {
 	if p.jq != nil {
 		v, err := jq.Query(p.jq, b)
 		if err != nil {
-			return b, err
+			return b, backoff.Permanent(err)
 		}
 		b = []byte(fmt.Sprintf("%v", v))
 	}


### PR DESCRIPTION
This avoids backoff retries for programming or parsing errors.