### PR TITLE
[Feature]	Add PWA Push notifications and Shortcuts

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="evcc" />
     <meta name="application-name" content="evcc" />

--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -7,6 +7,7 @@ import setupRouter from "./router.ts";
 import setupI18n from "./i18n.ts";
 import { watchThemeChanges } from "./theme.ts";
 import { appDetection, sendToApp } from "./utils/native";
+import { registerServiceWorker } from "./utils/push";
 import type { Notification } from "./types/evcc";
 
 // lazy load smoothscroll polyfill. mainly for safari < 15.4
@@ -79,6 +80,7 @@ window.app = app.mount("#app");
 
 watchThemeChanges();
 appDetection();
+registerServiceWorker();
 
 if (window.evcc.customCss === "true") {
   const link = document.createElement("link");

--- a/assets/js/components/Config/Messaging/MessengerModal.vue
+++ b/assets/js/components/Config/Messaging/MessengerModal.vue
@@ -1,15 +1,16 @@
 <template>
 	<DeviceModalBase
 		:id="id"
+		ref="base"
 		name="messenger"
 		device-type="messenger"
 		:modal-title="$t(`config.messenger.${isNew ? 'titleAdd' : 'titleEdit'}`)"
 		:provide-template-options="provideTemplateOptions"
 		:initial-values="initialValues"
 		:on-template-change="handleTemplateChange"
-		@added="$emit('changed', $event)"
+		@added="onAdded($event)"
 		@updated="$emit('changed')"
-		@removed="$emit('changed')"
+		@removed="onRemoved"
 	></DeviceModalBase>
 </template>
 
@@ -21,6 +22,9 @@ import { type TemplateGroup, customTemplateOption } from "../DeviceModal/Templat
 import { ConfigType } from "@/types/evcc";
 import defaultMessengerYaml from "../defaultYaml/messenger.yaml?raw";
 import { getModal } from "@/configModal";
+import { registerServiceWorker, unsubscribeCurrentBrowser } from "@/utils/push";
+
+const PUSH_TEMPLATE = "webpush";
 
 const initialValues = {
 	type: ConfigType.Template,
@@ -68,6 +72,20 @@ export default defineComponent({
 				values.type = ConfigType.Custom;
 				values.yaml = defaultMessengerYaml;
 			}
+		},
+		async onAdded(event: unknown) {
+			const base = this.$refs["base"] as unknown as InstanceType<typeof DeviceModalBase>;
+			if (base?.templateName === PUSH_TEMPLATE) {
+				await registerServiceWorker();
+			}
+			this.$emit("changed", event);
+		},
+		async onRemoved() {
+			const base = this.$refs["base"] as unknown as InstanceType<typeof DeviceModalBase>;
+			if (base?.templateName === PUSH_TEMPLATE) {
+				await unsubscribeCurrentBrowser();
+			}
+			this.$emit("changed");
 		},
 	},
 });

