### PR TITLE
Network: allow configuring external url (BC)

### DIFF
--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -1,7 +1,6 @@
 package globalconfig
 
 import (
-	"fmt"
 	"net"
 	"strconv"
 	"time"
@@ -152,18 +151,22 @@ type Tariffs struct {
 }
 
 type Network struct {
-	Schema string `json:"schema"`
-	Host   string `json:"host"`
-	Port   int    `json:"port"`
+	Schema_     string `json:"schema"`
+	ExternalUrl string `json:"external_url"`
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
 }
 
 func (c Network) HostPort() string {
-	if c.Schema == "http" && c.Port == 80 || c.Schema == "https" && c.Port == 443 {
+	if c.Port == 80 {
 		return c.Host
 	}
 	return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
 }
 
 func (c Network) URI() string {
-	return fmt.Sprintf("%s://%s", c.Schema, c.HostPort())
+	if c.ExternalUrl != "" {
+		return c.ExternalUrl
+	}
+	return "http://" + c.HostPort()
 }

--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evcc-io/evcc/plugin/mqtt"
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server/eebus"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/modbus"
 )
@@ -161,11 +162,13 @@ type Network struct {
 }
 
 func (c Network) HostPort() string {
-	host, err := os.Hostname()
-	if err != nil {
-		host = "localhost"
+	host := "localhost"
+	if h, err := os.Hostname(); err == nil {
+		host = h
 	}
-
+	if ips := util.LocalIPs(); len(ips) > 0 {
+		host = ips[0].IP.String()
+	}
 	if c.Port == 80 {
 		return host
 	}

--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evcc-io/evcc/plugin/mqtt"
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server/eebus"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/modbus"
 )
@@ -158,15 +159,24 @@ type Network struct {
 }
 
 func (c Network) HostPort() string {
-	if c.Port == 80 {
-		return c.Host
+	host := c.Host
+	if ips := util.LocalIPs(); len(ips) > 0 {
+		host = ips[0].IP.String()
 	}
-	return net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+
+	if c.Port == 80 {
+		return host
+	}
+	return net.JoinHostPort(host, strconv.Itoa(c.Port))
 }
 
-func (c Network) URI() string {
+func (c Network) InternalURL() string {
+	return "http://" + c.HostPort()
+}
+
+func (c Network) ExternalURL() string {
 	if c.ExternalUrl != "" {
 		return c.ExternalUrl
 	}
-	return "http://" + c.HostPort()
+	return c.InternalURL()
 }

--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -3,6 +3,7 @@ package globalconfig
 import (
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -152,7 +153,7 @@ type Tariffs struct {
 }
 
 type Network struct {
-	Schema_     string `json:"schema"`
+	Schema_     string `json:"schema"` // TODO deprecated
 	ExternalUrl string `json:"external_url"`
 	Host        string `json:"host"`
 	Port        int    `json:"port"`
@@ -176,7 +177,7 @@ func (c Network) InternalURL() string {
 
 func (c Network) ExternalURL() string {
 	if c.ExternalUrl != "" {
-		return c.ExternalUrl
+		return strings.TrimRight(c.ExternalUrl, "/")
 	}
 	return c.InternalURL()
 }

--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evcc-io/evcc/plugin/mqtt"
 	"github.com/evcc-io/evcc/push"
 	"github.com/evcc-io/evcc/server/eebus"
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/modbus"
 )
@@ -162,30 +161,15 @@ type Network struct {
 }
 
 func (c Network) HostPort() string {
-	host, err := c.Hostname()
+	host, err := os.Hostname()
 	if err != nil {
-		if ips := util.LocalIPs(); len(ips) > 0 {
-			host = ips[0].IP.String()
-		}
+		host = "localhost"
 	}
 
 	if c.Port == 80 {
 		return host
 	}
 	return net.JoinHostPort(host, strconv.Itoa(c.Port))
-}
-
-// Hostname returns the configured host name, falls back to operating system hostname
-func (c Network) Hostname() (string, error) {
-	if c.Host != "" {
-		return c.Host, nil
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", err
-	}
-	return hostname, nil
 }
 
 func (c Network) InternalURL() string {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -576,8 +576,8 @@ input.form-control:read-only,
 	color: var(--evcc-default-text);
 }
 
-.dark .form-control::placeholder {
-	color: var(--bs-gray-medium);
+.form-control::placeholder {
+	opacity: 0.5 !important;
 }
 
 input[type="time"]::-webkit-calendar-picker-indicator {

--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -97,8 +97,7 @@ export default {
 			return settings.hiddenFeatures === true;
 		},
 		networkStatus() {
-			const { host, port } = store.state?.network || {};
-			return host ? `${host}:${port}` : `${port || ""}`;
+			return store.state?.network?.port || "";
 		},
 		controlStatus() {
 			const sec = store.state?.interval;

--- a/assets/js/components/Config/JsonModal.vue
+++ b/assets/js/components/Config/JsonModal.vue
@@ -83,6 +83,7 @@ export default {
 		disableRemove: Boolean,
 		noButtons: Boolean,
 		transformReadValues: Function,
+		transformWriteValues: Function,
 		stateKey: String,
 		saveMethod: { type: String, default: "post" },
 		storeValuesInArray: Boolean,
@@ -134,8 +135,11 @@ export default {
 			this.saving = true;
 			this.error = "";
 			try {
-				const values = this.trimValues(this.values);
-				const res = await api[this.saveMethod](this.endpoint, values, {
+				const trimmedValues = this.trimValues(deepClone(this.values));
+				const payload = this.transformWriteValues
+					? this.transformWriteValues(trimmedValues)
+					: trimmedValues;
+				const res = await api[this.saveMethod](this.endpoint, payload, {
 					validateStatus: (code) => [200, 202, 400].includes(code),
 				});
 				if (res.status === 200 || res.status === 202) {

--- a/assets/js/components/Config/NetworkModal.vue
+++ b/assets/js/components/Config/NetworkModal.vue
@@ -4,49 +4,25 @@
 		:title="$t('config.network.title')"
 		endpoint="/config/network"
 		state-key="network"
+		:transform-write-values="transformWriteValues"
 		disable-remove
 		data-testid="network-modal"
 		@changed="$emit('changed')"
 	>
 		<template #default="{ values }">
 			<FormRow
-				id="networkSchema"
-				:label="$t('config.network.labelSchema')"
-				:help="$t('config.network.descriptionSchema')"
-			>
-				<div class="btn-group" role="group">
-					<input
-						id="networkSchemaHttp"
-						v-model="values.schema"
-						type="radio"
-						class="btn-check"
-						name="networkSchema"
-						tabindex="0"
-						value="http"
-						autocomplete="off"
-					/>
-					<label class="btn btn-outline-primary" for="networkSchemaHttp">HTTP</label>
-					<input
-						id="networkSchemaHttps"
-						v-model="values.schema"
-						type="radio"
-						class="btn-check"
-						name="networkSchema"
-						tabindex="0"
-						value="https"
-						autocomplete="off"
-					/>
-					<label class="btn btn-outline-primary" for="networkSchemaHttps">HTTPS</label>
-				</div>
-			</FormRow>
-
-			<FormRow
 				id="networkHost"
 				:label="$t('config.network.labelHost')"
 				:help="$t('config.network.descriptionHost')"
 				example="evcc.local"
+				optional
 			>
-				<input id="networkHost" v-model="values.host" class="form-control" />
+				<input
+					id="networkHost"
+					v-model="values.host"
+					class="form-control"
+					spellcheck="false"
+				/>
 			</FormRow>
 			<FormRow
 				id="networkPort"
@@ -62,6 +38,39 @@
 					required
 				/>
 			</FormRow>
+
+			<FormRow
+				id="networkInternalUrl"
+				:label="$t('config.network.labelInternalUrl')"
+				:help="$t('config.network.descriptionInternalUrl')"
+			>
+				<input
+					id="networkInternalUrl"
+					v-model="values.internalUrl"
+					class="form-control"
+					type="text"
+					readonly
+					tabindex="-1"
+				/>
+			</FormRow>
+
+			<FormRow
+				id="networkExternalUrl"
+				:label="$t('config.network.labelExternalUrl')"
+				:help="$t('config.network.descriptionExternalUrl')"
+				example="https://foo.local:220"
+				optional
+			>
+				<input
+					id="networkExternalUrl"
+					v-model="values.externalUrl"
+					class="form-control"
+					type="text"
+					inputmode="url"
+					autocomplete="off"
+					spellcheck="false"
+				/>
+			</FormRow>
 		</template>
 	</JsonModal>
 </template>
@@ -74,5 +83,13 @@ export default {
 	name: "NetworkModal",
 	components: { FormRow, JsonModal },
 	emits: ["changed"],
+	methods: {
+		transformWriteValues(values) {
+			const payload = { ...values };
+			delete payload.internalUrl;
+
+			return payload;
+		},
+	},
 };
 </script>

--- a/assets/js/components/Config/NetworkModal.vue
+++ b/assets/js/components/Config/NetworkModal.vue
@@ -11,30 +11,16 @@
 	>
 		<template #default="{ values }">
 			<FormRow
-				id="networkHost"
-				:label="$t('config.network.labelHost')"
-				:help="$t('config.network.descriptionHost')"
-				example="evcc.local"
-				optional
-			>
-				<input
-					id="networkHost"
-					v-model="values.host"
-					class="form-control"
-					spellcheck="false"
-				/>
-			</FormRow>
-			<FormRow
 				id="networkPort"
 				:label="$t('config.network.labelPort')"
 				:help="$t('config.network.descriptionPort')"
-				example="7070"
 			>
 				<input
 					id="networkPort"
 					v-model="values.port"
 					class="form-control w-50 me-2 w-50"
 					type="number"
+					placeholder="7070"
 					required
 				/>
 			</FormRow>
@@ -58,7 +44,7 @@
 				id="networkExternalUrl"
 				:label="$t('config.network.labelExternalUrl')"
 				:help="$t('config.network.descriptionExternalUrl')"
-				example="https://foo.local:220"
+				example="https://evcc.example.org"
 				optional
 			>
 				<input
@@ -69,6 +55,20 @@
 					inputmode="url"
 					autocomplete="off"
 					spellcheck="false"
+				/>
+			</FormRow>
+			<FormRow
+				id="networkHost"
+				:label="$t('config.network.labelHost')"
+				:help="$t('config.network.descriptionHost')"
+				optional
+			>
+				<input
+					id="networkHost"
+					v-model="values.host"
+					class="form-control"
+					spellcheck="false"
+					placeholder="evcc.local"
 				/>
 			</FormRow>
 		</template>

--- a/assets/js/components/Config/NetworkModal.vue
+++ b/assets/js/components/Config/NetworkModal.vue
@@ -68,7 +68,7 @@
 					v-model="values.host"
 					class="form-control"
 					spellcheck="false"
-					placeholder="evcc.local"
+					placeholder="evcc"
 				/>
 			</FormRow>
 		</template>

--- a/cmd/configure/configure.tpl
+++ b/cmd/configure/configure.tpl
@@ -1,7 +1,7 @@
 # open evcc at http://evcc.local:7070
 network:
   schema: http
-  host: evcc.local # announces the hostname on mDNS
+  host: evcc # announces the hostname on mDNS
   port: 7070
 
 log: debug

--- a/cmd/configure/configure.tpl
+++ b/cmd/configure/configure.tpl
@@ -1,7 +1,7 @@
 # open evcc at http://evcc.local:7070
 network:
   schema: http
-  host: evcc.local # .local suffix announces the hostname on MDNS
+  host: evcc.local # announces the hostname on mDNS
   port: 7070
 
 log: debug

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -249,7 +249,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	}
 
 	// announce on mDNS
-	if err == nil && strings.HasSuffix(conf.Network.Host, ".local") {
+	if err == nil {
 		err = configureMDNS(conf.Network)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -255,7 +255,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 	// start SHM server
 	if err == nil {
-		err = wrapErrorWithClass(ClassSHM, configureSHM(&conf.SHM, site, httpd))
+		err = wrapErrorWithClass(ClassSHM, configureSHM(&conf.SHM, conf.Network.ExternalURL(), site, httpd))
 	}
 
 	// start HEMS server

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -63,7 +63,7 @@ var conf = globalconfig.All{
 	Interval: 10 * time.Second,
 	Log:      "info",
 	Network: globalconfig.Network{
-		Host: "evcc.local",
+		Host: "",
 		Port: 7070,
 	},
 	Mqtt: globalconfig.Mqtt{
@@ -749,7 +749,11 @@ func networkSettings(conf *globalconfig.Network) error {
 
 // setup MDNS
 func configureMDNS(conf globalconfig.Network) error {
-	host := strings.TrimSuffix(conf.Host, ".local")
+	host, err := conf.Hostname()
+	if err != nil {
+		return fmt.Errorf("mDNS failed to determine hostname: %w", err)
+	}
+	host = strings.TrimSuffix(host, ".local")
 
 	internalURL := conf.InternalURL()
 	text := []string{"path=/", "internal_url=" + internalURL}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -749,11 +749,10 @@ func networkSettings(conf *globalconfig.Network) error {
 
 // setup MDNS
 func configureMDNS(conf globalconfig.Network) error {
-	host, err := conf.Hostname()
-	if err != nil {
-		return fmt.Errorf("mDNS failed to determine hostname: %w", err)
+	host := strings.TrimSuffix(conf.Host, ".local")
+	if host == "" {
+		host = "evcc"
 	}
-	host = strings.TrimSuffix(host, ".local")
 
 	internalURL := conf.InternalURL()
 	text := []string{"path=/", "internal_url=" + internalURL}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -63,9 +63,8 @@ var conf = globalconfig.All{
 	Interval: 10 * time.Second,
 	Log:      "info",
 	Network: globalconfig.Network{
-		Schema: "http",
-		Host:   "evcc.local",
-		Port:   7070,
+		Host: "evcc.local",
+		Port: 7070,
 	},
 	Mqtt: globalconfig.Mqtt{
 		Topic: "evcc",
@@ -676,14 +675,14 @@ func configureMqtt(conf *globalconfig.Mqtt) error {
 }
 
 // setup SHM
-func configureSHM(conf *shm.Config, site *core.Site, httpd *server.HTTPd) error {
+func configureSHM(conf *shm.Config, network globalconfig.Network, site *core.Site, httpd *server.HTTPd) error {
 	if settings.Exists(keys.Shm) {
 		if err := settings.Json(keys.Shm, &conf); err != nil {
 			return err
 		}
 	}
 
-	if err := shm.NewFromConfig(*conf, site, httpd.Addr, httpd.Router()); err != nil {
+	if err := shm.NewFromConfig(*conf, network, site, httpd.Addr, httpd.Router()); err != nil {
 		return fmt.Errorf("failed configuring shm: %w", err)
 	}
 
@@ -752,7 +751,19 @@ func networkSettings(conf *globalconfig.Network) error {
 func configureMDNS(conf globalconfig.Network) error {
 	host := strings.TrimSuffix(conf.Host, ".local")
 
-	zc, err := zeroconf.RegisterProxy("evcc", "_http._tcp", "local.", conf.Port, host, nil, []string{"path=/"}, nil)
+	text := []string{"path=/"}
+	if conf.ExternalUrl != "" {
+		text = append(text, "external_url="+conf.ExternalUrl)
+	}
+	if ips := util.LocalIPs(); len(ips) > 0 {
+		url := "http://" + ips[0].IP.String()
+		if conf.Port != 80 {
+			url += ":" + strconv.Itoa(conf.Port)
+		}
+		text = append(text, "internal_url="+url)
+	}
+
+	zc, err := zeroconf.RegisterProxy("evcc", "_http._tcp", "local.", conf.Port, host, nil, text, nil)
 	if err != nil {
 		return fmt.Errorf("mDNS announcement: %w", err)
 	}

--- a/cmd/token_tronity.go
+++ b/cmd/token_tronity.go
@@ -120,7 +120,7 @@ func tronityToken(conf globalconfig.All, vehicleConf config.Named) (*oauth2.Toke
 	}
 
 	if oc.RedirectURL = cc.RedirectURI; oc.RedirectURL == "" {
-		oc.RedirectURL = fmt.Sprintf("%s/auth/tronity", conf.Network.URI())
+		oc.RedirectURL = fmt.Sprintf("%s/auth/tronity", conf.Network.ExternalURL())
 	}
 
 	return tronityAuthorize(conf.Network.HostPort(), oc)

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -1,7 +1,4 @@
 network:
-  # schema is the HTTP schema
-  # setting to `https` does not enable https, it only changes the way URLs are generated
-  schema: http
   # host is the hostname or IP address
   # if the host name contains a `.local` suffix, the name will be announced on MDNS
   # docker: MDNS announcements don't work. host must be set to the docker host's name.
@@ -9,6 +6,8 @@ network:
   # port is the listening port for UI and api
   # evcc will listen on all available interfaces
   port: 7070
+  # externalurl is the user-configurable public url from outside
+  externalurl: https://behind-reverse-proxy/evcc
 
 interval: 30s # control cycle interval. Interval <30s can lead to unexpected behavior, see https://docs.evcc.io/docs/reference/configuration/interval
 

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -1,7 +1,7 @@
 network:
   # host is the hostname or IP address
   # for mDNS announcements. note: mDNS announcements don't work in docker. host must be set to the docker host's name.
-  host: evcc.local
+  host: evcc
   # port is the listening port for UI and api
   # evcc will listen on all available interfaces
   port: 7070

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -1,13 +1,12 @@
 network:
   # host is the hostname or IP address
-  # if the host name contains a `.local` suffix, the name will be announced on MDNS
-  # docker: MDNS announcements don't work. host must be set to the docker host's name.
+  # for mDNS announcements. note: mDNS announcements don't work in docker. host must be set to the docker host's name.
   host: evcc.local
   # port is the listening port for UI and api
   # evcc will listen on all available interfaces
   port: 7070
   # externalurl is the user-configurable public url from outside
-  externalurl: https://behind-reverse-proxy/evcc
+  externalurl: https://behind-reverse-proxy
 
 interval: 30s # control cycle interval. Interval <30s can lead to unexpected behavior, see https://docs.evcc.io/docs/reference/configuration/interval
 

--- a/hems/shm/shm.go
+++ b/hems/shm/shm.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 // NewFromConfig creates a new SEMP instance from configuration and starts it
-func NewFromConfig(cfg Config, externalUrl string, site site.API, addr string, router *mux.Router) error {
+func NewFromConfig(cfg Config, hostUri string, site site.API, addr string, router *mux.Router) error {
 	vendorId := cfg.VendorId
 	if vendorId == "" {
 		vendorId = "28081973"
@@ -82,7 +82,7 @@ func NewFromConfig(cfg Config, externalUrl string, site site.API, addr string, r
 		uid:  uid.String(),
 		vid:  vendorId,
 		did:  did,
-		uri:  externalUrl,
+		uri:  hostUri,
 	}
 
 	s.handlers(router)

--- a/hems/shm/shm.go
+++ b/hems/shm/shm.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/api/globalconfig"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/util"
@@ -24,7 +25,6 @@ import (
 
 const (
 	sempController   = "Sunny Home Manager"
-	sempBaseURLEnv   = "SEMP_BASE_URL"
 	sempGateway      = "urn:schemas-simple-energy-management-protocol:device:Gateway:1"
 	sempDeviceId     = "F-%s-%.12x-00" // 6 bytes
 	sempSerialNumber = "%s-%d"
@@ -53,7 +53,7 @@ type Config struct {
 }
 
 // NewFromConfig creates a new SEMP instance from configuration and starts it
-func NewFromConfig(cfg Config, site site.API, addr string, router *mux.Router) error {
+func NewFromConfig(cfg Config, network globalconfig.Network, site site.API, addr string, router *mux.Router) error {
 	vendorId := cfg.VendorId
 	if vendorId == "" {
 		vendorId = "28081973"

--- a/hems/shm/shm.go
+++ b/hems/shm/shm.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	sempController   = "Sunny Home Manager"
 	sempGateway      = "urn:schemas-simple-energy-management-protocol:device:Gateway:1"
 	sempDeviceId     = "F-%s-%.12x-00" // 6 bytes
 	sempSerialNumber = "%s-%d"

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -426,12 +426,14 @@
       "title": "MQTT"
     },
     "network": {
-      "descriptionHost": "Verwende den .local-Suffix, um mDNS zu aktivieren. Wird zur Erkennung der mobilen App und einiger OCPP-Wallboxen benötigt.",
+      "descriptionExternalUrl": "Dient als Callback-Endpunkt für Integrationen (SEMP, OAuth, OCPP, ...) und für die Autodiscovery der evcc-App. Wenn nicht gesetzt, wird die interne URL verwendet.",
+      "descriptionHost": "Bei leerem Feld wird der Hostname des Betriebssystems genutzt.",
+      "descriptionInternalUrl": "Wird für mDNS-Ankündigungen im lokalen Netzwerk verwendet. Ergibt sich aus dem konfigurierten Host und Port.",
       "descriptionPort": "Port für die Web-Oberfläche und API. Du musst deine Browser-URL aktualisieren, wenn du dies änderst.",
-      "descriptionSchema": "Beeinflusst nur die URL-Generierung. Die Auswahl von HTTPS aktiviert keine Verschlüsselung.",
+      "labelExternalUrl": "Externe URL",
       "labelHost": "Hostname",
+      "labelInternalUrl": "Interne URL",
       "labelPort": "Port",
-      "labelSchema": "Schema",
       "title": "Netzwerk"
     },
     "options": {

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -426,12 +426,12 @@
       "title": "MQTT"
     },
     "network": {
-      "descriptionExternalUrl": "Dient als Callback-Endpunkt für Integrationen (SEMP, OAuth, OCPP, ...) und für die Autodiscovery der evcc-App. Wenn nicht gesetzt, wird die interne URL verwendet.",
-      "descriptionHost": "Bei leerem Feld wird der Hostname des Betriebssystems genutzt.",
-      "descriptionInternalUrl": "Wird für mDNS-Ankündigungen im lokalen Netzwerk verwendet. Ergibt sich aus dem konfigurierten Host und Port.",
+      "descriptionExternalUrl": "Adresse, mit der sich andere Geräte mit evcc verbinden und für die Autodiscovery der evcc-App.",
+      "descriptionHost": "Wird verwendet, um evcc in deinem lokalen Netzwerk anzukündigen.",
+      "descriptionInternalUrl": "Lokale Netzwerkadresse von evcc.",
       "descriptionPort": "Port für die Web-Oberfläche und API. Du musst deine Browser-URL aktualisieren, wenn du dies änderst.",
       "labelExternalUrl": "Externe URL",
-      "labelHost": "Hostname",
+      "labelHost": "mDNS-Hostname",
       "labelInternalUrl": "Interne URL",
       "labelPort": "Port",
       "title": "Netzwerk"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -427,12 +427,14 @@
       "title": "MQTT"
     },
     "network": {
-      "descriptionHost": "Use .local suffix to enable mDNS. Relevant for discovery of the mobile app and some OCPP chargers.",
+      "descriptionExternalUrl": "Used as callback endpoint for integrations (SEMP, OAuth, OCPP, ...) and for autodiscovery of the evcc app. If not set, internal URL is used.",
+      "descriptionHost": "Operating system hostname will be used if left blank.",
+      "descriptionInternalUrl": "Used for mDNS advertising in the local network. Based on the configured host and port.",
       "descriptionPort": "Port for the web interface and API. You'll need to update your browser URL if you change this.",
-      "descriptionSchema": "Only affects how URLs are generated. Selecting HTTPS will not enable encryption.",
+      "labelExternalUrl": "External URL",
       "labelHost": "Hostname",
+      "labelInternalUrl": "Internal URL",
       "labelPort": "Port",
-      "labelSchema": "Schema",
       "title": "Network"
     },
     "options": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -427,12 +427,12 @@
       "title": "MQTT"
     },
     "network": {
-      "descriptionExternalUrl": "Used as callback endpoint for integrations (SEMP, OAuth, OCPP, ...) and for autodiscovery of the evcc app. If not set, internal URL is used.",
-      "descriptionHost": "Operating system hostname will be used if left blank.",
-      "descriptionInternalUrl": "Used for mDNS advertising in the local network. Based on the configured host and port.",
+      "descriptionExternalUrl": "Address for other devices that want to connect to evcc and for autodiscovery of the evcc app.",
+      "descriptionHost": "Used to announce evcc in your local network.",
+      "descriptionInternalUrl": "Local network address of evcc.",
       "descriptionPort": "Port for the web interface and API. You'll need to update your browser URL if you change this.",
       "labelExternalUrl": "External URL",
-      "labelHost": "Hostname",
+      "labelHost": "mDNS Hostname",
       "labelInternalUrl": "Internal URL",
       "labelPort": "Port",
       "title": "Network"

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -79,14 +79,14 @@ test.describe("network modal", async () => {
     await expectModalVisible(modal);
 
     const portValue = await modal.getByLabel("Port").inputValue();
-    await modal.getByLabel("Hostname").fill(NETWORK_HOST);
     await modal.getByLabel("External URL").fill(NETWORK_EXTERNAL_URL);
+    await modal.getByLabel("mDNS Hostname").fill(NETWORK_HOST);
 
     await modal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(modal);
 
     // values immediatelly visible
-    await expect(networkEntry).toContainText(`${NETWORK_HOST}:${portValue}`);
+    await expect(networkEntry).toContainText(portValue);
 
     // check persistance
     await restart(CONFIG_GRID_ONLY);
@@ -96,12 +96,11 @@ test.describe("network modal", async () => {
     await networkEntry.getByRole("button", { name: "edit" }).click();
     await expectModalVisible(modal);
 
-    await expect(modal.getByLabel("Hostname")).toHaveValue(NETWORK_HOST);
+    await expect(modal.getByLabel("mDNS Hostname")).toHaveValue(NETWORK_HOST);
     await expect(modal.getByLabel("Port")).toHaveValue(portValue);
     await expect(modal.getByLabel("External URL")).toHaveValue(NETWORK_EXTERNAL_URL);
-    const expectedInternal =
-      portValue === "80" ? `http://${NETWORK_HOST}` : `http://${NETWORK_HOST}:${portValue}`;
-    await expect(modal.getByLabel("Internal URL")).toHaveValue(expectedInternal);
+    const internalUrl = await modal.getByLabel("Internal URL").inputValue();
+    expect(internalUrl).toContain(`:${portValue}`);
 
     await modal.getByRole("button", { name: "Cancel" }).click();
     await expectModalHidden(modal);

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { start, stop, baseUrl } from "./evcc";
+import { start, stop, restart, baseUrl } from "./evcc";
 import {
   enableExperimental,
   expectModalHidden,
@@ -9,6 +9,8 @@ import {
 } from "./utils";
 
 const CONFIG_GRID_ONLY = "config-grid-only.evcc.yaml";
+const NETWORK_HOST = "somehostname.local";
+const NETWORK_EXTERNAL_URL = "https://ext.evcc.example";
 
 test.use({ baseURL: baseUrl() });
 
@@ -61,5 +63,47 @@ test.describe("general", async () => {
     // check changed value on main ui
     await page.getByTestId("home-link").click();
     await expect(page.getByRole("heading", { name: "Ahoy World" })).toBeVisible();
+  });
+});
+
+test.describe("network modal", async () => {
+  test("persists host and external url across restart", async ({ page }) => {
+    await page.goto("/#/config");
+    await enableExperimental(page, false);
+
+    const networkEntry = page.getByTestId("generalconfig-network");
+    await expect(networkEntry).toBeVisible();
+    await networkEntry.getByRole("button", { name: "edit" }).click();
+
+    const modal = page.getByTestId("network-modal");
+    await expectModalVisible(modal);
+
+    const portValue = await modal.getByLabel("Port").inputValue();
+    await modal.getByLabel("Hostname").fill(NETWORK_HOST);
+    await modal.getByLabel("External URL").fill(NETWORK_EXTERNAL_URL);
+
+    await modal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(modal);
+
+    // values immediatelly visible
+    await expect(networkEntry).toContainText(`${NETWORK_HOST}:${portValue}`);
+
+    // check persistance
+    await restart(CONFIG_GRID_ONLY);
+    await page.reload();
+
+    await expect(networkEntry).toBeVisible();
+    await networkEntry.getByRole("button", { name: "edit" }).click();
+    await expectModalVisible(modal);
+
+    await expect(modal.getByLabel("Hostname")).toHaveValue(NETWORK_HOST);
+    await expect(modal.getByLabel("Port")).toHaveValue(portValue);
+    await expect(modal.getByLabel("External URL")).toHaveValue(NETWORK_EXTERNAL_URL);
+    const expectedInternal =
+      portValue === "80" ? `http://${NETWORK_HOST}` : `http://${NETWORK_HOST}:${portValue}`;
+    await expect(modal.getByLabel("Internal URL")).toHaveValue(expectedInternal);
+
+    await modal.getByRole("button", { name: "Cancel" }).click();
+    await expectModalHidden(modal);
   });
 });


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/22963

- add `externalurl` parameter
- advertise `internal_url` and `external_url` as mDNS text records similar to Homeassistant
- deprecate `scheme` (replaced by `externalurl`)
- drop `SEMP_BASE_URL`
- mDNS always active (independent of .local host config)
- ~drop `evcc.local` host default, use os hostname instead~
- ~use os hostname to generate `internal_url` (not `host` config, mdns only)~

TODO

- [x] config ui @naltatis 