### PR TITLE
MG: add trace logging for decoded API responses

### DIFF
--- a/vehicle/saic/api.go
+++ b/vehicle/saic/api.go
@@ -127,6 +127,8 @@ func doRequest[T any](v *API, req *http.Request, result *requests.Answer[T]) (st
 			return event_id, fmt.Errorf("decrypt: %w", err2)
 		}
 
+		v.log.TRACE.Printf("decoded response: %s", body)
+
 		if err2 := json.Unmarshal(body, result); err2 == nil && result.Code != 0 {
 			if result.Code == 4 {
 				err = api.ErrMustRetry

--- a/vehicle/saic/api.go
+++ b/vehicle/saic/api.go
@@ -127,7 +127,7 @@ func doRequest[T any](v *API, req *http.Request, result *requests.Answer[T]) (st
 			return event_id, fmt.Errorf("decrypt: %w", err2)
 		}
 
-		v.log.TRACE.Printf("decoded response: %s", body)
+		v.log.TRACE.Printf("recv: %s", body)
 
 		if err2 := json.Unmarshal(body, result); err2 == nil && result.Code != 0 {
 			if result.Code == 4 {


### PR DESCRIPTION
Log decrypted API response bodies at TRACE level to aid debugging of MG/SAIC vehicle communication issues.

Refs https://github.com/evcc-io/evcc/issues/28420