### PR TITLE
waitForResponse provider

### DIFF
--- a/provider/wait_for_response.go
+++ b/provider/wait_for_response.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/evcc-io/evcc/util"
+)
+
+type waitForResponseProvider struct {
+	ctx  context.Context
+	set  Config
+	get  Config
+	done chan getterResult
+	log  *util.Logger
+}
+
+type getterResult struct {
+	val string
+	err error
+}
+
+func init() {
+	registry.AddCtx("waitForResponse", NewWaitForResponseFromConfig)
+}
+
+func NewWaitForResponseFromConfig(ctx context.Context, other map[string]interface{}) (Provider, error) {
+	var cc struct {
+		Set Config
+		Get Config
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	log := util.NewLogger("waitForResponse")
+
+	wfr := &waitForResponseProvider{
+		ctx:  ctx,
+		set:  cc.Set,
+		get:  cc.Get,
+		log:  log,
+		done: make(chan getterResult),
+	}
+
+	return wfr, nil
+}
+
+func (wfr *waitForResponseProvider) IntSetter(param string) (func(int64) error, error) {
+	return func(val int64) error {
+		setter, err := NewIntSetterFromConfig(wfr.ctx, param, wfr.set)
+		if err != nil {
+			return err
+		}
+
+		getter, err := NewStringGetterFromConfig(wfr.ctx, wfr.get)
+		if err != nil {
+			return err
+		}
+
+		go func() {
+			val, err := getter()
+			wfr.log.DEBUG.Println("got", val, err)
+			wfr.done <- getterResult{val, err}
+		}()
+		wfr.log.DEBUG.Println("setting", val)
+		setter(val)
+		result := <-wfr.done
+		if result.err != nil {
+			return fmt.Errorf("timeout waiting for response")
+		}
+
+		success, err := strconv.ParseBool(result.val)
+		if err != nil {
+			return err
+		}
+		if !success {
+			return fmt.Errorf("failed to set value: %s", result.val)
+		}
+		return nil
+	}, nil
+}


### PR DESCRIPTION
The waitForResponse provider (final name tbd) is useful for waiting on (and checking) a response to a setter that executes its side effect asynchronously. This provider itself is a setter and is configured with two separate providers, one a `set` provider that will asynchronously cause a side effect, and one `get` provider that will block until a response to the side effect is available. The result of the get is converted into a boolean using `strconv.ParseBool` to determine if the set was successful.

The classic example where this is useful is an MQTT based API where a request is made by publishing to a given topic, which is consumed by a device. The device then publishes the response on a separate topic to be consumed by the caller. This provider can connect the two legs of this exchange to make it possible to treat this style of communication as a synchronous API call.

Note that this will not work correctly if the configured get provider is does not block while waiting for the response as the implementation first attempts to read the getter and while that blocks calls the setter.

An example configuration that uses this provider looks like:
```
batterymode:
  source: switch
  switch:
  - case: 1
    set:
      source: sequence
      set:
        - source: waitForResponse
          set:
            source: mqtt
            topic: dongle-40:4C:CA:xx:xx:xx/update
            payload: '{"setting": "DischgPowerPercentCMD", "value": 100, "from": "evcc"}'
          get:
            source: mqtt
            topic: dongle-40:4C:CA:xx:xx:xx/response
            jq: .status == "success"
            timeout: 30s
```
In this example, the `DischgPowerPercentCMD` command is sent to the `/update` topic which is consumed by the LUX inverter. The result status is then published to the `/response` topic (which looks like `{"status":"success"}`). This is consumed by the get MQTT provider and transformed by the jq expression into something that `strconv.ParseBool` can parse.

@andig curious what you think! if you like the direction, I'm wondering if I should be implementing setters for bool and float as well. Also I'm happy to change the name if you can think of something better.

