### PR TITLE
Vehicle status: improve wrap behaviour

### DIFF
--- a/assets/js/components/VehicleStatus.story.vue
+++ b/assets/js/components/VehicleStatus.story.vue
@@ -14,7 +14,7 @@ const planProjectedEnd = getFutureTime(5, 43);
 </script>
 
 <template>
-	<Story title="VehicleStatus" :layout="{ type: 'grid', iframe: false, width: 420 }">
+	<Story title="VehicleStatus" :layout="{ type: 'grid', iframe: false, width: 320 }">
 		<Variant title="status: disconnected">
 			<VehicleStatus />
 		</Variant>
@@ -124,7 +124,6 @@ const planProjectedEnd = getFutureTime(5, 43);
 			<VehicleStatus
 				connected
 				enabled
-				charging
 				:smartCostLimit="500"
 				smartCostType="co2"
 				:smartCostNextStart="planProjectedStart"
@@ -219,7 +218,7 @@ const planProjectedEnd = getFutureTime(5, 43);
 		<Variant title="combination: maximal">
 			<VehicleStatus
 				connected
-				charging
+				enabled
 				:sessionSolarPercentage="94"
 				:minSoc="20"
 				:vehicleSoc="10"

--- a/assets/js/components/VehicleStatus.vue
+++ b/assets/js/components/VehicleStatus.vue
@@ -1,13 +1,13 @@
 <template>
 	<div
-		class="d-flex justify-content-between gap-4 evcc-gray align-items-start"
+		class="d-flex justify-content-between gap-3 evcc-gray align-items-start flex-wrap"
 		style="min-height: 24px"
 		data-testid="vehicle-status"
 	>
-		<div class="text-wrap charger-status" data-testid="vehicle-status-charger">
+		<div class="charger-status" data-testid="vehicle-status-charger">
 			{{ chargerStatus }}
 		</div>
-		<div class="d-flex flex-wrap justify-content-end gap-3">
+		<div class="d-flex flex-wrap justify-content-end gap-3 flex-grow-1">
 			<!-- pv/phase timer -->
 			<div
 				v-if="pvTimerVisible"

--- a/assets/js/components/VehicleStatus.vue
+++ b/assets/js/components/VehicleStatus.vue
@@ -1,10 +1,12 @@
 <template>
 	<div
-		class="d-flex justify-content-between gap-4 evcc-gray"
+		class="d-flex justify-content-between gap-4 evcc-gray align-items-start"
 		style="min-height: 24px"
 		data-testid="vehicle-status"
 	>
-		<div class="text-nowrap" data-testid="vehicle-status-charger">{{ chargerStatus }}</div>
+		<div class="text-wrap charger-status" data-testid="vehicle-status-charger">
+			{{ chargerStatus }}
+		</div>
 		<div class="d-flex flex-wrap justify-content-end gap-3">
 			<!-- pv/phase timer -->
 			<div
@@ -716,6 +718,9 @@ export default {
 </script>
 
 <style scoped>
+.charger-status {
+	padding-top: 2px;
+}
 .entry {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
fixes  https://github.com/evcc-io/evcc/issues/17647

Allow status text to wrap when not enough space is available.

![Bildschirmfoto 2024-12-08 um 20 29 30](https://github.com/user-attachments/assets/2d0288ee-b8a3-4302-ad11-e948e416b001)
