### PR TITLE
Add Sigenergy

### DIFF
--- a/plugin/modbus.go
+++ b/plugin/modbus.go
@@ -45,7 +45,14 @@ func NewModbusFromConfig(ctx context.Context, other map[string]interface{}) (Plu
 	modbus.Lock()
 	defer modbus.Unlock()
 
-	conn, err := modbus.NewConnection(ctx, cc.URI, cc.Device, cc.Comset, cc.Baudrate, cc.Settings.Protocol(), cc.ID)
+	var slaveID uint8
+	if cc.SubDevice != 0 {
+		slaveID = uint8(cc.SubDevice)
+	} else {
+		slaveID = cc.ID
+	}
+
+	conn, err := modbus.NewConnection(ctx, cc.URI, cc.Device, cc.Comset, cc.Baudrate, cc.Settings.Protocol(), slaveID)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/modbus.go
+++ b/plugin/modbus.go
@@ -45,14 +45,7 @@ func NewModbusFromConfig(ctx context.Context, other map[string]interface{}) (Plu
 	modbus.Lock()
 	defer modbus.Unlock()
 
-	var slaveID uint8
-	if cc.SubDevice > 0 && cc.SubDevice <= 255 {
-		slaveID = uint8(cc.SubDevice)
-	} else {
-		slaveID = cc.ID
-	}
-
-	conn, err := modbus.NewConnection(ctx, cc.URI, cc.Device, cc.Comset, cc.Baudrate, cc.Settings.Protocol(), slaveID)
+	conn, err := modbus.NewConnection(ctx, cc.URI, cc.Device, cc.Comset, cc.Baudrate, cc.Settings.Protocol(), cc.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/modbus.go
+++ b/plugin/modbus.go
@@ -46,7 +46,7 @@ func NewModbusFromConfig(ctx context.Context, other map[string]interface{}) (Plu
 	defer modbus.Unlock()
 
 	var slaveID uint8
-	if cc.SubDevice != 0 {
+	if cc.SubDevice > 0 && cc.SubDevice <= 255 {
 		slaveID = uint8(cc.SubDevice)
 	} else {
 		slaveID = cc.ID

--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -1,0 +1,95 @@
+template: sigenergy
+products:
+  - brand: Sigenergy
+    description:
+      generic: Sigen Hybrid/Sigen PV Max/SigenStore EC
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+    allinone: true
+  - name: modbus
+    choice: ["tcpip", "rs485"]
+    id: 1
+  - name: capacity
+    advanced: true
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    subdevice: 247
+    register:
+      address: 30005 # [Grid sensor] Active power
+      type: holding
+      decode: int32
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 30562 # Accumulated import energy
+      type: holding
+      decode: uint64
+    scale: 0.01
+  currents:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 31017 # Phase A current
+        type: holding
+        decode: int32
+      scale: 0.01
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 31019 # Phase B current
+        type: holding
+        decode: int32
+      scale: 0.01
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 31021 # Phase C current
+        type: holding
+        decode: int32
+      scale: 0.01
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    subdevice: 247
+    register:
+      type: holding
+      address: 30035 # Photovoltaic power
+      decode: int32
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    subdevice: 247
+    register:
+      type: holding
+      address: 30037 # Battery power
+      decode: int32
+    scale: -1
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 30574 # Battery accumulated discharge energy
+      type: holding
+      decode: uint64
+    scale: 0.01
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    subdevice: 247
+    register:
+      address: 30014 # Energy storage system SOC
+      type: holding
+      decode: uint16
+    scale: 0.1
+  capacity: {{ .capacity }} # kWh
+  {{- end }}

--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -7,9 +7,9 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery"]
     allinone: true
-  - name: modbus
-    choice: ["tcpip", "rs485"]
-    id: 1
+  - name: host
+  - name: port
+  - name: id
   - name: capacity
     advanced: true
 render: |
@@ -17,15 +17,18 @@ render: |
   {{- if eq .usage "grid" }}
   power:
     source: modbus
-    {{- include "modbus" . | indent 2 }}
-    subdevice: 247
+    uri: {{ .host }}:{{ .port }}
+    id: 247
+    rtu: false
     register:
       address: 30005 # [Grid sensor] Active power
       type: holding
       decode: int32
   energy:
     source: modbus
-    {{- include "modbus" . | indent 2 }}
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    rtu: false
     register:
       address: 30562 # Accumulated import energy
       type: holding
@@ -33,21 +36,27 @@ render: |
     scale: 0.01
   currents:
     - source: modbus
-      {{- include "modbus" . | indent 4 }}
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      rtu: false
       register:
         address: 31017 # Phase A current
         type: holding
         decode: int32
       scale: 0.01
     - source: modbus
-      {{- include "modbus" . | indent 4 }}
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      rtu: false
       register:
         address: 31019 # Phase B current
         type: holding
         decode: int32
       scale: 0.01
     - source: modbus
-      {{- include "modbus" . | indent 4 }}
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      rtu: false
       register:
         address: 31021 # Phase C current
         type: holding
@@ -57,8 +66,9 @@ render: |
   {{- if eq .usage "pv" }}
   power:
     source: modbus
-    {{- include "modbus" . | indent 2 }}
-    subdevice: 247
+    uri: {{ .host }}:{{ .port }}
+    id: 247
+    rtu: false
     register:
       type: holding
       address: 30035 # Photovoltaic power
@@ -67,8 +77,9 @@ render: |
   {{- if eq .usage "battery" }}
   power:
     source: modbus
-    {{- include "modbus" . | indent 2 }}
-    subdevice: 247
+    uri: {{ .host }}:{{ .port }}
+    id: 247
+    rtu: false
     register:
       type: holding
       address: 30037 # Battery power
@@ -76,7 +87,9 @@ render: |
     scale: -1
   energy:
     source: modbus
-    {{- include "modbus" . | indent 2 }}
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    rtu: false
     register:
       address: 30574 # Battery accumulated discharge energy
       type: holding
@@ -84,8 +97,9 @@ render: |
     scale: 0.01
   soc:
     source: modbus
-    {{- include "modbus" . | indent 2 }}
-    subdevice: 247
+    uri: {{ .host }}:{{ .port }}
+    id: 247
+    rtu: false
     register:
       address: 30014 # Energy storage system SOC
       type: holding

--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -13,7 +13,9 @@ params:
     allinone: true
   - name: host
   - name: port
+    default: 502
   - name: id
+    default: 1
   - name: capacity
     advanced: true
 render: |
@@ -23,7 +25,6 @@ render: |
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: 247
-    rtu: false
     register:
       address: 30005 # [Grid sensor] Active power
       type: holding
@@ -32,7 +33,6 @@ render: |
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
-    rtu: false
     register:
       address: 30562 # Accumulated import energy
       type: holding
@@ -42,7 +42,6 @@ render: |
     - source: modbus
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
-      rtu: false
       register:
         address: 31017 # Phase A current
         type: holding
@@ -51,7 +50,6 @@ render: |
     - source: modbus
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
-      rtu: false
       register:
         address: 31019 # Phase B current
         type: holding
@@ -60,7 +58,6 @@ render: |
     - source: modbus
       uri: {{ .host }}:{{ .port }}
       id: {{ .id }}
-      rtu: false
       register:
         address: 31021 # Phase C current
         type: holding
@@ -72,7 +69,6 @@ render: |
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: 247
-    rtu: false
     register:
       type: holding
       address: 30035 # Photovoltaic power
@@ -83,7 +79,6 @@ render: |
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: 247
-    rtu: false
     register:
       type: holding
       address: 30037 # Battery power
@@ -93,7 +88,6 @@ render: |
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
-    rtu: false
     register:
       address: 30574 # Battery accumulated discharge energy
       type: holding
@@ -103,7 +97,6 @@ render: |
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: 247
-    rtu: false
     register:
       address: 30014 # Energy storage system SOC
       type: holding

--- a/templates/definition/meter/sigenergy.yaml
+++ b/templates/definition/meter/sigenergy.yaml
@@ -3,6 +3,10 @@ products:
   - brand: Sigenergy
     description:
       generic: Sigen Hybrid/Sigen PV Max/SigenStore EC
+requirements:
+  description:
+    de: Der Elektriker muss die Funktion Modbus via TCP/IP in seiner Version der Sigen App aktivieren bevor diese Konfiguration funktional ist. Diese Option ist in der mySigen App für Kunden nicht verfügbar.
+    en: The electrician needs to enable the Modbus via TCP/IP in their service app before the setup is functional. This is not available in the customers mySigen app.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]


### PR DESCRIPTION
Added the modbus config from discussion here https://github.com/evcc-io/evcc/discussions/16246 as proper template. The modbus implementation has an additional static slave id at 247 as per the [modbus docs](https://github.com/user-attachments/files/17077437/Sigenergy.Modbus.Protocol.-.20240409.pdf). Due to that I added the subdevice support from the sunspec modbus variant to general modbus. This shouldn't change anything for sunspec devices as they have their own source different from modbus. But if I missed something let me know.

Also its possible to read the rated battery capacity from the bus but I couldn't quite find a way to add the evaluation routine for capacity as well.