### PR TITLE
Config UI: reset lp smart cost limit

### DIFF
--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -748,13 +748,8 @@ func (lp *Loadpoint) SetSmartCostLimit(val *float64) {
 	if !ptrValueEqual(lp.smartCostLimit, val) {
 		lp.smartCostLimit = val
 
-		if val == nil {
-			lp.settings.SetString(keys.SmartCostLimit, "")
-			lp.publish(keys.SmartCostLimit, nil)
-		} else {
-			lp.settings.SetFloat(keys.SmartCostLimit, *val)
-			lp.publish(keys.SmartCostLimit, *val)
-		}
+		lp.settings.SetFloatPtr(keys.SmartCostLimit, val)
+		lp.publish(keys.SmartCostLimit, val)
 	}
 }
 

--- a/core/settings/config.go
+++ b/core/settings/config.go
@@ -56,6 +56,10 @@ func (s *ConfigSettings) SetFloat(key string, val float64) {
 	s.set(key, val)
 }
 
+func (s *ConfigSettings) SetFloatPtr(key string, val *float64) {
+	s.set(key, val)
+}
+
 func (s *ConfigSettings) SetTime(key string, val time.Time) {
 	s.set(key, val)
 }

--- a/core/settings/database.go
+++ b/core/settings/database.go
@@ -28,6 +28,14 @@ func (s *dbSettings) SetFloat(key string, val float64) {
 	db.SetFloat(s.Key+key, val)
 }
 
+func (s *dbSettings) SetFloatPtr(key string, val *float64) {
+	if val == nil {
+		db.SetString(s.Key+key, "")
+	} else {
+		db.SetFloat(s.Key+key, *val)
+	}
+}
+
 func (s *dbSettings) SetTime(key string, val time.Time) {
 	db.SetTime(s.Key+key, val)
 }

--- a/core/settings/settings.go
+++ b/core/settings/settings.go
@@ -6,6 +6,7 @@ type Settings interface {
 	SetString(key string, val string)
 	SetInt(key string, val int64)
 	SetFloat(key string, val float64)
+	SetFloatPtr(key string, val *float64)
 	SetTime(key string, val time.Time)
 	SetJson(key string, val any) error
 	SetBool(key string, val bool)


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/19884

In `settings` `nil` `float64` ist stored as `""`. This does not work with dynamic config json decode.