### PR TITLE
Sungrow: remove sponsorship requirement

### DIFF
--- a/charger/sungrow.go
+++ b/charger/sungrow.go
@@ -25,7 +25,6 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/modbus"
-	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/volkszaehler/mbmd/meters/rs485"
 )
 
@@ -85,10 +84,6 @@ func NewSungrow(ctx context.Context, uri, device, comset string, baudrate int, p
 	conn, err := modbus.NewConnection(ctx, uri, device, comset, baudrate, proto, id)
 	if err != nil {
 		return nil, err
-	}
-
-	if !sponsor.IsAuthorized() {
-		return nil, api.ErrSponsorRequired
 	}
 
 	log := util.NewLogger("sungrow")

--- a/templates/definition/charger/sungrow.yaml
+++ b/templates/definition/charger/sungrow.yaml
@@ -7,8 +7,6 @@ products:
     description:
       generic: AC22E-01
 capabilities: ["mA", "1p3p"]
-requirements:
-  evcc: ["sponsorship"]
 params:
   - name: modbus
     choice: ["rs485", "tcpip"]


### PR DESCRIPTION
Sungrow is now supporting us directly- big thank you from the evcc team!