### PR TITLE
Plugins: Formatieren von Payloads per jq

### DIFF
--- a/plugin/mqtt_test.go
+++ b/plugin/mqtt_test.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatPayload(t *testing.T) {
+	p, err := NewMqttPluginFromConfig(
+		context.TODO(),
+		map[string]any{
+			"topic":    "some-topic",
+			"broker":   "test.mosquitto.org:1884",
+			"user":     "rw",
+			"password": "readwrite",
+			"jq":       ". * 2",
+		},
+	)
+	assert.NoError(t, err)
+
+	{
+		payload, err := p.(*Mqtt).FormatPayload(
+			"",
+			"",
+			10,
+		)
+
+		assert.NoError(t, err)
+
+		assert.Equal(t, "20", payload)
+	}
+}


### PR DESCRIPTION
Fix #20501

Erster Versuch, erst mal nur im MQTT-Plugin.

Achtung: Das erste Mal, dass ich Go-Code umbaue bzw. in Go programmiere. Anfängerfehler vorprogrammiert, was vielleicht auch die nachfolgenden Fragen zeigen.

Fragen:

- Wie kann man das grundsätzlich testen, ohne dass gleich ein echter MQTT-Server im Hintergrund laufen muss?
- Kann man das mit weniger Änderungen testen, ohne das MQTT-Plugin nur wegen des Tests so zu refactoren?
- Aktuell wird die neue `FormatPayload`-Funktion getestet (die gibt es eigentlich nur, damit man sie im Test nutzen kann 😅 ), aber eigentlich wäre es besser zu testen, was am Ende zu `m.client.Publish` gesendet wird – also was letztendlich "rausgeht". Sehe aktuell nicht, wie man das `m.client.Publish` im test mocken könnte, damit man dort das `payload` rausfischen kann.

Ich denke ich brauche etwas Hilfe/Denkanstöße von erfahrenen Programmieren, damit ich hier sauber weiterkomme. Gebt gerne kritisches Feedback und/oder ein paar Hinweise, wie ihr es angehen könntet.

## Summary by Sourcery

Introduce payload formatting using `jq` in the MQTT plugin and refactor publishing logic.

New Features:
- Allow formatting MQTT message payloads using `jq` expressions before publishing.

Enhancements:
- Refactor MQTT publishing logic into reusable `FormatPayload` and `Publish` methods.

Tests:
- Add a unit test for the new `jq` payload formatting functionality.