### PR TITLE
Planner: continue a 100% plan as long as the vehicle is connected

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -137,8 +137,8 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	maxPower := lp.EffectiveMaxPower()
 	requiredDuration := lp.GetPlanRequiredDuration(goal, maxPower)
 	if requiredDuration <= 0 {
-		// continue a 100% plan as long as the vehicle is charging
-		if lp.planActive && isSocBased && goal == 100 && lp.charging() {
+		// continue a 100% plan as long as the vehicle is connected
+		if lp.planActive && isSocBased && goal == 100 {
 			return true
 		}
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/26200