### PR TITLE
LG Therma: map all modes

### DIFF
--- a/templates/definition/charger/lg-therma.yaml
+++ b/templates/definition/charger/lg-therma.yaml
@@ -61,10 +61,16 @@ render: |
         encoding: uint16
   getmode:
     source: map
-    values:
-      {{ if eq .energystate "SGReady" -}} 1 {{ else if eq .energystate "IndividualEnergystate" -}} 7 {{ else -}} 1 {{- end }}: 1 # 1 Erzwungen Aus, 7 Energiesparmodus # Energiesparen
-      2: 2 # Normalbetrieb
-      {{ if eq .energystate "IndividualEnergystate" -}} 6 {{ else -}} 3 {{- end }}: 3 # 3 Ein-Empfehlung, 6 Ein-Empfehlung Schritt 1
+    values: # added all possible states of holding 9, since another state could have been that from a different configuration
+      0: 2 # 0: Nicht verwenden, ist standardmäßig im Auslieferzustand gesetzt
+      1: 1 # 1: Erzwungen Aus (gleich TB_SG1=schließen/TB_SG2=öffnen)
+      2: 2 # 2: Normalbetrieb (gleich TB_SG1=öffnen/TB_SG2=öffnen)
+      3: 3 # 3 : Ein-Empfehlung (gleich TB_SG1=öffnen/TB_SG2=schließen)
+      4: 3 # 4 : Ein-Befehl (gleich TB_SG1=schließen/TB_SG2=schließen)
+      5: 3 # 5 : Ein-Befehl Schritt 2 (++ Stromverbrauch verglichen mit Normal)
+      6: 3 # 6 : Ein-Empfehlung Schritt 1 (+ Stromverbrauch verglichen mit Normal)
+      7: 1 # 7 : Energiesparmodus (- Stromverbrauch verglichen mit Normal)
+      8: 1 # 8 : Superenergiesparmodus (-- Stromverbrauch verglichen mit Normal)
     get:
       source: modbus
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/charger/lg-therma.yaml
+++ b/templates/definition/charger/lg-therma.yaml
@@ -61,16 +61,16 @@ render: |
         encoding: uint16
   getmode:
     source: map
-    values: # added all possible states of holding 9, since another state could have been that from a different configuration
-      0: 2 # 0: Nicht verwenden, ist standardmäßig im Auslieferzustand gesetzt
-      1: 1 # 1: Erzwungen Aus (gleich TB_SG1=schließen/TB_SG2=öffnen)
-      2: 2 # 2: Normalbetrieb (gleich TB_SG1=öffnen/TB_SG2=öffnen)
-      3: 3 # 3 : Ein-Empfehlung (gleich TB_SG1=öffnen/TB_SG2=schließen)
-      4: 3 # 4 : Ein-Befehl (gleich TB_SG1=schließen/TB_SG2=schließen)
-      5: 3 # 5 : Ein-Befehl Schritt 2 (++ Stromverbrauch verglichen mit Normal)
-      6: 3 # 6 : Ein-Empfehlung Schritt 1 (+ Stromverbrauch verglichen mit Normal)
-      7: 1 # 7 : Energiesparmodus (- Stromverbrauch verglichen mit Normal)
-      8: 1 # 8 : Superenergiesparmodus (-- Stromverbrauch verglichen mit Normal)
+    values:
+      0: 2 # Auslieferzustand gesetzt
+      1: 1 # Erzwungen Aus
+      2: 2 # Normalbetrieb
+      3: 3 # Ein-Empfehlung
+      4: 3 # Ein-Befehl
+      5: 3 # Ein-Befehl (anpassbar)
+      6: 3 # Ein-Empfehlung (anpassbar)
+      7: 1 # Energiesparmodus
+      8: 1 # Superenergiesparmodus
     get:
       source: modbus
       {{- include "modbus" . | indent 4 }}


### PR DESCRIPTION
Added all possible states to GETMODE mapping since the heat pump could be in a different state from a default setting (0) or a previous setting. User reported that "0" was not found in status mapping.