### PR TITLE
Navigation: solid blur fallback

### DIFF
--- a/assets/js/components/BottomTabs/Bar.vue
+++ b/assets/js/components/BottomTabs/Bar.vue
@@ -98,11 +98,17 @@ export default defineComponent({
 <style scoped>
 .bottom-tab-bar {
 	z-index: 1030;
-	background: color-mix(in srgb, var(--tab-bar-background) 60%, transparent);
-	backdrop-filter: var(--evcc-backdrop-blur);
+	background: var(--tab-bar-background);
 	border-top: 1px solid var(--evcc-gray-25);
 	box-shadow: 0 -1px 6px var(--evcc-gray-25);
 	transition: transform var(--evcc-transition-fast) ease-in;
+}
+
+@supports (backdrop-filter: blur(1px)) {
+	.bottom-tab-bar {
+		background: color-mix(in srgb, var(--tab-bar-background) 60%, transparent);
+		backdrop-filter: var(--evcc-backdrop-blur);
+	}
 }
 
 .bottom-tab-bar--hidden {

--- a/assets/js/views/Sessions.vue
+++ b/assets/js/views/Sessions.vue
@@ -748,9 +748,15 @@ export default defineComponent({
 	right: 0;
 	top: max(0rem, env(safe-area-inset-top)) !important;
 	margin: 0 calc(calc(1.5rem + var(--vertical-shift)) * -1);
-	backdrop-filter: var(--evcc-backdrop-blur);
-	background-color: #0000;
+	background-color: var(--evcc-background);
 	box-shadow: 0 1px 8px 0px var(--evcc-background);
+}
+
+@supports (backdrop-filter: blur(1px)) {
+	.header-outer {
+		background-color: #0000;
+		backdrop-filter: var(--evcc-backdrop-blur);
+	}
 }
 
 @media (--sm-and-up) {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/28740

use solid background fallback if browser does not support blur
affects bottom nav and top sessions filter (time select)

macOS Safari 14 screenshots
<img width="854" height="591" alt="Bildschirmfoto 2026-04-02 um 17 05 54" src="https://github.com/user-attachments/assets/e9fdd534-e34a-43b3-bc79-edf8e9449d4a" />
<img width="836" height="601" alt="Bildschirmfoto 2026-04-02 um 17 03 13" src="https://github.com/user-attachments/assets/9afc028f-44eb-4a12-a6c9-0bbc87083e1e" />
