### PR TITLE
fix(easee): disable phase switching on non TN grid installations

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -161,20 +161,7 @@ func NewEasee(ctx context.Context, user, password, charger string, timeout time.
 		return nil, err
 	}
 
-	// find single charger per circuit
-	for _, circuit := range site.Circuits {
-		if len(circuit.Chargers) > 1 {
-			continue
-		}
-
-		for _, charger := range circuit.Chargers {
-			if charger.ID == c.charger {
-				c.site = site.ID
-				c.circuit = circuit.ID
-				break
-			}
-		}
-	}
+	c.determineCircuit(site)
 
 	client, err := signalr.NewClient(ctx,
 		signalr.WithConnector(c.connect(ts)),
@@ -242,6 +229,35 @@ func isTNGrid(gridType int) bool {
 		return true
 	}
 	return false
+}
+
+func (c *Easee) chargerConfig(charger string) (res easee.ChargerConfig, err error) {
+	uri := fmt.Sprintf("%s/chargers/%s/config", easee.API, charger)
+	err = c.GetJSON(uri, &res)
+	return res, err
+}
+
+func (c *Easee) determineCircuit(site easee.Site) {
+	config, err := c.chargerConfig(c.charger)
+	if err != nil {
+		c.log.WARN.Printf("charger config unavailable, using charger-level phase control: %v", err)
+		return
+	}
+	if !isTNGrid(config.DetectedPowerGridType) {
+		return
+	}
+	for _, circuit := range site.Circuits {
+		if len(circuit.Chargers) > 1 {
+			continue
+		}
+		for _, charger := range circuit.Chargers {
+			if charger.ID == c.charger {
+				c.site = site.ID
+				c.circuit = circuit.ID
+				return
+			}
+		}
+	}
 }
 
 // connect creates an HTTP connection to the signalR hub

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -236,6 +236,14 @@ func (c *Easee) chargerSite(charger string) (easee.Site, error) {
 	return res, err
 }
 
