### PR TITLE
Migrate telemetry state to publishing (BC)

### DIFF
--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -87,7 +87,7 @@ export default {
 	},
 	computed: {
 		telemetryEnabled() {
-			return settings.telemetry === true;
+			return store.state?.telemetry === true;
 		},
 		hiddenFeatures() {
 			return settings.hiddenFeatures === true;

--- a/assets/js/components/GlobalSettings/GlobalSettingsModal.vue
+++ b/assets/js/components/GlobalSettings/GlobalSettingsModal.vue
@@ -4,7 +4,7 @@
 		:title="$t('settings.title')"
 		data-testid="global-settings-modal"
 	>
-		<UserInterfaceSettings :sponsor="sponsor" />
+		<UserInterfaceSettings :sponsor="sponsor" :telemetry="telemetry" />
 	</GenericModal>
 </template>
 
@@ -19,6 +19,7 @@ export default defineComponent({
 	components: { GenericModal, UserInterfaceSettings },
 	props: {
 		sponsor: { type: Object as PropType<Sponsor>, default: () => ({}) },
+		telemetry: Boolean,
 	},
 });
 </script>

--- a/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
+++ b/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
@@ -58,7 +58,11 @@
 			/>
 		</FormRow>
 		<FormRow id="telemetryEnabled" :label="$t('settings.telemetry.label')">
-			<TelemetrySettings :sponsorActive="sponsor && !!sponsor.name" class="mt-1 mb-0" />
+			<TelemetrySettings
+				:sponsorActive="sponsor && !!sponsor.name"
+				:telemetry="telemetry"
+				class="mt-1 mb-0"
+			/>
 		</FormRow>
 		<FormRow id="hiddenFeaturesEnabled" :label="`${$t('settings.hiddenFeatures.label')} 🧪`">
 			<div class="form-check form-switch my-1">
@@ -116,6 +120,7 @@ export default defineComponent({
 	components: { TelemetrySettings, FormRow, SelectGroup },
 	props: {
 		sponsor: Object as PropType<Sponsor>,
+		telemetry: Boolean,
 	},
 	data() {
 		return {

--- a/assets/js/components/Savings/Savings.vue
+++ b/assets/js/components/Savings/Savings.vue
@@ -190,7 +190,10 @@
 							</div>
 							<div v-else class="my-4">
 								<LiveCommunity />
-								<TelemetrySettings :sponsorActive="!!sponsor?.name" />
+								<TelemetrySettings
+									:sponsorActive="!!sponsor?.name"
+									:telemetry="telemetry"
+								/>
 							</div>
 							<Sponsor v-bind="sponsor" />
 						</div>
@@ -226,6 +229,7 @@ export default defineComponent({
 		co2Configured: Boolean,
 		sponsor: Object as PropType<SponsorType>,
 		currency: String as PropType<CURRENCY>,
+		telemetry: Boolean,
 	},
 	data() {
 		return {

--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -153,6 +153,7 @@ export default defineComponent({
 		smartFeedInPriorityAvailable: Boolean,
 		fatal: Object,
 		forecast: Object as PropType<Forecast>,
+		telemetry: Boolean,
 	},
 	computed: {
 		batteryConfigured() {
@@ -216,6 +217,7 @@ export default defineComponent({
 					co2Configured: this.tariffCo2 !== undefined,
 					priceConfigured: this.tariffGrid !== undefined,
 					currency: this.currency,
+					telemetry: this.telemetry,
 				},
 			};
 		},

--- a/assets/js/components/TelemetrySettings.vue
+++ b/assets/js/components/TelemetrySettings.vue
@@ -3,7 +3,7 @@
 	<div class="form-check form-switch my-3">
 		<input
 			id="telemetryEnabled"
-			:checked="enabled"
+			:checked="telemetry"
 			class="form-check-input"
 			type="checkbox"
 			role="switch"
@@ -34,7 +34,6 @@
 import { defineComponent } from "vue";
 import api from "../api";
 import { docsPrefix } from "../i18n";
-import settings from "@/settings.ts";
 import type { AxiosError } from "axios";
 
 function parseMarkdown(markdownText: string) {
@@ -47,52 +46,27 @@ function parseMarkdown(markdownText: string) {
 
 export default defineComponent({
 	name: "TelemetrySettings",
-	props: { sponsorActive: Boolean },
+	props: { sponsorActive: Boolean, telemetry: Boolean },
 	data() {
 		return {
 			error: null as string | null,
 		};
 	},
 	computed: {
-		enabled() {
-			return !!settings.telemetry;
-		},
 		docsLink() {
 			return `${docsPrefix()}/docs/faq#telemetry`;
 		},
-	},
-	async mounted() {
-		await this.update();
 	},
 	methods: {
 		async change(e: Event) {
 			try {
 				this.error = null;
-				const response = await api.post(
-					`settings/telemetry/${(e.target as HTMLInputElement).checked}`
-				);
-				settings.telemetry = response.data.result;
+				await api.post(`settings/telemetry/${(e.target as HTMLInputElement).checked}`);
 			} catch (err) {
 				const e = err as AxiosError<{ error: string }>;
 				if (e.response) {
 					this.error = parseMarkdown("**Error:** " + e.response.data.error);
-					settings.telemetry = false;
 				}
-			}
-		},
-		async update() {
-			if (settings.telemetry !== null) {
-				return;
-			}
-			try {
-				const response = await api.get("settings/telemetry", {
-					validateStatus: () => true,
-				});
-				if (response.status === 200) {
-					settings.telemetry = response.data.result;
-				}
-			} catch (err) {
-				console.error(err);
 			}
 		},
 	},

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -58,7 +58,6 @@ function saveArray(key: string) {
 }
 
 export interface Settings {
-  telemetry: boolean | null; // status is unknown on start
   locale: keyof typeof LOCALES | null;
   theme: THEME | null;
   unit: string;
@@ -78,7 +77,6 @@ export interface Settings {
 }
 
 const settings: Settings = reactive({
-  telemetry: null,
   locale: read(SETTINGS_LOCALE),
   theme: read(SETTINGS_THEME),
   unit: read(SETTINGS_UNIT),

--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -273,3 +273,6 @@ tariffs:
     template: demo-co2-forecast
     base: 350
     variation: 0.4
+
+# trial token, valid until 2025-08-12
+sponsortoken: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJldmNjLmlvIiwic3ViIjoidHJpYWwiLCJleHAiOjE3NTQ5OTI4MDAsImlhdCI6MTc1MzY5NjgwMCwic3BlIjp0cnVlLCJzcmMiOiJtYSJ9.XKa5DHT-icCM9awcX4eS8feW0J_KIjsx2IxjcRRQOcQ

--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -273,6 +273,3 @@ tariffs:
     template: demo-co2-forecast
     base: 350
     variation: 0.4
-
-# trial token, valid until 2025-08-12
-sponsortoken: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJldmNjLmlvIiwic3ViIjoidHJpYWwiLCJleHAiOjE3NTQ5OTI4MDAsImlhdCI6MTc1MzY5NjgwMCwic3BlIjp0cnVlLCJzcmMiOiJtYSJ9.XKa5DHT-icCM9awcX4eS8feW0J_KIjsx2IxjcRRQOcQ

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -189,7 +189,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 	// setup telemetry
 	if err == nil {
-		telemetry.Create(conf.Plant)
+		telemetry.Create(conf.Plant, valueChan)
 		if conf.Telemetry {
 			err = telemetry.Enable(true)
 		}

--- a/server/http.go
+++ b/server/http.go
@@ -154,7 +154,6 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API, valueChan chan<- util.Param)
 		"sessions":                {"GET", "/sessions", sessionHandler},
 		"updatesession":           {"PUT", "/session/{id:[0-9]+}", updateSessionHandler},
 		"deletesession":           {"DELETE", "/session/{id:[0-9]+}", deleteSessionHandler},
-		"telemetry":               {"GET", "/settings/telemetry", getHandler(telemetry.Enabled)},
 		"telemetry2":              {"POST", "/settings/telemetry/{value:[01truefalse]+}", boolHandler(telemetry.Enable, telemetry.Enabled)},
 	}
 


### PR DESCRIPTION
replaces https://github.com/evcc-io/evcc/pull/22588
fixes https://github.com/evcc-io/evcc/issues/22188

Replace `GET /telemetry` endpoint with state publishing. Updated UI accordingly.

**Breaking Change**
Removed endpoint `GET /telemetry`. Value can now be queried via `GET /state?jq=.telemetry`.