### PR TITLE
MBMD: fix simple meters

### DIFF
--- a/templates/definition/meter/ddm-18sd.yaml
+++ b/templates/definition/meter/ddm-18sd.yaml
@@ -12,5 +12,5 @@ render: |
   type: mbmd
   {{- include "modbus" . }}
   model: ddm
-  power: {{ if eq .usage "pv" }}-{{ end }}Power
+  power: Power
   energy: Sum

--- a/templates/definition/meter/orno-we504.yaml
+++ b/templates/definition/meter/orno-we504.yaml
@@ -12,5 +12,5 @@ render: |
   type: mbmd
   {{- include "modbus" . }}
   model: orno1p504
-  power: {{ if eq .usage "pv" }}-{{ end }}Power
+  power: Power
   energy: Sum

--- a/templates/definition/meter/orno-we514_515.yaml
+++ b/templates/definition/meter/orno-we514_515.yaml
@@ -15,5 +15,5 @@ render: |
   type: mbmd
   {{- include "modbus" . }}
   model: orno1p
-  power: {{ if eq .usage "pv" }}-{{ end }}Power
+  power: Power
   energy: Sum


### PR DESCRIPTION
This PR fixes an issue with simple MBMD meters (DDM, ORNO1P, ORNO1P504) where power values were being incorrectly inverted based on the `usage` configuration.

## Problem

The affected meter templates contained conditional logic that automatically negated the `Power` reading when the meter was configured with `usage: pv`.

This automatic sign inversion is problematic for simple meters because these meters report actual measured values without inherent direction (unsigned).

## Impact

- Fixes incorrect power sign for these simple meters when used with `usage: pv`
- Power values are now reported as measured by the hardware

Fixes #26843