### PR TITLE
chore: allow number vehicle capacity in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -101,7 +101,7 @@
             "type": "string"
           },
           "capacity": {
-            "type": "integer"
+            "type": "number"
           },
           "phases": {
             "type": "integer"


### PR DESCRIPTION
Zumindest die demo.yaml nutzt für die vehicle capacity eine Dezimalzahl

https://github.com/evcc-io/evcc/blob/acca717cfcd1c3f7dc8861700c20451ebfcfb4cf/cmd/demo.yaml#L229