### PR TITLE
Safari: ensure ws reconnect on reopen

### DIFF
--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -189,13 +189,15 @@ export default defineComponent({
 			};
 			this.ws.onopen = () => {
 				console.log("websocket connected");
-				window.app.setOnline();
 			};
 			this.ws.onclose = () => {
+				window.clearTimeout(dataTimeout);
 				window.app.setOffline();
 				this.reconnect();
 			};
 			this.ws.onmessage = (evt) => {
+				window.clearTimeout(dataTimeout);
+				window.app.setOnline();
 				try {
 					const msg = JSON.parse(evt.data);
 					if (msg.startupCompleted) {
@@ -210,6 +212,13 @@ export default defineComponent({
 					});
 				}
 			};
+
+			// Safari/iOS 26 may fail WS handshake or open without delivering data.
+			// If no message received within 10s, tear down and retry.
+			const dataTimeout = window.setTimeout(() => {
+				console.log("websocket data timeout, reconnecting");
+				this.ws?.close();
+			}, 10000);
 		},
 		reload() {
 			window.location.reload();

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -111,11 +111,13 @@ export default defineComponent({
 	mounted() {
 		this.connect();
 		document.addEventListener("visibilitychange", this.pageVisibilityChanged, false);
+		window.addEventListener("pageshow", this.pageShowHandler);
 	},
 	unmounted() {
 		this.disconnect();
 		this.clearReconnectTimeout();
 		document.removeEventListener("visibilitychange", this.pageVisibilityChanged, false);
+		window.removeEventListener("pageshow", this.pageShowHandler);
 	},
 	methods: {
 		clearReconnectTimeout() {
@@ -123,11 +125,18 @@ export default defineComponent({
 				window.clearTimeout(this.reconnectTimeout);
 			}
 		},
+		pageShowHandler(event: PageTransitionEvent) {
+			if (event.persisted) {
+				this.disconnect();
+				this.connect();
+			}
+		},
 		pageVisibilityChanged() {
 			if (document.hidden) {
 				this.clearReconnectTimeout();
 				this.disconnect();
 			} else {
+				this.disconnect();
 				this.connect();
 			}
 		},

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -127,16 +127,16 @@ export default defineComponent({
 		},
 		pageShowHandler(event: PageTransitionEvent) {
 			if (event.persisted) {
+				this.clearReconnectTimeout();
 				this.disconnect();
 				this.connect();
 			}
 		},
 		pageVisibilityChanged() {
-			if (document.hidden) {
-				this.clearReconnectTimeout();
-				this.disconnect();
-			} else {
-				this.disconnect();
+			// disconnect in any case to ensure fresh connection
+			this.clearReconnectTimeout();
+			this.disconnect();
+			if (!document.hidden) {
 				this.connect();
 			}
 		},

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -57,6 +57,7 @@ export default defineComponent({
 	data: () => {
 		return {
 			reconnectTimeout: null as number | null,
+			dataTimeout: null as number | null,
 			ws: null as WebSocket | null,
 			authNotConfigured: false,
 		};
@@ -148,6 +149,10 @@ export default defineComponent({
 			}, 2500);
 		},
 		disconnect() {
+			if (this.dataTimeout) {
+				window.clearTimeout(this.dataTimeout);
+				this.dataTimeout = null;
+			}
 			if (this.ws) {
 				this.ws.onerror = null;
 				this.ws.onopen = null;
@@ -191,12 +196,18 @@ export default defineComponent({
 				console.log("websocket connected");
 			};
 			this.ws.onclose = () => {
-				window.clearTimeout(dataTimeout);
+				if (this.dataTimeout) {
+					window.clearTimeout(this.dataTimeout);
+					this.dataTimeout = null;
+				}
 				window.app.setOffline();
 				this.reconnect();
 			};
 			this.ws.onmessage = (evt) => {
-				window.clearTimeout(dataTimeout);
+				if (this.dataTimeout) {
+					window.clearTimeout(this.dataTimeout);
+					this.dataTimeout = null;
+				}
 				window.app.setOnline();
 				try {
 					const msg = JSON.parse(evt.data);
@@ -214,9 +225,11 @@ export default defineComponent({
 			};
 
 			// Safari/iOS 26 may fail WS handshake or open without delivering data.
+			// Safari/iOS 26 may fail WS handshake or open without delivering data.
 			// If no message received within 10s, tear down and retry.
-			const dataTimeout = window.setTimeout(() => {
+			this.dataTimeout = window.setTimeout(() => {
 				console.log("websocket data timeout, reconnecting");
+				this.dataTimeout = null;
 				this.ws?.close();
 			}, 10000);
 		},


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/27684
addition to https://github.com/evcc-io/evcc/pull/27849

Discard ws connections that are successfully established but did not receive any data.