### PR TITLE
Versicharge: add mA regulation

### DIFF
--- a/charger/versicharge.go
+++ b/charger/versicharge.go
@@ -127,13 +127,22 @@ func (wb *Versicharge) Enable(enable bool) error {
 
 // MaxCurrent implements the api.Charger interface
 func (wb *Versicharge) MaxCurrent(current int64) error {
+	return wb.MaxCurrentMillis(float64(current))
+}
+
+var _ api.ChargerEx = (*Versicharge)(nil)
+
+// MaxCurrentMillis implements the api.ChargerEx interface
+func (wb *Versicharge) MaxCurrentMillis(current float64) error {
 	if current < 6 {
-		return fmt.Errorf("invalid current %d", current)
+		return fmt.Errorf("invalid current %.1f", current)
 	}
 
-	_, err := wb.conn.WriteSingleRegister(versiRegMaxCurrent, uint16(current))
+	curr := uint16(current * 100)
+
+	_, err := wb.conn.WriteSingleRegister(versiRegMaxCurrent, curr)
 	if err == nil {
-		wb.current = uint16(current)
+		wb.current = curr
 	}
 
 	return err

--- a/templates/definition/charger/versicharge.yaml
+++ b/templates/definition/charger/versicharge.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Siemens
     description:
       generic: Versicharge GEN3
+capabilities: ["mA"]
 requirements:
   evcc: ["sponsorship"]
   description:


### PR DESCRIPTION
Based on the latest versicharge modbus map, mA regulation in 0.01A increments is added. Reference: https://support.industry.siemens.com/cs/attachments/109814359/versicharge_wallbox_modBus_map_en-US.pdf?download=true

For Register 1633 values from 0-100 are interpreted in A. Values from 101-8000 are in 0.01A units. Example: 6 or 600 are 6A. 850 is 8.5A.

api.ChargerEx interface is implemented with MaxCurrentMillis function. MaxCurrent function is changed to call MaxCurrentMillis based on keba-modbus implementation. Reading currents is still available in A only as uint16 value.