### PR TITLE
Fix docu and version check for LG ESS Home 8 battery

### DIFF
--- a/meter/lgess.go
+++ b/meter/lgess.go
@@ -82,7 +82,7 @@ func NewLgEss(uri, usage, registration, password string, cache time.Duration, ca
 	var setBatteryMode func(api.BatteryMode) error
 	if usage == "battery" {
 		batterySoc = m.batterySoc
-		if version, err := conn.GetFirmwareVersion(); err == nil && version >= 7433 {
+		if version, err := conn.GetFirmwareVersion(); err == nil && version >= 7430 {
 			setBatteryMode = m.batteryMode(batterySocLimits)
 		}
 	}

--- a/templates/definition/meter/lg-ess-home-8-10.yaml
+++ b/templates/definition/meter/lg-ess-home-8-10.yaml
@@ -7,9 +7,9 @@ capabilities: ["battery-control"]
 requirements:
   description:
     en: >
-      To use the battery control, a firmware version greater than or equal to 10.05.7433 / R2155 is required
+      To use the battery control, a firmware version greater than or equal to 10.05.7430 / R2155 is required
     de: >
-      Um die Batteriesteuerung zu nutzen, wird eine Firmwareversionen größer gleich 10.05.7433 / R2155 benötigt
+      Um die Batteriesteuerung zu nutzen, wird eine Firmwareversionen größer gleich 10.05.7430 / R2155 benötigt
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]


### PR DESCRIPTION
Fixing the documentation and the firmware version check => 10.05.7430 / R2155