### PR TITLE
OpenEMS: align maxchargepower configuration (BC)

### DIFF
--- a/templates/definition/meter/openems-modbus.yaml
+++ b/templates/definition/meter/openems-modbus.yaml
@@ -216,6 +216,7 @@ render: |
               encoding: float32
       - case: 3 # charge
         set:
+          {{- if .maxchargepower }}
           source: const
           value: {{ mul .maxchargepower -1 }} # charge power is negative
           set:
@@ -225,6 +226,10 @@ render: |
               address: {{ .battery_set_register }}
               type: writemultiple
               encoding: float32
+          {{- else }}
+          source: error
+          error: ErrNotAvailable
+          {{- end }}              
   {{- end }}
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -60,7 +60,6 @@ params:
   - name: capacity
     advanced: true
   - name: maxchargepower
-    default: 4200
   - name: maxdischargepower
   - name: maxacpower
 render: |
@@ -153,6 +152,7 @@ render: |
           body: '{"value": 0}'
       - case: 3 # charge
         set:
+          {{- if .maxchargepower }}
           source: http
           uri: http://{{ .host }}/rest/channel/{{ .battery }}/SetActivePowerLessOrEquals
           auth:
@@ -163,6 +163,10 @@ render: |
           headers:
           - content-type: application/json
           body: '{"value": {{ mul .maxchargepower -1 }}}' # charge power is negative
+          {{- else }}
+          source: error
+          error: ErrNotAvailable
+          {{- end }}
   {{- end }}
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %


### PR DESCRIPTION
Removed default value for maxchargepower as it is unkown.

The parameter maxchargepower is not to be required because to control a battery is optional. As it should not be empty if battery control is configured, error handling is required. 

Works for UI-based and yaml-based configurations.

**Required**: set a proper value for maxchargepower to make grid charging available (default was 4200, higher values possible)