### PR TITLE
Goodwe-Hybrid: make discharge-mode selectable in yaml and ui

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -409,6 +409,10 @@
         "no": "nein",
         "yes": "ja"
       },
+      "dischargemode": {
+        "2": "Charge-PV (PV für Batterieladung nutzen)",
+        "8": "Standby (Batterie im Leerlauf)"
+      },
       "endianness": {
         "big": "big-endian",
         "little": "little-endian"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -409,6 +409,10 @@
         "no": "no",
         "yes": "yes"
       },
+      "dischargemode": {
+        "2": "Charge-PV (use PV to charge battery)",
+        "8": "Standby (battery idle)"
+      },
       "endianness": {
         "big": "big-endian",
         "little": "little-endian"

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -20,6 +20,18 @@ params:
     choice: [1, 2]
   - name: capacity
     advanced: true
+  - name: dischargemode
+    default: 2
+    type: choice
+    advanced: true
+    description:
+      en: Discharge hold mode (2=Charge-PV, 8=Standby)
+      de: Entladesperre-Modus (2=Charge-PV, 8=Standby)
+    help:
+      en: "Mode 2 (Charge-PV): Uses PV power to charge battery, uses grid power for AC loads. Mode 8 (Standby): Battery neither charges nor discharges."
+      de: "Modus 2 (Charge-PV): Nutzt PV-Strom für Batterieladung, Netzstrom für AC-Lasten. Modus 8 (Standby): Batterie lädt oder entlädt nicht."
+    choice: [2, 8]
+    usages: ["battery"]
   - name: maxacpower
 render: |
   type: custom
@@ -182,7 +194,7 @@ render: |
           source: sequence
           set:
           - source: const
-            value: 2 # EMSPowerMode 2 "Charge-PV"-Mode. If EMSPowerSet=0 only PV is used to charge. Value 6 "Conserve"-Mode can be alternatively used.
+            value: {{ .dischargemode }} # EMSPowerMode: 2="Charge-PV" (uses PV to charge, grid for AC loads) or 8="Standby" (battery standby, no charge/discharge)
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}


### PR DESCRIPTION
As discussed in https://github.com/evcc-io/evcc/pull/16649#issuecomment-3171884498 and later comments Some users would prefer the old behavior

This pr provides the option to  select the Mode via yaml or UI
keeps the current behaviour as a default to not change systems during an update

That should make more users happy

@maatinh & @andiwist should we add "Value 6 "Conserve" as an third viable option?