### PR TITLE
chore: use uniform uppercase of SENEC

### DIFF
--- a/templates/definition/charger/senec-plus.yaml
+++ b/templates/definition/charger/senec-plus.yaml
@@ -1,6 +1,6 @@
 template: senec-plus
 products:
-  - brand: Senec
+  - brand: SENEC
     description:
       generic: Plus
 capabilities: ["mA", "1p3p"]

--- a/templates/definition/charger/senec-premium.yaml
+++ b/templates/definition/charger/senec-premium.yaml
@@ -1,6 +1,6 @@
 template: senec-premium
 products:
-  - brand: Senec
+  - brand: SENEC
     description:
       generic: Premium
 capabilities: ["mA", "rfid", "1p3p"]


### PR DESCRIPTION
The casing was not uniform. Results into two sections in the doc https://docs.evcc.io/en/docs/devices/chargers#senec and https://docs.evcc.io/en/docs/devices/chargers#senec-1

Unsure if it should be upper- or lowercase.

The place of the uppercase SENEC
https://github.com/evcc-io/evcc/blob/ae68505bd2aa4348067dfc0b3a4556a74dec1b60/templates/definition/charger/heidelberg.yaml#L6

https://github.com/evcc-io/evcc/blob/a40a1575b8e11db4fb5bc5346038e905ef274a08/templates/definition/meter/senec-home.yaml#L3