### PR TITLE
Mercedes: Fix Refresh Token Handling

### DIFF
--- a/vehicle/mercedes/identity.go
+++ b/vehicle/mercedes/identity.go
@@ -68,19 +68,19 @@ func NewIdentity(log *util.Logger, token *oauth2.Token, account string, region s
 		token.Expiry = time.Now().Add(time.Duration(10) * time.Second)
 	}
 
-	if !token.Valid() && token.RefreshToken != "" {
-		v.log.DEBUG.Println("identity.NewIdentity - refreshToken started")
-		if tok, err := v.RefreshToken(token); err == nil {
-			token = tok
-		}
-	}
-
 	// database token
 	if !token.Valid() {
 		var tok oauth2.Token
 		if err := settings.Json(v.settingsKey(), &tok); err == nil {
 			v.log.DEBUG.Println("identity.NewIdentity - database token found")
 			token = &tok
+		}
+	}
+
+	if !token.Valid() && token.RefreshToken != "" {
+		v.log.DEBUG.Println("identity.NewIdentity - refreshToken started")
+		if tok, err := v.RefreshToken(token); err == nil {
+			token = tok
 		}
 	}
 

--- a/vehicle/mercedes/identity.go
+++ b/vehicle/mercedes/identity.go
@@ -68,19 +68,19 @@ func NewIdentity(log *util.Logger, token *oauth2.Token, account string, region s
 		token.Expiry = time.Now().Add(time.Duration(10) * time.Second)
 	}
 
+	if !token.Valid() && token.RefreshToken != "" {
+		v.log.DEBUG.Println("identity.NewIdentity - refreshToken started")
+		if tok, err := v.RefreshToken(token); err == nil {
+			token = tok
+		}
+	}
+
 	// database token
 	if !token.Valid() {
 		var tok oauth2.Token
 		if err := settings.Json(v.settingsKey(), &tok); err == nil {
 			v.log.DEBUG.Println("identity.NewIdentity - database token found")
 			token = &tok
-		}
-	}
-
-	if !token.Valid() && token.RefreshToken != "" {
-		v.log.DEBUG.Println("identity.NewIdentity - refreshToken started")
-		if tok, err := v.RefreshToken(token); err == nil {
-			token = tok
 		}
 	}
 
@@ -115,6 +115,10 @@ func (v *Identity) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 	var res oauth2.Token
 	if err := v.DoJSON(req, &res); err != nil {
 		return nil, err
+	}
+
+	if res.RefreshToken == "" {
+		res.RefreshToken = token.RefreshToken
 	}
 
 	tok := util.TokenWithExpiry(&res)


### PR DESCRIPTION
MB removed the refresh token rollover.

Changes:
- Use the old refresh token if a new refresh token is missing

Fixes: #18863 