### PR TITLE
fox-ess-h3-smart: fix grid charging and discharge lock behavior

### DIFF
--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -102,18 +102,194 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 37612 # Soc
+      address: 37612 # BatSoC
       type: holding
       decode: int16
-  limitsoc:
-    source: convert
-    convert: float2int
-    set:
-      source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 46611 # Minimum SoC OnGrid
-        type: writesingle
-        decode: uint16
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal — Self Use, restore default SoC limits
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48010 # Group 1 Disable
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48000 # Time Period Disable
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: {{ .maxsoc }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 46620 # MaxSoC FromGrid (V1.24+, must be written before 46611)
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 500
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 46608 # Battery max discharge current = 50A (restore)
+              type: writesingle
+              decode: uint16
+    - case: 2 # hold — Battery Lock (prevent discharge)
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48010 # Group 1 Disable
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48000 # Time Period Disable
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 100
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 46620 # MaxSoC FromGrid = 100% (must be written before 46611)
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 46608 # Battery max discharge current = 0A (lock)
+              type: writesingle
+              decode: uint16
+    - case: 3 # charge — Force Charge via Time Period System
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48000 # Time Period Enable
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48010 # Group 1 Enable
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48011 # Start Time 00:00
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 5947
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48012 # End Time 23:59 (0x173B)
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 6
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48013 # Work Mode = Force Charge
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: {{ add (mul .maxsoc 256) .minsoc }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48014 # (maxsoc<<8)|minsoc
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: {{ .maxsoc }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48015 # FDSOC = maxsoc
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: {{ .maxchargepower }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48016 # FDPWR — charge power in watts
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48017 # Reserve
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48018 # Reserve
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 48019 # Enable Flag (undocumented, required!)
+              type: writesingle
+              decode: uint16
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/27614

Summary

Fix two issues in the fox-ess-h3-smart template related to grid charging and discharge prevention.

Issue 1 – Grid charging limited to ~400W

Setting batterymode: charge resulted in ~400W maintenance charging instead of full power.
The previous implementation relied on MinSoC/MaxSoC manipulation, which does not trigger actual Force Charge on FoxESS H3 Smart inverters.

Change:
	•	Implement Force Charge using Time Period System (registers 48000–48019)
	•	Introduce configurable maxchargepower
	•	Do not define limitsoc, since meter.go ignores batterymode if limitsoc is present

Issue 2 – Discharge prevention ineffective

The option “Verhindere Entladung im Schnell-Modus und bei geplantem Laden” had no actual effect.

Change:
	•	Set max discharge current (register 46608) to 0A in hold mode
	•	Restore to 50A in normal mode
	•	Approach aligned with Sungrow template implementation

Firmware notes (tested on V1.24)
	•	46610 (MaxSoC) locked → use 46620 (MaxSoC FromGrid)
	•	49203 blocks Force Charge → use Time Period Work Mode (48013)
	•	48019 must be set to 1 for Force Charge
	•	46611 unstable with FC 0x10 sequences → use 46608 instead

Compatibility

Tested on:
	•	FoxESS H3-12.0-Smart
	•	Firmware V1.24
	•	Modbus TCP
	•	evcc 0.301.1

No breaking changes expected for existing configs.