### PR TITLE
SHM: generate stable device ids (BC)

### DIFF
--- a/assets/js/components/Config/ShmModal.vue
+++ b/assets/js/components/Config/ShmModal.vue
@@ -52,8 +52,27 @@
 							minlength="12"
 							maxlength="12"
 							pattern="[A-Fa-f0-9]{12}"
-						/> </FormRow
-				></template>
+						/>
+					</FormRow>
+					<FormRow
+						id="shmLegacyid"
+						:label="$t('config.shm.labelLegacyId')"
+						:help="$t('config.shm.descriptionLegacyId')"
+					>
+						<div class="d-flex">
+							<input
+								id="shmLegacyid"
+								v-model="values.legacyId"
+								data-testid="shmLegacyid"
+								class="form-check-input"
+								type="checkbox"
+							/>
+							<label class="form-check-label ms-2" for="shmLegacyid">
+								{{ $t("config.shm.legacyIdLabel") }}
+							</label>
+						</div>
+					</FormRow>
+				</template>
 			</PropertyCollapsible>
 		</template>
 	</JsonModal>

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -40,6 +40,7 @@ export interface HemsConfig {
 export interface ShmConfig {
   vendorId: string;
   deviceId: string;
+  legacyId: boolean;
 }
 
 export interface FatalError {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,10 +17,12 @@ import (
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server"
 	"github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/server/mcp"
 	"github.com/evcc-io/evcc/server/updater"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/auth"
+	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/pipe"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/evcc-io/evcc/util/telemetry"
@@ -278,6 +280,16 @@ func runRoot(cmd *cobra.Command, args []string) {
 	if err == nil {
 		pushChan, err = configureMessengers(&conf.Messaging, site.Vehicles(), valueChan, cache)
 		err = wrapErrorWithClass(ClassMessenger, err)
+	}
+
+	// publish SHM legacy setting
+	if err == nil {
+		legacy, err := settings.Bool(keys.SHMLegacyScheme)
+		if err != nil {
+			legacy = len(config.Loadpoints().Devices()) > 0
+			settings.SetBool(keys.SHMLegacyScheme, legacy)
+		}
+		valueChan <- util.Param{Key: keys.SHMLegacyScheme, Val: legacy}
 	}
 
 	// publish initial settings

--- a/core/keys/global.go
+++ b/core/keys/global.go
@@ -24,4 +24,5 @@ const (
 	DemoMode           = "demoMode"
 	AuthDisabled       = "authDisabled"
 	AuthProviders      = "authProviders"
+	SHMLegacyScheme    = "shmLegacy"
 )

--- a/hems/shm/shm.go
+++ b/hems/shm/shm.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -334,7 +335,7 @@ func (s *SEMP) deviceID(id int) string {
 	// build stable device id of unique id plus charger ref
 	lp := s.site.Loadpoints()[id]
 
-	did := s.did
+	did := slices.Clone(s.did)
 	for i, b := range sha256.Sum256([]byte(lp.GetChargerRef())) {
 		did[i%len(did)] ^= b
 	}

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -458,10 +458,13 @@
       "descriptionDeviceId": "12-stelliger HEX-String. Präfix für alle Geräte (Ladepunkt, ..).",
       "descriptionIdPattern": "Kennungsmuster",
       "descriptionIds": "Im Sunny Portal benötigt jeder Verbraucher (Ladepunkt, ..) eine eindeutige Kennung. evcc generiert basierend auf deiner Hardware eine eindeutige Kennung. Wenn du evcc auf andere Hardware migrierst, kann sich diese Kennung ändern. Um die Historie zu erhalten, kannst du die generierten Kennungen hier überschreiben. Öffne die SEMP-URL (/semp), um deine aktuellen Kennungen zu überprüfen.",
+      "descriptionLegacyId": "Die Generierung von Legacy-IDs hängt von der Reihenfolge der Ladepunkte ab und ist möglicherweise nicht stabil. Sie wird im Allgemeinen nicht empfohlen.",
       "descriptionSempUrl": "SEMP-URL",
       "descriptionVendorId": "8-stelliger HEX-String. Allgemeines Präfix aller Entitäten. Standardmäßig verwendet evcc seine eigene interne Hersteller-ID.",
       "labelDeviceId": "Geräte-ID",
+      "labelLegacyId": "Legacy-ID",
       "labelVendorId": "Hersteller-ID",
+      "legacyIdLabel": "Verwende alte ID-Generierung",
       "title": "SMA Sunny Home Manager"
     },
     "sponsor": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -458,10 +458,13 @@
       "descriptionDeviceId": "12 characters HEX string. Prefix for all devices (charging point, ..).",
       "descriptionIdPattern": "Identifier pattern",
       "descriptionIds": "In Sunny Portal every consumer device needs a unique identifier. evcc generates a unique identifier based on your hardware. If you migrate evcc to another hardware these identifiers might change. If you want to maintain history you can override the generated identifiers here. Open the SEMP URL (/semp) to check your current identifiers.",
+      "descriptionLegacyId": "Legacy ID generation depends on the order of loadpoints and may not be stable. It is generally not recommended.",
       "descriptionSempUrl": "SEMP URL",
       "descriptionVendorId": "8 characters HEX string. General prefix of all entities. By default evcc will use its own internal vendor ID.",
       "labelDeviceId": "Device ID",
+      "labelLegacyId": "Legacy ID",
       "labelVendorId": "Vendor ID",
+      "legacyIdLabel": "Use legacy ID generation",
       "title": "SMA Sunny Home Manager"
     },
     "sponsor": {

--- a/tests/config-shm.spec.ts
+++ b/tests/config-shm.spec.ts
@@ -44,6 +44,11 @@ test.describe("SHM", () => {
     await device.fill(VALID_DEVICE_ID);
     expect(await device.evaluate((el: HTMLInputElement) => el.validity.valid)).toBe(true);
 
+    // check legacy ID
+    const legacy = modal.getByTestId("shmLegacyid");
+    await legacy.check();
+    await expect(legacy).toBeChecked();
+
     await modal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(modal);
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/24768

To disable the new behaviour and keep IDs stable, set `legacyId: true`.

**TODO**

- [x] UI option @naltatis 
- [x] backend "stable" setting
- [ ] use backend "stable" setting in UI @naltatis 