### PR TITLE
fix: messaging ui and events filter

### DIFF
--- a/assets/js/components/Config/Messaging/EventItem.vue
+++ b/assets/js/components/Config/Messaging/EventItem.vue
@@ -51,7 +51,7 @@
 						:disabled="disabled"
 						:rows="3"
 						required
-						@change="updateMessage($event.target.value)"
+						@update:model-value="updateMessage"
 					/>
 					<div class="text-end small text-gray mt-1">
 						<a

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -425,6 +425,7 @@ import type {
 	DeviceType,
 	Notification,
 	ConfigMessenger,
+	MessagingEvent,
 } from "@/types/evcc";
 
 type DeviceValuesMap = Record<DeviceType, Record<string, any>>;
@@ -698,7 +699,7 @@ export default defineComponent({
 		messagingUiConfigured() {
 			return (
 				this.messengers.length > 0 ||
-				Object.keys(store.state.messagingEvents ?? {}).length > 0
+				Object.values(store.state.messagingEvents ?? {}).some((e: MessagingEvent) => !e.disabled)
 			);
 		},
 	},

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -425,7 +425,6 @@ import type {
 	DeviceType,
 	Notification,
 	ConfigMessenger,
-	MessagingEvent,
 } from "@/types/evcc";
 
 type DeviceValuesMap = Record<DeviceType, Record<string, any>>;
@@ -699,7 +698,7 @@ export default defineComponent({
 		messagingUiConfigured() {
 			return (
 				this.messengers.length > 0 ||
-				Object.values(store.state.messagingEvents ?? {}).some((e: MessagingEvent) => !e.disabled)
+				Object.values(store.state.messagingEvents ?? {}).some((e) => !e.disabled)
 			);
 		},
 	},

--- a/messenger/hub.go
+++ b/messenger/hub.go
@@ -54,7 +54,7 @@ func NewHub(cc globalconfig.MessagingEvents, vv Vehicles, cache *util.ParamCache
 	}
 
 	h := &Hub{
-		definitions: cc,
+		definitions: filtered,
 		cache:       cache,
 		vehicles:    vv,
 	}

--- a/tests/config-messaging.spec.ts
+++ b/tests/config-messaging.spec.ts
@@ -174,6 +174,6 @@ test.describe("messaging", async () => {
     await page.keyboard.press("Escape");
     await expectModalHidden(modal);
 
-    await expect(card).toContainText(["Events", "0", "Services", "0"].join(""));
+    await expect(card).toContainText(["Configured", "no"].join(""));
   });
 });


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/pull/26946#issuecomment-3926003577
Fix https://github.com/evcc-io/evcc/pull/27512#issuecomment-3926854378
Fix: Only show messaging as configured if at least one event is enabled.

\cc @naltatis 