### PR TITLE
EMS-ESP: make SG-Ready inputs and bitmask values configurable

### DIFF
--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -28,6 +28,64 @@ params:
   - name: tempsource
     type: choice
     choice: ["warmwater"]
+  - name: sg1
+    advanced: true
+    type: choice
+    choice: ["hpin1opt", "hpin2opt", "hpin3opt", "hpin4opt"]
+    default: hpin1opt
+    description:
+      de: "SG1-Eingang"
+      en: "SG1 input"
+  - name: sg4
+    advanced: true
+    type: choice
+    choice: ["hpin1opt", "hpin2opt", "hpin3opt", "hpin4opt"]
+    default: hpin4opt
+    description:
+      de: "SG4-Eingang"
+      en: "SG4 input"
+  - name: value_normal_sg4
+    advanced: true
+    type: string
+    default: "0xxxxxxxxxxx"
+    description:
+      de: "Bitmask für SG4 im Normalbetrieb"
+      en: "Bitmask for SG4 in normal mode"
+  - name: value_normal_sg1
+    advanced: true
+    type: string
+    default: "0xxxxxxxxxxxxxx"
+    description:
+      de: "Bitmask für SG1 im Normalbetrieb"
+      en: "Bitmask for SG1 in normal mode"
+  - name: value_boost_sg4
+    advanced: true
+    type: string
+    default: "1xxxxxxxxxxx"
+    description:
+      de: "Bitmask für SG4 im Boost-Betrieb"
+      en: "Bitmask for SG4 in boost mode"
+  - name: value_boost_sg1
+    advanced: true
+    type: string
+    default: ""
+    description:
+      de: "Bitmask für SG1 im Boost-Betrieb"
+      en: "Bitmask for SG1 in boost mode"
+  - name: value_dim_sg1
+    advanced: true
+    type: string
+    default: "1xxxxxxxxxxxxxx"
+    description:
+      de: "Bitmask für SG1 im Dimm-Betrieb"
+      en: "Bitmask for SG1 in dim mode"
+  - name: value_dim_sg4
+    advanced: true
+    type: string
+    default: "0xxxxxxxxxxx"
+    description:
+      de: "Bitmask für SG4 im Dimm-Betrieb"
+      en: "Bitmask for SG4 in dim mode"
 render: |
   type: sgready
   power:
@@ -51,13 +109,13 @@ render: |
       type: string
       config: 
         source: http
-        uri: http://{{ .host }}/api/boiler/hpin1opt
+        uri: http://{{ .host }}/api/boiler/{{ .sg1 }}
         jq: '.value[0:1]'
     - name: SG4
       type: string
       config: 
         source: http
-        uri: http://{{ .host }}/api/boiler/hpin4opt
+        uri: http://{{ .host }}/api/boiler/{{ .sg4 }}
         jq: '.value[0:1]'
   setmode:
     source: switch
@@ -67,51 +125,63 @@ render: |
         source: sequence
         set:
         - source: http
-          uri: http://{{ .host }}/api/boiler/hpin4opt 
+          uri: http://{{ .host }}/api/boiler/{{ .sg4 }} 
           method: POST 
           headers:  
             - content-type: application/json
             - authorization: Bearer {{ .token}}
           body: >
-            { "value" : "0xxxxxxxxxxx" }
+            { "value" : "{{ .value_normal_sg4 }}" }
         - source: http
-          uri: http://{{ .host }}/api/boiler/hpin1opt 
+          uri: http://{{ .host }}/api/boiler/{{ .sg1 }} 
           method: POST 
           headers:  
             - content-type: application/json
             - authorization: Bearer {{ .token}}
           body: >
-            { "value" : "0xxxxxxxxxxxxxx" }
+            { "value" : "{{ .value_normal_sg1 }}" }
     - case: 3 # boost
       set:
-        source: http
-        uri: http://{{ .host }}/api/boiler/hpin4opt 
-        method: POST 
-        headers:  
-          - content-type: application/json
-          - authorization: Bearer {{ .token}}
-        body: >
-          { "value" : "1xxxxxxxxxxx" }
+        source: sequence
+        set:
+        - source: http
+          uri: http://{{ .host }}/api/boiler/{{ .sg4 }} 
+          method: POST 
+          headers:  
+            - content-type: application/json
+            - authorization: Bearer {{ .token}}
+          body: >
+            { "value" : "{{ .value_boost_sg4 }}" }
+        {{- if .value_boost_sg1 }}
+        - source: http
+          uri: http://{{ .host }}/api/boiler/{{ .sg1 }} 
+          method: POST 
+          headers:  
+            - content-type: application/json
+            - authorization: Bearer {{ .token}}
+          body: >
+            { "value" : "{{ .value_boost_sg1 }}" }
+        {{- end }}
     - case: 1 # dimm
       set:
         source: sequence
         set:
         - source: http
-          uri: http://{{ .host }}/api/boiler/hpin1opt 
+          uri: http://{{ .host }}/api/boiler/{{ .sg1 }} 
           method: POST 
           headers:  
             - content-type: application/json
             - authorization: Bearer {{ .token}}
           body: >
-            { "value" : "1xxxxxxxxxxxxxx" }
+            { "value" : "{{ .value_dim_sg1 }}" }
         - source: http
-          uri: http://{{ .host }}/api/boiler/hpin4opt 
+          uri: http://{{ .host }}/api/boiler/{{ .sg4 }} 
           method: POST 
           headers:  
             - content-type: application/json
             - authorization: Bearer {{ .token}}
           body: >
-            { "value" : "0xxxxxxxxxxx" }    
+            { "value" : "{{ .value_dim_sg4 }}" }    
   {{- if .tempsource }}
   temp:
     source: http


### PR DESCRIPTION
Fixes #28584

On Buderus/Bosch heat pumps connected via EMS-ESP, Input 1 ("hpin1opt") is often hardwired to the utility provider's grid lock (EVU-Sperre), not SG-Ready signalling. The previous template hardwired "hpin1opt" as the SG1 entity and "hpin4opt" as the SG4 entity, which broke SG-Ready control on these systems.

This PR adds two sets of configurable "advanced" params:

**Input selection** — choose which EMS-ESP digital input entity is wired to each SG-Ready line:
- "sg1" (default: "hpin1opt") -> entity for the SG1 signal
- "sg4" (default: "hpin4opt") -> entity for the SG4 signal

**Bitmask values** — override the bitmask strings sent to the EMS-ESP API per mode:
- "value_normal_sg4" / "value_normal_sg1" -> normal mode (SG off)
- "value_boost_sg4" / "value_boost_sg1" -> boost mode (SG2)
- "value_dim_sg4" / "value_dim_sg1" -> dim mode (SG1)

"value_boost_sg1" is empty by default - the original template did not write to SG1 in boost mode. Setting it adds an optional POST to "hpin1opt" in boost mode for heat pump models that require it.

All params are "advanced: true" and default to the original hardcoded values, so existing configurations continue to work without changes.

> I used AI tools while working on this fix to enhance the code quality.
