### PR TITLE
Support for amsleser.no meters using HTTP API

### DIFF
--- a/templates/definition/meter/amsleser.yaml
+++ b/templates/definition/meter/amsleser.yaml
@@ -30,6 +30,7 @@ render: |
     {{- else }}
     jq: .w
     {{- end }}
+    cache: 2s
   energy:
     source: http
     uri: {{ include "uri" . }}
@@ -38,33 +39,43 @@ render: |
     {{- else }}
     jq: .ic
     {{- end }}
+    cache: 2s
   currents:
   - source: http
     uri: {{ include "uri" . }}
     jq: .l1.i
+    cache: 2s
   - source: http
     uri: {{ include "uri" . }}
     jq: .l2.i
+    cache: 2s
   - source: http
     uri: {{ include "uri" . }}
     jq: .l3.i
+    cache: 2s
   voltages:
   - source: http
     uri: {{ include "uri" . }}
     jq: .l1.u
+    cache: 2s
   - source: http
     uri: {{ include "uri" . }}
     jq: .l2.u
+    cache: 2s
   - source: http
     uri: {{ include "uri" . }}
     jq: .l3.u
+    cache: 2s
   powers:
   - source: http
     uri: {{ include "uri" . }}
     jq: .l1.p
+    cache: 2s
   - source: http
     uri: {{ include "uri" . }}
     jq: .l2.p
+    cache: 2s
   - source: http
     uri: {{ include "uri" . }}
     jq: .l3.p
+    cache: 2s

--- a/templates/definition/meter/amsleser.yaml
+++ b/templates/definition/meter/amsleser.yaml
@@ -1,0 +1,70 @@
+template: amsleser
+products:
+  - brand: amsleser.no
+    description:
+      generic: Pow-K
+  - brand: amsleser.no
+    description:
+      generic: Pow-U
+  - brand: amsleser.no
+    description:
+      generic: Pow-P1
+params:
+  - name: usage
+    choice: ["grid", "pv", "charge"]
+  - name: host
+  - name: user
+    advanced: true
+  - name: password
+    advanced: true
+render: |
+  {{- define "uri" -}}
+  http://{{ if .user }}{{ urlEncode .user }}:{{ urlEncode .password }}@{{ end }}{{ .host }}/data.json
+  {{- end }}
+  type: custom
+  power:
+    source: http
+    uri: {{ include "uri" . }}
+    {{- if eq .usage "pv" }}
+    jq: .e
+    {{- else }}
+    jq: .w
+    {{- end }}
+  energy:
+    source: http
+    uri: {{ include "uri" . }}
+    {{- if eq .usage "pv" }}
+    jq: .ec
+    {{- else }}
+    jq: .ic
+    {{- end }}
+  currents:
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l1.i
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l2.i
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l3.i
+  voltages:
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l1.u
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l2.u
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l3.u
+  powers:
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l1.p
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l2.p
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .l3.p


### PR DESCRIPTION
## Summary by Sourcery

Introduce a custom amsleser meter definition template that retrieves and parses data from a remote HTTP JSON endpoint with caching and usage-specific extraction

New Features:
- Add new amsleser meter template to fetch power, energy, phase currents, voltages, and powers via HTTP API
- Support configurable usage modes (grid, pv, charge) and optional HTTP basic authentication