### PR TITLE
Hyundai/Kia: Updated link for refresh token documentation

### DIFF
--- a/templates/definition/vehicle/hyundai.yaml
+++ b/templates/definition/vehicle/hyundai.yaml
@@ -6,11 +6,11 @@ products:
 requirements:
   description:
     en: |
-      Instead of your account's password, the password field needs to be filled with a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh%E2%80%90Token-ermitteln#english-version)).  
+      Instead of your account's password, the password field needs to be filled with a `refresh_token` ([instructions](https://gist.github.com/RustyDust/e2a7be978affd85fb5ef5a345f31f67a)).  
         
       Some models (e.g. Kona) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: |
-      Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh%E2%80%90Token-ermitteln)).  
+      Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://gist.github.com/RustyDust/e2a7be978affd85fb5ef5a345f31f67a)).  
         
       Manche Modelle (z.B. Kona) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -6,11 +6,11 @@ products:
 requirements:
   description:
     en: |
-      Instead of your account's password, the password field needs to be filled with a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh%E2%80%90Token-ermitteln#english-version)).  
+      Instead of your account's password, the password field needs to be filled with a `refresh_token` ([instructions](https://gist.github.com/RustyDust/e2a7be978affd85fb5ef5a345f31f67a)).  
         
       Some models (e.g. Niro EV) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: |
-      Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh%E2%80%90Token-ermitteln)).  
+      Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://gist.github.com/RustyDust/e2a7be978affd85fb5ef5a345f31f67a)).  
         
       Manche Modelle (z.B. Niro EV) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:


### PR DESCRIPTION
Updated the link in the Hyundai and Kia templates to point to the better documentation from @RustyDust instead of the grown and complex documentation from the EVCC Wiki at https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh%E2%80%90Token-ermitteln