### PR TITLE
optimizer: fix first slot of homeProfile

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -392,7 +392,7 @@ func prorateFirstSlot(profile []float64, firstSlotDuration time.Duration) []floa
 
 	// Take only slots from current hour onwards
 	res := profile[firstSlot:]
-	res[0] *= float64(firstSlotDuration / tariff.SlotDuration)
+	res[0] *= float64(firstSlotDuration) / float64(tariff.SlotDuration)
 
 	return res
 }


### PR DESCRIPTION
fix prorateFirstSlot, homeProfile[0] was always set to 0.0

handcrafted and breakpoint-debugged, free of any claude :-)

(@VolkerK62 already mentioned this bug somewhere)