### PR TITLE
fix modbus fox-ess-h3-smart

### DIFF
--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -30,31 +30,31 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 38817 # Meter Power R
+        address: 38816 # Meter Power R
         type: holding
-        decode: int16
+        decode: int32
       scale: -0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 38819 # Meter Power S
+        address: 38818 # Meter Power S
         type: holding
-        decode: int16
+        decode: int32
       scale: -0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 38821 # Meter Power T
+        address: 38820 # Meter Power T
         type: holding
-        decode: int16
+        decode: int32
       scale: -0.1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 39618 # Grid Consumption Total
+      address: 39617 # Grid Consumption Total
       type: holding
-      decode: uint16
+      decode: uint32
     scale: 0.01
   {{- end }}
   {{- if eq .usage "pv" }}
@@ -64,39 +64,39 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 39280 # PV1
+        address: 39279 # PV1
         type: holding
-        decode: int16
+        decode: int32
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 39282 # PV2
+        address: 39281 # PV2
         type: holding
-        decode: int16
+        decode: int32
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 39284 # PV3
+        address: 39283 # PV3
         type: holding
-        decode: int16
+        decode: int32
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 39286 # PV4
+        address: 39285 # PV4
         type: holding
-        decode: int16
+        decode: int32
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 39288 # PV5
+        address: 39287 # PV5
         type: holding
-        decode: int16
+        decode: int32
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 39290 # PV6
+        address: 39289 # PV6
         type: holding
-        decode: int16
+        decode: int32
   maxacpower: {{ .maxacpower }}
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -104,9 +104,9 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 39238 # Battery Charge/Discharge
+      address: 39237 # Battery Charge/Discharge
       type: holding
-      decode: int16
+      decode: int32
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -2,7 +2,7 @@ template: fox-ess-h3-smart
 products:
   - brand: FoxESS
     description:
-      generic: H3-Smart Series Hybrid Inverter
+      generic: H3-Pro/Smart Series Hybrid Inverter
 capabilities: ["battery-control"]
 params:
   - name: usage


### PR DESCRIPTION
fix #22668 

~~Test steht noch aus~~
https://github.com/evcc-io/evcc/discussions/24234#discussioncomment-14741606

Register sind jetzt mit denen der HA-Integration identisch.
Zwei positive Testfeedbacks.