### PR TITLE
Loadpoint: limit released power to available excess

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1354,16 +1354,14 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	// calculate target charge current from delta power and actual current
 	activePhases := lp.ActivePhases()
 	effectiveCurrent := lp.effectiveCurrent()
-
-	switch {
-	case scaledTo == 3:
+	if scaledTo == 3 {
 		// if we did scale, adjust the effective current to the new phase count
 		effectiveCurrent /= 3.0
-	case lp.chargerHasFeature(api.IntegratedDevice):
-		// especially for slow-acting heating devices, only take actually consumed power into account
+	}
+	if lp.chargerHasFeature(api.IntegratedDevice) {
+		// for slow-acting heating devices, only take actually consumed power into account
 		effectiveCurrent = powerToCurrent(lp.chargePower, activePhases)
 	}
-
 	deltaCurrent := powerToCurrent(-sitePower, activePhases)
 	targetCurrent := max(effectiveCurrent+deltaCurrent, 0)
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1354,10 +1354,16 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	// calculate target charge current from delta power and actual current
 	activePhases := lp.ActivePhases()
 	effectiveCurrent := lp.effectiveCurrent()
-	if scaledTo == 3 {
+
+	switch {
+	case scaledTo == 3:
 		// if we did scale, adjust the effective current to the new phase count
 		effectiveCurrent /= 3.0
+	case lp.chargerHasFeature(api.IntegratedDevice):
+		// especially for slow-acting heating devices, only take actually consumed power into account
+		effectiveCurrent = powerToCurrent(lp.chargePower, activePhases)
 	}
+
 	deltaCurrent := powerToCurrent(-sitePower, activePhases)
 	targetCurrent := max(effectiveCurrent+deltaCurrent, 0)
 


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/discussions/19384, https://github.com/evcc-io/evcc/discussions/19677, https://github.com/evcc-io/evcc/discussions/20179, insbesondere https://github.com/evcc-io/evcc/discussions/19677#discussioncomment-12677186.

Note: selbst wenn evcc nur den exakten Überschuss schreibt ist das im Allgemeinen immer noch nicht "richtig". Denn es kann durchaus >1 Gerät geben das träge ist und Überschuss konsumieren möchte. Es gibt aktuell keinen Balancing Algorithmus der Überschuss aufteilen würde sondern nur first come, first serve.

Fazit: https://github.com/evcc-io/evcc/discussions/19677#discussioncomment-12687405