### PR TITLE
Easee: remove outdated special handling of SessionEnergy

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -291,13 +291,10 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 	case easee.TOTAL_POWER:
 		c.currentPower = 1e3 * value.(float64)
 	case easee.SESSION_ENERGY:
-		// SESSION_ENERGY must not be set to 0 by Productupdates, they occur erratic
-		// Reset to 0 is done in case CHARGER_OP_MODE
-		if value.(float64) != 0 {
-			c.sessionEnergy = value.(float64)
-		}
+		c.sessionEnergy = value.(float64)
 	case easee.LIFETIME_ENERGY:
 		c.totalEnergy = value.(float64)
+		// Remember value of LIFETIME_ENERGY as start value of the charging session
 		if c.sessionStartEnergy == nil {
 			f := c.totalEnergy
 			c.sessionStartEnergy = &f
@@ -324,12 +321,8 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 	case easee.CHARGER_OP_MODE:
 		opMode := value.(int)
 
-		// New charging session pending, reset internal value of SESSION_ENERGY to 0, and its observation timestamp to "now".
-		// This should be done in a proper way by the api, but it's not.
-		// Remember value of LIFETIME_ENERGY as start value of the charging session
+		// New charging session pending, reset sessionStartEnergy
 		if c.opMode <= easee.ModeDisconnected && opMode >= easee.ModeAwaitingStart {
-			c.sessionEnergy = 0
-			c.obsTime[easee.SESSION_ENERGY] = time.Now()
 			c.sessionStartEnergy = nil
 		}
 

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -50,23 +50,6 @@ func TestProductUpdate_IgnoreOutdatedProductUpdate(t *testing.T) {
 	assert.Equal(t, 2, e.opMode)
 }
 
-func TestProductUpdate_IgnoreZeroSessionEnergy(t *testing.T) {
-	e := newEasee()
-
-	now := time.Now().UTC().Truncate(0)
-	e.ProductUpdate(createPayload(easee.SESSION_ENERGY, now, easee.Double, "20"))
-
-	assert.Equal(t, now, e.obsTime[easee.SESSION_ENERGY])
-	assert.Equal(t, float64(20), e.sessionEnergy)
-
-	t2 := time.Now().UTC().Truncate(0)
-	e.ProductUpdate(createPayload(easee.SESSION_ENERGY, t2, easee.Double, "0.0"))
-
-	//expect observation timestamp updated, value however not
-	assert.Equal(t, t2, e.obsTime[easee.SESSION_ENERGY])
-	assert.Equal(t, float64(20), e.sessionEnergy)
-}
-
 func TestProductUpdate_LifetimeEnergyAndSessionStartEnergy(t *testing.T) {
 	e := newEasee()
 


### PR DESCRIPTION
The resetting of the internal session energy values is no longer required.
The ProductUpdates for SESSION_ENERGY are coming in reliably (again).