### PR TITLE
feat: implement dynamic scaling for price charts

### DIFF
--- a/assets/js/components/ChargingPlans/Preview.stories.ts
+++ b/assets/js/components/ChargingPlans/Preview.stories.ts
@@ -79,6 +79,18 @@ const dynamicData = {
   targetTime: createDate(13),
 };
 
+// Small variations - tests dynamic scaling
+const smallVariationsData = {
+  rates: [0.25, 0.26, 0.255, 0.27, 0.265, 0.26, 0.255, 0.27, 0.265, 0.26, 0.25, 0.255].map(
+    (value, i) => createRate(value, i)
+  ),
+  duration: 8695,
+  plan: [createRate(0.255, 6, 3)],
+  smartCostType: SMART_COST_TYPE.PRICE_DYNAMIC,
+  currency: CURRENCY.EUR,
+  targetTime: createDate(11),
+};
+
 export default {
   title: "ChargingPlans/Preview",
   component: Preview,
@@ -114,3 +126,6 @@ Unknown.args = unknownData;
 
 export const Dynamic = Template.bind({});
 Dynamic.args = dynamicData;
+
+export const SmallVariations = Template.bind({});
+SmallVariations.args = smallVariationsData;

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -38,6 +38,7 @@ import colors, { lighterColor } from "@/colors";
 import type { CURRENCY } from "@/types/evcc";
 import { ForecastType, highestSlotIndexByDay } from "@/utils/forecast";
 import type { ForecastSlot, SolarDetails, TimeseriesEntry } from "./types";
+import { calculateDynamicScale } from "@/utils/chartScaling";
 
 registerChartComponents([
 	BarController,
@@ -111,6 +112,11 @@ export default defineComponent({
 		},
 		maxSolarIndex() {
 			return this.maxEntryIndex(this.solarEntries);
+		},
+		priceScale() {
+			// Calculate dynamic scale for price data with 10% margin
+			const values = this.gridSlots.map((s) => s.value);
+			return calculateDynamicScale(values, 10, 0.01);
 		},
 		solarHighlights() {
 			const { today, tomorrow, dayAfterTomorrow } = this.solar || {};
@@ -381,8 +387,8 @@ export default defineComponent({
 					},
 					yPrice: {
 						...this.yScaleOptions(ForecastType.Price),
-						suggestedMin: 0,
-						max: this.yMax(this.gridSlots),
+						min: this.priceScale.min,
+						max: this.priceScale.max,
 					},
 				},
 			};

--- a/assets/js/components/Tariff/TariffChart.vue
+++ b/assets/js/components/Tariff/TariffChart.vue
@@ -61,6 +61,7 @@ import { is12hFormat } from "@/units";
 import PlanEndIcon from "../MaterialIcon/PlanEnd.vue";
 import formatter from "@/mixins/formatter";
 import type { Slot } from "@/types/evcc";
+import { calculateDynamicScale, normalizeToHeight } from "@/utils/chartScaling";
 const BAR_WIDTH = 8;
 
 export default defineComponent({
@@ -85,16 +86,9 @@ export default defineComponent({
 	},
 	computed: {
 		valueInfo() {
-			let max = Number.MIN_VALUE;
-			let min = 0;
-			this.slots
-				.map((s) => s.value)
-				.filter((value) => value !== undefined)
-				.forEach((value) => {
-					max = Math.max(max, value);
-					min = Math.min(min, value);
-				});
-			return { min, range: max - min };
+			const values = this.slots.map((s) => s.value);
+			const scale = calculateDynamicScale(values, 10, 0.01);
+			return { min: scale.min, range: scale.range };
 		},
 		targetLeft() {
 			return `${(this.targetOffset / 0.25) * BAR_WIDTH}px`;
@@ -150,7 +144,7 @@ export default defineComponent({
 			const val = value === undefined ? this.avgValue : value;
 			const height =
 				value !== undefined && !isNaN(val)
-					? `${10 + (90 / this.valueInfo.range) * (val - this.valueInfo.min)}%`
+					? `${normalizeToHeight(val, this.valueInfo.min, this.valueInfo.range)}%`
 					: "50%";
 			return { height };
 		},

--- a/assets/js/utils/chartScaling.ts
+++ b/assets/js/utils/chartScaling.ts
@@ -1,0 +1,79 @@
+/**
+ * Dynamic chart scaling utilities for price visualizations.
+ * These functions ensure that price differences are visible even when values are similar.
+ */
+
+export interface ScalingResult {
+  min: number;
+  max: number;
+  range: number;
+}
+
+/**
+ * Calculate dynamic y-axis boundaries for price data with visual margins.
+ * This ensures bars remain visually distinguishable even when prices vary slightly.
+ *
+ * @param values - Array of numeric values to scale
+ * @param marginPercent - Percentage of range to add as margin (default: 10%)
+ * @param minMargin - Minimum absolute margin to ensure visibility (default: 0.01)
+ * @returns Object with min, max, and range values
+ */
+export const calculateDynamicScale = (
+  values: (number | undefined)[],
+  marginPercent: number = 10,
+  minMargin: number = 0.01
+): ScalingResult => {
+  // Filter out undefined values
+  const validValues = values.filter((v): v is number => v !== undefined && !isNaN(v));
+
+  if (validValues.length === 0) {
+    return { min: 0, max: 1, range: 1 };
+  }
+
+  const dataMin = Math.min(...validValues);
+  const dataMax = Math.max(...validValues);
+  const dataRange = dataMax - dataMin;
+
+  // Calculate margin as percentage of range, but at least minMargin
+  const margin = Math.max(dataRange * (marginPercent / 100), minMargin);
+
+  // Apply margins
+  const min = dataMin - margin;
+  const max = dataMax + margin;
+  const range = max - min;
+
+  return { min, max, range };
+};
+
+/**
+ * Normalize a value to a percentage (0-100) based on dynamic scale.
+ * Used for calculating bar heights relative to min/max boundaries.
+ *
+ * @param value - The value to normalize
+ * @param min - Minimum boundary
+ * @param range - Range (max - min)
+ * @param minHeight - Minimum height percentage (default: 10%)
+ * @param maxHeight - Maximum height percentage (default: 90%)
+ * @returns Percentage height (minHeight to maxHeight)
+ */
+export const normalizeToHeight = (
+  value: number | undefined,
+  min: number,
+  range: number,
+  minHeight: number = 10,
+  maxHeight: number = 90
+): number => {
+  if (value === undefined || isNaN(value)) {
+    return (minHeight + maxHeight) / 2; // Return middle height for undefined values
+  }
+
+  if (range === 0) {
+    return (minHeight + maxHeight) / 2; // Return middle height if all values are the same
+  }
+
+  // Calculate normalized position (0 to 1)
+  const normalized = (value - min) / range;
+
+  // Map to height range (minHeight% to maxHeight%)
+  return minHeight + normalized * (maxHeight - minHeight);
+};

--- a/tests/dynamic-chartScaling.ts
+++ b/tests/dynamic-chartScaling.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { calculateDynamicScale, normalizeToHeight } from "../assets/js/utils/chartScaling";
+
+describe("calculateDynamicScale", () => {
+  it("should calculate scale for normal price range", () => {
+    const values = [0.1, 0.2, 0.3, 0.4];
+    const result = calculateDynamicScale(values);
+
+    expect(result.min).toBeLessThan(0.1);
+    expect(result.max).toBeGreaterThan(0.4);
+    expect(result.range).toBe(result.max - result.min);
+  });
+
+  it("should handle small variations with minimum margin", () => {
+    const values = [0.25, 0.26, 0.27];
+    const result = calculateDynamicScale(values);
+
+    // Range is 0.02, 10% would be 0.002, but minMargin is 0.01
+    expect(result.range).toBeGreaterThan(0.02);
+    expect(result.min).toBeLessThan(0.25);
+    expect(result.max).toBeGreaterThan(0.27);
+  });
+
+  it("should handle identical values", () => {
+    const values = [0.3, 0.3, 0.3];
+    const result = calculateDynamicScale(values);
+
+    // With zero range, should use minMargin
+    expect(result.min).toBeLessThan(0.3);
+    expect(result.max).toBeGreaterThan(0.3);
+    expect(result.range).toBeGreaterThan(0);
+  });
+
+  it("should filter out undefined values", () => {
+    const values = [0.1, undefined, 0.3, undefined, 0.5];
+    const result = calculateDynamicScale(values);
+
+    expect(result.min).toBeLessThan(0.1);
+    expect(result.max).toBeGreaterThan(0.5);
+  });
+
+  it("should handle negative values", () => {
+    const values = [-0.1, 0.0, 0.1];
+    const result = calculateDynamicScale(values);
+
+    expect(result.min).toBeLessThan(-0.1);
+    expect(result.max).toBeGreaterThan(0.1);
+  });
+
+  it("should return default scale for empty array", () => {
+    const values: number[] = [];
+    const result = calculateDynamicScale(values);
+
+    expect(result.min).toBe(0);
+    expect(result.max).toBe(1);
+    expect(result.range).toBe(1);
+  });
+
+  it("should handle array with only undefined values", () => {
+    const values = [undefined, undefined, undefined];
+    const result = calculateDynamicScale(values);
+
+    expect(result.min).toBe(0);
+    expect(result.max).toBe(1);
+    expect(result.range).toBe(1);
+  });
+
+  it("should respect custom margin percentage", () => {
+    const values = [1.0, 2.0];
+    const result5 = calculateDynamicScale(values, 5);
+    const result20 = calculateDynamicScale(values, 20);
+
+    // Higher margin should create larger range
+    expect(result20.range).toBeGreaterThan(result5.range);
+  });
+
+  it("should handle NaN values", () => {
+    const values = [0.1, NaN, 0.3];
+    const result = calculateDynamicScale(values);
+
+    expect(result.min).toBeLessThan(0.1);
+    expect(result.max).toBeGreaterThan(0.3);
+  });
+});
+
+describe("normalizeToHeight", () => {
+  it("should normalize value to height percentage", () => {
+    const min = 0;
+    const range = 10;
+
+    expect(normalizeToHeight(0, min, range)).toBe(10); // Minimum value -> 10%
+    expect(normalizeToHeight(10, min, range)).toBe(90); // Maximum value -> 90%
+    expect(normalizeToHeight(5, min, range)).toBe(50); // Middle value -> 50%
+  });
+
+  it("should handle undefined values with middle height", () => {
+    const result = normalizeToHeight(undefined, 0, 10);
+    expect(result).toBe(50); // Middle of 10% and 90%
+  });
+
+  it("should handle zero range with middle height", () => {
+    const result = normalizeToHeight(5, 5, 0);
+    expect(result).toBe(50);
+  });
+
+  it("should respect custom height boundaries", () => {
+    const min = 0;
+    const range = 10;
+
+    expect(normalizeToHeight(0, min, range, 20, 80)).toBe(20);
+    expect(normalizeToHeight(10, min, range, 20, 80)).toBe(80);
+    expect(normalizeToHeight(5, min, range, 20, 80)).toBe(50);
+  });
+
+  it("should handle negative min values", () => {
+    const min = -5;
+    const range = 10; // -5 to 5
+
+    expect(normalizeToHeight(-5, min, range)).toBe(10);
+    expect(normalizeToHeight(5, min, range)).toBe(90);
+    expect(normalizeToHeight(0, min, range)).toBe(50);
+  });
+
+  it("should handle NaN values with middle height", () => {
+    const result = normalizeToHeight(NaN, 0, 10);
+    expect(result).toBe(50);
+  });
+
+  it("should clamp values within range", () => {
+    const min = 0;
+    const range = 10;
+
+    // Values outside range should still be normalized
+    const below = normalizeToHeight(-5, min, range);
+    const above = normalizeToHeight(15, min, range);
+
+    expect(below).toBeLessThan(10);
+    expect(above).toBeGreaterThan(90);
+  });
+});


### PR DESCRIPTION
fix https://github.com/evcc-io/evcc/issues/25202

## Overview
Price-related charts previously used a **fixed zero baseline**, causing small variations (e.g., **25.0–27.0 ct/kWh**) to appear visually identical. Bars rendered at ~100% height regardless of the actual difference, making the charts misleading and hard to interpret.

This PR introduces **dynamic Y-axis scaling** across all relevant chart components to ensure that both small and large value ranges are visually meaningful.

---

### Reusable Scaling Utility (`chartScaling.ts`)
A new utility centralizes all price-scale logic:

`calculateDynamicScale()` computes min/max with margins (default 10%, minimum 0.01 absolute)
`normalizeToHeight()` maps values to 10-90% height range
Handles edge cases: identical values, negatives, undefined/NaN



### Visual Impact

Small variations (25.0-27.0 ct/kWh) - bars now clearly distinguishable:

![7270F1B9-4D7E-483A-AC28-F1CFC1788E52](https://github.com/user-attachments/assets/714a9ec2-e44c-4a74-bc93-f489d25236bd)


Large variations with negatives - handles full range:

![B39ECF2C-F9E2-4ED9-A901-A0ED9A74BFED](https://github.com/user-attachments/assets/e8f7e394-833d-464b-a637-601e334540df)


