### PR TITLE
Tariffs: add OMIE day-ahead source for Portugal and Spain

### DIFF
--- a/templates/definition/tariff/omie.yaml
+++ b/templates/definition/tariff/omie.yaml
@@ -30,172 +30,118 @@ render: |
   {{ include "tariff-base" . }}
   {{ include "tariff-features" . }}
   forecast:
-    source: go
-    script: |
-      secondsPerHour := 3600
-      quarterHour := 15 * time.Minute
-      maxExpectedPeriod := 96
-      spanishPriceIndex := 2
-      portuguesePriceIndex := 3
-      spanishPriceHeaderHint := "espa"
-      portuguesePriceHeaderHint := "portug"
-      spanishStandardOffsetSeconds := 1 * secondsPerHour
-      spanishDaylightOffsetSeconds := 2 * secondsPerHour
-      portugueseStandardOffsetSeconds := 0
-      portugueseDaylightOffsetSeconds := 1 * secondsPerHour
+    source: http
+    uri: https://www.omie.es/sites/default/files/dados/NUEVA_SECCION/INT_PBC_EV_H_ACUM.TXT
+    cache: 1h
+    regex: '(?ms)((?:^[0-9]{2}/[0-9]{2}/[0-9]{4};[^\r\n]*(?:\r?\n|$))+)'
+    default: ""
+    quote: true
+    jq: |
+      def market:
+        {{ if eq .country "PT" }}
+        { code: "PT", priceIndex: 3 }
+        {{ else }}
+        { code: "ES", priceIndex: 2 }
+        {{ end }};
 
-      marketCode := "{{ .country }}"
-      priceIndex := spanishPriceIndex
-      priceHeaderHint := spanishPriceHeaderHint
-      standardOffsetSeconds := spanishStandardOffsetSeconds
-      daylightOffsetSeconds := spanishDaylightOffsetSeconds
+      def quarterHourSeconds: 900;
+      def standardOffsetSeconds: 3600;
+      def daylightOffsetSeconds: 7200;
 
-      switch marketCode {
-      case "ES":
-      case "PT":
-        priceIndex = portuguesePriceIndex
-        priceHeaderHint = portuguesePriceHeaderHint
-        standardOffsetSeconds = portugueseStandardOffsetSeconds
-        daylightOffsetSeconds = portugueseDaylightOffsetSeconds
-      default:
-        panic(fmt.Errorf("unsupported OMIE country: %q", marketCode))
-      }
+      def pad2:
+        tostring | if length == 1 then "0" + . else . end;
 
-      // The embedded Go runtime used by template scripts may not have IANA tzdata
-      // available. Keep the market-specific rules centralized here and only use
-      // FixedZone for the final timestamps.
+      def isoDate($y; $m; $d):
+        "\($y)-\($m | pad2)-\($d | pad2)";
 
-      lastSunday := func(year int, month time.Month) int {
-        day := time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC)
-        for day.Weekday() != time.Sunday {
-          day = day.AddDate(0, 0, -1)
-        }
-        return day.Day()
-      }
+      def lastSunday($y; $m):
+        first([31, 30, 29, 28, 27, 26, 25][] | select(((isoDate($y; $m; .) + "T00:00:00Z") | fromdateiso8601 | gmtime | .[6]) == 0));
 
-      marketOffsetAtUTC := func(ts time.Time) int {
-        year := ts.UTC().Year()
-        dstStart := time.Date(year, time.March, lastSunday(year, time.March), 1, 0, 0, 0, time.UTC)
-        dstEnd := time.Date(year, time.October, lastSunday(year, time.October), 1, 0, 0, 0, time.UTC)
-        if !ts.Before(dstStart) && ts.Before(dstEnd) {
-          return daylightOffsetSeconds
-        }
-        return standardOffsetSeconds
-      }
+      def marketStartOffsetSeconds($y; $m; $d):
+        if $m < 3 or $m > 10 then
+          standardOffsetSeconds
+        elif $m > 3 and $m < 10 then
+          daylightOffsetSeconds
+        elif $m == 3 then
+          if $d <= lastSunday($y; 3) then standardOffsetSeconds else daylightOffsetSeconds end
+        else
+          if $d <= lastSunday($y; 10) then daylightOffsetSeconds else standardOffsetSeconds end
+        end;
 
