### PR TITLE
AlphaESS - Fix Modbus Register *Total energy feed to Grid*

### DIFF
--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -116,7 +116,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 144 # 0x90 Total energy feed to Grid (PV)
+      address: 16 # 0x10 Total energy feed to Grid (Grid Meter)
       type: holding
       decode: uint32
     scale: 0.01


### PR DESCRIPTION
Änderung der Modbus-Registeradresse für *Total energy feed to Grid*:

- Vorher: 0x90 (144) → Register des PV-Zählers  
- Jetzt: 0x10 (16) → Register des Grid-Meters  

Damit wird die Energieeinspeisung korrekt aus dem Grid-Meter gelesen und nicht mehr aus dem PV-Register.

Fix https://github.com/evcc-io/evcc/issues/23360