### PR TITLE
Plugins: add valid plugin

### DIFF
--- a/plugin/valid.go
+++ b/plugin/valid.go
@@ -39,7 +39,7 @@ func NewValidFromConfig(ctx context.Context, other map[string]interface{}) (Plug
 	return o, nil
 }
 
-// NewValidPlugin creates provider for OpenWB status converted from MQTT topics
+// NewValidPlugin creates valid provider
 func NewValidPlugin(ctx context.Context, valid func() (bool, error), value Config) *validPlugin {
 	return &validPlugin{
 		ctx:   ctx,

--- a/plugin/valid.go
+++ b/plugin/valid.go
@@ -1,0 +1,90 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+)
+
+func init() {
+	registry.AddCtx("valid", NewValidFromConfig)
+}
+
+// validPlugin validates a reading via a second reading
+type validPlugin struct {
+	ctx   context.Context
+	valid func() (bool, error)
+	value Config
+}
+
+// NewValidFromConfig creates valid provider
+func NewValidFromConfig(ctx context.Context, other map[string]interface{}) (Plugin, error) {
+	var cc struct {
+		Valid, Value Config
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	valid, err := cc.Valid.BoolGetter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("valid: %w", err)
+	}
+
+	o := NewValidPlugin(ctx, valid, cc.Value)
+
+	return o, nil
+}
+
+// NewValidPlugin creates provider for OpenWB status converted from MQTT topics
+func NewValidPlugin(ctx context.Context, valid func() (bool, error), value Config) *validPlugin {
+	return &validPlugin{
+		ctx:   ctx,
+		valid: valid,
+		value: value,
+	}
+}
+
+var _ StringGetter = (*validPlugin)(nil)
+
+func validGetter[T any](o *validPlugin, valuer func(ctx context.Context) (func() (T, error), error)) (func() (T, error), error) {
+	value, err := valuer(o.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("valid: %w", err)
+	}
+
+	return func() (T, error) {
+		var zero T
+
+		valid, err := o.valid()
+		if err != nil {
+			return zero, err
+		}
+		if !valid {
+			return zero, api.ErrNotAvailable
+		}
+
+		return value()
+	}, nil
+}
+
+var _ StringGetter = (*validPlugin)(nil)
+
+func (o *validPlugin) StringGetter() (func() (string, error), error) {
+	return validGetter(o, o.value.StringGetter)
+}
+
+var _ FloatGetter = (*validPlugin)(nil)
+
+func (o *validPlugin) FloatGetter() (func() (float64, error), error) {
+	return validGetter(o, o.value.FloatGetter)
+}
+
+var _ IntGetter = (*validPlugin)(nil)
+
+func (o *validPlugin) IntGetter() (func() (int64, error), error) {
+	return validGetter(o, o.value.IntGetter)
+}

--- a/templates/definition/vehicle/ioBroker.bmw.yaml
+++ b/templates/definition/vehicle/ioBroker.bmw.yaml
@@ -27,24 +27,54 @@ render: |
   type: custom
   {{ include "vehicle-common" . }}
   soc:
-    source: http
-    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingLevelPercent
+    source: valid
+    valid:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
+      cache: 10s
+    value:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingLevelPercent
   limitsoc:
-    source: http
-    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingTarget
+    source: valid
+    valid:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
+      cache: 10s
+    value:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingTarget
   status:
-    source: combined
-    plugged:
+    source: valid
+    valid:
       source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.isChargerConnected
-    charging:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingStatus
-      jq: '. == "CHARGING"'
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
+      cache: 10s
+    value:
+      source: combined
+      plugged:
+        source: http
+        uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.isChargerConnected
+      charging:
+        source: http
+        uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingStatus
+        jq: '. == "CHARGING"'
   range:
-    source: http
-    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.range
+    source: valid
+    valid:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
+      cache: 10s
+    value:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.range
   odometer:
-    source: http
-    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.currentMileage
+    source: valid
+    valid:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
+      cache: 10s
+    value:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.currentMileage
   {{ include "vehicle-features" . }}


### PR DESCRIPTION
Plugins are limited in the sense that they can only unconditionally provide a single value. Some integrations like ioBroker separate validity from actual values. This can already be worked around using the `go` plugin, however that still doesn't (currently) allow to return errors and is difficult to setup.

The new `valid` plugin makes the availability of a plugin result depending on another value. Updated `ioBroker.bmw` to show usage:

```yaml
soc:
  source: valid
  valid:
    source: ...
  value:
    source: ...
```

where `valid` must return a boolean value. If false, `api.ErrNotAvailable` is returned.

/cc @VolkerK62 @Maschga 