### PR TITLE
Senergy-hybrid: fix template

### DIFF
--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -212,7 +212,7 @@ render: |
               type: writesingle
               encoding: uint16
         - source: const
-          value: 1 # disable
+          value: 1 # enable
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}

--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -91,7 +91,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 0x1021 # Total Energy 
+      address: 0x1021 # Total Energy
       type: holding
       decode: uint32
   maxacpower: {{ .maxacpower }} # W
@@ -120,6 +120,16 @@ render: |
       address: 0x2000 # Battery SOC
       type: holding
       decode: uint16
+  limitsoc:
+    source: convert
+    convert: float2int
+    set:
+      source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 0x211B # Capacity of discharge end (%) 
+        type: writesingle
+        decode: uint16
   capacity: {{ .capacity }} # kWh
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %

--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -15,10 +15,14 @@ params:
     id: 1
   - name: capacity
     advanced: true
+  - name: maxchargepower
+    default: 10000
+  - name: maxdischargepower
+    default: 10000    
   - name: minsoc
-    advanced: true
+    default: 10
   - name: maxsoc
-    advanced: true
+    default: 100
   - name: maxacpower
 render: |
   type: custom
@@ -120,17 +124,108 @@ render: |
       address: 0x2000 # Battery SOC
       type: holding
       decode: uint16
-  limitsoc:
-    source: convert
-    convert: float2int
+  batterymode:
+    source: switch
+    switch:
     set:
-      source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 0x211B # Capacity of discharge end (%) 
-        type: writesingle
-        decode: uint16
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 0 # Self used mode
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x2100 # Hybrid work mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # disable
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x214C # Time-based control Enable
+                type: writesingle
+                encoding: uint16
+      - case: 2 # hold - stop battery discharge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 3 # Back-up mode
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x2100 # Hybrid work mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # disable
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x214C # Time-based control Enable
+                type: writesingle
+                encoding: uint16
+      - case: 3 # charge - force battery charge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 1 # Every day
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x2101 # Once/Everyday
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0x0000 # 00:00
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x2102 # Charge start time 1
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0x173B # 23:59
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x2103 # Charge end time 1
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # Self used mode
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x2100 # Hybrid work mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # disable
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 0x214C # Time-based control Enable
+                type: writesingle
+                encoding: uint16
   capacity: {{ .capacity }} # kWh
+  maxchargepower: {{ .maxchargepower }} # W
+  maxdischargepower: {{ .maxdischargepower }} # W
   minsoc: {{ .minsoc }} # %
   maxsoc: {{ .maxsoc }} # %
   {{- end }}

--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -127,102 +127,99 @@ render: |
   batterymode:
     source: switch
     switch:
-    set:
-      source: switch
-      switch:
-      - case: 1 # normal
+    - case: 1 # normal
+      set:
+        source: sequence
         set:
-          source: sequence
+        - source: const
+          value: 0 # Self used mode
           set:
-          - source: const
-            value: 0 # Self used mode
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x2100 # Hybrid work mode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 0 # disable
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x214C # Time-based control Enable
-                type: writesingle
-                encoding: uint16
-      - case: 2 # hold - stop battery discharge
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x2100 # Hybrid work mode
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0 # disable
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x214C # Time-based control Enable
+              type: writesingle
+              encoding: uint16
+    - case: 2 # hold - stop battery discharge
+      set:
+        source: sequence
         set:
-          source: sequence
+        - source: const
+          value: 3 # Back-up mode
           set:
-          - source: const
-            value: 3 # Back-up mode
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x2100 # Hybrid work mode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 0 # disable
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x214C # Time-based control Enable
-                type: writesingle
-                encoding: uint16
-      - case: 3 # charge - force battery charge
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x2100 # Hybrid work mode
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0 # disable
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x214C # Time-based control Enable
+              type: writesingle
+              encoding: uint16
+    - case: 3 # charge - force battery charge
+      set:
+        source: sequence
         set:
-          source: sequence
+        - source: const
+          value: 1 # Every day
           set:
