### PR TITLE
fix: generate all slot timestamps in optimizer asTimestamps

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -615,11 +615,16 @@ func timeSteps(minLen int) []int {
 }
 
 func asTimestamps(dt []int) []time.Time {
+	if len(dt) == 0 {
+		return nil
+	}
+
 	res := make([]time.Time, 0, len(dt))
 	eoh := endOfHour(time.Now())
-	res = append(res, eoh.Add(-time.Duration(dt[0])*time.Second))
-	for i := range len(res) - 1 {
-		res = append(res, eoh.Add(time.Duration(dt[i+1])*time.Second))
+	ts := eoh.Add(-time.Duration(dt[0]) * time.Second)
+	for _, d := range dt {
+		res = append(res, ts)
+		ts = ts.Add(time.Duration(d) * time.Second)
 	}
 	return res
 }

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -615,10 +615,6 @@ func timeSteps(minLen int) []int {
 }
 
 func asTimestamps(dt []int) []time.Time {
-	if len(dt) == 0 {
-		return nil
-	}
-
 	res := make([]time.Time, 0, len(dt))
 	eoh := endOfHour(time.Now())
 	ts := eoh.Add(-time.Duration(dt[0]) * time.Second)


### PR DESCRIPTION
## Summary

`asTimestamps` only returned 1 timestamp instead of one per slot. The loop `for i := range len(res) - 1` evaluated to `range 0` since `len(res)` was always 1, so it never executed. Timestamp offsets also weren't cumulative.

Rewrote to iterate over all `dt` entries and accumulate timestamps from the first slot's start time.

## Test plan
- [ ] `go test ./core/... -v` passes
- [ ] Verify optimizer schedule produces correct timestamps for multi-slot plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)