### PR TITLE
feat: add plugin for retrieving tariff/solar forecast from HomeAssistant

### DIFF
--- a/tariff/homeassistant.go
+++ b/tariff/homeassistant.go
@@ -48,9 +48,9 @@ func NewHATariffFromConfig(other map[string]any) (api.Tariff, error) {
 	cc := struct {
 		embed      `mapstructure:",squash"`
 		URI        string
-		Entities   []string // one or more entity IDs to merge (e.g. today, d1, d2, d3)
-		Attributes []string // attributes to read from each entity
-		Format     string   // "nordpool" (native), "zonneplan", "entsoe", "watts", "solcast"
+		Entities   []string       // one or more entity IDs to merge (e.g. today, d1, d2, d3)
+		Attributes []string       // attributes to read from each entity
+		Format     string         // "nordpool" (native), "zonneplan", "entsoe", "watts", "solcast"
 		Tariff     api.TariffType `mapstructure:"tariff"`
 		Interval   time.Duration
 		Cache      time.Duration

--- a/tariff/homeassistant.go
+++ b/tariff/homeassistant.go
@@ -1,0 +1,402 @@
+package tariff
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/homeassistant"
+)
+
+func init() {
+	registry.Add("homeassistant", NewHATariffFromConfig)
+}
+
+// haStateSource abstracts HA state fetching for testability
+type haStateSource interface {
+	GetFloatState(entity string) (float64, error)
+	GetJSON(uri string, result any) error
+}
+
+// HATariff reads electricity prices or solar forecast from Home Assistant entities
+type HATariff struct {
+	*embed
+	log        *util.Logger
+	source     haStateSource
+	baseURI    string
+	entities   []string
+	attributes []string
+	format     string
+	priceG     func() (float64, error)
+	data       *util.Monitor[api.Rates]
+	typ        api.TariffType
+}
+
+var _ api.Tariff = (*HATariff)(nil)
+
+func NewHATariffFromConfig(other map[string]any) (api.Tariff, error) {
+	cc := struct {
+		embed      `mapstructure:",squash"`
+		URI        string
+		Entities   []string // one or more entity IDs to merge (e.g. today, d1, d2, d3)
+		Attributes []string // attributes to read from each entity
+		Format     string   // "nordpool" (native), "zonneplan", "entsoe", "watts", "solcast"
+		Tariff     api.TariffType `mapstructure:"tariff"`
+		Interval   time.Duration
+		Cache      time.Duration
+	}{
+		Interval: time.Hour,
+		Cache:    5 * time.Minute,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.URI == "" {
+		return nil, errors.New("missing uri")
+	}
+
+	if len(cc.Entities) == 0 {
+		return nil, errors.New("missing entities")
+	}
+
+	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
+	log := util.NewLogger("homeassistant")
+
+	conn, err := homeassistant.NewConnection(log, cc.URI, "")
+	if err != nil {
+		return nil, err
+	}
+
+	baseURI := util.DefaultScheme(strings.TrimSuffix(cc.URI, "/"), "http")
+
+	return newHATariff(&cc.embed, log, conn, baseURI, cc.Entities, cc.Attributes, cc.Format, cc.Tariff, cc.Interval, cc.Cache)
+}
+
+func newHATariff(
+	emb *embed,
+	log *util.Logger,
+	source haStateSource,
+	baseURI string,
+	entities []string,
+	attributes []string,
+	format string,
+	typ api.TariffType,
+	interval, cache time.Duration,
+) (api.Tariff, error) {
+	t := &HATariff{
+		embed:      emb,
+		log:        log,
+		source:     source,
+		baseURI:    baseURI,
+		entities:   entities,
+		attributes: attributes,
+		format:     format,
+		typ:        typ,
+		data:       util.NewMonitor[api.Rates](2 * interval),
+	}
+
+	if len(attributes) == 0 {
+		// price mode: only a single entity makes sense
+		if len(entities) != 1 {
+			return nil, errors.New("price mode requires exactly one entity")
+		}
+		priceG := func() (float64, error) {
+			v, err := source.GetFloatState(entities[0])
+			if err != nil {
+				t.log.WARN.Printf("entity %s: %v", entities[0], err)
+			}
+			return v, err
+		}
+		t.priceG = util.Cached(priceG, cache)
+		return t, nil
+	}
+
+	// forecast mode: background loop over all entities and attributes
+	return runOrError(t)
+}
+
+func (t *HATariff) run(done chan error) {
+	var once sync.Once
+
+	for tick := time.Tick(time.Hour); ; <-tick {
+		if err := backoff.Retry(func() error {
+			var combined api.Rates
+
+			for _, entity := range t.entities {
+				uri := fmt.Sprintf("%s/api/states/%s", t.baseURI, url.PathEscape(entity))
+
+				var res struct {
+					Attributes map[string]json.RawMessage `json:"attributes"`
+				}
+
+				if err := t.source.GetJSON(uri, &res); err != nil {
+					return backoffPermanentError(fmt.Errorf("entity %s: %w", entity, err))
+				}
+
+				for _, attr := range t.attributes {
+					raw, ok := res.Attributes[attr]
+					if !ok {
+						t.log.DEBUG.Printf("attribute %q not found on %s, skipping", attr, entity)
+						continue
+					}
+
+					rates, err := t.parseRates(raw)
+					if err != nil {
+						return backoff.Permanent(fmt.Errorf("%s attribute %q: %w", entity, attr, err))
+					}
+					combined = append(combined, rates...)
+				}
+			}
+
+			for i, r := range combined {
+				combined[i] = api.Rate{
+					Value: t.totalPrice(r.Value, r.Start),
+					Start: r.Start.Local(),
+					End:   r.End.Local(),
+				}
+			}
+
+			if len(combined) == 0 {
+				t.log.WARN.Println("no rates collected from any entity/attribute")
+			}
+			mergeRates(t.data, combined)
+			return nil
+		}, bo()); err != nil {
+			once.Do(func() { done <- err })
+			t.log.ERROR.Println(err)
+			continue
+		}
+
+		once.Do(func() { close(done) })
+	}
+}
+
+// parseRates converts a raw JSON attribute to api.Rates using the configured format
+func (t *HATariff) parseRates(raw json.RawMessage) (api.Rates, error) {
+	switch t.format {
+	case "zonneplan":
+		return parseZonneplan(raw)
+	case "entsoe":
+		return parseEntsoe(raw)
+	case "watts":
+		return parseWatts(raw)
+	case "solcast":
+		return parseSolcast(raw)
+	default: // "" or "nordpool" — native api.Rates JSON (start/end/value)
+		var rates api.Rates
+		if err := json.Unmarshal(raw, &rates); err != nil {
+			return nil, err
+		}
+		return rates, nil
+	}
+}
+
+// zonneplanEntry is one slot from the Zonneplan forecast attribute
+type zonneplanEntry struct {
+	Datetime         string `json:"datetime"`
+	ElectricityPrice int64  `json:"electricity_price"`
+}
+
+// parseZonneplan converts Zonneplan forecast entries to api.Rates.
+// electricity_price is in units of 1e-7 €/kWh.
+// Slot end is inferred from the next entry's start; the last slot is 1h.
+func parseZonneplan(raw json.RawMessage) (api.Rates, error) {
+	var entries []zonneplanEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, err
+	}
+
+	rates := make(api.Rates, len(entries))
+	for i, e := range entries {
+		start, err := time.Parse(time.RFC3339Nano, e.Datetime)
+		if err != nil {
+			return nil, fmt.Errorf("datetime %q: %w", e.Datetime, err)
+		}
+
+		var end time.Time
+		if i+1 < len(entries) {
+			end, err = time.Parse(time.RFC3339Nano, entries[i+1].Datetime)
+			if err != nil {
+				return nil, fmt.Errorf("datetime %q: %w", entries[i+1].Datetime, err)
+			}
+		} else {
+			end = start.Add(time.Hour)
+		}
+
+		rates[i] = api.Rate{
+			Start: start,
+			End:   end,
+			Value: float64(e.ElectricityPrice) / 1e7,
+		}
+	}
+
+	return rates, nil
+}
+
+// entsoeEntry is one slot from the ENTSO-E HA integration attribute (prices_today / prices_tomorrow)
+type entsoeEntry struct {
+	Time  string  `json:"time"`
+	Price float64 `json:"price"`
+}
+
+// entsoeTimeFormat matches "2026-02-23 00:00:00+01:00"
+const entsoeTimeFormat = "2006-01-02 15:04:05-07:00"
+
+// parseEntsoe converts ENTSO-E HA integration entries to api.Rates.
+// Slot end is inferred from the next entry's time; the last slot is 1h.
+func parseEntsoe(raw json.RawMessage) (api.Rates, error) {
+	var entries []entsoeEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, err
+	}
+
+	rates := make(api.Rates, len(entries))
+	for i, e := range entries {
+		start, err := time.Parse(entsoeTimeFormat, e.Time)
+		if err != nil {
+			return nil, fmt.Errorf("time %q: %w", e.Time, err)
+		}
+
+		var end time.Time
+		if i+1 < len(entries) {
+			end, err = time.Parse(entsoeTimeFormat, entries[i+1].Time)
+			if err != nil {
+				return nil, fmt.Errorf("time %q: %w", entries[i+1].Time, err)
+			}
+		} else {
+			end = start.Add(time.Hour)
+		}
+
+		rates[i] = api.Rate{
+			Start: start,
+			End:   end,
+			Value: e.Price,
+		}
+	}
+
+	return rates, nil
+}
+
+// parseWatts converts a {ISO-8601 timestamp → watts} dict attribute to api.Rates.
+// Used by Forecast.Solar and Open-Meteo HA integrations (attribute: watts), 15-min slots.
+func parseWatts(raw json.RawMessage) (api.Rates, error) {
+	var data map[string]float64
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, err
+	}
+
+	keys := slices.Sorted(maps.Keys(data))
+	rates := make(api.Rates, len(keys))
+
+	for i, k := range keys {
+		start, err := time.Parse(time.RFC3339, k)
+		if err != nil {
+			return nil, fmt.Errorf("timestamp %q: %w", k, err)
+		}
+
+		var end time.Time
+		if i+1 < len(keys) {
+			if end, err = time.Parse(time.RFC3339, keys[i+1]); err != nil {
+				return nil, fmt.Errorf("timestamp %q: %w", keys[i+1], err)
+			}
+		} else {
+			end = start.Add(SlotDuration)
+		}
+
+		rates[i] = api.Rate{
+			Start: start,
+			End:   end,
+			Value: data[k],
+		}
+	}
+
+	return rates, nil
+}
+
+// solcastEntry is one 30-min slot from the Solcast HA integration detailedForecast attribute
+type solcastEntry struct {
+	PeriodStart string  `json:"period_start"`
+	PvEstimate  float64 `json:"pv_estimate"`
+}
+
+// parseSolcast converts Solcast detailedForecast entries to api.Rates.
+// pv_estimate is in kW; slots are fixed at 30 minutes.
+func parseSolcast(raw json.RawMessage) (api.Rates, error) {
+	var entries []solcastEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, err
+	}
+	rates := make(api.Rates, len(entries))
+	for i, e := range entries {
+		start, err := time.Parse(time.RFC3339, e.PeriodStart)
+		if err != nil {
+			return nil, fmt.Errorf("period_start %q: %w", e.PeriodStart, err)
+		}
+		rates[i] = api.Rate{
+			Start: start,
+			End:   start.Add(30 * time.Minute),
+			Value: e.PvEstimate * 1000, // kW → W
+		}
+	}
+	return rates, nil
+}
+
+func (t *HATariff) priceRates() (api.Rates, error) {
+	price, err := t.priceG()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(api.Rates, 48*4) // 2 days of 15-min slots
+	start := time.Now().Truncate(SlotDuration)
+
+	for i := range res {
+		slot := start.Add(time.Duration(i) * SlotDuration)
+		res[i] = api.Rate{
+			Start: slot,
+			End:   slot.Add(SlotDuration),
+			Value: t.totalPrice(price, slot),
+		}
+	}
+
+	return res, nil
+}
+
+// Rates implements the api.Tariff interface
+func (t *HATariff) Rates() (api.Rates, error) {
+	if t.priceG != nil {
+		return t.priceRates()
+	}
+
+	var res api.Rates
+	err := t.data.GetFunc(func(val api.Rates) {
+		res = slices.Clone(val)
+	})
+	return res, err
+}
+
+// Type implements the api.Tariff interface
+func (t *HATariff) Type() api.TariffType {
+	switch {
+	case t.typ != 0:
+		return t.typ
+	case t.priceG != nil:
+		return api.TariffTypePriceDynamic
+	default:
+		return api.TariffTypePriceForecast
+	}
+}

