### PR TITLE
Skoda: fix OAuth login flow

### DIFF
--- a/vehicle/skoda/params.go
+++ b/vehicle/skoda/params.go
@@ -12,7 +12,7 @@ const (
 
 // Skoda native api
 var AuthParams = url.Values{
-	"response_type": {"code id_token"},
+	"response_type": {"code"},
 	"client_id":     {"7f045eee-7003-4379-9968-9355ed2adb06@apps_vw-dilab_com"},
 	"redirect_uri":  {"myskoda://redirect/login/"},
 	"scope":         {"address badge birthdate cars driversLicense dealers email mileage mbb nationalIdentifier openid phone profession profile vin"},

--- a/vehicle/skoda/tokenrefreshservice/endpoint.go
+++ b/vehicle/skoda/tokenrefreshservice/endpoint.go
@@ -45,7 +45,7 @@ func New(log *util.Logger, q url.Values) *Service {
 }
 
 func (v *Service) Exchange(q url.Values) (*vag.Token, error) {
-	if err := urlvalues.Require(q, "id_token", "code"); err != nil {
+	if err := urlvalues.Require(q, "code"); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
fix #25112 

Updated OAuth authentication to align with changes in Skoda's API. Removed id_token from response_type parameter and validation, as the updated OAuth flow now only returns authorization code.

Fixes "form not found" error during vehicle login.

Based on changes from https://github.com/skodaconnect/myskoda/pull/487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Tested successfully for my vehicle via `./evcc vehicle`.

