### PR TITLE
Added ConnectionDuration() for phoenix-ev-eth.go

### DIFF
--- a/charger/phoenix-ev-eth.go
+++ b/charger/phoenix-ev-eth.go
@@ -252,7 +252,6 @@ var _ api.ConnectionTimer = (*PhoenixEVEth)(nil)
 
 // ConnectionDuration implements the api.ConnectionTimer interface
 func (wb *PhoenixEVEth) ConnectionDuration() (time.Duration, error) {
-
 	// The following chargetime counter gets valid until first energy is charged,
 	// until that it could hold the charge time of the previous session.
 	eb, err := wb.conn.ReadInputRegisters(phxRegChargedEnergy, 2)


### PR DESCRIPTION
The Phoenix charger is now also able to detect a reconnect lowlevel like the new feature in the TWC3 via ConnectionDuration() function. Final target would be a DisconnectDetect() Interface which covers the real logic per charger and every charger can implement it with his own capabilities.

- [x] - Implement ConnectionDuration logic which works. 
- [ ] - Change ConnectionDuration() Interface into DisconnectDetected() Interface
- [ ] - Simplify implementation