### PR TITLE
Config UI: fix icon in customer chargers

### DIFF
--- a/assets/js/components/Config/ChargerModal.vue
+++ b/assets/js/components/Config/ChargerModal.vue
@@ -304,6 +304,10 @@ export default defineComponent({
 			if (this.values.type === ConfigType.Template) {
 				data["template"] = this.templateName;
 			}
+			if (this.showYamlInput) {
+				// Icon is extracted from yaml on GET for UI purpose only. Don't write it back.
+				delete data["icon"];
+			}
 			return data;
 		},
 		isNew() {

--- a/assets/js/components/Config/defaultYaml/customCharger.yaml
+++ b/assets/js/components/Config/defaultYaml/customCharger.yaml
@@ -15,6 +15,7 @@ maxcurrent: # set maximum charge current in A
 
 ## optional attributes (read-only)
 
+#icon: generic # icon for UI purpose only
 #power: # charge power in W
 #  source: const
 #  value: 11000

--- a/assets/js/components/Config/defaultYaml/customHeater.yaml
+++ b/assets/js/components/Config/defaultYaml/customHeater.yaml
@@ -17,6 +17,8 @@ features:
   - heating # treat as a heating device
   - integrateddevice # no charging sessions, no connected vehicles
 
+icon: heater # icon for UI purpose only
+
 ## optional attributes (read-only)
 
 #power: # heating power in W

--- a/assets/js/components/Config/defaultYaml/switchsocketCharger.yaml
+++ b/assets/js/components/Config/defaultYaml/switchsocketCharger.yaml
@@ -16,6 +16,7 @@ features:
 
 ## optional attributes (read-only)
 
+#icon: generic # icon for UI purpose only
 #energy: # meter reading in kWh
 #  source: const
 #  value: 42.5

--- a/assets/js/components/Config/defaultYaml/switchsocketHeater.yaml
+++ b/assets/js/components/Config/defaultYaml/switchsocketHeater.yaml
@@ -15,6 +15,8 @@ features:
   - heating # treat as a heating device
   - integrateddevice # no charging sessions, no connected vehicles
 
+icon: heater # icon for UI purpose only
+
 ## optional attributes (read-only)
 
 #energy: # meter reading in kWh


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/22942

Fix superfluous "icon" param for custom chargers. Add ´icon` to sample YAML files.

Background: When reading existing configuration we extract "icon" param from YAML-configuration to show the appropriate icon in the device tile. This change ensures that we do not write this extracted param back when testing and updating a device.