### PR TITLE
Fix forecast chart gaps by aggregating data into hourly intervals

### DIFF
--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -482,9 +482,9 @@ export default defineComponent({
 			// Sort by start time
 			aggregatedSlots.sort(
 				(a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
-		    );
-			
-			return aggregatedSlots
+			);
+
+			return aggregatedSlots;
 		},
 		filterEntries(entries: TimeseriesEntry[] = []) {
 			// include 1 hour before and after

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -427,72 +427,11 @@ export default defineComponent({
 			now.setMilliseconds(0);
 			this.startDate = now;
 		},
-		aggregateSlotsByHour(slots: ForecastSlot[] = []) {
-			if (slots.length === 0) return [];
-
-			// Group slots by hour
-			const hourlyGroups = new Map();
-
-			for (const slot of slots) {
-				const slotStart = new Date(slot.start);
-				// Create hour key (YYYY-MM-DD HH:00)
-				const hourKey = new Date(
-					slotStart.getFullYear(),
-					slotStart.getMonth(),
-					slotStart.getDate(),
-					slotStart.getHours()
-				).getTime();
-
-				if (!hourlyGroups.has(hourKey)) {
-					hourlyGroups.set(hourKey, []);
-				}
-				hourlyGroups.get(hourKey).push(slot);
-			}
-
-			// Create aggregated slots (one per hour)
-			const aggregatedSlots = [];
-			for (const [hourKey, groupSlots] of hourlyGroups) {
-				const hourDate = new Date(hourKey);
-				const hourEnd = new Date(hourDate);
-				hourEnd.setHours(hourEnd.getHours() + 1);
-
-				// Calculate weighted average value for the hour
-				let totalValue = 0;
-				let totalDuration = 0;
-
-				for (const slot of groupSlots) {
-					const slotStart = new Date(slot.start);
-					const slotEnd = new Date(slot.end);
-					const duration = slotEnd.getTime() - slotStart.getTime();
-					totalValue += slot.value * duration;
-					totalDuration += duration;
-				}
-
-				aggregatedSlots.push({
-					start: hourDate.toISOString(),
-					end: hourEnd.toISOString(),
-					value: totalDuration > 0 ? totalValue / totalDuration : 0,
-				});
-			}
-
-			// Sort by start time
-			aggregatedSlots.sort(
-				(a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
-			);
-
-			return aggregatedSlots;
-		},
-		// Add duration filtering to prevent zero-duration entries from creating empty graph positions
 		filterSlots(slots: ForecastSlot[] = []) {
-			return slots.filter((slot) => {
-				const slotStart = new Date(slot.start);
-				const slotEnd = new Date(slot.end);
-				// Filter out zero-duration entries (where start equals end or duration is less than 1 minute)
-				const duration = slotEnd.getTime() - slotStart.getTime();
-				const hasValidDuration = duration >= 60000; // At least 1 minute
-				const isInRange = slotEnd >= this.startDate && slotStart <= this.endDate;
-				return hasValidDuration && isInRange;
-			});
+			return slots.filter(
+				(slot) =>
+					new Date(slot.end) >= this.startDate && new Date(slot.start) <= this.endDate
+			);
 		},
 		filterEntries(entries: TimeseriesEntry[] = []) {
 			// include 1 hour before and after

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -92,10 +92,10 @@ export default defineComponent({
 			return this.filterEntries(this.solar?.timeseries || []);
 		},
 		gridSlots() {
-			return this.filterSlots(this.grid);
+			return this.aggregateSlotsByHour(this.filterSlots(this.grid));
 		},
 		co2Slots() {
-			return this.filterSlots(this.co2);
+			return this.aggregateSlotsByHour(this.filterSlots(this.co2));
 		},
 		maxPriceIndex() {
 			return this.maxIndex(this.gridSlots);
@@ -425,11 +425,72 @@ export default defineComponent({
 			now.setMilliseconds(0);
 			this.startDate = now;
 		},
-		filterSlots(slots: ForecastSlot[] = []) {
-			return slots.filter(
-				(slot) =>
-					new Date(slot.end) >= this.startDate && new Date(slot.start) <= this.endDate
+		aggregateSlotsByHour(slots: ForecastSlot[] = []) {
+			if (slots.length === 0) return [];
+
+			// Group slots by hour
+			const hourlyGroups = new Map();
+
+			for (const slot of slots) {
+				const slotStart = new Date(slot.start);
+				// Create hour key (YYYY-MM-DD HH:00)
+				const hourKey = new Date(
+					slotStart.getFullYear(),
+					slotStart.getMonth(),
+					slotStart.getDate(),
+					slotStart.getHours()
+				).getTime();
+
+				if (!hourlyGroups.has(hourKey)) {
+					hourlyGroups.set(hourKey, []);
+				}
+				hourlyGroups.get(hourKey).push(slot);
+			}
+
+			// Create aggregated slots (one per hour)
+			const aggregatedSlots = [];
+			for (const [hourKey, groupSlots] of hourlyGroups) {
+				const hourDate = new Date(hourKey);
+				const hourEnd = new Date(hourDate);
+				hourEnd.setHours(hourEnd.getHours() + 1);
+
+				// Calculate weighted average value for the hour
+				let totalValue = 0;
+				let totalDuration = 0;
+
+				for (const slot of groupSlots) {
+					const slotStart = new Date(slot.start);
+					const slotEnd = new Date(slot.end);
+					const duration = slotEnd.getTime() - slotStart.getTime();
+					totalValue += slot.value * duration;
+					totalDuration += duration;
+				}
+
+				aggregatedSlots.push({
+					start: hourDate.toISOString(),
+					end: hourEnd.toISOString(),
+					value: totalDuration > 0 ? totalValue / totalDuration : 0,
+				});
+			}
+
+			// Sort by start time
+			aggregatedSlots.sort(
+				(a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
 			);
+
+			return aggregatedSlots;
+		},
+		// Add duration filtering to prevent zero-duration entries from creating empty graph positions
+		filterSlots(slots: ForecastSlot[] = []) {
+			return slots.filter((slot) => {
+				const slotStart = new Date(slot.start);
+				const slotEnd = new Date(slot.end);
+				// Filter out zero-duration entries (where start equals end or duration is less than 1 minute)
+				const duration = slotEnd.getTime() - slotStart.getTime();
+				const hasValidDuration = duration >= 60000; // At least 1 minute
+				const isInRange = slotEnd >= this.startDate && slotStart <= this.endDate;
+				return hasValidDuration && isInRange;
+			});
 		},
 		filterEntries(entries: TimeseriesEntry[] = []) {
 			// include 1 hour before and after

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -93,10 +93,8 @@ export default defineComponent({
 		},
 		gridSlots() {
 			return this.aggregateSlotsByHour(this.filterSlots(this.grid));
-			return this.aggregateSlotsByHour(this.filterSlots(this.grid));
 		},
 		co2Slots() {
-			return this.aggregateSlotsByHour(this.filterSlots(this.co2));
 			return this.aggregateSlotsByHour(this.filterSlots(this.co2));
 		},
 		maxPriceIndex() {

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -92,10 +92,10 @@ export default defineComponent({
 			return this.filterEntries(this.solar?.timeseries || []);
 		},
 		gridSlots() {
-			return this.filterSlots(this.grid);
+			return this.aggregateSlotsByHour(this.filterSlots(this.grid));
 		},
 		co2Slots() {
-			return this.filterSlots(this.co2);
+			return this.aggregateSlotsByHour(this.filterSlots(this.co2));
 		},
 		maxPriceIndex() {
 			return this.maxIndex(this.gridSlots);
@@ -425,12 +425,73 @@ export default defineComponent({
 			now.setMilliseconds(0);
 			this.startDate = now;
 		},
-		filterSlots(slots: ForecastSlot[] = []) {
-			return slots.filter(
-				(slot) =>
-					new Date(slot.end) >= this.startDate && new Date(slot.start) <= this.endDate
+		aggregateSlotsByHour(slots: ForecastSlot[] = []) {
+			if (slots.length === 0) return [];
+			
+			// Group slots by hour
+			const hourlyGroups = new Map();
+			
+			for (const slot of slots) {
+				const slotStart = new Date(slot.start);
+				// Create hour key (YYYY-MM-DD HH:00)
+				const hourKey = new Date(
+					slotStart.getFullYear(),
+					slotStart.getMonth(),
+					slotStart.getDate(),
+					slotStart.getHours()
+				).getTime();
+				
+				if (!hourlyGroups.has(hourKey)) {
+					hourlyGroups.set(hourKey, []);
+				}
+				hourlyGroups.get(hourKey).push(slot);
+			}
+			
+			// Create aggregated slots (one per hour)
+			const aggregatedSlots = [];
+			for (const [hourKey, groupSlots] of hourlyGroups) {
+				const hourDate = new Date(hourKey);
+				const hourEnd = new Date(hourDate);
+				hourEnd.setHours(hourEnd.getHours() + 1);
+				
+				// Calculate weighted average value for the hour
+				let totalValue = 0;
+				let totalDuration = 0;
+				
+				for (const slot of groupSlots) {
+					const slotStart = new Date(slot.start);
+					const slotEnd = new Date(slot.end);
+					const duration = slotEnd.getTime() - slotStart.getTime();
+					totalValue += slot.value * duration;
+					totalDuration += duration;
+				}
+				
+				aggregatedSlots.push({
+					start: hourDate.toISOString(),
+					end: hourEnd.toISOString(),
+					value: totalDuration > 0 ? totalValue / totalDuration : 0,
+				});
+			}
+			
+			// Sort by start time
+			aggregatedSlots.sort((a, b) => 
+				new Date(a.start).getTime() - new Date(b.start).getTime()
 			);
+			
+			return aggregatedSlots;
 		},
+// Add duration filtering to prevent zero-duration entries from creating empty graph positions
+	filterSlots(slots: ForecastSlot[] = []) {
+		return slots.filter((slot) => {
+			const slotStart = new Date(slot.start);
+			const slotEnd = new Date(slot.end);
+			// Filter out zero-duration entries (where start equals end or duration is less than 1 minute)
+			const duration = slotEnd.getTime() - slotStart.getTime();
+			const hasValidDuration = duration >= 60000; // At least 1 minute
+			const isInRange = slotEnd >= this.startDate && slotStart <= this.endDate;
+			return hasValidDuration && isInRange;
+		});
+	},
 		filterEntries(entries: TimeseriesEntry[] = []) {
 			// include 1 hour before and after
 			const start = new Date(this.startDate);

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -431,6 +431,61 @@ export default defineComponent({
 					new Date(slot.end) >= this.startDate && new Date(slot.start) <= this.endDate
 			);
 		},
+		aggregateSlotsByHour(slots: ForecastSlot[] = []) {
+			if (slots.length === 0) return [];
+
+			// Group slots by hour
+			const hourlyGroups = new Map();
+
+			for (const slot of slots) {
+				const slotStart = new Date(slot.start);
+				// Create hour key (YYYY-MM-DD HH:00)
+				const hourKey = new Date(
+					slotStart.getFullYear(),
+					slotStart.getMonth(),
+					slotStart.getDate(),
+					slotStart.getHours()
+				).getTime();
+
+				if (!hourlyGroups.has(hourKey)) {
+					hourlyGroups.set(hourKey, []);
+				}
+				hourlyGroups.get(hourKey).push(slot);
+			}
+
+			// Create aggregated slots (one per hour)
+			const aggregatedSlots = [];
+			for (const [hourKey, groupSlots] of hourlyGroups) {
+				const hourDate = new Date(hourKey);
+				const hourEnd = new Date(hourDate);
+				hourEnd.setHours(hourEnd.getHours() + 1);
+
+				// Calculate weighted average value for the hour
+				let totalValue = 0;
+				let totalDuration = 0;
+
+				for (const slot of groupSlots) {
+					const slotStart = new Date(slot.start);
+					const slotEnd = new Date(slot.end);
+					const duration = slotEnd.getTime() - slotStart.getTime();
+					totalValue += slot.value * duration;
+					totalDuration += duration;
+				}
+
+				aggregatedSlots.push({
+					start: hourDate.toISOString(),
+					end: hourEnd.toISOString(),
+					value: totalDuration > 0 ? totalValue / totalDuration : 0,
+				});
+			}
+
+			// Sort by start time
+			aggregatedSlots.sort(
+				(a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+		    );
+			
+			return aggregatedSlots
+		},
 		filterEntries(entries: TimeseriesEntry[] = []) {
 			// include 1 hour before and after
 			const start = new Date(this.startDate);


### PR DESCRIPTION
- Individual forecast slots were creating gaps between bars when they didn't align perfectly with hour boundaries
- Added aggregateSlotsByHour method to group slots by hour and calculate weighted averages
- Updated gridSlots and co2Slots computed properties to use hourly aggregation
- Ensures exactly one bar per hour with no gaps and proper x-axis label spacing
- Fixes visualization issues on dates like 'Saturday 11-11' with malformed bar chart gaps