### PR TITLE
Fix `this.updatePlanPreviewDebounced is null`

### DIFF
--- a/assets/js/components/ChargingPlans/PlansSettings.vue
+++ b/assets/js/components/ChargingPlans/PlansSettings.vue
@@ -207,7 +207,7 @@ export default defineComponent({
 			},
 		},
 	},
-	mounted(): void {
+	created(): void {
 		this.updatePlanPreviewDebounced = debounceLeading(
 			async () => await this.updatePreviewPlan(),
 			300
@@ -216,6 +216,8 @@ export default defineComponent({
 			async () => await this.updateActivePlan(),
 			300
 		);
+	},
+	mounted(): void {
 		this.updatePlanDebounced();
 	},
 	methods: {


### PR DESCRIPTION
`ChargingPlanStaticSettings.mounted()` can emit plan-preview before the parent `PlansSettings.mounted()` has a chance to assign the debounced functions, causing `null` errors.

Moving initialization to `created()` ensures the functions exist before any child lifecycle hooks fire.