### PR TITLE
Config UI: ensure cleanup when template switch

### DIFF
--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -483,7 +483,9 @@ export default defineComponent({
 			}
 
 			const isYamlInput = this.isYamlInputTypeByValue(newValue as ConfigType);
-			if (!isYamlInput) {
+			if (isYamlInput) {
+				this.template = null;
+			} else {
 				this.loadTemplate();
 			}
 

--- a/tests/config-ext-meter.spec.ts
+++ b/tests/config-ext-meter.spec.ts
@@ -104,9 +104,11 @@ test.describe("ext meter", async () => {
     await meterModal.getByRole("button", { name: "Add regular consumer" }).click();
 
     await meterModal.getByLabel("Title").fill("Custom ext meter");
-    await meterModal.getByLabel("Usage").selectOption("battery");
-    await meterModal.getByLabel("Manufacturer").selectOption("Demo battery");
-    await meterModal.getByLabel("Charge").fill("50");
+    await meterModal.getByLabel("Usage").selectOption("pv");
+
+    // switch to an in-beteen template to ensure we dont leak values
+    await meterModal.getByLabel("Manufacturer").selectOption("SunSpec Hybrid Inverter");
+    await expect(meterModal.getByLabel("IP address or hostname")).toBeVisible();
 
     await meterModal.getByLabel("Manufacturer").selectOption("User-defined device");
     await page.waitForLoadState("networkidle");


### PR DESCRIPTION
from Slack https://evccgroup.slack.com/archives/C01321PUJAD/p1774024127003499

fixes `invalid config: cannot mix yaml and other` error, when switching from a modbus-based template to custom.