### PR TITLE
Remove calls to btmgmt

### DIFF
--- a/charger/nrgble_linux.go
+++ b/charger/nrgble_linux.go
@@ -66,24 +66,6 @@ func NewNRGKickBLE(device, mac string, pin int) (*NRGKickBLE, error) {
 		return nil, err
 	}
 
-	// set LE mode
-	btmgmt := hw.NewBtMgmt(ainfo.AdapterID)
-
-	err = btmgmt.SetPowered(false)
-	if err == nil {
-		err = btmgmt.SetLe(true)
-		if err == nil {
-			err = btmgmt.SetBredr(false)
-			if err == nil {
-				err = btmgmt.SetPowered(true)
-			}
-		}
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
 	adapt, err := adapter.NewAdapter1FromAdapterID(ainfo.AdapterID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
BtMgmt in go-bluetooth calls the btmgmt command, which waits forever on Trixie based Raspberry Pi OS. Dual mode (EDR and LE) seems to be the default of bluez and works-for-me(tm). So it seems to work withoug forcing bluez to LE mode.