### PR TITLE
chore: fix goreleaser deprecations

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -35,12 +35,12 @@ builds:
           - -tags=release,timetzdata
 
 archives:
-  - builds:
+  - ids:
       - evcc
-    format: tar.gz
+    formats: tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
     files:
       - evcc.dist.yaml
     name_template: >-

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -37,10 +37,10 @@ builds:
 archives:
   - ids:
       - evcc
-    formats: tar.gz
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        formats: zip
+        formats: [zip]
     files:
       - evcc.dist.yaml
     name_template: >-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,12 +43,12 @@ env:
   - CGO_ENABLED=0
 
 archives:
-  - builds:
+  - ids:
       - evcc
-    format: tar.gz
+    formats: tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
     files:
       - evcc.dist.yaml
     name_template: >-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,10 +45,10 @@ env:
 archives:
   - ids:
       - evcc
-    formats: tar.gz
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        formats: zip
+        formats: [zip]
     files:
       - evcc.dist.yaml
     name_template: >-


### PR DESCRIPTION
This PR updates the goreleaser.yml and goreleaser-nightly.yml configuration files to resolve deprecation warnings.


These changes align the configuration with Goreleaser v2.6+ standards as documented here:

[archives.format](https://goreleaser.com/deprecations/#archivesformat)
[archives.format_overrides.format](https://goreleaser.com/deprecations/#archivesformat_overridesformat)
[archives.builds](https://goreleaser.com/deprecations/#archivesbuilds)