### PR TITLE
Battery Settings UI: improve readability

### DIFF
--- a/assets/js/components/Battery/BatterySettingsModal.vue
+++ b/assets/js/components/Battery/BatterySettingsModal.vue
@@ -555,18 +555,20 @@ export default defineComponent({
 	transform: translateY(-50%);
 }
 .batterySoc {
-	border-radius: 0.5rem;
-	left: 0.5rem;
-	right: 0.5rem;
-	height: 0.5rem;
-	opacity: 0.5;
+	--size: 0.7rem;
+	border-radius: var(--size);
+	left: 1rem;
+	right: 1rem;
+	height: var(--size);
+	opacity: 0.8;
 }
 
 .bufferStartIndicator {
+	--size: 0.7rem;
 	display: flex;
 	justify-content: space-between;
-	left: 0;
-	right: 0;
+	left: calc(-1 * var(--size) / 4);
+	right: calc(-1 * var(--size) / 4);
 }
 .bufferStartIndicator--hidden {
 	opacity: 0;
@@ -574,15 +576,15 @@ export default defineComponent({
 }
 .bufferStartIndicator__left,
 .bufferStartIndicator__right {
-	height: 0.5rem;
-	width: 0.5rem;
+	height: var(--size);
+	width: var(--size);
 	background-color: var(--evcc-box);
 }
 .bufferStartIndicator__left {
-	border-radius: 0 0.5rem 0.5rem 0;
+	border-radius: 0 var(--size) var(--size) 0;
 }
 .bufferStartIndicator__right {
-	border-radius: 0.5rem 0 0 0.5rem;
+	border-radius: var(--size) 0 0 var(--size);
 }
 .progress {
 	flex: 1;


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/20788

- ☯️ improve contrast for battery soc indicator (less opacity)
- 🐘 increased size of buffer soc start and battery soc indicator by 40%

Note: In the future it might be a good idea to implement a dedicated high contrast color scheme based on browsers [prefer contrast](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast) settings. 

**before**
<img width="1028" alt="before" src="https://github.com/user-attachments/assets/86abcdf2-793c-499f-b655-b0d5f9f8c34d" />

**after**
<img width="1018" alt="after" src="https://github.com/user-attachments/assets/c26831b2-1baf-4e51-8170-467d314719e9" />


**after (more states)**
<img width="1069" alt="Bildschirmfoto 2025-04-23 um 08 59 26" src="https://github.com/user-attachments/assets/8e2bebf9-4af7-4f4f-a3a2-c79136b53705" />

<img width="1131" alt="Bildschirmfoto 2025-04-23 um 08 58 37" src="https://github.com/user-attachments/assets/2ccc2fc0-f0f2-49d8-b624-b6f475f349a3" />

<img width="979" alt="Bildschirmfoto 2025-04-23 um 08 59 03" src="https://github.com/user-attachments/assets/c77914ab-d31a-4ab2-8251-153cc8b869d6" />

<img width="1089" alt="Bildschirmfoto 2025-04-23 um 08 59 00" src="https://github.com/user-attachments/assets/dfdc1a47-68e4-4f9e-a77c-05469da22541" />

<img width="1149" alt="Bildschirmfoto 2025-04-23 um 08 58 41" src="https://github.com/user-attachments/assets/57ec76f0-806a-4c24-b822-5d78426d157c" />
