### PR TITLE
CSV export price with four decimal digits

### DIFF
--- a/util/csv/writer.go
+++ b/util/csv/writer.go
@@ -78,7 +78,7 @@ func writeRow(ww *csv.Writer, mp *message.Printer, structVal any) error {
 			continue
 		}
 
-		digits := 3
+		digits := 4
 		if format := f.Tag("format"); format == "int" {
 			digits = 0
 		}


### PR DESCRIPTION
Currently, price values exported to CSV files are limited to three decimal digits. This may not reflect the true price from the tariffs. Also, price/kWh values are sometimes rounded downwards and upwards incorrectly (i.e. if the tariff is 0.3005, it is exported as both 0.3 and 0.301).

This PR modifies the CSV writer to export up to four decimal digits.