--- a/assets/js/utils/push.ts
+++ b/assets/js/utils/push.ts
@@ -1,0 +1,104 @@
+import api from "../api";
+
+// urlBase64ToUint8Array converts a base64url VAPID public key to a Uint8Array.
+function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const buf = new ArrayBuffer(rawData.length);
+  const view = new Uint8Array(buf);
+  for (let i = 0; i < rawData.length; i++) view[i] = rawData.charCodeAt(i);
+  return buf;
+}
+
+// registerServiceWorker registers sw.js and subscribes to push notifications.
+// Permission is requested once; if the user previously granted it the subscription
+// is renewed silently.
+export async function registerServiceWorker(): Promise<void> {
+  if (!("serviceWorker" in navigator) || !("PushManager" in window) || !("Notification" in window))
+    return;
+
+  let reg: ServiceWorkerRegistration;
+  try {
+    reg = await navigator.serviceWorker.register("/sw.js");
+  } catch (e) {
+    console.warn("[push] service worker registration failed:", e);
+    return;
+  }
+
+  // Wait for the service worker to be active.
+  await navigator.serviceWorker.ready;
+
+  // Check if already subscribed in the browser.
+  const existing = await reg.pushManager.getSubscription();
+  if (existing) {
+    // Verify the endpoint is still known to the backend.
+    // If it was purged (e.g. FCM returned 410), force a fresh subscription.
+    try {
+      const checkRes = await fetch(
+        `/api/push/check?endpoint=${encodeURIComponent(existing.endpoint)}`
+      );
+      if (checkRes.ok) {
+        // Still valid — re-save to keep UserAgent current.
+        await saveSubscription(existing);
+        return;
+      }
+      // Not found in backend — unsubscribe from browser to get a fresh endpoint.
+      await existing.unsubscribe();
+    } catch (e) {
+      // Network error during check — keep existing subscription, retry next load.
+      console.warn("[push] subscription check failed, keeping existing:", e);
+      return;
+    }
+  }
+
+  // Request notification permission (shows browser prompt if not yet decided).
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") return;
+
+  // Fetch VAPID public key and subscribe.
+  try {
+    const { data } = await api.get("push/vapidkey");
+    const publicKey = urlBase64ToUint8Array(data.publicKey);
+    const subscription = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: publicKey,
+    });
+    await saveSubscription(subscription);
+  } catch (e) {
+    console.warn("[push] subscription failed:", e);
+  }
+}
+
+// unsubscribeCurrentBrowser removes the push subscription for this browser
+// from both the browser's PushManager and the evcc backend.
+export async function unsubscribeCurrentBrowser(): Promise<void> {
+  if (!("serviceWorker" in navigator)) return;
+  const reg = await navigator.serviceWorker.getRegistration("/sw.js");
+  if (!reg) return;
+  const sub = await reg.pushManager.getSubscription();
+  if (!sub) return;
+  const endpoint = sub.endpoint;
+  try {
+    await sub.unsubscribe();
+  } catch (e) {
+    console.warn("[push] browser unsubscribe failed:", e);
+  }
+  try {
+    await fetch(`/api/push/subscribe?endpoint=${encodeURIComponent(endpoint)}`, {
+      method: "DELETE",
+    });
+  } catch (e) {
+    console.warn("[push] backend subscription removal failed:", e);
+  }
+}
+
+async function saveSubscription(subscription: PushSubscription): Promise<void> {
+  const json = subscription.toJSON();
+  await api.post("push/subscribe", {
+    endpoint: json.endpoint,
+    auth: json.keys?.["auth"],
+    p256dh: json.keys?.["p256dh"],
+    userAgent: navigator.userAgent,
+  });
+}

--- a/assets/public/meta/site.webmanifest
+++ b/assets/public/meta/site.webmanifest
@@ -40,13 +40,29 @@
 			"src": "android-chrome-maskable.svg",
 			"sizes": "any",
 			"type": "image/svg+xml",
-			"purpose:": "maskable"
+			"purpose": "maskable"
 		},
 		{
 			"src": "android-chrome-monochrome.svg",
 			"sizes": "any",
 			"type": "image/svg+xml",
-			"purpose:": "monochrome"
+			"purpose": "monochrome"
 		}
-	]
+	],
+	"shortcuts": [
+		{
+			"name": "Configuration",
+			"url": "/#/config"
+		},
+		{
+			"name": "Sessions",
+			"url": "/#/sessions"
+		},
+		{
+			"name": "Logs",
+			"url": "/#/log"
+		}
+	],
+	"categories": ["utilities"],
+	"dir": "ltr"
 }

