### PR TITLE
Revert "KOSTAL Plenticore (Gen 2): Enables charging while being on hold"

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -97,7 +97,7 @@ render: |
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
-              address: 1040 # Battery max. discharge power limit, absolute [W]
+              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
       - case: 3 # charge

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -9,13 +9,25 @@ covers: ["kostal-plenticore-hw0200"]
 requirements:
   description:
     de: |
-      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die Funktion externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. **_Ist grundsätzlich anwendbar für verschiedene Wechselrichter Generationen (G1/G2/G3)._**
-      **Das Netzladen der Batterie steht mit dieser Vorlage zur Verfügung, ist aktuell jedoch inkompatibel mit wenigen älteren Wechselrichtern - _sorgfältig testen_!**
-      _siehe auch https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore_
+      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die Funktion externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein.
+
+      **Einschränkung:** Im gesperrten Zustand ist keine Ladung der Hausbatterie möglich.
+
+      **Wechselrichter-Generationen:** Grundsätzlich anwendbar für G1/G2/G3
+
+      **Netzladen:** Funktion verfügbar, jedoch mit wenigen älteren Wechselrichtern inkompatibel - _sorgfältig testen_!
+
+      Weitere Informationen: [github.com/evcc-io/evcc/wiki/Kostal-Plenticore](https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore)
     en: |
-      Only a single system may access the inverter! For active battery control, the feature external battery control via modbus must be activated using installer access. **_Can basically be used for various inverter generations (G1/G2/G3)._**
-      **The function for grid charging the battery is available using this template, but is currently incompatible with some older inverters - _test carefully_!**
-      _see also https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore_
+      Only a single system may access the inverter! For active battery control, the feature external battery control via Modbus must be activated using installer access.
+
+      **Limitation:** Battery charging is not possible when locked.
+
+      **Inverter generations:** Can basically be used for G1/G2/G3
+
+      **Grid charging:** Function available, but currently incompatible with some older inverters - _test carefully_!
+
+      Further information: [github.com/evcc-io/evcc/wiki/Kostal-Plenticore](https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore)
 params:
   - name: usage
     choice: ["pv", "battery"]

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -7,11 +7,17 @@ capabilities: ["battery-control"]
 requirements:
   description:
     de: |
-      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die Funktion externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein. 
-      **Das Netzladen der Batterie steht nicht zur Verfügung!** _siehe auch https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore_
+      Nur ein System kann und darf auf den Wechselrichter zugreifen! Für die aktive Batteriesteuerung muss die Funktion externe Batteriesteuerung über Modbus mit dem Handwerkerzugang aktiviert sein.
+
+      **Einschränkung:** Das Netzladen der Batterie steht nicht zur Verfügung!
+
+      Weitere Informationen: [github.com/evcc-io/evcc/wiki/Kostal-Plenticore](https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore)
     en: |
       Only a single system may access the inverter! For active battery control the function external battery control via Modbus must be activated using installer access.
-      **Grid charging is not available!** _see also https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore_
+
+      **Limitation:** Grid charging is not available!
+
+      Further information: [github.com/evcc-io/evcc/wiki/Kostal-Plenticore](https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore)
 params:
   - name: usage
     choice: ["pv", "battery"]


### PR DESCRIPTION
Based on discussions #26709 and probably #25773, 

- reverts evcc-io/evcc#26169, because (grid-)charge to hold continuous to charge the battery

A change from battery mode "charge" to "hold" actually has written to charge power into Register 1034 and starts writing the value 0 in register 1040 which means continued charging and avoidance of discharging.

Same might occur for an edge-case directly after switching to normal: batteryMode normal has written 0 to 1034. Going into hold within 60s is starting to write 0 to register 1040. Because 1034 and 1040 are set the inverter is not able to charge surplus into the battery, discharging is avoided.

This is because we had no reset to internal mode between battery mode transition and the written values remain while being externally controlled. The use of two registers leads into unexpected behavior.

The change restores the limitation where surplus charging is not possible during hold as a required and unwanted limitation.
