### PR TITLE
Forecast UI: no savings-modal rerender, fixed safari scroll overlays

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -461,8 +461,8 @@ html:has(.modal.show) {
 }
 
 /* Safari renders non-overlay scrollbars above modal backdrops at compositor level */
-body.modal-open .forecast-chart-scroll::-webkit-scrollbar {
-	opacity: 0;
+body.modal-open .scroll-overlay-fix {
+	scrollbar-color: transparent transparent;
 }
 
 .cursor-pointer {

--- a/assets/js/components/Forecast/Co2Chart.vue
+++ b/assets/js/components/Forecast/Co2Chart.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="scrollEl" class="forecast-chart-scroll" @scroll="onScroll">
+	<div ref="scrollEl" class="forecast-chart-scroll scroll-overlay-fix" @scroll="onScroll">
 		<div ref="chartEl" :style="{ height: '200px', width: chartWidth + 'px' }"></div>
 	</div>
 </template>

--- a/assets/js/components/Forecast/PriceChart.vue
+++ b/assets/js/components/Forecast/PriceChart.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="scrollEl" class="forecast-chart-scroll" @scroll="onScroll">
+	<div ref="scrollEl" class="forecast-chart-scroll scroll-overlay-fix" @scroll="onScroll">
 		<div ref="chartEl" :style="{ height: '200px', width: chartWidth + 'px' }"></div>
 	</div>
 </template>

--- a/assets/js/components/Forecast/SolarChart.vue
+++ b/assets/js/components/Forecast/SolarChart.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="scrollEl" class="forecast-chart-scroll" @scroll="onScroll">
+	<div ref="scrollEl" class="forecast-chart-scroll scroll-overlay-fix" @scroll="onScroll">
 		<div ref="chartEl" :style="{ height: '200px', width: chartWidth + 'px' }"></div>
 	</div>
 </template>

--- a/assets/js/components/Tariff/TariffChart.vue
+++ b/assets/js/components/Tariff/TariffChart.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="root position-relative">
 		<div
-			class="chart position-relative"
+			class="chart scroll-overlay-fix position-relative"
 			:class="{ 'chart--with-target': targetText, inactive }"
 		>
 			<div

--- a/assets/js/views/Forecast.vue
+++ b/assets/js/views/Forecast.vue
@@ -3,10 +3,9 @@
 		class="container px-4 safe-area-inset d-flex flex-column"
 		:class="{ 'empty-container': !forecastAvailable }"
 	>
-		<TopHeader v-if="forecastAvailable" :title="$t('forecast.modalTitle')" />
+		<TopHeader :title="$t('forecast.modalTitle')" />
 		<div v-if="!forecastAvailable" class="flex-grow-1 d-flex">
 			<div class="empty-box d-flex flex-column p-5">
-				<h2 class="fs-4 mb-4">{{ $t("forecast.empty.title") }}</h2>
 				<ul class="list-unstyled mb-4">
 					<li class="d-flex align-items-start gap-2 mb-3">
 						<shopicon-regular-sun

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -929,8 +929,7 @@
       "co2": "Erfahre, wann Netzstrom in deiner Region sauber ist. Ladepläne werden auf niedrige Emissionen optimiert und CO₂-Einsparungen berechnet.",
       "price": "Dynamischen Stromtarif konfigurieren, um Ladepläne automatisch zu optimieren und Einsparungen zu berechnen.",
       "setup": "Tarife und Vorhersagen einrichten",
-      "solar": "Erwartete Solarproduktion für heute und die nächsten Tage. Wird in Zukunft auch für die automatische Ladeoptimierung verwendet.",
-      "title": "Tarife & Vorhersagen"
+      "solar": "Erwartete Solarproduktion für heute und die nächsten Tage. Wird in Zukunft auch für die automatische Ladeoptimierung verwendet."
     },
     "modalTitle": "Vorhersage",
     "price": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -930,8 +930,7 @@
       "co2": "See when grid energy in your region is clean. Charging plans will optimize for low emissions and calculate CO₂ savings.",
       "price": "Configure your dynamic electricity tariff to automatically optimize charging plans and calculate savings.",
       "setup": "Set up tariffs and forecasts",
-      "solar": "See expected solar production for today and the coming days. Will also be used for automatic charging optimization in the future.",
-      "title": "Tariffs & Forecasts"
+      "solar": "See expected solar production for today and the coming days. Will also be used for automatic charging optimization in the future."
     },
     "modalTitle": "Forecast",
     "price": {

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -937,8 +937,7 @@
       "co2": "Näytä milloin sähköverkon energia on puhdasta. Lataussuunnitelmissa optimoidaan alhaiset päästöt ja laskelmoidut CO₂-säästöt.",
       "price": "Määritä vaihteleva energian hintasi optimoidaksesi automaattisesti lataussuunnitelmasi ja laskeaksesi käytetyn energian kustannukset.",
       "setup": "Määritä hinnat ja ennusteet",
-      "solar": "Katso aurinkotuotannon ennuste täksi ja tuleviksi päiviksi. Käytetään tulevaisuudessa myös latauksien optimoitiin.",
-      "title": "Hinnat & ennusteet"
+      "solar": "Katso aurinkotuotannon ennuste täksi ja tuleviksi päiviksi. Käytetään tulevaisuudessa myös latauksien optimoitiin."
     },
     "modalTitle": "Ennuste",
     "price": {

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -938,8 +938,7 @@
       "co2": "Sužinokite, kada jūsų regione energija yra mažiausiai tarši. Įkrovimo planai bus optimizuoti mažiausiam išmetamųjų teršalų kiekiui, apskaičiuosime CO₂ sutaupymą.",
       "price": "Sukonfigūruokite dinaminį elektros energijos tarifą, kad automatiškai optimizuotumėte įkrovimo planus ir apskaičiuotumėte sutaupytas lėšas.",
       "setup": "Sukonfigūruoti tarifus ir prognozes",
-      "solar": "Prognozuojama saulės energijos gamyba šiandienai ir ateinančiomis dienomis. Ateityje taip pat bus naudojama automatiniam įkrovimo optimizavimui.",
-      "title": "Tarifai ir Prognozės"
+      "solar": "Prognozuojama saulės energijos gamyba šiandienai ir ateinančiomis dienomis. Ateityje taip pat bus naudojama automatiniam įkrovimo optimizavimui."
     },
     "modalTitle": "Prognozė",
     "price": {

--- a/tests/bottom-nav.spec.ts
+++ b/tests/bottom-nav.spec.ts
@@ -73,7 +73,7 @@ test.describe("bottom navigation", async () => {
     await expect(page.getByRole("heading", { name: "Home Battery" })).toBeVisible();
 
     await tabForecast.click();
-    await expect(page.getByRole("heading", { name: "Tariffs & Forecasts" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Forecast" })).toBeVisible();
 
     await tabSessions.click();
     await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible();


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/28566

- hide safari scrollbars when overlay is open (refined https://github.com/evcc-io/evcc/pull/28605)
- prevent forecast header (savings modal) from resetting on ws reconnect
- no alternative forecast header in empty-state