### PR TITLE
Lambda: start watchdog immediately

### DIFF
--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -42,6 +42,7 @@ render: |
   setmaxpower:
     source: watchdog
     timeout: {{ .watchdog }} # re-write at timeout/2
+    initial: 0
     set:
       source: modbus
       {{- include "modbus" . | indent 4 }}


### PR DESCRIPTION
Watchdog parameter initial is working and tested.

- add initial: 0 to send values after restart to prevent manual switch over a charge mode.

https://github.com/evcc-io/evcc/discussions/19949#discussioncomment-12598930

https://github.com/evcc-io/evcc/pull/20057