### PR TITLE
Add power consumption meter to Weishaupt WPM

### DIFF
--- a/templates/definition/charger/weishaupt-wpm.yaml
+++ b/templates/definition/charger/weishaupt-wpm.yaml
@@ -141,4 +141,4 @@ render: |
         type: input
         encoding: int16
       scale: 10 
-  {{- end }}  
+  {{- end }}

--- a/templates/definition/charger/weishaupt-wpm.yaml
+++ b/templates/definition/charger/weishaupt-wpm.yaml
@@ -15,6 +15,10 @@ params:
     description:
       de: "Temperaturquelle"
       en: "Temperature source"
+  - name: powerconsumption
+    description:
+      de: "Max. Leistungsaufnahme in kW. Kein exakter Wert, nur zur Anzeige."
+      en: "Max. power consumption in kW. Not an exact value, only for display."
 render: |
   type: sgready
   getmode:
@@ -123,4 +127,18 @@ render: |
       type: input
       encoding: int16
     scale: 0.1
-  {{- end }}
+  {{- end }}  
+  {{- if .powerconsumption }}
+  power:
+    source: calc
+    mul:
+    - source: const
+      value: {{ .powerconsumption }}
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 33103 # Leistungsanforderung
+        type: input
+        encoding: int16
+      scale: 10 
+  {{- end }}  


### PR DESCRIPTION
Introduce a power consumption parameter for display purposes, allowing users to see the maximum power requirement in kW. This value is not exact and serves only for informational display.