### PR TITLE
docs: fix mennekes escaping

### DIFF
--- a/templates/definition/charger/ocpp-mennekes-acu.yaml
+++ b/templates/definition/charger/ocpp-mennekes-acu.yaml
@@ -16,7 +16,7 @@ requirements:
     en: |
       To configure, open the web interface of the ACU.
       Setup, Backend, Communication Protocol: Open Charge Point Protocol v1.6J
-      Setup, Backend, Backend Server: The EVCC URL ws://<evcc-address>:8887/ must be entered here. Basic Authentication: Disabled. OCPP 1.6 Settings: Enable all options.
+      Setup, Backend, Backend Server: The EVCC URL `ws://<evcc-address>:8887/` must be entered here. Basic Authentication: Disabled. OCPP 1.6 Settings: Enable all options.
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp-mennekes-acu.yaml
+++ b/templates/definition/charger/ocpp-mennekes-acu.yaml
@@ -16,7 +16,7 @@ requirements:
     en: |
       To configure, open the web interface of the ACU.
       Setup, Backend, Communication Protocol: Open Charge Point Protocol v1.6J
-      Setup, Backend, Backend Server: The EVCC URL `ws://<evcc-address>:8887/` must be entered here. Basic Authentication: Disabled. OCPP 1.6 Settings: Enable all options.
+      Setup, Backend, Backend Server: The evcc URL `ws://<evcc-address>:8887/` must be entered here. Basic Authentication: Disabled. OCPP 1.6 Settings: Enable all options.
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp


### PR DESCRIPTION
fixes broken docs

Note: `<foo>` always have to be escaped in a code block `` to avoid rendering issues.

Quickfix in docs: https://github.com/evcc-io/docs/commit/61d3fe1ac4e3c64c4e8bb98646806b58818108ae