### PR TITLE
chore: add deprecated template test

### DIFF
--- a/tests/config-deprecated-false.tpl.yaml
+++ b/tests/config-deprecated-false.tpl.yaml
@@ -1,0 +1,18 @@
+template: deprecated-meter
+# deprecated: true
+group: generic
+products:
+  - description:
+      generic: Old Meter
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: power
+    description:
+      generic: Power
+
+render: |
+  type: custom
+  power:
+    source: const
+    value: {{ .power }}

--- a/tests/config-deprecated-true.tpl.yaml
+++ b/tests/config-deprecated-true.tpl.yaml
@@ -1,0 +1,18 @@
+template: deprecated-meter
+deprecated: true
+group: generic
+products:
+  - description:
+      generic: Deprecated Meter
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: power
+    description:
+      generic: Power
+
+render: |
+  type: custom
+  power:
+    source: const
+    value: {{ .power }}

--- a/tests/config-deprecated.spec.ts
+++ b/tests/config-deprecated.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, restart, baseUrl } from "./evcc";
+import { expectModalVisible, expectModalHidden } from "./utils";
+
+test.use({ baseURL: baseUrl() });
+
+const flags = ["--disable-auth", "--template-type", "meter", "--template"];
+const templateFlags = [...flags, "tests/config-deprecated-false.tpl.yaml"];
+const deprecatedFlags = [...flags, "tests/config-deprecated-true.tpl.yaml"];
+
+test.beforeAll(async () => {
+  await start(undefined, undefined, templateFlags);
+});
+
+test.afterAll(async () => {
+  await stop();
+});
+
+test.describe("deprecated template", async () => {
+  test("editable after deprecation", async ({ page }) => {
+    await page.goto("/#/config");
+
+    await page.getByRole("button", { name: "Add grid meter" }).click();
+    const meterModal = page.getByTestId("meter-modal");
+    await expectModalVisible(meterModal);
+    await meterModal.getByLabel("Manufacturer").selectOption("Old Meter");
+    await meterModal.getByLabel("Power").fill("5000");
+    await meterModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(meterModal);
+
+    await expect(page.getByTestId("grid")).toBeVisible();
+    await expect(page.getByTestId("grid")).toContainText("Grid meter");
+
+    await restart(undefined, deprecatedFlags);
+    await page.reload();
+
+    await expect(page.getByTestId("grid")).toBeVisible();
+
+    await page.getByTestId("grid").getByRole("button", { name: "edit" }).click();
+    await expectModalVisible(meterModal);
+    await expect(meterModal.getByLabel("Manufacturer")).toHaveValue("Old Meter");
+    await expect(meterModal.getByLabel("Power")).toHaveValue("5000");
+    await meterModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(meterModal);
+
+    await page.getByTestId("grid").getByRole("button", { name: "edit" }).click();
+    await expectModalVisible(meterModal);
+    await meterModal.getByRole("button", { name: "Delete" }).click();
+    await expectModalHidden(meterModal);
+
+    await expect(page.getByTestId("grid")).not.toBeVisible();
+
+    await page.getByRole("button", { name: "Add grid meter" }).click();
+    await expectModalVisible(meterModal);
+    const manufacturerSelect = meterModal.getByLabel("Manufacturer");
+    const options = await manufacturerSelect.locator("option").allTextContents();
+    expect(options).not.toContain("Old Meter");
+    expect(options).not.toContain("Deprecated Meter");
+  });
+});


### PR DESCRIPTION
verifies https://github.com/evcc-io/evcc/pull/26970#issuecomment-3835688346

Add test case to ensure that devices remain editable in UI when their templates become deprecated. Deprecated templates can not be selected for creating a new device.