### PR TITLE
Allow the TAG_NAME and SHA Makefile variable to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # build vars
-TAG_NAME := $(shell test -d .git && git describe --abbrev=0 --tags)
-SHA := $(shell test -d .git && git rev-parse --short HEAD)
+TAG_NAME ?= $(shell test -d .git && git describe --abbrev=0 --tags)
+SHA ?= $(shell test -d .git && git rev-parse --short HEAD)
 COMMIT := $(SHA)
 # hide commit for releases
 ifeq ($(RELEASE),1)


### PR DESCRIPTION
This makes it possible to pass a version to the build process if the project is not cloned as a git repository. This will show a version of evcc on FreeBSD.