### PR TITLE
cli: add heartbeat option to charger/meter

### DIFF
--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -28,7 +28,7 @@ func init() {
 	chargerCmd.Flags().Bool(flagDiagnose, false, flagDiagnoseDescription)
 	chargerCmd.Flags().BoolP(flagWakeup, "w", false, flagWakeupDescription)
 	chargerCmd.Flags().IntP(flagPhases, "p", 0, flagPhasesDescription)
-	chargerCmd.Flags().Bool(flagHeartbeat, 0, flagHeartbeatDescription)
+	chargerCmd.Flags().Bool(flagHeartbeat, false, flagHeartbeatDescription)
 }
 
 func runCharger(cmd *cobra.Command, args []string) {

--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/config"
@@ -27,6 +28,7 @@ func init() {
 	chargerCmd.Flags().Bool(flagDiagnose, false, flagDiagnoseDescription)
 	chargerCmd.Flags().BoolP(flagWakeup, "w", false, flagWakeupDescription)
 	chargerCmd.Flags().IntP(flagPhases, "p", 0, flagPhasesDescription)
+	chargerCmd.Flags().Bool(flagHeartbeat, 0, flagHeartbeatDescription)
 }
 
 func runCharger(cmd *cobra.Command, args []string) {
@@ -115,6 +117,11 @@ func runCharger(cmd *cobra.Command, args []string) {
 				log.ERROR.Println("phases: not implemented")
 			}
 		}
+	}
+
+	if ok, _ := cmd.Flags().GetBool(flagHeartbeat); flagUsed && ok {
+		log.INFO.Println("running heartbeat until interrupted (Ctrl-C to stop)")
+		time.Sleep(time.Hour)
 	}
 
 	if !flagUsed {

--- a/cmd/charger.go
+++ b/cmd/charger.go
@@ -136,6 +136,9 @@ func runCharger(cmd *cobra.Command, args []string) {
 				d.DumpDiagnosis(v)
 			}
 		}
+	} else if ok, _ := cmd.Flags().GetBool(flagHeartbeat); ok {
+		log.INFO.Println("running heartbeat (if any) until interrupted (Ctrl-C to stop)")
+		time.Sleep(time.Hour)
 	}
 
 	// wait for shutdown

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -66,7 +66,7 @@ const (
 	flagRepeatIntervalDescription = "Interval between repetitions"
 
 	flagHeartbeat            = "heartbeat"
-	flagHeartbeatDescription = "After command, continue running heartbeat until interrupted"
+	flagHeartbeatDescription = "After command, continue running device heartbeats (if any) until interrupted"
 
 	flagDigits = "digits"
 	flagDelay  = "delay"

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -65,6 +65,9 @@ const (
 	flagRepeatInterval            = "repeat-interval"
 	flagRepeatIntervalDescription = "Interval between repetitions"
 
+	flagHeartbeat            = "heartbeat"
+	flagHeartbeatDescription = "After command, continue running heartbeat until interrupted"
+
 	flagDigits = "digits"
 	flagDelay  = "delay"
 	flagForce  = "force"

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -22,6 +22,7 @@ func init() {
 	meterCmd.Flags().DurationP(flagBatteryModeWait, "w", 0, flagBatteryModeWaitDescription)
 	meterCmd.Flags().BoolP(flagRepeat, "r", false, flagRepeatDescription)
 	meterCmd.Flags().Duration(flagRepeatInterval, 0, flagRepeatIntervalDescription)
+	meterCmd.Flags().Bool(flagHeartbeat, false, flagHeartbeatDescription)
 }
 
 func runMeter(cmd *cobra.Command, args []string) {
@@ -66,6 +67,11 @@ func runMeter(cmd *cobra.Command, args []string) {
 				time.Sleep(d)
 			}
 		}
+	}
+
+	if ok, _ := cmd.Flags().GetBool(flagHeartbeat); flagUsed && ok {
+		log.INFO.Println("running heartbeat until interrupted (Ctrl-C to stop)")
+		time.Sleep(time.Hour)
 	}
 
 	if !flagUsed {

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -69,11 +69,6 @@ func runMeter(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if ok, _ := cmd.Flags().GetBool(flagHeartbeat); flagUsed && ok {
-		log.INFO.Println("running heartbeat until interrupted (Ctrl-C to stop)")
-		time.Sleep(time.Hour)
-	}
-
 	if !flagUsed {
 		d := dumper{len: len(meters)}
 	REPEAT:
@@ -89,6 +84,9 @@ func runMeter(cmd *cobra.Command, args []string) {
 			}
 			goto REPEAT
 		}
+	} else if ok, _ := cmd.Flags().GetBool(flagHeartbeat); ok {
+		log.INFO.Println("running heartbeat (if any) until interrupted (Ctrl-C to stop)")
+		time.Sleep(time.Hour)
 	}
 
 	// wait for shutdown


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/22079#issuecomment-3026616013

Add `--heartbeat` to evcc charger or meter to continue running heartbeat (if any) before stopping command.