### PR TITLE
chore: faster runner for playwright

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -203,7 +203,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: depot-ubuntu-24.04-arm-64
 
     permissions:
       contents: read

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -203,7 +203,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04-arm-32
 
     permissions:
       contents: read

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -203,7 +203,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: depot-ubuntu-24.04-arm-32
+    runs-on: depot-ubuntu-24.04-32
 
     permissions:
       contents: read

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -203,7 +203,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: depot-ubuntu-24.04-arm-64
+    runs-on: depot-ubuntu-24.04-arm-32
 
     permissions:
       contents: read


### PR DESCRIPTION
Depot now offers 64 core runners. Let's see how this impacts our integration test speed and stability.

Observed improvement (non scientific)

- 16 core arm: ~4:10m (before)
- 32 core arm: 3:26m
- 32 core amd: 3:24m
- 62 core arm: 3:06m

👉 Picking 32 core arm for now. We'd have to rework parallel execution setup to benefit from more concurrency. 