### PR TITLE
Update lambda-zewotherm.yaml

### DIFF
--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -14,6 +14,12 @@ requirements:
 params:
   - name: modbus
     choice: ["tcpip"]
+  - name: tempsource
+    type: choice
+    choice: ["", "warmwater_top", "warmwater_bottom", "buffer_top", "buffer_bottom"]
+    description:
+      de: "Temperaturquelle"
+      en: "Temperature source"
   - name: phases
     type: int
     advanced: true
@@ -25,12 +31,30 @@ render: |
     {{- include "modbus" . | indent 2 }}
     register:
       address: 102 # PV Überschussleistung
-      type: holding
+      type: writemultiple # λ erwartet single value als FC16
       decode: int16
   power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 103 # aktuelle Aufnahmeleistung der WP
+      address: 103 # aktuelle Aufnahmeleistung [E] der WP
       type: holding
       decode: int16
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 1022 # Accumulated thermal energy output [Q] since last reset
+      type: holding
+      decode: int32
+    scale: 0.001
+  {{- if .tempsource }}
+  temp:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: {{ if eq .tempsource "warmwater_top" -}} 2002 {{ else if eq .tempsource "warmwater_bottom" -}} 2003 {{ else if eq .tempsource "buffer_top" -}} 3002 {{ else }} 3003 {{- end }} # 2002 Trinkwasser Oben, 2003 Trinkwasser Unten, 3002 Wärmespeicher Oben, 3003 Wärmespeicher Unten
+      type: holding
+      decode: int16
+    scale: 0.1
+  {{- end }}


### PR DESCRIPTION
- fix writing to register PV Excess (λ expects a single value as FC16)
- Add Temp for buffer & boiler (top plus bottom) 
- Add Thermal Energy [Q]
- Adapt scaling