### PR TITLE
fix: E.G.O. Smart Heater template - set Modbus ID 247 and mincurrent 0.2A

### DIFF
--- a/templates/definition/charger/ego-smartheater.yaml
+++ b/templates/definition/charger/ego-smartheater.yaml
@@ -9,15 +9,16 @@ requirements:
     de: |
       Der Smart Heater muss mit dem lokalen Netzwerk verbunden sein. Nachrichten müssen mindestens alle 60 Sekunden wiederholt werden, sonst schaltet sich der Heater aus Sicherheitsgründen ab.
 
-      **Wichtig:** Im Loadpoint-Setup `mincurrent: 4` und `maxcurrent: 16` setzen, sowie `phases: 1` für einphasigen Betrieb konfigurieren.
+      **Wichtig:** Im Loadpoint-Setup `mincurrent: 0.2` und `maxcurrent: 16` setzen, sowie `phases: 1` für einphasigen Betrieb konfigurieren.
     en: |
       The Smart Heater must be connected to the local network. Messages must be repeated at least every 60 seconds, otherwise the heater will turn off for safety reasons.
 
-      **Important:** In the loadpoint configuration, set `mincurrent: 4` and `maxcurrent: 16`, as well as `phases: 1` for single-phase operation.
+      **Important:** In the loadpoint configuration, set `mincurrent: 0.2` and `maxcurrent: 16`, as well as `phases: 1` for single-phase operation.
   evcc: ["sponsorship"]
 params:
   - name: modbus
     choice: ["tcpip"]
+    id: 247
 render: |
   type: ego-smartheater
   {{- include "modbus" . }}


### PR DESCRIPTION
Fixes two issues in the E.G.O. Smart Heater template:

- Set default Modbus slave ID to 247 (device default, not 1)
- Update recommended `mincurrent` to `0.2` in loadpoint configuration