### PR TITLE
Fix deadlock when using multiple connectors

### DIFF
--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -75,12 +75,14 @@ func (cs *CS) RegisterChargepoint(id string, newfun func() *CP, init func(*CP) e
 		cs.regs[id] = reg
 	}
 
+	cs.mu.Unlock()
+
 	// serialise on chargepoint id
 	reg.setup.Lock()
 	defer reg.setup.Unlock()
 
+	cs.mu.Lock()
 	cp := reg.cp
-
 	cs.mu.Unlock()
 
 	// setup already completed?


### PR DESCRIPTION
`cs.RegisterChargepoint` ruft am Anfang `cs.mu.Lock()` auf und gibt den lock erst nach 
```
// serialise on chargepoint id
reg.setup.Lock()
```
wieder frei. Bei mehreren Connectors wartet der zweite auf `reg.setup.Lock()` bevor es weiter geht. Gleichzeitig bleibt `cs.mu.Lock()` gelockt. Wenn sich nun der charge point connected, wird `cs.NewChargePoint` aufgerufen, dort wird ebenfalls `cs.mu.Lock()` aufgerufen und evcc bleibt erstmal stehen, bis das connect timeout abläuft.

Dieser PR behebt den Deadlock.