### PR TITLE
Fronius Solar API: fix battery mode for firmware >= 1.38

### DIFF
--- a/plugin/http_auth.go
+++ b/plugin/http_auth.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"strings"
@@ -12,6 +13,11 @@ import (
 	"github.com/jpfielding/go-http-digest/pkg/digest"
 	"golang.org/x/oauth2"
 )
+
+func init() {
+	// some servers send SHA256 instead of the RFC 7616 compliant SHA-256
+	digest.Algs["SHA256"] = sha256.New
+}
 
 // Auth is the authorization config
 type Auth struct {


### PR DESCRIPTION
fixes #27669

Fronius firmware >= 1.38 switched HTTP Digest authentication from MD5 to SHA-256 and sends `algorithm=SHA256` (without dash) in the `X-WWW-Authenticate` challenge, which deviates from RFC 7616.

The digest library only recognizes `SHA-256` (with dash), causing `alg not implemented` when setting battery mode (e.g. prevent discharging).

Fix: register `SHA256` as alias in `digest.Algs`.
