### PR TITLE
Document that EM2GO Duo Power Support is currently broken

### DIFF
--- a/templates/definition/charger/em2go-duo.yaml
+++ b/templates/definition/charger/em2go-duo.yaml
@@ -3,6 +3,14 @@ products:
   - brand: EM2GO
     description:
       generic: Duo Power
+requirements:
+  description:
+    de: |
+      Die Unterstützung ist im Moment vollständig kaputt und keine Verbindung möglich.
+      Alternativ [OCPP 1.6J](https://docs.evcc.io/docs/devices/chargers#ocpp-16j-kompatibel) mit `connector` Parameter nutzen.
+    en: |
+      Support is currently completely broken and no connection possible.
+      Alternatively use [OCPP 1.6J](https://docs.evcc.io/en/docs/devices/chargers#ocpp-16j-compatible) with `connector` parameter.
 capabilities: ["mA"]
 params:
   - name: modbus


### PR DESCRIPTION
As can be seen with Wireshark the wrong Modbus registers for the Duo Power are used. This is to document the current state until the issue is fixed.

It seems https://github.com/evcc-io/evcc/pull/22528 was YOLO merged. As can be seen with Wireshark the wrong Modbus registers for the Duo Power are used. This is to document the current state until the issue is fixed. evcc uses Modbus registers as documented for the Pro Power to which the Duo Power rightfully not responds.

I have an EM2GO Pro Power and Duo Power available and can support in fixing the code, but would like to know what kind of license evcc actually uses. [evcc/license](https://github.com/evcc-io/evcc?tab=MIT-1-ov-file) shows the MIT license being used. But why do you then state that [individual files](https://github.com/evcc-io/evcc/blob/668344bf320cd0b4a55b272a833ac827d66e93fb/charger/em2go.go#L7) are not covered by the MIT license?

Caused by https://github.com/evcc-io/evcc/issues/23317