### PR TITLE
Add note about leading zero on Fiat pin

### DIFF
--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -9,8 +9,8 @@ params:
   - name: pin
     mask: true
     help:
-      en: Required for evcc to refresh the SoC while charging.
-      de: Benötigt zur Aktualisierung des Ladestands während der Ladung.
+      en: Required for evcc to refresh the SoC while charging. Embed it in double quotes in case of leading zeroes.
+      de: Benötigt zur Aktualisierung des Ladestands während der Ladung. Bei führenden Nullen bitte in doppelte Hochkommata setzen.
   - preset: vehicle-features
 render: |
   type: fiat


### PR DESCRIPTION
Related to https://github.com/evcc-io/evcc/discussions/12404

If the pin starts with a zero, it may not function properly when not set in quotes.