### PR TITLE
Fix Slimmelezer-v2 - grid powers: add[0]: strconv.ParseFloat: parsing "<nil>": invalid syntax 

### DIFF
--- a/templates/definition/meter/slimmelezer-v2.yaml
+++ b/templates/definition/meter/slimmelezer-v2.yaml
@@ -51,12 +51,12 @@ render: |
     uri: http://{{ .host }}/sensor/current_phase_2
     headers:
     - content-type: application/json
-    jq: .value
+    jq: (.value // 0)
   - source: http
     uri: http://{{ .host }}/sensor/current_phase_3
     headers:
     - content-type: application/json
-    jq: .value
+    jq: (.value // 0)
   powers:
   - source: calc
     add:
@@ -78,13 +78,13 @@ render: |
       uri: http://{{ .host }}/sensor/power_produced_phase_2
       headers:
       - content-type: application/json
-      jq: .value
+      jq: (.value // 0)
       scale: -1000
     - source: http
       uri: http://{{ .host }}/sensor/power_consumed_phase_2
       headers:
       - content-type: application/json
-      jq: .value
+      jq: (.value // 0)
       scale: 1000
   - source: calc
     add:
@@ -92,11 +92,11 @@ render: |
       uri: http://{{ .host }}/sensor/power_produced_phase_3
       headers:
       - content-type: application/json
-      jq: .value
+      jq: (.value // 0)
       scale: -1000
     - source: http
       uri: http://{{ .host }}/sensor/power_consumed_phase_3
       headers:
       - content-type: application/json
-      jq: .value
+      jq: (.value // 0)
       scale: 1000


### PR DESCRIPTION
Should fix the error described in https://github.com/evcc-io/evcc/discussions/23560