### PR TITLE
Startup data tracking and UI rendering

### DIFF
--- a/assets/js/views/Main.vue
+++ b/assets/js/views/Main.vue
@@ -1,6 +1,6 @@
 <template>
 	<Site
-		v-if="state.startup"
+		v-if="startupDataReceived"
 		:notifications="notifications"
 		v-bind="state"
 		:selected-loadpoint-index="selectedLoadpointIndex"


### PR DESCRIPTION
This PR introduces a tracking system for the initial data load state. It ensures that UI state transitions occur only after the backend data is fully processed, preventing temporary display of setup screens or flickering during initialization.

Ref: #21306
