### PR TITLE
Loadpoint: display kW next to amperes

### DIFF
--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -280,13 +280,13 @@ export default defineComponent({
 		changePhasesConfigured() {
 			this.$emit("phasesconfigured-updated", this.selectedPhases);
 		},
-		currentOption(value: number, isDefault: boolean, isMax: boolean) {
-			const kw = this.fmtW((isMax ? this.maxPower : this.minPower) * value);
-			let name = `${this.fmtNumber(value, value <= 1 ? undefined : 0)} A (${kw})`;
+		currentOption(current: number, isDefault: boolean, isMax: boolean) {
+			const kw = this.fmtW((isMax ? this.maxPower : this.minPower) * current);
+			let name = `${this.fmtNumber(current, current <= 1 ? undefined : 0)} A (${kw})`;
 			if (isDefault) {
 				name += ` [${this.$t("main.loadpointSettings.default")}]`;
 			}
-			return { value, name };
+			return { value: current, name };
 		},
 		modalVisible() {
 			this.isModalVisible = true;

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -67,8 +67,8 @@
 									$t(
 										`main.loadpointSettings.phasesConfigured.phases_${phases}_hint`,
 										{
-											min: fmtW(V() * phases * minCurrent),
-											max: fmtW(V() * phases * maxCurrent),
+											min: fmtPhasePower(minCurrent, phases),
+											max: fmtPhasePower(maxCurrent, phases),
 										}
 									)
 								}}
@@ -134,6 +134,8 @@ import SmartFeedInPriority from "../Tariff/SmartFeedInPriority.vue";
 import SettingsBatteryBoost from "./SettingsBatteryBoost.vue";
 import { defineComponent, type PropType } from "vue";
 import { PHASES, CURRENCY, SMART_COST_TYPE, type Forecast } from "@/types/evcc";
+
+const V = 230;
 
 const range = (start: number, stop: number, step = -1) =>
 	Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
@@ -250,8 +252,8 @@ export default defineComponent({
 		},
 	},
 	methods: {
-		V() {
-			return 230;
+		fmtPhasePower(current: number, phases: PHASES) {
+			return this.fmtW(V * current * phases);
 		},
 		formId(name: string) {
 			return `loadpoint_${this.id}_${name}`;
@@ -266,7 +268,7 @@ export default defineComponent({
 			this.$emit("phasesconfigured-updated", this.selectedPhases);
 		},
 		currentOption(current: number, isDefault: boolean, phases: number) {
-			const kw = this.fmtW(this.V() * phases * current);
+			const kw = this.fmtPhasePower(current, phases);
 			let name = `${this.fmtNumber(current, current <= 1 ? undefined : 0)} A (${kw})`;
 			if (isDefault) {
 				name += ` [${this.$t("main.loadpointSettings.default")}]`;

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -82,11 +82,11 @@
 				<label :for="formId('maxcurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
 					{{ $t("main.loadpointSettings.maxCurrent.label") }}
 				</label>
-				<div class="col-sm-8 pe-0 d-flex align-items-center">
+				<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
 					<select
 						:id="formId('maxcurrent')"
 						v-model.number="selectedMaxCurrent"
-						class="form-select form-select-sm w-75"
+						class="form-select form-select-sm"
 						@change="changeMaxCurrent"
 					>
 						<option
@@ -104,11 +104,11 @@
 				<label :for="formId('mincurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
 					{{ $t("main.loadpointSettings.minCurrent.label") }}
 				</label>
-				<div class="col-sm-8 pe-0 d-flex align-items-center">
+				<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
 					<select
 						:id="formId('mincurrent')"
 						v-model.number="selectedMinCurrent"
-						class="form-select form-select-sm w-75"
+						class="form-select form-select-sm"
 						@change="changeMinCurrent"
 					>
 						<option

--- a/tests/basics.spec.ts
+++ b/tests/basics.spec.ts
@@ -69,16 +69,19 @@ test.describe("session info", async () => {
 
 test.describe("loadpoint settings", async () => {
   test("phase selection", async ({ page }) => {
+    const minCurrentSelected = page.getByLabel("Min. current").locator("option:checked");
+    const maxCurrentSelected = page.getByLabel("Max. current").locator("option:checked");
+
     await page.getByTestId("loadpoint-settings-button").nth(1).click();
     await expect(page.getByLabel("auto-switching")).not.toBeVisible();
     await expect(page.getByLabel("3 phase")).toBeChecked();
     await expect(page.getByLabel("1 phase")).not.toBeChecked();
-    await expect(page.getByText("~ 11.0 kW")).toBeVisible();
-    await expect(page.getByText("~ 4.1 kW")).toBeVisible();
+    await expect(maxCurrentSelected).toHaveText("16 A (11.0 kW) [default]");
+    await expect(minCurrentSelected).toHaveText("6 A (4.1 kW) [default]");
 
     await page.getByLabel("1 phase").click();
-    await expect(page.getByText("~ 3.7 kW")).toBeVisible();
-    await expect(page.getByText("~ 1.4 kW")).toBeVisible();
+    await expect(maxCurrentSelected).toHaveText("16 A (3.7 kW) [default]");
+    await expect(minCurrentSelected).toHaveText("6 A (1.4 kW) [default]");
   });
 });
 

--- a/tests/currents.spec.ts
+++ b/tests/currents.spec.ts
@@ -22,22 +22,22 @@ test.describe("currents", async () => {
     await expectModalVisible(modal);
 
     const minCurrent = modal.getByLabel("Min. current");
+    const minCurrentSelected = minCurrent.locator("option:checked");
     const maxCurrent = modal.getByLabel("Max. current");
-    const minPower = modal.getByTestId("min-power");
-    const maxPower = modal.getByTestId("max-power");
+    const maxCurrentSelected = maxCurrent.locator("option:checked");
 
     // initial values
     await expect(maxCurrent).toHaveValue("16");
-    await expect(maxPower).toContainText("~ 11.0 kW");
+    await expect(maxCurrentSelected).toHaveText("16 A (11.0 kW) [default]");
     await expect(minCurrent).toHaveValue("6");
-    await expect(minPower).toContainText("~ 4.1 kW");
+    await expect(minCurrentSelected).toHaveText("6 A (4.1 kW) [default]");
 
     // change min current
-    await minCurrent.selectOption("0.125 A");
-    await expect(minPower).toContainText("~ 0.1 kW");
+    await minCurrent.selectOption("0.125 A (0.1 kW)");
+    await expect(minCurrentSelected).toHaveText("0.125 A (0.1 kW)");
 
     // change max current
-    await maxCurrent.selectOption("32 A");
-    await expect(maxPower).toContainText("~ 22.1 kW");
+    await maxCurrent.selectOption("32 A (22.1 kW)");
+    await expect(maxCurrentSelected).toHaveText("32 A (22.1 kW)");
   });
 });


### PR DESCRIPTION
Damit muss man nicht mehr die Ampere-optionen durchprobieren, um eine gewünschte kW Leistung einzustellen.

<img width="1666" height="1284" alt="grafik" src="https://github.com/user-attachments/assets/fd723cd5-b54f-40e8-b1c5-e3cf5e1f182c" />
<img width="1180" height="1023" alt="grafik" src="https://github.com/user-attachments/assets/89d8e6e5-68c1-421c-a2da-5ae9aedf51bc" />

\cc @naltatis 