### PR TITLE
Energyflow UI: align production and consumer

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -67,16 +67,14 @@
 						></span>
 					</div>
 				</div>
-				<div
-					class="col-12 col-md-6 pe-md-5 pb-4 d-flex flex-column justify-content-between"
-				>
+				<div class="col-12 col-md-6 pe-md-5 pb-4 d-flex flex-column">
 					<div class="d-flex justify-content-between align-items-baseline mb-4">
 						<h3 class="m-0">In</h3>
 						<span v-if="pvPossible" class="fw-bold">
 							<AnimatedNumber :to="inPower" :format="kw" />
 						</span>
 					</div>
-					<div>
+					<div class="d-flex flex-column justify-content-between flex-grow-1">
 						<EnergyflowEntry
 							v-if="pvPossible"
 							:name="$t('main.energyflow.pvProduction')"
@@ -105,193 +103,197 @@
 								/>
 							</template>
 						</EnergyflowEntry>
-						<EnergyflowEntry
-							v-if="batteryConfigured"
-							:name="batteryDischargeLabel"
-							icon="battery"
-							:power="batteryDischarge"
-							:powerUnit="powerUnit"
-							:iconProps="{
-								hold: batteryHold,
-								soc: batterySoc,
-								gridCharge: batteryGridChargeActive,
-							}"
-							:details="batterySoc"
-							:detailsFmt="batteryFmt"
-							:expanded="batteryExpanded"
-							detailsClickable
-							data-testid="energyflow-entry-batterydischarge"
-							@details-clicked="openBatterySettingsModal"
-							@toggle="toggleBattery"
-						>
-							<template v-if="batteryGridChargeLimitSet" #subline>
-								<div class="d-none d-md-block">&nbsp;</div>
-							</template>
-							<template v-if="battery.length > 1" #expanded>
-								<EnergyflowEntry
-									v-for="(b, index) in battery"
-									:key="index"
-									:name="b.title || genericBatteryTitle(index)"
-									:details="b.soc"
-									:detailsFmt="batteryFmt"
-									:power="dischargePower(b.power)"
-									:powerUnit="powerUnit"
-								/>
-							</template>
-						</EnergyflowEntry>
-						<EnergyflowEntry
-							:key="`grid-${showCo2}`"
-							:name="$t('main.energyflow.gridImport')"
-							icon="powersupply"
-							:power="gridImport"
-							:powerUnit="powerUnit"
-							:details="detailsValue(tariffGrid, tariffCo2)"
-							:detailsFmt="detailsFmt"
-							:detailsClickable="hasPriceAndCo2"
-							data-testid="energyflow-entry-gridimport"
-							@details-clicked="toggleCo2"
-						/>
+						<div>
+							<EnergyflowEntry
+								v-if="batteryConfigured"
+								:name="batteryDischargeLabel"
+								icon="battery"
+								:power="batteryDischarge"
+								:powerUnit="powerUnit"
+								:iconProps="{
+									hold: batteryHold,
+									soc: batterySoc,
+									gridCharge: batteryGridChargeActive,
+								}"
+								:details="batterySoc"
+								:detailsFmt="batteryFmt"
+								:expanded="batteryExpanded"
+								detailsClickable
+								data-testid="energyflow-entry-batterydischarge"
+								@details-clicked="openBatterySettingsModal"
+								@toggle="toggleBattery"
+							>
+								<template v-if="batteryGridChargeLimitSet" #subline>
+									<div class="d-none d-md-block">&nbsp;</div>
+								</template>
+								<template v-if="battery.length > 1" #expanded>
+									<EnergyflowEntry
+										v-for="(b, index) in battery"
+										:key="index"
+										:name="b.title || genericBatteryTitle(index)"
+										:details="b.soc"
+										:detailsFmt="batteryFmt"
+										:power="dischargePower(b.power)"
+										:powerUnit="powerUnit"
+									/>
+								</template>
+							</EnergyflowEntry>
+							<EnergyflowEntry
+								:key="`grid-${showCo2}`"
+								:name="$t('main.energyflow.gridImport')"
+								icon="powersupply"
+								:power="gridImport"
+								:powerUnit="powerUnit"
+								:details="detailsValue(tariffGrid, tariffCo2)"
+								:detailsFmt="detailsFmt"
+								:detailsClickable="hasPriceAndCo2"
+								data-testid="energyflow-entry-gridimport"
+								@details-clicked="toggleCo2"
+							/>
+						</div>
 					</div>
 				</div>
