### PR TITLE
chore: speedup continuous plan

### DIFF
--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -184,15 +184,15 @@ func findContinuousWindow(rates api.Rates, effectiveDuration time.Duration, targ
 
 		cost := prevWindowCost - lastSlotCost
 
-		// for length 1, lastSlotCost, rpf and rpl are identical, subtract only once
+		lastSlotCost = float64(rnl.End.Sub(rnl.Start)) * rnl.Value
+		cost += lastSlotCost
+
+		// for length 1, lastSlotCost, rpf and rpl costs are identical, subtract only once
 		if length > 1 {
 			rpf := rates[i-1]
 			rpl := rates[i+length-2]
 			cost = cost - float64(rpf.End.Sub(rpf.Start))*rpf.Value + float64(rpl.End.Sub(rpl.Start))*rpl.Value
 		}
-
-		lastSlotCost = float64(rnl.End.Sub(rnl.Start)) * rnl.Value
-		cost += lastSlotCost
 
 		if cost <= bestCost {
 			bestCost = cost

--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -202,6 +202,11 @@ func findContinuousWindow(rates api.Rates, effectiveDuration time.Duration, targ
 		prevWindowCost = cost
 	}
 
+	// No valid window found
+	if length == 0 {
+		return nil
+	}
+
 	// Build the best window only once
 	windowEnd := rates[bestIndex].Start.Add(effectiveDuration)
 

--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -162,7 +162,6 @@ func findContinuousWindow(rates api.Rates, effectiveDuration time.Duration, targ
 				lastSlotCost = float64(r.End.Sub(r.Start)) * r.Value
 				return lastSlotCost
 			})
-
 			prevWindowCost = bestCost
 
 			continue
@@ -204,6 +203,5 @@ func findContinuousWindow(rates api.Rates, effectiveDuration time.Duration, targ
 
 	// Build the best window only once
 	windowEnd := rates[bestIndex].Start.Add(effectiveDuration)
-
 	return clampRates(rates[bestIndex:], rates[bestIndex].Start, windowEnd)
 }

--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -146,13 +146,8 @@ func SumBySeq[T any, R float64](seq iter.Seq[T], iteratee func(item T) R) R {
 // - rates are filtered to [now, targetTime] window by caller
 // Returns the selected rates.
 func findContinuousWindow(rates api.Rates, effectiveDuration time.Duration, targetTime time.Time) api.Rates {
-	var (
-		length         int
-		bestIndex      int
-		bestCost       float64
-		lastSlotCost   float64
-		prevWindowCost float64
-	)
+	var length, bestIndex int
+	var bestCost, lastSlotCost, prevWindowCost float64
 
 	for i := range rates {
 		windowEnd := rates[i].Start.Add(effectiveDuration)

--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -152,8 +152,6 @@ func findContinuousWindow(rates api.Rates, effectiveDuration time.Duration, targ
 		bestCost  float64
 	)
 
-	// i: 0  1  2
-	// v: 1 10 20
 	for i := range rates {
 		windowEnd := rates[i].Start.Add(effectiveDuration)
 

--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -183,7 +183,6 @@ func findContinuousWindow(rates api.Rates, effectiveDuration time.Duration, targ
 			float64(rp.End.Sub(rp.Start))*rp.Value +
 			float64(rl.End.Sub(rl.Start))*rl.Value
 
-		// Prefer later start if equal cost
 		if cost <= bestCost {
 			bestCost = cost
 			bestIndex = i

--- a/core/planner/helper_test.go
+++ b/core/planner/helper_test.go
@@ -21,6 +21,25 @@ func TestSlitPrecondition(t *testing.T) {
 	assert.Equal(t, rr[3:], precond, "precond")
 }
 
+func TestFindContinuousWindow(t *testing.T) {
+	clock := clock.NewMock()
+	rr := rates([]float64{1, 2, 3}, clock.Now(), tariff.SlotDuration)
+
+	{
+		plan := findContinuousWindow(rr, 2*tariff.SlotDuration, rr[len(rr)-1].End)
+		assert.Equal(t, plan, rr[0:2], "full slots only")
+	}
+
+	{
+		plan := findContinuousWindow(rr, 3*tariff.SlotDuration/2, rr[len(rr)-1].End)
+		assert.Equal(t, plan, api.Rates{rr[0], {
+			Start: rr[1].Start,
+			End:   rr[1].End.Add(-tariff.SlotDuration / 2),
+			Value: rr[1].Value,
+		}}, "last slot half length")
+	}
+}
+
 func TestSlotHasSuccessor(t *testing.T) {
 	plan := rates([]float64{20, 60, 10, 80, 40, 90}, time.Now(), time.Hour)
 

--- a/core/planner/planner_continuous_test.go
+++ b/core/planner/planner_continuous_test.go
@@ -24,7 +24,7 @@ func TestContinuous_Simple(t *testing.T) {
 
 	{
 		plan := findContinuousWindow(rr, 3*tariff.SlotDuration/2, rr[len(rr)-1].End)
-		assert.Equal(t, plan, api.Rates{rr[0], api.Rate{
+		assert.Equal(t, plan, api.Rates{rr[0], {
 			Start: rr[1].Start,
 			End:   rr[1].End.Add(-tariff.SlotDuration / 2),
 			Value: rr[1].Value,

--- a/core/planner/planner_continuous_test.go
+++ b/core/planner/planner_continuous_test.go
@@ -16,8 +16,20 @@ import (
 func TestContinuous_Simple(t *testing.T) {
 	clock := clock.NewMock()
 	rr := rates([]float64{1, 2, 3}, clock.Now(), tariff.SlotDuration)
-	plan := findContinuousWindow(rr, 2*tariff.SlotDuration, rr[len(rr)-1].End)
-	require.Equal(t, plan, rr[0:1])
+
+	{
+		plan := findContinuousWindow(rr, 2*tariff.SlotDuration, rr[len(rr)-1].End)
+		assert.Equal(t, plan, rr[0:2], "full slots only")
+	}
+
+	{
+		plan := findContinuousWindow(rr, 3*tariff.SlotDuration/2, rr[len(rr)-1].End)
+		assert.Equal(t, plan, api.Rates{rr[0], api.Rate{
+			Start: rr[1].Start,
+			End:   rr[1].End.Add(-tariff.SlotDuration / 2),
+			Value: rr[1].Value,
+		}}, "last slot half length")
+	}
 }
 
 func TestContinuous_CheapestContiguousSlots(t *testing.T) {

--- a/core/planner/planner_continuous_test.go
+++ b/core/planner/planner_continuous_test.go
@@ -335,11 +335,11 @@ func TestContinuous_Precondition(t *testing.T) {
 		},
 	}, plan, "expected two slots")
 
-	plan = p.Plan(time.Duration(1.5*float64(tariff.SlotDuration)), tariff.SlotDuration, clock.Now().Add(4*tariff.SlotDuration), true)
+	plan = p.Plan(3*tariff.SlotDuration/2, tariff.SlotDuration, clock.Now().Add(4*tariff.SlotDuration), true)
 	assert.Equal(t, api.Rates{
 		{
 			Start: clock.Now(),
-			End:   clock.Now().Add(time.Duration(0.5 * float64(tariff.SlotDuration))),
+			End:   clock.Now().Add(tariff.SlotDuration / 2),
 			Value: 1,
 		},
 		{

--- a/core/planner/planner_continuous_test.go
+++ b/core/planner/planner_continuous_test.go
@@ -13,25 +13,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestContinuous_Simple(t *testing.T) {
-	clock := clock.NewMock()
-	rr := rates([]float64{1, 2, 3}, clock.Now(), tariff.SlotDuration)
-
-	{
-		plan := findContinuousWindow(rr, 2*tariff.SlotDuration, rr[len(rr)-1].End)
-		assert.Equal(t, plan, rr[0:2], "full slots only")
-	}
-
-	{
-		plan := findContinuousWindow(rr, 3*tariff.SlotDuration/2, rr[len(rr)-1].End)
-		assert.Equal(t, plan, api.Rates{rr[0], {
-			Start: rr[1].Start,
-			End:   rr[1].End.Add(-tariff.SlotDuration / 2),
-			Value: rr[1].Value,
-		}}, "last slot half length")
-	}
-}
-
 func TestContinuous_CheapestContiguousSlots(t *testing.T) {
 	now := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 	c := clock.NewMock()

--- a/core/planner/planner_continuous_test.go
+++ b/core/planner/planner_continuous_test.go
@@ -13,6 +13,13 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func TestContinuous_Simple(t *testing.T) {
+	clock := clock.NewMock()
+	rr := rates([]float64{1, 2, 3}, clock.Now(), tariff.SlotDuration)
+	plan := findContinuousWindow(rr, 2*tariff.SlotDuration, rr[len(rr)-1].End)
+	require.Equal(t, plan, rr[0:1])
+}
+
 func TestContinuous_CheapestContiguousSlots(t *testing.T) {
 	now := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 	c := clock.NewMock()


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/pull/26415

```
goos: darwin
goarch: arm64
pkg: github.com/evcc-io/evcc/core/planner
cpu: Apple M4 Pro
                        │     old     │                 new                 │
                        │   sec/op    │   sec/op     vs base                │
FindContinuousWindow-12   6.945µ ± 1%   1.879µ ± 1%  -72.94% (p=0.000 n=10)
OptimalPlan-12            74.97n ± 1%   75.85n ± 3%        ~ (p=0.052 n=10)
geomean                   721.6n        377.5n       -47.68%
```
