### PR TITLE
Tariff: Add epexprijzen.nl template

### DIFF
--- a/templates/definition/tariff/epexprijzen-nl.yaml
+++ b/templates/definition/tariff/epexprijzen-nl.yaml
@@ -58,7 +58,7 @@ render: |
     source: http
     uri: https://epexprijzen.nl/api/v1/prices/{{ .provider }}/{{ index . "price-interval" }}
     jq: |
-      .today + .tomorrow | 
+      (.today // []) + (.tomorrow // []) | 
       map({
         "start": (.t | strptime("%Y-%m-%dT%H:%M:%S%z") | strftime("%Y-%m-%dT%H:%M:%SZ")),
         "end": (.t | strptime("%Y-%m-%dT%H:%M:%S%z") | mktime + {{ if eq (index . "price-interval") "hourly" }}3600{{ else }}900{{ end }} | strftime("%Y-%m-%dT%H:%M:%SZ")),

--- a/templates/definition/tariff/epexprijzen-nl.yaml
+++ b/templates/definition/tariff/epexprijzen-nl.yaml
@@ -66,4 +66,3 @@ render: |
       }) | tostring
     cache: 1h
   interval: {{ .interval }}
-  

--- a/templates/definition/tariff/epexprijzen-nl.yaml
+++ b/templates/definition/tariff/epexprijzen-nl.yaml
@@ -1,0 +1,68 @@
+template: epexprijzen-nl
+products:
+  - brand: epexprijzen.nl
+    description:
+      en: Current energy prices in the Netherlands, including surcharges and taxes
+      de: Aktuelle Energiepreise in den Niederlanden, einschließlich Zuschlägen und Steuern
+requirements:
+  evcc: ["skiptest"]
+group: price
+countries: ["NL"]
+params:
+  - name: provider
+    description:
+      en: Energy provider
+      de: Energieversorger
+    type: choice
+    choice:
+      [
+        "anwb-energie",
+        "atoom-alliantie",
+        "budget-energie",
+        "coolblue-energie",
+        "easyenergy",
+        "eneco",
+        "energie-vanons",
+        "energyzero",
+        "frank-energie",
+        "frank-energie-slim",
+        "hegg",
+        "innova",
+        "nextenergy",
+        "samsam",
+        "tibber",
+        "vandebron",
+        "zonneplan",
+      ]
+    required: true
+  - name: price-interval
+    description:
+      en: Price interval
+      de: Preisintervall
+    type: choice
+    choice:
+      [
+        "hourly",
+        "quarterly",
+      ]
+    default: quarterly
+    required: true
+  - preset: tariff-base
+  - name: interval
+    default: 1h
+    advanced: true
+render: |
+  type: custom
+  {{ include "tariff-base" . }}
+  forecast:
+    source: http
+    uri: https://epexprijzen.nl/api/v1/prices/{{ .provider }}/{{ index . "price-interval" }}
+    jq: |
+      .today + .tomorrow | 
+      map({
+        "start": (.t | strptime("%Y-%m-%dT%H:%M:%S%z") | strftime("%Y-%m-%dT%H:%M:%SZ")),
+        "end": (.t | strptime("%Y-%m-%dT%H:%M:%S%z") | mktime + {{ if eq (index . "price-interval") "hourly" }}3600{{ else }}900{{ end }} | strftime("%Y-%m-%dT%H:%M:%SZ")),
+        "value": .price
+      }) | tostring
+    cache: 1h
+  interval: {{ .interval }}

--- a/templates/definition/tariff/epexprijzen-nl.yaml
+++ b/templates/definition/tariff/epexprijzen-nl.yaml
@@ -66,3 +66,4 @@ render: |
       }) | tostring
     cache: 1h
   interval: {{ .interval }}
+  

--- a/templates/definition/tariff/epexprijzen-nl.yaml
+++ b/templates/definition/tariff/epexprijzen-nl.yaml
@@ -40,11 +40,7 @@ params:
       en: Price interval
       de: Preisintervall
     type: choice
-    choice:
-      [
-        "hourly",
-        "quarterly",
-      ]
+    choice: ["hourly", "quarterly"]
     default: quarterly
     required: true
   - preset: tariff-base


### PR DESCRIPTION
- Support for 17 Dutch energy providers
- Hourly and quarterly price intervals
- Uses epexprijzen.nl API v1
- Combines today and tomorrow prices with 1h cache
- Prices include provider surcharges and energy tax

The template uses the epexprijzen.nl API v1 which provides current
market prices already including all taxes and provider-specific charges,
eliminating the need for additional tariff configuration (and periodic changes).