### PR TITLE
Fix non-deterministic parseAddOnSwitchID in Shelly Gen2

### DIFF
--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -330,16 +330,22 @@ func (c *gen2) getAddOnSwitchId(channel int) (int, error) {
 }
 
 func parseAddOnSwitchID(channel int, res Gen2ProAddOnGetPeripherals) (int, error) {
+	var ids []int
+
 	for key := range res.DigitalOut {
 		if strings.HasPrefix(key, "switch:") {
 			var id int
 			if _, err := fmt.Sscanf(key, "switch:%d", &id); err != nil {
 				return 0, fmt.Errorf("failed to get add-on switch id: %w", err)
 			}
-			return id, nil
+			ids = append(ids, id)
 		}
 	}
 
-	// if no switch ID is found, return the channel as default
-	return channel, nil
+	if len(ids) == 0 {
+		return channel, nil
+	}
+
+	// Return the minimum ID using slices.Min for deterministic behavior
+	return slices.Min(ids), nil
 }


### PR DESCRIPTION
Fix flapping test by making parseAddOnSwitchID deterministic. The function now uses slices.Min to always return the smallest switch ID, eliminating random behavior caused by Go map iteration order.