### PR TITLE
fix: restore battery settings when battery is removed

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -303,23 +303,22 @@ func (site *Site) restoreSettings() error {
 		return nil
 	}
 	if v, err := settings.Float(keys.BufferSoc); err == nil {
-		if err := site.SetBufferSoc(v); err != nil {
+		if err := site.SetBufferSoc(v); err != nil && !errors.Is(err, ErrBatteryNotConfigured) {
 			return err
 		}
 	}
 	if v, err := settings.Float(keys.BufferStartSoc); err == nil {
-		if err := site.SetBufferStartSoc(v); err != nil {
+		if err := site.SetBufferStartSoc(v); err != nil && !errors.Is(err, ErrBatteryNotConfigured) {
 			return err
 		}
 	}
-	// TODO migrate from YAML
 	if v, err := settings.Float(keys.PrioritySoc); err == nil {
-		if err := site.SetPrioritySoc(v); err != nil {
+		if err := site.SetPrioritySoc(v); err != nil && !errors.Is(err, ErrBatteryNotConfigured) {
 			return err
 		}
 	}
 	if v, err := settings.Bool(keys.BatteryDischargeControl); err == nil {
-		if err := site.SetBatteryDischargeControl(v); err != nil {
+		if err := site.SetBatteryDischargeControl(v); err != nil && !errors.Is(err, ErrBatteryControlNotAvailable) {
 			return err
 		}
 	}
@@ -329,7 +328,7 @@ func (site *Site) restoreSettings() error {
 		}
 	}
 	if v, err := settings.Float(keys.BatteryGridChargeLimit); err == nil {
-		if err := site.SetBatteryGridChargeLimit(&v); err != nil {
+		if err := site.SetBatteryGridChargeLimit(&v); err != nil && !errors.Is(err, ErrBatteryControlNotAvailable) {
 			return err
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/27221

Don't abort settings restore if no battery was found (user deleted) or battery capabilities changed (template update).
Validation (battery exists, battery controllable) will still apply when trying to change settings at runtime via API.