-      marketStartOfDayUTC := func(day time.Time) time.Time {
-        midnightLocal := time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, time.UTC)
-        midnightUTC := midnightLocal.Add(-time.Duration(standardOffsetSeconds) * time.Second)
-        if marketOffsetAtUTC(midnightUTC) == standardOffsetSeconds {
-          return midnightUTC
-        }
-        return midnightLocal.Add(-time.Duration(daylightOffsetSeconds) * time.Second)
-      }
+      def marketStartUtc($y; $m; $d):
+        ((isoDate($y; $m; $d) + "T00:00:00Z") | fromdateiso8601) - marketStartOffsetSeconds($y; $m; $d);
 
-      marketTime := func(ts time.Time) time.Time {
-        offset := marketOffsetAtUTC(ts)
-        return ts.In(time.FixedZone(marketCode, offset))
-      }
+      def parseDateParts:
+        split("/") | map(tonumber) | { d: .[0], m: .[1], y: .[2] };
 
-      var err error
-      cutoff := time.Now().UTC().Truncate(quarterHour)
-      lines := strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n")
+      def cutoffUtc:
+        ((now / quarterHourSeconds) | floor) * quarterHourSeconds;
 
-      var res strings.Builder
-      res.WriteString("[")
-      first := true
-      headerFound := false
-      parsed := 0
-
-      for _, line := range lines {
-        line = strings.TrimSpace(line)
-        if line == "" {
-          continue
-        }
-
-        fields := strings.Split(line, ";")
-
-        if !headerFound {
-          if len(fields) <= priceIndex {
-            continue
-          }
-
-          if strings.EqualFold(strings.TrimSpace(fields[0]), "Fecha") && strings.EqualFold(strings.TrimSpace(fields[1]), "Periodo") {
-            priceHeader := strings.ToLower(strings.TrimSpace(fields[priceIndex]))
-            if !strings.Contains(priceHeader, priceHeaderHint) {
-              panic(fmt.Errorf("unexpected OMIE %s price column: %q", marketCode, strings.TrimSpace(fields[priceIndex])))
-            }
-            headerFound = true
-          }
-
-          continue
-        }
-
-        if len(fields) <= priceIndex {
-          continue
-        }
-
-        var day time.Time
-        day, err = time.Parse("02/01/2006", strings.TrimSpace(fields[0]))
-        if err != nil {
-          continue
-        }
-
-        var period int
-        _, err = fmt.Sscanf(strings.TrimSpace(fields[1]), "%d", &period)
-        if err != nil || period < 1 || period > maxExpectedPeriod {
-          continue
-        }
-
-        priceText := strings.ReplaceAll(strings.TrimSpace(fields[priceIndex]), ",", ".")
-        if priceText == "" {
-          continue
-        }
-
-        var price float64
-        _, err = fmt.Sscanf(priceText, "%f", &price)
-        if err != nil {
-          continue
-        }
-
-        startUTC := marketStartOfDayUTC(day).Add(time.Duration(period-1) * quarterHour)
-        endUTC := startUTC.Add(quarterHour)
-        if !endUTC.After(cutoff) {
-          continue
-        }
-
-        start := marketTime(startUTC)
-        end := marketTime(endUTC)
-
-        parsed++
-
-        if !first {
-          res.WriteString(",")
-        }
-        first = false
-
-        res.WriteString(fmt.Sprintf(
-          "{\"start\":%q,\"end\":%q,\"value\":%.6f}",
-          start.Format(time.RFC3339),
-          end.Format(time.RFC3339),
-          price/1000,
-        ))
-      }
-
-      if !headerFound {
-        panic(fmt.Errorf("OMIE header not found"))
-      }
-
-      if parsed == 0 {
-        panic(fmt.Errorf("no OMIE %s rates parsed", marketCode))
-      }
-
-      res.WriteString("]")
-      res.String()
-    in:
-      - name: raw
-        type: string
-        config:
-          source: http
-          uri: https://www.omie.es/sites/default/files/dados/NUEVA_SECCION/INT_PBC_EV_H_ACUM.TXT
-          cache: 1h
+      split("\n")
+      | map(gsub("\r"; ""))
+      | map(select(length > 0)) as $lines
+      | if ($lines | length) == 0 then
+          error("OMIE data rows not found")
+        else
+          ($lines
+            | map(split(";"))
+            | map({
+                date: .[0],
+                dateParts: (.[0] | parseDateParts),
+                period: (.[1] | tonumber),
+                value: (.[(market.priceIndex)] | gsub(","; ".") | tonumber / 1000)
+              }
+              | . + .dateParts
+              | del(.dateParts)
+            )
+          ) as $entries
+          | if ($entries | length) == 0 then
+              error("no OMIE rows parsed")
+            else
+              $entries
+            end
+          | ($entries
+              | sort_by(.date, .period)
+              | group_by(.date)
+              | map(
+                  ([.[].period] | length) as $count
+                  | select($count == 92 or $count == 96 or $count == 100)
+                )
+            ) as $quarterHourDays
+          | if ($quarterHourDays | length) == 0 then
+              error("no OMIE quarter-hour days parsed")
+            else
+              $quarterHourDays
+            end
+          | ($quarterHourDays
+              | all(
+                  ([.[].period] | sort) as $periods
+                  | ($periods | length) as $count
+                  | ($periods == [range(1; $count + 1)])
+                )
+            ) as $validPeriods
+          | if ($validPeriods | not) then
+              error("unexpected OMIE period sequence")
+            else
+              ($quarterHourDays
+                | add
+                | sort_by(.y, .m, .d, .period)
+                | map(
+                    (marketStartUtc(.y; .m; .d) + ((.period - 1) * quarterHourSeconds)) as $start
+                    | ($start + quarterHourSeconds) as $end
+                    | select($end > cutoffUtc)
+                    | {
+                        start: ($start | todateiso8601),
+                        end: ($end | todateiso8601),
+                        value: .value
+                      }
+                  )
+              )
+            end
+          | if length == 0 then
+              error("no OMIE \(market.code) rates parsed")
+            else
+              .
+            end
+          | tostring
+        end

