### PR TITLE
Docker: add healthcheck on port 7070

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,5 +97,12 @@ EXPOSE 8899/udp
 # SMA Energy Manager
 EXPOSE 9522/udp
 
+HEALTHCHECK \
+  --interval=30s \
+  --timeout=5s \
+  --start-period=30s \
+  --retries=3 \
+  CMD wget -qO /dev/null http://localhost:7070 || exit 1
+
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 CMD [ "evcc" ]


### PR DESCRIPTION
Without a HEALTHCHECK instruction, Docker and for example Home Assistant have no way to distinguish between a container that is running and one that is actually ready to serve traffic. This means:

Docker shows the container as "healthy" even if evcc has crashed or is stuck initialising
Automated restart policies trigger only on process exit, not on a hung-but-alive process

This change adds a minimal healthcheck that polls the existing UI/API port (7070) every 30 seconds using wget, which is already present in the Alpine base image — no extra dependencies needed. The 30-second start period prevents false negatives during initialisation phase.