### PR TITLE
Loadpoint UI: do not disable Arrival tab if vehicle was not reachable

### DIFF
--- a/assets/js/components/ChargingPlans/Arrival.vue
+++ b/assets/js/components/ChargingPlans/Arrival.vue
@@ -11,7 +11,7 @@
 					:id="formId('minsoc')"
 					v-model.number="selectedMinSoc"
 					class="form-select mb-2"
-					:disabled="!socBasedCharging"
+					:disabled="arrivalDisabled"
 					@change="changeMinSoc"
 				>
 					<option v-for="soc in minSocOptions" :key="soc.value" :value="soc.value">
@@ -38,7 +38,7 @@
 					:id="formId('limitsoc')"
 					v-model.number="selectedLimitSoc"
 					class="form-select mb-2"
-					:disabled="!socBasedCharging"
+					:disabled="arrivalDisabled"
 					@change="changeLimitSoc"
 				>
 					<option v-for="soc in limitSocOptions" :key="soc.value" :value="soc.value">
@@ -51,7 +51,7 @@
 			</small>
 		</div>
 	</div>
-	<div v-if="!socBasedCharging" class="mx-2 small text-muted">
+	<div v-if="arrivalDisabled" class="mx-2 small text-muted">
 		<strong class="text-evcc">
 			{{ $t("main.loadpointSettings.disclaimerHint") }}
 		</strong>
@@ -73,6 +73,7 @@ export default defineComponent({
 		minSoc: { type: Number, default: 0 },
 		limitSoc: { type: Number, default: 0 },
 		vehicleName: String,
+		vehicleNotReachable: Boolean,
 		socBasedCharging: Boolean,
 		rangePerSoc: Number,
 	},
@@ -92,6 +93,9 @@ export default defineComponent({
 			return Array.from(Array(21).keys())
 				.map((i) => i * 5)
 				.map(this.socOption);
+		},
+		arrivalDisabled(): boolean {
+			return !(this.socBasedCharging || this.vehicleNotReachable);
 		},
 	},
 	watch: {

--- a/assets/js/components/ChargingPlans/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlans/ChargingPlan.vue
@@ -132,6 +132,7 @@ export default defineComponent({
 		capacity: Number,
 		vehicleSoc: Number,
 		vehicleLimitSoc: Number,
+		vehicleNotReachable: Boolean,
 		forecast: Object as PropType<Forecast>,
 	},
 	data() {

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -269,7 +269,10 @@ export default defineComponent({
 			return !!this.vehicleName;
 		},
 		vehicleHasSoc() {
-			return this.vehicleKnown && !this.vehicle?.features?.includes("Offline");
+			return (
+				(this.vehicleKnown && this.vehicle?.features?.includes("Offline")) ||
+				this.vehicleNotReachable
+			);
 		},
 		vehicleNotReachable() {
 			// online vehicle that was not reachable at startup

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -269,10 +269,7 @@ export default defineComponent({
 			return !!this.vehicleName;
 		},
 		vehicleHasSoc() {
-			return (
-				(this.vehicleKnown && this.vehicle?.features?.includes("Offline")) ||
-				this.vehicleNotReachable
-			);
+			return this.vehicleKnown && this.vehicle?.features?.includes("Offline");
 		},
 		vehicleNotReachable() {
 			// online vehicle that was not reachable at startup

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -269,7 +269,7 @@ export default defineComponent({
 			return !!this.vehicleName;
 		},
 		vehicleHasSoc() {
-			return this.vehicleKnown && this.vehicle?.features?.includes("Offline");
+			return this.vehicleKnown && !this.vehicle?.features?.includes("Offline");
 		},
 		vehicleNotReachable() {
 			// online vehicle that was not reachable at startup

--- a/tests/vehicle-error.spec.ts
+++ b/tests/vehicle-error.spec.ts
@@ -32,7 +32,7 @@ test.describe("vehicle startup error (using failing Tesla API)", async () => {
     await expect(page.getByTestId("vehicle-name")).toHaveText("Broken Tesla");
 
     await page.getByTestId("charging-plan").getByRole("button", { name: "none" }).click();
-    await page.getByRole("link", { name: "Arrival" }).click();
+    await modal.getByRole("link", { name: "Arrival" }).click();
     await expect(page.getByRole("combobox", { name: "Min. charge %" })).toBeEnabled();
     await expect(page.getByRole("combobox", { name: "Default limit" })).toBeEnabled();
   });

--- a/tests/vehicle-error.spec.ts
+++ b/tests/vehicle-error.spec.ts
@@ -32,8 +32,9 @@ test.describe("vehicle startup error (using failing Tesla API)", async () => {
     await expect(page.getByTestId("vehicle-name")).toHaveText("Broken Tesla");
 
     await page.getByTestId("charging-plan").getByRole("button", { name: "none" }).click();
+    const modal = page.getByTestId("charging-plan-modal");
     await modal.getByRole("link", { name: "Arrival" }).click();
-    await expect(page.getByRole("combobox", { name: "Min. charge %" })).toBeEnabled();
-    await expect(page.getByRole("combobox", { name: "Default limit" })).toBeEnabled();
+    await expect(modal.getByRole("combobox", { name: "Min. charge %" })).toBeEnabled();
+    await expect(modal.getByRole("combobox", { name: "Default limit" })).toBeEnabled();
   });
 });

--- a/tests/vehicle-error.spec.ts
+++ b/tests/vehicle-error.spec.ts
@@ -27,4 +27,13 @@ test.describe("vehicle startup error", async () => {
     await expect(page.getByTestId("vehicle-name")).toHaveText("Guest vehicle");
     await expect(page.getByTestId("vehicle-not-reachable-icon")).not.toBeVisible();
   });
+
+  test("broken vehicle: arrival enabeld", async ({ page }) => {
+    await expect(page.getByTestId("vehicle-name")).toHaveText("Broken Tesla");
+
+    await page.getByTestId("charging-plan").getByRole("button", { name: "none" }).click();
+    await page.getByRole("link", { name: "Arrival" }).click();
+    await expect(page.getByRole("combobox", { name: "Min. charge %" })).toBeEnabled();
+    await expect(page.getByRole("combobox", { name: "Default limit" })).toBeEnabled();
+  });
 });


### PR DESCRIPTION
Fix #23260

❗ Assumption: Unreachable means that the vehicle API normally provides the soc.

- [x] add test case to `vehicle-error.spec.ts`

\cc @naltatis 