### PR TITLE
chore: fix decorator

### DIFF
--- a/charger/shelly_decorators.go
+++ b/charger/shelly_decorators.go
@@ -8,10 +8,10 @@ import (
 
 func decorateShelly(base *Shelly, phaseVoltages func() (float64, float64, float64, error), phaseCurrents func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error)) api.Charger {
 	switch {
-	case phaseCurrents == nil && phaseVoltages == nil:
+	case phasePowers == nil && phaseVoltages == nil:
 		return base
 
-	case phaseCurrents == nil && phaseVoltages != nil:
+	case phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			*Shelly
 			api.PhaseVoltages
@@ -22,26 +22,26 @@ func decorateShelly(base *Shelly, phaseVoltages func() (float64, float64, float6
 			},
 		}
 
-	case phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			*Shelly
-			api.PhaseCurrents
+			api.PhasePowers
 		}{
 			Shelly: base,
-			PhaseCurrents: &decorateShellyPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
+			PhasePowers: &decorateShellyPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 		}
 
-	case phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case phaseCurrents == nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			*Shelly
-			api.PhaseCurrents
+			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Shelly: base,
-			PhaseCurrents: &decorateShellyPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
+			PhasePowers: &decorateShellyPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 			PhaseVoltages: &decorateShellyPhaseVoltagesImpl{
 				phaseVoltages: phaseVoltages,

--- a/cmd/decorate/decorate.go
+++ b/cmd/decorate/decorate.go
@@ -50,7 +50,7 @@ var dependents = make(map[string][]string)
 func init() {
 	reflectTypes := map[reflect.Type][]reflect.Type{
 		reflect.TypeFor[api.Meter]():             {reflect.TypeFor[api.MeterEnergy](), reflect.TypeFor[api.PhaseCurrents](), reflect.TypeFor[api.PhaseVoltages](), reflect.TypeFor[api.MaxACPowerGetter]()},
-		reflect.TypeFor[api.PhaseCurrents]():     {reflect.TypeFor[api.PhasePowers]()}, // phase powers are only used to determine currents sign
+		reflect.TypeFor[api.PhasePowers]():       {reflect.TypeFor[api.PhaseCurrents]()}, // phase powers are only used to determine currents sign
 		reflect.TypeFor[api.PhaseSwitcher]():     {reflect.TypeFor[api.PhaseGetter]()},
 		reflect.TypeFor[api.Battery]():           {reflect.TypeFor[api.BatteryCapacity](), reflect.TypeFor[api.SocLimiter](), reflect.TypeFor[api.BatteryController](), reflect.TypeFor[api.BatterySocLimiter](), reflect.TypeFor[api.BatteryPowerLimiter]()},
 		reflect.TypeFor[api.ChargeState]():       {reflect.TypeFor[api.ChargeController](), reflect.TypeFor[api.CurrentController]()},

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -8,10 +8,10 @@ import (
 
 func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCurrents func() (float64, float64, float64, error), phaseVoltages func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error), maxACPowerGetter func() float64) api.Meter {
 	switch {
-	case maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case maxACPowerGetter == nil && meterEnergy == nil && phasePowers == nil && phaseVoltages == nil:
 		return base
 
-	case maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case maxACPowerGetter == nil && meterEnergy != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -22,33 +22,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MeterEnergy
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case maxACPowerGetter == nil && meterEnergy == nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.PhaseVoltages
@@ -59,7 +33,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case maxACPowerGetter == nil && meterEnergy != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
@@ -74,37 +48,29 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
-			api.PhaseCurrents
-			api.PhaseVoltages
+			api.PhasePowers
 		}{
 			Meter: base,
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 		}
 
-	case maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhaseVoltages
+			api.PhasePowers
 		}{
 			Meter: base,
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 		}
 
@@ -139,6 +105,40 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 			PhasePowers: &decorateMeterPhasePowersImpl{
 				phasePowers: phasePowers,
+			},
+		}
+
+	case maxACPowerGetter == nil && meterEnergy == nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case maxACPowerGetter == nil && meterEnergy != nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.MeterEnergy
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
 			},
 		}
 
@@ -184,7 +184,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages == nil:
+	case maxACPowerGetter != nil && meterEnergy == nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MaxACPowerGetter
@@ -195,7 +195,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages == nil:
+	case maxACPowerGetter != nil && meterEnergy != nil && phasePowers == nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MaxACPowerGetter
@@ -210,41 +210,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
-				maxACPowerGetter: maxACPowerGetter,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
-		return &struct {
-			api.Meter
-			api.MaxACPowerGetter
-			api.MeterEnergy
-			api.PhaseCurrents
-		}{
-			Meter: base,
-			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
-				maxACPowerGetter: maxACPowerGetter,
-			},
-			MeterEnergy: &decorateMeterMeterEnergyImpl{
-				meterEnergy: meterEnergy,
-			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-		}
-
-	case maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phaseVoltages != nil:
+	case maxACPowerGetter != nil && meterEnergy == nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.MaxACPowerGetter
@@ -259,7 +225,7 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phaseVoltages != nil:
+	case maxACPowerGetter != nil && meterEnergy != nil && phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			api.Meter
 			api.MaxACPowerGetter
@@ -278,32 +244,27 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 		}
 
-	case maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MaxACPowerGetter
-			api.PhaseCurrents
-			api.PhaseVoltages
+			api.PhasePowers
 		}{
 			Meter: base,
 			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
 				maxACPowerGetter: maxACPowerGetter,
 			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 		}
 
