### PR TITLE
Fix Wh to kWh conversion

### DIFF
--- a/templates/definition/meter/iometer.yaml
+++ b/templates/definition/meter/iometer.yaml
@@ -20,5 +20,5 @@ render: |
     source: http
     uri: http://{{ .host }}/v1/reading
     method: GET
-    jq: .meter.reading.registers[] | select(.obis == "01-00:01.08.00*ff") | .value
+    jq: (.meter.reading.registers[] | select(.obis == "01-00:01.08.00*ff") | .value) / 1000
     cache: 10s


### PR DESCRIPTION
This is a follow up of PR https://github.com/evcc-io/evcc/pull/21242.

The IOmeter device returns energy consumption in Wh. evcc expects kWh, therefore we need to convert the reading.