### PR TITLE
amber: Use sites/:id/prices/current API instead of sites/:id/prices API

### DIFF
--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -85,10 +85,9 @@ func (t *Amber) run(done chan error) {
 
 	for tick := time.Tick(time.Minute); ; <-tick {
 		var res []amber.PriceInfo
-		uri := fmt.Sprintf("%s&endDate=%s", t.uri, time.Now().AddDate(0, 0, 2).Format("2006-01-02"))
 
 		if err := backoff.Retry(func() error {
-			return backoffPermanentError(t.GetJSON(uri, &res))
+			return backoffPermanentError(t.GetJSON(t.uri, &res))
 		}, bo()); err != nil {
 			once.Do(func() { done <- err })
 

--- a/tariff/amber/types.go
+++ b/tariff/amber/types.go
@@ -1,6 +1,6 @@
 package amber
 
-const URI = "https://api.amber.com.au/v1/sites/%s/prices?resolution=30"
+const URI = "https://api.amber.com.au/v1/sites/%s/prices/current?resolution=30&next=96"
 
 type AdvancedPrice struct {
 	Low       float64 `json:"low"`


### PR DESCRIPTION
As recommended by Amber devs: https://github.com/amberelectric/public-api/issues/244