### PR TITLE
fix: planner phase issue for 1p3p chargers when car charges on single phase

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1273,6 +1273,29 @@ func (lp *Loadpoint) scalePhases(phases int) error {
 
 		// some vehicles may hang on phase switch
 		lp.startWakeUpTimer()
+	} else if phases > 1 && lp.getMeasuredPhases() == 1 && lp.charging() && lp.phaseSwitchCompleted() {
+		// phases are configured to 3p but car is only using 1p — force session restart
+		lp.log.DEBUG.Printf("phase mismatch detected: %dp configured but 1p measured, restarting session", phases)
+
+		// disable charger
+		if err := lp.charger.Enable(false); err != nil {
+			return fmt.Errorf("charger disable for phase renegotiation: %w", err)
+		}
+
+		// re-send phase configuration
+		if err := cp.Phases1p3p(phases); err != nil {
+			return fmt.Errorf("switch phases: %w", err)
+		}
+
+		// re-enable charger
+		if err := lp.charger.Enable(true); err != nil {
+			return fmt.Errorf("charger enable for phase renegotiation: %w", err)
+		}
+
+		lp.log.DEBUG.Printf("session restarted for phase renegotiation to %dp", phases)
+		lp.phasesSwitched = lp.clock.Now()
+		lp.resetMeasuredPhases()
+		lp.startWakeUpTimer()
 	}
 
 	return nil

--- a/core/loadpoint_phases.go
+++ b/core/loadpoint_phases.go
@@ -137,6 +137,13 @@ func (lp *Loadpoint) maxActivePhases() int {
 	// if 1p3p supported then assume configured limit or 3p
 	if lp.hasPhaseSwitching() {
 		physical = lp.phasesConfigured
+
+		// don't let 1p measured constrain when targeting 3p or auto —
+		// the car may not have renegotiated yet after a phase switch
+		// physical == 0 means auto mode (expect() treats as 3p)
+		if (physical == 0 || physical > 1) && measured == 1 {
+			measured = 0
+		}
 	}
 
 	return min(expect(vehicle), expect(physical), expect(measured), expect(charger))

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -56,7 +56,7 @@ var phaseTests = []testCase{
 	{0, 1, 3, 0, 1, 3, 1, "u"},
 	// 1p3p, 3 currently active
 	{0, 3, 0, 0, unknownPhases, 3, 1, "d"},
-	{0, 3, 0, 1, 1, 1, 1, ""},
+	{0, 3, 0, 1, 1, 3, 1, ""}, // measured 1p doesn't constrain max for 1p3p targeting 3p; session restart handles mismatch
 	{0, 3, 0, 2, 2, 2, 1, "d"},
 	{0, 3, 0, 3, 3, 3, 1, "d"},
 	{0, 3, 1, 0, 1, 1, 1, ""},


### PR DESCRIPTION
I experienced an issue that was also reported by other users. Using a Zaptec Go 2 (1p3p) charger and then planning a charge the charger would not switch to 3p - potentially missing the target time and/or missing the best dynamic tariff times - if charging is currently running on 1p. 

I investigated and found out that when a 1p3p charger is configured for 3 phases but the car only draws on 1 phase, scalePhases() becomes a no-op since GetPhases() already equals the target. This causes maxActivePhases() to return 1 (constrained by the measured value), making the planner calculate with 1p power indefinitely instead of the expected 3p power.

Fix:
- scalePhases: when phases match but measuredPhases==1 while targeting multi-phase, detect the mismatch and force a session restart (disable -> re-send phase config -> enable) to trigger renegotiation
- maxActivePhases: don't let measured=1 constrain the result when a 1p3p charger targets 3p or auto mode, since the car may not have renegotiated yet after a phase switch

Also updates the corresponding test expectation in phaseTests.

This fix has been running for week without issue in my installation.