### PR TITLE
Planner: add precondition phase before departure

### DIFF
--- a/api/rates.go
+++ b/api/rates.go
@@ -13,11 +13,6 @@ type Rate struct {
 	Price float64   `json:"price"`
 }
 
-// IsZero returns is the rate is the zero value
-func (r Rate) IsZero() bool {
-	return r.Start.IsZero() && r.End.IsZero() && r.Price == 0
-}
-
 // Rates is a slice of (future) tariff rates
 type Rates []Rate
 
@@ -28,9 +23,9 @@ func (rr Rates) Sort() {
 	})
 }
 
-// At returns the rate for given timestamp or error.
+// At returns the rate for given timestamp.
 // Rates MUST be sorted by start time.
-func (rr Rates) At(ts time.Time) (Rate, error) {
+func (rr Rates) At(ts time.Time) *Rate {
 	if i, ok := slices.BinarySearchFunc(rr, ts, func(r Rate, ts time.Time) int {
 		switch {
 		case ts.Before(r.Start):
@@ -41,10 +36,10 @@ func (rr Rates) At(ts time.Time) (Rate, error) {
 			return 0
 		}
 	}); ok {
-		return rr[i], nil
+		return &rr[i]
 	}
 
-	return Rate{}, ErrNotAvailable
+	return nil
 }
 
 // MarshalMQTT implements server.MQTTMarshaler

--- a/api/rates_test.go
+++ b/api/rates_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRates(t *testing.T) {
@@ -20,19 +21,17 @@ func TestRates(t *testing.T) {
 
 	rr := Rates{rate(1, 1), rate(2, 2), rate(3, 3), rate(4, 4)}
 
-	_, err := rr.At(clock.Now())
-	assert.Error(t, err)
+	assert.Nil(t, rr.At(clock.Now()))
 
 	for i := 1; i <= 4; i++ {
-		r, err := rr.At(clock.Now().Add(time.Duration(i) * time.Hour))
-		assert.NoError(t, err)
+		r := rr.At(clock.Now().Add(time.Duration(i) * time.Hour))
+		require.NotNil(t, r)
 		assert.Equal(t, float64(i), r.Price)
 
-		r, err = rr.At(clock.Now().Add(time.Duration(i)*time.Hour + 30*time.Minute))
-		assert.NoError(t, err)
+		r = rr.At(clock.Now().Add(time.Duration(i)*time.Hour + 30*time.Minute))
+		require.NotNil(t, r)
 		assert.Equal(t, float64(i), r.Price)
 	}
 
-	_, err = rr.At(clock.Now().Add(5 * time.Hour))
-	assert.Error(t, err)
+	require.Nil(t, rr.At(clock.Now().Add(5*time.Hour)))
 }

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -68,6 +68,7 @@ const (
 	PlanTime           = "planTime"           // charge plan finish time goal
 	PlanEnergy         = "planEnergy"         // charge plan energy goal
 	PlanSoc            = "planSoc"            // charge plan soc goal
+	PlanPreCondition   = "planPreCondition"   // charge plan precondition duration
 	PlanActive         = "planActive"         // charge plan has determined current slot to be an active slot
 	PlanProjectedStart = "planProjectedStart" // charge plan start time (earliest slot)
 	PlanProjectedEnd   = "planProjectedEnd"   // charge plan ends (end of last slot)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -140,10 +140,11 @@ type Loadpoint struct {
 
 	// charge planning
 	planner     *planner.Planner
-	planTime    time.Time // time goal
-	planEnergy  float64   // Plan charge energy in kWh (dumb vehicles)
-	planSlotEnd time.Time // current plan slot end time
-	planActive  bool      // charge plan exists and has a currently active slot
+	planTime    time.Time     // time goal
+	planPreCond time.Duration // precondition duration
+	planEnergy  float64       // Plan charge energy in kWh (dumb vehicles)
+	planSlotEnd time.Time     // current plan slot end time
+	planActive  bool          // charge plan exists and has a currently active slot
 
 	// cached state
 	status         api.ChargeStatus       // Charger status
@@ -341,8 +342,9 @@ func (lp *Loadpoint) restoreSettings() {
 
 	t, err1 := lp.settings.Time(keys.PlanTime)
 	v, err2 := lp.settings.Float(keys.PlanEnergy)
+	d, _ := lp.settings.Int(keys.PlanPreCondition)
 	if err1 == nil && err2 == nil {
-		lp.setPlanEnergy(t, v)
+		lp.setPlanEnergy(t, time.Duration(d)*time.Second, v)
 	}
 }
 
@@ -945,7 +947,7 @@ func (lp *Loadpoint) repeatingPlanning() bool {
 	if !lp.socBasedPlanning() {
 		return false
 	}
-	_, _, id := lp.NextVehiclePlan()
+	_, _, _, id := lp.NextVehiclePlan()
 	return id > 1
 }
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1865,8 +1865,11 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, rates api.Rate
 	case mode == api.ModeMinPV || mode == api.ModePV:
 		// cheap tariff
 		if smartCostActive {
-			rate, _ := rates.At(time.Now())
-			lp.log.DEBUG.Printf("smart cost active: %.2f", rate.Price)
+			rr := "?"
+			if rate := rates.At(time.Now()); rate != nil {
+				rr = fmt.Sprintf("%.2f", rate.Price)
+			}
+			lp.log.DEBUG.Printf("smart cost active: %s", rr)
 			err = lp.fastCharging()
 			lp.resetPhaseTimer()
 			lp.elapsePVTimer() // let PV mode disable immediately afterwards

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -114,17 +114,19 @@ type API interface {
 	//
 
 	// GetPlanEnergy returns the charge plan energy
-	GetPlanEnergy() (time.Time, float64)
+	GetPlanEnergy() (time.Time, time.Duration, float64)
 	// SetPlanEnergy sets the charge plan energy
-	SetPlanEnergy(time.Time, float64) error
-	// GetPlanGoal returns the plan goal and if the goal is soc based
+	SetPlanEnergy(time.Time, time.Duration, float64) error
+	// GetPlanGoal returns the plan goal, precondition duration and if the goal is soc based
 	GetPlanGoal() (float64, bool)
 	// GetPlanRequiredDuration returns required duration of plan to reach the goal from current state
 	GetPlanRequiredDuration(goal, maxPower float64) time.Duration
+	// GetPlanPreCondDuration returns the precondition duration
+	GetPlanPreCondDuration() time.Duration
 	// SocBasedPlanning determines if the planner is soc based
 	SocBasedPlanning() bool
 	// GetPlan creates a charging plan
-	GetPlan(targetTime time.Time, requiredDuration time.Duration, late bool) api.Rates
+	GetPlan(targetTime time.Time, requiredDuration, preCond time.Duration) api.Rates
 
 	// GetSocConfig returns the soc poll settings
 	GetSocConfig() SocConfig

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -124,7 +124,7 @@ type API interface {
 	// SocBasedPlanning determines if the planner is soc based
 	SocBasedPlanning() bool
 	// GetPlan creates a charging plan
-	GetPlan(targetTime time.Time, requiredDuration time.Duration) api.Rates
+	GetPlan(targetTime time.Time, requiredDuration time.Duration, late bool) api.Rates
 
 	// GetSocConfig returns the soc poll settings
 	GetSocConfig() SocConfig

--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -26,6 +26,7 @@ type DynamicConfig struct {
 	SmartCostLimit   *float64  `json:"smartCostLimit"`
 	PlanEnergy       float64   `json:"planEnergy"`
 	PlanTime         time.Time `json:"planTime"`
+	PlanPreCondition int64     `json:"planPreCondition"`
 	LimitEnergy      float64   `json:"limitEnergy"`
 	LimitSoc         int       `json:"limitSoc"`
 
@@ -56,7 +57,7 @@ func (payload DynamicConfig) Apply(lp API) error {
 	lp.SetPriority(payload.Priority)
 	lp.SetSmartCostLimit(payload.SmartCostLimit)
 	lp.SetThresholds(payload.Thresholds)
-	lp.SetPlanEnergy(payload.PlanTime, payload.PlanEnergy)
+	lp.SetPlanEnergy(payload.PlanTime, time.Duration(payload.PlanPreCondition)*time.Second, payload.PlanEnergy)
 	lp.SetLimitEnergy(payload.LimitEnergy)
 	lp.SetLimitSoc(payload.LimitSoc)
 

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -420,26 +420,27 @@ func (mr *MockAPIMockRecorder) GetPhasesConfigured() *gomock.Call {
 }
 
 // GetPlan mocks base method.
-func (m *MockAPI) GetPlan(targetTime time.Time, requiredDuration time.Duration, late bool) api.Rates {
+func (m *MockAPI) GetPlan(targetTime time.Time, requiredDuration, preCond time.Duration) api.Rates {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlan", targetTime, requiredDuration, late)
+	ret := m.ctrl.Call(m, "GetPlan", targetTime, requiredDuration, preCond)
 	ret0, _ := ret[0].(api.Rates)
 	return ret0
 }
 
 // GetPlan indicates an expected call of GetPlan.
-func (mr *MockAPIMockRecorder) GetPlan(targetTime, requiredDuration, late any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPlan(targetTime, requiredDuration, preCond any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), targetTime, requiredDuration, late)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), targetTime, requiredDuration, preCond)
 }
 
 // GetPlanEnergy mocks base method.
-func (m *MockAPI) GetPlanEnergy() (time.Time, float64) {
+func (m *MockAPI) GetPlanEnergy() (time.Time, time.Duration, float64) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPlanEnergy")
 	ret0, _ := ret[0].(time.Time)
-	ret1, _ := ret[1].(float64)
-	return ret0, ret1
+	ret1, _ := ret[1].(time.Duration)
+	ret2, _ := ret[2].(float64)
+	return ret0, ret1, ret2
 }
 
 // GetPlanEnergy indicates an expected call of GetPlanEnergy.
@@ -461,6 +462,20 @@ func (m *MockAPI) GetPlanGoal() (float64, bool) {
 func (mr *MockAPIMockRecorder) GetPlanGoal() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlanGoal", reflect.TypeOf((*MockAPI)(nil).GetPlanGoal))
+}
+
+// GetPlanPreCondDuration mocks base method.
+func (m *MockAPI) GetPlanPreCondDuration() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlanPreCondDuration")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// GetPlanPreCondDuration indicates an expected call of GetPlanPreCondDuration.
+func (mr *MockAPIMockRecorder) GetPlanPreCondDuration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlanPreCondDuration", reflect.TypeOf((*MockAPI)(nil).GetPlanPreCondDuration))
 }
 
 // GetPlanRequiredDuration mocks base method.
@@ -844,17 +859,17 @@ func (mr *MockAPIMockRecorder) SetPhasesConfigured(arg0 any) *gomock.Call {
 }
 
 // SetPlanEnergy mocks base method.
-func (m *MockAPI) SetPlanEnergy(arg0 time.Time, arg1 float64) error {
+func (m *MockAPI) SetPlanEnergy(arg0 time.Time, arg1 time.Duration, arg2 float64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPlanEnergy", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetPlanEnergy", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPlanEnergy indicates an expected call of SetPlanEnergy.
-func (mr *MockAPIMockRecorder) SetPlanEnergy(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetPlanEnergy(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPlanEnergy", reflect.TypeOf((*MockAPI)(nil).SetPlanEnergy), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPlanEnergy", reflect.TypeOf((*MockAPI)(nil).SetPlanEnergy), arg0, arg1, arg2)
 }
 
 // SetPriority mocks base method.

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -420,17 +420,17 @@ func (mr *MockAPIMockRecorder) GetPhasesConfigured() *gomock.Call {
 }
 
 // GetPlan mocks base method.
-func (m *MockAPI) GetPlan(targetTime time.Time, requiredDuration time.Duration) api.Rates {
+func (m *MockAPI) GetPlan(targetTime time.Time, requiredDuration time.Duration, late bool) api.Rates {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlan", targetTime, requiredDuration)
+	ret := m.ctrl.Call(m, "GetPlan", targetTime, requiredDuration, late)
 	ret0, _ := ret[0].(api.Rates)
 	return ret0
 }
 
 // GetPlan indicates an expected call of GetPlan.
-func (mr *MockAPIMockRecorder) GetPlan(targetTime, requiredDuration any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPlan(targetTime, requiredDuration, late any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), targetTime, requiredDuration)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), targetTime, requiredDuration, late)
 }
 
 // GetPlanEnergy mocks base method.

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -33,9 +33,9 @@ func (lp *Loadpoint) finishPlan() {
 	if lp.repeatingPlanning() {
 		return // noting to do
 	} else if !lp.socBasedPlanning() {
-		lp.setPlanEnergy(time.Time{}, 0)
+		lp.setPlanEnergy(time.Time{}, 0, 0)
 	} else if v := lp.GetVehicle(); v != nil {
-		vehicle.Settings(lp.log, v).SetPlanSoc(time.Time{}, 0)
+		vehicle.Settings(lp.log, v).SetPlanSoc(time.Time{}, 0, 0)
 	}
 }
 
@@ -70,22 +70,36 @@ func (lp *Loadpoint) GetPlanGoal() (float64, bool) {
 	defer lp.RUnlock()
 
 	if lp.socBasedPlanning() {
-		_, soc, _ := lp.nextVehiclePlan()
+		_, _, soc, _ := lp.nextVehiclePlan()
 		return float64(soc), true
 	}
 
-	_, limit := lp.getPlanEnergy()
+	_, _, limit := lp.getPlanEnergy()
 	return limit, false
+}
+
+// GetPlanPreCondDuration returns the plan precondition duration
+func (lp *Loadpoint) GetPlanPreCondDuration() time.Duration {
+	lp.RLock()
+	defer lp.RUnlock()
+
+	if lp.socBasedPlanning() {
+		_, preCond, _, _ := lp.nextVehiclePlan()
+		return preCond
+	}
+
+	_, preCond, _ := lp.getPlanEnergy()
+	return preCond
 }
 
 // GetPlan creates a charging plan for given time and duration
 // The plan is sorted by time
-func (lp *Loadpoint) GetPlan(targetTime time.Time, requiredDuration time.Duration, late bool) api.Rates {
+func (lp *Loadpoint) GetPlan(targetTime time.Time, requiredDuration, preCond time.Duration) api.Rates {
 	if lp.planner == nil || targetTime.IsZero() {
 		return nil
 	}
 
-	return lp.planner.Plan(requiredDuration, targetTime, late)
+	return lp.planner.Plan(requiredDuration, preCond, targetTime)
 }
 
 // plannerActive checks if the charging plan has a currently active slot
@@ -133,7 +147,7 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 		return false
 	}
 
-	plan := lp.GetPlan(planTime, requiredDuration, false)
+	plan := lp.GetPlan(planTime, requiredDuration, lp.GetPlanPreCondDuration())
 	if plan == nil {
 		return false
 	}

--- a/core/loadpoint_smartcost.go
+++ b/core/loadpoint_smartcost.go
@@ -7,9 +7,9 @@ import (
 )
 
 func (lp *Loadpoint) smartCostActive(rates api.Rates) bool {
-	rate, err := rates.At(time.Now())
+	rate := rates.At(time.Now())
 	limit := lp.GetSmartCostLimit()
-	return err == nil && limit != nil && rate.Price <= *limit
+	return limit != nil && rate != nil && rate.Price <= *limit
 }
 
 // smartCostNextStart returns the next start time for a smart cost rate below the limit

--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -49,16 +49,6 @@ func AverageCost(plan api.Rates) float64 {
 	return cost / float64(duration)
 }
 
-// SlotAt returns the slot for the given time or an empty slot
-func SlotAt(time time.Time, plan api.Rates) api.Rate {
-	for _, slot := range plan {
-		if !slot.Start.After(time) && slot.End.After(time) {
-			return slot
-		}
-	}
-	return api.Rate{}
-}
-
 // SlotHasSuccessor returns if the slot has an immediate successor.
 // Does not require the plan to be sorted by start time.
 func SlotHasSuccessor(r api.Rate, plan api.Rates) bool {

--- a/core/planner/planner.go
+++ b/core/planner/planner.go
@@ -136,7 +136,7 @@ func (t *Planner) continuousPlan(rates api.Rates, start, end time.Time) api.Rate
 	return res
 }
 
-func (t *Planner) Plan(requiredDuration time.Duration, targetTime time.Time) api.Rates {
+func (t *Planner) Plan(requiredDuration time.Duration, targetTime time.Time, late bool) api.Rates {
 	if t == nil || requiredDuration <= 0 {
 		return nil
 	}
@@ -174,6 +174,11 @@ func (t *Planner) Plan(requiredDuration time.Duration, targetTime time.Time) api
 
 	// rates are by default sorted by date, oldest to newest
 	last := rates[len(rates)-1].End
+
+	// for late start ensure that the last slot is the cheapest
+	if r := rates.At(targetTime); r != nil && late {
+		r.Price = 0
+	}
 
 	// sort rates by price and time
 	slices.SortStableFunc(rates, sortByCost)

--- a/core/planner/planner_test.go
+++ b/core/planner/planner_test.go
@@ -230,11 +230,11 @@ func TestTargetAfterKnownPrices(t *testing.T) {
 		tariff: trf,
 	}
 
-	plan := p.Plan(40*time.Minute, clock.Now().Add(2*time.Hour), false) // charge efficiency does not allow to test with 1,falseh
-	assert.False(t, !plan.At(clock.Now()).IsZero(), "should not start if car can be charged completely after known prices ")
+	plan := p.Plan(40*time.Minute, clock.Now().Add(2*time.Hour), false) // charge efficiency does not allow to test with 1,false
+	assert.Nil(t, plan.At(clock.Now()), "should not start if car can be charged completely after known prices ")
 
 	plan = p.Plan(2*time.Hour, clock.Now().Add(2*time.Hour), false)
-	assert.True(t, !plan.At(clock.Now()).IsZero(), "should start if car can not be charged completely after known prices ")
+	assert.NotNil(t, plan.At(clock.Now()), "should start if car can not be charged completely after known prices ")
 }
 
 func TestChargeAfterTargetTime(t *testing.T) {

--- a/core/planner/planner_test.go
+++ b/core/planner/planner_test.go
@@ -230,7 +230,7 @@ func TestTargetAfterKnownPrices(t *testing.T) {
 		tariff: trf,
 	}
 
-	plan := p.Plan(40*time.Minute, clock.Now().Add(2*time.Hour), false) // charge efficiency does not allow to test with 1,false
+	plan := p.Plan(40*time.Minute, clock.Now().Add(2*time.Hour), false) // charge efficiency does not allow to test with 1h
 	assert.Nil(t, plan.At(clock.Now()), "should not start if car can be charged completely after known prices ")
 
 	plan = p.Plan(2*time.Hour, clock.Now().Add(2*time.Hour), false)

--- a/core/planner/planner_test.go
+++ b/core/planner/planner_test.go
@@ -133,7 +133,7 @@ func TestNilTariff(t *testing.T) {
 		clock: clock,
 	}
 
-	plan := p.Plan(time.Hour, clock.Now().Add(30*time.Minute), false)
+	plan := p.Plan(time.Hour, 0, clock.Now().Add(30*time.Minute))
 	assert.Equal(t, api.Rates{
 		{
 			Start: clock.Now(),
@@ -155,7 +155,7 @@ func TestRatesError(t *testing.T) {
 		tariff: trf,
 	}
 
-	plan := p.Plan(time.Hour, clock.Now().Add(30*time.Minute), false)
+	plan := p.Plan(time.Hour, 0, clock.Now().Add(30*time.Minute))
 	assert.Equal(t, api.Rates{
 		{
 			Start: clock.Now(),
@@ -184,10 +184,10 @@ func TestFlatTariffTargetInThePast(t *testing.T) {
 		},
 	}
 
-	plan := p.Plan(time.Hour, clock.Now().Add(30*time.Minute), false)
+	plan := p.Plan(time.Hour, 0, clock.Now().Add(30*time.Minute))
 	assert.Equal(t, simplePlan, plan, "expected simple plan")
 
-	plan = p.Plan(time.Hour, clock.Now().Add(-30*time.Minute), false)
+	plan = p.Plan(time.Hour, 0, clock.Now().Add(-30*time.Minute))
 	assert.Equal(t, simplePlan, plan, "expected simple plan")
 }
 
@@ -208,12 +208,12 @@ func TestFlatTariffLongSlots(t *testing.T) {
 	// that slots are not longer than 1 hour and with that context this is not a problem
 
 	// expect 00:00-01:00 UTC
-	plan := p.Plan(time.Hour, clock.Now().Add(2*time.Hour), false)
+	plan := p.Plan(time.Hour, 0, clock.Now().Add(2*time.Hour))
 	assert.Equal(t, &api.Rate{Start: clock.Now(), End: clock.Now().Add(time.Hour)}, plan.At(clock.Now()))
 	assert.Nil(t, plan.At(clock.Now().Add(time.Hour)))
 
 	// expect 00:00-01:00 UTC
-	plan = p.Plan(time.Hour, clock.Now().Add(time.Hour), false)
+	plan = p.Plan(time.Hour, 0, clock.Now().Add(time.Hour))
 	assert.Equal(t, &api.Rate{Start: clock.Now(), End: clock.Now().Add(time.Hour)}, plan.At(clock.Now()))
 }
 
@@ -230,10 +230,10 @@ func TestTargetAfterKnownPrices(t *testing.T) {
 		tariff: trf,
 	}
 
-	plan := p.Plan(40*time.Minute, clock.Now().Add(2*time.Hour), false) // charge efficiency does not allow to test with 1h
+	plan := p.Plan(40*time.Minute, 0, clock.Now().Add(2*time.Hour)) // charge efficiency does not allow to test with 1h
 	assert.Nil(t, plan.At(clock.Now()), "should not start if car can be charged completely after known prices ")
 
-	plan = p.Plan(2*time.Hour, clock.Now().Add(2*time.Hour), false)
+	plan = p.Plan(2*time.Hour, 0, clock.Now().Add(2*time.Hour))
 	assert.NotNil(t, plan.At(clock.Now()), "should start if car can not be charged completely after known prices ")
 }
 
@@ -257,10 +257,10 @@ func TestChargeAfterTargetTime(t *testing.T) {
 		},
 	}
 
-	plan := p.Plan(time.Hour, clock.Now(), false)
+	plan := p.Plan(time.Hour, 0, clock.Now())
 	assert.Equal(t, simplePlan, plan, "expected simple plan")
 
-	plan = p.Plan(time.Hour, clock.Now().Add(-time.Hour), false)
+	plan = p.Plan(time.Hour, 0, clock.Now().Add(-time.Hour))
 	assert.Equal(t, simplePlan, plan, "expected simple plan")
 }
 
@@ -272,7 +272,7 @@ func TestContinuousPlanNoTariff(t *testing.T) {
 		clock: clock,
 	}
 
-	plan := p.Plan(time.Hour, clock.Now(), false)
+	plan := p.Plan(time.Hour, 0, clock.Now())
 
 	// single-slot plan
 	assert.Len(t, plan, 1)
@@ -295,7 +295,7 @@ func TestContinuousPlan(t *testing.T) {
 		tariff: trf,
 	}
 
-	plan := p.Plan(150*time.Minute, clock.Now(), false)
+	plan := p.Plan(150*time.Minute, 0, clock.Now())
 
 	// 3-slot plan
 	assert.Len(t, plan, 3)
@@ -314,7 +314,7 @@ func TestContinuousPlanOutsideRates(t *testing.T) {
 		tariff: trf,
 	}
 
-	plan := p.Plan(30*time.Minute, clock.Now(), false)
+	plan := p.Plan(30*time.Minute, 0, clock.Now())
 
 	// 3-slot plan
 	assert.Len(t, plan, 1)

--- a/core/planner/planner_test.go
+++ b/core/planner/planner_test.go
@@ -209,12 +209,12 @@ func TestFlatTariffLongSlots(t *testing.T) {
 
 	// expect 00:00-01:00 UTC
 	plan := p.Plan(time.Hour, clock.Now().Add(2*time.Hour), false)
-	assert.Equal(t, api.Rate{Start: clock.Now(), End: clock.Now().Add(time.Hour)}, plan.At(clock.Now()))
-	assert.Equal(t, api.Rate{}, plan.At(clock.Now().Add(time.Hour)))
+	assert.Equal(t, &api.Rate{Start: clock.Now(), End: clock.Now().Add(time.Hour)}, plan.At(clock.Now()))
+	assert.Nil(t, plan.At(clock.Now().Add(time.Hour)))
 
 	// expect 00:00-01:00 UTC
 	plan = p.Plan(time.Hour, clock.Now().Add(time.Hour), false)
-	assert.Equal(t, api.Rate{Start: clock.Now(), End: clock.Now().Add(time.Hour)}, plan.At(clock.Now()))
+	assert.Equal(t, &api.Rate{Start: clock.Now(), End: clock.Now().Add(time.Hour)}, plan.At(clock.Now()))
 }
 
 func TestTargetAfterKnownPrices(t *testing.T) {

--- a/core/site.go
+++ b/core/site.go
@@ -898,8 +898,8 @@ func (site *Site) update(lp updater) {
 		flexiblePower = site.prioritizer.GetChargePowerFlexibility(lp)
 	}
 
-	rate, err := rates.At(time.Now())
-	if rates != nil && err != nil {
+	rate := rates.At(time.Now())
+	if rates != nil && rate == nil {
 		msg := fmt.Sprintf("no matching rate for: %s", time.Now().Format(time.RFC3339))
 		if len(rates) > 0 {
 			msg += fmt.Sprintf(", %d rates (%s to %s)", len(rates),

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -93,12 +93,12 @@ func (site *Site) plannerRates() (api.Rates, error) {
 
 func (site *Site) smartCostActive(lp loadpoint.API, rate *api.Rate) bool {
 	limit := lp.GetSmartCostLimit()
-	return limit != nil && rate != nil && rate.Price <= *limit
+	return rate != nil && limit != nil && rate.Price <= *limit
 }
 
 func (site *Site) batteryGridChargeActive(rate *api.Rate) bool {
 	limit := site.GetBatteryGridChargeLimit()
-	return limit != nil && rate != nil && rate.Price <= *limit
+	return rate != nil && limit != nil && rate.Price <= *limit
 }
 
 func (site *Site) dischargeControlActive(rate *api.Rate) bool {

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -93,12 +93,12 @@ func (site *Site) plannerRates() (api.Rates, error) {
 
 func (site *Site) smartCostActive(lp loadpoint.API, rate *api.Rate) bool {
 	limit := lp.GetSmartCostLimit()
-	return rate != nil && limit != nil && rate.Price <= *limit
+	return limit != nil && rate != nil && rate.Price <= *limit
 }
 
 func (site *Site) batteryGridChargeActive(rate *api.Rate) bool {
 	limit := site.GetBatteryGridChargeLimit()
-	return rate != nil && limit != nil && rate.Price <= *limit
+	return limit != nil && rate != nil && rate.Price <= *limit
 }
 
 func (site *Site) dischargeControlActive(rate *api.Rate) bool {

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -42,7 +42,7 @@ func (site *Site) SetBatteryMode(batMode api.BatteryMode) {
 }
 
 // requiredBatteryMode determines required battery mode based on grid charge and rate
-func (site *Site) requiredBatteryMode(batteryGridChargeActive bool, rate api.Rate) api.BatteryMode {
+func (site *Site) requiredBatteryMode(batteryGridChargeActive bool, rate *api.Rate) api.BatteryMode {
 	var res api.BatteryMode
 	batMode := site.GetBatteryMode()
 
@@ -91,17 +91,17 @@ func (site *Site) plannerRates() (api.Rates, error) {
 	return tariff.Rates()
 }
 
-func (site *Site) smartCostActive(lp loadpoint.API, rate api.Rate) bool {
+func (site *Site) smartCostActive(lp loadpoint.API, rate *api.Rate) bool {
 	limit := lp.GetSmartCostLimit()
-	return limit != nil && !rate.IsZero() && rate.Price <= *limit
+	return limit != nil && rate != nil && rate.Price <= *limit
 }
 
-func (site *Site) batteryGridChargeActive(rate api.Rate) bool {
+func (site *Site) batteryGridChargeActive(rate *api.Rate) bool {
 	limit := site.GetBatteryGridChargeLimit()
-	return limit != nil && !rate.IsZero() && rate.Price <= *limit
+	return limit != nil && rate != nil && rate.Price <= *limit
 }
 
-func (site *Site) dischargeControlActive(rate api.Rate) bool {
+func (site *Site) dischargeControlActive(rate *api.Rate) bool {
 	if !site.GetBatteryDischargeControl() {
 		return false
 	}

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -49,12 +49,12 @@ func (site *Site) greenShare(powerFrom float64, powerTo float64) float64 {
 
 // effectivePrice calculates the real energy price based on self-produced and grid-imported energy.
 func (site *Site) effectivePrice(greenShare float64) *float64 {
-	if grid, err := tariff.Now(site.GetTariff(api.TariffUsageGrid)); err == nil {
-		feedin, err := tariff.Now(site.GetTariff(api.TariffUsageFeedIn))
-		if err != nil {
-			feedin = 0
+	if grid := tariff.Now(site.GetTariff(api.TariffUsageGrid)); grid != nil {
+		feedin := tariff.Now(site.GetTariff(api.TariffUsageFeedIn))
+		if feedin == nil {
+			feedin = lo.ToPtr(0.0)
 		}
-		effPrice := grid*(1-greenShare) + feedin*greenShare
+		effPrice := (*grid)*(1-greenShare) + (*feedin)*greenShare
 		return &effPrice
 	}
 	return nil
@@ -62,8 +62,8 @@ func (site *Site) effectivePrice(greenShare float64) *float64 {
 
 // effectiveCo2 calculates the amount of emitted co2 based on self-produced and grid-imported energy.
 func (site *Site) effectiveCo2(greenShare float64) *float64 {
-	if co2, err := tariff.Now(site.GetTariff(api.TariffUsageCo2)); err == nil {
-		effCo2 := co2 * (1 - greenShare)
+	if co2 := tariff.Now(site.GetTariff(api.TariffUsageCo2)); co2 != nil {
+		effCo2 := (*co2) * (1 - greenShare)
 		return &effCo2
 	}
 	return nil
@@ -73,17 +73,17 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 	site.publish(keys.GreenShareHome, greenShareHome)
 	site.publish(keys.GreenShareLoadpoints, greenShareLoadpoints)
 
-	if v, err := tariff.Now(site.GetTariff(api.TariffUsageGrid)); err == nil {
-		site.publish(keys.TariffGrid, v)
+	if v := tariff.Now(site.GetTariff(api.TariffUsageGrid)); v != nil {
+		site.publish(keys.TariffGrid, *v)
 	}
-	if v, err := tariff.Now(site.GetTariff(api.TariffUsageFeedIn)); err == nil {
-		site.publish(keys.TariffFeedIn, v)
+	if v := tariff.Now(site.GetTariff(api.TariffUsageFeedIn)); v != nil {
+		site.publish(keys.TariffFeedIn, *v)
 	}
-	if v, err := tariff.Now(site.GetTariff(api.TariffUsageCo2)); err == nil {
-		site.publish(keys.TariffCo2, v)
+	if v := tariff.Now(site.GetTariff(api.TariffUsageCo2)); v != nil {
+		site.publish(keys.TariffCo2, *v)
 	}
-	if v, err := tariff.Now(site.GetTariff(api.TariffUsageSolar)); err == nil {
-		site.publish(keys.TariffSolar, v)
+	if v := tariff.Now(site.GetTariff(api.TariffUsageSolar)); v != nil {
+		site.publish(keys.TariffSolar, *v)
 	}
 	if v := site.effectivePrice(greenShareHome); v != nil {
 		site.publish(keys.TariffPriceHome, v)

--- a/core/site_test.go
+++ b/core/site_test.go
@@ -139,7 +139,7 @@ func TestRequiredBatteryMode(t *testing.T) {
 
 	{
 		// no battery
-		res := new(Site).requiredBatteryMode(true, api.Rate{})
+		res := new(Site).requiredBatteryMode(true, nil)
 		assert.Equal(t, api.BatteryUnknown, res, "expected %s, got %s", api.BatteryUnknown, res)
 	}
 
@@ -151,7 +151,7 @@ func TestRequiredBatteryMode(t *testing.T) {
 			batteryMode:   tc.mode,
 		}
 
-		res := s.requiredBatteryMode(tc.gridChargeActive, api.Rate{})
+		res := s.requiredBatteryMode(tc.gridChargeActive, nil)
 		assert.Equal(t, tc.res, res, "expected %s, got %s", tc.res, res)
 	}
 }

--- a/core/site_vehicles.go
+++ b/core/site_vehicles.go
@@ -13,8 +13,9 @@ import (
 )
 
 type planStruct struct {
-	Soc  int       `json:"soc"`
-	Time time.Time `json:"time"`
+	Soc          int       `json:"soc"`
+	PreCondition int64     `json:"preCondition"`
+	Time         time.Time `json:"time"`
 }
 
 type vehicleStruct struct {
@@ -40,8 +41,8 @@ func (site *Site) publishVehicles() {
 	for _, v := range vv {
 		var plan *planStruct
 
-		if time, soc := v.GetPlanSoc(); !time.IsZero() {
-			plan = &planStruct{Soc: soc, Time: time}
+		if time, preCond, soc := v.GetPlanSoc(); !time.IsZero() {
+			plan = &planStruct{Soc: soc, PreCondition: int64(preCond.Seconds()), Time: time}
 		}
 
 		instance := v.Instance()

--- a/core/vehicle/api.go
+++ b/core/vehicle/api.go
@@ -39,9 +39,9 @@ type API interface {
 	SetLimitSoc(soc int)
 
 	// GetPlanSoc returns the charge plan soc
-	GetPlanSoc() (time.Time, int)
+	GetPlanSoc() (time.Time, time.Duration, int)
 	// SetPlanSoc sets the charge plan time and soc
-	SetPlanSoc(time.Time, int) error
+	SetPlanSoc(time.Time, time.Duration, int) error
 
 	// GetRepeatingPlans returns every repeating plan
 	GetRepeatingPlans() []api.RepeatingPlanStruct

--- a/core/vehicle/dummy.go
+++ b/core/vehicle/dummy.go
@@ -39,12 +39,12 @@ func (v *dummy) SetLimitSoc(soc int) {
 }
 
 // GetPlanSoc returns the charge plan soc
-func (v *dummy) GetPlanSoc() (time.Time, int) {
-	return time.Time{}, 0
+func (v *dummy) GetPlanSoc() (time.Time, time.Duration, int) {
+	return time.Time{}, 0, 0
 }
 
 // SetPlanSoc sets the charge plan soc
-func (v *dummy) SetPlanSoc(ts time.Time, soc int) error {
+func (v *dummy) SetPlanSoc(ts time.Time, preCond time.Duration, soc int) error {
 	return nil
 }
 

--- a/core/vehicle/mock.go
+++ b/core/vehicle/mock.go
@@ -70,12 +70,13 @@ func (mr *MockAPIMockRecorder) GetMinSoc() *gomock.Call {
 }
 
 // GetPlanSoc mocks base method.
-func (m *MockAPI) GetPlanSoc() (time.Time, int) {
+func (m *MockAPI) GetPlanSoc() (time.Time, time.Duration, int) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPlanSoc")
 	ret0, _ := ret[0].(time.Time)
-	ret1, _ := ret[1].(int)
-	return ret0, ret1
+	ret1, _ := ret[1].(time.Duration)
+	ret2, _ := ret[2].(int)
+	return ret0, ret1, ret2
 }
 
 // GetPlanSoc indicates an expected call of GetPlanSoc.
@@ -151,17 +152,17 @@ func (mr *MockAPIMockRecorder) SetMinSoc(soc any) *gomock.Call {
 }
 
 // SetPlanSoc mocks base method.
-func (m *MockAPI) SetPlanSoc(arg0 time.Time, arg1 int) error {
+func (m *MockAPI) SetPlanSoc(arg0 time.Time, arg1 time.Duration, arg2 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPlanSoc", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetPlanSoc", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPlanSoc indicates an expected call of SetPlanSoc.
-func (mr *MockAPIMockRecorder) SetPlanSoc(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetPlanSoc(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPlanSoc", reflect.TypeOf((*MockAPI)(nil).SetPlanSoc), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPlanSoc", reflect.TypeOf((*MockAPI)(nil).SetPlanSoc), arg0, arg1, arg2)
 }
 
 // SetRepeatingPlans mocks base method.

--- a/push/hub.go
+++ b/push/hub.go
@@ -81,7 +81,7 @@ func (h *Hub) apply(ev Event, tmpl string) (string, error) {
 		if v, err := h.vehicles.ByName(name); err == nil {
 			attr["vehicleLimitSoc"] = v.GetLimitSoc()
 			attr["vehicleMinSoc"] = v.GetMinSoc()
-			attr["vehiclePlanTime"], attr["vehiclePlanSoc"] = v.GetPlanSoc()
+			attr["vehiclePlanTime"], _, attr["vehiclePlanSoc"] = v.GetPlanSoc()
 
 			instance := v.Instance()
 			attr["vehicleTitle"] = instance.Title()

--- a/server/helper.go
+++ b/server/helper.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // pass converts a simple api without return value to api with nil error return value
@@ -26,6 +27,15 @@ func parseFloat(payload string) (float64, error) {
 		err = fmt.Errorf("invalid float value: %s", payload)
 	}
 	return f, err
+}
+
+// parseDuration parses a duration string as seconds
+func parseDuration(payload string) (time.Duration, error) {
+	v, err := strconv.Atoi(payload)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(v) * time.Second, err
 }
 
 // jsonDecoder returns a json decoder with disallowed unknown fields

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -58,11 +58,6 @@ func TestMergeMaskedAny(t *testing.T) {
 		new, expected *testStruct
 	}{
 		{
-			old:      nil,
-			new:      &testStruct{"newValue1", 42},
-			expected: &testStruct{"newValue1", 42},
-		},
-		{
 			old:      &testStruct{"oldValue1", 24},
 			new:      &testStruct{"newValue1", 42},
 			expected: &testStruct{"newValue1", 42},

--- a/server/http_config_loadpoint_handler.go
+++ b/server/http_config_loadpoint_handler.go
@@ -27,7 +27,7 @@ func getLoadpointStaticConfig(lp loadpoint.API) loadpoint.StaticConfig {
 }
 
 func getLoadpointDynamicConfig(lp loadpoint.API) loadpoint.DynamicConfig {
-	planTime, planEnergy := lp.GetPlanEnergy()
+	planTime, planPreCondition, planEnergy := lp.GetPlanEnergy()
 	return loadpoint.DynamicConfig{
 		Title:            lp.GetTitle(),
 		DefaultMode:      string(lp.GetDefaultMode()),
@@ -40,6 +40,7 @@ func getLoadpointDynamicConfig(lp loadpoint.API) loadpoint.DynamicConfig {
 		Soc:              lp.GetSocConfig(),
 		PlanEnergy:       planEnergy,
 		PlanTime:         planTime,
+		PlanPreCondition: int64(planPreCondition.Seconds()),
 		LimitEnergy:      lp.GetLimitEnergy(),
 		LimitSoc:         lp.GetLimitSoc(),
 	}

--- a/server/http_loadpoint_handler.go
+++ b/server/http_loadpoint_handler.go
@@ -48,9 +48,10 @@ func planHandler(lp loadpoint.API) http.HandlerFunc {
 		planTime := lp.EffectivePlanTime()
 		id := lp.EffectivePlanId()
 
+		// TODO late option
 		goal, _ := lp.GetPlanGoal()
 		requiredDuration := lp.GetPlanRequiredDuration(goal, maxPower)
-		plan := lp.GetPlan(planTime, requiredDuration)
+		plan := lp.GetPlan(planTime, requiredDuration, false)
 
 		res := struct {
 			PlanId   int       `json:"planId"`
@@ -87,6 +88,12 @@ func staticPlanPreviewHandler(lp loadpoint.API) http.HandlerFunc {
 			return
 		}
 
+		late, err := strconv.ParseBool(vars["late"])
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
 		switch typ := vars["type"]; typ {
 		case "soc":
 			if !lp.SocBasedPlanning() {
@@ -105,7 +112,7 @@ func staticPlanPreviewHandler(lp loadpoint.API) http.HandlerFunc {
 
 		maxPower := lp.EffectiveMaxPower()
 		requiredDuration := lp.GetPlanRequiredDuration(goal, maxPower)
-		plan := lp.GetPlan(planTime, requiredDuration)
+		plan := lp.GetPlan(planTime, requiredDuration, late)
 
 		res := struct {
 			PlanTime time.Time `json:"planTime"`
@@ -152,9 +159,10 @@ func repeatingPlanPreviewHandler(lp loadpoint.API) http.HandlerFunc {
 			return
 		}
 
+		// TODO late option
 		maxPower := lp.EffectiveMaxPower()
 		requiredDuration := lp.GetPlanRequiredDuration(soc, maxPower)
-		plan := lp.GetPlan(planTime, requiredDuration)
+		plan := lp.GetPlan(planTime, requiredDuration, false)
 
 		res := struct {
 			PlanTime time.Time `json:"planTime"`

--- a/server/http_vehicle_handler.go
+++ b/server/http_vehicle_handler.go
@@ -92,19 +92,27 @@ func planSocHandler(site site.API) http.HandlerFunc {
 			return
 		}
 
-		if err := v.SetPlanSoc(ts, soc); err != nil {
+		preCond, err := parseDuration(vars["preCondition"])
+		if err != nil {
 			jsonError(w, http.StatusBadRequest, err)
 			return
 		}
 
-		ts, soc = v.GetPlanSoc()
+		if err := v.SetPlanSoc(ts, preCond, soc); err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		ts, preCond, soc = v.GetPlanSoc()
 
 		res := struct {
-			Soc  int       `json:"soc"`
-			Time time.Time `json:"time"`
+			Soc          int       `json:"soc"`
+			PreCondition int64     `json:"preCondition"`
+			Time         time.Time `json:"time"`
 		}{
-			Soc:  soc,
-			Time: ts,
+			Soc:          soc,
+			PreCondition: int64(preCond.Seconds()),
+			Time:         ts,
 		}
 
 		jsonResult(w, res)
@@ -152,7 +160,7 @@ func planSocRemoveHandler(site site.API) http.HandlerFunc {
 			return
 		}
 
-		if err := v.SetPlanSoc(time.Time{}, 0); err != nil {
+		if err := v.SetPlanSoc(time.Time{}, 0, 0); err != nil {
 			jsonError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -230,12 +230,13 @@ func (m *MQTT) listenLoadpointSetters(topic string, site site.API, lp loadpoint.
 		{"batteryBoost", boolSetter(lp.SetBatteryBoost)},
 		{"planEnergy", func(payload string) error {
 			var plan struct {
-				Time  time.Time `json:"time"`
-				Value float64   `json:"value"`
+				Time         time.Time `json:"time"`
+				PreCondition int64     `json:"preCondition"`
+				Value        float64   `json:"value"`
 			}
 			err := json.Unmarshal([]byte(payload), &plan)
 			if err == nil {
-				err = lp.SetPlanEnergy(plan.Time, plan.Value)
+				err = lp.SetPlanEnergy(plan.Time, time.Duration(plan.PreCondition)*time.Second, plan.Value)
 			}
 			return err
 		}},
@@ -266,12 +267,13 @@ func (m *MQTT) listenVehicleSetters(topic string, v vehicle.API) error {
 		{"minSoc", intSetter(pass(v.SetMinSoc))},
 		{"planSoc", func(payload string) error {
 			var plan struct {
-				Time  time.Time `json:"time"`
-				Value int       `json:"value"`
+				Time         time.Time `json:"time"`
+				PreCondition int64     `json:"preCondition"`
+				Value        int       `json:"value"`
 			}
 			err := json.Unmarshal([]byte(payload), &plan)
 			if err == nil {
-				err = v.SetPlanSoc(plan.Time, plan.Value)
+				err = v.SetPlanSoc(plan.Time, time.Duration(plan.PreCondition)*time.Second, plan.Value)
 			}
 			return err
 		}},

--- a/tariff/combined.go
+++ b/tariff/combined.go
@@ -40,13 +40,13 @@ func (t *combined) Rates() (api.Rates, error) {
 		var rate api.Rate
 
 		for _, t := range t.tariffs {
-			r, err := At(t, ts)
-			if err != nil {
+			r := At(t, ts)
+			if r == nil {
 				continue
 			}
 
 			if rate.Start.IsZero() {
-				rate = r
+				rate = *r
 				continue
 			}
 

--- a/tariff/tariffs.go
+++ b/tariff/tariffs.go
@@ -24,12 +24,11 @@ func At(t api.Tariff, ts time.Time) *api.Rate {
 }
 
 // Now returns the price/cost/value at the given time
-func Now(t api.Tariff) (float64, error) {
-	r := At(t, time.Now())
-	if r == nil {
-		return 0, api.ErrNotAvailable
+func Now(t api.Tariff) *float64 {
+	if r := At(t, time.Now()); r != nil {
+		return &r.Price
 	}
-	return r.Price, nil
+	return nil
 }
 
 func Forecast(t api.Tariff) api.Rates {

--- a/tariff/tariffs.go
+++ b/tariff/tariffs.go
@@ -14,21 +14,22 @@ type Tariffs struct {
 }
 
 // At returns the rate at the given time
-func At(t api.Tariff, ts time.Time) (api.Rate, error) {
+func At(t api.Tariff, ts time.Time) *api.Rate {
 	if t != nil {
 		if rr, err := t.Rates(); err == nil {
-			if r, err := rr.At(ts); err == nil {
-				return r, nil
-			}
+			return rr.At(ts)
 		}
 	}
-	return api.Rate{}, api.ErrNotAvailable
+	return nil
 }
 
 // Now returns the price/cost/value at the given time
 func Now(t api.Tariff) (float64, error) {
-	r, err := At(t, time.Now())
-	return r.Price, err
+	r := At(t, time.Now())
+	if r == nil {
+		return 0, api.ErrNotAvailable
+	}
+	return r.Price, nil
 }
 
 func Forecast(t api.Tariff) api.Rates {


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/19690

This PR modifies the planner for "late start". If late start is enabled, the plan will always include the latest possible slot. Planner will ensure this simply by marking the latest slot as having zero price.

Note: Planner does not take into account how long this latest slot lasts.

TODO

- [x] decide optionally adding second slot -> split slots to slice off last 60m @andig 
- [x] keep original price for ui @andig 
- [ ] test
- [x] update api: add `preCondition` in seconds @andig 
- [ ] split `rate.At` changes @andig
- [ ] add option to UI @naltatis 
- [ ] add option to repeating plans @naltatis 
- [ ] refactor duration API (add custom type) @andig 