### PR TITLE
Easee: remove incorrect ReasonDisconnectRequired for ModeCompleted

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -795,8 +795,6 @@ func (c *Easee) StatusReason() (api.Reason, error) {
 	switch c.opMode {
 	case easee.ModeAwaitingAuthentication:
 		return api.ReasonWaitingForAuthorization, nil
-	case easee.ModeCompleted:
-		return api.ReasonDisconnectRequired, nil
 	}
 	return api.ReasonUnknown, nil
 }

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -224,7 +224,7 @@ func TestEasee_StatusReason(t *testing.T) {
 		expectedReason api.Reason
 	}{
 		{easee.ModeAwaitingAuthentication, api.ReasonWaitingForAuthorization},
-		{easee.ModeCompleted, api.ReasonDisconnectRequired},
+		{easee.ModeCompleted, api.ReasonUnknown},
 		{easee.ModeDisconnected, api.ReasonUnknown},
 		{easee.ModeAwaitingStart, api.ReasonUnknown},
 		{easee.ModeCharging, api.ReasonUnknown},


### PR DESCRIPTION
## Summary
- Remove `ReasonDisconnectRequired` mapping for Easee `ModeCompleted` (opMode=4)
- `ModeCompleted` means the car finished charging — returning `ReasonDisconnectRequired` caused evcc to display "charging aborted, waiting for vehicle" instead of properly recognizing charge completion

Fixes #28469

🤖 Generated with [Claude Code](https://claude.com/claude-code)