### PR TITLE
Add SAJ H1 hybrid inverters

### DIFF
--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -15,15 +15,15 @@ params:
   # battery control
   - name: defaultmode
     type: int
-    default: 0 # (0=self-use,1=time-of-use,2=backup,3=passive)
+    default: 0 # (0=self-use,2=backup)
     advanced: true
   - name: holdmode
     type: int
-    default: 2 # (0=self-use,1=time-of-use,2=backup,3=passive)
+    default: 2 # (2=backup,3=passive)
     advanced: true
   - name: backupsoc
     type: int
-    default: 20 # used when backup mode is used as defaultmode to control the default backup soc
+    default: 20 # only used when .defaultmode is 2 (backup) to control the default backupsoc (from this soc, system will work as in self-use)
     advanced: true
 render: |
   type: custom
@@ -109,8 +109,9 @@ render: |
               address: 0x3247 # AppMode
               type: writeholding
               decode: uint16
+        {{- if eq .defaultmode "2" }} # 'backup soc' should only be set when .defaultmode is 2 (backup)
         - source: const
-          value: {{ .backupsoc }} # use backupsoc value to define the min backup soc to retain
+          value: {{ .backupsoc }} # use .backupsoc value as 'backup soc' from where the system will work as in self-use
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
@@ -119,6 +120,7 @@ render: |
               address: 0x3271 # BackModSOCRetain
               type: writeholding
               decode: uint16
+        {{- end }}
     - case: 2 # hold
       set:
         source: sequence
@@ -133,8 +135,9 @@ render: |
               address: 0x3247 # AppMode
               type: writeholding
               decode: uint16
+        {{- if eq .holdmode "2" }} # 'backup soc' should only be set when .holdmode is 2 (backup)
         - source: go
-          script: holdsoc
+          script: holdsoc # read 'current soc' and write it to the 'backup soc' to prevent battery discharge below this value
           in:
           - name: holdsoc
             type: int
@@ -158,6 +161,7 @@ render: |
                 address: 0x3271 # BackModSOCRetain
                 type: writeholding
                 decode: uint16
+        {{- end }}
     - case: 3 # charge
       set:
         source: sequence

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -133,16 +133,31 @@ render: |
               address: 0x3247 # AppMode
               type: writeholding
               decode: uint16
-        - source: const
-          value: {{ .soc }} # use current soc value to define the backup soc to retain
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            timeout: {{ .timeout }}
-            register:
-              address: 0x3271 # BackModSOCRetain
-              type: writeholding
-              decode: uint16
+        - source: go
+          script: holdsoc
+          in:
+          - name: holdsoc
+            type: int
+            config:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              timeout: {{ .timeout }}
+              register:
+                address: 0x406F # BatEnergyPercent
+                type: holding
+                decode: uint16
+              scale: 0.01
+          out:
+          - name: holdsoc
+            type: int
+            config:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              timeout: {{ .timeout }}
+              register:
+                address: 0x3271 # BackModSOCRetain
+                type: writeholding
+                decode: uint16
     - case: 3 # charge
       set:
         source: sequence

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -5,13 +5,30 @@ products:
       generic: H1 Series Hybrid Solar Inverter
 params:
   - name: usage
-    choice: ["pv", "battery"]
+    choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["tcpip"]
   - name: capacity
     advanced: true
 render: |
   type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x40A1 # SmartMeterTotalGridPowerWatt (undocumented)
+      type: holding
+      decode: int16
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x40FD # Total_FeedInEnergy
+      type: holding
+      decode: uint32
+    scale: 0.01
+  {{- end }}
   {{- if eq .usage "pv" }}
   power:
     source: modbus

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -14,9 +14,11 @@ params:
     advanced: true
   # battery control
   - name: defaultmode
+    type: int
     default: 0 # (0=self-use,1=time-of-use,2=backup,3=passive)
     advanced: true
   - name: holdmode
+    type: int
     default: 2 # (0=self-use,1=time-of-use,2=backup,3=passive)
     advanced: true
   - name: backupsoc
@@ -106,9 +108,9 @@ render: |
             register:
               address: 0x3247 # AppMode
               type: writeholding
-              decode: int16
+              decode: uint16
         - source: const
-          value: {{ .backupsoc }} # use backupsoc value when using backup mode as defaultmode
+          value: {{ .backupsoc }} # use backupsoc value to define the min backup soc to retain
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
@@ -116,7 +118,7 @@ render: |
             register:
               address: 0x3271 # BackModSOCRetain
               type: writeholding
-              decode: int16
+              decode: uint16
     - case: 2 # hold
       set:
         source: sequence
