### PR TITLE
PUN tariff: fix response body leak on 404 and hoist LoadLocation

### DIFF
--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -137,8 +137,12 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 	}
 
 	resp, err := client.Do(req)
-	if err != nil || resp.StatusCode == http.StatusNotFound {
+	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		return nil, fmt.Errorf("data not available for %s", day.Format("2006-01-02"))
 	}
 
 	body, err := request.ReadBody(resp)
@@ -174,6 +178,11 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 		return nil, err
 	}
 
+	location, err := time.LoadLocation("Europe/Rome")
+	if err != nil {
+		return nil, fmt.Errorf("load location: %w", err)
+	}
+
 	data := make(api.Rates, 0, len(dataSet.Prezzi))
 
 	for _, p := range dataSet.Prezzi {
@@ -191,11 +200,6 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 		if hour == 0 {
 			hour = 24
 			date = date.AddDate(0, 0, -1)
-		}
-
-		location, err := time.LoadLocation("Europe/Rome")
-		if err != nil {
-			return nil, fmt.Errorf("load location: %w", err)
 		}
 
 		price, err := strconv.ParseFloat(strings.ReplaceAll(p.PUN, ",", "."), 64)

--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
@@ -18,6 +19,12 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 )
+
+// ErrPunDataNotAvailable indicates that GME has not yet published prices for the requested day.
+var ErrPunDataNotAvailable = errors.New("PUN data not available")
+
+// romeLocation is resolved once at package init to avoid repeated filesystem lookups.
+var romeLocation *time.Location
 
 type Pun struct {
 	*embed
@@ -46,6 +53,7 @@ var _ api.Tariff = (*Pun)(nil)
 
 func init() {
 	registry.Add("pun", NewPunFromConfig)
+	romeLocation, _ = time.LoadLocation("Europe/Rome")
 }
 
 func NewPunFromConfig(other map[string]any) (api.Tariff, error) {
@@ -142,7 +150,7 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
-		return nil, fmt.Errorf("data not available for %s", day.Format("2006-01-02"))
+		return nil, fmt.Errorf("%w: %s", ErrPunDataNotAvailable, day.Format("2006-01-02"))
 	}
 
 	body, err := request.ReadBody(resp)
@@ -178,11 +186,6 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 		return nil, err
 	}
 
-	location, err := time.LoadLocation("Europe/Rome")
-	if err != nil {
-		return nil, fmt.Errorf("load location: %w", err)
-	}
-
 	data := make(api.Rates, 0, len(dataSet.Prezzi))
 
 	for _, p := range dataSet.Prezzi {
@@ -207,7 +210,7 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 			return nil, fmt.Errorf("parse price: %w", err)
 		}
 
-		ts := time.Date(date.Year(), date.Month(), date.Day(), hour-1, 0, 0, 0, location)
+		ts := time.Date(date.Year(), date.Month(), date.Day(), hour-1, 0, 0, 0, romeLocation)
 		ar := api.Rate{
 			Start: ts,
 			End:   ts.Add(time.Hour),

--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -148,8 +148,9 @@ func (t *Pun) getData(day time.Time) (api.Rates, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
-		resp.Body.Close()
 		return nil, fmt.Errorf("%w: %s", ErrPunDataNotAvailable, day.Format("2006-01-02"))
 	}
 


### PR DESCRIPTION
The PUN tariff's `getData` had a couple of issues:

When the GME API returns HTTP 404 (prices not yet published for a given day), the original code combined the error check and status check in a single condition: `if err != nil || resp.StatusCode == http.StatusNotFound`. This leaked the response body on 404 since `request.ReadBody` (which closes the body) was never called. It also returned a nil error, so `backoff.RetryWithData` treated the missing data as a successful empty result rather than retrying — previously cached rates could then get silently replaced with empty data.

I split the condition into two separate checks: return early on transport errors, and on 404, close the body and return an explicit error so the backoff logic can retry properly.

Also moved `time.LoadLocation("Europe/Rome")` out of the per-entry loop — it was doing a filesystem lookup on every price entry when it only needs to be resolved once.