### PR TITLE
Config UI: status fallback

### DIFF
--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -76,7 +76,7 @@ export default {
 				case "phasePowers":
 					return value.map((v) => this.fmtW(v, POWER_UNIT.KW, false)).join(" · ") + " kW";
 				case "chargeStatus":
-					return this.$t(`config.deviceValue.chargeStatus${value}`);
+					return this.$t(`config.deviceValue.chargeStatus${value || "F"}`);
 				case "gridPrice":
 				case "feedinPrice":
 					return this.fmtPricePerKWh(value, options.currency, true);


### PR DESCRIPTION
Use `F` as fallback when charger status disappears (e.g. ocpp client disconnected).