### PR TITLE
fix: publish optimizer results as single MQTT message

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -33,6 +34,22 @@ var (
 	updated time.Time
 	mu      atomic.Uint32
 )
+
+// optimizerResult wraps the optimizer publish payload to implement BytesMarshaler.
+// This ensures publishComplex serializes it as a single JSON message instead of
+// recursively decomposing each struct field and array element into individual MQTT
+// topics (~1,500 messages per optimizer run).
+type optimizerResult struct {
+	Req     optimizer.OptimizationInput  `json:"req"`
+	Res     optimizer.OptimizationResult `json:"res"`
+	Details requestDetails               `json:"details"`
+}
+
+var _ api.BytesMarshaler = (*optimizerResult)(nil)
+
+func (r optimizerResult) MarshalBytes() ([]byte, error) {
+	return json.Marshal(r)
+}
 
 type batteryType string
 
@@ -243,11 +260,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 		return errors.New(string(resp.JSON200.Status))
 	}
 
-	site.publish("evopt", struct {
-		Req     optimizer.OptimizationInput  `json:"req"`
-		Res     optimizer.OptimizationResult `json:"res"`
-		Details requestDetails               `json:"details"`
-	}{
+	site.publish("evopt", optimizerResult{
 		Req:     req,
 		Res:     *resp.JSON200,
 		Details: details,


### PR DESCRIPTION
## Problem

The optimizer publishes its full `OptimizationInput` + `OptimizationResult` via `site.publish("evopt", ...)`, which `publishComplex()` recursively decomposes into individual MQTT topics — one per struct field and array element.

With 60 time slots and 2 batteries, a single optimizer run generates **~1,200–1,500 MQTT publishes** in a burst. This overflows the default message queue of common MQTT brokers (e.g., EMQX `max_mqueue_len` defaults to 1,000), causing the broker to **drop incoming messages** for the evcc client — including vehicle SOC updates from integrations like TeslaMate.

In my case, this caused EVCC to display a stale/incorrect vehicle SOC (45% vs actual 19%), leading to wrong charge control decisions.

## Fix

Wrap the evopt publish payload in a named `optimizerResult` type that implements `api.BytesMarshaler`, so `publishComplex()` serializes it as a single JSON message instead of recursing into ~1,500 individual topics.

This follows the existing pattern used by:
- `api.Rates` (`api/rates.go`) — tariff rates published as JSON
- `core/solar.timeseries` (`core/solar.go`) — solar time-series data published as JSON

Both are array/time-series data, same as the optimizer results.

## Changes

- `core/site_optimizer.go`: Added `optimizerResult` type with `MarshalBytes()`, replaced anonymous struct in `site.publish("evopt", ...)` call

## Notes

- The EVCC web UI receives evopt data via websocket (`json.Marshal`), not MQTT — **UI is unaffected**
- The individual MQTT subtopics (e.g., `evcc/site/evopt/res/batteries/1/stateOfCharge/42`) are replaced by a single `evcc/site/evopt` topic containing the full JSON — more useful for external consumers
- This is a **breaking change for anyone subscribing to individual evopt MQTT subtopics**, though these topics are undocumented and unlikely to have external consumers