### PR TITLE
Add pysolarman hint to Deye documentation

### DIFF
--- a/util/templates/documentation.go
+++ b/util/templates/documentation.go
@@ -50,7 +50,9 @@ func (t *Template) RenderDocumentation(product Product, lang string) ([]byte, er
 				panic(err)
 			}
 
-			modbusData := make(map[string]interface{})
+			modbusData := map[string]interface{}{
+				"ProductBrand": product.Brand,
+			}
 			t.ModbusValues(RenderModeDocs, modbusData)
 
 			out := new(bytes.Buffer)

--- a/util/templates/documentation_modbus.tpl
+++ b/util/templates/documentation_modbus.tpl
@@ -10,6 +10,9 @@ comset: "{{ .comset }}" # Kommunikationsparameter für den Adapter
 {{- if .rs485tcpip }}
 
 # RS485 via TCP/IP (Modbus RTU)
+{{- if  eq .ProductBrand "Deye" }}
+# Some Solarman data loggers support running as Modbus bridge. To connect to them use [pysolarman](https://github.com/jmccrohan/pysolarmanv5) in proxy mode
+{{- end }}
 modbus: rs485tcpip
 id: {{ .id }}
 host: {{ .host }} # Hostname


### PR DESCRIPTION
This PR adds a hint to the documentation of Deye inverters that [pysolarman](https://github.com/jmccrohan/) can be used as a proxy.