### PR TITLE
UI: rename aux icon to smartconsumer (BC)

### DIFF
--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -198,7 +198,7 @@ function sleep(ms) {
 const CUSTOM_FIELDS = ["usage", "modbus"];
 
 const defaultIcons = {
-	aux: "aux",
+	aux: "smartconsumer",
 	ext: "meter",
 };
 

--- a/assets/js/components/VehicleIcon/SmartConsumer.vue
+++ b/assets/js/components/VehicleIcon/SmartConsumer.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-	name: "Aux",
+	name: "SmartConsumer",
 };
 </script>

--- a/assets/js/components/VehicleIcon/VehicleIcon.stories.js
+++ b/assets/js/components/VehicleIcon/VehicleIcon.stories.js
@@ -2,7 +2,6 @@ import VehicleIcon from "./VehicleIcon.vue";
 
 const icons = [
   "car",
-  "aux",
   "bike",
   "bus",
   "moped",
@@ -36,6 +35,7 @@ const icons = [
   "laundry2",
   "machine",
   "meter",
+  "smartconsumer",
   "microwave",
   "pump",
   "tool",

--- a/assets/js/components/VehicleIcon/VehicleIcon.vue
+++ b/assets/js/components/VehicleIcon/VehicleIcon.vue
@@ -8,7 +8,6 @@ import "@h2d2/shopicons/es/regular/car3";
 import MultiIcon from "../MultiIcon";
 
 import airpurifier from "./Airpurifier.vue";
-import aux from "./Aux.vue";
 import battery from "./Battery.vue";
 import bike from "./Bike.vue";
 import bulb from "./Bulb.vue";
@@ -40,6 +39,7 @@ import rickshaw from "./Rickshaw.vue";
 import rocket from "./Rocket.vue";
 import scooter from "./Scooter.vue";
 import shuttle from "./Shuttle.vue";
+import smartconsumer from "./SmartConsumer.vue";
 import taxi from "./Taxi.vue";
 import tool from "./Tool.vue";
 import tractor from "./Tractor.vue";
@@ -48,7 +48,6 @@ import waterheater from "./WaterHeater.vue";
 
 const icons = {
 	airpurifier,
-	aux,
 	battery,
 	bike,
 	bulb,
@@ -81,6 +80,7 @@ const icons = {
 	rocket,
 	scooter,
 	shuttle,
+	smartconsumer,
 	taxi,
 	tool,
 	tractor,

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -193,7 +193,7 @@
 							@edit="editMeter(meter.id, 'aux')"
 						>
 							<template #icon>
-								<VehicleIcon :name="meter.deviceIcon || 'aux'" />
+								<VehicleIcon :name="meter.deviceIcon || 'smartconsumer'" />
 							</template>
 							<template #tags>
 								<DeviceTags :tags="deviceTags('meter', meter.name)" />

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -269,6 +269,7 @@ params:
       - meter
       - microwave
       - pump
+      - smartconsumer
       - tool
       - waterheater
 


### PR DESCRIPTION
for Windows compatibility 

fixes https://github.com/evcc-io/evcc/issues/20213

Use `smartconsumer` instead of `aux` name for icon, which is a clearer name anyways.

**Breaking Change (tiny)**
Users who've previously added an aux meter via UI and went with the standard icon may have to update their selection.

<img width="613" alt="Bildschirmfoto 2025-03-28 um 12 06 19" src="https://github.com/user-attachments/assets/bbb55082-1a46-42bd-80c1-8500b3d307f3" />
