### PR TITLE
Planner: remove late start capability

### DIFF
--- a/core/planner/planner.go
+++ b/core/planner/planner.go
@@ -58,12 +58,7 @@ func (t *Planner) plan(rates api.Rates, requiredDuration time.Duration, targetTi
 
 		// slot covers more than we need, so shorten it
 		if requiredDuration < 0 {
-			// the first (if not single) slot should start as late as possible
-			if IsFirst(slot, plan) && len(plan) > 0 {
-				slot.Start = slot.Start.Add(-requiredDuration)
-			} else {
-				slot.End = slot.End.Add(requiredDuration)
-			}
+			slot.End = slot.End.Add(requiredDuration)
 			requiredDuration = 0
 
 			if slot.End.Before(slot.Start) {

--- a/core/planner/planner.go
+++ b/core/planner/planner.go
@@ -53,23 +53,14 @@ func (t *Planner) plan(rates api.Rates, requiredDuration time.Duration, targetTi
 			slot.End = targetTime
 		}
 
-		slotDuration := slot.End.Sub(slot.Start)
-		requiredDuration -= slotDuration
-
-		// slot covers more than we need, so shorten it
-		if requiredDuration < 0 {
-			slot.End = slot.End.Add(requiredDuration)
-			requiredDuration = 0
-
-			if slot.End.Before(slot.Start) {
-				panic("slot end before start")
-			}
-		}
-
 		plan = append(plan, slot)
 
-		// we found all necessary slots
-		if requiredDuration == 0 {
+		// all necessary slots found?
+		if requiredDuration -= slot.End.Sub(slot.Start); requiredDuration <= 0 {
+			// slot covers more than we need, so shorten it
+			slot.End = slot.End.Add(requiredDuration)
+			plan[len(plan)-1] = slot
+
 			break
 		}
 	}

--- a/core/planner/planner_test.go
+++ b/core/planner/planner_test.go
@@ -81,11 +81,11 @@ func TestPlan(t *testing.T) {
 			30,
 		},
 		{
-			"plan (30)30-0-60-0-0-0",
+			"plan 30-0-60-0-0-0",
 			90 * time.Minute,
 			clock.Now(),
 			clock.Now().Add(6 * time.Hour),
-			clock.Now().Add(30 * time.Minute),
+			clock.Now(),
 			20,
 		},
 		{
@@ -303,8 +303,8 @@ func TestPrecondition(t *testing.T) {
 	plan = p.Plan(time.Hour, 30*time.Minute, clock.Now().Add(4*time.Hour))
 	assert.Equal(t, api.Rates{
 		{
-			Start: clock.Now().Add(30 * time.Minute),
-			End:   clock.Now().Add(time.Hour),
+			Start: clock.Now(),
+			End:   clock.Now().Add(30 * time.Minute),
 			Value: 0,
 		},
 		{


### PR DESCRIPTION
With the switch to 15min slots this is no longer needed. Charging should start when slot starts. Partial slots are continued until end.