### PR TITLE
fix: loadpoint current decimals

### DIFF
--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -97,7 +97,7 @@
 							{{ name }}
 						</option>
 					</select>
-					<small class="ms-3">~ {{ maxPower }}</small>
+					<small class="ms-3" data-testid="max-power">~ {{ maxPower }}</small>
 				</div>
 			</div>
 
@@ -120,7 +120,7 @@
 							{{ name }}
 						</option>
 					</select>
-					<small class="ms-3">~ {{ minPower }}</small>
+					<small class="ms-3" data-testid="min-power">~ {{ minPower }}</small>
 				</div>
 			</div>
 		</div>
@@ -283,7 +283,7 @@ export default defineComponent({
 			this.$emit("phasesconfigured-updated", this.selectedPhases);
 		},
 		currentOption(value: number, isDefault: boolean) {
-			let name = `${this.fmtNumber(value, 0)} A`;
+			let name = `${this.fmtNumber(value, value <= 1 ? undefined : 0)} A`;
 			if (isDefault) {
 				name += ` (${this.$t("main.loadpointSettings.default")})`;
 			}

--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -90,7 +90,7 @@ export default defineComponent({
     fmtWh(watt: number, format = POWER_UNIT.KW, withUnit = true, digits?: number) {
       return this.fmtW(watt, format, withUnit, digits) + (withUnit ? "h" : "");
     },
-    fmtNumber(number: number, decimals: number, unit?: string) {
+    fmtNumber(number: number, decimals: number | undefined, unit?: string) {
       const style = unit ? "unit" : "decimal";
       return new Intl.NumberFormat(this.$i18n?.locale, {
         style,

--- a/tests/currents.spec.ts
+++ b/tests/currents.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+import { expectModalVisible } from "./utils";
+test.use({ baseURL: baseUrl() });
+
+test.beforeAll(async () => {
+  await start("basics.evcc.yaml");
+});
+test.afterAll(async () => {
+  await stop();
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+test.describe("currents", async () => {
+  test("change min and max current", async ({ page }) => {
+    // Open loadpoint settings modal
+    await page.getByTestId("loadpoint-settings-button").nth(1).click();
+    const modal = page.getByTestId("loadpoint-settings-modal");
+    await expectModalVisible(modal);
+
+    const minCurrent = modal.getByLabel("Min. current");
+    const maxCurrent = modal.getByLabel("Max. current");
+    const minPower = modal.getByTestId("min-power");
+    const maxPower = modal.getByTestId("max-power");
+
+    // initial values
+    await expect(maxCurrent).toHaveValue("16");
+    await expect(maxPower).toContainText("~ 11.0 kW");
+    await expect(minCurrent).toHaveValue("6");
+    await expect(minPower).toContainText("~ 4.1 kW");
+
+    // change min current
+    await minCurrent.selectOption("0.125 A");
+    await expect(minPower).toContainText("~ 0.1 kW");
+
+    // change max current
+    await maxCurrent.selectOption("32 A");
+    await expect(maxPower).toContainText("~ 22.1 kW");
+  });
+});


### PR DESCRIPTION
replaces https://github.com/evcc-io/evcc/pull/21891
fixes https://github.com/evcc-io/evcc/issues/21885

Because https://github.com/evcc-io/evcc/pull/21187 was reverted and still has things to be discussed, here the specific formatting fix for the loadpoint settings modal. Also added proper tests to avoid future regressions.

<img width="776" height="574" alt="Bildschirmfoto 2025-07-12 um 17 41 48" src="https://github.com/user-attachments/assets/4a1efb81-d56c-4043-9b5f-c856c744b1d6" />
