### PR TITLE
Eliminate temporary override of site.batterySoc with incorrect value.

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -549,7 +549,7 @@ func (site *Site) updateBatteryMeters() {
 		mm[i].Controllable = lo.ToPtr(controllable)
 	}
 
-	batterySocAccumulator := lo.SumBy(mm, func(m measurement) float64 {
+	batterySocAcc := lo.SumBy(mm, func(m measurement) float64 {
 		// weigh soc by capacity
 		if *m.Capacity > 0 {
 			return *m.Soc * *m.Capacity

--- a/core/site.go
+++ b/core/site.go
@@ -564,7 +564,7 @@ func (site *Site) updateBatteryMeters() {
 	if totalCapacity == 0 {
 		totalCapacity = float64(len(site.batteryMeters))
 	}
-	site.batterySoc = batterySocAccumulator / totalCapacity
+	site.batterySoc = batterySocAcc / totalCapacity
 
 	site.batteryPower = lo.SumBy(mm, func(m measurement) float64 {
 		return m.Power

--- a/core/site.go
+++ b/core/site.go
@@ -549,7 +549,7 @@ func (site *Site) updateBatteryMeters() {
 		mm[i].Controllable = lo.ToPtr(controllable)
 	}
 
-	site.batterySoc = lo.SumBy(mm, func(m measurement) float64 {
+	batterySocAccumulator := lo.SumBy(mm, func(m measurement) float64 {
 		// weigh soc by capacity
 		if *m.Capacity > 0 {
 			return *m.Soc * *m.Capacity
@@ -564,7 +564,7 @@ func (site *Site) updateBatteryMeters() {
 	if totalCapacity == 0 {
 		totalCapacity = float64(len(site.batteryMeters))
 	}
-	site.batterySoc /= totalCapacity
+	site.batterySoc = batterySocAccumulator / totalCapacity
 
 	site.batteryPower = lo.SumBy(mm, func(m measurement) float64 {
 		return m.Power


### PR DESCRIPTION
the value currently gets set to a vastly incorrect value. this PR eliminates the possibility of a concurrent access reading a very wrong value