### PR TITLE
Battery boost: only elapse phase timer when running

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1349,7 +1349,11 @@ func (lp *Loadpoint) boostPower(batteryBoostPower float64) float64 {
 		delta = lp.EffectiveMaxPower()
 
 		// expire timers
-		lp.phaseTimer = elapsed
+		if !lp.phaseTimer.IsZero() {
+			// only elapse when the phase timer is active. This prevent setting it
+			// to elapsed in case the load point does not support phase switching
+			lp.phaseTimer = elapsed
+		}
 		lp.pvTimer = elapsed
 
 		if lp.charging() {


### PR DESCRIPTION
Fix #22425

- When starting battery boost, the phase timer is elapsed in https://github.com/evcc-io/evcc/blob/ba29e4c16ec50eb436fbdd34266c9f35c7755f6c/core/loadpoint.go#L1352
- When the loadpoint does not support phase switching it will not be reset to Zero when the PV mode stays active (this is only done in `setPhases`, when switching to `ModeNow` or `ModeOff`, when `minSocNotReached || plannerActive`, when `smartCostActive`, when `smartFeedInPriorityActive` or in `scalePhases`)
- This leads to a problem in `pvMaxCurrent`. When the `phaseTimer` is not Zero, it will not stop charging when the power is enough with `minCurrent` on just one phase. https://github.com/evcc-io/evcc/blob/ba29e4c16ec50eb436fbdd34266c9f35c7755f6c/core/loadpoint.go#L1405

This PR makes sure to only elapse the timer when it is running.
