### PR TITLE
load management ui added

### DIFF
--- a/assets/js/components/Site/LoadManagement.vue
+++ b/assets/js/components/Site/LoadManagement.vue
@@ -99,7 +99,7 @@
 					<div
 						class="load-management-progress progress"
 						role="progressbar"
-						:aria-valuenow="usagePercent(entry.circuit)"
+						:aria-valuenow="entry.circuit.power ?? 0"
 						aria-valuemin="0"
 						:aria-valuemax="entry.circuit.maxPower"
 					>
@@ -166,7 +166,7 @@
 <script lang="ts">
 import "@h2d2/shopicons/es/regular/powersupply";
 import "@h2d2/shopicons/es/regular/arrowdropdown";
-import { defineComponent, type PropType, computed } from "vue";
+import { defineComponent, type PropType, computed, getCurrentInstance } from "vue";
 import type { Circuit } from "@/types/evcc";
 import formatter, { POWER_UNIT } from "@/mixins/formatter";
 import AnimatedNumber from "../Helper/AnimatedNumber.vue";
@@ -192,8 +192,10 @@ export default defineComponent({
 	setup(props: { circuits?: Record<string, Circuit> }) {
 		const circuitsList = computed(() => props.circuits ?? {});
 		const transition = { transition: "width var(--evcc-transition-fast) linear" };
-		const collapseId = "load-management-content";
-		const headerId = "load-management-header";
+		const instance = getCurrentInstance();
+		const idSuffix = instance?.uid ?? Math.random().toString(36).slice(2, 9);
+		const collapseId = `load-management-content-${idSuffix}`;
+		const headerId = `load-management-header-${idSuffix}`;
 		const orderedCircuits = computed(() => {
 			const circuits = circuitsList.value;
 			const entries: { name: string; circuit: Circuit; depth: number }[] = [];
@@ -304,13 +306,6 @@ export default defineComponent({
 		},
 		maxCurrentFormat(v: number): string {
 			return Number(v.toFixed(1)).toString();
-		},
-		formatCurrent(v: number, maxCurrent?: number): string {
-			const current = `${Number(v.toFixed(1))} A`;
-			if (typeof maxCurrent === "number" && maxCurrent > 0) {
-				return `${current} / ${Number(maxCurrent.toFixed(1))} A`;
-			}
-			return current;
 		},
 	},
 });

--- a/assets/js/components/Site/LoadManagement.vue
+++ b/assets/js/components/Site/LoadManagement.vue
@@ -1,0 +1,391 @@
+<template>
+	<div
+		class="container container--loadpoint px-0 mb-md-2"
+		data-testid="load-management"
+	>
+		<button
+			type="button"
+			class="btn-reset d-flex align-items-center justify-content-between w-100 mb-3 mt-0 evcc-default-text load-management-header"
+			:id="headerId"
+			:aria-expanded="open"
+			:aria-controls="collapseId"
+			:aria-label="$t('main.loadManagement.toggleExpand')"
+			@click="open = !open"
+		>
+			<h3 class="mb-0 evcc-default-text">{{ $t("main.loadManagement.title") }}</h3>
+			<shopicon-regular-arrowdropdown
+				class="load-management-chevron flex-shrink-0 ms-2"
+				:class="{ 'load-management-chevron--open': open }"
+				aria-hidden="true"
+			></shopicon-regular-arrowdropdown>
+		</button>
+		<div
+			:id="collapseId"
+			:aria-labelledby="headerId"
+			class="load-management-content"
+			:class="{ 'load-management-content--ready': ready }"
+			:style="{ height: contentHeight }"
+		>
+			<div ref="contentInner" class="d-flex flex-column gap-3">
+			<div
+				v-for="entry in visibleCircuits"
+				:key="entry.name"
+				class="load-management-circuit rounded p-3 px-sm-4 mx-2 mx-sm-0"
+				:class="{ 'load-management-circuit--child': entry.depth > 0 }"
+				:style="entry.depth ? { marginLeft: (entry.depth * 1.25 + 0.5) + 'rem' } : undefined"
+			>
+				<div class="mb-2">
+					<div class="d-flex justify-content-between align-items-center">
+						<span class="d-flex flex-nowrap flex-grow-1 me-3 align-items-center text-truncate">
+							<shopicon-regular-powersupply class="flex-shrink-0 me-2"></shopicon-regular-powersupply>
+							<span class="text-truncate evcc-default-text">
+								{{ circuitTitle(entry.circuit, entry.name) }}
+							</span>
+						</span>
+						<span class="text-end text-nowrap ps-1 d-flex align-items-center gap-2 flex-shrink-0">
+							<span
+								v-if="entry.circuit.dimmed"
+								class="badge bg-warning text-dark"
+								data-bs-toggle="tooltip"
+								:title="$t('main.loadManagement.dimmedTooltip')"
+							>
+								{{ $t("main.loadManagement.dimmed") }}
+							</span>
+							<span
+								v-if="entry.circuit.curtailed"
+								class="badge bg-secondary"
+								data-bs-toggle="tooltip"
+								:title="$t('main.loadManagement.curtailedTooltip')"
+							>
+								{{ $t("main.loadManagement.curtailed") }}
+							</span>
+							<span
+								v-if="showHeaderPower(entry.circuit)"
+								class="fw-bold evcc-default-text"
+							>
+								<template v-if="hasLimit(entry.circuit)">
+									<AnimatedNumber
+										:to="entry.circuit.power ?? 0"
+										:format="kwFormat"
+									/>
+									/
+									<AnimatedNumber
+										:to="entry.circuit.maxPower"
+										:format="kwFormat"
+									/>
+								</template>
+								<template v-else>
+									<AnimatedNumber
+										:to="entry.circuit.power ?? 0"
+										:format="kwFormat"
+									/>
+								</template>
+							</span>
+						</span>
+					</div>
+				</div>
+				<!-- Power bar: 0 ——————— max power (kW) -->
+				<div v-if="hasLimit(entry.circuit)" class="load-management-bars mt-2">
+					<div class="d-flex justify-content-between small evcc-gray mb-1">
+						<span>{{ $t("main.loadManagement.power") }}</span>
+						<span class="text-nowrap">
+							0 —
+							<AnimatedNumber
+								:to="entry.circuit.maxPower"
+								:format="kwFormat"
+							/>
+						</span>
+					</div>
+					<div
+						class="load-management-progress progress"
+						role="progressbar"
+						:aria-valuenow="usagePercent(entry.circuit)"
+						aria-valuemin="0"
+						:aria-valuemax="entry.circuit.maxPower"
+					>
+						<div
+							class="progress-bar load-management-bar-fill"
+							:class="{ 'load-management-bar-fill--warning': (entry.circuit.power ?? 0) >= entry.circuit.maxPower }"
+							:style="{ width: usagePercent(entry.circuit) + '%', ...transition }"
+						>
+							<span
+								v-if="(entry.circuit.power ?? 0) > 0"
+								class="progress-bar-value"
+							>
+								<AnimatedNumber
+									:to="entry.circuit.power ?? 0"
+									:format="kwFormat"
+								/>
+							</span>
+						</div>
+					</div>
+				</div>
+				<!-- Current bar: 0 ——————— max current (A) -->
+				<div v-if="hasCurrentInfo(entry.circuit)" class="load-management-bars mt-3">
+					<div class="d-flex justify-content-between small evcc-gray mb-1">
+						<span>{{ $t("main.loadManagement.current") }}</span>
+						<span class="text-nowrap">
+							0 —
+							<AnimatedNumber
+								:to="entry.circuit.maxCurrent"
+								:format="maxCurrentFormat"
+							/>
+							A
+						</span>
+					</div>
+					<div
+						class="load-management-progress progress"
+						role="progressbar"
+						:aria-valuenow="entry.circuit.current ?? 0"
+						aria-valuemin="0"
+						:aria-valuemax="entry.circuit.maxCurrent"
+					>
+						<div
+							class="progress-bar load-management-bar-fill"
+							:class="{ 'load-management-bar-fill--warning': (entry.circuit.current ?? 0) >= entry.circuit.maxCurrent }"
+							:style="{ width: currentPercent(entry.circuit) + '%', ...transition }"
+						>
+							<span
+								v-if="(entry.circuit.current ?? 0) > 0"
+								class="progress-bar-value"
+							>
+								<AnimatedNumber
+									:to="entry.circuit.current ?? 0"
+									:format="(v) => maxCurrentFormat(v) + ' A'"
+								/>
+							</span>
+						</div>
+					</div>
+				</div>
+			</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script lang="ts">
+import "@h2d2/shopicons/es/regular/powersupply";
+import "@h2d2/shopicons/es/regular/arrowdropdown";
+import { defineComponent, type PropType, computed } from "vue";
+import type { Circuit } from "@/types/evcc";
+import formatter, { POWER_UNIT } from "@/mixins/formatter";
+import AnimatedNumber from "../Helper/AnimatedNumber.vue";
+
+export default defineComponent({
+	name: "LoadManagement",
+	components: { AnimatedNumber },
+	mixins: [formatter],
+	props: {
+		circuits: {
+			type: Object as PropType<Record<string, Circuit>>,
+			default: () => ({}),
+		},
+	},
+	data() {
+		return {
+			open: true,
+			ready: false,
+			contentCompleteHeight: null as number | null,
+			collapsedHeight: null as number | null,
+		};
+	},
+	setup(props: { circuits?: Record<string, Circuit> }) {
+		const circuitsList = computed(() => props.circuits ?? {});
+		const transition = { transition: "width var(--evcc-transition-fast) linear" };
+		const collapseId = "load-management-content";
+		const headerId = "load-management-header";
+		const orderedCircuits = computed(() => {
+			const circuits = circuitsList.value;
+			const entries: { name: string; circuit: Circuit; depth: number }[] = [];
+			const byParent = new Map<string, string[]>();
+			const names = Object.keys(circuits);
+			for (const name of names) {
+				const c = circuits[name];
+				const parent = c.parent ?? "";
+				if (!byParent.has(parent)) byParent.set(parent, []);
+				byParent.get(parent)!.push(name);
+			}
+			const pushChildren = (parentKey: string, depth: number) => {
+				const children = byParent.get(parentKey);
+				if (!children) return;
+				for (const name of children) {
+					entries.push({ name, circuit: circuits[name], depth });
+					pushChildren(name, depth + 1);
+				}
+			};
+			pushChildren("", 0);
+			return entries;
+		});
+		return { circuitsList, orderedCircuits, transition, collapseId, headerId };
+	},
+	computed: {
+		rootCircuits(): { name: string; circuit: Circuit; depth: number }[] {
+			return this.orderedCircuits.filter((e) => e.depth === 0);
+		},
+		visibleCircuits(): { name: string; circuit: Circuit; depth: number }[] {
+			return this.open ? this.orderedCircuits : this.rootCircuits;
+		},
+		contentHeight(): string {
+			if (this.open && this.contentCompleteHeight != null) {
+				return `${this.contentCompleteHeight}px`;
+			}
+			if (!this.open) {
+				const h = this.collapsedHeight ?? this.contentCompleteHeight;
+				if (h != null) return `${h}px`;
+			}
+			return "0";
+		},
+	},
+	watch: {
+		open() {
+			this.$nextTick(this.updateHeight);
+		},
+		orderedCircuits: {
+			handler() {
+				this.$nextTick(this.updateHeight);
+			},
+			deep: true,
+		},
+	},
+	mounted() {
+		window.addEventListener("resize", this.updateHeight);
+		setTimeout(() => {
+			this.ready = true;
+			this.updateHeight();
+		}, 200);
+	},
+	unmounted() {
+		window.removeEventListener("resize", this.updateHeight);
+	},
+	methods: {
+		updateHeight() {
+			const height =
+				(this.$refs["contentInner"] as HTMLElement | undefined)?.offsetHeight ?? 0;
+			if (this.open) {
+				this.contentCompleteHeight = height;
+			} else {
+				this.collapsedHeight = height;
+			}
+		},
+		showHeaderPower(circuit: Circuit): boolean {
+			return this.hasLimit(circuit) || typeof circuit.power === "number";
+		},
+		kwFormat(v: number): string {
+			return this.fmtW(v, POWER_UNIT.KW);
+		},
+		circuitTitle(circuit: Circuit, name: string): string {
+			return (
+				circuit.title ??
+				(circuit.config as { title?: string } | undefined)?.title ??
+				name
+			);
+		},
+		hasLimit(circuit: Circuit): boolean {
+			return typeof circuit.maxPower === "number" && circuit.maxPower > 0;
+		},
+		hasCurrentInfo(circuit: Circuit): boolean {
+			return (
+				typeof circuit.maxCurrent === "number" &&
+				circuit.maxCurrent > 0 &&
+				circuit.current != null
+			);
+		},
+		usagePercent(circuit: Circuit): number {
+			if (!this.hasLimit(circuit)) return 0;
+			const power = circuit.power ?? 0;
+			const max = circuit.maxPower;
+			return Math.min(100, Math.round((power / max) * 100));
+		},
+		currentPercent(circuit: Circuit): number {
+			if (!this.hasCurrentInfo(circuit)) return 0;
+			const current = circuit.current ?? 0;
+			const max = circuit.maxCurrent;
+			return Math.min(100, Math.round((current / max) * 100));
+		},
+		maxCurrentFormat(v: number): string {
+			return Number(v.toFixed(1)).toString();
+		},
+		formatCurrent(v: number, maxCurrent?: number): string {
+			const current = `${Number(v.toFixed(1))} A`;
+			if (typeof maxCurrent === "number" && maxCurrent > 0) {
+				return `${current} / ${Number(maxCurrent.toFixed(1))} A`;
+			}
+			return current;
+		},
+	},
+});
+</script>
+
+<style scoped>
+.load-management-header {
+	cursor: pointer;
+	text-align: left;
+}
+
+.load-management-header:hover {
+	opacity: 0.9;
+}
+
+.load-management-chevron {
+	transition: transform var(--evcc-transition-medium) ease;
+	transform: rotate(-90deg);
+}
+
+.load-management-chevron--open {
+	transform: rotate(0deg);
+}
+
+.load-management-content {
+	overflow: hidden;
+	transition-property: height;
+	transition-duration: 0;
+	transition-timing-function: ease-out;
+}
+
+.load-management-content--ready {
+	transition-duration: var(--evcc-transition-medium);
+}
+
+.load-management-circuit {
+	background-color: var(--evcc-box);
+}
+
+.load-management-circuit--child {
+	border-left: 3px solid var(--evcc-gray);
+}
+
+.load-management-progress {
+	height: 32px;
+	font-size: 1rem;
+	background: var(--evcc-background);
+	position: relative;
+}
+
+.load-management-progress .progress-bar {
+	position: relative;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+}
+
+.load-management-bar-fill {
+	background-color: var(--evcc-dark-green);
+}
+
+.load-management-bar-fill--warning {
+	background-color: var(--evcc-orange);
+}
+
+.progress-bar-value {
+	position: absolute;
+	left: 0.5rem;
+	top: 50%;
+	transform: translateY(-50%);
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--evcc-default-text);
+	white-space: nowrap;
+	text-shadow: 0 0 2px var(--evcc-box);
+	pointer-events: none;
+}
+</style>

--- a/assets/js/components/Site/LoadManagement.vue
+++ b/assets/js/components/Site/LoadManagement.vue
@@ -31,8 +31,19 @@
 				v-for="entry in visibleCircuits"
 				:key="entry.name"
 				class="load-management-circuit rounded p-3 px-sm-4 mx-2 mx-sm-0"
-				:class="{ 'load-management-circuit--child': entry.depth > 0 }"
+				:class="{
+					'load-management-circuit--child': entry.depth > 0,
+					'load-management-circuit--expand-trigger': entry.depth === 0,
+				}"
 				:style="entry.depth ? { marginLeft: (entry.depth * 1.25 + 0.5) + 'rem' } : undefined"
+				:role="entry.depth === 0 ? 'button' : undefined"
+				:tabindex="entry.depth === 0 ? 0 : undefined"
+				:aria-label="
+					entry.depth === 0 ? $t('main.loadManagement.toggleExpand') : undefined
+				"
+				@click.stop="toggleExpandFromRoot(entry)"
+				@keydown.enter.prevent="toggleExpandFromRoot(entry)"
+				@keydown.space.prevent="toggleExpandFromRoot(entry)"
 			>
 				<div class="mb-2">
 					<div class="d-flex justify-content-between align-items-center">
@@ -183,7 +194,7 @@ export default defineComponent({
 	},
 	data() {
 		return {
-			open: true,
+			open: false,
 			ready: false,
 			contentCompleteHeight: null as number | null,
 			collapsedHeight: null as number | null,
@@ -200,7 +211,7 @@ export default defineComponent({
 			const circuits = circuitsList.value;
 			const entries: { name: string; circuit: Circuit; depth: number }[] = [];
 			const byParent = new Map<string, string[]>();
-			const names = Object.keys(circuits);
+			const names = Object.keys(circuits).sort((a, b) => a.localeCompare(b));
 			for (const name of names) {
 				const c = circuits[name];
 				if (c === undefined) continue;
@@ -253,16 +264,22 @@ export default defineComponent({
 		},
 	},
 	mounted() {
-		window.addEventListener("resize", this.updateHeight);
-		setTimeout(() => {
-			this.ready = true;
+		this.ready = true;
+		const el = this.$refs["contentInner"] as HTMLElement | undefined;
+		if (el) {
 			this.updateHeight();
-		}, 200);
+			const ro = new ResizeObserver(() => this.updateHeight());
+			ro.observe(el);
+			(this as { _resizeObserver?: ResizeObserver })._resizeObserver = ro;
+		}
 	},
 	unmounted() {
-		window.removeEventListener("resize", this.updateHeight);
+		(this as { _resizeObserver?: ResizeObserver })._resizeObserver?.disconnect();
 	},
 	methods: {
+		toggleExpandFromRoot(entry: { depth: number }) {
+			if (entry.depth === 0) this.open = !this.open;
+		},
 		updateHeight() {
 			const height =
 				(this.$refs["contentInner"] as HTMLElement | undefined)?.offsetHeight ?? 0;
@@ -348,8 +365,17 @@ export default defineComponent({
 	background-color: var(--evcc-box);
 }
 
+.load-management-circuit--expand-trigger {
+	cursor: pointer;
+}
+
+.load-management-circuit--expand-trigger:hover {
+	opacity: 0.95;
+}
+
 .load-management-circuit--child {
-	border-left: 3px solid var(--evcc-gray);
+	border-left: 6px solid var(--evcc-gray);
+	box-shadow: inset 10px 0 14px -6px rgba(0, 0, 0, 0.12);
 }
 
 .load-management-progress {

--- a/assets/js/components/Site/LoadManagement.vue
+++ b/assets/js/components/Site/LoadManagement.vue
@@ -203,6 +203,7 @@ export default defineComponent({
 			const names = Object.keys(circuits);
 			for (const name of names) {
 				const c = circuits[name];
+				if (c === undefined) continue;
 				const parent = c.parent ?? "";
 				if (!byParent.has(parent)) byParent.set(parent, []);
 				byParent.get(parent)!.push(name);
@@ -211,7 +212,9 @@ export default defineComponent({
 				const children = byParent.get(parentKey);
 				if (!children) return;
 				for (const name of children) {
-					entries.push({ name, circuit: circuits[name], depth });
+					const circuit = circuits[name];
+					if (circuit === undefined) continue;
+					entries.push({ name, circuit, depth });
 					pushChildren(name, depth + 1);
 				}
 			};

--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -49,27 +49,33 @@
 					</router-link>
 				</div>
 			</div>
-			<Loadpoints
-				v-else
-				:key="`loadpoints-${orderedVisibleLoadpoints.length}`"
-				class="mt-1 mt-sm-2 flex-grow-1"
-				:loadpoints="orderedVisibleLoadpoints"
-				:vehicles="vehicleList"
-				:smartCostType="smartCostType"
-				:smartCostAvailable="smartCostAvailable"
-				:smartFeedInPriorityAvailable="smartFeedInPriorityAvailable"
-				:tariffGrid="tariffGrid"
-				:tariffCo2="tariffCo2"
-				:tariffFeedIn="tariffFeedIn"
-				:currency="currency"
-				:gridConfigured="gridConfigured"
-				:pvConfigured="pvConfigured"
-				:batteryConfigured="batteryConfigured"
-				:batterySoc="batterySoc"
-				:forecast="forecast"
-				:selectedId="selectedLoadpointId"
-				@id-changed="selectedLoadpointChanged"
-			/>
+			<template v-else>
+				<LoadManagement
+					v-if="hasCircuits"
+					:circuits="circuits"
+					class="mt-1 mt-sm-2"
+				/>
+				<Loadpoints
+					:key="`loadpoints-${orderedVisibleLoadpoints.length}`"
+					class="mt-1 mt-sm-2 flex-grow-1"
+					:loadpoints="orderedVisibleLoadpoints"
+					:vehicles="vehicleList"
+					:smartCostType="smartCostType"
+					:smartCostAvailable="smartCostAvailable"
+					:smartFeedInPriorityAvailable="smartFeedInPriorityAvailable"
+					:tariffGrid="tariffGrid"
+					:tariffCo2="tariffCo2"
+					:tariffFeedIn="tariffFeedIn"
+					:currency="currency"
+					:gridConfigured="gridConfigured"
+					:pvConfigured="pvConfigured"
+					:batteryConfigured="batteryConfigured"
+					:batterySoc="batterySoc"
+					:forecast="forecast"
+					:selectedId="selectedLoadpointId"
+					@id-changed="selectedLoadpointChanged"
+				/>
+			</template>
 			<Footer v-bind="footer"></Footer>
 		</div>
 	</div>
@@ -80,6 +86,7 @@ import "@h2d2/shopicons/es/regular/arrowup";
 import TopNavigationArea from "../Top/TopNavigationArea.vue";
 import Energyflow from "../Energyflow/Energyflow.vue";
 import HemsWarning from "../HemsWarning.vue";
+import LoadManagement from "./LoadManagement.vue";
 import Loadpoints from "../Loadpoints/Loadpoints.vue";
 import Footer from "../Footer/Footer.vue";
 import formatter from "@/mixins/formatter";
@@ -105,6 +112,7 @@ import type { Grid } from "./types";
 export default defineComponent({
 	name: "Site",
 	components: {
+		LoadManagement,
 		Loadpoints,
 		Energyflow,
 		Footer,
@@ -224,6 +232,10 @@ export default defineComponent({
 			return this.fatal.map(({ error, class: errorClass }) =>
 				errorClass ? `${errorClass}: ${error}` : error
 			);
+		},
+		hasCircuits() {
+			const c = this.circuits;
+			return c != null && Object.keys(c).length > 0;
 		},
 	},
 	methods: {

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -139,11 +139,16 @@ export interface Config {
 
 export interface Circuit {
   name: string;
+  parent?: string;
   maxPower: number;
   power?: number;
   maxCurrent: number;
   current?: number;
   config?: Config;
+  title?: string;
+  icon?: string;
+  dimmed?: boolean;
+  curtailed?: boolean;
 }
 
 export interface Entity {

--- a/cmd/demo.yaml
+++ b/cmd/demo.yaml
@@ -92,6 +92,30 @@ meters:
       vm: shared
       script: state.loadpoints[1].chargepower;
 
+  - name: circuit_meter
+    type: template
+    template: demo-meter
+    power: 1500
+    currentL1: 3
+    currentL2: 3
+    currentL3: 3
+
+  - name: circuit_meter_sub1
+    type: template
+    template: demo-meter
+    power: 800
+    currentL1: 2
+    currentL2: 2
+    currentL3: 2
+
+  - name: circuit_meter_sub2
+    type: template
+    template: demo-meter
+    power: 700
+    currentL1: 2
+    currentL2: 2
+    currentL3: 2
+
 chargers:
   - name: charger_1
     type: custom
@@ -240,17 +264,58 @@ site:
     pv: pv
     battery: battery
 
+# Load management: root circuit and subcircuits. Optional per circuit:
+#   title, parent, meter, maxcurrent, maxpower, timeout (e.g. 1m, 30s),
+#   getmaxpower / getmaxcurrent (plugin for dynamic limits, e.g. source: const value: 11000)
+circuits:
+  # Root circuit (no parent): main house / feed
+  - name: main
+    title: Main
+    meter: circuit_meter
+    maxcurrent: 16
+    maxpower: 11000
+    timeout: 1m
+
+  # Subcircuit: Carport branch under main
+  - name: carport_branch
+    title: Carport
+    parent: main
+    meter: circuit_meter_sub1
+    maxcurrent: 10
+    maxpower: 6900
+    timeout: 1m
+
+  # Subcircuit: Garage branch under main
+  - name: garage_branch
+    title: Garage
+    parent: main
+    meter: circuit_meter_sub2
+    maxcurrent: 10
+    maxpower: 6900
+    timeout: 30s
+
+  # Subcircuit with optional values omitted: no meter, no maxcurrent, no maxpower
+  - name: office_branch
+    title: Office
+    parent: main
+
+  # Minimal subcircuit: only name and parent (no title, no meter, no limits)
+  - name: shed_branch
+    parent: main
+
 loadpoints:
   - title: Carport
     charger: charger_1
     mode: pv
     meter: meter_charger_1
     vehicle: vehicle_1
+    circuit: carport_branch
   - title: Garage
     charger: charger_2
     mode: "off"
     meter: meter_charger_2
     vehicle: vehicle_2
+    circuit: garage_branch
 
 tariffs:
   currency: EUR # three letter ISO-4217 currency code (default EUR)

--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -34,6 +34,11 @@ func collectRefs(conf globalconfig.All) error {
 		return err
 	}
 
+	// circuits (meter refs required so circuit meters are configured before circuits)
+	if err := collectCircuitRefs(conf.Circuits); err != nil {
+		return err
+	}
+
 	// append devices from database
 	configurable, err := config.ConfigurationsByClass(templates.Loadpoint)
 	if err != nil {
@@ -104,6 +109,25 @@ func collectTariffRefs() error {
 		references.tariff = append(references.tariff, refs.Planner)
 	}
 	references.tariff = append(references.tariff, refs.Solar...)
+
+	return nil
+}
+
+func collectCircuitRefs(circuits []config.Named) error {
+	for _, cc := range circuits {
+		var refs struct {
+			MeterRef string         `mapstructure:"meter"` // Circuit meter reference
+			Other    map[string]any `mapstructure:",remain"`
+		}
+
+		if err := util.DecodeOther(cc.Other, &refs); err != nil {
+			return err
+		}
+
+		if refs.MeterRef != "" {
+			references.meter = append(references.meter, refs.MeterRef)
+		}
+	}
 
 	return nil
 }

--- a/core/circuit/circuit.go
+++ b/core/circuit/circuit.go
@@ -79,14 +79,18 @@ func NewFromConfig(ctx context.Context, log *util.Logger, other map[string]any) 
 		return nil, err
 	}
 
-	circuit.getMaxPower, err = cc.GetMaxPower.FloatGetter(ctx)
-	if err != nil {
-		return nil, err
+	if cc.GetMaxPower != nil {
+		circuit.getMaxPower, err = cc.GetMaxPower.FloatGetter(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	circuit.getMaxCurrent, err = cc.GetMaxCurrent.FloatGetter(ctx)
-	if err != nil {
-		return nil, err
+	if cc.GetMaxCurrent != nil {
+		circuit.getMaxCurrent, err = cc.GetMaxCurrent.FloatGetter(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if cc.ParentRef != "" {

--- a/core/site_circuits.go
+++ b/core/site_circuits.go
@@ -14,6 +14,7 @@ import (
 type circuitStruct struct {
 	Title      string   `json:"title,omitempty"`
 	Icon       string   `json:"icon,omitempty"`
+	Parent     string   `json:"parent,omitempty"`
 	Power      float64  `json:"power"`
 	Current    *float64 `json:"current,omitempty"`
 	MaxPower   float64  `json:"maxPower,omitempty"`
@@ -39,6 +40,15 @@ func (site *Site) publishCircuits() {
 			MaxCurrent: instance.GetMaxCurrent(),
 			Dimmed:     instance.Dimmed(),
 			Curtailed:  instance.Curtailed(),
+		}
+
+		if parent := instance.GetParent(); parent != nil {
+			for _, d := range cc {
+				if d.Instance() == parent {
+					data.Parent = d.Config().Name
+					break
+				}
+			}
 		}
 
 		if instance.GetMaxCurrent() > 0 {

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1100,6 +1100,16 @@
       "description": "Reduziere Ladeleistung, um {limit} nicht zu überschreiten.",
       "title": "Externe Begrenzung:"
     },
+    "loadManagement": {
+      "curtailed": "Abgeregelt",
+      "curtailedTooltip": "Einspeisereduktion aktiv (§9 EEG)",
+      "current": "Strom",
+      "dimmed": "Gedimmt",
+      "dimmedTooltip": "Lastreduktion aktiv (§14a EnWG)",
+      "power": "Leistung",
+      "title": "Lastmanagement",
+      "toggleExpand": "Lastmanagement ein- oder ausklappen"
+    },
     "loadpoint": {
       "avgPrice": "⌀ Preis",
       "charged": "Geladen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1100,6 +1100,16 @@
       "description": "Reduced charging to not exceed {limit}.",
       "title": "External limit:"
     },
+    "loadManagement": {
+      "curtailed": "Curtailed",
+      "curtailedTooltip": "Feed-in curtailment active (§9 EEG)",
+      "current": "Current",
+      "dimmed": "Dimmed",
+      "dimmedTooltip": "Demand reduction active (§14a EnWG)",
+      "power": "Power",
+      "title": "Load Management",
+      "toggleExpand": "Expand or collapse load management"
+    },
     "loadpoint": {
       "avgPrice": "⌀ Price",
       "charged": "Charged",


### PR DESCRIPTION
Load Management is no longer only visible in the configuration menu, but now also visible on the home UI page. 
This now consists out of :

- A Load Management block on the main view that lists your circuits (e.g. main, carport, garage).
- For each circuit you see current power and limits (and optional current/power bars) when the data exists. 
- If you have a lot of subcircuits the load management takes up a lot of space, thus also added a collapsible section where it only shows the main circuit
- Demo setup was extended with subcircuits and examples with only some options set

<img width="1548" height="897" alt="image" src="https://github.com/user-attachments/assets/a80b1a62-6155-4830-b1bf-4542b863ca79" />

<img width="1426" height="846" alt="image" src="https://github.com/user-attachments/assets/74aa899d-c47c-479f-b604-d9ff41cb7ce5" />


<img width="1391" height="269" alt="image" src="https://github.com/user-attachments/assets/5eaea403-5e46-4850-914e-da2972245839" />
