### PR TITLE
metrics: align 15min profile aggregation with local time

### DIFF
--- a/core/metrics/db.go
+++ b/core/metrics/db.go
@@ -36,11 +36,12 @@ func Profile(from time.Time) (*[96]float64, error) {
 		return nil, err
 	}
 
+	// Use 'localtime' in strftime to fix https://github.com/evcc-io/evcc/discussions/23759
 	rows, err := db.Query(`SELECT min(ts) AS ts, avg(val) AS val
 		FROM meters
 		WHERE meter = ? AND ts >= ?
-		GROUP BY strftime("%H:%M", ts)
-		ORDER BY strftime("%H:%M", ts) ASC`, 1, from,
+		GROUP BY strftime("%H:%M", ts, 'localtime')
+		ORDER BY strftime("%H:%M", ts, 'localtime') ASC`, 1, from,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/evcc-io/evcc/discussions/23759

Tested in the following way:
* Copy real database and evcc.yaml into devcontainer
* Run locally
* Verify that the household demand now fits the correct hours

<img width="1330" height="227" alt="image" src="https://github.com/user-attachments/assets/92bc5661-70eb-4ae1-9a45-e869f5ef065a" />

<img width="675" height="297" alt="image" src="https://github.com/user-attachments/assets/03dbbe47-1193-4a9c-85d2-1bb286f7e8d2" />
