### PR TITLE
Add Stegen SmartEVSE v3 MQTT charger template

### DIFF
--- a/templates/definition/charger/stegen-smartevse-3.yaml
+++ b/templates/definition/charger/stegen-smartevse-3.yaml
@@ -44,8 +44,8 @@ params:
     en: MQTT topic prefix (e.g. SmartEVSE-8088)
     de: MQTT-Topic-Praefix (z.B. SmartEVSE-8088)
   help:
-    en: Found in SmartEVSE settings -> MQTT -> Topic prefix. Common formats: SmartEVSE-8088 or SmartEVSE/8088
-    de: In den SmartEVSE-Einstellungen unter MQTT -> Topic-Praefix. Gaengige Formate: SmartEVSE-8088 oder SmartEVSE/8088
+    en: Found in SmartEVSE web interface under Settings, MQTT, Topic prefix. Typical values are SmartEVSE-8088 or SmartEVSE/8088
+    de: In der SmartEVSE-Weboberflaeche unter Einstellungen, MQTT, Topic-Praefix. Typische Werte sind SmartEVSE-8088 oder SmartEVSE/8088
   example: "SmartEVSE-8088"
 - name: phases1p3p
   type: bool

--- a/templates/definition/charger/stegen-smartevse-3.yaml
+++ b/templates/definition/charger/stegen-smartevse-3.yaml
@@ -105,5 +105,5 @@ render: |
   phases1p3p:
     source: mqtt
     topic: {{ .topic }}/Set/EnableC2
-    payload: '{{"{{"}}.phases1p3p{{"}}"}}'
+    payload: '{{"{{"}}if eq .phases1p3p 3{{"}}"}}3{{"{{"}}else{{"}}"}}1{{"{{"}}end{{"}}"}}'
   {{- end }}

