### PR TITLE
Planner/Estimator: Ladung bei Ziel 100% nicht vorzeitig beenden

### DIFF
--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -63,7 +63,7 @@ func (s *Estimator) Reset() {
 func (s *Estimator) RemainingChargeDuration(targetSoc int, chargePower float64) time.Duration {
 	// For 100% target with calculated SoC >= 100%, return small remaining duration
 	// This allows the vehicle to charge until it stops itself when actually full
-	if targetSoc >= 100 && s.vehicleSoc >= 100 && chargePower > 0 {
+	if targetSoc >= 100 && s.vehicleSoc >= 100 {
 		return time.Minute
 	}
 

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -61,6 +61,12 @@ func (s *Estimator) Reset() {
 
 // RemainingChargeDuration returns the estimated remaining duration
 func (s *Estimator) RemainingChargeDuration(targetSoc int, chargePower float64) time.Duration {
+	// For 100% target with calculated SoC >= 100%, return small remaining duration
+	// This allows the vehicle to charge until it stops itself when actually full
+	if targetSoc >= 100 && s.vehicleSoc >= 100 && chargePower > 0 {
+		return time.Minute
+	}
+
 	const minChargeSoc = 100
 
 	dy := s.minChargePower - s.maxChargePower
@@ -93,6 +99,12 @@ func (s *Estimator) RemainingChargeDuration(targetSoc int, chargePower float64) 
 
 // RemainingChargeEnergy returns the remaining charge energy in kWh
 func (s *Estimator) RemainingChargeEnergy(targetSoc int) float64 {
+	// For 100% target with calculated SoC >= 100%, return small remaining energy
+	// This allows the vehicle to charge until it stops itself when actually full
+	if targetSoc >= 100 && s.vehicleSoc >= 100 {
+		return 0.1 // 100Wh
+	}
+
 	percentRemaining := float64(targetSoc) - s.vehicleSoc
 	if percentRemaining <= 0 || s.virtualCapacity <= 0 {
 		return 0


### PR DESCRIPTION
Behebt das Problem, bei dem evcc bzw. der Ladeplaner die Ladung vorzeitig beendet, wenn das Ladeziel 100% ist und der **berechnete** SoC 100% erreicht, obwohl die Fahrzeugbatterie in Wirklichkeit noch nicht ganz voll ist.

### Problem

1. Der SoC-Estimator schätzt den Ladezustand basierend auf der geladenen Energie
2. Durch Ungenauigkeiten kann der geschätzte SoC 100% erreichen, bevor die Batterie tatsächlich ganz voll ist
3. Wenn `RemainingChargeDuration()` und `RemainingChargeEnergy()` dann 0 zurückgeben, denkt der Ladeplaner, dass das Ziel erreicht ist und beendet die Ladung

### Lösung

Zwei Sonderbehandlungen hinzugefügt:

1. **In `RemainingChargeDuration()`**: Wenn das Ziel 100% ist und der berechnete SoC bereits >= 100% ist (aber noch geladen wird), gibt die Funktion 1 Minute Restzeit zurück statt 0. Dies signalisiert dem Planner, dass noch geladen werden soll.

2. **In `RemainingChargeEnergy()`**: Analog wird eine kleine Restenergie von 0,1 kWh (100Wh) zurückgegeben statt 0.

### Wie es funktioniert

- Wenn das Ladeziel **nicht** 100% ist, verhält sich evcc wie bisher
- Wenn das Ladeziel **100%** ist:
  - evcc lädt weiter, auch wenn der geschätzte SoC 100% erreicht
  - Das **Fahrzeug** entscheidet selbst, wann es wirklich voll ist und stoppt die Ladung
  - Die Ladefreigabe seitens evcc bleibt bestehen
  - evcc greift nicht vorzeitig ein

So wird sichergestellt, dass die Batterie tatsächlich vollständig geladen wird, wenn 100% als Ladeziel gewählt wurde.