### PR TITLE
tariff/octopus: Properly support Export tariffs

### DIFF
--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -2,6 +2,7 @@ package tariff
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -61,9 +62,17 @@ func buildOctopusFromConfig(other map[string]interface{}) (*Octopus, error) {
 		return nil, err
 	}
 
-	// Do not permit invalid TariffDirections.
-	if cc.TariffDirection != octoGql.TariffDirectionImport && cc.TariffDirection != octoGql.TariffDirectionExport {
-		return nil, errors.New("invalid tariff direction")
+	switch cc.TariffDirection {
+	case "", octoGql.TariffDirectionImport:
+		// default to Import if unset
+		if cc.TariffDirection == "" {
+			cc.TariffDirection = octoGql.TariffDirectionImport
+		}
+	case octoGql.TariffDirectionExport:
+		// OK
+	default:
+		// Do not permit invalid TariffDirections.
+		return nil, fmt.Errorf("invalid tariff direction %q", cc.TariffDirection)
 	}
 
 	// Allow ApiKey to be missing only if Region and Tariff are not.

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -64,7 +64,7 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		}
 		if cc.TariffType != string(octoGql.TariffDirectionImport) {
 			// Throw a WARN if it appears the user has set the key when it's not necessary to do so
-			logger.WARN.Print("The 'tariffType' key is ignored when using product code")
+			logger.WARN.Println("tariffType ignored when using product code")
 		}
 	} else {
 		// ApiKey validators

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -34,13 +34,13 @@ func init() {
 
 func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	var cc struct {
-		Region        string
-		Tariff        string // DEPRECATED: use ProductCode
-		ProductCode   string
-		DirectDebit   bool
-		ApiKey        string
-		AccountNumber string
-		TariffType    octoGql.TariffDirection
+		Region          string
+		Tariff          string // DEPRECATED: use ProductCode
+		ProductCode     string
+		DirectDebit     bool
+		ApiKey          string
+		AccountNumber   string
+		TariffDirection octoGql.TariffDirection
 	}
 
 	logger := util.NewLogger("octopus")
@@ -50,7 +50,7 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 	}
 
 	// Do not permit invalid TariffTypes.
-	if cc.TariffType != octoGql.TariffDirectionImport && cc.TariffType != octoGql.TariffDirectionExport {
+	if cc.TariffDirection != octoGql.TariffDirectionImport && cc.TariffDirection != octoGql.TariffDirectionExport {
 		return nil, errors.New("invalid tariff type")
 	}
 
@@ -67,7 +67,7 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		if cc.ProductCode == "" {
 			return nil, errors.New("missing product code")
 		}
-		if cc.TariffType != octoGql.TariffDirectionImport {
+		if cc.TariffDirection != octoGql.TariffDirectionImport {
 			// Throw a WARN if it appears the user has set the key when it's not necessary to do so
 			logger.WARN.Println("tariffType ignored when using product code")
 		}
@@ -93,7 +93,7 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		apikey:          cc.ApiKey,
 		accountnumber:   cc.AccountNumber,
 		paymentMethod:   paymentMethod,
-		tariffDirection: cc.TariffType,
+		tariffDirection: cc.TariffDirection,
 		data:            util.NewMonitor[api.Rates](2 * time.Hour),
 	}
 

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -76,7 +76,8 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		if cc.Region != "" || cc.Tariff != "" {
 			return nil, errors.New("cannot use apikey at same time as product code")
 		}
-		if len(cc.ApiKey) != 32 || !strings.HasPrefix(cc.ApiKey, "sk_live_") {
+		// We permit the specific special apiKey "test" as sk_live_ keys are considered Stripe secrets by Github
+		if cc.ApiKey != "test" && (len(cc.ApiKey) != 32 || !strings.HasPrefix(cc.ApiKey, "sk_live_")) {
 			return nil, errors.New("invalid apikey format")
 		}
 	}

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -62,8 +62,9 @@ func NewOctopusFromConfig(other map[string]interface{}) (api.Tariff, error) {
 		if cc.ProductCode == "" {
 			return nil, errors.New("missing product code")
 		}
-		if cc.TariffDirection != "" {
-			logger.WARN.Print("The 'type' key is ignored when using product code")
+		if cc.TariffDirection != string(octoGql.TariffDirectionImport) {
+			// Throw a WARN if it appears the user has set the key when it's not necessary to do so
+			logger.WARN.Print("The 'tariffType' key is ignored when using product code")
 		}
 	} else {
 		// ApiKey validators

--- a/tariff/octopus/graphql/api.go
+++ b/tariff/octopus/graphql/api.go
@@ -175,7 +175,7 @@ func (c *OctopusGraphQLClient) TariffCode(direction TariffDirection) (string, er
 	}
 
 	if tariffCode == "" {
-		return "", errors.New(fmt.Sprint("no electricity agreement found of type", direction))
+		return "", fmt.Errorf("no electricity agreement for type %s", direction)
 	}
 
 	c.log.TRACE.Println("GraphQL: tariff code found:", tariffCode)

--- a/tariff/octopus/graphql/api.go
+++ b/tariff/octopus/graphql/api.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -174,7 +175,7 @@ func (c *OctopusGraphQLClient) TariffCode(direction TariffDirection) (string, er
 	}
 
 	if tariffCode == "" {
-		return "", errors.New("no appropriate electricity agreement found")
+		return "", errors.New(fmt.Sprint("no electricity agreement found of type", direction))
 	}
 
 	c.log.TRACE.Println("GraphQL: tariff code found:", tariffCode)

--- a/tariff/octopus/graphql/api.go
+++ b/tariff/octopus/graphql/api.go
@@ -157,12 +157,6 @@ func (c *OctopusGraphQLClient) TariffCode(direction TariffDirection) (string, er
 		return "", errors.New("no electricity agreements found")
 	}
 
-	// check type
-	// (theoretically) not needed for our uses
-	//switch t := q.Account.ElectricityAgreements[0].Tariff.(type) {
-	//
-	//}
-
 	// Filter out any inappropriate tariffs; select the first tariff that aligns with our configuration.
 	var tariffCode string
 	for _, agreement := range q.Account.ElectricityAgreements {

--- a/tariff/octopus/graphql/api.go
+++ b/tariff/octopus/graphql/api.go
@@ -131,8 +131,9 @@ func (c *OctopusGraphQLClient) AccountNumber() (accountNumber string, err error)
 	return c.accountNumber, nil
 }
 
-// TariffCode queries the Tariff Code of the first IMPORT Electricity Agreement active on the account.
-func (c *OctopusGraphQLClient) TariffCode() (string, error) {
+// TariffCode queries the Tariff Code of the first valid Electricity Agreement active on the account.
+// If export is set to false, return the first IMPORT tariff. If true, return the first EXPORT tariff.
+func (c *OctopusGraphQLClient) TariffCode(export bool) (string, error) {
 	// Update refresh token (if necessary)
 	if err := c.refreshToken(); err != nil {
 		return "", err
@@ -162,11 +163,11 @@ func (c *OctopusGraphQLClient) TariffCode() (string, error) {
 	//
 	//}
 
-	// Filter out any export tariffs; select the first import tariff.
+	// Filter out any inappropriate tariffs; select the first tariff that aligns with our configuration.
 	var tariffCode string
 	for _, agreement := range q.Account.ElectricityAgreements {
-		if agreement.Tariff.IsExport() {
-			c.log.TRACE.Println("GraphQL: filtering export tariff", agreement.Tariff.TariffCode())
+		if agreement.Tariff.IsExport() != export {
+			c.log.TRACE.Println("GraphQL: filtering tariff with incorrect import/export type:", agreement.Tariff.TariffCode())
 			continue
 		}
 		tariffCode = agreement.Tariff.TariffCode()

--- a/tariff/octopus/graphql/types.go
+++ b/tariff/octopus/graphql/types.go
@@ -42,10 +42,10 @@ func (d *tariffData) TariffCode() string {
 type TariffDirection string
 
 const (
-	// TariffTypeImport is for energy flow INTO the meter FROM the grid (to the property)
+	// TariffDirectionImport is for energy flow INTO the meter FROM the grid (to the property)
 	TariffDirectionImport TariffDirection = "import"
 
-	// TariffTypeExport is for energy flow OUT OF the meter FROM the property (to the grid)
+	// TariffDirectionExport is for energy flow OUT OF the meter FROM the property (to the grid)
 	TariffDirectionExport TariffDirection = "export"
 )
 

--- a/tariff/octopus/graphql/types.go
+++ b/tariff/octopus/graphql/types.go
@@ -38,9 +38,22 @@ func (d *tariffData) TariffCode() string {
 	return d.standardTariff.TariffCode
 }
 
-// IsExport is a shortcut function for determining whether the given tariff is for export, regardless of tariff type.
-func (d *tariffData) IsExport() bool {
-	return d.standardTariff.IsExport
+// TariffDirection defines which direction of energy flow is being denoted by the given tariff.
+type TariffDirection string
+
+const (
+	// TariffTypeImport is for energy flow INTO the meter FROM the grid (to the property)
+	TariffDirectionImport TariffDirection = "import"
+
+	// TariffTypeExport is for energy flow OUT OF the meter FROM the property (to the grid)
+	TariffDirectionExport TariffDirection = "export"
+)
+
+func (d *tariffData) TariffDirection() TariffDirection {
+	if d.standardTariff.IsExport {
+		return TariffDirectionExport
+	}
+	return TariffDirectionImport
 }
 
 type tariffType struct {

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -14,6 +14,7 @@ func TestOctopusConfigParse(t *testing.T) {
 	validTariffConfig := map[string]interface{}{
 		"region":      "H",
 		"tariff":      "GO-22-03-29",
+		"tariffType":  "import",
 		"directDebit": "True",
 	}
 
@@ -23,6 +24,7 @@ func TestOctopusConfigParse(t *testing.T) {
 	validProductCodeConfig := map[string]interface{}{
 		"region":      "H",
 		"productcode": "GO-22-03-29",
+		"tariffType":  "import",
 		"directDebit": "False",
 	}
 
@@ -32,8 +34,16 @@ func TestOctopusConfigParse(t *testing.T) {
 	invalidApiAndProductCodeConfig := map[string]interface{}{
 		"region":      "H",
 		"productcode": "GO-22-03-29",
+		"tariffType":  "import",
 		"apikey":      "nope",
 	}
 	_, err = NewOctopusFromConfig(invalidApiAndProductCodeConfig)
 	require.Error(t, err)
+
+	invalidTariffTypeConfig := map[string]interface{}{
+		"tariffType": "invalid",
+		"apikey":     "sk_live_TESTTESTTESTTESTTESTTEST",
+	}
+	_, err = NewOctopusFromConfig(invalidTariffTypeConfig)
+	require.Errorf(t, err, "invalid tariff type")
 }

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -18,7 +18,7 @@ func TestOctopusConfigParse(t *testing.T) {
 		"directDebit":     "True",
 	}
 
-	_, err := NewOctopusFromConfig(validTariffConfig)
+	_, err := buildOctopusFromConfig(validTariffConfig)
 	require.NoError(t, err)
 
 	validProductCodeConfig := map[string]interface{}{
@@ -28,7 +28,7 @@ func TestOctopusConfigParse(t *testing.T) {
 		"directDebit":     "False",
 	}
 
-	_, err = NewOctopusFromConfig(validProductCodeConfig)
+	_, err = buildOctopusFromConfig(validProductCodeConfig)
 	require.NoError(t, err)
 
 	invalidApiAndProductCodeConfig := map[string]interface{}{
@@ -37,13 +37,20 @@ func TestOctopusConfigParse(t *testing.T) {
 		"tariffDirection": "import",
 		"apikey":          "invalid_key",
 	}
-	_, err = NewOctopusFromConfig(invalidApiAndProductCodeConfig)
+	_, err = buildOctopusFromConfig(invalidApiAndProductCodeConfig)
 	require.Error(t, err)
 
 	invalidTariffDirectionConfig := map[string]interface{}{
 		"tariffDirection": "invalid",
 		"apikey":          "test",
 	}
-	_, err = NewOctopusFromConfig(invalidTariffDirectionConfig)
+	_, err = buildOctopusFromConfig(invalidTariffDirectionConfig)
 	require.Errorf(t, err, "invalid tariff type")
+
+	validApiExportConfig := map[string]interface{}{
+		"tariffDirection": "export",
+		"apikey":          "test",
+	}
+	_, err = buildOctopusFromConfig(validApiExportConfig)
+	require.NoError(t, err)
 }

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -12,38 +12,38 @@ func TestOctopusConfigParse(t *testing.T) {
 
 	// This test will start failing if you remove the deprecated "tariff" config var.
 	validTariffConfig := map[string]interface{}{
-		"region":      "H",
-		"tariff":      "GO-22-03-29",
-		"tariffType":  "import",
-		"directDebit": "True",
+		"region":          "H",
+		"tariff":          "GO-22-03-29",
+		"tariffDirection": "import",
+		"directDebit":     "True",
 	}
 
 	_, err := NewOctopusFromConfig(validTariffConfig)
 	require.NoError(t, err)
 
 	validProductCodeConfig := map[string]interface{}{
-		"region":      "H",
-		"productcode": "GO-22-03-29",
-		"tariffType":  "import",
-		"directDebit": "False",
+		"region":          "H",
+		"productcode":     "GO-22-03-29",
+		"tariffDirection": "import",
+		"directDebit":     "False",
 	}
 
 	_, err = NewOctopusFromConfig(validProductCodeConfig)
 	require.NoError(t, err)
 
 	invalidApiAndProductCodeConfig := map[string]interface{}{
-		"region":      "H",
-		"productcode": "GO-22-03-29",
-		"tariffType":  "import",
-		"apikey":      "invalid_key",
+		"region":          "H",
+		"productcode":     "GO-22-03-29",
+		"tariffDirection": "import",
+		"apikey":          "invalid_key",
 	}
 	_, err = NewOctopusFromConfig(invalidApiAndProductCodeConfig)
 	require.Error(t, err)
 
-	invalidTariffTypeConfig := map[string]interface{}{
-		"tariffType": "invalid",
-		"apikey":     "test",
+	invalidTariffDirectionConfig := map[string]interface{}{
+		"tariffDirection": "invalid",
+		"apikey":          "test",
 	}
-	_, err = NewOctopusFromConfig(invalidTariffTypeConfig)
+	_, err = NewOctopusFromConfig(invalidTariffDirectionConfig)
 	require.Errorf(t, err, "invalid tariff type")
 }

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -35,14 +35,14 @@ func TestOctopusConfigParse(t *testing.T) {
 		"region":      "H",
 		"productcode": "GO-22-03-29",
 		"tariffType":  "import",
-		"apikey":      "nope",
+		"apikey":      "invalid_key",
 	}
 	_, err = NewOctopusFromConfig(invalidApiAndProductCodeConfig)
 	require.Error(t, err)
 
 	invalidTariffTypeConfig := map[string]interface{}{
 		"tariffType": "invalid",
-		"apikey":     "sk_live_TESTTESTTESTTESTTESTTEST",
+		"apikey":     "test",
 	}
 	_, err = NewOctopusFromConfig(invalidTariffTypeConfig)
 	require.Errorf(t, err, "invalid tariff type")

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -12,20 +12,18 @@ func TestOctopusConfigParse(t *testing.T) {
 
 	// This test will start failing if you remove the deprecated "tariff" config var.
 	validTariffConfig := map[string]interface{}{
-		"region":          "H",
-		"tariff":          "GO-22-03-29",
-		"tariffDirection": "import",
-		"directDebit":     "True",
+		"region":      "H",
+		"tariff":      "GO-22-03-29",
+		"directDebit": "True",
 	}
 
 	_, err := buildOctopusFromConfig(validTariffConfig)
 	require.NoError(t, err)
 
 	validProductCodeConfig := map[string]interface{}{
-		"region":          "H",
-		"productcode":     "GO-22-03-29",
-		"tariffDirection": "import",
-		"directDebit":     "False",
+		"region":      "H",
+		"productcode": "GO-22-03-29",
+		"directDebit": "False",
 	}
 
 	_, err = buildOctopusFromConfig(validProductCodeConfig)

--- a/templates/definition/tariff/octopus-api.yaml
+++ b/templates/definition/tariff/octopus-api.yaml
@@ -23,7 +23,17 @@ params:
       en: "Only required if you have multiple accounts."
       de: "Nur erforderlich, wenn mehrere Konten vorhanden sind."
     example: "X-XXXXXXXX"
+  - name: export
+    description:
+      de: Einspeisetarif Nutzen
+      en: Use Export Tariffs
+    help:
+      en: "Setting this will query the export tariff associated with this account. Set this when using feedin:"
+    type: bool
+    required: false
+    default: false
 render: |
   type: octopusenergy
   apikey: {{ .apiKey }}
   accountNumber: {{ .accountNumber }}
+  export: {{ .export }}

--- a/templates/definition/tariff/octopus-api.yaml
+++ b/templates/definition/tariff/octopus-api.yaml
@@ -25,7 +25,7 @@ params:
     example: "X-XXXXXXXX"
   - name: tariffType
     type: choice
-    choice: [ "import", "export" ]
+    choice: ["import", "export"]
     required: false
     default: "import"
     description:
@@ -37,4 +37,4 @@ render: |
   type: octopusenergy
   apikey: {{ .apiKey }}
   accountNumber: {{ .accountNumber }}
-  tariffDirection: {{ .tariffType }}
+  tariffType: {{ .tariffType }}

--- a/templates/definition/tariff/octopus-api.yaml
+++ b/templates/definition/tariff/octopus-api.yaml
@@ -23,17 +23,18 @@ params:
       en: "Only required if you have multiple accounts."
       de: "Nur erforderlich, wenn mehrere Konten vorhanden sind."
     example: "X-XXXXXXXX"
-  - name: export
-    description:
-      de: Einspeisetarif Nutzen
-      en: Use Export Tariffs
-    help:
-      en: "Setting this will query the export tariff associated with this account. Set this when using feedin:"
-    type: bool
+  - name: tariffType
+    type: choice
+    choice: [ "import", "export" ]
     required: false
-    default: false
+    default: "import"
+    description:
+      generic: The type of tariff to query from Octopus.
+    help:
+      generic: "Set to 'export' when using feedin:"
+
 render: |
   type: octopusenergy
   apikey: {{ .apiKey }}
   accountNumber: {{ .accountNumber }}
-  export: {{ .export }}
+  tariffDirection: {{ .tariffType }}

--- a/templates/definition/tariff/octopus-api.yaml
+++ b/templates/definition/tariff/octopus-api.yaml
@@ -23,13 +23,13 @@ params:
       en: "Only required if you have multiple accounts."
       de: "Nur erforderlich, wenn mehrere Konten vorhanden sind."
     example: "X-XXXXXXXX"
-  - name: tariffType
+  - name: tariffDirection
     type: choice
     choice: ["import", "export"]
     required: false
     default: "import"
     description:
-      generic: The type of tariff to query from Octopus.
+      generic: The tariff flow direction to query from Octopus.
     help:
       generic: "Set to 'export' when using feedin:"
 
@@ -37,4 +37,4 @@ render: |
   type: octopusenergy
   apikey: {{ .apiKey }}
   accountNumber: {{ .accountNumber }}
-  tariffType: {{ .tariffType }}
+  tariffDirection: {{ .tariffDirection }}


### PR DESCRIPTION
This PR allows for setting `export: true` on a tariff template to acquire only the first Export tariff.

Works best in conjunction with the `feedin:` tariff type (obviously). Defaults to classic behaviour (which is to get the _import_ tariff).