### PR TITLE
TP-Link Tapo: handle concurrent handshakes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/hasura/go-graphql-client v0.15.0
 	github.com/holoplot/go-evdev v0.0.0-20240306072622-217e18f17db1
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/insomniacslk/tapo v1.0.1
+	github.com/insomniacslk/tapo v1.0.2
 	github.com/itchyny/gojq v0.12.17
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/jeremywohl/flatten v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3If
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf h1:7JTmneyiNEwVBOHSjoMxiWAqB992atOeepeFYegn5RU=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/insomniacslk/tapo v1.0.1 h1:W7K/1SXR8fvCNqY1Qg+GB3ELUjsHAqXtBjBjes7aRQ0=
-github.com/insomniacslk/tapo v1.0.1/go.mod h1:1wuMYu0+alZ4oE4BIzxAwQNveZgbb2tRqiIUwIe7SZE=
+github.com/insomniacslk/tapo v1.0.2 h1:o2Bz941/Kp3LEjO5kvBbAE9Z4z9BcQMXRols3QkTnI0=
+github.com/insomniacslk/tapo v1.0.2/go.mod h1:1wuMYu0+alZ4oE4BIzxAwQNveZgbb2tRqiIUwIe7SZE=
 github.com/insomniacslk/xjson v0.0.0-20240821125711-1236daaf6808 h1:BVD0pRpDWgbzkPYACLLPomriAnUGVfFdFoxs7aCLJkY=
 github.com/insomniacslk/xjson v0.0.0-20240821125711-1236daaf6808/go.mod h1:Z4EVr4bVv9LZbbje9xyZEyOLpdCOmCvr5S9BJtrdTfw=
 github.com/itchyny/gojq v0.12.17 h1:8av8eGduDb5+rvEdaOO+zQUjA04MS0m3Ps8HiD+fceg=

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -72,7 +72,7 @@ func (c *Connection) Enabled() (bool, error) {
 func (c *Connection) CurrentPower() (float64, error) {
 	resp, err := c.plug.GetEnergyUsage()
 	if err != nil {
-		return c.MissingMeterCheck(err)
+		return 0, c.checkMeterError(err)
 	}
 
 	return float64(resp.CurrentPower) / 1e3, nil
@@ -82,7 +82,7 @@ func (c *Connection) CurrentPower() (float64, error) {
 func (c *Connection) ChargedEnergy() (float64, error) {
 	resp, err := c.plug.GetEnergyUsage()
 	if err != nil {
-		return c.MissingMeterCheck(err)
+		return 0, c.checkMeterError(err)
 	}
 
 	if int64(resp.TodayEnergy) > c.lasttodayenergy {
@@ -93,12 +93,11 @@ func (c *Connection) ChargedEnergy() (float64, error) {
 	return float64(c.energy) / 1000, nil
 }
 
-// MissingMeterCheck checks for missing meter error
-func (c *Connection) MissingMeterCheck(err error) (float64, error) {
+// checkMeterError checks for missing meter error
+func (c *Connection) checkMeterError(err error) error {
 	if strings.Contains(err.Error(), "-1001") {
-		c.log.DEBUG.Printf("meter not available")
-		return 0, nil
-	} else {
-		return 0, err
+		return nil
 	}
+
+	return err
 }

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -72,12 +72,7 @@ func (c *Connection) Enabled() (bool, error) {
 func (c *Connection) CurrentPower() (float64, error) {
 	resp, err := c.plug.GetEnergyUsage()
 	if err != nil {
-		if strings.Contains(err.Error(), "-1001") {
-			c.log.DEBUG.Printf("meter not available")
-			return 0, nil
-		} else {
-			return 0, err
-		}
+		return c.MissingMeterCheck(err)
 	}
 
 	return float64(resp.CurrentPower) / 1e3, nil
@@ -87,12 +82,7 @@ func (c *Connection) CurrentPower() (float64, error) {
 func (c *Connection) ChargedEnergy() (float64, error) {
 	resp, err := c.plug.GetEnergyUsage()
 	if err != nil {
-		if strings.Contains(err.Error(), "-1001") {
-			c.log.DEBUG.Printf("meter not available")
-			return 0, nil
-		} else {
-			return 0, err
-		}
+		return c.MissingMeterCheck(err)
 	}
 
 	if int64(resp.TodayEnergy) > c.lasttodayenergy {
@@ -101,4 +91,14 @@ func (c *Connection) ChargedEnergy() (float64, error) {
 	c.lasttodayenergy = int64(resp.TodayEnergy)
 
 	return float64(c.energy) / 1000, nil
+}
+
+// MissingMeterCheck checks for missing meter error
+func (c *Connection) MissingMeterCheck(err error) (float64, error) {
+	if strings.Contains(err.Error(), "-1001") {
+		c.log.DEBUG.Printf("meter not available")
+		return 0, nil
+	} else {
+		return 0, err
+	}
 }

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -65,12 +65,7 @@ func (c *Connection) Enable(enable bool) error {
 
 // Enabled implements the api.Charger interface
 func (c *Connection) Enabled() (bool, error) {
-	resp, err := c.plug.GetDeviceInfo()
-	if err != nil {
-		return false, err
-	}
-
-	return resp.DeviceON, nil
+	return c.plug.IsOn()
 }
 
 // CurrentPower provides current power consuption


### PR DESCRIPTION
This PR implements the following improvements for Tapo devices:
1. Switch to new tap repo version 1.0.2 (Handels concurrent handshakes)
2. Simplification of Enabled function
3. Standardization of missing meter check

This PR is replacing PR #25469 and is fixing #25247.

Spezial kudos to @insomniaslk ! 