### PR TITLE
feat(ui): add loadpoint maximize-to-viewport with URL deep-linking

### DIFF
--- a/.github/workflows/docker-branch.yml
+++ b/.github/workflows/docker-branch.yml
@@ -1,0 +1,49 @@
+name: Docker Branch Build
+
+on:
+  push:
+    branches:
+      - feature/*
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Build & Push Docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/api/globalconfig/types.go
+++ b/api/globalconfig/types.go
@@ -36,6 +36,7 @@ const (
 
 type All struct {
 	Network         Network
+	UILock          UILock
 	Ocpp            ocpp.Config
 	Log             string
 	SponsorToken    string

--- a/api/globalconfig/uilock.go
+++ b/api/globalconfig/uilock.go
@@ -1,0 +1,87 @@
+package globalconfig
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+)
+
+const (
+	// DefaultUILockTimeout is the default idle timeout before the UI lock asks for the PIN again.
+	DefaultUILockTimeout = 5 * time.Minute
+)
+
+// UILock configures an optional PIN lock for the web UI for selected client IPs.
+type UILock struct {
+	Enabled        bool          `json:"enabled" yaml:"enabled"`
+	Timeout        time.Duration `json:"-" yaml:"timeout"`
+	IPs            []string      `json:"ips" yaml:"ips"`
+	TrustedProxies []string      `json:"trustedProxies" yaml:"trustedProxies"`
+	// Pin is only read from YAML for one-time bootstrap; it is not persisted in JSON settings.
+	Pin string `json:"-" yaml:"pin,omitempty"`
+}
+
+// DefaultUILock returns defaults: disabled, 5m timeout, localhost only.
+func DefaultUILock() UILock {
+	return UILock{
+		Enabled: false,
+		Timeout: DefaultUILockTimeout,
+		IPs:     []string{"127.0.0.1", "::1"},
+	}
+}
+
+// MarshalJSON encodes timeout as seconds for the UI.
+func (u UILock) MarshalJSON() ([]byte, error) {
+	type out struct {
+		Enabled        bool     `json:"enabled"`
+		Timeout        float64  `json:"timeout"`
+		IPs            []string `json:"ips"`
+		TrustedProxies []string `json:"trustedProxies"`
+		Pin            string   `json:"pin,omitempty"`
+	}
+	return json.Marshal(out{
+		Enabled:        u.Enabled,
+		Timeout:        u.Timeout.Seconds(),
+		IPs:            u.IPs,
+		TrustedProxies: u.TrustedProxies,
+		Pin:            u.Pin,
+	})
+}
+
+// UnmarshalJSON decodes timeout from a JSON number (seconds).
+func (u *UILock) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Enabled        bool     `json:"enabled"`
+		Timeout        float64  `json:"timeout"`
+		IPs            []string `json:"ips"`
+		TrustedProxies []string `json:"trustedProxies"`
+		Pin            string   `json:"pin"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	u.Enabled = aux.Enabled
+	u.Timeout = time.Duration(aux.Timeout * float64(time.Second))
+	u.IPs = aux.IPs
+	u.TrustedProxies = aux.TrustedProxies
+	u.Pin = aux.Pin
+	return nil
+}
+
+// UILockPublished is the shape broadcast to the UI (includes masked pin field).
+type UILockPublished struct {
+	Enabled        bool     `json:"enabled"`
+	Timeout        float64  `json:"timeout"`
+	IPs            []string `json:"ips"`
+	TrustedProxies []string `json:"trustedProxies"`
+	Pin            string   `json:"pin"`
+	PinConfigured  bool     `json:"pinConfigured"`
+}
+
+var _ api.Redactor = UILockPublished{}
+
+// Redacted implements api.Redactor.
+func (u UILockPublished) Redacted() any {
+	return u
+}

--- a/assets/js/components/Auth/PinLockOverlay.vue
+++ b/assets/js/components/Auth/PinLockOverlay.vue
@@ -134,6 +134,7 @@ export default {
 					this.$emit("unlocked");
 					return;
 				}
+				this.pin = "";
 				this.error = this.$t("main.uilock.wrongPin");
 			} finally {
 				this.submitting = false;

--- a/assets/js/components/Auth/PinLockOverlay.vue
+++ b/assets/js/components/Auth/PinLockOverlay.vue
@@ -25,10 +25,7 @@
 						@input="onDirectInput"
 						@keydown.enter="submit"
 					/>
-					<p
-						v-if="error"
-						class="text-danger text-center mb-0 pin-lock-error"
-					>
+					<p v-if="error" class="text-danger text-center mb-0 pin-lock-error">
 						{{ error }}
 					</p>
 					<button
@@ -64,18 +61,10 @@
 						>
 							0
 						</button>
-						<button
-							type="button"
-							class="btn btn-outline-warning"
-							@click="backspace"
-						>
+						<button type="button" class="btn btn-outline-warning" @click="backspace">
 							⌫
 						</button>
-						<button
-							type="button"
-							class="btn btn-outline-danger"
-							@click="clearPin"
-						>
+						<button type="button" class="btn btn-outline-danger" @click="clearPin">
 							C
 						</button>
 					</div>

--- a/assets/js/components/Auth/PinLockOverlay.vue
+++ b/assets/js/components/Auth/PinLockOverlay.vue
@@ -1,0 +1,291 @@
+<template>
+	<div
+		class="pin-lock-overlay"
+		role="dialog"
+		aria-modal="true"
+		:aria-label="$t('main.uilock.title')"
+	>
+		<div class="pin-lock-card card">
+			<div class="pin-lock-body">
+				<div class="pin-lock-side-info">
+					<p class="pin-lock-title text-center fw-bold mb-0">
+						{{ $t("main.uilock.title") }}
+					</p>
+					<input
+						ref="pinInput"
+						class="pin-display font-monospace text-center"
+						type="password"
+						inputmode="numeric"
+						:value="pin"
+						:placeholder="$t('main.uilock.pinInput')"
+						autocomplete="one-time-code"
+						autocorrect="off"
+						spellcheck="false"
+						aria-live="polite"
+						@input="onDirectInput"
+						@keydown.enter="submit"
+					/>
+					<p
+						v-if="error"
+						class="text-danger text-center mb-0 pin-lock-error"
+					>
+						{{ error }}
+					</p>
+					<button
+						type="button"
+						class="btn btn-primary w-100 pin-lock-submit"
+						:disabled="pin.length < 1 || submitting"
+						@click="submit"
+					>
+						<span
+							v-if="submitting"
+							class="spinner-border spinner-border-sm"
+							role="status"
+							aria-hidden="true"
+						></span>
+						{{ $t("main.uilock.unlock") }}
+					</button>
+				</div>
+				<div class="pin-lock-side-pad">
+					<div class="pin-lock-grid">
+						<button
+							v-for="n in 9"
+							:key="n"
+							type="button"
+							class="btn btn-outline-secondary"
+							@click="appendDigit(String(n))"
+						>
+							{{ n }}
+						</button>
+						<button
+							type="button"
+							class="btn btn-outline-secondary"
+							@click="appendDigit('0')"
+						>
+							0
+						</button>
+						<button
+							type="button"
+							class="btn btn-outline-warning"
+							@click="backspace"
+						>
+							⌫
+						</button>
+						<button
+							type="button"
+							class="btn btn-outline-danger"
+							@click="clearPin"
+						>
+							C
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import api from "@/api";
+
+export default {
+	name: "PinLockOverlay",
+	emits: ["unlocked"],
+	data() {
+		return {
+			pin: "",
+			submitting: false,
+			error: "",
+		};
+	},
+	methods: {
+		appendDigit(d) {
+			if (this.pin.length >= 12) return;
+			this.error = "";
+			this.pin += d;
+		},
+		backspace() {
+			this.pin = this.pin.slice(0, -1);
+			this.error = "";
+		},
+		clearPin() {
+			this.pin = "";
+			this.error = "";
+		},
+		onDirectInput(e) {
+			const digits = (e.target.value || "").replace(/\D/g, "").slice(0, 12);
+			this.pin = digits;
+			e.target.value = this.pin;
+			this.error = "";
+		},
+		async submit() {
+			if (this.pin.length < 1 || this.submitting) return;
+			this.submitting = true;
+			this.error = "";
+			try {
+				const res = await api.post(
+					"auth/uilock/unlock",
+					{ pin: this.pin },
+					{
+						validateStatus: (s) => [204, 401].includes(s),
+					}
+				);
+				if (res.status === 204) {
+					this.$emit("unlocked");
+					return;
+				}
+				this.error = this.$t("main.uilock.wrongPin");
+			} finally {
+				this.submitting = false;
+			}
+		},
+	},
+};
+</script>
+
+<style scoped>
+.pin-lock-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 2000;
+	box-sizing: border-box;
+	width: 100%;
+	height: 100dvh;
+	overflow: hidden;
+	display: grid;
+	place-items: center;
+	place-content: center;
+	padding: max(0.5rem, env(safe-area-inset-top)) max(0.75rem, env(safe-area-inset-right))
+		max(0.5rem, env(safe-area-inset-bottom)) max(0.75rem, env(safe-area-inset-left));
+	background: rgba(0, 0, 0, 0.55);
+	backdrop-filter: blur(2px);
+}
+
+.pin-lock-card {
+	width: 80vw;
+	height: 80vh;
+	max-width: calc(100vw - 1rem);
+	max-height: calc(100dvh - 1rem);
+	overflow: hidden;
+	padding: 1.5rem 2rem;
+	font-size: 1rem;
+	line-height: 1.35;
+	border-radius: 1rem;
+	border: none;
+}
+
+.pin-lock-body {
+	display: grid;
+	grid-template-columns: 1fr 2fr;
+	gap: 2rem;
+	align-items: center;
+	height: 100%;
+}
+
+.pin-lock-side-info {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 0.5rem;
+	height: 100%;
+}
+
+.pin-lock-title {
+	font-size: 1.5em;
+	line-height: 1.25;
+}
+
+.pin-display {
+	font-size: 2rem;
+	letter-spacing: 0.15em;
+	min-height: 1.3em;
+	line-height: 1.3;
+	text-align: center;
+	background: transparent;
+	border: 1px solid var(--bs-border-color-translucent, rgba(0, 0, 0, 0.15));
+	border-radius: 0.5rem;
+	padding: 0.35rem 0.5rem;
+	color: inherit;
+	width: 100%;
+	cursor: text;
+}
+
+/* hide browser-native password reveal toggle */
+.pin-display::-ms-reveal,
+.pin-display::-webkit-credentials-auto-fill-button {
+	display: none;
+}
+
+.pin-display::placeholder {
+	color: var(--evcc-gray, #93949e);
+	opacity: 0.6;
+	font-size: 0.6em;
+	letter-spacing: 0;
+}
+
+.pin-display:focus {
+	outline: none;
+	border-color: var(--bs-primary, #0ba631);
+	box-shadow: 0 0 0 0.2rem rgba(11, 166, 49, 0.2);
+}
+
+.pin-lock-side-pad {
+	height: 100%;
+	display: flex;
+	align-items: stretch;
+}
+
+.pin-lock-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	grid-template-rows: repeat(4, 1fr);
+	gap: 0.5rem;
+	width: 100%;
+	height: 100%;
+}
+
+.pin-lock-grid .btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	font-size: 1.5em;
+	line-height: 1;
+	border-radius: 0.5rem;
+	min-height: 0;
+}
+
+.pin-lock-error {
+	font-size: 0.9em;
+	line-height: 1.3;
+}
+
+.pin-lock-submit {
+	padding: 0.6rem;
+	font-size: 1.1em;
+	border-radius: 0.5rem;
+}
+
+/* Narrow / portrait: stack vertically */
+@media (max-width: 480px) {
+	.pin-lock-card {
+		width: calc(100vw - 1rem);
+		height: calc(100dvh - 1rem);
+		padding: 1rem;
+	}
+
+	.pin-lock-body {
+		grid-template-columns: 1fr;
+		grid-template-rows: auto 1fr;
+		gap: 0.75rem;
+	}
+
+	.pin-lock-side-info {
+		height: auto;
+	}
+
+	.pin-lock-grid {
+		font-size: 0.9rem;
+	}
+}
+</style>

