### PR TITLE
Versicharge: fix power reading

### DIFF
--- a/charger/versicharge.go
+++ b/charger/versicharge.go
@@ -149,7 +149,7 @@ func (wb *Versicharge) CurrentPower() (float64, error) {
 
 	var sum float64
 	for i := range 3 {
-		sum += float64(binary.BigEndian.Uint16(b[2*i:]))
+		sum += float64(int16(binary.BigEndian.Uint16(b[2*i:])))
 	}
 
 	return sum, nil

--- a/charger/versicharge.go
+++ b/charger/versicharge.go
@@ -149,7 +149,9 @@ func (wb *Versicharge) CurrentPower() (float64, error) {
 
 	var sum float64
 	for i := range 3 {
-		sum += float64(int16(binary.BigEndian.Uint16(b[2*i:])))
+		if u := binary.BigEndian.Uint16(b[2*i:]); u != 0xFFFF {
+			sum += float64(u)
+		}
 	}
 
 	return sum, nil


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/18318

Alternative: `ff ff` als "Fehler" ignorieren.