### PR TITLE
SMA charger: deprecate  `smaevcharger` in favor of `semp-sma`

### DIFF
--- a/charger/smaevcharger.go
+++ b/charger/smaevcharger.go
@@ -46,6 +46,7 @@ type Smaevcharger struct {
 }
 
 func init() {
+	// TODO remove deprecated
 	registry.Add("smaevcharger", NewSmaevchargerFromConfig)
 }
 

--- a/templates/definition/charger/semp-sma.yaml
+++ b/templates/definition/charger/semp-sma.yaml
@@ -13,9 +13,11 @@ requirements:
     en: |
       Configure the SEMP base URL (e.g. http://192.168.178.100/SEMP) and the device ID of the charger.
       IMPORTANT: The charger must NOT be registered directly as a consumer in the Sunny Home Manager / Sunny Portal at the same time!
+      The configuration option "Disconnect after full charge" must be disabled.
     de: |
       Konfiguriere die SEMP Basis-URL (z.B. http://192.168.178.100/SEMP) und die Geräte-ID des Chargers.
       WICHTIG: Der Charger darf NICHT gleichzeitig im Sunny Home Manager bzw. im Sunny Portal direkt als Verbraucher registriert sein!
+      Die Konfigurationsoption "Trennung nach Vollladung" muss deaktiviert sein.
 params:
   - name: uri
     description:

--- a/templates/definition/charger/smaevcharger.yaml
+++ b/templates/definition/charger/smaevcharger.yaml
@@ -3,10 +3,10 @@ deprecated: true
 products:
   - brand: SMA
     description:
-      generic: EV Charger
+      generic: EV Charger (HTTP)
   - brand: SMA
     description:
-      generic: eCharger
+      generic: eCharger (HTTP)
 capabilities: ["mA"]
 requirements:
   evcc: ["sponsorship"]

--- a/templates/definition/charger/smaevcharger.yaml
+++ b/templates/definition/charger/smaevcharger.yaml
@@ -1,4 +1,5 @@
 template: smaevcharger
+deprecated: true
 products:
   - brand: SMA
     description:


### PR DESCRIPTION
Deprecate legacy `smaevcharger` implementation (using WebUI-API)

Replaced by `semp-sma`.

Fixes https://github.com/evcc-io/evcc/discussions/16071#discussioncomment-14909397
Fixes #25178