### PR TITLE
Fronius-GEN24: add 1 phase grid meter

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -30,13 +30,15 @@ params:
     advanced: true
 render: |
   type: custom
-  # sunspec model 203 (int+sf)/ 213 (float) meter
+  # sunspec model 20x (int+sf)/ 21x (float) meter
   {{- if eq .usage "grid" }}
   power:
     source: sunspec
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     value:
+      - 201:W
+      - 211:W
       - 203:W
       - 213:W
   energy:
@@ -44,6 +46,8 @@ render: |
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     value:
+      - 201:TotWhImp
+      - 211:TotWhImp
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
@@ -52,18 +56,24 @@ render: |
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:AphA
+        - 211:AphA
         - 203:AphA
         - 213:AphA
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:AphB
+        - 211:AphB
         - 203:AphB
         - 213:AphB
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:AphC
+        - 211:AphC
         - 203:AphC
         - 213:AphC
   voltages:
@@ -71,18 +81,24 @@ render: |
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:PhVphA
+        - 211:PhVphA
         - 203:PhVphA
         - 213:PhVphA
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:PhVphB
+        - 211:PhVphB
         - 203:PhVphB
         - 213:PhVphB
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:PhVphC
+        - 211:PhVphC
         - 203:PhVphC
         - 213:PhVphC
   powers:
@@ -90,18 +106,24 @@ render: |
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:WphA
+        - 211:WphA
         - 203:WphA
         - 213:WphA
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:WphB
+        - 211:WphB
         - 203:WphB
         - 213:WphB
     - source: sunspec
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
       value:
+        - 201:WphC
+        - 211:WphC
         - 203:WphC
         - 213:WphC
   {{- end }}


### PR DESCRIPTION
Add 1 phase grid meter.

Needed for a typical setup with Fronius Primo GEN24 inverter.