### PR TITLE
Zaptec: keep phases low until evcc charge begins

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -229,6 +229,9 @@ func (c *Zaptec) Enable(enable bool) error {
 	}
 	if c.version == zaptec.ZaptecGo2 {
 		phases, err := c.configuredPhases()
+		if err != nil {
+			return err
+		}
 
 		if enable && phases == 0 {
 			err = c.Phases1p3p(c.desiredPhases)

--- a/charger/zaptec/types.go
+++ b/charger/zaptec/types.go
@@ -85,8 +85,11 @@ type SessionPriority struct {
 }
 
 type Installation struct {
-	Id         string  `json:"id"`
-	MaxCurrent float64 `json:"maxCurrent"`
+	Id                     string  `json:"id"`
+	MaxCurrent             float64 `json:"maxCurrent"`
+	AvailableCurrentPhase1 float64 `json:"availableCurrentPhase1,omitempty"`
+	AvailableCurrentPhase2 float64 `json:"availableCurrentPhase2,omitempty"`
+	AvailableCurrentPhase3 float64 `json:"availableCurrentPhase3,omitempty"`
 }
 
 type UpdateInstallation struct {


### PR DESCRIPTION
This PR will keep the phases low until evcc start the charge. Solves the issue, that zaptec2 starts to charge as soon as a car is plugged in