### PR TITLE
Fix OAuth authorization callback route compatibility

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1139,6 +1139,9 @@ func configureAuth(router *mux.Router, paramC chan<- util.Param) {
 		handlers.AllowedHeaders([]string{"Content-Type"}),
 	))
 
+	// backwards-compatible revert of https://github.com/evcc-io/evcc/pull/21266
+	router.PathPrefix("/oauth").Handler(auth)
+
 	// wire the handler
 	providerauth.Setup(auth, paramC)
 }


### PR DESCRIPTION
## Summary
- Restore backward compatibility for OAuth authorization callbacks
- Route legacy `/oauth` path to the new `/providerauth` handler
- Fixes authorization buttons not triggering login after upgrade to v0.209.2

## Background
After the route change from `/oauth` to `/providerauth` in PR #21266, vehicle authorization buttons stopped working because OAuth providers still redirect to the old `/oauth` callback URL.

## Changes
- Added backward-compatible route handler in `cmd/setup.go:1142` that routes `/oauth` requests to the `/providerauth` handler
- Preserves existing functionality while supporting legacy OAuth callback URLs

## Test Plan
- [ ] Verify vehicle authorization flow works for vehicles configured before v0.209.2
- [ ] Verify new vehicle authorization still works with `/providerauth` path
- [ ] Test with Volvo EX90 and MINI vehicles (reported affected)

Fixes #24445

🤖 Generated with [Claude Code](https://claude.com/claude-code)