### PR TITLE
fix: resolves issues with wallbox pulsar plus

### DIFF
--- a/charger/ocpp/connector_requests.go
+++ b/charger/ocpp/connector_requests.go
@@ -19,6 +19,10 @@ func (conn *Connector) RemoteStartTransactionRequest(idTag string) error {
 	return conn.cp.RemoteStartTransactionRequest(conn.id, idTag)
 }
 
+func (conn *Connector) RemoteStopTransactionRequest(transactionId int) error {
+	return conn.cp.RemoteStopTransactionRequest(transactionId)
+}
+
 func (conn *Connector) SetChargingProfileRequest(profile *types.ChargingProfile) error {
 	return conn.cp.SetChargingProfileRequest(conn.id, profile)
 }

--- a/charger/ocpp/cp_requests.go
+++ b/charger/ocpp/cp_requests.go
@@ -57,6 +57,20 @@ func (cp *CP) RemoteStartTransactionRequest(connectorId int, idTag string) error
 	return wait(err, rc)
 }
 
+func (cp *CP) RemoteStopTransactionRequest(transactionId int) error {
+	rc := make(chan error, 1)
+
+	err := Instance().RemoteStopTransaction(cp.id, func(request *core.RemoteStopTransactionConfirmation, err error) {
+		if err == nil && request != nil && request.Status != types.RemoteStartStopStatusAccepted {
+			err = errors.New(string(request.Status))
+		}
+
+		rc <- err
+	}, transactionId)
+
+	return wait(err, rc)
+}
+
 func (cp *CP) SetChargingProfileRequest(connectorId int, profile *types.ChargingProfile) error {
 	rc := make(chan error, 1)
 


### PR DESCRIPTION
This pull request introduces several improvements to OCPP charger transaction management and loadpoint synchronization logic. The main focus is on ensuring that active transactions are properly stopped before disabling the charger, refining the handling of charging profiles, and improving the consistency of charger state and current settings.

**OCPP Transaction and Availability Management:**

* When disabling the charger via `OCPP.Enable`, the code now attempts to remotely stop any active transaction before making the connector inoperative, ensuring proper transaction closure and state synchronization. (`charger/ocpp.go`)
* Added `RemoteStopTransactionRequest` methods to both `Connector` and `CP` to enable remote stopping of transactions through the OCPP protocol. (`charger/ocpp/connector_requests.go`, `charger/ocpp/cp_requests.go`) [[1]](diffhunk://#diff-83322d3a749f99a3662cdab827d09e7249a60531a70677cee6d76465b5b97295R22-R25) [[2]](diffhunk://#diff-543bc3cec27859e53f5e06cd649df1a070e1eb3271d9126e02b912e227f03dfaR60-R73)
* The charging profile creation now always sets stack level 0 for TxDefault profiles, following OCPP 1.6 specification, and clarifies phase handling defaults. (`charger/ocpp.go`) [[1]](diffhunk://#diff-428bcc3f4e7da95e0dbd70c679c4cd4c4f672004721185ee58131593bfa12d92R338-R350) [[2]](diffhunk://#diff-428bcc3f4e7da95e0dbd70c679c4cd4c4f672004721185ee58131593bfa12d92L348-R370)

**Loadpoint Synchronization and Error Handling:**

* Improved logic in `Loadpoint.syncCharger` to actively correct current mismatches only when charging, and to handle correction failures by updating the offered current and publishing the change. (`core/loadpoint.go`) [[1]](diffhunk://#diff-c456526d4bd9022a488ce32de208b40d86016e2c40b0c81a2dffe557c186377dL779-R789) [[2]](diffhunk://#diff-c456526d4bd9022a488ce32de208b40d86016e2c40b0c81a2dffe557c186377dL794-R810)
* Enhanced handling of enabled state mismatches to ignore noise when the vehicle is unplugged and charger is idle, reducing unnecessary warnings. (`core/loadpoint.go`)

**Documentation and Minor Corrections:**

* Fixed a comment typo to reference the correct error type for phase switching availability. (`core/loadpoint.go`)