### PR TITLE
Enable HomeWizard kWh meter as charge meter (#20633)

### DIFF
--- a/templates/definition/meter/homewizard-kwh.yaml
+++ b/templates/definition/meter/homewizard-kwh.yaml
@@ -5,7 +5,7 @@ products:
       generic: kWh Meter
 params:
   - name: usage
-    choice: ["pv"]
+    choice: ["pv", "charge"]
   - name: host
 render: |
   type: homewizard


### PR DESCRIPTION
fix https://github.com/evcc-io/evcc/issues/20633

I'm not very familiar with the Go language, but after some attempts, I managed to enable the HomeWizard kWh meter as a charge meter. Earlier today I created an issue #20633 for this request.