### PR TITLE
Fix French translation syntax error in confirmLogout

### DIFF
--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -625,7 +625,7 @@
   "header": {
     "about": "À propos",
     "authProviders": {
-      "confirmLogout": "Êtes-vous sûr de vouloir déconnecter {titre} ?",
+      "confirmLogout": "Êtes-vous sûr de vouloir déconnecter {title} ?",
       "title": "Statut de l'autorisation"
     },
     "blog": "Blog",


### PR DESCRIPTION
Replace {titre} with {title} to match the expected template variable name used in Vue/i18n. This prevents runtime errors when the confirmLogout message is displayed.

resolves: https://github.com/evcc-io/evcc/issues/23492

🤖 Generated with [Claude Code](https://claude.ai/code)