### PR TITLE
Config UI: default mode behavior

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -303,7 +303,7 @@ func (lp *Loadpoint) restoreSettings() {
 	}
 
 	// restore runtime configuration (database & yaml LPs)
-	if v, err := lp.settings.String(keys.Mode); err == nil && v != "" {
+	if v, err := lp.settings.String(keys.Mode); err == nil && v != "" && lp.DefaultMode == api.ModeEmpty {
 		lp.setMode(api.ChargeMode(v))
 	}
 	if v, err := lp.settings.Int(keys.Priority); err == nil && v > 0 {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/18703

@TobiasHuber1980 bitte teste das noch mal bei dir. Dein beschriebenes Verhalten konnte ich nicht mehr reproduzieren. Möglicherweise ist das schon durch einen vorherigen Fix erledigt worden. Aber es gab in der Tat noch ein Problem, dass wir den "letzten Modus" nur dann wiederherstellen dürfen, wenn es keinen Default Modus gibt.