### PR TITLE
fix missing modbus defaults in validation request

### DIFF
--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -351,7 +351,12 @@ export default defineComponent({
 			return requirements?.EVCC?.includes("sponsorship") && !this.isSponsor;
 		},
 		apiData(): ApiData {
+			// Filter out undefined values from modbusDefaults
+			const filteredModbusDefaults = Object.fromEntries(
+				Object.entries(this.modbusDefaults).filter(([, value]) => value !== undefined)
+			);
 			let data: ApiData = {
+				...filteredModbusDefaults,
 				...this.values,
 			};
 			if (this.values.type === ConfigType.Template && this.templateName) {

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -351,12 +351,8 @@ export default defineComponent({
 			return requirements?.EVCC?.includes("sponsorship") && !this.isSponsor;
 		},
 		apiData(): ApiData {
-			// Filter out undefined values from modbusDefaults
-			const filteredModbusDefaults = Object.fromEntries(
-				Object.entries(this.modbusDefaults).filter(([, value]) => value !== undefined)
-			);
 			let data: ApiData = {
-				...filteredModbusDefaults,
+				...this.modbusDefaults,
 				...this.values,
 			};
 			if (this.values.type === ConfigType.Template && this.templateName) {

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -352,7 +352,6 @@ export default defineComponent({
 		},
 		apiData(): ApiData {
 			let data: ApiData = {
-				...this.modbusDefaults,
 				...this.values,
 			};
 			if (this.values.type === ConfigType.Template && this.templateName) {

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -352,6 +352,7 @@ export default defineComponent({
 		},
 		apiData(): ApiData {
 			let data: ApiData = {
+				...this.modbusDefaults,
 				...this.values,
 			};
 			if (this.values.type === ConfigType.Template && this.templateName) {

--- a/tests/config-param-service-modbus.spec.ts
+++ b/tests/config-param-service-modbus.spec.ts
@@ -77,11 +77,8 @@ test.describe("modbus service expansion", async () => {
     const requestPromise = page.waitForRequest(
       (req) => req.url().includes("/api/config/test/meter") && req.method() === "POST"
     );
-
     await meterModal.getByRole("button", { name: "Save" }).click();
-
-    const request = await requestPromise;
-    const body = request.postDataJSON();
+    const body = (await requestPromise).postDataJSON();
 
     // Template has id: 2 - verify it's included even though user didn't set it
     expect(body.id).toBe(2);

--- a/tests/config-param-service-modbus.spec.ts
+++ b/tests/config-param-service-modbus.spec.ts
@@ -74,8 +74,8 @@ test.describe("modbus service expansion", async () => {
     await meterModal.getByLabel("Test value").fill("test");
 
     // Intercept validation POST request
-    const requestPromise = page.waitForRequest((req) =>
-      req.url().includes("/api/config/test/meter") && req.method() === "POST"
+    const requestPromise = page.waitForRequest(
+      (req) => req.url().includes("/api/config/test/meter") && req.method() === "POST"
     );
 
     await meterModal.getByRole("button", { name: "Save" }).click();


### PR DESCRIPTION
recent modbus UI changes broke the population of initial template values for validation and persisting on configure

follow-up on #25908