### PR TITLE
fix for POST loadpoint /batteryboost/

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -182,7 +182,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, valueChan chan<- util.Param)
 			"smartCost":            {"POST", "/smartcostlimit/{value:-?[0-9.]+}", floatPtrHandler(pass(lp.SetSmartCostLimit), lp.GetSmartCostLimit)},
 			"smartCostDelete":      {"DELETE", "/smartcostlimit", floatPtrHandler(pass(lp.SetSmartCostLimit), lp.GetSmartCostLimit)},
 			"priority":             {"POST", "/priority/{value:[0-9]+}", intHandler(pass(lp.SetPriority), lp.GetPriority)},
-			"batteryBoost":         {"POST", "/batteryboost/{value:[01truefalse]}", boolHandler(lp.SetBatteryBoost, lp.GetBatteryBoost)},
+			"batteryBoost":         {"POST", "/batteryboost/{value:[01truefalse]+}", boolHandler(lp.SetBatteryBoost, lp.GetBatteryBoost)},
 		}
 
 		for _, r := range routes {


### PR DESCRIPTION
the other 'boolHandler's all use the `[01truefalse]+` - so I assume the `+` is missing for the batteryboost endpoint? - If this is totally nonesense - please excuse that I have wasted your time - I just try to find the root cause why the implemented switch in the HA integration does not work...