### PR TITLE
Templates-translations-fr

### DIFF
--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -15,6 +15,7 @@ params:
     description:
       en: "Temperature sensor"
       de: "Temperatursensor"
+      fr: "Senseur de température"
 render: |
   type: ac-thor
   {{- include "modbus" . }}

--- a/templates/definition/charger/alfen.yaml
+++ b/templates/definition/charger/alfen.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: Die "Active load balancing" Lizenz wird benötigt um die Wallbox via Modbus extern zu steuern. In den Einstellungen muss "Active Load Balancing" aktiviert und "Energy Management System" als Data Source ausgewählt werden. Es wird empfohlen "ValidityTime" (Menu "TCP/IP EMS") auf 300s einzustellen. Falls die "Double"-Box verwendet wird müssen beide Ladepunkte getrennt voneinander hinzugefügt werden. Der erste Port (oder einzelne Port) ist unter ID 1 zugänglich, der zweite unter ID 2.
     en: The "Active load balancing" license is required for external Modbus control of the charger. Enable "Active Load Balancing" and select "Energy Management System" as Data Source in the configuration. It is recommended to set "ValidityTime" ("TCP/IP EMS" menu) to 300s. When using "Double" charger both loadpoints need to be added. The the first port (or single) is accessable on ID 1, second port on ID 2.
+    fr: La licence « Active load balancing » est nécessaire pour le contrôle Modbus externe du chargeur. Activer « Active Load Balancing » et sélectionner « Energy Management System » comme Data Source dans la configuration. Il est recommandé de régler « ValidityTime » (menu « TCP/IP EMS ») sur 300s. Lors de l'utilisation du chargeur « Double », les deux points de charge doivent être ajoutés. Le premier port (ou simple) est accessible sur l'ID 1, le second sur l'ID 2.
   evcc: ["sponsorship"]
 params:
   - name: modbus

--- a/templates/definition/charger/alphatec.yaml
+++ b/templates/definition/charger/alphatec.yaml
@@ -13,6 +13,7 @@ requirements:
   description:
     de: Die Hauptplatine benötigt eine aktuelle Firmware. Eine aktuelle Softwareversion kann man daran erkennen, dass die Seriennummer auf dem braunen Relais mit 2022 beginnt oder auf den kleinen weißen Relais eine 15 steht. Andernfalls bitte direkt an den Hersteller wenden.
     en: The motherboard requires current firmware. You can recognize a current software version by the fact that the serial number on the brown relay starts with 2022 or there is a 15 on the small white relays. Otherwise, please contact the manufacturer directly.
+    fr: La carte mère doit être dotée d'un micrologiciel à jour. La version actuelle du logiciel est reconnaissable au fait que le numéro de série du relais marron commence par 2022 ou qu'il y a un 15 sur les petits relais blancs. Dans le cas contraire, veuillez contacter directement le fabricant.
   evcc: ["sponsorship"]
 params:
   - name: modbus

--- a/templates/definition/charger/bender.yaml
+++ b/templates/definition/charger/bender.yaml
@@ -50,6 +50,7 @@ requirements:
   description:
     de: Der 'Modbus TCP Server für Energiemanagement-Systeme' muss aktiviert sein. 'Registersatz' darf NICHT auf 'Phoenix' oder 'TQ-DM100' eingestellt sein. Die dritte Auswahlmöglichkeit 'Ebee', 'Bender', 'MENNEKES' etc. ist richtig. 'UID Übertragung erlauben' muss aktiviert sein.
     en: The 'Modbus TCP Server' must be enabled. The setting 'Register Address Set' must NOT be set to 'Phoenix' or 'TQ-DM100'. Use the third selection labeled 'Ebee', 'Bender', 'MENNEKES' etc. Set 'Allow UID Disclose' to On.
+    fr: Le 'Serveur Modbus TCP' doit être activé. Le paramètre 'Register Address Set' ne doit PAS être réglé sur 'Phoenix' ou 'TQ-DM100'. Utilisez la troisième sélection intitulée 'Ebee', 'Bender', 'MENNEKES', etc. Réglez le paramètre « Allow UID Disclose » sur On.
   evcc: ["sponsorship"]
 params:
   - name: host

--- a/templates/definition/charger/cfos.yaml
+++ b/templates/definition/charger/cfos.yaml
@@ -12,6 +12,9 @@ requirements:
     en: |
       S0 meters must be configured separately as charge meter.
       Phase switching is only available with the Solar variant and must be enabled by the user.
+    fr: |
+      Les compteurs S0 doivent être configurés séparément en tant que compteur de charge.
+      La commutation de phase n'est disponible qu'avec la variante solaire et doit être activée par l'utilisateur.
   evcc: ["sponsorship"]
 params:
   - name: host

--- a/templates/definition/charger/daheimladen-mb.yaml
+++ b/templates/definition/charger/daheimladen-mb.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     de: Die Wallbox muss über eine aktuelle Firmware mit Modbus-Unterstützung verfügen. In den Einstellungen muss "Nachladen" (Smart) bzw. "RSDA" (Touch) aktiviert sein
     en: Wallbox must be operated with a recent firmware including Modbus support. Furthermore, “Nachladen” (Smart) or “RSDA” (Touch) must be activated in settings.
+    fr: La Wallbox doit fonctionner avec un firmware récent incluant la prise en charge du Modbus. En outre, la fonction « Nachladen » (Smart) ou « RSDA » (Touch) doit être activée dans les paramètres.
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/demo-charger.yaml
+++ b/templates/definition/charger/demo-charger.yaml
@@ -4,15 +4,18 @@ products:
   - description:
       de: Demowallbox
       en: Demo charger
+      fr: Chargeur de démo
 requirements:
   description:
     en: For demonstration purposes. Charger with a fixed set of values.
     de: Zu Demonstrationszwecken. Wallbox mit festen Werten.
+    fr: Chargeur avec des valeurs fixes pour démonstration
 params:
   - name: status
     description:
       de: Ladezustand
       en: Charge status
+      fr: Status de charge
     type: choice
     choice: [A, B, C]
     default: A
@@ -20,18 +23,21 @@ params:
     description:
       de: Leistung
       en: Power
+      en: Puissance
     type: int
     default: 0
   - name: enabled
     description:
       de: Ladebereit
       en: Enabled
+      fr: Activé
     type: bool
     default: true
   - name: maxcurrent
     description:
       de: Maximale Stromstärke (A)
       en: Maximum amperage (A)
+      fr: Courant maximum (A)
     help:
     example: 16
     type: int
@@ -40,6 +46,7 @@ params:
     description:
       de: Phasenumschaltung
       en: Phase switching
+      fr: Commutation de phases
     type: bool
     default: false
     advanced: true

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -21,11 +21,13 @@ params:
     help:
       de: Emailadresse
       en: Email address
