### PR TITLE
Bender: handle invalid power meter reading

### DIFF
--- a/charger/bender.go
+++ b/charger/bender.go
@@ -372,10 +372,11 @@ func (wb *BenderCC) currentPower() (float64, error) {
 		return 0, err
 	}
 
+	u := binary.BigEndian.Uint32(b)
+
 	// some Bender chargers temporarily return 0xffffffff
 	// return error in this case to trigger retry and avoid wrong power readings
 	// https://github.com/evcc-io/evcc/discussions/27736
-	u := binary.BigEndian.Uint32(b)
 	if u == math.MaxUint32 {
 		return 0, fmt.Errorf("power meter value not present")
 	}

--- a/charger/bender.go
+++ b/charger/bender.go
@@ -375,11 +375,12 @@ func (wb *BenderCC) currentPower() (float64, error) {
 	// some Bender chargers temporarily return 0xffffffff
 	// return error in this case to trigger retry and avoid wrong power readings
 	// https://github.com/evcc-io/evcc/discussions/27736
-	if u := binary.BigEndian.Uint32(b); u == math.MaxUint32 {
+	u := binary.BigEndian.Uint32(b)
+	if u == math.MaxUint32 {
 		return 0, fmt.Errorf("power meter value not present")
 	}
 
-	return float64(binary.BigEndian.Uint32(b)), nil
+	return float64(u), nil
 }
 
 // removed: https://github.com/evcc-io/evcc/issues/13726

--- a/charger/bender.go
+++ b/charger/bender.go
@@ -372,6 +372,13 @@ func (wb *BenderCC) currentPower() (float64, error) {
 		return 0, err
 	}
 
+	// some Bender chargers temporarily return 0xffffffff
+	// return error in this case to trigger retry and avoid wrong power readings
+	// https://github.com/evcc-io/evcc/discussions/27736
+	if u := binary.BigEndian.Uint32(b); u == math.MaxUint32 {
+		return 0, fmt.Errorf("power meter value not present")
+	}
+
 	return float64(binary.BigEndian.Uint32(b)), nil
 }
 

--- a/charger/bender.go
+++ b/charger/bender.go
@@ -378,7 +378,7 @@ func (wb *BenderCC) currentPower() (float64, error) {
 	// return error in this case to trigger retry and avoid wrong power readings
 	// https://github.com/evcc-io/evcc/discussions/27736
 	if u == math.MaxUint32 {
-		return 0, fmt.Errorf("power meter value not present")
+		return 0, api.ErrMustRetry
 	}
 
 	return float64(u), nil


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/discussions/27736

In https://github.com/evcc-io/evcc/discussions/27736, we see Mennekes chargers with the most recent firmware version temporarily returning 0xffffffff when reading the power register, resulting in a reported power of 4294967295 W. The next reading is ok again.

```
[lp-1 ] DEBUG 2026/03/29 16:44:36 charge power: 4294967295W
```

The Bender specs https://www.bender.de/docs/charge-controller/APIs/Modbus-API/#meter-values-from-ocpp-primary-meter says

> 💡 TIP
When not available, registers contain a 0xffffffff value to indicate that no meter value for the requested register is present.

So this seems to be a valid behavior when no value for the register is available in the moment of reading (although I believe it is - in these cases - caused by an issue in the new Mennekes Firmware  5.33.9. It btw. does not happen with the also Bender-based Spelsberg Smart Pro with Firmware 5.34.3 (and I haven't seen it with the previous 5.33 either, but haven't used this version very long).

The PR will make power meter return an error in this case. The exponential backoff in the loadpoint for power readings should make sure to re-read. Seems to be justifyable for me, since it is documented behavior.

