### PR TITLE
Docs: consistant charger naming

### DIFF
--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -2,7 +2,10 @@ template: ac-thor
 products:
   - brand: my-PV
     description:
-      generic: AC THOR, AC THOR 9s
+      generic: AC•THOR
+  - brand: my-PV
+    description:
+      generic: AC•THOR 9s
 group: heating
 requirements:
   evcc: ["sponsorship"]

--- a/templates/definition/charger/alphatec.yaml
+++ b/templates/definition/charger/alphatec.yaml
@@ -2,7 +2,10 @@ template: alphatec
 products:
   - brand: Alphatec
     description:
-      generic: Wallbox Mini, Power
+      generic: Wallbox Mini
+  - brand: Alphatec
+    description:
+      generic: Wallbox Power
   - brand: Alphatec
     description:
       generic: Ladesäule Twin

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -14,7 +14,7 @@ products:
       generic: Charger Pro
   - brand: Audi
     description:
-      generic: Audi Wallbox pro
+      generic: Wallbox pro
 capabilities: ["mA"]
 requirements:
   evcc: ["eebus"]

--- a/templates/definition/charger/em2go.yaml
+++ b/templates/definition/charger/em2go.yaml
@@ -2,7 +2,7 @@ template: em2go
 products:
   - brand: EM2GO
     description:
-      generic: Pro Power, OCPP/ONC
+      generic: Pro Power (OCPP/ONC)
 capabilities: ["mA"]
 requirements:
   description:

--- a/templates/definition/charger/hardybarth-salia.yaml
+++ b/templates/definition/charger/hardybarth-salia.yaml
@@ -1,11 +1,17 @@
 template: hardybarth-salia
 products:
-  - brand: HardyBarth
+  - brand: Hardy Barth
     description:
-      generic: cPH2, cPμ2
+      generic: cPH2
+  - brand: Hardy Barth
+    description:
+      generic: cPμ2
   - brand: echarge
     description:
-      generic: cPH2, cPμ2
+      generic: cPH2
+  - brand: echarge
+    description:
+      generic: cPμ2
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/hesotec.yaml
+++ b/templates/definition/charger/hesotec.yaml
@@ -2,7 +2,10 @@ template: hesotec
 products:
   - brand: Hesotec
     description:
-      generic: eSat, eBox
+      generic: eSat
+  - brand: Hesotec
+    description:
+      generic: eBox
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/kathrein.yaml
+++ b/templates/definition/charger/kathrein.yaml
@@ -2,7 +2,22 @@ template: Kathrein
 products:
   - brand: Kathrein
     description:
-      generic: KWB-AC20, KWB-AC40, KWB-AC60, KWB-AC40E, KWB-AC60E
+      generic: KWB-AC20
+  - brand: Kathrein
+    description:
+      generic: KWB-AC35
+  - brand: Kathrein
+    description:
+      generic: KWB-AC40
+  - brand: Kathrein
+    description:
+      generic: KWB-AC60
+  - brand: Kathrein
+    description:
+      generic: KWB-AC40 E
+  - brand: Kathrein
+    description:
+      generic: KWB-AC60 E
 capabilities: ["1p3p", "mA"]
 requirements:
   description:

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -2,10 +2,19 @@ template: keba-modbus
 products:
   - brand: KEBA
     description:
-      generic: KeContact P20, P30, C/X Series
+      generic: KeContact P20
   - brand: KEBA
     description:
-      generic: KeContact P40, P40 Pro
+      generic: KeContact P30 C-Series
+  - brand: KEBA
+    description:
+      generic: KeContact P30 X-Series
+  - brand: KEBA
+    description:
+      generic: KeContact P40
+  - brand: KEBA
+    description:
+      generic: KeContact P40 Pro
   - brand: BMW
     description:
       generic: i Wallbox

--- a/templates/definition/charger/keba-udp.yaml
+++ b/templates/definition/charger/keba-udp.yaml
@@ -3,10 +3,16 @@ deprecated: true
 products:
   - brand: KEBA
     description:
