### PR TITLE
Zaptec: add per-user token caching

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -106,12 +106,12 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 
 	// Create a separate HTTP client for OAuth token requests to avoid circular dependency
 	// (c.Transport will be modified to use oauth2.Transport, which would create a loop)
-	tokenClient := &http.Client{
+	tsCtx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
 		Transport: c.Transport,
-	}
+	})
 
 	// Get shared token source for this user (per-user uniqueness)
-	ts, err := zaptec.GetTokenSource(ctx, tokenClient, user, password)
+	ts, err := zaptec.GetTokenSource(tsCtx, user, password)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -31,6 +31,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/evcc-io/evcc/util/sponsor"
+	"github.com/evcc-io/evcc/util/transport"
 	"golang.org/x/oauth2"
 )
 
@@ -92,6 +93,14 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 		log:      log,
 		priority: priority,
 		passive:  passive,
+	}
+
+	// Add User-Agent header for Zaptec API compliance
+	c.Client.Transport = &transport.Decorator{
+		Decorator: transport.DecorateHeaders(map[string]string{
+			"User-Agent": "evcc/" + util.Version,
+		}),
+		Base: c.Client.Transport,
 	}
 
 	// setup cached values

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -26,7 +26,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/charger/zaptec"
 	"github.com/evcc-io/evcc/util"
@@ -53,18 +52,6 @@ type Zaptec struct {
 
 func init() {
 	registry.AddCtx("zaptec", NewZaptecFromConfig)
-}
-
-// passwordTokenSource implements oauth2.TokenSource for password grant flow
-type passwordTokenSource struct {
-	ctx    context.Context
-	config *oauth2.Config
-	user   string
-	pass   string
-}
-
-func (p passwordTokenSource) Token() (*oauth2.Token, error) {
-	return p.config.PasswordCredentialsToken(p.ctx, p.user, p.pass)
 }
 
 //go:generate go tool decorate -f decorateZaptec -b *Zaptec -r api.Charger -t "api.PhaseSwitcher,Phases1p3p,func(int) error"
@@ -117,42 +104,17 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 		return res, err
 	}, cache)
 
-	provider, err := oidc.NewProvider(ctx, zaptec.ApiURL+"/")
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize OIDC provider: %s", err)
-	}
-
-	oc := &oauth2.Config{
-		Endpoint: provider.Endpoint(),
-		Scopes: []string{
-			oidc.ScopeOpenID,
-		},
-	}
-
 	// Create a separate HTTP client for OAuth token requests to avoid circular dependency
 	// (c.Transport will be modified to use oauth2.Transport, which would create a loop)
 	tokenClient := &http.Client{
 		Transport: c.Transport,
 	}
 
-	oauthCtx := context.WithValue(
-		ctx,
-		oauth2.HTTPClient,
-		tokenClient,
-	)
-
-	token, err := oc.PasswordCredentialsToken(oauthCtx, user, password)
+	// Get shared token source for this user (per-user uniqueness)
+	ts, err := zaptec.GetTokenSource(ctx, tokenClient, user, password)
 	if err != nil {
 		return nil, err
 	}
