### PR TITLE
Device Cards: bool value formatting

### DIFF
--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -181,12 +181,7 @@ export default {
 			if (entry.warning) {
 				return "value--warning";
 			}
-			if (
-				entry.muted ||
-				entry.value === false ||
-				entry.value === null ||
-				entry.value === undefined
-			) {
+			if (entry.muted || entry.value === null || entry.value === undefined) {
 				return "value--muted";
 			}
 			return "";


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/29105

bool false values in device cards are not always green (when no errors)
relic from previous "configured: no" handling which is now addressed differently

<img width="742" height="341" alt="Bildschirmfoto 2026-04-15 um 14 42 38" src="https://github.com/user-attachments/assets/41f16029-832d-432b-9836-f1d5e9e1641f" />
