### PR TITLE
SolarEdge: avoid sporadic "power is negative" warning

### DIFF
--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -90,18 +90,22 @@ render: |
   {{- if eq .usage "pv" }}
   power:
     source: calc
-    add:
-      - source: sunspec
-        {{- include "modbus" . | indent 6 }}
-        value:
-          - 101:DCW
-          - 103:DCW
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 62836 # Battery 1 Instantaneous Power
-          type: holding
-          decode: float32nans
+    max:
+      - source: const
+        value: 0
+      - source: calc
+        add:
+          - source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value:
+              - 101:DCW
+              - 103:DCW
+          - source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 0xE174 # Battery 1 Instantaneous Power
+              type: holding
+              decode: float32nans
   energy:
     source: sunspec
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
* avoid sporadic "power is negative - check configuration if sign is correct" warning
* consistent use of "Battery 1 Instantaneous Power" register 0xE174 instead of mirrored register 62836 (0xF574)