### PR TITLE
OCPP: assume 1p3p support for power

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -313,6 +313,7 @@ func (c *OCPP) setCurrent(current float64) error {
 func (c *OCPP) createTxDefaultChargingProfile(current float64) *types.ChargingProfile {
 	phases := c.phases
 	period := types.NewChargingSchedulePeriod(0, current)
+
 	if c.cp.ChargingRateUnit == types.ChargingRateUnitWatts {
 		// get (expectedly) active phases from loadpoint
 		if c.lp != nil {
@@ -322,11 +323,12 @@ func (c *OCPP) createTxDefaultChargingProfile(current float64) *types.ChargingPr
 			phases = 3
 		}
 		period = types.NewChargingSchedulePeriod(0, math.Trunc(230.0*current*float64(phases)))
-	}
-
-	// OCPP assumes phases == 3 if not set
-	if phases != 0 {
-		period.NumberPhases = &phases
+	} else {
+		// OCPP assumes phases == 3 if not set
+		if phases != 0 {
+			// set explicit phase configuration
+			period.NumberPhases = &phases
+		}
 	}
 
 	res := &types.ChargingProfile{

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -52,6 +52,7 @@ func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.
 		case match(KeyChargingScheduleAllowedChargingRateUnit):
 			if *opt.Value == "Power" || *opt.Value == "W" { // "W" is not allowed by spec but used by some CPs
 				cp.ChargingRateUnit = types.ChargingRateUnitWatts
+				cp.PhaseSwitching = true // assume phase switching is available for power-based charging
 			}
 
 		case match(KeyConnectorSwitch3to1PhaseSupported) || match(KeyChargeAmpsPhaseSwitchingSupported):


### PR DESCRIPTION
* assume implicit 1p3p support if charger does support power control only
* request explicit phase configuration for current control if 1p3p support is indicated only

May fix https://github.com/evcc-io/evcc/discussions/16603 and other chargers like Huawei (partly).