### PR TITLE
Vestel: decorate RFID based on version

### DIFF
--- a/charger/vestel.go
+++ b/charger/vestel.go
@@ -115,21 +115,24 @@ func NewVestel(ctx context.Context, uri string, id uint8) (api.Charger, error) {
 
 	// compare firmware version to determine if RFID is available
 	var identify func() (string, error)
-	if b, err := wb.conn.ReadInputRegisters(vestelRegFirmware, 50); err == nil {
-		fw := strings.TrimPrefix(bytesAsString(b), "v")
 
-		if v, err := version.NewSemver(fw); err == nil {
-			if v.Compare(version.Must(version.NewSemver("3.156.0"))) >= 0 {
-				// firmware >= v3.156.0 supports RFID according to https://github.com/evcc-io/evcc/issues/21359
-				identify = wb.identify
-			}
-		} else {
-			log.WARN.Printf("failed to parse firmware version %q: %v", string(b), err)
+	b, err := wb.conn.ReadInputRegisters(vestelRegFirmware, 50)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read firmware version: %w", err)
+	}
+
+	fw := strings.TrimPrefix(bytesAsString(b), "v")
+	if v, err := version.NewSemver(fw); err == nil {
+		if v.Compare(version.Must(version.NewSemver("3.156.0"))) >= 0 {
+			// firmware >= v3.156.0 supports RFID according to https://github.com/evcc-io/evcc/issues/21359
+			identify = wb.identify
 		}
+	} else {
+		log.WARN.Printf("failed to parse firmware version %q: %v", string(b), err)
 	}
 
 	// get failsafe timeout from charger
-	b, err := wb.conn.ReadHoldingRegisters(vestelRegFailsafeTimeout, 1)
+	b, err = wb.conn.ReadHoldingRegisters(vestelRegFailsafeTimeout, 1)
 	if err != nil {
 		return nil, fmt.Errorf("failsafe timeout: %w", err)
 	}

--- a/charger/vestel.go
+++ b/charger/vestel.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/modbus"
 	"github.com/evcc-io/evcc/util/sponsor"
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -116,9 +116,15 @@ func NewVestel(ctx context.Context, uri string, id uint8) (api.Charger, error) {
 	// compare firmware version to determine if RFID is available
 	var identify func() (string, error)
 	if b, err := wb.conn.ReadInputRegisters(vestelRegFirmware, 50); err == nil {
-		if versionGreaterOrEqual(string(b), "v3.156.0") {
-			// firmware >= v3.156.0 supports RFID according to https://github.com/evcc-io/evcc/issues/21359
-			identify = wb.identify
+		fw := strings.TrimPrefix(bytesAsString(b), "v")
+
+		if v, err := version.NewSemver(fw); err == nil {
+			if v.Compare(version.Must(version.NewSemver("3.156.0"))) >= 0 {
+				// firmware >= v3.156.0 supports RFID according to https://github.com/evcc-io/evcc/issues/21359
+				identify = wb.identify
+			}
+		} else {
+			log.WARN.Printf("failed to parse firmware version %q: %v", string(b), err)
 		}
 	}
 
@@ -137,40 +143,6 @@ func NewVestel(ctx context.Context, uri string, id uint8) (api.Charger, error) {
 	go wb.heartbeat(ctx, timeout)
 
 	return decorateVestel(wb, phasesS, phasesG, identify), err
-}
-
-// versionGreaterOrEqual compares two version strings in the vXXX.YYY.ZZZ scheme.
-// It returns true if v1 is greater than or equal to v2.
-func versionGreaterOrEqual(v1, v2 string) bool {
-	v1 = strings.TrimPrefix(v1, "v")
-	v2 = strings.TrimPrefix(v2, "v")
-
-	parts1 := strings.Split(v1, ".")
-	parts2 := strings.Split(v2, ".")
-
-	if len(parts1) != 3 || len(parts2) != 3 {
-		// Unexpected version format
-		return false
-	}
-
-	for i := range 3 {
-		n1, err1 := strconv.Atoi(parts1[i])
-		n2, err2 := strconv.Atoi(parts2[i])
-		if err1 != nil || err2 != nil {
-			// Not numeric: compare strings directly.
-			if parts1[i] == parts2[i] {
-				continue
-			}
-			return parts1[i] >= parts2[i]
-		}
-		if n1 == n2 {
-			continue
-		}
-		return n1 > n2
-	}
-
-	// All parts are equal: v1 is equal to v2.
-	return true
 }
 
 func (wb *Vestel) heartbeat(ctx context.Context, timeout time.Duration) {

--- a/templates/definition/charger/vestel.yaml
+++ b/templates/definition/charger/vestel.yaml
@@ -16,8 +16,8 @@ products:
 capabilities: ["rfid", "1p3p"]
 requirements:
   description:
-    de: 1P3P und RFID erfordern Firmware 3.187.0 oder neuer.
-    en: 1P3P and RFID require at least firmware version 3.187.0.
+    de: 1P3P erfordert Firmware 3.187.0 oder neuer, RFID erfordert 3.156.0 oder neuer.
+    en: 1P3P requires at least firmware version 3.187.0, RFID at least 3.156.0.
   evcc: ["sponsorship"]
 params:
   - name: modbus


### PR DESCRIPTION
Follow-up to #21124

The current RFID decoration mechanism (attempt to read the registers) leads to a "connection reset by peer" error with versions not supporting the RFID registers. This PR decorates RFID based on version, the minimum version we know it works with is v3.156.0, see https://github.com/evcc-io/evcc/issues/21359#issuecomment-2898162220

Since I have no EVC04, I cannot test it.

Fixes #21359, #21313, #21172