### PR TITLE
Huawei: set maxchargepower/maxdischargepower based on real battery capabilities

### DIFF
--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -283,40 +283,32 @@ render: |
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %
+
+  {{ $c := .capacity }}
+  {{ $p := 2500 }}
+  {{ if eq $c "5" }}
+    {{ $p = 2500 }}
+  {{ else if eq $c "6.9" }}
+    {{ $p = 3500 }}
+  {{ else if or (eq $c "10") (eq $c "15") }}
+    {{ $p = 5000 }}
+  {{ else if eq $c "13.8" }}
+    {{ $p = 7000 }}
+  {{ else if eq $c "20.7" }}
+    {{ $p = 10500 }}
+  {{ end }}
+
   maxchargepower: {{
     if .maxchargepower }}
       {{ .maxchargepower }}
-    {{ else if eq .capacity "5" }}
-      2500
-    {{ else if eq .capacity "10" }}
-      5000
-    {{ else if eq .capacity "15" }}
-      5000
-    {{ else if eq .capacity "6.9" }}
-      3500
-    {{ else if eq .capacity "13.8" }}
-      7000
-    {{ else if eq .capacity "20.7" }}
-      10500
     {{ else }}
-      2500
+      {{ $p }}
     {{ end }}
   maxdischargepower: {{
     if .maxdischargepower }}
       {{ .maxdischargepower }}
-    {{ else if eq .capacity "5" }}
-      2500
-    {{ else if eq .capacity "10" }}
-      5000
-    {{ else if eq .capacity "15" }}
-      5000
-    {{ else if eq .capacity "6.9" }}
-      3500
-    {{ else if eq .capacity "13.8" }}
-      7000
-    {{ else if eq .capacity "20.7" }}
-      10500
     {{ else }}
-      2500
+      {{ $p }}
     {{ end }}
+
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -9,7 +9,7 @@ requirements:
   description:
     de: |
       Grid und Batterie erfordern den PowerSensor.
-      "Modbus/TCP" erfordert Freischaltung via "Errichterzugang" in den Kommunikationseinstellungen des Wechselrichters. 
+      "Modbus/TCP" erfordert Freischaltung via "Errichterzugang" in den Kommunikationseinstellungen des Wechselrichters.
       Siehe https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264
     en: |
       Grid and Battery require the PowerSensor.
@@ -32,10 +32,9 @@ params:
   - name: maxsoc
     advanced: true
   - name: maxchargepower
-    default: 10000
   - name: maxdischargepower
   - name: capacity
-    advanced: true
+    required: true
   - name: maxacpower
   - name: forceaccharging
     default: false
@@ -284,6 +283,40 @@ render: |
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %
-  maxchargepower: {{ .maxchargepower }} # W
-  maxdischargepower: {{ .maxdischargepower }} # W
+  maxchargepower: {{
+    if .maxchargepower }}
+      {{ .maxchargepower }}
+    {{ else if eq .capacity "5" }}
+      2500
+    {{ else if eq .capacity "10" }}
+      5000
+    {{ else if eq .capacity "15" }}
+      5000
+    {{ else if eq .capacity "6.9" }}
+      3500
+    {{ else if eq .capacity "13.8" }}
+      7000
+    {{ else if eq .capacity "20.7" }}
+      10500
+    {{ else }}
+      2500
+    {{ end }}
+  maxdischargepower: {{
+    if .maxdischargepower }}
+      {{ .maxdischargepower }}
+    {{ else if eq .capacity "5" }}
+      2500
+    {{ else if eq .capacity "10" }}
+      5000
+    {{ else if eq .capacity "15" }}
+      5000
+    {{ else if eq .capacity "6.9" }}
+      3500
+    {{ else if eq .capacity "13.8" }}
+      7000
+    {{ else if eq .capacity "20.7" }}
+      10500
+    {{ else }}
+      2500
+    {{ end }}
   {{- end }}


### PR DESCRIPTION
### Changes

1. [BREAKING CHANGE] `capacity` is now required
2. `maxchargepower`/`maxdischargepower` are automatically determined based on `capacity`

This is in preparation for more fine-grained battery charge/discharge control.

### Ultimate goal

Huawei also supports the reading of `capacity` and `maxchargepower`/`maxdischargepower` via Modbus (registers `37758` and `37046`/`37048`) (and also min./max. SOC via registers `47081`/`47082`). A mechanism to read the capabilities (e.g. via Modbus) on startup (not cyclically) would be great.

### Read Battery Capabilities via Modbus

| Name  | Address | Type | Unit | Gain | Description
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| capacity  | 37758  |  UINT32  |  Wh  |  1  |
| maxchargepower  | 37046  |  UINT32  |  W  |  1  |  The value is the smaller value of the sum of the maximum charge capability of the solar inverter and the charge capability of the connected ESU.  |
| maxdischargepower  | 37048  |  UINT32  |  W  |  1  |  The value is the smaller value of the sum of the maximum discharge capability of the solar inverter and the discharge capability of the connected ESU.  
| minsoc  | 47081  |  UINT16  |  %  |  10  |
| maxsoc  | 47082  |  UINT16  |  %  |  10  |