### PR TITLE
Fix EEBus UI config: save fails after successful validation

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -100,6 +100,12 @@ func NewEEBus(ctx context.Context, ski, ip string, hasMeter, hasChargedEnergy, v
 		return nil, err
 	}
 
+	// unregister device when context is cancelled (e.g. UI config validation)
+	go func() {
+		<-ctx.Done()
+		eebus.Instance.UnregisterDevice(ski, c)
+	}()
+
 	if hasMeter {
 		var energyG func() (float64, error)
 		if hasChargedEnergy {

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -99,6 +99,12 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 		return nil, err
 	}
 
+	// unregister device when context is cancelled (e.g. UI config validation)
+	go func() {
+		<-ctx.Done()
+		eebus.Instance.UnregisterDevice(ski, c)
+	}()
+
 	// monitoring appliance
 	eebus.LogEntities(c.log.DEBUG, "MA MPC", c.ma.MaMPCInterface)
 	eebus.LogEntities(c.log.DEBUG, "MA MGCP", c.ma.MaMGCPInterface)

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -236,13 +236,17 @@ func (c *EEBus) UnregisterDevice(ski string, device Device) {
 	ski = shiputil.NormalizeSKI(ski)
 	c.log.TRACE.Printf("unregistering ski: %s", ski)
 
-	c.service.UnregisterRemoteSKI(ski)
-
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
 	if idx := slices.Index(c.clients[ski], device); idx != -1 {
 		c.clients[ski] = slices.Delete(c.clients[ski], idx, idx+1)
+	}
+
+	// only tear down SHIP connection when no more clients need it
+	if len(c.clients[ski]) == 0 {
+		delete(c.clients, ski)
+		c.service.UnregisterRemoteSKI(ski)
 	}
 }
 


### PR DESCRIPTION
When adding an EEBus charger through the UI, both the validation ("prüfen") and save ("Speichere") steps call the same constructor which registers a device with the EEBus SHIP service and establishes a connection. After successful validation, this registration was never cleaned up. When save then creates a second instance for the same SKI, two SHIP connections compete, causing a connect/disconnect loop that prevents saving.

When validation fails, save works correctly because the constructor's error path already calls UnregisterDevice, leaving a clean state.

The fix has three parts:

1. charger/eebus.go: Store SKI on the EEBus struct and implement io.Closer to unregister the device on Close().

2. server/eebus/eebus.go: Fix UnregisterDevice to only tear down the SHIP connection (UnregisterRemoteSKI) when the last client for a SKI is removed. Previously it always tore down the connection, which would break other clients still using the same SKI.

3. server/http_config_device_handler.go: Close test instances after validation completes to release persistent connections.