### PR TITLE
Config UI: rename HEMS

### DIFF
--- a/assets/js/components/Config/defaultYaml/hems.yaml
+++ b/assets/js/components/Config/defaultYaml/hems.yaml
@@ -1,4 +1,4 @@
-## external control via digital signal
+## external control via relay
 
 #type: relay
 #maxPower: 4200 # limit loadpoints to 4.2 kW total
@@ -6,7 +6,7 @@
 #  source: mqtt
 #  topic: hems/limit/status # 0/false = normal, 1/true = limit active
 
-## external control via EEBus protocol
+## external control via EEBus
 
 #type: eebus # general EEBus setup (cert gen) required
 #ski: "1234-5678-90AB-CDEF" # SKI of control box (grid operator)

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -243,11 +243,11 @@
         "limitpower": "Limit (kW)",
         "type": "Typ"
       },
-      "description": "Leistungsbegrenzung durch externe Systeme (bspw. Steuerboxen, § 14a EnWG). Setzt Lastmanagementkonfiguration voraus.",
+      "description": "Leistungsbegrenzung durch externe Systeme (z.B. §14a EnWG, §9 EEG Schnittstelle oder übergeordnetes Energiemanagementsystem). Spielt mit dem Lastmanagement Feature zusammen.",
       "downloadCsv": "CSV herunterladen",
       "eventsRecorded": "{count} Netzbegrenzungen gespeichert.",
       "lastEvent": "Zuletzt {timeAgo}.",
-      "title": "HEMS",
+      "title": "Externe Begrenzung",
       "yamlConfigured": "Hinweis: Konfiguriert über evcc.yaml. Entferne den Eintrag aus der Datei, um die Bearbeitung hier zu aktivieren."
     },
     "icon": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -243,11 +243,11 @@
         "limitpower": "Limit (kW)",
         "type": "Type"
       },
-      "description": "Power limitation by external systems (e.g. EnWG 14a controllers). Requires load management configuration.",
+      "description": "Power limitation by external systems (e.g. §14a EnWG, §9 EEG interface or higher-level energy management system). Works together with the load management feature.",
       "downloadCsv": "Download CSV",
       "eventsRecorded": "Recorded {count} grid limitation events.",
       "lastEvent": "Most recent {timeAgo}.",
-      "title": "HEMS",
+      "title": "External Limit",
       "yamlConfigured": "Note: Configured via evcc.yaml. Remove the entry from the file to enable editing here."
     },
     "icon": {

--- a/tests/hems.spec.ts
+++ b/tests/hems.spec.ts
@@ -120,7 +120,7 @@ limit:
 
     // verify circuits
     await expect(page.getByTestId("circuits")).toContainText(
-      ["HEMS (lpc)", "Power", "0.0 kW"].join("")
+      ["External Limit (lpc)", "Power", "0.0 kW"].join("")
     );
 
     // enable hems in simulator
@@ -132,7 +132,7 @@ limit:
     // verify config ui
     await page.goto("/#/config");
     await expect(page.getByTestId("circuits")).toContainText(
-      ["HEMS (lpc)", "Power", "0.0 kW / 4.2 kW"].join("")
+      ["External Limit (lpc)", "Power", "0.0 kW / 4.2 kW"].join("")
     );
 
     // verify main ui


### PR DESCRIPTION
Wording: Use `External Limit` instead of `HEMS` to avoid confusion: evcc == hems, other hems?

Improved the descriptions text: Added §9 EEG and higher-order EMS. Replaced "requires load management" with "works together".

<img width="445" height="259" alt="Bildschirmfoto 2026-01-08 um 16 25 49" src="https://github.com/user-attachments/assets/1044f1f4-5ea7-4643-96bd-0ac2d7d51c8b" />

<img width="951" height="282" alt="Bildschirmfoto 2026-01-08 um 16 26 02" src="https://github.com/user-attachments/assets/fab51071-6878-4876-92a5-2534ed6b2012" />