-          - source: const
-            value: 1 # Every day
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x2101 # Once/Everyday
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 0x0000 # 00:00
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x2102 # Charge start time 1
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 0x173B # 23:59
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x2103 # Charge end time 1
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 0 # Self used mode
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x2100 # Hybrid work mode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 1 # disable
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 0x214C # Time-based control Enable
-                type: writesingle
-                encoding: uint16
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x2101 # Once/Everyday
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0x0000 # 00:00
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x2102 # Charge start time 1
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0x173B # 23:59
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x2103 # Charge end time 1
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0 # Self used mode
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x2100 # Hybrid work mode
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 1 # disable
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0x214C # Time-based control Enable
+              type: writesingle
+              encoding: uint16
   capacity: {{ .capacity }} # kWh
   maxchargepower: {{ .maxchargepower }} # W
   maxdischargepower: {{ .maxdischargepower }} # W

--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -18,7 +18,7 @@ params:
   - name: maxchargepower
     default: 10000
   - name: maxdischargepower
-    default: 10000    
+    default: 10000
   - name: minsoc
     default: 10
   - name: maxsoc

--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -181,7 +181,7 @@ render: |
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
-              address: 0x2101 # Once/Everyday
+              address: 0x2101 # Once/Everyday 1
               type: writesingle
               encoding: uint16
         - source: const

--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -24,12 +24,29 @@ render: |
   type: custom
   {{- if eq .usage "grid" }}
   power:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 0x1066 # Grid Total Power
-      type: holding
-      decode: int32
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 0x1300 # L1 watt of grid
+        type: holding
+        decode: int32
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 0x1302 # L2 watt of grid
+        type: holding
+        decode: int32
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 0x1304 # L3 watt of grid
+        type: holding
+        decode: int32
+      scale: 0.1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -45,21 +62,21 @@ render: |
         address: 0x131D # Grid Phase A Current
         type: holding
         decode: int32
-      scale: 100
+      scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 0x131F # Grid Phase B Current
         type: holding
         decode: int32
-      scale: 100
+      scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 0x1321 # Grid Phase C Current
         type: holding
         decode: int32
-      scale: 100
+      scale: 0.01
   {{- end }}
   {{- if eq .usage "pv" }}
   power:
@@ -69,23 +86,15 @@ render: |
       address: 0x1048 # PV Total Input Power
       type: holding
       decode: uint32
-    scale: 10
+    scale: 0.1
   energy:
-    source: calc
-    add:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 0x1021 # Total Energy 
-        type: holding
-        decode: uint32
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 0x104C # Decimals of total energy 
-        type: holding
-        decode: uint32
-      scale: 0.001
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0x1021 # Total Energy 
+      type: holding
+      decode: uint32
+  maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
Fixes and enhances the Senergy hybrid inverter Modbus template configuration to improve accuracy and add battery control capabilities.

### Changes Made

**Grid Power Measurement:**
- Changed from inexistent single total power register (0x1066) to sum of three-phase power readings (0x1300, 0x1302, 0x1304)

**Scale Factor Corrections:**
- Fixed grid current scale factors from 100 to 0.01 (registers 0x131D, 0x131F, 0x1321)
- Fixed PV power scale factor from 10 to 0.1 (register 0x1048)
- These corrections ensure proper unit conversion for current (A) and power (W) values

**PV Energy Reading:**
- Simplified energy calculation by using single register 0x1021 instead of combining total and the not available decimal register

**Battery Control:**
- Added `batterymode` implementation with three modes:
  - **Normal (1):** Self-use mode with time-based control disabled
  - **Hold (2):** Backup mode to prevent battery discharge
  - **Charge (3):** Force charge mode with 24/7 charging window
- Implemented using Modbus register sequences for proper mode switching

**Configuration Parameters:**
- Added default values for `maxchargepower` (10000W) and `maxdischargepower` (10000W)
- Added default values for `minsoc` (10%) and `maxsoc` (100%)
- Made battery SoC parameters non-advanced for easier configuration
- Added `maxacpower` parameter for PV configuration