### PR TITLE
chore: ensure markdown links instead of raw urls

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -65,6 +65,8 @@ Either `brand`, or `description` need to be set.
 - The content can be multiline
 - The content supports Markdown formatting
 - External URLs should always use Markdown link format with the hostname as display text: `[docs.example.com](https://docs.example.com/path/to/page)`. This provides clear context while keeping the text readable.
+- Omit `www.` from the display text: `[example.com](https://www.example.com/path)`
+- GitHub URLs use `github.com/user/repo` as display text: `[github.com/user/repo](https://github.com/user/repo)`
 - Use code formatting `` `text` `` for technical identifiers, tokens, configuration values, and entity patterns
 - Use bold formatting `**text**` sparingly and only for important warnings or critical information
 

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -24,8 +24,8 @@ params:
   - name: password
     required: true
     help:
-      de: wie Login für Easee App oder Web Portal (https://easee.cloud)
-      en: same as Easee app or the web portal (https://easee.cloud)
+      de: wie Login für Easee App oder Web Portal ([easee.cloud](https://easee.cloud))
+      en: same as Easee app or the web portal ([easee.cloud](https://easee.cloud))
   - name: charger
     required: true
     description:

--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -12,8 +12,8 @@ products:
 group: heating
 requirements:
   description:
-    de: "Eingebunden via [EMSESP](https://emsesp.org/)"
-    en: "Integrated via [EMSESP](https://emsesp.org/)"
+    de: "Eingebunden via [emsesp.org](https://emsesp.org/)"
+    en: "Integrated via [emsesp.org](https://emsesp.org/)"
 #   evcc: ["sponsorship"]
 params:
   - name: host

--- a/templates/definition/charger/ocpp-abb-tac.yaml
+++ b/templates/definition/charger/ocpp-abb-tac.yaml
@@ -8,7 +8,7 @@ capabilities: ["mA", "rfid"]
 requirements:
   evcc: ["sponsorship", "skiptest"]
   description:
-    generic: https://library.e.abb.com/public/8f07987a3a284da6bf4e4f8f53cd6502/ABB_Terra_AC_Charger_OCPP1.6_ImplementationOverview%20_v1.8_FW1.6.6.pdf
+    generic: "[library.e.abb.com](https://library.e.abb.com/public/8f07987a3a284da6bf4e4f8f53cd6502/ABB_Terra_AC_Charger_OCPP1.6_ImplementationOverview%20_v1.8_FW1.6.6.pdf)"
 params:
   - preset: ocpp
 render: |

--- a/templates/definition/charger/ocpp-enercab.yaml
+++ b/templates/definition/charger/ocpp-enercab.yaml
@@ -9,8 +9,7 @@ products:
 capabilities: ["1p3p"]
 requirements:
   description:
-    generic: |
-      https://www.enercab.at/index.php?controller=attachment&id_attachment=311
+    generic: "[enercab.at](https://www.enercab.at/index.php?controller=attachment&id_attachment=311)"
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/ocpp-wallbox-fw5.yaml
+++ b/templates/definition/charger/ocpp-wallbox-fw5.yaml
@@ -16,7 +16,7 @@ products:
 requirements:
   description:
     de: |
-      Anleitung: https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/
+      Anleitung: [support.wallbox.com](https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/)
 
       * “OCPP aktivieren” (myWallbox app) bzw. den “OCPP-WebSocket-Verbindung” Schalter (myWallbox Portal) aktivieren
       * Zusätzlich die “Verbesserte Ladegerätsteuerung” (Profil -> Experimentelle Funktionen) einschalten (myWallbox app)
@@ -24,7 +24,7 @@ requirements:
       * Ladepunktidentität: beliebiger Wert (z.B. die Seriennummer der Box), der als *stationid* verwendet wird
       * Passwort: leer lassen
     en: |
-      Setup Guide: https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/
+      Setup Guide: [support.wallbox.com](https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/)
 
       * Switch on “Enable OCPP” (myWallbox app) or enable the “OCPP WebSocket connection” switch (myWallbox Portal)
       * Enable “Improved charger control” (Profile -> Experimental functions) (myWallbox app) 

--- a/templates/definition/charger/ocpp-wallbox.yaml
+++ b/templates/definition/charger/ocpp-wallbox.yaml
@@ -16,7 +16,7 @@ products:
 requirements:
   description:
     de: |
-      Anleitung: https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/
+      Anleitung: [support.wallbox.com](https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/)
 
       * “OCPP aktivieren” (myWallbox app) bzw. den “OCPP-WebSocket-Verbindung” Schalter (myWallbox Portal) aktivieren
       * Zusätzlich die “Verbesserte Ladegerätsteuerung” (Profil -> Experimentelle Funktionen) einschalten (myWallbox app)
@@ -24,7 +24,7 @@ requirements:
       * Ladepunktidentität: beliebiger Wert (z.B. die Seriennummer der Box), der als *stationid* verwendet wird
       * Passwort: leer lassen
     en: |
-      Setup Guide: https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/
+      Setup Guide: [support.wallbox.com](https://support.wallbox.com/en/knowledge-base/ocpp-activation-and-setup-guide/)
 
       * Switch on “Enable OCPP” (myWallbox app) or enable the “OCPP WebSocket connection” switch (myWallbox Portal)
       * Enable “Improved charger control” (Profile -> Experimental functions) (myWallbox app) 

--- a/templates/definition/charger/ocpp-zaptec.yaml
+++ b/templates/definition/charger/ocpp-zaptec.yaml
@@ -6,10 +6,7 @@ products:
 capabilities: ["rfid"]
 requirements:
   description:
-    generic: |
-      OCPP 1.6J (Box-Level Integration)
-
-      https://docs.zaptec.com/docs/ocpp16j
+    generic: "OCPP 1.6J (Box-Level Integration) [docs.zaptec.com](https://docs.zaptec.com/docs/ocpp16j)"
   evcc: ["sponsorship", "skiptest"]
 params:
   - preset: ocpp

--- a/templates/definition/charger/twc3.yaml
+++ b/templates/definition/charger/twc3.yaml
@@ -5,8 +5,8 @@ products:
       generic: Wall Connector (Gen 3)
 requirements:
   description:
-    en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be selected at the TWC3 loadpoint. At this time only [Tesla vehicles](https://docs.evcc.io/en/docs/devices/vehicles#tesla) are supported.
-    de: Die TWC Wallbox ist nicht direkt regelbar. Die Regelung erfolgt über das Fahrzeug. Das Fahrzeug muss am TWC3 Ladepunkt ausgewählt sein. Aktuell ausschließlich mit [Tesla Fahrzeugen](https://docs.evcc.io/docs/devices/vehicles#tesla) nutzbar.
+    en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be selected at the TWC3 loadpoint. At this time only [docs.evcc.io](https://docs.evcc.io/en/docs/devices/vehicles#tesla) supported Tesla vehicles are supported.
+    de: Die TWC Wallbox ist nicht direkt regelbar. Die Regelung erfolgt über das Fahrzeug. Das Fahrzeug muss am TWC3 Ladepunkt ausgewählt sein. Aktuell ausschließlich mit [docs.evcc.io](https://docs.evcc.io/docs/devices/vehicles#tesla) unterstützten Tesla Fahrzeugen nutzbar.
 params:
   - name: host
 render: |

--- a/templates/definition/charger/twc3.yaml
+++ b/templates/definition/charger/twc3.yaml
@@ -5,7 +5,7 @@ products:
       generic: Wall Connector (Gen 3)
 requirements:
   description:
-    en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be selected at the TWC3 loadpoint. At this time only [docs.evcc.io](https://docs.evcc.io/en/docs/devices/vehicles#tesla) supported Tesla vehicles are supported.
+    en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be selected at the TWC3 loadpoint. At this time only Tesla vehicles listed on [docs.evcc.io](https://docs.evcc.io/en/docs/devices/vehicles#tesla) are supported.
     de: Die TWC Wallbox ist nicht direkt regelbar. Die Regelung erfolgt über das Fahrzeug. Das Fahrzeug muss am TWC3 Ladepunkt ausgewählt sein. Aktuell ausschließlich mit [docs.evcc.io](https://docs.evcc.io/docs/devices/vehicles#tesla) unterstützten Tesla Fahrzeugen nutzbar.
 params:
   - name: host

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -13,8 +13,8 @@ params:
     advanced: true
   - name: token
     help:
-      en: "Required if Envoy Firmware D7.x.xxx. Token is valid for one year. Instructions for obtaining a token via web UI: https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
-      de: "Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication"
+      en: "Required if Envoy Firmware D7.x.xxx. Token is valid for one year. Instructions for obtaining a token via web UI: [enphase.com](https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication)"
+      de: "Ab Envoy Firmware D7.x.xxx notwendig. Token ist ein Jahr gültig. Anleitung (Obtaining a token via web UI): [enphase.com](https://enphase.com/download/accessing-iq-gateway-local-apis-or-local-ui-token-based-authentication)"
   - name: battery_type
     description:
       en: "Enphase Battery Type (AC or IQ)"

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -14,8 +14,8 @@ products:
       generic: SOFAR 5…24KTL-G3
 requirements:
   description:
-    de: Zu den Details wie man den Wechselrichter verbindet siehe die [Sofar Solar Installations Anleitung von homeassistant-solax-modbus](https://homeassistant-solax-modbus.readthedocs.io/en/latest/sofar-installation/).
-    en: For more details on how to establish a connection to the inverter see the [Sofar Solar installation doc of homeassistant-solax-modbus](https://homeassistant-solax-modbus.readthedocs.io/en/latest/sofar-installation/).
+    de: Zu den Details wie man den Wechselrichter verbindet siehe die Sofar Solar Installations Anleitung von [homeassistant-solax-modbus.readthedocs.io](https://homeassistant-solax-modbus.readthedocs.io/en/latest/sofar-installation/).
+    en: For more details on how to establish a connection to the inverter see the Sofar Solar installation doc at [homeassistant-solax-modbus.readthedocs.io](https://homeassistant-solax-modbus.readthedocs.io/en/latest/sofar-installation/).
 capabilities: ["battery-control"]
 params:
   - name: usage

--- a/templates/definition/meter/solax-hybrid-cloud.yaml
+++ b/templates/definition/meter/solax-hybrid-cloud.yaml
@@ -22,16 +22,16 @@ params:
     description:
       generic: SolaxCloud TokenID
     help:
-      de: "https://www.solaxcloud.com/ -> Support -> Drittanbieter-Ökosystem (alte Website) oder Dienst -> API (neue Website), den Wert von `tokenID` hier in Anführungszeichen eintragen (Beispiel: '20241028488283838')"
-      en: "https://www.solaxcloud.com/ -> Support -> Third-party Ecology (old site) or Service -> API (new site), put the value of `tokenID` here in single quotes (Example: '20241028488283838')"
+      de: "[solaxcloud.com](https://www.solaxcloud.com/) -> Support -> Drittanbieter-Ökosystem (alte Website) oder Dienst -> API (neue Website), den Wert von `tokenID` hier in Anführungszeichen eintragen (Beispiel: '20241028488283838')"
+      en: "[solaxcloud.com](https://www.solaxcloud.com/) -> Support -> Third-party Ecology (old site) or Service -> API (new site), put the value of `tokenID` here in single quotes (Example: '20241028488283838')"
   - name: serial
     required: true
     description:
       de: Seriennummer
       en: Serial number
     help:
-      de: https://www.solaxcloud.com/ -> Gerät -> Wechselrichter (neue Website) oder Support (alte Website), Wert von Registrierungsnummer hier eintragen
-      en: https://www.solaxcloud.com/ -> Device -> Inverter (new site) or Support (old site), use the registration number
+      de: "[solaxcloud.com](https://www.solaxcloud.com/) -> Gerät -> Wechselrichter (neue Website) oder Support (alte Website), Wert von Registrierungsnummer hier eintragen"
+      en: "[solaxcloud.com](https://www.solaxcloud.com/) -> Device -> Inverter (new site) or Support (old site), use the registration number"
   - preset: battery-params
   - name: cache
     default: 1s

--- a/templates/definition/meter/solax-inverter-cloud.yaml
+++ b/templates/definition/meter/solax-inverter-cloud.yaml
@@ -22,16 +22,16 @@ params:
     description:
       generic: SolaxCloud TokenID
     help:
-      de: "https://www.solaxcloud.com/ -> Support -> Drittanbieter-Ökosystem (alte Website) oder Dienst -> API (neue Website), den Wert von `tokenID` hier in Anführungszeichen eintragen (Beispiel: '20241028488283838')"
-      en: "https://www.solaxcloud.com/ -> Support -> Third-party Ecology (old site) or Service -> API (new site), put the value of `tokenID` here in single quotes (Example: '20241028488283838')"
+      de: "[solaxcloud.com](https://www.solaxcloud.com/) -> Support -> Drittanbieter-Ökosystem (alte Website) oder Dienst -> API (neue Website), den Wert von `tokenID` hier in Anführungszeichen eintragen (Beispiel: '20241028488283838')"
+      en: "[solaxcloud.com](https://www.solaxcloud.com/) -> Support -> Third-party Ecology (old site) or Service -> API (new site), put the value of `tokenID` here in single quotes (Example: '20241028488283838')"
   - name: serial
     required: true
     description:
       de: Seriennummer
       en: Serial number
     help:
-      de: https://www.solaxcloud.com/ -> Gerät -> Wechselrichter (neue Website) oder Support (alte Website), Wert von Registrierungsnummer hier eintragen
-      en: https://www.solaxcloud.com/ -> Device -> Inverter (new site) or Support (old site), use the registration number
+      de: "[solaxcloud.com](https://www.solaxcloud.com/) -> Gerät -> Wechselrichter (neue Website) oder Support (alte Website), Wert von Registrierungsnummer hier eintragen"
+      en: "[solaxcloud.com](https://www.solaxcloud.com/) -> Device -> Inverter (new site) or Support (old site), use the registration number"
 render: |
   type: custom
   power:

--- a/templates/definition/tariff/electricitymaps-free.yaml
+++ b/templates/definition/tariff/electricitymaps-free.yaml
@@ -18,8 +18,8 @@ params:
       generic: Zone
     example: "DE"
     help:
-      de: "siehe https://api.electricitymap.org/v3/zones"
-      en: "see https://api.electricitymap.org/v3/zones"
+      de: "siehe [api.electricitymap.org](https://api.electricitymap.org/v3/zones)"
+      en: "see [api.electricitymap.org](https://api.electricitymap.org/v3/zones)"
 render: |
   type: custom
   price:

--- a/templates/definition/tariff/electricitymaps.yaml
+++ b/templates/definition/tariff/electricitymaps.yaml
@@ -21,8 +21,8 @@ params:
       generic: Zone
     example: "DE"
     help:
-      de: "siehe https://api.electricitymap.org/v3/zones"
-      en: "see https://api.electricitymap.org/v3/zones"
+      de: "siehe [api.electricitymap.org](https://api.electricitymap.org/v3/zones)"
+      en: "see [api.electricitymap.org](https://api.electricitymap.org/v3/zones)"
 render: |
   type: electricitymaps
   uri: {{ .uri }}

--- a/templates/definition/tariff/forecast-solar.yaml
+++ b/templates/definition/tariff/forecast-solar.yaml
@@ -14,8 +14,8 @@ params:
       en: Horizon
       de: Horizont
     help:
-      en: Simulates terrain shadows, [more information](https://doc.forecast.solar/horizon)
-      de: Simuliert Verschattung durch Gelände, [mehr Informationen](https://doc.forecast.solar/horizon)
+      en: Simulates terrain shadows, [doc.forecast.solar](https://doc.forecast.solar/horizon)
+      de: Simuliert Verschattung durch Gelände, [doc.forecast.solar](https://doc.forecast.solar/horizon)
     example: 0,0,15,30,45,60,60,60,45,30,15,0
     advanced: true
   - name: apikey

--- a/templates/definition/tariff/gruenstromindex.yaml
+++ b/templates/definition/tariff/gruenstromindex.yaml
@@ -3,8 +3,8 @@ products:
   - brand: Grünstromindex
 requirements:
   description:
-    de: "Regionale Emissionsdaten von https://gruenstromindex.de"
-    en: "Regional emission data from https://gruenstromindex.de"
+    de: "Regionale Emissionsdaten von [gruenstromindex.de](https://gruenstromindex.de)"
+    en: "Regional emission data from [gruenstromindex.de](https://gruenstromindex.de)"
   evcc: ["skiptest"]
 group: co2
 countries: ["DE"]
@@ -13,8 +13,8 @@ params:
     required: true
   - name: token
     help:
-      de: "Token für den Zugriff auf die API von https://console.corrently.io/"
-      en: "Token for accessing the API from https://console.corrently.io"
+      de: "Token für den Zugriff auf die API von [console.corrently.io](https://console.corrently.io/)"
+      en: "Token for accessing the API from [console.corrently.io](https://console.corrently.io/)"
 render: |
   type: grünstromindex
   features: ["cacheable"]

--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -49,8 +49,8 @@ params:
       en: Cooling type [Ross Model]
       de: Kühlung [Ross-Modell]
     help:
-      en: Well Cooled (0.0200), Free Standing (0.0208), Flat on Roof (0.0260), Not So Well Cooled (0.0342), Transparent PV (0.0455), Facade Integrated (0.0538), On Sloped Roof (0.0563) [Paper](https://www.sciencedirect.com/science/article/pii/S0038092X20309107)
-      de: Gut Gekühlt (0.0200), Freistehend (0.0208), Flach auf Dach (0.0260), Nicht So Gut Gekühlt (0.0342), Transparentes PV (0.0455), Fassadenintegriert (0.0538), Auf Schrägdach (0.0563) [Paper](https://www.sciencedirect.com/science/article/pii/S0038092X20309107)
+      en: Well Cooled (0.0200), Free Standing (0.0208), Flat on Roof (0.0260), Not So Well Cooled (0.0342), Transparent PV (0.0455), Facade Integrated (0.0538), On Sloped Roof (0.0563) [sciencedirect.com](https://www.sciencedirect.com/science/article/pii/S0038092X20309107)
+      de: Gut Gekühlt (0.0200), Freistehend (0.0208), Flach auf Dach (0.0260), Nicht So Gut Gekühlt (0.0342), Transparentes PV (0.0455), Fassadenintegriert (0.0538), Auf Schrägdach (0.0563) [sciencedirect.com](https://www.sciencedirect.com/science/article/pii/S0038092X20309107)
     type: float
     default: 0.0342
     advanced: true

--- a/templates/definition/vehicle/flobz.yaml
+++ b/templates/definition/vehicle/flobz.yaml
@@ -5,7 +5,7 @@ products:
 group: generic
 requirements:
   description:
-    generic: Remote Control of PSA car https://github.com/flobz/psa_car_controller
+    generic: Remote Control of PSA car [github.com/flobz/psa_car_controller](https://github.com/flobz/psa_car_controller)
 params:
   - name: url
     example: http://192.0.2.2

--- a/templates/definition/vehicle/ford-connect-query.yaml
+++ b/templates/definition/vehicle/ford-connect-query.yaml
@@ -7,22 +7,22 @@ params:
     description:
       generic: FordConnect Query Client ID
     help:
-      de: Einrichtung unter https://developer.ford.com/developer-eu
-      en: Setup at https://developer.ford.com/developer-eu
+      de: Einrichtung unter [developer.ford.com](https://developer.ford.com/developer-eu)
+      en: Setup at [developer.ford.com](https://developer.ford.com/developer-eu)
     required: true
   - name: clientsecret
     description:
       generic: FordConnect Query Client Secret
     help:
-      de: Einrichtung unter https://developer.ford.com/developer-eu
-      en: Setup at https://developer.ford.com/developer-eu
+      de: Einrichtung unter [developer.ford.com](https://developer.ford.com/developer-eu)
+      en: Setup at [developer.ford.com](https://developer.ford.com/developer-eu)
     required: true
   - name: redirecturi
     description:
       generic: FordConnect Query Redirect URL
     help:
-      de: Einrichtung unter https://developer.ford.com/developer-eu
-      en: Setup at https://developer.ford.com/developer-eu
+      de: Einrichtung unter [developer.ford.com](https://developer.ford.com/developer-eu)
+      en: Setup at [developer.ford.com](https://developer.ford.com/developer-eu)
     service: auth/redirecturi
     required: true
   - name: vin

--- a/templates/definition/vehicle/ford-connect.yaml
+++ b/templates/definition/vehicle/ford-connect.yaml
@@ -8,15 +8,15 @@ params:
     description:
       generic: FordConnect API Client ID
     help:
-      de: Einrichtung unter https://developer.ford.com
-      en: Setup at https://developer.ford.com
+      de: Einrichtung unter [developer.ford.com](https://developer.ford.com)
+      en: Setup at [developer.ford.com](https://developer.ford.com)
     required: true
   - name: clientsecret
     description:
       generic: FordConnect API Client Secret
     help:
-      de: Einrichtung unter https://developer.ford.com
-      en: Setup at https://developer.ford.com
+      de: Einrichtung unter [developer.ford.com](https://developer.ford.com)
+      en: Setup at [developer.ford.com](https://developer.ford.com)
     required: true
   - name: accessToken
     required: true

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -96,8 +96,8 @@ params:
     service: homeassistant/entities?uri={uri}&domain=script,switch
     example: "script.vehicle_start_charge; switch.vehicle_charger"
     help:
-      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [Vehicle API-only charger](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger). If a switch is provided, Service to stop charging must be left empty.
-      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [Fahrzeug-API Ladesteuerung](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger). Wenn ein Schalter angegeben wird, muss der Service zum Stoppen des Ladens leer bleiben.
+      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger). If a switch is provided, Service to stop charging must be left empty.
+      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger). Wenn ein Schalter angegeben wird, muss der Service zum Stoppen des Ladens leer bleiben.
   - name: stop_charging
     description:
       de: Service zum Laden stoppen
@@ -105,8 +105,8 @@ params:
     service: homeassistant/entities?uri={uri}&domain=script
     example: "script.vehicle_stop_charge"
     help:
-      en: Entity ID for a script that stops charging the vehicle. Only useful with the [Vehicle API-only charger](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger).
-      de: Entitäts-ID für ein Skript zum Stoppen des Ladevorgangs. Nur sinnvoll mit der [Fahrzeug-API Ladesteuerung](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger).
+      en: Entity ID for a script that stops charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger).
+      de: Entitäts-ID für ein Skript zum Stoppen des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger).
   - name: wakeup
     description:
       de: Service zum Aufwecken

--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -6,8 +6,8 @@ products:
 group: generic
 requirements:
   description:
-    en: Required MQTT broker configuration and a mazda2mqtt installation https://github.com/C64Axel/mazda2mqtt.
-    de: Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation https://github.com/C64Axel/mazda2mqtt.
+    en: Required MQTT broker configuration and a mazda2mqtt installation [github.com/C64Axel/mazda2mqtt](https://github.com/C64Axel/mazda2mqtt).
+    de: Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation [github.com/C64Axel/mazda2mqtt](https://github.com/C64Axel/mazda2mqtt).
 params:
   - preset: vehicle-common
   - name: vin

--- a/templates/definition/vehicle/mg2mqtt.yaml
+++ b/templates/definition/vehicle/mg2mqtt.yaml
@@ -5,8 +5,8 @@ products:
 group: generic
 requirements:
   description:
-    en: Required MQTT broker configuration and a SAIC/MQTT Gateway (https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway or https://github.com/SAIC-iSmart-API/saic-java-client)
-    de: Voraussetzung ist ein konfigurierter MQTT Broker und ein SAIC/MQTT Gateway (https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway oder https://github.com/SAIC-iSmart-API/saic-java-client)
+    en: Required MQTT broker configuration and a SAIC/MQTT Gateway ([github.com/SAIC-iSmart-API/saic-python-mqtt-gateway](https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway) or [github.com/SAIC-iSmart-API/saic-java-client](https://github.com/SAIC-iSmart-API/saic-java-client))
+    de: Voraussetzung ist ein konfigurierter MQTT Broker und ein SAIC/MQTT Gateway ([github.com/SAIC-iSmart-API/saic-python-mqtt-gateway](https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway) oder [github.com/SAIC-iSmart-API/saic-java-client](https://github.com/SAIC-iSmart-API/saic-java-client))
 params:
   - name: user
     required: true

--- a/templates/definition/vehicle/mz2mqtt.yaml
+++ b/templates/definition/vehicle/mz2mqtt.yaml
@@ -6,8 +6,8 @@ products:
 group: generic
 requirements:
   description:
-    en: myMazda to MQTT. Required MQTT broker configuration and a mz2mqtt installation https://github.com/C64Axel/mz2mqtt.
-    de: myMazda zu MQTT. Voraussetzung ist ein konfigurierter MQTT Broker und eine mz2mqtt Installation https://github.com/C64Axel/mz2mqtt.
+    en: myMazda to MQTT. Required MQTT broker configuration and a mz2mqtt installation [github.com/C64Axel/mz2mqtt](https://github.com/C64Axel/mz2mqtt).
+    de: myMazda zu MQTT. Voraussetzung ist ein konfigurierter MQTT Broker und eine mz2mqtt Installation [github.com/C64Axel/mz2mqtt](https://github.com/C64Axel/mz2mqtt).
 params:
   - preset: vehicle-common
   - name: vin

--- a/templates/definition/vehicle/ovms.yaml
+++ b/templates/definition/vehicle/ovms.yaml
@@ -5,8 +5,8 @@ products:
 group: generic
 requirements:
   description:
-    de: Unterstützung für alle Fahrzeuge via ODB2 Adapter im Fahrzeug. Mehr Infos bei [Open Vehicle Monitoring System](http://api.openvehicles.com/).
-    en: Support for all vehicles via ODB2 adapter in the vehicle. More info at [Open Vehicle Monitoring System](http://api.openvehicles.com/).
+    de: Unterstützung für alle Fahrzeuge via ODB2 Adapter im Fahrzeug. Mehr Infos bei [api.openvehicles.com](http://api.openvehicles.com/).
+    en: Support for all vehicles via ODB2 adapter in the vehicle. More info at [api.openvehicles.com](http://api.openvehicles.com/).
 params:
   - preset: vehicle-common
   - name: user

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -7,7 +7,7 @@ requirements:
   description:
     de: |
       Tesla bietet eine offizielle, aber kostenpflichtige Fahrzeug-API an.
-      Für private Nutzung kannst du dir einen [Tesla Developer Account](https://developer.tesla.com/) erstellen und erhältst ein monatliches API-Guthaben von 10 €.
+      Für private Nutzung kannst du dir einen Tesla Developer Account auf [developer.tesla.com](https://developer.tesla.com/) erstellen und erhältst ein monatliches API-Guthaben von 10 €.
       Das ist für die gängigen evcc-Anwendungsfälle in der Regel ausreichend.
 
       Die Anleitung von [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) erklärt den Prozess und generiert dir kostenfrei die für evcc benötigten Access- und Refresh-Token.
@@ -19,10 +19,10 @@ requirements:
       Konfiguriere dafür bei myteslamate.com die Command-Berechtigungen und trage das Proxy-Token hier ein.
       Start-, Stopp- und Stromstärken-Kommandos werden über diesen Proxy an Tesla geschickt.
 
-      Weitere Informationen und Alternativen findest du in [unserem Blogbeitrag](https://docs.evcc.io/blog/2025/01/20/tesla-api-update).
+      Weitere Informationen und Alternativen findest du unter [docs.evcc.io/blog](https://docs.evcc.io/blog/2025/01/20/tesla-api-update).
     en: |
       Tesla offers an official, but paid vehicle API.
-      For private use, you can create a [Tesla Developer Account](https://developer.tesla.com/) and receive a monthly API credit of $10.
+      For private use, you can create a Tesla Developer Account at [developer.tesla.com](https://developer.tesla.com/) and receive a monthly API credit of $10.
       This is usually sufficient for the common evcc use cases.
 
       The [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) guide explains the process and generates a free Access and Refresh Token.
@@ -34,15 +34,15 @@ requirements:
       Configure the Command permissions at myteslamate.com and enter the Proxy Token here.
       Start, stopp and current commands are sent to Tesla via this proxy.
 
-      More information and alternatives can be found in [our blog post](https://docs.evcc.io/en/blog/2025/01/20/tesla-api-update).
+      More information and alternatives can be found at [docs.evcc.io/blog](https://docs.evcc.io/en/blog/2025/01/20/tesla-api-update).
 params:
   - preset: vehicle-common
   - name: clientId
     description:
       generic: Client ID
     help:
-      en: from [Tesla Developer App](https://developer.tesla.com/dashboard).
-      de: von [Tesla Developer App](https://developer.tesla.com/dashboard).
+      en: from [developer.tesla.com](https://developer.tesla.com/dashboard).
+      de: von [developer.tesla.com](https://developer.tesla.com/dashboard).
     required: true
   - name: accessToken
     help:

--- a/templates/definition/vehicle/teslalogger.yaml
+++ b/templates/definition/vehicle/teslalogger.yaml
@@ -5,8 +5,8 @@ products:
 group: generic
 requirements:
   description:
-    de: Open Source Tesla Datenlogger https://github.com/bassmaster187/TeslaLogger
-    en: Open source Tesla data logger https://github.com/bassmaster187/TeslaLogger
+    de: Open Source Tesla Datenlogger [github.com/bassmaster187/TeslaLogger](https://github.com/bassmaster187/TeslaLogger)
+    en: Open source Tesla data logger [github.com/bassmaster187/TeslaLogger](https://github.com/bassmaster187/TeslaLogger)
 params:
   - preset: vehicle-common
   - name: id

--- a/templates/definition/vehicle/tessie.yaml
+++ b/templates/definition/vehicle/tessie.yaml
@@ -5,8 +5,8 @@ products:
 group: generic
 requirements:
   description:
-    de: Verbinden Sie Ihr Tesla-Fahrzeug über die Tessie-API. Dies wird das Fahrzeug niemals aufwecken; das Polling kann auf „always“ und interval „1M“ eingestellt werden. Wenn das Fahrzeug wach ist, sind die Daten normalerweise weniger als 15 Sekunden alt. Wenn das Fahrzeug schläft, stammen die Daten aus dem Zeitpunkt, zu dem es eingeschlafen ist. Holen Sie sich Ihr Token unter https://dash.tessie.com/settings/api
-    en: Connect your Tesla using the Tessie API. This will never wake up the car, polling can be set to "always" and interval "1M". If the vehicle is awake, the data is usually less than 15 seconds old. If the vehicle is asleep, the data is from the time the vehicle went to sleep. Get your token at https://dash.tessie.com/settings/api
+    de: Verbinden Sie Ihr Tesla-Fahrzeug über die Tessie-API. Dies wird das Fahrzeug niemals aufwecken; das Polling kann auf „always” und interval „1M” eingestellt werden. Wenn das Fahrzeug wach ist, sind die Daten normalerweise weniger als 15 Sekunden alt. Wenn das Fahrzeug schläft, stammen die Daten aus dem Zeitpunkt, zu dem es eingeschlafen ist. Holen Sie sich Ihr Token unter [dash.tessie.com](https://dash.tessie.com/settings/api)
+    en: Connect your Tesla using the Tessie API. This will never wake up the car, polling can be set to “always” and interval “1M”. If the vehicle is awake, the data is usually less than 15 seconds old. If the vehicle is asleep, the data is from the time the vehicle went to sleep. Get your token at [dash.tessie.com](https://dash.tessie.com/settings/api)
 params:
   - preset: vehicle-common
   - name: vin

--- a/templates/definition/vehicle/tronity.yaml
+++ b/templates/definition/vehicle/tronity.yaml
@@ -11,15 +11,15 @@ params:
     description:
       generic: Tronity API Client ID
     help:
-      de: Einrichtung unter https://app.tronity.tech
-      en: Setup at https://app.tronity.tech
+      de: Einrichtung unter [app.tronity.tech](https://app.tronity.tech)
+      en: Setup at [app.tronity.tech](https://app.tronity.tech)
     required: true
   - name: clientsecret
     description:
       generic: Tronity API Client Secret
     help:
-      de: Einrichtung unter https://app.tronity.tech
-      en: Setup at https://app.tronity.tech
+      de: Einrichtung unter [app.tronity.tech](https://app.tronity.tech)
+      en: Setup at [app.tronity.tech](https://app.tronity.tech)
     required: true
   - name: vin
     example: W...

--- a/templates/definition/vehicle/volvo2mqtt.yaml
+++ b/templates/definition/vehicle/volvo2mqtt.yaml
@@ -6,8 +6,8 @@ products:
 group: generic
 requirements:
   description:
-    en: Requires MQTT broker configuration and a volvo2mqtt installation https://github.com/Dielee/volvo2mqtt
-    de: Erforderlich ist eine konfigurierte MQTT Broker-Konfiguration und eine volvo2mqtt-Installation https://github.com/Dielee/volvo2mqtt.
+    en: Requires MQTT broker configuration and a volvo2mqtt installation [github.com/Dielee/volvo2mqtt](https://github.com/Dielee/volvo2mqtt)
+    de: Erforderlich ist eine konfigurierte MQTT Broker-Konfiguration und eine volvo2mqtt-Installation [github.com/Dielee/volvo2mqtt](https://github.com/Dielee/volvo2mqtt).
 params:
   - preset: vehicle-common
   - name: vin


### PR DESCRIPTION
- consistent link formatting in templates
- use markdown links with hostname instead of full urls
  - better readability, eliminates long links
  - prevents layout/wrapping issues in docs and web ui
- adjust templates/README.md rules (more examples)

Note: I updated @sourcery-ai configuration to honor `templates/README.md` rules when template files are changed