### PR TITLE
fix: auto-create circuit for hems

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -26,6 +26,7 @@ import (
 	coresettings "github.com/evcc-io/evcc/core/settings"
 	"github.com/evcc-io/evcc/hems"
 	hemsapi "github.com/evcc-io/evcc/hems/hems"
+	"github.com/evcc-io/evcc/hems/shared"
 	"github.com/evcc-io/evcc/hems/shm"
 	"github.com/evcc-io/evcc/meter"
 	"github.com/evcc-io/evcc/plugin/golang"
@@ -722,6 +723,13 @@ func configureHEMS(conf *globalconfig.Hems, site *core.Site) (hemsapi.API, error
 	props, err := customDevice(conf.Other)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode custom hems '%s': %w", conf.Type, err)
+	}
+
+	if circuit.Root() == nil {
+		log.INFO.Println("no loadmanagement configured, auto-creating circuit 'lpc' for hems")
+		if _, err := shared.GetOrCreateCircuit("lpc", "lpc"); err != nil {
+			return nil, fmt.Errorf("failed creating root circuit for hems: %w", err)
+		}
 	}
 
 	hems, err := hems.NewFromConfig(context.TODO(), conf.Type, props, site)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -726,7 +726,6 @@ func configureHEMS(conf *globalconfig.Hems, site *core.Site) (hemsapi.API, error
 	}
 
 	if circuit.Root() == nil {
-		log.INFO.Println("no loadmanagement configured, auto-creating circuit 'lpc' for hems")
 		if _, err := shared.GetOrCreateCircuit("lpc", "lpc"); err != nil {
 			return nil, fmt.Errorf("failed creating root circuit for hems: %w", err)
 		}

--- a/tests/hems-yaml.evcc.yaml
+++ b/tests/hems-yaml.evcc.yaml
@@ -6,6 +6,3 @@ hems:
   limit:
     source: const
     value: true
-
-circuits:
-  - name: main


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/25949

create single `lpc` circuit if hems but no load management is configured.

<img width="981" height="624" alt="Bildschirmfoto 2026-01-06 um 14 17 05" src="https://github.com/user-attachments/assets/74f42aa2-1a9a-4e4f-9b05-8b8220d0fc1f" />
<img width="739" height="307" alt="Bildschirmfoto 2026-01-06 um 14 17 17" src="https://github.com/user-attachments/assets/2b972db6-dffb-406d-9973-5e3f7faf5427" />
