### PR TITLE
mz2mqtt deprecated

### DIFF
--- a/templates/definition/vehicle/mz2mqtt.yaml
+++ b/templates/definition/vehicle/mz2mqtt.yaml
@@ -1,4 +1,5 @@
 template: mz2mqtt
+deprecated: true
 products:
   - description:
       generic: mz2mqtt


### PR DESCRIPTION
mz2mqtt no longer works because of mazda change their api and the lib from bdr99 is not working any more