### PR TITLE
OCPP: adjust log level for new connections

### DIFF
--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -208,7 +208,7 @@ func (cs *CS) NewChargePoint(chargePoint ocpp16.ChargePointConnection) {
 
 	// register unknown charge point
 	cs.regs[chargePoint.ID()] = newRegistration()
-	cs.log.WARN.Printf("unknown charge point connected: %s", chargePoint.ID())
+	cs.log.INFO.Printf("unknown charge point connected: %s", chargePoint.ID())
 
 	cs.mu.Unlock()
 	cs.publish()


### PR DESCRIPTION
from Slack with @VolkerK62 

Reduce log level from WARN to INFO when an unknown charger connects to evcc. This is standard procedure with config ui configuration. Unknown station ids are shown/suggested in UI, no need for prominent logging any more.