### PR TITLE
Add meter fritzdect_new

### DIFF
--- a/meter/fritzdect/fritzdect.go
+++ b/meter/fritzdect/fritzdect.go
@@ -1,112 +1,8 @@
 package fritzdect
 
 import (
-	"crypto/md5"
-	"encoding/hex"
-	"encoding/xml"
-	"errors"
-	"fmt"
-	"net/url"
 	"strconv"
-	"strings"
-	"time"
-
-	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/request"
-	"github.com/evcc-io/evcc/util/transport"
-	"golang.org/x/text/encoding/unicode"
 )
-
-// FRITZ! FritzBox AHA interface and authentication specifications:
-// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf
-// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AVM_Technical_Note_-_Session_ID.pdf
-
-// FritzDECT settings
-type Settings struct {
-	URI, AIN, User, Password string
-}
-
-// FritzDECT connection
-type Connection struct {
-	*request.Helper
-	*Settings
-	SID     string
-	updated time.Time
-}
-
-// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AVM_Technical_Note_-_Session_ID_english_2021-05-03.pdf
-const sessionTimeout = 15 * time.Minute
-
-// Devicestats structures getbasicdevicesstats command response (AHA-HTTP-Interface)
-type Devicestats struct {
-	XMLName xml.Name `xml:"devicestats"`
-	Energy  Energy   `xml:"energy"`
-}
-
-// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
-type Energy struct {
-	XMLName xml.Name `xml:"energy"`
-	Values  []string `xml:"stats"`
-}
-
-// NewConnection creates FritzDECT connection
-func NewConnection(uri, ain, user, password string) (*Connection, error) {
-	if uri == "" {
-		uri = "https://fritz.box"
-	}
-
-	if ain == "" {
-		return nil, errors.New("missing ain")
-	}
-
-	settings := &Settings{
-		URI:      strings.TrimRight(uri, "/"),
-		AIN:      ain,
-		User:     user,
-		Password: password,
-	}
-
-	log := util.NewLogger("fritzdect").Redact(password)
-
-	fritzdect := &Connection{
-		Helper:   request.NewHelper(log),
-		Settings: settings,
-	}
-
-	fritzdect.Client.Transport = request.NewTripper(log, transport.Insecure())
-
-	return fritzdect, nil
-}
-
-// ExecCmd execautes an FritzDECT AHA-HTTP-Interface command
-func (c *Connection) ExecCmd(function string) (string, error) {
-	// refresh Fritzbox session id
-	if time.Since(c.updated) >= sessionTimeout {
-		if err := c.getSessionID(); err != nil {
-			return "", err
-		}
-		// update session timestamp
-		c.updated = time.Now()
-	}
-
-	parameters := url.Values{
-		"sid":       {c.SID},
-		"ain":       {c.AIN},
-		"switchcmd": {function},
-	}
-
-	uri := fmt.Sprintf("%s/webservices/homeautoswitch.lua", c.URI)
-	body, err := c.GetBody(uri + "?" + parameters.Encode())
-
-	res := strings.TrimSpace(string(body))
-
-	if err == nil && res == "inval" {
-		err = api.ErrNotAvailable
-	}
-
-	return res, err
-}
 
 // CurrentPower implements the api.Meter interface
 func (c *Connection) CurrentPower() (float64, error) {
@@ -121,8 +17,6 @@ func (c *Connection) CurrentPower() (float64, error) {
 	return power / 1000, err // mW ==> W
 }
 
-var _ api.MeterEnergy = (*Connection)(nil)
-
 // CurrentPower implements the api.MeterEnergy interface
 func (c *Connection) TotalEnergy() (float64, error) {
 	// Energy value in Wh (total switch energy, refresh approximately every 2 minutes)
@@ -134,55 +28,4 @@ func (c *Connection) TotalEnergy() (float64, error) {
 	energy, err := strconv.ParseFloat(resp, 64)
 
 	return energy / 1000, err // Wh ==> KWh
-}
-
-// Fritzbox helpers (credits to https://github.com/rsdk/ahago)
-
-// getSessionID fetches a session-id based on the username and password in the connection struct
-func (c *Connection) getSessionID() error {
-	uri := fmt.Sprintf("%s/login_sid.lua", c.URI)
-	body, err := c.GetBody(uri)
-	if err != nil {
-		return err
-	}
-
-	var v struct {
-		SID       string
-		Challenge string
-		BlockTime string
-	}
-
-	if err = xml.Unmarshal(body, &v); err == nil && v.SID == "0000000000000000" {
-		var challresp string
-		if challresp, err = createChallengeResponse(v.Challenge, c.Password); err == nil {
-			params := url.Values{
-				"username": {c.User},
-				"response": {challresp},
-			}
-
-			if body, err = c.GetBody(uri + "?" + params.Encode()); err == nil {
-				err = xml.Unmarshal(body, &v)
-				if v.SID == "0000000000000000" {
-					return errors.New("invalid user or password")
-				}
-				c.SID = v.SID
-			}
-		}
-	}
-
-	return err
-}
-
-// createChallengeResponse creates the Fritzbox challenge response string
-func createChallengeResponse(challenge, pass string) (string, error) {
-	encoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
-	utf16le, err := encoder.String(challenge + "-" + pass)
-	if err != nil {
-		return "", err
-	}
-
-	hash := md5.Sum([]byte(utf16le))
-	md5hash := hex.EncodeToString(hash[:])
-
-	return challenge + "-" + md5hash, nil
 }

--- a/meter/fritzdect/fritzdect_common.go
+++ b/meter/fritzdect/fritzdect_common.go
@@ -1,0 +1,127 @@
+package fritzdect
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+	"golang.org/x/text/encoding/unicode"
+)
+
+// NewConnection creates FritzDECT connection
+func NewConnection(uri, ain, user, password string) (*Connection, error) {
+	if uri == "" {
+		uri = "https://fritz.box"
+	}
+
+	if ain == "" {
+		return nil, errors.New("missing ain")
+	}
+
+	settings := &Settings{
+		URI:      strings.TrimRight(uri, "/"),
+		AIN:      ain,
+		User:     user,
+		Password: password,
+	}
+
+	log := util.NewLogger("fritzdect").Redact(password)
+
+	fritzdect := &Connection{
+		Helper:   request.NewHelper(log),
+		Settings: settings,
+	}
+
+	fritzdect.Client.Transport = request.NewTripper(log, transport.Insecure())
+
+	return fritzdect, nil
+}
+
+// ExecCmd execautes an FritzDECT AHA-HTTP-Interface command
+func (c *Connection) ExecCmd(function string) (string, error) {
+	// refresh Fritzbox session id
+	if time.Since(c.updated) >= sessionTimeout {
+		if err := c.getSessionID(); err != nil {
+			return "", err
+		}
+		// update session timestamp
+		c.updated = time.Now()
+	}
+
+	parameters := url.Values{
+		"sid":       {c.SID},
+		"ain":       {c.AIN},
+		"switchcmd": {function},
+	}
+
+	uri := fmt.Sprintf("%s/webservices/homeautoswitch.lua", c.URI)
+	body, err := c.GetBody(uri + "?" + parameters.Encode())
+
+	res := strings.TrimSpace(string(body))
+
+	if err == nil && res == "inval" {
+		err = api.ErrNotAvailable
+	}
+
+	return res, err
+}
+
+// Fritzbox helpers (credits to https://github.com/rsdk/ahago)
+
+// getSessionID fetches a session-id based on the username and password in the connection struct
+func (c *Connection) getSessionID() error {
+	uri := fmt.Sprintf("%s/login_sid.lua", c.URI)
+	body, err := c.GetBody(uri)
+	if err != nil {
+		return err
+	}
+
+	var v struct {
+		SID       string
+		Challenge string
+		BlockTime string
+	}
+
+	if err = xml.Unmarshal(body, &v); err == nil && v.SID == "0000000000000000" {
+		var challresp string
+		if challresp, err = createChallengeResponse(v.Challenge, c.Password); err == nil {
+			params := url.Values{
+				"username": {c.User},
+				"response": {challresp},
+			}
+
+			if body, err = c.GetBody(uri + "?" + params.Encode()); err == nil {
+				err = xml.Unmarshal(body, &v)
+				if v.SID == "0000000000000000" {
+					return errors.New("invalid user or password")
+				}
+				c.SID = v.SID
+			}
+		}
+	}
+
+	return err
+}
+
+// createChallengeResponse creates the Fritzbox challenge response string
+func createChallengeResponse(challenge, pass string) (string, error) {
+	encoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
+	utf16le, err := encoder.String(challenge + "-" + pass)
+	if err != nil {
+		return "", err
+	}
+
+	hash := md5.Sum([]byte(utf16le))
+	md5hash := hex.EncodeToString(hash[:])
+
+	return challenge + "-" + md5hash, nil
+}

--- a/meter/fritzdect/types.go
+++ b/meter/fritzdect/types.go
@@ -1,0 +1,54 @@
+package fritzdect
+
+import (
+	"encoding/xml"
+	"time"
+
+	"github.com/evcc-io/evcc/util/request"
+)
+
+// FRITZ! FritzBox AHA interface and authentication specifications:
+// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf
+// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AVM_Technical_Note_-_Session_ID.pdf
+
+// FritzDECT settings
+type Settings struct {
+	URI, AIN, User, Password string
+}
+
+// FritzDECT connection
+type Connection struct {
+	*request.Helper
+	*Settings
+	SID     string
+	updated time.Time
+}
+
+// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AVM_Technical_Note_-_Session_ID_english_2021-05-03.pdf
+const sessionTimeout = 15 * time.Minute
+
+// Devicestats structures getbasicdevicesstats command response (AHA-HTTP-Interface)
+type Devicestats struct {
+	XMLName xml.Name `xml:"devicestats"`
+	Energy  Energy   `xml:"energy"`
+	Power   Power    `xml:"power"`
+	Voltage Voltage  `xml:"voltage"`
+}
+
+// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+type Energy struct {
+	XMLName xml.Name `xml:"energy"`
+	Values  []string `xml:"stats"`
+}
+
+// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+type Voltage struct {
+	XMLName xml.Name `xml:"voltage"`
+	Values  []string `xml:"stats"`
+}
+
+// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+type Power struct {
+	XMLName xml.Name `xml:"power"`
+	Values  []string `xml:"stats"`
+}

