### PR TITLE
Forecast Chart: dynamic width

### DIFF
--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -225,33 +225,24 @@ export default defineComponent({
 				datasets,
 			};
 		},
-		chartDataMinMax() {
-			let min = new Date();
-			let max = new Date();
+		chartDataMaxDate() {
+			let result: Date | null = null;
 			for (const dataset of this.chartData.datasets) {
 				for (const data of dataset.data) {
-					if (data.x.getTime() < min.getTime()) {
-						min = data.x;
-					}
-					if (data.x.getTime() > max.getTime()) {
-						max = data.x;
-					}
+					if (!result || data.x.getTime() > result.getTime()) result = data.x;
 				}
 			}
-			return { min, max };
+			return result;
 		},
 		chartWidth() {
 			const minWidth = 780;
 			const maxWidth = 1500; // allow diagram to to grow depending on available data
-			const realStart = this.chartDataMinMax.min;
-			const realEnd = this.chartDataMinMax.max;
-			const maxEnd = this.endDate;
-
-			// 0 = no data, 1 = chart has values until end
-			const scale =
-				(realEnd.getTime() - realStart.getTime()) /
-				(maxEnd.getTime() - realStart.getTime());
-
+			const realEndDate = this.chartDataMaxDate;
+			if (!realEndDate) return minWidth;
+			const maxRange = this.endDate.getTime() - this.startDate.getTime();
+			const realRange = realEndDate.getTime() - this.startDate.getTime();
+			if (maxRange <= 0 || realRange <= 0) return minWidth;
+			const scale = realRange / maxRange;
 			return Math.round(Math.min(maxWidth, Math.max(minWidth, scale * maxWidth)));
 		},
 		options() {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/25883
follow-up to https://github.com/evcc-io/evcc/pull/25385

The introduction of 4-day forecast chart condensed the data shown in the chart quite significantly. This PR introduced dynamic width calculation for the chart. On large screens you'll now see around 2 days of data at once and can scroll right of more data exists.

↔ calculate chart with based on available data
🐭 reduce bar height of fixed tariffs since this data is not very interesting and should not visually dominate


3 days of data
<img width="1047" height="723" alt="Bildschirmfoto 2025-12-15 um 10 15 38" src="https://github.com/user-attachments/assets/57463036-faf7-4d88-ac79-aca3cb8727a8" />

4 days of data
<img width="979" height="683" alt="Bildschirmfoto 2025-12-15 um 10 16 00" src="https://github.com/user-attachments/assets/7fd4a86d-8755-4696-b2a5-4638bd9d8040" />

4 days of data, fixed tariff, scrolled right, reduced bar heights
<img width="954" height="655" alt="Bildschirmfoto 2025-12-15 um 10 16 08" src="https://github.com/user-attachments/assets/0e0c9201-2549-4225-b493-5254bf8b6cdb" />

1 day of co2, stretched, use available space
<img width="1008" height="678" alt="Bildschirmfoto 2025-12-15 um 10 19 03" src="https://github.com/user-attachments/assets/57542869-9add-4756-8a6a-ae40ca90f135" />

1 day of solar and price, stretched, use available space
<img width="924" height="663" alt="Bildschirmfoto 2025-12-15 um 10 21 29" src="https://github.com/user-attachments/assets/d16ca590-e17c-4444-851c-b669a7e48d65" />

