### PR TITLE
Homeassistant Switch: use common naming standard (BC)

### DIFF
--- a/templates/definition/charger/homeassistant-switch.yaml
+++ b/templates/definition/charger/homeassistant-switch.yaml
@@ -8,8 +8,6 @@ group: switchsockets
 requirements:
   evcc: ["skiptest"]
 params:
-  - name: baseurl
-    deprecated: true
   - name: uri
     required: true
     example: http://homeassistant.local:8123
@@ -22,13 +20,13 @@ params:
     help:
       de: aus Home Assistant Profil
       en: from Home Assistant profile
-  - name: switchentity
+  - name: switch
     required: true
     description:
       de: Entity ID des schaltbaren Geräts
       en: Entity ID of the switch device
     example: switch.smartsocket
-  - name: powerentity
+  - name: power
     description:
       de: Entity ID für Leistungsmessung
       en: Entity ID for power measurement
@@ -36,8 +34,8 @@ params:
   - preset: switchsocket
 render: |
   type: homeassistant-switch
-  uri: {{ if (eq .uri "") }}{{ .baseurl }}{{ else }}{{ .uri }}{{ end }}
+  uri: {{ .uri }}
   token: {{ .token }}
-  enable: {{ .switchentity }}
-  power: {{ .powerentity }}
+  enable: {{ .switch }}
+  power: {{ .power }}
   {{ include "switchsocket" . }}


### PR DESCRIPTION
- replace `baseurl` with `uri`
- replace `switchentity` with `switch`
- replace `powerentity` with `power`

Refs https://github.com/evcc-io/evcc/issues/24280