### PR TITLE
Planner: improve plan selection

### DIFF
--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -81,7 +81,7 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 			plans = append(plans, plan{Id: index + 2, Soc: rp.Soc, End: time})
 		}
 
-		// calculate last possible start times
+		// calculate earliest required plan start
 		if plan := lp.nextActivePlan(lp.EffectiveMaxPower(), plans); plan != nil {
 			return plan.End, plan.Soc, plan.Id
 		}

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -82,7 +82,7 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 		}
 
 		// calculate earliest required plan start
-		if plan := lp.nextActivePlan(lp.EffectiveMaxPower(), plans); plan != nil {
+		if plan := lp.nextActivePlan(plans); plan != nil {
 			return plan.End, plan.Soc, plan.Id
 		}
 	}

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -82,7 +82,7 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 		}
 
 		// calculate earliest required plan start
-		if plan := lp.nextActivePlan(plans); plan != nil {
+		if plan := lp.nextActivePlan(lp.EffectiveMaxPower(), plans); plan != nil {
 			return plan.End, plan.Soc, plan.Id
 		}
 	}

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -32,10 +32,10 @@ func (lp *Loadpoint) EffectivePriority() int {
 }
 
 type plan struct {
+	Id    int
 	Start time.Time // last possible start time
 	End   time.Time // user-selected finish time
 	Soc   int
-	Id    int
 }
 
 func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -31,21 +31,39 @@ func (lp *Loadpoint) EffectivePriority() int {
 	return lp.GetPriority()
 }
 
+type plan struct {
+	Start time.Time // last possible start time
+	End   time.Time // user-selected finish time
+	Soc   int
+	Id    int
+}
+
+func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {
+	for i, p := range plans {
+		requiredDuration := lp.GetPlanRequiredDuration(float64(p.Soc), maxPower)
+		plans[i].Start = p.End.Add(-requiredDuration)
+	}
+
+	// sort plans by start time
+	slices.SortStableFunc(plans, func(i, j plan) int {
+		return i.Start.Compare(j.Start)
+	})
+
+	if len(plans) > 0 {
+		return &plans[0]
+	}
+
+	return nil
+}
+
 // nextVehiclePlan returns the next vehicle plan time, soc and id
 func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 	if v := lp.GetVehicle(); v != nil {
-		type plan struct {
-			Start time.Time // last possible start time
-			Time  time.Time // user-selected finish time
-			Soc   int
-			Id    int
-		}
-
 		var plans []plan
 
 		// static plan
 		if planTime, soc := vehicle.Settings(lp.log, v).GetPlanSoc(); soc != 0 {
-			plans = append(plans, plan{Id: 1, Soc: soc, Time: planTime})
+			plans = append(plans, plan{Id: 1, Soc: soc, End: planTime})
 		}
 
 		// repeating plans
@@ -60,23 +78,12 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 				continue
 			}
 
-			plans = append(plans, plan{Id: index + 2, Soc: rp.Soc, Time: time})
+			plans = append(plans, plan{Id: index + 2, Soc: rp.Soc, End: time})
 		}
 
 		// calculate last possible start times
-		for i, p := range plans {
-			maxPower := lp.EffectiveMaxPower()
-			requiredDuration := lp.GetPlanRequiredDuration(float64(p.Soc), maxPower)
-			plans[i].Start = p.Time.Add(-requiredDuration)
-		}
-
-		// sort plans by start time
-		sort.Slice(plans, func(i, j int) bool {
-			return plans[i].Start.Before(plans[j].Start)
-		})
-
-		if len(plans) > 0 {
-			return plans[0].Time, plans[0].Soc, plans[0].Id
+		if plan := lp.nextActivePlan(lp.EffectiveMaxPower(), plans); plan != nil {
+			return plan.End, plan.Soc, plan.Id
 		}
 	}
 	return time.Time{}, 0, 0

