### PR TITLE
Loadpoint: keep charger enabled if vehicle has stopped charging

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -700,10 +700,10 @@ func (lp *Loadpoint) setAndPublishEnabled(enabled bool) {
 }
 
 // syncCharger updates charger status and synchronizes it with expectations
-func (lp *Loadpoint) syncCharger() error {
+func (lp *Loadpoint) syncCharger() (bool, error) {
 	enabled, err := lp.charger.Enabled()
 	if err != nil {
-		return fmt.Errorf("charger enabled: %w", err)
+		return false, fmt.Errorf("charger enabled: %w", err)
 	}
 
 	shouldBeConsistent := lp.shouldBeConsistent()
@@ -723,11 +723,11 @@ func (lp *Loadpoint) syncCharger() error {
 
 		if shouldBeConsistent {
 			if err := lp.charger.Enable(true); err != nil { // also enable charger to correct internal state
-				return fmt.Errorf("charger enable: %w", err)
+				return false, fmt.Errorf("charger enable: %w", err)
 			}
 
 			lp.elapsePVTimer() // elapse PV timer so loadpoint can immediately switch charger if necessary
-			return nil
+			return false, nil
 		}
 	}
 
@@ -753,7 +753,7 @@ func (lp *Loadpoint) syncCharger() error {
 					lp.bus.Publish(evChargeCurrent, lp.chargeCurrent)
 				}
 			} else if !errors.Is(err, api.ErrNotAvailable) {
-				return fmt.Errorf("charger get max current: %w", err)
+				return false, fmt.Errorf("charger get max current: %w", err)
 			}
 		}
 
@@ -787,9 +787,9 @@ func (lp *Loadpoint) syncCharger() error {
 					}
 				} else {
 					if errors.Is(err, api.ErrNotAvailable) {
-						return nil
+						return enabled, nil
 					}
-					return fmt.Errorf("charger get phases: %w", err)
+					return false, fmt.Errorf("charger get phases: %w", err)
 				}
 			}
 
@@ -809,7 +809,7 @@ func (lp *Loadpoint) syncCharger() error {
 		// some chargers (i.E. Easee in some configurations) disable themselves to be able to switch phases
 		// -> enable charger
 		if err := lp.charger.Enable(true); err != nil {
-			return fmt.Errorf("charger enable: %w", err)
+			return false, fmt.Errorf("charger enable: %w", err)
 		}
 
 	case shouldBeConsistent && (enabled || lp.connected()):
@@ -817,7 +817,7 @@ func (lp *Loadpoint) syncCharger() error {
 		lp.log.WARN.Printf("charger out of sync: expected %vd, got %vd", status[lp.enabled], status[enabled])
 	}
 
-	return nil
+	return enabled, nil
 }
 
 // coarseCurrent returns true if charger or vehicle require full amp steps
@@ -1794,7 +1794,8 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, rates api.Rate
 	lp.publishSocAndRange()
 
 	// sync settings with charger
-	if err := lp.syncCharger(); err != nil {
+	enabled, err := lp.syncCharger()
+	if err != nil {
 		lp.log.ERROR.Println(err)
 		return
 	}
@@ -1858,9 +1859,10 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, rates api.Rate
 			break
 		}
 
+		keepEnabled := enabled && lp.GetStatus() == api.StatusB
 		targetCurrent := lp.pvMaxCurrent(mode, sitePower, batteryBoostPower, batteryBuffered, batteryStart)
 
-		if targetCurrent == 0 && lp.vehicleClimateActive() {
+		if targetCurrent == 0 && (keepEnabled || lp.vehicleClimateActive()) {
 			targetCurrent = lp.effectiveMinCurrent()
 		}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1863,6 +1863,9 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, rates api.Rate
 		targetCurrent := lp.pvMaxCurrent(mode, sitePower, batteryBoostPower, batteryBuffered, batteryStart)
 
 		if targetCurrent == 0 && (keepEnabled || lp.vehicleClimateActive()) {
+			if keepEnabled {
+				lp.log.DEBUG.Println("keeping charger active after vehicle stopped charging")
+			}
 			targetCurrent = lp.effectiveMinCurrent()
 		}
 


### PR DESCRIPTION
Follow-up to https://github.com/evcc-io/evcc/issues/18367#issuecomment-2609020334

In PV modes, if the vehicle has stopped charging due to battery full or vehicle-set limit reached, keep the charger enabled. This will allow preconditioning from grid without PV or need for climater api.

TODO

- [ ] handle mode changes