### PR TITLE
Windows: embed tz data for planner

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/fs"
 	"log"
-
 	_ "time/tzdata" // embed timezones for windows, see https://pkg.go.dev/time/tzdata
 
 	"github.com/evcc-io/evcc/cmd"

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"log"
 
+	_ "time/tzdata" // embed timezones for windows, see https://pkg.go.dev/time/tzdata
+
 	"github.com/evcc-io/evcc/cmd"
 	"github.com/evcc-io/evcc/server/assets"
 	_ "golang.org/x/crypto/x509roots/fallback" // fallback certificates


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/17850

> This package will be automatically imported if you build with -tags timetzdata.
https://pkg.go.dev/time/tzdata

@andig Die Doku sagt, dass das alternativ auch über Build Parameter geht. Wäre das eine alternative? Müsste dann in den Release-Prozess eingebaut werden. Hat den Vorteil, dass wir das "Windows only" machen könnten und das App-Bundle nicht für alle größer wird.