### PR TITLE
KEBA: fix phase switching state

### DIFF
--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -395,7 +395,7 @@ func (wb *Keba) getPhases() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if binary.BigEndian.Uint32(b) == 1 {
+	return binary.BigEndian.Uint32(b), nil
 		return 1, nil
 	}
 	return 3, nil

--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -395,7 +395,7 @@ func (wb *Keba) getPhases() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if binary.BigEndian.Uint32(b) == 0 {
+	if binary.BigEndian.Uint32(b) == 1 {
 		return 1, nil
 	}
 	return 3, nil

--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -395,10 +395,7 @@ func (wb *Keba) getPhases() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return binary.BigEndian.Uint32(b), nil
-		return 1, nil
-	}
-	return 3, nil
+	return int(binary.BigEndian.Uint32(b)), nil
 }
 
 var _ api.Diagnosis = (*Keba)(nil)


### PR DESCRIPTION
Fixes the phase switching state in GetPhases.
The register actually returns 1 instead of 0 for 1p charging.

Modbus docs for P30:
<img width="687" height="198" alt="image" src="https://github.com/user-attachments/assets/c4fb5146-1160-453a-a97a-a673bfeb675b" />

Modbus docs for P40:
<img width="652" height="239" alt="image" src="https://github.com/user-attachments/assets/e1595e46-4d7a-4ae6-9485-86648f5272c9" />
