### PR TITLE
HomeAssistant: make home a choice input

### DIFF
--- a/templates/definition/charger/homeassistant-switch.yaml
+++ b/templates/definition/charger/homeassistant-switch.yaml
@@ -13,15 +13,6 @@ params:
   - name: token
     deprecated: true
   - name: home
-    description:
-      de: Home Assistant Instanz
-      en: Home Assistant Instance
-    help:
-      en: Can be found in Home Assistant UI under Settings -> System -> General -> Name. Used to identify your instance via mDNS.
-      de: Kann in der Home Assistant UI unter Einstellungen -> System -> Allgemein -> Name gefunden werden. Wird verwendet, um die Instanz via mDNS zu identifizieren.
-    example: Home
-    service: homeassistant/homes
-    required: true
   - name: switch
     description:
       de: Entity ID des schaltbaren Geräts

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -17,15 +17,6 @@ params:
   - name: token
     deprecated: true
   - name: home
-    description:
-      de: Home Assistant Instanz
-      en: Home Assistant Instance
-    help:
-      en: Can be found in Home Assistant UI under Settings -> System -> General -> Name. Used to identify your instance via mDNS.
-      de: Kann in der Home Assistant UI unter Einstellungen -> System -> Allgemein -> Name gefunden werden. Wird verwendet, um die Instanz via mDNS zu identifizieren.
-    example: Home
-    service: homeassistant/homes
-    required: true
   - name: power
     description:
       de: Leistungsentität

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -16,15 +16,6 @@ params:
   - name: token
     deprecated: true
   - name: home
-    description:
-      de: Home Assistant Instanz
-      en: Home Assistant Instance
-    help:
-      en: Can be found in Home Assistant UI under Settings -> System -> General -> Name. Used to identify your instance via mDNS.
-      de: Kann in der Home Assistant UI unter Einstellungen -> System -> Allgemein -> Name gefunden werden. Wird verwendet, um die Instanz via mDNS zu identifizieren.
-    example: Home
-    service: homeassistant/homes
-    required: true
   - name: soc
     description:
       de: Ladezustand [%]

--- a/util/homeassistant/service.go
+++ b/util/homeassistant/service.go
@@ -38,7 +38,6 @@ func getHomes(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var res []entry
-
 	for _, k := range slices.Sorted(maps.Keys(instances)) {
 		res = append(res, entry{k, instances[k]})
 	}

--- a/util/homeassistant/service.go
+++ b/util/homeassistant/service.go
@@ -32,7 +32,18 @@ func getHomes(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	jsonWrite(w, slices.Sorted(maps.Keys(instances)))
+	type entry struct {
+		Key string `json:"key"`
+		Val string `json:"val"`
+	}
+
+	var res []entry
+
+	for _, k := range slices.Sorted(maps.Keys(instances)) {
+		res = append(res, entry{k, instances[k]})
+	}
+
+	jsonWrite(w, res)
 }
 
 func getEntities(w http.ResponseWriter, req *http.Request) {

--- a/util/homeassistant/service.go
+++ b/util/homeassistant/service.go
@@ -2,6 +2,7 @@ package homeassistant
 
 import (
 	"encoding/json"
+	"errors"
 	"maps"
 	"net/http"
 	"slices"
@@ -25,6 +26,11 @@ func init() {
 func getHomes(w http.ResponseWriter, req *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
+
+	if len(instances) == 0 {
+		jsonError(w, http.StatusPreconditionFailed, errors.New("no instances found"))
+		return
+	}
 
 	jsonWrite(w, slices.Sorted(maps.Keys(instances)))
 }

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -449,6 +449,18 @@ params:
     type: float
     example: 9.1275
 
+  - name: home
+    type: choice
+    description:
+      de: Home Assistant Instanz
+      en: Home Assistant Instance
+    help:
+      en: Can be found in Home Assistant UI under Settings -> System -> General -> Name. Used to identify your instance via mDNS.
+      de: Kann in der Home Assistant UI unter Einstellungen -> System -> Allgemein -> Name gefunden werden. Wird verwendet, um die Instanz via mDNS zu identifizieren.
+    example: Home
+    service: homeassistant/homes
+    required: true
+
 presets:
   vehicle-base:
     - name: user


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/25618

**TODO**

- [ ] Aktuell funktioniert das Dropdown gar nicht @naltatis hat sich erledigt wenn wir das choice wieder weg nehmen?
- [x] falls keine Werte bräuchte es noch eine Fehlermeldung. Wenns hilft könnte die auch der Service generieren.
- [x] return key/val from service to cover instance + url
- [ ] ui: use key/val slice to show `<Instance> (<uri>)` @naltatis 
- [ ] Document mDNS required