### PR TITLE
docs: remove Tesla sponsorship flag

### DIFF
--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -19,7 +19,6 @@ requirements:
       The [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) guide explains the process and generates a free Access and Refresh Token. With this token pair and your Client ID created in the Tesla Developer Account, evcc can directly communicate with the Tesla API. You can see your used credit at Tesla.
 
       To use a Tesla Wall Connector, you need a public Command Proxy Server. [myteslamate.com](https://app.myteslamate.com/) provides this service for 12€/year. Configure the Command permissions at myteslamate.com and enter the Proxy Token here. Start, stopp and current commands are sent to Tesla via this proxy.
-  evcc: ["sponsorship"]
 params:
   - preset: vehicle-common
   - name: clientId


### PR DESCRIPTION
This is not required any more due to the deprecation of tesla.evcc.io.

See https://github.com/evcc-io/evcc/discussions/17501#discussioncomment-11920544