### PR TITLE
Loadpoint: consider available circuit power for phase switching

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1282,9 +1282,15 @@ func (lp *Loadpoint) fastCharging() error {
 		maxPower1p := Voltage * lp.effectiveMaxCurrent()
 
 		// load management limit active
-		if circuitMaxPower := circuitMaxPower(lp.circuit); circuitMaxPower > 0 && circuitMaxPower < 1.1*maxPower1p {
-			phases = 1
-			lp.log.DEBUG.Printf("fast charging: scaled to 1p to match %.0fW max circuit power", circuitMaxPower)
+		if circuitMaxPower := circuitMaxPower(lp.circuit); circuitMaxPower > 0 {
+			// Available headroom = circuit limit - current circuit load + EV's own current draw.
+			// Adding back lp.chargePower avoids double-counting when the EV is already charging,
+			// which would otherwise cause oscillation between 1p and 3p on each tick.
+			available := circuitMaxPower - lp.circuit.GetChargePower() + lp.chargePower
+			if available < 1.1*maxPower1p {
+				phases = 1
+				lp.log.DEBUG.Printf("fast charging: scaled to 1p, available circuit power %.0fW < %.0fW 1p threshold", available, 1.1*maxPower1p)
+			}
 		}
 
 		if err := lp.scalePhasesIfAvailable(phases); err != nil {

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -479,3 +479,94 @@ func TestScalePhasesIfAvailable(t *testing.T) {
 		ctrl.Finish()
 	}
 }
+
+func TestFastChargingCircuit(t *testing.T) {
+	Voltage = 230
+
+	// maxPower1p = Voltage * maxA = 230 * 16 = 3680W
+	// threshold   = 1.1 * maxPower1p          = 4048W
+
+	tc := []struct {
+		desc            string
+		circuitMaxPower float64 // 0 = no circuit
+		circuitPower    float64 // current circuit meter reading (negative = solar export)
+		evPower         float64 // EV charge power already reflected in circuit reading
+		expectPhases    int
+	}{
+		{
+			desc:         "no circuit: always use 3p",
+			expectPhases: 3,
+		},
+		{
+			desc:            "circuit limit above threshold, no solar: use 3p",
+			circuitMaxPower: 5750,
+			circuitPower:    500,
+			expectPhases:    3,
+		},
+		{
+			desc:            "circuit limit below threshold, no solar: use 1p",
+			circuitMaxPower: 2500,
+			circuitPower:    500,
+			expectPhases:    1,
+		},
+		{
+			desc:            "circuit limit below threshold, solar surplus: use 3p",
+			circuitMaxPower: 2500,
+			circuitPower:    -5000, // solar surplus, net grid export
+			expectPhases:    3,
+		},
+		{
+			desc:            "circuit limit below threshold, solar surplus, EV already charging: no oscillation, use 3p",
+			circuitMaxPower: 2500,
+			circuitPower:    -3000, // house(1k)+EV(2k)-solar(6k) = -3k
+			evPower:         2000,
+			expectPhases:    3,
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			plainCharger := api.NewMockCharger(ctrl)
+			phaseCharger := api.NewMockPhaseSwitcher(ctrl)
+
+			lp := &Loadpoint{
+				log:         util.NewLogger("foo"),
+				clock:       clock.NewMock(),
+				wakeUpTimer: NewTimer(),
+				bus:         evbus.New(),
+				charger: struct {
+					*api.MockCharger
+					*api.MockPhaseSwitcher
+				}{plainCharger, phaseCharger},
+				minCurrent:  minA,
+				maxCurrent:  maxA,
+				phases:      1, // start at 1-phase
+				chargePower: tc.evPower,
+			}
+
+			if tc.circuitMaxPower > 0 {
+				circuit := api.NewMockCircuit(ctrl)
+				circuit.EXPECT().GetMaxPower().Return(tc.circuitMaxPower)
+				circuit.EXPECT().GetChargePower().Return(tc.circuitPower)
+				circuit.EXPECT().ValidateCurrent(gomock.Any(), gomock.Any()).DoAndReturn(func(_, new float64) float64 { return new })
+				circuit.EXPECT().ValidatePower(gomock.Any(), gomock.Any()).DoAndReturn(func(_, new float64) float64 { return new })
+				lp.circuit = circuit
+			}
+
+			if tc.expectPhases != lp.phases {
+				phaseCharger.EXPECT().Phases1p3p(tc.expectPhases).Return(nil)
+			}
+
+			plainCharger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
+			plainCharger.EXPECT().Enable(true).Return(nil)
+
+			err := lp.fastCharging()
+			require.NoError(t, err)
+			require.Equal(t, tc.expectPhases, lp.phases)
+
+			ctrl.Finish()
+		})
+	}
+}


### PR DESCRIPTION
When you:

- set a low (lower than _3 x 6 x 230_ 😊) maxPower to your circuit
- starting fast (or planned) charging
- have auto switching of phases on

You'll notice that the phase switcher limits to 1p, even when there is **solar surpluss**, as reported in https://github.com/evcc-io/evcc/issues/24160.

I'm opening up this PR to take solar into account, when running the phases logic. I'm a software engineer but have no experience with Go. Nor I have no clue how to test this myself. I'm running evcc as an app on Home Assistant. Please review / give feedback 🙇.