### PR TITLE
Homeassistant: align implementations (BC)

### DIFF
--- a/charger/homeassistant-switch.go
+++ b/charger/homeassistant-switch.go
@@ -37,8 +37,6 @@ func NewHomeAssistantSwitchFromConfig(other map[string]interface{}) (api.Charger
 }
 
 func NewHomeAssistantSwitch(embed embed, uri, token, switchEntity, powerEntity string, standbypower float64) (api.Charger, error) {
-	log := util.NewLogger("ha-switch")
-
 	if switchEntity == "" {
 		return nil, errors.New("missing switch entity")
 	}
@@ -48,6 +46,7 @@ func NewHomeAssistantSwitch(embed embed, uri, token, switchEntity, powerEntity s
 		return nil, errors.New("missing either power entity or negative standbypower")
 	}
 
+	log := util.NewLogger("ha-switch")
 	conn, err := homeassistant.NewConnection(log, uri, token)
 	if err != nil {
 		return nil, err

--- a/charger/homeassistant-switch.go
+++ b/charger/homeassistant-switch.go
@@ -2,21 +2,18 @@ package charger
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/request"
-	"github.com/evcc-io/evcc/util/transport"
+	"github.com/evcc-io/evcc/util/homeassistant"
 )
 
 type HomeAssistantSwitch struct {
-	baseURL string
-	switchE string
-	powerE  string
-	*request.Helper
+	baseURL      string
+	switchEntity string
+	powerEntity  string
+	conn         *homeassistant.Connection
 	*switchSocket
 }
 
@@ -29,8 +26,8 @@ func NewHomeAssistantSwitchFromConfig(other map[string]interface{}) (api.Charger
 		embed        `mapstructure:",squash"`
 		BaseURL      string
 		Token        string
-		Switch       string
-		Power        string
+		SwitchEntity string
+		PowerEntity  string
 		StandbyPower float64
 	}
 
@@ -38,77 +35,49 @@ func NewHomeAssistantSwitchFromConfig(other map[string]interface{}) (api.Charger
 		return nil, err
 	}
 
-	return NewHomeAssistantSwitch(cc.embed, cc.BaseURL, cc.Token, cc.Switch, cc.Power, cc.StandbyPower)
+	return NewHomeAssistantSwitch(cc.embed, cc.BaseURL, cc.Token, cc.SwitchEntity, cc.PowerEntity, cc.StandbyPower)
 }
 
