### PR TITLE
Plugins: add timeseries

### DIFF
--- a/provider/timeseries.go
+++ b/provider/timeseries.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/jinzhu/now"
+)
+
+type timeseriesProvider struct{}
+
+func init() {
+	registry.AddCtx("timeseries", TimeSeriesFromConfig)
+}
+
+// TimeSeriesFromConfig creates timeseries provider
+func TimeSeriesFromConfig(ctx context.Context, other map[string]interface{}) (Provider, error) {
+	p := &timeseriesProvider{}
+
+	return p, nil
+}
+
+var _ StringProvider = (*timeseriesProvider)(nil)
+
+func (p *timeseriesProvider) StringGetter() (func() (string, error), error) {
+	return func() (string, error) {
+		res := make(api.Rates, 48)
+		ts := now.BeginningOfHour()
+		for i := 0; i < 48; i++ {
+			res[i] = api.Rate{
+				Start: ts,
+				End:   ts.Add(time.Hour),
+			}
+			ts = ts.Add(time.Hour)
+		}
+
+		b, err := json.Marshal(res)
+		return string(b), err
+	}, nil
+}

--- a/provider/timeseries.go
+++ b/provider/timeseries.go
@@ -16,10 +16,8 @@ func init() {
 }
 
 // TimeSeriesFromConfig creates timeseries provider
-func TimeSeriesFromConfig(ctx context.Context, other map[string]interface{}) (Provider, error) {
-	p := &timeseriesProvider{}
-
-	return p, nil
+func TimeSeriesFromConfig(_ context.Context, _ map[string]interface{}) (Provider, error) {
+	return new(timeseriesProvider), nil
 }
 
 var _ StringProvider = (*timeseriesProvider)(nil)


### PR DESCRIPTION
`timeseries` plugin can be used with custom tariffs that provide forecast based on formula like this: 

```yaml
type: custom
forecast:
  source: timeseries
formula: |
  base := 0.35;
  if ts.Month() >= 6 && ts.Month() <= 9 {
    base = 0.40;
    if ts.Hour() >= 15 && ts.Hour() < 16 {
      base = 0.45
    } else if ts.Hour() >= 16 && ts.Hour() < 21 {
      base = 0.62
    } else if ts.Hour() >= 21 {
      base = 0.45
    }
  } else if ts.Hour() >= 15 && ts.Hour() < 16 {
    base = 0.36
  } else if ts.Hour() >= 16 && ts.Hour() < 21 {
    base = 0.38
  } else if ts.Hour() >= 21 {
    base = 0.36
  };
  base
```

Length of the time series is 48 hours.

/cc @VolkerK62 