### PR TITLE
Add support for the Ratio Solar

### DIFF
--- a/templates/definition/charger/ocpp-ratio-solar.yaml
+++ b/templates/definition/charger/ocpp-ratio-solar.yaml
@@ -1,0 +1,24 @@
+template: ocpp-ratio-solar
+products:
+  - brand: Ratio
+    description:
+      generic: Solar
+capabilities: ["mA"]
+requirements:
+  description:
+    en: |
+      This charger only supports OCPP over secure websockets (wss://) with a signed certificate. To integrate it into evcc you'll need to setup a proxy that is capable of proxying websockets using SSL (such as nginx). Setting up OCPP is done in the Ratio app:
+
+      * Go to "Charger settings" -> "Advanced settings" -> "OCPP settings"
+      * Go to "Charge Point Operator" and select "Custom"
+      * Url: wss://[proxy-domain]
+      * Save and turn on OCPP, the CPID can be used as station id
+  evcc: ["sponsorship", "skiptest"]
+params:
+  - preset: ocpp
+  - name: metervalues
+    default: -SoC,Current.Offered,Power.Offered,Voltage,Current.Import
+render: |
+  {{ include "ocpp" . }}
+  remotestart: true
+  stacklevelzero: true

--- a/templates/definition/charger/ocpp-ratio-solar.yaml
+++ b/templates/definition/charger/ocpp-ratio-solar.yaml
@@ -16,8 +16,6 @@ requirements:
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp
-  - name: metervalues
-    default: -SoC,Current.Offered,Power.Offered,Voltage,Current.Import
 render: |
   {{ include "ocpp" . }}
   remotestart: true


### PR DESCRIPTION
I've got my [Ratio Solar charger](https://www.ratio.nl/nl/producten/laadpalen/laadpalen/laadpaal-ratio-solar/groups/g+c+a+view) to work with evcc. Ratio chargers require a wss:// endpoint with a valid certificate. I managed to do this by proxying the evcc OCPP websocket through nginx with a letsencrypt certificate.

I'm not sure if the requirement for wss:// means the charger is not supported by evcc, but in case this is not an issue, the template for the charger is in this pull request.

I have not included the German translation yet as I can't write German, but if someone can supply a translation I'll include it.