### PR TITLE
Tapo: evcc requires active third party compatibility option.

### DIFF
--- a/templates/definition/charger/tapo.yaml
+++ b/templates/definition/charger/tapo.yaml
@@ -4,6 +4,10 @@ products:
     description:
       generic: Tapo P-Series Smart Plug
 group: switchsockets
+requirements:
+  description:
+    en: Third-party compatibility must be enabled in the Tapo app to allow evcc to control the device!
+    de: Die Kompatibilität mit Drittanbietern muss in der Tapo-App aktiviert werden, um evcc die Steuerung des Geräts zu ermöglichen!
 params:
   - name: host
   - name: user

--- a/templates/definition/meter/tapo.yaml
+++ b/templates/definition/meter/tapo.yaml
@@ -4,6 +4,10 @@ products:
     description:
       generic: Tapo P-Series Smart Plug
 group: switchsockets
+requirements:
+  description:
+    en: Third-party compatibility must be enabled in the Tapo app to allow evcc to control the device!
+    de: Die Kompatibilität mit Drittanbietern muss in der Tapo-App aktiviert werden, um evcc die Steuerung des Geräts zu ermöglichen!
 params:
   - name: usage
     choice: ["pv"]


### PR DESCRIPTION
Refer to #25247