### PR TITLE
Config UI: improve device updates

### DIFF
--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -619,16 +619,17 @@ export default {
 		async updateValues() {
 			clearTimeout(this.deviceValueTimeout);
 			if (!this.offline) {
-				const promises = [
-					...this.meters.map((meter) => this.updateDeviceValue("meter", meter.name)),
-					...this.vehicles.map((vehicle) =>
-						this.updateDeviceValue("vehicle", vehicle.name)
-					),
-				];
-
-				await Promise.all(promises);
+				for (const meter of this.meters) {
+					await this.updateDeviceValue("meter", meter.name);
+				}
+				for (const vehicle of this.vehicles) {
+					await this.updateDeviceValue("vehicle", vehicle.name);
+				}
 			}
-			this.deviceValueTimeout = setTimeout(this.updateValues, 10000);
+			// ensure that component is still mounted
+			if (!this.$el) return;
+			const interval = (store.state?.interval || 30) * 1000;
+			this.deviceValueTimeout = setTimeout(this.updateValues, interval);
 		},
 		deviceTags(type, id) {
 			return this.deviceValues[type]?.[id] || [];


### PR DESCRIPTION
Improves device status update on config page.

⏳ resepect `interval` setting for status update cycle (before 10s) to prevent overloading sensible devices
♻️ update devices sequentially to reduce concurrent network calls
🚪 ensure status updates are stopped when leaving config page
