### PR TITLE
Optimizer: the saved amount of money is positive

### DIFF
--- a/assets/js/views/Optimize.vue
+++ b/assets/js/views/Optimize.vue
@@ -16,7 +16,7 @@
 							<span class="d-block no-wrap text-truncate">Result: Charging Plan</span>
 							<small class="d-block no-wrap text-truncate">
 								{{ evopt.res.status }} ・
-								{{ fmtMoney(evopt.res.objective_value || 0, currency, true, true) }}
+								{{ fmtMoney((evopt.res.objective_value || 0) * -1, currency, true, true) }}
 								saved
 							</small>
 						</h3>

--- a/assets/js/views/Optimize.vue
+++ b/assets/js/views/Optimize.vue
@@ -17,12 +17,12 @@
 							<small class="d-block no-wrap text-truncate">
 								{{ evopt.res.status }} ・
 								{{
-										fmtMoney(
-											(evopt.res.objective_value || 0) * -1,
-											currency,
-											true,
-											true
-										)
+									fmtMoney(
+										(evopt.res.objective_value || 0) * -1,
+										currency,
+										true,
+										true
+									)
 								}}
 								saved
 							</small>

--- a/assets/js/views/Optimize.vue
+++ b/assets/js/views/Optimize.vue
@@ -16,7 +16,14 @@
 							<span class="d-block no-wrap text-truncate">Result: Charging Plan</span>
 							<small class="d-block no-wrap text-truncate">
 								{{ evopt.res.status }} ・
-								{{ fmtMoney((evopt.res.objective_value || 0) * -1, currency, true, true) }}
+								{{
+										fmtMoney(
+											(evopt.res.objective_value || 0) * -1,
+											currency,
+											true,
+											true
+										)
+								}}
 								saved
 							</small>
 						</h3>


### PR DESCRIPTION
When the optimizer has successfully optimized, it writes e.g. "-€0.44 saved" (a negative value).

<img width="465" height="293" alt="evopt" src="https://github.com/user-attachments/assets/890ab510-58a5-4fea-9ac8-8f3af3fbd0cc" />

 But it fact it has saved 0.44€. Can we maybe invert the result just for the display?