### PR TITLE
Add Zendure Solarflow 2400 AC

### DIFF
--- a/templates/definition/meter/zendure-solarflow-2400-ac.yaml
+++ b/templates/definition/meter/zendure-solarflow-2400-ac.yaml
@@ -2,21 +2,14 @@ template: zendure-solarflow-2400-ac
 products:
   - brand: Zendure
     description:
-      en: "Solarflow 2400 AC Battery"
-      de: "Solarflow 2400 AC Speicher"
+      generic: Solarflow 2400 AC
 
 params:
   - name: host
     required: true
-    description:
-      en: "IP address of the Zendure Solarflow 2400 AC"
-      de: "IP-Adresse des Zendure Solarflow 2400 AC"
 
   - name: capacity
     required: true
-    description:
-      en: "Battery capacity in kWh"
-      de: "Speicherkapazität in kWh"
 
 render: |
   type: custom
@@ -26,14 +19,15 @@ render: |
       - source: http
         uri: http://{{ .host }}/properties/report
         jq: .properties.packInputPower
-        scale: 1
+        cache: 1s
       - source: http
         uri: http://{{ .host }}/properties/report
         jq: .properties.outputPackPower
         scale: -1
+        cache: 1s
   soc:
     source: http
     uri: http://{{ .host }}/properties/report
     jq: .properties.electricLevel
+    cache: 1s
   capacity: {{ .capacity }}
-

--- a/templates/definition/meter/zendure-solarflow-2400-ac.yaml
+++ b/templates/definition/meter/zendure-solarflow-2400-ac.yaml
@@ -5,9 +5,10 @@ products:
       generic: Solarflow 2400 AC
 
 params:
+  - name: usage
+    choice: ["battery"]
   - name: host
     required: true
-
   - name: capacity
     required: true
 

--- a/templates/definition/meter/zendure-solarflow-2400-ac.yaml
+++ b/templates/definition/meter/zendure-solarflow-2400-ac.yaml
@@ -1,0 +1,39 @@
+template: zendure-solarflow-2400-ac
+products:
+  - brand: Zendure
+    description:
+      en: "Solarflow 2400 AC Battery"
+      de: "Solarflow 2400 AC Speicher"
+
+params:
+  - name: host
+    required: true
+    description:
+      en: "IP address of the Zendure Solarflow 2400 AC"
+      de: "IP-Adresse des Zendure Solarflow 2400 AC"
+
+  - name: capacity
+    required: true
+    description:
+      en: "Battery capacity in kWh"
+      de: "Speicherkapazität in kWh"
+
+render: |
+  type: custom
+  power:
+    source: calc
+    add:
+      - source: http
+        uri: http://{{ .host }}/properties/report
+        jq: .properties.packInputPower
+        scale: 1
+      - source: http
+        uri: http://{{ .host }}/properties/report
+        jq: .properties.outputPackPower
+        scale: -1
+  soc:
+    source: http
+    uri: http://{{ .host }}/properties/report
+    jq: .properties.electricLevel
+  capacity: {{ .capacity }}
+


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/22894, fix https://github.com/evcc-io/evcc/issues/14797

The Zendure solarflow 2400 AC is an ac-coupled battery introduced in 2025. Two separate values from its API must be added into a single power measurement for evcc, hence the proposed template. The template has been tested and is in use with this battery integrated into a local instance of Evcc. Information on the Zendure's API can be found at https://github.com/Zendure/zenSDK  Notes: 
1) This template should also work for the Zendure Solarflow 800 but this has not been tested.  2) Zendure allows for active battery management but this template is a Power and SoC read-only  integration