### PR TITLE
Repeating plan: finish behavior

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -939,6 +939,15 @@ func (lp *Loadpoint) socBasedPlanning() bool {
 	return (v != nil && v.Capacity() > 0) && (lp.vehicleHasSoc() || lp.vehicleSoc > 0)
 }
 
+// repeatingPlanning returns true if the current plan is a repeating plan
+func (lp *Loadpoint) repeatingPlanning() bool {
+	if !lp.socBasedPlanning() {
+		return false
+	}
+	_, _, id := lp.nextVehiclePlan()
+	return id > 1
+}
+
 // vehicleHasSoc returns true if active vehicle supports returning soc, i.e. it is not an offline vehicle
 func (lp *Loadpoint) vehicleHasSoc() bool {
 	return lp.GetVehicle() != nil && !lp.vehicleHasFeature(api.Offline)

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -28,8 +28,8 @@ func (lp *Loadpoint) setPlanActive(active bool) {
 	}
 }
 
-// finishedPlan deletes the charging plan, either loadpoint or vehicle
-func (lp *Loadpoint) finishedPlan() {
+// finishePlan deletes the charging plan, either loadpoint or vehicle
+func (lp *Loadpoint) finishePlan() {
 	if lp.repeatingPlanning() {
 		return // noting to do
 	} else if !lp.socBasedPlanning() {
@@ -106,7 +106,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	// keep overrunning plans as long as a vehicle is connected
 	if lp.clock.Until(planTime) < 0 && (!lp.planActive || !lp.connected()) {
 		lp.log.DEBUG.Println("plan: deleting expired plan")
-		lp.finishedPlan()
+		lp.finishePlan()
 		return false
 	}
 
@@ -119,7 +119,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 			return true
 		}
 
-		lp.finishedPlan()
+		lp.finishePlan()
 		return false
 	}
 

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -28,9 +28,11 @@ func (lp *Loadpoint) setPlanActive(active bool) {
 	}
 }
 
-// deletePlan deletes the charging plan, either loadpoint or vehicle
-func (lp *Loadpoint) deletePlan() {
-	if !lp.socBasedPlanning() {
+// finishedPlan deletes the charging plan, either loadpoint or vehicle
+func (lp *Loadpoint) finishedPlan() {
+	if lp.repeatingPlanning() {
+		return // noting to do
+	} else if !lp.socBasedPlanning() {
 		lp.setPlanEnergy(time.Time{}, 0)
 	} else if v := lp.GetVehicle(); v != nil {
 		vehicle.Settings(lp.log, v).SetPlanSoc(time.Time{}, 0)
@@ -104,7 +106,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	// keep overrunning plans as long as a vehicle is connected
 	if lp.clock.Until(planTime) < 0 && (!lp.planActive || !lp.connected()) {
 		lp.log.DEBUG.Println("plan: deleting expired plan")
-		lp.deletePlan()
+		lp.finishedPlan()
 		return false
 	}
 
@@ -117,7 +119,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 			return true
 		}
 
-		lp.deletePlan()
+		lp.finishedPlan()
 		return false
 	}
 

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -28,8 +28,8 @@ func (lp *Loadpoint) setPlanActive(active bool) {
 	}
 }
 
-// finishePlan deletes the charging plan, either loadpoint or vehicle
-func (lp *Loadpoint) finishePlan() {
+// finishPlan deletes the charging plan, either loadpoint or vehicle
+func (lp *Loadpoint) finishPlan() {
 	if lp.repeatingPlanning() {
 		return // noting to do
 	} else if !lp.socBasedPlanning() {
@@ -106,7 +106,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	// keep overrunning plans as long as a vehicle is connected
 	if lp.clock.Until(planTime) < 0 && (!lp.planActive || !lp.connected()) {
 		lp.log.DEBUG.Println("plan: deleting expired plan")
-		lp.finishePlan()
+		lp.finishPlan()
 		return false
 	}
 
@@ -119,7 +119,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 			return true
 		}
 
-		lp.finishePlan()
+		lp.finishPlan()
 		return false
 	}
 


### PR DESCRIPTION
Fixes plan finished behavior. Currently, the static plan (1) is removed every time a plan finishes - also a repeating one. This way a static plan will never be executed after a repeating one.

\\cc @Maschga 