### PR TITLE
EEBus meter: use standard config (BC)

### DIFF
--- a/templates/definition/meter/eebus-mcp.yaml
+++ b/templates/definition/meter/eebus-mcp.yaml
@@ -1,8 +1,8 @@
 template: eebus-mcp
 products:
   - description:
-      de: "EEBus: Verbraucher"
-      en: "EEBus: consumer"
+      de: "EEBus Verbraucher"
+      en: "EEBus Consumer"
 group: generic
 requirements:
   description:
@@ -12,19 +12,7 @@ requirements:
 params:
   - name: usage
     choice: ["charge"]
-  - name: ski
-    description:
-      en: SKI (Subject Key Identifier)
-      de: SKI (Subject Key Identifier)
-  - name: host
-    required: false
-    help:
-      en: If not specified, the device will be discovered automatically via mDNS.
-      de: Falls nicht angegeben, wird das Gerät automatisch über mDNS gefunden.
+  - preset: eebus
 render: |
-  type: eebus
-  ski: {{ .ski }}
-  {{- if .host }}
-  ip: {{ .host }}
-  {{- end }}
+  {{ include "eebus" . }}
   usage: {{ .usage }}

--- a/templates/definition/meter/eebus-mgcp.yaml
+++ b/templates/definition/meter/eebus-mgcp.yaml
@@ -1,8 +1,8 @@
 template: eebus-mgcp
 products:
   - description:
-      de: "EEBus: Netzanschlusspunkt"
-      en: "EEBus: grid connection point"
+      de: "EEBus Netzanschlusspunkt"
+      en: "EEBus Grid Connection Point"
 group: generic
 requirements:
   description:
@@ -12,19 +12,7 @@ requirements:
 params:
   - name: usage
     choice: ["grid"]
-  - name: ski
-    description:
-      en: SKI (Subject Key Identifier)
-      de: SKI (Subject Key Identifier)
-  - name: host
-    required: false
-    help:
-      en: If not specified, the device will be discovered automatically via mDNS.
-      de: Falls keine Angabe, wird das Gerät automatisch über mDNS gefunden.
+  - preset: eebus
 render: |
-  type: eebus
-  ski: {{ .ski }}
-  {{- if .host }}
-  ip: {{ .host }}
-  {{- end }}
+  {{ include "eebus" . }}
   usage: {{ .usage }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/24623, fix https://github.com/evcc-io/evcc/issues/24624.

Regarding https://github.com/evcc-io/evcc/issues/24624 the naming is still bad. Now we have "demo meter" but "eebus consumer". The difference is not obvious and confusing.

/cc @naltatis 