### PR TITLE
Fix issue with MD5  hash

### DIFF
--- a/vehicle/saic/requests/helper.go
+++ b/vehicle/saic/requests/helper.go
@@ -13,7 +13,8 @@ func sum(hash hash.Hash, value string) string {
 	if len(value) == 0 {
 		return ""
 	}
-	return hex.EncodeToString(hash.Sum([]byte(value)))
+	hash.Write([]byte(value))
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 func Md5(value string) string {


### PR DESCRIPTION
`MD5.new()` returns a hash interface. Its sum() function is different from the MD5.sum() function. This is why all requests failed.

`MD5.sum()` returns the checksum of the data given in the call. This has been used inthe original code

`MD5.New` returns a new [hash.Hash](https://pkg.go.dev/hash#Hash)

`Hash.Sum(b [][byte](https://pkg.go.dev/builtin#byte)) [][byte](https://pkg.go.dev/builtin#byte)`
appends the current hash to b and returns the resulting slice.
It does not change the underlying hash state.

Since the current Hash is empty calling `Hash.sum("anything")` will return "anything", not the hash of "anything".