### PR TITLE
Config UI: integration card order

### DIFF
--- a/assets/js/components/Config/DeviceCard.vue
+++ b/assets/js/components/Config/DeviceCard.vue
@@ -111,6 +111,7 @@ export default {
 	background: none;
 	border: 1px solid var(--evcc-gray-50);
 	transition: border-color var(--evcc-transition-fast) linear;
+	order: 1; /* unconfigured tiles at the end of the list */
 }
 .root--unconfigured:hover {
 	border-color: var(--evcc-default-text);


### PR DESCRIPTION
Show configured integrations first. Cleaner appearance and improved focus.

Note: the order inside the groups (configured / unconfigured) remains stable.

\cc @VolkerK62 

<img width="1496" height="640" alt="Bildschirmfoto 2025-12-21 um 11 06 09" src="https://github.com/user-attachments/assets/5322047b-ce50-4731-b8cd-bbb3f4c27e85" />
