### PR TITLE
PSA: make climater robust agains missing fields in json

### DIFF
--- a/vehicle/psa/provider.go
+++ b/vehicle/psa/provider.go
@@ -132,7 +132,7 @@ var _ api.VehicleClimater = (*Provider)(nil)
 func (v *Provider) Climater() (bool, error) {
 	res, err := v.statusG()
 	if err == nil {
-		active := strings.ToLower(res.Preconditionning.AirConditioning.Status) != "disabled"
+		active := strings.ToLower(res.Preconditionning.AirConditioning.Status) == "enabled"
 		return active, nil
 	}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/discussions/19142

Changed the logic to not assume that climater is running when the PSA API response does not contain the field `Preconditionning.AirConditioning.Status`. Instead, only assume it is active when the status is explicitly `enabled` (possible values according to https://github.com/flobz/psa_car_controller/blob/0bbd8a1828ba2040ed598b37f5253447ec89ba35/psa_car_controller/psa/connected_car_api/models/preconditioning_air_conditioning.py are  `Enabled`, `Disabled`, `Finished` and `Failure`. Maybe the API changed, failed or it depends on booked features.