### PR TITLE
myStrom: add optional authentication token support

### DIFF
--- a/charger/mystrom.go
+++ b/charger/mystrom.go
@@ -28,6 +28,7 @@ func NewMyStromFromConfig(other map[string]any) (api.Charger, error) {
 	cc := struct {
 		embed        `mapstructure:",squash"`
 		URI          string
+		Token        string
 		StandbyPower float64
 		Cache        time.Duration
 	}{
@@ -39,7 +40,7 @@ func NewMyStromFromConfig(other map[string]any) (api.Charger, error) {
 	}
 
 	c := &MyStrom{
-		conn: mystrom.NewConnection(cc.URI),
+		conn: mystrom.NewConnection(cc.URI, cc.Token),
 	}
 
 	c.switchSocket = NewSwitchSocket(&cc.embed, c.Enabled, c.conn.CurrentPower, cc.StandbyPower)

--- a/meter/mystrom.go
+++ b/meter/mystrom.go
@@ -16,12 +16,13 @@ func init() {
 // NewMyStromFromConfig creates a myStrom meter from generic config
 func NewMyStromFromConfig(other map[string]any) (api.Meter, error) {
 	var cc struct {
-		URI string
+		URI   string
+		Token string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return mystrom.NewConnection(cc.URI), nil
+	return mystrom.NewConnection(cc.URI, cc.Token), nil
 }

--- a/meter/mystrom/mystrom.go
+++ b/meter/mystrom/mystrom.go
@@ -31,27 +31,22 @@ func NewConnection(uri, token string) *Connection {
 
 func (c *Connection) Request(path string) error {
 	uri := fmt.Sprintf("%s/%s", c.uri, path)
-	req, err := request.New(http.MethodGet, uri, nil, nil)
-	if err == nil {
-		if c.token != "" {
-			req.Header.Set("Token", c.token)
-		}
-		_, err = c.DoBody(req)
+	req, _ := request.New(http.MethodGet, uri, nil, nil)
+	if c.token != "" {
+		req.Header.Set("Token", c.token)
 	}
+	_, err := c.DoBody(req)
 	return err
 }
 
 func (c *Connection) Report() (Report, error) {
 	var res Report
 	uri := fmt.Sprintf("%s/report", c.uri)
-	req, err := request.New(http.MethodGet, uri, nil, request.AcceptJSON)
-	if err != nil {
-		return res, err
-	}
+	req, _ := request.New(http.MethodGet, uri, nil, request.AcceptJSON)
 	if c.token != "" {
 		req.Header.Set("Token", c.token)
 	}
-	err = c.DoJSON(req, &res)
+	err := c.DoJSON(req, &res)
 	return res, err
 }
 

--- a/templates/definition/charger/mystrom.yaml
+++ b/templates/definition/charger/mystrom.yaml
@@ -8,13 +8,11 @@ params:
   - name: host
   - name: token
     help:
-      en: API token (optional), only needed if token is set on device (Advanced -> Enable REST API -> Token)
-      de: API-Token (optional), nur erforderlich wenn ein Token auf Gerät gesetzt ist (Experte -> REST API aktivieren -> Token)
+      en: API token, only needed if token is set on device (Advanced -> Enable REST API -> Token)
+      de: API-Token, nur erforderlich wenn ein Token auf Gerät dem gesetzt ist (Experte -> REST API aktivieren -> Token)
   - preset: switchsocket
 render: |
   type: mystrom
   uri: http://{{ .host }}
-  {{- if .token }}
   token: {{ .token }}
-  {{- end }}
   {{ include "switchsocket" . }}

--- a/templates/definition/charger/mystrom.yaml
+++ b/templates/definition/charger/mystrom.yaml
@@ -6,8 +6,15 @@ products:
 group: switchsockets
 params:
   - name: host
+  - name: token
+    help:
+      en: API token (optional), only needed if token is set on device (Advanced -> Enable REST API -> Token)
+      de: API-Token (optional), nur erforderlich wenn ein Token auf Gerät gesetzt ist (Experte -> REST API aktivieren -> Token)
   - preset: switchsocket
 render: |
   type: mystrom
   uri: http://{{ .host }}
+  {{- if .token }}
+  token: {{ .token }}
+  {{- end }}
   {{ include "switchsocket" . }}

--- a/templates/definition/meter/mystrom.yaml
+++ b/templates/definition/meter/mystrom.yaml
@@ -8,6 +8,13 @@ params:
   - name: usage
     choice: ["pv", "charge"]
   - name: host
+  - name: token
+    help:
+      en: API token (optional), only needed if token is set on device (Advanced -> Enable REST API -> Token)
+      de: API-Token (optional), nur erforderlich wenn ein Token auf Gerät gesetzt ist (Experte -> REST API aktivieren -> Token)
 render: |
   type: mystrom
   uri: http://{{ .host }}
+  {{- if .token }}
+  token: {{ .token }}
+  {{- end }}

--- a/templates/definition/meter/mystrom.yaml
+++ b/templates/definition/meter/mystrom.yaml
@@ -10,11 +10,9 @@ params:
   - name: host
   - name: token
     help:
-      en: API token (optional), only needed if token is set on device (Advanced -> Enable REST API -> Token)
-      de: API-Token (optional), nur erforderlich wenn ein Token auf Gerät gesetzt ist (Experte -> REST API aktivieren -> Token)
+      en: API token, only needed if token is set on device (Advanced -> Enable REST API -> Token)
+      de: API-Token, nur erforderlich wenn ein Token auf Gerät dem gesetzt ist (Experte -> REST API aktivieren -> Token)
 render: |
   type: mystrom
   uri: http://{{ .host }}
-  {{- if .token }}
   token: {{ .token }}
-  {{- end }}


### PR DESCRIPTION
Add support for optional authentication token for myStrom WiFi Switch devices. The token can be configured on the device to restrict API access. When a token is set on the device, it must be provided via the `Token` HTTP header in all API requests. Devices without a token configured continue to work as before.

The authentication is described in the Security section of their API documentation:
https://api.mystrom.ch/