### PR TITLE
Apply quoting yaml values only the string parameters

### DIFF
--- a/util/templates/documentation.go
+++ b/util/templates/documentation.go
@@ -30,12 +30,12 @@ func (t *Template) RenderDocumentation(product Product, lang string) ([]byte, er
 		switch p.Type {
 		case TypeList:
 			for _, e := range v.([]string) {
-				t.Params[index].Values = append(p.Values, yamlQuote(p.Type, e))
+				t.Params[index].Values = append(p.Values, p.yamlQuote(e))
 			}
 		default:
 			switch v := v.(type) {
 			case string:
-				t.Params[index].Value = yamlQuote(p.Type, v)
+				t.Params[index].Value = p.yamlQuote(v)
 			case int:
 				t.Params[index].Value = strconv.Itoa(v)
 			}

--- a/util/templates/documentation.go
+++ b/util/templates/documentation.go
@@ -30,12 +30,12 @@ func (t *Template) RenderDocumentation(product Product, lang string) ([]byte, er
 		switch p.Type {
 		case TypeList:
 			for _, e := range v.([]string) {
-				t.Params[index].Values = append(p.Values, yamlQuote(e))
+				t.Params[index].Values = append(p.Values, yamlQuote(p.Type, e))
 			}
 		default:
 			switch v := v.(type) {
 			case string:
-				t.Params[index].Value = yamlQuote(v)
+				t.Params[index].Value = yamlQuote(p.Type, v)
 			case int:
 				t.Params[index].Value = strconv.Itoa(v)
 			}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -229,12 +229,12 @@ func (t *Template) RenderProxyWithValues(values map[string]interface{}, lang str
 		switch p.Type {
 		case TypeList:
 			for _, e := range v.([]string) {
-				t.Params[index].Values = append(p.Values, yamlQuote(p.Type, e))
+				t.Params[index].Values = append(p.Values, p.yamlQuote(e))
 			}
 		default:
 			switch v := v.(type) {
 			case string:
-				t.Params[index].Value = yamlQuote(p.Type, v)
+				t.Params[index].Value = p.yamlQuote(v)
 			case int:
 				t.Params[index].Value = strconv.Itoa(v)
 			}
@@ -314,7 +314,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 		case []interface{}:
 			var list []string
 			for _, v := range typed {
-				list = append(list, yamlQuote(p.Type, fmt.Sprintf("%v", v)))
+				list = append(list, p.yamlQuote(fmt.Sprintf("%v", v)))
 			}
 			if res[out] == nil || len(res[out].([]interface{})) == 0 {
 				res[out] = list
@@ -323,7 +323,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 		case []string:
 			var list []string
 			for _, v := range typed {
-				list = append(list, yamlQuote(p.Type, v))
+				list = append(list, p.yamlQuote(v))
 			}
 			if res[out] == nil || len(res[out].([]string)) == 0 {
 				res[out] = list
@@ -334,7 +334,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 				// prevent rendering nil interfaces as "<nil>" string
 				var s string
 				if val != nil {
-					s = yamlQuote(p.Type, fmt.Sprintf("%v", val))
+					s = p.yamlQuote(fmt.Sprintf("%v", val))
 				}
 				res[out] = s
 			}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -229,12 +229,12 @@ func (t *Template) RenderProxyWithValues(values map[string]interface{}, lang str
 		switch p.Type {
 		case TypeList:
 			for _, e := range v.([]string) {
-				t.Params[index].Values = append(p.Values, yamlQuote(e))
+				t.Params[index].Values = append(p.Values, yamlQuote(p.Type, e))
 			}
 		default:
 			switch v := v.(type) {
 			case string:
-				t.Params[index].Value = yamlQuote(v)
+				t.Params[index].Value = yamlQuote(p.Type, v)
 			case int:
 				t.Params[index].Value = strconv.Itoa(v)
 			}
@@ -297,7 +297,8 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 	for key, val := range values {
 		out := strings.ToLower(key)
 
-		if i, p := t.ParamByName(key); i == -1 {
+		i, p := t.ParamByName(key)
+		if i == -1 {
 			if !slices.Contains(predefinedTemplateProperties, out) {
 				return nil, values, fmt.Errorf("invalid key: %s", key)
 			}
@@ -313,7 +314,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 		case []interface{}:
 			var list []string
 			for _, v := range typed {
-				list = append(list, yamlQuote(fmt.Sprintf("%v", v)))
+				list = append(list, yamlQuote(p.Type, fmt.Sprintf("%v", v)))
 			}
 			if res[out] == nil || len(res[out].([]interface{})) == 0 {
 				res[out] = list
@@ -322,7 +323,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 		case []string:
 			var list []string
 			for _, v := range typed {
-				list = append(list, yamlQuote(v))
+				list = append(list, yamlQuote(p.Type, v))
 			}
 			if res[out] == nil || len(res[out].([]string)) == 0 {
 				res[out] = list
@@ -333,7 +334,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 				// prevent rendering nil interfaces as "<nil>" string
 				var s string
 				if val != nil {
-					s = yamlQuote(fmt.Sprintf("%v", val))
+					s = yamlQuote(p.Type, fmt.Sprintf("%v", val))
 				}
 				res[out] = s
 			}

--- a/util/templates/utils.go
+++ b/util/templates/utils.go
@@ -17,7 +17,11 @@ func quote(value string) string {
 }
 
 // yamlQuote quotes strings for yaml if they would otherwise by modified by the unmarshaler
-func yamlQuote(value string) string {
+func yamlQuote(typ ParamType, value string) string {
+	if typ != TypeString {
+		return value
+	}
+
 	input := fmt.Sprintf("key: %s", value)
 
 	var res struct {
@@ -28,8 +32,8 @@ func yamlQuote(value string) string {
 		return quote(value)
 	}
 
-	// fix 0815, but not 0; allow float values containing .
-	if strings.HasPrefix(value, "0") && len(value) > 1 && !strings.Contains(value, ".") {
+	// fix 0815
+	if strings.HasPrefix(value, "0") {
 		return quote(value)
 	}
 

--- a/util/templates/utils.go
+++ b/util/templates/utils.go
@@ -8,36 +8,11 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"gopkg.in/yaml.v3"
 )
 
 func quote(value string) string {
 	quoted := strings.ReplaceAll(value, `'`, `''`)
 	return fmt.Sprintf("'%s'", quoted)
-}
-
-// yamlQuote quotes strings for yaml if they would otherwise by modified by the unmarshaler
-func yamlQuote(typ ParamType, value string) string {
-	if typ != TypeString {
-		return value
-	}
-
-	input := fmt.Sprintf("key: %s", value)
-
-	var res struct {
-		Value string `yaml:"key"`
-	}
-
-	if err := yaml.Unmarshal([]byte(input), &res); err != nil || value != res.Value {
-		return quote(value)
-	}
-
-	// fix 0815, but not 0
-	if strings.HasPrefix(value, "0") && len(value) > 1 {
-		return quote(value)
-	}
-
-	return value
 }
 
 func trimLines(s string) string {

--- a/util/templates/utils.go
+++ b/util/templates/utils.go
@@ -32,8 +32,8 @@ func yamlQuote(typ ParamType, value string) string {
 		return quote(value)
 	}
 
-	// fix 0815
-	if strings.HasPrefix(value, "0") {
+	// fix 0815, but not 0
+	if strings.HasPrefix(value, "0") && len(value) > 1 {
 		return quote(value)
 	}
 

--- a/util/templates/utils_test.go
+++ b/util/templates/utils_test.go
@@ -12,7 +12,7 @@ import (
 func TestYamlDecode(t *testing.T) {
 	for _, value := range []string{`value`, `!value`, `@value`, `"value"`, `"va"lue"`, `va'lue`, `@va'lue`, `0815`, `"0815"`, `4711`, `#pwd`, ``} {
 		t.Run(value, func(t *testing.T) {
-			quoted := yamlQuote(value)
+			quoted := yamlQuote(TypeString, value)
 			input := fmt.Sprintf("key: %s", quoted)
 
 			var res struct {
@@ -29,7 +29,7 @@ func TestYamlDecode(t *testing.T) {
 func TestYamlDecodeLeadingZero(t *testing.T) {
 	exp := "'0815'"
 
-	if res := yamlQuote("0815"); res != exp {
+	if res := yamlQuote(TypeString, "0815"); res != exp {
 		t.Fatalf("expected %s, got %s", exp, res)
 	}
 }

--- a/util/templates/utils_test.go
+++ b/util/templates/utils_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 func TestYamlDecode(t *testing.T) {
+	p := Param{Type: TypeString}
 	for _, value := range []string{`value`, `!value`, `@value`, `"value"`, `"va"lue"`, `va'lue`, `@va'lue`, `0815`, `"0815"`, `4711`, `#pwd`, ``} {
 		t.Run(value, func(t *testing.T) {
-			quoted := yamlQuote(TypeString, value)
+			quoted := p.yamlQuote(value)
 			input := fmt.Sprintf("key: %s", quoted)
 
 			var res struct {
@@ -27,9 +28,6 @@ func TestYamlDecode(t *testing.T) {
 }
 
 func TestYamlDecodeLeadingZero(t *testing.T) {
-	exp := "'0815'"
-
-	if res := yamlQuote(TypeString, "0815"); res != exp {
-		t.Fatalf("expected %s, got %s", exp, res)
-	}
+	p := Param{Type: TypeString}
+	assert.Equal(t, "'0815'", p.yamlQuote("0815"))
 }


### PR DESCRIPTION
Fix invalid yaml quoting like in https://github.com/evcc-io/evcc/pull/19443 by applying quoting only to string parameters.

/cc @VolkerK62 @thecem fyi