### PR TITLE
Set template for SOLARWATT Manager flex deprecated.

### DIFF
--- a/templates/definition/meter/solarwatt-flex.yaml
+++ b/templates/definition/meter/solarwatt-flex.yaml
@@ -2,12 +2,18 @@ template: solarwatt-flex
 products:
   - brand: Solarwatt
     description:
-      generic: Manager flex
+      generic: Manager flex (DEPRECATED, do not use!)
 requirements:
   description:
     en: |
+      ! Since SOLARWATT has changed the API the connection does not work anymore (see https://github.com/evcc-io/evcc/issues/24549).
+      ! Better connect all devices separately.
+
       Combines data of all connected PV inverters or batteries.
     de: |
+      ! Da SOLARWATT seine API geändert hat funktioniert die Verbindung nicht mehr (siehe https://github.com/evcc-io/evcc/issues/24549).
+      ! Es ist besser alle angeschlossenen Geräte separat zu verbinden.
+
       Kombiniert Daten von allen verbundenen Solar-Wechselrichtern oder Batterien.
 params:
   - name: usage


### PR DESCRIPTION
The template accessed an undocumented interface of the SOLARWATT Manager flex. SOLARWATT explicitly warns against this and changes this interface without notice. Now template no longer works. Adapting it appears to be time-consuming.

It is safer to access the connected devices directly.

I couldn't find a flag to prevent the template from being offered to new users during selection.