### PR TITLE
Energyflow UI: expand loadpoints

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -192,7 +192,23 @@
 								detailsTooltip(tariffPriceLoadpoints, tariffCo2Loadpoints)
 							"
 							data-testid="energyflow-entry-loadpoints"
-						/>
+							:expanded="loadpointsExpanded"
+							@toggle="toggleLoadpoints"
+						>
+							<template v-if="activeLoadpointsCount > 1" #expanded>
+								<EnergyflowEntry
+									v-for="(lp, index) in activeLoadpoints"
+									:key="index"
+									:name="lp.title"
+									:power="lp.power"
+									:powerUnit="powerUnit"
+									icon="vehicle"
+									:iconProps="{ names: [lp.icon] }"
+									:details="lp.soc || undefined"
+									:detailsFmt="lp.heating ? fmtLoadpointTemp : fmtLoadpointSoc"
+								/>
+							</template>
+						</EnergyflowEntry>
 						<EnergyflowEntry
 							v-if="batteryConfigured"
 							:name="batteryChargeLabel"
@@ -387,6 +403,12 @@ export default {
 		batteryFmt() {
 			return (soc) => this.fmtPercentage(soc, 0);
 		},
+		fmtLoadpointSoc() {
+			return (soc) => this.fmtPercentage(soc, 0);
+		},
+		fmtLoadpointTemp() {
+			return (temp) => this.fmtTemperature(temp);
+		},
 		co2Available() {
 			return this.smartCostType === CO2_TYPE;
 		},
@@ -439,6 +461,9 @@ export default {
 		batteryExpanded() {
 			return settings.energyflowBattery;
 		},
+		loadpointsExpanded() {
+			return settings.energyflowLoadpoints;
+		},
 	},
 	watch: {
 		pvConfigured() {
@@ -451,6 +476,9 @@ export default {
 			this.$nextTick(this.updateHeight);
 		},
 		batteryMode() {
+			this.$nextTick(this.updateHeight);
+		},
+		activeLoadpointsCount() {
 			this.$nextTick(this.updateHeight);
 		},
 	},
@@ -527,6 +555,10 @@ export default {
 		},
 		togglePv() {
 			settings.energyflowPv = !settings.energyflowPv;
+			this.$nextTick(this.updateHeight);
+		},
+		toggleLoadpoints() {
+			settings.energyflowLoadpoints = !settings.energyflowLoadpoints;
 			this.$nextTick(this.updateHeight);
 		},
 		genericBatteryTitle(index) {

--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -153,9 +153,15 @@ export default {
 			return this.loadpoints.map((lp) => {
 				const vehicleIcon = this.vehicles?.[lp.vehicleName]?.icon;
 				const icon = lp.chargerIcon || vehicleIcon || "car";
+				const title =
+					this.vehicleTitle(lp.vehicleName) ||
+					lp.title ||
+					this.$t("main.loadpoint.fallbackName");
 				const charging = lp.charging;
+				const soc = lp.vehicleSoc;
 				const power = lp.chargePower || 0;
-				return { icon, charging, power };
+				const heating = lp.chargerFeatureHeating;
+				return { icon, title, charging, power, soc, heating };
 			});
 		},
 		vehicleList() {
@@ -197,6 +203,9 @@ export default {
 	methods: {
 		selectedLoadpointChanged(index) {
 			this.$router.push({ query: { lp: index + 1 } });
+		},
+		vehicleTitle(vehicleName) {
+			return this.vehicles?.[vehicleName]?.title;
 		},
 	},
 };

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -7,6 +7,7 @@ const SETTINGS_HIDDEN_FEATURES = "settings_hidden_features";
 const SETTINGS_ENERGYFLOW_DETAILS = "settings_energyflow_details";
 const SETTINGS_ENERGYFLOW_PV = "settings_energyflow_pv";
 const SETTINGS_ENERGYFLOW_BATTERY = "settings_energyflow_battery";
+const SETTINGS_ENERGYFLOW_LOADPOINTS = "settings_energyflow_loadpoints";
 const SESSION_INFO = "session_info";
 const SESSION_COLUMNS = "session_columns";
 const SAVINGS_PERIOD = "savings_period";
@@ -62,6 +63,7 @@ const settings = reactive({
   energyflowDetails: readBool(SETTINGS_ENERGYFLOW_DETAILS),
   energyflowPv: readBool(SETTINGS_ENERGYFLOW_PV),
   energyflowBattery: readBool(SETTINGS_ENERGYFLOW_BATTERY),
+  energyflowLoadpoints: readBool(SETTINGS_ENERGYFLOW_LOADPOINTS),
   sessionInfo: readArray(SESSION_INFO),
   sessionColumns: readArray(SESSION_COLUMNS),
   savingsPeriod: read(SAVINGS_PERIOD),
@@ -78,6 +80,7 @@ watch(() => settings.hiddenFeatures, saveBool(SETTINGS_HIDDEN_FEATURES));
 watch(() => settings.energyflowDetails, saveBool(SETTINGS_ENERGYFLOW_DETAILS));
 watch(() => settings.energyflowPv, saveBool(SETTINGS_ENERGYFLOW_PV));
 watch(() => settings.energyflowBattery, saveBool(SETTINGS_ENERGYFLOW_BATTERY));
+watch(() => settings.energyflowLoadpoints, saveBool(SETTINGS_ENERGYFLOW_LOADPOINTS));
 watch(() => settings.sessionInfo, saveArray(SESSION_INFO));
 watch(() => settings.sessionColumns, saveArray(SESSION_COLUMNS));
 watch(() => settings.savingsPeriod, save(SAVINGS_PERIOD));


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/9818
follow-up to https://github.com/evcc-io/evcc/pull/20389

- 🚕🚙 make load points expandable in energy flow
- 🔌 only active load points are show
- 🔥🔋 show temp/battery
- 🚘 show connected vehicle title, fallback to loadpoint name
- 💾 remember toggle state

<img width="767" alt="Bildschirmfoto 2025-04-04 um 21 19 54" src="https://github.com/user-attachments/assets/7bfa1d2b-861c-4571-98c3-5caff451afd3" />
