### PR TITLE
Tariff: Expand epexprijzen.nl template to allow excluding taxes and charges

### DIFF
--- a/templates/definition/tariff/epexprijzen-nl.yaml
+++ b/templates/definition/tariff/epexprijzen-nl.yaml
@@ -67,8 +67,8 @@ render: |
     uri: https://epexprijzen.nl/api/v1/prices/{{ .provider }}/{{ index . "price-interval" }}
     jq: |
       . as $root |
-      ({{ if index . "exclude-energy-tax" }}$root.energy_tax{{ else }}0{{ end }}) as $energy_tax |
-      ({{ if index . "exclude-provider-charge" }}$root.provider_charge{{ else }}0{{ end }}) as $provider_charge |
+      ({{ if index . "exclude-energy-tax" }}($root.energy_tax // 0){{ else }}0{{ end }}) as $energy_tax |
+      ({{ if index . "exclude-provider-charge" }}($root.provider_charge // 0){{ else }}0{{ end }}) as $provider_charge |
       ($root.today // []) + ($root.tomorrow // []) | 
       map({
         "start": (.t | strptime("%Y-%m-%dT%H:%M:%S%z") | strftime("%Y-%m-%dT%H:%M:%SZ")),

--- a/templates/definition/tariff/epexprijzen-nl.yaml
+++ b/templates/definition/tariff/epexprijzen-nl.yaml
@@ -2,8 +2,8 @@ template: epexprijzen-nl
 products:
   - brand: epexprijzen.nl
     description:
-      en: Current energy prices in the Netherlands, including surcharges and taxes
-      de: Aktuelle Energiepreise in den Niederlanden, einschließlich Zuschlägen und Steuern
+      en: Current energy prices in the Netherlands, with optional surcharges and taxes
+      de: Aktuelle Energiepreise in den Niederlanden, mit optionalen Zuschlägen und Steuern
 requirements:
   evcc: ["skiptest"]
 group: price
@@ -43,6 +43,18 @@ params:
     choice: ["hourly", "quarterly"]
     default: quarterly
     required: true
+  - name: exclude-energy-tax
+    description:
+      en: Exclude energy tax from prices
+      de: Energiesteuer von Preisen ausschließen
+    type: bool
+    default: false
+  - name: exclude-provider-charge
+    description:
+      en: Exclude provider charge from prices
+      de: Anbietergebühr von Preisen ausschließen
+    type: bool
+    default: false
   - preset: tariff-base
   - name: interval
     default: 1h
@@ -54,11 +66,14 @@ render: |
     source: http
     uri: https://epexprijzen.nl/api/v1/prices/{{ .provider }}/{{ index . "price-interval" }}
     jq: |
-      (.today // []) + (.tomorrow // []) | 
+      . as $root |
+      ({{ if index . "exclude-energy-tax" }}$root.energy_tax{{ else }}0{{ end }}) as $energy_tax |
+      ({{ if index . "exclude-provider-charge" }}$root.provider_charge{{ else }}0{{ end }}) as $provider_charge |
+      ($root.today // []) + ($root.tomorrow // []) | 
       map({
         "start": (.t | strptime("%Y-%m-%dT%H:%M:%S%z") | strftime("%Y-%m-%dT%H:%M:%SZ")),
         "end": (.t | strptime("%Y-%m-%dT%H:%M:%S%z") | mktime + {{ if eq (index . "price-interval") "hourly" }}3600{{ else }}900{{ end }} | strftime("%Y-%m-%dT%H:%M:%SZ")),
-        "value": .price
+        "value": (.price - $energy_tax - $provider_charge)
       }) | tostring
     cache: 1h
   interval: {{ .interval }}


### PR DESCRIPTION
## Add optional tax and charge exclusion to epexprijzen-nl template

### Summary
Adds two optional boolean parameters to exclude energy tax and provider charges from prices.

### Motivation
When "salderen" (net metering) ends in the Netherlands, feed-in prices will be calculated excluding energy taxes and provider charges. This change makes the template flexible enough to properly handle both grid consumption (taxes included) and feed-in tariffs (taxes excluded).

### Changes
- Added `exclude-energy-tax` parameter (default: `false`)
- Added `exclude-provider-charge` parameter (default: `false`)
- Modified jq logic to conditionally subtract these values from API prices

### Example Usage

    tariffs:
      grid:
        type: template
        template: epexprijzen-nl
        provider: frank-energie
        price-interval: hourly
        exclude-energy-tax: false      # Grid prices include tax

      feedin:
        type: template
        template: epexprijzen-nl
        provider: frank-energie
        price-interval: hourly
        exclude-energy-tax: true       # Feed-in prices exclude tax
        exclude-provider-charge: true  # Feed-in prices exclude charges

### Backward Compatibility
Fully backward compatible - existing configurations work unchanged (both default to `false`).