### PR TITLE
Additional states for Porsche in Homeassistant

### DIFF
--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -233,7 +233,6 @@ func (v *HomeAssistant) status(sensor string) (api.ChargeStatus, error) {
 		"unknown":             api.StatusA,
 		"notreadyforcharging": api.StatusA,
 		"not_plugged":         api.StatusA,
-		"charging_error":      api.StatusA,
 	}
 
 	s, err := v.getState(sensor)

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -224,6 +224,7 @@ func (v *HomeAssistant) status(sensor string) (api.ChargeStatus, error) {
 		"ready":               api.StatusB,
 		"plugged":             api.StatusB,
 		"charging_completed":  api.StatusB,
+		"initialising":        api.StatusB,
 		"a":                   api.StatusA,
 		"disconnected":        api.StatusA,
 		"off":                 api.StatusA,
@@ -231,6 +232,8 @@ func (v *HomeAssistant) status(sensor string) (api.ChargeStatus, error) {
 		"unavailable":         api.StatusA,
 		"unknown":             api.StatusA,
 		"notreadyforcharging": api.StatusA,
+		"not_plugged":         api.StatusA,
+		"charging_error":      api.StatusA,
 	}
 
 	s, err := v.getState(sensor)


### PR DESCRIPTION
There are few additional charging states:
 - not_plugged - vehicle is not plugged into the charger
 - initialising - vehicle is in process of negotiating connection with the charger, but still not charging
 - charging_error - an error occurred during charge session; at the moment we treat this one the same as 'unknown' status