--- a/meter/fritzdect/types.go
+++ b/meter/fritzdect/types.go
@@ -41,13 +41,13 @@ type Energy struct {
 	Values  []string `xml:"stats"`
 }
 
-// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+// Voltage structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
 type Voltage struct {
 	XMLName xml.Name `xml:"voltage"`
 	Values  []string `xml:"stats"`
 }
 
-// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+// Power structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
 type Power struct {
 	XMLName xml.Name `xml:"power"`
 	Values  []string `xml:"stats"`

--- a/meter/fritzdect_new.go
+++ b/meter/fritzdect_new.go
@@ -1,0 +1,28 @@
+package meter
+
+import (
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/meter/fritzdect_new"
+	"github.com/evcc-io/evcc/util"
+)
+
+// AVM FritzBox AHA interface specifications:
+// https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf
+
+func init() {
+	registry.Add("fritzdect_new", NewFritzDECTFromConfig2)
+}
+
+// NewFritzDECTFromConfig creates a fritzdect meter from generic config
+func NewFritzDECTFromConfig2(other map[string]any) (api.Meter, error) {
+	var cc fritzdect_new.Settings
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.User == "" || cc.Password == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
+	return fritzdect_new.NewConnection(cc.URI, cc.AIN, cc.User, cc.Password)
+}

--- a/meter/fritzdect_new/fritzdect_common.go
+++ b/meter/fritzdect_new/fritzdect_common.go
@@ -1,0 +1,127 @@
+package fritzdect_new
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+	"golang.org/x/text/encoding/unicode"
+)
+
+// NewConnection creates FritzDECT connection
+func NewConnection(uri, ain, user, password string) (*Connection, error) {
+	if uri == "" {
+		uri = "https://fritz.box"
+	}
+
+	if ain == "" {
+		return nil, errors.New("missing ain")
+	}
+
+	settings := &Settings{
+		URI:      strings.TrimRight(uri, "/"),
+		AIN:      ain,
+		User:     user,
+		Password: password,
+	}
+
+	log := util.NewLogger("fritzdect").Redact(password)
+
+	fritzdect_new := &Connection{
+		Helper:   request.NewHelper(log),
+		Settings: settings,
+	}
+
+	fritzdect_new.Client.Transport = request.NewTripper(log, transport.Insecure())
+
+	return fritzdect_new, nil
+}
+
+// ExecCmd execautes an FritzDECT AHA-HTTP-Interface command
+func (c *Connection) ExecCmd(function string) (string, error) {
+	// refresh Fritzbox session id
+	if time.Since(c.updated) >= sessionTimeout {
+		if err := c.getSessionID(); err != nil {
+			return "", err
+		}
+		// update session timestamp
+		c.updated = time.Now()
+	}
+
+	parameters := url.Values{
+		"sid":       {c.SID},
+		"ain":       {c.AIN},
+		"switchcmd": {function},
+	}
+
+	uri := fmt.Sprintf("%s/webservices/homeautoswitch.lua", c.URI)
+	body, err := c.GetBody(uri + "?" + parameters.Encode())
+
+	res := strings.TrimSpace(string(body))
+
+	if err == nil && res == "inval" {
+		err = api.ErrNotAvailable
+	}
+
+	return res, err
+}
+
+// Fritzbox helpers (credits to https://github.com/rsdk/ahago)
+
+// getSessionID fetches a session-id based on the username and password in the connection struct
+func (c *Connection) getSessionID() error {
+	uri := fmt.Sprintf("%s/login_sid.lua", c.URI)
+	body, err := c.GetBody(uri)
+	if err != nil {
+		return err
+	}
+
+	var v struct {
+		SID       string
+		Challenge string
+		BlockTime string
+	}
+
+	if err = xml.Unmarshal(body, &v); err == nil && v.SID == "0000000000000000" {
+		var challresp string
+		if challresp, err = createChallengeResponse(v.Challenge, c.Password); err == nil {
+			params := url.Values{
+				"username": {c.User},
+				"response": {challresp},
+			}
+
+			if body, err = c.GetBody(uri + "?" + params.Encode()); err == nil {
+				err = xml.Unmarshal(body, &v)
+				if v.SID == "0000000000000000" {
+					return errors.New("invalid user or password")
+				}
+				c.SID = v.SID
+			}
+		}
+	}
+
+	return err
+}
+
+// createChallengeResponse creates the Fritzbox challenge response string
+func createChallengeResponse(challenge, pass string) (string, error) {
+	encoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
+	utf16le, err := encoder.String(challenge + "-" + pass)
+	if err != nil {
+		return "", err
+	}
+
+	hash := md5.Sum([]byte(utf16le))
+	md5hash := hex.EncodeToString(hash[:])
+
+	return challenge + "-" + md5hash, nil
+}

