### PR TITLE
fix: OCPP test race on logger and connector clock

### DIFF
--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -80,6 +80,8 @@ func NewConnector(ctx context.Context, log *util.Logger, id int, cp *CP, idTag s
 }
 
 func (conn *Connector) TestClock(clock clock.Clock) {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
 	conn.clock = clock
 }
 

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -50,8 +50,6 @@ func (suite *ocppTestSuite) SetupSuite() {
 }
 
 func (suite *ocppTestSuite) TearDownSuite() {
-	// Prevent background server goroutines from calling t.Log after the
-	// test has completed, which panics since Go 1.24.
 	suite.logger.close()
 }
 

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -33,7 +33,8 @@ func TestOcpp(t *testing.T) {
 
 type ocppTestSuite struct {
 	suite.Suite
-	clock *clock.Mock
+	clock  *clock.Mock
+	logger *ocppLogger
 }
 
 func (suite *ocppTestSuite) SetupSuite() {
@@ -41,10 +42,17 @@ func (suite *ocppTestSuite) SetupSuite() {
 
 	// setup cs so we can overwrite logger afterwards
 	_ = ocpp.Instance()
-	ocppj.SetLogger(&ocppLogger{suite.T()})
+	suite.logger = &ocppLogger{t: suite.T()}
+	ocppj.SetLogger(suite.logger)
 
 	suite.clock = clock.NewMock()
 	suite.NotNil(ocpp.Instance())
+}
+
+func (suite *ocppTestSuite) TearDownSuite() {
+	// Prevent background server goroutines from calling t.Log after the
+	// test has completed, which panics since Go 1.24.
+	suite.logger.close()
 }
 
 func (suite *ocppTestSuite) startChargePoint(id string, connectorId int) (ocpp16.ChargePoint, *ocppj.Client) {

--- a/charger/ocpp_test_logger.go
+++ b/charger/ocpp_test_logger.go
@@ -12,9 +12,6 @@ type ocppLogger struct {
 	t  *testing.T
 }
 
-// close clears the testing.T reference so that background goroutines
-// (e.g. the OCPP server) that keep logging after the test finishes
-// no longer call t.Log on a completed test (which panics since Go 1.24).
 func (l *ocppLogger) close() {
 	l.mu.Lock()
 	l.t = nil

--- a/charger/ocpp_test_logger.go
+++ b/charger/ocpp_test_logger.go
@@ -2,27 +2,36 @@ package charger
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
 
 type ocppLogger struct {
-	t *testing.T
+	mu sync.Mutex
+	t  *testing.T
 }
 
-func print(t *testing.T, s string) {
-	t.Log((time.Now().Format(time.DateTime)), s)
+// close clears the testing.T reference so that background goroutines
+// (e.g. the OCPP server) that keep logging after the test finishes
+// no longer call t.Log on a completed test (which panics since Go 1.24).
+func (l *ocppLogger) close() {
+	l.mu.Lock()
+	l.t = nil
+	l.mu.Unlock()
 }
 
-func (l *ocppLogger) Debug(args ...any) { print(l.t, fmt.Sprint(args...)) }
-func (l *ocppLogger) Debugf(format string, args ...any) {
-	print(l.t, fmt.Sprintf(format, args...))
+func (l *ocppLogger) print(s string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.t != nil {
+		l.t.Log(time.Now().Format(time.DateTime), s)
+	}
 }
-func (l *ocppLogger) Info(args ...any) { print(l.t, fmt.Sprint(args...)) }
-func (l *ocppLogger) Infof(format string, args ...any) {
-	print(l.t, fmt.Sprintf(format, args...))
-}
-func (l *ocppLogger) Error(args ...any) { print(l.t, fmt.Sprint(args...)) }
-func (l *ocppLogger) Errorf(format string, args ...any) {
-	print(l.t, fmt.Sprintf(format, args...))
-}
+
+func (l *ocppLogger) Debug(args ...any)                 { l.print(fmt.Sprint(args...)) }
+func (l *ocppLogger) Debugf(format string, args ...any) { l.print(fmt.Sprintf(format, args...)) }
+func (l *ocppLogger) Info(args ...any)                  { l.print(fmt.Sprint(args...)) }
+func (l *ocppLogger) Infof(format string, args ...any)  { l.print(fmt.Sprintf(format, args...)) }
+func (l *ocppLogger) Error(args ...any)                 { l.print(fmt.Sprint(args...)) }
+func (l *ocppLogger) Errorf(format string, args ...any) { l.print(fmt.Sprintf(format, args...)) }


### PR DESCRIPTION
## Summary
- Fix flaky OCPP test suite caused by background server goroutines calling `t.Log()` after `TestOcpp` completes (panics since Go 1.24)
- Make `ocppLogger` thread-safe with a mutex; add `close()` called in `TearDownSuite` to nil out the `*testing.T` before it expires
- Acquire `conn.mu` in `TestClock()` to fix data race with `WatchDog()` reading `conn.clock` under the same mutex

## Reproducer
```
CGO_ENABLED=1 go test -tags=release -race -run TestOcpp -v -count=1 ./charger/
```
Before this fix: `panic: Log in goroutine after TestOcpp has completed` + DATA RACE warnings.

## Test plan
- [x] `go test -tags=release -run TestOcpp ./charger/` passes
- [x] `go test -tags=release -race -run TestOcpp ./charger/` passes (no races, no panics)
- [x] `golangci-lint run ./charger/ ./charger/ocpp/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)