### PR TITLE
Safari: ensure ws reconnect on reopen

### DIFF
--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -111,11 +111,13 @@ export default defineComponent({
 	mounted() {
 		this.connect();
 		document.addEventListener("visibilitychange", this.pageVisibilityChanged, false);
+		window.addEventListener("pageshow", this.pageShowHandler);
 	},
 	unmounted() {
 		this.disconnect();
 		this.clearReconnectTimeout();
 		document.removeEventListener("visibilitychange", this.pageVisibilityChanged, false);
+		window.removeEventListener("pageshow", this.pageShowHandler);
 	},
 	methods: {
 		clearReconnectTimeout() {
@@ -123,11 +125,18 @@ export default defineComponent({
 				window.clearTimeout(this.reconnectTimeout);
 			}
 		},
+		pageShowHandler(event: PageTransitionEvent) {
+			if (event.persisted) {
+				this.disconnect();
+				this.connect();
+			}
+		},
 		pageVisibilityChanged() {
 			if (document.hidden) {
 				this.clearReconnectTimeout();
 				this.disconnect();
 			} else {
+				this.disconnect();
 				this.connect();
 			}
 		},

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -127,16 +127,16 @@ export default defineComponent({
 		},
 		pageShowHandler(event: PageTransitionEvent) {
 			if (event.persisted) {
+				this.clearReconnectTimeout();
 				this.disconnect();
 				this.connect();
 			}
 		},
 		pageVisibilityChanged() {
-			if (document.hidden) {
-				this.clearReconnectTimeout();
-				this.disconnect();
-			} else {
-				this.disconnect();
+			// disconnect in any case to ensure fresh connection
+			this.clearReconnectTimeout();
+			this.disconnect();
+			if (!document.hidden) {
 				this.connect();
 			}
 		},


### PR DESCRIPTION
(hopefully) fixes https://github.com/evcc-io/evcc/issues/27684

🔌 add `disconnect` on page visibility restore to get rid of potential stuck ws connection
💾 force reconnect when site is restored from [bfcache](https://developer.mozilla.org/en-US/docs/Glossary/bfcache)