### PR TITLE
Viessman: update API endpoints

### DIFF
--- a/templates/definition/charger/viessmann.yaml
+++ b/templates/definition/charger/viessmann.yaml
@@ -84,7 +84,7 @@ params:
 
         ```
         curl --silent -H "Authorization: Bearer $VIESSMANN_TOKEN" \
-          https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations?includeGateways=true \
+          https://api.viessmann-climatesolutions.com/iot/v2/equipment/installations?includeGateways=true \
           | jq '.data[].id'
         ```
       en: |
@@ -126,7 +126,7 @@ params:
 
         ```
         curl --silent -H "Authorization: Bearer $VIESSMANN_TOKEN" \
-          https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations?includeGateways=true \
+          https://api.viessmann-climatesolutions.com/iot/v2/equipment/installations?includeGateways=true \
           | jq '.data[].id'
         ```
   - name: device_id


### PR DESCRIPTION
I've got the following error when following the documentation:

```bash
curl --silent -H "Authorization: Bearer $VIESSMANN_TOKEN" \
  "https://api.viessmann-climatesolutions.com/iot/v1/equipment/installations?includeGateways=true"
{"viErrorId":"req-9d174120b348496fa0ea99f48d2065f4","statusCode":410,"errorType":"GONE","message":"This endpoint has been deprecated and is no longer available. Sunset date: 2025-12-15T12:00:00.000Z Replacement: GET /iot/v2/equipment/installations","extendedPayload":{"sunsetDate":"2025-12-15T12:00:00.000Z","replacement":"GET /iot/v2/equipment/installations"}}
```

https://community.viessmann.de/t5/Announcements/Important-Update-to-Viessmann-API-effective-April-30-2025/td-p/525421#