### PR TITLE
Vaillant: support more countries (BC)

### DIFF
--- a/templates/definition/charger/vaillant.yaml
+++ b/templates/definition/charger/vaillant.yaml
@@ -14,8 +14,8 @@ params:
   - name: password
   - name: realm
     type: choice
-    choice: [DE, AT]
-    default: DE
+    choice: ['albania', 'austria', 'belgium', 'bosnia', 'bulgaria', 'croatia', 'cyprus', 'czechrepublic', 'denmark', 'estonia', 'finland', 'france', 'georgia', 'germany', 'greece', 'hungary', 'ireland', 'italy', 'kosovo', 'latvia', 'lithuania', 'luxembourg', 'moldavia', 'netherlands', 'new-zealand', 'north-macedonia', 'norway', 'poland', 'portugal', 'romania', 'serbia', 'slovakia', 'slovenia', 'spain', 'sweden', 'switzerland', 'turkiye', 'ukraine', 'unitedkingdom', 'uzbekistan']
+    default: germany
     description:
       de: Region
       en: Region
@@ -42,7 +42,7 @@ render: |
   type: vaillant
   user: {{ .user }}
   password: {{ .password }}
-  realm: {{ if eq .realm "AT" -}} vaillant-austria-b2c {{- end }}
+  realm: {{ if eq .realm "DE" -}} vaillant-germany-b2c {{ else if eq .realm "AT" -}} vaillant-austria-b2c {{ else }} vaillant-{{ .realm }}-b2c {{ end }}
   {{- if .system }}
   system: {{ .system }}
   {{- end }}

--- a/templates/definition/charger/vaillant.yaml
+++ b/templates/definition/charger/vaillant.yaml
@@ -14,7 +14,49 @@ params:
   - name: password
   - name: realm
     type: choice
-    choice: ['albania', 'austria', 'belgium', 'bosnia', 'bulgaria', 'croatia', 'cyprus', 'czechrepublic', 'denmark', 'estonia', 'finland', 'france', 'georgia', 'germany', 'greece', 'hungary', 'ireland', 'italy', 'kosovo', 'latvia', 'lithuania', 'luxembourg', 'moldavia', 'netherlands', 'new-zealand', 'north-macedonia', 'norway', 'poland', 'portugal', 'romania', 'serbia', 'slovakia', 'slovenia', 'spain', 'sweden', 'switzerland', 'turkiye', 'ukraine', 'unitedkingdom', 'uzbekistan']
+    choice:
+      [
+        "albania",
+        "austria",
+        "belgium",
+        "bosnia",
+        "bulgaria",
+        "croatia",
+        "cyprus",
+        "czechrepublic",
+        "denmark",
+        "estonia",
+        "finland",
+        "france",
+        "georgia",
+        "germany",
+        "greece",
+        "hungary",
+        "ireland",
+        "italy",
+        "kosovo",
+        "latvia",
+        "lithuania",
+        "luxembourg",
+        "moldavia",
+        "netherlands",
+        "new-zealand",
+        "north-macedonia",
+        "norway",
+        "poland",
+        "portugal",
+        "romania",
+        "serbia",
+        "slovakia",
+        "slovenia",
+        "spain",
+        "sweden",
+        "switzerland",
+        "turkiye",
+        "ukraine",
+        "unitedkingdom",
+        "uzbekistan",
+      ]
     default: germany
     description:
       de: Region


### PR DESCRIPTION
fix: add support for many more countries to use as realm in vaillan template fixes issues (#25700)(#25476)
Added many more countries to the realm choices in the charger template 
Swiched from DE,AT to country names as used by myPyllant ( used in HomeAssistant myVAILLANT integration)
Existing DE and AT settings are mapped to correct realm. 
<img width="481" height="649" alt="image" src="https://github.com/user-attachments/assets/aa1ecc4b-5852-44d3-8988-9b6965c28994" />
