### PR TITLE
Loadpoint: improve battery boost coarse current step-up

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1332,7 +1332,11 @@ func (lp *Loadpoint) boostPower(batteryBoostPower float64) float64 {
 	delta := math.Max(100, math.Abs(lp.site.GetResidualPower()))
 
 	if lp.coarseCurrent() {
-		delta = math.Max(delta, lp.EffectiveStepPower())
+		// add effective step power to delta to make sure to step up to the next full amp
+		// just using lp.EffectiveStepPower() as delta is not enough because this will result
+		// in a too low current when there is a bit remaining grid consumption due to the accuracy
+		// of the battery controller
+		delta += lp.EffectiveStepPower()
 	}
 
 	// start boosting by setting maximum power


### PR DESCRIPTION
When the EffectiveStepPower is 1A (coarsecurrent), the battery boost will not step-up again when disabling a consumer is case the battery is not regulating the grid power to 0 or a negative value. By adding residualpower to the EffectiveStepPower, this is resolved.

Fixes #20898

## Summary by Sourcery

Improve battery boost current step-up logic by adding residual power to the effective step power when in coarse current mode

Bug Fixes:
- Resolve issue with battery boost not stepping up when a consumer is disabled in certain grid power conditions

Enhancements:
- Modify delta calculation to ensure more accurate current stepping in coarse current mode