### PR TITLE
Docs: annotate params with description not help

### DIFF
--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -3,8 +3,8 @@
   {{- range .Values }}
   - {{ . }}
   {{- end }}
-  {{- $help := localize .Help | replace "\n" " " -}}
-  {{- if $help }} # {{ $help }}{{- end }}{{- if not .IsRequired }}{{ if not $help }} # {{ else }} ({{ end }}optional{{ if $help }}){{ end }}{{ end }}
+  {{- $description := localize .Description | replace "\n" " " -}}
+  {{- if $description }} # {{ $description }}{{- end }}{{- if not .IsRequired }}{{ if not $description }} # {{ else }} ({{ end }}optional{{ if $description }}){{ end }}{{ end }}
 {{- end }}
 
 {{- define "header" }}


### PR DESCRIPTION
This will change the rendering of the autogenerated docs. It will print the "description" instead of the "help" values from template to the docs as comment after each param.