### PR TITLE
Issue UI: add system and timezone

### DIFF
--- a/assets/js/components/Issue/template.test.ts
+++ b/assets/js/components/Issue/template.test.ts
@@ -8,6 +8,8 @@ describe("Issue Utils", () => {
     description: "This is a test description",
     steps: "1. Do something\n2. See error",
     version: "v1.0.0",
+    system: "Linux/amd64",
+    timezone: "MST -07:00",
   };
 
   const mockSections: Sections = {
@@ -51,7 +53,11 @@ other: test
 
 ## Version
 
-v1.0.0`);
+v1.0.0
+
+## System
+
+Linux/amd64, MST -07:00`);
       expect(result.additional).toBeUndefined();
     });
 

--- a/assets/js/components/Issue/template.ts
+++ b/assets/js/components/Issue/template.ts
@@ -35,6 +35,8 @@ function generateBody(issue: IssueData, additional: string): string {
     additional,
     "## Version",
     issue.version,
+    "## System",
+    `${issue.system}, ${issue.timezone}`,
   ];
 
   return toString(sections);

--- a/assets/js/components/Issue/types.d.ts
+++ b/assets/js/components/Issue/types.d.ts
@@ -3,6 +3,8 @@ export interface IssueData {
   description: string;
   steps: string;
   version: string;
+  system: string;
+  timezone: string;
 }
 
 export interface SectionData {

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -69,6 +69,8 @@ export interface State {
   authProviders?: AuthProviders;
   evopt?: EvOpt;
   version?: string;
+  system?: string;
+  timezone?: string;
   battery?: BatteryMeter[];
   pv?: Meter[];
   aux?: Meter[];

--- a/assets/js/views/Issue.vue
+++ b/assets/js/views/Issue.vue
@@ -107,18 +107,44 @@
 									required
 								></textarea>
 							</div>
-							<div class="mb-4">
-								<label for="version" class="form-label">
-									{{ $t("issue.version") }}
-								</label>
-								<input
-									id="version"
-									v-model="versionString"
-									type="text"
-									class="form-control"
-									required
-									readonly
-								/>
+							<div class="row mb-4">
+								<div class="col-12 col-md-4 mb-4 mb-md-0">
+									<label for="version" class="form-label">
+										{{ $t("issue.version") }}
+									</label>
+									<input
+										id="version"
+										v-model="versionString"
+										type="text"
+										class="form-control"
+										required
+										readonly
+									/>
+								</div>
+								<div class="col-12 col-md-4 mb-4 mb-md-0">
+									<label for="system" class="form-label">
+										{{ $t("issue.system") }}
+									</label>
+									<input
+										id="system"
+										v-model="systemString"
+										type="text"
+										class="form-control"
+										readonly
+									/>
+								</div>
+								<div class="col-12 col-md-4">
+									<label for="timezone" class="form-label">
+										{{ $t("issue.timezone") }}
+									</label>
+									<input
+										id="timezone"
+										v-model="timezoneString"
+										type="text"
+										class="form-control"
+										readonly
+									/>
+								</div>
 							</div>
 							<div class="text-end">
 								<small class="text-muted">* required</small>
@@ -362,6 +388,12 @@ export default defineComponent({
 		versionString(): string {
 			return `v${store.state.version || ""}`;
 		},
+		systemString(): string {
+			return store.state.system || "";
+		},
+		timezoneString(): string {
+			return store.state.timezone || "";
+		},
 		configPath(): string | undefined {
 			return store.state.config;
 		},
@@ -369,7 +401,12 @@ export default defineComponent({
 			return store.state.database;
 		},
 		issueData(): IssueData {
-			return { ...this.issue, version: this.versionString };
+			return {
+				...this.issue,
+				version: this.versionString,
+				system: this.systemString,
+				timezone: this.timezoneString,
+			};
 		},
 		logAreaOptions() {
 			return this.logAvailableAreas.map((area) => ({ name: area, value: area }));

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -366,6 +366,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 	valueChan <- util.Param{Key: keys.Version, Val: util.FormattedVersion()}
 	valueChan <- util.Param{Key: keys.Config, Val: viper.ConfigFileUsed()}
 	valueChan <- util.Param{Key: keys.Database, Val: db.FilePath}
+	valueChan <- util.Param{Key: keys.System, Val: util.System()}
+	valueChan <- util.Param{Key: keys.Timezone, Val: time.Now().Format("MST -07:00")}
 
 	// run shutdown functions on stop
 	var once sync.Once

--- a/core/keys/global.go
+++ b/core/keys/global.go
@@ -18,6 +18,8 @@ const (
 	Version            = "version"
 	Config             = "config"
 	Database           = "database"
+	System             = "system"
+	Timezone           = "timezone"
 	Fatal              = "fatal"
 	StartupCompleted   = "startupCompleted" // false: starting, true: started
 	SetupRequired      = "setupRequired"    // initial setup is required (lp = 0), fresh installation

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -830,6 +830,8 @@
       "stepTwo": "Schritt 2: Zusätzliche Informationen kopieren",
       "title": "GitHub Problem-Zusammenfassung"
     },
+    "system": "System",
+    "timezone": "Zeitzone",
     "title": "Problem melden",
     "version": "Version"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -830,6 +830,8 @@
       "stepTwo": "Step 2: Copy additional information",
       "title": "GitHub Problem Summary"
     },
+    "system": "System",
+    "timezone": "Timezone",
     "title": "Report a problem",
     "version": "Version"
   },

--- a/util/version.go
+++ b/util/version.go
@@ -1,6 +1,9 @@
 package util
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+)
 
 const DevVersion = "0.0.0"
 
@@ -17,4 +20,9 @@ func FormattedVersion() string {
 		return fmt.Sprintf("%s (%s)", Version, Commit)
 	}
 	return Version
+}
+
+// System returns the operating system and architecture
+func System() string {
+	return runtime.GOOS + "/" + runtime.GOARCH
 }


### PR DESCRIPTION
add operating system and server timezone to issue form and bug report template
improves debugging (see https://github.com/evcc-io/evcc/issues/26063#issuecomment-3669654540)

📢 publish `system` and `timezone` on start

Issue Form
<img width="734" height="801" alt="Bildschirmfoto 2025-12-18 um 14 03 15" src="https://github.com/user-attachments/assets/47c92ce8-e8ba-4808-b7c4-1da596030dc9" />

GitHub Issue/Discussion Template
<img width="626" height="358" alt="Bildschirmfoto 2025-12-18 um 14 06 20" src="https://github.com/user-attachments/assets/f64bd626-aa12-4c71-bf3f-1393bf6ac1c3" />

