### PR TITLE
RCT: fix battery control

### DIFF
--- a/meter/rct.go
+++ b/meter/rct.go
@@ -140,7 +140,7 @@ func NewRCT(ctx context.Context, uri, usage string, batterySocLimits batterySocL
 				}
 
 				// check for normal operating mode
-				if batStatus != 1032 {
+				if batStatus != 0 || batStatus != 1032 {
 					return fmt.Errorf("invalid battery operating mode: %d", batStatus)
 				}
 			}

--- a/meter/rct.go
+++ b/meter/rct.go
@@ -140,7 +140,7 @@ func NewRCT(ctx context.Context, uri, usage string, batterySocLimits batterySocL
 				}
 
 				// check for normal operating mode
-				if batStatus != 0 || batStatus != 1032 {
+				if batStatus != 0 && batStatus != 1032 {
 					return fmt.Errorf("invalid battery operating mode: %d", batStatus)
 				}
 			}

--- a/templates/definition/meter/rct-power.yaml
+++ b/templates/definition/meter/rct-power.yaml
@@ -6,9 +6,6 @@ products:
 capabilities: ["battery-control"]
 requirements:
   evcc: ["skiptest"]
-  description:
-    de: Es wird mindestens die BMS-Version 5615 benötigt.
-    en: At least BMS version 5615 is needed.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]


### PR DESCRIPTION
Ref https://github.com/evcc-io/evcc/discussions/25243#discussioncomment-15385856
Ref https://github.com/evcc-io/evcc/discussions/12377#discussioncomment-15352225

Several user reported that their battery returns status code `0` instead of `1032` even though they used the latest BMS software.
So I decided to include `0` too.

I don't know why some systems report a different status, but I generally blame it on the RCT software.
However, it may be due to the fact that some setups have two battery towers.

\cc @andig 