### PR TITLE
Polestar: change regex to find resume path for authorization

### DIFF
--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -93,7 +93,8 @@ func (v *Identity) login() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	matches := regexp.MustCompile(`url:\s*"/as/(.+?)/resume/as/authorization\.ping"`).FindStringSubmatch(string(body))
+	matches := regexp.MustCompile(`(?:url|action):\s*"/as/(.+?)/resume/as/authorization\.ping"`).FindStringSubmatch(string(body))
+
 	if len(matches) < 2 {
 		return nil, errors.New("could not find resume path")
 	}


### PR DESCRIPTION
Change regex to find ``resume path``

This should fix https://github.com/evcc-io/evcc/issues/20648