### PR TITLE
Add Sigenergy EVAC series charger

### DIFF
--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -2,7 +2,7 @@ package charger
 
 // LICENSE
 
-// Copyright © 2025 premultiply
+// Copyright (c) 2025 premultiply
 
 // This module is NOT covered by the MIT license. All rights reserved.
 

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -1,5 +1,22 @@
 package charger
 
+// LICENSE
+
+// Copyright © 2025 premultiply
+
+// This module is NOT covered by the MIT license. All rights reserved.
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 import (
 	"context"
 	"encoding/binary"
@@ -12,7 +29,6 @@ import (
 )
 
 // Sigenergy charger implementation
-// Based on https://github.com/TypQxQ/Sigenergy-Local-Modbus/tree/main/custom_components/sigen
 type Sigenergy struct {
 	*embed
 	log     *util.Logger

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -187,7 +187,7 @@ var _ api.Diagnosis = (*Sigenergy)(nil)
 func (wb *Sigenergy) Diagnose() {
 	if b, err := wb.conn.ReadHoldingRegisters(regSigSystemState, 1); err == nil {
 		state := binary.BigEndian.Uint16(b)
-		stateNames := []string{"Initializing", "Not Connected", "Reserving", "Preparing", "EV Ready", "Charging", "Fault", "Error"}
+		stateNames := []string{"System init", "A1/A2", "B1", "B2", "C1", "C2", "F", "E"}
 		stateName := "Unknown"
 		if int(state) < len(stateNames) {
 			stateName = stateNames[state]
@@ -197,16 +197,16 @@ func (wb *Sigenergy) Diagnose() {
 
 	if b, err := wb.conn.ReadHoldingRegisters(regSigOutputCurrent, 2); err == nil {
 		current := float64(binary.BigEndian.Uint32(b)) / 100
-		fmt.Printf("\tOutput Current:\t%.1fA\n", current)
+		fmt.Printf("\tOutput Current:\t%.2f A\n", current)
 	}
 
 	if b, err := wb.conn.ReadHoldingRegisters(regSigChargingPower, 2); err == nil {
 		powerKW := float64(int32(binary.BigEndian.Uint32(b))) / 1000
-		fmt.Printf("\tCharging Power:\t%.1fkW\n", powerKW)
+		fmt.Printf("\tCharging Power:\t%.3f kW\n", powerKW)
 	}
 
 	if b, err := wb.conn.ReadHoldingRegisters(regSigTotalEnergyConsumed, 2); err == nil {
 		energy := float64(binary.BigEndian.Uint32(b)) / 100
-		fmt.Printf("\tTotal Energy:\t%.1fkWh\n", energy)
+		fmt.Printf("\tTotal Energy:\t%.2f kWh\n", energy)
 	}
 }

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -160,7 +160,7 @@ func (wb *Sigenergy) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
-	return float64(int32(binary.BigEndian.Uint32(b))), nil
+	return float64(binary.BigEndian.Uint32(b)), nil
 }
 
 var _ api.MeterEnergy = (*Sigenergy)(nil)

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -171,9 +171,8 @@ func (wb *Sigenergy) currentPower() (float64, error) {
 		return 0, err
 	}
 
-	// S32 register with gain 1000, divide by 1000 to get kW, then convert to W
-	powerKW := float64(int32(binary.BigEndian.Uint32(b))) / 1000
-	return powerKW * 1000, nil
+	// S32 register with gain 1000, convert directly to W
+	return float64(int32(binary.BigEndian.Uint32(b))), nil
 }
 
 // totalEnergy implements the api.MeterEnergy interface  

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -147,8 +147,7 @@ func (wb *Sigenergy) MaxCurrentMillis(current float64) error {
 
 	b := make([]byte, 4)
 
-	curr := uint32(current * 100)
-	binary.BigEndian.PutUint32(b, curr)
+	binary.BigEndian.PutUint32(b, uint32(current*100)) // Convert to mA (100x for 0.01 A resolution)
 
 	_, err := wb.conn.WriteMultipleRegisters(regSigOutputCurrent, 2, b)
 
@@ -164,7 +163,6 @@ func (wb *Sigenergy) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
-	// S32 register with gain 1000, convert directly to W
 	return float64(int32(binary.BigEndian.Uint32(b))), nil
 }
 

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -142,8 +142,9 @@ func (wb *Sigenergy) Enable(enable bool) error {
 	}
 
 	// Write U32 value to register (2 registers)
-	_, err := wb.conn.WriteMultipleRegisters(sigenACChargerOutputCurrent, 2, 
-		[]byte{byte(u >> 24), byte(u >> 16), byte(u >> 8), byte(u)})
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, u)
+	_, err := wb.conn.WriteMultipleRegisters(sigenACChargerOutputCurrent, 2, b)
 	return err
 }
 
@@ -153,8 +154,9 @@ func (wb *Sigenergy) MaxCurrent(current int64) error {
 	u := uint32(curr) * 100 // Apply gain 100
 	
 	// Write U32 value to register (2 registers)
-	_, err := wb.conn.WriteMultipleRegisters(sigenACChargerOutputCurrent, 2,
-		[]byte{byte(u >> 24), byte(u >> 16), byte(u >> 8), byte(u)})
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, u)
+	_, err := wb.conn.WriteMultipleRegisters(sigenACChargerOutputCurrent, 2, b)
 	if err == nil {
 		wb.current = curr
 	}

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -41,19 +41,17 @@ func NewSigenergyFromConfig(ctx context.Context, other map[string]interface{}) (
 	cc := struct {
 		embed              `mapstructure:",squash"`
 		modbus.TcpSettings `mapstructure:",squash"`
-		MinCurrent         uint16
 	}{
 		TcpSettings: modbus.TcpSettings{
 			ID: 1,
 		},
-		MinCurrent: 6, // Default minimum current as per register description
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	wb, err := NewSigenergy(ctx, cc.embed, cc.URI, cc.ID, cc.MinCurrent)
+	wb, err := NewSigenergy(ctx, cc.embed, cc.URI, cc.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +70,7 @@ func NewSigenergyFromConfig(ctx context.Context, other map[string]interface{}) (
 }
 
 // NewSigenergy creates a new charger
-func NewSigenergy(ctx context.Context, embed embed, uri string, slaveID uint8, minCurrent uint16) (*Sigenergy, error) {
+func NewSigenergy(ctx context.Context, embed embed, uri string, slaveID uint8) (*Sigenergy, error) {
 	conn, err := modbus.NewConnection(ctx, uri, "", "", 0, modbus.Tcp, slaveID)
 	if err != nil {
 		return nil, err
@@ -85,7 +83,6 @@ func NewSigenergy(ctx context.Context, embed embed, uri string, slaveID uint8, m
 		embed:      &embed,
 		log:        log,
 		conn:       conn,
-		minCurrent: minCurrent,
 	}
 
 	return wb, nil

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -49,12 +49,8 @@ func init() {
 
 // NewSigenergyFromConfig creates a new Sigenergy ModbusTCP charger
 func NewSigenergyFromConfig(ctx context.Context, other map[string]interface{}) (api.Charger, error) {
-	cc := struct {
-		modbus.TcpSettings `mapstructure:",squash"`
-	}{
-		TcpSettings: modbus.TcpSettings{
-			ID: 1,
-		},
+	cc := modbus.TcpSettings{
+		ID: 1,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -1,0 +1,227 @@
+package charger
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/modbus"
+)
+
+// Sigenergy charger implementation
+// Based on https://github.com/TypQxQ/Sigenergy-Local-Modbus/tree/main/custom_components/sigen
+type Sigenergy struct {
+	*embed
+	log         *util.Logger
+	conn        *modbus.Connection
+	current     uint16
+	minCurrent  uint16
+}
+
+const (
+	// AC Charger Running Info Registers
+	sigenACChargerSystemState         = 32000 // System states according to IEC61851-1 definition
+	sigenACChargerTotalEnergyConsumed = 32001 // kWh, total energy consumed during charging
+	sigenACChargerChargingPower       = 32003 // kW, instantaneous charging power
+	
+	// AC Charger Parameter Registers
+	sigenACChargerOutputCurrent       = 42001 // Amperes, R/W, charger output current ([6, X] X is the smaller value between the rated current and the AC-Charger input breaker rated current.)
+)
+
+func init() {
+	registry.AddCtx("sigenergy", NewSigenergyFromConfig)
+}
+
+//go:generate go tool decorate -f decorateSigenergy -b *Sigenergy -r api.Charger -t "api.Meter,CurrentPower,func() (float64, error)" -t "api.MeterEnergy,TotalEnergy,func() (float64, error)"
+
+// NewSigenergyFromConfig creates a new Sigenergy ModbusTCP charger
+func NewSigenergyFromConfig(ctx context.Context, other map[string]interface{}) (api.Charger, error) {
+	cc := struct {
+		embed              `mapstructure:",squash"`
+		modbus.TcpSettings `mapstructure:",squash"`
+		MinCurrent         uint16
+	}{
+		TcpSettings: modbus.TcpSettings{
+			ID: 1,
+		},
+		MinCurrent: 6, // Default minimum current as per register description
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	wb, err := NewSigenergy(ctx, cc.embed, cc.URI, cc.ID, cc.MinCurrent)
+	if err != nil {
+		return nil, err
+	}
+
+	// optional features
+	var (
+		currentPower func() (float64, error)
+		totalEnergy  func() (float64, error)
+	)
+
+	// Enable power and energy measurement
+	currentPower = wb.currentPower
+	totalEnergy = wb.totalEnergy
+
+	return decorateSigenergy(wb, currentPower, totalEnergy), nil
+}
+
+// NewSigenergy creates a new charger
+func NewSigenergy(ctx context.Context, embed embed, uri string, slaveID uint8, minCurrent uint16) (*Sigenergy, error) {
+	conn, err := modbus.NewConnection(ctx, uri, "", "", 0, modbus.Tcp, slaveID)
+	if err != nil {
+		return nil, err
+	}
+
+	log := util.NewLogger("sigenergy")
+	conn.Logger(log.TRACE)
+
+	wb := &Sigenergy{
+		embed:      &embed,
+		log:        log,
+		conn:       conn,
+		minCurrent: minCurrent,
+	}
+
+	return wb, nil
+}
+
+// Status implements the api.Charger interface
+func (wb *Sigenergy) Status() (api.ChargeStatus, error) {
+	b, err := wb.conn.ReadHoldingRegisters(sigenACChargerSystemState, 1)
+	if err != nil {
+		return api.StatusNone, err
+	}
+
+	state := binary.BigEndian.Uint16(b)
+
+	// System states according to IEC61851-1 definition:
+	// 0: Initializing
+	// 1: Not Connected
+	// 2: Reserving  
+	// 3: Preparing
+	// 4: EV Ready
+	// 5: Charging
+	// 6: Fault
+	// 7: Error
+
+	switch state {
+	case 5: // Charging
+		return api.StatusC, nil
+	case 4: // EV Ready
+		return api.StatusB, nil
+	case 1: // Not Connected
+		return api.StatusA, nil
+	case 6, 7: // Fault, Error
+		return api.StatusF, nil
+	default: // Initializing, Reserving, Preparing
+		return api.StatusB, nil
+	}
+}
+
+// Enabled implements the api.Charger interface
+func (wb *Sigenergy) Enabled() (bool, error) {
+	b, err := wb.conn.ReadHoldingRegisters(sigenACChargerOutputCurrent, 2)
+	if err != nil {
+		return false, err
+	}
+
+	// U32 register with gain 100, so divide by 100 to get amperes
+	current := float64(binary.BigEndian.Uint32(b)) / 100
+	return current >= float64(wb.minCurrent), nil
+}
+
+// Enable implements the api.Charger interface
+func (wb *Sigenergy) Enable(enable bool) error {
+	var u uint32
+	if enable {
+		u = uint32(wb.current) * 100 // Apply gain 100
+		if u < uint32(wb.minCurrent)*100 {
+			u = uint32(wb.minCurrent) * 100
+		}
+	} else {
+		u = 0
+	}
+
+	// Write U32 value to register (2 registers)
+	_, err := wb.conn.WriteMultipleRegisters(sigenACChargerOutputCurrent, 2, 
+		[]byte{byte(u >> 24), byte(u >> 16), byte(u >> 8), byte(u)})
+	return err
+}
+
+// MaxCurrent implements the api.Charger interface
+func (wb *Sigenergy) MaxCurrent(current int64) error {
+	if current < int64(wb.minCurrent) {
+		return fmt.Errorf("current %d below minimum %d", current, wb.minCurrent)
+	}
+
+	curr := uint16(current)
+	u := uint32(curr) * 100 // Apply gain 100
+	
+	// Write U32 value to register (2 registers)
+	_, err := wb.conn.WriteMultipleRegisters(sigenACChargerOutputCurrent, 2,
+		[]byte{byte(u >> 24), byte(u >> 16), byte(u >> 8), byte(u)})
+	if err == nil {
+		wb.current = curr
+	}
+
+	return err
+}
+
+// currentPower implements the api.Meter interface
+func (wb *Sigenergy) currentPower() (float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(sigenACChargerChargingPower, 2)
+	if err != nil {
+		return 0, err
+	}
+
+	// S32 register with gain 1000, divide by 1000 to get kW, then convert to W
+	powerKW := float64(int32(binary.BigEndian.Uint32(b))) / 1000
+	return powerKW * 1000, nil
+}
+
+// totalEnergy implements the api.MeterEnergy interface  
+func (wb *Sigenergy) totalEnergy() (float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(sigenACChargerTotalEnergyConsumed, 2)
+	if err != nil {
+		return 0, err
+	}
+
+	// U32 register with gain 100, divide by 100 to get kWh
+	return float64(binary.BigEndian.Uint32(b)) / 100, nil
+}
+
+var _ api.Diagnosis = (*Sigenergy)(nil)
+
+// Diagnose implements the api.Diagnosis interface
+func (wb *Sigenergy) Diagnose() {
+	if b, err := wb.conn.ReadHoldingRegisters(sigenACChargerSystemState, 1); err == nil {
+		state := binary.BigEndian.Uint16(b)
+		stateNames := []string{"Initializing", "Not Connected", "Reserving", "Preparing", "EV Ready", "Charging", "Fault", "Error"}
+		stateName := "Unknown"
+		if int(state) < len(stateNames) {
+			stateName = stateNames[state]
+		}
+		fmt.Printf("\tSystem State:\t%d (%s)\n", state, stateName)
+	}
+	
+	if b, err := wb.conn.ReadHoldingRegisters(sigenACChargerOutputCurrent, 2); err == nil {
+		current := float64(binary.BigEndian.Uint32(b)) / 100
+		fmt.Printf("\tOutput Current:\t%.1fA\n", current)
+	}
+	
+	if b, err := wb.conn.ReadHoldingRegisters(sigenACChargerChargingPower, 2); err == nil {
+		powerKW := float64(int32(binary.BigEndian.Uint32(b))) / 1000
+		fmt.Printf("\tCharging Power:\t%.1fkW\n", powerKW)
+	}
+	
+	if b, err := wb.conn.ReadHoldingRegisters(sigenACChargerTotalEnergyConsumed, 2); err == nil {
+		energy := float64(binary.BigEndian.Uint32(b)) / 100
+		fmt.Printf("\tTotal Energy:\t%.1fkWh\n", energy)
+	}
+}

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/modbus"
+	"github.com/evcc-io/evcc/util/sponsor"
 )
 
 // Sigenergy charger implementation
@@ -53,6 +54,10 @@ func NewSigenergy(ctx context.Context, embed embed, uri string, slaveID uint8) (
 	conn, err := modbus.NewConnection(ctx, uri, "", "", 0, modbus.Tcp, slaveID)
 	if err != nil {
 		return nil, err
+	}
+
+	if !sponsor.IsAuthorized() {
+		return nil, api.ErrSponsorRequired
 	}
 
 	log := util.NewLogger("sigenergy")

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -33,7 +33,6 @@ type Sigenergy struct {
 	*embed
 	log     *util.Logger
 	conn    *modbus.Connection
-	current uint32
 	enabled bool
 }
 
@@ -152,9 +151,6 @@ func (wb *Sigenergy) MaxCurrentMillis(current float64) error {
 	binary.BigEndian.PutUint32(b, curr)
 
 	_, err := wb.conn.WriteMultipleRegisters(regSigOutputCurrent, 2, b)
-	if err == nil {
-		wb.current = curr
-	}
 
 	return err
 }

--- a/charger/sigenergy.go
+++ b/charger/sigenergy.go
@@ -24,6 +24,7 @@ const (
 	regSigSystemState         = 32000 // System states according to IEC61851-1 definition
 	regSigTotalEnergyConsumed = 32001 // kWh, total energy consumed during charging
 	regSigChargingPower       = 32003 // kW, instantaneous charging power
+	regSigStartStop           = 42000 // Start/Stop charger (0: Start 1: Stop), WO
 	regSigOutputCurrent       = 42001 // Amperes, R/W, charger output current ([6, X] X is the smaller value between the rated current and the AC-Charger input breaker rated current.)
 )
 

--- a/templates/definition/charger/sigenergy.yaml
+++ b/templates/definition/charger/sigenergy.yaml
@@ -1,0 +1,15 @@
+template: sigenergy
+products:
+  - brand: Sigenergy
+    description:
+      generic: EV Charger
+capabilities: ["mA"]
+requirements:
+  evcc: ["sponsorship"]
+params:
+  - name: modbus
+    choice: ["tcpip"]
+    id: 1
+render: |
+  type: sigenergy
+  {{- include "modbus" . }}

--- a/templates/definition/charger/sigenergy.yaml
+++ b/templates/definition/charger/sigenergy.yaml
@@ -2,7 +2,7 @@ template: sigenergy
 products:
   - brand: Sigenergy
     description:
-      generic: EV Charger
+      generic: EVAC series
 capabilities: ["mA"]
 requirements:
   evcc: ["sponsorship"]


### PR DESCRIPTION
## Summary
- Add Modbus TCP charger implementation for Sigenergy EV chargers
- Implements api.Charger, api.Meter, api.MeterEnergy interfaces

Fixes https://github.com/evcc-io/evcc/issues/22932