### PR TITLE
Safari: fix scrollbar overlay issue

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -460,6 +460,11 @@ html:has(.modal.show) {
 	overflow-y: hidden;
 }
 
+/* Safari renders non-overlay scrollbars above modal backdrops at compositor level */
+body.modal-open .forecast-chart-scroll::-webkit-scrollbar {
+	opacity: 0;
+}
+
 .cursor-pointer {
 	cursor: pointer;
 }


### PR DESCRIPTION
Refs https://github.com/evcc-io/evcc/issues/28566

Working around a Safari bug where inline scrollbars are not drawn in layer order.