### PR TITLE
mbmd: allow value negation

### DIFF
--- a/MBMD_INVERSION_FEATURE.md
+++ b/MBMD_INVERSION_FEATURE.md
@@ -1,0 +1,106 @@
+# MBMD Meters: Value Negation Feature
+
+## Overview
+
+This feature adds support for inverting measurement values in mbmd meters by prefixing alias names with a `-` (minus sign). This is particularly useful when meters are used in different configurations or mounting orientations and the sign of measurement values needs to be adjusted.
+
+## Usage
+
+In `mbmd` type templates, you can now prefix alias names with `-`. The meter will automatically invert the sign of the respective measurement value.
+
+### Syntax
+
+```yaml
+type: mbmd
+model: <model-name>
+power: -Power      # inverts the power value
+```
+
+**Note**: Negation is **only** available for `power` and phase arrays (`currents`, `powers`). Negation is not possible for `energy`, `soc`, and `voltages` as these values should always be positive.
+
+### Examples
+
+#### Example 1: Inverted Total Power, Exported Energy
+
+```yaml
+type: mbmd
+model: cgex3x0
+power: -Power      # Power will be inverted (e.g. +1000W becomes -1000W)
+energy: Export     # Energy CANNOT be inverted
+```
+
+#### Example 2: Inverted Phase Powers
+
+```yaml
+type: mbmd
+model: cgex3x0
+power: Power
+powers:
+  - -PowerL1      # Phase 1 inverted
+  - -PowerL2      # Phase 2 inverted
+  - -PowerL3      # Phase 3 inverted
+```
+
+#### Example 3: Inverted Currents (very theoretical)
+
+```yaml
+type: mbmd
+model: cgex3x0
+power: Power
+currents:
+  - -CurrentL1    # Current Phase 1 inverted
+  - CurrentL2     # Current Phase 2 normal
+  - -CurrentL3    # Current Phase 3 inverted
+```
+
+## Technical Details
+
+### Supported Measurements
+
+Negation works for the following mbmd measurements:
+
+- `power` - Total power ✓
+- `currents` - Currents per phase (array) ✓
+- `powers` - Powers per phase (array) ✓
+
+**Not supported** (and not sensible):
+- `energy` - Energy (Import/Export) ✗ - Energy counter values are always positive
+- `soc` - State of Charge (for batteries) ✗ - SOC values are always positive (0-100%)
+- `voltages` - Voltages per phase (array) ✗ - Voltage values are always positive (e.g. 230V)
+
+### Behavior
+
+- **Normal operation**: `power: Power` → Value is returned unchanged
+- **Inverted**: `power: -Power` → Value is multiplied by -1
+- **NaN error handling**: Remains intact (NaN becomes 0, then optionally inverted)
+
+## Use Cases
+
+### 1. Incorrectly Mounted Meters
+
+If a current sensor/meter is physically installed in the "wrong" direction, you can correct the values in software:
+
+```yaml
+power: -Power
+```
+
+### 2. Grid Feed-in vs. Consumption
+
+For PV meters where the sign convention needs to be reversed:
+
+```yaml
+type: mbmd
+usage: grid
+power: -Power
+```
+
+### 3. Different CT Orientations
+
+For multi-phase installations with differently oriented current transformers:
+
+```yaml
+currents:
+  - CurrentL1      # CT normally oriented
+  - -CurrentL2     # CT reversed
+  - CurrentL3      # CT normally oriented
+```