--- a/templates/definition/charger/stegen-smartevse-3.yaml
+++ b/templates/definition/charger/stegen-smartevse-3.yaml
@@ -1,0 +1,107 @@
+template: smartevse-3
+
+products:
+- brand: Stegen Smart EVSE
+  description:
+    generic: Smart EVSE v3 (MQTT)
+  capabilities: ["1p3p"]
+
+requirements:
+  description:
+    en: |
+      Requires SmartEVSE v3 firmware with MQTT and Pause mode support (v3.6+).
+      Verified against firmware fork [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5).
+
+      **Device setup:**
+      1. Enable MQTT on the SmartEVSE web interface (Settings → MQTT Broker)
+      2. Set the device Mode to **Normal** before connecting evcc
+      3. The MQTT topic prefix is shown on the SmartEVSE web interface (e.g. `SmartEVSE-1111`)
+
+      **evcc setup:**
+      - Configure the MQTT broker globally in evcc.yaml
+      - For phase switching, add `tos: true` to the loadpoint
+    de: |
+      Benötigt SmartEVSE v3 Firmware mit MQTT- und Pause-Modus-Unterstützung (v3.6+).
+      Verifiziert mit Firmware-Fork [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5).
+
+      **Gerätekonfiguration:**
+      1. MQTT auf der SmartEVSE-Weboberfläche aktivieren (Einstellungen → MQTT Broker)
+      2. Gerätmodus vor dem Verbinden mit evcc auf **Normal** setzen
+      3. Das MQTT Topic-Präfix ist in der SmartEVSE-Weboberfläche ersichtlich (z.B. `SmartEVSE-1111`)
+
+      **evcc-Konfiguration:**
+      - MQTT-Broker global in evcc.yaml konfigurieren
+      - Für Phasenumschaltung `tos: true` zum Ladepunkt hinzufügen
+
+params:
+- name: topic
+  description:
+    en: MQTT topic prefix as shown on the SmartEVSE web interface
+    de: MQTT Topic-Präfix wie auf der SmartEVSE-Weboberfläche angezeigt
+  example: SmartEVSE-1111
+- name: phases1p3p
+  type: bool
+  description:
+    en: Phase switching supported (C2 contactor installed, SmartEVSE SWITCH setting configured)
+    de: Phasenumschaltung unterstützt (C2-Schütz vorhanden, SmartEVSE SWITCH-Einstellung konfiguriert)
+  advanced: true
+  default: false
+
+render: |
+  type: custom
+  status:
+    source: combined
+    plugged:
+      source: mqtt
+      topic: {{ .topic }}/EVPlugState
+      timeout: 30s
+      quote: true
+      jq: '. == "Connected"'
+    charging:
+      source: mqtt
+      topic: {{ .topic }}/State
+      timeout: 30s
+      quote: true
+      jq: '. == "Charging" or . == "D" or . == "State C OK" or . == "Stop Charging"'
+  enabled:
+    source: mqtt
+    topic: {{ .topic }}/Mode
+    timeout: 30s
+    quote: true
+    jq: '. != "Pause" and . != "Off"'
+  enable:
+    source: mqtt
+    topic: {{ .topic }}/Set/Mode
+    payload: '{{"{{"}}if .enable{{"}}"}}Normal{{"{{"}}else{{"}}"}}Pause{{"{{"}}end{{"}}"}}'
+  maxcurrent:
+    source: mqtt
+    topic: {{ .topic }}/Set/CurrentOverride
+    payload: '{{"{{"}}int .maxcurrent | mul 10{{"}}"}}'
+  power:
+    source: mqtt
+    topic: {{ .topic }}/EVChargePower
+    timeout: 30s
+  energy:
+    source: mqtt
+    topic: {{ .topic }}/EVTotalEnergyCharged
+    timeout: 30s
+    scale: 0.001
+  currents:
+  - source: mqtt
+    topic: {{ .topic }}/EVCurrentL1
+    timeout: 30s
+    scale: 0.1
+  - source: mqtt
+    topic: {{ .topic }}/EVCurrentL2
+    timeout: 30s
+    scale: 0.1
+  - source: mqtt
+    topic: {{ .topic }}/EVCurrentL3
+    timeout: 30s
+    scale: 0.1
+  {{- if ne .phases1p3p "false" }}
+  phases1p3p:
+    source: mqtt
+    topic: {{ .topic }}/Set/EnableC2
+    payload: '{{"{{"}}.phases1p3p{{"}}"}}'
+  {{- end }}

--- a/templates/definition/charger/stegen-smartevse-3.yaml
+++ b/templates/definition/charger/stegen-smartevse-3.yaml
@@ -1,7 +1,7 @@
-template: smartevse-3
+template: stegen-smartevse-3
 
 products:
-- brand: Stegen Smart EVSE
+- brand: Stegen
   description:
     generic: Smart EVSE v3 (MQTT)
   capabilities: ["1p3p"]
@@ -9,13 +9,13 @@ products:
 requirements:
   description:
     en: |
-      Requires SmartEVSE v3 firmware with MQTT and Pause mode support (v3.6+).
+      Requires Smart EVSE v3 firmware with MQTT and Pause mode support (v3.6+).
       Verified against firmware fork [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5).
 
       **Device setup:**
       1. Enable MQTT on the SmartEVSE web interface (Settings → MQTT Broker)
       2. Set the device Mode to **Normal** before connecting evcc
-      3. The MQTT topic prefix is shown on the SmartEVSE web interface (e.g. `SmartEVSE-1111`)
+      3. Find your device serial number on the SmartEVSE web interface (e.g. `1111` from topic `SmartEVSE-1111`)
 
       **evcc setup:**
       - Configure the MQTT broker globally in evcc.yaml
@@ -27,18 +27,18 @@ requirements:
       **Gerätekonfiguration:**
       1. MQTT auf der SmartEVSE-Weboberfläche aktivieren (Einstellungen → MQTT Broker)
       2. Gerätmodus vor dem Verbinden mit evcc auf **Normal** setzen
