### PR TITLE
Open-Meteo: remove cacheable feature

### DIFF
--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -70,7 +70,6 @@ params:
 render: |
   type: custom
   tariff: solar
-  features: ["cacheable"]
   forecast:
     source: http
     uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=3&timezone=GMT&timeformat=unixtime


### PR DESCRIPTION
Caching leads to infrequent refreshes of forecast data and is not needed for Open-Meteo due to high API call limits.

fix https://github.com/evcc-io/evcc/issues/24283#issuecomment-3391894635