### PR TITLE
em2go: remove unreliable session energy

### DIFF
--- a/charger/em2go.go
+++ b/charger/em2go.go
@@ -51,7 +51,6 @@ const (
 	em2GoRegMinCurrent      = 34  // Uint16 RO 0.1A
 	em2GoRegCableMaxCurrent = 36  // Uint16 RO 0.1A
 	em2GoRegSerial          = 38  // Chr[16] RO UTF16
-	em2GoRegChargedEnergy   = 72  // Uint16 RO 0.1kWh
 	em2GoRegChargeDuration  = 78  // Uint32 RO 1s
 	em2GoRegSafeCurrent     = 87  // Uint16 WR 0.1A
 	em2GoRegCommTimeout     = 89  // Uint16 WR 1s
@@ -60,6 +59,9 @@ const (
 	em2GoRegChargeCommand   = 95  // Uint16 WR ENUM
 	em2GoRegVoltages        = 109 // Uint16 RO 0.1V
 	em2GoRegPhases          = 200 // Set charging phase 1 unsigned
+
+	//removed due to unreliable session energy when pausing or switching phases
+	//em2GoRegChargedEnergy   = 72  // Uint16 RO 0.1kWh
 )
 
 func init() {
@@ -278,18 +280,6 @@ var _ api.PhaseVoltages = (*Em2Go)(nil)
 // Currents implements the api.PhaseVoltages interface
 func (wb *Em2Go) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(em2GoRegVoltages)
-}
-
-var _ api.ChargeRater = (*Em2Go)(nil)
-
-// ChargedEnergy implements the api.ChargeRater interface
-func (wb *Em2Go) ChargedEnergy() (float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(em2GoRegChargedEnergy, 2)
-	if err != nil {
-		return 0, err
-	}
-
-	return float64(binary.BigEndian.Uint16(b)) / 10, nil
 }
 
 var _ api.ChargeTimer = (*Em2Go)(nil)


### PR DESCRIPTION
Session energy is unreliable when resuming paused charging or switching phases. See #19824, #17485