-      3. Das MQTT Topic-Präfix ist in der SmartEVSE-Weboberfläche ersichtlich (z.B. `SmartEVSE-1111`)
+      3. Seriennummer in der SmartEVSE-Weboberfläche ablesen (z.B. `1111` aus Topic `SmartEVSE-1111`)
 
       **evcc-Konfiguration:**
       - MQTT-Broker global in evcc.yaml konfigurieren
       - Für Phasenumschaltung `tos: true` zum Ladepunkt hinzufügen
 
 params:
-- name: topic
+- name: serial
   description:
-    en: MQTT topic prefix as shown on the SmartEVSE web interface
-    de: MQTT Topic-Präfix wie auf der SmartEVSE-Weboberfläche angezeigt
-  example: SmartEVSE-1111
+    en: Device serial number (shown on the SmartEVSE web interface, e.g. 1111 from topic SmartEVSE-1111)
+    de: Seriennummer des Geräts (in der SmartEVSE-Weboberfläche, z.B. 1111 aus Topic SmartEVSE-1111)
+  example: "1111"
 - name: phases1p3p
   type: bool
   description:
@@ -53,55 +53,55 @@ render: |
     source: combined
     plugged:
       source: mqtt
-      topic: {{ .topic }}/EVPlugState
+      topic: SmartEVSE-{{ .serial }}/EVPlugState
       timeout: 30s
       quote: true
       jq: '. == "Connected"'
     charging:
       source: mqtt
-      topic: {{ .topic }}/State
+      topic: SmartEVSE-{{ .serial }}/State
       timeout: 30s
       quote: true
       jq: '. == "Charging" or . == "D" or . == "State C OK" or . == "Stop Charging"'
   enabled:
     source: mqtt
-    topic: {{ .topic }}/Mode
+    topic: SmartEVSE-{{ .serial }}/Mode
     timeout: 30s
     quote: true
     jq: '. != "Pause" and . != "Off"'
   enable:
     source: mqtt
-    topic: {{ .topic }}/Set/Mode
+    topic: SmartEVSE-{{ .serial }}/Set/Mode
     payload: '{{"{{"}}if .enable{{"}}"}}Normal{{"{{"}}else{{"}}"}}Pause{{"{{"}}end{{"}}"}}'
   maxcurrent:
     source: mqtt
-    topic: {{ .topic }}/Set/CurrentOverride
+    topic: SmartEVSE-{{ .serial }}/Set/CurrentOverride
     payload: '{{"{{"}}int .maxcurrent | mul 10{{"}}"}}'
   power:
     source: mqtt
-    topic: {{ .topic }}/EVChargePower
+    topic: SmartEVSE-{{ .serial }}/EVChargePower
     timeout: 30s
   energy:
     source: mqtt
-    topic: {{ .topic }}/EVTotalEnergyCharged
+    topic: SmartEVSE-{{ .serial }}/EVTotalEnergyCharged
     timeout: 30s
     scale: 0.001
   currents:
   - source: mqtt
-    topic: {{ .topic }}/EVCurrentL1
+    topic: SmartEVSE-{{ .serial }}/EVCurrentL1
     timeout: 30s
     scale: 0.1
   - source: mqtt
-    topic: {{ .topic }}/EVCurrentL2
+    topic: SmartEVSE-{{ .serial }}/EVCurrentL2
     timeout: 30s
     scale: 0.1
   - source: mqtt
-    topic: {{ .topic }}/EVCurrentL3
+    topic: SmartEVSE-{{ .serial }}/EVCurrentL3
     timeout: 30s
     scale: 0.1
   {{- if ne .phases1p3p "false" }}
   phases1p3p:
     source: mqtt
-    topic: {{ .topic }}/Set/EnableC2
+    topic: SmartEVSE-{{ .serial }}/Set/EnableC2
     payload: '{{"{{"}}.phases1p3p{{"}}"}}'
   {{- end }}

