### PR TITLE
Kathrein: add RFID support

### DIFF
--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -115,6 +115,7 @@ const (
 	kathreinRegGrantedPower     = 0x0066 // uint16 Granted charging power [1380 … 22080] @230VAC (W)
 	kathreinRegChargingDuration = 0x0067 // uint32 Duration Charging (s)
 	kathreinRegChargingEnergy   = 0x0069 // uint32 Energy Charging Energy (per charging session) (Wh)
+	kathreinRegRfid             = 0x0070 // String RFID tag Info
 
 	// EMS-Control - Control register (uint16)
 	//   0x8000 : Enable EMS-Control
@@ -396,6 +397,22 @@ func (wb *Kathrein) GetPhases() (int, error) {
 	default:
 		return 0, nil
 	}
+}
+
+var _ api.Identifier = (*Kathrein)(nil)
+
+// Identify implements the api.Identifier interface
+func (wb *Kathrein) Identify() (string, error) {
+	b, err := wb.conn.ReadHoldingRegisters(kathreinRegRfid, 16)
+	if err != nil {
+		return "", err
+	}
+
+	if string(b) == "VOID" {
+		return "", nil
+	}
+
+	return string(b), nil
 }
 
 var _ api.Diagnosis = (*Kathrein)(nil)

--- a/templates/definition/charger/kathrein.yaml
+++ b/templates/definition/charger/kathrein.yaml
@@ -18,11 +18,11 @@ products:
   - brand: Kathrein
     description:
       generic: KWB-AC60 E
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "rfid"]
 requirements:
   description:
-    de: Der Modbus-Server (TCP-Port 502) muss über die Weboberfläche der Wallbox aktiviert werden. Getestet mit Firmware-Version v2.3.2
-    en: The Modbus server (TCP port 502) must be activated on the Wallbox using the Web interface. Tested with Firmware version v2.3.2
+    de: Der Modbus-Server (TCP-Port 502) muss über die Weboberfläche der Wallbox aktiviert werden. Getestet mit Firmware-Version v2.7.0
+    en: The Modbus server (TCP port 502) must be activated on the Wallbox using the Web interface. Tested with Firmware version v2.7.0
   evcc: ["sponsorship"]
 params:
   - name: modbus


### PR DESCRIPTION
With Kathrein firmware version 2.7.0 the RFID tag information is added at modbus register 0x0070. Now this register represents the tag, that authorized the current charging session.
This pull request implements the api.Identifier interface in kathrein.go and updates the template file accordingly.