### PR TITLE
Revert "Circuit: fix validateCurrent and validatePower (#20183)" and fix problem in old logic

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -239,8 +239,8 @@ type Circuit interface {
 	SetMaxPower(float64)
 	SetMaxCurrent(float64)
 	Update([]CircuitLoad) error
-	ValidateCurrent(old, new float64, charging bool) float64
-	ValidatePower(old, new float64, charging bool) float64
+	ValidateCurrent(old, new float64) float64
+	ValidatePower(old, new float64) float64
 }
 
 // Redactor is an interface to redact sensitive data

--- a/api/mock.go
+++ b/api/mock.go
@@ -953,31 +953,31 @@ func (mr *MockCircuitMockRecorder) Update(arg0 any) *gomock.Call {
 }
 
 // ValidateCurrent mocks base method.
-func (m *MockCircuit) ValidateCurrent(old, new float64, charging bool) float64 {
+func (m *MockCircuit) ValidateCurrent(old, new float64) float64 {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateCurrent", old, new, charging)
+	ret := m.ctrl.Call(m, "ValidateCurrent", old, new)
 	ret0, _ := ret[0].(float64)
 	return ret0
 }
 
 // ValidateCurrent indicates an expected call of ValidateCurrent.
-func (mr *MockCircuitMockRecorder) ValidateCurrent(old, new, charging any) *gomock.Call {
+func (mr *MockCircuitMockRecorder) ValidateCurrent(old, new any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCurrent", reflect.TypeOf((*MockCircuit)(nil).ValidateCurrent), old, new, charging)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCurrent", reflect.TypeOf((*MockCircuit)(nil).ValidateCurrent), old, new)
 }
 
 // ValidatePower mocks base method.
-func (m *MockCircuit) ValidatePower(old, new float64, charging bool) float64 {
+func (m *MockCircuit) ValidatePower(old, new float64) float64 {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidatePower", old, new, charging)
+	ret := m.ctrl.Call(m, "ValidatePower", old, new)
 	ret0, _ := ret[0].(float64)
 	return ret0
 }
 
 // ValidatePower indicates an expected call of ValidatePower.
-func (mr *MockCircuitMockRecorder) ValidatePower(old, new, charging any) *gomock.Call {
+func (mr *MockCircuitMockRecorder) ValidatePower(old, new any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePower", reflect.TypeOf((*MockCircuit)(nil).ValidatePower), old, new, charging)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePower", reflect.TypeOf((*MockCircuit)(nil).ValidatePower), old, new)
 }
 
 // Wrap mocks base method.

--- a/core/circuit/circuit.go
+++ b/core/circuit/circuit.go
@@ -320,54 +320,45 @@ func (c *Circuit) GetMaxPhaseCurrent() float64 {
 }
 
 // ValidatePower validates power request
-func (c *Circuit) ValidatePower(old, new float64, charging bool) float64 {
+func (c *Circuit) ValidatePower(old, new float64) float64 {
 	if maxPower := c.GetMaxPower(); maxPower != 0 {
+		delta := max(0, new-old)
 		potential := maxPower - c.power
 
-		var capped float64
-		if charging {
-			capped = min(new, maxPower, max(0, potential+old))
-		} else {
-			capped = min(new, max(0, potential))
-		}
-		if new > capped {
+		if delta > potential {
+			capped := min(new, max(0, old+potential))
 			c.log.DEBUG.Printf("validate power: %.5gW + (%.5gW -> %.5gW) > %.5gW capped at %.5gW", c.power, old, new, maxPower, capped)
+			new = capped
 		} else {
 			c.log.TRACE.Printf("validate power: %.5gW + (%.5gW -> %.5gW) <= %.5gW ok", c.power, old, new, maxPower)
 		}
-		new = capped
 	}
 
 	if c.parent == nil {
 		return new
 	}
 
-	return c.parent.ValidatePower(old, new, charging)
+	return c.parent.ValidatePower(old, new)
 }
 
 // ValidateCurrent validates current request
-func (c *Circuit) ValidateCurrent(old, new float64, charging bool) float64 {
+func (c *Circuit) ValidateCurrent(old, new float64) float64 {
 	if maxCurrent := c.GetMaxCurrent(); maxCurrent != 0 {
+		delta := max(0, new-old)
 		potential := maxCurrent - c.current
 
-		var capped float64
-		if charging {
-			capped = min(new, maxCurrent, max(0, potential+old))
-		} else {
-			capped = min(new, max(0, potential))
-		}
-		if new > capped {
+		if delta > potential {
+			capped := min(new, max(0, old+potential))
 			c.log.DEBUG.Printf("validate current: %.3gA + (%.3gA -> %.3gA) > %.3gA capped at %.3gA", c.current, old, new, maxCurrent, capped)
+			new = capped
 		} else {
 			c.log.TRACE.Printf("validate current: %.3gA + (%.3gA -> %.3gA) <= %.3gA ok", c.current, old, new, maxCurrent)
 		}
-
-		new = capped
 	}
 
 	if c.parent == nil {
 		return new
 	}
 
-	return c.parent.ValidateCurrent(old, new, charging)
+	return c.parent.ValidateCurrent(old, new)
 }

--- a/core/circuit/circuit_test.go
+++ b/core/circuit/circuit_test.go
@@ -32,12 +32,13 @@ func circuitTests() []circuitTest {
 		{0, 1, 0, 2, 1, 1}, // -
 
 		// circuit 1 overloaded
-		{0, 2, 0, 0, 0, 0}, // =
-		{0, 2, 0, 0, 1, 0}, // +
-		{0, 2, 0, 1, 1, 0}, // =
-		{0, 2, 0, 2, 2, 1}, // =
-		{0, 2, 0, 2, 3, 1}, // +
-		{0, 2, 0, 2, 1, 1}, // -
+		{0, 2, 0, 0, 0, 0},   // =
+		{0, 2, 0, 0, 1, 0},   // +
+		{0, 2, 0, 1, 1, 0},   // =
+		{0, 2, 0, 2, 2, 1},   // =
+		{0, 2, 0, 2, 3, 1},   // +
+		{0, 2, 0, 2, 1, 1},   // -
+		{0, 1.2, 0, 2, 1, 1}, // -
 
 		// parent loaded
 		{1, 0, 0, 0, 0, 0}, // =
@@ -47,13 +48,12 @@ func circuitTests() []circuitTest {
 		{1, 0, 0, 2, 1, 1}, // -
 
 		// parent overloaded
-		{2, 0, 0, 0, 0, 0},   // =
-		{2, 0, 0, 0, 1, 0},   // +
-		{2, 0, 0, 1, 1, 0},   // =
-		{2, 0, 0, 2, 2, 1},   // =
-		{2, 0, 0, 2, 3, 1},   // +
-		{2, 0, 0, 2, 1, 1},   // -
-		{1.1, 0, 0, 1, 0, 0}, // -
+		{2, 0, 0, 0, 0, 0}, // =
+		{2, 0, 0, 0, 1, 0}, // +
+		{2, 0, 0, 1, 1, 0}, // =
+		{2, 0, 0, 2, 2, 1}, // =
+		{2, 0, 0, 2, 3, 1}, // +
+		{2, 0, 0, 2, 1, 1}, // -
 	}
 }
 
@@ -83,7 +83,7 @@ func TestCircuitPower(t *testing.T) {
 		cm2.EXPECT().CurrentPower().Return(tc.c2, nil)
 		require.NoError(t, pc.Update(nil))
 
-		assert.Equal(t, tc.res, c1.ValidatePower(tc.old, tc.new, true), tc)
+		assert.Equal(t, tc.res, c1.ValidatePower(tc.old, tc.new), tc)
 
 		ctrl.Finish()
 	}
@@ -125,7 +125,7 @@ func TestCircuitCurrents(t *testing.T) {
 		cm2.MockPhaseCurrents.EXPECT().Currents().Return(tc.c2, tc.c2, tc.c2, nil)
 		require.NoError(t, pc.Update(nil))
 
-		assert.Equal(t, tc.res, c1.ValidateCurrent(tc.old, tc.new, true), tc)
+		assert.Equal(t, tc.res, c1.ValidateCurrent(tc.old, tc.new), tc)
 
 		ctrl.Finish()
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -836,10 +836,10 @@ func (lp *Loadpoint) setLimit(current float64) error {
 
 	// apply circuit limits
 	if lp.circuit != nil {
-		currentLimit := lp.circuit.ValidateCurrent(lp.offeredCurrent, current, lp.charging())
+		currentLimit := lp.circuit.ValidateCurrent(max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2]), current)
 
 		activePhases := lp.ActivePhases()
-		powerLimit := lp.circuit.ValidatePower(lp.chargePower, currentToPower(current, activePhases), lp.charging())
+		powerLimit := lp.circuit.ValidatePower(lp.chargePower, currentToPower(current, activePhases))
 		currentLimitViaPower := powerToCurrent(powerLimit, activePhases)
 
 		current = lp.roundedCurrent(min(currentLimit, currentLimitViaPower))


### PR DESCRIPTION
Fixes #20717, #20712, #19166, refs #20365


- Revert "Circuit: fix validateCurrent and validatePower (#20183)"
- https://github.com/evcc-io/evcc/issues/20365#issuecomment-2781394719 call ValidateCurrent with actual charge current
- never return more than requested from ValidateCurrent and ValidatePower. see https://github.com/evcc-io/evcc/pull/20183#issue-2953805118 "Allow charge current reduction in case of circuit overcurrent + overpower"
     - added a test for this scenario