### PR TITLE
Polestar: API change reading resume path

### DIFF
--- a/vehicle/polestar/api.go
+++ b/vehicle/polestar/api.go
@@ -2,7 +2,6 @@ package polestar
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
@@ -43,8 +42,7 @@ func (v *API) Vehicles(ctx context.Context) ([]ConsumerCar, error) {
 		GetConsumerCarsV2 []ConsumerCar `graphql:"getConsumerCarsV2"`
 	}
 
-	err := v.client.WithRequestModifier(func(req *http.Request) {
-	}).Query(ctx, &res, nil, graphql.OperationName("getCars"))
+	err := v.client.Query(ctx, &res, nil, graphql.OperationName("getCars"))
 
 	return res.GetConsumerCarsV2, err
 }

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -79,7 +79,7 @@ func (v *Identity) login() (*oauth2.Token, error) {
 	// Request authorization URL with browser-like headers
 	uri := fmt.Sprintf("%s/as/authorization.oauth2?%s", OAuthURI, data.Encode())
 	req, _ := request.New(http.MethodGet, uri, nil, map[string]string{
-		"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+		"Accept": "text/html,application/xhtml+xml,application/xml;",
 	})
 
 	resp, err := v.Do(req)

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -93,25 +93,20 @@ func (v *Identity) login() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	htmlContent := string(body)
-	re := regexp.MustCompile(`url: "(/as/[^/]+)/resume/as/authorization\.ping"`)
-	matches := re.FindStringSubmatch(htmlContent)
-
+	matches := regexp.MustCompile(`url:\s*"/as/(.*?)/resume/as/authorization\.ping"`).FindStringSubmatch(string(body))
 	if len(matches) < 2 {
 		return nil, errors.New("could not find resume path")
 	}
 
-	resumePath := strings.TrimPrefix(matches[1], "/as/")
-
 	// Submit credentials to login endpoint
-	loginURL := fmt.Sprintf("%s/as/%s/resume/as/authorization.ping", OAuthURI, resumePath)
 	data = url.Values{
 		"pf.username": {v.user},
 		"pf.pass":     {v.password},
 		"client_id":   {ClientID},
 	}
 
-	req, _ = request.New(http.MethodPost, loginURL, strings.NewReader(data.Encode()), map[string]string{
+	uri = fmt.Sprintf("%s/as/%s/resume/as/authorization.ping", OAuthURI, matches[1])
+	req, _ = request.New(http.MethodPost, uri, strings.NewReader(data.Encode()), map[string]string{
 		"Content-Type": "application/x-www-form-urlencoded",
 		"Accept":       "application/json",
 	})

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -56,12 +56,6 @@ func NewIdentity(log *util.Logger, user, password string) (*Identity, error) {
 	}
 	v.token = token
 
-	// Use the Identity itself as token source for automatic refresh
-	v.Client.Transport = &oauth2.Transport{
-		Source: v.TokenSource(),
-		Base:   v.Client.Transport,
-	}
-
 	return v, nil
 }
 

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -157,14 +157,6 @@ func (v *Identity) login() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	// Configure transport for API requests
-	v.Client.Transport = &oauth2.Transport{
-		Source: oauth2.StaticTokenSource(&token),
-		Base: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		},
-	}
-
 	return util.TokenWithExpiry(&token), nil
 }
 

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -93,7 +93,7 @@ func (v *Identity) login() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	matches := regexp.MustCompile(`url:\s*"/as/(.*?)/resume/as/authorization\.ping"`).FindStringSubmatch(string(body))
+	matches := regexp.MustCompile(`url:\s*"/as/(.+?)/resume/as/authorization\.ping"`).FindStringSubmatch(string(body))
 	if len(matches) < 2 {
 		return nil, errors.New("could not find resume path")
 	}

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -84,14 +84,14 @@ func (v *Identity) login() (*oauth2.Token, error) {
 
 	resp, err := v.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("initial request failed: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	// Extract resume path from HTML response
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return nil, err
 	}
 
 	htmlContent := string(body)
@@ -107,7 +107,7 @@ func (v *Identity) login() (*oauth2.Token, error) {
 	}
 
 	if resumePath == "" {
-		return nil, errors.New("could not find resume path in response")
+		return nil, errors.New("could not find resume path")
 	}
 
 	// Submit credentials to login endpoint
@@ -125,7 +125,7 @@ func (v *Identity) login() (*oauth2.Token, error) {
 
 	resp, err = v.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("login request failed: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -153,9 +153,8 @@ func (v *Identity) login() (*oauth2.Token, error) {
 		},
 	)
 
-	err = v.DoJSON(req, &token)
-	if err != nil {
-		return nil, fmt.Errorf("token exchange failed: %w", err)
+	if err := v.DoJSON(req, &token); err != nil {
+		return nil, err
 	}
 
 	// Configure transport for API requests

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -49,14 +49,16 @@ func NewIdentity(log *util.Logger, user, password string) (*Identity, error) {
 	}
 	v.Client.Jar = jar
 
+	// Get initial token
 	token, err := v.login()
 	if err != nil {
 		return nil, err
 	}
 	v.token = token
 
+	// Use the Identity itself as token source for automatic refresh
 	v.Client.Transport = &oauth2.Transport{
-		Source: oauth2.StaticTokenSource(token),
+		Source: v.TokenSource(),
 		Base:   v.Client.Transport,
 	}
 


### PR DESCRIPTION
Polestar has changed the way how you have to connect to the API again. We now read the required resume path from the HTML body. I also added some logic for the auth token handling.

This should fix https://github.com/evcc-io/evcc/issues/20070