### PR TITLE
eProWallbox: fix total energy

### DIFF
--- a/charger/eprowallbox.go
+++ b/charger/eprowallbox.go
@@ -191,7 +191,7 @@ var _ api.MeterEnergy = (*EProWallbox)(nil)
 // TotalEnergy implements the api.MeterEnergy interface
 func (wb *EProWallbox) TotalEnergy() (float64, error) {
 	l1, l2, l3, err := wb.getPhaseValues(eproRegActiveEnergies, 1000)
-	return l1 + l2 + l3, err
+	return -1.0 * (l1 + l2 + l3), err
 }
 
 var _ api.PhaseCurrents = (*EProWallbox)(nil)

--- a/charger/eprowallbox.go
+++ b/charger/eprowallbox.go
@@ -191,7 +191,7 @@ var _ api.MeterEnergy = (*EProWallbox)(nil)
 // TotalEnergy implements the api.MeterEnergy interface
 func (wb *EProWallbox) TotalEnergy() (float64, error) {
 	l1, l2, l3, err := wb.getPhaseValues(eproRegActiveEnergies, 1000)
-	return -1.0 * (l1 + l2 + l3), err
+	return -(l1 + l2 + l3), err
 }
 
 var _ api.PhaseCurrents = (*EProWallbox)(nil)


### PR DESCRIPTION
energy is returned negative via Modbus:

`Energy:
  Active [Wh]        -97389.0  -98813.0  -98742.0
`

With the change, the energy is properly recognized:

<img width="621" alt="image" src="https://github.com/user-attachments/assets/8e954111-7b44-478c-af0e-1f192e4010bb" />
