### PR TITLE
tariff/octopus: Support new-format 40-character API keys

### DIFF
--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -97,9 +97,9 @@ func buildOctopusFromConfig(other map[string]any) (*Octopus, error) {
 		if cc.Region != "" || cc.Tariff != "" {
 			return nil, errors.New("cannot use apikey at same time as product code")
 		}
-		// We permit the specific special apiKey "test" as sk_live_ keys are considered Stripe secrets by Github
-		// Keys can be either 32 or 40 characters long
-		if cc.ApiKey != "test" && ((len(cc.ApiKey) != 32 && len(cc.ApiKey) != 40) || !strings.HasPrefix(cc.ApiKey, "sk_live_")) {
+		// We permit the special "oe_test_" key prefix as sk_live_ keys are considered Stripe secrets by GitHub
+		// Keys are either 32 or 40 characters long
+		if (len(cc.ApiKey) != 32 && len(cc.ApiKey) != 40) || (!strings.HasPrefix(cc.ApiKey, "sk_live_") && !strings.HasPrefix(cc.ApiKey, "oe_test_")) {
 			return nil, errors.New("invalid apikey format")
 		}
 	}

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -98,7 +98,8 @@ func buildOctopusFromConfig(other map[string]any) (*Octopus, error) {
 			return nil, errors.New("cannot use apikey at same time as product code")
 		}
 		// We permit the specific special apiKey "test" as sk_live_ keys are considered Stripe secrets by Github
-		if cc.ApiKey != "test" && (len(cc.ApiKey) != 32 || !strings.HasPrefix(cc.ApiKey, "sk_live_")) {
+		// Keys can be either 32 or 40 characters long
+		if cc.ApiKey != "test" && ((len(cc.ApiKey) != 32 && len(cc.ApiKey) != 40) || !strings.HasPrefix(cc.ApiKey, "sk_live_")) {
 			return nil, errors.New("invalid apikey format")
 		}
 	}

--- a/tariff/octopus_test.go
+++ b/tariff/octopus_test.go
@@ -10,6 +10,9 @@ import (
 func TestOctopusConfigParse(t *testing.T) {
 	test.SkipCI(t)
 
+	validTestApiKey32 := "oe_test_testingYqLeoRu2xsn9WEiv6"
+	validTestApiKey40 := "oe_test_testingYBsFMxfqXG9guAdTVgFssdJmv"
+
 	// This test will start failing if you remove the deprecated "tariff" config var.
 	validTariffConfig := map[string]any{
 		"region":      "H",
@@ -40,15 +43,22 @@ func TestOctopusConfigParse(t *testing.T) {
 
 	invalidTariffDirectionConfig := map[string]any{
 		"tariffDirection": "invalid",
-		"apikey":          "test",
+		"apikey":          validTestApiKey32,
 	}
 	_, err = buildOctopusFromConfig(invalidTariffDirectionConfig)
 	require.Errorf(t, err, "invalid tariff type")
 
-	validApiExportConfig := map[string]any{
+	validApiExportConfig32 := map[string]any{
 		"tariffDirection": "export",
-		"apikey":          "test",
+		"apikey":          validTestApiKey32,
 	}
-	_, err = buildOctopusFromConfig(validApiExportConfig)
+	_, err = buildOctopusFromConfig(validApiExportConfig32)
+	require.NoError(t, err)
+
+	validApiExportConfig40 := map[string]any{
+		"tariffDirection": "export",
+		"apikey":          validTestApiKey40,
+	}
+	_, err = buildOctopusFromConfig(validApiExportConfig40)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
It seems Octopus Energy have switched to now supplying 40-character long API keys for their API - existing 32-character keys seem unaffected.

This PR allows 40-character keys to be set, and adds a test case for such (to do so, I changed the testing key from `test` to `oe_test_[...]`).

Closes #26744
