### PR TITLE
fix(MQTT): limit the max parallel MQTT publish inflight

### DIFF
--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -81,7 +81,8 @@ func masked(s any) string {
 
 type Mqtt struct {
 	mqtt.Config `mapstructure:",squash"`
-	Topic       string `json:"topic"`
+	Topic       string   `json:"topic"`
+	NoPublish   []string `json:"noPublish"`
 }
 
 // Redacted implements the redactor interface used by the tee publisher

--- a/cmd/configure/helper.go
+++ b/cmd/configure/helper.go
@@ -266,7 +266,7 @@ func (c *CmdConfigure) configureMQTT(_ templates.Template) (map[string]interface
 
 		log := util.NewLogger("mqtt")
 
-		if mqtt.Instance, err = mqtt.RegisteredClient(log, broker, user, password, "", 1, false, caCert, clientCert, clientKey); err == nil {
+		if mqtt.Instance, err = mqtt.RegisteredClient(log, broker, user, password, "", 1, false, caCert, clientCert, clientKey, 512); err == nil {
 			return mqttConfig, nil
 		}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -610,7 +610,7 @@ func configureMqtt(conf *globalconfig.Mqtt) error {
 
 	log := util.NewLogger("mqtt")
 
-	instance, err := mqtt.RegisteredClient(log, conf.Broker, conf.User, conf.Password, conf.ClientID, 1, conf.Insecure, conf.CaCert, conf.ClientCert, conf.ClientKey, func(options *paho.ClientOptions) {
+	instance, err := mqtt.RegisteredClient(log, conf.Broker, conf.User, conf.Password, conf.ClientID, 1, conf.Insecure, conf.CaCert, conf.ClientCert, conf.ClientKey, conf.ParallelInflightLimit, func(options *paho.ClientOptions) {
 		if !runAsService {
 			return
 		}

--- a/meter/zendure/connection.go
+++ b/meter/zendure/connection.go
@@ -41,7 +41,7 @@ func NewConnection(region, account, serial string, timeout time.Duration) (*Conn
 	client, err := mqtt.NewClient(
 		log,
 		net.JoinHostPort(res.Data.MqttUrl, strconv.Itoa(res.Data.Port)), res.Data.AppKey, res.Data.Secret,
-		"", 0, false, "", "", "",
+		"", 0, false, "", "", "", 64,
 	)
 	if err != nil {
 		return nil, err

--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -130,7 +130,8 @@ func (m *Mqtt) IntSetter(param string) (func(int64) error, error) {
 			return err
 		}
 
-		return m.client.Publish(m.topic, m.retained, payload)
+		m.client.Publish(m.topic, m.retained, payload)
+		return nil
 	}, nil
 }
 
@@ -144,7 +145,8 @@ func (m *Mqtt) FloatSetter(param string) (func(float64) error, error) {
 			return err
 		}
 
-		return m.client.Publish(m.topic, m.retained, payload)
+		m.client.Publish(m.topic, m.retained, payload)
+		return nil
 	}, nil
 }
 
@@ -158,7 +160,8 @@ func (m *Mqtt) BoolSetter(param string) (func(bool) error, error) {
 			return err
 		}
 
-		return m.client.Publish(m.topic, m.retained, payload)
+		m.client.Publish(m.topic, m.retained, payload)
+		return nil
 	}, nil
 }
 
@@ -172,6 +175,7 @@ func (m *Mqtt) StringSetter(param string) (func(string) error, error) {
 			return err
 		}
 
-		return m.client.Publish(m.topic, m.retained, payload)
+		m.client.Publish(m.topic, m.retained, payload)
+		return nil
 	}, nil
 }

--- a/plugin/mqtt/registry.go
+++ b/plugin/mqtt/registry.go
@@ -31,7 +31,7 @@ var (
 )
 
 // RegisteredClient reuses an registered Mqtt publisher or creates a new one
-func RegisteredClient(log *util.Logger, broker, user, password, clientID string, qos byte, insecure bool, caCert, clientCert, clientKey string, opts ...Option) (*Client, error) {
+func RegisteredClient(log *util.Logger, broker, user, password, clientID string, qos byte, insecure bool, caCert, clientCert, clientKey string, parallelInflightLimit uint32, opts ...Option) (*Client, error) {
 	key := fmt.Sprintf("%s.%s:%s", broker, user, password)
 
 	mu.Lock()
@@ -42,7 +42,7 @@ func RegisteredClient(log *util.Logger, broker, user, password, clientID string,
 			clientID = ClientID()
 		}
 
-		if client, err = NewClient(log, broker, user, password, clientID, qos, insecure, caCert, clientCert, clientKey, opts...); err == nil {
+		if client, err = NewClient(log, broker, user, password, clientID, qos, insecure, caCert, clientCert, clientKey, parallelInflightLimit, opts...); err == nil {
 			registry.Add(key, client)
 		}
 	}
@@ -57,7 +57,7 @@ func RegisteredClientOrDefault(log *util.Logger, cc Config) (*Client, error) {
 
 	var err error
 	if cc.Broker != "" {
-		client, err = RegisteredClient(log, cc.Broker, cc.User, cc.Password, cc.ClientID, 1, cc.Insecure, cc.CaCert, cc.ClientCert, cc.ClientKey)
+		client, err = RegisteredClient(log, cc.Broker, cc.User, cc.Password, cc.ClientID, 1, cc.Insecure, cc.CaCert, cc.ClientCert, cc.ClientKey, cc.ParallelInflightLimit)
 	}
 
 	if client == nil && err == nil {

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -141,8 +141,7 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload interface{}) 
 }
 
 func (m *MQTT) publishString(topic string, retained bool, payload string) {
-	token := m.Handler.Client.Publish(topic, m.Handler.Qos, retained, m.encode(payload))
-	go m.Handler.WaitForToken("send", topic, token)
+	m.Handler.Publish(topic, retained, m.encode(payload))
 }
 
 func (m *MQTT) publishSingleValue(topic string, retained bool, payload interface{}) {


### PR DESCRIPTION
The old implantation did DOS the MQTT broker with 256+ messages inflight at the time. This can be problematic with MQTT brokers on embedded hardware or when the MQTT broker enforces limits.

This code change allows to:
 - set a `parallelInflightLimit` for the publish
 - configure a filter for the Dropper via `noPublish`
 
 Note:
 the 512 default limit is high and selected on a "work as before" bases, my Broker for example does not like more then 128.