### PR TITLE
Loadpoint: when scaling phases take vehicle into account for target current

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1356,7 +1356,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	effectiveCurrent := lp.effectiveCurrent()
 	if scaledTo == 3 {
 		// if we did scale, adjust the effective current to the new phase count
-		effectiveCurrent /= 3.0
+		effectiveCurrent /= lp.MaxActivePhases()
 	}
 	if lp.chargerHasFeature(api.IntegratedDevice) {
 		// for slow-acting heating devices, only take actually consumed power into account

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1356,7 +1356,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	effectiveCurrent := lp.effectiveCurrent()
 	if scaledTo == 3 {
 		// if we did scale, adjust the effective current to the new phase count
-		effectiveCurrent /= lp.MaxActivePhases()
+		effectiveCurrent /= (float64)lp.MaxActivePhases()
 	}
 	if lp.chargerHasFeature(api.IntegratedDevice) {
 		// for slow-acting heating devices, only take actually consumed power into account

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1356,7 +1356,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	effectiveCurrent := lp.effectiveCurrent()
 	if scaledTo == 3 {
 		// if we did scale, adjust the effective current to the new phase count
-		effectiveCurrent /= (float64)lp.MaxActivePhases()
+		effectiveCurrent /= float64(lp.maxActivePhases())
 	}
 	if lp.chargerHasFeature(api.IntegratedDevice) {
 		// for slow-acting heating devices, only take actually consumed power into account

--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -111,6 +111,7 @@ func (lp *Loadpoint) minActivePhases() int {
 	if lp.hasPhaseSwitching() || lp.phasesConfigured == 1 {
 		return 1
 	}
+
 	return lp.maxActivePhases()
 }
 

--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -111,8 +111,7 @@ func (lp *Loadpoint) minActivePhases() int {
 	if lp.hasPhaseSwitching() || lp.phasesConfigured == 1 {
 		return 1
 	}
-
-	return lp.maxActivePhases()
+	return min(expect(lp.maxActivePhases()), expect(lp.getVehiclePhases()))
 }
 
 // MaxActivePhases returns the maximum number of active phases for the loadpoint.

--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -111,7 +111,7 @@ func (lp *Loadpoint) minActivePhases() int {
 	if lp.hasPhaseSwitching() || lp.phasesConfigured == 1 {
 		return 1
 	}
-	return min(expect(lp.maxActivePhases()), expect(lp.getVehiclePhases()))
+	return lp.maxActivePhases()
 }
 
 // MaxActivePhases returns the maximum number of active phases for the loadpoint.


### PR DESCRIPTION
Currently when a 2-phase vehicle is connected to a 3-phase loadpoint, PV charging will start if PV power is 3 times the minimum current. Reason is that lp.pvMaxCurrent does not consider maxActivePhases.
This PR addresses that shortcoming.