### PR TITLE
OCPP: wait for BootNotification after CP connection

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -217,6 +217,11 @@ func NewOCPP(ctx context.Context,
 
 	// monitor for charger reboots and re-run setup (once per CP, not per connector)
 	cp.StartMonitor(func() {
+		// drain boot notification from initial setup
+		select {
+		case <-cp.BootNotificationC():
+		default:
+		}
 		go c.monitorReboot(ctx, meterValues, meterInterval, forcePowerCtrl)
 	})
 

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -217,8 +217,10 @@ func NewOCPP(ctx context.Context,
 		go conn.WatchDog(ctx, 10*time.Second)
 	}
 
-	// monitor for charger reboots and re-run setup
-	go c.monitorReboot(ctx, meterValues, meterInterval, forcePowerCtrl)
+	// monitor for charger reboots and re-run setup (once per CP, not per connector)
+	cp.StartMonitor(func() {
+		go c.monitorReboot(ctx, meterValues, meterInterval, forcePowerCtrl)
+	})
 
 	return c, conn.Initialized()
 }

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -182,7 +182,7 @@ func NewOCPP(ctx context.Context,
 				case <-ctx.Done():
 					return ctx.Err()
 				case <-timeout:
-					return err
+					return api.ErrTimeout
 				case <-cp.BootNotificationC():
 				}
 			}

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -237,11 +237,6 @@ func (c *OCPP) monitorReboot(ctx context.Context, meterValues string, meterInter
 			return
 
 		case boot := <-c.cp.BootNotificationC():
-			// only re-initialize if the charge point was previously initialized
-			if !c.cp.Initialized() {
-				continue
-			}
-
 			c.log.INFO.Printf("charger reboot detected (model: %s, vendor: %s), re-initializing",
 				boot.ChargePointModel, boot.ChargePointVendor)
 

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -181,7 +181,8 @@ func NewOCPP(ctx context.Context,
 					return ctx.Err()
 				case <-time.After(connectTimeout):
 					return api.ErrTimeout
-				case <-cp.BootNotificationC():
+					// TODO remove here since handled below?
+					// case <-cp.BootNotificationC():
 				}
 			}
 		},
@@ -216,45 +217,11 @@ func NewOCPP(ctx context.Context,
 	}
 
 	// monitor for charger reboots and re-run setup (once per CP, not per connector)
-	cp.StartMonitor(func() {
-		// drain boot notification from initial setup
-		select {
-		case <-cp.BootNotificationC():
-		default:
-		}
-		go c.monitorReboot(ctx, meterValues, meterInterval, forcePowerCtrl)
+	cp.MonitorReboot(ctx, func() error {
+		return c.cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl)
 	})
 
 	return c, conn.Initialized()
-}
-
-// monitorReboot watches for charger reboots (detected via BootNotification
-// after initial setup) and re-runs setup to reconfigure the charger.
-func (c *OCPP) monitorReboot(ctx context.Context, meterValues string, meterInterval time.Duration, forcePowerCtrl bool) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-
-		case boot := <-c.cp.BootNotificationC():
-			c.log.INFO.Printf("charger reboot detected (model: %s, vendor: %s), re-initializing",
-				boot.ChargePointModel, boot.ChargePointVendor)
-
-			if err := c.cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl); err != nil {
-				c.log.ERROR.Printf("failed to re-initialize after reboot: %v, retrying", err)
-
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(ocpp.Timeout):
-				}
-
-				if err := c.cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl); err != nil {
-					c.log.ERROR.Printf("failed to re-initialize after reboot: %v", err)
-				}
-			}
-		}
-	}
 }
 
 // Connector returns the connector instance

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -166,25 +166,7 @@ func NewOCPP(ctx context.Context,
 			case <-cp.HasConnected():
 			}
 
