### PR TITLE
refactor: simplify vehicleDefaultOrDetect logic for setting active vehicle

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -248,13 +248,11 @@ func (lp *Loadpoint) vehicleUnidentified() bool {
 // vehicleDefaultOrDetect will assign and update default vehicle or start detection
 func (lp *Loadpoint) vehicleDefaultOrDetect() {
 	if lp.defaultVehicle != nil {
-		if lp.vehicle != lp.defaultVehicle {
-			lp.setActiveVehicle(lp.defaultVehicle)
-		} else {
-			// default vehicle is already active, update odometer anyway
-			// need to do this here since setActiveVehicle would short-circuit
-			lp.addTask(lp.vehicleOdometer)
-		}
+		// Always call setActiveVehicle even if defaultVehicle is already active.
+		// This ensures a fresh SOC estimator is created on each vehicle connect,
+		// which resets the estimator's initial values for the new charging session.
+		// setActiveVehicle is safe to call repeatedly - it only logs when vehicle actually changes.
+		lp.setActiveVehicle(lp.defaultVehicle)
 	} else if len(lp.coordinatedVehicles()) > 0 && lp.connected() {
 		lp.startVehicleDetection()
 	}


### PR DESCRIPTION
remove optimization to not set the default vehicle again if it's already set to create a new estimator even on reconnect.

Fix #27359 