### PR TITLE
Loadpoint: publish upcoming session id

### DIFF
--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -302,6 +302,7 @@ export interface Loadpoint {
   pvRemaining: number;
   sessionCo2PerKWh: number | null;
   sessionEnergy: number;
+  sessionId: number | null;
   sessionPrice: number | null;
   sessionPricePerKWh: number | null;
   sessionSolarPercentage: number;

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -72,6 +72,7 @@ const (
 	ChargeTotalImport = "chargeTotalImport" // charge meter total import
 
 	// session
+	SessionId               = "sessionId"               // session id
 	ConnectedDuration       = "connectedDuration"       // connected duration
 	ChargeRemainingDuration = "chargeRemainingDuration" // charge remaining duration
 	ChargeRemainingEnergy   = "chargeRemainingEnergy"   // charge remaining energy

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -101,6 +101,7 @@ func (lp *Loadpoint) updateSession(opts ...sessionOption) {
 
 	if !lp.session.Created.IsZero() {
 		lp.db.Persist(lp.session)
+		lp.publish(keys.SessionId, lp.session.ID)
 	}
 }
 
@@ -112,6 +113,7 @@ func (lp *Loadpoint) clearSession() {
 	}
 
 	lp.session = nil
+	lp.publish(keys.SessionId, nil)
 }
 
 func (lp *Loadpoint) resetHeatingSession() {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/28586

Publishes the upcoming charging session id.

Note: `/api/sessions` only returns completed charging sessions. So the actual entry will become available when disconnecting the vehicle. Session id is created once first charging starts (not immediately at connect).