### PR TITLE
Forecast/Planner: 4-day forecast data

### DIFF
--- a/assets/js/components/ChargingPlans/Preview.test.ts
+++ b/assets/js/components/ChargingPlans/Preview.test.ts
@@ -39,8 +39,8 @@ describe("basics", () => {
     result = wrapper.vm.slots;
   });
 
-  test("should return 39 slots", () => {
-    expect(result.length).eq(192);
+  test("should return 384 slots", () => {
+    expect(result.length).eq(384);
   });
 
   test("slots should be an hour apart", () => {

--- a/assets/js/components/ChargingPlans/Preview.vue
+++ b/assets/js/components/ChargingPlans/Preview.vue
@@ -144,7 +144,7 @@ export default defineComponent({
 			base.setSeconds(0, 0);
 			base.setMinutes(base.getMinutes() - (base.getMinutes() % 15));
 
-			return Array.from({ length: 48 * 4 }, (_, i) => {
+			return Array.from({ length: 96 * 4 }, (_, i) => {
 				const start = new Date(base.getTime() + quarterHour * i);
 				const end = new Date(start.getTime() + quarterHour);
 				const charging = !!this.findSlotInRange(start, end, plan);

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -85,7 +85,7 @@ export default defineComponent({
 	computed: {
 		endDate() {
 			const end = new Date(this.startDate);
-			end.setHours(end.getHours() + 48);
+			end.setHours(end.getHours() + 96);
 			return end;
 		},
 		solarEntries() {

--- a/assets/js/components/Forecast/Details.vue
+++ b/assets/js/components/Forecast/Details.vue
@@ -71,7 +71,7 @@ import { ForecastType, findLowestSumSlotIndex } from "@/utils/forecast";
 import type { ForecastSlot, SolarDetails } from "./types";
 const LOCALES_WITHOUT_DAY_AFTER_TOMORROW = ["en", "tr"];
 
-const FORECASTED_HOURS = 48;
+const FORECASTED_HOURS = 96;
 const SLOTS_PER_HOUR = 4;
 
 export interface Energy {

--- a/assets/js/components/Tariff/SmartTariffBase.vue
+++ b/assets/js/components/Tariff/SmartTariffBase.vue
@@ -216,7 +216,7 @@ export default defineComponent({
 			base.setSeconds(0, 0);
 			base.setMinutes(base.getMinutes() - (base.getMinutes() % 15));
 
-			return Array.from({ length: 48 * 4 }, (_, i) => {
+			return Array.from({ length: 96 * 4 }, (_, i) => {
 				const start = new Date(base.getTime() + quarterHour * i);
 				const end = new Date(start.getTime() + quarterHour);
 				const value = this.findRateInRange(start, end, rates)?.value;

--- a/tests/battery-settings-co2.spec.ts
+++ b/tests/battery-settings-co2.spec.ts
@@ -22,7 +22,7 @@ test.describe("battery settings co2", async () => {
     await modal.getByLabel("Enable limit").check();
     await modal.getByLabel("CO₂ limit").selectOption({ label: "≤ 150 g/kWh" });
     // CO2 demo tariff provides 72 hours, so active hours vary by test execution time
-    await expect(modal.getByTestId("active-hours").locator('.value')).toHaveText(/^\d+ hr$/);
+    await expect(modal.getByTestId("active-hours").locator(".value")).toHaveText(/^\d+ hr$/);
     await expect(modal).toContainText("20 g – 150 g");
     await page.getByRole("button", { name: "Close" }).click();
     await expectModalHidden(modal);

--- a/tests/battery-settings-co2.spec.ts
+++ b/tests/battery-settings-co2.spec.ts
@@ -22,7 +22,7 @@ test.describe("battery settings co2", async () => {
     await modal.getByLabel("Enable limit").check();
     await modal.getByLabel("CO₂ limit").selectOption({ label: "≤ 150 g/kWh" });
     // CO2 demo tariff provides 72 hours, so active hours vary by test execution time
-    await expect(modal.getByTestId("active-hours").locator(".value")).toHaveText(/^\d+ hr$/);
+    await expect(modal.getByTestId("active-hours").locator(".value")).toHaveText(/^\d+ hr/);
     await expect(modal).toContainText("20 g – 150 g");
     await page.getByRole("button", { name: "Close" }).click();
     await expectModalHidden(modal);

--- a/tests/battery-settings-co2.spec.ts
+++ b/tests/battery-settings-co2.spec.ts
@@ -21,7 +21,8 @@ test.describe("battery settings co2", async () => {
     await modal.getByRole("link", { name: "Grid charging" }).click();
     await modal.getByLabel("Enable limit").check();
     await modal.getByLabel("CO₂ limit").selectOption({ label: "≤ 150 g/kWh" });
-    await expect(modal.getByTestId("active-hours")).toHaveText(["Active time", "48 hr"].join(""));
+    // CO2 demo tariff provides 72 hours, so active hours vary by test execution time
+    await expect(modal.getByTestId("active-hours").locator('.value')).toHaveText(/^\d+ hr$/);
     await expect(modal).toContainText("20 g – 150 g");
     await page.getByRole("button", { name: "Close" }).click();
     await expectModalHidden(modal);

--- a/tests/battery-settings.spec.ts
+++ b/tests/battery-settings.spec.ts
@@ -49,7 +49,7 @@ test.describe("battery settings", async () => {
     await modal.getByRole("link", { name: "Grid charging" }).click();
     await modal.getByLabel("Enable limit").check();
     await modal.getByLabel("Price limit").selectOption({ label: "≤ 50.0 ct/kWh" });
-    await expect(modal.getByTestId("active-hours")).toHaveText(["Active time", "48 hr"].join(""));
+    await expect(modal.getByTestId("active-hours")).toHaveText(["Active time", "96 hr"].join(""));
     await expect(modal).toContainText("5.0 ct – 50.0 ct");
     await page.getByRole("button", { name: "Close" }).click();
     await expectModalHidden(modal);

--- a/tests/smart-cost.spec.ts
+++ b/tests/smart-cost.spec.ts
@@ -42,7 +42,7 @@ test.describe("smart cost limit", async () => {
     await expect(modal).toBeVisible();
     await modal.getByLabel("Enable limit").check();
     await modal.getByLabel("Price limit").selectOption("≤ 40.0 ct/kWh");
-    await expect(modal.getByTestId("active-hours")).toHaveText(["Active time", "48 hr"].join(""));
+    await expect(modal.getByTestId("active-hours")).toHaveText(["Active time", "96 hr"].join(""));
     await modal.getByLabel("Close").click();
     await expect(modal).not.toBeVisible();
     await expect(page.getByTestId("vehicle-status-charger")).toHaveText("Charging…");

--- a/tests/smart-feedin.spec.ts
+++ b/tests/smart-feedin.spec.ts
@@ -31,7 +31,7 @@ test.describe("smart feed-in priority", async () => {
     await expectModalVisible(modal);
     await modal.getByLabel("Enable limit").check();
     await modal.getByLabel("Feed-in limit").selectOption("≥ 10.0 ct/kWh");
-    await expect(modal.getByTestId("active-hours")).toHaveText(["Paused time", "48 hr"].join(""));
+    await expect(modal.getByTestId("active-hours")).toHaveText(["Paused time", "96 hr"].join(""));
     await modal.getByLabel("Close").click();
     await expectModalHidden(modal);
 
@@ -59,7 +59,7 @@ test.describe("smart feed-in priority", async () => {
     await expectModalVisible(modal1);
     await modal1.getByLabel("Enable limit").check();
     await modal1.getByLabel("Feed-in limit").selectOption("≥ 10.0 ct/kWh");
-    await expect(modal1.getByTestId("active-hours")).toHaveText(["Paused time", "48 hr"].join(""));
+    await expect(modal1.getByTestId("active-hours")).toHaveText(["Paused time", "96 hr"].join(""));
     await modal1.getByRole("button", { name: "Apply everywhere?" }).click();
     await modal1.getByLabel("Close").click();
     await expectModalHidden(modal1);


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/25383
fixes https://github.com/evcc-io/evcc/issues/24986
replaces https://github.com/evcc-io/evcc/pull/25314

Increase the tariff range shown in UI from 48h to 96h.

Implications: forecast data on large screens are shown more dense, since horizontal scrolling is only introduced on smaller screens. This still works for this amount of data. Switching to a larger time-frame (data-dependent) would require a more intelligent space handling here. 

<img width="1025" height="616" alt="Bildschirmfoto 2025-11-18 um 13 02 04" src="https://github.com/user-attachments/assets/ccd2dc45-e398-4fa9-b951-f238b7425016" />
<img width="1010" height="648" alt="Bildschirmfoto 2025-11-18 um 13 02 12" src="https://github.com/user-attachments/assets/b2d67557-380b-488f-b751-90bcd0e86a44" />
<img width="1035" height="704" alt="Bildschirmfoto 2025-11-18 um 13 02 28" src="https://github.com/user-attachments/assets/0ab01672-3c9d-4ca3-8b4c-5d9b5ce615b5" />
<img width="929" height="501" alt="Bildschirmfoto 2025-11-18 um 13 02 53" src="https://github.com/user-attachments/assets/33e4e645-0a9c-47da-a346-fb453db85643" />
