### PR TITLE
Templates: constrain validating required parameters by usage

### DIFF
--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -368,7 +368,6 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 				// validate required fields from yaml
 				if s == "" && p.IsRequired() && (renderMode == RenderModeUnitTest ||
 					renderMode == RenderModeInstance && !testing.Testing()) {
-
 					// validate required per usage
 					if len(p.Usages) == 0 || slices.Contains(p.Usages, usage) {
 						return nil, nil, fmt.Errorf("missing required `%s`", p.Name)

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/spf13/cast"
 )
 
 // Template describes is a proxy device for use with cli and automated testing
@@ -302,6 +303,14 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 
 	res := make(map[string]any)
 
+	var usage string
+	for k, v := range values {
+		if strings.ToLower(k) == "usage" {
+			usage = strings.ToLower(cast.ToString(v))
+			break
+		}
+	}
+
 	// TODO this is an utterly horrible hack
 	//
 	// When decoding the actual values ("other" parameter) into the
@@ -359,7 +368,11 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 				// validate required fields from yaml
 				if s == "" && p.IsRequired() && (renderMode == RenderModeUnitTest ||
 					renderMode == RenderModeInstance && !testing.Testing()) {
-					return nil, nil, fmt.Errorf("missing required `%s`", p.Name)
+
+					// validate required per usage
+					if len(p.Usages) == 0 || slices.Contains(p.Usages, usage) {
+						return nil, nil, fmt.Errorf("missing required `%s`", p.Name)
+					}
 				}
 
 				res[out] = s

--- a/util/templates/template_test.go
+++ b/util/templates/template_test.go
@@ -84,6 +84,12 @@ func TestRequiredPerUsage(t *testing.T) {
 
 	_, _, err := tmpl.RenderResult(RenderModeUnitTest, map[string]any{
 		"Param": nil,
+		"Usage": nil,
+	})
+	require.NoError(t, err)
+
+	_, _, err = tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"Param": nil,
 		"Usage": "pv",
 	})
 	require.NoError(t, err)

--- a/util/templates/template_test.go
+++ b/util/templates/template_test.go
@@ -65,3 +65,35 @@ func TestRequired(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestRequiredPerUsage(t *testing.T) {
+	tmpl := &Template{
+		TemplateDefinition: TemplateDefinition{
+			Params: []Param{
+				{
+					Name:     "param",
+					Required: true,
+					Usages:   []string{"battery"},
+				},
+			},
+		},
+	}
+
+	_, _, err := tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"Param": nil,
+		"Usage": "pv",
+	})
+	require.NoError(t, err)
+
+	_, _, err = tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"Param": nil,
+		"Usage": "battery",
+	})
+	require.Error(t, err)
+
+	_, _, err = tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"Param": "foo",
+		"Usage": "battery",
+	})
+	require.NoError(t, err)
+}

--- a/util/templates/template_test.go
+++ b/util/templates/template_test.go
@@ -71,6 +71,9 @@ func TestRequiredPerUsage(t *testing.T) {
 		TemplateDefinition: TemplateDefinition{
 			Params: []Param{
 				{
+					Name: "usage",
+				},
+				{
 					Name:     "param",
 					Required: true,
 					Usages:   []string{"battery"},


### PR DESCRIPTION
Follow-up to https://github.com/evcc-io/evcc/pull/25932. Refs https://github.com/evcc-io/evcc/pull/26149.

/cc @iseeberg79 discussed re OpenEMS. Test shows this is broken atm.