### PR TITLE
chore: reset interval to 0.25s

### DIFF
--- a/tests/plan.evcc.yaml
+++ b/tests/plan.evcc.yaml
@@ -1,4 +1,4 @@
-interval: 0.1s
+interval: 0.25s
 
 site:
   title: Plan

--- a/tests/plan.evcc.yaml
+++ b/tests/plan.evcc.yaml
@@ -1,4 +1,4 @@
-interval: 0.5s
+interval: 0.1s
 
 site:
   title: Plan


### PR DESCRIPTION
Ref #21162: https://github.com/evcc-io/evcc/pull/21162/commits/55e98604fed57ed30906098578199c9cda1970ea
With the latest improvements, it may be possible to reset the interval to `0.1s`.