### PR TITLE
Temperature sensor of AC Thor / AC Thor 9s can be choosen as source for Soc

### DIFF
--- a/charger/mypv.go
+++ b/charger/mypv.go
@@ -42,12 +42,12 @@ type MyPv struct {
 }
 
 const (
-	elwaRegSetPower = 1000
-	// elwaRegTemp      = 1001
+	elwaRegSetPower  = 1000
 	elwaRegTempLimit = 1002
 	elwaRegStatus    = 1003
 	elwaRegPower     = 1000 // https://github.com/evcc-io/evcc/issues/18020#issuecomment-2585300804
 )
+var thorRegTempArray = [3]uint16{1001, 1030, 1031}
 
 func init() {
 	// https://github.com/evcc-io/evcc/discussions/12761
@@ -65,8 +65,7 @@ func init() {
 func newMyPvFromConfig(ctx context.Context, name string, other map[string]interface{}, statusC uint16) (api.Charger, error) {
 	cc := struct {
 		modbus.TcpSettings `mapstructure:",squash"`
-		// Temp               plugin.Config
-		ThorRegTemp uint16
+		ThorRegTempIndex uint16
 	}{
 		TcpSettings: modbus.TcpSettings{
 			ID: 1, // default
@@ -77,7 +76,7 @@ func newMyPvFromConfig(ctx context.Context, name string, other map[string]interf
 		return nil, err
 	}
 
-	return NewMyPv(ctx, name, cc.URI, cc.ID, cc.ThorRegTemp, statusC)
+	return NewMyPv(ctx, name, cc.URI, cc.ID, thorRegTempArray[cc.ThorRegTempIndex-1], statusC)
 }
 
 // NewMyPv creates myPV AC Elwa 2 or Thor charger

--- a/charger/mypv.go
+++ b/charger/mypv.go
@@ -32,17 +32,18 @@ import (
 
 // MyPv charger implementation
 type MyPv struct {
-	log     *util.Logger
-	conn    *modbus.Connection
-	lp      loadpoint.API
-	power   uint32
-	statusC uint16
-	enabled bool
+	log         *util.Logger
+	conn        *modbus.Connection
+	lp          loadpoint.API
+	power       uint32
+	statusC     uint16
+	enabled     bool
+	thorRegTemp uint16
 }
 
 const (
-	elwaRegSetPower  = 1000
-	elwaRegTemp      = 1001
+	elwaRegSetPower = 1000
+	// elwaRegTemp      = 1001
 	elwaRegTempLimit = 1002
 	elwaRegStatus    = 1003
 	elwaRegPower     = 1000 // https://github.com/evcc-io/evcc/issues/18020#issuecomment-2585300804
@@ -62,19 +63,25 @@ func init() {
 
 // newMyPvFromConfig creates a MyPv charger from generic config
 func newMyPvFromConfig(ctx context.Context, name string, other map[string]interface{}, statusC uint16) (api.Charger, error) {
-	cc := modbus.TcpSettings{
-		ID: 1,
+	cc := struct {
+		modbus.TcpSettings `mapstructure:",squash"`
+		// Temp               plugin.Config
+		ThorRegTemp uint16
+	}{
+		TcpSettings: modbus.TcpSettings{
+			ID: 1, // default
+		},
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewMyPv(ctx, name, cc.URI, cc.ID, statusC)
+	return NewMyPv(ctx, name, cc.URI, cc.ID, cc.ThorRegTemp, statusC)
 }
 
 // NewMyPv creates myPV AC Elwa 2 or Thor charger
-func NewMyPv(ctx context.Context, name, uri string, slaveID uint8, statusC uint16) (api.Charger, error) {
+func NewMyPv(ctx context.Context, name, uri string, slaveID uint8, thorRegTemp uint16, statusC uint16) (api.Charger, error) {
 	conn, err := modbus.NewConnection(uri, "", "", 0, modbus.Tcp, slaveID)
 	if err != nil {
 		return nil, err
@@ -88,9 +95,10 @@ func NewMyPv(ctx context.Context, name, uri string, slaveID uint8, statusC uint1
 	conn.Logger(log.TRACE)
 
 	wb := &MyPv{
-		log:     log,
-		conn:    conn,
-		statusC: statusC,
+		log:         log,
+		conn:        conn,
+		statusC:     statusC,
+		thorRegTemp: thorRegTemp,
 	}
 
 	go wb.heartbeat(ctx, 30*time.Second)
@@ -225,7 +233,7 @@ var _ api.Battery = (*MyPv)(nil)
 
 // CurrentPower implements the api.Meter interface
 func (wb *MyPv) Soc() (float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(elwaRegTemp, 1)
+	b, err := wb.conn.ReadHoldingRegisters(wb.thorRegTemp, 1)
 	if err != nil {
 		return 0, err
 	}

--- a/charger/mypv.go
+++ b/charger/mypv.go
@@ -76,7 +76,7 @@ func newMyPvFromConfig(ctx context.Context, name string, other map[string]interf
 		return nil, err
 	}
 
-	return NewMyPv(ctx, name, cc.URI, cc.ID, thorRegTempArray[cc.ThorRegTempIndex-1], statusC)
+	return NewMyPv(ctx, name, cc.URI, cc.ID, thorRegTempArray[cc.ThorRegTempIndex], statusC)
 }
 
 // NewMyPv creates myPV AC Elwa 2 or Thor charger

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -12,4 +12,4 @@ params:
 render: |
   type: ac-elwa-2
   {{- include "modbus" . }}
-  ThorRegTempIndex: 1
+  ThorRegTempIndex: 0

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -12,3 +12,4 @@ params:
 render: |
   type: ac-elwa-2
   {{- include "modbus" . }}
+  ThorRegTemp: "1001"

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -12,4 +12,4 @@ params:
 render: |
   type: ac-elwa-2
   {{- include "modbus" . }}
-  ThorRegTemp: 1001
+  ThorRegTempIndex: 1

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -12,4 +12,3 @@ params:
 render: |
   type: ac-elwa-2
   {{- include "modbus" . }}
-  ThorRegTempIndex: 0

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -12,4 +12,4 @@ params:
 render: |
   type: ac-elwa-2
   {{- include "modbus" . }}
-  ThorRegTemp: "1001"
+  ThorRegTemp: 1001

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -9,6 +9,14 @@ requirements:
 params:
   - name: modbus
     choice: ["tcpip"]
+  - name: tempsource
+    choice: ["1001", "1030", "1034"]
+    default: "1001"
+    description: 
+      en: "modbus register used for calculating Soc"
+      de: "Modbusregister zur Berechnung des SoC"
 render: |
   type: ac-thor
   {{- include "modbus" . }}
+  ThorRegTemp: {{- if eq .tempsource "1031" }} 1031 {{- else if eq .tempsource "1030" }} 1030 {{- else }} 1001 {{- end }}
+  

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -18,5 +18,5 @@ params:
 render: |
   type: ac-thor
   {{- include "modbus" . }}
-  ThorRegTempIndex: {{- if eq .tempsource "3" }} 3 {{- else if eq .tempsource "2" }} 2 {{- else }} 1 {{- end }}
+  ThorRegTempIndex: {{- if eq .tempsource "3" }} 2 {{- else if eq .tempsource "2" }} 1 {{- else }} 0 {{- end }}
   

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -13,10 +13,10 @@ params:
     choice: ["1", "2", "3"]
     default: "1"
     description: 
-      en: "choose temperature sensor ("1", "2" or "3") according to AC Thor documentation for calculating Soc"
-      de: "Wählen Sie den Temperatursensor ("1", "2" oder "3") gemäß der AC Thor-Dokumentation zur Berechnung des SoC"
+      en: "choose temperature sensor (1, 2 or 3) according to AC Thor documentation for calculating Soc"
+      de: "Wählen Sie den Temperatursensor (1, 2 oder 3) gemäß der AC Thor-Dokumentation zur Berechnung des SoC"
 render: |
   type: ac-thor
   {{- include "modbus" . }}
-  ThorRegTemp: {{- if eq .tempsource "3" }} 1031 {{- else if eq .tempsource "2" }} 1030 {{- else }} 1001 {{- end }}
+  ThorRegTempIndex: {{- if eq .tempsource "3" }} 3 {{- else if eq .tempsource "2" }} 2 {{- else }} 1 {{- end }}
   

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -13,8 +13,8 @@ params:
     choice: ["1", "2", "3"]
     default: "1"
     description: 
-      en: "modbus register used for calculating Soc"
-      de: "Modbusregister zur Berechnung des SoC"
+      en: "choose temperature sensor ("1", "2" or "3") according to AC Thor documentation for calculating Soc"
+      de: "Wählen Sie den Temperatursensor ("1", "2" oder "3") gemäß der AC Thor-Dokumentation zur Berechnung des SoC"
 render: |
   type: ac-thor
   {{- include "modbus" . }}

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -10,13 +10,13 @@ params:
   - name: modbus
     choice: ["tcpip"]
   - name: tempsource
-    choice: ["1001", "1030", "1031"]
-    default: "1001"
+    choice: ["1", "2", "3"]
+    default: "1"
     description: 
       en: "modbus register used for calculating Soc"
       de: "Modbusregister zur Berechnung des SoC"
 render: |
   type: ac-thor
   {{- include "modbus" . }}
-  ThorRegTemp: {{- if eq .tempsource "1031" }} 1031 {{- else if eq .tempsource "1030" }} 1030 {{- else }} 1001 {{- end }}
+  ThorRegTemp: {{- if eq .tempsource "3" }} 1031 {{- else if eq .tempsource "2" }} 1030 {{- else }} 1001 {{- end }}
   

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -12,11 +12,10 @@ params:
   - name: tempsource
     choice: ["1", "2", "3"]
     default: "1"
-    description: 
-      en: "choose temperature sensor (1, 2 or 3) according to AC Thor documentation for calculating Soc"
-      de: "Wählen Sie den Temperatursensor (1, 2 oder 3) gemäß der AC Thor-Dokumentation zur Berechnung des SoC"
+    description:
+      en: "Temperature sensor"
+      de: "Temperatursensor"
 render: |
   type: ac-thor
   {{- include "modbus" . }}
-  ThorRegTempIndex: {{- if eq .tempsource "3" }} 2 {{- else if eq .tempsource "2" }} 1 {{- else }} 0 {{- end }}
-  
+  tempsource: {{ .tempsource }}

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -10,7 +10,7 @@ params:
   - name: modbus
     choice: ["tcpip"]
   - name: tempsource
-    choice: ["1001", "1030", "1034"]
+    choice: ["1001", "1030", "1031"]
     default: "1001"
     description: 
       en: "modbus register used for calculating Soc"


### PR DESCRIPTION
in evcc.yaml, the temperature sensor of the AC Thor (9s) can be choosen by entering tempsource: "value".
"value" is the modbus register of the respective temperature sensor (1001, 1030 or 1031). Default is 1001