### PR TITLE
OCPP: warn when charger reports non-compliant meter type

### DIFF
--- a/charger/ocpp/const.go
+++ b/charger/ocpp/const.go
@@ -4,6 +4,11 @@ import "time"
 
 var Timeout = time.Minute // default request / response timeout on protocol level
 
+// triggerBootDelay defines how long to wait after WebSocket connect before
+// proactively triggering a BootNotification. This allows the connection to
+// stabilize and gives the charger a chance to send a spontaneous BootNotification.
+const triggerBootDelay = 5 * time.Second
+
 const (
 	// Core profile keys
 	KeyMeterValueSampleInterval        = "MeterValueSampleInterval"

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
@@ -142,12 +143,51 @@ func (cp *CP) connect(connect bool) {
 // onTransportConnect is called when the WebSocket connection is established.
 // Instead of marking the CP as connected immediately, it waits for the
 // BootNotification handshake to complete (or a timeout to expire).
+//
+// Some chargers (e.g. Wallbox Pulsar Pro FW 6.x) do not send BootNotification
+// spontaneously on connect. For these chargers, we proactively trigger it
+// after a short delay, which typically yields a response within 1 second
+// instead of waiting for the full timeout.
 func (cp *CP) onTransportConnect() {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 
 	cp.stopBootTimer()
 	cp.bootTimer = time.AfterFunc(Timeout, cp.onBootTimeout)
+
+	// Proactively trigger BootNotification after a short delay.
+	// This helps chargers that don't send it spontaneously (e.g. Wallbox FW 6.x).
+	// The TriggerMessage is sent directly via the OCPP instance, bypassing the
+	// Connected() check which would fail at this point.
+	id := cp.id
+	go func() {
+		time.Sleep(triggerBootDelay)
+
+		cp.mu.RLock()
+		// If BootNotification already arrived or timer was cancelled (disconnect),
+		// there is nothing to do.
+		if cp.bootTimer == nil || cp.BootNotificationResult != nil {
+			cp.mu.RUnlock()
+			return
+		}
+		cp.mu.RUnlock()
+
+		cp.log.DEBUG.Printf("proactively triggering BootNotification")
+
+		err := Instance().TriggerMessage(
+			id,
+			func(conf *remotetrigger.TriggerMessageConfirmation, err error) {
+				if err != nil {
+					cp.log.DEBUG.Printf("trigger BootNotification response error: %v", err)
+				}
+			},
+			core.BootNotificationFeatureName,
+			func(request *remotetrigger.TriggerMessageRequest) {},
+		)
+		if err != nil {
+			cp.log.DEBUG.Printf("failed to trigger BootNotification: %v", err)
+		}
+	}()
 }
 
 // onBootTimeout is called when the BootNotification wait timer expires.

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -129,6 +129,15 @@ func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.
 		}
 	}
 
+	// warn about non-compliant meters (e.g. Wallbox Pulsar Pro FW 6.x)
+	cp.mu.RLock()
+	bootResult := cp.BootNotificationResult
+	cp.mu.RUnlock()
+
+	if bootResult != nil && strings.Contains(strings.ToLower(bootResult.MeterType), "non compliant") {
+		cp.log.WARN.Printf("charger reports non-compliant meter (%s), meter values will not be available via OCPP - consider adding an external meter", bootResult.MeterType)
+	}
+
 	// autodetect measurands
 	if meterValues == "" && meterValuesSampledDataMaxLength > 0 {
 		sampledMeasurands := cp.tryMeasurands(desiredMeasurands, KeyMeterValuesSampledData)


### PR DESCRIPTION
## Summary

Log a warning when a charger's BootNotification declares a non-compliant meter type, advising the user to add an external meter.

## Problem

Wallbox Pulsar Pro FW 6.x reports `meterType: "Internal NON compliant"` in BootNotification. The charger accepts all MeterValues configuration (`ChangeConfiguration` returns `Accepted`) but never sends actual MeterValues data. This causes repeated `meter timeout` and `charge power: timeout` errors in the log without any explanation of why.

## Solution

After BootNotification is received, check if `meterType` contains "non compliant". If so, log a warning:

```
charger reports non-compliant meter (Internal NON compliant), meter values will not be available via OCPP - consider adding an external meter
```

This gives the user immediate clarity on why meter data is missing and what to do about it.

## Testing

- All 15 existing OCPP tests pass
- Verified with Wallbox Pulsar Pro FW 6.11.16 OCPP capture (see #28539)

Related to #28539