### PR TITLE
Optimizer: Include empty batteries in optimization

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -220,7 +220,7 @@ func (site *Site) optimizerUpdate(battery []measurement) error {
 
 	for i, b := range battery {
 		// TODO decide if nil should be only indicator
-		if b.Capacity == nil || *b.Capacity == 0 || b.Soc == nil || *b.Soc == 0 {
+		if b.Capacity == nil || *b.Capacity == 0 || b.Soc == nil {
 			continue
 		}
 

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -219,7 +219,6 @@ func (site *Site) optimizerUpdate(battery []measurement) error {
 	}
 
 	for i, b := range battery {
-		// TODO decide if nil should be only indicator
 		if b.Capacity == nil || *b.Capacity == 0 || b.Soc == nil {
 			continue
 		}


### PR DESCRIPTION
I'm not 100% sure, but I think the comparison `*b.Soc == 0` was excluding empty home batteries from the optimization process. This change will include empty batteries in the optimization.

I've observed this behavior when my Sonnenbatterie was empty, using todays' nightly build.