### PR TITLE
Kathrein: remove unreliable session energy

### DIFF
--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -321,6 +321,9 @@ func (wb *Kathrein) ChargeDuration() (time.Duration, error) {
 	return time.Duration(binary.BigEndian.Uint32(b)) * time.Second, nil
 }
 
+// removed since broken, see https://github.com/evcc-io/evcc/pull/25427
+// var _ api.ChargeRater = (*Kathrein)(nil)
+
 var _ api.MeterEnergy = (*Kathrein)(nil)
 
 // TotalEnergy implements the api.MeterEnergy interface

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -321,18 +321,6 @@ func (wb *Kathrein) ChargeDuration() (time.Duration, error) {
 	return time.Duration(binary.BigEndian.Uint32(b)) * time.Second, nil
 }
 
-var _ api.ChargeRater = (*Kathrein)(nil)
-
-// ChargedEnergy implements the api.ChargeRater interface
-func (wb *Kathrein) ChargedEnergy() (float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(kathreinRegChargingEnergy, 2)
-	if err != nil {
-		return 0, err
-	}
-
-	return float64(binary.BigEndian.Uint32(b)) / 1e3, err
-}
-
 var _ api.MeterEnergy = (*Kathrein)(nil)
 
 // TotalEnergy implements the api.MeterEnergy interface


### PR DESCRIPTION
The session energy reported by the charger seems to be unreliable, not resetting sometimes, leading to wrong SoC estimation and charge reposts..

Should fix #25396 and #25422