### PR TITLE
EVNotify: Add Vehicle Status to template

### DIFF
--- a/templates/definition/vehicle/evnotify.yaml
+++ b/templates/definition/vehicle/evnotify.yaml
@@ -16,3 +16,13 @@ render: |
     source: http
     uri: https://app.evnotify.de/soc?akey={{ urlEncode .akey }}&token={{ urlEncode .token }}
     jq: .soc_display
+  status:
+    source: combined
+    plugged:
+      source: http
+      uri: https://app.evnotify.de/extended?akey={{ urlEncode .akey }}&token={{ urlEncode .token }}
+      jq: .normal_charge_port
+    charging:
+      source: http
+      uri: https://app.evnotify.de/extended?akey={{ urlEncode .akey }}&token={{ urlEncode .token }}
+      jq: .charging


### PR DESCRIPTION
Previously the EVNotify Template could only get the current SOC from the vehicle. With these changes it is also possible to get the current status (plugged in, charging) from the same API.

The extended URI includes quite a few parameters, but I think the most important is the status so EVCC can assign the vehicle automatically.

Example of the extended URI of a Hyundai Ioniq 28 vFL:
`{
  "soh": 100,
  "charging": 0,
  "rapid_charge_port": 0,
  "normal_charge_port": 0,
  "slow_charge_port": null,
  "aux_battery_voltage": 14.4,
  "dc_battery_voltage": 337.5,
  "dc_battery_current": 70.6,
  "dc_battery_power": 23.8275,
  "cumulative_energy_charged": 26582.2,
  "cumulative_energy_discharged": 25684.8,
  "battery_min_temperature": 6,
  "battery_max_temperature": 7,
  "battery_inlet_temperature": 3,
  "external_temperature": null,
  "odo": null,
  "last_extended": 1739429062
}` 

I tried a sample configuration in my evcc.yaml and it works flawlessly.