### PR TITLE
Phase switching not working when you have a hierarchy of circuits and only the parent has maxPower

### DIFF
--- a/core/helper.go
+++ b/core/helper.go
@@ -72,13 +72,22 @@ func deviceTitleOrName[T any](dev config.Device[T]) string {
 	return dev.Config().Name
 }
 
-// circuitMaxPower returns a circuits power limit
-func circuitMaxPower(circuit api.Circuit) float64 {
+// circuitChainMaxPower returns the power limit of all circuits up the parent chain
+func circuitChainMaxPower(circuit api.Circuit) float64 {
 	if circuit == nil {
 		return 0
 	}
 
-	return circuit.GetMaxPower()
+	maxPower := circuit.GetMaxPower()
+	parentMaxPower := circuitChainMaxPower(circuit.GetParent())
+
+	if maxPower > 0 && parentMaxPower > 0 {
+		maxPower = min(maxPower, parentMaxPower)
+	} else if parentMaxPower > 0 {
+		maxPower = parentMaxPower
+	}
+
+	return maxPower
 }
 
 // circuitDimmed returns a circuits dim status

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1227,7 +1227,7 @@ func (lp *Loadpoint) fastCharging() error {
 		maxPower1p := Voltage * lp.effectiveMaxCurrent()
 
 		// load management limit active
-		if circuitMaxPower := circuitMaxPower(lp.circuit); circuitMaxPower > 0 && circuitMaxPower < 1.1*maxPower1p {
+		if circuitMaxPower := circuitChainMaxPower(lp.circuit); circuitMaxPower > 0 && circuitMaxPower < 1.1*maxPower1p {
 			phases = 1
 			lp.log.DEBUG.Printf("fast charging: scaled to 1p to match %.0fW max circuit power", circuitMaxPower)
 		}

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -223,7 +223,7 @@ func (lp *Loadpoint) EffectiveMaxPower() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
 
-	if circuitMaxPower := circuitMaxPower(lp.circuit); circuitMaxPower > 0 {
+	if circuitMaxPower := circuitChainMaxPower(lp.circuit); circuitMaxPower > 0 {
 		return min(lp.effectiveMaxPower(), circuitMaxPower)
 	}
 


### PR DESCRIPTION
In my usecase, I have two circuits, a main circuit covering the consumption for the entire house and a child circuit to cover the EV consumption. For the "main circuit", I defined the max power (through GetMaxPower), to support the Flemish Capacity Tariffs. 

The Charging settings for "Fast Charging" would not go from 3 phases to 1 phase when the available power in the main circuit is low, like 2500 watts. This is because the "fastCharging" method would only look at the max power of the directly connected circuit of the loadpoint. 

This change adds support to traverse the hierarchy, taking all needed power constraints into account. `core/loadpoint_effective.go` is using the same method `circuitMaxPower` from `core/helper.go` and I believe this should use the same logic, so adapted that as well, while renaming the original method `circuitMaxPower` to `circuitChainMaxPower` for clarity of what the method does. 