### PR TITLE
Update energyforecast.yaml to use 96 hours api route

### DIFF
--- a/templates/definition/tariff/energyforecast.yaml
+++ b/templates/definition/tariff/energyforecast.yaml
@@ -16,7 +16,7 @@ render: |
   {{ include "tariff-features" . }}
   forecast:
     source: http
-    uri: https://www.energyforecast.de/api/v1/predictions/next_48_hours?resolution=QUARTER_HOURLY&fixed_cost_cent=0&vat=0&token={{ .token }}
+    uri: https://www.energyforecast.de/api/v1/predictions/next_96_hours?resolution=QUARTER_HOURLY&fixed_cost_cent=0&vat=0&token={{ .token }}
     jq: |
       map({
         "start": .start | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime | strftime("%Y-%m-%dT%H:%M:%SZ"),


### PR DESCRIPTION
I changed the used api route to next_96_hours instead of next_48_hours. next_96_hours will check if a user is allowed to get the full 96 hours if not they will get 48 hours. See api docs for details: https://www.energyforecast.de/api-docs/index.html