### PR TITLE
Messaging: Enable AI formatting (OpenAI)

### DIFF
--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evcc-io/evcc/plugin/mqtt"
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server/eebus"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/modbus"
 )
@@ -133,6 +134,7 @@ type DB struct {
 type Messaging struct {
 	Events   map[string]push.EventTemplateConfig
 	Services []config.Typed
+	AIAgent  util.AIAgent
 }
 
 func (c Messaging) Configured() bool {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -735,7 +735,7 @@ func configureMessengers(conf *globalconfig.Messaging, vehicles push.Vehicles, v
 
 	messageChan := make(chan push.Event, 1)
 
-	messageHub, err := push.NewHub(conf.Events, vehicles, cache)
+	messageHub, err := push.NewHub(conf.Events, vehicles, cache, conf.AIAgent)
 	if err != nil {
 		return messageChan, fmt.Errorf("failed configuring push services: %w", err)
 	}

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -195,6 +195,16 @@ eebus:
 
 # push messages
 messaging:
+  aiagent: # AI agent for rewriting messages
+    # type: openai
+    # token: sk-Replace-with-your-openai-key
+    # context: |
+    #   You are an EV charging assistant based on the opensource evcc software.
+    #   You help users to charge their electric vehicles.
+    # prompt: |
+    #   Please rewrite the message in a more human-readable format, keeping the original meaning intact.
+    #   Always start your conversation with a kind hello to the driver and end your event information with a nice personal wish to have a healthy next trip or similar.
+    # language: de # language for AI responses, use "en" for English
   events:
     start: # charge start event
       title: Charge started

--- a/go.mod
+++ b/go.mod
@@ -187,6 +187,7 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sashabaranov/go-openai v1.40.0
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spali/go-slicereader v0.0.0-20201122145524-8e262e1a5127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -612,6 +612,8 @@ github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppK
 github.com/samber/lo v1.50.0 h1:XrG0xOeHs+4FQ8gJR97zDz5uOFMW7OwFWiFVzqopKgY=
 github.com/samber/lo v1.50.0/go.mod h1:RjZyNk6WSnUFRKK6EyOhsRJMqft3G+pg7dCWHQCWvsc=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/sashabaranov/go-openai v1.40.0 h1:Peg9Iag5mUJtPW00aYatlsn97YML0iNULiLNe74iPrU=
+github.com/sashabaranov/go-openai v1.40.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=

--- a/push/hub.go
+++ b/push/hub.go
@@ -37,7 +37,6 @@ type Hub struct {
 
 // NewHub creates push hub with definitions and receiver
 func NewHub(cc map[string]EventTemplateConfig, vv Vehicles, cache *util.ParamCache, ai util.AIAgent) (*Hub, error) {
-
 	// instantiate all event templates
 	for k, v := range cc {
 		if _, err := template.New("out").Funcs(sprig.FuncMap()).Parse(v.Title); err != nil {

--- a/push/hub.go
+++ b/push/hub.go
@@ -133,9 +133,12 @@ func (h *Hub) Run(events <-chan Event, valueChan chan<- util.Param) {
 			}
 
 		}
+
 		if strings.TrimSpace(msg) == "" {
 			continue
 		}
+
+		log.TRACE.Printf("Event %s: %s", ev.Event, msg)
 
 		for _, sender := range h.sender {
 			go sender.Send(title, msg)

--- a/push/hub.go
+++ b/push/hub.go
@@ -131,7 +131,6 @@ func (h *Hub) Run(events <-chan Event, valueChan chan<- util.Param) {
 			if err != nil {
 				log.ERROR.Printf("AI formatter error for %s: %v", ev.Event, err)
 			}
-
 		}
 
 		if strings.TrimSpace(msg) == "" {

--- a/util/aiagent.go
+++ b/util/aiagent.go
@@ -27,8 +27,14 @@ func AIFormatter(ai AIAgent, msg string) (string, error) {
 			},
 		},
 	)
+
 	if err != nil {
 		return "", err
 	}
+
+	if len(resp.Choices) == 0 {
+		return msg, nil
+	}
+
 	return resp.Choices[0].Message.Content, nil
 }

--- a/util/aiagent.go
+++ b/util/aiagent.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"context"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type AIAgent struct {
+	Type, Token, Context, Prompt, Language string
+}
+
+func AIFormatter(ai AIAgent, msg string) (string, error) {
+	client := openai.NewClient(ai.Token)
+	resp, err := client.CreateChatCompletion(
+		context.Background(),
+		openai.ChatCompletionRequest{
+			Model: openai.GPT3Dot5Turbo,
+			Messages: []openai.ChatCompletionMessage{
+				{
+					Role: openai.ChatMessageRoleUser,
+					Content: "Context: " + ai.Context + "\n\n" +
+						"evcc event message: " + msg + "\n\n" +
+						ai.Prompt + "\n\n" +
+						"Use the language of the following language iso code: " + ai.Language + "\n\n",
+				},
+			},
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	return resp.Choices[0].Message.Content, nil
+}

--- a/util/aiagent.go
+++ b/util/aiagent.go
@@ -10,19 +10,30 @@ type AIAgent struct {
 	Type, Token, Context, Prompt, Language string
 }
 
-func AIFormatter(ai AIAgent, msg string) (string, error) {
-	client := openai.NewClient(ai.Token)
-	resp, err := client.CreateChatCompletion(
-		context.Background(),
+type AIInstance struct {
+	Client *openai.Client
+	Ctx    context.Context
+	AIAgent
+}
+
+func (i *AIInstance) NewAIAgent(p AIAgent) {
+	i.Client = openai.NewClient(p.Token)
+	i.Ctx = context.Background()
+	i.AIAgent = p
+}
+
+func (i *AIInstance) AIFormat(msg string) (string, error) {
+	resp, err := i.Client.CreateChatCompletion(
+		i.Ctx,
 		openai.ChatCompletionRequest{
 			Model: openai.GPT3Dot5Turbo,
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: "Context: " + ai.Context + "\n\n" +
+					Content: "Context: " + i.Context + "\n\n" +
 						"evcc event message: " + msg + "\n\n" +
-						ai.Prompt + "\n\n" +
-						"Use the language of the following language iso code: " + ai.Language + "\n\n",
+						i.Prompt + "\n\n" +
+						"Use the language of the following language iso code: " + i.Language + "\n\n",
 				},
 			},
 		},


### PR DESCRIPTION
New optional messaging feature: Beautify your messages with OpenAI!

AI-generated push  messages will look like this:
```bash
[push  ] TRACE 2025/05/25 17:15:15 Event disconnect: Hallo Fahrer! Dein Auto wurde nach 19 Sekunden vom Ladevorgang getrennt. Wir hoffen, dass du eine sichere Fahrt hast!
[push  ] TRACE 2025/05/25 17:15:16 Event connect: Hallo Fahrer! Dein Auto ist mit einer Leistung von 0,0 kW an die PV-Anlage angeschlossen. Wir wünschen dir eine sichere und angenehme Weiterfahrt!
```

You can change the AI-message output by adapting the context and prompt config strings to your needs.
With the AI agent not configured, messaging behaves like before!

Sample `evcc.yaml` configuration:
([How to get your token/api-key](https://www.howtogeek.com/885918/how-to-get-an-openai-api-key/))
...
```yaml
# push messages
messaging:
  aiagent: # AI agent for rewriting messages
    type: openai
    token: sk-Replace-with-your-openai-key
    context: |
      You are an EV charging assistant based on the open-source EVCC software.
      You help users to charge their electric vehicles.
    prompt: |
      Please rewrite the message in a more human-readable format, keeping the original meaning intact.
      You can always start your conversation with a kind hello to the driver and end your event information with a nice personal wish to have a healthy next trip or similar.
    language: de # language for AI responses, use "en" for English
  events:
    start: # charge start event
      title: Charge started
      msg: Started charging in "${mode}" mode
    stop: # charge stop event
...
```
Todos:

- [x] Pass a context from the caller to AIFormatter to support cancellation and timeouts for the OpenAI request.
- [x] Avoid recreating the OpenAI client on every message—initialise and reuse it on the AIAgent struct to reduce allocation and setup overhead.