### PR TITLE
Repeating plans: improve overrun behavior 

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -164,7 +164,7 @@ type Loadpoint struct {
 	planEnergy     float64   // Plan charge energy in kWh (dumb vehicles)
 	planSlotEnd    time.Time // current plan slot end time
 	planActive     bool      // charge plan exists and has a currently active slot
-	planActiveTime time.Time      // needed to calculate the EffectivePlanTime
+	planActiveTime time.Time // needed to calculate the EffectivePlanTime
 	planActiveSoc  int       // needed to calculate the EffectivePlanSoc
 
 	// cached state

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -164,8 +164,8 @@ type Loadpoint struct {
 	planEnergy     float64   // Plan charge energy in kWh (dumb vehicles)
 	planSlotEnd    time.Time // current plan slot end time
 	planActive     bool      // charge plan exists and has a currently active slot
-	planActiveTime time.Time // needed to calculate the EffectivePlanTime
-	planActiveSoc  int       // needed to calculate the EffectivePlanSoc
+	planActiveTime time.Time // needed to calculate the EffectivePlanTime if loading exceeds the target time
+	planActiveSoc  float64   // needed to calculate the EffectivePlanSoc if loading exceeds the target time
 
 	// cached state
 	status         api.ChargeStatus       // Charger status

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -159,11 +159,13 @@ type Loadpoint struct {
 	socEstimator   *soc.Estimator
 
 	// charge planning
-	planner     *planner.Planner
-	planTime    time.Time // time goal
-	planEnergy  float64   // Plan charge energy in kWh (dumb vehicles)
-	planSlotEnd time.Time // current plan slot end time
-	planActive  bool      // charge plan exists and has a currently active slot
+	planner        *planner.Planner
+	planTime       time.Time // time goal
+	planEnergy     float64   // Plan charge energy in kWh (dumb vehicles)
+	planSlotEnd    time.Time // current plan slot end time
+	planActive     bool      // charge plan exists and has a currently active slot
+	planActiveTime time.Time      // needed to calculate the EffectivePlanTime
+	planActiveSoc  int       // needed to calculate the EffectivePlanSoc
 
 	// cached state
 	status         api.ChargeStatus       // Charger status

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -164,8 +164,8 @@ type Loadpoint struct {
 	planEnergy     float64   // Plan charge energy in kWh (dumb vehicles)
 	planSlotEnd    time.Time // current plan slot end time
 	planActive     bool      // charge plan exists and has a currently active slot
-	planActiveTime time.Time // needed to calculate the EffectivePlanTime if loading exceeds the target time
-	planActiveSoc  float64   // needed to calculate the EffectivePlanSoc if loading exceeds the target time
+	planActiveTime time.Time // needed to calculate the EffectivePlanTime if charging exceeds the target time
+	planActiveSoc  float64   // needed to calculate the EffectivePlanSoc if charging exceeds the target time
 
 	// cached state
 	status         api.ChargeStatus       // Charger status

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -77,11 +77,10 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 // EffectivePlanSoc returns the soc target for the current plan
 func (lp *Loadpoint) EffectivePlanSoc() int {
 	if lp.planActive {
-		return lp.planActiveSoc
+		return int(lp.planActiveSoc)
 	}
 
 	_, soc, _ := lp.nextVehiclePlan()
-	lp.planActiveSoc = soc
 
 	return soc
 }
@@ -101,19 +100,17 @@ func (lp *Loadpoint) EffectivePlanId() int {
 
 // EffectivePlanTime returns the effective plan time
 func (lp *Loadpoint) EffectivePlanTime() time.Time {
-	var ts time.Time
-
 	if lp.planActive {
 		return lp.planActiveTime
 	}
+
+	var ts time.Time
 
 	if lp.socBasedPlanning() {
 		ts, _, _ = lp.nextVehiclePlan()
 	} else {
 		ts, _ = lp.GetPlanEnergy()
 	}
-
-	lp.planActiveTime = ts
 
 	return ts
 }

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -76,7 +76,13 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 
 // EffectivePlanSoc returns the soc target for the current plan
 func (lp *Loadpoint) EffectivePlanSoc() int {
+	if lp.planActive {
+		return lp.planActiveSoc
+	}
+
 	_, soc, _ := lp.nextVehiclePlan()
+	lp.planActiveSoc = soc
+
 	return soc
 }
 
@@ -95,12 +101,20 @@ func (lp *Loadpoint) EffectivePlanId() int {
 
 // EffectivePlanTime returns the effective plan time
 func (lp *Loadpoint) EffectivePlanTime() time.Time {
-	if lp.socBasedPlanning() {
-		ts, _, _ := lp.nextVehiclePlan()
-		return ts
+	var ts time.Time
+
+	if lp.planActive {
+		return lp.planActiveTime
 	}
 
-	ts, _ := lp.GetPlanEnergy()
+	if lp.socBasedPlanning() {
+		ts, _, _ = lp.nextVehiclePlan()
+	} else {
+		ts, _ = lp.GetPlanEnergy()
+	}
+
+	lp.planActiveTime = ts
+
 	return ts
 }
 

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -37,6 +37,7 @@ func (lp *Loadpoint) finishPlan() {
 	} else if v := lp.GetVehicle(); v != nil {
 		vehicle.Settings(lp.log, v).SetPlanSoc(time.Time{}, 0)
 	}
+	lp.log.DEBUG.Println("plan: deleting expired plan")
 }
 
 // remainingPlanEnergy returns missing energy amount in kWh
@@ -105,7 +106,6 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 
 	// keep overrunning plans as long as a vehicle is connected
 	if lp.clock.Until(planTime) < 0 && (!lp.planActive || !lp.connected()) {
-		lp.log.DEBUG.Println("plan: deleting expired plan")
 		lp.finishPlan()
 		return false
 	}


### PR DESCRIPTION
Fix #17704

Hi,
dieser PR soll den richtigen Timestamp anzeigen, wenn bei den wiederholenden Plänen die Ladezeit über die festgelegte Zeit hinausgeht.
Diese Implementierung funktioniert soweit schonmal. Ich weiß aber nicht, ob alle Use Cases abgedeckt sind, da wäre es super, wenn ihr auch einmal austestet was geht.

Vielen Dank für das tolle Projekt!
~Maschga