### PR TITLE
Add battery control to Zendure Solarflow templates

### DIFF
--- a/templates/definition/meter/zendure-solarflow-ac.yaml
+++ b/templates/definition/meter/zendure-solarflow-ac.yaml
@@ -4,12 +4,31 @@ products:
   - brand: Zendure
     description:
       generic: Solarflow AC
+capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Für die aktive Batteriesteuerung muss die lokale API über die Zendure App aktiviert werden (HEMS hinzufügen und wieder verlassen).
+      Die Seriennummer des Geräts ist in der Zendure App in den Geräteeinstellungen zu finden.
+    en: |
+      For active battery control, the local API must be enabled via the Zendure App (add HEMS and then exit to apply).
+      The device serial number can be found in the Zendure App in the device settings.
 params:
   - name: usage
     choice: ["battery"]
   - name: host
     required: true
+  - name: serial
+    required: true
+    example: WOB1NHMAMXXXXX3
+    help:
+      de: Seriennummer des Geräts (zu finden in der Zendure App)
+      en: Device serial number (can be found in the Zendure App)
   - preset: battery-params
+  - name: maxchargepower
+    default: 1200
+  - name: maxdischargepower
+    default: 800
   - name: cache
     advanced: true
     default: 1s
@@ -25,4 +44,35 @@ render: |
     uri: http://{{ .host }}/properties/report
     jq: .properties.electricLevel
     cache: {{ .cache }}
+  batterymode:
+    source: watchdog
+    timeout: 60s
+    reset: 1 # reset to normal
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"outputLimit":{{ .maxdischargepower }},"inputLimit":{{ .maxchargepower }}}}'
+      - case: 2 # hold
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"outputLimit":0}}'
+      - case: 3 # charge
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"outputLimit":0,"inputLimit":{{ .maxchargepower }}}}'
   {{- include "battery-params" . }}

--- a/templates/definition/meter/zendure-solarflow-pro.yaml
+++ b/templates/definition/meter/zendure-solarflow-pro.yaml
@@ -3,13 +3,33 @@ products:
   - brand: Zendure
     description:
       generic: Solarflow 800 Pro
+capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Für die aktive Batteriesteuerung muss die lokale API über die Zendure App aktiviert werden (HEMS hinzufügen und wieder verlassen).
+      Die Seriennummer des Geräts ist in der Zendure App in den Geräteeinstellungen zu finden.
+    en: |
+      For active battery control, the local API must be enabled via the Zendure App (add HEMS and then exit to apply).
+      The device serial number can be found in the Zendure App in the device settings.
 params:
   - name: usage
     choice: ["pv", "battery"]
   - name: host
+  - name: serial
+    required: true
+    example: WOB1NHMAMXXXXX3
+    usages: ["battery"]
+    help:
+      de: Seriennummer des Geräts (zu finden in der Zendure App)
+      en: Device serial number (can be found in the Zendure App)
   - name: maxacpower
     default: 800 # W
   - preset: battery-params
+  - name: maxchargepower
+    default: 800
+  - name: maxdischargepower
+    default: 800
   - name: capacity
     default: 1.92 # kWh
   - name: cache
@@ -36,5 +56,36 @@ render: |
     uri: http://{{ .host }}/properties/report
     jq: .properties.electricLevel
     cache: {{ .cache }}
+  batterymode:
+    source: watchdog
+    timeout: 60s
+    reset: 1 # reset to normal
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"outputLimit":{{ .maxdischargepower }},"inputLimit":{{ .maxchargepower }}}}'
+      - case: 2 # hold
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"outputLimit":0}}'
+      - case: 3 # charge
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"outputLimit":0,"inputLimit":{{ .maxchargepower }}}}'
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
## Summary
- Add battery control (`batterymode`) to **Zendure Solarflow AC** and **Solarflow 800 Pro** templates using the [ZenSDK](https://github.com/Zendure/zenSDK) local REST API (`POST /properties/write`)
- Supports all three battery modes: **normal** (restore limits), **hold** (prevent discharge via `outputLimit: 0`), and **charge** (force grid charging via `inputLimit`)
- Uses `smartMode: 1` to avoid flash wear on frequent automated writes
- Includes a 60s watchdog that resets to normal mode if evcc stops communicating
- New required parameter `serial` (device serial number) for the write API; scoped to battery usage only on the Pro template

## How it works

The ZenSDK exposes a local HTTP API on the device (no authentication). Battery control is achieved by writing `inputLimit` (charge power) and `outputLimit` (discharge power) properties:

| Mode | outputLimit | inputLimit |
|------|-----------|-----------|
| Normal | maxdischargepower | maxchargepower |
| Hold | 0 | (unchanged) |
| Charge | 0 | maxchargepower |

## Prerequisites

The local API must be enabled via the Zendure App (add HEMS and then exit to apply), per [EN 18031 compliance](https://github.com/Zendure/zenSDK#readme).

## Test plan
- [ ] Verify Solarflow AC template renders correctly with `serial` parameter
- [ ] Verify Solarflow Pro template renders correctly (battery usage with `serial`, PV usage without)
- [ ] Test battery mode switching on actual Zendure hardware (normal → hold → charge → normal)
- [ ] Verify watchdog resets to normal after 60s timeout

Refs: https://github.com/evcc-io/evcc/discussions/15946#discussioncomment-16439041

🤖 Generated with [Claude Code](https://claude.com/claude-code)