### PR TITLE
Tibber: change to 15min interval

### DIFF
--- a/meter/tibber/types.go
+++ b/meter/tibber/types.go
@@ -24,7 +24,7 @@ type Address struct {
 type Subscription struct {
 	ID        string
 	Status    string
-	PriceInfo PriceInfo
+	PriceInfo PriceInfo `graphql:"priceInfo(resolution: QUARTER_HOURLY)"`
 }
 
 type PriceInfo struct {

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -115,7 +115,7 @@ func (t *Tibber) rates(pi []tibber.Price) api.Rates {
 		}
 		ar := api.Rate{
 			Start: r.StartsAt.Local(),
-			End:   r.StartsAt.Add(15*time.Minute).Local(),
+			End:   r.StartsAt.Add(SlotDuration).Local(),
 			Value: price,
 		}
 		data = append(data, ar)

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -115,7 +115,7 @@ func (t *Tibber) rates(pi []tibber.Price) api.Rates {
 		}
 		ar := api.Rate{
 			Start: r.StartsAt.Local(),
-			End:   r.StartsAt.Add(time.Hour).Local(),
+			End:   r.StartsAt.Add(15*time.Minute).Local(),
 			Value: price,
 		}
 		data = append(data, ar)


### PR DESCRIPTION
adapted implementation (also suggested by tpd-opitz)

documented here: https://developer.tibber.com/docs/changelog: 
`The Subscription.priceInfo field (i.e. the type PriceInfo) now takes an optional argument resolution that can either be HOURLY or QUARTER_HOURLY.`