### PR TITLE
fix: vehicle plan publish fails on boot

### DIFF
--- a/core/site_vehicles.go
+++ b/core/site_vehicles.go
@@ -72,8 +72,10 @@ func (site *Site) publishVehicles() {
 			PlanContinuous:   strategy.Continuous,
 		}
 
-		if lp := site.coordinator.Owner(instance); lp != nil {
-			go lp.PublishEffectiveValues()
+		if site.coordinator != nil {
+			if lp := site.coordinator.Owner(instance); lp != nil {
+				go lp.PublishEffectiveValues()
+			}
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/26272
follow-up to https://github.com/evcc-io/evcc/pull/24423

Seems to be an issue when booting with db-configured vehicles. We changed publish behavior in https://github.com/evcc-io/evcc/pull/24423.

@andig I'm currently unable to create a reproducible failing test. Maybe race-condition. But we could merge this anyways.