### PR TITLE
Extend InfluxDB meter title support to meters

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -62,6 +62,8 @@ type measurement struct {
 	Controllable  *bool     `json:"controllable,omitempty"`
 }
 
+var _ api.TitleDescriber = (*measurement)(nil)
+
 // GetTitle implements api.TitleDescriber interface for InfluxDB tagging
 func (m measurement) GetTitle() string {
 	return m.Title

--- a/core/site.go
+++ b/core/site.go
@@ -62,6 +62,11 @@ type measurement struct {
 	Controllable  *bool     `json:"controllable,omitempty"`
 }
 
+// GetTitle implements api.TitleDescriber interface for InfluxDB tagging
+func (m measurement) GetTitle() string {
+	return m.Title
+}
+
 var _ site.API = (*Site)(nil)
 
 // Site is the main configuration container. A site can host multiple loadpoints.

--- a/server/influxdb.go
+++ b/server/influxdb.go
@@ -139,18 +139,17 @@ func (m *Influx) writeComplexPoint(writer pointWriter, key string, val any, tags
 			// loop slice
 			for i := range val.Len() {
 				// clone tags to prevent leakage between elements
-				elementTags := make(map[string]string, len(tags)+2)
-				maps.Copy(elementTags, tags)
-				elementTags["id"] = strconv.Itoa(i + 1)
+				tags := maps.Clone(tags)
+				tags["id"] = strconv.Itoa(i + 1)
 
-				elemValue := val.Index(i)
+				ival := val.Index(i)
 				// Check if element provides a title
-				if tp, ok := reflect.TypeAssert[api.TitleDescriber](elemValue); ok {
+				if tp, ok := reflect.TypeAssert[api.TitleDescriber](ival); ok {
 					if title := tp.GetTitle(); title != "" {
-						elementTags["title"] = title
+						tags["title"] = title
 					}
 				}
-				m.writeComplexPoint(writer, key, elemValue.Interface(), elementTags)
+				m.writeComplexPoint(writer, key, ival.Interface(), tags)
 			}
 			return
 		}


### PR DESCRIPTION
Add support for title tagging on meters, enhancing data organization and querying capabilities in InfluxDB while maintaining backward compatibility. Introduce helper functions for meter title checks and ensure proper title handling during data processing. 