### PR TITLE
Daheimladen: prevent autostart

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -197,7 +197,8 @@ func (wb *DaheimLaden) Status() (api.ChargeStatus, error) {
 func (wb *DaheimLaden) Enabled() (bool, error) {
 	curr, err := wb.getCurrent()
 
-	return curr > 0, err
+	return curr > 10, err
+	// assume enabled if current limit > 1A to have the option to avoid AutoStart
 }
 
 // Enable implements the api.Charger interface

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -197,13 +197,13 @@ func (wb *DaheimLaden) Status() (api.ChargeStatus, error) {
 func (wb *DaheimLaden) Enabled() (bool, error) {
 	curr, err := wb.getCurrent()
 
-	// assume enabled if current limit > 1A (instead 0A), to have the option to avoid AutoStart
-	return curr > 10, err
+	return curr >= 60, err
 }
 
 // Enable implements the api.Charger interface
 func (wb *DaheimLaden) Enable(enable bool) error {
-	var current uint16
+	// must be > 0 to disable unauthorised autostart
+	var current uint16 = 1
 	if enable {
 		current = wb.curr
 	}

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -107,7 +107,7 @@ func NewDaheimLaden(ctx context.Context, uri string, id uint8, phases bool) (api
 	if err != nil {
 		return nil, fmt.Errorf("current limit: %w", err)
 	}
-	if curr > 60 {
+	if curr >= 60 {
 		wb.curr = curr
 	}
 

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -197,7 +197,7 @@ func (wb *DaheimLaden) Status() (api.ChargeStatus, error) {
 func (wb *DaheimLaden) Enabled() (bool, error) {
 	curr, err := wb.getCurrent()
 
-	return curr >= 60, err
+	return curr >= 50, err
 }
 
 // Enable implements the api.Charger interface

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -107,7 +107,7 @@ func NewDaheimLaden(ctx context.Context, uri string, id uint8, phases bool) (api
 	if err != nil {
 		return nil, fmt.Errorf("current limit: %w", err)
 	}
-	if curr > 0 {
+	if curr > 60 {
 		wb.curr = curr
 	}
 

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -203,7 +203,7 @@ func (wb *DaheimLaden) Enabled() (bool, error) {
 // Enable implements the api.Charger interface
 func (wb *DaheimLaden) Enable(enable bool) error {
 	// must be > 0 to disable unauthorised autostart
-	var current uint16 = 1
+	current := uint16(1)
 	if enable {
 		current = wb.curr
 	}

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -197,7 +197,7 @@ func (wb *DaheimLaden) Status() (api.ChargeStatus, error) {
 func (wb *DaheimLaden) Enabled() (bool, error) {
 	curr, err := wb.getCurrent()
 
-	return curr >= 50, err
+	return curr >= 60, err
 }
 
 // Enable implements the api.Charger interface

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -197,8 +197,8 @@ func (wb *DaheimLaden) Status() (api.ChargeStatus, error) {
 func (wb *DaheimLaden) Enabled() (bool, error) {
 	curr, err := wb.getCurrent()
 
+	// assume enabled if current limit > 1A (instead 0A), to have the option to avoid AutoStart
 	return curr > 10, err
-	// assume enabled if current limit > 1A to have the option to avoid AutoStart
 }
 
 // Enable implements the api.Charger interface


### PR DESCRIPTION
Change current threshold for charger enabled state.

The charger starts automatically if current=0 (register 91) when plugged in.
This change opens the possibility to preset the charging current to 1A (externally) without EVCC recognizing it as enabled.