### PR TITLE
Add support for Connected Cars API (used by Volkswagen Australia)

### DIFF
--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -18,13 +18,11 @@ params:
     description:
       en: API Domain
       de: API-Domain
-    advanced: true
   - name: namespace
     default: "vwaustralia:app"
     description:
       en: Organization Namespace
       de: Organisations-Namespace
-    advanced: true
   - name: vin
   - preset: vehicle-common
   - name: cache

--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -1,0 +1,39 @@
+template: connected-cars
+products:
+  - description:
+      generic: Connected Cars (connectedcars.io)
+group: generic
+params:
+  - name: deviceToken
+    required: true
+    mask: true
+    description:
+      en: Device Token
+      de: Geräte-Token
+    help:
+      en: Obtained via Connected Cars device registration
+      de: Über die Connected Cars Geräteregistrierung erhalten
+  - name: domain
+    default: au1.connectedcars.io
+    description:
+      en: API Domain
+      de: API-Domain
+    advanced: true
+  - name: namespace
+    default: "vwaustralia:app"
+    description:
+      en: Organization Namespace
+      de: Organisations-Namespace
+    advanced: true
+  - name: vin
+  - preset: vehicle-common
+  - name: cache
+    default: 15m
+render: |
+  type: connected-cars
+  deviceToken: {{ .deviceToken }}
+  domain: {{ .domain }}
+  namespace: {{ .namespace }}
+  vin: {{ .vin }}
+  {{ include "vehicle-common" . }}
+  cache: {{ .cache }}

--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -9,7 +9,7 @@ params:
     mask: true
     description:
       en: Device Token
-      de: Geräte-Token
+      de: Gerätetoken
     help:
       en: Obtained via Connected Cars device registration.  See https://github.com/brettch/evcc-connected-cars for scripts to perform device registration.
       de: Die Daten wurden über die Geräteregistrierung von Connected Cars bezogen. Skripte zur Geräteregistrierung finden Sie unter https://github.com/brettch/evcc-connected-cars.
@@ -17,15 +17,15 @@ params:
     default: au1.connectedcars.io
     description:
       en: API Domain
