### PR TITLE
Ford: change setup url of fordconnect-query api

### DIFF
--- a/templates/definition/vehicle/ford-connect-query.yaml
+++ b/templates/definition/vehicle/ford-connect-query.yaml
@@ -7,22 +7,22 @@ params:
     description:
       generic: FordConnect Query Client ID
     help:
-      de: Einrichtung unter https://developer.ford.com/apis/fordconnect-query
-      en: Setup at https://developer.ford.com/apis/fordconnect-query
+      de: Einrichtung unter https://developer.ford.com/developer-eu
+      en: Setup at https://developer.ford.com/developer-eu
     required: true
   - name: clientsecret
     description:
       generic: FordConnect Query Client Secret
     help:
-      de: Einrichtung unter https://developer.ford.com/apis/fordconnect-query
-      en: Setup at https://developer.ford.com/apis/fordconnect-query
+      de: Einrichtung unter https://developer.ford.com/developer-eu
+      en: Setup at https://developer.ford.com/developer-eu
     required: true
   - name: redirecturi
     description:
       generic: FordConnect Query Redirect URL
     help:
-      de: Einrichtung unter https://developer.ford.com/apis/fordconnect-query
-      en: Setup at https://developer.ford.com/apis/fordconnect-query
+      de: Einrichtung unter https://developer.ford.com/developer-eu
+      en: Setup at https://developer.ford.com/developer-eu
     service: auth/redirecturi
     required: true
   - name: vin


### PR DESCRIPTION
I changed the URL for the FordConnect query API from **https://developer.ford.com/apis/fordconnect-query** to **https://developer.ford.com/developer-eu**, because the original URL only contains the API description without the option to register for a client ID.