### PR TITLE
Fix Spelsberg Smart Pro naming

### DIFF
--- a/templates/definition/charger/bender.yaml
+++ b/templates/definition/charger/bender.yaml
@@ -44,7 +44,7 @@ products:
       generic: C11E, C22E
   - brand: Spelsberg
     description:
-      generic: Wallbox
+      generic: Wallbox Smart Pro
 capabilities: ["rfid"]
 requirements:
   description:


### PR DESCRIPTION
There are two Spelsberg Wallbox models, "Wallbox Pure" and "Wallbox Smart Pro". Only the latter one is controllable by evcc.