### PR TITLE
fix: email service

### DIFF
--- a/messenger/shoutrrr.go
+++ b/messenger/shoutrrr.go
@@ -9,6 +9,7 @@ import (
 )
 
 func init() {
+	registry.Add("email", NewShoutrrrFromConfig)
 	registry.Add("shout", NewShoutrrrFromConfig)
 }
 

--- a/templates/definition/messenger/email.yaml
+++ b/templates/definition/messenger/email.yaml
@@ -12,9 +12,7 @@ params:
     example: 465
     default: 465
   - name: user
-    required: true
   - name: password
-    required: true
   - name: from
     required: true
     example: john.doe@example.com


### PR DESCRIPTION
Fix #27578, follow-up to https://github.com/evcc-io/evcc/pull/26946

- Re-add `email` service type to avoid BC (@andig do we want to do this?)
- make `user` and `password` optional in template

Changes need to be tested, especially the email template without user and password set - maybe in nightly?