### PR TITLE
Planner: fix repeating overrun

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -153,7 +153,7 @@ type Loadpoint struct {
 	planActive       bool             // charge plan exists and has a currently active slot
 	planOverrunSent  bool             // notification has been sent already
 	planLockedTime   time.Time        // locked plan target time (committed goal, persists during overrun)
-	planLockedSoc    int              // locked plan target soc (0 if not soc-based)
+	planLockedSoc    int              // locked plan target soc
 	planLockedId     int              // locked plan id (0=none, 1=static, 2+=repeating), needed to highlight the plan in ui
 
 	// cached state

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -537,7 +537,7 @@ func (lp *Loadpoint) evVehicleDisconnectHandler() {
 	lp.clearSession()
 
 	// clear locked plan goal on disconnect
-	lp.clearPlanLocks()
+	lp.clearPlanLock()
 
 	// phases are unknown when vehicle disconnects
 	lp.ResetMeasuredPhases()

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -152,9 +152,7 @@ type Loadpoint struct {
 	planSlotEnd      time.Time        // current plan slot end time
 	planActive       bool             // charge plan exists and has a currently active slot
 	planOverrunSent  bool             // notification has been sent already
-	planLockedTime   time.Time        // locked plan target time (committed goal, persists during overrun)
-	planLockedSoc    int              // locked plan target soc
-	planLockedId     int              // locked plan id (0=none, 1=static, 2+=repeating), needed to highlight the plan in ui
+	planLocked       PlanLock         // locked plan
 
 	// cached state
 	status         api.ChargeStatus // Charger status

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -121,6 +121,8 @@ type API interface {
 	GetPlanEnergy() (time.Time, float64)
 	// SetPlanEnergy sets the charge plan energy
 	SetPlanEnergy(time.Time, float64) error
+	// ClearPlanLocks clears the locked plan goal
+	ClearPlanLocks()
 	// GetPlanGoal returns the plan goal and if the goal is soc based
 	GetPlanGoal() (float64, bool)
 	// GetPlanRequiredDuration returns required duration of plan to reach the goal from current state

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -121,8 +121,8 @@ type API interface {
 	GetPlanEnergy() (time.Time, float64)
 	// SetPlanEnergy sets the charge plan energy
 	SetPlanEnergy(time.Time, float64) error
-	// ClearPlanLocks clears the locked plan goal
-	ClearPlanLocks()
+	// ClearPlanLock clears the locked plan goal
+	ClearPlanLock()
 	// GetPlanGoal returns the plan goal and if the goal is soc based
 	GetPlanGoal() (float64, bool)
 	// GetPlanRequiredDuration returns required duration of plan to reach the goal from current state

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -55,6 +55,18 @@ func (mr *MockAPIMockRecorder) ActivePhases() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivePhases", reflect.TypeOf((*MockAPI)(nil).ActivePhases))
 }
 
+// ClearPlanLock mocks base method.
+func (m *MockAPI) ClearPlanLock() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ClearPlanLock")
+}
+
+// ClearPlanLock indicates an expected call of ClearPlanLock.
+func (mr *MockAPIMockRecorder) ClearPlanLock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearPlanLock", reflect.TypeOf((*MockAPI)(nil).ClearPlanLock))
+}
+
 // EffectiveLimitSoc mocks base method.
 func (m *MockAPI) EffectiveLimitSoc() int {
 	m.ctrl.T.Helper()

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -356,6 +356,9 @@ func (lp *Loadpoint) getPlanEnergy() (time.Time, float64) {
 
 // setPlanEnergy sets plan target energy (no mutex)
 func (lp *Loadpoint) setPlanEnergy(finishAt time.Time, energy float64) {
+	// clear locked goal when energy plan changes
+	lp.clearPlanLocks()
+
 	lp.planEnergy = energy
 	lp.publish(keys.PlanEnergy, energy)
 	lp.settings.SetFloat(keys.PlanEnergy, energy)

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -357,7 +357,7 @@ func (lp *Loadpoint) getPlanEnergy() (time.Time, float64) {
 // setPlanEnergy sets plan target energy (no mutex)
 func (lp *Loadpoint) setPlanEnergy(finishAt time.Time, energy float64) {
 	// clear locked goal when energy plan changes
-	lp.clearPlanLocks()
+	lp.clearPlanLock()
 
 	lp.planEnergy = energy
 	lp.publish(keys.PlanEnergy, energy)

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -61,15 +61,15 @@ func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {
 	return nil
 }
 
-// NextVehiclePlan returns the next vehicle plan time, soc and id
-func (lp *Loadpoint) NextVehiclePlan() (time.Time, int, int) {
-	lp.RLock()
-	defer lp.RUnlock()
-	return lp.nextVehiclePlan()
-}
-
 // nextVehiclePlan returns the next vehicle plan time, soc, id
+// Returns locked plan if available, otherwise calculates fresh
 func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
+	// return locked plan if available
+	if lp.planLockedId > 0 && lp.socBasedPlanning() {
+		return lp.planLockedTime, lp.planLockedSoc, lp.planLockedId
+	}
+
+	// calculate fresh plan
 	if v := lp.GetVehicle(); v != nil {
 		var plans []plan
 
@@ -101,33 +101,43 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 	return time.Time{}, 0, 0
 }
 
-// EffectivePlanSoc returns the soc target for the current plan
-func (lp *Loadpoint) EffectivePlanSoc() int {
-	_, soc, _ := lp.NextVehiclePlan()
-	return soc
-}
-
-// EffectivePlanId returns the id for the current plan
-func (lp *Loadpoint) EffectivePlanId() int {
+// getPlanId returns the plan id of the current/next plan
+func (lp *Loadpoint) getPlanId() int {
 	if lp.socBasedPlanning() {
-		_, _, id := lp.NextVehiclePlan()
+		_, _, id := lp.nextVehiclePlan()
 		return id
 	}
 	if lp.planEnergy > 0 {
 		return 1
 	}
-	// no plan
 	return 0
+}
+
+// EffectivePlanSoc returns the soc target for the current plan
+func (lp *Loadpoint) EffectivePlanSoc() int {
+	lp.RLock()
+	defer lp.RUnlock()
+	_, soc, _ := lp.nextVehiclePlan()
+	return soc
+}
+
+// EffectivePlanId returns the id for the current plan
+func (lp *Loadpoint) EffectivePlanId() int {
+	lp.RLock()
+	defer lp.RUnlock()
+	return lp.getPlanId()
 }
 
 // EffectivePlanTime returns the effective plan time
 func (lp *Loadpoint) EffectivePlanTime() time.Time {
+	lp.RLock()
+	defer lp.RUnlock()
 	if lp.socBasedPlanning() {
-		ts, _, _ := lp.NextVehiclePlan()
+		ts, _, _ := lp.nextVehiclePlan()
 		return ts
 	}
 
-	ts, _ := lp.GetPlanEnergy()
+	ts, _ := lp.getPlanEnergy()
 	return ts
 }
 

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -65,7 +65,7 @@ func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {
 // Returns locked plan if available, otherwise calculates fresh
 func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 	// return locked plan if available
-	if lp.planLockedId > 0 && lp.socBasedPlanning() {
+	if lp.planLockedId > 0 {
 		return lp.planLockedTime, lp.planLockedSoc, lp.planLockedId
 	}
 

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -101,6 +101,14 @@ func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 	return time.Time{}, 0, 0
 }
 
+// EffectivePlanSoc returns the soc target for the current plan
+func (lp *Loadpoint) EffectivePlanSoc() int {
+	lp.RLock()
+	defer lp.RUnlock()
+	_, soc, _ := lp.nextVehiclePlan()
+	return soc
+}
+
 // getPlanId returns the plan id of the current/next plan
 func (lp *Loadpoint) getPlanId() int {
 	if lp.socBasedPlanning() {
@@ -111,14 +119,6 @@ func (lp *Loadpoint) getPlanId() int {
 		return 1
 	}
 	return 0
-}
-
-// EffectivePlanSoc returns the soc target for the current plan
-func (lp *Loadpoint) EffectivePlanSoc() int {
-	lp.RLock()
-	defer lp.RUnlock()
-	_, soc, _ := lp.nextVehiclePlan()
-	return soc
 }
 
 // EffectivePlanId returns the id for the current plan

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -65,8 +65,8 @@ func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {
 // Returns locked plan if available, otherwise calculates fresh
 func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
 	// return locked plan if available
-	if lp.planLockedId > 0 {
-		return lp.planLockedTime, lp.planLockedSoc, lp.planLockedId
+	if p := lp.planLocked; p.Id > 0 {
+		return p.Time, p.Soc, p.Id
 	}
 
 	// calculate fresh plan

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -13,18 +13,18 @@ import (
 
 // TODO planActive is not guarded by mutex
 
-// clearPlanLocks clears the locked plan goal (internal)
-func (lp *Loadpoint) clearPlanLocks() {
+// clearPlanLock clears the locked plan goal
+func (lp *Loadpoint) clearPlanLock() {
 	lp.planLockedTime = time.Time{}
 	lp.planLockedSoc = 0
 	lp.planLockedId = 0
 }
 
-// ClearPlanLocks clears the locked plan goal (public API)
-func (lp *Loadpoint) ClearPlanLocks() {
+// ClearPlanLock clears the locked plan goal
+func (lp *Loadpoint) ClearPlanLock() {
 	lp.Lock()
 	defer lp.Unlock()
-	lp.clearPlanLocks()
+	lp.clearPlanLock()
 }
 
 // lockPlanGoal locks the current plan goal to handle overruns (soc-based plans)
@@ -39,7 +39,7 @@ func (lp *Loadpoint) setPlanActive(active bool) {
 	if !active {
 		lp.planOverrunSent = false
 		lp.planSlotEnd = time.Time{}
-		lp.clearPlanLocks()
+		lp.clearPlanLock()
 	}
 	if lp.planActive != active {
 		lp.planActive = active

--- a/core/site.go
+++ b/core/site.go
@@ -500,7 +500,7 @@ func (site *Site) Publish(key string, val any) {
 // clearPlanLocks clears locked plan goals for all loadpoints
 func (site *Site) clearPlanLocks() {
 	for _, lp := range site.Loadpoints() {
-		lp.ClearPlanLocks()
+		lp.ClearPlanLock()
 	}
 }
 

--- a/core/site.go
+++ b/core/site.go
@@ -497,6 +497,13 @@ func (site *Site) Publish(key string, val any) {
 	site.publish(key, val)
 }
 
+// clearPlanLocks clears locked plan goals for all loadpoints
+func (site *Site) clearPlanLocks() {
+	for _, lp := range site.Loadpoints() {
+		lp.ClearPlanLocks()
+	}
+}
+
 func (site *Site) collectMeters(key string, meters []config.Device[api.Meter]) []measurement {
 	mm := make([]measurement, len(meters))
 
@@ -1051,6 +1058,7 @@ func (site *Site) prepare() {
 	site.publishVehicles()
 	site.publishTariffs(0, 0)
 	vehicle.Publish = site.publishVehicles
+	vehicle.ClearPlanLocks = site.clearPlanLocks
 }
 
 // Prepare attaches communication channels to site and loadpoints

--- a/core/vehicle/adapter.go
+++ b/core/vehicle/adapter.go
@@ -109,7 +109,7 @@ func (v *adapter) SetPlanSoc(ts time.Time, soc int) error {
 	settings.SetTime(v.key()+keys.PlanTime, ts)
 	settings.SetInt(v.key()+keys.PlanSoc, int64(soc))
 
-	// note: could be optimized my only clearing plan lock of the relevent loadpoint
+	// note: could be optimized by only clearing plan lock of the relevant loadpoint
 	v.clearPlanLocks()
 
 	v.publish()
@@ -138,7 +138,7 @@ func (v *adapter) SetRepeatingPlans(plans []api.RepeatingPlan) error {
 
 	v.log.DEBUG.Printf("update repeating plans for %s to: %v", v.name, plans)
 
-	// note: could be optimized my only clearing plan lock of the relevent loadpoint
+	// note: could be optimized by only clearing plan lock of the relevant loadpoint
 	v.clearPlanLocks()
 
 	v.publish()

--- a/core/vehicle/adapter.go
+++ b/core/vehicle/adapter.go
@@ -16,6 +16,9 @@ var _ API = (*adapter)(nil)
 // Publish publishes vehicle updates at site level
 var Publish func()
 
+// ClearPlanLocks clears locked plan goals across all loadpoints
+var ClearPlanLocks func()
+
 type adapter struct {
 	log         *util.Logger
 	name        string
@@ -29,6 +32,12 @@ func (v *adapter) key() string {
 func (v *adapter) publish() {
 	if Publish != nil {
 		Publish()
+	}
+}
+
+func (v *adapter) clearPlanLocks() {
+	if ClearPlanLocks != nil {
+		ClearPlanLocks()
 	}
 }
 
@@ -100,6 +109,9 @@ func (v *adapter) SetPlanSoc(ts time.Time, soc int) error {
 	settings.SetTime(v.key()+keys.PlanTime, ts)
 	settings.SetInt(v.key()+keys.PlanSoc, int64(soc))
 
+	// note: could be optimized my only clearing plan lock of the relevent loadpoint
+	v.clearPlanLocks()
+
 	v.publish()
 
 	return nil
@@ -125,6 +137,10 @@ func (v *adapter) SetRepeatingPlans(plans []api.RepeatingPlan) error {
 	}
 
 	v.log.DEBUG.Printf("update repeating plans for %s to: %v", v.name, plans)
+
+	// note: could be optimized my only clearing plan lock of the relevent loadpoint
+	v.clearPlanLocks()
+
 	v.publish()
 
 	return nil


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/24339

Fixes issue where repeating SOC-based plans prematurely switch to the next plan (e.g. wrap to next day) when charging takes longer than the initial time.

🔐 added a locking/unlocking mechanism for time/soc/id
🔓 remove lock on vehicle disconnect, plan finish and user interaction (vehicle plan change)
🚗 only active for soc based vehicle charging

**TODO**

- [x] add unit tests
- [x] manual tests
- [x] verify/add mutex usage @andig 