### PR TITLE
Uncached UI reload after update

### DIFF
--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -45,6 +45,7 @@ func getPreferredLanguage(header string) string {
 func indexHandler(customCss bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		w.Header().Set("Cache-Control", "no-cache")
 
 		indexTemplate, err := fs.ReadFile(assets.Web, "index.html")
 		if err != nil {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/27168

The UI already has a version watcher and auto-reload mechanism that triggers when a new evcc version (stable, nightly) is deployed. However, the initial HTML is cache-allowed which may lead to stale UI code even after refresh.

Adding explicit `Cache-Control: no-cache` for our initial HTML to prevent browser caching.

Note: Static assets (JS, CSS) are still cache-allowed since we use proper file name hashing.