### PR TITLE
stekker tariff: add tariff-features  (hourly averaging)

### DIFF
--- a/templates/definition/tariff/stekker.yaml
+++ b/templates/definition/tariff/stekker.yaml
@@ -51,7 +51,9 @@ params:
         "HR",
       ]
   - preset: tariff-base
+  - preset: tariff-features
 render: |
   type: stekker
   region: {{ .region }}
   {{ include "tariff-base" . }}
+  {{ include "tariff-features" . }}


### PR DESCRIPTION
den verwende ich ja selber mit averaging.

wurde auch sinn machen fuer die anderen generischen boersenpreise
demo-dynamic-grid
energyforecast
energy-charts-api

und tibber
https://github.com/evcc-io/evcc/issues/24769

machen? 
4 PRs oder einen?
