### PR TITLE
Solis Hybrid S: Add Battery Control

### DIFF
--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -7,6 +7,16 @@ products:
     description:
       generic: AXIhycon 12-15H
 capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Um die aktive Ladesteuerung zum Netzladen nutzen zu können ist eine einmalige manuelle Einrichtung notwendig.
+      Navigiere zu "System Settings" > "Storage Mode" im Wechselrichter Menü und aktiviere "Allow grid charging".
+      Wenn die aktive Ladesteuerung dann die "Battery Reserve"-Einstellung anpasst, lädt der Wechselrichter die Batterie aus dem Netz bis zum hier konfigurierten Max SOC Wert auf (Standard: 95%).
+    en: |
+      To use active battery control with grid charging, a one-time manual setup is required.
+      Navigate to "System Settings" > "Storage Mode" in the inverter menu and enable "Allow grid charging".
+      When active battery control adjusts the "Battery Reserve" setting, the inverter will charge the battery from the grid up to the Max SOC setting configured here (Default: 95%).
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -29,15 +29,8 @@ params:
     advanced: true
   - name: maxacpower
   - name: minsoc
-    type: int
-    default: 20
     advanced: true
   - name: maxsoc
-    type: int
-    default: 95
-    advanced: true
-  - name: delay
-    default: 100ms
     advanced: true
 render: |
   type: custom
@@ -158,7 +151,6 @@ render: |
   limitsoc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
-    delay: {{ .delay }}
     register:
       address: 43024 # Battery Reserve Mode SOC
       type: writeholding

--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -6,6 +6,7 @@ products:
   - brand: Axitec
     description:
       generic: AXIhycon 12-15H
+capabilities: ["battery-control"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -17,6 +18,17 @@ params:
   - name: capacity
     advanced: true
   - name: maxacpower
+  - name: minsoc
+    type: int
+    default: 20
+    advanced: true
+  - name: maxsoc
+    type: int
+    default: 95
+    advanced: true
+  - name: delay
+    default: 100ms
+    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -133,5 +145,15 @@ render: |
       address: 33139 # Battery capacity SOC
       type: input
       decode: uint16
+  limitsoc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    delay: {{ .delay }}
+    register:
+      address: 43024 # Battery Reserve Mode SOC
+      type: writeholding
+      encoding: uint16
   capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }} # %
+  maxsoc: {{ .maxsoc }} # %
   {{- end }}


### PR DESCRIPTION
This adds the battery control capability to the Solis Hybrid S Inverters template to charge the battery from the grid. 

Tested with a Solis S6-EH3P15K02-NV-YD-L. Grid charging needs to get enabled manually via the inverter's display menu for it to work.