### PR TITLE
Docker: fix legacy browser assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN --mount=type=cache,target=/root/.npm npm ci
 COPY Makefile .
 COPY *.js ./
 COPY *.ts *.mts ./
+COPY .browserslistrc .
 COPY assets assets
 COPY i18n i18n
 


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/28429

The newly added `.browserslistrc` https://github.com/evcc-io/evcc/pull/28436 was not used in Docker builds. Leading to a less browser-compatible build.