### PR TITLE
EEBus: fix failsafe limit not left

### DIFF
--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -197,8 +197,6 @@ func (c *EEBus) run() error {
 		// LPC-914/1
 		if c.consumptionLimit != nil && c.consumptionLimit.IsActive {
 			c.log.WARN.Println("active consumption limit")
-			c.mux.RLock()
-			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusLimited, c.consumptionLimit.Value)
 		}
 
@@ -206,8 +204,6 @@ func (c *EEBus) run() error {
 		// limit updated?
 		if !c.consumptionLimit.IsActive {
 			c.log.WARN.Println("inactive consumption limit")
-			c.mux.RLock()
-			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusUnlimited, 0)
 			break
 		}
@@ -219,8 +215,6 @@ func (c *EEBus) run() error {
 			c.consumptionLimit = nil
 
 			c.log.DEBUG.Println("limit duration exceeded- return to normal")
-			c.mux.RLock()
-			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusUnlimited, 0)
 		}
 
@@ -228,8 +222,6 @@ func (c *EEBus) run() error {
 		// LPC-914/2
 		if d := c.failsafeDuration; heartbeatErr == nil || time.Since(c.statusUpdated) > d {
 			c.log.DEBUG.Println("heartbeat returned and failsafe duration exceeded- return to normal")
-			c.mux.RLock()
-			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusUnlimited, 0)
 		}
 	}

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -219,7 +219,7 @@ func (c *EEBus) run() error {
 
 	case StatusFailsafe:
 		// LPC-914/2
-		if d := c.failsafeDuration; heartbeatErr == nil && time.Since(c.statusUpdated) > d {
+		if d := c.failsafeDuration; heartbeatErr == nil || time.Since(c.statusUpdated) > d {
 			c.log.DEBUG.Println("heartbeat returned and failsafe duration exceeded- return to normal")
 			c.setStatusAndLimit(StatusUnlimited, 0)
 		}

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -172,8 +172,8 @@ func (c *EEBus) Run() {
 // TODO check state machine against spec
 func (c *EEBus) run() error {
 	c.mux.RLock()
-c.mux.Lock()
-defer c.mux.Unlock()
+	c.mux.Lock()
+	defer c.mux.Unlock()
 
 	c.log.TRACE.Println("status:", c.status)
 

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -196,6 +196,8 @@ func (c *EEBus) run() error {
 		// LPC-914/1
 		if c.consumptionLimit != nil && c.consumptionLimit.IsActive {
 			c.log.WARN.Println("active consumption limit")
+			c.mux.RLock()
+			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusLimited, c.consumptionLimit.Value)
 		}
 
@@ -203,6 +205,8 @@ func (c *EEBus) run() error {
 		// limit updated?
 		if !c.consumptionLimit.IsActive {
 			c.log.WARN.Println("inactive consumption limit")
+			c.mux.RLock()
+			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusUnlimited, 0)
 			break
 		}
@@ -214,6 +218,8 @@ func (c *EEBus) run() error {
 			c.consumptionLimit = nil
 
 			c.log.DEBUG.Println("limit duration exceeded- return to normal")
+			c.mux.RLock()
+			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusUnlimited, 0)
 		}
 
@@ -221,6 +227,8 @@ func (c *EEBus) run() error {
 		// LPC-914/2
 		if d := c.failsafeDuration; heartbeatErr == nil || time.Since(c.statusUpdated) > d {
 			c.log.DEBUG.Println("heartbeat returned and failsafe duration exceeded- return to normal")
+			c.mux.RLock()
+			defer c.mux.RUnlock()
 			c.setStatusAndLimit(StatusUnlimited, 0)
 		}
 	}

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -172,7 +172,8 @@ func (c *EEBus) Run() {
 // TODO check state machine against spec
 func (c *EEBus) run() error {
 	c.mux.RLock()
-	defer c.mux.RUnlock()
+c.mux.Lock()
+defer c.mux.Unlock()
 
 	c.log.TRACE.Println("status:", c.status)
 


### PR DESCRIPTION
It shouldn't be &&, but ||

Failsafe Duration exceeded, but no Heartbeat -> Leave Failsafe
Or (not and)
Heartbeat returned, but Failsafe duration not exceeded -> Leave Failsafe.