### PR TITLE
Establish stricter sqlite file permissions

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -25,7 +25,7 @@ func New(driver, dsn string) (*gorm.DB, error) {
 			return nil, err
 		}
 		log.INFO.Println("using sqlite database:", file)
-		if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(file), 0700); err != nil {
 			return nil, err
 		}
 		// avoid busy errors


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/21928

Restrict permissions of the `~/.evcc` evcc creates on new systems (default behavior).

Does not change permissions for existing sqlite files or custom database locations where the folder already exists. Here user is responsible for securing the location.