### PR TITLE
fix: providerauth UI not shown

### DIFF
--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -50,7 +50,7 @@ export interface State {
   forecast?: Forecast;
   currency?: CURRENCY;
   fatal?: FatalError[];
-  providerAuth?: AuthProviders;
+  authProviders?: AuthProviders;
   version?: string;
   battery?: Battery[];
   tariffGrid?: number;

--- a/core/keys/global.go
+++ b/core/keys/global.go
@@ -20,5 +20,5 @@ const (
 	Telemetry          = "telemetry"
 	DemoMode           = "demoMode"
 	AuthDisabled       = "authDisabled"
-	ProviderAuth       = "providerAuth"
+	AuthProviders      = "authProviders"
 )

--- a/server/providerauth/providerauth.go
+++ b/server/providerauth/providerauth.go
@@ -85,16 +85,10 @@ func (a *Handler) Publish(paramC chan<- util.Param) {
 		apMap[provider.DisplayName()] = ap
 	}
 
-	val := struct {
-		AuthProviders map[string]*AuthProvider `json:"authProviders,omitempty"`
-	}{
-		AuthProviders: apMap,
-	}
-
 	a.log.DEBUG.Printf("publishing %d auth providers", len(apMap))
 
 	// publish the updated auth providers
-	paramC <- util.Param{Key: keys.ProviderAuth, Val: val}
+	paramC <- util.Param{Key: keys.AuthProviders, Val: apMap}
 }
 
 // Register registers a specific AuthProvider. Returns login path as string.


### PR DESCRIPTION
Fix für https://github.com/evcc-io/evcc/pull/21266

Gab wohl durch ein kleines Refactoring Diskrepanzen bei der Benennung der Variable. Jetzt ist es wieder repariert.