### PR TITLE
fix enable timer

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1212,6 +1212,14 @@ func (lp *Loadpoint) resetPVTimer(typ ...string) {
 	lp.publishTimer(pvTimer, 0, timerInactive)
 }
 
+// pvTimerElapsed returns elapsed time since the pv enable/disable timer was started,
+// rounded to the nearest second. Rounding is required because poll cycles can land a
+// fraction of a second short of the configured delay, which would prevent the timer
+// from firing until the next full poll cycle.
+func (lp *Loadpoint) pvTimerElapsed() time.Duration {
+	return lp.clock.Since(lp.pvTimer).Round(time.Second)
+}
+
 // resetPhaseTimer resets the phase switch timer to disabled state
 func (lp *Loadpoint) resetPhaseTimer() {
 	if lp.phaseTimer.IsZero() {
@@ -1379,7 +1387,13 @@ func (lp *Loadpoint) publishTimer(name string, delay time.Duration, action strin
 		timer = lp.phaseTimer
 	}
 
-	remaining := max(delay-lp.clock.Since(timer), 0)
+	var since time.Duration
+	if name == pvTimer {
+		since = lp.pvTimerElapsed()
+	} else {
+		since = lp.clock.Since(timer).Round(time.Second)
+	}
+	remaining := max(delay-since, 0)
 
 	lp.publish(name+"Action", action)
 	lp.publish(name+"Remaining", remaining)
@@ -1387,7 +1401,7 @@ func (lp *Loadpoint) publishTimer(name string, delay time.Duration, action strin
 	if action == timerInactive {
 		lp.log.DEBUG.Printf("%s timer %s", name, action)
 	} else {
-		lp.log.DEBUG.Printf("%s %s in %v", name, action, remaining.Round(time.Second))
+		lp.log.DEBUG.Printf("%s %s in %v", name, action, remaining)
 	}
 }
 
@@ -1485,7 +1499,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 			lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
 
-			elapsed := lp.clock.Since(lp.pvTimer)
+			elapsed := lp.pvTimerElapsed()
 			if elapsed >= lp.GetDisableDelay() {
 				lp.log.DEBUG.Println("pv disable timer elapsed")
 
@@ -1497,7 +1511,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 			// suppress duplicate log message after timer started
 			if elapsed > time.Second {
-				lp.log.DEBUG.Printf("pv disable timer remaining: %v", (lp.GetDisableDelay() - elapsed).Round(time.Second))
+				lp.log.DEBUG.Printf("pv disable timer remaining: %v", lp.GetDisableDelay()-elapsed)
 			}
 		} else {
 			// reset timer
@@ -1521,7 +1535,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 			lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
 
-			elapsed := lp.clock.Since(lp.pvTimer)
+			elapsed := lp.pvTimerElapsed()
 			if elapsed >= lp.GetEnableDelay() {
 				lp.log.DEBUG.Println("pv enable timer elapsed")
 
@@ -1533,7 +1547,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 			// suppress duplicate log message after timer started
 			if elapsed > time.Second {
-				lp.log.DEBUG.Printf("pv enable timer remaining: %v", (lp.GetEnableDelay() - elapsed).Round(time.Second))
+				lp.log.DEBUG.Printf("pv enable timer remaining: %v", lp.GetEnableDelay()-elapsed)
 			}
 		} else {
 			// reset timer

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -191,6 +191,7 @@ func TestUpdatePowerZero(t *testing.T) {
 
 func TestPVHysteresis(t *testing.T) {
 	const dt = time.Minute
+	const ds = time.Second
 	const phases = 3
 	type se struct {
 		site    float64
@@ -205,98 +206,98 @@ func TestPVHysteresis(t *testing.T) {
 		// keep disabled
 		{false, 0, 0, []se{
 			{0, 0, 0},
-			{0, 1, 0},
-			{0, dt - 1, 0},
-			{0, dt + 1, 0},
+			{0, ds, 0},
+			{0, dt - ds, 0},
+			{0, dt + ds, 0},
 		}},
 		// enable when threshold not configured but min power met
 		{false, 0, 0, []se{
 			{-6 * 100 * phases, 0, 0},
-			{-6 * 100 * phases, 1, 0},
-			{-6 * 100 * phases, dt - 1, 0},
-			{-6 * 100 * phases, dt + 1, minA},
+			{-6 * 100 * phases, ds, 0},
+			{-6 * 100 * phases, dt - ds, 0},
+			{-6 * 100 * phases, dt + ds, minA},
 		}},
 		// keep disabled when threshold not configured
 		{false, 0, 0, []se{
 			{-400, 0, 0},
-			{-400, 1, 0},
-			{-400, dt - 1, 0},
-			{-400, dt + 1, 0},
+			{-400, ds, 0},
+			{-400, dt - ds, 0},
+			{-400, dt + ds, 0},
 		}},
 		// keep disabled when threshold (lower minCurrent) not met
 		{false, -500, 0, []se{
 			{-400, 0, 0},
-			{-400, 1, 0},
-			{-400, dt - 1, 0},
-			{-400, dt + 1, 0},
+			{-400, ds, 0},
+			{-400, dt - ds, 0},
+			{-400, dt + ds, 0},
 		}},
 		// keep disabled when threshold (higher minCurrent) not met
 		{false, -7 * 100 * phases, 0, []se{
 			{-6 * 100 * phases, 0, 0},
-			{-6 * 100 * phases, 1, 0},
-			{-6 * 100 * phases, dt - 1, 0},
-			{-6 * 100 * phases, dt + 1, 0},
+			{-6 * 100 * phases, ds, 0},
+			{-6 * 100 * phases, dt - ds, 0},
+			{-6 * 100 * phases, dt + ds, 0},
 		}},
 		// enable when threshold met
 		{false, -500, 0, []se{
 			{-500, 0, 0},
-			{-500, 1, 0},
-			{-500, dt - 1, 0},
-			{-500, dt + 1, minA},
+			{-500, ds, 0},
+			{-500, dt - ds, 0},
+			{-500, dt + ds, minA},
 		}},
 		// keep enabled at max
 		{true, 500, 0, []se{
 			{-16 * 100 * phases, 0, maxA},
-			{-16 * 100 * phases, 1, maxA},
-			{-16 * 100 * phases, dt - 1, maxA},
-			{-16 * 100 * phases, dt + 1, maxA},
+			{-16 * 100 * phases, ds, maxA},
+			{-16 * 100 * phases, dt - ds, maxA},
+			{-16 * 100 * phases, dt + ds, maxA},
 		}},
 		// keep enabled at min
 		{true, 500, 0, []se{
 			{-6 * 100 * phases, 0, minA},
-			{-6 * 100 * phases, 1, minA},
-			{-6 * 100 * phases, dt - 1, minA},
-			{-6 * 100 * phases, dt + 1, minA},
+			{-6 * 100 * phases, ds, minA},
+			{-6 * 100 * phases, dt - ds, minA},
+			{-6 * 100 * phases, dt + ds, minA},
 		}},
 		// keep enabled at min (negative threshold)
 		{true, 0, 500, []se{
 			{-500, 0, minA},
-			{-500, 1, minA},
-			{-500, dt - 1, minA},
-			{-500, dt + 1, minA},
+			{-500, ds, minA},
+			{-500, dt - ds, minA},
+			{-500, dt + ds, minA},
 		}},
 		// disable when threshold met
 		{true, 0, 500, []se{
 			{500, 0, minA},
-			{500, 1, minA},
-			{500, dt - 1, minA},
-			{500, dt + 1, 0},
+			{500, ds, minA},
+			{500, dt - ds, minA},
+			{500, dt + ds, 0},
 		}},
 		// reset enable timer when threshold not met while timer active
 		{false, -500, 0, []se{
 			{-500, 0, 0},
-			{-500, 1, 0},
-			{-499, dt - 1, 0}, // should reset timer
-			{-500, dt + 1, 0}, // new begin of timer
+			{-500, ds, 0},
+			{-499, dt - ds, 0}, // should reset timer
+			{-500, dt + ds, 0}, // new begin of timer
 			{-500, 2 * dt, 0},
-			{-500, 2*dt + 1, minA},
+			{-500, 2*dt + ds, minA},
 		}},
 		// reset enable timer when threshold not met while timer active and threshold not configured
 		{false, 0, 0, []se{
-			{-6*100*10 - 1, dt + 1, 0},
-			{-6 * 100 * phases, dt + 1, 0},
-			{-6 * 100 * phases, dt + 2, 0},
+			{-6*100*10 - 1, dt + ds, 0},
+			{-6 * 100 * phases, dt + ds, 0},
+			{-6 * 100 * phases, dt + 2*ds, 0},
 			{-6 * 100 * phases, 2 * dt, 0},
-			{-6 * 100 * phases, 2*dt + 1, minA},
+			{-6 * 100 * phases, 2*dt + ds, minA},
 		}},
 		// reset disable timer when threshold not met while timer active
 		{true, 0, 500, []se{
 			{500, 0, minA},
-			{500, 1, minA},
-			{499, dt - 1, minA}, // reset timer
-			{500, dt + 1, minA}, // within reset timer duration
-			{500, 2 * dt, minA}, // still within reset timer duration
-			{500, 2*dt + 1, 0},  // reset timer elapsed
+			{500, ds, minA},
+			{499, dt - ds, minA}, // reset timer
+			{500, dt + ds, minA}, // within reset timer duration
+			{500, 2 * dt, minA},  // still within reset timer duration
+			{500, 2*dt + ds, 0},  // reset timer elapsed
 		}},
 	}
 
@@ -699,6 +700,7 @@ func TestSocPoll(t *testing.T) {
 // test PV hysteresis after phase switch down, depending on remaining energy
 func TestPVHysteresisAfterPhaseSwitch(t *testing.T) {
 	const dt = time.Minute
+	const ds = time.Second
 	type se struct {
 		site    float64
 		delay   time.Duration // test case delay since start
@@ -710,16 +712,16 @@ func TestPVHysteresisAfterPhaseSwitch(t *testing.T) {
 		// immediately disable when threshold met after phase switch
 		{[]se{
 			{1200, 0, minA},
-			{1200, 1, minA},
-			{1200, dt - 1, minA},
-			{1200, dt + 1, 0},
+			{1200, ds, minA},
+			{1200, dt - ds, minA},
+			{1200, dt + ds, 0},
 		}},
 		// stay enabled when threshold not met after phase switch
 		{[]se{
 			{500, 0, minA},
-			{500, 1, minA},
-			{500, dt - 1, minA},
-			{500, dt + 1, minA},
+			{500, ds, minA},
+			{500, dt - ds, minA},
+			{500, dt + ds, minA},
 		}},
 	}
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -863,3 +863,85 @@ func TestWelcomeChargeAppliedOnlyOnce(t *testing.T) {
 	welcomeCharge, _ = lp.updateChargerStatus()
 	assert.False(t, welcomeCharge)
 }
+
+// TestPVTimerSubSecondJitter reproduces a real-world issue where the PV enable (or
+// disable) timer fails to fire despite showing "0s remaining" in the log.
+//
+// Scenario: a site with 5 loadpoints at 15s interval means each loadpoint's full
+// Update cycle runs every 75s (round-robin). With an enable delay of 150s, the timer
+// check lands at exactly 2×75s = 150s from clock start. But pvTimer was set with
+// sub-second precision (e.g. 400ms into the second), so elapsed = 149.6s < 150s.
+// The log rounds remaining (0.4s) to "0s" but the strict >= check fails, delaying
+// the enable by another full 75s cycle.
+func TestPVTimerSubSecondJitter(t *testing.T) {
+	const (
+		enableDelay     = 150 * time.Second // 2m30s
+		phases          = 3
+		numLoadpoints   = 5
+		siteInterval    = 15 * time.Second
+		lpUpdateCycle   = time.Duration(numLoadpoints) * siteInterval // 75s
+		subSecondOffset = 400 * time.Millisecond
+	)
+
+	tc := []struct {
+		name    string
+		enabled bool
+		site    float64
+	}{
+		{"enable", false, -float64(phases) * minA * 100},
+		{"disable", true, 500},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			clk := clock.NewMock()
+
+			Voltage = 100
+			lp := &Loadpoint{
+				log:            util.NewLogger("foo"),
+				clock:          clk,
+				minCurrent:     minA,
+				maxCurrent:     maxA,
+				phases:         phases,
+				measuredPhases: phases,
+				Enable: loadpoint.ThresholdConfig{
+					Delay:     enableDelay,
+					Threshold: -500,
+				},
+				Disable: loadpoint.ThresholdConfig{
+					Delay:     enableDelay,
+					Threshold: 500,
+				},
+			}
+			lp.status = api.StatusB
+			lp.enabled = tc.enabled
+
+			// Step 1: Simulate the clock being 400ms past the second when pvMaxCurrent
+			// first runs and starts the timer. This gives pvTimer sub-second precision.
+			clk.Add(subSecondOffset)
+			current := lp.pvMaxCurrent(api.ModePV, tc.site, 0, false, false)
+			assert.False(t, lp.pvTimer.IsZero(), "timer should have started")
+
+			if tc.enabled {
+				assert.Equal(t, minA, current, "should stay enabled while timer runs")
+			} else {
+				assert.Equal(t, 0.0, current, "should stay disabled while timer runs")
+			}
+
+			// Step 2: Advance to 2 × lpUpdateCycle = 150.0s from clock zero.
+			// pvTimer started at 0.4s, so elapsed = 149.6s.
+			// remaining = 150s - 149.6s = 0.4s → rounds to "0s" in the log.
+			// Without fix: 149.6s < 150s → timer does NOT fire.
+			// With fix (rounding elapsed): 149.6s.Round(1s) = 150s >= 150s → timer fires.
+			clk.Set(clk.Now().Add(2*lpUpdateCycle - subSecondOffset))
+
+			current = lp.pvMaxCurrent(api.ModePV, tc.site, 0, false, false)
+
+			if tc.enabled {
+				assert.Equal(t, 0.0, current, "disable: timer should have fired")
+			} else {
+				assert.Equal(t, minA, current, "enable: timer should have fired")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #27784

Each loadpoint only receives a full `Update()` call (including pvMaxCurrent) once every N × interval seconds via the round-robin in site `loopLoadpoints`. With 5 loadpoints at 15s interval, that is every 75s. In my situation that is exactly half of 2:30 configured enable delay. 

This means I can get the log to display "pv enable in 0s" but still not enabling the loadpoint when there is slight jitter in the timer processing, especially when the enable interval is a multiple of the site interval.

```
[lp-2 ] DEBUG 2026/02/27 13:14:57 pv enable in 0s
[lp-2 ] DEBUG 2026/02/27 13:14:57 pv enable timer remaining: 0s
[lp-2 ] DEBUG 2026/02/27 13:15:12 charge power: 0W
```

I have included a regression test `TestPVEnableTimerSubSecondBoundary` that demonstrates the failure and passes with the fix applied. I think the best fix is to use the same rounding to second-precision as the log statements to for the enable/disable decision, as this ensures logs are consistent with control behavior.

Unfortunately I had to adapt a few other test cases that relied on nanosecond deltas for setting up timing cases, but those changes should hopefully be easy to review (i just changed them to use whole second deltas).

- **test: reproduce PV timer sub-second jitter causing missed enable/disable**
- **fix: round pvTimer elapsed to second to prevent sub-second boundary miss**
- **fix: adapt existing timer test cases to use second-precision triggering**



