### PR TITLE
Feature: Add battery control for Zendure devices

### DIFF
--- a/meter/zendure.go
+++ b/meter/zendure.go
@@ -15,8 +15,10 @@ func init() {
 }
 
 type Zendure struct {
-	usage string
-	conn  *zendure.Connection
+	usage             string
+	conn              *zendure.Connection
+	maxChargePower    int
+	maxDischargePower int
 }
 
 // NewZendureFromConfig creates a Zendure meter from generic config
@@ -42,15 +44,22 @@ func NewZendureFromConfig(other map[string]any) (api.Meter, error) {
 	}
 
 	m := &Zendure{
-		usage: cc.Usage,
-		conn:  conn,
+		usage:             cc.Usage,
+		conn:              conn,
+		maxChargePower:    int(cc.MaxChargePower),
+		maxDischargePower: int(cc.MaxDischargePower),
 	}
 
 	// decorate battery
 	if cc.Usage == "battery" {
+		var setBatteryMode func(api.BatteryMode) error
+		if m.maxDischargePower > 0 {
+			setBatteryMode = m.batteryMode()
+		}
+
 		return decorateMeterBattery(
 			m, nil, m.soc, cc.batteryCapacity.Decorator(),
-			cc.batterySocLimits.Decorator(), cc.batteryPowerLimits.Decorator(), nil,
+			cc.batterySocLimits.Decorator(), cc.batteryPowerLimits.Decorator(), setBatteryMode,
 		), nil
 	}
 
@@ -81,4 +90,38 @@ func (c *Zendure) soc() (float64, error) {
 		return 0, err
 	}
 	return float64(res.ElectricLevel), nil
+}
+
+// batteryMode implements the api.BatteryController interface
+func (c *Zendure) batteryMode() func(api.BatteryMode) error {
+	return func(mode api.BatteryMode) error {
+		switch mode {
+		case api.BatteryNormal:
+			props := map[string]int{
+				"outputLimit": c.maxDischargePower,
+			}
+			if c.maxChargePower > 0 {
+				props["acMode"] = 2 // output (discharge to home)
+			}
+			return c.conn.SetProperties(props)
+
+		case api.BatteryHold:
+			return c.conn.SetProperties(map[string]int{
+				"outputLimit": 0,
+			})
+
+		case api.BatteryCharge:
+			props := map[string]int{
+				"outputLimit": 0,
+			}
+			if c.maxChargePower > 0 {
+				props["acMode"] = 1 // input (charge from grid)
+				props["inputLimit"] = c.maxChargePower
+			}
+			return c.conn.SetProperties(props)
+
+		default:
+			return api.ErrNotAvailable
+		}
+	}
 }

--- a/meter/zendure/connection.go
+++ b/meter/zendure/connection.go
@@ -2,6 +2,7 @@ package zendure
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strconv"
 	"sync"
