### PR TITLE
fix(plenticore): proper set min/maxsoc values

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -99,7 +99,7 @@ render: |
               value: 0
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1034 # Battery charge power (DC) setpoint, absolute [W]
                   type: writemultiple
@@ -109,7 +109,7 @@ render: |
               value: {{ .minsoc }}
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1042 # Minimum SOC [%]
                   type: writemultiple
@@ -119,12 +119,12 @@ render: |
               value: 100
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1044 # Maximum SOC [%]
                   type: writemultiple
                   encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }
-
+         
       - case: 2 # hold
         set:
           source: sequence
@@ -135,7 +135,7 @@ render: |
               value: 0
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1034 # Battery charge power (DC) setpoint, absolute [W]
                   type: writemultiple
@@ -151,7 +151,7 @@ render: |
               value: 100
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1042 # Minimum SOC [%]
                   type: writemultiple
@@ -161,7 +161,7 @@ render: |
               value: 100
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1044 # Maximum SOC [%]
                   type: writemultiple
@@ -176,7 +176,7 @@ render: |
               value: {{ if .maxchargepower }}-{{ .maxchargepower }}{{ end }} # W
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1034 # Battery charge power (DC) setpoint, absolute [W]
                   type: writemultiple
@@ -186,7 +186,7 @@ render: |
               value: {{ .maxsoc }}
               set:
                 source: modbus
-                {{- include "modbus" . | indent 10 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 1044 # Maximum SOC [%]
                   type: writemultiple

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -91,36 +91,98 @@ render: |
       switch:
       - case: 1 # normal
         set:
-          source: const
-          value: 0 # W (set once to reset from forced charge)
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-              type: writemultiple
-              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Immediately stop grid-charging if the mode is switched from
+          # "charge" to "normal"
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Limit min-soc in normal mode to prevent discharge below
+          - source: const
+            value: {{ .minsoc }} 
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1042 # Minimum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Reset max-soc too 100% to allow full-charge via PV
+          - source: const
+            value: 100 
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1044 # Maximum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+
       - case: 2 # hold
         set:
-          source: const
-          value: 0 # W
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 1040 # Battery max. discharge power limit, absolute [W]
-              type: writemultiple
-              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Immediately stop grid-charging if the mode is switched from 
+          # "charge" to "hold"
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Limiting discharge power via register 1040 is not always reliable 
+          # and has side-effects when switching modes. Register 1034 to limit 
+          # via charge power prevents surplus to be charged in hold mode.
+          # Therefor use 100% min-soc limit to stop discharging and ensure 
+          # charging surplus is possible.
+          - source: const
+            value: 100
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1042 # Minimum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Reset max-soc too 100% to allow full-charge via PV
+          - source: const
+            value: 100 
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1044 # Maximum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+
       - case: 3 # charge
         set:
-          source: const
-          value: {{ if .maxchargepower }}-{{ .maxchargepower }}{{ end }} # W
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-              type: writemultiple
-              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Start grid-charging with configured power
+          - source: const
+            value: {{ if .maxchargepower }}-{{ .maxchargepower }}{{ end }} # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Limit grid-charging by configured max soc-limit
+          - source: const
+            value: {{ .maxsoc }} 
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 10 }}
+              register:
+                address: 1044 # Maximum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }} 
+
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -112,7 +112,7 @@ render: |
                 address: 1042 # Minimum SOC [%]
                 type: writemultiple
                 encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-          # Reset max-soc too 100% to allow full-charge via PV
+          # Reset max-soc to 100% to allow full-charge via PV
           - source: const
             value: 100 
             set:
@@ -139,6 +139,8 @@ render: |
           # Limiting discharge power via register 1040 is not always reliable 
           # and has side-effects when switching modes. Register 1034 to limit 
           # via charge power prevents surplus to be charged in hold mode.
+          # Therefore use a 100% min-soc limit to stop discharging and ensure
+          # charging surplus is possible.
           # Therefor use 100% min-soc limit to stop discharging and ensure 
           # charging surplus is possible.
           - source: const

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -123,7 +123,7 @@ render: |
               register:
                 address: 1044 # Maximum SOC [%]
                 type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
 
       - case: 2 # hold
         set:

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -93,104 +93,104 @@ render: |
         set:
           source: sequence
           set:
