### PR TITLE
Add FoxESS H3 PRO

### DIFF
--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -2,7 +2,7 @@ template: fox-ess-h3-smart
 products:
   - brand: FoxESS
     description:
-      generic: H3-Smart Series Hybrid Inverter
+      generic: "H3-Smart & H3 PRO Series Hybrid Inverter"
 capabilities: ["battery-control"]
 params:
   - name: usage


### PR DESCRIPTION
Following the latest changes and discussions in this topic (evcc-io/evcc#21129), the template can now handle ESS H3 Pro devices.