### PR TITLE
Fronius Solar API V1: add pv lifetime energy

### DIFF
--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -48,6 +48,11 @@ render: |
   {{- end }}
   {{- if eq .usage "battery" }}
     jq: if .Body.Data.Site.P_Akku == null then 0 else .Body.Data.Site.P_Akku end
+  energy:
+    source: http
+    uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+    jq: if .Body.Data.Site.E_Total == null then 0 else .Body.Data.Site.E_Total end
+  {{- if .password }}
   soc:
     source: http
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -46,12 +46,14 @@ render: |
   {{- if eq .usage "pv" }}
     jq: if .Body.Data.Site.P_PV == null then 0 else .Body.Data.Site.P_PV end
   {{- end }}
-  {{- if eq .usage "battery" }}
-    jq: if .Body.Data.Site.P_Akku == null then 0 else .Body.Data.Site.P_Akku end
+  {{- if eq .usage "pv" }}
   energy:
     source: http
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi
     jq: if .Body.Data.Site.E_Total == null then 0 else .Body.Data.Site.E_Total end
+  {{- end }}
+  {{- if eq .usage "battery" }}
+    jq: if .Body.Data.Site.P_Akku == null then 0 else .Body.Data.Site.P_Akku end
   soc:
     source: http
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -52,7 +52,6 @@ render: |
     source: http
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi
     jq: if .Body.Data.Site.E_Total == null then 0 else .Body.Data.Site.E_Total end
-  {{- if .password }}
   soc:
     source: http
     uri: http://{{ .host }}/solar_api/v1/GetPowerFlowRealtimeData.fcgi


### PR DESCRIPTION
like #19095 the same for Solar API

sample json output of an inverter:
```
{
   "Body" : {
      "Data" : {
         "Inverters" : {
            "1" : {
               "DT" : 233,
               "E_Day" : 0,
               "E_Total" : 25624600,
               "E_Year" : 781735.5,
               "P" : 0
            }
         },
         "Site" : {
            "E_Day" : 0,
            "E_Total" : 25624600,
            "E_Year" : 781735.5,
            "Meter_Location" : "unknown",
            "Mode" : "produce-only",
            "P_Akku" : null,
            "P_Grid" : null,
            "P_Load" : null,
            "P_PV" : null,
            "rel_Autonomy" : null,
            "rel_SelfConsumption" : null
         },
         "Version" : "12"
      }
   },
   "Head" : {
      "RequestArguments" : {},
      "Status" : {
         "Code" : 0,
         "Reason" : "",
         "UserMessage" : ""
      },
      "Timestamp" : "2025-02-26T06:50:19+01:00"
   }
}
```

