### PR TITLE
Add currents and voltages to goodwe-hybrid meter template

### DIFF
--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -84,7 +84,7 @@ render: |
       type: holding
       decode: uint16
     scale: 0.1
-    {{- end }}
+  {{- end }}
   {{- if eq .usage "pv" }}
   power:
     source: calc

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -40,7 +40,51 @@ render: |
       type: holding
       decode: float32
     scale: 0.001
-  {{- end }}
+    currents:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 35122 # R phase Grid current, A
+      type: holding
+      decode: uint16
+    scale: 0.1
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 35127 # S phase Grid current, A
+      type: holding
+      decode: uint16
+    scale: 0.1
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 35132 # T phase Grid current, A
+      type: holding
+      decode: uint16
+    scale: 0.1
+  voltages:
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 35121 # R phase Grid voltage, V
+      type: holding
+      decode: uint16
+    scale: 0.1
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 35126 # S phase Grid voltage, V
+      type: holding
+      decode: uint16
+    scale: 0.1
+  - source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 35131 # T phase Grid voltage, V
+      type: holding
+      decode: uint16
+    scale: 0.1
+    {{- end }}
   {{- if eq .usage "pv" }}
   power:
     source: calc

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -62,28 +62,6 @@ render: |
       type: holding
       decode: uint16
     scale: 0.1
-  voltages:
-  - source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 35121 # R phase Grid voltage, V
-      type: holding
-      decode: uint16
-    scale: 0.1
-  - source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 35126 # S phase Grid voltage, V
-      type: holding
-      decode: uint16
-    scale: 0.1
-  - source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 35131 # T phase Grid voltage, V
-      type: holding
-      decode: uint16
-    scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -40,7 +40,7 @@ render: |
       type: holding
       decode: float32
     scale: 0.001
-    currents:
+  currents:
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:


### PR DESCRIPTION
um auch die Ströme und Spannungen der einzelnen Phasen am Meter des Goodwe-Hybrid template zu sehen, wurden diese per Modbus ausgelesen