### PR TITLE
fix(modbus): close connection when unregistering

### DIFF
--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -88,6 +88,7 @@ func unregisterConnection(key string) {
 		return
 	}
 
+	conn.Close()
 	delete(connections, key)
 }
 


### PR DESCRIPTION
Ich habe eine neue Amperfied connect.home Wallbox, die leider nicht mit evcc funktioniert.

Beim Verbinden via Modbus funktioniert das Testen, aber das Testen und Speichern mündet in einem "Connection reset by peer". Offensichtlich erlaubt die Wallbox genau eine gleichzeitige Verbindung. Bei "Testen und Speichern" wird eine Verbindung zum Testen aufgebaut, die dann aber nicht ordnungsgemäß geschlossen wird. Der Speichern Schritt versucht dann eine zweite Verbindung aufzubauen, die fehlschlägt, weil die vorherige noch nicht in ein Timeout gelaufen/geschlossen ist.

Mit folgendem simplen Fix ist es repariert.