### PR TITLE
meter: add Marstek Venus A, D and fix Venus E, E Gen 2.0, Venus C and E Gen 3.0 templates

### DIFF
--- a/templates/definition/meter/marstek-venus-a.yaml
+++ b/templates/definition/meter/marstek-venus-a.yaml
@@ -22,7 +22,7 @@ params:
   - name: maxsoc
     default: 100
   - name: maxchargepower
-    default: 2200
+    default: 1200
   - name: work_mode_normal
     default: 1
     advanced: true
@@ -41,28 +41,28 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30037 # MPPT1 power
+        address: 30037 # MPPT1 power (W)
         type: holding
         decode: uint16
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30038 # MPPT2 power
+        address: 30038 # MPPT2 power (W)
         type: holding
         decode: uint16
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30039 # MPPT3 power
+        address: 30039 # MPPT3 power (W)
         type: holding
         decode: uint16
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30040 # MPPT4 power
+        address: 30040 # MPPT4 power (W)
         type: holding
         decode: uint16
       scale: 0.1
@@ -72,9 +72,10 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 32102 # Battery power (W)
+      address: 30001 # Battery power (W)
       type: holding
-      decode: int32
+      decode: int16
+    scale: -1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/marstek-venus-a.yaml
+++ b/templates/definition/meter/marstek-venus-a.yaml
@@ -1,8 +1,8 @@
-template: marstek-venus-d
+template: marstek-venus-a
 products:
   - brand: Marstek
     description:
-      generic: Venus D
+      generic: Venus A
 capabilities: ["battery-control"]
 params:
   - name: usage
@@ -13,10 +13,10 @@ params:
     comset: 8N1
   - preset: battery-params
   - name: capacity
-    default: 2.56
+    default: 2.12
     help:
-      de: Basisgerät 2.56 kWh, jede Erweiterung zzgl. 2.56 kWh
-      en: Base unit 2.56 kWh, each extension plus 2.56 kWh
+      de: Basisgerät 2.12 kWh, jede Erweiterung zzgl. 2.12 kWh
+      en: Base unit 2.12 kWh, each extension plus 2.12 kWh
   - name: minsoc
     default: 11
   - name: maxsoc

--- a/templates/definition/meter/marstek-venus-d.yaml
+++ b/templates/definition/meter/marstek-venus-d.yaml
@@ -41,28 +41,28 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30037 # MPPT1 power
+        address: 30037 # MPPT1 power (W)
         type: holding
         decode: uint16
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30038 # MPPT2 power
+        address: 30038 # MPPT2 power (W)
         type: holding
         decode: uint16
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30039 # MPPT3 power
+        address: 30039 # MPPT3 power (W)
         type: holding
         decode: uint16
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 30040 # MPPT4 power
+        address: 30040 # MPPT4 power (W)
         type: holding
         decode: uint16
       scale: 0.1
@@ -72,9 +72,10 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 32102 # Battery power (W)
+      address: 30001 # Battery power (W)
       type: holding
-      decode: int32
+      decode: int16
+    scale: -1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/marstek-venus-d.yaml
+++ b/templates/definition/meter/marstek-venus-d.yaml
@@ -41,6 +41,9 @@ params:
       en: 0=manual, 1=anti-feed, 2=trade mode.
       de: 0=manuell, 1=Eigenverbrauch, 2=AI-Optimierung.
 render: |
+  # NOTE: MPPT1-4 registers (30037-30040) are read in both pv and battery modes.
+  # They cannot be shared via define/include because pv uses scale 0.1 (positive)
+  # while battery uses scale -0.1 (negative, to subtract PV from AC power).
   type: custom
   {{- if eq .usage "pv" }}
   power:
@@ -128,6 +131,7 @@ render: |
       set:
         source: sequence
         set:
+        # Enable RS485 Control Mode
         - source: const
           value: 21930
           set:
@@ -137,6 +141,7 @@ render: |
               address: 42000 # RS485 Control Mode = Enabled
               type: writesingle
               decode: uint16
+        # Set User Work Mode
         - source: const
           value: {{ .work_mode_normal }}
           set:
@@ -146,6 +151,7 @@ render: |
               address: 43000 # User Work Mode
               type: writesingle
               decode: uint16
+        # Disable RS485 Control Mode
         - source: const
           value: 21947
           set:
@@ -159,6 +165,7 @@ render: |
       set:
         source: sequence
         set:
+        # Enable RS485 Control Mode
         - source: const
           value: 21930
           set:
@@ -168,6 +175,7 @@ render: |
               address: 42000 # RS485 Control Mode = Enabled
               type: writesingle
               decode: uint16
+        # Set Force Charge/Discharge to Stop
         - source: const
           value: 0
           set:
@@ -177,10 +185,12 @@ render: |
               address: 42010 # Force Charge/Discharge = Stop
               type: writesingle
               decode: uint16
+    # Do not disable RS485 Control Mode because it will reset the device and let it charge/discharge again
     - case: 3 # charge
       set:
         source: sequence
         set:
+        # Enable RS485 Control Mode
         - source: const
           value: 21930
           set:
@@ -190,6 +200,7 @@ render: |
               address: 42000 # RS485 Control Mode = Enabled
               type: writesingle
               decode: uint16
+        # Set Force Charge/Discharge to Charge
         - source: const
           value: 1
           set:
@@ -199,6 +210,7 @@ render: |
               address: 42010 # Force Charge/Discharge = Charge
               type: writesingle
               decode: uint16
+        # Set Forcible Charge Power
         - source: const
           value: {{ .maxchargepower }}
           set:
@@ -208,5 +220,6 @@ render: |
               address: 42020 # Forcible Charge Power
               type: writesingle
               decode: uint16
