### PR TITLE
Support Enphase IQ Batteries

### DIFF
--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -23,6 +23,16 @@ params:
   - name: cache
     advanced: true
     default: 1s
+  - name: battery_type
+    description:
+      en: "Enphase Battery Type (AC or IQ)"
+      de: "Enphase Batterietyp (AC oder IQ)"
+    help:
+      en: "Select 'iq' for new Enphase IQ Batteries. Leave at default 'ac' for older generation AC Batteries."
+      de: "Wähle 'iq' falls die neuere 'IQ Battery' Generation installiert ist. Standardeinstellung 'ac' für die ältere 'AC Battery' Generation."
+    default: ac
+    choice: ["ac", "iq"]
+    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -128,7 +138,11 @@ render: |
   {{- if eq .usage "battery" }}
   power:
     source: http
+    {{- if eq .battery_type "iq" }}
+    uri: {{ .schema }}://{{ .host }}/ivp/livedata/status
+    {{- else }}
     uri: {{ .schema }}://{{ .host }}/production.json?details=1
+    {{- end}}
     {{- if .token }}
     auth:
       type: bearer
@@ -136,7 +150,11 @@ render: |
     insecure: true
     {{- end }}
     cache: {{ .cache }}
+    {{- if eq .battery_type "iq" }}
+    jq: ((.meters.storage.agg_p_mw // 0) / 1000 | round)
+    {{- else }}
     jq: .storage[] | .wNow
+    {{- end}}
   soc:
     source: http
     uri: {{ .schema }}://{{ .host }}/ivp/ensemble/inventory

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -4,9 +4,6 @@ products:
     description:
       generic: IQ Envoy
 requirements:
-  description:
-    de: 'Als Batteriespeicher werden seitens der Enphase-API derzeit nur die Batterien vom Typ "AC Battery" unterstützt.'
-    en: 'Only batteries of type "AC Battery" are currently supported by Enphase-API.'
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]


### PR DESCRIPTION
The Enphase template currently only supports power metering for older "AC Batteries". This PR adds a template parameter to let the user witch to the newer "IQ Battery" type which requires querying power from a different API endpoint.

This PR is a revival of PR #23063