### PR TITLE
Tinkerforge: Fix websocket not using Digest Auth

### DIFF
--- a/charger/warp/types.go
+++ b/charger/warp/types.go
@@ -1,5 +1,7 @@
 package warp
 
+import "github.com/evcc-io/evcc/util/request"
+
 const (
 	FeatureMeter          = "meter"
 	FeatureMeters         = "meters"
@@ -8,6 +10,22 @@ const (
 	FeatureNfc            = "nfc"
 	FeaturePhaseSwitch    = "phase_switch"
 )
+
+type Connection struct {
+	*Endpoint           // Default Endpoint
+	Pm        *Endpoint // Points to default endpoint or to the Energy Manager Endpoint
+}
+
+type Endpoint struct {
+	Helper *request.Helper
+	URI    string
+	Auth   *Auth
+}
+
+type Auth struct {
+	User     string
+	Password string
+}
 
 // https://www.warp-charger.com/api.html#evse_state
 type EvseState struct {

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/hashicorp/go-version v1.8.0
 	github.com/hasura/go-graphql-client v0.15.1
 	github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83
+	github.com/icholy/digest v1.1.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/insomniacslk/tapo v1.0.2
 	github.com/itchyny/gojq v0.12.18

--- a/go.sum
+++ b/go.sum
@@ -399,6 +399,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
+github.com/icholy/digest v1.1.0 h1:HfGg9Irj7i+IX1o1QAmPfIBNu/Q5A5Tu3n/MED9k9H4=
+github.com/icholy/digest v1.1.0/go.mod h1:QNrsSGQ5v7v9cReDI0+eyjsXGUoRSUZQHeQ5C4XLa0Y=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -1066,6 +1068,8 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/gorm v1.31.1 h1:7CA8FTFz/gRfgqgpeKIBcervUn3xSyPUmr6B2WXJ7kg=
 gorm.io/gorm v1.31.1/go.mod h1:XyQVbO2k6YkOis7C2437jSit3SsDK72s7n7rsSHd+Gs=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
# Description
This PR refactors the WARP WebSocket charger integration to introduce a structured connection model and improve authentication handling. It fixes #27664.

# Key Improvements

Introduces warp.Connection and warp.Endpoint types for cleaner separation of charger and Energy Manager endpoints.
Adds support for independent Energy Manager URI and credentials.
Replaces the old digest auth library with github.com/icholy/digest and adds proper WebSocket Digest authentication.
Consolidates HTTP/WS requests through endpoint‑specific helpers, removing URI duplication.
Simplifies and hardens phase‑switching logic, including automatic fallback to the default endpoint.
Improves WebSocket connection handling with explicit retry backoff and clearer logging.