### PR TITLE
fix: removes failing .*.ts .*.mts copy in clean container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN npm ci
 # build ui
 COPY Makefile .
 COPY *.js ./
-COPY .*.ts .*.mts ./
 COPY *.ts *.mts ./
 COPY assets assets
 COPY i18n i18n


### PR DESCRIPTION
Hello,
since some weeks my local container build from this repository is failing because of:

```
COPY .*.ts .*.mts ./
```

With the build:
```
Error: building at STEP "COPY .*.ts .*.mts ./": checking on sources under "/var/lib/evcc-build/evcc_local": Rel: can't make relative to /var/lib/evcc-build/evcc_local; copier: stat: ["/.*.ts" "/.*.mts"]: no such file or directory
```

Tested with `podman version 5.7.0`. As there is no `.*.ts`or `.*.mts` in the root of the repo, this will fail on building.

Not sure if there was a former use case for e.g.:
```
.config.ts
.types.ts
```

So to have a clean build, there needs to be at least on file that contains that pattern in the repository, or just removing it.
In this PR I decided to remove the not required copy call and it's working fine for me now. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes container build failures by removing the Dockerfile COPY for dot‑prefixed TypeScript files (.*.ts and .*.mts). These files don’t exist in the repo, so the step always failed during builds (e.g., with Podman).

<sup>Written for commit 0701e2f05ab8063fa713029817b3d5ed0585097f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

