### PR TITLE
Config UI: fix boolean default

### DIFF
--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -214,7 +214,7 @@ export default {
 				}
 
 				if (this.boolean) {
-					return this.modelValue === true;
+					return this.modelValue === "true";
 				}
 
 				if (this.array) {


### PR DESCRIPTION
Hi,
bisher wurde bei boolean-Parametern immer `nein` in der Config UI angezeigt, auch wenn im Template `default: true` gesetzt wurde.
Beispiel Demowallbox:
![grafik](https://github.com/user-attachments/assets/92862d48-52aa-455a-bc69-696aba0b766d)

Das liegt daran, dass `this.modelValue` ein String ist.
Wenn der Wert mit `"true"` verglichen wird, ist das Problem behoben.
(s. [StackOverflow](https://stackoverflow.com/a/264037))