### PR TITLE
Sofar: Updated documentation with detailed external link for connection details

### DIFF
--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -14,8 +14,8 @@ products:
       generic: SOFAR 5…24KTL-G3
 requirements:
   description:
-    de: Die Verbindung über einen LSE-3 Logger Stick mittels LAN Anschluss und ModBus TCP über Port 8899 ist die einfachste Anbindung. Der LSW-3 WLAN Stick wird nicht unterstützt. Bei seriellem Anschluss via RS485 am COM Port ist eine wechselrichterseitige Terminierung notwendig.
-    en: LSE-3 logger stick using a LAN connection and ModBus TCP via the port 8899 is the easiest connection. The LSW-3 WiFi stick is not supported. For a RS485 serial connection using the inverter's COM port the inverter's side must be properly terminated.
+    de: Zu den Details wie man den Wechselrichter verbindet siehe https://homeassistant-solax-modbus.readthedocs.io/en/latest/sofar-installation/.
+    en: For more details on how to establish a connection to the inverter see https://homeassistant-solax-modbus.readthedocs.io/en/latest/sofar-installation/.
 capabilities: ["battery-control"]
 params:
   - name: usage


### PR DESCRIPTION
A lot has changed in the last month and there are various methods to connect the inverter where each has several pros and cons. The full doc does not fit in a single line. As my proposal for extended docs on the evcc GitHub was not answered in #21007, I am proposing to add an external link (that I am regularly updating).