### PR TITLE
Config UI: improve readonly style

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -56,7 +56,7 @@
 	--evcc-gray: var(--bs-gray-medium);
 	--evcc-gray-50: #93949e80;
 	--evcc-gray-25: #93949e40;
-
+	--evcc-gray-10: #93949e20;
 	--evcc-accent1: var(--evcc-dark-yellow);
 	--evcc-accent2: var(--evcc-darker-green);
 	--evcc-accent3: var(--evcc-darkest-green);
@@ -548,8 +548,8 @@ input::-webkit-datetime-edit {
 .form-control:read-only,
 .dark .form-control:disabled,
 .dark .form-control:read-only {
-	background-color: var(--bs-secondary-bg);
-	color: var(--bs-gray-dark);
+	background-color: var(--evcc-gray-10);
+	color: var(--bs-default-text);
 	opacity: 1;
 }
 

--- a/assets/js/components/Config/ChargerModal.vue
+++ b/assets/js/components/Config/ChargerModal.vue
@@ -55,12 +55,7 @@
 				:label="$t('config.charger.ocppLabel')"
 				:help="$t('config.charger.ocppHelp')"
 			>
-				<input
-					type="text"
-					class="form-control border border-success bg-transparent"
-					:value="ocppUrl"
-					readonly
-				/>
+				<input type="text" class="form-control border" :value="ocppUrl" readonly />
 			</FormRow>
 
 			<Modbus


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/19125

🌚 readable read only text in dark mode
🖌️ clearer outlines and background to distinguish readonly from other fields

OCPP address and configured charger/meter (lp modal) are affected 

<img width="686" alt="Bildschirmfoto 2025-02-24 um 09 32 14" src="https://github.com/user-attachments/assets/4c0bbc4e-cb7e-4b50-ac07-f3c5bc04871f" />
<img width="647" alt="Bildschirmfoto 2025-02-24 um 09 32 20" src="https://github.com/user-attachments/assets/2a8e2751-48f3-4a8b-9c91-d88257517f77" />

<img width="592" alt="Bildschirmfoto 2025-02-24 um 09 33 21" src="https://github.com/user-attachments/assets/99c5de2d-6117-4a2b-8c73-eeb5452488f0" />
<img width="630" alt="Bildschirmfoto 2025-02-24 um 09 33 16" src="https://github.com/user-attachments/assets/8a1695c9-6023-4dce-b76c-ed9c923f0b4e" />


\\cc @typxxi