### PR TITLE
Improved pv/phase timer logic

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1384,14 +1384,15 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 			lp.phaseTimer = now
 		}
 
-		if elapsed := now.Sub(lp.phaseTimer); elapsed >= lp.GetDisableDelay() {
+		delay := lp.GetDisableDelay()
+		if elapsed := now.Sub(lp.phaseTimer); elapsed >= delay {
 			if err := lp.scalePhases(1); err != nil {
 				lp.log.ERROR.Println(err)
 			}
 			return 1
 		}
 
-		lp.publishTimer(phaseTimer, lp.GetDisableDelay(), phaseScale1p)
+		lp.publishTimer(phaseTimer, delay, phaseScale1p)
 	} else if upscalable && targetCurrentMaxP >= minCurrent && targetCurrent1P > maxCurrent {
 		// scale up phases
 		lp.log.DEBUG.Printf("available 1p current %.3gA > %.3gA max threshold", targetCurrent1P, maxCurrent)
@@ -1405,35 +1406,44 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 			lp.phaseTimer = now
 		}
 
-		if elapsed := now.Sub(lp.phaseTimer); elapsed >= lp.GetEnableDelay() {
+		delay := lp.GetEnableDelay()
+		if elapsed := now.Sub(lp.phaseTimer); elapsed >= delay {
 			if err := lp.scalePhases(3); err != nil {
 				lp.log.ERROR.Println(err)
 			}
 			return maxPhases
 		}
 
-		lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
+		lp.publishTimer(phaseTimer, delay, phaseScale3p)
 	} else if !lp.phaseTimer.IsZero() {
-		if upscalable == downscalable || lp.phaseTimer.Equal(elapsed) {
+		// reset timer if possible scaling direction is ambiguous
+		if upscalable == downscalable {
+			lp.resetPhaseTimer()
+			return 0
+		}
+
+		// set to timerInactive for consistency, no need to differentiate between timerInactive and timerIncreasing
+		lp.phaseTimerAction = timerInactive
+
+		delay := lp.GetDisableDelay()
+		if upscalable {
+			delay = lp.GetEnableDelay()
+		}
+
+		// apply the "timerIncreasing" logic to an elapsed timer as well
+		if lp.phaseTimer.Equal(elapsed) {
+			lp.phaseTimer = now.Add(-delay)
+		}
+
+		// increase the remaining delay duration
+		timeSinceLastEval := now.Sub(phaseTimerLastEvaluation)
+		lp.phaseTimer = lp.phaseTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+
+		// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
+		if cutoffTime := now.Add(timeSinceLastEval); lp.phaseTimer.After(cutoffTime) {
 			lp.resetPhaseTimer()
 		} else {
-			// set to timerInactive for consistency, no need to differentiate between timerInactive and timerIncreasing
-			lp.phaseTimerAction = timerInactive
-
-			// increase the remaining delay duration
-			timeSinceLastEval := now.Sub(phaseTimerLastEvaluation)
-			lp.phaseTimer = lp.phaseTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
-
-			// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
-			if cutoffTime := now.Add(timeSinceLastEval); lp.phaseTimer.After(cutoffTime) {
-				lp.resetPhaseTimer()
-			} else {
-				delay := lp.GetDisableDelay()
-				if upscalable {
-					delay = lp.GetEnableDelay()
-				}
-				lp.publishTimer(phaseTimer, delay, timerIncreasing)
-			}
+			lp.publishTimer(phaseTimer, delay, timerIncreasing)
 		}
 	}
 
@@ -1555,32 +1565,36 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 		// kick off disable sequence
 		if projectedSitePower >= lp.Disable.Threshold && targetCurrent < minCurrent {
 			lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
+			delay := lp.GetDisableDelay()
 
 			if lp.pvTimer.IsZero() || lp.pvTimer.After(now) {
-				lp.log.DEBUG.Printf("pv disable timer start: %v", lp.GetDisableDelay())
+				lp.log.DEBUG.Printf("pv disable timer start: %v", delay)
 				lp.pvTimer = now
 			}
 
-			if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetDisableDelay() {
+			if elapsed := now.Sub(lp.pvTimer); elapsed >= delay {
 				lp.log.DEBUG.Println("pv disable timer elapsed")
 				return 0
 			}
 
-			lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
+			lp.publishTimer(pvTimer, delay, pvDisable)
 		} else if !lp.pvTimer.IsZero() {
+			delay := lp.GetDisableDelay()
+
+			// apply the "timerIncreasing" logic to an elapsed timer as well
 			if lp.pvTimer.Equal(elapsed) {
+				lp.pvTimer = now.Add(-delay)
+			}
+
+			// increase the remaining delay duration
+			timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
+			lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+
+			// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
+			if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
 				lp.resetPVTimer()
 			} else {
-				// increase the remaining delay duration
-				timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
-				lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
-
-				// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
-				if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
-					lp.resetPVTimer()
-				} else {
-					lp.publishTimer(pvTimer, lp.GetDisableDelay(), timerIncreasing)
-				}
+				lp.publishTimer(pvTimer, delay, timerIncreasing)
 			}
 		}
 
@@ -1595,32 +1609,36 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	// kick off enable sequence
 	if sitePower <= enableThreshold {
 		lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, enableThreshold)
+		delay := lp.GetEnableDelay()
 
 		if lp.pvTimer.IsZero() || lp.pvTimer.After(now) {
-			lp.log.DEBUG.Printf("pv enable timer start: %v", lp.GetEnableDelay())
+			lp.log.DEBUG.Printf("pv enable timer start: %v", delay)
 			lp.pvTimer = now
 		}
 
-		if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetEnableDelay() {
+		if elapsed := now.Sub(lp.pvTimer); elapsed >= delay {
 			lp.log.DEBUG.Println("pv enable timer elapsed")
 			return legalTargetCurrent
 		}
 
-		lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
+		lp.publishTimer(pvTimer, delay, pvEnable)
 	} else if !lp.pvTimer.IsZero() {
+		delay := lp.GetEnableDelay()
+
+		// apply the "timerIncreasing" logic to an elapsed timer as well
 		if lp.pvTimer.Equal(elapsed) {
+			lp.pvTimer = now.Add(-delay)
+		}
+
+		// increase the remaining delay duration
+		timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
+		lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+
+		// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
+		if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
 			lp.resetPVTimer()
 		} else {
-			// increase the remaining delay duration
-			timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
-			lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
-
-			// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
-			if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
-				lp.resetPVTimer()
-			} else {
-				lp.publishTimer(pvTimer, lp.GetEnableDelay(), timerIncreasing)
-			}
+			lp.publishTimer(pvTimer, delay, timerIncreasing)
 		}
 	}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -161,16 +161,15 @@ type Loadpoint struct {
 	planLocked       PlanLock         // locked plan
 
 	// cached state
-	status                   api.ChargeStatus // Charger status
-	chargePower              float64          // Charging power
-	chargeCurrents           []float64        // Phase currents
-	connectedTime            time.Time        // Time when vehicle was connected
-	pvTimer                  time.Time        // PV enable/disable timer
-	pvTimerLastEvaluation    time.Time        // PV enable/disable timer last evaluation time
-	phaseTimer               time.Time        // 1p3p switch timer
-	phaseTimerLastEvaluation time.Time        // 1p3p switch timer last evaluation time
-	phaseTimerAction         string           // 1p3p switch timer action (timerInactive, phaseScale1p, phaseScale3p)
-	wakeUpTimer              *Timer           // Vehicle wake-up timeout
+	status           api.ChargeStatus // Charger status
+	chargePower      float64          // Charging power
+	chargeCurrents   []float64        // Phase currents
+	connectedTime    time.Time        // Time when vehicle was connected
+	pvTimer          time.Time        // PV enable/disable timer
+	phaseTimer       time.Time        // 1p3p switch timer
+	phaseTimerAction string           // 1p3p switch timer action (timerInactive, phaseScale1p, phaseScale3p)
+	wakeUpTimer      *Timer           // Vehicle wake-up timeout
+	lastUpdate       time.Time        // last time Update() completed
 
 	// charge progress
 	vehicleSoc              float64       // Vehicle or charger soc
@@ -328,6 +327,7 @@ func NewLoadpoint(log *util.Logger, settings settings.Settings) *Loadpoint {
 		coordinator:      coordinator.NewDummy(),                                          // dummy vehicle coordinator
 		tasks:            util.NewQueue[Task](),                                           // task queue
 		phaseTimerAction: timerInactive,                                                   // avoid "" to improve consistency
+		lastUpdate:       clock.Now(),                                                     // initialize lastUpdate
 	}
 
 	return lp
@@ -539,7 +539,7 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 	}
 
 	// immediately allow pv mode activity
