### PR TITLE
Smartevse: disable during phase switch

### DIFF
--- a/charger/smartevse.go
+++ b/charger/smartevse.go
@@ -241,12 +241,11 @@ func (wb *smartEVSE) Phases1p3p(phases int) error {
 		settings |= 1 // set bit 0 (smartEVSEConfPhases)
 	}
 
-	if _, err := wb.conn.WriteSingleRegister(smartEVSERegSettings, settings); err != nil {
+	return whenDisabled(wb, func() error {
+		// Switch phases
+		_, err := wb.conn.WriteSingleRegister(smartEVSERegSettings, settings)
 		return err
-	}
-
-	// we need to stop charging quickly for the setting to take effect
-	return wb.Enable(false)
+	})
 }
 
 var _ api.Diagnosis = (*smartEVSE)(nil)


### PR DESCRIPTION
Fix #22348

If that doesn't work either, we will completely remove the phase switching for this charger.