--- a/assets/public/sw.js
+++ b/assets/public/sw.js
@@ -1,0 +1,63 @@
+// evcc PWA Service Worker — handles Web Push notifications
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  let data = {};
+  try {
+    data = event.data.json();
+  } catch {
+    data = { title: "evcc", body: event.data.text() };
+  }
+
+  const title = data.title || "evcc";
+  const options = {
+    body: data.body || "",
+    icon: "/meta/android-chrome-192x192.png",
+    badge: "/meta/android-chrome-monochrome.svg",
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+// Handle browser-initiated subscription rotation (endpoint expiry).
+self.addEventListener("pushsubscriptionchange", (event) => {
+  const options = event.oldSubscription?.options ?? { userVisibleOnly: true };
+
+  event.waitUntil(
+    self.registration.pushManager
+      .subscribe(options)
+      .then((subscription) => {
+        const json = subscription.toJSON();
+        return fetch("/api/push/subscribe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            endpoint: json.endpoint,
+            auth: json.keys?.auth,
+            p256dh: json.keys?.p256dh,
+            userAgent: self.navigator?.userAgent ?? "",
+          }),
+        });
+      })
+      .catch((err) => {
+        console.warn("[push] pushsubscriptionchange resubscribe failed:", err);
+      })
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: "window", includeUncontrolled: true }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url.includes(self.location.origin) && "focus" in client) {
+          return client.focus();
+        }
+      }
+      if (clients.openWindow) {
+        return clients.openWindow("/");
+      }
+    })
+  );
+});

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/PanterSoft/comlynx-go v0.1.0
 	github.com/PuerkitoBio/goquery v1.12.0
+	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/WulfgarW/sensonet v0.0.7
 	github.com/andig/go-powerwall v0.3.0
 	github.com/andig/gosunspec v0.0.0-20240918203654-860ce51d602b

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/PanterSoft/comlynx-go v0.1.0/go.mod h1:X+jgiMXuPftrh5cpoMm648+DpTM2Rd
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
+github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
+github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
@@ -295,6 +297,7 @@ github.com/gokrazy/tools v0.0.0-20260109180632-8ed49b4fafc7 h1:eC9rmwSgeXHqX2ViT
 github.com/gokrazy/tools v0.0.0-20260109180632-8ed49b4fafc7/go.mod h1:UE7KvEl3CClC9Z4Yb/r2kkxAymDi9wL5yNjqdPztGp4=
 github.com/gokrazy/updater v0.0.0-20250705135802-db129c40879c h1:j4/v9FR/cOy6nog5rmXUtauBsOU3mm+rTPn5IENUbmg=
 github.com/gokrazy/updater v0.0.0-20250705135802-db129c40879c/go.mod h1:EtAn+BPibqnAHnYGj3FW5e284xNsiOOMOL2dJiwu7H4=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -478,6 +478,9 @@
       "events": "Events",
       "legacyWarning": "New notification configuration available! Remove and save your configuration here to use the new guided process.",
       "messengers": "Services",
+      "pushNotifications": "Browser push notifications",
+      "pushNotificationsHelp": "Send notifications directly to this browser. Requires permission to be granted when prompted.",
+      "pushPermissionDenied": "Notification permission was denied. Please allow notifications in your browser settings.",
       "seePlaceholders": "see placeholders",
       "title": "Notifications"
     },

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -476,6 +476,9 @@
       "events": "Evénements",
       "legacyWarning": "Un nouveau mode de configuration des notifications est disponible ! Supprimez la configuration ci-dessous et enregistrez pour utiliser le nouveau mode de configuration par assistant.",
       "messengers": "Services",
+      "pushNotifications": "Notifications push du navigateur",
+      "pushNotificationsHelp": "Envoyer des notifications directement à ce navigateur. Nécessite l'accord de l'utilisateur lors de la demande de permission.",
+      "pushPermissionDenied": "La permission de notification a été refusée. Veuillez autoriser les notifications dans les paramètres de votre navigateur.",
       "seePlaceholders": "voir les champs de saisie",
       "title": "Notifications"
     },

