### PR TITLE
Renault: fix for incomplete json payload in MY24 wakeupmode

### DIFF
--- a/vehicle/renault/kamereon/api.go
+++ b/vehicle/renault/kamereon/api.go
@@ -148,6 +148,7 @@ func (v *API) WakeUpMY24(accountID string, vin string) (Response, error) {
 		ChargeTimeStart:             "21:00",
 		ChargeDuration:              1615,
 		PreconditioningTemperature:  20.0,
+		Programs:                    []interface{}{},
 	}
 
 	return v.request(uri, request.MarshalJSON(data))


### PR DESCRIPTION
Fix for [Renault servers refusing wakeup command with internal error 500](https://github.com/evcc-io/evcc/pull/21432#issuecomment-2924843551) due to [removing](https://github.com/evcc-io/evcc/pull/21432/commits/a84fb6ecb1c442f144bcc1b2c48886cb7e2cc6e8) program information from payload.