### PR TITLE
Hassio: delete old docker nightly tags, only keep last 2

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker meta
+      - name: Define tags
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -75,6 +75,14 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Delete old nightly.* tags
+        run: |
+          old_tags=$(curl -s "https://hub.docker.com/v2/repositories/evcc/evcc/tags/?page_size=100" | jq -r '.results | map(select(.name | startswith("nightly."))) | sort_by(.last_updated) | reverse | .[1:] | .[].name')
+          for tag in $old_tags; do
+            echo "Deleting tag: $tag"
+            curl -s -H "Authorization: Bearer ${{ secrets.DOCKER_TOKEN }}" -X DELETE "https://hub.docker.com/v2/repositories/evcc/evcc/tags/$tag/"
+          done
 
   hassio:
     name: Hassio Addon :nightly


### PR DESCRIPTION
this PR removed the old nightly.* tags from docker hub and keeps only the last 2 (the one currently build and the last one that is currently published).

to make this work we need to create a docker hub token and place it into the repo:

1. create docker hub token with DELETE access here:
https://app.docker.com/settings/personal-access-tokens/create

2. put it as `DOCKER_TOKEN` here:
https://github.com/evcc-io/evcc/settings/secrets/actions