### PR TITLE
Add PV usage support to Janitza meter template

### DIFF
--- a/templates/definition/meter/janitza.yaml
+++ b/templates/definition/meter/janitza.yaml
@@ -8,7 +8,7 @@ products:
       generic: UMG series
 params:
   - name: usage
-    choice: ["grid", "charge"]
+    choice: ["grid", "pv", "charge"]
   - name: modbus
     choice: ["rs485", "tcpip"]
 render: |


### PR DESCRIPTION
## Summary
- Adds "pv" option to usage choices for Janitza UMG/B series meters
- Allows Janitza meters to be used as PV production meters
- Existing grid and charge usage options remain unchanged

## Changes
- Updated usage parameter in `templates/definition/meter/janitza.yaml`
- Added "pv" to the choice array: `["grid", "pv", "charge"]`

## Test plan
- [x] Template updated with new PV usage option
- [ ] Test with actual Janitza UMG meter configured as PV meter (requires user hardware)

Fixes #22584

🤖 Generated with [Claude Code](https://claude.ai/code)