### PR TITLE
Fix docorating by promoting embedded type methods as capabilities

### DIFF
--- a/charger/abl_decorators.go
+++ b/charger/abl_decorators.go
@@ -33,6 +33,9 @@ type decorateABLeMHCapable struct {
 
 func (d *decorateABLeMHCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/abl_decorators.go
+++ b/charger/abl_decorators.go
@@ -33,8 +33,8 @@ type decorateABLeMHCapable struct {
 
 func (d *decorateABLeMHCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/alfen_decorators.go
+++ b/charger/alfen_decorators.go
@@ -33,6 +33,9 @@ type decorateAlfenCapable struct {
 
 func (d *decorateAlfenCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/alfen_decorators.go
+++ b/charger/alfen_decorators.go
@@ -33,8 +33,8 @@ type decorateAlfenCapable struct {
 
 func (d *decorateAlfenCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/amperfied_decorators.go
+++ b/charger/amperfied_decorators.go
@@ -33,6 +33,9 @@ type decorateAmperfiedCapable struct {
 
 func (d *decorateAmperfiedCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/amperfied_decorators.go
+++ b/charger/amperfied_decorators.go
@@ -33,8 +33,8 @@ type decorateAmperfiedCapable struct {
 
 func (d *decorateAmperfiedCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/bender_decorators.go
+++ b/charger/bender_decorators.go
@@ -61,8 +61,8 @@ type decorateBenderCCCapable struct {
 
 func (d *decorateBenderCCCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/bender_decorators.go
+++ b/charger/bender_decorators.go
@@ -61,6 +61,9 @@ type decorateBenderCCCapable struct {
 
 func (d *decorateBenderCCCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/cfos_decorators.go
+++ b/charger/cfos_decorators.go
@@ -41,6 +41,9 @@ type decorateCfosCapable struct {
 
 func (d *decorateCfosCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/cfos_decorators.go
+++ b/charger/cfos_decorators.go
@@ -41,8 +41,8 @@ type decorateCfosCapable struct {
 
 func (d *decorateCfosCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/charger_decorators.go
+++ b/charger/charger_decorators.go
@@ -65,6 +65,9 @@ type decorateCustomCapable struct {
 
 func (d *decorateCustomCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/charger_decorators.go
+++ b/charger/charger_decorators.go
@@ -65,8 +65,8 @@ type decorateCustomCapable struct {
 
 func (d *decorateCustomCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/daheimladen_decorators.go
+++ b/charger/daheimladen_decorators.go
@@ -33,6 +33,9 @@ type decorateDaheimLadenCapable struct {
 
 func (d *decorateDaheimLadenCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/daheimladen_decorators.go
+++ b/charger/daheimladen_decorators.go
@@ -33,8 +33,8 @@ type decorateDaheimLadenCapable struct {
 
 func (d *decorateDaheimLadenCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/eebus_decorators.go
+++ b/charger/eebus_decorators.go
@@ -37,8 +37,8 @@ type decorateEEBusCapable struct {
 
 func (d *decorateEEBusCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/eebus_decorators.go
+++ b/charger/eebus_decorators.go
@@ -37,6 +37,9 @@ type decorateEEBusCapable struct {
 
 func (d *decorateEEBusCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/em2go_decorators.go
+++ b/charger/em2go_decorators.go
@@ -37,6 +37,9 @@ type decorateEm2GoCapable struct {
 
 func (d *decorateEm2GoCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/em2go_decorators.go
+++ b/charger/em2go_decorators.go
@@ -37,8 +37,8 @@ type decorateEm2GoCapable struct {
 
 func (d *decorateEm2GoCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/etek_decorators.go
+++ b/charger/etek_decorators.go
@@ -37,8 +37,8 @@ type decorateEtekCapable struct {
 
 func (d *decorateEtekCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/etek_decorators.go
+++ b/charger/etek_decorators.go
@@ -37,6 +37,9 @@ type decorateEtekCapable struct {
 
 func (d *decorateEtekCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/evecube_decorators.go
+++ b/charger/evecube_decorators.go
@@ -33,8 +33,8 @@ type decorateEVECUBECapable struct {
 
 func (d *decorateEVECUBECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/evecube_decorators.go
+++ b/charger/evecube_decorators.go
@@ -33,6 +33,9 @@ type decorateEVECUBECapable struct {
 
 func (d *decorateEVECUBECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/evsedin_decorators.go
+++ b/charger/evsedin_decorators.go
@@ -29,8 +29,8 @@ type decorateEvseDINCapable struct {
 
 func (d *decorateEvseDINCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/evsedin_decorators.go
+++ b/charger/evsedin_decorators.go
@@ -29,6 +29,9 @@ type decorateEvseDINCapable struct {
 
 func (d *decorateEvseDINCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/evsewifi_decorators.go
+++ b/charger/evsewifi_decorators.go
@@ -49,8 +49,8 @@ type decorateEVSECapable struct {
 
 func (d *decorateEVSECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/evsewifi_decorators.go
+++ b/charger/evsewifi_decorators.go
@@ -49,6 +49,9 @@ type decorateEVSECapable struct {
 
 func (d *decorateEVSECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/ghosteebus_decorators.go
+++ b/charger/ghosteebus_decorators.go
@@ -45,8 +45,8 @@ type decorateGhostEEBusCapable struct {
 
 func (d *decorateGhostEEBusCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/ghosteebus_decorators.go
+++ b/charger/ghosteebus_decorators.go
@@ -45,6 +45,9 @@ type decorateGhostEEBusCapable struct {
 
 func (d *decorateGhostEEBusCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/go-e_decorators.go
+++ b/charger/go-e_decorators.go
@@ -33,8 +33,8 @@ type decorateGoECapable struct {
 
 func (d *decorateGoECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/go-e_decorators.go
+++ b/charger/go-e_decorators.go
@@ -33,6 +33,9 @@ type decorateGoECapable struct {
 
 func (d *decorateGoECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/hardybarth-salia_decorators.go
+++ b/charger/hardybarth-salia_decorators.go
@@ -45,8 +45,8 @@ type decorateSaliaCapable struct {
 
 func (d *decorateSaliaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/hardybarth-salia_decorators.go
+++ b/charger/hardybarth-salia_decorators.go
@@ -45,6 +45,9 @@ type decorateSaliaCapable struct {
 
 func (d *decorateSaliaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/heatpump_decorators.go
+++ b/charger/heatpump_decorators.go
@@ -41,6 +41,9 @@ type decorateHeatpumpCapable struct {
 
 func (d *decorateHeatpumpCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/heatpump_decorators.go
+++ b/charger/heatpump_decorators.go
@@ -41,8 +41,8 @@ type decorateHeatpumpCapable struct {
 
 func (d *decorateHeatpumpCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/homeassistant_decorators.go
+++ b/charger/homeassistant_decorators.go
@@ -49,8 +49,8 @@ type decorateHomeAssistantCapable struct {
 
 func (d *decorateHomeAssistantCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/homeassistant_decorators.go
+++ b/charger/homeassistant_decorators.go
@@ -49,6 +49,9 @@ type decorateHomeAssistantCapable struct {
 
 func (d *decorateHomeAssistantCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/innogy_decorators.go
+++ b/charger/innogy_decorators.go
@@ -33,8 +33,8 @@ type decorateInnogyCapable struct {
 
 func (d *decorateInnogyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/innogy_decorators.go
+++ b/charger/innogy_decorators.go
@@ -33,6 +33,9 @@ type decorateInnogyCapable struct {
 
 func (d *decorateInnogyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/keba-modbus_decorators.go
+++ b/charger/keba-modbus_decorators.go
@@ -53,6 +53,9 @@ type decorateKebaCapable struct {
 
 func (d *decorateKebaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/keba-modbus_decorators.go
+++ b/charger/keba-modbus_decorators.go
@@ -53,8 +53,8 @@ type decorateKebaCapable struct {
 
 func (d *decorateKebaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/keba-udp_decorators.go
+++ b/charger/keba-udp_decorators.go
@@ -37,8 +37,8 @@ type decorateKebaUdpCapable struct {
 
 func (d *decorateKebaUdpCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/keba-udp_decorators.go
+++ b/charger/keba-udp_decorators.go
@@ -37,6 +37,9 @@ type decorateKebaUdpCapable struct {
 
 func (d *decorateKebaUdpCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/kse_decorators.go
+++ b/charger/kse_decorators.go
@@ -37,8 +37,8 @@ type decorateKSECapable struct {
 
 func (d *decorateKSECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/kse_decorators.go
+++ b/charger/kse_decorators.go
@@ -37,6 +37,9 @@ type decorateKSECapable struct {
 
 func (d *decorateKSECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/mennekes-compact_decorators.go
+++ b/charger/mennekes-compact_decorators.go
@@ -29,6 +29,9 @@ type decorateMennekesCompactCapable struct {
 
 func (d *decorateMennekesCompactCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/mennekes-compact_decorators.go
+++ b/charger/mennekes-compact_decorators.go
@@ -29,8 +29,8 @@ type decorateMennekesCompactCapable struct {
 
 func (d *decorateMennekesCompactCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/nrggen2_decorators.go
+++ b/charger/nrggen2_decorators.go
@@ -29,8 +29,8 @@ type decorateNRGKickGen2Capable struct {
 
 func (d *decorateNRGKickGen2Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/nrggen2_decorators.go
+++ b/charger/nrggen2_decorators.go
@@ -29,6 +29,9 @@ type decorateNRGKickGen2Capable struct {
 
 func (d *decorateNRGKickGen2Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/ocpp_decorators.go
+++ b/charger/ocpp_decorators.go
@@ -53,8 +53,8 @@ type decorateOCPPCapable struct {
 
 func (d *decorateOCPPCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/ocpp_decorators.go
+++ b/charger/ocpp_decorators.go
@@ -53,6 +53,9 @@ type decorateOCPPCapable struct {
 
 func (d *decorateOCPPCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/openevse_decorators.go
+++ b/charger/openevse_decorators.go
@@ -29,6 +29,9 @@ type decorateOpenEVSECapable struct {
 
 func (d *decorateOpenEVSECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/openevse_decorators.go
+++ b/charger/openevse_decorators.go
@@ -29,8 +29,8 @@ type decorateOpenEVSECapable struct {
 
 func (d *decorateOpenEVSECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/openwb-2.0_decorators.go
+++ b/charger/openwb-2.0_decorators.go
@@ -33,8 +33,8 @@ type decorateOpenWB20Capable struct {
 
 func (d *decorateOpenWB20Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/openwb-2.0_decorators.go
+++ b/charger/openwb-2.0_decorators.go
@@ -33,6 +33,9 @@ type decorateOpenWB20Capable struct {
 
 func (d *decorateOpenWB20Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/openwb-native_decorators_linux.go
+++ b/charger/openwb-native_decorators_linux.go
@@ -37,6 +37,9 @@ type decorateOpenWbNativeCapable struct {
 
 func (d *decorateOpenWbNativeCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
+	}
 	return c, ok
 }
 

--- a/charger/openwb-pro_decorators.go
+++ b/charger/openwb-pro_decorators.go
@@ -29,8 +29,8 @@ type decorateOpenWBProCapable struct {
 
 func (d *decorateOpenWBProCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/openwb-pro_decorators.go
+++ b/charger/openwb-pro_decorators.go
@@ -29,6 +29,9 @@ type decorateOpenWBProCapable struct {
 
 func (d *decorateOpenWBProCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/openwb_decorators.go
+++ b/charger/openwb_decorators.go
@@ -33,6 +33,9 @@ type decorateOpenWBCapable struct {
 
 func (d *decorateOpenWBCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/openwb_decorators.go
+++ b/charger/openwb_decorators.go
@@ -33,8 +33,8 @@ type decorateOpenWBCapable struct {
 
 func (d *decorateOpenWBCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/pcelectric_decorators.go
+++ b/charger/pcelectric_decorators.go
@@ -37,6 +37,9 @@ type decoratePCECapable struct {
 
 func (d *decoratePCECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/pcelectric_decorators.go
+++ b/charger/pcelectric_decorators.go
@@ -37,8 +37,8 @@ type decoratePCECapable struct {
 
 func (d *decoratePCECapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/peblar_decorators.go
+++ b/charger/peblar_decorators.go
@@ -33,6 +33,9 @@ type decoratePeblarCapable struct {
 
 func (d *decoratePeblarCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/peblar_decorators.go
+++ b/charger/peblar_decorators.go
@@ -33,8 +33,8 @@ type decoratePeblarCapable struct {
 
 func (d *decoratePeblarCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/phoenix-charx_decorators.go
+++ b/charger/phoenix-charx_decorators.go
@@ -41,6 +41,9 @@ type decoratePhoenixCharxCapable struct {
 
 func (d *decoratePhoenixCharxCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/phoenix-charx_decorators.go
+++ b/charger/phoenix-charx_decorators.go
@@ -41,8 +41,8 @@ type decoratePhoenixCharxCapable struct {
 
 func (d *decoratePhoenixCharxCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/phoenix-em-eth_decorators.go
+++ b/charger/phoenix-em-eth_decorators.go
@@ -41,6 +41,9 @@ type decoratePhoenixEMEthCapable struct {
 
 func (d *decoratePhoenixEMEthCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/phoenix-em-eth_decorators.go
+++ b/charger/phoenix-em-eth_decorators.go
@@ -41,8 +41,8 @@ type decoratePhoenixEMEthCapable struct {
 
 func (d *decoratePhoenixEMEthCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/phoenix-ev-eth_decorators.go
+++ b/charger/phoenix-ev-eth_decorators.go
@@ -49,6 +49,9 @@ type decoratePhoenixEVEthCapable struct {
 
 func (d *decoratePhoenixEVEthCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/phoenix-ev-eth_decorators.go
+++ b/charger/phoenix-ev-eth_decorators.go
@@ -49,8 +49,8 @@ type decoratePhoenixEVEthCapable struct {
 
 func (d *decoratePhoenixEVEthCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/pulsares_decorators.go
+++ b/charger/pulsares_decorators.go
@@ -29,6 +29,9 @@ type decoratePulsaresCapable struct {
 
 func (d *decoratePulsaresCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/pulsares_decorators.go
+++ b/charger/pulsares_decorators.go
@@ -29,8 +29,8 @@ type decoratePulsaresCapable struct {
 
 func (d *decoratePulsaresCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/semp_decorators.go
+++ b/charger/semp_decorators.go
@@ -37,6 +37,9 @@ type decorateSEMPCapable struct {
 
 func (d *decorateSEMPCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/semp_decorators.go
+++ b/charger/semp_decorators.go
@@ -37,8 +37,8 @@ type decorateSEMPCapable struct {
 
 func (d *decorateSEMPCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/sgready_decorators.go
+++ b/charger/sgready_decorators.go
@@ -41,8 +41,8 @@ type decorateSgReadyCapable struct {
 
 func (d *decorateSgReadyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/sgready_decorators.go
+++ b/charger/sgready_decorators.go
@@ -41,6 +41,9 @@ type decorateSgReadyCapable struct {
 
 func (d *decorateSgReadyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/shelly_decorators.go
+++ b/charger/shelly_decorators.go
@@ -37,8 +37,8 @@ type decorateShellyCapable struct {
 
 func (d *decorateShellyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/shelly_decorators.go
+++ b/charger/shelly_decorators.go
@@ -37,6 +37,9 @@ type decorateShellyCapable struct {
 
 func (d *decorateShellyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/solax_decorators.go
+++ b/charger/solax_decorators.go
@@ -33,8 +33,8 @@ type decorateSolaxCapable struct {
 
 func (d *decorateSolaxCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/solax_decorators.go
+++ b/charger/solax_decorators.go
@@ -33,6 +33,9 @@ type decorateSolaxCapable struct {
 
 func (d *decorateSolaxCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/switchsocket_decorators.go
+++ b/charger/switchsocket_decorators.go
@@ -33,6 +33,9 @@ type decorateSwitchSocketCapable struct {
 
 func (d *decorateSwitchSocketCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/switchsocket_decorators.go
+++ b/charger/switchsocket_decorators.go
@@ -33,8 +33,8 @@ type decorateSwitchSocketCapable struct {
 
 func (d *decorateSwitchSocketCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/tasmota_decorators.go
+++ b/charger/tasmota_decorators.go
@@ -33,8 +33,8 @@ type decorateTasmotaCapable struct {
 
 func (d *decorateTasmotaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/tasmota_decorators.go
+++ b/charger/tasmota_decorators.go
@@ -33,6 +33,9 @@ type decorateTasmotaCapable struct {
 
 func (d *decorateTasmotaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/vaillant_decorators.go
+++ b/charger/vaillant_decorators.go
@@ -33,6 +33,9 @@ type decorateVaillantCapable struct {
 
 func (d *decorateVaillantCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/vaillant_decorators.go
+++ b/charger/vaillant_decorators.go
@@ -33,8 +33,8 @@ type decorateVaillantCapable struct {
 
 func (d *decorateVaillantCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/vestel_decorators.go
+++ b/charger/vestel_decorators.go
@@ -37,6 +37,9 @@ type decorateVestelCapable struct {
 
 func (d *decorateVestelCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/vestel_decorators.go
+++ b/charger/vestel_decorators.go
@@ -37,8 +37,8 @@ type decorateVestelCapable struct {
 
 func (d *decorateVestelCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/victron_decorators.go
+++ b/charger/victron_decorators.go
@@ -33,8 +33,8 @@ type decorateVictronCapable struct {
 
 func (d *decorateVictronCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/victron_decorators.go
+++ b/charger/victron_decorators.go
@@ -33,6 +33,9 @@ type decorateVictronCapable struct {
 
 func (d *decorateVictronCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/wallbe_decorators.go
+++ b/charger/wallbe_decorators.go
@@ -41,6 +41,9 @@ type decorateWallbeCapable struct {
 
 func (d *decorateWallbeCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/wallbe_decorators.go
+++ b/charger/wallbe_decorators.go
@@ -41,8 +41,8 @@ type decorateWallbeCapable struct {
 
 func (d *decorateWallbeCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/warp-ws_decorators.go
+++ b/charger/warp-ws_decorators.go
@@ -53,6 +53,9 @@ type decorateWarpWSCapable struct {
 
 func (d *decorateWarpWSCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/warp-ws_decorators.go
+++ b/charger/warp-ws_decorators.go
@@ -53,8 +53,8 @@ type decorateWarpWSCapable struct {
 
 func (d *decorateWarpWSCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/warp2-mqtt_decorators.go
+++ b/charger/warp2-mqtt_decorators.go
@@ -53,8 +53,8 @@ type decorateWarp2Capable struct {
 
 func (d *decorateWarp2Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/warp2-mqtt_decorators.go
+++ b/charger/warp2-mqtt_decorators.go
@@ -53,6 +53,9 @@ type decorateWarp2Capable struct {
 
 func (d *decorateWarp2Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/weidmüller_decorators.go
+++ b/charger/weidmüller_decorators.go
@@ -29,6 +29,9 @@ type decorateWeidmüllerCapable struct {
 
 func (d *decorateWeidmüllerCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/weidmüller_decorators.go
+++ b/charger/weidmüller_decorators.go
@@ -29,8 +29,8 @@ type decorateWeidmüllerCapable struct {
 
 func (d *decorateWeidmüllerCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/charger/zaptec_decorators.go
+++ b/charger/zaptec_decorators.go
@@ -29,6 +29,9 @@ type decorateZaptecCapable struct {
 
 func (d *decorateZaptecCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/charger/zaptec_decorators.go
+++ b/charger/zaptec_decorators.go
@@ -29,8 +29,8 @@ type decorateZaptecCapable struct {
 
 func (d *decorateZaptecCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/cmd/decorate/decorate.tpl
+++ b/cmd/decorate/decorate.tpl
@@ -22,8 +22,8 @@ type {{.Function}}Capable struct {
 
 func (d *{{.Function}}Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/cmd/decorate/decorate.tpl
+++ b/cmd/decorate/decorate.tpl
@@ -22,6 +22,9 @@ type {{.Function}}Capable struct {
 
 func (d *{{.Function}}Capable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/cmd/decorate/decorate_decorators.go
+++ b/cmd/decorate/decorate_decorators.go
@@ -37,6 +37,9 @@ type decorateTestCapable struct {
 
 func (d *decorateTestCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/cmd/decorate/decorate_decorators.go
+++ b/cmd/decorate/decorate_decorators.go
@@ -37,8 +37,8 @@ type decorateTestCapable struct {
 
 func (d *decorateTestCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/core/capable_test.go
+++ b/core/capable_test.go
@@ -1,0 +1,106 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/stretchr/testify/assert"
+)
+
+type charger struct {
+	caps map[reflect.Type]any
+}
+
+var _ api.Capable = (*charger)(nil)
+
+func (c *charger) Capability(typ reflect.Type) (any, bool) {
+	cap, ok := c.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
+	return cap, ok
+}
+
+var _ api.Meter = (*charger)(nil)
+
+func (c *charger) CurrentPower() (float64, error) {
+	return 0, nil
+}
+
+var _ api.BatteryCapacity = (*charger)(nil)
+
+func (c *charger) Capacity() float64 {
+	return 0
+}
+
+var _ api.MeterEnergy = (*charger)(nil)
+
+func (c *charger) TotalEnergy() (float64, error) {
+	return 0, nil
+}
+
+var _ api.Battery = (*batteryImpl)(nil)
+
+type batteryImpl struct {
+	soc func() (float64, error)
+}
+
+func (impl *batteryImpl) Soc() (float64, error) {
+	return impl.soc()
+}
+
+func TestCapsWrapping(t *testing.T) {
+	// type is just a shortcut for something simple that is not a meter
+	var c api.BatteryCapacity
+
+	c = &charger{
+		caps: make(map[reflect.Type]any),
+	}
+
+	c.(*charger).caps[reflect.TypeFor[api.Battery]()] = &batteryImpl{
+		soc: func() (float64, error) {
+			return 0, nil
+		},
+	}
+
+	{
+		_, ok := c.(api.Meter)
+		assert.True(t, ok)
+	}
+	{
+		_, ok := c.(api.MeterEnergy)
+		assert.True(t, ok)
+	}
+	{
+		_, ok := c.(api.Battery)
+		assert.False(t, ok)
+		assert.True(t, api.HasCap[api.Battery](c))
+	}
+
+	var m api.Meter
+
+	if mt, ok := api.Cap[api.Meter](c); ok {
+		if c, ok := c.(api.Capable); ok {
+			m = &capableMeter{Meter: mt, Capable: c}
+		} else {
+			m = mt
+		}
+	}
+
+	{
+		_, ok := m.(api.MeterEnergy)
+		assert.False(t, ok, "unexpected promoted energy")
+		assert.True(t, api.HasCap[api.MeterEnergy](m), "missing promoted energy cap")
+
+		var mm any = m.(*capableMeter).Meter
+		_, ok = mm.(api.MeterEnergy)
+		assert.True(t, ok, "missing embedded energy")
+		assert.True(t, api.HasCap[api.MeterEnergy](mm), "missing embedded energy cap")
+	}
+	{
+		_, ok := m.(api.Battery)
+		assert.False(t, ok)
+		assert.True(t, api.HasCap[api.Battery](m), "missing battery cap")
+	}
+}

--- a/meter/dsmr_decorators.go
+++ b/meter/dsmr_decorators.go
@@ -33,6 +33,9 @@ type decorateDsmrCapable struct {
 
 func (d *decorateDsmrCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/dsmr_decorators.go
+++ b/meter/dsmr_decorators.go
@@ -33,8 +33,8 @@ type decorateDsmrCapable struct {
 
 func (d *decorateDsmrCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/e3dc_decorators.go
+++ b/meter/e3dc_decorators.go
@@ -49,6 +49,9 @@ type decorateE3dcCapable struct {
 
 func (d *decorateE3dcCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/e3dc_decorators.go
+++ b/meter/e3dc_decorators.go
@@ -49,8 +49,8 @@ type decorateE3dcCapable struct {
 
 func (d *decorateE3dcCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/goodwe-wifi_decorators.go
+++ b/meter/goodwe-wifi_decorators.go
@@ -33,6 +33,9 @@ type decorateGoodWeWifiCapable struct {
 
 func (d *decorateGoodWeWifiCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/goodwe-wifi_decorators.go
+++ b/meter/goodwe-wifi_decorators.go
@@ -33,8 +33,8 @@ type decorateGoodWeWifiCapable struct {
 
 func (d *decorateGoodWeWifiCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/lgess_decorators.go
+++ b/meter/lgess_decorators.go
@@ -49,8 +49,8 @@ type decorateLgEssCapable struct {
 
 func (d *decorateLgEssCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/lgess_decorators.go
+++ b/meter/lgess_decorators.go
@@ -49,6 +49,9 @@ type decorateLgEssCapable struct {
 
 func (d *decorateLgEssCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -45,6 +45,9 @@ type decorateMeterCapable struct {
 
 func (d *decorateMeterCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 
@@ -129,6 +132,9 @@ type decorateMeterBatteryCapable struct {
 
 func (d *decorateMeterBatteryCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/meter_decorators.go
+++ b/meter/meter_decorators.go
@@ -45,8 +45,8 @@ type decorateMeterCapable struct {
 
 func (d *decorateMeterCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }
@@ -132,8 +132,8 @@ type decorateMeterBatteryCapable struct {
 
 func (d *decorateMeterBatteryCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/powerwall_decorators.go
+++ b/meter/powerwall_decorators.go
@@ -49,6 +49,9 @@ type decoratePowerWallCapable struct {
 
 func (d *decoratePowerWallCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/powerwall_decorators.go
+++ b/meter/powerwall_decorators.go
@@ -49,8 +49,8 @@ type decoratePowerWallCapable struct {
 
 func (d *decoratePowerWallCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/rct_decorators.go
+++ b/meter/rct_decorators.go
@@ -57,6 +57,9 @@ type decorateRCTCapable struct {
 
 func (d *decorateRCTCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/rct_decorators.go
+++ b/meter/rct_decorators.go
@@ -57,8 +57,8 @@ type decorateRCTCapable struct {
 
 func (d *decorateRCTCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/shelly_decorators.go
+++ b/meter/shelly_decorators.go
@@ -37,8 +37,8 @@ type decorateShellyCapable struct {
 
 func (d *decorateShellyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/shelly_decorators.go
+++ b/meter/shelly_decorators.go
@@ -37,6 +37,9 @@ type decorateShellyCapable struct {
 
 func (d *decorateShellyCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/tasmota_decorators.go
+++ b/meter/tasmota_decorators.go
@@ -37,6 +37,9 @@ type decorateTasmotaCapable struct {
 
 func (d *decorateTasmotaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/meter/tasmota_decorators.go
+++ b/meter/tasmota_decorators.go
@@ -37,8 +37,8 @@ type decorateTasmotaCapable struct {
 
 func (d *decorateTasmotaCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/tq-em_decorators.go
+++ b/meter/tq-em_decorators.go
@@ -29,8 +29,8 @@ type decorateTqEmCapable struct {
 
 func (d *decorateTqEmCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/meter/tq-em_decorators.go
+++ b/meter/tq-em_decorators.go
@@ -29,6 +29,9 @@ type decorateTqEmCapable struct {
 
 func (d *decorateTqEmCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/vehicle/tronity_decorators.go
+++ b/vehicle/tronity_decorators.go
@@ -37,8 +37,8 @@ type decorateTronityCapable struct {
 
 func (d *decorateTronityCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }

--- a/vehicle/tronity_decorators.go
+++ b/vehicle/tronity_decorators.go
@@ -37,6 +37,9 @@ type decorateTronityCapable struct {
 
 func (d *decorateTronityCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/vehicle/vehicle_decorators.go
+++ b/vehicle/vehicle_decorators.go
@@ -74,6 +74,9 @@ type decorateVehicleCapable struct {
 
 func (d *decorateVehicleCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
+	if !ok && reflect.TypeOf(c).Implements(typ) {
+		return c, true
+	}
 	return c, ok
 }
 

--- a/vehicle/vehicle_decorators.go
+++ b/vehicle/vehicle_decorators.go
@@ -74,8 +74,8 @@ type decorateVehicleCapable struct {
 
 func (d *decorateVehicleCapable) Capability(typ reflect.Type) (any, bool) {
 	c, ok := d.caps[typ]
-	if !ok && reflect.TypeOf(c).Implements(typ) {
-		return c, true
+	if !ok && reflect.TypeOf(d).Implements(typ) {
+		return d, true
 	}
 	return c, ok
 }


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/28978

The key point here is allowing the capability registry to reach into the original object for native interface implementations:

```go
func (c *charger) Capability(typ reflect.Type) (any, bool) {
	cap, ok := c.caps[typ]
	if !ok && reflect.TypeOf(c).Implements(typ) { // <- this is the "trick"
		return c, true
	}
	return cap, ok
}
```

Doing this so means that hoisting the `api. Capable` interface implies hoisting all native interfaces, too, even when embedding.