### PR TITLE
sungrow-hybrid: refactor hold battery mechanism

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -186,12 +186,22 @@ render: |
               address: 13050 # Charge/discharge command
               type: writesingle
               decode: uint16
+        # Reset max battery discharge power
+        - source: const
+          value: 1060 # 10.6kW, max allowed value for register
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 33047 # Battery max discharge power
+              type: writesingle
+              decode: uint16
     - case: 2 # hold
       set:
         source: sequence
         set:
         - source: const
-          value: 2 # Forced mode (charge/discharge/stop)
+          value: 0 # Self-consumption mode (Default)
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
@@ -206,6 +216,16 @@ render: |
             {{- include "modbus" . | indent 10 }}
             register:
               address: 13050 # Charge/discharge command
+              type: writesingle
+              decode: uint16
+        # Set max battery discharge power, effectively stops discharging
+        - source: const
+          value: 1 # 0.01kW, min allowed value for register
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 33047 # Battery max discharge power
               type: writesingle
               decode: uint16
     - case: 3 # charge


### PR DESCRIPTION
The previously used forced-mode does not allow charging the battery if enough solar is available. 

Instead, we should limit the battery max discharge power which effectively stops discharging but still allows for charging. 

This workaround is based on the HA script from here: https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/blob/e8142fce09930a8b7c879ed18160f4e094b2a433/modbus_sungrow.yaml#L3315