### PR TITLE
Home Assistant: fix crash if SEMP_BASE_URL is not set in config

### DIFF
--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -7,7 +7,10 @@ HASSIO_OPTIONSFILE=/data/options.json
 if [ -f ${HASSIO_OPTIONSFILE} ]; then
 	CONFIG=$(grep -o '"config_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
 	SQLITE_FILE=$(grep -o '"sqlite_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
-	SEMP_BASE_URL=$(grep -o '"SEMP_BASE_URL": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
+	SEMP_BASE_URL=""
+	if grep -q '"SEMP_BASE_URL":' ${HASSIO_OPTIONSFILE}; then
+		SEMP_BASE_URL=$(grep -o '"SEMP_BASE_URL": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
+	fi
 
 	# Config File Migration
 	# If there is no config file found in '/config' we copy it from '/homeassistant' and rename the old config file to .migrated


### PR DESCRIPTION
The `set -e` conflicts with the grep if the value is not set, grep will return an error code which with the set causes an abort.

Therefore check if the value is set and read only if it does.

Fixes #24894.