### PR TITLE
Optimizer: added minsoc/maxsoc to Fronius GEN24 template

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -31,10 +31,8 @@ params:
   - name: capacity
     advanced: true
   - name: minsoc
-    type: int
     advanced: true
   - name: maxsoc
-    type: int
     advanced: true
 render: |
   type: custom

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -30,6 +30,12 @@ params:
     advanced: true
   - name: capacity
     advanced: true
+  - name: minsoc
+    type: int
+    advanced: true
+  - name: maxsoc
+    type: int
+    advanced: true
 render: |
   type: custom
   # sunspec model 20x (int+sf)/ 21x (float) meter
@@ -245,4 +251,6 @@ render: |
             id: 1
             value: 124:0:OutWRte
   capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }} # %
+  maxsoc: {{ .maxsoc }} # %
   {{- end }}


### PR DESCRIPTION
This PR adds minimum and maximum state of charge (minsoc/maxsoc) parameters to the Fronius GEN24 template for the battery configuration, so that the optimizer can properly take them into account.