### PR TITLE
Docs: consistant charger/meter naming

### DIFF
--- a/templates/definition/charger/abl-em4.yaml
+++ b/templates/definition/charger/abl-em4.yaml
@@ -2,7 +2,10 @@ template: abl-em4
 products:
   - brand: ABL
     description:
-      generic: eM4 (SBCx)
+      generic: eM4 Single (SBCx)
+  - brand: ABL
+    description:
+      generic: eM4 Twin (SBCx)
 capabilities: ["mA"]
 requirements:
   evcc: ["sponsorship"]

--- a/templates/definition/charger/bender-cc.yaml
+++ b/templates/definition/charger/bender-cc.yaml
@@ -1,9 +1,6 @@
 template: bender-cc
 covers: ["bender"]
 products:
-  - brand: Ampure
-    description:
-      generic: Live
   - brand: Bender
     description:
       generic: CC612
@@ -19,7 +16,6 @@ products:
   - brand: Mennekes
     description:
       generic: AMTRON ChargeControl
-
   - brand: Webasto
     description:
       generic: Live
@@ -37,7 +33,16 @@ products:
       generic: Mobility One
   - brand: Garo
     description:
-      generic: GLB, GLB+, LS4, LS4 compact
+      generic: GLB
+  - brand: Garo
+    description:
+      generic: GLB+
+  - brand: Garo
+    description:
+      generic: LS4
+  - brand: Garo
+    description:
+      generic: LS4 compact
   - brand: Ensto
     description:
       generic: Chago Wallbox
@@ -46,7 +51,10 @@ products:
       generic: Heinz
   - brand: CUBOS
     description:
-      generic: C11E, C22E
+      generic: C11E
+  - brand: CUBOS
+    description:
+      generic: C22E
   - brand: Spelsberg
     description:
       generic: Wallbox Smart Pro

--- a/templates/definition/charger/hardybarth-ecb1.yaml
+++ b/templates/definition/charger/hardybarth-ecb1.yaml
@@ -1,6 +1,6 @@
 template: hardybarth-ecb1
 products:
-  - brand: HardyBarth
+  - brand: Hardy Barth
     description:
       generic: cPH1
   - brand: echarge

--- a/templates/definition/charger/ocpp-abl.yaml
+++ b/templates/definition/charger/ocpp-abl.yaml
@@ -1,14 +1,17 @@
 template: ocpp-abl
 products:
-  - brand: ABL Sursum
+  - brand: ABL
     description:
-      generic: eMH2
-  - brand: ABL Sursum
+      generic: eMH2 (OCPP)
+  - brand: ABL
     description:
-      generic: eMH3
-  - brand: ABL Sursum
+      generic: eMH3 (OCPP)
+  - brand: ABL
     description:
-      generic: eMH4
+      generic: eM4 Single (OCPP)
+  - brand: ABL
+    description:
+      generic: eM4 Twin (OCPP)
 capabilities: ["mA", "rfid"]
 requirements:
   evcc: ["sponsorship", "skiptest"]

--- a/templates/definition/charger/shelly.yaml
+++ b/templates/definition/charger/shelly.yaml
@@ -1,6 +1,9 @@
 template: shelly
 products:
-  - brand: Shelly
+  - { brand: Shelly, description: { generic: 1 } }
+  - { brand: Shelly, description: { generic: Plus 1 } }
+  - { brand: Shelly, description: { generic: Pro 1 } }
+  - { brand: Shelly, description: { generic: Plug S } }
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/meter/abb-ab.yaml
+++ b/templates/definition/meter/abb-ab.yaml
@@ -2,7 +2,16 @@ template: abb-ab
 products:
   - brand: ABB
     description:
-      generic: A43, A44, B23, B24
+      generic: A43
+  - brand: ABB
+    description:
+      generic: A44
+  - brand: ABB
+    description:
+      generic: B23
+  - brand: ABB
+    description:
+      generic: B24
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/acrel-adw300.yaml
+++ b/templates/definition/meter/acrel-adw300.yaml
@@ -2,7 +2,7 @@ template: acrel-adw300
 products:
   - brand: Acrel
     description:
