### PR TITLE
UI: fix ui dev mode / custom css

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -1,42 +1,40 @@
 <!doctype html>
 <html lang="[[.DefaultLang]]">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="evcc" />
+    <meta name="application-name" content="evcc" />
+    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-  <meta name="apple-mobile-web-app-title" content="evcc" />
-  <meta name="application-name" content="evcc" />
-  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
+    <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
+    <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
+    <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
+    <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
+    <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
+    <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
+    <meta name="msapplication-TileColor" content="#1C2445" />
+    <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
+    <meta name="theme-color" content="#020318" />
+    <meta name="evcc-app-compatible" content="true" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
-  <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
-  <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
-  <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
-  <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
-  <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
-  <meta name="msapplication-TileColor" content="#1C2445" />
-  <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
-  <meta name="theme-color" content="#020318" />
-  <meta name="evcc-app-compatible" content="true" />
+    <title>evcc</title>
+  </head>
 
-  <title>evcc</title>
-</head>
+  <body>
+    <script>
+      window.evcc = {
+        version: "[[.Version]]",
+        configured: "[[.Configured]]",
+        commit: "[[.Commit]]",
+        customCss: "[[.CustomCss]]",
+      };
+    </script>
 
-<body>
-  <script>
-    window.evcc = {
-      version: "[[.Version]]",
-      configured: "[[.Configured]]",
-      commit: "[[.Commit]]",
-      customCss: "[[.CustomCss]]",
-    };
-  </script>
-
-  <div id="app"></div>
-  <script type="module" src="./js/app.js"></script>
-</body>
-
+    <div id="app"></div>
+    <script type="module" src="./js/app.js"></script>
+  </body>
 </html>

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,40 +1,42 @@
 <!doctype html>
 <html lang="[[.DefaultLang]]">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="evcc" />
-    <meta name="application-name" content="evcc" />
-    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
 
-    <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
-    <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
-    <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
-    <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
-    <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
-    <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
-    <meta name="msapplication-TileColor" content="#1C2445" />
-    <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
-    <meta name="theme-color" content="#020318" />
-    <meta name="evcc-app-compatible" content="true" />
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="apple-mobile-web-app-title" content="evcc" />
+  <meta name="application-name" content="evcc" />
+  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
 
-    <title>evcc</title>
-  </head>
+  <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
+  <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />
+  <link rel="icon" type="image/png" sizes="16x16" href="meta/favicon-16x16.png?[[.Version]]" />
+  <link rel="manifest" href="meta/site.webmanifest?[[.Version]]" crossorigin="use-credentials" />
+  <link rel="mask-icon" href="meta/safari-pinned-tab.svg?[[.Version]]" color="#1C2445" />
+  <link rel="shortcut icon" href="meta/favicon.ico?[[.Version]]" />
+  <meta name="msapplication-TileColor" content="#1C2445" />
+  <meta name="msapplication-config" content="meta/browserconfig.xml?[[.Version]]" />
+  <meta name="theme-color" content="#020318" />
+  <meta name="evcc-app-compatible" content="true" />
 
-  <body>
-    <script>
-      window.evcc = {
-        version: "[[.Version]]",
-        configured: "[[.Configured]]",
-        commit: "[[.Commit]]",
-        customCss: [[.CustomCss]],
-      };
-    </script>
+  <title>evcc</title>
+</head>
 
-    <div id="app"></div>
-    <script type="module" src="./js/app.js"></script>
-  </body>
+<body>
+  <script>
+    window.evcc = {
+      version: "[[.Version]]",
+      configured: "[[.Configured]]",
+      commit: "[[.Commit]]",
+      customCss: "[[.CustomCss]]",
+    };
+  </script>
+
+  <div id="app"></div>
+  <script type="module" src="./js/app.js"></script>
+</body>
+
 </html>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -76,7 +76,7 @@ window.app = app.mount("#app");
 watchThemeChanges();
 appDetection();
 
-if (window.evcc.customCss) {
+if (window.evcc.customCss === "true") {
   const link = document.createElement("link");
   link.href = `./custom.css`;
   link.rel = "stylesheet";


### PR DESCRIPTION
regression from #21263 

fixes Vite dev mode (`npm run dev`) due to missing go template handling.
