### PR TITLE
CLI: optional config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,13 +140,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 			log.FATAL.Fatal(err)
 		}
 	} else {
-		if cfgErr := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); errors.As(cfgErr, &vpr.ConfigFileNotFoundError{}) {
-			log.INFO.Println("config file missing, create configuration using config UI")
-			// evcc.yaml not found, use default configuration
-			if err := viper.UnmarshalExact(&conf); err != nil {
-				log.FATAL.Fatalf("failed to unmarshal default configuration: %v", err)
-			}
-		} else {
+		if cfgErr := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); cfgErr != nil {
 			// evcc.yaml found, might have errors
 			err = wrapErrorWithClass(ClassConfigFile, cfgErr)
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -89,7 +89,7 @@ func loadConfigFile(conf *globalconfig.All, checkDB bool) error {
 	cfgFile := viper.ConfigFileUsed()
 
 	if cfgFile == "" {
-		log.INFO.Println("no config file found, database-only mode")
+		log.INFO.Println("no config file specified, database-only mode")
 	} else if err = viper.ReadInConfig(); err != nil {
 		err = fmt.Errorf("failed reading config file: %w", err)
 	} else {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -51,6 +51,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
+	vpr "github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/text/currency"
 )
@@ -85,18 +86,20 @@ func nameValid(name string) error {
 }
 
 func loadConfigFile(conf *globalconfig.All, checkDB bool) error {
-	var err error
-	cfgFile := viper.ConfigFileUsed()
-
-	if cfgFile == "" {
-		log.INFO.Println("no config file specified, database-only mode")
-	} else if err = viper.ReadInConfig(); err != nil {
-		err = fmt.Errorf("failed reading config file: %w", err)
-	} else {
-		log.INFO.Println("using config file:", cfgFile)
-		if err = viper.UnmarshalExact(conf); err != nil {
-			err = fmt.Errorf("failed parsing config file: %w", err)
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(vpr.ConfigFileNotFoundError); !ok {
+			return fmt.Errorf("failed reading config file: %w", err)
 		}
+	}
+
+	if cfgFile := viper.ConfigFileUsed(); cfgFile != "" {
+		log.INFO.Println("using config file:", cfgFile)
+	} else {
+		log.INFO.Println("no config file found, database-only mode")
+	}
+
+	if err := viper.UnmarshalExact(conf); err != nil {
+		return fmt.Errorf("failed parsing config file: %w", err)
 	}
 
 	// user did not specify a database path
@@ -126,11 +129,9 @@ If you know what you're doing, you can skip the database check with the --ignore
 	}
 
 	// parse log levels after reading config
-	if err == nil {
-		parseLogLevels()
-	}
+	parseLogLevels()
 
-	return err
+	return nil
 }
 
 func isWritable(filePath string) bool {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -87,7 +87,7 @@ func nameValid(name string) error {
 
 func loadConfigFile(conf *globalconfig.All, checkDB bool) error {
 	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(vpr.ConfigFileNotFoundError); !ok {
+		if !errors.As(err, &vpr.ConfigFileNotFoundError{}) {
 			return fmt.Errorf("failed reading config file: %w", err)
 		}
 	}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -85,15 +85,15 @@ func nameValid(name string) error {
 }
 
 func loadConfigFile(conf *globalconfig.All, checkDB bool) error {
-	err := viper.ReadInConfig()
+	var err error
+	cfgFile := viper.ConfigFileUsed()
 
-	if cfgFile = viper.ConfigFileUsed(); cfgFile == "" {
-		return err
-	}
-
-	log.INFO.Println("using config file:", cfgFile)
-
-	if err == nil {
+	if cfgFile == "" {
+		log.INFO.Println("no config file found, database-only mode")
+	} else if err = viper.ReadInConfig(); err != nil {
+		err = fmt.Errorf("failed reading config file: %w", err)
+	} else {
+		log.INFO.Println("using config file:", cfgFile)
 		if err = viper.UnmarshalExact(conf); err != nil {
 			err = fmt.Errorf("failed parsing config file: %w", err)
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -95,7 +95,7 @@ func loadConfigFile(conf *globalconfig.All, checkDB bool) error {
 	if cfgFile := viper.ConfigFileUsed(); cfgFile != "" {
 		log.INFO.Println("using config file:", cfgFile)
 	} else {
-		log.INFO.Println("no config file found, database-only mode")
+		log.INFO.Println("config file not found, database-only mode")
 	}
 
 	if err := viper.UnmarshalExact(conf); err != nil {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/22382

Enable all CLI commands to run even if no `evcc.yaml` was found or specified.

With https://github.com/evcc-io/evcc/issues/18946 we added this behavior for the root command (starting server). Now it's applied to everything.