### PR TITLE
spottyenergy: change to 15min interval

### DIFF
--- a/templates/definition/tariff/spottyenergy.yaml
+++ b/templates/definition/tariff/spottyenergy.yaml
@@ -36,6 +36,6 @@ render: |
     jq: |
       [ .[] | {
         start: .from,
-        end:   (.from | fromdate + 3600 | todate),
+        end:   (.from | fromdate + 900 | todate),
         value: (.price/100)
       } ] | tostring


### PR DESCRIPTION
The "spottyenergy" template was still calculating end timestamps based on hourly prices.
Partially fixes #24090