### PR TITLE
Changed calculation of battery charge/discharge power

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -112,32 +112,22 @@ render: |
   power:
     source: calc
     mul:
-    - source: calc
-      abs:
-        source: modbus
-        {{- include "modbus" . | indent 6 }}
-        timeout: {{ .timeout }}
-        register:
-          type: input
-          address: 13021 # Battery power
-          decode: int16
-    - source: calc
-      add:
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          type: input
-          address: 13000 # Battery running state
-          decode: bool16
-          bitmask: 2 # Charging
-        scale: -1
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          type: input
-          address: 13000 # Battery running state
-          decode: bool16
-          bitmask: 4 # Discharging
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      register:
+        type: input
+        address: 13019 # Battery voltage
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      timeout: {{ .timeout }}
+      register:
+        type: input
+        address: 13020 # Battery current
+        decode: uint16
+      scale: 0.1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
Sungrow is not updating the "Running State" register 13000 anymore, which was used to determine the charging/discharging state of the battery.
This change will calculate to power using the "Battery voltage" and "Battery current" and remove the need of the "Running State".