### PR TITLE
tarrif akkudokter: set default interval to 2h

### DIFF
--- a/templates/definition/tariff/api-akkudoktor-de.yaml
+++ b/templates/definition/tariff/api-akkudoktor-de.yaml
@@ -81,7 +81,7 @@ params:
     example: "10,0,10,15"
     advanced: true
   - name: interval
-    default: 1h
+    default: 2h
     advanced: true
 render: |
   type: custom


### PR DESCRIPTION
ref https://github.com/evcc-io/evcc/issues/20612#issuecomment-2840889971

## Summary by Sourcery

Enhancements:
- Changed the default interval parameter for the Akkudokter API tariff definition