### PR TITLE
Check, if all required tarif's are at least configured & log why 'optimizer' might not be available

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -75,6 +75,20 @@ func (site *Site) optimizerUpdate(battery []measurement) error {
 		return nil
 	}
 
+	for _, t := range []struct {
+		usage api.TariffUsage
+		name  string
+	}{
+		{api.TariffUsageSolar, "solar"},
+		{api.TariffUsageGrid, "grid"},
+		{api.TariffUsageFeedIn, "feedin"},
+	} {
+		if site.GetTariff(t.usage) == nil {
+			site.log.WARN.Printf("optimizer: Configuration missing: No '%s' tariff configured - Optimizer will not be available", t.name)
+			return nil
+		}
+	}
+
 	solar := currentRates(site.GetTariff(api.TariffUsageSolar))
 	grid := currentRates(site.GetTariff(api.TariffUsageGrid))
 	feedIn := currentRates(site.GetTariff(api.TariffUsageFeedIn))


### PR DESCRIPTION
It took me quite a while to realize why the Optimizer will not appear in my evcc-menu. The simple error log `not enough slots for optimization: ...` was not understandable for me. 

Only after I looked into the source code; I realized that the three different tarif's must be configured - YES that's totally logical that this tarifs must be present in the evcc configuration.

But still - why not tell the user, that some configuration is missing?