### PR TITLE
Zendure Solarflow 800 Pro: remove invalid grid usage (BC)

### DIFF
--- a/templates/definition/meter/zendure-solarflow-pro.yaml
+++ b/templates/definition/meter/zendure-solarflow-pro.yaml
@@ -5,7 +5,7 @@ products:
       generic: Solarflow 800 Pro
 params:
   - name: usage
-    choice: ["pv", "battery", "grid"]
+    choice: ["pv", "battery"]
   - name: host
   - name: maxacpower
     default: 800 # W
@@ -17,13 +17,6 @@ params:
     default: 1s
 render: |
   type: custom
-  {{- if eq .usage "grid" }}
-  power:
-    source: http
-    uri: http://{{ .host }}/properties/report
-    jq: .properties.energyPower
-    cache: {{ .cache }}
-  {{- end }}
   {{- if eq .usage "pv" }}
   power:
     source: http


### PR DESCRIPTION
## Summary

- Remove `grid` from the usage choices for `zendure-solarflow-pro` template
- Remove the corresponding `{{- if eq .usage "grid" }}` block that referenced the non-existent `.properties.energyPower` field

The SolarFlow 800 Pro is a solar/battery system and does not expose a grid power property. The `energyPower` field does not exist in the device's `/properties/report` API response.

## Test plan

- [ ] `make docs` completes without errors
- [ ] Template tests pass (`go test ./meter/...`)
- [ ] Existing `pv` and `battery` usage remain unchanged