### PR TITLE
Plan UI: Fix inaccurate day formatting for negative TZs

### DIFF
--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -384,7 +384,7 @@ export default defineComponent({
     fmtMonthByIndex(index: number, format: Intl.DateTimeFormatOptions["month"]) {
       return new Intl.DateTimeFormat(this.$i18n?.locale, {
         month: format,
-      }).format(new Date(Date.UTC(2021, index, 1)));
+      }).format(new Date(2021, index, 1)); // local date avoids UTC timezone day shift
     },
     getWeekdaysList(
       format: Intl.DateTimeFormatOptions["weekday"]

--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -379,7 +379,7 @@ export default defineComponent({
       const day = index === 0 ? 6 : 6 + index;
       return new Intl.DateTimeFormat(this.$i18n?.locale, {
         weekday: format,
-      }).format(new Date(Date.UTC(2021, 5, day)));
+      }).format(new Date(2021, 5, day)); // local date avoids UTC timezone day shift
     },
     fmtMonthByIndex(index: number, format: Intl.DateTimeFormatOptions["month"]) {
       return new Intl.DateTimeFormat(this.$i18n?.locale, {


### PR DESCRIPTION
I had a very confusing bug where I would create a repeating plan scheduled for day X, but the backend would schedule it for day X+1. So my Monday plan would execute on Tuesday, etc.

I confirmed the data in the DB was all good (we use Go days starting at Sun = 0). Eventually I realized this was a UI display issue related to my timezone.

`Date.UTC` creates a UTC midnight timestamp. When formatted by `Intl.DateTimeFormat` in a negative UTC offset timezone like mine (UTC-7), March 21 00:00 UTC becomes March 20 17:00 PDT = Friday, not Saturday.

This causes every displayed weekday label to be shifted one day earlier than its stored value.

The fix is to format the day using the local timezone.