### PR TITLE
Templates: don't validate deprecated parameters

### DIFF
--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -366,7 +366,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 				}
 
 				// validate required fields from yaml
-				if s == "" && p.IsRequired() && (renderMode == RenderModeUnitTest ||
+				if s == "" && p.IsRequired() && !p.IsDeprecated() && (renderMode == RenderModeUnitTest ||
 					renderMode == RenderModeInstance && !testing.Testing()) {
 					// validate required per usage
 					if len(p.Usages) == 0 || slices.Contains(p.Usages, usage) {

--- a/util/templates/template_test.go
+++ b/util/templates/template_test.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,22 +49,56 @@ func TestRequired(t *testing.T) {
 	_, _, err := tmpl.RenderResult(RenderModeUnitTest, map[string]any{
 		"Param": "foo",
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err, "test: required present")
 
 	_, _, err = tmpl.RenderResult(RenderModeUnitTest, map[string]any{
 		"Param": "",
 	})
-	require.Error(t, err)
+	assert.Error(t, err, "test: required present but empty")
 
 	_, _, err = tmpl.RenderResult(RenderModeUnitTest, map[string]any{
 		"Param": nil,
 	})
-	require.Error(t, err)
+	assert.Error(t, err, "test: required present but nil")
 
 	_, _, err = tmpl.RenderResult(RenderModeDocs, map[string]any{
 		"Param": nil,
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err, "docs: required present but nil")
+}
+
+func TestRequiredDeprecated(t *testing.T) {
+	tmpl := &Template{
+		TemplateDefinition: TemplateDefinition{
+			Params: []Param{
+				{
+					Name:       "param",
+					Required:   true,
+					Deprecated: true,
+				},
+			},
+		},
+	}
+
+	_, _, err := tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"Param": "foo",
+	})
+	assert.NoError(t, err, "test: required present")
+
+	_, _, err = tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"Param": "",
+	})
+	assert.NoError(t, err, "test: required present but empty")
+
+	_, _, err = tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"Param": nil,
+	})
+	assert.NoError(t, err, "test: required present but nil")
+
+	_, _, err = tmpl.RenderResult(RenderModeDocs, map[string]any{
+		"Param": nil,
+	})
+	assert.NoError(t, err, "docs: required present but nil")
 }
 
 func TestRequiredPerUsage(t *testing.T) {


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/26285. Corrects https://github.com/evcc-io/evcc/pull/25932.