--- a/tariff/homeassistant_test.go
+++ b/tariff/homeassistant_test.go
@@ -1,0 +1,378 @@
+package tariff
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockHASource implements haStateSource for testing.
+// attributes maps entity → attribute name → value.
+type mockHASource struct {
+	price      float64
+	priceErr   error
+	attributes map[string]map[string]any
+	jsonErr    error
+}
+
+func (m *mockHASource) GetFloatState(_ string) (float64, error) {
+	return m.price, m.priceErr
+}
+
+func (m *mockHASource) GetJSON(uri string, result any) error {
+	if m.jsonErr != nil {
+		return m.jsonErr
+	}
+	// extract entity from URI: .../api/states/<entity>
+	parts := splitURI(uri)
+	entity := parts[len(parts)-1]
+
+	attrs, ok := m.attributes[entity]
+	if !ok {
+		attrs = map[string]any{}
+	}
+
+	b, err := json.Marshal(map[string]any{"attributes": attrs})
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, result)
+}
+
+func splitURI(uri string) []string {
+	parts := []string{}
+	cur := ""
+	for _, c := range uri {
+		if c == '/' {
+			if cur != "" {
+				parts = append(parts, cur)
+			}
+			cur = ""
+		} else {
+			cur += string(c)
+		}
+	}
+	if cur != "" {
+		parts = append(parts, cur)
+	}
+	return parts
+}
+
+func newTestTariff(t *testing.T, source haStateSource, entities []string, attrs []string, format string) api.Tariff {
+	t.Helper()
+	emb := &embed{}
+	require.NoError(t, emb.init())
+	tar, err := newHATariff(emb, util.NewLogger("test"), source,
+		"http://ha.local:8123", entities, attrs, format,
+		0, time.Hour, time.Minute)
+	require.NoError(t, err)
+	return tar
+}
+
+// --- price mode ---
+
+func TestHATariffPriceMode(t *testing.T) {
+	source := &mockHASource{price: 0.25}
+	tar := newTestTariff(t, source, []string{"sensor.price"}, nil, "")
+
+	assert.Equal(t, api.TariffTypePriceDynamic, tar.Type())
+
+	rates, err := tar.Rates()
+	require.NoError(t, err)
+	assert.Equal(t, 48*4, len(rates))
+	assert.Equal(t, 0.25, rates[0].Value)
+	assert.Equal(t, rates[0].End, rates[1].Start)
+}
+
+func TestHATariffPriceModeError(t *testing.T) {
+	source := &mockHASource{priceErr: fmt.Errorf("unavailable")}
+	tar := newTestTariff(t, source, []string{"sensor.price"}, nil, "")
+	_, err := tar.Rates()
+	require.Error(t, err)
+}
+
+func TestHATariffPriceModeMultiEntityRejected(t *testing.T) {
+	emb := &embed{}
+	require.NoError(t, emb.init())
+	_, err := newHATariff(emb, util.NewLogger("test"), &mockHASource{},
+		"http://ha.local:8123", []string{"sensor.a", "sensor.b"}, nil, "",
+		0, time.Hour, time.Minute)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one entity")
+}
+
+// --- native forecast (Nordpool) ---
+
+func TestHATariffNativeForecast(t *testing.T) {
+	now := time.Now().Truncate(time.Hour)
+	rates := api.Rates{
+		{Start: now, End: now.Add(time.Hour), Value: 0.25},
+		{Start: now.Add(time.Hour), End: now.Add(2 * time.Hour), Value: 0.20},
+	}
+	raw, _ := json.Marshal(rates)
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.nordpool": {"raw_today": json.RawMessage(raw)},
+		},
+	}
+	tar := newTestTariff(t, source, []string{"sensor.nordpool"}, []string{"raw_today"}, "nordpool")
+
+	assert.Equal(t, api.TariffTypePriceForecast, tar.Type())
+	result, err := tar.Rates()
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, 0.25, result[0].Value)
+}
+
+func TestHATariffMultiAttributeMerge(t *testing.T) {
+	now := time.Now().Truncate(time.Hour)
+	today := api.Rates{{Start: now, End: now.Add(time.Hour), Value: 0.25}}
+	tomorrow := api.Rates{{Start: now.Add(24 * time.Hour), End: now.Add(25 * time.Hour), Value: 0.20}}
+	rawToday, _ := json.Marshal(today)
+	rawTomorrow, _ := json.Marshal(tomorrow)
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.nordpool": {
+				"raw_today":    json.RawMessage(rawToday),
+				"raw_tomorrow": json.RawMessage(rawTomorrow),
+			},
+		},
+	}
+	tar := newTestTariff(t, source, []string{"sensor.nordpool"}, []string{"raw_today", "raw_tomorrow"}, "nordpool")
+
+	result, err := tar.Rates()
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+}
+
+func TestHATariffMissingAttributeSkipped(t *testing.T) {
+	now := time.Now().Truncate(time.Hour)
+	today := api.Rates{{Start: now, End: now.Add(time.Hour), Value: 0.25}}
+	raw, _ := json.Marshal(today)
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.nordpool": {"raw_today": json.RawMessage(raw)},
+			// raw_tomorrow absent — silently skipped
+		},
+	}
+	tar := newTestTariff(t, source, []string{"sensor.nordpool"}, []string{"raw_today", "raw_tomorrow"}, "nordpool")
+
+	result, err := tar.Rates()
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+}
+
+// --- multi-entity (solar day-ahead) ---
+
+func TestHATariffMultiEntityMerge(t *testing.T) {
+	makeRaw := func(start time.Time, w float64) json.RawMessage {
+		key := start.Format(time.RFC3339)
+		b, _ := json.Marshal(map[string]float64{key: w})
+		return b
+	}
+
+	now := time.Now().Truncate(time.Hour)
+	d1 := now.Add(24 * time.Hour)
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.solar_today": {"watts": makeRaw(now, 500)},
+			"sensor.solar_d1":    {"watts": makeRaw(d1, 450)},
+		},
+	}
+	tar := newTestTariff(t, source,
+		[]string{"sensor.solar_today", "sensor.solar_d1"},
+		[]string{"watts"}, "watts")
+
+	result, err := tar.Rates()
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, float64(500), result[0].Value)
+	assert.Equal(t, float64(450), result[1].Value)
+}
+
+// --- Zonneplan ---
+
+func TestParseZonneplan(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"datetime":"2026-02-23T10:00:00.000000Z","electricity_price":1830020},
+		{"datetime":"2026-02-23T11:00:00.000000Z","electricity_price":1413750},
+		{"datetime":"2026-02-23T12:00:00.000000Z","electricity_price":1364957}
+	]`)
+
+	rates, err := parseZonneplan(raw)
+	require.NoError(t, err)
+	require.Len(t, rates, 3)
+
+	assert.InDelta(t, 0.183002, rates[0].Value, 1e-6)
+	assert.Equal(t, rates[0].End, rates[1].Start)
+	assert.Equal(t, rates[1].End, rates[2].Start)
+	assert.Equal(t, rates[2].Start.Add(time.Hour), rates[2].End)
+}
+
+func TestHATariffZonneplan(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"datetime":"2026-02-23T10:00:00.000000Z","electricity_price":1830020},
+		{"datetime":"2026-02-23T11:00:00.000000Z","electricity_price":1413750}
+	]`)
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.zonneplan_current_electricity_tariff": {"forecast": json.RawMessage(raw)},
+		},
+	}
+	tar := newTestTariff(t, source,
+		[]string{"sensor.zonneplan_current_electricity_tariff"},
+		[]string{"forecast"}, "zonneplan")
+
+	result, err := tar.Rates()
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.InDelta(t, 0.183002, result[0].Value, 1e-6)
+}
+
+// --- ENTSO-E ---
+
+func TestParseEntsoe(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"time":"2026-02-23 10:00:00+01:00","price":0.23093},
+		{"time":"2026-02-23 11:00:00+01:00","price":0.21048},
+		{"time":"2026-02-23 12:00:00+01:00","price":0.16886}
+	]`)
+
+	rates, err := parseEntsoe(raw)
+	require.NoError(t, err)
+	require.Len(t, rates, 3)
+
+	assert.Equal(t, 0.23093, rates[0].Value)
+	assert.Equal(t, rates[0].End, rates[1].Start)
+	assert.Equal(t, rates[2].Start.Add(time.Hour), rates[2].End)
+}
+
+// --- Forecast.Solar / Open-Meteo ---
+
+func TestParseWatts(t *testing.T) {
+	raw := json.RawMessage(`{
+		"2026-02-23T08:45:00+01:00": 220,
+		"2026-02-23T09:00:00+01:00": 358,
+		"2026-02-23T09:15:00+01:00": 492,
+		"2026-02-23T08:30:00+01:00": 114
+	}`)
+
+	rates, err := parseWatts(raw)
+	require.NoError(t, err)
+	require.Len(t, rates, 4)
+
+	assert.True(t, rates[0].Start.Before(rates[1].Start)) // sorted
+	assert.Equal(t, float64(114), rates[0].Value)         // 08:30 first
+	assert.Equal(t, rates[0].End, rates[1].Start)         // contiguous
+	assert.Equal(t, rates[3].Start.Add(SlotDuration), rates[3].End)
+}
+
+func TestHATariffWatts(t *testing.T) {
+	raw := json.RawMessage(`{
+		"2026-02-23T13:00:00+01:00": 789,
+		"2026-02-23T13:15:00+01:00": 1005,
+		"2026-02-23T13:30:00+01:00": 1046
+	}`)
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.energy_production_today": {"watts": json.RawMessage(raw)},
+		},
+	}
+	tar := newTestTariff(t, source,
+		[]string{"sensor.energy_production_today"},
+		[]string{"watts"}, "watts")
+
+	result, err := tar.Rates()
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+	assert.Equal(t, float64(789), result[0].Value)
+}
+
+// --- Solcast ---
+
+func TestParseSolcast(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"period_start":"2026-02-23T08:00:00+00:00","pv_estimate":0.5,"pv_estimate10":0.3,"pv_estimate90":0.7},
+		{"period_start":"2026-02-23T08:30:00+00:00","pv_estimate":1.2,"pv_estimate10":0.9,"pv_estimate90":1.5},
+		{"period_start":"2026-02-23T09:00:00+00:00","pv_estimate":2.0,"pv_estimate10":1.5,"pv_estimate90":2.5}
+	]`)
+
+	rates, err := parseSolcast(raw)
+	require.NoError(t, err)
+	require.Len(t, rates, 3)
+
+	assert.InDelta(t, 500.0, rates[0].Value, 1e-6) // 0.5 kW → 500 W
+	assert.InDelta(t, 1200.0, rates[1].Value, 1e-6)
+	assert.Equal(t, 30*time.Minute, rates[0].End.Sub(rates[0].Start))
+	assert.Equal(t, rates[0].End, rates[1].Start)
+}
+
+func TestHATariffSolcast(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"period_start":"2026-02-23T08:00:00+00:00","pv_estimate":1.5},
+		{"period_start":"2026-02-23T08:30:00+00:00","pv_estimate":2.3}
+	]`)
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.solcast_pv_forecast": {"detailedForecast": json.RawMessage(raw)},
+		},
+	}
+	tar := newTestTariff(t, source,
+		[]string{"sensor.solcast_pv_forecast"},
+		[]string{"detailedForecast"}, "solcast")
+
+	result, err := tar.Rates()
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.InDelta(t, 1500.0, result[0].Value, 1e-6)
+}
+
+// --- config validation ---
+
+func TestHATariffMissingURI(t *testing.T) {
+	_, err := NewHATariffFromConfig(map[string]any{"entities": []string{"sensor.price"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uri")
+}
+
+func TestHATariffMissingEntities(t *testing.T) {
+	_, err := NewHATariffFromConfig(map[string]any{"uri": "http://ha.local:8123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entities")
+}
+
+func TestHATariffEntitiesListDecoding(t *testing.T) {
+	emb := &embed{}
+	require.NoError(t, emb.init())
+
+	now := time.Now().Truncate(time.Hour)
+	raw, _ := json.Marshal(map[string]float64{now.Format(time.RFC3339): 500})
+
+	source := &mockHASource{
+		attributes: map[string]map[string]any{
+			"sensor.solar_today": {"watts": json.RawMessage(raw)},
+			"sensor.solar_d1":    {"watts": json.RawMessage(raw)},
+		},
+	}
+
+	tar, err := newHATariff(emb, util.NewLogger("test"), source,
+		"http://ha.local:8123",
+		[]string{"sensor.solar_today", "sensor.solar_d1"},
+		[]string{"watts"}, "watts",
+		0, time.Hour, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sensor.solar_today", "sensor.solar_d1"}, tar.(*HATariff).entities)
+}

--- a/tariff/homeassistant_test.go
+++ b/tariff/homeassistant_test.go
@@ -231,7 +231,7 @@ func TestHATariffZonneplan(t *testing.T) {
 
 	source := &mockHASource{
 		attributes: map[string]map[string]any{
-			"sensor.zonneplan_current_electricity_tariff": {"forecast": json.RawMessage(raw)},
+			"sensor.zonneplan_current_electricity_tariff": {"forecast": raw},
 		},
 	}
 	tar := newTestTariff(t, source,
@@ -291,7 +291,7 @@ func TestHATariffWatts(t *testing.T) {
 
 	source := &mockHASource{
 		attributes: map[string]map[string]any{
-			"sensor.energy_production_today": {"watts": json.RawMessage(raw)},
+			"sensor.energy_production_today": {"watts": raw},
 		},
 	}
 	tar := newTestTariff(t, source,
@@ -331,7 +331,7 @@ func TestHATariffSolcast(t *testing.T) {
 
 	source := &mockHASource{
 		attributes: map[string]map[string]any{
-			"sensor.solcast_pv_forecast": {"detailedForecast": json.RawMessage(raw)},
+			"sensor.solcast_pv_forecast": {"detailedForecast": raw},
 		},
 	}
 	tar := newTestTariff(t, source,


### PR DESCRIPTION
The current tariff/solar forecast config in EVCC queries API's directly, sometimes requiring an API key / extra config. 

Since people may already have this information available in HA it makes more sense to retrieve this information straight from HA instead of querying the API. 
This also prevents hitting the external API's with unnecessary requests (which may, depending on the API, eat up the API usage quota).

This PR adds support for retrieving the state information from HA from various integrations. It uses the globally configured authentication token to authenticate.

## Config examples - Grid

### Flat price (repeated for 48h)

Can be used for static energy price (e.g. for non-dynamic energy contracts).

```yaml
tariffs:
  grid:
    type: homeassistant
    uri: http://homeassistant.local:8123
    entities:
      - sensor.electricity_price   # state must be a numeric price (€/kWh)
