### PR TITLE
fix: migrate solar forecast settings from legacy format

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -327,13 +327,20 @@ func (site *Site) restoreSettings() error {
 
 	if err == nil && settings.Json(keys.SolarAccYield, &pvEnergy) == nil {
 		var nok bool
+		var produced float64
 		for _, name := range site.Meters.PVMetersRef {
 			if fcst, ok := pvEnergy[name]; ok {
 				site.pvEnergy[name].Import = fcst.Import
+				produced += fcst.Import
 			} else {
 				nok = true
 				site.log.WARN.Printf("accumulated solar yield: cannot restore %s", name)
 			}
+		}
+
+		// reset if produced is 0 but forecast is not (inconsistent state)
+		if produced == 0 && fcstEnergy > 0 {
+			nok = true
 		}
 
 		if !nok {


### PR DESCRIPTION
## Summary
- Fixes #29165
- Resets solar forecast metrics when state is inconsistent

## Problem
PR #23185 changed the JSON field name from `"accumulated"` to `"import"`. On upgrade, `pvEnergy` values become 0 while `fcstEnergy` is preserved, causing scale = 0/98000 ≈ -100%.

## Solution
Detect inconsistent state (produced=0 but forecast>0) and reset both metrics to start fresh.

## Test plan
- [ ] Build passes
- [ ] Upgrade from pre-#23185: metrics reset, scale correct going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)