### PR TITLE
Kostal Plenticore: add maxchargepower and maxdischargepower (BC)

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -120,6 +120,7 @@ render: |
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
       - case: 3 # charge
         set:
+          {{- if .maxchargepower }}
           source: const
           value: -{{ .maxchargepower }} # W
           set:
@@ -129,6 +130,10 @@ render: |
               address: 1034 # Battery charge power (DC) setpoint, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          {{- else }}
+          source: error
+          error: ErrNotAvailable
+          {{- end }}
   capacity: {{ .capacity }} # kWh
   maxchargepower: {{ .maxchargepower }} # W
   maxdischargepower: {{ .maxdischargepower }} # W

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -42,11 +42,15 @@ params:
     advanced: true
   - name: maxacpower
   - name: maxchargerate
+    deprecated: true
     advanced: true
   - name: minsoc
     advanced: true
   - name: maxsoc
     advanced: true
+  - name: maxchargepower
+    default: 4200
+  - name: maxdischargepower
   - name: watchdog
     type: duration
     default: 60s
@@ -95,35 +99,37 @@ render: |
       - case: 1 # normal
         set:
           source: const
-          value: 0 # % (set once to reset from forced charge)
+          value: 0 # W (set once to reset from forced charge)
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
-              address: 1028 # battery charge current (DC) setpoint, relative [%]
+              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
       - case: 2 # hold
         set:
           source: const
-          value: 0 # %
+          value: 0 # W
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
-              address: 1028 # battery charge current (DC) setpoint, relative [%]
+              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
       - case: 3 # charge
         set:
           source: const
-          value: -{{ .maxchargerate }} # %
+          value: -{{ .maxchargepower }} # W
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
-              address: 1028 # battery charge current (DC) setpoint, relative [%]
+              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
   capacity: {{ .capacity }} # kWh
+  maxchargepower: {{ .maxchargepower }} # W
+  maxdischargepower: {{ .maxdischargepower }} # W
   {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -49,7 +49,7 @@ params:
   - name: maxsoc
     advanced: true
   - name: maxchargepower
-    default: 4200
+    required: true
   - name: maxdischargepower
   - name: watchdog
     type: duration


### PR DESCRIPTION
**breaking change** for this template only:
- deprecates maxchargerate
- **requires setting of maxchargepower for grid charging**

Howto: open evcc - configuration - open your battery - click on advanced settings - enter the required maxchargepower

The setting is depending on your hardware configuration. Default was 100% before, 4200 might be an option and higher settings are possible. The battery and inverter datasheet should provide required information.

- changes for absolute setpoint to register 1034 instead of 1028


