### PR TITLE
Add EpexPredictor

### DIFF
--- a/templates/definition/tariff/epex-predictor.yaml
+++ b/templates/definition/tariff/epex-predictor.yaml
@@ -22,25 +22,31 @@ params:
     type: choice
     choice: ["DE", "AT", "NL", "BE", "SE_1", "SE_2", "SE_3", "SE_4", "DK_1", "DK_2"]
     required: true
-  - name: surcharge
-    example: 13.15
+  - name: charges
+    example: 0.1315
     type: float
     required: true
     description:
-      en: Surcharge in ct/kWh
-      de: Aufschlag in ct/kWh
-  - name: taxPercent
-    example: 19
+      en: Surcharge in EUR/kWh
+      de: Aufschlag in EUR/kWh
+    help:
+      en: e.g., 0.1315 for 13.15 ct/kWh
+      de: z.B. 0.1315 für 13,15 ct/kWh
+  - name: tax
+    example: 0.19
     type: float
     required: true
     description:
-      en: Tax percentage (e.g., 19 for 19%)
-      de: MwSt. in Prozent (z.B. 19 für 19%)
+      en: Tax rate
+      de: Steuersatz
+    help:
+      en: e.g., 0.19 for 19%
+      de: z.B. 0.19 für 19%
 render: |
   type: custom
   forecast:
     source: http
-    uri: {{ .uri }}/prices?region={{ .region }}&surcharge={{ .surcharge }}&taxPercent={{ .taxPercent }}&unit=EUR_PER_KWH&timezone=UTC
+    uri: {{ .uri }}/prices?region={{ .region }}&surcharge={{ mul .charges 100 }}&taxPercent={{ mul .tax 100 }}&unit=EUR_PER_KWH&timezone=UTC
     jq: |
       [.prices[] | {
         "start": .startsAt,

--- a/templates/definition/tariff/epex-predictor.yaml
+++ b/templates/definition/tariff/epex-predictor.yaml
@@ -1,0 +1,43 @@
+template: epex-predictor
+products:
+  - brand: EPEX Predictor
+    description:
+      generic: Predicted EPEX spot prices
+requirements:
+  description:
+    de: EPEX Spot Preisvorhersagen von epexpredictor.batzill.com
+    en: EPEX spot price predictions from epexpredictor.batzill.com
+  evcc: ["skiptest"]
+group: price
+countries: ["DE", "AT", "NL", "BE", "SE", "DK"]
+params:
+  - name: region
+    example: DE
+    type: choice
+    choice: ["DE", "AT", "NL", "BE", "SE_1", "SE_2", "SE_3", "SE_4", "DK_1", "DK_2"]
+    required: true
+  - name: surcharge
+    example: 13.15
+    type: float
+    required: true
+    description:
+      en: Surcharge in ct/kWh
+      de: Aufschlag in ct/kWh
+  - name: taxPercent
+    example: 19
+    type: float
+    required: true
+    description:
+      en: Tax percentage (e.g., 19 for 19%)
+      de: MwSt. in Prozent (z.B. 19 für 19%)
+render: |
+  type: custom
+  forecast:
+    source: http
+    uri: https://epexpredictor.batzill.com/prices?region={{ .region }}&surcharge={{ .surcharge }}&taxPercent={{ .taxPercent }}&unit=EUR_PER_KWH&timezone=UTC
+    jq: |
+      [.prices[] | {
+        "start": .startsAt,
+        "end": (.startsAt | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime + 900 | strftime("%Y-%m-%dT%H:%M:%SZ")),
+        "value": .total
+      }] | tostring

--- a/templates/definition/tariff/epex-predictor.yaml
+++ b/templates/definition/tariff/epex-predictor.yaml
@@ -22,31 +22,12 @@ params:
     type: choice
     choice: ["DE", "AT", "NL", "BE", "SE_1", "SE_2", "SE_3", "SE_4", "DK_1", "DK_2"]
     required: true
-  - name: charges
-    example: 0.1315
-    type: float
-    required: true
-    description:
-      en: Surcharge in EUR/kWh
-      de: Aufschlag in EUR/kWh
-    help:
-      en: e.g., 0.1315 for 13.15 ct/kWh
-      de: z.B. 0.1315 für 13,15 ct/kWh
-  - name: tax
-    example: 0.19
-    type: float
-    required: true
-    description:
-      en: Tax rate
-      de: Steuersatz
-    help:
-      en: e.g., 0.19 for 19%
-      de: z.B. 0.19 für 19%
+  - preset: tariff-base
 render: |
   type: custom
   forecast:
     source: http
-    uri: {{ .uri }}/prices?region={{ .region }}&surcharge={{ mul .charges 100 }}&taxPercent={{ mul .tax 100 }}&unit=EUR_PER_KWH&timezone=UTC
+    uri: {{ .uri }}/prices?region={{ .region }}&surcharge={{ mulf .charges 100 }}&taxPercent={{ mulf .tax 100 }}&unit=EUR_PER_KWH&timezone=UTC
     jq: |
       [.prices[] | {
         "start": .startsAt,

--- a/templates/definition/tariff/epex-predictor.yaml
+++ b/templates/definition/tariff/epex-predictor.yaml
@@ -11,6 +11,12 @@ requirements:
 group: price
 countries: ["DE", "AT", "NL", "BE", "SE", "DK"]
 params:
+  - name: uri
+    default: https://epexpredictor.batzill.com
+    description:
+      en: API endpoint (for self-hosted instances)
+      de: API-Endpunkt (für selbst gehostete Instanzen)
+    advanced: true
   - name: region
     example: DE
     type: choice
@@ -34,7 +40,7 @@ render: |
   type: custom
   forecast:
     source: http
-    uri: https://epexpredictor.batzill.com/prices?region={{ .region }}&surcharge={{ .surcharge }}&taxPercent={{ .taxPercent }}&unit=EUR_PER_KWH&timezone=UTC
+    uri: {{ .uri }}/prices?region={{ .region }}&surcharge={{ .surcharge }}&taxPercent={{ .taxPercent }}&unit=EUR_PER_KWH&timezone=UTC
     jq: |
       [.prices[] | {
         "start": .startsAt,

--- a/templates/definition/tariff/epex-predictor.yaml
+++ b/templates/definition/tariff/epex-predictor.yaml
@@ -25,9 +25,10 @@ params:
   - preset: tariff-base
 render: |
   type: custom
+  {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: {{ .uri }}/prices?region={{ .region }}&surcharge={{ mulf .charges 100 }}&taxPercent={{ mulf .tax 100 }}&unit=EUR_PER_KWH&timezone=UTC
+    uri: {{ .uri }}/prices?region={{ .region }}&unit=EUR_PER_KWH&timezone=UTC
     jq: |
       [.prices[] | {
         "start": .startsAt,

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -525,7 +525,7 @@ presets:
     - name: language
   tariff-base:
     - name: charges
-      type: int
+      type: float
       advanced: true
       description:
         en: Charge
@@ -534,7 +534,7 @@ presets:
         de: Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent)
         en: Additional fixed charge per kWh (e.g. 0.05 for 5 cents)
     - name: tax
-      type: int
+      type: float
       advanced: true
       description:
         en: Tax


### PR DESCRIPTION
Add a template to use https://github.com/b3nn0/EpexPredictor for price prediction. Defaults to the public API, for a private instance use the "uri" setting.

The API call is the same as the suggested custom HTTP call from the EpexPredictor documentation: https://github.com/b3nn0/EpexPredictor?tab=readme-ov-file#evcc-integration
