### PR TITLE
OCPP: fix meterInterval watchdog timing

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -195,7 +195,7 @@ func NewOCPP(ctx context.Context,
 	}
 
 	if cp.HasRemoteTriggerFeature {
-		go conn.WatchDog(ctx, 10*time.Second)
+		go conn.WatchDog(ctx, meterInterval)
 	}
 
 	return c, conn.Initialized()


### PR DESCRIPTION
Update the watchdog timing to use the configurable `meterInterval` instead of a hardcoded 10s value.

Fixes #27686