### PR TITLE
Sessions: fix missing loadpoint names

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -241,6 +241,14 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, other 
 		lp.mode = api.ModeOff
 	}
 
+	if lp.Title != "" {
+		lp.setTitle(lp.Title)
+	}
+
+	if lp.Priority > 0 {
+		lp.setPriority(lp.Priority)
+	}
+
 	return lp, nil
 }
 
@@ -278,14 +286,6 @@ func NewLoadpoint(log *util.Logger, settings settings.Settings) *Loadpoint {
 func (lp *Loadpoint) restoreSettings() {
 	if testing.Testing() {
 		return
-	}
-
-	// from yaml
-	if lp.Title != "" {
-		lp.setTitle(lp.Title)
-	}
-	if lp.Priority > 0 {
-		lp.setPriority(lp.Priority)
 	}
 
 	// deprecated yaml properties


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/18850

- loadpoint title (from yaml) has to be present before db/session init

Problem was, that `newStore` was called with an uninitialized (`""`) title for yaml configured LPs.
 https://github.com/evcc-io/evcc/blob/bbe5982b4c9868c38541affbfcb4f68cf55d1aae/core/site.go#L163-L163

Note: In 0.200 loadpoint title was not stored in the database. We have no way to auto-recover. The only way to fix this data right now is manual db-edit.