### PR TITLE
Solar Forecast: only publish if exists

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -83,12 +83,12 @@
 							icon="sun"
 							:power="pvProduction"
 							:powerTooltip="pvTooltip"
-							:details="solarForecast"
+							:details="solarForecastRemainingToday"
 							:detailsFmt="forecastFmt"
-							:detailsTooltip="forecastTooltip(solarForecast)"
-							:detailsInactive="solarForecast === 0"
-							:detailsIcon="solarForecast !== undefined ? 'forecast' : undefined"
-							:detailsClickable="solarForecast !== undefined"
+							:detailsTooltip="solarForecastTooltip"
+							:detailsInactive="!solarForecastExists"
+							:detailsIcon="solarForecastIcon"
+							:detailsClickable="solarForecastExists"
 							:powerUnit="powerUnit"
 							data-testid="energyflow-entry-production"
 							@details-clicked="openForecastModal"
@@ -389,8 +389,20 @@ export default {
 			}
 			return this.fmtPricePerKWh(this.batteryGridChargeLimit, this.currency, true);
 		},
-		solarForecast() {
-			return this.forecast?.solar?.today?.energy || undefined;
+		solarForecastExists() {
+			return !!this.forecast?.solar?.today;
+		},
+		solarForecastRemainingToday() {
+			return this.forecast?.solar?.today?.energy || 0;
+		},
+		solarForecastIcon() {
+			return this.solarForecastExists ? "forecast" : undefined;
+		},
+		solarForecastTooltip() {
+			if (this.solarForecastExists) {
+				return [this.$t("main.energyflow.forecastTooltip")];
+			}
+			return [];
 		},
 	},
 	watch: {
@@ -428,12 +440,6 @@ export default {
 				result.push(`${this.fmtPricePerKWh(price, this.currency)}`);
 			}
 			return result;
-		},
-		forecastTooltip(value) {
-			if (value !== null) {
-				return [this.$t("main.energyflow.forecastTooltip")];
-			}
-			return [];
 		},
 		detailsValue(price, co2) {
 			if (this.co2Available) {

--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -390,7 +390,7 @@ export default {
 			return this.fmtPricePerKWh(this.batteryGridChargeLimit, this.currency, true);
 		},
 		solarForecastExists() {
-			return !!this.forecast?.solar?.today;
+			return !!this.forecast?.solar;
 		},
 		solarForecastRemainingToday() {
 			return this.forecast?.solar?.today?.energy || 0;

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -111,8 +111,7 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 
 	// calculate adjusted solar forecast
 	if solar := timestampSeries(tariff.Forecast(site.GetTariff(api.TariffUsageSolar))); len(solar) > 0 {
-		solarDetails := site.solarDetails(solar)
-		fc.Solar = &solarDetails
+		fc.Solar = lo.ToPtr(site.solarDetails(solar))
 	}
 
 	site.publish(keys.Forecast, fc)

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -99,10 +99,10 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 	}
 
 	fc := struct {
-		Co2    api.Rates    `json:"co2,omitempty"`
-		FeedIn api.Rates    `json:"feedin,omitempty"`
-		Grid   api.Rates    `json:"grid,omitempty"`
-		Solar  solarDetails `json:"solar,omitempty"`
+		Co2    api.Rates     `json:"co2,omitempty"`
+		FeedIn api.Rates     `json:"feedin,omitempty"`
+		Grid   api.Rates     `json:"grid,omitempty"`
+		Solar  *solarDetails `json:"solar,omitempty"`
 	}{
 		Co2:    tariff.Forecast(site.GetTariff(api.TariffUsageCo2)),
 		FeedIn: tariff.Forecast(site.GetTariff(api.TariffUsageFeedIn)),
@@ -111,7 +111,8 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 
 	// calculate adjusted solar forecast
 	if solar := timestampSeries(tariff.Forecast(site.GetTariff(api.TariffUsageSolar))); len(solar) > 0 {
-		fc.Solar = site.solarDetails(solar)
+		solarDetails := site.solarDetails(solar)
+		fc.Solar = &solarDetails
 	}
 
 	site.publish(keys.Forecast, fc)


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/discussions/19559
regression from https://github.com/evcc-io/evcc/pull/18867

☀️ only publish solar forecast structure if forecast exists
📱 simplify, cleanup energy flow UI
🌅 ensure forecast does not disappear if remaining daily production is `0`