### PR TITLE
Skoda: handle missing limit soc

### DIFF
--- a/vehicle/skoda/provider.go
+++ b/vehicle/skoda/provider.go
@@ -128,7 +128,10 @@ var _ api.SocLimiter = (*Provider)(nil)
 func (v *Provider) GetLimitSoc() (int64, error) {
 	res, err := v.chargerG()
 	if err == nil {
-		return int64(res.Settings.TargetStateOfChargeInPercent), nil
+		if res.Settings.TargetStateOfChargeInPercent == nil {
+			return 0, api.ErrNotAvailable
+		}
+		return int64(*res.Settings.TargetStateOfChargeInPercent), nil
 	}
 
 	return 0, err

--- a/vehicle/skoda/types.go
+++ b/vehicle/skoda/types.go
@@ -62,7 +62,7 @@ type ChargerResponse struct {
 type SettingsResponse struct {
 	AutoUnlockPlugWhenCharged    string `json:"autoUnlockPlugWhenCharged"`
 	MaxChargeCurrentAc           string `json:"maxChargeCurrentAc"`
-	TargetStateOfChargeInPercent int    `json:"targetStateOfChargeInPercent"`
+	TargetStateOfChargeInPercent *int   `json:"targetStateOfChargeInPercent"`
 }
 
 // ChargerResponse is the /v2/air-conditioning/<vin> api


### PR DESCRIPTION
Settings.TargetStateOfChargeInPercent is not available for all vehicles, this leads to remaining charge time beeing not available. Resolves https://github.com/evcc-io/evcc/discussions/19621