### PR TITLE
pin versions for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "evcc",
-	"image": "mcr.microsoft.com/devcontainers/go",
+	"image": "mcr.microsoft.com/devcontainers/go:2.0.5-1.25-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
 			"moby": true,


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/25950

Fixes this error at container start:
```
0.310 (!) The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution.
0.310 (!) To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
```

This pins the devcontainer's
* go version to the one currently used i in evcc (1.25),
* os version to one that supports moby (bookworm).