### PR TITLE
chore: prepare deprecating legacy apt  repo (BC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,13 @@ publish-release::
 apt-nightly::
 	$(foreach file, $(wildcard $(PACKAGES)/*.deb), \
 		cloudsmith push deb evcc/unstable/any-distro/any-version $(file); \
+		cloudsmith push deb evcc/unstable-cached/any-distro/any-version $(file); \
 	)
 
 apt-release::
 	$(foreach file, $(wildcard $(PACKAGES)/*.deb), \
 		cloudsmith push deb evcc/stable/any-distro/any-version $(file); \
+		cloudsmith push deb evcc/stable-cached/any-distro/any-version $(file); \
 	)
 
 # gokrazy image


### PR DESCRIPTION
@naltatis mit dieser Änderung können wir zu gegebener Zeit das alte Cloudsmith Repo deaktivieren um sicherzustellen, dass wir vollen Benefit durch der GCore Caching erhalten. Die neuen Cloudsmith Repos sind bereits angelegt.

TODO

- [x] populate cached repo
- [ ] switch proxy