### PR TITLE
chore: mention evcc config in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -38,7 +38,7 @@ body:
       label: Configuration details
       render: yaml
       description: >
-        Show evcc configuration file <code>evcc.yaml</code>
+        Show evcc configuration file <code>evcc.yaml</code> and when using Config UI the output of `evcc config`
 
         Please make sure your report does NOT contain **passwords**, **sponsor token** or other **credentials**!
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -38,7 +38,7 @@ body:
       label: Configuration details
       render: yaml
       description: >
-        Show evcc configuration file <code>evcc.yaml</code> and when using Config UI the output of `evcc config`
+        Show evcc configuration file <code>evcc.yaml</code> and if using Config UI the output of `evcc config`
 
         Please make sure your report does NOT contain **passwords**, **sponsor token** or other **credentials**!
 


### PR DESCRIPTION
Leider gibt es in letzter Zeit öfter Issue Reports wo nur "UI based config" öa in der Config steht.