### PR TITLE
Forecast chart: fix solar area glitch

### DIFF
--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -433,14 +433,9 @@ export default defineComponent({
 			);
 		},
 		filterEntries(entries: TimeseriesEntry[] = []) {
-			// include 1 hour before and after
-			const start = new Date(this.startDate);
-			start.setHours(start.getHours() - 1);
-			const end = new Date(this.endDate);
-			end.setHours(end.getHours() + 1);
-
 			return entries.filter(
-				(entry) => new Date(entry.ts) >= start && new Date(entry.ts) <= end
+				(entry) =>
+					new Date(entry.ts) >= this.startDate && new Date(entry.ts) <= this.endDate
 			);
 		},
 		onMouseLeave() {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/24387

Issue was caused by items rendered outside our actual x-scale. Removed special handling. Consequence: green chart now might not start/end exactly at the chart edges, but since we're now on finer grain 15min intervals this is not a real issue any more.