### PR TITLE
Hardy-Barth Salia: Set cutoff Point for new behavior at 2.3.64

### DIFF
--- a/charger/hardybarth-salia.go
+++ b/charger/hardybarth-salia.go
@@ -45,7 +45,7 @@ type Salia struct {
 	log     *util.Logger
 	uri     string
 	current int64
-	fw      int // 2 if fw 2.0 3 if fw >= 2.3.0
+	fw      int // 2 if fw 2.0 3 if fw >= 2.3.64 (oldest firmware we seen with the new behavior)
 	apiG    util.Cacheable[salia.Api]
 }
 
@@ -116,7 +116,7 @@ func NewSalia(ctx context.Context, uri, user, password string, cache time.Durati
 		wb.fw = 2
 	}
 
-	if v.GreaterThanOrEqual(version.Must(version.NewSemver("2.3.0"))) {
+	if v.GreaterThanOrEqual(version.Must(version.NewSemver("2.3.64"))) {
 		wb.fw = 3
 	}
 


### PR DESCRIPTION
Set cutoff Point for Hardybarth at 2.3.64 oldest Firmware we have seen with the new behavior

fixes: https://github.com/evcc-io/evcc/issues/24615