### PR TITLE
docs: clarify description for keba variants

### DIFF
--- a/templates/definition/charger/keba-modbus-p40.yaml
+++ b/templates/definition/charger/keba-modbus-p40.yaml
@@ -9,9 +9,6 @@ products:
 capabilities: ["mA", "rfid"]
 requirements:
   evcc: ["sponsorship"]
-  description:
-    de: Phasenumschaltung wird von der Wallbox derzeit noch nicht unterstützt.
-    en: Phase switching is currently not supported by the wallbox.
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/keba-modbus-p40.yaml
+++ b/templates/definition/charger/keba-modbus-p40.yaml
@@ -1,0 +1,26 @@
+template: keba-modbus-p40
+products:
+  - brand: KEBA
+    description:
+      generic: KeContact P40
+  - brand: KEBA
+    description:
+      generic: KeContact P40 Pro
+capabilities: ["mA", "rfid"]
+requirements:
+  evcc: ["sponsorship"]
+  description:
+    de: Phasenumschaltung wird von der Wallbox derzeit noch nicht unterstützt.
+    en: Phase switching is currently not supported by the wallbox.
+params:
+  - name: modbus
+    choice: ["tcpip"]
+    id: 255
+  - name: welcomecharge
+    advanced: true
+render: |
+  type: keba-modbus
+  {{- include "modbus" . }}
+  {{- if eq .welcomecharge "true" }}
+  features: ["welcomecharge"]
+  {{- end }}

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -25,8 +25,8 @@ capabilities: ["1p3p", "mA", "rfid"]
 requirements:
   evcc: ["sponsorship"]
   description:
-    de: P40 und P40 Pro: Phasenumschaltung wird derzeit noch nicht unterstützt. P30 und Varianten: Erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der x-Serie im WebMenü, bei der C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
-    en: P40 and P40 Pro: Phase switching is currently not supported. P30 and variants: Requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the X-series in the web menu, for the C-series via Modbus by setting the value "3" in register 5050.
+    de: P40 und P40 Pro unterstützt die Phasenumschaltung derzeit noch nicht. P30 und Varianten erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird bei P30 zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der P30 x-Serie im WebMenü, bei der P30 C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
+    en: P40 and P40 Pro Phase switching is currently not supported. P30 and variants requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching with the P30 the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the P30 X-series in the web menu, for the P30 C-series via Modbus by setting the value "3" in register 5050.
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -25,8 +25,8 @@ capabilities: ["1p3p", "mA", "rfid"]
 requirements:
   evcc: ["sponsorship"]
   description:
-    de: Erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der x-Serie im WebMenü, bei der C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
-    en: Requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the X-series in the web menu, for the C-series via Modbus by setting the value "3" in register 5050.
+    de: P40 und P40 Pro: Phasenumschaltung wird derzeit noch nicht unterstützt. P30 und Varianten: Erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der x-Serie im WebMenü, bei der C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
+    en: P40 and P40 Pro: Phase switching is currently not supported. P30 and variants: Requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the X-series in the web menu, for the C-series via Modbus by setting the value "3" in register 5050.
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -21,7 +21,7 @@ requirements:
   description:
     de: Erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der x-Serie im WebMenü, bei der C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
     en: Requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the X-series in the web menu, for the C-series via Modbus by setting the value "3" in register 5050.
-  params:
+params:
   - name: modbus
     choice: ["tcpip"]
     id: 255

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -9,12 +9,6 @@ products:
   - brand: KEBA
     description:
       generic: KeContact P30 X-Series
-  - brand: KEBA
-    description:
-      generic: KeContact P40
-  - brand: KEBA
-    description:
-      generic: KeContact P40 Pro
   - brand: BMW
     description:
       generic: i Wallbox
@@ -25,9 +19,9 @@ capabilities: ["1p3p", "mA", "rfid"]
 requirements:
   evcc: ["sponsorship"]
   description:
-    de: P40 und P40 Pro unterstützt die Phasenumschaltung derzeit noch nicht. P30 und Varianten erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird bei P30 zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der P30 x-Serie im WebMenü, bei der P30 C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
-    en: P40 and P40 Pro Phase switching is currently not supported. P30 and variants requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching with the P30 the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the P30 X-series in the web menu, for the P30 C-series via Modbus by setting the value "3" in register 5050.
-params:
+    de: Erfordert Firmwareversion 3.10.42 (C-series) bzw. 1.11 (X-series). Zur Phasenumschaltung wird zusätzlich der Keba Phasenumschalter (KeContact S10) benötigt und in den Wallboxeinstellungen muss die Umschaltsteuerung per Modbus aktiviert werden. Bei der x-Serie im WebMenü, bei der C-Serie per Modbus durch setzen des Wertes "3" im Register 5050.
+    en: Requires firmware version 3.10.42 (C-series) bzw. 1.11 (X-series). For phase switching the Keba phase switch (KeContact S10) is also required and the switching control via Modbus must be set in the wallbox settings. For the X-series in the web menu, for the C-series via Modbus by setting the value "3" in register 5050.
+  params:
   - name: modbus
     choice: ["tcpip"]
     id: 255


### PR DESCRIPTION
The docs description for all keba wallboxes is the same but they are very different devices. I clarified some differences between the P40 and P30 variants to prevent confusion.

For example the P40 currently does not support phase switching, it has to be added via update by keba. Also the P40 does not need the Keba S10 for phase switching and so on.

It would be better to have separate doc entries for P30 and P40 variants, if thats possible. Then we could remove the 1P3P tag from the P40 until it's supported.