### PR TITLE
VW: set token expiration time after refresh

### DIFF
--- a/vehicle/vag/loginapps/endpoint.go
+++ b/vehicle/vag/loginapps/endpoint.go
@@ -1,17 +1,16 @@
 package loginapps
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/evcc-io/evcc/util/urlvalues"
 	"github.com/evcc-io/evcc/vehicle/vag/cariad"
-	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 )
 
@@ -79,16 +78,7 @@ func (v *Service) Refresh(token *Token) (*Token, error) {
 		err = v.DoJSON(req, &res)
 	}
 
-	if err == nil {
-		var claims jwt.RegisteredClaims
-		if _, _, parseErr := jwt.NewParser().ParseUnverified(res.AccessToken, &claims); parseErr != nil {
-			err = fmt.Errorf("parse access token: %w", parseErr)
-		} else if claims.ExpiresAt == nil {
-			err = fmt.Errorf("access token missing exp claim")
-		} else {
-			res.Expiry = claims.ExpiresAt.Time
-		}
-	}
+	res.Expiry = time.Now().Add(time.Duration(res.ExpiresIn) * time.Second)
 
 	t := Token(res)
 	return &t, err


### PR DESCRIPTION
fixes #25580 (again)

According to [my assumption](https://github.com/evcc-io/evcc/issues/25580#issuecomment-3591899489) I now explicitly set the `Expiry` field in the `oauth2.Token` so that we can recognize when the access token will expire.
Currently, we seem to just use the once-refreshed access token forever, because expiration is not handled correctly.

I'll leave this on draft until I verified this behavior.