### PR TITLE
Klarstellung Eingabe maxacpower

### DIFF
--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -97,11 +97,11 @@ params:
     usages: ["vehicle", "battery"]
   - name: maxacpower
     description:
-      de: Maximale AC Leistung des Hybrid-Wechselrichters
-      en: Maximum AC power of the hybrid inverter
+      de: Maximale AC Leistung des Hybrid-Wechselrichters in W
+      en: Maximum AC power of the hybrid inverter in W
     help:
-      de: Maximale AC Leistung des Hybrid-Wechselrichters
-      en: Maximum AC power of the hybrid inverter
+      de: Maximale AC Leistung des Hybrid-Wechselrichters in W
+      en: Maximum AC power of the hybrid inverter in W
     default: 0
     example: 5000
     type: float


### PR DESCRIPTION
kommt gelegentlich vor, dass es als kWh Wert eingetragen wird und führt dann zu Diskussionen