### PR TITLE
Update energinet-co2.yaml

### DIFF
--- a/templates/definition/tariff/energinet-co2.yaml
+++ b/templates/definition/tariff/energinet-co2.yaml
@@ -19,7 +19,7 @@ render: |
   tariff: co2
   forecast:
     source: http
-    uri: https://api.energidataservice.dk/dataset/CO2EmisProg?filter={"PriceArea":["{{ .region }}"]}
+    uri: https://api.energidataservice.dk/dataset/CO2EmisProg?filter={"PriceArea":["{{ .region }}"]}&start=now
     jq: |
       [.records[]
         | {


### PR DESCRIPTION
The current API call to `CO2EmisProg` includes neither a `start` nor a `limit` parameter, so the response is limited to 100 records by default. Since the data is provided in 5-minute intervals and returned in descending order from midnight (local time), the API returns the last 100 forecast records furthest in the future, covering only the time range from 15:40 to 23:59.

As a result, evcc does not receive any forecast data for the earlier part of the day (00:00–15:40).

By adding `start=now` to the API call, evcc will receive data for the full forecast period.