--- a/templates/definition/tariff/omie.yaml
+++ b/templates/definition/tariff/omie.yaml
@@ -45,8 +45,14 @@ render: |
         {{ end }};
 
       def quarterHourSeconds: 900;
+      def dstStartMonth: 3;
+      def dstEndMonth: 10;
       def standardOffsetSeconds: 3600;
       def daylightOffsetSeconds: 7200;
+      def shortDayPeriodCount: 92;
+      def normalDayPeriodCount: 96;
+      def longDayPeriodCount: 100;
+      def minimumRequiredColumnCount: market.priceIndex + 1;
 
       def pad2:
         tostring | if length == 1 then "0" + . else . end;
@@ -57,19 +63,32 @@ render: |
       def lastSunday($y; $m):
         first([31, 30, 29, 28, 27, 26, 25][] | select(((isoDate($y; $m; .) + "T00:00:00Z") | fromdateiso8601 | gmtime | .[6]) == 0));
 
+      def daylightSavingSwitchDay($y; $m):
+        lastSunday($y; $m);
+
+      def isStandardOffsetMonth($m):
+        $m < dstStartMonth or $m > dstEndMonth;
+
+      def isDaylightOffsetMonth($m):
+        $m > dstStartMonth and $m < dstEndMonth;
+
       def marketStartOffsetSeconds($y; $m; $d):
-        if $m < 3 or $m > 10 then
+        if isStandardOffsetMonth($m) then
           standardOffsetSeconds
-        elif $m > 3 and $m < 10 then
+        elif isDaylightOffsetMonth($m) then
           daylightOffsetSeconds
-        elif $m == 3 then
-          if $d <= lastSunday($y; 3) then standardOffsetSeconds else daylightOffsetSeconds end
+        elif $m == dstStartMonth then
+          if $d <= daylightSavingSwitchDay($y; dstStartMonth) then standardOffsetSeconds else daylightOffsetSeconds end
         else
-          if $d <= lastSunday($y; 10) then daylightOffsetSeconds else standardOffsetSeconds end
+          if $d <= daylightSavingSwitchDay($y; dstEndMonth) then daylightOffsetSeconds else standardOffsetSeconds end
         end;
 
       def marketStartUtc($y; $m; $d):
         ((isoDate($y; $m; $d) + "T00:00:00Z") | fromdateiso8601) - marketStartOffsetSeconds($y; $m; $d);
