### PR TITLE
Provider Auth: use base logger if available

### DIFF
--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -92,7 +92,7 @@ func NewOAuth(ctx context.Context, name, device string, oc *oauth2.Config, opts 
 		return instance, nil
 	}
 
-	log := util.NewLogger("oauth-" + hash)
+	log := util.ContextLoggerWithDefault(ctx, util.NewLogger("oauth-"+hash))
 
 	if client, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); client == nil || !ok {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, request.NewClient(log))

--- a/plugin/helper.go
+++ b/plugin/helper.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -33,16 +32,6 @@ func knownErrors(b []byte) error {
 	default:
 		return nil
 	}
-}
-
-func contextLogger(ctx context.Context, log *util.Logger) *util.Logger {
-	if ctx != nil {
-		if l, ok := ctx.Value(util.CtxLogger).(*util.Logger); ok {
-			log = l
-		}
-	}
-
-	return log
 }
 
 // parseFloat rejects NaN and Inf values

--- a/plugin/http.go
+++ b/plugin/http.go
@@ -61,7 +61,7 @@ func NewHTTPPluginFromConfig(ctx context.Context, other map[string]any) (Plugin,
 		return nil, errors.New("missing uri")
 	}
 
-	log := contextLogger(ctx, util.NewLogger("http"))
+	log := util.ContextLoggerWithDefault(ctx, util.NewLogger("http"))
 	p := NewHTTP(
 		log,
 		strings.ToUpper(cc.Method),

--- a/plugin/modbus.go
+++ b/plugin/modbus.go
@@ -59,7 +59,7 @@ func NewModbusFromConfig(ctx context.Context, other map[string]any) (Plugin, err
 	// set non-default connect delay
 	conn.ConnectDelay(cc.ConnectDelay)
 
-	log := contextLogger(ctx, util.NewLogger("modbus"))
+	log := util.ContextLoggerWithDefault(ctx, util.NewLogger("modbus"))
 	conn.Logger(log.TRACE)
 
 	if err := cc.Register.Error(); err != nil {

--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -42,7 +42,7 @@ func NewMqttPluginFromConfig(ctx context.Context, other map[string]any) (Plugin,
 		return nil, err
 	}
 
-	log := contextLogger(ctx, util.NewLogger("mqtt"))
+	log := util.ContextLoggerWithDefault(ctx, util.NewLogger("mqtt"))
 
 	client, err := mqtt.RegisteredClientOrDefault(log, cc.Config)
 	if err != nil {

--- a/plugin/watchdog.go
+++ b/plugin/watchdog.go
@@ -41,7 +41,7 @@ func NewWatchDogFromConfig(ctx context.Context, other map[string]any) (Plugin, e
 
 	o := &watchdogPlugin{
 		ctx:     ctx,
-		log:     contextLogger(ctx, util.NewLogger("watchdog")),
+		log:     util.ContextLoggerWithDefault(ctx, util.NewLogger("watchdog")),
 		reset:   cc.Reset,
 		initial: cc.Initial,
 		set:     cc.Set,

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evcc-io/evcc/plugin/auth"
 	"github.com/evcc-io/evcc/server/network"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
 
@@ -48,9 +47,6 @@ func NewHomeAssistant(uri string) (oauth2.TokenSource, error) {
 	extUrl := network.Config().ExternalURL()
 	redirectUri := extUrl + network.CallbackPath
 
-	log := util.NewLogger("homeassistant")
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, request.NewClient(log))
-
 	oc := oauth2.Config{
 		ClientID:    extUrl,
 		RedirectURL: redirectUri,
@@ -76,6 +72,9 @@ func NewHomeAssistant(uri string) (oauth2.TokenSource, error) {
 	if name := instanceNameByUri(uri); name != "" {
 		host = name
 	}
+
+	log := util.NewLogger("homeassistant")
+	ctx := util.WithLogger(context.Background(), log)
 
 	return auth.NewOAuth(ctx, "HomeAssistant", host, &oc)
 }

--- a/util/log_context.go
+++ b/util/log_context.go
@@ -9,3 +9,21 @@ var CtxLogger = struct{}{}
 func WithLogger(ctx context.Context, log *Logger) context.Context {
 	return context.WithValue(ctx, CtxLogger, log)
 }
+
+func ContextLogger(ctx context.Context) *Logger {
+	if ctx != nil {
+		if l, ok := ctx.Value(CtxLogger).(*Logger); ok {
+			return l
+		}
+	}
+
+	return nil
+}
+
+func ContextLoggerWithDefault(ctx context.Context, log *Logger) *Logger {
+	if log := ContextLogger(ctx); log != nil {
+		return log
+	}
+
+	return log
+}

--- a/vehicle/bmw/cardata/oauth2.go
+++ b/vehicle/bmw/cardata/oauth2.go
@@ -19,7 +19,8 @@ func init() {
 			return nil, err
 		}
 
-		return NewOAuth(cc.ClientID, "")
+		ctx := util.WithLogger(context.Background(), util.NewLogger("cardata").Redact(cc.ClientID))
+		return NewOAuth(ctx, cc.ClientID, "")
 	})
 }
 
@@ -40,10 +41,10 @@ func OAuthConfig(clientId string) *oauth2.Config {
 	}
 }
 
-func NewOAuth(clientId, title string) (oauth2.TokenSource, error) {
+func NewOAuth(ctx context.Context, clientId, title string) (oauth2.TokenSource, error) {
 	oc := OAuthConfig(clientId)
 
-	return auth.NewOAuth(context.Background(), "BMW/Mini", title, oc,
+	return auth.NewOAuth(ctx, "BMW/Mini", title, oc,
 		auth.WithOauthDeviceFlowOption(),
 		auth.WithTokenRetrieverOption(func(data string, res *oauth2.Token) error {
 			var token Token

--- a/vehicle/cardata.go
+++ b/vehicle/cardata.go
@@ -53,7 +53,8 @@ func NewCardataFromConfig(ctx context.Context, other map[string]any) (api.Vehicl
 
 	log := util.NewLogger("cardata").Redact(cc.ClientID, cc.VIN)
 
-	ts, err := cardata.NewOAuth(cc.ClientID, cc.embed.GetTitle())
+	authCtx := util.WithLogger(context.Background(), log)
+	ts, err := cardata.NewOAuth(authCtx, cc.ClientID, cc.embed.GetTitle())
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/ford-connect-query.go
+++ b/vehicle/ford-connect-query.go
@@ -1,6 +1,7 @@
 package vehicle
 
 import (
+	"context"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -44,13 +45,14 @@ func NewFordConnectQueryFromConfig(other map[string]any) (api.Vehicle, error) {
 		return nil, err
 	}
 
+	log := util.NewLogger("ford").Redact(cc.Credentials.ID, cc.VIN)
+
 	oc := query.OAuth2Config(cc.Credentials.ID, cc.Credentials.Secret, cc.RedirectURI)
-	ts, err := query.NewOAuth(oc, cc.embed.GetTitle())
+	ts, err := query.NewOAuth(util.WithLogger(context.Background(), log), oc, cc.embed.GetTitle())
 	if err != nil {
 		return nil, err
 	}
 
-	log := util.NewLogger("ford").Redact(cc.VIN)
 	api := query.NewAPI(log, ts)
 
 	vehicle, err := ensureVehicleEx(cc.VIN, api.Vehicles, func(v query.Vehicle) (string, error) {

--- a/vehicle/ford/query/oauth2.go
+++ b/vehicle/ford/query/oauth2.go
@@ -21,9 +21,10 @@ func init() {
 			return nil, err
 		}
 
+		log := util.NewLogger("ford").Redact(cc.ClientID)
 		oc := OAuth2Config(cc.ClientID, cc.ClientSecret, cc.RedirectURI)
 
-		return NewOAuth(oc, "")
+		return NewOAuth(util.WithLogger(context.Background(), log), oc, "")
 	})
 }
 
@@ -45,6 +46,6 @@ func OAuth2Config(id, secret, redirectUri string) *oauth2.Config {
 }
 
 // NewOAuth creates FordConnect token source
-func NewOAuth(oc *oauth2.Config, title string) (oauth2.TokenSource, error) {
-	return auth.NewOAuth(context.Background(), "Ford Connect", title, oc)
+func NewOAuth(ctx context.Context, oc *oauth2.Config, title string) (oauth2.TokenSource, error) {
+	return auth.NewOAuth(ctx, "Ford Connect", title, oc)
 }

--- a/vehicle/volvo-connected.go
+++ b/vehicle/volvo-connected.go
@@ -52,7 +52,7 @@ func NewVolvoConnectedFromConfig(ctx context.Context, other map[string]any) (api
 	log := util.NewLogger("volvo-connected").Redact(cc.VIN, cc.Credentials.ID, cc.Credentials.Secret, cc.VccApiKey)
 
 	oc := connected.OAuthConfig(cc.Credentials.ID, cc.Credentials.Secret, cc.RedirectUri)
-	ts, err := connected.NewOAuth(oc, cc.embed.GetTitle())
+	ts, err := connected.NewOAuth(util.WithLogger(context.Background(), log), oc, cc.embed.GetTitle())
 	if err != nil {
 		return nil, err
 	}

--- a/vehicle/volvo/connected/oauth2.go
+++ b/vehicle/volvo/connected/oauth2.go
@@ -21,9 +21,10 @@ func init() {
 			return nil, err
 		}
 
+		log := util.NewLogger("volvo").Redact(cc.ClientID)
 		oc := OAuthConfig(cc.ClientID, cc.ClientSecret, cc.RedirectUri)
 
-		return NewOAuth(oc, "")
+		return NewOAuth(util.WithLogger(context.Background(), log), oc, "")
 	})
 }
 
@@ -46,6 +47,6 @@ func OAuthConfig(id, secret, redirectUri string) *oauth2.Config {
 	}
 }
 
-func NewOAuth(oc *oauth2.Config, title string) (oauth2.TokenSource, error) {
-	return auth.NewOAuth(context.Background(), "Volvo", title, oc)
+func NewOAuth(ctx context.Context, oc *oauth2.Config, title string) (oauth2.TokenSource, error) {
+	return auth.NewOAuth(ctx, "Volvo", title, oc)
 }


### PR DESCRIPTION
This PR logs provider auth token exchange under the base logger instead of `oauth-<hash>` which should make logfiles easier to read and discover dependencies. Noticed during https://github.com/evcc-io/evcc/issues/26119.