### PR TITLE
UI: don't show setup-screen on slow connections

### DIFF
--- a/assets/js/views/Main.vue
+++ b/assets/js/views/Main.vue
@@ -1,5 +1,6 @@
 <template>
 	<Site
+		v-if="state.startup || state.offline"
 		:notifications="notifications"
 		v-bind="state"
 		:selected-loadpoint-index="selectedLoadpointIndex"

--- a/assets/js/views/Main.vue
+++ b/assets/js/views/Main.vue
@@ -1,6 +1,6 @@
 <template>
 	<Site
-		v-if="state.startup || state.offline"
+		v-if="state.startup"
 		:notifications="notifications"
 		v-bind="state"
 		:selected-loadpoint-index="selectedLoadpointIndex"

--- a/tests/ws.spec.js
+++ b/tests/ws.spec.js
@@ -39,4 +39,5 @@ test("show offline when websocket is closed", async ({ page }) => {
   });
   await page.goto("/");
   await expect(page.getByText("Not connected to a server.")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Let's start configuration" })).toBeHidden();
 });

--- a/tests/ws.spec.js
+++ b/tests/ws.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+test.use({ baseURL: baseUrl() });
+
+test.beforeAll(async () => {
+  await start("basics.evcc.yaml");
+});
+test.afterAll(async () => {
+  await stop();
+});
+
+test("show loadpoint with connect websocket", async ({ page }) => {
+  await page.routeWebSocket("/ws", (ws) => {
+    const server = ws.connectToServer();
+    ws.onMessage((message) => {
+      server.send(message);
+    });
+    server.onMessage((message) => {
+      ws.send(message);
+    });
+  });
+  await page.goto("/");
+  await expect(page.getByRole("link", { name: "Let's start configuration" })).toBeHidden();
+  await expect(page.getByText("Not connected to a server.")).toBeHidden();
+  await expect(page.getByTestId("loadpoint")).toBeVisible();
+});
+
+test("show no config screen while startup", async ({ page }) => {
+  await page.routeWebSocket("/ws", () => {
+    // connect, but don't send any messages
+  });
+  await page.goto("/");
+  await expect(page.getByRole("link", { name: "Let's start configuration" })).toBeHidden();
+});
+
+test("show offline when websocket is closed", async ({ page }) => {
+  await page.routeWebSocket("/ws", (ws) => {
+    ws.close();
+  });
+  await page.goto("/");
+  await expect(page.getByText("Not connected to a server.")).toBeVisible();
+});


### PR DESCRIPTION
Wenn evcc die websocket Verbindung aufbaut, gibt es einen kurzen Moment wo die Verbindung bereits besteht, aber noch keine Informationen in State sind. Dies führt dazu, dass die Liste der loadpoints leer ist und für einen kurzen Augenblick, die Nachricht zum beginnen der Konfiguration angezeigt wird. Ich kann das nur auf meinem Android Phone sehen, mein Desktop Browser scheint dort ein anderes Timing zu haben und daher ist das nicht zu sehen.

Dies wird damit gefixt, dass die Site erst gerendet wird, wenn die startup Nachricht angekommen ist.

ref https://github.com/evcc-io/evcc/discussions/21120#discussioncomment-13078087