### PR TITLE
chore: fix Toyota integration test compilation

### DIFF
--- a/vehicle/toyota/identity_test.go
+++ b/vehicle/toyota/identity_test.go
@@ -35,7 +35,7 @@ func TestIdentityLogin(t *testing.T) {
 	originalAccessToken := token.AccessToken
 
 	// Test token refresh
-	newToken, err := identity.RefreshToken(token)
+	newToken, err := identity.refreshToken(token)
 	require.NoError(t, err)
 	require.NotEmpty(t, newToken.AccessToken)
 	require.NotEmpty(t, newToken.RefreshToken)


### PR DESCRIPTION
- `RefreshToken` was renamed to `refreshToken` (unexported) in 19a30ac9c ("switch to ReuseTokenSource") but the integration test was never updated
- The test has `//go:build integration` so CI never caught the breakage EOF