### PR TITLE
Fix incorrect variable used in regex compile error message

### DIFF
--- a/plugin/pipeline/pipeline.go
+++ b/plugin/pipeline/pipeline.go
@@ -68,7 +68,7 @@ func New(log *util.Logger, cc Settings) (*Pipeline, error) {
 func (p *Pipeline) WithRegex(regex, dflt string) (*Pipeline, error) {
 	re, err := regexp.Compile(regex)
 	if err != nil {
-		return nil, fmt.Errorf("invalid regex '%s': %w", re, err)
+		return nil, fmt.Errorf("invalid regex '%s': %w", regex, err)
 	}
 
 	p.re = re


### PR DESCRIPTION
The error message in WithRegex uses the compiled regex (re) instead of the original input string (regex). When regexp.Compile fails, re is nil, which leads to an unhelpful error message.

This change ensures the original regex string is included in the error output.