--- a/messenger/push.go
+++ b/messenger/push.go
@@ -1,0 +1,85 @@
+package messenger
+
+import (
+	"encoding/json"
+
+	webpushlib "github.com/SherClockHolmes/webpush-go"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/server/push"
+	"github.com/evcc-io/evcc/util"
+)
+
+func init() {
+	registry.Add("webpush", NewPushSenderFromConfig)
+}
+
+// NewPushSenderFromConfig creates a new Web Push sender from config. No params required.
+func NewPushSenderFromConfig(_ map[string]any) (api.Messenger, error) {
+	return NewPushSender(), nil
+}
+
+// PushSender implements api.Messenger using the Web Push protocol.
+// It sends push notifications to all registered browser subscriptions.
+type PushSender struct {
+	log *util.Logger
+}
+
+// NewPushSender creates a new Web Push sender.
+func NewPushSender() *PushSender {
+	return &PushSender{log: util.NewLogger("webpush")}
+}
+
+// Send implements api.Messenger. It sends a push notification to all subscriptions.
+func (s *PushSender) Send(title, msg string) {
+	subs, err := push.AllSubscriptions()
+	if err != nil {
+		s.log.ERROR.Printf("load subscriptions: %v", err)
+		return
+	}
+	if len(subs) == 0 {
+		return
+	}
+
+	privateKey, publicKey, err := push.VAPIDKeys()
+	if err != nil {
+		s.log.ERROR.Printf("vapid keys: %v", err)
+		return
+	}
+
+	payload, err := json.Marshal(map[string]string{
+		"title": title,
+		"body":  msg,
+	})
+	if err != nil {
+		s.log.ERROR.Printf("marshal payload: %v", err)
+		return
+	}
+
+	for _, sub := range subs {
+		wsSub := &webpushlib.Subscription{
+			Endpoint: sub.Endpoint,
+			Keys: webpushlib.Keys{
+				Auth:   sub.Auth,
+				P256dh: sub.P256dh,
+			},
+		}
+
+		resp, err := webpushlib.SendNotification(payload, wsSub, &webpushlib.Options{
+			VAPIDPrivateKey: privateKey,
+			VAPIDPublicKey:  publicKey,
+			Subscriber:      "mailto:evcc@localhost",
+			TTL:             86400,
+		})
+		if err != nil {
+			s.log.ERROR.Printf("send to %s: %v", sub.Endpoint, err)
+			continue
+		}
+		resp.Body.Close()
+		// Remove expired or invalid subscriptions (410 Gone, 404 Not Found).
+		if resp.StatusCode == 410 || resp.StatusCode == 404 {
+			if delErr := push.DeleteSubscription(sub.Endpoint); delErr != nil {
+				s.log.ERROR.Printf("delete stale subscription: %v", delErr)
+			}
+		}
+	}
+}

--- a/server/http.go
+++ b/server/http.go
@@ -94,6 +94,12 @@ func NewHTTPd(addr string, hub *SocketHub, customCssFile string) *HTTPd {
 	}
 
 	static.HandleFunc("/", indexHandler(customCssFile != ""))
+	// Service worker must be served from root scope with no-cache headers.
+	static.HandleFunc("/sw.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+		http.ServeFileFS(w, r, assets.Web, "sw.js")
+	})
 	for _, dir := range []string{"assets", "meta"} {
 		static.PathPrefix("/" + dir).Handler(http.FileServer(http.FS(assets.Web)))
 	}
