### PR TITLE
fix: skip unreferenced chargers

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -238,7 +238,7 @@ func configureMeters(static []config.Named, names ...string) error {
 			return fmt.Errorf("cannot create meter %d: missing name", i+1)
 		}
 
-		if len(names) > 0 && !slices.Contains(names, cc.Name) {
+		if !slices.Contains(names, cc.Name) {
 			continue
 		}
 
@@ -272,7 +272,7 @@ func configureMeters(static []config.Named, names ...string) error {
 		eg.Go(func() error {
 			cc := conf.Named()
 
-			if len(names) > 0 && !slices.Contains(names, cc.Name) {
+			if !slices.Contains(names, cc.Name) {
 				return nil
 			}
 
@@ -310,7 +310,7 @@ func configureChargers(static []config.Named, names ...string) error {
 			return fmt.Errorf("cannot create charger %d: missing name", i+1)
 		}
 
-		if len(names) > 0 && !slices.Contains(names, cc.Name) {
+		if !slices.Contains(names, cc.Name) {
 			continue
 		}
 
@@ -344,7 +344,7 @@ func configureChargers(static []config.Named, names ...string) error {
 		eg.Go(func() error {
 			cc := conf.Named()
 
-			if len(names) > 0 && !slices.Contains(names, cc.Name) {
+			if !slices.Contains(names, cc.Name) {
 				return nil
 			}
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -238,7 +238,8 @@ func configureMeters(static []config.Named, names ...string) error {
 			return fmt.Errorf("cannot create meter %d: missing name", i+1)
 		}
 
-		if !slices.Contains(names, cc.Name) {
+		// configure all, if no name refs are given
+		if len(names) > 0 && !slices.Contains(names, cc.Name) {
 			continue
 		}
 
@@ -272,6 +273,7 @@ func configureMeters(static []config.Named, names ...string) error {
 		eg.Go(func() error {
 			cc := conf.Named()
 
+			// always skip unreferenced db devices
 			if !slices.Contains(names, cc.Name) {
 				return nil
 			}
@@ -310,7 +312,8 @@ func configureChargers(static []config.Named, names ...string) error {
 			return fmt.Errorf("cannot create charger %d: missing name", i+1)
 		}
 
-		if !slices.Contains(names, cc.Name) {
+		// configure all, if no name refs are given
+		if len(names) > 0 && !slices.Contains(names, cc.Name) {
 			continue
 		}
 
@@ -344,6 +347,7 @@ func configureChargers(static []config.Named, names ...string) error {
 		eg.Go(func() error {
 			cc := conf.Named()
 
+			// always skip unreferenced db devices
 			if !slices.Contains(names, cc.Name) {
 				return nil
 			}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/26834

We already have logic, that we only initialize chargers/meters that are actually referenced. However, we also had special logic that leads to "initialize all" if the reference list is empty - which happens in the above issue.

The empty list logic was likely introduced for `evcc charger`. This PR changes this logic to only initialize/test referenced devices.

~Note: this also changes `evcc charger|meter` behavior. Now unreferenced devices are omitted - which is consequent. If we want to keep old behavior we could keep the "empty list logic" for static (evcc.yaml) devices and only make this change to ui configured devices.~