### PR TITLE
Kathrein: remove incorrect charge duration

### DIFF
--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -309,17 +309,8 @@ func (wb *Kathrein) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(kathreinRegVoltages, 1)
 }
 
-var _ api.ChargeTimer = (*Kathrein)(nil)
-
-// ChargeDuration implements the api.ChargeTimer interface
-func (wb *Kathrein) ChargeDuration() (time.Duration, error) {
-	b, err := wb.conn.ReadHoldingRegisters(kathreinRegChargingDuration, 2)
-	if err != nil {
-		return 0, err
-	}
-
-	return time.Duration(binary.BigEndian.Uint32(b)) * time.Second, nil
-}
+// removed since broken, see https://github.com/evcc-io/evcc/pull/XXXX
+// var _ api.ChargeTimer = (*Kathrein)(nil)
 
 // removed since broken, see https://github.com/evcc-io/evcc/pull/25427
 // var _ api.ChargeRater = (*Kathrein)(nil)

--- a/charger/kathrein.go
+++ b/charger/kathrein.go
@@ -309,7 +309,7 @@ func (wb *Kathrein) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(kathreinRegVoltages, 1)
 }
 
-// removed since broken, see https://github.com/evcc-io/evcc/pull/XXXX
+// removed since broken, see https://github.com/evcc-io/evcc/pull/25934
 // var _ api.ChargeTimer = (*Kathrein)(nil)
 
 // removed since broken, see https://github.com/evcc-io/evcc/pull/25427


### PR DESCRIPTION
The charge duration reported by the charger seems to be incorrect. The charging time is measured from the moment of connection, not from the start of charging.

Should fix #25914 