--- a/templates/definition/charger/stegen-smartevse-3.yaml
+++ b/templates/definition/charger/stegen-smartevse-3.yaml
@@ -9,99 +9,101 @@ products:
 requirements:
   description:
     en: |
-      Requires Smart EVSE v3 firmware with MQTT and Pause mode support (v3.6+).
+      Requires SmartEVSE v3 firmware with MQTT and Pause mode support (v3.6+).
       Verified against firmware fork [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5).
 
       **Device setup:**
-      1. Enable MQTT on the SmartEVSE web interface (Settings → MQTT Broker)
+      1. Enable MQTT on the SmartEVSE web interface (Settings -> MQTT Broker)
       2. Set the device Mode to **Normal** before connecting evcc
-      3. Find your device serial number on the SmartEVSE web interface (e.g. `1111` from topic `SmartEVSE-1111`)
+      3. Find your MQTT topic prefix and IP address on the SmartEVSE web interface (Settings -> MQTT)
 
       **evcc setup:**
       - Configure the MQTT broker globally in evcc.yaml
-      - For phase switching, add `tos: true` to the loadpoint
+      - Phase switching is enabled via the `phases1p3p` parameter
     de: |
-      Benötigt SmartEVSE v3 Firmware mit MQTT- und Pause-Modus-Unterstützung (v3.6+).
+      Benoetigt SmartEVSE v3 Firmware mit MQTT- und Pause-Modus-Unterstuetzung (v3.6+).
       Verifiziert mit Firmware-Fork [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5).
 
-      **Gerätekonfiguration:**
-      1. MQTT auf der SmartEVSE-Weboberfläche aktivieren (Einstellungen → MQTT Broker)
-      2. Gerätmodus vor dem Verbinden mit evcc auf **Normal** setzen
-      3. Seriennummer in der SmartEVSE-Weboberfläche ablesen (z.B. `1111` aus Topic `SmartEVSE-1111`)
+      **Geraetekonfiguration:**
+      1. MQTT auf der SmartEVSE-Weboberflaeche aktivieren (Einstellungen -> MQTT Broker)
+      2. Geraetmodus vor dem Verbinden mit evcc auf **Normal** setzen
+      3. MQTT-Topic-Praefix und IP-Adresse in der SmartEVSE-Weboberflaeche ablesen (Einstellungen -> MQTT)
 
       **evcc-Konfiguration:**
       - MQTT-Broker global in evcc.yaml konfigurieren
-      - Für Phasenumschaltung `tos: true` zum Ladepunkt hinzufügen
+      - Phasenumschaltung wird ueber den Parameter `phases1p3p` aktiviert
 
 params:
-- name: serial
+- name: host
   description:
-    en: Device serial number (shown on the SmartEVSE web interface, e.g. 1111 from topic SmartEVSE-1111)
-    de: Seriennummer des Geräts (in der SmartEVSE-Weboberfläche, z.B. 1111 aus Topic SmartEVSE-1111)
-  example: "1111"
+    en: SmartEVSE IP address or hostname
+    de: IP-Adresse oder Hostname des SmartEVSE
+  example: "192.168.1.100"
+- name: topic
+  description:
+    en: MQTT topic prefix (e.g. SmartEVSE-8088)
+    de: MQTT-Topic-Praefix (z.B. SmartEVSE-8088)
+  help:
+    en: Found in SmartEVSE settings -> MQTT -> Topic prefix. Common formats: SmartEVSE-8088 or SmartEVSE/8088
+    de: In den SmartEVSE-Einstellungen unter MQTT -> Topic-Praefix. Gaengige Formate: SmartEVSE-8088 oder SmartEVSE/8088
+  example: "SmartEVSE-8088"
 - name: phases1p3p
   type: bool
   description:
