### PR TITLE
Autel: clarify firmware version

### DIFF
--- a/templates/definition/charger/ocpp-autel.yaml
+++ b/templates/definition/charger/ocpp-autel.yaml
@@ -20,7 +20,7 @@ requirements:
       * Autorisierungsschlüssel: leer lassen
     en: |
       Setup Guide:
-      * Important! First check that at least the following firmware version is installed on the wallbox: Charge Control Module: V1.51.00 and Power Control Module: V1.19.00
+      * Validate required firmware version: Charge Control Module: V1.51.00, Power Control Module: V1.19.00
       * In the Autel Charge app, click on “OCPP Server”
       * In the search bar type “Custom” and select it.
       * Server URL: ws://[evcc-address]:8887/ (local network connection)

--- a/templates/definition/charger/ocpp-autel.yaml
+++ b/templates/definition/charger/ocpp-autel.yaml
@@ -12,7 +12,7 @@ requirements:
   description:
     de: |
       Anleitung:
-      * Wichtig! Als erstes prüfen ob auf der Wallbox mindestens folgende Firmwareversion installiert ist: Ladesteuergerät: V1.51.00 und Leistungsregelmodul: V1.19.00
+      * Erforderliche Firmwareversion verifizieren: Ladesteuergerät: V1.51.00, Leistungsregelmodul: V1.19.00
       * In der Autel Charge app, klicken sie auf “OCPP Server”
       * Geben Sie "Custom" in das Feld ein und wählen Sie "Personalisierung" darunter
       * Server-URL: ws://[evcc-adresse]:8887/ (Verbindung über das lokale Netzwerk)

--- a/templates/definition/charger/ocpp-autel.yaml
+++ b/templates/definition/charger/ocpp-autel.yaml
@@ -12,6 +12,7 @@ requirements:
   description:
     de: |
       Anleitung:
+      * Wichtig! Als erstes prüfen ob auf der Wallbox mindestens fogende Firmwareversion installiert ist: Ladesteuergerät: V1.51.00 und Leistungsregelmodul: V1.19.00
       * In der Autel Charge app, klicken sie auf “OCPP Server”
       * Geben Sie "Custom" in das Feld ein und wählen Sie "Personalisierung" darunter
       * Server-URL: ws://[evcc-adresse]:8887/ (Verbindung über das lokale Netzwerk)
@@ -19,6 +20,7 @@ requirements:
       * Autorisierungsschlüssel: leer lassen
     en: |
       Setup Guide:
+      * Important! First check that at least the following firmware version is installed on the wallbox: Charge Control Module: V1.51.00 and Power Control Module: V1.19.00
       * In the Autel Charge app, click on “OCPP Server”
       * In the search bar type “Custom” and select it.
       * Server URL: ws://[evcc-address]:8887/ (local network connection)

--- a/templates/definition/charger/ocpp-autel.yaml
+++ b/templates/definition/charger/ocpp-autel.yaml
@@ -12,7 +12,7 @@ requirements:
   description:
     de: |
       Anleitung:
-      * Wichtig! Als erstes prüfen ob auf der Wallbox mindestens fogende Firmwareversion installiert ist: Ladesteuergerät: V1.51.00 und Leistungsregelmodul: V1.19.00
+      * Wichtig! Als erstes prüfen ob auf der Wallbox mindestens folgende Firmwareversion installiert ist: Ladesteuergerät: V1.51.00 und Leistungsregelmodul: V1.19.00
       * In der Autel Charge app, klicken sie auf “OCPP Server”
       * Geben Sie "Custom" in das Feld ein und wählen Sie "Personalisierung" darunter
       * Server-URL: ws://[evcc-adresse]:8887/ (Verbindung über das lokale Netzwerk)


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/21868

Meine Autel Wallbox kam mit einer uralten Firmware, in der Autel App wurde lange Zeit angezeigt, dass die Firmware auf dem letzten Stand wäre.
Dies stimmte aber nicht und mit dieser uralten Firmware funktioniert OCPP nicht mit evcc. Es hat einiges an Fehlersuche gebraucht bis dieser Fehler gefunden wurde.
Ab der in der Anleitung genannten Firmware sollte OCPP mit evcc funktionieren.