### PR TITLE
Http: add  pluggable authentication and token (BC)

### DIFF
--- a/plugin/auth/api.go
+++ b/plugin/auth/api.go
@@ -1,0 +1,7 @@
+package auth
+
+import "net/http"
+
+type Authorizer interface {
+	Transport(base http.RoundTripper) (http.RoundTripper, error)
+}

--- a/plugin/auth/config.go
+++ b/plugin/auth/config.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	reg "github.com/evcc-io/evcc/util/registry"
+)
+
+var registry = reg.New[Authorizer]("auth")
+
+// NewFromConfig creates auth from configuration
+func NewFromConfig(ctx context.Context, typ string, other map[string]any) (Authorizer, error) {
+	factory, err := registry.Get(strings.ToLower(typ))
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := factory(ctx, other)
+	if err != nil {
+		err = fmt.Errorf("cannot create auth type '%s': %w", typ, err)
+	}
+
+	return v, err
+}

--- a/plugin/auth/nop.go
+++ b/plugin/auth/nop.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/evcc-io/evcc/util"
+)
+
+type nop struct{}
+
+func init() {
+	registry.AddCtx("nop", NewNopFromConfig)
+}
+
+func NewNopFromConfig(ctx context.Context, other map[string]any) (Authorizer, error) {
+	var cc struct{}
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	return new(nop), nil
+}
+
+func (p *nop) Transport(base http.RoundTripper) (http.RoundTripper, error) {
+	return base, nil
+}

--- a/plugin/http_auth.go
+++ b/plugin/http_auth.go
@@ -28,22 +28,22 @@ func (p *Auth) Transport(ctx context.Context, base http.RoundTripper) (http.Roun
 	case "digest":
 		return digest.NewTransport(p.User, p.Password, base), nil
 	default:
-		if p.Source != "" {
-			if p.User != "" {
-				p.Other["user"] = p.User
-			}
-			if p.Password != "" {
-				p.Other["password"] = p.Password
-			}
-
-			authorizer, err := auth.NewFromConfig(ctx, p.Source, p.Other)
-			if err != nil {
-				return nil, err
-			}
-
-			return authorizer.Transport(base)
+		if p.Source == "" {
+			return nil, fmt.Errorf("unknown auth type '%s'", p.Type)
 		}
 
-		return nil, fmt.Errorf("unknown auth type '%s'", p.Type)
+		if p.User != "" {
+			p.Other["user"] = p.User
+		}
+		if p.Password != "" {
+			p.Other["password"] = p.Password
+		}
+
+		authorizer, err := auth.NewFromConfig(ctx, p.Source, p.Other)
+		if err != nil {
+			return nil, err
+		}
+
+		return authorizer.Transport(base)
 	}
 }

