### PR TITLE
Energyflow: forecast/battery navigation

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -652,12 +652,20 @@ export default defineComponent({
 			this.detailsCompleteHeight = this.$refs["detailsInner"]?.offsetHeight ?? 0;
 		},
 		openBatterySettingsModal() {
+			if (this.experimental) {
+				this.$router.push("/battery");
+				return;
+			}
 			const modal = Modal.getOrCreateInstance(
 				document.getElementById("batterySettingsModal") as HTMLElement
 			);
 			modal.show();
 		},
 		openForecastModal() {
+			if (this.experimental) {
+				this.$router.push("/forecast");
+				return;
+			}
 			const modal = Modal.getOrCreateInstance(
 				document.getElementById("forecastModal") as HTMLElement
 			);

--- a/assets/js/components/Top/Navigation.vue
+++ b/assets/js/components/Top/Navigation.vue
@@ -249,12 +249,20 @@ export default defineComponent({
 			modal.show();
 		},
 		openBatterySettingsModal() {
+			if (this.experimental) {
+				this.$router.push("/battery");
+				return;
+			}
 			const modal = Modal.getOrCreateInstance(
 				document.getElementById("batterySettingsModal") as HTMLElement
 			);
 			modal.show();
 		},
 		openForecastModal() {
+			if (this.experimental) {
+				this.$router.push("/forecast");
+				return;
+			}
 			const modal = Modal.getOrCreateInstance(
 				document.getElementById("forecastModal") as HTMLElement
 			);


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/28776

Navigate to forecast or battery page instead of opening modals.