### PR TITLE
feat: Add a native IoTaWatt meter

### DIFF
--- a/meter/iotawatt.go
+++ b/meter/iotawatt.go
@@ -2,7 +2,6 @@ package meter
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/meter/iotawatt"
@@ -19,10 +18,7 @@ func NewIoTaWattFromConfig(other map[string]any) (api.Meter, error) {
 		URI      string
 		Channels []string
 		Usage    string
-		Cache    time.Duration
-	}{
-		Cache: time.Second,
-	}
+	}{}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -40,16 +36,16 @@ func NewIoTaWattFromConfig(other map[string]any) (api.Meter, error) {
 		return nil, fmt.Errorf("missing channels")
 	}
 
-	return NewIoTaWatt(cc.URI, channels, cc.Cache)
+	return NewIoTaWatt(cc.URI, channels)
 }
 
 // NewIoTaWatt creates an IoTaWatt meter
-func NewIoTaWatt(uri string, channels []string, cache time.Duration) (api.Meter, error) {
+func NewIoTaWatt(uri string, channels []string) (api.Meter, error) {
 	if len(channels) != 1 && len(channels) != 3 {
 		return nil, fmt.Errorf("channels must have 1 (single-phase) or 3 (three-phase) entries, got %d", len(channels))
 	}
 
-	conn, err := iotawatt.NewConnection(uri, cache)
+	conn, err := iotawatt.NewConnection(uri)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/iotawatt.go
+++ b/meter/iotawatt.go
@@ -1,0 +1,112 @@
+package meter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/meter/iotawatt"
+	"github.com/evcc-io/evcc/util"
+)
+
+func init() {
+	registry.Add("iotawatt", NewIoTaWattFromConfig)
+}
+
+// NewIoTaWattFromConfig creates an IoTaWatt meter from generic config
+func NewIoTaWattFromConfig(other map[string]any) (api.Meter, error) {
+	cc := struct {
+		URI      string
+		Channels []string
+		Usage    string
+		Cache    time.Duration
+	}{
+		Cache: time.Second,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	// filter empty channel names (from unset template params)
+	channels := make([]string, 0, len(cc.Channels))
+	for _, ch := range cc.Channels {
+		if ch != "" {
+			channels = append(channels, ch)
+		}
+	}
+
+	if len(channels) == 0 {
+		return nil, fmt.Errorf("missing channels")
+	}
+
+	return NewIoTaWatt(cc.URI, channels, cc.Cache)
+}
+
+// NewIoTaWatt creates an IoTaWatt meter
+func NewIoTaWatt(uri string, channels []string, cache time.Duration) (api.Meter, error) {
+	if len(channels) != 1 && len(channels) != 3 {
+		return nil, fmt.Errorf("channels must have 1 (single-phase) or 3 (three-phase) entries, got %d", len(channels))
+	}
+
+	conn, err := iotawatt.NewConnection(uri, cache)
+	if err != nil {
+		return nil, err
+	}
+
+	// validate all channels are Watts series
+	if _, err := conn.ValidateSeries(channels, "Watts"); err != nil {
+		return nil, err
+	}
+
+	// power getter — sum all channels
+	powerG := func() (float64, error) {
+		values, err := conn.QueryPower(channels...)
+		if err != nil {
+			return 0, err
+		}
+		var sum float64
+		for _, v := range values {
+			sum += v
+		}
+		return sum, nil
+	}
+
+	m, _ := NewConfigurable(powerG)
+
+	// energy getter — sum Wh across all channels
+	energyG := func() (float64, error) {
+		return conn.TotalEnergy(channels...)
+	}
+
+	// per-phase getters (3-phase only)
+	var currentsG, voltagesG, powersG func() (float64, float64, float64, error)
+
+	if len(channels) == 3 {
+		powersG = func() (float64, float64, float64, error) {
+			values, err := conn.QueryPower(channels...)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			return values[0], values[1], values[2], nil
+		}
+
+		currentsG = func() (float64, float64, float64, error) {
+			values, err := conn.QueryCurrents(channels...)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			return values[0], values[1], values[2], nil
+		}
+
+		voltagesG = func() (float64, float64, float64, error) {
+			values, err := conn.QueryVoltages(channels...)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			return values[0], values[1], values[2], nil
+		}
+	}
+
+	return m.Decorate(energyG, currentsG, voltagesG, powersG, nil), nil
+}

--- a/meter/iotawatt/connection.go
+++ b/meter/iotawatt/connection.go
@@ -1,0 +1,192 @@
+package iotawatt
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+)
+
+var errMissingURI = errors.New("missing uri")
+
+// Connection is the IoTaWatt connection
+type Connection struct {
+	*request.Helper
+	uri   string
+	cache time.Duration
+
+	mu          sync.Mutex
+	lastEnergy  time.Time
+	totalEnergy float64
+}
+
+// NewConnection creates an IoTaWatt connection
+func NewConnection(uri string, cache time.Duration) (*Connection, error) {
+	if uri == "" {
+		return nil, errMissingURI
+	}
+
+	log := util.NewLogger("iotawatt")
+
+	uri = util.DefaultScheme(strings.TrimRight(uri, "/"), "http")
+
+	c := &Connection{
+		Helper: request.NewHelper(log),
+		uri:    uri,
+		cache:  cache,
+	}
+
+	return c, nil
+}
+
+// ShowSeries returns the available IoTaWatt series (inputs and outputs).
+func (c *Connection) ShowSeries() ([]Series, error) {
+	var res ShowSeriesResponse
+	err := c.GetJSON(fmt.Sprintf("%s/query?show=series", c.uri), &res)
+	return res.Series, err
+}
+
+// DeviceConfig returns the IoTaWatt device configuration from /config.txt.
+func (c *Connection) DeviceConfig() (*DeviceConfig, error) {
+	var res DeviceConfig
+	err := c.GetJSON(fmt.Sprintf("%s/config.txt", c.uri), &res)
+	return &res, err
+}
+
+// ValidateSeries checks that all given series names exist on the device
+// and have one of the expected units. It returns the actual unit of the
+// first series (all must share the same unit).
+func (c *Connection) ValidateSeries(names []string, allowedUnits ...string) (string, error) {
+	if len(names) == 0 {
+		return "", nil
+	}
+
+	series, err := c.ShowSeries()
+	if err != nil {
+		return "", fmt.Errorf("fetching series: %w", err)
+	}
+
+	available := make(map[string]string, len(series))
+	for _, s := range series {
+		available[s.Name] = s.Unit
+	}
+
+	var unit string
+	for _, name := range names {
+		got, ok := available[name]
+		if !ok {
+			return "", fmt.Errorf("unknown iotawatt series: %s", name)
+		}
+
+		// check allowed units
+		allowed := false
+		for _, u := range allowedUnits {
+			if strings.EqualFold(got, u) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return "", fmt.Errorf("iotawatt series %s has unit %q, expected one of %v", name, got, allowedUnits)
+		}
+
+		// all series must share the same unit
+		if unit == "" {
+			unit = got
+		} else if !strings.EqualFold(unit, got) {
+			return "", fmt.Errorf("iotawatt phase series have mixed units: %s is %q, but expected %q", name, got, unit)
+		}
+	}
+
+	return unit, nil
+}
+
+// queryValues executes a query for the given channels and unit modifier.
+// It returns one float64 per channel.
+func (c *Connection) queryValues(unit string, channels ...string) ([]float64, error) {
+	if len(channels) == 0 {
+		return nil, errors.New("no channels specified")
+	}
+
+	// build select parameter: [ch1.unit,ch2.unit,...]
+	parts := make([]string, len(channels))
+	for i, ch := range channels {
+		parts[i] = ch + "." + unit
+	}
+	sel := "[" + strings.Join(parts, ",") + "]"
+
+	uri := fmt.Sprintf("%s/query?select=%s&begin=s-10s&end=s&group=all",
+		c.uri, url.QueryEscape(sel))
+
+	var res [][]float64
+	if err := c.GetJSON(uri, &res); err != nil {
+		return nil, err
+	}
+
+	if len(res) != 1 || len(res[0]) != len(channels) {
+		return nil, fmt.Errorf("unexpected query response: expected 1 row with %d values, got %d rows", len(channels), len(res))
+	}
+
+	return res[0], nil
+}
+
+// QueryPower returns the current power in Watts for each channel.
+func (c *Connection) QueryPower(channels ...string) ([]float64, error) {
+	return c.queryValues("watts", channels...)
+}
+
+// QueryCurrents returns the current in Amps for each channel.
+func (c *Connection) QueryCurrents(channels ...string) ([]float64, error) {
+	return c.queryValues("amps", channels...)
+}
+
+// QueryVoltages returns the voltage in Volts for each channel.
+func (c *Connection) QueryVoltages(channels ...string) ([]float64, error) {
+	return c.queryValues("volts", channels...)
+}
+
+// TotalEnergy returns the accumulated energy in kWh for the given channels.
+// It uses delta-based accumulation: each call queries Wh since the last call
+// and adds it to a running counter. Multiple channels are summed.
+func (c *Connection) TotalEnergy(channels ...string) (float64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+
+	// first call: seed the timestamp, return 0
+	if c.lastEnergy.IsZero() {
+		c.lastEnergy = now
+		return 0, nil
+	}
+
+	begin := fmt.Sprintf("%d", c.lastEnergy.Unix())
+
+	parts := make([]string, len(channels))
+	for i, ch := range channels {
+		parts[i] = ch + ".wh"
+	}
+	sel := url.QueryEscape("[" + strings.Join(parts, ",") + "]")
+
+	uri := fmt.Sprintf("%s/query?select=%s&begin=%s&end=s&group=all",
+		c.uri, sel, begin)
+
+	var res [][]float64
+	if err := c.GetJSON(uri, &res); err != nil {
+		return c.totalEnergy, err
+	}
+
+	if len(res) == 1 && len(res[0]) == len(channels) {
+		for _, wh := range res[0] {
+			c.totalEnergy += wh / 1000 // Wh to kWh
+		}
+		c.lastEnergy = now
+	}
+
+	return c.totalEnergy, nil
+}

--- a/meter/iotawatt/connection.go
+++ b/meter/iotawatt/connection.go
@@ -17,8 +17,7 @@ var errMissingURI = errors.New("missing uri")
 // Connection is the IoTaWatt connection
 type Connection struct {
 	*request.Helper
-	uri   string
-	cache time.Duration
+	uri string
 
 	mu          sync.Mutex
 	lastEnergy  time.Time
@@ -26,7 +25,7 @@ type Connection struct {
 }
 
 // NewConnection creates an IoTaWatt connection
-func NewConnection(uri string, cache time.Duration) (*Connection, error) {
+func NewConnection(uri string) (*Connection, error) {
 	if uri == "" {
 		return nil, errMissingURI
 	}
@@ -38,7 +37,6 @@ func NewConnection(uri string, cache time.Duration) (*Connection, error) {
 	c := &Connection{
 		Helper: request.NewHelper(log),
 		uri:    uri,
-		cache:  cache,
 	}
 
 	return c, nil

--- a/meter/iotawatt/connection_test.go
+++ b/meter/iotawatt/connection_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
+
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,7 +26,7 @@ func TestShowSeries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, time.Second)
+	conn, err := NewConnection(srv.URL)
 	require.NoError(t, err)
 
 	series, err := conn.ShowSeries()
@@ -55,7 +55,7 @@ func TestValidateSeries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, time.Second)
+	conn, err := NewConnection(srv.URL)
 	require.NoError(t, err)
 
 	// valid Watts series
@@ -112,7 +112,7 @@ func TestQueryPower(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, time.Second)
+	conn, err := NewConnection(srv.URL)
 	require.NoError(t, err)
 
 	t.Run("single channel", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestQueryCurrents(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, time.Second)
+	conn, err := NewConnection(srv.URL)
 	require.NoError(t, err)
 
 	values, err := conn.QueryCurrents("Grid_A", "Grid_B", "Grid_C")
@@ -149,7 +149,7 @@ func TestQueryCurrents(t *testing.T) {
 }
 
 func TestQueryPowerNoChannels(t *testing.T) {
-	conn, err := NewConnection("http://localhost", time.Second)
+	conn, err := NewConnection("http://localhost")
 	require.NoError(t, err)
 
 	_, err = conn.QueryPower()
@@ -173,7 +173,7 @@ func TestQueryPowerUnexpectedResponse(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			conn, err := NewConnection(srv.URL, time.Second)
+			conn, err := NewConnection(srv.URL)
 			require.NoError(t, err)
 
 			_, err = conn.QueryPower("GridNet")
@@ -202,7 +202,7 @@ func TestTotalEnergy(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, time.Second)
+	conn, err := NewConnection(srv.URL)
 	require.NoError(t, err)
 
 	// first call seeds the timestamp, returns 0
@@ -230,7 +230,7 @@ func TestTotalEnergyOnError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	conn, err := NewConnection(srv.URL, time.Second)
+	conn, err := NewConnection(srv.URL)
 	require.NoError(t, err)
 
 	// seed
@@ -244,19 +244,19 @@ func TestTotalEnergyOnError(t *testing.T) {
 }
 
 func TestNewConnectionMissingURI(t *testing.T) {
-	_, err := NewConnection("", time.Second)
+	_, err := NewConnection("")
 	assert.ErrorContains(t, err, "missing uri")
 }
 
 func TestNewConnectionDefaultScheme(t *testing.T) {
 	// should not panic with a hostname-only URI
-	conn, err := NewConnection("iotawatt.local", time.Second)
+	conn, err := NewConnection("iotawatt.local")
 	require.NoError(t, err)
 	assert.Contains(t, conn.uri, "http://")
 }
 
 func TestNewConnectionTrailingSlash(t *testing.T) {
-	conn, err := NewConnection("http://iotawatt.local/", time.Second)
+	conn, err := NewConnection("http://iotawatt.local/")
 	require.NoError(t, err)
 	assert.Equal(t, "http://iotawatt.local", conn.uri)
 }

--- a/meter/iotawatt/connection_test.go
+++ b/meter/iotawatt/connection_test.go
@@ -1,0 +1,275 @@
+package iotawatt
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShowSeries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/query", r.URL.Path)
+		assert.Equal(t, "series", r.URL.Query().Get("show"))
+
+		fmt.Fprint(w, `{"series":[
+			{"name":"Input_0","unit":"Volts"},
+			{"name":"Grid_A","unit":"Watts"},
+			{"name":"Solar","unit":"Watts"},
+			{"name":"GridNet","unit":"Watts"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	conn, err := NewConnection(srv.URL, time.Second)
+	require.NoError(t, err)
+
+	series, err := conn.ShowSeries()
+	require.NoError(t, err)
+
+	assert.Len(t, series, 4)
+	assert.Equal(t, "Input_0", series[0].Name)
+	assert.Equal(t, "Volts", series[0].Unit)
+	assert.Equal(t, "GridNet", series[3].Name)
+	assert.Equal(t, "Watts", series[3].Unit)
+}
+
+func TestValidateSeries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"series":[
+			{"name":"Input_0","unit":"Volts"},
+			{"name":"Grid_A","unit":"Watts"},
+			{"name":"Grid_B","unit":"Watts"},
+			{"name":"Grid_C","unit":"Watts"},
+			{"name":"Grid_A_Current","unit":"Amps"},
+			{"name":"Grid_B_Current","unit":"Amps"},
+			{"name":"Grid_C_Current","unit":"Amps"},
+			{"name":"GridNet","unit":"Watts"},
+			{"name":"Solar","unit":"Watts"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	conn, err := NewConnection(srv.URL, time.Second)
+	require.NoError(t, err)
+
+	// valid Watts series
+	unit, err := conn.ValidateSeries([]string{"GridNet"}, "Watts")
+	assert.NoError(t, err)
+	assert.Equal(t, "Watts", unit)
+
+	// valid Watts phases
+	unit, err = conn.ValidateSeries([]string{"Grid_A", "Grid_B", "Grid_C"}, "Watts", "Amps")
+	assert.NoError(t, err)
+	assert.Equal(t, "Watts", unit)
+
+	// valid Amps phases
+	unit, err = conn.ValidateSeries([]string{"Grid_A_Current", "Grid_B_Current", "Grid_C_Current"}, "Watts", "Amps")
+	assert.NoError(t, err)
+	assert.Equal(t, "Amps", unit)
+
+	// unknown series
+	_, err = conn.ValidateSeries([]string{"NonExistent"}, "Watts")
+	assert.ErrorContains(t, err, "unknown iotawatt series: NonExistent")
+
+	// wrong unit
+	_, err = conn.ValidateSeries([]string{"Input_0"}, "Watts")
+	assert.ErrorContains(t, err, "has unit")
+
+	// mixed units
+	_, err = conn.ValidateSeries([]string{"Grid_A", "Grid_A_Current", "Grid_C"}, "Watts", "Amps")
+	assert.ErrorContains(t, err, "mixed units")
+
+	// empty list
+	unit, err = conn.ValidateSeries(nil, "Watts")
+	assert.NoError(t, err)
+	assert.Equal(t, "", unit)
+}
+
+func TestQueryPower(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/query", r.URL.Path)
+
+		sel := r.URL.Query().Get("select")
+		assert.Equal(t, "s-10s", r.URL.Query().Get("begin"))
+		assert.Equal(t, "s", r.URL.Query().Get("end"))
+		assert.Equal(t, "all", r.URL.Query().Get("group"))
+
+		switch sel {
+		case "[GridNet.watts]":
+			fmt.Fprint(w, `[[16554.17]]`)
+		case "[Grid_A.watts,Grid_B.watts,Grid_C.watts]":
+			fmt.Fprint(w, `[[5370,4992,5935]]`)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "unexpected select: %s", sel)
+		}
+	}))
+	defer srv.Close()
+
+	conn, err := NewConnection(srv.URL, time.Second)
+	require.NoError(t, err)
+
+	t.Run("single channel", func(t *testing.T) {
+		values, err := conn.QueryPower("GridNet")
+		require.NoError(t, err)
+		assert.Len(t, values, 1)
+		assert.InDelta(t, 16554.17, values[0], 0.01)
+	})
+
+	t.Run("multiple channels", func(t *testing.T) {
+		values, err := conn.QueryPower("Grid_A", "Grid_B", "Grid_C")
+		require.NoError(t, err)
+		assert.Len(t, values, 3)
+		assert.Equal(t, 5370.0, values[0])
+		assert.Equal(t, 4992.0, values[1])
+		assert.Equal(t, 5935.0, values[2])
+	})
+}
+
+func TestQueryCurrents(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sel := r.URL.Query().Get("select")
+		assert.Equal(t, "[Grid_A.amps,Grid_B.amps,Grid_C.amps]", sel)
+		fmt.Fprint(w, `[[19.2,17.2,22.6]]`)
+	}))
+	defer srv.Close()
+
+	conn, err := NewConnection(srv.URL, time.Second)
+	require.NoError(t, err)
+
+	values, err := conn.QueryCurrents("Grid_A", "Grid_B", "Grid_C")
+	require.NoError(t, err)
+	assert.Equal(t, []float64{19.2, 17.2, 22.6}, values)
+}
+
+func TestQueryPowerNoChannels(t *testing.T) {
+	conn, err := NewConnection("http://localhost", time.Second)
+	require.NoError(t, err)
+
+	_, err = conn.QueryPower()
+	assert.ErrorContains(t, err, "no channels specified")
+}
+
+func TestQueryPowerUnexpectedResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{"empty response", `[]`},
+		{"wrong column count", `[[1,2]]`},
+		{"multiple rows", `[[1],[2]]`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, tc.response)
+			}))
+			defer srv.Close()
+
+			conn, err := NewConnection(srv.URL, time.Second)
+			require.NoError(t, err)
+
+			_, err = conn.QueryPower("GridNet")
+			assert.ErrorContains(t, err, "unexpected query response")
+		})
+	}
+}
+
+func TestTotalEnergy(t *testing.T) {
+	var callCount int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
+		sel := r.URL.Query().Get("select")
+		assert.Equal(t, "[Solar.wh]", sel)
+		assert.Equal(t, "s", r.URL.Query().Get("end"))
+		assert.Equal(t, "all", r.URL.Query().Get("group"))
+
+		// begin should be a unix timestamp (not empty)
+		begin := r.URL.Query().Get("begin")
+		assert.NotEmpty(t, begin)
+
+		// return 500 Wh for each call
+		fmt.Fprint(w, `[[500]]`)
+	}))
+	defer srv.Close()
+
+	conn, err := NewConnection(srv.URL, time.Second)
+	require.NoError(t, err)
+
+	// first call seeds the timestamp, returns 0
+	energy, err := conn.TotalEnergy("Solar")
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, energy)
+	assert.Equal(t, 0, callCount)
+
+	// second call queries and accumulates
+	energy, err = conn.TotalEnergy("Solar")
+	require.NoError(t, err)
+	assert.Equal(t, 0.5, energy) // 500 Wh = 0.5 kWh
+	assert.Equal(t, 1, callCount)
+
+	// third call accumulates further
+	energy, err = conn.TotalEnergy("Solar")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, energy) // 500 + 500 Wh = 1.0 kWh
+	assert.Equal(t, 2, callCount)
+}
+
+func TestTotalEnergyOnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	conn, err := NewConnection(srv.URL, time.Second)
+	require.NoError(t, err)
+
+	// seed
+	_, err = conn.TotalEnergy("Solar")
+	require.NoError(t, err)
+
+	// on error, returns last known total
+	energy, err := conn.TotalEnergy("Solar")
+	assert.Error(t, err)
+	assert.Equal(t, 0.0, energy)
+}
+
+func TestNewConnectionMissingURI(t *testing.T) {
+	_, err := NewConnection("", time.Second)
+	assert.ErrorContains(t, err, "missing uri")
+}
+
+func TestNewConnectionDefaultScheme(t *testing.T) {
+	// should not panic with a hostname-only URI
+	conn, err := NewConnection("iotawatt.local", time.Second)
+	require.NoError(t, err)
+	assert.Contains(t, conn.uri, "http://")
+}
+
+func TestNewConnectionTrailingSlash(t *testing.T) {
+	conn, err := NewConnection("http://iotawatt.local/", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "http://iotawatt.local", conn.uri)
+}
+
+func TestUnmarshalShowSeriesResponse(t *testing.T) {
+	jsonstr := `{"series":[{"name":"voltage","unit":"Volts"},{"name":"mains1","unit":"Watts"},{"name":"solar","unit":"Watts"}]}`
+
+	var res ShowSeriesResponse
+	require.NoError(t, json.Unmarshal([]byte(jsonstr), &res))
+
+	assert.Len(t, res.Series, 3)
+	assert.Equal(t, "voltage", res.Series[0].Name)
+	assert.Equal(t, "Volts", res.Series[0].Unit)
+	assert.Equal(t, "mains1", res.Series[1].Name)
+	assert.Equal(t, "Watts", res.Series[1].Unit)
+}

--- a/meter/iotawatt/service.go
+++ b/meter/iotawatt/service.go
@@ -19,8 +19,8 @@ func init() {
 
 // configResponse is the response from the /config service endpoint.
 type configResponse struct {
-	ThreePhase bool              `json:"threephase"`
-	Phases     map[string]int    `json:"phases"` // input name -> phase (1, 2, 3)
+	ThreePhase bool           `json:"threephase"`
+	Phases     map[string]int `json:"phases"` // input name -> phase (1, 2, 3)
 }
 
 func connectionFromRequest(req *http.Request) (*Connection, error) {
@@ -29,7 +29,7 @@ func connectionFromRequest(req *http.Request) (*Connection, error) {
 		return nil, errMissingURI
 	}
 
-	return NewConnection(uri, 0)
+	return NewConnection(uri)
 }
 
 // getSeries returns the available Watts series names from the IoTaWatt device.

--- a/meter/iotawatt/service.go
+++ b/meter/iotawatt/service.go
@@ -1,0 +1,103 @@
+package iotawatt
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/evcc-io/evcc/server/service"
+	"github.com/evcc-io/evcc/util"
+)
+
+func init() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /series", getSeries)
+	mux.HandleFunc("GET /config", getConfig)
+
+	service.Register("iotawatt", mux)
+}
+
+// configResponse is the response from the /config service endpoint.
+type configResponse struct {
+	ThreePhase bool              `json:"threephase"`
+	Phases     map[string]int    `json:"phases"` // input name -> phase (1, 2, 3)
+}
+
+func connectionFromRequest(req *http.Request) (*Connection, error) {
+	uri := util.DefaultScheme(strings.TrimSuffix(req.URL.Query().Get("uri"), "/"), "http")
+	if uri == "" {
+		return nil, errMissingURI
+	}
+
+	return NewConnection(uri, 0)
+}
+
+// getSeries returns the available Watts series names from the IoTaWatt device.
+func getSeries(w http.ResponseWriter, req *http.Request) {
+	conn, err := connectionFromRequest(req)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(util.ErrorAsJson(err))
+		return
+	}
+
+	series, err := conn.ShowSeries()
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(util.ErrorAsJson(err))
+		return
+	}
+
+	// filter to Watts series only — these are the ones usable for power/current/energy
+	unit := req.URL.Query().Get("unit")
+	if unit == "" {
+		unit = "Watts"
+	}
+
+	var result []string
+	for _, s := range series {
+		if strings.EqualFold(s.Unit, unit) {
+			result = append(result, s.Name)
+		}
+	}
+
+	w.Header().Set("Cache-Control", "max-age=10")
+	json.NewEncoder(w).Encode(result)
+}
+
+// getConfig returns phase configuration from the IoTaWatt device.
+// The UI uses this to determine single-phase vs three-phase mode and
+// to know which phase each input belongs to.
+func getConfig(w http.ResponseWriter, req *http.Request) {
+	conn, err := connectionFromRequest(req)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(util.ErrorAsJson(err))
+		return
+	}
+
+	cfg, err := conn.DeviceConfig()
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(util.ErrorAsJson(err))
+		return
+	}
+
+	phases := make(map[string]int)
+	phasesSeen := make(map[int]bool)
+	for _, inp := range cfg.Inputs {
+		if inp != nil && inp.Type == "CT" {
+			p := inp.Phase()
+			phases[inp.Name] = p
+			phasesSeen[p] = true
+		}
+	}
+
+	res := configResponse{
+		ThreePhase: len(phasesSeen) == 3,
+		Phases:     phases,
+	}
+
+	w.Header().Set("Cache-Control", "max-age=10")
+	json.NewEncoder(w).Encode(res)
+}

--- a/meter/iotawatt/service_test.go
+++ b/meter/iotawatt/service_test.go
@@ -1,0 +1,160 @@
+package iotawatt
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockIoTaWatt() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/config.txt":
+			fmt.Fprint(w, `{
+				"derive3ph": true,
+				"inputs": [
+					{"channel":0,"name":"Input_0","type":"VT","vphase":0},
+					{"channel":1,"name":"Grid_A","type":"CT","vphase":0},
+					{"channel":2,"name":"Grid_B","type":"CT","vphase":120},
+					{"channel":3,"name":"Grid_C","type":"CT","vphase":240},
+					{"channel":5,"name":"Solar_A","type":"CT","vphase":0},
+					{"channel":7,"name":"Solar_B","type":"CT","vphase":120},
+					{"channel":10,"name":"Solar_C","type":"CT","vphase":240},
+					null,
+					{"channel":12,"name":"Pool","type":"CT","vphase":240}
+				],
+				"outputs": [
+					{"name":"GridNet","units":"Watts"},
+					{"name":"Solar","units":"Watts"}
+				]
+			}`)
+		case r.URL.Query().Get("show") == "series":
+			fmt.Fprint(w, `{"series":[
+				{"name":"Input_0","unit":"Volts"},
+				{"name":"Grid_A","unit":"Watts"},
+				{"name":"Grid_B","unit":"Watts"},
+				{"name":"Grid_C","unit":"Watts"},
+				{"name":"Solar_A","unit":"Watts"},
+				{"name":"Solar_B","unit":"Watts"},
+				{"name":"Solar_C","unit":"Watts"},
+				{"name":"Pool","unit":"Watts"},
+				{"name":"GridNet","unit":"Watts"},
+				{"name":"Solar","unit":"Watts"},
+				{"name":"Grid_A_Current","unit":"Amps"}
+			]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestGetSeriesService(t *testing.T) {
+	device := newMockIoTaWatt()
+	defer device.Close()
+
+	t.Run("FilterWatts", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/series?uri="+device.URL, nil)
+		w := httptest.NewRecorder()
+
+		getSeries(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var result []string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		assert.Equal(t, []string{"Grid_A", "Grid_B", "Grid_C", "Solar_A", "Solar_B", "Solar_C", "Pool", "GridNet", "Solar"}, result)
+	})
+
+	t.Run("FilterAmps", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/series?uri="+device.URL+"&unit=Amps", nil)
+		w := httptest.NewRecorder()
+
+		getSeries(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var result []string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		assert.Equal(t, []string{"Grid_A_Current"}, result)
+	})
+
+	t.Run("MissingURI", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/series", nil)
+		w := httptest.NewRecorder()
+
+		getSeries(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestGetConfigService(t *testing.T) {
+	device := newMockIoTaWatt()
+	defer device.Close()
+
+	t.Run("ThreePhase", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/config?uri="+device.URL, nil)
+		w := httptest.NewRecorder()
+
+		getConfig(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var result configResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+		assert.True(t, result.ThreePhase)
+		assert.Equal(t, 1, result.Phases["Grid_A"])
+		assert.Equal(t, 2, result.Phases["Grid_B"])
+		assert.Equal(t, 3, result.Phases["Grid_C"])
+		assert.Equal(t, 1, result.Phases["Solar_A"])
+		assert.Equal(t, 2, result.Phases["Solar_B"])
+		assert.Equal(t, 3, result.Phases["Solar_C"])
+		assert.Equal(t, 3, result.Phases["Pool"])
+		// VT (Input_0) should not appear
+		_, ok := result.Phases["Input_0"]
+		assert.False(t, ok)
+	})
+
+	t.Run("SinglePhase", func(t *testing.T) {
+		device := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{
+				"derive3ph": false,
+				"inputs": [
+					{"channel":0,"name":"Voltage","type":"VT","vphase":0},
+					{"channel":1,"name":"Grid","type":"CT","vphase":0},
+					{"channel":2,"name":"Solar","type":"CT","vphase":0}
+				]
+			}`)
+		}))
+		defer device.Close()
+
+		req := httptest.NewRequest("GET", "/config?uri="+device.URL, nil)
+		w := httptest.NewRecorder()
+
+		getConfig(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var result configResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+		assert.False(t, result.ThreePhase)
+		assert.Equal(t, 1, result.Phases["Grid"])
+		assert.Equal(t, 1, result.Phases["Solar"])
+	})
+
+	t.Run("MissingURI", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/config", nil)
+		w := httptest.NewRecorder()
+
+		getConfig(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/meter/iotawatt/types.go
+++ b/meter/iotawatt/types.go
@@ -13,17 +13,17 @@ type ShowSeriesResponse struct {
 
 // DeviceConfig is the IoTaWatt device configuration from /config.txt.
 type DeviceConfig struct {
-	Inputs    []*InputConfig `json:"inputs"`
+	Inputs    []*InputConfig  `json:"inputs"`
 	Outputs   []*OutputConfig `json:"outputs"`
-	Derive3Ph bool           `json:"derive3ph"`
+	Derive3Ph bool            `json:"derive3ph"`
 }
 
 // InputConfig describes an input channel in the device config.
 type InputConfig struct {
 	Channel int     `json:"channel"`
 	Name    string  `json:"name"`
-	Type    string  `json:"type"`    // "VT" or "CT"
-	VPhase  float64 `json:"vphase"`  // 0=L1, 120=L2, 240=L3
+	Type    string  `json:"type"`   // "VT" or "CT"
+	VPhase  float64 `json:"vphase"` // 0=L1, 120=L2, 240=L3
 }
 
 // OutputConfig describes an output in the device config.

--- a/meter/iotawatt/types.go
+++ b/meter/iotawatt/types.go
@@ -1,0 +1,45 @@
+package iotawatt
+
+// Series describes an available IoTaWatt input or output series.
+type Series struct {
+	Name string `json:"name"`
+	Unit string `json:"unit"`
+}
+
+// ShowSeriesResponse is the response from the query?show=series endpoint.
+type ShowSeriesResponse struct {
+	Series []Series `json:"series"`
+}
+
+// DeviceConfig is the IoTaWatt device configuration from /config.txt.
+type DeviceConfig struct {
+	Inputs    []*InputConfig `json:"inputs"`
+	Outputs   []*OutputConfig `json:"outputs"`
+	Derive3Ph bool           `json:"derive3ph"`
+}
+
+// InputConfig describes an input channel in the device config.
+type InputConfig struct {
+	Channel int     `json:"channel"`
+	Name    string  `json:"name"`
+	Type    string  `json:"type"`    // "VT" or "CT"
+	VPhase  float64 `json:"vphase"`  // 0=L1, 120=L2, 240=L3
+}
+
+// OutputConfig describes an output in the device config.
+type OutputConfig struct {
+	Name  string `json:"name"`
+	Units string `json:"units"`
+}
+
+// Phase returns the phase number (1, 2, or 3) based on VPhase.
+func (c *InputConfig) Phase() int {
+	switch {
+	case c.VPhase >= 100 && c.VPhase < 140:
+		return 2
+	case c.VPhase >= 220:
+		return 3
+	default:
+		return 1
+	}
+}

--- a/meter/iotawatt_test.go
+++ b/meter/iotawatt_test.go
@@ -1,0 +1,224 @@
+package meter
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// iotawattHandler serves mock IoTaWatt API responses
+type iotawattHandler struct {
+	series string
+}
+
+func (h *iotawattHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("show") == "series" {
+		fmt.Fprint(w, h.series)
+		return
+	}
+
+	sel := r.URL.Query().Get("select")
+	switch sel {
+	case "[GridNet.watts]":
+		fmt.Fprint(w, `[[5000]]`)
+	case "[Solar.watts]":
+		fmt.Fprint(w, `[[2500]]`)
+	case "[Grid_A.watts,Grid_B.watts,Grid_C.watts]":
+		fmt.Fprint(w, `[[1700,1600,1700]]`)
+	case "[Grid_A.amps,Grid_B.amps,Grid_C.amps]":
+		fmt.Fprint(w, `[[7.3,6.9,7.3]]`)
+	case "[Grid_A.volts,Grid_B.volts,Grid_C.volts]":
+		fmt.Fprint(w, `[[233,231,232]]`)
+	case "[GridNet.wh]", "[Solar.wh]":
+		fmt.Fprint(w, `[[100]]`)
+	case "[Grid_A.wh,Grid_B.wh,Grid_C.wh]":
+		fmt.Fprint(w, `[[40,30,30]]`)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "unexpected select: %s", sel)
+	}
+}
+
+func newIoTaWattTestServer() *httptest.Server {
+	return httptest.NewServer(&iotawattHandler{
+		series: `{"series":[
+			{"name":"GridNet","unit":"Watts"},
+			{"name":"Solar","unit":"Watts"},
+			{"name":"Grid_A","unit":"Watts"},
+			{"name":"Grid_B","unit":"Watts"},
+			{"name":"Grid_C","unit":"Watts"},
+			{"name":"Input_0","unit":"Volts"}
+		]}`,
+	})
+}
+
+func TestIoTaWattSingleChannel(t *testing.T) {
+	srv := newIoTaWattTestServer()
+	defer srv.Close()
+
+	m, err := NewIoTaWatt(srv.URL, []string{"GridNet"}, 0)
+	require.NoError(t, err)
+
+	t.Run("CurrentPower", func(t *testing.T) {
+		power, err := m.CurrentPower()
+		require.NoError(t, err)
+		assert.Equal(t, 5000.0, power)
+	})
+
+	t.Run("MeterEnergy", func(t *testing.T) {
+		em, ok := m.(api.MeterEnergy)
+		require.True(t, ok, "expected api.MeterEnergy")
+
+		// first call seeds, returns 0
+		energy, err := em.TotalEnergy()
+		require.NoError(t, err)
+		assert.Equal(t, 0.0, energy)
+
+		// second call accumulates
+		energy, err = em.TotalEnergy()
+		require.NoError(t, err)
+		assert.Equal(t, 0.1, energy) // 100 Wh = 0.1 kWh
+	})
+
+	t.Run("NoPhaseInterfaces", func(t *testing.T) {
+		_, ok := m.(api.PhasePowers)
+		assert.False(t, ok, "should not implement PhasePowers for single channel")
+
+		_, ok = m.(api.PhaseCurrents)
+		assert.False(t, ok, "should not implement PhaseCurrents for single channel")
+
+		_, ok = m.(api.PhaseVoltages)
+		assert.False(t, ok, "should not implement PhaseVoltages for single channel")
+	})
+}
+
+func TestIoTaWattSolarSingleChannel(t *testing.T) {
+	srv := newIoTaWattTestServer()
+	defer srv.Close()
+
+	m, err := NewIoTaWatt(srv.URL, []string{"Solar"}, 0)
+	require.NoError(t, err)
+
+	power, err := m.CurrentPower()
+	require.NoError(t, err)
+	assert.Equal(t, 2500.0, power)
+}
+
+func TestIoTaWattThreePhase(t *testing.T) {
+	srv := newIoTaWattTestServer()
+	defer srv.Close()
+
+	channels := []string{"Grid_A", "Grid_B", "Grid_C"}
+	m, err := NewIoTaWatt(srv.URL, channels, 0)
+	require.NoError(t, err)
+
+	t.Run("CurrentPower", func(t *testing.T) {
+		power, err := m.CurrentPower()
+		require.NoError(t, err)
+		assert.Equal(t, 5000.0, power) // 1700+1600+1700
+	})
+
+	t.Run("PhasePowers", func(t *testing.T) {
+		pp, ok := m.(api.PhasePowers)
+		require.True(t, ok, "expected api.PhasePowers")
+
+		p1, p2, p3, err := pp.Powers()
+		require.NoError(t, err)
+		assert.Equal(t, 1700.0, p1)
+		assert.Equal(t, 1600.0, p2)
+		assert.Equal(t, 1700.0, p3)
+	})
+
+	t.Run("PhaseCurrents", func(t *testing.T) {
+		pc, ok := m.(api.PhaseCurrents)
+		require.True(t, ok, "expected api.PhaseCurrents")
+
+		i1, i2, i3, err := pc.Currents()
+		require.NoError(t, err)
+		assert.Equal(t, 7.3, i1)
+		assert.Equal(t, 6.9, i2)
+		assert.Equal(t, 7.3, i3)
+	})
+
+	t.Run("PhaseVoltages", func(t *testing.T) {
+		pv, ok := m.(api.PhaseVoltages)
+		require.True(t, ok, "expected api.PhaseVoltages")
+
+		v1, v2, v3, err := pv.Voltages()
+		require.NoError(t, err)
+		assert.Equal(t, 233.0, v1)
+		assert.Equal(t, 231.0, v2)
+		assert.Equal(t, 232.0, v3)
+	})
+
+	t.Run("MeterEnergy", func(t *testing.T) {
+		em, ok := m.(api.MeterEnergy)
+		require.True(t, ok, "expected api.MeterEnergy")
+
+		// first call seeds
+		energy, err := em.TotalEnergy()
+		require.NoError(t, err)
+		assert.Equal(t, 0.0, energy)
+
+		// second call: 40+30+30 = 100 Wh = 0.1 kWh
+		energy, err = em.TotalEnergy()
+		require.NoError(t, err)
+		assert.Equal(t, 0.1, energy)
+	})
+}
+
+func TestIoTaWattInvalidChannel(t *testing.T) {
+	srv := newIoTaWattTestServer()
+	defer srv.Close()
+
+	_, err := NewIoTaWatt(srv.URL, []string{"NonExistent"}, 0)
+	assert.ErrorContains(t, err, "unknown iotawatt series: NonExistent")
+}
+
+func TestIoTaWattVoltageChannelRejected(t *testing.T) {
+	srv := newIoTaWattTestServer()
+	defer srv.Close()
+
+	_, err := NewIoTaWatt(srv.URL, []string{"Input_0"}, 0)
+	assert.ErrorContains(t, err, "has unit")
+}
+
+func TestIoTaWattInvalidChannelCount(t *testing.T) {
+	srv := newIoTaWattTestServer()
+	defer srv.Close()
+
+	_, err := NewIoTaWatt(srv.URL, []string{"Grid_A", "Grid_B"}, 0)
+	assert.ErrorContains(t, err, "1 (single-phase) or 3 (three-phase)")
+}
+
+func TestIoTaWattMissingChannels(t *testing.T) {
+	_, err := NewIoTaWattFromConfig(map[string]any{
+		"uri": "http://localhost",
+	})
+	assert.ErrorContains(t, err, "missing channels")
+}
+
+func TestIoTaWattEmptyChannelsFiltered(t *testing.T) {
+	srv := newIoTaWattTestServer()
+	defer srv.Close()
+
+	// simulates template with only L1 set, L2/L3 empty
+	m, err := NewIoTaWattFromConfig(map[string]any{
+		"uri":      srv.URL,
+		"channels": []string{"GridNet", "", ""},
+	})
+	require.NoError(t, err)
+
+	power, err := m.CurrentPower()
+	require.NoError(t, err)
+	assert.Equal(t, 5000.0, power)
+
+	// should be single-phase (no phase interfaces)
+	_, ok := m.(api.PhasePowers)
+	assert.False(t, ok)
+}

--- a/meter/iotawatt_test.go
+++ b/meter/iotawatt_test.go
@@ -61,7 +61,7 @@ func TestIoTaWattSingleChannel(t *testing.T) {
 	srv := newIoTaWattTestServer()
 	defer srv.Close()
 
-	m, err := NewIoTaWatt(srv.URL, []string{"GridNet"}, 0)
+	m, err := NewIoTaWatt(srv.URL, []string{"GridNet"})
 	require.NoError(t, err)
 
 	t.Run("CurrentPower", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestIoTaWattSolarSingleChannel(t *testing.T) {
 	srv := newIoTaWattTestServer()
 	defer srv.Close()
 
-	m, err := NewIoTaWatt(srv.URL, []string{"Solar"}, 0)
+	m, err := NewIoTaWatt(srv.URL, []string{"Solar"})
 	require.NoError(t, err)
 
 	power, err := m.CurrentPower()
@@ -114,7 +114,7 @@ func TestIoTaWattThreePhase(t *testing.T) {
 	defer srv.Close()
 
 	channels := []string{"Grid_A", "Grid_B", "Grid_C"}
-	m, err := NewIoTaWatt(srv.URL, channels, 0)
+	m, err := NewIoTaWatt(srv.URL, channels)
 	require.NoError(t, err)
 
 	t.Run("CurrentPower", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestIoTaWattInvalidChannel(t *testing.T) {
 	srv := newIoTaWattTestServer()
 	defer srv.Close()
 
-	_, err := NewIoTaWatt(srv.URL, []string{"NonExistent"}, 0)
+	_, err := NewIoTaWatt(srv.URL, []string{"NonExistent"})
 	assert.ErrorContains(t, err, "unknown iotawatt series: NonExistent")
 }
 
@@ -184,7 +184,7 @@ func TestIoTaWattVoltageChannelRejected(t *testing.T) {
 	srv := newIoTaWattTestServer()
 	defer srv.Close()
 
-	_, err := NewIoTaWatt(srv.URL, []string{"Input_0"}, 0)
+	_, err := NewIoTaWatt(srv.URL, []string{"Input_0"})
 	assert.ErrorContains(t, err, "has unit")
 }
 
@@ -192,7 +192,7 @@ func TestIoTaWattInvalidChannelCount(t *testing.T) {
 	srv := newIoTaWattTestServer()
 	defer srv.Close()
 
-	_, err := NewIoTaWatt(srv.URL, []string{"Grid_A", "Grid_B"}, 0)
+	_, err := NewIoTaWatt(srv.URL, []string{"Grid_A", "Grid_B"})
 	assert.ErrorContains(t, err, "1 (single-phase) or 3 (three-phase)")
 }
 

--- a/templates/definition/meter/iotawatt.yaml
+++ b/templates/definition/meter/iotawatt.yaml
@@ -1,0 +1,65 @@
+template: iotawatt
+products:
+  - brand: IoTaWatt
+    description:
+      generic: Energy Monitor
+requirements:
+  description:
+    en: |
+      Configure one IoTaWatt series (input or output) per channel.
+      For single-phase setups, only the L1 series is required (e.g. `Solar` or `GridNet`).
+      For three-phase setups, specify the series for each phase (e.g. `Grid_A`, `Grid_B`, `Grid_C`).
+      Three-phase mode automatically provides per-phase power, current, and voltage readings.
+      All series must be of unit Watts.
+    de: |
+      Konfiguriere eine IoTaWatt Serie (Eingang oder Ausgang) pro Kanal.
+      Für einphasige Installationen wird nur die L1 Serie benötigt (z.B. `Solar` oder `GridNet`).
+      Für dreiphasige Installationen die Serie für jede Phase angeben (z.B. `Grid_A`, `Grid_B`, `Grid_C`).
+      Der Dreiphasen-Modus liefert automatisch phasenweise Leistungs-, Strom- und Spannungsmessungen.
+      Alle Serien müssen die Einheit Watt haben.
+params:
+  - name: usage
+    choice: ["grid", "pv", "charge"]
+  - name: uri
+    description:
+      en: IoTaWatt URI
+      de: IoTaWatt URI
+    example: http://192.0.2.2
+    required: true
+    help:
+      en: "URI of the IoTaWatt device (e.g. `http://192.168.1.100` or `http://iotawatt.local`)."
+      de: "URI des IoTaWatt-Geräts (z.B. `http://192.168.1.100` oder `http://iotawatt.local`)."
+  - name: series
+    required: true
+    description:
+      en: L1 / single-phase series
+      de: L1 / Einphasig-Serie
+    example: GridNet
+    service: iotawatt/series?uri={uri}
+    help:
+      en: "IoTaWatt series name (Watts). Examples: `GridNet` (grid), `Solar` (pv), `Tesla` (charge). For single-phase setups this is the only series needed."
+      de: "IoTaWatt Serienname (Watt). Beispiele: `GridNet` (Netz), `Solar` (PV), `Tesla` (Laden). Für einphasige Installationen ist dies die einzige benötigte Serie."
+  - name: seriesL2
+    description:
+      en: L2 series (three-phase)
+      de: L2 Serie (Dreiphasig)
+    service: iotawatt/series?uri={uri}
+    help:
+      en: "IoTaWatt series name for phase L2. Leave empty for single-phase setups."
+      de: "IoTaWatt Serienname für Phase L2. Für einphasige Installationen leer lassen."
+  - name: seriesL3
+    description:
+      en: L3 series (three-phase)
+      de: L3 Serie (Dreiphasig)
+    service: iotawatt/series?uri={uri}
+    help:
+      en: "IoTaWatt series name for phase L3. Leave empty for single-phase setups."
+      de: "IoTaWatt Serienname für Phase L3. Für einphasige Installationen leer lassen."
+render: |
+  type: iotawatt
+  uri: {{ .uri }}
+  usage: {{ .usage }}
+  channels:
+    - {{ .series }}
+    - {{ .seriesL2 }}
+    - {{ .seriesL3 }}


### PR DESCRIPTION
This PR adds native support for [IoTaWatt](https://iotawatt.com) energy monitors as a meter type, querying the device REST API directly instead of proxying through Home Assistant.

IoTaWatt is a popular open-source WiFi energy monitor (up to 14 CT channels) used in solar/EV setups for per-circuit monitoring. Currently the only way to use one with evcc is through the `homeassistant` meter template, which adds latency, an extra failure point, and loses per-phase granularity. A native meter gives evcc direct access to real-time power, current, voltage and energy and provides proper three-phase support.

I've added unit tests for the connection and service layers as well as the meter integration (including both single and three-phase support).

I've also run it on my fork for a week without issue