### PR TITLE
Add maxacpower/maxchargepower for LG inverters

### DIFF
--- a/templates/definition/meter/lg-ess-home-15.yaml
+++ b/templates/definition/meter/lg-ess-home-15.yaml
@@ -28,6 +28,11 @@ params:
       de: Nummer des LG ESS HOME Wechselrichters.
   - name: capacity
     advanced: true
+  - name: maxacpower
+    default: 15000
+    advanced: true
+  - name: maxchargepower
+    advanced: true
   # battery control
   - name: minsoc
     type: int

--- a/templates/definition/meter/lg-ess-home-8-10.yaml
+++ b/templates/definition/meter/lg-ess-home-8-10.yaml
@@ -41,8 +41,8 @@ params:
       de: 8000 für ESS Home 8, 10000 für ESS Home 10
   - name: maxchargepower
     help:
-      en: 5000 for one battery, 7000 for two batteries
-      de: 5000 für eine Batterie, 7000 für zwei Batterien
+      en: 4000 or 5000 for one battery, 7000 for two batteries
+      de: 4000 oder 5000 für eine Batterie, 7000 für zwei Batterien
     advanced: true
   # battery control
   - name: minsoc

--- a/templates/definition/meter/lg-ess-home-8-10.yaml
+++ b/templates/definition/meter/lg-ess-home-8-10.yaml
@@ -34,6 +34,16 @@ params:
       de: Nummer des LG ESS HOME Wechselrichters.
   - name: capacity
     advanced: true
+  - name: maxacpower
+    advanced: true
+    help:
+      en: 8000 for ESS Home 8, 10000 for ESS Home 10
+      de: 8000 für ESS Home 8, 10000 für ESS Home 10
+  - name: maxchargepower
+    help:
+      en: 5000 for one battery, 7000 for two batteries
+      de: 5000 für eine Batterie, 7000 für zwei Batterien
+    advanced: true
   # battery control
   - name: minsoc
     type: int


### PR DESCRIPTION
Adds `maxacpower` & `maxchargepower` parameters for LG inverters.

* [LG ESS Home 8/10 old/Gen1 data sheet](https://www.lg.com/global/business/download/resources/ess/ESS_HOME%208_10_Datasheet_DE.pdf)
* [LG ESS Home 8/10 new/Gen2 data sheet](https://www.lg.com/global/business/download/resources/ess/ESS_HOME_8_10_Datasheet_EN.pdf)
* [LG ESS Home 15 manual](https://www.lg.com/global/business/download/resources/ess/HOME15_10_8_Owners_Installation_Manual_DE_June_2024.pdf)
