### PR TITLE
Add Param Choice to Docs

### DIFF
--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -7,9 +7,12 @@
   {{- $choice := .Choice }}
 
   {{- if or (not .IsRequired) $help $choice }} #
-    {{- if $help }} {{ $help }}{{- end }}
+    {{- if not .IsRequired }} optional{{- end }}
+    {{- if $help }}
+      {{- if not .IsRequired }};{{- end }} {{ $help }}
+    {{- end }}
     {{- if $choice }}
-      {{- if $help }} ;{{- end }}
+      {{- if or (not .IsRequired) $help }};{{- end }}
       {{- if kindIs "string" $choice }}
         {{- if regexMatch "^[0-9]+$" $choice }} Choices: {{ $choice }} {{- else }} Choices: "{{ $choice }}" {{- end }}
       {{- else if kindIs "slice" $choice }} Choices: {{ range $index, $element := $choice }}{{ if $index }}, {{ end }}{{- if kindIs "string" $element }}

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -4,8 +4,22 @@
   - {{ . }}
   {{- end }}
   {{- $help := localize .Help | replace "\n" " " -}}
-  {{- if $help }} # {{ $help }}{{- end }}{{- if not .IsRequired }}{{ if not $help }} # {{ else }} ({{ end }}optional{{ if $help }}){{ end }}{{ end }}
+  {{- $choice := .Choice }}
+
+  {{- if or (not .IsRequired) $help $choice }} #
+    {{- if $help }} {{ $help }}{{- end }}
+    {{- if $choice }}
+      {{- if $help }} ;{{- end }}
+      {{- if kindIs "string" $choice }}
+        {{- if regexMatch "^[0-9]+$" $choice }} Choices: {{ $choice }} {{- else }} Choices: "{{ $choice }}" {{- end }}
+      {{- else if kindIs "slice" $choice }} Choices: {{ range $index, $element := $choice }}{{ if $index }}, {{ end }}{{- if kindIs "string" $element }}
+          {{- if regexMatch "^[0-9]+$" $element }}{{ $element }}{{- else }}"{{ $element }}"{{ end }}
+        {{- else }}{{ $element }}{{- end }}{{ end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
+
 
 {{- define "header" }}
   type: template


### PR DESCRIPTION
Parameter Typ Choice werden in den Docs berücksichtigt (Darstellung im Kommentar)
Aufbau:
'# <optional> ; <helptext> ; <choices>'
Bei Choices werden Texte in "" gesetzt und Zahlen ohne dargestellt (trenner bei mehreren Choices ist , )
<img width="389" alt="image" src="https://github.com/user-attachments/assets/5228bdd0-174b-4f0a-819c-524d1acd2048" />
<img width="673" alt="image" src="https://github.com/user-attachments/assets/93fb7b15-7ffc-4646-b613-b50e9ee520c7" />
