### PR TITLE
fix grid charging with broken tariff

### DIFF
--- a/tariff/tariffs.go
+++ b/tariff/tariffs.go
@@ -44,6 +44,11 @@ func Rates(t api.Tariff) api.Rates {
 	return rr
 }
 
+// ensure tariff is not a wrapper
+func exists(t api.Tariff) bool {
+	return t != nil && t.Type() != 0
+}
+
 func (t *Tariffs) Get(u api.TariffUsage) api.Tariff {
 	switch u {
 	case api.TariffUsageCo2:
@@ -58,15 +63,15 @@ func (t *Tariffs) Get(u api.TariffUsage) api.Tariff {
 	// TODO solar
 	case api.TariffUsagePlanner:
 		switch {
-		case t.Planner != nil:
+		case exists(t.Planner):
 			// prio 0: manually set planner tariff
 			return t.Planner
 
-		case t.Grid != nil && t.Grid.Type() == api.TariffTypePriceForecast:
+		case exists(t.Grid) && t.Grid.Type() == api.TariffTypePriceForecast:
 			// prio 1: grid tariff with forecast
 			return t.Grid
 
-		case t.Co2 != nil:
+		case exists(t.Co2):
 			// prio 2: co2 tariff
 			return t.Co2
 

--- a/tariff/tariffs.go
+++ b/tariff/tariffs.go
@@ -44,12 +44,12 @@ func Rates(t api.Tariff) api.Rates {
 	return rr
 }
 
-// ensure tariff is not a wrapper
-func exists(t api.Tariff) bool {
-	return t != nil && t.Type() != 0
-}
-
 func (t *Tariffs) Get(u api.TariffUsage) api.Tariff {
+	// ensure tariff is not a wrapper
+	exists := func(t api.Tariff) bool {
+		return t != nil && t.Type() != 0
+	}
+
 	switch u {
 	case api.TariffUsageCo2:
 		return t.Co2


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/26442

Check for failed-tariff-wrappers when choosing the planner tariff. With this fix `smartCostAvailable` and `smartCostType` are published correctly - ignoring failed tariffs. As a positive side effect we also get rid of this message that happened once per update cycle:

```
[site  ] WARN 2026/02/13 11:36:54 planner: tariff not available: cannot create tariff type 'template:grünstromindex': cannot create tariff type 'grünstromindex': invalid ...
```