--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -53,6 +53,13 @@
 		/>
 
 		<GeneralConfigEntry
+			test-id="generalconfig-uilock"
+			:label="$t('config.uilock.title')"
+			:text="uilockStatus"
+			@edit="openModal('uilock')"
+		/>
+
+		<GeneralConfigEntry
 			test-id="generalconfig-control"
 			:label="$t('config.control.title')"
 			:text="controlStatus"
@@ -66,11 +73,13 @@
 			@edit="openModal('currency')"
 		/>
 		<CurrencyModal @changed="$emit('site-changed')" />
+		<UILockModal @changed="$emit('site-changed')" />
 	</div>
 </template>
 
 <script>
 import CurrencyModal from "./CurrencyModal.vue";
+import UILockModal from "./UILockModal.vue";
 import GeneralConfigEntry from "./GeneralConfigEntry.vue";
 import { openModal } from "@/configModal";
 import store from "@/store";
@@ -78,7 +87,7 @@ import formatter from "@/mixins/formatter";
 
 export default {
 	name: "GeneralConfig",
-	components: { CurrencyModal, GeneralConfigEntry },
+	components: { CurrencyModal, UILockModal, GeneralConfigEntry },
 	mixins: [formatter],
 	props: {
 		sponsorError: Boolean,
@@ -94,6 +103,13 @@ export default {
 		},
 		networkStatus() {
 			return `${store.state?.network?.port ?? ""}`;
+		},
+		uilockStatus() {
+			const u = store.state?.uilock;
+			if (!u?.enabled) {
+				return this.$t("config.general.off");
+			}
+			return this.$t("config.general.on");
 		},
 		controlStatus() {
 			const sec = store.state?.interval;

--- a/assets/js/components/Config/UILockModal.vue
+++ b/assets/js/components/Config/UILockModal.vue
@@ -1,0 +1,139 @@
+<template>
+	<JsonModal
+		name="uilock"
+		:title="$t('config.uilock.title')"
+		endpoint="/config/uilock"
+		state-key="uilock"
+		:transform-read-values="transformReadValues"
+		:transform-write-values="transformWriteValues"
+		:confirm-remove="$t('config.uilock.confirmRemove')"
+		@changed="$emit('changed')"
+	>
+		<template #default="{ values }">
+			<FormRow
+				id="uilockEnabled"
+				:label="$t('config.uilock.labelEnabled')"
+				:help="$t('config.uilock.descriptionEnabled')"
+			>
+				<div class="form-check form-switch">
+					<input
+						id="uilockEnabled"
+						v-model="values.enabled"
+						class="form-check-input"
+						type="checkbox"
+						role="switch"
+					/>
+				</div>
+			</FormRow>
+
+			<FormRow
+				id="uilockTimeout"
+				:label="$t('config.uilock.labelTimeout')"
+				:help="$t('config.uilock.descriptionTimeout')"
+			>
+				<input
+					id="uilockTimeout"
+					v-model.number="values.timeout"
+					class="form-control w-50"
+					type="number"
+					min="30"
+					max="86400"
+					step="1"
+					required
+				/>
+			</FormRow>
+
+			<FormRow
+				id="uilockIps"
+				:label="$t('config.uilock.labelIps')"
+				:help="$t('config.uilock.descriptionIps')"
+			>
+				<textarea
+					id="uilockIps"
+					v-model="ipsText"
+					class="form-control font-monospace"
+					rows="3"
+					spellcheck="false"
+				/>
+			</FormRow>
+
+			<FormRow
+				id="uilockTrusted"
+				:label="$t('config.uilock.labelTrustedProxies')"
+				:help="$t('config.uilock.descriptionTrustedProxies')"
+				optional
+			>
+				<textarea
+					id="uilockTrusted"
+					v-model="trustedText"
+					class="form-control font-monospace"
+					rows="3"
+					spellcheck="false"
+				/>
+			</FormRow>
+
+			<FormRow
+				id="uilockPin"
+				:label="$t('config.uilock.labelPin')"
+				:help="$t('config.uilock.descriptionPin')"
+				optional
+			>
+				<input
+					id="uilockPin"
+					v-model="values.pin"
+					class="form-control"
+					type="password"
+					autocomplete="new-password"
+				/>
+			</FormRow>
+		</template>
+	</JsonModal>
+</template>
+
+<script>
+import JsonModal from "./JsonModal.vue";
+import FormRow from "./FormRow.vue";
+
+const MASK = "***";
+
+export default {
+	name: "UILockModal",
+	components: { JsonModal, FormRow },
+	emits: ["changed"],
+	data() {
+		return {
+			ipsText: "",
+			trustedText: "",
+		};
+	},
+	methods: {
+		transformReadValues(v) {
+			const ips = v?.ips || [];
+			const trusted = v?.trustedProxies || [];
+			this.ipsText = ips.join("\n");
+			this.trustedText = trusted.join("\n");
+			const pin = v?.pin;
+			return {
+				...v,
+				pin: pin === MASK ? "" : pin || "",
+			};
+		},
+		transformWriteValues(values) {
+			const v = { ...values };
+			delete v.pinConfigured;
+			v.ips = this.ipsText
+				.split(/[\n,]+/)
+				.map((s) => s.trim())
+				.filter(Boolean);
+			v.trustedProxies = this.trustedText
+				.split(/[\n,]+/)
+				.map((s) => s.trim())
+				.filter(Boolean);
+			if (v.pin === MASK || v.pin === "") {
+				delete v.pin;
+			}
+			return v;
+		},
+	},
+};
+</script>

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -1,104 +1,250 @@
 <template>
-	<div class="loadpoint d-flex flex-column pt-4 pb-2 px-3 px-sm-4 mx-2 mx-sm-0">
+	<Teleport to="body" :disabled="!loadpointViewportMaximized">
 		<div
-			class="d-block d-sm-flex justify-content-between align-items-center mb-3"
-			:class="expandLoadpointHeader ? 'd-lg-block d-xl-flex' : ''"
+			:class="
+				loadpointViewportMaximized ? 'loadpoint-viewport-overlay safe-area-inset' : 'loadpoint-inline-host'
+			"
 		>
-			<div class="d-flex justify-content-between align-items-center mb-3 text-truncate">
-				<h3 class="me-2 mb-0 text-truncate d-flex">
-					<VehicleIcon
-						v-if="chargerIcon"
-						:name="chargerIcon"
-						class="me-2 flex-shrink-0"
+			<div
+				class="loadpoint d-flex flex-column pt-4 pb-2 px-3 px-sm-4"
+				v-bind="loadpointRootAttrs"
+				:class="[
+					loadpointViewportMaximized
+						? 'loadpoint--viewport-expanded flex-grow-1 mx-0'
+						: 'mx-2 mx-sm-0',
+				]"
+			>
+				<!-- sm+: title, expand/collapse, mode, settings in one row -->
+				<div class="d-none d-sm-flex align-items-center gap-2 mb-3 flex-wrap loadpoint-header-wide">
+					<h3 class="mb-0 text-truncate d-flex min-w-0 loadpoint-header-wide__title">
+						<VehicleIcon
+							v-if="chargerIcon"
+							:name="chargerIcon"
+							class="me-2 flex-shrink-0"
+						/>
+						<div class="text-truncate">
+							{{ loadpointTitle }}
+						</div>
+					</h3>
+					<button
+						type="button"
+						class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
+						:aria-label="
+							loadpointViewportMaximized
+								? $t('main.loadpoint.backToOverview')
+								: $t('main.loadpoint.expandViewport')
+						"
+						:data-testid="
+							loadpointViewportMaximized
+								? 'loadpoint-viewport-back'
+								: 'loadpoint-viewport-expand'
+						"
+						@click.stop="
+							loadpointViewportMaximized ? collapseViewport() : expandViewport()
+						"
+					>
+						<svg
+							v-if="loadpointViewportMaximized"
+							class="loadpoint-expand-icon"
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path d="M4 14h6v6" />
+							<path d="M20 10h-6V4" />
+							<path d="M14 10l7-7" />
+							<path d="M3 21l7-7" />
+						</svg>
+						<svg
+							v-else
+							class="loadpoint-expand-icon"
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path d="M8 3H5a2 2 0 0 0-2 2v3" />
+							<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+							<path d="M3 16v3a2 2 0 0 0 2 2h3" />
+							<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+						</svg>
+					</button>
+					<Mode
+						class="loadpoint-header-wide__mode flex-shrink-0"
+						v-bind="modeProps"
+						@updated="setTargetMode"
 					/>
-					<div class="text-truncate">
-						{{ loadpointTitle }}
-					</div>
-				</h3>
-				<LoadpointSettingsButton
-					:class="expandLoadpointHeader ? 'd-lg-block d-xl-none' : ''"
-					class="d-block d-sm-none"
-					@click="openSettingsModal"
-				/>
-			</div>
-			<div class="mb-3 d-flex align-items-center">
-				<Mode class="flex-grow-1" v-bind="modeProps" @updated="setTargetMode" />
-				<LoadpointSettingsButton
-					:id="id"
-					:class="expandLoadpointHeader ? 'd-lg-none d-xl-block' : ''"
-					class="d-none d-sm-block ms-2"
-					@click="openSettingsModal"
-				/>
-			</div>
-		</div>
-		<LoadpointSettingsModal
-			:id="id"
-			v-bind="settingsModal"
-			@maxcurrent-updated="setMaxCurrent"
-			@mincurrent-updated="setMinCurrent"
-			@phasesconfigured-updated="setPhasesConfigured"
-			@batteryboostlimit-updated="setBatteryBoostLimit"
-		/>
-
-		<div
-			v-if="remoteDisabled"
-			class="alert alert-warning my-4 py-2"
-			:class="`${remoteDisabled === 'hard' ? 'alert-danger' : 'alert-warning'}`"
-			role="alert"
-		>
-			{{
-				$t(
-					remoteDisabled === "hard"
-						? "main.loadpoint.remoteDisabledHard"
-						: "main.loadpoint.remoteDisabledSoft",
-					{ source: remoteDisabledSource }
-				)
-			}}
-		</div>
-
-		<div class="details d-flex align-items-start mb-2">
-			<div>
-				<div class="d-flex align-items-center">
-					<LabelAndValue
-						:label="$t('main.loadpoint.power')"
-						:value="chargePower"
-						:valueFmt="fmtPower"
-						class="mb-2 text-nowrap text-truncate-xs-only"
-						align="start"
+					<LoadpointSettingsButton
+						:id="id"
+						:class="expandLoadpointHeader ? 'd-lg-none d-xl-block' : ''"
+						class="flex-shrink-0"
+						@click="openSettingsModal"
 					/>
-					<shopicon-regular-lightning
-						class="text-evcc opacity-transiton"
-						:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
-						size="m"
-					></shopicon-regular-lightning>
 				</div>
-				<Phases
-					v-bind="phasesProps"
-					class="opacity-transiton"
-					:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
+				<!-- xs: stacked -->
+				<div class="d-flex d-sm-none flex-column mb-3">
+					<div class="d-flex justify-content-between align-items-center gap-2 mb-3">
+						<div class="d-flex align-items-center gap-2 min-w-0 flex-grow-1">
+							<h3 class="mb-0 text-truncate d-flex min-w-0 flex-grow-1">
+								<VehicleIcon
+									v-if="chargerIcon"
+									:name="chargerIcon"
+									class="me-2 flex-shrink-0"
+								/>
+								<div class="text-truncate">
+									{{ loadpointTitle }}
+								</div>
+							</h3>
+							<button
+								type="button"
+								class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
+								:aria-label="
+									loadpointViewportMaximized
+										? $t('main.loadpoint.backToOverview')
+										: $t('main.loadpoint.expandViewport')
+								"
+								:data-testid="
+									loadpointViewportMaximized
+										? 'loadpoint-viewport-back-xs'
+										: 'loadpoint-viewport-expand-xs'
+								"
+								@click.stop="
+									loadpointViewportMaximized
+										? collapseViewport()
+										: expandViewport()
+								"
+							>
+								<svg
+									v-if="loadpointViewportMaximized"
+									class="loadpoint-expand-icon"
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									aria-hidden="true"
+									focusable="false"
+								>
+									<path d="M4 14h6v6" />
+									<path d="M20 10h-6V4" />
+									<path d="M14 10l7-7" />
+									<path d="M3 21l7-7" />
+								</svg>
+								<svg
+									v-else
+									class="loadpoint-expand-icon"
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									aria-hidden="true"
+									focusable="false"
+								>
+									<path d="M8 3H5a2 2 0 0 0-2 2v3" />
+									<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+									<path d="M3 16v3a2 2 0 0 0 2 2h3" />
+									<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+								</svg>
+							</button>
+						</div>
+						<LoadpointSettingsButton
+							:class="expandLoadpointHeader ? 'd-lg-block d-xl-none' : ''"
+							class="flex-shrink-0"
+							@click="openSettingsModal"
+						/>
+					</div>
+					<Mode v-bind="modeProps" @updated="setTargetMode" />
+				</div>
+				<LoadpointSettingsModal
+					:id="id"
+					v-bind="settingsModal"
+					@maxcurrent-updated="setMaxCurrent"
+					@mincurrent-updated="setMinCurrent"
+					@phasesconfigured-updated="setPhasesConfigured"
+					@batteryboostlimit-updated="setBatteryBoostLimit"
+				/>
+
+				<div
+					v-if="remoteDisabled"
+					class="alert alert-warning my-4 py-2"
+					:class="`${remoteDisabled === 'hard' ? 'alert-danger' : 'alert-warning'}`"
+					role="alert"
+				>
+					{{
+						$t(
+							remoteDisabled === "hard"
+								? "main.loadpoint.remoteDisabledHard"
+								: "main.loadpoint.remoteDisabledSoft",
+							{ source: remoteDisabledSource }
+						)
+					}}
+				</div>
+
+				<div class="details d-flex align-items-start mb-2">
+					<div>
+						<div class="d-flex align-items-center">
+							<LabelAndValue
+								:label="$t('main.loadpoint.power')"
+								:value="chargePower"
+								:valueFmt="fmtPower"
+								class="mb-2 text-nowrap text-truncate-xs-only"
+								align="start"
+							/>
+							<shopicon-regular-lightning
+								class="text-evcc opacity-transiton"
+								:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
+								size="m"
+							></shopicon-regular-lightning>
+						</div>
+						<Phases
+							v-bind="phasesProps"
+							class="opacity-transiton"
+							:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
+						/>
+					</div>
+					<LabelAndValue
+						v-show="socBasedCharging"
+						:label="$t('main.loadpoint.charged')"
+						:value="chargedEnergy"
+						:valueFmt="fmtEnergy"
+						align="center"
+					/>
+					<LoadpointSessionInfo v-bind="sessionInfoProps" />
+				</div>
+				<hr class="divider" />
+				<Vehicle
+					class="flex-grow-1 d-flex flex-column justify-content-end"
+					v-bind="vehicleProps"
+					@limit-soc-updated="setLimitSoc"
+					@limit-energy-updated="setLimitEnergy"
+					@change-vehicle="changeVehicle"
+					@remove-vehicle="removeVehicle"
+					@open-loadpoint-settings="openSettingsModal"
+					@batteryboost-updated="setBatteryBoost"
 				/>
 			</div>
-			<LabelAndValue
-				v-show="socBasedCharging"
-				:label="$t('main.loadpoint.charged')"
-				:value="chargedEnergy"
-				:valueFmt="fmtEnergy"
-				align="center"
-			/>
-			<LoadpointSessionInfo v-bind="sessionInfoProps" />
 		</div>
-		<hr class="divider" />
-		<Vehicle
-			class="flex-grow-1 d-flex flex-column justify-content-end"
-			v-bind="vehicleProps"
-			@limit-soc-updated="setLimitSoc"
-			@limit-energy-updated="setLimitEnergy"
-			@change-vehicle="changeVehicle"
-			@remove-vehicle="removeVehicle"
-			@open-loadpoint-settings="openSettingsModal"
-			@batteryboost-updated="setBatteryBoost"
-		/>
-	</div>
+	</Teleport>
 </template>
 
 <script lang="ts">
@@ -143,6 +289,7 @@ export default defineComponent({
 		VehicleIcon,
 	},
 	mixins: [formatter, collector],
+	inheritAttrs: false,
 	props: {
 		id: { type: String, required: true },
 		single: Boolean,
@@ -249,9 +396,14 @@ export default defineComponent({
 			pvRemainingInterpolated: this.pvRemaining,
 			chargeDurationInterpolated: this.chargeDuration,
 			chargeRemainingDurationInterpolated: this.chargeRemainingDuration,
+			loadpointViewportMaximized: false,
+			bodyOverflowBefore: null as string | null,
 		};
 	},
 	computed: {
+		loadpointRootAttrs() {
+			return this.$attrs;
+		},
 		expandLoadpointHeader() {
 			return this.multipleLoadpoints && !this.fullWidth;
 		},
@@ -327,6 +479,9 @@ export default defineComponent({
 		plannerForecast() {
 			return this.forecast?.planner;
 		},
+		shouldMaximizeFromRoute(): boolean {
+			return this.$route?.query?.maximize === this.id;
+		},
 	},
 	watch: {
 		phaseRemaining() {
@@ -341,13 +496,35 @@ export default defineComponent({
 		chargeRemainingDuration() {
 			this.chargeRemainingDurationInterpolated = this.chargeRemainingDuration;
 		},
+		loadpointViewportMaximized(expanded: boolean) {
+			if (expanded) {
+				this.bodyOverflowBefore = document.body.style.overflow;
+				document.body.style.overflow = "hidden";
+			} else {
+				document.body.style.overflow = this.bodyOverflowBefore ?? "";
+				this.bodyOverflowBefore = null;
+			}
+		},
+		shouldMaximizeFromRoute: {
+			handler(shouldMaximize: boolean) {
+				if (shouldMaximize && !this.loadpointViewportMaximized) {
+					this.loadpointViewportMaximized = true;
+				}
+			},
+			immediate: true,
+		},
 	},
 	mounted() {
 		this.tickerHandler = setInterval(this.tick, 1000);
+		window.addEventListener("keydown", this.handleViewportEscape);
 	},
 	unmounted() {
 		if (this.tickerHandler) {
 			clearInterval(this.tickerHandler);
+		}
+		window.removeEventListener("keydown", this.handleViewportEscape);
+		if (this.loadpointViewportMaximized) {
+			document.body.style.overflow = this.bodyOverflowBefore ?? "";
 		}
 	},
 	methods: {
@@ -410,6 +587,26 @@ export default defineComponent({
 			);
 			modal.show();
 		},
+		expandViewport() {
+			this.loadpointViewportMaximized = true;
+			const query = { ...this.$route.query, maximize: this.id };
+			this.$router.replace({ query });
+		},
+		collapseViewport() {
+			this.loadpointViewportMaximized = false;
+			const query = { ...this.$route.query };
+			delete query.maximize;
+			this.$router.replace({ query });
+		},
+		handleViewportEscape(ev: KeyboardEvent) {
+			if (ev.key !== "Escape" || !this.loadpointViewportMaximized) {
+				return;
+			}
+			if (document.querySelector(".modal.show")) {
+				return;
+			}
+			this.collapseViewport();
+		},
 	},
 });
 </script>
@@ -417,10 +614,44 @@ export default defineComponent({
 <style scoped>
 @import "../../../css/breakpoints.css";
 
+.loadpoint-inline-host {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
+.loadpoint-viewport-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 1030;
+	display: flex;
+	flex-direction: column;
+	min-height: 100dvh;
+	min-height: 100vh;
+	background: var(--evcc-background);
+	overflow: hidden;
+}
+
 .loadpoint {
 	border-radius: 2rem;
 	color: var(--evcc-default-text);
 	background: var(--evcc-box);
+}
+
+.loadpoint--viewport-expanded {
+	min-height: 0;
+	flex: 1 1 auto;
+	overflow: auto;
+}
+
+.loadpoint-header-wide__title {
+	flex: 1 1 8rem;
+	min-width: 0;
+}
+
+.loadpoint-expand-icon {
+	display: block;
 }
 
 .details > div {

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -26,62 +26,10 @@
 							{{ loadpointTitle }}
 						</div>
 					</h3>
-					<button
-						type="button"
-						class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
-						:aria-label="
-							loadpointViewportMaximized
-								? $t('main.loadpoint.backToOverview')
-								: $t('main.loadpoint.expandViewport')
-						"
-						:data-testid="
-							loadpointViewportMaximized
-								? 'loadpoint-viewport-back'
-								: 'loadpoint-viewport-expand'
-						"
-						@click.stop="
-							loadpointViewportMaximized ? collapseViewport() : expandViewport()
-						"
-					>
-						<svg
-							v-if="loadpointViewportMaximized"
-							class="loadpoint-expand-icon"
-							width="18"
-							height="18"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-							focusable="false"
-						>
-							<path d="M4 14h6v6" />
-							<path d="M20 10h-6V4" />
-							<path d="M14 10l7-7" />
-							<path d="M3 21l7-7" />
-						</svg>
-						<svg
-							v-else
-							class="loadpoint-expand-icon"
-							width="18"
-							height="18"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-							focusable="false"
-						>
-							<path d="M8 3H5a2 2 0 0 0-2 2v3" />
-							<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
-							<path d="M3 16v3a2 2 0 0 0 2 2h3" />
-							<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
-						</svg>
-					</button>
+					<ViewportToggleButton
+						:expanded="loadpointViewportMaximized"
+						@toggle="toggleViewport"
+					/>
 					<Mode
 						class="loadpoint-header-wide__mode flex-shrink-0"
 						v-bind="modeProps"
@@ -108,64 +56,11 @@
 									{{ loadpointTitle }}
 								</div>
 							</h3>
-							<button
-								type="button"
-								class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
-								:aria-label="
-									loadpointViewportMaximized
-										? $t('main.loadpoint.backToOverview')
-										: $t('main.loadpoint.expandViewport')
-								"
-								:data-testid="
-									loadpointViewportMaximized
-										? 'loadpoint-viewport-back-xs'
-										: 'loadpoint-viewport-expand-xs'
-								"
-								@click.stop="
-									loadpointViewportMaximized
-										? collapseViewport()
-										: expandViewport()
-								"
-							>
-								<svg
-									v-if="loadpointViewportMaximized"
-									class="loadpoint-expand-icon"
-									width="18"
-									height="18"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									aria-hidden="true"
-									focusable="false"
-								>
-									<path d="M4 14h6v6" />
-									<path d="M20 10h-6V4" />
-									<path d="M14 10l7-7" />
-									<path d="M3 21l7-7" />
-								</svg>
-								<svg
-									v-else
-									class="loadpoint-expand-icon"
-									width="18"
-									height="18"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									aria-hidden="true"
-									focusable="false"
-								>
-									<path d="M8 3H5a2 2 0 0 0-2 2v3" />
-									<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
-									<path d="M3 16v3a2 2 0 0 0 2 2h3" />
-									<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
-								</svg>
-							</button>
+							<ViewportToggleButton
+								:expanded="loadpointViewportMaximized"
+								:mobile="true"
+								@toggle="toggleViewport"
+							/>
 						</div>
 						<LoadpointSettingsButton
 							:class="expandLoadpointHeader ? 'd-lg-block d-xl-none' : ''"
@@ -261,6 +156,7 @@ import SettingsButton from "./SettingsButton.vue";
 import SettingsModal from "./SettingsModal.vue";
 import VehicleIcon from "../VehicleIcon";
 import SessionInfo from "./SessionInfo.vue";
+import ViewportToggleButton from "./ViewportToggleButton.vue";
 import Modal from "bootstrap/js/dist/modal";
 import { defineComponent, type PropType } from "vue";
 import type {
@@ -276,6 +172,26 @@ import type {
 } from "@/types/evcc";
 import type { PlanStrategy } from "@/components/ChargingPlans/types";
 
+const maximizedLoadpointIds = new Set<string>();
+let previousBodyOverflow: string | null = null;
+
+const setBodyScrollLock = (id: string, expanded: boolean) => {
+	if (expanded) {
+		if (maximizedLoadpointIds.size === 0) {
+			previousBodyOverflow = document.body.style.overflow;
+			document.body.style.overflow = "hidden";
+		}
+		maximizedLoadpointIds.add(id);
+		return;
+	}
+
+	maximizedLoadpointIds.delete(id);
+	if (maximizedLoadpointIds.size === 0) {
+		document.body.style.overflow = previousBodyOverflow ?? "";
+		previousBodyOverflow = null;
+	}
+};
+
 export default defineComponent({
 	name: "Loadpoint",
 	components: {
@@ -287,6 +203,7 @@ export default defineComponent({
 		LoadpointSettingsModal: SettingsModal,
 		LoadpointSessionInfo: SessionInfo,
 		VehicleIcon,
+		ViewportToggleButton,
 	},
 	mixins: [formatter, collector],
 	inheritAttrs: false,
@@ -397,7 +314,6 @@ export default defineComponent({
 			chargeDurationInterpolated: this.chargeDuration,
 			chargeRemainingDurationInterpolated: this.chargeRemainingDuration,
 			loadpointViewportMaximized: false,
-			bodyOverflowBefore: null as string | null,
 		};
 	},
 	computed: {
@@ -497,18 +413,12 @@ export default defineComponent({
 			this.chargeRemainingDurationInterpolated = this.chargeRemainingDuration;
 		},
 		loadpointViewportMaximized(expanded: boolean) {
-			if (expanded) {
-				this.bodyOverflowBefore = document.body.style.overflow;
-				document.body.style.overflow = "hidden";
-			} else {
-				document.body.style.overflow = this.bodyOverflowBefore ?? "";
-				this.bodyOverflowBefore = null;
-			}
+			setBodyScrollLock(this.id, expanded);
 		},
 		shouldMaximizeFromRoute: {
 			handler(shouldMaximize: boolean) {
-				if (shouldMaximize && !this.loadpointViewportMaximized) {
-					this.loadpointViewportMaximized = true;
+				if (this.loadpointViewportMaximized !== shouldMaximize) {
+					this.loadpointViewportMaximized = shouldMaximize;
 				}
 			},
 			immediate: true,
@@ -524,7 +434,7 @@ export default defineComponent({
 		}
 		window.removeEventListener("keydown", this.handleViewportEscape);
 		if (this.loadpointViewportMaximized) {
-			document.body.style.overflow = this.bodyOverflowBefore ?? "";
+			setBodyScrollLock(this.id, false);
 		}
 	},
 	methods: {
@@ -586,6 +496,13 @@ export default defineComponent({
 				document.getElementById(`loadpointSettingsModal_${this.id}`) as HTMLElement
 			);
 			modal.show();
+		},
+		toggleViewport() {
+			if (this.loadpointViewportMaximized) {
+				this.collapseViewport();
+				return;
+			}
+			this.expandViewport();
 		},
 		expandViewport() {
 			this.loadpointViewportMaximized = true;

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -396,7 +396,7 @@ export default defineComponent({
 			return this.forecast?.planner;
 		},
 		shouldMaximizeFromRoute(): boolean {
-			return this.$route?.query?.maximize === this.id;
+			return this.$route?.query?.["maximize"] === this.id;
 		},
 	},
 	watch: {
@@ -512,7 +512,7 @@ export default defineComponent({
 		collapseViewport() {
 			this.loadpointViewportMaximized = false;
 			const query = { ...this.$route.query };
-			delete query.maximize;
+			delete query["maximize"];
 			this.$router.replace({ query });
 		},
 		handleViewportEscape(ev: KeyboardEvent) {

--- a/assets/js/components/Loadpoints/ViewportToggleButton.vue
+++ b/assets/js/components/Loadpoints/ViewportToggleButton.vue
@@ -1,0 +1,71 @@
+<template>
+	<button
+		type="button"
+		class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
+		:aria-label="
+			expanded ? $t('main.loadpoint.backToOverview') : $t('main.loadpoint.expandViewport')
+		"
+		:data-testid="
+			expanded
+				? mobile
+					? 'loadpoint-viewport-back-xs'
+					: 'loadpoint-viewport-back'
+				: mobile
+					? 'loadpoint-viewport-expand-xs'
+					: 'loadpoint-viewport-expand'
+		"
+		@click.stop="$emit('toggle')"
+	>
+		<svg
+			v-if="expanded"
+			class="loadpoint-expand-icon"
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path d="M4 14h6v6" />
+			<path d="M20 10h-6V4" />
+			<path d="M14 10l7-7" />
+			<path d="M3 21l7-7" />
+		</svg>
+		<svg
+			v-else
+			class="loadpoint-expand-icon"
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path d="M8 3H5a2 2 0 0 0-2 2v3" />
+			<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+			<path d="M3 16v3a2 2 0 0 0 2 2h3" />
+			<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+		</svg>
+	</button>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+	name: "ViewportToggleButton",
+	props: {
+		expanded: Boolean,
+		mobile: Boolean,
+	},
+	emits: ["toggle"],
+});
+</script>

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -91,6 +91,16 @@ export interface State {
   config?: string;
   database?: string;
   ocpp?: Ocpp;
+  uilock?: UILockConfig;
+}
+
+export interface UILockConfig {
+  enabled: boolean;
+  timeout: number;
+  ips: string[];
+  trustedProxies: string[];
+  pin?: string;
+  pinConfigured?: boolean;
 }
 
 export interface ConfigStatus<C, S> {

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -140,6 +140,9 @@ export default defineComponent({
 				const res = await api.get("auth/uilock/status", {
 					validateStatus: (s) => s >= 200 && s < 500,
 				});
+				if (res.status >= 500) {
+					throw new Error(`status endpoint returned ${res.status}`);
+				}
 				const data = res.data as {
 					appliesToClient?: boolean;
 					unlocked?: boolean;
@@ -153,6 +156,10 @@ export default defineComponent({
 				}
 			} catch (e) {
 				console.warn("uilock status", e);
+				if (store.state.uilock?.enabled && store.state.uilock?.pinConfigured) {
+					store.update({ startupCompleted: true });
+					this.showUiLock = true;
+				}
 			}
 			this.connect();
 		},

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -192,7 +192,7 @@ export default defineComponent({
 			};
 			const events = ["mousedown", "keydown", "touchstart", "scroll"];
 			events.forEach((e) =>
-				document.addEventListener(e, this.idleActivityHandler!, { passive: true }),
+				document.addEventListener(e, this.idleActivityHandler!, { passive: true })
 			);
 
 			this.resetIdleTimer();

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -1,5 +1,6 @@
 <template>
 	<div class="app">
+		<PinLockOverlay v-if="showUiLock" @unlocked="onUiLockUnlocked" />
 		<router-view
 			v-if="showRoutes"
 			:notifications="notifications"
@@ -23,7 +24,9 @@ import BatterySettingsModal from "../components/Battery/BatterySettingsModal.vue
 import ForecastModal from "../components/Forecast/ForecastModal.vue";
 import OfflineIndicator from "../components/Footer/OfflineIndicator.vue";
 import PasswordModal from "../components/Auth/PasswordModal.vue";
+import PinLockOverlay from "../components/Auth/PinLockOverlay.vue";
 import LoginModal from "../components/Auth/LoginModal.vue";
+import api from "../api";
 import HelpModal from "../components/HelpModal.vue";
 import collector from "../mixins/collector";
 import { defineComponent } from "vue";
@@ -49,6 +52,7 @@ export default defineComponent({
 		BatterySettingsModal,
 		ForecastModal,
 		PasswordModal,
+		PinLockOverlay,
 		LoginModal,
 		OfflineIndicator,
 	},
@@ -63,6 +67,12 @@ export default defineComponent({
 			openTimeout: null as number | null,
 			ws: null as WebSocket | null,
 			authNotConfigured: false,
+			showUiLock: false,
+			idleTimer: null as number | null,
+			refreshTimer: null as number | null,
+			idleActivityHandler: null as (() => void) | null,
+			uilockTimeoutMs: 0,
+			lastActivityTs: 0,
 		};
 	},
 	head() {
@@ -113,17 +123,102 @@ export default defineComponent({
 		},
 	},
 	mounted() {
-		this.connect();
+		void this.bootstrapUiLock();
 		document.addEventListener("visibilitychange", this.pageVisibilityChanged, false);
 		window.addEventListener("pageshow", this.pageShowHandler);
 	},
 	unmounted() {
 		this.disconnect();
 		this.clearReconnectTimeout();
+		this.stopIdleMonitor();
 		document.removeEventListener("visibilitychange", this.pageVisibilityChanged, false);
 		window.removeEventListener("pageshow", this.pageShowHandler);
 	},
 	methods: {
+		async bootstrapUiLock() {
+			try {
+				const res = await api.get("auth/uilock/status", {
+					validateStatus: (s) => s >= 200 && s < 500,
+				});
+				const data = res.data as {
+					appliesToClient?: boolean;
+					unlocked?: boolean;
+					timeout?: number;
+				};
+				if (data.appliesToClient && !data.unlocked) {
+					store.update({ startupCompleted: true });
+					this.showUiLock = true;
+				} else if (data.appliesToClient && data.unlocked && data.timeout) {
+					this.startIdleMonitor(data.timeout);
+				}
+			} catch (e) {
+				console.warn("uilock status", e);
+			}
+			this.connect();
+		},
+		async onUiLockUnlocked() {
+			this.showUiLock = false;
+			try {
+				const res = await api.get("auth/uilock/status", {
+					validateStatus: (s) => s >= 200 && s < 500,
+				});
+				const timeout = (res.data as { timeout?: number }).timeout;
+				if (timeout) this.startIdleMonitor(timeout);
+			} catch {
+				// fall back to store value if available
+				const timeout = store.state.uilock?.timeout as number | undefined;
+				if (timeout) this.startIdleMonitor(timeout);
+			}
+		},
+		startIdleMonitor(timeoutSec: number) {
+			this.stopIdleMonitor();
+			if (timeoutSec <= 0) return;
+
+			this.uilockTimeoutMs = timeoutSec * 1000;
+			this.lastActivityTs = Date.now();
+
+			this.idleActivityHandler = () => {
+				const now = Date.now();
+				if (now - this.lastActivityTs < 1000) return;
+				this.lastActivityTs = now;
+				this.resetIdleTimer();
+			};
+			const events = ["mousedown", "keydown", "touchstart", "scroll"];
+			events.forEach((e) =>
+				document.addEventListener(e, this.idleActivityHandler!, { passive: true }),
+			);
+
+			this.resetIdleTimer();
+
+			const refreshMs = Math.min(60_000, Math.max(30_000, this.uilockTimeoutMs / 3));
+			this.refreshTimer = window.setInterval(() => {
+				if (!this.showUiLock && Date.now() - this.lastActivityTs < this.uilockTimeoutMs) {
+					api.get("auth/uilock/status", { validateStatus: (s: number) => s < 500 });
+				}
+			}, refreshMs);
+		},
+		resetIdleTimer() {
+			if (this.idleTimer) window.clearTimeout(this.idleTimer);
+			this.idleTimer = window.setTimeout(() => {
+				this.showUiLock = true;
+				this.stopIdleMonitor();
+			}, this.uilockTimeoutMs);
+		},
+		stopIdleMonitor() {
+			if (this.idleTimer) {
+				window.clearTimeout(this.idleTimer);
+				this.idleTimer = null;
+			}
+			if (this.refreshTimer) {
+				window.clearInterval(this.refreshTimer);
+				this.refreshTimer = null;
+			}
+			if (this.idleActivityHandler) {
+				const events = ["mousedown", "keydown", "touchstart", "scroll"];
+				events.forEach((e) => document.removeEventListener(e, this.idleActivityHandler!));
+				this.idleActivityHandler = null;
+			}
+		},
 		clearReconnectTimeout() {
 			if (this.reconnectTimeout) {
 				window.clearTimeout(this.reconnectTimeout);

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/evcc-io/evcc/util/pipe"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/evcc-io/evcc/util/telemetry"
+	"github.com/evcc-io/evcc/util/uilock"
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cast"
@@ -192,6 +193,11 @@ func runRoot(cmd *cobra.Command, args []string) {
 	// configure network
 	if err == nil {
 		err = networkSettings(&conf.Network)
+	}
+
+	// configure UI lock (after database)
+	if err == nil {
+		err = uilockSettings(&conf.UILock)
 	}
 
 	// configure plugin external url
@@ -373,6 +379,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	valueChan <- util.Param{Key: keys.ModbusProxy, Val: conf.ModbusProxy}
 	valueChan <- util.Param{Key: keys.Mqtt, Val: conf.Mqtt}
 	valueChan <- util.Param{Key: keys.Network, Val: conf.Network}
+	valueChan <- util.Param{Key: keys.UILock, Val: uilock.NewManager().Published(server.CurrentUILockConfig(conf.UILock))}
 	valueChan <- util.Param{Key: keys.Ocpp, Val: globalconfig.ConfigStatus{
 		Config: conf.Ocpp,
 		Status: ocpp.GetStatus(),
@@ -427,9 +434,12 @@ func runRoot(cmd *cobra.Command, args []string) {
 		valueChan <- util.Param{Key: keys.DemoMode, Val: true}
 	}
 
+	uilockMgr := uilock.NewManager()
 	httpd.RegisterSystemHandler(site, func(k string, v any) {
 		valueChan <- util.Param{Key: k, Val: v}
-	}, cache, authObject, func() {
+	}, cache, authObject, uilockMgr, func() globalconfig.UILock {
+		return server.CurrentUILockConfig(conf.UILock)
+	}, func() {
 		log.INFO.Println("evcc was stopped by user. OS should restart the service. Or restart manually.")
 		err = errors.New("restart required") // https://gokrazy.org/development/process-interface/
 		once.Do(func() { close(stopC) })     // signal loop to end

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/evcc-io/evcc/util/service"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/evcc-io/evcc/util/templates"
+	"github.com/evcc-io/evcc/util/uilock"
 	"github.com/evcc-io/evcc/vehicle"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -66,6 +67,7 @@ var conf = globalconfig.All{
 		Host: "",
 		Port: 7070,
 	},
+	UILock: globalconfig.DefaultUILock(),
 	Ocpp: ocpp.Config{
 		Port: 8887,
 	},
@@ -739,6 +741,28 @@ func networkSettings(conf *globalconfig.Network) error {
 		return settings.Json(keys.Network, &conf)
 	}
 
+	return nil
+}
+
+// uilockSettings merges DB settings over YAML and applies optional YAML PIN bootstrap.
+func uilockSettings(conf *globalconfig.UILock) error {
+	yamlPin := conf.Pin
+	if settings.Exists(keys.UILock) {
+		var stored globalconfig.UILock
+		if err := settings.Json(keys.UILock, &stored); err != nil {
+			return err
+		}
+		*conf = stored
+	}
+	if yamlPin != "" {
+		mgr := uilock.NewManager()
+		if !mgr.PinConfigured() {
+			if err := mgr.SetPin(yamlPin); err != nil {
+				return err
+			}
+		}
+	}
+	conf.Pin = ""
 	return nil
 }
 

--- a/core/keys/auth.go
+++ b/core/keys/auth.go
@@ -3,4 +3,5 @@ package keys
 const (
 	AdminPassword = "adminPassword"
 	JwtSecret     = "jwtSecretKey"
+	UiLockPin     = "uiLockPin"
 )

--- a/core/keys/global.go
+++ b/core/keys/global.go
@@ -31,4 +31,5 @@ const (
 	DemoMode           = "demoMode"
 	AuthDisabled       = "authDisabled"
 	AuthProviders      = "authProviders"
+	UILock             = "uilock"
 )

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1119,10 +1119,12 @@
     },
     "loadpoint": {
       "avgPrice": "⌀ Preis",
+      "backToOverview": "Zurück zur Übersicht",
       "charged": "Geladen",
       "co2": "⌀ CO₂",
       "duration": "Ladedauer",
       "emission": "Emission",
+      "expandViewport": "Vollansicht",
       "fallbackName": "Ladepunkt",
       "finished": "Ladeende",
       "power": "Leistung",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1105,10 +1105,12 @@
     },
     "loadpoint": {
       "avgPrice": "⌀ Preis",
+      "backToOverview": "Zurück zur Übersicht",
       "charged": "Geladen",
       "co2": "⌀ CO₂",
       "duration": "Ladedauer",
       "emission": "Emission",
+      "expandViewport": "Vollansicht",
       "fallbackName": "Ladepunkt",
       "finished": "Ladeende",
       "power": "Leistung",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -790,6 +790,20 @@
       "label": "Titel",
       "title": "Titel bearbeiten"
     },
+    "uilock": {
+      "confirmRemove": "Bildschirmsperre zurücksetzen und PIN löschen?",
+      "descriptionEnabled": "Sperrt die Oberfläche nach einer einstellbaren Zeit ohne Bedienung. Die PIN-Eingabe erscheint nur im Browser – API- und WebSocket-Zugriffe bleiben unberührt.",
+      "descriptionIps": "IP-Adressen, die zur PIN-Eingabe aufgefordert werden (z.\u00a0B. ein Kiosk-Display). Eine pro Zeile oder kommagetrennt.",
+      "descriptionPin": "Feld leer lassen, um die bestehende PIN beizubehalten.",
+      "descriptionTimeout": "Zeit ohne Bedienung in Sekunden, nach der die Sperre aktiv wird.",
+      "descriptionTrustedProxies": "CIDR-Bereiche vertrauenswürdiger Reverse-Proxys (z.\u00a0B. 127.0.0.1/32). Damit wird die echte Client-IP aus X-Forwarded-For ermittelt. Ohne Eintrag wird der Header ignoriert.",
+      "labelEnabled": "Bildschirmsperre",
+      "labelIps": "Gesperrte IPs",
+      "labelPin": "PIN",
+      "labelTimeout": "Timeout (Sekunden)",
+      "labelTrustedProxies": "Vertrauenswürdige Proxys",
+      "title": "Bildschirmsperre"
+    },
     "validation": {
       "failed": "fehlgeschlagen",
       "label": "Status",
@@ -1216,6 +1230,12 @@
     "targetEnergy": {
       "label": "Ladelimit",
       "noLimit": "keins"
+    },
+    "uilock": {
+      "pinInput": "PIN eingeben",
+      "title": "Gesperrt",
+      "unlock": "OK",
+      "wrongPin": "Falsche PIN"
     },
     "vehicle": {
       "addVehicle": "Fahrzeug hinzufügen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1105,10 +1105,12 @@
     },
     "loadpoint": {
       "avgPrice": "⌀ Price",
+      "backToOverview": "Back to overview",
       "charged": "Charged",
       "co2": "⌀ CO₂",
       "duration": "Duration",
       "emission": "Emission",
+      "expandViewport": "Expand to full view",
       "fallbackName": "Charging point",
       "finished": "Finish time",
       "power": "Power",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1119,10 +1119,12 @@
     },
     "loadpoint": {
       "avgPrice": "⌀ Price",
+      "backToOverview": "Back to overview",
       "charged": "Charged",
       "co2": "⌀ CO₂",
       "duration": "Duration",
       "emission": "Emission",
+      "expandViewport": "Expand to full view",
       "fallbackName": "Charging point",
       "finished": "Finish time",
       "power": "Power",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -790,6 +790,20 @@
       "label": "Title",
       "title": "Edit Title"
     },
+    "uilock": {
+      "confirmRemove": "Reset screen lock and delete the PIN?",
+      "descriptionEnabled": "Locks the interface after a period of inactivity. The PIN prompt only appears in the browser — API and WebSocket access is not affected.",
+      "descriptionIps": "IP addresses that will be prompted for the PIN (e.g. a kiosk display). One per line or comma-separated.",
+      "descriptionPin": "Leave empty to keep the current PIN.",
+      "descriptionTimeout": "Seconds of inactivity before the lock activates.",
+      "descriptionTrustedProxies": "CIDR ranges of trusted reverse proxies (e.g. 127.0.0.1/32). Used to determine the real client IP from X-Forwarded-For. Leave empty to ignore the header.",
+      "labelEnabled": "Screen lock",
+      "labelIps": "Locked IPs",
+      "labelPin": "PIN",
+      "labelTimeout": "Timeout (seconds)",
+      "labelTrustedProxies": "Trusted proxies",
+      "title": "Screen lock"
+    },
     "validation": {
       "failed": "failed",
       "label": "Status",
@@ -1216,6 +1230,12 @@
     "targetEnergy": {
       "label": "Limit",
       "noLimit": "none"
+    },
+    "uilock": {
+      "pinInput": "Enter PIN",
+      "title": "Locked",
+      "unlock": "OK",
+      "wrongPin": "Wrong PIN"
     },
     "vehicle": {
       "addVehicle": "Add vehicle",

--- a/server/http.go
+++ b/server/http.go
@@ -20,6 +20,7 @@ import (
 	"github.com/evcc-io/evcc/util/auth"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/telemetry"
+	"github.com/evcc-io/evcc/util/uilock"
 	"github.com/go-http-utils/etag"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -225,7 +226,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 }
 
 // RegisterSystemHandler provides system level handlers
-func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *util.ParamCache, auth auth.Auth, shutdown func(), configFile string) {
+func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *util.ParamCache, auth auth.Auth, uilockMgr *uilock.Manager, uilockCurrent func() globalconfig.UILock, shutdown func(), configFile string) {
 	router := s.Server.Handler.(*mux.Router)
 
 	// api
@@ -262,10 +263,13 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *uti
 		api := api.PathPrefix("/auth").Subrouter()
 
 		routes := map[string]route{
-			"password": {"PUT", "/password", updatePasswordHandler(auth)},
-			"auth":     {"GET", "/status", authStatusHandler(auth)},
-			"login":    {"POST", "/login", loginHandler(auth)},
-			"logout":   {"POST", "/logout", logoutHandler},
+			"password":     {"PUT", "/password", updatePasswordHandler(auth)},
+			"auth":         {"GET", "/status", authStatusHandler(auth)},
+			"login":        {"POST", "/login", loginHandler(auth)},
+			"logout":       {"POST", "/logout", logoutHandler},
+			"uilockstatus": {"GET", "/uilock/status", uilockStatusHandler(uilockMgr, uilockCurrent)},
+			"uilockunlock": {"POST", "/uilock/unlock", uilockUnlockHandler(uilockMgr, uilockCurrent)},
+			"uilocklock":   {"POST", "/uilock/lock", uilockLockHandler},
 		}
 
 		for _, r := range routes {
@@ -323,6 +327,9 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *uti
 			routes["update"+key] = route{Method: "POST", Pattern: "/" + key, HandlerFunc: settingsSetJsonHandler(key, pub, fun)}
 			routes["delete"+key] = route{Method: "DELETE", Pattern: "/" + key, HandlerFunc: settingsDeleteJsonHandler(key, pub, fun())}
 		}
+
+		routes["update"+keys.UILock] = route{Method: "POST", Pattern: "/" + keys.UILock, HandlerFunc: settingsSetUILockHandler(pub, uilockCurrent)}
+		routes["delete"+keys.UILock] = route{Method: "DELETE", Pattern: "/" + keys.UILock, HandlerFunc: settingsDeleteUILockHandler(pub, uilockCurrent)}
 
 		for _, r := range routes {
 			api.Methods(r.Methods()...).Path(r.Pattern).Handler(r.HandlerFunc)

--- a/server/http_uilock.go
+++ b/server/http_uilock.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/evcc-io/evcc/api/globalconfig"
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/util/uilock"
+)
+
+// CurrentUILockConfig returns DB-backed UI lock settings when present, otherwise fallback (typically from YAML / startup merge).
+func CurrentUILockConfig(fallback globalconfig.UILock) globalconfig.UILock {
+	if settings.Exists(keys.UILock) {
+		var u globalconfig.UILock
+		if err := settings.Json(keys.UILock, &u); err == nil {
+			return u
+		}
+	}
+	return fallback
+}
+
+type uilockStatusResponse struct {
+	Enabled         bool    `json:"enabled"`
+	AppliesToClient bool    `json:"appliesToClient"`
+	Unlocked        bool    `json:"unlocked"`
+	PinConfigured   bool    `json:"pinConfigured"`
+	Timeout         float64 `json:"timeout"`
+}
+
+func uilockStatusHandler(m *uilock.Manager, current func() globalconfig.UILock) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cfg := current()
+		applies := m.Applies(r, cfg)
+		unlocked := !applies
+		if applies {
+			unlocked = m.RefreshUnlockCookieIfValid(w, r, cfg)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(uilockStatusResponse{
+			Enabled:         cfg.Enabled,
+			AppliesToClient: applies,
+			Unlocked:        unlocked,
+			PinConfigured:   m.PinConfigured(),
+			Timeout:         cfg.Timeout.Seconds(),
+		})
+	}
+}
+
+type uilockUnlockRequest struct {
+	Pin string `json:"pin"`
+}
+
+func uilockUnlockHandler(m *uilock.Manager, current func() globalconfig.UILock) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req uilockUnlockRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !m.IsPinValid(req.Pin) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		cfg := current()
+		if err := m.IssueUnlockCookie(w, cfg); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func uilockLockHandler(w http.ResponseWriter, r *http.Request) {
+	uilock.ClearUnlockCookie(w)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func settingsSetUILockHandler(pub publisher, current func() globalconfig.UILock) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req globalconfig.UILock
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		var old globalconfig.UILock
+		_ = settings.Json(keys.UILock, &old)
+
+		old.Enabled = req.Enabled
+		old.Timeout = req.Timeout
+		old.IPs = req.IPs
+		old.TrustedProxies = req.TrustedProxies
+		old.Pin = ""
+
+		mgr := uilock.NewManager()
+		switch req.Pin {
+		case "", uilock.MaskedPin:
+			// unchanged
+		default:
+			if err := mgr.SetPin(req.Pin); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		if err := settings.SetJson(keys.UILock, old); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		setConfigDirty()
+
+		pub(keys.UILock, mgr.Published(CurrentUILockConfig(current())))
+		jsonWrite(w, true)
+	}
+}
+
+func settingsDeleteUILockHandler(pub publisher, current func() globalconfig.UILock) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defaults := globalconfig.DefaultUILock()
+		if err := settings.SetJson(keys.UILock, defaults); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		settings.SetString(keys.UiLockPin, "")
+		setConfigDirty()
+
+		mgr := uilock.NewManager()
+		pub(keys.UILock, mgr.Published(CurrentUILockConfig(current())))
+		jsonWrite(w, true)
+	}
+}

--- a/util/uilock/manager.go
+++ b/util/uilock/manager.go
@@ -87,10 +87,7 @@ func (m *Manager) Applies(r *http.Request, conf globalconfig.UILock) bool {
 	if !conf.Enabled || !m.PinConfigured() {
 		return false
 	}
-	nets, err := ParseCIDRList(conf.TrustedProxies)
-	if err != nil {
-		return false
-	}
+	nets := ParseCIDRList(conf.TrustedProxies)
 	clientIP := EffectiveClientIP(r, nets)
 	if clientIP == nil {
 		return false

--- a/util/uilock/manager.go
+++ b/util/uilock/manager.go
@@ -1,0 +1,206 @@
+package uilock
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/evcc-io/evcc/api/globalconfig"
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	uilockCookieName = "uilock"
+	uilockSubject    = "uilock"
+	// MaskedPin is the placeholder sent to the UI when a PIN is configured (compare Influx etc.).
+	MaskedPin = "***"
+)
+
+// Manager holds UI lock state and validates unlock tokens.
+type Manager struct {
+	settings settings.API
+}
+
+// NewManager creates a Manager using the default settings store.
+func NewManager() *Manager {
+	return &Manager{settings: new(settings.Settings)}
+}
+
+// NewManagerWithSettings allows tests to inject a mock settings API.
+func NewManagerWithSettings(s settings.API) *Manager {
+	return &Manager{settings: s}
+}
+
+// PinConfigured returns whether a PIN hash exists.
+func (m *Manager) PinConfigured() bool {
+	h, err := m.settings.String(keys.UiLockPin)
+	return err == nil && h != ""
+}
+
+// SetPin stores a bcrypt hash of the PIN.
+func (m *Manager) SetPin(pin string) error {
+	if pin == "" {
+		m.settings.SetString(keys.UiLockPin, "")
+		return nil
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(pin), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	m.settings.SetString(keys.UiLockPin, string(hash))
+	return nil
+}
+
+// IsPinValid checks the PIN against the stored hash.
+func (m *Manager) IsPinValid(pin string) bool {
+	h, err := m.settings.String(keys.UiLockPin)
+	if err != nil || h == "" {
+		return false
+	}
+	return bcrypt.CompareHashAndPassword([]byte(h), []byte(pin)) == nil
+}
+
+// Published builds the value broadcast to the UI.
+func (m *Manager) Published(conf globalconfig.UILock) globalconfig.UILockPublished {
+	pinField := ""
+	if m.PinConfigured() {
+		pinField = MaskedPin
+	}
+	return globalconfig.UILockPublished{
+		Enabled:        conf.Enabled,
+		Timeout:        conf.Timeout.Seconds(),
+		IPs:            conf.IPs,
+		TrustedProxies: conf.TrustedProxies,
+		Pin:            pinField,
+		PinConfigured:  m.PinConfigured(),
+	}
+}
+
+// Applies returns whether the UI lock applies to this request (PIN required but not yet unlocked session).
+func (m *Manager) Applies(r *http.Request, conf globalconfig.UILock) bool {
+	if !conf.Enabled || !m.PinConfigured() {
+		return false
+	}
+	nets, err := ParseCIDRList(conf.TrustedProxies)
+	if err != nil {
+		return false
+	}
+	clientIP := EffectiveClientIP(r, nets)
+	if clientIP == nil {
+		return false
+	}
+	return ipMatchesList(clientIP, conf.IPs)
+}
+
+// ipMatchesList reports whether ip matches any entry (string form, IPv4/IPv6).
+func ipMatchesList(ip net.IP, list []string) bool {
+	for _, s := range list {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if other := net.ParseIP(s); other != nil && ip.Equal(other) {
+			return true
+		}
+	}
+	return false
+}
+
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func (m *Manager) jwtSecret() ([]byte, error) {
+	s, err := m.settings.String(keys.JwtSecret)
+	if err != nil || s == "" {
+		key, err := randomHex(32)
+		if err != nil {
+			return nil, err
+		}
+		m.settings.SetString(keys.JwtSecret, key)
+		return []byte(key), nil
+	}
+	return []byte(s), nil
+}
+
+// IssueUnlockCookie sets the uilock cookie with a JWT valid for the given idle duration.
+func (m *Manager) IssueUnlockCookie(w http.ResponseWriter, conf globalconfig.UILock) error {
+	secret, err := m.jwtSecret()
+	if err != nil {
+		return err
+	}
+	if conf.Timeout <= 0 {
+		conf.Timeout = globalconfig.DefaultUILockTimeout
+	}
+	now := time.Now()
+	claims := &jwt.RegisteredClaims{
+		Subject:   uilockSubject,
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(conf.Timeout)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := token.SignedString(secret)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     uilockCookieName,
+		Value:    s,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Expires:  now.Add(conf.Timeout),
+	})
+	return nil
+}
+
+// HasValidUnlockToken reports whether the uilock cookie is present and still valid (not expired).
+func (m *Manager) HasValidUnlockToken(r *http.Request) bool {
+	c, err := r.Cookie(uilockCookieName)
+	if err != nil || c == nil || c.Value == "" {
+		return false
+	}
+	secret, err := m.jwtSecret()
+	if err != nil {
+		return false
+	}
+	var claims jwt.RegisteredClaims
+	token, err := jwt.ParseWithClaims(c.Value, &claims, func(token *jwt.Token) (any, error) {
+		return secret, nil
+	})
+	if err != nil || !token.Valid || claims.Subject != uilockSubject {
+		return false
+	}
+	if claims.ExpiresAt != nil && time.Now().After(claims.ExpiresAt.Time) {
+		return false
+	}
+	return true
+}
+
+// RefreshUnlockCookieIfValid re-issues the cookie when the current token is valid (sliding idle timeout).
+func (m *Manager) RefreshUnlockCookieIfValid(w http.ResponseWriter, r *http.Request, conf globalconfig.UILock) bool {
+	if !m.HasValidUnlockToken(r) {
+		return false
+	}
+	return m.IssueUnlockCookie(w, conf) == nil
+}
+
+// ClearUnlockCookie clears the uilock cookie.
+func ClearUnlockCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     uilockCookieName,
+		Path:     "/",
+		HttpOnly: true,
+		MaxAge:   -1,
+	})
+}

--- a/util/uilock/realip.go
+++ b/util/uilock/realip.go
@@ -1,0 +1,83 @@
+package uilock
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// EffectiveClientIP returns the client IP for access control. If trustedProxies is non-empty
+// and the direct TCP peer matches one of those CIDRs, the IP is taken from X-Forwarded-For
+// (leftmost valid hop) or X-Real-IP; otherwise RemoteAddr is used and forwarded headers are ignored.
+func EffectiveClientIP(r *http.Request, trustedProxies []*net.IPNet) net.IP {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	direct := net.ParseIP(host)
+	if direct == nil {
+		return nil
+	}
+
+	if len(trustedProxies) == 0 || !ipInNets(direct, trustedProxies) {
+		return direct
+	}
+
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			// IPv6 in XFF can be bracketed
+			p = strings.TrimPrefix(strings.TrimSuffix(p, "]"), "[")
+			if ip := net.ParseIP(p); ip != nil {
+				return ip
+			}
+		}
+	}
+
+	if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); xr != "" {
+		if ip := net.ParseIP(xr); ip != nil {
+			return ip
+		}
+	}
+
+	return direct
+}
+
+func ipInNets(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseCIDRList parses CIDR strings; invalid entries are skipped.
+func ParseCIDRList(ss []string) ([]*net.IPNet, error) {
+	var out []*net.IPNet
+	for _, s := range ss {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if !strings.Contains(s, "/") {
+			if ip := net.ParseIP(s); ip != nil {
+				if ip4 := ip.To4(); ip4 != nil {
+					s = ip4.String() + "/32"
+				} else {
+					s = ip.String() + "/128"
+				}
+			}
+		}
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}

--- a/util/uilock/realip.go
+++ b/util/uilock/realip.go
@@ -4,7 +4,11 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/evcc-io/evcc/util"
 )
+
+var log = util.NewLogger("uilock")
 
 // EffectiveClientIP returns the client IP for access control. If trustedProxies is non-empty
 // and the direct TCP peer matches one of those CIDRs, the IP is taken from X-Forwarded-For
@@ -56,8 +60,9 @@ func ipInNets(ip net.IP, nets []*net.IPNet) bool {
 	return false
 }
 
-// ParseCIDRList parses CIDR strings; invalid entries are skipped.
-func ParseCIDRList(ss []string) ([]*net.IPNet, error) {
+// ParseCIDRList parses CIDR strings. Plain IPs are normalized to /32 or /128.
+// Invalid entries are skipped with a warning log.
+func ParseCIDRList(ss []string) []*net.IPNet {
 	var out []*net.IPNet
 	for _, s := range ss {
 		s = strings.TrimSpace(s)
@@ -75,9 +80,10 @@ func ParseCIDRList(ss []string) ([]*net.IPNet, error) {
 		}
 		_, n, err := net.ParseCIDR(s)
 		if err != nil {
-			return nil, err
+			log.WARN.Printf("ignoring invalid CIDR entry %q: %v", s, err)
+			continue
 		}
 		out = append(out, n)
 	}
-	return out, nil
+	return out
 }

--- a/util/uilock/realip_test.go
+++ b/util/uilock/realip_test.go
@@ -1,0 +1,47 @@
+package uilock
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCIDRList(t *testing.T) {
+	nets, err := ParseCIDRList([]string{"127.0.0.1/32", "10.0.0.0/8"})
+	require.NoError(t, err)
+	require.Len(t, nets, 2)
+
+	_, err = ParseCIDRList([]string{"not-a-cidr"})
+	require.Error(t, err)
+}
+
+func TestEffectiveClientIP(t *testing.T) {
+	t.Parallel()
+
+	cidr10, err := ParseCIDRList([]string{"10.0.0.0/8"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.1.2.3:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.5, 198.51.100.1")
+	ip := EffectiveClientIP(req, cidr10)
+	assert.Equal(t, "203.0.113.5", ip.String())
+
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.RemoteAddr = "198.51.100.1:443"
+	req2.Header.Set("X-Forwarded-For", "203.0.113.5")
+	ip2 := EffectiveClientIP(req2, cidr10)
+	assert.Equal(t, "198.51.100.1", ip2.String())
+}
+
+func TestIpMatchesList(t *testing.T) {
+	t.Parallel()
+	ip := net.ParseIP("127.0.0.1")
+	require.NotNil(t, ip)
+	assert.True(t, ipMatchesList(ip, []string{"127.0.0.1", "::1"}))
+	assert.False(t, ipMatchesList(ip, []string{"10.0.0.1"}))
+}

--- a/util/uilock/realip_test.go
+++ b/util/uilock/realip_test.go
@@ -11,37 +11,242 @@ import (
 )
 
 func TestParseCIDRList(t *testing.T) {
-	nets, err := ParseCIDRList([]string{"127.0.0.1/32", "10.0.0.0/8"})
-	require.NoError(t, err)
-	require.Len(t, nets, 2)
+	t.Parallel()
 
-	_, err = ParseCIDRList([]string{"not-a-cidr"})
-	require.Error(t, err)
+	tests := []struct {
+		name     string
+		input    []string
+		wantLen  int
+		wantNets []string
+	}{
+		{
+			name:     "valid IPv4 CIDRs",
+			input:    []string{"127.0.0.1/32", "10.0.0.0/8"},
+			wantLen:  2,
+			wantNets: []string{"127.0.0.1/32", "10.0.0.0/8"},
+		},
+		{
+			name:     "plain IPv4 normalized to /32",
+			input:    []string{"192.168.1.1"},
+			wantLen:  1,
+			wantNets: []string{"192.168.1.1/32"},
+		},
+		{
+			name:     "plain IPv6 normalized to /128",
+			input:    []string{"::1"},
+			wantLen:  1,
+			wantNets: []string{"::1/128"},
+		},
+		{
+			name:     "valid IPv6 CIDR",
+			input:    []string{"fd00::/64"},
+			wantLen:  1,
+			wantNets: []string{"fd00::/64"},
+		},
+		{
+			name:    "invalid entry skipped",
+			input:   []string{"not-a-cidr"},
+			wantLen: 0,
+		},
+		{
+			name:     "mixed valid and invalid",
+			input:    []string{"10.0.0.0/8", "garbage", "192.168.1.0/24"},
+			wantLen:  2,
+			wantNets: []string{"10.0.0.0/8", "192.168.1.0/24"},
+		},
+		{
+			name:    "empty and whitespace entries",
+			input:   []string{"", "  ", "\t"},
+			wantLen: 0,
+		},
+		{
+			name:     "whitespace around valid entry",
+			input:    []string{"  10.0.0.0/8  "},
+			wantLen:  1,
+			wantNets: []string{"10.0.0.0/8"},
+		},
+		{
+			name:    "nil input",
+			input:   nil,
+			wantLen: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nets := ParseCIDRList(tc.input)
+			require.Len(t, nets, tc.wantLen)
+			for i, want := range tc.wantNets {
+				assert.Equal(t, want, nets[i].String())
+			}
+		})
+	}
 }
 
 func TestEffectiveClientIP(t *testing.T) {
 	t.Parallel()
 
-	cidr10, err := ParseCIDRList([]string{"10.0.0.0/8"})
-	require.NoError(t, err)
+	cidr10 := ParseCIDRList([]string{"10.0.0.0/8"})
+	require.Len(t, cidr10, 1)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.RemoteAddr = "10.1.2.3:1234"
-	req.Header.Set("X-Forwarded-For", "203.0.113.5, 198.51.100.1")
-	ip := EffectiveClientIP(req, cidr10)
-	assert.Equal(t, "203.0.113.5", ip.String())
+	tests := []struct {
+		name           string
+		remoteAddr     string
+		xff            string
+		xRealIP        string
+		trustedProxies []*net.IPNet
+		want           string
+	}{
+		{
+			name:           "trusted proxy with X-Forwarded-For",
+			remoteAddr:     "10.1.2.3:1234",
+			xff:            "203.0.113.5, 198.51.100.1",
+			trustedProxies: cidr10,
+			want:           "203.0.113.5",
+		},
+		{
+			name:           "non-trusted proxy ignores XFF",
+			remoteAddr:     "198.51.100.1:443",
+			xff:            "203.0.113.5",
+			trustedProxies: cidr10,
+			want:           "198.51.100.1",
+		},
+		{
+			name:           "trusted proxy falls back to X-Real-IP",
+			remoteAddr:     "10.0.0.1:80",
+			xRealIP:        "172.16.0.5",
+			trustedProxies: cidr10,
+			want:           "172.16.0.5",
+		},
+		{
+			name:           "trusted proxy falls back to RemoteAddr when headers missing",
+			remoteAddr:     "10.0.0.1:80",
+			trustedProxies: cidr10,
+			want:           "10.0.0.1",
+		},
+		{
+			name:           "empty trustedProxies ignores forwarded headers",
+			remoteAddr:     "10.0.0.1:80",
+			xff:            "203.0.113.5",
+			trustedProxies: nil,
+			want:           "10.0.0.1",
+		},
+		{
+			name:           "IPv6 RemoteAddr",
+			remoteAddr:     "[::1]:1234",
+			trustedProxies: nil,
+			want:           "::1",
+		},
+		{
+			name:           "IPv6 trusted proxy with XFF containing bracketed IPv6",
+			remoteAddr:     "[fd00::1]:443",
+			xff:            "[2001:db8::1]",
+			trustedProxies: ParseCIDRList([]string{"fd00::/16"}),
+			want:           "2001:db8::1",
+		},
+		{
+			name:           "malformed RemoteAddr returns nil",
+			remoteAddr:     "not-an-ip",
+			trustedProxies: nil,
+			want:           "<nil>",
+		},
+		{
+			name:           "trusted proxy with invalid XFF falls back to X-Real-IP",
+			remoteAddr:     "10.0.0.1:80",
+			xff:            "not-an-ip",
+			xRealIP:        "192.168.1.1",
+			trustedProxies: cidr10,
+			want:           "192.168.1.1",
+		},
+		{
+			name:           "trusted proxy with invalid XFF and invalid X-Real-IP falls back to RemoteAddr",
+			remoteAddr:     "10.0.0.1:80",
+			xff:            "garbage",
+			xRealIP:        "also-garbage",
+			trustedProxies: cidr10,
+			want:           "10.0.0.1",
+		},
+	}
 
-	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
-	req2.RemoteAddr = "198.51.100.1:443"
-	req2.Header.Set("X-Forwarded-For", "203.0.113.5")
-	ip2 := EffectiveClientIP(req2, cidr10)
-	assert.Equal(t, "198.51.100.1", ip2.String())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tc.remoteAddr
+			if tc.xff != "" {
+				req.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if tc.xRealIP != "" {
+				req.Header.Set("X-Real-IP", tc.xRealIP)
+			}
+			ip := EffectiveClientIP(req, tc.trustedProxies)
+			if tc.want == "<nil>" {
+				assert.Nil(t, ip)
+			} else {
+				require.NotNil(t, ip)
+				assert.Equal(t, tc.want, ip.String())
+			}
+		})
+	}
 }
 
 func TestIpMatchesList(t *testing.T) {
 	t.Parallel()
-	ip := net.ParseIP("127.0.0.1")
-	require.NotNil(t, ip)
-	assert.True(t, ipMatchesList(ip, []string{"127.0.0.1", "::1"}))
-	assert.False(t, ipMatchesList(ip, []string{"10.0.0.1"}))
+
+	tests := []struct {
+		name string
+		ip   string
+		list []string
+		want bool
+	}{
+		{
+			name: "IPv4 match",
+			ip:   "127.0.0.1",
+			list: []string{"127.0.0.1", "::1"},
+			want: true,
+		},
+		{
+			name: "IPv4 no match",
+			ip:   "127.0.0.1",
+			list: []string{"10.0.0.1"},
+			want: false,
+		},
+		{
+			name: "IPv6 match",
+			ip:   "::1",
+			list: []string{"127.0.0.1", "::1"},
+			want: true,
+		},
+		{
+			name: "IPv6 no match",
+			ip:   "::1",
+			list: []string{"::2"},
+			want: false,
+		},
+		{
+			name: "whitespace around entry",
+			ip:   "10.0.0.1",
+			list: []string{"  10.0.0.1  "},
+			want: true,
+		},
+		{
+			name: "empty entries skipped",
+			ip:   "10.0.0.1",
+			list: []string{"", "  ", "10.0.0.1"},
+			want: true,
+		},
+		{
+			name: "empty list",
+			ip:   "10.0.0.1",
+			list: nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			require.NotNil(t, ip)
+			assert.Equal(t, tc.want, ipMatchesList(ip, tc.list))
+		})
+	}
 }

--- a/util/uilock/realip_test.go
+++ b/util/uilock/realip_test.go
@@ -73,7 +73,9 @@ func TestParseCIDRList(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			nets := ParseCIDRList(tc.input)
 			require.Len(t, nets, tc.wantLen)
 			for i, want := range tc.wantNets {
@@ -169,7 +171,9 @@ func TestEffectiveClientIP(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.RemoteAddr = tc.remoteAddr
 			if tc.xff != "" {
@@ -243,7 +247,9 @@ func TestIpMatchesList(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ip := net.ParseIP(tc.ip)
 			require.NotNil(t, ip)
 			assert.Equal(t, tc.want, ipMatchesList(ip, tc.list))


### PR DESCRIPTION
Allow users to expand a single loadpoint to fill the entire viewport via a toggle button next to the loadpoint title. The expanded state is reflected in the URL as ?maximize=<id>, enabling direct deep-links to a maximized loadpoint (e.g. for evcc running on a modified openWB or a wall-mounted tablets).

Especially useful together with: #28507

- Teleport pattern moves the loadpoint to <body> when expanded
- Expand/collapse SVG icon toggles in-place beside the title
- Escape key dismisses the expanded view (respects open modals)
- Body scroll is locked while expanded
- i18n strings added for en and de