### PR TITLE
Add Redfish BMC power meter template

### DIFF
--- a/templates/definition/meter/redfish-power.yaml
+++ b/templates/definition/meter/redfish-power.yaml
@@ -38,12 +38,18 @@ params:
       de: Redfish / BMC Benutzername
       en: Redfish / BMC username
     required: true
+    help:
+      de: "Empfohlen: Separaten Nur-Lese-Account anlegen"
+      en: "Recommended: Create separate read-only account"
   - name: password
     description:
       de: Redfish / BMC Passwort
       en: Redfish / BMC password
     required: true
     mask: true
+    help:
+      de: "Empfohlen: Separaten Nur-Lese-Account anlegen"
+      en: "Recommended: Create separate read-only account"
   - name: chassis
     default: "1"
     description:
@@ -53,14 +59,14 @@ params:
       de: Standard "1" für die meisten Hersteller. Dell iDRAC benötigt "System.Embedded.1"
       en: Default "1" for most vendors. Dell iDRAC requires "System.Embedded.1"
   - name: insecure
-    default: true
+    default: false
     type: bool
     description:
       de: TLS-Zertifikatsüberprüfung überspringen
       en: Skip TLS certificate verification
     help:
-      de: Nur in vertrauenswürdigen Netzwerken verwenden! BMCs nutzen selbstsignierte Zertifikate
-      en: Only use in trusted networks! BMCs use self-signed certificates
+      de: Auf 'true' setzen für selbstsignierte Zertifikate (Standard bei BMCs). Nur in vertrauenswürdigen Netzwerken verwenden!
+      en: Set to 'true' for self-signed certificates (common on BMCs). Only use in trusted networks!
 render: |
   type: custom
   power:

--- a/templates/definition/meter/redfish-power.yaml
+++ b/templates/definition/meter/redfish-power.yaml
@@ -1,0 +1,74 @@
+template: redfish-power
+products:
+  - brand: Redfish-compatible
+    description:
+      de: BMC
+      en: BMC
+  - brand: Supermicro
+    description:
+      de: IPMI BMC
+      en: IPMI BMC
+requirements:
+  description:
+    de: |
+      Redfish-kompatible BMC-Leistungsmessung für Server.
+
+      Hinweise:
+      - Manche BMCs benötigen kostenpflichtige Lizenzen
+      - Manche Systeme zeigen dauerhaft 0 Watt an (keine Sensoren)
+      - Kompatibilität vorab per curl-Test oder Web-Interface prüfen
+    en: |
+      Redfish-compatible BMC power measurement for servers.
+
+      Notes:
+      - Some BMCs require paid licenses
+      - Some systems always report 0 Watts (no sensors)
+      - Test compatibility beforehand via curl or web interface
+params:
+  - name: usage
+    choice: ["charge"]
+    default: charge
+  - name: host
+    required: true
+    help:
+      de: Hostname oder IP-Adresse des BMC
+      en: Hostname or IP address of the BMC
+  - name: user
+    description:
+      de: Redfish / BMC Benutzername
+      en: Redfish / BMC username
+    required: true
+  - name: password
+    description:
+      de: Redfish / BMC Passwort
+      en: Redfish / BMC password
+    required: true
+    mask: true
+  - name: chassis
+    default: "1"
+    description:
+      de: Redfish Chassis ID
+      en: Redfish Chassis ID
+    help:
+      de: Standard "1" für die meisten Hersteller. Dell iDRAC benötigt "System.Embedded.1"
+      en: Default "1" for most vendors. Dell iDRAC requires "System.Embedded.1"
+  - name: insecure
+    default: true
+    type: bool
+    description:
+      de: TLS-Zertifikatsüberprüfung überspringen
+      en: Skip TLS certificate verification
+    help:
+      de: Nur in vertrauenswürdigen Netzwerken verwenden! BMCs nutzen selbstsignierte Zertifikate
+      en: Only use in trusted networks! BMCs use self-signed certificates
+render: |
+  type: custom
+  power:
+    source: http
+    uri: https://{{ .host }}/redfish/v1/Chassis/{{ .chassis }}/Power
+    method: GET
+    insecure: {{ .insecure }}
+    headers:
+    - Accept: application/json
+    - Authorization: Basic {{ printf "%s:%s" .user .password | b64enc }}
+    jq: .PowerControl[0].PowerConsumedWatts // .PowerControl[0].PowerInputWatts // .PowerMetrics.AverageConsumedWatts // 0


### PR DESCRIPTION
Server power monitoring via Redfish-compatible BMCs.

Tested on Supermicro IPMI on Mainboard X12SPI-TF (Redfish 1.6)

- Power monitoring via Redfish API
- Configurable chassis ID
- Optional TLS verification skip

Template should work with other Redfish-compatible BMCs (HPE iLO, Dell iDRAC, Lenovo XClarity, etc.), but only Supermicro was tested, so only Supermicro and a generic Redfish-compatible device are listed