### PR TITLE
Pass more descriptive user agent when connecting to Tibber

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "evcc",
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.24-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
 			"moby": true,

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -26,15 +26,22 @@ func getUserAgent() string {
 	graphqlClientVersion := "0.13.2+unknown"
 
 	if info, ok := debug.ReadBuildInfo(); ok {
-		evccVersion = info.Main.Version
+		evccVersion = baseVersion(info.Main.Version)
 		for _, dep := range info.Deps {
 			if dep.Path == "github.com/hasura/go-graphql-client" {
-				graphqlClientVersion = dep.Version
+				graphqlClientVersion = baseVersion(dep.Version)
 			}
 		}
 	}
 
 	return fmt.Sprintf("evcc/%s hasura/go-graphql-client/%s", evccVersion, graphqlClientVersion)
+}
+
+func baseVersion(v string) string {
+	if i := strings.IndexAny(v, "-+"); i != -1 {
+		return v[:i]
+	}
+	return v
 }
 
 type Tibber struct {

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -3,7 +3,9 @@ package meter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -17,6 +19,22 @@ import (
 
 func init() {
 	registry.AddCtx("tibber-pulse", NewTibberFromConfig)
+}
+
+func getUserAgent() string {
+	evccVersion := "0.203.2+unknown"
+	graphqlClientVersion := "0.13.2+unknown"
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		evccVersion = info.Main.Version
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/hasura/go-graphql-client" {
+				graphqlClientVersion = dep.Version
+			}
+		}
+	}
+
+	return fmt.Sprintf("evcc/%s hasura/go-graphql-client/%s", evccVersion, graphqlClientVersion)
 }
 
 type Tibber struct {
@@ -78,7 +96,7 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 				Transport: &transport.Decorator{
 					Base: http.DefaultTransport,
 					Decorator: transport.DecorateHeaders(map[string]string{
-						"User-Agent": "go-graphql-client/0.9.0",
+						"User-Agent": getUserAgent(),
 					}),
 				},
 			},


### PR DESCRIPTION
We have recently started seeing big amounts of badly behaving clients connecting to Tibber websocket API (reconnecting super frequently even on error - basically DDOSing us) using user agent go-graphql-client/0.9.0.

This PR makes evcc pass more descriptive, up-to-date user agent so we don't mix it with the bad one. We might need to ban go-graphql-client/0.9.0 from connecting entirely.

Toni
Tibber