### PR TITLE
Config UI: add circuit meter options

### DIFF
--- a/assets/js/components/Config/CircuitsModal.vue
+++ b/assets/js/components/Config/CircuitsModal.vue
@@ -9,19 +9,56 @@
 		endpoint="/config/circuits"
 		data-testid="circuits-modal"
 		@changed="$emit('changed')"
-	/>
+	>
+		<template #extra>
+			<p class="my-2 small">
+				{{ $t("config.circuits.usableMeters") }}:
+				<code v-for="meter in usableMeters" :key="meter.name" class="ms-1 meter">
+					{{ meter.name }}<span v-if="meter.title" class="ms-1">({{ meter.title }})</span>
+				</code>
+			</p>
+		</template>
+	</YamlModal>
 </template>
 
-<script>
+<script lang="ts">
 import YamlModal from "./YamlModal.vue";
 import defaultYaml from "./defaultYaml/circuits.yaml?raw";
+import type { ConfigMeter } from "@/types/evcc";
+import type { PropType } from "vue";
 
 export default {
 	name: "CircuitsModal",
 	components: { YamlModal },
+	props: {
+		gridMeter: { type: Object as PropType<ConfigMeter>, default: null },
+		extMeters: { type: Array as PropType<ConfigMeter[]>, default: () => [] },
+	},
 	emits: ["changed"],
 	data() {
 		return { defaultYaml: defaultYaml.trim() };
 	},
+	computed: {
+		usableMeters() {
+			const result = [];
+			if (this.gridMeter) {
+				result.push({ name: this.gridMeter.name, title: this.$t("config.grid.title") });
+			}
+			if (this.extMeters) {
+				result.push(
+					...this.extMeters.map((m) => ({
+						name: m.name,
+						title: m.deviceTitle || m.deviceProduct || m.config["template"] || m.type,
+					}))
+				);
+			}
+			return result;
+		},
+	},
 };
 </script>
+<style scoped>
+.meter:not(:last-child)::after {
+	content: ",";
+}
+</style>

--- a/assets/js/components/Config/YamlModal.vue
+++ b/assets/js/components/Config/YamlModal.vue
@@ -16,6 +16,7 @@
 					:hidden="!modalVisible"
 				/>
 			</div>
+			<slot name="extra" />
 
 			<div class="mt-4 d-flex justify-content-between">
 				<button

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -375,7 +375,11 @@
 				<MessagingModal @changed="yamlChanged" />
 				<TariffsModal @changed="yamlChanged" />
 				<ModbusProxyModal @changed="yamlChanged" />
-				<CircuitsModal @changed="yamlChanged" />
+				<CircuitsModal
+					:gridMeter="gridMeter"
+					:extMeters="extMeters"
+					@changed="yamlChanged"
+				/>
 				<EebusModal @changed="yamlChanged" />
 				<BackupRestoreModal v-bind="backupRestoreProps" />
 				<PasswordModal update-mode />

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -65,7 +65,8 @@
     },
     "circuits": {
       "description": "Stellt sicher, dass die Summe aller Ladepunkte, die an einen Stromkreis angeschlossen sind, die konfigurierten Leistungs- und Stromgrenzen nicht überschreitet. Stromkreise können verschachtelt werden, um eine Hierarchie aufzubauen.",
-      "title": "Lastmanagement"
+      "title": "Lastmanagement",
+      "usableMeters": "Verwendbare Zählerreferenzen"
     },
     "control": {
       "description": "Normalerweise sind die Standardwerte in Ordnung. Ändere nur etwas, wenn du weißt, was du tust.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -65,7 +65,8 @@
     },
     "circuits": {
       "description": "Ensures, that the sum of all loadpoints connected to a circuit does not exceed the configured power and current limits. Circuits can be nested to build a hierarchy.",
-      "title": "Load Management"
+      "title": "Load Management",
+      "usableMeters": "Usable meter references"
     },
     "control": {
       "description": "Usually the default values are fine. Only change them if you know what you are doing.",


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/22890

Show usable grid and ext meter reference names.

<img width="957" height="722" alt="Bildschirmfoto 2025-08-22 um 14 33 00" src="https://github.com/user-attachments/assets/86b938eb-192d-4f19-a243-4859264ed115" />

Note: adding ext meters via UI is not yet possible (see https://github.com/evcc-io/evcc/issues/6029) 