### PR TITLE
fix: loadpoint ui indicator wrapping

### DIFF
--- a/assets/js/components/Loadpoints/Loadpoints.vue
+++ b/assets/js/components/Loadpoints/Loadpoints.vue
@@ -38,7 +38,7 @@
 				/>
 			</div>
 		</div>
-		<div v-if="loadpoints.length > 1" class="d-flex d-lg-none justify-content-center">
+		<div v-if="loadpoints.length > 1" class="d-flex d-lg-none justify-content-center flex-wrap">
 			<button
 				v-for="loadpoint in loadpoints"
 				:key="loadpoint.id"


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/27511

Allow loadpoint indicators to wrap. For when you have very very many loadpoints.

<img width="443" height="871" alt="Bildschirmfoto 2026-02-19 um 21 29 08" src="https://github.com/user-attachments/assets/d3fb13cf-d9ac-43b4-8ad9-3e2c522aee9d" />
