### PR TITLE
openevse: fix JSON key names

### DIFF
--- a/charger/openevse.go
+++ b/charger/openevse.go
@@ -199,7 +199,7 @@ func (c *OpenEVSE) ChargedEnergy() (float64, error) {
 		return 0, err
 	}
 
-	return res.SessionEnergy / 1e3, err
+	return res.Wattsec / 3600 / 1e3, err
 }
 
 var _ api.ChargeTimer = (*OpenEVSE)(nil)
@@ -210,7 +210,7 @@ func (c *OpenEVSE) ChargeDuration() (time.Duration, error) {
 		return 0, err
 	}
 
-	return time.Duration(res.SessionElapsed) * time.Second, err
+	return time.Duration(res.Elapsed) * time.Second, err
 }
 
 var _ api.MeterEnergy = (*OpenEVSE)(nil)
@@ -222,7 +222,7 @@ func (c *OpenEVSE) TotalEnergy() (float64, error) {
 		return 0, err
 	}
 
-	return res.TotalEnergy, err
+	return res.Watthour / 1e3, err
 }
 
 var _ api.Meter = (*OpenEVSE)(nil)
@@ -233,7 +233,7 @@ func (c *OpenEVSE) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
-	return res.Power, err
+	return res.Amp * res.Voltage / 1e3, err
 }
 
 // phases1p3p implements the api.PhaseSwitcher interface

--- a/charger/openevse/types.go
+++ b/charger/openevse/types.go
@@ -13,13 +13,12 @@ type Status struct {
 	Mode           string  `json:"mode,omitempty"`            // The current mode of the EVSE
 	Pilot          int     `json:"pilot,omitempty"`           // the pilot value, in amps
 	Power          float64 `json:"power,omitempty"`           // apparent power in watts
-	SessionEnergy  float64 `json:"session_energy"`            // The total amount of energy accumulated for current session (in wh)
-	SessionElapsed int     `json:"session_elapsed"`           // duration of this charging session in seconds
 	State          int     `json:"state,omitempty"`           // evse state 1=A 2=B 3=C 4=D 5-11=F 254=sleeping 255=disabled
 	Status         string  `json:"status,omitempty"`          // active, disabled, none, unknown
-	TotalEnergy    float64 `json:"total_energy"`              // The total amount of energy accumulated (in kwh)
 	Vehicle        int     `json:"vehicle,omitempty"`         // 0=not connected, 1=connected
 	Voltage        float64 `json:"voltage,omitempty"`         // supplied via MQTT/Tesla/HTTP or assume a default
+	Watthour       float64 `json:"watthour,omitempty"`        // The total amount of energy accumulated (in watt-hours)
+	Wattsec        float64 `json:"wattsec,omitempty"`         // The total amount of energy accumulated for current session (in watt-seconds)
 }
 
 type Override struct {

--- a/charger/openevse/types.go
+++ b/charger/openevse/types.go
@@ -12,7 +12,6 @@ type Status struct {
 	ManualOverride int     `json:"manual_override,omitempty"` // 1 = active, 0 = default
 	Mode           string  `json:"mode,omitempty"`            // The current mode of the EVSE
 	Pilot          int     `json:"pilot,omitempty"`           // the pilot value, in amps
-	Power          float64 `json:"power,omitempty"`           // apparent power in watts
 	State          int     `json:"state,omitempty"`           // evse state 1=A 2=B 3=C 4=D 5-11=F 254=sleeping 255=disabled
 	Status         string  `json:"status,omitempty"`          // active, disabled, none, unknown
 	Vehicle        int     `json:"vehicle,omitempty"`         // 0=not connected, 1=connected


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/28412

Use the correct JSON key names for OpenEVSE's status for elapsed, watthour, wattsec, and calculate power by multiplying current (milliamps) by voltage. Tested with OpenEVSE firmware 7.1.3. Fixes issue #28412.