### PR TITLE
Charger HA template: Wrap technical terms in backticks

### DIFF
--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -40,8 +40,8 @@ params:
     example: "binary_sensor.charger_enabled"
     required: true
     help:
-      en: Entity ID for enabled state (sensor, binary_sensor or switch with on/off or true/false state)
-      de: Entitäts-ID für Aktivierungsstatus (sensor, binary_sensor oder switch mit on/off oder true/false Zustand)
+      en: Entity ID for enabled state (`sensor`, `binary_sensor` or `switch` with `on`/`off` or `true`/`false` state)
+      de: Entitäts-ID für Aktivierungsstatus (`sensor`, `binary_sensor` oder `switch` mit `on`/`off` oder `true`/`false` Zustand)
   - name: enable
     description:
       de: Aktivierungsschalter
@@ -50,8 +50,8 @@ params:
     example: "switch.charger_enable"
     required: true
     help:
-      en: Entity ID for enable/disable control (switch or input_boolean)
-      de: Entitäts-ID für Aktivierungs-/Deaktivierungs-Steuerung (switch oder input_boolean)
+      en: Entity ID for enable/disable control (`switch` or `input_boolean`)
+      de: Entitäts-ID für Aktivierungs-/Deaktivierungs-Steuerung (`switch` oder `input_boolean`)
   - name: setMaxCurrent
     description:
       de: Maximale Stromstärke-Entität [A]
@@ -60,8 +60,8 @@ params:
     example: "number.charger_max_current"
     required: true
     help:
-      en: Entity ID for setting maximum current in amperes (number or input_number entity)
-      de: Entitäts-ID zum Setzen der maximalen Stromstärke in Ampere (number oder input_number Entität)
+      en: Entity ID for setting maximum current in amperes (`number` or `input_number` entity)
+      de: Entitäts-ID zum Setzen der maximalen Stromstärke in Ampere (`number` oder `input_number` Entität)
   - name: power
     description:
       de: Leistungsentität


### PR DESCRIPTION
This wraps entity type names and state values in backticks to prevent markdown from misinterpreting underscores as italic markers.

e.g. the `binary_sensor` was previously rendered incorrectly:

<img width="483" height="306" alt="Bildschirmfoto 2026-03-11 um 10 11 34" src="https://github.com/user-attachments/assets/b91cbcad-a1d4-4dbe-ae3b-c5a63b7ce9a6" />
