### PR TITLE
OCPP: enforce meterValues

### DIFF
--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -125,11 +125,10 @@ func (cp *CP) Setup(meterValues string, meterInterval time.Duration) error {
 
 	// configure measurands
 	if meterValues != "" {
-		if err := cp.ChangeConfigurationRequest(KeyMeterValuesSampledData, meterValues); err == nil || meterValues == "disable" {
-			cp.meterValuesSample = meterValues
-		} else {
+		if err := cp.ChangeConfigurationRequest(KeyMeterValuesSampledData, meterValues); err != nil {
 			cp.log.WARN.Printf("failed configuring %s: %v", KeyMeterValuesSampledData, err)
 		}
+		cp.meterValuesSample = meterValues
 	}
 
 	// trigger initial meter values


### PR DESCRIPTION
Fixes #18215

Allows manual `meterValues` configuration where charger does not export its fixed internal preconfigured measurands  (getConfiguration) and does not allow any auto-detection (read only / not supported / not implemented) but does send metering data.

In this case `meterValues` can be manually set to some of the supported measurands now and they will be always assumed to be available even if the configuration fails.