+
+      def isQuarterHourDay($day):
+        ([ $day[].period ] | length) as $count
+        | select($count == shortDayPeriodCount or $count == normalDayPeriodCount or $count == longDayPeriodCount);
 
       def parseDateParts:
         split("/") | map(tonumber) | { d: .[0], m: .[1], y: .[2] };
@@ -82,6 +101,8 @@ render: |
       | map(select(length > 0)) as $lines
       | if ($lines | length) == 0 then
           error("OMIE data rows not found")
+        elif (($lines[0] | split(";") | length) < minimumRequiredColumnCount) then
+          error("unexpected OMIE row layout")
         else
           ($lines
             | map(split(";"))
@@ -103,10 +124,7 @@ render: |
           | ($entries
               | sort_by(.date, .period)
               | group_by(.date)
-              | map(
-                  ([.[].period] | length) as $count
-                  | select($count == 92 or $count == 96 or $count == 100)
-                )
+              | map(isQuarterHourDay(.))
             ) as $quarterHourDays
           | if ($quarterHourDays | length) == 0 then
               error("no OMIE quarter-hour days parsed")

--- a/templates/definition/tariff/omie.yaml
+++ b/templates/definition/tariff/omie.yaml
@@ -32,38 +32,98 @@ render: |
   forecast:
     source: go
     script: |
-      loc, err := time.LoadLocation("Europe/Madrid")
-      if err != nil {
-        loc = time.Local
-      }
-
       priceIndex := 2
+      priceHeaderHint := "espa"
+      countryCode := "ES"
+      standardOffset := 3600
+      daylightOffset := 7200
       {{- if eq .country "PT" }}
       priceIndex = 3
+      priceHeaderHint = "portug"
+      countryCode = "PT"
+      standardOffset = 0
+      daylightOffset = 3600
       {{- end }}
 
-      cutoff := time.Now().In(loc).Truncate(15 * time.Minute)
+      lastSunday := func(year int, month time.Month) int {
+        day := time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC)
+        for day.Weekday() != time.Sunday {
+          day = day.AddDate(0, 0, -1)
+        }
+        return day.Day()
+      }
+
+      marketOffsetAtUTC := func(ts time.Time) int {
+        year := ts.UTC().Year()
+        dstStart := time.Date(year, time.March, lastSunday(year, time.March), 1, 0, 0, 0, time.UTC)
+        dstEnd := time.Date(year, time.October, lastSunday(year, time.October), 1, 0, 0, 0, time.UTC)
+        if !ts.Before(dstStart) && ts.Before(dstEnd) {
+          return daylightOffset
+        }
+        return standardOffset
+      }
+
+      marketMidnightUTC := func(day time.Time) time.Time {
+        midnightLocal := time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, time.UTC)
+        midnightUTC := midnightLocal.Add(-time.Duration(standardOffset) * time.Second)
+        if marketOffsetAtUTC(midnightUTC) == standardOffset {
+          return midnightUTC
+        }
+        return midnightLocal.Add(-time.Duration(daylightOffset) * time.Second)
+      }
+
+      marketTime := func(ts time.Time) time.Time {
+        offset := marketOffsetAtUTC(ts)
+        return ts.In(time.FixedZone(countryCode, offset))
+      }
+
+      var err error
+      cutoff := time.Now().UTC().Truncate(15 * time.Minute)
       lines := strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n")
 
       var res strings.Builder
       res.WriteString("[")
       first := true
