### PR TITLE
SonnenBatterie: add support for time-of-use operating mode

### DIFF
--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -9,11 +9,11 @@ requirements:
   description:
     de: |
       Für die aktive Batteriesteuerung muss über das Webinterface der sonnenBatterie (unter Software-Integration) das "JSON Write API" aktiviert und das dort generierte API-Token in der Batteriekonfiguration unter `token` eingetragen werden.
-      Als Betriebsart der sonnenBatterie werden die beiden Modi "Eigenverbrauch" (Standard) und "Time-of-use" unterstützt. Der Modus kann über den Parameter `operatingmode` an die Konfiguration der sonnenBatterie angepasst werden.
+      Als Betriebsart der sonnenBatterie werden die beiden Modi "Eigenverbrauch" (Standard) und "Time-of-use" unterstützt. Der Modus kann über den Parameter `defaultmode` an die Konfiguration der sonnenBatterie angepasst werden.
       Die Leistung für das Netzladen kann an die Wechselrichterleistung der sonnenBatterie über den Parameter `chargepower` angepasst werden.
     en: |
       For active battery control, the "JSON Write API" must be activated via the sonnenBatterie web interface (under Software-Integration) and the API token generated there must be entered in the battery configuration under `token`.
-      The two operating modes supported for the sonnenBatterie are “self-consumption” (default) and “time-of-use”. The mode can be adapted to the configuration of the sonnenBatterie via the 'operatingmode' parameter.
+      The two operating modes supported for the sonnenBatterie are “self-consumption” (default) and “time-of-use”. The mode can be adapted to the configuration of the sonnenBatterie via the 'defaultmode' parameter.
       The power for grid charging can be adapted to the inverter power of the sonnenBatterie via the `chargepower` parameter.
 params:
   - name: usage
@@ -30,14 +30,14 @@ params:
       de: API Token (benötigt für aktive Batteriesteuerung)
       en: API Token (required for active battery control)
     usages: ["battery"]
-  - name: operatingmode
+  - name: defaultmode
     type: choice
     choice: ["self-consumption", "time-of-use"]
     default: self-consumption
     advanced: true
     help:
-      de: Standardbetriebsart (self-consumption / time-of-use)
-      en: Default Operating Mode (self-consumption / time-of-use)
+      de: Standardmodus für die aktive Batteriesteuerung (self-consumption oder time-of-use)
+      en: Default mode for active battery control (self-consumption or time-of-use)
     usages: ["battery"]
   - name: chargepower
     default: 3300
@@ -77,7 +77,7 @@ render: |
         headers:
         - content-type: application/json
         - Auth-Token: {{ .token }}
-        {{- if eq .operatingmode "time-of-use" }}
+        {{- if eq .defaultmode "time-of-use" }}
         body: '{"EM_OperatingMode":"10"}' # Time-of-use
         {{- else }}
         body: '{"EM_OperatingMode":"2"}'  # Self-consumption
@@ -93,7 +93,7 @@ render: |
           headers:
           - content-type: application/json
           - Auth-Token: {{ .token }}
-          body: '{"EM_OperatingMode":"1"}'  # manual
+          body: '{"EM_OperatingMode":"1"}'  # Manual
         - source: http
           uri: http://{{ .host }}/api/v2/setpoint/discharge/0
           insecure: true

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -9,9 +9,11 @@ requirements:
   description:
     de: |
       Für die aktive Batteriesteuerung muss über das Webinterface der sonnenBatterie (unter Software-Integration) das "JSON Write API" aktiviert und das dort generierte API-Token in der Batteriekonfiguration unter `token` eingetragen werden.
+      Als Betriebsart der sonnenBatterie werden die beiden Modi "Eigenverbrauch" (Standard) und "Time-of-use" unterstützt. Der Modus kann über den Parameter `operatingmode` an die Konfiguration der sonnenBatterie angepasst werden.
       Die Leistung für das Netzladen kann an die Wechselrichterleistung der sonnenBatterie über den Parameter `chargepower` angepasst werden.
     en: |
       For active battery control, the "JSON Write API" must be activated via the sonnenBatterie web interface (under Software-Integration) and the API token generated there must be entered in the battery configuration under `token`.
+      The two operating modes supported for the sonnenBatterie are “self-consumption” (default) and “time-of-use”. The mode can be adapted to the configuration of the sonnenBatterie via the 'operatingmode' parameter.
       The power for grid charging can be adapted to the inverter power of the sonnenBatterie via the `chargepower` parameter.
 params:
   - name: usage
@@ -27,6 +29,15 @@ params:
     help:
       de: API Token (benötigt für aktive Batteriesteuerung)
       en: API Token (required for active battery control)
+    usages: ["battery"]
+  - name: operatingmode
+    type: choice
+    choice: ["self-consumption", "time-of-use"]
+    default: self-consumption
+    advanced: true
+    help:
+      de: Standardbetriebsart (self-consumption / time-of-use)
+      en: Default Operating Mode (self-consumption / time-of-use)
     usages: ["battery"]
   - name: chargepower
     default: 3300
@@ -66,7 +77,11 @@ render: |
         headers:
         - content-type: application/json
         - Auth-Token: {{ .token }}
-        body: '{"EM_OperatingMode":"2"}'  # self consumption
+        {{- if eq .operatingmode "time-of-use" }}
+        body: '{"EM_OperatingMode":"10"}' # Time-of-use
+        {{- else }}
+        body: '{"EM_OperatingMode":"2"}'  # Self-consumption
+        {{- end }}
     - case: 2 # hold
       set:
         source: sequence


### PR DESCRIPTION
Currently evcc only supports the` self-consumption` mode of the sonnenBatterie. This PR adds support for the `time-of-us`e mode for users who operate their battery in this mode.

By default, evcc still assumes `self-consumption`, but the mode can be selected with the `operatingmode` parameter.