### PR TITLE
Charger: remove unhandled status D, E, F

### DIFF
--- a/api/chargemodestatus.go
+++ b/api/chargemodestatus.go
@@ -33,7 +33,6 @@ const (
 	StatusC    ChargeStatus = "C" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt, Netzspannung liegt an
 	StatusD    ChargeStatus = "D" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt mit externer Belüfungsanforderung (für Blei-Säure-Batterien)
 	StatusE    ChargeStatus = "E" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler Fahrzeug / Kabel (CP-Kurzschluss, 0V)
-	StatusF    ChargeStatus = "F" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler EVSE oder Abstecken simulieren (CP-Wake-up, -12V)
 )
 
 var StatusEasA = map[ChargeStatus]ChargeStatus{StatusE: StatusA}

--- a/api/chargemodestatus.go
+++ b/api/chargemodestatus.go
@@ -31,7 +31,6 @@ const (
 	StatusA    ChargeStatus = "A" // Fzg. angeschlossen: nein    Laden aktiv: nein    Ladestation betriebsbereit, Fahrzeug getrennt
 	StatusB    ChargeStatus = "B" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fahrzeug verbunden, Netzspannung liegt nicht an
 	StatusC    ChargeStatus = "C" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt, Netzspannung liegt an
-	StatusD    ChargeStatus = "D" // Fzg. angeschlossen:   ja    Laden aktiv:   ja    Fahrzeug lädt mit externer Belüfungsanforderung (für Blei-Säure-Batterien)
 	StatusE    ChargeStatus = "E" // Fzg. angeschlossen:   ja    Laden aktiv: nein    Fehler Fahrzeug / Kabel (CP-Kurzschluss, 0V)
 )
 

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -183,7 +183,7 @@ func (wb *Amperfied) Status() (api.ChargeStatus, error) {
 			return api.StatusB, nil
 		}
 
-		return api.StatusF, nil
+		fallthrough
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", sb)
 	}

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -160,10 +160,6 @@ func (wb *Amperfied) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 6, 7:
 		return api.StatusC, nil
-	case 8:
-		return api.StatusD, nil
-	case 9:
-		return api.StatusE, nil
 	case 10:
 		// ensure RemoteLock is disabled after wake-up
 		b, err := wb.conn.ReadHoldingRegisters(ampRegRemoteLock, 1)

--- a/charger/cfos.go
+++ b/charger/cfos.go
@@ -114,10 +114,6 @@ func (wb *CfosPowerBrain) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 2: // laden
 		return api.StatusC, nil
-	case 3: // laden mit Kühlung
-		return api.StatusD, nil
-	case 4: // kein Strom
-		return api.StatusE, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])
 	}

--- a/charger/cfos.go
+++ b/charger/cfos.go
@@ -2,7 +2,7 @@ package charger
 
 import (
 	"encoding/binary"
-	"errors"
+	"fmt"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -118,10 +118,8 @@ func (wb *CfosPowerBrain) Status() (api.ChargeStatus, error) {
 		return api.StatusD, nil
 	case 4: // kein Strom
 		return api.StatusE, nil
-	case 5: // Fehler
-		return api.StatusF, nil
 	default:
-		return api.StatusNone, errors.New("invalid response")
+		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])
 	}
 }
 

--- a/charger/dadapower.go
+++ b/charger/dadapower.go
@@ -3,7 +3,6 @@ package charger
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"time"
 
@@ -107,19 +106,15 @@ func (wb *Dadapower) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
-	switch binary.BigEndian.Uint16(b) {
+	switch status := binary.BigEndian.Uint16(b); status {
 	case 0x0A: // ready
 		return api.StatusA, nil
 	case 0x0B: // EV is present
 		return api.StatusB, nil
 	case 0x0C: // charging
 		return api.StatusC, nil
-	case 0x0D: // charging with ventilation
-		return api.StatusD, nil
-	case 0x0E: // failure (e.g. diode check, RCD failure)
-		return api.StatusE, nil
 	default:
-		return api.StatusNone, errors.New("invalid response")
+		return api.StatusNone, fmt.Errorf("invalid status: %d", status)
 	}
 }
 

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -103,8 +103,6 @@ func (c *DaheimLaden) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case daheimladen.CHARGING, daheimladen.FINISHING:
 		return api.StatusC, nil
-	case daheimladen.FAULTED:
-		return api.StatusF, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %s", res.Status)
 	}

