### PR TITLE
Add tcpip to SAJ R5

### DIFF
--- a/templates/definition/meter/saj-r5.yaml
+++ b/templates/definition/meter/saj-r5.yaml
@@ -7,7 +7,7 @@ params:
   - name: usage
     choice: ["pv"]
   - name: modbus
-    choice: ["rs485"]
+    choice: ["rs485", "tcpip"]
     baudrate: 9600
     comset: 8N1
 render: |


### PR DESCRIPTION
Like described in my previous [PR for SAJ R5](https://github.com/evcc-io/evcc/pull/18014), I used `tcpip` for modbus. This PR adds that to docs too.