### PR TITLE
Update ioBroker.bmw.yaml - upper Case Description adapted

### DIFF
--- a/templates/definition/vehicle/ioBroker.bmw.yaml
+++ b/templates/definition/vehicle/ioBroker.bmw.yaml
@@ -58,5 +58,5 @@ render: |
     jq: if .state == "HEATING" or .state == "heating" or .state == "COOLING" or .state == "cooling" then true else false end
   limitsoc:
     source: http
-    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.powertrain.electric.battery.stateofcharge.target.value
+    uri: {{ .uri }}/getPlainValue/bmw.{{ .id }}.{{ .vin }}.stream.vehicle.powertrain.electric.battery.stateOfCharge.target.value
   {{ include "vehicle-features" . }}


### PR DESCRIPTION
stateOfCharge.target.value is written with upperCase, so this has to be adapted.

Before my ioBroker Adapter has not sendet out this feature.