### PR TITLE
Optimizer UI: fix mobile x labels

### DIFF
--- a/assets/js/components/Optimize/ChargeChart.vue
+++ b/assets/js/components/Optimize/ChargeChart.vue
@@ -211,7 +211,8 @@ export default defineComponent({
 								// Show ticks at exact hour boundaries
 								if (minute === 0) {
 									// Show labels only at hours divisible by 4
-									if (hour % 4 === 0) {
+									const step = window.innerWidth < 576 ? 6 : 4;
+									if (hour % step === 0) {
 										return hour.toString();
 									}
 									// Show tick but no label for other hours

--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -177,7 +177,8 @@ export default defineComponent({
 								// Show ticks at exact hour boundaries
 								if (minute === 0) {
 									// Show labels only at hours divisible by 4
-									if (hour % 4 === 0) {
+									const step = window.innerWidth < 576 ? 6 : 4;
+									if (hour % step === 0) {
 										return hour.toString();
 									}
 									// Show tick but no label for other hours

--- a/assets/js/components/Optimize/SocChart.vue
+++ b/assets/js/components/Optimize/SocChart.vue
@@ -189,7 +189,8 @@ export default defineComponent({
 								// Show ticks at exact hour boundaries
 								if (minute === 0) {
 									// Show labels only at hours divisible by 4
-									if (hour % 4 === 0) {
+									const step = window.innerWidth < 576 ? 6 : 4;
+									if (hour % step === 0) {
 										return hour.toString();
 									}
 									// Show tick but no label for other hours


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/27251

small screen
<img width="443" height="701" alt="Bildschirmfoto 2026-02-19 um 12 56 38" src="https://github.com/user-attachments/assets/4c138cd0-85bb-4f73-a71c-3cb8baa3d957" />

large screen
<img width="804" height="677" alt="Bildschirmfoto 2026-02-19 um 12 56 51" src="https://github.com/user-attachments/assets/bc505e0f-c978-49f9-81b6-4e5bab334914" />

