### PR TITLE
TP-Link H-Series Smart Plug: add charge usage

### DIFF
--- a/templates/definition/meter/tapo.yaml
+++ b/templates/definition/meter/tapo.yaml
@@ -10,7 +10,7 @@ requirements:
     de: Die Kompatibilität mit Drittanbietern muss in der Tapo-App aktiviert werden, um evcc die Steuerung des Geräts zu ermöglichen!
 params:
   - name: usage
-    choice: ["pv"]
+    choice: ["pv", "charge"]
   - name: host
   - name: user
     required: true

--- a/templates/definition/meter/tplink.yaml
+++ b/templates/definition/meter/tplink.yaml
@@ -6,7 +6,7 @@ products:
 group: switchsockets
 params:
   - name: usage
-    choice: ["pv"]
+    choice: ["pv", "charge"]
   - name: host
 render: |
   type: tplink


### PR DESCRIPTION
TP-Link HS110 is only meant to measure the consumption of the connected device (no bidirectional measurement). So it is not meant to measure production of a PV (Balkonsolar). HS100 does not measure at all.

So does it make sense to remove “pv” usage and make the meter template HS110 only? Or are there any other H-Series Smart Plugs than the HS110 that can perform metering?