### PR TITLE
Modbus: simplify TCP error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,6 +218,6 @@ tool (
 
 replace gopkg.in/yaml.v3 => github.com/andig/yaml v0.0.0-20240531135838-1ff5761ab467
 
-replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250326091001-7af143daf9d2
+replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250402165410-47f372320886
 
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20250322092544-c0c6094051c0

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6/go.mod h1:Bsz
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/evcc-io/modbus v0.0.0-20250326091001-7af143daf9d2 h1:i8arG7Vk3Vr4J6QdMBfxqPPtrmrcgj0fI7Flt1NB7Do=
-github.com/evcc-io/modbus v0.0.0-20250326091001-7af143daf9d2/go.mod h1:swrNGAVgI1r/3d/sEKE7qgujdRR9aHVPYKyc3gvpVTc=
+github.com/evcc-io/modbus v0.0.0-20250402165410-47f372320886 h1:TdAzEBy44eA4DVtd5TlYWidBy2R0MX8ehuqyVGmT8kg=
+github.com/evcc-io/modbus v0.0.0-20250402165410-47f372320886/go.mod h1:swrNGAVgI1r/3d/sEKE7qgujdRR9aHVPYKyc3gvpVTc=
 github.com/evcc-io/ocpp-go v0.0.0-20250322092544-c0c6094051c0 h1:Qz34Pm1Wr05jjJia5g2On3zRqdZh+BLTwqHgJGsiIh4=
 github.com/evcc-io/ocpp-go v0.0.0-20250322092544-c0c6094051c0/go.mod h1:2kcukDdhui4u730VfnYVWuwzDLgw+mBRGDir/QAyBhg=
 github.com/evcc-io/rct v0.1.2-0.20250315164247-d2f41b161785 h1:OWCBVMcPsVTffdiZN3VYaq9p4fsWlzd490J6pekaKLA=


### PR DESCRIPTION
Based on https://github.com/grid-x/modbus/issues/97. Depends on https://github.com/evcc-io/modbus/pull/14.