### PR TITLE
Easee: restore noop signal from dispatcher Send

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -486,7 +486,7 @@ func (c *Easee) Enable(enable bool) (err error) {
 		}
 
 		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
-		if err := c.dispatcher.Send(uri, data); err != nil {
+		if _, err := c.dispatcher.Send(uri, data); err != nil {
 			return err
 		}
 	}
@@ -508,7 +508,7 @@ func (c *Easee) Enable(enable bool) (err error) {
 	}
 
 	uri := fmt.Sprintf("%s/chargers/%s/commands/%s", easee.API, c.charger, action)
-	if err := c.dispatcher.Send(uri, nil); err != nil {
+	if _, err := c.dispatcher.Send(uri, nil); err != nil {
 		return err
 	}
 
@@ -620,11 +620,15 @@ func (c *Easee) MaxCurrent(current int64) error {
 	}
 
 	uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
-	if err := c.dispatcher.Send(uri, data); err != nil {
+	noop, err := c.dispatcher.Send(uri, data)
+	if err != nil {
 		return err
 	}
-	if err := c.waitForDynamicChargerCurrent(cur); err != nil {
-		return err
+
+	if !noop {
+		if err := c.waitForDynamicChargerCurrent(cur); err != nil {
+			return err
+		}
 	}
 
 	c.mux.Lock()
@@ -733,7 +737,7 @@ func (c *Easee) Phases1p3p(phases int) error {
 		// cloud sends on HTTP 200 (sync) responses is silently consumed rather
 		// than logged as rogue. On error we undo the registration.
 		c.dispatcher.ExpectOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
-		err = c.dispatcher.Send(uri, data)
+		_, err = c.dispatcher.Send(uri, data)
 		if err != nil {
 			c.dispatcher.CancelOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
 		}
@@ -751,7 +755,7 @@ func (c *Easee) Phases1p3p(phases int) error {
 
 			uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
 
-			if err = c.dispatcher.Send(uri, data); err != nil {
+			if _, err = c.dispatcher.Send(uri, data); err != nil {
 				return err
 			}
 		}
@@ -829,7 +833,7 @@ func (c *Easee) updateSmartCharging() {
 
 		uri := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
 
-		if err := c.dispatcher.Send(uri, data); err != nil {
+		if _, err := c.dispatcher.Send(uri, data); err != nil {
 			c.log.WARN.Printf("smart charging: %v", err)
 			return
 		}

--- a/charger/easee/dispatcher.go
+++ b/charger/easee/dispatcher.go
@@ -104,18 +104,21 @@ func (d *CommandDispatcher) CancelOrphan(id ObservationID) bool {
 // if the response is asynchronous (HTTP 202), waits for the matching SignalR
 // CommandResponse.
 //
-// Returns nil on success (both synchronous HTTP 200 and confirmed async HTTP 202,
-// including noops where Ticks == 0). Returns an error on HTTP failure, decode
-// failure, command rejection, or timeout.
-func (d *CommandDispatcher) Send(uri string, data any) error {
+// Returns noop=true when the API indicates no state change was needed (HTTP 200
+// or HTTP 202 with an empty settings array / Ticks == 0). Callers that wait for
+// a subsequent state observation (e.g. waitForDynamicChargerCurrent) must skip
+// the wait on noop to avoid a timeout.
+//
+// Returns an error on HTTP failure, decode failure, command rejection, or timeout.
+func (d *CommandDispatcher) Send(uri string, data any) (bool, error) {
 	resp, err := d.helper.Post(uri, request.JSONContent, request.MarshalJSON(data))
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 200 {
-		return nil
+		return true, nil
 	}
 
 	// Any status other than 200 or 202 is unexpected — return an error.
@@ -123,7 +126,7 @@ func (d *CommandDispatcher) Send(uri string, data any) error {
 	// not on HTTP error responses, so this guard is the actual defense against
 	// 4xx/5xx responses from the Easee API.
 	if resp.StatusCode != 202 {
-		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+		return false, fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}
 
 	// HTTP 202: parse the response body to get the command correlation info.
@@ -131,13 +134,13 @@ func (d *CommandDispatcher) Send(uri string, data any) error {
 	if strings.Contains(uri, "/commands/") {
 		// Command endpoints return a single object.
 		if err := json.NewDecoder(resp.Body).Decode(&cmd); err != nil {
-			return err
+			return false, err
 		}
 	} else {
 		// Settings endpoints return an array; take index 0 if present.
 		var cmdArr []RestCommandResponse
 		if err := json.NewDecoder(resp.Body).Decode(&cmdArr); err != nil {
-			return err
+			return false, err
 		}
 		if len(cmdArr) != 0 {
 			cmd = cmdArr[0]
@@ -149,7 +152,7 @@ func (d *CommandDispatcher) Send(uri string, data any) error {
 
 	if cmd.Ticks == 0 {
 		// Noop: the API indicates no state change was needed.
-		return nil
+		return true, nil
 	}
 
 	// Create a buffered channel (capacity 1) so Dispatch never blocks even if
@@ -177,10 +180,10 @@ func (d *CommandDispatcher) Send(uri string, data any) error {
 	select {
 	case res := <-ch:
 		if !res.WasAccepted {
-			return fmt.Errorf("command rejected: %d", res.Ticks)
+			return false, fmt.Errorf("command rejected: %d", res.Ticks)
 		}
-		return nil
+		return false, nil
 	case <-timer.C:
-		return api.ErrTimeout
+		return false, api.ErrTimeout
 	}
 }

--- a/charger/easee/dispatcher_test.go
+++ b/charger/easee/dispatcher_test.go
@@ -103,7 +103,9 @@ func TestDispatcher_Send_HTTP200Sync(t *testing.T) {
 	httpmock.RegisterResponder(http.MethodPost, testURI,
 		httpmock.NewStringResponder(http.StatusOK, ""))
 
-	assert.NoError(t, d.Send(testURI, nil))
+	noop, err := d.Send(testURI, nil)
+	assert.NoError(t, err)
+	assert.True(t, noop)
 }
 
 func TestDispatcher_Send_Noop(t *testing.T) {
@@ -115,7 +117,9 @@ func TestDispatcher_Send_Noop(t *testing.T) {
 	httpmock.RegisterResponder(http.MethodPost, testURI,
 		httpmock.NewStringResponder(http.StatusAccepted, "[]"))
 
-	assert.NoError(t, d.Send(testURI, nil))
+	noop, err := d.Send(testURI, nil)
+	assert.NoError(t, err)
+	assert.True(t, noop)
 }
 
 func TestDispatcher_Send_HTTP202_InvalidJSON(t *testing.T) {
@@ -125,7 +129,8 @@ func TestDispatcher_Send_HTTP202_InvalidJSON(t *testing.T) {
 	httpmock.RegisterResponder(http.MethodPost, testURI,
 		httpmock.NewStringResponder(http.StatusAccepted, "{not-json"))
 
-	assert.Error(t, d.Send(testURI, nil))
+	_, err := d.Send(testURI, nil)
+	assert.Error(t, err)
 }
 
 func TestDispatcher_Send_HTTP202_NonNumericTicks(t *testing.T) {
@@ -135,7 +140,8 @@ func TestDispatcher_Send_HTTP202_NonNumericTicks(t *testing.T) {
 	httpmock.RegisterResponder(http.MethodPost, testURI,
 		httpmock.NewStringResponder(http.StatusAccepted, `[{"ticks":"NaN"}]`))
 
-	assert.Error(t, d.Send(testURI, nil))
+	_, err := d.Send(testURI, nil)
+	assert.Error(t, err)
 }
 
 func TestDispatcher_Send_HTTPError(t *testing.T) {
@@ -146,7 +152,7 @@ func TestDispatcher_Send_HTTPError(t *testing.T) {
 	httpmock.RegisterResponder(http.MethodPost, testURI,
 		httpmock.NewStringResponder(http.StatusBadRequest, ""))
 
-	err := d.Send(testURI, nil)
+	_, err := d.Send(testURI, nil)
 	assert.Error(t, err)
 }
 
@@ -166,7 +172,9 @@ func TestDispatcher_Send_TicksMatch(t *testing.T) {
 		d.Dispatch(SignalRCommandResponse{Ticks: ticks, WasAccepted: true})
 	}()
 
-	assert.NoError(t, d.Send(testURI, nil))
+	noop, err := d.Send(testURI, nil)
+	assert.NoError(t, err)
+	assert.False(t, noop)
 }
 
 func TestDispatcher_Send_IDFallback(t *testing.T) {
@@ -187,7 +195,9 @@ func TestDispatcher_Send_IDFallback(t *testing.T) {
 		d.Dispatch(SignalRCommandResponse{ID: int(obsID), Ticks: ticks + 1, WasAccepted: true})
 	}()
 
-	assert.NoError(t, d.Send(testURI, nil))
+	noop, err := d.Send(testURI, nil)
+	assert.NoError(t, err)
+	assert.False(t, noop)
 }
 
 func TestDispatcher_Send_Timeout(t *testing.T) {
@@ -202,7 +212,8 @@ func TestDispatcher_Send_Timeout(t *testing.T) {
 		httpmock.NewStringResponder(http.StatusAccepted, body))
 
 	// No Dispatch call → Send times out
-	assert.ErrorIs(t, d.Send(testURI, nil), api.ErrTimeout)
+	_, err := d.Send(testURI, nil)
+	assert.ErrorIs(t, err, api.ErrTimeout)
 }
 
 func TestDispatcher_Send_Rejected(t *testing.T) {
@@ -221,7 +232,7 @@ func TestDispatcher_Send_Rejected(t *testing.T) {
 		d.Dispatch(SignalRCommandResponse{Ticks: ticks, WasAccepted: false})
 	}()
 
-	err := d.Send(testURI, nil)
+	_, err := d.Send(testURI, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "rejected")
 }
@@ -243,5 +254,7 @@ func TestDispatcher_Send_CommandURI(t *testing.T) {
 		d.Dispatch(SignalRCommandResponse{Ticks: ticks, WasAccepted: true})
 	}()
 
-	assert.NoError(t, d.Send(testCmdURI, nil))
+	noop, err := d.Send(testCmdURI, nil)
+	assert.NoError(t, err)
+	assert.False(t, noop)
 }

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -330,7 +330,7 @@ func TestEasee_CommandResponse_legitimate(t *testing.T) {
 		errCh <- nil
 	}()
 
-	err = e.dispatcher.Send(uri, nil)
+	_, err = e.dispatcher.Send(uri, nil)
 	assert.NoError(t, err)
 	<-errCh
 }
@@ -420,7 +420,7 @@ func TestEasee_CommandResponse_matchedByID(t *testing.T) {
 		errCh <- nil
 	}()
 
-	err = e.dispatcher.Send(uri, nil)
+	_, err = e.dispatcher.Send(uri, nil)
 	assert.NoError(t, err)
 	<-errCh
 }


### PR DESCRIPTION
fix #28945

The dispatcher refactoring (5877d0acd) changed Send to return only error, losing the noop indicator that postJSONAndWait previously returned. This caused MaxCurrent to always call waitForDynamicChargerCurrent, even when the API indicated no state change was needed (empty settings array). In the charger-logic-error recovery path (Enable → resume → MaxCurrent), the API returns a noop for the DCC adjustment while the charger still reports DCC=32 from the resume, leading to a spurious timeout.