### PR TITLE
tariff/open-meteo: Fix incorrect cell temperature estimation

### DIFF
--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -111,7 +111,7 @@ render: |
                         ( ($h.temperature_2m[$i]
                             + ($h.temperature_2m[$i-1] // $h.temperature_2m[$i])
                           ) / 2)
-                        + ($h.global_tilted_irradiance[$i] / 800.0) * rossmodel - 25.0
+                        + $h.global_tilted_irradiance[$i] * rossmodel - 25.0
                       )
                     ))
                 * (1 - calculate_damping($time;


### PR DESCRIPTION
The current implementation of OpenMeteo based forecast estimates too high power yields, especially in in high irradiance cases. The cause is that the cell temperature estimate is too low. 

Cell temperature estimation using Ross model incorrectly uses the formula which uses module temperature delta between module normal operating cell temperature (NOCT) and normal operating conditions (20 degree C) instead of the ross model factor ( (NOCT - 20) / 800 ) while the given default value is the model factor already (cf. [https://www.mdpi.com/2071-1050/14/3/1500](https://www.mdpi.com/2071-1050/14/3/1500) equation 1 + 2 as well as table 1)

To ensure no breaking changes, the calculation formula is adjusted to provide correct results.