### PR TITLE
Gather tomorrow's tariffs when published at esios

### DIFF
--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -26,7 +26,7 @@ params:
     required: true
   - name: region
     description:
-      generic: "Retrieve 1 out of 5 regions from the API."
+      generic: "Retrieve 1 out of 5 regions from the API just for grid tariff."
     help:
       en: Península, Canarias, Baleares, Ceuta, Melilla
     example: Península
@@ -39,13 +39,13 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://api.esios.ree.es/indicators/{{.indicator}}
+    uri: https://api.esios.ree.es/indicators/{{ .indicator }}?start_date={{ now | date "2006-01-02" }}T00:00&end_date={{ (now.AddDate 0 0 1) | date "2006-01-02" }}T23:59
     auth:
       type: bearer
       token: {{ .securitytoken }}
     jq: |
       [.indicator.values[] 
-        | select(.geo_name == "{{.region}}") 
+        | select(.geo_name == {{ if eq .indicator "1739" }}"España"{{ else }}"{{.region}}"{{ end }})
         | {
           start: .datetime_utc,
           end: (.datetime_utc | strptime ("%FT%TZ") | mktime + 3600 | strftime("%FT%TZ")),

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -5,7 +5,7 @@ products:
 requirements:
   evcc: ["skiptest"]
   description:
-    generic: Spain PVPC tariff extracted from [api.esios.ree.es](https://api.esios.ree.es). It is possible to create grid and feed-in tariffs. You need a token in order to be able to use the API
+    generic: "Spain PVPC tariff extracted from [api.esios.ree.es](https://api.esios.ree.es). It is possible to create grid and feed-in tariffs. You need a token in order to be able to use the API"
 group: price
 countries: ["ES"]
 params:
@@ -13,7 +13,7 @@ params:
     description:
       generic: "Esios personal Security token"
     help:
-      en: "Request your token at <a href="mailto:consultasios@ree.es?subject=Personal token request">consultasios@ree.es</a>"
+      en: Request your token at <a href="mailto:consultasios@ree.es?subject=Personal token request">consultasios@ree.es</a>
     required: true
   - name: indicator
     description:

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -28,7 +28,7 @@ params:
     description:
       generic: "Retrieve the region for grid tariff."
     help:
-      en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."
+      en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."    
     example: Península
     type: choice
     choice: ["Península", "Canarias", "Baleares", "Ceuta", "Melilla"]
@@ -40,16 +40,16 @@ render: |
   forecast:
     source: http
     uri: https://api.esios.ree.es/indicators/{{ .indicator }}?start_date={{ now | date "2006-01-02" }}T00:00&end_date={{ (now.AddDate 0 0 1) | date "2006-01-02" }}T23:59
-    auth:
-      type: bearer
-      token: {{ .securitytoken }}
+    method: GET
+    headers:
+      x-api-key: "{{ .securitytoken }}"
+      Accept: "application/json"
     jq: |
       [.indicator.values[] 
-        | select(.geo_name == {{ if eq (printf "%v" .indicator) "1739" }}{{ "España" | printf "%q" }}{{ else }}{{ .region | printf "%q" }}{{ end }})
+        | select(.geo_name == {{ if eq .indicator "1739" }} "España" {{ else }}{{ .region | printf "%q" }}{{ end }})
         | {
           start: .datetime_utc,
           end: (.datetime_utc | strptime ("%FT%TZ") | mktime + 3600 | strftime("%FT%TZ")),
           value: (.value | tonumber) / 1000
           }
-      ]
-        | tostring
+      ] | tostring

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -5,7 +5,7 @@ products:
 requirements:
   evcc: ["skiptest"]
   description:
-    generic: "Spain PVPC tariff extracted from [api.esios.ree.es](https://api.esios.ree.es). It is possible to create grid and feed-in tariffs. You need a token in order to be able to use the API"
+    generic: Spain PVPC tariff extracted from [api.esios.ree.es](https://api.esios.ree.es). It is possible to create grid and feed-in tariffs. You need a token in order to be able to use the API
 group: price
 countries: ["ES"]
 params:

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -28,7 +28,7 @@ params:
     description:
       generic: "Retrieve the region for grid tariff."
     help:
-      en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."    
+      en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."
     example: Península
     type: choice
     choice: ["Península", "Canarias", "Baleares", "Ceuta", "Melilla"]

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -13,22 +13,22 @@ params:
     description:
       generic: "Esios personal Security token"
     help:
-      en: Request your token at <a href="mailto:consultasios@ree.es?subject=Personal token request">consultasios@ree.es</a>
+      en: "Request your token at <a href="mailto:consultasios@ree.es?subject=Personal token request">consultasios@ree.es</a>"
     required: true
   - name: indicator
     description:
       generic: "Indicator to retrieve from the API."
     help:
-      en: 1001 = Grid Tariff, 1739 = Feed-in Tariff
+      en: "Select the indicator to request to Esios 1001 = Grid Tariff, 1739 = Feed-in Tariff"
     example: 1001
     type: choice
     choice: [1001, 1739]
     required: true
   - name: region
     description:
-      generic: "Retrieve 1 out of 5 regions from the API just for grid tariff."
+      generic: "Retrieve the region for grid tariff."
     help:
-      en: Península, Canarias, Baleares, Ceuta, Melilla
+      en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."    
     example: Península
     type: choice
     choice: ["Península", "Canarias", "Baleares", "Ceuta", "Melilla"]
@@ -45,10 +45,11 @@ render: |
       token: {{ .securitytoken }}
     jq: |
       [.indicator.values[] 
-        | select(.geo_name == {{ if eq .indicator "1739" }}"España"{{ else }}"{{.region}}"{{ end }})
+        | select(.geo_name == {{ if eq (printf "%v" .indicator) "1739" }}{{ "España" | printf "%q" }}{{ else }}{{ .region | printf "%q" }}{{ end }})
         | {
           start: .datetime_utc,
           end: (.datetime_utc | strptime ("%FT%TZ") | mktime + 3600 | strftime("%FT%TZ")),
           value: (.value | tonumber) / 1000
           }
-      ] | tostring
+      ]
+        | tostring


### PR DESCRIPTION
This new version gathers tomorrow's tariffs when published (around 20:00 CET).

Also forces region "España" for feed in tariff (indicator 1739) becuase is the only one available. For the grid tariff (indicator 1001) there are 5 possibilities and user must select one