### PR TITLE
Fix Phoenix CHARX MaxCurrent(0) for OCPP mode

### DIFF
--- a/charger/phoenix-charx.go
+++ b/charger/phoenix-charx.go
@@ -167,7 +167,10 @@ func (wb *PhoenixCharx) Enable(enable bool) error {
 
 // MaxCurrent implements the api.Charger interface
 func (wb *PhoenixCharx) MaxCurrent(current int64) error {
-	if current < 6 {
+	// Allow 0A to stop charging - according to CHARX Modbus documentation,
+	// "The charging release is withdrawn if the value is exceeded or fallen below" the 6-80A range.
+	// This is required for "release by OCPP" mode where register 300 (Enable) is read-only.
+	if current != 0 && current < 6 {
 		return fmt.Errorf("invalid current %d", current)
 	}
 


### PR DESCRIPTION
## Summary

- Fixed issue where evcc cannot stop charging on Phoenix CHARX when configured in "release by OCPP" mode
- Allows MaxCurrent(0) as special case to stop charging, bypassing the 6A minimum validation  
- Uses proper Modbus register (301) instead of falling back to Enable register (300) which is ignored in OCPP mode

## Background

Phoenix CHARX chargers have two operational modes:
- **Release by Modbus**: Both registers 300 (Enable) and 301 (MaxCurrent) work for control
- **Release by OCPP**: Only register 301 (MaxCurrent) works, register 300 is read-only

According to CHARX Modbus documentation:
- Register 300: "Charging release (must be configured to release via Modbus)" - read-only in OCPP mode  
- Register 301: "Maximum charging current, value range 6-80A. The charging release is withdrawn if the value is exceeded or fallen below" - works in both modes

## Problem

evcc's previous behavior:
1. Try `MaxCurrent(0)` → fails due to 6A minimum validation
2. Fall back to `Enable(false)` on register 300 → gets ignored in OCPP mode
3. Charging cannot be stopped


## Solution

Modified MaxCurrent validation to allow 0A as special case:
```go
// Allow 0A to stop charging - according to CHARX Modbus documentation,
// "The charging release is withdrawn if the value is exceeded or fallen below" the 6-80A range.
// This is required for "release by OCPP" mode where register 300 (Enable) is read-only.
if current != 0 && current < 6 {
    return fmt.Errorf("invalid current %d", current)
}
```

## Test Plan

- [x] Code compiles successfully
- [x] Build completes without errors  
- [ ] Test with actual Phoenix CHARX in OCPP mode (user has hardware for testing)
- [ ] Verify charging can be stopped when MaxCurrent(0) is called
- [ ] Verify charging can still be started with valid currents (≥6A)

## Impact

Fixes compatibility with Phoenix CHARX chargers from vendors like Veton.be when using "release by OCPP" configuration, allowing proper integration with OCPP charge point operators while maintaining evcc control.

🤖 Generated with [Claude Code](https://claude.ai/code)