### PR TITLE
Add support for Solax Gen2 (HAC) chargers

### DIFF
--- a/charger/solax.go
+++ b/charger/solax.go
@@ -224,7 +224,7 @@ func (wb *Solax) TotalEnergy() (float64, error) {
 	if wb.isLegacyHw {
 		return float64(binary.BigEndian.Uint32(b)) / 10, err
 	} else {
-		return float64(encoding.Uint32(b)) / 10, err
+		return float64(encoding.Uint32LswFirst(b)) / 10, err
 	}
 }
 

--- a/charger/solax.go
+++ b/charger/solax.go
@@ -209,9 +209,9 @@ func (wb *Solax) TotalEnergy() (float64, error) {
 
 	if wb.isLegacyHw {
 		return float64(binary.BigEndian.Uint32(b)) / 10, err
-	} else {
-		return float64(encoding.Uint32LswFirst(b)) / 10, err
 	}
+
+	return float64(encoding.Uint32LswFirst(b)) / 10, err
 }
 
 var _ api.PhaseCurrents = (*Solax)(nil)

--- a/charger/solax.go
+++ b/charger/solax.go
@@ -116,13 +116,7 @@ func (wb *Solax) getPhaseValues(reg uint16) (float64, float64, float64, error) {
 
 	var res [3]float64
 	for i := range res {
-		var v uint16
-		if wb.isLegacyHw {
-			v = binary.BigEndian.Uint16(b[2*i:])
-		} else {
-			v = encoding.Uint16(b[2*i:])
-		}
-		res[i] = float64(v) / 100
+		res[i] = float64(binary.BigEndian.Uint16(b[2*i:])) / 100
 	}
 
 	return res[0], res[1], res[2], nil
@@ -160,11 +154,7 @@ func (wb *Solax) Enabled() (bool, error) {
 		return false, err
 	}
 
-	if wb.isLegacyHw {
-		return binary.BigEndian.Uint16(b) != solaxModeStop, nil
-	} else {
-		return encoding.Uint16(b) != solaxModeStop, nil
-	}
+	return binary.BigEndian.Uint16(b) != solaxModeStop, nil
 }
 
 // Enable implements the api.Charger interface
@@ -205,11 +195,7 @@ func (wb *Solax) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
-	if wb.isLegacyHw {
-		return float64(binary.BigEndian.Uint16(b)), err
-	} else {
-		return float64(encoding.Uint16(b)), err
-	}
+	return float64(binary.BigEndian.Uint16(b)), err
 }
 
 var _ api.MeterEnergy = (*Solax)(nil)

--- a/templates/definition/charger/solax-g2.yaml
+++ b/templates/definition/charger/solax-g2.yaml
@@ -1,4 +1,4 @@
-template: solax-hac
+template: solax-g2
 products:
   - brand: Solax
     description:
@@ -16,5 +16,5 @@ params:
     comset: 8N1
     id: 70
 render: |
-  type: solax-hac
+  type: solax-g2
   {{- include "modbus" . }}

--- a/templates/definition/charger/solax-hac.yaml
+++ b/templates/definition/charger/solax-hac.yaml
@@ -1,0 +1,20 @@
+template: solax-hac
+products:
+  - brand: Solax
+    description:
+      generic: X3-HAC
+capabilities: ["mA"]
+requirements:
+  evcc: ["sponsorship"]
+  description:
+    de: Die Wallbox muss sich im Modus "Schnell" befinden und vom Wechselrichtersystem entkoppelt sein.
+    en: The charger must be in “Fast” mode and decoupled from the inverter system.
+params:
+  - name: modbus
+    choice: ["rs485"]
+    baudrate: 9600
+    comset: 8N1
+    id: 70
+render: |
+  type: solax-hac
+  {{- include "modbus" . }}


### PR DESCRIPTION
The PR should fix the problem discussed in #22497. The Solax G2/HAC series needs a different way of reading the charger registers than the G1/EVC series. For backwards compatibility, I kept the original template as it was and just added a new one for the G2 series (similar to Victron).

Ideally, the specification of the series should not have to be specified manually but gets resolved dynamically like it happens for SMA chargers. But since i don't have any Solax charger on hand, I cannot implement this yet.