### PR TITLE
tariff/octopus: Add Multi-Account Support

### DIFF
--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -20,6 +20,7 @@ type Octopus struct {
 	region        string
 	productCode   string
 	apikey        string
+	accountnumber string
 	paymentMethod string
 	data          *util.Monitor[api.Rates]
 }
@@ -32,11 +33,12 @@ func init() {
 
 func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
-		Region      string
-		Tariff      string // DEPRECATED: use ProductCode
-		ProductCode string
-		DirectDebit bool
-		ApiKey      string
+		Region        string
+		Tariff        string // DEPRECATED: use ProductCode
+		ProductCode   string
+		DirectDebit   bool
+		ApiKey        string
+		AccountNumber string
 	}
 
 	logger := util.NewLogger("octopus")
@@ -77,6 +79,7 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		region:        cc.Region,
 		productCode:   cc.ProductCode,
 		apikey:        cc.ApiKey,
+		accountnumber: cc.AccountNumber,
 		paymentMethod: paymentMethod,
 		data:          util.NewMonitor[api.Rates](2 * time.Hour),
 	}
@@ -97,7 +100,7 @@ func (t *Octopus) run(done chan error) {
 	// If ApiKey is available, use GraphQL to get appropriate tariff code before entering execution loop.
 	if t.apikey != "" {
 		t.log.TRACE.Println("running in GraphQL mode")
-		gqlCli, err := octoGql.NewClient(t.log, t.apikey)
+		gqlCli, err := octoGql.NewClient(t.log, t.apikey, t.accountnumber)
 		if err != nil {
 			once.Do(func() { done <- err })
 			t.log.ERROR.Println(err)

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -106,7 +106,6 @@ func (t *Octopus) run(done chan error) {
 			t.log.ERROR.Println(err)
 			return
 		}
-		t.log.TRACE.Println("requesting tariff code")
 		tariffCode, err := gqlCli.TariffCode()
 		if err != nil {
 			once.Do(func() { done <- err })

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -115,7 +115,6 @@ func (t *Octopus) run(done chan error) {
 		}
 		t.log.TRACE.Println("GraphQL tariff code retrieved:", tariffCode)
 		restQueryUri = octoRest.ConstructRatesAPIFromTariffCode(tariffCode)
-
 	} else {
 		t.log.TRACE.Println("running in productCode mode")
 		// Construct Rest Query URI using tariff and region codes.
@@ -164,7 +163,7 @@ func (t *Octopus) run(done chan error) {
 				// UnitRates are supplied inclusive of tax, though this could be flipped easily with a config flag.
 				Value: r.PriceInclusiveTax / 1e2,
 			}
-			t.log.TRACE.Printf("rate: start %s, end %s, value %s", ar.Start, ar.End, ar.Value)
+			t.log.TRACE.Printf("rate: start %s, end %s, value %v", ar.Start, ar.End, ar.Value)
 			data = append(data, ar)
 		}
 

--- a/tariff/octopus/graphql/api.go
+++ b/tariff/octopus/graphql/api.go
@@ -125,7 +125,7 @@ func (c *OctopusGraphQLClient) AccountNumber() (string, error) {
 	if c.accountNumberDesire != "" {
 		for _, account := range q.Viewer.Accounts {
 			if account.Number == c.accountNumberDesire {
-				c.accountNumber = q.Viewer.Accounts[0].Number
+				c.accountNumber = account.Number
 				break
 			}
 		}

--- a/tariff/octopus/graphql/api.go
+++ b/tariff/octopus/graphql/api.go
@@ -132,7 +132,7 @@ func (c *OctopusGraphQLClient) TariffCode() (string, error) {
 	// Get Account Number
 	acc, err := c.AccountNumber()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/tariff/octopus/graphql/api_test.go
+++ b/tariff/octopus/graphql/api_test.go
@@ -1,13 +1,14 @@
 package graphql
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestOctopusGraphQLAccountFiltration(t *testing.T) {
 	validAccountNumber := "A-AAAAAAAA"
-	noAccounts := []krakenAccount{}
+	var noAccounts []krakenAccount
 	oneAccount := []krakenAccount{
 		{Number: validAccountNumber},
 	}

--- a/tariff/octopus/graphql/api_test.go
+++ b/tariff/octopus/graphql/api_test.go
@@ -1,0 +1,53 @@
+package graphql
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestOctopusGraphQLAccountFiltration(t *testing.T) {
+	validAccountNumber := "A-AAAAAAAA"
+	noAccounts := []krakenAccount{}
+	oneAccount := []krakenAccount{
+		{Number: validAccountNumber},
+	}
+	multipleAccounts := []krakenAccount{
+		{Number: validAccountNumber},
+		{Number: "X-XXXXXXXX"},
+		{Number: "Y-YYYYYYYY"},
+		{Number: "Z-ZZZZZZZZ"},
+	}
+
+	var accNum string
+
+	// No accounts (invalid state)
+	_, err := filterAccount(noAccounts, "")
+	require.ErrorIs(t, err, ErrNoAccounts)
+
+	// One account, no filtration
+	accNum, err = filterAccount(oneAccount, "")
+	require.NoError(t, err)
+	require.Equal(t, accNum, validAccountNumber)
+
+	// One account, valid filtration
+	accNum, err = filterAccount(oneAccount, validAccountNumber)
+	require.NoError(t, err)
+	require.Equal(t, accNum, validAccountNumber)
+
+	// One account, invalid filtration (invalid state)
+	_, err = filterAccount(oneAccount, "0-00000000")
+	require.ErrorIs(t, err, ErrAccountNotFound)
+
+	// Multiple accounts, no filtration (invalid state)
+	_, err = filterAccount(multipleAccounts, "")
+	require.ErrorIs(t, err, ErrMultipleAccounts)
+
+	// Multiple accounts, valid filtration
+	accNum, err = filterAccount(multipleAccounts, validAccountNumber)
+	require.NoError(t, err)
+	require.Equal(t, accNum, validAccountNumber)
+
+	// Multiple accounts, invalid filtration (invalid state)
+	_, err = filterAccount(multipleAccounts, "0-00000000")
+	require.ErrorIs(t, err, ErrAccountNotFound)
+}

--- a/tariff/octopus/graphql/errors.go
+++ b/tariff/octopus/graphql/errors.go
@@ -1,0 +1,11 @@
+package graphql
+
+import (
+	"errors"
+)
+
+var (
+	ErrAccountNotFound  = errors.New("unable to find configured account")
+	ErrMultipleAccounts = errors.New("multiple accounts on this api key - specific an account to use in configuration")
+	ErrNoAccounts       = errors.New("no accounts on this api key")
+)

--- a/tariff/octopus/graphql/types.go
+++ b/tariff/octopus/graphql/types.go
@@ -11,10 +11,13 @@ type krakenTokenAuthentication struct {
 // credentials used to authorize the request.
 type krakenAccountLookup struct {
 	Viewer struct {
-		Accounts []struct {
-			Number string
-		}
+		Accounts []krakenAccount
 	}
+}
+
+// krakenAccount represents an Octopus Energy account.
+type krakenAccount struct {
+	Number string
 }
 
 type tariffData struct {

--- a/templates/definition/tariff/octopus-api.yaml
+++ b/templates/definition/tariff/octopus-api.yaml
@@ -15,6 +15,12 @@ params:
     required: true
     help:
       generic: "Octopus Energy API Key."
+  - name: accountNumber
+    type: string
+    required: false
+    help:
+      generic: "Optional Account Number (usually in the format X-XXXXXXXX). Only required if you have multiple Accounts."
 render: |
   type: octopusenergy
   apikey: {{ .apiKey }}
+  accountNumber: {{ .accountNumber }}


### PR DESCRIPTION
This PR properly handles instances when Octopus Energy accounts have multiple accountNumbers.

An accountNumber configuration flag can be set alongside apiKey to filter for a match. If multiple accounts are on the key, and a filter is not set, an error will be returned but the available accounts will be logged to console to aid the user in setting one.

If a filter is set but a match is not found, an error will be returned, even if only one accountNumber is on the key.

This PR also adds trace logging to aid in future.

Closes https://github.com/evcc-io/evcc/issues/21382