### PR TITLE
LG ESS: add battery control

### DIFF
--- a/meter/lgess.go
+++ b/meter/lgess.go
@@ -177,7 +177,7 @@ func (m *LgEss) batteryMode(battery battery) func(api.BatteryMode) error {
 			}
 			return m.conn.BatteryMode("on", int(soc), true)
 		case api.BatteryCharge:
-			return m.conn.BatteryMode("on", int(battery.MinSoc), true)
+			return m.conn.BatteryMode("on", int(battery.MaxSoc), true)
 		default:
 			return api.ErrNotAvailable
 		}

--- a/meter/lgess.go
+++ b/meter/lgess.go
@@ -11,38 +11,6 @@ import (
 	"github.com/evcc-io/evcc/util"
 )
 
-/*
-This meter supports the LGESS HOME 8, LGESS HOME 10 and LGESS HOME 15 systems from LG with / without battery.
-
-
-** Usages **
-The following usages are supported:
-- grid    ... for reading the power imported or exported to the grid
-- pv      ... for reading the power produced by the pv
-- battery ... for reading the power imported or exported to the battery
-
-** Example configuration **
-meters:
-- name: GridMeter
-  type: template
-  template: lg-ess-home-15
-  usage: grid
-  uri: https://192.168.1.23
-  password: "DE200....."
-- name: PvMeter
-  type: template
-  template: lg-ess-home-15
-  usage: pv
-- name: BatteryMeter
-  type: template
-  template: lg-ess-home-15
-  usage: battery
-
-** Limitations **
-It is not allowed to provide different URIs or passwords for different lgess meters since always the
-same hardware instance is accessed with the different usages.
-*/
-
 // LgEss implements the api.Meter interface
 type LgEss struct {
 	usage string     // grid, pv, battery

--- a/meter/lgess.go
+++ b/meter/lgess.go
@@ -54,7 +54,7 @@ func init() {
 	registry.Add("lgess15", NewLgEss15FromConfig)
 }
 
-//go:generate go tool decorate -f decorateLgEss -b *LgEss -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryCapacity,Capacity,func() float64"
+//go:generate go tool decorate -f decorateLgEss -b *LgEss -r api.Meter -t "api.MeterEnergy,TotalEnergy,func() (float64, error)" -t "api.Battery,Soc,func() (float64, error)" -t "api.BatteryController,SetBatteryMode,func(api.BatteryMode) error" -t "api.BatteryCapacity,Capacity,func() float64"
 
 func NewLgEss8FromConfig(other map[string]interface{}) (api.Meter, error) {
 	return NewLgEssFromConfig(other, lgpcs.LgEss8)
@@ -70,8 +70,13 @@ func NewLgEssFromConfig(other map[string]interface{}, essType lgpcs.Model) (api.
 		capacity               `mapstructure:",squash"`
 		URI, Usage             string
 		Registration, Password string
+		battery                `mapstructure:",squash"`
 		Cache                  time.Duration
 	}{
+		battery: battery{
+			MinSoc: 20,
+			MaxSoc: 95,
+		},
 		Cache: time.Second,
 	}
 
@@ -83,11 +88,11 @@ func NewLgEssFromConfig(other map[string]interface{}, essType lgpcs.Model) (api.
 		return nil, errors.New("missing usage")
 	}
 
-	return NewLgEss(cc.URI, cc.Usage, cc.Registration, cc.Password, cc.Cache, cc.capacity.Decorator(), essType)
+	return NewLgEss(cc.URI, cc.Usage, cc.Registration, cc.Password, cc.Cache, cc.capacity.Decorator(), cc.battery, essType)
 }
 
 // NewLgEss creates an LgEss Meter
-func NewLgEss(uri, usage, registration, password string, cache time.Duration, capacity func() float64, essType lgpcs.Model) (api.Meter, error) {
+func NewLgEss(uri, usage, registration, password string, cache time.Duration, capacity func() float64, battery battery, essType lgpcs.Model) (api.Meter, error) {
 	conn, err := lgpcs.GetInstance(uri, registration, password, cache, essType)
 	if err != nil {
 		return nil, err
@@ -106,11 +111,13 @@ func NewLgEss(uri, usage, registration, password string, cache time.Duration, ca
 
 	// decorate api.BatterySoc
 	var batterySoc func() (float64, error)
+	var setBatteryMode func(api.BatteryMode) error
 	if usage == "battery" {
 		batterySoc = m.batterySoc
+		setBatteryMode = m.batteryMode(battery)
 	}
 
-	return decorateLgEss(m, totalEnergy, batterySoc, capacity), nil
+	return decorateLgEss(m, totalEnergy, batterySoc, setBatteryMode, capacity), nil
 }
 
 // CurrentPower implements the api.Meter interface
@@ -155,4 +162,24 @@ func (m *LgEss) batterySoc() (float64, error) {
 	}
 
 	return data.GetBatUserSoc(), nil
+}
+
+// batteryMode implements the api.BatteryController interface
+func (m *LgEss) batteryMode(battery battery) func(api.BatteryMode) error {
+	return func(mode api.BatteryMode) error {
+		switch mode {
+		case api.BatteryNormal:
+			return m.conn.BatteryMode("on", int(battery.MinSoc), true)
+		case api.BatteryHold:
+			soc, err := m.batterySoc()
+			if err != nil {
+				return err
+			}
+			return m.conn.BatteryMode("on", int(soc), true)
+		case api.BatteryCharge:
+			return m.conn.BatteryMode("on", int(battery.MinSoc), true)
+		default:
+			return api.ErrNotAvailable
+		}
+	}
 }

--- a/meter/lgpcs/lgpcs.go
+++ b/meter/lgpcs/lgpcs.go
@@ -136,9 +136,9 @@ func (m *Com) Data() (EssData, error) {
 
 // essInfo reads essinfo/home
 func (m *Com) essInfo() (EssData, error) {
-	f := func(_ any) (*http.Request, error) {
+	f := func(payload any) (*http.Request, error) {
 		uri := fmt.Sprintf("%s/v1/user/essinfo/home", m.uri)
-		return request.New(http.MethodPost, uri, nil, request.JSONEncoding)
+		return request.New(http.MethodPost, uri, request.MarshalJSON(payload), request.JSONEncoding)
 	}
 
 	if m.essType == LgEss8 {
@@ -176,7 +176,8 @@ func (m *Com) request(f func(any) (*http.Request, error), payload map[string]str
 		return err
 	}
 
-	if err := m.DoJSON(req, &res); err == nil {
+	err = m.DoJSON(req, &res)
+	if err == nil {
 		return nil
 	}
 

--- a/meter/lgpcs/lgpcs.go
+++ b/meter/lgpcs/lgpcs.go
@@ -123,7 +123,7 @@ func (m *Com) Data() (EssData, error) {
 // essInfo reads essinfo/home
 func (m *Com) essInfo() (EssData, error) {
 	f := func(body io.ReadSeeker) (*http.Request, error) {
-		uri := fmt.Sprintf("%s/v1/essinfo/home", m.uri)
+		uri := fmt.Sprintf("%s/v1/user/essinfo/home", m.uri)
 		return request.New(http.MethodPost, uri, body, request.JSONEncoding)
 	}
 

--- a/meter/lgpcs/lgpcs.go
+++ b/meter/lgpcs/lgpcs.go
@@ -142,7 +142,7 @@ func (m *Com) essInfo() (EssData, error) {
 func (m *Com) BatteryMode(mode string, soc int, autocharge bool) error {
 	var res struct{}
 	return m.request(func(body io.ReadSeeker) (*http.Request, error) {
-		uri := fmt.Sprintf("%s/v1/setting/batt", m.uri)
+		uri := fmt.Sprintf("%s/v1/user/setting/batt", m.uri)
 		return request.New(http.MethodPost, uri, body, request.JSONEncoding)
 	}, map[string]string{
 		"backupmode": mode,

--- a/templates/definition/meter/lg-ess-home-15.yaml
+++ b/templates/definition/meter/lg-ess-home-15.yaml
@@ -3,6 +3,7 @@ products:
   - brand: LG
     description:
       generic: ESS Home 15
+capabilities: ["battery-control"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -24,6 +25,13 @@ params:
       de: Registriernummer des LG ESS HOME Wechselrichters.
   - name: capacity
     advanced: true
+  # battery control
+  - name: minsoc
+    type: int
+    advanced: true
+  - name: maxsoc
+    type: int
+    advanced: true
 render: |
   type: lgess15
   usage: {{ .usage }}
@@ -35,4 +43,8 @@ render: |
   {{- if .registration }}
   registration: {{ .registration }}
   {{- end }}
+  {{- if eq .usage "battery" }}
   capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }}
+  maxsoc: {{ .maxsoc }}
+  {{- end }}

--- a/templates/definition/meter/lg-ess-home-8-10.yaml
+++ b/templates/definition/meter/lg-ess-home-8-10.yaml
@@ -3,6 +3,7 @@ products:
   - brand: LG
     description:
       generic: ESS Home 8/10
+capabilities: ["battery-control"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -24,6 +25,13 @@ params:
       de: Registriernummer des LG ESS HOME Wechselrichters.
   - name: capacity
     advanced: true
+  # battery control
+  - name: minsoc
+    type: int
+    advanced: true
+  - name: maxsoc
+    type: int
+    advanced: true
 render: |
   type: lgess8
   usage: {{ .usage }}
@@ -35,4 +43,8 @@ render: |
   {{- if .registration }}
   registration: {{ .registration }}
   {{- end }}
+  {{- if eq .usage "battery" }}
   capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }}
+  maxsoc: {{ .maxsoc }}
+  {{- end }}


### PR DESCRIPTION
Fix #16637, replace #18416, #18492
Rebased on 0.200.8, reworked installer login
Required firmware for active battery control on Home 8/10: at least R2155, tested with R2173.