### PR TITLE
OpenEMS: enhanced battery control

### DIFF
--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -77,7 +77,7 @@ render: |
       - case: 1 # normal
         set:
           source: http
-          uri: http://{{ .host }}/rest/channel/{{ .battery }}/SetActivePowerEquals
+          uri: http://{{ .host }}/rest/channel/{{ .battery }}/SetActivePowerLessOrEquals
           auth:
             type: basic
             user: x
@@ -89,7 +89,7 @@ render: |
       - case: 2 # hold
         set:
           source: http
-          uri: http://{{ .host }}/rest/channel/{{ .battery }}/SetActivePowerEquals
+          uri: http://{{ .host }}/rest/channel/{{ .battery }}/SetActivePowerLessOrEquals
           auth:
             type: basic
             user: x


### PR DESCRIPTION
The adaption allows charging the battery but no discharging. The previous implementation did not allow charging the battery using remaining PV production or grid energy.

Not using a PID filter for the ESS power allows quicker settlement, otherwise it takes a moment.

follow up on #20948