### PR TITLE
fix: disable moby in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"image": "mcr.microsoft.com/devcontainers/go",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
-			"moby": true,
+			"moby": false,
 			"installDockerBuildx": true,
 			"installDockerComposeSwitch": true,
 			"version": "latest",


### PR DESCRIPTION
Devcontainer baut nicht auf Debian Trixie mit `moby: true`