### PR TITLE
MaxACPower: fix decoration

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -44,8 +44,8 @@ type BatteryCapacity interface {
 	Capacity() float64
 }
 
-// MaxACPower provides max AC power in W
-type MaxACPower interface {
+// MaxACPowerGetter provides max AC power in W
+type MaxACPowerGetter interface {
 	MaxACPower() float64
 }
 

--- a/cmd/decorate/decorate.go
+++ b/cmd/decorate/decorate.go
@@ -40,7 +40,7 @@ var a struct {
 	api.PhaseCurrents
 	api.PhaseVoltages
 	api.PhasePowers
-	api.MaxACPower
+	api.MaxACPowerGetter
 
 	api.PhaseSwitcher
 	api.PhaseGetter
@@ -55,7 +55,7 @@ func typ(i any) string {
 }
 
 var dependents = map[string][]string{
-	typ(&a.Meter):         {typ(&a.MeterEnergy), typ(&a.PhaseCurrents), typ(&a.PhaseVoltages), typ(&a.PhasePowers), typ(&a.MaxACPower)},
+	typ(&a.Meter):         {typ(&a.MeterEnergy), typ(&a.PhaseCurrents), typ(&a.PhaseVoltages), typ(&a.PhasePowers), typ(&a.MaxACPowerGetter)},
 	typ(&a.PhaseCurrents): {typ(&a.PhasePowers)}, // phase powers are only used to determine currents sign
 	typ(&a.PhaseSwitcher): {typ(&a.PhaseGetter)},
 	typ(&a.Battery):       {typ(&a.BatteryCapacity), typ(&a.BatteryController)},

--- a/cmd/dumper.go
+++ b/cmd/dumper.go
@@ -120,7 +120,7 @@ func (d *dumper) Dump(name string, v interface{}) {
 		fmt.Fprintf(w, "Capacity:\t%.1fkWh\n", v.Capacity())
 	}
 
-	if v, ok := v.(api.MaxACPower); ok {
+	if v, ok := v.(api.MaxACPowerGetter); ok {
 		fmt.Fprintf(w, "Max AC power:\t%.0fW\n", v.MaxACPower())
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -483,7 +483,7 @@ func (site *Site) updatePvMeters() {
 			site.log.WARN.Printf("pv %d power: %.0fW is negative - check configuration if sign is correct", i+1, power)
 		}
 
-		if m, ok := meter.(api.MaxACPower); ok {
+		if m, ok := meter.(api.MaxACPowerGetter); ok {
 			if dc := m.MaxACPower() - power; dc < 0 && power > 0 {
 				mm[i].ExcessDCPower = -dc
 				site.log.DEBUG.Printf("pv %d excess DC: %.0fW", i+1, -dc)

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -14,7 +14,7 @@ func init() {
 	registry.AddCtx(api.Custom, NewConfigurableFromConfig)
 }
 
-//go:generate go tool decorate -f decorateMeter -b api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.PhaseCurrents,Currents,func() (float64, float64, float64, error)" -t "api.PhaseVoltages,Voltages,func() (float64, float64, float64, error)" -t "api.PhasePowers,Powers,func() (float64, float64, float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64" -t "api.MaxACPower,MaxACPower,func() float64" -t "api.BatteryController,SetBatteryMode,func(api.BatteryMode) error"
+//go:generate go tool decorate -f decorateMeter -b api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.PhaseCurrents,Currents,func() (float64, float64, float64, error)" -t "api.PhaseVoltages,Voltages,func() (float64, float64, float64, error)" -t "api.PhasePowers,Powers,func() (float64, float64, float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64" -t "api.MaxACPowerGetter,MaxACPower,func() float64" -t "api.BatteryController,SetBatteryMode,func(api.BatteryMode) error"
 
 // NewConfigurableFromConfig creates api.Meter from config
 func NewConfigurableFromConfig(ctx context.Context, other map[string]interface{}) (api.Meter, error) {
@@ -106,10 +106,10 @@ func (m *Meter) Decorate(
 	powers func() (float64, float64, float64, error),
 	batterySoc func() (float64, error),
 	batteryCapacity func() float64,
-	MaxACPower func() float64,
+	maxACPower func() float64,
 	setBatteryMode func(api.BatteryMode) error,
 ) api.Meter {
-	return decorateMeter(m, totalEnergy, currents, voltages, powers, batterySoc, batteryCapacity, MaxACPower, setBatteryMode)
+	return decorateMeter(m, totalEnergy, currents, voltages, powers, batterySoc, batteryCapacity, maxACPower, setBatteryMode)
 }
 
 // CurrentPower implements the api.Meter interface

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -6,12 +6,12 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error), battery func() (float64, error), batteryCapacity func() float64, maxACPower func() float64, batteryController func(api.BatteryMode) error) api.Meter {
+func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error), battery func() (float64, error), batteryCapacity func() float64, maxACPowerGetter func() float64, batteryController func(api.BatteryMode) error) api.Meter {
 	switch {
-	case battery == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return base
 
-	case battery == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -22,7 +22,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.PhaseCurrents
@@ -33,7 +33,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -48,7 +48,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.PhaseVoltages
@@ -59,7 +59,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -74,7 +74,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.PhaseCurrents
@@ -89,7 +89,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -108,7 +108,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.PhaseCurrents
@@ -123,7 +123,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -142,7 +142,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.PhaseCurrents
@@ -161,7 +161,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -184,7 +184,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -195,7 +195,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -210,7 +210,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -225,7 +225,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -244,7 +244,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -259,7 +259,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -278,7 +278,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -297,7 +297,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -320,7 +320,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -339,7 +339,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -362,7 +362,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -385,7 +385,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -412,7 +412,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -427,7 +427,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -446,7 +446,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -465,7 +465,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -488,7 +488,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -507,7 +507,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -530,7 +530,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -553,7 +553,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -580,7 +580,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -603,7 +603,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -611,61 +611,6 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-		}
-
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryCapacity
-			api.PhaseCurrents
-			api.PhasePowers
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryCapacity
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhasePowers
-			api.PhaseVoltages
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
@@ -683,200 +628,23 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			PhasePowers: &decorateMeterPhasePowersImpl{
 				phasePowers: phasePowers,
 			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
 		}
 
-	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPowerGetter
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.MeterEnergy
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.PhaseCurrents
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.PhaseCurrents
-			api.PhasePowers
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhasePowers
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-		}
-
-	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
+			api.Battery
+			api.BatteryCapacity
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -889,18 +657,22 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPowerGetter
+			api.Battery
+			api.BatteryCapacity
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -916,73 +688,57 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.MeterEnergy
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -992,39 +748,31 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
 				phaseVoltages: phaseVoltages,
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1034,20 +782,16 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -1057,21 +801,17 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1084,20 +824,16 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -1107,21 +843,17 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1134,21 +866,17 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -1161,10 +889,9 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.Battery
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
@@ -1172,11 +899,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1192,30 +916,25 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.MeterEnergy
 		}{
@@ -1223,22 +942,18 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 		}{
@@ -1246,22 +961,18 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
@@ -1270,11 +981,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1284,11 +992,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.PhaseVoltages
 		}{
@@ -1296,22 +1003,18 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
 				phaseVoltages: phaseVoltages,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseVoltages
@@ -1320,11 +1023,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1334,11 +1034,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhaseVoltages
@@ -1347,11 +1046,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -1361,11 +1057,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
@@ -1375,11 +1070,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1392,11 +1084,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
@@ -1405,11 +1096,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -1419,11 +1107,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
@@ -1433,11 +1120,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1450,11 +1134,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
@@ -1464,11 +1147,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -1481,11 +1161,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
@@ -1496,11 +1175,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -1516,7 +1192,331 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.MeterEnergy
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+			api.PhasePowers
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+			api.PhasePowers
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController == nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1531,7 +1531,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1550,7 +1550,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1569,7 +1569,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1592,7 +1592,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1611,7 +1611,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1634,7 +1634,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1657,7 +1657,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1684,7 +1684,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1707,7 +1707,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1715,61 +1715,6 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.PhaseCurrents
-			api.PhasePowers
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhasePowers
-			api.PhaseVoltages
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
@@ -1787,12 +1732,67 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			PhasePowers: &decorateMeterPhasePowersImpl{
 				phasePowers: phasePowers,
 			},
+		}
+
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryController
+			api.PhaseCurrents
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
 				phaseVoltages: phaseVoltages,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryController
+			api.MeterEnergy
+			api.PhaseCurrents
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1811,7 +1811,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1834,7 +1834,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1857,7 +1857,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1884,7 +1884,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1907,7 +1907,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1934,7 +1934,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1961,7 +1961,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -1992,7 +1992,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -2019,7 +2019,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -2028,69 +2028,6 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-		}
-
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryCapacity
-			api.BatteryController
-			api.PhaseCurrents
-			api.PhasePowers
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryCapacity
-			api.BatteryController
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhasePowers
-			api.PhaseVoltages
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
@@ -2111,275 +2048,14 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			PhasePowers: &decorateMeterPhasePowersImpl{
 				phasePowers: phasePowers,
 			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
+			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPowerGetter
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.MeterEnergy
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.PhaseCurrents
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhaseVoltages
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.PhaseCurrents
-			api.PhasePowers
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhasePowers
-		}{
-			Meter: base,
-			Battery: &decorateMeterBatteryImpl{
-				battery: battery,
-			},
-			BatteryController: &decorateMeterBatteryControllerImpl{
-				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhasePowers: &decorateMeterPhasePowersImpl{
-				phasePowers: phasePowers,
-			},
-		}
-
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
-		return &struct {
-			api.Meter
-			api.Battery
-			api.BatteryController
-			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
@@ -2388,11 +2064,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -2405,12 +2081,12 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
+			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -2420,11 +2096,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
-			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -2440,11 +2116,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 		}{
@@ -2452,22 +2127,18 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.MeterEnergy
@@ -2476,25 +2147,21 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.PhaseCurrents
@@ -2503,25 +2170,21 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.MeterEnergy
@@ -2531,14 +2194,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -2548,11 +2208,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.PhaseVoltages
@@ -2561,25 +2220,21 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
 				phaseVoltages: phaseVoltages,
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.MeterEnergy
@@ -2589,14 +2244,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -2606,11 +2258,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.PhaseCurrents
@@ -2620,14 +2271,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -2637,11 +2285,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.MeterEnergy
@@ -2652,14 +2299,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -2672,11 +2316,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.PhaseCurrents
@@ -2686,14 +2329,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -2703,11 +2343,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.Battery
-			api.BatteryCapacity
 			api.BatteryController
 			api.MaxACPowerGetter
 			api.MeterEnergy
@@ -2718,14 +2357,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
-				batteryCapacity: batteryCapacity,
-			},
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -2738,7 +2374,371 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity == nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.MeterEnergy
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.PhaseCurrents
+			api.PhasePowers
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
+		return &struct {
+			api.Meter
+			api.Battery
+			api.BatteryCapacity
+			api.BatteryController
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhaseCurrents
+			api.PhasePowers
+		}{
+			Meter: base,
+			Battery: &decorateMeterBatteryImpl{
+				battery: battery,
+			},
+			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
+				batteryCapacity: batteryCapacity,
+			},
+			BatteryController: &decorateMeterBatteryControllerImpl{
+				batteryController: batteryController,
+			},
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
+				phaseCurrents: phaseCurrents,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+		}
+
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -2759,8 +2759,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
 				phaseCurrents: phaseCurrents,
@@ -2773,7 +2773,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
+	case battery != nil && batteryCapacity != nil && batteryController != nil && maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.Battery
@@ -2795,8 +2795,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
-				maxACPower: maxACPower,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
@@ -2840,12 +2840,12 @@ func (impl *decorateMeterBatteryControllerImpl) SetBatteryMode(p0 api.BatteryMod
 	return impl.batteryController(p0)
 }
 
-type decorateMeterMaxACPowerImpl struct {
-	maxACPower func() float64
+type decorateMeterMaxACPowerGetterImpl struct {
+	maxACPowerGetter func() float64
 }
 
-func (impl *decorateMeterMaxACPowerImpl) MaxACPower() float64 {
-	return impl.maxACPower()
+func (impl *decorateMeterMaxACPowerGetterImpl) MaxACPower() float64 {
+	return impl.maxACPowerGetter()
 }
 
 type decorateMeterMeterEnergyImpl struct {

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -691,10 +691,10 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 		}
@@ -702,11 +702,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -717,11 +717,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -732,12 +732,12 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -751,11 +751,11 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
@@ -766,12 +766,12 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -785,12 +785,12 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -804,13 +804,13 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -827,12 +827,12 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -846,13 +846,13 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -869,13 +869,13 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -892,14 +892,14 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 	case battery == nil && maxACPower != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Meter: base,
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -920,13 +920,13 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 		}
@@ -935,14 +935,14 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -954,14 +954,14 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -973,7 +973,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 		}{
@@ -981,7 +981,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -996,14 +996,14 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseVoltages
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
@@ -1015,7 +1015,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseVoltages
 		}{
@@ -1023,7 +1023,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1038,7 +1038,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
@@ -1046,7 +1046,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -1061,7 +1061,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhaseVoltages
@@ -1070,7 +1070,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1088,7 +1088,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
@@ -1096,7 +1096,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -1111,7 +1111,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -1120,7 +1120,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1138,7 +1138,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
@@ -1147,7 +1147,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -1165,7 +1165,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 		return &struct {
 			api.Meter
 			api.Battery
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -1175,7 +1175,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			Battery: &decorateMeterBatteryImpl{
 				battery: battery,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1197,7 +1197,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
@@ -1206,7 +1206,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 		}
@@ -1216,7 +1216,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 		}{
 			Meter: base,
@@ -1226,7 +1226,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1239,7 +1239,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 		}{
 			Meter: base,
@@ -1249,7 +1249,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -1262,7 +1262,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 		}{
@@ -1273,7 +1273,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1289,7 +1289,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseVoltages
 		}{
 			Meter: base,
@@ -1299,7 +1299,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
@@ -1312,7 +1312,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseVoltages
 		}{
@@ -1323,7 +1323,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1339,7 +1339,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
@@ -1350,7 +1350,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -1366,7 +1366,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhaseVoltages
@@ -1378,7 +1378,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1397,7 +1397,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
@@ -1408,7 +1408,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -1424,7 +1424,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -1436,7 +1436,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -1455,7 +1455,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
@@ -1467,7 +1467,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -1486,7 +1486,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryCapacity
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -1499,7 +1499,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryCapacity: &decorateMeterBatteryCapacityImpl{
 				batteryCapacity: batteryCapacity,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2121,7 +2121,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
@@ -2130,7 +2130,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 		}
@@ -2140,7 +2140,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 		}{
 			Meter: base,
@@ -2150,7 +2150,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2163,7 +2163,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 		}{
 			Meter: base,
@@ -2173,7 +2173,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2186,7 +2186,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 		}{
@@ -2197,7 +2197,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2213,7 +2213,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseVoltages
 		}{
 			Meter: base,
@@ -2223,7 +2223,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
@@ -2236,7 +2236,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseVoltages
 		}{
@@ -2247,7 +2247,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2263,7 +2263,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
@@ -2274,7 +2274,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2290,7 +2290,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhaseVoltages
@@ -2302,7 +2302,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2321,7 +2321,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
@@ -2332,7 +2332,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2348,7 +2348,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -2360,7 +2360,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2379,7 +2379,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
@@ -2391,7 +2391,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2410,7 +2410,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Meter
 			api.Battery
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -2423,7 +2423,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2446,7 +2446,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 		}{
 			Meter: base,
 			Battery: &decorateMeterBatteryImpl{
@@ -2458,7 +2458,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 		}
@@ -2469,7 +2469,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 		}{
 			Meter: base,
@@ -2482,7 +2482,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2496,7 +2496,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 		}{
 			Meter: base,
@@ -2509,7 +2509,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2523,7 +2523,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 		}{
@@ -2537,7 +2537,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2554,7 +2554,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseVoltages
 		}{
 			Meter: base,
@@ -2567,7 +2567,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
@@ -2581,7 +2581,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseVoltages
 		}{
@@ -2595,7 +2595,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2612,7 +2612,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhaseVoltages
 		}{
@@ -2626,7 +2626,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2643,7 +2643,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhaseVoltages
@@ -2658,7 +2658,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2678,7 +2678,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 		}{
@@ -2692,7 +2692,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2709,7 +2709,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -2724,7 +2724,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
@@ -2744,7 +2744,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.PhaseCurrents
 			api.PhasePowers
 			api.PhaseVoltages
@@ -2759,7 +2759,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
@@ -2779,7 +2779,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			api.Battery
 			api.BatteryCapacity
 			api.BatteryController
-			api.MaxACPower
+			api.MaxACPowerGetter
 			api.MeterEnergy
 			api.PhaseCurrents
 			api.PhasePowers
@@ -2795,7 +2795,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			BatteryController: &decorateMeterBatteryControllerImpl{
 				batteryController: batteryController,
 			},
-			MaxACPower: &decorateMeterMaxACPowerImpl{
+			MaxACPowerGetter: &decorateMeterMaxACPowerImpl{
 				maxACPower: maxACPower,
 			},
 			MeterEnergy: &decorateMeterMeterEnergyImpl{


### PR DESCRIPTION
@andig I had a look at https://github.com/evcc-io/evcc/discussions/18943 and https://github.com/evcc-io/evcc/discussions/18937 and did some debugging.
After a while, I figured out, that the test for api.MaxACPower in https://github.com/evcc-io/evcc/blob/714438d0581c11fe14fb7496747250cd9f659398/core/site.go#L486 always failed, although the interface was decorated.
After renaming the interface from MaxACPower to something not matching the api function name, in this case MaxACPowerGetter, it started to work. As a golang newbie, I am not sure exactly why.
