### PR TITLE
Plugins: Formatieren von Payloads per jq - überarbeitete Version für http, mqtt

### DIFF
--- a/plugin/helper.go
+++ b/plugin/helper.go
@@ -12,21 +12,19 @@ import (
 )
 
 // setFormattedValue formats a message template or returns the value formatted as %v if the message template is empty
-func _setFormattedValue(message, param string, v interface{}) (string, error) {
-	if message == "" {
-		return fmt.Sprintf("%v", v), nil
-	}
-
-	return util.ReplaceFormatted(message, map[string]interface{}{
-		param: v,
-	})
-}
-
-// setFormattedValue with pipeline support
+// a given pipeline is processed afterwards
 func setFormattedValue(message, param string, v interface{}, pipeline *pipeline.Pipeline) (string, error) {
-	payload, err := _setFormattedValue(message, param, v)
-	if err != nil {
-		return "", err
+	var payload string
+	if message == "" {
+		payload = fmt.Sprintf("%v", v)
+	} else {
+		var err error
+		payload, err = util.ReplaceFormatted(message, map[string]interface{}{
+			param: v,
+		})
+		if err != nil {
+			return "", err
+		}
 	}
 	if pipeline != nil {
 		processed_payload, err := pipeline.Process([]byte(payload))

--- a/plugin/helper.go
+++ b/plugin/helper.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/plugin/pipeline"
 )
 
 // setFormattedValue formats a message template or returns the value formatted as %v if the message template is empty
-func setFormattedValue(message, param string, v interface{}) (string, error) {
+func _setFormattedValue(message, param string, v interface{}) (string, error) {
 	if message == "" {
 		return fmt.Sprintf("%v", v), nil
 	}
@@ -19,6 +20,24 @@ func setFormattedValue(message, param string, v interface{}) (string, error) {
 	return util.ReplaceFormatted(message, map[string]interface{}{
 		param: v,
 	})
+}
+
+// setFormattedValue with pipeline support
+func setFormattedValue(message, param string, v interface{}, pipeline *pipeline.Pipeline) (string, error) {
+	payload, err := _setFormattedValue(message, param, v)
+	if err != nil {
+		return "", err
+	}
+	if pipeline != nil {
+		processed_payload, err := pipeline.Process([]byte(payload))
+		if err != nil {
+			return "", err
+		}
+		
+		payload = string(processed_payload)
+	}
+
+	return payload, nil
 }
 
 // knownErrors maps string responses to known error codes

--- a/plugin/http.go
+++ b/plugin/http.go
@@ -75,7 +75,7 @@ func NewHTTPPluginFromConfig(ctx context.Context, other map[string]interface{}) 
 	p.getter = defaultGetters(p, cc.Scale)
 
 	if cc.Auth.Type != "" || cc.Auth.Source != "" {
-		transport, err := cc.Auth.Transport(ctx, log, p.Client.Transport)
+		transport, err := cc.Auth.Transport(ctx, p.Client.Transport)
 		if err != nil {
 			return nil, err
 		}
@@ -170,7 +170,7 @@ var _ Getters = (*HTTP)(nil)
 // StringGetter sends string request
 func (p *HTTP) StringGetter() (func() (string, error), error) {
 	return func() (string, error) {
-		url, err := setFormattedValue(p.url, "", "")
+		url, err := setFormattedValue(p.url, "", "", p.pipeline)
 		if err != nil {
 			return "", err
 		}
@@ -186,12 +186,12 @@ func (p *HTTP) StringGetter() (func() (string, error), error) {
 }
 
 func (p *HTTP) set(param string, val interface{}) error {
-	url, err := setFormattedValue(p.url, param, val)
+	url, err := setFormattedValue(p.url, param, val, p.pipeline)
 	if err != nil {
 		return err
 	}
 
-	body, err := setFormattedValue(p.body, param, val)
+	body, err := setFormattedValue(p.body, param, val, p.pipeline)
 	if err != nil {
 		return err
 	}

--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -125,7 +125,7 @@ var _ IntSetter = (*Mqtt)(nil)
 // IntSetter publishes topic with parameter replaced by int value
 func (m *Mqtt) IntSetter(param string) (func(int64) error, error) {
 	return func(v int64) error {
-		payload, err := setFormattedValue(m.payload, param, v)
+		payload, err := setFormattedValue(m.payload, param, v, m.pipeline)
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ var _ FloatSetter = (*Mqtt)(nil)
 // FloatSetter publishes topic with parameter replaced by float value
 func (m *Mqtt) FloatSetter(param string) (func(float64) error, error) {
 	return func(v float64) error {
-		payload, err := setFormattedValue(m.payload, param, v)
+		payload, err := setFormattedValue(m.payload, param, v, m.pipeline)
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ var _ BoolSetter = (*Mqtt)(nil)
 // BoolSetter invokes script with parameter replaced by bool value
 func (m *Mqtt) BoolSetter(param string) (func(bool) error, error) {
 	return func(v bool) error {
-		payload, err := setFormattedValue(m.payload, param, v)
+		payload, err := setFormattedValue(m.payload, param, v, m.pipeline)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ var _ StringSetter = (*Mqtt)(nil)
 // StringSetter invokes script with parameter replaced by string value
 func (m *Mqtt) StringSetter(param string) (func(string) error, error) {
 	return func(v string) error {
-		payload, err := setFormattedValue(m.payload, param, v)
+		payload, err := setFormattedValue(m.payload, param, v, m.pipeline)
 		if err != nil {
 			return err
 		}

--- a/plugin/mqtt_test.go
+++ b/plugin/mqtt_test.go
@@ -1,0 +1,50 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatPayloadMultiply(t *testing.T) {
+	p, err := NewMqttPluginFromConfig(
+		context.TODO(),
+		map[string]any{
+			"topic":    "some-topic",
+			"broker":   "test.mosquitto.org:1884",
+			"user":     "rw",
+			"password": "readwrite",
+			"jq":       ". * 2",
+			"payload":  "${var:%d}",
+		},
+	)
+	assert.NoError(t, err)
+
+	{
+		payload, err := setFormattedValue(p.(*Mqtt).payload, "var", 10, p.(*Mqtt).pipeline)
+		assert.NoError(t, err)
+		assert.Equal(t, "20", payload)
+	}	
+}
+
+func TestFormatPayloadAdd(t *testing.T) {
+	p, err := NewMqttPluginFromConfig(
+		context.TODO(),
+		map[string]any{
+			"topic":    "some-topic",
+			"broker":   "test.mosquitto.org:1884",
+			"user":     "rw",
+			"password": "readwrite",
+			"jq":       ". + 1",
+			"payload":  "${var:%d}",
+		},
+	)
+	assert.NoError(t, err)
+
+	{
+		payload, err := setFormattedValue(p.(*Mqtt).payload, "var", 0, p.(*Mqtt).pipeline)
+		assert.NoError(t, err)
+		assert.Equal(t, "1", payload)
+	}	
+}


### PR DESCRIPTION
Basierend auf #20913 habe ich den Vorschlag von @andig aufgegriffen und eine Variante für die beiden Plugins erabreitet, die `setFormattedValue()` nutzen.

Die Funktionalität bleibt gleich:

```yaml
chargers:
  - name: xxx
    enable:
      source: mqtt
      topic: 'a/b/c'
      payload: ${enable:%d}
      jq: if . == 1 then 65 else 50 end
```
