### PR TITLE
OpenEMS: add battery control

### DIFF
--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -2,6 +2,7 @@ template: openems
 products:
   - brand: OpenEMS
   - brand: FENECON
+capabilities: ["battery-control"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -11,6 +12,15 @@ params:
     mask: true
     default: user
     advanced: true
+  - name: battery
+    default: ess0
+    usages: ["battery"]	
+    advanced: true
+  - name: cycle
+    type: duration
+    default: 1s
+    usages: ["battery"]	
+    advanced: true	
   - name: maxacpower
   - name: capacity
     advanced: true
@@ -44,5 +54,46 @@ render: |
       user: x
       password: {{ .password }}
     jq: (.value // 0)
+  batterymode:
+    source: watchdog
+    timeout: {{ .cycle }} # re-write at timeout/2
+    reset: 1
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: const
+          value: 0 # % (set once to reset)
+          set:
+            source: http
+              uri: http://{{ .host }}/rest/channel/{{ .device }}/SetActivePowerEquals
+              auth:
+                type: basic
+                user: x
+                password: {{ .password }}
+              method: POST
+              headers:
+              - content-type: application/json
+              body: '{"value":0}'		  
+        - case: 2 # hold
+          set:
+            source: const
+            value: 0 # % (set once to reset from forced charge)
+            set:
+              source: http
+              uri: http://{{ .host }}/rest/channel/{{ .device }}/SetActivePowerEquals
+              auth:
+                type: basic
+                user: x
+                password: {{ .password }}
+              method: POST
+              headers:
+              - content-type: application/json
+              body: '{"value":0}'
+        - case: 3 # charge (not implemented)
+          set:
+            source: error
+            error: ErrNotAvailable
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -13,7 +13,6 @@ params:
     default: user
     advanced: true
   - name: battery
-    default: ess0
     usages: ["battery"]	
     advanced: true
   - name: watchdog

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -3,6 +3,12 @@ products:
   - brand: OpenEMS
   - brand: FENECON
 capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Für FEMS FENECON-Systeme ist eine kommerzielle Lizenz für die aktive Batteriesteuerung erforderlich.
+    en: |
+      A commercial license is required for FEMS FENECON systems for active battery control.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -17,7 +23,7 @@ params:
     help:
       de: steuerbare Batterie Komponente
       en: controllable battery component
-    usages: ["battery"]	
+    usages: ["battery"]
     advanced: true
   - name: watchdog
     type: duration
@@ -25,8 +31,8 @@ params:
     help:
       de: abgestimmt auf das API-Timeout
       en: adjusted to the API timout
-    usages: ["battery"]	
-    advanced: true	
+    usages: ["battery"]
+    advanced: true
   - name: maxacpower
   - name: capacity
     advanced: true
@@ -79,7 +85,7 @@ render: |
           method: POST
           headers:
           - content-type: application/json
-          body: '{"value":0}'		  
+          body: '{"value":0}'
       - case: 2 # hold
         set:
           source: http

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -13,11 +13,18 @@ params:
     default: user
     advanced: true
   - name: battery
+    example: ess0
+    help:
+      de: steuerbare Batterie Komponente
+      en: controllable battery component
     usages: ["battery"]	
     advanced: true
   - name: watchdog
     type: duration
     default: 60s
+    help:
+      de: abgestimmt auf das API-Timeout
+      en: adjusted to the API timout
     usages: ["battery"]	
     advanced: true	
   - name: maxacpower

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -54,6 +54,7 @@ render: |
       user: x
       password: {{ .password }}
     jq: (.value // 0)
+  {{- if .battery }}
   batterymode:
     source: watchdog
     timeout: {{ .cycle }} # re-write at timeout/2
@@ -63,37 +64,32 @@ render: |
       switch:
       - case: 1 # normal
         set:
-          source: const
-          value: 0 # % (set once to reset)
-          set:
-            source: http
-              uri: http://{{ .host }}/rest/channel/{{ .device }}/SetActivePowerEquals
-              auth:
-                type: basic
-                user: x
-                password: {{ .password }}
-              method: POST
-              headers:
-              - content-type: application/json
-              body: '{"value":0}'		  
-        - case: 2 # hold
-          set:
-            source: const
-            value: 0 # % (set once to reset from forced charge)
-            set:
-              source: http
-              uri: http://{{ .host }}/rest/channel/{{ .device }}/SetActivePowerEquals
-              auth:
-                type: basic
-                user: x
-                password: {{ .password }}
-              method: POST
-              headers:
-              - content-type: application/json
-              body: '{"value":0}'
-        - case: 3 # charge (not implemented)
-          set:
-            source: error
-            error: ErrNotAvailable
+          source: http
+          uri: http://{{ .host }}/rest/channel/{{ .battery }}/SetActivePowerEquals
+          auth:
+            type: basic
+            user: x
+            password: {{ .password }}
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"value":0}'		  
+      - case: 2 # hold
+        set:
+          source: http
+          uri: http://{{ .host }}/rest/channel/{{ .battery }}/SetActivePowerEquals
+          auth:
+            type: basic
+            user: x
+            password: {{ .password }}
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"value":0}'
+      - case: 3 # charge (not implemented)
+        set:
+          source: error
+          error: ErrNotAvailable
+  {{- end }}
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -16,9 +16,9 @@ params:
     default: ess0
     usages: ["battery"]	
     advanced: true
-  - name: cycle
+  - name: watchdog
     type: duration
-    default: 1s
+    default: 60s
     usages: ["battery"]	
     advanced: true	
   - name: maxacpower
@@ -57,7 +57,7 @@ render: |
   {{- if .battery }}
   batterymode:
     source: watchdog
-    timeout: {{ .cycle }} # re-write at timeout/2
+    timeout: {{ .watchdog }} # re-write at timeout/2
     reset: 1
     set:
       source: switch


### PR DESCRIPTION
see #11501 

uses channel SetActivePowerEquals to control ess device via HTTP/REST API
relies on REST/API controller, correct ess device name and proper watchdog/timeout definition

## Summary by Sourcery

Add battery control capabilities for OpenEMS devices using HTTP/REST API

New Features:
- Implement battery control mode functionality for OpenEMS devices

Enhancements:
- Introduced new parameters for battery control, including battery device selection and watchdog timeout

## Summary by Sourcery

Add battery control capabilities for OpenEMS devices using HTTP/REST API

New Features:
- Implement battery control mode functionality for OpenEMS devices

Documentation:
- Add license requirement description for active battery control on FENECON systems