@@ -18,9 +19,11 @@ var (
 )
 
 type Connection struct {
-	log    *util.Logger
-	data   *util.Monitor[Data]
-	serial string
+	log        *util.Logger
+	data       *util.Monitor[Data]
+	serial     string
+	client     *mqtt.Client
+	writeTopic string
 }
 
 func NewConnection(region, account, serial string, timeout time.Duration) (*Connection, error) {
@@ -48,9 +51,11 @@ func NewConnection(region, account, serial string, timeout time.Duration) (*Conn
 	}
 
 	conn := &Connection{
-		log:    log,
-		data:   util.NewMonitor[Data](timeout),
-		serial: serial,
+		log:        log,
+		data:       util.NewMonitor[Data](timeout),
+		serial:     serial,
+		client:     client,
+		writeTopic: fmt.Sprintf("iot/%s/%s/properties/write", res.Data.AppKey, serial),
 	}
 
 	topic := res.Data.AppKey + "/#"
@@ -85,4 +90,21 @@ func (c *Connection) handler(data string) {
 
 func (c *Connection) Data() (Data, error) {
 	return c.data.Get()
+}
+
+// SetProperties publishes writable properties to the Zendure cloud MQTT API
+func (c *Connection) SetProperties(props map[string]int) error {
+	payload := struct {
+		Properties map[string]int `json:"properties"`
+	}{
+		Properties: props,
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal properties: %w", err)
+	}
+
+	c.client.Publish(c.writeTopic, false, string(data))
+	return nil
 }

--- a/meter/zendure/connection_test.go
+++ b/meter/zendure/connection_test.go
@@ -36,3 +36,42 @@ func TestHandler(t *testing.T) {
 		assert.Equal(t, Data{SolarInputPower: 125, Sn: "serial"}, res)
 	}
 }
+
+func TestHandlerMinSoc(t *testing.T) {
+	conn := &Connection{
+		log:    util.NewLogger("test"),
+		data:   util.NewMonitor[Data](time.Millisecond),
+		serial: "serial",
+	}
+
+	conn.handler(`{"minSoc":200,"outputLimit":600,"acMode":2,"sn":"serial"}`)
+	res, err := conn.data.Get()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 200, res.MinSoc)
+	assert.Equal(t, 600, res.OutputLimit)
+	assert.Equal(t, 2, res.AcMode)
+}
+
+func TestHandlerMerge(t *testing.T) {
+	conn := &Connection{
+		log:    util.NewLogger("test"),
+		data:   util.NewMonitor[Data](time.Millisecond),
+		serial: "serial",
+	}
+
+	// first message with some fields
+	conn.handler(`{"electricLevel":75,"outputLimit":600,"sn":"serial"}`)
+	res, err := conn.data.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, 75, res.ElectricLevel)
+	assert.Equal(t, 600, res.OutputLimit)
+
+	// second message merges minSoc without losing outputLimit
+	conn.handler(`{"minSoc":100,"electricLevel":74,"sn":"serial"}`)
+	res, err = conn.data.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, 100, res.MinSoc)
+	assert.Equal(t, 74, res.ElectricLevel)
+	assert.Equal(t, 600, res.OutputLimit) // preserved from previous message
+}

--- a/meter/zendure/types.go
+++ b/meter/zendure/types.go
@@ -46,6 +46,7 @@ type Data struct {
 	InputLimit      int    `json:"inputLimit"`      // 100,
 	InverseMaxPower int    `json:"inverseMaxPower"` // 1200,
 	MasterSwitch    bool   `json:"masterSwitch"`    // true,
+	MinSoc          int    `json:"minSoc"`          // 100 (= 10.0%)
 	OutputLimit     int    `json:"outputLimit"`     // 0,
 	OutputPackPower int    `json:"outputPackPower"` // 70,
 	PackInputPower  int    `json:"packInputPower"`  // 70,

--- a/templates/definition/meter/zendure-hyper.yaml
+++ b/templates/definition/meter/zendure-hyper.yaml
@@ -1,5 +1,6 @@
 template: zendure-hyper
 covers: [zendure]
+capabilities: ["battery-control"]
 products:
   - brand: Zendure
     description:

--- a/templates/definition/meter/zendure-solarflow-ac.yaml
+++ b/templates/definition/meter/zendure-solarflow-ac.yaml
@@ -1,5 +1,6 @@
 template: zendure-solarflow-ac
 covers: [zendure-solarflow-2400-ac]
+capabilities: ["battery-control"]
 products:
   - brand: Zendure
     description:
@@ -9,7 +10,19 @@ params:
     choice: ["battery"]
   - name: host
     required: true
+  - name: serial
+    required: true
+    description:
+      de: Seriennummer des Geräts
+      en: Device serial number
+    help:
+      de: "Zu finden in der Zendure App in den Einstellungen des Geräts"
+      en: "You can find this in the Zendure App in the settings of the device"
   - preset: battery-params
+  - name: maxchargepower
+    default: 1200 # W
+  - name: maxdischargepower
+    default: 800 # W
   - name: cache
     advanced: true
     default: 1s
@@ -25,4 +38,47 @@ render: |
     uri: http://{{ .host }}/properties/report
     jq: .properties.electricLevel
     cache: {{ .cache }}
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: sequence
+        set:
+        - source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"acMode":2}}'
+        - source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"outputLimit":{{ .maxdischargepower }}}}'
+    - case: 2 # hold
+      set:
+        source: http
+        uri: http://{{ .host }}/properties/write
+        method: POST
+        headers:
+        - content-type: application/json
+        body: '{"sn":"{{ .serial }}","properties":{"outputLimit":0}}'
+    - case: 3 # charge
+      set:
+        source: sequence
+        set:
+        - source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"outputLimit":0}}'
+        - source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"acMode":1,"inputLimit":{{ .maxchargepower }}}}'
   {{- include "battery-params" . }}

