### PR TITLE
myPV: fix current calculation by enforcing 1p config

### DIFF
--- a/charger/mypv.go
+++ b/charger/mypv.go
@@ -236,3 +236,10 @@ func (wb *MyPv) GetLimitSoc() (int64, error) {
 
 	return int64(binary.BigEndian.Uint16(b)) / 10, nil
 }
+
+var _ api.PhaseDescriber = (*switchSocket)(nil)
+
+// Phases implements the api.PhasesDescriber interface
+func (v *MyPv) Phases() int {
+	return 1
+}

--- a/charger/mypv.go
+++ b/charger/mypv.go
@@ -237,9 +237,9 @@ func (wb *MyPv) GetLimitSoc() (int64, error) {
 	return int64(binary.BigEndian.Uint16(b)) / 10, nil
 }
 
-var _ api.PhaseDescriber = (*switchSocket)(nil)
+var _ api.PhaseDescriber = (*MyPv)(nil)
 
 // Phases implements the api.PhasesDescriber interface
-func (v *MyPv) Phases() int {
+func (wb *MyPv) Phases() int {
 	return 1
 }


### PR DESCRIPTION
Depends on https://github.com/evcc-io/evcc/pull/18234.

Currently, phase configuration depends on loadpoint. The charger has no access to the loadpoint's phase configuration. myPV charger is controlled by power and assumes 1p connection for converting current to power in `MaxCurrent()`. Hence, we must make sure that loadpoint is configured 1p.