### PR TITLE
Fix Zaptec OAuth2 authentication for new format

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -154,7 +154,6 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 	oc := &oauth2.Config{
 		Endpoint: provider.Endpoint(),
 		Scopes: []string{
-			oidc.ScopeOpenID,
 			oidc.ScopeOfflineAccess,
 		},
 	}


### PR DESCRIPTION
Since last week I experienced issue with the Zaptec charger. 

Logs were showing entries this

"ERROR 2025/11/09 23:47:21 charge power: Get "[https://api.zaptec.com/api/chargers/caaexxxxxxxxxxxxxa57-a45f-19bdssssssss/state":](https://api.zaptec.com/api/chargers/xxxxxxxxxxxxxxxxxxxxxxxxxxxx/state%22:) oauth2: cannot fetch token: 503 Service Unavailable Response: 503 Service Temporarily Unavailable503 Service Temporarily Unavailable nginx/1.29.0"

I observed the same issue at several Zaptec installation with EVCC. I reached out to Zaptec support and they pointed to a change in the authentication format.

From Zaptec Support :
"On Monday, we migrated our authentication solution and the Grant_Type was changed from password&username to password only.
Could this be the cause of your error?
 
https://docs.zaptec.com/docs/api-authentication#/
 
curl --location 'https://api.zaptec.com/oauth/token' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'grant_type=password' \
--data-urlencode 'username={[your_email@your.com](mailto:your_email@your.com)}' \
--data-urlencode 'password={your_password}' \
--data-urlencode 'scope=offline_access'
"

I made the change in the authentication format. It solved the issue at my installation and 2 others. No more authentication errors are thrown.