### PR TITLE
Homewizard improvements

### DIFF
--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -28,9 +28,11 @@ func NewHomeWizardFromConfig(other map[string]any) (api.Charger, error) {
 		embed        `mapstructure:",squash"`
 		URI          string
 		Usage        string
+		Phase        int
 		StandbyPower float64
 		Cache        time.Duration
 	}{
+		Phase: 1,
 		Cache: time.Second,
 	}
 
@@ -38,12 +40,12 @@ func NewHomeWizardFromConfig(other map[string]any) (api.Charger, error) {
 		return nil, err
 	}
 
-	return NewHomeWizard(cc.embed, cc.URI, cc.Usage, cc.StandbyPower, cc.Cache)
+	return NewHomeWizard(cc.embed, cc.URI, cc.Usage, cc.Phase, cc.StandbyPower, cc.Cache)
 }
 
 // NewHomeWizard creates HomeWizard charger
-func NewHomeWizard(embed embed, uri string, usage string, standbypower float64, cache time.Duration) (*HomeWizard, error) {
-	conn, err := homewizard.NewConnection(uri, usage, 1, cache)
+func NewHomeWizard(embed embed, uri string, usage string, phase int, standbypower float64, cache time.Duration) (*HomeWizard, error) {
+	conn, err := homewizard.NewConnection(uri, usage, phase, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -43,7 +43,7 @@ func NewHomeWizardFromConfig(other map[string]any) (api.Charger, error) {
 
 // NewHomeWizard creates HomeWizard charger
 func NewHomeWizard(embed embed, uri string, usage string, standbypower float64, cache time.Duration) (*HomeWizard, error) {
-	conn, err := homewizard.NewConnection(uri, usage, cache)
+	conn, err := homewizard.NewConnection(uri, usage, 1, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/homewizard.go
+++ b/charger/homewizard.go
@@ -53,7 +53,7 @@ func NewHomeWizard(embed embed, uri string, usage string, standbypower float64, 
 	}
 
 	// Check compatible product type
-	if c.conn.ProductType != "HWE-SKT" {
+	if c.conn.ProductType != homewizard.ProductTypeSocket {
 		return nil, errors.New("unsupported product type: " + c.conn.ProductType)
 	}
 

--- a/meter/homewizard.go
+++ b/meter/homewizard.go
@@ -23,8 +23,10 @@ func NewHomeWizardFromConfig(other map[string]any) (api.Meter, error) {
 	cc := struct {
 		URI   string
 		Usage string
+		Phase int
 		Cache time.Duration
 	}{
+		Phase: 1,
 		Cache: time.Second,
 	}
 
@@ -32,12 +34,12 @@ func NewHomeWizardFromConfig(other map[string]any) (api.Meter, error) {
 		return nil, err
 	}
 
-	return NewHomeWizard(cc.URI, cc.Usage, cc.Cache)
+	return NewHomeWizard(cc.URI, cc.Usage, cc.Phase, cc.Cache)
 }
 
 // NewHomeWizard creates HomeWizard meter
-func NewHomeWizard(uri string, usage string, cache time.Duration) (*HomeWizard, error) {
-	conn, err := homewizard.NewConnection(uri, usage, cache)
+func NewHomeWizard(uri string, usage string, phase int, cache time.Duration) (*HomeWizard, error) {
+	conn, err := homewizard.NewConnection(uri, usage, phase, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -111,9 +111,9 @@ func (c *Connection) CurrentPower() (float64, error) {
 func (c *Connection) TotalEnergy() (float64, error) {
 	res, err := c.dataG.Get()
 	if c.usage == "pv" {
-		return res.TotalPowerExportT1kWh + res.TotalPowerExportT2kWh + res.TotalPowerExportT3kWh + res.TotalPowerExportT4kWh, err
+		return res.TotalPowerExportkWh, err
 	}
-	return res.TotalPowerImportT1kWh + res.TotalPowerImportT2kWh + res.TotalPowerImportT3kWh + res.TotalPowerImportT4kWh, err
+	return res.TotalPowerImportkWh, err
 }
 
 // Currents implements the api.PhaseCurrents interface

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -101,7 +101,7 @@ func (c *Connection) Enabled() (bool, error) {
 // CurrentPower implements the api.Meter interface
 func (c *Connection) CurrentPower() (float64, error) {
 	res, err := c.dataG.Get()
-	if c.usage == "pv" {
+	if c.usage == "pv" || c.usage == "battery" {
 		return -res.ActivePowerW, err
 	}
 	return res.ActivePowerW, err
@@ -110,7 +110,7 @@ func (c *Connection) CurrentPower() (float64, error) {
 // TotalEnergy implements the api.MeterEnergy interface
 func (c *Connection) TotalEnergy() (float64, error) {
 	res, err := c.dataG.Get()
-	if c.usage == "pv" {
+	if c.usage == "pv" || c.usage == "battery" {
 		return res.TotalPowerExportkWh, err
 	}
 	return res.TotalPowerImportkWh, err
@@ -122,14 +122,14 @@ func (c *Connection) Currents() (float64, float64, float64, error) {
 
 	// Single-phase meters only have one current reading
 	if c.ProductType == "HWE-KWH1" || c.ProductType == "SDM230-wifi" {
-		if c.usage == "pv" {
+		if c.usage == "pv" || c.usage == "battery" {
 			return -res.ActiveCurrentA, 0, 0, err
 		}
 		return res.ActiveCurrentA, 0, 0, err
 	}
 
 	// Three-phase meters have separate current readings per phase
-	if c.usage == "pv" {
+	if c.usage == "pv" || c.usage == "battery" {
 		return -res.ActiveCurrentL1A, -res.ActiveCurrentL2A, -res.ActiveCurrentL3A, err
 	}
 	return res.ActiveCurrentL1A, res.ActiveCurrentL2A, res.ActiveCurrentL3A, err

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -119,6 +119,16 @@ func (c *Connection) TotalEnergy() (float64, error) {
 // Currents implements the api.PhaseCurrents interface
 func (c *Connection) Currents() (float64, float64, float64, error) {
 	res, err := c.dataG.Get()
+
+	// Single-phase meters only have one current reading
+	if c.ProductType == "HWE-KWH1" || c.ProductType == "SDM230-wifi" {
+		if c.usage == "pv" {
+			return -res.ActiveCurrentA, 0, 0, err
+		}
+		return res.ActiveCurrentA, 0, 0, err
+	}
+
+	// Three-phase meters have separate current readings per phase
 	if c.usage == "pv" {
 		return -res.ActiveCurrentL1A, -res.ActiveCurrentL2A, -res.ActiveCurrentL3A, err
 	}
@@ -128,5 +138,12 @@ func (c *Connection) Currents() (float64, float64, float64, error) {
 // Voltages implements the api.PhaseVoltages interface
 func (c *Connection) Voltages() (float64, float64, float64, error) {
 	res, err := c.dataG.Get()
+
+	// Single-phase meters only have one voltage reading
+	if c.ProductType == "HWE-KWH1" || c.ProductType == "SDM230-wifi" {
+		return res.ActiveVoltageV, 0, 0, err
+	}
+
+	// Three-phase meters have separate voltage readings per phase
 	return res.ActiveVoltageL1V, res.ActiveVoltageL2V, res.ActiveVoltageL3V, err
 }

--- a/meter/homewizard/connection.go
+++ b/meter/homewizard/connection.go
@@ -147,6 +147,27 @@ func (c *Connection) CurrentPower() (float64, error) {
 	return res.ActivePowerW, err
 }
 
+// Powers implements the PhasePowers interface
+func (c *Connection) Powers() (float64, float64, float64, error) {
+	res, err := c.dataG.Get()
+
+	if isSinglePhase(c.ProductType) {
+		power := res.ActivePowerW
+		if c.usage == "pv" || c.usage == "battery" {
+			power = -power
+		}
+
+		l1, l2, l3 := mapValueToPhase(power, c.phase)
+		return l1, l2, l3, err
+	}
+
+	if c.usage == "pv" || c.usage == "battery" {
+		return -res.ActivePowerL1W, -res.ActivePowerL2W, -res.ActivePowerL3W, err
+	}
+
+	return res.ActivePowerL1W, res.ActivePowerL2W, res.ActivePowerL3W, err
+}
+
 // TotalEnergy implements the api.MeterEnergy interface
 func (c *Connection) TotalEnergy() (float64, error) {
 	res, err := c.dataG.Get()

--- a/meter/homewizard/types.go
+++ b/meter/homewizard/types.go
@@ -19,9 +19,11 @@ type DataResponse struct {
 	ActivePowerW        float64 `json:"active_power_w"`
 	TotalPowerImportkWh float64 `json:"total_power_import_kwh"`
 	TotalPowerExportkWh float64 `json:"total_power_export_kwh"`
+	ActiveCurrentA      float64 `json:"active_current_a"`
 	ActiveCurrentL1A    float64 `json:"active_current_l1_a"`
 	ActiveCurrentL2A    float64 `json:"active_current_l2_a"`
 	ActiveCurrentL3A    float64 `json:"active_current_l3_a"`
+	ActiveVoltageV      float64 `json:"active_voltage_v"`
 	ActiveVoltageL1V    float64 `json:"active_voltage_l1_v"`
 	ActiveVoltageL2V    float64 `json:"active_voltage_l2_v"`
 	ActiveVoltageL3V    float64 `json:"active_voltage_l3_v"`

--- a/meter/homewizard/types.go
+++ b/meter/homewizard/types.go
@@ -17,6 +17,9 @@ type StateResponse struct {
 // https://homewizard-energy-api.readthedocs.io/endpoints.html#state-api-v1-state
 type DataResponse struct {
 	ActivePowerW        float64 `json:"active_power_w"`
+	ActivePowerL1W      float64 `json:"active_power_l1_w"`
+	ActivePowerL2W      float64 `json:"active_power_l2_w"`
+	ActivePowerL3W      float64 `json:"active_power_l3_w"`
 	TotalPowerImportkWh float64 `json:"total_power_import_kwh"`
 	TotalPowerExportkWh float64 `json:"total_power_export_kwh"`
 	ActiveCurrentA      float64 `json:"active_current_a"`

--- a/meter/homewizard/types.go
+++ b/meter/homewizard/types.go
@@ -16,19 +16,13 @@ type StateResponse struct {
 // DataResponse returns the most recent measurements from the HomeWizard device
 // https://homewizard-energy-api.readthedocs.io/endpoints.html#state-api-v1-state
 type DataResponse struct {
-	ActivePowerW          float64 `json:"active_power_w"`
-	TotalPowerImportT1kWh float64 `json:"total_power_import_t1_kwh"`
-	TotalPowerImportT2kWh float64 `json:"total_power_import_t2_kwh"`
-	TotalPowerImportT3kWh float64 `json:"total_power_import_t3_kwh"`
-	TotalPowerImportT4kWh float64 `json:"total_power_import_t4_kwh"`
-	TotalPowerExportT1kWh float64 `json:"total_power_export_t1_kwh"`
-	TotalPowerExportT2kWh float64 `json:"total_power_export_t2_kwh"`
-	TotalPowerExportT3kWh float64 `json:"total_power_export_t3_kwh"`
-	TotalPowerExportT4kWh float64 `json:"total_power_export_t4_kwh"`
-	ActiveCurrentL1A      float64 `json:"active_current_l1_a"`
-	ActiveCurrentL2A      float64 `json:"active_current_l2_a"`
-	ActiveCurrentL3A      float64 `json:"active_current_l3_a"`
-	ActiveVoltageL1V      float64 `json:"active_voltage_l1_v"`
-	ActiveVoltageL2V      float64 `json:"active_voltage_l2_v"`
-	ActiveVoltageL3V      float64 `json:"active_voltage_l3_v"`
+	ActivePowerW        float64 `json:"active_power_w"`
+	TotalPowerImportkWh float64 `json:"total_power_import_kwh"`
+	TotalPowerExportkWh float64 `json:"total_power_export_kwh"`
+	ActiveCurrentL1A    float64 `json:"active_current_l1_a"`
+	ActiveCurrentL2A    float64 `json:"active_current_l2_a"`
+	ActiveCurrentL3A    float64 `json:"active_current_l3_a"`
+	ActiveVoltageL1V    float64 `json:"active_voltage_l1_v"`
+	ActiveVoltageL2V    float64 `json:"active_voltage_l2_v"`
+	ActiveVoltageL3V    float64 `json:"active_voltage_l3_v"`
 }

--- a/meter/homewizard/types_test.go
+++ b/meter/homewizard/types_test.go
@@ -38,11 +38,11 @@ func TestUnmarshalKwhDataResponse(t *testing.T) {
 	{
 		var res DataResponse
 		// https://www.homewizard.com/shop/wi-fi-kwh-meter-1-phase/
-		jsonstr := `{"wifi_ssid": "My Wi-Fi","wifi_strength": 100,"total_power_import_t1_kwh": 30.511,"total_power_export_t1_kwh": 85.951,"active_power_w": 543,"active_power_l1_w": 28,"active_power_l2_w": 0,"active_power_l3_w": -181,"active_voltage_l1_v": 235.4,"active_voltage_l2_v": 235.8,"active_voltage_l3_v": 236.1,"active_current_l1_a": 1.19,"active_current_l2_a": 0.37,"active_current_l3_a": -0.93}`
+		jsonstr := `{"wifi_ssid": "My Wi-Fi","wifi_strength": 100,"total_power_import_kwh": 30.511,"total_power_export_kwh": 85.951,"total_power_import_t1_kwh": 30.511,"total_power_export_t1_kwh": 85.951,"active_power_w": 543,"active_power_l1_w": 28,"active_power_l2_w": 0,"active_power_l3_w": -181,"active_voltage_l1_v": 235.4,"active_voltage_l2_v": 235.8,"active_voltage_l3_v": 236.1,"active_current_l1_a": 1.19,"active_current_l2_a": 0.37,"active_current_l3_a": -0.93}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
 
-		assert.Equal(t, float64(30.511), res.TotalPowerImportT1kWh+res.TotalPowerImportT2kWh+res.TotalPowerImportT3kWh+res.TotalPowerImportT4kWh)
-		assert.Equal(t, float64(85.951), res.TotalPowerExportT1kWh+res.TotalPowerExportT2kWh+res.TotalPowerExportT3kWh+res.TotalPowerExportT4kWh)
+		assert.Equal(t, float64(30.511), res.TotalPowerImportkWh)
+		assert.Equal(t, float64(85.951), res.TotalPowerExportkWh)
 		assert.Equal(t, float64(543), res.ActivePowerW)
 		assert.Equal(t, float64(235.4), res.ActiveVoltageL1V)
 		assert.Equal(t, float64(235.8), res.ActiveVoltageL2V)
@@ -61,8 +61,8 @@ func TestUnmarshalP1DataResponse(t *testing.T) {
 		jsonstr := `{"wifi_ssid":"redacted","wifi_strength":78,"smr_version":50,"meter_model":"Landis + Gyr","unique_id":"redacted","active_tariff":2,"total_power_import_kwh":18664.997,"total_power_import_t1_kwh":10909.724,"total_power_import_t2_kwh":7755.273,"total_power_export_kwh":13823.608,"total_power_export_t1_kwh":4243.981,"total_power_export_t2_kwh":9579.627,"active_power_w":203.000,"active_power_l1_w":-21.000,"active_power_l2_w":57.000,"active_power_l3_w":168.000,"active_voltage_l1_v":228.000,"active_voltage_l2_v":226.000,"active_voltage_l3_v":225.000,"active_current_a":1.091,"active_current_l1_a":-0.092,"active_current_l2_a":0.252,"active_current_l3_a":0.747,"voltage_sag_l1_count":12.000,"voltage_sag_l2_count":12.000,"voltage_sag_l3_count":19.000,"voltage_swell_l1_count":5055.000,"voltage_swell_l2_count":1950.000,"voltage_swell_l3_count":0.000,"any_power_fail_count":12.000,"long_power_fail_count":2.000,"total_gas_m3":5175.363,"gas_timestamp":241106093006,"gas_unique_id":"redacted","external":[{"unique_id":"redacted","type":"gas_meter","timestamp":241106093006,"value":5175.363,"unit":"m3"}]}`
 		require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
 
-		assert.Equal(t, float64(18664.997), res.TotalPowerImportT1kWh+res.TotalPowerImportT2kWh+res.TotalPowerImportT3kWh+res.TotalPowerImportT4kWh)
-		assert.Equal(t, float64(13823.608), res.TotalPowerExportT1kWh+res.TotalPowerExportT2kWh+res.TotalPowerExportT3kWh+res.TotalPowerExportT4kWh)
+		assert.Equal(t, float64(18664.997), res.TotalPowerImportkWh)
+		assert.Equal(t, float64(13823.608), res.TotalPowerExportkWh)
 		assert.Equal(t, float64(203), res.ActivePowerW)
 		assert.Equal(t, float64(228), res.ActiveVoltageL1V)
 		assert.Equal(t, float64(226), res.ActiveVoltageL2V)

--- a/templates/definition/charger/homewizard.yaml
+++ b/templates/definition/charger/homewizard.yaml
@@ -7,7 +7,18 @@ products:
 group: switchsockets
 params:
   - name: host
+  - name: phase
+    description:
+      en: Installation phase
+      de: Installationsphase
+    default: 1
+    choice: [1, 2, 3]
+    advanced: true
+    help:
+      en: Phase on which socket is installed (L1=1, L2=2, L3=3)
+      de: Phase an der die Steckdose installiert ist (L1=1, L2=2, L3=3)
   - preset: switchsocket
 render: |
   type: homewizard
   uri: http://{{ .host }}
+  phase: {{ .phase }}

--- a/templates/definition/charger/homewizard.yaml
+++ b/templates/definition/charger/homewizard.yaml
@@ -22,4 +22,3 @@ render: |
   type: homewizard
   uri: http://{{ .host }}
   phase: {{ .phase }}
-  

--- a/templates/definition/charger/homewizard.yaml
+++ b/templates/definition/charger/homewizard.yaml
@@ -1,6 +1,9 @@
 template: homewizard
 products:
   - brand: HomeWizard
+    description:
+      en: Smart Socket (HWE-SKT)
+      de: Smart-Steckdose (HWE-SKT)
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/homewizard.yaml
+++ b/templates/definition/charger/homewizard.yaml
@@ -22,3 +22,4 @@ render: |
   type: homewizard
   uri: http://{{ .host }}
   phase: {{ .phase }}
+  

--- a/templates/definition/meter/homewizard-kwh.yaml
+++ b/templates/definition/meter/homewizard-kwh.yaml
@@ -3,11 +3,24 @@ products:
   - brand: HomeWizard
     description:
       generic: kWh Meter
+      en: kWh Meter (HWE-KWH1, HWE-KWH3, SDM230-wifi, SDM630-wifi)
+      de: kWh-Zähler (HWE-KWH1, HWE-KWH3, SDM230-wifi, SDM630-wifi)
 params:
   - name: usage
     choice: ["pv", "charge", "battery"]
   - name: host
+  - name: phase
+    default: 1
+    choice: [1, 2, 3]
+    advanced: true
+    description:
+      en: Installation phase
+      de: Installationsphase
+    help:
+      en: Phase on which the single-phase meter is installed (L1=1, L2=2, L3=3). Only relevant for HWE-KWH1 and SDM230-wifi.
+      de: Phase an der der einphasige Zähler installiert ist (L1=1, L2=2, L3=3). Nur relevant für HWE-KWH1 und SDM230-wifi.
 render: |
   type: homewizard
   uri: http://{{ .host }}
   usage: {{ .usage }}
+  phase: {{ .phase }}

--- a/templates/definition/meter/homewizard-kwh.yaml
+++ b/templates/definition/meter/homewizard-kwh.yaml
@@ -5,7 +5,7 @@ products:
       generic: kWh Meter
 params:
   - name: usage
-    choice: ["pv", "charge"]
+    choice: ["pv", "charge", "battery"]
   - name: host
 render: |
   type: homewizard


### PR DESCRIPTION
## Summary
This PR improves HomeWizard kWh meter support with better single-phase meter handling and adds battery meter functionality.

## Changes

### Single-phase meter improvements
- Add proper support for single-phase meters (HWE-KWH1, SDM230-wifi)
- Use `ActiveVoltageV` and `ActiveCurrentA` fields instead of phase-specific fields for single-phase meters
- Add configurable `phase` parameter (1-3) to specify which phase a single-phase meter is installed on
- Three-phase meters (HWE-KWH3, SDM630-wifi) continue to work as before

### Battery meter support
- Enable HomeWizard kWh meters to be used as battery meters
- Add `battery` option to the `usage` parameter (alongside existing `pv` and `charge`)
- Battery meters correctly report power flow direction (negative for discharge, positive for charge)
- Use `TotalPowerExportkWh` for battery energy tracking

### Configuration
- Added `phase` parameter to meter template (default: 1, options: 1-3, advanced setting)
- Parameter only relevant for single-phase meters
- Updated product descriptions to list supported meter types

## Testing
Tested with:
- [x] HWE-KWH1 single-phase meter
- [x] HWE-KWH3 three-phase meter
- [x] Battery usage scenario

## Breaking Changes
None. All changes are backwards compatible with default values.