### PR TITLE
chore: escape doc templates

### DIFF
--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -59,7 +59,7 @@ product:
   brand: {{ quote .ProductBrand }}
 {{- end }}
 {{- if .ProductDescription }}
-  description: "{{ .ProductDescription }}"
+  description: {{ quote .ProductDescription }}
 {{- end }}
 {{- if .ProductGroup }}
   group: {{ .ProductGroup }}

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -56,10 +56,10 @@ template: {{ .Template }}
 product:
   identifier: {{ .ProductIdentifier }}
 {{- if .ProductBrand }}
-  brand: {{ .ProductBrand }}
+  brand: "{{ .ProductBrand }}"
 {{- end }}
 {{- if .ProductDescription }}
-  description: {{ .ProductDescription }}
+  description: "{{ .ProductDescription }}"
 {{- end }}
 {{- if .ProductGroup }}
   group: {{ .ProductGroup }}

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -56,7 +56,7 @@ template: {{ .Template }}
 product:
   identifier: {{ .ProductIdentifier }}
 {{- if .ProductBrand }}
-  brand: "{{ .ProductBrand }}"
+  brand: {{ quote .ProductBrand }}
 {{- end }}
 {{- if .ProductDescription }}
   description: "{{ .ProductDescription }}"


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/24647#event-20434304186

ensure brand and description are escaped in generated doc templates to avoid rendering issues like this
https://github.com/evcc-io/docs/actions/runs/18735746775/job/53441878607#step:5:84