### PR TITLE
Easee: wait for optional state during boot

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -200,12 +200,13 @@ func NewEasee(user, password, charger string, timeout time.Duration, authorize b
 }
 
 func (c *Easee) waitForOptionalState() {
-    for i := 0; i < 30; i++ {
-        if c.optionalStatePresent() {
-    	    return
-        }
-        time.Sleep(100 * time.Millisecond)
+	for i := 0; i < 30; i++ {
+		if c.optionalStatePresent() {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
+	c.log.WARN.Println("did not receive full state from cloud")
 }
 
 // check c.obsTime for presence of ALL of the following keys: easee.SESSION_ENERGY, easee.LIFETIME_ENERGY

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -219,12 +219,8 @@ func (c *Easee) waitForOptionalState() {
 func (c *Easee) optionalStatePresent() bool {
 	c.mux.Lock()
 	defer c.mux.Unlock()
-	for _, key := range []easee.ObservationID{easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.TOTAL_POWER} {
-		if _, exists := c.obsTime[key]; !exists {
-			return false
-		}
-	}
-	return true
+	wanted := []easee.ObservationID{easee.SESSION_ENERGY, easee.LIFETIME_ENERGY, easee.TOTAL_POWER}
+	return len(wanted) == len(lo.Intersect(wanted, lo.Keys(c.obsTime)))
 }
 
 func (c *Easee) chargerSite(charger string) (easee.Site, error) {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -200,18 +200,11 @@ func NewEasee(user, password, charger string, timeout time.Duration, authorize b
 }
 
 func (c *Easee) waitForOptionalState() {
-	if !c.optionalStatePresent() {
-		timeout := time.After(3 * time.Second)
-		for {
-			select {
-			case <-time.Tick(500 * time.Millisecond):
-				if c.optionalStatePresent() {
-					return
-				}
-			case <-timeout:
-				return
-			}
-		}
+    for i := 0; i < 30; i++ {
+        if c.optionalStatePresent() {
+    	    return
+        }
+        time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -87,22 +87,6 @@ func TestProductUpdate_InitialStateCheck(t *testing.T) {
 	}
 }
 
-func TestEasee_waitForOptionalStateTimeout(t *testing.T) {
-	e := newEasee()
-
-	done := make(chan bool, 1)
-	go func(chan bool) {
-		e.waitForOptionalState()
-		done <- true
-	}(done)
-
-	select {
-	case <-done:
-	case <-time.After(4 * time.Second):
-		assert.Fail(t, "waitForOptionalState did not return")
-	}
-}
-
 // TestInExpectedOpMode tests the inExpectedOpMode function with different scenarios
 func TestInExpectedOpMode(t *testing.T) {
 	tc := []struct {


### PR DESCRIPTION
fix #20384 

changed approach compared to the previous solution:
* charger op mode remains the sole mandatory state
* once that is available, we wait for up to 3 seconds max for further optional states (session energy, and meter values)

## Summary by Sourcery

Improve Easee charger initialization by waiting for optional states during boot

Bug Fixes:
- Ensure more complete state retrieval during charger initialization

Enhancements:
- Add a mechanism to wait for optional charger states with a timeout
- Implement optional state presence check

Tests:
- Add test cases to verify optional state initialization and tracking