### PR TITLE
Vestel: decorate RFID support

### DIFF
--- a/templates/definition/charger/vestel.yaml
+++ b/templates/definition/charger/vestel.yaml
@@ -13,8 +13,11 @@ products:
   - brand: E.ON Drive
     description:
       generic: vBox
-capabilities: ["1p3p"]
+capabilities: ["rfid", "1p3p"]
 requirements:
+  description:
+    de: 1P3P und RFID erfordern Firmware 3.187.0 oder neuer.
+    en: 1P3P and RFID require at least firmware version 3.187.0.
   evcc: ["sponsorship"]
 params:
   - name: modbus


### PR DESCRIPTION
RFID support through Modbus depends on the Vestel Firmware Version. Since updates of the charger are not easy to perform, this PR makes sure to only decorate Identify when the registers are available. Adds hints to the template requirements.
Fixes #21048, fix https://github.com/evcc-io/evcc/issues/21127, refs #20848