### PR TITLE
Sessions UI: show decimal in scale for low money values

### DIFF
--- a/assets/js/components/Sessions/CostHistoryChart.vue
+++ b/assets/js/components/Sessions/CostHistoryChart.vue
@@ -327,7 +327,7 @@ export default defineComponent({
 						ticks: {
 							callback: (value: number) => {
 								if (this.costType === TYPES.PRICE) {
-									const showDecimals = this.suggestedMaxCost < 5;
+									const showDecimals = this.suggestedMaxCost < 4;
 									return this.fmtMoney(value, this.currency, showDecimals, true);
 								} else {
 									return this.fmtNumber(value / 1e3, 0);

--- a/assets/js/components/Sessions/CostHistoryChart.vue
+++ b/assets/js/components/Sessions/CostHistoryChart.vue
@@ -329,7 +329,7 @@ export default defineComponent({
 								this.costType === TYPES.PRICE
 									? this.suggestedMaxCost < 5
 										? this.fmtMoney(value, this.currency, true, true)
-										:this.fmtMoney(value, this.currency, false, true)
+										: this.fmtMoney(value, this.currency, false, true)
 									: this.fmtNumber(value / 1e3, 0),
 							color: colors.muted,
 							maxTicksLimit: 6,

--- a/assets/js/components/Sessions/CostHistoryChart.vue
+++ b/assets/js/components/Sessions/CostHistoryChart.vue
@@ -327,7 +327,9 @@ export default defineComponent({
 						ticks: {
 							callback: (value: number) =>
 								this.costType === TYPES.PRICE
-									? this.fmtMoney(value, this.currency, false, true)
+									? this.suggestedMaxCost < 5
+										? this.fmtMoney(value, this.currency, true, true)
+										:this.fmtMoney(value, this.currency, false, true)
 									: this.fmtNumber(value / 1e3, 0),
 							color: colors.muted,
 							maxTicksLimit: 6,

--- a/assets/js/components/Sessions/CostHistoryChart.vue
+++ b/assets/js/components/Sessions/CostHistoryChart.vue
@@ -325,12 +325,14 @@ export default defineComponent({
 							color: colors.muted,
 						},
 						ticks: {
-							callback: (value: number) =>
-								this.costType === TYPES.PRICE
-									? this.suggestedMaxCost < 5
-										? this.fmtMoney(value, this.currency, true, true)
-										: this.fmtMoney(value, this.currency, false, true)
-									: this.fmtNumber(value / 1e3, 0),
+							callback: (value: number) => {
+								if (this.costType === TYPES.PRICE) {
+									const showDecimals = this.suggestedMaxCost < 5;
+									return this.fmtMoney(value, this.currency, showDecimals, true);
+								} else {
+									return this.fmtNumber(value / 1e3, 0);
+								}
+							},
 							color: colors.muted,
 							maxTicksLimit: 6,
 						},


### PR DESCRIPTION
fixes #23079

Show cent Values on Chartlines lines below 5 Euro suggestedMaxCost in … CostHistoryChart.vue

Before: 
<img width="1308" height="367" alt="Bildschirmfoto 2025-08-23 um 18 49 22" src="https://github.com/user-attachments/assets/b5684b02-dcf6-4891-b932-bdef7debf5a2" />

After:
<img width="1308" height="367" alt="Bildschirmfoto 2025-08-23 um 18 47 00" src="https://github.com/user-attachments/assets/33eba0aa-9d8f-45ea-8fc1-fb532fa74a70" />


Fixes: https://github.com/evcc-io/evcc/issues/23079

after I had the codebase on my system... it was hard to control my inner Monk ;-)
