### PR TITLE
chore: restore prettier vscode/cursor integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN npm ci
 
 # build ui
 COPY Makefile .
+COPY *.js ./
 COPY .*.ts .*.mts ./
 COPY *.ts *.mts ./
 COPY assets assets

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,6 @@
-import { type Config } from "prettier";
-
+/** @type {import("prettier").Config} */
 export default {
   printWidth: 100,
   trailingComma: "es5",
   plugins: ["prettier-plugin-sh"],
-} satisfies Config;
+};


### PR DESCRIPTION
🐞 fix broken prettier vscode integration since ts migration. Revert to js.

\cc @Maschga

```
["INFO" - 18:23:54] Extension Name:
esbenp.prettier-vscode.
["INFO" - 18:23:54] Extension Version: 11.0.0.
["ERROR" - 18:23:59] Invalid prettier configuration file detected.
["ERROR" - 18:23:59] Unknown file extension ".ts" for /Users/.../Lab/evcc/.prettierrc.ts
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/.../Lab/evcc/.prettierrc.ts
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:190:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:233:36)
    at defaultLoad (node:internal/modules/esm/load:144:22)
    at async ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:477:45)
    at async ModuleJob._link (node:internal/modules/esm/module_job:110:19)
["ERROR" - 18:23:59] Invalid prettier configuration file detected. See log for details.
["ERROR" - 18:24:15] Invalid prettier configuration file detected.
["ERROR" - 18:24:15] Unknown file extension ".ts" for /Users/.../Lab/evcc/.prettierrc.ts
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/.../Lab/evcc/.prettierrc.ts
```