### PR TITLE
UI: layout stability status timer

### DIFF
--- a/assets/js/components/Vehicles/Status.vue
+++ b/assets/js/components/Vehicles/Status.vue
@@ -18,6 +18,7 @@
 				:data-testid="item.testId"
 				:class="item.itemClass"
 				:clickable="item.clickable"
+				:tabular="item.tabular"
 				@click="item.clickHandler"
 			>
 				<!-- items with complex content -->
@@ -224,6 +225,7 @@ export default defineComponent({
 					tooltipContent: this.pvAction === "enable" ? t("pvEnable") : t("pvDisable"),
 					iconComponent: this.pvAction === "enable" ? SunUpIcon : SunDownIcon,
 					testId: "vehicle-status-pvtimer",
+					tabular: true,
 				},
 				{
 					id: "phaseTimer",
@@ -233,6 +235,7 @@ export default defineComponent({
 					iconComponent: "shopicon-regular-angledoublerightsmall",
 					iconClass: this.phaseAction === "scale1p" ? "phaseUp" : "phaseDown",
 					testId: "vehicle-status-phasetimer",
+					tabular: true,
 				},
 				{
 					id: "tempLimit",

--- a/assets/js/components/Vehicles/StatusItem.vue
+++ b/assets/js/components/Vehicles/StatusItem.vue
@@ -1,7 +1,7 @@
 <template>
 	<button v-if="clickable" type="button" class="entry" @click="handleClick">
 		<component :is="iconComponent" v-if="iconComponent" :class="iconClass" />
-		<div v-if="hasContent">
+		<div v-if="hasContent" :class="{ tabular }">
 			<slot>
 				{{ content }}
 			</slot>
@@ -9,7 +9,7 @@
 	</button>
 	<div v-else class="entry">
 		<component :is="iconComponent" v-if="iconComponent" :class="iconClass" />
-		<div v-if="hasContent">
+		<div v-if="hasContent" :class="{ tabular }">
 			<slot>
 				{{ content }}
 			</slot>
@@ -29,6 +29,7 @@ export default defineComponent({
 		iconComponent: { type: [String, Object], default: null },
 		iconClass: { type: String, default: "" },
 		clickable: { type: Boolean, default: false },
+		tabular: { type: Boolean, default: false },
 	},
 	emits: ["click"],
 	data() {
@@ -103,5 +104,8 @@ export default defineComponent({
 
 .phaseDown {
 	transform: rotate(-90deg);
+}
+.tabular {
+	font-variant-numeric: tabular-nums;
 }
 </style>


### PR DESCRIPTION
Use tabular number font mode for timer to avoid jumping icon left to the timer.

[timer.webm](https://github.com/user-attachments/assets/0e8183fd-e676-46b7-a2c6-72ad515148d9)

Tradeoff: Tabular numbers look a little different (especial 1). In this case the inconsistency is acceptable in favor to layout stability.