### PR TITLE
battery: add SOC-targeted house battery control modes

### DIFF
--- a/api/batterymode.go
+++ b/api/batterymode.go
@@ -11,4 +11,5 @@ const (
 	BatteryCharge
 	BatteryNoCharge
 	BatteryChargeToSoc
+	BatteryHoldAtSoc
 )

--- a/api/batterymode.go
+++ b/api/batterymode.go
@@ -10,4 +10,5 @@ const (
 	BatteryHold
 	BatteryCharge
 	BatteryNoCharge
+	BatteryChargeToSoc
 )

--- a/api/batterymode.go
+++ b/api/batterymode.go
@@ -9,4 +9,5 @@ const (
 	BatteryNormal
 	BatteryHold
 	BatteryCharge
+	BatteryNoCharge
 )

--- a/api/batterymode_enumer.go
+++ b/api/batterymode_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _BatteryModeName = "unknownnormalholdcharge"
+const _BatteryModeName = "unknownnormalholdchargenocharge"
 
-var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23}
+var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23, 31}
 
-const _BatteryModeLowerName = "unknownnormalholdcharge"
+const _BatteryModeLowerName = "unknownnormalholdchargenocharge"
 
 func (i BatteryMode) String() string {
 	if i < 0 || i >= BatteryMode(len(_BatteryModeIndex)-1) {
@@ -28,9 +28,10 @@ func _BatteryModeNoOp() {
 	_ = x[BatteryNormal-(1)]
 	_ = x[BatteryHold-(2)]
 	_ = x[BatteryCharge-(3)]
+	_ = x[BatteryNoCharge-(4)]
 }
 
-var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge}
+var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge, BatteryNoCharge}
 
 var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeName[0:7]:        BatteryUnknown,
@@ -41,6 +42,8 @@ var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeLowerName[13:17]: BatteryHold,
 	_BatteryModeName[17:23]:      BatteryCharge,
 	_BatteryModeLowerName[17:23]: BatteryCharge,
+	_BatteryModeName[23:31]:      BatteryNoCharge,
+	_BatteryModeLowerName[23:31]: BatteryNoCharge,
 }
 
 var _BatteryModeNames = []string{
@@ -48,6 +51,7 @@ var _BatteryModeNames = []string{
 	_BatteryModeName[7:13],
 	_BatteryModeName[13:17],
 	_BatteryModeName[17:23],
+	_BatteryModeName[23:31],
 }
 
 // BatteryModeString retrieves an enum value from the enum constants string name.

--- a/api/batterymode_enumer.go
+++ b/api/batterymode_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _BatteryModeName = "unknownnormalholdchargenocharge"
+const _BatteryModeName = "unknownnormalholdchargenochargechargetosoc"
 
-var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23, 31}
+var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23, 31, 42}
 
-const _BatteryModeLowerName = "unknownnormalholdchargenocharge"
+const _BatteryModeLowerName = "unknownnormalholdchargenochargechargetosoc"
 
 func (i BatteryMode) String() string {
 	if i < 0 || i >= BatteryMode(len(_BatteryModeIndex)-1) {
@@ -29,9 +29,10 @@ func _BatteryModeNoOp() {
 	_ = x[BatteryHold-(2)]
 	_ = x[BatteryCharge-(3)]
 	_ = x[BatteryNoCharge-(4)]
+	_ = x[BatteryChargeToSoc-(5)]
 }
 
-var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge, BatteryNoCharge}
+var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge, BatteryNoCharge, BatteryChargeToSoc}
 
 var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeName[0:7]:        BatteryUnknown,
@@ -44,6 +45,8 @@ var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeLowerName[17:23]: BatteryCharge,
 	_BatteryModeName[23:31]:      BatteryNoCharge,
 	_BatteryModeLowerName[23:31]: BatteryNoCharge,
