### PR TITLE
Loadpoint: replace empty session energy round trip with meter values

### DIFF
--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -74,8 +74,8 @@ func (lp *Loadpoint) stopSession() {
 		s.MeterStop = &meterStop
 
 		if s.MeterStart != nil {
-			// use meter stop to override charged energy
-			if chargedEnergy := *s.MeterStop - *s.MeterStart; chargedEnergy > s.ChargedEnergy {
+			// use meter stop to override charged energy, but prevent negative values
+			if chargedEnergy := *s.MeterStop - *s.MeterStart; chargedEnergy >= 0 && chargedEnergy > s.ChargedEnergy {
 				lp.energyMetrics.Update(chargedEnergy)
 			}
 		}

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -75,7 +75,7 @@ func (lp *Loadpoint) stopSession() {
 
 		if s.MeterStart != nil {
 			// use meter stop to override charged energy, but prevent negative values
-			if chargedEnergy := *s.MeterStop - *s.MeterStart; chargedEnergy >= 0 && chargedEnergy > s.ChargedEnergy {
+			if chargedEnergy := *s.MeterStop - *s.MeterStart; chargedEnergy > max(0, s.ChargedEnergy) {
 				lp.energyMetrics.Update(chargedEnergy)
 			}
 		}

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -68,12 +68,17 @@ func (lp *Loadpoint) stopSession() {
 	}
 
 	s.Finished = lp.clock.Now()
+
+	// record meter stop
 	if meterStop := lp.chargeMeterTotal(); meterStop > 0 {
 		s.MeterStop = &meterStop
-	}
 
-	if chargedEnergy := lp.GetChargedEnergy() / 1e3; chargedEnergy > s.ChargedEnergy {
-		lp.energyMetrics.Update(chargedEnergy)
+		if s.MeterStart != nil {
+			// use meter stop to override charged energy
+			if chargedEnergy := *s.MeterStop - *s.MeterStart; chargedEnergy > s.ChargedEnergy {
+				lp.energyMetrics.Update(chargedEnergy)
+			}
+		}
 	}
 
 	s.SolarPercentage = lo.ToPtr(lp.energyMetrics.SolarPercentage())

--- a/core/loadpoint_session_test.go
+++ b/core/loadpoint_session_test.go
@@ -241,7 +241,7 @@ func TestResetHeatingSession(t *testing.T) {
 	assert.Equal(t, clock.Now(), lp.session.Created)
 
 	clock.Add(36 * time.Hour)
-	me.EXPECT().TotalEnergy().Return(1.0, nil).MaxTimes(2)
+	me.EXPECT().TotalEnergy().Return(1.0, nil).Times(2)
 
 	lp.resetHeatingSession()
 	require.NotNil(t, lp.session)


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/22221
