### PR TITLE
Allow (again) loadpoint configuration of 'phases', 'minCurrent' & 'maxCurrent' via evcc.yaml

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -313,15 +313,6 @@ func (lp *Loadpoint) restoreSettings() {
 	}
 
 	// deprecated yaml properties
-	if lp.Phases_ > 0 {
-		lp.log.WARN.Printf("ignoring deprecated phases: %d. please configure via UI", lp.Phases_)
-	}
-	if lp.MinCurrent_ > 0 {
-		lp.log.WARN.Printf("ignoring deprecated minCurrent: %f. please configure via UI", lp.MinCurrent_)
-	}
-	if lp.MaxCurrent_ > 0 {
-		lp.log.WARN.Printf("ignoring deprecated maxCurrent: %f. please configure via UI", lp.MaxCurrent_)
-	}
 	if lp.GuardDuration_ > 0 {
 		lp.log.WARN.Printf("ignoring deprecated guardduration: %s. please configure via UI", lp.GuardDuration_)
 	}
@@ -333,13 +324,23 @@ func (lp *Loadpoint) restoreSettings() {
 	if v, err := lp.settings.Int(keys.Priority); err == nil {
 		lp.setPriority(int(v))
 	}
-	if v, err := lp.settings.Int(keys.PhasesConfigured); err == nil && (v > 0 || lp.hasPhaseSwitching()) {
+	_deprecatedMsgTemplate := "setting '%s' via yaml is deprecated. A possible existing configuration done vie the GUI will be ignored during the restart."
+	if lp.Phases_ > 0 {
+		lp.log.WARN.Printf(_deprecatedMsgTemplate, "phases")
+		lp.setPhasesConfigured(lp.Phases_)
+	} else if v, err := lp.settings.Int(keys.PhasesConfigured); err == nil && (v > 0 || lp.hasPhaseSwitching()) {
 		lp.setPhasesConfigured(int(v))
 	}
-	if v, err := lp.settings.Float(keys.MinCurrent); err == nil && v > 0 {
+	if lp.MinCurrent_ > 0 {
+		lp.log.WARN.Printf(_deprecatedMsgTemplate, "minCurrent")
+		lp.setMinCurrent(lp.MinCurrent_)
+	} else if v, err := lp.settings.Float(keys.MinCurrent); err == nil && v > 0 {
 		lp.setMinCurrent(v)
 	}
-	if v, err := lp.settings.Float(keys.MaxCurrent); err == nil && v > 0 {
+	if lp.MaxCurrent_ > 0 {
+		lp.log.WARN.Printf(_deprecatedMsgTemplate, "maxCurrent")
+		lp.setMaxCurrent(lp.MaxCurrent_)
+	} else if v, err := lp.settings.Float(keys.MaxCurrent); err == nil && v > 0 {
 		lp.setMaxCurrent(v)
 	}
 	if v, err := lp.settings.Int(keys.LimitSoc); err == nil && v > 0 {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -324,21 +324,20 @@ func (lp *Loadpoint) restoreSettings() {
 	if v, err := lp.settings.Int(keys.Priority); err == nil {
 		lp.setPriority(int(v))
 	}
-	_deprecatedMsgTemplate := "setting '%s' via yaml is deprecated. A possible existing configuration done vie the GUI will be ignored during the restart."
 	if lp.Phases_ > 0 {
-		lp.log.WARN.Printf(_deprecatedMsgTemplate, "phases")
+		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the GUI will be ignored during the restart.", "phases")
 		lp.setPhasesConfigured(lp.Phases_)
 	} else if v, err := lp.settings.Int(keys.PhasesConfigured); err == nil && (v > 0 || lp.hasPhaseSwitching()) {
 		lp.setPhasesConfigured(int(v))
 	}
 	if lp.MinCurrent_ > 0 {
-		lp.log.WARN.Printf(_deprecatedMsgTemplate, "minCurrent")
+		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the GUI will be ignored during the restart.", "minCurrent")
 		lp.setMinCurrent(lp.MinCurrent_)
 	} else if v, err := lp.settings.Float(keys.MinCurrent); err == nil && v > 0 {
 		lp.setMinCurrent(v)
 	}
 	if lp.MaxCurrent_ > 0 {
-		lp.log.WARN.Printf(_deprecatedMsgTemplate, "maxCurrent")
+		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the GUI will be ignored during the restart.", "maxCurrent")
 		lp.setMaxCurrent(lp.MaxCurrent_)
 	} else if v, err := lp.settings.Float(keys.MaxCurrent); err == nil && v > 0 {
 		lp.setMaxCurrent(v)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -325,19 +325,19 @@ func (lp *Loadpoint) restoreSettings() {
 		lp.setPriority(int(v))
 	}
 	if lp.Phases_ > 0 {
-		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the GUI will be ignored during the restart.", "phases")
+		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the UI will be ignored during the restart.", "phases")
 		lp.setPhasesConfigured(lp.Phases_)
 	} else if v, err := lp.settings.Int(keys.PhasesConfigured); err == nil && (v > 0 || lp.hasPhaseSwitching()) {
 		lp.setPhasesConfigured(int(v))
 	}
 	if lp.MinCurrent_ > 0 {
-		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the GUI will be ignored during the restart.", "minCurrent")
+		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the UI will be ignored during the restart.", "minCurrent")
 		lp.setMinCurrent(lp.MinCurrent_)
 	} else if v, err := lp.settings.Float(keys.MinCurrent); err == nil && v > 0 {
 		lp.setMinCurrent(v)
 	}
 	if lp.MaxCurrent_ > 0 {
-		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the GUI will be ignored during the restart.", "maxCurrent")
+		lp.log.WARN.Printf("setting '%s' via yaml is deprecated. A possible existing configuration done via the UI will be ignored during the restart.", "maxCurrent")
 		lp.setMaxCurrent(lp.MaxCurrent_)
 	} else if v, err := lp.settings.Float(keys.MaxCurrent); err == nil && v > 0 {
 		lp.setMaxCurrent(v)


### PR DESCRIPTION
As (tried) to introduced in #22462 I want to be able (again) to configure my loadpoint via evcc.yaml. Even if my issue was marked as 'won't fix', Andreas said, I can give it a try - so I just did.

Based on my knowledge, (and local build version) there is no need to roll-back [this](https://github.com/evcc-io/evcc/pull/18137/files#diff-c456526d4bd9022a488ce32de208b40d86016e2c40b0c81a2dffe557c186377dL255-L272.) complete change. With some small adjustments in the loadpoint.go it's possible will bring back the functionality of setting phases, minCurrent & maxCurrent via yaml. 

For all users using the UI-Configuration, this change has no impact (as long as they do not configure the attributes in an additional evcc.yaml) - Of course when the values exist in the evcc.yaml, __then__ any UI based setting will be ignored on restart  of evcc. Any adjustment in the UI while evcc is running will still work as they are. But it's correct on restart (when attributes exist), UI settings will be ignored... That's why the warning is generated.

_IMHO that's fine_ - since I don't want to use the UI anyhow - and as long as evcc.yaml exists, I will/want use it.

You might like to improve/enhance the log-message.