### PR TITLE
Fix Backup Download for reverse Proxy

### DIFF
--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -304,7 +304,7 @@ export default defineComponent({
 						timeout: 30000,
 						headers: {
 							Accept: "application/octet-stream",
-						}
+						},
 					}
 				)
 			);

--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -301,7 +301,6 @@ export default defineComponent({
 						responseType: "stream",
 						adapter: "fetch",
 						validateStatus,
-						timeout: 30000,
 						headers: {
 							Accept: "application/octet-stream",
 						},

--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -299,11 +299,11 @@ export default defineComponent({
 					{ password: this.password },
 					{
 						responseType: "stream",
-						adapter: 'fetch',
+						adapter: "fetch",
 						validateStatus,
 						timeout: 30000,
 						headers: {
-							'Accept': 'application/octet-stream'
+							Accept: "application/octet-stream"
 						}
 					}
 				)

--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -303,7 +303,7 @@ export default defineComponent({
 						validateStatus,
 						timeout: 30000,
 						headers: {
-							Accept: "application/octet-stream"
+							Accept: "application/octet-stream",
 						}
 					}
 				)

--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -297,7 +297,15 @@ export default defineComponent({
 				api.post(
 					"/system/backup",
 					{ password: this.password },
-					{ responseType: "blob", validateStatus }
+					{
+						responseType: "stream",
+						adapter: 'fetch',
+						validateStatus,
+						timeout: 30000,
+						headers: {
+							'Accept': 'application/octet-stream'
+						}
+					}
 				)
 			);
 			if (res) {


### PR DESCRIPTION
by change the responseType to stream I am able to download a backup on an reverse proxied installation...

maybe also a Fix for home assistant if there are users that would test that would be great

also make Accept header match the server Response and added a Timeout.. 

fixes parts of:
https://github.com/evcc-io/evcc/issues/23326

are there some HA add-on users that could test if the fix also helps with the HA download problems ? 