### PR TITLE
chore: make defaultmode, maxchargepower/rate battery-specific

### DIFF
--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -19,11 +19,7 @@ params:
     advanced: true
   - name: maxacpower
   - name: defaultmode
-    description:
-      de: Standardmodus für die aktive Batteriesteuerung
-      en: Default mode for battery control
     default: 0 # "SelfUse"
-    usages: ["battery"]
     advanced: true
 render: |
   type: custom

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -293,8 +293,15 @@ params:
     help:
       en: Charger will enable charging for short time when vehicle is connected, irrespective of configured charge mode. This is useful for vehicles that require power supply when connecting.
       de: Wallbox gibt kurzzeitige Ladefreigabe bei Fahrzeugverbindung. Das ermöglicht es Fahrzeugen, die eine Stromversorgung beim Anschließen benötigen, einen Fehlerzustand zu vermeiden.
+  - name: defaultmode
+    type: int
+    usages: ["battery"]
+    description:
+      de: Standardmodus für die aktive Batteriesteuerung
+      en: Default mode for battery control
   - name: maxchargepower
     type: int
+    usages: ["battery"]
     description:
       en: Maximum charge power (W)
       de: Maximale Ladeleistung (W)
@@ -303,6 +310,7 @@ params:
       de: Leistungslimit für Netzladung.
   - name: maxchargerate
     type: int
+    usages: ["battery"]
     description:
       en: Maximum charge power (%)
       de: Maximale Ladeleistung (%)


### PR DESCRIPTION
`maxacpower` is pv-specific, so lets make the remaining parameters battery-specific.

Fix https://github.com/evcc-io/evcc/issues/17687