### PR TITLE
Config UI: handle breaking changes in templates

### DIFF
--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -105,10 +105,6 @@ func deviceConfigMap[T any](class templates.Class, dev config.Device[T]) (map[st
 			if err != nil {
 				return nil, err
 			}
-			params, err = filterValidTemplateParams(class, params)
-			if err != nil {
-				return nil, err
-			}
 			dc["config"] = params
 		} else {
 			// custom device, no masking

--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -101,8 +101,11 @@ func deviceConfigMap[T any](class templates.Class, dev config.Device[T]) (map[st
 		}
 
 		if conf.Type == typeTemplate {
-			// template device, mask config
 			params, err := sanitizeMasked(class, conf.Other)
+			if err != nil {
+				return nil, err
+			}
+			params, err = filterValidTemplateParams(class, params)
 			if err != nil {
 				return nil, err
 			}

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -43,15 +43,13 @@ type configReq struct {
 
 func init() {
 	for _, f := range structs.Fields(config.Properties{}) {
+		prop := f.Name()
 		if tag := f.Tag("json"); tag != "" {
-			// Use JSON tag name (before comma)
-			if name, _, _ := strings.Cut(tag, ","); name != "" {
-				defaultTemplateProperties = append(defaultTemplateProperties, name)
+			if name := strings.Split(tag, ",")[0]; name != "" {
+				prop = name
 			}
-		} else {
-			// No JSON tag, use lowercase field name
-			defaultTemplateProperties = append(defaultTemplateProperties, strings.ToLower(f.Name()))
 		}
+		defaultTemplateProperties = append(defaultTemplateProperties, prop)
 	}
 }
 

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -43,7 +43,15 @@ type configReq struct {
 
 func init() {
 	for _, f := range structs.Fields(config.Properties{}) {
-		defaultTemplateProperties = append(defaultTemplateProperties, strings.ToLower(f.Name()))
+		if tag := f.Tag("json"); tag != "" {
+			// Use JSON tag name (before comma)
+			if name, _, _ := strings.Cut(tag, ","); name != "" {
+				defaultTemplateProperties = append(defaultTemplateProperties, name)
+			}
+		} else {
+			// No JSON tag, use lowercase field name
+			defaultTemplateProperties = append(defaultTemplateProperties, strings.ToLower(f.Name()))
+		}
 	}
 }
 

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -16,7 +16,6 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/templates"
-	"github.com/fatih/structs"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/samber/lo"
 	"go.yaml.in/yaml/v4"
@@ -29,28 +28,12 @@ const (
 
 var (
 	customTypes = []string{"custom", "template", "heatpump", "switchsocket", "sgready", "sgready-boost"}
-
-	// defaultTemplateProperties are general template configuration properties (id, name, templates) and
-	// config.Properties members and preserved for all templates independent of their params
-	defaultTemplateProperties = []string{"id", "name", "template"}
 )
 
 type configReq struct {
 	config.Properties `json:",inline" mapstructure:",squash"`
 	Yaml              string
 	Other             map[string]any `json:",inline" mapstructure:",remain"`
-}
-
-func init() {
-	for _, f := range structs.Fields(config.Properties{}) {
-		prop := f.Name()
-		if tag := f.Tag("json"); tag != "" {
-			if name := strings.Split(tag, ",")[0]; name != "" {
-				prop = name
-			}
-		}
-		defaultTemplateProperties = append(defaultTemplateProperties, prop)
-	}
 }
 
 // TODO get rid of this 2-pass unmarshal once https://github.com/golang/go/issues/71497 is implemented
@@ -128,7 +111,7 @@ func filterValidTemplateParams(tmpl *templates.Template, conf map[string]any) ma
 	res := make(map[string]any)
 
 	for k, v := range conf {
-		if slices.Contains(defaultTemplateProperties, k) {
+		if k == "template" {
 			res[k] = v
 			continue
 		}

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -29,8 +29,8 @@ const (
 var (
 	customTypes = []string{"custom", "template", "heatpump", "switchsocket", "sgready", "sgready-boost"}
 
-	// specialConfigFields are always preserved during template param filtering
-	specialConfigFields = []string{"template", "type", "name", "id", "usage", "modbus", "title", "icon"}
+	// generalTemplateFields are preserved for all templates independent of their params
+	generalTemplateFields = []string{"template", "type", "name", "id", "title", "icon"}
 )
 
 type configReq struct {
@@ -138,7 +138,7 @@ func filterValidTemplateParams(class templates.Class, conf map[string]any) (map[
 	res := make(map[string]any)
 
 	for k, v := range conf {
-		if slices.Contains(specialConfigFields, k) {
+		if slices.Contains(generalTemplateFields, k) {
 			res[k] = v
 			continue
 		}
@@ -167,19 +167,7 @@ func mergeMasked(class templates.Class, conf, old map[string]any) (map[string]an
 		res[k] = v
 	}
 
-	filtered := make(map[string]any)
-	for k, v := range res {
-		if slices.Contains(specialConfigFields, k) {
-			filtered[k] = v
-			continue
-		}
-
-		if i, _ := tmpl.ParamByName(k); i >= 0 {
-			filtered[k] = v
-		}
-	}
-
-	return filtered, nil
+	return filterValidTemplateParams(class, res)
 }
 
 func startDeviceTimeout() (context.Context, context.CancelFunc, chan struct{}) {

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -30,8 +30,9 @@ const (
 var (
 	customTypes = []string{"custom", "template", "heatpump", "switchsocket", "sgready", "sgready-boost"}
 
-	// configPropertiesFields are preserved for all templates independent of their params
-	configPropertiesFields = []string{"id", "name"}
+	// defaultTemplateProperties are general template configuration properties (id, name, templates) and
+	// config.Properties members and preserved for all templates independent of their params
+	defaultTemplateProperties = []string{"id", "name", "template"}
 )
 
 type configReq struct {
@@ -42,7 +43,7 @@ type configReq struct {
 
 func init() {
 	for _, f := range structs.Fields(config.Properties{}) {
-		configPropertiesFields = append(configPropertiesFields, strings.ToLower(f.Name()))
+		defaultTemplateProperties = append(defaultTemplateProperties, strings.ToLower(f.Name()))
 	}
 }
 
@@ -121,7 +122,7 @@ func filterValidTemplateParams(tmpl *templates.Template, conf map[string]any) ma
 	res := make(map[string]any)
 
 	for k, v := range conf {
-		if slices.Contains(configPropertiesFields, k) {
+		if slices.Contains(defaultTemplateProperties, k) {
 			res[k] = v
 			continue
 		}

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/templates"
+	"github.com/fatih/structs"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/samber/lo"
 	"go.yaml.in/yaml/v4"
@@ -29,14 +30,20 @@ const (
 var (
 	customTypes = []string{"custom", "template", "heatpump", "switchsocket", "sgready", "sgready-boost"}
 
-	// generalTemplateFields are preserved for all templates independent of their params
-	generalTemplateFields = []string{"template", "type", "name", "id", "title", "icon"}
+	// configPropertiesFields are preserved for all templates independent of their params
+	configPropertiesFields = []string{"id", "name"}
 )
 
 type configReq struct {
 	config.Properties `json:",inline" mapstructure:",squash"`
 	Yaml              string
 	Other             map[string]any `json:",inline" mapstructure:",remain"`
+}
+
+func init() {
+	for _, f := range structs.Fields(config.Properties{}) {
+		configPropertiesFields = append(configPropertiesFields, strings.ToLower(f.Name()))
+	}
 }
 
 // TODO get rid of this 2-pass unmarshal once https://github.com/golang/go/issues/71497 is implemented
@@ -114,7 +121,7 @@ func filterValidTemplateParams(tmpl *templates.Template, conf map[string]any) ma
 	res := make(map[string]any)
 
 	for k, v := range conf {
-		if slices.Contains(generalTemplateFields, k) {
+		if slices.Contains(configPropertiesFields, k) {
 			res[k] = v
 			continue
 		}

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -134,3 +134,47 @@ func TestSquashedMergeMaskedAny(t *testing.T) {
 		assert.Equal(t, "new", new.User)
 	}
 }
+
+func TestMergeMaskedFiltersBehavior(t *testing.T) {
+	conf := map[string]any{
+		"template": "generic",
+		"power":    200.0,
+	}
+
+	old := map[string]any{
+		"template":      "generic",
+		"power":         100.0,
+		"outdatedField": "old-value",
+	}
+
+	result, err := mergeMasked(0, conf, old)
+
+	if err != nil {
+		t.Skip("template not available in test, integration test covers full scenario")
+	}
+
+	assert.Equal(t, 200.0, result["power"])
+	assert.Equal(t, "generic", result["template"])
+	assert.NotContains(t, result, "outdatedField")
+}
+
+func TestFilterValidTemplateParams(t *testing.T) {
+	conf := map[string]any{
+		"template":      "generic",
+		"usage":         "grid",
+		"capacity":      50.0,
+		"power":         100.0,
+		"outdatedField": "should-be-removed",
+	}
+
+	result, err := filterValidTemplateParams(0, conf)
+
+	if err != nil {
+		t.Skip("template not available in test, integration test covers full scenario")
+	}
+
+	assert.Equal(t, "generic", result["template"])
+	assert.Equal(t, "grid", result["usage"])
+	assert.NotContains(t, result, "outdatedField")
+}
+

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -177,4 +177,3 @@ func TestFilterValidTemplateParams(t *testing.T) {
 	assert.Equal(t, "grid", result["usage"])
 	assert.NotContains(t, result, "outdatedField")
 }
-

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evcc-io/evcc/api/globalconfig"
 	"github.com/evcc-io/evcc/plugin/mqtt"
 	"github.com/evcc-io/evcc/util/config"
+	"github.com/evcc-io/evcc/util/templates"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -167,13 +168,17 @@ func TestFilterValidTemplateParams(t *testing.T) {
 		"outdatedField": "should-be-removed",
 	}
 
-	result, err := filterValidTemplateParams(0, conf)
+	result := filterValidTemplateParams(&templates.Template{
+		TemplateDefinition: templates.TemplateDefinition{
+			Params: []templates.Param{
+				{Name: "usage"},
+				{Name: "power"},
+				{Name: "capacity"},
+			},
+		},
+	}, conf)
 
-	if err != nil {
-		t.Skip("template not available in test, integration test covers full scenario")
-	}
-
-	assert.Equal(t, "generic", result["template"])
-	assert.Equal(t, "grid", result["usage"])
+	assert.Equal(t, "generic", result["template"], "template")
+	assert.Equal(t, "grid", result["usage"], "usage")
 	assert.NotContains(t, result, "outdatedField")
 }

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -138,15 +138,13 @@ func TestSquashedMergeMaskedAny(t *testing.T) {
 
 func TestMergeMaskedFiltersBehavior(t *testing.T) {
 	conf := map[string]any{
-		"template":    "demo-meter",
-		"power":       200.0,
-		"deviceTitle": "Demo!",
+		"template": "demo-meter",
+		"power":    200.0,
 	}
 
 	old := map[string]any{
 		"template":      "demo-meter",
 		"power":         100.0,
-		"deviceTitle":   "Old Title",
 		"outdatedField": "old-value",
 	}
 
@@ -154,7 +152,6 @@ func TestMergeMaskedFiltersBehavior(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 200.0, result["power"])
-	assert.Equal(t, "Demo!", result["deviceTitle"])
 	assert.Equal(t, "demo-meter", result["template"])
 	assert.NotContains(t, result, "outdatedField")
 }

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -138,24 +138,24 @@ func TestSquashedMergeMaskedAny(t *testing.T) {
 
 func TestMergeMaskedFiltersBehavior(t *testing.T) {
 	conf := map[string]any{
-		"template": "generic",
-		"power":    200.0,
+		"template":    "demo-meter",
+		"power":       200.0,
+		"deviceTitle": "Demo!",
 	}
 
 	old := map[string]any{
-		"template":      "generic",
+		"template":      "demo-meter",
 		"power":         100.0,
+		"deviceTitle":   "Old Title",
 		"outdatedField": "old-value",
 	}
 
-	result, err := mergeMasked(0, conf, old)
-
-	if err != nil {
-		t.Skip("template not available in test, integration test covers full scenario")
-	}
+	result, err := mergeMasked(templates.Meter, conf, old)
+	require.NoError(t, err)
 
 	assert.Equal(t, 200.0, result["power"])
-	assert.Equal(t, "generic", result["template"])
+	assert.Equal(t, "Demo!", result["deviceTitle"])
+	assert.Equal(t, "demo-meter", result["template"])
 	assert.NotContains(t, result, "outdatedField")
 }
 

--- a/tests/config-invalid-template.spec.ts
+++ b/tests/config-invalid-template.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, restart, baseUrl } from "./evcc";
+import { expectModalVisible, expectModalHidden, enableExperimental } from "./utils";
+
+const CONFIG_INVALID_TEMPLATE = "config-invalid-template.sql";
+
+test.use({ baseURL: baseUrl() });
+
+test.afterEach(async () => {
+  await stop();
+});
+
+test.describe("invalid template migration", async () => {
+  test("fix broken grid meter with outdated field", async ({ page }) => {
+    await start(undefined, CONFIG_INVALID_TEMPLATE);
+
+    await page.goto("/#/config");
+    await enableExperimental(page, false);
+
+    // startup error
+    await expect(page.getByTestId("fatal-error")).toBeVisible();
+    await expect(page.getByTestId("fatal-error")).toContainText("invalid key: power_old");
+    await expect(page.getByTestId("grid")).toBeVisible();
+
+    // edit and save broken meter
+    await page.getByTestId("grid").getByRole("button", { name: "edit" }).click();
+    const meterModal = page.getByTestId("meter-modal");
+    await expectModalVisible(meterModal);
+    await expect(meterModal.getByLabel("Manufacturer")).toHaveValue("Demo meter");
+    await meterModal.getByLabel("Power").fill("222");
+    await meterModal.getByRole("button", { name: "Validate & save" }).click();
+    await expectModalHidden(meterModal);
+    await expect(page.getByTestId("grid")).toBeVisible();
+
+    // verify restart
+    await restart();
+    await page.reload();
+    await expect(page.getByTestId("fatal-error")).not.toBeVisible();
+    await expect(page.getByTestId("grid")).toBeVisible();
+    await page.getByTestId("grid").getByRole("button", { name: "edit" }).click();
+    await expectModalVisible(meterModal);
+    await expect(meterModal.getByLabel("Power")).toHaveValue("222");
+    await meterModal.getByRole("button", { name: "Close" }).click();
+    await expectModalHidden(meterModal);
+  });
+});

--- a/tests/config-invalid-template.sql
+++ b/tests/config-invalid-template.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+CREATE TABLE `configs` (
+    `id` integer PRIMARY KEY AUTOINCREMENT
+  , `class` integer
+  , `type` text
+  , `title` text
+  , `icon` text
+  , `product` text
+  , `value` text
+);
+CREATE TABLE `settings` (
+    `key` text
+  , `value` text
+  , PRIMARY KEY(`key`)
+);
+
+INSERT INTO configs(id, class, type, title, icon, product, value) VALUES(1, 2, 'template', '', '', 'Demo meter', '{"maxacpower":"0","power_old":222,"template":"demo-meter","usage":"grid"}');
+INSERT INTO settings("key", value) VALUES('gridMeter', 'db:1');
+
+COMMIT;


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/discussions/24543

A breaking change in a template definition (e.g. field rename `power_old` > `power`) will lead to an evcc startup error. This error was not fixable via UI. This PR changes this.

✂️ GET device endpoint only returns known template fields
💽 PUT only merges known fields when updated an entry (before existing fields were never removed)
🔬 added e2e test case