-    en: Phase switching supported (C2 contactor installed, SmartEVSE SWITCH setting configured)
-    de: Phasenumschaltung unterstützt (C2-Schütz vorhanden, SmartEVSE SWITCH-Einstellung konfiguriert)
+    en: Phase switching (C2 contactor installed)
+    de: Phasenumschaltung (C2-Schuetz vorhanden)
+  help:
+    en: Requires C2 contactor and SmartEVSE SWITCH setting configured
+    de: Erfordert C2-Schuetz und konfigurierte SmartEVSE SWITCH-Einstellung
   advanced: true
   default: false
 
 render: |
   type: custom
+  tos: true
   status:
-    source: combined
-    plugged:
-      source: mqtt
-      topic: SmartEVSE-{{ .serial }}/EVPlugState
-      timeout: 30s
-      quote: true
-      jq: '. == "Connected"'
-    charging:
-      source: mqtt
-      topic: SmartEVSE-{{ .serial }}/State
-      timeout: 30s
-      quote: true
-      jq: '. == "Charging" or . == "D" or . == "State C OK" or . == "Stop Charging"'
+    source: http
+    uri: http://{{ .host }}/settings
+    jq: 'if .car_connected == false then "A" elif .evse.state_id == 2 or .evse.state_id == 3 then "C" else "B" end'
   enabled:
     source: mqtt
-    topic: SmartEVSE-{{ .serial }}/Mode
+    topic: {{ .topic }}/Mode
     timeout: 30s
     quote: true
     jq: '. != "Pause" and . != "Off"'
   enable:
     source: mqtt
-    topic: SmartEVSE-{{ .serial }}/Set/Mode
+    topic: {{ .topic }}/Set/Mode
     payload: '{{"{{"}}if .enable{{"}}"}}Normal{{"{{"}}else{{"}}"}}Pause{{"{{"}}end{{"}}"}}'
   maxcurrent:
     source: mqtt
-    topic: SmartEVSE-{{ .serial }}/Set/CurrentOverride
+    topic: {{ .topic }}/Set/CurrentOverride
     payload: '{{"{{"}}int .maxcurrent | mul 10{{"}}"}}'
   power:
     source: mqtt
-    topic: SmartEVSE-{{ .serial }}/EVChargePower
+    topic: {{ .topic }}/EVChargePower
     timeout: 30s
   energy:
     source: mqtt
-    topic: SmartEVSE-{{ .serial }}/EVTotalEnergyCharged
+    topic: {{ .topic }}/EVTotalEnergyCharged
     timeout: 30s
     scale: 0.001
   currents:
   - source: mqtt
-    topic: SmartEVSE-{{ .serial }}/EVCurrentL1
+    topic: {{ .topic }}/EVCurrentL1
     timeout: 30s
     scale: 0.1
   - source: mqtt
-    topic: SmartEVSE-{{ .serial }}/EVCurrentL2
+    topic: {{ .topic }}/EVCurrentL2
     timeout: 30s
     scale: 0.1
   - source: mqtt
-    topic: SmartEVSE-{{ .serial }}/EVCurrentL3
+    topic: {{ .topic }}/EVCurrentL3
     timeout: 30s
     scale: 0.1
   {{- if ne .phases1p3p "false" }}
   phases1p3p:
     source: mqtt
-    topic: SmartEVSE-{{ .serial }}/Set/EnableC2
+    topic: {{ .topic }}/Set/EnableC2
     payload: '{{"{{"}}.phases1p3p{{"}}"}}'
   {{- end }}

--- a/templates/definition/charger/stegen-smartevse-3.yaml
+++ b/templates/definition/charger/stegen-smartevse-3.yaml
@@ -4,7 +4,7 @@ products:
 - brand: Stegen
   description:
     generic: Smart EVSE v3 (MQTT)
-  capabilities: ["1p3p"]
+capabilities: ["1p3p"]
 
 requirements:
   description:

--- a/templates/definition/charger/stegen-smartevse-3.yaml
+++ b/templates/definition/charger/stegen-smartevse-3.yaml
@@ -1,11 +1,9 @@
 template: stegen-smartevse-3
-
 products:
