### PR TITLE
Sungrow: disable charger during phase switching

### DIFF
--- a/charger/sungrow.go
+++ b/charger/sungrow.go
@@ -246,6 +246,13 @@ func (wb *Sungrow) Phases1p3p(phases int) error {
 		u = 1
 	}
 
+	if wb.enabled {
+		if err := wb.Enable(false); err != nil {
+			return err
+		}
+		defer wb.Enable(true)
+	}
+
 	// Switch phases
 	_, err := wb.conn.WriteSingleRegister(sgRegPhaseSwitch, u)
 

--- a/charger/sungrow.go
+++ b/charger/sungrow.go
@@ -246,17 +246,11 @@ func (wb *Sungrow) Phases1p3p(phases int) error {
 		u = 1
 	}
 
-	if wb.enabled {
-		if err := wb.Enable(false); err != nil {
-			return err
-		}
-		defer wb.Enable(true)
-	}
-
-	// Switch phases
-	_, err := wb.conn.WriteSingleRegister(sgRegPhaseSwitch, u)
-
-	return err
+	return whenDisabled(wb, func() error {
+		// Switch phases
+		_, err := wb.conn.WriteSingleRegister(sgRegPhaseSwitch, u)
+		return err
+	})
 }
 
 var _ api.PhaseGetter = (*Sungrow)(nil)


### PR DESCRIPTION
This PR fixes an issue where the Sungrow charger needs to be disabled during phase switching operations to prevent potential problems. The fix ensures the charger is safely disabled before switching phases and re-enabled afterward.

- Adds safety check to disable charger before phase switching
- Implements automatic re-enabling
- Guards the operation to only disable if charger was previously enabled

Fixes #23715
