### PR TITLE
Extending SAX template's grid functionality

### DIFF
--- a/templates/definition/meter/sax.yaml
+++ b/templates/definition/meter/sax.yaml
@@ -17,7 +17,7 @@ params:
   - name: port
     default: 502
   - name: modbus
-    choice: ["tcpip"]
+    choi  ce: ["tcpip"]
     port: 502
     id: 64
   - name: maxchargepower

--- a/templates/definition/meter/sax.yaml
+++ b/templates/definition/meter/sax.yaml
@@ -7,21 +7,28 @@ capabilities: ["battery-control"]
 requirements:
   description:
     de: |
-      Für Batteriesteuerung müssen die Register 40044/40045 (43/44) vom techn. Support freigeschaltet werden. Hierzu ist die Seriennummer des Gerätes notwendig.
+      Für die Batteriesteuerung müssen die Register 40044/40045 (43/44) vom techn. Support freigeschaltet werden. Hierzu ist die Seriennummer des Gerätes notwendig.
     en: |
       For battery control, registers 40044/40045 (43/44) must be enabled by technical support. The device's serial number is required for this.
 params:
   - name: usage
     choice: ["grid", "battery"]
+  - name: host
+  - name: port
+    default: 502
   - name: modbus
     choice: ["tcpip"]
     port: 502
     id: 64
+  - name: maxchargepower
+    default: 1400
+  - name: maxdischargepower
+    default: 4600
   - name: capacity
     advanced: true
   - name: watchdog
     type: duration
-    default: 240s
+    default: 240s 
     advanced: true
 render: |
   type: custom
@@ -30,24 +37,51 @@ render: |
     source: calc
     add:
     - source: modbus
-      {{- include "modbus" . | indent 4 }}
+      uri: {{ .host }}:{{ .port }}
+      id: 64
       # register details
       register:
-        address: 48 # Leistung des Smartmeters
+        address: 48 # Grid power (l1+l2+l3)
         type: holding
         decode: uint16
     - source: const
       value: -16384
+  currents:
+  - source: modbus
+    uri: {{ .host }}:{{ .port }}
+    id: 40
+    register:
+      address: 40100 # Current[A] of L1 phase
+      type: holding
+      decode: int16
+    scale: 0.01
+  - source: modbus
+    uri: {{ .host }}:{{ .port }}
+    id: 40
+    register:
+      address: 40101 # Current[A] of L2 phase
+      type: holding
+      decode: int16
+    scale: 0.01
+  - source: modbus
+    uri: {{ .host }}:{{ .port }}
+    id: 40
+    register:
+      address: 40102 # Current[A] of L3 phase
+      type: holding
+      decode: int16
+    scale: 0.01
   {{- end }}
   {{- if eq .usage "battery" }}
   power:
     source: calc
     add:
     - source: modbus
-      {{- include "modbus" . | indent 4 }}
+      uri: {{ .host }}:{{ .port }}
+      id: 64
       # register details
       register:
-        address: 47 # Leistung P[W] des Speichers 
+        address: 47 # Power P[W] of the battery
         type: holding
         decode: uint16
     - source: const
@@ -57,37 +91,41 @@ render: |
     {{- include "modbus" . | indent 2 }}
     # register details
     register:
-      address: 46 # SOC[%] des Speichers 
+      address: 46 # SOC[%] of the battery
       type: holding
       decode: uint16
   batterymode:
     source: watchdog
-    timeout: {{ .watchdog }}
+    timeout: {{ .watchdog }}  # re-write at timeout/2
     reset: 1 # reset watchdog on normal
     set:
       source: switch
       switch:
-      - case: 1 # normal mode with maximum discharge of 4600W
+      - case: 1 # normal mode with maximum discharge of maxdischargepower
         set:
           source: const
-          value: 4600
+          value: {{ .maxdischargepower }}
           set:
             source: modbus
-            {{- include "modbus" . | indent 10 }}
+            uri: {{ .host }}:{{ .port }}
+            id: 64
             register:
               address: 43 # 2Bh battery discharging power [W]
               type: writemultiple
-              encoding: uint16
+              decode: uint16
+              #encoding: uint16
       - case: 2 # holding mode puts discharge to 0W
         set:
           source: const
           value: 0
           set:
             source: modbus
-            {{- include "modbus" . | indent 10 }}
+            uri: {{ .host }}:{{ .port }}
+            id: 64
             register:
               address: 43 # 2Bh battery discharging power [W]
               type: writemultiple
-              encoding: uint16
+              decode: uint16
+              #encoding: uint16
   capacity: {{ .capacity }} # kWh
   {{- end }}


### PR DESCRIPTION
The smartmeter's phase currents (l1,l2,l3) figures were integrated.