### PR TITLE
Tariffs: reduce cache cpu cycles

### DIFF
--- a/tariff/proxy.go
+++ b/tariff/proxy.go
@@ -164,15 +164,16 @@ func (p *CachingProxy) cacheGet(until time.Time) (*cached, error) {
 		return nil, errors.New("not enough rates")
 	}
 
-	rates := currentRates(p.cached.Rates)
-	if len(rates) == 0 {
+	res := &cached{
+		Rates: currentRates(p.cached.Rates),
+		Type:  p.cached.Type,
+	}
+
+	if len(res.Rates) == 0 {
 		return nil, errors.New("no current rates")
 	}
 
-	return &cached{
-		Rates: rates,
-		Type:  p.cached.Type,
-	}, nil
+	return res, nil
 }
 
 func (p *CachingProxy) cachePut(typ api.TariffType, rates api.Rates) error {

--- a/tariff/proxy.go
+++ b/tariff/proxy.go
@@ -195,11 +195,7 @@ func untilEndOfTomorrow() time.Time {
 }
 
 func ratesValid(rr api.Rates, until time.Time) bool {
-	if l := len(rr); l > 0 && !rr[l-1].End.Before(until) {
-		return true
-	}
-
-	return false
+	return len(rr) > 0 && !rr[len(rr)-1].End.Before(until)
 }
 
 func currentRates(rr api.Rates) api.Rates {


### PR DESCRIPTION
Discussed on Slack:

> Ok, Problem gefunden. Jeder einzelne Zugriff auf einen gecacheten Tarif bedeutet jetzt einen Roundtrip in die Datenbank einschl. JSON Unmarshal. Wenn man dann mit den Tarifen häufige Abfragen hat ist das tödlich. Muss allerdings schon seit einiger Zeit so sein 😮

@naltatis das sollte auch das Problem mit der Performance aufgrund Datenmenge lösen!