### PR TITLE
fix gradient overrun

### DIFF
--- a/core/planner/planner.go
+++ b/core/planner/planner.go
@@ -102,6 +102,7 @@ func (t *Planner) Plan(requiredDuration, precondition time.Duration, targetTime 
 	now := t.clock.Now().Truncate(time.Second)
 
 	latestStart := targetTime.Add(-requiredDuration)
+	originalTargetTime := targetTime
 	if latestStart.Before(now) {
 		latestStart = now
 		targetTime = latestStart.Add(requiredDuration)
@@ -127,8 +128,8 @@ func (t *Planner) Plan(requiredDuration, precondition time.Duration, targetTime 
 		return simplePlan
 	}
 
-	// consume remaining time
-	if t.clock.Until(targetTime) <= requiredDuration {
+	// consume remaining time until original plan finish time
+	if t.clock.Until(originalTargetTime) <= requiredDuration {
 		return continuousPlan(rates, latestStart, targetTime)
 	}
 


### PR DESCRIPTION
I’ve analyzed https://github.com/evcc-io/evcc/discussions/26676 and likely related issues. It appears that the targetTime can shift. Since this timestamp is used to trigger an emergency plan (simple continuous), the condition may fail by several minutes when gradient corrections occur.

It’s important to note that at this point we are already past the originally planned completion time.