### PR TITLE
chore: remove redundant minsoc/maxsoc defaults from meter templates

### DIFF
--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -21,12 +21,8 @@ params:
   - name: capacity
     advanced: true
   - name: minsoc
-    default: 20
-    type: int
     advanced: true
   - name: maxsoc
-    default: 95
-    type: int
     advanced: true
   - name: maxacpower
 render: |

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -19,12 +19,8 @@ params:
   - name: capacity
     advanced: true
   - name: minsoc
-    type: int
-    default: 20
     advanced: true
   - name: maxsoc
-    type: int
-    default: 95
     advanced: true
   - name: maxacpower
 render: |

--- a/templates/definition/meter/deye-hybrid-hp3.yaml
+++ b/templates/definition/meter/deye-hybrid-hp3.yaml
@@ -22,12 +22,8 @@ params:
   - name: capacity
     advanced: true
   - name: minsoc
-    type: int
-    default: 20
     advanced: true
   - name: maxsoc
-    type: int
-    default: 95
     advanced: true
   - name: maxacpower
   - name: includegenport

--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -20,12 +20,8 @@ params:
     default: 2
     advanced: true
   - name: minsoc
-    type: int
-    default: 20
     advanced: true
   - name: maxsoc
-    type: int
-    default: 95
     advanced: true
 render: |
   type: custom

--- a/templates/definition/meter/wattsonic.yaml
+++ b/templates/definition/meter/wattsonic.yaml
@@ -17,12 +17,8 @@ params:
   - name: capacity
     advanced: true
   - name: minsoc
-    type: int
-    default: 20
     advanced: true
   - name: maxsoc
-    type: int
-    default: 95
     advanced: true
   - name: delay
     default: 100ms


### PR DESCRIPTION
> check all meter templates using "type: custom". for any minsoc and maxsoc properties remove the type and the default values if they are equal to minsoc=20 and maxsoc=95.  

- Remove redundant type and default value specifications for minsoc=20 and maxsoc=95 from custom meter templates
- Reduces configuration verbosity while maintaining functionality

🤖 Generated with [Claude Code](https://claude.ai/code)