-      de: API-Domain
+      de: API-Domäne
     help:
       en: The API domain to use for Connected Cars. Each country typically has a unique domain. It can be found by logging into the Connected Cars GraphiQL tool (https://api.connectedcars.io/graphql/graphiql/), logging into the relevant country, and viewing the domain it uses (minus the leading "api.").
       de: Die für Connected Cars zu verwendende API-Domäne. Jedes Land hat in der Regel eine eigene Domäne. Diese finden Sie, indem Sie sich im Connected Cars GraphiQL-Tool (https://api.connectedcars.io/graphql/graphiql/) anmelden, das entsprechende Land auswählen und die verwendete Domäne (ohne das vorangestellte „api.“) anzeigen.
   - name: namespace
     default: "vwaustralia:app"
     description:
-      en: Organization Namespace that uniquely identifies the organization within Connected Cars.
-      de: Organisations-Namensraum, der die Organisation innerhalb von Connected Cars eindeutig identifiziert.
+      en: Organization Namespace
+      de: Namespace der Organisation
     help:
       en: The namespace is used to identify the organization within Connected Cars. It can be found by logging into the Connected Cars GraphiQL tool (https://api.connectedcars.io/graphql/graphiql/), logging into the relevant country, and viewing the "X-Organization-Namespace" header it sets for you.
       de: Der Namespace dient zur Identifizierung der Organisation innerhalb von Connected Cars. Er kann ermittelt werden, indem man sich beim Connected Cars GraphiQL-Tool (https://api.connectedcars.io/graphql/graphiql/) anmeldet, das entsprechende Land auswählt und den automatisch festgelegten Header „X-Organization-Namespace“ anzeigt.

--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -1,7 +1,7 @@
 template: connected-cars
 products:
   - description:
-      generic: Connected Cars
+      generic: Connected Cars (Volkswagen Australia)
 group: generic
 params:
   - name: deviceToken

--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -1,7 +1,7 @@
 template: connected-cars
 products:
   - description:
-      generic: Connected Cars (connectedcars.io)
+      generic: Connected Cars
 group: generic
 params:
   - name: deviceToken

--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -11,18 +11,24 @@ params:
       en: Device Token
       de: Geräte-Token
     help:
-      en: Obtained via Connected Cars device registration.  See https://github.com/brettch/evcc-connected-cars for scripts to perform this.
-      de: Die Daten werden über die Geräteregistrierung von Connected Cars abgerufen. Skripte hierfür finden Sie unter https://github.com/brettch/evcc-connected-cars.
+      en: Obtained via Connected Cars device registration.  See https://github.com/brettch/evcc-connected-cars for scripts to perform device registration.
+      de: Die Daten wurden über die Geräteregistrierung von Connected Cars bezogen. Skripte zur Geräteregistrierung finden Sie unter https://github.com/brettch/evcc-connected-cars.
   - name: domain
     default: au1.connectedcars.io
     description:
       en: API Domain
       de: API-Domain
+    help:
+      en: The API domain to use for Connected Cars. Each country typically has a unique domain. It can be found by logging into the Connected Cars GraphiQL tool (https://api.connectedcars.io/graphql/graphiql/), logging into the relevant country, and viewing the domain it uses (minus the leading "api.").
+      de: Die für Connected Cars zu verwendende API-Domäne. Jedes Land hat in der Regel eine eigene Domäne. Diese finden Sie, indem Sie sich im Connected Cars GraphiQL-Tool (https://api.connectedcars.io/graphql/graphiql/) anmelden, das entsprechende Land auswählen und die verwendete Domäne (ohne das vorangestellte „api.“) anzeigen.
   - name: namespace
     default: "vwaustralia:app"
     description:
       en: Organization Namespace that uniquely identifies the organization within Connected Cars.
       de: Organisations-Namensraum, der die Organisation innerhalb von Connected Cars eindeutig identifiziert.
+    help:
+      en: The namespace is used to identify the organization within Connected Cars. It can be found by logging into the Connected Cars GraphiQL tool (https://api.connectedcars.io/graphql/graphiql/), logging into the relevant country, and viewing the "X-Organization-Namespace" header it sets for you.
+      de: Der Namespace dient zur Identifizierung der Organisation innerhalb von Connected Cars. Er kann ermittelt werden, indem man sich beim Connected Cars GraphiQL-Tool (https://api.connectedcars.io/graphql/graphiql/) anmeldet, das entsprechende Land auswählt und den automatisch festgelegten Header „X-Organization-Namespace“ anzeigt.
   - name: vin
   - preset: vehicle-common
   - name: cache

--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -11,8 +11,8 @@ params:
       en: Device Token
       de: Geräte-Token
     help:
-      en: Obtained via Connected Cars device registration
-      de: Über die Connected Cars Geräteregistrierung erhalten
+      en: Obtained via Connected Cars device registration.  See https://github.com/brettch/evcc-connected-cars for scripts to perform this.
+      de: Die Daten werden über die Geräteregistrierung von Connected Cars abgerufen. Skripte hierfür finden Sie unter https://github.com/brettch/evcc-connected-cars.
   - name: domain
     default: au1.connectedcars.io
     description:
@@ -21,8 +21,8 @@ params:
   - name: namespace
     default: "vwaustralia:app"
     description:
-      en: Organization Namespace
-      de: Organisations-Namespace
+      en: Organization Namespace that uniquely identifies the organization within Connected Cars.
+      de: Organisations-Namensraum, der die Organisation innerhalb von Connected Cars eindeutig identifiziert.
   - name: vin
   - preset: vehicle-common
   - name: cache

--- a/vehicle/connectedcars.go
+++ b/vehicle/connectedcars.go
@@ -1,0 +1,120 @@
+package vehicle
+
+import (
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/vehicle/connectedcars"
+)
+
+// ConnectedCars is an api.Vehicle implementation for the Connected Cars platform (connectedcars.io).
+type ConnectedCars struct {
+	*embed
+	dataG func() (connectedcars.VehicleData, error)
+}
+
+func init() {
+	registry.Add("connected-cars", NewConnectedCarsFromConfig)
+}
+
+// NewConnectedCarsFromConfig creates a new vehicle
+func NewConnectedCarsFromConfig(other map[string]any) (api.Vehicle, error) {
+	cc := struct {
+		embed       `mapstructure:",squash"`
+		DeviceToken string
+		Domain      string
+		Namespace   string
+		VIN         string
+		Cache       time.Duration
+	}{
+		Domain:    "au1.connectedcars.io",
+		Namespace: "vwaustralia:app",
+		Cache:     interval,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.DeviceToken == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
+	log := util.NewLogger("connected-cars").Redact(cc.DeviceToken)
+
+	api := connectedcars.NewAPI(log, cc.Domain, cc.Namespace, cc.DeviceToken)
+
+	vehicle, err := ensureVehicleEx(
+		cc.VIN, api.Vehicles,
+		func(v connectedcars.Vehicle) (string, error) {
+			return v.VIN, nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &ConnectedCars{
+		embed: &cc.embed,
+		dataG: util.Cached(func() (connectedcars.VehicleData, error) {
+			return api.Data(vehicle.ID)
+		}, cc.Cache),
+	}
+
+	return v, nil
+}
+
+// Soc implements the api.Vehicle interface
+func (v *ConnectedCars) Soc() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	if res.ChargePercentage == nil {
+		return 0, api.ErrNotAvailable
+	}
+	return res.ChargePercentage.Pct, nil
+}
+
+var _ api.ChargeState = (*ConnectedCars)(nil)
+
+// Status implements the api.ChargeState interface
+func (v *ConnectedCars) Status() (api.ChargeStatus, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return api.StatusNone, err
+	}
+	if res.ChargingState != nil && res.ChargingState.Enabled {
+		return api.StatusC, nil
+	}
+	return api.StatusA, nil
+}
+
+var _ api.VehicleRange = (*ConnectedCars)(nil)
+
+// Range implements the api.VehicleRange interface
+func (v *ConnectedCars) Range() (int64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	if res.RangeTotalKm == nil {
+		return 0, api.ErrNotAvailable
+	}
+	return int64(res.RangeTotalKm.Km), nil
+}
+
+var _ api.VehicleOdometer = (*ConnectedCars)(nil)
+
+// Odometer implements the api.VehicleOdometer interface
+func (v *ConnectedCars) Odometer() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+	if res.Odometer == nil {
+		return 0, api.ErrNotAvailable
+	}
+	return res.Odometer.Odometer, nil
+}

--- a/vehicle/connectedcars/api.go
+++ b/vehicle/connectedcars/api.go
@@ -1,0 +1,133 @@
+package connectedcars
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+	"golang.org/x/oauth2"
+)
+
+// API provides access to the Connected Cars GraphQL API.
+type API struct {
+	*request.Helper
+	domain    string
+	namespace string
+}
+
+// graphqlRequest is a generic GraphQL request body.
+type graphqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// NewAPI creates a new Connected Cars API client with device-token authentication.
+func NewAPI(log *util.Logger, domain, namespace, deviceToken string) *API {
+	api := &API{
+		Helper:    request.NewHelper(log),
+		domain:    domain,
+		namespace: namespace,
+	}
+
+	// Use RefreshTokenSource to handle JWT refresh via device token.
+	// The device token is stored as RefreshToken; it never changes.
+	token := &oauth2.Token{
+		RefreshToken: deviceToken,
+	}
+
+	ts := oauth.RefreshTokenSource(token, api.refreshToken)
+
+	// Install oauth2.Transport for Bearer token, plus a decorator for the
+	// namespace header required by all API endpoints.
+	api.Client.Transport = &transport.Decorator{
+		Decorator: transport.DecorateHeaders(map[string]string{
+			"X-Organization-Namespace": namespace,
+		}),
+		Base: &oauth2.Transport{
+			Source: ts,
+			Base:   api.Client.Transport,
+		},
+	}
+
+	return api
+}
+
+// refreshToken exchanges the device token for a new JWT access token.
+func (a *API) refreshToken(token *oauth2.Token) (*oauth2.Token, error) {
+	data := struct {
+		DeviceToken string `json:"deviceToken"`
+	}{
+		DeviceToken: token.RefreshToken,
+	}
+
+	uri := fmt.Sprintf("https://auth-api.%s/auth/login/deviceToken", a.domain)
+
+	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(data), map[string]string{
+		"Content-Type":             request.JSONContent,
+		"X-Organization-Namespace": a.namespace,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res TokenResponse
+
+	// Use a plain client to avoid circular dependency with oauth2 transport.
+	client := request.NewHelper(util.NewLogger("cc-auth"))
+	if err := client.DoJSON(req, &res); err != nil {
+		return nil, fmt.Errorf("device token login: %w", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken:  res.Token,
+		RefreshToken: token.RefreshToken,
+		Expiry:       time.Now().Add(time.Duration(res.Expires) * time.Second),
+	}, nil
+}
+
+// Vehicles returns the list of vehicles on the account.
+func (a *API) Vehicles() ([]Vehicle, error) {
+	uri := fmt.Sprintf("https://api.%s/graphql", a.domain)
+
+	body := graphqlRequest{
+		Query: `{ vehicles(first:100) { items { id licensePlate vin } } }`,
+	}
+
+	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(body), request.JSONEncoding)
+	if err != nil {
+		return nil, err
+	}
+
+	var res VehiclesResponse
+	if err := a.DoJSON(req, &res); err != nil {
+		return nil, fmt.Errorf("list vehicles: %w", err)
+	}
+
+	return res.Data.Vehicles.Items, nil
+}
+
+// Data fetches the current vehicle telemetry data.
+func (a *API) Data(vehicleID string) (VehicleData, error) {
+	uri := fmt.Sprintf("https://api.%s/graphql", a.domain)
+
+	body := graphqlRequest{
+		Query:     `query($id: ID!) { vehicle(id: $id) { id chargePercentage { pct } odometer { odometer } rangeTotalKm { km } chargingState { enabled } }}`,
+		Variables: map[string]any{"id": vehicleID},
+	}
+
+	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(body), request.JSONEncoding)
+	if err != nil {
+		return VehicleData{}, err
+	}
+
+	var res DataResponse
+	if err := a.DoJSON(req, &res); err != nil {
+		return VehicleData{}, fmt.Errorf("vehicle data: %w", err)
+	}
+
+	return res.Data.Vehicle, nil
+}

--- a/vehicle/connectedcars/api.go
+++ b/vehicle/connectedcars/api.go
@@ -108,6 +108,10 @@ func (a *API) Vehicles() ([]Vehicle, error) {
 		return nil, fmt.Errorf("list vehicles: %w", err)
 	}
 
+	if res.Data == nil {
+		return nil, fmt.Errorf("list vehicles: missing data in response")
+	}
+
 	return res.Data.Vehicles.Items, nil
 }
 
@@ -128,6 +132,10 @@ func (a *API) Data(vehicleID string) (VehicleData, error) {
 	var res DataResponse
 	if err := a.DoJSON(req, &res); err != nil {
 		return VehicleData{}, fmt.Errorf("vehicle data: %w", err)
+	}
+
+	if res.Data == nil {
+		return VehicleData{}, fmt.Errorf("vehicle data: missing data in response")
 	}
 
 	return res.Data.Vehicle, nil

--- a/vehicle/connectedcars/api.go
+++ b/vehicle/connectedcars/api.go
@@ -15,8 +15,9 @@ import (
 // API provides access to the Connected Cars GraphQL API.
 type API struct {
 	*request.Helper
-	domain    string
-	namespace string
+	authHelper *request.Helper // plain client for token refresh; no oauth2 transport to avoid circular dependency
+	domain     string
+	namespace  string
 }
 
 // graphqlRequest is a generic GraphQL request body.
@@ -28,9 +29,10 @@ type graphqlRequest struct {
 // NewAPI creates a new Connected Cars API client with device-token authentication.
 func NewAPI(log *util.Logger, domain, namespace, deviceToken string) *API {
 	api := &API{
-		Helper:    request.NewHelper(log),
-		domain:    domain,
-		namespace: namespace,
+		Helper:     request.NewHelper(log),
+		authHelper: request.NewHelper(log),
+		domain:     domain,
+		namespace:  namespace,
 	}
 
 	// Use RefreshTokenSource to handle JWT refresh via device token.
@@ -76,9 +78,8 @@ func (a *API) refreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 
 	var res TokenResponse
 
-	// Use a plain client to avoid circular dependency with oauth2 transport.
-	client := request.NewHelper(util.NewLogger("cc-auth"))
-	if err := client.DoJSON(req, &res); err != nil {
+	// Use the plain authHelper (no oauth2 transport) to avoid circular dependency.
+	if err := a.authHelper.DoJSON(req, &res); err != nil {
 		return nil, fmt.Errorf("device token login: %w", err)
 	}
 

--- a/vehicle/connectedcars/types.go
+++ b/vehicle/connectedcars/types.go
@@ -1,0 +1,46 @@
+package connectedcars
+
+// TokenResponse is the response from the device token login endpoint.
+type TokenResponse struct {
+	Token   string `json:"token"`
+	Expires int    `json:"expires"`
+}
+
+// VehiclesResponse is the GraphQL response for listing vehicles.
+type VehiclesResponse struct {
+	Data struct {
+		Vehicles struct {
+			Items []Vehicle `json:"items"`
+		} `json:"vehicles"`
+	} `json:"data"`
+}
+
+// Vehicle represents a vehicle from the Connected Cars API.
+type Vehicle struct {
+	ID           string `json:"id"`
+	LicensePlate string `json:"licensePlate"`
+	VIN          string `json:"vin"`
+}
+
+// DataResponse is the GraphQL response for vehicle data.
+type DataResponse struct {
+	Data struct {
+		Vehicle VehicleData `json:"vehicle"`
+	} `json:"data"`
+}
+
+// VehicleData contains the vehicle telemetry fields.
+type VehicleData struct {
+	ChargePercentage *struct {
+		Pct float64 `json:"pct"`
+	} `json:"chargePercentage"`
+	Odometer *struct {
+		Odometer float64 `json:"odometer"`
+	} `json:"odometer"`
+	RangeTotalKm *struct {
+		Km float64 `json:"km"`
+	} `json:"rangeTotalKm"`
+	ChargingState *struct {
+		Enabled bool `json:"enabled"`
+	} `json:"chargingState"`
+}

--- a/vehicle/connectedcars/types.go
+++ b/vehicle/connectedcars/types.go
@@ -8,7 +8,7 @@ type TokenResponse struct {
 
 // VehiclesResponse is the GraphQL response for listing vehicles.
 type VehiclesResponse struct {
-	Data struct {
+	Data *struct {
 		Vehicles struct {
 			Items []Vehicle `json:"items"`
 		} `json:"vehicles"`
@@ -24,7 +24,7 @@ type Vehicle struct {
 
 // DataResponse is the GraphQL response for vehicle data.
 type DataResponse struct {
-	Data struct {
+	Data *struct {
 		Vehicle VehicleData `json:"vehicle"`
 	} `json:"data"`
 }


### PR DESCRIPTION
This is the first time I've attempted to work with the EVCC source code and my golang isn't strong (I have a Java/TypeScript background). I'm very happy to receive feedback and answer any questions about how this works.

Claude Code & Opus have done some heavy lifting but I have read through the code to understand the logic and I _think_ it's done a decent job.

## Purpose

Add support for the Connected Cars API which is used by Volkswagen EVs in Australia.

## Background

Connected Cars provides a solution for accessing and analysing data obtained from car fleets. It is an end to end solution that includes in-car hardware, central infrastructure and APIs for collecting and analysing data, and mobile applications for end users.

One of those clients of this solution is Volkswagen Australia who use it due to their standard MyVW solution not being available in Australia.

## Implementation Notes

I have proven the API via shell scripts that I can invoke using the EVCC Shell plugin.
https://github.com/brettch/evcc-connected-cars

I have used the shell scripts mentioned above to guide the implementation in this PR.

The vehicle configuration requires a device token that can be generated using the shell scripts. I am not sure how to best reference those scripts and token registration steps within the documentation for this new native implementation. I have currently linked to [https://github.com/brettch/evcc-connected-cars](https://github.com/brettch/evcc-connected-cars) from the vehicle template.

## Testing

I have tested this using my own Connected Cars account provided by Volkswagen Australia (it's based as GoConnect here). It appears to be working reliably so far.