+	_BatteryModeName[31:42]:      BatteryChargeToSoc,
+	_BatteryModeLowerName[31:42]: BatteryChargeToSoc,
 }
 
 var _BatteryModeNames = []string{
@@ -52,6 +55,7 @@ var _BatteryModeNames = []string{
 	_BatteryModeName[13:17],
 	_BatteryModeName[17:23],
 	_BatteryModeName[23:31],
+	_BatteryModeName[31:42],
 }
 
 // BatteryModeString retrieves an enum value from the enum constants string name.

--- a/api/batterymode_enumer.go
+++ b/api/batterymode_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _BatteryModeName = "unknownnormalholdchargenochargechargetosoc"
+const _BatteryModeName = "unknownnormalholdchargenochargechargetosocholdatsoc"
 
-var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23, 31, 42}
+var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23, 31, 42, 51}
 
-const _BatteryModeLowerName = "unknownnormalholdchargenochargechargetosoc"
+const _BatteryModeLowerName = "unknownnormalholdchargenochargechargetosocholdatsoc"
 
 func (i BatteryMode) String() string {
 	if i < 0 || i >= BatteryMode(len(_BatteryModeIndex)-1) {
@@ -30,9 +30,10 @@ func _BatteryModeNoOp() {
 	_ = x[BatteryCharge-(3)]
 	_ = x[BatteryNoCharge-(4)]
 	_ = x[BatteryChargeToSoc-(5)]
+	_ = x[BatteryHoldAtSoc-(6)]
 }
 
-var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge, BatteryNoCharge, BatteryChargeToSoc}
+var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge, BatteryNoCharge, BatteryChargeToSoc, BatteryHoldAtSoc}
 
 var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeName[0:7]:        BatteryUnknown,
@@ -47,6 +48,8 @@ var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeLowerName[23:31]: BatteryNoCharge,
 	_BatteryModeName[31:42]:      BatteryChargeToSoc,
 	_BatteryModeLowerName[31:42]: BatteryChargeToSoc,
