### PR TITLE
Config UI: don't show "Logout" when started with --disable-auth

### DIFF
--- a/assets/js/components/BottomTabs/Bar.vue
+++ b/assets/js/components/BottomTabs/Bar.vue
@@ -32,6 +32,7 @@
 				:sponsor="sponsor"
 				:fatal="fatal"
 				:experimental="experimental"
+				:auth-disabled="authDisabled"
 				:evopt="evopt"
 				:installed="installed"
 				:commit="commit"
@@ -68,6 +69,7 @@ export default defineComponent({
 		sponsor: { type: Object as PropType<Sponsor>, default: () => ({}) },
 		fatal: { type: Array as PropType<FatalError[]>, default: () => [] },
 		experimental: Boolean,
+		authDisabled: Boolean,
 		offline: Boolean,
 		startupCompleted: Boolean,
 		evopt: { type: Object as PropType<EvOpt>, required: false },

--- a/assets/js/components/BottomTabs/MoreItem.vue
+++ b/assets/js/components/BottomTabs/MoreItem.vue
@@ -15,6 +15,7 @@
 				:sponsor="sponsor"
 				:fatal="fatal"
 				:experimental="experimental"
+				:auth-disabled="authDisabled"
 				:evopt="evopt"
 				:installed="installed"
 				:commit="commit"
@@ -41,6 +42,7 @@ export default defineComponent({
 		sponsor: { type: Object as PropType<Sponsor>, default: () => ({}) },
 		fatal: { type: Array as PropType<FatalError[]>, default: () => [] },
 		experimental: Boolean,
+		authDisabled: Boolean,
 		evopt: { type: Object as PropType<EvOpt>, required: false },
 		installed: String,
 		commit: String,


### PR DESCRIPTION
fixes #29073

The logout visibility check already existed in MoreMenu, but authDisabled was never passed through the bottom-tab component chain.