### PR TITLE
Home Assistant: prevent auth creation on uri type

### DIFF
--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -325,7 +325,7 @@ export default defineComponent({
 			return this.templateParams.filter((p) => p.Advanced || p.Deprecated);
 		},
 		visibleParams() {
-			return this.authRequired ? this.authParams : this.normalParams;
+			return this.authRequired ? this.authParams : this.templateParams;
 		},
 		modbus(): ModbusParam | undefined {
 			const params = this.template?.Params || [];

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -324,6 +324,9 @@ export default defineComponent({
 		advancedParams() {
 			return this.templateParams.filter((p) => p.Advanced || p.Deprecated);
 		},
+		visibleParams() {
+			return this.authRequired ? this.authParams : this.normalParams;
+		},
 		modbus(): ModbusParam | undefined {
 			const params = this.template?.Params || [];
 			return (params as ModbusParam[]).find((p) => p.Name === "modbus");
@@ -744,7 +747,8 @@ export default defineComponent({
 				clearTimeout(this.serviceValuesTimer);
 			}
 			this.serviceValuesTimer = setTimeout(async () => {
-				this.serviceValues = await fetchServiceValues(this.templateParams, {
+				// Fetch only visible params to prevent premature auth instance creation
+				this.serviceValues = await fetchServiceValues(this.visibleParams, {
 					...this.modbusDefaults,
 					...this.values,
 				});


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/26802

Issue: Param value suggestions (`service`) were executed for all params of the template. Even for still invisible params. This triggered API calls like `/api/config/service/homeassistant/entities?uri=homeass...&domain=sensor` which intern did not check for an established auth but instead lazily created new instances.

With this change the `service` endpoints for all params are only done if auth is established. 

\\cc @iseeberg79 
