### PR TITLE
support for state sensors already providing a valid evcc state code

### DIFF
--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -214,17 +214,17 @@ func (v *HomeAssistant) getTimeSensor(entity string) (time.Time, error) {
 // status returns evcc charge status (optional, private)
 func (v *HomeAssistant) status(sensor string) (api.ChargeStatus, error) {
 	var haStatusMap = map[string]api.ChargeStatus{
-		"c":				   api.StatusC,
+		"c":                   api.StatusC,
 		"charging":            api.StatusC,
 		"on":                  api.StatusC,
 		"true":                api.StatusC,
 		"active":              api.StatusC,
-		"b":				   api.StatusB,
+		"b":                   api.StatusB,
 		"connected":           api.StatusB,
 		"ready":               api.StatusB,
 		"plugged":             api.StatusB,
 		"charging_completed":  api.StatusB,
-		"a":				   api.StatusA,
+		"a":                   api.StatusA,
 		"disconnected":        api.StatusA,
 		"off":                 api.StatusA,
 		"none":                api.StatusA,

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -214,14 +214,17 @@ func (v *HomeAssistant) getTimeSensor(entity string) (time.Time, error) {
 // status returns evcc charge status (optional, private)
 func (v *HomeAssistant) status(sensor string) (api.ChargeStatus, error) {
 	var haStatusMap = map[string]api.ChargeStatus{
+		"c":				   api.StatusC,
 		"charging":            api.StatusC,
 		"on":                  api.StatusC,
 		"true":                api.StatusC,
 		"active":              api.StatusC,
+		"b":				   api.StatusB,
 		"connected":           api.StatusB,
 		"ready":               api.StatusB,
 		"plugged":             api.StatusB,
 		"charging_completed":  api.StatusB,
+		"a":				   api.StatusA,
 		"disconnected":        api.StatusA,
 		"off":                 api.StatusA,
 		"none":                api.StatusA,


### PR DESCRIPTION
The correct evcc state might be a combination from different sensors in HA, therefor the user might create a own template sensor providing the correct evcc state (char)

Or there exist "crazy" vehicle ha integrations, that already provide a valid evcc code