### PR TITLE
Session: add reference price and CO2

### DIFF
--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -2,11 +2,13 @@ package core
 
 import (
 	"errors"
+	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/core/session"
 	"github.com/evcc-io/evcc/core/wrapper"
+	"github.com/evcc-io/evcc/tariff"
 	"github.com/jinzhu/now"
 )
 
@@ -49,6 +51,11 @@ func (lp *Loadpoint) createSession() {
 		if id, err := c.Identify(); err == nil {
 			lp.session.Identifier = id
 		}
+	}
+
+	if lp.site != nil {
+		lp.session.ReferencePricePerKWh = tariff.AverageRate(lp.site.GetTariff(api.TariffUsageGrid), 24*time.Hour)
+		lp.session.ReferenceCo2PerKWh = tariff.AverageRate(lp.site.GetTariff(api.TariffUsageCo2), 24*time.Hour)
 	}
 
 	// energy

--- a/core/session/session.go
+++ b/core/session/session.go
@@ -11,21 +11,23 @@ import (
 
 // Session is a single charging session
 type Session struct {
-	ID              uint           `json:"id" csv:"-" gorm:"primarykey"`
-	Created         time.Time      `json:"created"`
-	Finished        time.Time      `json:"finished"`
-	Loadpoint       string         `json:"loadpoint"`
-	Identifier      string         `json:"identifier"`
-	Vehicle         string         `json:"vehicle"`
-	Odometer        *float64       `json:"odometer" format:"int"`
-	MeterStart      *float64       `json:"meterStart" csv:"Meter Start (kWh)" gorm:"column:meter_start_kwh"`
-	MeterStop       *float64       `json:"meterStop" csv:"Meter Stop (kWh)" gorm:"column:meter_end_kwh"`
-	ChargedEnergy   float64        `json:"chargedEnergy" csv:"Charged Energy (kWh)" gorm:"column:charged_kwh"`
-	ChargeDuration  *time.Duration `json:"chargeDuration" csv:"Charge Duration" gorm:"column:charge_duration"`
-	SolarPercentage *float64       `json:"solarPercentage" csv:"Solar (%)" gorm:"column:solar_percentage"`
-	Price           *float64       `json:"price" csv:"Price" gorm:"column:price"`
-	PricePerKWh     *float64       `json:"pricePerKWh" csv:"Price/kWh" gorm:"column:price_per_kwh"`
-	Co2PerKWh       *float64       `json:"co2PerKWh" csv:"CO2/kWh (gCO2eq)" gorm:"column:co2_per_kwh"`
+	ID                   uint           `json:"id" csv:"-" gorm:"primarykey"`
+	Created              time.Time      `json:"created"`
+	Finished             time.Time      `json:"finished"`
+	Loadpoint            string         `json:"loadpoint"`
+	Identifier           string         `json:"identifier"`
+	Vehicle              string         `json:"vehicle"`
+	Odometer             *float64       `json:"odometer" format:"int"`
+	MeterStart           *float64       `json:"meterStart" csv:"Meter Start (kWh)" gorm:"column:meter_start_kwh"`
+	MeterStop            *float64       `json:"meterStop" csv:"Meter Stop (kWh)" gorm:"column:meter_end_kwh"`
+	ChargedEnergy        float64        `json:"chargedEnergy" csv:"Charged Energy (kWh)" gorm:"column:charged_kwh"`
+	ChargeDuration       *time.Duration `json:"chargeDuration" csv:"Charge Duration" gorm:"column:charge_duration"`
+	SolarPercentage      *float64       `json:"solarPercentage" csv:"Solar (%)" gorm:"column:solar_percentage"`
+	Price                *float64       `json:"price" csv:"Price" gorm:"column:price"`
+	PricePerKWh          *float64       `json:"pricePerKWh" csv:"Price/kWh" gorm:"column:price_per_kwh"`
+	Co2PerKWh            *float64       `json:"co2PerKWh" csv:"CO2/kWh (gCO2eq)" gorm:"column:co2_per_kwh"`
+	ReferencePricePerKWh *float64       `json:"referencePricePerKWh" csv:"Reference Price/kWh" gorm:"column:reference_price_per_kwh"`
+	ReferenceCo2PerKWh   *float64       `json:"referenceCo2PerKWh" csv:"Reference CO2/kWh (gCO2eq)" gorm:"column:reference_co2_per_kwh"`
 }
 
 // Sessions is a list of sessions

--- a/tariff/tariffs.go
+++ b/tariff/tariffs.go
@@ -44,6 +44,33 @@ func Rates(t api.Tariff) api.Rates {
 	return rr
 }
 
+// AverageRate returns the arithmetic mean of rates in [now, now+d), or nil if unavailable.
+func AverageRate(t api.Tariff, d time.Duration) *float64 {
+	rr := Rates(t)
+	if rr == nil {
+		return nil
+	}
+
+	now := time.Now()
+	end := now.Add(d)
+
+	var sum float64
+	var count int
+	for _, r := range rr {
+		if r.Start.Before(end) && r.End.After(now) {
+			sum += r.Value
+			count++
+		}
+	}
+
+	if count == 0 {
+		return nil
+	}
+
+	avg := sum / float64(count)
+	return &avg
+}
+
 func (t *Tariffs) Get(u api.TariffUsage) api.Tariff {
 	// ensure tariff is not a wrapper
 	exists := func(t api.Tariff) bool {

--- a/tariff/tariffs.go
+++ b/tariff/tariffs.go
@@ -67,8 +67,7 @@ func AverageRate(t api.Tariff, d time.Duration) *float64 {
 		return nil
 	}
 
-	avg := sum / float64(count)
-	return &avg
+	return new(sum / float64(count))
 }
 
 func (t *Tariffs) Get(u api.TariffUsage) api.Tariff {


### PR DESCRIPTION
addresses https://github.com/evcc-io/evcc/issues/11160

Snapshot average grid price and CO2 intensity (next 24h) when a charging session is created.
Adds referencePricePerKWh and referenceCo2PerKWh to the session DB schema and JSON/CSV response. This provides stable reference values for future savings calculations instead of relying on volatile forecast data.

Existing sessions get NULL via GORM auto-migration. 

**Next steps: (separate PRs)**
- Add a UI option to (bulk-)backfill reference data for old charging sessions.
- Replace the static savings calculation (hard coded region values) and use the new data fields. 