### PR TITLE
wrap log copy in ```

### DIFF
--- a/assets/js/views/Log.vue
+++ b/assets/js/views/Log.vue
@@ -86,10 +86,10 @@
 						</button>
 					</div>
 					<code
-						@copy="onCopy"
 						v-if="filteredLines.length"
 						class="d-block evcc-default-text flex-grow-1"
 						data-testid="log-content"
+						@copy="onCopy"
 					>
 						<div
 							v-for="{ line, className, key } in lineEntries"
@@ -304,8 +304,8 @@ export default {
 		},
 		onCopy(event) {
 			const selection = window.getSelection().toString();
-			event.clipboardData.setData('text/plain', '```\n' + selection + '\n```');	
-    		event.preventDefault();
+			event.clipboardData.setData("text/plain", "```\n" + selection + "\n```");
+			event.preventDefault();
 		},
 	},
 };

--- a/assets/js/views/Log.vue
+++ b/assets/js/views/Log.vue
@@ -86,6 +86,7 @@
 						</button>
 					</div>
 					<code
+						@copy="onCopy"
 						v-if="filteredLines.length"
 						class="d-block evcc-default-text flex-grow-1"
 						data-testid="log-content"
@@ -300,6 +301,11 @@ export default {
 		},
 		changeAreas(areas) {
 			this.updateQuery({ areas });
+		},
+		onCopy(event) {
+			const selection = window.getSelection().toString();
+			event.clipboardData.setData('text/plain', '```\n' + selection + '\n```');	
+    		event.preventDefault();
 		},
 	},
 };


### PR DESCRIPTION
Da bei Nutzern sich oft schwer damit tun Logs als Code formatiert in Issues und Diskussionen einzufügen, hatte ich heute morgen die Idee, ob man nicht den Code Format beim kopieren aus der UI einfach mit einfügen kann. Bei meinen kurzen PoC sieht das erst mal aus als würde das gehen.

Bleibt die Frage ist das eine gute Idee oder nicht.