-func NewHomeAssistantSwitch(embed embed, baseURL, token, switchE, powerE string, standbypower float64) (api.Charger, error) {
+func NewHomeAssistantSwitch(embed embed, baseURL, token, switchEntity, powerEntity string, standbypower float64) (api.Charger, error) {
 	log := util.NewLogger("ha-switch")
 
-	c := &HomeAssistantSwitch{
-		baseURL: strings.TrimSuffix(baseURL, "/"),
-		switchE: switchE,
-		powerE:  powerE,
-		Helper:  request.NewHelper(log),
-	}
-
-	if switchE == "" {
+	if switchEntity == "" {
 		return nil, errors.New("missing switch entity")
 	}
 
 	// standbypower < 0 ensures that currentPower is never used by the switch socket if not present
-	if powerE == "" && standbypower >= 0 {
+	if powerEntity == "" && standbypower >= 0 {
 		return nil, errors.New("missing either power entity or negative standbypower")
 	}
 
-	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.currentPower, standbypower)
-	c.Helper.Client.Transport = &transport.Decorator{
-		Decorator: transport.DecorateHeaders(map[string]string{
-			"Authorization": "Bearer " + token,
-			"Content-Type":  "application/json",
-		}),
-		Base: c.Helper.Client.Transport,
+	conn, err := homeassistant.NewConnection(log, baseURL, token)
+	if err != nil {
+		return nil, err
 	}
+
+	c := &HomeAssistantSwitch{
+		baseURL:      strings.TrimSuffix(baseURL, "/"),
+		switchEntity: switchEntity,
+		powerEntity:  powerEntity,
+		conn:         conn,
+	}
+
+	c.switchSocket = NewSwitchSocket(&embed, c.Enabled, c.currentPower, standbypower)
 
 	return c, nil
 }
 
 // Enabled implements the api.Charger interface
 func (c *HomeAssistantSwitch) Enabled() (bool, error) {
-	var res struct {
-		State string `json:"state"`
-	}
-
-	uri := fmt.Sprintf("%s/api/states/%s", c.baseURL, c.switchE)
-	err := c.Helper.GetJSON(uri, &res)
-
-	return res.State == "on", err
+	return c.conn.GetBoolState(c.switchEntity)
 }
 
 // Enable implements the api.Charger interface
 func (c *HomeAssistantSwitch) Enable(enable bool) error {
-	service := "turn_off"
-	if enable {
-		service = "turn_on"
-	}
-
-	data := map[string]any{"entity_id": c.switchE}
-	// the domain must not be necessary a 'switch' - it can be also an `input_boolean`
-	domain := strings.Split(c.switchE, ".")[0]
-
-	uri := fmt.Sprintf("%s/api/services/%s/%s", c.baseURL, domain, service)
-	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
-
-	return c.Helper.DoJSON(req, nil)
+	return c.conn.CallSwitchService(c.switchEntity, enable)
 }
 
 // currentPower implements the api.Meter interface (optional)
 func (c *HomeAssistantSwitch) currentPower() (float64, error) {
-	var res struct {
-		State float64 `json:"state,string"`
-	}
-
-	uri := fmt.Sprintf("%s/api/states/%s", c.baseURL, c.powerE)
-	err := c.Helper.GetJSON(uri, &res)
-
-	return res.State, err
+	return c.conn.GetFloatState(c.powerEntity)
 }

--- a/charger/homeassistant.go
+++ b/charger/homeassistant.go
@@ -28,7 +28,7 @@ func init() {
 // NewHomeAssistantFromConfig creates a HomeAssistant charger from generic config
 func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Charger, error) {
 	cc := struct {
-		BaseURL    string
+		URI        string
 		Token      string
 		Status     string   // required - sensor for charge status
 		Enabled    string   // required - sensor for enabled state
@@ -55,7 +55,7 @@ func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Charger, erro
 	}
 
 	log := util.NewLogger("ha-charger")
-	conn, err := homeassistant.NewConnection(log, cc.BaseURL, cc.Token)
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Token)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/homeassistant.go
+++ b/charger/homeassistant.go
@@ -58,7 +58,8 @@ func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Charger, erro
 		return nil, errors.New("missing enable switch entity")
 	}
 
-	conn, err := homeassistant.NewConnection(cc.BaseURL, cc.Token)
+	log := util.NewLogger("ha-charger")
+	conn, err := homeassistant.NewConnection(log, cc.BaseURL, cc.Token)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/homeassistant_decorators.go
+++ b/charger/homeassistant_decorators.go
@@ -6,12 +6,12 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), currentGetter func() (float64, error)) api.Charger {
+func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error)) api.Charger {
 	switch {
-	case currentGetter == nil && meter == nil:
+	case meter == nil:
 		return base
 
-	case currentGetter == nil && meter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case meter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -22,7 +22,7 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			},
 		}
 
-	case currentGetter == nil && meter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case meter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -37,7 +37,7 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			},
 		}
 
-	case currentGetter == nil && meter != nil && meterEnergy == nil && phaseCurrents != nil && phaseVoltages == nil:
+	case meter != nil && meterEnergy == nil && phaseCurrents != nil && phaseVoltages == nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -52,7 +52,7 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			},
 		}
 
-	case currentGetter == nil && meter != nil && meterEnergy != nil && phaseCurrents != nil && phaseVoltages == nil:
+	case meter != nil && meterEnergy != nil && phaseCurrents != nil && phaseVoltages == nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -71,7 +71,7 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			},
 		}
 
-	case currentGetter == nil && meter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case meter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -86,7 +86,7 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			},
 		}
 
-	case currentGetter == nil && meter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case meter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -105,7 +105,7 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			},
 		}
 
