### PR TITLE
Config UI: message configured status

### DIFF
--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -135,7 +135,7 @@ type Messaging struct {
 }
 
 func (c Messaging) Configured() bool {
-	return len(c.Services) > 0
+	return len(c.Services) > 0 || len(c.Events) > 0
 }
 
 type Tariffs struct {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/19159

📨 mark messaging as configured if `services` or `events` are defined 