### PR TITLE
EMS ESP: Add power configuration options

### DIFF
--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -32,7 +32,6 @@ render: |
   type: sgready
   power:
     source: http
-    uri: http://{{ .host }}/api/boiler/hpcurrpower
     uri: http://{{ .host }}/api/boiler/{{ .powersource }}
     jq: .value // 0
     {{- if eq .powersource "hppower" }}

--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -15,6 +15,11 @@ group: heating
 params:
   - name: host
   - name: token
+  - name: powersource
+    choice: ["hpcurrpower", "hppower"]
+    description:
+      de: "Leistungsquelle"
+      en: "Power source"
   - name: tempsource
     type: choice
     choice: ["warmwater"]
@@ -25,8 +30,15 @@ render: |
   type: sgready
   power:
     source: http
+    {{- if not .powersource }}
     uri: http://{{ .host }}/api/boiler/hpcurrpower
+    {{- else }}
+    uri: http://{{ .host }}/api/boiler/{{ .powersource }}
+    {{- end }}
     jq: .value
+    {{- if eq .powersource "hppower" }}
+    scale: 1000
+    {{- end}}
   getmode:
     source: go
     script: |

--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -21,6 +21,7 @@ params:
     description:
       de: "Leistungsquelle"
       en: "Power source"
+    default: hpcurrpower
   - name: tempsource
     type: choice
     choice: ["warmwater"]
@@ -31,11 +32,8 @@ render: |
   type: sgready
   power:
     source: http
-    {{- if not .powersource }}
     uri: http://{{ .host }}/api/boiler/hpcurrpower
-    {{- else }}
     uri: http://{{ .host }}/api/boiler/{{ .powersource }}
-    {{- end }}
     jq: .value // 0
     {{- if eq .powersource "hppower" }}
     scale: 1000

--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -15,11 +15,6 @@ group: heating
 params:
   - name: host
   - name: token
-  - name: powersource
-    choice: ["hpcurrpower", "hppower"]
-    description:
-      de: "Leistungsquelle"
-      en: "Power source"
   - name: tempsource
     type: choice
     choice: ["warmwater"]
@@ -29,16 +24,27 @@ params:
 render: |
   type: sgready
   power:
-    source: http
-    {{- if not .powersource }}
-    uri: http://{{ .host }}/api/boiler/hpcurrpower
-    {{- else }}
-    uri: http://{{ .host }}/api/boiler/{{ .powersource }}
-    {{- end }}
-    jq: .value
-    {{- if eq .powersource "hppower" }}
-    scale: 1000
-    {{- end}}
+    source: go
+    script: |
+      res := HPCURRPOWER
+      if res == nil {
+        res = HPPOWER
+      }
+      res
+    in:
+    - name: HPCURRPOWER
+      type: int
+      config:
+        source: http
+        uri: http://{{ .host }}/api/boiler/hpcurrpower
+        jq: .value
+    - name: HPPOWER
+      type: int
+      config:
+        source: http
+        uri: http://{{ .host }}/api/boiler/hppower
+        jq: .value
+        scale: 1000
   getmode:
     source: go
     script: |

--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -15,6 +15,12 @@ group: heating
 params:
   - name: host
   - name: token
+  - name: powersource
+    type: choice
+    choice: ["hpcurrpower", "hppower"]
+    description:
+      de: "Leistungsquelle"
+      en: "Power source"
   - name: tempsource
     type: choice
     choice: ["warmwater"]
@@ -24,15 +30,16 @@ params:
 render: |
   type: sgready
   power:
-    source: calc
-    add:
-    - source: http
-      uri: http://{{ .host }}/api/boiler/hpcurrpower
-      jq: .value // 0
-    - source: http
-      uri: http://{{ .host }}/api/boiler/hppower
-      jq: .value // 0
-      scale: 1000
+    source: http
+    {{- if not .powersource }}
+    uri: http://{{ .host }}/api/boiler/hpcurrpower
+    {{- else }}
+    uri: http://{{ .host }}/api/boiler/{{ .powersource }}
+    {{- end }}
+    jq: .value // 0
+    {{- if eq .powersource "hppower" }}
+    scale: 1000
+    {{- end}}
   getmode:
     source: go
     script: |

--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -24,27 +24,15 @@ params:
 render: |
   type: sgready
   power:
-    source: go
-    script: |
-      res := HPCURRPOWER
-      if res == nil {
-        res = HPPOWER
-      }
-      res
-    in:
-    - name: HPCURRPOWER
-      type: int
-      config:
-        source: http
-        uri: http://{{ .host }}/api/boiler/hpcurrpower
-        jq: .value
-    - name: HPPOWER
-      type: int
-      config:
-        source: http
-        uri: http://{{ .host }}/api/boiler/hppower
-        jq: .value
-        scale: 1000
+    source: calc
+    add:
+    - source: http
+      uri: http://{{ .host }}/api/boiler/hpcurrpower
+      jq: .value // 0
+    - source: http
+      uri: http://{{ .host }}/api/boiler/hppower
+      jq: .value // 0
+      scale: 1000
   getmode:
     source: go
     script: |


### PR DESCRIPTION
Da es in https://github.com/evcc-io/evcc/issues/19660 Probleme beim Auslesen der Kompressorleistung gab, habe ich den Endpunkt konfigurierbar gemacht.

-  `hpcurrpower` liefert den Wert in W
- `hppower` liefert den Wert in kW, deshalb der Skalierungsfaktor

Wenn nichts angegeben wird, soll der bisherige Endpunkt `hpcurrpower` genutzt werden.