### PR TITLE
Mobile UI: improve small screen layout

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -675,3 +675,10 @@ html.app .modal-dialog {
 input::-webkit-date-and-time-value {
 	text-align: left;
 }
+
+@media (max-width: 576px) {
+	.text-truncate-xs-only {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+}

--- a/assets/js/components/Helper/LabelAndValue.vue
+++ b/assets/js/components/Helper/LabelAndValue.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="root">
-		<div class="mb-2 label" :class="labelClass">
+		<div class="mb-2 label text-truncate-xs-only" :class="labelClass">
 			<slot name="label">{{ label }}</slot>
 		</div>
 		<slot>

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -372,7 +372,9 @@ export default {
 
 .details > div {
 	flex-grow: 1;
+	flex-shrink: 1;
 	flex-basis: 0;
+	min-width: 0;
 }
 .details > div:nth-child(2) {
 	text-align: center;

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -54,7 +54,7 @@
 						:label="$t('main.loadpoint.power')"
 						:value="chargePower"
 						:valueFmt="fmtPower"
-						class="mb-2 text-nowrap"
+						class="mb-2 text-nowrap text-truncate-xs-only"
 						align="start"
 					/>
 					<shopicon-regular-lightning

--- a/assets/js/components/Loadpoints/Mode.vue
+++ b/assets/js/components/Loadpoints/Mode.vue
@@ -71,6 +71,12 @@ export default {
 	color: var(--evcc-default-text);
 	border: none;
 }
+@media (max-width: 576px) {
+	.btn {
+		padding: 0.1em 0.2em;
+	}
+}
+
 .btn:hover {
 	color: var(--evcc-gray);
 }

--- a/assets/js/components/Loadpoints/Mode.vue
+++ b/assets/js/components/Loadpoints/Mode.vue
@@ -4,7 +4,7 @@
 			v-for="m in modes"
 			:key="m"
 			type="button"
-			class="btn flex-grow-1 flex-shrink-1"
+			class="btn flex-grow-1 flex-shrink-1 text-truncate-xs-only"
 			:class="{ active: isActive(m) }"
 			tabindex="0"
 			@click="setTargetMode(m)"

--- a/assets/js/components/Loadpoints/SessionInfo.vue
+++ b/assets/js/components/Loadpoints/SessionInfo.vue
@@ -8,9 +8,12 @@
 					data-testid="sessionInfoSelect"
 					@change="selectOption($event.target.value)"
 				>
-					<span class="text-decoration-underline" data-testid="sessionInfoLabel">
+					<div
+						class="text-decoration-underline text-truncate-xs-only"
+						data-testid="sessionInfoLabel"
+					>
 						{{ label }}
-					</span>
+					</div>
 				</CustomSelect>
 			</template>
 			<template #value>


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/19994

✂️ truncate text on mobile if necessary (small screens, long translations)
🍱 ensure loadpoint values don't outgrow their parent container

Note: Layouts below 320px (or high text-zoom levels) are not supported.

<img width="325" alt="Bildschirmfoto 2025-03-22 um 12 07 16" src="https://github.com/user-attachments/assets/bf18e713-2a8e-4837-a173-683459b1ff66" />

---

<img width="323" alt="Bildschirmfoto 2025-03-22 um 12 08 18" src="https://github.com/user-attachments/assets/fabef2df-97e5-4630-9198-984451ef537c" />

