### PR TITLE
Kathrein charger: Bug fixing after first tests

### DIFF
--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -375,8 +375,8 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 
 	// After (!!!) switching phases charging must be stopped to execute phase switching (special behavior of Kathrein WB)
 	if err := wb.Enable(false); err != nil {
-			return err
-		}		
+		return err
+	}		
 
 	// Re-enable charging if it was previously enabled
 	if enabled {

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -367,7 +367,7 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 	if _, err := wb.conn.WriteSingleRegister(kathreinRegEMSControlRegister, 0x8000); err != nil {
 		return err
 	}
-	
+
 	// Switch phases
 	if _, err := wb.conn.WriteSingleRegister(kathreinRegEMSSetpointRelais, u); err != nil {
 		return err

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -253,7 +253,7 @@ func (wb *Kathrein) Enable(enable bool) error {
 		u = wb.curr
 	}
 
-	// Enable EMS-Control
+	// EMS-Control must be enabled before sending first WriteReg Command
 	if _, err := wb.conn.WriteSingleRegister(kathreinRegEMSControlRegister, 0x8000); err != nil {
 		return err
 	}
@@ -363,7 +363,7 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 		return err
 	}
 
-	// Enable EMS-Control
+	// EMS-Control must be enabled before sending first WriteReg Command
 	if _, err := wb.conn.WriteSingleRegister(kathreinRegEMSControlRegister, 0x8000); err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 		return err
 	}
 
-	// After switching phases Kathrein WB must be disabled (Stop/Reset Charging)
+	// After (!!!) switching phases charging must be stopped to execute phase switching (special behavior of Kathrein WB)
 	if err := wb.Enable(false); err != nil {
 			return err
 		}		

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -380,7 +380,7 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 
 	// Re-enable charging if it was previously enabled
 	if enabled {
-		err = wb.Enable(true)
+		err := wb.Enable(true)
 	}
 
 	return err

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -254,7 +254,7 @@ func (wb *Kathrein) Enable(enable bool) error {
 	}
 
 	// Enable EMS-Control
-	if _, err = wb.conn.WriteSingleRegister(kathreinRegEMSControlRegister, 0x8000); err != nil {
+	if _, err := wb.conn.WriteSingleRegister(kathreinRegEMSControlRegister, 0x8000); err != nil {
 		return err
 	}
 
@@ -364,17 +364,17 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 	}
 
 	// Enable EMS-Control
-	if _, err = wb.conn.WriteSingleRegister(kathreinRegEMSControlRegister, 0x8000); err != nil {
+	if _, err := wb.conn.WriteSingleRegister(kathreinRegEMSControlRegister, 0x8000); err != nil {
 		return err
 	}
 	
 	// Switch phases
-	if _, err = wb.conn.WriteSingleRegister(kathreinRegEMSSetpointRelais, u); err != nil {
+	if _, err := wb.conn.WriteSingleRegister(kathreinRegEMSSetpointRelais, u); err != nil {
 		return err
 	}
 
 	// After switching phases Kathrein WB must be disabled (Stop/Reset Charging)
-	if err = wb.Enable(false); err != nil {
+	if err := wb.Enable(false); err != nil {
 			return err
 		}		
 

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -432,11 +432,7 @@ func (wb *Kathrein) Diagnose() {
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegTotalActivePower, 2); err == nil {
 		fmt.Printf("Meter - P tot (active):\t%f W\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
 	}
-
-	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegTotalEnergy, 2); err == nil {
-		fmt.Printf("Meter - W tot:\t%f kWh\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))) / 1e3)
-	}
-
+	
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegFrequencyLine, 2); err == nil {
 		fmt.Printf("Meter - W tot:\t%f Hz\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
 	}

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -380,7 +380,7 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 
 	// Re-enable charging if it was previously enabled
 	if enabled {
-		err := wb.Enable(true)
+		err = wb.Enable(true)
 	}
 
 	return err

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -434,7 +434,7 @@ func (wb *Kathrein) Diagnose() {
 	}
 	
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegFrequencyLine, 2); err == nil {
-		fmt.Printf("Meter - W tot:\t%f Hz\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
+		fmt.Printf("Meter - Frequency:\t%f Hz\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
 	}
 
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegChargingState, 1); err == nil {
@@ -490,6 +490,6 @@ func (wb *Kathrein) Diagnose() {
 	}
 
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegEMSTimeOutFallbackCurrent, 1); err == nil {
-		fmt.Printf("EMS-Control - Timeout Fallback Pattern:\t%d mA\n", b[1])
+		fmt.Printf("EMS-Control - Timeout Fallback Current:\t%d mA\n", b[1])
 	}
 }

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -373,17 +373,17 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 		return err
 	}
 
-	// After (!!!) switching phases charging must be stopped to execute phase switching (special behavior of Kathrein WB)
-	if err := wb.Enable(false); err != nil {
-		return err
-	}
-
-	// Re-enable charging if it was previously enabled
+	// Disable and re-enable charging to apply the new phase setting
 	if enabled {
-		err = wb.Enable(true)
+		if err := wb.Enable(false); err != nil {
+			return err
+		}
+		if err := wb.Enable(true); err != nil {
+			return err
+		}
 	}
 
-	return err
+	return nil
 }
 
 var _ api.PhaseGetter = (*Kathrein)(nil)
@@ -429,14 +429,6 @@ func (wb *Kathrein) Diagnose() {
 		fmt.Printf("Device - Serial:\t%s\n", b)
 	}
 
-	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegTotalActivePower, 2); err == nil {
-		fmt.Printf("Meter - P tot (active):\t%f W\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
-	}
-
-	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegFrequencyLine, 2); err == nil {
-		fmt.Printf("Meter - Frequency:\t%f Hz\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
-	}
-
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegChargingState, 1); err == nil {
 		fmt.Printf("EVSE - Charging-State:\t%d\n", b[1])
 	}
