### PR TITLE
Energyflow UI: expand solar/battery

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -82,7 +82,6 @@
 							:name="$t('main.energyflow.pvProduction')"
 							icon="sun"
 							:power="pvProduction"
-							:powerTooltip="pvTooltip"
 							:details="solarForecastRemainingToday"
 							:detailsFmt="forecastFmt"
 							:detailsTooltip="solarForecastTooltip"
@@ -90,15 +89,27 @@
 							:detailsIcon="solarForecastIcon"
 							:detailsClickable="solarForecastExists"
 							:powerUnit="powerUnit"
+							:expanded="pvExpanded"
 							data-testid="energyflow-entry-production"
 							@details-clicked="openForecastModal"
-						/>
+							@toggle="togglePv"
+						>
+							<template v-if="pv.length > 1" #expanded>
+								<EnergyflowEntry
+									v-for="(p, index) in pv"
+									:key="index"
+									:name="p.title || genericPvTitle(index)"
+									:power="p.power"
+									:powerUnit="powerUnit"
+									:data-testid="`energyflow-entry-production-${index}`"
+								/>
+							</template>
+						</EnergyflowEntry>
 						<EnergyflowEntry
 							v-if="batteryConfigured"
 							:name="batteryDischargeLabel"
 							icon="battery"
 							:power="batteryDischarge"
-							:powerTooltip="batteryDischargeTooltip"
 							:powerUnit="powerUnit"
 							:iconProps="{
 								hold: batteryHold,
@@ -107,12 +118,25 @@
 							}"
 							:details="batterySoc"
 							:detailsFmt="batteryFmt"
+							:expanded="batteryExpanded"
 							detailsClickable
 							data-testid="energyflow-entry-batterydischarge"
 							@details-clicked="openBatterySettingsModal"
+							@toggle="toggleBattery"
 						>
 							<template v-if="batteryGridChargeLimitSet" #subline>
 								<div class="d-none d-md-block">&nbsp;</div>
+							</template>
+							<template v-if="battery.length > 1" #expanded>
+								<EnergyflowEntry
+									v-for="(b, index) in battery"
+									:key="index"
+									:name="b.title || genericBatteryTitle(index)"
+									:details="b.soc"
+									:detailsFmt="batteryFmt"
+									:power="dischargePower(b.power)"
+									:powerUnit="powerUnit"
+								/>
 							</template>
 						</EnergyflowEntry>
 						<EnergyflowEntry
@@ -174,7 +198,6 @@
 							:name="batteryChargeLabel"
 							icon="battery"
 							:power="batteryCharge"
-							:powerTooltip="batteryChargeTooltip"
 							:powerUnit="powerUnit"
 							:iconProps="{
 								hold: batteryHold,
@@ -183,8 +206,10 @@
 							}"
 							:details="batterySoc"
 							:detailsFmt="batteryFmt"
+							:expanded="batteryExpanded"
 							detailsClickable
 							@details-clicked="openBatterySettingsModal"
+							@toggle="toggleBattery"
 						>
 							<template v-if="batteryGridChargeLimitSet" #subline>
 								<button
@@ -206,6 +231,17 @@
 										>
 									</span>
 								</button>
+							</template>
+							<template v-if="battery.length > 1" #expanded>
+								<EnergyflowEntry
+									v-for="(b, index) in battery"
+									:key="index"
+									:name="b.title || genericBatteryTitle(index)"
+									:details="b.soc"
+									:detailsFmt="batteryFmt"
+									:power="chargePower(b.power)"
+									:powerUnit="powerUnit"
+								/>
 							</template>
 						</EnergyflowEntry>
 						<EnergyflowEntry
