### PR TITLE
Increase timeout for Tibber subscription API to 90s

### DIFF
--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -113,7 +113,7 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 		}).
 		WithRetryTimeout(0).
 		WithRetryDelay(5 * time.Second).
-		WithTimeout(time.Minute). // default value, sometimes gap of 15s updates from Tibber
+		WithTimeout(90 * time.Second). // Tibber recommended, sometimes gap of more than 15s
 		WithLog(log.TRACE.Println).
 		OnError(func(_ *graphql.SubscriptionClient, err error) error {
 			// exit the subscription client due to unauthorized error

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -113,7 +113,7 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 		}).
 		WithRetryTimeout(0).
 		WithRetryDelay(5 * time.Second).
-		WithTimeout(request.Timeout).
+		WithTimeout(time.Minute). // default value, sometimes gap of 15s updates from Tibber
 		WithLog(log.TRACE.Println).
 		OnError(func(_ *graphql.SubscriptionClient, err error) error {
 			// exit the subscription client due to unauthorized error

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -113,7 +113,8 @@ func NewTibberFromConfig(ctx context.Context, other map[string]interface{}) (api
 		}).
 		WithRetryTimeout(0).
 		WithRetryDelay(5 * time.Second).
-		WithTimeout(90 * time.Second). // Tibber recommended, sometimes gap of more than 15s
+		WithWriteTimeout(request.Timeout).
+		WithReadTimeout(90 * time.Second).
 		WithLog(log.TRACE.Println).
 		OnError(func(_ *graphql.SubscriptionClient, err error) error {
 			// exit the subscription client due to unauthorized error


### PR DESCRIPTION
The Tibber pulse integration used a timeout of 10s before. This was leading to timeouts and re-connects to the Tibber subscription API.

The number of re-connections on the Tibber-API is limited to 20 / hour and caused high load on it.

Details see:
https://github.com/evcc-io/evcc/issues/20869

## Summary by Sourcery

Bug Fixes:
- Prevent frequent timeouts and reconnects to the Tibber subscription API by increasing the client timeout.