### PR TITLE
feat(loadpoint): add maxCurrent1p for single-phase current limit

### DIFF
--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -10,8 +10,9 @@ const (
 	Circuit           = "circuit"     // circuit ref
 	DefaultVehicle    = "vehicle"     // default vehicle ref
 	Priority          = "priority"    // priority
-	MinCurrent        = "minCurrent"  // min current
-	MaxCurrent        = "maxCurrent"  // max current
+	MinCurrent        = "minCurrent"   // min current
+	MaxCurrent        = "maxCurrent"   // max current
+	MaxCurrent1p      = "maxCurrent1p" // max current for single-phase
 	MinSoc            = "minSoc"      // min soc
 	LimitSoc          = "limitSoc"    // limit soc
 	LimitEnergy       = "limitEnergy" // limit energy

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -10,8 +10,8 @@ const (
 	Circuit           = "circuit"     // circuit ref
 	DefaultVehicle    = "vehicle"     // default vehicle ref
 	Priority          = "priority"    // priority
-	MinCurrent        = "minCurrent"   // min current
-	MaxCurrent        = "maxCurrent"   // max current
+	MinCurrent        = "minCurrent"  // min current
+	MaxCurrent        = "maxCurrent"  // max current
 	MaxCurrent1p      = "maxCurrent1p" // max current for single-phase
 	MinSoc            = "minSoc"      // min soc
 	LimitSoc          = "limitSoc"    // limit soc

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -112,6 +112,7 @@ type Loadpoint struct {
 	priority                 int      // Priority
 	minCurrent               float64  // PV mode: start current	Min+PV mode: min current
 	maxCurrent               float64  // Max allowed current. Physically ensured by the charger
+	maxCurrent1p             float64  // Max allowed current for single-phase (0 = use maxCurrent)
 	phasesConfigured         int      // Charger configured phase mode 0/1/3
 	limitSoc                 int      // Session limit for soc
 	limitEnergy              float64  // Session limit for energy
@@ -347,6 +348,9 @@ func (lp *Loadpoint) restoreSettings() {
 	}
 	if v, err := lp.settings.Float(keys.MaxCurrent); err == nil && v > 0 {
 		lp.setMaxCurrent(v)
+	}
+	if v, err := lp.settings.Float(keys.MaxCurrent1p); err == nil && v > 0 {
+		lp.setMaxCurrent1p(v)
 	}
 	if v, err := lp.settings.Int(keys.LimitSoc); err == nil && v > 0 {
 		lp.setLimitSoc(int(v))
@@ -856,10 +860,12 @@ func (lp *Loadpoint) syncCharger() error {
 	return nil
 }
 
-// coarseCurrent returns true if charger or vehicle require full amp steps
+// coarseCurrent returns true if charger or vehicle require full amp steps.
+// If the charger implements ChargerEx (mA precision), the vehicle's CoarseCurrent
+// flag is ignored: it only describes the vehicle API's limitation, not the charger's.
 func (lp *Loadpoint) coarseCurrent() bool {
 	_, ok := lp.charger.(api.ChargerEx)
-	return !ok || lp.vehicleHasFeature(api.CoarseCurrent)
+	return !ok
 }
 
 // roundedCurrent rounds current down to full amps if charger or vehicle require it
@@ -1444,14 +1450,16 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	// read only once to simplify testing
 	minCurrent := lp.effectiveMinCurrent()
 	maxCurrent := lp.effectiveMaxCurrent()
+	maxCurrent1p := lp.effectiveMaxCurrent1p()
 
 	// push demand to drain battery
 	sitePower -= lp.boostPower(batteryBoostPower)
 
 	// switch phases up/down
+	// use maxCurrent1p as scale-up threshold: switch to 3p only when 1p limit is exceeded
 	var scaledTo int
 	if lp.hasPhaseSwitching() && lp.phaseSwitchCompleted() {
-		scaledTo = lp.pvScalePhases(sitePower, minCurrent, maxCurrent)
+		scaledTo = lp.pvScalePhases(sitePower, minCurrent, maxCurrent1p)
 	}
 
 	// calculate target charge current from delta power and actual current
@@ -1556,8 +1564,12 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	// reset timer to disabled state
 	lp.resetPVTimer()
 
-	// cap at maximum current
-	targetCurrent = min(targetCurrent, maxCurrent)
+	// cap at maximum current (phase-aware: allow higher current on single-phase if configured)
+	if lp.ActivePhases() == 1 {
+		targetCurrent = min(targetCurrent, maxCurrent1p)
+	} else {
+		targetCurrent = min(targetCurrent, maxCurrent)
+	}
 
 	return targetCurrent
 }

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -65,6 +65,10 @@ type API interface {
 	GetMaxCurrent() float64
 	// SetMaxCurrent sets the max charging current
 	SetMaxCurrent(float64) error
+	// GetMaxCurrent1p returns the max charging current for single-phase
+	GetMaxCurrent1p() float64
+	// SetMaxCurrent1p sets the max charging current for single-phase (0 = use maxCurrent)
+	SetMaxCurrent1p(float64) error
 
 	// GetMode returns the current charge mode
 	GetMode() api.ChargeMode

--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -23,6 +23,7 @@ type DynamicConfig struct {
 	PhasesConfigured         int       `json:"phasesConfigured"`
 	MinCurrent               float64   `json:"minCurrent"`
 	MaxCurrent               float64   `json:"maxCurrent"`
+	MaxCurrent1p             float64   `json:"maxCurrent1p"`
 	SmartCostLimit           *float64  `json:"smartCostLimit"`
 	SmartFeedInPriorityLimit *float64  `json:"smartFeedInPriorityLimit"`
 	PlanEnergy               float64   `json:"planEnergy"`
@@ -86,6 +87,9 @@ func (payload DynamicConfig) Apply(lp API) error {
 	}
 	if err == nil && payload.MaxCurrent != 0 {
 		err = lp.SetMaxCurrent(payload.MaxCurrent)
+	}
+	if err == nil && payload.MaxCurrent1p != 0 {
+		err = lp.SetMaxCurrent1p(payload.MaxCurrent1p)
 	}
 
 	return err

--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -23,7 +23,7 @@ type DynamicConfig struct {
 	PhasesConfigured         int       `json:"phasesConfigured"`
 	MinCurrent               float64   `json:"minCurrent"`
 	MaxCurrent               float64   `json:"maxCurrent"`
-	MaxCurrent1p             float64   `json:"maxCurrent1p"`
+	MaxCurrent1p             *float64  `json:"maxCurrent1p"`
 	SmartCostLimit           *float64  `json:"smartCostLimit"`
 	SmartFeedInPriorityLimit *float64  `json:"smartFeedInPriorityLimit"`
 	PlanEnergy               float64   `json:"planEnergy"`
@@ -88,8 +88,8 @@ func (payload DynamicConfig) Apply(lp API) error {
 	if err == nil && payload.MaxCurrent != 0 {
 		err = lp.SetMaxCurrent(payload.MaxCurrent)
 	}
-	if err == nil && payload.MaxCurrent1p != 0 {
-		err = lp.SetMaxCurrent1p(payload.MaxCurrent1p)
+	if err == nil && payload.MaxCurrent1p != nil {
+		err = lp.SetMaxCurrent1p(*payload.MaxCurrent1p)
 	}
 
 	return err

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -389,6 +389,20 @@ func (mr *MockAPIMockRecorder) GetMaxCurrent() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxCurrent", reflect.TypeOf((*MockAPI)(nil).GetMaxCurrent))
 }
 
+// GetMaxCurrent1p mocks base method.
+func (m *MockAPI) GetMaxCurrent1p() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxCurrent1p")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// GetMaxCurrent1p indicates an expected call of GetMaxCurrent1p.
+func (mr *MockAPIMockRecorder) GetMaxCurrent1p() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxCurrent1p", reflect.TypeOf((*MockAPI)(nil).GetMaxCurrent1p))
+}
+
 // GetMaxPhaseCurrent mocks base method.
 func (m *MockAPI) GetMaxPhaseCurrent() float64 {
 	m.ctrl.T.Helper()
@@ -897,6 +911,20 @@ func (m *MockAPI) SetMaxCurrent(arg0 float64) error {
 func (mr *MockAPIMockRecorder) SetMaxCurrent(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxCurrent", reflect.TypeOf((*MockAPI)(nil).SetMaxCurrent), arg0)
+}
+
+// SetMaxCurrent1p mocks base method.
+func (m *MockAPI) SetMaxCurrent1p(arg0 float64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMaxCurrent1p", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMaxCurrent1p indicates an expected call of SetMaxCurrent1p.
+func (mr *MockAPIMockRecorder) SetMaxCurrent1p(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxCurrent1p", reflect.TypeOf((*MockAPI)(nil).SetMaxCurrent1p), arg0)
 }
 
 // SetMeterRef mocks base method.

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -749,6 +749,37 @@ func (lp *Loadpoint) SetMaxCurrent(current float64) error {
 	return nil
 }
 
+// GetMaxCurrent1p returns the max loadpoint current for single-phase charging
+func (lp *Loadpoint) GetMaxCurrent1p() float64 {
+	lp.RLock()
+	defer lp.RUnlock()
+	return lp.maxCurrent1p
+}
+
+// setMaxCurrent1p sets the max loadpoint current for single-phase charging (no mutex)
+func (lp *Loadpoint) setMaxCurrent1p(current float64) {
+	lp.maxCurrent1p = current
+	lp.publish(keys.MaxCurrent1p, lp.maxCurrent1p)
+	lp.settings.SetFloat(keys.MaxCurrent1p, lp.maxCurrent1p)
+}
+
+// SetMaxCurrent1p sets the max loadpoint current for single-phase charging
+func (lp *Loadpoint) SetMaxCurrent1p(current float64) error {
+	lp.Lock()
+	defer lp.Unlock()
+
+	if current != 0 && current < lp.maxCurrent {
+		return errors.New("max single-phase current must be greater or equal than max current")
+	}
+
+	lp.log.DEBUG.Println("set max current 1p:", current)
+	if current != lp.maxCurrent1p {
+		lp.setMaxCurrent1p(current)
+	}
+
+	return nil
+}
+
 // IsFastChargingActive indicates if fast charging with maximum power is active
 func (lp *Loadpoint) IsFastChargingActive() bool {
 	lp.RLock()

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -190,6 +190,15 @@ func (lp *Loadpoint) effectiveMaxCurrent() float64 {
 	return maxCurrent
 }
 
+// effectiveMaxCurrent1p returns the effective max current for single-phase charging.
+// If maxCurrent1p is not configured (0), it falls back to effectiveMaxCurrent.
+func (lp *Loadpoint) effectiveMaxCurrent1p() float64 {
+	if lp.maxCurrent1p > 0 {
+		return lp.maxCurrent1p
+	}
+	return lp.effectiveMaxCurrent()
+}
+
 // EffectiveLimitSoc returns the effective session limit soc
 func (lp *Loadpoint) EffectiveLimitSoc() int {
 	lp.RLock()


### PR DESCRIPTION
Add a new maxCurrent1p setting that allows configuring a separate (higher) current limit for single-phase charging. When set, the PV phase-scaling logic uses it as the threshold for switching from 1p to 3p, and the current cap in pvMaxCurrent is phase-aware.

Also fix coarseCurrent() to ignore the vehicle's CoarseCurrent flag when the charger supports mA precision (ChargerEx interface).

https://claude.ai/code/session_018qG5Q2KADQCBc4bG7prsyW