@@ -348,21 +384,6 @@ export default {
 		detailsHeight() {
 			return this.detailsOpen ? this.detailsCompleteHeight + "px" : 0;
 		},
-		pvTooltip() {
-			if (!Array.isArray(this.pv) || this.pv.length <= 1) {
-				return;
-			}
-			return this.pv.map(
-				({ power, title }) =>
-					`${title ? `${title}: ` : ""}${this.fmtW(power, this.powerUnit)}`
-			);
-		},
-		batteryDischargeTooltip() {
-			return this.batteryTooltip(true);
-		},
-		batteryChargeTooltip() {
-			return this.batteryTooltip(false);
-		},
 		batteryFmt() {
 			return (soc) => this.fmtPercentage(soc, 0);
 		},
@@ -411,6 +432,12 @@ export default {
 				return [this.$t("main.energyflow.forecastTooltip")];
 			}
 			return [];
+		},
+		pvExpanded() {
+			return settings.energyflowPv;
+		},
+		batteryExpanded() {
+			return settings.energyflowBattery;
 		},
 	},
 	watch: {
@@ -494,17 +521,19 @@ export default {
 		chargePower(power) {
 			return Math.abs(Math.min(0, power) * -1);
 		},
-		batteryTooltip(discharge = false) {
-			if (!Array.isArray(this.battery) || this.battery.length <= 1) {
-				return;
-			}
-			return this.battery.map(({ power, soc, title }) => {
-				const value = discharge ? this.dischargePower(power) : this.chargePower(power);
-
-				const powerFmt = this.fmtW(value, this.powerUnit);
-				const socFmt = this.fmtPercentage(soc, 0);
-				return `${title ? `${title}: ` : ""}${powerFmt} (${socFmt})`;
-			});
+		toggleBattery() {
+			settings.energyflowBattery = !settings.energyflowBattery;
+			this.$nextTick(this.updateHeight);
+		},
+		togglePv() {
+			settings.energyflowPv = !settings.energyflowPv;
+			this.$nextTick(this.updateHeight);
+		},
+		genericBatteryTitle(index) {
+			return `${this.$t("config.devices.batteryStorage")} #${index + 1}`;
+		},
+		genericPvTitle(index) {
+			return `${this.$t("config.devices.solarSystem")} #${index + 1}`;
 		},
 	},
 };

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -5,6 +5,8 @@ const SETTINGS_THEME = "settings_theme";
 const SETTINGS_UNIT = "settings_unit";
 const SETTINGS_HIDDEN_FEATURES = "settings_hidden_features";
 const SETTINGS_ENERGYFLOW_DETAILS = "settings_energyflow_details";
+const SETTINGS_ENERGYFLOW_PV = "settings_energyflow_pv";
+const SETTINGS_ENERGYFLOW_BATTERY = "settings_energyflow_battery";
 const SESSION_INFO = "session_info";
 const SESSION_COLUMNS = "session_columns";
 const SAVINGS_PERIOD = "savings_period";
@@ -58,6 +60,8 @@ const settings = reactive({
   unit: read(SETTINGS_UNIT),
   hiddenFeatures: readBool(SETTINGS_HIDDEN_FEATURES),
   energyflowDetails: readBool(SETTINGS_ENERGYFLOW_DETAILS),
+  energyflowPv: readBool(SETTINGS_ENERGYFLOW_PV),
+  energyflowBattery: readBool(SETTINGS_ENERGYFLOW_BATTERY),
   sessionInfo: readArray(SESSION_INFO),
   sessionColumns: readArray(SESSION_COLUMNS),
   savingsPeriod: read(SAVINGS_PERIOD),
@@ -72,6 +76,8 @@ watch(() => settings.theme, save(SETTINGS_THEME));
 watch(() => settings.unit, save(SETTINGS_UNIT));
 watch(() => settings.hiddenFeatures, saveBool(SETTINGS_HIDDEN_FEATURES));
 watch(() => settings.energyflowDetails, saveBool(SETTINGS_ENERGYFLOW_DETAILS));
+watch(() => settings.energyflowPv, saveBool(SETTINGS_ENERGYFLOW_PV));
+watch(() => settings.energyflowBattery, saveBool(SETTINGS_ENERGYFLOW_BATTERY));
 watch(() => settings.sessionInfo, saveArray(SESSION_INFO));
 watch(() => settings.sessionColumns, saveArray(SESSION_COLUMNS));
 watch(() => settings.savingsPeriod, save(SAVINGS_PERIOD));

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -108,6 +108,11 @@ A = "A (nicht verbunden)"
 B = "B (verbunden)"
 C = "C (lädt)"
 
+[config.devices]
+auxMeter = "Smarter Verbraucher"
+batteryStorage = "Batterie"
+solarSystem = "PV-Anlage"
+
 [config.eebus]
 description = "Grundkonfiguration für die Kommunikation mit anderen EEBus-Geräten."
 title = "EEBus"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -108,6 +108,11 @@ A = "A (not connected)"
 B = "B (connected)"
 C = "C (charging)"
 
+[config.devices]
+auxMeter = "Smart consumer"
+batteryStorage = "Battery storage"
+solarSystem = "Solar system"
+
 [config.eebus]
 description = "Configuration that enables evcc to communicate with other EEBus devices."
 title = "EEBus"
@@ -591,6 +596,7 @@ gridImport = "Grid use"
 homePower = "Consumption"
 loadpoints = "Charger| Charger | {count} chargers"
 noEnergy = "No meter data"
+pv = "Solar system"
 pvExport = "Grid export"
 pvProduction = "Production"
 selfConsumption = "Self-consumption"


### PR DESCRIPTION
relates to https://github.com/evcc-io/evcc/issues/9818

- ☀️🔋 replaced multi pv/battery tooltip with expand collapse
- 🏷️ use meter title for ui-configured devices (yaml entries get `#..` fallback)
- 💾 toggle positions (global, pv, battery) are stored in browser (local storage)
- 👯 toggle only available if you have at lease devices

**next steps (follow-up pr)**:
implement similar mechanism for load points and house (ext/aux)

large screen
<img width="986" alt="Bildschirmfoto 2025-04-04 um 16 19 06" src="https://github.com/user-attachments/assets/f1393e94-494c-4084-9dfc-b65038245255" />

smaller screen
<img width="575" alt="Bildschirmfoto 2025-04-04 um 16 19 13" src="https://github.com/user-attachments/assets/febe6d73-7f17-4b33-8d01-965a389e1ebb" />

---

video

[expand pv battery.webm](https://github.com/user-attachments/assets/0f19b279-06d1-4b67-9bff-318b30afdf31)
