### PR TITLE
Improve rct battery control

### DIFF
--- a/meter/rct.go
+++ b/meter/rct.go
@@ -142,7 +142,7 @@ func NewRCT(uri, usage string, minSoc, maxSoc int, cache time.Duration, capacity
 					return err
 				}
 
-				return m.conn.Write(rct.BatterySoCTargetMin, m.floatVal(float32(maxSoc)/100))
+				return m.conn.Write(rct.BatterySoCTargetMin, m.floatVal(0.97))
 
 			case api.BatteryCharge:
 				if err := m.conn.Write(rct.PowerMngBatteryPowerExternW, m.floatVal(float32(-10_000))); err != nil {

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -142,7 +142,7 @@ func NewRCT(uri, usage string, minSoc, maxSoc int, cache time.Duration, capacity
 					return err
 				}
 
-				return m.conn.Write(rct.BatterySoCTargetMin, m.floatVal(0.97))
+				return m.conn.Write(rct.BatterySoCTargetMin, m.floatVal(float32(maxSoc)/100))
 
 			case api.BatteryCharge:
 				if err := m.conn.Write(rct.PowerMngUseGridPowerEnable, []byte{1}); err != nil {

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -145,6 +145,10 @@ func NewRCT(uri, usage string, minSoc, maxSoc int, cache time.Duration, capacity
 				return m.conn.Write(rct.BatterySoCTargetMin, m.floatVal(0.97))
 
 			case api.BatteryCharge:
+				if err := m.conn.Write(rct.PowerMngUseGridPowerEnable, []byte{1}); err != nil {
+					return err
+				}
+
 				if err := m.conn.Write(rct.PowerMngBatteryPowerExternW, m.floatVal(float32(-10_000))); err != nil {
 					return err
 				}


### PR DESCRIPTION
Hi, 👋

- Für Netzladen: Setze den Parameter `PowerMngUseGridPowerEnable `auf `true`, damit RCT im Modus `Extern` vom Netz lädt und sich nicht auf die PV-Produktion begrenzt