### PR TITLE
Volvo Connected: require vin (BC)

### DIFF
--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -178,6 +178,7 @@ func (o *OAuth) Token() (*oauth2.Token, error) {
 	if err != nil {
 		// force logout
 		if strings.Contains(err.Error(), "invalid_grant") && settings.Exists(o.subject) {
+			o.token = nil
 			o.onlineC <- false
 			settings.Delete(o.subject)
 		}

--- a/templates/definition/vehicle/volvo-connected.yaml
+++ b/templates/definition/vehicle/volvo-connected.yaml
@@ -49,6 +49,7 @@ params:
     example: "https://evcc.example.org/providerauth/callback"
   - name: vin
     example: WF0FXX...
+    required: true
   - name: accessToken
     deprecated: true
   - name: refreshToken

--- a/vehicle/volvo-connected.go
+++ b/vehicle/volvo-connected.go
@@ -53,7 +53,7 @@ func NewVolvoConnectedFromConfig(ctx context.Context, other map[string]interface
 	log := util.NewLogger("volvo-connected").Redact(cc.VIN, cc.Credentials.ID, cc.Credentials.Secret, cc.VccApiKey)
 
 	oc := connected.Oauth2Config(cc.Credentials.ID, cc.Credentials.Secret, cc.RedirectUri)
-	ts, err := auth.NewOauth(ctx, cc.embed.GetTitle(), oc)
+	ts, err := auth.NewOauth(ctx, "Volvo", oc)
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/volvo-connected.go
+++ b/vehicle/volvo-connected.go
@@ -2,6 +2,7 @@ package vehicle
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -37,7 +38,19 @@ func NewVolvoConnectedFromConfig(ctx context.Context, other map[string]interface
 		return nil, err
 	}
 
-	log := util.NewLogger("volvo-connected").Redact(cc.VIN, cc.VccApiKey)
+	if cc.VccApiKey == "" {
+		return nil, errors.New("missing vccapikey")
+	}
+
+	if cc.VIN == "" {
+		return nil, errors.New("missing vin")
+	}
+
+	if err := cc.Credentials.Error(); err != nil {
+		return nil, err
+	}
+
+	log := util.NewLogger("volvo-connected").Redact(cc.VIN, cc.Credentials.ID, cc.Credentials.Secret, cc.VccApiKey)
 
 	oc := connected.Oauth2Config(cc.Credentials.ID, cc.Credentials.Secret, cc.RedirectUri)
 	ts, err := auth.NewOauth(ctx, cc.embed.GetTitle(), oc)
@@ -47,11 +60,9 @@ func NewVolvoConnectedFromConfig(ctx context.Context, other map[string]interface
 
 	api := connected.NewAPI(log, cc.VccApiKey, ts)
 
-	cc.VIN, err = ensureVehicle(cc.VIN, api.Vehicles)
-
 	v := &VolvoConnected{
 		embed:    &cc.embed,
-		Provider: connected.NewProvider(api, cc.VIN, cc.Cache),
+		Provider: connected.NewProvider(api, ts, cc.VIN, cc.Cache),
 	}
 
 	return v, err


### PR DESCRIPTION
This allows to skip the initial api call and always successfully create the vehicle. Later API calls will return `not available` until user login has completed.

/cc @lehmanju this is part of the fine-tuning of the provider auth approach.