### PR TITLE
chore: use stamped version

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -11,7 +11,7 @@ builds:
       - -trimpath
       - -tags=release
     ldflags:
-      - -X github.com/evcc-io/evcc/server.Version={{ .Tag }} -X github.com/evcc-io/evcc/server.Commit={{ .ShortCommit }} -s -w
+      - -X github.com/evcc-io/evcc/util.Version={{ .Tag }} -X github.com/evcc-io/evcc/util.Commit={{ .ShortCommit }} -s -w
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
       - -trimpath
       - -tags=release
     ldflags:
-      - -X github.com/evcc-io/evcc/server.Version={{ .Version }} -s -w
+      - -X github.com/evcc-io/evcc/util.Version={{ .Version }} -s -w
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/configure/main.go
+++ b/cmd/configure/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/cloudfoundry/jibber_jabber"
 	"github.com/evcc-io/evcc/hems/semp"
-	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/machine"
 	"github.com/evcc-io/evcc/util/templates"
@@ -47,7 +46,7 @@ func (c *CmdConfigure) Run(log *util.Logger, flagLang string, advancedMode, expa
 	c.advancedMode = advancedMode
 	c.expandedMode = expandedMode
 
-	c.log.INFO.Printf("evcc %s", server.FormattedVersion())
+	c.log.INFO.Printf("evcc %s", util.FormattedVersion())
 
 	bundle := i18n.NewBundle(language.German)
 	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)

--- a/cmd/discuss.go
+++ b/cmd/discuss.go
@@ -9,7 +9,7 @@ import (
 	"text/template"
 
 	"github.com/cli/browser"
-	"github.com/evcc-io/evcc/server"
+	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +54,7 @@ func runDiscuss(cmd *cobra.Command, args []string) {
 		"CfgFile":    file,
 		"CfgError":   errorString(cfgErr),
 		"CfgContent": redacted,
-		"Version":    server.FormattedVersion(),
+		"Version":    util.FormattedVersion(),
 	})
 
 	body := out.String()

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/evcc-io/evcc/core"
-	"github.com/evcc-io/evcc/server"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/spf13/cobra"
 )
@@ -78,7 +78,7 @@ func runDump(cmd *cobra.Command, args []string) {
 			"CfgFile":    file,
 			"CfgError":   errorString(err),
 			"CfgContent": redacted,
-			"Version":    server.FormattedVersion(),
+			"Version":    util.FormattedVersion(),
 		})
 
 		fmt.Println(out.String())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:     "evcc",
 	Short:   "evcc - open source solar charging",
-	Version: server.FormattedVersion(),
+	Version: util.FormattedVersion(),
 	Run:     runRoot,
 }
 
@@ -112,7 +112,7 @@ func initConfig() {
 
 	// print version
 	util.LogLevel("info", nil)
-	log.INFO.Printf("evcc %s", server.FormattedVersion())
+	log.INFO.Printf("evcc %s", util.FormattedVersion())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -308,8 +308,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 	})
 
 	// show and check version, reduce api load during development
-	if server.Version != server.DevVersion {
-		valueChan <- util.Param{Key: keys.Version, Val: server.FormattedVersion()}
+	if util.Version != util.DevVersion {
+		valueChan <- util.Param{Key: keys.Version, Val: util.FormattedVersion()}
 		go updater.Run(log, httpd, valueChan)
 	}
 

--- a/hems/semp/semp.go
+++ b/hems/semp/semp.go
@@ -34,7 +34,7 @@ const (
 	maxAge           = 1800
 )
 
-var serverName = "EVCC SEMP Server " + server.Version
+var serverName = "EVCC SEMP Server " + util.Version
 
 // SEMP is the SMA SEMP server
 type SEMP struct {

--- a/meter/tibber-pulse.go
+++ b/meter/tibber-pulse.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func getUserAgent() string {
-	evccVersion := "0.203.2+unknown"
+	evccVersion := util.Version
 	graphqlClientVersion := "0.13.2+unknown"
 
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -57,8 +57,8 @@ func indexHandler() http.HandlerFunc {
 		defaultLang := getPreferredLanguage(r.Header.Get("Accept-Language"))
 
 		if err := t.Execute(w, map[string]interface{}{
-			"Version":     Version,
-			"Commit":      Commit,
+			"Version":     util.Version,
+			"Commit":      util.Commit,
 			"DefaultLang": defaultLang,
 		}); err != nil {
 			log.ERROR.Println("httpd: failed to render main page:", err.Error())

--- a/server/updater/run.go
+++ b/server/updater/run.go
@@ -3,7 +3,6 @@
 package updater
 
 import (
-	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/util"
 	"github.com/google/go-github/v32/github"
 )
@@ -17,7 +16,7 @@ func Run(log *util.Logger, httpd webServer, outChan chan<- util.Param) {
 	}
 
 	c := make(chan *github.RepositoryRelease, 1)
-	go u.watchReleases(server.Version, c) // endless
+	go u.watchReleases(util.Version, c) // endless
 
 	for rel := range c {
 		u.Send("availableVersion", *rel.TagName)

--- a/server/updater/run_gokrazy.go
+++ b/server/updater/run_gokrazy.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/util"
 	"github.com/google/go-github/v32/github"
 )
@@ -24,7 +23,7 @@ func Run(log *util.Logger, httpd webServer, outChan chan<- util.Param) {
 	httpd.Router().PathPrefix("/api/update").HandlerFunc(u.updateHandler)
 
 	c := make(chan *github.RepositoryRelease, 1)
-	go u.watchReleases(server.Version, c) // endless
+	go u.watchReleases(util.Version, c) // endless
 
 	// signal update support
 	u.Send("hasUpdater", true)

--- a/util/version.go
+++ b/util/version.go
@@ -1,4 +1,4 @@
-package server
+package util
 
 import "fmt"
 


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/20869

## Summary by Sourcery

Consolidate application version information into the `util` package.

Enhancements:
- Move version information handling from the `server` package to the `util` package.
- Update references across the codebase to use version information from the `util` package instead of the `server` package.
- Move the `version.go` file from the `server` package to the `util` package (implied by diff).

Build:
- Update goreleaser configurations to inject version details into the `util` package.