### PR TITLE
Tariffs: add cacheable feature

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -4,11 +4,12 @@ type Feature int
 
 //go:generate go tool enumer -type Feature -text
 const (
-	_ Feature = iota
-	Offline
-	CoarseCurrent
-	IntegratedDevice
-	Heating
-	Retryable
-	WelcomeCharge
+	_                Feature = iota
+	CoarseCurrent            // charger
+	IntegratedDevice         // charger
+	Heating                  // charger
+	Cacheable                // tariff
+	Offline                  // vehicle
+	Retryable                // vehicle
+	WelcomeCharge            // vehicle
 )

--- a/api/feature_enumer.go
+++ b/api/feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "OfflineCoarseCurrentIntegratedDeviceHeatingRetryableWelcomeCharge"
+const _FeatureName = "CoarseCurrentIntegratedDeviceHeatingCacheableOfflineRetryableWelcomeCharge"
 
-var _FeatureIndex = [...]uint8{0, 7, 20, 36, 43, 52, 65}
+var _FeatureIndex = [...]uint8{0, 13, 29, 36, 45, 52, 61, 74}
 
-const _FeatureLowerName = "offlinecoarsecurrentintegrateddeviceheatingretryablewelcomecharge"
+const _FeatureLowerName = "coarsecurrentintegrateddeviceheatingcacheableofflineretryablewelcomecharge"
 
 func (i Feature) String() string {
 	i -= 1
@@ -25,38 +25,42 @@ func (i Feature) String() string {
 // Re-run the stringer command to generate them again.
 func _FeatureNoOp() {
 	var x [1]struct{}
-	_ = x[Offline-(1)]
-	_ = x[CoarseCurrent-(2)]
-	_ = x[IntegratedDevice-(3)]
-	_ = x[Heating-(4)]
-	_ = x[Retryable-(5)]
-	_ = x[WelcomeCharge-(6)]
+	_ = x[CoarseCurrent-(1)]
+	_ = x[IntegratedDevice-(2)]
+	_ = x[Heating-(3)]
+	_ = x[Cacheable-(4)]
+	_ = x[Offline-(5)]
+	_ = x[Retryable-(6)]
+	_ = x[WelcomeCharge-(7)]
 }
 
-var _FeatureValues = []Feature{Offline, CoarseCurrent, IntegratedDevice, Heating, Retryable, WelcomeCharge}
+var _FeatureValues = []Feature{CoarseCurrent, IntegratedDevice, Heating, Cacheable, Offline, Retryable, WelcomeCharge}
 
 var _FeatureNameToValueMap = map[string]Feature{
-	_FeatureName[0:7]:        Offline,
-	_FeatureLowerName[0:7]:   Offline,
-	_FeatureName[7:20]:       CoarseCurrent,
-	_FeatureLowerName[7:20]:  CoarseCurrent,
-	_FeatureName[20:36]:      IntegratedDevice,
-	_FeatureLowerName[20:36]: IntegratedDevice,
-	_FeatureName[36:43]:      Heating,
-	_FeatureLowerName[36:43]: Heating,
-	_FeatureName[43:52]:      Retryable,
-	_FeatureLowerName[43:52]: Retryable,
-	_FeatureName[52:65]:      WelcomeCharge,
-	_FeatureLowerName[52:65]: WelcomeCharge,
+	_FeatureName[0:13]:       CoarseCurrent,
+	_FeatureLowerName[0:13]:  CoarseCurrent,
+	_FeatureName[13:29]:      IntegratedDevice,
+	_FeatureLowerName[13:29]: IntegratedDevice,
+	_FeatureName[29:36]:      Heating,
+	_FeatureLowerName[29:36]: Heating,
+	_FeatureName[36:45]:      Cacheable,
+	_FeatureLowerName[36:45]: Cacheable,
+	_FeatureName[45:52]:      Offline,
+	_FeatureLowerName[45:52]: Offline,
+	_FeatureName[52:61]:      Retryable,
+	_FeatureLowerName[52:61]: Retryable,
+	_FeatureName[61:74]:      WelcomeCharge,
+	_FeatureLowerName[61:74]: WelcomeCharge,
 }
 
 var _FeatureNames = []string{
-	_FeatureName[0:7],
-	_FeatureName[7:20],
-	_FeatureName[20:36],
-	_FeatureName[36:43],
-	_FeatureName[43:52],
-	_FeatureName[52:65],
+	_FeatureName[0:13],
+	_FeatureName[13:29],
+	_FeatureName[29:36],
+	_FeatureName[36:45],
+	_FeatureName[45:52],
+	_FeatureName[52:61],
+	_FeatureName[61:74],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/tariff/proxy.go
+++ b/tariff/proxy.go
@@ -35,10 +35,23 @@ func NewCachedFromConfig(ctx context.Context, typ string, other map[string]any) 
 		}
 	}
 
+	var embed struct {
+		Features []api.Feature  `mapstructure:"features"`
+		other    map[string]any `mapstructure:",remain"`
+	}
+
+	if err := util.DecodeOther(other, &embed); err != nil {
+		return nil, err
+	}
+
+	if !slices.Contains(embed.Features, api.Cacheable) {
+		return NewFromConfig(ctx, typ, other)
+	}
+
 	p := &CachingProxy{
 		ctx:    ctx,
 		typ:    typ,
-		config: other,
+		config: embed.other,
 		key:    tariffType + "-" + cacheKey(typ, other),
 	}
 

--- a/tariff/proxy.go
+++ b/tariff/proxy.go
@@ -37,7 +37,7 @@ func NewCachedFromConfig(ctx context.Context, typ string, other map[string]any) 
 
 	var embed struct {
 		Features []api.Feature  `mapstructure:"features"`
-		other    map[string]any `mapstructure:",remain"`
+		Other    map[string]any `mapstructure:",remain"`
 	}
 
 	if err := util.DecodeOther(other, &embed); err != nil {
@@ -51,7 +51,7 @@ func NewCachedFromConfig(ctx context.Context, typ string, other map[string]any) 
 	p := &CachingProxy{
 		ctx:    ctx,
 		typ:    typ,
-		config: embed.other,
+		config: embed.Other,
 		key:    tariffType + "-" + cacheKey(typ, other),
 	}
 

--- a/templates/definition/tariff/forecast-solar.yaml
+++ b/templates/definition/tariff/forecast-solar.yaml
@@ -35,6 +35,7 @@ params:
 render: |
   type: custom
   tariff: solar
+  features: ["cacheable"]
   forecast:
     source: http
     uri: https://api.forecast.solar/{{ if .apikey }}{{ .apikey }}/{{ end }}estimate/{{ .lat }}/{{ .lon }}/{{ .dec }}/{{ .az }}/{{ .kwp }}?time=utc&full=1&resolution=60{{ if .horizon }}&horizon={{ unquote .horizon }}{{ end }}

--- a/templates/definition/tariff/gruenstromindex.yaml
+++ b/templates/definition/tariff/gruenstromindex.yaml
@@ -17,5 +17,6 @@ params:
       en: "Token for accessing the API from https://console.corrently.io"
 render: |
   type: grünstromindex
+  features: ["cacheable"]
   zip: {{ .zip }}
   token: {{ .token }}

--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -70,6 +70,7 @@ params:
 render: |
   type: custom
   tariff: solar
+  features: ["cacheable"]
   forecast:
     source: http
     uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&hourly=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=3&timezone=GMT&timeformat=unixtime

--- a/templates/definition/tariff/solcast.yaml
+++ b/templates/definition/tariff/solcast.yaml
@@ -38,6 +38,7 @@ params:
     advanced: true
 render: |
   type: solcast
+  features: ["cacheable"]
   site: {{ .site }}
   token: {{ .token }}
   interval: {{ .interval }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/22871 

This PR adds a `cacheable` pseudo-feature. By default, it's only added to `gsi` and `solcast` tariffs which we know are problematic. All other tariffs are hence exempt from caching by default. `Cacheable` is pseudo-feature in the sense that it cannot be queried during runtime but is pre-processed and removed during tariff creation.