--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -217,10 +217,8 @@ func (c *EEBus) Status() (res api.ChargeStatus, err error) {
 			return api.StatusC, nil
 		}
 		return api.StatusB, nil
-	case ucapi.EVChargeStateTypeError: // Error
-		return api.StatusF, nil
 	default:
-		return api.StatusNone, fmt.Errorf("properties unknown result: %s", currentState)
+		return api.StatusNone, fmt.Errorf("invalid status: %s", currentState)
 	}
 }
 

--- a/charger/em2go.go
+++ b/charger/em2go.go
@@ -148,10 +148,8 @@ func (wb *Em2Go) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 4, 6:
 		return api.StatusC, nil
-	case 5, 7:
-		return api.StatusF, nil
 	default:
-		return api.StatusNone, fmt.Errorf("invalid status: %0x", b[1])
+		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])
 	}
 }
 

--- a/charger/evsedin.go
+++ b/charger/evsedin.go
@@ -1,7 +1,7 @@
 package charger
 
 import (
-	"errors"
+	"fmt"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -76,12 +76,8 @@ func (evse *EvseDIN) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 3: // charging
 		return api.StatusC, nil
-	case 4: // charging with ventilation
-		return api.StatusD, nil
-	case 5: // failure (e.g. diode check, RCD failure)
-		return api.StatusE, nil
 	default:
-		return api.StatusNone, errors.New("invalid response")
+		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])
 	}
 }
 

--- a/charger/evsewifi.go
+++ b/charger/evsewifi.go
@@ -154,12 +154,8 @@ func (wb *EVSEWifi) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 3: // charging
 		return api.StatusC, nil
-	case 4: // charging with ventilation
-		return api.StatusD, nil
-	case 5: // failure (e.g. diode check, RCD failure)
-		return api.StatusE, nil
 	default:
-		return api.StatusNone, errors.New("invalid response")
+		return api.StatusNone, fmt.Errorf("invalid status: %d", params.VehicleState)
 	}
 }
 

--- a/charger/heidelberg-ec.go
+++ b/charger/heidelberg-ec.go
@@ -157,10 +157,6 @@ func (wb *HeidelbergEC) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 6, 7:
 		return api.StatusC, nil
-	case 8:
-		return api.StatusD, nil
-	case 9:
-		return api.StatusE, nil
 	case 10:
 		// ensure RemoteLock is disabled after wake-up
 		b, err := wb.conn.ReadHoldingRegisters(hecRegRemoteLock, 1)

--- a/charger/heidelberg-ec.go
+++ b/charger/heidelberg-ec.go
@@ -180,7 +180,7 @@ func (wb *HeidelbergEC) Status() (api.ChargeStatus, error) {
 			return api.StatusB, nil
 		}
 
-		return api.StatusF, nil
+		fallthrough
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", sb)
 	}

--- a/charger/kse.go
+++ b/charger/kse.go
@@ -121,19 +121,15 @@ func (wb *KSE) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
-	s := binary.BigEndian.Uint16(b)
-
-	switch s {
+	switch status := binary.BigEndian.Uint16(b); status {
 	case 0, 1, 3:
 		return api.StatusA, nil
 	case 4:
 		return api.StatusB, nil
 	case 5:
 		return api.StatusC, nil
-	case 6, 7, 8:
-		return api.StatusE, nil
 	default:
-		return api.StatusNone, fmt.Errorf("invalid status: %d", s)
+		return api.StatusNone, fmt.Errorf("invalid status: %d", status)
 	}
 }
 

--- a/charger/mennekes-hcc3.go
+++ b/charger/mennekes-hcc3.go
@@ -96,17 +96,15 @@ func (wb *MennekesHcc3) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
-	switch binary.BigEndian.Uint16(b) {
+	switch status := binary.BigEndian.Uint16(b); status {
 	case 1, 2:
 		return api.StatusA, nil
 	case 3, 4:
 		return api.StatusB, nil
 	case 5, 6:
 		return api.StatusC, nil
-	case 7, 8:
-		return api.StatusD, nil
 	default:
-		return api.StatusNone, fmt.Errorf("invalid status: %0x", b[1])
+		return api.StatusNone, fmt.Errorf("invalid status: %d", status)
 	}
 }
 