-            # Immediately stop grid-charging if the mode is switched from
-            # "charge" to "normal"
-            - source: const
-              value: 0
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-            # Limit min-soc in normal mode to prevent discharge below
-            - source: const
-              value: {{ .minsoc }}
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1042 # Minimum SOC [%]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-            # Reset max-soc to 100% to allow full-charge via PV
-            - source: const
-              value: 100
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1044 # Maximum SOC [%]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }
-         
+          # Immediately stop grid-charging if the mode is switched from
+          # "charge" to "normal"
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Limit min-soc in normal mode to prevent discharge below
+          - source: const
+            value: {{ .minsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1042 # Minimum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Reset max-soc to 100% to allow full-charge via PV
+          - source: const
+            value: 100
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1044 # Maximum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }
+
       - case: 2 # hold
         set:
           source: sequence
           set:
-            # Immediately stop grid-charging if the mode is switched from
-            # "charge" to "hold"
-            - source: const
-              value: 0
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-            # Limiting discharge power via register 1040 is not always reliable
-            # and has side-effects when switching modes. Register 1034 to limit
-            # via charge power prevents surplus to be charged in hold mode.
-            # Therefore use a 100% min-soc limit to stop discharging and ensure
-            # charging surplus is possible.
-            # Therefor use 100% min-soc limit to stop discharging and ensure
-            # charging surplus is possible.
-            - source: const
-              value: 100
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1042 # Minimum SOC [%]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-            # Reset max-soc too 100% to allow full-charge via PV
-            - source: const
-              value: 100
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1044 # Maximum SOC [%]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Immediately stop grid-charging if the mode is switched from
+          # "charge" to "hold"
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Limiting discharge power via register 1040 is not always reliable
+          # and has side-effects when switching modes. Register 1034 to limit
+          # via charge power prevents surplus to be charged in hold mode.
+          # Therefore use a 100% min-soc limit to stop discharging and ensure
+          # charging surplus is possible.
+          # Therefor use 100% min-soc limit to stop discharging and ensure
+          # charging surplus is possible.
+          - source: const
+            value: 100
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1042 # Minimum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Reset max-soc too 100% to allow full-charge via PV
+          - source: const
+            value: 100
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1044 # Maximum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
 
       - case: 3 # charge
         set:
           source: sequence
           set:
-            # Start grid-charging with configured power
-            - source: const
-              value: {{ if .maxchargepower }}-{{ .maxchargepower }}{{ end }} # W
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-            # Limit grid-charging by configured max soc-limit
-            - source: const
-              value: {{ .maxsoc }}
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 1044 # Maximum SOC [%]
-                  type: writemultiple
-                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Start grid-charging with configured power
+          - source: const
+            value: {{ if .maxchargepower }}-{{ .maxchargepower }}{{ end }} # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          # Limit grid-charging by configured max soc-limit
+          - source: const
+            value: {{ .maxsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 1044 # Maximum SOC [%]
+                type: writemultiple
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
 
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -104,7 +104,7 @@ render: |
                 encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
           # Limit min-soc in normal mode to prevent discharge below
           - source: const
-            value: {{ .minsoc }} 
+            value: {{ .minsoc }}
             set:
               source: modbus
               {{- include "modbus" . | indent 10 }}
@@ -114,7 +114,7 @@ render: |
                 encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
           # Reset max-soc to 100% to allow full-charge via PV
           - source: const
-            value: 100 
+            value: 100
             set:
               source: modbus
               {{- include "modbus" . | indent 10 }}
@@ -125,7 +125,7 @@ render: |
 
       - case: 2 # hold
         set:
-          # Immediately stop grid-charging if the mode is switched from 
+          # Immediately stop grid-charging if the mode is switched from
           # "charge" to "hold"
           - source: const
             value: 0
@@ -136,12 +136,12 @@ render: |
                 address: 1034 # Battery charge power (DC) setpoint, absolute [W]
                 type: writemultiple
                 encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-          # Limiting discharge power via register 1040 is not always reliable 
-          # and has side-effects when switching modes. Register 1034 to limit 
+          # Limiting discharge power via register 1040 is not always reliable
+          # and has side-effects when switching modes. Register 1034 to limit
           # via charge power prevents surplus to be charged in hold mode.
           # Therefore use a 100% min-soc limit to stop discharging and ensure
           # charging surplus is possible.
-          # Therefor use 100% min-soc limit to stop discharging and ensure 
+          # Therefor use 100% min-soc limit to stop discharging and ensure
           # charging surplus is possible.
           - source: const
             value: 100
@@ -154,7 +154,7 @@ render: |
                 encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
           # Reset max-soc too 100% to allow full-charge via PV
           - source: const
-            value: 100 
+            value: 100
             set:
               source: modbus
               {{- include "modbus" . | indent 10 }}
@@ -177,14 +177,14 @@ render: |
                 encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
           # Limit grid-charging by configured max soc-limit
           - source: const
-            value: {{ .maxsoc }} 
+            value: {{ .maxsoc }}
             set:
               source: modbus
               {{- include "modbus" . | indent 10 }}
               register:
                 address: 1044 # Maximum SOC [%]
                 type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }} 
+                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
 
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -91,100 +91,106 @@ render: |
       switch:
       - case: 1 # normal
         set:
-          # Immediately stop grid-charging if the mode is switched from
-          # "charge" to "normal"
-          - source: const
-            value: 0
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-          # Limit min-soc in normal mode to prevent discharge below
-          - source: const
-            value: {{ .minsoc }}
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1042 # Minimum SOC [%]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-          # Reset max-soc to 100% to allow full-charge via PV
-          - source: const
-            value: 100
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1044 # Maximum SOC [%]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          source: sequence
+          set:
+            # Immediately stop grid-charging if the mode is switched from
+            # "charge" to "normal"
+            - source: const
+              value: 0
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+            # Limit min-soc in normal mode to prevent discharge below
+            - source: const
+              value: {{ .minsoc }}
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1042 # Minimum SOC [%]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+            # Reset max-soc to 100% to allow full-charge via PV
+            - source: const
+              value: 100
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1044 # Maximum SOC [%]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }
 
       - case: 2 # hold
         set:
-          # Immediately stop grid-charging if the mode is switched from
-          # "charge" to "hold"
-          - source: const
-            value: 0
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-          # Limiting discharge power via register 1040 is not always reliable
-          # and has side-effects when switching modes. Register 1034 to limit
-          # via charge power prevents surplus to be charged in hold mode.
-          # Therefore use a 100% min-soc limit to stop discharging and ensure
-          # charging surplus is possible.
-          # Therefor use 100% min-soc limit to stop discharging and ensure
-          # charging surplus is possible.
-          - source: const
-            value: 100
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1042 # Minimum SOC [%]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-          # Reset max-soc too 100% to allow full-charge via PV
-          - source: const
-            value: 100
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1044 # Maximum SOC [%]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          source: sequence
+          set:
+            # Immediately stop grid-charging if the mode is switched from
+            # "charge" to "hold"
+            - source: const
+              value: 0
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+            # Limiting discharge power via register 1040 is not always reliable
+            # and has side-effects when switching modes. Register 1034 to limit
+            # via charge power prevents surplus to be charged in hold mode.
+            # Therefore use a 100% min-soc limit to stop discharging and ensure
+            # charging surplus is possible.
+            # Therefor use 100% min-soc limit to stop discharging and ensure
+            # charging surplus is possible.
+            - source: const
+              value: 100
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1042 # Minimum SOC [%]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+            # Reset max-soc too 100% to allow full-charge via PV
+            - source: const
+              value: 100
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1044 # Maximum SOC [%]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
 
       - case: 3 # charge
         set:
-          # Start grid-charging with configured power
-          - source: const
-            value: {{ if .maxchargepower }}-{{ .maxchargepower }}{{ end }} # W
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-          # Limit grid-charging by configured max soc-limit
-          - source: const
-            value: {{ .maxsoc }}
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 10 }}
-              register:
-                address: 1044 # Maximum SOC [%]
-                type: writemultiple
-                encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          source: sequence
+          set:
+            # Start grid-charging with configured power
+            - source: const
+              value: {{ if .maxchargepower }}-{{ .maxchargepower }}{{ end }} # W
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+            # Limit grid-charging by configured max soc-limit
+            - source: const
+              value: {{ .maxsoc }}
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 10 }}
+                register:
+                  address: 1044 # Maximum SOC [%]
+                  type: writemultiple
+                  encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
 
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
For kostal-plenticore-gen2 the minmax-soc values weren't written to registers and therefor the inverters webui-settings still took effect instead of evcc's config.
Additionally 100% minsoc is now used to stop discharge in hold-mode which allows surplus charging.

Related to discussion #26709

I will test this for a few days and give feedback to ensure everything works as expected now.