-	if lp.GetMode() == api.ModePV {
+	if !lp.enabled && lp.GetMode() == api.ModePV {
 		lp.elapsePVTimer()
 	}
 
@@ -1361,10 +1361,6 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 
 	now := lp.clock.Now()
 
-	// timestamp used to increase the remaining delay duration
-	phaseTimerLastEvaluation := lp.phaseTimerLastEvaluation
-	lp.phaseTimerLastEvaluation = now
-
 	activePhases := lp.ActivePhases()
 	maxPhases := lp.MaxActivePhases()
 	targetCurrent1P := effectiveCurrent*float64(activePhases) + powerToCurrent(-sitePower, 1)
@@ -1436,11 +1432,11 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 		}
 
 		// increase the remaining delay duration
-		timeSinceLastEval := now.Sub(phaseTimerLastEvaluation)
-		lp.phaseTimer = lp.phaseTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+		timeSinceLastUpdate := now.Sub(lp.lastUpdate)
+		lp.phaseTimer = lp.phaseTimer.Add(timeSinceLastUpdate * (timerIncreasingSpeed + 1))
 
 		// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
-		if cutoffTime := now.Add(timeSinceLastEval); lp.phaseTimer.After(cutoffTime) {
+		if cutoffTime := now.Add(timeSinceLastUpdate); lp.phaseTimer.After(cutoffTime) {
 			lp.resetPhaseTimer()
 		} else {
 			lp.publishTimer(phaseTimer, delay, timerIncreasing)
@@ -1548,10 +1544,6 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 	now := lp.clock.Now()
 
-	// timestamp used to increase the remaining delay duration
-	pvTimerLastEvaluation := lp.pvTimerLastEvaluation
-	lp.pvTimerLastEvaluation = now
-
 	if lp.enabled {
 		// estimate future site power after adjusting the charge current
 		projectedDeltaCurrent := legalTargetCurrent - effectiveCurrent
@@ -1587,11 +1579,11 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 			}
 
 			// increase the remaining delay duration
-			timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
-			lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+			timeSinceLastUpdate := now.Sub(lp.lastUpdate)
+			lp.pvTimer = lp.pvTimer.Add(timeSinceLastUpdate * (timerIncreasingSpeed + 1))
 
 			// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
-			if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
+			if cutoffTime := now.Add(timeSinceLastUpdate); lp.pvTimer.After(cutoffTime) {
 				lp.resetPVTimer()
 			} else {
 				lp.publishTimer(pvTimer, delay, timerIncreasing)
@@ -1631,11 +1623,11 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 		}
 
 		// increase the remaining delay duration
-		timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
-		lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+		timeSinceLastUpdate := now.Sub(lp.lastUpdate)
+		lp.pvTimer = lp.pvTimer.Add(timeSinceLastUpdate * (timerIncreasingSpeed + 1))
 
 		// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
-		if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
+		if cutoffTime := now.Add(timeSinceLastUpdate); lp.pvTimer.After(cutoffTime) {
 			lp.resetPVTimer()
 		} else {
 			lp.publishTimer(pvTimer, delay, timerIncreasing)
@@ -1956,6 +1948,10 @@ func (lp *Loadpoint) phaseSwitchCompleted() bool {
 
 // Update is the main control function. It reevaluates meters and charger state
 func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+	defer func() {
+		lp.lastUpdate = lp.clock.Now()
+	}()
+
 	// auto-disable battery boost when SOC drops below limit
 	if lp.GetBatteryBoost() != boostDisabled {
 		if limit := lp.GetBatteryBoostLimit(); limit < 100 {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -205,6 +205,13 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, other 
 		lp.Soc.Poll.Mode = loadpoint.PollCharging
 	}
 
+	// validate thresholds
+	if lp.Enable.Threshold > lp.Disable.Threshold {
+		lp.log.WARN.Printf("PV mode enable threshold (%.0fW) is larger than disable threshold (%.0fW)", lp.Enable.Threshold, lp.Disable.Threshold)
+	} else if lp.Enable.Threshold > 0 {
+		lp.log.WARN.Printf("PV mode enable threshold %.0fW > 0 will start PV charging on grid power consumption. Did you mean -%.0f?", lp.Enable.Threshold, lp.Enable.Threshold)
+	}
+
 	// choose sane default if mode is not set
 	if lp.mode = lp.DefaultMode; lp.mode == "" {
 		lp.mode = api.ModeOff
@@ -276,25 +283,6 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, other 
 
 		lp.phasesConfigured = phases
 		lp.phases = phases
-	}
-
-	// validate thresholds
-	if lp.Enable.Threshold > 0 {
-		lp.log.WARN.Printf("PV mode enable threshold %.0fW > 0 will start PV charging below residualPower (grid import). Did you mean %.0f?", lp.Enable.Threshold, -lp.Enable.Threshold)
-	}
-	if lp.Disable.Threshold < 0 {
-		lp.log.WARN.Printf("PV mode disable threshold %.0fW < 0 will stop PV charging above residualPower (grid export). Did you mean %.0f?", lp.Disable.Threshold, -lp.Disable.Threshold)
-	}
-	if lp.Enable.Threshold != 0 {
-		phases := lp.phasesConfigured
-		if phases == 0 {
-			phases = 3
-		}
-		minPower := defaultVoltage * lp.minCurrent * float64(phases) // "Voltage" has not yet been set
-		switchHysteresis := lp.Disable.Threshold - lp.Enable.Threshold
-		if switchHysteresis < minPower {
-			lp.log.WARN.Printf("disable threshold - enable threshold = %.0fW < %.0fW min %d-phase charge power", switchHysteresis, minPower, phases)
-		}
 	}
 
 	return lp, nil

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -167,7 +167,7 @@ type Loadpoint struct {
 	connectedTime    time.Time        // Time when vehicle was connected
 	pvTimer          time.Time        // PV enable/disable timer
 	phaseTimer       time.Time        // 1p3p switch timer
-	phaseTimerAction string           // 1p3p switch timer action (timerInactive, phaseScale1p, phaseScale3p)
+	phaseTimerAction string           // 1p3p switch timer action (timerInactive, timerIncreasing, phaseScale1p, phaseScale3p)
 	wakeUpTimer      *Timer           // Vehicle wake-up timeout
 	lastUpdate       time.Time        // last time Update() completed
 
@@ -1406,9 +1406,6 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 			return 0
 		}
 
-		// set to timerInactive for consistency, no need to differentiate between timerInactive and timerIncreasing
-		lp.phaseTimerAction = timerInactive
-
 		delay := lp.GetDisableDelay()
 		if upscalable {
 			delay = lp.GetEnableDelay()
@@ -1427,6 +1424,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 		if cutoffTime := now.Add(timeSinceLastUpdate); lp.phaseTimer.After(cutoffTime) {
 			lp.resetPhaseTimer()
 		} else {
+			lp.phaseTimerAction = timerIncreasing
 			lp.publishTimer(phaseTimer, delay, timerIncreasing)
 		}
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1579,7 +1579,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 	enableThreshold := lp.Enable.Threshold
 	if enableThreshold == 0 {
-		enableThreshold = -currentToPower(minCurrent, lp.MinActivePhases())
+		enableThreshold = -currentToPower(minCurrent, projectedActivePhases)
 	}
 
 	// kick off enable sequence

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -55,6 +55,8 @@ const (
 	timerReset      = "reset"
 	timerElapse     = "elapse"
 
+	timerIncreasingSpeed = 2 // speed at which the remaining delay duration increases when switching conditions are not met
+
 	minActiveCurrent = 1.0 // minimum current at which a phase is treated as active
 	minActiveVoltage = 207 // minimum voltage at which a phase is treated as active
 
@@ -65,13 +67,13 @@ const (
 	boostDisabled = 0
 	boostStart    = 1
 	boostContinue = 2
+
+	// poll modes
+	pollInterval = 60 * time.Minute
 )
 
 // elapsed is the time an expired timer will be set to
 var elapsed = time.Unix(0, 1)
-
-// Poll modes
-const pollInterval = 60 * time.Minute
 
 // Task is the task type
 type Task = func()
@@ -1412,24 +1414,26 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 
 		lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
 	} else if !lp.phaseTimer.IsZero() {
-		// reset the timer if at least one condition is met:
-		//  - possible scaling direction is ambiguous
-		//  - the remaining delay duration already exceeds the upper limit
-		//  - the timer was put into elapsed state
-		// otherwise...
-		if upscalable == downscalable || lp.phaseTimer.After(now) || lp.phaseTimer.Equal(elapsed) {
+		if upscalable == downscalable || lp.phaseTimer.Equal(elapsed) {
 			lp.resetPhaseTimer()
-		} else { // ...increase the remaining delay duration
-			lp.phaseTimer = lp.phaseTimer.Add(2 * now.Sub(phaseTimerLastEvaluation))
-
+		} else {
 			// set to timerInactive for consistency, no need to differentiate between timerInactive and timerIncreasing
 			lp.phaseTimerAction = timerInactive
 
-			delay := lp.GetDisableDelay()
-			if upscalable {
-				delay = lp.GetEnableDelay()
+			// increase the remaining delay duration
+			timeSinceLastEval := now.Sub(phaseTimerLastEvaluation)
+			lp.phaseTimer = lp.phaseTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+
+			// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
+			if cutoffTime := now.Add(timeSinceLastEval); lp.phaseTimer.After(cutoffTime) {
+				lp.resetPhaseTimer()
+			} else {
+				delay := lp.GetDisableDelay()
+				if upscalable {
+					delay = lp.GetEnableDelay()
+				}
+				lp.publishTimer(phaseTimer, delay, timerIncreasing)
 			}
-			lp.publishTimer(phaseTimer, delay, timerIncreasing)
 		}
 	}
 
@@ -1564,13 +1568,19 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 			lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
 		} else if !lp.pvTimer.IsZero() {
-			// reset the timer if the remaining delay duration already exceeds the upper limit or
-			// if the timer was put into elapsed state, otherwise...
-			if lp.pvTimer.After(now) || lp.pvTimer.Equal(elapsed) {
+			if lp.pvTimer.Equal(elapsed) {
 				lp.resetPVTimer()
-			} else { // ...increase the remaining delay duration
-				lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(pvTimerLastEvaluation))
-				lp.publishTimer(pvTimer, lp.GetDisableDelay(), timerIncreasing)
+			} else {
+				// increase the remaining delay duration
+				timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
+				lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+
+				// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
+				if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
+					lp.resetPVTimer()
+				} else {
+					lp.publishTimer(pvTimer, lp.GetDisableDelay(), timerIncreasing)
+				}
 			}
 		}
 
@@ -1598,13 +1608,19 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 		lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
 	} else if !lp.pvTimer.IsZero() {
-		// reset the timer if the remaining delay duration already exceeds the upper limit or
-		// if the timer was put into elapsed state, otherwise...
-		if lp.pvTimer.After(now) || lp.pvTimer.Equal(elapsed) {
+		if lp.pvTimer.Equal(elapsed) {
 			lp.resetPVTimer()
-		} else { // ...increase the remaining delay duration
-			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(pvTimerLastEvaluation))
-			lp.publishTimer(pvTimer, lp.GetEnableDelay(), timerIncreasing)
+		} else {
+			// increase the remaining delay duration
+			timeSinceLastEval := now.Sub(pvTimerLastEvaluation)
+			lp.pvTimer = lp.pvTimer.Add(timeSinceLastEval * (timerIncreasingSpeed + 1))
+
+			// reset timer if the configured delay duration is still expected to be exceeded during the next evaluation
+			if cutoffTime := now.Add(timeSinceLastEval); lp.pvTimer.After(cutoffTime) {
+				lp.resetPVTimer()
+			} else {
+				lp.publishTimer(pvTimer, lp.GetEnableDelay(), timerIncreasing)
+			}
 		}
 	}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1936,7 +1936,13 @@ func (lp *Loadpoint) phaseSwitchCompleted() bool {
 
 // Update is the main control function. It reevaluates meters and charger state
 func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+	// reset timers by default
+	resetTimers := true
 	defer func() {
+		if resetTimers {
+			lp.resetPhaseTimer()
+			lp.resetPVTimer()
+		}
 		lp.lastUpdate = lp.clock.Now()
 	}()
 
@@ -2056,7 +2062,7 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	minSocNotReached := lp.minSocNotReached()
 	lp.publish(keys.MinSocNotReached, minSocNotReached)
 
-	// execute loading strategy
+	// execute charging strategy
 	switch {
 	case !lp.connected():
 		// always disable charger if not connected
@@ -2075,6 +2081,7 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 
 	// minimum or target charging
 	case minSocNotReached || plannerActive:
+		resetTimers = false
 		err = lp.fastCharging()
 		lp.resetPhaseTimer()
 		lp.elapsePVTimer() // let PV mode disable immediately afterwards
@@ -2082,20 +2089,18 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	case lp.LimitEnergyReached():
 		lp.log.DEBUG.Printf("limitEnergy reached: %.0fkWh > %0.1fkWh", lp.GetChargedEnergy()/1e3, lp.limitEnergy)
 		err = lp.disableUnlessClimater()
-		lp.resetPhaseTimer() // limit can be increased anytime
-		lp.resetPVTimer()
 
 	case lp.LimitSocReached():
 		lp.log.DEBUG.Printf("limitSoc reached: %.1f%% > %d%%", lp.vehicleSoc, lp.EffectiveLimitSoc())
 		err = lp.disableUnlessClimater()
-		lp.resetPhaseTimer() // limit can be increased anytime
-		lp.resetPVTimer()
 
 	// immediate charging- must be placed after limits are evaluated
 	case mode == api.ModeNow:
 		err = lp.fastCharging()
 
 	case mode == api.ModeMinPV || mode == api.ModePV:
+		resetTimers = false
+
 		// cheap tariff
 		if smartCostActive {
 			rate, _ := consumption.At(time.Now())

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -50,7 +50,10 @@ const (
 	phaseScale1p = "scale1p"
 	phaseScale3p = "scale3p"
 
-	timerInactive = "inactive"
+	timerInactive   = "inactive"
+	timerIncreasing = "increasing"
+	timerReset      = "reset"
+	timerElapse     = "elapse"
 
 	minActiveCurrent = 1.0 // minimum current at which a phase is treated as active
 	minActiveVoltage = 207 // minimum voltage at which a phase is treated as active
@@ -156,13 +159,16 @@ type Loadpoint struct {
 	planLocked       PlanLock         // locked plan
 
 	// cached state
-	status         api.ChargeStatus // Charger status
-	chargePower    float64          // Charging power
-	chargeCurrents []float64        // Phase currents
-	connectedTime  time.Time        // Time when vehicle was connected
-	pvTimer        time.Time        // PV enabled/disable timer
-	phaseTimer     time.Time        // 1p3p switch timer
-	wakeUpTimer    *Timer           // Vehicle wake-up timeout
+	status                   api.ChargeStatus // Charger status
+	chargePower              float64          // Charging power
+	chargeCurrents           []float64        // Phase currents
+	connectedTime            time.Time        // Time when vehicle was connected
+	pvTimer                  time.Time        // PV enable/disable timer
+	pvTimerLastEvaluation    time.Time        // PV enable/disable timer last evaluation time
+	phaseTimer               time.Time        // 1p3p switch timer
+	phaseTimerLastEvaluation time.Time        // 1p3p switch timer last evaluation time
+	phaseTimerAction         string           // 1p3p switch timer action (timerInactive, phaseScale1p, phaseScale3p)
+	wakeUpTimer              *Timer           // Vehicle wake-up timeout
 
 	// charge progress
 	vehicleSoc              float64       // Vehicle or charger soc
@@ -196,13 +202,6 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, other 
 		lp.log.WARN.Printf("poll mode '%s' may deplete your battery or lead to API misuse. USE AT YOUR OWN RISK.", lp.Soc.Poll)
 	default:
 		lp.Soc.Poll.Mode = loadpoint.PollCharging
-	}
-
-	// validate thresholds
-	if lp.Enable.Threshold > lp.Disable.Threshold {
-		lp.log.WARN.Printf("PV mode enable threshold (%.0fW) is larger than disable threshold (%.0fW)", lp.Enable.Threshold, lp.Disable.Threshold)
-	} else if lp.Enable.Threshold > 0 {
-		lp.log.WARN.Printf("PV mode enable threshold %.0fW > 0 will start PV charging on grid power consumption. Did you mean -%.0f?", lp.Enable.Threshold, lp.Enable.Threshold)
 	}
 
 	// choose sane default if mode is not set
@@ -278,6 +277,25 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, other 
 		lp.phases = phases
 	}
 
+	// validate thresholds
+	if lp.Enable.Threshold > 0 {
+		lp.log.WARN.Printf("PV mode enable threshold %.0fW > 0 will start PV charging below residualPower (grid import). Did you mean %.0f?", lp.Enable.Threshold, -lp.Enable.Threshold)
+	}
+	if lp.Disable.Threshold < 0 {
+		lp.log.WARN.Printf("PV mode disable threshold %.0fW < 0 will stop PV charging above residualPower (grid export). Did you mean %.0f?", lp.Disable.Threshold, -lp.Disable.Threshold)
+	}
+	if lp.Enable.Threshold != 0 {
+		phases := lp.phasesConfigured
+		if phases == 0 {
+			phases = 3
+		}
+		minPower := defaultVoltage * lp.minCurrent * float64(phases) // "Voltage" has not yet been set
+		switchHysteresis := lp.Disable.Threshold - lp.Enable.Threshold
+		if switchHysteresis < minPower {
+			lp.log.WARN.Printf("disable threshold - enable threshold = %.0fW < %.0fW min %d-phase charge power", switchHysteresis, minPower, phases)
+		}
+	}
+
 	return lp, nil
 }
 
@@ -302,11 +320,12 @@ func NewLoadpoint(log *util.Logger, settings settings.Settings) *Loadpoint {
 				Mode:     loadpoint.PollCharging,
 			},
 		},
-		Enable:      loadpoint.ThresholdConfig{Delay: time.Minute, Threshold: 0},     // t, W
-		Disable:     loadpoint.ThresholdConfig{Delay: 3 * time.Minute, Threshold: 0}, // t, W
-		progress:    NewProgress(0, 10),                                              // soc progress indicator
-		coordinator: coordinator.NewDummy(),                                          // dummy vehicle coordinator
-		tasks:       util.NewQueue[Task](),                                           // task queue
+		Enable:           loadpoint.ThresholdConfig{Delay: time.Minute, Threshold: 0},     // t, W
+		Disable:          loadpoint.ThresholdConfig{Delay: 3 * time.Minute, Threshold: 0}, // t, W
+		progress:         NewProgress(0, 10),                                              // soc progress indicator
+		coordinator:      coordinator.NewDummy(),                                          // dummy vehicle coordinator
+		tasks:            util.NewQueue[Task](),                                           // task queue
+		phaseTimerAction: timerInactive,                                                   // avoid "" to improve consistency
 	}
 
 	return lp
@@ -518,7 +537,9 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 	}
 
 	// immediately allow pv mode activity
-	lp.elapsePVTimer()
+	if lp.GetMode() == api.ModePV {
+		lp.elapsePVTimer()
+	}
 
 	// create charging session
 	lp.createSession()
@@ -731,6 +752,7 @@ func (lp *Loadpoint) setAndPublishEnabled(enabled bool) {
 	if enabled != lp.enabled {
 		lp.log.DEBUG.Printf("charger %s", status[enabled])
 		lp.enabled = enabled
+		lp.resetPVTimer() // prevent immediate re-enabling / re-disabling
 	}
 	lp.publish(keys.Enabled, enabled)
 }
@@ -1198,26 +1220,18 @@ func (lp *Loadpoint) elapsePVTimer() {
 		return
 	}
 
-	lp.log.DEBUG.Printf("pv timer elapse")
-
 	lp.pvTimer = elapsed
-	lp.publishTimer(pvTimer, 0, timerInactive)
+	lp.publishTimer(pvTimer, 0, timerElapse)
 }
 
 // resetPVTimer resets the pv enable/disable timer to disabled state
-func (lp *Loadpoint) resetPVTimer(typ ...string) {
+func (lp *Loadpoint) resetPVTimer() {
 	if lp.pvTimer.IsZero() {
 		return
 	}
 
-	msg := "pv timer reset"
-	if len(typ) == 1 {
-		msg = fmt.Sprintf("pv %s timer reset", typ[0])
-	}
-	lp.log.DEBUG.Println(msg)
-
 	lp.pvTimer = time.Time{}
-	lp.publishTimer(pvTimer, 0, timerInactive)
+	lp.publishTimer(pvTimer, 0, timerReset)
 }
 
 // resetPhaseTimer resets the phase switch timer to disabled state
@@ -1227,7 +1241,30 @@ func (lp *Loadpoint) resetPhaseTimer() {
 	}
 
 	lp.phaseTimer = time.Time{}
-	lp.publishTimer(phaseTimer, 0, timerInactive)
+	lp.phaseTimerAction = timerInactive
+	lp.publishTimer(phaseTimer, 0, timerReset)
+}
+
+// publishTimer sends timer data to UI and generates a log message
+func (lp *Loadpoint) publishTimer(name string, delay time.Duration, action string) {
+	timer := lp.pvTimer
+	if name == phaseTimer {
+		timer = lp.phaseTimer
+	}
+
+	remaining := max(delay-lp.clock.Since(timer), 0)
+
+	lp.publish(name+"Action", action)
+	lp.publish(name+"Remaining", remaining)
+
+	switch action {
+	case timerInactive, timerReset, timerElapse:
+		lp.log.DEBUG.Printf("%s timer %s", name, action)
+	case timerIncreasing:
+		lp.log.DEBUG.Printf("%s timer %s to %v", name, action, remaining.Round(time.Second))
+	default:
+		lp.log.DEBUG.Printf("%s %s in %v", name, action, remaining.Round(time.Second))
+	}
 }
 
 // scalePhasesRequired validates if fixed phase configuration matches enabled phases
@@ -1299,8 +1336,13 @@ func (lp *Loadpoint) fastCharging() error {
 	return lp.setLimit(lp.effectiveMaxCurrent())
 }
 
-// pvScalePhases switches phases if necessary and returns number of phases switched to
-func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) int {
+// pvScalePhases switches phases if necessary according to the given parameters
+// Returns:
+//
+//	1                    if switched to 1p
+//	lp.MaxActivePhases() if switched to 3p
+//	0                    otherwise
+func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveCurrent float64) int {
 	phases := lp.GetPhases()
 
 	// observed phase state inconsistency
@@ -1315,90 +1357,83 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		lp.ResetMeasuredPhases()
 	}
 
-	var waiting bool
-	activePhases := lp.ActivePhases()
-	availablePower := lp.chargePower - sitePower
-	scalable := (sitePower > 0 || !lp.enabled) && activePhases > 1 && lp.phasesConfigured < 3
+	now := lp.clock.Now()
 
-	// scale down phases
-	if targetCurrent := powerToCurrent(availablePower, activePhases); targetCurrent < minCurrent && scalable {
-		lp.log.DEBUG.Printf("available power %.0fW < %.0fW min %dp threshold", availablePower, float64(activePhases)*Voltage*minCurrent, activePhases)
+	// timestamp used to increase the remaining delay duration
+	phaseTimerLastEvaluation := lp.phaseTimerLastEvaluation
+	lp.phaseTimerLastEvaluation = now
+
+	activePhases := lp.ActivePhases()
+	maxPhases := lp.MaxActivePhases()
+	targetCurrent1P := effectiveCurrent*float64(activePhases) + powerToCurrent(-sitePower, 1)
+	targetCurrentMaxP := targetCurrent1P / float64(maxPhases)
+	upscalable := maxPhases > 1 && phases < maxPhases
+	downscalable := activePhases > 1 && lp.phasesConfigured < 3
+
+	if downscalable && targetCurrentMaxP < minCurrent {
+		// scale down phases
+		lp.log.DEBUG.Printf("available %dp current %.3gA < %.3gA min threshold", maxPhases, targetCurrentMaxP, minCurrent)
+		lp.phaseTimerAction = phaseScale1p
 
 		if !lp.charging() { // scale immediately if not charging
 			lp.phaseTimer = elapsed
-		}
-
-		if lp.phaseTimer.IsZero() {
+		} else if lp.phaseTimer.IsZero() || lp.phaseTimer.After(now) {
 			lp.log.DEBUG.Printf("start phase %s timer", phaseScale1p)
-			lp.phaseTimer = lp.clock.Now()
+			lp.phaseTimer = now
 		}
 
-		lp.publishTimer(phaseTimer, lp.GetDisableDelay(), phaseScale1p)
-
-		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetDisableDelay() {
+		if elapsed := now.Sub(lp.phaseTimer); elapsed >= lp.GetDisableDelay() {
 			if err := lp.scalePhases(1); err != nil {
 				lp.log.ERROR.Println(err)
 			}
 			return 1
 		}
 
-		waiting = true
-	}
-
-	maxPhases := lp.MaxActivePhases()
-	target1pCurrent := powerToCurrent(availablePower, 1)
-	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent
-
-	// scale up phases
-	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {
-		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, float64(maxPhases)*Voltage*minCurrent, maxPhases)
+		lp.publishTimer(phaseTimer, lp.GetDisableDelay(), phaseScale1p)
+	} else if upscalable && targetCurrentMaxP >= minCurrent && targetCurrent1P > maxCurrent {
+		// scale up phases
+		lp.log.DEBUG.Printf("available 1p current %.3gA > %.3gA max threshold", targetCurrent1P, maxCurrent)
+		lp.log.DEBUG.Printf("available %dp current %.3gA >= %.3gA min threshold", maxPhases, targetCurrentMaxP, minCurrent)
+		lp.phaseTimerAction = phaseScale3p
 
 		if !lp.charging() { // scale immediately if not charging
 			lp.phaseTimer = elapsed
-		}
-
-		if lp.phaseTimer.IsZero() {
+		} else if lp.phaseTimer.IsZero() || lp.phaseTimer.After(now) {
 			lp.log.DEBUG.Printf("start phase %s timer", phaseScale3p)
-			lp.phaseTimer = lp.clock.Now()
+			lp.phaseTimer = now
 		}
 
-		lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
-
-		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetEnableDelay() {
+		if elapsed := now.Sub(lp.phaseTimer); elapsed >= lp.GetEnableDelay() {
 			if err := lp.scalePhases(3); err != nil {
 				lp.log.ERROR.Println(err)
 			}
-			return 3
+			return maxPhases
 		}
 
-		waiting = true
-	}
+		lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
+	} else if !lp.phaseTimer.IsZero() {
+		// reset the timer if at least one condition is met:
+		//  - scaling is currently disallowed
+		//  - the remaining delay duration already exceeds the upper limit
+		//  - the timer was put into elapsed state
+		// otherwise...
+		if !upscalable && !downscalable || lp.phaseTimer.After(now) || lp.phaseTimer.Equal(elapsed) {
+			lp.resetPhaseTimer()
+		} else { // ...increase the remaining delay duration
+			lp.phaseTimer = lp.phaseTimer.Add(2 * now.Sub(phaseTimerLastEvaluation))
 
-	// reset timer to disabled state
-	if !waiting && !lp.phaseTimer.IsZero() {
-		lp.resetPhaseTimer()
+			// set to timerInactive for consistency, no need to differentiate between timerInactive and timerIncreasing
+			lp.phaseTimerAction = timerInactive
+
+			delay := lp.GetDisableDelay()
+			if upscalable {
+				delay = lp.GetEnableDelay()
+			}
+			lp.publishTimer(phaseTimer, delay, timerIncreasing)
+		}
 	}
 
 	return 0
-}
-
-// TODO move up to timer functions
-func (lp *Loadpoint) publishTimer(name string, delay time.Duration, action string) {
-	timer := lp.pvTimer
-	if name == phaseTimer {
-		timer = lp.phaseTimer
-	}
-
-	remaining := max(delay-lp.clock.Since(timer), 0)
-
-	lp.publish(name+"Action", action)
-	lp.publish(name+"Remaining", remaining)
-
-	if action == timerInactive {
-		lp.log.DEBUG.Printf("%s timer %s", name, action)
-	} else {
-		lp.log.DEBUG.Printf("%s %s in %v", name, action, remaining.Round(time.Second))
-	}
 }
 
 // boostPower returns the additional power that the loadpoint should draw from the battery
@@ -1441,126 +1476,147 @@ func (lp *Loadpoint) boostPower(batteryBoostPower float64) float64 {
 }
 
 // pvMaxCurrent calculates the maximum target current for PV mode
-func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPower float64, batteryBuffered, batteryStart bool) float64 {
+func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPower float64, batteryBuffered, forcedCharging bool) float64 {
 	// read only once to simplify testing
 	minCurrent := lp.effectiveMinCurrent()
 	maxCurrent := lp.effectiveMaxCurrent()
+
+	activePhases := lp.ActivePhases()
+	effectiveCurrent := lp.effectiveCurrent()
+	if lp.chargerHasFeature(api.IntegratedDevice) {
+		// for slow-acting heating devices, only take actually consumed power into account
+		effectiveCurrent = powerToCurrent(lp.chargePower, activePhases)
+	}
 
 	// push demand to drain battery
 	sitePower -= lp.boostPower(batteryBoostPower)
 
 	// switch phases up/down
-	var scaledTo int
+	projectedActivePhases := activePhases
 	if lp.hasPhaseSwitching() && lp.phaseSwitchCompleted() {
-		scaledTo = lp.pvScalePhases(sitePower, minCurrent, maxCurrent)
+		projectedActivePhases = lp.pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveCurrent)
+		if projectedActivePhases > 0 {
+			// if we did scale, adjust the effective current to the new phase count
+			effectiveCurrent *= float64(activePhases) / float64(projectedActivePhases)
+		} else {
+			projectedActivePhases = activePhases
+		}
 	}
 
-	// calculate target charge current from delta power and actual current
-	activePhases := lp.ActivePhases()
-	effectiveCurrent := lp.effectiveCurrent()
-	if scaledTo == 3 {
-		// if we did scale, adjust the effective current to the new phase count
-		effectiveCurrent /= float64(lp.maxActivePhases())
-	}
-	if lp.chargerHasFeature(api.IntegratedDevice) {
-		// for slow-acting heating devices, only take actually consumed power into account
-		effectiveCurrent = powerToCurrent(lp.chargePower, activePhases)
-	}
-	deltaCurrent := powerToCurrent(-sitePower, activePhases)
+	// calculate target charge current from delta power and actual (scaled) current
+	deltaCurrent := powerToCurrent(-sitePower, projectedActivePhases)
 	targetCurrent := max(effectiveCurrent+deltaCurrent, 0)
 
-	// in MinPV mode or under special conditions return at least minCurrent
-	if battery := batteryStart || batteryBuffered && lp.charging(); (mode == api.ModeMinPV || battery) && targetCurrent < minCurrent {
-		lp.log.DEBUG.Printf("pv charge current: min %.3gA > %.3gA (%.0fW @ %dp, battery: %t)", minCurrent, targetCurrent, sitePower, activePhases, battery)
+	// compile log message
+	options := []byte(", batteryBuffered, forcedCharging")
+	lo, hi := 17, 17
+	if batteryBuffered {
+		lo = 0
+	}
+	if forcedCharging {
+		hi = len(options)
+	}
+	lp.log.DEBUG.Printf("pv charge current: %.3gA = %.3gA + %.3gA (%.0fW @ %dp%s)", targetCurrent, effectiveCurrent, deltaCurrent, sitePower, projectedActivePhases, options[lo:hi])
+
+	// if battery buffering is enabled while charging, return at least minCurrent
+	if targetCurrent < minCurrent && batteryBuffered && lp.charging() {
+		lp.resetPVTimer() // reset timer to avoid skipping the delay unexpectedly
 		return minCurrent
 	}
 
-	lp.log.DEBUG.Printf("pv charge current: %.3gA = %.3gA + %.3gA (%.0fW @ %dp)", targetCurrent, effectiveCurrent, deltaCurrent, sitePower, activePhases)
+	// apply limits
+	legalTargetCurrent := min(max(minCurrent, targetCurrent), maxCurrent)
 
-	if mode == api.ModePV && lp.enabled && targetCurrent < minCurrent {
-		projectedSitePower := sitePower
-		if lp.hasPhaseSwitching() && !lp.phaseTimer.IsZero() {
-			// calculate site power after a phase switch from activePhases phases -> 1 phase
-			// notes: activePhases can be 1, 2 or 3 and phaseTimer can only be active if lp current is already at minCurrent
-			projectedSitePower -= Voltage * minCurrent * float64(activePhases-1)
-		}
-		// kick off disable sequence
-		if projectedSitePower >= lp.Disable.Threshold {
-			lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
-
-			if lp.pvTimer.IsZero() {
-				lp.log.DEBUG.Printf("pv disable timer start: %v", lp.GetDisableDelay())
-				lp.pvTimer = lp.clock.Now()
-			}
-
-			lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
-
-			elapsed := lp.clock.Since(lp.pvTimer)
-			if elapsed >= lp.GetDisableDelay() {
-				lp.log.DEBUG.Println("pv disable timer elapsed")
-
-				// reset timer to prevent immediate charger re-enabling
-				lp.resetPVTimer()
-
-				return 0
-			}
-
-			// suppress duplicate log message after timer started
-			if elapsed > time.Second {
-				lp.log.DEBUG.Printf("pv disable timer remaining: %v", (lp.GetDisableDelay() - elapsed).Round(time.Second))
-			}
-		} else {
-			// reset timer
-			lp.resetPVTimer("disable")
-		}
-
-		// lp.log.DEBUG.Println("pv disable timer: keep enabled")
-		return minCurrent
+	if forcedCharging || mode != api.ModePV {
+		lp.resetPVTimer() // reset timer to avoid skipping the delay unexpectedly
+		return legalTargetCurrent
 	}
 
-	if mode == api.ModePV && !lp.enabled {
+	now := lp.clock.Now()
+
+	// timestamp used to increase the remaining delay duration
+	pvTimerLastEvaluation := lp.pvTimerLastEvaluation
+	lp.pvTimerLastEvaluation = now
+
+	if !lp.enabled {
+		enableThreshold := lp.Enable.Threshold
+		if enableThreshold == 0 {
+			enableThreshold = -currentToPower(minCurrent, lp.MinActivePhases())
+		}
+
 		// kick off enable sequence
-		if (lp.Enable.Threshold == 0 && targetCurrent >= minCurrent) ||
-			(lp.Enable.Threshold != 0 && sitePower <= lp.Enable.Threshold) {
-			lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, lp.Enable.Threshold)
+		if sitePower <= enableThreshold {
+			lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, enableThreshold)
 
-			if lp.pvTimer.IsZero() {
+			if lp.pvTimer.IsZero() || lp.pvTimer.After(now) {
 				lp.log.DEBUG.Printf("pv enable timer start: %v", lp.GetEnableDelay())
-				lp.pvTimer = lp.clock.Now()
+				lp.pvTimer = now
 			}
 
-			lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
-
-			elapsed := lp.clock.Since(lp.pvTimer)
-			if elapsed >= lp.GetEnableDelay() {
+			if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetEnableDelay() {
 				lp.log.DEBUG.Println("pv enable timer elapsed")
 
 				// reset timer to prevent immediate charger re-disabling
 				lp.resetPVTimer()
 
-				return minCurrent
+				return legalTargetCurrent
 			}
 
-			// suppress duplicate log message after timer started
-			if elapsed > time.Second {
-				lp.log.DEBUG.Printf("pv enable timer remaining: %v", (lp.GetEnableDelay() - elapsed).Round(time.Second))
+			lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
+		} else if !lp.pvTimer.IsZero() {
+			// reset the timer if the remaining delay duration already exceeds the upper limit or
+			// if the timer was put into elapsed state, otherwise...
+			if lp.pvTimer.After(now) || lp.pvTimer.Equal(elapsed) {
+				lp.resetPVTimer()
+			} else { // ...increase the remaining delay duration
+				lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(pvTimerLastEvaluation))
+				lp.publishTimer(pvTimer, lp.GetEnableDelay(), timerIncreasing)
 			}
-		} else {
-			// reset timer
-			lp.resetPVTimer("enable")
 		}
 
-		// lp.log.DEBUG.Println("pv enable timer: keep disabled")
 		return 0
 	}
 
-	// reset timer to disabled state
-	lp.resetPVTimer()
+	// estimate future site power after adjusting the charge current
+	projectedDeltaCurrent := legalTargetCurrent - effectiveCurrent
+	projectedSitePower := sitePower + currentToPower(projectedDeltaCurrent, projectedActivePhases)
 
-	// cap at maximum current
-	targetCurrent = min(targetCurrent, maxCurrent)
+	// adjust projectedSitePower if a phase switch down is expected to happen soon
+	if lp.phaseTimerAction == phaseScale1p {
+		projectedSitePower -= currentToPower(legalTargetCurrent, projectedActivePhases-1)
+	}
 
-	return targetCurrent
+	// kick off disable sequence
+	if projectedSitePower >= lp.Disable.Threshold && targetCurrent < minCurrent {
+		lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
+
+		if lp.pvTimer.IsZero() || lp.pvTimer.After(now) {
+			lp.log.DEBUG.Printf("pv disable timer start: %v", lp.GetDisableDelay())
+			lp.pvTimer = now
+		}
+
+		if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetDisableDelay() {
+			lp.log.DEBUG.Println("pv disable timer elapsed")
+
+			// reset timer to prevent immediate charger re-enabling
+			lp.resetPVTimer()
+
+			return 0
+		}
+
+		lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
+	} else if !lp.pvTimer.IsZero() {
+		// reset the timer if the remaining delay duration already exceeds the upper limit or
+		// if the timer was put into elapsed state, otherwise...
+		if lp.pvTimer.After(now) || lp.pvTimer.Equal(elapsed) {
+			lp.resetPVTimer()
+		} else { // ...increase the remaining delay duration
+			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(pvTimerLastEvaluation))
+			lp.publishTimer(pvTimer, lp.GetDisableDelay(), timerIncreasing)
+		}
+	}
+
+	return legalTargetCurrent
 }
 
 // UpdateChargePowerAndCurrents updates charge meter power and currents for load management
@@ -2016,10 +2072,14 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	case lp.LimitEnergyReached():
 		lp.log.DEBUG.Printf("limitEnergy reached: %.0fkWh > %0.1fkWh", lp.GetChargedEnergy()/1e3, lp.limitEnergy)
 		err = lp.disableUnlessClimater()
+		lp.resetPhaseTimer() // limit can be increased anytime
+		lp.resetPVTimer()
 
 	case lp.LimitSocReached():
 		lp.log.DEBUG.Printf("limitSoc reached: %.1f%% > %d%%", lp.vehicleSoc, lp.EffectiveLimitSoc())
 		err = lp.disableUnlessClimater()
+		lp.resetPhaseTimer() // limit can be increased anytime
+		lp.resetPVTimer()
 
 	// immediate charging- must be placed after limits are evaluated
 	case mode == api.ModeNow:
@@ -2052,16 +2112,8 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 			break
 		}
 
-		targetCurrent := lp.pvMaxCurrent(mode, sitePower, batteryBoostPower, batteryBuffered, batteryStart)
-
-		if targetCurrent == 0 && lp.vehicleClimateActive() {
-			targetCurrent = lp.effectiveMinCurrent()
-		}
-
-		if targetCurrent == 0 && welcomeCharge {
-			targetCurrent = lp.effectiveMinCurrent()
-			lp.resetPVTimer()
-		}
+		forcedCharging := batteryStart || welcomeCharge || lp.vehicleClimateActive()
+		targetCurrent := lp.pvMaxCurrent(mode, sitePower, batteryBoostPower, batteryBuffered, forcedCharging)
 
 		err = lp.setLimit(targetCurrent)
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1538,31 +1538,35 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	pvTimerLastEvaluation := lp.pvTimerLastEvaluation
 	lp.pvTimerLastEvaluation = now
 
-	if !lp.enabled {
-		enableThreshold := lp.Enable.Threshold
-		if enableThreshold == 0 {
-			enableThreshold = -currentToPower(minCurrent, lp.MinActivePhases())
+	if lp.enabled {
+		// estimate future site power after adjusting the charge current
+		projectedDeltaCurrent := legalTargetCurrent - effectiveCurrent
+		projectedSitePower := sitePower + currentToPower(projectedDeltaCurrent, projectedActivePhases)
+
+		// adjust projectedSitePower if a phase switch down is expected to happen soon
+		if lp.phaseTimerAction == phaseScale1p {
+			projectedSitePower -= currentToPower(legalTargetCurrent, projectedActivePhases-1)
 		}
 
-		// kick off enable sequence
-		if sitePower <= enableThreshold {
-			lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, enableThreshold)
+		// kick off disable sequence
+		if projectedSitePower >= lp.Disable.Threshold && targetCurrent < minCurrent {
+			lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
 
 			if lp.pvTimer.IsZero() || lp.pvTimer.After(now) {
-				lp.log.DEBUG.Printf("pv enable timer start: %v", lp.GetEnableDelay())
+				lp.log.DEBUG.Printf("pv disable timer start: %v", lp.GetDisableDelay())
 				lp.pvTimer = now
 			}
 
-			if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetEnableDelay() {
-				lp.log.DEBUG.Println("pv enable timer elapsed")
+			if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetDisableDelay() {
+				lp.log.DEBUG.Println("pv disable timer elapsed")
 
-				// reset timer to prevent immediate charger re-disabling
+				// reset timer to prevent immediate charger re-enabling
 				lp.resetPVTimer()
 
-				return legalTargetCurrent
+				return 0
 			}
 
-			lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
+			lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
 		} else if !lp.pvTimer.IsZero() {
 			// reset the timer if the remaining delay duration already exceeds the upper limit or
 			// if the timer was put into elapsed state, otherwise...
@@ -1570,41 +1574,37 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 				lp.resetPVTimer()
 			} else { // ...increase the remaining delay duration
 				lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(pvTimerLastEvaluation))
-				lp.publishTimer(pvTimer, lp.GetEnableDelay(), timerIncreasing)
+				lp.publishTimer(pvTimer, lp.GetDisableDelay(), timerIncreasing)
 			}
 		}
 
-		return 0
+		return legalTargetCurrent
 	}
 
-	// estimate future site power after adjusting the charge current
-	projectedDeltaCurrent := legalTargetCurrent - effectiveCurrent
-	projectedSitePower := sitePower + currentToPower(projectedDeltaCurrent, projectedActivePhases)
-
-	// adjust projectedSitePower if a phase switch down is expected to happen soon
-	if lp.phaseTimerAction == phaseScale1p {
-		projectedSitePower -= currentToPower(legalTargetCurrent, projectedActivePhases-1)
+	enableThreshold := lp.Enable.Threshold
+	if enableThreshold == 0 {
+		enableThreshold = -currentToPower(minCurrent, lp.MinActivePhases())
 	}
 
-	// kick off disable sequence
-	if projectedSitePower >= lp.Disable.Threshold && targetCurrent < minCurrent {
-		lp.log.DEBUG.Printf("projected site power %.0fW >= %.0fW disable threshold", projectedSitePower, lp.Disable.Threshold)
+	// kick off enable sequence
+	if sitePower <= enableThreshold {
+		lp.log.DEBUG.Printf("site power %.0fW <= %.0fW enable threshold", sitePower, enableThreshold)
 
 		if lp.pvTimer.IsZero() || lp.pvTimer.After(now) {
-			lp.log.DEBUG.Printf("pv disable timer start: %v", lp.GetDisableDelay())
+			lp.log.DEBUG.Printf("pv enable timer start: %v", lp.GetEnableDelay())
 			lp.pvTimer = now
 		}
 
-		if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetDisableDelay() {
-			lp.log.DEBUG.Println("pv disable timer elapsed")
+		if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetEnableDelay() {
+			lp.log.DEBUG.Println("pv enable timer elapsed")
 
-			// reset timer to prevent immediate charger re-enabling
+			// reset timer to prevent immediate charger re-disabling
 			lp.resetPVTimer()
 
-			return 0
+			return legalTargetCurrent
 		}
 
-		lp.publishTimer(pvTimer, lp.GetDisableDelay(), pvDisable)
+		lp.publishTimer(pvTimer, lp.GetEnableDelay(), pvEnable)
 	} else if !lp.pvTimer.IsZero() {
 		// reset the timer if the remaining delay duration already exceeds the upper limit or
 		// if the timer was put into elapsed state, otherwise...
@@ -1612,11 +1612,11 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 			lp.resetPVTimer()
 		} else { // ...increase the remaining delay duration
 			lp.pvTimer = lp.pvTimer.Add(2 * now.Sub(pvTimerLastEvaluation))
-			lp.publishTimer(pvTimer, lp.GetDisableDelay(), timerIncreasing)
+			lp.publishTimer(pvTimer, lp.GetEnableDelay(), timerIncreasing)
 		}
 	}
 
-	return legalTargetCurrent
+	return 0
 }
 
 // UpdateChargePowerAndCurrents updates charge meter power and currents for load management

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1505,7 +1505,7 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 	// calculate target charge current from delta power and actual (scaled) current
 	deltaCurrent := powerToCurrent(-sitePower, projectedActivePhases)
-	targetCurrent := max(effectiveCurrent+deltaCurrent, 0)
+	targetCurrent := effectiveCurrent + deltaCurrent
 
 	// compile log message
 	options := []byte(", batteryBuffered, forcedCharging")

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1559,10 +1559,6 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 			if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetDisableDelay() {
 				lp.log.DEBUG.Println("pv disable timer elapsed")
-
-				// reset timer to prevent immediate charger re-enabling
-				lp.resetPVTimer()
-
 				return 0
 			}
 
@@ -1597,10 +1593,6 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 		if elapsed := now.Sub(lp.pvTimer); elapsed >= lp.GetEnableDelay() {
 			lp.log.DEBUG.Println("pv enable timer elapsed")
-
-			// reset timer to prevent immediate charger re-disabling
-			lp.resetPVTimer()
-
 			return legalTargetCurrent
 		}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1413,11 +1413,11 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent, effectiveC
 		lp.publishTimer(phaseTimer, lp.GetEnableDelay(), phaseScale3p)
 	} else if !lp.phaseTimer.IsZero() {
 		// reset the timer if at least one condition is met:
-		//  - scaling is currently disallowed
+		//  - possible scaling direction is ambiguous
 		//  - the remaining delay duration already exceeds the upper limit
 		//  - the timer was put into elapsed state
 		// otherwise...
-		if !upscalable && !downscalable || lp.phaseTimer.After(now) || lp.phaseTimer.Equal(elapsed) {
+		if upscalable == downscalable || lp.phaseTimer.After(now) || lp.phaseTimer.Equal(elapsed) {
 			lp.resetPhaseTimer()
 		} else { // ...increase the remaining delay duration
 			lp.phaseTimer = lp.phaseTimer.Add(2 * now.Sub(phaseTimerLastEvaluation))

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -177,7 +177,7 @@ func testScale(t *testing.T, lp *Loadpoint, sitePower float64, direction string,
 		// scale-up should only execute when the 1p max current is exceeded
 		// we're testing this here and remove the upscale expectation for the following test below 1p max current
 		if maxAmp := -sitePower / Voltage; maxAmp < maxA {
-			if scaled := lp.pvScalePhases(sitePower, minA, maxAmp-0.0001); scaled != 3 {
+			if scaled := lp.pvScalePhases(sitePower, minA, maxAmp-0.0001, 0); scaled != tc.maxExpected {
 				t.Errorf("%v act=%d max=%d missing scale %s at reduced max current %.1fA", tc, act, max, direction, maxAmp)
 			}
 
@@ -186,7 +186,7 @@ func testScale(t *testing.T, lp *Loadpoint, sitePower float64, direction string,
 		}
 	}
 
-	scaled := lp.pvScalePhases(sitePower, minA, maxA)
+	scaled := lp.pvScalePhases(sitePower, minA, maxA, 0)
 
 	if strings.Contains(testExpectation, testDirection) {
 		if scaled == 0 {
@@ -352,13 +352,8 @@ func TestPvScalePhasesTimer(t *testing.T) {
 
 		// switch down from 3p/3p configured/active
 		{"3/3->1, enough power", 3, 3, 0, 3, 0, nil},
-		{"3/3->1, enough power, timer elapsed, load point enabled", 3, 3, 0, 3, 0, func(lp *Loadpoint) {
+		{"3/3->1, enough power, timer elapsed", 3, 3, 0, 1, 1, func(lp *Loadpoint) {
 			lp.phaseTimer = elapsed
-			lp.enabled = true
-		}},
-		{"3/3->1, enough power, timer elapsed, load point disabled", 3, 3, 0, 1, 1, func(lp *Loadpoint) {
-			lp.phaseTimer = elapsed
-			lp.enabled = false
 		}},
 		{"3/3->1, kickoff", 3, 3, 0.1, 3, 0, func(lp *Loadpoint) {
 			lp.phaseTimer = time.Time{}
@@ -423,7 +418,7 @@ func TestPvScalePhasesTimer(t *testing.T) {
 			charger.MockPhaseSwitcher.EXPECT().Phases1p3p(tc.toPhases).Return(nil)
 		}
 
-		res := lp.pvScalePhases(tc.sitePower, minA, maxA)
+		res := lp.pvScalePhases(tc.sitePower, minA, maxA, 0)
 
 		require.Equal(t, tc.res, res, tc.desc)
 		require.Equal(t, tc.toPhases, lp.phases, tc.desc)

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -307,6 +307,7 @@ func TestPVHysteresis(t *testing.T) {
 			clock := clock.NewMock()
 			ctrl := gomock.NewController(t)
 			charger := api.NewMockCharger(ctrl)
+			start := clock.Now()
 
 			Voltage = 100
 			lp := &Loadpoint{
@@ -325,12 +326,11 @@ func TestPVHysteresis(t *testing.T) {
 					Threshold: tc.disable,
 					Delay:     dt,
 				},
+				lastUpdate: start,
 			}
 
 			// charging, otherwise PV mode logic is short-circuited
 			lp.status = status
-
-			start := clock.Now()
 
 			for step, se := range tc.series {
 				clock.Set(start.Add(se.delay))
@@ -340,6 +340,7 @@ func TestPVHysteresis(t *testing.T) {
 
 				lp.enabled = tc.enabled
 				current := lp.pvMaxCurrent(api.ModePV, se.site, 0, false, false)
+				lp.lastUpdate = clock.Now()
 
 				if current != se.current {
 					t.Errorf("step %d: wanted %.1f, got %.1f", step, se.current, current)

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -276,10 +276,10 @@ func TestPVHysteresis(t *testing.T) {
 		{false, -500, 0, []se{
 			{-500, 0, 0},
 			{-500, 10, 0},
-			{-499, 20, 0}, // should increase timer by 2 * (20 - 10) = 20 ns
-			{-500, 30, 0}, // should not change timer
-			{-500, dt + 19, 0},
-			{-500, dt + 20, minA},
+			{-499, 20, 0}, // should increase timer by (timerIncreasingSpeed+1) * (20 - 10)
+			{-500, dt, 0},
+			{-500, dt + (timerIncreasingSpeed+1)*10 - 1, 0},
+			{-500, dt + (timerIncreasingSpeed+1)*10, minA},
 		}},
 		// reset enable timer when threshold not met while timer active and threshold not configured
 		{false, 0, 0, []se{
@@ -293,10 +293,10 @@ func TestPVHysteresis(t *testing.T) {
 		{true, 0, 500, []se{
 			{-6*100*phases + 500, 0, minA},
 			{-6*100*phases + 500, 1, minA},
-			{-6*100*phases + 499, dt - 1, minA}, // increase timer by 2 * (dt - 1 - 1) = 2*dt - 4 ns
-			{-6*100*phases + 500, dt + 1, minA}, // restart timer
-			{-6*100*phases + 500, 2 * dt, minA}, // timer not elapsed
-			{-6*100*phases + 500, 2*dt + 1, 0},  // timer elapsed
+			{-6*100*phases + 499, dt - 1, minA},   // increase timer by (timerIncreasingSpeed+1) * (dt - 1 - 1)
+			{-6*100*phases + 500, dt + 1, minA},   // restart timer
+			{-6*100*phases + 500, 2*dt - 3, minA}, // timer not elapsed
+			{-6*100*phases + 500, 2*dt + 1, 0},    // timer elapsed
 		}},
 	}
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -258,28 +258,28 @@ func TestPVHysteresis(t *testing.T) {
 			{-6 * 100 * phases, dt - 1, minA},
 			{-6 * 100 * phases, dt + 1, minA},
 		}},
-		// keep enabled at min (negative threshold)
+		// keep enabled at min
 		{true, 0, 500, []se{
-			{-500, 0, minA},
-			{-500, 1, minA},
-			{-500, dt - 1, minA},
-			{-500, dt + 1, minA},
+			{-6*100*phases + 499, 0, minA},
+			{-6*100*phases + 499, 1, minA},
+			{-6*100*phases + 499, dt - 1, minA},
+			{-6*100*phases + 499, dt + 1, minA},
 		}},
 		// disable when threshold met
 		{true, 0, 500, []se{
-			{500, 0, minA},
-			{500, 1, minA},
-			{500, dt - 1, minA},
-			{500, dt + 1, 0},
+			{-6*100*phases + 500, 0, minA},
+			{-6*100*phases + 500, 1, minA},
+			{-6*100*phases + 500, dt - 1, minA},
+			{-6*100*phases + 500, dt + 1, 0},
 		}},
-		// reset enable timer when threshold not met while timer active
+		// increase enable timer when threshold not met while timer active
 		{false, -500, 0, []se{
 			{-500, 0, 0},
-			{-500, 1, 0},
-			{-499, dt - 1, 0}, // should reset timer
-			{-500, dt + 1, 0}, // new begin of timer
-			{-500, 2 * dt, 0},
-			{-500, 2*dt + 1, minA},
+			{-500, 10, 0},
+			{-499, 20, 0}, // should increase timer by 2 * (20 - 10) = 20 ns
+			{-500, 30, 0}, // should not change timer
+			{-500, dt + 19, 0},
+			{-500, dt + 20, minA},
 		}},
 		// reset enable timer when threshold not met while timer active and threshold not configured
 		{false, 0, 0, []se{
@@ -289,14 +289,14 @@ func TestPVHysteresis(t *testing.T) {
 			{-6 * 100 * phases, 2 * dt, 0},
 			{-6 * 100 * phases, 2*dt + 1, minA},
 		}},
-		// reset disable timer when threshold not met while timer active
+		// restart disable timer when threshold not met while timer active
 		{true, 0, 500, []se{
-			{500, 0, minA},
-			{500, 1, minA},
-			{499, dt - 1, minA}, // reset timer
-			{500, dt + 1, minA}, // within reset timer duration
-			{500, 2 * dt, minA}, // still within reset timer duration
-			{500, 2*dt + 1, 0},  // reset timer elapsed
+			{-6*100*phases + 500, 0, minA},
+			{-6*100*phases + 500, 1, minA},
+			{-6*100*phases + 499, dt - 1, minA}, // increase timer by 2 * (dt - 1 - 1) = 2*dt - 4 ns
+			{-6*100*phases + 500, dt + 1, minA}, // restart timer
+			{-6*100*phases + 500, 2 * dt, minA}, // timer not elapsed
+			{-6*100*phases + 500, 2*dt + 1, 0},  // timer elapsed
 		}},
 	}
 
@@ -709,17 +709,24 @@ func TestPVHysteresisAfterPhaseSwitch(t *testing.T) {
 	}{
 		// immediately disable when threshold met after phase switch
 		{[]se{
-			{1200, 0, minA},
-			{1200, 1, minA},
-			{1200, dt - 1, minA},
-			{1200, dt + 1, 0},
+			{-minA*100 + 1, 0, minA},
+			{-minA*100 + 1, 1, minA},
+			{-minA*100 + 1, dt - 1, minA},
+			{-minA*100 + 1, dt + 1, 0},
 		}},
 		// stay enabled when threshold not met after phase switch
 		{[]se{
-			{500, 0, minA},
-			{500, 1, minA},
-			{500, dt - 1, minA},
-			{500, dt + 1, minA},
+			{-minA * 100, 0, minA},
+			{-minA * 100, 1, minA},
+			{-minA * 100, dt - 1, minA},
+			{-minA * 100, dt + 1, minA},
+		}},
+		// immediately adjust current after phase switch (test requires maxA / minA < 3)
+		{[]se{
+			{-maxA * 100, 0, minA},
+			{-maxA * 100, 1, minA},
+			{-maxA * 100, dt - 1, minA},
+			{-maxA * 100, dt + 1, maxA},
 		}},
 	}
 

--- a/core/site.go
+++ b/core/site.go
@@ -41,7 +41,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const standbyPower = 10 // consider less than 10W as charger in standby
+const (
+	standbyPower   = 10  // consider less than 10W as charger in standby
+	defaultVoltage = 230 // V
+)
 
 // updater abstracts the Loadpoint implementation for testing
 type updater interface {
@@ -241,7 +244,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 func NewSite() *Site {
 	site := &Site{
 		log:             util.NewLogger("site"),
-		Voltage:         230, // V
+		Voltage:         defaultVoltage,
 		pvEnergy:        make(map[string]*meterEnergy),
 		fcstEnergy:      &meterEnergy{clock: clock.New()},
 		householdEnergy: &meterEnergy{clock: clock.New()},

--- a/core/site.go
+++ b/core/site.go
@@ -41,10 +41,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	standbyPower   = 10  // consider less than 10W as charger in standby
-	defaultVoltage = 230 // V
-)
+const standbyPower = 10 // consider less than 10W as charger in standby
 
 // updater abstracts the Loadpoint implementation for testing
 type updater interface {
@@ -244,7 +241,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 func NewSite() *Site {
 	site := &Site{
 		log:             util.NewLogger("site"),
-		Voltage:         defaultVoltage,
+		Voltage:         230, // V
 		pvEnergy:        make(map[string]*meterEnergy),
 		fcstEnergy:      &meterEnergy{clock: clock.New()},
 		householdEnergy: &meterEnergy{clock: clock.New()},


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/28723#issuecomment-4178818303

The delay logic for enabling/disabling the charger or switching phases in pv mode is now increasing the remaining delay times at real-time pace if their respective thresholds are not reached. Previously these delays would simply reset as soon as the threshold condition was not met once.
This is invisible in the UI as the timer just disappears like it does now, but it may reappear starting at an already lowered time a few intervals later instead of being reset to the full delay again.
This makes these delays more predictable and usable in practice, especially if the configured delay times are set to high values. Periodically switching high power loads, fast moving clouds and random noise lead to a very inconsistent behaviour with the current logic.

Additionally I fixed a few other minor issues related to those delay timers and adjusted a few tests if they required the old instant-reset logic to work.