### PR TITLE
Amperfied connect.solar: fix phase switching

### DIFF
--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -32,27 +32,34 @@ import (
 
 // Amperfied charger implementation
 type Amperfied struct {
-	log     *util.Logger
-	conn    *modbus.Connection
-	current uint16
-	phases  int
-	wakeup  bool
+	log                 *util.Logger
+	conn                *modbus.Connection
+	current             uint16
+	phases              int
+	wakeup              bool
+	phaseswitchduration time.Duration
+	phaseSwitchStart    time.Time
 }
 
 const (
-	ampRegChargingState      = 5    // Input
-	ampRegCurrents           = 6    // Input 6,7,8
-	ampRegTemperature        = 9    // Input
-	ampRegVoltages           = 10   // Input 10,11,12
-	ampRegPower              = 14   // Input
-	ampRegEnergy             = 17   // Input
-	ampRegTimeoutConfig      = 257  // Holding
-	ampRegRemoteLock         = 259  // Holding
-	ampRegAmpsConfig         = 261  // Holding
-	ampRegFailSafeConfig     = 262  // Holding
-	ampRegPhaseSwitchControl = 501  // Holding
-	ampRegPhaseSwitchState   = 5001 // Input
-	ampRegRfidUID            = 2002 // Input
+	ampRegChargingState       = 5    // Input
+	ampRegCurrents            = 6    // Input 6,7,8
+	ampRegTemperature         = 9    // Input
+	ampRegVoltages            = 10   // Input 10,11,12
+	ampRegPower               = 14   // Input
+	ampRegEnergy              = 17   // Input
+	ampRegTimeoutConfig       = 257  // Holding
+	ampRegRemoteLock          = 259  // Holding
+	ampRegAmpsConfig          = 261  // Holding
+	ampRegFailSafeConfig      = 262  // Holding
+	ampRegPhaseSwitchControl  = 501  // Holding
+	ampRegPhaseSwitchDuration = 503  // Holding
+	ampRegPhaseSwitchState    = 5001 // Input
+	ampRegRfidUID             = 2002 // Input
+)
+
+const (
+	phaseSwitchDurationDefault = 90
 )
 
 func init() {
@@ -64,23 +71,25 @@ func init() {
 // NewAmperfiedFromConfig creates a Amperfied charger from generic config
 func NewAmperfiedFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
 	cc := struct {
-		modbus.TcpSettings `mapstructure:",squash"`
-		Phases1p3p         bool
+		modbus.TcpSettings  `mapstructure:",squash"`
+		Phases1p3p          bool
+		Phaseswitchduration uint16
 	}{
 		TcpSettings: modbus.TcpSettings{
 			ID: 255,
 		},
+		Phaseswitchduration: phaseSwitchDurationDefault,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewAmperfied(ctx, cc.URI, cc.ID, cc.Phases1p3p)
+	return NewAmperfied(ctx, cc.URI, cc.ID, cc.Phases1p3p, cc.Phaseswitchduration)
 }
 
 // NewAmperfied creates Amperfied charger
-func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool) (api.Charger, error) {
+func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool, phaseswitchduration uint16) (api.Charger, error) {
 	conn, err := modbus.NewConnection(ctx, uri, "", "", 0, modbus.Tcp, slaveID)
 	if err != nil {
 		return nil, err
@@ -94,9 +103,11 @@ func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool) (
 	conn.Logger(log.TRACE)
 
 	wb := &Amperfied{
-		log:     log,
-		conn:    conn,
-		current: 60, // assume min current
+		log:                 log,
+		conn:                conn,
+		current:             60, // assume min current
+		phaseswitchduration: time.Duration(phaseswitchduration) * time.Second,
+		phaseSwitchStart:    time.Now(), // initialize in the past to avoid startup error
 	}
 
 	// get failsafe timeout from charger
@@ -231,17 +242,23 @@ func (wb *Amperfied) MaxCurrentMillis(current float64) error {
 		return fmt.Errorf("invalid current %.1f", current)
 	}
 
+	// If phase switch timer is running, than do not write new Amps, ignore right after startup
+	if wb.phaseSwitchStart.Add(wb.phaseswitchduration).After(time.Now()) && time.Now().Second() > int(wb.phaseswitchduration) {
+		return fmt.Errorf("MaxCurrent Change ignored due to phase-switch in progress for %.0f seconds", (wb.phaseSwitchStart.Add(wb.phaseswitchduration).Sub(time.Now())).Seconds())
+	}
+
 	curr := uint16(10 * current)
 
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, curr)
 
 	_, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b)
-	if err == nil {
-		wb.current = curr
+	if err != nil {
+		return err
 	}
+	wb.current = curr
 
-	return err
+	return nil
 }
 
 var _ api.Meter = (*Amperfied)(nil)
@@ -347,21 +364,41 @@ func (wb *Amperfied) phases1p3p(phases int) error {
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, uint16(phases))
 
+	// Read current Phase Switch State
+	c, err := wb.conn.ReadInputRegisters(ampRegPhaseSwitchState, 1)
+	if err != nil {
+		wb.log.ERROR.Println("Error reading ampRegPhaseSwitchState")
+		return err
+	}
+	phases_cur := int(binary.BigEndian.Uint16(c))
+
+	if phases_cur == 0 {
+		return fmt.Errorf("phase-switch still in progress")
+	}
+	// Set new phases
+	_, err = wb.conn.WriteMultipleRegisters(ampRegPhaseSwitchControl, 1, b)
+	if err != nil {
+		wb.log.ERROR.Println("Error reading ampRegPhaseSwitchControl")
+		return err
+	}
 	wb.phases = phases
 
-	_, err := wb.conn.WriteMultipleRegisters(ampRegPhaseSwitchControl, 1, b)
-	return err
+	// Set Timer to phase switch duration and avoid new switching or current settings during timer
+	wb.phaseSwitchStart = time.Now()
+	return nil
 }
 
 // getPhases implements the api.PhaseGetter interface
 func (wb *Amperfied) getPhases() (int, error) {
 	b, err := wb.conn.ReadInputRegisters(ampRegPhaseSwitchState, 1)
 	if err != nil {
+		wb.log.ERROR.Println("Error reading ampRegPhaseSwitchState")
 		return 0, err
 	}
 
 	phases := int(binary.BigEndian.Uint16(b))
 	if phases == 0 {
+		wb.log.DEBUG.Println("phase-switching in progress")
 		return wb.phases, nil
 	}
 

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -202,16 +202,7 @@ func (wb *Amperfied) Enabled() (bool, error) {
 		return false, err
 	}
 
-	cur := binary.BigEndian.Uint16(b)
-
-	enabled := cur != 0
-	if enabled {
-		wb.mu.Lock()
-		wb.current = cur
-		wb.mu.Unlock()
-	}
-
-	return enabled, nil
+	return binary.BigEndian.Uint16(b) != 0, nil
 }
 
 // Enable implements the api.Charger interface

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -367,7 +367,6 @@ func (wb *Amperfied) phases1p3p(phases int) error {
 	if err != nil {
 		return err
 	}
-	wb.phases = phases
 
 	// read phase-switch duration during which no current changes are accepted
 	d, err := wb.conn.ReadHoldingRegisters(ampRegPhaseSwitchDuration, 1)
@@ -378,6 +377,7 @@ func (wb *Amperfied) phases1p3p(phases int) error {
 	// block current writes until phase-switch completes
 	duration := time.Duration(binary.BigEndian.Uint16(d)) * time.Second
 	wb.mu.Lock()
+	wb.phases = phases
 	wb.phaseSwitchEnd = time.Now().Add(duration)
 	wb.mu.Unlock()
 
@@ -408,6 +408,8 @@ func (wb *Amperfied) getPhases() (int, error) {
 	phases := int(binary.BigEndian.Uint16(b))
 	if phases == 0 {
 		wb.log.DEBUG.Println("phase-switching in progress")
+		wb.mu.Lock()
+		defer wb.mu.Unlock()
 		return wb.phases, nil
 	}
 

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -246,22 +246,14 @@ func (wb *Amperfied) MaxCurrentMillis(current float64) error {
 
 	curr := uint16(10 * current)
 
-	// skip write while phase-switch is in progress; re-apply happens via timer
 	wb.mu.Lock()
 	inSwitch := time.Now().Before(wb.phaseSwitchEnd)
-	if inSwitch {
-		wb.current = curr
-	}
 	wb.mu.Unlock()
-
-	if inSwitch {
-		return nil
-	}
 
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, curr)
 
-	if _, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b); err != nil {
+	if _, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b); err != nil && !inSwitch {
 		return err
 	}
 

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -38,6 +38,7 @@ type Amperfied struct {
 	mu             sync.Mutex
 	current        uint16
 	phases         int
+	enabled        bool
 	wakeup         bool
 	phaseSwitchEnd time.Time
 }
@@ -112,14 +113,14 @@ func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool) (
 		go wb.heartbeat(ctx, time.Duration(u)*time.Millisecond/2)
 	}
 
-	// disable phase-switch waiting time
-	if err := wb.set(ampRegPhaseSwitchWaitingTime, 0); err != nil {
-		return nil, fmt.Errorf("phase-switch waiting time: %w", err)
-	}
-
 	var phases1p3p func(int) error
 	var phasesG func() (int, error)
 	if phases {
+		// disable phase-switch waiting time
+		if err := wb.set(ampRegPhaseSwitchWaitingTime, 0); err != nil {
+			return nil, fmt.Errorf("phase-switch waiting time: %w", err)
+		}
+
 		phases1p3p = wb.phases1p3p
 		phasesG = wb.getPhases
 	}
@@ -205,11 +206,12 @@ func (wb *Amperfied) Enabled() (bool, error) {
 	cur := binary.BigEndian.Uint16(b)
 
 	enabled := cur != 0
+	wb.mu.Lock()
+	wb.enabled = enabled
 	if enabled {
-		wb.mu.Lock()
 		wb.current = cur
-		wb.mu.Unlock()
 	}
+	wb.mu.Unlock()
 
 	return enabled, nil
 }
@@ -226,9 +228,15 @@ func (wb *Amperfied) Enable(enable bool) error {
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, cur)
 
-	_, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b)
+	if _, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b); err != nil {
+		return err
+	}
 
