### PR TITLE
Config UI: add curtailed device info

### DIFF
--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -340,6 +340,11 @@ func testInstance(instance any) map[string]testResult {
 		makeResult("dimmed", val, err)
 	}
 
+	if dev, ok := api.Cap[api.Curtailer](instance); ok {
+		val, err := dev.Curtailed()
+		makeResult("curtailed", val, err)
+	}
+
 	if dev, ok := api.Cap[api.Identifier](instance); ok {
 		val, err := dev.Identify()
 		makeResult("identifier", val, err)


### PR DESCRIPTION
see https://github.com/evcc-io/evcc/pull/28877

`api.Dimmer` already existed and `curtailed` i18n texts are present from `circuits` visualization. Only `curtailed` info wasn't published in device info.