### PR TITLE
fix: warn when battery capacity is missing in multi-battery SOC calculation

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -630,6 +630,15 @@ func (site *Site) updateBatteryMeters() {
 		mm[i].Controllable = new(controllable)
 	}
 
+	// warn about missing capacity in multi-battery setups
+	if len(site.batteryMeters) > 1 {
+		for i, m := range mm {
+			if m.Soc != nil && (m.Capacity == nil || *m.Capacity <= 0) {
+				site.log.WARN.Printf("battery %d has no capacity configured - SOC weighting will be inaccurate; configure capacity for correct results", i+1)
+			}
+		}
+	}
+
 	batterySocAcc := lo.SumBy(mm, func(m types.Measurement) float64 {
 		if m.Soc == nil {
 			return 0

--- a/core/site_battery_test.go
+++ b/core/site_battery_test.go
@@ -164,6 +164,82 @@ func TestExternalBatteryModeChange(t *testing.T) {
 	}
 }
 
+// batteryMeterWithCapacity implements api.Meter, api.Battery, and api.BatteryCapacity
+type batteryMeterWithCapacity struct {
+	power    float64
+	soc      float64
+	capacity float64
+}
+
+func (m batteryMeterWithCapacity) CurrentPower() (float64, error) { return m.power, nil }
+func (m batteryMeterWithCapacity) Soc() (float64, error)          { return m.soc, nil }
+func (m batteryMeterWithCapacity) Capacity() float64              { return m.capacity }
+
+var _ api.Meter = batteryMeterWithCapacity{}
+var _ api.Battery = batteryMeterWithCapacity{}
+var _ api.BatteryCapacity = batteryMeterWithCapacity{}
+
+// batteryMeterWithoutCapacity implements api.Meter and api.Battery (no capacity)
+type batteryMeterWithoutCapacity struct {
+	power float64
+	soc   float64
+}
+
+func (m batteryMeterWithoutCapacity) CurrentPower() (float64, error) { return m.power, nil }
+func (m batteryMeterWithoutCapacity) Soc() (float64, error)          { return m.soc, nil }
+
+var _ api.Meter = batteryMeterWithoutCapacity{}
+var _ api.Battery = batteryMeterWithoutCapacity{}
+
+func TestBatterySocWeightedAverage(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		meters      []api.Meter
+		expectedSoc float64
+	}{
+		{
+			"two batteries both with capacity",
+			[]api.Meter{
+				batteryMeterWithCapacity{soc: 81, capacity: 11.8},
+				batteryMeterWithCapacity{soc: 53, capacity: 1.92},
+			},
+			// (81*11.8 + 53*1.92) / (11.8 + 1.92) = (955.8 + 101.76) / 13.72 ≈ 77.08
+			77.08,
+		},
+		{
+			"single battery with capacity",
+			[]api.Meter{
+				batteryMeterWithCapacity{soc: 75, capacity: 10},
+			},
+			75.0,
+		},
+		{
+			"single battery without capacity",
+			[]api.Meter{
+				batteryMeterWithoutCapacity{soc: 75},
+			},
+			75.0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var devices []config.Device[api.Meter]
+			for _, m := range tc.meters {
+				devices = append(devices, config.NewStaticDevice(config.Named{}, m))
+			}
+
+			site := &Site{
+				log:           util.NewLogger("foo"),
+				batteryMeters: devices,
+			}
+
+			site.updateBatteryMeters()
+
+			assert.InDelta(t, tc.expectedSoc, site.battery.Soc, 0.01,
+				"combined battery soc should be correct for: %s", tc.name)
+		})
+	}
+}
+
 func TestForcedBatteryChargeLimits(t *testing.T) {
 	limit := 80.0
 


### PR DESCRIPTION
## Summary

- Add warning log when a battery in a multi-battery setup has no capacity configured, causing inaccurate SOC weighting
- Add tests for the battery SOC weighted average calculation

## Test plan

- [ ] Run `go test ./core/ -run TestBatterySoc`
- [ ] Verify warning log appears when battery capacity is missing in multi-battery setup

Fixes #28123