+	_BatteryModeName[42:51]:      BatteryHoldAtSoc,
+	_BatteryModeLowerName[42:51]: BatteryHoldAtSoc,
 }
 
 var _BatteryModeNames = []string{
@@ -56,6 +59,7 @@ var _BatteryModeNames = []string{
 	_BatteryModeName[17:23],
 	_BatteryModeName[23:31],
 	_BatteryModeName[31:42],
+	_BatteryModeName[42:51],
 }
 
 // BatteryModeString retrieves an enum value from the enum constants string name.

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -51,7 +51,8 @@ const (
 	BatteryMode = "batteryMode"
 
 	// external battery control
-	BatteryModeExternal = "batteryModeExternal"
+	BatteryModeExternal    = "batteryModeExternal"
+	BatteryModeExternalSoc = "batteryModeExternalSoc"
 
 	// smart charging
 	SmartCostAvailable           = "smartCostAvailable"           // smart cost available

--- a/core/site.go
+++ b/core/site.go
@@ -99,6 +99,7 @@ type Site struct {
 	battery                  types.BatteryState // Battery cached and published state
 	batteryMode              api.BatteryMode    // Battery mode (runtime only, not persisted)
 	batteryModeExternal      api.BatteryMode    // Battery mode (external, runtime only, not persisted)
+	batteryModeExternalSoc   float64            // Battery mode target SOC for ChargeToSoc (external, runtime only)
 	batteryModeExternalTimer time.Time          // Battery mode timer for external control
 }
 

--- a/core/site/api.go
+++ b/core/site/api.go
@@ -83,4 +83,8 @@ type API interface {
 	GetBatteryModeExternal() api.BatteryMode
 	// SetBatteryModeExternal sets the external battery mode
 	SetBatteryModeExternal(api.BatteryMode) error
+	// GetBatteryModeExternalSoc returns the target SOC for ChargeToSoc mode
+	GetBatteryModeExternalSoc() float64
+	// SetBatteryModeExternalSoc sets the external battery mode with a target SOC
+	SetBatteryModeExternalSoc(api.BatteryMode, float64) error
 }

--- a/meter/e3dc.go
+++ b/meter/e3dc.go
@@ -227,6 +227,11 @@ func (m *E3dc) setBatteryMode(mode api.BatteryMode) error {
 			e3dcDischargeBatteryLimit(false, 0),
 			e3dcBatteryCharge(50000), // max. 50kWh
 		}
+	case api.BatteryNoCharge:
+		messages = []rscp.Message{
+			e3dcDischargeBatteryLimit(false, 0),
+			e3dcBatteryCharge(0),
+		}
 	default:
 		return api.ErrNotAvailable
 	}

--- a/meter/usage_battery.go
+++ b/meter/usage_battery.go
@@ -68,6 +68,9 @@ func (m *batterySocLimits) LimitController(socG func() (float64, error), limitSo
 		case api.BatteryCharge:
 			return limitSocS(m.MaxSoc)
 
+		case api.BatteryNoCharge:
+			return limitSocS(m.MinSoc)
+
 		default:
 			return api.ErrNotAvailable
 		}

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -194,9 +194,37 @@ func updateBatteryMode(site site.API) http.HandlerFunc {
 			val = s
 		}
 
-		site.SetBatteryModeExternal(val)
+		// parse optional target soc for chargetosoc mode
+		var soc float64
+		if val == api.BatteryChargeToSoc {
+			socStr := r.URL.Query().Get("soc")
+			if socStr == "" {
+				jsonError(w, http.StatusBadRequest, errors.New("soc parameter required for chargetosoc mode"))
+				return
+			}
 
-		jsonWrite(w, site.GetBatteryModeExternal())
+			var err error
+			soc, err = strconv.ParseFloat(socStr, 64)
+			if err != nil || soc <= 0 || soc > 100 {
+				jsonError(w, http.StatusBadRequest, fmt.Errorf("invalid soc value: %s", socStr))
+				return
+			}
+		}
+
+		if err := site.SetBatteryModeExternalSoc(val, soc); err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		res := struct {
+			Mode api.BatteryMode `json:"mode"`
+			Soc  float64         `json:"soc,omitempty"`
+		}{
+			Mode: site.GetBatteryModeExternal(),
+			Soc:  site.GetBatteryModeExternalSoc(),
+		}
+
+		jsonWrite(w, res)
 	}
 }
 

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -194,12 +194,12 @@ func updateBatteryMode(site site.API) http.HandlerFunc {
 			val = s
 		}
 
-		// parse optional target soc for chargetosoc mode
+		// parse target soc required for chargetosoc/holdatsoc mode
 		var soc float64