```

### Nordpool

Retrieves from the [Custom Nordpool component](https://github.com/custom-components/nordpool)

```yaml
tariffs:
  grid:
    type: homeassistant
    uri: http://homeassistant.local:8123
    entities:
      - sensor.nordpool
    attributes:
      - raw_today
      - raw_tomorrow
```

### Zonneplan

Retrieves from the [Custom Zonneplan-One component](https://github.com/fsaris/home-assistant-zonneplan-one).

```yaml
tariffs:
   grid:
      type: homeassistant
      uri: http://homeassistant.local:8123
      entities:
        - sensor.zonneplan_current_electricity_tariff
      attributes:
        - forecast
      format: zonneplan
```

### ENTSO-E

Retrieves from the [Custom ENTSO-E component](https://github.com/JaccoR/hass-entso-e).

```yaml
tariffs:
   grid:
      type: homeassistant
      uri: http://homeassistant.local:8123
      entities:
        - sensor.entsoe_average_electricity_price_today
      attributes:
        - prices_today
        - prices_tomorrow
      format: entsoe
```

## Config examples - Solar

### Open-Meteo

Retrieves from the [custom Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast)

```yaml
tariffs:
  solar:
    - type: homeassistant
      uri: http://homeassistant.local:8123
      entities:
        - sensor.energy_production_today
        - sensor.energy_production_d1
        - sensor.energy_production_d2
        - sensor.energy_production_d3
      attributes:
        - watts
      format: watts
```

### Solcast

Retrieves from the [custom HA Solcast PV Solar Forecast Integration](https://github.com/BJReplay/ha-solcast-solar)

```yaml
tariffs:
  solar:
    - type: homeassistant
      uri: http://homeassistant.local:8123
      entities:
        - sensor.solcast_pv_forecast
      attributes:
        - detailedForecast
      format: solcast
```

## Related

Also created a PR for adding a Home Assistant notification plugin: https://github.com/evcc-io/evcc/pull/27641