### PR TITLE
Hardy-Barth Salia: support firmware 2.3.0+

### DIFF
--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -181,13 +181,12 @@ func (wb *Salia) heartbeat(ctx context.Context) {
 }
 
 func (wb *Salia) post(key, val string) error {
-
 	data := map[string]string{key: val}
 	httpmethod := http.MethodPut
 	uri := fmt.Sprintf("%s/secc", wb.uri)
 
 	if wb.fw >= 3 {
-	    //remove /api for fw >= 2.3.0 and use /save_mqtt.php instead of /api/secc
+		// remove /api for fw >= 2.3.0 and use /save_mqtt.php instead of /api/secc
 		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"
 		httpmethod = http.MethodPost
 	}

--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -185,8 +185,8 @@ func (wb *Salia) post(key, val string) error {
 	httpmethod := http.MethodPut
 	uri := fmt.Sprintf("%s/secc", wb.uri)
 
+	// remove /api for fw >= 2.3.0 and use /save_mqtt.php instead of /api/secc
 	if wb.fw >= 3 {
-		// remove /api for fw >= 2.3.0 and use /save_mqtt.php instead of /api/secc
 		httpmethod = http.MethodPost
 		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"
 	}

--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -187,8 +187,8 @@ func (wb *Salia) post(key, val string) error {
 
 	if wb.fw >= 3 {
 		// remove /api for fw >= 2.3.0 and use /save_mqtt.php instead of /api/secc
-		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"
 		httpmethod = http.MethodPost
+		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"
 	}
 
 	req, err := request.New(httpmethod, uri, request.MarshalJSON(data), request.JSONEncoding)

--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -185,7 +185,7 @@ func (wb *Salia) post(key, val string) error {
 	httpmethod := http.MethodPut
 	uri := fmt.Sprintf("%s/secc", wb.uri)
 
-	// for fw >= 2.3.0 replace remove /api  and use /save_mqtt.php instead of /api/secc
+	// for fw >= 2.3.0 replace use /save_mqtt.php instead of /api/secc
 	if wb.fw >= 3 {
 		httpmethod = http.MethodPost
 		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"

--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -190,9 +190,6 @@ func (wb *Salia) post(key, val string) error {
 	    //remove /api for fw >= 2.3.0 and use /save_mqtt.php instead of /api/secc
 		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"
 		httpmethod = http.MethodPost
-	}else{
-	   	uri = fmt.Sprintf("%s/secc", wb.uri)
-	    httpmethod = http.MethodPut
 	}
 
 	req, err := request.New(httpmethod, uri, request.MarshalJSON(data), request.JSONEncoding)

--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -185,7 +185,7 @@ func (wb *Salia) post(key, val string) error {
 	httpmethod := http.MethodPut
 	uri := fmt.Sprintf("%s/secc", wb.uri)
 
-	// remove /api for fw >= 2.3.0 and use /save_mqtt.php instead of /api/secc
+	// for fw >= 2.3.0 replace remove /api  and use /save_mqtt.php instead of /api/secc
 	if wb.fw >= 3 {
 		httpmethod = http.MethodPost
 		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"

--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -185,7 +185,7 @@ func (wb *Salia) post(key, val string) error {
 	httpmethod := http.MethodPut
 	uri := fmt.Sprintf("%s/secc", wb.uri)
 
-	// for fw >= 2.3.0 replace use /save_mqtt.php instead of /api/secc
+	// for fw >= 2.3. use /save_mqtt.php instead of /api/secc
 	if wb.fw >= 3 {
 		httpmethod = http.MethodPost
 		uri = strings.TrimSuffix(wb.uri, "/api") + "/save_mqtt.php"


### PR DESCRIPTION
Since at least FW 2.3.64 firmware forces user and password for commands (basic auth)
and the endpoint for commands changed

Set the cut of point at 2.3 I hope they do some kind of semver

I did a screensharing session with a user
https://github.com/evcc-io/evcc/discussions/24004#discussioncomment-14649168

the changes here use an different endpoint (/save_mqtt.php) (used also by the Webui of the wallbox..) if FW > 2.3.0 

For Post commands to the Wallbox