@@ -130,9 +132,9 @@ render: |
             register:
               address: 0x3247 # AppMode
               type: writeholding
-              decode: int16
+              decode: uint16
         - source: const
-          value: {{ .soc }} # hold on current soc value when using backup mode as holdmode
+          value: {{ .soc }} # use current soc value to define the backup soc to retain
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
@@ -140,7 +142,7 @@ render: |
             register:
               address: 0x3271 # BackModSOCRetain
               type: writeholding
-              decode: int16
+              decode: uint16
     - case: 3 # charge
       set:
         source: sequence
@@ -154,7 +156,7 @@ render: |
             register:
               address: 0x3247 # AppMode
               type: writeholding
-              decode: int16
+              decode: uint16
         - source: const
           value: 1 # enable
           set:
@@ -164,7 +166,7 @@ render: |
             register:
               address: 0x3604 # Charge time enable control
               type: writeholding
-              decode: int16
+              decode: uint16
         - source: const
           value: 0 # start time (00:00)
           set:
@@ -174,7 +176,7 @@ render: |
             register:
               address: 0x3606 # Battery first charging time (start)
               type: writeholding
-              decode: int16
+              decode: uint16
         - source: const
           value: 0x173B # end time (23:59)
           set:
@@ -184,7 +186,7 @@ render: |
             register:
               address: 0x3607 # Battery first charging time (end)
               type: writeholding
-              decode: int16
+              decode: uint16
         - source: const
           value: 0x7F64 # every day (0x7f) at 100% (0x64)
           set:
@@ -194,6 +196,6 @@ render: |
             register:
               address: 0x3608 # Battery first charging time (power)
               type: writeholding
-              decode: int16
+              decode: uint16
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -12,6 +12,17 @@ params:
     default: 5s
   - name: capacity
     advanced: true
