### PR TITLE
template: add vehicle-features to vw

### DIFF
--- a/templates/definition/vehicle/vw.yaml
+++ b/templates/definition/vehicle/vw.yaml
@@ -14,7 +14,9 @@ params:
     example: WVWZZZ...
   - name: timeout
     default: 10s
+  - preset: vehicle-features
 render: |
   type: vw
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}
   timeout: {{ .timeout }}


### PR DESCRIPTION
Mein ID.3 (SW 3.7) kann keine Milliampere Schritte. In meiner yaml hatte ich bisher daher `type: vw`. Das geht in der Config UI nicht.

Mir ist dabei aufgefallen, dass einige Fahrzeug APIs `vehicle-features` haben (z.B. [bmw](https://github.com/evcc-io/evcc/blob/1b1f637c1478175be49ef46a8b3439ccf6ba1972/templates/definition/vehicle/bmw.yaml#L25) und [dacia](https://github.com/evcc-io/evcc/blob/1b1f637c1478175be49ef46a8b3439ccf6ba1972/templates/definition/vehicle/dacia.yaml#L6)), aber viele nicht. 

Soll es `coarsecurrent` und `welcomecharge` nur für Hersteller wo es bekannt ist, dass Autos dies benötigen? Soll es dann immer beides geben oder nur das wo bekannt ist, dass der Hersteller Fahrzeuge hat die dies benötigen?