### PR TITLE
Add Amtron 4You 310, delete Amtron Start 2.0s

### DIFF
--- a/templates/definition/charger/mennekes-compact.yaml
+++ b/templates/definition/charger/mennekes-compact.yaml
@@ -3,10 +3,10 @@ covers: ["mennekes"]
 products:
   - brand: Mennekes
     description:
-      generic: Amtron Compact 2.0s
+      generic: AMTRON Compact 2.0s
   - brand: Mennekes
     description:
-      generic: Amtron Start 2.0s
+      generic: AMTRON 4You 310
   - brand: Kostal
     description:
       generic: Enector


### PR DESCRIPTION
Amtron Start 2.0s was not sold.

Modbus Docs are inkluding the new Amtron 4You 310.
https://www.mennekes.de/fileadmin/MEN-Deutschland/emobility/01_documents/04_installer/Modbus_RTU_Register-AMTRON_4YOU_300-Compact_2.0s-Start_2.0s-v2.0.pdf