### PR TITLE
fix EM2GO charger charging state, add comments for returned status code

### DIFF
--- a/charger/em2go.go
+++ b/charger/em2go.go
@@ -145,11 +145,15 @@ func (wb *Em2Go) Status() (api.ChargeStatus, error) {
 	}
 
 	switch binary.BigEndian.Uint16(b) {
-	case 1:
+	case 1: //Standby
 		return api.StatusA, nil
-	case 2, 3:
+	case
+		2, //Connected
+		3, //Starting
+		6: //Charging end
 		return api.StatusB, nil
-	case 4, 6:
+	case
+		4: //Charging
 		return api.StatusC, nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])


### PR DESCRIPTION
As reported with issue #21256 EM2GO charger reports charging state when it´s in finishing state. 
This was due to status code 6 (Charging end) of ModBus register 0 was assigned to api.StatusC which in result lead to logic errors. 

This commit aims to fix this error. It changes status code 6 (Charging end) to api.StatusB. Secondly we have added comments for each status code foe better readability. 