+  # battery control
+  - name: defaultmode
+    default: 0 # (0=self-use,1=time-of-use,2=backup,3=passive)
+    advanced: true
+  - name: holdmode
+    default: 2 # (0=self-use,1=time-of-use,2=backup,3=passive)
+    advanced: true
+  - name: backupsoc
+    type: int
+    default: 20 # used when backup mode is used as defaultmode to control the default backup soc
+    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -79,5 +90,110 @@ render: |
       type: holding
       decode: uint16
     scale: 0.01
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: {{ .defaultmode }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3247 # AppMode
+              type: writeholding
+              decode: int16
+        - source: const
+          value: {{ .backupsoc }} # use backupsoc value when using backup mode as defaultmode
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3271 # BackModSOCRetain
+              type: writeholding
+              decode: int16
+    - case: 2 # hold
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: {{ .holdmode }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3247 # AppMode
+              type: writeholding
+              decode: int16
+        - source: const
+          value: {{ .soc }} # hold on current soc value when using backup mode as holdmode
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3271 # BackModSOCRetain
+              type: writeholding
+              decode: int16
+    - case: 3 # charge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1 # Time-Of-Use
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3247 # AppMode
+              type: writeholding
+              decode: int16
+        - source: const
+          value: 1 # enable
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3604 # Charge time enable control
+              type: writeholding
+              decode: int16
+        - source: const
+          value: 0 # start time (00:00)
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3606 # Battery first charging time (start)
+              type: writeholding
+              decode: int16
+        - source: const
+          value: 0x173B # end time (23:59)
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3607 # Battery first charging time (end)
+              type: writeholding
+              decode: int16
+        - source: const
+          value: 0x7F64 # every day (0x7f) at 100% (0x64)
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            timeout: {{ .timeout }}
+            register:
+              address: 0x3608 # Battery first charging time (power)
+              type: writeholding
+              decode: int16
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -8,6 +8,8 @@ params:
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["tcpip"]
+  - name: timeout
+    default: 5s
   - name: capacity
     advanced: true
 render: |
@@ -16,6 +18,7 @@ render: |
   power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
     register:
       address: 0x40A1 # SmartMeterTotalGridPowerWatt (undocumented)
       type: holding
@@ -23,6 +26,7 @@ render: |
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
     register:
       address: 0x40FD # Total_FeedInEnergy
       type: holding
@@ -33,6 +37,7 @@ render: |
   power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
     register:
       address: 0x40A5 # TotalPVPower
       type: holding
@@ -40,6 +45,7 @@ render: |
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
     register:
       address: 0x40C5 # Total PVEnergy
       type: holding
@@ -50,6 +56,7 @@ render: |
   power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
     register:
       address: 0x40A6 # TotalBatteryPower
       type: holding
@@ -57,6 +64,7 @@ render: |
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
     register:
       address: 0x40D5 # Total BatDisEnergy
       type: holding
@@ -65,6 +73,7 @@ render: |
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
     register:
       address: 0x406F # BatEnergyPercent
       type: holding

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -110,7 +110,6 @@ render: |
               address: 0x3247 # AppMode
               type: writeholding
               decode: uint16
-        {{- end }}
     - case: 3 # charge
       set:
         source: sequence

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -12,19 +12,6 @@ params:
     default: 5s
   - name: capacity
     advanced: true
-  # battery control
-  - name: defaultmode
-    type: int
-    default: 0 # (0=self-use,2=backup)
-    advanced: true
-  - name: holdmode
-    type: int
-    default: 2 # (2=backup,3=passive)
-    advanced: true
-  - name: backupsoc
-    type: int
-    default: 20 # only used when .defaultmode is 2 (backup) to control the default backupsoc (from this soc, system will work as in self-use)
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -100,7 +87,7 @@ render: |
         source: sequence
         set:
         - source: const
-          value: {{ .defaultmode }}
+          value: 0 # self-use mode
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
@@ -109,24 +96,12 @@ render: |
               address: 0x3247 # AppMode
               type: writeholding
               decode: uint16
-        {{- if eq .defaultmode "2" }} # 'backup soc' should only be set when .defaultmode is 2 (backup)
-        - source: const
-          value: {{ .backupsoc }} # use .backupsoc value as 'backup soc' from where the system will work as in self-use
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            timeout: {{ .timeout }}
-            register:
-              address: 0x3271 # BackModSOCRetain
-              type: writeholding
-              decode: uint16
-        {{- end }}
     - case: 2 # hold
       set:
         source: sequence
         set:
         - source: const
-          value: {{ .holdmode }}
+          value: 3 # passive mode
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
@@ -135,39 +110,13 @@ render: |
               address: 0x3247 # AppMode
               type: writeholding
               decode: uint16
-        {{- if eq .holdmode "2" }} # 'backup soc' should only be set when .holdmode is 2 (backup)
-        - source: go
-          script: holdsoc # read 'current soc' and write it to the 'backup soc' to prevent battery discharge below this value
-          in:
-          - name: holdsoc
-            type: int
-            config:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              timeout: {{ .timeout }}
-              register:
-                address: 0x406F # BatEnergyPercent
-                type: holding
-                decode: uint16
-              scale: 0.01
-          out:
-          - name: holdsoc
-            type: int
-            config:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              timeout: {{ .timeout }}
-              register:
-                address: 0x3271 # BackModSOCRetain
-                type: writeholding
-                decode: uint16
         {{- end }}
     - case: 3 # charge
       set:
         source: sequence
         set:
         - source: const
-          value: 1 # Time-Of-Use
+          value: 1 # time-of-use mode
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -1,0 +1,57 @@
+template: saj-h1
+products:
+  - brand: SAJ
+    description:
+      generic: H1 Series Hybrid Solar Inverter
+params:
+  - name: usage
+    choice: ["pv", "battery"]
+  - name: modbus
+    choice: ["tcpip"]
+  - name: capacity
+    advanced: true
+render: |
+  type: custom
+  {{- if eq .usage "pv" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x40A5 # TotalPVPower
+      type: holding
+      decode: int16
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x40C5 # Total PVEnergy
+      type: holding
+      decode: uint32
+    scale: 0.01
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x40A6 # TotalBatteryPower
+      type: holding
+      decode: int16
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x40D5 # Total BatDisEnergy
+      type: holding
+      decode: uint32
+    scale: 0.01
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x406F # BatEnergyPercent
+      type: holding
+      decode: uint16
+    scale: 0.01
+  capacity: {{ .capacity }} # kWh
+  {{- end }}


### PR DESCRIPTION
This PR contains the setup for a SAJ H1 inverter and is the continuation of https://github.com/evcc-io/evcc/pull/18097.

H1 inverter is quite similar as the H2 inverter, so I based myself the template for the H2 (https://github.com/evcc-io/evcc/blob/master/templates/definition/meter/saj-h2.yaml)

Documentation about H1: 
https://img.saj-electric.com/file/H1-3-6K-S2-15%C2%A0user%20manual%20EN-V0.0-2023041004191770.pdf
https://github.com/sgsancho/saj_h1_s2_modbus_esp32/blob/main/documentacion/SAJ_Modbus_Communication_Protocol_2020.pdf

Included meters:
- [x] pv
    - [x] power
    - [x] energy 
- [x] battery
    - [x] power
    - [x] energy
    - [x] soc 
    - [x] batterymode
- [x] grid
    - [x] power (smart meter grid power)
    - [ ] ~~currents~~ -> N/A

