### PR TITLE
Loadpoint UI: Make mincurrent decimal place visible

### DIFF
--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -315,7 +315,7 @@ export default defineComponent({
 			this.$emit("phasesconfigured-updated", this.selectedPhases);
 		},
 		currentOption(value: number, isDefault: boolean) {
-			let name = `${this.fmtNumber(value, 0)} A`;
+			let name = `${this.fmtNumber(value, value <= 1 ? 1 : 0)} A`;
 			if (isDefault) {
 				name += ` (${this.$t("main.loadpointSettings.default")})`;
 			}


### PR DESCRIPTION
Fix #21885

📍Show decimal place if mincurrent value is `<=1`