### PR TITLE
Tibber Pulse: fix duplicate subscriptions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/grid-x/modbus v0.0.0-20241004123532-f6c6fb5201b3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hasura/go-graphql-client v0.13.2-0.20250210080311-cf325bddb83b
+	github.com/hasura/go-graphql-client v0.13.2-0.20250219070609-5970b87363a3
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/insomniacslk/tapo v1.0.1
 	github.com/itchyny/gojq v0.12.17

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hasura/go-graphql-client v0.13.2-0.20250210080311-cf325bddb83b h1:TNn5zg7P6l9aCDjdlT+ryc35fmDbK888O7F4TTs/pFQ=
-github.com/hasura/go-graphql-client v0.13.2-0.20250210080311-cf325bddb83b/go.mod h1:k7FF7h53C+hSNFRG3++DdVZWIuHdCaTbI7siTJ//zGQ=
 github.com/hasura/go-graphql-client v0.13.2-0.20250219070609-5970b87363a3 h1:DsBHMwn8AqZRx/aChi3sSLriBKRnSlaWb28fY9QVzJ8=
 github.com/hasura/go-graphql-client v0.13.2-0.20250219070609-5970b87363a3/go.mod h1:k7FF7h53C+hSNFRG3++DdVZWIuHdCaTbI7siTJ//zGQ=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=

--- a/go.sum
+++ b/go.sum
@@ -331,6 +331,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hasura/go-graphql-client v0.13.2-0.20250210080311-cf325bddb83b h1:TNn5zg7P6l9aCDjdlT+ryc35fmDbK888O7F4TTs/pFQ=
 github.com/hasura/go-graphql-client v0.13.2-0.20250210080311-cf325bddb83b/go.mod h1:k7FF7h53C+hSNFRG3++DdVZWIuHdCaTbI7siTJ//zGQ=
+github.com/hasura/go-graphql-client v0.13.2-0.20250219070609-5970b87363a3 h1:DsBHMwn8AqZRx/aChi3sSLriBKRnSlaWb28fY9QVzJ8=
+github.com/hasura/go-graphql-client v0.13.2-0.20250219070609-5970b87363a3/go.mod h1:k7FF7h53C+hSNFRG3++DdVZWIuHdCaTbI7siTJ//zGQ=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -20,8 +20,7 @@ func init() {
 }
 
 type Tibber struct {
-	data   *util.Monitor[tibber.LiveMeasurement]
-	homeID string
+	data *util.Monitor[tibber.LiveMeasurement]
 }
 
 func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api.Meter, error) {
@@ -68,8 +67,7 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 	}
 
 	t := &Tibber{
-		data:   util.NewMonitor[tibber.LiveMeasurement](cc.Timeout),
-		homeID: cc.HomeID,
+		data: util.NewMonitor[tibber.LiveMeasurement](cc.Timeout),
 	}
 
 	// subscription client
@@ -101,8 +99,18 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 			return nil
 		})
 
-	if err := t.ensureSubscribed(client, cc.Timeout); err != nil {
-		return nil, err
+	done := make(chan error, 1)
+	go func(done chan error) {
+		done <- t.subscribe(client, cc.HomeID)
+	}(done)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return nil, err
+		}
+	case <-time.After(cc.Timeout):
+		return nil, api.ErrTimeout
 	}
 
 	go func() {
@@ -113,6 +121,9 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 	}()
 
 	go func() {
+		// The pulse sometimes declines valid(!) subscription requests, and asks the client to disconnect.
+		// Therefore we need to restart the client when exiting gracefully upon server request
+		// https://github.com/evcc-io/evcc/issues/17925#issuecomment-2621458890
 		for tick := time.Tick(10 * time.Second); ; {
 			if err := client.Run(); err != nil {
 				log.ERROR.Println(err)
@@ -129,27 +140,13 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 	return t, nil
 }
 
-func (t *Tibber) ensureSubscribed(client *graphql.SubscriptionClient, timeout time.Duration) error {
-	done := make(chan error, 1)
-	go func(done chan error) {
-		done <- t.subscribe(client)
-	}(done)
-
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(timeout):
-		return api.ErrTimeout
-	}
-}
-
-func (t *Tibber) subscribe(client *graphql.SubscriptionClient) error {
+func (t *Tibber) subscribe(client *graphql.SubscriptionClient, homeID string) error {
 	var query struct {
 		tibber.LiveMeasurement `graphql:"liveMeasurement(homeId: $homeId)"`
 	}
 
 	_, err := client.Subscribe(&query, map[string]any{
-		"homeId": graphql.ID(t.homeID),
+		"homeId": graphql.ID(homeID),
 	}, func(data []byte, err error) error {
 		if err != nil {
 			return err

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -114,15 +114,7 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 
 	go func() {
 		for tick := time.Tick(10 * time.Second); ; {
-			err := client.Run()
-			if err == nil {
-				// The pulse sometimes declines valid(!) subscription requests, and asks the client to disconnect.
-				// This invalidates the subscription, and therefore we resubscribe when exiting Run() gracefully
-				// upon server request.
-				// https://github.com/evcc-io/evcc/issues/17925#issuecomment-2621458890
-				err = t.ensureSubscribed(client, cc.Timeout)
-			}
-			if err != nil {
+			if err := client.Run(); err != nil {
 				log.ERROR.Println(err)
 			}
 


### PR DESCRIPTION
[According to graphql-client maintainers](https://github.com/hasura/go-graphql-client/issues/164#issuecomment-2672246361), resubscribing after client disconnect has become counterproductive after the recent changes.
Removing the re-subscribe should fix the duplicate subscriptions observed [here](https://github.com/evcc-io/evcc/issues/17925#issuecomment-2663935721).

<strike>@andig I used `go get github.com/hasura/go-graphql-client@5970b87` to update the client. Looking at the change set, I see there's now two entries for graphql in `go.sum`. Is this OK/correct, or should the previous entry be removed? If the latter, any reason why `go get` did not do so on its own?</strike>

Nevermind, broke porcelain - fixed it.