### PR TITLE
chore: GitHub Actions permissions

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -138,6 +138,8 @@ jobs:
 
   ui:
     name: UI
+    permissions:
+      contents: read
     runs-on: depot-ubuntu-24.04-arm
 
     steps:

--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -1,4 +1,7 @@
 name: Create Documentation Issue
+permissions:
+  issues: write
+  contents: read
 
 on:
   pull_request_target:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,6 @@
 name: Nightly Build
+permissions:
+  contents: read
 
 on:
   schedule: # runs on the default branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     needs:
       - call-build-workflow
     runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   stale:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: depot-ubuntu-24.04-arm
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,4 +1,6 @@
 name: Deploy data to website
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/evcc-io/evcc/security/code-scanning/21](https://github.com/evcc-io/evcc/security/code-scanning/21)

The best fix is to define the `permissions` key at the workflow (top) level, granting only the minimum necessary privilege: `contents: read`. This approach means jobs will not inherit broad (possibly write-enabled) default permissions, reducing risk. This permissions block should be inserted after the `name:` definition and before the `on:` block for maximal clarity and to cover all jobs unless more granular control is necessary. No further changes to the steps or jobs are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
