### PR TITLE
Heidelberg: simplify

### DIFF
--- a/charger/heidelberg-ec.go
+++ b/charger/heidelberg-ec.go
@@ -220,12 +220,12 @@ func (wb *HeidelbergEC) MaxCurrentMillis(current float64) error {
 
 	curr := uint16(10 * current)
 
-	if err := wb.set(hecRegAmpsConfig, curr); err != nil {
-		return err
+	err := wb.set(hecRegAmpsConfig, curr)
+	if err == nil {
+		wb.current = curr
 	}
 
-	wb.current = curr
-	return nil
+	return err
 }
 
 var _ api.Meter = (*HeidelbergEC)(nil)


### PR DESCRIPTION
This PR simplifies the Heidelberg EC charger implementation by using the more appropriate Modbus `WriteSingleRegister` function instead of `WriteMultipleRegisters` for single register writes, and improves the logger naming.

**Changes:**
- Updated logger name from "heidel" to "heidelberg" for better clarity
- Simplified to use `WriteSingleRegister` instead of `WriteMultipleRegisters`

Fix #26636