### PR TITLE
Add currents to Youless meter definition

### DIFF
--- a/templates/definition/meter/youless.yaml
+++ b/templates/definition/meter/youless.yaml
@@ -24,6 +24,16 @@ render: |
     source: http
     uri: http://{{ .host }}/e
     jq: .[0]|.p1+.p2
+  currents:
+  - source: http
+    uri: http://{{ .host }}/f
+    jq: .i1
+  - source: http
+    uri: http://{{ .host }}/f
+    jq: .i2
+  - source: http
+    uri: http://{{ .host }}/f
+    jq: .i3
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/youless.yaml
+++ b/templates/definition/meter/youless.yaml
@@ -27,13 +27,23 @@ render: |
   currents:
   - source: http
     uri: http://{{ .host }}/f
-    jq: (.i1 * (if .l1 < 0 then -1 else 1 end)) # Invert the sign of i1 if l1 is negative to reflect direction
+    jq: .i1
   - source: http
     uri: http://{{ .host }}/f
-    jq: (.i2 * (if .l2 < 0 then -1 else 1 end))
+    jq: .i2
   - source: http
     uri: http://{{ .host }}/f
-    jq: (.i3 * (if .l3 < 0 then -1 else 1 end))
+    jq: .i3
+  powers:
+  - source: http
+    uri: http://{{ .host }}/f
+    jq: .l1
+  - source: http
+    uri: http://{{ .host }}/f
+    jq: .l2
+  - source: http
+    uri: http://{{ .host }}/f
+    jq: .l3
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/youless.yaml
+++ b/templates/definition/meter/youless.yaml
@@ -27,13 +27,13 @@ render: |
   currents:
   - source: http
     uri: http://{{ .host }}/f
-    jq: .i1
+    jq: (.i1 * (if .l1 < 0 then -1 else 1 end)) # Invert the sign of i1 if l1 is negative to reflect direction
   - source: http
     uri: http://{{ .host }}/f
-    jq: .i2
+    jq: (.i2 * (if .l2 < 0 then -1 else 1 end))
   - source: http
     uri: http://{{ .host }}/f
-    jq: .i3
+    jq: (.i3 * (if .l3 < 0 then -1 else 1 end))
   {{- end }}
   {{- if eq .usage "pv" }}
   power:


### PR DESCRIPTION
These can be used for phase-specific monitoring & load management.