--- a/meter/fritzdect_new/fritzdect_common.go
+++ b/meter/fritzdect_new/fritzdect_common.go
@@ -46,7 +46,7 @@ func NewConnection(uri, ain, user, password string) (*Connection, error) {
 	return fritzdect_new, nil
 }
 
-// ExecCmd execautes an FritzDECT AHA-HTTP-Interface command
+// ExecCmd executes an FritzDECT AHA-HTTP-Interface command
 func (c *Connection) ExecCmd(function string) (string, error) {
 	// refresh Fritzbox session id
 	if time.Since(c.updated) >= sessionTimeout {

--- a/meter/fritzdect_new/fritzdect_new.go
+++ b/meter/fritzdect_new/fritzdect_new.go
@@ -1,0 +1,60 @@
+package fritzdect_new
+
+import (
+	"encoding/xml"
+	"log"
+	"strconv"
+	"strings"
+)
+
+// CurrentPower implements the api.MeterEnergy interface
+func (c *Connection) TotalEnergy() (float64, error) {
+	// Energy value in Wh (total switch energy, refresh approximately every 2 minutes)
+	resp, err := c.ExecCmd("getswitchenergy")
+	if err != nil {
+		return 0, err
+	}
+
+	energy, err := strconv.ParseFloat(resp, 64)
+
+	return energy / 1000, err // Wh ==> KWh
+}
+
+// CurrentPower implements the api.Meter interface
+func (c *Connection) CurrentPower() (float64, error) {
+	// power value in 0,001 W (current switch power, refresh approximately every 2 minutes)
+	resp, err := c.ExecCmd("getbasicdevicestats")
+	if err != nil {
+		return 0, err
+	}
+
+	var f = ParseFXml(resp, err)
+	//power, err := strconv.ParseFloat(resp, 64)
+
+	return (f * 10) / 1000, err // mW ==> W
+}
+
+func ParseFXml(s string, err error) float64 {
+
+	var v Devicestats
+
+	err2 := xml.Unmarshal([]byte(s), &v)
+	if err2 != nil {
+		//
+	}
+
+	var csv = v.Power.Values[0]
+
+	parts := strings.Split(csv, ",")
+	if len(parts) == 0 {
+		//
+	}
+
+	//Parse first element into a float64
+	f, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		log.Fatalf("Error converting '%s' to float: %v", parts[0], err)
+	}
+
+	return float64(f)
+}

--- a/meter/fritzdect_new/fritzdect_new.go
+++ b/meter/fritzdect_new/fritzdect_new.go
@@ -6,16 +6,15 @@ import (
 	"strings"
 )
 
-// CurrentPower implements the api.MeterEnergy interface
+// TotalEnergy implements the api.MeterEnergy interface
 func (c *Connection) TotalEnergy() (float64, error) {
 	// Energy value in Wh (total switch energy, refresh approximately every 2 minutes)
-	resp, err := c.ExecCmd("getswitchenergy")
+	resp, err := c.ExecCmd("getbasicdevicestats")
 	if err != nil {
 		return 0, err
 	}
 
-	energy, err := strconv.ParseFloat(resp, 64)
-
+	var energy = ParseFXml2(resp, err)
 	return energy / 1000, err // Wh ==> KWh
 }
 
@@ -27,8 +26,8 @@ func (c *Connection) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
-	var f = ParseFXml(resp, err)
-	return (f * 10) / 1000, err // 1/100W ==> W
+	var power = ParseFXml(resp, err)
+	return (power * 10) / 1000, err // 1/100W ==> W
 }
 
 func ParseFXml(s string, err error) float64 {
@@ -40,6 +39,29 @@ func ParseFXml(s string, err error) float64 {
 	}
 
 	var csv = v.Power.Values[0]
+
+	parts := strings.Split(csv, ",")
+	if len(parts) == 0 {
+		//
+	}
+
+	f, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		//
+	}
+
+	return float64(f)
+}
+
+func ParseFXml2(s string, err error) float64 {
+	var v Devicestats
+
+	err2 := xml.Unmarshal([]byte(s), &v)
+	if err2 != nil {
+		//
+	}
+
+	var csv = v.Energy.Values[0]
 
 	parts := strings.Split(csv, ",")
 	if len(parts) == 0 {

--- a/meter/fritzdect_new/fritzdect_new.go
+++ b/meter/fritzdect_new/fritzdect_new.go
@@ -35,7 +35,6 @@ func (c *Connection) CurrentPower() (float64, error) {
 }
 
 func ParseFXml(s string, err error) float64 {
-
 	var v Devicestats
 
 	err2 := xml.Unmarshal([]byte(s), &v)

--- a/meter/fritzdect_new/fritzdect_new.go
+++ b/meter/fritzdect_new/fritzdect_new.go
@@ -2,7 +2,6 @@ package fritzdect_new
 
 import (
 	"encoding/xml"
-	"log"
 	"strconv"
 	"strings"
 )
@@ -22,16 +21,14 @@ func (c *Connection) TotalEnergy() (float64, error) {
 
 // CurrentPower implements the api.Meter interface
 func (c *Connection) CurrentPower() (float64, error) {
-	// power value in 0,001 W (current switch power, refresh approximately every 2 minutes)
+	// power value in 0,01 W (current switch power, refresh approximately every 2 minutes)
 	resp, err := c.ExecCmd("getbasicdevicestats")
 	if err != nil {
 		return 0, err
 	}
 
 	var f = ParseFXml(resp, err)
-	//power, err := strconv.ParseFloat(resp, 64)
-
-	return (f * 10) / 1000, err // mW ==> W
+	return (f * 10) / 1000, err // 1/100W ==> W
 }
 
 func ParseFXml(s string, err error) float64 {
@@ -49,10 +46,9 @@ func ParseFXml(s string, err error) float64 {
 		//
 	}
 
-	//Parse first element into a float64
 	f, err := strconv.ParseFloat(parts[0], 64)
 	if err != nil {
-		log.Fatalf("Error converting '%s' to float: %v", parts[0], err)
+		//
 	}
 
 	return float64(f)

--- a/meter/fritzdect_new/types.go
+++ b/meter/fritzdect_new/types.go
@@ -41,13 +41,13 @@ type Energy struct {
 	Values  []string `xml:"stats"`
 }
 
-// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+// Voltage structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
 type Voltage struct {
 	XMLName xml.Name `xml:"voltage"`
 	Values  []string `xml:"stats"`
 }
 
-// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+// Power structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
 type Power struct {
 	XMLName xml.Name `xml:"power"`
 	Values  []string `xml:"stats"`

--- a/meter/fritzdect_new/types.go
+++ b/meter/fritzdect_new/types.go
@@ -1,0 +1,54 @@
+package fritzdect_new
+
+import (
+	"encoding/xml"
+	"time"
+
+	"github.com/evcc-io/evcc/util/request"
+)
+
+// FRITZ! FritzBox AHA interface and authentication specifications:
+// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AHA-HTTP-Interface.pdf
+// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AVM_Technical_Note_-_Session_ID.pdf
+
+// FritzDECT settings
+type Settings struct {
+	URI, AIN, User, Password string
+}
+
+// FritzDECT connection
+type Connection struct {
+	*request.Helper
+	*Settings
+	SID     string
+	updated time.Time
+}
+
+// https://fritz.com/fileadmin/user_upload/Global/Service/Schnittstellen/AVM_Technical_Note_-_Session_ID_english_2021-05-03.pdf
+const sessionTimeout = 15 * time.Minute
+
+// Devicestats structures getbasicdevicesstats command response (AHA-HTTP-Interface)
+type Devicestats struct {
+	XMLName xml.Name `xml:"devicestats"`
+	Energy  Energy   `xml:"energy"`
+	Power   Power    `xml:"power"`
+	Voltage Voltage  `xml:"voltage"`
+}
+
+// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+type Energy struct {
+	XMLName xml.Name `xml:"energy"`
+	Values  []string `xml:"stats"`
+}
+
+// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+type Voltage struct {
+	XMLName xml.Name `xml:"voltage"`
+	Values  []string `xml:"stats"`
+}
+
+// Energy structures getbasicdevicesstats command energy response (AHA-HTTP-Interface)
+type Power struct {
+	XMLName xml.Name `xml:"power"`
+	Values  []string `xml:"stats"`
+}

--- a/templates/definition/meter/fritzgrid_new.yaml
+++ b/templates/definition/meter/fritzgrid_new.yaml
@@ -1,0 +1,22 @@
+template: fritzgrid_new
+products:
+  - brand: "FRITZ!"
+    description:
+      generic: "FRITZ!Smart Energy 250 New"
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: uri
+    default: https://fritz.box
+  - name: user
+    required: true
+  - name: password
+    required: true
+  - name: ain
+    required: true
+render: |
+  type: fritzdect_new
+  uri: {{ .uri }}
+  user: {{ .user }}
+  password: {{ .password }}
+  ain: {{ .ain }} # switch actor identification number without blanks (see AIN number on switch sticker)


### PR DESCRIPTION
Addresses #28906 by adding a new device using the Fritz HTTP API instead to the existing lua one.

This is a quick and dirty fix, it introduces much duplicated code and there are several other ways to implement a fix (like trying both APIs in fritzdect). Guidance on improving this PR is much appreciated.

make lint unfortunately failed because of an internal error, so linting errors might exist.
```
make lint
Schwerwiegend: Keine Namen gefunden, kann nichts beschreiben.
golangci-lint run
0 issues.
go tool modernize -test -c 0 -stringsbuilder=false -omitzero=false ./...
panic: unexpected import edits

goroutine 9723 [running]:
golang.org/x/tools/go/analysis/passes/modernize.runAtomic(0x3dbf3236eb60)
        /home/simon/go/pkg/mod/golang.org/x/tools@v0.43.0/go/analysis/passes/modernize/atomic.go:152 +0x17ab
golang.org/x/tools/go/analysis/checker.(*Action).execOnce.func3(...)
        /home/simon/go/pkg/mod/golang.org/x/tools@v0.43.0/go/analysis/checker/checker.go:357
golang.org/x/tools/go/analysis/checker.(*Action).execOnce(0x3dbf2f3ece60)
        /home/simon/go/pkg/mod/golang.org/x/tools@v0.43.0/go/analysis/checker/checker.go:378 +0xb3c
sync.(*Once).doSlow(0x0?, 0x0?)
        /usr/lib/go/src/sync/once.go:78 +0xac
sync.(*Once).Do(...)
        /usr/lib/go/src/sync/once.go:69
golang.org/x/tools/go/analysis/checker.(*Action).exec(...)
        /home/simon/go/pkg/mod/golang.org/x/tools@v0.43.0/go/analysis/checker/checker.go:258
golang.org/x/tools/go/analysis/checker.execAll.func1(0x0?)
        /home/simon/go/pkg/mod/golang.org/x/tools@v0.43.0/go/analysis/checker/checker.go:246 +0x45
created by golang.org/x/tools/go/analysis/checker.execAll in goroutine 1
        /home/simon/go/pkg/mod/golang.org/x/tools@v0.43.0/go/analysis/checker/checker.go:252 +0x147
make: *** [Makefile:56: lint] Fehler 2
```

works on my machine:
<img width="420" height="240" alt="Konfiguration evcc" src="https://github.com/user-attachments/assets/97b15697-06a8-49ad-91f0-ad5578b9fe64" />
