### PR TITLE
Templates: add countries for tariffs

### DIFF
--- a/templates/definition/devices-schema.json
+++ b/templates/definition/devices-schema.json
@@ -31,6 +31,13 @@
             "$ref": "#/definitions/Linked"
           }
         },
+        "countries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z]{2}$"
+          }
+        },
         "capabilities": {
           "type": "array",
           "items": {

--- a/templates/definition/tariff/allinpower.yaml
+++ b/templates/definition/tariff/allinpower.yaml
@@ -4,10 +4,8 @@ products:
   - brand: All in Power
 requirements:
   evcc: ["skiptest"]
-  description:
-    de: "Nur für die Niederlande verfügbar."
-    en: "Only available for the Netherlands."
 group: price
+countries: ["NL"]
 params:
   - preset: tariff-base
 render: |

--- a/templates/definition/tariff/amber.yaml
+++ b/templates/definition/tariff/amber.yaml
@@ -1,11 +1,8 @@
 template: amber
 products:
   - brand: Amber Electric
-requirements:
-  description:
-    de: "Nur für Australien verfügbar."
-    en: "Only available for Australia."
 group: price
+countries: ["AU"]
 params:
   - name: token
   - name: siteid

--- a/templates/definition/tariff/awattar.yaml
+++ b/templates/definition/tariff/awattar.yaml
@@ -1,11 +1,8 @@
 template: awattar
 products:
   - brand: Awattar
-requirements:
-  description:
-    de: "Nur für Deutschland und Österreich verfügbar."
-    en: "Only available for Germany and Austria."
 group: price
+countries: ["DE", "AT"]
 params:
   - name: region
     example: AT

--- a/templates/definition/tariff/elering.yaml
+++ b/templates/definition/tariff/elering.yaml
@@ -4,11 +4,8 @@ products:
   - brand: Nordpool
     description:
       generic: "Elering"
-requirements:
-  description:
-    de: "Nur für Estland verfügbar."
-    en: "Only available for Estonia."
 group: price
+countries: ["EE", "LT", "LV", "FI"]
 params:
   - name: region
     example: ee

--- a/templates/definition/tariff/energinet.yaml
+++ b/templates/definition/tariff/energinet.yaml
@@ -2,11 +2,9 @@ template: energinet
 products:
   - brand: Energinet
 requirements:
-  description:
-    de: "Nur für Dänemark verfügbar."
-    en: "Only available for Denmark."
   evcc: ["skiptest"]
 group: price
+countries: ["DK"]
 params:
   - name: region
     example: dk1

--- a/templates/definition/tariff/energy-charts-api.yaml
+++ b/templates/definition/tariff/energy-charts-api.yaml
@@ -7,6 +7,7 @@ requirements:
     en: "Day-ahead forecast of energy prices (per kWh) on the exchange. No prior registration for https://api.energy-charts.info/ necessary. Can be used for dynamic electricity tariffs, for example, where the supplier does not yet offer a price forecast on the customer interface."
   evcc: ["skiptest"]
 group: price
+countries: ["EU"]
 params:
   - name: bzn
     type: choice

--- a/templates/definition/tariff/enever.yaml
+++ b/templates/definition/tariff/enever.yaml
@@ -2,11 +2,9 @@ template: enever
 products:
   - brand: Enever
 requirements:
-  description:
-    de: Nur für Niederlande verfügbar.
-    en: Only available for Netherlands.
   evcc: ["skiptest"]
 group: price
+countries: ["NL"]
 params:
   - name: token
     required: true

--- a/templates/definition/tariff/entsoe.yaml
+++ b/templates/definition/tariff/entsoe.yaml
@@ -10,6 +10,7 @@ requirements:
       Day-ahead prices for the European electricity market. See https://transparency.entsoe.eu for more information.
       Basis for many dynamic tariffs.
 group: price
+countries: ["EU"]
 params:
   - name: securitytoken
     help:

--- a/templates/definition/tariff/groupe-e.yaml
+++ b/templates/definition/tariff/groupe-e.yaml
@@ -4,11 +4,9 @@ products:
     description:
       generic: Vario Plus
 requirements:
-  description:
-    de: "Nur für die Schweiz verfügbar."
-    en: "Only available for Switzerland."
   evcc: ["skiptest"]
 group: price
+countries: ["CH"]
 params:
   - preset: tariff-base
 render: |

--- a/templates/definition/tariff/gruenstromindex.yaml
+++ b/templates/definition/tariff/gruenstromindex.yaml
@@ -3,10 +3,11 @@ products:
   - brand: Grünstromindex
 requirements:
   description:
-    de: "Regionale Emissionsdaten von https://gruenstromindex.de. Nur für Deutschland verfügbar."
-    en: "Regional emission data from https://gruenstromindex.de. Only available for Germany."
+    de: "Regionale Emissionsdaten von https://gruenstromindex.de"
+    en: "Regional emission data from https://gruenstromindex.de"
   evcc: ["skiptest"]
 group: co2
+countries: ["DE"]
 params:
   - name: zip
     required: true

--- a/templates/definition/tariff/ngeso.yaml
+++ b/templates/definition/tariff/ngeso.yaml
@@ -1,11 +1,8 @@
 template: ngeso
 products:
   - brand: National Grid ESO
-requirements:
-  description:
-    de: "Nur für Großbritannien verfügbar."
-    en: "Only available for the United Kingdom."
 group: co2
+countries: ["GB"]
 params:
   - name: region
     type: string

--- a/templates/definition/tariff/nordpool.yaml
+++ b/templates/definition/tariff/nordpool.yaml
@@ -7,6 +7,7 @@ requirements:
     en: "Nordpool spot prices in day-ahead market for all markets in the Nordpool region."
   evcc: ["skiptest"]
 group: price
+countries: ["EU"]
 params:
   - name: region
     example: GER

--- a/templates/definition/tariff/octopus-api.yaml
+++ b/templates/definition/tariff/octopus-api.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     de: "Den API-Key bekommst du im Octopus Portal https://octopus.energy/dashboard/new/accounts/personal-details/api-access"
     en: "You can get the API key in the Octopus portal https://octopus.energy/dashboard/new/accounts/personal-details/api-access"
+countries: ["GB"]
 group: price
 params:
   - name: apiKey

--- a/templates/definition/tariff/octopus-productcode.yaml
+++ b/templates/definition/tariff/octopus-productcode.yaml
@@ -4,6 +4,7 @@ products:
     description:
       generic: Product Code
 group: price
+countries: ["GB"]
 params:
   - name: productCode
     type: string

--- a/templates/definition/tariff/ostrom.yaml
+++ b/templates/definition/tariff/ostrom.yaml
@@ -7,6 +7,7 @@ requirements:
     de: "Erzeuge einen 'Production Client' im Ostrom-Entwicklerportal: https://developer.ostrom-api.io/"
   evcc: ["skiptest"]
 group: price
+countries: ["DE"]
 params:
   - name: clientid
     example: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4

--- a/templates/definition/tariff/pun.yaml
+++ b/templates/definition/tariff/pun.yaml
@@ -4,9 +4,10 @@ products:
 requirements:
   evcc: ["skiptest"]
   description:
-    de: "Preisdaten von https://www.mercatoelettrico.org/it/. Wird oft zur Einspeisung ins Netz verwendet. Nur für Italien verfügbar."
-    en: "Price data from https://www.mercatoelettrico.org/it/. Often used for feeding into the grid. Only available for Italy."
+    de: "Preisdaten von https://www.mercatoelettrico.org/it/. Wird oft zur Einspeisung ins Netz verwendet."
+    en: "Price data from https://www.mercatoelettrico.org/it/. Often used for feeding into the grid."
 group: price
+countries: ["IT"]
 params:
   - preset: tariff-base
 render: |

--- a/templates/definition/tariff/smartenergy.yaml
+++ b/templates/definition/tariff/smartenergy.yaml
@@ -3,11 +3,8 @@ products:
   - brand: SmartEnergy
     description:
       generic: smartCONTROL
-requirements:
-  description:
-    de: Nur für Österreich verfügbar.
-    en: Only available for Austria.
 group: price
+countries: ["AT"]
 params:
   - preset: tariff-base
 render: |

--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -1,11 +1,8 @@
 template: spottyenergy
 products:
   - brand: Spotty Energie
-requirements:
-  description:
-    de: "Nur für Österreich verfügbar."
-    en: "Only available for Austria."
 group: price
+countries: ["AT"]
 params:
   - name: contractid
     example: ffffffff-4444-6666-2222-aaaaaabbbbbb

--- a/templates/definition/tariff/tibber.yaml
+++ b/templates/definition/tariff/tibber.yaml
@@ -7,6 +7,7 @@ requirements:
     de: "Hol dir deinen API-Token aus dem Tibber-Entwicklerportal: https://developer.tibber.com/"
   evcc: ["skiptest"]
 group: price
+countries: ["NO", "SE", "DE", "NL"]
 params:
   - name: token
     example: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4

--- a/util/templates/documentation.go
+++ b/util/templates/documentation.go
@@ -95,6 +95,7 @@ func (t *Template) RenderDocumentation(product Product, lang string) ([]byte, er
 		"ProductDescription":     product.Description.String(lang),
 		"ProductGroup":           t.GroupTitle(lang),
 		"Capabilities":           t.Capabilities,
+		"Countries":              t.Countries,
 		"Requirements":           t.Requirements.EVCC,
 		"RequirementDescription": t.Requirements.Description.String(lang),
 		"Params":                 filteredParams,

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -52,6 +52,9 @@ product:
 {{- if .Capabilities }}
 capabilities: ["{{ join "\", \"" .Capabilities }}"]
 {{- end }}
+{{- if .Countries }}
+countries: ["{{ join "\", \"" .Countries }}"]
+{{- end }}
 {{- if .Requirements }}
 requirements: ["{{ join "\", \"" .Requirements }}"]
 {{- end }}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -45,6 +45,12 @@ func (t *Template) Validate() error {
 		}
 	}
 
