### PR TITLE
Huawei: suggest defaults (BC)

### DIFF
--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -26,7 +26,6 @@ params:
     type: int
     default: 1
     advanced: true
-  - name: maxacpower
   - name: forceaccharging
     default: false
     advanced: true
@@ -38,9 +37,23 @@ params:
     help:
       en: Keep AC charging active to charge the storage from other inverters via AC. Prevents stand-by.
       de: AC-Laden bleibt aktiv zum Laden des Speichers aus anderen AC Quellen für Wechselrichterkaskaden. Verhindert Stand-by.
+  - name: maxacpower
+    service: modbus/read?address=30073&type=holding&encoding=uint32&{modbus}
   - preset: battery-params
+  - name: capacity
+    service: modbus/read?address=37758&type=holding&encoding=uint32&scale=0.001&{modbus}
   - name: maxchargepower
-    default: 10000
+    service: modbus/read?address=37046&type=holding&encoding=uint32&{modbus}
+    required: true
+  - name: maxdischargepower
+    service: modbus/read?address=37048&type=holding&encoding=uint32&{modbus}
+    required: true
+  - name: minsoc
+    service: modbus/read?address=47082&type=holding&encoding=uint16&scale=0.1&{modbus}
+    advanced: true
+  - name: maxsoc
+    service: modbus/read?address=47081&type=holding&encoding=uint16&scale=0.1&{modbus}
+    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -22,6 +22,8 @@ params:
     choice: ["rs485", "tcpip"]
   - name: timeout
     default: 15s
+  - name: maxacpower
+    service: modbus/read?address=30073&type=holding&encoding=uint32&{modbus}
   - name: storageunit
     type: int
     default: 1
@@ -37,8 +39,6 @@ params:
     help:
       en: Keep AC charging active to charge the storage from other inverters via AC. Prevents stand-by.
       de: AC-Laden bleibt aktiv zum Laden des Speichers aus anderen AC Quellen für Wechselrichterkaskaden. Verhindert Stand-by.
-  - name: maxacpower
-    service: modbus/read?address=30073&type=holding&encoding=uint32&{modbus}
   - preset: battery-params
   - name: capacity
     service: modbus/read?address=37758&type=holding&encoding=uint32&scale=0.001&{modbus}

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -50,10 +50,8 @@ params:
     required: true
   - name: minsoc
     service: modbus/read?address=47082&type=holding&encoding=uint16&scale=0.1&{modbus}
-    advanced: true
   - name: maxsoc
     service: modbus/read?address=47081&type=holding&encoding=uint16&scale=0.1&{modbus}
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/huawei-sun2000.yaml
+++ b/templates/definition/meter/huawei-sun2000.yaml
@@ -47,7 +47,6 @@ params:
     required: true
   - name: maxdischargepower
     service: modbus/read?address=37048&type=holding&encoding=uint32&{modbus}
-    required: true
   - name: minsoc
     service: modbus/read?address=47082&type=holding&encoding=uint16&scale=0.1&{modbus}
   - name: maxsoc


### PR DESCRIPTION
### Scope

Suggest default values for inverter (`maxacpower`) and battery (`capacity`, `minsoc`, `maxsoc`, `maxchargepower`, `maxdischargepower`) params by reading capabilities via Modbus.

[BREAKING CHANGE] `maxchargepower` is now requird.

### Test

<img width="436" height="136" alt="image" src="https://github.com/user-attachments/assets/1d28e3ba-c80c-4fed-badd-4618ee7b53f8" />
<img width="323" height="126" alt="image" src="https://github.com/user-attachments/assets/e8cbe3cf-d545-4359-a0a6-62f00b6a7e8b" />
<img width="345" height="129" alt="image" src="https://github.com/user-attachments/assets/85e365ad-c6ab-400a-a9f5-448605842706" />
<img width="344" height="136" alt="image" src="https://github.com/user-attachments/assets/415a3f58-5208-4313-a744-753874f954eb" />
<img width="322" height="140" alt="image" src="https://github.com/user-attachments/assets/b90680a6-0c95-4fa3-b183-d7b937f256c3" />
<img width="320" height="140" alt="image" src="https://github.com/user-attachments/assets/ea4b674b-5a11-4663-bf17-87343399a0df" />

### Open Points

- [x] Test with `evcc.yaml` whether required fields are honored