### PR TITLE
chore: playwright stability

### DIFF
--- a/tests/backup-restore.spec.ts
+++ b/tests/backup-restore.spec.ts
@@ -157,6 +157,7 @@ test.describe("backup and restore", async () => {
     await backupConfirmModal.getByRole("button", { name: "Download backup" }).click();
     await expectModalHidden(backupConfirmModal);
     const download = await downloadPromise;
+    await expectModalVisible(backupModal)
     await backupModal.locator(".btn-close").click();
     await expectModalHidden(backupModal);
 

--- a/tests/backup-restore.spec.ts
+++ b/tests/backup-restore.spec.ts
@@ -157,7 +157,7 @@ test.describe("backup and restore", async () => {
     await backupConfirmModal.getByRole("button", { name: "Download backup" }).click();
     await expectModalHidden(backupConfirmModal);
     const download = await downloadPromise;
-    await expectModalVisible(backupModal)
+    await expectModalVisible(backupModal);
     await backupModal.locator(".btn-close").click();
     await expectModalHidden(backupModal);
 

--- a/tests/config-fatals.spec.ts
+++ b/tests/config-fatals.spec.ts
@@ -106,6 +106,7 @@ test.describe("fatal config handling", async () => {
     await expectModalVisible(meterModal);
     await meterModal.getByRole("button", { name: "Delete" }).click();
     await expectModalHidden(meterModal);
+    await expectModalVisible(lpModal);
     await lpModal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(lpModal);
     await page.waitForLoadState("networkidle");

--- a/tests/config-loadpoint.spec.ts
+++ b/tests/config-loadpoint.spec.ts
@@ -475,6 +475,7 @@ power:
     await expect(meterRestResult).toContainText(["Power", "5.0 kW"].join(""));
     await meterModal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(meterModal);
+    await expectModalVisible(lpModal);
 
     // create
     await lpModal.getByRole("button", { name: "Save" }).click();

--- a/tests/evcc.ts
+++ b/tests/evcc.ts
@@ -93,7 +93,12 @@ async function _start(config?: string, flags: string | string[] = []) {
   const port = workerPort();
   log(`wait until port ${port} is available`);
   // wait for port to be available
-  await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED, timeout: STARTUP_TIMEOUT });
+  await waitOn({
+    resources: [`tcp:${port}`],
+    reverse: true,
+    log: LOG_ENABLED,
+    timeout: STARTUP_TIMEOUT,
+  });
   const additionalFlags = typeof flags === "string" ? [flags] : flags;
   additionalFlags.push("--log", "debug,httpd:trace");
   log("starting evcc", { config, port, additionalFlags });

--- a/tests/evcc.ts
+++ b/tests/evcc.ts
@@ -8,7 +8,8 @@ import path from "path";
 import { Transform } from "stream";
 
 const BINARY = "./evcc";
-const LOG_ENABLED = false;
+const LOG_ENABLED = !process.env["GITHUB_ACTIONS"];
+const STARTUP_TIMEOUT = 60000; // 60 seconds for evcc startup operations
 
 function workerPort() {
   const index = Number(process.env["TEST_WORKER_INDEX"] ?? 0);
@@ -92,7 +93,7 @@ async function _start(config?: string, flags: string | string[] = []) {
   const port = workerPort();
   log(`wait until port ${port} is available`);
   // wait for port to be available
-  await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED });
+  await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED, timeout: STARTUP_TIMEOUT });
   const additionalFlags = typeof flags === "string" ? [flags] : flags;
   additionalFlags.push("--log", "debug,httpd:trace");
   log("starting evcc", { config, port, additionalFlags });
@@ -107,7 +108,7 @@ async function _start(config?: string, flags: string | string[] = []) {
     log("evcc terminated", { code, port, config });
     steamLog.end();
   });
-  await waitOn({ resources: [baseUrl()], log: LOG_ENABLED });
+  await waitOn({ resources: [baseUrl()], log: LOG_ENABLED, timeout: STARTUP_TIMEOUT });
   return instance;
 }
 

--- a/tests/plan.spec.ts
+++ b/tests/plan.spec.ts
@@ -557,6 +557,7 @@ test.describe("repeating", async () => {
     // activate
     await modal.getByTestId("repeating-plan-time").fill("02:22");
     await modal.getByTestId("repeating-plan-active").click();
+    await page.waitForLoadState("networkidle");
 
     // specific weekday and time
     await expect(modal.getByTestId("plan-preview-title")).toHaveText("Next plan #2");

--- a/tests/simulator.ts
+++ b/tests/simulator.ts
@@ -7,7 +7,7 @@ import { spawn } from "child_process";
 import { Transform } from "stream";
 import type { Page } from "@playwright/test";
 
-const LOG_ENABLED = false;
+const LOG_ENABLED = !process.env["GITHUB_ACTIONS"];
 
 function workerPort() {
   const index = parseInt(process.env["TEST_WORKER_INDEX"] ?? "-1");

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -28,8 +28,8 @@ export async function closeTopNavigation(page: Page): Promise<void> {
 }
 
 export async function expectTopNavigationOpened(page: Page): Promise<void> {
-  await expect(page.getByTestId("topnavigation-button")).toHaveAttribute("aria-expanded", "true");
   await expect(page.getByTestId("topnavigation-dropdown")).toBeVisible();
+  await expect(page.getByTestId("topnavigation-button")).toHaveAttribute("aria-expanded", "true");
 }
 
 export async function expectTopNavigationClosed(page: Page): Promise<void> {


### PR DESCRIPTION
🪵 enable logging for local runs
⏲️ add 60s evcc start timeout (fail faster on resource issue)
🎏 ensure modal (in)visibility 