### PR TITLE
Update Amber docs to clarify required settings

### DIFF
--- a/templates/definition/tariff/amber.yaml
+++ b/templates/definition/tariff/amber.yaml
@@ -5,8 +5,13 @@ group: price
 countries: ["AU"]
 params:
   - name: token
+    required: true
   - name: siteid
+    required: true
   - name: channel
+    type: choice
+    choice: ["general", "feedIn", "controlledLoad"]
+    required: true
   - preset: tariff-base
 render: |
   type: amber


### PR DESCRIPTION
As per https://github.com/evcc-io/evcc/issues/21797 looks like the docs could be a bit clearer on what the valid `channel`s are. Note these three are the only allowed values for `channel`, straight from the Amber OpenAPI docs.

Also made `token` and `siteId` required (API will need these)