-	return err
+	wb.mu.Lock()
+	wb.enabled = enable
+	wb.mu.Unlock()
+
+	return nil
 }
 
 // MaxCurrent implements the api.Charger interface
@@ -384,13 +392,19 @@ func (wb *Amperfied) phases1p3p(phases int) error {
 	// re-apply current after phase-switch completes to honor interim changes
 	time.AfterFunc(duration, func() {
 		wb.mu.Lock()
+		enabled := wb.enabled
 		cur := wb.current
 		wb.mu.Unlock()
+
+		// skip re-apply if charging was disabled during the phase-switch window
+		if !enabled {
+			return
+		}
 
 		b := make([]byte, 2)
 		binary.BigEndian.PutUint16(b, cur)
 		if _, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b); err != nil {
-			wb.log.ERROR.Printf("re-apply current after phase switch: %v", err)
+			wb.log.DEBUG.Printf("re-apply current after phase switch: %v", err)
 		}
 	})
 
@@ -401,13 +415,11 @@ func (wb *Amperfied) phases1p3p(phases int) error {
 func (wb *Amperfied) getPhases() (int, error) {
 	b, err := wb.conn.ReadInputRegisters(ampRegPhaseSwitchState, 1)
 	if err != nil {
-		wb.log.ERROR.Println("Error reading ampRegPhaseSwitchState")
 		return 0, err
 	}
 
 	phases := int(binary.BigEndian.Uint16(b))
 	if phases == 0 {
-		wb.log.DEBUG.Println("phase-switching in progress")
 		wb.mu.Lock()
 		defer wb.mu.Unlock()
 		return wb.phases, nil

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -337,11 +337,6 @@ func (wb *Amperfied) WakeUp() error {
 
 // phases1p3p implements the api.PhaseSwitcher interface
 func (wb *Amperfied) phases1p3p(phases int) error {
-	// reduce current to minimum before phase-switching
-	if err := wb.set(ampRegAmpsConfig, 60); err != nil {
-		return err
-	}
-
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, uint16(phases))
 

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -32,34 +33,30 @@ import (
 
 // Amperfied charger implementation
 type Amperfied struct {
-	log                 *util.Logger
-	conn                *modbus.Connection
-	current             uint16
-	phases              int
-	wakeup              bool
-	phaseswitchduration time.Duration
-	phaseSwitchStart    time.Time
+	log            *util.Logger
+	conn           *modbus.Connection
+	mu             sync.Mutex
+	current        uint16
+	phases         int
+	wakeup         bool
+	phaseSwitchEnd time.Time
 }
 
 const (
-	ampRegChargingState       = 5    // Input
-	ampRegCurrents            = 6    // Input 6,7,8
-	ampRegTemperature         = 9    // Input
-	ampRegVoltages            = 10   // Input 10,11,12
-	ampRegPower               = 14   // Input
-	ampRegEnergy              = 17   // Input
-	ampRegTimeoutConfig       = 257  // Holding
-	ampRegRemoteLock          = 259  // Holding
-	ampRegAmpsConfig          = 261  // Holding
-	ampRegFailSafeConfig      = 262  // Holding
-	ampRegPhaseSwitchControl  = 501  // Holding
-	ampRegPhaseSwitchDuration = 503  // Holding
-	ampRegPhaseSwitchState    = 5001 // Input
-	ampRegRfidUID             = 2002 // Input
-)
-
-const (
-	phaseSwitchDurationDefault = 90
+	ampRegChargingState          = 5    // Input   (uint16)
+	ampRegCurrents               = 6    // Input   (uint16*3)
+	ampRegVoltages               = 10   // Input   (uint16*3)
+	ampRegPower                  = 14   // Input   (uint16)
+	ampRegEnergy                 = 17   // Input   (uint32)
+	ampRegTimeoutConfig          = 257  // Holding (uint16)
+	ampRegRemoteLock             = 259  // Holding (uint16)
+	ampRegAmpsConfig             = 261  // Holding (uint16)
+	ampRegFailSafeConfig         = 262  // Holding (uint16)
+	ampRegPhaseSwitchControl     = 501  // Holding (uint16)
+	ampRegPhaseSwitchDuration    = 503  // Holding (uint16)
+	ampRegPhaseSwitchWaitingTime = 504  // Holding (uint16)
+	ampRegPhaseSwitchState       = 5001 // Input   (uint16)
+	ampRegRfidUID                = 2002 // Input   (uint16*6)
 )
 
 func init() {
@@ -71,25 +68,23 @@ func init() {
 // NewAmperfiedFromConfig creates a Amperfied charger from generic config
 func NewAmperfiedFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
 	cc := struct {
-		modbus.TcpSettings  `mapstructure:",squash"`
-		Phases1p3p          bool
-		Phaseswitchduration uint16
+		modbus.TcpSettings `mapstructure:",squash"`
+		Phases1p3p         bool
 	}{
 		TcpSettings: modbus.TcpSettings{
 			ID: 255,
 		},
-		Phaseswitchduration: phaseSwitchDurationDefault,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewAmperfied(ctx, cc.URI, cc.ID, cc.Phases1p3p, cc.Phaseswitchduration)
+	return NewAmperfied(ctx, cc.URI, cc.ID, cc.Phases1p3p)
 }
 
 // NewAmperfied creates Amperfied charger
-func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool, phaseswitchduration uint16) (api.Charger, error) {
+func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool) (api.Charger, error) {
 	conn, err := modbus.NewConnection(ctx, uri, "", "", 0, modbus.Tcp, slaveID)
 	if err != nil {
 		return nil, err
@@ -103,11 +98,9 @@ func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool, p
 	conn.Logger(log.TRACE)
 
 	wb := &Amperfied{
-		log:                 log,
-		conn:                conn,
-		current:             60, // assume min current
-		phaseswitchduration: time.Duration(phaseswitchduration) * time.Second,
-		phaseSwitchStart:    time.Now(), // initialize in the past to avoid startup error
+		log:     log,
+		conn:    conn,
+		current: 60, // assume min current
 	}
 
 	// get failsafe timeout from charger
@@ -117,6 +110,11 @@ func NewAmperfied(ctx context.Context, uri string, slaveID uint8, phases bool, p
 	}
 	if u := binary.BigEndian.Uint16(b); u > 0 {
 		go wb.heartbeat(ctx, time.Duration(u)*time.Millisecond/2)
+	}
+
+	// disable phase-switch waiting time
+	if err := wb.set(ampRegPhaseSwitchWaitingTime, 0); err != nil {
+		return nil, fmt.Errorf("phase-switch waiting time: %w", err)
 	}
 
 	var phases1p3p func(int) error
@@ -208,7 +206,9 @@ func (wb *Amperfied) Enabled() (bool, error) {
 
 	enabled := cur != 0
 	if enabled {
+		wb.mu.Lock()
 		wb.current = cur
+		wb.mu.Unlock()
 	}
 
 	return enabled, nil
@@ -218,7 +218,9 @@ func (wb *Amperfied) Enabled() (bool, error) {
 func (wb *Amperfied) Enable(enable bool) error {
 	var cur uint16
 	if enable {
+		wb.mu.Lock()
 		cur = wb.current
+		wb.mu.Unlock()
 	}
 
 	b := make([]byte, 2)
@@ -242,21 +244,30 @@ func (wb *Amperfied) MaxCurrentMillis(current float64) error {
 		return fmt.Errorf("invalid current %.1f", current)
 	}
 
-	// If phase switch timer is running, than do not write new Amps, ignore right after startup
-	if wb.phaseSwitchStart.Add(wb.phaseswitchduration).After(time.Now()) && time.Now().Second() > int(wb.phaseswitchduration) {
-		return fmt.Errorf("MaxCurrent Change ignored due to phase-switch in progress for %.0f seconds", (wb.phaseSwitchStart.Add(wb.phaseswitchduration).Sub(time.Now())).Seconds())
-	}
-
 	curr := uint16(10 * current)
+
+	// skip write while phase-switch is in progress; re-apply happens via timer
+	wb.mu.Lock()
+	inSwitch := time.Now().Before(wb.phaseSwitchEnd)
+	if inSwitch {
+		wb.current = curr
+	}
+	wb.mu.Unlock()
+
+	if inSwitch {
+		return nil
+	}
 
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, curr)
 
-	_, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b)
-	if err != nil {
+	if _, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b); err != nil {
 		return err
 	}
+
+	wb.mu.Lock()
 	wb.current = curr
+	wb.mu.Unlock()
 
 	return nil
 }
@@ -326,24 +337,6 @@ func (wb *Amperfied) Identify() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-var _ api.Diagnosis = (*Amperfied)(nil)
-
-// Diagnose implements the api.Diagnosis interface
-func (wb *Amperfied) Diagnose() {
-	if b, err := wb.conn.ReadInputRegisters(ampRegTemperature, 1); err == nil {
-		fmt.Printf("Temperature:\t%.1fC\n", float64(int16(binary.BigEndian.Uint16(b)))/10)
-	}
-	if b, err := wb.conn.ReadHoldingRegisters(ampRegTimeoutConfig, 1); err == nil {
-		fmt.Printf("Timeout:\t%d\n", binary.BigEndian.Uint16(b))
-	}
-	if b, err := wb.conn.ReadHoldingRegisters(ampRegRemoteLock, 1); err == nil {
-		fmt.Printf("Remote Lock:\t%d\n", binary.BigEndian.Uint16(b))
-	}
-	if b, err := wb.conn.ReadHoldingRegisters(ampRegFailSafeConfig, 1); err == nil {
-		fmt.Printf("FailSafe:\t%d\n", binary.BigEndian.Uint16(b))
-	}
-}
-
 var _ api.Resurrector = (*Amperfied)(nil)
 
 // WakeUp implements the api.Resurrector interface
@@ -361,30 +354,46 @@ func (wb *Amperfied) WakeUp() error {
 
 // phases1p3p implements the api.PhaseSwitcher interface
 func (wb *Amperfied) phases1p3p(phases int) error {
+	// reduce current to minimum before phase-switching
+	if err := wb.set(ampRegAmpsConfig, 60); err != nil {
+		return err
+	}
+
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, uint16(phases))
 
-	// Read current Phase Switch State
-	c, err := wb.conn.ReadInputRegisters(ampRegPhaseSwitchState, 1)
-	if err != nil {
-		wb.log.ERROR.Println("Error reading ampRegPhaseSwitchState")
-		return err
-	}
-	phases_cur := int(binary.BigEndian.Uint16(c))
-
-	if phases_cur == 0 {
-		return fmt.Errorf("phase-switch still in progress")
-	}
 	// Set new phases
-	_, err = wb.conn.WriteMultipleRegisters(ampRegPhaseSwitchControl, 1, b)
+	_, err := wb.conn.WriteMultipleRegisters(ampRegPhaseSwitchControl, 1, b)
 	if err != nil {
-		wb.log.ERROR.Println("Error reading ampRegPhaseSwitchControl")
 		return err
 	}
 	wb.phases = phases
 
-	// Set Timer to phase switch duration and avoid new switching or current settings during timer
-	wb.phaseSwitchStart = time.Now()
+	// read phase-switch duration during which no current changes are accepted
+	d, err := wb.conn.ReadHoldingRegisters(ampRegPhaseSwitchDuration, 1)
+	if err != nil {
+		return err
+	}
+
+	// block current writes until phase-switch completes
+	duration := time.Duration(binary.BigEndian.Uint16(d)) * time.Second
+	wb.mu.Lock()
+	wb.phaseSwitchEnd = time.Now().Add(duration)
+	wb.mu.Unlock()
+
+	// re-apply current after phase-switch completes to honor interim changes
+	time.AfterFunc(duration, func() {
+		wb.mu.Lock()
+		cur := wb.current
+		wb.mu.Unlock()
+
+		b := make([]byte, 2)
+		binary.BigEndian.PutUint16(b, cur)
+		if _, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b); err != nil {
+			wb.log.ERROR.Printf("re-apply current after phase switch: %v", err)
+		}
+	})
+
 	return nil
 }
 
@@ -403,4 +412,31 @@ func (wb *Amperfied) getPhases() (int, error) {
 	}
 
 	return phases, nil
+}
+
+var _ api.Diagnosis = (*Amperfied)(nil)
+
+// Diagnose implements the api.Diagnosis interface
+func (wb *Amperfied) Diagnose() {
+	if b, err := wb.conn.ReadHoldingRegisters(ampRegTimeoutConfig, 1); err == nil {
+		fmt.Printf("Timeout:\t%d\n", binary.BigEndian.Uint16(b))
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(ampRegRemoteLock, 1); err == nil {
+		fmt.Printf("Remote Lock:\t%d\n", binary.BigEndian.Uint16(b))
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(ampRegFailSafeConfig, 1); err == nil {
+		fmt.Printf("FailSafe:\t%d\n", binary.BigEndian.Uint16(b))
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(ampRegAmpsConfig, 1); err == nil {
+		fmt.Printf("Amps Config:\t%d\n", binary.BigEndian.Uint16(b))
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(ampRegPhaseSwitchDuration, 1); err == nil {
+		fmt.Printf("Phase Switch Duration:\t%d\n", binary.BigEndian.Uint16(b))
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(ampRegPhaseSwitchWaitingTime, 1); err == nil {
+		fmt.Printf("Phase Switch Waiting Time:\t%d\n", binary.BigEndian.Uint16(b))
+	}
+	if b, err := wb.conn.ReadInputRegisters(ampRegPhaseSwitchState, 1); err == nil {
+		fmt.Printf("Phase Switch State:\t%d\n", binary.BigEndian.Uint16(b))
+	}
 }

--- a/charger/amperfied.go
+++ b/charger/amperfied.go
@@ -38,7 +38,6 @@ type Amperfied struct {
 	mu             sync.Mutex
 	current        uint16
 	phases         int
-	enabled        bool
 	wakeup         bool
 	phaseSwitchEnd time.Time
 }
@@ -206,12 +205,11 @@ func (wb *Amperfied) Enabled() (bool, error) {
 	cur := binary.BigEndian.Uint16(b)
 
 	enabled := cur != 0
-	wb.mu.Lock()
-	wb.enabled = enabled
 	if enabled {
+		wb.mu.Lock()
 		wb.current = cur
+		wb.mu.Unlock()
 	}
-	wb.mu.Unlock()
 
 	return enabled, nil
 }
@@ -228,15 +226,9 @@ func (wb *Amperfied) Enable(enable bool) error {
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, cur)
 
-	if _, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b); err != nil {
-		return err
-	}
+	_, err := wb.conn.WriteMultipleRegisters(ampRegAmpsConfig, 1, b)
 
-	wb.mu.Lock()
-	wb.enabled = enable
-	wb.mu.Unlock()
-
-	return nil
+	return err
 }
 
 // MaxCurrent implements the api.Charger interface
@@ -391,15 +383,14 @@ func (wb *Amperfied) phases1p3p(phases int) error {
 
 	// re-apply current after phase-switch completes to honor interim changes
 	time.AfterFunc(duration, func() {
-		wb.mu.Lock()
-		enabled := wb.enabled
-		cur := wb.current
-		wb.mu.Unlock()
-
 		// skip re-apply if charging was disabled during the phase-switch window
-		if !enabled {
+		if enabled, err := wb.Enabled(); err != nil || !enabled {
 			return
 		}
+
+		wb.mu.Lock()
+		cur := wb.current
+		wb.mu.Unlock()
 
 		b := make([]byte, 2)
 		binary.BigEndian.PutUint16(b, cur)


### PR DESCRIPTION
This tries to fix phase-switching on Amperfied `connect.solar` wallboxes.
Writes to the current register (261) during an ongoing phase switch were being rejected by the charger. This PR synchronizes evcc's current updates with the wallbox's phase-switch state.

## Changes

- **Disable wallbox-side waiting time** by writing `0` to register `504` on startup (only when 1p3p phase-switching is enabled, i.e. `connect.solar`), so the wallbox no longer blocks writes with its own grace period. The waiting period is maintained within evcc's own timers instead.
- **Tolerate write errors during the switch**: read the phase-switch duration from register `503` after the switch is triggered and, while that window is active, suppress modbus errors on writes to `261`. `wb.current` is still tracked locally so interim setpoint changes are not lost.
- **Re-apply after the switch**: a `time.AfterFunc` writes the latest `wb.current` to register `261` once the duration has passed, honoring any setpoint changes that arrived during the window. The callback queries `Enabled()` first and skips the re-apply if the charger was disabled in the meantime.
- **Thread safety**: guard `wb.current`, `wb.phases` and `wb.phaseSwitchEnd` with a `sync.Mutex` since the `AfterFunc` callback runs concurrently with the loadpoint goroutine.
- **Diagnose**: additional output for registers `261`, `503`, `504` and `5001`.
- Register constants annotated with their data types.

## Background

Based on the approach proposed in the closed #20525, reduced to the timer-based path (the internal-phase-switch / power-register variant was dropped).