### PR TITLE
Add SunSpec meter

### DIFF
--- a/templates/definition/meter/fronius-smartmeter-inverter.yaml
+++ b/templates/definition/meter/fronius-smartmeter-inverter.yaml
@@ -6,7 +6,7 @@ products:
       en: Smartmeter (via Inverter)
 params:
   - name: usage
-    choice: ["grid", "pv", "aux"]
+    choice: ["grid", "pv"]
     allinone: true
   - name: host
   - name: port

--- a/templates/definition/meter/fronius-smartmeter-inverter.yaml
+++ b/templates/definition/meter/fronius-smartmeter-inverter.yaml
@@ -1,4 +1,4 @@
-template: fronius-meter
+template: fronius-smartmeter-inverter
 products:
   - brand: Fronius
     description:

--- a/templates/definition/meter/fronius-smartmeter-inverter.yaml
+++ b/templates/definition/meter/fronius-smartmeter-inverter.yaml
@@ -1,0 +1,128 @@
+template: fronius-meter
+products:
+  - brand: Fronius
+    description:
+      de: Smartmeter (über Wechselrichter)
+	    en: Smartmeter (via Inverter)
+params:
+  - name: usage
+    choice: ["grid", "pv", "aux"]
+    allinone: true
+  - name: host
+  - name: port
+    default: 502
+  - name: id
+    default: 201
+    help:
+      en: "Meter adress of primary or secondary meters. On the web interface of the inverter, only the address of the first meter (e.g., 200 for GEN24 or 240 for Snapinverter) can be set. Additional meters receive an ascending number (e.g., 201 or 241)."
+      de: "Zähleradresse von Primär- oder Sekundärzählern. Auf der Weboberfläche des Wechselrichters kann nur die Adresse des ersten Zählers (z.B. 200 für GEN24 oder 240 für Snapinverter) eingestellt werden. Zusätzliche Zähler erhalten eine aufsteigende Nummer (z.B: 201 oder 241)."
+  - name: integer
+    deprecated: true
+render: |
+  type: custom
+  # sunspec model 201 or 203 (int+sf)/ 211 or 213 (float) meter
+  {{- if eq .usage "grid" }}
+  power:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    value:
+	    - 201:W
+      - 211:W
+      - 203:W
+      - 213:W
+  energy:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    value:
+      - 201:TotWhImp
+      - 211:TotWhImp
+      - 203:TotWhImp
+      - 213:TotWhImp
+    scale: 0.001
+  currents:
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:AphA
+        - 211:AphA
+        - 203:AphA
+        - 213:AphA
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 203:AphB
+        - 213:AphB
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 203:AphC
+        - 213:AphC
+  voltages:
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:PhVphA
+        - 211:PhVphA
+        - 203:PhVphA
+        - 213:PhVphA
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 203:PhVphB
+        - 213:PhVphB
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 203:PhVphC
+        - 213:PhVphC
+  powers:
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:WphA
+        - 211:WphA
+        - 203:WphA
+        - 213:WphA
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 203:WphB
+        - 213:WphB
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 203:WphC
+        - 213:WphC
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    value:
+	    - 201:W
+      - 211:W
+      - 203:W
+      - 213:W
+  energy:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    value:
+      - 201:TotWhExp
+      - 211:TotWhExp
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
+  {{- end }}

--- a/templates/definition/meter/fronius-smartmeter-inverter.yaml
+++ b/templates/definition/meter/fronius-smartmeter-inverter.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Fronius
     description:
       de: Smartmeter (über Wechselrichter)
-	    en: Smartmeter (via Inverter)
+      en: Smartmeter (via Inverter)
 params:
   - name: usage
     choice: ["grid", "pv", "aux"]
@@ -27,7 +27,7 @@ render: |
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     value:
-	    - 201:W
+      - 201:W
       - 211:W
       - 203:W
       - 213:W
@@ -111,7 +111,7 @@ render: |
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     value:
-	    - 201:W
+      - 201:W
       - 211:W
       - 203:W
       - 213:W

--- a/templates/definition/meter/sunspec-meter.yaml
+++ b/templates/definition/meter/sunspec-meter.yaml
@@ -1,5 +1,8 @@
-template: fronius-smartmeter-inverter
+template: sunspec-meter
 products:
+  - description:
+      de: SunSpec Zähler
+      en: SunSpec Meter
   - brand: Fronius
     description:
       de: Smartmeter (über Wechselrichter)
@@ -7,17 +10,8 @@ products:
 params:
   - name: usage
     choice: ["grid", "pv"]
-    allinone: true
-  - name: host
-  - name: port
-    default: 502
-  - name: id
-    default: 201
-    help:
-      en: "Meter adress of primary or secondary meters. On the web interface of the inverter, only the address of the first meter (e.g., 200 for GEN24 or 240 for Snapinverter) can be set. Additional meters receive an ascending number (e.g., 201 or 241)."
-      de: "Zähleradresse von Primär- oder Sekundärzählern. Auf der Weboberfläche des Wechselrichters kann nur die Adresse des ersten Zählers (z.B. 200 für GEN24 oder 240 für Snapinverter) eingestellt werden. Zusätzliche Zähler erhalten eine aufsteigende Nummer (z.B: 201 oder 241)."
-  - name: integer
-    deprecated: true
+  - name: modbus
+    choice: ["tcpip"]
 render: |
   type: custom
   # sunspec model 201 or 203 (int+sf)/ 211 or 213 (float) meter


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/19905

this way it can be used with UI config
For older Symo, Primo, Eco, IG, ... Inverters (all with Display)
and newer GEN24 Symo, Primo, Tauro, Verto.

Than this can be reverted: https://github.com/evcc-io/evcc/pull/19341