### PR TITLE
Revert Amber tariff to fetch every minute

### DIFF
--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -83,7 +83,7 @@ func NewAmberFromConfig(other map[string]interface{}) (api.Tariff, error) {
 func (t *Amber) run(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := time.Tick(time.Minute); ; <-tick {
 		var res []amber.PriceInfo
 		uri := fmt.Sprintf("%s&endDate=%s", t.uri, time.Now().AddDate(0, 0, 2).Format("2006-01-02"))
 


### PR DESCRIPTION
It looks like the Amber tariff was changed to fetch every hour as part of https://github.com/evcc-io/evcc/pull/17601

To me this seems like a simple copy/paste error. This PR reverts to the previous behaviour. If there is an issue with fetching every minute, please let me know.

Amber's pricing will change _extremely_ frequently, and fetching it every hour is not sufficient to get an accurate view of pricing.

Additionally, Amber will be switching to 5-minute settlement (down from the current 30-minute) early this year, which makes the fetch frequency even more important.