-      generic: ADW300 Wireless Metering Meter
+      generic: ADW300
 params:
   - name: usage
     choice: ["grid", "pv", "charge"]

--- a/templates/definition/meter/janitza.yaml
+++ b/templates/definition/meter/janitza.yaml
@@ -2,7 +2,10 @@ template: janitza
 products:
   - brand: Janitza
     description:
-      generic: B series, UMG series
+      generic: B series
+  - brand: Janitza
+    description:
+      generic: UMG series
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/kostal-piko-pv.yaml
+++ b/templates/definition/meter/kostal-piko-pv.yaml
@@ -2,7 +2,10 @@ template: kostal-piko-pv
 products:
   - brand: Kostal
     description:
-      generic: Piko, Piko BA
+      generic: Piko
+  - brand: Kostal
+    description:
+      generic: Piko BA
 params:
   - name: usage
     choice: ["grid", "pv"]

--- a/templates/definition/meter/orno.yaml
+++ b/templates/definition/meter/orno.yaml
@@ -1,8 +1,11 @@
 template: orno
 products:
-  - brand: Orno
+  - brand: ORNO
     description:
-      generic: OR-WE-516, OR-WE-517
+      generic: OR-WE-516
+  - brand: ORNO
+    description:
+      generic: OR-WE-517
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/sbc-axx3.yaml
+++ b/templates/definition/meter/sbc-axx3.yaml
@@ -1,8 +1,11 @@
 template: sbc-axx3
 products:
-  - brand: Saia-Burgess Controls
+  - brand: Saia-Burgess Controls (SBC)
     description:
-      generic: ALE3, AWD3
+      generic: ALE3
+  - brand: Saia-Burgess Controls (SBC)
+    description:
+      generic: AWD3
 params:
   - name: usage
     choice: ["grid", "charge"]

--- a/templates/definition/meter/shelly-1pm.yaml
+++ b/templates/definition/meter/shelly-1pm.yaml
@@ -1,17 +1,13 @@
 template: shelly-1pm
 products:
-  - brand: Shelly
-    description:
-      generic: 1PM
-  - brand: Shelly
-    description:
-      generic: EM
-  - brand: Shelly
-    description:
-      generic: Plug S
-  - brand: Shelly
-    description:
-      generic: Pro 3EM in monophase mode
+  - { brand: Shelly, description: { generic: 1PM } }
+  - { brand: Shelly, description: { generic: 1PM mini } }
+  - { brand: Shelly, description: { generic: Pro 1PM } }
+  - { brand: Shelly, description: { generic: PM mini } }
+  - { brand: Shelly, description: { generic: EM } }
+  - { brand: Shelly, description: { generic: Pro EM } }
+  - { brand: Shelly, description: { generic: Pro 3EM (monophase mode) } }
+  - { brand: Shelly, description: { generic: Plug S } }
 group: switchsockets
 params:
   - name: usage

--- a/templates/definition/meter/shelly-1pm.yaml
+++ b/templates/definition/meter/shelly-1pm.yaml
@@ -2,7 +2,16 @@ template: shelly-1pm
 products:
   - brand: Shelly
     description:
-      generic: 1PM, EM, Plug S, Pro 3EM in monophase mode
+      generic: 1PM
+  - brand: Shelly
+    description:
+      generic: EM
+  - brand: Shelly
+    description:
+      generic: Plug S
+  - brand: Shelly
+    description:
+      generic: Pro 3EM in monophase mode
 group: switchsockets
 params:
   - name: usage

--- a/templates/definition/meter/shelly-3em.yaml
+++ b/templates/definition/meter/shelly-3em.yaml
@@ -3,6 +3,9 @@ products:
   - brand: Shelly
     description:
       generic: 3EM
