### PR TITLE
fix #28750: unsupported decode float32

### DIFF
--- a/plugin/aa55udp.go
+++ b/plugin/aa55udp.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"strings"
 	"time"
@@ -68,9 +69,9 @@ func NewAA55UDPFromConfig(_ context.Context, other map[string]interface{}) (Plug
 	}
 
 	switch cc.Decode {
-	case "int32be", "uint32be", "int16be", "uint16be":
+	case "int32be", "uint32be", "int16be", "uint16be", "float32be":
 	default:
-		return nil, fmt.Errorf("aa55udp: unsupported decode %q (want int32be|uint32be|int16be|uint16be)", cc.Decode)
+		return nil, fmt.Errorf("aa55udp: unsupported decode %q (want int32be|uint32be|int16be|uint16be|float32be)", cc.Decode)
 	}
 
 	pdu := buildPDU(cc.Register, cc.Count)
@@ -183,6 +184,12 @@ func stripAA55Header(buf []byte) ([]byte, error) {
 // interprets it according to decode.
 func decodeAt(payload []byte, offset int, decode string) (float64, error) {
 	switch decode {
+	case "float32be":
+		if len(payload) < offset+4 {
+			return 0, fmt.Errorf("payload too short for float32be at offset %d (len=%d)", offset, len(payload))
+		}
+		bits := binary.BigEndian.Uint32(payload[offset:])
+		return float64(math.Float32frombits(bits)), nil
 	case "int32be":
 		if len(payload) < offset+4 {
 			return 0, fmt.Errorf("payload too short for int32be at offset %d (len=%d)", offset, len(payload))

--- a/plugin/aa55udp_test.go
+++ b/plugin/aa55udp_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"math"
 	"net"
 	"testing"
 
@@ -151,6 +152,15 @@ func TestDecodeAt_Int16BE_Negative(t *testing.T) {
 	v, err := decodeAt(payload, 0, "int16be")
 	require.NoError(t, err)
 	assert.InDelta(t, -300.0, v, 0)
+}
+
+func TestDecodeAt_Float32BE(t *testing.T) {
+	payload := make([]byte, 4)
+	bits := math.Float32bits(123.456)
+	binary.BigEndian.PutUint32(payload, bits)
+	v, err := decodeAt(payload, 0, "float32be")
+	require.NoError(t, err)
+	assert.InDelta(t, 123.456, v, 0.001)
 }
 
 func TestDecodeAt_TooShort(t *testing.T) {

--- a/templates/definition/meter/goodwe-wifi-et.yaml
+++ b/templates/definition/meter/goodwe-wifi-et.yaml
@@ -23,7 +23,7 @@ render: |
     host: {{ .host }}
     register: 36017
     count: 2
-    decode: float32
+    decode: float32be
     scale: 0.001
   {{- end }}
   {{- if eq .usage "pv" }}


### PR DESCRIPTION
fix https://github.com/evcc-io/evcc/issues/28750#

Fix missing decode for et register in aa55udp plugin (and add big endian)