### PR TITLE
Update ioBroker.bmw.yaml to new ioBroker Adapter V4.05

### DIFF
--- a/templates/definition/vehicle/ioBroker.bmw.yaml
+++ b/templates/definition/vehicle/ioBroker.bmw.yaml
@@ -56,4 +56,7 @@ render: |
     source: http
     uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.vehicle.preConditioning.activity.value
     jq: if .state == "HEATING" or .state == "heating" or .state == "COOLING" or .state == "cooling" then true else false end
+  limitsoc:
+    source: http
+    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.powertrain.electric.battery.stateofcharge.target.value
   {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/ioBroker.bmw.yaml
+++ b/templates/definition/vehicle/ioBroker.bmw.yaml
@@ -34,54 +34,26 @@ render: |
   type: custom
   {{ include "vehicle-common" . }}
   soc:
-    source: valid
-    valid:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
-      cache: 10s
-    value:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingLevelPercent
-  limitsoc:
-    source: valid
-    valid:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
-      cache: 10s
-    value:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingTarget
+    source: http
+    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.drivetrain.batteryManagement.header.value
   status:
-    source: valid
-    valid:
+    source: combined
+    plugged:
       source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
-      cache: 10s
-    value:
-      source: combined
-      plugged:
-        source: http
-        uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.isChargerConnected
-      charging:
-        source: http
-        uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.chargingStatus
-        jq: '. == "CHARGING"'
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.body.chargingPort.status.value
+      jq: '. == "CONNECTED"'
+    charging:
+      source: http
+      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.drivetrain.electricEngine.charging.status.value
+      jq: '. == "CHARGINGACTIVE"'
   range:
-    source: valid
-    valid:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
-      cache: 10s
-    value:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.electricChargingState.range
+    source: http
+    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.drivetrain.electricEngine.kombiRemainingElectricRange.value
   odometer:
-    source: valid
-    valid:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.info.connection
-      cache: 10s
-    value:
-      source: http
-      uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.state.currentMileage
+    source: http
+    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.vehicle.travelledDistance.value
+  climater:
+    source: http
+    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.vehicle.preConditioning.activity.value
+    jq: if .state == "HEATING" or .state == "heating" or .state == "COOLING" or .state == "cooling" then true else false end
   {{ include "vehicle-features" . }}


### PR DESCRIPTION
Because of the change of BMW Data Act, we the ioBroker Adapter has been adjusted and therfore also EVCC Vehicle Template has to be changed.

Unfortunally limitsoc is not yet supported from our ix2. I dont know why :(