### PR TITLE
Fix Home Assistant Vehicle wake to use Button API instead of Switch API

### DIFF
--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -259,13 +259,11 @@ func (c *Connection) CallButtonService(entity string) error {
 		return err
 	}
 
-	service := "press"
-
 	data := map[string]any{
 		"entity_id": entity,
 	}
 
-	return c.CallService(domain, service, data)
+	return c.CallService(domain, "press", data)
 }
 
 // CallNumberService is a convenience method for setting number entity values

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -252,6 +252,22 @@ func (c *Connection) CallSwitchService(entity string, turnOn bool) error {
 	return c.CallService(domain, service, data)
 }
 
+// CallButtonService is a convenience method for button services
+func (c *Connection) CallButtonService(entity string) error {
+	domain, err := domain(entity)
+	if err != nil {
+		return err
+	}
+
+	service := "press"
+
+	data := map[string]any{
+		"entity_id": entity,
+	}
+
+	return c.CallService(domain, service, data)
+}
+
 // CallNumberService is a convenience method for setting number entity values
 func (c *Connection) CallNumberService(entity string, value float64) error {
 	domain, err := domain(entity)

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -116,7 +116,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 	}
 
 	if cc.Services.Wakeup != "" {
-		wakeup = func() error { return conn.CallSwitchService(cc.Services.Wakeup, true) }
+		wakeup = func() error { return conn.CallButtonService(cc.Services.Wakeup) }
 	}
 	if cc.Services.SetMaxCurrent != "" {
 		maxcurrent = func(current int64) error { return conn.CallNumberService(cc.Services.SetMaxCurrent, float64(current)) }


### PR DESCRIPTION
With the Home Assistant vehicle integration, the parameter "Service to wake up vehicle" is specified as being a button.  However, EVCC was call the Home Assistant "turn_on" service, which is meant for switches, not buttons.  As a result Home Assistant was returning an HTTP 400 error, EVCC was unable to wake the vehicle.  This PR introduces a new function to use "press", which is the proper way to activate a button.  See https://developers.home-assistant.io/docs/core/entity/button for the differences between a switch and button within Home Assistant.

Has been locally tested with a Lucid Air, where the only vehicle integration available is via Home Assistant.  EVCC correctly wakes up the vehicle with is change.