### PR TITLE
Plan UI: handle plan not found

### DIFF
--- a/assets/js/components/ChargingPlansSettings.vue
+++ b/assets/js/components/ChargingPlansSettings.vue
@@ -207,7 +207,7 @@ export default {
 		},
 		fetchActivePlan: async function () {
 			try {
-				const res = await api.get(`loadpoints/${this.id}/plan`);
+				const res = await this.apiFetchPlan(`loadpoints/${this.id}/plan`);
 				this.plan = res.data.result;
 				this.nextPlanId = this.plan.planId;
 			} catch (e) {
@@ -217,18 +217,33 @@ export default {
 		},
 		fetchStaticPreviewSoc: async function (soc, time) {
 			const timeISO = time.toISOString();
-			return await api.get(`loadpoints/${this.id}/plan/static/preview/soc/${soc}/${timeISO}`);
+			return await this.apiFetchPlan(
+				`loadpoints/${this.id}/plan/static/preview/soc/${soc}/${timeISO}`
+			);
 		},
 		fetchRepeatingPreview: async function (weekdays, soc, time, tz) {
-			return await api.get(
+			return await this.apiFetchPlan(
 				`loadpoints/${this.id}/plan/repeating/preview/${soc}/${weekdays}/${time}/${encodeURIComponent(tz)}`
 			);
 		},
 		fetchStaticPreviewEnergy: async function (energy, time) {
 			const timeISO = time.toISOString();
-			return await api.get(
+			return await this.apiFetchPlan(
 				`loadpoints/${this.id}/plan/static/preview/energy/${energy}/${timeISO}`
 			);
+		},
+		apiFetchPlan: async function (url) {
+			try {
+				const res = await api.get(url, {
+					validateStatus: (code) => [200, 404].includes(code),
+				});
+				if (res.status === 404) {
+					return { data: { result: {} } };
+				}
+				return res;
+			} catch (e) {
+				console.error(e);
+			}
 		},
 		fetchPreviewPlan: async function () {
 			// only show preview of no plan is active

--- a/server/http_loadpoint_handler.go
+++ b/server/http_loadpoint_handler.go
@@ -52,7 +52,7 @@ func planHandler(lp loadpoint.API) http.HandlerFunc {
 		requiredDuration := lp.GetPlanRequiredDuration(goal, maxPower)
 		plan := lp.GetPlan(planTime, requiredDuration)
 		if plan == nil {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 
@@ -111,7 +111,7 @@ func staticPlanPreviewHandler(lp loadpoint.API) http.HandlerFunc {
 		requiredDuration := lp.GetPlanRequiredDuration(goal, maxPower)
 		plan := lp.GetPlan(planTime, requiredDuration)
 		if plan == nil {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 
@@ -164,7 +164,7 @@ func repeatingPlanPreviewHandler(lp loadpoint.API) http.HandlerFunc {
 		requiredDuration := lp.GetPlanRequiredDuration(soc, maxPower)
 		plan := lp.GetPlan(planTime, requiredDuration)
 		if plan == nil {
-			w.WriteHeader(http.StatusBadRequest)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/19167

👮 return `404 not found` instead of `400 bad request` when no plan can be provided
🏷️ handle 404 case in UI (no visible error)