### PR TITLE
Energyflow UI: add price/co2 toggle

### DIFF
--- a/assets/js/components/Energyflow/Entry.vue
+++ b/assets/js/components/Energyflow/Entry.vue
@@ -30,7 +30,7 @@
 				<span class="text-end text-nowrap ps-1 fw-bold d-flex align-items-center">
 					<div
 						ref="details"
-						class="fw-normal d-flex align-items-center"
+						class="fw-normal d-flex align-items-center user-select-none"
 						:class="{
 							'text-decoration-underline': detailsClickable,
 							'evcc-gray': detailsInactive,

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -8,6 +8,7 @@ const SETTINGS_UNIT = "settings_unit";
 const SETTINGS_12H_FORMAT = "settings_12h_format";
 const SETTINGS_HIDDEN_FEATURES = "settings_hidden_features";
 const SETTINGS_ENERGYFLOW_DETAILS = "settings_energyflow_details";
+const SETTINGS_ENERGYFLOW_CO2 = "settings_energyflow_co2";
 const SETTINGS_ENERGYFLOW_PV = "settings_energyflow_pv";
 const SETTINGS_ENERGYFLOW_BATTERY = "settings_energyflow_battery";
 const SETTINGS_ENERGYFLOW_LOADPOINTS = "settings_energyflow_loadpoints";
@@ -105,6 +106,7 @@ export interface Settings {
   is12hFormat: boolean;
   hiddenFeatures: boolean;
   energyflowDetails: boolean;
+  energyflowCo2: boolean;
   energyflowPv: boolean;
   energyflowBattery: boolean;
   energyflowLoadpoints: boolean;
@@ -126,6 +128,7 @@ const settings: Settings = reactive({
   is12hFormat: readBool(SETTINGS_12H_FORMAT),
   hiddenFeatures: readBool(SETTINGS_HIDDEN_FEATURES),
   energyflowDetails: readBool(SETTINGS_ENERGYFLOW_DETAILS),
+  energyflowCo2: readBool(SETTINGS_ENERGYFLOW_CO2),
   energyflowPv: readBool(SETTINGS_ENERGYFLOW_PV),
   energyflowBattery: readBool(SETTINGS_ENERGYFLOW_BATTERY),
   energyflowLoadpoints: readBool(SETTINGS_ENERGYFLOW_LOADPOINTS),
@@ -146,6 +149,7 @@ watch(() => settings.unit, save(SETTINGS_UNIT));
 watch(() => settings.is12hFormat, saveBool(SETTINGS_12H_FORMAT));
 watch(() => settings.hiddenFeatures, saveBool(SETTINGS_HIDDEN_FEATURES));
 watch(() => settings.energyflowDetails, saveBool(SETTINGS_ENERGYFLOW_DETAILS));
+watch(() => settings.energyflowCo2, saveBool(SETTINGS_ENERGYFLOW_CO2));
 watch(() => settings.energyflowPv, saveBool(SETTINGS_ENERGYFLOW_PV));
 watch(() => settings.energyflowBattery, saveBool(SETTINGS_ENERGYFLOW_BATTERY));
 watch(() => settings.energyflowLoadpoints, saveBool(SETTINGS_ENERGYFLOW_LOADPOINTS));

--- a/tests/energyflow.spec.ts
+++ b/tests/energyflow.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+
+const CONFIG = "config-with-tariffs.evcc.yaml";
+
+test.use({ baseURL: baseUrl() });
+
+test.beforeAll(async () => {
+  await start(CONFIG);
+});
+
+test.afterAll(async () => {
+  await stop();
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+test("tariff toggle", async ({ page }) => {
+  const energyflow = page.getByTestId("energyflow");
+  await energyflow.click();
+
+  const details = page
+    .getByTestId("energyflow-entry-gridimport")
+    .getByTestId("energyflow-entry-details");
+
+  // check price
+  await expect(details).toHaveText("30.0 öre");
+
+  // toggle to co2
+  await details.click();
+  await expect(details).toHaveText("300 g");
+
+  // reload page and verify persistence
+  await page.reload();
+  await expect(details).toHaveText("300 g");
+
+  // toggle back to price
+  await details.click();
+  await expect(details).toHaveText("30.0 öre");
+});


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/25442

This PR replaces the fixed price vs co2 display logic (dynamic tariff > co2 tariff > static tariff) in the energy flow table with a user selection.

💰/🍃 add ability to toggle between price and co2 if both exist
🥇 price is default
💾 toggle selection is persistent (browser)
♻️ values (grid import/export, consumer, loadpoints) always change together
📱 replaces the tooltip (see screenshot) which was suboptimal for touch use

**Video:** Toggle between price and co2 (if both exist)

[co2 toggle.webm](https://github.com/user-attachments/assets/4e16c98c-f1dc-4895-9c76-a1ed9dd68528)


**Screenshots**

before (fixed rule, both values in tooltip)
<img width="1384" height="204" alt="before" src="https://github.com/user-attachments/assets/463e9182-739e-4db4-b348-e7c92bd759f8" />

only co2 configured
<img width="1372" height="476" alt="co2 only" src="https://github.com/user-attachments/assets/7a56d97b-1b03-4f88-acf9-124d4fa5b16a" />

only price configured
<img width="1391" height="512" alt="price only" src="https://github.com/user-attachments/assets/5fddc65d-f406-477e-b336-3cdd010fafd4" />

