### PR TITLE
Fix Hyundai/Kia EU authentication

### DIFF
--- a/vehicle/bluelink.go
+++ b/vehicle/bluelink.go
@@ -29,8 +29,8 @@ func NewHyundaiFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		BasicToken:        "NmQ0NzdjMzgtM2NhNC00Y2YzLTk1NTctMmExOTI5YTk0NjU0OktVeTQ5WHhQekxwTHVvSzB4aEJDNzdXNlZYaG10UVI5aVFobUlGampvWTRJcHhzVg==",
 		CCSPServiceID:     "6d477c38-3ca4-4cf3-9557-2a1929a94654",
 		CCSPApplicationID: bluelink.HyundaiAppID,
-		AuthClientID:      "64621b96-0f0d-11ec-82a8-0242ac130003",
-		BrandAuthUrl:      "https://eu-account.hyundai.com/auth/realms/euhyundaiidm/protocol/openid-connect/auth?client_id=%s&scope=openid+profile+email+phone&response_type=code&hkid_session_reset=true&redirect_uri=%s/api/v1/user/integration/redirect/login&ui_locales=%s&state=%s:%s",
+		AuthClientID:      "6d477c38-3ca4-4cf3-9557-2a1929a94654",
+		BrandAuthUrl:      "https://idpconnect-eu.hyundai.com/oauth2/authorize?client_id=%s&response_type=code&redirect_uri=%s/api/v1/user/oauth2/redirect&state=ccsp",
 		PushType:          "GCM",
 		Cfb:               "RFtoRq/vDXJmRndoZaZQyfOot7OrIqGVFj96iY2WL3yyH5Z/pUvlUhqmCxD2t+D65SQ=",
 	}
@@ -45,8 +45,8 @@ func NewKiaFromConfig(other map[string]interface{}) (api.Vehicle, error) {
 		BasicToken:        "ZmRjODVjMDAtMGEyZi00YzY0LWJjYjQtMmNmYjE1MDA3MzBhOnNlY3JldA==",
 		CCSPServiceID:     "fdc85c00-0a2f-4c64-bcb4-2cfb1500730a",
 		CCSPApplicationID: bluelink.KiaAppID,
-		AuthClientID:      "572e0304-5f8d-4b4c-9dd5-41aa84eed160",
-		BrandAuthUrl:      "https://eu-account.kia.com/auth/realms/eukiaidm/protocol/openid-connect/auth?client_id=%s&scope=openid+profile+email+phone&response_type=code&hkid_session_reset=true&redirect_uri=%s/api/v1/user/integration/redirect/login&ui_locales=%s&state=%s:%s",
+		AuthClientID:      "fdc85c00-0a2f-4c64-bcb4-2cfb1500730a",
+		BrandAuthUrl:      "https://idpconnect-eu.kia.com/oauth2/authorize?client_id=%s&response_type=code&redirect_uri=%s/api/v1/user/oauth2/redirect&state=ccsp",
 		PushType:          "APNS",
 		Cfb:               "wLTVxwidmH8CfJYBWSnHD6E0huk0ozdiuygB4hLkM5XCgzAL1Dk5sE36d/bx5PFMbZs=",
 	}


### PR DESCRIPTION
## Summary
- Update EU authentication URLs from `eu-account.*` to `idpconnect-eu.*`
- Update client IDs for both Hyundai and Kia EU regions
- Simplify OAuth2 flow based on August 2025 upstream fixes

## Test plan
- [ ] Test Hyundai EU authentication
- [ ] Test Kia EU authentication

🤖 Generated with [Claude Code](https://claude.ai/code)