### PR TITLE
Tariff: pvnode - change default to 24h interval

### DIFF
--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -6,11 +6,11 @@ requirements:
     en: |
       [pvnode](https://pvnode.com) provides 15-minute PV production forecasts via REST API.
       An API key is required (free plan available with +1 day forecast).
-      **Attention**: With free plan only one location (lat, lon) is allowed. Location is saved on first request and can not be changed afterwards, otherwise a 403 response is sent.
+      **Attention**: The free plan only allows 40 queries per month. These queries must be from only one location (lat, lon). Location is saved on first request and can not be changed afterwards, otherwise a 403 response is sent.
     de: |
       [pvnode](https://pvnode.com) liefert 15-Minuten PV Vorhersagen per REST API.
       Ein API-Key ist erforderlich (kostenloser Plan mit +1 Tag Vorhersage verfügbar).
-      **Achtung**: Mit dem kostenlosen Plan ist lediglich ein Standort (lat, lon) erlaubt. Der Standort wird bei der ersten Abfrage gespeichert und kann danach nicht mehr angepasst werden, andernfalls wird eine 403 Antwort gesendet.
+      **Achtung**: Mit dem kostenlosen Plan sind lediglich 40 Abfragen/Monat erlaubt. Diese Abfragen dürfen nur von einem Standort (lat, lon) sein. Der Standort wird bei der ersten Abfrage gespeichert und kann danach nicht mehr angepasst werden, andernfalls wird eine 403 Antwort gesendet.
   evcc: ["skiptest"]
 group: solar
 
@@ -37,7 +37,7 @@ params:
     default: 1
     advanced: true
   - name: interval
-    default: 1h
+    default: 24h
     advanced: true
 
 render: |


### PR DESCRIPTION
The limitation of queries in the free plan is 40 queries **per month**, not per days.
Therefore, the default interval is changed to 24h.

Also added this limitation to description.