### PR TITLE
Fix up persistence of accumulated PV energy

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -595,10 +595,15 @@ func (site *Site) updatePvMeters() {
 		}
 	}
 
-	// store
-	if err := settings.SetJson(keys.SolarAccYield, site.pvEnergy); err != nil {
+	// store - extract accumulated values to match expected read format
+	pvAccumulated := make(map[string]float64)
+	for name, energy := range site.pvEnergy {
+		pvAccumulated[name] = energy.Accumulated
+	}
+
+	if err := settings.SetJson(keys.SolarAccYield, pvAccumulated); err != nil {
 		site.log.ERROR.Println("accumulated solar yield:", err)
-		for k, v := range site.pvEnergy {
+		for k, v := range pvAccumulated {
 			site.log.ERROR.Printf("!! %s: %+v", k, v)
 		}
 	}

--- a/tariff/test_solar_forecast_test.go
+++ b/tariff/test_solar_forecast_test.go
@@ -1,0 +1,156 @@
+package tariff
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolarForecastStatic(t *testing.T) {
+	// Test static solar forecast template
+	tariff, err := NewFromConfig(context.TODO(), "template", map[string]any{
+		"template": "test-solar-forecast-static",
+		"power":    3000.0,
+		"interval": "1h",
+	})
+	require.NoError(t, err)
+
+	rates, err := tariff.Rates()
+	require.NoError(t, err)
+
+	// Should have 48 hours of data (2 days)
+	assert.Equal(t, 48, len(rates))
+
+	// All rates should have the same power value
+	for _, rate := range rates {
+		assert.Equal(t, 3000.0, rate.Value, "All rates should have constant power value")
+		assert.Equal(t, time.Hour, rate.End.Sub(rate.Start), "Each rate should be 1 hour duration")
+	}
+
+	// Check tariff type
+	assert.Equal(t, api.TariffTypeSolar, tariff.Type())
+}
+
+func TestSolarForecastCurve(t *testing.T) {
+	// Test bell curve solar forecast template
+	tariff, err := NewFromConfig(context.TODO(), "template", map[string]any{
+		"template": "test-solar-forecast-curve",
+		"peak":     4500.0,
+		"sunrise":  6,
+		"sunset":   18,
+		"interval": "1h",
+	})
+	require.NoError(t, err)
+
+	rates, err := tariff.Rates()
+	require.NoError(t, err)
+
+	// Should have 48 hours of data (2 days)
+	assert.Equal(t, 48, len(rates))
+
+	// Check that we have both days with similar patterns
+	day1Rates := rates[:24]
+	day2Rates := rates[24:]
+
+	// Verify bell curve characteristics for day 1
+	validateBellCurve(t, day1Rates, 4500.0, 6, 18)
+
+	// Verify bell curve characteristics for day 2 (should be similar)
+	validateBellCurve(t, day2Rates, 4500.0, 6, 18)
+
+	// Check tariff type
+	assert.Equal(t, api.TariffTypeSolar, tariff.Type())
+}
+
+func validateBellCurve(t *testing.T, rates []api.Rate, expectedPeak float64, sunrise, sunset int) {
+	t.Helper()
+
+	// Find the maximum value (should be around noon)
+	var maxValue float64
+	var maxHour int
+
+	for i, rate := range rates {
+		if rate.Value > maxValue {
+			maxValue = rate.Value
+			maxHour = i
+		}
+
+		// Check hourly duration
+		assert.Equal(t, time.Hour, rate.End.Sub(rate.Start), "Each rate should be 1 hour duration")
+	}
+
+	// Peak should be close to the expected value (within 10% tolerance for bell curve calculation)
+	assert.InDelta(t, expectedPeak, maxValue, expectedPeak*0.1, "Peak value should be close to expected")
+
+	// Peak should occur around noon (sunrise + (sunset-sunrise)/2)
+	expectedNoon := sunrise + (sunset-sunrise)/2
+	assert.InDelta(t, expectedNoon, maxHour, 1, "Peak should occur around noon")
+
+	// Values before sunrise should be 0
+	for i := 0; i < sunrise; i++ {
+		assert.Equal(t, 0.0, rates[i].Value, "Power before sunrise should be 0")
+	}
+
+	// Values after sunset should be 0
+	for i := sunset + 1; i < 24; i++ {
+		assert.Equal(t, 0.0, rates[i].Value, "Power after sunset should be 0")
+	}
+
+	// Values should increase from sunrise to noon
+	for i := sunrise; i < maxHour; i++ {
+		assert.LessOrEqual(t, rates[i].Value, rates[i+1].Value, "Power should increase towards noon")
+	}
+
+	// Values should decrease from noon to sunset
+	for i := maxHour; i < sunset; i++ {
+		assert.GreaterOrEqual(t, rates[i].Value, rates[i+1].Value, "Power should decrease after noon")
+	}
+}
+
+func TestSolarForecastTemplateDefaults(t *testing.T) {
+	// Test that templates work with default values
+	tests := []struct {
+		name     string
+		template string
+		checks   func(t *testing.T, rates api.Rates)
+	}{
+		{
+			name:     "static default",
+			template: "test-solar-forecast-static",
+			checks: func(t *testing.T, rates api.Rates) {
+				// Default power should be 2000W
+				for _, rate := range rates {
+					assert.Equal(t, 2000.0, rate.Value)
+				}
+			},
+		},
+		{
+			name:     "curve default",
+			template: "test-solar-forecast-curve",
+			checks: func(t *testing.T, rates api.Rates) {
+				// Should have bell curve with default parameters
+				day1Rates := rates[:24]
+				validateBellCurve(t, day1Rates, 4500.0, 6, 18)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tariff, err := NewFromConfig(context.TODO(), "template", map[string]any{
+				"template": tt.template,
+			})
+			require.NoError(t, err)
+
+			rates, err := tariff.Rates()
+			require.NoError(t, err)
+
+			assert.Equal(t, 48, len(rates), "Should have 48 hours of data")
+			tt.checks(t, rates)
+		})
+	}
+}

--- a/tariff/test_solar_forecast_test.go
+++ b/tariff/test_solar_forecast_test.go
@@ -22,8 +22,8 @@ func TestSolarForecastStatic(t *testing.T) {
 	rates, err := tariff.Rates()
 	require.NoError(t, err)
 
-	// Should have 48 hours of data (2 days)
-	assert.Equal(t, 48, len(rates))
+	// Should have 72 hours of data (3 days)
+	assert.Equal(t, 72, len(rates))
 
 	// All rates should have the same power value
 	for _, rate := range rates {
@@ -49,18 +49,22 @@ func TestSolarForecastCurve(t *testing.T) {
 	rates, err := tariff.Rates()
 	require.NoError(t, err)
 
-	// Should have 48 hours of data (2 days)
-	assert.Equal(t, 48, len(rates))
+	// Should have 72 hours of data (3 days)
+	assert.Equal(t, 72, len(rates))
 
-	// Check that we have both days with similar patterns
+	// Check that we have all three days with similar patterns
 	day1Rates := rates[:24]
-	day2Rates := rates[24:]
+	day2Rates := rates[24:48]
+	day3Rates := rates[48:72]
 
 	// Verify bell curve characteristics for day 1
 	validateBellCurve(t, day1Rates, 4500.0, 6, 18)
 
 	// Verify bell curve characteristics for day 2 (should be similar)
 	validateBellCurve(t, day2Rates, 4500.0, 6, 18)
+
+	// Verify bell curve characteristics for day 3 (should be similar)
+	validateBellCurve(t, day3Rates, 4500.0, 6, 18)
 
 	// Check tariff type
 	assert.Equal(t, api.TariffTypeSolar, tariff.Type())
@@ -149,7 +153,7 @@ func TestSolarForecastTemplateDefaults(t *testing.T) {
 			rates, err := tariff.Rates()
 			require.NoError(t, err)
 
-			assert.Equal(t, 48, len(rates), "Should have 48 hours of data")
+			assert.Equal(t, 72, len(rates), "Should have 72 hours of data")
 			tt.checks(t, rates)
 		})
 	}

--- a/templates/definition/tariff/test-solar-forecast-curve.yaml
+++ b/templates/definition/tariff/test-solar-forecast-curve.yaml
@@ -1,0 +1,84 @@
+template: test-solar-forecast-curve
+group: solar
+products:
+  - brand: Test
+    description:
+      de: Realistische Solarvorhersage (Glockenkurve)
+      en: Realistic solar forecast (bell curve)
+requirements:
+  description:
+    en: For testing purposes. Provides realistic solar production curve peaking at noon.
+    de: Zu Testzwecken. Liefert realistische Solarproduktionskurve mit Spitze zur Mittagszeit.
+params:
+  - name: peak
+    description:
+      de: Spitzenleistung zur Mittagszeit
+      en: Peak power at noon
+    type: float
+    unit: W
+    default: 4500
+    help:
+      de: Maximale Solarleistung zur Mittagszeit in Watt
+      en: Maximum solar power at noon in watts
+  - name: sunrise
+    description:
+      de: Sonnenaufgang (Stunde)
+      en: Sunrise hour
+    type: int
+    default: 6
+    help:
+      de: Stunde des Sonnenaufgangs (0-23)
+      en: Hour of sunrise (0-23)
+  - name: sunset
+    description:
+      de: Sonnenuntergang (Stunde)
+      en: Sunset hour
+    type: int
+    default: 18
+    help:
+      de: Stunde des Sonnenuntergangs (0-23)
+      en: Hour of sunset (0-23)
+  - name: interval
+    default: 1h
+    advanced: true
+
+render: |
+  type: custom
+  tariff: solar
+  forecast:
+    source: js
+    script: |
+      // Generate realistic solar forecast with bell curve for next 48 hours
+      var now = new Date();
+      var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+      var rates = [];
+      var peakPower = {{ .peak }};
+      var sunrise = {{ .sunrise }};
+      var sunset = {{ .sunset }};
+      var noon = sunrise + (sunset - sunrise) / 2;
+      var dayLength = sunset - sunrise;
+
+      for (var day = 0; day < 2; day++) {
+        for (var hour = 0; hour < 24; hour++) {
+          var time = new Date(start.getTime() + (day * 24 + hour) * 60 * 60 * 1000);
+          var nextTime = new Date(time.getTime() + 60 * 60 * 1000);
+
+          // Calculate solar power using bell curve
+          var solarValue = 0;
+          if (hour >= sunrise && hour <= sunset) {
+            // Normalize hour to range -1 to 1, with 0 at noon
+            var normalizedHour = (hour - noon) / (dayLength / 2);
+            // Bell curve: peak at noon, zero at sunrise/sunset
+            solarValue = Math.max(0, peakPower * (1 - Math.pow(normalizedHour, 2)));
+          }
+
+          rates.push({
+            start: time.toISOString(),
+            end: nextTime.toISOString(),
+            value: Math.round(solarValue)
+          });
+        }
+      }
+
+      JSON.stringify(rates);
+  interval: {{ .interval }}

--- a/templates/definition/tariff/test-solar-forecast-curve.yaml
+++ b/templates/definition/tariff/test-solar-forecast-curve.yaml
@@ -48,7 +48,7 @@ render: |
   forecast:
     source: js
     script: |
-      // Generate realistic solar forecast with bell curve for next 48 hours
+      // Generate realistic solar forecast with bell curve for next 72 hours
       var now = new Date();
       var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
       var rates = [];
@@ -58,7 +58,7 @@ render: |
       var noon = sunrise + (sunset - sunrise) / 2;
       var dayLength = sunset - sunrise;
 
-      for (var day = 0; day < 2; day++) {
+      for (var day = 0; day < 3; day++) {
         for (var hour = 0; hour < 24; hour++) {
           var time = new Date(start.getTime() + (day * 24 + hour) * 60 * 60 * 1000);
           var nextTime = new Date(time.getTime() + 60 * 60 * 1000);

--- a/templates/definition/tariff/test-solar-forecast-static.yaml
+++ b/templates/definition/tariff/test-solar-forecast-static.yaml
@@ -30,13 +30,13 @@ render: |
   forecast:
     source: js
     script: |
-      // Generate static solar forecast for next 48 hours
+      // Generate static solar forecast for next 72 hours
       var now = new Date();
       var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
       var rates = [];
       var constantPower = {{ .power }};
 
-      for (var day = 0; day < 2; day++) {
+      for (var day = 0; day < 3; day++) {
         for (var hour = 0; hour < 24; hour++) {
           var time = new Date(start.getTime() + (day * 24 + hour) * 60 * 60 * 1000);
           var nextTime = new Date(time.getTime() + 60 * 60 * 1000);

--- a/templates/definition/tariff/test-solar-forecast-static.yaml
+++ b/templates/definition/tariff/test-solar-forecast-static.yaml
@@ -1,0 +1,53 @@
+template: test-solar-forecast-static
+group: solar
+products:
+  - brand: Test
+    description:
+      de: Statische Solarvorhersage
+      en: Static solar forecast
+requirements:
+  description:
+    en: For testing purposes. Provides constant solar production 24/7.
+    de: Zu Testzwecken. Liefert konstante Solarproduktion rund um die Uhr.
+params:
+  - name: power
+    description:
+      de: Konstante Solarleistung
+      en: Constant solar power
+    type: float
+    unit: W
+    default: 2000
+    help:
+      de: Konstante Solarleistung in Watt
+      en: Constant solar power in watts
+  - name: interval
+    default: 1h
+    advanced: true
+
+render: |
+  type: custom
+  tariff: solar
+  forecast:
+    source: js
+    script: |
+      // Generate static solar forecast for next 48 hours
+      var now = new Date();
+      var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+      var rates = [];
+      var constantPower = {{ .power }};
+
+      for (var day = 0; day < 2; day++) {
+        for (var hour = 0; hour < 24; hour++) {
+          var time = new Date(start.getTime() + (day * 24 + hour) * 60 * 60 * 1000);
+          var nextTime = new Date(time.getTime() + 60 * 60 * 1000);
+
+          rates.push({
+            start: time.toISOString(),
+            end: nextTime.toISOString(),
+            value: constantPower
+          });
+        }
+      }
+
+      JSON.stringify(rates);
+  interval: {{ .interval }}

--- a/tests/battery-settings.evcc.yaml
+++ b/tests/battery-settings.evcc.yaml
@@ -69,3 +69,7 @@ tariffs:
         price: 0.05
       - hours: 17-21
         price: 0.5
+  solar:
+    type: template
+    template: test-solar-forecast-static
+    power: 1500  # 1.5kW constant solar forecast

--- a/tests/solar-format-bug.spec.ts
+++ b/tests/solar-format-bug.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "@playwright/test";
-import { start, stop, baseUrl } from "./evcc";
+import { test } from "@playwright/test";
+import { start, baseUrl } from "./evcc";
 import { execSync } from "child_process";
 import path from "path";
 import os from "os";
@@ -37,8 +37,8 @@ test.describe("Solar Format Bug Test", async () => {
       );
 
       return result.trim() || null;
-    } catch (error) {
-      console.log("Database read error:", error);
+    } catch {
+      console.log("Database read error");
       return null;
     }
   };
@@ -47,7 +47,7 @@ test.describe("Solar Format Bug Test", async () => {
     const dbPath = getWorkerDbPath();
     try {
       execSync(`echo "DELETE FROM settings WHERE key IN ('solarAccYield', 'solarAccForecast');" | sqlite3 "${dbPath}"`);
-    } catch (error) {
+    } catch {
       console.log("Database might not exist yet, will be created by evcc");
     }
   };
@@ -74,7 +74,7 @@ test.describe("Solar Format Bug Test", async () => {
       await axios.post(`${baseUrl()}/api/system/shutdown`, {});
       // Give it a moment to shutdown
       await page.waitForTimeout(2000);
-    } catch (error) {
+    } catch {
       console.log("Graceful shutdown failed, using force kill");
       instance.kill("SIGKILL");
       await page.waitForTimeout(1000);
@@ -109,7 +109,7 @@ test.describe("Solar Format Bug Test", async () => {
         } else {
           throw new Error(`❌ UNEXPECTED FORMAT: ${format}`);
         }
-      } catch (e) {
+      } catch {
         throw new Error(`❌ INVALID JSON FORMAT: ${format}`);
       }
     }

--- a/tests/solar-format-bug.spec.ts
+++ b/tests/solar-format-bug.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+import { execSync } from "child_process";
+import path from "path";
+import os from "os";
+import axios from "axios";
+
+test.use({ baseURL: baseUrl() });
+
+test.describe("Solar Format Bug Test", async () => {
+
+  const getWorkerDbPath = () => {
+    const workerIndex = Number(process.env["TEST_WORKER_INDEX"] ?? 0);
+    const port = 11000 + workerIndex;
+    const file = `evcc-${port}.db`;
+    return path.join(os.tmpdir(), file);
+  };
+
+  const getDatabaseFormat = async (): Promise<string | null> => {
+    const dbPath = getWorkerDbPath();
+
+    try {
+      // First check if database and table exist
+      const tableCheck = execSync(
+        `echo "SELECT name FROM sqlite_master WHERE type='table' AND name='settings';" | sqlite3 "${dbPath}"`,
+        { encoding: 'utf8', timeout: 5000 }
+      );
+
+      if (!tableCheck.trim()) {
+        console.log("Settings table does not exist yet");
+        return null;
+      }
+
+      const result = execSync(
+        `echo "SELECT value FROM settings WHERE key = 'solarAccYield';" | sqlite3 "${dbPath}"`,
+        { encoding: 'utf8', timeout: 5000 }
+      );
+
+      return result.trim() || null;
+    } catch (error) {
+      console.log("Database read error:", error);
+      return null;
+    }
+  };
+
+  const clearDatabase = async () => {
+    const dbPath = getWorkerDbPath();
+    try {
+      execSync(`echo "DELETE FROM settings WHERE key IN ('solarAccYield', 'solarAccForecast');" | sqlite3 "${dbPath}"`);
+    } catch (error) {
+      console.log("Database might not exist yet, will be created by evcc");
+    }
+  };
+
+  test("Solar format consistency - Clean Playwright Lifecycle", async ({ page }) => {
+    test.setTimeout(30000); // 30 second timeout
+    console.log("🧪 Testing solar format bug with clean Playwright lifecycle");
+
+    // 1. COMPLETELY CLEAR DATABASE - no seeded data whatsoever
+    await clearDatabase();
+    console.log("✅ Database cleared completely");
+
+    // 2. START EVCC using Playwright's method and KEEP THE INSTANCE
+    console.log("🚀 Starting evcc...");
+    const instance = await start("battery-settings.evcc.yaml");
+
+    // 3. LET EVCC RUN for enough time to accumulate solar data
+    console.log("⏱️  Letting evcc run for 5 seconds to accumulate solar data...");
+    await page.waitForTimeout(5000);
+
+    // 4. STOP EVCC cleanly WITHOUT cleaning database
+    console.log("🛑 Stopping evcc gracefully without cleaning database...");
+    try {
+      await axios.post(`${baseUrl()}/api/system/shutdown`, {});
+      // Give it a moment to shutdown
+      await page.waitForTimeout(2000);
+    } catch (error) {
+      console.log("Graceful shutdown failed, using force kill");
+      instance.kill("SIGKILL");
+      await page.waitForTimeout(1000);
+    }
+
+    // 5. CHECK WHAT FORMAT EVCC WROTE TO DATABASE
+    const format = await getDatabaseFormat();
+    console.log("📊 Database format written by evcc:", format);
+
+    if (!format) {
+      console.log("⚠️  No solar data found in database - this could mean:");
+      console.log("   - evcc didn't run long enough to accumulate data");
+      console.log("   - solar forecast is 0 or very small");
+      console.log("   - the solar meter is not generating data");
+      console.log("📝 This test demonstrates the clean lifecycle but can't verify the format bug without data");
+      return; // Exit gracefully - no data to test
+    }
+
+    // 6. ANALYZE THE FORMAT
+    if (format.includes('"accumulated":') || format.includes('accumulated:')) {
+      // BUGGY FORMAT DETECTED
+      throw new Error(`❌ BUGGY FORMAT: evcc wrote nested format: ${format}`);
+    } else {
+      // Check if it's valid flat format
+      try {
+        // Handle unquoted keys from sqlite output
+        const normalizedJson = format.replace(/\{(\w+):/g, '{"$1":');
+        const parsed = JSON.parse(normalizedJson);
+
+        if (parsed.pv !== undefined && typeof parsed.pv === 'number') {
+          console.log(`✅ CORRECT FORMAT: Flat structure {"pv": ${parsed.pv}}`);
+        } else {
+          throw new Error(`❌ UNEXPECTED FORMAT: ${format}`);
+        }
+      } catch (e) {
+        throw new Error(`❌ INVALID JSON FORMAT: ${format}`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR builds on top of https://github.com/evcc-io/evcc/pull/21971

---

`evcc` didn't seem to correctly persist the solar yield/forecast data for yield correction:

```
Jun 21 15:05:41 abundantia evcc[3317999]: [site  ] DEBUG 2025/06/21 15:05:41 solar forecast: accumulated 365.718kWh, produced 271.752kWh, scale 0.743
Jun 21 15:06:03 abundantia systemd[1]: Stopping evcc.service - evcc...
Jun 21 15:06:03 abundantia evcc[3317999]: [lp-1  ] DEBUG 2025/06/21 15:06:03 charge total import: 4860.115kWh
Jun 21 15:06:03 abundantia systemd[1]: evcc.service: Deactivated successfully.
Jun 21 15:06:03 abundantia systemd[1]: Stopped evcc.service - evcc.
Jun 21 15:06:15 abundantia systemd[1]: Started evcc.service - evcc.
[..]
Jun 21 15:06:21 abundantia evcc[3425913]: [site  ] DEBUG 2025/06/21 15:06:21 solar forecast: accumulated 0.002kWh, produced 0.000kWh, scale 0.000
```

This turned out to be a serialization mismatch, we persist `site.pvEnergy` directly:

https://github.com/evcc-io/evcc/blob/aa77183bc8109a69d1998cb42af80a8e24ed515d/core/site.go#L599

https://github.com/evcc-io/evcc/blob/aa77183bc8109a69d1998cb42af80a8e24ed515d/core/site.go#L101

https://github.com/evcc-io/evcc/blob/aa77183bc8109a69d1998cb42af80a8e24ed515d/core/meterenergy.go#L11-L16


Which means that the marshalled json looks something like this

```
{
  "meter1": { "accumulated": 123.4, },
  "meter2": { "accumulated": 234.5, }
}
```

but when restoring on startup:

https://github.com/evcc-io/evcc/blob/aa77183bc8109a69d1998cb42af80a8e24ed515d/core/site.go#L320-L328

we expect just

```
{
  "meter1": 123.4,
  "meter2": 234.5,
}
```

This mismatch seems to have caused the json unmarshal to fail and cause the entire "restore accumulated energy" block to be silently skipped.

---

Testing the restore logic isn't entirely trivial at the moment since we bail early during testing:

https://github.com/evcc-io/evcc/blob/aa77183bc8109a69d1998cb42af80a8e24ed515d/core/site.go#L286-L289

Since I don't know the context around the bail I opted for a playwright test to ensure the correct format is being serialized.

Down the line we should introduce proper integration tests for the restore logic.

