### PR TITLE
chore: increase robustness

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -539,6 +539,7 @@ func (site *Site) collectMeters(key string, meters []config.Device[api.Meter]) [
 	var wg sync.WaitGroup
 
 	for i, meter := range meters {
+		i, meter := i, meter
 		wg.Go(func(i int, meter config.Device[api.Meter]) func() {
 			return func() { fun(i, meter) }
 		}(i, meter))
@@ -1111,17 +1112,18 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 
 	site.update(<-loadpointChan) // start immediately
 
-	ticker := time.NewTicker(interval)
+    ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
+		var lp updater
 		select {
 		case <-ticker.C:
-			site.update(<-loadpointChan)
-		case lp := <-site.lpUpdateChan:
-			site.update(lp)
+			lp = <-loadpointChan
+		case lp = <-site.lpUpdateChan:
 		case <-stopC:
 			return
 		}
+		site.update(lp)
 	}
 }

--- a/core/site.go
+++ b/core/site.go
@@ -1112,7 +1112,7 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 
 	site.update(<-loadpointChan) // start immediately
 
-    ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {

--- a/core/site.go
+++ b/core/site.go
@@ -1116,14 +1116,13 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 	defer ticker.Stop()
 
 	for {
-		var lp updater
 		select {
 		case <-ticker.C:
-			lp = <-loadpointChan
-		case lp = <-site.lpUpdateChan:
+			site.update(<-loadpointChan)
+		case lp := <-site.lpUpdateChan:
+			site.update(lp)
 		case <-stopC:
 			return
 		}
-		site.update(lp)
 	}
 }

--- a/core/site.go
+++ b/core/site.go
@@ -540,9 +540,9 @@ func (site *Site) collectMeters(key string, meters []config.Device[api.Meter]) [
 
 	for i, meter := range meters {
 		i, meter := i, meter
-		wg.Go(func(i int, meter config.Device[api.Meter]) func() {
-			return func() { fun(i, meter) }
-		}(i, meter))
+		wg.Go(func() {
+			fun(i, meter)
+		})
 	}
 	wg.Wait()
 


### PR DESCRIPTION
## Summary by Sourcery

Fix goroutine closure capture issue and prevent ticker resource leak

Bug Fixes:
- Capture loop variables before spawning goroutines to avoid incorrect references
- Replace time.Tick with time.NewTicker and defer Stop to prevent ticker leakage