### PR TITLE
Docker: add CLI_ARGS env

### DIFF
--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -36,19 +36,19 @@ if [ -f ${HASSIO_OPTIONSFILE} ]; then
 		echo "For details see evcc documentation at https://github.com/evcc-io/evcc#readme."
 	else
 		if [ "${SQLITE_FILE}" ]; then
-			echo "starting evcc: 'EVCC_DATABASE_DSN=${SQLITE_FILE} evcc --config ${CONFIG}'"
-			exec env EVCC_DATABASE_DSN="${SQLITE_FILE}" evcc --config "${CONFIG}"
+			echo "starting evcc: 'EVCC_DATABASE_DSN=${SQLITE_FILE} evcc --config ${CONFIG} ${CLI_ARGS}'"
+			exec env EVCC_DATABASE_DSN="${SQLITE_FILE}" evcc --config "${CONFIG}" ${CLI_ARGS}
 		else
-			echo "starting evcc: 'evcc --config ${CONFIG}'"
-			exec evcc --config "${CONFIG}"
+			echo "starting evcc: 'evcc --config ${CONFIG} ${CLI_ARGS}'"
+			exec evcc --config "${CONFIG}" ${CLI_ARGS}
 		fi
 	fi
 else
 	if [ "$1" = 'evcc' ]; then
 		shift
-		exec evcc "$@"
+		exec evcc ${CLI_ARGS} "$@"
 	elif expr "$1" : '-.*' > /dev/null; then
-		exec evcc "$@"
+		exec evcc ${CLI_ARGS} "$@"
 	else
 		exec "$@"
 	fi


### PR DESCRIPTION
add option to specify additional cli args via CLI_ARGS env variable.

```
docker run -e CLI_ARGS="--demo" evcc/evcc
```

See also #18946 #21263