### PR TITLE
fix(tesla): pre-set EU base URL from JWT ou_code claim

### DIFF
--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evcc-io/evcc/util/transport"
 	"github.com/evcc-io/evcc/vehicle/tesla"
 	teslaclient "github.com/evcc-io/tesla-proxy-client"
+	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 )
 
@@ -74,6 +75,15 @@ func NewTeslaFromConfig(other map[string]any) (api.Vehicle, error) {
 	tc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(hc))
 	if err != nil {
 		return nil, err
+	}
+
+	// set base url for EU users to avoid client_not_found on NA region endpoint
+	var jwtClaims struct {
+		OuCode string `json:"ou_code"`
+		jwt.RegisteredClaims
+	}
+	if _, _, err := jwt.NewParser().ParseUnverified(token.AccessToken, &jwtClaims); err == nil && jwtClaims.OuCode == "EU" {
+		tc.SetBaseUrl(teslaclient.FleetAudienceEU)
 	}
 
 	// validate base url


### PR DESCRIPTION
EU-registered Tesla apps receive 'client_not_found' when evcc queries the default NA region endpoint (fleet-api.prd.na.vn.cloud.tesla.com) to determine the user's region. The NA endpoint doesn't know about apps registered only in the EU.

Fix: parse the ou_code claim from the access token JWT before calling UserRegion(). If ou_code == 'EU', pre-set the base URL to the EU Fleet API endpoint so the region lookup succeeds.

Fixes #28153