### PR TITLE
mDNS: warn instead of fatal error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -269,7 +269,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 	// announce on mDNS
 	if err == nil {
-		err = configureMDNS(conf.Network)
+		if err := configureMDNS(conf.Network); err != nil {
+			log.WARN.Println("mDNS:", err)
+		}
 	}
 
 	// start SHM server

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -763,7 +763,7 @@ func configureMDNS(conf globalconfig.Network) error {
 
 	zc, err := zeroconf.RegisterProxy("evcc", "_http._tcp", "local.", conf.Port, host, nil, text, nil)
 	if err != nil {
-		return fmt.Errorf("mDNS announcement: %w", err)
+		return err
 	}
 
 	shutdown.Register(zc.Shutdown)


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/25511

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
mDNS registration failures now log a warning and no longer block startup. This prevents fatal exits during announce and fixes #25511.

<sup>Written for commit 07d94c93432a63dc02a8e667c4646f3c32e037c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

