### PR TITLE
Kathrein: fix RFID (part 2)

### DIFF
--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -18,6 +18,7 @@ package charger
 // SOFTWARE.
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -427,12 +428,25 @@ func (wb *Kathrein) Identify() (string, error) {
 		return "", nil
 	}
 
-	b, err := wb.conn.ReadHoldingRegisters(kathreinRegRfid, 16)
+	b, err := wb.conn.ReadHoldingRegisters(kathreinRegRfid, 24)
 	if err != nil {
 		return "", err
 	}
 
-	return string(b), nil
+	rfid := string(b)
+	i := bytes.IndexByte(b, 0)
+
+	if i != -1 {
+		rfid = string(b[:i])
+	}
+
+	// "VOID" case
+	if len(rfid) < 6 {
+		return rfid, nil
+	}
+
+	// Remove prefix "RFID:"
+	return rfid[5:], nil
 }
 
 var _ api.Diagnosis = (*Kathrein)(nil)

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -433,20 +434,13 @@ func (wb *Kathrein) Identify() (string, error) {
 		return "", err
 	}
 
-	rfid := string(b)
-	i := bytes.IndexByte(b, 0)
+	rfid := string(bytes.TrimRight(b, "\x00"))
 
-	if i != -1 {
-		rfid = string(b[:i])
+	if strings.HasPrefix(rfid, "RFID:") {
+		return rfid[5:], nil
 	}
 
-	// "VOID" case
-	if len(rfid) < 6 {
-		return rfid, nil
-	}
-
-	// Remove prefix "RFID:"
-	return rfid[5:], nil
+	return rfid, nil
 }
 
 var _ api.Diagnosis = (*Kathrein)(nil)


### PR DESCRIPTION
May fix #23582 

- Read 24 registers for RFID (instead of 16, error in Kathrein modbus document),
- Remove null bytes,
- Remove prefix “RFID:”

