### PR TITLE
OpenEMS: add energy

### DIFF
--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -40,23 +40,15 @@ params:
     advanced: true
 render: |
   type: custom
+  {{- if eq .usage "grid" }} 
   power:
     source: http
-    {{- if eq .usage "grid" }}
     uri: http://{{ .host }}/rest/channel/_sum/GridActivePower
-    {{- end }}
-    {{- if eq .usage "pv" }}
-    uri: http://{{ .host }}/rest/channel/_sum/ProductionActivePower
-    {{- end }}
-    {{- if eq .usage "battery" }}
-    uri: http://{{ .host }}/rest/channel/_sum/EssDischargePower
-    {{- end }}
     auth:
       type: basic
       user: x
       password: {{ .password }}
     jq: (.value // 0)
-  {{- if eq .usage "grid" }} 
   energy:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/GridBuyActiveEnergy
@@ -67,6 +59,14 @@ render: |
     jq: (.value / 1000 // 0) # convert Wh to kWh
   {{- end }}
   {{- if eq .usage "pv" }}
+  power:
+    source: http
+    uri: http://{{ .host }}/rest/channel/_sum/ProductionActivePower
+    auth:
+      type: basic
+      user: x
+      password: {{ .password }}
+    jq: (.value // 0)
   energy:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/ProductionActiveEnergy
@@ -78,6 +78,14 @@ render: |
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}
+  power:
+    source: http
+    uri: http://{{ .host }}/rest/channel/_sum/EssDischargePower
+    auth:
+      type: basic
+      user: x
+      password: {{ .password }}
+    jq: (.value // 0)
   soc:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/EssSoc

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -56,6 +56,21 @@ render: |
       user: x
       password: {{ .password }}
     jq: (.value // 0)
+  {{- if ne .usage "battery" }} # only for pv and grid meters
+  energy:
+    source: http
+    {{- if eq .usage "grid" }}
+    uri: http://{{ .host }}/rest/channel/_sum/GridBuyActiveEnergy
+    {{- end }}
+    {{- if eq .usage "pv" }}
+    uri: http://{{ .host }}/rest/channel/_sum/ProductionActiveEnergy
+    {{- end }}
+    auth:
+      type: basic
+      user: x
+      password: {{ .password }}
+    jq: (.value / 1000 // 0) # convert Wh to kWh
+  {{- end }}
   {{- if eq .usage "pv" }}
   maxacpower: {{ .maxacpower }} # W
   {{- end }}

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -56,7 +56,7 @@ render: |
       user: x
       password: {{ .password }}
     jq: (.value // 0)
-  {{- if ne .usage "battery" }} # only for pv and grid meters
+  {{- if or (eq .usage "grid") (eq .usage "pv") }} 
   energy:
     source: http
     {{- if eq .usage "grid" }}

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -56,15 +56,10 @@ render: |
       user: x
       password: {{ .password }}
     jq: (.value // 0)
-  {{- if or (eq .usage "grid") (eq .usage "pv") }} 
+  {{- if eq .usage "grid" }} 
   energy:
     source: http
-    {{- if eq .usage "grid" }}
     uri: http://{{ .host }}/rest/channel/_sum/GridBuyActiveEnergy
-    {{- end }}
-    {{- if eq .usage "pv" }}
-    uri: http://{{ .host }}/rest/channel/_sum/ProductionActiveEnergy
-    {{- end }}
     auth:
       type: basic
       user: x
@@ -72,6 +67,14 @@ render: |
     jq: (.value / 1000 // 0) # convert Wh to kWh
   {{- end }}
   {{- if eq .usage "pv" }}
+  energy:
+    source: http
+    uri: http://{{ .host }}/rest/channel/_sum/ProductionActiveEnergy
+    auth:
+      type: basic
+      user: x
+      password: {{ .password }}
+    jq: (.value / 1000 // 0) # convert Wh to kWh
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/tests/simulator/api.ts
+++ b/tests/simulator/api.ts
@@ -4,7 +4,7 @@ import type { ServerResponse } from "http";
 
 let state = {
   site: {
-    grid: { power: 0 },
+    grid: { power: 0, energy: 0 },
     pv: { power: 0, energy: 0 },
     battery: { power: 0, soc: 0 },
   },
@@ -49,10 +49,13 @@ const openemsMiddleware = (
 ) => {
   const endpoints = {
     "/rest/channel/_sum/GridActivePower": { value: state.site.grid.power },
+    "/rest/channel/_sum/GridBuyActiveEnergy": { value: state.site.grid.energy },
     "/rest/channel/_sum/ProductionActivePower": { value: state.site.pv.power },
+    "/rest/channel/_sum/ProductionActiveEnergy": { value: state.site.pv.energy },
     "/rest/channel/_sum/EssDischargePower": { value: state.site.battery.power },
     "/rest/channel/_sum/EssSoc": { value: state.site.battery.soc },
   };
+
   const endpoint = endpoints[req.originalUrl as keyof typeof endpoints];
   if (req.method === "GET" && endpoint) {
     console.log("[simulator] GET", req.originalUrl);


### PR DESCRIPTION
adding energy for PV and Grid meter as discussed in #22330 

https://docs.fenecon.de/en/fems/fems-app/App_REST-JSON_Lesezugriff.html

data sources:
- for grid meter:
GridBuyActiveEnergy
Cumulative electrical energy of grid consumption
Watt hours [Wh]

- for PV meter:
ProductionActiveEnergy
Cumulative electrical energy of PV generation + external inverter generation
Watt hours [Wh]

The implementation provides energy values from datasources (component _sum) being incremental.
I realized from discussions that it's internally used by evcc and useful for reportings as well. 