### PR TITLE
sungrow-hybrid: fix reset to normal battery mode

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -187,6 +187,18 @@ render: |
               type: writesingle
               decode: uint16
         # Reset max battery discharge power
+        {{- if .maxchargepower }}
+        - source: const
+          value: {{ .maxchargepower | int }} # W
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 33047 # Battery max discharge power
+              type: writesingle
+              decode: uint16
+            scale: 0.1
+        {{- else }}
         - source: const
           value: 1060 # 10.6kW, max allowed value for register
           set:
@@ -196,6 +208,7 @@ render: |
               address: 33047 # Battery max discharge power
               type: writesingle
               decode: uint16
+        {{- end }}
     - case: 2 # hold
       set:
         source: sequence

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -187,9 +187,9 @@ render: |
               type: writesingle
               decode: uint16
         # Reset max battery discharge power
-        {{- if .maxchargepower }}
         - source: const
-          value: {{ .maxchargepower | int }} # W
+          value: {{- if .maxchargepower }}{{ .maxchargepower }}{{ else }} 1060 # 10.6kW, max allowed value for register
+ {{ end }} ```
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
@@ -197,18 +197,6 @@ render: |
               address: 33047 # Battery max discharge power
               type: writesingle
               decode: uint16
-            scale: 0.1
-        {{- else }}
-        - source: const
-          value: 1060 # 10.6kW, max allowed value for register
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 33047 # Battery max discharge power
-              type: writesingle
-              decode: uint16
-        {{- end }}
     - case: 2 # hold
       set:
         source: sequence

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -188,8 +188,7 @@ render: |
               decode: uint16
         # Reset max battery discharge power
         - source: const
-          value: {{- if .maxchargepower }}{{ .maxchargepower }}{{ else }} 1060 # 10.6kW, max allowed value for register
- {{ end }} ```
+          value: {{- if .maxchargepower }}{{ .maxchargepower }}{{ else }} 1060 # 10.6kW, max allowed value for register {{ end }}
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -21,6 +21,7 @@ params:
     advanced: true
   - name: maxacpower
   - name: maxchargepower
+    usages: ["battery"]
     advanced: true
 render: |
   type: custom


### PR DESCRIPTION
The previously used forced value does not work reliably on my SH5.0RT. I'm proposing using the initial implementation that I successfully tested locally.