-	case currentGetter == nil && meter != nil && meterEnergy == nil && phaseCurrents != nil && phaseVoltages != nil:
+	case meter != nil && meterEnergy == nil && phaseCurrents != nil && phaseVoltages != nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -124,7 +124,7 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			},
 		}
 
-	case currentGetter == nil && meter != nil && meterEnergy != nil && phaseCurrents != nil && phaseVoltages != nil:
+	case meter != nil && meterEnergy != nil && phaseCurrents != nil && phaseVoltages != nil:
 		return &struct {
 			*HomeAssistant
 			api.Meter
@@ -133,185 +133,6 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 			api.PhaseVoltages
 		}{
 			HomeAssistant: base,
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-			MeterEnergy: &decorateHomeAssistantMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateHomeAssistantPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateHomeAssistantPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case currentGetter != nil && meter == nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-			api.MeterEnergy
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-			MeterEnergy: &decorateHomeAssistantMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy == nil && phaseCurrents != nil && phaseVoltages == nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-			api.PhaseCurrents
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-			PhaseCurrents: &decorateHomeAssistantPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy != nil && phaseCurrents != nil && phaseVoltages == nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-			api.MeterEnergy
-			api.PhaseCurrents
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-			MeterEnergy: &decorateHomeAssistantMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateHomeAssistantPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-			api.PhaseVoltages
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-			PhaseVoltages: &decorateHomeAssistantPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-			api.MeterEnergy
-			api.PhaseVoltages
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-			MeterEnergy: &decorateHomeAssistantMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseVoltages: &decorateHomeAssistantPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy == nil && phaseCurrents != nil && phaseVoltages != nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-			api.PhaseCurrents
-			api.PhaseVoltages
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
-			Meter: &decorateHomeAssistantMeterImpl{
-				meter: meter,
-			},
-			PhaseCurrents: &decorateHomeAssistantPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateHomeAssistantPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
-			},
-		}
-
-	case currentGetter != nil && meter != nil && meterEnergy != nil && phaseCurrents != nil && phaseVoltages != nil:
-		return &struct {
-			*HomeAssistant
-			api.CurrentGetter
-			api.Meter
-			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhaseVoltages
-		}{
-			HomeAssistant: base,
-			CurrentGetter: &decorateHomeAssistantCurrentGetterImpl{
-				currentGetter: currentGetter,
-			},
 			Meter: &decorateHomeAssistantMeterImpl{
 				meter: meter,
 			},
@@ -328,14 +149,6 @@ func decorateHomeAssistant(base *HomeAssistant, meter func() (float64, error), m
 	}
 
 	return nil
-}
-
-type decorateHomeAssistantCurrentGetterImpl struct {
-	currentGetter func() (float64, error)
-}
-
-func (impl *decorateHomeAssistantCurrentGetterImpl) GetMaxCurrent() (float64, error) {
-	return impl.currentGetter()
 }
 
 type decorateHomeAssistantMeterImpl struct {

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -43,7 +43,8 @@ func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Meter, error)
 		return nil, errors.New("missing power sensor entity")
 	}
 
-	conn, err := homeassistant.NewConnection(cc.BaseURL, cc.Token)
+	log := util.NewLogger("ha-meter")
+	conn, err := homeassistant.NewConnection(log, cc.BaseURL, cc.Token)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -27,7 +27,7 @@ func init() {
 // NewHomeAssistantFromConfig creates a HomeAssistant meter from generic config
 func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		BaseURL  string
+		URI      string
 		Token    string
 		Power    string
 		Energy   string
@@ -44,7 +44,7 @@ func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Meter, error)
 	}
 
 	log := util.NewLogger("ha-meter")
