### PR TITLE
Extending instead of resetting charger delay times

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1306,7 +1306,6 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		lp.ResetMeasuredPhases()
 	}
 
-	var waiting bool
 	activePhases := lp.ActivePhases()
 	availablePower := lp.chargePower - sitePower
 	scalable := (sitePower > 0 || !lp.enabled) && activePhases > 1 && lp.phasesConfigured < 3
@@ -1333,8 +1332,18 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 			}
 			return 1
 		}
+	}
+	else if !lp.phaseTimer.IsZero() {
+		// increase delay
+		lp.phaseTimer = lp.phaseTimer.Add(2 * now.Sub(lp.phaseTimerEvaluated))
 
-		waiting = true
+		// reset timer to disabled state if the delay would be too long
+		if lp.phaseTimer.After(now) {
+			lp.resetPhaseTimer()
+		}
+		else {
+			lp.publishTimer(phaseTimer, lp.GetDisableDelay(), phaseScale1p)
+		}
 	}
 
 	maxPhases := lp.MaxActivePhases()
@@ -1362,17 +1371,17 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 			}
 			return 3
 		}
-
-		waiting = true
 	}
-
-	if !waiting && !lp.phaseTimer.IsZero() {
+	else if !lp.phaseTimer.IsZero() {
 		// increase delay
 		lp.phaseTimer = lp.phaseTimer.Add(2 * now.Sub(lp.phaseTimerEvaluated))
 
 		// reset timer to disabled state if the delay would be too long
 		if lp.phaseTimer.After(now) {
 			lp.resetPhaseTimer()
+		}
+		else {
+			lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
 		}
 	}
 
@@ -1513,10 +1522,15 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 		} else if !lp.pvTimer.IsZero() {
 			// increase delay
 			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
+			elapsed := now.Sub(lp.pvTimer)
 
 			// reset timer if the delay would be too long
-			if lp.pvTimer.After(now) {
+			if elapsed < 0 {
 				lp.resetPVTimer("disable")
+			}
+			else {
+				lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
+				lp.log.DEBUG.Printf("pv disable timer remaining: %v", (lp.GetDisableDelay() - elapsed).Round(time.Second))
 			}
 		}
 
@@ -1557,10 +1571,15 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 		} else if !lp.pvTimer.IsZero() {
 			// increase delay
 			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
+			elapsed := now.Sub(lp.pvTimer)
 
 			// reset timer if the delay would be too long
-			if lp.pvTimer.After(now) {
+			if elapsed < 0 {
 				lp.resetPVTimer("enable")
+			}
+			else {
+				lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
+				lp.log.DEBUG.Printf("pv enable timer remaining: %v", (lp.GetEnableDelay() - elapsed).Round(time.Second))
 			}
 		}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1480,7 +1480,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 		if lp.enabled {
 			currentReduction := effectiveCurrent - max(minCurrent, targetCurrent)
-			projectedSitePower := sitePower - Voltage * currentReduction * float64(activePhases)
+			projectedSitePower := sitePower - Voltage * currentReduction * float64(activePhases) //nolint:all
 
 			if lp.hasPhaseSwitching() && !lp.phaseTimer.IsZero() {
 				// calculate site power after a phase switch from activePhases phases -> 1 phase

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1524,8 +1524,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 			// lp.log.DEBUG.Println("pv disable timer: keep enabled")
 			lp.pvTimerEvaluated = now
 			return max(minCurrent, targetCurrent)
-		}
-		else {
+		} else {
 			now := lp.clock.Now()
 	
 			// kick off enable sequence

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1475,98 +1475,99 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 	lp.log.DEBUG.Printf("pv charge current: %.3gA = %.3gA + %.3gA (%.0fW @ %dp)", targetCurrent, effectiveCurrent, deltaCurrent, sitePower, activePhases)
 
-	if mode == api.ModePV && lp.enabled && targetCurrent < minCurrent {
-		now := lp.clock.Now()
-		projectedSitePower := sitePower
-
-		if lp.hasPhaseSwitching() && !lp.phaseTimer.IsZero() {
-			// calculate site power after a phase switch from activePhases phases -> 1 phase
-			// notes: activePhases can be 1, 2 or 3 and phaseTimer can only be active if lp current is already at minCurrent
-			projectedSitePower -= Voltage * minCurrent * float64(activePhases-1)
+	if mode == api.ModePV {
+		if lp.enabled {
+			now := lp.clock.Now()
+			projectedSitePower := sitePower - Voltage * (effectiveCurrent - max(minCurrent, targetCurrent)) * activePhases
+	
+			if lp.hasPhaseSwitching() && !lp.phaseTimer.IsZero() {
+				// calculate site power after a phase switch from activePhases phases -> 1 phase
+				// notes: activePhases can be 1, 2 or 3 and phaseTimer can only be active if lp current is already at minCurrent
+				projectedSitePower -= Voltage * minCurrent * (activePhases-1)
+			}
+	
+			// kick off disable sequence
+			if projectedSitePower >= lp.Disable.Threshold {
+				lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
+	
+				if lp.pvTimer.IsZero() {
+					lp.log.DEBUG.Printf("pv disable timer start: %v", lp.GetDisableDelay())
+					lp.pvTimer = now
+				}
+	
+				lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
+	
+				elapsed := now.Sub(lp.pvTimer)
+				if elapsed >= lp.GetDisableDelay() {
+					lp.log.DEBUG.Println("pv disable timer elapsed")
+	
+					// reset timer to prevent immediate charger re-enabling
+					lp.resetPVTimer()
+	
+					return 0
+				}
+	
+				// suppress duplicate log message after timer started
+				if elapsed > time.Second {
+					lp.log.DEBUG.Printf("pv disable timer remaining: %v", (lp.GetDisableDelay() - elapsed).Round(time.Second))
+				}
+			} else if !lp.pvTimer.IsZero() {
+				// increase delay
+				lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
+	
+				// reset timer if the delay would be too long
+				if lp.pvTimer.After(now) {
+					lp.resetPVTimer("disable")
+				}
+			}
+	
+			// lp.log.DEBUG.Println("pv disable timer: keep enabled")
+			lp.pvTimerEvaluated = now
+			return max(minCurrent, targetCurrent)
 		}
-
-		// kick off disable sequence
-		if projectedSitePower >= lp.Disable.Threshold {
-			lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
-
-			if lp.pvTimer.IsZero() {
-				lp.log.DEBUG.Printf("pv disable timer start: %v", lp.GetDisableDelay())
-				lp.pvTimer = now
+		else {
+			now := lp.clock.Now()
+	
+			// kick off enable sequence
+			if (lp.Enable.Threshold == 0 && targetCurrent >= minCurrent) ||
+				(lp.Enable.Threshold != 0 && sitePower <= lp.Enable.Threshold) {
+				lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, lp.Enable.Threshold)
+	
+				if lp.pvTimer.IsZero() {
+					lp.log.DEBUG.Printf("pv enable timer start: %v", lp.GetEnableDelay())
+					lp.pvTimer = now
+				}
+	
+				lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
+	
+				elapsed := now.Sub(lp.pvTimer)
+				if elapsed >= lp.GetEnableDelay() {
+					lp.log.DEBUG.Println("pv enable timer elapsed")
+	
+					// reset timer to prevent immediate charger re-disabling
+					lp.resetPVTimer()
+	
+					return minCurrent
+				}
+	
+				// suppress duplicate log message after timer started
+				if elapsed > time.Second {
+					lp.log.DEBUG.Printf("pv enable timer remaining: %v", (lp.GetEnableDelay() - elapsed).Round(time.Second))
+				}
+			} else if !lp.pvTimer.IsZero() {
+				// increase delay
+				lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
+	
+				// reset timer if the delay would be too long
+				if lp.pvTimer.After(now) {
+					lp.resetPVTimer("enable")
+				}
 			}
-
-			lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
-
-			elapsed := now.Sub(lp.pvTimer)
-			if elapsed >= lp.GetDisableDelay() {
-				lp.log.DEBUG.Println("pv disable timer elapsed")
-
-				// reset timer to prevent immediate charger re-enabling
-				lp.resetPVTimer()
-
-				return 0
-			}
-
-			// suppress duplicate log message after timer started
-			if elapsed > time.Second {
-				lp.log.DEBUG.Printf("pv disable timer remaining: %v", (lp.GetDisableDelay() - elapsed).Round(time.Second))
-			}
-		} else if !lp.pvTimer.IsZero() {
-			// increase delay
-			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
-
-			// reset timer if the delay would be too long
-			if lp.pvTimer.After(now) {
-				lp.resetPVTimer("disable")
-			}
+	
+			// lp.log.DEBUG.Println("pv enable timer: keep disabled")
+			lp.pvTimerEvaluated = now
+			return 0
 		}
-
-		// lp.log.DEBUG.Println("pv disable timer: keep enabled")
-		lp.pvTimerEvaluated = now
-		return minCurrent
-	}
-
-	if mode == api.ModePV && !lp.enabled {
-		now := lp.clock.Now()
-
-		// kick off enable sequence
-		if (lp.Enable.Threshold == 0 && targetCurrent >= minCurrent) ||
-			(lp.Enable.Threshold != 0 && sitePower <= lp.Enable.Threshold) {
-			lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, lp.Enable.Threshold)
-
-			if lp.pvTimer.IsZero() {
-				lp.log.DEBUG.Printf("pv enable timer start: %v", lp.GetEnableDelay())
-				lp.pvTimer = now
-			}
-
-			lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
-
-			elapsed := now.Sub(lp.pvTimer)
-			if elapsed >= lp.GetEnableDelay() {
-				lp.log.DEBUG.Println("pv enable timer elapsed")
-
-				// reset timer to prevent immediate charger re-disabling
-				lp.resetPVTimer()
-
-				return minCurrent
-			}
-
-			// suppress duplicate log message after timer started
-			if elapsed > time.Second {
-				lp.log.DEBUG.Printf("pv enable timer remaining: %v", (lp.GetEnableDelay() - elapsed).Round(time.Second))
-			}
-		} else if !lp.pvTimer.IsZero() {
-			// increase delay
-			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
-
-			// reset timer if the delay would be too long
-			if lp.pvTimer.After(now) {
-				lp.resetPVTimer("enable")
-			}
-		}
-
-		// lp.log.DEBUG.Println("pv enable timer: keep disabled")
-		lp.pvTimerEvaluated = now
-		return 0
 	}
 
 	// reset timer to disabled state

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1478,12 +1478,12 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	if mode == api.ModePV {
 		if lp.enabled {
 			now := lp.clock.Now()
-			projectedSitePower := sitePower - Voltage * (effectiveCurrent - max(minCurrent, targetCurrent)) * activePhases
+			projectedSitePower := sitePower - Voltage * (effectiveCurrent - max(minCurrent, targetCurrent)) * float64(activePhases)
 	
 			if lp.hasPhaseSwitching() && !lp.phaseTimer.IsZero() {
 				// calculate site power after a phase switch from activePhases phases -> 1 phase
 				// notes: activePhases can be 1, 2 or 3 and phaseTimer can only be active if lp current is already at minCurrent
-				projectedSitePower -= Voltage * minCurrent * (activePhases-1)
+				projectedSitePower -= Voltage * minCurrent * float64(activePhases-1)
 			}
 	
 			// kick off disable sequence

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1479,8 +1479,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 		now := lp.clock.Now()
 
 		if lp.enabled {
-			currentReduction := effectiveCurrent - max(minCurrent, targetCurrent)
-			projectedSitePower := sitePower - Voltage * currentReduction * float64(activePhases) //nolint:all
+			projectedSitePower := sitePower
 
 			if lp.hasPhaseSwitching() && !lp.phaseTimer.IsZero() {
 				// calculate site power after a phase switch from activePhases phases -> 1 phase
@@ -1489,7 +1488,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 			}
 
 			// kick off disable sequence
-			if projectedSitePower >= lp.Disable.Threshold {
+			if projectedSitePower >= lp.Disable.Threshold && targetCurrent < minCurrent {
 				lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
 
 				if lp.pvTimer.IsZero() {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1306,7 +1306,6 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		lp.ResetMeasuredPhases()
 	}
 
-	var waiting bool
 	activePhases := lp.ActivePhases()
 	availablePower := lp.chargePower - sitePower
 	scalable := (sitePower > 0 || !lp.enabled) && activePhases > 1 && lp.phasesConfigured < 3
@@ -1333,8 +1332,16 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 			}
 			return 1
 		}
+	} else if !lp.phaseTimer.IsZero() {
+		// increase delay
+		lp.phaseTimer = lp.phaseTimer.Add(2 * now.Sub(lp.phaseTimerEvaluated))
 
-		waiting = true
+		// reset timer to disabled state if the delay would be too long
+		if lp.phaseTimer.After(now) {
+			lp.resetPhaseTimer()
+		} else {
+			lp.publishTimer(phaseTimer, lp.GetDisableDelay(), phaseScale1p)
+		}
 	}
 
 	maxPhases := lp.MaxActivePhases()
@@ -1362,17 +1369,15 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 			}
 			return 3
 		}
-
-		waiting = true
-	}
-
-	if !waiting && !lp.phaseTimer.IsZero() {
+	} else if !lp.phaseTimer.IsZero() {
 		// increase delay
 		lp.phaseTimer = lp.phaseTimer.Add(2 * now.Sub(lp.phaseTimerEvaluated))
 
 		// reset timer to disabled state if the delay would be too long
 		if lp.phaseTimer.After(now) {
 			lp.resetPhaseTimer()
+		} else {
+			lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
 		}
 	}
 
@@ -1515,10 +1520,14 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 			} else if !lp.pvTimer.IsZero() {
 				// increase delay
 				lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
+				elapsed := now.Sub(lp.pvTimer)
 
 				// reset timer if the delay would be too long
-				if lp.pvTimer.After(now) {
+				if elapsed < 0 {
 					lp.resetPVTimer("disable")
+				} else {
+					lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
+					lp.log.DEBUG.Printf("pv disable timer remaining: %v", (lp.GetDisableDelay() - elapsed).Round(time.Second))
 				}
 			}
 
@@ -1556,10 +1565,14 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 		} else if !lp.pvTimer.IsZero() {
 			// increase delay
 			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(lp.pvTimerEvaluated))
+			elapsed := now.Sub(lp.pvTimer)
 
 			// reset timer if the delay would be too long
-			if lp.pvTimer.After(now) {
+			if elapsed < 0 {
 				lp.resetPVTimer("enable")
+			} else {
+				lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
+				lp.log.DEBUG.Printf("pv enable timer remaining: %v", (lp.GetEnableDelay() - elapsed).Round(time.Second))
 			}
 		}
 


### PR DESCRIPTION
A running delay before phase switching or toggling the charger enabled state will be prolonged if the associated threshold condition isn't met. If the remaining delay time would exceed its initial duration a timer reset occurs instead.