### PR TITLE
Sessions: negative prices in bar chart

### DIFF
--- a/assets/js/components/Sessions/CostHistoryChart.vue
+++ b/assets/js/components/Sessions/CostHistoryChart.vue
@@ -314,7 +314,7 @@ export default {
 							maxTicksLimit: 6,
 						},
 						suggestedMax: this.suggestedMaxCost,
-						min: 0,
+						suggestedMin: 0,
 					},
 					y1: {
 						position: "left",


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/21188

<img width="481" alt="Bildschirmfoto 2025-05-15 um 23 48 46" src="https://github.com/user-attachments/assets/cad6f051-5e98-4c66-8d86-db7cff8f283f" />
<img width="470" alt="Bildschirmfoto 2025-05-15 um 23 49 05" src="https://github.com/user-attachments/assets/ecae27e8-0b2e-43e3-b3a7-2f14a84caa75" />
<img width="1016" alt="Bildschirmfoto 2025-05-15 um 23 50 33" src="https://github.com/user-attachments/assets/caa78ebd-1a33-4ebf-b3c6-8b95c244d4ea" />

---

Limitation: Negative bars don't have rounded bottom edges due to limitations for chart.js border radius mechanism in combination with positive/negative stacked values.