### PR TITLE
Lambda Zewotherm: use "E-Eintrag" mode only [BC]

### DIFF
--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -33,6 +33,10 @@ params:
     deprecated: true
   - name: excess
     deprecated: true
+    default: "plus"
+    description:
+      de: E-Eintrag
+      en: Energy-Input
   - name: watchdog
     type: duration
     default: 60s

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -31,6 +31,8 @@ params:
     choice: ["warmwater_top", "warmwater_bottom", "buffer_top", "buffer_bottom"]
   - name: phases
     deprecated: true
+  - name: excess
+    deprecated: true
   - name: watchdog
     type: duration
     default: 60s

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -51,7 +51,6 @@ render: |
         address: 102 # PV Überschussleistung
         type: writemultiple # λ erwartet single value als FC16
         decode: int16
-      scale: 1
   power:
     source: modbus
     uri: {{ .host }}:{{ .port }}

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -16,12 +16,12 @@ requirements:
       Energiemanagementeinstellungen am Gerät:
 
       - E-Meter Kommunikationsart: "ModBus Client"
-      - E-Meter Messpunkt: "Pos. E-Überschuss" oder "Neg. E-Überschuss"
+      - E-Meter Messpunkt: "E-Eintrag"
     en: |
       Energy management settings of the device:
 
       - E-Meter communication type: "ModBus Client"
-      - E-Meter measuring point: "Pos. Excess Energy" or "Neg. Excess Energy"
+      - E-Meter measuring point: "Energy-Input"
 params:
   - name: host
   - name: port
@@ -29,13 +29,6 @@ params:
   - name: tempsource
     type: choice
     choice: ["warmwater_top", "warmwater_bottom", "buffer_top", "buffer_bottom"]
-  - name: excess
-    type: choice
-    choice: ["plus", "minus"]
-    default: "plus"
-    description:
-      de: E-Überschuss ("plus" oder "minus")
-      en: Excess Energy ("plus" or "minus")
   - name: phases
     deprecated: true
   - name: watchdog
@@ -56,7 +49,7 @@ render: |
         address: 102 # PV Überschussleistung
         type: writemultiple # λ erwartet single value als FC16
         decode: int16
-      scale: {{ if eq .excess "plus" }}1{{ else }}-1{{ end }}
+      scale: 1
   power:
     source: modbus
     uri: {{ .host }}:{{ .port }}

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -33,10 +33,6 @@ params:
     deprecated: true
   - name: excess
     deprecated: true
-    default: "plus"
-    description:
-      de: E-Eintrag
-      en: Energy-Input
   - name: watchdog
     type: duration
     default: 60s


### PR DESCRIPTION
Lambda template corrected for E-Eintrag setting. With this setting the Lambda is allowed to consume the power, that EVCC reports.
