### PR TITLE
Update e3dc-rscp.yaml add hint to subnet restrictions

### DIFF
--- a/templates/definition/meter/e3dc-rscp.yaml
+++ b/templates/definition/meter/e3dc-rscp.yaml
@@ -5,11 +5,11 @@ capabilities: ["battery-control"]
 requirements:
   description:
     de: |
-      Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key (=RSCP-Passwort) muss im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt werden.
+      Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key (=RSCP-Passwort) muss im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt werden. Die IP-Adressen von evcc und des Hauskraftwerks müssen sich im selben Subnetz befinden.
 
       **Achtung**: Die aktive Batteriesteuerung überschreibt Einstellungen im Smart-Power/Betriebsbereich.
     en: |
-      Username and password are identical to Web Portal or My E3/DC App access. Key (=RSCP-Password) must be set in the E3/DC System at Personalize/User Profile.
+      Username and password are identical to Web Portal or My E3/DC App access. Key (=RSCP-Password) must be set in the E3/DC system at Personalize/User Profile. The IP adresses of evcc and E3/DC system must be in the same subnet.
 
       **Note**: Active battery control will override Smart-Power/Operating Range settings.
 params:


### PR DESCRIPTION
When connecting to E3/DC system, IP adress of evcc must be in the same subnet. This was not mentioned in the docs before.