--- a/meter/mbmd.go
+++ b/meter/mbmd.go
@@ -22,7 +22,7 @@ type ModbusMbmd struct {
 	opPower     rs485.Operation
 	opEnergy    rs485.Operation
 	opSoc       rs485.Operation
-	invertPower bool
+	invertValue bool
 }
 
 func init() {
@@ -96,7 +96,7 @@ func NewModbusMbmdFromConfig(ctx context.Context, other map[string]any) (api.Met
 		return nil, fmt.Errorf("invalid measurement for power: %s", cc.Power)
 	}
 	m.opPower = opWithInv.op
-	m.invertPower = opWithInv.invert
+	m.invertValue = opWithInv.invert
 
 	// decorate energy
 	var totalEnergy func() (float64, error)
@@ -207,7 +207,7 @@ func (m *ModbusMbmd) floatGetterWithInversion(op rs485.Operation, invert bool) (
 
 // CurrentPower implements the api.Meter interface
 func (m *ModbusMbmd) CurrentPower() (float64, error) {
-	return m.floatGetterWithInversion(m.opPower, m.invertPower)
+	return m.floatGetterWithInversion(m.opPower, m.invertValue)
 }
 
 // totalEnergy implements the api.MeterEnergy interface

--- a/meter/mbmd.go
+++ b/meter/mbmd.go
@@ -105,8 +105,11 @@ func NewModbusMbmdFromConfig(ctx context.Context, other map[string]any) (api.Met
 		if err != nil {
 			return nil, fmt.Errorf("invalid measurement for energy: %s", cc.Energy)
 		}
+		if opWithInv.invert {
+			// Energy inversion is not supported - energy values should always be positive
+			return nil, fmt.Errorf("energy inversion not supported for measurement: %s", cc.Energy)
+		}
 		m.opEnergy = opWithInv.op
-		// Energy inversion is not supported - energy values should always be positive
 
 		totalEnergy = m.totalEnergy
 	}
@@ -136,9 +139,12 @@ func NewModbusMbmdFromConfig(ctx context.Context, other map[string]any) (api.Met
 		if err != nil {
 			return nil, fmt.Errorf("invalid measurement for soc: %s", cc.Soc)
 		}
-		m.opSoc = opWithInv.op
 		// SOC inversion is not supported - SOC values should always be positive
+		if opWithInv.invert {
+			return nil, fmt.Errorf("soc inversion not supported: %s", cc.Soc)
+		}
 
+		m.opSoc = opWithInv.op
 		soc = m.soc
 	}
 

--- a/meter/mbmd_operation.go
+++ b/meter/mbmd_operation.go
@@ -24,7 +24,7 @@ type operationWithInversion struct {
 	invert bool
 }
 
-// rs485FindDeviceOp checks is RS485 device supports operation.
+// rs485FindDeviceOp checks if RS485 device supports operation.
 // If the name starts with '-', the value will be inverted.
 func rs485FindDeviceOp(ops []rs485.Operation, name string) (operationWithInversion, error) {
 	// Check for inversion prefix

--- a/templates/definition/meter/cg-emt3xx-inverted-example.yaml
+++ b/templates/definition/meter/cg-emt3xx-inverted-example.yaml
@@ -1,0 +1,46 @@
+# Beispiel Template für einen CG EMT3xx Zähler mit invertierten Werten
+# Dies demonstriert die neue Inversions-Funktionalität für mbmd-Zähler
+
+template: cg-emt3xx-inverted-example
+products:
+  - brand: Carlo Gavazzi
+    description:
+      generic: ET330/ET340 (mit invertierter Leistung)
+params:
+  - name: usage
+    choice: ["grid", "charge"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+
+render: |
+  type: mbmd
+  {{- include "modbus" . }}
+  model: cgex3x0
+  
+  # Beispiel 1: Normale Power-Messung
+  power: Power
+  
+  # Beispiel 2: Invertierte Power-Messung (mit "-" Präfix)
+  # power: -Power
+  
+  energy: Import
+  
+  currents:
+    - CurrentL1
+    - CurrentL2
+    - CurrentL3
+  
+  {{- if eq .usage "grid" }}
+  powers:
+    # Beispiel für invertierte Phasenleistungen
+    - -PowerL1
+    - -PowerL2
+    - -PowerL3
+  {{- end }}
+  
+  {{- if eq .usage "charge" }}
+  voltages:
+    - VoltageL1
+    - VoltageL2
+    - VoltageL3
+  {{- end }}


### PR DESCRIPTION
This feature adds support for inverting measurement values in mbmd meters by prefixing alias names with a `-` (minus sign). This is particularly useful when meters are used in different configurations or mounting orientations and the sign of measurement values needs to be adjusted.

## Usage

In `mbmd` type templates, you can now prefix alias names with `-`. The meter will automatically invert the sign of the respective measurement value.

### Syntax

```yaml
type: mbmd
model: <model-name>
power: -Power      # inverts the power value
```

**Note**: Negation is **only** available for `power` and phase arrays (`currents`, `powers`). Negation is not possible for `energy`, `soc`, and `voltages` as these values should always be positive.

### Examples

#### Example 1: Inverted Total Power, Exported Energy

```yaml
type: mbmd
model: cgex3x0
power: -Power      # Power will be inverted (e.g. +1000W becomes -1000W)
energy: Export     # Energy CANNOT be inverted
```

#### Example 2: Inverted Phase Powers

```yaml
type: mbmd
model: cgex3x0
power: Power
powers:
  - -PowerL1      # Phase 1 inverted
  - -PowerL2      # Phase 2 inverted
  - -PowerL3      # Phase 3 inverted
```

#### Example 3: Inverted Currents (very theoretical)

```yaml
type: mbmd
model: cgex3x0
power: Power
currents:
  - -CurrentL1    # Current Phase 1 inverted
  - CurrentL2     # Current Phase 2 normal
  - -CurrentL3    # Current Phase 3 inverted
```

## Technical Details

### Supported Measurements

Negation works for the following mbmd measurements:

- `power` - Total power ✓
- `currents` - Currents per phase (array) ✓
- `powers` - Powers per phase (array) ✓

**Not supported** (and not sensible):
- `energy` - Energy (Import/Export) ✗ - Energy counter values are always positive
- `soc` - State of Charge (for batteries) ✗ - SOC values are always positive (0-100%)
- `voltages` - Voltages per phase (array) ✗ - Voltage values are always positive (e.g. 230V)

### Behavior

- **Normal operation**: `power: Power` → Value is returned unchanged
- **Inverted**: `power: -Power` → Value is multiplied by -1
- **NaN error handling**: Remains intact (NaN becomes 0, then optionally inverted)

## Use Cases

### 1. Incorrectly Mounted Meters

If a current sensor/meter is physically installed in the wrong direction, you can correct the values in software:

```yaml
power: -Power
```

### 2. Grid Feed-in vs. Consumption

For PV meters where the sign convention needs to be reversed:

```yaml
type: mbmd
usage: pv
power: -Power
energy: Export
```

### 3. Different CT Orientations

For multi-phase installations with differently oriented current transformers:

```yaml
currents:
  - CurrentL1      # CT normally oriented
  - -CurrentL2     # CT reversed
  - CurrentL3      # CT normally oriented
```