### PR TITLE
chore: make sharder caching configurable

### DIFF
--- a/server/socket.go
+++ b/server/socket.go
@@ -145,7 +145,7 @@ func (h *SocketHub) broadcast(p util.Param) {
 
 	// Sharder splits data into chunks
 	if sp, ok := (p.Val).(util.Sharder); ok {
-		for key, val := range sp.Shards(true) {
+		for key, val := range sp.ModifiedShards() {
 			msg[k+"."+key] = json.RawMessage(socketEncode(val))
 		}
 	} else {

--- a/server/socket.go
+++ b/server/socket.go
@@ -145,13 +145,8 @@ func (h *SocketHub) broadcast(p util.Param) {
 
 	// Sharder splits data into chunks
 	if sp, ok := (p.Val).(util.Sharder); ok {
-		shards := sp.Shards()
-		if len(shards) == 0 {
-			return // nothing changed, skip broadcast
-		}
-
-		for _, shard := range shards {
-			msg[k+"."+shard.Key] = json.RawMessage(socketEncode(shard.Value))
+		for key, val := range sp.Shards(false) {
+			msg[k+"."+key] = json.RawMessage(socketEncode(val))
 		}
 	} else {
 		msg[k] = json.RawMessage(socketEncode(p.Val))

--- a/server/socket.go
+++ b/server/socket.go
@@ -145,7 +145,7 @@ func (h *SocketHub) broadcast(p util.Param) {
 
 	// Sharder splits data into chunks
 	if sp, ok := (p.Val).(util.Sharder); ok {
-		for key, val := range sp.Shards(false) {
+		for key, val := range sp.Shards(true) {
 			msg[k+"."+key] = json.RawMessage(socketEncode(val))
 		}
 	} else {

--- a/util/param_shard.go
+++ b/util/param_shard.go
@@ -14,7 +14,8 @@ import (
 
 // Sharder splits data into chunks, omitting unmodified chunks
 type Sharder interface {
-	Shards(useCache bool) iter.Seq2[string, any]
+	ModifiedShards() iter.Seq2[string, any]
+	AllShards() iter.Seq2[string, any]
 }
 
 type Shard struct {
@@ -37,7 +38,15 @@ func (s *sharderImpl) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.struc)
 }
 
-func (s *sharderImpl) Shards(useCache bool) iter.Seq2[string, any] {
+func (s *sharderImpl) AllShards() iter.Seq2[string, any] {
+	return s.shards(false)
+}
+
+func (s *sharderImpl) ModifiedShards() iter.Seq2[string, any] {
+	return s.shards(true)
+}
+
+func (s *sharderImpl) shards(useCache bool) iter.Seq2[string, any] {
 	if useCache {
 		shardMu.Lock()
 		defer shardMu.Unlock()
@@ -45,33 +54,44 @@ func (s *sharderImpl) Shards(useCache bool) iter.Seq2[string, any] {
 
 	return func(yield func(string, any) bool) {
 		for _, f := range structs.Fields(s.struc) {
-			key := f.Name()
-			if t := f.Tag("json"); t != "" {
-				if n := strings.Split(t, ",")[0]; n != "" {
-					key = n
-				}
+			key := jsonKey(f)
+			if useCache && s.skipCachedShard(key, f.Value()) {
+				continue
 			}
-
-			if useCache {
-				// Use JSON for stable hashing (fmt.Append includes pointer addresses)
-				b, err := json.Marshal(f.Value())
-				if err != nil {
-					// Fallback to fmt.Append if JSON fails
-					b = fmt.Append(nil, f.Value())
-				}
-
-				hash := sha256.Sum256(b)
-				if cached, ok := shardCache[s.prefix+key]; ok && hash == cached {
-					continue
-				}
-				shardCache[s.prefix+key] = hash
-			}
-
 			if !yield(key, f.Value()) {
 				break
 			}
 		}
 	}
+}
+
+func jsonKey(f *structs.Field) string {
+	key := f.Name()
+	if t := f.Tag("json"); t != "" {
+		if n := strings.Split(t, ",")[0]; n != "" {
+			key = n
+		}
+	}
+	return key
+}
+
+func (s *sharderImpl) skipCachedShard(key string, value any) bool {
+	// Use JSON for stable hashing (fmt.Append includes pointer addresses)
+	b, err := json.Marshal(value)
+	if err != nil {
+		// Fallback to fmt.Append if JSON fails
+		b = fmt.Append(nil, value)
+	}
+
+	hash := sha256.Sum256(b)
+	cacheKey := s.prefix + key
+
+	if cached, ok := shardCache[cacheKey]; ok && hash == cached {
+		return true
+	}
+
+	shardCache[cacheKey] = hash
+	return false
 }
 
 var _ api.StructMarshaler = (*sharderImpl)(nil)

--- a/util/param_shard.go
+++ b/util/param_shard.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"strings"
 	"sync"
 
@@ -13,7 +14,7 @@ import (
 
 // Sharder splits data into chunks, omitting unmodified chunks
 type Sharder interface {
-	Shards() []Shard
+	Shards(useCache bool) iter.Seq2[string, any]
 }
 
 type Shard struct {
@@ -36,41 +37,43 @@ func (s *sharderImpl) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.struc)
 }
 
-func (s *sharderImpl) Shards() []Shard {
+func (s *sharderImpl) Shards(useCache bool) iter.Seq2[string, any] {
 	ff := structs.Fields(s.struc)
-	res := make([]Shard, 0, len(ff))
 
-	shardMu.Lock()
-	defer shardMu.Unlock()
-
-	for _, f := range ff {
-		key := f.Name()
-		if t := f.Tag("json"); t != "" {
-			if n := strings.Split(t, ",")[0]; n != "" {
-				key = n
-			}
-		}
-
-		// Use JSON for stable hashing (fmt.Append includes pointer addresses)
-		b, err := json.Marshal(f.Value())
-		if err != nil {
-			// Fallback to fmt.Append if JSON fails
-			b = fmt.Append(nil, f.Value())
-		}
-
-		hash := sha256.Sum256(b)
-		if cached, ok := shardCache[s.prefix+key]; ok && hash == cached {
-			continue
-		}
-		shardCache[s.prefix+key] = hash
-
-		res = append(res, Shard{
-			Key:   key,
-			Value: f.Value(),
-		})
+	if useCache {
+		shardMu.Lock()
+		defer shardMu.Unlock()
 	}
 
-	return res
+	return func(yield func(string, any) bool) {
+		for _, f := range ff {
+			key := f.Name()
+			if t := f.Tag("json"); t != "" {
+				if n := strings.Split(t, ",")[0]; n != "" {
+					key = n
+				}
+			}
+
+			if useCache {
+				// Use JSON for stable hashing (fmt.Append includes pointer addresses)
+				b, err := json.Marshal(f.Value())
+				if err != nil {
+					// Fallback to fmt.Append if JSON fails
+					b = fmt.Append(nil, f.Value())
+				}
+
+				hash := sha256.Sum256(b)
+				if cached, ok := shardCache[s.prefix+key]; ok && hash == cached {
+					continue
+				}
+				shardCache[s.prefix+key] = hash
+			}
+
+			if !yield(key, f.Value()) {
+				break
+			}
+		}
+	}
 }
 
 var _ api.StructMarshaler = (*sharderImpl)(nil)

--- a/util/param_shard.go
+++ b/util/param_shard.go
@@ -38,15 +38,13 @@ func (s *sharderImpl) MarshalJSON() ([]byte, error) {
 }
 
 func (s *sharderImpl) Shards(useCache bool) iter.Seq2[string, any] {
-	ff := structs.Fields(s.struc)
-
 	if useCache {
 		shardMu.Lock()
 		defer shardMu.Unlock()
 	}
 
 	return func(yield func(string, any) bool) {
-		for _, f := range ff {
+		for _, f := range structs.Fields(s.struc) {
 			key := f.Name()
 			if t := f.Tag("json"); t != "" {
 				if n := strings.Split(t, ",")[0]; n != "" {

--- a/util/param_shard_test.go
+++ b/util/param_shard_test.go
@@ -17,12 +17,12 @@ func TestSharder(t *testing.T) {
 	assert.Equal(t, map[string]any{
 		"A": "a",
 		"B": "b",
-	}, maps.Collect(s.Shards(false)), "non-cached")
+	}, maps.Collect(s.AllShards()), "non-cached")
 
 	assert.Equal(t, map[string]any{
 		"A": "a",
 		"B": "b",
-	}, maps.Collect(s.Shards(true)), "cache cold")
+	}, maps.Collect(s.ModifiedShards()), "cache cold")
 
-	assert.Equal(t, map[string]any{}, maps.Collect(s.Shards(true)), "cache warm")
+	assert.Equal(t, map[string]any{}, maps.Collect(s.ModifiedShards()), "cache warm")
 }

--- a/util/param_shard_test.go
+++ b/util/param_shard_test.go
@@ -25,4 +25,10 @@ func TestSharder(t *testing.T) {
 	}, maps.Collect(s.ModifiedShards()), "cache cold")
 
 	assert.Equal(t, map[string]any{}, maps.Collect(s.ModifiedShards()), "cache warm")
+
+	s = NewSharder("foo", S{"a", "c"})
+
+	assert.Equal(t, map[string]any{
+		"B": "c",
+	}, maps.Collect(s.ModifiedShards()), "cache modied")
 }

--- a/util/param_shard_test.go
+++ b/util/param_shard_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSharder(t *testing.T) {
+	type S struct {
+		A, B string
+	}
+
+	s := NewSharder("foo", S{"a", "b"})
+
+	assert.Equal(t, map[string]any{
+		"A": "a",
+		"B": "b",
+	}, maps.Collect(s.Shards(false)), "non-cached")
+
+	assert.Equal(t, map[string]any{
+		"A": "a",
+		"B": "b",
+	}, maps.Collect(s.Shards(true)), "cache cold")
+
+	assert.Equal(t, map[string]any{}, maps.Collect(s.Shards(true)), "cache warm")
+}


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/pull/27967

Purpose of the `util.Sharder` is to break large structs into chunks and allow to eliminate processing/publishing non-modified data by caching it. This is used by the websocket publisher.

The sharder logic is quite subtle and not free of side-effects. For time being this is hopefully good enough but it will immediately break with multiple consumers on the same sharder. Right now, the socket API is the only consumer so this should be good enough.