### PR TITLE
Fix tooltip translation for vehicle limit warning

### DIFF
--- a/assets/js/components/Vehicles/Status.vue
+++ b/assets/js/components/Vehicles/Status.vue
@@ -273,7 +273,7 @@ export default defineComponent({
 					tooltipContent: this.vehicleLimitReached
 						? t("vehicleLimitReached")
 						: this.vehicleLimitWarning
-							? t("targetIsAboveVehicleLimit")
+							? this.$t("main.targetCharge.targetIsAboveVehicleLimit")
 							: t("vehicleLimit"),
 					iconComponent: this.vehicleLimitReached
 						? VehicleLimitReachedIcon


### PR DESCRIPTION
The vehicle limit warning tooltip was displaying the raw translation key main.vehicleStatus.targetIsAboveVehicleLimit instead of the translated text.


<img width="733" height="490" alt="image" src="https://github.com/user-attachments/assets/0b253cc7-89c5-42b8-a3fa-087eee52841b" />
