### PR TITLE
open-meteo: query 4-day forecast data

### DIFF
--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -72,7 +72,7 @@ render: |
   tariff: solar
   forecast:
     source: http
-    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=3&timezone=GMT&timeformat=unixtime
+    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=5&timezone=GMT&timeformat=unixtime
     jq: |
       def alphatemp: {{ .alphatemp }}; # temperature coefficient
       def rossmodel: {{ .rossmodel }}; # cooling type


### PR DESCRIPTION
After https://github.com/evcc-io/evcc/pull/25385 shows 2 days more, query 2 additional days.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the Open-Meteo forecast range from 3 to 5 days in the tariff template to provide a full 4-day ahead forecast (API includes today). This matches the UI which now shows two more days.

<sup>Written for commit 4a6b3155535956624a68bd5e31c1a0db06e1411c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

