### PR TITLE
Update kostal-plenticore-gen2.yaml

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -84,7 +84,17 @@ render: |
     {{- include "modbus" . | indent 2 }}
     value: 802:SoC # 802 battery control
   minsoc: {{ .minsoc }} # %
-  maxsoc: {{ .maxsoc }} # %
+  maxsoc: {{ .maxsoc }} # %	
+  limitsoc:
+    source: watchdog
+    timeout: {{ .watchdog }} # re-write at timeout/2
+    set:
+      source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 1042 # limit soc
+        type: writemultiple
+        encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
   batterymode:
     source: watchdog
     timeout: {{ .watchdog }} # re-write at timeout/2


### PR DESCRIPTION
add limitsoc to set minSoc for home battery with new gen2-kostal template as in the old one