### PR TITLE
WattSonic: Scale battery soc

### DIFF
--- a/templates/definition/meter/wattsonic.yaml
+++ b/templates/definition/meter/wattsonic.yaml
@@ -103,6 +103,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     delay: {{ .delay }}
+    scale: 0.01 
     register:
       address: 43000    # SOC
       type: holding

--- a/templates/definition/meter/wattsonic.yaml
+++ b/templates/definition/meter/wattsonic.yaml
@@ -103,7 +103,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     delay: {{ .delay }}
-    scale: 0.01 
+    scale: 0.01
     register:
       address: 43000    # SOC
       type: holding


### PR DESCRIPTION
Follow-up to #16104 the battery soc must be scaled by 0.01

