### PR TITLE
Config UI: fix boolean default

### DIFF
--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -214,7 +214,7 @@ export default {
 				}
 
 				if (this.boolean) {
-					return this.modelValue === "true";
+					return this.modelValue === "true" || this.modelValue === true;
 				}
 
 				if (this.array) {


### PR DESCRIPTION
Nachtrag zu #21233

Erklärung:
Zuerst ist `this.modelValue` ein String und muss mit `"true"` verglichen werden.
Nach dem Ändern von z.B. `ja` auf `nein` ist `this.modelValue` ein Boolean und muss mit `true` verglichen werden.