### PR TITLE
fix deprecated element filtering

### DIFF
--- a/server/http_config_metadata_handler.go
+++ b/server/http_config_metadata_handler.go
@@ -34,10 +34,15 @@ func templatesHandler(w http.ResponseWriter, r *http.Request) {
 
 	// filter deprecated properties
 	filterParams := func(t templates.Template) templates.Template {
-		t.Params = slices.DeleteFunc(t.Params, func(p templates.Param) bool {
-			return p.IsDeprecated()
-		})
-		return t
+		// Create a copy of the template to avoid mutating the original
+		filtered := t
+		filtered.Params = make([]templates.Param, 0, len(t.Params))
+		for _, p := range t.Params {
+			if !p.IsDeprecated() {
+				filtered.Params = append(filtered.Params, p)
+			}
+		}
+		return filtered
 	}
 
 	if name := r.URL.Query().Get("name"); name != "" {


### PR DESCRIPTION
when filtering templates for the api the original gets mutated in memory to avoid that we create a copy.. 
that we filter..

fixes: https://github.com/evcc-io/evcc/issues/23219