### PR TITLE
Feature/loadpoint maximize viewport

### DIFF
--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -585,6 +585,20 @@ export default defineComponent({
 	background: var(--evcc-box);
 }
 
+@media (max-width: 991.98px) {
+	.loadpoint {
+		opacity: 1;
+		transform: scale(1);
+		transition-property: opacity, transform;
+		transition-duration: var(--evcc-transition-fast);
+		transition-timing-function: ease-in;
+	}
+	.loadpoint-unselected {
+		transform: scale(0.95);
+		opacity: 0.5;
+	}
+}
+
 .loadpoint--viewport-expanded {
 	min-height: 0;
 	flex: 1 1 auto;

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -1,104 +1,250 @@
 <template>
-	<div class="loadpoint d-flex flex-column pt-4 pb-2 px-3 px-sm-4 mx-2 mx-sm-0">
+	<Teleport to="body" :disabled="!loadpointViewportMaximized">
 		<div
-			class="d-block d-sm-flex justify-content-between align-items-center mb-3"
-			:class="expandLoadpointHeader ? 'd-lg-block d-xl-flex' : ''"
+			:class="
+				loadpointViewportMaximized ? 'loadpoint-viewport-overlay safe-area-inset' : 'loadpoint-inline-host'
+			"
 		>
-			<div class="d-flex justify-content-between align-items-center mb-3 text-truncate">
-				<h3 class="me-2 mb-0 text-truncate d-flex">
-					<VehicleIcon
-						v-if="chargerIcon"
-						:name="chargerIcon"
-						class="me-2 flex-shrink-0"
+			<div
+				class="loadpoint d-flex flex-column pt-4 pb-2 px-3 px-sm-4"
+				v-bind="loadpointRootAttrs"
+				:class="[
+					loadpointViewportMaximized
+						? 'loadpoint--viewport-expanded flex-grow-1 mx-0'
+						: 'mx-2 mx-sm-0',
+				]"
+			>
+				<!-- sm+: title, expand/collapse, mode, settings in one row -->
+				<div class="d-none d-sm-flex align-items-center gap-2 mb-3 flex-wrap loadpoint-header-wide">
+					<h3 class="mb-0 text-truncate d-flex min-w-0 loadpoint-header-wide__title">
+						<VehicleIcon
+							v-if="chargerIcon"
+							:name="chargerIcon"
+							class="me-2 flex-shrink-0"
+						/>
+						<div class="text-truncate">
+							{{ loadpointTitle }}
+						</div>
+					</h3>
+					<button
+						type="button"
+						class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
+						:aria-label="
+							loadpointViewportMaximized
+								? $t('main.loadpoint.backToOverview')
+								: $t('main.loadpoint.expandViewport')
+						"
+						:data-testid="
+							loadpointViewportMaximized
+								? 'loadpoint-viewport-back'
+								: 'loadpoint-viewport-expand'
+						"
+						@click.stop="
+							loadpointViewportMaximized ? collapseViewport() : expandViewport()
+						"
+					>
+						<svg
+							v-if="loadpointViewportMaximized"
+							class="loadpoint-expand-icon"
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path d="M4 14h6v6" />
+							<path d="M20 10h-6V4" />
+							<path d="M14 10l7-7" />
+							<path d="M3 21l7-7" />
+						</svg>
+						<svg
+							v-else
+							class="loadpoint-expand-icon"
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path d="M8 3H5a2 2 0 0 0-2 2v3" />
+							<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+							<path d="M3 16v3a2 2 0 0 0 2 2h3" />
+							<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+						</svg>
+					</button>
+					<Mode
+						class="loadpoint-header-wide__mode flex-shrink-0"
+						v-bind="modeProps"
+						@updated="setTargetMode"
 					/>
-					<div class="text-truncate">
-						{{ loadpointTitle }}
-					</div>
-				</h3>
-				<LoadpointSettingsButton
-					:class="expandLoadpointHeader ? 'd-lg-block d-xl-none' : ''"
-					class="d-block d-sm-none"
-					@click="openSettingsModal"
-				/>
-			</div>
-			<div class="mb-3 d-flex align-items-center">
-				<Mode class="flex-grow-1" v-bind="modeProps" @updated="setTargetMode" />
-				<LoadpointSettingsButton
-					:id="id"
-					:class="expandLoadpointHeader ? 'd-lg-none d-xl-block' : ''"
-					class="d-none d-sm-block ms-2"
-					@click="openSettingsModal"
-				/>
-			</div>
-		</div>
-		<LoadpointSettingsModal
-			:id="id"
-			v-bind="settingsModal"
-			@maxcurrent-updated="setMaxCurrent"
-			@mincurrent-updated="setMinCurrent"
-			@phasesconfigured-updated="setPhasesConfigured"
-			@batteryboostlimit-updated="setBatteryBoostLimit"
-		/>
-
-		<div
-			v-if="remoteDisabled"
-			class="alert alert-warning my-4 py-2"
-			:class="`${remoteDisabled === 'hard' ? 'alert-danger' : 'alert-warning'}`"
-			role="alert"
-		>
-			{{
-				$t(
-					remoteDisabled === "hard"
-						? "main.loadpoint.remoteDisabledHard"
-						: "main.loadpoint.remoteDisabledSoft",
-					{ source: remoteDisabledSource }
-				)
-			}}
-		</div>
-
-		<div class="details d-flex align-items-start mb-2">
-			<div>
-				<div class="d-flex align-items-center">
-					<LabelAndValue
-						:label="$t('main.loadpoint.power')"
-						:value="chargePower"
-						:valueFmt="fmtPower"
-						class="mb-2 text-nowrap text-truncate-xs-only"
-						align="start"
+					<LoadpointSettingsButton
+						:id="id"
+						:class="expandLoadpointHeader ? 'd-lg-none d-xl-block' : ''"
+						class="flex-shrink-0"
+						@click="openSettingsModal"
 					/>
-					<shopicon-regular-lightning
-						class="text-evcc opacity-transiton"
-						:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
-						size="m"
-					></shopicon-regular-lightning>
 				</div>
-				<Phases
-					v-bind="phasesProps"
-					class="opacity-transiton"
-					:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
+				<!-- xs: stacked -->
+				<div class="d-flex d-sm-none flex-column mb-3">
+					<div class="d-flex justify-content-between align-items-center gap-2 mb-3">
+						<div class="d-flex align-items-center gap-2 min-w-0 flex-grow-1">
+							<h3 class="mb-0 text-truncate d-flex min-w-0 flex-grow-1">
+								<VehicleIcon
+									v-if="chargerIcon"
+									:name="chargerIcon"
+									class="me-2 flex-shrink-0"
+								/>
+								<div class="text-truncate">
+									{{ loadpointTitle }}
+								</div>
+							</h3>
+							<button
+								type="button"
+								class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
+								:aria-label="
+									loadpointViewportMaximized
+										? $t('main.loadpoint.backToOverview')
+										: $t('main.loadpoint.expandViewport')
+								"
+								:data-testid="
+									loadpointViewportMaximized
+										? 'loadpoint-viewport-back-xs'
+										: 'loadpoint-viewport-expand-xs'
+								"
+								@click.stop="
+									loadpointViewportMaximized
+										? collapseViewport()
+										: expandViewport()
+								"
+							>
+								<svg
+									v-if="loadpointViewportMaximized"
+									class="loadpoint-expand-icon"
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									aria-hidden="true"
+									focusable="false"
+								>
+									<path d="M4 14h6v6" />
+									<path d="M20 10h-6V4" />
+									<path d="M14 10l7-7" />
+									<path d="M3 21l7-7" />
+								</svg>
+								<svg
+									v-else
+									class="loadpoint-expand-icon"
+									width="18"
+									height="18"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									aria-hidden="true"
+									focusable="false"
+								>
+									<path d="M8 3H5a2 2 0 0 0-2 2v3" />
+									<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+									<path d="M3 16v3a2 2 0 0 0 2 2h3" />
+									<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+								</svg>
+							</button>
+						</div>
+						<LoadpointSettingsButton
+							:class="expandLoadpointHeader ? 'd-lg-block d-xl-none' : ''"
+							class="flex-shrink-0"
+							@click="openSettingsModal"
+						/>
+					</div>
+					<Mode v-bind="modeProps" @updated="setTargetMode" />
+				</div>
+				<LoadpointSettingsModal
+					:id="id"
+					v-bind="settingsModal"
+					@maxcurrent-updated="setMaxCurrent"
+					@mincurrent-updated="setMinCurrent"
+					@phasesconfigured-updated="setPhasesConfigured"
+					@batteryboostlimit-updated="setBatteryBoostLimit"
+				/>
+
+				<div
+					v-if="remoteDisabled"
+					class="alert alert-warning my-4 py-2"
+					:class="`${remoteDisabled === 'hard' ? 'alert-danger' : 'alert-warning'}`"
+					role="alert"
+				>
+					{{
+						$t(
+							remoteDisabled === "hard"
+								? "main.loadpoint.remoteDisabledHard"
+								: "main.loadpoint.remoteDisabledSoft",
+							{ source: remoteDisabledSource }
+						)
+					}}
+				</div>
+
+				<div class="details d-flex align-items-start mb-2">
+					<div>
+						<div class="d-flex align-items-center">
+							<LabelAndValue
+								:label="$t('main.loadpoint.power')"
+								:value="chargePower"
+								:valueFmt="fmtPower"
+								class="mb-2 text-nowrap text-truncate-xs-only"
+								align="start"
+							/>
+							<shopicon-regular-lightning
+								class="text-evcc opacity-transiton"
+								:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
+								size="m"
+							></shopicon-regular-lightning>
+						</div>
+						<Phases
+							v-bind="phasesProps"
+							class="opacity-transiton"
+							:class="`opacity-${showChargingIndicator ? '100' : '0'}`"
+						/>
+					</div>
+					<LabelAndValue
+						v-show="socBasedCharging"
+						:label="$t('main.loadpoint.charged')"
+						:value="chargedEnergy"
+						:valueFmt="fmtEnergy"
+						align="center"
+					/>
+					<LoadpointSessionInfo v-bind="sessionInfoProps" />
+				</div>
+				<hr class="divider" />
+				<Vehicle
+					class="flex-grow-1 d-flex flex-column justify-content-end"
+					v-bind="vehicleProps"
+					@limit-soc-updated="setLimitSoc"
+					@limit-energy-updated="setLimitEnergy"
+					@change-vehicle="changeVehicle"
+					@remove-vehicle="removeVehicle"
+					@open-loadpoint-settings="openSettingsModal"
+					@batteryboost-updated="setBatteryBoost"
 				/>
 			</div>
-			<LabelAndValue
-				v-show="socBasedCharging"
-				:label="$t('main.loadpoint.charged')"
-				:value="chargedEnergy"
-				:valueFmt="fmtEnergy"
-				align="center"
-			/>
-			<LoadpointSessionInfo v-bind="sessionInfoProps" />
 		</div>
-		<hr class="divider" />
-		<Vehicle
-			class="flex-grow-1 d-flex flex-column justify-content-end"
-			v-bind="vehicleProps"
-			@limit-soc-updated="setLimitSoc"
-			@limit-energy-updated="setLimitEnergy"
-			@change-vehicle="changeVehicle"
-			@remove-vehicle="removeVehicle"
-			@open-loadpoint-settings="openSettingsModal"
-			@batteryboost-updated="setBatteryBoost"
-		/>
-	</div>
+	</Teleport>
 </template>
 
 <script lang="ts">
@@ -143,6 +289,7 @@ export default defineComponent({
 		VehicleIcon,
 	},
 	mixins: [formatter, collector],
+	inheritAttrs: false,
 	props: {
 		id: { type: String, required: true },
 		single: Boolean,
@@ -249,9 +396,14 @@ export default defineComponent({
 			pvRemainingInterpolated: this.pvRemaining,
 			chargeDurationInterpolated: this.chargeDuration,
 			chargeRemainingDurationInterpolated: this.chargeRemainingDuration,
+			loadpointViewportMaximized: false,
+			bodyOverflowBefore: null as string | null,
 		};
 	},
 	computed: {
+		loadpointRootAttrs() {
+			return this.$attrs;
+		},
 		expandLoadpointHeader() {
 			return this.multipleLoadpoints && !this.fullWidth;
 		},
@@ -327,6 +479,9 @@ export default defineComponent({
 		plannerForecast() {
 			return this.forecast?.planner;
 		},
+		shouldMaximizeFromRoute(): boolean {
+			return this.$route?.query?.maximize === this.id;
+		},
 	},
 	watch: {
 		phaseRemaining() {
@@ -341,13 +496,35 @@ export default defineComponent({
 		chargeRemainingDuration() {
 			this.chargeRemainingDurationInterpolated = this.chargeRemainingDuration;
 		},
+		loadpointViewportMaximized(expanded: boolean) {
+			if (expanded) {
+				this.bodyOverflowBefore = document.body.style.overflow;
+				document.body.style.overflow = "hidden";
+			} else {
+				document.body.style.overflow = this.bodyOverflowBefore ?? "";
+				this.bodyOverflowBefore = null;
+			}
+		},
+		shouldMaximizeFromRoute: {
+			handler(shouldMaximize: boolean) {
+				if (shouldMaximize && !this.loadpointViewportMaximized) {
+					this.loadpointViewportMaximized = true;
+				}
+			},
+			immediate: true,
+		},
 	},
 	mounted() {
 		this.tickerHandler = setInterval(this.tick, 1000);
+		window.addEventListener("keydown", this.handleViewportEscape);
 	},
 	unmounted() {
 		if (this.tickerHandler) {
 			clearInterval(this.tickerHandler);
+		}
+		window.removeEventListener("keydown", this.handleViewportEscape);
+		if (this.loadpointViewportMaximized) {
+			document.body.style.overflow = this.bodyOverflowBefore ?? "";
 		}
 	},
 	methods: {
@@ -410,6 +587,26 @@ export default defineComponent({
 			);
 			modal.show();
 		},
+		expandViewport() {
+			this.loadpointViewportMaximized = true;
+			const query = { ...this.$route.query, maximize: this.id };
+			this.$router.replace({ query });
+		},
+		collapseViewport() {
+			this.loadpointViewportMaximized = false;
+			const query = { ...this.$route.query };
+			delete query.maximize;
+			this.$router.replace({ query });
+		},
+		handleViewportEscape(ev: KeyboardEvent) {
+			if (ev.key !== "Escape" || !this.loadpointViewportMaximized) {
+				return;
+			}
+			if (document.querySelector(".modal.show")) {
+				return;
+			}
+			this.collapseViewport();
+		},
 	},
 });
 </script>
@@ -417,10 +614,44 @@ export default defineComponent({
 <style scoped>
 @import "../../../css/breakpoints.css";
 
+.loadpoint-inline-host {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
+.loadpoint-viewport-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 1030;
+	display: flex;
+	flex-direction: column;
+	min-height: 100dvh;
+	min-height: 100vh;
+	background: var(--evcc-background);
+	overflow: hidden;
+}
+
 .loadpoint {
 	border-radius: 2rem;
 	color: var(--evcc-default-text);
 	background: var(--evcc-box);
+}
+
+.loadpoint--viewport-expanded {
+	min-height: 0;
+	flex: 1 1 auto;
+	overflow: auto;
+}
+
+.loadpoint-header-wide__title {
+	flex: 1 1 8rem;
+	min-width: 0;
+}
+
+.loadpoint-expand-icon {
+	display: block;
 }
 
 .details > div {

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -139,7 +139,7 @@
 				</div>
 				<hr class="divider" />
 				<Vehicle
-					class="flex-grow-1 d-flex flex-column justify-content-end"
+					class="flex-grow-1 d-flex flex-column"
 					v-bind="vehicleProps"
 					@limit-soc-updated="setLimitSoc"
 					@limit-energy-updated="setLimitEnergy"
@@ -150,7 +150,22 @@
 				/>
 			</div>
 		</div>
+<<<<<<< HEAD
 	</Teleport>
+=======
+		<hr class="divider" />
+		<Vehicle
+			class="flex-grow-1 d-flex flex-column"
+			v-bind="vehicleProps"
+			@limit-soc-updated="setLimitSoc"
+			@limit-energy-updated="setLimitEnergy"
+			@change-vehicle="changeVehicle"
+			@remove-vehicle="removeVehicle"
+			@open-loadpoint-settings="openSettingsModal"
+			@batteryboost-updated="setBatteryBoost"
+		/>
+	</div>
+>>>>>>> d0ca0bd70 (fix(ui): restore loadpoint spacing and scrolling behavior)
 </template>
 
 <script lang="ts">

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -2,7 +2,9 @@
 	<Teleport to="body" :disabled="!loadpointViewportMaximized">
 		<div
 			:class="
-				loadpointViewportMaximized ? 'loadpoint-viewport-overlay safe-area-inset' : 'loadpoint-inline-host'
+				loadpointViewportMaximized
+					? 'loadpoint-viewport-overlay safe-area-inset'
+					: 'loadpoint-inline-host'
 			"
 		>
 			<div
@@ -43,7 +45,9 @@
 					<Mode v-bind="modeProps" @updated="setTargetMode" />
 				</div>
 				<!-- sm+: title, expand/collapse, mode, settings in one row -->
-				<div class="d-none d-sm-flex align-items-center gap-2 mb-3 flex-wrap loadpoint-header-wide">
+				<div
+					class="d-none d-sm-flex align-items-center gap-2 mb-3 flex-wrap loadpoint-header-wide"
+				>
 					<h3 class="mb-0 text-truncate d-flex min-w-0 loadpoint-header-wide__title">
 						<VehicleIcon
 							v-if="chargerIcon"

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -150,22 +150,7 @@
 				/>
 			</div>
 		</div>
-<<<<<<< HEAD
 	</Teleport>
-=======
-		<hr class="divider" />
-		<Vehicle
-			class="flex-grow-1 d-flex flex-column"
-			v-bind="vehicleProps"
-			@limit-soc-updated="setLimitSoc"
-			@limit-energy-updated="setLimitEnergy"
-			@change-vehicle="changeVehicle"
-			@remove-vehicle="removeVehicle"
-			@open-loadpoint-settings="openSettingsModal"
-			@batteryboost-updated="setBatteryBoost"
-		/>
-	</div>
->>>>>>> d0ca0bd70 (fix(ui): restore loadpoint spacing and scrolling behavior)
 </template>
 
 <script lang="ts">

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -14,34 +14,6 @@
 						: 'mx-2 mx-sm-0',
 				]"
 			>
-				<!-- sm+: title, expand/collapse, mode, settings in one row -->
-				<div class="d-none d-sm-flex align-items-center gap-2 mb-3 flex-wrap loadpoint-header-wide">
-					<h3 class="mb-0 text-truncate d-flex min-w-0 loadpoint-header-wide__title">
-						<VehicleIcon
-							v-if="chargerIcon"
-							:name="chargerIcon"
-							class="me-2 flex-shrink-0"
-						/>
-						<div class="text-truncate">
-							{{ loadpointTitle }}
-						</div>
-					</h3>
-					<ViewportToggleButton
-						:expanded="loadpointViewportMaximized"
-						@toggle="toggleViewport"
-					/>
-					<Mode
-						class="loadpoint-header-wide__mode flex-shrink-0"
-						v-bind="modeProps"
-						@updated="setTargetMode"
-					/>
-					<LoadpointSettingsButton
-						:id="id"
-						:class="expandLoadpointHeader ? 'd-lg-none d-xl-block' : ''"
-						class="flex-shrink-0"
-						@click="openSettingsModal"
-					/>
-				</div>
 				<!-- xs: stacked -->
 				<div class="d-flex d-sm-none flex-column mb-3">
 					<div class="d-flex justify-content-between align-items-center gap-2 mb-3">
@@ -69,6 +41,34 @@
 						/>
 					</div>
 					<Mode v-bind="modeProps" @updated="setTargetMode" />
+				</div>
+				<!-- sm+: title, expand/collapse, mode, settings in one row -->
+				<div class="d-none d-sm-flex align-items-center gap-2 mb-3 flex-wrap loadpoint-header-wide">
+					<h3 class="mb-0 text-truncate d-flex min-w-0 loadpoint-header-wide__title">
+						<VehicleIcon
+							v-if="chargerIcon"
+							:name="chargerIcon"
+							class="me-2 flex-shrink-0"
+						/>
+						<div class="text-truncate">
+							{{ loadpointTitle }}
+						</div>
+					</h3>
+					<ViewportToggleButton
+						:expanded="loadpointViewportMaximized"
+						@toggle="toggleViewport"
+					/>
+					<Mode
+						class="loadpoint-header-wide__mode flex-shrink-0"
+						v-bind="modeProps"
+						@updated="setTargetMode"
+					/>
+					<LoadpointSettingsButton
+						:id="id"
+						:class="expandLoadpointHeader ? 'd-lg-none d-xl-block' : ''"
+						class="flex-shrink-0"
+						@click="openSettingsModal"
+					/>
 				</div>
 				<LoadpointSettingsModal
 					:id="id"
@@ -176,6 +176,10 @@ const maximizedLoadpointIds = new Set<string>();
 let previousBodyOverflow: string | null = null;
 
 const setBodyScrollLock = (id: string, expanded: boolean) => {
+	if (typeof document === "undefined") {
+		return;
+	}
+
 	if (expanded) {
 		if (maximizedLoadpointIds.size === 0) {
 			previousBodyOverflow = document.body.style.overflow;
@@ -516,7 +520,11 @@ export default defineComponent({
 			this.$router.replace({ query });
 		},
 		handleViewportEscape(ev: KeyboardEvent) {
-			if (ev.key !== "Escape" || !this.loadpointViewportMaximized) {
+			if (ev.defaultPrevented || ev.key !== "Escape" || !this.loadpointViewportMaximized) {
+				return;
+			}
+			const target = ev.target as HTMLElement | null;
+			if (target?.closest("input, textarea, select, [contenteditable='true']")) {
 				return;
 			}
 			if (document.querySelector(".modal.show")) {
@@ -565,10 +573,6 @@ export default defineComponent({
 .loadpoint-header-wide__title {
 	flex: 1 1 8rem;
 	min-width: 0;
-}
-
-.loadpoint-expand-icon {
-	display: block;
 }
 
 .details > div {

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -20,7 +20,10 @@
 				<div class="d-flex d-sm-none flex-column mb-3">
 					<div class="d-flex justify-content-between align-items-center gap-2 mb-3">
 						<div class="d-flex align-items-center gap-2 min-w-0 flex-grow-1">
-							<h3 class="mb-0 text-truncate d-flex min-w-0 flex-grow-1">
+							<h3
+								v-if="!isDesktopBreakpoint"
+								class="mb-0 text-truncate d-flex min-w-0 flex-grow-1"
+							>
 								<VehicleIcon
 									v-if="chargerIcon"
 									:name="chargerIcon"
@@ -42,13 +45,20 @@
 							@click="openSettingsModal"
 						/>
 					</div>
-					<Mode v-bind="modeProps" @updated="setTargetMode" />
+					<Mode
+						v-if="!isDesktopBreakpoint"
+						v-bind="modeProps"
+						@updated="setTargetMode"
+					/>
 				</div>
 				<!-- sm+: title, expand/collapse, mode, settings in one row -->
 				<div
 					class="d-none d-sm-flex align-items-center gap-2 mb-3 flex-wrap loadpoint-header-wide"
 				>
-					<h3 class="mb-0 text-truncate d-flex min-w-0 loadpoint-header-wide__title">
+					<h3
+						v-if="isDesktopBreakpoint"
+						class="mb-0 text-truncate d-flex min-w-0 loadpoint-header-wide__title"
+					>
 						<VehicleIcon
 							v-if="chargerIcon"
 							:name="chargerIcon"
@@ -63,6 +73,7 @@
 						@toggle="toggleViewport"
 					/>
 					<Mode
+						v-if="isDesktopBreakpoint"
 						class="loadpoint-header-wide__mode flex-shrink-0"
 						v-bind="modeProps"
 						@updated="setTargetMode"
@@ -322,6 +333,7 @@ export default defineComponent({
 			chargeDurationInterpolated: this.chargeDuration,
 			chargeRemainingDurationInterpolated: this.chargeRemainingDuration,
 			loadpointViewportMaximized: false,
+			isDesktopBreakpoint: true,
 		};
 	},
 	computed: {
@@ -434,12 +446,15 @@ export default defineComponent({
 	},
 	mounted() {
 		this.tickerHandler = setInterval(this.tick, 1000);
+		this.updateBreakpointFlags();
+		window.addEventListener("resize", this.updateBreakpointFlags);
 		window.addEventListener("keydown", this.handleViewportEscape);
 	},
 	unmounted() {
 		if (this.tickerHandler) {
 			clearInterval(this.tickerHandler);
 		}
+		window.removeEventListener("resize", this.updateBreakpointFlags);
 		window.removeEventListener("keydown", this.handleViewportEscape);
 		if (this.loadpointViewportMaximized) {
 			setBodyScrollLock(this.id, false);
@@ -511,6 +526,12 @@ export default defineComponent({
 				return;
 			}
 			this.expandViewport();
+		},
+		updateBreakpointFlags() {
+			if (typeof window === "undefined") {
+				return;
+			}
+			this.isDesktopBreakpoint = window.innerWidth >= 576;
 		},
 		expandViewport() {
 			this.loadpointViewportMaximized = true;

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -26,62 +26,10 @@
 							{{ loadpointTitle }}
 						</div>
 					</h3>
-					<button
-						type="button"
-						class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
-						:aria-label="
-							loadpointViewportMaximized
-								? $t('main.loadpoint.backToOverview')
-								: $t('main.loadpoint.expandViewport')
-						"
-						:data-testid="
-							loadpointViewportMaximized
-								? 'loadpoint-viewport-back'
-								: 'loadpoint-viewport-expand'
-						"
-						@click.stop="
-							loadpointViewportMaximized ? collapseViewport() : expandViewport()
-						"
-					>
-						<svg
-							v-if="loadpointViewportMaximized"
-							class="loadpoint-expand-icon"
-							width="18"
-							height="18"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-							focusable="false"
-						>
-							<path d="M4 14h6v6" />
-							<path d="M20 10h-6V4" />
-							<path d="M14 10l7-7" />
-							<path d="M3 21l7-7" />
-						</svg>
-						<svg
-							v-else
-							class="loadpoint-expand-icon"
-							width="18"
-							height="18"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-							focusable="false"
-						>
-							<path d="M8 3H5a2 2 0 0 0-2 2v3" />
-							<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
-							<path d="M3 16v3a2 2 0 0 0 2 2h3" />
-							<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
-						</svg>
-					</button>
+					<ViewportToggleButton
+						:expanded="loadpointViewportMaximized"
+						@toggle="toggleViewport"
+					/>
 					<Mode
 						class="loadpoint-header-wide__mode flex-shrink-0"
 						v-bind="modeProps"
@@ -108,64 +56,11 @@
 									{{ loadpointTitle }}
 								</div>
 							</h3>
-							<button
-								type="button"
-								class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
-								:aria-label="
-									loadpointViewportMaximized
-										? $t('main.loadpoint.backToOverview')
-										: $t('main.loadpoint.expandViewport')
-								"
-								:data-testid="
-									loadpointViewportMaximized
-										? 'loadpoint-viewport-back-xs'
-										: 'loadpoint-viewport-expand-xs'
-								"
-								@click.stop="
-									loadpointViewportMaximized
-										? collapseViewport()
-										: expandViewport()
-								"
-							>
-								<svg
-									v-if="loadpointViewportMaximized"
-									class="loadpoint-expand-icon"
-									width="18"
-									height="18"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									aria-hidden="true"
-									focusable="false"
-								>
-									<path d="M4 14h6v6" />
-									<path d="M20 10h-6V4" />
-									<path d="M14 10l7-7" />
-									<path d="M3 21l7-7" />
-								</svg>
-								<svg
-									v-else
-									class="loadpoint-expand-icon"
-									width="18"
-									height="18"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									aria-hidden="true"
-									focusable="false"
-								>
-									<path d="M8 3H5a2 2 0 0 0-2 2v3" />
-									<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
-									<path d="M3 16v3a2 2 0 0 0 2 2h3" />
-									<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
-								</svg>
-							</button>
+							<ViewportToggleButton
+								:expanded="loadpointViewportMaximized"
+								:mobile="true"
+								@toggle="toggleViewport"
+							/>
 						</div>
 						<LoadpointSettingsButton
 							:class="expandLoadpointHeader ? 'd-lg-block d-xl-none' : ''"
@@ -261,6 +156,7 @@ import SettingsButton from "./SettingsButton.vue";
 import SettingsModal from "./SettingsModal.vue";
 import VehicleIcon from "../VehicleIcon";
 import SessionInfo from "./SessionInfo.vue";
+import ViewportToggleButton from "./ViewportToggleButton.vue";
 import Modal from "bootstrap/js/dist/modal";
 import { defineComponent, type PropType } from "vue";
 import type {
@@ -276,6 +172,26 @@ import type {
 } from "@/types/evcc";
 import type { PlanStrategy } from "@/components/ChargingPlans/types";
 
+const maximizedLoadpointIds = new Set<string>();
+let previousBodyOverflow: string | null = null;
+
+const setBodyScrollLock = (id: string, expanded: boolean) => {
+	if (expanded) {
+		if (maximizedLoadpointIds.size === 0) {
+			previousBodyOverflow = document.body.style.overflow;
+			document.body.style.overflow = "hidden";
+		}
+		maximizedLoadpointIds.add(id);
+		return;
+	}
+
+	maximizedLoadpointIds.delete(id);
+	if (maximizedLoadpointIds.size === 0) {
+		document.body.style.overflow = previousBodyOverflow ?? "";
+		previousBodyOverflow = null;
+	}
+};
+
 export default defineComponent({
 	name: "Loadpoint",
 	components: {
@@ -287,6 +203,7 @@ export default defineComponent({
 		LoadpointSettingsModal: SettingsModal,
 		LoadpointSessionInfo: SessionInfo,
 		VehicleIcon,
+		ViewportToggleButton,
 	},
 	mixins: [formatter, collector],
 	inheritAttrs: false,
@@ -397,7 +314,6 @@ export default defineComponent({
 			chargeDurationInterpolated: this.chargeDuration,
 			chargeRemainingDurationInterpolated: this.chargeRemainingDuration,
 			loadpointViewportMaximized: false,
-			bodyOverflowBefore: null as string | null,
 		};
 	},
 	computed: {
@@ -497,18 +413,12 @@ export default defineComponent({
 			this.chargeRemainingDurationInterpolated = this.chargeRemainingDuration;
 		},
 		loadpointViewportMaximized(expanded: boolean) {
-			if (expanded) {
-				this.bodyOverflowBefore = document.body.style.overflow;
-				document.body.style.overflow = "hidden";
-			} else {
-				document.body.style.overflow = this.bodyOverflowBefore ?? "";
-				this.bodyOverflowBefore = null;
-			}
+			setBodyScrollLock(this.id, expanded);
 		},
 		shouldMaximizeFromRoute: {
 			handler(shouldMaximize: boolean) {
-				if (shouldMaximize && !this.loadpointViewportMaximized) {
-					this.loadpointViewportMaximized = true;
+				if (this.loadpointViewportMaximized !== shouldMaximize) {
+					this.loadpointViewportMaximized = shouldMaximize;
 				}
 			},
 			immediate: true,
@@ -524,7 +434,7 @@ export default defineComponent({
 		}
 		window.removeEventListener("keydown", this.handleViewportEscape);
 		if (this.loadpointViewportMaximized) {
-			document.body.style.overflow = this.bodyOverflowBefore ?? "";
+			setBodyScrollLock(this.id, false);
 		}
 	},
 	methods: {
@@ -586,6 +496,13 @@ export default defineComponent({
 				document.getElementById(`loadpointSettingsModal_${this.id}`) as HTMLElement
 			);
 			modal.show();
+		},
+		toggleViewport() {
+			if (this.loadpointViewportMaximized) {
+				this.collapseViewport();
+				return;
+			}
+			this.expandViewport();
 		},
 		expandViewport() {
 			this.loadpointViewportMaximized = true;

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -396,7 +396,7 @@ export default defineComponent({
 			return this.forecast?.planner;
 		},
 		shouldMaximizeFromRoute(): boolean {
-			return this.$route?.query?.maximize === this.id;
+			return this.$route?.query?.["maximize"] === this.id;
 		},
 	},
 	watch: {
@@ -512,7 +512,7 @@ export default defineComponent({
 		collapseViewport() {
 			this.loadpointViewportMaximized = false;
 			const query = { ...this.$route.query };
-			delete query.maximize;
+			delete query["maximize"];
 			this.$router.replace({ query });
 		},
 		handleViewportEscape(ev: KeyboardEvent) {

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -45,11 +45,7 @@
 							@click="openSettingsModal"
 						/>
 					</div>
-					<Mode
-						v-if="!isDesktopBreakpoint"
-						v-bind="modeProps"
-						@updated="setTargetMode"
-					/>
+					<Mode v-if="!isDesktopBreakpoint" v-bind="modeProps" @updated="setTargetMode" />
 				</div>
 				<!-- sm+: title, expand/collapse, mode, settings in one row -->
 				<div

--- a/assets/js/components/Loadpoints/Loadpoints.vue
+++ b/assets/js/components/Loadpoints/Loadpoints.vue
@@ -1,8 +1,5 @@
 <template>
-	<div
-		class="container container--loadpoint px-0 mb-md-2 d-flex flex-column justify-content-center"
-		data-testid="loadpoints"
-	>
+	<div class="container container--loadpoint px-0 mb-md-2 d-flex flex-column" data-testid="loadpoints">
 		<div
 			v-if="loadpoints.length > 0"
 			ref="carousel"
@@ -96,6 +93,7 @@ export default defineComponent({
 			scrollTimeout: null as Timeout,
 			highlightedIndex: 0,
 			viewportHeight: 0 as number,
+			viewportWidth: 0 as number,
 		};
 	},
 	computed: {
@@ -106,11 +104,15 @@ export default defineComponent({
 			return this.loadpoints.length > 1;
 		},
 		fullWidth() {
+			if (this.viewportWidth < 992) {
+				return false;
+			}
+			const landscape = this.viewportWidth > this.viewportHeight;
 			return (
-				// breakpoint lg, tall screen, 2 loadpoints rows
-				(this.loadpoints.length === 2 && this.viewportHeight >= 1450) ||
-				// breakpoint lg, taller screen, 3 loadpoints rows
-				(this.loadpoints.length === 3 && this.viewportHeight >= 1900)
+				// desktop breakpoint, 2 loadpoints rows
+				(this.loadpoints.length === 2 && this.viewportHeight >= (landscape ? 1050 : 1450)) ||
+				// desktop breakpoint, 3 loadpoints rows
+				(this.loadpoints.length === 3 && this.viewportHeight >= (landscape ? 1500 : 1900))
 			);
 		},
 	},
@@ -165,6 +167,7 @@ export default defineComponent({
 		},
 		updateViewport() {
 			this.viewportHeight = window.innerHeight;
+			this.viewportWidth = window.innerWidth;
 		},
 		left(index: number) {
 			return (this.$refs["carousel"]?.children[0] as HTMLElement).offsetWidth * index;
@@ -194,6 +197,7 @@ export default defineComponent({
 
 .container--loadpoint:not(:empty) {
 	min-height: 300px;
+	overflow-x: clip;
 }
 
 @media (max-width: 991.98px) {
@@ -243,10 +247,10 @@ export default defineComponent({
 		max-width: none;
 	}
 	.carousel > *:first-child {
-		margin-left: calc((100vw - var(--slide-width)) / 2);
+		margin-left: max(0px, calc((100% - var(--slide-width)) / 2));
 	}
 	.carousel > *:last-child {
-		margin-right: calc((100vw - var(--slide-width)) / 2);
+		margin-right: max(0px, calc((100% - var(--slide-width)) / 2));
 	}
 	/* fixes safari issue with end-side padding https://webplatform.news/issues/2019-08-07 */
 	.carousel::after {
@@ -276,12 +280,13 @@ export default defineComponent({
 @media (--lg-and-up) {
 	.carousel {
 		display: grid !important;
-		grid-gap: 2rem;
+		column-gap: clamp(1.25rem, 1.8vw, 2rem);
+		row-gap: clamp(1.5rem, 2.2vw, 2.25rem);
 		grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
 	}
 	/* breakpoint lg, full width override */
 	.carousel--fullwidth {
-		grid-gap: 4rem;
+		row-gap: clamp(2.25rem, 4vw, 3.5rem);
 		grid-template-columns: 1fr;
 	}
 }

--- a/assets/js/components/Loadpoints/Loadpoints.vue
+++ b/assets/js/components/Loadpoints/Loadpoints.vue
@@ -280,9 +280,9 @@ export default defineComponent({
 @media (--lg-and-up) {
 	.carousel {
 		display: grid !important;
-		column-gap: clamp(1.25rem, 1.8vw, 2rem);
+		column-gap: clamp(1.75rem, 2.2vw, 2.5rem);
 		row-gap: clamp(1.5rem, 2.2vw, 2.25rem);
-		grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(520px, 1fr));
 	}
 	/* breakpoint lg, full width override */
 	.carousel--fullwidth {

--- a/assets/js/components/Loadpoints/Loadpoints.vue
+++ b/assets/js/components/Loadpoints/Loadpoints.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="container container--loadpoint px-0 mb-md-2 d-flex flex-column" data-testid="loadpoints">
+	<div
+		class="container container--loadpoint px-0 mb-md-2 d-flex flex-column justify-content-center"
+		data-testid="loadpoints"
+	>
 		<div
 			v-if="loadpoints.length > 0"
 			ref="carousel"
@@ -197,7 +200,6 @@ export default defineComponent({
 
 .container--loadpoint:not(:empty) {
 	min-height: 300px;
-	overflow-x: clip;
 }
 
 @media (max-width: 991.98px) {
@@ -241,31 +243,16 @@ export default defineComponent({
 	}
 }
 
-/* keep stacked cards on narrow desktop/laptop viewports */
-@media (max-width: 991.98px) and (hover: hover) and (pointer: fine) {
-	.carousel {
-		display: block;
-		overflow-x: visible;
-		scroll-snap-type: none;
-	}
-	.carousel > * {
-		min-width: 0;
-	}
-	.indicator {
-		display: none !important;
-	}
-}
-
 /* show truncated tiles on breakpoint sm,md */
 @media (min-width: 576px) and (max-width: 991.98px) {
 	.container--loadpoint {
 		max-width: none;
 	}
 	.carousel > *:first-child {
-		margin-left: max(0px, calc((100% - var(--slide-width)) / 2));
+		margin-left: calc((100vw - var(--slide-width)) / 2);
 	}
 	.carousel > *:last-child {
-		margin-right: max(0px, calc((100% - var(--slide-width)) / 2));
+		margin-right: calc((100vw - var(--slide-width)) / 2);
 	}
 	/* fixes safari issue with end-side padding https://webplatform.news/issues/2019-08-07 */
 	.carousel::after {
@@ -295,13 +282,12 @@ export default defineComponent({
 @media (--lg-and-up) {
 	.carousel {
 		display: grid !important;
-		column-gap: clamp(1.75rem, 2.2vw, 2.5rem);
-		row-gap: clamp(1.5rem, 2.2vw, 2.25rem);
-		grid-template-columns: repeat(auto-fit, minmax(520px, 1fr));
+		grid-gap: 2rem;
+		grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
 	}
 	/* breakpoint lg, full width override */
 	.carousel--fullwidth {
-		row-gap: clamp(2.25rem, 4vw, 3.5rem);
+		grid-gap: 4rem;
 		grid-template-columns: 1fr;
 	}
 }

--- a/assets/js/components/Loadpoints/Loadpoints.vue
+++ b/assets/js/components/Loadpoints/Loadpoints.vue
@@ -241,6 +241,21 @@ export default defineComponent({
 	}
 }
 
+/* keep stacked cards on narrow desktop/laptop viewports */
+@media (max-width: 991.98px) and (hover: hover) and (pointer: fine) {
+	.carousel {
+		display: block;
+		overflow-x: visible;
+		scroll-snap-type: none;
+	}
+	.carousel > * {
+		min-width: 0;
+	}
+	.indicator {
+		display: none !important;
+	}
+}
+
 /* show truncated tiles on breakpoint sm,md */
 @media (min-width: 576px) and (max-width: 991.98px) {
 	.container--loadpoint {

--- a/assets/js/components/Loadpoints/ViewportToggleButton.vue
+++ b/assets/js/components/Loadpoints/ViewportToggleButton.vue
@@ -1,0 +1,71 @@
+<template>
+	<button
+		type="button"
+		class="btn btn-sm btn-outline-secondary border-0 p-2 evcc-gray flex-shrink-0 loadpoint-expand-btn"
+		:aria-label="
+			expanded ? $t('main.loadpoint.backToOverview') : $t('main.loadpoint.expandViewport')
+		"
+		:data-testid="
+			expanded
+				? mobile
+					? 'loadpoint-viewport-back-xs'
+					: 'loadpoint-viewport-back'
+				: mobile
+					? 'loadpoint-viewport-expand-xs'
+					: 'loadpoint-viewport-expand'
+		"
+		@click.stop="$emit('toggle')"
+	>
+		<svg
+			v-if="expanded"
+			class="loadpoint-expand-icon"
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path d="M4 14h6v6" />
+			<path d="M20 10h-6V4" />
+			<path d="M14 10l7-7" />
+			<path d="M3 21l7-7" />
+		</svg>
+		<svg
+			v-else
+			class="loadpoint-expand-icon"
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path d="M8 3H5a2 2 0 0 0-2 2v3" />
+			<path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+			<path d="M3 16v3a2 2 0 0 0 2 2h3" />
+			<path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+		</svg>
+	</button>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+	name: "ViewportToggleButton",
+	props: {
+		expanded: Boolean,
+		mobile: Boolean,
+	},
+	emits: ["toggle"],
+});
+</script>

--- a/assets/js/components/Loadpoints/ViewportToggleButton.vue
+++ b/assets/js/components/Loadpoints/ViewportToggleButton.vue
@@ -69,3 +69,9 @@ export default defineComponent({
 	emits: ["toggle"],
 });
 </script>
+
+<style scoped>
+.loadpoint-expand-icon {
+	display: block;
+}
+</style>

--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -240,6 +240,7 @@ export default defineComponent({
 }
 .content-area {
 	flex-grow: 1;
+	min-height: 0;
 	z-index: 1;
 }
 .configure-button:not(:active):not(:hover),

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1105,10 +1105,12 @@
     },
     "loadpoint": {
       "avgPrice": "⌀ Preis",
+      "backToOverview": "Zurück zur Übersicht",
       "charged": "Geladen",
       "co2": "⌀ CO₂",
       "duration": "Ladedauer",
       "emission": "Emission",
+      "expandViewport": "Vollansicht",
       "fallbackName": "Ladepunkt",
       "finished": "Ladeende",
       "power": "Leistung",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1105,10 +1105,12 @@
     },
     "loadpoint": {
       "avgPrice": "⌀ Price",
+      "backToOverview": "Back to overview",
       "charged": "Charged",
       "co2": "⌀ CO₂",
       "duration": "Duration",
       "emission": "Emission",
+      "expandViewport": "Expand to full view",
       "fallbackName": "Charging point",
       "finished": "Finish time",
       "power": "Power",


### PR DESCRIPTION
Allow users to expand a single loadpoint to fill the entire viewport via a toggle button next to the loadpoint title. The expanded state is reflected in the URL as ?maximize=, enabling direct deep-links to a maximized loadpoint (e.g. for evcc running on a modified openWB or a wall-mounted tablets).

Especially useful together with: https://github.com/evcc-io/evcc/pull/28507

- Teleport pattern moves the loadpoint to when expanded
- Expand/collapse SVG icon toggles in-place beside the title
- Escape key dismisses the expanded view (respects open modals)
- Body scroll is locked while expanded
- i18n strings added for en and de