### PR TITLE
Update tariff/ostrom.go: add support for SimplyDynamic_V2 contract type

### DIFF
--- a/tariff/ostrom.go
+++ b/tariff/ostrom.go
@@ -256,11 +256,12 @@ func (t *Ostrom) Rates() (api.Rates, error) {
 // Type implements the api.Tariff interface
 func (t *Ostrom) Type() api.TariffType {
 	switch t.contractType {
-	case ostrom.PRODUCT_DYNAMIC:
+	case ostrom.PRODUCT_DYNAMIC, ostrom.PRODUCT_DYNAMIC_V2:
 		return api.TariffTypePriceForecast
 	case ostrom.PRODUCT_FAIR, ostrom.PRODUCT_FAIR_CAP:
 		return api.TariffTypePriceStatic
 	default:
-		panic("invalid contract type: " + t.contractType)
+		log.ERROR.Printf("ostrom: unknown contract type %q, assuming dynamic", t.contractType)
+		return api.TariffTypePriceForecast
 	}
 }


### PR DESCRIPTION
Ostrom has introduced a new contract type `SimplyDynamic_V2` which  uses the same hourly dynamic pricing as `SIMPLY_DYNAMIC`, but is not  yet known to evcc, causing a panic on startup.

Changes:
- Add `PRODUCT_DYNAMIC_V2` constant for `SimplyDynamic_V2`
- Handle `SimplyDynamic_V2` the same as `SIMPLY_DYNAMIC` in `Type()`
- Replace `panic` with a log warning + safe fallback for any future  unknown contract types

Fixes #28719