### PR TITLE
easee: warn on rogue CommandResponse not triggered by evcc

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -65,6 +65,7 @@ type Easee struct {
 	lp              loadpoint.API
 	cmdMu           sync.Mutex
 	pendingTicks    map[int64]chan easee.SignalRCommandResponse
+	pendingByID     map[easee.ObservationID]chan easee.SignalRCommandResponse
 	expectedOrphans map[easee.ObservationID]int
 	obsC            chan easee.Observation
 	obsTime         map[easee.ObservationID]time.Time
@@ -116,6 +117,7 @@ func NewEasee(ctx context.Context, user, password, charger string, timeout time.
 		current:         6, // default current
 		startDone:       sync.OnceFunc(func() { close(done) }),
 		pendingTicks:    make(map[int64]chan easee.SignalRCommandResponse),
+		pendingByID:     make(map[easee.ObservationID]chan easee.SignalRCommandResponse),
 		expectedOrphans: make(map[easee.ObservationID]int),
 		obsC:            make(chan easee.Observation),
 		obsTime:         make(map[easee.ObservationID]time.Time),
@@ -224,6 +226,18 @@ func (c *Easee) unregisterPendingTick(tick int64) {
 	c.cmdMu.Lock()
 	delete(c.pendingTicks, tick)
 	c.cmdMu.Unlock()
+}
+
+func (c *Easee) registerPendingByID(id easee.ObservationID, ch chan easee.SignalRCommandResponse) {
+	c.cmdMu.Lock()
+	defer c.cmdMu.Unlock()
+	c.pendingByID[id] = ch
+}
+
+func (c *Easee) unregisterPendingByID(id easee.ObservationID) {
+	c.cmdMu.Lock()
+	defer c.cmdMu.Unlock()
+	delete(c.pendingByID, id)
 }
 
 func (c *Easee) registerExpectedOrphan(ids ...easee.ObservationID) {
@@ -419,16 +433,23 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 
 	c.log.TRACE.Printf("CommandResponse %s: %+v", res.SerialNumber, res)
 
+	obsID := easee.ObservationID(res.ID)
+
 	c.cmdMu.Lock()
-	ch, ok := c.pendingTicks[res.Ticks]
+	chTick, tickOk := c.pendingTicks[res.Ticks]
+	chID, idOk := c.pendingByID[obsID]
 	c.cmdMu.Unlock()
 
-	if ok {
-		ch <- res
+	if tickOk {
+		chTick <- res
 		return
 	}
 
-	obsID := easee.ObservationID(res.ID)
+	if idOk {
+		chID <- res
+		return
+	}
+
 	if c.consumeExpectedOrphan(obsID) {
 		return
 	}
@@ -596,6 +617,9 @@ func (c *Easee) postJSONAndWait(uri string, data any) (bool, error) {
 		ch := make(chan easee.SignalRCommandResponse, 1)
 		c.registerPendingTick(cmd.Ticks, ch)
 		defer c.unregisterPendingTick(cmd.Ticks)
+		obsID := easee.ObservationID(cmd.CommandId)
+		c.registerPendingByID(obsID, ch)
+		defer c.unregisterPendingByID(obsID)
 		return false, c.waitForTickResponse(ch)
 	}
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -212,6 +212,18 @@ func (c *Easee) waitForOptionalState() {
 	c.log.WARN.Println("did not receive full state from cloud")
 }
 
+func (c *Easee) registerPendingTick(tick int64, ch chan easee.SignalRCommandResponse) {
+	c.cmdMu.Lock()
+	c.pendingTicks[tick] = ch
+	c.cmdMu.Unlock()
+}
+
+func (c *Easee) unregisterPendingTick(tick int64) {
+	c.cmdMu.Lock()
+	delete(c.pendingTicks, tick)
+	c.cmdMu.Unlock()
+}
+
 // check c.obsTime for presence of ALL of the following keys: easee.SESSION_ENERGY, easee.LIFETIME_ENERGY
 func (c *Easee) optionalStatePresent() bool {
 	c.mux.Lock()

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -109,16 +109,16 @@ func NewEasee(ctx context.Context, user, password, charger string, timeout time.
 	done := make(chan struct{})
 
 	c := &Easee{
-		Helper:       request.NewHelper(log),
-		charger:      charger,
-		authorize:    authorize,
-		log:          log,
-		current:      6, // default current
-		startDone:    sync.OnceFunc(func() { close(done) }),
+		Helper:          request.NewHelper(log),
+		charger:         charger,
+		authorize:       authorize,
+		log:             log,
+		current:         6, // default current
+		startDone:       sync.OnceFunc(func() { close(done) }),
 		pendingTicks:    make(map[int64]chan easee.SignalRCommandResponse),
 		expectedOrphans: make(map[easee.ObservationID]int),
-		obsC:         make(chan easee.Observation),
-		obsTime:      make(map[easee.ObservationID]time.Time),
+		obsC:            make(chan easee.Observation),
+		obsTime:         make(map[easee.ObservationID]time.Time),
 	}
 
 	c.Client.Timeout = timeout

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -63,7 +63,8 @@ type Easee struct {
 	currentL1, currentL2, currentL3 float64
 	rfid      string
 	lp        loadpoint.API
-	cmdC      chan easee.SignalRCommandResponse
+	cmdMu        sync.Mutex
+	pendingTicks map[int64]chan easee.SignalRCommandResponse
 	obsC      chan easee.Observation
 	obsTime   map[easee.ObservationID]time.Time
 	startDone func()
@@ -113,7 +114,7 @@ func NewEasee(ctx context.Context, user, password, charger string, timeout time.
 		log:       log,
 		current:   6, // default current
 		startDone: sync.OnceFunc(func() { close(done) }),
-		cmdC:      make(chan easee.SignalRCommandResponse),
+		pendingTicks: make(map[int64]chan easee.SignalRCommandResponse),
 		obsC:      make(chan easee.Observation),
 		obsTime:   make(map[easee.ObservationID]time.Time),
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -61,13 +61,13 @@ type Easee struct {
 	phaseMode             int
 	currentPower, sessionEnergy, totalEnergy,
 	currentL1, currentL2, currentL3 float64
-	rfid      string
-	lp        loadpoint.API
+	rfid         string
+	lp           loadpoint.API
 	cmdMu        sync.Mutex
 	pendingTicks map[int64]chan easee.SignalRCommandResponse
-	obsC      chan easee.Observation
-	obsTime   map[easee.ObservationID]time.Time
-	startDone func()
+	obsC         chan easee.Observation
+	obsTime      map[easee.ObservationID]time.Time
+	startDone    func()
 }
 
 func init() {
@@ -108,15 +108,15 @@ func NewEasee(ctx context.Context, user, password, charger string, timeout time.
 	done := make(chan struct{})
 
 	c := &Easee{
-		Helper:    request.NewHelper(log),
-		charger:   charger,
-		authorize: authorize,
-		log:       log,
-		current:   6, // default current
-		startDone: sync.OnceFunc(func() { close(done) }),
+		Helper:       request.NewHelper(log),
+		charger:      charger,
+		authorize:    authorize,
+		log:          log,
+		current:      6, // default current
+		startDone:    sync.OnceFunc(func() { close(done) }),
 		pendingTicks: make(map[int64]chan easee.SignalRCommandResponse),
-		obsC:      make(chan easee.Observation),
-		obsTime:   make(map[easee.ObservationID]time.Time),
+		obsC:         make(chan easee.Observation),
+		obsTime:      make(map[easee.ObservationID]time.Time),
 	}
 
 	c.Client.Timeout = timeout

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -570,14 +570,14 @@ func (c *Easee) postJSONAndWait(uri string, data any) (bool, error) {
 		ch := make(chan easee.SignalRCommandResponse, 1)
 		c.registerPendingTick(cmd.Ticks, ch)
 		defer c.unregisterPendingTick(cmd.Ticks)
-		return false, c.waitForTickResponse(cmd.Ticks, ch)
+		return false, c.waitForTickResponse(ch)
 	}
 
 	// all other response codes lead to an error
 	return false, fmt.Errorf("invalid status: %d", resp.StatusCode)
 }
 
-func (c *Easee) waitForTickResponse(expectedTick int64, ch <-chan easee.SignalRCommandResponse) error {
+func (c *Easee) waitForTickResponse(ch <-chan easee.SignalRCommandResponse) error {
 	select {
 	case cmdResp := <-ch:
 		if !cmdResp.WasAccepted {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -226,6 +226,24 @@ func (c *Easee) unregisterPendingTick(tick int64) {
 	c.cmdMu.Unlock()
 }
 
+func (c *Easee) registerExpectedOrphan(ids ...easee.ObservationID) {
+	c.cmdMu.Lock()
+	defer c.cmdMu.Unlock()
+	for _, id := range ids {
+		c.expectedOrphans[id]++
+	}
+}
+
+func (c *Easee) consumeExpectedOrphan(id easee.ObservationID) bool {
+	c.cmdMu.Lock()
+	defer c.cmdMu.Unlock()
+	if c.expectedOrphans[id] > 0 {
+		c.expectedOrphans[id]--
+		return true
+	}
+	return false
+}
+
 // check c.obsTime for presence of ALL of the following keys: easee.SESSION_ENERGY, easee.LIFETIME_ENERGY
 func (c *Easee) optionalStatePresent() bool {
 	c.mux.Lock()

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -64,8 +64,9 @@ type Easee struct {
 	rfid         string
 	lp           loadpoint.API
 	cmdMu        sync.Mutex
-	pendingTicks map[int64]chan easee.SignalRCommandResponse
-	obsC         chan easee.Observation
+	pendingTicks    map[int64]chan easee.SignalRCommandResponse
+	expectedOrphans map[easee.ObservationID]int
+	obsC            chan easee.Observation
 	obsTime      map[easee.ObservationID]time.Time
 	startDone    func()
 }
@@ -114,7 +115,8 @@ func NewEasee(ctx context.Context, user, password, charger string, timeout time.
 		log:          log,
 		current:      6, // default current
 		startDone:    sync.OnceFunc(func() { close(done) }),
-		pendingTicks: make(map[int64]chan easee.SignalRCommandResponse),
+		pendingTicks:    make(map[int64]chan easee.SignalRCommandResponse),
+		expectedOrphans: make(map[easee.ObservationID]int),
 		obsC:         make(chan easee.Observation),
 		obsTime:      make(map[easee.ObservationID]time.Time),
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -815,8 +815,15 @@ func (c *Easee) Phases1p3p(phases int) error {
 			data.DynamicCircuitCurrentP3 = &max3
 		}
 
+		// Register before POST so the SignalR CommandResponse that the Easee
+		// cloud sends on HTTP 200 (sync) responses is silently consumed rather
+		// than logged as rogue. On error we undo the registration; on 202/noop
+		// paths no extra CommandResponse is expected, so the counter is
+		// intentionally left to be consumed by the eventual SignalR message.
 		c.registerExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
-		_, err = c.postJSONAndWait(uri, data)
+		if _, err = c.postJSONAndWait(uri, data); err != nil {
+			c.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
+		}
 	} else {
 		// charger level
 		if phases == 3 {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -403,14 +403,12 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 	c.cmdMu.Unlock()
 
 	if !ok {
-		c.log.WARN.Printf("CommandResponse: no pending tick for %d (serial=%s), ignoring", res.Ticks, res.SerialNumber)
+		c.log.WARN.Printf("rogue CommandResponse: charger %s sent Ticks=%d (accepted=%v, resultCode=%d) "+
+			"which was not triggered by evcc — another system may be controlling this charger",
+			res.SerialNumber, res.Ticks, res.WasAccepted, res.ResultCode)
 		return
 	}
-
-	select {
-	case ch <- res:
-	default:
-	}
+	ch <- res
 }
 
 func (c *Easee) chargers() ([]easee.Charger, error) {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -423,6 +423,8 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 	c.cmdMu.Lock()
 	ch, ok := c.pendingTicks[res.Ticks]
 	c.cmdMu.Unlock()
+	// ch is safe to use outside the lock: it is only removed from pendingTicks
+	// (and never closed) by the caller that created it, after this handler returns.
 
 	if ok {
 		ch <- res

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -793,6 +793,7 @@ func (c *Easee) Phases1p3p(phases int) error {
 			data.DynamicCircuitCurrentP3 = &max3
 		}
 
+		c.registerExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
 		_, err = c.postJSONAndWait(uri, data)
 	} else {
 		// charger level

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -398,8 +398,17 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 	}
 	c.log.TRACE.Printf("CommandResponse %s: %+v", res.SerialNumber, res)
 
+	c.cmdMu.Lock()
+	ch, ok := c.pendingTicks[res.Ticks]
+	c.cmdMu.Unlock()
+
+	if !ok {
+		c.log.WARN.Printf("CommandResponse: no pending tick for %d (serial=%s), ignoring", res.Ticks, res.SerialNumber)
+		return
+	}
+
 	select {
-	case c.cmdC <- res:
+	case ch <- res:
 	default:
 	}
 }
@@ -558,26 +567,25 @@ func (c *Easee) postJSONAndWait(uri string, data any) (bool, error) {
 			return true, nil
 		}
 
-		return false, c.waitForTickResponse(cmd.Ticks)
+		ch := make(chan easee.SignalRCommandResponse, 1)
+		c.registerPendingTick(cmd.Ticks, ch)
+		defer c.unregisterPendingTick(cmd.Ticks)
+		return false, c.waitForTickResponse(cmd.Ticks, ch)
 	}
 
 	// all other response codes lead to an error
 	return false, fmt.Errorf("invalid status: %d", resp.StatusCode)
 }
 
-func (c *Easee) waitForTickResponse(expectedTick int64) error {
-	for {
-		select {
-		case cmdResp := <-c.cmdC:
-			if cmdResp.Ticks == expectedTick {
-				if !cmdResp.WasAccepted {
-					return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
-				}
-				return nil
-			}
-		case <-time.After(c.Client.Timeout):
-			return api.ErrTimeout
+func (c *Easee) waitForTickResponse(expectedTick int64, ch <-chan easee.SignalRCommandResponse) error {
+	select {
+	case cmdResp := <-ch:
+		if !cmdResp.WasAccepted {
+			return fmt.Errorf("command rejected: %d", cmdResp.Ticks)
 		}
+		return nil
+	case <-time.After(c.Client.Timeout):
+		return api.ErrTimeout
 	}
 }
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -416,19 +416,27 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 		c.log.ERROR.Printf("invalid message: %s %v", i, err)
 		return
 	}
+
+	obsID := easee.ObservationID(res.ID)
 	c.log.TRACE.Printf("CommandResponse %s: %+v", res.SerialNumber, res)
 
 	c.cmdMu.Lock()
 	ch, ok := c.pendingTicks[res.Ticks]
 	c.cmdMu.Unlock()
 
-	if !ok {
-		c.log.WARN.Printf("rogue CommandResponse: charger %s sent Ticks=%d (accepted=%v, resultCode=%d) "+
-			"which was not triggered by evcc — another system may be controlling this charger",
-			res.SerialNumber, res.Ticks, res.WasAccepted, res.ResultCode)
+	if ok {
+		ch <- res
 		return
 	}
-	ch <- res
+
+	if c.consumeExpectedOrphan(obsID) {
+		return
+	}
+
+	c.log.WARN.Printf("rogue CommandResponse: charger %s ObservationID=%s Ticks=%d "+
+		"(accepted=%v, resultCode=%d) which was not triggered by evcc — "+
+		"another system may be controlling this charger",
+		res.SerialNumber, obsID, res.Ticks, res.WasAccepted, res.ResultCode)
 }
 
 func (c *Easee) chargers() ([]easee.Charger, error) {

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -61,14 +61,14 @@ type Easee struct {
 	phaseMode             int
 	currentPower, sessionEnergy, totalEnergy,
 	currentL1, currentL2, currentL3 float64
-	rfid         string
-	lp           loadpoint.API
-	cmdMu        sync.Mutex
+	rfid            string
+	lp              loadpoint.API
+	cmdMu           sync.Mutex
 	pendingTicks    map[int64]chan easee.SignalRCommandResponse
 	expectedOrphans map[easee.ObservationID]int
 	obsC            chan easee.Observation
-	obsTime      map[easee.ObservationID]time.Time
-	startDone    func()
+	obsTime         map[easee.ObservationID]time.Time
+	startDone       func()
 }
 
 func init() {
@@ -417,20 +417,18 @@ func (c *Easee) CommandResponse(i json.RawMessage) {
 		return
 	}
 
-	obsID := easee.ObservationID(res.ID)
 	c.log.TRACE.Printf("CommandResponse %s: %+v", res.SerialNumber, res)
 
 	c.cmdMu.Lock()
 	ch, ok := c.pendingTicks[res.Ticks]
 	c.cmdMu.Unlock()
-	// ch is safe to use outside the lock: it is only removed from pendingTicks
-	// (and never closed) by the caller that created it, after this handler returns.
 
 	if ok {
 		ch <- res
 		return
 	}
 
+	obsID := easee.ObservationID(res.ID)
 	if c.consumeExpectedOrphan(obsID) {
 		return
 	}

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -173,7 +173,7 @@ func TestEasee_waitForTickResponse(t *testing.T) {
 				ch <- *tc.cmdCValue
 			}
 
-			err := e.waitForTickResponse(tc.expectedTick, ch)
+			err := e.waitForTickResponse(ch)
 
 			// Assert the result
 			if tc.expectedErr != nil {

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -442,3 +442,31 @@ func TestEasee_CommandResponse_legitimate(t *testing.T) {
 		t.Fatal("CommandResponse did not deliver to pending channel")
 	}
 }
+
+func TestEasee_registerAndConsumeExpectedOrphan(t *testing.T) {
+	e := newEasee()
+
+	// Not registered yet — consume returns false
+	assert.False(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
+
+	// Register once
+	e.registerExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
+
+	// First consume succeeds
+	assert.True(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
+
+	// Second consume fails (counter back to zero)
+	assert.False(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
+}
+
+func TestEasee_registerExpectedOrphan_multipleRegistrations(t *testing.T) {
+	e := newEasee()
+
+	// Register twice (two concurrent calls in flight)
+	e.registerExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
+	e.registerExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
+
+	assert.True(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
+	assert.True(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
+	assert.False(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
+}

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -481,7 +481,8 @@ func TestEasee_CommandResponse_rogueAfterOrphanConsumed(t *testing.T) {
 		Ticks:        111111111,
 		WasAccepted:  true,
 	}
-	raw, _ := json.Marshal(resp)
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
 	e.CommandResponse(raw) // consumes the counter
 
 	// A second identical response with counter=0 should be treated as rogue (not panic)

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -33,7 +33,8 @@ func newEasee() *Easee {
 	e := Easee{
 		Helper:       request.NewHelper(log),
 		obsTime:      make(map[easee.ObservationID]time.Time),
-		pendingTicks: make(map[int64]chan easee.SignalRCommandResponse),
+		pendingTicks:    make(map[int64]chan easee.SignalRCommandResponse),
+		expectedOrphans: make(map[easee.ObservationID]int),
 		log:          log,
 		startDone:    func() {},
 		obsC:         make(chan easee.Observation),

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -443,6 +443,58 @@ func TestEasee_CommandResponse_legitimate(t *testing.T) {
 	}
 }
 
+func TestEasee_CommandResponse_expectedOrphan(t *testing.T) {
+	e := newEasee()
+
+	// Pre-register the expected orphan
+	e.registerExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
+
+	resp := easee.SignalRCommandResponse{
+		SerialNumber: "EH123456",
+		ID:           int(easee.CIRCUIT_MAX_CURRENT_P1),
+		Ticks:        111111111,
+		WasAccepted:  true,
+		ResultCode:   0,
+	}
+
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	// Should not panic and should consume the orphan counter
+	assert.NotPanics(t, func() {
+		e.CommandResponse(raw)
+	})
+
+	// Counter should now be zero — a second response would be rogue
+	assert.False(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
+}
+
+func TestEasee_CommandResponse_rogueAfterOrphanConsumed(t *testing.T) {
+	e := newEasee()
+
+	// Register and immediately consume via CommandResponse
+	e.registerExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
+
+	resp := easee.SignalRCommandResponse{
+		SerialNumber: "EH123456",
+		ID:           int(easee.CIRCUIT_MAX_CURRENT_P1),
+		Ticks:        111111111,
+		WasAccepted:  true,
+	}
+	raw, _ := json.Marshal(resp)
+	e.CommandResponse(raw) // consumes the counter
+
+	// A second identical response with counter=0 should be treated as rogue (not panic)
+	assert.NotPanics(t, func() {
+		e.CommandResponse(raw)
+	})
+
+	// pendingTicks untouched
+	e.cmdMu.Lock()
+	assert.Empty(t, e.pendingTicks)
+	e.cmdMu.Unlock()
+}
+
 func TestEasee_registerAndConsumeExpectedOrphan(t *testing.T) {
 	e := newEasee()
 

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -523,3 +523,43 @@ func TestEasee_registerExpectedOrphan_multipleRegistrations(t *testing.T) {
 	assert.True(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
 	assert.False(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
 }
+
+func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
+	const siteID = 12345
+	const circuitID = 67890
+	const chargerID = "TESTTEST"
+
+	e := newEasee()
+	e.charger = chargerID
+	e.site = siteID
+	e.circuit = circuitID
+
+	httpmock.ActivateNonDefault(e.Client)
+	defer httpmock.DeactivateAndReset()
+
+	// Mock GET circuit settings
+	getURI := fmt.Sprintf("%s/sites/%d/circuits/%d/settings", easee.API, siteID, circuitID)
+	maxP1, maxP2, maxP3 := 32.0, 32.0, 32.0
+	getResp := easee.CircuitSettings{
+		MaxCircuitCurrentP1: &maxP1,
+		MaxCircuitCurrentP2: &maxP2,
+		MaxCircuitCurrentP3: &maxP3,
+	}
+	body, _ := json.Marshal(getResp)
+	httpmock.RegisterResponder(http.MethodGet, getURI,
+		httpmock.NewBytesResponder(200, body))
+
+	// Mock POST circuit settings — return 200 (sync)
+	httpmock.RegisterResponder(http.MethodPost, getURI,
+		httpmock.NewStringResponder(200, ""))
+
+	err := e.Phases1p3p(1)
+	assert.NoError(t, err)
+
+	// The orphan counter should have been registered before the POST.
+	// Since no CommandResponse arrived in this test, the counter stays at 1.
+	e.cmdMu.Lock()
+	count := e.expectedOrphans[easee.CIRCUIT_MAX_CURRENT_P1]
+	e.cmdMu.Unlock()
+	assert.Equal(t, 1, count, "expected orphan should be registered before the POST")
+}

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -34,7 +34,6 @@ func newEasee() *Easee {
 		obsTime:   make(map[easee.ObservationID]time.Time),
 		log:       log,
 		startDone: func() {},
-		cmdC:      make(chan easee.SignalRCommandResponse),
 		obsC:      make(chan easee.Observation),
 	}
 	e.Client.Timeout = 500 * time.Millisecond //aggressive timeout to accelerate testing
@@ -166,15 +165,12 @@ func TestEasee_waitForTickResponse(t *testing.T) {
 
 			e := newEasee()
 
-			// Set up the command channel for test and Easee to share
-			cmdC := make(chan easee.SignalRCommandResponse, 1) // make it buffered for ease of testing
-			e.cmdC = cmdC
-
+			ch := make(chan easee.SignalRCommandResponse, 1)
 			if tc.cmdCValue != nil {
-				cmdC <- *tc.cmdCValue
+				ch <- *tc.cmdCValue
 			}
 
-			err := e.waitForTickResponse(tc.expectedTick)
+			err := e.waitForTickResponse(tc.expectedTick, ch)
 
 			// Assert the result
 			if tc.expectedErr != nil {
@@ -227,7 +223,18 @@ func TestEasee_postJsonAndWait(t *testing.T) {
 
 		if tc.cmdResp != nil {
 			go func() {
-				e.cmdC <- *tc.cmdResp
+				// wait for postJSONAndWait to register the per-tick channel
+				var ch chan easee.SignalRCommandResponse
+				for {
+					e.cmdMu.Lock()
+					ch = e.pendingTicks[tc.cmdResp.Ticks]
+					e.cmdMu.Unlock()
+					if ch != nil {
+						break
+					}
+					time.Sleep(time.Millisecond)
+				}
+				ch <- *tc.cmdResp
 			}()
 		}
 

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Helper function to create a payload
@@ -30,11 +31,12 @@ func createPayload(id easee.ObservationID, timestamp time.Time, dataType easee.D
 func newEasee() *Easee {
 	log := util.NewLogger("easee")
 	e := Easee{
-		Helper:    request.NewHelper(log),
-		obsTime:   make(map[easee.ObservationID]time.Time),
-		log:       log,
-		startDone: func() {},
-		obsC:      make(chan easee.Observation),
+		Helper:       request.NewHelper(log),
+		obsTime:      make(map[easee.ObservationID]time.Time),
+		pendingTicks: make(map[int64]chan easee.SignalRCommandResponse),
+		log:          log,
+		startDone:    func() {},
+		obsC:         make(chan easee.Observation),
 	}
 	e.Client.Timeout = 500 * time.Millisecond //aggressive timeout to accelerate testing
 	return &e
@@ -385,5 +387,57 @@ func TestEasee_MaxCurrent(t *testing.T) {
 		assert.Equal(t, tc.expectCurrent, e.current)
 		//TODO this fails, either current or dynamicChargerCurrent need to go
 		//assert.Equal(t, e.current, e.dynamicChargerCurrent)
+	}
+}
+
+func TestEasee_CommandResponse_rogue(t *testing.T) {
+	e := newEasee()
+
+	rogueResp := easee.SignalRCommandResponse{
+		SerialNumber: "EH123456",
+		Ticks:        999999999,
+		WasAccepted:  true,
+		ResultCode:   0,
+	}
+
+	raw, err := json.Marshal(rogueResp)
+	require.NoError(t, err)
+
+	// No pending tick registered → should log WARN (not panic, not block)
+	assert.NotPanics(t, func() {
+		e.CommandResponse(raw)
+	})
+
+	// pendingTicks should still be empty
+	e.cmdMu.Lock()
+	assert.Empty(t, e.pendingTicks)
+	e.cmdMu.Unlock()
+}
+
+func TestEasee_CommandResponse_legitimate(t *testing.T) {
+	e := newEasee()
+
+	ticks := int64(638798974487432600)
+	ch := make(chan easee.SignalRCommandResponse, 1)
+	e.registerPendingTick(ticks, ch)
+
+	resp := easee.SignalRCommandResponse{
+		SerialNumber: "EH123456",
+		Ticks:        ticks,
+		WasAccepted:  true,
+	}
+
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	e.CommandResponse(raw)
+
+	// Channel should have received the response
+	select {
+	case got := <-ch:
+		assert.Equal(t, ticks, got.Ticks)
+		assert.True(t, got.WasAccepted)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("CommandResponse did not deliver to pending channel")
 	}
 }

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -545,7 +545,8 @@ func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
 		MaxCircuitCurrentP2: &maxP2,
 		MaxCircuitCurrentP3: &maxP3,
 	}
-	body, _ := json.Marshal(getResp)
+	body, err := json.Marshal(getResp)
+	require.NoError(t, err)
 	httpmock.RegisterResponder(http.MethodGet, getURI,
 		httpmock.NewBytesResponder(200, body))
 
@@ -553,7 +554,7 @@ func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
 	httpmock.RegisterResponder(http.MethodPost, getURI,
 		httpmock.NewStringResponder(200, ""))
 
-	err := e.Phases1p3p(1)
+	err = e.Phases1p3p(1)
 	assert.NoError(t, err)
 
 	// The orphan counter should have been registered before the POST.

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -31,13 +31,13 @@ func createPayload(id easee.ObservationID, timestamp time.Time, dataType easee.D
 func newEasee() *Easee {
 	log := util.NewLogger("easee")
 	e := Easee{
-		Helper:       request.NewHelper(log),
-		obsTime:      make(map[easee.ObservationID]time.Time),
+		Helper:          request.NewHelper(log),
+		obsTime:         make(map[easee.ObservationID]time.Time),
 		pendingTicks:    make(map[int64]chan easee.SignalRCommandResponse),
 		expectedOrphans: make(map[easee.ObservationID]int),
-		log:          log,
-		startDone:    func() {},
-		obsC:         make(chan easee.Observation),
+		log:             log,
+		startDone:       func() {},
+		obsC:            make(chan easee.Observation),
 	}
 	e.Client.Timeout = 500 * time.Millisecond //aggressive timeout to accelerate testing
 	return &e

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -34,6 +34,7 @@ func newEasee() *Easee {
 		Helper:          request.NewHelper(log),
 		obsTime:         make(map[easee.ObservationID]time.Time),
 		pendingTicks:    make(map[int64]chan easee.SignalRCommandResponse),
+		pendingByID:     make(map[easee.ObservationID]chan easee.SignalRCommandResponse),
 		expectedOrphans: make(map[easee.ObservationID]int),
 		log:             log,
 		startDone:       func() {},
@@ -494,6 +495,41 @@ func TestEasee_CommandResponse_rogueAfterOrphanConsumed(t *testing.T) {
 	e.cmdMu.Lock()
 	assert.Empty(t, e.pendingTicks)
 	e.cmdMu.Unlock()
+}
+
+func TestEasee_CommandResponse_matchedByID(t *testing.T) {
+	e := newEasee()
+
+	ch := make(chan easee.SignalRCommandResponse, 1)
+	e.registerPendingByID(easee.LOCATION, ch)
+	defer e.unregisterPendingByID(easee.LOCATION)
+
+	// Ticks do NOT match any pendingTicks entry — only the ID matches
+	resp := easee.SignalRCommandResponse{
+		SerialNumber: "EH123456",
+		ID:           int(easee.LOCATION),
+		Ticks:        999999999, // not in pendingTicks
+		WasAccepted:  true,
+		ResultCode:   0,
+	}
+
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		e.CommandResponse(raw)
+	})
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, resp.Ticks, got.Ticks)
+		assert.True(t, got.WasAccepted)
+	default:
+		t.Fatal("expected CommandResponse to be delivered to pendingByID channel")
+	}
+
+	// pendingByID consumed the response — expectedOrphans untouched
+	assert.False(t, e.consumeExpectedOrphan(easee.LOCATION))
 }
 
 func TestEasee_registerAndConsumeExpectedOrphan(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces the shared unbuffered `cmdC` channel with a `pendingTicks map[int64]chan SignalRCommandResponse` — each outgoing API command registers its tick to a per-tick buffered channel
- `CommandResponse()` is now the single routing point: known tick → delivers to channel; unknown tick → emits `WARN` log identifying the charger serial, tick value, and a note that another system may be controlling the charger
- Helps users detect third-party apps (Easee app, another evcc instance, partner integrations) sending commands to their charger unnoticed

## Test Plan

- [x] All existing `TestEasee_*` tests pass (`go test ./charger/ -run TestEasee`)
- [x] `TestEasee_CommandResponse_rogue` — verifies unknown tick logs WARN without panic
- [x] `TestEasee_CommandResponse_legitimate` — verifies known tick is delivered to the registered channel
- [x] Verify `go vet ./charger/` is clean
- [x] Observe WARN log in a real evcc trace when Easee app sends a command in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)