### PR TITLE
Sofar: Support for multiple, individual storage units

### DIFF
--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -170,7 +170,6 @@ render: |
   # Removed for supporting multiple storage units
   # energy:
   #   source: modbus
-  #   {{- include "modbus" . | indent 2 }}
   #   register:
   #     address: 0x069A # Bat_Discharge_Total
   #     type: holding

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -27,6 +27,13 @@ params:
     id: 1
   - name: delay
     deprecated: true
+  - name: storageunit
+    help:
+      de: Nummer des Batteriespeichers. Im Fall eines BTS Speichers nicht die Adresse eines BTS 5K Batteriemodules, sondern der Speicherturm (BTS 5K-BDU Steuerungseinheit mit 1-4 BTS 5K Modulen).
+      en: Number of the battery storage. In case of a BTS storage not the address of a BTS 5K battery module, but the storage tower (BTS 5K-BDU control unit with 1-4 BTS 5K modules).
+    type: int
+    default: 1
+    advanced: true
   - name: capacity
     advanced: true
   - name: maxacpower
@@ -133,23 +140,70 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 0x0667 # Power_Bat_Total
+      {{- if eq .storageunit "1" }}
+      address: 0x0607 # Power_Bat1
+      {{- end }}
+      {{- if eq .storageunit "2" }}
+      address: 0x060D # Power_Bat2
+      {{- end }}
+      {{- if eq .storageunit "3" }}
+      address: 0x0614 # Power_Bat3
+      {{- end }}
+      {{- if eq .storageunit "4" }}
+      address: 0x061B # Power_Bat4
+      {{- end }}
+      {{- if eq .storageunit "5" }}
+      address: 0x0622 # Power_Bat5
+      {{- end }}
+      {{- if eq .storageunit "6" }}
+      address: 0x0629 # Power_Bat6
+      {{- end }}
+      {{- if eq .storageunit "7" }}
+      address: 0x0630 # Power_Bat7
+      {{- end }}
+      {{- if eq .storageunit "8" }}
+      address: 0x0637 # Power_Bat8
+      {{- end }}
       type: holding
       decode: int16
-    scale: -100
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 0x069A # Bat_Discharge_Total
-      type: holding
-      decode: uint32
-    scale: 0.1
+    scale: -10
+  # Removed for supporting multiple storage units
+  # energy:
+  #   source: modbus
+  #   {{- include "modbus" . | indent 2 }}
+  #   register:
+  #     address: 0x069A # Bat_Discharge_Total
+  #     type: holding
+  #     decode: uint32
+  #   scale: 0.1
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 0x0668 # SOC_Bat_Average
+      {{- if eq .storageunit "1" }}
+      address: 0x0608 # SOC_Bat1
+      {{- end }}
+      {{- if eq .storageunit "2" }}
+      address: 0x060F # SOC_Bat2
+      {{- end }}
+      {{- if eq .storageunit "3" }}
+      address: 0x0616 # SOC_Bat3
+      {{- end }}
+      {{- if eq .storageunit "4" }}
+      address: 0x061D # SOC_Bat4
+      {{- end }}
+      {{- if eq .storageunit "5" }}
+      address: 0x0624 # SOC_Bat5
+      {{- end }}
+      {{- if eq .storageunit "6" }}
+      address: 0x062B # SOC_Bat6
+      {{- end }}
+      {{- if eq .storageunit "7" }}
+      address: 0x0632 # SOC_Bat7
+      {{- end }}
+      {{- if eq .storageunit "8" }}
+      address: 0x0639 # SOC_Bat8
+      {{- end }}
       type: holding
       decode: uint16
   batterymode:

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -141,26 +141,19 @@ render: |
     register:
       {{- if eq .storageunit "1" }}
       address: 0x0607 # Power_Bat1
-      {{- end }}
-      {{- if eq .storageunit "2" }}
+      {{- else if eq .storageunit "2" }}
       address: 0x060D # Power_Bat2
