### PR TITLE
chore: mark playwright tests using device mocks

### DIFF
--- a/tests/config-fatals.spec.ts
+++ b/tests/config-fatals.spec.ts
@@ -16,7 +16,7 @@ test.afterEach(async () => {
 });
 
 test.describe("fatal config handling", async () => {
-  test("broken pv meter", async ({ page }) => {
+  test("broken pv meter (using Shelly simulator)", async ({ page }) => {
     await startSimulator();
     await start();
 
@@ -56,7 +56,7 @@ test.describe("fatal config handling", async () => {
     await expect(page.getByTestId("fatal-error")).not.toBeVisible();
   });
 
-  test("broken loadpoint meter", async ({ page }) => {
+  test("broken loadpoint meter (using Shelly simulator)", async ({ page }) => {
     await startSimulator();
     await start();
 
@@ -117,7 +117,7 @@ test.describe("fatal config handling", async () => {
     await expect(page.getByTestId("fatal-error")).not.toBeVisible(); // error should be gone
   });
 
-  test("broken grid meter", async ({ page }) => {
+  test("broken grid meter (using Shelly simulator)", async ({ page }) => {
     // setup test data for mock api
     await startSimulator();
     await start();

--- a/tests/config-grid.spec.ts
+++ b/tests/config-grid.spec.ts
@@ -31,7 +31,7 @@ test.describe("main screen", async () => {
 });
 
 test.describe("grid meter", async () => {
-  test("create, edit and remove grid meter", async ({ page }) => {
+  test("create, edit and remove grid meter (using OpenEMS simulator)", async ({ page }) => {
     // setup test data for mock openems api
     await page.goto(simulatorUrl());
     await page.getByLabel("Grid Power").fill("5000");

--- a/tests/vehicle-error.spec.ts
+++ b/tests/vehicle-error.spec.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
 });
 
-test.describe("vehicle startup error", async () => {
+test.describe("vehicle startup error (using failing Tesla API)", async () => {
   test("broken vehicle: normal title and 'not reachable' icon", async ({ page }) => {
     await expect(page.getByTestId("vehicle-name")).toHaveText("Broken Tesla");
     await expect(page.getByTestId("vehicle-not-reachable-icon")).toBeVisible();


### PR DESCRIPTION
Clearly marks playwright tests that rely on mocked devices (simulator). Avoids confusion when a device integration change leads to a failing acceptance test. Affects OpenEMS, Shelly and Tesla.

\cc @thierolm @iseeberg79 