### PR TITLE
template for monitormysolar dongle

### DIFF
--- a/templates/definition/meter/monitormysolar.yaml
+++ b/templates/definition/meter/monitormysolar.yaml
@@ -12,25 +12,25 @@ requirements:
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
-  - name: dongle_id
+  - name: dongleId
     type: string
     required: true
     description:
       generic: The ID of the dongle.
     example: dongle-40:4C:xx:xx:xx:xx
-  - name: dongle_host
+  - name: dongleHost
     type: string
     description:
       generic: The hostname or IP address of the dongle. Required for battery control.
     example: monitormysolar.local
-  - name: battery_hold_percent
+  - name: batteryHoldPercent
     type: int
     advanced: true
     description:
       generic: Power percentage to discharge the battery when in hold mode.
     example: 0
     default: 0
-  - name: battery_charge_percent
+  - name: batteryChargePercent
     type: int
     advanced: true
     description:
@@ -44,41 +44,41 @@ render: |
   {{- if eq .usage "grid" }}
   power:
     source: mqtt
-    topic: {{ .dongle_id }}/inputbank1
+    topic: {{ .dongleId }}/inputbank1
     jq: (-1 * .payload.Ptogrid) + .payload.Ptouser
     timeout: 30s
   energy:
     source: mqtt
-    topic: {{ .dongle_id }}/inputbank1
+    topic: {{ .dongleId }}/inputbank1
     jq: .payload.Einv_day
     timeout: 30s
   {{- end }}
   {{- if eq .usage "pv" }}
   power:
     source: mqtt
-    topic: {{ .dongle_id }}/inputbank1
+    topic: {{ .dongleId }}/inputbank1
     jq: .payload.Pall
     timeout: 30s
   energy:
     source: mqtt
-    topic: {{ .dongle_id }}/inputbank1
+    topic: {{ .dongleId }}/inputbank1
     jq: .payload.Epv1_day + .payload.Epv2_day + .payload.Epv3_day
     timeout: 30s
   {{- end }}
   {{- if eq .usage "battery" }}
   power:
     source: mqtt
-    topic: {{ .dongle_id }}/inputbank1
+    topic: {{ .dongleId }}/inputbank1
     jq: (-1 * .payload.Pcharge) + .payload.Pdischarge
     timeout: 30s
   energy:
     source: mqtt
-    topic: {{ .dongle_id }}/inputbank1
+    topic: {{ .dongleId }}/inputbank1
     jq: .payload.Edischg_day
     timeout: 30s
   soc:
     source: mqtt
-    topic: {{ .dongle_id }}/inputbank1
+    topic: {{ .dongleId }}/inputbank1
     jq: .payload.SOC
     timeout: 30s
   batterymode:
@@ -87,7 +87,7 @@ render: |
     - case: 1 # normal 
       set:
         source: http
-        uri: http://{{ .dongle_host }}/evcc/update
+        uri: http://{{ .dongleHost }}/evcc/update
         method: POST
         headers:
         - content-type: application/json
@@ -95,18 +95,18 @@ render: |
     - case: 2 # hold
       set:
         source: http
-        uri: http://{{ .dongle_host }}/evcc/update
+        uri: http://{{ .dongleHost }}/evcc/update
         method: POST
         headers:
         - content-type: application/json
-        body: '{ "update": "batteryhold", "value": {{ .battery_hold_percent }} }'
+        body: '{ "update": "batteryhold", "value": {{ .batteryHoldPercent }} }'
     - case: 3 # charge
       set:
         source: http
-        uri: http://{{ .dongle_host }}/evcc/update
+        uri: http://{{ .dongleHost }}/evcc/update
         method: POST
         headers:
         - content-type: application/json
