### PR TITLE
Stiebel Eltron WPM: Modbus-Register für Leistungsaufnahme

### DIFF
--- a/templates/definition/charger/stiebel-wpm.yaml
+++ b/templates/definition/charger/stiebel-wpm.yaml
@@ -111,7 +111,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 680
+      address: 3680
       type: input
       encoding: int16
     scale: 0.1


### PR DESCRIPTION
Modbus Adresse korrigiert: 3680 für Inverterleistungsaufnahme. siehe: https://github.com/evcc-io/evcc/issues/23345