### PR TITLE
daheimladen-pro: fix phases on connect change

### DIFF
--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -30,12 +30,12 @@ import (
 
 // DaheimLadenMB charger implementation
 type DaheimLadenMB struct {
-	log    			*util.Logger
-	conn   			*modbus.Connection
-	curr   			uint16
-	phases 			uint16
-	connState 		uint16
-	hasPhaseSwap	bool
+	log    		 *util.Logger
+	conn   		 *modbus.Connection
+	curr   		 uint16
+	phases 		 uint16
+	connState 	 uint16
+	hasPhaseSwap bool
 }
 
 const (

--- a/charger/daheimladen-mb.go
+++ b/charger/daheimladen-mb.go
@@ -191,7 +191,7 @@ func (wb *DaheimLadenMB) Status() (api.ChargeStatus, error) {
 			if wb.hasPhaseSwap {
 				wb.phases = 3
 			} 
-                                                                 wb.connState = connState
+            wb.connState = connState
 		}
 	} else {
 		wb.log.TRACE.Println("read connector state:", err)


### PR DESCRIPTION
Die DaheimLaden PRO ändern beim Ab- und Anstecken des Fahrzeugs den Phasenwert in Register 184 immer auf 3.
Das führt dann zu einem unschönen Ladestart, wenn evcc noch phases: 1 „in Erinnerung“ hat.
Dieser PR setzt immer dann `wb.phases` auf 3, wenn sich der Verbindungsstatus (Register 2) ändert.

Hinweis:
Ehrlicherweise muss ich zugeben, dass ich den Code nur rudimentär verstehe. Die Erstellung der Änderungen erfolgte mit Copilot.
