### PR TITLE
Fix chargeMeter capability wrapping for meters with own registry

### DIFF
--- a/api/capable_test.go
+++ b/api/capable_test.go
@@ -112,6 +112,51 @@ func TestCap_ExtractedCapabilityLosesRegistry(t *testing.T) {
 	assert.Equal(t, 99.0, energy)
 }
 
+func TestCap_ExtractedMeterWithOwnCapableRegistry(t *testing.T) {
+	// Reproduces https://github.com/evcc-io/evcc/issues/28978
+	// When a Meter extracted from a charger already implements Capable itself,
+	// wrapping it with capableMeter using the charger's registry must NOT
+	// override the meter's own capability registry.
+
+	// meter that carries its own capability registry (e.g. Alfen charger)
+	meterWithCaps := &decoratedMeter{
+		Meter: &testMeterImpl{},
+		caps: map[reflect.Type]any{
+			reflect.TypeFor[MeterEnergy](): &testMeterEnergyImpl{},
+		},
+	}
+
+	// charger with a different (empty) capability registry
+	charger := &decoratedCharger{
+		caps: map[reflect.Type]any{
+			reflect.TypeFor[Meter](): meterWithCaps,
+		},
+	}
+
+	// extract Meter from charger
+	mt, ok := Cap[Meter](charger)
+	require.True(t, ok)
+
+	// meter itself is Capable — should find MeterEnergy via its own registry
+	me, ok := Cap[MeterEnergy](mt)
+	require.True(t, ok, "meter with own Capable registry should find MeterEnergy")
+
+	energy, err := me.TotalEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 99.0, energy)
+
+	// wrapping with charger's Capable would LOSE the meter's own capabilities
+	type capableMeter struct {
+		Meter
+		Capable
+	}
+	wrapped := &capableMeter{Meter: mt, Capable: charger}
+
+	// charger's registry does NOT have MeterEnergy — wrapping breaks it
+	_, ok = Cap[MeterEnergy](wrapped)
+	assert.False(t, ok, "wrapping meter that has own Capable with charger's Capable loses meter capabilities")
+}
+
 func TestCap_NilValue(t *testing.T) {
 	_, ok := Cap[MeterEnergy](nil)
 	assert.False(t, ok)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -415,10 +415,13 @@ func (lp *Loadpoint) configureChargerType(charger api.Charger) {
 			// preserve charger's capability registry so that subsequent
 			// capability checks on chargeMeter (e.g. MeterEnergy, PhaseCurrents)
 			// still work for decorated chargers (https://github.com/evcc-io/evcc/issues/28915)
-			if c, ok := charger.(api.Capable); ok {
+			// only wrap mt if it does not carry its own capability registry (https://github.com/evcc-io/evcc/issues/28978)
+			_, mtCapable := mt.(api.Capable)
+			c, chargerCapable := charger.(api.Capable)
+
+			lp.chargeMeter = mt
+			if !mtCapable && chargerCapable {
 				lp.chargeMeter = &capableMeter{Meter: mt, Capable: c}
-			} else {
-				lp.chargeMeter = mt
 			}
 		} else {
 			mt := new(wrapper.ChargeMeter)


### PR DESCRIPTION
## Summary

- Fixes #28978: charger voltages, currents, and total import missing on loadpoints where the extracted meter already implements `api.Capable` (e.g. Alfen charger)
- Only wraps `mt` with `capableMeter` when the meter does **not** carry its own capability registry, preventing the charger's registry from overriding the meter's own capabilities
- Adds regression test `TestCap_ExtractedMeterWithOwnCapableRegistry`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./api/... ./core/...` passes
- [x] `golangci-lint run ./api/... ./core/...` — 0 issues
- [ ] Manual verification with Alfen charger: voltages, currents, and total import should appear in lp logs again

🤖 Generated with [Claude Code](https://claude.com/claude-code)