### PR TITLE
Config: prevent mixing yaml and db data

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -142,15 +142,16 @@ func isWritable(filePath string) bool {
 	return true
 }
 
-func configureCircuits(conf []config.Named) error {
+func configureCircuits(conf *[]config.Named) error {
 	// migrate settings
 	if settings.Exists(keys.Circuits) {
+		conf = &[]config.Named{}
 		if err := settings.Yaml(keys.Circuits, new([]map[string]any), &conf); err != nil {
 			return err
 		}
 	}
 
-	children := slices.Clone(conf)
+	children := slices.Clone(*conf)
 
 	// TODO: check for circular references
 NEXT:
@@ -641,6 +642,7 @@ func configureGo(conf []globalconfig.Go) error {
 func configureHEMS(conf *globalconfig.Hems, site *core.Site, httpd *server.HTTPd) error {
 	// migrate settings
 	if settings.Exists(keys.Hems) {
+		conf = &globalconfig.Hems{}
 		if err := settings.Yaml(keys.Hems, new(map[string]any), &conf); err != nil {
 			return err
 		}
@@ -687,6 +689,7 @@ func configureMDNS(conf globalconfig.Network) error {
 func configureEEBus(conf *eebus.Config) error {
 	// migrate settings
 	if settings.Exists(keys.EEBus) {
+		conf = &eebus.Config{}
 		if err := settings.Yaml(keys.EEBus, new(map[string]any), &conf); err != nil {
 			return err
 		}
@@ -711,6 +714,7 @@ func configureEEBus(conf *eebus.Config) error {
 func configureMessengers(conf *globalconfig.Messaging, vehicles push.Vehicles, valueChan chan<- util.Param, cache *util.ParamCache) (chan push.Event, error) {
 	// migrate settings
 	if settings.Exists(keys.Messaging) {
+		conf = &globalconfig.Messaging{}
 		if err := settings.Yaml(keys.Messaging, new(map[string]any), &conf); err != nil {
 			return nil, err
 		}
@@ -797,9 +801,10 @@ func configureSolarTariff(conf []config.Typed, t *api.Tariff) error {
 	return nil
 }
 
-func configureTariffs(conf globalconfig.Tariffs) (*tariff.Tariffs, error) {
+func configureTariffs(conf *globalconfig.Tariffs) (*tariff.Tariffs, error) {
 	// migrate settings
 	if settings.Exists(keys.Tariffs) {
+		conf = &globalconfig.Tariffs{}
 		if err := settings.Yaml(keys.Tariffs, new(map[string]any), &conf); err != nil {
 			return nil, err
 		}
@@ -847,7 +852,7 @@ func configureDevices(conf globalconfig.All) error {
 	if err := configureVehicles(conf.Vehicles); err != nil {
 		return &ClassError{ClassVehicle, err}
 	}
-	if err := configureCircuits(conf.Circuits); err != nil {
+	if err := configureCircuits(&conf.Circuits); err != nil {
 		return &ClassError{ClassCircuit, err}
 	}
 	return nil
@@ -856,6 +861,7 @@ func configureDevices(conf globalconfig.All) error {
 func configureModbusProxy(conf *[]globalconfig.ModbusProxy) error {
 	// migrate settings
 	if settings.Exists(keys.ModbusProxy) {
+		conf = &[]globalconfig.ModbusProxy{}
 		if err := settings.Yaml(keys.ModbusProxy, new([]map[string]any), conf); err != nil {
 			return err
 		}
@@ -898,7 +904,7 @@ func configureSiteAndLoadpoints(conf *globalconfig.All) (*core.Site, error) {
 		return nil, &ClassError{ClassLoadpoint, err}
 	}
 
-	tariffs, err := configureTariffs(conf.Tariffs)
+	tariffs, err := configureTariffs(&conf.Tariffs)
 	if err != nil {
 		return nil, &ClassError{ClassTariff, err}
 	}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -642,7 +642,7 @@ func configureGo(conf []globalconfig.Go) error {
 func configureHEMS(conf *globalconfig.Hems, site *core.Site, httpd *server.HTTPd) error {
 	// migrate settings
 	if settings.Exists(keys.Hems) {
-		conf = &globalconfig.Hems{}
+		conf = new(globalconfig.Hems)
 		if err := settings.Yaml(keys.Hems, new(map[string]any), &conf); err != nil {
 			return err
 		}
@@ -689,7 +689,7 @@ func configureMDNS(conf globalconfig.Network) error {
 func configureEEBus(conf *eebus.Config) error {
 	// migrate settings
 	if settings.Exists(keys.EEBus) {
-		conf = &eebus.Config{}
+		conf = new(eebus.Config)
 		if err := settings.Yaml(keys.EEBus, new(map[string]any), &conf); err != nil {
 			return err
 		}
@@ -714,7 +714,7 @@ func configureEEBus(conf *eebus.Config) error {
 func configureMessengers(conf *globalconfig.Messaging, vehicles push.Vehicles, valueChan chan<- util.Param, cache *util.ParamCache) (chan push.Event, error) {
 	// migrate settings
 	if settings.Exists(keys.Messaging) {
-		conf = &globalconfig.Messaging{}
+		conf = new(globalconfig.Messaging)
 		if err := settings.Yaml(keys.Messaging, new(map[string]any), &conf); err != nil {
 			return nil, err
 		}
@@ -804,7 +804,7 @@ func configureSolarTariff(conf []config.Typed, t *api.Tariff) error {
 func configureTariffs(conf *globalconfig.Tariffs) (*tariff.Tariffs, error) {
 	// migrate settings
 	if settings.Exists(keys.Tariffs) {
-		conf = &globalconfig.Tariffs{}
+		conf = new(globalconfig.Tariffs)
 		if err := settings.Yaml(keys.Tariffs, new(map[string]any), &conf); err != nil {
 			return nil, err
 		}
@@ -862,7 +862,7 @@ func configureModbusProxy(conf *[]globalconfig.ModbusProxy) error {
 	// migrate settings
 	if settings.Exists(keys.ModbusProxy) {
 		conf = &[]globalconfig.ModbusProxy{}
-		if err := settings.Yaml(keys.ModbusProxy, new([]map[string]any), conf); err != nil {
+		if err := settings.Yaml(keys.ModbusProxy, new([]map[string]any), &conf); err != nil {
 			return err
 		}
 	}

--- a/cmd/setup_circuits_test.go
+++ b/cmd/setup_circuits_test.go
@@ -51,7 +51,7 @@ loadpoints:
 
 	suite.Require().NoError(viper.UnmarshalExact(&conf))
 
-	suite.Require().NoError(configureCircuits(conf.Circuits))
+	suite.Require().NoError(configureCircuits(&conf.Circuits))
 	suite.Require().Len(config.Circuits().Devices(), 2)
 	suite.Require().False(config.Circuits().Devices()[0].Instance().HasMeter())
 
@@ -82,7 +82,7 @@ loadpoints:
 
 	suite.Require().NoError(viper.UnmarshalExact(&conf))
 
-	suite.Require().NoError(configureCircuits(conf.Circuits))
+	suite.Require().NoError(configureCircuits(&conf.Circuits))
 	suite.Require().Len(config.Circuits().Devices(), 2)
 	suite.Require().False(config.Circuits().Devices()[0].Instance().HasMeter())
 
@@ -141,7 +141,7 @@ loadpoints:
 
 	suite.Require().NoError(viper.UnmarshalExact(&conf))
 
-	suite.Require().NoError(configureCircuits(conf.Circuits))
+	suite.Require().NoError(configureCircuits(&conf.Circuits))
 	suite.Require().Len(config.Circuits().Devices(), 1)
 
 	// mock charger

--- a/cmd/tariff.go
+++ b/cmd/tariff.go
@@ -32,7 +32,7 @@ func runTariff(cmd *cobra.Command, args []string) {
 		fatal(err)
 	}
 
-	tariffs, err := configureTariffs(conf.Tariffs)
+	tariffs, err := configureTariffs(&conf.Tariffs)
 	if err != nil {
 		fatal(err)
 	}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/18945

- prevent merging data from yaml and db entries
- UI configuration always takes precedence over `evcc.yaml` values (top level)