### PR TITLE
Add Greenely as a tariff option

### DIFF
--- a/meter/greenely/client.go
+++ b/meter/greenely/client.go
@@ -1,0 +1,179 @@
+package greenely
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	urlLogin          = "https://api2.greenely.com/v1/login"
+	urlFacilitiesBase = "https://api2.greenely.com/v1/facilities/"
+	urlCheckAuth      = "https://api2.greenely.com/v1/checkauth"
+)
+
+type Client struct {
+	// Allow users to set Facility ID to avoid fetching it during login.
+	FacilityID int
+
+	c        *http.Client
+	email    string
+	password string
+	headers  map[string]string
+}
+
+func NewClient(email, password string) *Client {
+	headers := map[string]string{
+		"Accept-Language": "sv-SE",
+		"User-Agent":      "Android 2 111",
+		"Content-Type":    "application/json; charset=utf-8",
+	}
+
+	return &Client{
+		c:        http.DefaultClient,
+		email:    email,
+		password: password,
+		headers:  headers,
+	}
+}
+
+func (c *Client) applyHeaders(req *http.Request) {
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+}
+
+func (c *Client) get(ctx context.Context, url string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	c.applyHeaders(req)
+	resp, err := c.c.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	return body, resp.StatusCode, err
+}
+
+func (c *Client) post(ctx context.Context, url string, payload any) ([]byte, int, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return nil, 0, err
+	}
+	c.applyHeaders(req)
+	resp, err := c.c.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	return body, resp.StatusCode, err
+}
+
+func (c *Client) Login(ctx context.Context) error {
+	payload := map[string]string{"email": c.email, "password": c.password}
+	body, status, err := c.post(ctx, urlLogin, payload)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("login failed: status=%d body=%s", status, string(body))
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		return err
+	}
+	jwtRaw, ok := m["jwt"].(string)
+	if !ok || jwtRaw == "" {
+		return fmt.Errorf("login response missing jwt: %s", string(body))
+	}
+
+	c.headers["Authorization"] = "JWT " + jwtRaw
+
+	if c.FacilityID == 0 {
+		if err := c.getFacilityID(ctx); err != nil {
+			return fmt.Errorf("failed to fetch primary facility id: %w", err)
+		}
+	}
+	return nil
+}
+
+// CheckAuth checks whether the current JWT is valid. If not, it will attempt
+// to re-login and return the final state.
+func (c *Client) CheckAuth(ctx context.Context) error {
+	_, status, err := c.get(ctx, urlCheckAuth)
+	if err != nil {
+		return err
+	}
+	if status == http.StatusOK {
+		return nil
+	}
+
+	return c.Login(ctx)
+}
+
+func (c *Client) getFacilityID(ctx context.Context) error {
+	body, status, err := c.get(ctx, urlFacilitiesBase)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("failed fetching facilities: status=%d body=%s", status, string(body))
+	}
+	var resp struct {
+		Data []struct {
+			ID        int  `json:"id"`
+			IsPrimary bool `json:"is_primary"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return err
+	}
+	if len(resp.Data) == 0 {
+		return fmt.Errorf("no facilities returned")
+	}
+	primaryID := resp.Data[0].ID
+	for _, f := range resp.Data {
+		if f.IsPrimary {
+			primaryID = f.ID
+			break
+		}
+	}
+
+	c.FacilityID = primaryID
+
+	return nil
+}
+
+// GetSpotPrice fetches spot-price data. It only considers the date part of the
+// 'from' and 'to' parameters, ignoring the time.
+func (c *Client) GetSpotPrice(ctx context.Context, from, to time.Time) (SpotPrice, error) {
+	start := fmt.Sprintf("?from=%04d-%02d-%02d", from.Year(), from.Month(), from.Day())
+	end := fmt.Sprintf("&to=%04d-%02d-%02d", to.Year(), to.Month(), to.Day())
+	url := urlFacilitiesBase + fmt.Sprint(c.FacilityID) + "/spot-price" + start + end + "&resolution=hourly"
+	fmt.Println("Getting: " + url)
+	body, status, err := c.get(ctx, url)
+	if err != nil {
+		return SpotPrice{}, err
+	}
+	if status != http.StatusOK {
+		return SpotPrice{}, fmt.Errorf("get spot price failed: status=%d body=%s", status, string(body))
+	}
+	var resp SpotPrice
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return SpotPrice{}, err
+	}
+
+	return resp, nil
+}

--- a/meter/greenely/client.go
+++ b/meter/greenely/client.go
@@ -162,7 +162,6 @@ func (c *Client) GetSpotPrice(ctx context.Context, from, to time.Time) (SpotPric
 	start := fmt.Sprintf("?from=%04d-%02d-%02d", from.Year(), from.Month(), from.Day())
 	end := fmt.Sprintf("&to=%04d-%02d-%02d", to.Year(), to.Month(), to.Day())
 	url := urlFacilitiesBase + fmt.Sprint(c.FacilityID) + "/spot-price" + start + end + "&resolution=hourly"
-	fmt.Println("Getting: " + url)
 	body, status, err := c.get(ctx, url)
 	if err != nil {
 		return SpotPrice{}, err

--- a/meter/greenely/types.go
+++ b/meter/greenely/types.go
@@ -1,0 +1,39 @@
+package greenely
+
+import (
+	"strings"
+	"time"
+)
+
+// localTime is a wrapper around time.Time to handle the "YYYY-MM-DD HH:MM" format from the API.
+type localTime struct {
+	time.Time
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (ct *localTime) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		return nil
+	}
+
+	t, err := time.ParseInLocation("2006-01-02 15:04", s, time.Local)
+	if err != nil {
+		return err
+	}
+	ct.Time = t
+	return nil
+}
+
+type SpotPrice struct {
+	Data map[int]struct {
+		Price          int
+		LocalTime      localTime `json:"localtime"`
+		QuartersPrices struct {
+			Quarter1 int
+			Quarter2 int
+			Quarter3 int
+			Quarter4 int
+		} `json:"quarters_prices"`
+	}
+}

--- a/tariff/greenely.go
+++ b/tariff/greenely.go
@@ -98,37 +98,26 @@ func fromMilliOreToKrona(val int) float64 {
 func (t *Greenely) rates(sp greenely.SpotPrice) api.Rates {
 	data := make(api.Rates, 0, len(sp.Data)*4)
 	for _, hourData := range sp.Data {
-		q1Start := hourData.LocalTime.Time.Local()
-		q1End := q1Start.Add(SlotDuration).Local()
-		data = append(data, api.Rate{
-			Start: q1Start,
-			End:   q1Start.Add(SlotDuration),
-			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter1), q1Start),
-		})
+		start := hourData.LocalTime.Time.Local()
 
-		q2Start := q1End
-		q2End := q2Start.Add(SlotDuration).Local()
-		data = append(data, api.Rate{
-			Start: q2Start,
-			End:   q2End,
-			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter2), q2Start),
-		})
+		prices := []int{
+			hourData.QuartersPrices.Quarter1,
+			hourData.QuartersPrices.Quarter2,
+			hourData.QuartersPrices.Quarter3,
+			hourData.QuartersPrices.Quarter4,
+		}
 
-		q3Start := q2End
-		q3End := q3Start.Add(SlotDuration).Local()
-		data = append(data, api.Rate{
-			Start: q3Start,
-			End:   q3End,
-			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter3), q3Start),
-		})
+		for _, p := range prices {
+			end := start.Add(SlotDuration)
 
-		q4Start := q3End
-		q4End := q4Start.Add(SlotDuration).Local()
-		data = append(data, api.Rate{
-			Start: q4Start,
-			End:   q4End,
-			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter4), q4Start),
-		})
+			data = append(data, api.Rate{
+				Start: start,
+				End:   end,
+				Value: t.totalPrice(fromMilliOreToKrona(p), start),
+			})
+
+			start = end
+		}
 	}
 	return data
 }

--- a/tariff/greenely.go
+++ b/tariff/greenely.go
@@ -76,7 +76,7 @@ func (t *Greenely) run(done chan error) {
 				return err
 			}
 
-			r, err := t.client.GetSpotPrice(ctx, time.Now(), time.Now().Add(24*time.Hour))
+			r, err := t.client.GetSpotPrice(ctx, time.Now(), time.Now().Add(48*time.Hour))
 			resp = r
 			return err
 		}, bo()); err != nil {

--- a/tariff/greenely.go
+++ b/tariff/greenely.go
@@ -1,0 +1,148 @@
+package tariff
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/meter/greenely"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+)
+
+type Greenely struct {
+	*embed
+	log    *util.Logger
+	client *greenely.Client
+	data   *util.Monitor[api.Rates]
+}
+
+var _ api.Tariff = (*Greenely)(nil)
+
+func init() {
+	registry.Add("greenely", NewGreenelyFromConfig)
+}
+
+func NewGreenelyFromConfig(other map[string]any) (api.Tariff, error) {
+	var cc struct {
+		embed      `mapstructure:",squash"`
+		Email      string
+		Password   string
+		FacilityID int
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.Email == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
+	log := util.NewLogger("greenely").Redact(cc.Email, cc.Password)
+
+	t := &Greenely{
+		embed:  &cc.embed,
+		log:    log,
+		client: greenely.NewClient(cc.Email, cc.Password),
+		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+	}
+
+	if cc.FacilityID != 0 {
+		t.client.FacilityID = cc.FacilityID
+	}
+
+	return runOrError(t)
+}
+
+func (t *Greenely) run(done chan error) {
+	var once sync.Once
+
+	for tick := time.Tick(time.Hour); ; <-tick {
+		var resp greenely.SpotPrice
+
+		if err := backoff.Retry(func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+			defer cancel()
+
+			if err := t.client.CheckAuth(ctx); err != nil {
+				return err
+			}
+
+			r, err := t.client.GetSpotPrice(ctx, time.Now(), time.Now().Add(24*time.Hour))
+			resp = r
+			return err
+		}, bo()); err != nil {
+			once.Do(func() { done <- err })
+
+			t.log.ERROR.Println(err)
+			continue
+		}
+
+		mergeRates(t.data, t.rates(resp))
+		once.Do(func() { close(done) })
+	}
+}
+
+func fromMilliOreToKrona(val int) float64 {
+	return float64(val) / 1000 / 100
+}
+
+func (t *Greenely) rates(sp greenely.SpotPrice) api.Rates {
+	data := make(api.Rates, 0, len(sp.Data)*4)
+	for _, hourData := range sp.Data {
+		q1Start := hourData.LocalTime.Time.Local()
+		q1End := q1Start.Add(SlotDuration).Local()
+		data = append(data, api.Rate{
+			Start: q1Start,
+			End:   q1Start.Add(SlotDuration),
+			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter1), q1Start),
+		})
+
+		q2Start := q1End
+		q2End := q2Start.Add(SlotDuration).Local()
+		data = append(data, api.Rate{
+			Start: q2Start,
+			End:   q2End,
+			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter2), q2Start),
+		})
+
+		q3Start := q2End
+		q3End := q3Start.Add(SlotDuration).Local()
+		data = append(data, api.Rate{
+			Start: q3Start,
+			End:   q3End,
+			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter3), q3Start),
+		})
+
+		q4Start := q3End
+		q4End := q4Start.Add(SlotDuration).Local()
+		data = append(data, api.Rate{
+			Start: q4Start,
+			End:   q4End,
+			Value: t.totalPrice(fromMilliOreToKrona(hourData.QuartersPrices.Quarter4), q4Start),
+		})
+	}
+	return data
+}
+
+// Rates implements the api.Tariff interface
+func (t *Greenely) Rates() (api.Rates, error) {
+	var res api.Rates
+	err := t.data.GetFunc(func(val api.Rates) {
+		res = slices.Clone(val)
+	})
+	return res, err
+}
+
+// Type implements the api.Tariff interface
+func (t *Greenely) Type() api.TariffType {
+	return api.TariffTypePriceForecast
+}

--- a/templates/definition/tariff/greenely.yaml
+++ b/templates/definition/tariff/greenely.yaml
@@ -8,7 +8,7 @@ countries: ["SE"]
 params:
   - name: email
     description:
-      generic: Email accociated with your Greenely account
+      generic: Email associated with your Greenely account
     example: user@example.com
     required: true
   - name: password

--- a/templates/definition/tariff/greenely.yaml
+++ b/templates/definition/tariff/greenely.yaml
@@ -1,0 +1,32 @@
+template: greenely
+products:
+  - brand: Greenely
+requirements:
+  evcc: ["skiptest"]
+group: price
+countries: ["SE"]
+params:
+  - name: email
+    description:
+      generic: Email accociated with your Greenely account
+    example: user@example.com
+    required: true
+  - name: password
+    description:
+      generic: Your Greenely account password
+    example: password123
+    required: true
+  - name: facilityid
+    description:
+      generic: Ask Greenely for your facility ID if you need it
+    example: 123456
+    help:
+      de: Nur erforderlich, wenn du mehrere Häuser in deinem Greenely-Konto hast.
+      en: Only required if you have multiple homes in your Greenely account.
+  - preset: tariff-base
+render: |
+  type: greenely
+  email: {{ .email }}
+  password: {{ .password }}
+  facilityid: {{ .facilityid }}
+  {{ include "tariff-base" . }}


### PR DESCRIPTION
Adding support for grabbing tariffs from [Greenely](https://www.greenely.com/), a Swedish electricity producer.
Took most of my inspiration from the existing Tibber integration. 
API implementation was taken from [this Home Assistant integration](https://github.com/linsvensson/sensor.greenely/blob/master/custom_components/greenely/api.py).

I tested this with my own config, and it seems to work well.

Please let me know if there are any improvements to be made or if I missed something, and you are welcome to make any changes you want to the PR.
