### PR TITLE
Add support for Canaan AvalonQ Bitcoin Miners

### DIFF
--- a/charger/avalonq.go
+++ b/charger/avalonq.go
@@ -1,0 +1,309 @@
+package charger
+
+import (
+    "fmt"
+    "net"
+    "strconv"
+    "strings"
+    "time"
+
+    "github.com/evcc-io/evcc/api"
+    "github.com/evcc-io/evcc/util"
+)
+
+// AvalonQ charger implementation
+type AvalonQ struct {
+    host     string
+    port     string
+    username string
+    password string
+}
+
+func init() {
+    registry.Add("avalonq", NewAvalonQFromConfig)
+}
+
+// NewAvalonQFromConfig creates a new AvalonQ charger from generic config
+func NewAvalonQFromConfig(other map[string]interface{}) (api.Charger, error) {
+    cc := struct {
+        Host     string
+        Port     string
+        Username string
+        Password string
+    }{
+        Port:     "4028",
+        Username: "admin",
+        Password: "admin",
+    }
+
+    if err := util.DecodeOther(other, &cc); err != nil {
+        return nil, err
+    }
+
+    return NewAvalonQ(cc.Host, cc.Port, cc.Username, cc.Password)
+}
+
+// NewAvalonQ creates AvalonQ charger
+func NewAvalonQ(host, port, username, password string) (api.Charger, error) {
+    if port == "" {
+        port = "4028"
+    }
+    if username == "" {
+        username = "admin"
+    }
+    if password == "" {
+        password = "admin"
+    }
+
+    c := &AvalonQ{
+        host:     host,
+        port:     port,
+        username: username,
+        password: password,
+    }
+
+    return c, nil
+}
+
+// sendCommand sends a command to the miner via TCP
+func (c *AvalonQ) sendCommand(command string) (string, error) {
+    address := net.JoinHostPort(c.host, c.port)
+    
+    conn, err := net.DialTimeout("tcp", address, 10*time.Second)
+    if err != nil {
+        return "", fmt.Errorf("failed to connect to miner: %v", err)
+    }
+    defer conn.Close()
+
+    // Send command
+    _, err = conn.Write([]byte(command))
+    if err != nil {
+        return "", fmt.Errorf("failed to send command: %v", err)
+    }
+
+    // Read response
+    buffer := make([]byte, 8192)
+    conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+    n, err := conn.Read(buffer)
+    if err != nil {
+        return "", fmt.Errorf("failed to read response: %v", err)
+    }
+
+    return string(buffer[:n]), nil
+}
+
+// parseResponse parses the miner response format
+func (c *AvalonQ) parseResponse(response string) map[string]string {
+    result := make(map[string]string)
+    
+    // Split by | and ,
+    parts := strings.Split(response, "|")
+    for _, part := range parts {
+        fields := strings.Split(part, ",")
+        for _, field := range fields {
+            if kv := strings.SplitN(field, "=", 2); len(kv) == 2 {
+                result[kv[0]] = kv[1]
+            }
+        }
+    }
+    
+    return result
+}
+
+// Status implements the api.Charger interface
+func (c *AvalonQ) Status() (api.ChargeStatus, error) {
+    response, err := c.sendCommand("summary")
+    if err != nil {
+        return api.StatusNone, err
+    }
+
+    data := c.parseResponse(response)
+    
+    // Check if miner is actively mining
+    if mhsAv, exists := data["MHS av"]; exists {
+        if hashrate, err := strconv.ParseFloat(mhsAv, 64); err == nil && hashrate > 1000 {
+            return api.StatusC, nil // Mining actively (equivalent to charging)
+        }
+    }
+
+    // Check if miner is connected but not mining much
+    if elapsed, exists := data["Elapsed"]; exists {
+        if elapsedTime, err := strconv.Atoi(elapsed); err == nil && elapsedTime > 0 {
+            return api.StatusB, nil // Connected but low/no mining
+        }
+    }
+
+    return api.StatusA, nil // Not connected or error
+}
+
+// Enabled implements the api.Charger interface
+func (c *AvalonQ) Enabled() (bool, error) {
+    response, err := c.sendCommand("summary")
+    if err != nil {
+        return false, err
+    }
+
+    data := c.parseResponse(response)
+    
+    // Check if mining is active (hashrate > threshold)
+    if mhsAv, exists := data["MHS av"]; exists {
+        if hashrate, err := strconv.ParseFloat(mhsAv, 64); err == nil {
+            return hashrate > 100, nil // Consider enabled if hashrate > 100 MH/s
+        }
+    }
+
+    return false, nil
+}
+
+// Enable implements the api.Charger interface
+func (c *AvalonQ) Enable(enable bool) error {
+    if enable {
+        // Wake up miner - set softon for immediate activation
+        timestamp := time.Now().Unix()
+        command := fmt.Sprintf("ascset|0,softon,1:%d", timestamp)
+        
+        _, err := c.sendCommand(command)
+        if err != nil {
+            return fmt.Errorf("failed to enable mining: %v", err)
+        }
+        
+        // Optional: Also reboot to ensure clean start
+        time.Sleep(2 * time.Second)
+        _, err = c.sendCommand("ascset|0,reboot,0")
+        return err
+        
+    } else {
+        // Put miner in standby - set softoff for immediate standby
+        timestamp := time.Now().Unix()
+        command := fmt.Sprintf("ascset|0,softoff,1:%d", timestamp)
+        
+        _, err := c.sendCommand(command)
+        if err != nil {
+            return fmt.Errorf("failed to disable mining: %v", err)
+        }
+        return nil
+    }
+}
+
+// MaxCurrent implements the api.Charger interface
+// Maps current to fan speed (power control proxy)
+func (c *AvalonQ) MaxCurrent(current int64) error {
+    // Map current (6-32A) to fan speed (15-100%)
+    // Higher current = more power = higher fan speed
+    var fanSpeed int64
+    
+    if current <= 0 {
+        fanSpeed = -1 // Auto fan control
+    } else if current <= 6 {
+        fanSpeed = 15 // Minimum fan speed
+    } else if current >= 32 {
+        fanSpeed = 100 // Maximum fan speed
+    } else {
+        // Linear mapping: 6A->15%, 32A->100%
+        fanSpeed = 15 + (current-6)*(100-15)/(32-6)
+    }
+
+    command := fmt.Sprintf("ascset|0,fan-spd,%d", fanSpeed)
+    
+    _, err := c.sendCommand(command)
+    if err != nil {
+        return fmt.Errorf("failed to set fan speed: %v", err)
+    }
+
+    return nil
+}
+
+// Additional mining-specific methods
+
+// GetHashrate returns current hashrate in MH/s
+func (c *AvalonQ) GetHashrate() (float64, error) {
+    response, err := c.sendCommand("summary")
+    if err != nil {
+        return 0, err
+    }
+
+    data := c.parseResponse(response)
+    
+    if mhsAv, exists := data["MHS av"]; exists {
+        return strconv.ParseFloat(mhsAv, 64)
+    }
+
+    return 0, fmt.Errorf("hashrate not found in response")
+}
+
+// GetTemperature returns average temperature
+func (c *AvalonQ) GetTemperature() (float64, error) {
+    response, err := c.sendCommand("estats")
+    if err != nil {
+        return 0, err
+    }
+
+    data := c.parseResponse(response)
+    
+    if tAvg, exists := data["TAvg"]; exists {
+        return strconv.ParseFloat(tAvg, 64)
+    }
+
+    return 0, fmt.Errorf("temperature not found in response")
+}
+
+// GetVersion returns miner version info
+func (c *AvalonQ) GetVersion() (string, error) {
+    response, err := c.sendCommand("version")
+    if err != nil {
+        return "", err
+    }
+
+    data := c.parseResponse(response)
+    
+    if version, exists := data["CGMiner"]; exists {
+        if model, exists := data["MODEL"]; exists {
+            return fmt.Sprintf("%s %s", model, version), nil
+        }
+        return version, nil
+    }
+
+    return "", fmt.Errorf("version not found in response")
+}
+
+// SetWorkMode sets the work mode (0-2)
+func (c *AvalonQ) SetWorkMode(mode int) error {
+    if mode < 0 || mode > 2 {
+        return fmt.Errorf("invalid work mode: %d (must be 0-2)", mode)
+    }
+
+    command := fmt.Sprintf("ascset|0,workmode,set,%d", mode)
+    
+    _, err := c.sendCommand(command)
+    if err != nil {
+        return fmt.Errorf("failed to set work mode: %v", err)
+    }
+
+    return nil
+}
+
+// SetPool configures mining pool
+func (c *AvalonQ) SetPool(poolNum int, poolAddr, worker, workerPass string) error {
+    if poolNum < 0 || poolNum > 2 {
+        return fmt.Errorf("invalid pool number: %d (must be 0-2)", poolNum)
+    }
+
+    command := fmt.Sprintf("setpool|%s,%s,%d,%s,%s,%s", 
+        c.username, c.password, poolNum, poolAddr, worker, workerPass)
+    
+    _, err := c.sendCommand(command)
+    if err != nil {
+        return fmt.Errorf("failed to set pool: %v", err)
+    }
+
+    return nil
+}
+
+// Reboot reboots the miner
+func (c *AvalonQ) Reboot() error {
+    _, err := c.sendCommand("ascset|0,reboot,0")
+    if err != nil {
+        return fmt.Errorf("failed to reboot miner: %v", err)
+    }
+    return nil
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,37 @@
+services:
+  evcc:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: evcc-avalonq
+    restart: unless-stopped
+    ports:
+      - "7070:7070"
+    volumes:
+      - ./evcc.yaml:/app/evcc.yaml
+      - evcc-data:/app/data
+    environment:
+      - TZ=Europe/Berlin
+    networks:
+      - evcc-network
+
+  # Optional: Monitoring
+  portainer:
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer-data:/data
+    networks:
+      - evcc-network
+
+volumes:
+  evcc-data:
+  portainer-data:
+
+networks:
+  evcc-network:
+    driver: bridge

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,41 @@
+# Build stage
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apk add --no-cache git gcc musl-dev
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build evcc
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-w -s" \
+    -o evcc \
+    ./cmd/evcc
+
+# Runtime stage
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates tzdata
+
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /app/evcc .
+
+# Copy templates and assets
+COPY --from=builder /app/templates ./templates
+COPY --from=builder /app/assets ./assets
+
+# Create data directory
+RUN mkdir -p /app/data
+
+EXPOSE 7070
+
+CMD ["./evcc"]

--- a/evcc.yaml
+++ b/evcc.yaml
@@ -1,0 +1,158 @@
+# open evcc at http://evcc.local:7070
+network:
+  schema: http
+  host: evcc.local # .local suffix announces the hostname on MDNS
+  port: 7070
+
+log: debug
+levels:
+  cache: error
+
+# unique installation id
+#plant: c87d99735c1f49513d41db22a391253b73faa86cbc270a67ab7542cf7d737ec6
+
+database:
+  type: sqlite
+  dsn: /var/lib/evcc/evcc.db
+
+interval: 30s # control cycle interval
+
+#sponsortoken: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJldmNjLmlvIiwic3ViIjoiZjFuY2g4NyIsImV4cCI6MTgzNzAwNDQwMCwiaWF0IjoxNzQyMzk2NDAwLCJzcmMiOiJnaCJ9.d4SAPZAP7GoVcsc1QIQGNzwMj-a501l-SyCHZ6xkeA0
+mqtt:
+  broker: 192.168.1.51:1883
+  topic: growatt
+  user: pmqtt
+  password: Quoka123#
+
+tariffs:
+  currency: EUR
+  grid:
+    type: fixed
+    price: 0.2729 # EUR/kWh
+
+  feedin:
+    type: fixed
+    price: 0.07
+
+telemetry: false
+
+meters:
+- name: tasmota
+  type: template
+  template: tasmota-sml
+  usage: grid
+  host: 192.168.1.191
+
+- name: pv_huawei
+  type: template
+  template: huawei-dongle-powersensor
+  id: 1
+  host: 192.168.1.30
+  port: 502
+  usage: pv
+  storageunit: 1
+  modbus: tcpip
+  timeout: 15s
+
+- name: battery_huawei
+  type: template
+  template: huawei-dongle-powersensor
+  id: 1
+  host: 192.168.1.30
+  port: 502
+  usage: battery
+  storageunit: 1
+  modbus: tcpip
+  timeout: 15s
+
+chargers:
+- name: schneider_wallbox
+  type: template
+  template: schneider-evlink-v3
+  id: 255
+  host: 192.168.1.83
+  port: 502
+  modbus: tcpip
+
+- name: avalon_1241
+  type: template
+  template: avalonq
+  host: 192.168.1.130  # Ihre Miner IP
+  title: "AvalonMiner 1241"
+    
+- name: avalon_1246
+  type: template
+  template: avalonq
+  host: 192.168.1.131  # Ihre Miner IP
+  title: "AvalonMiner 1246"
+    
+- name: avalon_1066
+  type: template
+  template: avalonq
+  host: 192.168.1.132  # Ihre Miner IP
+  title: "AvalonMiner 1066"
+
+vehicles:
+- name: MG4
+  type: template
+  template: mg
+  user: s.gerwald@googlemail.com
+  password: Quoka123
+  vin: LSJWH4090PN201241
+  title: MG4
+  capacity: 64
+  icon: car
+  phases: 1
+  mode: pv
+  minCurrent: 6
+  maxCurrent: 32
+  #identifiers: # Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/features/vehicle (optional)
+  #priority: # Priorität des Ladepunktes oder Fahrzeugs in Relation zu anderen Ladepunkten oder Fahrzeugen für die Zuweisung von PV-Energie (optional)
+  cache: 15m
+  region: EU
+
+- name: generic_vehicle
+  type: template
+  template: offline
+  title: "Mining Load"
+  capacity: 100
+
+loadpoints:
+- title: Hoftor
+  charger: schneider_wallbox
+  mode: pv
+
+- title: "AvalonMiner 1241"
+  charger: avalon_1241
+  vehicle: generic_vehicle
+  mode: pv
+  phases: 1
+  mincurrent: 6
+  maxcurrent: 16
+    
+- title: "AvalonMiner 1246" 
+  charger: avalon_1246
+  vehicle: generic_vehicle
+  mode: pv
+  phases: 1
+  mincurrent: 6
+  maxcurrent: 16
+    
+- title: "AvalonMiner 1066"
+  charger: avalon_1066  
+  vehicle: generic_vehicle
+  mode: pv
+  phases: 1
+  mincurrent: 6
+  maxcurrent: 16
+
+site:
+  title: Home Gerwald
+  meters:
+    grid: tasmota
+    pv:
+    - pv_huawei
+    - pv_growatt
+    battery:
+    - battery_huawei
+  residualPower: 100

--- a/templates/definition/charger/avalonq.yaml
+++ b/templates/definition/charger/avalonq.yaml
@@ -2,43 +2,32 @@ template: avalonq
 products:
   - brand: Canaan
     description:
-      generic: Avalon Q Series Bitcoin Miner
-required:
-  - host
-properties:
+      en: AvalonMiner with workmode control
+      de: AvalonMiner mit Workmode-Steuerung
+group: mining
+requirements:
+  evcc: ["0.124"]
+params:
   - name: host
     description:
-      en: AvalonQ Miner IP address
-      de: AvalonQ Miner IP-Adresse
-    example: "192.168.1.100"
+      en: Hostname or IP address
+      de: Hostname oder IP-Adresse
+    help:
+      en: Hostname or IP address of the miner
+      de: Hostname oder IP-Adresse des Miners
     required: true
+    example: 192.168.1.130
   - name: port
     description:
-      en: API port (default 4028)
-      de: API Port (Standard 4028)  
-    example: "4028"
-    default: "4028"
-  - name: username
+      en: Port (optional)
+      de: Port (optional)
+    default: 80
+  - name: timeout
     description:
-      en: Web interface username (default admin)
-      de: Web-Interface Benutzername (Standard admin)
-    example: "admin"
-    default: "admin"
-  - name: password
-    description:
-      en: Web interface password (default admin)
-      de: Web-Interface Passwort (Standard admin)
-    example: "admin"
-    default: "admin"
+      en: Timeout (optional)
+      de: Timeout (optional)
+    default: 10s
 render: |
   type: avalonq
-  host: {{ .host }}
-  {{- if .port }}
-  port: {{ .port }}
-  {{- end }}
-  {{- if .username }}
-  username: {{ .username }}
-  {{- end }}
-  {{- if .password }}
-  password: {{ .password }}
-  {{- end }}
+  uri: http://{{ .host }}{{ if ne .port 80 }}:{{ .port }}{{ end }}
+  timeout: {{ .timeout }}

--- a/templates/definition/charger/avalonq.yaml
+++ b/templates/definition/charger/avalonq.yaml
@@ -1,0 +1,44 @@
+template: avalonq
+products:
+  - brand: Canaan
+    description:
+      generic: Avalon Q Series Bitcoin Miner
+required:
+  - host
+properties:
+  - name: host
+    description:
+      en: AvalonQ Miner IP address
+      de: AvalonQ Miner IP-Adresse
+    example: "192.168.1.100"
+    required: true
+  - name: port
+    description:
+      en: API port (default 4028)
+      de: API Port (Standard 4028)  
+    example: "4028"
+    default: "4028"
+  - name: username
+    description:
+      en: Web interface username (default admin)
+      de: Web-Interface Benutzername (Standard admin)
+    example: "admin"
+    default: "admin"
+  - name: password
+    description:
+      en: Web interface password (default admin)
+      de: Web-Interface Passwort (Standard admin)
+    example: "admin"
+    default: "admin"
+render: |
+  type: avalonq
+  host: {{ .host }}
+  {{- if .port }}
+  port: {{ .port }}
+  {{- end }}
+  {{- if .username }}
+  username: {{ .username }}
+  {{- end }}
+  {{- if .password }}
+  password: {{ .password }}
+  {{- end }}


### PR DESCRIPTION
## Add AvalonQ Bitcoin Miner Charger Support

This PR adds support for Canaan AvalonQ Bitcoin miners as controllable chargers in evcc.

### Features:
- ✅ TCP API communication (port 4028)  
- ✅ Enable/Disable mining via softon/softoff
- ✅ Status monitoring (hashrate, temperature)
- ✅ Fan speed control as power proxy
- ✅ All official AvalonQ API commands

### Configuration:
```yaml
chargers:
  - name: avalon_miner
    type: avalonq  
    host: 192.168.1.100
    port: 4028
    username: admin
    password: admin