### PR TITLE
chore: depot > gh action runners; AWS outage

### DIFF
--- a/.github/workflows/_claude-issue-triage.yml_
+++ b/.github/workflows/_claude-issue-triage.yml_
@@ -6,7 +6,8 @@ on:
 
 jobs:
   triage-issue:
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   clean:
     name: Clean
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -50,7 +51,8 @@ jobs:
 
   build:
     name: Build
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -88,7 +90,8 @@ jobs:
 
   test:
     name: Test
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -119,7 +122,8 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -161,7 +165,8 @@ jobs:
     permissions:
       contents: read
       actions: write
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v5
@@ -203,7 +208,8 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: depot-ubuntu-24.04-arm-16
+    # runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/docs-issue.yml
+++ b/.github/workflows/docs-issue.yml
@@ -10,7 +10,8 @@ on:
 
 jobs:
   check-label-and-create-issue:
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == true && github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name
     steps:
       - name: Check for 'needs documentation' label

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   docupdate:
     name: Deploy updated templates
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   check_date:
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     name: Check latest commit
 
     permissions:
@@ -45,7 +46,8 @@ jobs:
     name: Publish Docker :nightly
     needs:
       - call-build-workflow
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -105,7 +107,8 @@ jobs:
     name: Hassio Addon :nightly
     needs:
       - docker
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -137,7 +140,8 @@ jobs:
     name: Publish APT nightly
     needs:
       - call-build-workflow
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -167,7 +171,7 @@ jobs:
       - name: Create nightly build
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: '~> v2'
+          version: "~> v2"
           args: --snapshot -f .goreleaser-nightly.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
     name: Publish Docker :release
     needs:
       - call-build-workflow
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
@@ -60,7 +61,8 @@ jobs:
     name: Github & APT
     needs:
       - call-build-workflow
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write
@@ -105,7 +107,7 @@ jobs:
       - name: Create Github Release
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: '~> v2'
+          version: "~> v2"
           args: release --clean
         env:
           # use RELEASE_DEPLOY_TOKEN for access to evcc-io/homebrew-tap
@@ -127,7 +129,8 @@ jobs:
     name: Demo
     needs:
       - docker
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -145,7 +148,8 @@ jobs:
     name: Hassio Addon
     needs:
       - docker
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   brandupdate:
     name: Deploy data to website
-    runs-on: depot-ubuntu-24.04-arm
+    # runs-on: depot-ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read


### PR DESCRIPTION
AWS outage affects our Depot Github Runners
https://status.depot.dev

Temporary switch back to native Github runners. Revert when Depot is stable again.