### PR TITLE
ac-elwa-2: add tempsource

### DIFF
--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -15,7 +15,13 @@ params:
     description:
       en: "Scale factor for power limit"
       de: "Skalierungsfaktor der Leistungsvorgabe"
+  - name: tempsource
+    default: "http"
+    description:
+      en: "Temperature source"
+      de: "Temperaturquelle"
 render: |
   type: ac-elwa-2
   {{- include "modbus" . }}
   scale: {{ .scale }}
+  tempsource: {{ .tempsource }}

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -16,7 +16,8 @@ params:
       en: "Scale factor for power limit"
       de: "Skalierungsfaktor der Leistungsvorgabe"
   - name: tempsource
-    default: "http"
+    choice: ["temp1", "temp2"]
+    default: "temp1"
     description:
       en: "Temperature source"
       de: "Temperaturquelle"

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -16,11 +16,8 @@ params:
       en: "Scale factor for power limit"
       de: "Skalierungsfaktor der Leistungsvorgabe"
   - name: tempsource
-    choice: ["temp1", "temp2"]
-    default: "temp1"
-    description:
-      en: "Temperature source"
-      de: "Temperaturquelle"
+    choice: ["1", "2"]
+    default: "1"
 render: |
   type: ac-elwa-2
   {{- include "modbus" . }}

--- a/templates/definition/meter/ac-elwa-2.yaml
+++ b/templates/definition/meter/ac-elwa-2.yaml
@@ -17,7 +17,7 @@ render: |
     uri: http://{{ .host }}/data.jsn
     jq: .power_elwa2
   soc:
-    source: {{ .tempsource }}
+    source: http
     uri: http://{{ .host }}/data.jsn
     jq: .temp{{ .tempsource }}
     scale: 0.1

--- a/templates/definition/meter/ac-elwa-2.yaml
+++ b/templates/definition/meter/ac-elwa-2.yaml
@@ -14,7 +14,7 @@ render: |
     uri: http://{{ .host }}/data.jsn
     jq: .power_elwa2
   soc:
-    source: http
+    source: {{ .tempsource }}
     uri: http://{{ .host }}/data.jsn
     jq: .temp1
     scale: 0.1

--- a/templates/definition/meter/ac-elwa-2.yaml
+++ b/templates/definition/meter/ac-elwa-2.yaml
@@ -7,6 +7,9 @@ params:
   - name: usage
     choice: ["aux"]
   - name: host
+  - name: tempsource
+    choice: ["1", "2"]
+    default: "1"
 render: |
   type: custom
   power:
@@ -16,5 +19,5 @@ render: |
   soc:
     source: {{ .tempsource }}
     uri: http://{{ .host }}/data.jsn
-    jq: .{{ .tempsource }}
+    jq: .temp{{ .tempsource }}
     scale: 0.1

--- a/templates/definition/meter/ac-elwa-2.yaml
+++ b/templates/definition/meter/ac-elwa-2.yaml
@@ -16,5 +16,5 @@ render: |
   soc:
     source: {{ .tempsource }}
     uri: http://{{ .host }}/data.jsn
-    jq: .temp1
+    jq: .{{ .tempsource }}
     scale: 0.1


### PR DESCRIPTION
This PR adds the  parameter to the  file to allow for a configurable temperature source. Fixes #22536