### PR TITLE
Navigation: fix chrome blur

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -94,6 +94,7 @@
 
 	--tab-bar-height: 3rem;
 	--tab-bar-background: var(--evcc-background);
+	--evcc-backdrop-blur: blur(20px);
 }
 
 :root.dark {
@@ -392,8 +393,7 @@ a:hover {
 
 .modal-backdrop {
 	--bs-backdrop-bg: var(--evcc-backdrop);
-	-webkit-backdrop-filter: blur(8px);
-	backdrop-filter: blur(8px);
+	backdrop-filter: var(--evcc-backdrop-blur);
 }
 
 .modal-backdrop.fade {

--- a/assets/js/components/BottomTabs/Bar.vue
+++ b/assets/js/components/BottomTabs/Bar.vue
@@ -98,11 +98,10 @@ export default defineComponent({
 <style scoped>
 .bottom-tab-bar {
 	z-index: 1030;
-	background: color-mix(in srgb, var(--tab-bar-background) 80%, transparent);
-	backdrop-filter: blur(20px);
-	-webkit-backdrop-filter: blur(20px);
-	border-top: 1px solid var(--evcc-gray-10);
-	box-shadow: 0 -1px 6px rgba(0, 0, 0, 0.05);
+	background: color-mix(in srgb, var(--tab-bar-background) 60%, transparent);
+	backdrop-filter: var(--evcc-backdrop-blur);
+	border-top: 1px solid var(--evcc-gray-25);
+	box-shadow: 0 -1px 6px var(--evcc-gray-50);
 	transition: transform var(--evcc-transition-fast) ease-in;
 }
 

--- a/assets/js/components/BottomTabs/Bar.vue
+++ b/assets/js/components/BottomTabs/Bar.vue
@@ -101,7 +101,7 @@ export default defineComponent({
 	background: color-mix(in srgb, var(--tab-bar-background) 60%, transparent);
 	backdrop-filter: var(--evcc-backdrop-blur);
 	border-top: 1px solid var(--evcc-gray-25);
-	box-shadow: 0 -1px 6px var(--evcc-gray-50);
+	box-shadow: 0 -1px 6px var(--evcc-gray-25);
 	transition: transform var(--evcc-transition-fast) ease-in;
 }
 

--- a/assets/js/components/BottomTabs/MoreMenu.vue
+++ b/assets/js/components/BottomTabs/MoreMenu.vue
@@ -175,8 +175,7 @@ export default defineComponent({
 	inset: 0;
 	z-index: 1029;
 	background-color: var(--evcc-backdrop);
-	-webkit-backdrop-filter: blur(8px);
-	backdrop-filter: blur(8px);
+	backdrop-filter: var(--evcc-backdrop-blur);
 	opacity: 0;
 	visibility: hidden;
 	transition:

--- a/assets/js/views/Sessions.vue
+++ b/assets/js/views/Sessions.vue
@@ -748,8 +748,7 @@ export default defineComponent({
 	right: 0;
 	top: max(0rem, env(safe-area-inset-top)) !important;
 	margin: 0 calc(calc(1.5rem + var(--vertical-shift)) * -1);
-	-webkit-backdrop-filter: blur(35px);
-	backdrop-filter: blur(35px);
+	backdrop-filter: var(--evcc-backdrop-blur);
 	background-color: #0000;
 	box-shadow: 0 1px 8px 0px var(--evcc-background);
 }


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/28563

<img width="989" height="739" alt="Bildschirmfoto 2026-03-27 um 14 57 27" src="https://github.com/user-attachments/assets/c7f10523-67dd-44a7-84c9-ce059bef0a83" />


<img width="989" height="739" alt="Bildschirmfoto 2026-03-27 um 14 57 23" src="https://github.com/user-attachments/assets/0e39c16a-c478-4fb8-948c-78945802b967" />

Unprefixed `backdrop-filter` was dropped by css optimizer. Relying on lightingcss vendor prefixing now. Extracted blur values.

@VolkerK62 I've also increased the top border and shadow of the navigation. Especially in light mode, where same background color is used.