-	case maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			api.Meter
 			api.MaxACPowerGetter
 			api.MeterEnergy
-			api.PhaseCurrents
-			api.PhaseVoltages
+			api.PhasePowers
 		}{
 			Meter: base,
 			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
@@ -312,11 +273,8 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			MeterEnergy: &decorateMeterMeterEnergyImpl{
 				meterEnergy: meterEnergy,
 			},
-			PhaseCurrents: &decorateMeterPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
-			},
-			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
-				phaseVoltages: phaseVoltages,
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 		}
 
@@ -359,6 +317,48 @@ func decorateMeter(base api.Meter, meterEnergy func() (float64, error), phaseCur
 			},
 			PhasePowers: &decorateMeterPhasePowersImpl{
 				phasePowers: phasePowers,
+			},
+		}
+
+	case maxACPowerGetter != nil && meterEnergy == nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.MaxACPowerGetter
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
+			},
+		}
+
+	case maxACPowerGetter != nil && meterEnergy != nil && phaseCurrents == nil && phasePowers != nil && phaseVoltages != nil:
+		return &struct {
+			api.Meter
+			api.MaxACPowerGetter
+			api.MeterEnergy
+			api.PhasePowers
+			api.PhaseVoltages
+		}{
+			Meter: base,
+			MaxACPowerGetter: &decorateMeterMaxACPowerGetterImpl{
+				maxACPowerGetter: maxACPowerGetter,
+			},
+			MeterEnergy: &decorateMeterMeterEnergyImpl{
+				meterEnergy: meterEnergy,
+			},
+			PhasePowers: &decorateMeterPhasePowersImpl{
+				phasePowers: phasePowers,
+			},
+			PhaseVoltages: &decorateMeterPhaseVoltagesImpl{
+				phaseVoltages: phaseVoltages,
 			},
 		}
 

--- a/meter/shelly_decorators.go
+++ b/meter/shelly_decorators.go
@@ -8,10 +8,10 @@ import (
 
 func decorateShelly(base *Shelly, phaseVoltages func() (float64, float64, float64, error), phaseCurrents func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error)) api.Meter {
 	switch {
-	case phaseCurrents == nil && phaseVoltages == nil:
+	case phasePowers == nil && phaseVoltages == nil:
 		return base
 
-	case phaseCurrents == nil && phaseVoltages != nil:
+	case phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			*Shelly
 			api.PhaseVoltages
@@ -22,26 +22,26 @@ func decorateShelly(base *Shelly, phaseVoltages func() (float64, float64, float6
 			},
 		}
 
-	case phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			*Shelly
-			api.PhaseCurrents
+			api.PhasePowers
 		}{
 			Shelly: base,
-			PhaseCurrents: &decorateShellyPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
+			PhasePowers: &decorateShellyPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 		}
 
-	case phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case phaseCurrents == nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			*Shelly
-			api.PhaseCurrents
+			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Shelly: base,
-			PhaseCurrents: &decorateShellyPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
+			PhasePowers: &decorateShellyPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 			PhaseVoltages: &decorateShellyPhaseVoltagesImpl{
 				phaseVoltages: phaseVoltages,

--- a/meter/tasmota_decorators.go
+++ b/meter/tasmota_decorators.go
@@ -8,10 +8,10 @@ import (
 
 func decorateTasmota(base *Tasmota, phaseVoltages func() (float64, float64, float64, error), phaseCurrents func() (float64, float64, float64, error), phasePowers func() (float64, float64, float64, error)) api.Meter {
 	switch {
-	case phaseCurrents == nil && phaseVoltages == nil:
+	case phasePowers == nil && phaseVoltages == nil:
 		return base
 
-	case phaseCurrents == nil && phaseVoltages != nil:
+	case phasePowers == nil && phaseVoltages != nil:
 		return &struct {
 			*Tasmota
 			api.PhaseVoltages
@@ -22,26 +22,26 @@ func decorateTasmota(base *Tasmota, phaseVoltages func() (float64, float64, floa
 			},
 		}
 
-	case phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+	case phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
 		return &struct {
 			*Tasmota
-			api.PhaseCurrents
+			api.PhasePowers
 		}{
 			Tasmota: base,
-			PhaseCurrents: &decorateTasmotaPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
+			PhasePowers: &decorateTasmotaPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 		}
 
-	case phaseCurrents != nil && phasePowers == nil && phaseVoltages != nil:
+	case phaseCurrents == nil && phasePowers != nil && phaseVoltages != nil:
 		return &struct {
 			*Tasmota
-			api.PhaseCurrents
+			api.PhasePowers
 			api.PhaseVoltages
 		}{
 			Tasmota: base,
-			PhaseCurrents: &decorateTasmotaPhaseCurrentsImpl{
-				phaseCurrents: phaseCurrents,
+			PhasePowers: &decorateTasmotaPhasePowersImpl{
+				phasePowers: phasePowers,
 			},
 			PhaseVoltages: &decorateTasmotaPhaseVoltagesImpl{
 				phaseVoltages: phaseVoltages,


### PR DESCRIPTION
Since `api.PhaseCurrents` can't be defined without `api.PhasePowers` they need to be switched:
`api.PhasePowers`, on the other hand, can be defined on its own.

Diff:
```diff
- case phaseCurrents != nil && phasePowers == nil && phaseVoltages == nil:
+ case phaseCurrents == nil && phasePowers != nil && phaseVoltages == nil:
```