### PR TITLE
Shelly Pro 3EM: support switch addon

### DIFF
--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -152,20 +152,27 @@ func newGen2(helper *request.Helper, uri, model string, channel int, user, passw
 
 // execCmd executes a shelly api gen2+ command and provides the response
 func (c *gen2) execCmd(method string, enable bool, res any) error {
-	var data any
-	if method == "Switch.Set" {
-		data = &Gen2SetRpcPost{
-			Id:     c.selectChannelId(method),
-			Src:    "evcc",
-			Method: method,
-			On:     enable,
-		}
-	} else {
-		data = &Gen2GetRpcPost{
-			Id:     c.selectChannelId(method),
-			Src:    "evcc",
-			Method: method,
-		}
+	data := &Gen2GetRpcPost{
+		Id:     c.selectChannelId(method),
+		Src:    "evcc",
+		Method: method,
+	}
+
+	req, err := request.New(http.MethodPost, fmt.Sprintf("%s/%s", c.uri, method), request.MarshalJSON(data), request.JSONEncoding)
+	if err != nil {
+		return err
+	}
+
+	return c.DoJSON(req, &res)
+}
+
+// execCmd executes a shelly api gen2+ command and provides the response
+func (c *gen2) execEnableCmd(method string, enable bool, res any) error {
+	data := &Gen2SetRpcPost{
+		Id:     c.selectChannelId(method),
+		Src:    "evcc",
+		Method: method,
+		On:     enable,
 	}
 
 	req, err := request.New(http.MethodPost, fmt.Sprintf("%s/%s", c.uri, method), request.MarshalJSON(data), request.JSONEncoding)
@@ -210,7 +217,7 @@ func (c *gen2) Enabled() (bool, error) {
 func (c *gen2) Enable(enable bool) error {
 	var res Gen2SwitchStatus
 	c.switchstatus.Reset()
-	return c.execCmd("Switch.Set", enable, &res)
+	return c.execEnableCmd("Switch.Set", enable, &res)
 }
 
 // TotalEnergy implements the api.Meter interface

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -199,7 +199,7 @@ func (c *gen2) Enabled() (bool, error) {
 func (c *gen2) Enable(enable bool) error {
 	var res Gen2SwitchStatus
 	c.switchstatus.Reset()
-	return c.execCmd("Switch.Set?id="+strconv.Itoa(c.channel), enable, &res)
+	return c.execCmd("Switch.Set?id="+strconv.Itoa(c.switchchannel), enable, &res)
 }
 
 // TotalEnergy implements the api.Meter interface

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -14,14 +14,14 @@ import (
 
 // Gen2API endpoint reference: https://shelly-api-docs.shelly.cloud/gen2/
 
-type Gen2GetRpcPost struct {
+type Gen2RpcRequest struct {
 	Id     int    `json:"id"`
 	Src    string `json:"src"`
 	Method string `json:"method"`
 }
 
 type Gen2SetRpcPost struct {
-	Gen2GetRpcPost
+	Gen2RpcRequest
 	On bool `json:"on"`
 }
 
@@ -150,7 +150,7 @@ func newGen2(helper *request.Helper, uri, model string, channel int, user, passw
 
 // execCmd executes a shelly api gen2+ command and provides the response
 func (c *gen2) execCmd(id int, method string, res any) error {
-	data := &Gen2GetRpcPost{
+	data := &Gen2RpcRequest{
 		Id:     id,
 		Src:    apisrc,
 		Method: method,
@@ -167,7 +167,7 @@ func (c *gen2) execCmd(id int, method string, res any) error {
 // execCmd executes a shelly api gen2+ command and provides the response
 func (c *gen2) execEnableCmd(id int, method string, enable bool, res any) error {
 	data := &Gen2SetRpcPost{
-		Gen2GetRpcPost: Gen2GetRpcPost{
+		Gen2RpcRequest: Gen2RpcRequest{
 			Id:     id,
 			Src:    apisrc,
 			Method: method,

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -310,6 +310,10 @@ func (c *gen2) getAddOnSwitchId() (int, error) {
 		return c.channel, err
 	}
 
+	return c.parseAddOnSwitchID(res)
+}
+
+func (c *gen2) parseAddOnSwitchID(res Gen2ProAddOnGetPeripherals) (int, error) {
 	for key := range res.DigitalOut {
 		if strings.HasPrefix(key, "switch:") {
 			var id int

--- a/meter/shelly/gen2_test.go
+++ b/meter/shelly/gen2_test.go
@@ -40,44 +40,42 @@ func TestUnmarshalGen2StatusResponse(t *testing.T) {
 
 	{
 		// ProOutputAddon.GetPeripherals Endpoint
-		c := &gen2{
-			channel: 0,
-		}
 		var res Gen2ProAddOnGetPeripherals
+		channel := 0
 
 		// Test with a valid switch ID
 		jsonstr := `{"digital_out":{"switch:100":{}}}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
 		assert.NotEmpty(t, res.DigitalOut)
-		id, err := c.parseAddOnSwitchID(res)
+		id, err := parseAddOnSwitchID(channel, res)
 		require.NoError(t, err)
 		assert.Equal(t, 100, id)
 		// Test with no AddOn installed
 		res = Gen2ProAddOnGetPeripherals{}
 		jsonstr = `{"code":404,"message":"No handler for ProOutputAddon.GetPeripherals"}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
-		id, err = c.parseAddOnSwitchID(res)
+		id, err = parseAddOnSwitchID(channel, res)
 		require.NoError(t, err)
 		assert.Equal(t, 0, id)
 		// Test for empty digital_out map in AddOn response
 		res = Gen2ProAddOnGetPeripherals{}
 		jsonstr = `{"digital_out":{}}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
-		id, err = c.parseAddOnSwitchID(res)
+		id, err = parseAddOnSwitchID(channel, res)
 		require.NoError(t, err)
 		assert.Equal(t, 0, id)
 		// Test with multiple AddOns installed (only the first ID will be returned)
 		res = Gen2ProAddOnGetPeripherals{}
 		jsonstr = `{"digital_out":{"switch:100":{},"switch:101":{}}}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
-		id, err = c.parseAddOnSwitchID(res)
+		id, err = parseAddOnSwitchID(channel, res)
 		require.NoError(t, err)
 		assert.Equal(t, 100, id)
 		// Test for malformed switch keys
 		res = Gen2ProAddOnGetPeripherals{}
 		jsonstr = `{"digital_out":{"switch:abc":{}}}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
-		id, err = c.parseAddOnSwitchID(res)
+		id, err = parseAddOnSwitchID(channel, res)
 		require.ErrorContains(t, err, "failed to get add-on switch id:")
 		assert.Equal(t, 0, id)
 	}

--- a/meter/shelly/gen2_test.go
+++ b/meter/shelly/gen2_test.go
@@ -37,4 +37,35 @@ func TestUnmarshalGen2StatusResponse(t *testing.T) {
 		assert.Equal(t, 1264.15, res.TotalActEnergy)
 		assert.Equal(t, 144792.28, res.TotalActRetEnergy)
 	}
+
+	{
+		// ProOutputAddon.GetPeripherals Endpoint
+		c := &gen2{
+			channel: 0,
+		}
+		var res Gen2ProAddOnGetPeripherals
+
+		// Test with a valid switch ID
+		jsonstr := `{"digital_out":{"switch:100":{}}}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+		assert.NotEmpty(t, res.DigitalOut)
+		id, err := c.parseAddOnSwitchID(res)
+		require.NoError(t, err)
+		assert.Equal(t, 100, id)
+		// Test with no AddOn installed
+		res = Gen2ProAddOnGetPeripherals{}
+		jsonstr = `{"code":404,"message":"No handler for ProOutputAddon.GetPeripherals"}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+		id, err = c.parseAddOnSwitchID(res)
+		require.NoError(t, err)
+		assert.Equal(t, 0, id)
+		// Test with multiple AddOns installed (only the first ID will be returned)
+		res = Gen2ProAddOnGetPeripherals{}
+		jsonstr = `{"digital_out":{"switch:100":{},"switch:101":{}}}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+		id, err = c.parseAddOnSwitchID(res)
+		require.NoError(t, err)
+		assert.Equal(t, 100, id)
+
+	}
 }

--- a/meter/shelly/gen2_test.go
+++ b/meter/shelly/gen2_test.go
@@ -59,6 +59,13 @@ func TestUnmarshalGen2StatusResponse(t *testing.T) {
 		id, err = c.parseAddOnSwitchID(res)
 		require.NoError(t, err)
 		assert.Equal(t, 0, id)
+		// Test for empty digital_out map in AddOn response
+		res = Gen2ProAddOnGetPeripherals{}
+		jsonstr = `{"digital_out":{}}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+		id, err = c.parseAddOnSwitchID(res)
+		require.NoError(t, err)
+		assert.Equal(t, 0, id)
 		// Test with multiple AddOns installed (only the first ID will be returned)
 		res = Gen2ProAddOnGetPeripherals{}
 		jsonstr = `{"digital_out":{"switch:100":{},"switch:101":{}}}`
@@ -66,5 +73,12 @@ func TestUnmarshalGen2StatusResponse(t *testing.T) {
 		id, err = c.parseAddOnSwitchID(res)
 		require.NoError(t, err)
 		assert.Equal(t, 100, id)
+		// Test for malformed switch keys
+		res = Gen2ProAddOnGetPeripherals{}
+		jsonstr = `{"digital_out":{"switch:abc":{}}}`
+		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+		id, err = c.parseAddOnSwitchID(res)
+		require.ErrorContains(t, err, "failed to get add-on switch id:")
+		assert.Equal(t, 0, id)
 	}
 }

--- a/meter/shelly/gen2_test.go
+++ b/meter/shelly/gen2_test.go
@@ -66,6 +66,5 @@ func TestUnmarshalGen2StatusResponse(t *testing.T) {
 		id, err = c.parseAddOnSwitchID(res)
 		require.NoError(t, err)
 		assert.Equal(t, 100, id)
-
 	}
 }

--- a/tests/simulator/api.ts
+++ b/tests/simulator/api.ts
@@ -100,7 +100,7 @@ const shellyMiddleware = (
     res.end(JSON.stringify({ gen: 2 }));
   } else if (req.originalUrl === "/rpc/Shelly.ListMethods") {
     res.end(JSON.stringify({ methods: ["Switch.GetStatus"] }));
-  } else if (req.originalUrl === "/rpc/Switch.GetStatus?id=0") {
+  } else if (req.originalUrl === "/rpc/Switch.GetStatus") {
     res.end(
       JSON.stringify({
         apower: state.site.pv.power,


### PR DESCRIPTION
In case a shelly Pro 3EM swicth addon is installed, evcc identifies now the correct channel id to query and set the Switch status.

Fixes #22881