### PR TITLE
Set default energy storage mode for sofarsolar-g3

### DIFF
--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -29,6 +29,13 @@ params:
     deprecated: true
   - name: capacity
     advanced: true
+  - name: defaultmode
+    description:
+      de: Standardmodus für die aktive Batteriesteuerung. Gültige Werte sind 0 (Eigenbedarfsmodus), 1 (Nutzungszeitmodus), 2 (Zeitmodus), 4 (Peak-shaving Modus)
+      en: Default mode for battery control. Valid values are 0 (self use), 1 (time of use), 2 (timing mode), 4 (peak-shaving mode)
+    default: 0 # self use
+    usages: ["battery"]
+    advanced: true
   # battery control
   - name: minsoc
     type: int
@@ -150,7 +157,7 @@ render: |
     - case: 1 # normal
       set:
         source: const
-        value: 0 # self-use
+        value: {{ .defaultmode }} # set back to default energy storage mode
         set:
           source: ignore
           error: "modbus: response data size '18' does not match count '4'"


### PR DESCRIPTION
Closes #17776

Allow to set default energy storage mode for sofarsolar-g3