### PR TITLE
Don't wait for PV timer when battery boost ends without surplus

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1473,6 +1473,12 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	// in MinPV mode or under special conditions return at least minCurrent
 	if battery := batteryStart || batteryBuffered && lp.charging(); (mode == api.ModeMinPV || battery) && targetCurrent < minCurrent {
 		lp.log.DEBUG.Printf("pv charge current: min %.3gA > %.3gA (%.0fW @ %dp, battery: %t)", minCurrent, targetCurrent, sitePower, activePhases, battery)
+		if battery {
+			// Pre-expire the pvTimer while battery mode is active. When battery
+			// mode ends (bufferSoc crossed), pvDisableDelay fires immediately
+			// instead of starting a fresh delay period.
+			lp.pvTimer = elapsed
+		}
 		return minCurrent
 	}
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -765,6 +765,48 @@ func TestPVHysteresisAfterPhaseSwitch(t *testing.T) {
 	}
 }
 
+// TestPVDisableImmediatelyAfterBatteryBufferedTransition verifies that when
+// battery-buffered mode ends (battery SoC drops below bufferSoc), the PV
+// disable timer fires immediately rather than starting a fresh delay period.
+func TestPVDisableImmediatelyAfterBatteryBufferedTransition(t *testing.T) {
+	Voltage = 100
+	const phases = 1
+	const disableDelay = time.Minute
+
+	clk := clock.NewMock()
+
+	lp := &Loadpoint{
+		log:            util.NewLogger("foo"),
+		clock:          clk,
+		minCurrent:     minA,
+		maxCurrent:     maxA,
+		phases:         phases,
+		measuredPhases: phases,
+		Disable: loadpoint.ThresholdConfig{
+			Threshold: 0,
+			Delay:     disableDelay,
+		},
+		enabled: true,
+	}
+	lp.status = api.StatusC // charging
+
+	// sitePower: positive (no solar, battery is discharging to supply car)
+	sitePower := float64(phases) * minA * Voltage
+
+	// Cycle 1 (t=0): battery buffered above bufferSoc. Early return fires at minCurrent.
+	current := lp.pvMaxCurrent(api.ModePV, sitePower, 0, true, false)
+	assert.Equal(t, minA, current, "battery buffered: should charge at minCurrent")
+
+	// Simulate time passing while battery mode was active (> disableDelay).
+	// elapsed sentinel = time.Unix(0,1); mock clock starts at time.Unix(0,0).
+	// Advance clock so that clock.Since(elapsed) > disableDelay.
+	clk.Set(elapsed.Add(disableDelay + time.Second))
+
+	// Cycle 2: battery SoC crosses bufferSoc → batteryBuffered=false.
+	current = lp.pvMaxCurrent(api.ModePV, sitePower, 0, false, false)
+	assert.Equal(t, 0.0, current, "battery threshold crossed: should disable immediately, not wait for another full delay period")
+}
+
 func TestConnectionDurationDropDetection(t *testing.T) {
 	clock := clock.NewMock()
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
If we start battery boosting with PV surplus, and the boost finishes when no more surplus remains, then we end up waiting for the full `pvTimer` duration before we stop charging. This ends up sipping a little extra from the battery, and it can give the impression that the feature isn't working correctly because the battery continues discharging despite hitting the cutoff.

Instead, if boosting ends without a PV surplus we can stop charging immediately by pre-expiring `pvTimer`. This _only_ triggers an immediate stop when boost ends in a no-surplus situation.

If boosting ends with PV surplus still available, `targetCurrent >= minCurrent` so the disable sequence is never entered and the pre-expired `pvTimer` has no effect.

A failing unit test is included to confirm the behavior.

NB: I can understand if this isn't accepted, since it does introduce an (unlikely) edge case where boosting could expire when the surplus is borderline, which could lead to some flapping. I'm also very excited for the optimizer work since this battery boosting is very valuable but also very suboptimal due to all the manual thresholds!