-		if val == api.BatteryChargeToSoc {
+		if val == api.BatteryChargeToSoc || val == api.BatteryHoldAtSoc {
 			socStr := r.URL.Query().Get("soc")
 			if socStr == "" {
-				jsonError(w, http.StatusBadRequest, errors.New("soc parameter required for chargetosoc mode"))
+				jsonError(w, http.StatusBadRequest, errors.New("soc parameter required for chargetosoc/holdatsoc mode"))
 				return
 			}
 

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -248,5 +248,23 @@ render: |
             uri: {{ .host }}:{{ .port }}
             id: 1
             value: 124:0:OutWRte
+    - case: 4 # nocharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:StorCtl_Mod
+        - source: const
+          value: 0 # %
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:InWRte
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -110,6 +110,10 @@ render: |
           body: '{"timeofuse":[]}'
         - source: error
           error: ErrNotAvailable
+    - case: 4 # nocharge (not implemented)
+      set:
+        source: error
+        error: ErrNotAvailable
   {{- end }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -244,5 +244,23 @@ render: |
             uri: {{ .host }}:{{ .port }}
             id: 1
             value: 124:0:OutWRte
+    - case: 4 # nocharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:StorCtl_Mod
+        - source: const
+          value: 0 # %
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:InWRte
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sunspec-inverter-control.yaml
+++ b/templates/definition/meter/sunspec-inverter-control.yaml
@@ -104,5 +104,27 @@ render: |
             source: sunspec
             {{- include "modbus" . | indent 10 }}
             value: 124:0:InOutWRte_RvrtTms
+    - case: 4 # nocharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 124:0:StorCtl_Mod
+        - source: const
+          value: 0 # %
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 124:0:InWRte
+        - source: const
+          value: 0 # s
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 124:0:InOutWRte_RvrtTms
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
This PR introduces three new **house battery modes** that enable SOC-aware house battery management via the external battery control API. This PR is only about the house battery and does not affect the vehicle battery.

With these modes, you can implement a schedule like:

- **Sunrise:** allow charging up to **60% SOC**. This avoids reaching 100% early (e.g., by 9am) and then sitting at a high SOC for many hours, which can reduce battery health over time.
- **Midday:** allow **normal operation** (charge/use as usual). This lets the battery reach **100% SOC** closer to the evening when the capacity is more likely needed.
- **Sunset:** allow discharge down to **40% SOC**, then hold. This prevents the battery from being drained to the minimum SOC after an evening of high usage (e.g., cooking) and then sitting at a very low SOC overnight, which also benefits battery health.
- **Midnight:** return to **normal operation**, allowing discharge down to the configured minimum SOC (e.g., **7%** in my setup).

Longer term, I’d like to explore an **evcc-controlled battery management** approach as discussed in https://github.com/evcc-io/evcc/discussions/26825, incorporating PV forecasts if the project maintainers agree with this direction.

Since I am not really familiar with this project I used Copilot AI. The PR is best reviewed per commit.

##  New modes

- `nocharge`: Hardware-level mode that stops all battery charging while still allowing discharge. Implemented via SunSpec Model 124 InWRte register (charge rate limit set  to 0%). This is the building block used by the higher-level modes below.

- `chargetosoc?soc=<target>`: Charges the battery from PV surplus only (no grid) until the target SOC is reached, then switches to `nocharge`. Useful for topping up the battery to a specific level using only solar production.

- `holdatsoc?soc=<target>`: Prevents battery discharge below the target SOC while allowing normal operation above it. When SOC drops to the target, the battery is held;  when PV surplus charges it above the target, discharge resumes. Useful for reserving a minimum battery level for evening self-consumption or backup.

 Both `chargetosoc` and `holdatsoc` are logical modes that resolve each control cycle into existing hardware modes (`normal`, `nocharge`, `hold`), so no new hardware capabilities are required beyond `nocharge`.

 ## API

 - `POST /api/batterymode/chargetosoc?soc=<target>`
 - `POST /api/batterymode/holdatsoc?soc=<target>`

The existing 1-minute watchdog applies — clients must keep re-sending the mode.

 ## Template support

 - Fronius GEN24 (case 4: StorCtl_Mod=1, InWRte=0)
 - Fronius Verto Plus (same)
 - Generic SunSpec inverter control (same + InOutWRte_RvrtTms)
 - Fronius Solar API (returns ErrNotAvailable — no HTTP equivalent)
 - E3DC (native protocol)
 - SOC-based battery limit controller

Should I add something like this to the remaining (untested) templates?

```
    - case: 4 # nocharge (not implemented)
      set:
        source: error
        error: ErrNotAvailable
```

 ## Testing

 - Unit tests for resolution logic, state transitions, and watchdog expiry
 - Hardware-verified on Fronius GEN24 over multiple hours:
  - `chargetosoc`: PV-only `charging` → `NoCharge` transition when target reached (confirmed `InWRte=0` via Modbus trace)
  - `holdatsoc`: normal `discharge` → `hold` transition when SOC drops to target, stable hold confirmed with grid load