-
-	// Create custom token source that always uses password grant (no refresh tokens)
-	ts := oauth2.ReuseTokenSource(token, passwordTokenSource{
-		ctx:    oauthCtx,
-		config: oc,
-		user:   user,
-		pass:   password,
-	})
 
 	c.Transport = &oauth2.Transport{
 		Source: ts,

--- a/charger/zaptec/auth.go
+++ b/charger/zaptec/auth.go
@@ -3,7 +3,6 @@ package zaptec
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"sync"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -44,7 +43,7 @@ func getOIDCProvider(ctx context.Context) (*oidc.Provider, error) {
 // GetTokenSource returns a shared oauth2.TokenSource for the given user credentials.
 // Multiple chargers using the same user credentials will share the same TokenSource,
 // ensuring tokens are reused and authentication is deduplicated.
-func GetTokenSource(ctx context.Context, httpClient *http.Client, user, pass string) (oauth2.TokenSource, error) {
+func GetTokenSource(ctx context.Context, user, pass string) (oauth2.TokenSource, error) {
 	tokenSourceMu.Lock()
 	defer tokenSourceMu.Unlock()
 
@@ -66,10 +65,8 @@ func GetTokenSource(ctx context.Context, httpClient *http.Client, user, pass str
 		},
 	}
 
-	oauthCtx := context.WithValue(ctx, oauth2.HTTPClient, httpClient)
-
 	// Get initial token
-	token, err := oc.PasswordCredentialsToken(oauthCtx, user, pass)
+	token, err := oc.PasswordCredentialsToken(ctx, user, pass)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/zaptec/auth.go
+++ b/charger/zaptec/auth.go
@@ -1,0 +1,89 @@
+package zaptec
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+// passwordTokenSource implements oauth2.TokenSource for password grant flow
+type passwordTokenSource struct {
+	config *oauth2.Config
+	user   string
+	pass   string
+}
+
+// Token returns a token or an error.
+// Implements oauth2.TokenSource interface
+func (p *passwordTokenSource) Token() (*oauth2.Token, error) {
+	return p.config.PasswordCredentialsToken(context.Background(), p.user, p.pass)
+}
+
+// tokenSourceCache stores per-user token sources
+var (
+	tokenSourceMu    sync.Mutex
+	tokenSourceCache = make(map[string]oauth2.TokenSource)
+
+	oidcProvider     *oidc.Provider
+	oidcProviderOnce sync.Once
+	oidcProviderErr  error
+)
+
+// getOIDCProvider returns the cached OIDC provider, initializing it once if needed
+func getOIDCProvider(ctx context.Context) (*oidc.Provider, error) {
+	oidcProviderOnce.Do(func() {
+		oidcProvider, oidcProviderErr = oidc.NewProvider(ctx, ApiURL+"/")
+	})
+	return oidcProvider, oidcProviderErr
+}
+
+// GetTokenSource returns a shared oauth2.TokenSource for the given user credentials.
+// Multiple chargers using the same user credentials will share the same TokenSource,
+// ensuring tokens are reused and authentication is deduplicated.
+func GetTokenSource(ctx context.Context, httpClient *http.Client, user, pass string) (oauth2.TokenSource, error) {
+	tokenSourceMu.Lock()
+	defer tokenSourceMu.Unlock()
+
+	// Use username as the cache key (assuming username is unique)
+	if ts, exists := tokenSourceCache[user]; exists {
+		return ts, nil
+	}
+
+	// Get the cached OIDC provider (initialized once)
+	provider, err := getOIDCProvider(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize OIDC provider: %w", err)
+	}
+
+	oc := &oauth2.Config{
+		Endpoint: provider.Endpoint(),
+		Scopes: []string{
+			oidc.ScopeOpenID,
+		},
+	}
+
+	oauthCtx := context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+
+	// Get initial token
+	token, err := oc.PasswordCredentialsToken(oauthCtx, user, pass)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the password token source
+	pts := &passwordTokenSource{
+		config: oc,
+		user:   user,
+		pass:   pass,
+	}
+
+	// Wrap with ReuseTokenSource to cache tokens
+	ts := oauth2.ReuseTokenSource(token, pts)
+	tokenSourceCache[user] = ts
+
+	return ts, nil
+}


### PR DESCRIPTION
Replace https://github.com/evcc-io/evcc/pull/26108

## Summary
- Moves `passwordTokenSource` implementation from the main charger package to the `zaptec` subpackage
- Implements per-user token source caching to ensure multiple chargers with the same credentials share a single `oauth2.TokenSource`
- Consolidates OIDC provider initialization logic into the `GetTokenSource` function

## Benefits
- **Token Reuse**: Multiple chargers configured with the same Zaptec user credentials share a single token source, ensuring tokens are reused across chargers
- **Deduplication**: Authentication requests are automatically deduplicated when multiple chargers use the same account
- **Better Organization**: Authentication logic is now centralized in the `zaptec` package where it belongs
- **Improved Efficiency**: Reduces unnecessary authentication requests when users have multiple chargers on the same account

## Implementation Details
The new `GetTokenSource` function in `charger/zaptec/auth.go`:
1. Maintains a per-user cache of token sources (keyed by username)
2. Returns the cached token source if one exists for the user
3. Otherwise, initializes the OIDC provider, obtains an initial token, and creates a new reusable token source
4. Uses `context.Background()` for credential token requests to avoid context lifecycle issues when the token source is shared

This replaces PR #26108 with a cleaner architecture that addresses the root cause by deduplicating authentication per user account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)