### PR TITLE
Add Mennekes Amtron 4You/4Business (OCPP)

### DIFF
--- a/templates/definition/charger/ocpp-mennekes-4business.yaml
+++ b/templates/definition/charger/ocpp-mennekes-4business.yaml
@@ -1,0 +1,12 @@
+template: ocpp-mennekes-business
+products:
+  - brand: Mennekes
+    description:
+      generic: Amtron 4Business
+capabilities: ["rfid"]
+  evcc: ["sponsorship", "skiptest"]
+params:
+  - preset: ocpp
+render: |
+  {{ include "ocpp" . }}
+  connecttimeout: 15m

--- a/templates/definition/charger/ocpp-mennekes-4business.yaml
+++ b/templates/definition/charger/ocpp-mennekes-4business.yaml
@@ -3,6 +3,9 @@ products:
   - brand: Mennekes
     description:
       generic: Amtron 4Business
+  - brand: Mennekes
+    description:
+      generic: Amtron 4You
 capabilities: ["rfid"]
   evcc: ["sponsorship", "skiptest"]
 params:

--- a/templates/definition/charger/ocpp-mennekes-4you.yaml
+++ b/templates/definition/charger/ocpp-mennekes-4you.yaml
@@ -7,6 +7,7 @@ products:
     description:
       generic: Amtron 4You
 capabilities: ["rfid"]
+requirements:
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp-mennekes-4you.yaml
+++ b/templates/definition/charger/ocpp-mennekes-4you.yaml
@@ -1,4 +1,4 @@
-template: ocpp-mennekes-business
+template: ocpp-mennekes-4you
 products:
   - brand: Mennekes
     description:


### PR DESCRIPTION
Adds a dedicated OCPP charger template for Mennekes AMTRON 4You / 4Business devices to improve compatibility (Fixes #26837), including a longer initial connection wait time during startup.

**Changes:**
- Introduces a new `ocpp-mennekes-4you` charger template covering AMTRON 4Business and AMTRON 4You.
- Enables RFID capability for this template.
- Sets a longer `connecttimeout` (15m) for these devices.