### PR TITLE
refactor(warp-ws): replace helper/URI fields with Connection struct and consolidate digest auth

### DIFF
--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -98,14 +98,10 @@ func NewWarpWSFromConfig(ctx context.Context, other map[string]any) (api.Charger
 	}
 
 	// Feature: Phase Switching
-	if w.hasFeature(warp.FeaturePhaseSwitch) && w.pm == nil {
-		w.pm = w.Connection // Energy Manager not needed, charger will do the phase switching
-	}
-
 	// only setup phase switching methods if power manager endpoint is set
 	var phases func(int) error
 	var getPhases func() (int, error)
-	if w.pm != nil {
+	if w.hasFeature(warp.FeaturePhaseSwitch) && w.pm != nil {
 		if res, err := w.ensurePmState(); err == nil && res.ExternalControl != warp.ExternalControlDeactivated {
 			w.pmState = res
 			phases = w.phases1p3p
@@ -141,6 +137,8 @@ func NewWarpWS(ctx context.Context, uri, user, pass, emURI, emUser, emPass strin
 
 	if emURI != "" {
 		w.pm = warp.NewConnection(log, emURI, emUser, emPass)
+	} else {
+		w.pm = w.Connection
 	}
 
 	wsURI, err := parseURI(w.URI)
@@ -479,13 +477,10 @@ func (w *WarpWS) phases1p3p(phases int) error {
 	if ec, err := w.ensurePmState(); err != nil || ec.ExternalControl > warp.ExternalControlAvailable {
 		return fmt.Errorf("external control not available: %d", ec.ExternalControl)
 	}
-	w.mu.RLock()
-	em := w.pm
-	w.mu.RUnlock()
 
-	uri := fmt.Sprintf("%s/power_manager/external_control", em.URI)
+	uri := fmt.Sprintf("%s/power_manager/external_control", w.pm.URI)
 	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(map[string]int{"phases_wanted": phases}), request.JSONEncoding)
-	_, err := em.Do(req)
+	_, err := w.pm.Do(req)
 	return err
 }
 
@@ -505,20 +500,15 @@ func (w *WarpWS) getPhases() (int, error) {
 func (w *WarpWS) ensurePmLowLevelState() (warp.PmLowLevelState, error) {
 	w.mu.RLock()
 	s := w.pmLowLevelState
-	em := w.pm
 	w.mu.RUnlock()
-	if em == nil {
+	if w.pm == nil {
 		return s, nil
 	}
 
 	var ns warp.PmLowLevelState
-	if err := em.GetJSON(fmt.Sprintf("%s/power_manager/low_level_state", em.URI), &ns); err != nil {
+	if err := w.pm.GetJSON(fmt.Sprintf("%s/power_manager/low_level_state", w.pm.URI), &ns); err != nil {
 		return warp.PmLowLevelState{}, err
 	}
-
-	w.mu.Lock()
-	w.pmLowLevelState = ns
-	w.mu.Unlock()
 
 	return ns, nil
 }
@@ -536,12 +526,6 @@ func (w *WarpWS) ensurePmState() (warp.PmState, error) {
 	if err := w.pm.GetJSON(fmt.Sprintf("%s/power_manager/state", w.pm.URI), &res); err != nil {
 		return warp.PmState{}, err
 	}
-
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	// TODO why assign and return?
-	w.pmState = res
 
 	return res, nil
 }

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -47,8 +47,8 @@ type WarpWS struct {
 	chargeTracker warp.ChargeTrackerCurrentCharge
 
 	// power manager
-	pmState         warp.PmState
-	pmLowLevelState warp.PmLowLevelState
+	pmState         *warp.PmState
+	pmLowLevelState *warp.PmLowLevelState
 }
 
 func init() {
@@ -103,7 +103,7 @@ func NewWarpWSFromConfig(ctx context.Context, other map[string]any) (api.Charger
 	var getPhases func() (int, error)
 	if w.hasFeature(warp.FeaturePhaseSwitch) && w.pm != nil {
 		if res, err := w.ensurePmState(); err == nil && res.ExternalControl != warp.ExternalControlDeactivated {
-			w.pmState = res
+			w.pmState = &res
 			phases = w.phases1p3p
 			getPhases = w.getPhases
 		}
@@ -458,6 +458,7 @@ func (w *WarpWS) disablePhaseAutoSwitch() error {
 
 // phases1p3p implements the api.PhaseSwitcher interface
 func (w *WarpWS) phases1p3p(phases int) error {
+	// ensure that phases can be switched
 	if ec, err := w.ensurePmState(); err != nil || ec.ExternalControl > warp.ExternalControlAvailable {
 		return fmt.Errorf("external control not available: %d", ec.ExternalControl)
 	}
@@ -485,8 +486,8 @@ func (w *WarpWS) ensurePmLowLevelState() (warp.PmLowLevelState, error) {
 	w.mu.RLock()
 	s := w.pmLowLevelState
 	w.mu.RUnlock()
-	if w.pm == nil {
-		return s, nil
+	if s != nil {
+		return *s, nil
 	}
 
 	var ns warp.PmLowLevelState
@@ -501,9 +502,8 @@ func (w *WarpWS) ensurePmState() (warp.PmState, error) {
 	w.mu.RLock()
 	s := w.pmState
 	w.mu.RUnlock()
-
-	if w.pm == nil || s.ExternalControl != warp.ExternalControlAvailable {
-		return s, nil
+	if s != nil {
+		return *s, nil
 	}
 
 	var res warp.PmState

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -360,9 +360,7 @@ func (w *WarpWS) hasFeature(feature string) bool {
 func (w *WarpWS) Enable(enable bool) error {
 	var curr int64
 	if enable {
-		w.mu.RLock()
 		curr = w.maxCurrent
-		w.mu.RUnlock()
 	}
 	return w.setCurrent(curr)
 }
@@ -385,9 +383,7 @@ func (w *WarpWS) MaxCurrentMillis(current float64) error {
 	curr := int64(current * 1e3)
 	err := w.setCurrent(curr)
 	if err == nil {
-		w.mu.Lock()
 		w.maxCurrent = curr
-		w.mu.Unlock()
 	}
 	return err
 }

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -24,7 +24,7 @@ import (
 
 type WarpWS struct {
 	*warp.Connection
-	PM *warp.Connection // separate Energy Manager
+	pm *warp.Connection // separate Energy Manager
 
 	// config
 	log        *util.Logger
@@ -98,14 +98,14 @@ func NewWarpWSFromConfig(ctx context.Context, other map[string]any) (api.Charger
 	}
 
 	// Feature: Phase Switching
-	if wb.hasFeature(warp.FeaturePhaseSwitch) && wb.PM == nil {
-		wb.PM = wb.Connection // Energy Manager not needed, charger will do the phase switching
+	if wb.hasFeature(warp.FeaturePhaseSwitch) && wb.pm == nil {
+		wb.pm = wb.Connection // Energy Manager not needed, charger will do the phase switching
 	}
 
 	// only setup phase switching methods if power manager endpoint is set
 	var phases func(int) error
 	var getPhases func() (int, error)
-	if wb.PM != nil {
+	if wb.pm != nil {
 		if res, err := wb.ensurePmState(); err == nil && res.ExternalControl != warp.ExternalControlDeactivated {
 			wb.pmState = res
 			phases = wb.phases1p3p
@@ -119,7 +119,7 @@ func NewWarpWSFromConfig(ctx context.Context, other map[string]any) (api.Charger
 	if err != nil {
 		return nil, err
 	}
-	if typ == "warp3" || (typ == "warp2" && wb.PM != nil && wb.PM != wb.Connection) {
+	if typ == "warp3" || (typ == "warp2" && wb.pm != nil && wb.pm != wb.Connection) {
 		if err := wb.disablePhaseAutoSwitch(); err != nil {
 			return nil, err
 		}
@@ -140,7 +140,7 @@ func NewWarpWS(ctx context.Context, uri, user, pass, emURI, emUser, emPass strin
 
 	w := &WarpWS{
 		Connection: c,
-		PM:         pm,
+		pm:         pm,
 		log:        log,
 		meterIndex: meterIndex,
 		meterMap:   map[int]int{},
@@ -483,7 +483,7 @@ func (w *WarpWS) phases1p3p(phases int) error {
 		return fmt.Errorf("external control not available: %d", ec.ExternalControl)
 	}
 	w.mu.RLock()
-	em := w.PM
+	em := w.pm
 	w.mu.RUnlock()
 
 	uri := fmt.Sprintf("%s/power_manager/external_control", em.URI)
@@ -508,7 +508,7 @@ func (w *WarpWS) getPhases() (int, error) {
 func (w *WarpWS) ensurePmLowLevelState() (warp.PmLowLevelState, error) {
 	w.mu.RLock()
 	s := w.pmLowLevelState
-	em := w.PM
+	em := w.pm
 	w.mu.RUnlock()
 	if em == nil {
 		return s, nil
@@ -529,7 +529,7 @@ func (w *WarpWS) ensurePmLowLevelState() (warp.PmLowLevelState, error) {
 func (w *WarpWS) ensurePmState() (warp.PmState, error) {
 	w.mu.RLock()
 	s := w.pmState
-	em := w.PM
+	em := w.pm
 	w.mu.RUnlock()
 
 	if em == nil || s.ExternalControl != warp.ExternalControlAvailable {

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -24,7 +24,7 @@ import (
 
 type WarpWS struct {
 	*warp.Connection
-	PM *warp.Connection
+	PM *warp.Connection // separate Energy Manager
 
 	// config
 	log        *util.Logger
@@ -485,11 +485,6 @@ func (w *WarpWS) phases1p3p(phases int) error {
 	w.mu.RLock()
 	em := w.PM
 	w.mu.RUnlock()
-
-	// Should point to warp connection or energy manager connection
-	if em == nil {
-		return fmt.Errorf("Power Manager endpoint shouldn't be nil")
-	}
 
 	uri := fmt.Sprintf("%s/power_manager/external_control", em.URI)
 	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(map[string]int{"phases_wanted": phases}), request.JSONEncoding)

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -72,58 +72,58 @@ func NewWarpWSFromConfig(ctx context.Context, other map[string]any) (api.Charger
 		return nil, err
 	}
 
-	wb, err := NewWarpWS(ctx, cc.URI, cc.User, cc.Password, cc.EnergyManagerURI, cc.EnergyManagerUser, cc.EnergyManagerPassword, cc.EnergyMeterIndex)
+	w, err := NewWarpWS(ctx, cc.URI, cc.User, cc.Password, cc.EnergyManagerURI, cc.EnergyManagerUser, cc.EnergyManagerPassword, cc.EnergyMeterIndex)
 	if err != nil {
 		return nil, err
 	}
 
 	// Feature: Meter -> Meter is legacy API, Meters is the new API
 	var currentPower, totalEnergy func() (float64, error)
-	if wb.hasFeature(warp.FeatureMeter) || wb.hasFeature(warp.FeatureMeters) {
-		currentPower = wb.currentPower
-		totalEnergy = wb.totalEnergy
+	if w.hasFeature(warp.FeatureMeter) || w.hasFeature(warp.FeatureMeters) {
+		currentPower = w.currentPower
+		totalEnergy = w.totalEnergy
 	}
 
 	// Feature: Meters | MeterAllValues
 	var currents, voltages func() (float64, float64, float64, error)
-	if wb.hasFeature(warp.FeatureMeters) || wb.hasFeature(warp.FeatureMeterAllValues) {
-		currents = wb.currents
-		voltages = wb.voltages
+	if w.hasFeature(warp.FeatureMeters) || w.hasFeature(warp.FeatureMeterAllValues) {
+		currents = w.currents
+		voltages = w.voltages
 	}
 
 	// Feature: NFC
 	var identify func() (string, error)
-	if wb.hasFeature(warp.FeatureNfc) {
-		identify = wb.identify
+	if w.hasFeature(warp.FeatureNfc) {
+		identify = w.identify
 	}
 
 	// Feature: Phase Switching
-	if wb.hasFeature(warp.FeaturePhaseSwitch) && wb.pm == nil {
-		wb.pm = wb.Connection // Energy Manager not needed, charger will do the phase switching
+	if w.hasFeature(warp.FeaturePhaseSwitch) && w.pm == nil {
+		w.pm = w.Connection // Energy Manager not needed, charger will do the phase switching
 	}
 
 	// only setup phase switching methods if power manager endpoint is set
 	var phases func(int) error
 	var getPhases func() (int, error)
-	if wb.pm != nil {
-		if res, err := wb.ensurePmState(); err == nil && res.ExternalControl != warp.ExternalControlDeactivated {
-			wb.pmState = res
-			phases = wb.phases1p3p
-			getPhases = wb.getPhases
+	if w.pm != nil {
+		if res, err := w.ensurePmState(); err == nil && res.ExternalControl != warp.ExternalControlDeactivated {
+			w.pmState = res
+			phases = w.phases1p3p
+			getPhases = w.getPhases
 		}
 	}
 
 	// Phase Auto Switching needs to be disabled for WARP3 and WARP2 + EM
 	// Necessary if charging 1p only vehicles
-	typ, err := wb.getWarpType()
+	typ, err := w.getWarpType()
 	if err != nil {
 		return nil, err
 	}
-	if typ == "warp3" || (typ == "warp2" && wb.pm != nil && wb.pm != wb.Connection) {
-		if err := wb.disablePhaseAutoSwitch(); err != nil {
+	if typ == "warp3" || (typ == "warp2" && w.pm != nil && w.pm != w.Connection) {
+		if err := w.disablePhaseAutoSwitch(); err != nil {
 			return nil, err
 		}
-		wb.log.TRACE.Println("disabled phase auto switching")
+		w.log.TRACE.Println("disabled phase auto switching")
 	}
 
 	return decorateWarpWS(wb, currentPower, totalEnergy, currents, voltages, identify, phases, getPhases), nil
@@ -132,18 +132,15 @@ func NewWarpWSFromConfig(ctx context.Context, other map[string]any) (api.Charger
 func NewWarpWS(ctx context.Context, uri, user, pass, emURI, emUser, emPass string, meterIndex uint) (*WarpWS, error) {
 	log := util.NewLogger("warp-ws")
 
-	c := warp.NewConnection(log, uri, user, pass)
-	var pm *warp.Connection
-	if emURI != "" {
-		pm = warp.NewConnection(log, emURI, emUser, emPass)
-	}
-
 	w := &WarpWS{
-		Connection: c,
-		pm:         pm,
+		Connection: warp.NewConnection(log, uri, user, pass),
 		log:        log,
 		meterIndex: meterIndex,
 		meterMap:   map[int]int{},
+	}
+
+	if emURI != "" {
+		w.pm = warp.NewConnection(log, emURI, emUser, emPass)
 	}
 
 	wsURI, err := parseURI(w.URI)
@@ -529,23 +526,24 @@ func (w *WarpWS) ensurePmLowLevelState() (warp.PmLowLevelState, error) {
 func (w *WarpWS) ensurePmState() (warp.PmState, error) {
 	w.mu.RLock()
 	s := w.pmState
-	em := w.pm
 	w.mu.RUnlock()
 
-	if em == nil || s.ExternalControl != warp.ExternalControlAvailable {
+	if w.pm == nil || s.ExternalControl != warp.ExternalControlAvailable {
 		return s, nil
 	}
 
-	var ns warp.PmState
-	if err := em.GetJSON(fmt.Sprintf("%s/power_manager/state", em.URI), &ns); err != nil {
+	var res warp.PmState
+	if err := w.pm.GetJSON(fmt.Sprintf("%s/power_manager/state", w.pm.URI), &res); err != nil {
 		return warp.PmState{}, err
 	}
 
 	w.mu.Lock()
-	w.pmState = ns
-	w.mu.Unlock()
+	defer w.mu.Unlock()
 
-	return ns, nil
+	// TODO why assign and return?
+	w.pmState = res
+
+	return res, nil
 }
 
 func (w *WarpWS) getWarpType() (string, error) {

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -135,6 +135,10 @@ func NewWarpWS(ctx context.Context, uri, user, pass, emURI, emUser, emPass strin
 		meterMap:   map[int]int{},
 	}
 
+	if err := w.GetJSON(fmt.Sprintf("%s/info/features", w.URI), &w.features); err != nil {
+		return nil, err
+	}
+
 	if emURI != "" {
 		w.pm = warp.NewConnection(log, emURI, emUser, emPass)
 	} else {
@@ -292,7 +296,7 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 	case "evse/state":
 		err = json.Unmarshal(payload, &w.evse.State)
 	case "meter/all_values":
-		if !slices.Contains(w.features, warp.FeatureMeterAllValues) || slices.Contains(w.features, warp.FeatureMeters) {
+		if !w.hasFeature(warp.FeatureMeterAllValues) || w.hasFeature(warp.FeatureMeters) {
 			return nil
 		}
 		err = json.Unmarshal(payload, &w.meter.TmpValues)
@@ -301,7 +305,7 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 			copy(w.meter.Currents[:], w.meter.TmpValues[3:6])
 		}
 	case "meter/values":
-		if !slices.Contains(w.features, warp.FeatureMeter) || slices.Contains(w.features, warp.FeatureMeters) {
+		if !w.hasFeature(warp.FeatureMeter) || w.hasFeature(warp.FeatureMeters) {
 			return nil
 		}
 		err = json.Unmarshal(payload, &w.meter)
@@ -350,23 +354,7 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 }
 
 func (w *WarpWS) hasFeature(feature string) bool {
-	w.mu.RLock()
-	if w.features != nil {
-		w.mu.RUnlock()
-		return slices.Contains(w.features, feature)
-	}
-	uri := fmt.Sprintf("%s/info/features", w.URI)
-	w.mu.RUnlock()
-
-	var f []string
-	if err := w.GetJSON(uri, &f); err == nil {
-		w.mu.Lock()
-		w.features = f
-		w.mu.Unlock()
-		return slices.Contains(f, feature)
-	}
-
-	return false
+	return slices.Contains(w.features, feature)
 }
 
 func (w *WarpWS) Enable(enable bool) error {

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -126,7 +126,7 @@ func NewWarpWSFromConfig(ctx context.Context, other map[string]any) (api.Charger
 		w.log.TRACE.Println("disabled phase auto switching")
 	}
 
-	return decorateWarpWS(wb, currentPower, totalEnergy, currents, voltages, identify, phases, getPhases), nil
+	return decorateWarpWS(w, currentPower, totalEnergy, currents, voltages, identify, phases, getPhases), nil
 }
 
 func NewWarpWS(ctx context.Context, uri, user, pass, emURI, emUser, emPass string, meterIndex uint) (*WarpWS, error) {

--- a/charger/warp/connection.go
+++ b/charger/warp/connection.go
@@ -1,0 +1,30 @@
+package warp
+
+import (
+	"strings"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/icholy/digest"
+)
+
+func NewConnection(log *util.Logger, uri, user, pass string) *Connection {
+	c := &Connection{
+		Helper:   request.NewHelper(log),
+		URI:      util.DefaultScheme(strings.TrimRight(uri, "/"), "http"),
+		Username: user,
+		Password: pass,
+	}
+	c.ApplyDigest()
+	return c
+}
+
+func (c *Connection) ApplyDigest() {
+	if c.Username != "" && c.Password != "" {
+		c.Client.Transport = &digest.Transport{
+			Username:  c.Username,
+			Password:  c.Password,
+			Transport: c.Client.Transport,
+		}
+	}
+}

--- a/charger/warp/connection.go
+++ b/charger/warp/connection.go
@@ -8,6 +8,13 @@ import (
 	"github.com/icholy/digest"
 )
 
+type Connection struct {
+	*request.Helper
+	URI      string
+	Username string
+	Password string
+}
+
 func NewConnection(log *util.Logger, uri, user, pass string) *Connection {
 	c := &Connection{
 		Helper:   request.NewHelper(log),
@@ -15,11 +22,7 @@ func NewConnection(log *util.Logger, uri, user, pass string) *Connection {
 		Username: user,
 		Password: pass,
 	}
-	c.ApplyDigest()
-	return c
-}
 
-func (c *Connection) ApplyDigest() {
 	if c.Username != "" && c.Password != "" {
 		c.Client.Transport = &digest.Transport{
 			Username:  c.Username,
@@ -27,4 +30,6 @@ func (c *Connection) ApplyDigest() {
 			Transport: c.Client.Transport,
 		}
 	}
+
+	return c
 }

--- a/charger/warp/types.go
+++ b/charger/warp/types.go
@@ -1,5 +1,7 @@
 package warp
 
+import "github.com/evcc-io/evcc/util/request"
+
 const (
 	FeatureMeter          = "meter"
 	FeatureMeters         = "meters"
@@ -8,6 +10,13 @@ const (
 	FeatureNfc            = "nfc"
 	FeaturePhaseSwitch    = "phase_switch"
 )
+
+type Connection struct {
+	*request.Helper
+	URI      string
+	Username string
+	Password string
+}
 
 // https://www.warp-charger.com/api.html#evse_state
 type EvseState struct {

--- a/charger/warp/types.go
+++ b/charger/warp/types.go
@@ -1,7 +1,5 @@
 package warp
 
-import "github.com/evcc-io/evcc/util/request"
-
 const (
 	FeatureMeter          = "meter"
 	FeatureMeters         = "meters"
@@ -10,13 +8,6 @@ const (
 	FeatureNfc            = "nfc"
 	FeaturePhaseSwitch    = "phase_switch"
 )
-
-type Connection struct {
-	*request.Helper
-	URI      string
-	Username string
-	Password string
-}
 
 // https://www.warp-charger.com/api.html#evse_state
 type EvseState struct {


### PR DESCRIPTION
Replaces scattered URI, helper, and credential handling with a unified Connection abstraction for both EVSE and optional Energy Manager endpoints. Centralizes Digest authentication to avoid duplicated transport setup and inconsistent client state. Removes aliasing between PM and EVSE helpers, fixes implicit fallback behavior, and ensures phase‑switching logic is based on actual PM availability. This reduces hidden coupling, eliminates several edge‑case bugs, and makes the WARP WebSocket backend easier to reason about and extend.
