### PR TITLE
fix(cupra): map "NotReadyForCharging" to StatusB instead of StatusA

### DIFF
--- a/vehicle/seat/cupra/provider.go
+++ b/vehicle/seat/cupra/provider.go
@@ -66,7 +66,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	res, err := v.statusG()
 	if err == nil {
 		switch strings.ToLower(res.Services.Charging.Status) {
-		case "connected", "readyforcharging", "error":
+		case "connected", "readyforcharging", "notreadyforcharging", "error":
 			status = api.StatusB
 		case "charging":
 			status = api.StatusC


### PR DESCRIPTION
Problem
When a Cupra Born is plugged in but not actively charging (e.g. waiting for PV surplus in evcc), the Cupra API returns "NotReadyForCharging" as the charging status.
In vehicle/seat/cupra/provider.go, the Status() method only maps "connected", "readyforcharging", and "error" to StatusB. The "NotReadyForCharging" status falls through to the default StatusA (disconnected).
This causes evcc to report vehicle status: A even though the charger correctly reports charger status: B, leading to:

evcc not starting or resuming charge sessions
The loadpoint showing "waiting for vehicle" indefinitely
Users having to physically unplug and replug the cable to trigger charging

The issue is well documented:

#18174 (Cupra Born Fahrzeugerkennung funktioniert nicht)
#17079 (Cupra Born MY25 wird nicht erkannt)

Fix
Add "notreadyforcharging" to the StatusB case in the switch statement. "NotReadyForCharging" means the cable is connected but charging has not been initiated — this is exactly the definition of EVSE Status B.
Change
vehicle/seat/cupra/provider.go, line 77:
go// before
case "connected", "readyforcharging", "error":
    status = api.StatusB

// after
case "connected", "readyforcharging", "notreadyforcharging", "error":
    status = api.StatusB
