### PR TITLE
Heatpump: move phase configuration to loadpoint

### DIFF
--- a/charger/heatpump.go
+++ b/charger/heatpump.go
@@ -160,7 +160,7 @@ func (wb *Heatpump) MaxCurrentEx(current float64) error {
 	return wb.setMaxPower(int64(230 * current * float64(phases)))
 }
 
-var _ loadpoint.Controller = (*EEBus)(nil)
+var _ loadpoint.Controller = (*Heatpump)(nil)
 
 // LoadpointControl implements loadpoint.Controller
 func (wb *Heatpump) LoadpointControl(lp loadpoint.API) {

--- a/charger/vaillant.go
+++ b/charger/vaillant.go
@@ -53,16 +53,14 @@ func NewVaillantFromConfig(ctx context.Context, other map[string]interface{}) (a
 		Realm           string
 		HeatingZone     int
 		HeatingSetpoint float32
-		Phases          int
 		Cache           time.Duration
 	}{
 		embed: embed{
 			Icon_:     "heatpump",
 			Features_: []api.Feature{api.Heating, api.IntegratedDevice},
 		},
-		Realm:  sensonet.REALM_GERMANY,
-		Phases: 1,
-		Cache:  time.Minute,
+		Realm: sensonet.REALM_GERMANY,
+		Cache: time.Minute,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/templates/definition/charger/idm.yaml
+++ b/templates/definition/charger/idm.yaml
@@ -14,11 +14,9 @@ params:
       de: "Temperaturquelle"
       en: "Temperature source"
   - name: phases
-    type: int
-    advanced: true
+    deprecated: true
 render: |
   type: heatpump
-  phases: {{ .phases }}
   setmaxpower:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -21,11 +21,9 @@ params:
       de: "Temperaturquelle"
       en: "Temperature source"
   - name: phases
-    type: int
-    advanced: true
+    deprecated: true
 render: |
   type: heatpump
-  phases: {{ .phases }}
   setmaxpower:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/charger/vaillant.yaml
+++ b/templates/definition/charger/vaillant.yaml
@@ -23,12 +23,10 @@ params:
       de: Boost Temperatur
       en: Boost temperature setpoint
   - name: phases
-    type: int
-    advanced: true
+    deprecated: true
 render: |
   type: vaillant
   user: {{ .user }}
   password: {{ .password }}
   heatingzone: {{ .zone }}
   heatingsetpoint: {{ .setpoint }}
-  phases: {{ .phases }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/19706

@premultiply analog bisheriger Lösung- irgendwie habe ich das bei den WPs übersehen.

/cc @SolarPowerEV 