### PR TITLE
Config UI: make lpc circuit visible

### DIFF
--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -72,8 +72,8 @@ func New(ctx context.Context, other map[string]interface{}, site site.API) (*EEB
 	}
 
 	// register LPC-Circuit for use in config, if not already registered
-	if _, err := config.Circuits().ByName("lpc-eebus"); err != nil {
-		_ = config.Circuits().Add(config.NewStaticDevice(config.Named{Name: "lpc-eebus"}, api.Circuit(lpc)))
+	if _, err := config.Circuits().ByName("lpc"); err != nil {
+		_ = config.Circuits().Add(config.NewStaticDevice(config.Named{Name: "lpc"}, api.Circuit(lpc)))
 	}
 
 	// wrap old root with new pc parent

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
 )
 
 type EEBus struct {
@@ -68,6 +69,11 @@ func New(ctx context.Context, other map[string]interface{}, site site.API) (*EEB
 	lpc, err := circuit.New(util.NewLogger("lpc"), "eebus", 0, 0, nil, time.Minute)
 	if err != nil {
 		return nil, err
+	}
+
+	// register LPC-Circuit for use in config, if not already registered
+	if _, err := config.Circuits().ByName("lpc-eebus"); err != nil {
+		_ = config.Circuits().Add(config.NewStaticDevice(config.Named{Name: "lpc-eebus"}, api.Circuit(lpc)))
 	}
 
 	// wrap old root with new pc parent

--- a/hems/relay/relay.go
+++ b/hems/relay/relay.go
@@ -45,8 +45,8 @@ func New(ctx context.Context, other map[string]interface{}, site site.API) (*Rel
 	}
 
 	// register LPC-Circuit for use in config, if not already registered
-	if _, err := config.Circuits().ByName("lpc-relay"); err != nil {
-		_ = config.Circuits().Add(config.NewStaticDevice(config.Named{Name: "lpc-relay"}, api.Circuit(lpc)))
+	if _, err := config.Circuits().ByName("lpc"); err != nil {
+		_ = config.Circuits().Add(config.NewStaticDevice(config.Named{Name: "lpc"}, api.Circuit(lpc)))
 	}
 
 	// wrap old root with new pc parent

--- a/hems/relay/relay.go
+++ b/hems/relay/relay.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/plugin"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
 )
 
 type Relay struct {
@@ -41,6 +42,11 @@ func New(ctx context.Context, other map[string]interface{}, site site.API) (*Rel
 	lpc, err := circuit.New(util.NewLogger("lpc"), "relay", 0, 0, nil, time.Minute)
 	if err != nil {
 		return nil, err
+	}
+
+	// register LPC-Circuit for use in config, if not already registered
+	if _, err := config.Circuits().ByName("lpc-relay"); err != nil {
+		_ = config.Circuits().Add(config.NewStaticDevice(config.Named{Name: "lpc-relay"}, api.Circuit(lpc)))
 	}
 
 	// wrap old root with new pc parent


### PR DESCRIPTION
Der LPC Circuit zur Konfiguration von §14a konnte nur in der evcc.yaml verwendet werden. Diese Änderung macht ihn auch in der UI sichtbar.