### PR TITLE
Battery Control: hold charging when battery is dimmed

### DIFF
--- a/core/helper.go
+++ b/core/helper.go
@@ -73,3 +73,12 @@ func circuitMaxPower(circuit api.Circuit) float64 {
 
 	return circuit.GetMaxPower()
 }
+
+// circuitDimmed returns a circuits dim status
+func circuitDimmed(circuit api.Circuit) bool {
+	if circuit == nil {
+		return false
+	}
+
+	return circuit.Dimmed()
+}

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -43,6 +43,13 @@ func (site *Site) SetBatteryMode(batMode api.BatteryMode) {
 func (site *Site) updateBatteryMode(batteryGridChargeActive bool, rate api.Rate) {
 	batteryMode := site.requiredBatteryMode(batteryGridChargeActive, rate)
 
+	// put battery into hold mode when charging and load management limit active
+	fromToCharge := batteryMode == api.BatteryCharge || batteryMode == api.BatteryUnknown && site.batteryMode == api.BatteryCharge
+	if fromToCharge && circuitDimmed(site.circuit) {
+		site.log.DEBUG.Println("battery mode: circuit dimmed")
+		batteryMode = api.BatteryHold
+	}
+
 	// NOTE: applyBatteryMode is always called when charge mode is active to validate max soc
 	if modeChanged := batteryMode != api.BatteryUnknown; modeChanged || site.batteryMode == api.BatteryCharge {
 		if err := site.applyBatteryMode(batteryMode); err == nil {
@@ -128,14 +135,7 @@ func (site *Site) batteryMaxSocReached(dev config.Device[api.Meter]) (bool, erro
 //	The current soc is validated against max soc.
 //	In case max soc is reached, hold mode is applied.
 func (site *Site) applyBatteryMode(mode api.BatteryMode) error {
-	isCharge := mode == api.BatteryCharge || mode == api.BatteryUnknown && site.batteryMode == api.BatteryCharge
-
-	// put battery into hold mode when charging and load management limit active
-	if circuitMaxPower := circuitMaxPower(site.circuit); isCharge && circuitMaxPower > 0 {
-		// TODO do this only once
-		site.log.DEBUG.Printf("battery mode: load management active at %.0fW", circuitMaxPower)
-		mode = api.BatteryHold
-	}
+	fromToCharge := mode == api.BatteryCharge || mode == api.BatteryUnknown && site.batteryMode == api.BatteryCharge
 
 	for _, dev := range site.batteryMeters {
 		meter := dev.Instance()
@@ -146,7 +146,7 @@ func (site *Site) applyBatteryMode(mode api.BatteryMode) error {
 		}
 
 		// validate max soc
-		if isCharge && mode != api.BatteryHold {
+		if fromToCharge && mode != api.BatteryHold {
 			ok, err := site.batteryMaxSocReached(dev)
 			if err != nil {
 				return err

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -43,7 +43,7 @@ func (site *Site) SetBatteryMode(batMode api.BatteryMode) {
 func (site *Site) updateBatteryMode(batteryGridChargeActive bool, rate api.Rate) {
 	batteryMode := site.requiredBatteryMode(batteryGridChargeActive, rate)
 
-	// put battery into hold mode when charging and load management limit active
+	// put battery into hold mode when charging is active and circuit dimmed
 	fromToCharge := batteryMode == api.BatteryCharge || batteryMode == api.BatteryUnknown && site.batteryMode == api.BatteryCharge
 	if fromToCharge && circuitDimmed(site.circuit) {
 		site.log.DEBUG.Println("battery mode: circuit dimmed")


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/24132. Refs https://github.com/evcc-io/evcc/issues/24132#issuecomment-3370210816, follow-up to https://github.com/evcc-io/evcc/pull/23927.

Fast grid charging demand (`charge` battery mode) is ignored and replaced with `hold` battery mode when circuit is dimmed by §14a regime.

/cc @mfuchs1984 @premultiply 