### PR TITLE
Ocpp-wallbox: use relative profile

### DIFF
--- a/templates/definition/charger/ocpp-wallbox.yaml
+++ b/templates/definition/charger/ocpp-wallbox.yaml
@@ -36,3 +36,4 @@ params:
   - preset: ocpp
 render: |
   {{ include "ocpp" . }}
+  profilekindrelative: true


### PR DESCRIPTION
According to https://github.com/evcc-io/evcc/discussions/24993#discussioncomment-14869879, it works with the new relative profiles, while the default absolute profiles are not well supported by the wallbox.com chargers.

Should hopefully fix #23052, #22087, #18974