### PR TITLE
Esios: extend forecast range

### DIFF
--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -26,7 +26,7 @@ params:
     required: true
   - name: region
     description:
-      generic: "Retrieve the region for grid tariff."
+      generic: "Region"
     help:
       en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."    
     example: Península

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -26,9 +26,9 @@ params:
     required: true
   - name: region
     description:
-      generic: "Retrieve 1 out of 5 regions from the API."
+      generic: "Retrieve the region for grid tariff."
     help:
-      en: Península, Canarias, Baleares, Ceuta, Melilla
+      en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."    
     example: Península
     type: choice
     choice: ["Península", "Canarias", "Baleares", "Ceuta", "Melilla"]
@@ -39,13 +39,14 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://api.esios.ree.es/indicators/{{.indicator}}
-    auth:
-      type: bearer
-      token: {{ .securitytoken }}
+    uri: https://api.esios.ree.es/indicators/{{ .indicator }}?start_date={{ now | date "2006-01-02" }}T00:00&end_date={{ (now.AddDate 0 0 1) | date "2006-01-02" }}T23:59
+    method: GET
+    headers:
+      x-api-key: "{{ .securitytoken }}"
+      Accept: "application/json"
     jq: |
       [.indicator.values[] 
-        | select(.geo_name == "{{.region}}") 
+        | select(.geo_name == {{ if eq .indicator "1739" }} "España" {{ else }}{{ .region | printf "%q" }}{{ end }})
         | {
           start: .datetime_utc,
           end: (.datetime_utc | strptime ("%FT%TZ") | mktime + 3600 | strftime("%FT%TZ")),

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -44,7 +44,7 @@ render: |
       Accept: "application/json"
     jq: |
       [.indicator.values[] 
-        | select(.geo_name == {{ if eq .indicator "1739" }} "España" {{ else }}{{ .region | printf "%q" }}{{ end }})
+        | select(.geo_name == {{ if eq .indicator "1739" }} "España" {{ else }}"{{.region}}"{{ end }})
         | {
           start: .datetime_utc,
           end: (.datetime_utc | strptime ("%FT%TZ") | mktime + 3600 | strftime("%FT%TZ")),

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -27,8 +27,6 @@ params:
   - name: region
     description:
       generic: "Region"
-    help:
-      en: "Select 1 out of 5 regions for the grid tariff (Península, Canarias, Baleares, Ceuta, Melilla)."    
     example: Península
     type: choice
     choice: ["Península", "Canarias", "Baleares", "Ceuta", "Melilla"]


### PR DESCRIPTION
Fixes:

- Improve description and help for region parameter
- Change URI and authentication to gather today's and tomorrow's prices when available
- Implement the logic to force region España when indicator is 1739