### PR TITLE
OCPP: accept `Scheduled` as positive response to ChangeAvailibility request

### DIFF
--- a/charger/ocpp/cp_requests.go
+++ b/charger/ocpp/cp_requests.go
@@ -13,7 +13,7 @@ func (cp *CP) ChangeAvailabilityRequest(connectorId int, availabilityType core.A
 	rc := make(chan error, 1)
 
 	err := Instance().ChangeAvailability(cp.id, func(request *core.ChangeAvailabilityConfirmation, err error) {
-		if err == nil && request != nil && request.Status != core.AvailabilityStatusAccepted {
+		if err == nil && request != nil && request.Status != core.AvailabilityStatusAccepted && request.Status != core.AvailabilityStatusScheduled {
 			err = errors.New(string(request.Status))
 		}
 


### PR DESCRIPTION
Modified the `ChangeAvailabilityRequest` function to accept both `Accepted` and `Scheduled` status responses as successful.

- Previously, only `Accepted` was considered a successful response
- Now both `Accepted` and `Scheduled` are treated as successful
- This allows for scenarios where availability changes are scheduled for future execution rather than immediately applied
- Other status values (like `Rejected`) will still return an error as expected

The `Scheduled` status indicates that the availability change request has been accepted but will be applied at a later time (e.g., when current charging sessions complete). This is a valid successful response that should not be treated as an error.