### PR TITLE
chore: ensure yaml editor npm updates

### DIFF
--- a/assets/js/components/Config/YamlEditor.vue
+++ b/assets/js/components/Config/YamlEditor.vue
@@ -27,8 +27,8 @@
 import { VueMonacoEditor, loader } from "@guolao/vue-monaco-editor";
 import { cleanYaml } from "@/utils/cleanYaml.js";
 // don't bundle monaco-editor but ensure that it get updated regularly
-import { dependencies } from "../../../../package.json";
-const monacoVersion = dependencies["monaco-editor"];
+import { packages } from "../../../../package-lock.json";
+const monacoVersion = packages["node_modules/monaco-editor"].version;
 
 const $html = document.querySelector("html");
 export default {

--- a/assets/js/components/Config/YamlEditor.vue
+++ b/assets/js/components/Config/YamlEditor.vue
@@ -26,6 +26,9 @@
 <script>
 import { VueMonacoEditor, loader } from "@guolao/vue-monaco-editor";
 import { cleanYaml } from "@/utils/cleanYaml.js";
+// don't bundle monaco-editor but ensure that it get updated regularly
+import { dependencies } from "../../../../package.json";
+const monacoVersion = dependencies["monaco-editor"];
 
 const $html = document.querySelector("html");
 export default {
@@ -77,7 +80,7 @@ export default {
 	},
 	beforeMount() {
 		loader.config({
-			paths: { vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.50.0/min/vs" },
+			paths: { vs: `https://cdn.jsdelivr.net/npm/monaco-editor@${monacoVersion}/min/vs` },
 		});
 		loader.init();
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-plugin-vue": "^9.3.0",
         "globals": "^16.0.0",
         "happy-dom": "^17.4.4",
+        "monaco-editor": "^0.52.2",
         "mqtt": "^5.11.0",
         "prettier": "^3.0.0",
         "prettier-plugin-sh": "^0.15.0",
@@ -7864,8 +7865,7 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mqtt": {
       "version": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-vue": "^9.3.0",
     "globals": "^16.0.0",
     "happy-dom": "^17.4.4",
+    "monaco-editor": "^0.52.2",
     "mqtt": "^5.11.0",
     "prettier": "^3.0.0",
     "prettier-plugin-sh": "^0.15.0",


### PR DESCRIPTION
see discussion https://github.com/evcc-io/evcc/discussions/20661#discussioncomment-12875555
\\cc @StefanSchoof

## Summary by Sourcery

Update Monaco Editor version dynamically by importing the version from package.json

Chores:
- Update Monaco Editor package to version 0.52.2
- Dynamically load Monaco Editor CDN path using package.json dependency version