### PR TITLE
Config UI: fix default for required choice params

### DIFF
--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -68,6 +68,7 @@ export type ApiData = {
   icon?: string;
   usage?: MeterTemplateUsage;
   title?: string;
+  priority?: number;
   identifiers?: string[];
   [key: string]: any;
 };

--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -89,14 +89,9 @@ export function handleError(e: any, msg: string) {
 export function applyDefaultsFromTemplate(template: Template | null, values: DeviceValues) {
   const params = template?.Params || [];
   params
-    .filter((p) => !values[p.Name])
+    .filter((p) => p.Default && !values[p.Name])
     .forEach((p) => {
-      if (p.Default) {
-        values[p.Name] = p.Default;
-      } else if (p.Required && p.Choice?.length) {
-        // auto-select first choice for required select params without explicit default
-        values[p.Name] = p.Choice[0];
-      }
+      values[p.Name] = p.Default;
     });
 }
 

--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -89,9 +89,14 @@ export function handleError(e: any, msg: string) {
 export function applyDefaultsFromTemplate(template: Template | null, values: DeviceValues) {
   const params = template?.Params || [];
   params
-    .filter((p) => p.Default && !values[p.Name])
+    .filter((p) => !values[p.Name])
     .forEach((p) => {
-      values[p.Name] = p.Default;
+      if (p.Default) {
+        values[p.Name] = p.Default;
+      } else if (p.Required && p.Choice?.length) {
+        // auto-select first choice for required select params without explicit default
+        values[p.Name] = p.Choice[0];
+      }
     });
 }
 

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -114,7 +114,6 @@
 								v-model="values.defaultMode"
 								type="Choice"
 								class="w-100"
-								required
 								:choice="[
 									{ key: '', name: '---' },
 									{ key: 'off', name: $t('main.mode.off') },
@@ -302,8 +301,8 @@
 								type="Choice"
 								size="w-100"
 								class="me-2"
-								:choice="priorityOptions"
 								required
+								:choice="priorityOptions"
 							/>
 						</FormRow>
 
@@ -435,7 +434,6 @@
 									type="Choice"
 									class="me-2"
 									:choice="circuitOptions"
-									required
 								/>
 							</FormRow>
 						</div>
@@ -465,7 +463,6 @@
 										type="Choice"
 										class="me-2"
 										:choice="allVehicleOptions"
-										required
 									/>
 								</FormRow>
 
@@ -744,7 +741,6 @@ export default {
 				name: string;
 			}[];
 			result[0]!.name = "0 (default)";
-			result[0]!.key = undefined;
 			result[10]!.name = "10 (highest)";
 			return result;
 		},

--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -304,11 +304,6 @@ export default {
 		},
 		value: {
 			get() {
-				// use first option if no value is set
-				if (this.selectOptions.length > 0 && !this.modelValue) {
-					return this.required ? this.selectOptions[0].key : "";
-				}
-
 				if (this.scale) {
 					return this.modelValue * this.scale;
 				}

--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -51,9 +51,10 @@
 		v-model="value"
 		class="form-select"
 		:class="inputClasses"
+		:required="required"
 		:disabled="disabled"
 	>
-		<option v-if="!required" value="" :disabled="disabled">---</option>
+		<option v-if="!required || !modelValue" value="" :disabled="disabled">---</option>
 		<template v-for="({ key, name }, idx) in selectOptions">
 			<option
 				v-if="key !== null && name !== null"
@@ -304,6 +305,10 @@ export default {
 		},
 		value: {
 			get() {
+				if (this.select && this.modelValue == null) {
+					return "";
+				}
+
 				if (this.scale) {
 					return this.modelValue * this.scale;
 				}

--- a/assets/js/components/Config/VehicleModal.vue
+++ b/assets/js/components/Config/VehicleModal.vue
@@ -162,6 +162,7 @@ import { getModal } from "@/configModal";
 const initialValues = {
 	type: ConfigType.Template,
 	icon: "car",
+	priority: 0,
 	deviceProduct: undefined,
 	yaml: undefined,
 	template: null,
@@ -206,7 +207,6 @@ export default defineComponent({
 				(_, i) => ({ key: i, name: `${i}` })
 			);
 			result[0]!.name = "0 (default)";
-			result[0]!.key = undefined;
 			result[10]!.name = "10 (highest)";
 			return result;
 		},
@@ -258,6 +258,7 @@ export default defineComponent({
 			if (values.type === ConfigType.Custom) {
 				delete data.icon;
 				delete data.title;
+				delete data.priority;
 			}
 			if (Array.isArray(data.identifiers)) {
 				data.identifiers = data.identifiers.map((i) => i.trim()).filter((i) => i);

--- a/tests/boost.spec.ts
+++ b/tests/boost.spec.ts
@@ -87,6 +87,7 @@ test.describe("boost", async () => {
     await lp1.getByTestId("mode").getByRole("button", { name: "Solar", exact: true }).click();
     await lp1.getByTestId("loadpoint-settings-button").last().click();
     const modal = page.getByTestId("loadpoint-settings-modal").first();
+    await expectModalVisible(modal);
     await modal.getByTestId("battery-boost-limit").selectOption("0 %");
     await modal.getByLabel("Close").click();
     await expectModalHidden(modal);

--- a/tests/config-device-auth.spec.ts
+++ b/tests/config-device-auth.spec.ts
@@ -50,8 +50,7 @@ test.describe("config device auth", async () => {
     await expect(meterModal.getByRole("button", { name: "Save" })).not.toBeVisible();
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
-    // first choice ("redirect") should be auto-selected for required choice params
-    await expect(meterModal.getByLabel("Authentication Method")).toHaveValue("redirect");
+    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     // Get the login link and remove target="_blank" to keep it in same page
@@ -85,6 +84,7 @@ test.describe("config device auth", async () => {
     // step 2: show regular device form - auth is complete, fill in server details again
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
+    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
 
     // Even though auth is already done, still need to click prepare connection to proceed to device fields
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
@@ -161,6 +161,7 @@ test.describe("config device auth", async () => {
     await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
     await meterModal.getByLabel("Server").fill("invalid-url-without-scheme");
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
+    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     await expect(meterModal).toContainText("server must start with http:// or https://");
@@ -198,6 +199,7 @@ test.describe("config device auth", async () => {
     await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
+    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     // Get the login link and remove target="_blank" to keep it in same page
@@ -233,6 +235,7 @@ test.describe("config device auth", async () => {
     await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
+    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     // verify connection link is ready but close modal instead of clicking it

--- a/tests/config-device-auth.spec.ts
+++ b/tests/config-device-auth.spec.ts
@@ -50,7 +50,8 @@ test.describe("config device auth", async () => {
     await expect(meterModal.getByRole("button", { name: "Save" })).not.toBeVisible();
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
-    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
+    // first choice ("redirect") should be auto-selected for required choice params
+    await expect(meterModal.getByLabel("Authentication Method")).toHaveValue("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     // Get the login link and remove target="_blank" to keep it in same page
@@ -84,7 +85,6 @@ test.describe("config device auth", async () => {
     // step 2: show regular device form - auth is complete, fill in server details again
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
-    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
 
     // Even though auth is already done, still need to click prepare connection to proceed to device fields
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
@@ -161,7 +161,6 @@ test.describe("config device auth", async () => {
     await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
     await meterModal.getByLabel("Server").fill("invalid-url-without-scheme");
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
-    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     await expect(meterModal).toContainText("server must start with http:// or https://");
@@ -199,7 +198,6 @@ test.describe("config device auth", async () => {
     await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
-    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     // Get the login link and remove target="_blank" to keep it in same page
@@ -235,7 +233,6 @@ test.describe("config device auth", async () => {
     await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
-    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
     await meterModal.getByRole("button", { name: "Prepare connection" }).click();
 
     // verify connection link is ready but close modal instead of clicking it

--- a/tests/config-loadpoint.spec.ts
+++ b/tests/config-loadpoint.spec.ts
@@ -156,7 +156,7 @@ test.describe("charging loadpoint", async () => {
     // second loadpoint: increase priority
     await page.getByTestId("loadpoint").nth(1).getByRole("button", { name: "edit" }).click();
     await expectModalVisible(lpModal);
-    await expect(lpModal.getByLabel("Priority")).toHaveValue("0 (default)");
+    await expect(lpModal.getByLabel("Priority")).toHaveValue("0");
     await lpModal.getByLabel("Priority").selectOption("1");
     await lpModal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(lpModal);
@@ -182,7 +182,7 @@ test.describe("charging loadpoint", async () => {
     // check priorities
     await page.getByTestId("loadpoint").nth(1).getByRole("button", { name: "edit" }).click();
     await expectModalVisible(lpModal);
-    await expect(lpModal.getByLabel("Priority")).toHaveValue("0 (default)");
+    await expect(lpModal.getByLabel("Priority")).toHaveValue("0");
   });
 
   test("vehicle", async ({ page }) => {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/28916

- ~Explicitly pick the first option as default for required choice params.~
- Add selected empty (`---`) option for required choice fields without default.
- Fix browser validation to not allow empty select values for required params.

[select.webm](https://github.com/user-attachments/assets/77712382-b0be-494f-9293-6457e539a9ad)
