### PR TITLE
Openwb-native: follow-up

### DIFF
--- a/charger/openwb-native_linux.go
+++ b/charger/openwb-native_linux.go
@@ -126,11 +126,11 @@ var _ api.Resurrector = (*OpenWbNative)(nil)
 // WakeUp implements the api.Resurrector interface
 func (wb *OpenWbNative) WakeUp() error {
 	cpPin := rpio.Pin(native.ChargePoints[wb.connector-1].PIN_CP)
-	seq := []gpioAction{
+
+	return wb.runGpioSequence([]gpioAction{
 		{pin: cpPin, high: true, delay: wb.cpWait},
 		{pin: cpPin, high: false, delay: 0},
-	}
-	return wb.runGpioSequence(seq)
+	})
 }
 
 // gpioAction defines a single GPIO pin operation with timing
@@ -174,13 +174,12 @@ func (wb *OpenWbNative) gpioSwitchPhases(phases int) error {
 		phPin = rpio.Pin(native.ChargePoints[wb.connector-1].PIN_1P)
 	}
 
-	seq := []gpioAction{
+	return wb.runGpioSequence([]gpioAction{
 		{pin: cpPin, high: true, delay: time.Second},    // enable phases switch relay (NO), disconnect CP
 		{pin: phPin, high: true, delay: wb.cpWait / 2},  // move latching relay to desired position
 		{pin: phPin, high: false, delay: wb.cpWait / 2}, // lock latching relay
 		{pin: cpPin, high: false, delay: time.Second},   // disable phase switching, reconnect CP
-	}
-	return wb.runGpioSequence(seq)
+	})
 }
 
 // Identify implements the api.Identifier interface

--- a/charger/openwb-native_linux.go
+++ b/charger/openwb-native_linux.go
@@ -24,13 +24,20 @@ type OpenWbNative struct {
 	chargeState api.ChargeStatus
 }
 
+// gpioAction defines a single GPIO pin operation with timing
+type gpioAction struct {
+	pin   rpio.Pin
+	high  bool
+	delay time.Duration
+}
+
 func init() {
 	registry.AddCtx("openwb-native", NewOpenWbNativeFromConfig)
 }
 
 //go:generate go tool decorate -o openwb-native_decorators_linux.go -f decorateOpenWbNative -b *OpenWbNative -r api.Charger -t "api.PhaseSwitcher,Phases1p3p,func(int) error" -t "api.Identifier,Identify,func() (string, error)"
 
-// NewOpenWbNativeFromConfig creates an OpenWbNative DIN charger from generic config
+// NewOpenWbNativeFromConfig creates an OpenWbNative charger from generic config
 func NewOpenWbNativeFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
 	cc := struct {
 		Phases1p3p      bool
@@ -131,13 +138,6 @@ func (wb *OpenWbNative) WakeUp() error {
 		{pin: cpPin, high: true, delay: wb.cpWait},
 		{pin: cpPin, high: false, delay: 0},
 	})
-}
-
-// gpioAction defines a single GPIO pin operation with timing
-type gpioAction struct {
-	pin   rpio.Pin
-	high  bool
-	delay time.Duration
 }
 
 // runGpioSequence executes a sequence of GPIO operations

--- a/charger/openwb/native/rfid.go
+++ b/charger/openwb/native/rfid.go
@@ -23,11 +23,14 @@ func (c *RfIdContainer) Set(rfId string) {
 }
 
 func (c *RfIdContainer) Get() string {
+	c.mut.Lock()
+	defer c.mut.Unlock()
 	return c.rfId
 }
 
-// NewRFIDHandler initializes RFID device monitoring and returns the channel for RFID reads.
-// It also returns a cancel function to stop monitoring and clean up resources.
+// NewRFIDHandler initializes RFID device monitoring.
+// It starts goroutines that monitor RFID devices and update the rfIdContainer.
+// Monitoring stops when the context is cancelled.
 func NewRFIDHandler(rfIdVidPid string, ctx context.Context, rfIdContainer *RfIdContainer, log *util.Logger) error {
 	devicePaths, err := evdev.ListDevicePaths()
 	if err != nil {

--- a/charger/openwb/native/rfid.go
+++ b/charger/openwb/native/rfid.go
@@ -12,19 +12,19 @@ import (
 )
 
 type RfIdContainer struct {
-	mut  sync.Mutex
+	mu   sync.Mutex
 	rfId string
 }
 
 func (c *RfIdContainer) Set(rfId string) {
-	c.mut.Lock()
-	defer c.mut.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.rfId = rfId
 }
 
 func (c *RfIdContainer) Get() string {
-	c.mut.Lock()
-	defer c.mut.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.rfId
 }
 


### PR DESCRIPTION
Follow-up from #21984

1. RfIdContainer.Get() thread-safe gemacht (rfid.go)
2. NewRFIDHandler Docstring korrigiert (rfid.go)
3. GPIO Operationen refactored (openwb-native_linux.go)