### PR TITLE
Ochsner: fix setting power

### DIFF
--- a/templates/definition/charger/ochsner-bwwp.yaml
+++ b/templates/definition/charger/ochsner-bwwp.yaml
@@ -38,16 +38,16 @@ render: |
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     register:
-     address: 2000 # angezeigte Temperatur Auflösung 0,1°C
-     type: input
-     decode: uint16
-    scale: 0.1
+       address: 2000 # angezeigte Temperatur Auflösung 0,1°C
+       type: input
+       decode: uint16
+      scale: 0.1
   limittemp:
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     register:
-     address: 2203 # Legionellen/Überschuss Solltemperatur Auflösung 0,1°C
-     type: holding
-     decode: uint16
-    scale: 0.1         
+       address: 2203 # Legionellen/Überschuss Solltemperatur Auflösung 0,1°C
+       type: holding
+       decode: uint16
+      scale: 0.1

--- a/templates/definition/charger/ochsner-bwwp.yaml
+++ b/templates/definition/charger/ochsner-bwwp.yaml
@@ -10,50 +10,44 @@ params:
     default: 502
   - name: id
     default: 1
-  # - name: tempsource
-  #   type: choice
-  #   choice: ["warmwater", "buffer"]
-  #   description:
-  #     de: Temperaturquelle (Warmwasser oder Pufferspeicher)
-  #     en: Temperature source (warm water or buffer)
 render: |
   type: heatpump
   setmaxpower:
-    source: const
-    value: 0
-    set:
-      source: modbus
-      uri: {{ .host }}:{{ .port }}
-      id: {{ .id }}
-      register:
-        address: 2201 # SUR Überschussleistung Auflösung 1 W
-        type: writesingle
-        decode: int16
-  power:
+    source: watchdog
+    timeout: 600s  # da WP nach 10 min ohne Meldung abschaltet
+    set:  
+      source: delta  # nur Differenz zu letztem Wert
+      get:
+        source: modbus
+        uri: {{ .host }}:{{ .port }}
+        id: {{ .id }}
+        register:
+         address: 2012 # totale von der WP berechnete Überschussleistung Auflösung 1 W
+         type: input
+         decode: uint16
+      set:
+        source: modbus
+        uri: {{ .host }}:{{ .port }}
+        id: {{ .id }}
+        register:
+         address: 2201 # SUR Überschussleistung Auflösung 1 W
+         type: writeholding
+         decode: uint16
+  temp:
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     register:
-      address: 2010 # aktuelle Leistungsaufnahme
-      type: holding
-      decode: int16
-  # {{- if .tempsource }}
-  # temp:
-  #   source: modbus
-  #   uri: {{ .host }}:{{ .port }}
-  #   id: {{ .id }}
-  #   register:
-  #     address: 2200 # C1 Solltemperatur Auflösung 0,1°C
-  #     type: holding
-  #     decode: int16
-  #   scale: 0.1
+     address: 2000 # angezeigte Temperatur Auflösung 0,1°C
+     type: input
+     decode: uint16
+    scale: 0.1
   limittemp:
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     register:
-      address: 2200 # C1 Solltemperatur Auflösung 0,1°C
-      type: holding
-      decode: int16
-    scale: 0.1
-  # {{- end }}
+     address: 2203 # Legionellen/Überschuss Solltemperatur Auflösung 0,1°C
+     type: holding
+     decode: uint16
+    scale: 0.1         

--- a/templates/definition/charger/ochsner-bwwp.yaml
+++ b/templates/definition/charger/ochsner-bwwp.yaml
@@ -22,32 +22,32 @@ render: |
         uri: {{ .host }}:{{ .port }}
         id: {{ .id }}
         register:
-         address: 2012 # totale von der WP berechnete Überschussleistung Auflösung 1 W
-         type: input
-         decode: uint16
+          address: 2012 # totale von der WP berechnete Überschussleistung Auflösung 1 W
+          type: input
+          decode: uint16
       set:
         source: modbus
         uri: {{ .host }}:{{ .port }}
         id: {{ .id }}
         register:
-         address: 2201 # SUR Überschussleistung Auflösung 1 W
-         type: writeholding
-         decode: uint16
+          address: 2201 # SUR Überschussleistung Auflösung 1 W
+          type: writeholding
+          decode: uint16
   temp:
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     register:
-       address: 2000 # angezeigte Temperatur Auflösung 0,1°C
-       type: input
-       decode: uint16
-      scale: 0.1
+      address: 2000 # angezeigte Temperatur Auflösung 0,1°C
+      type: input
+      decode: uint16
+    scale: 0.1
   limittemp:
     source: modbus
     uri: {{ .host }}:{{ .port }}
     id: {{ .id }}
     register:
-       address: 2203 # Legionellen/Überschuss Solltemperatur Auflösung 0,1°C
-       type: holding
-       decode: uint16
-      scale: 0.1
+      address: 2203 # Legionellen/Überschuss Solltemperatur Auflösung 0,1°C
+      type: holding
+      decode: uint16
+    scale: 0.1


### PR DESCRIPTION
Update ochsner-bwwp.yaml using delta plugin

not yet implemented - another nice-to-have:
a display if the heatpump is running (not the electical heating rods) - register 2005 (Ventilator) > 0 rpm

a suggestion how to realise?