### PR TITLE
Loadpoint: fix reentrant locks

### DIFF
--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -133,10 +133,15 @@ func (lp *Loadpoint) SetDefaultMode(mode api.ChargeMode) {
 	}
 }
 
-// getChargedEnergy returns session charge energy in Wh
-func (lp *Loadpoint) getChargedEnergy() float64 {
+// GetChargedEnergy returns session charge energy in Wh
+func (lp *Loadpoint) GetChargedEnergy() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
+	return lp.getChargedEnergy()
+}
+
+// getChargedEnergy returns session charge energy in Wh
+func (lp *Loadpoint) getChargedEnergy() float64 {
 	return lp.energyMetrics.TotalWh()
 }
 
@@ -233,6 +238,11 @@ func (lp *Loadpoint) SetLimitSoc(soc int) {
 func (lp *Loadpoint) GetLimitEnergy() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
+	return lp.getLimitEnergy()
+}
+
+// getLimitEnergy returns the session limit energy
+func (lp *Loadpoint) getLimitEnergy() float64 {
 	return lp.limitEnergy
 }
 
@@ -261,6 +271,11 @@ func (lp *Loadpoint) SetLimitEnergy(energy float64) {
 func (lp *Loadpoint) GetPlanEnergy() (time.Time, float64) {
 	lp.RLock()
 	defer lp.RUnlock()
+	return lp.getPlanEnergy()
+}
+
+// getPlanEnergy returns plan target energy
+func (lp *Loadpoint) getPlanEnergy() (time.Time, float64) {
 	return lp.planTime, lp.planEnergy
 }
 
@@ -581,6 +596,11 @@ func (lp *Loadpoint) SetMinCurrent(current float64) error {
 func (lp *Loadpoint) GetMaxCurrent() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
+	return lp.getMaxCurrent()
+}
+
+// getMaxCurrent returns the max loadpoint current
+func (lp *Loadpoint) getMaxCurrent() float64 {
 	return lp.maxCurrent
 }
 

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -175,6 +175,11 @@ func (lp *Loadpoint) SetPriority(prio int) {
 func (lp *Loadpoint) GetPhases() int {
 	lp.RLock()
 	defer lp.RUnlock()
+	return lp.getPhases()
+}
+
+// getPhases returns loadpoint enabled phases
+func (lp *Loadpoint) getPhases() int {
 	return lp.phases
 }
 

--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -60,7 +60,7 @@ func expect(phases int) int {
 // ActivePhases returns the number of expectedly active phases for the meter.
 // If unknown for 1p3p chargers during startup it will assume 3p.
 func (lp *Loadpoint) ActivePhases() int {
-	physical := lp.GetPhases()
+	physical := lp.getPhases()
 	vehicle := lp.getVehiclePhases()
 	measured := lp.getMeasuredPhases()
 	charger := lp.getChargerPhysicalPhases()
@@ -91,7 +91,7 @@ func (lp *Loadpoint) minActivePhases() int {
 
 // maxActivePhases returns the maximum number of active phases for the loadpoint.
 func (lp *Loadpoint) maxActivePhases() int {
-	physical := lp.GetPhases()
+	physical := lp.getPhases()
 	measured := lp.getMeasuredPhases()
 	vehicle := lp.getVehiclePhases()
 	charger := lp.getChargerPhysicalPhases()

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -70,7 +70,7 @@ func (lp *Loadpoint) GetPlanGoal() (float64, bool) {
 		return float64(soc), true
 	}
 
-	_, limit := lp.GetPlanEnergy()
+	_, limit := lp.getPlanEnergy()
 	return limit, false
 }
 

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -63,7 +63,7 @@ func (lp *Loadpoint) stopSession() {
 		s.MeterStop = &meterStop
 	}
 
-	if chargedEnergy := lp.getChargedEnergy() / 1e3; chargedEnergy > s.ChargedEnergy {
+	if chargedEnergy := lp.GetChargedEnergy() / 1e3; chargedEnergy > s.ChargedEnergy {
 		lp.energyMetrics.Update(chargedEnergy)
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/18603

/cc @GrimmiMeloni @naltatis Bisher bin ich davon ausgegangen, dass `RLocks` reentrant sind. Tatsächlich ist das nicht der Fall wie @GrimmiMeloni dankbarer Weise in https://github.com/evcc-io/evcc/issues/18603#issuecomment-2640900927 heraus gefunden hat.
Wir müssen daher (leider) sehr vorsichtig sein, welche Funktionen mit Locks aufgerufen werden. Die Strategie hier ist jetzt:
- `RLocks` nur einmalig in den API Funktionen zu nutzen (exportiert, groß geschrieben)
- keine zusätzlichen `RLocks` in internen Funktionen (klein geschrieben)
- `Update` verwendet nach Möglichkeit nur noch API Funktionen
- Kleinschreibung einer Loadpoint Methode ist eine Indikation für fehlendes Locking, aber keine Garantie
- Großschreibung SOLL Locking sicherstellen

Ich habe hier auf den großen Umbau verzichtet sondern nur punktuell offensichtliche Probleme angefasst. Leider gibt es kein Tooling das uns hier helfen kann.

TODO

- [ ] configuredPhases depends on https://github.com/evcc-io/evcc/pull/18638 @naltatis 