### PR TITLE
Amperfied phase switching improvement

### DIFF
--- a/templates/definition/charger/amperfied-solar.yaml
+++ b/templates/definition/charger/amperfied-solar.yaml
@@ -10,7 +10,27 @@ params:
   - name: modbus
     choice: ["tcpip"]
     id: 255
+  - name: phaseswitchduration
+    default: 90
+    type: int
+    description:
+      de: Dauer Phasenumschaltung
+      en: Phase-Switch Duration
+    help:
+      de: Gibt an, wie lange die Wallbox für die Phasenumschaltung benötigt.
+      en: Defines how long it takes for the wallbox to switch phases.
+  - name: internalphaseswitch
+    default: false
+    type: bool
+    description:
+      de: Interne Phasenumschaltung
+      en: Use internal Phase-Switching
+    help:
+      de: Phasenumschaltung wird durch die Wallbox gesteuert.
+      en: Phase-Switch will be handled by wallbox.
 render: |
   type: amperfied
   {{- include "modbus" . }}
   phases1p3p: true
+  phaseswitchduration: {{ .phaseswitchduration }}
+  internalphaseswitch: {{ .internalphaseswitch }}


### PR DESCRIPTION
This change adds a timer which starts when phase-switching is triggered and blocks evcc from sending new max-current commands to the wallbox while phase-switch is in progress to avoid the wallbox aborting the ongoing phase-switching process.
Alternatively internal-phase-switching can be enabled which makes evcc to use a different register and send the Power value to the WB and let WB decide how if 1 or 3 phases are required to deliver the power.
