### PR TITLE
huawei-emma: fix pv energy scaling

### DIFF
--- a/templates/definition/meter/huawei-emma.yaml
+++ b/templates/definition/meter/huawei-emma.yaml
@@ -74,7 +74,7 @@ render: |
       address: 30344 # E-Total
       type: holding
       decode: uint32
-    scale: 0.1
+    scale: 0.01
   {{- end }}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
kommt aus https://github.com/evcc-io/evcc/discussions/20733

Laut Modbus Doku ist der Faktor 100 und nicht 10.

[SmartHEMS V100R024C00 MODBUS Interface Definitions.pdf](https://github.com/user-attachments/files/19831796/SmartHEMS.V100R024C00.MODBUS.Interface.Definitions.pdf)

cc/ @Mungg1818 