-	conn, err := homeassistant.NewConnection(log, cc.BaseURL, cc.Token)
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Token)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -27,12 +27,12 @@ func init() {
 // NewHomeAssistantFromConfig creates a HomeAssistant meter from generic config
 func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Meter, error) {
 	cc := struct {
-		BaseURL  string   `mapstructure:"baseurl"`
-		Token    string   `mapstructure:"token"`
-		Power    string   `mapstructure:"power"`
-		Energy   string   `mapstructure:"energy"`
-		Currents []string `mapstructure:"currents"`
-		Voltages []string `mapstructure:"voltages"`
+		BaseURL  string
+		Token    string
+		Power    string
+		Energy   string
+		Currents []string
+		Voltages []string
 	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -74,43 +74,20 @@ func NewHomeAssistantFromConfig(other map[string]interface{}) (api.Meter, error)
 	}
 
 	// decorators for optional interfaces
-	var meterEnergy func() (float64, error)
-	var phaseCurrents func() (float64, float64, float64, error)
-	var phaseVoltages func() (float64, float64, float64, error)
+	var energy func() (float64, error)
+	var currents, voltages func() (float64, float64, float64, error)
 
 	if m.energy != "" {
-		meterEnergy = m.TotalEnergy
+		energy = m.totalEnergy
 	}
 	if m.currentEntities[0] != "" {
-		phaseCurrents = m.Currents
+		currents = m.currents
 	}
 	if m.voltageEntities[0] != "" {
-		phaseVoltages = m.Voltages
+		voltages = m.voltages
 	}
 
-	return decorateHomeAssistant(m, meterEnergy, phaseCurrents, phaseVoltages), nil
-}
-
-// NewHomeAssistant creates HomeAssistant meter
-func NewHomeAssistant(baseURL, token, power, energy string, currents, voltages []string) (*HomeAssistant, error) {
-	if power == "" {
-		return nil, errors.New("missing power sensor entity")
-	}
-
-	conn, err := homeassistant.NewConnection(baseURL, token)
-	if err != nil {
-		return nil, err
-	}
-
-	m := &HomeAssistant{
-		conn:            conn,
-		power:           power,
-		energy:          energy,
-		currentEntities: currents,
-		voltageEntities: voltages,
-	}
-
-	return m, nil
+	return decorateHomeAssistant(m, energy, currents, voltages), nil
 }
 
 var _ api.Meter = (*HomeAssistant)(nil)
@@ -120,26 +97,17 @@ func (m *HomeAssistant) CurrentPower() (float64, error) {
 	return m.conn.GetFloatState(m.power)
 }
 
