### PR TITLE
Optimizer: wording on debug view

### DIFF
--- a/assets/js/views/Optimize.vue
+++ b/assets/js/views/Optimize.vue
@@ -34,7 +34,7 @@
 										true
 									)
 								}}
-								saved
+								net cost
 							</small>
 						</h3>
 						<ChargeChart


### PR DESCRIPTION
The current wording 'saved' is misleading and raises unwarranted expectations.

I would vote for 'net cost' 
The objective_value is total grid import cost minus export revenue, adjusted for changes in battery stored monetary value.

I would also volunteer to adjust the doc from 
'how much money can be saved'
to sth like 
'what the the expected grid net cost over the optimization horizon will be.'
(skipping the battery value subtlety)
