### PR TITLE
Teslamate: Switched battery_level into usable_battery_level

### DIFF
--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -21,7 +21,7 @@ render: |
   {{- include "vehicle-common" . }}
   soc:
     source: mqtt
-    topic: teslamate/cars/{{ .id }}/battery_level
+    topic: teslamate/cars/{{ .id }}/usable_battery_level
     timeout: {{ .timeout }}
   status:
     source: combined


### PR DESCRIPTION
Use same values like in native tesla implementation.