### PR TITLE
Add Rabot Energy

### DIFF
--- a/tariff/rabot.go
+++ b/tariff/rabot.go
@@ -33,12 +33,12 @@ func init() {
 }
 
 func NewRabotFromConfig(other map[string]any) (api.Tariff, error) {
-	cc := struct {
+	var cc {
 		embed    `mapstructure:",squash"`
 		Login    string
 		Password string
 		Gross    bool
-	}{}
+	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err

--- a/tariff/rabot.go
+++ b/tariff/rabot.go
@@ -1,0 +1,195 @@
+package tariff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/tariff/rabot"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+)
+
+type Rabot struct {
+	*embed
+	*request.Helper
+	log        *util.Logger
+	login      string
+	password   string
+	gross      bool
+	contractId string
+	data       *util.Monitor[api.Rates]
+}
+
+var _ api.Tariff = (*Rabot)(nil)
+
+func init() {
+	registry.Add("rabot", NewRabotFromConfig)
+}
+
+func NewRabotFromConfig(other map[string]any) (api.Tariff, error) {
+	cc := struct {
+		embed `mapstructure:",squash"`
+		Login    string
+		Password string
+		Gross    bool
+	}{
+		Gross: true,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
+	if cc.Gross && (cc.Login == "" || cc.Password == "") {
+		return nil, api.ErrMissingCredentials
+	}
+
+	log := util.NewLogger("rabot").Redact(cc.Password)
+
+	t := &Rabot{
+		embed:    &cc.embed,
+		log:      log,
+		login:    cc.Login,
+		password: cc.Password,
+		gross:    cc.Gross,
+		Helper:   request.NewHelper(log),
+		data:     util.NewMonitor[api.Rates](2 * time.Hour),
+	}
+
+	if cc.Login != "" && cc.Password != "" {
+		sessionToken, err := t.authenticate()
+		if err != nil {
+			return nil, err
+		}
+
+		t.Client.Transport = transport.BearerAuth(sessionToken, t.Client.Transport)
+	} else {
+		t.Client.Transport = transport.BearerAuth(rabot.AppToken, t.Client.Transport)
+	}
+
+	return runOrError(t)
+}
+
+func (t *Rabot) authenticate() (string, error) {
+	body, err := json.Marshal(struct {
+		Login    string `json:"login"`
+		Password string `json:"password"`
+	}{
+		Login:    t.login,
+		Password: t.password,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := request.New(http.MethodPost, rabot.BaseURI+"/api/prosumer/session/login", bytes.NewReader(body), map[string]string{
+		"Authorization": "Bearer " + rabot.AppToken,
+		"Content-Type":  request.JSONContent,
+		"Accept":        request.JSONContent,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	client := request.NewHelper(t.log)
+	var loginRes rabot.LoginResponse
+	if err := client.DoJSON(req, &loginRes); err != nil {
+		return "", fmt.Errorf("login: %w", err)
+	}
+
+	t.log.Redact(loginRes.SessionToken)
+
+	// fetch contract ID
+	req, err = request.New(http.MethodGet, rabot.BaseURI+"/api/prosumer/v2/contract/list?contractStatus=active", nil, map[string]string{
+		"Authorization": "Bearer " + loginRes.SessionToken,
+		"Accept":        request.JSONContent,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var contractsRes rabot.ContractsResponse
+	if err := client.DoJSON(req, &contractsRes); err != nil {
+		return "", fmt.Errorf("contracts: %w", err)
+	}
+
+	if len(contractsRes.Contracts) == 0 {
+		return "", fmt.Errorf("no active contracts found")
+	}
+
+	t.contractId = contractsRes.Contracts[0].ID
+
+	return loginRes.SessionToken, nil
+}
+
+func (t *Rabot) run(done chan error) {
+	var once sync.Once
+
+	for tick := time.Tick(time.Hour); ; <-tick {
+		var uri string
+		if t.gross {
+			sessionToken, err := t.authenticate()
+			if err != nil {
+				once.Do(func() { done <- err })
+				t.log.ERROR.Println(err)
+				continue
+			}
+
+			t.Client.Transport = transport.BearerAuth(sessionToken, http.DefaultTransport)
+			uri = fmt.Sprintf("%s/api/price-preview/%s", rabot.BaseURI, t.contractId)
+		} else {
+			uri = rabot.BaseURI + "/api/price-preview"
+		}
+
+		var res rabot.PriceResponse
+		if err := backoff.Retry(func() error {
+			return backoffPermanentError(t.GetJSON(uri, &res))
+		}, bo()); err != nil {
+			once.Do(func() { done <- err })
+			t.log.ERROR.Println(err)
+			continue
+		}
+
+		data := make(api.Rates, 0, len(res.Records))
+		for _, r := range res.Records {
+			price := r.PriceNet.Value
+			if t.gross {
+				price = r.PriceGross.Value
+			}
+
+			ar := api.Rate{
+				Start: r.Moment,
+				End:   r.Moment.Add(15 * time.Minute),
+				Value: t.totalPrice(price/100, r.Moment),
+			}
+			data = append(data, ar)
+		}
+
+		mergeRates(t.data, data)
+		once.Do(func() { close(done) })
+	}
+}
+
+func (t *Rabot) Rates() (api.Rates, error) {
+	var res api.Rates
+	err := t.data.GetFunc(func(val api.Rates) {
+		res = slices.Clone(val)
+	})
+	return res, err
+}
+
+func (t *Rabot) Type() api.TariffType {
+	return api.TariffTypePriceForecast
+}

--- a/tariff/rabot/api.go
+++ b/tariff/rabot/api.go
@@ -8,7 +8,9 @@ const (
 )
 
 type LoginResponse struct {
-	SessionToken string `json:"sessionToken"`
+	SessionToken string  `json:"sessionToken"`
+	RefreshToken string  `json:"refreshToken"`
+	ExpiresIn    float32 `json:"expiresIn"`
 }
 
 type Contract struct {

--- a/tariff/rabot/api.go
+++ b/tariff/rabot/api.go
@@ -1,0 +1,34 @@
+package rabot
+
+import "time"
+
+const (
+	BaseURI  = "https://api.rabot-charge.de"
+	AppToken = "41ee682c-a700-4c6f-85b5-fd912ec4a70d"
+)
+
+type LoginResponse struct {
+	SessionToken string `json:"sessionToken"`
+}
+
+type Contract struct {
+	ID string `json:"id"`
+}
+
+type ContractsResponse struct {
+	Contracts []Contract `json:"contracts"`
+}
+
+type PriceValue struct {
+	Value float64 `json:"value"`
+}
+
+type Record struct {
+	Moment     time.Time  `json:"moment"`
+	PriceGross PriceValue `json:"priceGross_inCentPerKwh"`
+	PriceNet   PriceValue `json:"priceNet_inCentPerKwh"`
+}
+
+type PriceResponse struct {
+	Records []Record `json:"records"`
+}

--- a/tariff/rabot/api.go
+++ b/tariff/rabot/api.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	BaseURI  = "https://api.rabot-charge.de"
-	AppToken = "41ee682c-a700-4c6f-85b5-fd912ec4a70d"
+	AppToken = "41ee682c-a700-4c6f-85b5-fd912ec4a70d" // gitleaks:allow (public API token)
 )
 
 type LoginResponse struct {

--- a/tariff/rabot/identity.go
+++ b/tariff/rabot/identity.go
@@ -1,0 +1,93 @@
+package rabot
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
+	"github.com/evcc-io/evcc/util/request"
+	"golang.org/x/oauth2"
+)
+
+type tokenSource struct {
+	*request.Helper
+	log             *util.Logger
+	login, password string
+}
+
+func TokenSource(log *util.Logger, login, password string) (oauth2.TokenSource, error) {
+	c := &tokenSource{
+		Helper:   request.NewHelper(log),
+		log:      log,
+		login:    login,
+		password: password,
+	}
+
+	token, err := c.authenticate()
+	if err != nil {
+		return nil, err
+	}
+
+	return oauth.RefreshTokenSource(token, c.refreshToken), nil
+}
+
+func (c *tokenSource) authenticate() (*oauth2.Token, error) {
+	data := struct {
+		Login    string `json:"login"`
+		Password string `json:"password"`
+	}{
+		Login:    c.login,
+		Password: c.password,
+	}
+
+	req, err := request.New(http.MethodPost, BaseURI+"/api/prosumer/session/login", request.MarshalJSON(data), request.JSONEncoding, map[string]string{
+		"Authorization": "Bearer " + AppToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res LoginResponse
+	if err := c.DoJSON(req, &res); err != nil {
+		return nil, fmt.Errorf("login: %w", err)
+	}
+
+	c.log.Redact(res.SessionToken, res.RefreshToken)
+
+	return &oauth2.Token{
+		AccessToken:  res.SessionToken,
+		RefreshToken: res.RefreshToken,
+		Expiry:       time.Now().Add(time.Second * time.Duration(res.ExpiresIn)),
+	}, nil
+}
+
+func (c *tokenSource) refreshToken(token *oauth2.Token) (*oauth2.Token, error) {
+	data := struct {
+		RefreshToken string `json:"refreshToken"`
+	}{
+		RefreshToken: token.RefreshToken,
+	}
+
+	req, err := request.New(http.MethodPost, BaseURI+"/api/prosumer/session/refresh", request.MarshalJSON(data), request.JSONEncoding, map[string]string{
+		"Authorization": "Bearer " + AppToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res LoginResponse
+	if err := c.DoJSON(req, &res); err != nil {
+		// fall back to full re-authentication
+		return c.authenticate()
+	}
+
+	c.log.Redact(res.SessionToken, res.RefreshToken)
+
+	return &oauth2.Token{
+		AccessToken:  res.SessionToken,
+		RefreshToken: res.RefreshToken,
+		Expiry:       time.Now().Add(time.Second * time.Duration(res.ExpiresIn)),
+	}, nil
+}

--- a/templates/definition/tariff/rabot-energy.yaml
+++ b/templates/definition/tariff/rabot-energy.yaml
@@ -1,0 +1,27 @@
+template: rabot-energy
+products:
+  - brand: rabot.energy
+group: price
+countries: ["DE"]
+params:
+  - name: gross
+    type: bool
+    default: false
+    description:
+      en: use gross prices (login mandatory)
+      de: Bruttopreise verwenden (Login notwendig)
+  - name: login
+    description:
+      en: Login / email address
+      de: Login / E-Mail-Adresse
+  - name: password
+    description:
+      en: password
+      de: Passwort
+  - preset: tariff-base
+render: |
+  type: rabot
+  gross: {{ .gross }}
+  login: {{ .login }}
+  password: {{ .password }}
+  {{ include "tariff-base" . }}

--- a/templates/definition/tariff/rabot-energy.yaml
+++ b/templates/definition/tariff/rabot-energy.yaml
@@ -15,9 +15,6 @@ params:
       en: Login / email address
       de: Login / E-Mail-Adresse
   - name: password
-    description:
-      en: password
-      de: Passwort
   - preset: tariff-base
 render: |
   type: rabot


### PR DESCRIPTION
https://www.rabot.energy/ offers dynamic tarifs for Germany. Unfortunately they don't offer an official API. 
Therefore I did reverse engineer their mobile app. My basic finding is that net prices can be fetched anonymously. For gross prices (including taxes and "netzentgelt") you need first acquire a session token using your login and passowrd. In a subsequent API call you get your customer data and finally pass in your contract id in the price endpoint to get gross prices.

The following snippets do use the VS Code's http plugin notation:

net prices
```
@baseUrl = https://api.rabot-charge.de
@appToken = 41ee682c-a700-4c6f-85b5-fd912ec4a70d

GET {{baseUrl}}/api/price-preview
Authorization: Bearer {{appToken}}
```

gross prices:
```
@baseUrl = https://api.rabot-charge.de
@appToken = 41ee682c-a700-4c6f-85b5-fd912ec4a70d

### 1. Login
# @name login
POST {{baseUrl}}/api/prosumer/session/login
Authorization: Bearer {{appToken}}
Content-Type: application/json

{
  "login": "{{$dotenv RABOT_LOGIN}}",
  "password": "{{$dotenv RABOT_PASSWORD}}"
}

### 2. Get contract ID
# @name contracts
GET {{baseUrl}}/api/prosumer/v2/contract/list?contractStatus=active
Authorization: Bearer {{login.response.body.sessionToken}}

### 3. Get day-ahead prices (net + gross)
GET {{baseUrl}}/api/price-preview/{{contracts.response.body.contracts[0].id}}
Authorization: Bearer {{login.response.body.sessionToken}}
```

Based on these findings I've created a tarif implementation for evcc. Since this is my very first go code please do carefully check if it's reasonable.

I've tested it by starting `./evcc` and putting in this snippet in the tarif config:
```
grid: # price using energy from the grid
  type: template
  template: rabot-energy
  login: <redacted>
  password: <redacted>
  gross: true
```

Looking at "Vorhersage" I got the price data displayed:
<img width="871" height="515" alt="image" src="https://github.com/user-attachments/assets/44a9b65c-4775-4d95-9c69-8e30db8837da" />

