### PR TITLE
Planner: adjust session energy by initial value plan

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -148,6 +148,7 @@ type Loadpoint struct {
 	planTime         time.Time     // time goal
 	planPrecondition time.Duration // precondition duration
 	planEnergy       float64       // Plan charge energy in kWh (dumb vehicles)
+	planEnergyOffset float64       // already charged energy in kWh when plan was set
 	planSlotEnd      time.Time     // current plan slot end time
 	planActive       bool          // charge plan exists and has a currently active slot
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -515,6 +515,9 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 
 	// create charging session
 	lp.createSession()
+
+	// reset energy-based charging plan offset
+	lp.planEnergyOffset = 0
 }
 
 // evVehicleDisconnectHandler sends external start event

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -368,6 +368,7 @@ func (lp *Loadpoint) setPlanEnergy(finishAt time.Time, precondition time.Duratio
 
 	lp.planTime = finishAt
 	lp.planPrecondition = precondition
+	lp.planEnergyOffset = lp.getChargedEnergy() / 1e3
 	lp.publish(keys.PlanTime, finishAt)
 	lp.publish(keys.PlanPrecondition, precondition)
 	lp.settings.SetTime(keys.PlanTime, finishAt)

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -37,7 +37,7 @@ func (lp *Loadpoint) finishPlan() {
 
 // remainingPlanEnergy returns missing energy amount in kWh
 func (lp *Loadpoint) remainingPlanEnergy(planEnergy float64) float64 {
-	return max(0, planEnergy-lp.getChargedEnergy()/1e3)
+	return max(0, planEnergy+lp.planEnergyOffset-lp.getChargedEnergy()/1e3)
 }
 
 // GetPlanRequiredDuration is the estimated total charging duration

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -37,7 +37,7 @@ func (lp *Loadpoint) finishPlan() {
 
 // remainingPlanEnergy returns missing energy amount in kWh
 func (lp *Loadpoint) remainingPlanEnergy(planEnergy float64) float64 {
-	return max(0, planEnergy+lp.planEnergyOffset-lp.getChargedEnergy()/1e3)
+	return max(0, planEnergy-(lp.getChargedEnergy()/1e3-lp.planEnergyOffset))
 }
 
 // GetPlanRequiredDuration is the estimated total charging duration


### PR DESCRIPTION
Fixes #25148 where already charged energy would be subtracted from the plan goal, leading to charging stopping too early.