### PR TITLE
Ecoflow: improve config

### DIFF
--- a/templates/definition/meter/ecoflow-powerocean.yaml
+++ b/templates/definition/meter/ecoflow-powerocean.yaml
@@ -43,11 +43,12 @@ params:
   - name: region
     choice: ["auto", "europe", "america"]
     default: auto
+    advanced: true
     description:
-      generic: "API Region: auto (default), europe, or america."
+      generic: "API Region"
     help:
-      en: 'If you sometimes see an error "8513: accessKey is invalid", which for example Starlink users do, you can set API region explicitly. Passible values: auto (default), europe, or america.'
-      de: 'Manche Nutzer, z.B. mit Starlink-Internet, sehen in den Logs den "Fehler 8513: accessKey is invalid". Um das zu beheben, kann man die API Region manuell setzen. Mögliche Werte: auto (Standard), europe oder america.'
+      en: "If you sometimes see error code 8513, like for example Starlink users do, automatic region detection fails. Here, you can set the API region manually. Possible values: auto (default), europe, or america."
+      de: 'Manche Nutzer, z.B. mit Starlink-Internet, sehen gelegentlich in den Logs den "error code 8513". Das passiert, wenn die API Region nicht korrekt erkannt wird. Um das zu beheben, kann man die API Region manuell setzen. Mögliche Werte: auto (Standard), europe oder america.'
   - name: cache
     default: 30s
     advanced: true

--- a/templates/definition/meter/ecoflow-stream.yaml
+++ b/templates/definition/meter/ecoflow-stream.yaml
@@ -37,14 +37,19 @@ params:
       en: Secret Key from EcoFlow Developer Console
       de: Secret Key aus der EcoFlow Developer Console
   - name: serial
+    required: true
+    help:
+      en: Serial number of the main device in your Stream system, normally the first device of your system
+      de: Seriennummer des Hauptgeräts (normalerweise das erste Gerät) Ihres Stream Systems
   - name: region
     choice: ["auto", "europe", "america"]
     default: auto
+    advanced: true
     description:
-      generic: "API Region: auto (default), europe, or america."
+      generic: "API Region"
     help:
-      en: 'If you sometimes see an error "8513: accessKey is invalid", which for example Starlink users do, you can set API region explicitly. Passible values: auto (default), europe, or america.'
-      de: 'Manche Nutzer, z.B. mit Starlink-Internet, sehen in den Logs den "Fehler 8513: accessKey is invalid". Um das zu beheben, kann man die API Region manuell setzen. Mögliche Werte: auto (Standard), europe oder america.'
+      en: "If you sometimes see error code 8513, like for example Starlink users do, automatic region detection fails. Here, you can set the API region manually. Possible values: auto (default), europe, or america."
+      de: 'Manche Nutzer, z.B. mit Starlink-Internet, sehen gelegentlich in den Logs den "error code 8513". Das passiert, wenn die API Region nicht korrekt erkannt wird. Um das zu beheben, kann man die API Region manuell setzen. Mögliche Werte: auto (Standard), europe oder america.'
   - name: cache
     default: 30s
     advanced: true


### PR DESCRIPTION
During my testing with the nightly build in the ui config I found some issues:
1. Serial was optional
2. For Stream systems it should be clarified that main serial is needed.
3. Mentioned error message was not accurate
4. Api region should be under Advanced