### PR TITLE
KEBA: Add support for KeContact P40 charger

### DIFF
--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -3,6 +3,9 @@ products:
   - brand: KEBA
     description:
       generic: KeContact P20, P30, C/X Series
+  - brand: KEBA
+    description:
+      generic: KeContact P40, P40 Pro
   - brand: BMW
     description:
       generic: i Wallbox


### PR DESCRIPTION
The modbus implementation for the KeContact P40 is mostly the same as for the P30 devices. There are some differences:

  - The "Product type and features" register (1016) has a slightly different layout.

  - Enabling/disabling needs to be done by setting the maximum current to 0, which is not supported by the P30 devices.