### PR TITLE
Optimizer: fix charging goal unit

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -195,7 +195,7 @@ func (site *Site) optimizerUpdate(battery []measurement) error {
 			goal, socBased := lp.GetPlanGoal()
 			if goal > 0 {
 				if v := lp.GetVehicle(); socBased && v != nil {
-					goal *= v.Capacity()
+					goal *= v.Capacity() * 10
 				}
 			}
 


### PR DESCRIPTION
Currently, this is % * kWh, while the unit should be Wh. The correct formula is IMHO `goal / 100 * capacity * 1000` which results in `goal * capacity * 10`

Example from slack https://evccgroup.slack.com/archives/C0988S1U11N/p1758886572917209 
`80% * 86 kWh = 6880`
should be `68800 Wh`
