### PR TITLE
UI: fix en fallback locale

### DIFF
--- a/assets/js/i18n.ts
+++ b/assets/js/i18n.ts
@@ -73,7 +73,7 @@ export default function setupI18n() {
     silentTranslationWarn: true,
     locale: DEFAULT_LOCALE,
     fallbackLocale: DEFAULT_LOCALE,
-    messages: { "en-US": en },
+    messages: { en },
   });
   setI18nLanguage(i18n.global, getLocale());
   return i18n;


### PR DESCRIPTION
Use `en` language if no other language is available (yet). Regression from https://github.com/evcc-io/evcc/pull/21719.

<img width="443" alt="Bildschirmfoto 2025-06-23 um 16 59 25" src="https://github.com/user-attachments/assets/97af1d5f-da45-47b7-92fa-34e0741c4f27" />
