### PR TITLE
tariff/octopus: Fix improper template render to struct

### DIFF
--- a/templates/definition/tariff/octopus-api.yaml
+++ b/templates/definition/tariff/octopus-api.yaml
@@ -17,4 +17,4 @@ params:
       generic: "Octopus Energy API Key."
 render: |
   type: octopusenergy
-  apikey: {{ .apikey }}
+  apikey: {{ .apiKey }}


### PR DESCRIPTION
Closes #20298

... who knows why this broke, it's just a single character typo