### PR TITLE
fix: treat charging status "error" as StatusB for cupra provider

### DIFF
--- a/vehicle/seat/cupra/provider.go
+++ b/vehicle/seat/cupra/provider.go
@@ -66,7 +66,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	res, err := v.statusG()
 	if err == nil {
 		switch strings.ToLower(res.Services.Charging.Status) {
-		case "connected", "readyforcharging":
+		case "connected", "readyforcharging", "error":
 			status = api.StatusB
 		case "charging":
 			status = api.StatusC


### PR DESCRIPTION
Fix #19970 