### PR TITLE
Log UI: fix trace areas with special characters

### DIFF
--- a/assets/js/views/Log.vue
+++ b/assets/js/views/Log.vue
@@ -197,7 +197,7 @@ export default {
 		},
 	},
 	watch: {
-		selectedAreas() {
+		areas() {
 			this.updateLogs();
 		},
 		level() {
@@ -339,7 +339,7 @@ export default {
 	--opacity: 1;
 	opacity: var(--opacity);
 	animation-name: fadeIn;
-	animation-duration: 1s;
+	animation-duration: var(--transition-duration-fast);
 	animation-fill-mode: forwards;
 	animation-timing-function: ease-out;
 	text-indent: 1rem hanging;
@@ -361,9 +361,9 @@ export default {
 	color: var(--bs-danger);
 }
 .log-debug {
-	--opacity: 0.6;
+	--opacity: 0.7;
 }
 .log-trace {
-	--opacity: 0.4;
+	--opacity: 0.5;
 }
 </style>

--- a/util/logstash/element.go
+++ b/util/logstash/element.go
@@ -9,7 +9,7 @@ import (
 
 type element string
 
-var re = regexp.MustCompile(`^\[([a-zA-Z0-9-_.]+)\s*\] (\w+) `)
+var re = regexp.MustCompile(`^\[([a-zA-Z0-9-_.:]+)\s*\] (\w+) `)
 
 func (e element) areaLevel() (string, jww.Threshold) {
 	m := re.FindAllStringSubmatch(string(e), 1)

--- a/util/logstash/element.go
+++ b/util/logstash/element.go
@@ -9,7 +9,7 @@ import (
 
 type element string
 
-var re = regexp.MustCompile(`^\[([a-zA-Z0-9-]+)\s*\] (\w+) `)
+var re = regexp.MustCompile(`^\[([a-zA-Z0-9-_]+)\s*\] (\w+) `)
 
 func (e element) areaLevel() (string, jww.Threshold) {
 	m := re.FindAllStringSubmatch(string(e), 1)

--- a/util/logstash/element.go
+++ b/util/logstash/element.go
@@ -9,7 +9,7 @@ import (
 
 type element string
 
-var re = regexp.MustCompile(`^\[([a-zA-Z0-9-_]+)\s*\] (\w+) `)
+var re = regexp.MustCompile(`^\[([a-zA-Z0-9-_.]+)\s*\] (\w+) `)
 
 func (e element) areaLevel() (string, jww.Threshold) {
 	m := re.FindAllStringSubmatch(string(e), 1)

--- a/util/logstash/element.go
+++ b/util/logstash/element.go
@@ -9,7 +9,7 @@ import (
 
 type element string
 
-var re = regexp.MustCompile(`^\[([a-zA-Z0-9-_.:]+)\s*\] (\w+) `)
+var re = regexp.MustCompile(`^\[(.+?)\s*\] (\w+) `)
 
 func (e element) areaLevel() (string, jww.Threshold) {
 	m := re.FindAllStringSubmatch(string(e), 1)


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/17768

- 🪲 log areas with special characters (`battery_sma`) were not filtered and part of areas selection in ui
- 🔁 updating areas selection refreshes the log output instantly
- 🎨 more contrast, faster appear animation