### PR TITLE
UI: initial password modal can't be dismissed

### DIFF
--- a/assets/js/components/Auth/PasswordModal.vue
+++ b/assets/js/components/Auth/PasswordModal.vue
@@ -1,15 +1,15 @@
 <template>
 	<GenericModal
-		id="passwordModal"
+		:id="modalId"
 		ref="modal"
 		:title="title"
-		data-testid="password-modal"
-		:uncloseable="!updateMode"
+		:data-testid="dataTestId"
+		:uncloseable="isUncloseable"
 		@open="open"
 		@closed="closed"
 	>
-		<p v-if="error" class="text-danger">{{ $t("passwordModal.error") }} "{{ error.trim() }}"</p>
-		<p v-if="!updateMode" class="mb-4">{{ $t("passwordModal.description") }}</p>
+		<p v-if="error" class="text-danger">{{ $t("passwordModal.error") }} "{{ error }}"</p>
+		<p v-if="isSetupMode" class="mb-4">{{ $t("passwordModal.description") }}</p>
 		<form
 			v-if="modalVisible"
 			ref="form"
@@ -19,7 +19,7 @@
 		>
 			<!-- password manager hint -->
 			<input
-				id="username"
+				:id="formId('Username')"
 				class="d-none"
 				type="text"
 				name="username"
@@ -28,20 +28,20 @@
 			/>
 			<FormRow
 				v-if="updateMode"
-				id="passwordCurrent"
+				:id="formId('Current')"
 				:label="$t('passwordModal.labelCurrent')"
 			>
 				<input
-					id="passwordCurrent"
+					:id="formId('Current')"
 					v-model="passwordCurrent"
 					type="password"
 					class="form-control"
 					autocomplete="current-password"
 				/>
 			</FormRow>
-			<FormRow id="passwordNew" :label="$t('passwordModal.labelNew')">
+			<FormRow :id="formId('New')" :label="$t('passwordModal.labelNew')">
 				<input
-					id="passwordNew"
+					:id="formId('New')"
 					v-model="passwordNew"
 					type="password"
 					class="form-control"
@@ -52,9 +52,9 @@
 					{{ $t("passwordModal.empty") }}
 				</div>
 			</FormRow>
-			<FormRow id="passwordRepeat" :label="$t('passwordModal.labelRepeat')">
+			<FormRow :id="formId('Repeat')" :label="$t('passwordModal.labelRepeat')">
 				<input
-					id="passwordRepeat"
+					:id="formId('Repeat')"
 					ref="passwordRepeat"
 					v-model="passwordRepeat"
 					type="password"
@@ -85,17 +85,20 @@
 	</GenericModal>
 </template>
 
-<script type="ts">
+<script lang="ts">
 import GenericModal from "../Helper/GenericModal.vue";
 import FormRow from "../Helper/FormRow.vue";
 import api from "@/api";
