### PR TITLE
 Add fronius symo gen24 inverter template definition

### DIFF
--- a/templates/definition/meter/fronius-gen24-inverter.yaml
+++ b/templates/definition/meter/fronius-gen24-inverter.yaml
@@ -1,0 +1,142 @@
+template: fronius-gen24-inverter
+products:
+  - brand: Fronius
+    description:
+      generic: Symo GEN24
+params:
+  - name: usage
+    choice: ["grid", "pv"]
+    allinone: true
+  - name: host
+  - name: port
+    default: 502
+  - name: id
+    default: 200
+    advanced: true
+    help:
+      en: "Meter address of primary or secondary meters. On the web interface of the inverter, only the address of the first meter (e.g., 200) can be set. Additional meters receive an ascending number (e.g., 201)."
+      de: "Zähleradresse von Primär- oder Sekundärzählern. Auf der Weboberfläche des Wechselrichters kann nur die Adresse des ersten Zählers (z.B. 200) eingestellt werden. Zusätzliche Zähler erhalten eine aufsteigende Nummer (z.B: 201)."
+    usages: ["grid"]
+render: |
+  type: custom
+  # sunspec model 20x (int+sf)/ 21x (float) meter
+  {{- if eq .usage "grid" }}
+  power:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    value:
+      - 201:W
+      - 211:W
+      - 203:W
+      - 213:W
+  energy:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    value:
+      - 201:TotWhImp
+      - 211:TotWhImp
+      - 203:TotWhImp
+      - 213:TotWhImp
+    scale: 0.001
+  currents:
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:AphA
+        - 211:AphA
+        - 203:AphA
+        - 213:AphA
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:AphB
+        - 211:AphB
+        - 203:AphB
+        - 213:AphB
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:AphC
+        - 211:AphC
+        - 203:AphC
+        - 213:AphC
+  voltages:
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:PhVphA
+        - 211:PhVphA
+        - 203:PhVphA
+        - 213:PhVphA
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:PhVphB
+        - 211:PhVphB
+        - 203:PhVphB
+        - 213:PhVphB
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:PhVphC
+        - 211:PhVphC
+        - 203:PhVphC
+        - 213:PhVphC
+  powers:
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:WphA
+        - 211:WphA
+        - 203:WphA
+        - 213:WphA
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:WphB
+        - 211:WphB
+        - 203:WphB
+        - 213:WphB
+    - source: sunspec
+      uri: {{ .host }}:{{ .port }}
+      id: {{ .id }}
+      value:
+        - 201:WphC
+        - 211:WphC
+        - 203:WphC
+        - 213:WphC
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: 1
+    value:
+      - 101:W
+      - 111:W
+      - 102:W
+      - 112:W
+      - 103:W
+      - 113:W
+  energy:
+    source: sunspec
+    uri: {{ .host }}:{{ .port }}
+    id: 1
+    value:
+      - 101:WH
+      - 111:WH
+      - 102:WH
+      - 112:WH
+      - 103:WH
+      - 113:WH
+  {{- end }}


### PR DESCRIPTION
# Add Fronius Symo GEN24 inverter-only template (AC power)

## 📖 Beschreibung
Der Fronius **Symo GEN24** wird in evcc bislang nur als **Hybridwechselrichter** PLUS Variante (mit Batterie-Integration) unterstützt. [Siehe Dokumentation.](https://docs.evcc.io/docs/devices/meters#fronius)

Bei Anlagen **ohne Speicher** führt dies dazu, dass **DC-Leistung** statt **AC-Leistung** genutzt wird.  
Mit der AC-Leistung kann die **genauere aktuelle Einspeiseleistung** ausgewiesen werden.


## 🧪 Tests

- CLI:

```
  evcc --template ~/fronius-gen24-inverter.yaml --template-type "meter"
```

- make build (VM)
```
  Template direkt unter templates/definition/meter/fronius-gen24-inverter.yaml abgelegt.
```
→ evcc startet fehlerfrei, Template wird erkannt und liefert korrekte AC-Werte im Dashboard.


## ⚙️ Beispielkonfiguration
```
meters:
  - name: my_pv
    type: template
    template: fronius-gen24-inverter
    usage: pv
    host: 192.168.x.x # IP-Adresse oder Hostname
    port: 502 # Port, optional
```