### PR TITLE
use Go 1.23 to avoid issues with new Map implementation in Go 1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 			"nvmVersion": "latest"
 		},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "latest"
+			"version": "1.23"
 		}
 	},
 	"postCreateCommand": "make install-ui && make install",


### PR DESCRIPTION
using "latest" I could not get the devcontainer to work. make install failed.