### PR TITLE
OCPP: allow phase key in Energy.Active.Import.Register

### DIFF
--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -321,6 +321,13 @@ func (conn *Connector) TotalEnergy() (float64, error) {
 		return scale(f, m.Unit) / 1e3, err
 	}
 
+	// fallback for missing total energy
+	for _, suffix := range []types.Measurand{"", "-N"} {
+		if res, found, err := conn.phaseMeasurements(types.MeasurandEnergyActiveImportRegister, suffix); found {
+			return res[0] + res[1] + res[2], err
+		}
+	}
+
 	return 0, api.ErrNotAvailable
 }
 


### PR DESCRIPTION
Workaround for #19351 where a charger reported a phase for the measurand Energy.Active.Import.Register.

Ocpp specs are - as far as I can see - not clear about where the optional phase key is required, allowed or not allowed.