### PR TITLE
daheimladen-mb: fix status verification for B/C states

### DIFF
--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -175,11 +175,11 @@ func (wb *DaheimLadenMB) Status() (api.ChargeStatus, error) {
 	case 3: // Start-up State (B2)
 		return api.StatusB, nil
 	case 4: // Charging (C)
-		enabled, err := wb.Enabled()
-		if !enabled {
+		power, err := wb.CurrentPower()
+		if power == 0 {
 			return api.StatusB, err
 		}
-		return api.StatusC, nil
+		return api.StatusC, err
 	case 5: // Start-UP Fail (B2)
 		return api.StatusB, nil
 	case 6: // Session Terminated by EVSE


### PR DESCRIPTION
## Summary
- Fix status verification for daheimladen-mb charger to better distinguish between Status B and C states
- Use `CurrentPower()` instead of `Enabled()` to determine charging state
- When power is 0, return Status B; otherwise return Status C

## Background
This change addresses the status detection issue discussed in #22231. The original implementation using `Enabled()` wasn't accurately reflecting the actual charging state.

## Changes
- Modified `Status()` method in `charger/daheimladen-mb.go:175-182`
- Changed condition from checking `Enabled()` to checking `CurrentPower() == 0`
- Improved error handling by returning the error from `CurrentPower()`

## Test plan
- [ ] Test with daheimladen-mb charger in various states
- [ ] Verify Status B is returned when no power flow
- [ ] Verify Status C is returned when charging with power

Replaces #22454

🤖 Generated with [Claude Code](https://claude.ai/code)