### PR TITLE
Migrate meters, vehicles, chargers and loadpoints

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -120,6 +120,12 @@ func runDump(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	for id, name := range site.Meters.ExtMetersRef {
+		if name != "" {
+			d.DumpWithHeader(fmt.Sprintf("ext %d: %s", id+1, name), handle(name, config.Meters()))
+		}
+	}
+
 	for _, v := range site.Vehicles().Instances() {
 		d.DumpWithHeader(fmt.Sprintf("vehicle: %s", v.GetTitle()), v)
 	}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -49,6 +49,9 @@ func runMigrate(cmd *cobra.Command, args []string) {
 	} else {
 		settings.SetInt(keys.Interval, int64(conf.Interval))
 		settings.SetString(keys.SponsorToken, conf.SponsorToken)
+		if title, ok := conf.Site["title"].(string); ok {
+			settings.SetString(keys.Title, title)
+		}
 	}
 
 	log.INFO.Println("- network")

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -136,7 +136,7 @@ func runMigrate(cmd *cobra.Command, args []string) {
 				title = meter.Name
 			}
 			if product, ok := meter.Other["template"].(string); ok {
-				properties := config.Properties{meter.Type, title, "", product}
+				properties := config.Properties{Type: meter.Type, Title: title, Product: product}
 				cnf, err := config.AddConfig(templates.Meter, meter.Other, config.WithProperties(properties))
 				if err != nil {
 					log.WARN.Printf("migration of meter failed with error: %s", err)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/server/db"
 	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/util/config"
+	"github.com/evcc-io/evcc/util/templates"
 	"github.com/spf13/cobra"
 )
 
@@ -110,24 +114,92 @@ func runMigrate(cmd *cobra.Command, args []string) {
 		_ = settings.SetYaml(keys.Tariffs, conf.Tariffs)
 	}
 
-	log.INFO.Println("- circuits")
-	if reset {
-		settings.Delete(keys.Circuits)
-	} else if len(conf.Circuits) > 0 {
-		_ = settings.SetYaml(keys.Circuits, conf.Circuits)
-	}
-
 	log.INFO.Println("- device configs")
+	meterDbIDs := make(map[string]int) // used to migrate circuits
 	if reset {
 		// site keys
 		settings.Delete(keys.GridMeter)
 		settings.Delete(keys.PvMeters)
 		settings.Delete(keys.AuxMeters)
 		settings.Delete(keys.BatteryMeters)
+		settings.Delete(keys.ExtMeters)
 		// clear config table
 		result := db.Instance.Delete(&config.Config{}, "true")
 		log.INFO.Printf("  %d entries deleted", result.RowsAffected)
+	} else {
+		// migrate meters to devices
+		for _, meter := range conf.Meters {
+			title, ok := meter.Other["title"].(string)
+			if ok {
+				delete(meter.Other, "title")
+			} else {
+				title = meter.Name
+			}
+			if product, ok := meter.Other["template"].(string); ok {
+				properties := config.Properties{meter.Type, title, "", product}
+				cnf, err := config.AddConfig(templates.Meter, meter.Other, config.WithProperties(properties))
+				if err != nil {
+					log.WARN.Printf("migration of meter failed with error: %s", err)
+				} else {
+					meterDbIDs[meter.Name] = cnf.ID
+					log.INFO.Printf("added meter %s with ID %d to database", meter.Name, cnf.ID)
+				}
+			}
+		}
+		// migrate site meter references
+		if siteMeters, ok := conf.Site["meters"].(map[string]interface{}); ok {
+			//settings.SetString(keys.Title, title)
+			log.INFO.Printf("Site meters are: %s", siteMeters)
+			meterTypes := []string{"pv", "battery", "ext", "aux"}
+			for _, meterType := range meterTypes {
+				if meters, ck := siteMeters[meterType]; ck {
+					var dbIDs []string
+					if meterList, ok := meters.([]interface{}); ok {
+						for _, meterName := range meterList {
+							if id, found := meterDbIDs[meterName.(string)]; found {
+								dbIDs = append(dbIDs, fmt.Sprintf("db:%d", id))
+							}
+						}
+					} else {
+						if id, found := meterDbIDs[meters.(string)]; found {
+							dbIDs = append(dbIDs, fmt.Sprintf("db:%d", id))
+						} else {
+							log.WARN.Printf("meter '%s' of type '%s' not found in database", meters.(string), meterType)
+						}
+					}
+					if len(dbIDs) > 0 {
+						log.INFO.Printf("Set %sMeters to '%s'", meterType, dbIDs)
+						settings.SetString(meterType+"Meters", strings.Join(dbIDs, ","))
+					}
+				}
+			}
+			if gridMeter, ok := conf.Site["meters"].(map[string]interface{})["grid"].(string); ok {
+				if id, found := meterDbIDs[gridMeter]; found {
+					log.INFO.Printf("Set grid meter ('%s') to 'db:%d'", gridMeter, id)
+					settings.SetString(keys.GridMeter, fmt.Sprintf("db:%d", id))
+				}
+			}
+		}
 	}
+
+	log.INFO.Println("- circuits")
+	if reset {
+		settings.Delete(keys.Circuits)
+	} else if len(conf.Circuits) > 0 {
+		// migrate meter names to device references
+		for _, circuit := range conf.Circuits {
+			if m, ok := circuit.Other["meter"].(string); ok {
+				if id, found := meterDbIDs[m]; found {
+					circuit.Other["meter"] = fmt.Sprintf("db:%d", id)
+					log.INFO.Printf("circuit '%s' meter changed from '%v' to '%v'", circuit.Name, m, circuit.Other["meter"])
+				} else {
+					log.WARN.Printf("meter '%s' of circuit '%s' not found in database", m, circuit.Name)
+				}
+			}
+		}
+		_ = settings.SetYaml(keys.Circuits, conf.Circuits)
+	}
+
 	// wait for shutdown
 	<-shutdownDoneC()
 }


### PR DESCRIPTION
The migrate command does not yet migrate configured devices/objects, such as meters, chargers, load points and vehicles.
This PR addresses this issue and updates all references to the relevant database objects. Consequently, a fully functional database configuration is created, eliminating the need to recreate additional parts of the YAML configuration.

During the migration, I discovered that circuits are still implemented using YAML in the settings table, even though a circuit class is available (`templates.Circuit`).
Also, vehicle and load point titles are obtained from the JSON configuration in the configs.value column rather than the title column, unlike meters.
Chargers are always shown with their template name followed by [db:id] (e.g. 'easee [db:4]'). The title column is ignored, as is the "title" key in JSON - only the "name" key is allowed, but it is ignored.

This can be resolved through additional PRs, regardless of this migration PR.