### PR TITLE
Hide experimental UI features toggle when not authenticated

### DIFF
--- a/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
+++ b/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
@@ -74,7 +74,11 @@
 				{{ $t("settings.fullscreen.enter") }}
 			</button>
 		</FormRow>
-		<FormRow id="hiddenFeaturesEnabled" :label="`${$t('settings.hiddenFeatures.label')} 🧪`">
+		<FormRow
+			v-if="isLoggedIn()"
+			id="hiddenFeaturesEnabled"
+			:label="`${$t('settings.hiddenFeatures.label')} 🧪`"
+		>
 			<div class="form-check form-switch my-1">
 				<input
 					id="hiddenFeaturesEnabled"
@@ -110,6 +114,7 @@ import { getThemePreference, setThemePreference } from "@/theme.ts";
 import { getUnits, setUnits, is12hFormat, set12hFormat } from "@/units";
 import { getHiddenFeatures, setHiddenFeatures } from "@/featureflags.ts";
 import { isApp } from "@/utils/native";
+import { isLoggedIn } from "../Auth/auth";
 import { defineComponent, type PropType } from "vue";
 import { LENGTH_UNIT, THEME, type UiLoadpoint } from "@/types/evcc";
 
@@ -183,6 +188,7 @@ export default defineComponent({
 	},
 	methods: {
 		isApp,
+		isLoggedIn,
 		enterFullscreen() {
 			document.documentElement.requestFullscreen();
 		},


### PR DESCRIPTION
### Description

The **"Experimental UI features"** toggle was accessible in the **User Interface** dropdown menu *without authentication*, while the same setting in the **Configuration** page correctly required login.

### Note

I think it’s important that experimental features can only be enabled or disabled by authenticated users. These settings can significantly affect how the UI behaves, so they should be limited to logged-in users who understand what they’re changing.

---

### UI Behavior

**Without authentication:**  
Toggle is **hidden**  
<img width="1280" height="720" alt="Hidden toggle" src="https://github.com/user-attachments/assets/db21b92f-8d27-49d7-82a5-b8479c99f45c" />

**With authentication:**  
Toggle is **visible**  
<img width="1280" height="720" alt="Visible toggle" src="https://github.com/user-attachments/assets/2860bc1f-54f1-40ee-ba7e-e1cb5c1bd4bd" />

