### PR TITLE
Marstek Venus E: add Modbus TCPIP support (fixes #25373)

### DIFF
--- a/templates/definition/meter/marstek-venus.yaml
+++ b/templates/definition/meter/marstek-venus.yaml
@@ -8,7 +8,7 @@ params:
   - name: usage
     choice: ["battery"]
   - name: modbus
-    choice: ["rs485"]
+    choice: ["rs485", "tcpip"]
     baudrate: 115200
     comset: 8N1
   - name: capacity


### PR DESCRIPTION
Add Modbus TCPIP support for Marstek Venus-E battery devices.

This enables compatibility with the Modbus TCP mode for adapters that do the translation from Modbus RTU to TCP themselves, instead of having EVCC send Modbus RTU data directly.

Fixes #25373 