### PR TITLE
Tariffs: add caching

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -805,7 +805,7 @@ func tariffInstance(name string, conf config.Typed) (api.Tariff, error) {
 		return nil, fmt.Errorf("cannot decode custom tariff '%s': %w", name, err)
 	}
 
-	instance, err := tariff.NewCachingProxy(ctx, conf.Type, props)
+	instance, err := tariff.NewCachedFromConfig(ctx, conf.Type, props)
 	if err != nil {
 		if ce := new(util.ConfigError); errors.As(err, &ce) {
 			return nil, err

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -805,7 +805,7 @@ func tariffInstance(name string, conf config.Typed) (api.Tariff, error) {
 		return nil, fmt.Errorf("cannot decode custom tariff '%s': %w", name, err)
 	}
 
-	instance, err := tariff.NewFromConfig(ctx, conf.Type, props)
+	instance, err := tariff.NewCachingProxy(ctx, conf.Type, props)
 	if err != nil {
 		if ce := new(util.ConfigError); errors.As(err, &ce) {
 			return nil, err

--- a/tariff/proxy.go
+++ b/tariff/proxy.go
@@ -79,7 +79,14 @@ func (p *CachingProxy) Rates() (api.Rates, error) {
 
 	p.createInstance()
 
-	return p.tariff.Rates()
+	res, err := p.tariff.Rates()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO cache the result
+
+	return res, nil
 }
 
 // Type returns the tariff type

--- a/tariff/proxy.go
+++ b/tariff/proxy.go
@@ -1,0 +1,101 @@
+package tariff
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+)
+
+// CachingProxy wraps a tariff with caching
+type CachingProxy struct {
+	log *util.Logger
+	mu  sync.Mutex
+
+	ctx    context.Context
+	typ    string
+	config map[string]any
+
+	tariff api.Tariff // Will be nil initially
+}
+
+var _ api.Tariff = (*CachingProxy)(nil)
+
+// NewCachingProxy creates a proxy that controls tariff instantiation and caching
+func NewCachingProxy(ctx context.Context, typ string, other map[string]any) (api.Tariff, error) {
+	actualTyp := typ
+	if typ == "template" {
+		if template, ok := other["template"].(string); ok {
+			actualTyp = template
+		}
+	}
+
+	// cache, hash := NewSolarCacheManager(actualTyp, other)
+
+	log := util.NewLogger(fmt.Sprintf("%s-%s", actualTyp, "hash"))
+
+	proxy := &CachingProxy{
+		log:    log,
+		ctx:    ctx,
+		typ:    typ,
+		config: other,
+	}
+
+	if false { // TODO no data
+		tariff, err := NewFromConfig(ctx, typ, other)
+		if err != nil {
+			return nil, err
+		}
+
+		proxy.tariff = tariff
+	}
+
+	return proxy, nil
+}
+
+func (p *CachingProxy) createInstance() {
+	t, err := NewFromConfig(p.ctx, p.typ, p.config)
+	if err != nil {
+		t = &proxyError{err}
+	}
+
+	p.tariff = t
+}
+
+// Rates returns cached data until underlying tariff is created, then delegates to tariff
+func (p *CachingProxy) Rates() (api.Rates, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.tariff != nil {
+		return p.tariff.Rates()
+	}
+
+	if true { // TODO get from cache
+		return api.Rates{}, nil
+	}
+
+	p.createInstance()
+
+	return p.tariff.Rates()
+}
+
+// Type returns the tariff type
+func (p *CachingProxy) Type() api.TariffType {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.tariff != nil {
+		return p.tariff.Type()
+	}
+
+	if true { // TODO get from cache
+		return 0
+	}
+
+	p.createInstance()
+
+	return p.tariff.Type()
+}

--- a/tariff/proxy_cache.go
+++ b/tariff/proxy_cache.go
@@ -1,10 +1,30 @@
 package tariff
 
 import (
+	"crypto/sha256"
+	"fmt"
+
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/server/db/settings"
 )
 
 type cached struct {
-	typ   api.TariffType
-	rates api.Rates
+	Type  api.TariffType `json:"type"`
+	Rates api.Rates      `json:"rates"`
+}
+
+func cacheKey(typ string, other map[string]any) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s-%v", typ, other))))
+}
+
+func cachePut(key string, typ api.TariffType, rates api.Rates) error {
+	return settings.SetJson(key, &cached{
+		Type:  api.TariffType(typ),
+		Rates: rates,
+	})
+}
+
+func cacheGet(key string) (*cached, error) {
+	var res cached
+	return &res, settings.Json(key, &res)
 }

--- a/tariff/proxy_cache.go
+++ b/tariff/proxy_cache.go
@@ -1,0 +1,10 @@
+package tariff
+
+import (
+	"github.com/evcc-io/evcc/api"
+)
+
+type cached struct {
+	typ   api.TariffType
+	rates api.Rates
+}

--- a/tariff/proxy_cache.go
+++ b/tariff/proxy_cache.go
@@ -19,7 +19,7 @@ func cacheKey(typ string, other map[string]any) string {
 
 func cachePut(key string, typ api.TariffType, rates api.Rates) error {
 	return settings.SetJson(key, &cached{
-		Type:  api.TariffType(typ),
+		Type:  typ,
 		Rates: rates,
 	})
 }

--- a/tariff/proxy_error.go
+++ b/tariff/proxy_error.go
@@ -1,0 +1,17 @@
+package tariff
+
+import "github.com/evcc-io/evcc/api"
+
+type proxyError struct {
+	error
+}
+
+var _ api.Tariff = (*proxyError)(nil)
+
+func (t *proxyError) Rates() (api.Rates, error) {
+	return api.Rates{}, t.error
+}
+
+func (t *proxyError) Type() api.TariffType {
+	return 0
+}

--- a/tariff/proxy_error.go
+++ b/tariff/proxy_error.go
@@ -13,5 +13,5 @@ func (t *proxyError) Rates() (api.Rates, error) {
 }
 
 func (t *proxyError) Type() api.TariffType {
-	return 0
+	return 0 // unknown
 }


### PR DESCRIPTION
Based on https://github.com/evcc-io/evcc/pull/21980

This PR adds a tariff cache. On restart, dynamic tariffs are read from cache. If cache contains enough data for next 24 hours, this data is used. Actual tariff is lazy-initialized only when cache doesn't contain enough valid data.

This fixes an issue where regular restarts run into api rate limits.

TODO

- [x] more sophisticated rules or control over when to use the cache or not