-        body: '{ "update": "batterycharge", "value": {{ .battery_charge_percent }} }'
+        body: '{ "update": "batterycharge", "value": {{ .batteryChargePercent }} }'
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/monitormysolar.yaml
+++ b/templates/definition/meter/monitormysolar.yaml
@@ -1,0 +1,112 @@
+template: monitormysolar
+products:
+  - brand: LUX
+    description:
+      generic: TODO
+capabilities: ["battery-control"]
+requirements:
+  description:
+    en: |
+      This meter is compatible with inverters with the MonitorMySolar dongle. See https://monitormy.solar/ for more information.
+      Dongle firmware version XX or greater is required.
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+  - name: dongle_id
+    type: string
+    required: true
+    description:
+      generic: The ID of the dongle.
+    example: dongle-40:4C:xx:xx:xx:xx
+  - name: dongle_host
+    type: string
+    description:
+      generic: The hostname or IP address of the dongle. Required for battery control.
+    example: monitormysolar.local
+  - name: battery_hold_percent
+    type: int
+    advanced: true
+    description:
+      generic: Power percentage to discharge the battery when in hold mode.
+    example: 0
+    default: 0
+  - name: battery_charge_percent
+    type: int
+    advanced: true
+    description:
+      generic: Power percentage to charge the battery when in charge mode.
+    example: 100
+    default: 100
+  - name: capacity
+    advanced: true
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: mqtt
+    topic: {{ .dongle_id }}/inputbank1
+    jq: (-1 * .payload.Ptogrid) + .payload.Ptouser
+    timeout: 30s
+  energy:
+    source: mqtt
+    topic: {{ .dongle_id }}/inputbank1
+    jq: .payload.Einv_day
+    timeout: 30s
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: mqtt
+    topic: {{ .dongle_id }}/inputbank1
+    jq: .payload.Pall
+    timeout: 30s
+  energy:
+    source: mqtt
+    topic: {{ .dongle_id }}/inputbank1
+    jq: .payload.Epv1_day + .payload.Epv2_day + .payload.Epv3_day
+    timeout: 30s
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: mqtt
+    topic: {{ .dongle_id }}/inputbank1
+    jq: (-1 * .payload.Pcharge) + .payload.Pdischarge
+    timeout: 30s
+  energy:
+    source: mqtt
+    topic: {{ .dongle_id }}/inputbank1
+    jq: .payload.Edischg_day
+    timeout: 30s
+  soc:
+    source: mqtt
+    topic: {{ .dongle_id }}/inputbank1
+    jq: .payload.SOC
+    timeout: 30s
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal 
+      set:
+        source: http
+        uri: http://{{ .dongle_host }}/evcc/update
+        method: POST
+        headers:
+        - content-type: application/json
+        body: '{ "update": "batterynormal" }'
+    - case: 2 # hold
+      set:
+        source: http
+        uri: http://{{ .dongle_host }}/evcc/update
+        method: POST
+        headers:
+        - content-type: application/json
+        body: '{ "update": "batteryhold", "value": {{ .battery_hold_percent }} }'
+    - case: 3 # charge
+      set:
+        source: http
+        uri: http://{{ .dongle_host }}/evcc/update
+        method: POST
+        headers:
+        - content-type: application/json
+        body: '{ "update": "batterycharge", "value": {{ .battery_charge_percent }} }'
+  capacity: {{ .capacity }} # kWh
+  {{- end }}


### PR DESCRIPTION
This PR adds a meter template for the monitormysolar dongle (https://monitormy.solar/detail/13) which gives evcc access to LUX inverters (and others in the future). This template provides grid, pv, and battery data as well as battery control support.

Sample config:
```
meters:
  - name: my_grid
    type: template
    template: monitormysolar
    usage: grid
    dongleId: dongle-40:4C:CA:xx:xx:xx
  - name: my_pv
    type: template
    template: monitormysolar
    usage: pv
    dongleId: dongle-40:4C:CA:xx:xx:xx
  - name: my_battery
    type: template
    template: monitormysolar
    usage: battery
    dongleId: dongle-40:4C:CA:xx:xx:xx
    dongleHost: e06d094c-1fa7-4fb7-80ee-b250dce7ea49.mock.pstmn.io
```

Sample `meter` output:

```
$ ./evcc -c ./evcc.yaml meter
[main  ] INFO 2025/01/08 16:44:01 evcc b728e23c (b728e23c)
[main  ] INFO 2025/01/08 16:44:01 using config file: ./evcc.yaml
[db    ] INFO 2025/01/08 16:44:01 using sqlite database: /Users/skrul/.evcc/evcc.db
[mqtt  ] INFO 2025/01/08 16:44:01 connecting evcc-2068687641 at tcp://10.0.0.101:1883
[mqtt  ] DEBUG 2025/01/08 16:44:01 tcp://10.0.0.101:1883 connected
my_grid
-------
Power:  0W
Energy: 10.9kWh

my_pv
-----
Power:  107W
Energy: 19.8kWh

my_battery
----------
Power:        234W
Energy:       3.0kWh
Soc:          97%
Controllable: true
```