### PR TITLE
iobroker.bmw: fix ui description

### DIFF
--- a/templates/definition/vehicle/ioBroker.bmw.yaml
+++ b/templates/definition/vehicle/ioBroker.bmw.yaml
@@ -13,12 +13,12 @@ params:
     example: WBMW...
   - name: uri
     required: true
-    help:
+    description:
       generic: ioBroker URL
   - name: id
     default: 0
     type: int
-    help:
+    description:
       de: Instanz-ID
       en: Instance ID
     advanced: true

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -284,10 +284,10 @@ params:
       de: Ist auf dem Typenschild auf der Geräterückseite aufgedruckt. Bei führenden Nullen bitte in doppelte Hochkommata setzen.
   - name: coarsecurrent
     type: bool
-    help:
+    description:
       en: 1A current control
       de: 1A Ladestromvorgabe
-    description:
+    help:
       en: Vehicle supports 1A current steps only
       de: Fahrzeug unterstützt nur 1A Schritte der Ladestromvorgabe
   - name: welcomecharge


### PR DESCRIPTION
Sorgt für schönere Darstellung im Config UI:

<img width="383" alt="Screenshot 2025-06-08 at 12 28 24" src="https://github.com/user-attachments/assets/87abea5a-c1be-47a7-a2df-2a5c72d98344" />

@naltatis hast Du eine Idee, wo/wir das generell noch prüfen könnten, also "description vor help"?