### PR TITLE
Implement `SocLimiter` for supported Renault vehicles

### DIFF
--- a/vehicle/renault.go
+++ b/vehicle/renault.go
@@ -72,12 +72,12 @@ func NewRenaultDaciaFromConfig(brand string, other map[string]any) (api.Vehicle,
 		return nil, err
 	}
 
-	api := kamereon.New(log, keys.Kamereon, identity, func() error {
+	api := kamereon.NewAPI(log, keys.Kamereon, identity, func() error {
 		return identity.Login(cc.User, cc.Password)
 	})
 	api.Client.Timeout = cc.Timeout
 
-	accountID, err := api.Person(identity.PersonID, brand)
+	accountID, err := api.AccountID(identity.PersonID, brand)
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/renault/kamereon/api.go
+++ b/vehicle/renault/kamereon/api.go
@@ -142,46 +142,36 @@ func (v *API) Position(accountID string, vin string) (Position, error) {
 	return res.Data.Attributes, err
 }
 
-func (v *API) DoAction(uri string, data any, res any) error {
-	resContainer := map[string]any{
-		"data": res,
-	}
-
-	reqData := map[string]any{
-		"data": data,
-	}
-
-	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(reqData))
-
-	if err != nil {
-		return err
-	}
-
-	err = v.DoJSON(req, &resContainer)
-
-	return err
-}
-
 func (v *API) WakeUp(accountID string, vin string) (ChargeAction, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kcm/v1/vehicles/%s/charge/pause-resume", v.keys.Target, accountID, vin)
 
-	data := ChargeAction{
-		Type: "ChargePauseResume",
-		Attributes: ChargeActionAttributes{
-			Action: ActionResume,
+	reqBody := map[string]any{
+		"data": ChargeAction{
+			Type: "ChargePauseResume",
+			Attributes: ChargeActionAttributes{
+				Action: ActionResume,
+			},
 		},
 	}
 
-	var res ChargeAction
-	err := v.DoAction(uri, data, &res)
+	var res struct {
+		Data ChargeAction `json:"data"`
+	}
+	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(reqBody))
 
-	return res, err
+	if err != nil {
+		return ChargeAction{}, err
+	}
+
+	err = v.DoJSON(req, &res)
+
+	return res.Data, err
 }
 
 func (v *API) WakeUpMy24(accountID string, vin string) (EvSettingsResponse, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kcm/v1/vehicles/%s/ev/settings", v.keys.Target, accountID, vin)
 
-	data := EvSettingsRequest{
+	reqBody := EvSettingsRequest{
 		LastSettingsUpdateTimestamp: "2025-04-24T12:41:41.823Z",
 		DelegatedActivated:          false,
 		ChargeModeRq:                "SCHEDULED",
@@ -191,7 +181,7 @@ func (v *API) WakeUpMy24(accountID string, vin string) (EvSettingsResponse, erro
 		Programs:                    []any{},
 	}
 
-	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(data))
+	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(reqBody))
 
 	if err != nil {
 		return EvSettingsResponse{}, err
@@ -206,15 +196,25 @@ func (v *API) WakeUpMy24(accountID string, vin string) (EvSettingsResponse, erro
 func (v *API) ChargeAction(accountID, action string, vin string) (ChargeAction, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kca/car-adapter/v1/cars/%s/actions/charging-start", v.keys.Target, accountID, vin)
 
-	data := ChargeAction{
-		Type: "ChargingStart",
-		Attributes: ChargeActionAttributes{
-			Action: action,
+	reqBody := map[string]any{
+		"data": ChargeAction{
+			Type: "ChargingStart",
+			Attributes: ChargeActionAttributes{
+				Action: action,
+			},
 		},
 	}
 
-	var res ChargeAction
-	err := v.DoAction(uri, data, &res)
+	var res struct {
+		Data ChargeAction `json:"data"`
+	}
+	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(reqBody))
 
-	return res, err
+	if err != nil {
+		return ChargeAction{}, err
+	}
+
+	err = v.DoJSON(req, &res)
+
+	return res.Data, err
 }

--- a/vehicle/renault/kamereon/api.go
+++ b/vehicle/renault/kamereon/api.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	ActionStart = "start"
-	ActionStop  = "stop"
+	ActionStart  = "start"
+	ActionStop   = "stop"
+	ActionResume = "resume"
 )
 
 type API struct {
@@ -167,7 +168,7 @@ func (v *API) WakeUp(accountID string, vin string) (ChargeAction, error) {
 	data := ChargeAction{
 		Type: "ChargePauseResume",
 		Attributes: ChargeActionAttributes{
-			Action: "resume",
+			Action: ActionResume,
 		},
 	}
 

--- a/vehicle/renault/kamereon/api.go
+++ b/vehicle/renault/kamereon/api.go
@@ -84,11 +84,7 @@ func (v *API) Vehicles(accountID string) ([]Vehicle, error) {
 func (v *API) BatteryStatus(accountID string, vin string) (BatteryStatus, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kca/car-adapter/v2/cars/%s/battery-status", v.keys.Target, accountID, vin)
 
-	var res struct {
-		Data struct {
-			Attributes BatteryStatus `json:"attributes"`
-		} `json:"data"`
-	}
+	var res DataEnvelope[BatteryStatus]
 	err := v.GetJSON(uri, &res)
 
 	return res.Data.Attributes, err
@@ -97,11 +93,7 @@ func (v *API) BatteryStatus(accountID string, vin string) (BatteryStatus, error)
 func (v *API) HvacStatus(accountID string, vin string) (HvacStatus, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kca/car-adapter/v1/cars/%s/hvac-status", v.keys.Target, accountID, vin)
 
-	var res struct {
-		Data struct {
-			Attributes HvacStatus `json:"attributes"`
-		} `json:"data"`
-	}
+	var res DataEnvelope[HvacStatus]
 	err := v.GetJSON(uri, &res)
 
 	return res.Data.Attributes, err
@@ -110,11 +102,7 @@ func (v *API) HvacStatus(accountID string, vin string) (HvacStatus, error) {
 func (v *API) Cockpit(accountID string, vin string) (Cockpit, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kca/car-adapter/v1/cars/%s/cockpit", v.keys.Target, accountID, vin)
 
-	var res struct {
-		Data struct {
-			Attributes Cockpit `json:"attributes"`
-		} `json:"data"`
-	}
+	var res DataEnvelope[Cockpit]
 	err := v.GetJSON(uri, &res)
 
 	return res.Data.Attributes, err
@@ -132,11 +120,7 @@ func (v *API) SocLevels(accountID string, vin string) (SocLevels, error) {
 func (v *API) Position(accountID string, vin string) (Position, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kca/car-adapter/v1/cars/%s/location", v.keys.Target, accountID, vin)
 
-	var res struct {
-		Data struct {
-			Attributes Position `json:"attributes"`
-		} `json:"data"`
-	}
+	var res DataEnvelope[Position]
 	err := v.GetJSON(uri, &res)
 
 	return res.Data.Attributes, err

--- a/vehicle/renault/kamereon/api.go
+++ b/vehicle/renault/kamereon/api.go
@@ -123,6 +123,11 @@ func (v *API) Cockpit(accountID string, vin string) (Response, error) {
 	return v.request(uri, nil)
 }
 
+func (v *API) SocLevels(accountID string, vin string) (Response, error) {
+	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kcm/v1/vehicles/%s/ev/soc-levels", v.keys.Target, accountID, vin)
+	return v.request(uri, nil)
+}
+
 func (v *API) WakeUp(accountID string, vin string) (Response, error) {
 	uri := fmt.Sprintf("%s/commerce/v1/accounts/%s/kamereon/kcm/v1/vehicles/%s/charge/pause-resume", v.keys.Target, accountID, vin)
 

--- a/vehicle/renault/kamereon/auth.go
+++ b/vehicle/renault/kamereon/auth.go
@@ -1,0 +1,40 @@
+package kamereon
+
+import (
+	"net/http"
+
+	"github.com/evcc-io/evcc/vehicle/renault/gigya"
+	"github.com/evcc-io/evcc/vehicle/renault/keys"
+)
+
+type AuthDecorator struct {
+	Base     http.RoundTripper
+	Login    func() error
+	Keys     keys.ConfigServer
+	Identity *gigya.Identity
+}
+
+func (rt *AuthDecorator) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Set required headers
+	req.Header.Set("content-type", "application/vnd.api+json")
+	req.Header.Set("x-gigya-id_token", rt.Identity.Token)
+	req.Header.Set("apikey", rt.Keys.APIKey)
+
+	// Set country query parameter
+	q := req.URL.Query()
+	q.Set("country", "DE")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := rt.Base.RoundTrip(req)
+	if err == nil {
+		return resp, nil
+	}
+
+	// Try reauthenticating
+	if err := rt.Login(); err != nil {
+		return resp, err
+	}
+
+	// Retry the request
+	return rt.Base.RoundTrip(req)
+}

--- a/vehicle/renault/kamereon/auth.go
+++ b/vehicle/renault/kamereon/auth.go
@@ -34,7 +34,11 @@ func (rt *AuthDecorator) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	resp, err := rt.executeRequest(req)
 
-	if resp.StatusCode == http.StatusUnauthorized {
+	if err == nil && resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		// Drain and close response body
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
 		// Try reauthenticating
 		if err := rt.Login(); err != nil {
 			return nil, err

--- a/vehicle/renault/kamereon/types.go
+++ b/vehicle/renault/kamereon/types.go
@@ -5,15 +5,6 @@ import (
 	"strings"
 )
 
-type Response struct {
-	Accounts     []Account // /commerce/v1/persons/%s
-	AccessToken  string    // /commerce/v1/accounts/%s/kamereon/token
-	VehicleLinks []Vehicle // /commerce/v1/accounts/%s/vehicles
-	Data         Data      // /commerce/v1/accounts/%s/kamereon/kca/car-adapter/vX/cars/%s/...
-	SocMin       *int      // /commerce/v1/accounts/%s/kamereon/kcm/vX/vehicles/%s/ev/soc-levels
-	SocTarget    *int      // /commerce/v1/accounts/%s/kamereon/kcm/vX/vehicles/%s/ev/soc-levels
-}
-
 type Account struct {
 	AccountID     string
 	AccountType   string
@@ -46,31 +37,47 @@ func (v *Vehicle) Available() error {
 	return nil
 }
 
-type Data struct {
-	Attributes attributes
+type BatteryStatus struct {
+	Timestamp          string   `json:"timestamp"`
+	ChargingStatus     float32  `json:"chargingStatus"`
+	InstantaneousPower int      `json:"instantaneousPower"`
+	RangeHvacOff       int      `json:"rangeHvacOff"`
+	BatteryAutonomy    int      `json:"batteryAutonomy"`
+	BatteryLevel       *float64 `json:"batteryLevel"`
+	BatteryTemperature int      `json:"batteryTemperature"`
+	PlugStatus         int      `json:"plugStatus"`
+	LastUpdateTime     string   `json:"lastUpdateTime"`
+	ChargePower        int      `json:"chargePower"`
+	RemainingTime      *int     `json:"chargingRemainingTime"`
 }
 
-type attributes struct {
-	// battery-status
-	Timestamp          string  `json:"timestamp"`
-	ChargingStatus     float32 `json:"chargingStatus"`
-	InstantaneousPower int     `json:"instantaneousPower"`
-	RangeHvacOff       int     `json:"rangeHvacOff"`
-	BatteryAutonomy    int     `json:"batteryAutonomy"`
-	BatteryLevel       *int    `json:"batteryLevel"`
-	BatteryTemperature int     `json:"batteryTemperature"`
-	PlugStatus         int     `json:"plugStatus"`
-	LastUpdateTime     string  `json:"lastUpdateTime"`
-	ChargePower        int     `json:"chargePower"`
-	RemainingTime      *int    `json:"chargingRemainingTime"`
-	// hvac-status
+type HvacStatus struct {
 	ExternalTemperature float64 `json:"externalTemperature"`
 	HvacStatus          string  `json:"hvacStatus"`
-	// cockpit
-	TotalMileage *float64 `json:"totalMileage"`
-	// position
+}
+
+type Cockpit struct {
+	TotalMileage *int `json:"totalMileage"`
+}
+
+type SocLevels struct {
+	SocMin                    *int   `json:"socMin"`
+	SocTarget                 *int   `json:"socTarget"`
+	LastEnergyUpdateTimestamp string `json:"lastEnergyUpdateTimestamp"`
+}
+
+type Position struct {
 	Latitude  float64 `json:"gpsLatitude"`
 	Longitude float64 `json:"gpsLongitude"`
+}
+
+type ChargeAction struct {
+	Type       string                 `json:"type"`
+	Attributes ChargeActionAttributes `json:"attributes"`
+}
+
+type ChargeActionAttributes struct {
+	Action string `json:"action"`
 }
 
 type EvSettingsRequest struct {
@@ -84,4 +91,10 @@ type EvSettingsRequest struct {
 	PreconditioningHeatedRightSeat bool    `json:"preconditioningHeatedRightSeat"`
 	PreconditioningHeatedLeftSeat  bool    `json:"preconditioningHeatedLeftSeat"`
 	Programs                       []any   `json:"programs"`
+}
+
+type EvSettingsResponse struct {
+	CommandId string `json:"commandId"`
+	Type      string `json:"type"`
+	Status    string `json:"status"`
 }

--- a/vehicle/renault/kamereon/types.go
+++ b/vehicle/renault/kamereon/types.go
@@ -38,17 +38,17 @@ func (v *Vehicle) Available() error {
 }
 
 type BatteryStatus struct {
-	Timestamp          string   `json:"timestamp"`
-	ChargingStatus     float32  `json:"chargingStatus"`
-	InstantaneousPower int      `json:"instantaneousPower"`
-	RangeHvacOff       int      `json:"rangeHvacOff"`
-	BatteryAutonomy    int      `json:"batteryAutonomy"`
-	BatteryLevel       *float64 `json:"batteryLevel"`
-	BatteryTemperature int      `json:"batteryTemperature"`
-	PlugStatus         int      `json:"plugStatus"`
-	LastUpdateTime     string   `json:"lastUpdateTime"`
-	ChargePower        int      `json:"chargePower"`
-	RemainingTime      *int     `json:"chargingRemainingTime"`
+	Timestamp          string  `json:"timestamp"`
+	ChargingStatus     float32 `json:"chargingStatus"`
+	InstantaneousPower int     `json:"instantaneousPower"`
+	RangeHvacOff       int     `json:"rangeHvacOff"`
+	BatteryAutonomy    int     `json:"batteryAutonomy"`
+	BatteryLevel       *int    `json:"batteryLevel"`
+	BatteryTemperature int     `json:"batteryTemperature"`
+	PlugStatus         int     `json:"plugStatus"`
+	LastUpdateTime     string  `json:"lastUpdateTime"`
+	ChargePower        int     `json:"chargePower"`
+	RemainingTime      *int    `json:"chargingRemainingTime"`
 }
 
 type HvacStatus struct {

--- a/vehicle/renault/kamereon/types.go
+++ b/vehicle/renault/kamereon/types.go
@@ -57,7 +57,7 @@ type HvacStatus struct {
 }
 
 type Cockpit struct {
-	TotalMileage *int `json:"totalMileage"`
+	TotalMileage *float64 `json:"totalMileage"`
 }
 
 type SocLevels struct {

--- a/vehicle/renault/kamereon/types.go
+++ b/vehicle/renault/kamereon/types.go
@@ -10,6 +10,8 @@ type Response struct {
 	AccessToken  string    // /commerce/v1/accounts/%s/kamereon/token
 	VehicleLinks []Vehicle // /commerce/v1/accounts/%s/vehicles
 	Data         Data      // /commerce/v1/accounts/%s/kamereon/kca/car-adapter/vX/cars/%s/...
+	SocMin       *int      // /commerce/v1/accounts/%s/kamereon/kcm/vX/vehicles/%s/ev/soc-levels
+	SocTarget    *int      // /commerce/v1/accounts/%s/kamereon/kcm/vX/vehicles/%s/ev/soc-levels
 }
 
 type Account struct {

--- a/vehicle/renault/kamereon/types.go
+++ b/vehicle/renault/kamereon/types.go
@@ -80,6 +80,12 @@ type ChargeActionAttributes struct {
 	Action string `json:"action"`
 }
 
+type DataEnvelope[T any] struct {
+	Data struct {
+		Attributes T `json:"attributes"`
+	} `json:"data"`
+}
+
 type EvSettingsRequest struct {
 	LastSettingsUpdateTimestamp    string  `json:"lastSettingsUpdateTimestamp"`
 	DelegatedActivated             bool    `json:"delegatedActivated"`

--- a/vehicle/renault/provider.go
+++ b/vehicle/renault/provider.go
@@ -48,6 +48,11 @@ func NewProvider(api *kamereon.API, accountID, vin string, wakeupMode string, ca
 				_, err = api.WakeUpMy24(accountID, vin)
 			default:
 				_, err = api.WakeUp(accountID, vin)
+
+				// Check if default wakeup is unsupported
+				if se := new(request.StatusError); errors.As(err, &se) && se.StatusCode() == http.StatusForbidden {
+					_, err = api.WakeUpMy24(accountID, vin)
+				}
 			}
 			return err
 		},

--- a/vehicle/renault/provider.go
+++ b/vehicle/renault/provider.go
@@ -79,7 +79,7 @@ func (v *Provider) Soc() (float64, error) {
 		return 0, api.ErrNotAvailable
 	}
 
-	return *res.BatteryLevel, nil
+	return float64(*res.BatteryLevel), nil
 }
 
 var _ api.ChargeState = (*Provider)(nil)

--- a/vehicle/renault/provider.go
+++ b/vehicle/renault/provider.go
@@ -136,7 +136,16 @@ var _ api.SocLimiter = (*Provider)(nil)
 func (v *Provider) GetLimitSoc() (int64, error) {
 	res, err := v.socLevelsG()
 
-	if err == nil && res.SocTarget != nil {
+	// Check if endpoint is unavailable
+	if se := new(request.StatusError); errors.As(err, &se) && se.HasStatus(http.StatusForbidden, http.StatusNotFound, http.StatusBadGateway) {
+		return 0, api.ErrNotAvailable
+	}
+
+	if err != nil {
+		return 0, err
+	}
+
+	if res.SocTarget != nil {
 		return int64(*res.SocTarget), nil
 	}
 

--- a/vehicle/renault/provider.go
+++ b/vehicle/renault/provider.go
@@ -50,7 +50,8 @@ func NewProvider(api *kamereon.API, accountID, vin string, wakeupMode string, ca
 				_, err = api.WakeUp(accountID, vin)
 
 				// Check if default wakeup is unsupported
-				if se := new(request.StatusError); errors.As(err, &se) && se.StatusCode() == http.StatusForbidden {
+				var se *request.StatusError
+				if errors.As(err, &se) && se.HasStatus(http.StatusForbidden, http.StatusNotFound, http.StatusBadGateway) {
 					_, err = api.WakeUpMy24(accountID, vin)
 				}
 			}

--- a/vehicle/renault/provider.go
+++ b/vehicle/renault/provider.go
@@ -15,45 +15,47 @@ import (
 
 // Provider is an api.Vehicle implementation for PSA cars
 type Provider struct {
-	batteryG   func() (kamereon.Response, error)
-	cockpitG   func() (kamereon.Response, error)
-	socLevelsG func() (kamereon.Response, error)
-	hvacG      func() (kamereon.Response, error)
-	wakeup     func() (kamereon.Response, error)
-	position   func() (kamereon.Response, error)
-	action     func(action string) (kamereon.Response, error)
+	batteryStatusG func() (kamereon.BatteryStatus, error)
+	cockpitG       func() (kamereon.Cockpit, error)
+	socLevelsG     func() (kamereon.SocLevels, error)
+	hvacG          func() (kamereon.HvacStatus, error)
+	wakeup         func() error
+	position       func() (kamereon.Position, error)
+	chargeAction   func(action string) (kamereon.ChargeAction, error)
 }
 
 // NewProvider creates a vehicle api provider
 func NewProvider(api *kamereon.API, accountID, vin string, wakeupMode string, cache time.Duration) *Provider {
 	impl := &Provider{
-		batteryG: util.Cached(func() (kamereon.Response, error) {
-			return api.Battery(accountID, vin)
+		batteryStatusG: util.Cached(func() (kamereon.BatteryStatus, error) {
+			return api.BatteryStatus(accountID, vin)
 		}, cache),
-		cockpitG: util.Cached(func() (kamereon.Response, error) {
+		cockpitG: util.Cached(func() (kamereon.Cockpit, error) {
 			return api.Cockpit(accountID, vin)
 		}, cache),
-		socLevelsG: util.Cached(func() (kamereon.Response, error) {
+		socLevelsG: util.Cached(func() (kamereon.SocLevels, error) {
 			return api.SocLevels(accountID, vin)
 		}, cache),
-		hvacG: util.Cached(func() (kamereon.Response, error) {
-			return api.Hvac(accountID, vin)
+		hvacG: util.Cached(func() (kamereon.HvacStatus, error) {
+			return api.HvacStatus(accountID, vin)
 		}, cache),
-		wakeup: func() (kamereon.Response, error) {
+		wakeup: func() error {
+			var err error
 			switch wakeupMode {
 			case "alternative":
-				return api.Action(accountID, kamereon.ActionStart, vin)
+				_, err = api.ChargeAction(accountID, kamereon.ActionStart, vin)
 			case "MY24":
-				return api.WakeUpMY24(accountID, vin)
+				_, err = api.WakeUpMy24(accountID, vin)
 			default:
-				return api.WakeUp(accountID, vin)
+				_, err = api.WakeUp(accountID, vin)
 			}
+			return err
 		},
-		position: func() (kamereon.Response, error) {
+		position: func() (kamereon.Position, error) {
 			return api.Position(accountID, vin)
 		},
-		action: func(action string) (kamereon.Response, error) {
-			return api.Action(accountID, action, vin)
+		chargeAction: func(action string) (kamereon.ChargeAction, error) {
+			return api.ChargeAction(accountID, action, vin)
 		},
 	}
 	return impl
@@ -63,16 +65,16 @@ var _ api.Battery = (*Provider)(nil)
 
 // Soc implements the api.Vehicle interface
 func (v *Provider) Soc() (float64, error) {
-	res, err := v.batteryG()
+	res, err := v.batteryStatusG()
 	if err != nil {
 		return 0, err
 	}
 
-	if res.Data.Attributes.BatteryLevel == nil {
+	if res.BatteryLevel == nil {
 		return 0, api.ErrNotAvailable
 	}
 
-	return float64(*res.Data.Attributes.BatteryLevel), nil
+	return *res.BatteryLevel, nil
 }
 
 var _ api.ChargeState = (*Provider)(nil)
@@ -81,12 +83,12 @@ var _ api.ChargeState = (*Provider)(nil)
 func (v *Provider) Status() (api.ChargeStatus, error) {
 	status := api.StatusA // disconnected
 
-	res, err := v.batteryG()
+	res, err := v.batteryStatusG()
 	if err == nil {
-		if res.Data.Attributes.PlugStatus == 1 {
+		if res.PlugStatus == 1 {
 			status = api.StatusB
 		}
-		if res.Data.Attributes.ChargingStatus >= 1.0 {
+		if res.ChargingStatus >= 1.0 {
 			status = api.StatusC
 		}
 	}
@@ -98,10 +100,10 @@ var _ api.VehicleRange = (*Provider)(nil)
 
 // Range implements the api.VehicleRange interface
 func (v *Provider) Range() (int64, error) {
-	res, err := v.batteryG()
+	res, err := v.batteryStatusG()
 
 	if err == nil {
-		return int64(res.Data.Attributes.BatteryAutonomy), nil
+		return int64(res.BatteryAutonomy), nil
 	}
 
 	return 0, err
@@ -116,8 +118,8 @@ func (v *Provider) Odometer() (float64, error) {
 		return 0, err
 	}
 
-	if res.Data.Attributes.TotalMileage != nil {
-		return *res.Data.Attributes.TotalMileage, nil
+	if res.TotalMileage != nil {
+		return float64(*res.TotalMileage), nil
 	}
 
 	return 0, api.ErrNotAvailable
@@ -140,16 +142,16 @@ var _ api.VehicleFinishTimer = (*Provider)(nil)
 
 // FinishTime implements the api.VehicleFinishTimer interface
 func (v *Provider) FinishTime() (time.Time, error) {
-	res, err := v.batteryG()
+	res, err := v.batteryStatusG()
 
 	if err == nil {
-		timestamp, err := time.Parse(time.RFC3339, res.Data.Attributes.Timestamp)
+		timestamp, err := time.Parse(time.RFC3339, res.Timestamp)
 
-		if res.Data.Attributes.RemainingTime == nil {
+		if res.RemainingTime == nil {
 			return time.Time{}, api.ErrNotAvailable
 		}
 
-		return timestamp.Add(time.Duration(*res.Data.Attributes.RemainingTime) * time.Minute), err
+		return timestamp.Add(time.Duration(*res.RemainingTime) * time.Minute), err
 	}
 
 	return time.Time{}, err
@@ -167,7 +169,7 @@ func (v *Provider) Climater() (bool, error) {
 	}
 
 	if err == nil {
-		state := strings.ToLower(res.Data.Attributes.HvacStatus)
+		state := strings.ToLower(res.HvacStatus)
 		if state == "" {
 			return false, api.ErrNotAvailable
 		}
@@ -183,8 +185,7 @@ var _ api.Resurrector = (*Provider)(nil)
 
 // WakeUp implements the api.Resurrector interface
 func (v *Provider) WakeUp() error {
-	_, err := v.wakeup()
-	return err
+	return v.wakeup()
 }
 
 var _ api.VehiclePosition = (*Provider)(nil)
@@ -193,7 +194,7 @@ var _ api.VehiclePosition = (*Provider)(nil)
 func (v *Provider) Position() (float64, float64, error) {
 	res, err := v.position()
 	if err == nil {
-		return res.Data.Attributes.Latitude, res.Data.Attributes.Longitude, nil
+		return res.Latitude, res.Longitude, nil
 	}
 
 	return 0, 0, err
@@ -204,6 +205,6 @@ var _ api.ChargeController = (*Provider)(nil)
 // ChargeEnable implements the api.ChargeController interface
 func (v *Provider) ChargeEnable(enable bool) error {
 	action := map[bool]string{true: kamereon.ActionStart, false: kamereon.ActionStop}
-	_, err := v.action(action[enable])
+	_, err := v.chargeAction(action[enable])
 	return err
 }

--- a/vehicle/renault/provider.go
+++ b/vehicle/renault/provider.go
@@ -124,7 +124,7 @@ func (v *Provider) Odometer() (float64, error) {
 	}
 
 	if res.TotalMileage != nil {
-		return float64(*res.TotalMileage), nil
+		return *res.TotalMileage, nil
 	}
 
 	return 0, api.ErrNotAvailable

--- a/vehicle/renault/provider.go
+++ b/vehicle/renault/provider.go
@@ -137,7 +137,8 @@ func (v *Provider) GetLimitSoc() (int64, error) {
 	res, err := v.socLevelsG()
 
 	// Check if endpoint is unavailable
-	if se := new(request.StatusError); errors.As(err, &se) && se.HasStatus(http.StatusForbidden, http.StatusNotFound, http.StatusBadGateway) {
+	var se *request.StatusError
+	if errors.As(err, &se) && se.HasStatus(http.StatusForbidden, http.StatusNotFound, http.StatusBadGateway) {
 		return 0, api.ErrNotAvailable
 	}
 
@@ -178,7 +179,8 @@ func (v *Provider) Climater() (bool, error) {
 	res, err := v.hvacG()
 
 	// Zoe Ph2, Megane e-tech
-	if se := new(request.StatusError); errors.As(err, &se) && se.HasStatus(http.StatusForbidden, http.StatusNotFound, http.StatusBadGateway) {
+	var se *request.StatusError
+	if errors.As(err, &se) && se.HasStatus(http.StatusForbidden, http.StatusNotFound, http.StatusBadGateway) {
 		return false, api.ErrNotAvailable
 	}
 


### PR DESCRIPTION
This implements `GetLimitSoc` for Renault vehicles using the API's `soc-levels` endpoint. Vehicles that don't support the endpoint will keep the current functionality.