### PR TITLE
Config UI: vehicle priority

### DIFF
--- a/assets/js/components/Config/VehicleModal.vue
+++ b/assets/js/components/Config/VehicleModal.vue
@@ -124,7 +124,6 @@
 					size="w-100"
 					class="me-2"
 					:choice="priorityOptions"
-					required
 				/>
 			</FormRow>
 


### PR DESCRIPTION
keep vehicle priority optional
relevant for existing vehicles
new vehicles get 0 default (similar to loadpoint), see also https://github.com/evcc-io/evcc/pull/28935
