### PR TITLE
Plan UI: always show settings

### DIFF
--- a/assets/js/components/ChargingPlans/PlanStrategy.vue
+++ b/assets/js/components/ChargingPlans/PlanStrategy.vue
@@ -8,10 +8,19 @@
 							{{ $t("main.chargingPlan.optimization.label") }}
 						</label>
 						<div class="col-7 col-sm-12">
+							<input
+								v-if="disabled"
+								:id="formId('continuous')"
+								class="form-select"
+								disabled
+								value="---"
+							/>
 							<select
+								v-else
 								:id="formId('continuous')"
 								v-model="localContinuous"
 								class="form-select"
+								:disabled="disabled"
 								@change="updateStrategy"
 							>
 								<option :value="false">
@@ -30,10 +39,19 @@
 							{{ $t("main.chargingPlan.precondition.label") }}
 						</label>
 						<div class="col-7 col-sm-12">
+							<input
+								v-if="disabled"
+								:id="formId('precondition')"
+								class="form-select"
+								disabled
+								value="---"
+							/>
 							<select
+								v-else
 								:id="formId('precondition')"
 								v-model="localPrecondition"
 								class="form-select"
+								:disabled="disabled"
 								@change="updateStrategy"
 							>
 								<option :value="0">
@@ -49,6 +67,12 @@
 							</select>
 						</div>
 					</div>
+				</div>
+				<div v-if="disabled" class="small text-muted mb-4 col-sm-12 col-lg-6 offset-lg-3">
+					<strong class="text-primary">
+						{{ $t("main.chargingPlan.strategyDisabledHint") }}
+					</strong>
+					{{ $t("main.chargingPlan.strategyDisabledDescription") }}
 				</div>
 			</div>
 		</div>
