### PR TITLE
chore: missed required change for stamped version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 VERSION := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 BUILD_TAGS := -tags=release
-LD_FLAGS := -X github.com/evcc-io/evcc/server.Version=$(VERSION) -X github.com/evcc-io/evcc/server.Commit=$(COMMIT) -s -w
+LD_FLAGS := -X github.com/evcc-io/evcc/util.Version=$(VERSION) -X github.com/evcc-io/evcc/util.Commit=$(COMMIT) -s -w
 BUILD_ARGS := -trimpath -ldflags='$(LD_FLAGS)'
 
 # docker


### PR DESCRIPTION
The commit "[chore](chore: use stamped version ([#20909](https://github.com/guido4096/evcc/issues/20909)))" missed to update the makefile.