### PR TITLE
add build constraint for linux in charger/openwb/native/rfid.go

### DIFF
--- a/charger/openwb/native/rfid.go
+++ b/charger/openwb/native/rfid.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package native
 
 import (


### PR DESCRIPTION
add linux-only build constraint to charger/openwb/native/rfid.go to exclude it on non-Linux platforms (fixes lint error on Windows) typechecking error: ... could not import github.com/holoplot/go-evdev