### PR TITLE
chore: log ui/ocpp url format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,9 +184,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 			Status: ocpp.GetStatus(),
 		}}
 	})
-	log.INFO.Printf("OCPP local:    ws://127.0.0.1:%d/<stationId>", conf.Ocpp.Port)
+	log.INFO.Printf("OCPP local url:    ws://127.0.0.1:%d/<stationId>", conf.Ocpp.Port)
 	if ocpp.ExternalUrl() != "" {
-		log.INFO.Printf("OCPP external: %s/<stationId>", ocpp.ExternalUrl())
+		log.INFO.Printf("OCPP external url: %s/<stationId>", ocpp.ExternalUrl())
 	}
 
 	// value cache
@@ -204,9 +204,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 	}()
-	log.INFO.Printf("UI local:      http://127.0.0.1:%d", conf.Network.Port)
+	log.INFO.Printf("UI local url:      http://127.0.0.1:%d", conf.Network.Port)
 	if conf.Network.ExternalUrl != "" {
-		log.INFO.Printf("UI external:   %s", conf.Network.ExternalURL())
+		log.INFO.Printf("UI external url:   %s", conf.Network.ExternalURL())
 	}
 
 	// publish to UI


### PR DESCRIPTION
add ` url`

```
EVCC_NETWORK_EXTERNALURL=https://example.home go run main.go
[main  ] INFO 2026/01/06 13:53:37 evcc 0.0.0
[main  ] INFO 2026/01/06 13:53:37 config file not found, database-only mode
[main  ] INFO 2026/01/06 13:53:37 using sqlite database: /Users/.../.evcc/evcc.db?_pragma=busy_timeout(5000)
[main  ] INFO 2026/01/06 13:53:37 OCPP local url:    ws://127.0.0.1:8887/<stationId>
[main  ] INFO 2026/01/06 13:53:37 OCPP external url: wss://example.home:8887/<stationId>
[main  ] INFO 2026/01/06 13:53:37 UI local url:      http://127.0.0.1:7070
[main  ] INFO 2026/01/06 13:53:37 UI external url:   https://example.home
```