### PR TITLE
Move telemetry reading to state alignment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,6 +204,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 	var site *core.Site
 	if err == nil {
 		site, err = configureSiteAndLoadpoints(&conf)
+		if site != nil {
+			telemetry.SetSiteAPI(site)
+		}
 	}
 
 	// setup influx

--- a/core/site.go
+++ b/core/site.go
@@ -325,7 +325,7 @@ func (site *Site) restoreSettings() error {
 		site.SetBatteryGridChargeLimit(&v)
 	}
 	if v, err := settings.Bool(keys.Telemetry); err == nil {
-		site.telemetryEnabled = v
+		site.SetTelemetryEnabled(v)
 		site.publish(keys.Telemetry, v)
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -93,6 +93,9 @@ type Site struct {
 	batteryDischargeControl bool     // prevent battery discharge for fast and planned charging
 	batteryGridChargeLimit  *float64 // grid charging limit
 
+	// telemetry settings
+	telemetryEnabled bool // telemetry enabled state
+
 	loadpoints  []*Loadpoint             // Loadpoints
 	tariffs     *tariff.Tariffs          // Tariffs
 	coordinator *coordinator.Coordinator // Vehicles
@@ -320,6 +323,10 @@ func (site *Site) restoreSettings() error {
 	}
 	if v, err := settings.Float(keys.BatteryGridChargeLimit); err == nil {
 		site.SetBatteryGridChargeLimit(&v)
+	}
+	if v, err := settings.Bool(keys.Telemetry); err == nil {
+		site.telemetryEnabled = v
+		site.publish(keys.Telemetry, v)
 	}
 
 	// restore accumulated energy

--- a/core/site/api.go
+++ b/core/site/api.go
@@ -76,4 +76,13 @@ type API interface {
 	GetBatteryModeExternal() api.BatteryMode
 	// SetBatteryModeExternal sets the external battery mode
 	SetBatteryModeExternal(api.BatteryMode)
+
+	//
+	// telemetry
+	//
+
+	// TelemetryEnabled returns the telemetry enabled state
+	TelemetryEnabled() bool
+	// SetTelemetryEnabled sets the telemetry enabled state
+	SetTelemetryEnabled(bool) error
 }

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -337,6 +337,29 @@ func (site *Site) SetBatteryGridChargeLimit(val *float64) {
 	}
 }
 
+// TelemetryEnabled returns the telemetry enabled state
+func (site *Site) TelemetryEnabled() bool {
+	site.RLock()
+	defer site.RUnlock()
+	return site.telemetryEnabled
+}
+
+// SetTelemetryEnabled sets the telemetry enabled state
+func (site *Site) SetTelemetryEnabled(val bool) error {
+	site.log.DEBUG.Println("set telemetry enabled:", val)
+
+	site.Lock()
+	defer site.Unlock()
+
+	if site.telemetryEnabled != val {
+		site.telemetryEnabled = val
+		settings.SetBool(keys.Telemetry, val)
+		site.publish(keys.Telemetry, val)
+	}
+
+	return nil
+}
+
 // GetBatteryMode returns the battery mode
 func (site *Site) GetBatteryMode() api.BatteryMode {
 	site.RLock()

--- a/util/telemetry/charge.go
+++ b/util/telemetry/charge.go
@@ -35,7 +35,7 @@ type TelemetryProvider interface {
 }
 
 func Enabled() bool {
-	enabled := false
+	var enabled bool
 	if siteAPI != nil {
 		enabled = siteAPI.TelemetryEnabled()
 	} else {


### PR DESCRIPTION
Fixes #22188

## Summary
- Moves telemetry configuration reading from direct database access to the state system
- Aligns telemetry handling with other settings like battery discharge control
- Makes telemetry state available via the `/state` API endpoint

## Changes
- Add `telemetryEnabled` field to Site struct and restore on startup
- Publish telemetry state changes via `site.publish()` 
- Update telemetry package to use site API instead of direct database access with fallback
- Add `TelemetryEnabled()`/`SetTelemetryEnabled()` methods to site API
- Register site with telemetry package during initialization

**Todos**

- [ ] Verify telemetry setting appears in `/state` API response
- [ ] Test telemetry enable/disable functionality
- [ ] Confirm backwards compatibility with fallback to database access
- [ ] Remove GET /telemetry endpoint (BC, but non severe) @andig 
- [ ] Update UI @naltatis 


🤖 Generated with [Claude Code](https://claude.ai/code)