### PR TITLE
Fix database backup download error (Gzip mismatch)

### DIFF
--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -347,13 +347,6 @@ func getBackup(authObject auth.Auth) http.HandlerFunc {
 
 		filename := "evcc-backup-" + time.Now().Format("2006-01-02--15-04") + ".db"
 
-		fi, err := f.Stat()
-		if err != nil {
-			http.Error(w, "Could not stat DB file: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Content-Length", strconv.FormatInt(fi.Size(), 10))
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
 


### PR DESCRIPTION
Fixes #27331

**Description**
This PR fixes a bug where database backup downloads fail in Chrome (and via curl --gzip) with a `net::ERR_CONTENT_LENGTH_MISSMATCH`.

The issue was caused by a conflict between the manual Content-Length header in the backup handler and the global CompressHandler middleware. While the middleware compresses the backup file, the header remained at the original (uncompressed) file size, leading the browser to expect more data than actually delivered.

**Changes**

- Removed manual Content-Length header in `server/http_site_handler.go`.

- This allows the `CompressHandler` middleware to either set the correct compressed length or use chunked transfer encoding automatically.

**How to test**

1. Go to Configuration -> Backup & Restore -> Download Backup.

2. Verification: The download should complete successfully without "Network Error" or console errors.