### PR TITLE
SMA EM: use export register for energy

### DIFF
--- a/meter/sma.go
+++ b/meter/sma.go
@@ -109,6 +109,9 @@ var _ api.MeterEnergy = (*SMA)(nil)
 // TotalEnergy implements the api.MeterEnergy interface
 func (sm *SMA) TotalEnergy() (float64, error) {
 	values, err := sm.device.Values()
+	if sm.scale < 0 {
+		return sma.AsFloat(values[sunny.ActiveEnergyMinus]) / 3600000, err
+	}
 	return sma.AsFloat(values[sunny.ActiveEnergyPlus]) / 3600000, err
 }
 
@@ -130,7 +133,7 @@ func (sm *SMA) Currents() (float64, float64, float64, error) {
 		res[i] = util.SignFromPower(sma.AsFloat(values[id]), powers[i])
 	}
 
-	return res[0], res[1], res[2], err
+	return sm.scale * res[0], sm.scale * res[1], sm.scale * res[2], err
 }
 
 var _ api.PhaseVoltages = (*SMA)(nil)
@@ -161,7 +164,7 @@ func (sm *SMA) Powers() (float64, float64, float64, error) {
 		res[i] -= sma.AsFloat(values[id])
 	}
 
-	return res[0], res[1], res[2], err
+	return sm.scale * res[0], sm.scale * res[1], sm.scale * res[2], err
 }
 
 // soc implements the api.Battery interface


### PR DESCRIPTION
This PR modifies the SMA energy meter implementation to properly handle energy meters used as solar production meters by using the **export** energy register when scale is negative and applying scale factor to current and power measurements.

- Uses the export register (`ActiveEnergyMinus`) instead of import register when `scale < 0`
- Applies scale factor to current measurements returned by `Currents()` method
- Applies scale factor to power measurements returned by `Powers()` method

Attention: SMA Speedwire (sma.go) is also used for real solar inverters with `usage: pv` where this does NOT apply.

Replace #23691

Should fix #23398 #23589