### PR TITLE
Add dedicated db cache table

### DIFF
--- a/cmd/cache-clear.go
+++ b/cmd/cache-clear.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/evcc-io/evcc/server/db/cache"
+	"github.com/spf13/cobra"
+)
+
+// cacheClearCmd represents the cache clear command
+var cacheClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Clear all cache entries",
+	Run:   runCacheClear,
+}
+
+func init() {
+	cacheCmd.AddCommand(cacheClearCmd)
+	cacheClearCmd.Flags().BoolP(flagForce, "f", false, "Force (no confirmation)")
+}
+
+func runCacheClear(cmd *cobra.Command, args []string) {
+	// load config
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	// setup persistence
+	if err := configureDatabase(conf.Database); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	confirmation, _ := cmd.Flags().GetBool(flagForce)
+	if !confirmation {
+		prompt := &survey.Confirm{
+			Message: "Clear all cache entries",
+		}
+
+		if err := survey.AskOne(prompt, &confirmation); err != nil {
+			log.FATAL.Fatal(err)
+		}
+	}
+
+	if confirmation {
+		if err := cache.Clear(); err != nil {
+			log.FATAL.Fatal(err)
+		}
+		log.INFO.Println("Cache cleared successfully")
+	}
+
+	// wait for shutdown
+	<-shutdownDoneC()
+}

--- a/cmd/cache-get.go
+++ b/cmd/cache-get.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/evcc-io/evcc/server/db/cache"
+	"github.com/spf13/cobra"
+)
+
+// cacheGetCmd represents the cache get command
+var cacheGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get cache entries",
+	Run:   runCacheGet,
+	Args:  cobra.MaximumNArgs(1),
+}
+
+func init() {
+	cacheCmd.AddCommand(cacheGetCmd)
+}
+
+func runCacheGet(cmd *cobra.Command, args []string) {
+	// load config
+	if err := loadConfigFile(&conf, !cmd.Flag(flagIgnoreDatabase).Changed); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	// setup persistence
+	if err := configureDatabase(conf.Database); err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	var re *regexp.Regexp
+	if len(args) > 0 {
+		re = regexp.MustCompile(args[0])
+	}
+
+	entries, err := cache.All()
+	if err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	for _, entry := range entries {
+		if re != nil && !re.MatchString(entry.Key) {
+			continue
+		}
+
+		fmt.Printf("%s:\n", entry.Key)
+		fmt.Println(entry.Value)
+		fmt.Println("---")
+	}
+}

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// cacheCmd represents the cache command
+var cacheCmd = &cobra.Command{
+	Use:   "cache",
+	Short: "Manage cache entries",
+}
+
+func init() {
+	rootCmd.AddCommand(cacheCmd)
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/server/db/cache"
 	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/evcc-io/evcc/server/modbus"
@@ -585,6 +586,10 @@ func configureDatabase(conf globalconfig.DB) error {
 	}
 
 	if err := settings.Init(); err != nil {
+		return err
+	}
+
+	if err := cache.Init(); err != nil {
 		return err
 	}
 

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -457,7 +457,7 @@
           "sessions": "Ladevorgänge",
           "sessionsDescription": "Löscht den Verlauf deiner Ladevorgänge.",
           "settings": "Konfiguration & Einstellungen",
-          "settingsDescription": "Löscht alle konfigurierten Geräte, Dienste, Pläne, usw.",
+          "settingsDescription": "Löscht alle konfigurierten Geräte, Dienste, Pläne, Caches, usw.",
           "title": "Zurücksetzen"
         },
         "restore": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -457,7 +457,7 @@
           "sessions": "Charging sessions",
           "sessionsDescription": "Deletes your charging session history.",
           "settings": "Configuration & settings",
-          "settingsDescription": "Deletes all configured devices, services, plans, etc.",
+          "settingsDescription": "Deletes all configured devices, services, plans, caches, etc.",
           "title": "Reset"
         },
         "restore": {

--- a/server/db/cache/cache.go
+++ b/server/db/cache/cache.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/evcc-io/evcc/server/db"
+	"gorm.io/gorm"
+)
+
+var ErrNotFound = errors.New("cache entry not found")
+
+type cache struct {
+	Key   string `json:"key" gorm:"primarykey"`
+	Value string `json:"value"`
+}
+
+func Init() error {
+	return db.Instance.AutoMigrate(new(cache))
+}
+
+func Put(key string, value interface{}) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	return db.Instance.Save(&cache{
+		Key:   key,
+		Value: string(data),
+	}).Error
+}
+
+func Get(key string, result interface{}) error {
+	var cacheEntry cache
+
+	err := db.Instance.First(&cacheEntry, "key = ?", key).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	return json.Unmarshal([]byte(cacheEntry.Value), result)
+}

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -505,20 +505,13 @@ func resetDatabase(authObject auth.Auth, shutdown func()) http.HandlerFunc {
 		}
 
 		if req.Settings {
-			query := db.Instance.Exec("DELETE FROM settings")
-			if query.Error != nil {
-				jsonError(w, http.StatusInternalServerError, query.Error)
-				return
-			}
-			query = db.Instance.Exec("DELETE FROM configs")
-			if query.Error != nil {
-				jsonError(w, http.StatusInternalServerError, query.Error)
-				return
-			}
-			query = db.Instance.Exec("DELETE FROM caches")
-			if query.Error != nil {
-				jsonError(w, http.StatusInternalServerError, query.Error)
-				return
+			tables := []string{"settings", "configs", "caches", "meters"}
+
+			for _, table := range tables {
+				if err := db.Instance.Exec("DELETE FROM " + table).Error; err != nil {
+					jsonError(w, http.StatusInternalServerError, err)
+					return
+				}
 			}
 		}
 

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -515,6 +515,11 @@ func resetDatabase(authObject auth.Auth, shutdown func()) http.HandlerFunc {
 				jsonError(w, http.StatusInternalServerError, query.Error)
 				return
 			}
+			query = db.Instance.Exec("DELETE FROM caches")
+			if query.Error != nil {
+				jsonError(w, http.StatusInternalServerError, query.Error)
+				return
+			}
 		}
 
 		// close db connection to avoid on-shutdown writes

--- a/tariff/proxy_cache.go
+++ b/tariff/proxy_cache.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/server/db/cache"
 )
 
 type cached struct {
@@ -18,7 +18,7 @@ func cacheKey(typ string, other map[string]any) string {
 }
 
 func cachePut(key string, typ api.TariffType, rates api.Rates) error {
-	return settings.SetJson(key, &cached{
+	return cache.Put(key, &cached{
 		Type:  typ,
 		Rates: rates,
 	})
@@ -26,5 +26,5 @@ func cachePut(key string, typ api.TariffType, rates api.Rates) error {
 
 func cacheGet(key string) (*cached, error) {
 	var res cached
-	return &res, settings.Json(key, &res)
+	return &res, cache.Get(key, &res)
 }


### PR DESCRIPTION
see https://github.com/evcc-io/evcc/pull/22446#discussion_r2246992938

Introduces a dedicated `cache` key/value table to separate important data from ephemeral data.

- 💸 use cache for tariffs
- 🗑️ clear `caches` and `meters` on user reset

**Possible future extensions:**

- per-entry expiry mechanism
- regular cleanup call based on interval or cache-size