### PR TITLE
EM2GO: workaround for home FW 1.4

### DIFF
--- a/charger/em2go.go
+++ b/charger/em2go.go
@@ -200,13 +200,13 @@ func (wb *Em2Go) Enable(enable bool) error {
 		// send default current
 		return wb.setCurrent(wb.current)
 	}
-	
+
 	// experimental workaround for EM2GO home FW 1.4
 	// https://github.com/evcc-io/evcc/discussions/25940#discussioncomment-15221487
 	if !enable {
 		return wb.setCurrent(0)
 	}
-	
+
 	return nil
 }
 

--- a/charger/em2go.go
+++ b/charger/em2go.go
@@ -200,7 +200,13 @@ func (wb *Em2Go) Enable(enable bool) error {
 		// send default current
 		return wb.setCurrent(wb.current)
 	}
-
+	
+	// experimental workaround for EM2GO home FW 1.4
+	// https://github.com/evcc-io/evcc/discussions/25940#discussioncomment-15221487
+	if !enable {
+		return wb.setCurrent(0)
+	}
+	
 	return nil
 }
 


### PR DESCRIPTION
adresses https://github.com/evcc-io/evcc/discussions/25549
implements hint from D-PARTS https://github.com/evcc-io/evcc/discussions/25940#discussioncomment-15221487

Der Workaround trifft alle em2go, macht aber auch nichts kaputt, denke ich (tested EM2GO PRO).
@dniakamal bessere Idee?
