### PR TITLE
daheimladen-mb: delete identifier

### DIFF
--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -45,7 +45,6 @@ const (
 	dlRegEvseMaxCurrent  = 32  // Uint16 RO 0.1A
 	dlRegCableMaxCurrent = 36  // Uint16 RO 0.1A
 	dlRegStationId       = 38  // Chr[16] RO UTF16
-	dlRegCardId          = 54  // Chr[16] RO UTF16
 	dlRegChargedEnergy   = 72  // Uint16 RO 0.1kWh
 	dlRegChargingTime    = 78  // Uint32 RO 1s
 	dlRegSafeCurrent     = 87  // Uint16 WR 0.1A
@@ -258,17 +257,6 @@ func (wb *DaheimLadenMB) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(dlRegVoltages)
 }
 
-var _ api.Identifier = (*DaheimLadenMB)(nil)
-
-// Identify implements the api.Identifier interface
-func (wb *DaheimLadenMB) Identify() (string, error) {
-	b, err := wb.conn.ReadHoldingRegisters(dlRegCardId, 16)
-	if err != nil {
-		return "", err
-	}
-	return unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewDecoder().String(string(b))
-}
-
 var _ api.Diagnosis = (*DaheimLadenMB)(nil)
 
 // Diagnose implements the api.Diagnosis interface
@@ -292,9 +280,6 @@ func (wb *DaheimLadenMB) Diagnose() {
 	}
 	if b, err := wb.conn.ReadHoldingRegisters(dlRegStationId, 16); err == nil {
 		fmt.Printf("\tStation ID:\t%s\n", utf16BytesToString(b))
-	}
-	if b, err := wb.conn.ReadHoldingRegisters(dlRegCardId, 16); err == nil {
-		fmt.Printf("\tCard ID:\t%s\n", utf16BytesToString(b))
 	}
 	if b, err := wb.conn.ReadHoldingRegisters(dlRegSafeCurrent, 1); err == nil {
 		fmt.Printf("\tSafe Current:\t%.1fA\n", float64(binary.BigEndian.Uint16(b)/10))


### PR DESCRIPTION
Da das noch nie funktioniert hat und in der aktuellen Modbus Doku von DaheimLaden nicht mehr enthalten ist, kann man das auch rauswerfen. Ich hoffe, ich hab nicht zuviel gelöscht.