### PR TITLE
fix: forecast default to empty array

### DIFF
--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -163,7 +163,7 @@ export default defineComponent({
 					order: active ? 0 : 1,
 				});
 			}
-			if (this.gridSlots.length > 0) {
+			if (this.gridSlots && this.gridSlots.length > 0) {
 				const active = this.selected === ForecastType.Price;
 				const color = active ? colors.price : colors.border;
 				datasets.push({
@@ -184,7 +184,7 @@ export default defineComponent({
 					order: active ? 0 : 1,
 				});
 			}
-			if (this.co2Slots.length > 0) {
+			if (this.co2Slots && this.co2Slots.length > 0) {
 				const active = this.selected === ForecastType.Co2;
 				const color = active ? colors.co2 : colors.border;
 				datasets.push({
@@ -427,6 +427,10 @@ export default defineComponent({
 			this.startDate = now;
 		},
 		filterSlots(slots: ForecastSlot[] = []) {
+			if (!slots) {
+				return undefined;
+			}
+
 			return slots.filter(
 				(slot) =>
 					new Date(slot.end) >= this.startDate && new Date(slot.start) <= this.endDate


### PR DESCRIPTION
Wenn die evcc Website für mehrere Tage ohne Neuladen angezeigt wird und in der Zwischenzeit z.B. GrünStromIndex nicht mehr erreichbar ist, kommt es zu dem Fehler, dass das Vorhersagemodel den Chart nicht mehr anzeigt.

### Fehlermeldung im Log:
```
planner: cannot create tariff type 'template': cannot create tariff type 'grünstromindex': unexpected status: 429 (Too Many Requests)
```

### Kamerabilder:
<details>
<summary>Toggle me!</summary>

![forecast](https://github.com/user-attachments/assets/066fda0b-ebeb-46f0-a004-7383541b99a5)
![log1](https://github.com/user-attachments/assets/27b40314-5a9a-49c0-a342-795a484f9613)
![log2](https://github.com/user-attachments/assets/ffc9fa87-3ee1-4ac4-9f60-9eadbe48e0a7)
</details>

Ich gehe davon aus, dass diese Zeilen das Problem sind, wenn `nil` zurückgegeben wird.
https://github.com/evcc-io/evcc/blob/b928514dd8f3c5f7512bd74db9bdee3ae2943dc6/core/site_tariffs.go#L103-L114
https://github.com/evcc-io/evcc/blob/b928514dd8f3c5f7512bd74db9bdee3ae2943dc6/tariff/tariffs.go#L34-L45
Deshalb habe ich `api.Rates{}` hinzugefügt.

