### PR TITLE
Heating: improve connected status

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -579,6 +579,7 @@ selfConsumption = "Eigenverbrauch"
 
 [main.heatingStatus]
 charging = "Heize …"
+connected = "Standby."
 vehicleLimit = "Heizungslimit"
 waitForVehicle = "Bereit. Warte auf Heizung …"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -579,6 +579,7 @@ selfConsumption = "Self-consumption"
 
 [main.heatingStatus]
 charging = "Heating…"
+connected = "Standby."
 vehicleLimit = "Heater limit"
 waitForVehicle = "Ready. Waiting for heater…"
 


### PR DESCRIPTION
addresses https://github.com/evcc-io/evcc/issues/19753

Show `Standby.` instead of `Connected.` when heating devices is not supposed to run.