### PR TITLE
cardata: fix charge status

### DIFF
--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,15 +190,15 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	hv, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
-	if err != nil || hv == "" || hv == "INVALID" {
-		hv, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
+	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
+	if err != nil || cs == "" {
+		cs, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
 	}
 
 	if slices.Contains([]string{
-		"CHARGING",       // vehicle.drivetrain.electricEngine.charging.hvStatus
 		"CHARGINGACTIVE", // vehicle.drivetrain.electricEngine.charging.status
-	}, hv) {
+		"CHARGING",       // vehicle.drivetrain.electricEngine.charging.hvStatus
+	}, cs) {
 		return api.StatusC, nil
 	}
 

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,9 +190,9 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	hv, err := v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
+	hv, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
 	if err != nil || hv == "" || hv == "INVALID" {
-		hv, err = v.String("vehicle.drivetrain.electricEngine.charging.status")
+		hv, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
 	}
 
 	if slices.Contains([]string{

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,8 +190,8 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	// evaluate charging.status first since it is usually available through mqtt 
-	// while charging.hvStatus might only be available through rest 
+	// evaluate charging.status first, since it is usually available through 
+	// mqtt, while charging.hvStatus might only be available through rest 
 	// (https://github.com/evcc-io/evcc/pull/26235)
 	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status") 
 	if err != nil || cs == "" {

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -189,7 +189,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	if port == "CONNECTED" {
 		status = api.StatusB
 	}
-	
+
 	// evaluate status first, since it's usually available through 
 	// mqtt, while hvStatus might only be available through rest 
 	// (https://github.com/evcc-io/evcc/pull/26235)

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,8 +190,8 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	// evaluate status first, since it's usually available through 
-	// mqtt, while hvStatus might only be available through rest 
+	// evaluate status first, since it's usually available through
+	// mqtt, while hvStatus might only be available through rest
 	// (https://github.com/evcc-io/evcc/pull/26235)
 	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status") 
 	if err != nil || cs == "" {

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -191,7 +191,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	}
 
 	// evaluate charging.status first since it is usually available through mqtt 
-	// while charging.hvStatus might only be available through rest
+	// while charging.hvStatus might only be available through rest 
 	// (https://github.com/evcc-io/evcc/pull/26235)
 	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status") 
 	if err != nil || cs == "" {

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -189,7 +189,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	if port == "CONNECTED" {
 		status = api.StatusB
 	}
-
+	
 	// evaluate status first, since it's usually available through 
 	// mqtt, while hvStatus might only be available through rest 
 	// (https://github.com/evcc-io/evcc/pull/26235)

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,7 +190,10 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
+	// evaluate charging.status first since it is usually available through mqtt 
+	// while charging.hvStatus might only be available through rest
+	// (https://github.com/evcc-io/evcc/pull/26235)
+	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status") 
 	if err != nil || cs == "" {
 		cs, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
 	}

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -193,7 +193,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	// evaluate status first, since it's usually available through
 	// mqtt, while hvStatus might only be available through rest
 	// (https://github.com/evcc-io/evcc/pull/26235)
-	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status") 
+	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
 	if err != nil || cs == "" {
 		cs, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
 	}

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,8 +190,8 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	// evaluate charging.status first, since it is usually available through 
-	// mqtt, while charging.hvStatus might only be available through rest 
+	// evaluate status first, since it's usually available through 
+	// mqtt, while hvStatus might only be available through rest 
 	// (https://github.com/evcc-io/evcc/pull/26235)
 	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status") 
 	if err != nil || cs == "" {


### PR DESCRIPTION
hvStatus seems to be only provided through the telematics rest API, not mqtt, and thus, is sometimes outdated. To make sure to prefer the most up to date values, prefer status. Should fix https://github.com/evcc-io/evcc/discussions/25103.

- changed evaluation order of status and hvStatus to prefer status
- renamed hv to cs for charging status
- remove INVALID which is not among the values listed in the BMW streaming portal
- change order of comparison strings