### PR TITLE
Ocpp: warn when unknown chargepoint connects

### DIFF
--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -127,6 +127,8 @@ func (cs *CS) NewChargePoint(chargePoint ocpp16.ChargePointConnection) {
 		return
 	}
 
+	cs.log.WARN.Printf("unknown charge point connected: %s", chargePoint.ID())
+
 	// check for configured anonymous charge point
 	reg, ok = cs.regs[""]
 	if ok && reg.cp != nil {
@@ -142,8 +144,6 @@ func (cs *CS) NewChargePoint(chargePoint ocpp16.ChargePointConnection) {
 
 		return
 	}
-
-	cs.log.WARN.Printf("unknown charge point connected: %s", chargePoint.ID())
 
 	// register unknown charge point
 	// when charge point setup is complete, it will eventually be associated with the connected id


### PR DESCRIPTION
Prepare for #22115

Raise a warning when an unknown chargepoint connects. This includes warning when a placeholder charger with empty station id has been configured to notify the user of the actual station id.

/cc @mfuchs1984 