### PR TITLE
Shelly: Heat control via Add-On

### DIFF
--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -16,6 +16,7 @@ type Generation interface {
 	Enabled() (bool, error)
 	Enable(bool) error
 	TotalEnergy() (float64, error)
+	ExecCmd(string, bool, any) error
 }
 
 type Phases interface {

--- a/meter/shelly/gen1.go
+++ b/meter/shelly/gen1.go
@@ -133,3 +133,7 @@ func (c *gen1) energy(energy float64) float64 {
 	}
 	return energy
 }
+
+func (c *gen1) ExecCmd(method string, enable bool, res any) error {
+	return nil
+}

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -85,7 +85,7 @@ type gen2 struct {
 func apiCall[T any](c *gen2, api string) func() (T, error) {
 	return func() (T, error) {
 		var res T
-		if err := c.execCmd(fmt.Sprintf("%s?id=%d", api, c.channel), false, &res); err != nil {
+		if err := c.ExecCmd(fmt.Sprintf("%s?id=%d", api, c.channel), false, &res); err != nil {
 			return res, err
 		}
 		return res, nil
@@ -110,7 +110,7 @@ func newGen2(helper *request.Helper, uri, model string, channel int, user, passw
 	}
 
 	var res Gen2Methods
-	if err := c.execCmd("Shelly.ListMethods", false, &res); err != nil {
+	if err := c.ExecCmd("Shelly.ListMethods", false, &res); err != nil {
 		return nil, err
 	}
 
@@ -130,7 +130,7 @@ func newGen2(helper *request.Helper, uri, model string, channel int, user, passw
 }
 
 // execCmd executes a shelly api gen2+ command and provides the response
-func (c *gen2) execCmd(method string, enable bool, res any) error {
+func (c *gen2) ExecCmd(method string, enable bool, res any) error {
 	data := &Gen2RpcPost{
 		Id:     c.channel,
 		On:     enable,
@@ -180,7 +180,7 @@ func (c *gen2) Enabled() (bool, error) {
 func (c *gen2) Enable(enable bool) error {
 	var res Gen2SwitchStatus
 	c.switchstatus.Reset()
-	return c.execCmd("Switch.Set?id="+strconv.Itoa(c.channel), enable, &res)
+	return c.ExecCmd("Switch.Set?id="+strconv.Itoa(c.channel), enable, &res)
 }
 
 // TotalEnergy implements the api.Meter interface

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -31,7 +31,7 @@ render: |
     {{- end }}
     {{- if .icon }}
     icon: {{ .icon }}
-    {{- end }}    
+    {{- end }}
     uri: http://{{ .host }}
     {{- if .user }}
     user: {{ .user }}
@@ -41,4 +41,4 @@ render: |
     {{- end }}
     channel: {{ .channel }}  # shelly device relay channel
     targettc: {{ .targettc }}
-    capacity: {{ .capacity }}    
+    capacity: {{ .capacity }}

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -18,6 +18,7 @@ params:
       de: Shelly Add-On Mess-Kanal
       en: Shelly Add-On channel
   - name: targettc
+    default: 45
     required: true
     description:
       de: Zieltemperatur in °C

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -1,0 +1,44 @@
+template: shelly-heat-control
+products:
+  - brand: Shelly
+    description:
+      generic: Sensor Add-On (Temperature)
+group: heating
+params:
+  - name: title
+  - name: icon
+    default: heater
+  - name: host
+    required: true
+  - name: user
+  - name: password
+  - name: channel
+    default: 100
+    description:
+      de: Shelly Add-On Mess-Kanal
+      en: Shelly Add-On channel
+  - name: targettc
+    required: true
+    description:
+      de: Zieltemperatur in °C
+      en: Target temperature in °C
+  - name: capacity
+    default: 12
+render: |
+    type: shelly-heat-control
+    {{- if .title }}
+    title: {{ .title }}
+    {{- end }}
+    {{- if .icon }}
+    icon: {{ .icon }}
+    {{- end }}    
+    uri: http://{{ .host }}
+    {{- if .user }}
+    user: {{ .user }}
+    {{- end }}
+    {{- if .password }}
+    password: {{ .password }}
+    {{- end }}
+    channel: {{ .channel }}  # shelly device relay channel
+    targettc: {{ .targettc }}
+    capacity: {{ .capacity }}    

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -26,20 +26,20 @@ params:
   - name: capacity
     default: 12
 render: |
-    type: shelly-heat-control
-    {{- if .title }}
-    title: {{ .title }}
-    {{- end }}
-    {{- if .icon }}
-    icon: {{ .icon }}
-    {{- end }}
-    uri: http://{{ .host }}
-    {{- if .user }}
-    user: {{ .user }}
-    {{- end }}
-    {{- if .password }}
-    password: {{ .password }}
-    {{- end }}
-    channel: {{ .channel }}  # shelly device relay channel
-    targettc: {{ .targettc }}
-    capacity: {{ .capacity }}
+  type: shelly-heat-control
+  {{- if .title }}
+  title: {{ .title }}
+  {{- end }}
+  {{- if .icon }}
+  icon: {{ .icon }}
+  {{- end }}
+  uri: http://{{ .host }}
+  {{- if .user }}
+  user: {{ .user }}
+  {{- end }}
+  {{- if .password }}
+  password: {{ .password }}
+  {{- end }}
+  channel: {{ .channel }}  # shelly device relay channel
+  targettc: {{ .targettc }}
+  capacity: {{ .capacity }}

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Shelly
     description:
       generic: Sensor Add-On (Temperature)
-group: heating
+group: generic
 params:
   - name: title
   - name: icon

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -2,7 +2,7 @@ template: shelly-heat-control
 products:
   - brand: Shelly
     description:
-      generic: Sensor Add-On (Temperature)
+      generic: Temperature Sensor Add-On
 group: generic
 params:
   - name: title

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -2,7 +2,7 @@ template: shelly-heat-control
 products:
   - brand: Shelly
     description:
-      generic: Temperature Sensor Add-On
+      generic: Sensor Add-On (Temperature)
 group: generic
 params:
   - name: title
@@ -21,8 +21,8 @@ params:
     default: 45
     required: true
     description:
-      de: Zieltemperatur in °C
-      en: Target temperature in °C
+      de: "Zieltemperatur in °C"
+      en: "Target temperature in °C"
   - name: capacity
     default: 12
 render: |

--- a/templates/definition/vehicle/shelly-heat-control.yaml
+++ b/templates/definition/vehicle/shelly-heat-control.yaml
@@ -19,10 +19,10 @@ params:
       en: Shelly Add-On channel
   - name: targettc
     default: 45
-    required: true
     description:
-      de: "Zieltemperatur in °C"
-      en: "Target temperature in °C"
+      de: Zieltemperatur in °C
+      en: Target temperature in °C
+    required: true
   - name: capacity
     default: 12
 render: |

--- a/tests/simulator/api.js
+++ b/tests/simulator/api.js
@@ -76,11 +76,13 @@ const shellyMiddleware = (req, res, next) => {
   if (req.originalUrl === "/shelly") {
     res.end(JSON.stringify({ gen: 2 }));
   } else if (req.originalUrl === "/rpc/Shelly.ListMethods") {
-    res.end(JSON.stringify({ methods: ["Switch.GetStatus"] }));
+    res.end(JSON.stringify({ methods: ["Switch.GetStatus","Temperature.GetStatus"] }));
   } else if (req.originalUrl === "/rpc/Switch.GetStatus?id=0") {
     res.end(
       JSON.stringify({ apower: state.site.pv.power, aenergy: { total: state.site.pv.energy } })
     );
+  } else if (req.originalUrl === "/rpc/Temperature.GetStatus?id=100") {
+    res.end(JSON.stringify({ tC: 24, tF: 75 }));
   } else {
     next();
   }

--- a/tests/simulator/api.js
+++ b/tests/simulator/api.js
@@ -76,13 +76,11 @@ const shellyMiddleware = (req, res, next) => {
   if (req.originalUrl === "/shelly") {
     res.end(JSON.stringify({ gen: 2 }));
   } else if (req.originalUrl === "/rpc/Shelly.ListMethods") {
-    res.end(JSON.stringify({ methods: ["Switch.GetStatus","Temperature.GetStatus"] }));
+    res.end(JSON.stringify({ methods: ["Switch.GetStatus"] }));
   } else if (req.originalUrl === "/rpc/Switch.GetStatus?id=0") {
     res.end(
       JSON.stringify({ apower: state.site.pv.power, aenergy: { total: state.site.pv.energy } })
     );
-  } else if (req.originalUrl === "/rpc/Temperature.GetStatus?id=100") {
-    res.end(JSON.stringify({ tC: 24, tF: 75 }));
   } else {
     next();
   }

--- a/vehicle/shelly-heat-control.go
+++ b/vehicle/shelly-heat-control.go
@@ -1,0 +1,78 @@
+package vehicle
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/meter/shelly"
+	"github.com/evcc-io/evcc/util"
+)
+
+type Gen2Temperature struct {
+	TC, TF        float64
+	Code, Message string
+}
+
+type Shelly struct {
+	*embed
+	conn     *shelly.Connection
+	targetTC float64
+}
+
+func init() {
+	registry.Add("shelly-heat-control", NewShellyFromConfig)
+}
+
+func NewShellyFromConfig(other map[string]any) (api.Vehicle, error) {
+	var vc struct {
+		embed               `mapstructure:",squash"`
+		URI, User, Password string
+		Channel             int
+		TargetTC            float64
+	}
+
+	if err := util.DecodeOther(other, &vc); err != nil {
+		return nil, err
+	}
+
+	if vc.TargetTC == 0 {
+		return nil, errors.New("target temperature cannot be 0")
+	}
+	return NewShelly(vc.embed, vc.URI, vc.User, vc.Password, vc.Channel, vc.TargetTC)
+}
+
+func NewShelly(embed embed, uri, user, password string, channel int, targettc float64) (*Shelly, error) {
+	conn, err := shelly.NewConnection(uri, user, password, channel, time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &Shelly{
+		conn:     conn,
+		embed:    &embed,
+		targetTC: targettc,
+	}
+
+	var res shelly.Gen2Methods
+	if err := v.conn.ExecCmd("Shelly.ListMethods", false, &res); err != nil {
+		return nil, err
+	}
+	if !slices.Contains(res.Methods, "Temperature.GetStatus") {
+		return nil, errors.New("Temperature.GetStatus method not available")
+	}
+
+	return v, nil
+}
+
+// Soc implements the api.Vehicle interface
+func (v *Shelly) Soc() (float64, error) {
+	var res Gen2Temperature
+	err := v.conn.ExecCmd("Temperature.GetStatus", false, &res)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s", err, res.Message)
+	}
+	return (res.TC / v.targetTC) * 100, err
+}


### PR DESCRIPTION
Introduce a new vehicle type to control heating devices using [Shelly Add-On](https://www.shelly.com/de/products/shelly-plus-addon-3x-sensor-ds) temperature sensors, calculating an SoC based on a target temperature.

New Features:
- Add `shelly-heat-control` vehicle type using Shelly Add-On temperature sensor.
- Calculate SoC based on the ratio of current temperature to a configured target temperature.

Enhancements:
- Refactor Shelly meter code to expose the command execution function (`ExecCmd`) via the `Generation` interface.

Chores:
- Add YAML configuration template for the `shelly-heat-control` vehicle type.

Sample generic vehicle definition:
```yaml
vehicles:
- type: template
  template: shelly-heat-control 
  title: Heißwasser  
  icon: waterheater  
  host: 192.168.XXX.XXX  
  channel: 100 
  targettc: 50  
  name: heater1
```

```bash
xxxx@LAPTOP-KQMMVN3H:~/git-repos/evcc$ ./evcc -l debug vehicle
[main  ] INFO 2025/04/26 19:54:40 evcc 0.203.3 (832012ef1)
[main  ] INFO 2025/04/26 19:54:40 using config file: ./evcc_shelly_test.yaml
[db    ] INFO 2025/04/26 19:54:40 using sqlite database: /home/xxxx/.evcc/evcc.db
heater1
-------
Soc:      96%
Capacity: 12.0kWh
```