### PR TITLE
creating nightly.DATE-HASH in docker hub and set it in the home assistant nightly addon

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,14 +59,51 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: evcc/evcc
+          tags: |
+            type=raw,value=nightly
+            type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
+
       - name: Publish
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true
-          tags: |
-            evcc/evcc:nightly
+          tags: ${{ steps.meta.outputs.tags }}
+
+  hassio:
+    name: Hassio Addon :nightly
+    needs:
+      - docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          repository: evcc-io/hassio-addon
+          token: ${{ secrets.GH_TOKEN }}
+          path: ./hassio
+
+      - name: Update version
+        run: |
+          current_date=$(date +%Y%m%d)
+          short_sha=$(echo "${{ github.sha }}" | cut -c 1-7)
+          sed -i -e "s/version:.*/version: nightly.${current_date}-${short_sha}/" ./hassio/evcc-nightly/config.yaml
+
+      - name: Push
+        run: |
+          cd ./hassio
+          git add .
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -am "Mirror evcc nightly release"
+          git push
 
   apt:
     name: Publish APT nightly


### PR DESCRIPTION
this change tags all nightlies in docker with a date and git hash. i.e. `nightly.20250213-3c5bea9`. the old `nightly` tag will still be available and not changed (to ensure we are not breaking anything that is using this tag currently).

and modifies the hassio-addon nightly (added here: https://github.com/evcc-io/hassio-addon/pull/126) with this tag name, like it is done for the release.