### PR TITLE
Keba: fix enabled

### DIFF
--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -273,9 +273,7 @@ func (wb *Keba) Enabled() (bool, error) {
 		return false, err
 	}
 
-	u := binary.BigEndian.Uint16(b)
-
-	return u != 0, nil
+	return binary.BigEndian.Uint16(b) != 0, nil
 }
 
 // Enable implements the api.Charger interface

--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -268,12 +268,14 @@ func (wb *Keba) statusReason() (api.Reason, error) {
 
 // Enabled implements the api.Charger interface
 func (wb *Keba) Enabled() (bool, error) {
-	s, err := wb.getChargingState()
+	b, err := wb.conn.ReadHoldingRegisters(wb.regEnable, 1)
 	if err != nil {
 		return false, err
 	}
 
-	return !(s == 5 || s == 1), nil
+	u := binary.BigEndian.Uint16(b)
+
+	return u != 0, nil
 }
 
 // Enable implements the api.Charger interface


### PR DESCRIPTION
Should fix #21689

refactor: update Enabled method to read enable register directly

Overview
Modified the Enabled method to determine charger status by directly reading the enable register instead of using the charging state.