+      headerFound := false
+      parsed := 0
 
       for _, line := range lines {
+        line = strings.TrimSpace(line)
+        if line == "" {
+          continue
+        }
+
         fields := strings.Split(line, ";")
+
+        if !headerFound {
+          if len(fields) <= priceIndex {
+            continue
+          }
+
+          if strings.EqualFold(strings.TrimSpace(fields[0]), "Fecha") && strings.EqualFold(strings.TrimSpace(fields[1]), "Periodo") {
+            priceHeader := strings.ToLower(strings.TrimSpace(fields[priceIndex]))
+            if !strings.Contains(priceHeader, priceHeaderHint) {
+              panic(fmt.Errorf("unexpected OMIE %s price column: %q", countryCode, strings.TrimSpace(fields[priceIndex])))
+            }
+            headerFound = true
+          }
+
+          continue
+        }
+
         if len(fields) <= priceIndex {
           continue
         }
 
         var day time.Time
-        day, err = time.ParseInLocation("02/01/2006", strings.TrimSpace(fields[0]), loc)
+        day, err = time.Parse("02/01/2006", strings.TrimSpace(fields[0]))
         if err != nil {
           continue
         }
 
         var period int
         _, err = fmt.Sscanf(strings.TrimSpace(fields[1]), "%d", &period)
-        if err != nil || period < 1 {
+        if err != nil || period < 1 || period > 100 {
           continue
         }
 
@@ -78,11 +138,16 @@ render: |
           continue
         }
 
-        start := day.Add(time.Duration(period-1) * 15 * time.Minute)
-        end := start.Add(15 * time.Minute)
-        if !end.After(cutoff) {
+        startUTC := marketMidnightUTC(day).Add(time.Duration(period-1) * 15 * time.Minute)
+        endUTC := startUTC.Add(15 * time.Minute)
+        if !endUTC.After(cutoff) {
           continue
         }
+
+        start := marketTime(startUTC)
+        end := marketTime(endUTC)
+
+        parsed++
 
         if !first {
           res.WriteString(",")
@@ -95,6 +160,14 @@ render: |
           end.Format(time.RFC3339),
           price/1000,
         ))
+      }
+
+      if !headerFound {
+        panic(fmt.Errorf("OMIE header not found"))
+      }
+
+      if parsed == 0 {
+        panic(fmt.Errorf("no OMIE %s rates parsed", countryCode))
       }
 
       res.WriteString("]")

--- a/templates/definition/tariff/omie.yaml
+++ b/templates/definition/tariff/omie.yaml
@@ -1,0 +1,105 @@
+template: omie
+products:
+  - brand: OMIE
+    description:
+      en: Iberian day-ahead market prices
+      de: Iberische Day-Ahead-Marktpreise
+requirements:
+  evcc: ["skiptest"]
+  description:
+    en: "Day-ahead electricity prices from OMIE for Portugal and Spain. No API key is required."
+    de: "Day-Ahead-Strompreise von OMIE fuer Portugal und Spanien. Es ist kein API-Schluessel erforderlich."
+group: price
+countries: ["PT", "ES"]
+params:
+  - name: country
+    description:
+      en: Country
+      de: Land
+    help:
+      en: Select whether to use the Portuguese or Spanish market price published by OMIE.
+      de: Waehlt aus, ob der von OMIE veroeffentlichte portugiesische oder spanische Marktpreis verwendet werden soll.
+    type: choice
+    choice: ["PT", "ES"]
+    default: PT
+    required: true
+  - preset: tariff-base
+  - preset: tariff-features
+render: |
+  type: custom
+  {{ include "tariff-base" . }}
+  {{ include "tariff-features" . }}
+  forecast:
+    source: go
+    script: |
+      loc, err := time.LoadLocation("Europe/Madrid")
+      if err != nil {
+        panic(err)
+      }
+
+      priceIndex := 2
+      {{- if eq .country "PT" }}
+      priceIndex = 3
+      {{- end }}
+
+      cutoff := time.Now().In(loc).Truncate(15 * time.Minute)
+      lines := strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n")
+
+      var res strings.Builder
+      res.WriteString("[")
+      first := true
+
+      for _, line := range lines {
+        fields := strings.Split(line, ";")
+        if len(fields) <= priceIndex {
+          continue
+        }
+
+        day, err := time.ParseInLocation("02/01/2006", strings.TrimSpace(fields[0]), loc)
+        if err != nil {
+          continue
+        }
+
+        var period int
+        if _, err := fmt.Sscanf(strings.TrimSpace(fields[1]), "%d", &period); err != nil || period < 1 {
+          continue
+        }
+
+        priceText := strings.ReplaceAll(strings.TrimSpace(fields[priceIndex]), ",", ".")
+        if priceText == "" {
+          continue
+        }
+
+        var price float64
+        if _, err := fmt.Sscanf(priceText, "%f", &price); err != nil {
+          continue
+        }
+
+        start := day.Add(time.Duration(period-1) * 15 * time.Minute)
+        end := start.Add(15 * time.Minute)
+        if !end.After(cutoff) {
+          continue
+        }
+
+        if !first {
+          res.WriteString(",")
+        }
+        first = false
+
+        res.WriteString(fmt.Sprintf(
+          "{\"start\":%q,\"end\":%q,\"value\":%.6f}",
+          start.Format(time.RFC3339),
+          end.Format(time.RFC3339),
+          price/1000,
+        ))
+      }
+
+      res.WriteString("]")
+      res.String()
+    in:
+      - name: raw
+        type: string
+        config:
+          source: http
+          uri: https://www.omie.es/sites/default/files/dados/NUEVA_SECCION/INT_PBC_EV_H_ACUM.TXT
+          cache: 1h

