### PR TITLE
Backup Restore: clarify password

### DIFF
--- a/assets/js/components/Auth/LoginModal.vue
+++ b/assets/js/components/Auth/LoginModal.vue
@@ -11,12 +11,7 @@
 			{{ $t("loginModal.demoMode") }}
 		</div>
 		<form v-else-if="modalVisible" @submit.prevent="login">
-			<PasswordInput
-				v-model:password="password"
-				:error="error"
-				:iframe-hint="iframeHint"
-				:label="$t('loginModal.password')"
-			/>
+			<PasswordInput v-model:password="password" :error="error" :iframe-hint="iframeHint" />
 
 			<button type="submit" class="btn btn-primary w-100 mb-3" :disabled="loading">
 				<span

--- a/assets/js/components/Auth/LoginModal.vue
+++ b/assets/js/components/Auth/LoginModal.vue
@@ -11,7 +11,12 @@
 			{{ $t("loginModal.demoMode") }}
 		</div>
 		<form v-else-if="modalVisible" @submit.prevent="login">
-			<PasswordInput v-model:password="password" :error="error" :iframe-hint="iframeHint" />
+			<PasswordInput
+				v-model:password="password"
+				:error="error"
+				:iframe-hint="iframeHint"
+				:label="$t('loginModal.password')"
+			/>
 
 			<button type="submit" class="btn btn-primary w-100 mb-3" :disabled="loading">
 				<span

--- a/assets/js/components/Auth/PasswordInput.vue
+++ b/assets/js/components/Auth/PasswordInput.vue
@@ -13,6 +13,7 @@
 				class="form-control"
 				autocomplete="current-password"
 				type="password"
+				required
 				@input="updatePassword"
 			/>
 		</div>

--- a/assets/js/components/Auth/PasswordInput.vue
+++ b/assets/js/components/Auth/PasswordInput.vue
@@ -3,7 +3,7 @@
 		<div class="mb-4">
 			<label for="loginPassword" class="col-form-label">
 				<div class="w-100">
-					<span class="label">{{ $t("loginModal.password") }}</span>
+					<span class="label">{{ labelText }}</span>
 				</div>
 			</label>
 			<input
@@ -13,12 +13,11 @@
 				class="form-control"
 				autocomplete="current-password"
 				type="password"
-				:required="required"
 				@input="updatePassword"
 			/>
 		</div>
 
-		<p v-if="error" class="text-danger my-4">{{ $t("loginModal.error") }}{{ error }}</p>
+		<p v-if="error" class="text-danger my-4">{{ error }}</p>
 		<a
 			v-if="iframeHint"
 			class="text-muted my-4 d-block text-center"
