### PR TITLE
Meter: add generic property to indicated reversed installations

### DIFF
--- a/meter/config.go
+++ b/meter/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/config"
+	"github.com/spf13/cast"
 )
 
 var registry = config.Registry
@@ -16,5 +17,35 @@ func Types() []string {
 
 // NewFromConfig creates meter from configuration
 func NewFromConfig(ctx context.Context, typ string, other map[string]any) (api.Meter, error) {
-	return config.NewFromConfig(ctx, typ, other)
+	reversed := cast.ToBool(other["reversed"])
+	if reversed {
+		other = withoutReverse(other)
+	}
+
+	meter, err := config.NewFromConfig(ctx, typ, other)
+	if err != nil {
+		return nil, err
+	}
+
+	if reversed {
+		meter = Reverse(meter)
+	}
+
+	return meter, nil
+}
+
+func withoutReverse(other map[string]any) map[string]any {
+	if len(other) == 0 {
+		return other
+	}
+
+	cloned := make(map[string]any, len(other))
+	for k, v := range other {
+		if k == "reversed" {
+			continue
+		}
+		cloned[k] = v
+	}
+
+	return cloned
 }

--- a/meter/reverse.go
+++ b/meter/reverse.go
@@ -1,0 +1,85 @@
+package meter
+
+import "github.com/evcc-io/evcc/api"
+
+func reverseFloatGetter(g func() (float64, error)) func() (float64, error) {
+	if g == nil {
+		return nil
+	}
+
+	return func() (float64, error) {
+		f, err := g()
+		return -f, err
+	}
+}
+
+func reversePhaseGetter(g func() (float64, float64, float64, error)) func() (float64, float64, float64, error) {
+	if g == nil {
+		return nil
+	}
+
+	return func() (float64, float64, float64, error) {
+		l1, l2, l3, err := g()
+		return -l1, -l2, -l3, err
+	}
+}
+
+func Reverse(m api.Meter) api.Meter {
+	meter, _ := NewConfigurable(reverseFloatGetter(m.CurrentPower))
+
+	var totalEnergy func() (float64, error)
+	if energyMeter, ok := m.(api.MeterEnergy); ok {
+		totalEnergy = energyMeter.TotalEnergy
+	}
+
+	var currents func() (float64, float64, float64, error)
+	if phaseMeter, ok := m.(api.PhaseCurrents); ok {
+		currents = reversePhaseGetter(phaseMeter.Currents)
+	}
+
+	var voltages func() (float64, float64, float64, error)
+	if phaseMeter, ok := m.(api.PhaseVoltages); ok {
+		voltages = phaseMeter.Voltages
+	}
+
+	var powers func() (float64, float64, float64, error)
+	if phaseMeter, ok := m.(api.PhasePowers); ok {
+		powers = reversePhaseGetter(phaseMeter.Powers)
+	}
+
+	var maxACPower func() float64
+	if pvMeter, ok := m.(api.MaxACPowerGetter); ok {
+		maxACPower = pvMeter.MaxACPower
+	}
+
+	var soc func() (float64, error)
+	if battery, ok := m.(api.Battery); ok {
+		soc = battery.Soc
+	}
+
+	var capacity func() float64
+	if battery, ok := m.(api.BatteryCapacity); ok {
+		capacity = battery.Capacity
+	}
+
+	var socLimits func() (float64, float64)
+	if battery, ok := m.(api.BatterySocLimiter); ok {
+		socLimits = battery.GetSocLimits
+	}
+
+	var powerLimits func() (float64, float64)
+	if battery, ok := m.(api.BatteryPowerLimiter); ok {
+		powerLimits = battery.GetPowerLimits
+	}
+
+	var setMode func(api.BatteryMode) error
+	if battery, ok := m.(api.BatteryController); ok {
+		setMode = battery.SetBatteryMode
+	}
+
+	if soc != nil {
+		return meter.DecorateBattery(totalEnergy, soc, capacity, socLimits, powerLimits, setMode)
+	}
+
+	return meter.Decorate(totalEnergy, currents, voltages, powers, maxACPower)
+}

--- a/meter/reverse_test.go
+++ b/meter/reverse_test.go
@@ -1,0 +1,144 @@
+package meter
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReverseConfigurable(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewConfigurableFromConfig(t.Context(), map[string]any{
+		"power": map[string]any{
+			"source": "const",
+			"value":  "123.4",
+		},
+		"currents": []plugin.Config{
+			{Source: "const", Other: map[string]any{"value": "1"}},
+			{Source: "const", Other: map[string]any{"value": "2"}},
+			{Source: "const", Other: map[string]any{"value": "3"}},
+		},
+		"powers": []plugin.Config{
+			{Source: "const", Other: map[string]any{"value": "10"}},
+			{Source: "const", Other: map[string]any{"value": "20"}},
+			{Source: "const", Other: map[string]any{"value": "30"}},
+		},
+	})
+	require.NoError(t, err)
+
+	m = Reverse(m)
+
+	p, err := m.CurrentPower()
+	require.NoError(t, err)
+	require.Equal(t, -123.4, p)
+
+	c, ok := m.(api.PhaseCurrents)
+	require.True(t, ok)
+	l1, l2, l3, err := c.Currents()
+	require.NoError(t, err)
+	require.Equal(t, -1.0, l1)
+	require.Equal(t, -2.0, l2)
+	require.Equal(t, -3.0, l3)
+
+	pp, ok := m.(api.PhasePowers)
+	require.True(t, ok)
+	l1, l2, l3, err = pp.Powers()
+	require.NoError(t, err)
+	require.Equal(t, -10.0, l1)
+	require.Equal(t, -20.0, l2)
+	require.Equal(t, -30.0, l3)
+}
+
+func TestReverseLeavesTotalEnergyUntouched(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewConfigurableFromConfig(t.Context(), map[string]any{
+		"power": map[string]any{
+			"source": "const",
+			"value":  "123.4",
+		},
+		"energy": map[string]any{
+			"source": "const",
+			"value":  "456.7",
+		},
+	})
+	require.NoError(t, err)
+
+	reversed := Reverse(m)
+
+	me, ok := reversed.(api.MeterEnergy)
+	require.True(t, ok)
+	e, err := me.TotalEnergy()
+	require.NoError(t, err)
+	require.Equal(t, 456.7, e)
+}
+
+func TestNewFromTemplateConfigReversed(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewFromTemplateConfig(t.Context(), map[string]any{
+		"template":  "demo-meter",
+		"usage":     "grid",
+		"power":     123,
+		"currentL1": 1,
+		"currentL2": 2,
+		"currentL3": 3,
+		"reversed":  true,
+	})
+	require.NoError(t, err)
+
+	p, err := m.CurrentPower()
+	require.NoError(t, err)
+	require.Equal(t, -123.0, p)
+
+	c, ok := m.(api.PhaseCurrents)
+	require.True(t, ok)
+	l1, l2, l3, err := c.Currents()
+	require.NoError(t, err)
+	require.Equal(t, -1.0, l1)
+	require.Equal(t, -2.0, l2)
+	require.Equal(t, -3.0, l3)
+}
+
+func TestNewFromConfigReversed(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewFromConfig(t.Context(), api.Custom, map[string]any{
+		"reversed": true,
+		"power": map[string]any{
+			"source": "const",
+			"value":  "12",
+		},
+		"currents": []plugin.Config{
+			{Source: "const", Other: map[string]any{"value": "1"}},
+			{Source: "const", Other: map[string]any{"value": "2"}},
+			{Source: "const", Other: map[string]any{"value": "3"}},
+		},
+		"energy": map[string]any{
+			"source": "const",
+			"value":  "9",
+		},
+	})
+	require.NoError(t, err)
+
+	p, err := m.CurrentPower()
+	require.NoError(t, err)
+	require.Equal(t, -12.0, p)
+
+	c, ok := m.(api.PhaseCurrents)
+	require.True(t, ok)
+	l1, l2, l3, err := c.Currents()
+	require.NoError(t, err)
+	require.Equal(t, -1.0, l1)
+	require.Equal(t, -2.0, l2)
+	require.Equal(t, -3.0, l3)
+
+	me, ok := m.(api.MeterEnergy)
+	require.True(t, ok)
+	e, err := me.TotalEnergy()
+	require.NoError(t, err)
+	require.Equal(t, 9.0, e)
+}

--- a/meter/template.go
+++ b/meter/template.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/templates"
+	"github.com/spf13/cast"
 )
 
 func init() {
@@ -12,9 +13,18 @@ func init() {
 }
 
 func NewFromTemplateConfig(ctx context.Context, other map[string]any) (api.Meter, error) {
+	reversed := cast.ToBool(other["reversed"])
+
 	instance, err := templates.RenderInstance(templates.Meter, other)
 	if err != nil {
 		return nil, err
+	}
+
+	if reversed {
+		if instance.Other == nil {
+			instance.Other = make(map[string]any)
+		}
+		instance.Other["reversed"] = true
 	}
 
 	return NewFromConfig(ctx, instance.Type, instance.Other)

--- a/util/templates/init.go
+++ b/util/templates/init.go
@@ -45,7 +45,7 @@ func Register(class Class, filepath string) error {
 		return err
 	}
 
-	tmpl, err := fromBytes(b)
+	tmpl, err := fromBytes(class, b)
 	if err != nil {
 		return fmt.Errorf("processing template '%s' failed: %w", filepath, err)
 	}
@@ -63,7 +63,7 @@ func register(class Class, tmpl Template) error {
 	return nil
 }
 
-func fromBytes(b []byte) (Template, error) {
+func fromBytes(class Class, b []byte) (Template, error) {
 	// error on unknown fields
 	dec := yaml.NewDecoder(bytes.NewReader(b))
 	dec.KnownFields(true)
@@ -72,6 +72,8 @@ func fromBytes(b []byte) (Template, error) {
 	if err := dec.Decode(&tmpl); err != nil {
 		return Template{}, err
 	}
+
+	tmpl.prepare(class)
 
 	for _, f := range []func() error{tmpl.ResolvePresets, tmpl.ResolveGroup, tmpl.UpdateParamsWithDefaults, tmpl.UpdateModbusParamsWithDefaults, tmpl.SortRequiredParamsFirst, tmpl.Validate} {
 		if err := f(); err != nil {
@@ -96,7 +98,7 @@ func load(class Class) {
 			return err
 		}
 
-		tmpl, err := fromBytes(b)
+		tmpl, err := fromBytes(class, b)
 		if err != nil {
 			return fmt.Errorf("processing template '%s' failed: %w", filepath, err)
 		}

--- a/util/templates/meter.go
+++ b/util/templates/meter.go
@@ -1,0 +1,27 @@
+package templates
+
+var meterReversedParam = Param{
+	Name: ParamReversed,
+	Description: TextLanguage{
+		DE: "Richtung vertauscht",
+		EN: "Direction reversed",
+	},
+	Help: TextLanguage{
+		DE: "Kehrt das Vorzeichen von Leistung und Strömen um",
+		EN: "Inverts the sign of power and currents",
+	},
+	Type:    TypeBool,
+	Default: "false",
+}
+
+func (t *Template) prepare(class Class) {
+	if class != Meter {
+		return
+	}
+
+	if _, p := t.ParamByName(ParamReversed); p.Name == ParamReversed {
+		return
+	}
+
+	t.Params = append(t.Params, meterReversedParam)
+}

--- a/util/templates/meter_test.go
+++ b/util/templates/meter_test.go
@@ -1,0 +1,37 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMeterTemplateInjectsReversedParam(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"eastron-sdm72", "homewizard-kwh"} {
+		tmpl, err := ByName(Meter, name)
+		require.NoError(t, err)
+
+		_, param := tmpl.ParamByName(ParamReversed)
+		require.Equal(t, ParamReversed, param.Name)
+		require.Equal(t, TypeBool, param.Type)
+		require.Equal(t, "false", param.Default)
+	}
+}
+
+func TestMeterTemplateDoesNotRenderReversedFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpl, err := ByName(Meter, "demo-meter")
+	require.NoError(t, err)
+
+	res, _, err := tmpl.RenderResult(RenderModeInstance, map[string]any{
+		"template": "demo-meter",
+		"usage":    "grid",
+		"power":    123,
+		"reversed": true,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(res), "reversed:")
+}

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	ParamUsage  = "usage"
-	ParamModbus = "modbus"
+	ParamUsage    = "usage"
+	ParamModbus   = "modbus"
+	ParamReversed = "reversed"
 
 	HemsTypeSMA = "sma"
 


### PR DESCRIPTION
For people who have their meter installed in reverse, this PR will add a generic option on meters to reverse the readings for power and current (not total energy!)

Ideally, the energy component would also be reversed (import <--> export), but this requires a bigger refactor for the Meter API (`TotalEnergy()` would need to be refactored for `TotalImport()` and `TotalExport()`)