### PR TITLE
Energinet price forecast breaking change

### DIFF
--- a/templates/definition/tariff/energinet-price.yaml
+++ b/templates/definition/tariff/energinet-price.yaml
@@ -17,15 +17,22 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://api.energidataservice.dk/dataset/Elspotprices?filter={"PriceArea":["{{ .region }}"]}
+    uri: https://api.energidataservice.dk/dataset/DayAheadPrices?start=now&filter={"PriceArea":["{{ .region }}"]}
     jq: |
-      [.records[] |
-        {
-          start: (.HourUTC[0:13] + ":00:00Z"),
-          end: (.HourUTC[0:13] 
-                | strptime("%Y-%m-%dT%H") 
-                | mktime + 3600 
+      [.records[]
+        | {
+          start: (.TimeUTC[0:13] + ":00:00Z"),
+          end: (.TimeUTC[0:13]
+                | strptime("%Y-%m-%dT%H")
+                | mktime + 3600
                 | strftime("%Y-%m-%dT%H:%M:%SZ")),
-          value: .SpotPriceDKK / 1e3
+          value: .DayAheadPriceDKK / 1e3
         }
-      ] | tostring
+      ]
+      | group_by(.start)
+      | map({
+          start: .[0].start,
+          end: .[0].end,
+          value: (map(.value) | add / length)
+        })
+      | tostring


### PR DESCRIPTION
See news: https://energidataservice.dk/news

Danish Energidataservice has discontinued the dataset [Elspot Prices](https://www.energidataservice.dk/tso-electricity/Elspotprices) with effect 30.09.2025. 

Instead, users should use the dataset [Day-Ahead Prices](https://www.energidataservice.dk/tso-electricity/DayAheadPrices) which provides prices in 15-minute resolution. The first available data is for October 1, 2025.

The suggested template should calculate the average hourly prices for use in evcc. 

**==> Please review thoroughly!! -- I am not at all sure about what I am doing... (●'◡'●)**