### PR TITLE
Warp3: split Smart and Pro models

### DIFF
--- a/templates/definition/charger/tinkerforge-warp3-smart.yaml
+++ b/templates/definition/charger/tinkerforge-warp3-smart.yaml
@@ -1,0 +1,17 @@
+template: tinkerforge-warp3-smart
+products:
+  - brand: TinkerForge
+    description:
+      generic: WARP3 Charger Smart
+capabilities: ["mA", "rfid"]
+requirements:
+  evcc: ["skiptest"]
+params:
+  - preset: mqtt
+  - name: topic
+    default: warp
+render: |
+  type: warp2
+  {{ include "mqtt" . }}
+  topic: {{ .topic }}
+  energymanager: {{ .topic }}

--- a/templates/definition/charger/tinkerforge-warp3-smart.yaml
+++ b/templates/definition/charger/tinkerforge-warp3-smart.yaml
@@ -3,7 +3,7 @@ products:
   - brand: TinkerForge
     description:
       generic: WARP3 Charger Smart
-capabilities: ["mA", "rfid"]
+capabilities: ["mA", "1p3p", "rfid"]
 requirements:
   evcc: ["skiptest"]
 params:

--- a/templates/definition/charger/tinkerforge-warp3.yaml
+++ b/templates/definition/charger/tinkerforge-warp3.yaml
@@ -2,9 +2,6 @@ template: tinkerforge-warp3
 products:
   - brand: TinkerForge
     description:
-      generic: WARP3 Charger Smart
-  - brand: TinkerForge
-    description:
       generic: WARP3 Charger Pro
 capabilities: ["mA", "1p3p", "rfid"]
 requirements:


### PR DESCRIPTION
Follow-up to https://github.com/evcc-io/evcc/pull/14494