### PR TITLE
fix: Shelly TopAC - missing charger status (#26520)

### DIFF
--- a/charger/shelly-topac.go
+++ b/charger/shelly-topac.go
@@ -139,7 +139,7 @@ func (c *ShellyTopAC) Status() (api.ChargeStatus, error) {
 	switch res.Result.Value {
 	case "charger_free":
 		return api.StatusA, nil
-	case "charger_wait", "charger_pause", "charger_complete":
+	case "charger_wait", "charger_pause", "charger_complete", "charger_end":
 		return api.StatusB, nil
 	case "charger_charging":
 		return api.StatusC, nil


### PR DESCRIPTION
https://github.com/evcc-io/evcc/pull/26520 got merged too early, so it still contains some bugs. This fixes one of them.

From the logs:

```
[lp-1  ] WARN 2026/01/10 18:44:43 charger out of sync: expected disabled, got enabled
[lp-1  ] WARN 2026/01/10 18:45:44 charger out of sync: expected disabled, got enabled
[lp-1  ] ERROR 2026/01/10 18:46:13 charger status: unknown work state: charger_end
```