### PR TITLE
Dump: add configurable timeout

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -68,6 +68,9 @@ const (
 	flagHeartbeat            = "heartbeat"
 	flagHeartbeatDescription = "After command, continue running device heartbeats (if any) until interrupted"
 
+	flagTimeout            = "timeout"
+	flagTimeoutDescription = "Timeout for device queries"
+
 	flagDigits = "digits"
 	flagDelay  = "delay"
 	flagForce  = "force"

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -69,7 +69,7 @@ const (
 	flagHeartbeatDescription = "After command, continue running device heartbeats (if any) until interrupted"
 
 	flagTimeout            = "timeout"
-	flagTimeoutDescription = "Timeout for device queries"
+	flagTimeoutDescription = "Timeout"
 
 	flagDigits = "digits"
 	flagDelay  = "delay"

--- a/cmd/meter.go
+++ b/cmd/meter.go
@@ -24,6 +24,7 @@ func init() {
 	meterCmd.Flags().BoolP(flagRepeat, "r", false, flagRepeatDescription)
 	meterCmd.Flags().Duration(flagRepeatInterval, 0, flagRepeatIntervalDescription)
 	meterCmd.Flags().Bool(flagHeartbeat, false, flagHeartbeatDescription)
+	meterCmd.Flags().Duration(flagTimeout, time.Second, flagTimeoutDescription)
 }
 
 func runMeter(cmd *cobra.Command, args []string) {
@@ -71,7 +72,8 @@ func runMeter(cmd *cobra.Command, args []string) {
 	}
 
 	if !flagUsed {
-		d := dumper{len: len(meters)}
+		timeout, _ := cmd.Flags().GetDuration(flagTimeout)
+		d := dumper{len: len(meters), timeout: timeout}
 		flag := cmd.Flag(flagDiagnose).Changed
 
 	REPEAT:


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable timeout for meter queries via a new CLI flag and apply it to the backoff retry logic

New Features:
- Add a --timeout flag to meter commands to control device query timeout

Enhancements:
- Extend dumper to include a timeout field and use it as the max elapsed time for backoff retries
- Convert the exponential backoff function into a dumper method to leverage the timeout field
- Remove redundant error printing within the retry callback