--- a/plugin/http_auth.go
+++ b/plugin/http_auth.go
@@ -14,8 +14,9 @@ import (
 // Auth is the authorization config
 type Auth struct {
 	Type, User, Password, Token string
-	Source                      string
-	Other                       map[string]any
+
+	Source string
+	Other  map[string]any `mapstructure:",remain"`
 }
 
 func (p *Auth) Transport(ctx context.Context, base http.RoundTripper) (http.RoundTripper, error) {
@@ -28,10 +29,18 @@ func (p *Auth) Transport(ctx context.Context, base http.RoundTripper) (http.Roun
 		return digest.NewTransport(p.User, p.Password, base), nil
 	default:
 		if p.Source != "" {
+			if p.User != "" {
+				p.Other["user"] = p.User
+			}
+			if p.Password != "" {
+				p.Other["password"] = p.Password
+			}
+
 			authorizer, err := auth.NewFromConfig(ctx, p.Source, p.Other)
 			if err != nil {
 				return nil, err
 			}
+
 			return authorizer.Transport(base)
 		}
 

--- a/plugin/http_auth.go
+++ b/plugin/http_auth.go
@@ -21,12 +21,15 @@ type Auth struct {
 
 func (p *Auth) Transport(ctx context.Context, base http.RoundTripper) (http.RoundTripper, error) {
 	switch strings.ToLower(p.Type) {
-	case "basic":
-		return transport.BasicAuth(p.User, p.Password, base), nil
-	case "bearer":
-		return transport.BearerAuth(p.Token, base), nil
 	case "digest":
 		return digest.NewTransport(p.User, p.Password, base), nil
+
+	case "basic":
+		return transport.BasicAuth(p.User, p.Password, base), nil
+
+	case "bearer":
+		return transport.BearerAuth(p.Token, base), nil
+
 	default:
 		if p.Source == "" {
 			return nil, fmt.Errorf("unknown auth type '%s'", p.Type)

--- a/plugin/http_auth.go
+++ b/plugin/http_auth.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/evcc-io/evcc/plugin/auth"
+	"github.com/evcc-io/evcc/util/transport"
+	"github.com/jpfielding/go-http-digest/pkg/digest"
+)
+
+// Auth is the authorization config
+type Auth struct {
+	Type, User, Password, Token string
+	Source                      string
+	Other                       map[string]any
+}
+
+func (p *Auth) Transport(ctx context.Context, base http.RoundTripper) (http.RoundTripper, error) {
+	switch strings.ToLower(p.Type) {
+	case "basic":
+		return transport.BasicAuth(p.User, p.Password, base), nil
+	case "bearer":
+		return transport.BearerAuth(p.Token, base), nil
+	case "digest":
+		return digest.NewTransport(p.User, p.Password, base), nil
+	default:
+		if p.Source != "" {
+			authorizer, err := auth.NewFromConfig(ctx, p.Source, p.Other)
+			if err != nil {
+				return nil, err
+			}
+			return authorizer.Transport(base)
+		}
+
+		return nil, fmt.Errorf("unknown auth type '%s'", p.Type)
+	}
+}

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -29,7 +29,7 @@ render: |
     {{- if .token }}
     auth:
       type: bearer
-      password: {{ .token }}
+      token: {{ .token }}
     insecure: true
     {{- end }}
     cache: {{ .cache }}
@@ -40,7 +40,7 @@ render: |
       {{- if .token }}
       auth:
         type: bearer
-        password: {{ .token }}
+        token: {{ .token }}
       insecure: true
       {{- end }}
       cache: {{ .cache }}
@@ -50,7 +50,7 @@ render: |
       {{- if .token }}
       auth:
         type: bearer
-        password: {{ .token }}
+        token: {{ .token }}
       insecure: true
       {{- end }}
       cache: {{ .cache }}
@@ -60,7 +60,7 @@ render: |
       {{- if .token }}
       auth:
         type: bearer
-        password: {{ .token }}
+        token: {{ .token }}
       insecure: true
       {{- end }}
       cache: {{ .cache }}
@@ -73,7 +73,7 @@ render: |
     {{- if .token }}
     auth:
       type: bearer
-      password: {{ .token }}
+      token: {{ .token }}
     insecure: true
     {{- end }}
     cache: {{ .cache }}
@@ -84,7 +84,7 @@ render: |
     {{- if .token }}
     auth:
       type: bearer
-      password: {{ .token }}
+      token: {{ .token }}
     insecure: true
     {{- end }}
     cache: {{ .cache }}
@@ -96,7 +96,7 @@ render: |
       {{- if .token }}
       auth:
         type: bearer
-        password: {{ .token }}
+        token: {{ .token }}
       insecure: true
       {{- end }}
       cache: {{ .cache }}
@@ -106,7 +106,7 @@ render: |
       {{- if .token }}
       auth:
         type: bearer
-        password: {{ .token }}
+        token: {{ .token }}
       insecure: true
       {{- end }}
       cache: {{ .cache }}
@@ -116,7 +116,7 @@ render: |
       {{- if .token }}
       auth:
         type: bearer
-        password: {{ .token }}
+        token: {{ .token }}
       insecure: true
       {{- end }}
       cache: {{ .cache }}
@@ -129,7 +129,7 @@ render: |
     {{- if .token }}
     auth:
       type: bearer
-      password: {{ .token }}
+      token: {{ .token }}
     insecure: true
     {{- end }}
     cache: {{ .cache }}
@@ -140,7 +140,7 @@ render: |
     {{- if .token }}
     auth:
       type: bearer
-      password: {{ .token }}
+      token: {{ .token }}
     insecure: true
     {{- end }}
     cache: {{ .cache }}


### PR DESCRIPTION
This PR adds the ability to develop and customise authentication plugins. The plugins are useful in combination with templates using the `http` plugin. Making authentication pluggable allows to use templates instead of custom code for configuration integration and using custom code only for authentication purposes where necessary.

Configuration example:

```yaml
power:
  source: http
  uri: https://...
  auth:
    source: viessmann # to be developed
    user: foo
    password: bar
    clientid: baz
```

Additionally, Bearer auth must use `token` now and not `password`:

```yaml
auth:
  type: bearer
  token:  <token>
```
