### PR TITLE
Remove charge state from ConnectedCars

### DIFF
--- a/vehicle/connectedcars.go
+++ b/vehicle/connectedcars.go
@@ -77,20 +77,6 @@ func (v *ConnectedCars) Soc() (float64, error) {
 	return res.ChargePercentage.Pct, nil
 }
 
-var _ api.ChargeState = (*ConnectedCars)(nil)
-
-// Status implements the api.ChargeState interface
-func (v *ConnectedCars) Status() (api.ChargeStatus, error) {
-	res, err := v.dataG()
-	if err != nil {
-		return api.StatusNone, err
-	}
-	if res.ChargingState != nil && res.ChargingState.Enabled {
-		return api.StatusC, nil
-	}
-	return api.StatusA, nil
-}
-
 var _ api.VehicleRange = (*ConnectedCars)(nil)
 
 // Range implements the api.VehicleRange interface

--- a/vehicle/connectedcars/api.go
+++ b/vehicle/connectedcars/api.go
@@ -120,7 +120,7 @@ func (a *API) Data(vehicleID string) (VehicleData, error) {
 	uri := fmt.Sprintf("https://api.%s/graphql", a.domain)
 
 	body := graphqlRequest{
-		Query:     `query($id: ID!) { vehicle(id: $id) { id chargePercentage { pct } odometer { odometer } rangeTotalKm { km } chargingState { enabled } }}`,
+		Query:     `query($id: ID!) { vehicle(id: $id) { id chargePercentage { pct } odometer { odometer } rangeTotalKm { km } }}`,
 		Variables: map[string]any{"id": vehicleID},
 	}
 

--- a/vehicle/connectedcars/types.go
+++ b/vehicle/connectedcars/types.go
@@ -40,7 +40,4 @@ type VehicleData struct {
 	RangeTotalKm *struct {
 		Km float64 `json:"km"`
 	} `json:"rangeTotalKm"`
-	ChargingState *struct {
-		Enabled bool `json:"enabled"`
-	} `json:"chargingState"`
 }


### PR DESCRIPTION
We can't distinguish between A and B status which makes the current implementation misleading. It's safer to remove it entirely to avoid confusing the EVCC logic based on it.

This is a tweak to https://github.com/evcc-io/evcc/pull/28899 and it is in response to https://github.com/evcc-io/evcc/pull/28899#discussion_r3091554103