### PR TITLE
Config UI: meter order

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -182,6 +182,7 @@
 									:power="c.power"
 									:powerUnit="powerUnit"
 									icon="vehicle"
+									data-testid="energyflow-entry-consumer"
 									:iconProps="{ names: [c.icon || 'generic'] }"
 								/>
 							</template>

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -752,7 +752,7 @@ export default defineComponent({
 			if (!names || !this.meters) {
 				return [];
 			}
-			return this.meters.filter((m) => names.includes(m.name));
+			return names.map((name) => this.meters.find((m) => m.name === name)).filter((m) => m);
 		},
 		getMeterById(id?: number) {
 			if (!id || !this.meters) {

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -748,11 +748,13 @@ export default defineComponent({
 			const response = await api.get("/config/loadpoints");
 			this.loadpoints = response.data || [];
 		},
-		getMetersByNames(names: string[] | null) {
+		getMetersByNames(names: string[] | null): ConfigMeter[] {
 			if (!names || !this.meters) {
 				return [];
 			}
-			return names.map((name) => this.meters.find((m) => m.name === name)).filter((m) => m);
+			return names
+				.map((name) => this.meters.find((m) => m.name === name))
+				.filter((m): m is ConfigMeter => m !== undefined);
 		},
 		getMeterById(id?: number) {
 			if (!id || !this.meters) {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/25553

API response of `/api/config/device/meter` is not deterministic. I assume due to lazy/parallel initialization (@andig). Before config UI rendered meters in order or api response. Now meters are explicitly sorted in order of creation (`site` array) in UI.

🧪 add order e2e tests
🔖 sort meters (battery, aux, pv, ext) by creation order (e.g. `site.ext`)