### PR TITLE
HA Addon: Fix config file check in entrypoint script

### DIFF
--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -5,12 +5,12 @@ set -e
 HASSIO_OPTIONSFILE=/data/options.json
 
 if [ -f ${HASSIO_OPTIONSFILE} ]; then
-	CONFIG=$(grep -o '"config_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
+	CONFIG=$(grep -o '"config_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$' || true)
 	SQLITE_FILE=$(grep -o '"sqlite_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
 
 	# Config File Migration
 	# If there is no config file found in '/config' we copy it from '/homeassistant' and rename the old config file to .migrated
-	if [ ! -f "${CONFIG}" ]; then
+	if [ -n "${CONFIG}" ] && [ ! -f "${CONFIG}" ]; then
 		CONFIG_OLD=$(echo "${CONFIG}" | sed 's#^/config#/homeassistant#')
 		if [ -f "${CONFIG_OLD}" ]; then
 			mkdir -p "$(dirname "${CONFIG}")" && cp "${CONFIG_OLD}" "${CONFIG}"

--- a/packaging/docker/bin/entrypoint.sh
+++ b/packaging/docker/bin/entrypoint.sh
@@ -6,7 +6,7 @@ HASSIO_OPTIONSFILE=/data/options.json
 
 if [ -f ${HASSIO_OPTIONSFILE} ]; then
 	CONFIG=$(grep -o '"config_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$' || true)
-	SQLITE_FILE=$(grep -o '"sqlite_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$')
+	SQLITE_FILE=$(grep -o '"sqlite_file": "[^"]*' ${HASSIO_OPTIONSFILE} | grep -o '[^"]*$' || true)
 
 	# Config File Migration
 	# If there is no config file found in '/config' we copy it from '/homeassistant' and rename the old config file to .migrated


### PR DESCRIPTION
Identified why the add-on never reached the “start-from-database” branch: with set -e, the original CONFIG=$(grep ...) command exited with status 1 whenever the config_file entry was missing in options.json, so the script terminated before doing anything else. I wrapped that lookup in || true and skipped the migration block when CONFIG is empty, allowing the rest of the logic (including the database fallback) to run. Ran npx prettier [entrypoint.sh](http://_vscodecontentref_/0) --write to ensure the formatting matches CI expectations. After this change, specifying only sqlite_file (plus other env vars such as EVOPT_URI) works—the script will start evcc directly from the database when no YAML file is present, and it retains the previous behaviour when a config file exists.