-import { updateAuthStatus, isConfigured } from "./auth";
-import  { defineComponent } from "vue";
+import { updateAuthStatus } from "./auth";
+import { defineComponent } from "vue";
 
 export default defineComponent({
 	name: "PasswordModal",
 	components: { FormRow, GenericModal },
-	data: () => {
+	props: {
+		updateMode: Boolean,
+	},
+	data() {
 		return {
 			modalVisible: false,
 			passwordCurrent: "",
@@ -103,18 +106,27 @@ export default defineComponent({
 			passwordRepeat: "",
 			showValidation: false,
 			loading: false,
-			error: false,
+			error: "" as string,
 		};
 	},
 	computed: {
+		modalId() {
+			return this.updateMode ? "passwordUpdateModal" : "passwordSetupModal";
+		},
+		dataTestId() {
+			return this.updateMode ? "password-update-modal" : "password-setup-modal";
+		},
+		isSetupMode() {
+			return !this.updateMode;
+		},
+		isUncloseable() {
+			return !this.updateMode;
+		},
 		passwordsMatch() {
 			return this.passwordNew === this.passwordRepeat;
 		},
 		passwordEmpty() {
 			return this.passwordNew.length === 0;
-		},
-		updateMode() {
-			return isConfigured();
 		},
 		title() {
 			return this.updateMode
@@ -128,6 +140,10 @@ export default defineComponent({
 		},
 	},
 	methods: {
+		formId(name: string) {
+			const prefix = this.updateMode ? "passwordUpdate" : "passwordSetup";
+			return `${prefix}_${name}`;
+		},
 		open() {
 			this.modalVisible = true;
 		},
@@ -136,12 +152,13 @@ export default defineComponent({
 			this.passwordCurrent = "";
 			this.passwordNew = "";
 			this.passwordRepeat = "";
-			this.error = false;
+			this.error = "";
 			this.loading = false;
 			this.showValidation = false;
 		},
-		async setPassword(e) {
-			this.$refs.passwordRepeat.setCustomValidity(
+		async setPassword(e: Event) {
+			const passwordRepeatInput = this.$refs["passwordRepeat"] as HTMLInputElement;
+			passwordRepeatInput.setCustomValidity(
 				this.passwordsMatch && !this.passwordEmpty ? "" : "invalid"
 			);
 
@@ -149,14 +166,15 @@ export default defineComponent({
 			e.stopPropagation();
 			this.showValidation = true;
 
-			if (this.$refs.form.checkValidity()) {
+			const form = this.$refs["form"] as HTMLFormElement;
+			if (form.checkValidity()) {
 				await this.savePassword();
 				await updateAuthStatus();
 			}
 		},
 		async savePassword() {
 			this.loading = true;
-			this.error = null;
+			this.error = "";
 			try {
 				const data = {
 					current: this.passwordCurrent,
@@ -164,8 +182,8 @@ export default defineComponent({
 				};
 				await api.put("/auth/password", data);
 				this.loading = false;
-				this.$refs.modal?.close();
-			} catch (error) {
+				(this.$refs["modal"] as any)?.close();
+			} catch (error: any) {
 				console.error(error);
 				this.error = error.response.data;
 				this.showValidation = false;

--- a/assets/js/components/Auth/auth.ts
+++ b/assets/js/components/Auth/auth.ts
@@ -89,7 +89,7 @@ watch(
   (configured) => {
     console.log("configured", configured);
     const modal = Modal.getOrCreateInstance(
-      document.getElementById("passwordModal") as HTMLElement
+      document.getElementById("passwordSetupModal") as HTMLElement
     );
     if (configured) {
       modal.hide();

--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -12,7 +12,7 @@
 			test-id="generalconfig-password"
 			:label="$t('config.general.password')"
 			text="*******"
-			modal-id="passwordModal"
+			modal-id="passwordUpdateModal"
 		/>
 
 		<GeneralConfigEntry

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -374,6 +374,7 @@
 				<CircuitsModal @changed="yamlChanged" />
 				<EebusModal @changed="yamlChanged" />
 				<BackupRestoreModal v-bind="backupRestoreProps" />
+				<PasswordModal update-mode />
 			</div>
 		</div>
 	</div>
@@ -422,6 +423,7 @@ import VehicleModal from "../components/Config/VehicleModal.vue";
 import BackupRestoreModal from "@/components/Config/BackupRestoreModal.vue";
 import WelcomeBanner from "../components/Config/WelcomeBanner.vue";
 import ExperimentalBanner from "../components/Config/ExperimentalBanner.vue";
+import PasswordModal from "../components/Auth/PasswordModal.vue";
 
 export default {
 	name: "Config",
@@ -458,6 +460,7 @@ export default {
 		VehicleIcon,
 		VehicleModal,
 		WelcomeBanner,
+		PasswordModal,
 	},
 	mixins: [formatter, collector],
 	props: {

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -14,10 +14,16 @@ test("set initial password", async ({ page }) => {
   await start(BASIC, null, "");
   await page.goto("/");
 
-  const modal = page.getByTestId("password-modal");
+  const modal = page.getByTestId("password-setup-modal");
 
   await expectModalVisible(modal);
   await expect(modal.getByRole("heading", { name: "Set Administrator Password" })).toBeVisible();
+
+  // should not be closable via ESC or outside click
+  await page.keyboard.press("Escape");
+  await expectModalVisible(modal);
+  await page.click("body");
+  await expectModalVisible(modal);
 
   // empty password
   await modal.getByRole("button", { name: "Create Password" }).click();
@@ -111,7 +117,7 @@ test("update password", async ({ page }) => {
 
   // update password
   await page.getByTestId("generalconfig-password").getByRole("button", { name: "edit" }).click();
-  const modal = page.getByTestId("password-modal");
+  const modal = page.getByTestId("password-update-modal");
   await expectModalVisible(modal);
   await expect(modal.getByRole("heading", { name: "Update Administrator Password" })).toBeVisible();
   await modal.getByLabel("Current password").fill(oldPassword);
@@ -158,7 +164,7 @@ test("disable auth", async ({ page }) => {
   await page.goto("/");
 
   // no password modal
-  const modal = page.getByTestId("password-modal");
+  const modal = page.getByTestId("password-setup-modal");
   await expectModalHidden(modal);
 
   // configuration page without login

--- a/tests/config-onboarding.spec.ts
+++ b/tests/config-onboarding.spec.ts
@@ -18,7 +18,7 @@ test.describe("onboarding", async () => {
     await page.goto("/");
 
     // set admin password
-    const admin = page.getByTestId("password-modal");
+    const admin = page.getByTestId("password-setup-modal");
     await expectModalVisible(admin);
     await admin.getByLabel("New password").fill(PASSWORD);
     await admin.getByLabel("Repeat password").fill(PASSWORD);

--- a/tests/demo.spec.ts
+++ b/tests/demo.spec.ts
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe("demo mode", async () => {
   test("no admin password prompt", async ({ page }) => {
-    await expectModalHidden(page.getByTestId("password-modal"));
+    await expectModalHidden(page.getByTestId("password-setup-modal"));
   });
 
   test("site title", async ({ page }) => {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/22484

The `unclosable` modal mechanism was not reliable when modal instances are reused (create password vs update password). Thats why the close button was hidden, but dismissing the modal via ESC or outside click still worked.

👬 create dedicated instances for creating and updating password