### PR TITLE
UI: improve CHF price format

### DIFF
--- a/assets/js/mixins/formatter.test.ts
+++ b/assets/js/mixins/formatter.test.ts
@@ -115,6 +115,20 @@ describe("pricePerKWhUnit", () => {
   });
 });
 
+describe("energyPriceSubunit", () => {
+  test("should return subunit or undefined", () => {
+    expect(fmt.energyPriceSubunit(CURRENCY.EUR)).eq("ct");
+    expect(fmt.energyPriceSubunit(CURRENCY.CNY)).eq(undefined);
+  });
+  test("should handle CHF locale-specific logic", () => {
+    config.global.mocks["$i18n"].locale = "de";
+    expect(fmt.energyPriceSubunit(CURRENCY.CHF)).eq("Rp.");
+    config.global.mocks["$i18n"].locale = "fr";
+    expect(fmt.energyPriceSubunit(CURRENCY.CHF)).eq("ct.");
+    config.global.mocks["$i18n"].locale = "de-DE";
+  });
+});
+
 describe("fmtDuration", () => {
   test("should format zero duration", () => {
     expect(fmt.fmtDuration(0)).eq("—");

--- a/assets/js/mixins/formatter.test.ts
+++ b/assets/js/mixins/formatter.test.ts
@@ -7,7 +7,7 @@ import { CURRENCY } from "@/types/evcc";
 
 const is12hSpy = vi.spyOn(units, "is12hFormat").mockReturnValue(false);
 
-config.global.mocks["$i18n"] = { locale: "de-DE" };
+config.global.mocks["$i18n"] = { locale: "de" };
 config.global.mocks["$t"] = (a: string) => a;
 
 const fmt = mount(
@@ -100,7 +100,7 @@ describe("fmtPricePerKWh", () => {
     expect(fmt.fmtPricePerKWh(0.234, CURRENCY.USD)).eq("23,4 ¢/kWh");
     expect(fmt.fmtPricePerKWh(1234, CURRENCY.SEK)).eq("123.400,0 öre/kWh");
     expect(fmt.fmtPricePerKWh(0.2, CURRENCY.EUR, false, false)).eq("20,0");
-    expect(fmt.fmtPricePerKWh(0.123, CURRENCY.CHF)).eq("12,3 rp/kWh");
+    expect(fmt.fmtPricePerKWh(0.123, CURRENCY.CHF)).eq("12,3 Rp./kWh");
   });
 });
 
@@ -111,7 +111,7 @@ describe("pricePerKWhUnit", () => {
     expect(fmt.pricePerKWhUnit(CURRENCY.USD)).eq("¢/kWh");
     expect(fmt.pricePerKWhUnit(CURRENCY.SEK)).eq("öre/kWh");
     expect(fmt.pricePerKWhUnit(CURRENCY.SEK, true)).eq("öre");
-    expect(fmt.pricePerKWhUnit(CURRENCY.CHF)).eq("rp/kWh");
+    expect(fmt.pricePerKWhUnit(CURRENCY.CHF)).eq("Rp./kWh");
   });
 });
 
@@ -125,7 +125,7 @@ describe("energyPriceSubunit", () => {
     expect(fmt.energyPriceSubunit(CURRENCY.CHF)).eq("Rp.");
     config.global.mocks["$i18n"].locale = "fr";
     expect(fmt.energyPriceSubunit(CURRENCY.CHF)).eq("ct.");
-    config.global.mocks["$i18n"].locale = "de-DE";
+    config.global.mocks["$i18n"].locale = "de";
   });
 });
 

