### PR TITLE
Charger HA template: Remove unsupported `F=error` status from help text

### DIFF
--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -30,8 +30,8 @@ params:
     example: "sensor.charger_status"
     required: true
     help:
-      en: Entity ID for charging status (A=ready, B=connected, C=charging, F=error)
-      de: Entitäts-ID für Ladestatus (A=bereit, B=verbunden, C=laden, F=fehler)
+      en: Entity ID for charging status (A=ready, B=connected, C=charging)
+      de: Entitäts-ID für Ladestatus (A=bereit, B=verbunden, C=laden)
   - name: enabled
     description:
       de: Aktivierungsstatus-Sensor


### PR DESCRIPTION
The codebase only defines `StatusE` for errors, which would be `E` instead of `F`, but that status isn't part of the HA `chargeStatusMap` either, so this PR removes the incorrect documentation for now.