### PR TITLE
Plan UI: Always show price/co2 on hover when known

### DIFF
--- a/assets/js/components/ChargingPlans/Preview.vue
+++ b/assets/js/components/ChargingPlans/Preview.vue
@@ -97,7 +97,7 @@ export default {
 			return hourSum ? priceSum / hourSum : undefined;
 		},
 		fmtAvgPrice() {
-			if (!this.targetTime || this.duration === 0) {
+			if (this.duration === 0) {
 				return "—";
 			}
 			const price = this.activeSlot ? this.activeSlot.price : this.avgPrice;


### PR DESCRIPTION
Fix #19716

Hi,
Ich verstehe nicht, wieso `!this.targetTime` überprüft wurde.
Diese Bedingung zu entfernen, führt aber zum gewünschten Verhalten.
Mir fallen auch keine Edge Cases ein, die mit dieser Änderung auftreten könnten.
Vielleicht weißt du da mehr, @naltatis.