### PR TITLE
Fix/ocpp initial status 3

### DIFF
--- a/charger/ocpp/connector_test.go
+++ b/charger/ocpp/connector_test.go
@@ -23,6 +23,10 @@ type connTestSuite struct {
 }
 
 func (suite *connTestSuite) SetupTest() {
+	// instance = &CS{
+	// 	regs: make(map[string]*registration),
+	// }
+	Instance()
 	suite.cp = NewChargePoint(util.NewLogger("foo"), "abc")
 	suite.conn, _ = NewConnector(util.NewLogger("foo"), 1, suite.cp, "")
 

--- a/charger/ocpp/connector_test.go
+++ b/charger/ocpp/connector_test.go
@@ -23,9 +23,7 @@ type connTestSuite struct {
 }
 
 func (suite *connTestSuite) SetupTest() {
-	// instance = &CS{
-	// 	regs: make(map[string]*registration),
-	// }
+	// setup instance
 	Instance()
 	suite.cp = NewChargePoint(util.NewLogger("foo"), "abc")
 	suite.conn, _ = NewConnector(util.NewLogger("foo"), 1, suite.cp, "")

--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -133,8 +133,7 @@ func (cs *CS) NewChargePoint(chargePoint ocpp16.ChargePointConnection) {
 
 		// update id
 		cp.RegisterID(chargePoint.ID())
-
-		cs.regs[chargePoint.ID()].cp = cp
+		cs.regs[chargePoint.ID()] = reg
 		delete(cs.regs, "")
 
 		cp.connect(true)

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -62,10 +62,6 @@ func (cs *CS) OnMeterValues(id string, request *core.MeterValuesRequest) (*core.
 }
 
 func (cs *CS) OnStatusNotification(id string, request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {
-	if cp, err := cs.ChargepointByID(id); err == nil {
-		return cp.OnStatusNotification(request)
-	}
-
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
@@ -74,6 +70,10 @@ func (cs *CS) OnStatusNotification(id string, request *core.StatusNotificationRe
 		reg.mu.Lock()
 		reg.status[request.ConnectorId] = request
 		reg.mu.Unlock()
+	}
+
+	if cp, err := cs.ChargepointByID(id); err == nil {
+		return cp.OnStatusNotification(request)
 	}
 
 	return new(core.StatusNotificationConfirmation), nil

--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -63,14 +63,13 @@ func (cs *CS) OnMeterValues(id string, request *core.MeterValuesRequest) (*core.
 
 func (cs *CS) OnStatusNotification(id string, request *core.StatusNotificationRequest) (*core.StatusNotificationConfirmation, error) {
 	cs.mu.Lock()
-	defer cs.mu.Unlock()
-
 	// cache status for future cp connection
 	if reg, ok := cs.regs[id]; ok && request != nil {
 		reg.mu.Lock()
 		reg.status[request.ConnectorId] = request
 		reg.mu.Unlock()
 	}
+	cs.mu.Unlock()
 
 	if cp, err := cs.ChargepointByID(id); err == nil {
 		return cp.OnStatusNotification(request)


### PR DESCRIPTION
@andig I took your branch fix/ocpp-initial-status-3 made to resolve #15677 and performed some debugging to resolve #18443. It was successfully initializing with the eProwallbox that does not support remote trigger after my changes.

Basically, the changes are:
1. Fix a panic in https://github.com/evcc-io/evcc/commit/8adb8feb6e94775a046f23fc042ef2dcfae0c4fe. The original code was accessing cs.regs[chargePoint.ID()].cp which was not existing yet.
2.  Change the order of caching status and calling cp.OnStatusNotification(request) in https://github.com/evcc-io/evcc/commit/67fe2696190b5890fb4213fc6b1b313002d679dc. Without this change, the caching never happened since in the moment the function is called, cs.ChargepointByID(id) already succeeds, only the connector is not available yet. With the change it will now always do the caching, but I think this is no issue since the cached status is only used during init. Commit https://github.com/evcc-io/evcc/commit/5c3fb4aaa797cf94bdabb6dfe43ab7781515172e fixed a mutex deadlock I introduces with the change.
3. Use the cached status when the charger does not support RemoteTrigger in https://github.com/evcc-io/evcc/commit/236ed2a57ccc62cf5ced9a2a4822b38b6b5c3073. In addition, I guarded all other calls to `TriggerMessageRequest` with `HasRemoteTriggerFeature `