### PR TITLE
TP-Link Tapo Devices: Redo Handshake in case of concurrent api access

### DIFF
--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -86,9 +86,11 @@ func (c *Connection) CurrentPower() (float64, error) {
 			if err != nil {
 				return c.MissingMeterCheck(err)
 			}
+		} else {
+			return 0, err
 		}
 	}
-	return float64(resp.CurrentPower) / 1e3, err
+	return float64(resp.CurrentPower) / 1e3, nil
 }
 
 // ChargedEnergy collects the daily charged energy

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -60,17 +60,16 @@ func NewConnection(uri, user, password string) (*Connection, error) {
 
 // Enable implements the api.Charger interface
 func (c *Connection) Enable(enable bool) error {
-	return c.plug.SetDeviceInfo(enable)
+	if enable {
+		return c.plug.On()
+	} else {
+		return c.plug.Off()
+	}
 }
 
 // Enabled implements the api.Charger interface
 func (c *Connection) Enabled() (bool, error) {
-	resp, err := c.plug.GetDeviceInfo()
-	if err != nil {
-		return false, err
-	}
-
-	return resp.DeviceON, nil
+	return c.plug.IsOn()
 }
 
 // CurrentPower provides current power consuption

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -88,7 +88,7 @@ func (c *Connection) CurrentPower() (float64, error) {
 			}
 		}
 	}
