### PR TITLE
Site: allow custom titles for battery and ext meter refs

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -103,21 +103,21 @@ func runDump(cmd *cobra.Command, args []string) {
 		d.DumpWithHeader(fmt.Sprintf("grid: %s", name), handle(name, config.Meters()))
 	}
 
-	for id, name := range site.Meters.PVMetersRef {
-		if name != "" {
-			d.DumpWithHeader(fmt.Sprintf("pv %d: %s", id+1, name), handle(name, config.Meters()))
+	for id, ref := range site.Meters.PVMetersRef {
+		if ref.Source != "" {
+			d.DumpWithHeader(fmt.Sprintf("pv %d: %s", id+1, ref.Source), handle(ref.Source, config.Meters()))
 		}
 	}
 
-	for id, name := range site.Meters.BatteryMetersRef {
-		if name != "" {
-			d.DumpWithHeader(fmt.Sprintf("battery %d: %s", id+1, name), handle(name, config.Meters()))
+	for id, ref := range site.Meters.BatteryMetersRef {
+		if ref.Source != "" {
+			d.DumpWithHeader(fmt.Sprintf("battery %d: %s", id+1, ref.Source), handle(ref.Source, config.Meters()))
 		}
 	}
 
-	for id, name := range site.Meters.AuxMetersRef {
-		if name != "" {
-			d.DumpWithHeader(fmt.Sprintf("aux %d: %s", id+1, name), handle(name, config.Meters()))
+	for id, ref := range site.Meters.AuxMetersRef {
+		if ref.Source != "" {
+			d.DumpWithHeader(fmt.Sprintf("aux %d: %s", id+1, ref.Source), handle(ref.Source, config.Meters()))
 		}
 	}
 

--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -60,10 +60,10 @@ func collectSiteRefs(conf globalconfig.All) error {
 	}
 
 	references.meter = append(references.meter, refs.Meters.GridMeterRef)
-	references.meter = append(references.meter, refs.Meters.PVMetersRef...)
-	references.meter = append(references.meter, refs.Meters.BatteryMetersRef...)
-	references.meter = append(references.meter, refs.Meters.ExtMetersRef...)
-	references.meter = append(references.meter, refs.Meters.AuxMetersRef...)
+	references.meter = append(references.meter, refs.Meters.PVMetersRef.Sources()...)
+	references.meter = append(references.meter, refs.Meters.BatteryMetersRef.Sources()...)
+	references.meter = append(references.meter, refs.Meters.ExtMetersRef.Sources()...)
+	references.meter = append(references.meter, refs.Meters.AuxMetersRef.Sources()...)
 
 	// append devices from settings
 	if v, err := settings.String(keys.GridMeter); err == nil && v != "" {

--- a/core/site.go
+++ b/core/site.go
@@ -102,11 +102,44 @@ type Site struct {
 
 // MetersConfig contains the site's meter configuration
 type MetersConfig struct {
-	GridMeterRef     string   `mapstructure:"grid"`    // Grid usage meter
-	PVMetersRef      []string `mapstructure:"pv"`      // PV meter
-	BatteryMetersRef []string `mapstructure:"battery"` // Battery charging meter
-	ExtMetersRef     []string `mapstructure:"ext"`     // Meters used only for monitoring
-	AuxMetersRef     []string `mapstructure:"aux"`     // Auxiliary meters
+	GridMeterRef     string    `mapstructure:"grid"`    // Grid usage meter
+	PVMetersRef      MeterRefs `mapstructure:"pv"`      // PV meter
+	BatteryMetersRef MeterRefs `mapstructure:"battery"` // Battery charging meter
+	ExtMetersRef     MeterRefs `mapstructure:"ext"`     // Meters used only for monitoring
+	AuxMetersRef     MeterRefs `mapstructure:"aux"`     // Auxiliary meters
+}
+
+// MeterRef defines a meter reference with an optional display title.
+// It supports both scalar ("meter-name") and object ({source, title}) YAML notation.
+type MeterRef struct {
+	Source string `mapstructure:"source"`
+	Title  string `mapstructure:"title"`
+}
+
+func (r *MeterRef) UnmarshalText(text []byte) error {
+	r.Source = string(text)
+	return nil
+}
+
+// MeterRefs is a list of meter references.
+type MeterRefs []MeterRef
+
+func (refs MeterRefs) Sources() []string {
+	res := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Source != "" {
+			res = append(res, ref.Source)
+		}
+	}
+	return res
+}
+
+func meterRefsFromSources(sources []string) MeterRefs {
+	refs := make(MeterRefs, 0, len(sources))
+	for _, source := range sources {
+		refs = append(refs, MeterRef{Source: source})
+	}
+	return refs
 }
 
 // NewSiteFromConfig creates a new site
@@ -198,7 +231,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 	}
 
 	// multiple pv
-	for _, ref := range site.Meters.PVMetersRef {
+	for _, ref := range site.Meters.PVMetersRef.Sources() {
 		dev, err := config.Meters().ByName(ref)
 		if err != nil {
 			return err
@@ -210,7 +243,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 	}
 
 	// multiple batteries
-	for _, ref := range site.Meters.BatteryMetersRef {
+	for _, ref := range site.Meters.BatteryMetersRef.Sources() {
 		dev, err := config.Meters().ByName(ref)
 		if err != nil {
 			return err
@@ -219,7 +252,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 	}
 
 	// meters used only for monitoring
-	for _, ref := range site.Meters.ExtMetersRef {
+	for _, ref := range site.Meters.ExtMetersRef.Sources() {
 		dev, err := config.Meters().ByName(ref)
 		if err != nil {
 			return err
@@ -228,7 +261,7 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 	}
 
 	// auxiliary meters
-	for _, ref := range site.Meters.AuxMetersRef {
+	for _, ref := range site.Meters.AuxMetersRef.Sources() {
 		dev, err := config.Meters().ByName(ref)
 		if err != nil {
 			return err
@@ -272,16 +305,16 @@ func (site *Site) restoreMetersAndTitle() {
 		site.Meters.GridMeterRef = v
 	}
 	if v, err := settings.String(keys.PvMeters); err == nil && v != "" {
-		site.Meters.PVMetersRef = append(site.Meters.PVMetersRef, filterConfigurable(strings.Split(v, ","))...)
+		site.Meters.PVMetersRef = append(site.Meters.PVMetersRef, meterRefsFromSources(filterConfigurable(strings.Split(v, ",")))...)
 	}
 	if v, err := settings.String(keys.BatteryMeters); err == nil && v != "" {
-		site.Meters.BatteryMetersRef = append(site.Meters.BatteryMetersRef, filterConfigurable(strings.Split(v, ","))...)
+		site.Meters.BatteryMetersRef = append(site.Meters.BatteryMetersRef, meterRefsFromSources(filterConfigurable(strings.Split(v, ",")))...)
 	}
 	if v, err := settings.String(keys.ExtMeters); err == nil && v != "" {
-		site.Meters.ExtMetersRef = append(site.Meters.ExtMetersRef, filterConfigurable(strings.Split(v, ","))...)
+		site.Meters.ExtMetersRef = append(site.Meters.ExtMetersRef, meterRefsFromSources(filterConfigurable(strings.Split(v, ",")))...)
 	}
 	if v, err := settings.String(keys.AuxMeters); err == nil && v != "" {
-		site.Meters.AuxMetersRef = append(site.Meters.AuxMetersRef, filterConfigurable(strings.Split(v, ","))...)
+		site.Meters.AuxMetersRef = append(site.Meters.AuxMetersRef, meterRefsFromSources(filterConfigurable(strings.Split(v, ",")))...)
 	}
 }
 
@@ -327,7 +360,7 @@ func (site *Site) restoreSettings() error {
 
 	if err == nil && settings.Json(keys.SolarAccYield, &pvEnergy) == nil {
 		var nok bool
-		for _, name := range site.Meters.PVMetersRef {
+		for _, name := range site.Meters.PVMetersRef.Sources() {
 			if fcst, ok := pvEnergy[name]; ok {
 				site.pvEnergy[name].Import = fcst.Import
 			} else {
@@ -490,7 +523,7 @@ func (site *Site) clearPlanLocks() {
 	}
 }
 
-func (site *Site) collectMeters(key string, meters []config.Device[api.Meter]) []types.Measurement {
+func (site *Site) collectMeters(key string, meters []config.Device[api.Meter], refs MeterRefs) []types.Measurement {
 	mm := make([]types.Measurement, len(meters))
 
 	fun := func(i int, dev config.Device[api.Meter]) {
@@ -518,8 +551,12 @@ func (site *Site) collectMeters(key string, meters []config.Device[api.Meter]) [
 		}
 
 		props := deviceProperties(dev)
+		title := props.Title
+		if i < len(refs) && refs[i].Title != "" {
+			title = refs[i].Title
+		}
 		mm[i] = types.Measurement{
-			Title:  props.Title,
+			Title:  title,
 			Icon:   props.Icon,
 			Power:  power,
 			Energy: energy,
@@ -544,7 +581,7 @@ func (site *Site) updatePvMeters() {
 		return
 	}
 
-	mm := site.collectMeters("pv", site.pvMeters)
+	mm := site.collectMeters("pv", site.pvMeters, site.Meters.PVMetersRef)
 
 	for i, dev := range site.pvMeters {
 		meter := dev.Instance()
@@ -616,7 +653,7 @@ func (site *Site) updateBatteryMeters() {
 		return
 	}
 
-	mm := site.collectMeters("battery", site.batteryMeters)
+	mm := site.collectMeters("battery", site.batteryMeters, site.Meters.BatteryMetersRef)
 
 	for i, dev := range site.batteryMeters {
 		meter := dev.Instance()
@@ -699,7 +736,7 @@ func (site *Site) updateAuxMeters() {
 		return
 	}
 
-	mm := site.collectMeters("aux", site.auxMeters)
+	mm := site.collectMeters("aux", site.auxMeters, site.Meters.AuxMetersRef)
 	site.auxPower = lo.SumBy(mm, func(m types.Measurement) float64 {
 		return m.Power
 	})
@@ -718,7 +755,7 @@ func (site *Site) updateExtMeters() {
 		return
 	}
 
-	mm := site.collectMeters("ext", site.extMeters)
+	mm := site.collectMeters("ext", site.extMeters, site.Meters.ExtMetersRef)
 	site.publish(keys.Ext, mm)
 }
 

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -72,7 +72,7 @@ func (site *Site) SetGridMeterRef(ref string) {
 func (site *Site) GetPVMeterRefs() []string {
 	site.RLock()
 	defer site.RUnlock()
-	return site.Meters.PVMetersRef
+	return site.Meters.PVMetersRef.Sources()
 }
 
 // SetPVMeterRefs sets the PvMeterRef
@@ -80,7 +80,7 @@ func (site *Site) SetPVMeterRefs(ref []string) {
 	site.Lock()
 	defer site.Unlock()
 
-	site.Meters.PVMetersRef = ref
+	site.Meters.PVMetersRef = meterRefsFromSources(ref)
 	settings.SetString(keys.PvMeters, strings.Join(filterConfigurable(ref), ","))
 }
 
@@ -88,7 +88,7 @@ func (site *Site) SetPVMeterRefs(ref []string) {
 func (site *Site) GetBatteryMeterRefs() []string {
 	site.RLock()
 	defer site.RUnlock()
-	return site.Meters.BatteryMetersRef
+	return site.Meters.BatteryMetersRef.Sources()
 }
 
 // SetBatteryMeterRefs sets the BatteryMeterRef
@@ -96,7 +96,7 @@ func (site *Site) SetBatteryMeterRefs(ref []string) {
 	site.Lock()
 	defer site.Unlock()
 
-	site.Meters.BatteryMetersRef = ref
+	site.Meters.BatteryMetersRef = meterRefsFromSources(ref)
 	settings.SetString(keys.BatteryMeters, strings.Join(filterConfigurable(ref), ","))
 }
 
@@ -104,7 +104,7 @@ func (site *Site) SetBatteryMeterRefs(ref []string) {
 func (site *Site) GetAuxMeterRefs() []string {
 	site.RLock()
 	defer site.RUnlock()
-	return site.Meters.AuxMetersRef
+	return site.Meters.AuxMetersRef.Sources()
 }
 
 // SetAuxMeterRefs sets the AuxMeterRef
@@ -112,7 +112,7 @@ func (site *Site) SetAuxMeterRefs(ref []string) {
 	site.Lock()
 	defer site.Unlock()
 
-	site.Meters.AuxMetersRef = ref
+	site.Meters.AuxMetersRef = meterRefsFromSources(ref)
 	settings.SetString(keys.AuxMeters, strings.Join(filterConfigurable(ref), ","))
 }
 
@@ -120,7 +120,7 @@ func (site *Site) SetAuxMeterRefs(ref []string) {
 func (site *Site) GetExtMeterRefs() []string {
 	site.RLock()
 	defer site.RUnlock()
-	return site.Meters.ExtMetersRef
+	return site.Meters.ExtMetersRef.Sources()
 }
 
 // SetExtMeterRefs sets the ExtMeterRef
@@ -128,7 +128,7 @@ func (site *Site) SetExtMeterRefs(ref []string) {
 	site.Lock()
 	defer site.Unlock()
 
-	site.Meters.ExtMetersRef = ref
+	site.Meters.ExtMetersRef = meterRefsFromSources(ref)
 	settings.SetString(keys.ExtMeters, strings.Join(filterConfigurable(ref), ","))
 }
 

--- a/core/site_meterref_test.go
+++ b/core/site_meterref_test.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testMeter struct {
+	power float64
+}
+
+func (m testMeter) CurrentPower() (float64, error) {
+	return m.power, nil
+}
+
+func TestMetersConfigDecodesMeterRefs(t *testing.T) {
+	var cfg struct {
+		Meters MetersConfig `mapstructure:"meters"`
+	}
+
+	err := util.DecodeOther(map[string]any{
+		"meters": map[string]any{
+			"battery": []any{
+				"battery-1",
+				map[string]any{
+					"source": "battery-2",
+					"title":  "Battery Upstairs",
+				},
+			},
+			"ext": []any{
+				map[string]any{
+					"source": "ext-1",
+					"title":  "Heat Pump",
+				},
+			},
+		},
+	}, &cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, MeterRefs{
+		{Source: "battery-1"},
+		{Source: "battery-2", Title: "Battery Upstairs"},
+	}, cfg.Meters.BatteryMetersRef)
+	assert.Equal(t, MeterRefs{
+		{Source: "ext-1", Title: "Heat Pump"},
+	}, cfg.Meters.ExtMetersRef)
+}
+
+func TestCollectMetersUsesRefTitleOverride(t *testing.T) {
+	site := NewSite()
+
+	meters := []config.Device[api.Meter]{
+		config.NewStaticDevice(config.Named{Name: "battery-1"}, testMeter{power: 1200}),
+	}
+	refs := MeterRefs{
+		{Source: "battery-1", Title: "Battery Basement"},
+	}
+
+	res := site.collectMeters("battery", meters, refs)
+	require.Len(t, res, 1)
+	assert.Equal(t, "Battery Basement", res[0].Title)
+	assert.Equal(t, 1200.0, res[0].Power)
+}

--- a/core/site_meterref_test.go
+++ b/core/site_meterref_test.go
@@ -55,7 +55,7 @@ func TestCollectMetersUsesRefTitleOverride(t *testing.T) {
 	site := NewSite()
 
 	meters := []config.Device[api.Meter]{
-		config.NewStaticDevice(config.Named{Name: "battery-1"}, testMeter{power: 1200}),
+		config.NewStaticDevice[api.Meter](config.Named{Name: "battery-1"}, testMeter{power: 1200}),
 	}
 	refs := MeterRefs{
 		{Source: "battery-1", Title: "Battery Basement"},

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -181,6 +181,7 @@
       "auxMeter": "Smarter Verbraucher",
       "batteryStorage": "Batterie",
       "consumer": "Verbraucher",
+      "extMeter": "Zusatzzähler",
       "solarSystem": "PV-Anlage"
     },
     "editor": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -182,6 +182,7 @@
       "auxMeter": "Smart consumer",
       "batteryStorage": "Battery storage",
       "consumer": "Consumer",
+      "extMeter": "Additional meter",
       "solarSystem": "Solar system"
     },
     "editor": {

--- a/schema.json
+++ b/schema.json
@@ -163,7 +163,7 @@
                 "array"
               ],
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/meterRef"
               },
               "minItems": 1,
               "uniqueItems": true
@@ -175,7 +175,7 @@
                 "array"
               ],
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/meterRef"
               },
               "minItems": 1,
               "uniqueItems": true
@@ -187,7 +187,18 @@
                 "array"
               ],
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/meterRef"
+              },
+              "uniqueItems": true
+            },
+            "ext": {
+              "description": "External meters (0 or more)",
+              "type": [
+                "string",
+                "array"
+              ],
+              "items": {
+                "$ref": "#/definitions/meterRef"
               },
               "uniqueItems": true
             }
@@ -318,6 +329,28 @@
           "type": "string"
         }
       }
+    },
+    "meterRef": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "required": [
+            "source"
+          ],
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "loglevel": {
       "enum": [


### PR DESCRIPTION
## Summary

Allows site meter entries for `battery` and `ext` to be defined with an optional `title` field that overrides the device name in the UI. This is useful when using generic integrations (e.g. Home Assistant) where the device name cannot be customised.

**Before:**
```yaml
site:
  meters:
    battery:
      - battery1
      - battery2
```
Shows as "Battery storage #1", "Battery storage #2" in the energy flow.

**After:**
```yaml
site:
  meters:
    battery:
      - source: battery1
        title: "Home battery"
      - source: battery2
        title: "Shed battery"
    ext:
      - source: heatpump
        title: "Heat pump"
```
Shows custom titles in the energy flow expanded view.

Plain string refs remain fully backward compatible.

## Changes

- `core/site.go`: introduce `MeterRef` struct and `MeterRefs` type; update `MetersConfig` to use `MeterRefs` for all meter types; `collectMeters()` applies ref title override when set
- `core/site_api.go`: update getters/setters to use `.Sources()` helper
- `cmd/dump.go`, `cmd/refs.go`: update to iterate `MeterRef` structs
- `core/site_meterref_test.go`: tests for decoding and title override behaviour
- `schema.json`: update `battery`, `aux`, `ext` items to accept `meterRef` (string or `{source, title}` object); add `meterRef` definition; add missing `ext` schema entry
- `i18n/en.json`, `i18n/de.json`: add missing `config.devices.extMeter` translation key used by `MeterCard.vue`