### PR TITLE
chore: fix vue type warning

### DIFF
--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -97,7 +97,7 @@ export default {
 			return settings.hiddenFeatures === true;
 		},
 		networkStatus() {
-			return store.state?.network?.port || "";
+			return `${store.state?.network?.port ?? ""}`;
 		},
 		controlStatus() {
 			const sec = store.state?.interval;


### PR DESCRIPTION
```
[Vue warn]: Invalid prop: type check failed for prop "text". Expected String with value "7070", got Number with value 7070. 
```