### PR TITLE
Fix JS Plugin Variable Names for SG Ready

### DIFF
--- a/assets/js/components/Config/defaultYaml/sgready.yaml
+++ b/assets/js/components/Config/defaultYaml/sgready.yaml
@@ -2,7 +2,7 @@
 
 setmode: # set operation mode (1: reduced, 2: normal, 3 boost)
   source: js
-  script: console.log(setmode) #
+  script: console.log(mode) #
 
 ## optional attributes (read-only)
 
@@ -26,4 +26,4 @@ setmode: # set operation mode (1: reduced, 2: normal, 3 boost)
 
 #setmaxpower: # update the maximum charging power
 #  source: js
-#  script: console.log(setmaxpower);
+#  script: console.log(maxpower);


### PR DESCRIPTION
If I understand the [code here](https://github.com/evcc-io/evcc/blob/1af26adbb1e91a2d3edb8ee4333031275818add9/charger/sgready.go#L87), the names of the variables are actually `maxpower` and `mode`. I've tested this in my own evcc instance on version 0.207.1.