### PR TITLE
Ocpp: zero phase powers when transaction stops

### DIFF
--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -106,27 +106,23 @@ func (conn *Connector) OnStartTransaction(request *core.StartTransactionRequest)
 }
 
 func (conn *Connector) setPowerToZero() {
+	zero_power :=
+		types.SampledValue{Value: "0", Unit: types.UnitOfMeasureW}
+
 	if _, ok := conn.measurements[types.MeasurandPowerActiveImport]; ok {
-		conn.measurements[types.MeasurandPowerActiveImport] = types.SampledValue{
-			Value: "0",
-			Unit:  types.UnitOfMeasureW,
-		}
+		conn.measurements[types.MeasurandPowerActiveImport] = zero_power
 	}
 
 	for phase := 1; phase <= 3; phase++ {
-		if _, ok := conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)]; ok {
-			conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)] = types.SampledValue{
-				Value: "0",
-				Unit:  types.UnitOfMeasureW,
-			}
+		key := getPhaseKey(types.MeasurandPowerActiveImport, phase)
+		if _, ok := conn.measurements[key]; ok {
+			conn.measurements[key] = zero_power
 		}
 
 		// Connector.CurrentPower() checks "phase-N" as matter of last resort
-		if _, ok := conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)+"-N"]; ok {
-			conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)+"-N"] = types.SampledValue{
-				Value: "0",
-				Unit:  types.UnitOfMeasureW,
-			}
+		keyN := getPhaseKey(types.MeasurandPowerActiveImport, phase) + "-N"
+		if _, ok := conn.measurements[keyN]; ok {
+			conn.measurements[keyN] = zero_power
 		}
 	}
 }

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -105,15 +105,35 @@ func (conn *Connector) OnStartTransaction(request *core.StartTransactionRequest)
 	return res, nil
 }
 
-func (conn *Connector) assumeMeterStopped() {
-	conn.meterUpdated = conn.clock.Now()
-
+func (conn *Connector) setPowerToZero() {
 	if _, ok := conn.measurements[types.MeasurandPowerActiveImport]; ok {
 		conn.measurements[types.MeasurandPowerActiveImport] = types.SampledValue{
 			Value: "0",
 			Unit:  types.UnitOfMeasureW,
 		}
 	}
+
+	for phase := 1; phase <= 3; phase++ {
+		if _, ok := conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)]; ok {
+			conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)] = types.SampledValue{
+				Value: "0",
+				Unit:  types.UnitOfMeasureW,
+			}
+		}
+
+		// Connector.CurrentPower() checks "phase-N" as matter of last resort
+		if _, ok := conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)+"-N"]; ok {
+			conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport, phase)+"-N"] = types.SampledValue{
+				Value: "0",
+				Unit:  types.UnitOfMeasureW,
+			}
+		}
+	}
+}
+
+func (conn *Connector) assumeMeterStopped() {
+	conn.meterUpdated = conn.clock.Now()
+	conn.setPowerToZero()
 
 	for phase := 1; phase <= 3; phase++ {
 		if _, ok := conn.measurements[getPhaseKey(types.MeasurandCurrentImport, phase)]; ok {

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -118,9 +118,8 @@ func (conn *Connector) assumeMeterStopped() {
 	for phase := 1; phase <= 3; phase++ {
 		// phase powers
 		for _, suffix := range []types.Measurand{"", "-N"} {
-			key := getPhaseKey(types.MeasurandPowerActiveImport+suffix, phase)
-			if _, ok := conn.measurements[key]; ok {
-				conn.measurements[key] = types.SampledValue{
+			if _, ok := conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport+suffix, phase)]; ok {
+				conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport+suffix, phase)] = types.SampledValue{
 					Value: "0",
 					Unit:  types.UnitOfMeasureW,
 				}

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -118,8 +118,9 @@ func (conn *Connector) assumeMeterStopped() {
 	for phase := 1; phase <= 3; phase++ {
 		// phase powers
 		for _, suffix := range []types.Measurand{"", "-N"} {
-			if _, ok := conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport+suffix, phase)]; ok {
-				conn.measurements[getPhaseKey(types.MeasurandPowerActiveImport+suffix, phase)] = types.SampledValue{
+			key := getPhaseKey(types.MeasurandPowerActiveImport, phase) + suffix
+			if _, ok := conn.measurements[key]; ok {
+				conn.measurements[key] = types.SampledValue{
 					Value: "0",
 					Unit:  types.UnitOfMeasureW,
 				}
@@ -127,8 +128,9 @@ func (conn *Connector) assumeMeterStopped() {
 		}
 
 		// phase currents
-		if _, ok := conn.measurements[getPhaseKey(types.MeasurandCurrentImport, phase)]; ok {
-			conn.measurements[getPhaseKey(types.MeasurandCurrentImport, phase)] = types.SampledValue{
+		key := getPhaseKey(types.MeasurandCurrentImport, phase)
+		if _, ok := conn.measurements[key]; ok {
+			conn.measurements[key] = types.SampledValue{
 				Value: "0",
 				Unit:  types.UnitOfMeasureA,
 			}

--- a/charger/ocpp/connector_test.go
+++ b/charger/ocpp/connector_test.go
@@ -165,7 +165,7 @@ func (suite *connTestSuite) TestOnStopTransactionResetsReportedPower() {
 	suite.NoError(err, "CurrentPower")
 	suite.Equal(res, 3.0, "CurrentPower")
 
-	// This should set any power to zero
+	// set powers to zero
 	suite.conn.OnStopTransaction(nil)
 
 	res, err = suite.conn.CurrentPower()

--- a/charger/ocpp/connector_test.go
+++ b/charger/ocpp/connector_test.go
@@ -152,3 +152,23 @@ func (suite *connTestSuite) TestConnectorMeasurementsRunningTxn() {
 	_, _, _, err = suite.conn.Voltages()
 	suite.NoError(err, "Voltages")
 }
+
+func (suite *connTestSuite) TestOnStopTransactionResetsReportedPower() {
+	suite.conn.meterUpdated = suite.clock.Now()
+
+	// Set some power
+	suite.conn.measurements[types.MeasurandPowerActiveImport+".L1-N"] = types.SampledValue{Value: "1"}
+	suite.conn.measurements[types.MeasurandPowerActiveImport+".L2-N"] = types.SampledValue{Value: "1"}
+	suite.conn.measurements[types.MeasurandPowerActiveImport+".L3-N"] = types.SampledValue{Value: "1"}
+
+	res, err := suite.conn.CurrentPower()
+	suite.NoError(err, "CurrentPower")
+	suite.Equal(res, 3.0, "CurrentPower")
+
+	// This should set any power to zero
+	suite.conn.OnStopTransaction(nil)
+
+	res, err = suite.conn.CurrentPower()
+	suite.NoError(err, "CurrentPower")
+	suite.Equal(res, 0.0, "CurrentPower")
+}


### PR DESCRIPTION
Connector.CurrentPower() checks first for total power, then phases and last phases-N values. It returns the first found value. assumeMeterStopped() was not aligned with that because it only might zero the total power.

When a wallbox only reports power per phase, assumeMeterStopped() will not set its power to zero without this change.