### PR TITLE
update chargeStatusMap to support wallbox paused status

### DIFF
--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -145,6 +145,7 @@ var chargeStatusMap = map[string]api.ChargeStatus{
 	"complete":           api.StatusB,
 	"stopped":            api.StatusB,
 	"starting":           api.StatusB,
+	"paused":             api.StatusB,
 
 	// Status A - Disconnected
 	"a":                   api.StatusA,


### PR DESCRIPTION
Trying to use the Home Assistant plugin instead of OCPP for my Wallbox Pulsar Plus (OCPP seems to be very finicky with these).

When I manually pause the charging in the app or via Home Assistant, it gets stuck though since it doesn't recognize `paused` as a valid status:
```
[lp-1  ] ERROR 2025/12/14 13:33:10 charger status: unknown charge status: Paused
```

<img width="558" height="514" alt="image" src="https://github.com/user-attachments/assets/b5dbae2c-b9f0-435c-bd4b-73c26850785b" />

