### PR TITLE
UI: fix double percentage in the plan list

### DIFF
--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -160,6 +160,10 @@ const LAST_SOC_GOAL_KEY = "last_soc_goal";
 const LAST_ENERGY_GOAL_KEY = "last_energy_goal";
 const DEFAULT_TARGET_TIME = "7:00";
 
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
 export default defineComponent({
 	name: "ChargingPlanStaticSettings",
 	mixins: [formatter],
@@ -276,11 +280,14 @@ export default defineComponent({
 		},
 		initInputFields() {
 			if (!this.selectedSoc) {
-				this.selectedSoc = Number(window.localStorage[LAST_SOC_GOAL_KEY]) || 100;
+				const lastSocGoal = window.localStorage[LAST_SOC_GOAL_KEY];
+				this.selectedSoc = isNonEmptyString(lastSocGoal) ? Number(lastSocGoal) : 100;
 			}
 			if (!this.selectedEnergy) {
-				this.selectedEnergy =
-					Number(window.localStorage[LAST_ENERGY_GOAL_KEY]) || this.capacity || 10;
+				const lastEnergyGoal = window.localStorage[LAST_ENERGY_GOAL_KEY];
+				this.selectedEnergy = isNonEmptyString(lastEnergyGoal)
+					? Number(lastEnergyGoal)
+					: (this.capacity ?? 10);
 			}
 
 			let t = this.time;

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -154,15 +154,9 @@ import { distanceUnit } from "@/units";
 import formatter from "@/mixins/formatter";
 import { energyOptions } from "@/utils/energyOptions.ts";
 import { defineComponent } from "vue";
+import settings from "@/settings";
 
-const LAST_TARGET_TIME_KEY = "last_target_time";
-const LAST_SOC_GOAL_KEY = "last_soc_goal";
-const LAST_ENERGY_GOAL_KEY = "last_energy_goal";
 const DEFAULT_TARGET_TIME = "7:00";
-
-function isNonEmptyString(value: unknown): value is string {
-	return typeof value === "string" && value.length > 0;
-}
 
 export default defineComponent({
 	name: "ChargingPlanStaticSettings",
@@ -280,14 +274,10 @@ export default defineComponent({
 		},
 		initInputFields() {
 			if (!this.selectedSoc) {
-				const lastSocGoal = window.localStorage[LAST_SOC_GOAL_KEY];
-				this.selectedSoc = isNonEmptyString(lastSocGoal) ? Number(lastSocGoal) : 100;
+				this.selectedSoc = settings.lastSocGoal ?? 100;
 			}
 			if (!this.selectedEnergy) {
-				const lastEnergyGoal = window.localStorage[LAST_ENERGY_GOAL_KEY];
-				this.selectedEnergy = isNonEmptyString(lastEnergyGoal)
-					? Number(lastEnergyGoal)
-					: (this.capacity ?? 10);
+				this.selectedEnergy = settings.lastEnergyGoal ?? this.capacity ?? 10;
 			}
 
 			let t = this.time;
@@ -328,13 +318,9 @@ export default defineComponent({
 			try {
 				const hours = this.selectedDate.getHours();
 				const minutes = this.selectedDate.getMinutes();
-				window.localStorage[LAST_TARGET_TIME_KEY] = `${hours}:${minutes}`;
-				if (this.selectedSoc) {
-					window.localStorage[LAST_SOC_GOAL_KEY] = this.selectedSoc;
-				}
-				if (this.selectedEnergy) {
-					window.localStorage[LAST_ENERGY_GOAL_KEY] = this.selectedEnergy;
-				}
+				settings.lastTargetTime = `${hours}:${minutes}`;
+				settings.lastSocGoal = this.selectedSoc;
+				settings.lastEnergyGoal = this.selectedEnergy;
 			} catch (e) {
 				console.warn(e);
 			}
@@ -365,9 +351,7 @@ export default defineComponent({
 			this.active = checked;
 		},
 		defaultTime() {
-			const [hours, minutes] = (
-				window.localStorage[LAST_TARGET_TIME_KEY] || DEFAULT_TARGET_TIME
-			).split(":");
+			const [hours, minutes] = (settings.lastTargetTime || DEFAULT_TARGET_TIME).split(":");
 
 			const target = new Date();
 			target.setSeconds(0);

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -277,7 +277,7 @@ export default defineComponent({
 				this.selectedSoc = settings.lastSocGoal ?? 100;
 			}
 			if (!this.selectedEnergy) {
-				this.selectedEnergy = settings.lastEnergyGoal ?? this.capacity ?? 10;
+				this.selectedEnergy = settings.lastEnergyGoal ?? (this.capacity || 10);
 			}
 
 			let t = this.time;

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -351,7 +351,9 @@ export default defineComponent({
 			this.active = checked;
 		},
 		defaultTime() {
-			const [hours, minutes] = (settings.lastTargetTime || DEFAULT_TARGET_TIME).split(":");
+			const [hours, minutes] = (settings.lastTargetTime || DEFAULT_TARGET_TIME)
+				.split(":")
+				.map(Number);
 
 			const target = new Date();
 			target.setSeconds(0);

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -352,7 +352,8 @@ export default defineComponent({
 		},
 		defaultTime() {
 			const lastTargetTime = (settings.lastTargetTime || DEFAULT_TARGET_TIME).split(":");
-			const [hours, minutes] = [Number(lastTargetTime[0]), Number(lastTargetTime[1])];
+			const hours = Number(lastTargetTime[0]);
+			const minutes = Number(lastTargetTime[1]);
 
 			const target = new Date();
 			target.setSeconds(0);

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -351,9 +351,8 @@ export default defineComponent({
 			this.active = checked;
 		},
 		defaultTime() {
-			const [hours, minutes] = (settings.lastTargetTime || DEFAULT_TARGET_TIME)
-				.split(":")
-				.map(Number);
+			const lastTargetTime = (settings.lastTargetTime || DEFAULT_TARGET_TIME).split(":");
+			const [hours, minutes] = [Number(lastTargetTime[0]), Number(lastTargetTime[1])];
 
 			const target = new Date();
 			target.setSeconds(0);

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -276,11 +276,11 @@ export default defineComponent({
 		},
 		initInputFields() {
 			if (!this.selectedSoc) {
-				this.selectedSoc = window.localStorage[LAST_SOC_GOAL_KEY] || 100;
+				this.selectedSoc = Number(window.localStorage[LAST_SOC_GOAL_KEY]) || 100;
 			}
 			if (!this.selectedEnergy) {
 				this.selectedEnergy =
-					window.localStorage[LAST_ENERGY_GOAL_KEY] || this.capacity || 10;
+					Number(window.localStorage[LAST_ENERGY_GOAL_KEY]) || this.capacity || 10;
 			}
 
 			let t = this.time;

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -25,7 +25,7 @@ const LAST_TARGET_TIME = "last_target_time";
 const LAST_SOC_GOAL = "last_soc_goal";
 const LAST_ENERGY_GOAL = "last_energy_goal";
 
-function read(key: string) {
+function read(key: string): string | null {
   return window.localStorage[key];
 }
 
@@ -54,7 +54,8 @@ function saveBool(key: string) {
 }
 
 function readNumber(key: string) {
-  return read(key) ? parseFloat(read(key)) : undefined;
+  const value = read(key);
+  return value ? parseFloat(value) : undefined;
 }
 
 function saveNumber(key: string) {

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -64,12 +64,6 @@ function saveNumber(key: string) {
   };
 }
 
-function saveString(key: string) {
-  return (value: string | undefined) => {
-    save(key)(value ?? null);
-  };
-}
-
 function readArray(key: string) {
   const value = read(key);
   return value ? value.split(",") : [];
@@ -129,7 +123,7 @@ export interface Settings {
   solarAdjusted: boolean;
   loadpoints: Record<string, LoadpointSettings>;
   lastBatterySmartCostLimit: number | undefined;
-  lastTargetTime: string | undefined;
+  lastTargetTime: string | null;
   lastSocGoal: number | undefined;
   lastEnergyGoal: number | undefined;
 }
@@ -178,7 +172,7 @@ watch(() => settings.sessionsType, save(SESSIONS_TYPE));
 watch(() => settings.solarAdjusted, saveBool(SETTINGS_SOLAR_ADJUSTED));
 watch(() => settings.loadpoints, saveJSON(LOADPOINTS), { deep: true });
 watch(() => settings.lastBatterySmartCostLimit, saveNumber(LAST_BATTERY_SMART_COST_LIMIT));
-watch(() => settings.lastTargetTime, saveString(LAST_TARGET_TIME));
+watch(() => settings.lastTargetTime, save(LAST_TARGET_TIME));
 watch(() => settings.lastSocGoal, saveNumber(LAST_SOC_GOAL));
 watch(() => settings.lastEnergyGoal, saveNumber(LAST_ENERGY_GOAL));
 

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -21,6 +21,9 @@ const SESSIONS_GROUP = "sessions_group";
 const SESSIONS_TYPE = "sessions_type";
 const SETTINGS_SOLAR_ADJUSTED = "settings_solar_adjusted";
 const LAST_BATTERY_SMART_COST_LIMIT = "last_battery_smart_cost_limit";
+const LAST_TARGET_TIME = "last_target_time";
+const LAST_SOC_GOAL = "last_soc_goal";
+const LAST_ENERGY_GOAL = "last_energy_goal";
 
 function read(key: string) {
   return window.localStorage[key];
@@ -57,6 +60,12 @@ function readNumber(key: string) {
 function saveNumber(key: string) {
   return (value: number | undefined) => {
     save(key)(value ? value.toString() : null);
+  };
+}
+
+function saveString(key: string) {
+  return (value: string | undefined) => {
+    save(key)(value ?? null);
   };
 }
 
@@ -119,6 +128,9 @@ export interface Settings {
   solarAdjusted: boolean;
   loadpoints: Record<string, LoadpointSettings>;
   lastBatterySmartCostLimit: number | undefined;
+  lastTargetTime: string | undefined;
+  lastSocGoal: number | undefined;
+  lastEnergyGoal: number | undefined;
 }
 
 const settings: Settings = reactive({
@@ -141,6 +153,9 @@ const settings: Settings = reactive({
   solarAdjusted: readBool(SETTINGS_SOLAR_ADJUSTED),
   loadpoints: readJSON(LOADPOINTS),
   lastBatterySmartCostLimit: readNumber(LAST_BATTERY_SMART_COST_LIMIT),
+  lastTargetTime: read(LAST_TARGET_TIME),
+  lastSocGoal: readNumber(LAST_SOC_GOAL),
+  lastEnergyGoal: readNumber(LAST_ENERGY_GOAL),
 });
 
 watch(() => settings.locale, save(SETTINGS_LOCALE));
@@ -162,6 +177,9 @@ watch(() => settings.sessionsType, save(SESSIONS_TYPE));
 watch(() => settings.solarAdjusted, saveBool(SETTINGS_SOLAR_ADJUSTED));
 watch(() => settings.loadpoints, saveJSON(LOADPOINTS), { deep: true });
 watch(() => settings.lastBatterySmartCostLimit, saveNumber(LAST_BATTERY_SMART_COST_LIMIT));
+watch(() => settings.lastTargetTime, saveString(LAST_TARGET_TIME));
+watch(() => settings.lastSocGoal, saveNumber(LAST_SOC_GOAL));
+watch(() => settings.lastEnergyGoal, saveNumber(LAST_ENERGY_GOAL));
 
 export default settings;
 

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -25,7 +25,7 @@ const LAST_TARGET_TIME = "last_target_time";
 const LAST_SOC_GOAL = "last_soc_goal";
 const LAST_ENERGY_GOAL = "last_energy_goal";
 
-function read(key: string): string | null {
+function read(key: string) {
   return window.localStorage[key];
 }
 


### PR DESCRIPTION
I noticed that you could have 1 percentage in the charging goal twice.

<img width="203" height="78" alt="image" src="https://github.com/user-attachments/assets/7e746663-0e5c-4e90-aaa4-38b161ef25fd" />

**Steps to reproduce**
* Disable your (not repeating) plan, by toggling the Active
* Reload your browser window
* Open the charging plan modal
* Open the **Charging goal** list
<img width="892" height="311" alt="image" src="https://github.com/user-attachments/assets/f8fa9695-6a03-498a-9cd0-09a94dac6ac6" />
