### PR TITLE
charger/easee: implement StatusReasoner interface

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -794,6 +794,21 @@ func (c *Easee) GetPhases() (int, error) {
 	return phases, nil
 }
 
+var _ api.StatusReasoner = (*Easee)(nil)
+
+// StatusReason implements the api.StatusReasoner interface
+func (c *Easee) StatusReason() (api.Reason, error) {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	switch c.opMode {
+	case easee.ModeAwaitingAuthentication:
+		return api.ReasonWaitingForAuthorization, nil
+	case easee.ModeCompleted:
+		return api.ReasonDisconnectRequired, nil
+	}
+	return api.ReasonUnknown, nil
+}
+
 var _ api.Identifier = (*Easee)(nil)
 
 // Currents implements the api.PhaseCurrents interface

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -323,7 +323,7 @@ func TestEasee_waitForDynamicChargerCurrent(t *testing.T) {
 }
 
 func TestEasee_StatusReason(t *testing.T) {
-	tc := []struct {
+	testcases := []struct {
 		opMode         int
 		expectedReason api.Reason
 	}{
@@ -335,7 +335,7 @@ func TestEasee_StatusReason(t *testing.T) {
 		{easee.ModeReadyToCharge, api.ReasonUnknown},
 		{easee.ModeDeauthenticating, api.ReasonUnknown},
 	}
-	for _, tc := range tc {
+	for _, tc := range testcases {
 		t.Logf("%+v", tc)
 
 		e := newEasee()

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -322,6 +322,31 @@ func TestEasee_waitForDynamicChargerCurrent(t *testing.T) {
 	}
 }
 
+func TestEasee_StatusReason(t *testing.T) {
+	tc := []struct {
+		opMode         int
+		expectedReason api.Reason
+	}{
+		{easee.ModeAwaitingAuthentication, api.ReasonWaitingForAuthorization},
+		{easee.ModeCompleted, api.ReasonDisconnectRequired},
+		{easee.ModeDisconnected, api.ReasonUnknown},
+		{easee.ModeAwaitingStart, api.ReasonUnknown},
+		{easee.ModeCharging, api.ReasonUnknown},
+		{easee.ModeReadyToCharge, api.ReasonUnknown},
+		{easee.ModeDeauthenticating, api.ReasonUnknown},
+	}
+	for _, tc := range tc {
+		t.Logf("%+v", tc)
+
+		e := newEasee()
+		e.opMode = tc.opMode
+
+		reason, err := e.StatusReason()
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expectedReason, reason)
+	}
+}
+
 func TestEasee_MaxCurrent(t *testing.T) {
 	testCases := []struct {
 		targetCurrent int64


### PR DESCRIPTION
## Summary

- Implements the `api.StatusReasoner` interface on the Easee charger, which was missing despite the Easee API already delivering the required information via `CHARGER_OP_MODE`
- `ModeAwaitingAuthentication` (opmode 7) → `ReasonWaitingForAuthorization` — evcc now correctly indicates when the charger is waiting for RFID/auth
- `ModeCompleted` (opmode 4) → `ReasonDisconnectRequired` — evcc now correctly indicates when a session has ended and the cable should be unplugged

## Test Plan

- [x] Unit tests added for `StatusReason()` covering all relevant op modes
- [x] All existing Easee tests still pass

Fixes #27788