### PR TITLE
Site: remove cuircuit and maxGridSupplyWhileBatteyCharging (BC)

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -76,9 +76,6 @@ type Site struct {
 	Voltage       float64      `mapstructure:"voltage"`       // Operating voltage. 230V for Germany.
 	ResidualPower float64      `mapstructure:"residualPower"` // PV meter only: household usage. Grid meter: household safety margin
 	Meters        MetersConfig `mapstructure:"meters"`        // Meter references
-	// TODO deprecated
-	CircuitRef_                        string  `mapstructure:"circuit"`                           // Circuit reference
-	MaxGridSupplyWhileBatteryCharging_ float64 `mapstructure:"maxGridSupplyWhileBatteryCharging"` // ignore battery charging if AC consumption is above this value
 
 	// meters
 	circuit       api.Circuit                // Circuit
@@ -234,10 +231,6 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 			return err
 		}
 		site.auxMeters = append(site.auxMeters, dev)
-	}
-
-	if site.MaxGridSupplyWhileBatteryCharging_ != 0 {
-		site.log.WARN.Println("`MaxGridSupplyWhileBatteryCharging` is deprecated- use `maxACPower` in pv configuration instead")
 	}
 
 	// revert battery mode on shutdown


### PR DESCRIPTION
Remove `site:` deprecations: 

- `MaxGridSupplyWhileBatteryCharging` is deprecated- use `maxACPower` in pv configuration instead
- `circuit` is deprecated- site always uses the root circuit automatically