### PR TITLE
Prioritizer: don't redistribute power from loadpoints with active plan

### DIFF
--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -654,7 +654,7 @@ func (lp *Loadpoint) GetChargePower() float64 {
 func (lp *Loadpoint) GetChargePowerFlexibility(rates api.Rates) float64 {
 	mode := lp.GetMode()
 	if mode == api.ModeNow || !lp.charging() || lp.minSocNotReached() ||
-		lp.smartLimitActive(lp.GetSmartCostLimit(), rates, true) {
+		lp.planActive || lp.smartLimitActive(lp.GetSmartCostLimit(), rates, true) {
 		return 0
 	}
 


### PR DESCRIPTION
A loadpoint in PV mode with an active plan slot reported its charge power as flexible, allowing higher-priority loadpoints to claim it. Since the plan commits that power regardless of priority, treat planActive the same as ModeNow in GetChargePowerFlexibility — return 0, not flexible.

Including tests for the prioritizer.

fixes #27739