### PR TITLE
CLI: remove --database shortcut

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ func init() {
 
 	// global options
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Config file (default \"~/evcc.yaml\" or \"/etc/evcc.yaml\")")
-	rootCmd.PersistentFlags().StringVarP(&cfgDatabase, "database", "d", "", "Database location (default \"~/.evcc/evcc.db\")")
+	rootCmd.PersistentFlags().StringVarP(&cfgDatabase, "database", "db", "", "Database location (default \"~/.evcc/evcc.db\")")
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Help")
 	rootCmd.PersistentFlags().Bool(flagHeaders, false, flagHeadersDescription)
 	rootCmd.PersistentFlags().Bool(flagIgnoreDatabase, false, flagIgnoreDatabaseDescription)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ func init() {
 
 	// global options
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Config file (default \"~/evcc.yaml\" or \"/etc/evcc.yaml\")")
-	rootCmd.PersistentFlags().StringVarP(&cfgDatabase, "database", "db", "", "Database location (default \"~/.evcc/evcc.db\")")
+	rootCmd.PersistentFlags().StringVar(&cfgDatabase, "database", "", "Database location (default \"~/.evcc/evcc.db\")")
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Help")
 	rootCmd.PersistentFlags().Bool(flagHeaders, false, flagHeadersDescription)
 	rootCmd.PersistentFlags().Bool(flagIgnoreDatabase, false, flagIgnoreDatabaseDescription)


### PR DESCRIPTION
The existing `evcc charger --disable` shortcut conflicts with the new `evcc --database` shortcut (both `d`) introduced in https://github.com/evcc-io/evcc/pull/17993

Removed `-d` shortcut for `--database`. 

See Slack: https://evccgroup.slack.com/archives/C01321PUJAD/p1737832831315889
