### PR TITLE
Tariffs: reduce published data volume

### DIFF
--- a/assets/js/store.ts
+++ b/assets/js/store.ts
@@ -31,6 +31,7 @@ const initialState: State = {
   offline: false,
   loadpoints: [],
   vehicles: {},
+  forecast: {},
 };
 
 const state = reactive(initialState);

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -52,7 +52,7 @@ export interface State {
   offline: boolean;
   startup?: boolean;
   loadpoints: Loadpoint[];
-  forecast?: Forecast;
+  forecast: Forecast;
   currency?: CURRENCY;
   fatal?: FatalError[];
   authProviders?: AuthProviders;

--- a/core/site.go
+++ b/core/site.go
@@ -67,7 +67,6 @@ var _ site.API = (*Site)(nil)
 // Site is the main configuration container. A site can host multiple loadpoints.
 type Site struct {
 	uiChan       chan<- util.Param // client push messages
-	uiCache      map[string][32]byte
 	lpUpdateChan chan *Loadpoint
 
 	*Health
@@ -260,7 +259,6 @@ func NewSite() *Site {
 	site := &Site{
 		log:             util.NewLogger("site"),
 		Voltage:         230, // V
-		uiCache:         make(map[string][32]byte),
 		pvEnergy:        make(map[string]*meterEnergy),
 		fcstEnergy:      &meterEnergy{clock: clock.New()},
 		householdEnergy: &meterEnergy{clock: clock.New()},
@@ -476,7 +474,7 @@ func (site *Site) DumpConfig() {
 }
 
 // publish sends values to UI and databases
-func (site *Site) publish(key string, val any) {
+func (site *Site) publish(key string, val interface{}) {
 	// test helper
 	if site.uiChan == nil {
 		return

--- a/core/site.go
+++ b/core/site.go
@@ -485,38 +485,6 @@ func (site *Site) publish(key string, val any) {
 	site.uiChan <- util.Param{Key: key, Val: val}
 }
 
-// // publishCached uses SHA256 to calculate a hash and publishes only if updated
-// func (site *Site) publishCached(key string, val any) {
-// 	hash := sha256.Sum256(fmt.Append(nil, val))
-// 	if site.uiCache == nil {
-// 		site.uiCache = make(map[string][32]byte)
-// 	}
-// 	cached, ok := site.uiCache[key]
-// 	if !ok || hash != cached {
-// 		site.uiCache[key] = hash
-// 		site.publish(key, val)
-// 	}
-// }
-
-// // publishPartialUpdates publishes structs field by field to improve caching
-// func (site *Site) publishPartialUpdates(key string, val any) {
-// 	if rv := reflect.ValueOf(val); rv.Kind() != reflect.Struct {
-// 		site.publishCached(key, val)
-// 		return
-// 	}
-
-// 	for _, f := range structs.Fields(val) {
-// 		name := f.Name()
-// 		if t := f.Tag("json"); t != "" {
-// 			if n := strings.Split(t, ",")[0]; n != "" {
-// 				name = n
-// 			}
-// 		}
-
-// 		site.publishCached(key+"."+name, f.Value())
-// 	}
-// }
-
 func (site *Site) collectMeters(key string, meters []config.Device[api.Meter]) []measurement {
 	mm := make([]measurement, len(meters))
 

--- a/core/site.go
+++ b/core/site.go
@@ -510,7 +510,9 @@ func (site *Site) publishPartialUpdates(key string, val any) {
 	for _, f := range structs.Fields(val) {
 		name := f.Name()
 		if t := f.Tag("json"); t != "" {
-			name = strings.Split(t, ",")[0]
+			if n := strings.Split(t, ",")[0]; n != "" {
+				name = n
+			}
 		}
 
 		site.publishCached(key+"."+name, f.Value())

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -120,7 +120,7 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 		fc.Solar = lo.ToPtr(site.solarDetails(solar))
 	}
 
-	site.publish(keys.Forecast, util.NewSharder(site.uiCache, fc))
+	site.publish(keys.Forecast, util.NewSharder(keys.Forecast, fc))
 }
 
 func (site *Site) solarDetails(solar api.Rates) solarDetails {

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -15,14 +15,6 @@ import (
 	"github.com/samber/lo"
 )
 
-type forecast struct {
-	Co2     api.Rates     `json:"co2,omitempty"`
-	FeedIn  api.Rates     `json:"feedin,omitempty"`
-	Grid    api.Rates     `json:"grid,omitempty"`
-	Planner api.Rates     `json:"planner,omitempty"`
-	Solar   *solarDetails `json:"solar,omitempty"`
-}
-
 type solarDetails struct {
 	Scale            *float64     `json:"scale,omitempty"`            // scale factor yield/forecasted today
 	Today            dailyDetails `json:"today,omitempty"`            // tomorrow
@@ -108,7 +100,13 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 		site.publish(keys.TariffCo2Loadpoints, v)
 	}
 
-	fc := forecast{
+	fc := struct {
+		Co2     api.Rates     `json:"co2,omitempty"`
+		FeedIn  api.Rates     `json:"feedin,omitempty"`
+		Grid    api.Rates     `json:"grid,omitempty"`
+		Planner api.Rates     `json:"planner,omitempty"`
+		Solar   *solarDetails `json:"solar,omitempty"`
+	}{
 		Co2:     tariff.Rates(site.GetTariff(api.TariffUsageCo2)),
 		FeedIn:  tariff.Rates(site.GetTariff(api.TariffUsageFeedIn)),
 		Planner: tariff.Rates(site.GetTariff(api.TariffUsagePlanner)),

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -10,9 +10,18 @@ import (
 	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/tariff"
+	"github.com/evcc-io/evcc/util"
 	"github.com/jinzhu/now"
 	"github.com/samber/lo"
 )
+
+type forecast struct {
+	Co2     api.Rates     `json:"co2,omitempty"`
+	FeedIn  api.Rates     `json:"feedin,omitempty"`
+	Grid    api.Rates     `json:"grid,omitempty"`
+	Planner api.Rates     `json:"planner,omitempty"`
+	Solar   *solarDetails `json:"solar,omitempty"`
+}
 
 type solarDetails struct {
 	Scale            *float64     `json:"scale,omitempty"`            // scale factor yield/forecasted today
@@ -99,13 +108,7 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 		site.publish(keys.TariffCo2Loadpoints, v)
 	}
 
-	fc := struct {
-		Co2     api.Rates     `json:"co2,omitempty"`
-		FeedIn  api.Rates     `json:"feedin,omitempty"`
-		Grid    api.Rates     `json:"grid,omitempty"`
-		Planner api.Rates     `json:"planner,omitempty"`
-		Solar   *solarDetails `json:"solar,omitempty"`
-	}{
+	fc := forecast{
 		Co2:     tariff.Rates(site.GetTariff(api.TariffUsageCo2)),
 		FeedIn:  tariff.Rates(site.GetTariff(api.TariffUsageFeedIn)),
 		Planner: tariff.Rates(site.GetTariff(api.TariffUsagePlanner)),
@@ -117,7 +120,7 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 		fc.Solar = lo.ToPtr(site.solarDetails(solar))
 	}
 
-	site.publishPartialUpdates(keys.Forecast, fc)
+	site.publish(keys.Forecast, util.NewSharder(site.uiCache, fc))
 }
 
 func (site *Site) solarDetails(solar api.Rates) solarDetails {

--- a/server/socket.go
+++ b/server/socket.go
@@ -122,10 +122,7 @@ func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 		msg[k] = json.RawMessage(socketEncode(p.Val))
 	}
 
-	b, err := json.Marshal(msg)
-	if err != nil {
-		panic(err)
-	}
+	b, _ := json.Marshal(msg)
 
 	// should not block
 	subscriber.send <- b
@@ -160,10 +157,7 @@ func (h *SocketHub) broadcast(p util.Param) {
 		msg[k] = json.RawMessage(socketEncode(p.Val))
 	}
 
-	b, err := json.Marshal(msg)
-	if err != nil {
-		panic(err)
-	}
+	b, _ := json.Marshal(msg)
 
 	for s := range h.subscribers {
 		select {

--- a/server/socket.go
+++ b/server/socket.go
@@ -119,7 +119,7 @@ func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 			k = "loadpoints." + p.UniqueID()
 		}
 
-		msg[k] = json.RawMessage(kv(p.Val))
+		msg[k] = json.RawMessage(socketEncode(p.Val))
 	}
 
 	b, err := json.Marshal(msg)
@@ -154,10 +154,10 @@ func (h *SocketHub) broadcast(p util.Param) {
 		}
 
 		for _, shard := range shards {
-			msg[k+"."+shard.Key] = json.RawMessage(kv(shard.Value))
+			msg[k+"."+shard.Key] = json.RawMessage(socketEncode(shard.Value))
 		}
 	} else {
-		msg[k] = json.RawMessage(kv(p.Val))
+		msg[k] = json.RawMessage(socketEncode(p.Val))
 	}
 
 	b, err := json.Marshal(msg)

--- a/server/socket_helper.go
+++ b/server/socket_helper.go
@@ -30,7 +30,7 @@ func encodeSliceAsString(v any) (string, error) {
 	return fmt.Sprintf("[%s]", strings.Join(res, ",")), nil
 }
 
-func kv(pval any) string {
+func socketEncode(pval any) string {
 	var (
 		val string
 		err error

--- a/server/socket_helper.go
+++ b/server/socket_helper.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/encode"
 )
 
@@ -31,36 +30,22 @@ func encodeSliceAsString(v any) (string, error) {
 	return fmt.Sprintf("[%s]", strings.Join(res, ",")), nil
 }
 
-func kv(p util.Param) string {
+func kv(pval any) string {
 	var (
 		val string
 		err error
 	)
 
 	// unwrap slices
-	if p.Val != nil && reflect.TypeOf(p.Val).Kind() == reflect.Slice {
-		val, err = encodeSliceAsString(p.Val)
+	if pval != nil && reflect.TypeOf(pval).Kind() == reflect.Slice {
+		val, err = encodeSliceAsString(pval)
 	} else {
-		val, err = encodeAsString(p.Val)
+		val, err = encodeAsString(pval)
 	}
 
 	if err != nil {
 		panic(err)
 	}
 
-	if p.Key == "" && val == "" {
-		log.ERROR.Printf("invalid key/val for %+v, please report to https://github.com/evcc-io/evcc/issues/6439", p)
-		return "\"foo\":\"bar\""
-	}
-
-	var msg strings.Builder
-	msg.WriteString("\"")
-	if p.Loadpoint != nil {
-		msg.WriteString(fmt.Sprintf("loadpoints.%d.", *p.Loadpoint))
-	}
-	msg.WriteString(p.Key)
-	msg.WriteString("\":")
-	msg.WriteString(val)
-
-	return msg.String()
+	return val
 }

--- a/server/socket_helper.go
+++ b/server/socket_helper.go
@@ -37,7 +37,7 @@ func kv(pval any) string {
 	)
 
 	// unwrap slices
-	if pval != nil && reflect.TypeOf(pval).Kind() == reflect.Slice {
+	if rv := reflect.ValueOf(pval); pval != nil && rv.Kind() == reflect.Slice && !rv.IsNil() {
 		val, err = encodeSliceAsString(pval)
 	} else {
 		val, err = encodeAsString(pval)

--- a/tests/plan.evcc.yaml
+++ b/tests/plan.evcc.yaml
@@ -1,4 +1,4 @@
-interval: 0.25s
+interval: 0.1s
 
 site:
   title: Plan

--- a/util/param.go
+++ b/util/param.go
@@ -4,7 +4,6 @@ import (
 	"maps"
 	"slices"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/evcc-io/evcc/util/encode"
@@ -19,15 +18,11 @@ type Param struct {
 
 // UniqueID returns unique identifier for parameter Loadpoint/Key combination
 func (p Param) UniqueID() string {
-	var b strings.Builder
-
 	if p.Loadpoint != nil {
-		b.WriteString(strconv.Itoa(*p.Loadpoint) + ".")
+		return strconv.Itoa(*p.Loadpoint) + "." + p.Key
 	}
 
-	b.WriteString(p.Key)
-
-	return b.String()
+	return p.Key
 }
 
 // ParamCache is a data store

--- a/util/param_shard.go
+++ b/util/param_shard.go
@@ -40,7 +40,14 @@ func (s *sharderImpl) Shards() []Shard {
 			}
 		}
 
-		hash := sha256.Sum256(fmt.Append(nil, f.Value()))
+		// Use JSON for stable hashing (fmt.Append includes pointer addresses)
+		b, err := json.Marshal(f.Value())
+		if err != nil {
+			// Fallback to fmt.Append if JSON fails
+			b = fmt.Append(nil, f.Value())
+		}
+
+		hash := sha256.Sum256(b)
 		if cached, ok := s.cache[key]; ok && hash == cached {
 			continue
 		}

--- a/util/param_shard.go
+++ b/util/param_shard.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/structs"
+)
+
+// Sharder splits data into chunks, omitting unmodified chunks
+type Sharder interface {
+	Shards() []Shard
+}
+
+type Shard struct {
+	Key   string
+	Value any
+}
+
+type sharderImpl struct {
+	cache map[string][32]byte
+	struc any
+}
+
+func (s *sharderImpl) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.struc)
+}
+
+func (s *sharderImpl) Shards() []Shard {
+	ff := structs.Fields(s.struc)
+	res := make([]Shard, 0, len(ff))
+
+	for _, f := range ff {
+		key := f.Name()
+		if t := f.Tag("json"); t != "" {
+			if n := strings.Split(t, ",")[0]; n != "" {
+				key = n
+			}
+		}
+
+		hash := sha256.Sum256(fmt.Append(nil, f.Value()))
+		if cached, ok := s.cache[key]; ok && hash == cached {
+			continue
+		}
+
+		s.cache[key] = hash
+
+		res = append(res, Shard{
+			Key:   key,
+			Value: f.Value(),
+		})
+	}
+
+	return res
+}
+
+var _ Sharder = (*sharderImpl)(nil)
+
+// NewSharder creates a Sharder that splits structs into sub-structs for space-efficient socket publishing
+// Passing anything else than a struct will panic
+func NewSharder(cache map[string][32]byte, struc any) Sharder {
+	return &sharderImpl{cache, struc}
+}

--- a/util/tee.go
+++ b/util/tee.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"reflect"
 	"sync"
 
 	"github.com/evcc-io/evcc/api"
@@ -37,11 +36,13 @@ func (t *Tee) add(out chan<- Param) {
 // Run starts parameter distribution
 func (t *Tee) Run(in <-chan Param) {
 	for msg := range in {
-		if val := reflect.ValueOf(msg.Val); val.Kind() == reflect.Ptr {
-			if ptr := reflect.Indirect(val); ptr.IsValid() {
-				msg.Val = ptr.Addr().Elem().Interface()
-			}
-		}
+		// TODO MUST NOT PUBLISH POINTERS
+		//
+		// if val := reflect.ValueOf(msg.Val); val.Kind() == reflect.Ptr {
+		// 	if ptr := reflect.Indirect(val); ptr.IsValid() {
+		// 		msg.Val = ptr.Addr().Elem().Interface()
+		// 	}
+		// }
 
 		if val, ok := (msg.Val).(api.Redactor); ok {
 			msg.Val = val.Redacted()

--- a/util/tee.go
+++ b/util/tee.go
@@ -36,7 +36,7 @@ func (t *Tee) add(out chan<- Param) {
 // Run starts parameter distribution
 func (t *Tee) Run(in <-chan Param) {
 	for msg := range in {
-		// TODO MUST NOT PUBLISH POINTERS
+		// TODO MUST NOT PUBLISH POINTERS (WHO'S VALUES ARE LATER MODIFIED)
 		// if val := reflect.ValueOf(msg.Val); val.Kind() == reflect.Ptr {
 		// 	if ptr := reflect.Indirect(val); ptr.IsValid() {
 		// 		fmt.Println("DANGER pointer value:", msg.Key)

--- a/util/tee.go
+++ b/util/tee.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-	"reflect"
 	"sync"
 
 	"github.com/evcc-io/evcc/api"
@@ -39,12 +37,11 @@ func (t *Tee) add(out chan<- Param) {
 func (t *Tee) Run(in <-chan Param) {
 	for msg := range in {
 		// TODO MUST NOT PUBLISH POINTERS
-
-		if val := reflect.ValueOf(msg.Val); val.Kind() == reflect.Ptr {
-			if ptr := reflect.Indirect(val); ptr.IsValid() {
-				fmt.Println("DANGER pointer value:", msg.Key)
-			}
-		}
+		// if val := reflect.ValueOf(msg.Val); val.Kind() == reflect.Ptr {
+		// 	if ptr := reflect.Indirect(val); ptr.IsValid() {
+		// 		fmt.Println("DANGER pointer value:", msg.Key)
+		// 	}
+		// }
 
 		if val, ok := (msg.Val).(api.Redactor); ok {
 			msg.Val = val.Redacted()

--- a/util/tee.go
+++ b/util/tee.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/evcc-io/evcc/api"
@@ -37,12 +39,12 @@ func (t *Tee) add(out chan<- Param) {
 func (t *Tee) Run(in <-chan Param) {
 	for msg := range in {
 		// TODO MUST NOT PUBLISH POINTERS
-		//
-		// if val := reflect.ValueOf(msg.Val); val.Kind() == reflect.Ptr {
-		// 	if ptr := reflect.Indirect(val); ptr.IsValid() {
-		// 		msg.Val = ptr.Addr().Elem().Interface()
-		// 	}
-		// }
+
+		if val := reflect.ValueOf(msg.Val); val.Kind() == reflect.Ptr {
+			if ptr := reflect.Indirect(val); ptr.IsValid() {
+				fmt.Println("DANGER pointer value:", msg.Key)
+			}
+		}
 
 		if val, ok := (msg.Val).(api.Redactor); ok {
 			msg.Val = val.Redacted()


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/24371

This PR publishes tariff updates only if changed. Unfortunately, the published struct contains the prorated and accrued solar forecast which changes continuously. We still need to figure out how to publish incremental updates that can leave other parts of the struct unchanged.

Another low-effort optimization would be to only publish every 5 minutes.

/cc @Maschga @naltatis 