### PR TITLE
Fix precondition checkbox for static plan

### DIFF
--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -216,7 +216,7 @@ export default defineComponent({
 			selectedSoc: this.soc,
 			selectedEnergy: this.energy,
 			active: false,
-			selectedPrecondition: 0,
+			selectedPrecondition: this.precondition,
 		};
 	},
 	computed: {


### PR DESCRIPTION
Quick fix for the precondition state for the static plan, It does not show the current state upon loading due to the data for precondition always being initialised to 0, The repeating plans are ok

![image](https://github.com/user-attachments/assets/cc7f701b-dd15-4b6c-b001-d5e18a4ac048)
