### PR TITLE
TWC3: add ConnectionTimer to detect vehicle swaps

### DIFF
--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -165,6 +165,14 @@ func (v *Twc3) ChargedEnergy() (float64, error) {
 	return res.SessionEnergyWh / 1e3, err
 }
 
+var _ api.ConnectionTimer = (*Twc3)(nil)
+
+// ConnectionDuration implements the api.ConnectionTimer interface
+func (v *Twc3) ConnectionDuration() (time.Duration, error) {
+	res, err := v.vitalsG()
+	return time.Duration(res.SessionS) * time.Second, err
+}
+
 // removed: https://github.com/evcc-io/evcc/issues/13555
 // var _ api.ChargeTimer = (*Twc3)(nil)
 


### PR DESCRIPTION
### Problem

When two vehicles share a single TWC3 charger, swapping the cable from one car to another can happen faster than the 30s polling interval. When this happens, evcc never sees `StatusA` (disconnected) — it just sees `StatusB` on consecutive polls and keeps the previous vehicle assigned.

This means the wrong vehicle is shown in the UI, the wrong SoC/range is displayed, and charging sessions are attributed to the wrong car. The vehicle assignment is stuck until evcc is restarted or the car physically disconnects long enough for a poll to catch it.

The loadpoint already has logic in `getStatusChanges()` to handle exactly this scenario but only works for chargers that implement `api.ConnectionTimer`. 

The TWC3 already has the data available via `session_s` in its `/api/1/vitals` response, which resets to 0 whenever a vehicle disconnects. It just wasn't exposed as a `ConnectionTimer`.

### Fix

Implement `api.ConnectionTimer` on the TWC3 using the existing `session_s` field from the vitals API. This is the same approach used by the Phoenix CHARX charger (added in #24957).

When the loadpoint detects the connection duration drop, it synthesizes a disconnect→reconnect event, which triggers fresh vehicle detection.

### Debugging

I have two Teslas (configured via Home Assistant) sharing a single TWC3. This morning one car was swapped for the other. The TWC3 vitals confirm what happened:

```
session_s: 6049      ← current session ~100 minutes old
uptime_s: 195376     ← TWC3 has been up ~54 hours
session_energy_wh: 0 ← nothing charged in current session
vehicle_connected: true
```

- `session_s` (6049) < `uptime_s` (195376) confirms `session_s` resets per-connection, not per-boot, so it's a valid connection duration signal.
- The current session started at 09:41:11 with 0 Wh charged. The previous EVCC charging session (2.7 kWh to the other car) ended at 09:41:09. The TWC3 clearly saw a disconnect and started a new session.
- EVCC's logs show **zero** `car disconnected` events
- Before the swap, `connectedDuration` in evcc was ~70,000s (connected since the previous day). After the swap, `session_s` reset to 0. A drop from 70,000→0 would be immediately caught by the existing `getStatusChanges()` duration check.

Without this fix, evcc showed the wrong vehicle for over an hour until I manually corrected it via the UI.