### PR TITLE
Mercedes:  Fix Refresh token handling

### DIFF
--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -10,6 +10,7 @@ requirements:
 params:
   - preset: vehicle-common
   - name: user
+    deprecated: true
     required: true
   - name: region
     required: true
@@ -17,21 +18,22 @@ params:
     choice: ["EMEA", "APAC", "NORAM"]
     default: EMEA
   - name: accessToken
-    required: true
+    required: false
     mask: true
+    deprecated: true
+    default: not_used
   - name: refreshToken
     required: true
     mask: true
   - name: vin
     example: V...
+    required: true
   - name: cache
     default: 15m
 render: |
   type: mercedes
   vin: {{ .vin }}
-  user: {{ .user }}
   region: {{ .region }}
   tokens:
-    access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}

--- a/vehicle/mercedes/helper.go
+++ b/vehicle/mercedes/helper.go
@@ -3,7 +3,6 @@ package mercedes
 import (
 	"fmt"
 	"net/http"
-	"sync"
 
 	"github.com/google/uuid"
 )
@@ -11,20 +10,6 @@ import (
 // Helper provides utility primitives
 type Helper struct {
 	*http.Client
-}
-
-var (
-	mu         sync.Mutex
-	identities = make(map[string]*Identity)
-)
-
-func getInstance(subject string) *Identity {
-	v := identities[subject]
-	return v
-}
-
-func addInstance(subject string, identity *Identity) {
-	identities[subject] = identity
 }
 
 const (

--- a/vehicle/mercedes/identity.go
+++ b/vehicle/mercedes/identity.go
@@ -39,7 +39,6 @@ var OAuth2Config = &oauth2.Config{
 
 // NewIdentity creates Mercedes identity
 func NewIdentity(log *util.Logger, token *oauth2.Token, account string, region string) (*Identity, error) {
-
 	v := &Identity{
 		Helper:  request.NewHelper(log),
 		log:     log,


### PR DESCRIPTION
With the latest API changes made by Mercedes, the refresh token is stable and is not changed anymore with every token refresh. (Not sure if this is a config bug on MB side as this will reduce the security level) - this PR will remove all the code that handled the rolling refresh token logic. 

Now, the refresh token out of the config is the only source of true. 

Setting store usage is removed. No need to delete of tokens in the db anymore...

User account is not needed anymore, for each car a separate refresh token is needed now. --> **breaking change**...

The new code was running in my environment for multiple hours and multiple restarts...

@andig: May I ask you to check it with your knowledge of evcc. Thx. I planned to remove the not needed access token in the config, but not sure why it is still visible in the frontend. (We need the refresh token only, as we request a new access token on restart.)

fixes: #18863