### PR TITLE
Config UI: add provider auth subject to login errors

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -1,6 +1,10 @@
 package api
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/cenkalti/backoff/v4"
+)
 
 // ErrNotAvailable indicates that a feature is not available
 var ErrNotAvailable = errors.New("not available")
@@ -12,26 +16,19 @@ var ErrMustRetry = errors.New("must retry")
 var ErrSponsorRequired = errors.New("sponsorship required, see https://docs.evcc.io/docs/sponsorship")
 
 // ErrMissingCredentials indicates that user/password are missing
-var ErrMissingCredentials = errors.New("missing user/password credentials")
+var ErrMissingCredentials = backoff.Permanent(errors.New("missing user/password credentials"))
 
 // ErrLoginRequired indicates that retrieving tokens credentials waits for login
-var ErrLoginRequired = errors.New("login required")
+var ErrLoginRequired = backoff.Permanent(errors.New("login required"))
 
 // ErrMissingToken indicates that access/refresh tokens are missing
-var ErrMissingToken = errors.New("missing token credentials")
+var ErrMissingToken = backoff.Permanent(errors.New("missing token credentials"))
 
 // ErrOutdated indicates that result is outdated
 var ErrOutdated = errors.New("outdated")
 
-// ErrTimeout is the error returned when a timeout happened.
-// Modeled after context.DeadlineError
-var ErrTimeout error = errTimeoutError{}
-
-type errTimeoutError struct{}
-
-func (errTimeoutError) Error() string   { return "timeout" }
-func (errTimeoutError) Timeout() bool   { return true }
-func (errTimeoutError) Temporary() bool { return true }
+// ErrTimeout is the error returned when a timeout happened
+var ErrTimeout error = errors.New("timeout")
 
 // ErrAsleep indicates that vehicle is asleep. Caller may chose to wake up the vehicle and retry.
 var ErrAsleep error = errAsleep{}