-- brand: Stegen
-  description:
-    generic: Smart EVSE v3 (MQTT)
+  - brand: Stegen
+    description:
+      generic: Smart EVSE v3 (MQTT)
 capabilities: ["1p3p"]
-
 requirements:
   description:
     en: |
@@ -32,32 +30,30 @@ requirements:
       **evcc-Konfiguration:**
       - MQTT-Broker global in evcc.yaml konfigurieren
       - Phasenumschaltung wird ueber den Parameter `phases1p3p` aktiviert
-
 params:
-- name: host
-  description:
-    en: SmartEVSE IP address or hostname
-    de: IP-Adresse oder Hostname des SmartEVSE
-  example: "192.168.1.100"
-- name: topic
-  description:
-    en: MQTT topic prefix (e.g. SmartEVSE-8088)
-    de: MQTT-Topic-Praefix (z.B. SmartEVSE-8088)
-  help:
-    en: Found in SmartEVSE web interface under Settings, MQTT, Topic prefix. Typical values are SmartEVSE-8088 or SmartEVSE/8088
-    de: In der SmartEVSE-Weboberflaeche unter Einstellungen, MQTT, Topic-Praefix. Typische Werte sind SmartEVSE-8088 oder SmartEVSE/8088
-  example: "SmartEVSE-8088"
-- name: phases1p3p
-  type: bool
-  description:
-    en: Phase switching (C2 contactor installed)
-    de: Phasenumschaltung (C2-Schuetz vorhanden)
-  help:
-    en: Requires C2 contactor and SmartEVSE SWITCH setting configured
-    de: Erfordert C2-Schuetz und konfigurierte SmartEVSE SWITCH-Einstellung
-  advanced: true
-  default: false
-
+  - name: host
+    description:
+      en: SmartEVSE IP address or hostname
+      de: IP-Adresse oder Hostname des SmartEVSE
+    example: "192.168.1.100"
+  - name: topic
+    description:
+      en: MQTT topic prefix (e.g. SmartEVSE-8088)
+      de: MQTT-Topic-Praefix (z.B. SmartEVSE-8088)
+    help:
+      en: Found in SmartEVSE web interface under Settings, MQTT, Topic prefix. Typical values are SmartEVSE-8088 or SmartEVSE/8088
+      de: In der SmartEVSE-Weboberflaeche unter Einstellungen, MQTT, Topic-Praefix. Typische Werte sind SmartEVSE-8088 oder SmartEVSE/8088
+    example: "SmartEVSE-8088"
+  - name: phases1p3p
+    type: bool
+    description:
+      en: Phase switching (C2 contactor installed)
+      de: Phasenumschaltung (C2-Schuetz vorhanden)
+    help:
+      en: Requires C2 contactor and SmartEVSE SWITCH setting configured
+      de: Erfordert C2-Schuetz und konfigurierte SmartEVSE SWITCH-Einstellung
+    advanced: true
+    default: false
 render: |
   type: custom
   tos: true


### PR DESCRIPTION
# Add Stegen Smart EVSE v3 MQTT charger template
_Note: this PR description was updated to reflect the latest changes in the charger template (move to http for status detection, predominantly)_
## Summary

