### PR TITLE
chore: depot e2e stability

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -169,7 +169,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: depot-ubuntu-24.04-arm-8
+    runs-on: depot-ubuntu-24.04-arm-16
 
     steps:
       - uses: actions/checkout@v4
@@ -201,24 +201,24 @@ jobs:
       - name: Build Go
         run: make build
 
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+      #- name: Get Playwright version
+      #  id: playwright-version
+      #  run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+      #- name: Cache Playwright browsers
+      #  uses: actions/cache@v4
+      #  id: playwright-cache
+      #  with:
+      #    path: ~/.cache/ms-playwright
+      #    key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright (browsers + deps)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        #  if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      - name: Install Playwright (deps only)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+      #- name: Install Playwright (deps only)
+      #  if: steps.playwright-cache.outputs.cache-hit == 'true'
+      #  run: npx playwright install-deps chromium
 
       - name: Run tests
         run: npx playwright test

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -169,7 +169,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: depot-ubuntu-24.04-arm-8
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
address failing jobs on depot runners
https://github.com/evcc-io/evcc/actions/runs/16158961437/job/45606830524
https://github.com/evcc-io/evcc/actions/runs/16153497173/job/45590355011

- [ ] try lower concurrency (4 instead of 8)
- [ ] try playwrights parallelization feature (multiple workers)