### PR TITLE
Add Zendure 3CT meter

### DIFF
--- a/templates/definition/meter/zendure-3ct.yaml
+++ b/templates/definition/meter/zendure-3ct.yaml
@@ -1,0 +1,35 @@
+template: zendure-3ct
+products:
+  - brand: Zendure
+    description:
+      generic: 3CT
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: host
+  - name: cache
+    advanced: true
+    default: 1s
+render: |
+  {{- define "uri" -}}
+  http://{{ .host }}/properties/report
+  {{- end }}
+  type: custom
+  power:
+    source: http
+    uri: {{ include "uri" . }}
+    jq: .total_power
+    cache: {{ .cache }}
+  powers:
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .a_aprt_power
+    cache: {{ .cache }}
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .b_aprt_power
+    cache: {{ .cache }}
+  - source: http
+    uri: {{ include "uri" . }}
+    jq: .c_aprt_power
+    cache: {{ .cache }}


### PR DESCRIPTION
## Summary

- Add new meter template for the Zendure 3CT, a 3-phase CT clamp meter
- Uses local HTTP API at `/properties/report` returning flat JSON with `total_power`, `a_aprt_power`, `b_aprt_power`, `c_aprt_power`
- Grid usage only, includes per-phase `powers` readings
- Follows the `pstryk` template pattern with `{{- define "uri" -}}` helper

## Test plan

- [ ] `make docs` completes without errors
- [ ] Template tests pass (`go test ./meter/...`)
- [ ] YAML is valid (no tabs, correct indentation)