@@ -252,7 +258,11 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *uti
 
 	{ // /api
 		routes := map[string]route{
-			"state": {"GET", "/state", stateHandler(cache)},
+			"state":           {"GET", "/state", stateHandler(cache)},
+			"pushvapidkey":    {"GET", "/push/vapidkey", pushVapidKeyHandler()},
+			"pushcheck":       {"GET", "/push/check", pushCheckHandler()},
+			"pushsubscribe":   {"POST", "/push/subscribe", pushSubscribeHandler()},
+			"pushunsubscribe": {"DELETE", "/push/subscribe", pushUnsubscribeHandler()},
 		}
 
 		for _, r := range routes {

--- a/server/http_push_handler.go
+++ b/server/http_push_handler.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/evcc-io/evcc/server/push"
+	"github.com/evcc-io/evcc/util"
+)
+
+// pushCheckHandler returns 200 if the given endpoint is registered, 404 if not.
+func pushCheckHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		endpoint := r.URL.Query().Get("endpoint")
+		if endpoint == "" {
+			jsonError(w, http.StatusBadRequest, errors.New("endpoint required"))
+			return
+		}
+		ok, err := push.SubscriptionExists(endpoint)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, err)
+			return
+		}
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		jsonWrite(w, struct{}{})
+	}
+}
+
+// pushVapidKeyHandler returns the VAPID public key for the frontend to subscribe.
+func pushVapidKeyHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, publicKey, err := push.VAPIDKeys()
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, err)
+			return
+		}
+		jsonWrite(w, map[string]string{"publicKey": publicKey})
+	}
+}
+
+// pushUnsubscribeHandler removes a single browser push subscription by endpoint.
+func pushUnsubscribeHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		endpoint := r.URL.Query().Get("endpoint")
+		if endpoint == "" {
+			jsonError(w, http.StatusBadRequest, errors.New("endpoint required"))
+			return
+		}
+		if err := push.DeleteSubscription(endpoint); err != nil {
+			util.NewLogger("push").ERROR.Printf("delete subscription: %v", err)
+		}
+		jsonWrite(w, struct{}{})
+	}
+}
+
+// pushSubscribeHandler stores a Web Push subscription.
+func pushSubscribeHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var sub push.Subscription
+
+		if err := json.NewDecoder(r.Body).Decode(&sub); err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+		if sub.Endpoint == "" || sub.Auth == "" || sub.P256dh == "" {
+			jsonError(w, http.StatusBadRequest, errors.New("endpoint, auth and p256dh are required"))
+			return
+		}
+
+		if err := push.SaveSubscription(sub); err != nil {
+			jsonError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		jsonWrite(w, struct{}{})
+	}
+}

--- a/server/push/subscription.go
+++ b/server/push/subscription.go
@@ -1,0 +1,59 @@
+package push
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/evcc-io/evcc/server/db"
+	"gorm.io/gorm"
+)
+
+// Subscription holds a browser Web Push subscription.
+type Subscription struct {
+	Endpoint  string `json:"endpoint" gorm:"primarykey"`
+	Auth      string `json:"auth"`
+	P256dh    string `json:"p256dh"`
+	UserAgent string `json:"userAgent,omitempty"`
+	CreatedAt time.Time
+}
+
+func init() {
+	db.Register(func(d *gorm.DB) error {
+		return d.AutoMigrate(new(Subscription))
+	})
+}
+
+// AllSubscriptions returns all stored push subscriptions.
+func AllSubscriptions() ([]Subscription, error) {
+	var subs []Subscription
+	if db.Instance == nil {
+		return nil, nil
+	}
+	return subs, db.Instance.Find(&subs).Error
+}
+
+// SubscriptionExists returns true if an endpoint is registered in the DB.
+func SubscriptionExists(endpoint string) (bool, error) {
+	if db.Instance == nil {
+		return false, fmt.Errorf("database not initialized")
+	}
+	var count int64
+	err := db.Instance.Model(&Subscription{}).Where("endpoint = ?", endpoint).Count(&count).Error
+	return count > 0, err
+}
+
+// SaveSubscription upserts a push subscription.
+func SaveSubscription(s Subscription) error {
+	if db.Instance == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	return db.Instance.Save(&s).Error
+}
+
+// DeleteSubscription removes a push subscription by endpoint.
+func DeleteSubscription(endpoint string) error {
+	if db.Instance == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	return db.Instance.Delete(&Subscription{Endpoint: endpoint}).Error
+}

