### PR TITLE
Estimator/Planner: Improve charge time estimation

### DIFF
--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 )
 
-const ChargeEfficiency = 0.8 // assume 80% charge efficiency
+const ChargeEfficiency = 0.85 // assume 85% charge efficiency
 
 // Estimator provides vehicle soc and charge duration
 // Vehicle Soc can be estimated to provide more granularity

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -9,7 +9,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 )
 
-const ChargeEfficiency = 0.9 // assume charge 90% efficiency
+const ChargeEfficiency = 0.8 // assume 80% charge efficiency
 
 // Estimator provides vehicle soc and charge duration
 // Vehicle Soc can be estimated to provide more granularity


### PR DESCRIPTION
This PR addresses the planner overshooting issue reported in #25079 by adjusting the assumed charging efficiency from 90% to 85%.

### Background
Some users reported that the charging planner consistently finishes earlier than planned. This is caused by the assumed charging efficiency being too optimistic. Real-world charging losses (due to heat dissipation, power electronics, and battery management) seem to be typically higher than the previously assumed 10%.

### Changes
- Reduced `ChargeEfficiency` constant from `0.90` to `0.85`
- Updated all related tests to reflect the new efficiency assumption

### Impact
- **More realistic charge time estimates**: Times will be ~6% longer, providing better planning accuracy
- **More conservative energy calculations**: The planner will start charging slightly earlier to ensure target SoC is reached on time
- **No breaking changes**: Existing configurations continue to work; users will simply see better predictions

Closes #25079