### PR TITLE
Config UI: split SMA HEMS into separate config (BC)

### DIFF
--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -64,11 +64,23 @@ var _ api.Redactor = (*Hems)(nil)
 type Hems config.Typed
 
 func (c Hems) Redacted() any {
-	return struct {
-		Type string `json:"type,omitempty"`
-	}{
-		Type: c.Type,
+	var allowControl bool
+	if v, ok := c.Other["allowcontrol"]; ok && v != nil {
+		allowControl, _ = v.(bool)
 	}
+	var vendorId string
+	if v, ok := c.Other["vendorid"]; ok && v != nil {
+		vendorId, _ = v.(string)
+	}
+	var deviceId string
+	if v, ok := c.Other["deviceid"]; ok && v != nil {
+		deviceId, _ = v.(string)
+	}
+	return Hems{Type: c.Type, Other: map[string]any{
+		"allowcontrol": allowControl,
+		"vendorId":     vendorId,
+		"deviceId":     deviceId,
+	}}
 }
 
 var _ api.Redactor = (*Mqtt)(nil)

--- a/assets/js/components/Config/DeviceModal/TemplateSelector.vue
+++ b/assets/js/components/Config/DeviceModal/TemplateSelector.vue
@@ -51,7 +51,7 @@ export interface PrimaryOption {
 
 export interface TemplateGroup {
 	label: string;
-	options: TemplateOption[];
+	options?: TemplateOption[];
 }
 
 export default defineComponent({

--- a/assets/js/components/Config/HemsModal.vue
+++ b/assets/js/components/Config/HemsModal.vue
@@ -6,7 +6,6 @@
 		docs="/docs/reference/configuration/hems"
 		endpoint="/config/hems"
 		state-key="hems"
-		:offerSaveWithoutModifications="true"
 		:initalValues="{ Other: {} }"
 		data-testid="hems-modal"
 		@changed="$emit('changed')"

--- a/assets/js/components/Config/HemsModal.vue
+++ b/assets/js/components/Config/HemsModal.vue
@@ -6,75 +6,87 @@
 		docs="/docs/reference/configuration/hems"
 		endpoint="/config/hems"
 		state-key="hems"
+		:disableRemove="true"
 		:initalValues="{ Other: {} }"
 		data-testid="hems-modal"
 		@changed="$emit('changed')"
 	>
 		<template #default="{ values }">
-			<TemplateSelector
-				device-type="hems"
-				:is-new="false"
-				product-name="Sunny Home Manager 2.0"
-			/>
-			<FormRow id="hemsControl" :label="$t('config.hems.labelControl')" optional>
-				<div class="d-flex">
-					<input
-						id="hemsControl"
-						v-model="values.Other.allowcontrol"
-						class="form-check-input"
-						type="checkbox"
-					/>
-					<label class="form-check-label ms-2" for="hemsControl">
-						{{ $t("config.hems.labelAllowControl") }}
-					</label>
-				</div>
-			</FormRow>
-			<PropertyCollapsible>
-				<template #advanced>
-					<FormRow
-						id="hemsVendorid"
-						:label="$t('config.hems.labelVendorid')"
-						:help="$t('config.hems.descriptionVendorid')"
-						example="12312312"
-						optional
-					>
+			<div class="mb-4">
+				<label for="hemsSystemSelect" class="form-label">{{
+					$t("config.hems.template")
+				}}</label>
+				<select
+					name="hemsSystem"
+					id="hemsSystemSelect"
+					class="form-select w-100"
+					:value="values.type"
+					@input="(e) => (values.type = (e.target as HTMLInputElement).value)"
+				>
+					<option value="">{{ $t("config.hems.noSystem") }}</option>
+					<option value="sma">Sunny Home Manager 2.0</option>
+				</select>
+			</div>
+			<div v-if="values.type">
+				<FormRow id="hemsControl" :label="$t('config.hems.labelControl')" optional>
+					<div class="d-flex">
 						<input
-							id="hemsVendorid"
-							v-model="values.Other.vendorId"
-							class="form-control"
-							minlength="8"
-							maxlength="8"
+							id="hemsControl"
+							v-model="values.Other.allowcontrol"
+							class="form-check-input"
+							type="checkbox"
 						/>
-					</FormRow>
-					<FormRow
-						id="hemsDeviceid"
-						:label="$t('config.hems.labelDeviceid')"
-						:help="$t('config.hems.descriptionDeviceid')"
-						example="BBBBBBBBBBBB"
-						optional
-					>
-						<input
+						<label class="form-check-label ms-2" for="hemsControl">
+							{{ $t("config.hems.labelAllowControl") }}
+						</label>
+					</div>
+				</FormRow>
+				<PropertyCollapsible>
+					<template #advanced>
+						<FormRow
+							id="hemsVendorid"
+							:label="$t('config.hems.labelVendorid')"
+							:help="$t('config.hems.descriptionVendorid')"
+							example="12312312"
+							optional
+						>
+							<input
+								id="hemsVendorid"
+								v-model="values.Other.vendorId"
+								class="form-control"
+								minlength="8"
+								maxlength="8"
+							/>
+						</FormRow>
+						<FormRow
 							id="hemsDeviceid"
-							v-model="values.Other.deviceId"
-							class="form-control"
-							minlength="10"
-							maxlength="10"
-						/> </FormRow
-				></template>
-			</PropertyCollapsible>
+							:label="$t('config.hems.labelDeviceid')"
+							:help="$t('config.hems.descriptionDeviceid')"
+							example="BBBBBBBBBBBB"
+							optional
+						>
+							<input
+								id="hemsDeviceid"
+								v-model="values.Other.deviceId"
+								class="form-control"
+								minlength="10"
+								maxlength="10"
+							/> </FormRow
+					></template>
+				</PropertyCollapsible>
+			</div>
 		</template>
 	</JsonModal>
 </template>
 
 <script lang="ts">
-import TemplateSelector from "./DeviceModal/TemplateSelector.vue";
 import FormRow from "./FormRow.vue";
 import JsonModal from "./JsonModal.vue";
 import PropertyCollapsible from "./PropertyCollapsible.vue";
 
 export default {
 	name: "HemsModal",
-	components: { JsonModal, TemplateSelector, FormRow, PropertyCollapsible },
+	components: { JsonModal, FormRow, PropertyCollapsible },
 	emits: ["changed"],
 };
 </script>

--- a/assets/js/components/Config/HemsModal.vue
+++ b/assets/js/components/Config/HemsModal.vue
@@ -1,27 +1,81 @@
 <template>
-	<YamlModal
+	<JsonModal
 		id="hemsModal"
 		:title="$t('config.hems.title')"
 		:description="$t('config.hems.description')"
 		docs="/docs/reference/configuration/hems"
-		:defaultYaml="defaultYaml"
 		endpoint="/config/hems"
-		removeKey="hems"
-		size="md"
+		state-key="hems"
+		:offerSaveWithoutModifications="true"
+		:initalValues="{ Other: {} }"
+		data-testid="hems-modal"
 		@changed="$emit('changed')"
-	/>
+	>
+		<template #default="{ values }">
+			<TemplateSelector
+				device-type="hems"
+				:is-new="false"
+				product-name="Sunny Home Manager 2.0"
+			/>
+			<FormRow id="hemsControl" :label="$t('config.hems.labelControl')" optional>
+				<div class="d-flex">
+					<input
+						id="hemsControl"
+						v-model="values.Other.allowcontrol"
+						class="form-check-input"
+						type="checkbox"
+					/>
+					<label class="form-check-label ms-2" for="hemsControl">
+						{{ $t("config.hems.labelAllowControl") }}
+					</label>
+				</div>
+			</FormRow>
+			<PropertyCollapsible>
+				<template #advanced>
+					<FormRow
+						id="hemsVendorid"
+						:label="$t('config.hems.labelVendorid')"
+						:help="$t('config.hems.descriptionVendorid')"
+						example="12312312"
+						optional
+					>
+						<input
+							id="hemsVendorid"
+							v-model="values.Other.vendorId"
+							class="form-control"
+							minlength="8"
+							maxlength="8"
+						/>
+					</FormRow>
+					<FormRow
+						id="hemsDeviceid"
+						:label="$t('config.hems.labelDeviceid')"
+						:help="$t('config.hems.descriptionDeviceid')"
+						example="BBBBBBBBBBBB"
+						optional
+					>
+						<input
+							id="hemsDeviceid"
+							v-model="values.Other.deviceId"
+							class="form-control"
+							minlength="10"
+							maxlength="10"
+						/> </FormRow
+				></template>
+			</PropertyCollapsible>
+		</template>
+	</JsonModal>
 </template>
 
-<script>
-import YamlModal from "./YamlModal.vue";
-import defaultYaml from "./defaultYaml/hems.yaml?raw";
+<script lang="ts">
+import TemplateSelector from "./DeviceModal/TemplateSelector.vue";
+import FormRow from "./FormRow.vue";
+import JsonModal from "./JsonModal.vue";
+import PropertyCollapsible from "./PropertyCollapsible.vue";
 
 export default {
 	name: "HemsModal",
-	components: { YamlModal },
+	components: { JsonModal, TemplateSelector, FormRow, PropertyCollapsible },
 	emits: ["changed"],
-	data() {
-		return { defaultYaml: defaultYaml.trim() };
-	},
 };
 </script>

--- a/assets/js/components/Config/HemsModal.vue
+++ b/assets/js/components/Config/HemsModal.vue
@@ -13,9 +13,9 @@
 	>
 		<template #default="{ values }">
 			<div class="mb-4">
-				<label for="hemsSystemSelect" class="form-label">{{
-					$t("config.hems.template")
-				}}</label>
+				<label for="hemsSystemSelect" class="form-label">
+					{{ $t("config.hems.template") }}
+				</label>
 				<select
 					name="hemsSystem"
 					id="hemsSystemSelect"

--- a/assets/js/components/Config/JsonModal.vue
+++ b/assets/js/components/Config/JsonModal.vue
@@ -83,7 +83,12 @@ export default {
 		transformReadValues: Function,
 		stateKey: String,
 		saveMethod: { type: String, default: "post" },
-		initalValues: { type: Object, default: () => {} },
+		initalValues: {
+			type: Object,
+			default: () => {
+				return {};
+			},
+		},
 	},
 	emits: ["changed", "open"],
 	data() {

--- a/assets/js/components/Config/JsonModal.vue
+++ b/assets/js/components/Config/JsonModal.vue
@@ -47,7 +47,7 @@
 				<button
 					type="submit"
 					class="btn btn-primary order-1 order-sm-2 flex-grow-1 flex-sm-grow-0 px-4"
-					:disabled="saving || nothingChanged"
+					:disabled="!offerSaveWithoutModifications && (saving || nothingChanged)"
 				>
 					<span
 						v-if="saving"
@@ -67,6 +67,7 @@ import GenericModal from "../Helper/GenericModal.vue";
 import api from "@/api";
 import { docsPrefix } from "@/i18n";
 import store from "@/store";
+import deepClone from "@/utils/deepClone";
 
 export default {
 	name: "JsonModal",
@@ -82,6 +83,8 @@ export default {
 		transformReadValues: Function,
 		stateKey: String,
 		saveMethod: { type: String, default: "post" },
+		offerSaveWithoutModifications: Boolean,
+		initalValues: { type: Object, default: () => {} },
 	},
 	emits: ["changed", "open"],
 	data() {
@@ -89,7 +92,7 @@ export default {
 			saving: false,
 			removing: false,
 			error: "",
-			values: {},
+			values: this.initalValues,
 			serverValues: {},
 		};
 	},
@@ -119,7 +122,8 @@ export default {
 			if (this.transformReadValues) {
 				this.serverValues = this.transformReadValues(this.serverValues);
 			}
-			this.values = { ...this.serverValues };
+
+			this.values = deepClone(this.serverValues);
 		},
 		async save() {
 			this.saving = true;

--- a/assets/js/components/Config/JsonModal.vue
+++ b/assets/js/components/Config/JsonModal.vue
@@ -47,7 +47,7 @@
 				<button
 					type="submit"
 					class="btn btn-primary order-1 order-sm-2 flex-grow-1 flex-sm-grow-0 px-4"
-					:disabled="!offerSaveWithoutModifications && (saving || nothingChanged)"
+					:disabled="saving || nothingChanged"
 				>
 					<span
 						v-if="saving"
@@ -83,7 +83,6 @@ export default {
 		transformReadValues: Function,
 		stateKey: String,
 		saveMethod: { type: String, default: "post" },
-		offerSaveWithoutModifications: Boolean,
 		initalValues: { type: Object, default: () => {} },
 	},
 	emits: ["changed", "open"],

--- a/assets/js/components/Config/defaultYaml/hems.yaml
+++ b/assets/js/components/Config/defaultYaml/hems.yaml
@@ -1,4 +1,0 @@
-#type: sma
-#allowcontrol: false
-#vendorid: AAAAAAAA
-#deviceid: BBBBBBBB

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -318,7 +318,7 @@ export interface SelectOption<T> {
   disabled?: boolean;
 }
 
-export type DeviceType = "charger" | "meter" | "vehicle" | "loadpoint";
+export type DeviceType = "charger" | "meter" | "vehicle" | "loadpoint" | "hems";
 export type SelectedMeterType = "grid" | "pv" | "battery" | "charge" | "aux" | "ext";
 
 // see https://stackoverflow.com/a/54178819

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -318,7 +318,7 @@ export interface SelectOption<T> {
   disabled?: boolean;
 }
 
-export type DeviceType = "charger" | "meter" | "vehicle" | "loadpoint" | "hems";
+export type DeviceType = "charger" | "meter" | "vehicle" | "loadpoint";
 export type SelectedMeterType = "grid" | "pv" | "battery" | "charge" | "aux" | "ext";
 
 // see https://stackoverflow.com/a/54178819

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -177,6 +177,13 @@
     },
     "hems": {
       "description": "Connect evcc to another home energy management system.",
+      "descriptionDeviceid": "TODO",
+      "descriptionVendorid": "TODO",
+      "labelAllowControl": "System should take over the charging control of evcc",
+      "labelControl": "Control",
+      "labelDeviceid": "Device ID",
+      "labelVendorid": "Vendor ID",
+      "template": "System",
       "title": "HEMS"
     },
     "icon": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -183,6 +183,7 @@
       "labelControl": "Control",
       "labelDeviceid": "Device ID",
       "labelVendorid": "Vendor ID",
+      "noSystem": "none",
       "template": "System",
       "title": "HEMS"
     },

--- a/server/http.go
+++ b/server/http.go
@@ -292,7 +292,6 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, valueChan chan<- util.Par
 		// yaml handlers
 		for key, fun := range map[string]func() (any, any){
 			keys.EEBus:       func() (any, any) { return map[string]any{}, eebus.Config{} },
-			keys.Hems:        func() (any, any) { return map[string]any{}, config.Typed{} },
 			keys.Tariffs:     func() (any, any) { return map[string]any{}, globalconfig.Tariffs{} },
 			keys.Messaging:   func() (any, any) { return map[string]any{}, globalconfig.Messaging{} },       // has default
 			keys.ModbusProxy: func() (any, any) { return []map[string]any{}, []globalconfig.ModbusProxy{} }, // slice
@@ -306,6 +305,7 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, valueChan chan<- util.Par
 
 		// json handlers
 		for key, fun := range map[string]func() any{
+			keys.Hems:    func() any { return new(globalconfig.Hems) },
 			keys.Network: func() any { return new(globalconfig.Network) }, // has default
 			keys.Mqtt:    func() any { return new(globalconfig.Mqtt) },    // has default
 			keys.Influx:  func() any { return new(globalconfig.Influx) },


### PR DESCRIPTION
✨ switch from yaml input to text fields and check box
💪 use TypeScript

TODO:
- [ ] migration strategy
- [ ] add descriptions and explanations for `Vendor ID` and `Device ID`
- [ ] testing

\cc @naltatis 

<img width="600" alt="grafik" src="https://github.com/user-attachments/assets/9f974180-f308-4f4b-bfee-6829a7be8b31" />
<img  width="600" alt="grafik" src="https://github.com/user-attachments/assets/cc28aaae-715a-4f1b-b3b2-d37e6953d0c1" />
