### PR TITLE
Config UI: network settings on fatal

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -189,11 +189,6 @@ func runRoot(cmd *cobra.Command, args []string) {
 		err = configureEnvironment(cmd, &conf)
 	}
 
-	// configure network
-	if err == nil {
-		err = networkSettings(&conf.Network)
-	}
-
 	// configure plugin external url
 	if err == nil {
 		// network configuration complete, start dependent services like HomeAssistant discovery

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -513,6 +513,11 @@ func configureEnvironment(cmd *cobra.Command, conf *globalconfig.All) error {
 	// setup persistence
 	err := wrapErrorWithClass(ClassDatabase, configureDatabase(conf.Database))
 
+	// configure network
+	if err == nil {
+		err = networkSettings(&conf.Network)
+	}
+
 	// setup additional templates
 	if err == nil {
 		if cmd.Flags().Changed(flagTemplate) {


### PR DESCRIPTION
Ensure that db network settings are applied early and are not skipped due to other errors (expired sponsor token). Moved settings read directly behind db-init.

see https://github.com/evcc-io/evcc/discussions/22961#discussioncomment-16278937

\cc @deify