### PR TITLE
chore: simplify repeating plans

### DIFF
--- a/api/plans.go
+++ b/api/plans.go
@@ -1,6 +1,6 @@
 package api
 
-type RepeatingPlanStruct struct {
+type RepeatingPlan struct {
 	Weekdays     []int  `json:"weekdays"`     // 0-6 (Sunday-Saturday)
 	Time         string `json:"time"`         // HH:MM
 	Tz           string `json:"tz"`           // timezone in IANA format

--- a/assets/js/components/ChargingPlans/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlans/ChargingPlan.vue
@@ -301,7 +301,7 @@ export default defineComponent({
 			}
 		},
 		updateRepeatingPlans(plans: RepeatingPlan[]): void {
-			api.post(`${this.apiVehicle}plan/repeating`, { plans });
+			api.post(`${this.apiVehicle}plan/repeating`, plans);
 		},
 		setMinSoc(soc: number): void {
 			api.post(`${this.apiVehicle}minsoc/${soc}`);

--- a/assets/js/components/ChargingPlans/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlans/ChargingPlan.vue
@@ -181,7 +181,11 @@ export default defineComponent({
 			return null;
 		},
 		repeatingPlans(): RepeatingPlan[] {
-			if (this.vehicle && this.vehicle.repeatingPlans.length > 0) {
+			if (
+				this.vehicle &&
+				this.vehicle.repeatingPlans &&
+				this.vehicle.repeatingPlans.length > 0
+			) {
 				return [...this.vehicle.repeatingPlans];
 			}
 			return [];

--- a/assets/js/components/ChargingPlans/types.d.ts
+++ b/assets/js/components/ChargingPlans/types.d.ts
@@ -13,7 +13,7 @@ export interface PlanWrapper {
   planId: number;
   planTime: Date;
   duration: number;
-  plan: Rate[];
+  plan: Rate[] | null;
   power: number;
 }
 

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -375,7 +375,7 @@ export interface Vehicle {
   minSoc?: number;
   limitSoc?: number;
   plan?: StaticPlan;
-  repeatingPlans: RepeatingPlan[];
+  repeatingPlans: RepeatingPlan[] | null;
   title: string;
   features?: string[];
   capacity?: number;

--- a/core/site_vehicles.go
+++ b/core/site_vehicles.go
@@ -19,18 +19,18 @@ type planStruct struct {
 }
 
 type vehicleStruct struct {
-	Title          string                    `json:"title"`
-	Icon           string                    `json:"icon,omitempty"`
-	Capacity       float64                   `json:"capacity,omitempty"`
-	Phases         int                       `json:"phases,omitempty"`
-	MinSoc         int                       `json:"minSoc,omitempty"`
-	LimitSoc       int                       `json:"limitSoc,omitempty"`
-	MinCurrent     float64                   `json:"minCurrent,omitempty"`
-	MaxCurrent     float64                   `json:"maxCurrent,omitempty"`
-	Priority       int                       `json:"priority,omitempty"`
-	Features       []string                  `json:"features,omitempty"`
-	Plan           *planStruct               `json:"plan,omitempty"`
-	RepeatingPlans []api.RepeatingPlanStruct `json:"repeatingPlans"`
+	Title          string              `json:"title"`
+	Icon           string              `json:"icon,omitempty"`
+	Capacity       float64             `json:"capacity,omitempty"`
+	Phases         int                 `json:"phases,omitempty"`
+	MinSoc         int                 `json:"minSoc,omitempty"`
+	LimitSoc       int                 `json:"limitSoc,omitempty"`
+	MinCurrent     float64             `json:"minCurrent,omitempty"`
+	MaxCurrent     float64             `json:"maxCurrent,omitempty"`
+	Priority       int                 `json:"priority,omitempty"`
+	Features       []string            `json:"features,omitempty"`
+	Plan           *planStruct         `json:"plan,omitempty"`
+	RepeatingPlans []api.RepeatingPlan `json:"repeatingPlans"`
 }
 
 // publishVehicles returns a list of vehicle titles

--- a/core/vehicle/adapter.go
+++ b/core/vehicle/adapter.go
@@ -142,5 +142,5 @@ func (v *adapter) GetRepeatingPlans() []api.RepeatingPlan {
 		return plans
 	}
 
-	return []api.RepeatingPlan{}
+	return nil
 }

--- a/core/vehicle/adapter.go
+++ b/core/vehicle/adapter.go
@@ -137,10 +137,9 @@ func (v *adapter) SetRepeatingPlans(plans []api.RepeatingPlan) error {
 func (v *adapter) GetRepeatingPlans() []api.RepeatingPlan {
 	var plans []api.RepeatingPlan
 
-	err := settings.Json(v.key()+keys.RepeatingPlans, &plans)
-	if err == nil {
-		return plans
+	if err := settings.Json(v.key()+keys.RepeatingPlans, &plans); err != nil {
+		return nil
 	}
 
-	return nil
+	return plans
 }

--- a/core/vehicle/adapter.go
+++ b/core/vehicle/adapter.go
@@ -110,7 +110,7 @@ func (v *adapter) SetPlanSoc(ts time.Time, precondition time.Duration, soc int) 
 	return nil
 }
 
-func (v *adapter) SetRepeatingPlans(plans []api.RepeatingPlanStruct) error {
+func (v *adapter) SetRepeatingPlans(plans []api.RepeatingPlan) error {
 	for _, plan := range plans {
 		for _, day := range plan.Weekdays {
 			if day < 0 || day > 6 {
@@ -134,13 +134,13 @@ func (v *adapter) SetRepeatingPlans(plans []api.RepeatingPlanStruct) error {
 	return nil
 }
 
-func (v *adapter) GetRepeatingPlans() []api.RepeatingPlanStruct {
-	var plans []api.RepeatingPlanStruct
+func (v *adapter) GetRepeatingPlans() []api.RepeatingPlan {
+	var plans []api.RepeatingPlan
 
 	err := settings.Json(v.key()+keys.RepeatingPlans, &plans)
 	if err == nil {
 		return plans
 	}
 
-	return []api.RepeatingPlanStruct{}
+	return []api.RepeatingPlan{}
 }

--- a/core/vehicle/api.go
+++ b/core/vehicle/api.go
@@ -44,9 +44,9 @@ type API interface {
 	SetPlanSoc(time.Time, time.Duration, int) error
 
 	// GetRepeatingPlans returns every repeating plan
-	GetRepeatingPlans() []api.RepeatingPlanStruct
+	GetRepeatingPlans() []api.RepeatingPlan
 	// SetRepeatingPlans stores every repeating plan
-	SetRepeatingPlans([]api.RepeatingPlanStruct) error
+	SetRepeatingPlans([]api.RepeatingPlan) error
 
 	// // GetMinCurrent returns the min charging current
 	// GetMinCurrent() float64

--- a/core/vehicle/dummy.go
+++ b/core/vehicle/dummy.go
@@ -54,5 +54,5 @@ func (v *dummy) SetRepeatingPlans(plans []api.RepeatingPlan) error {
 }
 
 func (v *dummy) GetRepeatingPlans() []api.RepeatingPlan {
-	return []api.RepeatingPlan{}
+	return nil
 }

--- a/core/vehicle/dummy.go
+++ b/core/vehicle/dummy.go
@@ -49,10 +49,10 @@ func (v *dummy) SetPlanSoc(ts time.Time, precondition time.Duration, soc int) er
 }
 
 // SetRepeatingPlans stores every repeating plan
-func (v *dummy) SetRepeatingPlans(plans []api.RepeatingPlanStruct) error {
+func (v *dummy) SetRepeatingPlans(plans []api.RepeatingPlan) error {
 	return nil
 }
 
-func (v *dummy) GetRepeatingPlans() []api.RepeatingPlanStruct {
-	return []api.RepeatingPlanStruct{}
+func (v *dummy) GetRepeatingPlans() []api.RepeatingPlan {
+	return []api.RepeatingPlan{}
 }

--- a/core/vehicle/mock.go
+++ b/core/vehicle/mock.go
@@ -86,10 +86,10 @@ func (mr *MockAPIMockRecorder) GetPlanSoc() *gomock.Call {
 }
 
 // GetRepeatingPlans mocks base method.
-func (m *MockAPI) GetRepeatingPlans() []api.RepeatingPlanStruct {
+func (m *MockAPI) GetRepeatingPlans() []api.RepeatingPlan {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRepeatingPlans")
-	ret0, _ := ret[0].([]api.RepeatingPlanStruct)
+	ret0, _ := ret[0].([]api.RepeatingPlan)
 	return ret0
 }
 
@@ -166,7 +166,7 @@ func (mr *MockAPIMockRecorder) SetPlanSoc(arg0, arg1, arg2 any) *gomock.Call {
 }
 
 // SetRepeatingPlans mocks base method.
-func (m *MockAPI) SetRepeatingPlans(arg0 []api.RepeatingPlanStruct) error {
+func (m *MockAPI) SetRepeatingPlans(arg0 []api.RepeatingPlan) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRepeatingPlans", arg0)
 	ret0, _ := ret[0].(error)

--- a/server/http_vehicle_handler.go
+++ b/server/http_vehicle_handler.go
@@ -131,22 +131,18 @@ func addRepeatingPlansHandler(site site.API) http.HandlerFunc {
 			return
 		}
 
-		var plansWrapper struct {
-			RepeatingPlans []api.RepeatingPlanStruct `json:"plans"`
-		}
-
-		err = json.NewDecoder(r.Body).Decode(&plansWrapper)
-		if err != nil {
+		var res []api.RepeatingPlanStruct
+		if err := json.NewDecoder(r.Body).Decode(&res); err != nil {
 			jsonError(w, http.StatusBadRequest, err)
 			return
 		}
 
-		if err := v.SetRepeatingPlans(plansWrapper.RepeatingPlans); err != nil {
+		if err := v.SetRepeatingPlans(res); err != nil {
 			jsonError(w, http.StatusBadRequest, err)
 			return
 		}
 
-		jsonWrite(w, plansWrapper)
+		jsonWrite(w, res)
 	}
 }
 

--- a/server/http_vehicle_handler.go
+++ b/server/http_vehicle_handler.go
@@ -131,7 +131,7 @@ func addRepeatingPlansHandler(site site.API) http.HandlerFunc {
 			return
 		}
 
-		var res []api.RepeatingPlanStruct
+		var res []api.RepeatingPlan
 		if err := json.NewDecoder(r.Body).Decode(&res); err != nil {
 			jsonError(w, http.StatusBadRequest, err)
 			return

--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -606,17 +606,6 @@
         },
         "type": "object"
       },
-      "RepeatingPlans": {
-        "properties": {
-          "plans": {
-            "items": {
-              "$ref": "#/components/schemas/RepeatingPlan"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
       "Soc": {
         "description": "SOC in %",
         "example": 60,
@@ -2232,7 +2221,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RepeatingPlans"
+                "items": {
+                  "$ref": "#/components/schemas/RepeatingPlan"
+                },
+                "type": "array"
               }
             }
           },
@@ -2245,7 +2237,10 @@
                 "schema": {
                   "properties": {
                     "result": {
-                      "$ref": "#/components/schemas/RepeatingPlans"
+                      "items": {
+                        "$ref": "#/components/schemas/RepeatingPlan"
+                      },
+                      "type": "array"
                     }
                   },
                   "type": "object"

--- a/server/mcp/openapi.md
+++ b/server/mcp/openapi.md
@@ -1017,7 +1017,7 @@ Updates the repeating charging plan.
 | Name | Type | Description |
 |------|------|-------------|
 | name | string | Vehicle name |
-| requestBody | object | The JSON request body. |
+| requestBody | array | The JSON request body. |
 
 **Example call:**
 

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -941,7 +941,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RepeatingPlans"
+              type: array
+              items:
+                $ref: "#/components/schemas/RepeatingPlan"
       responses:
         200:
           description: Success
@@ -951,7 +953,9 @@ paths:
                 type: object
                 properties:
                   result:
-                    $ref: "#/components/schemas/RepeatingPlans"
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RepeatingPlan"
   /vehicles/{name}/plan/soc:
     delete:
       operationId: deleteVehicleSocPlan
@@ -1197,13 +1201,6 @@ components:
           $ref: "#/components/schemas/IANATimeZone"
         weekdays:
           $ref: "#/components/schemas/Weekdays"
-    RepeatingPlans:
-      type: object
-      properties:
-        plans:
-          type: array
-          items:
-            $ref: "#/components/schemas/RepeatingPlan"
     Soc:
       description: SOC in %
       type: number


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/pull/24423#issuecomment-3444061189

@naltatis @Maschga könntet ihr den UI Teil beisteuern? Ich finde im FE leider nicht den passenden Aufruf fürs vehicle :(

Vermutlich hier, aber ich sehe nicht, warum das ein Property `plans` haben sollte?

```js
		updateRepeatingPlans(plans: RepeatingPlan[]): void {
			api.post(`${this.apiVehicle}plan/repeating`, { plans });
		},
```

**TODO**

- [x] openapi (es scheint als wäre die Doku auch bisher schon falsch gewesen)