--- a/templates/definition/tariff/omie.yaml
+++ b/templates/definition/tariff/omie.yaml
@@ -32,18 +32,38 @@ render: |
   forecast:
     source: go
     script: |
-      priceIndex := 2
-      priceHeaderHint := "espa"
-      countryCode := "ES"
-      standardOffset := 3600
-      daylightOffset := 7200
-      {{- if eq .country "PT" }}
-      priceIndex = 3
-      priceHeaderHint = "portug"
-      countryCode = "PT"
-      standardOffset = 0
-      daylightOffset = 3600
-      {{- end }}
+      secondsPerHour := 3600
+      quarterHour := 15 * time.Minute
+      maxExpectedPeriod := 96
+      spanishPriceIndex := 2
+      portuguesePriceIndex := 3
+      spanishPriceHeaderHint := "espa"
+      portuguesePriceHeaderHint := "portug"
+      spanishStandardOffsetSeconds := 1 * secondsPerHour
+      spanishDaylightOffsetSeconds := 2 * secondsPerHour
+      portugueseStandardOffsetSeconds := 0
+      portugueseDaylightOffsetSeconds := 1 * secondsPerHour
+
+      marketCode := "{{ .country }}"
+      priceIndex := spanishPriceIndex
+      priceHeaderHint := spanishPriceHeaderHint
+      standardOffsetSeconds := spanishStandardOffsetSeconds
+      daylightOffsetSeconds := spanishDaylightOffsetSeconds
+
+      switch marketCode {
+      case "ES":
+      case "PT":
+        priceIndex = portuguesePriceIndex
+        priceHeaderHint = portuguesePriceHeaderHint
+        standardOffsetSeconds = portugueseStandardOffsetSeconds
+        daylightOffsetSeconds = portugueseDaylightOffsetSeconds
+      default:
+        panic(fmt.Errorf("unsupported OMIE country: %q", marketCode))
+      }
+
+      // The embedded Go runtime used by template scripts may not have IANA tzdata
+      // available. Keep the market-specific rules centralized here and only use
+      // FixedZone for the final timestamps.
 
       lastSunday := func(year int, month time.Month) int {
         day := time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC)
@@ -58,27 +78,27 @@ render: |
         dstStart := time.Date(year, time.March, lastSunday(year, time.March), 1, 0, 0, 0, time.UTC)
         dstEnd := time.Date(year, time.October, lastSunday(year, time.October), 1, 0, 0, 0, time.UTC)
         if !ts.Before(dstStart) && ts.Before(dstEnd) {
-          return daylightOffset
+          return daylightOffsetSeconds
         }
-        return standardOffset
+        return standardOffsetSeconds
       }
 
