### PR TITLE
openevse: fix api keys again

### DIFF
--- a/charger/openevse.go
+++ b/charger/openevse.go
@@ -199,7 +199,7 @@ func (c *OpenEVSE) ChargedEnergy() (float64, error) {
 		return 0, err
 	}
 
-	return res.Wattsec / 3600 / 1e3, err
+	return res.SessionEnergy / 1e3, err
 }
 
 var _ api.ChargeTimer = (*OpenEVSE)(nil)
@@ -222,7 +222,7 @@ func (c *OpenEVSE) TotalEnergy() (float64, error) {
 		return 0, err
 	}
 
-	return res.Watthour / 1e3, err
+	return res.TotalEnergy, err
 }
 
 var _ api.Meter = (*OpenEVSE)(nil)

--- a/charger/openevse/types.go
+++ b/charger/openevse/types.go
@@ -12,12 +12,12 @@ type Status struct {
 	ManualOverride int     `json:"manual_override,omitempty"` // 1 = active, 0 = default
 	Mode           string  `json:"mode,omitempty"`            // The current mode of the EVSE
 	Pilot          int     `json:"pilot,omitempty"`           // the pilot value, in amps
+	SessionEnergy  float64 `json:"session_energy"`            // The total amount of energy accumulated for current session (in wh)
 	State          int     `json:"state,omitempty"`           // evse state 1=A 2=B 3=C 4=D 5-11=F 254=sleeping 255=disabled
 	Status         string  `json:"status,omitempty"`          // active, disabled, none, unknown
+	TotalEnergy    float64 `json:"total_energy"`              // The total amount of energy accumulated (in kwh)
 	Vehicle        int     `json:"vehicle,omitempty"`         // 0=not connected, 1=connected
 	Voltage        float64 `json:"voltage,omitempty"`         // supplied via MQTT/Tesla/HTTP or assume a default
-	Watthour       float64 `json:"watthour,omitempty"`        // The total amount of energy accumulated (in watt-hours)
-	Wattsec        float64 `json:"wattsec,omitempty"`         // The total amount of energy accumulated for current session (in watt-seconds)
 }
 
 type Override struct {


### PR DESCRIPTION
As [@jeremypoulter recommended](https://github.com/evcc-io/evcc/issues/28412#issuecomment-4108307931), we should use `session_energy` and `total_energy` keys, not the old (deprecated) ones. Previous PR #28479 was merged before I had a chance to fix this, sorry!