### PR TITLE
Config UI: edit existing ocpp chargers

### DIFF
--- a/assets/js/components/Config/ChargerModal.vue
+++ b/assets/js/components/Config/ChargerModal.vue
@@ -16,7 +16,7 @@
 		:apply-custom-defaults="applyCustomDefaults"
 		:custom-fields="customFields"
 		:get-product-name="getProductName"
-		:hide-template-fields="hideTemplateFields"
+		:hide-template-fields="showOcppOnboarding"
 		@added="$emit('added', $event)"
 		@updated="$emit('updated')"
 		@removed="$emit('removed')"
@@ -48,7 +48,7 @@
 			</FormRow>
 
 			<div
-				v-if="!ocppNextStepConfirmed && !values.stationid"
+				v-if="showOcppOnboarding"
 				class="my-4 d-flex justify-content-end gap-2 align-items-center"
 			>
 				<span v-if="ocppStationIdDetected">{{ $t("config.charger.ocppConnected") }}</span>
@@ -175,8 +175,11 @@ export default defineComponent({
 			const stations = this.ocpp.status.stations;
 			return stations.find((station) => station.status === "unknown")?.id;
 		},
-		hideTemplateFields(): boolean {
-			return this.isOcpp && !this.ocppNextStepConfirmed;
+		showOcppOnboarding(): boolean {
+			if (!this.isOcpp) return false;
+			if (this.ocppNextStepConfirmed) return false;
+			if (this.currentValues.stationid) return false;
+			return true;
 		},
 	},
 	methods: {
@@ -269,6 +272,7 @@ export default defineComponent({
 			}
 		},
 		applyCustomDefaults(template: Template | null, values: DeviceValues) {
+			console.log("applyCustomDefaults", template, values);
 			// Store template and values for ocppUrl computation
 			this.currentTemplate = template;
 			this.currentValues = values;

--- a/assets/js/components/Config/ChargerModal.vue
+++ b/assets/js/components/Config/ChargerModal.vue
@@ -272,7 +272,6 @@ export default defineComponent({
 			}
 		},
 		applyCustomDefaults(template: Template | null, values: DeviceValues) {
-			console.log("applyCustomDefaults", template, values);
 			// Store template and values for ocppUrl computation
 			this.currentTemplate = template;
 			this.currentValues = values;


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/26484#issuecomment-3716013705

Editing an existing OCPP charger should not show the onboarding instruction but instead should show all fields.