### PR TITLE
Zaptec: fix password quoting

### DIFF
--- a/templates/definition/charger/zaptec.yaml
+++ b/templates/definition/charger/zaptec.yaml
@@ -32,5 +32,5 @@ render: |
   type: zaptec
   id: {{ .id }}
   user: {{ .user }}
-  password: '{{ .password }}'
+  password: {{ .password }}
   passive: {{ .passive }}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/26509

The password value in the Zaptec render block was quoted. This is unnecessary and leads to side-effects since the actual values are already quoted before.

Also checked other templates for the same effect. All look fine. @johannrichard you seem to have found the only odd one 😄.