### PR TITLE
docs: add minsoc, maxsoc

### DIFF
--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -38,15 +38,9 @@ params:
   - name: minsoc
     type: int
     advanced: true
-    help:
-      en: the battery reserve percentage to reset to when switching the Battery back to normal operations
-      de: die Energyreserve auf die zurückgesetzt wird, wenn die Entladung wieder freigegeben wird
   - name: maxsoc
     type: int
     advanced: true
-    help:
-      en: the battery reserve percentage to set to when switching the Battery to charge mode
-      de: die Energyreserve auf die gesetzt wird, wenn Batterieladung angefordert wird
 render: |
   type: powerwall
   uri: {{ .host }}

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -156,21 +156,21 @@ params:
     type: chargemodes
   - name: minsoc
     description:
-      de: Minimaler Ladestand (Soc) in %
-      en: Minimum state of charge (Soc) in %
+      de: Minimaler Ladestand (%)
+      en: Minimum charge (%)
     help:
-      de: Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht
-      en: Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off'
+      de: Untere Grenze beim Entladen der Batterie (normaler Betrieb)
+      en: Lower limit when discharging the battery (normal operation)
     example: 25
     type: int
-  - name: targetsoc
+  - name: maxsoc
     description:
-      de: Zielladestand (Soc) in %
-      en: Target state of charge (Soc) in %
+      de: Maximale Ladestand (%)
+      en: Maximum charge (%)
     help:
-      de: Bis zu welchem Ladestand (Soc) soll das Fahrzeug geladen werden
-      en: Until which state of charge (Soc) should the vehicle be charged
-    example: 80
+      de: Oberes Limit beim Laden der Batterie aus dem Netz
+      en: Upper limit when charging the battery from the grid
+    example: 95
     type: int
   - name: mincurrent
     description:


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/18583

- replaced old vehicle `minsoc` text with battery wording
- added `maxsoc`
- removed unused `targetsoc`

<img width="618" alt="Bildschirmfoto 2025-02-07 um 15 09 02" src="https://github.com/user-attachments/assets/1dda5344-c889-443a-9cbd-2015b1df81d8" />
