### PR TITLE
Deprecate mz2mqtt

### DIFF
--- a/templates/definition/vehicle/mz2mqtt.yaml
+++ b/templates/definition/vehicle/mz2mqtt.yaml
@@ -1,4 +1,5 @@
 template: mz2mqtt
+deprecated: true
 products:
   - description:
       generic: mz2mqtt


### PR DESCRIPTION
Mazda has migrated EU regions to a new authentication backend (API v2). So mz2mqtt is not working any more.