### PR TITLE
Bugfix: MG: avoid blockig new requests

### DIFF
--- a/vehicle/saic/api.go
+++ b/vehicle/saic/api.go
@@ -103,6 +103,11 @@ func (v *API) repeatRequest(path string, event_id string) {
 		count++
 	}
 
+	// Make sure that we don't exit here with status running (probably after 20 tries).
+	// This would not allow us to ever do a query again.
+	if v.request.Status == StatRunning {
+		v.request.Status = StatInvalid
+	}
 	v.Logger.DEBUG.Printf("Exiting repeated query. Count: %d\n", count)
 }
 


### PR DESCRIPTION
The SAIC Code tries to repeat requests that failed consecutively, so that the main loop is not blocked.
It has a mechanism to make sure that this is only started once. That mechanism could falsely be labeled as running which would block all further requests.
This change fixes that.