-      {{- end }}
-      {{- if eq .storageunit "3" }}
+      {{- else if eq .storageunit "3" }}
       address: 0x0614 # Power_Bat3
-      {{- end }}
-      {{- if eq .storageunit "4" }}
+      {{- else if eq .storageunit "4" }}
       address: 0x061B # Power_Bat4
-      {{- end }}
-      {{- if eq .storageunit "5" }}
+      {{- else if eq .storageunit "5" }}
       address: 0x0622 # Power_Bat5
-      {{- end }}
-      {{- if eq .storageunit "6" }}
+      {{- else if eq .storageunit "6" }}
       address: 0x0629 # Power_Bat6
-      {{- end }}
-      {{- if eq .storageunit "7" }}
+      {{- else if eq .storageunit "7" }}
       address: 0x0630 # Power_Bat7
-      {{- end }}
-      {{- if eq .storageunit "8" }}
+      {{- else if eq .storageunit "8" }}
       address: 0x0637 # Power_Bat8
       {{- end }}
       type: holding
@@ -172,26 +165,19 @@ render: |
     register:
       {{- if eq .storageunit "1" }}
       address: 0x0608 # SOC_Bat1
-      {{- end }}
-      {{- if eq .storageunit "2" }}
+      {{- else if eq .storageunit "2" }}
       address: 0x060F # SOC_Bat2
-      {{- end }}
-      {{- if eq .storageunit "3" }}
+      {{- else if eq .storageunit "3" }}
       address: 0x0616 # SOC_Bat3
-      {{- end }}
-      {{- if eq .storageunit "4" }}
+      {{- else if eq .storageunit "4" }}
       address: 0x061D # SOC_Bat4
-      {{- end }}
-      {{- if eq .storageunit "5" }}
+      {{- else if eq .storageunit "5" }}
       address: 0x0624 # SOC_Bat5
-      {{- end }}
-      {{- if eq .storageunit "6" }}
+      {{- else if eq .storageunit "6" }}
       address: 0x062B # SOC_Bat6
-      {{- end }}
-      {{- if eq .storageunit "7" }}
+      {{- else if eq .storageunit "7" }}
       address: 0x0632 # SOC_Bat7
-      {{- end }}
-      {{- if eq .storageunit "8" }}
+      {{- else if eq .storageunit "8" }}
       address: 0x0639 # SOC_Bat8
       {{- end }}
       type: holding

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -166,14 +166,6 @@ render: |
       type: holding
       decode: int16
     scale: -10
-  # Removed for supporting multiple storage units
-  # energy:
-  #   source: modbus
-  #   register:
-  #     address: 0x069A # Bat_Discharge_Total
-  #     type: holding
-  #     decode: uint32
-  #   scale: 0.1
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -12,7 +12,6 @@ products:
   - brand: SofarSolar
     description:
       generic: SOFAR 5…24KTL-G3
-# capabilities: ["battery-control"]
 requirements:
   description:
     de: Die Verbindung über einen LSE-3 Logger Stick mittels LAN Anschluss und ModBus TCP über Port 8899 ist die einfachste Anbindung. Der LSW-3 WLAN Stick wird nicht unterstützt. Bei seriellem Anschluss via RS485 am COM Port ist eine wechselrichterseitige Terminierung notwendig.


### PR DESCRIPTION
Closes #19219

BREAKING CHANGE

Does no longer support one single meter entry for all storage units. Instead users need to configure separate meters with different storage units like this:

```yaml
site:
  meters:
    battery:
      - storageunit-1
      - storageunit-2

meters:
  - name: storageunit-1
    type: template
    template: sofarsolar-g3
    usage: battery   
    modbus: tcpip
    id: 1
    host: 192.168.158.13 
    port: 502 
  - name: storageunit-2
    type: template
    template: sofarsolar-g3
    usage: battery   
    modbus: tcpip
    id: 1
    host: 192.168.158.13 
    port: 502 
    storageunit: 2
```

Advantage: We are back to an accuracy of 10W instead of 100W