### PR TITLE
Energyflow: align text/icons

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.stories.ts
+++ b/assets/js/components/Energyflow/Energyflow.stories.ts
@@ -56,6 +56,13 @@ GridAndPV.args = {
 	smartCostType: "price",
 	currency: CURRENCY.EUR,
 	pv: [{ power: 5000 }, { power: 2300 }],
+	forecast: {
+		solar: {
+			today: { energy: 1000, complete: true },
+			tomorrow: { energy: 1000, complete: false },
+			dayAfterTomorrow: { energy: 1000, complete: false },
+		},
+	},
 };
 
 export const BatteryAndGrid = Template.bind({});

--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -70,7 +70,7 @@
 				<div
 					class="col-12 col-md-6 pe-md-5 pb-4 d-flex flex-column justify-content-between"
 				>
-					<div class="d-flex justify-content-between align-items-end mb-4">
+					<div class="d-flex justify-content-between align-items-baseline mb-4">
 						<h3 class="m-0">In</h3>
 						<span v-if="pvPossible" class="fw-bold">
 							<AnimatedNumber :to="inPower" :format="kw" />
@@ -154,7 +154,7 @@
 				<div
 					class="col-12 col-md-6 ps-md-5 pb-4 d-flex flex-column justify-content-between"
 				>
-					<div class="d-flex justify-content-between align-items-end mb-4">
+					<div class="d-flex justify-content-between align-items-baseline mb-4">
 						<h3 class="m-0">Out</h3>
 						<span v-if="pvPossible" class="fw-bold">
 							<AnimatedNumber :to="outPower" :format="kw" />

--- a/assets/js/components/Energyflow/Entry.vue
+++ b/assets/js/components/Energyflow/Entry.vue
@@ -2,7 +2,7 @@
 	<div>
 		<div class="mb-2 entry" :class="{ 'evcc-gray': !active }">
 			<div class="d-flex justify-content-between">
-				<span class="d-flex flex-nowrap align-items-top">
+				<span class="d-flex flex-nowrap">
 					<BatteryIcon v-if="isBattery" v-bind="iconProps" />
 					<VehicleIcon v-else-if="isVehicle" v-bind="iconProps" />
 					<div v-else-if="!icon" class="icon-placeholder"></div>

--- a/assets/js/components/Energyflow/Entry.vue
+++ b/assets/js/components/Energyflow/Entry.vue
@@ -2,22 +2,24 @@
 	<div>
 		<div class="mb-2 entry" :class="{ 'evcc-gray': !active }">
 			<div class="d-flex justify-content-between">
-				<span class="d-flex flex-nowrap">
+				<span class="d-flex flex-nowrap align-items-top">
 					<BatteryIcon v-if="isBattery" v-bind="iconProps" />
 					<VehicleIcon v-else-if="isVehicle" v-bind="iconProps" />
 					<div v-else-if="!icon" class="icon-placeholder"></div>
 					<component :is="`shopicon-regular-${icon}`" v-else></component>
 				</span>
-				<div class="d-block flex-grow-1 ms-3 text-truncate">
-					<span v-if="!$slots['expanded']">{{ name }}</span>
+				<div class="d-flex flex-grow-1 ms-3 align-items-center text-truncate">
+					<span v-if="!$slots['expanded']" class="text-truncate">
+						{{ name }}
+					</span>
 					<button
 						v-else
-						class="btn-neutral d-flex align-items-baseline flex-shrink-1 flex-grow-1"
+						class="btn-neutral d-flex align-items-center flex-shrink-1 flex-grow-1"
 						style="max-width: 100%"
 						@click="toggle"
 					>
-						<div class="text-truncate flex-shrink-1 flex-grow-0">
-							{{ name }}
+						<div class="flex-shrink-1 flex-grow-0 d-flex text-truncate">
+							<span class="text-truncate"> {{ name }} </span>
 						</div>
 						<shopicon-regular-arrowdropdown
 							class="expand-icon flex-shrink-0 flex-grow-0"
@@ -25,10 +27,10 @@
 						/>
 					</button>
 				</div>
-				<span class="text-end text-nowrap ps-1 fw-bold d-flex">
+				<span class="text-end text-nowrap ps-1 fw-bold d-flex align-items-center">
 					<div
 						ref="details"
-						class="fw-normal"
+						class="fw-normal d-flex align-items-center"
 						:class="{
 							'text-decoration-underline': detailsClickable,
 							'evcc-gray': detailsInactive,


### PR DESCRIPTION
proper alignment and truncation for energy flow icons and texts

<img width="375" alt="Bildschirmfoto 2025-05-25 um 23 32 44" src="https://github.com/user-attachments/assets/4972439c-0880-49d5-a2da-314f98bd4ef5" />

<img width="923" alt="Bildschirmfoto 2025-05-25 um 23 37 47" src="https://github.com/user-attachments/assets/cf28d22c-4824-4e14-93fe-61ed2d031ff2" />
