### PR TITLE
devcontainer: fix conflicting go versions on setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,9 +17,6 @@
 			"version": "lts",
 			"pnpmVersion": "latest",
 			"nvmVersion": "latest"
-		},
-		"ghcr.io/devcontainers/features/go:1": {
-			"version": "latest"
 		}
 	},
 	"postCreateCommand": "make install-ui && make install",


### PR DESCRIPTION
the devcontainer will install conflicting versions of go which results in initialization errors during startup. This has been fixed

fixes #20824