### PR TITLE
Account for a microinverter connected at the generator input of the deye hp3 inverter

### DIFF
--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -113,7 +113,7 @@ render: |
       register:
         address: 667 # "input power of micro-inverter connected at GEN-Port"
         type: holding
-        decode: uint16
+        decode: int16
       scale: 1
     {{- end }}
   energy:

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -30,6 +30,10 @@ params:
     default: 95
     advanced: true
   - name: maxacpower
+  - name: GenPortUse
+    choice: ["Generator", "SmartLoad", "MicroInverter"]
+    default: "Generator"
+    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -103,6 +107,7 @@ render: |
         type: holding
         decode: uint16
       scale: 10
+    {{- if eq .GenPortUse "MicroInverter" }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -110,6 +115,7 @@ render: |
         type: holding
         decode: uint16
       scale: 1
+    {{- end }}
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -103,6 +103,13 @@ render: |
         type: holding
         decode: uint16
       scale: 10
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 667 # "input power of micro-inverter connected at GEN-Port"
+        type: holding
+        decode: uint16
+      scale: 1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -107,7 +107,7 @@ render: |
         type: holding
         decode: uint16
       scale: 10
-    {{- if eq .includegenport true }}
+    {{- if eq .includegenport "true" }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -126,7 +126,7 @@ render: |
         type: holding
         decode: uint32s
       scale: 0.1
-    {{- if eq .includegenport true }}
+    {{- if eq .includegenport "true" }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -32,7 +32,6 @@ params:
   - name: maxacpower
   - name: includegenport
     type: bool
-    default: false
     advanced: true
 render: |
   type: custom

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -34,8 +34,8 @@ params:
     type: bool
     advanced: true
     description:
-      de: (optional) addiert Leistung und Energiestatistik vom Generator-Port des Wechselrichters zur PV-Erzeugung hinzu.
-      en: (optional) adds power and energy statistics from the generator port of the inverter to the pv production.
+      de: GEN-Anschluss als Solar-Eingang verwenden
+      en: Treat GEN port as solar input
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -115,7 +115,7 @@ render: |
       register:
         address: 667 # "low word of input power at GEN-Port"
         type: holding
-        decode: int16 # "value is actually a signed 32 bit value but high word in address 671 for powers over 32kW at the gen port is not considered at the moment"
+        decode: int16 # "value is actually a signed 32 bit value but high word is at reg 671
       scale: 1
     {{- end }}
   energy:
@@ -134,7 +134,7 @@ render: |
       register:
         address: 537 # "Total_Gen_Power_Wh"
         type: holding
-        decode: int32s # "value is signed 32 bit value with low word in 537 and high word in 538"
+        decode: int32s
       scale: 0.1
     {{- end }}
   maxacpower: {{ .maxacpower }}

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -30,9 +30,9 @@ params:
     default: 95
     advanced: true
   - name: maxacpower
-  - name: GenPortUse
-    choice: ["Generator", "SmartLoad", "MicroInverter"]
-    default: "Generator"
+  - name: includegenport
+    type: bool
+    default: false
     advanced: true
 render: |
   type: custom
@@ -107,23 +107,34 @@ render: |
         type: holding
         decode: uint16
       scale: 10
-    {{- if eq .GenPortUse "MicroInverter" }}
+    {{- if eq .includegenport true }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 667 # "input power of micro-inverter connected at GEN-Port"
+        address: 667 # "low word of input power at GEN-Port"
         type: holding
-        decode: int16
+        decode: int16 # "value is actually a signed 32 bit value but high word in address 671 for powers over 32kW at the gen port is not considered at the moment"
       scale: 1
     {{- end }}
   energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 534 # "Total_PV_Power_Wh"
-      type: holding
-      decode: uint32s
-    scale: 0.1
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 534 # "Total_PV_Power_Wh"
+        type: holding
+        decode: uint32s
+      scale: 0.1
+    {{- if eq .includegenport true }}
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 537 # "Total_Gen_Power_Wh"
+        type: holding
+        decode: int32s # "value is signed 32 bit value with low word in 537 and high word in 538"
+      scale: 0.1
+    {{- end }}
   maxacpower: {{ .maxacpower }}
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -33,6 +33,9 @@ params:
   - name: includegenport
     type: bool
     advanced: true
+    description:
+      de: (optional) addiert Leistung und Energiestatistik vom Generator-Port des Wechselrichters zur PV-Erzeugung hinzu.
+      en: (optional) adds power and energy statistics from the generator port of the inverter to the pv production.
 render: |
   type: custom
   {{- if eq .usage "grid" }}


### PR DESCRIPTION
Added register 667 to total pv power to account for a microinverter connected at the generator input of the deye inverter.

Fix https://github.com/evcc-io/evcc/issues/19171, fix https://github.com/evcc-io/evcc/issues/20235