### PR TITLE
Fiat: add help text for PIN

### DIFF
--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -9,7 +9,7 @@ params:
   - name: pin
     mask: true
     help:
-      en: Required for evcc to refresh the SOC while charging.
+      en: Required for evcc to refresh the SoC while charging.
       de: Benötigt zur Aktualisierung des Ladestands während der Ladung.
   - preset: vehicle-features
 render: |

--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -8,6 +8,9 @@ params:
     example: ZFAE...
   - name: pin
     mask: true
+    help:
+      en: Required for evcc to refresh the SOC while charging.
+      de: Benötigt zur Aktualisierung des Ladestands während der Ladung.
   - preset: vehicle-features
 render: |
   type: fiat


### PR DESCRIPTION
As a new Fiat user it was not clear to me from looking at the docs that I need to provide my PIN for the SOC refresh. Added a help text to enhance the documentation.