### PR TITLE
use content type text/plain

### DIFF
--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -241,8 +241,8 @@ func healthHandler(site site.API) http.HandlerFunc {
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "OK")
 	}
 }

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -242,6 +242,7 @@ func healthHandler(site site.API) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintln(w, "OK")
 	}
 }


### PR DESCRIPTION
Hi,
the `/health`-Api responds with a simple `OK` while the content type is specified as `application/json`:
![brwoser](https://github.com/user-attachments/assets/fe65ef06-7744-419a-8a26-635d72053b13)
![headers](https://github.com/user-attachments/assets/f787151e-01ea-488b-8424-7ca959ebc8c6)
Therefore I added the correct content type `text/plain`.
~Maschga