+    # Do not disable RS485 Control Mode because it will reset the device and let it charge/discharge again
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/marstek-venus-d.yaml
+++ b/templates/definition/meter/marstek-venus-d.yaml
@@ -1,0 +1,212 @@
+template: marstek-venus-d
+products:
+  - brand: Marstek
+    description:
+      generic: Venus D
+      en: Venus D Battery Storage with integrated PV (MPPT)
+      de: Venus D Batteriespeicher mit integrierter PV (MPPT)
+capabilities: ["battery-control"]
+params:
+  - name: usage
+    choice: ["pv", "battery"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+    baudrate: 115200
+    comset: 8N1
+  - preset: battery-params
+    usages: ["battery"]
+  - name: capacity
+    default: 2.56
+    usages: ["battery"]
+    help:
+      de: Basisgerät 2.56 kWh, jede Erweiterung zzgl. 2.56 kWh
+      en: Base unit 2.56 kWh, each extension plus 2.56 kWh
+  - name: minsoc
+    default: 11
+    usages: ["battery"]
+  - name: maxsoc
+    default: 100
+    usages: ["battery"]
+  - name: maxchargepower
+    default: 2200
+    usages: ["battery"]
+  - name: work_mode_normal
+    default: 1
+    advanced: true
+    usages: ["battery"]
+    description:
+      en: Work mode for Normal state
+      de: Work mode für Normal-Modus
+    help:
+      en: 0=manual, 1=anti-feed, 2=trade mode.
+      de: 0=manuell, 1=Eigenverbrauch, 2=AI-Optimierung.
+render: |
+  type: custom
+  {{- if eq .usage "pv" }}
+  power:
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30037 # MPPT1 power
+        type: holding
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30038 # MPPT2 power
+        type: holding
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30039 # MPPT3 power
+        type: holding
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30040 # MPPT4 power
+        type: holding
+        decode: uint16
+      scale: 0.1
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 32202 # AC Power (Watt)
+        type: holding
+        decode: int32
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30037 # MPPT1 power — subtract PV to get true battery power
+        type: holding
+        decode: uint16
+      scale: -0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30038 # MPPT2 power
+        type: holding
+        decode: uint16
+      scale: -0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30039 # MPPT3 power
+        type: holding
+        decode: uint16
+      scale: -0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 30040 # MPPT4 power
+        type: holding
+        decode: uint16
+      scale: -0.1
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 32104 # Battery SOC (%)
+      type: holding
+      decode: uint16
+    scale: 1
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 21930
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Enabled
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: {{ .work_mode_normal }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 43000 # User Work Mode
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 21947
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Disabled
+              type: writesingle
+              decode: uint16
+    - case: 2 # hold
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 21930
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Enabled
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42010 # Force Charge/Discharge = Stop
+              type: writesingle
+              decode: uint16
+    - case: 3 # charge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 21930
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Enabled
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42010 # Force Charge/Discharge = Charge
+              type: writesingle
+              decode: uint16
+        - source: const
+          value: {{ .maxchargepower }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42020 # Forcible Charge Power
+              type: writesingle
+              decode: uint16
+  {{- include "battery-params" . }}
+  {{- end }}

--- a/templates/definition/meter/marstek-venus-e-v3.yaml
+++ b/templates/definition/meter/marstek-venus-e-v3.yaml
@@ -13,7 +13,7 @@ params:
     comset: 8N1
   - preset: battery-params
   - name: capacity
-    default: 5.12  
+    default: 5.12
   - name: minsoc
     default: 11
   - name: maxsoc

--- a/templates/definition/meter/marstek-venus-e-v3.yaml
+++ b/templates/definition/meter/marstek-venus-e-v3.yaml
@@ -1,28 +1,27 @@
-template: marstek-venus-d
+template: marstek-venus-e-v3
 products:
   - brand: Marstek
     description:
-      generic: Venus D
+      generic: Venus E Gen 3.0
 capabilities: ["battery-control"]
 params:
   - name: usage
-    choice: ["pv", "battery"]
+    choice: ["battery"]
   - name: modbus
     choice: ["rs485", "tcpip"]
     baudrate: 115200
     comset: 8N1
   - preset: battery-params
   - name: capacity
-    default: 2.56
     help:
-      de: Basisgerät 2.56 kWh, jede Erweiterung zzgl. 2.56 kWh
-      en: Base unit 2.56 kWh, each extension plus 2.56 kWh
+      de: Venus-E 5.12 kWh, Venus-C 2.56 kWh
+      en: Venus-E 5.12 kWh, Venus-C 2.56 kWh
   - name: minsoc
     default: 11
   - name: maxsoc
     default: 100
   - name: maxchargepower
-    default: 2200
+    default: 2500
   - name: work_mode_normal
     default: 1
     advanced: true
@@ -34,55 +33,14 @@ params:
       de: 0=manuell, 1=Eigenverbrauch, 2=AI-Optimierung.
 render: |
   type: custom
-  {{- if eq .usage "pv" }}
-  power:
-    source: calc
-    add:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 30037 # MPPT1 power
-        type: holding
-        decode: uint16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 30038 # MPPT2 power
-        type: holding
-        decode: uint16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 30039 # MPPT3 power
-        type: holding
-        decode: uint16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 30040 # MPPT4 power
-        type: holding
-        decode: uint16
-      scale: 0.1
-  {{- end }}
-  {{- if eq .usage "battery" }}
   power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 32102 # Battery power (W)
+      address: 32202 # AC Power (Watt)
       type: holding
       decode: int32
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 33002 # Total energy discharged from battery (kWh)
-      type: holding
-      decode: uint32
-    scale: 0.01
+    scale: 1
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -90,6 +48,7 @@ render: |
       address: 32104 # Battery SOC (%)
       type: holding
       decode: uint16
+    scale: 1
   batterymode:
     source: switch
     switch:
@@ -188,4 +147,3 @@ render: |
               decode: uint16
     # Do not disable RS485 Control Mode because it will reset the device and let it charge/discharge again
   {{- include "battery-params" . }}
-  {{- end }}

--- a/templates/definition/meter/marstek-venus-e-v3.yaml
+++ b/templates/definition/meter/marstek-venus-e-v3.yaml
@@ -13,9 +13,7 @@ params:
     comset: 8N1
   - preset: battery-params
   - name: capacity
-    help:
-      de: Venus-E 5.12 kWh, Venus-C 2.56 kWh
-      en: Venus-E 5.12 kWh, Venus-C 2.56 kWh
+    default: 5.12  
   - name: minsoc
     default: 11
   - name: maxsoc
@@ -37,18 +35,26 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 32202 # AC Power (Watt)
+      address: 30006 # AC Power (W)
       type: holding
-      decode: int32
+      decode: int16
     scale: 1
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 33002 # Total energy discharged from battery (kWh)
+      type: holding
+      decode: uint32
+    scale: 0.01
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 32104 # Battery SOC (%)
+      address: 34002 # Battery SOC (%)
       type: holding
       decode: uint16
-    scale: 1
+    scale: 0.1
   batterymode:
     source: switch
     switch:

--- a/templates/definition/meter/marstek-venus-e.yaml
+++ b/templates/definition/meter/marstek-venus-e.yaml
@@ -1,8 +1,9 @@
-template: marstek-venus
+template: marstek-venus-e
+covers: ["marstek-venus"]
 products:
   - brand: Marstek
     description:
-      generic: Venus Battery Storage
+      generic: Venus E
 capabilities: ["battery-control"]
 params:
   - name: usage

--- a/templates/definition/meter/marstek-venus-e.yaml
+++ b/templates/definition/meter/marstek-venus-e.yaml
@@ -4,6 +4,12 @@ products:
   - brand: Marstek
     description:
       generic: Venus E
+  - brand: Marstek
+    description:
+      generic: Venus E Gen 2.0
+  - brand: Marstek
+    description:
+      generic: Venus C
 capabilities: ["battery-control"]
 params:
   - name: usage
@@ -14,9 +20,7 @@ params:
     comset: 8N1
   - preset: battery-params
   - name: capacity
-    help:
-      de: Venus-E 5.12 kWh, Venus-C 2.56 kWh
-      en: Venus-E 5.12 kWh, Venus-C 2.56 kWh
+    default: 5.12
   - name: minsoc
     default: 11
   - name: maxsoc
@@ -38,10 +42,18 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 32202 # AC Power (Watt)
+      address: 32202 # AC Power (W)
       type: holding
       decode: int32
     scale: 1
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 33002 # Total energy discharged from battery (kWh)
+      type: holding
+      decode: uint32
+    scale: 0.01
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
## Summary

Adds new meter templates for **Marstek Venus A** and **Venus D** (both with integrated solar), fixes and extends the existing templates for **Venus E / E Gen 2.0 / Venus C** and renames the existing `marstek-venus` template to **Venus E Gen 3.0** (`marstek-venus-e-v3`).

### New templates

#### `marstek-venus-a` — Marstek Venus A
*Hybrid device without grid metering*
- Supports `usage: ["pv", "battery"]`
- **PV mode**: sums MPPT1–4 registers (30037–30040, ×0.1 W, uint16)
- **Battery mode**:
  - `power`: register 30001 (battery power, int16, ×−1 W — inverted to match evcc convention: positive = discharge)
  - `energy`: register 33002 (total discharged energy, uint32, ×0.01 kWh)
  - `soc`: register 32104 (uint16, ×1 %)
  - `maxchargepower` default: 1200 W

#### `marstek-venus-d` — Marstek Venus D
*Hybrid device without grid metering*
- Supports `usage: ["pv", "battery"]`
- **PV mode**: sums MPPT1–4 registers (30037–30040, ×0.1 W, uint16)
- **Battery mode**:
  - `power`: register 30001 (battery power, int16, ×−1 W)
  - `energy`: register 33002 (total discharged energy, uint32, ×0.01 kWh)
  - `soc`: register 32104 (uint16, ×1 %)
  - `maxchargepower` default: 2200 W

### Fixed / extended templates

#### `marstek-venus-e` — Marstek Venus E, Venus E Gen 2.0, Venus C (covers `marstek-venus`)
*Pure battery storage without integrated solar — uses AC-side values to include inverter losses.*
- Added `covers: ["marstek-venus"]` to replace the old template
- Added `Venus E Gen 2.0` and `Venus C` to the products list
- `power`: register 32202 (AC power, int32, ×1 W — positive = discharge ✓)
- `energy`: register 33002 (total discharged energy, uint32, ×0.01 kWh) — **newly added**
- `soc`: register 32104 (uint16, ×1 %)
- `maxchargepower` default: 2500 W
- `capacity` default: 5.12 kWh

#### `marstek-venus-e-v3` — Marstek Venus E Gen 3.0 (renamed from `marstek-venus`)
*Pure battery storage without integrated solar — uses AC-side values to include inverter losses.*
- `power`: register **30006** (AC power, int16, ×1 W) — corrected from 32202 (does not exist on v3)
- `energy`: register 33002 (total discharged energy, uint32, ×0.01 kWh) — **newly added**
- `soc`: register **34002** (uint16, ×0.1 %) — corrected from 32104 (wrong register for v3)
- `capacity` default: 5.12 kWh

## Register sources

All register addresses verified against the [ViperRNMC/marstek_venus_modbus](https://github.com/ViperRNMC/marstek_venus_modbus/tree/main/custom_components/marstek_modbus/registers) Home Assistant integration (files `a.yaml`, `d.yaml`, `e_v12.yaml`, `e_v3.yaml`).

> ⚠️ Venus A and Venus D register maps are marked "untested" in the upstream source. Corrections welcome from hardware owners.