### PR TITLE
Add SAJ R5 template

### DIFF
--- a/templates/definition/meter/saj-r5.yaml
+++ b/templates/definition/meter/saj-r5.yaml
@@ -1,0 +1,31 @@
+template: saj-r5
+products:
+  - brand: SAJ
+    description:
+      generic: R5 Series Solar Inverter
+params:
+  - name: usage
+    choice: ["pv"]
+  - name: modbus
+    choice: ["rs485"]
+    baudrate: 9600
+    comset: 8N1
+render: |
+  type: custom
+  {{- if eq .usage "pv" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 275 # 0x0113 Active power of inverter total output
+      type: holding
+      decode: uint16
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 305 # 0x0131 Total Energy
+      type: holding
+      decode: uint32
+    scale: 0.01
+  {{- end }}


### PR DESCRIPTION
This PR adds support for SAJ R5 inverters, based on both https://github.com/tcoenraad/evcc/blob/ad76e2c140258fc64ecc10bb25ff0fb83c43329c/templates/definition/meter/saj-h2.yaml and https://github.com/wimb0/home-assistant-saj-r5-modbus.

Tested with our own SAJ R5 inverter on a EW11 via `modbus: tcpip`:

<img width="780" alt="image" src="https://github.com/user-attachments/assets/17193263-0ccf-4aca-9130-02f0953aeac3" />
