### PR TITLE
easee: fix stale power/current readings when charger goes offline

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -763,6 +763,10 @@ func (c *Easee) CurrentPower() (float64, error) {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 
+	if time.Since(c.lastObsReceived) > observationTimeout {
+		return 0, nil
+	}
+
 	return c.currentPower, nil
 }
 
@@ -781,6 +785,11 @@ var _ api.PhaseCurrents = (*Easee)(nil)
 func (c *Easee) Currents() (float64, float64, float64, error) {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
+
+	if time.Since(c.lastObsReceived) > observationTimeout {
+		return 0, 0, 0, nil
+	}
+
 	return c.currentL1, c.currentL2, c.currentL3, nil
 }
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -40,6 +40,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// observationTimeout is the maximum age of the most recently received charger
+// observation before power and current readings are considered stale and zeroed.
+// The Easee charger sends a thermal heartbeat every ~15 minutes when idle, so
+// 20 minutes gives a comfortable margin above that while staying well below the
+// time a user would expect stale data to linger.
+const observationTimeout = 20 * time.Minute
+
 // Easee charger implementation
 type Easee struct {
 	*request.Helper
@@ -69,6 +76,7 @@ type Easee struct {
 	expectedOrphans map[easee.ObservationID]int
 	obsC            chan easee.Observation
 	obsTime         map[easee.ObservationID]time.Time
+	lastObsReceived time.Time
 	startDone       func()
 }
 
@@ -349,6 +357,12 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 	}
 
 	c.obsTime[res.ID] = res.Timestamp
+
+	// Update liveness timestamp for observations with a fresh charger-side timestamp.
+	// Stale cloud replay on restart has old timestamps and must not refresh this.
+	if time.Since(res.Timestamp) < observationTimeout {
+		c.lastObsReceived = time.Now()
+	}
 
 	switch res.ID {
 	case easee.USER_IDTOKEN:

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -622,3 +622,39 @@ func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
 	e.cmdMu.Unlock()
 	assert.Equal(t, 1, count, "expected orphan should be registered before the POST")
 }
+
+func TestLivenessCheck_staleObservations(t *testing.T) {
+	e := newEasee()
+	e.opMode = easee.ModeCharging
+	e.currentPower = 7280
+	e.currentL1, e.currentL2, e.currentL3 = 16, 16, 16
+	e.lastObsReceived = time.Now().Add(-(observationTimeout + time.Minute))
+
+	power, err := e.CurrentPower()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), power, "expired observations: CurrentPower must return 0W")
+
+	l1, l2, l3, err := e.Currents()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), l1)
+	assert.Equal(t, float64(0), l2)
+	assert.Equal(t, float64(0), l3)
+}
+
+func TestLivenessCheck_freshObservations(t *testing.T) {
+	e := newEasee()
+	e.opMode = easee.ModeCharging
+	e.currentPower = 7280
+	e.currentL1, e.currentL2, e.currentL3 = 16, 16, 16
+	e.lastObsReceived = time.Now()
+
+	power, err := e.CurrentPower()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(7280), power)
+
+	l1, l2, l3, err := e.Currents()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(16), l1)
+	assert.Equal(t, float64(16), l2)
+	assert.Equal(t, float64(16), l3)
+}

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -560,6 +560,28 @@ func TestEasee_registerExpectedOrphan_multipleRegistrations(t *testing.T) {
 	assert.False(t, e.consumeExpectedOrphan(easee.CIRCUIT_MAX_CURRENT_P1))
 }
 
+func TestProductUpdate_updatesLastObsReceived_freshTimestamp(t *testing.T) {
+	e := newEasee()
+	assert.True(t, e.lastObsReceived.IsZero())
+
+	// Observation with a fresh charger-side timestamp (seconds ago)
+	now := time.Now().UTC().Truncate(0)
+	e.ProductUpdate(createPayload(easee.TOTAL_POWER, now, easee.Double, "3.5"))
+
+	assert.False(t, e.lastObsReceived.IsZero())
+	assert.WithinDuration(t, time.Now(), e.lastObsReceived, 2*time.Second)
+}
+
+func TestProductUpdate_doesNotUpdateLastObsReceived_staleTimestamp(t *testing.T) {
+	e := newEasee()
+
+	// Observation with a charger-side timestamp older than observationTimeout
+	stale := time.Now().UTC().Add(-(observationTimeout + time.Minute))
+	e.ProductUpdate(createPayload(easee.TOTAL_POWER, stale, easee.Double, "3.5"))
+
+	assert.True(t, e.lastObsReceived.IsZero(), "stale replay must not update lastObsReceived")
+}
+
 func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
 	const siteID = 12345
 	const circuitID = 67890

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -569,7 +569,7 @@ func TestProductUpdate_updatesLastObsReceived_freshTimestamp(t *testing.T) {
 	e.ProductUpdate(createPayload(easee.TOTAL_POWER, now, easee.Double, "3.5"))
 
 	assert.False(t, e.lastObsReceived.IsZero())
-	assert.WithinDuration(t, time.Now(), e.lastObsReceived, 2*time.Second)
+	assert.WithinDuration(t, time.Now(), e.lastObsReceived, 5*time.Second)
 }
 
 func TestProductUpdate_doesNotUpdateLastObsReceived_staleTimestamp(t *testing.T) {


### PR DESCRIPTION
## Summary

- Tracks liveness via a single `lastObsReceived` field, updated in `ProductUpdate()` only when an observation's charger-side timestamp is fresher than `observationTimeout` (20 min)
- `CurrentPower()` and `Currents()` return 0 when `lastObsReceived` has not been updated within `observationTimeout`
- On restart with an offline charger, the SignalR cloud replay delivers observations with hours-old timestamps — these never refresh `lastObsReceived`, so power/current immediately read as 0

## Why `lastObsReceived` instead of per-observation staleness

The previous fix (#28078) used a 5-minute staleness threshold on `TOTAL_POWER` specifically. This caused a regression (#28282) because the Easee cloud sends observations **on value change**, not on a timer — during steady-state charging `TOTAL_POWER` can be silent for 10–15 minutes legitimately.

The new approach tracks the most recent receipt of **any** observation with a fresh charger-side timestamp. The Easee thermal heartbeat (temperatures, voltages, circuit currents) arrives every ~15 minutes during idle, so a 20-minute threshold safely distinguishes a truly offline charger from one that's just not changing power.

fixes #28077
refs #28282