### PR TITLE
Änderung Standard Algorithmus Solarprognose.de

### DIFF
--- a/templates/definition/tariff/solarprognose.yaml
+++ b/templates/definition/tariff/solarprognose.yaml
@@ -37,7 +37,6 @@ params:
     description:
       en: Forecasting Algorithm (mosmix, own-v1 or clearsky)
       de: Prognosealgorithmus (mosmix, own-v1 oder clearsky)
-    default: mosmix
     advanced: true
   - name: interval
     default: 1h
@@ -48,7 +47,7 @@ render: |
   forecast:
     source: http
     # Base URL with required params (format, type, algorithm, access token), then optional item-based parameters
-    uri: https://www.solarprognose.de/web/solarprediction/api/v1?_format=json&type=hourly&algorithm={{ .algorithm }}&access-token={{ .token }}{{ if .item }}&item={{ .item }}{{ if .id }}&id={{ .id }}{{ else }}&token={{ unquote .uniquetoken }}{{ end }}{{ end }}
+    uri: https://www.solarprognose.de/web/solarprediction/api/v1?_format=json&type=hourly{{ if .algorithm }}&algorithm={{ .algorithm }}{{ end }}&access-token={{ .token }}{{ if .item }}&item={{ .item }}{{ if .id }}&id={{ .id }}{{ else }}&token={{ unquote .uniquetoken }}{{ end }}{{ end }}
     jq: |
       [ .data | to_entries.[] | {
         "start": (.key | tonumber | strftime("%FT%TZ") ),


### PR DESCRIPTION
Bisher wurde als Standard Algorithmus mosmix ausgewählt. Da dieser jedoch nicht überall verfügbar ist, habe ich den Standardwert herausgenommen und das Feld als optional in die URL aufgenommen.

Ist meine erster PR, hoffe das passt so alles!