### PR TITLE
Easee: wait for essential state during boot

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -55,6 +55,7 @@ type Easee struct {
 	smartCharging         bool
 	authorize             bool
 	enabled               bool
+	initialStatePresent   bool
 	opMode                int
 	pilotMode             string
 	reasonForNoCurrent    int
@@ -345,8 +346,9 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 	default:
 	}
 
-	if c.checkInitialStatePresent() {
+	if !c.initialStatePresent && c.checkInitialStatePresent() {
 		// startup completed
+		c.initialStatePresent = true
 		c.startDone()
 	}
 }

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -334,9 +334,6 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 
 		c.opMode = opMode
 
-		// startup completed
-		c.startDone()
-
 	case easee.REASON_FOR_NO_CURRENT:
 		c.reasonForNoCurrent = value.(int)
 	case easee.PILOT_MODE:
@@ -346,6 +343,19 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 	select {
 	case c.obsC <- res:
 	default:
+	}
+
+	// check c.obsTime for presence of ALL of the following keys: easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.CHARGER_OP_MODE
+	allKeysPresent := true
+	for _, key := range []easee.ObservationID{easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.CHARGER_OP_MODE} {
+		if _, exists := c.obsTime[key]; !exists {
+			allKeysPresent = false
+		}
+	}
+
+	if allKeysPresent {
+		// startup completed
+		c.startDone()
 	}
 }
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -345,18 +345,20 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 	default:
 	}
 
-	// check c.obsTime for presence of ALL of the following keys: easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.CHARGER_OP_MODE
-	allKeysPresent := true
-	for _, key := range []easee.ObservationID{easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.CHARGER_OP_MODE} {
-		if _, exists := c.obsTime[key]; !exists {
-			allKeysPresent = false
-		}
-	}
-
-	if allKeysPresent {
+	if c.checkInitialStatePresent() {
 		// startup completed
 		c.startDone()
 	}
+}
+
+// check c.obsTime for presence of ALL of the following keys: easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.CHARGER_OP_MODE
+func (c *Easee) checkInitialStatePresent() bool {
+	for _, key := range []easee.ObservationID{easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.CHARGER_OP_MODE, easee.TOTAL_POWER} {
+		if _, exists := c.obsTime[key]; !exists {
+			return false
+		}
+	}
+	return true
 }
 
 // ChargerUpdate implements the signalr receiver


### PR DESCRIPTION
fix #20384

@andig this likely works, but I don't like it - so I would appreciate your input on my thinking below.

The former solution waited for a single ProductUpdate (CHARGER_OP_MODE) and this signalling was quite elegant.
Also, since OP_MODE does not change often and no compute was needed this was fine.

Now, the situation is different, as we need to check for presence of multiple ProductUpdates to have arrived.
Currently, I am reusing the map with the observation timestamps (`c.obsTime`) and check for the respective keys to be present.

What I don't like in particular is that this check is now done whenever a product update arrives. I don't know how compute expensive checking for keys is, but given we have roughly 75 items in that map and ProductUpdates arrive a few a minute when idle, and more if a charge is on-going this seems kind of wasteful. Also, given we only need to have this check complete successfully once, it kind of feels not great to keep doing these checks once they have served their purpose.

I was thinking if it were to make more sense to move this check into the initialization of Easee instead, using some fixed frequency (aka busy waiting). Not as elegant, but would at least not keep performing those checks for entire runtime of evcc.  