### PR TITLE
Fix rct battery charge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -210,4 +210,4 @@ replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20241027151
 
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20241230132027-815870498cc3
 
-replace github.com/mlnoga/rct => github.com/Maschga/rct v0.1.2-0.20250112094625-b2df451c7ef9
+replace github.com/mlnoga/rct => github.com/Maschga/rct v0.1.2-0.20250112193044-2980bbd48edf

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/Maschga/rct v0.1.2-0.20250112094625-b2df451c7ef9 h1:rr2Rk9DNdyFCN8OEIVlxkSt9ftgO1MRWj+3ar39Ldu0=
-github.com/Maschga/rct v0.1.2-0.20250112094625-b2df451c7ef9/go.mod h1:0lfd2mmBnBzIvuzYtdhG+2371u+cUfIxsYErm4P9KRI=
+github.com/Maschga/rct v0.1.2-0.20250112193044-2980bbd48edf h1:OxSUCmjj+ovko/IdC2755mGRNn2G3ksaOkp74Fm0QAI=
+github.com/Maschga/rct v0.1.2-0.20250112193044-2980bbd48edf/go.mod h1:0lfd2mmBnBzIvuzYtdhG+2371u+cUfIxsYErm4P9KRI=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -115,30 +115,34 @@ func NewRCT(uri, usage string, minSoc, maxSoc int, cache time.Duration, capacity
 		batteryMode = func(mode api.BatteryMode) error {
 			switch mode {
 			case api.BatteryNormal:
-				if err := m.conn.Write(rct.PowerMngSocStrategy, []byte{rct.SOCTargetInternal}); err != nil {
+				if err := m.conn.Write(rct.BatterySoCTargetMin, m.floatVal(float32(minSoc)/100)); err != nil {
 					return err
 				}
 
-				return m.conn.Write(rct.PowerMngSocMin, m.floatVal(float32(minSoc)/100))
+				if err := m.conn.Write(rct.PowerMngSocCharge, m.floatVal(float32(0.05))); err != nil {
+					return err
+				}
+
+				if err := m.conn.Write(rct.PowerMngSocChargePowerW, m.floatVal(float32(100))); err != nil {
+					return err
+				}
+
+				return m.conn.Write(rct.BatterySoCTargetMinIsland, m.floatVal(float32(minSoc)/100))
 
 			case api.BatteryHold:
-				if err := m.conn.Write(rct.PowerMngSocStrategy, []byte{rct.SOCTargetInternal}); err != nil {
-					return err
-				}
-
 				soc, err := m.batterySoc()
 				if err != nil {
 					return err
 				}
 
-				return m.conn.Write(rct.PowerMngSocMin, m.floatVal(float32(soc)/100))
+				return m.conn.Write(rct.BatterySoCTargetMin, m.floatVal(float32(soc)/100))
 
 			case api.BatteryCharge:
-				if err := m.conn.Write(rct.PowerMngSocStrategy, []byte{rct.SOCTargetExternal}); err != nil {
+				if err := m.conn.Write(rct.PowerMngSocChargePowerW, m.floatVal(float32(10_000))); err != nil {
 					return err
 				}
 
-				return m.conn.Write(rct.PowerMngSocTargetSet, m.floatVal(float32(maxSoc)/100))
+				return m.conn.Write(rct.PowerMngSocCharge, m.floatVal(float32(maxSoc)/100))
 
 			default:
 				return api.ErrNotAvailable

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -142,6 +142,7 @@ func NewRCT(uri, usage string, minSoc, maxSoc int, cache time.Duration, capacity
 					return err
 				}
 
+				// automatically sets BatterySoCTargetMin and BatterySoCTargetMinIsland to maxsoc
 				return m.conn.Write(rct.PowerMngSocCharge, m.floatVal(float32(maxSoc)/100))
 
 			default:

--- a/templates/definition/meter/rct-power.yaml
+++ b/templates/definition/meter/rct-power.yaml
@@ -14,9 +14,11 @@ params:
   # battery control
   - name: minsoc
     type: int
+    default: 7
     advanced: true
   - name: maxsoc
     type: int
+    default: 97
     advanced: true
 render: |
   type: rct


### PR DESCRIPTION
Hi,

My contribution to https://github.com/evcc-io/evcc/pull/18178

Setting `PowerMngSocCharge` to the wanted SoC makes RCT charge.
However, this automatically sets `BatterySoCTargetMin` and `BatterySoCTargetMinIsland` to the same SoC.
That's the reason, why I reset to these parameters in the case `BatteryNormal`.

~Maschga