### PR TITLE
Green Grid Compass: upgrade api (BC)

### DIFF
--- a/plugin/auth/clientcredentials.go
+++ b/plugin/auth/clientcredentials.go
@@ -13,24 +13,11 @@ func init() {
 }
 
 func NewClientcredentialsFromConfig(ctx context.Context, other map[string]any) (oauth2.TokenSource, error) {
-	var cc struct {
-		ClientID     string
-		ClientSecret string
-		TokenURL     string
-		Scopes       []string
-	}
+	var conf clientcredentials.Config
 
-	if err := util.DecodeOther(other, &cc); err != nil {
+	if err := util.DecodeOther(other, &conf); err != nil {
 		return nil, err
 	}
-
-	conf := &clientcredentials.Config{
-		ClientID:     cc.ClientID,
-		ClientSecret: cc.ClientSecret,
-		TokenURL:     cc.TokenURL,
-		Scopes:       cc.Scopes,
-	}
-
 	ts := conf.TokenSource(ctx)
 
 	return ts, nil

--- a/plugin/auth/clientcredentials.go
+++ b/plugin/auth/clientcredentials.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/evcc-io/evcc/util"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+func init() {
+	registry.AddCtx("clientcredentials", NewClientcredentialsFromConfig)
+}
+
+func NewClientcredentialsFromConfig(ctx context.Context, other map[string]any) (oauth2.TokenSource, error) {
+	var cc struct {
+		ClientID     string
+		ClientSecret string
+		TokenURL     string
+		Scopes       []string
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	conf := &clientcredentials.Config{
+		ClientID:     cc.ClientID,
+		ClientSecret: cc.ClientSecret,
+		TokenURL:     cc.TokenURL,
+		Scopes:       cc.Scopes,
+	}
+
+	ts := conf.TokenSource(ctx)
+
+	return ts, nil
+}

--- a/plugin/auth/clientcredentials.go
+++ b/plugin/auth/clientcredentials.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 
 	"github.com/evcc-io/evcc/util"
 	"golang.org/x/oauth2"
@@ -13,12 +14,20 @@ func init() {
 }
 
 func NewClientcredentialsFromConfig(ctx context.Context, other map[string]any) (oauth2.TokenSource, error) {
-	var conf clientcredentials.Config
+	var cc clientcredentials.Config
 
-	if err := util.DecodeOther(other, &conf); err != nil {
+	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
-	ts := conf.TokenSource(ctx)
 
-	return ts, nil
+	switch {
+	case cc.ClientID == "":
+		return nil, errors.New("clientcredentials: missing required clientid")
+	case cc.ClientSecret == "":
+		return nil, errors.New("clientcredentials: missing required clientsecret")
+	case cc.TokenURL == "":
+		return nil, errors.New("clientcredentials: missing required tokenurl")
+	}
+
+	return cc.TokenSource(ctx), nil
 }

--- a/plugin/http_auth.go
+++ b/plugin/http_auth.go
@@ -17,9 +17,8 @@ import (
 type Auth struct {
 	Type, User, Password, Token string
 
-	Source      string
-	TokenSource *Config
-	Other       map[string]any `mapstructure:",remain"`
+	Source string
+	Other  map[string]any `mapstructure:",remain"`
 }
 
 func (p *Auth) Transport(ctx context.Context, log *util.Logger, base http.RoundTripper) (http.RoundTripper, error) {
@@ -36,21 +35,6 @@ func (p *Auth) Transport(ctx context.Context, log *util.Logger, base http.RoundT
 			log.WARN.Println("using password for bearer auth is deprecated, use token instead")
 		}
 		return transport.BearerAuth(p.Token, base), nil
-
-	case "tokensource":
-		if p.TokenSource == nil {
-			return nil, fmt.Errorf("token source config required for tokensource auth")
-		}
-
-		tokenFunc, err := p.TokenSource.StringGetter(ctx)
-		if err != nil {
-			return nil, err
-		}
-		token, err := tokenFunc()
-		if err != nil {
-			return nil, err
-		}
-		return transport.BearerAuth(token, base), nil
 
 	default:
 		if p.Source == "" {

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -17,23 +17,16 @@ params:
       de: "Erstelle eine App in [api-portal.eco2grid.com](https://api-portal.eco2grid.com) und kopiere den Key"
       en: "Create an app in [api-portal.eco2grid.com](https://api-portal.eco2grid.com) and copy the key"
     deprecated: true
-  - name: clientId
-    description:
-      de: Client ID
-      en: Client ID
+  - name: clientid
     help:
       de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client ID"
       en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client ID"
     type: string
     required: true
-  - name: clientSecret
-    description:
-      de: Client Secret
-      en: Client Secret
+  - name: clientsecret
     help:
       de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client Secret"
       en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client Secret"
-    type: string
     required: true
   - name: zone
     description:
@@ -54,7 +47,7 @@ render: |
         source: http
         uri: https://signin.energy/am/oauth2/realms/root/realms/difesp/access_token
         method: POST
-        body: grant_type=client_credentials&client_id={{ .clientId }}&client_secret={{ .clientSecret }}&scope=esp  
+        body: grant_type=client_credentials&client_id={{ .clientid }}&client_secret={{ .clientsecret }}&scope=esp  
         headers:
           Content-Type: application/x-www-form-urlencoded
         jq: .access_token

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -4,8 +4,14 @@ products:
   - brand: Green Grid Compass
 requirements:
   description:
-    de: "Europäische CO₂-Intensitätsdaten von [greengrid-compass.eu](https://www.greengrid-compass.eu). Liefert Vorhersagen der nächsten Stunden und ist nach Registrierung kostenlos nutzbar."
-    en: "European CO₂ intensity data from [greengrid-compass.eu](https://www.greengrid-compass.eu). Provides forecasts for the next hours and is free of charge after registration."
+    de: |
+      Europäische CO₂-Intensitätsdaten von [greengrid-compass.eu](https://www.greengrid-compass.eu). Liefert Vorhersagen der nächsten Stunden und ist nach Registrierung kostenlos nutzbar.
+
+      Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client ID und das Client Secret.
+    en: |
+      European CO₂ intensity data from [greengrid-compass.eu](https://www.greengrid-compass.eu). Provides forecasts for the next hours and is free to use after registration.
+
+      Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client ID and Client Secret.
   evcc: ["skiptest"]
 group: co2
 countries: ["BE", "DE", "LU"]
@@ -18,15 +24,9 @@ params:
       en: "Create an app in [api-portal.eco2grid.com](https://api-portal.eco2grid.com) and copy the key"
     deprecated: true
   - name: clientid
-    help:
-      de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client ID"
-      en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client ID"
     type: string
     required: true
   - name: clientsecret
-    help:
-      de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client Secret"
-      en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client Secret"
     required: true
   - name: zone
     description:

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -1,5 +1,4 @@
 template: green-grid-compass
-deprecated: true
 products:
   - brand: Green Grid Compass
 requirements:

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -47,7 +47,7 @@ render: |
       clientsecret: {{ .clientsecret }}
       TokenURL: https://signin.energy/am/oauth2/realms/root/realms/difesp/access_token
       scopes: [esp]
-    uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T15" }}` }}:00:00Z&end={{ `{{ addDate now 0 0 2 | date "2006-01-02T15" }}` }}:00:00Z&time-resolution=hourly&calculation-type=consumption&emission-type=operational&forecast-type=actual
+    uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T15" }}` }}:00:00Z&end={{ `{{ addDate now 0 0 2 | date "2006-01-02T15" }}` }}:00:00Z&time-resolution=hourly&calculation-type=production&emission-type=operational&forecast-type=actual
     jq: |
       .measurements[0].measurementValues |  map({ 
         "start": (.timestamp ),

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -50,7 +50,7 @@ render: |
     uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T15" }}` }}:00:00Z&end={{ `{{ addDate now 0 0 2 | date "2006-01-02T15" }}` }}:00:00Z&time-resolution=hourly&calculation-type=production&emission-type=operational&forecast-type=actual
     jq: |
       .measurements[0].measurementValues |  map({ 
-        "start": (.timestamp ),
+        "start": .timestamp,
         "end": (.timestamp | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime + 3600 | strftime("%FT%TZ")),
         "value": .value
       }) | tostring

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -19,12 +19,18 @@ params:
     deprecated: true
   - name: clientId
     description:
+      de: Client ID
+      en: Client ID
+    help:
       de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client ID"
       en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client ID"
     type: string
     required: true
   - name: clientSecret
     description:
+      de: Client Secret
+      en: Client Secret
+    help:
       de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client Secret"
       en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client Secret"
     type: string

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -42,15 +42,11 @@ render: |
   forecast:
     source: http
     auth:
-      type: tokensource
-      tokensource:
-        source: http
-        uri: https://signin.energy/am/oauth2/realms/root/realms/difesp/access_token
-        method: POST
-        body: grant_type=client_credentials&client_id={{ .clientid }}&client_secret={{ .clientsecret }}&scope=esp  
-        headers:
-          Content-Type: application/x-www-form-urlencoded
-        jq: .access_token
+      source: clientcredentials
+      clientid: {{ .clientid }}
+      clientsecret: {{ .clientsecret }}
+      TokenURL: https://signin.energy/am/oauth2/realms/root/realms/difesp/access_token
+      scopes: [esp]
     uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T15" }}` }}:00:00Z&end={{ `{{ addDate now 0 0 2 | date "2006-01-02T15" }}` }}:00:00Z&time-resolution=hourly&calculation-type=consumption&emission-type=operational&forecast-type=actual
     jq: |
       .measurements[0].measurementValues |  map({ 

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -46,7 +46,7 @@ render: |
       clientsecret: {{ .clientsecret }}
       TokenURL: https://signin.energy/am/oauth2/realms/root/realms/difesp/access_token
       scopes: [esp]
-    uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T15" }}` }}:00:00Z&end={{ `{{ addDate now 0 0 2 | date "2006-01-02T15" }}` }}:00:00Z&time-resolution=hourly&calculation-type=production&emission-type=operational&forecast-type=actual
+    uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T" }}` }}00:00:00Z&end={{ `{{ addDate now 0 0 5 | date "2006-01-02T" }}` }}00:00:00Z&time-resolution=hourly&calculation-type=production&emission-type=operational&forecast-type=actual
     jq: |
       .measurements[0].measurementValues |  map({ 
         "start": .timestamp,

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -16,6 +16,19 @@ params:
     help:
       de: "Erstelle eine App in [api-portal.eco2grid.com](https://api-portal.eco2grid.com) und kopiere den Key"
       en: "Create an app in [api-portal.eco2grid.com](https://api-portal.eco2grid.com) and copy the key"
+    deprecated: true
+  - name: clientId
+    description:
+      de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client ID"
+      en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client ID"
+    type: string
+    required: true
+  - name: clientSecret
+    description:
+      de: "Erstelle App nach der Anleitung auf [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) und kopiere die Client Secret"
+      en: "Create app according to the instructions on [traxes.io](https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation) and copy the Client Secret"
+    type: string
+    required: true
   - name: zone
     description:
       de: Zonencode
@@ -29,11 +42,21 @@ render: |
   tariff: co2
   forecast:
     source: http
-    uri: https://eco2grid.com/green-grid-compass/v2/forecast/hourly?zone_code={{ .zone }}&start={{ `{{ now | date "2006-01-02T15" }}` }}:00:00&end={{ `{{ addDate now 0 0 2 | date "2006-01-02T15" }}` }}:00:00&apikey={{ .apiKey }}
+    auth:
+      type: tokensource
+      tokensource:
+        source: http
+        uri: https://signin.energy/am/oauth2/realms/root/realms/difesp/access_token
+        method: POST
+        body: grant_type=client_credentials&client_id={{ .clientId }}&client_secret={{ .clientSecret }}&scope=esp  
+        headers:
+          Content-Type: application/x-www-form-urlencoded
+        jq: .access_token
+    uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T15" }}` }}:00:00Z&end={{ `{{ addDate now 0 0 2 | date "2006-01-02T15" }}` }}:00:00Z&time-resolution=hourly&calculation-type=consumption&emission-type=operational&forecast-type=actual
     jq: |
-      .zone_data | map({ 
-        "start": (.interval + "+02:00"),
-        "end": (.interval + "+02:00" | strptime("%Y-%m-%dT%H:%M:%S%z") | mktime + 3600 | strftime("%FT%TZ")),
-        "value": .consumption_co2_intensity 
+      .measurements[0].measurementValues |  map({ 
+        "start": (.timestamp ),
+        "end": (.timestamp | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime + 3600 | strftime("%FT%TZ")),
+        "value": .value
       }) | tostring
     cache: 1h

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -23,7 +23,6 @@ params:
       en: "Create an app in [api-portal.eco2grid.com](https://api-portal.eco2grid.com) and copy the key"
     deprecated: true
   - name: clientid
-    type: string
     required: true
   - name: clientsecret
     required: true


### PR DESCRIPTION
Breaking Change: With the new API the old apiKey no longer works and a new App with Client ID and Client Secret must created at https://www.traxes.io/service/green-grid-compass/1.0.0/technical-documentation

fixes #26219