### PR TITLE
homeassistant: add insecure option for self-signed certificates

### DIFF
--- a/charger/homeassistant-switch.go
+++ b/charger/homeassistant-switch.go
@@ -25,6 +25,7 @@ func NewHomeAssistantSwitchFromConfig(other map[string]any) (api.Charger, error)
 		URI          string
 		Token_       string `mapstructure:"token"` // TODO deprecated
 		Home         string // TODO deprecated
+		Insecure     bool
 		Enable       string
 		Power        string
 		StandbyPower float64
@@ -34,10 +35,10 @@ func NewHomeAssistantSwitchFromConfig(other map[string]any) (api.Charger, error)
 		return nil, err
 	}
 
-	return NewHomeAssistantSwitch(cc.embed, cc.URI, cc.Home, cc.Enable, cc.Power, cc.StandbyPower)
+	return NewHomeAssistantSwitch(cc.embed, cc.URI, cc.Home, cc.Insecure, cc.Enable, cc.Power, cc.StandbyPower)
 }
 
-func NewHomeAssistantSwitch(embed embed, uri, home, enable, power string, standbypower float64) (api.Charger, error) {
+func NewHomeAssistantSwitch(embed embed, uri, home string, insecure bool, enable, power string, standbypower float64) (api.Charger, error) {
 	if enable == "" {
 		return nil, errors.New("missing enable switch entity")
 	}
@@ -49,7 +50,7 @@ func NewHomeAssistantSwitch(embed embed, uri, home, enable, power string, standb
 
 	log := util.NewLogger("ha-switch")
 
-	conn, err := homeassistant.NewConnection(log, uri, home)
+	conn, err := homeassistant.NewConnection(log, uri, home, insecure)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/homeassistant.go
+++ b/charger/homeassistant.go
@@ -31,6 +31,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 		URI        string
 		Token_     string   `mapstructure:"token"` // TODO deprecated
 		Home_      string   `mapstructure:"home"`  // TODO deprecated
+		Insecure   bool     // optional - allow self-signed certificates
 		Status     string   // required - sensor for charge status
 		Enabled    string   // required - sensor for enabled state
 		Enable     string   // required - switch/input_boolean for enable/disable
@@ -60,7 +61,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 
 	log := util.NewLogger("ha-charger")
 
-	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home_)
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home_, cc.Insecure)
 	if err != nil {
 		return nil, err
 	}

--- a/messenger/homeassistant.go
+++ b/messenger/homeassistant.go
@@ -40,7 +40,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Messenger, error) {
 
 	log := util.NewLogger("homeassistant")
 
-	conn, err := homeassistant.NewConnection(log, cc.URI, "")
+	conn, err := homeassistant.NewConnection(log, cc.URI, "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -19,6 +19,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 		URI      string
 		Token_   string `mapstructure:"token"` // TODO deprecated
 		Home_    string `mapstructure:"home"`  // TODO deprecated
+		Insecure bool
 		Power    string
 		Energy   string
 		Currents []string
@@ -50,7 +51,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 
 	log := util.NewLogger("ha-meter")
 
-	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home_)
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home_, cc.Insecure)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/definition/charger/homeassistant-switch.yaml
+++ b/templates/definition/charger/homeassistant-switch.yaml
@@ -28,11 +28,6 @@ params:
   - name: home
     deprecated: true
   - name: insecure
-    type: bool
-    description:
-      de: Selbstsignierte Zertifikate akzeptieren
-      en: Accept self-signed certificates
-    advanced: true
   - name: switch
     description:
       de: Entity ID des schaltbaren Geräts

--- a/templates/definition/charger/homeassistant-switch.yaml
+++ b/templates/definition/charger/homeassistant-switch.yaml
@@ -27,6 +27,12 @@ params:
     deprecated: true
   - name: home
     deprecated: true
+  - name: insecure
+    type: bool
+    description:
+      de: Selbstsignierte Zertifikate akzeptieren
+      en: Accept self-signed certificates
+    advanced: true
   - name: switch
     description:
       de: Entity ID des schaltbaren Geräts
@@ -45,6 +51,7 @@ render: |
   type: homeassistant-switch
   uri: {{ .uri }}
   home: {{ .home }} # deprecated
+  insecure: {{ .insecure }}
   enable: {{ .switch }}
   power: {{ .power }}
   {{ include "switchsocket" . }}

--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -22,6 +22,12 @@ params:
       de: " " # overwrite default
     service: homeassistant/instances
     required: true
+  - name: insecure
+    type: bool
+    description:
+      de: Selbstsignierte Zertifikate akzeptieren
+      en: Accept self-signed certificates
+    advanced: true
   - name: status
     description:
       de: Ladestatus-Sensor
@@ -145,6 +151,7 @@ params:
 render: |
   type: homeassistant
   uri: {{ .uri }}
+  insecure: {{ .insecure }}
   status: {{ .status }}
   enabled: {{ .enabled }}
   enable: {{ .enable }}

--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -23,11 +23,6 @@ params:
     service: homeassistant/instances
     required: true
   - name: insecure
-    type: bool
-    description:
-      de: Selbstsignierte Zertifikate akzeptieren
-      en: Accept self-signed certificates
-    advanced: true
   - name: status
     description:
       de: Ladestatus-Sensor

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -118,11 +118,6 @@ params:
       en: Entity ID for battery state of charge in percent
       de: Entitäts-ID für Batterieladestand in Prozent
   - name: insecure
