### PR TITLE
fix(nightly): remove redundant ${{ }} wrapper in if expression

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
     name: Call Build
     needs: check_date
     if: |
-      ${{ needs.check_date.outputs.should_run != 'false' }}
+      needs.check_date.outputs.should_run != 'false'
       && startsWith(github.ref, 'refs/heads/master')
       && ! contains(github.head_ref, 'refs/heads/chore/')
     uses: evcc-io/evcc/.github/workflows/default.yml@master


### PR DESCRIPTION
## Problem

The `call-build-workflow` job uses a multiline `if:` condition that wraps one of its clauses in `${{ }}`:

```yaml
if: |
  ${{ needs.check_date.outputs.should_run != 'false' }}
  && startsWith(github.ref, 'refs/heads/master')
  && ! contains(github.head_ref, 'refs/heads/chore/')
```

GHA processes `if:` in two phases:
1. **Token substitution**: `${{ expr }}` is replaced with its string value (`true` or `false`)
2. **Expression evaluation**: the resulting string — e.g. `"true\n&& startsWith(...)\n&& ..."` — is evaluated as an expression

At step 2, GHA can no longer parse the `&&` clauses as logical operators; it sees a non-empty string, which is always truthy. All three guards are silently ignored, and the build job runs unconditionally on every nightly trigger.

GitHub itself warns about this:
> Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy.

## Fix

Drop the `${{ }}` wrapper. The `if:` context already evaluates its content as an expression — no substitution syntax needed.

```yaml
if: |
  needs.check_date.outputs.should_run != 'false'
  && startsWith(github.ref, 'refs/heads/master')
  && ! contains(github.head_ref, 'refs/heads/chore/')
```

## Test plan

- [ ] Verify the nightly workflow no longer shows the syntax warning in GHA
- [ ] Confirm the build job is skipped on days with no commits (check_date returns `false`)