### PR TITLE
CHARX: use current to enable/disable charger

### DIFF
--- a/charger/phoenix-charx.go
+++ b/charger/phoenix-charx.go
@@ -107,6 +107,13 @@ func NewPhoenixCharx(ctx context.Context, uri string, id uint8, connector uint16
 		return nil, fmt.Errorf("invalid connector: %d", connector)
 	}
 
+	// Initialize current with the actual register value
+	if b, err := wb.conn.ReadHoldingRegisters(wb.register(charxRegMaxCurrent), 1); err == nil {
+		if current := encoding.Uint16(b); current >= wb.current {
+			wb.current = current
+		}
+	}
+
 	return wb, nil
 }
 

--- a/charger/phoenix-charx.go
+++ b/charger/phoenix-charx.go
@@ -2,7 +2,6 @@ package charger
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -123,7 +122,7 @@ func (wb *PhoenixCharx) controllers() (uint16, error) {
 		return 0, err
 	}
 
-	return binary.BigEndian.Uint16(b), nil
+	return encoding.Uint16(b), nil
 }
 
 func (wb *PhoenixCharx) register(reg uint16) uint16 {
@@ -166,7 +165,7 @@ func (wb *PhoenixCharx) Enabled() (bool, error) {
 func (wb *PhoenixCharx) Enable(enable bool) error {
 	b := make([]byte, 2)
 	if enable {
-		binary.BigEndian.PutUint16(b, wb.current)
+		encoding.PutUint16(b, wb.current)
 	}
 
 	_, err := wb.conn.WriteMultipleRegisters(wb.register(charxRegMaxCurrent), 1, b)
@@ -181,7 +180,7 @@ func (wb *PhoenixCharx) MaxCurrent(current int64) error {
 	}
 
 	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, uint16(current))
+	encoding.PutUint16(b, uint16(current))
 
 	_, err := wb.conn.WriteMultipleRegisters(wb.register(charxRegMaxCurrent), 1, b)
 	if err == nil {


### PR DESCRIPTION
This PR refactors the Phoenix CHARX charger implementation to use the current setting register for enabling/disabling the charger instead of a dedicated enable register. This approach treats the charger as enabled when current > 0 and disabled when current = 0.

Key changes:

- Switch from using a dedicated enable register to using the max current register for enable/disable operations
- Add tracking of the current value in the struct to restore when enabling
- Replace mixed encoding/binary lib usage with encoding lib only


Replaces #23178