--- a/api/error.go
+++ b/api/error.go
@@ -18,9 +18,6 @@ var ErrSponsorRequired = errors.New("sponsorship required, see https://docs.evcc
 // ErrMissingCredentials indicates that user/password are missing
 var ErrMissingCredentials = backoff.Permanent(errors.New("missing user/password credentials"))
 
-// ErrLoginRequired indicates that retrieving tokens credentials waits for login
-var ErrLoginRequired = backoff.Permanent(errors.New("login required"))
-
 // ErrMissingToken indicates that access/refresh tokens are missing
 var ErrMissingToken = backoff.Permanent(errors.New("missing token credentials"))
 
@@ -29,6 +26,22 @@ var ErrOutdated = errors.New("outdated")
 
 // ErrTimeout is the error returned when a timeout happened
 var ErrTimeout error = errors.New("timeout")
+
+// LoginRequiredError creates a login error for given auth provider
+func LoginRequiredError(providerAuth string) error {
+	return backoff.Permanent(&ErrLoginRequired{
+		ProviderAuth: providerAuth,
+	})
+}
+
+// ErrLoginRequired indicates that retrieving tokens credentials waits for login
+type ErrLoginRequired struct {
+	ProviderAuth string
+}
+
+func (err *ErrLoginRequired) Error() string {
+	return "login required"
+}
 
 // ErrAsleep indicates that vehicle is asleep. Caller may chose to wake up the vehicle and retry.
 var ErrAsleep error = errAsleep{}

--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -180,7 +180,7 @@ func (o *OAuth) Token() (*oauth2.Token, error) {
 	defer o.mu.Unlock()
 
 	if o.token == nil {
-		return nil, api.ErrMissingToken
+		return nil, api.LoginRequiredError(o.subject)
 	}
 
 	if o.token.Valid() {

--- a/plugin/auth/oauth_test.go
+++ b/plugin/auth/oauth_test.go
@@ -21,7 +21,7 @@ func TestOAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := ts.Token()
-	require.ErrorContains(t, err, "missing token credentials")
+	require.ErrorContains(t, err, "login required")
 	require.False(t, token.Valid())
 	require.Equal(t, 0, storerCalled)
 

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -26,7 +26,6 @@ import (
 	"github.com/evcc-io/evcc/util/logstash"
 	"github.com/gorilla/mux"
 	"github.com/itchyny/gojq"
-	"go.yaml.in/yaml/v4"
 	"golang.org/x/text/language"
 )
 
@@ -82,35 +81,12 @@ func jsonHandler(h http.Handler) http.Handler {
 }
 
 func jsonWrite(w http.ResponseWriter, data any) {
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		log.ERROR.Printf("httpd: failed to encode JSON: %v", err)
-	}
+	json.NewEncoder(w).Encode(data)
 }
 
 func jsonError(w http.ResponseWriter, status int, err error) {
 	w.WriteHeader(status)
-
-	res := struct {
-		Error       string `json:"error"`
-		Line        int    `json:"line,omitempty"`
-		IsAuthError bool   `json:"isAuthError,omitempty"`
-	}{
-		Error:       err.Error(),
-		IsAuthError: errors.Is(err, api.ErrLoginRequired) || errors.Is(err, api.ErrMissingToken),
-	}
-
-	var (
-		ype *yaml.ParserError
-		yue *yaml.UnmarshalError
-	)
-	switch {
-	case errors.As(err, &ype):
-		res.Line = ype.Line
-	case errors.As(err, &yue):
-		res.Line = yue.Line
-	}
-
-	jsonWrite(w, res)
+	jsonWrite(w, util.ErrorAsJson(err))
 }
 
 func handler[T any](conv func(string) (T, error), set func(T) error, get func() T) http.HandlerFunc {

--- a/util/error.go
+++ b/util/error.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"errors"
+
+	"github.com/evcc-io/evcc/api"
+	"go.yaml.in/yaml/v4"
+)
+
+// ErrorAsJson returns an error as json-formattable struct
+func ErrorAsJson(err error) any {
+	res := struct {
+		Error         string `json:"error"`
+		Line          int    `json:"line,omitempty"`
+		IsAuthError   bool   `json:"isAuthError,omitempty"`
+		LoginRequired string `json:"loginRequired,omitempty"`
+	}{
+		Error:       err.Error(),
+		IsAuthError: errors.Is(err, api.ErrMissingToken),
+	}
+
+	if ae := new(api.ErrLoginRequired); errors.As(err, &ae) {
+		res.IsAuthError = true
+		res.LoginRequired = ae.ProviderAuth
+	}
+
+	var (
+		ype *yaml.ParserError
+		yue *yaml.UnmarshalError
+	)
+	switch {
+	case errors.As(err, &ype):
+		res.Line = ype.Line
+	case errors.As(err, &yue):
+		res.Line = yue.Line
+	}
+
+	return res
+}

--- a/util/error.go
+++ b/util/error.go
@@ -12,15 +12,12 @@ func ErrorAsJson(err error) any {
 	res := struct {
 		Error         string `json:"error"`
 		Line          int    `json:"line,omitempty"`
-		IsAuthError   bool   `json:"isAuthError,omitempty"`
 		LoginRequired string `json:"loginRequired,omitempty"`
 	}{
-		Error:       err.Error(),
-		IsAuthError: errors.Is(err, api.ErrMissingToken),
+		Error: err.Error(),
 	}
 
 	if ae := new(api.ErrLoginRequired); errors.As(err, &ae) {
-		res.IsAuthError = true
 		res.LoginRequired = ae.ProviderAuth
 	}
 

--- a/vehicle/bmw/cardata/token.go
+++ b/vehicle/bmw/cardata/token.go
@@ -29,5 +29,6 @@ func TokenExtra(t *oauth2.Token, key string) string {
 }
 
 func tokenError(err error) bool {
-	return errors.Is(err, api.ErrLoginRequired) || errors.Is(err, api.ErrMissingToken)
+	ae := new(api.ErrLoginRequired)
+	return errors.As(err, &ae)
 }


### PR DESCRIPTION
@naltatis this PR adds `loginRequired: <auth item>` to error returns.

ATM this will work for creating new devices, but not for the status endpoint since that returns the plain error message only. We can change that, but maybe in step 2.

Please check if we can remove the `IsAuthError` property, it seems this might no longer be required now that we have `LoginRequired`?