### PR TITLE
EEBus HEMS: fix automatic re-activation of expired limits

### DIFF
--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -233,6 +233,7 @@ func (c *EEBus) run() error {
 		if time.Since(c.consumptionLimitActivated) > c.consumptionLimit.Duration {
 			c.log.DEBUG.Println("consumption limit duration exceeded")
 			c.setConsumptionLimit(0)
+			c.consumptionLimit.IsActive = false
 		}
 	}
 
@@ -246,6 +247,7 @@ func (c *EEBus) run() error {
 		if time.Since(c.productionLimitActivated) > c.productionLimit.Duration {
 			c.log.DEBUG.Println("production limit duration exceeded")
 			c.setProductionLimit(0, false)
+			c.productionLimit.IsActive = false
 		}
 	}
 


### PR DESCRIPTION
I noticed that Limits are automatically re-activated after they expired.
This fixes that. I am not sure if more than this has to be claned up, but it seems nobody ever set the IsActive flag to false.