### PR TITLE
fix broken solarwatt myreserve template

### DIFF
--- a/templates/definition/meter/solarwatt-myreserve-matrix.yaml
+++ b/templates/definition/meter/solarwatt-myreserve-matrix.yaml
@@ -11,14 +11,15 @@ params:
   - name: port
     default: 8080
   - name: path
-    default: / # usually /BSMData.shtml
+    default: / # usually /BMSData.shtml, always start with a /
   - name: capacity
     advanced: true
 render: |
   type: custom
+  {{- $uri := printf "http://%s:%s%s" .host .port .path }}
   power:
     source: http
-    uri: http://{{ .host }}:{{ .port }}{{ .path }}
+    uri: {{ $uri }}
   {{- if eq .usage "grid" }}
     jq: .FData.PGrid
   {{- end }}
@@ -29,7 +30,7 @@ render: |
     jq: .FData.IBat * .FData.VBat
   soc:
     source: http
-    uri: http://{{ .host }}:{{ .port }}{{ .path }}
+    uri: {{ $uri }}
     jq: .SData.SoC
   capacity: {{ .capacity }} # kWh
   {{- end }}

--- a/templates/definition/meter/solarwatt-myreserve-matrix.yaml
+++ b/templates/definition/meter/solarwatt-myreserve-matrix.yaml
@@ -10,24 +10,26 @@ params:
   - name: host
   - name: port
     default: 8080
+  - name: path
+    default: / # usually /BSMData.shtml
   - name: capacity
     advanced: true
 render: |
   type: custom
   power:
     source: http
-    uri: http://{{ .host }}:{{ .port }}/
+    uri: http://{{ .host }}:{{ .port }}{{ .path }}
   {{- if eq .usage "grid" }}
     jq: .FData.PGrid
   {{- end }}
   {{- if eq .usage "pv" }}
-    jq: .FData.IBat * .FData.VBa * -1
+    jq: .FData.IPV * .FData.VPV
   {{- end }}
   {{- if eq .usage "battery" }}
     jq: .FData.IBat * .FData.VBat
   soc:
     source: http
-    uri: http://{{ .host }}:{{ .port }}/
+    uri: http://{{ .host }}:{{ .port }}{{ .path }}
     jq: .SData.SoC
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
- fix broken "pv" computation by computing VPV * IPV as positive value
- add new parameter "path". 
PowerGateway provides bmsdata under http://hostname:port/BMSData.shtml
the parameter defaults to "/" so this patch does not break existing configs