### PR TITLE
Add Volvo (Connected Car)

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -71,6 +71,8 @@ func runToken(cmd *cobra.Command, args []string) {
 		token, err = tronityToken(conf, vehicleConf)
 	case "citroen", "ds", "opel", "peugeot":
 		token, err = psaToken(typ)
+	case "volvo-connected":
+		token, err = volvoToken(vehicleConf)
 
 	default:
 		log.FATAL.Fatalf("vehicle type '%s' does not support token authentication", vehicleConf.Type)

--- a/cmd/token_volvo.go
+++ b/cmd/token_volvo.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/vehicle"
+	"github.com/evcc-io/evcc/vehicle/volvo/connected"
+	"github.com/samber/lo"
+	"golang.org/x/oauth2"
+)
+
+func volvoToken(conf config.Named) (*oauth2.Token, error) {
+	var cc struct {
+		Credentials vehicle.ClientCredentials
+	}
+
+	if err := util.DecodeOther(conf.Other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.Credentials.ID == "" {
+		if err := survey.AskOne(&survey.Input{
+			Message: "Please enter your client id:",
+		}, &cc.Credentials.ID, survey.WithValidator(survey.Required)); err != nil {
+			return nil, err
+		}
+	}
+
+	if cc.Credentials.Secret == "" {
+		if err := survey.AskOne(&survey.Input{
+			Message: "Please enter your client secret:",
+		}, &cc.Credentials.Secret, survey.WithValidator(survey.Required)); err != nil {
+			return nil, err
+		}
+	}
+
+	oc := connected.Oauth2Config(cc.Credentials.ID, cc.Credentials.Secret)
+	cv := oauth2.GenerateVerifier()
+
+	state := lo.RandomString(16, lo.AlphanumericCharset)
+	authorize_url := oc.AuthCodeURL(state, oauth2.S256ChallengeOption(cv))
+
+	fmt.Println("Please visit: ", authorize_url)
+	fmt.Println("And grab the authorization code like described here: https://github.com/flobz/psa_car_controller/discussions/779")
+
+	var code string
+	prompt_code := &survey.Input{
+		Message: "Please enter your authorization code:",
+	}
+	if err := survey.AskOne(prompt_code, &code, survey.WithValidator(survey.Required)); err != nil {
+		return nil, err
+	}
+
+	client := request.NewClient(util.NewLogger("volvo-connected"))
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+
+	return oc.Exchange(ctx, code, oauth2.VerifierOption(cv))
+}

--- a/templates/definition/vehicle/volvo-connected.yaml
+++ b/templates/definition/vehicle/volvo-connected.yaml
@@ -1,17 +1,55 @@
 template: volvo-connected
 products:
   - brand: Volvo
-    description:
-      de: aktuell
-      en: latest
+requirements:
+  description:
+    de: |
+      Für die Nutzung mit EVCC benötigst du einen Volvo Account und einen Volvo Connected Car API Key. 
+      Erstelle dazu auf der [Account Seite](https://developer.volvocars.com/account/) eine neue Applikation und speichere den primären VCC API Key ab. 
+      Veröffentliche nun deine Applikation und wähle unter "Scopes" die Berechtigungen "Connected Vehicle API -> conve:vehicle_relation" und "Energy API -> (alles)" aus.
+      Als Redirect URL kannst du erstmal "http://localhost:9999" (oder etwas anderes nicht erreichbares) verwenden. Der Authorisierungscode wird später händisch aus dem Browser gelesen und eingegeben.
+      Sobald die Applikation erstellt ist, wird sie als "Publication under Review" angezeigt. Das ist nicht weiter schlimm, es funktioniert trotzdem.
+      Erstelle danach einen Token mit `evcc token <auto-name>` und speichere die Tokens in der Konfiguration. Falls Evcc wegen einem invaliden Refresh Token abbricht, lösche die Tokens mit `evcc settings` und generiere sie neu.
+    en: |
+      To use with EVCC, you need a Volvo account and a Volvo Connected Car API Key.
+      To do this, create a new application on the [Account page](https://developer.volvocars.com/account/) and save the primary VCC API key.
+      Now publish your application and select the permissions "Connected Vehicle API -> conve:vehicle_relation" and "Energy API -> (everything)" under "Scopes".
+      You can use "http://localhost:9999" (or something else unreachable) as the redirect URL for now. The authorization code will be read and entered manually from the browser later.
+      Once the application is created, it will be displayed as "Publication under Review". This is not a problem, it still works.
+      Then create a token with `evcc token <car-name>` and save the tokens in the configuration. If Evcc crashes due to an invalid refresh token, delete the tokens with `evcc settings` and generate them again.
 params:
-  - preset: vehicle-base
+  - preset: vehicle-common
   - name: vccapikey
     required: true
     help:
-      en: "Volvo developer portal VCC API Key, see https://github.com/evcc-io/evcc/discussions/3677#discussioncomment-4106300"
-      de: "Volvo developer portal VCC API Key, siehe https://github.com/evcc-io/evcc/discussions/3677#discussioncomment-4106300"
+      en: "Volvo developer portal VCC API Key"
+      de: "Volvo developer portal VCC API Key"
+  - name: clientId
+    required: true
+    help:
+      en: "Client ID of your [Volvo Developer App](https://developer.volvocars.com/)."
+      de: "Client ID deiner [Volvo Developer App](https://developer.volvocars.com/)."
+  - name: clientSecret
+    required: true
+    help:
+      en: "Client Secret of your [Volvo Developer App](https://developer.volvocars.com/)."
+      de: "Client Secret deiner [Volvo Developer App](https://developer.volvocars.com/)."
+  - name: accessToken
+    required: true
+    mask: true
+  - name: refreshToken
+    required: true
+    mask: true
+  - name: vin
+    example: WF0FXX...
 render: |
   type: volvo-connected
   vccapikey: {{ .vccapikey }}
-  {{ include "vehicle-base" . }}
+  credentials:
+    id: {{ .clientId }}
+    secret: {{ .clientSecret }}
+  tokens:
+    access: {{ .accessToken }}
+    refresh: {{ .refreshToken }}
+  vin: {{ .vin }}
+  {{ include "vehicle-common" . }}

--- a/templates/definition/vehicle/volvo.yaml
+++ b/templates/definition/vehicle/volvo.yaml
@@ -1,4 +1,5 @@
 template: volvo
+deprecated: true
 products:
   - brand: Volvo
     description:

--- a/vehicle/volvo/connected/api.go
+++ b/vehicle/volvo/connected/api.go
@@ -42,18 +42,15 @@ func NewAPI(log *util.Logger, identity oauth2.TokenSource, vccapikey string) *AP
 }
 
 func (v *API) Vehicles() ([]string, error) {
-	type Vehicle struct {
-		ID string
-	}
 	var res struct {
-		Vehicles []Vehicle
+		Vehicles []Vehicle `json:"data"`
 	}
 
-	uri := fmt.Sprintf("%s/extended-vehicle/v1/vehicles", ApiURL)
+	uri := fmt.Sprintf("%s/connected-vehicle/v2/vehicles", ApiURL)
 	err := v.GetJSON(uri, &res)
 
 	return lo.Map(res.Vehicles, func(v Vehicle, _ int) string {
-		return v.ID
+		return v.VIN
 	}), err
 }
 

--- a/vehicle/volvo/connected/helper.go
+++ b/vehicle/volvo/connected/helper.go
@@ -1,0 +1,20 @@
+package connected
+
+import (
+	"sync"
+
+	"golang.org/x/oauth2"
+)
+
+var (
+	mu         sync.Mutex
+	identities = make(map[string]oauth2.TokenSource)
+)
+
+func getInstance(subject string) oauth2.TokenSource {
+	return identities[subject]
+}
+
+func addInstance(subject string, identity oauth2.TokenSource) {
+	identities[subject] = identity
+}

--- a/vehicle/volvo/connected/types.go
+++ b/vehicle/volvo/connected/types.go
@@ -31,3 +31,7 @@ type RechargeStatus struct {
 		}
 	}
 }
+
+type Vehicle struct {
+	VIN string
+}

--- a/vehicle/volvo_deprecated.go
+++ b/vehicle/volvo_deprecated.go
@@ -11,7 +11,7 @@ import (
 	"github.com/evcc-io/evcc/vehicle/volvo"
 )
 
-// Volvo is an api.Vehicle implementation for Volvo. cars
+// Volvo is an api.Vehicle implementation for Volvo cars
 type Volvo struct {
 	*embed
 	*request.Helper


### PR DESCRIPTION
Bin mal so frei und führe die Arbeit von @andig aus #18260 weiter.

Ist noch nicht getestet, aber trotzdem ein paar Dinge Gedanken hier:

1. Statt extended-vehicle, connected-vehicle API nutzen, da muss der Endpoint zum Auflisten der Fahrzeuge nicht freigegeben werden.
2. Die RedirectURI, die man beim Erstellen der App im Developer Portal erzeugt, muss wohl später zur RedirectURI des Clients passen. Bin skeptisch, ob das mit localhost so einfach funktioniert.
