### PR TITLE
Restart: improve login flow

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -7,7 +7,8 @@ import { isSystemError } from "./utils/fatal";
 const auth = reactive({
   configured: true,
   loggedIn: null, // true / false / null (unknown)
-  nextUrl: null,
+  nextUrl: null, // url to navigate to after login
+  nextModal: null, // modal instance to show after login
 });
 
 export async function updateAuthStatus() {
@@ -64,8 +65,15 @@ export function getAndClearNextUrl() {
   return nextUrl;
 }
 
-export function openLoginModal(nextUrl = null) {
+export function getAndClearNextModal() {
+  const nextModal = auth.nextModal;
+  auth.nextModal = null;
+  return nextModal;
+}
+
+export function openLoginModal(nextUrl = null, nextModal = null) {
   auth.nextUrl = nextUrl;
+  auth.nextModal = nextModal;
   const modal = Modal.getOrCreateInstance(document.getElementById("loginModal"));
   modal.show();
 }

--- a/assets/js/components/HelpModal.vue
+++ b/assets/js/components/HelpModal.vue
@@ -140,6 +140,7 @@
 import Modal from "bootstrap/js/dist/modal";
 import { docsPrefix } from "../i18n";
 import { performRestart } from "../restart";
+import { isLoggedIn, openLoginModal } from "../auth";
 
 export default {
 	name: "HelpModal",
@@ -156,7 +157,11 @@ export default {
 		},
 		openConfirmRestartModal() {
 			const modal = Modal.getOrCreateInstance(document.getElementById("confirmRestartModal"));
-			modal.show();
+			if (!isLoggedIn()) {
+				openLoginModal(null, modal);
+			} else {
+				modal.show();
+			}
 		},
 		async restartConfirmed() {
 			await performRestart();

--- a/assets/js/components/LoginModal.vue
+++ b/assets/js/components/LoginModal.vue
@@ -61,7 +61,7 @@
 import GenericModal from "./GenericModal.vue";
 import Modal from "bootstrap/js/dist/modal";
 import api from "../api";
-import { updateAuthStatus, getAndClearNextUrl, isLoggedIn } from "../auth";
+import { updateAuthStatus, getAndClearNextUrl, getAndClearNextModal, isLoggedIn } from "../auth";
 import { docsPrefix } from "../i18n";
 
 export default {
@@ -119,8 +119,10 @@ export default {
 					await updateAuthStatus();
 					if (isLoggedIn()) {
 						this.closeModal();
-						const target = getAndClearNextUrl();
-						if (target) this.$router.push(target);
+						const url = getAndClearNextUrl();
+						if (url) this.$router.push(url);
+						const modal = getAndClearNextModal();
+						if (modal) modal.show();
 						this.password = "";
 					} else {
 						// login successful but auth cookie doesnt work


### PR DESCRIPTION
Improve login prompt when triggering a restart through help modal without being logged in.

Before we'd try to do the shutdown call, receive forbidden status, show login screen and the user was back to main view and had to navigate to the restart button again.
Now we'll check before executing, ask for password if needed, and then execute.