### PR TITLE
tariff/octopus: Fix tariff payment method API presumption

### DIFF
--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -129,7 +129,11 @@ func (t *Octopus) run(done chan error) {
 
 		data := make(api.Rates, 0, len(res.Results))
 		for _, r := range res.Results {
-			if t.paymentMethod != "" && r.PaymentMethod != t.paymentMethod {
+			// This checks whether:
+			// - a Payment Method is set on the Result
+			// - a Payment Method filter is set
+			// - the Payment Method in the Result matches the Payment Method filter
+			if r.PaymentMethod != "" && t.paymentMethod != "" && r.PaymentMethod != t.paymentMethod {
 				// A Payment Method filter is set, and this Tariff entry does not match our filter.
 				continue
 			}


### PR DESCRIPTION
I presumed that Octopus would send a "DIRECT_DEBIT" or "NON_DIRECT_DEBIT" payment_method on responses. Turns out this is not always the case.

This PR treats any `null` entries as valid regardless of the set filter.

If another tariff comes along that starts mixing `null` and a valid payment_method, then this will need a rethink.

Closes #21011 