### PR TITLE
fix: (Amber) normalise rates to 1-hour slots

### DIFF
--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -95,27 +95,74 @@ func (t *Amber) run(done chan error) {
 			continue
 		}
 
-		data := make(api.Rates, 0, len(res))
+		// Group by hour and average intervals within each hour
+		hourlyData := make(map[time.Time]*struct {
+			totalValue    float64
+			totalDuration time.Duration
+			start         time.Time
+			currentValue  *float64 // Override with current interval if present (for accurate charging session costs)
+		})
 
 		for _, r := range res {
 			if t.channel == strings.ToLower(r.ChannelType) {
 				startTime, _ := time.Parse("2006-01-02T15:04:05Z", r.StartTime)
 				endTime, _ := time.Parse("2006-01-02T15:04:05Z", r.EndTime)
-				ar := api.Rate{
-					Start: startTime.Local(),
-					End:   endTime.Local(),
-					Value: r.PerKwh / 1e2,
-				}
+
+				value := r.PerKwh / 1e2
 				if r.AdvancedPrice != nil {
-					ar.Value = r.AdvancedPrice.Predicted / 1e2
+					value = r.AdvancedPrice.Predicted / 1e2
 				}
 
 				// Invert feed-in prices to match evcc expectations (positive = paid for exports)
 				if t.channel == "feedin" {
-					ar.Value = -ar.Value
+					value = -value
 				}
-				data = append(data, ar)
+
+				localStart := startTime.Local()
+				localEnd := endTime.Local()
+				hourStart := localStart.Truncate(time.Hour) // Preserve date+hour
+				duration := localEnd.Sub(localStart)
+
+				// Initialize hour entry if needed
+				if hourlyData[hourStart] == nil {
+					hourlyData[hourStart] = &struct {
+						totalValue    float64
+						totalDuration time.Duration
+						start         time.Time
+						currentValue  *float64
+					}{start: hourStart}
+				}
+
+				hr := hourlyData[hourStart]
+
+				// If this is the current interval, use its value directly for this hour
+				if r.Type == "CurrentInterval" {
+					hr.currentValue = &value
+				} else {
+					// Add to weighted average for forecast intervals
+					hr.totalValue += value * duration.Seconds()
+					hr.totalDuration += duration
+				}
 			}
+		}
+
+		// Convert to final hourly rates
+		data := make(api.Rates, 0, len(hourlyData))
+		for _, hr := range hourlyData {
+			var finalValue float64
+			if hr.currentValue != nil {
+				// Use current interval value if available
+				finalValue = *hr.currentValue
+			} else if hr.totalDuration > 0 {
+				// Otherwise use weighted average of forecast intervals
+				finalValue = hr.totalValue / hr.totalDuration.Seconds()
+			}
+
+			data = append(data, api.Rate{
+				Start: hr.start,
+				End:   hr.start.Add(time.Hour),
+				Value: finalValue,
+			})
 		}
 
 		mergeRates(t.data, data)


### PR DESCRIPTION
Fixes https://github.com/evcc-io/evcc/issues/22858

This PR normalises the returned API data (which could be a mixture of 5-minute and 30-minute periods) into 1 hour slots, so it doesn't break the forecasting when multiple tariffs are in use (eg pv forecast)

This would ordinarily result in the charging session pricing becoming inaccurate, however, as a compromise I'm updating the current hour to be whatever the current price is, so the pricing for sessions remains accurate.

It works on a clean DB. However, there's a problem (unrelated to this PR)... This PR https://github.com/evcc-io/evcc/pull/22446 means that when evcc is restarted the tariff will not be invoked until there's <24 hours of data cached, meaning stale data could be used for well over a day until the tariff is finally re-invoked and it will continue to be updated once a minute as before from then on.