### PR TITLE
demo-battery: default für power und soc ergänzt

### DIFF
--- a/templates/definition/meter/demo-battery.yaml
+++ b/templates/definition/meter/demo-battery.yaml
@@ -15,11 +15,13 @@ params:
     description:
       de: Leistung (W)
       en: Power (W)
+    default: 0
     type: int
   - name: soc
     description:
       de: Ladestand (%)
       en: Charge (%)
+    default: 0
     type: int
   - name: controllable
     description:


### PR DESCRIPTION
Obwohl "optional" führt das Weglassen in der Config zu einem Fehler. Vermutlich durch `type: int`?
![image](https://github.com/user-attachments/assets/8fec0661-98d8-4a33-8b1e-f0e6e5d2cc2c)