-// TotalEnergy implements the api.MeterEnergy interface
-func (m *HomeAssistant) TotalEnergy() (float64, error) {
-	if m.energy == "" {
-		return 0, api.ErrNotAvailable
-	}
+// totalEnergy implements the api.MeterEnergy interface
+func (m *HomeAssistant) totalEnergy() (float64, error) {
 	return m.conn.GetFloatState(m.energy)
 }
 
-// Currents implements the api.PhaseCurrents interface
-func (m *HomeAssistant) Currents() (float64, float64, float64, error) {
-	if m.currentEntities[0] == "" {
-		return 0, 0, 0, api.ErrNotAvailable
-	}
-	return m.conn.GetPhaseStates(m.currentEntities)
+// currents implements the api.PhaseCurrents interface
+func (m *HomeAssistant) currents() (float64, float64, float64, error) {
+	return m.conn.GetPhaseFloatStates(m.currentEntities)
 }
 
-// Voltages implements the api.PhaseVoltages interface
-func (m *HomeAssistant) Voltages() (float64, float64, float64, error) {
-	if m.voltageEntities[0] == "" {
-		return 0, 0, 0, api.ErrNotAvailable
-	}
-	return m.conn.GetPhaseStates(m.voltageEntities)
+// voltages implements the api.PhaseVoltages interface
+func (m *HomeAssistant) voltages() (float64, float64, float64, error) {
+	return m.conn.GetPhaseFloatStates(m.voltageEntities)
 }

--- a/templates/definition/charger/homeassistant-switch.yaml
+++ b/templates/definition/charger/homeassistant-switch.yaml
@@ -8,10 +8,7 @@ group: switchsockets
 requirements:
   evcc: ["skiptest"]
 params:
-  - name: baseurl
-    description:
-      de: Basis-URL der Home Assistant Instanz
-      en: Base URL of the Home Assistant instance
+  - name: uri
     required: true
     example: http://homeassistant.local:8123
   - name: token
@@ -37,7 +34,7 @@ params:
   - preset: switchsocket
 render: |
   type: homeassistant-switch
-  baseurl: {{ .baseurl }}
+  uri: {{ if (ne .uri "") .uri .baseurl }}
   token: {{ .token }}
   switchentity: {{ .switchentity }}
   powerentity: {{ .powerentity }}

--- a/templates/definition/charger/homeassistant-switch.yaml
+++ b/templates/definition/charger/homeassistant-switch.yaml
@@ -8,6 +8,8 @@ group: switchsockets
 requirements:
   evcc: ["skiptest"]
 params:
+  - name: baseurl
+    deprecated: true
   - name: uri
     required: true
     example: http://homeassistant.local:8123
@@ -34,7 +36,7 @@ params:
   - preset: switchsocket
 render: |
   type: homeassistant-switch
-  uri: {{ if (ne .uri "") .uri .baseurl }}
+  uri: {{ if (eq .uri "") }}{{ .baseurl }}{{ else }}{{ .uri }}{{ end }}
   token: {{ .token }}
   switchentity: {{ .switchentity }}
   powerentity: {{ .powerentity }}

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -11,11 +11,8 @@ requirements:
 params:
   - preset: vehicle-common
   - name: uri
-    description:
-      de: Home Assistant URI
-      en: Home Assistant URI
-    example: "http://192.168.1.10:8123"
     required: true
+    example: http://homeassistant.local:8123
   - name: token
     description:
       de: Home Assistant Long-Lived Access Token

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -21,7 +21,7 @@ type Connection struct {
 }
 
 // NewConnection creates a new Home Assistant connection
-func NewConnection(baseURL, token string) (*Connection, error) {
+func NewConnection(log *util.Logger, baseURL, token string) (*Connection, error) {
 	if baseURL == "" {
 		return nil, errors.New("missing baseURL")
 	}
@@ -29,7 +29,6 @@ func NewConnection(baseURL, token string) (*Connection, error) {
 		return nil, errors.New("missing token")
 	}
 
-	log := util.NewLogger("homeassistant")
 	c := &Connection{
 		Helper: request.NewHelper(log.Redact(token)),
 		uri:    strings.TrimSuffix(baseURL, "/"),

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -21,9 +21,9 @@ type Connection struct {
 }
 
 // NewConnection creates a new Home Assistant connection
-func NewConnection(log *util.Logger, baseURL, token string) (*Connection, error) {
-	if baseURL == "" {
-		return nil, errors.New("missing baseURL")
+func NewConnection(log *util.Logger, uri, token string) (*Connection, error) {
+	if uri == "" {
+		return nil, errors.New("missing uri")
 	}
 	if token == "" {
 		return nil, errors.New("missing token")
@@ -31,7 +31,7 @@ func NewConnection(log *util.Logger, baseURL, token string) (*Connection, error)
 
 	c := &Connection{
 		Helper: request.NewHelper(log.Redact(token)),
-		uri:    strings.TrimSuffix(baseURL, "/"),
+		uri:    strings.TrimSuffix(uri, "/"),
 	}
 
 	// Set up authentication headers

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -71,16 +71,15 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 
 	// prepare optional feature functions with concise names
 	var (
-		limitSoc      func() (int64, error)
-		status        func() (api.ChargeStatus, error)
-		rng           func() (int64, error)
-		odo           func() (float64, error)
-		climater      func() (bool, error)
-		finish        func() (time.Time, error)
-		chargeEnable  func(bool) error
-		wakeup        func() error
-		maxCurrent    func(int64) error
-		getMaxCurrent func() (float64, error)
+		limitSoc   func() (int64, error)
+		status     func() (api.ChargeStatus, error)
+		rng        func() (int64, error)
+		odo        func() (float64, error)
+		climater   func() (bool, error)
+		finish     func() (time.Time, error)
+		enable     func(bool) error
+		wakeup     func() error
+		maxcurrent func(int64) error
 	)
 
 	if cc.Sensors.LimitSoc != "" {
@@ -102,14 +101,13 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		finish = func() (time.Time, error) { return res.getTimeSensor(cc.Sensors.FinishTime) }
 	}
 	if cc.Services.Start != "" && cc.Services.Stop != "" {
-		chargeEnable = func(enable bool) error { return res.enable(cc.Services.Start, cc.Services.Stop, enable) }
+		enable = func(enable bool) error { return res.enable(cc.Services.Start, cc.Services.Stop, enable) }
 	}
 	if cc.Services.Wakeup != "" {
 		wakeup = func() error { return conn.CallService(cc.Services.Wakeup) }
 	}
 	if cc.Services.SetMaxCurrent != "" {
-		maxCurrent = func(current int64) error { return res.setMaxCurrent(cc.Services.SetMaxCurrent, current) }
-		getMaxCurrent = func() (float64, error) { return conn.GetFloatState(cc.Services.SetMaxCurrent) }
+		maxcurrent = func(current int64) error { return res.setMaxCurrent(cc.Services.SetMaxCurrent, current) }
 	}
 
 	// decorate all features
@@ -120,11 +118,11 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		rng,
 		odo,
 		climater,
-		maxCurrent,
-		getMaxCurrent,
+		maxcurrent,
+		nil,
 		finish,
 		wakeup,
-		chargeEnable,
+		enable,
 	), nil
 }
 

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -2,25 +2,18 @@ package vehicle
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
-	"net/url"
-	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/request"
-	"github.com/evcc-io/evcc/util/transport"
+	"github.com/evcc-io/evcc/util/homeassistant"
 )
 
 type HomeAssistant struct {
 	*embed
-	*request.Helper
-	uri string
-	soc string
+	conn *homeassistant.Connection
+	soc  string
 }
 
 // Register on startup
@@ -32,7 +25,7 @@ func init() {
 func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error) {
 	var cc struct {
 		embed   `mapstructure:",squash"`
-		URI     string
+		BaseURL string
 		Token   string
 		Sensors struct {
 			Soc        string // required
@@ -56,26 +49,24 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 	}
 
 	switch {
-	case cc.URI == "":
-		return nil, errors.New("missing uri")
+	case cc.BaseURL == "":
+		return nil, errors.New("missing BaseURL")
 	case cc.Token == "":
 		return nil, errors.New("missing token")
 	case cc.Sensors.Soc == "":
 		return nil, errors.New("missing soc sensor")
 	}
 
-	res := &HomeAssistant{
-		embed:  &cc.embed,
-		Helper: request.NewHelper(util.NewLogger("ha-vehicle").Redact(cc.Token)),
-		uri:    strings.TrimSuffix(cc.URI, "/"),
-		soc:    cc.Sensors.Soc,
+	log := util.NewLogger("ha-charger")
+	conn, err := homeassistant.NewConnection(log, cc.BaseURL, cc.Token)
+	if err != nil {
+		return nil, err
 	}
 
-	res.Client.Transport = &transport.Decorator{
-		Base: res.Client.Transport,
-		Decorator: transport.DecorateHeaders(map[string]string{
-			"Authorization": "Bearer " + cc.Token,
-		}),
+	res := &HomeAssistant{
+		embed: &cc.embed,
+		conn:  conn,
+		soc:   cc.Sensors.Soc,
 	}
 
 	// prepare optional feature functions with concise names
@@ -93,37 +84,32 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 	)
 
 	if cc.Sensors.LimitSoc != "" {
-		limitSoc = func() (int64, error) { return res.getIntSensor(cc.Sensors.LimitSoc) }
+		limitSoc = func() (int64, error) { return conn.GetIntState(cc.Sensors.LimitSoc) }
 	}
 	if cc.Sensors.Status != "" {
-		status = func() (api.ChargeStatus, error) { return res.status(cc.Sensors.Status) }
+		status = func() (api.ChargeStatus, error) { return conn.GetChargeStatus(cc.Sensors.Status) }
 	}
 	if cc.Sensors.Range != "" {
-		rng = func() (int64, error) { return res.getIntSensor(cc.Sensors.Range) }
+		rng = func() (int64, error) { return conn.GetIntState(cc.Sensors.Range) }
 	}
 	if cc.Sensors.Odometer != "" {
-		odo = func() (float64, error) { return res.getFloatSensor(cc.Sensors.Odometer) }
+		odo = func() (float64, error) { return conn.GetFloatState(cc.Sensors.Odometer) }
 	}
 	if cc.Sensors.Climater != "" {
-		climater = func() (bool, error) { return res.getBoolSensor(cc.Sensors.Climater) }
+		climater = func() (bool, error) { return conn.GetBoolState(cc.Sensors.Climater) }
 	}
 	if cc.Sensors.FinishTime != "" {
 		finish = func() (time.Time, error) { return res.getTimeSensor(cc.Sensors.FinishTime) }
 	}
 	if cc.Services.Start != "" && cc.Services.Stop != "" {
-		chargeEnable = func(enable bool) error {
-			if enable {
-				return res.callScript(cc.Services.Start)
-			}
-			return res.callScript(cc.Services.Stop)
-		}
+		chargeEnable = func(enable bool) error { return res.enable(cc.Services.Start, cc.Services.Stop, enable) }
 	}
 	if cc.Services.Wakeup != "" {
-		wakeup = func() error { return res.callScript(cc.Services.Wakeup) }
+		wakeup = func() error { return conn.CallService(cc.Services.Wakeup) }
 	}
 	if cc.Services.SetMaxCurrent != "" {
 		maxCurrent = func(current int64) error { return res.setMaxCurrent(cc.Services.SetMaxCurrent, current) }
-		getMaxCurrent = func() (float64, error) { return res.getFloatSensor(cc.Services.SetMaxCurrent) }
+		getMaxCurrent = func() (float64, error) { return conn.GetFloatState(cc.Services.SetMaxCurrent) }
 	}
 
 	// decorate all features
@@ -143,100 +129,15 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 }
 
 func (v *HomeAssistant) Soc() (float64, error) {
-	return v.getFloatSensor(v.soc)
-}
-
-// Calls /api/states/<entity> and returns .state
-func (v *HomeAssistant) getState(entity string) (string, error) {
-	var res struct {
-		State string `json:"state"`
-	}
-
-	uri := fmt.Sprintf("%s/api/states/%s", v.uri, url.PathEscape(entity))
-	if err := v.GetJSON(uri, &res); err != nil {
-		return "", err
-	}
-
-	if res.State == "unknown" || res.State == "unavailable" {
-		return "", api.ErrNotAvailable
-	}
-
-	return res.State, nil
-}
-
-func (v *HomeAssistant) callScript(script string) error {
-	// All configured services are scripts, so always use script.turn_on
-	payload := fmt.Sprintf(`{"entity_id": "%s"}`, script)
-	uri := fmt.Sprintf("%s/api/services/script/turn_on", v.uri)
-	req, _ := request.New(http.MethodPost, uri, strings.NewReader(payload))
-	_, err := v.DoBody(req)
-	return err
+	return v.conn.GetFloatState(v.soc)
 }
 
 func (v *HomeAssistant) setMaxCurrent(entity string, current int64) error {
-	// Determine service domain from entity prefix
-	parts := strings.SplitN(entity, ".", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid entity format: %s", entity)
-	}
-
-	domain := parts[0]
-	var service string
-
-	switch domain {
-	case "number":
-		service = "set_value"
-	case "input_number":
-		service = "set_value"
-	default:
-		return fmt.Errorf("unsupported entity domain: %s", domain)
-	}
-
-	data := map[string]interface{}{
-		"entity_id": entity,
-		"value":     current,
-	}
-
-	uri := fmt.Sprintf("%s/api/services/%s/%s", v.uri, domain, service)
-	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
-	_, err := v.DoBody(req)
-	return err
-}
-
-// generic helpers for fetching and parsing sensor values
-func (v *HomeAssistant) getFloatSensor(entity string) (float64, error) {
-	s, err := v.getState(entity)
-	if err != nil {
-		return 0, err
-	}
-
-	return strconv.ParseFloat(s, 64)
-}
-
-func (v *HomeAssistant) getIntSensor(entity string) (int64, error) {
-	s, err := v.getState(entity)
-	if err != nil {
-		return 0, err
-	}
-
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, err
-	}
-	return int64(f), nil // truncation
-}
-
-func (v *HomeAssistant) getBoolSensor(entity string) (bool, error) {
-	s, err := v.getState(entity)
-	if err != nil {
-		return false, err
-	}
-
-	return slices.Contains([]string{"on", "true", "1", "active"}, strings.ToLower(s)), nil
+	return v.conn.CallNumberService(entity, float64(current))
 }
 
 func (v *HomeAssistant) getTimeSensor(entity string) (time.Time, error) {
-	s, err := v.getState(entity)
+	s, err := v.conn.GetState(entity)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -248,39 +149,10 @@ func (v *HomeAssistant) getTimeSensor(entity string) (time.Time, error) {
 	return time.Parse(time.RFC3339, s)
 }
 
-// status returns evcc charge status (optional, private)
-func (v *HomeAssistant) status(sensor string) (api.ChargeStatus, error) {
-	var haStatusMap = map[string]api.ChargeStatus{
-		"c":                   api.StatusC,
-		"charging":            api.StatusC,
-		"on":                  api.StatusC,
-		"true":                api.StatusC,
-		"active":              api.StatusC,
-		"b":                   api.StatusB,
-		"connected":           api.StatusB,
-		"ready":               api.StatusB,
-		"plugged":             api.StatusB,
-		"charging_completed":  api.StatusB,
-		"initialising":        api.StatusB,
-		"a":                   api.StatusA,
-		"disconnected":        api.StatusA,
-		"off":                 api.StatusA,
-		"none":                api.StatusA,
-		"unavailable":         api.StatusA,
-		"unknown":             api.StatusA,
-		"notreadyforcharging": api.StatusA,
-		"not_plugged":         api.StatusA,
+func (v *HomeAssistant) enable(on, off string, enable bool) error {
+	if enable {
+		return v.conn.CallService(on)
 	}
 
-	s, err := v.getState(sensor)
-	if err != nil {
-		return api.StatusNone, err
-	}
-
-	state := strings.ToLower(s)
-	if mapped, ok := haStatusMap[state]; ok {
-		return mapped, nil
-	}
-
-	return api.StatusNone, errors.New("invalid state: " + s)
+	return v.conn.CallService(off)
 }

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -25,7 +25,7 @@ func init() {
 func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error) {
 	var cc struct {
 		embed   `mapstructure:",squash"`
-		BaseURL string
+		URI     string
 		Token   string
 		Sensors struct {
 			Soc        string // required
@@ -49,8 +49,8 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 	}
 
 	switch {
-	case cc.BaseURL == "":
-		return nil, errors.New("missing BaseURL")
+	case cc.URI == "":
+		return nil, errors.New("missing uri")
 	case cc.Token == "":
 		return nil, errors.New("missing token")
 	case cc.Sensors.Soc == "":
@@ -58,7 +58,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 	}
 
 	log := util.NewLogger("ha-charger")
-	conn, err := homeassistant.NewConnection(log, cc.BaseURL, cc.Token)
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Token)
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -57,7 +57,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		return nil, errors.New("missing soc sensor")
 	}
 
-	log := util.NewLogger("ha-charger")
+	log := util.NewLogger("ha-vehicle")
 	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Token)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR cleans up the 4 different HA implementations in the code base. It proofs, that just adding new AI-assisted functionality creates downstream efforts. We should be more critical merging new functionality that overlaps with existing implementations as well as require full testing.

**Breaking changes**

- vehicle.getcurrent has been removed (was not part of the template anyway)
- switch.baseurl has been renamed to uri (same as vehicle and all other integrations)
- charger.maxcurrent is required

**Out of scope**

- charger template
- meter template