### PR TITLE
Added EWS Schönau API configuration to retrieve the dynamic 15 minutes eco power tariff prices.

### DIFF
--- a/templates/definition/tariff/ews.yaml
+++ b/templates/definition/tariff/ews.yaml
@@ -1,20 +1,14 @@
 template: ews
-
 products:
   - brand: EWS
     description:
       generic: Dynamic eco power price of EWS Elektrizitätswerke Schönau
-
 requirements:
   description:
     de: "Ein API-Key kann unter der E-Mail-Adresse api@ews-schoenau.de erfragt werden."
     en: "You can request an API key at api@ews-schoenau.de"
-
 countries: ["DE"]
 group: price
-
-preset: tariff-base
-
 params:
   - name: apiKey
     type: string
@@ -28,9 +22,8 @@ render: |
     uri: https://api.ews-schoenau.de/v1/dynamicprices/EWS-OEKO-DYN
     headers:
       - X-API-Key: {{ .apiKey }}
-    # optional: cache/timeout schonen die API
-    # cache: 30m
-    # timeout: 10s
+    cache: 60m
+    timeout: 10s
     jq: >
       ( .today + .tomorrow )
       | map({

--- a/templates/definition/tariff/ews.yaml
+++ b/templates/definition/tariff/ews.yaml
@@ -26,15 +26,13 @@ render: |
     cache: 60m
     timeout: 10s
     jq: >
-      ( .today + .tomorrow )
-      | map({
-          start: ( .startsAt
-                   | strptime("%Y-%m-%dT%H:%M:%S.%f%z")
-                   | strftime("%Y-%m-%dT%H:%M:%SZ") ),
-          end:   ( .startsAt
-                   | strptime("%Y-%m-%dT%H:%M:%S.%f%z")
-                   | mktime + 900
-                   | strftime("%Y-%m-%dT%H:%M:%SZ") ),
-          value: ( .total / 100.0 )
-        })
+      ( (.today // []) + (.tomorrow // []) )
+      | map(
+          ( .startsAt | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime ) as $s
+          | {
+              start: ( $s        | strftime("%Y-%m-%dT%H:%M:%SZ") ),
+              end:   ( ($s+900)  | strftime("%Y-%m-%dT%H:%M:%SZ") ),
+              value: ( .total / 100.0 )
+            }
+        )
       | tostring

--- a/templates/definition/tariff/ews.yaml
+++ b/templates/definition/tariff/ews.yaml
@@ -1,0 +1,46 @@
+template: ews
+
+products:
+  - brand: EWS
+    description:
+      generic: Dynamic eco power price of EWS Elektrizitätswerke Schönau
+
+requirements:
+  description:
+    de: "Ein API-Key kann unter der E-Mail-Adresse api@ews-schoenau.de erfragt werden."
+    en: "You can request an API key at api@ews-schoenau.de"
+
+countries: ["DE"]
+group: price
+
+preset: tariff-base
+
+params:
+  - name: apiKey
+    type: string
+    required: true
+    mask: true
+    example: pub_dpa_8476c477d8a039529478ebd690d35ddd80e3308ffc
+render: |
+  type: custom
+  forecast:
+    source: http
+    uri: https://api.ews-schoenau.de/v1/dynamicprices/EWS-OEKO-DYN
+    headers:
+      - X-API-Key: {{ .apiKey }}
+    # optional: cache/timeout schonen die API
+    # cache: 30m
+    # timeout: 10s
+    jq: >
+      ( .today + .tomorrow )
+      | map({
+          start: ( .startsAt
+                   | strptime("%Y-%m-%dT%H:%M:%S.%f%z")
+                   | strftime("%Y-%m-%dT%H:%M:%SZ") ),
+          end:   ( .startsAt
+                   | strptime("%Y-%m-%dT%H:%M:%S.%f%z")
+                   | mktime + 900
+                   | strftime("%Y-%m-%dT%H:%M:%SZ") ),
+          value: ( .total / 100.0 )
+        })
+      | tostring

--- a/templates/definition/tariff/ews.yaml
+++ b/templates/definition/tariff/ews.yaml
@@ -4,6 +4,7 @@ products:
     description:
       generic: Dynamic eco power price of EWS Elektrizitätswerke Schönau
 requirements:
+  evcc: ["skiptest"]
   description:
     de: "Ein API-Key kann unter der E-Mail-Adresse api@ews-schoenau.de erfragt werden."
     en: "You can request an API key at api@ews-schoenau.de"


### PR DESCRIPTION
This is a template to integrate the eco power tariff ot EWS easy in the evcc installation. It replaces follwing manual config in evcs:

tariffs:
  grid:
    type: custom
    forecast:
      source: http
      uri: https://api.ews-schoenau.de/v1/dynamicprices/EWS-OEKO-DYN
      headers:
        - X-API-Key: __PUT_YOUR_API_KEY_HERE__
      jq: >
        ( .today + .tomorrow )
        | map({
            start: ( .startsAt 
                     | strptime("%Y-%m-%dT%H:%M:%S.%f%z") 
                     | strftime("%Y-%m-%dT%H:%M:%SZ") ),
            end:   ( .startsAt 
                     | strptime("%Y-%m-%dT%H:%M:%S.%f%z") 
                     | mktime + 900 
                     | strftime("%Y-%m-%dT%H:%M:%SZ") ),
            value: ( .total / 100.0 )
          })
        | tostring