### PR TITLE
Add getMaxCurrent endpoint to tesla-ble.yaml

### DIFF
--- a/templates/definition/vehicle/tesla-ble.yaml
+++ b/templates/definition/vehicle/tesla-ble.yaml
@@ -48,7 +48,7 @@ render: |
     uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state
     jq: .response.response.charge_state.battery_level
     timeout: 30s
-  getMaxCurrent:
+  getmaxcurrent:
     source: http
     uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state
     jq: .response.response.charge_state.charge_amps

--- a/templates/definition/vehicle/tesla-ble.yaml
+++ b/templates/definition/vehicle/tesla-ble.yaml
@@ -48,6 +48,11 @@ render: |
     uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state
     jq: .response.response.charge_state.battery_level
     timeout: 30s
+  getMaxCurrent:
+    source: http
+    uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state
+    jq: .response.response.charge_state.charge_amps
+    timeout: 30s
   limitsoc:
     source: http
     uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state


### PR DESCRIPTION
Fix #24456

Added getMaxCurrent to the tesla-ble template to solve the issue https://github.com/evcc-io/evcc/issues/24456.

Since in my environment the planned charging works fine, I can't test if this fixes the issue.