### PR TITLE
UI: add IDs for mobile testing

### DIFF
--- a/assets/js/components/Config/BackupRestoreModal.vue
+++ b/assets/js/components/Config/BackupRestoreModal.vue
@@ -144,6 +144,7 @@
 					</button>
 
 					<button
+						id="backuprestoreDownloadButton"
 						type="submit"
 						class="btn text-truncate"
 						:class="confirmType === 'backup' ? 'btn-primary' : 'btn-danger'"

--- a/assets/js/components/Top/Navigation.vue
+++ b/assets/js/components/Top/Navigation.vue
@@ -23,7 +23,12 @@
 			data-testid="topnavigation-dropdown"
 		>
 			<li>
-				<router-link class="dropdown-item" to="/sessions" active-class="active">
+				<router-link
+					id="topNavigationSessions"
+					class="dropdown-item"
+					to="/sessions"
+					active-class="active"
+				>
 					{{ $t("header.sessions") }}
 				</router-link>
 			</li>
@@ -59,7 +64,12 @@
 				</button>
 			</li>
 			<li>
-				<router-link class="dropdown-item" to="/config" active-class="active">
+				<router-link
+					id="topNavigationConfig"
+					class="dropdown-item"
+					to="/config"
+					active-class="active"
+				>
 					<span
 						v-if="showConfigBadge"
 						class="d-inline-block p-1 rounded-circle bg-warning rounded-circle"
@@ -114,7 +124,12 @@
 				</a>
 			</li>
 			<li v-if="isApp">
-				<button type="button" class="dropdown-item" @click="openNativeSettings">
+				<button
+					id="topNavigationAppOpenNativeSettings"
+					type="button"
+					class="dropdown-item"
+					@click="openNativeSettings"
+				>
 					{{ $t("header.nativeSettings") }}
 				</button>
 			</li>

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -318,6 +318,7 @@
 						{{ $t("help.issueButton") }}
 					</router-link>
 					<button
+						id="backupRestoreButton"
 						class="btn btn-outline-secondary text-truncate"
 						@click="openModal('backupRestoreModal')"
 					>

--- a/assets/js/views/Sessions.vue
+++ b/assets/js/views/Sessions.vue
@@ -153,7 +153,13 @@
 					@show-session="showDetails"
 				/>
 				<div class="d-flex gap-2 mt-1 mb-5">
-					<a class="btn btn-outline-secondary" tabindex="0" :href="csvLink" download>
+					<a
+						id="sessionsDownload"
+						class="btn btn-outline-secondary"
+						tabindex="0"
+						:href="csvLink"
+						download
+					>
 						{{ csvLinkLabel }}
 					</a>
 					<button

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "playwright": "playwright test --ui",
     "simulator": "vite tests/simulator",
     "storybook": "storybook dev -p 6006",
-    "license": "license-compliance --production --report detailed --allow \"MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause\""
+    "license": "license-compliance --production --report detailed --allow \"MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;Python-2.0\""
   },
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "playwright": "playwright test --ui",
     "simulator": "vite tests/simulator",
     "storybook": "storybook dev -p 6006",
-    "license": "license-compliance --production --report detailed --allow \"MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause;Python-2.0\""
+    "license": "license-compliance --production --report detailed --allow \"MIT;Apache-2.0;ISC;BSD-2-Clause;BSD-3-Clause\""
   },
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Needed for https://github.com/evcc-io/app/pull/95

I have to use `by.web.id(id)` to find elements in the webview.
Detox can't find `data-testid`, it can only search for `id`.
See [Detox documentation](https://wix.github.io/Detox/docs/api/webviews#bywebidid)

I'd like to test downloading files.

Tested locally.
\cc @naltatis 