### PR TITLE
Sonnenbatterie 5/6 support batterymode

### DIFF
--- a/plugin/sleep.go
+++ b/plugin/sleep.go
@@ -1,0 +1,61 @@
+package plugin
+
+import (
+	"context"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+)
+
+type sleepPlugin struct {
+	duration time.Duration
+}
+
+func init() {
+	registry.AddCtx("sleep", NewSleepFromConfig)
+}
+
+// NewSleepFromConfig creates sleep provider
+func NewSleepFromConfig(ctx context.Context, other map[string]interface{}) (Plugin, error) {
+	var cc struct {
+		Duration time.Duration
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	o := &sleepPlugin{
+		duration: cc.Duration,
+	}
+
+	return o, nil
+}
+
+// sleeper is the generic sleeper function for sleepPlugin
+// it is currently not possible to write this as a method
+func sleeper[T comparable](o *sleepPlugin) func(T) error {
+	return func(val T) error {
+		<-time.After(o.duration)
+
+		return nil
+	}
+}
+
+var _ IntSetter = (*sleepPlugin)(nil)
+
+func (o *sleepPlugin) IntSetter(param string) (func(int64) error, error) {
+	return sleeper[int64](o), nil
+}
+
+var _ FloatSetter = (*sleepPlugin)(nil)
+
+func (o *sleepPlugin) FloatSetter(param string) (func(float64) error, error) {
+	return sleeper[float64](o), nil
+}
+
+var _ BoolSetter = (*sleepPlugin)(nil)
+
+func (o *sleepPlugin) BoolSetter(param string) (func(bool) error, error) {
+	return sleeper[bool](o), nil
+}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -11,6 +11,9 @@ params:
     default: 7979
   - name: capacity
     advanced: true
+  - name: chargepower
+    default: 3000
+    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -48,5 +51,37 @@ render: |
     source: http
     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery
     jq: .M30 # SOC relative to usable capacity (.M05 # display SOC)
+  batterymode:
+    source: switch
+    switch:
+      - case: 1 # normal
+        set:
+          source: http
+          method: PUT
+          uri: http://{{ .host }}:{{ .port }}/rest/devices/battery/C06
+          body: '10' # Automatic
+      - case: 2 # hold
+        set:
+          source: http
+          method: PUT
+          uri: http://{{ .host }}:{{ .port }}/rest/devices/battery/C06
+          body: '20' # Standby
+      - case: 3 # charge
+        set:
+          source: sequence
+          set:
+            - source: http
+              method: PUT
+              uri: http://{{ .host }}:{{ .port }}/rest/devices/battery/C06
+              body: '55' # slave mode
+            - source: sleep
+              duration: 1s
+            - source: watchdog
+              timeout: 30s # 3 minutes without setting a value will stop all charging
+              set:
+                source: http
+                method: PUT
+                uri: http://{{ .host }}:{{ .port }}/rest/devices/battery/C24
+                body: '{{ .chargepower }}'
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
This adds batterymode control support for the Sonnenbatterie eco 5/6 line.
There has to be a delay between the http request to set the battery into slave mode and setting the charging power. If both requests are sent without a delay the charging power will be set and returned by the api, but the battery won´t start charging, even on subsequent requests that set the charging power again.
This appears to be some sort of race condition with the timer that stops charging if no requests are received for three minutes.
Therefore I added a `sleep` plugin.