### PR TITLE
Planner: Respect circuit max power setting

### DIFF
--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -94,7 +94,7 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 		}
 
 		// calculate earliest required plan start
-		if plan := lp.nextActivePlan(lp.effectiveMaxPower(), plans); plan != nil {
+		if plan := lp.nextActivePlan(lp.EffectiveMaxPower(), plans); plan != nil {
 			return plan.End, plan.Soc, plan.Id
 		}
 	}


### PR DESCRIPTION
During planning circuit settings are ignored due to a case sensitivity typo. This PR fixes the issue.