### PR TITLE
Change energy unit from MWh to kWh

### DIFF
--- a/templates/definition/tariff/nordpool.yaml
+++ b/templates/definition/tariff/nordpool.yaml
@@ -59,7 +59,7 @@ render: |
               {
                 "start": .deliveryStart,
                 "end":   .deliveryEnd,
-                "price": .entryPerArea.{{ .region }}
+                "price": .entryPerArea.{{ .region }} / 1000
               }
             ] | tostring
       - name: tomorrow
@@ -73,7 +73,7 @@ render: |
               {
                 "start": .deliveryStart,
                 "end":   .deliveryEnd,
-                "price": .entryPerArea.{{ .region }}
+                "price": .entryPerArea.{{ .region }} / 1000
               }
             ] | tostring
   {{ include "tariff-base" . }}


### PR DESCRIPTION
Fix pricing from MWh to kWh. Prices in Nordpool API is in <currency>/MWh but evcc expects kWh.