### PR TITLE
Templates: sort required params first

### DIFF
--- a/templates/definition/meter/demo-meter.yaml
+++ b/templates/definition/meter/demo-meter.yaml
@@ -10,7 +10,6 @@ requirements:
     de: Zu Demonstrationszwecken. Zähler mit festen Werten.
 params:
   - name: usage
-    default: grid
     choice: ["grid", "pv", "aux", "charge"]
   - name: power
     description:

--- a/templates/definition/meter/demo-meter.yaml
+++ b/templates/definition/meter/demo-meter.yaml
@@ -10,6 +10,7 @@ requirements:
     de: Zu Demonstrationszwecken. Zähler mit festen Werten.
 params:
   - name: usage
+    default: grid
     choice: ["grid", "pv", "aux", "charge"]
   - name: power
     description:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -10,10 +10,12 @@ params:
     description:
       de: Verwendung
       en: Usage
+    required: true
   - name: modbus
     description:
       en: Modbus Type
       de: Modbus Typ
+    required: true
   - name: host
     required: true
     description:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -10,7 +10,6 @@ params:
     description:
       de: Verwendung
       en: Usage
-    required: true
   - name: modbus
     description:
       en: Modbus Type

--- a/util/templates/init.go
+++ b/util/templates/init.go
@@ -77,7 +77,7 @@ func fromBytes(b []byte) (Template, error) {
 		TemplateDefinition: definition,
 	}
 
-	for _, f := range []func() error{tmpl.ResolvePresets, tmpl.ResolveGroup, tmpl.UpdateParamsWithDefaults, tmpl.UpdateModbusParamsWithDefaults, tmpl.Validate} {
+	for _, f := range []func() error{tmpl.ResolvePresets, tmpl.ResolveGroup, tmpl.UpdateParamsWithDefaults, tmpl.UpdateModbusParamsWithDefaults, tmpl.SortRequiredParamsFirst, tmpl.Validate} {
 		if err := f(); err != nil {
 			return tmpl, fmt.Errorf("template '%s': %w", tmpl.Template, err)
 		}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -11,7 +11,6 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/samber/lo"
 	"github.com/spf13/cast"
 )
 
@@ -60,14 +59,6 @@ func (t *Template) UpdateModbusParamsWithDefaults() error {
 }
 
 func (t *Template) SortRequiredParamsFirst() error {
-	if t.Template != "sungrow-hybrid" {
-		return nil
-	}
-
-	fmt.Println(lo.Map(t.Params, func(p Param, _ int) string {
-		return p.Name
-	}))
-
 	slices.SortStableFunc(t.Params, func(a, b Param) int {
 		if a.Required && !b.Required {
 			return -1
@@ -78,11 +69,7 @@ func (t *Template) SortRequiredParamsFirst() error {
 		return 0
 	})
 
-	fmt.Println(lo.Map(t.Params, func(p Param, _ int) string {
-		return p.Name
-	}))
-
-	panic(1)
+	return nil
 }
 
 // validate the template (only rudimentary for now)

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/samber/lo"
 	"github.com/spf13/cast"
 )
 
@@ -56,6 +57,32 @@ func (t *Template) UpdateModbusParamsWithDefaults() error {
 
 	t.Params[idx] = modbusParam
 	return nil
+}
+
+func (t *Template) SortRequiredParamsFirst() error {
+	if t.Template != "sungrow-hybrid" {
+		return nil
+	}
+
+	fmt.Println(lo.Map(t.Params, func(p Param, _ int) string {
+		return p.Name
+	}))
+
+	slices.SortStableFunc(t.Params, func(a, b Param) int {
+		if a.Required && !b.Required {
+			return -1
+		}
+		if b.Required && !a.Required {
+			return +1
+		}
+		return 0
+	})
+
+	fmt.Println(lo.Map(t.Params, func(p Param, _ int) string {
+		return p.Name
+	}))
+
+	panic(1)
 }
 
 // validate the template (only rudimentary for now)


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/26773

@naltatis this works but brings other issues, see this sorting for Sungrow:

    [usage modbus maxacpower capacity minsoc maxsoc maxchargepower maxdischargepower]

to

    [maxchargepower maxdischargepower usage modbus maxacpower capacity minsoc maxsoc]