### PR TITLE
Forecast: add common parameter set

### DIFF
--- a/templates/definition/tariff/forecast-solar.yaml
+++ b/templates/definition/tariff/forecast-solar.yaml
@@ -8,27 +8,7 @@ requirements:
   evcc: ["skiptest"]
 group: solar
 params:
-  - name: lat
-    description:
-      en: Latitude
-      de: Breitengrad
-    example: "55.7351"
-    required: true
-  - name: lon
-    description:
-      en: Longitude
-      de: Längengrad
-    example: "9.1275"
-    required: true
-  - name: dec
-    description:
-      en: Decline
-      de: Neigung
-    help:
-      en: 0 = horizontal, 90 = vertical
-      de: 0 = horizontal, 90 = vertikal
-    example: 25
-    required: true
+  - preset: forecast-base
   - name: az
     description:
       en: Azimuth
@@ -37,12 +17,6 @@ params:
       en: -180 = north, -90 = east, 0 = south, 90 = west, 180 = north
       de: -180 = Norden, -90 = Osten, 0 = Süden, 90 = Westen, 180 = Norden
     example: 180
-    required: true
-  - name: kwp
-    description:
-      en: Maximum generator power [kWp]
-      de: Maximale Generatorleistung [kWp]
-    example: 9.8
     required: true
   - name: horizon
     description:

--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -8,30 +8,7 @@ requirements:
   evcc: ["skiptest"]
 group: solar
 params:
-  - name: lat
-    description:
-      en: Latitude
-      de: Breitengrad
-    type: float
-    example: 55.7351
-    required: true
-  - name: lon
-    description:
-      en: Longitude
-      de: Längengrad
-    type: float
-    example: 9.1275
-    required: true
-  - name: dec
-    description:
-      en: Decline
-      de: Neigung
-    help:
-      en: 0 = horizontal, 90 = vertical
-      de: 0 = horizontal, 90 = vertikal
-    type: int
-    example: 25
-    required: true
+  - preset: forecast-base
   - name: az
     description:
       en: Azimuth
@@ -41,13 +18,6 @@ params:
       de: -180 = Norden, -90 = Osten, 0 = Süden, 90 = Westen, 180 = Norden
     type: int
     example: 0
-    required: true
-  - name: kwp
-    description:
-      en: Maximum generator power [kWp]
-      de: Maximale Generatorleistung [kWp]
-    type: float
-    example: 9.8
     required: true
   - name: ac
     description:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -417,6 +417,40 @@ presets:
           de: Individuelle Formel zur Berechnung des Preises
           en: Individual formula for calculating the price
         example: "math.Max((price + charges) * (1 + tax), 0.0)"
+  forecast-base:
+    params:
+      - name: lat
+        description:
+          en: Latitude
+          de: Breitengrad
+        type: float
+        example: 55.7351
+        required: true
+      - name: lon
+        description:
+          en: Longitude
+          de: Längengrad
+        type: float
+        example: 9.1275
+        required: true
+      - name: dec
+        description:
+          en: Decline
+          de: Neigung
+        help:
+          en: 0 = horizontal, 90 = vertical
+          de: 0 = horizontal, 90 = vertikal
+        type: int
+        example: 25
+        required: true
+      - name: kwp
+        description:
+          en: Maximum generator power [kWp]
+          de: Maximale Generatorleistung [kWp]
+        type: float
+        example: 9.8
+        required: true
+
   eebus:
     params:
       - name: ski


### PR DESCRIPTION
Downside: we can't determine the parameter order when mixing presets with custom parameters. `az` is custom since forecasts might disagree on how to treat southern direction.