### PR TITLE
Config: messaging configured state

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -720,6 +720,10 @@ func configureMessengers(conf *globalconfig.Messaging, vehicles push.Vehicles, v
 		}
 	}
 
+	if len(conf.Services) == 0 {
+		return nil, nil
+	}
+
 	messageChan := make(chan push.Event, 1)
 
 	messageHub, err := push.NewHub(conf.Events, vehicles, cache)


### PR DESCRIPTION
fixes the issue, that `messaging` is already reported as "configured".