### PR TITLE
Planner UI: remove step from time input

### DIFF
--- a/assets/js/components/ChargingPlans/PlanRepeatingSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanRepeatingSettings.vue
@@ -65,7 +65,6 @@
 					v-model="selectedTime"
 					type="time"
 					class="form-control mx-0 text-start"
-					:step="60 * 5"
 					data-testid="repeating-plan-time"
 					required
 					@change="update()"

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -67,7 +67,6 @@
 					v-model="selectedTime"
 					type="time"
 					class="form-control mx-0"
-					:step="60 * 5"
 					data-testid="static-plan-time"
 					required
 					@change="preview()"


### PR DESCRIPTION
adresses https://github.com/evcc-io/evcc/issues/28550

Remove the 5min step increment browser hint for time selection. None of the major browsers seems to do something useful with it any more. Defaults to 60s, which means minute-based time input - which is fine for this use case.