-	return float64(resp.CurrentPower) / 1e3, nil
+	return float64(resp.CurrentPower) / 1e3, err
 }
 
 // ChargedEnergy collects the daily charged energy

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -95,9 +95,7 @@ func (c *Connection) CurrentPower() (float64, error) {
 func (c *Connection) ChargedEnergy() (float64, error) {
 	resp, err := c.plug.GetEnergyUsage()
 	if err != nil {
-		if strings.Contains(err.Error(), "-1001") {
-			return c.MissingMeterCheck(err)
-		}
+		return c.MissingMeterCheck(err)
 	}
 
 	if int64(resp.TodayEnergy) > c.lasttodayenergy {


### PR DESCRIPTION
fixes #25247

Since Tapo firmware version 1.4.0 third party access to the tapo api is restricted to ONE session only. In case multiple third party applications are requesting new session credintials via the handshake function, the previous session is invalidated and api requests are failing with a *Forbidden* error.

This change implements a redo handshake feature in the `CurrentPower` function, which is usually the first function called in the evcc device refresh cycle.

**Testlog**
Check log entries at 2025/11/22 00:16:05. At this time I simply did an `evcc charger` test from the command line, which invalidated the evcc service tapo session. 
The `CurrentPower` function failed with *Forbidden* error and initated a redo handshake. :-)
The **warning** will also appear in the GUI:
<img width="1297" height="401" alt="image" src="https://github.com/user-attachments/assets/71c149bb-42bf-42b8-815e-129558ff3659" />

Afterwards, evcc continued without api errors.
  
```bash
thierolm@LAPTOP-KQMMVN3H:~/git-repos/evcc$ ./evcc -l debug
[main  ] INFO 2025/11/22 00:13:36 evcc 0.209.8 (9083b99bc)
[main  ] INFO 2025/11/22 00:13:36 using config file: /home/thierolm/git-repos/evcc/evcc.yaml
[db    ] INFO 2025/11/22 00:13:36 using sqlite database: /home/thierolm/.evcc/evcc.db
[main  ] INFO 2025/11/22 00:13:36 UI listening at :7070
[tapo  ] DEBUG 2025/11/22 00:13:36 SMART.TAPOPLUG P110 connected (fw:1.4.0 Build 251020 Rel.161559,hw:1.0,mac:54-AF-97-1D-5E-98)
[lp-1  ] DEBUG 2025/11/22 00:13:36 set title: Tapo-Test
[lp-1  ] DEBUG 2025/11/22 00:13:36 set priority: 0
[lp-1  ] DEBUG 2025/11/22 00:13:36 set smart cost limit: <nil>
[lp-1  ] DEBUG 2025/11/22 00:13:36 set smart feed-in limit: <nil>
[lp-1  ] DEBUG 2025/11/22 00:13:36 set thresholds: {Enable:{Delay:1m0s Threshold:0} Disable:{Delay:3m0s Threshold:0}}
[lp-1  ] DEBUG 2025/11/22 00:13:36 set plan energy: 0kWh @ 0001-01-01 00:53:28 +0053 LMT
[lp-1  ] DEBUG 2025/11/22 00:13:36 set session energy limit: 0
[lp-1  ] DEBUG 2025/11/22 00:13:36 set session soc limit: 0
[lp-1  ] DEBUG 2025/11/22 00:13:36 set soc config: {Poll:{Mode:charging Interval:1h0m0s} Estimate:0xc0005e910c}
[lp-1  ] DEBUG 2025/11/22 00:13:36 set default mode: off
[lp-1  ] DEBUG 2025/11/22 00:13:36 set phases: 1
[site  ] INFO 2025/11/22 00:13:36 site config:
[site  ] INFO 2025/11/22 00:13:36   meters:      grid ✗ pv ✗ battery ✗
[site  ] INFO 2025/11/22 00:13:36   tariffs:
[site  ] INFO 2025/11/22 00:13:36     grid:      ✗
[site  ] INFO 2025/11/22 00:13:36     feed-in:   ✗
[site  ] INFO 2025/11/22 00:13:36     co2:       ✗
[site  ] INFO 2025/11/22 00:13:36     solar:     ✓
[lp-1  ] INFO 2025/11/22 00:13:36 loadpoint 1:
[lp-1  ] INFO 2025/11/22 00:13:36   mode:        off
[lp-1  ] INFO 2025/11/22 00:13:36   charger:     power ✓ energy ✗ currents ✗ phases ✗ wakeup ✗
[lp-1  ] INFO 2025/11/22 00:13:36   meters:      charge ✓
[lp-1  ] INFO 2025/11/22 00:13:36     charge:    power ✓ energy ✗ currents ✗
[lp-1  ] DEBUG 2025/11/22 00:13:36 phase timer inactive
[lp-1  ] DEBUG 2025/11/22 00:13:36 pv timer inactive
[site  ] WARN 2025/11/22 00:13:36 interval <30s can lead to unexpected behavior, see https://docs.evcc.io/docs/reference/configuration/interval
[site  ] DEBUG 2025/11/22 00:13:36 ----
[lp-1  ] DEBUG 2025/11/22 00:13:36 charge power: 0W
[site  ] DEBUG 2025/11/22 00:13:36 pv power: 0W
[site  ] DEBUG 2025/11/22 00:13:36 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:13:36 charger status: A
[lp-1  ] INFO 2025/11/22 00:13:36 car disconnected
[lp-1  ] DEBUG 2025/11/22 00:13:36 set battery boost: false
[lp-1  ] DEBUG 2025/11/22 00:13:36 set session soc limit: 0
[lp-1  ] DEBUG 2025/11/22 00:13:36 set session energy limit: 0
[site  ] DEBUG 2025/11/22 00:13:48 ----
[lp-1  ] DEBUG 2025/11/22 00:13:48 charge power: 0W
[site  ] DEBUG 2025/11/22 00:13:48 pv power: 0W
[site  ] DEBUG 2025/11/22 00:13:48 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:13:48 charger status: A
[lp-1  ] DEBUG 2025/11/22 00:13:57 set charge mode: now
[site  ] DEBUG 2025/11/22 00:13:57 ----
[lp-1  ] DEBUG 2025/11/22 00:13:57 charge power: 0W
[site  ] DEBUG 2025/11/22 00:13:57 pv power: 0W
[site  ] DEBUG 2025/11/22 00:13:57 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:13:57 charger status: B
[lp-1  ] INFO 2025/11/22 00:13:57 car connected
[lp-1  ] DEBUG 2025/11/22 00:13:57 pv timer elapse
[lp-1  ] DEBUG 2025/11/22 00:13:57 pv timer inactive
[lp-1  ] DEBUG 2025/11/22 00:13:57 set charge current limit: 16A
[lp-1  ] DEBUG 2025/11/22 00:13:57 charger enable
[lp-1  ] DEBUG 2025/11/22 00:13:57 wake-up timer: start
[site  ] DEBUG 2025/11/22 00:13:58 ----
[lp-1  ] DEBUG 2025/11/22 00:13:58 charge power: 0W
[site  ] DEBUG 2025/11/22 00:13:58 pv power: 0W
[site  ] DEBUG 2025/11/22 00:13:58 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:13:58 charger status: B
...

[lp-1  ] DEBUG 2025/11/22 00:14:20 set charge mode: off
[lp-1  ] DEBUG 2025/11/22 00:14:20 pv timer reset
[lp-1  ] DEBUG 2025/11/22 00:14:20 pv timer inactive
[lp-1  ] DEBUG 2025/11/22 00:14:20 charger disable
[lp-1  ] DEBUG 2025/11/22 00:14:20 wake-up timer: stop
[site  ] DEBUG 2025/11/22 00:14:20 ----
[lp-1  ] DEBUG 2025/11/22 00:14:20 charge power: 0W
[site  ] DEBUG 2025/11/22 00:14:20 pv power: 0W
[site  ] DEBUG 2025/11/22 00:14:20 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:14:20 charger status: A
[lp-1  ] INFO 2025/11/22 00:14:20 car disconnected
[lp-1  ] DEBUG 2025/11/22 00:14:20 set battery boost: false
[lp-1  ] DEBUG 2025/11/22 00:14:20 set session soc limit: 0
[lp-1  ] DEBUG 2025/11/22 00:14:20 set session energy limit: 0
[site  ] DEBUG 2025/11/22 00:14:29 ----
[lp-1  ] DEBUG 2025/11/22 00:14:29 charge power: 0W
[site  ] DEBUG 2025/11/22 00:14:29 pv power: 0W
[site  ] DEBUG 2025/11/22 00:14:29 site power: 0W
... [lp-1  ] DEBUG 2025/11/22 00:15:34 charger status: A
[lp-1  ] INFO 2025/11/22 00:15:34 car disconnected
[lp-1  ] DEBUG 2025/11/22 00:15:34 set battery boost: false
[lp-1  ] DEBUG 2025/11/22 00:15:34 set session soc limit: 0
[lp-1  ] DEBUG 2025/11/22 00:15:34 set session energy limit: 0
[lp-1  ] DEBUG 2025/11/22 00:15:34 charger disable
[lp-1  ] DEBUG 2025/11/22 00:15:34 wake-up timer: stop
[site  ] DEBUG 2025/11/22 00:15:43 ----
[lp-1  ] DEBUG 2025/11/22 00:15:43 charge power: 0W
[site  ] DEBUG 2025/11/22 00:15:43 pv power: 0W
[site  ] DEBUG 2025/11/22 00:15:43 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:15:43 charger status: A
[site  ] DEBUG 2025/11/22 00:15:53 ----
[lp-1  ] DEBUG 2025/11/22 00:15:53 charge power: 0W
[site  ] DEBUG 2025/11/22 00:15:53 pv power: 0W
[site  ] DEBUG 2025/11/22 00:15:53 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:15:53 charger status: A
[site  ] DEBUG 2025/11/22 00:16:05 ----
[tapo  ] ERROR 2025/11/22 00:16:05 LED Kette (192.168.178.40) 3rd party session was invalidated by another 3rd party app => redoing handshake
[lp-1  ] DEBUG 2025/11/22 00:16:05 charge power: 0W
[site  ] DEBUG 2025/11/22 00:16:05 pv power: 0W
[site  ] DEBUG 2025/11/22 00:16:05 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:16:05 charger status: A
[site  ] DEBUG 2025/11/22 00:16:15 ----
[lp-1  ] DEBUG 2025/11/22 00:16:15 charge power: 0W
[site  ] DEBUG 2025/11/22 00:16:15 pv power: 0W
[site  ] DEBUG 2025/11/22 00:16:15 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:16:15 charger status: A
[site  ] DEBUG 2025/11/22 00:16:25 ----
[lp-1  ] DEBUG 2025/11/22 00:16:25 charge power: 0W
[site  ] DEBUG 2025/11/22 00:16:25 pv power: 0W
[site  ] DEBUG 2025/11/22 00:16:25 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:16:25 charger status: A
[site  ] DEBUG 2025/11/22 00:16:37 ----
[lp-1  ] DEBUG 2025/11/22 00:16:37 charge power: 0W
[site  ] DEBUG 2025/11/22 00:16:37 pv power: 0W
[site  ] DEBUG 2025/11/22 00:16:37 site power: 0W
[lp-1  ] DEBUG 2025/11/22 00:16:37 charger status: A
``` 