### PR TITLE
UI: add 12h/24h setting

### DIFF
--- a/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
+++ b/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
@@ -42,6 +42,21 @@
 				equal-width
 			/>
 		</FormRow>
+		<FormRow id="settingsTimeFormat" :label="$t('settings.time.label')">
+			<SelectGroup
+				id="settingsTimeFormat"
+				v-model="timeFormat"
+				class="w-75"
+				transparent
+				:options="
+					TIME_FORMATS.map((value) => ({
+						value,
+						name: $t(`settings.time.${value}h`),
+					}))
+				"
+				equal-width
+			/>
+		</FormRow>
 		<FormRow id="telemetryEnabled" :label="$t('settings.telemetry.label')">
 			<TelemetrySettings :sponsorActive="sponsor && !!sponsor.name" class="mt-1 mb-0" />
 		</FormRow>
@@ -82,11 +97,14 @@ import FormRow from "../Helper/FormRow.vue";
 import SelectGroup from "../Helper/SelectGroup.vue";
 import { getLocalePreference, setLocalePreference, LOCALES, removeLocalePreference } from "@/i18n";
 import { getThemePreference, setThemePreference, THEMES } from "@/theme";
-import { getUnits, setUnits, UNITS } from "@/units";
+import { getUnits, setUnits, UNITS, is12hFormat, set12hFormat } from "@/units";
 import { getHiddenFeatures, setHiddenFeatures } from "@/featureflags";
 import { isApp } from "@/utils/native";
 import { defineComponent, type PropType } from "vue";
 import type { Sponsor } from "@/types/evcc";
