### PR TITLE
UI: select divider compatibility

### DIFF
--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -63,7 +63,7 @@
 			<option v-if="key !== null && name !== null" :key="key" :value="key">
 				{{ name }}
 			</option>
-			<hr v-else :key="idx" />
+			<option v-else :key="idx" disabled>─────</option>
 		</template>
 	</select>
 	<textarea

--- a/assets/js/components/Vehicles/Options.vue
+++ b/assets/js/components/Vehicles/Options.vue
@@ -14,7 +14,7 @@
 			>
 				{{ value }}
 			</option>
-			<hr />
+			<option disabled>─────</option>
 			<option value="" :selected="!selected">
 				{{ $t(`main.vehicle.${connected ? "unknown" : "none"}`) }}
 			</option>


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/21777

- 📱 switch from `<hr>` in `<select>` to disabled options to better support mobile browsers https://caniuse.com/mdn-html_elements_hr_hr_in_select

We may switch back later once all browsers support the native way.

fake disabled entry
<img width="466" alt="Bildschirmfoto 2025-06-11 um 10 57 20" src="https://github.com/user-attachments/assets/c16512d9-9721-40a5-a07f-517bee77615d" />
