### PR TITLE
HomeAssistant Smart Switch - support for alternative domains

### DIFF
--- a/charger/homeassistant-switch.go
+++ b/charger/homeassistant-switch.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -89,8 +90,10 @@ func (c *HomeAssistantSwitch) Enable(enable bool) error {
 	}
 
 	data := map[string]any{"entity_id": c.switchEntity}
+	// the domain must not be necessary a 'switch' - it can be also an `input_boolean`
+	domain := strings.Split(c.switchEntity, ".")[0]
 
-	uri := fmt.Sprintf("%s/api/services/switch/%s", c.baseURL, service)
+	uri := fmt.Sprintf("%s/api/services/%s/%s", c.baseURL, domain, service)
 	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
 
 	return c.Helper.DoJSON(req, nil)


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/22345

In HA there could exist different entities that allow the user to switch/toggle a state. A switch-entity is just one of them an input_boolean-entity is another one.

this is the result of https://github.com/evcc-io/evcc/issues/22345