### PR TITLE
Loadpoint: allow fine-grained battery boost

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1359,6 +1359,10 @@ func (lp *Loadpoint) boostPower(batteryBoostPower float64) float64 {
 
 	// push demand to drain battery
 	delta := lp.effectiveStepPower()
+	if !lp.coarseCurrent() {
+		// for >1p this will allow finer adjustments down to 100W
+		delta = max(100, delta/10)
+	}
 
 	// start boosting by setting maximum power
 	if boost == boostStart {


### PR DESCRIPTION
Currently, battery boost draw at least 1A per phase from grid, regardless if mA charging is available. This PR honors mA charging.