### PR TITLE
Add ADA P1 meter

### DIFF
--- a/templates/definition/meter/ada-p1-meter.yaml
+++ b/templates/definition/meter/ada-p1-meter.yaml
@@ -1,0 +1,55 @@
+template: ada-p1-meter
+products:
+  - brand: ADA
+    description: P1 Meter
+params:
+  - name: host
+    default: okosvillanyora.local:8989
+render: |
+  type: custom
+  power:
+    source: http
+    uri: http://{{ .host }}/json
+    method: GET
+    timeout: 5s
+    # Power (Watt): Calculated from Import - Export * 1000
+    jq: (.instantaneous_power_import | tonumber * 1000) - (.instantaneous_power_export | tonumber * 1000)
+  energy:
+    source: http
+    uri: http://{{ .host }}/json
+    method: GET
+    timeout: 5s
+    # Total Import Energy (kWh)
+    jq: .active_import_energy_total | tonumber
+  currents:
+    - source: http
+      uri: http://{{ .host }}/json
+      method: GET
+      timeout: 5s
+      jq: .current_phase_Bl1 | tonumber
+    - source: http
+      uri: http://{{ .host }}/json
+      method: GET
+      timeout: 5s
+      jq: .current_phase_Bl2 | tonumber
+    - source: http
+      uri: http://{{ .host }}/json
+      method: GET
+      timeout: 5s
+      jq: .current_phase_Bl3 | tonumber
+  voltages:
+    - source: http
+      uri: http://{{ .host }}/json
+      method: GET
+      timeout: 5s
+      jq: .voltage_phase_l1 | tonumber
+    - source: http
+      uri: http://{{ .host }}/json
+      method: GET
+      timeout: 5s
+      jq: .voltage_phase_l2 | tonumber
+    - source: http
+      uri: http://{{ .host }}/json
+      method: GET
+      timeout: 5s
+      jq: .voltage_phase_l3 | tonumber

--- a/templates/definition/meter/ada-p1-meter.yaml
+++ b/templates/definition/meter/ada-p1-meter.yaml
@@ -5,51 +5,53 @@ products:
 params:
   - name: host
     default: okosvillanyora.local:8989
+  - name: cache
+    default: 1s
 render: |
   type: custom
   power:
     source: http
     uri: http://{{ .host }}/json
     method: GET
-    timeout: 5s
+    cache: {{ .cache }}
     # Power (Watt): Calculated from Import - Export * 1000
     jq: (.instantaneous_power_import | tonumber * 1000) - (.instantaneous_power_export | tonumber * 1000)
   energy:
     source: http
     uri: http://{{ .host }}/json
     method: GET
-    timeout: 5s
+    cache: {{ .cache }}
     # Total Import Energy (kWh)
     jq: .active_import_energy_total | tonumber
   currents:
     - source: http
       uri: http://{{ .host }}/json
       method: GET
-      timeout: 5s
+      cache: {{ .cache }}
       jq: .current_phase_Bl1 | tonumber
     - source: http
       uri: http://{{ .host }}/json
       method: GET
-      timeout: 5s
+      cache: {{ .cache }}
       jq: .current_phase_Bl2 | tonumber
     - source: http
       uri: http://{{ .host }}/json
       method: GET
-      timeout: 5s
+      cache: {{ .cache }}
       jq: .current_phase_Bl3 | tonumber
   voltages:
     - source: http
       uri: http://{{ .host }}/json
       method: GET
-      timeout: 5s
+      cache: {{ .cache }}
       jq: .voltage_phase_l1 | tonumber
     - source: http
       uri: http://{{ .host }}/json
       method: GET
-      timeout: 5s
+      cache: {{ .cache }}
       jq: .voltage_phase_l2 | tonumber
     - source: http
       uri: http://{{ .host }}/json
       method: GET
-      timeout: 5s
+      cache: {{ .cache }}
       jq: .voltage_phase_l3 | tonumber

--- a/templates/definition/meter/ada-p1-meter.yaml
+++ b/templates/definition/meter/ada-p1-meter.yaml
@@ -2,7 +2,7 @@ template: ada-p1-meter
 products:
   - brand: ADA
     description:
-      generic: P1
+      generic: P1 Meter
 params:
   - name: host
     default: okosvillanyora.local:8989

--- a/templates/definition/meter/ada-p1-meter.yaml
+++ b/templates/definition/meter/ada-p1-meter.yaml
@@ -1,7 +1,8 @@
 template: ada-p1-meter
 products:
   - brand: ADA
-    description: P1
+    description:
+      generic: P1
 params:
   - name: host
     default: okosvillanyora.local:8989

--- a/templates/definition/meter/ada-p1-meter.yaml
+++ b/templates/definition/meter/ada-p1-meter.yaml
@@ -1,7 +1,7 @@
 template: ada-p1-meter
 products:
   - brand: ADA
-    description: P1 Meter
+    description: P1
 params:
   - name: host
     default: okosvillanyora.local:8989


### PR DESCRIPTION
This PR adds support for the ADA P1 Meter (smart meter interface).
The device provides a JSON output over HTTP.

- **Manufacturer:** GREENHESS
- **Communication:** HTTP / LAN
- **Tested:** Yes, tested with physical device on Windows environment (see attached screenshot in comments if needed).
- **Notes:** Logic handles import/export calculation correctly using jq.

Configuration example:
meters:
  - name: grid
    template: ada-p1-meter
    host: okosvillanyora.local:8989