### PR TITLE
Config UI: improve residual power input field

### DIFF
--- a/assets/js/components/Config/ControlModal.vue
+++ b/assets/js/components/Config/ControlModal.vue
@@ -16,7 +16,7 @@
 				example="30 s"
 				docsLink="/docs/reference/configuration/interval"
 			>
-				<div class="input-group w-50 w-sm-25">
+				<div class="input-group input-width">
 					<input
 						id="controlInterval"
 						v-model="values.interval"
@@ -38,7 +38,7 @@
 				example="100 W"
 				docsLink="/docs/reference/configuration/site#residualpower"
 			>
-				<div class="input-group w-50 w-sm-25">
+				<div class="input-group input-width">
 					<input
 						id="controlResidualPower"
 						v-model="values.residualPower"
@@ -153,5 +153,8 @@ export default {
 	margin-left: calc(var(--bs-gutter-x) * -0.5);
 	margin-right: calc(var(--bs-gutter-x) * -0.5);
 	padding-right: 0;
+}
+.input-width {
+	width: 140px;
 }
 </style>

--- a/assets/js/components/Config/FormRow.vue
+++ b/assets/js/components/Config/FormRow.vue
@@ -20,7 +20,7 @@
 			<div v-if="example" class="hyphenate">
 				{{ $t("config.form.example") }}: {{ example }}
 			</div>
-			<div v-if="help" class="d-flex gap-1">
+			<div v-if="help">
 				<Markdown :markdown="help" class="text-gray hyphenate" />
 				<a v-if="link" class="text-gray" :href="link" target="_blank">
 					{{ $t("config.general.docsLink") }}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/22434

- ↔ fixed width fields in control dialog
- ⏎ improve wrapping of field-level docs link


<img width="582" height="666" alt="Bildschirmfoto 2025-07-18 um 16 36 42" src="https://github.com/user-attachments/assets/5124daec-0547-405b-8f90-3e839ff371ab" />
