### PR TITLE
Added Range to Toyota Vehicles

### DIFF
--- a/vehicle/toyota/provider.go
+++ b/vehicle/toyota/provider.go
@@ -23,3 +23,9 @@ func (v *Provider) Soc() (float64, error) {
 	res, err := v.status()
 	return float64(res.Payload.BatteryLevel), err
 }
+
+// Range implements the api.VehicleRange interface
+func (v *Provider) Range() (int64, error) {
+	res, err := v.status()
+	return int64(res.Payload.EvRangeWithAc.Value), err
+}


### PR DESCRIPTION
This PR implements `api.VehicleRange` support for Toyota vehicles.

It extracts the `EvRangeWithAc` value from the existing `Status` struct and maps it to the expected `int64` return type used by the API.

Issue #24039 requested a PR for this addition, so this change addresses that request.

I do not have much experience with Go, so I would appreciate a review to ensure the implementation follows project conventions and best practices.