### PR TITLE
RCT: fix battery control

### DIFF
--- a/meter/rct.go
+++ b/meter/rct.go
@@ -139,8 +139,8 @@ func NewRCT(ctx context.Context, uri, usage string, batterySocLimits batterySocL
 					return err
 				}
 
-				// see https://github.com/weltenwort/home-assistant-rct-power-integration/issues/264#issuecomment-2124811644
-				if batStatus != 0 {
+				// check for normal operating mode
+				if batStatus != 1032 {
 					return fmt.Errorf("invalid battery operating mode: %d", batStatus)
 				}
 			}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/discussions/12377#discussioncomment-15259059

In the last BMS update, the code for normal operating mode was changed from 0 to 1032.

\cc @andig 