### PR TITLE
Loadpoint: validate fixed phase configuration

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -623,18 +623,23 @@ func (lp *Loadpoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 	lp.publish(keys.EnableDelay, lp.Enable.Delay)
 	lp.publish(keys.DisableDelay, lp.Disable.Delay)
 
+	if phases := lp.getChargerPhysicalPhases(); phases != 0 {
+		if lp.configuredPhases != phases {
+			lp.log.WARN.Printf("configured phases %d do not match physical phases %d", lp.configuredPhases, phases)
+		}
+		lp.phases = phases
+		lp.configuredPhases = phases
+		lp.publish(keys.ChargerPhysicalPhases, phases)
+	} else {
+		lp.publish(keys.ChargerPhysicalPhases, nil)
+	}
+
 	lp.publish(keys.PhasesConfigured, lp.configuredPhases)
 	lp.publish(keys.ChargerPhases1p3p, lp.hasPhaseSwitching())
 	lp.publish(keys.PhasesEnabled, lp.phases)
 	lp.publish(keys.PhasesActive, lp.ActivePhases())
 	lp.publishTimer(phaseTimer, 0, timerInactive)
 	lp.publishTimer(pvTimer, 0, timerInactive)
-
-	if phases := lp.getChargerPhysicalPhases(); phases != 0 {
-		lp.publish(keys.ChargerPhysicalPhases, phases)
-	} else {
-		lp.publish(keys.ChargerPhysicalPhases, nil)
-	}
 
 	// charger features
 	for _, f := range []api.Feature{api.IntegratedDevice, api.Heating} {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -624,7 +624,7 @@ func (lp *Loadpoint) Prepare(uiChan chan<- util.Param, pushChan chan<- push.Even
 	lp.publish(keys.DisableDelay, lp.Disable.Delay)
 
 	if phases := lp.getChargerPhysicalPhases(); phases != 0 {
-		if lp.configuredPhases != phases {
+		if lp.configuredPhases != phases && lp.configuredPhases != 0 {
 			lp.log.WARN.Printf("configured phases %d do not match physical phases %d", lp.configuredPhases, phases)
 		}
 		lp.phases = phases


### PR DESCRIPTION
In case of fixed-phase meters, we could/should validate if loadpoint config matches charger