### PR TITLE
KOSTAL Plenticore (Gen 2): Enables charging while being on hold

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -115,7 +115,7 @@ render: |
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
-              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+              address: 1040 # Battery max. discharge power limit, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
       - case: 3 # charge


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/26168

With this change, the battery being in hold mode will be able to charge (if excess power is available), but not discharge.