### PR TITLE
chore: GitHub actions security

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,8 +12,13 @@ jobs:
     name: Clean
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -47,8 +52,13 @@ jobs:
     name: Build
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -80,8 +90,13 @@ jobs:
     name: Test
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -106,8 +121,13 @@ jobs:
     name: Lint
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -140,10 +160,13 @@ jobs:
     name: UI
     permissions:
       contents: read
+      actions: write
     runs-on: depot-ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -180,8 +203,14 @@ jobs:
     name: Integration
     runs-on: depot-ubuntu-24.04-arm-16
 
+    permissions:
+      contents: read
+      actions: write
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   check-label-and-create-issue:
     runs-on: depot-ubuntu-24.04-arm
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name
     steps:
       - name: Check for 'needs documentation' label
         id: check-label
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.DOCS_ISSUE_TOKEN }}
           script: |
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
@@ -32,7 +32,7 @@ jobs:
         if: steps.check-label.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.DOCS_ISSUE_TOKEN }}
           script: |
             const title = `Document: ${context.payload.pull_request.title}`;
             const body = `We need to document the new feature introduced in this PR: ${context.payload.pull_request.html_url}`;

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,8 +12,13 @@ jobs:
     name: Deploy updated templates
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -26,7 +31,7 @@ jobs:
       - name: Deploy to docs repo
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.GH_TOKEN }}
+          personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
           publish_dir: ./templates/docs
           external_repository: evcc-io/docs
           publish_branch: main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,10 +11,15 @@ jobs:
   check_date:
     runs-on: depot-ubuntu-24.04-arm
     name: Check latest commit
+
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: print latest_commit
         run: echo ${{ github.sha }}
 
@@ -39,11 +44,16 @@ jobs:
       - call-build-workflow
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+      actions: read
+
     steps:
       - uses: actions/checkout@v5
         with:
           ref: refs/heads/master # force master
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get dist from cache
         uses: actions/cache/restore@v4
@@ -94,13 +104,17 @@ jobs:
       - docker
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v5
         with:
           repository: evcc-io/hassio-addon
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.HASSIO_DEPLOY_TOKEN }}
           path: ./hassio
+          persist-credentials: false
 
       - name: Update version
         run: |
@@ -123,10 +137,15 @@ jobs:
       - call-build-workflow
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+      actions: read
+
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -22,6 +25,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Login
         uses: docker/login-action@v3
@@ -55,10 +59,15 @@ jobs:
       - call-build-workflow
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: write
+      actions: read
+
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -96,8 +105,8 @@ jobs:
           version: latest
           args: release --clean
         env:
-          # use GH_TOKEN for access to evcc-io/homebrew-tap
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # use RELEASE_DEPLOY_TOKEN for access to evcc-io/homebrew-tap
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DEPLOY_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:
@@ -116,10 +125,16 @@ jobs:
     needs:
       - docker
     runs-on: depot-ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --local-only --config packaging/fly.toml
 
@@ -129,13 +144,17 @@ jobs:
       - docker
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@master
         with:
           repository: evcc-io/hassio-addon
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.HASSIO_DEPLOY_TOKEN }}
           path: ./hassio
+          persist-credentials: false
 
       - name: Update version
         run: |

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -14,8 +14,13 @@ jobs:
   build:
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: nwisbeta/validate-yaml-schema@v2.0.0
         with:
           yamlSchemasJson: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,8 +12,13 @@ jobs:
     name: Deploy data to website
     runs-on: depot-ubuntu-24.04-arm
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -29,7 +34,7 @@ jobs:
       - name: Deploy to evcc.io repo
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.GH_TOKEN }}
+          personal_token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
           publish_dir: ./templates/evcc.io/
           external_repository: evcc-io/evcc.io
           publish_branch: main


### PR DESCRIPTION
🔒 replace broad access `GH_TOKEN` with fine grained use-case specific tokens
👮 add strict permissions to every workflow
⏲️ tokens expire after 365 days (org limit)