### PR TITLE
TP-Link/Tapo: switch to real device names

### DIFF
--- a/templates/definition/charger/tapo.yaml
+++ b/templates/definition/charger/tapo.yaml
@@ -1,8 +1,8 @@
 template: tapo
 products:
-  - brand: TP-Link
-    description:
-      generic: Tapo P-Series Smart Plug
+  - { brand: TP-Link, description: { generic: Tapo P100 } }
+  - { brand: TP-Link, description: { generic: Tapo P110 } }
+  - { brand: TP-Link, description: { generic: Tapo P115 } }
 group: switchsockets
 requirements:
   description:

--- a/templates/definition/charger/tplink.yaml
+++ b/templates/definition/charger/tplink.yaml
@@ -1,8 +1,9 @@
 template: tplink
 products:
-  - brand: TP-Link
-    description:
-      generic: H-Series Smart Plug
+  - { brand: TP-Link, description: { generic: HS100 } }
+  - { brand: TP-Link, description: { generic: HS103 } }
+  - { brand: TP-Link, description: { generic: HS105 } }
+  - { brand: TP-Link, description: { generic: HS110 } }
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/meter/tapo.yaml
+++ b/templates/definition/meter/tapo.yaml
@@ -1,8 +1,7 @@
 template: tapo
 products:
-  - brand: TP-Link
-    description:
-      generic: Tapo P-Series Smart Plug
+  - { brand: TP-Link, description: { generic: Tapo P110 } }
+  - { brand: TP-Link, description: { generic: Tapo P115 } }
 group: switchsockets
 requirements:
   description:

--- a/templates/definition/meter/tplink.yaml
+++ b/templates/definition/meter/tplink.yaml
@@ -2,7 +2,7 @@ template: tplink
 products:
   - brand: TP-Link
     description:
-      generic: H-Series Smart Plug
+      generic: HS110
 group: switchsockets
 params:
   - name: usage


### PR DESCRIPTION
This should add more clarity about which devices are supported. I decided to go with separate brand entries for each device. We could also do one entry and add all devices in a single line, like:
```
  - brand: TP-Link
    description:
      generic: HS100/HS103/HS105/HS110 Smart Plug
```

/cc @thierolm 