--- a/charger/nrgble_linux.go
+++ b/charger/nrgble_linux.go
@@ -214,7 +214,7 @@ func (wb *NRGKickBLE) mergeSettings(info ble.Info) ble.Settings {
 func (wb *NRGKickBLE) Status() (api.ChargeStatus, error) {
 	var res ble.Power
 	if err := wb.read(ble.PowerService, &res); err != nil {
-		return api.StatusF, err
+		return api.StatusNone, err
 	}
 
 	wb.log.TRACE.Printf("read power: %+v", res)
@@ -226,9 +226,9 @@ func (wb *NRGKickBLE) Status() (api.ChargeStatus, error) {
 		return api.StatusC, nil
 	case 4:
 		return api.StatusA, nil
+	default:
+		return api.StatusNone, fmt.Errorf("invalid status: %d", res.CPSignal)
 	}
-
-	return api.StatusA, fmt.Errorf("unexpected cp signal: %d", res.CPSignal)
 }
 
 // Enabled implements the api.Charger interface

--- a/charger/nrggen2.go
+++ b/charger/nrggen2.go
@@ -164,11 +164,11 @@ func (nrg *NRGKickGen2) Status() (api.ChargeStatus, error) {
 		if err != nil {
 			return api.StatusNone, err
 		}
-		return api.StatusF, fmt.Errorf("%d", binary.BigEndian.Uint16(b))
+		return api.StatusNone, fmt.Errorf("charger error: %d", binary.BigEndian.Uint16(b))
 	case 7:
 		return api.StatusB, nil
 	default:
-		return api.StatusNone, fmt.Errorf("unhandled status type")
+		return api.StatusNone, fmt.Errorf("invalid status: %d", status)
 	}
 }
 

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -215,12 +215,8 @@ func (c *OCPP) Status() (api.ChargeStatus, error) {
 	case
 		core.ChargePointStatusCharging: // "Charging"
 		return api.StatusC, nil
-	case
-		core.ChargePointStatusReserved, // "Reserved"
-		core.ChargePointStatusFaulted:  // "Faulted"
-		return api.StatusF, fmt.Errorf("chargepoint status: %s", status)
 	default:
-		return api.StatusNone, fmt.Errorf("invalid chargepoint status: %s", status)
+		return api.StatusNone, fmt.Errorf("invalid status: %s", status)
 	}
 }
 

--- a/charger/openevse.go
+++ b/charger/openevse.go
@@ -137,6 +137,10 @@ func (c *OpenEVSE) hasPhaseSwitchCapabilities() error {
 // Status implements the api.Charger interface
 func (c *OpenEVSE) Status() (api.ChargeStatus, error) {
 	res, err := c.statusG.Get()
+	if err != nil {
+		return api.StatusNone, err
+	}
+
 	/*
 		0: "unknown",
 		1: "not connected",
@@ -154,20 +158,18 @@ func (c *OpenEVSE) Status() (api.ChargeStatus, error) {
 		255: "disabled"
 	*/
 
-	switch state := res.State; state {
+	switch res.State {
 	case 1:
-		return api.StatusA, err
+		return api.StatusA, nil
 	case 2, 254, 255:
 		if res.Vehicle == 1 {
-			return api.StatusB, err
+			return api.StatusB, nil
 		}
-		return api.StatusA, err
+		return api.StatusA, nil
 	case 3:
-		return api.StatusC, err
-	case 4:
-		return api.StatusD, err
+		return api.StatusC, nil
 	default:
-		return api.StatusNone, fmt.Errorf("invalid status: %d", state)
+		return api.StatusNone, fmt.Errorf("invalid status: %d", res.State)
 	}
 }
 

--- a/charger/openevse.go
+++ b/charger/openevse.go
@@ -166,10 +166,8 @@ func (c *OpenEVSE) Status() (api.ChargeStatus, error) {
 		return api.StatusC, err
 	case 4:
 		return api.StatusD, err
-	case 5, 6, 7, 8, 9, 10, 11:
-		return api.StatusF, err
 	default:
-		return api.StatusNone, fmt.Errorf("unknown EVSE state: %d", state)
+		return api.StatusNone, fmt.Errorf("invalid status: %d", state)
 	}
 }
 

--- a/charger/pcelectric.go
+++ b/charger/pcelectric.go
@@ -119,48 +119,25 @@ func (wb *PCElectric) Status() (api.ChargeStatus, error) {
 	}
 	wb.log.DEBUG.Printf("chargeStatus: %d", chargeStatus)
 
-	var res api.ChargeStatus
 	switch chargeStatus {
 	case 0x00, 0x10: // notconnected
-		res = api.StatusA
+		return api.StatusA, nil
 	case 0x30: // connected
-		res = api.StatusB
+		return api.StatusB, nil
 	case 0x40: // charging
-		res = api.StatusC
+		return api.StatusC, nil
 	case 0x42, // chargepaused
 		0x50, // chargefinished
 		0x60: // chargecancelled
-		res = api.StatusB
+		return api.StatusB, nil
 	case 0x90: // unavailable
 		if sessionStartTime > 0 {
-			res = api.StatusB
-		} else {
-			res = api.StatusF
+			return api.StatusB, nil
 		}
-	case 0x95, // dcfault
-		0x96, // dchardwarefault
-		0x9A, // cpfault
-		0x9B: // cpshorted
-		res = api.StatusE
-	case 0x70, // overheat
-		0x80, // criticaltemperature
-		0x91, // reserved
-		0x9C, // remotedisabled
-		0x9D, // dlmfault
-		0xA0, // cablefault
-		0xA1,
-		0xA2, // lockingfault
-		0xA3,
-		0xA4, // contactorfault
-		0xA8, // rcdfault
-		0xF0, // wait
-		0xF1: // ventfault
-		res = api.StatusF
-	default: // generalfault
-		res = api.StatusF
+		fallthrough
+	default:
+		return api.StatusNone, fmt.Errorf("invalid status: %d", chargeStatus)
 	}
-
-	return res, nil
 }
 
 // Enabled implements the api.Charger interface

