### PR TITLE
Enable setting SEMP_BASE_URL for Home Assistant addon

### DIFF
--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -7,6 +7,7 @@ HASSIO_OPTIONSFILE=/data/options.json
 if [ -f ${HASSIO_OPTIONSFILE} ]; then
 	CONFIG=$(grep -o '"config_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
 	SQLITE_FILE=$(grep -o '"sqlite_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
+	SEMP_BASE_URL=$(grep -o '"SEMP_BASE_URL": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
 
 	# Config File Migration
 	# If there is no config file found in '/config' we copy it from '/homeassistant' and rename the old config file to .migrated
@@ -36,11 +37,11 @@ if [ -f ${HASSIO_OPTIONSFILE} ]; then
 		echo "For details see evcc documentation at https://github.com/evcc-io/evcc#readme."
 	else
 		if [ "${SQLITE_FILE}" ]; then
-			echo "starting evcc: 'EVCC_DATABASE_DSN=${SQLITE_FILE} evcc --config ${CONFIG}'"
-			exec env EVCC_DATABASE_DSN="${SQLITE_FILE}" evcc --config "${CONFIG}"
+			echo "starting evcc: 'SEMP_BASE_URL=${SEMP_BASE_URL} EVCC_DATABASE_DSN=${SQLITE_FILE} evcc --config ${CONFIG}'"
+			exec env SEMP_BASE_URL="${SEMP_BASE_URL}" EVCC_DATABASE_DSN="${SQLITE_FILE}" evcc --config "${CONFIG}"
 		else
-			echo "starting evcc: 'evcc --config ${CONFIG}'"
-			exec evcc --config "${CONFIG}"
+			echo "starting evcc: 'SEMP_BASE_URL=${SEMP_BASE_URL} evcc --config ${CONFIG}'"
+			exec env SEMP_BASE_URL="${SEMP_BASE_URL}" evcc --config "${CONFIG}"
 		fi
 	fi
 else


### PR DESCRIPTION
When running as a Home Assistant addon, evcc is running in a container. Therefore, the IP of the container is not helpful to create the hems URL for SMA. It can already be overridden by an environment variable. This change enables to expose this variable via Home Assistant so that it can be set properly with the external URL.

A change to the add-on repo is forthcoming.

Unfortunately my testing is limited since I cannot cross-build atm.