### PR TITLE
Tinkerforge: fix meter api and phase switching (BC)

### DIFF
--- a/templates/definition/charger/tinkerforge-warp-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp-ws.yaml
@@ -1,14 +1,12 @@
-template: tinkerforge-warp3-ws
+template: tinkerforge-warp-ws
 products:
-  - { brand: TinkerForge, description: { generic: WARP2 Smart } }
-  - { brand: TinkerForge, description: { generic: WARP2 Pro } }
   - { brand: TinkerForge, description: { generic: WARP3 Smart } }
   - { brand: TinkerForge, description: { generic: WARP3 Pro } }
 capabilities: ["mA", "1p3p", "rfid"]
 requirements:
   description:
-    de: Die automatische Phasenumschaltung bei 1p Fahrzeugen muss deaktiviert sein. Siehe [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
-    en: The automatic phase switching for 1p vehicles must be deactivated. See [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
+    de: Die WARP-eigene automatische Phasenumschaltung wird von EVCC beim Verbinden mit der Wallbox deaktiviert. Siehe [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
+    en: WARP's own automatic phase switching will be deactivated by EVCC when connecting to the wallbox. See [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
   evcc: ["skiptest"]
 params:
   - name: uri
@@ -28,5 +26,5 @@ render: |
   uri: {{ .uri }}
   user: {{ .user }}
   password: {{ .password }}
-  energyMeterIndex: {{ .energyMeterIndex }}  
+  energyMeterIndex: {{ .energyMeterIndex }}
   disablePhaseAutoSwitch: true

--- a/templates/definition/charger/tinkerforge-warp1-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp1-ws.yaml
@@ -1,12 +1,11 @@
-template: tinkerforge-warp-ws
+template: tinkerforge-warp1-ws
 products:
+  - { brand: TinkerForge, description: { generic: WARP2 Smart } }
+  - { brand: TinkerForge, description: { generic: WARP2 Pro } }
   - { brand: TinkerForge, description: { generic: WARP1 Smart } }
   - { brand: TinkerForge, description: { generic: WARP1 Pro } }
-capabilities: ["mA", "1p3p", "rfid"]
+capabilities: ["mA", "rfid"]
 requirements:
-  description:
-    de: Die automatische Phasenumschaltung bei 1p Fahrzeugen muss deaktiviert sein. Siehe [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
-    en: The automatic phase switching for 1p vehicles must be deactivated. See [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
   evcc: ["skiptest"]
 params:
   - name: uri

--- a/templates/definition/charger/tinkerforge-warp2-em-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp2-em-ws.yaml
@@ -1,18 +1,26 @@
-template: tinkerforge-warp2-ws
+template: tinkerforge-warp2-em-ws
 products:
   - { brand: TinkerForge, description: { generic: WARP2 Smart + Energy Manager } }
   - { brand: TinkerForge, description: { generic: WARP2 Pro + Energy Manager } }
 capabilities: ["mA", "1p3p", "rfid"]
 requirements:
   description:
-    en: Firmware v2 required. Automatic phase switching requires the additional WARP Energy Manager.
-    de: Firmware v2 erforderlich. Für automatische Phasenumschaltung wird zusätzlich der WARP Energy Manager benötigt.
+    de: Firmware v2 erforderlich. Die WARP-eigene automatische Phasenumschaltung wird von EVCC beim Verbinden mit der Wallbox deaktiviert. Siehe [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
+    en: Firmware v2 required. WARP's own automatic phase switching will be deactivated by EVCC when connecting to the wallbox. See [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).
   evcc: ["skiptest"]
 params:
   - name: uri
     required: true
   - name: user
   - name: password
+  - name: energyMeterIndex
+    advanced: true
+    default: 0
+    description:
+      generic: Energy Meter Index
+    help:
+      de: Index des in der Warp konfigurierten Meters dessen Werte genutzt werden sollen.
+      en: Index of the meter configured in the WARP charger whose values should be used.
   - name: energyManagerUri
     description:
       generic: Energy Manager URI
@@ -41,4 +49,5 @@ render: |
   energyManagerUri: {{ .energyManagerUri }}
   energyManagerUser: {{ .energyManagerUser }}
   energyManagerPassword: {{ .energyManagerPassword }}
+  energyMeterIndex: {{ .energyMeterIndex }}
   disablePhaseAutoSwitch: true


### PR DESCRIPTION
Fixup Websocket implementation for Tinkerforge #26970:

- rename emURI to pmURI because feature is called power manager
- only populate phase switching methods if power manager feature is available
- filter websocket events for legacy meter api by using correct feature name
- adjust phase switching documentation because the implementation handles it automatically
- cleanup templates: warp3, warp2 with wem and warp1/2 without wem