--- a/charger/sgready.go
+++ b/charger/sgready.go
@@ -167,7 +167,7 @@ func (wb *SgReady) Status() (api.ChargeStatus, error) {
 	}
 
 	if mode == Stop {
-		return api.StatusE, errors.New("stop mode")
+		return api.StatusNone, errors.New("stop mode")
 	}
 
 	status := map[int64]api.ChargeStatus{Boost: api.StatusC, Normal: api.StatusB}[mode]

--- a/charger/smartevse.go
+++ b/charger/smartevse.go
@@ -117,10 +117,6 @@ func (wb *smartEVSE) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 3:
 		return api.StatusC, nil
-	case 4:
-		return api.StatusD, nil
-	case 5:
-		return api.StatusE, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", status)
 	}

--- a/charger/smartevse.go
+++ b/charger/smartevse.go
@@ -121,10 +121,8 @@ func (wb *smartEVSE) Status() (api.ChargeStatus, error) {
 		return api.StatusD, nil
 	case 5:
 		return api.StatusE, nil
-	case 6:
-		return api.StatusF, nil
 	default:
-		return api.StatusNone, fmt.Errorf("invalid status returned: %d", status)
+		return api.StatusNone, fmt.Errorf("invalid status: %d", status)
 	}
 }
 

--- a/charger/solax.go
+++ b/charger/solax.go
@@ -130,10 +130,6 @@ func (wb *Solax) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 2: // "Charging"
 		return api.StatusC, nil
-	case
-		6, // "Reserved"
-		4: // "Faulted"
-		return api.StatusF, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", s)
 	}

--- a/charger/sungrow.go
+++ b/charger/sungrow.go
@@ -134,11 +134,6 @@ func (wb *Sungrow) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 3: // Charging
 		return api.StatusC, nil
-	case
-		7, // Reserved
-		8, // Disabled
-		9: // Faulted
-		return api.StatusF, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", s)
 	}

--- a/vehicle/porsche/provider.go
+++ b/vehicle/porsche/provider.go
@@ -107,14 +107,12 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 				return api.StatusA, nil
 			}
 			switch res2.BatteryChargeStatus.ChargingState {
-			case "ERROR":
-				return api.StatusF, nil
 			case "OFF", "COMPLETED":
 				return api.StatusB, nil
 			case "ON", "CHARGING":
 				return api.StatusC, nil
 			default:
-				return api.StatusNone, errors.New("emobility - unknown charging state: " + res2.BatteryChargeStatus.ChargingState)
+				return api.StatusNone, errors.New("emobility - invalid status: " + res2.BatteryChargeStatus.ChargingState)
 			}
 		}
 	}


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/pull/17950#discussion_r1899398722

E kann nicht entfernt werden da wir den mit kleinem Hack bei einigen Chargern auf A mappen.

Out of scope:

- [ ] replace A/B/C with Disconnected, Connected, Charging
- [ ] replace ChargeStatusString and ChargeStatusStringWithMapping