Adds `stegen-smartevse-3.yaml` — a new charger template for the Stegen Smart EVSE v3 using the HTTP REST API for status and MQTT for control. See [this thread](https://github.com/evcc-io/evcc/discussions/10718) for a discussion on this particular charger.

The existing `smartevse.yaml` is for a different, but similarly named product. There is no relation between the products.

Verified against firmware fork [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5) (v3.10.2), which is the actively maintained community fork of the original [SmartEVSE/SmartEVSE-3](https://github.com/SmartEVSE/SmartEVSE-3) firmware.

## What it does

- **Status** — uses `source: http` to poll the device REST API (`/settings` endpoint). A single response contains both `car_connected` (physical cable presence, pilot-independent) and `evse.state_id` (IEC 61851 numeric state). This avoids the MQTT Pause mode deadlock where `State` stays `"Ready to Charge"` even when a car connects (pilot is inactive in Pause), making it impossible to detect the vehicle via MQTT alone.

  | Response field | Value | evcc status |
  |---|---|---|
  | `.car_connected == false` | no vehicle | A |
  | `.evse.state_id == 2 or 3` | Charging / Charging+ventilation | C |
  | else | vehicle connected, not charging | B |

- **Enable/disable** — publishes `Normal`/`Pause` to `Set/Mode`. `Pause` stops charging while keeping the pilot signal alive and preserving any OCPP transaction, as per the firmware's release notes.

- **Current control** — publishes to `Set/CurrentOverride` in deci-Amperes (firmware unit). Payload multiplies evcc's amp value by 10.

- **Phase switching** — publishes `1` (Always Off / single-phase) or `3` (Always On / three-phase) to `Set/EnableC2`. Optional, controlled by the `phases1p3p` template parameter.

- **Metering** — reads `EVChargePower` (W), `EVTotalEnergyCharged` (Wh, scaled to kWh), and `EVCurrentL1/L2/L3` (deci-Amperes, scaled to A) via MQTT.

## MQTT topic behaviour verified against firmware source

| Topic | Unit | Notes |
|---|---|---|
| `Mode` | string | `"Normal"`/`"Smart"`/`"Solar"` when `Access=ON`, `"Pause"` when `Access=PAUSE`, `"Off"` when `Access=OFF` |
| `Set/Mode` | string | Accepts `"Normal"`, `"Smart"`, `"Solar"`, `"Pause"`, `"Off"` — numeric values NOT accepted |
| `Set/CurrentOverride` | deci-Amperes | Validated by firmware against `MinCurrent*10`..`MaxCurrent*10` range |
| `EVCurrentL1/L2/L3` | deci-Amperes | `EVMeter.Irms[]` — divide by 10 for Amperes |
| `EVChargePower` | Watts | `EVMeter.PowerMeasured` |
| `EVTotalEnergyCharged` | Wh | `EVMeter.Energy` |
| `Set/EnableC2` | int | `0`=Not present, `1`=Always Off, `2`=Solar Off, `3`=Always On, `4`=Auto |

## REST API fields used for status

| Field | Values | Notes |
|---|---|---|
| `.car_connected` | `true`/`false` | Physical cable presence, independent of Mode/pilot state |
| `.evse.state_id` | int | IEC 61851 state: `2`=Charging, `3`=Charging+ventilation (D) |

Endpoint: `GET http://<host>/settings`










## Testing

Tested with:
- Stegen Smart EVSE v3 firmware v3.10.2 (dingo35/SmartEVSE-3.5 fork)
- evcc solar charging mode with 1p3p phase switching
- MQTT broker: Mosquitto

**Functional scenarios tested:**
- Car connect/disconnect detection including when Mode=Pause (deadlock scenario)
- Solar current throttling via `Set/CurrentOverride`
- Enable (Normal) / disable (Pause) during active session
- Phase switching via `Set/EnableC2`
- Power, energy, and per-phase current reporting

## Configuration example

```yaml
chargers:
  - name: smartevse
    type: template
    template: stegen-smartevse-3
    host: "192.168.1.100"    # SmartEVSE IP address or hostname
    topic: "SmartEVSE-1111" # MQTT topic prefix (Settings -> MQTT -> Topic prefix)
    phases1p3p: true         # only if C2 contactor is installed

loadpoints:
  - title: EV Charger
    charger: smartevse
    phases: 1
    guardduration: 5m       # protect C2 contactor between phase switches
    mincurrent: 6
    maxcurrent: 16
```

## Related
- SmartEVSE firmware: https://github.com/SmartEVSE/SmartEVSE-3
- Active fork: https://github.com/dingo35/SmartEVSE-3.5
- MQTT API docs: https://github.com/SmartEVSE/SmartEVSE-3/blob/master/docs/configuration.md#mqtt-api
- REST API: `GET http://<host>/settings`