### PR TITLE
docs: fix lambda template

### DIFF
--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -10,6 +10,7 @@ products:
       en: EU-L Series
 group: heating
 requirements:
+  # evcc: ["sponsorship"]
   description:
     de: |
       Energiemanagementeinstellungen am Gerät:

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -2,31 +2,25 @@ template: lambda-zewotherm
 products:
   - brand: Lambda
     description:
-      de: |
-        EU-L Serie
-        * Einstellungen des Energie Magagement der Lambda Steuerung:
-        * E-Meter Kommunikationsart: "ModBus Client"
-        * E-Meter Messpunkt: "Pos. E-Überschuss"
-      en: |
-        EU-L Series
-        * Energy management settings of the Lambda control:
-        * E-Meter communication type: "ModBus Client"
-        * E-Meter measuring point: "Pos. E-Überschuss"
+      de: EU-L Serie
+      en: EU-L Series
   - brand: Zewotherm
     description:
-      de: |
-        EU-L Serie
-        * Einstellungen des Energie Magagement der Zewotherm Steuerung:
-        * E-Meter Kommunikationsart: "ModBus Client"
-        * E-Meter Messpunkt: "Pos. E-Überschuss"
-      en: |
-        EU-L Series
-        * Energy management settings of the Zewotherm control:
-        * E-Meter communication type: "ModBus Client"
-        * E-Meter measuring point: "Pos. E-Überschuss"
+      de: EU-L Serie
+      en: EU-L Series
 group: heating
 requirements:
-  # evcc: ["sponsorship"]
+  description:
+    de: |
+      Energiemanagementeinstellungen am Gerät:
+
+      - E-Meter Kommunikationsart: "ModBus Client"
+      - E-Meter Messpunkt: "Pos. E-Überschuss"
+    en: |
+      Energy management settings of the device:
+
+      - E-Meter communication type: "ModBus Client"
+      - E-Meter measuring point: "Pos. E-Überschuss"
 params:
   - name: modbus
     choice: ["tcpip"]


### PR DESCRIPTION
fixes docs generation (temporary fix already applied: https://github.com/evcc-io/docs/commit/cd862fdfa69b0ad3597788a11ec52138a0cb0bc8)

Device instructions can be markdown but they have to go into the `requirements.description` block, not in the product name.

fyi: @thecem @andig