+      fr: Adresse email
   - name: password
     required: true
     help:
       de: wie Login für Easee App oder Web Portal (https://easee.cloud)
       en: same as Easee app or the web portal (https://easee.cloud)
+      en: identique à celui utilisé dans l'app Easee ou le portail web (https://easee.cloud)
   - name: charger
     required: true
     example: EH______
@@ -36,6 +38,7 @@ params:
     help:
       de: Steuert ob evcc die Authentifizierung am Charger vornimmt. Vorteil ist ein kontrollierter Ladestart. Nicht kompatibel mit RFID Identifikation von Fahrzeugen.
       en: Controls wether evcc shall perform authentication against charger. Benefit is a contolled start of charging. Not compatible with RFID identification of vehicles.
+      en: Contrôle si evcc doit s'authentifier sur le chargeur. L'avantage est un démarrage contrôlé de la charge. Non compatible avec l'identification RFID des véhicules.
 render: |
   type: easee
   user: {{ .user }}

--- a/templates/definition/charger/eebus.yaml
+++ b/templates/definition/charger/eebus.yaml
@@ -3,6 +3,7 @@ products:
   - description:
       de: EEBUS kompatible Wallbox
       en: EEBUS compatible Wallbox
+      en: Chargeur compatible EEBUS
 group: generic
 capabilities: ["mA"]
 requirements:

--- a/templates/definition/charger/elli-2.yaml
+++ b/templates/definition/charger/elli-2.yaml
@@ -52,6 +52,12 @@ requirements:
       The usage of phase switching is currently not possible in evcc.
 
       The identification of a vehicle using the RFID card is not possible.
+    fr: |
+      Le dispositif doit être utilisé en mode de charge normal.
+
+      L'utilisation de la commutation de phase n'est actuellement pas possible dans l'evcc.
+      
+      L'identification d'un véhicule à l'aide de la carte RFID n'est pas possible.
 params:
   - preset: eebus
 render: |

--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -35,6 +35,14 @@ requirements:
       Important: A mostly flawless functionality can only be provided with an external energy meter and no usage of CT coils, due to sosftware bugs of the Wallbox. Using a LAN connection is highly recommended.
 
       Note: If you've added an energy meter to your charger please use the Pro or Connected+ integration.
+    fr: |
+      L'appareil doit avoir une adresse IP fixe (manuelle ou via DHCP).
+
+      L'identification d'un véhicule à l'aide de la carte RFID n'est pas possible.
+
+      Important : une fonctionnalité presque parfaite ne peut être assurée qu'avec un compteur d'énergie externe et sans utilisation de bobines de TC, en raison de bogues logiciels de la Wallbox. L'utilisation d'une connexion LAN est fortement recommandée.
+
+      Note : Si vous avez ajouté un compteur d'énergie à votre chargeur, veuillez utiliser l'intégration Pro ou Connected+.
 params:
   - preset: eebus
   - name: ip

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -31,6 +31,12 @@ requirements:
       The identification of a vehicle using the RFID card is not possible.
 
       Important: A mostly flawless functionality can only be provided with an external energy meter and no usage of CT coils, due to sosftware bugs of the Wallbox.  Using a LAN connection is highly recommended.
+    fr: |
+      L'appareil doit avoir une adresse IP fixe (manuelle ou via DHCP).
+
+      L'identification d'un véhicule à l'aide de la carte RFID n'est pas possible.
+
+      Important : une fonctionnalité presque parfaite ne peut être assurée qu'avec un compteur d'énergie externe et sans utilisation de bobines de TC, en raison de bogues logiciels de la Wallbox. L'utilisation d'une connexion LAN est fortement recommandée.
 params:
   - preset: eebus
   - name: ip

--- a/templates/definition/charger/em2go-home.yaml
+++ b/templates/definition/charger/em2go-home.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: "Benötigt FW version >= E3C_V1.1. mA Regelung benötigt FW version >= E3C_V1.3."
     en: "Requires FW Version >= E3C_V1.1. mA regulation requires FW version >= E3C_V1.3."
+    fr: "Requiert une version de FW >= E3C_V1.1. La régulation mA requiert un FW version >= E3C_V1.3."
 params:
   - name: host
 render: |

--- a/templates/definition/charger/em2go.yaml
+++ b/templates/definition/charger/em2go.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: "Aktuelle Firmware mit Modbus-Unterstützung notwendig (Pro Power: 1.01 bzw. OCPP/ONC: 3.15)"
     en: "Recent firmware with Modbus support required (Pro Power: 1.01 and OCPP/ONC: 3.15)"
+    fr: "Un firmware récent avec support Modbus est requis (Pro Power: 1.01 and OCPP/ONC: 3.15)"
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/etrel-duo.yaml
+++ b/templates/definition/charger/etrel-duo.yaml
@@ -9,6 +9,7 @@ requirements:
   description:
     de: Die Wallbox muss sich im "Power" Modus befinden.
     en: The charger must be switched to "Power" charging mode.
+    fr: Le mode "Power" soit être défini sur le chargeur.
 params:
   - name: connector
   - name: host

--- a/templates/definition/charger/etrel.yaml
+++ b/templates/definition/charger/etrel.yaml
@@ -12,6 +12,7 @@ requirements:
   description:
     de: Die Wallbox muss sich im "Power" Modus befinden.
     en: The charger must be switched to "Power" charging mode.
+    fr: Le mode "Power" soit être défini sur le chargeur.
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/evbox-livo.yaml
+++ b/templates/definition/charger/evbox-livo.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: Das Gerät benötigt eine feste IP Adresse. Es ist wichtig, zuerst EEBus einzurichten. Danach erkennt das Ladegerät evcc als HEMS-Gerät im Netzwerk. Verwende das Installationstool, um evcc als HEMS auszuwählen. Kopiere anschließend den angegebenen SKI aus der Installations-App und fügen ihn zu Ihrem YAML hinzu.
     en: The device requires a fixed IP addres. It's important to set up EEBus first. After setting up EEBus the charger will recognize evcc as a HEMS device on the network. Please use the installer tool to select evcc as HEMS. After this has been done, copy the given SKI from the Install app and add it to your yaml.
+    fr: L'appareil a besoin d'une adresse IP fixe. Il est important de configurer d'abord EEBus. Après avoir configuré EEBus, le chargeur reconnaîtra evcc comme un appareil HEMS sur le réseau. Veuillez utiliser l'outil d'installation pour sélectionner evcc comme HEMS. Une fois que cela a été fait, copiez le SKI donné à partir de l'application Install et ajoutez-le à votre yaml. 
 params:
   - preset: eebus
 render: |

--- a/templates/definition/charger/fronius-wattpilot.yaml
+++ b/templates/definition/charger/fronius-wattpilot.yaml
@@ -11,6 +11,7 @@ requirements:
       Benötigt mindestens Firmware 36.3 oder neuer.
     en: |
       Requires firmware 36.3 or later.
+    fr: Requiert le firmware 36.3 au moins
 params:
   - name: host
   - name: password

--- a/templates/definition/charger/ghost.yaml
+++ b/templates/definition/charger/ghost.yaml
@@ -22,6 +22,12 @@ requirements:
       The usage of phase switching is currently not possible in evcc.
 
       The identification of a vehicle using the RFID card is not possible.
+    fr: |
+      Le dispositif doit être utilisé en mode de charge normal.
+
+      L'utilisation de la commutation de phase n'est actuellement pas possible dans l'evcc.
+
+      L'identification d'un véhicule à l'aide de la carte RFID n'est pas possible.
 params:
   - preset: eebus
 render: |

--- a/templates/definition/charger/go-e-v3.yaml
+++ b/templates/definition/charger/go-e-v3.yaml
@@ -15,6 +15,10 @@ requirements:
       Requires firmware 052.1 or later.
       Requires "HTTP API v1" api, "HTTP API v2" for 1P/3P phase switching.
       The “simulate unplugging” option should be activated in the Go-E app ("Car" menu item).
+    fr: |
+      Nécessite le micrologiciel 052.1 ou une version ultérieure.
+      Requiert l'api « HTTP API v1 », « HTTP API v2 » pour la commutation de phase 1P/3P.
+      L'option « simuler le débranchement » doit être activée dans l'application Go-E (menu « Véhicule »).
   evcc: ["sponsorship"]
 params:
   - name: host

--- a/templates/definition/charger/go-e.yaml
+++ b/templates/definition/charger/go-e.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     en: Requires firmware 040.0 or later. HTTP API v1 or v2 must be activated.
     de: Benötigt mindestens Firmware 040.0 oder neuer. Das HTTP API v1 oder v2 muss aktiviert sein.
+    fr: Nécessite le firmware 040.0 ou plus récent. L'API HTTP v1 ou v2 doit être activée.
   evcc: ["sponsorship"]
 params:
   - name: host

--- a/templates/definition/charger/hardybarth-ecb1.yaml
+++ b/templates/definition/charger/hardybarth-ecb1.yaml
@@ -11,6 +11,7 @@ requirements:
   description:
     de: Als Betriebsmodus muss `manual` ausgewählt sein
     en: Charge mode must be configured as `manual`
+    fr: Le mode de charge 'manuel' doit être configuré 
 params:
   - name: host
   - name: connector

--- a/templates/definition/charger/heidelberg.yaml
+++ b/templates/definition/charger/heidelberg.yaml
@@ -17,6 +17,7 @@ requirements:
   description:
     de: Bitte das Handbuch zur Verkabelung und Konfiguration genau lesen. Alle Boxen müssen für die externe Steuerung auf Follower-Modus konfiguriert sein (DIP S5/4 OFF). Jede Box braucht eine individuelle Modbus-ID (DIP S4). Auf korrekte RS485-Verkabelung inkl. Busterminierung (DIP S6/2) achten.
     en: Please read the wiring and configuration manual carefully. All boxes must be configured for external control in follower mode (DIP S5/4 OFF). Each box needs an individual Modbus ID (DIP S4). Ensure correct RS485 cabling including bus termination (DIP S6/2).
+    fr: Veuillez lire attentivement le manuel de câblage et de configuration. Tous les boîtiers doivent être configurés pour une commande externe en mode suiveur (DIP S5/4 OFF). Chaque boîtier a besoin d'un ID Modbus individuel (DIP S4). Veillez à ce que le câblage RS485 soit correct, y compris la terminaison du bus (DIP S6/2).
   evcc: ["sponsorship"]
 params:
   - name: modbus

--- a/templates/definition/charger/homematic.yaml
+++ b/templates/definition/charger/homematic.yaml
@@ -9,16 +9,19 @@ params:
     description:
       en: XML-RPC server port number (BidCos-Wired=2000, BidCos-RF=2001, HmIP=2010)
       de: XML-RPC-Server Port-Nummer (BidCos-Wired=2000, BidCos-RF=2001, HmIP=2010)
+      fr: XML-RPC-Server Port-Nummer (BidCos-Wired=2000, BidCos-RF=2001, HmIP=2010)
   - name: device
     description:
       de: Geräteadresse/Seriennummer
       en: Device address/Serial number
+      fr: Adresse/numéro de série de l'appareil
     required: true
     mask: false
     example: "0001EE89AAD848"
     help:
       en: Homematic device id like shown in the CCU web user interface.
       de: Homematic Geräte Id, wie im CCU Webfrontend angezeigt.
+      fr: Id d'appareil Homematic, tel qu'affiché sur l'interface web CCU.
   - name: user
     required: false
   - name: password
@@ -32,9 +35,11 @@ params:
     description:
       en: Meter channel number (HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5, HM=2)
       de: Kanalnummer des Power-Meters (HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5, HM=2)
+      fr: Numéro de canal du compteur (HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5, HM=2)
     help:
       en: Homematic meter channel number like shown in the CCU web user interface.
       de: Kanalnummer des Messwertkanals, wie im CCU Webfrontend angezeigt.
+      fr: Numéro de canal du compteur, tel qu'affiché sur l'interface web CCU.
   - name: switchchannel
     default: 3
     type: int
@@ -43,18 +48,22 @@ params:
     description:
       en: Switch/Actor channel number (HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2, HM=1)
       de: Kanalnummer der schaltbaren Steckdose (HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2, HM=1)
+      fr: Numéro de canal de l'actuateur (HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2, HM=1)
     help:
       en: Homematic switch actor channel number like shown in the CCU web user interface.
       de: Kanalnummer der schaltbaren Steckdose, wie im CCU Webfrontend angezeigt.
+      fr: Numéro de canal de l'actuateur, tel qu'affiché sur l'interface web CCU.
   - name: cache
     advanced: true
     default: 1s
     description:
       en: XML-RPC api cache duration - Default 1s. (valid units are s,m,h)
       de: XML-RPC API Cache Zeitraum - Default 1s. (gültige Einheiten s,m,h)
+      de: Durée de cach de l'API XML-RPC - Défault 1s. (les unités valides sont s,m,h)
     help:
       en: In case of duty cycle problems try a cache setting of 30s.
       de: Bei Problemen mit dem Duty Cycle setze den Cache auf bspw 30s.
+      de: En cas de problèmes de cycle, essayer une configuration à 30s.
   - preset: switchsocket
 render: |
   type: homematic

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -15,6 +15,7 @@ requirements:
   description:
     de: Erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der x-Serie im WebMenü, bei der C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
     en: Requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the X-series in the web menu, for the C-series via Modbus by setting the value "3" in register 5050.
+    fr: Requiert une version de firmware 3.10.42 (C-series) ou 1.11 (X-series). Pour la commutation de phase, le commutateur de phase Keba (KeContact S10) est également nécessaire et la commande de commutation via Modbus doit être réglée dans les paramètres de la wallbox. Pour la série X dans le menu web, pour la série C via Modbus en réglant la valeur « 3 » dans le registre 5050.
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/mennekes-compact.yaml
+++ b/templates/definition/charger/mennekes-compact.yaml
@@ -21,6 +21,10 @@ requirements:
       The wallbox must be configured as satellite/slave using the DIP switches on the mainboard and Modbus RTU must be enabled (bank S1: 4=ON, 5=ON, 7=OFF).
       No external meter should be connected directly to the wallbox, as all functions are controlled directly by evcc.
       For Kostal systems with Smart Energy Meter (KSEM), the additional activation code (Solar Pure Mode / Solar Plus Mode) for the KSEM is *not* required.
+    fr: |
+      La wallbox doit être configurée comme satellite/esclave à l'aide des commutateurs DIP de la carte mère et le Modbus RTU doit être activé (banque S1 : 4=ON, 5=ON, 7=OFF).
+      Aucun compteur externe ne doit être connecté directement à la wallbox, car toutes les fonctions sont contrôlées directement par evcc.
+      Pour les systèmes Kostal avec Smart Energy Meter (KSEM), le code d'activation supplémentaire (Solar Pure Mode / Solar Plus Mode) pour le KSEM n'est *pas* nécessaire.
   evcc: ["sponsorship"]
 params:
   - name: modbus

--- a/templates/definition/charger/nrggen2.yaml
+++ b/templates/definition/charger/nrggen2.yaml
@@ -17,6 +17,7 @@ params:
     help:
       de: Aktiviert Phasenumschaltung. Erweiterte Funktion "Phasenumschaltung" muss in der NRGkick App aktiviert sein.
       en: Activates phase switching. Extended feature "Phase Switching" must be activated in the NRGKick app.
+      fr: Active la commutation de phase. La fonction étendue « Commutation de phase » doit être activée dans l'application NRGKick.
 render: |
   type: nrggen2
   {{- include "modbus" . }}

--- a/templates/definition/charger/ocpp-autel.yaml
+++ b/templates/definition/charger/ocpp-autel.yaml
@@ -21,6 +21,13 @@ requirements:
       * Server URL: ws://[evcc-address]:8887/ (local network connection)
       * Charger ID: Leave empty (for use the serial number) or set custom value which is reused in configuration as *stationid*
       * Authorisation Key: leave empty
+    fr: |
+      Guide d'installation :
+      * Dans l'application Autel Charge, cliquez sur « Serveur OCPP »
+      * Dans la barre de recherche, tapez « Custom » et sélectionnez-le.
+      * URL du serveur : ws://[evcc-address]:8887/ (connexion réseau locale)
+      * ID du chargeur : Laisser vide (pour utiliser le numéro de série) ou définir une valeur personnalisée qui sera réutilisée dans la configuration en tant que *stationid*.
+      * Clé d'autorisation : laisser vide
 params:
   - preset: ocpp
 render: |

--- a/templates/definition/charger/ocpp-fronius-wattpilot.yaml
+++ b/templates/definition/charger/ocpp-fronius-wattpilot.yaml
@@ -13,6 +13,10 @@ requirements:
       Note on configuring the Wattpilot using the solar.wattpilot app: The symbol next to the 
       example OCPP server `wss://<username>:<password>@ocpp.cloud.fronius.com/<UID>` is used for configuration.
       The evcc URL `ws://<evcc-address>:8887/` must be entered here and "Add SN to URL" must be activated.
+    fr: |
+      Note sur la configuration du Wattpilot à l'aide de l'application solar.wattpilot : Le symbole à côté de l'exemple de serveur OCPP 
+      exemple de serveur OCPP `wss://<username>:<password>@ocpp.cloud.fronius.com/<UID>` est utilisé pour la configuration.
+      L'URL evcc `ws://<evcc-address>:8887/` doit être saisie ici et « Add SN to URL » doit être activé.
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp-homecharge.yaml
+++ b/templates/definition/charger/ocpp-homecharge.yaml
@@ -13,6 +13,10 @@ requirements:
       The charger must be equipped with a built-in meter (models HC11L/HC22L Energy or Profi).
       For the OCPP configuration, you need to access the EFR-SECC charge controller at http://host/secc.
       For login credentials, ask your dealer or the vendor EFR (www.efr.de).
+    fr: |
+      Le chargeur doit être équipé d'un compteur intégré (modèles HC11L/HC22L Energy ou Profi).
+      Pour la configuration de l'OCPP, vous devez accéder au régulateur de charge EFR-SECC à l'adresse http://host/secc.
+      Pour obtenir les identifiants de connexion, demandez à votre revendeur ou au vendeur EFR (www.efr.de).
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp-pulsarplus-fw5.yaml
+++ b/templates/definition/charger/ocpp-pulsarplus-fw5.yaml
@@ -19,6 +19,13 @@ requirements:
       * URL: ws://[evcc-adresse]:8887/ (local network connection)
       * Charge Point Identity: Custom value (e.g. serial number of charger) which is reused in configuration as *stationid*
       * Password: leave empty
+    fr: |
+      Guide d'installation : https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/
+      * Activer « Enable OCPP » (myWallbox app) ou activer l'interrupteur « OCPP WebSocket connection » (myWallbox Portal)
+      * Activer « Improved charger control » (Profile -> Experimental functions) (myWallbox app) 
+      * URL : ws://[evcc-adresse]:8887/ (connexion réseau locale)
+      * Identité du point de charge : Valeur personnalisée (par exemple, le numéro de série du chargeur) qui est réutilisée dans la configuration comme *stationid*.
+      * Mot de passe : laisser vide
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp-pulsarplus.yaml
+++ b/templates/definition/charger/ocpp-pulsarplus.yaml
@@ -19,6 +19,13 @@ requirements:
       * URL: ws://[evcc-adresse]:8887/ (local network connection)
       * Charge Point Identity: Custom value (e.g. serial number of charger) which is reused in configuration as *stationid*
       * Password: leave empty
+    fr: |
+      Guide d'installation : https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/
+      * Activer « Enable OCPP » (myWallbox app) ou activer l'interrupteur « OCPP WebSocket connection » (myWallbox Portal)
+      * Activer « Improved charger control » (Profile -> Experimental functions) (myWallbox app) 
+      * URL : ws://[evcc-adresse]:8887/ (connexion réseau locale)
+      * Identité du point de charge : Valeur personnalisée (par exemple, le numéro de série du chargeur) qui est réutilisée dans la configuration comme *stationid*.
+      * Mot de passe : laisser vide
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -3,6 +3,7 @@ products:
   - description:
       de: OCPP 1.6J kompatible Wallbox mit Smart Charging Profil
       en: OCPP 1.6J compatible charger with Smart Charging Profile
+      fr: Chargeur compatible OCPP 1.6J avec profil Smart Charging
 group: generic
 capabilities: ["mA", "rfid", "1p3p"]
 requirements:
@@ -47,6 +48,26 @@ requirements:
       * Local network connection
 
       The specific configuration and the actual usable functionality depend on the charger model and its software.
+    fr: |
+      Avec OCPP, la connexion est établie entre le chargeur (client) et l'evcc (serveur).
+      Le chargeur doit pouvoir atteindre evcc via le nom d'hôte (résolution DNS fonctionnelle requise !) ou via l'adresse IP sur le port 8887.
+      Par défaut, la première connexion entrante avec un identifiant de station est utilisée.
+      Pour pouvoir attribuer clairement plusieurs points de charge, il faut configurer l'identifiant de la station (`stationid : `) et le numéro du connecteur (`connector : `).
+      De nombreuses wallbox ajoutent automatiquement l'identifiant de la station à l'URL du backend, tandis que d'autres doivent le faire manuellement `ws://<evcc>:8887/<stationid>`.
+      Si le chargeur prend en charge l'envoi de valeurs de comptage, essayez d'ajuster l'intervalle à une courte durée (< 10s).
+      Utilisez vos étiquettes RFID (cela permet par exemple d'identifier le véhicule) ou réglez votre chargeur sur « free charging » ou « autostart » pour générer la transaction nécessaire à la libération de la charge.
+
+      Si le chargeur n'offre pas la possibilité de démarrer les transactions localement, l'option avancée `remotestart` peut être utilisée pour démarrer automatiquement une transaction dès qu'un véhicule est connecté.
+      Cela ne devrait être nécessaire que dans des cas exceptionnels.
+
+      Exigences :
+      * Si nécessaire, supprimer les profils OCPP précédemment configurés (par exemple, utilisés pour une connexion backend différente) dans la configuration du chargeur.
+      * URL du backend (système central) dans la configuration du chargeur : `ws://[evcc-adresse]:8887/` (ajouter éventuellement `stationid`)
+      * Protocole : OCPP-J v1.6, ocpp16j, JSO
+      * Pas d'encryption, pas d'authentification, pas de mot de passe
+      * Connection en réseau local
+
+      La configuration spécifique et les fonctionnalités réellement utilisables dépendent du modèle de chargeur et de son logiciel.
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/pcelectric-garo.yaml
+++ b/templates/definition/charger/pcelectric-garo.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: Es können momentan nur als Master konfigurierte Geräte verwendet werden!
     en: Only devices configured as master can be used right now!
+    en: Seuls les appareils configurés comme "master" peuvent être utilisés pour l'instant!
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/peblar.yaml
+++ b/templates/definition/charger/peblar.yaml
@@ -9,6 +9,7 @@ requirements:
   description:
     de: Peblar-Ladegeräte mit Firmware-Version 1.6 und höher unterstützen Modbus TCP über Port 502. Der Modbus-Server muss über die Weboberfläche des Ladegeräts aktiviert werden. Stellen Sie sicher, dass Smart-Charging-Strategien deaktiviert und auf Standard gesetzt sind.
     en: Peblar chargers with firmware version 1.6 and onwards support Modbus TCP via port 502. The Modbus server needs to be enabled via the charger web interface. Ensure that smart charging strategies are disabled and set to Default.
+    fr: Les chargeurs Peblar à partir de la version 1.6 du firmware supportent le Modbus TCP via le port 502. Le serveur Modbus doit être activé via l'interface web du chargeur. Assurez-vous que les stratégies de charge intelligente sont désactivées et réglées sur Défaut.
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/phoenix-ev-eth.yaml
+++ b/templates/definition/charger/phoenix-ev-eth.yaml
@@ -17,6 +17,7 @@ requirements:
   description:
     en: DIP switch 10 at the controller needs to be set to 'ON'. A recent controller firmware is recommended.
     de: DIP Schalter 10 des Controllers muss auf 'ON' gestellt sein. Eine aktuelle Controller-Firmware wird empfohlen.
+    fr: Le commutateur DIP 10 du contrôleur doit être réglé sur 'ON'. Il est recommandé d'avoir un firmware du contrôleur à jour.
   evcc: ["sponsorship"]
 params:
   - name: modbus

--- a/templates/definition/charger/porsche-wallbox.yaml
+++ b/templates/definition/charger/porsche-wallbox.yaml
@@ -19,6 +19,12 @@ requirements:
       The usage of phase switching is currently not possible in evcc.
 
       The identification of a vehicle using the RFID card is not possible.
+    fr: |
+      Le dispositif doit être utilisé en mode de charge normal.
+
+      L'utilisation de la commutation de phase n'est actuellement pas possible dans l'evcc.
+
+      L'identification d'un véhicule à l'aide de la carte RFID n'est pas possible.
 params:
   - preset: eebus
 render: |

--- a/templates/definition/charger/smaevcharger.yaml
+++ b/templates/definition/charger/smaevcharger.yaml
@@ -9,6 +9,7 @@ requirements:
   description:
     de: Der EV Charger muss sich im Modus "Fast" befinden und der Benutzer muss die Rechte "Administrator" haben.
     en: The charger must be switched to "Fast" charging mode and the user must have "Administrator" rights.
+    fr: Le chargeur doit être en mode de charge « rapide » et l'utilisateur doit avoir les droits « Administrateur ».
 params:
   - name: host
   - name: user

--- a/templates/definition/charger/solax.yaml
+++ b/templates/definition/charger/solax.yaml
@@ -15,6 +15,7 @@ requirements:
   description:
     de: Die Wallbox muss sich im Modus "Schnell" befinden und vom Wechselrichtersystem entkoppelt sein.
     en: The charger must be in “Fast” mode and decoupled from the inverter system.
+    fr: Le chargeur doit être en mode « rapide » et découplé du système d'onduleur.
 params:
   - name: modbus
     choice: ["rs485"]

--- a/templates/definition/charger/tasmota.yaml
+++ b/templates/definition/charger/tasmota.yaml
@@ -4,6 +4,7 @@ products:
     description:
       de: einphasig
       en: single phase
+      fr: une phase
 group: switchsockets
 params:
   - name: host
@@ -12,6 +13,7 @@ params:
     help:
       de: Standard-User ist admin
       en: admin is default
+      fr: par défaut "admin"
   - name: password
     required: false
     mask: true
@@ -21,9 +23,11 @@ params:
     description:
       de: Schaltkanal Nummer
       en: Relaychannel number
+      fr: Numéro de canal
     help:
       de: Schaltkanal (1-8)
       en: Relaychannel number (1-8)
+      fr: Numéro du canal du relai (1-8)
   - preset: switchsocket
 render: |
   type: tasmota

--- a/templates/definition/charger/tinkerforge-warp.yaml
+++ b/templates/definition/charger/tinkerforge-warp.yaml
@@ -13,6 +13,7 @@ requirements:
   description:
     en: WARP Firmware v2 required. Automatic phase switching requires the additional WARP Energy Manager.
     de: WARP Firmware v2 erforderlich. Für automatische Phasenumschaltung wird zusätzlich der WARP Energy Manager benötigt.
+    fr: Le firmware WARP v2 est nécessaire. Pour la commutation automatique des phases, le WARP Energy Manager est également nécessaire.
   evcc: ["skiptest"]
 params:
   - preset: mqtt
@@ -22,6 +23,7 @@ params:
     help:
       de: WEM Firmware v2 erforderlich. EnergyManager MQTT Topic (falls installiert)
       en: WEM Firmware v2 required. EnergyManager MQTT topic (if installed)
+      fr: Le firmwave WEM v2 est nécessaire. Le topic MQTT du EnergyManager (si installé)
 render: |
   type: warp2
   {{ include "mqtt" . }}

--- a/templates/definition/charger/tinkerforge-warp3.yaml
+++ b/templates/definition/charger/tinkerforge-warp3.yaml
@@ -11,6 +11,7 @@ requirements:
   description:
     de: Die automatische Phasenumschaltung bei 1p Fahrzeugen muss deaktiviert sein. Siehe https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3.
     en: The automatic phase switching for 1p vehicles must be deactivated. Siehe https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3.
+    fr: La commutation automatique des phases pour les véhicules 1p doit être désactivée. Voir https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3.
   evcc: ["skiptest"]
 params:
   - preset: mqtt

--- a/templates/definition/charger/twc3.yaml
+++ b/templates/definition/charger/twc3.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be associated with the TWC3 loadpoint. At this time only Tesla vehicles are supported.
     de: Die TWC Wallbox ist nicht direkt regelbar. Die Regelung erfolgt über das Fahrzeug. Das Fahrzeug muss dem TWC3 Ladepunkt zugewiesen sein. Aktuell ausschließlich mit Tesla Fahrzeugen nutzbar.
+    fr: Le Tesla Wall Connector ne peut pas être contrôlée directement. Le contrôle se fait par l'intermédiaire du véhicule. Le véhicule doit être associé au point de charge TWC3. Pour l'instant, seuls les véhicules Tesla sont pris en charge.
 params:
   - name: host
 render: |

--- a/templates/definition/charger/versicharge.yaml
+++ b/templates/definition/charger/versicharge.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: Erfordert Firmware >= 2.135
     en: Requires firmware >= 2.135
+    fr: Requiert le firmware >= 2.135
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/wallbe-meter.yaml
+++ b/templates/definition/charger/wallbe-meter.yaml
@@ -5,10 +5,12 @@ products:
     description:
       de: Eco, Pro (mit Strommessgerät)
       en: Eco, Pro (with meter)
+      fr: Eco, Pro (avec compteur)
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.
     de: Im Gerät muss der DIP Schalter 10 auf 'ON' gestellt sein.
+    fr: Le commutateur DIP 10 doit être sur 'ON'.
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/wallbe-pre2019-meter.yaml
+++ b/templates/definition/charger/wallbe-pre2019-meter.yaml
@@ -5,10 +5,12 @@ products:
     description:
       de: Eco, Pro (vor ~2019, mit Strommessgerät)
       en: Eco, Pro (pre ~2019, with meter)
+      fr: Eco, Pro (pre ~2019, avec compteur)
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.
     de: Im Gerät muss der DIP Schalter 10 auf 'ON' gestellt sein.
+    fr: Le commutateur DIP 10 doit être sur 'ON'.
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/wallbe-pre2019.yaml
+++ b/templates/definition/charger/wallbe-pre2019.yaml
@@ -5,10 +5,12 @@ products:
     description:
       de: Eco, Pro (vor ~2019)
       en: Eco, Pro (pre ~2019)
+      fr: Eco, Pro (pre ~2019)
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.
     de: Im Gerät muss der DIP Schalter 10 auf 'ON' gestellt sein.
+    fr: Le commutateur DIP 10 doit être sur 'ON'.
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/wallbe.yaml
+++ b/templates/definition/charger/wallbe.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     en: The Wallbe must be connected using Ethernet and the DIP switch 10 must be set to 'ON'.
     de: Die Wallbox muss über ein Netzwerkkabel angebunden sein und im Gerät muss der DIP Schalter 10 auf 'ON' gestellt sein.
+    fr: Le Wallbe doit être connecté par Ethernet et le commutateur DIP 10 doit être réglé sur 'ON'.
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/webasto-next.yaml
+++ b/templates/definition/charger/webasto-next.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: Modus "HEMS activated" muss aktiviert sein. RFID-Tags können durch evcc nur gelesen werden.
     en: Mode "HEMS activated" must be enabled. RFID tags can only be read by evcc.
+    fr: Le mode « HEMS activé » doit être activé. Les étiquettes RFID ne peuvent être lues que par evcc.
   evcc: ["sponsorship"]
 params:
   - name: host

--- a/templates/definition/meter/demo-battery.yaml
+++ b/templates/definition/meter/demo-battery.yaml
@@ -4,10 +4,12 @@ products:
   - description:
       de: Demobatterie
       en: Demo battery
+      fr: Batterie de démo
 requirements:
   description:
     en: For demonstration purposes. Battery with a fixed set of values.
     de: Zu Demonstrationszwecken. Hausbatterie mit festen Werten.
+    fr: Une batterie domestique avec des valeurs fixes pour démonstration.
 params:
   - name: usage
     choice: ["battery"]
@@ -15,42 +17,50 @@ params:
     description:
       de: Leistung (W)
       en: Power (W)
+      fr: Puissance (W)
     type: int
   - name: soc
     description:
       de: Ladestand (%)
       en: Charge (%)
+      fr: Charge (%)
     type: int
   - name: controllable
     description:
       de: Steuerbar
       en: Controllable
+      fr: Contrôlable
     type: bool
     help:
       de: "Unterstützt aktive Batteriesteuerung"
       en: "Supports active battery control"
+      fr: "Supporte un contrôle actif de la batterie"
   - name: energy
     description:
       de: Zählerstand (kWh)
       en: Meter reading (kWh)
+      fr: Valeur du compteur (kWh)
     type: int
     advanced: true
   - name: currentL1
     description:
       de: L1 Stromstärke (A)
       en: L1 current (A)
+      fr: L1 courant (A)
     type: int
     advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke (A)
       en: L2 current (A)
+      fr: L2 courant (A)
     type: int
     advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke (A)
       en: L3 current (A)
+      fr: L3 courant (A)
     type: int
     advanced: true
 

--- a/templates/definition/meter/demo-meter.yaml
+++ b/templates/definition/meter/demo-meter.yaml
@@ -4,10 +4,12 @@ products:
   - description:
       de: Demozähler
       en: Demo meter
+      fr: Compteur de démo
 requirements:
   description:
     en: For demonstration purposes. Meter with a fixed set of values.
     de: Zu Demonstrationszwecken. Zähler mit festen Werten.
+    fr: Compteur avec valeurs fixes pour démonstration.
 params:
   - name: usage
     choice: ["grid", "pv", "aux", "charge"]
@@ -15,29 +17,34 @@ params:
     description:
       de: Leistung (W)
       en: Power (W)
+      fr: Puissance (W)
     type: int
   - name: energy
     description:
       de: Zählerstand (kWh)
       en: Meter reading (kWh)
+      fr: Valeur du compteur (kWh)
     type: int
     advanced: true
   - name: currentL1
     description:
       de: L1 Stromstärke (A)
       en: L1 current (A)
+      fr: L1 courant (A)
     type: int
     advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke (A)
       en: L2 current (A)
+      fr: L2 courant (A)
     type: int
     advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke (A)
       en: L3 current (A)
+      fr: L3 courant (A)
     type: int
     advanced: true
 

--- a/templates/definition/tariff/electricitymaps-free.yaml
+++ b/templates/definition/tariff/electricitymaps-free.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     de: "CO₂-Daten für viele Länder von https://electricitymaps.com/. Der 'Free Personal Tier' beinhaltet leider keine Prognosedaten. Dafür benötigst du einen kommerziellen Account von https://api-portal.electricitymaps.com/. Kostenloser Testmonat verfügbar."
     en: "CO₂ data for many countries from https://electricitymaps.com/. The 'Free Personal Tier' unfortunately does not include forecast data. You'll need a commercial account from https://api-portal.electricitymaps.com/. Free trial available."
+    fr: "CO₂ pour de nombreux pays à partir de https://electricitymaps.com/. Le « Free Personal Tier » ne comprend malheureusement pas les données de prévision. Vous aurez besoin d'un compte commercial sur https://api-portal.electricitymaps.com/. Essai gratuit disponible."
   evcc: ["skiptest"]
 group: co2
 params:
@@ -18,6 +19,7 @@ params:
     help:
       de: "siehe https://api.electricitymap.org/v3/zones"
       en: "see https://api.electricitymap.org/v3/zones"
+      fr: "voir https://api.electricitymap.org/v3/zones"
 render: |
   type: custom
   price:

--- a/templates/definition/tariff/electricitymaps.yaml
+++ b/templates/definition/tariff/electricitymaps.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     de: "CO₂-Daten für viele Länder von https://electricitymaps.com/. Der 'Free Personal Tier' beinhaltet leider keine Prognosedaten. Dafür benötigst du einen kommerziellen Account von https://api-portal.electricitymaps.com/. Kostenloser Testmonat verfügbar."
     en: "CO₂ data for many countries from https://electricitymaps.com/. The 'Free Personal Tier' unfortunately does not include forecast data. You'll need a commercial account from https://api-portal.electricitymaps.com/. Free trial available."
+    fr: "CO₂ pour de nombreux pays à partir de https://electricitymaps.com/. Le « Free Personal Tier » ne comprend malheureusement pas les données de prévision. Vous aurez besoin d'un compte commercial sur https://api-portal.electricitymaps.com/. Essai gratuit disponible."
   evcc: ["skiptest"]
 group: co2
 params:
@@ -21,6 +22,7 @@ params:
     help:
       de: "siehe https://api.electricitymap.org/v3/zones"
       en: "see https://api.electricitymap.org/v3/zones"
+      fr: "voir https://api.electricitymap.org/v3/zones"
 render: |
   type: electricitymaps
   uri: {{ .uri }}

--- a/templates/definition/tariff/energy-charts-api.yaml
+++ b/templates/definition/tariff/energy-charts-api.yaml
@@ -5,6 +5,7 @@ requirements:
   description:
     de: "Day-ahead Energiepreise (je kWh) an der Börse. Kann ohne vorherige Anmeldung auf https://api.energy-charts.info/ abgerufen werden. Nutzbar u.a. für dynamische Stromtarife, wo der Anbieter bis dato auf der Kundenschnittstelle noch kein Preis-Vorhersagen anbietet."
     en: "Day-ahead forecast of energy prices (per kWh) on the exchange. No prior registration for https://api.energy-charts.info/ necessary. Can be used for dynamic electricity tariffs, for example, where the supplier does not yet offer a price forecast on the customer interface."
+    fr: "Prévisions à court terme des prix de l'énergie (par kWh) sur la bourse. Aucun enregistrement préalable sur https://api.energy-charts.info/ n'est nécessaire. Peut être utilisé pour les tarifs d'électricité dynamiques, par exemple, lorsque le fournisseur ne propose pas encore de prévisions de prix sur l'interface client."
   evcc: ["skiptest"]
 group: price
 countries: ["EU"]
@@ -35,6 +36,7 @@ params:
     help:
       de: "Gebotszonen - https://api.energy-charts.info/#/prices/day_ahead_price_price_get"
       en: "Bidding zones - https://api.energy-charts.info/#/prices/day_ahead_price_price_get"
+      fr: "Zones - https://api.energy-charts.info/#/prices/day_ahead_price_price_get"
   - preset: tariff-base
 render: |
   type: custom

--- a/templates/definition/vehicle/bmw.yaml
+++ b/templates/definition/vehicle/bmw.yaml
@@ -3,10 +3,9 @@ products:
   - brand: BMW
 requirements:
   description:
-    de: |
-      Benötigt `hcaptcha` Token. Dieses muss einmalig unter [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html) generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
-    en: |
-      Requires `hcaptcha` token. This must be generated once at [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html). The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
+    de: Benötigt `hcaptcha` Token. Dieses muss einmalig unter [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html) generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
+    en: Requires `hcaptcha` token. This must be generated once at [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html). The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
+    fr: Nécessite le jeton `hcaptcha`. Il doit être généré une fois sur [bimmer-connected.readthedocs.io] (https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html). Le jeton n'est valide que pour une courte durée. Veuillez le copier dans la configuration et démarrer evcc dès que possible après sa génération.
 params:
   - preset: vehicle-base
   - name: vin

--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -3,10 +3,9 @@ products:
   - brand: Citroën
 requirements:
   description:
-    de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
-    en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    de: Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+    en: Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    fr: Nécessite les jetons `access` et `refresh`. Ils peuvent être générés avec la commande `evcc token [name]`.
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -3,10 +3,9 @@ products:
   - brand: DS
 requirements:
   description:
-    de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
-    en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    de: Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+    en: Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    fr: Nécessite les jetons `access` et `refresh`. Ils peuvent être générés avec la commande `evcc token [name]`.
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -11,6 +11,7 @@ params:
     help:
       en: Required for evcc to refresh the SoC while charging. When connected to TWC3, used to start/stop charging.
       de: Benötigt zur Aktualisierung des Ladestands während der Ladung. Bei Nutzung mit TWC3 kann der Ladevorgang mittels PIN gestartet und gestoppt werden.
+      fr: Nécessaire à evcc pour rafraîchir le SoC pendant la charge. Lorsqu'il est connecté au TWC3, il est utilisé pour démarrer/arrêter la charge.
   - preset: vehicle-features
 render: |
   type: fiat

--- a/templates/definition/vehicle/flobz.yaml
+++ b/templates/definition/vehicle/flobz.yaml
@@ -21,6 +21,7 @@ params:
     help:
       de: alternativer wakeup-Code; könnte zu erhöhter Entladung der 12V-Batterie führen.
       en: alternative wakeup-code; could lead to increased discharge of the 12V battery.
+      fr: code de réveil alternatif ; pourrait conduire à une décharge accrue de la batterie 12V.
     default: false
     advanced: true
 render: |

--- a/templates/definition/vehicle/ford-connect.yaml
+++ b/templates/definition/vehicle/ford-connect.yaml
@@ -9,6 +9,7 @@ params:
     help:
       de: Einrichtung unter https://developer.ford.com
       en: Setup at https://developer.ford.com
+      fr: Instalation sur https://developer.ford.com
     required: true
   - name: clientsecret
     description:
@@ -16,6 +17,7 @@ params:
     help:
       de: Einrichtung unter https://developer.ford.com
       en: Setup at https://developer.ford.com
+      fr: Instalation sur https://developer.ford.com
     required: true
   - name: accessToken
     required: true

--- a/templates/definition/vehicle/hyundai.yaml
+++ b/templates/definition/vehicle/hyundai.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     en: Some models (e.g. Kona) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: Manche Modelle (z.B. Kona) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
+    fr: Certains modèles (p. ex. Kona) commutent en interne sur 2 phases à des courants de charge faibles (< 8A). Dans les cas où la wallbox mesure également les courants de phase, cela entraîne des fluctuations indésirables de la puissance de charge. La solution consiste à régler le courant de charge minimum sur 8A.
 params:
   - preset: vehicle-base
   - preset: vehicle-language

--- a/templates/definition/vehicle/iso15118.yaml
+++ b/templates/definition/vehicle/iso15118.yaml
@@ -16,6 +16,11 @@ requirements:
       Using ISO15118 with some VW group vehicles, e.g. Porsche Taycan, requires additional configuration in the vehicle.
       This requires an active location-based charging profile with the lowest minimum charge (25%) and direct charging disabled.
       Otherwise the vehicle cannot be put into sleep mode.
+    fr: |
+      Pris en charge uniquement si le véhicule peut fournir l'état de charge (Soc) au chargeur connecté.
+      L'utilisation de la norme ISO15118 avec certains véhicules du groupe VW, par exemple la Porsche Taycan, nécessite une configuration supplémentaire dans le véhicule.
+      Il faut un profil de charge actif basé sur la localisation avec la charge minimale la plus basse (25 %) et la charge directe désactivée.
+      Sinon, le véhicule ne peut pas être mis en mode veille.
 params:
   - preset: vehicle-common
 render: |

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     en: Some models (e.g. Niro EV) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: Manche Modelle (z.B. Niro EV) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
+    fr: Certains modèles (p. ex. Niro EV) commutent en interne sur 2 phases à des courants de charge faibles (< 8A). Dans les cas où la wallbox mesure également les courants de phase, cela entraîne des fluctuations indésirables de la puissance de charge. La solution consiste à régler le courant de charge minimum sur 8A.
 params:
   - preset: vehicle-base
   - preset: vehicle-language

--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     en: Required MQTT broker configuration and a mazda2mqtt installation https://github.com/C64Axel/mazda2mqtt.
     de: Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation https://github.com/C64Axel/mazda2mqtt.
+    fr: La condition préalable est un broker MQTT configuré et une installation mazda2mqtt https://github.com/C64Axel/mazda2mqtt.
 params:
   - preset: vehicle-common
   - name: vin

--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -3,10 +3,9 @@ products:
   - brand: Mercedes-Benz
 requirements:
   description:
-    de: |
-      Benötigt `access` und `refresh` Tokens. Anleitung zur Generierung hier: https://tinyurl.com/mbapi2020helptoken.
-    en: |
-      Requires `access` and `refresh` tokens. Documentation here: https://tinyurl.com/mbapi2020helptoken.
+    de: Benötigt `access` und `refresh` Tokens. Anleitung zur Generierung hier: https://tinyurl.com/mbapi2020helptoken.
+    en: Requires `access` and `refresh` tokens. Documentation here: https://tinyurl.com/mbapi2020helptoken.
+    fr: Nécessite les jetons `access` et `refresh`. Documentation ici : https://tinyurl.com/mbapi2020helptoken.
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/mg2mqtt.yaml
+++ b/templates/definition/vehicle/mg2mqtt.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     en: Required MQTT broker configuration and a SAIC/MQTT Gateway (https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway or https://github.com/SAIC-iSmart-API/saic-java-client)
     de: Voraussetzung ist ein konfigurierter MQTT Broker und ein SAIC/MQTT Gateway (https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway oder https://github.com/SAIC-iSmart-API/saic-java-client)
+    fr: La condition préalable est un broker MQTT configuré et une passerelle SAIC/MQTT (https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway ou https://github.com/SAIC-iSmart-API/saic-java-client). 
 params:
   - name: user
     required: true

--- a/templates/definition/vehicle/mini.yaml
+++ b/templates/definition/vehicle/mini.yaml
@@ -3,10 +3,9 @@ products:
   - brand: Mini
 requirements:
   description:
-    de: |
-      Benötigt `hcaptcha` Token. Dieses muss einmalig unter [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html) generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
-    en: |
-      Requires `hcaptcha` token. This must be generated once at [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html). The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
+    de: Benötigt `hcaptcha` Token. Dieses muss einmalig unter [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html) generiert werden. Das Token ist nur für kurze Zeit gültig. Bitte möglichst schnell nach Generierung in die Konfiguration kopieren und evcc starten.
+    en: Requires `hcaptcha` token. This must be generated once at [bimmer-connected.readthedocs.io](https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html). The token is only valid for a short time. Please copy it into the configuration and start evcc as soon as possible after generation.
+    fr: Nécessite le jeton `hcaptcha`. Il doit être généré une fois sur [bimmer-connected.readthedocs.io] (https://bimmer-connected.readthedocs.io/en/latest/captcha/rest_of_world.html). Le jeton n'est valide que pour une courte durée. Veuillez le copier dans la configuration et démarrer evcc dès que possible après sa génération.
 params:
   - preset: vehicle-base
   - name: vin

--- a/templates/definition/vehicle/mz2mqtt.yaml
+++ b/templates/definition/vehicle/mz2mqtt.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     en: myMazda to MQTT. Required MQTT broker configuration and a mz2mqtt installation https://github.com/C64Axel/mz2mqtt.
     de: myMazda zu MQTT. Voraussetzung ist ein konfigurierter MQTT Broker und eine mz2mqtt Installation https://github.com/C64Axel/mz2mqtt.
+    fr: myMazda vers MQTT. La condition préalable est un broker MQTT configuré et une installation mz2mqtt https://github.com/C64Axel/mz2mqtt. 
 params:
   - preset: vehicle-common
   - name: vin

--- a/templates/definition/vehicle/niu-e-scooter.yaml
+++ b/templates/definition/vehicle/niu-e-scooter.yaml
@@ -16,6 +16,7 @@ params:
     description:
       de: Scooter Seriennummer, wie in der NIU app angegeben
       en: Scooter serial number like shown in NIU app
+      fr: Numéro de série du scooter comme indiqué dans l'application NIU
     required: true
   - name: capacity
     default: 4

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -3,10 +3,9 @@ products:
   - brand: Opel
 requirements:
   description:
-    de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
-    en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    de: Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+    en: Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    fr: Nécessite les jetons `access` et `refresh`. Ils peuvent être générés avec la commande `evcc token [name]`.
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/ovms.yaml
+++ b/templates/definition/vehicle/ovms.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     de: Unterstützung für alle Fahrzeuge via ODB2 Adapter im Fahrzeug. Mehr Infos bei [Open Vehicle Monitoring System](http://api.openvehicles.com/).
     en: Support for all vehicles via ODB2 adapter in the vehicle. More info at [Open Vehicle Monitoring System](http://api.openvehicles.com/).
+    fr: Prise en charge de tous les véhicules via l'adaptateur ODB2 dans le véhicule. Plus d'informations à l'adresse suivante : [Open Vehicle Monitoring System] (http://api.openvehicles.com/).
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -3,10 +3,9 @@ products:
   - brand: Peugeot
 requirements:
   description:
-    de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
-    en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    de: Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+    en: Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    fr: Nécessite les jetons `access` et `refresh`. Ils peuvent être générés avec la commande `evcc token [name]`.
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/renault.yaml
+++ b/templates/definition/vehicle/renault.yaml
@@ -10,6 +10,7 @@ params:
     description:
       de: Alternativer Aufweckmechanismus
       en: Alternative wakeup mechanism
+      fr: Mécanisme de réveil alternatif
     advanced: true
 render: |
   type: renault

--- a/templates/definition/vehicle/smart.yaml
+++ b/templates/definition/vehicle/smart.yaml
@@ -5,10 +5,9 @@ products:
       generic: EQ
 requirements:
   description:
-    de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
-    en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    de: Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+    en: Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+    fr: Nécessite les jetons `access` et `refresh`. Ils peuvent être générés avec la commande `evcc token [name]`.
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/tesla-ble.yaml
+++ b/templates/definition/vehicle/tesla-ble.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     de: Open Source Tesla BLE HTTP Proxy https://github.com/wimaha/TeslaBleHttpProxy
     en: Open Source Tesla BLE HTTP Proxy https://github.com/wimaha/TeslaBleHttpProxy
+    fr: Proxy HTTP open source pour protocole Tesla BLE https://github.com/wimaha/TeslaBleHttpProxy
 params:
   - preset: vehicle-common
   - name: vin
@@ -15,18 +16,21 @@ params:
     help:
       de: Erforderlich für BLE-Verbindung
       en: Required for BLE connection
+      fr: Nécessaire pour la connection BLE
   - name: url
     required: true
     example: http://192.168.178.27
     help:
       de: URL des Tesla BLE HTTP Proxy
       en: URL of the Tesla BLE HTTP Proxy
+      fr: URL du proxy HTTP pour Tesla BLE
   - name: port
     example: 8080
     default: 8080
     help:
       de: Port des Tesla BLE HTTP Proxy
       en: Port of the Tesla BLE HTTP Proxy
+      fr: Port du proxy HTTP pour Tesla BLE
 render: |
   type: custom
   {{- include "vehicle-common" . }}

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -19,23 +19,33 @@ requirements:
       The [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) guide explains the process and generates a free Access and Refresh Token. With this token pair and your Client ID created in the Tesla Developer Account, evcc can directly communicate with the Tesla API. You can see your used credit at Tesla.
 
       To use a Tesla Wall Connector, you need a public Command Proxy Server. [myteslamate.com](https://app.myteslamate.com/) provides this service for 12€/year. Configure the Command permissions at myteslamate.com and enter the Proxy Token here. Start, stopp and current commands are sent to Tesla via this proxy.
+    fr: |
+      Tesla propose une API officielle, mais payante, pour les véhicules.
+      Pour un usage privé, vous pouvez créer un [Tesla Developer Account] (https://developer.tesla.com/) et recevoir un crédit API mensuel de 10 $. Cela est généralement suffisant pour les cas d'utilisation courants de l'evcc.
+
+      Le guide [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) explique le processus et génère un jeton d'accès et de rafraîchissement gratuit. Avec cette paire de jetons et votre identifiant client créé dans le compte développeur Tesla, evcc peut communiquer directement avec l'API Tesla. Vous pouvez voir votre crédit utilisé chez Tesla.
+
+      Pour utiliser un Tesla Wall Connector, vous avez besoin d'un serveur proxy de commande public. [myteslamate.com](https://app.myteslamate.com/) fournit ce service pour 12€/an. Configurez les autorisations de commande sur myteslamate.com et entrez le jeton de proxy ici. Les commandes de démarrage, d'arrêt et de courant sont envoyées à Tesla via ce proxy.
 params:
   - preset: vehicle-common
   - name: clientId
     help:
       en: Client ID of your [Tesla Developer App](https://developer.tesla.com/dashboard).
       de: Kunden ID deiner [Tesla Developer App](https://developer.tesla.com/dashboard).
+      fr: ID client de votre [Tesla Developer App](https://developer.tesla.com/dashboard).
     required: true
   - name: accessToken
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).
       de: von [myteslamate.com](https://app.myteslamate.com/).
+      fr: depuis [myteslamate.com](https://app.myteslamate.com/).
     required: true
     mask: true
   - name: refreshToken
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).
-      de: von [myteslamate.com](https://app.myteslamate.com/).
+      de: von [myteslamate.com](https://app.myteslamate.com/).      
+      fr: depuis [myteslamate.com](https://app.myteslamate.com/).
     required: true
     mask: true
   - name: vin
@@ -48,11 +58,13 @@ params:
     help:
       en: "When using a TWC3 (or other 'dumb' charger not capable of control), evcc can manage the charge directly by communicating with the vehicle through a Command Proxy. By default the [myteslamate.com](https://app.myteslamate.com/) proxy is used. With this parameter, you set the base URL of a custom Command Proxy. See for example [TeslaBleHttpProxy](https://github.com/wimaha/TeslaBleHttpProxy) for a proxy sending commands via bluetooth."
       de: "Bei Verwendung eines TWC3 (oder eines anderen 'dummen' Ladegeräts, das nicht steuerbar ist) kann evcc die Ladung direkt verwalten, indem es über einen Command Proxy mit dem Fahrzeug kommuniziert. Standardmäßig wird der [myteslamate.com](https://app.myteslamate.com/) Proxy verwendet. Mit diesem Parameter kannst du die Basis-URL ändern. Siehe zum Beispiel [TeslaBleHttpProxy](https://github.com/wimaha/TeslaBleHttpProxy) für einen Proxy, der Kommandos über Bluetooth sendet."
+      fr: "Lors de l'utilisation d'un TWC3 (ou d'un autre chargeur « muet » non capable de contrôle), evcc peut gérer la charge directement en communiquant avec le véhicule par l'intermédiaire d'un proxy de commande. Par défaut, le proxy [myteslamate.com](https://app.myteslamate.com/) est utilisé. Ce paramètre permet de définir l'URL de base d'un Command Proxy personnalisé. Voir par exemple [TeslaBleHttpProxy](https://github.com/wimaha/TeslaBleHttpProxy) pour un proxy envoyant des commandes via bluetooth."
   - name: proxyToken
     advanced: true
     help:
       en: Token for the [myteslamate.com](https://app.myteslamate.com/) command proxy (12€/year fee). Ensure, that you've installed their Virtual Key and granted 'Charge Start', 'Charge Stop' and 'Set Charging Amps' permissions.
       de: Token für den Command Proxy von [myteslamate.com](https://app.myteslamate.com/) (12€/Jahr). Stelle sicher, dass du den Virtual Key installiert hast und die Berechtigungen 'Ladung starten', 'Ladung stoppen' und 'Ladestrom setzen' erteilt hast.
+      fr: Token pour le Command Proxy de [myteslamate.com](https://app.myteslamate.com/) (12€/an). Assure-toi que tu as installé la clé virtuelle et que tu as donné les autorisations 'Démarrer la charge', 'Arrêter la charge' et 'Définir le courant de charge'.
   - name: cache
     default: 15m
 render: |

--- a/templates/definition/vehicle/teslalogger.yaml
+++ b/templates/definition/vehicle/teslalogger.yaml
@@ -7,12 +7,14 @@ requirements:
   description:
     de: Open Source Tesla Datenlogger https://github.com/bassmaster187/TeslaLogger
     en: Open source Tesla data logger https://github.com/bassmaster187/TeslaLogger
+    fr: Enregistreur de données Tesla open source https://github.com/bassmaster187/TeslaLogger
 params:
   - preset: vehicle-common
   - name: id
     description:
       de: TeslaLogger CarID
       en: TeslaLogger CarID
+      fr: TeslaLogger CarID
     default: 1
   - name: url
     required: true

--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -7,12 +7,14 @@ requirements:
   description:
     en: Open source Tesla data logger https://github.com/adriankumpf/teslamate. MQTT broker required.
     de: Open Source Tesla Datenlogger https://github.com/adriankumpf/teslamate. Voraussetzung ist konfigurierter MQTT Broker.
+    fr: Enregistreur de données Tesla open source https://github.com/adriankumpf/teslamate.  Courtier MQTT requis.
 params:
   - preset: vehicle-common
   - name: id
     description:
       de: Fahrzeug-ID
       en: Vehicle ID
+      fr: ID du véhicule
     default: 1
 render: |
   type: custom

--- a/templates/definition/vehicle/tessie.yaml
+++ b/templates/definition/vehicle/tessie.yaml
@@ -7,17 +7,20 @@ requirements:
   description:
     de: Verbinden Sie Ihr Tesla-Fahrzeug über die Tessie-API. Dies wird das Fahrzeug niemals aufwecken; das Polling kann auf „always“ und interval „1M“ eingestellt werden. Wenn das Fahrzeug wach ist, sind die Daten normalerweise weniger als 15 Sekunden alt. Wenn das Fahrzeug schläft, stammen die Daten aus dem Zeitpunkt, zu dem es eingeschlafen ist. Holen Sie sich Ihr Token unter https://dash.tessie.com/settings/api
     en: Connect your Tesla using the Tessie API. This will never wake up the car, polling can be set to "always" and interval "1M". If the vehicle is awake, the data is usually less than 15 seconds old. If the vehicle is asleep, the data is from the time the vehicle went to sleep. Get your token at https://dash.tessie.com/settings/api
+    fr: Connectez votre Tesla en utilisant l'API Tessie. Cela ne réveillera jamais la voiture, l'interrogation peut être réglée sur « toujours » et l'intervalle sur « 1M ». Si le véhicule est réveillé, les données datent généralement de moins de 15 secondes. Si le véhicule est endormi, les données datent du moment où le véhicule s'est endormi. Obtenez votre jeton à l'adresse suivante : https://dash.tessie.com/settings/api
 params:
   - preset: vehicle-common
   - name: vin
     description:
       de: Fahrzeug-VIN
       en: Vehicle VIN
+      fr: VIN du véhicule
     required: true
   - name: token
     description:
       de: Tessie API Token
       en: Tessie API Token
+      fr: Jeton d'API Tessie
     required: true
 render: |
   type: custom

--- a/templates/definition/vehicle/tronity.yaml
+++ b/templates/definition/vehicle/tronity.yaml
@@ -13,6 +13,7 @@ params:
     help:
       de: Einrichtung unter https://app.tronity.tech
       en: Setup at https://app.tronity.tech
+      fr: Installation sur https://app.tronity.tech
     required: true
   - name: clientsecret
     description:
@@ -20,6 +21,7 @@ params:
     help:
       de: Einrichtung unter https://app.tronity.tech
       en: Setup at https://app.tronity.tech
+      fr: Installation sur https://app.tronity.tech
     required: true
   - name: vin
     example: W...

--- a/templates/definition/vehicle/volvo-connected.yaml
+++ b/templates/definition/vehicle/volvo-connected.yaml
@@ -4,6 +4,7 @@ products:
     description:
       de: aktuell
       en: latest
+      fr: dernière version
 params:
   - preset: vehicle-base
   - name: vccapikey
@@ -11,6 +12,7 @@ params:
     help:
       en: "Volvo developer portal VCC API Key, see https://github.com/evcc-io/evcc/discussions/3677#discussioncomment-4106300"
       de: "Volvo developer portal VCC API Key, siehe https://github.com/evcc-io/evcc/discussions/3677#discussioncomment-4106300"
+      fr: "Volvo developer portal VCC API Key, voir https://github.com/evcc-io/evcc/discussions/3677#discussioncomment-4106300"
 render: |
   type: volvo-connected
   vccapikey: {{ .vccapikey }}

--- a/templates/definition/vehicle/volvo.yaml
+++ b/templates/definition/vehicle/volvo.yaml
@@ -4,6 +4,7 @@ products:
     description:
       de: veraltet
       en: legacy
+      fr: ancienne version
 params:
   - preset: vehicle-base
 render: |

--- a/templates/definition/vehicle/volvo2mqtt.yaml
+++ b/templates/definition/vehicle/volvo2mqtt.yaml
@@ -7,6 +7,7 @@ requirements:
   description:
     en: Requires MQTT broker configuration and a volvo2mqtt installation https://github.com/Dielee/volvo2mqtt
     de: Erforderlich ist eine konfigurierte MQTT Broker-Konfiguration und eine volvo2mqtt-Installation https://github.com/Dielee/volvo2mqtt.
+    fr: Nécessite une configuration de courtier MQTT configurée et une installation de volvo2mqtt https://github.com/Dielee/volvo2mqtt.
 params:
   - preset: vehicle-common
   - name: vin

--- a/templates/definition/vehicle/vw.yaml
+++ b/templates/definition/vehicle/vw.yaml
@@ -8,6 +8,7 @@ requirements:
   description:
     de: e-Golf, e-Up, ID Familie
     en: e-Golf, e-Up, ID family
+    fr: e-Golf, e-Up, gamme ID
 params:
   - preset: vehicle-base
   - name: vin


### PR DESCRIPTION
With the new configuration UI, most device configuration forms are displaying content coming from templates and not the i18n resources managed in Weblate. As an important contributor to evcc French translation, I’m going further and added in this PR French translations to field descriptions and help texts used in most templates. 