### PR TITLE
Update Zaptec Go OCPP configuration link and description in YAML file

### DIFF
--- a/templates/definition/charger/ocpp-zaptec.yaml
+++ b/templates/definition/charger/ocpp-zaptec.yaml
@@ -7,7 +7,7 @@ capabilities: ["rfid"]
 requirements:
   description:
     generic: |
-      OCPP Native mode
+      OCPP (Box-Level Integration)
 
       https://docs.zaptec.com/docs/ocpp16j
   evcc: ["sponsorship", "skiptest"]

--- a/templates/definition/charger/ocpp-zaptec.yaml
+++ b/templates/definition/charger/ocpp-zaptec.yaml
@@ -9,7 +9,7 @@ requirements:
     generic: |
       OCPP Native mode
 
-      https://help.zaptec.com/hc/en-001/articles/22330328601489-Zaptec-Go-OCPP-Native-configuration-guide#h_01HP261F5NP6Z9VY0MVHJCZEBJ
+      https://docs.zaptec.com/docs/ocpp16j
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp-zaptec.yaml
+++ b/templates/definition/charger/ocpp-zaptec.yaml
@@ -7,7 +7,7 @@ capabilities: ["rfid"]
 requirements:
   description:
     generic: |
-      OCPP (Box-Level Integration)
+      OCPP 1.6J (Box-Level Integration)
 
       https://docs.zaptec.com/docs/ocpp16j
   evcc: ["sponsorship", "skiptest"]


### PR DESCRIPTION
Zaptec moved their documentation for OCPP. The current URL is not valid anymore. See evcc-io/docs/pull/948 as well.