-				<div
-					class="col-12 col-md-6 ps-md-5 pb-4 d-flex flex-column justify-content-between"
-				>
+				<div class="col-12 col-md-6 ps-md-5 pb-4 d-flex flex-column">
 					<div class="d-flex justify-content-between align-items-baseline mb-4">
 						<h3 class="m-0">Out</h3>
 						<span v-if="pvPossible" class="fw-bold">
 							<AnimatedNumber :to="outPower" :format="kw" />
 						</span>
 					</div>
-					<div>
-						<EnergyflowEntry
-							v-if="pvPossible"
-							:key="`home-${showCo2}`"
-							:name="$t('main.energyflow.homePower')"
-							icon="home"
-							:power="homePower"
-							:powerUnit="powerUnit"
-							:details="detailsValue(tariffPriceHome, tariffCo2Home)"
-							:detailsFmt="detailsFmt"
-							:detailsClickable="hasPriceAndCo2"
-							data-testid="energyflow-entry-home"
-							:expanded="consumersExpanded"
-							@details-clicked="toggleCo2"
-							@toggle="toggleConsumers"
-						>
-							<template v-if="consumers.length > 0" #expanded>
-								<EnergyflowEntry
-									v-for="(c, index) in consumers"
-									:key="index"
-									:name="c.title || genericConsumerTitle(index)"
-									:power="c.power"
-									:powerUnit="powerUnit"
-									icon="vehicle"
-									data-testid="energyflow-entry-consumer"
-									:iconProps="{ names: [c.icon || 'generic'] }"
-								/>
-							</template>
-						</EnergyflowEntry>
-						<EnergyflowEntry
-							:key="`loadpoints-${showCo2}`"
-							:name="loadpointsLabel"
-							icon="vehicle"
-							:iconProps="{ names: vehicleIcons }"
-							:power="loadpointsPower"
-							:powerUnit="powerUnit"
-							:details="
-								activeLoadpointsCount
-									? detailsValue(tariffPriceLoadpoints, tariffCo2Loadpoints)
-									: undefined
-							"
-							:detailsFmt="detailsFmt"
-							:detailsClickable="hasPriceAndCo2"
-							data-testid="energyflow-entry-loadpoints"
-							:expanded="loadpointsExpanded"
-							@details-clicked="toggleCo2"
-							@toggle="toggleLoadpoints"
-						>
-							<template v-if="activeLoadpointsCount > 0" #expanded>
-								<EnergyflowEntry
-									v-for="lp in activeLoadpoints"
-									:key="lp.id"
-									:name="lp.displayTitle"
-									:power="lp.chargePower"
-									:powerUnit="powerUnit"
-									icon="vehicle"
-									:iconProps="{ names: [lp.icon] }"
-									:details="lp.vehicleSoc || undefined"
-									:detailsFmt="
-										lp.chargerFeatureHeating
-											? fmtLoadpointTemp
-											: fmtLoadpointSoc
-									"
-								/>
-							</template>
-						</EnergyflowEntry>
-						<EnergyflowEntry
-							v-if="batteryConfigured"
-							:name="batteryChargeLabel"
-							icon="battery"
-							:power="batteryCharge"
-							:powerUnit="powerUnit"
-							:iconProps="{
-								hold: batteryHold,
-								soc: batterySoc,
-								gridCharge: batteryGridChargeActive,
-							}"
-							:details="batterySoc"
-							:detailsFmt="batteryFmt"
-							:expanded="batteryExpanded"
-							detailsClickable
-							@details-clicked="openBatterySettingsModal"
-							@toggle="toggleBattery"
-						>
-							<template v-if="batteryGridChargeLimitSet" #subline>
-								<button
-									type="button"
-									class="btn-reset d-flex justify-content-between text-start pe-4"
-									@click.stop="openBatterySettingsModal"
-								>
-									<span v-if="batteryGridChargeActive">
-										{{ $t("main.energyflow.batteryGridChargeActive") }}
-										<span class="text-nowrap"
-											>(≤ <u>{{ batteryGridChargeLimitFmt }}</u
-											>)</span
-										>
-									</span>
-									<span v-else>
-										{{ $t("main.energyflow.batteryGridChargeLimit") }}
-										<span class="text-nowrap"
-											>≤ <u>{{ batteryGridChargeLimitFmt }}</u></span
-										>
-									</span>
-								</button>
-							</template>
-							<template v-if="battery.length > 1" #expanded>
-								<EnergyflowEntry
-									v-for="(b, index) in battery"
-									:key="index"
-									:name="b.title || genericBatteryTitle(index)"
-									:details="b.soc"
-									:detailsFmt="batteryFmt"
-									:power="chargePower(b.power)"
-									:powerUnit="powerUnit"
-								/>
-							</template>
-						</EnergyflowEntry>
-						<EnergyflowEntry
-							v-if="pvPossible"
-							:key="`export-${showCo2}`"
-							:name="$t('main.energyflow.pvExport')"
-							icon="powersupply"
-							:power="pvExport"
-							:powerUnit="powerUnit"
-							:details="detailsValue(-tariffFeedIn)"
-							:detailsFmt="detailsFmt"
-							:detailsClickable="hasPriceAndCo2"
-							data-testid="energyflow-entry-gridexport"
-							@details-clicked="toggleCo2"
-						/>
+					<div class="d-flex flex-column justify-content-between flex-grow-1">
+						<div>
+							<EnergyflowEntry
+								v-if="pvPossible"
+								:key="`home-${showCo2}`"
+								:name="$t('main.energyflow.homePower')"
+								icon="home"
+								:power="homePower"
+								:powerUnit="powerUnit"
+								:details="detailsValue(tariffPriceHome, tariffCo2Home)"
+								:detailsFmt="detailsFmt"
+								:detailsClickable="hasPriceAndCo2"
+								data-testid="energyflow-entry-home"
+								:expanded="consumersExpanded"
+								@details-clicked="toggleCo2"
+								@toggle="toggleConsumers"
+							>
+								<template v-if="consumers.length > 0" #expanded>
+									<EnergyflowEntry
+										v-for="(c, index) in consumers"
+										:key="index"
+										:name="c.title || genericConsumerTitle(index)"
+										:power="c.power"
+										:powerUnit="powerUnit"
+										icon="vehicle"
+										data-testid="energyflow-entry-consumer"
+										:iconProps="{ names: [c.icon || 'generic'] }"
+									/>
+								</template>
+							</EnergyflowEntry>
+							<EnergyflowEntry
+								:key="`loadpoints-${showCo2}`"
+								:name="loadpointsLabel"
+								icon="vehicle"
+								:iconProps="{ names: vehicleIcons }"
+								:power="loadpointsPower"
+								:powerUnit="powerUnit"
+								:details="
+									activeLoadpointsCount
+										? detailsValue(tariffPriceLoadpoints, tariffCo2Loadpoints)
+										: undefined
+								"
+								:detailsFmt="detailsFmt"
+								:detailsClickable="hasPriceAndCo2"
+								data-testid="energyflow-entry-loadpoints"
+								:expanded="loadpointsExpanded"
+								@details-clicked="toggleCo2"
+								@toggle="toggleLoadpoints"
+							>
+								<template v-if="activeLoadpointsCount > 0" #expanded>
+									<EnergyflowEntry
+										v-for="lp in activeLoadpoints"
+										:key="lp.id"
+										:name="lp.displayTitle"
+										:power="lp.chargePower"
+										:powerUnit="powerUnit"
+										icon="vehicle"
+										:iconProps="{ names: [lp.icon] }"
+										:details="lp.vehicleSoc || undefined"
+										:detailsFmt="
+											lp.chargerFeatureHeating
+												? fmtLoadpointTemp
+												: fmtLoadpointSoc
+										"
+									/>
+								</template>
+							</EnergyflowEntry>
+						</div>
+						<div>
+							<EnergyflowEntry
+								v-if="batteryConfigured"
+								:name="batteryChargeLabel"
+								icon="battery"
+								:power="batteryCharge"
+								:powerUnit="powerUnit"
+								:iconProps="{
+									hold: batteryHold,
+									soc: batterySoc,
+									gridCharge: batteryGridChargeActive,
+								}"
+								:details="batterySoc"
+								:detailsFmt="batteryFmt"
+								:expanded="batteryExpanded"
+								detailsClickable
+								@details-clicked="openBatterySettingsModal"
+								@toggle="toggleBattery"
+							>
+								<template v-if="batteryGridChargeLimitSet" #subline>
+									<button
+										type="button"
+										class="btn-reset d-flex justify-content-between text-start pe-4"
+										@click.stop="openBatterySettingsModal"
+									>
+										<span v-if="batteryGridChargeActive">
+											{{ $t("main.energyflow.batteryGridChargeActive") }}
+											<span class="text-nowrap"
+												>(≤ <u>{{ batteryGridChargeLimitFmt }}</u
+												>)</span
+											>
+										</span>
+										<span v-else>
+											{{ $t("main.energyflow.batteryGridChargeLimit") }}
+											<span class="text-nowrap"
+												>≤ <u>{{ batteryGridChargeLimitFmt }}</u></span
+											>
+										</span>
+									</button>
+								</template>
+								<template v-if="battery.length > 1" #expanded>
+									<EnergyflowEntry
+										v-for="(b, index) in battery"
+										:key="index"
+										:name="b.title || genericBatteryTitle(index)"
+										:details="b.soc"
+										:detailsFmt="batteryFmt"
+										:power="chargePower(b.power)"
+										:powerUnit="powerUnit"
+									/>
+								</template>
+							</EnergyflowEntry>
+							<EnergyflowEntry
+								v-if="pvPossible"
+								:key="`export-${showCo2}`"
+								:name="$t('main.energyflow.pvExport')"
+								icon="powersupply"
+								:power="pvExport"
+								:powerUnit="powerUnit"
+								:details="detailsValue(-tariffFeedIn)"
+								:detailsFmt="detailsFmt"
+								:detailsClickable="hasPriceAndCo2"
+								data-testid="energyflow-entry-gridexport"
+								@details-clicked="toggleCo2"
+							/>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/25729

↔️ v-align production and consumer (battery<>battery, grid<>grid were already aligned)
🎚️ improves expand/collapse transitions (less unexpected move-up animations)


**screenshots**

collapsed
<img width="1018" height="388" alt="compact" src="https://github.com/user-attachments/assets/60cfe80e-7e9f-4ab1-8ec8-29e9e0e6d7a0" />

production, consumer expanded
<img width="1037" height="401" alt="pv + consumer" src="https://github.com/user-attachments/assets/79b5c936-5911-4323-b66c-fb33cc34858a" />

production, battery expanded
<img width="1017" height="473" alt="battery + solar" src="https://github.com/user-attachments/assets/ffd0963b-11c3-4d4b-9f4a-c22c10971d91" />

all in
<img width="1239" height="514" alt="all in" src="https://github.com/user-attachments/assets/3b8b6fbb-e516-4dbf-8cfc-985e61d8a601" />

---

mobile (no change)

<img width="373" height="393" alt="mobile compact" src="https://github.com/user-attachments/assets/2407391f-a00f-4d6c-b111-5d9c4bbb1334" />

<img width="373" height="1046" alt="mobile all in" src="https://github.com/user-attachments/assets/f705a501-02d1-4b5a-a518-c28f0ef4f085" />
