### PR TITLE
TWC3: ignore MaxCurrent when vehicle does not support current control

### DIFF
--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -139,9 +139,12 @@ func (c *Twc3) MaxCurrent(current int64) error {
 
 	v, ok := api.Cap[api.CurrentController](c.lp.GetVehicle())
 	if !ok {
-		// vehicle does not support current control- ignore silently
-		// since TWC3 cannot limit current on its own
-		return nil
+		if c.lp.GetMode() == api.ModeNow {
+			// vehicle does not support current control- ignore silently
+			// since TWC3 cannot limit current on its own
+			return nil
+		}
+		return errors.New("vehicle not capable of current control")
 	}
 
 	return v.MaxCurrent(current)

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -139,7 +139,9 @@ func (c *Twc3) MaxCurrent(current int64) error {
 
 	v, ok := api.Cap[api.CurrentController](c.lp.GetVehicle())
 	if !ok {
-		return errors.New("vehicle not capable of current control")
+		// vehicle does not support current control- ignore silently
+		// since TWC3 cannot limit current on its own
+		return nil
 	}
 
 	return v.MaxCurrent(current)


### PR DESCRIPTION
The TWC3 wallbox delegates MaxCurrent() to the vehicle since it has no hardware current control of its own. When a non-Tesla vehicle is connected (e.g. Renault ZOE) that does not implement [api.CurrentController](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), this returns an error every cycle (~10s).

Because the error prevents offeredCurrent from being updated in the loadpoint, the equality check [current != lp.offeredCurrent](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) never short-circuits, causing an infinite error loop:

[lp-2] ERROR set charge current limit 16A: vehicle not capable of current control

Only Tesla and Fiat/Stellantis vehicles implement CurrentController. All other vehicles trigger this error when used with a TWC3.

Fix: Return nil instead of an error when the vehicle lacks current control capability. The TWC3 physically cannot limit current anyway — the vehicle charges at whatever the pilot signal allows. This lets the loadpoint update offeredCurrent and skip redundant calls on subsequent cycles.