### PR TITLE
chore: playwright stability charger/meter modal refactor

### DIFF
--- a/assets/js/components/Config/ChargerModal.vue
+++ b/assets/js/components/Config/ChargerModal.vue
@@ -1,6 +1,7 @@
 <template>
 	<GenericModal
 		id="chargerModal"
+		ref="modal"
 		:title="modalTitle"
 		data-testid="charger-modal"
 		:fade="fade"
@@ -375,8 +376,7 @@ export default {
 				const response = await api.post("config/devices/charger", this.apiData);
 				const { name } = response.data.result;
 				this.$emit("added", name);
-				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				this.handleCreateError(e);
 			}
@@ -402,7 +402,7 @@ export default {
 			try {
 				await api.put(`config/devices/charger/${this.id}`, this.apiData);
 				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				this.handleUpdateError(e);
 			}
@@ -412,8 +412,7 @@ export default {
 			try {
 				await api.delete(`config/devices/charger/${this.id}`);
 				this.$emit("removed", this.name);
-				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				this.handleRemoveError(e);
 			}

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -722,7 +722,6 @@ export default {
 	},
 	methods: {
 		reset() {
-			console.log("loadpoint modal reset");
 			this.values = deepClone(defaultValues);
 			this.updatePhases();
 		},
@@ -764,15 +763,10 @@ export default {
 		async create() {
 			this.saving = true;
 			try {
-				console.log("loadpoint modal create 1");
 				await api.post("config/loadpoints", this.values);
-				console.log("loadpoint modal create 2");
 				this.$emit("updated");
-				console.log("loadpoint modal create 3");
 				this.$refs.modal.close();
-				console.log("loadpoint modal create 4");
 				this.reset();
-				console.log("loadpoint modal create 5");
 			} catch (e) {
 				console.error(e);
 				const error = e.response?.data?.error;
@@ -787,10 +781,8 @@ export default {
 			this.$emit("opened");
 		},
 		onClose() {
-			console.log("LoadpointModal: onClose >");
 			this.showAllSelected = false;
 			this.isModalVisible = false;
-			console.log("LoadpointModal: onClose <");
 		},
 		editCharger() {
 			this.$emit("openChargerModal", this.values.charger);

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -744,7 +744,7 @@ export default {
 				const values = deepClone(this.values);
 				await api.put(`config/loadpoints/${this.id}`, values);
 				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				console.error(e);
 				alert("update failed");
@@ -755,7 +755,7 @@ export default {
 			try {
 				await api.delete(`config/loadpoints/${this.id}`);
 				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				console.error(e);
 				alert("delete failed");
@@ -769,7 +769,7 @@ export default {
 				console.log("loadpoint modal create 2");
 				this.$emit("updated");
 				console.log("loadpoint modal create 3");
-				this.close();
+				this.$refs.modal.close();
 				console.log("loadpoint modal create 4");
 				this.reset();
 				console.log("loadpoint modal create 5");
@@ -787,11 +787,10 @@ export default {
 			this.$emit("opened");
 		},
 		onClose() {
+			console.log("loadpoint modal onClose start");
 			this.showAllSelected = false;
 			this.isModalVisible = false;
-		},
-		close() {
-			this.$refs.modal.close();
+			this.$emit("loadpoint modal onClose end");
 		},
 		editCharger() {
 			this.$emit("openChargerModal", this.values.charger);

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -790,7 +790,7 @@ export default {
 			console.log("loadpoint modal onClose start");
 			this.showAllSelected = false;
 			this.isModalVisible = false;
-			this.$emit("loadpoint modal onClose end");
+			console.log("loadpoint modal onClose end");
 		},
 		editCharger() {
 			this.$emit("openChargerModal", this.values.charger);

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -787,10 +787,10 @@ export default {
 			this.$emit("opened");
 		},
 		onClose() {
-			console.log("loadpoint modal onClose start");
+			console.log("LoadpointModal: onClose >");
 			this.showAllSelected = false;
 			this.isModalVisible = false;
-			console.log("loadpoint modal onClose end");
+			console.log("LoadpointModal: onClose <");
 		},
 		editCharger() {
 			this.$emit("openChargerModal", this.values.charger);

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -763,9 +763,9 @@ export default {
 			this.saving = true;
 			try {
 				await api.post("config/loadpoints", this.values);
-				this.reset();
 				this.$emit("updated");
 				this.close();
+				this.reset();
 			} catch (e) {
 				console.error(e);
 				const error = e.response?.data?.error;

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -722,10 +722,12 @@ export default {
 	},
 	methods: {
 		reset() {
+			console.log("loadpoint modal reset");
 			this.values = deepClone(defaultValues);
 			this.updatePhases();
 		},
 		async loadConfiguration() {
+			console.log("loadpoint modal loadConfiguration");
 			try {
 				const res = await api.get(`config/loadpoints/${this.id}`);
 				this.values = deepClone(res.data.result);
@@ -762,10 +764,15 @@ export default {
 		async create() {
 			this.saving = true;
 			try {
+				console.log("loadpoint modal create 1");
 				await api.post("config/loadpoints", this.values);
+				console.log("loadpoint modal create 2");
 				this.$emit("updated");
+				console.log("loadpoint modal create 3");
 				this.close();
+				console.log("loadpoint modal create 4");
 				this.reset();
+				console.log("loadpoint modal create 5");
 			} catch (e) {
 				console.error(e);
 				const error = e.response?.data?.error;

--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -1,6 +1,7 @@
 <template>
 	<GenericModal
 		id="meterModal"
+		ref="modal"
 		:title="modalTitle"
 		data-testid="meter-modal"
 		:fade="fade"
@@ -430,8 +431,7 @@ export default {
 				const response = await api.post("config/devices/meter", this.apiData);
 				const { name } = response.data.result;
 				this.$emit("added", this.meterType, name);
-				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				this.handleCreateError(e);
 			}
@@ -457,7 +457,7 @@ export default {
 			try {
 				await api.put(`config/devices/meter/${this.id}`, this.apiData);
 				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				this.handleUpdateError(e);
 			}
@@ -467,8 +467,7 @@ export default {
 			try {
 				await api.delete(`config/devices/meter/${this.id}`);
 				this.$emit("removed", this.meterType, this.name);
-				this.$emit("updated");
-				this.close();
+				this.$refs.modal.close();
 			} catch (e) {
 				this.handleRemoveError(e);
 			}

--- a/assets/js/components/Helper/GenericModal.vue
+++ b/assets/js/components/Helper/GenericModal.vue
@@ -114,13 +114,17 @@ export default {
 		},
 		open() {
 			console.log("GenericModal: open >", this.id);
-			Modal.getOrCreateInstance(this.$refs.modal).show();
-			console.log("GenericModal: open <", this.id);
+			this.$nextTick(() => {
+				Modal.getOrCreateInstance(this.$refs.modal).show();
+				console.log("GenericModal: open <", this.id);
+			});
 		},
 		close() {
 			console.log("GenericModal: close >", this.id);
-			Modal.getOrCreateInstance(this.$refs.modal).hide();
-			console.log("GenericModal: close <", this.id);
+			this.$nextTick(() => {
+				Modal.getOrCreateInstance(this.$refs.modal).hide();
+				console.log("GenericModal: close <", this.id);
+			});
 		},
 	},
 };

--- a/assets/js/components/Helper/GenericModal.vue
+++ b/assets/js/components/Helper/GenericModal.vue
@@ -102,17 +102,25 @@ export default {
 			this.isModalVisible = true;
 		},
 		handleHide() {
+			console.log("GenericModal: hide >", this.id);
 			this.$emit("close");
+			console.log("GenericModal: hide <", this.id);
 		},
 		handleHidden() {
+			console.log("GenericModal: hidden >", this.id);
 			this.$emit("closed");
 			this.isModalVisible = false;
+			console.log("GenericModal: hidden <", this.id);
 		},
 		open() {
+			console.log("GenericModal: open >", this.id);
 			Modal.getOrCreateInstance(this.$refs.modal).show();
+			console.log("GenericModal: open <", this.id);
 		},
 		close() {
+			console.log("GenericModal: close >", this.id);
 			Modal.getOrCreateInstance(this.$refs.modal).hide();
+			console.log("GenericModal: close <", this.id);
 		},
 	},
 };

--- a/assets/js/components/Helper/GenericModal.vue
+++ b/assets/js/components/Helper/GenericModal.vue
@@ -109,14 +109,13 @@ export default {
 			this.isModalVisible = false;
 		},
 		open() {
-			this.$nextTick(() => {
-				Modal.getOrCreateInstance(this.$refs.modal).show();
-			});
+			Modal.getOrCreateInstance(this.$refs.modal).show();
 		},
 		close() {
-			this.$nextTick(() => {
-				Modal.getOrCreateInstance(this.$refs.modal).hide();
-			});
+			Modal.getOrCreateInstance(this.$refs.modal).hide();
+			// should not be needed, however, playwright in github actions sometimes does not trigger `hide[en].bs.modal` event
+			this.handleHide();
+			this.handleHidden();
 		},
 	},
 };

--- a/assets/js/components/Helper/GenericModal.vue
+++ b/assets/js/components/Helper/GenericModal.vue
@@ -102,28 +102,20 @@ export default {
 			this.isModalVisible = true;
 		},
 		handleHide() {
-			console.log("GenericModal: hide >", this.id);
 			this.$emit("close");
-			console.log("GenericModal: hide <", this.id);
 		},
 		handleHidden() {
-			console.log("GenericModal: hidden >", this.id);
 			this.$emit("closed");
 			this.isModalVisible = false;
-			console.log("GenericModal: hidden <", this.id);
 		},
 		open() {
-			console.log("GenericModal: open >", this.id);
 			this.$nextTick(() => {
 				Modal.getOrCreateInstance(this.$refs.modal).show();
-				console.log("GenericModal: open <", this.id);
 			});
 		},
 		close() {
-			console.log("GenericModal: close >", this.id);
 			this.$nextTick(() => {
 				Modal.getOrCreateInstance(this.$refs.modal).hide();
-				console.log("GenericModal: close <", this.id);
 			});
 		},
 	},

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -345,9 +345,9 @@
 					:type="selectedMeterType"
 					:typeChoices="selectedMeterTypeChoices"
 					:fade="loadpointSubModalOpen ? 'right' : ''"
-					@added="addMeter"
+					@added="meterAdded"
 					@updated="meterChanged"
-					@removed="removeMeter"
+					@removed="meterRemoved"
 					@close="meterModalClosed"
 				/>
 				<ChargerModal
@@ -355,9 +355,9 @@
 					:name="selectedChargerName"
 					:fade="loadpointSubModalOpen ? 'right' : ''"
 					:isSponsor="isSponsor"
-					@added="addCharger"
+					@added="chargerAdded"
 					@updated="chargerChanged"
-					@removed="removeCharger"
+					@removed="chargerRemoved"
 					@close="chargerModalClosed"
 				/>
 				<InfluxModal @changed="loadDirty" />
@@ -618,7 +618,7 @@ export default {
 			await this.loadLoadpoints();
 			await this.loadCircuits();
 			await this.loadDirty();
-			await this.updateValues();
+			this.updateValues();
 		},
 		async loadDirty() {
 			const response = await api.get("/config/dirty");
@@ -738,15 +738,13 @@ export default {
 		},
 		async meterChanged() {
 			await this.loadMeters();
-			this.meterModal().hide();
 			await this.loadDirty();
-			await this.updateValues();
+			this.updateValues();
 		},
 		async chargerChanged() {
 			await this.loadChargers();
-			this.chargerModal().hide();
 			await this.loadDirty();
-			await this.updateValues();
+			this.updateValues();
 		},
 		editLoadpoint(id) {
 			this.selectedLoadpointId = id;
@@ -782,7 +780,7 @@ export default {
 		yamlChanged() {
 			this.loadDirty();
 		},
-		addMeter(type, name) {
+		meterAdded(type, name) {
 			if (type === "charge") {
 				// update loadpoint
 				this.$refs.loadpointModal?.setMeter(name);
@@ -798,8 +796,9 @@ export default {
 				this.site[type].push(name);
 				this.saveSite(type);
 			}
+			this.meterChanged();
 		},
-		removeMeter(type) {
+		meterRemoved(type) {
 			if (type === "charge") {
 				// update loadpoint
 				this.$refs.loadpointModal?.setMeter(undefined);
@@ -808,12 +807,15 @@ export default {
 				this.loadSite();
 				this.loadDirty();
 			}
+			this.meterChanged();
 		},
-		addCharger(name) {
+		chargerAdded(name) {
 			this.$refs.loadpointModal?.setCharger(name);
+			this.chargerChanged();
 		},
-		removeCharger() {
+		chargerRemoved() {
 			this.$refs.loadpointModal?.setCharger(undefined);
+			this.chargerChanged();
 		},
 		meterModalClosed() {
 			if (this.selectedMeterType === "charge") {
@@ -830,7 +832,7 @@ export default {
 			await api.put("/config/site", body);
 			await this.loadSite();
 			await this.loadDirty();
-			await this.updateValues();
+			this.updateValues();
 		},
 		todo() {
 			alert("not implemented yet");

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -757,7 +757,6 @@ export default {
 		async loadpointChanged() {
 			this.selectedLoadpointId = undefined;
 			await this.loadLoadpoints();
-			this.loadpointModal().hide();
 			this.loadDirty();
 		},
 		editVehicle(id) {
@@ -809,9 +808,9 @@ export default {
 			}
 			this.meterChanged();
 		},
-		chargerAdded(name) {
+		async chargerAdded(name) {
+			await this.chargerChanged();
 			this.$refs.loadpointModal?.setCharger(name);
-			this.chargerChanged();
 		},
 		chargerRemoved() {
 			this.$refs.loadpointModal?.setCharger(undefined);

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -651,10 +651,8 @@ export default {
 			}
 		},
 		async loadLoadpoints() {
-			console.log("loadLoadpoints: start", this.loadpoints.length);
 			const response = await api.get("/config/loadpoints");
 			this.loadpoints = response.data?.result || [];
-			console.log("loadLoadpoints: end", this.loadpoints.length);
 		},
 		getMetersByNames(names) {
 			if (!names || !this.meters) {
@@ -757,12 +755,9 @@ export default {
 			this.$nextTick(() => this.loadpointModal().show());
 		},
 		async loadpointChanged() {
-			console.log("loadpointChanged: 1");
 			this.selectedLoadpointId = undefined;
 			await this.loadLoadpoints();
-			console.log("loadpointChanged: 2");
 			this.loadDirty();
-			console.log("loadpointChanged: 3");
 		},
 		editVehicle(id) {
 			this.selectedVehicleId = id;
@@ -814,11 +809,8 @@ export default {
 			this.meterChanged();
 		},
 		async chargerAdded(name) {
-			console.log("chargerAdded: 1");
 			await this.chargerChanged();
-			console.log("chargerAdded: 2");
 			this.$refs.loadpointModal?.setCharger(name);
-			console.log("chargerAdded: 3");
 		},
 		chargerRemoved() {
 			this.$refs.loadpointModal?.setCharger(undefined);

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -651,8 +651,10 @@ export default {
 			}
 		},
 		async loadLoadpoints() {
+			console.log("loadLoadpoints: start", this.loadpoints.length);
 			const response = await api.get("/config/loadpoints");
 			this.loadpoints = response.data?.result || [];
+			console.log("loadLoadpoints: end", this.loadpoints.length);
 		},
 		getMetersByNames(names) {
 			if (!names || !this.meters) {
@@ -755,9 +757,12 @@ export default {
 			this.$nextTick(() => this.loadpointModal().show());
 		},
 		async loadpointChanged() {
+			console.log("loadpointChanged: 1");
 			this.selectedLoadpointId = undefined;
 			await this.loadLoadpoints();
+			console.log("loadpointChanged: 2");
 			this.loadDirty();
+			console.log("loadpointChanged: 3");
 		},
 		editVehicle(id) {
 			this.selectedVehicleId = id;
@@ -809,8 +814,11 @@ export default {
 			this.meterChanged();
 		},
 		async chargerAdded(name) {
+			console.log("chargerAdded: 1");
 			await this.chargerChanged();
+			console.log("chargerAdded: 2");
 			this.$refs.loadpointModal?.setCharger(name);
+			console.log("chargerAdded: 3");
 		},
 		chargerRemoved() {
 			this.$refs.loadpointModal?.setCharger(undefined);


### PR DESCRIPTION
improve pipeline stability

- consistant naming
- move modal closing logic into modal
- avoid redundant events

This PR probably does not fix the root cause which seems to be that bootstraps `modal.hide()` gets correctly called but does not seem to have an effect (layer still visible, hide/hidden events not thrown). This does not happen locally (even in playwright).