### PR TITLE
Add heatpump dimming

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -185,6 +185,12 @@ type SocLimiter interface {
 	GetLimitSoc() (int64, error)
 }
 
+// Dimmer provides §14a dimming
+type Dimmer interface {
+	Dimmed() (bool, error)
+	Dimm() error
+}
+
 // ChargeController allows to start/stop the charging session on the vehicle side
 type ChargeController interface {
 	ChargeEnable(bool) error

--- a/api/api.go
+++ b/api/api.go
@@ -188,7 +188,7 @@ type SocLimiter interface {
 // Dimmer provides §14a dimming
 type Dimmer interface {
 	Dimmed() (bool, error)
-	Dimm() error
+	Dim(bool) error
 }
 
 // ChargeController allows to start/stop the charging session on the vehicle side

--- a/charger/sgready-boost.go
+++ b/charger/sgready-boost.go
@@ -53,7 +53,7 @@ func NewSgReadyBoostFromConfig(ctx context.Context, other map[string]interface{}
 func NewSgReadyBoost(ctx context.Context, embed *embed, charger api.Charger) (*SgReady, error) {
 	modeS := func(mode int64) error {
 		switch mode {
-		case Dimm:
+		case Dim:
 			return api.ErrNotAvailable
 		case Normal:
 			return charger.Enable(false)

--- a/charger/sgready.go
+++ b/charger/sgready.go
@@ -135,7 +135,7 @@ func (wb *SgReady) Status() (api.ChargeStatus, error) {
 	}
 
 	if mode == Dim {
-		return api.StatusNone, errors.New("dimm mode")
+		return api.StatusNone, errors.New("dim mode")
 	}
 
 	status := map[int64]api.ChargeStatus{Boost: api.StatusC, Normal: api.StatusB}

--- a/charger/sgready.go
+++ b/charger/sgready.go
@@ -161,6 +161,25 @@ func (wb *SgReady) Enable(enable bool) error {
 	return wb.setMaxPower(wb.power)
 }
 
+var _ api.Dimmer = (*SgReady)(nil)
+
+// Dimmed implements the api.Dimmer interface
+func (wb *SgReady) Dimmed() (bool, error) {
+	mode, err := wb.getMode()
+	return mode == Dimm, err
+}
+
+// Dimm implements the api.Dimmer interface
+func (wb *SgReady) Dimm() error {
+	if err := wb.modeS(Dimm); err != nil {
+		return err
+	}
+
+	wb.mode = Dimm
+
+	return nil
+}
+
 // MaxCurrent implements the api.Charger interface
 func (wb *SgReady) MaxCurrent(current int64) error {
 	return wb.MaxCurrentMillis(float64(current))

--- a/charger/sgready.go
+++ b/charger/sgready.go
@@ -47,7 +47,7 @@ func init() {
 
 const (
 	_      int64 = iota
-	Dimm         // 1
+	Dim          // 1
 	Normal       // 2
 	Boost        // 3
 )
@@ -134,7 +134,7 @@ func (wb *SgReady) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
-	if mode == Dimm {
+	if mode == Dim {
 		return api.StatusNone, errors.New("dimm mode")
 	}
 
@@ -166,16 +166,21 @@ var _ api.Dimmer = (*SgReady)(nil)
 // Dimmed implements the api.Dimmer interface
 func (wb *SgReady) Dimmed() (bool, error) {
 	mode, err := wb.getMode()
-	return mode == Dimm, err
+	return mode == Dim, err
 }
 
 // Dimm implements the api.Dimmer interface
-func (wb *SgReady) Dimm() error {
-	if err := wb.modeS(Dimm); err != nil {
+func (wb *SgReady) Dim(dim bool) error {
+	mode := Normal
+	if dim {
+		mode = Dim
+	}
+
+	if err := wb.modeS(mode); err != nil {
 		return err
 	}
 
-	wb.mode = Dimm
+	wb.mode = Dim
 
 	return nil
 }

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -36,6 +36,7 @@ const (
 	Enabled   = "enabled"   // loadpoint enabled
 	Connected = "connected" // connected
 	Charging  = "charging"  // charging
+	Dimmed    = "dimmed"    // dimmed pseudo-status
 
 	// loadpoint setpoint
 	OfferedCurrent = "offeredCurrent" // offered current

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1848,25 +1848,25 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	lp.PublishEffectiveValues()
 
 	// §14a
-	if dimmer, ok := lp.charger.(api.Dimmer); ok && false {
+	if dimmer, ok := lp.charger.(api.Dimmer); ok {
 		dimmed, err := dimmer.Dimmed()
 		if err != nil {
 			lp.log.ERROR.Printf("dimmed: %v", err)
 			return
 		}
 
-		if !dimmed {
-			if err := dimmer.Dimm(); err != nil {
-				lp.log.ERROR.Printf("dimm: %v", err)
+		mustDim := lp.circuit != nil && lp.circuit.Dimmed()
+
+		if mustDim != dimmed {
+			if err := dimmer.Dim(mustDim); err != nil {
+				lp.log.ERROR.Printf("dim: %v", err)
 				return
 			}
 
-			lp.publish(keys.Dimmed, true)
-			lp.log.INFO.Printf("§14a active: dimming")
+			lp.publish(keys.Dimmed, mustDim)
+			lp.log.INFO.Printf("§14a dim: %t", mustDim)
 			return
 		}
-	} else {
-		lp.publish(keys.Dimmed, false)
 	}
 
 	// read and publish status

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1847,6 +1847,28 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	lp.publishChargeProgress()
 	lp.PublishEffectiveValues()
 
+	// §14a
+	if dimmer, ok := lp.charger.(api.Dimmer); ok && false {
+		dimmed, err := dimmer.Dimmed()
+		if err != nil {
+			lp.log.ERROR.Printf("dimmed: %v", err)
+			return
+		}
+
+		if !dimmed {
+			if err := dimmer.Dimm(); err != nil {
+				lp.log.ERROR.Printf("dimm: %v", err)
+				return
+			}
+
+			lp.publish(keys.Dimmed, true)
+			lp.log.DEBUG.Printf("dimm active: %v", err)
+			return
+		}
+	} else {
+		lp.publish(keys.Dimmed, false)
+	}
+
 	// read and publish status
 	welcomeCharge, err := lp.updateChargerStatus()
 	if err != nil {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1855,16 +1855,19 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 			return
 		}
 
-		mustDim := lp.circuit != nil && lp.circuit.Dimmed()
+		dim := lp.circuit != nil && lp.circuit.Dimmed()
 
-		if mustDim != dimmed {
-			if err := dimmer.Dim(mustDim); err != nil {
+		if dim != dimmed {
+			if err := dimmer.Dim(dim); err != nil {
 				lp.log.ERROR.Printf("dim: %v", err)
 				return
 			}
 
-			lp.publish(keys.Dimmed, mustDim)
-			lp.log.INFO.Printf("§14a dim: %t", mustDim)
+			lp.publish(keys.Dimmed, dim)
+			lp.log.INFO.Printf("§14a dim: %t", dim)
+		}
+
+		if dim {
 			return
 		}
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1862,7 +1862,7 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 			}
 
 			lp.publish(keys.Dimmed, true)
-			lp.log.DEBUG.Printf("dimm active: %v", err)
+			lp.log.INFO.Printf("§14a active: dimming")
 			return
 		}
 	} else {


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/23912, fix https://github.com/evcc-io/evcc/issues/23510

For SG Ready heatpumps, add a dimmer api. Under §14a, the SG Ready heatpump is unconditionally dimmed.

**TODO**

- [x] §14a indicator https://github.com/evcc-io/evcc/pull/23927

**Out of scope**

- [ ] more devices