### PR TITLE
Websocket: split welcome message

### DIFF
--- a/server/socket.go
+++ b/server/socket.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/util"
 )
 
@@ -111,6 +113,14 @@ func (h *SocketHub) deleteSubscriber(s *socketSubscriber) {
 }
 
 func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
+	// ensure startupCompleted is first so client resets state before receiving data
+	slices.SortStableFunc(params, func(a, b util.Param) int {
+		if a.Key == keys.StartupCompleted {
+			return -1
+		}
+		return 0
+	})
+
 	for _, p := range params {
 		k := p.Key
 		if p.Loadpoint != nil {

--- a/server/socket.go
+++ b/server/socket.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/util"
 )
 
@@ -52,7 +52,12 @@ func (h *SocketHub) ServeWebsocket(w http.ResponseWriter, r *http.Request) {
 		InsecureSkipVerify: true,
 	}
 
-	acceptOptions.CompressionMode = websocket.CompressionContextTakeover
+	// Safari deflate message compression is broken, enable for others
+	// see: https://github.com/gorilla/websocket/issues/731
+	ua := strings.ToLower(r.Header.Get("User-Agent"))
+	if strings.Contains(ua, "chrome") || strings.Contains(ua, "firefox") {
+		acceptOptions.CompressionMode = websocket.CompressionContextTakeover
+	}
 
 	conn, err := websocket.Accept(w, r, acceptOptions)
 	if err != nil {
@@ -84,7 +89,7 @@ func (h *SocketHub) subscribe(ctx context.Context, conn *websocket.Conn) error {
 		select {
 		case msg := <-s.send:
 			if err := writeTimeout(ctx, socketWriteTimeout, conn, msg); err != nil {
-				log.INFO.Printf("ws write error: %v, msg len: %.1fkB", err, float64(len(msg))/1024)
+				log.INFO.Printf("ws write error: %v, len: %.1fkB, msg: %s", err, float64(len(msg))/1024, msg[:min(len(msg), 20)])
 				return err
 			}
 		case <-ctx.Done():
@@ -109,7 +114,7 @@ func (h *SocketHub) deleteSubscriber(s *socketSubscriber) {
 
 func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 	msg := make(map[string]json.RawMessage, len(params))
-	forecast := make(map[string]json.RawMessage)
+	var sharded []map[string]json.RawMessage
 
 	for _, p := range params {
 		k := p.Key
@@ -117,19 +122,25 @@ func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 			k = "loadpoints." + p.UniqueID()
 		}
 
-		if p.Key == keys.Forecast {
-			forecast[k] = json.RawMessage(socketEncode(p.Val))
+		// Sharder splits data into chunks, sent individually after main state
+		if sp, ok := (p.Val).(util.Sharder); ok {
+			for key, val := range sp.AllShards() {
+				shard := map[string]json.RawMessage{
+					k + "." + key: json.RawMessage(socketEncode(val)),
+				}
+				sharded = append(sharded, shard)
+			}
 		} else {
 			msg[k] = json.RawMessage(socketEncode(p.Val))
 		}
 	}
 
-	// send complete state (small), then forecast (potentially large)
+	// send complete state first, then shards individually
 	if b, err := json.Marshal(msg); err == nil {
 		subscriber.send <- b
 	}
-	if len(forecast) > 0 {
-		if b, err := json.Marshal(forecast); err == nil {
+	for _, shard := range sharded {
+		if b, err := json.Marshal(shard); err == nil {
 			subscriber.send <- b
 		}
 	}

--- a/server/socket.go
+++ b/server/socket.go
@@ -84,6 +84,7 @@ func (h *SocketHub) subscribe(ctx context.Context, conn *websocket.Conn) error {
 		select {
 		case msg := <-s.send:
 			if err := writeTimeout(ctx, socketWriteTimeout, conn, msg); err != nil {
+				log.INFO.Printf("ws write error: %v, msg len: %.1fkB", err, float64(len(msg))/1024)
 				return err
 			}
 		case <-ctx.Done():

--- a/server/socket.go
+++ b/server/socket.go
@@ -114,7 +114,7 @@ func (h *SocketHub) deleteSubscriber(s *socketSubscriber) {
 
 func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 	msg := make(map[string]json.RawMessage, len(params))
-	var sharded []map[string]json.RawMessage
+	sharders := make(map[string]util.Sharder)
 
 	for _, p := range params {
 		k := p.Key
@@ -122,26 +122,26 @@ func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 			k = "loadpoints." + p.UniqueID()
 		}
 
-		// Sharder splits data into chunks, sent individually after main state
-		if sp, ok := (p.Val).(util.Sharder); ok {
-			for key, val := range sp.AllShards() {
-				shard := map[string]json.RawMessage{
-					k + "." + key: json.RawMessage(socketEncode(val)),
-				}
-				sharded = append(sharded, shard)
-			}
+		// Sharder values are split into shards and sent as a separate message
+		if sharder, ok := (p.Val).(util.Sharder); ok {
+			sharders[k] = sharder
 		} else {
 			msg[k] = json.RawMessage(socketEncode(p.Val))
 		}
 	}
 
-	// send complete state first, then shards individually
+	// send compact state first, then potentially large sharded data
 	if b, err := json.Marshal(msg); err == nil {
 		subscriber.send <- b
 	}
-	for _, shard := range sharded {
-		if b, err := json.Marshal(shard); err == nil {
-			subscriber.send <- b
+
+	for k, sharder := range sharders {
+		for key, val := range sharder.AllShards() {
+			if b, err := json.Marshal(map[string]json.RawMessage{
+				k + "." + key: json.RawMessage(socketEncode(val)),
+			}); err == nil {
+				subscriber.send <- b
+			}
 		}
 	}
 }

--- a/server/socket.go
+++ b/server/socket.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -113,13 +112,8 @@ func (h *SocketHub) deleteSubscriber(s *socketSubscriber) {
 }
 
 func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
-	// ensure startupCompleted is first so client resets state before receiving data
-	slices.SortStableFunc(params, func(a, b util.Param) int {
-		if a.Key == keys.StartupCompleted {
-			return -1
-		}
-		return 0
-	})
+	msg := make(map[string]json.RawMessage, len(params))
+	forecast := make(map[string]json.RawMessage)
 
 	for _, p := range params {
 		k := p.Key
@@ -127,13 +121,19 @@ func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 			k = "loadpoints." + p.UniqueID()
 		}
 
-		msg := map[string]json.RawMessage{
-			k: json.RawMessage(socketEncode(p.Val)),
+		if p.Key == keys.Forecast {
+			forecast[k] = json.RawMessage(socketEncode(p.Val))
+		} else {
+			msg[k] = json.RawMessage(socketEncode(p.Val))
 		}
+	}
 
-		if b, err := json.Marshal(msg); err == nil {
-			subscriber.send <- b
-		}
+	// send complete state (small), then forecast (potentially large)
+	if b, err := json.Marshal(msg); err == nil {
+		subscriber.send <- b
+	}
+	if b, err := json.Marshal(forecast); err == nil {
+		subscriber.send <- b
 	}
 }
 

--- a/server/socket.go
+++ b/server/socket.go
@@ -127,8 +127,10 @@ func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
 	if b, err := json.Marshal(msg); err == nil {
 		subscriber.send <- b
 	}
-	if b, err := json.Marshal(forecast); err == nil {
-		subscriber.send <- b
+	if len(forecast) > 0 {
+		if b, err := json.Marshal(forecast); err == nil {
+			subscriber.send <- b
+		}
 	}
 }
 

--- a/server/socket.go
+++ b/server/socket.go
@@ -111,21 +111,20 @@ func (h *SocketHub) deleteSubscriber(s *socketSubscriber) {
 }
 
 func (h *SocketHub) welcome(subscriber *socketSubscriber, params []util.Param) {
-	msg := make(map[string]json.RawMessage, len(params))
-
 	for _, p := range params {
 		k := p.Key
 		if p.Loadpoint != nil {
 			k = "loadpoints." + p.UniqueID()
 		}
 
-		msg[k] = json.RawMessage(socketEncode(p.Val))
+		msg := map[string]json.RawMessage{
+			k: json.RawMessage(socketEncode(p.Val)),
+		}
+
+		if b, err := json.Marshal(msg); err == nil {
+			subscriber.send <- b
+		}
 	}
-
-	b, _ := json.Marshal(msg)
-
-	// should not block
-	subscriber.send <- b
 }
 
 func (h *SocketHub) broadcast(p util.Param) {

--- a/server/socket.go
+++ b/server/socket.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -53,11 +52,7 @@ func (h *SocketHub) ServeWebsocket(w http.ResponseWriter, r *http.Request) {
 		InsecureSkipVerify: true,
 	}
 
-	// https://github.com/nhooyr/websocket/issues/218
-	ua := strings.ToLower(r.Header.Get("User-Agent"))
-	if strings.Contains(ua, "safari") && !strings.Contains(ua, "chrome") && !strings.Contains(ua, "android") {
-		acceptOptions.CompressionMode = websocket.CompressionDisabled
-	}
+	acceptOptions.CompressionMode = websocket.CompressionContextTakeover
 
 	conn, err := websocket.Accept(w, r, acceptOptions)
 	if err != nil {

--- a/server/socket.go
+++ b/server/socket.go
@@ -89,7 +89,7 @@ func (h *SocketHub) subscribe(ctx context.Context, conn *websocket.Conn) error {
 		select {
 		case msg := <-s.send:
 			if err := writeTimeout(ctx, socketWriteTimeout, conn, msg); err != nil {
-				log.INFO.Printf("ws write error: %v, len: %.1fkB, msg: %s", err, float64(len(msg))/1024, msg[:min(len(msg), 20)])
+				log.TRACE.Printf("ws write error: %v, len: %.1fkB, msg: %s", err, float64(len(msg))/1024, msg[:min(len(msg), 20)])
 				return err
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
adresses https://github.com/evcc-io/evcc/issues/27684, depends on https://github.com/evcc-io/evcc/pull/27994

Just did network analysis on what what's going on with Safari and web sockets. Findings:

- our welcome message can be quite massive (~260kb for my installation)
- largest parts: `forecast: 214kb`, `evopt: 34kb`, any other top level key `> 10kb`
- we dont compress ws messages for safari due do an old browser bug
 https://github.com/evcc-io/evcc/blob/master/server/socket.go#L55-L59
 Note: library default is no ws compression at all
- `tcpdump` sends a close frame after receiving 54kb of the welcome message

The Safari ws close behavior does not seem deterministic since it sometimes just works. Also unsure if the first message has stricter limits than subsequent data updates. However, the increase of state size is a plausible explanation why we did not have similar problems in the past.

**Changes**

- splitting the welcome message into multiple parts (shards). reduces start time.
- enabling compression for ~all clients~ Chrome, Firefox (if request `permessage-deflate`). The before referenced Safari bug https://github.com/coder/websocket/issues/218 as long been fixed (Safari 13) ~and should not be relevant any more~. Safari still handles ws compression incorrectly :/

🏃‍➡️ Changes result in noticeably faster web ui first load > faster first message
💽 Chrome/Firefox consume considerably less bandwidth (-92%)

**Savings (demo mode)**

```
                                                Raw       Deflate    Saving
    --------------------------------------------------------------------
    BEFORE (single message, no compression)  205.9 kB        n/a         —

    AFTER (split + per-message deflate):
      main state                              25.1 kB      6.5 kB      74%
      forecast.co2                             6.8 kB      0.7 kB      90%
      forecast.feedin                         52.8 kB      3.2 kB      94%
      forecast.grid                           60.6 kB      3.4 kB      94%
      forecast.planner                        60.6 kB      3.4 kB      94%

    Overall: before → after                  205.9 kB     17.2 kB      92%
```