### PR TITLE
Home Assistant: identify instance by URI

### DIFF
--- a/charger/homeassistant-switch.go
+++ b/charger/homeassistant-switch.go
@@ -20,15 +20,15 @@ func init() {
 }
 
 func NewHomeAssistantSwitchFromConfig(other map[string]any) (api.Charger, error) {
-	cc := struct {
+	var cc struct {
 		embed        `mapstructure:",squash"`
 		URI          string
 		Token_       string `mapstructure:"token"` // TODO deprecated
-		Home         string // TODO deprecated, backward compatibility (v0.210.x)
+		Home         string // TODO deprecated
 		Enable       string
 		Power        string
 		StandbyPower float64
-	}{}
+	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err

--- a/charger/homeassistant-switch.go
+++ b/charger/homeassistant-switch.go
@@ -22,24 +22,22 @@ func init() {
 func NewHomeAssistantSwitchFromConfig(other map[string]any) (api.Charger, error) {
 	cc := struct {
 		embed        `mapstructure:",squash"`
-		URI_         string `mapstructure:"uri"`   // TODO deprecated
+		URI          string
 		Token_       string `mapstructure:"token"` // TODO deprecated
-		Home         string
+		Home         string // TODO deprecated, backward compatibility (v0.210.x)
 		Enable       string
 		Power        string
 		StandbyPower float64
-	}{
-		Home: "Home",
-	}
+	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewHomeAssistantSwitch(cc.embed, cc.Home, cc.Enable, cc.Power, cc.StandbyPower)
+	return NewHomeAssistantSwitch(cc.embed, cc.URI, cc.Home, cc.Enable, cc.Power, cc.StandbyPower)
 }
 
-func NewHomeAssistantSwitch(embed embed, home, enable, power string, standbypower float64) (api.Charger, error) {
+func NewHomeAssistantSwitch(embed embed, uri, home, enable, power string, standbypower float64) (api.Charger, error) {
 	if enable == "" {
 		return nil, errors.New("missing enable switch entity")
 	}
@@ -50,7 +48,8 @@ func NewHomeAssistantSwitch(embed embed, home, enable, power string, standbypowe
 	}
 
 	log := util.NewLogger("ha-switch")
-	conn, err := homeassistant.NewConnection(log, home)
+
+	conn, err := homeassistant.NewConnection(log, uri, home)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/homeassistant.go
+++ b/charger/homeassistant.go
@@ -28,9 +28,9 @@ func init() {
 // NewHomeAssistantFromConfig creates a HomeAssistant charger from generic config
 func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 	cc := struct {
-		URI_       string `mapstructure:"uri"`   // TODO deprecated
-		Token_     string `mapstructure:"token"` // TODO deprecated
-		Home       string
+		URI        string
+		Token_     string   `mapstructure:"token"` // TODO deprecated
+		Home       string   // TODO deprecated, backward compatibility (v0.210.x)
 		Status     string   // required - sensor for charge status
 		Enabled    string   // required - sensor for enabled state
 		Enable     string   // required - switch/input_boolean for enable/disable
@@ -39,9 +39,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 		Energy     string   // optional - energy sensor
 		Currents   []string // optional - current sensors for L1, L2, L3
 		Voltages   []string // optional - voltage sensors for L1, L2, L3
-	}{
-		Home: "Home",
-	}
+	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -58,7 +56,8 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 	}
 
 	log := util.NewLogger("ha-charger")
-	conn, err := homeassistant.NewConnection(log, cc.Home)
+
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/homeassistant.go
+++ b/charger/homeassistant.go
@@ -27,10 +27,10 @@ func init() {
 
 // NewHomeAssistantFromConfig creates a HomeAssistant charger from generic config
 func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
-	cc := struct {
+	var cc struct {
 		URI        string
 		Token_     string   `mapstructure:"token"` // TODO deprecated
-		Home       string   // TODO deprecated, backward compatibility (v0.210.x)
+		Home       string   // TODO deprecated
 		Status     string   // required - sensor for charge status
 		Enabled    string   // required - sensor for enabled state
 		Enable     string   // required - switch/input_boolean for enable/disable
@@ -39,7 +39,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 		Energy     string   // optional - energy sensor
 		Currents   []string // optional - current sensors for L1, L2, L3
 		Voltages   []string // optional - voltage sensors for L1, L2, L3
-	}{}
+	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -24,9 +24,9 @@ func init() {
 // NewHomeAssistantFromConfig creates a HomeAssistant meter from generic config
 func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 	cc := struct {
-		URI_     string `mapstructure:"uri"`   // TODO deprecated
+		URI      string
 		Token_   string `mapstructure:"token"` // TODO deprecated
-		Home     string
+		Home     string // TODO deprecated, backward compatibility (v0.210.x)
 		Power    string
 		Energy   string
 		Currents []string
@@ -41,7 +41,6 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 		batterySocLimits   `mapstructure:",squash"`
 		batteryPowerLimits `mapstructure:",squash"`
 	}{
-		Home: "Home",
 		batterySocLimits: batterySocLimits{
 			MinSoc: 20,
 			MaxSoc: 95,
@@ -57,7 +56,8 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 	}
 
 	log := util.NewLogger("ha-meter")
-	conn, err := homeassistant.NewConnection(log, cc.Home)
+
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/definition/charger/homeassistant-switch.yaml
+++ b/templates/definition/charger/homeassistant-switch.yaml
@@ -4,41 +4,44 @@ products:
 group: switchsockets
 requirements:
   evcc: ["skiptest"]
+  description:
+    en: Home Assistant instances in your network will be auto-discovered and suitable entities (e.g. `switch.*`, `sensor.*`) will be suggested.
+    de: Home Assistant Instanzen in deinem Netzwerk werden automatisch erkannt und passende Entitäten (z.B. `switch.*`, `sensor.*`) werden vorgeschlagen.
 auth:
   type: homeassistant
-  params: [home]
+  params: [uri]
 params:
   - name: uri
-    deprecated: true
+    description:
+      de: Home Assistant URI
+      en: Home Assistant URI
+    example: http://homeassistant.local:8123
+    help:
+      en: " " # overwrite default
+      de: " " # overwrite default
+    service: homeassistant/instances
+    required: true
   - name: token
     deprecated: true
   - name: home
-    description:
-      de: Home Assistant Instanz
-      en: Home Assistant Instance
-    help:
-      en: Can be found in Home Assistant UI under Settings -> System -> General -> Name. Used to identify your instance via mDNS.
-      de: Kann in der Home Assistant UI unter Einstellungen -> System -> Allgemein -> Name gefunden werden. Wird verwendet, um die Instanz via mDNS zu identifizieren.
-    example: Home
-    service: homeassistant/homes
-    required: true
+    deprecated: true
   - name: switch
     description:
       de: Entity ID des schaltbaren Geräts
       en: Entity ID of the switch device
-    service: homeassistant/homes/{home}/entities?domain=switch
+    service: homeassistant/entities?uri={uri}&domain=switch
     example: switch.smartsocket
     required: true
   - name: power
     description:
       de: Entity ID für Leistungsmessung
       en: Entity ID for power measurement
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: sensor.smartsocket_power
   - preset: switchsocket
 render: |
   type: homeassistant-switch
-  home: {{ .home }}
+  uri: {{ .uri }}
   enable: {{ .switch }}
   power: {{ .power }}
   {{ include "switchsocket" . }}

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -4,34 +4,34 @@ products:
 group: generic
 requirements:
   description:
-    en: Requires a running Home Assistant instance with suitable sensor entities. All values are Home Assistant entity IDs (e.g. `sensor.*`)
-    de: Erfordert eine laufende Home Assistant Instanz mit passenden Sensor-Entitäten. Alle Werte sind Home Assistant Entity IDs (z.B. `sensor.*`)
+    en: Home Assistant instances in your network will be auto-discovered and suitable entities (e.g. `sensor.*`) will be suggested.
+    de: Home Assistant Instanzen in deinem Netzwerk werden automatisch erkannt und passende Entitäten (z.B. `sensor.*`) werden vorgeschlagen.
 auth:
   type: homeassistant
-  params: [home]
+  params: [uri]
 params:
   - name: usage
     choice: ["grid", "pv", "battery", "aux", "charge"]
   - name: uri
-    deprecated: true
+    description:
+      de: Home Assistant URI
+      en: Home Assistant URI
+    example: http://homeassistant.local:8123
+    help:
+      en: " " # overwrite default
+      de: " " # overwrite default
+    service: homeassistant/instances
+    required: true
   - name: token
     deprecated: true
   - name: home
-    description:
-      de: Home Assistant Instanz
-      en: Home Assistant Instance
-    help:
-      en: Can be found in Home Assistant UI under Settings -> System -> General -> Name. Used to identify your instance via mDNS.
-      de: Kann in der Home Assistant UI unter Einstellungen -> System -> Allgemein -> Name gefunden werden. Wird verwendet, um die Instanz via mDNS zu identifizieren.
-    example: Home
-    service: homeassistant/homes
-    required: true
+    deprecated: true
   - name: power
     description:
       de: Leistungsentität
       en: Power Entity
     required: true
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_power"
     help:
       en: Entity ID for instantaneous power measurement in watts. The entity must provide numeric values only (e.g., "1234", not "1234 W").
@@ -40,7 +40,7 @@ params:
     description:
       de: Energieentität
       en: Energy Entity
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_energy"
     advanced: true
     help:
@@ -50,7 +50,7 @@ params:
     description:
       de: L1 Stromentität
       en: L1 Current Entity
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l1"
     advanced: true
     help:
@@ -60,7 +60,7 @@ params:
     description:
       de: L2 Stromentität
       en: L2 Current Entity
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l2"
     advanced: true
     help:
@@ -70,7 +70,7 @@ params:
     description:
       de: L3 Stromentität
       en: L3 Current Entity
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l3"
     advanced: true
     help:
@@ -80,7 +80,7 @@ params:
     description:
       de: L1 Spannungsentität
       en: L1 Voltage Entity
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_voltage_l1"
     advanced: true
     help:
@@ -90,7 +90,7 @@ params:
     description:
       de: L2 Spannungsentität
       en: L2 Voltage Entity
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_voltage_l2"
     advanced: true
     help:
@@ -100,7 +100,7 @@ params:
     description:
       de: L3 Spannungsentität
       en: L3 Voltage Entity
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_voltage_l3"
     advanced: true
     help:
@@ -110,7 +110,7 @@ params:
     description:
       de: Batterieladestand
       en: Battery State of Charge
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.battery_soc"
     advanced: true
     help:
@@ -124,7 +124,7 @@ params:
   - name: maxacpower
 render: |
   type: homeassistant
-  home: {{ .home }}
+  uri: {{ .uri }}
   power: {{ .power }}
   energy: {{ .energy }}
   currents:

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -4,93 +4,93 @@ products:
 group: generic
 requirements:
   description:
-    en: Requires a running Home Assistant instance with suitable vehicle entities and services. All values are Home Assistant entity IDs (e.g. `sensor.*`, `binary_sensor.*`, `number.*`, `script.*`)
-    de: Erfordert eine laufende Home Assistant Instanz mit passenden Fahrzeug-Entities und Services. Alle Werte sind Home Assistant Entity IDs (z.B. `sensor.*`, `binary_sensor.*`, `number.*`, `script.*`)
+    en: Home Assistant instances in your network will be auto-discovered and suitable vehicle entities and services (e.g. `sensor.*`) will be suggested.
+    de: Home Assistant Instanzen in deinem Netzwerk werden automatisch erkannt und passende Entitäten und Services (z.B. `sensor.*`) werden vorgeschlagen.
 auth:
   type: homeassistant
-  params: [home]
+  params: [uri]
 params:
   - preset: vehicle-common
   - name: uri
-    deprecated: true
+    description:
+      de: Home Assistant URI
+      en: Home Assistant URI
+    example: http://homeassistant.local:8123
+    help:
+      en: " " # overwrite default
+      de: " " # overwrite default
+    service: homeassistant/instances
+    required: true
   - name: token
     deprecated: true
   - name: home
-    description:
-      de: Home Assistant Instanz
-      en: Home Assistant Instance
-    help:
-      en: Can be found in Home Assistant UI under Settings -> System -> General -> Name. Used to identify your instance via mDNS.
-      de: Kann in der Home Assistant UI unter Einstellungen -> System -> Allgemein -> Name gefunden werden. Wird verwendet, um die Instanz via mDNS zu identifizieren.
-    example: Home
-    service: homeassistant/homes
-    required: true
+    deprecated: true
   - name: soc
     description:
       de: Ladezustand [%]
       en: State of charge [%]
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}?domain=sensor
     example: "sensor.vehicle_soc"
     required: true
   - name: range
     description:
       de: Restreichweite [km]
       en: Remaining range [km]
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}?domain=sensor
     example: "sensor.vehicle_range"
   - name: status
     description:
       de: Ladestatus
       en: Charging status
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}?domain=sensor
     example: "sensor.vehicle_charging"
   - name: limitSoc
     description:
       de: Ziel-Ladezustand [%]
       en: Target state of charge [%]
-    service: homeassistant/homes/{home}/entities?domain=number,input_number
+    service: homeassistant/entities?uri={uri}?domain=number,input_number
     example: "number.vehicle_target_state_of_charge"
   - name: odometer
     description:
       de: Kilometerstand [km]
       en: Odometer [km]
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}?domain=sensor
     example: "sensor.vehicle_odometer"
   - name: climater
     description:
       de: Klimatisierung aktiv
       en: Climatisation active
-    service: homeassistant/homes/{home}/entities?domain=binary_sensor
+    service: homeassistant/entities?uri={uri}?domain=binary_sensor
     example: "binary_sensor.vehicle_climater"
   - name: finishTime
     description:
       de: Ladeende (ISO8601 oder Unix)
       en: Finish time (ISO8601 or Unix)
-    service: homeassistant/homes/{home}/entities?domain=sensor
+    service: homeassistant/entities?uri={uri}?domain=sensor
     example: "sensor.vehicle_finish_time"
   - name: start_charging
     description:
       de: Service zum Laden starten
       en: Service to start charging
-    service: homeassistant/homes/{home}/entities?domain=script
+    service: homeassistant/entities?uri={uri}?domain=script
     example: "script.vehicle_start_charge"
   - name: stop_charging
     description:
       de: Service zum Laden stoppen
       en: Service to stop charging
-    service: homeassistant/homes/{home}/entities?domain=script
+    service: homeassistant/entities?uri={uri}?domain=script
     example: "script.vehicle_stop_charge"
   - name: wakeup
     description:
       de: Service zum Aufwecken
       en: Service to wake up vehicle
-    service: homeassistant/homes/{home}/entities?domain=script
+    service: homeassistant/entities?uri={uri}?domain=script
     example: "script.vehicle_wakeup"
   - name: setMaxCurrent
     description:
       de: Ladestromstärke setzen [A]
       en: Set charging current [A]
-    service: homeassistant/homes/{home}/entities?domain=number,input_number
+    service: homeassistant/entities?uri={uri}?domain=number,input_number
     example: "number.vehicle_charging_current"
   - preset: vehicle-features
   - name: streaming
@@ -99,7 +99,7 @@ render: |
   type: homeassistant
   {{ include "vehicle-common" . }}
   {{ include "vehicle-features" . }}
-  home: {{ .home }}
+  uri: {{ .uri }}
   sensors:
     soc: {{ .soc }}
     range: {{ .range }}

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -29,68 +29,68 @@ params:
     description:
       de: Ladezustand [%]
       en: State of charge [%]
-    service: homeassistant/entities?uri={uri}?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.vehicle_soc"
     required: true
   - name: range
     description:
       de: Restreichweite [km]
       en: Remaining range [km]
-    service: homeassistant/entities?uri={uri}?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.vehicle_range"
   - name: status
     description:
       de: Ladestatus
       en: Charging status
-    service: homeassistant/entities?uri={uri}?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.vehicle_charging"
   - name: limitSoc
     description:
       de: Ziel-Ladezustand [%]
       en: Target state of charge [%]
-    service: homeassistant/entities?uri={uri}?domain=number,input_number
+    service: homeassistant/entities?uri={uri}&domain=number,input_number
     example: "number.vehicle_target_state_of_charge"
   - name: odometer
     description:
       de: Kilometerstand [km]
       en: Odometer [km]
-    service: homeassistant/entities?uri={uri}?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.vehicle_odometer"
   - name: climater
     description:
       de: Klimatisierung aktiv
       en: Climatisation active
-    service: homeassistant/entities?uri={uri}?domain=binary_sensor
+    service: homeassistant/entities?uri={uri}&domain=binary_sensor
     example: "binary_sensor.vehicle_climater"
   - name: finishTime
     description:
       de: Ladeende (ISO8601 oder Unix)
       en: Finish time (ISO8601 or Unix)
-    service: homeassistant/entities?uri={uri}?domain=sensor
+    service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.vehicle_finish_time"
   - name: start_charging
     description:
       de: Service zum Laden starten
       en: Service to start charging
-    service: homeassistant/entities?uri={uri}?domain=script
+    service: homeassistant/entities?uri={uri}&domain=script
     example: "script.vehicle_start_charge"
   - name: stop_charging
     description:
       de: Service zum Laden stoppen
       en: Service to stop charging
-    service: homeassistant/entities?uri={uri}?domain=script
+    service: homeassistant/entities?uri={uri}&domain=script
     example: "script.vehicle_stop_charge"
   - name: wakeup
     description:
       de: Service zum Aufwecken
       en: Service to wake up vehicle
-    service: homeassistant/entities?uri={uri}?domain=script
+    service: homeassistant/entities?uri={uri}&domain=script
     example: "script.vehicle_wakeup"
   - name: setMaxCurrent
     description:
       de: Ladestromstärke setzen [A]
       en: Set charging current [A]
-    service: homeassistant/entities?uri={uri}?domain=number,input_number
+    service: homeassistant/entities?uri={uri}&domain=number,input_number
     example: "number.vehicle_charging_current"
   - preset: vehicle-features
   - name: streaming

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -23,11 +23,6 @@ type Connection struct {
 
 // NewConnection creates a new Home Assistant connection
 func NewConnection(log *util.Logger, uri, home string) (*Connection, error) {
-	inst := &proxyInstance{
-		home: home,
-		uri:  uri,
-	}
-
 	if home != "" {
 		log.WARN.Printf("using deprecated 'home' parameter '%s', please use 'uri' instead", home)
 	}
@@ -37,8 +32,11 @@ func NewConnection(log *util.Logger, uri, home string) (*Connection, error) {
 	}
 
 	c := &Connection{
-		Helper:   request.NewHelper(log),
-		instance: inst,
+		Helper: request.NewHelper(log),
+		instance: &proxyInstance{
+			home: home,
+			uri:  uri,
+		},
 	}
 
 	// Set up authentication headers

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -33,7 +33,7 @@ func NewConnection(log *util.Logger, uri, home string) (*Connection, error) {
 	}
 
 	if uri == "" && home == "" {
-		return nil, errors.New("missing uri or home parameter")
+		return nil, errors.New("missing either uri or home")
 	}
 
 	c := &Connection{

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -22,10 +22,23 @@ type Connection struct {
 }
 
 // NewConnection creates a new Home Assistant connection
-func NewConnection(log *util.Logger, home string) (*Connection, error) {
+func NewConnection(log *util.Logger, uri, home string) (*Connection, error) {
+	inst := &proxyInstance{
+		home: home,
+		uri:  uri,
+	}
+
+	if home != "" {
+		log.WARN.Printf("using deprecated 'home' parameter '%s', please use 'uri' instead", home)
+	}
+
+	if uri == "" && home == "" {
+		return nil, errors.New("missing uri or home parameter")
+	}
+
 	c := &Connection{
 		Helper:   request.NewHelper(log),
-		instance: &proxyInstance{home: home},
+		instance: inst,
 	}
 
 	// Set up authentication headers

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -3,6 +3,7 @@ package homeassistant
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/evcc-io/evcc/plugin/auth"
 	"github.com/evcc-io/evcc/server/network"
@@ -59,6 +60,11 @@ func NewHomeAssistant(uri string) (oauth2.TokenSource, error) {
 		},
 	}
 
-	// TODO: decide if uri as device name is fine
-	return auth.NewOAuth(ctx, "HomeAssistant", uri, &oc)
+	// use host as device name
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	return auth.NewOAuth(ctx, "HomeAssistant", u.Host, &oc)
 }

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -22,7 +22,7 @@ func init() {
 func NewHomeAssistantFromConfig(other map[string]any) (oauth2.TokenSource, error) {
 	var cc struct {
 		URI  string
-		Home string // TODO deprecate, backward compatibility (v0.210.x)
+		Home string // TODO deprecated
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -22,7 +22,7 @@ func init() {
 func NewHomeAssistantFromConfig(other map[string]any) (oauth2.TokenSource, error) {
 	var cc struct {
 		URI  string
-		Home string // TODO deprecated
+		Home string // TODO remove deprecated
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -3,6 +3,7 @@ package homeassistant
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 
 	"github.com/evcc-io/evcc/plugin/auth"
@@ -66,5 +67,10 @@ func NewHomeAssistant(uri string) (oauth2.TokenSource, error) {
 		return nil, err
 	}
 
-	return auth.NewOAuth(ctx, "HomeAssistant", u.Host, &oc)
+	host := u.Host
+	if h, _, err := net.SplitHostPort(u.Host); err == nil {
+		host = h
+	}
+
+	return auth.NewOAuth(ctx, "HomeAssistant", host, &oc)
 }

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -38,10 +38,6 @@ func NewHomeAssistantFromConfig(other map[string]any) (oauth2.TokenSource, error
 		}
 	}
 
-	if uri == "" {
-		return nil, fmt.Errorf("missing uri parameter")
-	}
-
 	return NewHomeAssistant(uri)
 }
 
@@ -61,7 +57,7 @@ func NewHomeAssistant(uri string) (oauth2.TokenSource, error) {
 		},
 	}
 
-	// use host as device name
+	// validate url
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -59,6 +59,6 @@ func NewHomeAssistant(uri string) (oauth2.TokenSource, error) {
 		},
 	}
 
-	// TODO: decide if uri as identifier is fine
+	// TODO: decide if uri as device name is fine
 	return auth.NewOAuth(ctx, "HomeAssistant", uri, &oc)
 }

--- a/util/homeassistant/service.go
+++ b/util/homeassistant/service.go
@@ -33,7 +33,7 @@ func getInstances(w http.ResponseWriter, req *http.Request) {
 func getEntities(w http.ResponseWriter, req *http.Request) {
 	uri := req.URL.Query().Get("uri")
 	if uri == "" {
-		jsonError(w, http.StatusBadRequest, errors.New("missing uri parameter"))
+		jsonError(w, http.StatusBadRequest, errors.New("missing uri"))
 		return
 	}
 

--- a/util/homeassistant/service.go
+++ b/util/homeassistant/service.go
@@ -2,6 +2,7 @@ package homeassistant
 
 import (
 	"encoding/json"
+	"errors"
 	"maps"
 	"net/http"
 	"slices"
@@ -16,28 +17,27 @@ var log = util.NewLogger("homeassistant")
 
 func init() {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /homes", getHomes)
-	mux.HandleFunc("GET /homes/{home}/entities", getEntities)
+	mux.HandleFunc("GET /instances", getInstances)
+	mux.HandleFunc("GET /entities", getEntities)
 
 	service.Register("homeassistant", mux)
 }
 
-func getHomes(w http.ResponseWriter, req *http.Request) {
+func getInstances(w http.ResponseWriter, req *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	jsonWrite(w, slices.Sorted(maps.Keys(instances)))
+	jsonWrite(w, slices.Sorted(maps.Values(instances)))
 }
 
 func getEntities(w http.ResponseWriter, req *http.Request) {
-	home := req.PathValue("home")
-
-	if instanceUriByName(home) == "" {
-		w.WriteHeader(http.StatusBadRequest)
+	uri := req.URL.Query().Get("uri")
+	if uri == "" {
+		jsonError(w, http.StatusBadRequest, errors.New("missing uri parameter"))
 		return
 	}
 
-	conn, _ := NewConnection(log, home)
+	conn, _ := NewConnection(log, uri, "")
 	res, err := conn.GetStates()
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, err)

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -23,11 +23,11 @@ func init() {
 
 // Constructor from YAML config
 func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error) {
-	cc := struct {
+	var cc struct {
 		embed   `mapstructure:",squash"`
 		URI     string
-		Token_  string `mapstructure:"token"` // deprecated, kept for backward compatibility
-		Home    string // deprecated, kept for backward compatibility
+		Token_  string `mapstructure:"token"` // TODO deprecated
+		Home    string // TODO deprecated
 		Sensors struct {
 			Soc        string // required
 			Range      string // optional
@@ -43,7 +43,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 			Wakeup        string // script.* optional
 			SetMaxCurrent string // number.* or input_number.* optional
 		}
-	}{}
+	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -25,9 +25,9 @@ func init() {
 func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error) {
 	cc := struct {
 		embed   `mapstructure:",squash"`
-		URI_    string `mapstructure:"uri"`   // TODO deprecated
-		Token_  string `mapstructure:"token"` // TODO deprecated
-		Home    string
+		URI     string
+		Token_  string `mapstructure:"token"` // deprecated, kept for backward compatibility
+		Home    string // deprecated, kept for backward compatibility
 		Sensors struct {
 			Soc        string // required
 			Range      string // optional
@@ -43,9 +43,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 			Wakeup        string // script.* optional
 			SetMaxCurrent string // number.* or input_number.* optional
 		}
-	}{
-		Home: "Home",
-	}
+	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -56,7 +54,8 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 	}
 
 	log := util.NewLogger("ha-vehicle")
-	conn, err := homeassistant.NewConnection(log, cc.Home)
+
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/25597
fixes https://github.com/evcc-io/evcc/issues/25618
replaces https://github.com/evcc-io/evcc/pull/25634

This PR reintroduces the `uri` param as the identifier for HA instances. Restoring support for integrating remote instances or local instances without mDNS connectivity.

- 🪄 auto-discover for instances and entities remain
- 🔐 new ui-based auth flow works with yaml configured devices (mDNS independent)
- 🕸️ keep `home` param to not break devices configured with `0.210.x` (deprecated)

**Screenshots**

setup via uri (autodiscover)
<img width="667" height="541" alt="Bildschirmfoto 2025-11-28 um 09 46 56" src="https://github.com/user-attachments/assets/0854f7ad-4617-4e1a-8155-12bba1cb8b19" />

entity name suggestions
<img width="597" height="876" alt="Bildschirmfoto 2025-11-28 um 09 47 42" src="https://github.com/user-attachments/assets/79ac7561-280d-4ffe-b523-aeff5552ef56" />

oauth status indicator (tbd)
<img width="425" height="205" alt="Bildschirmfoto 2025-11-28 um 10 04 55" src="https://github.com/user-attachments/assets/74fab36f-e7b9-4fd3-992e-beaf01b4dd48" />

**TODOs**

- [ ] verify home parameter compatibility works
- [x] throw error on invalid `uri` (try `example.org`) @andig 
- [x] decide what to use as auth provider name (extract ip/host?, see screenshot) @andig @naltatis 
