### PR TITLE
KEBA: revert phase switching state for P30 variants

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1301,7 +1301,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 
 	// scale up phases
 	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {
-		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, 3*Voltage*minCurrent, maxPhases)
+		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, float64(maxPhases)*Voltage*minCurrent, maxPhases)
 
 		if !lp.charging() { // scale immediately if not charging
 			lp.phaseTimer = elapsed


### PR DESCRIPTION
Revert the phase switching change from #23516 for P30 variants. Seems like the documentation is wrong and that's why the existing code worked. 

I implemented a condition to have both P40 and P30 working.

Fixes #23891