@@ -39,12 +38,15 @@ export default defineComponent({
 		error: { type: String, default: "" },
 		password: { type: String, default: "" },
 		iframeHint: { type: Boolean, default: false },
-		required: { type: Boolean, default: true },
+		label: { type: String },
 	},
 	emits: ["update:password"],
 	computed: {
 		evccUrl() {
 			return window.location.href;
+		},
+		labelText() {
+			return this.label || this.$t("loginModal.password");
 		},
 	},
 	methods: {

--- a/assets/js/components/Auth/PasswordInput.vue
+++ b/assets/js/components/Auth/PasswordInput.vue
@@ -3,7 +3,7 @@
 		<div class="mb-4">
 			<label for="loginPassword" class="col-form-label">
 				<div class="w-100">
-					<span class="label">{{ labelText }}</span>
+					<span class="label">{{ $t("loginModal.password") }}</span>
 				</div>
 			</label>
 			<input
@@ -38,15 +38,11 @@ export default defineComponent({
 		error: { type: String, default: "" },
 		password: { type: String, default: "" },
 		iframeHint: { type: Boolean, default: false },
-		label: { type: String },
 	},
 	emits: ["update:password"],
 	computed: {
 		evccUrl() {
 			return window.location.href;
-		},
-		labelText() {
-			return this.label || this.$t("loginModal.password");
 		},
 	},
 	methods: {

--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -131,7 +131,6 @@
 					v-model:password="password"
 					:error="error"
 					:iframe-hint="iframeHint"
-					:label="$t('config.system.backupRestore.password')"
 				/>
 
 				<div class="d-flex justify-content-between gap-2 flex-wrap">

--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -127,10 +127,11 @@
 				</p>
 
 				<PasswordInput
+					v-if="!authDisabled"
 					v-model:password="password"
 					:error="error"
 					:iframe-hint="iframeHint"
-					:required="false"
+					:label="$t('config.system.backupRestore.password')"
 				/>
 
 				<div class="d-flex justify-content-between gap-2 flex-wrap">
@@ -180,6 +181,9 @@ const validateStatus = (code: number) => [200, 204, 401, 403].includes(code);
 export default defineComponent({
 	name: "BackupRestoreModal",
 	components: { GenericModal, PropertyFileField, FormRow, PasswordInput },
+	props: {
+		authDisabled: Boolean,
+	},
 	data() {
 		return {
 			selectedReset: {

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -373,7 +373,7 @@
 				<ModbusProxyModal @changed="yamlChanged" />
 				<CircuitsModal @changed="yamlChanged" />
 				<EebusModal @changed="yamlChanged" />
-				<BackupRestoreModal />
+				<BackupRestoreModal v-bind="backupRestoreProps" />
 			</div>
 		</div>
 	</div>
@@ -597,6 +597,11 @@ export default {
 		},
 		messagingTags() {
 			return { configured: { value: store.state?.messaging || false } };
+		},
+		backupRestoreProps() {
+			return {
+				authDisabled: store.state?.authDisabled || false,
+			};
 		},
 	},
 	watch: {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -320,6 +320,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	if ok, _ := cmd.Flags().GetBool(flagDisableAuth); ok {
 		log.WARN.Println("❗❗❗ Authentication is disabled. This is dangerous. Your data and credentials are not protected.")
 		authObject.SetAuthMode(auth.Disabled)
+		valueChan <- util.Param{Key: keys.AuthDisabled, Val: true}
 	}
 
 	if ok, _ := cmd.Flags().GetBool(flagDemoMode); ok {

--- a/core/keys/global.go
+++ b/core/keys/global.go
@@ -19,4 +19,5 @@ const (
 	Plant              = "plant"
 	Telemetry          = "telemetry"
 	DemoMode           = "demoMode"
+	AuthDisabled       = "authDisabled"
 )

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -449,6 +449,7 @@
         "cancel": "Abbrechen",
         "description": "Sichern, wiederherstellen und zurücksetzen deiner Daten. Nützlich, wenn du deine Daten auf ein anderes System übertragen möchtest.",
         "note": "Hinweis: Alle oben genannten Aktionen betreffen nur deine Datenbankdaten. Die evcc.yaml-Konfigurationsdatei bleibt unverändert.",
+        "password": "evcc Passwort",
         "reset": {
           "action": "Zurücksetzen...",
           "confirmationButton": "Zurücksetzen & Neustart",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -447,7 +447,6 @@
           "title": "Sichern"
         },
         "cancel": "Abbrechen",
-        "confirmWithPassword": "Aktion bestätigen",
         "description": "Sichern, wiederherstellen und zurücksetzen deiner Daten. Nützlich, wenn du deine Daten auf ein anderes System übertragen möchtest.",
         "note": "Hinweis: Alle oben genannten Aktionen betreffen nur deine Datenbankdaten. Die evcc.yaml-Konfigurationsdatei bleibt unverändert.",
         "reset": {
@@ -665,7 +664,6 @@
   "loginModal": {
     "cancel": "Abbrechen",
     "demoMode": "Login ist im Demo-Modus nicht verfügbar.",
-    "error": "Login fehlgeschlagen: ",
     "iframeHint": "Öffne evcc in einem neuen Tab.",
     "iframeIssue": "Das Passwort ist korrekt, aber dein Browser hat das Authentifizierungscookie abgelehnt. Dies kann passieren, wenn du evcc in einem iframe über HTTP verwendest.",
     "invalid": "Passwort ist ungültig.",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -449,7 +449,6 @@
         "cancel": "Abbrechen",
         "description": "Sichern, wiederherstellen und zurücksetzen deiner Daten. Nützlich, wenn du deine Daten auf ein anderes System übertragen möchtest.",
         "note": "Hinweis: Alle oben genannten Aktionen betreffen nur deine Datenbankdaten. Die evcc.yaml-Konfigurationsdatei bleibt unverändert.",
-        "password": "Administrator Passwort",
         "reset": {
           "action": "Zurücksetzen...",
           "confirmationButton": "Zurücksetzen & Neustart",
@@ -669,7 +668,7 @@
     "iframeIssue": "Das Passwort ist korrekt, aber dein Browser hat das Authentifizierungscookie abgelehnt. Dies kann passieren, wenn du evcc in einem iframe über HTTP verwendest.",
     "invalid": "Passwort ist ungültig.",
     "login": "Anmelden",
-    "password": "Passwort",
+    "password": "Administrator Passwort",
     "reset": "Passwort zurücksetzen?",
     "title": "Authentifizierung"
   },

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -449,7 +449,7 @@
         "cancel": "Abbrechen",
         "description": "Sichern, wiederherstellen und zurücksetzen deiner Daten. Nützlich, wenn du deine Daten auf ein anderes System übertragen möchtest.",
         "note": "Hinweis: Alle oben genannten Aktionen betreffen nur deine Datenbankdaten. Die evcc.yaml-Konfigurationsdatei bleibt unverändert.",
-        "password": "evcc Passwort",
+        "password": "Administrator Passwort",
         "reset": {
           "action": "Zurücksetzen...",
           "confirmationButton": "Zurücksetzen & Neustart",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -449,7 +449,7 @@
         "cancel": "Cancel",
         "description": "Backup, restore and reset your data. Useful if you want to move your data to another system.",
         "note": "Note: All above actions only affect your database data. The evcc.yaml configuration file remains unchanged.",
-        "password": "evcc Password",
+        "password": "Administrator Password",
         "reset": {
           "action": "Reset...",
           "confirmationButton": "Reset & restart",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -449,7 +449,6 @@
         "cancel": "Cancel",
         "description": "Backup, restore and reset your data. Useful if you want to move your data to another system.",
         "note": "Note: All above actions only affect your database data. The evcc.yaml configuration file remains unchanged.",
-        "password": "Administrator Password",
         "reset": {
           "action": "Reset...",
           "confirmationButton": "Reset & restart",
@@ -669,7 +668,7 @@
     "iframeIssue": "Your password is correct, but your browser seems to have dropped the authentication cookie. This can happen if you run evcc in an iframe via HTTP.",
     "invalid": "Password is invalid.",
     "login": "Login",
-    "password": "Password",
+    "password": "Administrator Password",
     "reset": "Reset password?",
     "title": "Authentication"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -447,9 +447,9 @@
           "title": "Backup"
         },
         "cancel": "Cancel",
-        "confirmWithPassword": "Confirm action",
         "description": "Backup, restore and reset your data. Useful if you want to move your data to another system.",
         "note": "Note: All above actions only affect your database data. The evcc.yaml configuration file remains unchanged.",
+        "password": "evcc Password",
         "reset": {
           "action": "Reset...",
           "confirmationButton": "Reset & restart",
@@ -665,7 +665,6 @@
   "loginModal": {
     "cancel": "Cancel",
     "demoMode": "Login is not supported in demo mode.",
-    "error": "Login failed: ",
     "iframeHint": "Open evcc in a new tab.",
     "iframeIssue": "Your password is correct, but your browser seems to have dropped the authentication cookie. This can happen if you run evcc in an iframe via HTTP.",
     "invalid": "Password is invalid.",

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -354,6 +354,11 @@ func logHandler(w http.ResponseWriter, r *http.Request) {
 	jsonResult(w, log)
 }
 
+// adminPasswordValid validates the admin password and returns true if valid
+func adminPasswordValid(authObject auth.Auth, password string) bool {
+	return authObject.GetAuthMode() == auth.Disabled || authObject.IsAdminPasswordValid(password)
+}
+
 func getBackup(authObject auth.Auth) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req loginRequest
@@ -362,7 +367,7 @@ func getBackup(authObject auth.Auth) http.HandlerFunc {
 			return
 		}
 
-		if authObject.GetAuthMode() == auth.Enabled && !authObject.IsAdminPasswordValid(req.Password) {
+		if !adminPasswordValid(authObject, req.Password) {
 			http.Error(w, "Invalid password", http.StatusUnauthorized)
 			return
 		}
@@ -422,7 +427,7 @@ func restoreDatabase(authObject auth.Auth, shutdown func()) http.HandlerFunc {
 			return
 		}
 
-		if authObject.GetAuthMode() == auth.Enabled && !authObject.IsAdminPasswordValid(r.FormValue("password")) {
+		if !adminPasswordValid(authObject, r.FormValue("password")) {
 			http.Error(w, "Invalid password", http.StatusUnauthorized)
 			return
 		}
@@ -479,7 +484,7 @@ func resetDatabase(authObject auth.Auth, shutdown func()) http.HandlerFunc {
 			return
 		}
 
-		if authObject.GetAuthMode() == auth.Enabled && !authObject.IsAdminPasswordValid(req.Password) {
+		if !adminPasswordValid(authObject, req.Password) {
 			http.Error(w, "Invalid password", http.StatusUnauthorized)
 			return
 		}

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -55,7 +55,7 @@ test("login", async ({ page }) => {
   // enter wrong password
   await login.getByLabel("Password").fill("wrong");
   await login.getByRole("button", { name: "Login" }).click();
-  await expect(login.getByText("Login failed: Password is invalid.")).toBeVisible();
+  await expect(login.getByText("Password is invalid.")).toBeVisible();
 
   // enter correct password
   await login.getByLabel("Password").fill("secret");

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -53,12 +53,12 @@ test("login", async ({ page }) => {
   await expect(login.getByRole("heading", { name: "Authentication" })).toBeVisible();
 
   // enter wrong password
-  await login.getByLabel("Password").fill("wrong");
+  await login.getByLabel("Administrator Password").fill("wrong");
   await login.getByRole("button", { name: "Login" }).click();
   await expect(login.getByText("Password is invalid.")).toBeVisible();
 
   // enter correct password
-  await login.getByLabel("Password").fill("secret");
+  await login.getByLabel("Administrator Password").fill("secret");
   await login.getByRole("button", { name: "Login" }).click();
   await expectModalHidden(login);
   await expect(page.getByRole("heading", { name: "Configuration" })).toBeVisible();
@@ -86,7 +86,7 @@ test("http iframe hint", async ({ page }) => {
   });
 
   // enter correct password
-  await login.getByLabel("Password").fill("secret");
+  await login.getByLabel("Administrator Password").fill("secret");
   await login.getByRole("button", { name: "Login" }).click();
 
   // iframe hint visible (login-iframe-hint)
@@ -105,7 +105,7 @@ test("update password", async ({ page }) => {
   await page.goto("/#/config");
   const loginModal = page.getByTestId("login-modal");
   await expectModalVisible(loginModal);
-  await loginModal.getByLabel("Password").fill(oldPassword);
+  await loginModal.getByLabel("Administrator Password").fill(oldPassword);
   await loginModal.getByRole("button", { name: "Login" }).click();
   await expectModalHidden(loginModal);
 
@@ -134,7 +134,7 @@ test("update password", async ({ page }) => {
   await expectTopNavigationClosed(page);
   const loginNew = page.getByTestId("login-modal");
   await expectModalVisible(loginNew);
-  await loginNew.getByLabel("Password").fill(newPassword);
+  await loginNew.getByLabel("Administrator Password").fill(newPassword);
   await loginNew.getByRole("button", { name: "Login" }).click();
   await expect(page.getByRole("heading", { name: "Configuration" })).toBeVisible();
   await expectModalHidden(loginNew);

--- a/tests/backup-restore.spec.ts
+++ b/tests/backup-restore.spec.ts
@@ -33,7 +33,7 @@ test.describe("reset", async () => {
     await modal.getByRole("button", { name: "Reset..." }).click();
     const confirmModal = page.getByTestId("backup-restore-confirm-modal");
     await expectModalVisible(confirmModal);
-    await expect(confirmModal.getByLabel("evcc Password")).not.toBeVisible(); // disable auth mode
+    await expect(confirmModal.getByLabel("Administrator Password")).not.toBeVisible(); // disable auth mode
     await confirmModal.getByRole("button", { name: "Reset & restart" }).click();
     await expectModalHidden(confirmModal);
     await expectModalHidden(modal);
@@ -88,7 +88,7 @@ test.describe("reset", async () => {
     await modal.getByRole("button", { name: "Reset..." }).click();
     const confirmModal = page.getByTestId("backup-restore-confirm-modal");
     await expectModalVisible(confirmModal);
-    await expect(confirmModal.getByLabel("evcc Password")).not.toBeVisible(); // disable auth mode
+    await expect(confirmModal.getByLabel("Administrator Password")).not.toBeVisible(); // disable auth mode
     await confirmModal.getByRole("button", { name: "Reset & restart" }).click();
     await expectModalHidden(confirmModal);
     await expectModalHidden(modal);
@@ -234,7 +234,7 @@ test.describe("backup and restore", async () => {
     await backupModal.getByRole("button", { name: "Download backup..." }).click();
     const backupConfirmModal = page.getByTestId("backup-restore-confirm-modal");
     await expectModalVisible(backupConfirmModal);
-    const passwordField = backupConfirmModal.getByLabel("evcc Password");
+    const passwordField = backupConfirmModal.getByLabel("Administrator Password");
     await expect(passwordField).toBeVisible();
     await passwordField.fill("wrongpassword");
     await backupConfirmModal.getByRole("button", { name: "Download backup" }).click();
@@ -247,7 +247,7 @@ test.describe("backup and restore", async () => {
 
     // verify backup was downloaded successfully
     const download = await downloadPromise;
-    await expect(download.suggestedFilename()).toContain("evcc-backup");
+    await expect(download.suggestedFilename()).toContain("Administrator-backup");
     await stop();
   });
 });

--- a/tests/backup-restore.spec.ts
+++ b/tests/backup-restore.spec.ts
@@ -33,6 +33,7 @@ test.describe("reset", async () => {
     await modal.getByRole("button", { name: "Reset..." }).click();
     const confirmModal = page.getByTestId("backup-restore-confirm-modal");
     await expectModalVisible(confirmModal);
+    await expect(confirmModal.getByLabel("evcc Password")).not.toBeVisible(); // disable auth mode
     await confirmModal.getByRole("button", { name: "Reset & restart" }).click();
     await expectModalHidden(confirmModal);
     await expectModalHidden(modal);
@@ -87,6 +88,7 @@ test.describe("reset", async () => {
     await modal.getByRole("button", { name: "Reset..." }).click();
     const confirmModal = page.getByTestId("backup-restore-confirm-modal");
     await expectModalVisible(confirmModal);
+    await expect(confirmModal.getByLabel("evcc Password")).not.toBeVisible(); // disable auth mode
     await confirmModal.getByRole("button", { name: "Reset & restart" }).click();
     await expectModalHidden(confirmModal);
     await expectModalHidden(modal);
@@ -232,10 +234,11 @@ test.describe("backup and restore", async () => {
     await backupModal.getByRole("button", { name: "Download backup..." }).click();
     const backupConfirmModal = page.getByTestId("backup-restore-confirm-modal");
     await expectModalVisible(backupConfirmModal);
-    const passwordField = backupConfirmModal.getByLabel("Password");
+    const passwordField = backupConfirmModal.getByLabel("evcc Password");
+    await expect(passwordField).toBeVisible();
     await passwordField.fill("wrongpassword");
     await backupConfirmModal.getByRole("button", { name: "Download backup" }).click();
-    await expect(backupConfirmModal.getByText("Login failed: Password is invalid.")).toBeVisible();
+    await expect(backupConfirmModal.getByText("Password is invalid.")).toBeVisible();
     await passwordField.clear();
     await passwordField.fill("secret");
     const downloadPromise = page.waitForEvent("download");

--- a/tests/backup-restore.spec.ts
+++ b/tests/backup-restore.spec.ts
@@ -247,7 +247,7 @@ test.describe("backup and restore", async () => {
 
     // verify backup was downloaded successfully
     const download = await downloadPromise;
-    await expect(download.suggestedFilename()).toContain("Administrator-backup");
+    await expect(download.suggestedFilename()).toContain("evcc-backup");
     await stop();
   });
 });

--- a/tests/config-onboarding.spec.ts
+++ b/tests/config-onboarding.spec.ts
@@ -32,7 +32,7 @@ test.describe("onboarding", async () => {
     // login
     const login = page.getByTestId("login-modal");
     await expectModalVisible(login);
-    await login.getByLabel("Password").fill(PASSWORD);
+    await login.getByLabel("Administrator Password").fill(PASSWORD);
     await login.getByRole("button", { name: "Login" }).click();
     await expectModalHidden(login);
 


### PR DESCRIPTION
Clarify user interface for https://github.com/evcc-io/evcc/pull/22071 to address misunderstandings as in https://github.com/evcc-io/evcc/discussions/22391

🔑 change "Password" labels in confirm dialog to "Administrator Password" to indicate that it's not a new one
❌ hide password field if auth is disabled. before it was visible but unchecked
👮 dropped confusing "Login error: " prefix for invalid confirm password entries.
🗑️ some cleanup and refactor

\cc @Maschga 