### PR TITLE
E3DC: fix auth errors

### DIFF
--- a/meter/e3dc.go
+++ b/meter/e3dc.go
@@ -21,6 +21,7 @@ type E3dc struct {
 	dischargeLimit uint32
 	usage          templates.Usage // TODO check if we really want to depend on templates
 	conn           *rscp.Client
+	cfg            rscp.ClientConfig // Try Workaround: configuration for the rscp client for workaround reconnecting
 }
 
 func init() {
@@ -87,6 +88,7 @@ func NewE3dc(cfg rscp.ClientConfig, usage templates.Usage, dischargeLimit uint32
 		usage:          usage,
 		conn:           conn,
 		dischargeLimit: dischargeLimit,
+		cfg:            cfg,
 	}
 
 	// decorate battery
@@ -114,6 +116,7 @@ func (m *E3dc) CurrentPower() (float64, error) {
 		res, err := m.conn.Send(*rscp.NewMessage(rscp.EMS_REQ_POWER_GRID, nil))
 		if err != nil {
 			m.conn.Disconnect()
+			m.conn, _ = rscp.NewClient(m.cfg) // Try Workaround:  because reconnecting with the old client does not work
 			return 0, err
 		}
 		return rscpValue(*res, cast.ToFloat64E)
@@ -125,6 +128,7 @@ func (m *E3dc) CurrentPower() (float64, error) {
 		})
 		if err != nil {
 			m.conn.Disconnect()
+			m.conn, _ = rscp.NewClient(m.cfg) // Try Workaround:  because reconnecting with the old client does not work
 			return 0, err
 		}
 
@@ -139,6 +143,7 @@ func (m *E3dc) CurrentPower() (float64, error) {
 		res, err := m.conn.Send(*rscp.NewMessage(rscp.EMS_REQ_POWER_BAT, nil))
 		if err != nil {
 			m.conn.Disconnect()
+			m.conn, _ = rscp.NewClient(m.cfg) // Try Workaround:  because reconnecting with the old client does not work
 			return 0, err
 		}
 		pwr, err := rscpValue(*res, cast.ToFloat64E)
@@ -160,6 +165,7 @@ func (m *E3dc) batterySoc() (float64, error) {
 	res, err := m.conn.Send(*rscp.NewMessage(rscp.EMS_REQ_BAT_SOC, nil))
 	if err != nil {
 		m.conn.Disconnect()
+		m.conn, _ = rscp.NewClient(m.cfg) // Try Workaround:  because reconnecting with the old client does not work
 		return 0, err
 	}
 
@@ -200,6 +206,7 @@ func (m *E3dc) setBatteryMode(mode api.BatteryMode) error {
 
 	if err != nil {
 		m.conn.Disconnect()
+		m.conn, _ = rscp.NewClient(m.cfg) // Try Workaround:  because reconnecting with the old client does not work
 	} else {
 		err = rscpError(res...)
 	}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/21475

When a network i/o error occrus, rscp lib returns an error. 
e3dc.go the does a disconnect and the next message internally do reconnect and auth again, but this is not working.

To check if this misbehavoir is tied to the rscp.Client, try to create a new Client after m.conn.Disconnet() is called

Working on https://github.com/evcc-io/evcc/issues/21475