-    type: bool
-    description:
-      de: Selbstsignierte Zertifikate akzeptieren
-      en: Accept self-signed certificates
-    advanced: true
   - name: maxacpower
   - preset: battery-params
 render: |

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -117,12 +117,19 @@ params:
     help:
       en: Entity ID for battery state of charge in percent
       de: Entitäts-ID für Batterieladestand in Prozent
+  - name: insecure
+    type: bool
+    description:
+      de: Selbstsignierte Zertifikate akzeptieren
+      en: Accept self-signed certificates
+    advanced: true
   - name: maxacpower
   - preset: battery-params
 render: |
   type: homeassistant
   uri: {{ .uri }}
   home: {{ .home }} # deprecated
+  insecure: {{ .insecure }}
   power: {{ .power }}
   energy: {{ .energy }}
   currents:

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -26,11 +26,6 @@ params:
   - name: home
     deprecated: true
   - name: insecure
-    type: bool
-    description:
-      de: Selbstsignierte Zertifikate akzeptieren
-      en: Accept self-signed certificates
-    advanced: true
   - name: soc
     description:
       de: Ladezustand [%]

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -25,6 +25,12 @@ params:
     deprecated: true
   - name: home
     deprecated: true
+  - name: insecure
+    type: bool
+    description:
+      de: Selbstsignierte Zertifikate akzeptieren
+      en: Accept self-signed certificates
+    advanced: true
   - name: soc
     description:
       de: Ladezustand [%]
@@ -134,6 +140,7 @@ render: |
   {{ include "vehicle-features" . }}
   uri: {{ .uri }}
   home: {{ .home }} # deprecated
+  insecure: {{ .insecure }}
   sensors:
     soc: {{ .soc }}
     range: {{ .range }}

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
 	"github.com/samber/lo"
 	"golang.org/x/oauth2"
 )
@@ -23,7 +24,7 @@ type Connection struct {
 }
 
 // NewConnection creates a new Home Assistant connection
-func NewConnection(log *util.Logger, uri, home string) (*Connection, error) {
+func NewConnection(log *util.Logger, uri, home string, insecure bool) (*Connection, error) {
 	if home != "" {
 		log.WARN.Printf("using deprecated 'home' parameter '%s', please use 'uri' instead", home)
 	}
@@ -38,6 +39,11 @@ func NewConnection(log *util.Logger, uri, home string) (*Connection, error) {
 			home: home,
 			uri:  util.DefaultScheme(strings.TrimSuffix(uri, "/"), "http"),
 		},
+	}
+
+	// override the transport to accept self-signed certificates
+	if insecure {
+		c.Client.Transport = request.NewTripper(log, transport.Insecure())
 	}
 
 	// Set up authentication headers

--- a/util/homeassistant/service.go
+++ b/util/homeassistant/service.go
@@ -35,7 +35,7 @@ func connectionFromRequest(req *http.Request) (*Connection, error) {
 	if uri == "" {
 		return nil, errors.New("missing uri")
 	}
-	return NewConnection(log, uri, "")
+	return NewConnection(log, uri, "", false)
 }
 
 // domainsFromRequest parses the comma-separated "domain" query parameter.

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -317,6 +317,12 @@ params:
     help:
       en: Charger will enable charging for short time when vehicle is connected, irrespective of configured charge mode. This is useful for vehicles that require power supply when connecting.
       de: Wallbox gibt kurzzeitige Ladefreigabe bei Fahrzeugverbindung. Das ermöglicht es Fahrzeugen, die eine Stromversorgung beim Anschließen benötigen, einen Fehlerzustand zu vermeiden.
+  - name: insecure
+    type: bool
+    advanced: true
+    description:
+      en: Accept self-signed certificates
+      de: Selbstsignierte Zertifikate akzeptieren
   - name: defaultmode
     type: int
     usages: ["battery"]

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -24,11 +24,12 @@ func init() {
 // Constructor from YAML config
 func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error) {
 	var cc struct {
-		embed   `mapstructure:",squash"`
-		URI     string
-		Token_  string `mapstructure:"token"` // TODO deprecated
-		Home_   string `mapstructure:"home"`  // TODO deprecated
-		Sensors struct {
+		embed    `mapstructure:",squash"`
+		URI      string
+		Token_   string `mapstructure:"token"` // TODO deprecated
+		Home_    string `mapstructure:"home"`  // TODO deprecated
+		Insecure bool
+		Sensors  struct {
 			Soc        string // required
 			Range      string // optional
 			Status     string // optional
@@ -55,7 +56,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 
 	log := util.NewLogger("ha-vehicle")
 
-	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home_)
+	conn, err := homeassistant.NewConnection(log, cc.URI, cc.Home_, cc.Insecure)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Adds `insecure: true` config option to all Home Assistant integrations (meter, charger, charger-switch, vehicle) to allow connecting to HA instances with self-signed TLS certificates
- Follows the existing pattern used by HTTP and MQTT plugins: when `insecure` is set, the HTTP transport uses `tls.Config{InsecureSkipVerify: true}`
- Updates all device templates with the new `insecure` parameter (as advanced option)

Fixes #26078

## Test plan
- [ ] Configure a Home Assistant meter/charger/vehicle with `insecure: true` and a self-signed HTTPS certificate
- [ ] Verify the TLS error `x509: certificate signed by unknown authority` no longer occurs
- [ ] Verify that without `insecure: true`, the default behavior (certificate validation) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)