### PR TITLE
OCPP UI: remove wss assumption

### DIFF
--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -49,8 +49,7 @@ func ExternalUrl() string {
 		return ""
 	}
 
-	// Replace protocol: http -> ws, https -> wss
-	u.Scheme = strings.Replace(u.Scheme, "http", "ws", 1)
+	u.Scheme = "ws"
 	u.Host = fmt.Sprintf("%s:%d", strings.Split(u.Host, ":")[0], 8887) // deliberately fixed, port configurability only for testing
 
 	return u.String()

--- a/charger/ocpp/instance_test.go
+++ b/charger/ocpp/instance_test.go
@@ -7,15 +7,9 @@ import (
 func TestExternalUrl(t *testing.T) {
 	tests := []struct{ input, expected string }{
 		{"", ""},
-		{"http://example.com:7070", "ws://example.com:8887"},
-		{"https://example.com:443", "wss://example.com:8887"},
 		{"http://example.com", "ws://example.com:8887"},
-		{"https://example.com", "wss://example.com:8887"},
+		{"https://example.com:443", "ws://example.com:8887"},
 		{"http://10.20.30.40:7070/path", "ws://10.20.30.40:8887/path"},
-		{"https://example.com/path", "wss://example.com:8887/path"},
-		{"ws://example.com", "ws://example.com:8887"},
-		{"wss://example.com:9000", "wss://example.com:8887"},
-		{"strange://example.com", "strange://example.com:8887"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
OCPP url now always shows `ws://` protocol.

Remove the assumption, that when http is proxied (secure ExternalUrl configured) the OCPP connection is also provided securely. Caused confusion in the past.

See also https://github.com/evcc-io/images/pull/30