### PR TITLE
Planner: Improved handling of charging efficiency

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1756,7 +1756,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 	if lp.chargerHasFeature(api.IntegratedDevice) || lp.vehicleSocPollAllowed() {
 		lp.socUpdated = lp.clock.Now()
 
-		f, err := socEstimator.Soc(lp.GetChargedEnergy())
+		f, err := socEstimator.Soc(lp.GetChargedEnergy(), lp.GetChargePower())
 		if err != nil {
 			if loadpoint.AcceptableError(err) {
 				lp.socUpdated = time.Time{}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1042,7 +1042,7 @@ func (lp *Loadpoint) minSocNotReached() bool {
 		return active
 	}
 
-	minEnergy := v.Capacity() * float64(minSoc) / 100 / soc.ChargeEfficiency
+	minEnergy := v.Capacity() * float64(minSoc) / 100 / soc.ChargeEfficiency(lp.chargePower)
 	return minEnergy > 0 && lp.getChargedEnergy() < minEnergy
 }
 
@@ -1796,7 +1796,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 		}
 		lp.SetRemainingDuration(d)
 
-		lp.SetRemainingEnergy(socEstimator.RemainingChargeEnergy(limitSoc))
+		lp.SetRemainingEnergy(socEstimator.RemainingChargeEnergy(limitSoc, lp.chargePower))
 
 		// range
 		if vs, ok := lp.GetVehicle().(api.VehicleRange); ok {

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -44,12 +44,18 @@ func NewEstimator(log *util.Logger, charger api.Charger, vehicle api.Vehicle, es
 	return s
 }
 
+const (
+	// power thresholds in watts
+	householdOutletMaxPowerW     = 2300 // regular household outlet: 1-p / 10A / 230V
+	singlePhaseWallboxMaxPowerW  = 3680 // wallbox: 1-p / 16A / 230V
+)
+
 // Computes the charge efficiency based on the charging power
 func ChargeEfficiency(chargePower float64) float64 {
-	if chargePower <= 2300 { // regular household outlet: 1-p / 10A / 230V
+	if chargePower <= householdOutletMaxPowerW {
 		return 0.85
 	}
-	if chargePower <= 3680 { // wallbox: 1-p / 16A / 230V
+	if chargePower <= singlePhaseWallboxMaxPowerW {
 		return 0.88
 	}
 	return 0.9 // wallbox: 1-p / 32A / 230V or 3-p / 16A / 400V or above

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -46,8 +46,8 @@ func NewEstimator(log *util.Logger, charger api.Charger, vehicle api.Vehicle, es
 
 const (
 	// power thresholds in watts
-	householdOutletMaxPowerW     = 2300 // regular household outlet: 1-p / 10A / 230V
-	singlePhaseWallboxMaxPowerW  = 3680 // wallbox: 1-p / 16A / 230V
+	householdOutletMaxPowerW    = 2300 // regular household outlet: 1-p / 10A / 230V
+	singlePhaseWallboxMaxPowerW = 3680 // wallbox: 1-p / 16A / 230V
 )
 
 // Computes the charge efficiency based on the charging power
@@ -66,8 +66,8 @@ func (s *Estimator) Reset() {
 	s.prevSoc = 0
 	s.prevChargedEnergy = 0
 	s.initialSoc = 0
-	s.capacity = s.vehicle.Capacity() * 1e3              // cache to simplify debugging
-	s.virtualCapacity = s.capacity / ChargeEfficiency(0) // initial capacity taking efficiency into account
+	s.capacity = s.vehicle.Capacity() * 1e3                                     // cache to simplify debugging
+	s.virtualCapacity = s.capacity / ChargeEfficiency(householdOutletMaxPowerW) // initial capacity taking efficiency into account
 	s.energyPerSocStep = s.virtualCapacity / 100
 	s.minChargePower = 1000  // default 1 kW
 	s.maxChargePower = 50000 // default 50 kW

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -214,7 +214,7 @@ func TestImprovedEstimatorRemainingChargeDuration(t *testing.T) {
 	vehicle := api.NewMockVehicle(ctrl)
 
 	// https://github.com/evcc-io/evcc/pull/7510#issuecomment-1512688548
-	// Updated for 85% charge efficiency (previously 90%)
+	// Updated for charge power adapted charge efficiency (previously 90%/85%)
 	tc := []struct {
 		capacity    float64
 		soc         float64
@@ -224,12 +224,12 @@ func TestImprovedEstimatorRemainingChargeDuration(t *testing.T) {
 	}{
 		{0.75, 10, 60, 300, 1*time.Hour + 28*time.Minute + 14*time.Second},
 		{0.75, 50, 100, 300, 1*time.Hour + 28*time.Minute + 14*time.Second},
-		{17, 10, 60, 7 * 1e3, 1*time.Hour + 25*time.Minute + 43*time.Second},
-		{17, 50, 100, 7 * 1e3, 1*time.Hour + 33*time.Minute + 35*time.Second},
-		{50, 10, 60, 11 * 1e3, 2*time.Hour + 40*time.Minute + 26*time.Second},
-		{50, 50, 100, 11 * 1e3, 3*time.Hour + 7*time.Minute + 43*time.Second},
-		{80, 10, 60, 22 * 1e3, 2*time.Hour + 8*time.Minute + 21*time.Second},
-		{80, 50, 100, 22 * 1e3, 2*time.Hour + 58*time.Minute + 34*time.Second},
+		{17, 10, 60, 7 * 1e3, 1*time.Hour + 20*time.Minute + 57*time.Second},
+		{17, 50, 100, 7 * 1e3, 1*time.Hour + 28*time.Minute + 23*time.Second},
+		{50, 10, 60, 11 * 1e3, 2*time.Hour + 31*time.Minute + 31*time.Second},
+		{50, 50, 100, 11 * 1e3, 2*time.Hour + 57*time.Minute + 17*time.Second},
+		{80, 10, 60, 22 * 1e3, 2*time.Hour + 1*time.Minute + 13*time.Second},
+		{80, 50, 100, 22 * 1e3, 2*time.Hour + 48*time.Minute + 39*time.Second},
 	}
 
 	for _, tc := range tc {


### PR DESCRIPTION
For time estimations evcc assumes a 85% charger efficiency independent of other parameters. However, recent tests ([[1]](https://www.adac.de/rund-ums-fahrzeug/elektromobilitaet/laden/ladeverluste-elektroauto-studie/), [[2]](https://www.readelectricavenue.com/p/an-inconvenient-truth)) show that the efficiency depends on the charging power.

Thus, a more realistic model for charging efficiency could be:
- Charging power <= 2,3kW (e.g. regular outlet) -> Efficiency 85%
- Charging power <= 3,6kW (e.g. 1-p / 16A / 220V) -> Efficiency 88%
- Charging power > 3,6kW (e.g. 3-p / 16A / 400V) -> Efficiency 90%

The attached PR implements the efficiency adapted to the current charging power to facilitate more accurate estimations.

This partially reverts #25168 (which was meant to address #25079), while #25079 is more properly addressed by #25303 in the meanwhile.

A even more realistic model could be based on regression.