### PR TITLE
fix(toyota): set expiry on refreshed token

### DIFF
--- a/vehicle/toyota/identity.go
+++ b/vehicle/toyota/identity.go
@@ -159,6 +159,7 @@ func (v *Identity) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 	if err := v.DoJSON(req, &res); err != nil {
 		return nil, err
 	}
+	res.Expiry = time.Now().Add(time.Duration(res.ExpiresIn) * time.Second)
 	return oauth.RefreshTokenSource(&res, v).Token()
 }
 

--- a/vehicle/toyota/identity.go
+++ b/vehicle/toyota/identity.go
@@ -141,7 +141,7 @@ func (v *Identity) fetchTokenCredentials(code string) error {
 	}
 
 	v.uuid = uuid
-	v.TokenSource = oauth.RefreshTokenSource(&resp.Token, v)
+	v.TokenSource = oauth.RefreshTokenSource(util.TokenWithExpiry(&resp.Token), v)
 	return nil
 }
 
@@ -159,8 +159,7 @@ func (v *Identity) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 	if err := v.DoJSON(req, &res); err != nil {
 		return nil, err
 	}
-	res.Expiry = time.Now().Add(time.Duration(res.ExpiresIn) * time.Second)
-	return oauth.RefreshTokenSource(&res, v).Token()
+	return util.TokenWithExpiry(&res), nil
 }
 
 func (v *Identity) Login(user, password string) error {


### PR DESCRIPTION
Should fix the problem that sometimes no refresh happens. Weird thing is that from my point of view refresh should have worked exactly once if that is the problem. However it takes several days for me to happen. 

A build with this change is running on my box now and I will keep an eye on it.