### PR TITLE
Battery Settings: fix initial buffer start options

### DIFF
--- a/assets/js/components/BatterySettingsModal.vue
+++ b/assets/js/components/BatterySettingsModal.vue
@@ -329,7 +329,7 @@ export default {
 		},
 		bufferStartOptions() {
 			const options = [];
-			for (let i = 100; i >= this.bufferSoc; i -= 5) {
+			for (let i = 100; i >= this.selectedBufferSoc; i -= 5) {
 				options.push({
 					value: i,
 					name: this.getBufferStartName(i),


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/19119

- 🪫 fixes buffer start soc options when buffersoc hasn't been changed yet -> new installations or api adjustments

For context: `buffersoc: 0` and `buffersoc: 100` have same semantics, meaning the feature is not active. Fixed the select options issue by using the normalized value.