### PR TITLE
Fiat: add wake up (requires pin)

### DIFF
--- a/templates/definition/vehicle/fiat.yaml
+++ b/templates/definition/vehicle/fiat.yaml
@@ -9,13 +9,13 @@ params:
   - name: pin
     mask: true
     help:
-      en: Required for evcc to refresh the SoC while charging. When connected to TWC3, used to start/stop charging.
-      de: Benötigt zur Aktualisierung des Ladestands während der Ladung. Bei Nutzung mit TWC3 kann der Ladevorgang mittels PIN gestartet und gestoppt werden.
+      en: Required for evcc to wake up the vehicle for charging and to refresh the SoC while charging. When connected to TWC3, used to start/stop charging.
+      de: Benötigt um das Fahrzeug zum Laden aufzuwecken and zur Aktualisierung des Ladestands während der Ladung. Bei Nutzung mit TWC3 kann der Ladevorgang mittels PIN gestartet und gestoppt werden.
   - preset: vehicle-features
 render: |
   type: fiat
   {{ include "vehicle-base" . }}
   {{- if .pin }}
-  pin: {{ .pin }} # mandatory to deep refresh Soc & start/stop charge
+  pin: {{ .pin }} # mandatory to wake up, deep refresh Soc & start/stop charge
   {{- end }}
   {{ include "vehicle-features" . }}

--- a/vehicle/fiat.go
+++ b/vehicle/fiat.go
@@ -60,7 +60,7 @@ func NewFiatFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 
 	if err == nil {
 		v.Provider = fiat.NewProvider(api, cc.VIN, cc.PIN, cc.Expiry, cc.Cache)
-		v.Controller = fiat.NewController(v.Provider, api, cc.VIN, cc.PIN)
+		v.Controller = fiat.NewController(v.Provider, api, log, cc.VIN, cc.PIN)
 	}
 
 	return v, err

--- a/vehicle/fiat/api.go
+++ b/vehicle/fiat/api.go
@@ -159,6 +159,10 @@ func (v *API) Action(vin, pin, action, cmd string) (ActionResponse, error) {
 	return res, err
 }
 
+func (v *API) ChargeNow(vin, pin string) (ActionResponse, error) {
+	return v.Action(vin, pin, "ev/chargenow", "CNOW")
+}
+
 func (v *API) UpdateSchedule(vin, pin string, schedules []Schedule) (ActionResponse, error) {
 	var res ActionResponse
 

--- a/vehicle/fiat/controller.go
+++ b/vehicle/fiat/controller.go
@@ -100,3 +100,18 @@ func (c *Controller) disableConflictingChargeSchedule(schedule *Schedule) {
 		schedule.EnableScheduleType = false
 	}
 }
+
+var _ api.Resurrector = (*Controller)(nil)
+
+func (c *Controller) WakeUp() error {
+	if c.pin == "" {
+		return api.ErrMissingCredentials
+	}
+
+	res, err := c.api.ChargeNow(c.vin, c.pin)
+	if err == nil && res.ResponseStatus != "pending" {
+		err = fmt.Errorf("invalid response status: %s", res.ResponseStatus)
+	}
+
+	return err
+}

--- a/vehicle/fiat/controller.go
+++ b/vehicle/fiat/controller.go
@@ -5,20 +5,23 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
 )
 
 type Controller struct {
 	pvd *Provider
 	api *API
+	log *util.Logger
 	vin string
 	pin string
 }
 
 // NewController creates a vehicle current and charge controller
-func NewController(provider *Provider, api *API, vin string, pin string) *Controller {
+func NewController(provider *Provider, api *API, log *util.Logger, vin string, pin string) *Controller {
 	impl := &Controller{
 		pvd: provider,
 		api: api,
+		log: log,
 		vin: vin,
 		pin: pin,
 	}
@@ -105,7 +108,8 @@ var _ api.Resurrector = (*Controller)(nil)
 
 func (c *Controller) WakeUp() error {
 	if c.pin == "" {
-		return api.ErrMissingCredentials
+		c.log.DEBUG.Printf("Pin needs to be configured to wakeup vehicle")
+		return nil
 	}
 
 	res, err := c.api.ChargeNow(c.vin, c.pin)


### PR DESCRIPTION
My Fiat 500e is very unreliable in restarting a charge, with the OCPP showing status B 'Vehicle connected not ready'. The Fiat app has a 'charge now' button which puts the vehicle in status C 'Vehicle connected ready'. This PR implements the 'wake up' method to call the same 'charge now' API. 