### PR TITLE
fix: stop OCPP tickers to prevent goroutine leaks

### DIFF
--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -113,7 +113,10 @@ func (conn *Connector) GetScheduleLimit(duration int) (float64, error) {
 // WatchDog triggers meter values messages if older than timeout.
 // Must be wrapped in a goroutine.
 func (conn *Connector) WatchDog(ctx context.Context, timeout time.Duration) {
-	for tick := time.NewTicker(2 * time.Second); ; {
+	tick := time.NewTicker(2 * time.Second)
+	defer tick.Stop()
+
+	for {
 		conn.mu.Lock()
 		update := conn.clock.Since(conn.meterUpdated) > timeout
 		conn.mu.Unlock()

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -99,8 +99,10 @@ func Instance() *CS {
 		go cs.Start(port, "/{ws}")
 
 		// wait for server to start
-		for range time.Tick(10 * time.Millisecond) {
+		tick := time.NewTicker(10 * time.Millisecond)
+		for range tick.C {
 			if dispatcher.IsRunning() {
+				tick.Stop()
 				break
 			}
 		}


### PR DESCRIPTION
Found two ticker leaks in `charger/ocpp`:

**connector.go — WatchDog**
The ticker was created inside the `for` loop initializer (`for tick := time.NewTicker(…); ; {`), so when the context was cancelled and the goroutine returned, `tick.Stop()` was never called. Every charge-point reconnect leaked a goroutine that kept firing every 2s forever. I moved the ticker before the loop and added `defer tick.Stop()`.

**instance.go — Instance()**
The startup poll used `time.Tick(10ms)` which permanently leaks its internal ticker goroutine (the Go docs explicitly warn about this). Switched to `time.NewTicker` with an explicit `Stop()` once the dispatcher is running.