### PR TITLE
Fix open-meteo value calculation / adjust timestamp

### DIFF
--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -101,8 +101,8 @@ render: |
           | $h.time[$i] as $time
           | ($i / 24 | floor) as $day
           | {
-              start: (($time - 3600) | todateiso8601),
-              end: ($time | todateiso8601),
+              start: (($time - 1800) | todateiso8601),
+              end: (($time + 1800) | todateiso8601),
               value: (
                 kwp
                 * ($h.global_tilted_irradiance[$i] / 1000)


### PR DESCRIPTION
Fixes #20939

## Summary by Sourcery

Bug Fixes:
- Corrected timestamp calculation by adjusting start and end times to be more precise