+  - brand: Shelly
+    description:
+      generic: Pro 3EM
 params:
   - name: usage
     choice: ["grid", "pv", "charge"]

--- a/templates/definition/meter/shelly-3em.yaml
+++ b/templates/definition/meter/shelly-3em.yaml
@@ -3,9 +3,6 @@ products:
   - brand: Shelly
     description:
       generic: 3EM
-  - brand: Shelly
-    description:
-      generic: Pro 3EM
 params:
   - name: usage
     choice: ["grid", "pv", "charge"]

--- a/templates/definition/meter/smartfox-em2.yaml
+++ b/templates/definition/meter/smartfox-em2.yaml
@@ -2,7 +2,19 @@ template: smartfox-em2
 products:
   - brand: Smartfox
     description:
-      generic: Pro, Pro 2, Pro Light, Pro Light 2, Light (EM2 firmware)
+      generic: Pro
+  - brand: Smartfox
+    description:
+      generic: Pro 2
+  - brand: Smartfox
+    description:
+      generic: Pro Light
+  - brand: Smartfox
+    description:
+      generic: Pro Light 2
+  - brand: Smartfox
+    description:
+      generic: Light (EM2 firmware)
 requirements:
   description:
     de: |

--- a/templates/definition/meter/smartfox.yaml
+++ b/templates/definition/meter/smartfox.yaml
@@ -2,7 +2,13 @@ template: smartfox
 products:
   - brand: Smartfox
     description:
-      generic: Box, Reg, Reg extended
+      generic: Box
+  - brand: Smartfox
+    description:
+      generic: Reg
+  - brand: Smartfox
+    description:
+      generic: Reg extended
 requirements:
   description:
     de: |

--- a/templates/definition/meter/sofarsolar.yaml
+++ b/templates/definition/meter/sofarsolar.yaml
@@ -2,10 +2,16 @@ template: sofarsolar
 products:
   - brand: SofarSolar
     description:
-      generic: Inverter, Hybrid Inverter
+      generic: Inverter
+  - brand: SofarSolar
+    description:
+      generic: Hybrid Inverter
   - brand: ZCS Azzurro
     description:
-      generic: Inverter, Hybrid Inverter
+      generic: Inverter
+  - brand: ZCS Azzurro
+    description:
+      generic: Hybrid Inverter
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/solarwatt.yaml
+++ b/templates/definition/meter/solarwatt.yaml
@@ -6,7 +6,10 @@ products:
       generic: MyReserve
   - brand: Solarwatt
     description:
-      generic: EnergyManager, EnergyManager Pro
+      generic: EnergyManager
+  - brand: Solarwatt
+    description:
+      generic: EnergyManager Pro
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -2,7 +2,16 @@ template: sonnenbatterie-eco56
 products:
   - brand: Sonnen
     description:
-      generic: comfort, eco 5, eco 6, oem 6.5
+      generic: comfort
+  - brand: Sonnen
+    description:
+      generic: eco 5
+  - brand: Sonnen
+    description:
+      generic: eco 6
+  - brand: Sonnen
+    description:
+      generic: oem 6.5
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/varta.yaml
+++ b/templates/definition/meter/varta.yaml
@@ -3,7 +3,13 @@ covers: ["varta-energiespeicher", "varta-energiespeicher-battery-only"]
 products:
   - brand: VARTA
     description:
-      generic: pulse, pulse neo, element
+      generic: pulse
+  - brand: VARTA
+    description:
+      generic: pulse neo
+  - brand: VARTA
+    description:
+      generic: element
 requirements:
   description:
     de: PV nur verfügbar mit PV-Sensor


### PR DESCRIPTION
continuation of https://github.com/evcc-io/evcc/pull/21684

a few notes:

- Drop "Sursum" from ABL brand name. Seems to be the old company name. We had both. @premultiply 
- Ampure Live doesn't seem to exist. We introduced it during a Webasto > Ampure rename @andig 
- Shelly product names @thierolm 