### PR TITLE
SolarEdge Hybrid: add min/max soc maxcharge/discharge power

### DIFF
--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -25,7 +25,7 @@ params:
     advanced: true
   - name: maxacpower
   - name: maxchargepower
-    required: true    
+    required: true
   - name: maxdischargepower
     required: true
   - name: minsoc

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -1,7 +1,7 @@
 template: solaredge-hybrid
 products:
   - brand: SolarEdge
-    description:
+    description:https://www.reddit.com/
       generic: Hybrid Inverter
 capabilities: ["battery-control"]
 requirements:
@@ -25,9 +25,8 @@ params:
     advanced: true
   - name: maxacpower
   - name: maxchargepower
-    required: true
   - name: maxdischargepower
-    required: true
+    default: 5000
   - name: minsoc
     advanced: true
   - name: maxsoc

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -1,7 +1,7 @@
 template: solaredge-hybrid
 products:
   - brand: SolarEdge
-    description:https://www.reddit.com/
+    description:
       generic: Hybrid Inverter
 capabilities: ["battery-control"]
 requirements:

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -25,9 +25,8 @@ params:
     advanced: true
   - name: maxacpower
   - name: maxchargepower
-    default: 5000
+    required: true    
   - name: maxdischargepower
-    default: 5000
     required: true
   - name: minsoc
     advanced: true

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -24,6 +24,15 @@ params:
   - name: capacity
     advanced: true
   - name: maxacpower
+  - name: maxchargepower
+    default: 5000
+  - name: maxdischargepower
+    default: 5000
+    required: true
+  - name: minsoc
+    advanced: true
+  - name: maxsoc
+    advanced: true
   - name: watchdog
     type: duration
     default: 60s
@@ -142,6 +151,8 @@ render: |
       address: 0xE184 # Battery 1 State of Energy (SOE)
       type: holding
       decode: float32nans
+  minsoc: {{ .minsoc }} # %
+  maxsoc: {{ .maxsoc }} # %
   batterymode:
     source: watchdog
     timeout: {{ .watchdog }}
@@ -163,7 +174,7 @@ render: |
                 type: writesingle
                 encoding: uint16
           - source: const
-            value: 5000 # W
+            value: {{ .maxdischargepower }} # W
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}
@@ -216,4 +227,6 @@ render: |
                 type: writemultiple
                 encoding: float32s
   capacity: {{ .capacity }} # kWh
+  maxchargepower: {{ .maxchargepower }} # W
+  maxdischargepower: {{ .maxdischargepower }} # W
   {{- end }}


### PR DESCRIPTION
Added minSoc, maxSoc, maxchargepower and maxdischargepower.

Replaced hardcoded discharge limit in battery control with maxdischargepower setting. Use hardcoded value as new default.

