### PR TITLE
Amber: invert feed-in prices to match evcc expectations

### DIFF
--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -109,6 +109,11 @@ func (t *Amber) run(done chan error) {
 				if r.AdvancedPrice != nil {
 					ar.Value = r.AdvancedPrice.Predicted / 1e2
 				}
+
+				// Invert feed-in prices to match evcc expectations (positive = paid for exports)
+				if t.channel == "feedin" {
+					ar.Value = -ar.Value
+				}
 				data = append(data, ar)
 			}
 		}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/22394

The Amber API returns all prices as prices (ie what you will be charged). This logic extends into feed-in prices. 

That means a feed-in price of -14c/kWh means you will be paid 14c per kWh for exports. Amber also has "negative" exports depending on the wholesale prices, which means you're charged for exports during that time, and these are represented as positive prices (ie exactly what you'd see for import pricing.)

This makes sense from a consistency point of view, but it appears evcc expects a positive feed-in rate to represent getting paid.

This is a real example from the API, representing a 8.3c/kWh earn rate per kWh:
```
  {
    "type": "ForecastInterval",
    "date": "2025-07-17",
    "duration": 30,
    "startTime": "2025-07-16T22:30:01Z",
    "endTime": "2025-07-16T23:00:00Z",
    "nemTime": "2025-07-17T09:00:00+10:00",
    "perKwh": -8.30172,
    "renewables": 34.02689292438913,
    "spotPerKwh": 8.71696,
    "channelType": "feedIn",
    "spikeStatus": "none",
    "descriptor": "high",
    "advancedPrice": {
      "low": -7.13763,
      "predicted": -11.13379,
      "high": -14.92346
    }
  },
  ```
  
I was confused by the display of the feed-in pricing in the UI and assumed that since this was showing as positive, evcc was interpreting the values correctly. At the time I don't think evcc did anything with the feed-in price besides displaying it. But now that the relatively new "feed-in priority" feature has come about, it has become clear this is actually inverted as described in https://github.com/evcc-io/evcc/issues/22394 .
 
This PR inverts feed-in pricing (only) to match evcc's model. It's worth noting that evcc after this change will actually show the inverse in the UI to what the Amber app shows for feed-in, which may be confusing for some users. But at least the feed-in priority feature will work.