### PR TITLE
Fix Energyforecast.de integration

### DIFF
--- a/templates/definition/tariff/energyforecast.yaml
+++ b/templates/definition/tariff/energyforecast.yaml
@@ -14,7 +14,7 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://www.energyforecast.de/api/v1/predictions/next_48_hours?token={{ .token }}
+    uri: https://www.energyforecast.de/api/v1/predictions/next_48_hours?fixed_cost_cent=0&vat=0&token={{ .token }}
     jq: |
       map({
         "start": .start | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime | strftime("%Y-%m-%dT%H:%M:%SZ"),


### PR DESCRIPTION
The energyforecast.de api applies non-zero default offset and tax values, which is incompatible with evcc's `tariff-base`. 
By setting these values to 0 in the API call, the offset and the tax factor from evcc can be applied as expected.

https://www.energyforecast.de/api-docs/index.html