### PR TITLE
Deye HP3: Use out-of-grid register for grid power

### DIFF
--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -43,7 +43,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 625 # Grid side total power
+      address: 619 # Out-of-grid –total power
       type: holding
       decode: int16
   energy:


### PR DESCRIPTION
I have a SUN-15K-SG01HP3-EU-AM2 running the latest firmware `3002-1087-1E08`.
The issue with the current template is that the inverter only reads the current feed-in/consumption of the inverter and not the power at the grid feed-in point. This is from the register documentation that I got from Deye:
![grafik](https://github.com/user-attachments/assets/0bfec520-599a-406c-903d-0362e0c8643e)
From the description I think register `619` is the correct one and after testing I can confirm that it works for me.
The challenge with this inverter is that there are three ways that the grid power can be measured:
1. With current clamps(I am using this)

| Grid | Current Clamps | Inverter  |
|------|----------------|-----------|
|      |                | Loads(WB) |
2. With an RS485 energy meter

| Grid | Energy Meter | Inverter  |
|------|--------------|-----------|
|      |              | Loads(WB) |
3. By connection everything behind the `Load` port of the inverter

| Grid | Inverter | Loads(WB) |
|------|----------|-----------|

I suspect that all previous users of this template are using the third mode which would then explain why register `625` was showing the correct values for them. It would be great if someone with another configuration can confirm that the new register also works for them.