### PR TITLE
tariff: don't treat HTTP 429 as permanent backoff error (#26654)

### DIFF
--- a/tariff/helper.go
+++ b/tariff/helper.go
@@ -2,6 +2,7 @@ package tariff
 
 import (
 	"errors"
+	"net/http"
 	"strings"
 	"time"
 
@@ -28,10 +29,16 @@ func bo() backoff.BackOff {
 	)
 }
 
-// backoffPermanentError returns a permanent error in case of HTTP 400
+// backoffPermanentError returns a permanent error for HTTP 4xx/5xx responses,
+// except for 429 (Too Many Requests) which is transient and should be retried
 func backoffPermanentError(err error) error {
 	if se, ok := errors.AsType[*request.StatusError](err); ok {
-		if code := se.StatusCode(); code >= 400 && code <= 599 {
+		code := se.StatusCode()
+		// 429 Too Many Requests is transient — let the exponential backoff handle it
+		if code == http.StatusTooManyRequests {
+			return err
+		}
+		if code >= 400 && code <= 599 {
 			return backoff.Permanent(se)
 		}
 	}

--- a/tariff/helper_test.go
+++ b/tariff/helper_test.go
@@ -2,12 +2,17 @@ package tariff
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
 	"github.com/jinzhu/now"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,5 +88,40 @@ func TestRunOrQError(t *testing.T) {
 		res, err := runOrError(&runner{errors.New("foo")})
 		require.Error(t, err)
 		require.Nil(t, res)
+	}
+}
+
+func statusError(code int) *request.StatusError {
+	rec := httptest.NewRecorder()
+	rec.Code = code
+	resp := rec.Result()
+	resp.Request = &http.Request{Method: http.MethodGet, URL: &url.URL{}}
+	return request.NewStatusError(resp)
+}
+
+func TestBackoffPermanentError(t *testing.T) {
+	tt := []struct {
+		name      string
+		code      int
+		permanent bool
+	}{
+		{name: "400 Bad Request is permanent", code: http.StatusBadRequest, permanent: true},
+		{name: "401 Unauthorized is permanent", code: http.StatusUnauthorized, permanent: true},
+		{name: "404 Not Found is permanent", code: http.StatusNotFound, permanent: true},
+		{name: "500 Internal Server Error is permanent", code: http.StatusInternalServerError, permanent: true},
+		{name: "429 Too Many Requests is NOT permanent (transient)", code: http.StatusTooManyRequests, permanent: false},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := backoffPermanentError(statusError(tc.code))
+			var pe *backoff.PermanentError
+			isPermanent := errors.As(err, &pe)
+			if tc.permanent {
+				assert.True(t, isPermanent, "expected permanent error for HTTP %d", tc.code)
+			} else {
+				assert.False(t, isPermanent, "expected non-permanent error for HTTP %d", tc.code)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #26654

The Corrently/GSI API sometimes returns a 429 on startup. `backoffPermanentError` was classifying all 4xx–5xx responses as permanent, so `backoff.Retry` gave up immediately and the tariff stayed broken until you restarted evcc.

429 means "try again later", not "give up forever". This adds an early check for that code so the exponential backoff actually gets to run. Everything else (400, 404, 500, etc.) is still treated as permanent since those won't fix themselves on retry.

Tested with the new cases in `tariff/helper_test.go`:

```
make test ./tariff/...
```

> I used AI tools while working on this fix.