-      marketMidnightUTC := func(day time.Time) time.Time {
+      marketStartOfDayUTC := func(day time.Time) time.Time {
         midnightLocal := time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, time.UTC)
-        midnightUTC := midnightLocal.Add(-time.Duration(standardOffset) * time.Second)
-        if marketOffsetAtUTC(midnightUTC) == standardOffset {
+        midnightUTC := midnightLocal.Add(-time.Duration(standardOffsetSeconds) * time.Second)
+        if marketOffsetAtUTC(midnightUTC) == standardOffsetSeconds {
           return midnightUTC
         }
-        return midnightLocal.Add(-time.Duration(daylightOffset) * time.Second)
+        return midnightLocal.Add(-time.Duration(daylightOffsetSeconds) * time.Second)
       }
 
       marketTime := func(ts time.Time) time.Time {
         offset := marketOffsetAtUTC(ts)
-        return ts.In(time.FixedZone(countryCode, offset))
+        return ts.In(time.FixedZone(marketCode, offset))
       }
 
       var err error
-      cutoff := time.Now().UTC().Truncate(15 * time.Minute)
+      cutoff := time.Now().UTC().Truncate(quarterHour)
       lines := strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n")
 
       var res strings.Builder
@@ -103,7 +123,7 @@ render: |
           if strings.EqualFold(strings.TrimSpace(fields[0]), "Fecha") && strings.EqualFold(strings.TrimSpace(fields[1]), "Periodo") {
             priceHeader := strings.ToLower(strings.TrimSpace(fields[priceIndex]))
             if !strings.Contains(priceHeader, priceHeaderHint) {
-              panic(fmt.Errorf("unexpected OMIE %s price column: %q", countryCode, strings.TrimSpace(fields[priceIndex])))
+              panic(fmt.Errorf("unexpected OMIE %s price column: %q", marketCode, strings.TrimSpace(fields[priceIndex])))
             }
             headerFound = true
           }
@@ -123,7 +143,7 @@ render: |
 
         var period int
         _, err = fmt.Sscanf(strings.TrimSpace(fields[1]), "%d", &period)
-        if err != nil || period < 1 || period > 100 {
+        if err != nil || period < 1 || period > maxExpectedPeriod {
           continue
         }
 
@@ -138,8 +158,8 @@ render: |
           continue
         }
 
-        startUTC := marketMidnightUTC(day).Add(time.Duration(period-1) * 15 * time.Minute)
-        endUTC := startUTC.Add(15 * time.Minute)
+        startUTC := marketStartOfDayUTC(day).Add(time.Duration(period-1) * quarterHour)
+        endUTC := startUTC.Add(quarterHour)
         if !endUTC.After(cutoff) {
           continue
         }
@@ -167,7 +187,7 @@ render: |
       }
 
       if parsed == 0 {
-        panic(fmt.Errorf("no OMIE %s rates parsed", countryCode))
+        panic(fmt.Errorf("no OMIE %s rates parsed", marketCode))
       }
 
       res.WriteString("]")

--- a/templates/definition/tariff/omie.yaml
+++ b/templates/definition/tariff/omie.yaml
@@ -34,7 +34,7 @@ render: |
     script: |
       loc, err := time.LoadLocation("Europe/Madrid")
       if err != nil {
-        panic(err)
+        loc = time.Local
       }
 
       priceIndex := 2
@@ -55,13 +55,15 @@ render: |
           continue
         }
 
-        day, err := time.ParseInLocation("02/01/2006", strings.TrimSpace(fields[0]), loc)
+        var day time.Time
+        day, err = time.ParseInLocation("02/01/2006", strings.TrimSpace(fields[0]), loc)
         if err != nil {
           continue
         }
 
         var period int
-        if _, err := fmt.Sscanf(strings.TrimSpace(fields[1]), "%d", &period); err != nil || period < 1 {
+        _, err = fmt.Sscanf(strings.TrimSpace(fields[1]), "%d", &period)
+        if err != nil || period < 1 {
           continue
         }
 
@@ -71,7 +73,8 @@ render: |
         }
 
         var price float64
-        if _, err := fmt.Sscanf(priceText, "%f", &price); err != nil {
+        _, err = fmt.Sscanf(priceText, "%f", &price)
+        if err != nil {
           continue
         }
 


### PR DESCRIPTION
## Summary
- add an OMIE day-ahead tariff template for Portugal and Spain so evcc can consume the published quarter-hour market prices directly
- harden the OMIE parser against runtime/header issues and fail loudly when the upstream file format no longer matches the expected columns
- calculate Portugal and Spain market slots with explicit DST-aware offsets so Portugal no longer inherits Spain's local time handling

## Testing
- validated the OMIE tariff parser manually for both `country: PT` and `country: ES` using `evcc tariff grid` against the live OMIE feed