-      generic: KeContact P20, P30, C/X Series (legacy UDP protocol)
+      generic: KeContact P20 (legacy UDP)
+  - brand: KEBA
+    description:
+      generic: KeContact P30 C-Series (legacy UDP)
+  - brand: KEBA
+    description:
+      generic: KeContact P30 X-Series (legacy UDP)
   - brand: BMW
     description:
-      generic: i Wallbox (legacy UDP protocol)
+      generic: i Wallbox (legacy UDP)
 capabilities: ["mA", "rfid"]
 requirements:
   description:

--- a/templates/definition/charger/luxtronik.yaml
+++ b/templates/definition/charger/luxtronik.yaml
@@ -2,28 +2,33 @@ template: luxtronik
 products:
   - brand: Buderus
     description:
-      generic: Luxtronik 2.1
+      generic: Logamatic HMC 20
+  - brand: Buderus
+    description:
+      generic: Logamatic HMC 20 Z
   - brand: alpha innotec
+  - brand: CTA All-In-One
     description:
-      generic: Luxtronik 2.1
-  - brand: CTA All-In-One (Aeroplus)
-    description:
-      generic: Luxtronik 2.1
+      generic: Aeroplus
   - brand: Elco
-    description:
-      generic: Luxtronik 2.1
   - brand: Nibe
     description:
-      generic: Luxtronik 2.1
-  - brand: Roth (ThermoAura, ThermoTerra)
+      generic: AP-AW10
+  - brand: Roth
     description:
-      generic: Luxtronik 2.1
+      generic: ThermoAura
+  - brand: Roth
+    description:
+      generic: ThermoTerra
   - brand: Novelan
     description:
-      generic: Luxtronik 2.1
-  - brand: Wolf (BWL/BWS)
+      generic: WPR NET
+  - brand: Wolf
     description:
-      generic: Luxtronik 2.1
+      generic: BWL
+  - brand: Wolf
+    description:
+      generic: BWS
 group: heating
 requirements:
   description:

--- a/templates/definition/charger/nrggen2.yaml
+++ b/templates/definition/charger/nrggen2.yaml
@@ -1,6 +1,6 @@
 template: nrggen2
 products:
-  - brand: NRGKick
+  - brand: NRGkick
     description:
       generic: Gen2
 requirements:

--- a/templates/definition/charger/nrgkick-bluetooth.yaml
+++ b/templates/definition/charger/nrgkick-bluetooth.yaml
@@ -1,7 +1,7 @@
 template: nrgkick-bluetooth
 deprecated: true
 products:
-  - brand: NRGKick
+  - brand: NRGkick
     description:
       generic: Bluetooth
 requirements:

--- a/templates/definition/charger/nrgkick-connect.yaml
+++ b/templates/definition/charger/nrgkick-connect.yaml
@@ -1,6 +1,6 @@
 template: nrgkick-connect
 products:
-  - brand: NRGKick
+  - brand: NRGkick
     description:
       generic: Connect
 requirements:

--- a/templates/definition/charger/ocpp-huawei.yaml
+++ b/templates/definition/charger/ocpp-huawei.yaml
@@ -2,7 +2,10 @@ template: ocpp-huawei
 products:
   - brand: Huawei
     description:
-      generic: SCharger-7KS-S0 / 22KT-S0
+      generic: SCharger-7KS-S0
+  - brand: Huawei
+    description:
+      generic: SCharger-22KT-S0
 requirements:
   evcc: ["sponsorship", "skiptest"]
 params:

--- a/templates/definition/charger/peblar.yaml
+++ b/templates/definition/charger/peblar.yaml
@@ -2,7 +2,13 @@ template: peblar
 products:
   - brand: Peblar
     description:
-      generic: Home, Home Plus, Business
+      generic: Home
+  - brand: Peblar
+    description:
+      generic: Home Plus
+  - brand: Peblar
+    description:
+      generic: Business
 capabilities: ["1p3p", "mA"]
 requirements:
   evcc: ["sponsorship"]

--- a/templates/definition/charger/phoenix-charx.yaml
+++ b/templates/definition/charger/phoenix-charx.yaml
@@ -5,7 +5,10 @@ products:
       generic: CHARX
   - brand: LadeFoxx
     description:
-      generic: EvLoad, Mikro 2.0
+      generic: EvLoad
+  - brand: LadeFoxx
+    description:
+      generic: Mikro 2.0
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/smaevcharger.yaml
+++ b/templates/definition/charger/smaevcharger.yaml
@@ -2,7 +2,10 @@ template: smaevcharger
 products:
   - brand: SMA
     description:
-      generic: EV Charger, eCharger
+      generic: EV Charger
+  - brand: SMA
+    description:
+      generic: eCharger
 capabilities: ["mA"]
 requirements:
   evcc: ["sponsorship"]

--- a/templates/definition/charger/twc3.yaml
+++ b/templates/definition/charger/twc3.yaml
@@ -2,7 +2,7 @@ template: twc3
 products:
   - brand: Tesla
     description:
-      generic: TWC3
+      generic: Wall Connector (Gen 3)
 requirements:
   description:
     en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be selected at the TWC3 loadpoint. At this time only [Tesla vehicles](https://docs.evcc.io/en/docs/devices/vehicles#tesla) are supported.

--- a/templates/definition/charger/vestel.yaml
+++ b/templates/definition/charger/vestel.yaml
@@ -6,7 +6,10 @@ products:
       generic: Unite
   - brand: Vestel
     description:
-      generic: EVC04 Home Smart, Connect Plus
+      generic: EVC04 Home Smart
+  - brand: Vestel
+    description:
+      generic: Connect Plus
   - brand: Webasto
     description:
       generic: Unite

--- a/templates/definition/charger/wallbe-meter.yaml
+++ b/templates/definition/charger/wallbe-meter.yaml
@@ -3,8 +3,12 @@ deprecated: true
 products:
   - brand: Wallbe
     description:
-      de: Eco, Pro (mit Strommessgerät)
-      en: Eco, Pro (with meter)
+      de: Eco (mit Strommessgerät)
+      en: Eco (with meter)
+  - brand: Wallbe
+    description:
+      de: Pro (ohne Strommessgerät)
+      en: Pro (without meter)
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.

--- a/templates/definition/charger/wallbe-pre2019-meter.yaml
+++ b/templates/definition/charger/wallbe-pre2019-meter.yaml
@@ -3,8 +3,12 @@ deprecated: true
 products:
   - brand: Wallbe
     description:
-      de: Eco, Pro (vor ~2019, mit Strommessgerät)
-      en: Eco, Pro (pre ~2019, with meter)
+      de: Eco (vor ~2019, mit Strommessgerät)
+      en: Eco (pre ~2019, with meter)
+  - brand: Wallbe
+    description:
+      de: Pro (vor ~2019, ohne Strommessgerät)
+      en: Pro (pre ~2019, without meter)
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.

--- a/templates/definition/charger/wallbe-pre2019.yaml
+++ b/templates/definition/charger/wallbe-pre2019.yaml
@@ -3,8 +3,12 @@ deprecated: true
 products:
   - brand: Wallbe
     description:
-      de: Eco, Pro (vor ~2019)
-      en: Eco, Pro (pre ~2019)
+      de: Eco (vor ~2019)
+      en: Eco (pre ~2019)
+  - brand: Wallbe
+    description:
+      de: Pro (vor ~2019)
+      en: Pro (pre ~2019)
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.

--- a/templates/definition/charger/wallbe.yaml
+++ b/templates/definition/charger/wallbe.yaml
@@ -3,7 +3,10 @@ deprecated: true
 products:
   - brand: Wallbe
     description:
-      generic: Eco, Pro
+      generic: Eco
+  - brand: Wallbe
+    description:
+      generic: Pro
 requirements:
   description:
     en: The Wallbe must be connected using Ethernet and the DIP switch 10 must be set to 'ON'.


### PR DESCRIPTION
relates to https://github.com/evcc-io/evcc/pull/21670

Cleaning up product brands and descriptions.

- brand field only contains the actual brand name itself (relevant vor website). 
- product description matches the commonly used product name as used by the brand or in online shops.
- different product lines have dedicated product entries

@daniel309 can you double check my Luxtronic modifications. I had some trouble finding the right devices from the manufacturers websites (e.g. Aeroplus). I added some infos from the description of your Luxtronic PR. If you have more infos no the devices just comment them here.