### PR TITLE
Optimizer: added minsoc/maxsoc to Huawei template

### DIFF
--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -28,10 +28,8 @@ params:
     default: 1
     advanced: true
   - name: minsoc
-    type: int
     advanced: true
   - name: maxsoc
-    type: int
     advanced: true
   - name: maxchargepower
     default: 10000

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -282,8 +282,8 @@ render: |
                 type: writesingle
                 encoding: uint16
   capacity: {{ .capacity }} # kWh
-  minsoc: {{ .minsoc }}
-  maxsoc: {{ .maxsoc }}
+  minsoc: {{ .minsoc }} # %
+  maxsoc: {{ .maxsoc }} # %
   maxchargepower: {{ .maxchargepower }} # W
   maxdischargepower: {{ .maxdischargepower }} # W
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -27,6 +27,12 @@ params:
     type: int
     default: 1
     advanced: true
+  - name: minsoc
+    type: int
+    advanced: true
+  - name: maxsoc
+    type: int
+    advanced: true
   - name: maxchargepower
     default: 10000
   - name: maxdischargepower
@@ -278,6 +284,8 @@ render: |
                 type: writesingle
                 encoding: uint16
   capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }}
+  maxsoc: {{ .maxsoc }}
   maxchargepower: {{ .maxchargepower }} # W
   maxdischargepower: {{ .maxdischargepower }} # W
   {{- end }}


### PR DESCRIPTION
This PR adds minsoc/maxsoc to Huawei template for the LUNA2000 battery so that the optimizer can properly take these into account.