### PR TITLE
UI: fix swipe highlight

### DIFF
--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -51,6 +51,7 @@
 			</div>
 			<Loadpoints
 				v-else
+				:key="`loadpoints-${orderedVisibleLoadpoints.length}`"
 				class="mt-1 mt-sm-2 flex-grow-1"
 				:loadpoints="orderedVisibleLoadpoints"
 				:vehicles="vehicleList"


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/26493
regression from https://github.com/evcc-io/evcc/pull/26248

Forcing loadpoints component to rerender when the number of items changes. Necessary to reliably (re)trigger initialization of the scroll listeners.

\cc @Maschga 