### PR TITLE
Carlo EM340: add PV Option

### DIFF
--- a/templates/definition/meter/cg-emt3xx.yaml
+++ b/templates/definition/meter/cg-emt3xx.yaml
@@ -20,7 +20,7 @@ products:
       generic: Energy Meter C (KEM-C)
 params:
   - name: usage
-    choice: ["grid", "charge"]
+    choice: ["grid", "pv", "charge"]
   - name: modbus
     choice: ["rs485", "tcpip"]
 render: |


### PR DESCRIPTION
I’ve added the option as discussed here (https://github.com/evcc-io/evcc/discussions/26098). This is required so that a non‑smart inverter located behind a Carlo EM340 meter can report its current production values.