+
+const TIME_12H = "12";
+const TIME_24H = "24";
 
 export default defineComponent({
 	name: "UserInterfaceSettings",
@@ -99,10 +117,12 @@ export default defineComponent({
 			theme: getThemePreference(),
 			language: getLocalePreference() || "",
 			unit: getUnits(),
+			timeFormat: is12hFormat() ? TIME_12H : TIME_24H,
 			hiddenFeatures: getHiddenFeatures(),
 			fullscreenActive: false,
 			THEMES,
 			UNITS,
+			TIME_FORMATS: [TIME_24H, TIME_12H],
 		};
 	},
 	computed: {
@@ -125,6 +145,9 @@ export default defineComponent({
 	watch: {
 		unit(value) {
 			setUnits(value);
+		},
+		timeFormat(value) {
+			set12hFormat(value === TIME_12H);
 		},
 		theme(value) {
 			setThemePreference(value);

--- a/assets/js/components/Tariff/TariffChart.vue
+++ b/assets/js/components/Tariff/TariffChart.vue
@@ -27,7 +27,7 @@
 				</div>
 				<div class="slot-label">
 					<span v-if="!slot.isTarget || targetNearlyOutOfRange">{{
-						slot.startHour
+						formatHour(slot.startHour)
 					}}</span>
 					<br />
 					<span v-if="showWeekday(index)">{{ slot.day }}</span>
@@ -55,6 +55,7 @@
 <script lang="ts">
 import type { PropType } from "vue";
 import "@h2d2/shopicons/es/regular/arrowright";
+import { is12hFormat } from "@/units";
 import PlanEndIcon from "../MaterialIcon/PlanEnd.vue";
 import formatter from "@/mixins/formatter";
 import type { Slot } from "@/types/evcc";
@@ -163,6 +164,9 @@ export default {
 		cancelLongPress() {
 			clearTimeout(this.longPressTimer);
 			this.hoverSlot(null);
+		},
+		formatHour(hour: number) {
+			return is12hFormat() ? hour % 12 : hour;
 		},
 	},
 };

--- a/assets/js/mixins/formatter.test.js
+++ b/assets/js/mixins/formatter.test.js
@@ -1,6 +1,9 @@
 import { mount, config } from "@vue/test-utils";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi, beforeEach } from "vitest";
 import formatter, { POWER_UNIT } from "./formatter";
+import * as units from "../units";
+
+const is12hSpy = vi.spyOn(units, "is12hFormat").mockReturnValue(false);
 
 config.global.mocks["$i18n"] = { locale: "de-DE" };
 config.global.mocks["$t"] = (a) => a;
@@ -181,5 +184,25 @@ describe("fmtPercentage", () => {
     expect(fmt.fmtPercentage(100, 0, false)).eq("100 %");
     expect(fmt.fmtPercentage(-100, 0, true)).eq("-100 %");
     expect(fmt.fmtPercentage(-100, 0, false)).eq("-100 %");
+  });
+});
+
+const testDate = new Date(2023, 0, 15, 15, 30); // Jan 15, 2023, 15:30 (3:30 PM)
+
+describe("12h/24h time format", () => {
+  test("12h format", () => {
+    is12hSpy.mockReturnValue(true);
+    expect(fmt.fmtHourMinute(testDate)).toBe("3:30 PM");
+    expect(fmt.fmtFullDateTime(testDate)).toBe("So., 15. Jan., 3:30 PM");
+    expect(fmt.fmtWeekdayTime(testDate)).toBe("So. 3:30 PM");
+    expect(fmt.fmtAbsoluteDate(testDate)).toBe("So 3:30 PM");
+  });
+
+  test("24h format", () => {
+    is12hSpy.mockReturnValue(false);
+    expect(fmt.fmtHourMinute(testDate)).toBe("15:30");
+    expect(fmt.fmtFullDateTime(testDate)).toBe("So., 15. Jan., 15:30");
+    expect(fmt.fmtWeekdayTime(testDate)).toBe("So., 15:30");
+    expect(fmt.fmtAbsoluteDate(testDate)).toBe("So 15:30");
   });
 });

--- a/assets/js/mixins/formatter.test.js
+++ b/assets/js/mixins/formatter.test.js
@@ -1,5 +1,5 @@
 import { mount, config } from "@vue/test-utils";
-import { describe, expect, test, vi, beforeEach } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import formatter, { POWER_UNIT } from "./formatter";
 import * as units from "../units";
 

--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -1,4 +1,5 @@
 import { defineComponent } from "vue";
+import { is12hFormat } from "@/units";
 import { CURRENCY } from "../types/evcc";
 
 // list of currencies where energy price should be displayed in subunits (factor 100)
@@ -198,6 +199,7 @@ export default defineComponent({
 			if (locale === "de") return date.getHours();
 			return new Intl.DateTimeFormat(locale, {
 				hour: "numeric",
+				hour12: is12hFormat(),
 			}).format(date);
 		},
 		weekdayShort(date: Date) {
@@ -210,6 +212,7 @@ export default defineComponent({
 			const hour = new Intl.DateTimeFormat(this.$i18n?.locale, {
 				hour: "numeric",
 				minute: "numeric",
+				hour12: is12hFormat(),
 			}).format(date);
 
 			return `${weekday} ${hour}`.trim();
@@ -218,6 +221,7 @@ export default defineComponent({
 			return new Intl.DateTimeFormat(this.$i18n?.locale, {
 				hour: "numeric",
 				minute: "numeric",
+				hour12: is12hFormat(),
 			}).format(date);
 		},
 		fmtFullDateTime(date: Date, short: boolean) {
@@ -227,6 +231,7 @@ export default defineComponent({
 				day: "numeric",
 				hour: "numeric",
 				minute: "numeric",
+				hour12: is12hFormat(),
 			}).format(date);
 		},
 		fmtWeekdayTime(date: Date) {
@@ -234,6 +239,7 @@ export default defineComponent({
 				weekday: "short",
 				hour: "numeric",
 				minute: "numeric",
+				hour12: is12hFormat(),
 			}).format(date);
 		},
 		fmtMonthYear(date: Date) {

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -3,6 +3,7 @@ import { reactive, watch } from "vue";
 const SETTINGS_LOCALE = "settings_locale";
 const SETTINGS_THEME = "settings_theme";
 const SETTINGS_UNIT = "settings_unit";
+const SETTINGS_12H_FORMAT = "settings_12h_format";
 const SETTINGS_HIDDEN_FEATURES = "settings_hidden_features";
 const SETTINGS_ENERGYFLOW_DETAILS = "settings_energyflow_details";
 const SETTINGS_ENERGYFLOW_PV = "settings_energyflow_pv";
@@ -59,6 +60,7 @@ const settings = reactive({
   locale: read(SETTINGS_LOCALE),
   theme: read(SETTINGS_THEME),
   unit: read(SETTINGS_UNIT),
+  is12hFormat: readBool(SETTINGS_12H_FORMAT),
   hiddenFeatures: readBool(SETTINGS_HIDDEN_FEATURES),
   energyflowDetails: readBool(SETTINGS_ENERGYFLOW_DETAILS),
   energyflowPv: readBool(SETTINGS_ENERGYFLOW_PV),
@@ -76,6 +78,7 @@ const settings = reactive({
 watch(() => settings.locale, save(SETTINGS_LOCALE));
 watch(() => settings.theme, save(SETTINGS_THEME));
 watch(() => settings.unit, save(SETTINGS_UNIT));
+watch(() => settings.is12hFormat, saveBool(SETTINGS_12H_FORMAT));
 watch(() => settings.hiddenFeatures, saveBool(SETTINGS_HIDDEN_FEATURES));
 watch(() => settings.energyflowDetails, saveBool(SETTINGS_ENERGYFLOW_DETAILS));
 watch(() => settings.energyflowPv, saveBool(SETTINGS_ENERGYFLOW_PV));

--- a/assets/js/units.js
+++ b/assets/js/units.js
@@ -29,3 +29,11 @@ export function getUnits() {
 export function setUnits(value) {
   settings.unit = value;
 }
+
+export function is12hFormat() {
+  return settings.is12hFormat;
+}
+
+export function set12hFormat(value) {
+  settings.is12hFormat = value;
+}

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -931,6 +931,11 @@
       "label": "Design",
       "light": "Hell"
     },
+    "time": {
+      "12h": "12h",
+      "24h": "24h",
+      "label": "Zeitformat"
+    },
     "title": "Darstellung",
     "unit": {
       "km": "Kilometer",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -931,6 +931,11 @@
       "label": "Design",
       "light": "light"
     },
+    "time": {
+      "12h": "12h",
+      "24h": "24h",
+      "label": "Time format"
+    },
     "title": "User Interface",
     "unit": {
       "km": "km",


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/21135

⏰ add 12h/24h setting (default 24h)
✏️ adapt all time formatting

Limitation: time input field (planner) does not support forcing 12/24h format. Always uses system settings.

**TODOs**

- [x] add tests

**Screenshots**

new setting

<img width="544" alt="setting" src="https://github.com/user-attachments/assets/8e78c842-2cd3-465a-bfb5-7b6d9e426348" />

---

forecast

<img width="846" alt="forecast 12" src="https://github.com/user-attachments/assets/9ac01348-3e71-4d95-965f-2ddd90dabc53" />
<img width="816" alt="forecast 24" src="https://github.com/user-attachments/assets/cacbcd4e-d1cd-4af5-bc89-6f7236a3fc3e" />

---

finish

<img width="320" alt="finish 12" src="https://github.com/user-attachments/assets/b1cd86bd-5b3d-48a0-a260-bc244d0a7d42" />
<br/>
<img width="335" alt="finish 24" src="https://github.com/user-attachments/assets/b143037b-2e46-4698-9629-7121fd1a1e8d" />
