### PR TITLE
Add minsoc and maxsoc to sungrow-hybrid template

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -20,6 +20,10 @@ params:
   - name: capacity
     advanced: true
   - name: maxacpower
+  - name: minsoc
+    advanced: true
+  - name: maxsoc
+    advanced: true
   - name: maxchargepower
     help:
       en: Maximum charge power for forced charging of the battery in watts. (0 to automatically set the value of the maximum BDC rated power)
@@ -292,4 +296,6 @@ render: |
                 decode: uint16
         {{- end }}
   capacity: {{ .capacity }} # kWh
+  minsoc: {{ .minsoc }} # %
+  maxsoc: {{ .maxsoc }} # %
   {{- end }}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -22,12 +22,8 @@ params:
   - name: maxacpower
   - name: minsoc
     advanced: true
-    help:
-      en: Minimum state of charge (%) to maintain in the battery. Prevents battery from discharging below this threshold.
   - name: maxsoc
     advanced: true
-    help:
-      en: Maximum state of charge (%) allowed in the battery. Prevents battery from charging above this threshold.
   - name: maxchargepower
     help:
       en: Maximum charge power for forced charging of the battery in watts. (0 to automatically set the value of the maximum BDC rated power)

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -22,8 +22,12 @@ params:
   - name: maxacpower
   - name: minsoc
     advanced: true
+    help:
+      en: Minimum state of charge (%) to maintain in the battery. Prevents battery from discharging below this threshold.
   - name: maxsoc
     advanced: true
+    help:
+      en: Maximum state of charge (%) allowed in the battery. Prevents battery from charging above this threshold.
   - name: maxchargepower
     help:
       en: Maximum charge power for forced charging of the battery in watts. (0 to automatically set the value of the maximum BDC rated power)


### PR DESCRIPTION
This PR is an attempt to solve the problem of https://github.com/evcc-io/evcc/discussions/23045#discussioncomment-14783485 by adding the min and max SOC to the sungrow hybrid template.
