### PR TITLE
Safari: ws cache busting

### DIFF
--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -185,7 +185,8 @@ export default defineComponent({
 				loc.hostname +
 				(loc.port ? ":" + loc.port : "") +
 				loc.pathname +
-				"ws";
+				"ws?t=" +
+				Date.now(); // force Safari to use a fresh connection
 
 			this.ws = new WebSocket(uri);
 			this.ws.onerror = () => {

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -177,16 +177,11 @@ export default defineComponent({
 				return;
 			}
 
-			const loc = window.location;
-			const protocol = loc.protocol == "https:" ? "wss:" : "ws:";
-			const uri =
-				protocol +
-				"//" +
-				loc.hostname +
-				(loc.port ? ":" + loc.port : "") +
-				loc.pathname +
-				"ws?t=" +
-				Date.now(); // force Safari to use a fresh connection
+			const loc = new URL("ws", window.location.href);
+			loc.protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+			// force Safari to use a fresh connection
+			loc.searchParams.set("t", String(Date.now()));
+			const uri = loc.href;
 
 			this.ws = new WebSocket(uri);
 			this.ws.onerror = () => {
@@ -225,7 +220,6 @@ export default defineComponent({
 				}
 			};
 
-			// Safari/iOS 26 may fail WS handshake or open without delivering data.
 			// Safari/iOS 26 may fail WS handshake or open without delivering data.
 			// If no message received within 10s, tear down and retry.
 			this.dataTimeout = window.setTimeout(() => {

--- a/tests/ws.spec.ts
+++ b/tests/ws.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { start, stop, baseUrl } from "./evcc";
 
+const wsPattern = /\/ws\?/;
+
 test.use({ baseURL: baseUrl() });
 test.describe.configure({ mode: "parallel" });
 
@@ -12,7 +14,7 @@ test.afterEach(async () => {
 });
 
 test("show loadpoint with connect websocket", async ({ page }) => {
-  await page.routeWebSocket("/ws", (ws) => {
+  await page.routeWebSocket(wsPattern, (ws) => {
     const server = ws.connectToServer();
     ws.onMessage((message) => {
       server.send(message);
@@ -28,7 +30,7 @@ test("show loadpoint with connect websocket", async ({ page }) => {
 });
 
 test("show no config screen while startup", async ({ page }) => {
-  await page.routeWebSocket("/ws", () => {
+  await page.routeWebSocket(wsPattern, () => {
     // connect, but don't send any messages
   });
   await page.goto("/");
@@ -36,7 +38,7 @@ test("show no config screen while startup", async ({ page }) => {
 });
 
 test("show offline when websocket is closed", async ({ page }) => {
-  await page.routeWebSocket("/ws", (ws) => {
+  await page.routeWebSocket(wsPattern, (ws) => {
     ws.close();
   });
   await page.goto("/");


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/27684

Now for real - was able to reproduce. Safari 26 seems to have trouble with stale ws connections. Using a unique URL on every (re)connect now.