--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -25,7 +25,6 @@ const ENERGY_PRICE_IN_SUBUNIT: Partial<Record<CURRENCY, string>> = {
   BGN: "st", // Bulgarian stotinka
   BRL: "¢", // Brazilian centavo
   CAD: "¢", // Canadian cent
-  CHF: "rp", // Swiss Rappen
   EUR: "ct", // Euro cent
   GBP: "p", // GB pence
   ILS: "ag", // Israeli agora
@@ -52,6 +51,12 @@ export default defineComponent({
     };
   },
   methods: {
+    energyPriceSubunit(currency: CURRENCY): string | undefined {
+      if (currency === CURRENCY.CHF) {
+        return this.$i18n?.locale === "de" ? "Rp." : "ct.";
+      }
+      return ENERGY_PRICE_IN_SUBUNIT[currency];
+    },
     round(num: number, precision: number) {
       const base = 10 ** precision;
       return (Math.round(num * base) / base).toFixed(precision);
@@ -305,7 +310,7 @@ export default defineComponent({
       let value = amout;
       let minimumFractionDigits = 1;
       let maximumFractionDigits = 3;
-      if (ENERGY_PRICE_IN_SUBUNIT[currency]) {
+      if (this.energyPriceSubunit(currency)) {
         value *= 100;
         minimumFractionDigits = 1;
         maximumFractionDigits = 1;
@@ -324,7 +329,7 @@ export default defineComponent({
       return Intl?.DateTimeFormat?.().resolvedOptions?.().timeZone || "UTC";
     },
     pricePerKWhUnit(currency = CURRENCY.EUR, short = false) {
-      const unit = ENERGY_PRICE_IN_SUBUNIT[currency] || CURRENCY_SYMBOLS[currency] || currency;
+      const unit = this.energyPriceSubunit(currency) || CURRENCY_SYMBOLS[currency] || currency;
       return `${unit}${short ? "" : "/kWh"}`;
     },
     fmtTimeAgo(elapsed: number) {

--- a/tests/config-tariffs.spec.ts
+++ b/tests/config-tariffs.spec.ts
@@ -68,7 +68,7 @@ grid:
     await expect(restartButton).not.toBeVisible();
 
     await expect(page.getByTestId("tariffs")).toContainText(
-      ["Currency", "CHF", "Grid price", "12.3 rp"].join("")
+      ["Currency", "CHF", "Grid price", "12.3 ct."].join("")
     );
   });
 

--- a/tests/statistics.spec.ts
+++ b/tests/statistics.spec.ts
@@ -54,7 +54,7 @@ test.describe("statistics values", async () => {
     await expect(page.getByTestId("savings-tile-solar")).toContainText("30 kWh solar");
     await expect(page.getByTestId("savings-tile-solar")).toContainText("20 kWh grid");
 
-    await expect(page.getByTestId("savings-tile-price")).toContainText("18.0rp/kWh");
+    await expect(page.getByTestId("savings-tile-price")).toContainText("18.0ct./kWh");
     await expect(page.getByTestId("savings-tile-price")).toContainText("6 Fr. saved");
 
     await expect(page.getByTestId("savings-tile-co2")).toContainText("8g/kWh");
@@ -74,7 +74,7 @@ test.describe("statistics values", async () => {
     await expect(page.getByTestId("savings-tile-solar")).toContainText("30 kWh solar");
     await expect(page.getByTestId("savings-tile-solar")).toContainText("70 kWh grid");
 
-    await expect(page.getByTestId("savings-tile-price")).toContainText("24.0rp/kWh");
+    await expect(page.getByTestId("savings-tile-price")).toContainText("24.0ct./kWh");
     await expect(page.getByTestId("savings-tile-price")).toContainText("6 Fr. saved");
 
     await expect(page.getByTestId("savings-tile-co2")).toContainText("14g/kWh");
@@ -87,7 +87,7 @@ test.describe("statistics values", async () => {
     await expect(page.getByTestId("savings-modal")).toBeVisible();
 
     await expect(page.getByTestId("savings-reference")).toContainText("Reference data:");
-    await expect(page.getByTestId("savings-reference")).toContainText("30.0 rp/kWh (grid)");
+    await expect(page.getByTestId("savings-reference")).toContainText("30.0 ct./kWh (grid)");
     await expect(page.getByTestId("savings-reference")).toContainText("⌀ 344 g/kWh");
     await expect(page.getByTestId("savings-reference")).toContainText("Germany");
 


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/7892#issuecomment-3805268172

Show Swiss energy prices in `Rp./kWh` (German) and `ct./kWh` (French, Italian, ...).

\cc @RSickenberg