### PR TITLE
Planner: fix projected end time not showing actual completion

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -233,6 +233,8 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 			return true
 		case strategy.Continuous && requiredDuration > strategy.Precondition:
 			lp.log.DEBUG.Printf("plan: ignoring restart at %s for continuous charging", planStart.Round(time.Second).Local())
+			planStart = lp.clock.Now()
+			planEnd = planStart.Add(requiredDuration)
 			return true
 		}
 	}


### PR DESCRIPTION
follow-up #27227

Solves a situation where the UI does not **show** the reason for a running charging session but a starting point of the future plan (see screenshot at comment).

A continuous session has started before but is superseeded by another later (equal costs) plan. The previous plan continues execution as expected but the reason is not visible (only from the logs). The later plan is not executed because the target is reached by the plan continue.

This fix shows the current plan execution.

Situation:

**13:16 – plan created: cheapest slot at 13:30, target 07:00 tomorrow**                                                                                                                 
```
Feb 22 13:16:19 [lp-1] plan: charge 1h25m37s between 2026-02-22 13:30:00 until 2026-02-23 07:00:00 (power: 7360W, avg cost: 0.184)
```                                                                                                                                     
                                                                                                                                                                                        
**13:30 – charging starts in active slot**
```
Feb 22 13:30:32 [lp-1] charge power: 326W                                                                                                                                             
Feb 22 13:30:45 [lp-1] charge power: 7266W       
```                                                                                                                                     

**14:00 – slot ended, ~46 min remaining energy needed**

next optimal slot: tonight 23:45 (same price)
continuous=true → charging continues (correct)
BUT planProjectedEnd points to end of FUTURE slot (07:00 tomorrow)
→ UI shows "→ tomorrow 00:36" instead of "→ today ~14:46"

```
Feb 22 14:00:15 [lp-1] plan: charge 46m37s between 2026-02-22 23:45:00 until 2026-02-23 07:00:00 (power: 7360W, avg cost: 0.185)
Feb 22 14:00:15 [lp-1] plan: ignoring restart at 2026-02-22 23:45:00 for continuous charging
Feb 22 14:00:09 [lp-1] charge power: 7162W
```

A screenshot (7.2 kW, "plan tomorrow 07:00 100%", "→ tomorrow 00:36") was taken at ~13:56: charging is correctly continuing (continuous=true), but planProjectedEnd = end of later alternative (07:00) instead of now + 46min (~14:46).

The new projected plan is later but at equal costs, original plan 18.4 ct/kWh (see log) was optimal.