### PR TITLE
fix: solar tariff configured log

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -922,7 +922,7 @@ func configureTariffs(conf *globalconfig.Tariffs) (*tariff.Tariffs, error) {
 	eg.Go(func() error { return configureTariff(api.TariffUsagePlanner, conf.Planner, &tariffs.Planner) })
 	if len(conf.Solar) == 1 {
 		eg.Go(func() error { return configureTariff(api.TariffUsageSolar, conf.Solar[0], &tariffs.Solar) })
-	} else {
+	} else if len(conf.Solar) > 1 {
 		eg.Go(func() error { return configureSolarTariff(conf.Solar, &tariffs.Solar) })
 	}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -920,10 +920,13 @@ func configureTariffs(conf *globalconfig.Tariffs) (*tariff.Tariffs, error) {
 	eg.Go(func() error { return configureTariff(api.TariffUsageFeedIn, conf.FeedIn, &tariffs.FeedIn) })
 	eg.Go(func() error { return configureTariff(api.TariffUsageCo2, conf.Co2, &tariffs.Co2) })
 	eg.Go(func() error { return configureTariff(api.TariffUsagePlanner, conf.Planner, &tariffs.Planner) })
-	if len(conf.Solar) == 1 {
-		eg.Go(func() error { return configureTariff(api.TariffUsageSolar, conf.Solar[0], &tariffs.Solar) })
-	} else if len(conf.Solar) > 1 {
-		eg.Go(func() error { return configureSolarTariff(conf.Solar, &tariffs.Solar) })
+	if len(conf.Solar) > 0 {
+		eg.Go(func() error {
+			if len(conf.Solar) == 1 {
+				return configureTariff(api.TariffUsageSolar, conf.Solar[0], &tariffs.Solar)
+			}
+			return configureSolarTariff(conf.Solar, &tariffs.Solar)
+		})
 	}
 
 	if err := eg.Wait(); err != nil {

--- a/core/site.go
+++ b/core/site.go
@@ -454,7 +454,7 @@ func (site *Site) DumpConfig() {
 	site.log.INFO.Printf("    grid:      %s", trf(api.TariffUsageGrid))
 	site.log.INFO.Printf("    feed-in:   %s", trf(api.TariffUsageFeedIn))
 	site.log.INFO.Printf("    co2:       %s", presence[site.GetTariff(api.TariffUsageCo2) != nil])
-	site.log.INFO.Printf("    solar:     %s", presence[len(tariff.Rates(site.GetTariff(api.TariffUsageSolar))) > 0])
+	site.log.INFO.Printf("    solar:     %s", presence[site.GetTariff(api.TariffUsageSolar) != nil])
 
 	for i, lp := range site.loadpoints {
 		lp.log.INFO.Printf("loadpoint %d:", i+1)

--- a/core/site.go
+++ b/core/site.go
@@ -454,7 +454,7 @@ func (site *Site) DumpConfig() {
 	site.log.INFO.Printf("    grid:      %s", trf(api.TariffUsageGrid))
 	site.log.INFO.Printf("    feed-in:   %s", trf(api.TariffUsageFeedIn))
 	site.log.INFO.Printf("    co2:       %s", presence[site.GetTariff(api.TariffUsageCo2) != nil])
-	site.log.INFO.Printf("    solar:     %s", presence[site.GetTariff(api.TariffUsageSolar) != nil])
+	site.log.INFO.Printf("    solar:     %s", presence[len(tariff.Rates(site.GetTariff(api.TariffUsageSolar))) > 0])
 
 	for i, lp := range site.loadpoints {
 		lp.log.INFO.Printf("loadpoint %d:", i+1)


### PR DESCRIPTION
Only log `solar: ✓` on startup if at least one solar tariff is configured. Currently checkmark is always shown.

Log from before this fix with empty config:

```
[main  ] INFO 2025/12/20 19:44:29 evcc 0.0.0
[main  ] INFO 2025/12/20 19:44:29 config file not found, database-only mode
[main  ] INFO 2025/12/20 19:44:29 using sqlite database: /tmp/foawddwaoa.db?_pragma=busy_timeout(5000)
[main  ] INFO 2025/12/20 19:44:29 OCPP local:    ws://127.0.0.1:8887/<stationId>
[main  ] INFO 2025/12/20 19:44:29 UI local:      http://127.0.0.1:7070
[site  ] INFO 2025/12/20 19:44:29 site config:
[site  ] INFO 2025/12/20 19:44:29   meters:      grid ✗ pv ✗ battery ✗
[site  ] INFO 2025/12/20 19:44:29   tariffs:
[site  ] INFO 2025/12/20 19:44:29     grid:      ✗
[site  ] INFO 2025/12/20 19:44:29     feed-in:   ✗
[site  ] INFO 2025/12/20 19:44:29     co2:       ✗
[site  ] INFO 2025/12/20 19:44:29     solar:     ✓
```