### PR TITLE
Optimizer: fix panic in prorate on continuousDemand returning nil 

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -200,8 +200,10 @@ func (site *Site) optimizerUpdate(battery []measurement) error {
 
 		case api.ModeNow, api.ModeMinPV:
 			// forced min/max charging
-			bat.PDemand = prorate(continuousDemand(lp, minLen), firstSlotDuration)
-
+			if demand := continuousDemand(lp, minLen); demand != nil  {
+				bat.PDemand = prorate(demand, firstSlotDuration)
+			}
+			
 		case api.ModePV:
 			// add plan goal
 			goal, socBased := lp.GetPlanGoal()

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -200,7 +200,7 @@ func (site *Site) optimizerUpdate(battery []measurement) error {
 
 		case api.ModeNow, api.ModeMinPV:
 			// forced min/max charging
-			if demand := continuousDemand(lp, minLen); demand != nil  {
+			if demand := continuousDemand(lp, minLen); demand != nil {
 				bat.PDemand = prorate(demand, firstSlotDuration)
 			}
 			

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -203,7 +203,7 @@ func (site *Site) optimizerUpdate(battery []measurement) error {
 			if demand := continuousDemand(lp, minLen); demand != nil {
 				bat.PDemand = prorate(demand, firstSlotDuration)
 			}
-			
+
 		case api.ModePV:
 			// add plan goal
 			goal, socBased := lp.GetPlanGoal()


### PR DESCRIPTION
prorate() wasn't happy when (forced min/max charging) and (status != C).
[site  ] ERROR 2025/11/03 09:27:15 optimizer: panic runtime error: index out of range [0] with length 0
refs https://github.com/evcc-io/evcc/discussions/23045#discussioncomment-14758431 et al