### PR TITLE
Forecast UI: negative prices

### DIFF
--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -326,7 +326,7 @@ export default defineComponent({
 						type: "timeseries",
 						display: true,
 						time: { unit: "day" },
-						border: { display: true },
+						border: { display: false },
 						grid: {
 							display: true,
 							color: colors.border,
@@ -374,7 +374,19 @@ export default defineComponent({
 						beginAtZero: true,
 					},
 					yCo2: { display: false, min: 0, max: this.yMax(this.co2Slots) },
-					yPrice: { display: false, min: 0, max: this.yMax(this.gridSlots) },
+					yPrice: {
+						display: true,
+						suggestedMin: 0,
+						max: this.yMax(this.gridSlots),
+						ticks: { display: false },
+						border: { display: false },
+						grid: {
+							// @ts-expect-error no-explicit-any
+							lineWidth: (context) => {
+								return context.tick?.value === 0 ? 1 : 0;
+							},
+						},
+					},
 				},
 			};
 		},

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -368,24 +368,20 @@ export default defineComponent({
 						},
 					},
 					yForecast: {
-						display: false,
+						...this.yScaleOptions(ForecastType.Solar),
 						min: 0,
 						max: this.yMaxEntry(this.solarEntries, this.solar?.scale),
 						beginAtZero: true,
 					},
-					yCo2: { display: false, min: 0, max: this.yMax(this.co2Slots) },
+					yCo2: {
+						...this.yScaleOptions(ForecastType.Co2),
+						min: 0,
+						max: this.yMax(this.co2Slots),
+					},
 					yPrice: {
-						display: true,
+						...this.yScaleOptions(ForecastType.Price),
 						suggestedMin: 0,
 						max: this.yMax(this.gridSlots),
-						ticks: { display: false },
-						border: { display: false },
-						grid: {
-							// @ts-expect-error no-explicit-any
-							lineWidth: (context) => {
-								return context.tick?.value === 0 ? 1 : 0;
-							},
-						},
 					},
 				},
 			};
@@ -499,6 +495,23 @@ export default defineComponent({
 			return entries.reduce((max, entry, index) => {
 				return entry.val > entries[max].val ? index : max;
 			}, 0);
+		},
+		yScaleOptions(type: ForecastType) {
+			return type === this.selected
+				? {
+						display: true,
+						ticks: { display: false },
+						border: { display: false },
+						grid: {
+							display: true,
+							color: colors.border,
+							// @ts-expect-error no-explicit-any
+							lineWidth: (context) => {
+								return context.tick?.value === 0 ? 1 : 0;
+							},
+						},
+					}
+				: { display: false };
 		},
 	},
 });


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/20973

📉 support negative grid prices in forecast diagram
↕️ selected chart defines the visual 0-axis

Note: the grid price visualization now differs from the planner / grid charge price visualization where bars are always bottom aligned and the lowest value sets the scale. Unifying forecast and planner chart is something we'll likely address when implementing https://github.com/evcc-io/evcc/issues/12915.

**positive prices**
<img width="1071" alt="Bildschirmfoto 2025-05-01 um 09 09 35" src="https://github.com/user-attachments/assets/255b8458-5bea-47ba-811b-6170cd6a5fa9" />

**negative prices**
<img width="966" alt="Bildschirmfoto 2025-05-01 um 09 11 11" src="https://github.com/user-attachments/assets/cb76db79-e8df-4cf4-bfdf-befa857a8d95" />

**co2 data with negative prices in background**
<img width="936" alt="Bildschirmfoto 2025-05-01 um 09 27 44" src="https://github.com/user-attachments/assets/e3160cd4-6237-4b3d-909b-3feb6a91daca" />

## Summary by Sourcery

Enhance the forecast chart to support and visualize negative grid prices, with improved axis and grid rendering for different forecast types

New Features:
- Support for displaying negative grid prices in the forecast diagram

Enhancements:
- Implement dynamic y-axis scaling based on selected forecast type
- Add zero-line highlighting for selected chart type