### PR TITLE
fronius-gen24: make meter id configurable

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -14,6 +14,12 @@ params:
   - name: host
   - name: port
     default: 502
+  - name: id
+    default: 200
+    advanced: true
+    help:
+      en: "Meter adress of primary or secondary meters. On the web interface of the inverter, only the address of the first meter (e.g., 200) can be set. Additional meters receive an ascending number (e.g., 201)."
+      de: "Zähleradresse von Primär- oder Sekundärzählern. Auf der Weboberfläche des Wechselrichters kann nur die Adresse des ersten Zählers (z.B. 200) eingestellt werden. Zusätzliche Zähler erhalten eine aufsteigende Nummer (z.B: 201)."
   - name: integer
     deprecated: true
   - name: maxacpower
@@ -28,14 +34,14 @@ render: |
   power:
     source: sunspec
     uri: {{ .host }}:{{ .port }}
-    id: 200
+    id: {{ .id }}
     value:
       - 203:W
       - 213:W
   energy:
     source: sunspec
     uri: {{ .host }}:{{ .port }}
-    id: 200
+    id: {{ .id }}
     value:
       - 203:TotWhImp
       - 213:TotWhImp
@@ -43,57 +49,57 @@ render: |
   currents:
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:AphA
         - 213:AphA
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:AphB
         - 213:AphB
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:AphC
         - 213:AphC
   voltages:
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:PhVphA
         - 213:PhVphA
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:PhVphB
         - 213:PhVphB
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:PhVphC
         - 213:PhVphC
   powers:
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:WphA
         - 213:WphA
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:WphB
         - 213:WphB
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
-      id: 200
+      id: {{ .id }}
       value:
         - 203:WphC
         - 213:WphC


### PR DESCRIPTION
Up to 7 secondary meters can be connected to a Fronius Gen24 inverter.
They get an ascendig id number of e.g. 201.