+	for _, c := range t.Countries {
+		if !c.IsValid() {
+			return fmt.Errorf("invalid country code '%s' in template %s", c, t.Template)
+		}
+	}
+
 	for _, r := range t.Requirements.EVCC {
 		if !slices.Contains(ValidRequirements, r) {
 			return fmt.Errorf("invalid requirement '%s' in template %s", r, t.Template)

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"dario.cat/mergo"
@@ -252,6 +253,19 @@ func (p Product) Title(lang string) string {
 	return strings.TrimSpace(fmt.Sprintf("%s %s", p.Brand, p.Description.String(lang)))
 }
 
+type CountryCode string
+
+func (c CountryCode) IsValid() bool {
+	// ensure ISO 3166-1 alpha-2 format
+	var validCode = regexp.MustCompile(`^[A-Z]{2}$`)
+	return validCode.MatchString(string(c))
+}
+
+const (
+	CountryCodeDE CountryCode = "DE"
+	CountryCodeUS CountryCode = "US"
+)
+
 // TemplateDefinition contains properties of a device template
 type TemplateDefinition struct {
 	Template     string
@@ -260,6 +274,7 @@ type TemplateDefinition struct {
 	Covers       []string         `json:",omitempty"` // list of covered outdated template names
 	Products     []Product        `json:",omitempty"` // list of products this template is compatible with
 	Capabilities []string         `json:",omitempty"`
+	Countries    []CountryCode    `json:",omitempty"` // list of countries supported by this template
 	Requirements Requirements     `json:",omitempty"`
 	Linked       []LinkedTemplate `json:",omitempty"` // a list of templates that should be processed as part of the guided setup
 	Params       []Param          `json:",omitempty"`

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -261,11 +261,6 @@ func (c CountryCode) IsValid() bool {
 	return validCode.MatchString(string(c))
 }
 
-const (
-	CountryCodeDE CountryCode = "DE"
-	CountryCodeUS CountryCode = "US"
-)
-
 // TemplateDefinition contains properties of a device template
 type TemplateDefinition struct {
 	Template     string


### PR DESCRIPTION
Replaces custom "Only available for ____." descriptions with structured data.
Prerequisite to better structure tariffs in docs.evcc.io.