### PR TITLE
Tariffs: update Pstryk API integration for pricing metrics

### DIFF
--- a/templates/definition/tariff/pstryk.yaml
+++ b/templates/definition/tariff/pstryk.yaml
@@ -37,13 +37,13 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://api.pstryk.pl/integrations/meter-data/unified-metrics/?metrics=pricing&resolution=hour&window_start={{ `{{ now.UTC | mustDateModify "-24h" | date "2006-01-02T15" }}` }}:00:00Z&window_end={{ `{{ now.UTC | mustDateModify "+72h" | date "2006-01-02" }}` }}:00:00Z
+    uri: https://api.pstryk.pl/integrations/meter-data/unified-metrics/?metrics=pricing&resolution=hour&window_start={{ `{{ now.UTC | mustDateModify "-24h" | date "2006-01-02" }}` }}:00:00Z&window_end={{ `{{ now.UTC | mustDateModify "+72h" | date "2006-01-02" }}` }}:00:00Z
     headers:
       Authorization: {{ .token }}
       Accept: application/json
     jq: |
       [(.frames // [])[]
-        | select(.metrics.pricing != null)
+        | select(.metrics?.pricing? != null)
         | {
           start: (.start | sub("\\+00:00$"; "Z")),
           end: (.end | sub("\\+00:00$"; "Z")),

--- a/templates/definition/tariff/pstryk.yaml
+++ b/templates/definition/tariff/pstryk.yaml
@@ -37,17 +37,17 @@ render: |
   {{ include "tariff-base" . }}
   forecast:
     source: http
-    uri: https://api.pstryk.pl/integrations/{{ .plan }}/?resolution=hour&window_start={{ `{{ now | mustDateModify "-24h" | date "2006-01-02" }}` }}&window_end={{ `{{ now | mustDateModify "+72h" | date "2006-01-02" }}` }}
+    uri: https://api.pstryk.pl/integrations/meter-data/unified-metrics/?metrics=pricing&resolution=hour&window_start={{ `{{ now.UTC | mustDateModify "-24h" | date "2006-01-02T15" }}` }}:00:00Z&window_end={{ `{{ now.UTC | mustDateModify "+72h" | date "2006-01-02" }}` }}:00:00Z
     headers:
       Authorization: {{ .token }}
       Accept: application/json
     jq: |
       [(.frames // [])[]
-        | select(.is_cheap != null or .is_expensive != null)
+        | select(.metrics.pricing != null)
         | {
           start: (.start | sub("\\+00:00$"; "Z")),
           end: (.end | sub("\\+00:00$"; "Z")),
-          value: .price_gross
+          value: .metrics.pricing.{{ if eq .plan "prosumer-pricing" }}price_prosumer_gross{{ else }}price_gross{{ end }}
         }
       ] | tostring
   interval: {{ .interval }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/28982

Pstryk changed their API since 01.04.2026.

Endpoints used in evcc no longer exist. Updated tariff template to match updated API.

Tested with newest stable binary (https://github.com/evcc-io/evcc/blob/411f194645b522e6221fd7d588e8b57f8c59e628/CONTRIBUTING.md#device-templates) - works.