### PR TITLE
Amber: use billing-native resolution, request up to 72 hours ahead

### DIFF
--- a/tariff/amber/types.go
+++ b/tariff/amber/types.go
@@ -1,6 +1,14 @@
 package amber
 
-const URI = "https://api.amber.com.au/v1/sites/%s/prices/current?next=864"
+import "fmt"
+
+const (
+	// ForecastIntervals represents 72 hours of 5-minute intervals for price forecasting
+	// This is an "up to" figure, so it should still be OK for 30-minute billing customers
+	ForecastIntervals = 864 // 72 hours * 12 intervals per hour
+)
+
+var URI = fmt.Sprintf("https://api.amber.com.au/v1/sites/%%s/prices/current?next=%d", ForecastIntervals)
 
 type AdvancedPrice struct {
 	Low       float64 `json:"low"`

--- a/tariff/amber/types.go
+++ b/tariff/amber/types.go
@@ -1,6 +1,6 @@
 package amber
 
-const URI = "https://api.amber.com.au/v1/sites/%s/prices/current?resolution=30&next=96"
+const URI = "https://api.amber.com.au/v1/sites/%s/prices/current?next=864"
 
 type AdvancedPrice struct {
 	Low       float64 `json:"low"`


### PR DESCRIPTION
Fixes https://github.com/evcc-io/evcc/issues/22521

This PR drops the `resolution` parameter, which has the effect of using whatever the site's billing interval is (for most people this will now be 5 minutes, rather than 30)

<img width="1129" height="637" alt="Screenshot 2025-07-26 at 9 20 26 pm" src="https://github.com/user-attachments/assets/42dd225f-59b1-4cce-b780-5be4684362c3" />


It will request the next 864 intervals, which for people on 5 minutes is equivalent to (5*864)/60=72 hours. Amber rarely has data this far ahead so it will return whatever it has. For people still on 30 minute billing this will likely have the same effect (but fewer intervals returned.) I have not tested this on a 30 minute billing account, as mine is 5-minute, but I see no reason this will not work.

This should improve session history pricing for those on 5 minute billing.