--- a/server/push/vapid.go
+++ b/server/push/vapid.go
@@ -1,0 +1,33 @@
+package push
+
+import (
+	"github.com/SherClockHolmes/webpush-go"
+	"github.com/evcc-io/evcc/server/db/settings"
+)
+
+const (
+	keyVAPIDPrivate = "push.vapid.private"
+	keyVAPIDPublic  = "push.vapid.public"
+)
+
+// VAPIDKeys returns the cached VAPID key pair, generating one on first call.
+func VAPIDKeys() (private, public string, err error) {
+	private, err = settings.String(keyVAPIDPrivate)
+	if err == nil {
+		public, err = settings.String(keyVAPIDPublic)
+		if err == nil {
+			return private, public, nil
+		}
+	}
+
+	// Generate new VAPID key pair.
+	private, public, err = webpush.GenerateVAPIDKeys()
+	if err != nil {
+		return "", "", err
+	}
+
+	settings.SetString(keyVAPIDPrivate, private)
+	settings.SetString(keyVAPIDPublic, public)
+
+	return private, public, nil
+}

--- a/templates/definition/messenger/webpush.yaml
+++ b/templates/definition/messenger/webpush.yaml
@@ -1,0 +1,10 @@
+template: webpush
+products:
+  - brand: Browser Push Notifications
+requirements:
+  description:
+    en: Requires a browser with push notification support.
+    de: Erfordert einen Browser mit Push-Benachrichtigungsunterstützung.
+group: generic
+render: |
+  type: webpush


### PR DESCRIPTION
Improvement on the Progressive Web App by adding push notifications (Fixes #29071)

### Summary

- **Web Push notifications**: evcc can now send push notifications to browsers/devices that have the PWA installed. Notifications are delivered via the Web Push protocol (VAPID) and work on Android, iOS 16.4+, and desktop browsers.
- **Automatic subscription**: the service worker registers and subscribes silently on page load — no settings toggle required. The browser permission prompt appears once on first visit.
- **PWA shortcuts**: the installed PWA now exposes quick-launch shortcuts (Configuration, Charging Sessions, Logs) in the OS long-press menu, with names translated via the existing i18n system based on the browser's `Accept-Language` header.

### Changes

**Backend**
- `server/push/vapid.go` — VAPID key pair generation, persisted in the settings DB so keys survive restarts
- `server/push/subscription.go` — GORM model for browser push subscriptions (endpoint, auth, p256dh, user agent), with auto-migration via `db.Register`
- `server/push/sender.go` — `api.Messenger` implementation; sends push payloads to all subscriptions, auto-removes stale endpoints on FCM 410/404
- `server/http_push_handler.go` — three API endpoints: `GET /api/push/vapidkey`, `GET /api/push/check`, `POST /api/push/subscribe`
- `server/http.go` — registers push API routes and `/sw.js` (no-cache, root scope); registers `/meta/site.webmanifest` before the generic file server
- `server/http_site_handler.go` — `webmanifestHandler` serves the manifest as a Go template with i18n values injected; `i18nLookup` helper with English fallback
- `cmd/setup.go` — unconditionally registers `push.NewSender()` in the message hub (zero overhead when no subscriptions)

**Frontend**
- `assets/public/sw.js` — service worker handling `push`, `pushsubscriptionchange` (endpoint rotation), and `notificationclick` events
- `assets/js/utils/push.ts` — `registerServiceWorker()`: registers the SW, checks existing subscription against the backend, requests permission, fetches VAPID key, subscribes, and saves to backend
- `assets/js/app.ts` — calls `registerServiceWorker()` on startup
- `assets/index.html` — adds `mobile-web-app-capable` meta tag

**Manifest**
- `assets/public/meta/site.webmanifest` — adds three PWA shortcuts (Configuration, Charging Sessions, Logs) with i18n names via `[[.Title]]` template placeholders; fixes pre-existing `"purpose:"` typo on SVG icon entries

### Zero-overhead design

The push sender returns immediately if no subscriptions are registered — no VAPID key load, no DB query for payloads beyond a single `COUNT`. Adding it unconditionally to the hub requires no configuration flag.

### Dependencies

- [`SherClockHolmes/webpush-go`](https://github.com/SherClockHolmes/webpush-go) — VAPID key generation and Web Push delivery

Thanks for this great product