### PR TITLE
Add HoldCharge battery mode

### DIFF
--- a/api/batterymode.go
+++ b/api/batterymode.go
@@ -9,4 +9,5 @@ const (
 	BatteryNormal
 	BatteryHold
 	BatteryCharge
+	BatteryHoldCharge
 )

--- a/api/batterymode_enumer.go
+++ b/api/batterymode_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _BatteryModeName = "unknownnormalholdcharge"
+const _BatteryModeName = "unknownnormalholdchargeholdcharge"
 
-var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23}
+var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23, 33}
 
-const _BatteryModeLowerName = "unknownnormalholdcharge"
+const _BatteryModeLowerName = "unknownnormalholdchargeholdcharge"
 
 func (i BatteryMode) String() string {
 	if i < 0 || i >= BatteryMode(len(_BatteryModeIndex)-1) {
@@ -28,9 +28,10 @@ func _BatteryModeNoOp() {
 	_ = x[BatteryNormal-(1)]
 	_ = x[BatteryHold-(2)]
 	_ = x[BatteryCharge-(3)]
+	_ = x[BatteryHoldCharge-(4)]
 }
 
-var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge}
+var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge, BatteryHoldCharge}
 
 var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeName[0:7]:        BatteryUnknown,
@@ -41,6 +42,8 @@ var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeLowerName[13:17]: BatteryHold,
 	_BatteryModeName[17:23]:      BatteryCharge,
 	_BatteryModeLowerName[17:23]: BatteryCharge,
+	_BatteryModeName[23:33]:      BatteryHoldCharge,
+	_BatteryModeLowerName[23:33]: BatteryHoldCharge,
 }
 
 var _BatteryModeNames = []string{
@@ -48,6 +51,7 @@ var _BatteryModeNames = []string{
 	_BatteryModeName[7:13],
 	_BatteryModeName[13:17],
 	_BatteryModeName[17:23],
+	_BatteryModeName[23:33],
 }
 
 // BatteryModeString retrieves an enum value from the enum constants string name.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -29,7 +29,7 @@ const (
 	flagCustomCssDescription = "Additional user-defined CSS file for custom styling. No compatibility guarantees."
 
 	flagBatteryMode                = "battery-mode"
-	flagBatteryModeDescription     = "Set battery mode (normal, hold, charge)"
+	flagBatteryModeDescription     = "Set battery mode (normal, hold, charge, holdcharge)"
 	flagBatteryModeWait            = "battery-mode-wait"
 	flagBatteryModeWaitDescription = "Wait given duration during which potential watchdogs are active"
 

--- a/meter/e3dc.go
+++ b/meter/e3dc.go
@@ -225,6 +225,11 @@ func (m *E3dc) setBatteryMode(mode api.BatteryMode) error {
 			e3dcDischargeBatteryLimit(false, 0),
 			e3dcBatteryCharge(50000), // max. 50kWh
 		}
+	case api.BatteryHoldCharge:
+		messages = []rscp.Message{
+			e3dcDischargeBatteryLimit(false, 0),
+			e3dcBatteryCharge(0),
+		}
 	default:
 		return api.ErrNotAvailable
 	}

--- a/meter/usage_battery.go
+++ b/meter/usage_battery.go
@@ -68,6 +68,8 @@ func (m *batterySocLimits) LimitController(socG func() (float64, error), limitSo
 		case api.BatteryCharge:
 			return limitSocS(m.MaxSoc)
 
+		// BatteryHoldCharge is not handled explicitly as it requires charge
+		// rate limiting, which this implementation does not provide.
 		default:
 			return api.ErrNotAvailable
 		}

--- a/meter/usage_battery.go
+++ b/meter/usage_battery.go
@@ -68,8 +68,7 @@ func (m *batterySocLimits) LimitController(socG func() (float64, error), limitSo
 		case api.BatteryCharge:
 			return limitSocS(m.MaxSoc)
 
-		// BatteryHoldCharge is not handled explicitly as it requires charge
-		// rate limiting, which this implementation does not provide.
+		// BatteryHoldCharge implementable via limit soc
 		default:
 			return api.ErrNotAvailable
 		}

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -264,5 +264,23 @@ render: |
             uri: {{ joinHostPort .host .port }}
             id: 1
             value: 124:0:OutWRte
+    - case: 4 # holdcharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:StorCtl_Mod
+        - source: const
+          value: 0 # %
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:InWRte
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -110,6 +110,10 @@ render: |
           body: '{"timeofuse":[]}'
         - source: error
           error: ErrNotAvailable
+    - case: 4 # holdcharge (not implemented)
+      set:
+        source: error
+        error: ErrNotAvailable
   {{- end }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -260,5 +260,23 @@ render: |
             uri: {{ joinHostPort .host .port }}
             id: 1
             value: 124:0:OutWRte
+    - case: 4 # holdcharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:StorCtl_Mod
+        - source: const
+          value: 0 # %
+          set:
+            source: sunspec
+            uri: {{ .host }}:{{ .port }}
+            id: 1
+            value: 124:0:InWRte
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sunspec-inverter-control.yaml
+++ b/templates/definition/meter/sunspec-inverter-control.yaml
@@ -104,5 +104,27 @@ render: |
             source: sunspec
             {{- include "modbus" . | indent 10 }}
             value: 124:0:InOutWRte_RvrtTms
+    - case: 4 # holdcharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 1
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 124:0:StorCtl_Mod
+        - source: const
+          value: 0 # %
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 124:0:InWRte
+        - source: const
+          value: 0 # s
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 124:0:InOutWRte_RvrtTms
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
This is a stripped down version of https://github.com/evcc-io/evcc/pull/27801 based on @andig 's [comment](https://github.com/evcc-io/evcc/pull/27801#issuecomment-3979622059) that a no-charge mode might be acceptable.

I realized that I should be able to implement what I want to do with only the no-charge mode and that might be useful for others too. 

@andig I hope you are not annoyed because of this second PR.

---

Introduce a new hardware-level battery mode that prevents charging while still allowing discharge. This is implemented via the SunSpec Model 124 InWRte register (charge rate limit set to 0%), which has been verified on Fronius GEN24 hardware.

The mode is mapped as case 4 in battery controller templates:
- StorCtl_Mod=1 (limit charge rate)
- InWRte=0% (zero charge rate)

Template support is added for Fronius GEN24, Fronius Verto Plus, and the generic SunSpec inverter control template. The Solar API template returns ErrNotAvailable as it has no equivalent HTTP endpoint.

E3DC and SOC-based battery limit controllers are also updated to handle the new mode.

Fix https://github.com/evcc-io/evcc/issues/30249