### PR TITLE
open-meteo: Use instant irradiance and UTC timestamps.

### DIFF
--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -72,7 +72,7 @@ render: |
   tariff: solar
   forecast:
     source: http
-    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&hourly=temperature_2m,global_tilted_irradiance&daily=sunrise,sunset&forecast_days=3&timezone=auto&timeformat=unixtime
+    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&hourly=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=3&timezone=GMT&timeformat=unixtime
     jq: |
       def alphatemp: {{ .alphatemp }}; # temperature coefficient
       def rossmodel: {{ .rossmodel }}; # cooling type
@@ -101,17 +101,17 @@ render: |
           | $h.time[$i] as $time
           | ($i / 24 | floor) as $day
           | {
-              start: (($time - 3600) | todateiso8601),
-              end: ($time | todateiso8601),
+              start: ($time | todateiso8601),
+              end: (($time + 3600) | todateiso8601),
               value: (
                 kwp
-                * ($h.global_tilted_irradiance[$i] / 1000)
+                * ($h.global_tilted_irradiance_instant[$i] / 1000)
                 * (1 + ( alphatemp *
                       (
                         ( ($h.temperature_2m[$i]
                             + ($h.temperature_2m[$i-1] // $h.temperature_2m[$i])
                           ) / 2)
-                        + $h.global_tilted_irradiance[$i] * rossmodel - 25.0
+                        + $h.global_tilted_irradiance_instant[$i] * rossmodel - 25.0
                       )
                     ))
                 * (1 - calculate_damping($time;


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/20939

Switch from average irradiance (global_tilted_irradiance) to instant irradiance at beginning of slot (global_tilted_irradiance_instant).
Request unixtimestamps in UTC (timezone GMT).