### PR TITLE
Add IOmeter

### DIFF
--- a/templates/definition/meter/iometer.yaml
+++ b/templates/definition/meter/iometer.yaml
@@ -1,9 +1,6 @@
 template: iometer
 products:
   - brand: IOmeter
-    description:
-      generic: HTTP API
-group: generic
 params:
   - name: usage
     choice: ["grid"]
@@ -17,11 +14,11 @@ render: |
     source: http
     uri: http://{{ .host }}/v1/reading
     method: GET
-    timeout: 10s
     jq: .meter.reading.registers[] | select(.obis == "01-00:10.07.00*ff") | .value
+    cache: 10s
   energy:
     source: http
     uri: http://{{ .host }}/v1/reading
     method: GET
-    timeout: 10s
     jq: .meter.reading.registers[] | select(.obis == "01-00:01.08.00*ff") | .value
+    cache: 10s

--- a/templates/definition/meter/iometer.yaml
+++ b/templates/definition/meter/iometer.yaml
@@ -1,0 +1,27 @@
+template: iometer
+products:
+  - brand: IOmeter
+    description:
+      generic: HTTP API
+group: generic
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: host
+    description:
+      de: IP deines IOmeter
+      en: IP of your IOmeter
+render: |
+  type: custom
+  power:
+    source: http
+    uri: http://{{ .host }}/v1/reading
+    method: GET
+    timeout: 10s
+    jq: .meter.reading.registers[] | select(.obis == "01-00:10.07.00*ff") | .value
+  energy:
+    source: http
+    uri: http://{{ .host }}/v1/reading
+    method: GET
+    timeout: 10s
+    jq: .meter.reading.registers[] | select(.obis == "01-00:01.08.00*ff") | .value


### PR DESCRIPTION
Hi,

this PR introduces the IOmeter energy meter for the German consumer market. More information here: [iometer.de](iometer.de).

The device exposes a lcoal HTTP API that can be queried. More information on how the local endpoint works [here](https://github.com/iometer-gmbh/iometer.py/blob/main/docs/api.md).

This PR contains the UI template for the device. The parameters power and energy consumed from the grid are included.

I am happy to here your feedback.