@@ -459,14 +451,6 @@ func (wb *Kathrein) Diagnose() {
 
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegGrantedPower, 1); err == nil {
 		fmt.Printf("EVSE - Granted Power:\t%d W\n", b[1])
-	}
-
-	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegChargingDuration, 2); err == nil {
-		fmt.Printf("Charging - Duration:\t%d s\n", b)
-	}
-
-	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegChargingEnergy, 2); err == nil {
-		fmt.Printf("Charging - Energy:\t%d Wh\n", b)
 	}
 
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegEMSControlRegister, 1); err == nil {

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -67,8 +67,7 @@ const (
 	kathreinRegCurrents         = 0x0036 // float32 Line 1 Current (A)
 	kathreinRegPowers           = 0x003C // float32 Line 1 Power (W)
 	kathreinRegTotalActivePower = 0x0054 // float32 Total active power (W)
-	kathreinRegTotalEnergy      = 0x005C // float32 Total Energy (since production) (Wh - deviating from Kathrein Register Document)
-	kathreinRegFrequencyLine    = 0x005E // float32 Frequency line (Hz)
+	kathreinRegTotalEnergy      = 0x005C // float32 Total Energy (since production) (Wh)
 
 	// EVSE - Charging state (uint16)
 	//   0 : Idle

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -376,7 +376,7 @@ func (wb *Kathrein) Phases1p3p(phases int) error {
 	// After (!!!) switching phases charging must be stopped to execute phase switching (special behavior of Kathrein WB)
 	if err := wb.Enable(false); err != nil {
 		return err
-	}		
+	}
 
 	// Re-enable charging if it was previously enabled
 	if enabled {

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -432,7 +432,7 @@ func (wb *Kathrein) Diagnose() {
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegTotalActivePower, 2); err == nil {
 		fmt.Printf("Meter - P tot (active):\t%f W\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
 	}
-	
+
 	if b, err := wb.conn.ReadHoldingRegisters(kathreinRegFrequencyLine, 2); err == nil {
 		fmt.Printf("Meter - Frequency:\t%f Hz\n", float64(math.Float32frombits(binary.BigEndian.Uint32(b))))
 	}


### PR DESCRIPTION
Mit diesem Pull Request sollen die folgenden Fehler behoben werden:

- Kein steuernder Zugriff auf die Wallbox nach Wallbox-Neustart möglich: evcc muss in diesem Fall erst wieder neu gestartet werden, um EMS-Control zu aktivieren. Erst dann werden Write-Register-Befehle verarbeitet.
Lösung: EMS-Control wird beim Start des Ladevorgangs aktiviert (Wert 0800 in das Register 00A0 „EMS-Control“ schreiben, Einfügen in die Funktionen "Enable" und "Phases1p3p").
- Phasenumschaltung funktioniert nicht (siehe https://github.com/evcc-io/evcc/discussions/13132 ). 
Lösung: Nach der Phasenumschaltung muss der Ladevorgang zunächst gestoppt werden durch Enable(false) 
- Der Wert für „Total Charge Energy“ ist um den Faktor 1000 zu groß. Gemäß Modbus-Register-Dokument von Kathrein soll das Register 005C einen Wert in der Einheit kWh liefern. In der Realität wird ein Wert in Wh geliefert.

## Summary by Sourcery

Enable EMS-Control on charger startup and before phase operations, fix phase switching by restarting charging, correct energy unit conversion, and remove outdated diagnostics to streamline Kathrein charger integration.

Bug Fixes:
- Activate EMS-Control on charging start and before phase switching to allow write register commands without restarting EVCC
- Restart charging (stop and start) around phase switch to ensure correct relay update
- Divide total energy reading by 1000 to convert from Wh to kWh as per actual register behavior

Enhancements:
- Remove incorrect diagnostic logs and correct output labels for cleaner output