--- a/templates/definition/meter/zendure-solarflow-pro.yaml
+++ b/templates/definition/meter/zendure-solarflow-pro.yaml
@@ -1,4 +1,5 @@
 template: zendure-solarflow-pro
+capabilities: ["battery-control"]
 products:
   - brand: Zendure
     description:
@@ -7,9 +8,19 @@ params:
   - name: usage
     choice: ["pv", "battery"]
   - name: host
+  - name: serial
+    required: true
+    description:
+      de: Seriennummer des Geräts
+      en: Device serial number
+    help:
+      de: "Zu finden in der Zendure App in den Einstellungen des Geräts"
+      en: "You can find this in the Zendure App in the settings of the device"
   - name: maxacpower
     default: 800 # W
   - preset: battery-params
+  - name: maxdischargepower
+    default: 800 # W
   - name: capacity
     default: 1.92 # kWh
   - name: cache
@@ -36,5 +47,32 @@ render: |
     uri: http://{{ .host }}/properties/report
     jq: .properties.electricLevel
     cache: {{ .cache }}
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: http
+        uri: http://{{ .host }}/properties/write
+        method: POST
+        headers:
+        - content-type: application/json
+        body: '{"sn":"{{ .serial }}","properties":{"outputLimit":{{ .maxdischargepower }}}}'
+    - case: 2 # hold
+      set:
+        source: http
+        uri: http://{{ .host }}/properties/write
+        method: POST
+        headers:
+        - content-type: application/json
+        body: '{"sn":"{{ .serial }}","properties":{"outputLimit":0}}'
+    - case: 3 # charge
+      set:
+        source: http
+        uri: http://{{ .host }}/properties/write
+        method: POST
+        headers:
+        - content-type: application/json
+        body: '{"sn":"{{ .serial }}","properties":{"outputLimit":0}}'
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
## Summary

- Add battery mode control (normal/hold/charge) for Zendure Solarflow 800 Pro, Solarflow AC and Hyper 2000
- **Solarflow 800 Pro**: controls `outputLimit` to manage discharge
- **Solarflow AC**: controls `outputLimit`, `acMode`, and `inputLimit` via HTTP sequences for full charge/discharge control
- **Hyper 2000**: controls via `SetProperties` on the existing cloud MQTT connection
- Add `serial` parameter to Solarflow Pro and AC templates
- Add `maxchargepower`/`maxdischargepower` configuration with sensible defaults
- Add `MinSoc` field to Zendure data types
- Add `battery-control` capability to all Zendure templates
- Add tests for new data fields and MQTT message merging

## Test plan

- [ ] Verify battery control modes on Solarflow 800 Pro (outputLimit changes)
- [ ] Verify battery control modes on Solarflow AC (acMode + outputLimit + inputLimit)
- [ ] Verify Hyper 2000 battery control via cloud MQTT
- [ ] Run `go test ./meter/zendure/`

Fixes #28127