### PR TITLE
Fix non conforming Go version number in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evcc-io/evcc
 
-go 1.24
+go 1.24.0
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
Make gives error "go: download go1.24 for linux/amd64: toolchain not available". This is caused by go.mod declaring version 1.24. Version should be denoted according to semantic versioning 1.24.0. 