--- a/core/loadpoint_effective_test.go
+++ b/core/loadpoint_effective_test.go
@@ -80,29 +80,28 @@ func TestNextPlan(t *testing.T) {
 	lp.charger = api.NewMockCharger(ctrl)
 
 	for _, tc := range []struct {
-		name   string
 		planId int
 		plans  []plan
 	}{
-		{"first wins", 1, []plan{
+		{1, []plan{
 			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
 			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 10},
 		}},
-		{"first wins (overlap)", 1, []plan{
+		{1, []plan{
 			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 20},
 			{Id: 2, End: clock.Now().Add(9 * time.Hour), Soc: 20},
 		}},
-		{"first wins (reverse overlap)", 2, []plan{
+		{2, []plan{
 			{Id: 2, End: clock.Now().Add(8 * time.Hour), Soc: 20},
 			{Id: 1, End: clock.Now().Add(9 * time.Hour), Soc: 20},
 		}},
-		{"last wins", 2, []plan{
+		{2, []plan{
 			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
 			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 60},
 		}},
 	} {
 		res := lp.nextActivePlan(1e4, tc.plans)
-		require.NotNil(t, res, tc.name)
-		assert.Equal(t, tc.planId, res.Id, tc.name)
+		require.NotNil(t, res)
+		assert.Equal(t, tc.planId, res.Id)
 	}
 }

--- a/core/loadpoint_effective_test.go
+++ b/core/loadpoint_effective_test.go
@@ -2,10 +2,13 @@ package core
 
 import (
 	"testing"
+	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -66,5 +69,40 @@ func TestEffectiveMinMaxCurrent(t *testing.T) {
 
 		assert.Equal(t, tc.effectiveMin, lp.effectiveMinCurrent(), "min")
 		assert.Equal(t, tc.effectiveMax, lp.effectiveMaxCurrent(), "max")
+	}
+}
+
+func TestNextPlan(t *testing.T) {
+	clock := clock.NewMock()
+
+	ctrl := gomock.NewController(t)
+	lp := NewLoadpoint(util.NewLogger("foo"), nil)
+	lp.charger = api.NewMockCharger(ctrl)
+
+	for _, tc := range []struct {
+		name   string
+		planId int
+		plans  []plan
+	}{
+		{"first wins", 1, []plan{
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
+			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 10},
+		}},
+		{"first wins (overlap)", 1, []plan{
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 20},
+			{Id: 2, End: clock.Now().Add(9 * time.Hour), Soc: 20},
+		}},
+		{"first wins (reverse overlap)", 2, []plan{
+			{Id: 2, End: clock.Now().Add(8 * time.Hour), Soc: 20},
+			{Id: 1, End: clock.Now().Add(9 * time.Hour), Soc: 20},
+		}},
+		{"last wins", 2, []plan{
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
+			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 60},
+		}},
+	} {
+		res := lp.nextActivePlan(1e4, tc.plans)
+		require.NotNil(t, res, tc.name)
+		assert.Equal(t, tc.planId, res.Id, tc.name)
 	}
 }

--- a/tests/plan.spec.js
+++ b/tests/plan.spec.js
@@ -546,51 +546,6 @@ test.describe("repeating", async () => {
     await expect(modal.getByTestId("target-text")).toContainText("9:30 AM");
   });
 
-  test("next plan selection", async ({ page }) => {
-    const tomorrow = getWeekday(1);
-
-    await page.goto("/");
-
-    const lp1 = await page.getByTestId("loadpoint").first();
-    await lp1
-      .getByTestId("change-vehicle")
-      .locator("select")
-      .selectOption("Vehicle with SoC with Capacity");
-
-    await lp1.getByTestId("charging-plan").getByRole("button", { name: "none" }).click();
-    const modal = await page.getByTestId("charging-plan-modal");
-
-    // daily: 8:00 at 60% plan
-    await modal.getByRole("button", { name: "Add repeating plan" }).click();
-    const plan2 = modal.getByTestId("plan-entry").last();
-    const days = plan2.getByTestId("repeating-plan-weekdays");
-    await days.click();
-    await days.getByRole("checkbox", { name: "Select all" }).check();
-    await days.click(); // close
-    await plan2.getByTestId("repeating-plan-time").fill("08:00");
-    await plan2.getByTestId("repeating-plan-soc").selectOption("60%");
-    await plan2.getByTestId("repeating-plan-active").click();
-
-    // static: 9:00 at 65% for a trip
-    const plan1 = modal.getByTestId("plan-entry").nth(0);
-    await plan1.getByTestId("static-plan-day").selectOption({ index: 1 });
-    await plan1.getByTestId("static-plan-time").fill("09:00");
-    await plan1.getByTestId("static-plan-soc").selectOption("65%");
-    await plan1.getByTestId("static-plan-active").click();
-
-    // verify plan #2 is next, enough time for the following plan (1h for +5%)
-    await expect(modal.getByTestId("plan-preview-title")).toHaveText("Next plan #2");
-    await expect(modal.getByTestId("target-text")).toContainText("8:00 AM");
-
-    // static: increase plan soc to 100%
-    await modal.getByTestId("static-plan-soc").selectOption("100%");
-    await modal.getByTestId("static-plan-apply").click();
-
-    // verify plan #1 is next, skip plan #2 since 1h is not enough for +40%
-    await expect(modal.getByTestId("plan-preview-title")).toHaveText("Next plan #1");
-    await expect(modal.getByTestId("target-text")).toContainText("9:00 AM");
-  });
-
   test("repeating plan persistence", async ({ page }) => {
     await page.goto("/");
 

--- a/tests/plan.spec.js
+++ b/tests/plan.spec.js
@@ -497,6 +497,7 @@ test.describe("repeating", async () => {
     const plan1 = modal.getByTestId("plan-entry").nth(0);
     await plan1.getByTestId("static-plan-day").selectOption({ index: 1 });
     await plan1.getByTestId("static-plan-time").fill("09:30");
+    await plan1.getByTestId("static-plan-soc").selectOption("80%");
     await plan1.getByTestId("static-plan-active").click();
 
     // add repeating plan for tomorrow
@@ -543,6 +544,51 @@ test.describe("repeating", async () => {
     await plan2.getByTestId("repeating-plan-apply").click();
     await expect(modal.getByTestId("plan-preview-title")).toHaveText("Next plan #1");
     await expect(modal.getByTestId("target-text")).toContainText("9:30 AM");
+  });
+
+  test("next plan selection", async ({ page }) => {
+    const tomorrow = getWeekday(1);
+
+    await page.goto("/");
+
+    const lp1 = await page.getByTestId("loadpoint").first();
+    await lp1
+      .getByTestId("change-vehicle")
+      .locator("select")
+      .selectOption("Vehicle with SoC with Capacity");
+
+    await lp1.getByTestId("charging-plan").getByRole("button", { name: "none" }).click();
+    const modal = await page.getByTestId("charging-plan-modal");
+
+    // daily: 8:00 at 60% plan
+    await modal.getByRole("button", { name: "Add repeating plan" }).click();
+    const plan2 = modal.getByTestId("plan-entry").last();
+    const days = plan2.getByTestId("repeating-plan-weekdays");
+    await days.click();
+    await days.getByRole("checkbox", { name: "Select all" }).check();
+    await days.click(); // close
+    await plan2.getByTestId("repeating-plan-time").fill("08:00");
+    await plan2.getByTestId("repeating-plan-soc").selectOption("60%");
+    await plan2.getByTestId("repeating-plan-active").click();
+
+    // static: 9:00 at 65% for a trip
+    const plan1 = modal.getByTestId("plan-entry").nth(0);
+    await plan1.getByTestId("static-plan-day").selectOption({ index: 1 });
+    await plan1.getByTestId("static-plan-time").fill("09:00");
+    await plan1.getByTestId("static-plan-soc").selectOption("65%");
+    await plan1.getByTestId("static-plan-active").click();
+
+    // verify plan #2 is next, enough time for the following plan (1h for +5%)
+    await expect(modal.getByTestId("plan-preview-title")).toHaveText("Next plan #2");
+    await expect(modal.getByTestId("target-text")).toContainText("8:00 AM");
+
+    // static: increase plan soc to 100%
+    await modal.getByTestId("static-plan-soc").selectOption("100%");
+    await modal.getByTestId("static-plan-apply").click();
+
+    // verify plan #1 is next, skip plan #2 since 1h is not enough for +40%
+    await expect(modal.getByTestId("plan-preview-title")).toHaveText("Next plan #1");
+    await expect(modal.getByTestId("target-text")).toContainText("9:00 AM");
   });
 
   test("repeating plan persistence", async ({ page }) => {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/18212

- 🔢 select the plan by "last possible start time" instead of "plan time"

TODO:

- [x] add tests
- [x] backend tests
- [x] check which files the diff belongs to (effective or plan)