### PR TITLE
Loadpoint: don't validate currents for heating devices with external meter

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -781,7 +781,7 @@ func (lp *Loadpoint) syncCharger() error {
 		if !isCg || errors.Is(err, api.ErrNotAvailable) {
 			// validate if current too high by more than 1A (https://github.com/evcc-io/evcc/issues/14731)
 			if current := lp.GetMaxPhaseCurrent(); current > lp.offeredCurrent+1.0 {
-				if shouldBeConsistent {
+				if shouldBeConsistent && !lp.chargerHasFeature(api.Heating) {
 					lp.log.WARN.Printf("charger logic error: current mismatch (got %.3gA measured, expected %.3gA) - make sure your interval is at least 30s", current, lp.offeredCurrent)
 				}
 				lp.offeredCurrent = current

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -607,7 +607,8 @@ func (lp *Loadpoint) GetChargePowerFlexibility(rates api.Rates) float64 {
 	return max(0, lp.GetChargePower()-lp.EffectiveMinPower())
 }
 
-// GetMaxPhaseCurrent returns the current charge power
+// GetMaxPhaseCurrent returns the maximum charge current per phase or- if not available-
+// the offered current from either charger or charge meter
 func (lp *Loadpoint) GetMaxPhaseCurrent() float64 {
 	lp.RLock()
 	defer lp.RUnlock()


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/24382#issuecomment

Most, if not any, heating devices are not current-controlled. An internal meter would typically also not return currents. An external might do so. With this PR, we're ignoring current measurements from external meters for heating devices.