### PR TITLE
Huawei SUN2000: handle cascading inverters

### DIFF
--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -40,8 +40,8 @@ params:
       en: Inverter cascade
       de: Wechselrichterkaskade
     help:
-      en: For inverter cascades (AC charging remains active to charge the storage from other inverters via AC) set to Yes.
-      de: Für Wechselrichterkaskaden (AC-Laden bleibt aktiv zum Laden des Speichers aus anderen WR via AC) auf Ja.
+      en: Keep AC charging active to charge the storage from other inverters via AC. Prevents stand-by.
+      de: AC-Laden bleibt aktiv zum Laden des Speichers aus anderen AC Quellen für Wechselrichterkaskaden. Verhindert Stand-by.
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -32,6 +32,9 @@ params:
     advanced: true
   - name: capacity
     advanced: true
+  - name: cascade
+    default: false
+    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -164,6 +167,7 @@ render: |
                 address: 47100 # Forcible charge/discharge
                 type: writesingle
                 encoding: uint16
+          {{- if eq .cascade "false" }}
           - source: const
             value: 0 # Disable
             set:
@@ -173,6 +177,7 @@ render: |
                 address: 47087 # Charge from grid
                 type: writesingle
                 encoding: uint16
+          {{- end }}
       - case: 2 # hold
         set:
           source: sequence

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -32,7 +32,7 @@ params:
     advanced: true
   - name: capacity
     advanced: true
-  - name: cascade
+  - name: sun2000cascade
     default: false
     advanced: true
 render: |
@@ -167,7 +167,7 @@ render: |
                 address: 47100 # Forcible charge/discharge
                 type: writesingle
                 encoding: uint16
-          {{- if eq .cascade "false" }}
+          {{- if eq .sun2000cascade "false" }}
           - source: const
             value: 0 # Disable
             set:

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -32,9 +32,16 @@ params:
     advanced: true
   - name: capacity
     advanced: true
-  - name: sun2000cascade
+  - name: forceaccharging
     default: false
     advanced: true
+    type: bool
+    description:
+      en: Inverter cascade
+      de: Wechselrichterkaskade
+    help:
+      en: For inverter cascades (AC charging remains active to charge the storage from other inverters via AC) set to Yes.
+      de: Für Wechselrichterkaskaden (AC-Laden bleibt aktiv zum Laden des Speichers aus anderen WR via AC) auf Ja.
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -167,7 +174,7 @@ render: |
                 address: 47100 # Forcible charge/discharge
                 type: writesingle
                 encoding: uint16
-          {{- if eq .sun2000cascade "false" }}
+          {{- if eq .forceaccharging "false" }}
           - source: const
             value: 0 # Disable
             set:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -310,15 +310,6 @@ params:
       en: Power limit for grid charging.
       de: Leistungslimit für Netzladung.
     default: 100
-  - name: sun2000cascade
-    type: bool
-    description:
-      en: Inverter cascade
-      de: Wechselrichterkaskade
-    help:
-      en: For inverter cascades (AC charging remains active to charge the storage from other inverters via AC) set to Yes.
-      de: Für Wechselrichterkaskaden (AC-Laden bleibt aktiv zum Laden des Speichers aus anderen WR via AC) auf Ja.
-    usages: ["battery"]
 
 presets:
   vehicle-base:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -310,7 +310,6 @@ params:
       en: Power limit for grid charging.
       de: Leistungslimit für Netzladung.
     default: 100
-
 presets:
   vehicle-base:
     params:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -310,6 +310,16 @@ params:
       en: Power limit for grid charging.
       de: Leistungslimit für Netzladung.
     default: 100
+  - name: cascade
+    type: bool
+    description:
+      en: Inverter cascade
+      de: Wechselrichterkaskade
+    help:
+      en: For inverter cascades (AC charging remains active to charge the storage from other inverters via AC) set to Yes.
+      de: Für Wechselrichterkaskaden (AC-Laden bleib aktiv zum Laden des Speichers aus anderen WR via AC) auf Ja.
+    usages: ["battery"]
+
 presets:
   vehicle-base:
     params:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -310,14 +310,14 @@ params:
       en: Power limit for grid charging.
       de: Leistungslimit für Netzladung.
     default: 100
-  - name: cascade
+  - name: sun2000cascade
     type: bool
     description:
       en: Inverter cascade
       de: Wechselrichterkaskade
     help:
       en: For inverter cascades (AC charging remains active to charge the storage from other inverters via AC) set to Yes.
-      de: Für Wechselrichterkaskaden (AC-Laden bleib aktiv zum Laden des Speichers aus anderen WR via AC) auf Ja.
+      de: Für Wechselrichterkaskaden (AC-Laden bleibt aktiv zum Laden des Speichers aus anderen WR via AC) auf Ja.
     usages: ["battery"]
 
 presets:


### PR DESCRIPTION
**Beschreibung des Fixes**
Beim gestrigen Update des Huawei-SUN2000-Templates habe ich nicht berücksichtigt, dass in bestimmten Wechselrichter-Konstellationen (z.B. Wechselrichter-Kaskaden, bei denen andere AC-angebundenen Wechselrichter den Batteriewechselrichter speisen) das AC-Laden dauerhaft aktiv bleiben muss.

Um dieses Verhalten anzupassen, habe ich eine neue Konfigurationsmöglichkeit über die Variable cascade eingeführt:

cascade: "true" → AC-Laden bleibt aktiv.
cascade: "false" → Standardverhalten.

Diese Einstellung kann nun über die evcc.yaml-Datei oder direkt im Konfigurations-UI angepasst werden.

**Links**
Verwandtes Issue: [#17692](https://github.com/evcc-io/evcc/issues/17692)
Pull Request: [#17695](https://github.com/evcc-io/evcc/pull/17695)

**Änderungen**
Neue Variable: cascade für die Konfiguration des AC-Ladeverhaltens.
Anpassung des Huawei-SUN2000-Templates, um die neue Option zu unterstützen.

**Testanleitung**
Konfiguriere die Variable cascade: "true" in der evcc.yaml oder über das UI.
Überprüfe das Verhalten in Wechselrichter-Kaskaden, bei denen der Batteriewechselrichter über AC versorgt wird.

**Hintergrund**
Mit dieser Anpassung wird sichergestellt, dass das AC-Laden in komplexeren Wechselrichter-Setups korrekt funktioniert.