@@ -68,6 +92,7 @@ export default defineComponent({
 		show: Boolean,
 		precondition: { type: Number, default: 0 },
 		continuous: { type: Boolean, default: false },
+		disabled: Boolean,
 	},
 	emits: ["update"],
 	data() {

--- a/assets/js/components/ChargingPlans/PlanStrategy.vue
+++ b/assets/js/components/ChargingPlans/PlanStrategy.vue
@@ -1,22 +1,20 @@
 <template>
 	<div class="strategy-wrapper" :class="{ open: show }">
 		<div class="strategy-content">
-			<div class="row">
+			<div v-if="disabled" class="row mb-4">
+				<div class="small text-muted">
+					<strong class="text-primary">{{ $t("general.note") }}</strong>
+					{{ $t("main.chargingPlan.strategyDisabledDescription") }}
+				</div>
+			</div>
+			<div v-else class="row">
 				<div class="col-12 col-sm-6 col-lg-3 offset-lg-3 mb-3">
 					<div class="row">
 						<label :for="formId('continuous')" class="col-form-label col-5 col-sm-12">
 							{{ $t("main.chargingPlan.optimization.label") }}
 						</label>
 						<div class="col-7 col-sm-12">
-							<input
-								v-if="disabled"
-								:id="formId('continuous')"
-								class="form-select"
-								disabled
-								value="---"
-							/>
 							<select
-								v-else
 								:id="formId('continuous')"
 								v-model="localContinuous"
 								class="form-select"
@@ -38,15 +36,7 @@
 							{{ $t("main.chargingPlan.precondition.label") }}
 						</label>
 						<div class="col-7 col-sm-12">
-							<input
-								v-if="disabled"
-								:id="formId('precondition')"
-								class="form-select"
-								disabled
-								value="---"
-							/>
 							<select
-								v-else
 								:id="formId('precondition')"
 								v-model="localPrecondition"
 								class="form-select"
@@ -65,12 +55,6 @@
 							</select>
 						</div>
 					</div>
-				</div>
-				<div v-if="disabled" class="small text-muted mb-4 col-sm-12 col-lg-6 offset-lg-3">
-					<strong class="text-primary">
-						{{ $t("main.chargingPlan.strategyDisabledHint") }}
-					</strong>
-					{{ $t("main.chargingPlan.strategyDisabledDescription") }}
 				</div>
 			</div>
 		</div>

--- a/assets/js/components/ChargingPlans/PlanStrategy.vue
+++ b/assets/js/components/ChargingPlans/PlanStrategy.vue
@@ -20,7 +20,6 @@
 								:id="formId('continuous')"
 								v-model="localContinuous"
 								class="form-select"
-								:disabled="disabled"
 								@change="updateStrategy"
 							>
 								<option :value="false">
@@ -51,7 +50,6 @@
 								:id="formId('precondition')"
 								v-model="localPrecondition"
 								class="form-select"
-								:disabled="disabled"
 								@change="updateStrategy"
 							>
 								<option :value="0">

--- a/assets/js/components/ChargingPlans/PlansSettings.vue
+++ b/assets/js/components/ChargingPlans/PlansSettings.vue
@@ -44,7 +44,6 @@
 				<span v-else-if="alreadyReached">{{ $t("main.targetCharge.goalReached") }}</span>
 				<span v-else>{{ nextPlanTitle }}</span>
 				<button
-					v-if="showStrategy"
 					type="button"
 					class="btn btn-sm"
 					:class="strategyOpen ? 'btn-secondary' : 'evcc-gray'"
@@ -57,8 +56,8 @@
 			</div>
 		</h5>
 		<ChargingPlanStrategy
-			v-if="showStrategy"
 			v-bind="chargingPlanStrategyProps"
+			:disabled="strategyDisabled"
 			:show="strategyOpen"
 			@update="updatePlanStrategy"
 		/>
@@ -173,11 +172,12 @@ export default defineComponent({
 		nextPlanTitle(): string {
 			return `${this.$t("main.targetCharge.nextPlan")} #${this.nextPlanId}`;
 		},
-		showStrategy(): boolean {
-			// only show option if planner forecast has different values
+		strategyDisabled(): boolean {
+			// options only make sense if there are variable prices
+			// TODO: make this logic more robus (api fails, missing data)
 			const slots = this.forecast?.planner || [];
 			const values = new Set(slots.map(({ value }) => value));
-			return values.size > 1;
+			return values.size <= 1;
 		},
 	},
 	watch: {

--- a/assets/js/components/ChargingPlans/PlansSettings.vue
+++ b/assets/js/components/ChargingPlans/PlansSettings.vue
@@ -174,7 +174,7 @@ export default defineComponent({
 		},
 		strategyDisabled(): boolean {
 			// options only make sense if there are variable prices
-			// TODO: make this logic more robus (api fails, missing data)
+			// TODO: make this logic more robust (api fails, missing data)
 			const slots = this.forecast?.planner || [];
 			const values = new Set(slots.map(({ value }) => value));
 			return values.size <= 1;

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -893,6 +893,8 @@
       "repeating": "wiederholend",
       "repeatingPlans": "Wiederholende Pläne",
       "selectAll": "Alle wählen",
+      "strategyDisabledDescription": "Diese Optionen sind nur verfügbar, wenn ein dynamischer Netzpreis oder CO₂-Tarif konfiguriert ist.",
+      "strategyDisabledHint": "Hinweis:",
       "strategySettings": "Strategie-Einstellungen",
       "time": "Zeit",
       "title": "Plan",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -896,7 +896,7 @@
       "repeating": "wiederholend",
       "repeatingPlans": "Wiederholende Pläne",
       "selectAll": "Alle wählen",
-      "strategyDisabledDescription": "Das Laden wird rechtzeitig zur Abfahrt abgeschlossen. Mit dynamischen Netzpreisen oder einem CO₂-Tarif stehen hier weitere Optimierungsoptionen zur Verfügung.",
+      "strategyDisabledDescription": "Das Laden startet so spät wie möglich und wird rechtzeitig zur Abfahrt abgeschlossen. Mit dynamischen Netzpreisen oder einem CO₂-Tarif stehen hier weitere Optionen zur Verfügung.",
       "strategySettings": "Strategie-Einstellungen",
       "time": "Zeit",
       "title": "Plan",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -760,6 +760,9 @@
       "solar": "Solar"
     }
   },
+  "general": {
+    "note": "Hinweis:"
+  },
   "header": {
     "about": "Über",
     "blog": "Blog",
@@ -893,8 +896,7 @@
       "repeating": "wiederholend",
       "repeatingPlans": "Wiederholende Pläne",
       "selectAll": "Alle wählen",
-      "strategyDisabledDescription": "Diese Optionen sind nur verfügbar, wenn ein dynamischer Netzpreis oder CO₂-Tarif konfiguriert ist.",
-      "strategyDisabledHint": "Hinweis:",
+      "strategyDisabledDescription": "Das Laden wird rechtzeitig zur Abfahrt abgeschlossen. Mit dynamischen Netzpreisen oder einem CO₂-Tarif stehen hier weitere Optimierungsoptionen zur Verfügung.",
       "strategySettings": "Strategie-Einstellungen",
       "time": "Zeit",
       "title": "Plan",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -893,6 +893,8 @@
       "repeating": "repeating",
       "repeatingPlans": "Repeating plans",
       "selectAll": "Select all",
+      "strategyDisabledDescription": "These options are only available when a dynamic grid prices or CO₂ tariff is configured.",
+      "strategyDisabledHint": "Note:",
       "strategySettings": "Strategy settings",
       "time": "Time",
       "title": "Plan",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -760,6 +760,9 @@
       "solar": "Solar"
     }
   },
+  "general": {
+    "note": "Note:"
+  },
   "header": {
     "about": "About",
     "blog": "Blog",
@@ -893,8 +896,7 @@
       "repeating": "repeating",
       "repeatingPlans": "Repeating plans",
       "selectAll": "Select all",
-      "strategyDisabledDescription": "These options are only available when a dynamic grid prices or CO₂ tariff is configured.",
-      "strategyDisabledHint": "Note:",
+      "strategyDisabledDescription": "The planner will schedule charging to finish just in time for your departure. With dynamic grid prices or a CO₂ tariff, additional optimization options are available here.",
       "strategySettings": "Strategy settings",
       "time": "Time",
       "title": "Plan",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -896,7 +896,7 @@
       "repeating": "repeating",
       "repeatingPlans": "Repeating plans",
       "selectAll": "Select all",
-      "strategyDisabledDescription": "The planner will schedule charging to finish just in time for your departure. With dynamic grid prices or a CO₂ tariff, additional optimization options are available here.",
+      "strategyDisabledDescription": "Charging starts as late as possible to finish just in time for departure. With dynamic grid prices or CO₂ tariff, more options are available here.",
       "strategySettings": "Strategy settings",
       "time": "Time",
       "title": "Plan",

--- a/tests/evcc.ts
+++ b/tests/evcc.ts
@@ -12,6 +12,10 @@ const BINARY = "./evcc";
 const IS_CI = !!process.env["GITHUB_ACTIONS"];
 const LOG_ENABLED = !IS_CI;
 
+console.log(
+  "REMINDER: Playwright tests run against the ./evcc binary. Rebuild with 'make ui build' after application changes."
+);
+
 // sometimes evcc startup fails due to infra issues in runner ususally fixed by retry. allowing some fails to avoid github annotations clutter
 let allowedStartupFails = IS_CI ? 2 : 0;
 
@@ -105,6 +109,7 @@ async function _start(config?: string, flags: string | string[] = []) {
   const configArgs = config ? ["--config", config.includes("/") ? config : `tests/${config}`] : [];
   const port = workerPort();
   const ocpp = ocppPort();
+
   log(`wait until port ${port} is available`);
   // wait for port to be available
   await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED });

--- a/tests/plan.spec.ts
+++ b/tests/plan.spec.ts
@@ -688,16 +688,12 @@ test.describe("plan strategy", async () => {
     const modal = page.getByTestId("charging-plan-modal");
     await expect(modal.getByTestId("static-plan-active")).toBeVisible();
 
+    // Strategy toggle should be visible but expand to show informational note only
     await expect(modal.getByRole("button", { name: "Strategy settings" })).toBeVisible();
     await modal.getByRole("button", { name: "Strategy settings" }).click();
-
-    await expect(modal.getByLabel("Optimization")).toBeDisabled();
-    await expect(modal.getByLabel("Late Charging")).toBeDisabled();
-    await expect(
-      modal.getByText(
-        "These options are only available when a dynamic grid prices or CO₂ tariff is configured."
-      )
-    ).toBeVisible();
+    await expect(modal.getByLabel("Optimization")).not.toBeVisible();
+    await expect(modal.getByLabel("Late Charging")).not.toBeVisible();
+    await expect(modal).toContainText("just in time for your departure");
   });
 
   test("visible and functional on mobile", async ({ page }) => {

--- a/tests/plan.spec.ts
+++ b/tests/plan.spec.ts
@@ -693,7 +693,7 @@ test.describe("plan strategy", async () => {
     await modal.getByRole("button", { name: "Strategy settings" }).click();
     await expect(modal.getByLabel("Optimization")).not.toBeVisible();
     await expect(modal.getByLabel("Late Charging")).not.toBeVisible();
-    await expect(modal).toContainText("just in time for your departure");
+    await expect(modal).toContainText("just in time for departure");
   });
 
   test("visible and functional on mobile", async ({ page }) => {

--- a/tests/plan.spec.ts
+++ b/tests/plan.spec.ts
@@ -688,16 +688,11 @@ test.describe("plan strategy", async () => {
     const modal = page.getByTestId("charging-plan-modal");
     await expect(modal.getByTestId("static-plan-active")).toBeVisible();
 
-    // Strategy toggle should be visible but expand to show disabled state with hint
     await expect(modal.getByRole("button", { name: "Strategy settings" })).toBeVisible();
     await modal.getByRole("button", { name: "Strategy settings" }).click();
 
-    // Strategy controls should be disabled and accessible by label
     await expect(modal.getByLabel("Optimization")).toBeDisabled();
     await expect(modal.getByLabel("Late Charging")).toBeDisabled();
-
-    // Hint text should be visible
-    await expect(modal.getByText("Note:")).toBeVisible();
     await expect(
       modal.getByText(
         "These options are only available when a dynamic grid prices or CO₂ tariff is configured."

--- a/tests/plan.spec.ts
+++ b/tests/plan.spec.ts
@@ -687,8 +687,22 @@ test.describe("plan strategy", async () => {
     await lp1.getByTestId("charging-plan").getByRole("button", { name: "none" }).click();
     const modal = page.getByTestId("charging-plan-modal");
     await expect(modal.getByTestId("static-plan-active")).toBeVisible();
-    // Strategy toggle should not be visible when no dynamic tariff exists
-    await expect(modal.getByRole("button", { name: "Strategy settings" })).not.toBeVisible();
+
+    // Strategy toggle should be visible but expand to show disabled state with hint
+    await expect(modal.getByRole("button", { name: "Strategy settings" })).toBeVisible();
+    await modal.getByRole("button", { name: "Strategy settings" }).click();
+
+    // Strategy controls should be disabled and accessible by label
+    await expect(modal.getByLabel("Optimization")).toBeDisabled();
+    await expect(modal.getByLabel("Late Charging")).toBeDisabled();
+
+    // Hint text should be visible
+    await expect(modal.getByText("Note:")).toBeVisible();
+    await expect(
+      modal.getByText(
+        "These options are only available when a dynamic grid prices or CO₂ tariff is configured."
+      )
+    ).toBeVisible();
   });
 
   test("visible and functional on mobile", async ({ page }) => {


### PR DESCRIPTION
replaces https://github.com/evcc-io/evcc/pull/26485
fixes https://github.com/evcc-io/evcc/issues/26446, https://github.com/evcc-io/evcc/discussions/26463

Plan settings are only relevant if we have a dynamic plan (price or co2). This PR now always shows the settings, but disables the options and presents an explanation why the options are not available.

English (small screen)
<img width="761" height="577" alt="Bildschirmfoto 2026-01-07 um 09 45 32" src="https://github.com/user-attachments/assets/dab60abf-ae44-4e45-9e86-71559705b942" />

German (large screen)
<img width="1051" height="468" alt="Bildschirmfoto 2026-01-07 um 09 45 02" src="https://github.com/user-attachments/assets/bd001fe1-4285-4739-80ea-a4cada5ceee8" />


\cc @iseeberg79 