### PR TITLE
DaheimLaden: Add debug log for phase switch in progress

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -330,7 +330,7 @@ func (wb *DaheimLaden) getPhases() (int, error) {
 
 		wb.phases = binary.BigEndian.Uint16(b)
 	} else {
-		wb.log.DEBUG("phase switch in progress")
+		wb.log.DEBUG.Println("phase switch in progress")
 	}
 
 	return int(wb.phases), nil

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -329,6 +329,8 @@ func (wb *DaheimLaden) getPhases() (int, error) {
 		}
 
 		wb.phases = binary.BigEndian.Uint16(b)
+	} else {
+		wb.log.DEBUG("phase switch in progress")
 	}
 
 	return int(wb.phases), nil


### PR DESCRIPTION
Since the phase switch takes 2 minutes, a note in the log could be quite useful.