### PR TITLE
Charger template for tesla-ble

### DIFF
--- a/templates/definition/charger/tesla-ble.yaml
+++ b/templates/definition/charger/tesla-ble.yaml
@@ -1,0 +1,63 @@
+template: tesla-ble
+products:
+  - description:
+      generic: Tesla BLE
+group: generic
+requirements:
+  description:
+    de: Open Source Tesla BLE HTTP Proxy https://github.com/wimaha/TeslaBleHttpProxy
+    en: Open Source Tesla BLE HTTP Proxy https://github.com/wimaha/TeslaBleHttpProxy
+params:
+  - preset: vehicle-common
+  - name: vin
+    required: true
+    example: W...
+    help:
+      de: Erforderlich für BLE-Verbindung
+      en: Required for BLE connection
+  - name: url
+    required: true
+    example: http://192.168.178.27
+    help:
+      de: URL des Tesla BLE HTTP Proxy
+      en: URL of the Tesla BLE HTTP Proxy
+  - name: port
+    example: 8080
+    default: 8080
+    help:
+      de: Port des Tesla BLE HTTP Proxy
+      en: Port of the Tesla BLE HTTP Proxy
+render: |
+  type: custom
+  power:
+    source: http
+    uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state
+    method: GET
+    jq: .response.response.charge_state.charger_voltage * .response.response.charge_state.charger_actual_current
+    timeout: 30s
+  status:
+    source: http
+    uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state
+    method: GET
+    jq: (if (.response.response.charge_state.charging_state == "Charging") then "C"
+      elif (.response.response.charge_state.charging_state == "Stopped") then "B"
+      elif (.response.response.charge_state.charging_state == "NoPower") then "B"
+      elif (.response.response.charge_state.charging_state == "Complete") then "B" 
+      else "A" end)
+    timeout: 30s
+  enabled:
+    source: http
+    uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state
+    method: GET
+    jq: (.response.response.charge_state.charging_state == "Charging" 
+          and .response.response.charge_state.charger_power > 0)
+    timeout: 30s
+  enable:
+    source: http
+    uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/command/{{`{{ if .chargeenable }}charge_start{{ else }}charge_stop{{ end }}`}}
+    method: POST
+  maxcurrent:
+    source: http
+    uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/command/set_charging_amps
+    method: POST
+    body: '{"charging_amps": ${maxcurrent}}'


### PR DESCRIPTION
This change compliments the tesla-ble vehicle template (see https://github.com/evcc-io/evcc/pull/17866) by interfacing with [TeslaBleHttpProxy](https://github.com/wimaha/TeslaBleHttpProxy) to control charging. This is useful for folks that are using TeslaBleHttpProxy to communicate with their Tesla but who do not have the TWC (wall charger) but rather use the UMC (mobile charger).

Several of the field definitions are the same as the tesla-ble vehicle template since there seems to be a bit of overlap between the vehicle and charger devices.

An example config (has the same fields as the tesla-ble vehicle template):
```
chargers:
  - name: my_charger
    type: template
    template: tesla-ble
    vin: 5YJ3E1Exxxxxxxxxx
    url: http://10.0.0.104
```
