### PR TITLE
Config UI: loadpoint estimate default true

### DIFF
--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -574,7 +574,7 @@ const defaultValues = {
 	},
 	soc: {
 		poll: { mode: "charging", interval: 60 * nsPerMin },
-		estimate: false,
+		estimate: true,
 	},
 	vehicle: "",
 	charger: "",

--- a/tests/basics.spec.js
+++ b/tests/basics.spec.js
@@ -84,6 +84,8 @@ test.describe("loadpoint settings", async () => {
 
 test.describe("network requests", async () => {
   test("no failed requests", async ({ page }) => {
+    await page.waitForLoadState("networkidle");
+
     const failedRequests = [];
     page.on("requestfailed", (request) => failedRequests.push(request.url()));
 

--- a/tests/config-loadpoint.spec.js
+++ b/tests/config-loadpoint.spec.js
@@ -245,6 +245,8 @@ test.describe("loadpoint", async () => {
     // set vehicle as default for loadpoint 1
     await page.getByTestId("loadpoint").nth(0).getByRole("button", { name: "edit" }).click();
     await expectModalVisible(lpModal);
+    await expect(lpModal.getByTestId("loadpointPollMode-charging")).toHaveClass(/active/);
+    await expect(lpModal.getByRole("checkbox", { name: "Interpolate charge level" })).toBeChecked();
     await lpModal.getByLabel("Default vehicle").selectOption(VEHICLE_1);
     await lpModal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(lpModal);


### PR DESCRIPTION
Make "Interpolate charge level" checked by default to align with existing evcc.yaml behavior https://docs.evcc.io/docs/reference/configuration/loadpoints#estimate