### PR TITLE
Loadpoint settings: show decimals for min/max current

### DIFF
--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -269,7 +269,7 @@ export default defineComponent({
 		},
 		currentOption(current: number, isDefault: boolean, phases: number) {
 			const kw = this.fmtPhasePower(current, phases);
-			let name = `${this.fmtNumber(current, current <= 1 ? undefined : 0)} A (${kw})`;
+			let name = `${this.fmtNumber(current, current <= 11 ? 2 : 0)} A (${kw})`;
 			if (isDefault) {
 				name += ` [${this.$t("main.loadpointSettings.default")}]`;
 			}

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -269,7 +269,7 @@ export default defineComponent({
 		},
 		currentOption(current: number, isDefault: boolean, phases: number) {
 			const kw = this.fmtPhasePower(current, phases);
-			let name = `${this.fmtNumber(current)} A (${kw})`;
+			let name = `${this.fmtNumber(current, undefined)} A (${kw})`;
 			if (isDefault) {
 				name += ` [${this.$t("main.loadpointSettings.default")}]`;
 			}

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -269,7 +269,7 @@ export default defineComponent({
 		},
 		currentOption(current: number, isDefault: boolean, phases: number) {
 			const kw = this.fmtPhasePower(current, phases);
-			let name = `${this.fmtNumber(current, current <= 11 ? undefined : 0)} A (${kw})`;
+			let name = `${this.fmtNumber(current)} A (${kw})`;
 			if (isDefault) {
 				name += ` [${this.$t("main.loadpointSettings.default")}]`;
 			}

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -269,7 +269,7 @@ export default defineComponent({
 		},
 		currentOption(current: number, isDefault: boolean, phases: number) {
 			const kw = this.fmtPhasePower(current, phases);
-			let name = `${this.fmtNumber(current, current <= 11 ? 2 : 0)} A (${kw})`;
+			let name = `${this.fmtNumber(current, current <= 11 ? undefined : 0)} A (${kw})`;
 			if (isDefault) {
 				name += ` [${this.$t("main.loadpointSettings.default")}]`;
 			}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/24867
why 11 A? 
covers custom currents for Heizstaebe, Oelradiatoren etc up to 2.5 kW
