### PR TITLE
sungrow-hybrid: fix maxchargepower. Cannot create meter battery could…

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -189,7 +189,9 @@ render: |
               decode: uint16
         # Reset max battery discharge power
         - source: const
-          value: {{- if .maxchargepower }}{{ .maxchargepower }}{{ else }} 1060 # 10.6kW, max allowed value for register {{ end }}
+          {{- if .maxchargepower }}
+          value: {{ .maxchargepower }}
+          {{ else }}value: 1060 # 10.6kW, max allowed value for register {{ end }}
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -191,7 +191,9 @@ render: |
         - source: const
           {{- if .maxchargepower }}
           value: {{ .maxchargepower }}
-          {{ else }}value: 1060 # 10.6kW, max allowed value for register {{ end }}
+          {{ else }}
+          value: 1060 # 10.6kW, max allowed value for register
+          {{ end }}
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -191,9 +191,9 @@ render: |
         - source: const
           {{- if .maxchargepower }}
           value: {{ .maxchargepower }}
-          {{ else }}
+          {{- else }}
           value: 1060 # 10.6kW, max allowed value for register
-          {{ end }}
+          {{- end }}
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/20150, fix https://github.com/evcc-io/evcc/issues/20134

Fixed FATAL Error with maxchargepower

```
FATAL 2025/03/26 21:23:03 meter [battery3] cannot create meter 'battery3': cannot create meter type 'template': yaml: line 102: could not find expected ':':
```


 