-			// retry setup on failure; handles firmware that connects
-			// but doesn't respond until after reconnect
-			for {
-				err := cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl)
-				if err == nil {
-					return nil
-				}
-
-				log.WARN.Printf("setup failed: %v, waiting for reconnect", err)
-
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-time.After(connectTimeout):
-					return api.ErrTimeout
-					// TODO remove here since handled below?
-					// case <-cp.BootNotificationC():
-				}
-			}
+			return cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl)
 		},
 	)
 	if err != nil {

--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -117,7 +117,7 @@ func (conn *Connector) WatchDog(ctx context.Context, timeout time.Duration) {
 		update := conn.clock.Since(conn.meterUpdated) > timeout
 		conn.mu.Unlock()
 
-		if update && conn.cp.Connected() {
+		if update {
 			conn.TriggerMessageRequest(core.MeterValuesFeatureName)
 		}
 

--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -117,7 +117,7 @@ func (conn *Connector) WatchDog(ctx context.Context, timeout time.Duration) {
 		update := conn.clock.Since(conn.meterUpdated) > timeout
 		conn.mu.Unlock()
 
-		if update {
+		if update && conn.cp.Connected() {
 			conn.TriggerMessageRequest(core.MeterValuesFeatureName)
 		}
 

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -145,6 +145,10 @@ func (cp *CP) onTransportConnect() {
 	}
 
 	cp.bootTimer = time.AfterFunc(Timeout, func() {
+		cp.mu.Lock()
+		cp.bootTimer = nil
+		cp.mu.Unlock()
+
 		if !cp.Connected() {
 			cp.log.DEBUG.Printf("boot notification timeout, proceeding")
 			cp.connect(true)

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -16,6 +16,7 @@ type CP struct {
 	mu          sync.RWMutex
 	log         *util.Logger
 	onceConnect sync.Once
+	onceMonitor sync.Once
 
 	id string
 
@@ -179,4 +180,10 @@ func (cp *CP) HasConnected() <-chan struct{} {
 // BootNotificationC returns the channel for monitoring BootNotification messages.
 func (cp *CP) BootNotificationC() <-chan *core.BootNotificationRequest {
 	return cp.bootNotificationRequestC
+}
+
+// StartMonitor ensures the given function runs only once per CP instance.
+// Used to start the reboot monitor goroutine for multi-connector charge points.
+func (cp *CP) StartMonitor(start func()) {
+	cp.onceMonitor.Do(start)
 }

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -145,18 +145,22 @@ func (cp *CP) onTransportConnect() {
 		cp.bootTimer.Stop()
 	}
 
-	cp.bootTimer = time.AfterFunc(Timeout, func() {
-		cp.mu.Lock()
-		cp.bootTimer = nil
-		cp.mu.Unlock()
-
-		if !cp.Connected() {
-			cp.log.DEBUG.Printf("boot notification timeout, proceeding")
-			cp.connect(true)
-		}
-	})
+	cp.bootTimer = time.AfterFunc(Timeout, cp.onBootTimeout)
 
 	cp.mu.Unlock()
+}
+
+// onBootTimeout is called when the BootNotification wait timer expires.
+func (cp *CP) onBootTimeout() {
+	cp.mu.Lock()
+	cp.bootTimer = nil
+	connected := cp.connected
+	cp.mu.Unlock()
+
+	if !connected {
+		cp.log.DEBUG.Printf("boot notification timeout, proceeding")
+		cp.connect(true)
+	}
 }
 
 func (cp *CP) Connected() bool {

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -153,14 +153,16 @@ func (cp *CP) onTransportConnect() {
 // onBootTimeout is called when the BootNotification wait timer expires.
 func (cp *CP) onBootTimeout() {
 	cp.mu.Lock()
+	if cp.bootTimer == nil {
+		// timer was cancelled by disconnect or BootNotification
+		cp.mu.Unlock()
+		return
+	}
 	cp.bootTimer = nil
-	connected := cp.connected
 	cp.mu.Unlock()
 
-	if !connected {
-		cp.log.DEBUG.Printf("boot notification timeout, proceeding")
-		cp.connect(true)
-	}
+	cp.log.DEBUG.Printf("boot notification timeout, proceeding")
+	cp.connect(true)
 }
 
 func (cp *CP) Connected() bool {

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -176,11 +176,6 @@ func (cp *CP) HasConnected() <-chan struct{} {
 	return cp.connectC
 }
 
-// // BootNotificationC returns the channel for monitoring BootNotification messages.
-// func (cp *CP) BootNotificationC() <-chan *core.BootNotificationRequest {
-// 	return cp.bootNotificationRequestC
-// }
-
 // MonitorReboot ensures the given function runs only once per CP instance.
 // Used to start the reboot monitor goroutine for multi-connector charge points.
 func (cp *CP) MonitorReboot(ctx context.Context, setup func() error) {

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -1,6 +1,7 @@
 package ocpp
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -175,13 +176,38 @@ func (cp *CP) HasConnected() <-chan struct{} {
 	return cp.connectC
 }
 
-// BootNotificationC returns the channel for monitoring BootNotification messages.
-func (cp *CP) BootNotificationC() <-chan *core.BootNotificationRequest {
-	return cp.bootNotificationRequestC
+// // BootNotificationC returns the channel for monitoring BootNotification messages.
+// func (cp *CP) BootNotificationC() <-chan *core.BootNotificationRequest {
+// 	return cp.bootNotificationRequestC
+// }
+
+// MonitorReboot ensures the given function runs only once per CP instance.
+// Used to start the reboot monitor goroutine for multi-connector charge points.
+func (cp *CP) MonitorReboot(ctx context.Context, setup func() error) {
+	cp.onceMonitor.Do(func() {
+		// drain boot notification from initial setup
+		select {
+		case <-cp.bootNotificationRequestC:
+		default:
+		}
+
+		go cp.monitorReboot(ctx, setup)
+	})
 }
 
-// StartMonitor ensures the given function runs only once per CP instance.
-// Used to start the reboot monitor goroutine for multi-connector charge points.
-func (cp *CP) StartMonitor(start func()) {
-	cp.onceMonitor.Do(start)
+func (cp *CP) monitorReboot(ctx context.Context, setup func() error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case boot := <-cp.bootNotificationRequestC:
+			cp.log.INFO.Printf("reboot detected (model: %s, vendor: %s), re-initializing",
+				boot.ChargePointModel, boot.ChargePointVendor)
+
+			if err := setup(); err != nil {
+				cp.log.ERROR.Printf("failed to re-initialize after reboot: %v", err)
+			}
+		}
+	}
 }

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -38,7 +38,7 @@ func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.B
 	select {
 	case cp.bootNotificationRequestC <- request:
 	default:
-		cp.log.DEBUG.Println("boot notification channel full, discarding")
+		cp.log.DEBUG.Printf("boot notification channel full, discarding")
 	}
 
 	return res, nil

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -20,15 +20,9 @@ func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.B
 		Status:      core.RegistrationStatusAccepted,
 	}
 
-	// store boot notification result
 	cp.mu.Lock()
 	cp.BootNotificationResult = request
-
-	// stop boot timer - BootNotification arrived before timeout
-	if cp.bootTimer != nil {
-		cp.bootTimer.Stop()
-		cp.bootTimer = nil
-	}
+	cp.stopBootTimer()
 	cp.mu.Unlock()
 
 	// mark charge point as ready for communication

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -1,0 +1,185 @@
+package ocpp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootNotificationStoresResultAndConnects(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	assert.False(t, cp.Connected(), "should not be connected initially")
+	assert.Nil(t, cp.BootNotificationResult, "should have no boot result initially")
+
+	bootReq := &core.BootNotificationRequest{
+		ChargePointModel:  "TestModel",
+		ChargePointVendor: "TestVendor",
+	}
+
+	res, err := cp.OnBootNotification(bootReq)
+	require.NoError(t, err)
+	assert.Equal(t, core.RegistrationStatusAccepted, res.Status)
+
+	// should be connected after BootNotification
+	assert.True(t, cp.Connected(), "should be connected after BootNotification")
+	assert.Equal(t, bootReq, cp.BootNotificationResult, "should store boot result")
+
+	// should have sent to channel
+	select {
+	case req := <-cp.bootNotificationRequestC:
+		assert.Equal(t, bootReq, req)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("bootNotificationRequestC should have received notification")
+	}
+}
+
+func TestBootNotificationStopsTimer(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	// simulate WebSocket connect (starts timer)
+	cp.onTransportConnect()
+
+	// timer should be set
+	cp.mu.RLock()
+	assert.NotNil(t, cp.bootTimer, "boot timer should be active after transport connect")
+	cp.mu.RUnlock()
+
+	// BootNotification arrives - should stop timer and connect
+	bootReq := &core.BootNotificationRequest{
+		ChargePointModel:  "TestModel",
+		ChargePointVendor: "TestVendor",
+	}
+	_, err := cp.OnBootNotification(bootReq)
+	require.NoError(t, err)
+
+	assert.True(t, cp.Connected(), "should be connected after BootNotification")
+
+	cp.mu.RLock()
+	assert.Nil(t, cp.bootTimer, "boot timer should be nil after BootNotification")
+	cp.mu.RUnlock()
+
+	// drain the channel
+	<-cp.bootNotificationRequestC
+}
+
+func TestTransportConnectTimeoutFallback(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	// use a short timeout for testing
+	origTimeout := Timeout
+	Timeout = 50 * time.Millisecond
+	defer func() { Timeout = origTimeout }()
+
+	assert.False(t, cp.Connected(), "should not be connected initially")
+
+	cp.onTransportConnect()
+
+	// should not be connected yet
+	assert.False(t, cp.Connected(), "should not be connected immediately after transport connect")
+
+	// wait for timeout
+	time.Sleep(100 * time.Millisecond)
+
+	// should be connected after timeout (fallback)
+	assert.True(t, cp.Connected(), "should be connected after boot timeout")
+}
+
+func TestDisconnectCancelsTimer(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	// use a short timeout for testing
+	origTimeout := Timeout
+	Timeout = 200 * time.Millisecond
+	defer func() { Timeout = origTimeout }()
+
+	cp.onTransportConnect()
+
+	cp.mu.RLock()
+	assert.NotNil(t, cp.bootTimer, "boot timer should be active")
+	cp.mu.RUnlock()
+
+	// disconnect should cancel timer
+	cp.connect(false)
+
+	cp.mu.RLock()
+	assert.Nil(t, cp.bootTimer, "boot timer should be nil after disconnect")
+	cp.mu.RUnlock()
+
+	// wait past the original timeout
+	time.Sleep(250 * time.Millisecond)
+
+	// should still be disconnected (timer was cancelled)
+	assert.False(t, cp.Connected(), "should not be connected after cancelled timer")
+}
+
+func TestBootNotificationChannelFull(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	// fill the channel (buffer size 1)
+	cp.bootNotificationRequestC <- &core.BootNotificationRequest{
+		ChargePointModel: "First",
+	}
+
+	// second notification should be dropped (channel full, non-blocking send)
+	bootReq := &core.BootNotificationRequest{
+		ChargePointModel:  "Second",
+		ChargePointVendor: "TestVendor",
+	}
+
+	res, err := cp.OnBootNotification(bootReq)
+	require.NoError(t, err)
+	assert.Equal(t, core.RegistrationStatusAccepted, res.Status)
+
+	// result should still be updated even though channel was full
+	assert.Equal(t, bootReq, cp.BootNotificationResult)
+	assert.True(t, cp.Connected())
+
+	// channel should have the first message (second was dropped)
+	req := <-cp.bootNotificationRequestC
+	assert.Equal(t, "First", req.ChargePointModel)
+}
+
+func TestReconnectAfterReboot(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	// simulate initial connection + setup
+	cp.connect(true)
+	cp.mu.Lock()
+	cp.initialized = true
+	cp.mu.Unlock()
+
+	// simulate disconnect
+	cp.connect(false)
+	assert.False(t, cp.Connected())
+
+	// simulate reconnect with BootNotification (reboot)
+	cp.onTransportConnect()
+
+	bootReq := &core.BootNotificationRequest{
+		ChargePointModel:  "TestModel",
+		ChargePointVendor: "TestVendor",
+	}
+	_, err := cp.OnBootNotification(bootReq)
+	require.NoError(t, err)
+
+	assert.True(t, cp.Connected(), "should be connected after reboot BootNotification")
+
+	// channel should have the notification for monitorReboot to pick up
+	select {
+	case req := <-cp.bootNotificationRequestC:
+		assert.Equal(t, bootReq, req)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("bootNotificationRequestC should have received reboot notification")
+	}
+}

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -154,11 +154,8 @@ func TestReconnectAfterReboot(t *testing.T) {
 	log := util.NewLogger("test")
 	cp := NewChargePoint(log, "test-cp")
 
-	// simulate initial connection + setup
+	// simulate initial connection
 	cp.connect(true)
-	cp.mu.Lock()
-	cp.initialized = true
-	cp.mu.Unlock()
 
 	// simulate disconnect
 	cp.connect(false)
@@ -197,18 +194,4 @@ func TestStartMonitorOnlyOnce(t *testing.T) {
 	cp.StartMonitor(start)
 
 	assert.Equal(t, 1, callCount, "StartMonitor should only call start once")
-}
-
-func TestInitializedFlag(t *testing.T) {
-	log := util.NewLogger("test")
-	cp := NewChargePoint(log, "test-cp")
-
-	assert.False(t, cp.Initialized(), "should not be initialized initially")
-
-	// simulate Setup completing
-	cp.mu.Lock()
-	cp.initialized = true
-	cp.mu.Unlock()
-
-	assert.True(t, cp.Initialized(), "should be initialized after setup")
 }

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -85,11 +85,9 @@ func TestTransportConnectTimeoutFallback(t *testing.T) {
 	// should not be connected yet
 	assert.False(t, cp.Connected(), "should not be connected immediately after transport connect")
 
-	// wait for timeout
-	time.Sleep(100 * time.Millisecond)
-
 	// should be connected after timeout (fallback)
-	assert.True(t, cp.Connected(), "should be connected after boot timeout")
+	require.Eventually(t, cp.Connected, time.Second, 10*time.Millisecond,
+		"should be connected after boot timeout")
 }
 
 func TestDisconnectCancelsTimer(t *testing.T) {
@@ -114,11 +112,9 @@ func TestDisconnectCancelsTimer(t *testing.T) {
 	assert.Nil(t, cp.bootTimer, "boot timer should be nil after disconnect")
 	cp.mu.RUnlock()
 
-	// wait past the original timeout
-	time.Sleep(250 * time.Millisecond)
-
 	// should still be disconnected (timer was cancelled)
-	assert.False(t, cp.Connected(), "should not be connected after cancelled timer")
+	require.Never(t, cp.Connected, 300*time.Millisecond, 10*time.Millisecond,
+		"should not be connected after cancelled timer")
 }
 
 func TestBootNotificationChannelFull(t *testing.T) {

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -1,6 +1,7 @@
 package ocpp
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -182,16 +183,24 @@ func TestReconnectAfterReboot(t *testing.T) {
 	}
 }
 
-func TestStartMonitorOnlyOnce(t *testing.T) {
+func TestMonitorRebootOnlyOnce(t *testing.T) {
 	log := util.NewLogger("test")
 	cp := NewChargePoint(log, "test-cp")
 
-	callCount := 0
-	start := func() { callCount++ }
+	ctx := t.Context()
+	var callCount atomic.Int32
+	setup := func() error { callCount.Add(1); return nil }
 
-	cp.StartMonitor(start)
-	cp.StartMonitor(start)
-	cp.StartMonitor(start)
+	cp.MonitorReboot(ctx, setup)
+	cp.MonitorReboot(ctx, setup)
+	cp.MonitorReboot(ctx, setup)
 
-	assert.Equal(t, 1, callCount, "StartMonitor should only call start once")
+	// send a boot notification to trigger the monitor
+	cp.bootNotificationRequestC <- &core.BootNotificationRequest{
+		ChargePointModel: "TestModel",
+	}
+
+	// wait for the goroutine to process it
+	require.Eventually(t, func() bool { return callCount.Load() == 1 }, time.Second, 10*time.Millisecond,
+		"setup should be called exactly once")
 }

--- a/charger/ocpp/cp_requests.go
+++ b/charger/ocpp/cp_requests.go
@@ -3,6 +3,7 @@ package ocpp
 import (
 	"errors"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
@@ -72,6 +73,10 @@ func (cp *CP) SetChargingProfileRequest(connectorId int, profile *types.Charging
 }
 
 func (cp *CP) TriggerMessageRequest(connectorId int, requestedMessage remotetrigger.MessageTrigger) error {
+	if !cp.Connected() {
+		return api.ErrTimeout
+	}
+
 	rc := make(chan error, 1)
 
 	err := Instance().TriggerMessage(cp.id, func(request *remotetrigger.TriggerMessageConfirmation, err error) {

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -118,6 +118,8 @@ func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.
 		}
 
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-time.After(Timeout):
 			cp.log.DEBUG.Printf("BootNotification timeout")
 		case res := <-cp.bootNotificationRequestC:

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -174,10 +174,6 @@ func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.
 		cp.PhaseSwitching = true // assume phase switching is available for power-based charging
 	}
 
-	cp.mu.Lock()
-	cp.initialized = true
-	cp.mu.Unlock()
-
 	return nil
 }
 

--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -163,7 +163,7 @@ func (cs *CS) RegisterChargepoint(id string, newfun func() *CP, init func(*CP) e
 	cs.mu.Unlock()
 
 	if registered {
-		cp.connect(true)
+		cp.onTransportConnect()
 	}
 
 	return cp, init(cp)
@@ -178,9 +178,9 @@ func (cs *CS) NewChargePoint(chargePoint ocpp16.ChargePointConnection) {
 	if ok {
 		cs.log.DEBUG.Printf("charge point connected: %s", chargePoint.ID())
 
-		// trigger initial connection
+		// wait for BootNotification before marking as connected
 		if cp := reg.cp; cp != nil {
-			cp.connect(true)
+			cp.onTransportConnect()
 		}
 
 		cs.mu.Unlock()
@@ -199,7 +199,7 @@ func (cs *CS) NewChargePoint(chargePoint ocpp16.ChargePointConnection) {
 		cs.regs[chargePoint.ID()] = reg
 		delete(cs.regs, "")
 
-		cp.connect(true)
+		cp.onTransportConnect()
 
 		cs.mu.Unlock()
 		cs.publish()


### PR DESCRIPTION
## Summary

Defer marking the charge point as connected until BootNotification is received (with 30s timeout fallback). This prevents sending commands before the handshake completes, which causes Wallbox chargers to disconnect in a loop after their daily reboot.

Also re-runs Setup automatically when a reboot is detected via BootNotification, and retries Setup within the connect timeout if the charger initially connects but doesn't respond (another Wallbox firmware quirk).

Fixes #27203
Replaces #25069

## Test plan

- [x] `go test ./charger/ocpp/...` (6 new tests)
- [x] `go build ./charger/...`
- [x] Fixed my Wallbox issues on firmware 6.1.12, not sure if it solves the reboot issues with 6.7.33+