+func isTNGrid(gridType int) bool {
+	switch gridType {
+	case easee.PowerGridTN3Phase, easee.PowerGridTN2PhasePin234, easee.PowerGridTN1Phase:
+		return true
+	}
+	return false
+}
+
 // connect creates an HTTP connection to the signalR hub
 func (c *Easee) connect(ts oauth2.TokenSource) func() (signalr.Connection, error) {
 	bo := backoff.NewExponentialBackOff(backoff.WithMaxInterval(time.Minute), backoff.WithMaxElapsedTime(0))

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -161,7 +161,9 @@ func NewEasee(ctx context.Context, user, password, charger string, timeout time.
 		return nil, err
 	}
 
-	c.determineCircuit(site)
+	if err := c.determineCircuit(site); err != nil {
+		return nil, err
+	}
 
 	client, err := signalr.NewClient(ctx,
 		signalr.WithConnector(c.connect(ts)),
@@ -237,14 +239,13 @@ func (c *Easee) chargerConfig(charger string) (res easee.ChargerConfig, err erro
 	return res, err
 }
 
-func (c *Easee) determineCircuit(site easee.Site) {
+func (c *Easee) determineCircuit(site easee.Site) error {
 	config, err := c.chargerConfig(c.charger)
 	if err != nil {
-		c.log.WARN.Printf("charger config unavailable, using charger-level phase control: %v", err)
-		return
+		return fmt.Errorf("charger config unavailable: %w", err)
 	}
 	if !isTNGrid(config.DetectedPowerGridType) {
-		return
+		return nil
 	}
 	for _, circuit := range site.Circuits {
 		if len(circuit.Chargers) > 1 {
@@ -254,10 +255,11 @@ func (c *Easee) determineCircuit(site easee.Site) {
 			if charger.ID == c.charger {
 				c.site = site.ID
 				c.circuit = circuit.ID
-				return
+				return nil
 			}
 		}
 	}
+	return nil
 }
 
 // connect creates an HTTP connection to the signalR hub

--- a/charger/easee/types.go
+++ b/charger/easee/types.go
@@ -10,6 +10,13 @@ const (
 	ChargeResume = "resume_charging"
 )
 
+// DetectedPowerGridType values
+const (
+	PowerGridTN3Phase       = 1
+	PowerGridTN2PhasePin234 = 2
+	PowerGridTN1Phase       = 3
+)
+
 // charge mode definition
 const (
 	ModeOffline                int = 0

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -513,3 +513,89 @@ func TestIsTNGrid(t *testing.T) {
 	assert.False(t, isTNGrid(0))  // absent / unknown
 	assert.False(t, isTNGrid(99)) // arbitrary unknown
 }
+
+// makeTestSite returns a Site with a single Circuit containing the given charger IDs.
+// Site.ID = 111, Circuit.ID = 222.
+func makeTestSite(chargerIDs ...string) easee.Site {
+	chargers := make([]easee.Charger, len(chargerIDs))
+	for i, id := range chargerIDs {
+		chargers[i] = easee.Charger{ID: id}
+	}
+	return easee.Site{
+		ID: 111,
+		Circuits: []easee.Circuit{
+			{ID: 222, Chargers: chargers},
+		},
+	}
+}
+
+func TestDetermineCircuit(t *testing.T) {
+	const chargerID = "TESTTEST"
+	configURI := fmt.Sprintf("%s/chargers/%s/config", easee.API, chargerID)
+
+	tests := []struct {
+		name         string
+		httpStatus   int
+		gridType     int
+		chargerIDs   []string
+		wantCircuit  int
+		suppressWarn bool
+	}{
+		{
+			name:        "TN grid, sole charger — circuit assigned",
+			httpStatus:  200,
+			gridType:    easee.PowerGridTN3Phase,
+			chargerIDs:  []string{chargerID},
+			wantCircuit: 222,
+		},
+		{
+			name:        "IT grid, sole charger — circuit not assigned",
+			httpStatus:  200,
+			gridType:    4, // IT3Phase
+			chargerIDs:  []string{chargerID},
+			wantCircuit: 0,
+		},
+		{
+			name:         "config fetch fails — circuit not assigned",
+			httpStatus:   500,
+			chargerIDs:   []string{chargerID},
+			wantCircuit:  0,
+			suppressWarn: true,
+		},
+		{
+			name:        "TN grid, multi-charger circuit — circuit not assigned",
+			httpStatus:  200,
+			gridType:    easee.PowerGridTN3Phase,
+			chargerIDs:  []string{chargerID, "OTHER"},
+			wantCircuit: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEasee()
+			e.charger = chargerID
+
+			httpmock.ActivateNonDefault(e.Client)
+			defer httpmock.DeactivateAndReset()
+
+			if tc.httpStatus == 200 {
+				body, _ := json.Marshal(easee.ChargerConfig{DetectedPowerGridType: tc.gridType})
+				httpmock.RegisterResponder(http.MethodGet, configURI,
+					httpmock.NewBytesResponder(200, body))
+			} else {
+				httpmock.RegisterResponder(http.MethodGet, configURI,
+					httpmock.NewStringResponder(tc.httpStatus, ""))
+			}
+
+			if tc.suppressWarn {
+				util.LogLevel("error", nil)
+				t.Cleanup(func() { util.LogLevel("info", nil) })
+			}
+
+			e.determineCircuit(makeTestSite(tc.chargerIDs...))
+
+			assert.Equal(t, tc.wantCircuit, e.circuit)
+		})
+	}
+}

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -534,12 +534,12 @@ func TestDetermineCircuit(t *testing.T) {
 	configURI := fmt.Sprintf("%s/chargers/%s/config", easee.API, chargerID)
 
 	tests := []struct {
-		name         string
-		httpStatus   int
-		gridType     int
-		chargerIDs   []string
-		wantCircuit  int
-		suppressWarn bool
+		name        string
+		httpStatus  int
+		gridType    int
+		chargerIDs  []string
+		wantCircuit int
+		wantErr     bool
 	}{
 		{
 			name:        "TN grid, sole charger — circuit assigned",
@@ -556,11 +556,10 @@ func TestDetermineCircuit(t *testing.T) {
 			wantCircuit: 0,
 		},
 		{
-			name:         "config fetch fails — circuit not assigned",
-			httpStatus:   500,
-			chargerIDs:   []string{chargerID},
-			wantCircuit:  0,
-			suppressWarn: true,
+			name:       "config fetch fails — error returned",
+			httpStatus: 500,
+			chargerIDs: []string{chargerID},
+			wantErr:    true,
 		},
 		{
 			name:        "TN grid, multi-charger circuit — circuit not assigned",
@@ -588,14 +587,14 @@ func TestDetermineCircuit(t *testing.T) {
 					httpmock.NewStringResponder(tc.httpStatus, ""))
 			}
 
-			if tc.suppressWarn {
-				util.LogLevel("error", nil)
-				t.Cleanup(func() { util.LogLevel("info", nil) })
+			err := e.determineCircuit(makeTestSite(tc.chargerIDs...))
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantCircuit, e.circuit)
 			}
-
-			e.determineCircuit(makeTestSite(tc.chargerIDs...))
-
-			assert.Equal(t, tc.wantCircuit, e.circuit)
 		})
 	}
 }

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -500,3 +500,16 @@ func TestLivenessCheck_freshObservations(t *testing.T) {
 	assert.Equal(t, float64(16), l2)
 	assert.Equal(t, float64(16), l3)
 }
+
+func TestIsTNGrid(t *testing.T) {
+	// TN grid types must return true
+	assert.True(t, isTNGrid(easee.PowerGridTN3Phase))
+	assert.True(t, isTNGrid(easee.PowerGridTN2PhasePin234))
+	assert.True(t, isTNGrid(easee.PowerGridTN1Phase))
+
+	// IT grid types, zero, and unknown values must return false
+	assert.False(t, isTNGrid(4))  // IT3Phase
+	assert.False(t, isTNGrid(5))  // IT1Phase
+	assert.False(t, isTNGrid(0))  // absent / unknown
+	assert.False(t, isTNGrid(99)) // arbitrary unknown
+}


### PR DESCRIPTION
## Problem

Easee chargers installed on IT grids (common in Belgium and Norway) experienced
broken phase switching. When evcc detected a sole charger on a circuit, it
engaged circuit-level phase control — setting dynamic circuit currents P2 and
P3 to zero for 1-phase operation. On IT grids this is incorrect: the IT wiring
uses L1+L3 (no neutral), so zeroing P3 cuts the return conductor and disrupts
charging.
Additionally the aforementioned use of L1+L3 also lead to incorrect detection of 3p charging for IT-grid based installations.

The root cause was that evcc's circuit assignment logic did not account for
grid type. A sole charger on a circuit would always get circuit-level phase
control, regardless of whether the installation was TN or IT.

## Fix

Before assigning circuit-level phase control, query the Easee charger config
API (`GET /api/chargers/{id}/config`) to read `DetectedPowerGridType`. Circuit
control is only engaged for confirmed TN grids (types 1–3). IT grids (types 4–5),
unreachable config endpoints, and any unknown grid type all fall back to
charger-level phase control, which is safe for all grid types.

fixes #27911