### PR TITLE
Fix: update vehicle identifier in session

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -42,7 +42,7 @@ func (lp *Loadpoint) setVehicleIdentifier(id string) {
 		lp.vehicleIdentifier = id
 		lp.publish(keys.VehicleIdentity, id)
 		lp.updateSession(func(session *session.Session) {
-			lp.session.Identifier = id
+			session.Identifier = id
 		})
 	}
 }

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -41,9 +41,11 @@ func (lp *Loadpoint) setVehicleIdentifier(id string) {
 	if lp.vehicleIdentifier != id {
 		lp.vehicleIdentifier = id
 		lp.publish(keys.VehicleIdentity, id)
-		lp.updateSession(func(session *session.Session) {
-			session.Identifier = id
-		})
+		if id != "" {
+			lp.updateSession(func(session *session.Session) {
+				session.Identifier = id
+			})
+		}
 	}
 }
 

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -38,14 +38,17 @@ func (lp *Loadpoint) coordinatedVehicles() []api.Vehicle {
 
 // setVehicleIdentifier updated the vehicle id as read from the charger
 func (lp *Loadpoint) setVehicleIdentifier(id string) {
-	if lp.vehicleIdentifier != id {
-		lp.vehicleIdentifier = id
-		lp.publish(keys.VehicleIdentity, id)
-		if id != "" {
-			lp.updateSession(func(session *session.Session) {
-				session.Identifier = id
-			})
-		}
+	if lp.vehicleIdentifier == id {
+		return
+	}
+
+	lp.vehicleIdentifier = id
+	lp.publish(keys.VehicleIdentity, id)
+
+	if id != "" {
+		lp.updateSession(func(session *session.Session) {
+			session.Identifier = id
+		})
 	}
 }
 
@@ -165,12 +168,9 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 	lp.PublishEffectiveValues()
 
 	lp.updateSession(func(session *session.Session) {
-		var title string
 		if v != nil {
-			title = v.GetTitle()
+			session.Vehicle = v.GetTitle()
 		}
-
-		lp.session.Vehicle = title
 	})
 }
 

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -41,6 +41,9 @@ func (lp *Loadpoint) setVehicleIdentifier(id string) {
 	if lp.vehicleIdentifier != id {
 		lp.vehicleIdentifier = id
 		lp.publish(keys.VehicleIdentity, id)
+		lp.updateSession(func(session *session.Session) {
+			lp.session.Identifier = id
+		})
 	}
 }
 


### PR DESCRIPTION
If the session was created before the vehicle identifier is set, lp.session.Identifier is empty.
As a result database and charging sessions csv file have no identifier entry.

Update vehicle identifier in session after reading the identifier from charger will fix this issue.