### PR TITLE
Update huawei-sun2000.yaml

### DIFF
--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -146,28 +146,30 @@ render: |
     timeout: 30s
     reset: 1 # reset watchdog on normal
     set:
-      source: sequence
+      source: switch
       switch:
       - case: 1 # normal
         set:
-        - source: const
-          value: 0 # stop
+          source: sequence
           set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 47100 # Forcible charge/discharge
-              type: writesingle
-              encoding: uint16
-        - source: const
-          value: 0 # Disable
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 12 }}
-            register:
-              address: 47087 # Charge from grid
-              type: writesingle
-              encoding: uint16
+          - source: const
+            value: 0 # stop
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47100 # Forcible charge/discharge
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # Disable
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 47087 # Charge from grid
+                type: writesingle
+                encoding: uint16
       - case: 2 # hold
         set:
           source: sequence

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -146,17 +146,26 @@ render: |
     timeout: 30s
     reset: 1 # reset watchdog on normal
     set:
-      source: switch
+      source: sequence
       switch:
       - case: 1 # normal
         set:
-          source: const
+        - source: const
           value: 0 # stop
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
               address: 47100 # Forcible charge/discharge
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0 # Disable
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 12 }}
+            register:
+              address: 47087 # Charge from grid
               type: writesingle
               encoding: uint16
       - case: 2 # hold


### PR DESCRIPTION
This PR enhances battery control by deactivating Modbus register 47087 when stopping the charge process (case 1). This allows the inverter/battery to enter deep sleep mode and prevents standby losses.

Fix https://github.com/evcc-io/evcc/issues/17692