### PR TITLE
fix(api.akkudoktor.net): forecast not working with azimuth=0

### DIFF
--- a/templates/definition/tariff/api-akkudoktor-de.yaml
+++ b/templates/definition/tariff/api-akkudoktor-de.yaml
@@ -1,5 +1,4 @@
 template: api.akkudoktor.net
-deprecated: true
 products:
   - brand: Akkudoktor API
 requirements:
@@ -91,9 +90,9 @@ render: |
     uri: "https://api.akkudoktor.net/forecast?\
       lat={{ .lat }}\
       &lon={{ .lon }}\
-      &tilt={{ .dec }}\
+      &tilt={{ if or (eq .dec "0") (eq .dec "0.0") }}0.001{{ else }}{{ .dec }}{{ end }}\
       &power={{ mulf .kwp 1000 }}\
-      &azimuth={{ .az }}\
+      &azimuth={{ if or (eq .az "0") (eq .az "0.0") }}0.001{{ else }}{{ .az }}{{ end }}\
       &powerInverter={{ mulf .ac 1000 }}\
       &inverterEfficiency={{ divf .efficiency 100 }}\
       &cellCoEff={{ mulf .alphatemp 100 }}\


### PR DESCRIPTION
fix https://github.com/evcc-io/evcc/issues/20612 using a workaround
Should be fixed directly in the api in the future https://github.com/nick81nrw/solApi/pull/5

## Summary by Sourcery

Fix forecast calculation for Akkudoktor API by handling zero values for tilt and azimuth

Bug Fixes:
- Resolved issue with forecast not working when tilt or azimuth is zero by using a small non-zero value
- Removed deprecated flag from the API template