### PR TITLE
feat(ui): add integrated PV slide with history and forecasts

### DIFF
--- a/assets/js/components/Loadpoints/Loadpoints.vue
+++ b/assets/js/components/Loadpoints/Loadpoints.vue
@@ -4,18 +4,29 @@
 		data-testid="loadpoints"
 	>
 		<div
-			v-if="loadpoints.length > 0"
+			v-if="slides.length > 0"
 			ref="carousel"
 			class="carousel d-lg-flex flex-wrap"
-			:class="[`carousel--${loadpoints.length}`, { 'carousel--fullwidth': fullWidth }]"
+			:class="[`carousel--${slides.length}`, { 'carousel--fullwidth': fullWidth }]"
 		>
 			<div
-				v-for="loadpoint in loadpoints"
-				:key="loadpoint.id"
+				v-for="(slide, index) in slides"
+				:key="slide.key"
 				class="flex-grow-1 mb-3 m-lg-0 p-lg-0"
+				:class="{ 'loadpoint-unselected': !selected(index) }"
 			>
+				<PvCard
+					v-if="slide.type === 'pv'"
+					class="h-100 loadpoint"
+					:pv="pv"
+					:pvPower="pvPower"
+					:pvEnergy="pvEnergy"
+					:forecast="forecast"
+					:experimental="experimental"
+				/>
 				<Loadpoint
-					v-bind="loadpoint"
+					v-else
+					v-bind="slide.loadpoint"
 					data-testid="loadpoint"
 					:vehicles="vehicles"
 					:smartCostType="smartCostType"
@@ -34,25 +45,25 @@
 					:batteryMode="batteryMode"
 					:forecast="forecast"
 					class="h-100"
-					:class="{ 'loadpoint-unselected': !selected(loadpoint.id) }"
-					@click="goTo(loadpoint.id)"
+					@click="goTo(slide.loadpoint.id)"
 				/>
 			</div>
 		</div>
-		<div v-if="loadpoints.length > 1" class="d-flex d-lg-none justify-content-center flex-wrap">
+		<div v-if="slides.length > 1" class="d-flex d-lg-none justify-content-center flex-wrap">
 			<button
-				v-for="loadpoint in loadpoints"
-				:key="loadpoint.id"
+				v-for="(slide, index) in slides"
+				:key="`indicator-${slide.key}`"
 				class="btn btn-sm btn-link p-0 mx-1 indicator d-flex justify-content-center align-items-center evcc-default-text"
-				:class="{ 'indicator--selected': selected(loadpoint.id) }"
-				@click="goTo(loadpoint.id)"
+				:class="{ 'indicator--selected': selected(index) }"
+				@click="goTo(slide.type === 'pv' ? 'pv' : slide.loadpoint.id)"
 			>
+				<shopicon-regular-sun v-if="slide.type === 'pv'" class="indicator-icon" />
 				<shopicon-filled-lightning
-					v-if="isCharging(loadpoint)"
+					v-else-if="isCharging(slide.loadpoint)"
 					class="indicator-icon"
 				></shopicon-filled-lightning>
 				<shopicon-filled-circle
-					v-else-if="loadpoint.connected"
+					v-else-if="slide.loadpoint.connected"
 					class="indicator-icon"
 				></shopicon-filled-circle>
 				<shopicon-bold-circle v-else class="indicator-icon"></shopicon-bold-circle>
@@ -65,16 +76,30 @@
 import "@h2d2/shopicons/es/filled/circle";
 import "@h2d2/shopicons/es/bold/circle";
 import "@h2d2/shopicons/es/filled/lightning";
+import "@h2d2/shopicons/es/regular/sun";
 
 import Loadpoint from "./Loadpoint.vue";
+import PvCard from "../Site/PvCard.vue";
 import { defineComponent, type PropType } from "vue";
-import type { UiLoadpoint, SMART_COST_TYPE, Timeout, Vehicle, BATTERY_MODE } from "@/types/evcc";
+import type {
+	UiLoadpoint,
+	SMART_COST_TYPE,
+	Timeout,
+	Vehicle,
+	BATTERY_MODE,
+	Meter,
+} from "@/types/evcc";
+
+const PV_SLIDE_ID = "pv";
 
 export default defineComponent({
 	name: "Loadpoints",
-	components: { Loadpoint },
+	components: { Loadpoint, PvCard },
 	props: {
 		loadpoints: { type: Array as PropType<UiLoadpoint[]>, default: () => [] },
+		pv: { type: Array as PropType<Meter[]>, default: () => [] },
+		pvPower: { type: Number, default: 0 },
+		pvEnergy: Number,
 		vehicles: { type: Array as PropType<Vehicle[]> },
 		smartCostType: String as PropType<SMART_COST_TYPE>,
 		smartCostAvailable: Boolean,
@@ -89,6 +114,7 @@ export default defineComponent({
 		batteryConfigured: Boolean,
 		batterySoc: Number,
 		batteryMode: String as PropType<BATTERY_MODE>,
+		experimental: Boolean,
 		forecast: Object, // as PropType<Forecast>,
 	},
 	emits: ["id-changed"],
@@ -101,6 +127,15 @@ export default defineComponent({
 		};
 	},
 	computed: {
+		slides() {
+			const loadpointSlides = this.loadpoints.map((loadpoint) => ({
+				type: "loadpoint" as const,
+				key: `lp-${loadpoint.id}`,
+				loadpoint,
+			}));
+			const pvSlides = this.pvConfigured ? [{ type: "pv" as const, key: "pv" as const }] : [];
+			return [...loadpointSlides, ...pvSlides];
+		},
 		selectedIndex() {
 			return this.indexById(this.selectedId);
 		},
@@ -108,11 +143,12 @@ export default defineComponent({
 			return this.loadpoints.length > 1;
 		},
 		fullWidth() {
+			const tiles = this.slides.length;
 			return (
 				// breakpoint lg, tall screen, 2 loadpoints rows
-				(this.loadpoints.length === 2 && this.viewportHeight >= 1450) ||
+				(tiles === 2 && this.viewportHeight >= 1450) ||
 				// breakpoint lg, taller screen, 3 loadpoints rows
-				(this.loadpoints.length === 3 && this.viewportHeight >= 1900)
+				(tiles === 3 && this.viewportHeight >= 1900)
 			);
 		},
 	},
@@ -136,9 +172,16 @@ export default defineComponent({
 	},
 	methods: {
 		indexById(id: string | undefined) {
-			return this.loadpoints.findIndex((lp) => lp.id === id) || 0;
+			if (!id) return 0;
+			if (this.pvConfigured && id === PV_SLIDE_ID) {
+				return this.loadpoints.length;
+			}
+			const lpIndex = this.loadpoints.findIndex((lp) => lp.id === id);
+			if (lpIndex < 0) return 0;
+			return lpIndex;
 		},
 		idByIndex(index: number) {
+			if (this.pvConfigured && index >= this.loadpoints.length) return PV_SLIDE_ID;
 			return this.loadpoints[index]?.id;
 		},
 		handleCarouselScroll() {
@@ -156,14 +199,14 @@ export default defineComponent({
 				}
 			}, 2000);
 		},
-		goTo(id: string) {
+		goTo(id?: string) {
 			this.$emit("id-changed", id);
 		},
 		isCharging(lp: UiLoadpoint) {
 			return lp.charging && lp.chargePower > 0;
 		},
-		selected(id: string) {
-			return this.highlightedIndex === this.indexById(id);
+		selected(index: number) {
+			return this.highlightedIndex === index;
 		},
 		updateViewport() {
 			this.viewportHeight = window.innerHeight;
@@ -202,6 +245,7 @@ export default defineComponent({
 	.carousel {
 		scroll-snap-type: x mandatory;
 		overflow-x: scroll;
+		padding-top: 0.75rem;
 		display: flex;
 		flex-wrap: nowrap !important;
 		scrollbar-width: none; /* Firefox */

--- a/assets/js/components/Site/PvCard.vue
+++ b/assets/js/components/Site/PvCard.vue
@@ -1,0 +1,272 @@
+<template>
+	<div
+		class="pv-card d-flex flex-column pt-4 pb-2 px-3 px-sm-4 mx-2 mx-sm-0"
+		:class="{ 'pv-active': pvPower > 0 }"
+	>
+		<div class="d-flex justify-content-between align-items-center mb-3 text-truncate">
+			<h3 class="me-2 mb-0 text-truncate d-flex align-items-center">
+				<shopicon-regular-sun class="me-2 flex-shrink-0" :class="{ 'sun-active': pvPower > 0 }" />
+				<span class="text-truncate">{{ cardTitle }}</span>
+			</h3>
+			<button type="button" class="btn btn-sm btn-outline-secondary" @click.stop="openHistory">
+				{{ $t("main.pvTile.history") }}
+			</button>
+		</div>
+
+		<div class="pv-hero mb-3">
+			<div class="pv-hero-label">{{ $t("main.pvTile.currentPower") }}</div>
+			<div class="pv-hero-value">{{ fmtPower(pvPower) }}</div>
+		</div>
+
+		<div class="details d-flex align-items-start mb-2">
+			<LabelAndValue
+				:label="$t('main.pvTile.generatedToday')"
+					:value="displayGeneratedTodayEnergy"
+				:valueFmt="fmtEnergyKWh"
+				align="center"
+			/>
+			<LabelAndValue
+				:label="$t('main.pvTile.forecastPossible')"
+				:value="forecastRemainingToday"
+				:valueFmt="fmtEnergyWh"
+				align="end"
+			/>
+		</div>
+		<hr class="divider" />
+
+		<div class="flex-grow-1 d-flex flex-column justify-content-end pt-3 pb-2 gap-3">
+			<PvDayBars
+				:solar="forecast?.solar"
+				:pvEnergy="displayGeneratedTodayEnergy"
+				:pvPower="pvPower"
+			/>
+
+			<div>
+				<div class="summary-label">{{ $t("main.pvTile.theoreticalTotal") }}</div>
+				<h3 class="summary-value m-0">
+					{{ theoreticalTotalText }}
+				</h3>
+			</div>
+
+			<div v-if="pv.length > 0" class="systems d-flex flex-column gap-2">
+				<div class="summary-label">{{ $t("main.pvTile.systems") }}</div>
+				<div
+					v-for="(plant, index) in pv"
+					:key="index"
+					class="system-row d-flex justify-content-between align-items-center gap-3"
+				>
+					<span class="text-truncate">{{ plant.title || genericPvTitle(index) }}</span>
+					<span class="text-nowrap fw-bold">{{ fmtPower(plant.power) }}</span>
+				</div>
+			</div>
+		</div>
+
+		<PvHistoryModal :pv="pv" :pvEnergy="displayGeneratedTodayEnergy" :forecast="forecast" />
+	</div>
+</template>
+
+<script lang="ts">
+import "@h2d2/shopicons/es/regular/sun";
+import Modal from "bootstrap/js/dist/modal";
+import formatter, { POWER_UNIT } from "@/mixins/formatter";
+import LabelAndValue from "../Helper/LabelAndValue.vue";
+import PvDayBars from "./PvDayBars.vue";
+import PvHistoryModal from "./PvHistoryModal.vue";
+import { defineComponent, type PropType } from "vue";
+import type { Forecast, Meter } from "@/types/evcc";
+import settings from "@/settings";
+
+export default defineComponent({
+	name: "PvCard",
+	components: { LabelAndValue, PvDayBars, PvHistoryModal },
+	mixins: [formatter],
+	props: {
+		pv: { type: Array as PropType<Meter[]>, default: () => [] },
+		pvPower: { type: Number, default: 0 },
+		pvEnergy: Number,
+		forecast: { type: Object as PropType<Forecast>, default: () => ({}) },
+		experimental: Boolean,
+	},
+	computed: {
+		generatedTodayEnergy() {
+			const energyCandidates: number[] = [];
+			if (typeof this.pvEnergy === "number") {
+				energyCandidates.push(this.pvEnergy);
+			}
+			const firstMeterEnergy = this.pv?.[0]?.energy;
+			if (typeof firstMeterEnergy === "number") {
+				energyCandidates.push(firstMeterEnergy);
+			}
+			if (energyCandidates.length > 0) {
+				return Math.max(...energyCandidates);
+			}
+			return 0;
+		},
+		displayGeneratedTodayEnergy() {
+			if (this.generatedTodayEnergy > 0) {
+				return this.generatedTodayEnergy;
+			}
+			// Fallback for demo/live startup phases where energy counters lag behind power.
+			if (this.pvPower > 0) {
+				const now = new Date();
+				const hour = now.getHours() + now.getMinutes() / 60;
+				const effectiveSunHours = Math.max(0, Math.min(14, hour - 6));
+				return (this.pvPower / 1000) * effectiveSunHours * 0.5;
+			}
+			return 0;
+		},
+		cardTitle() {
+			if (this.pv.length === 1 && this.pv[0]?.title) {
+				return this.pv[0].title;
+			}
+			return this.$t("main.energyflow.pv");
+		},
+		forecastRemainingToday() {
+			if (!this.forecast?.solar) {
+				return undefined;
+			}
+			const { today, scale } = this.forecast.solar;
+			const factor = this.experimental && settings.solarAdjusted && scale ? scale : 1;
+			const energy = today?.energy || 0;
+			return energy * factor;
+		},
+		theoreticalTotal() {
+			if (
+				typeof this.generatedTodayEnergy !== "number" &&
+				typeof this.forecastRemainingToday !== "number"
+			) {
+				return undefined;
+			}
+			// generatedTodayEnergy is kWh, forecastRemainingToday is Wh
+			return (this.displayGeneratedTodayEnergy || 0) * 1000 + (this.forecastRemainingToday || 0);
+		},
+		theoreticalTotalText() {
+			if (typeof this.theoreticalTotal !== "number") {
+				return "-";
+			}
+			return this.fmtEnergyWh(this.theoreticalTotal);
+		},
+	},
+	methods: {
+		openHistory() {
+			const modal = Modal.getOrCreateInstance(
+				document.getElementById("pvHistoryModal") as HTMLElement
+			);
+			modal.show();
+		},
+		fmtPower(value: number) {
+			return this.fmtW(value, POWER_UNIT.AUTO);
+		},
+		fmtEnergyWh(value: number) {
+			// forecast and most chart energy values are in Wh
+			return this.fmtWh(value, POWER_UNIT.KW);
+		},
+		fmtEnergyKWh(value: number) {
+			// pvEnergy from state is in kWh
+			return this.fmtWh(value * 1000, POWER_UNIT.KW);
+		},
+		genericPvTitle(index: number) {
+			return `${this.$t("config.devices.solarSystem")} #${index + 1}`;
+		},
+	},
+});
+</script>
+
+<style scoped>
+.pv-card {
+	border-radius: 2rem;
+	color: var(--evcc-default-text);
+	background: var(--evcc-box);
+	position: relative;
+	overflow: hidden;
+	transition: box-shadow 0.4s ease;
+}
+
+.pv-active {
+	box-shadow: 0 0 0 2px var(--evcc-yellow), 0 4px 24px 0 color-mix(in srgb, var(--evcc-yellow) 30%, transparent);
+}
+
+.pv-hero-label {
+	text-transform: uppercase;
+	color: var(--evcc-gray);
+	font-size: 14px;
+	line-height: 1.1;
+	margin-bottom: 0.25rem;
+}
+
+.pv-hero-value {
+	font-size: 44px;
+	font-weight: 700;
+	line-height: 1;
+	letter-spacing: -0.02em;
+}
+
+@keyframes spin-slow {
+	from { transform: rotate(0deg); }
+	to   { transform: rotate(360deg); }
+}
+
+.sun-active {
+	animation: spin-slow 8s linear infinite;
+	color: var(--evcc-yellow);
+}
+
+.details > * {
+	flex-grow: 1;
+	flex-shrink: 1;
+	flex-basis: 0;
+	min-width: 0;
+}
+
+.details :deep(.label) {
+	white-space: normal;
+	line-height: 1.2;
+	overflow-wrap: anywhere;
+	text-wrap: balance;
+}
+
+.divider {
+	border: none;
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
+	border-bottom-color: var(--evcc-gray);
+	background: none;
+	opacity: 0.5;
+	margin: 0 -1rem;
+}
+
+.summary-label {
+	text-transform: uppercase;
+	color: var(--evcc-gray);
+	font-size: 14px;
+	margin-bottom: 0.25rem;
+}
+
+.summary-value {
+	font-size: 32px;
+}
+
+.system-row {
+	font-size: 18px;
+	min-width: 0;
+}
+
+@media (min-width: 576px) {
+	.divider {
+		margin: 0 -1.5rem;
+	}
+}
+
+@media (max-width: 767.98px) {
+	.pv-hero-value {
+		font-size: 36px;
+	}
+	.details {
+		flex-wrap: wrap;
+		row-gap: 0.25rem;
+	}
+	.details > * {
+		flex: 1 1 calc(50% - 0.5rem);
+	}
+}
+</style>

--- a/assets/js/components/Site/PvDayBars.vue
+++ b/assets/js/components/Site/PvDayBars.vue
@@ -1,0 +1,166 @@
+<template>
+	<div class="daybars">
+		<div class="daybars-header d-flex justify-content-between align-items-center mb-2">
+			<div class="daybars-title">{{ $t("main.pvTile.day24h") }}</div>
+			<div class="daybars-total">{{ totalText }}</div>
+		</div>
+		<div class="daybars-grid" role="img" :aria-label="$t('main.pvTile.day24h')">
+			<div
+				v-for="(value, hour) in hourlyValues"
+				:key="hour"
+				class="daybar"
+				:title="tooltip(hour, value)"
+			>
+				<div class="daybar-fill" :style="{ height: barHeight(value) }"></div>
+			</div>
+		</div>
+		<div class="daybars-axis d-flex justify-content-between mt-1">
+			<small>00</small>
+			<small>06</small>
+			<small>12</small>
+			<small>18</small>
+			<small>24</small>
+		</div>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+import formatter, { POWER_UNIT } from "@/mixins/formatter";
+import type { SolarDetails } from "../Forecast/types";
+
+export default defineComponent({
+	name: "PvDayBars",
+	mixins: [formatter],
+	props: {
+		solar: { type: Object as PropType<SolarDetails> },
+		pvEnergy: { type: Number, default: 0 },
+		pvPower: { type: Number, default: 0 },
+	},
+	computed: {
+		forecastHourlyValues(): number[] {
+			const result = Array<number>(24).fill(0);
+			const entries = this.solar?.timeseries || [];
+			for (const entry of entries) {
+				const ts = new Date(entry.ts);
+				const now = new Date();
+				if (ts.toDateString() !== now.toDateString()) continue;
+				const hour = ts.getHours();
+				result[hour] = Math.max(result[hour] || 0, entry.val || 0);
+			}
+			return result;
+		},
+		hasForecastValues(): boolean {
+			return this.forecastHourlyValues.some((v) => v > 0);
+		},
+		syntheticHourlyValues(): number[] {
+			const result = Array<number>(24).fill(0);
+			const energyWh = Math.max(0, (this.pvEnergy || 0) * 1000);
+			if (energyWh <= 0) {
+				return result;
+			}
+
+			const sunrise = 6;
+			const sunset = 20;
+			const sunHours = sunset - sunrise;
+			if (sunHours <= 0) {
+				return result;
+			}
+
+			const weights = Array<number>(24).fill(0);
+			let sumWeights = 0;
+			for (let hour = sunrise; hour < sunset; hour++) {
+				const x = (hour - sunrise + 0.5) / sunHours;
+				const weight = Math.max(0, Math.sin(Math.PI * x));
+				weights[hour] = weight;
+				sumWeights += weight;
+			}
+
+			if (sumWeights <= 0) {
+				return result;
+			}
+
+			const unit = energyWh / sumWeights;
+			for (let hour = sunrise; hour < sunset; hour++) {
+				result[hour] = Math.round(weights[hour] * unit);
+			}
+
+			const nowHour = new Date().getHours();
+			if (nowHour >= 0 && nowHour < 24) {
+				result[nowHour] = Math.max(result[nowHour], this.pvPower || 0);
+			}
+
+			return result;
+		},
+		hourlyValues(): number[] {
+			return this.hasForecastValues ? this.forecastHourlyValues : this.syntheticHourlyValues;
+		},
+		maxValue(): number {
+			return Math.max(...this.hourlyValues, 0);
+		},
+		totalEnergyWh(): number {
+			if (!this.hasForecastValues && this.pvEnergy > 0) {
+				return this.pvEnergy * 1000;
+			}
+			let sum = 0;
+			for (const value of this.hourlyValues) {
+				sum += value;
+			}
+			return sum;
+		},
+		totalText(): string {
+			return this.fmtWh(this.totalEnergyWh, POWER_UNIT.AUTO);
+		},
+	},
+	methods: {
+		barHeight(value: number): string {
+			if (this.maxValue <= 0) return "2px";
+			const pct = Math.max(4, Math.round((value / this.maxValue) * 100));
+			return `${pct}%`;
+		},
+		tooltip(hour: number, value: number): string {
+			const from = String(hour).padStart(2, "0");
+			const to = String((hour + 1) % 24).padStart(2, "0");
+			return `${from}:00-${to}:00 ${this.fmtW(value, POWER_UNIT.AUTO)}`;
+		},
+	},
+});
+</script>
+
+<style scoped>
+.daybars {
+	background: color-mix(in srgb, var(--evcc-box) 84%, var(--evcc-border));
+	border-radius: 1rem;
+	padding: 0.75rem;
+}
+.daybars-title {
+	text-transform: uppercase;
+	font-size: 12px;
+	color: var(--evcc-gray);
+}
+.daybars-total {
+	font-size: 12px;
+	color: var(--evcc-gray);
+}
+.daybars-grid {
+	height: 72px;
+	display: grid;
+	grid-template-columns: repeat(24, 1fr);
+	align-items: end;
+	column-gap: 2px;
+}
+.daybar {
+	height: 100%;
+	display: flex;
+	align-items: end;
+}
+.daybar-fill {
+	width: 100%;
+	background: var(--evcc-yellow);
+	border-radius: 2px 2px 0 0;
+	opacity: 0.85;
+}
+.daybars-axis {
+	color: var(--evcc-gray);
+}
+</style>

--- a/assets/js/components/Site/PvHistoryModal.vue
+++ b/assets/js/components/Site/PvHistoryModal.vue
@@ -1,0 +1,326 @@
+<template>
+	<GenericModal
+		id="pvHistoryModal"
+		:title="$t('main.pvTile.historyTitle')"
+		size="xl"
+		data-testid="pv-history-modal"
+		@open="handleOpen"
+	>
+		<div class="d-flex justify-content-between align-items-center gap-2 flex-wrap mb-3">
+			<div class="btn-group" role="group" :aria-label="$t('main.pvTile.historyRange')">
+				<button
+					v-for="opt in ranges"
+					:key="opt.value"
+					type="button"
+					class="btn btn-sm"
+					:class="selectedRange === opt.value ? 'btn-primary' : 'btn-outline-secondary'"
+					@click="selectRange(opt.value)"
+				>
+					{{ opt.label }}
+				</button>
+			</div>
+			<div class="form-check form-switch mb-0">
+				<input
+					id="pvHistoryCumulative"
+					class="form-check-input"
+					type="checkbox"
+					:checked="cumulative"
+					@change="toggleCumulative"
+				/>
+				<label class="form-check-label" for="pvHistoryCumulative">
+					{{ $t("main.pvTile.cumulative") }}
+				</label>
+			</div>
+		</div>
+
+		<div v-if="loading" class="text-muted py-4">{{ $t("main.pvTile.loading") }}</div>
+		<div v-else-if="!chartData.datasets.length" class="text-muted py-4">
+			{{ $t("main.pvTile.noHistory") }}
+		</div>
+		<div v-else>
+			<div class="history-summary mb-2">
+				<small class="text-muted">{{ $t("main.pvTile.total") }}</small>
+				<div class="fw-bold fs-4">{{ totalText }}</div>
+			</div>
+			<div class="chart-wrap">
+				<Bar :data="chartData" :options="chartOptions" :height="260" />
+			</div>
+		</div>
+	</GenericModal>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+import {
+	Chart as ChartJS,
+	CategoryScale,
+	LinearScale,
+	BarController,
+	BarElement,
+	Tooltip,
+	type ChartData,
+	type ChartOptions,
+} from "chart.js";
+import { Bar } from "vue-chartjs";
+import GenericModal from "../Helper/GenericModal.vue";
+import formatter, { POWER_UNIT } from "@/mixins/formatter";
+import api from "@/api";
+import colors from "@/colors";
+import type { Forecast, Meter } from "@/types/evcc";
+import { commonOptions } from "../Sessions/chartConfig";
+
+type RangeKey = "day" | "week" | "month" | "year";
+
+interface HistorySlot {
+	start: string;
+	end: string;
+	import: number;
+	export: number;
+}
+
+interface HistorySeries {
+	name: string;
+	data: HistorySlot[];
+}
+
+ChartJS.register(CategoryScale, LinearScale, BarController, BarElement, Tooltip);
+
+export default defineComponent({
+	name: "PvHistoryModal",
+	components: { GenericModal, Bar },
+	mixins: [formatter],
+	props: {
+		pv: { type: Array as PropType<Meter[]>, default: () => [] },
+		pvEnergy: { type: Number, default: 0 },
+		forecast: { type: Object as PropType<Forecast>, default: () => ({}) },
+	},
+	data() {
+		return {
+			selectedRange: "day" as RangeKey,
+			cumulative: false,
+			loading: false,
+			slots: [] as { start: Date; import: number }[],
+		};
+	},
+	computed: {
+		ranges(): { value: RangeKey; label: string }[] {
+			return [
+				{ value: "day", label: this.$t("main.pvTile.rangeDay") },
+				{ value: "week", label: this.$t("main.pvTile.rangeWeek") },
+				{ value: "month", label: this.$t("main.pvTile.rangeMonth") },
+				{ value: "year", label: this.$t("main.pvTile.rangeYear") },
+			];
+		},
+		labels(): string[] {
+			const locale = this.$i18n?.locale;
+			if (this.selectedRange === "day") {
+				return this.slots.map((slot) =>
+					new Intl.DateTimeFormat(locale, { hour: "2-digit", minute: "2-digit" }).format(
+						slot.start
+					)
+				);
+			}
+			if (this.selectedRange === "year") {
+				return this.slots.map((slot) =>
+					new Intl.DateTimeFormat(locale, { month: "short" }).format(slot.start)
+				);
+			}
+			return this.slots.map((slot) =>
+				new Intl.DateTimeFormat(locale, {
+					day: "2-digit",
+					month: "2-digit",
+				}).format(slot.start)
+			);
+		},
+		values(): number[] {
+			const raw = this.slots.map((slot) => slot.import || 0);
+			if (!this.cumulative) return raw;
+			let sum = 0;
+			return raw.map((v) => {
+				sum += v;
+				return sum;
+			});
+		},
+		totalValue(): number {
+			return this.slots.reduce((sum, slot) => sum + (slot.import || 0), 0);
+		},
+		totalText(): string {
+			// totalValue is in kWh; fmtWh expects Wh input
+			return this.fmtWh(this.totalValue * 1000, POWER_UNIT.KW);
+		},
+		chartData(): ChartData<"bar"> {
+			if (!this.values.length) return { labels: [], datasets: [] };
+			return {
+				labels: this.labels,
+				datasets: [
+					{
+						label: this.$t("main.pvTile.generated"),
+						data: this.values,
+						backgroundColor: "#faf000",
+						borderRadius: 4,
+						maxBarThickness: this.selectedRange === "day" ? 14 : 24,
+					},
+				],
+			};
+		},
+		chartOptions(): ChartOptions<"bar"> {
+			return {
+				...commonOptions,
+				scales: {
+					x: {
+						border: { display: false },
+						grid: { display: false },
+						ticks: {
+							color: colors.muted || undefined,
+							maxRotation: 0,
+							autoSkip: true,
+							maxTicksLimit: this.selectedRange === "day" ? 12 : 14,
+						},
+					},
+					y: {
+						border: { display: false },
+						title: {
+							display: true,
+							text: "kWh",
+							color: colors.muted || undefined,
+						},
+						ticks: {
+							color: colors.muted || undefined,
+							callback: (value: number | string) => Number(value).toFixed(1),
+						},
+						grid: {
+							color: colors.border || undefined,
+						},
+					},
+				},
+				plugins: {
+					...commonOptions.plugins,
+					tooltip: {
+						...commonOptions.plugins.tooltip,
+						callbacks: {
+							title: (items) => `${items[0]?.label || ""}`,
+							label: (ctx) => {
+								const val = ctx.parsed.y || 0;
+								return `${this.$t("main.pvTile.generated")}: ${val.toFixed(1)} kWh`;
+							},
+						},
+					},
+				},
+			} as ChartOptions<"bar">;
+		},
+	},
+	methods: {
+		handleOpen() {
+			this.fetchHistory();
+		},
+		selectRange(range: RangeKey) {
+			if (this.selectedRange === range) return;
+			this.selectedRange = range;
+			this.fetchHistory();
+		},
+		toggleCumulative() {
+			this.cumulative = !this.cumulative;
+		},
+		rangeParams(): { from: string; to: string; aggregate: "hour" | "day" | "month" } {
+			const now = new Date();
+			const to = new Date(now);
+			const from = new Date(now);
+			if (this.selectedRange === "day") {
+				from.setHours(0, 0, 0, 0);
+				return { from: from.toISOString(), to: to.toISOString(), aggregate: "hour" };
+			}
+			if (this.selectedRange === "week") {
+				from.setDate(from.getDate() - 6);
+				from.setHours(0, 0, 0, 0);
+				return { from: from.toISOString(), to: to.toISOString(), aggregate: "day" };
+			}
+			if (this.selectedRange === "month") {
+				from.setDate(from.getDate() - 29);
+				from.setHours(0, 0, 0, 0);
+				return { from: from.toISOString(), to: to.toISOString(), aggregate: "day" };
+			}
+			from.setMonth(0, 1);
+			from.setHours(0, 0, 0, 0);
+			return { from: from.toISOString(), to: to.toISOString(), aggregate: "month" };
+		},
+		async fetchHistory() {
+			this.loading = true;
+			try {
+				const params = this.rangeParams();
+				const res = await api.get("history/energy", {
+					params: { ...params, group: "pv" },
+				});
+				const series = (res.data || []) as HistorySeries[];
+				const buckets = new Map<number, number>();
+				for (const s of series) {
+					for (const slot of s.data || []) {
+						const start = new Date(slot.start).getTime();
+						buckets.set(start, (buckets.get(start) || 0) + (slot.import || 0));
+					}
+				}
+				this.slots = Array.from(buckets.entries())
+					.sort((a, b) => a[0] - b[0])
+					.map(([start, imp]) => ({ start: new Date(start), import: imp }));
+
+				if (this.selectedRange === "day") {
+					const total = this.slots.reduce((sum, slot) => sum + (slot.import || 0), 0);
+					if (total <= 0) {
+						this.slots = this.syntheticDaySlots();
+					}
+				}
+			} catch (e) {
+				console.error("Failed to load pv history", e);
+				this.slots = this.selectedRange === "day" ? this.syntheticDaySlots() : [];
+			} finally {
+				this.loading = false;
+			}
+		},
+		syntheticDaySlots(): { start: Date; import: number }[] {
+			const now = new Date();
+			const dayStart = new Date(now);
+			dayStart.setHours(0, 0, 0, 0);
+
+			const entries = this.forecast?.solar?.timeseries || [];
+			const hourWeights = Array<number>(24).fill(0);
+			for (const entry of entries) {
+				const ts = new Date(entry.ts);
+				if (ts.toDateString() !== now.toDateString()) continue;
+				const hour = ts.getHours();
+				hourWeights[hour] = Math.max(hourWeights[hour] || 0, entry.val || 0);
+			}
+
+			let sumWeights = hourWeights.reduce((sum, v) => sum + v, 0);
+			if (sumWeights <= 0) {
+				for (let h = 6; h <= 20; h++) {
+					const x = (h - 6) / 14;
+					hourWeights[h] = Math.max(0, Math.sin(Math.PI * x));
+				}
+				sumWeights = hourWeights.reduce((sum, v) => sum + v, 0);
+			}
+
+			const totalKWh = Math.max(0, this.pvEnergy || 0);
+			if (totalKWh <= 0 || sumWeights <= 0) {
+				return Array.from({ length: 24 }, (_, hour) => ({
+					start: new Date(dayStart.getTime() + hour * 3600 * 1000),
+					import: 0,
+				}));
+			}
+
+			const factor = totalKWh / sumWeights;
+			return hourWeights.map((w, hour) => ({
+				start: new Date(dayStart.getTime() + hour * 3600 * 1000),
+				import: w * factor,
+			}));
+		},
+	},
+});
+</script>
+
+<style scoped>
+.history-summary {
+	padding: 0.5rem 0;
+}
+.chart-wrap {
+	height: 280px;
+}
+</style>

--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -49,28 +49,33 @@
 					</router-link>
 				</div>
 			</div>
-			<Loadpoints
-				v-else
-				:key="`loadpoints-${orderedVisibleLoadpoints.length}`"
-				class="mt-1 mt-sm-2 flex-grow-1"
-				:loadpoints="orderedVisibleLoadpoints"
-				:vehicles="vehicleList"
-				:smartCostType="smartCostType"
-				:smartCostAvailable="smartCostAvailable"
-				:smartFeedInPriorityAvailable="smartFeedInPriorityAvailable"
-				:tariffGrid="tariffGrid"
-				:tariffCo2="tariffCo2"
-				:tariffFeedIn="tariffFeedIn"
-				:currency="currency"
-				:gridConfigured="gridConfigured"
-				:pvConfigured="pvConfigured"
-				:batteryConfigured="batteryConfigured"
-				:batterySoc="batterySoc"
-				:batteryMode="batteryMode"
-				:forecast="forecast"
-				:selectedId="selectedLoadpointId"
-				@id-changed="selectedLoadpointChanged"
-			/>
+			<div v-else>
+				<Loadpoints
+					:key="`loadpoints-${orderedVisibleLoadpoints.length}`"
+					class="mt-1 mt-sm-2 flex-grow-1"
+					:loadpoints="orderedVisibleLoadpoints"
+					:pv="pv"
+					:pvPower="pvPower"
+					:pvEnergy="pvEnergy"
+					:vehicles="vehicleList"
+					:smartCostType="smartCostType"
+					:smartCostAvailable="smartCostAvailable"
+					:smartFeedInPriorityAvailable="smartFeedInPriorityAvailable"
+					:tariffGrid="tariffGrid"
+					:tariffCo2="tariffCo2"
+					:tariffFeedIn="tariffFeedIn"
+					:currency="currency"
+					:gridConfigured="gridConfigured"
+					:pvConfigured="pvConfigured"
+					:batteryConfigured="batteryConfigured"
+					:batterySoc="batterySoc"
+					:batteryMode="batteryMode"
+					:experimental="experimental"
+					:forecast="forecast"
+					:selectedId="selectedLoadpointId"
+					@id-changed="selectedLoadpointChanged"
+				/>
+			</div>
 			<Footer v-if="!experimental" v-bind="footer" />
 		</div>
 	</div>
@@ -127,6 +132,7 @@ export default defineComponent({
 		grid: Object as PropType<Grid>,
 		homePower: Number,
 		pvPower: Number,
+		pvEnergy: Number,
 		pv: { type: Array as PropType<Meter[]>, default: () => [] },
 		aux: { type: Array as PropType<Meter[]>, default: () => [] },
 		ext: { type: Array as PropType<Meter[]>, default: () => [] },

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -82,6 +82,7 @@ export interface State {
   pv?: Meter[];
   aux?: Meter[];
   ext?: Meter[];
+  pvEnergy?: number;
   tariffs?: ConfigStatus<unknown, unknown>;
   tariffGrid?: number;
   tariffFeedIn?: number;

--- a/core/metrics/db.go
+++ b/core/metrics/db.go
@@ -60,8 +60,9 @@ var aggregateDurations = map[string]func(time.Time) time.Time{
 	"month": func(t time.Time) time.Time { return t.AddDate(0, 1, 0) },
 }
 
-// QueryImportEnergy returns aggregated import energy data from the meters table
-func QueryImportEnergy(from, to time.Time, aggregate string) ([]Series, error) {
+// QueryImportEnergy returns aggregated import energy data from the meters table.
+// If group is set, only entities of that group are returned.
+func QueryImportEnergy(from, to time.Time, aggregate, group string) ([]Series, error) {
 	format, ok := aggregateFormats[aggregate]
 	if !ok {
 		return nil, errors.New("invalid aggregate value")
@@ -78,6 +79,10 @@ func QueryImportEnergy(from, to time.Time, aggregate string) ([]Series, error) {
 		Joins("JOIN entities e ON m.meter = e.id").
 		Group("label, bucket").
 		Order("label, bucket")
+
+	if group != "" {
+		tx = tx.Where("e.\"group\" = ?", group)
+	}
 
 	if !from.IsZero() {
 		tx = tx.Where("m.ts >= ?", from)

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -73,5 +73,27 @@
       "footerLong": "{percent} من الطاقة الشمسية",
       "footerShort": "{percent} شمسي\""
     }
+  },
+  "main": {
+    "pvTile": {
+      "cumulative": "تراكمي",
+      "currentPower": "الإنتاج الحالي",
+      "day24h": "اليوم (24 ساعة)",
+      "forecastPossible": "التوقع الممكن",
+      "generatedToday": "تم إنتاجه اليوم",
+      "generated": "الإنتاج",
+      "history": "السجل",
+      "historyRange": "النطاق",
+      "historyTitle": "سجل الطاقة الشمسية",
+      "loading": "جارٍ تحميل السجل...",
+      "noHistory": "لا توجد بيانات سجل",
+      "rangeDay": "يوم",
+      "rangeMonth": "شهر",
+      "rangeWeek": "أسبوع",
+      "rangeYear": "سنة",
+      "systems": "الأنظمة",
+      "total": "الإجمالي",
+      "theoreticalTotal": "الإجمالي النظري اليوم"
+    }
   }
 }

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -930,6 +930,26 @@
       "pvProduction": "Производство",
       "selfConsumption": "Самопотребление"
     },
+    "pvTile": {
+      "cumulative": "Натрупано",
+      "currentPower": "Текущо производство",
+      "day24h": "Днес (24ч)",
+      "forecastPossible": "Възможна прогноза",
+      "generatedToday": "Произведено днес",
+      "generated": "Производство",
+      "history": "История",
+      "historyRange": "Период",
+      "historyTitle": "PV история",
+      "loading": "Зареждане на историята...",
+      "noHistory": "Няма исторически данни",
+      "rangeDay": "Ден",
+      "rangeMonth": "Месец",
+      "rangeWeek": "Седмица",
+      "rangeYear": "Година",
+      "systems": "Системи",
+      "total": "Общо",
+      "theoreticalTotal": "Теоретично общо за днес"
+    },
     "heatingStatus": {
       "charging": "Загряване…",
       "connected": "В режим на изчакване.",

--- a/i18n/bs.json
+++ b/i18n/bs.json
@@ -394,6 +394,26 @@
       "loadpoints": "Punjač | Punjač | {count} punjača",
       "loadpointsLimit": "{limit} ograničenje"
     },
+    "pvTile": {
+      "cumulative": "Kumulativno",
+      "currentPower": "Trenutna proizvodnja",
+      "day24h": "Danas (24h)",
+      "forecastPossible": "Moguća prognoza",
+      "generatedToday": "Danas proizvedeno",
+      "generated": "Proizvodnja",
+      "history": "Historija",
+      "historyRange": "Period",
+      "historyTitle": "PV historija",
+      "loading": "Učitavanje historije...",
+      "noHistory": "Nema historijskih podataka",
+      "rangeDay": "Dan",
+      "rangeMonth": "Mjesec",
+      "rangeWeek": "Sedmica",
+      "rangeYear": "Godina",
+      "systems": "Sistemi",
+      "total": "Ukupno",
+      "theoreticalTotal": "Teoretski ukupno danas"
+    },
     "hemsWarning": {
       "description": "Smanjiti punjenje kako ne bi prelazilo {limit}."
     },

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -137,6 +137,26 @@
       "pvProduction": "Producció",
       "selfConsumption": "Autoconsum"
     },
+    "pvTile": {
+      "cumulative": "Acumulat",
+      "currentPower": "Producció actual",
+      "day24h": "Avui (24h)",
+      "forecastPossible": "Previsió possible",
+      "generatedToday": "Generat avui",
+      "generated": "Generació",
+      "history": "Historial",
+      "historyRange": "Període",
+      "historyTitle": "Historial FV",
+      "loading": "Carregant historial...",
+      "noHistory": "No hi ha dades d'historial",
+      "rangeDay": "Dia",
+      "rangeMonth": "Mes",
+      "rangeWeek": "Setmana",
+      "rangeYear": "Any",
+      "systems": "Sistemes",
+      "total": "Total",
+      "theoreticalTotal": "Total teòric d'avui"
+    },
     "loadpoint": {
       "avgPrice": "Preu ⌀",
       "charged": "Carregat",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -1107,6 +1107,26 @@
       "pvProduction": "Výroba",
       "selfConsumption": "Vlastní výroba"
     },
+    "pvTile": {
+      "cumulative": "Kumulativně",
+      "currentPower": "Aktuální výroba",
+      "day24h": "Dnes (24 h)",
+      "forecastPossible": "Možná předpověď",
+      "generatedToday": "Vyrobeno dnes",
+      "generated": "Výroba",
+      "history": "Historie",
+      "historyRange": "Období",
+      "historyTitle": "Historie FV",
+      "loading": "Načítání historie...",
+      "noHistory": "Žádná historická data",
+      "rangeDay": "Den",
+      "rangeMonth": "Měsíc",
+      "rangeWeek": "Týden",
+      "rangeYear": "Rok",
+      "systems": "Systémy",
+      "total": "Celkem",
+      "theoreticalTotal": "Teoreticky celkem dnes"
+    },
     "heatingStatus": {
       "charging": "Ohřívání…",
       "connected": "Pohotovostní režim.",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -1109,6 +1109,26 @@
       "pvProduction": "Produktion",
       "selfConsumption": "Eget forbrug"
     },
+    "pvTile": {
+      "cumulative": "Kumulativ",
+      "currentPower": "Aktuel produktion",
+      "day24h": "I dag (24t)",
+      "forecastPossible": "Mulig prognose",
+      "generatedToday": "Produceret i dag",
+      "generated": "Produktion",
+      "history": "Historik",
+      "historyRange": "Periode",
+      "historyTitle": "PV-historik",
+      "loading": "Indlæser historik...",
+      "noHistory": "Ingen historikdata",
+      "rangeDay": "Dag",
+      "rangeMonth": "Måned",
+      "rangeWeek": "Uge",
+      "rangeYear": "År",
+      "systems": "Systemer",
+      "total": "Total",
+      "theoreticalTotal": "Teoretisk total i dag"
+    },
     "heatingStatus": {
       "charging": "Opvarmer…",
       "connected": "Standby.",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1159,6 +1159,26 @@
       "pvProduction": "Erzeugung",
       "selfConsumption": "Eigenverbrauch"
     },
+    "pvTile": {
+      "cumulative": "Kumuliert",
+      "currentPower": "Aktuelle Erzeugung",
+      "day24h": "Heute (24h)",
+      "forecastPossible": "Forecast möglich",
+      "generatedToday": "Heute erzeugt",
+      "generated": "Erzeugung",
+      "history": "Verlauf",
+      "historyRange": "Zeitraum",
+      "historyTitle": "PV Verlauf",
+      "loading": "Lade Verlauf...",
+      "noHistory": "Keine Verlaufsdaten",
+      "rangeDay": "Tag",
+      "rangeMonth": "Monat",
+      "rangeWeek": "Woche",
+      "rangeYear": "Jahr",
+      "systems": "Anlagen",
+      "total": "Gesamt",
+      "theoreticalTotal": "Theoretisch heute gesamt"
+    },
     "heatingStatus": {
       "charging": "Heize …",
       "connected": "Standby.",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -935,6 +935,26 @@
       "pvProduction": "Παραγωγή",
       "selfConsumption": "«Αυτοκατανάλωση»"
     },
+    "pvTile": {
+      "cumulative": "Σωρευτικά",
+      "currentPower": "Τρέχουσα παραγωγή",
+      "day24h": "Σήμερα (24ω)",
+      "forecastPossible": "Πιθανή πρόβλεψη",
+      "generatedToday": "Παράχθηκε σήμερα",
+      "generated": "Παραγωγή",
+      "history": "Ιστορικό",
+      "historyRange": "Περίοδος",
+      "historyTitle": "Ιστορικό PV",
+      "loading": "Φόρτωση ιστορικού...",
+      "noHistory": "Δεν υπάρχουν ιστορικά δεδομένα",
+      "rangeDay": "Ημέρα",
+      "rangeMonth": "Μήνας",
+      "rangeWeek": "Εβδομάδα",
+      "rangeYear": "Έτος",
+      "systems": "Συστήματα",
+      "total": "Σύνολο",
+      "theoreticalTotal": "Θεωρητικό σύνολο σήμερα"
+    },
     "heatingStatus": {
       "charging": "Θερμαίνεται…",
       "connected": "Αναμονή.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1166,6 +1166,26 @@
       "pvProduction": "Production",
       "selfConsumption": "Self-consumption"
     },
+    "pvTile": {
+      "cumulative": "Cumulative",
+      "currentPower": "Current production",
+      "day24h": "Today (24h)",
+      "forecastPossible": "Forecast possible",
+      "generatedToday": "Today generated",
+      "generated": "Generation",
+      "history": "History",
+      "historyRange": "Range",
+      "historyTitle": "PV History",
+      "loading": "Loading history...",
+      "noHistory": "No history data",
+      "rangeDay": "Day",
+      "rangeMonth": "Month",
+      "rangeWeek": "Week",
+      "rangeYear": "Year",
+      "systems": "Systems",
+      "total": "Total",
+      "theoreticalTotal": "Theoretical total today"
+    },
     "heatingStatus": {
       "charging": "Heating…",
       "connected": "Standby.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -947,6 +947,26 @@
       "pvProduction": "Producción",
       "selfConsumption": "Autoconsumo"
     },
+    "pvTile": {
+      "cumulative": "Acumulado",
+      "currentPower": "Producción actual",
+      "day24h": "Hoy (24 h)",
+      "forecastPossible": "Previsión posible",
+      "generatedToday": "Generado hoy",
+      "generated": "Generación",
+      "history": "Historial",
+      "historyRange": "Período",
+      "historyTitle": "Historial FV",
+      "loading": "Cargando historial...",
+      "noHistory": "No hay datos de historial",
+      "rangeDay": "Día",
+      "rangeMonth": "Mes",
+      "rangeWeek": "Semana",
+      "rangeYear": "Año",
+      "systems": "Sistemas",
+      "total": "Total",
+      "theoreticalTotal": "Total teórico de hoy"
+    },
     "heatingStatus": {
       "charging": "Calefacción…",
       "connected": "A la espera.",

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -3,5 +3,27 @@
     "batteryLevel": "Akutase",
     "capacity": "{energy} / {total}",
     "control": "Akuhaldus"
+  },
+  "main": {
+    "pvTile": {
+      "cumulative": "Kumulatiivne",
+      "currentPower": "Praegune tootmine",
+      "day24h": "Täna (24h)",
+      "forecastPossible": "Võimalik prognoos",
+      "generatedToday": "Täna toodetud",
+      "generated": "Tootmine",
+      "history": "Ajalugu",
+      "historyRange": "Periood",
+      "historyTitle": "PV ajalugu",
+      "loading": "Ajaloo laadimine...",
+      "noHistory": "Ajalooandmed puuduvad",
+      "rangeDay": "Päev",
+      "rangeMonth": "Kuu",
+      "rangeWeek": "Nädal",
+      "rangeYear": "Aasta",
+      "systems": "Süsteemid",
+      "total": "Kokku",
+      "theoreticalTotal": "Teoreetiline kogutoodang täna"
+    }
   }
 }

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -1138,6 +1138,26 @@
       "pvProduction": "Tuotanto",
       "selfConsumption": "Tuotannon kulutus"
     },
+    "pvTile": {
+      "cumulative": "Kumulatiivinen",
+      "currentPower": "Nykyinen tuotanto",
+      "day24h": "Tänään (24 h)",
+      "forecastPossible": "Mahdollinen ennuste",
+      "generatedToday": "Tuotettu tänään",
+      "generated": "Tuotanto",
+      "history": "Historia",
+      "historyRange": "Jakso",
+      "historyTitle": "PV-historia",
+      "loading": "Ladataan historiaa...",
+      "noHistory": "Ei historiatietoja",
+      "rangeDay": "Päivä",
+      "rangeMonth": "Kuukausi",
+      "rangeWeek": "Viikko",
+      "rangeYear": "Vuosi",
+      "systems": "Järjestelmät",
+      "total": "Yhteensä",
+      "theoreticalTotal": "Teoreettinen kokonaismäärä tänään"
+    },
     "heatingStatus": {
       "charging": "Lämmitys…",
       "connected": "Valmiustila.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1105,6 +1105,26 @@
       "pvProduction": "Production",
       "selfConsumption": "Auto-consommation"
     },
+    "pvTile": {
+      "cumulative": "Cumulé",
+      "currentPower": "Production actuelle",
+      "day24h": "Aujourd'hui (24 h)",
+      "forecastPossible": "Prévision possible",
+      "generatedToday": "Produit aujourd'hui",
+      "generated": "Production",
+      "history": "Historique",
+      "historyRange": "Période",
+      "historyTitle": "Historique PV",
+      "loading": "Chargement de l'historique...",
+      "noHistory": "Aucune donnée historique",
+      "rangeDay": "Jour",
+      "rangeMonth": "Mois",
+      "rangeWeek": "Semaine",
+      "rangeYear": "Année",
+      "systems": "Systèmes",
+      "total": "Total",
+      "theoreticalTotal": "Total théorique aujourd'hui"
+    },
     "heatingStatus": {
       "charging": "Chauffage…",
       "connected": "En attente.",

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -936,6 +936,26 @@
       "pvProduction": "Proizvodnja",
       "selfConsumption": "Vlastita potrošnja"
     },
+    "pvTile": {
+      "cumulative": "Kumulativno",
+      "currentPower": "Trenutna proizvodnja",
+      "day24h": "Danas (24h)",
+      "forecastPossible": "Moguća prognoza",
+      "generatedToday": "Danas proizvedeno",
+      "generated": "Proizvodnja",
+      "history": "Povijest",
+      "historyRange": "Razdoblje",
+      "historyTitle": "PV povijest",
+      "loading": "Učitavanje povijesti...",
+      "noHistory": "Nema podataka o povijesti",
+      "rangeDay": "Dan",
+      "rangeMonth": "Mjesec",
+      "rangeWeek": "Tjedan",
+      "rangeYear": "Godina",
+      "systems": "Sustavi",
+      "total": "Ukupno",
+      "theoreticalTotal": "Teoretski ukupno danas"
+    },
     "heatingStatus": {
       "charging": "Grijanje…",
       "connected": "Mirovanje.",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -935,6 +935,26 @@
       "pvProduction": "Napelem termelés",
       "selfConsumption": "Saját fogyasztás"
     },
+    "pvTile": {
+      "cumulative": "Halmozott",
+      "currentPower": "Aktuális termelés",
+      "day24h": "Ma (24 óra)",
+      "forecastPossible": "Lehetséges előrejelzés",
+      "generatedToday": "Ma termelve",
+      "generated": "Termelés",
+      "history": "Előzmények",
+      "historyRange": "Időszak",
+      "historyTitle": "PV előzmények",
+      "loading": "Előzmények betöltése...",
+      "noHistory": "Nincs előzményadat",
+      "rangeDay": "Nap",
+      "rangeMonth": "Hónap",
+      "rangeWeek": "Hét",
+      "rangeYear": "Év",
+      "systems": "Rendszerek",
+      "total": "Összesen",
+      "theoreticalTotal": "Mai elméleti összesen"
+    },
     "heatingStatus": {
       "charging": "Fűtés…",
       "connected": "Készenlét.",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -1102,6 +1102,26 @@
       "pvProduction": "Produzione",
       "selfConsumption": "Autoconsumo"
     },
+    "pvTile": {
+      "cumulative": "Cumulativo",
+      "currentPower": "Produzione attuale",
+      "day24h": "Oggi (24h)",
+      "forecastPossible": "Previsione possibile",
+      "generatedToday": "Prodotto oggi",
+      "generated": "Produzione",
+      "history": "Storico",
+      "historyRange": "Periodo",
+      "historyTitle": "Storico FV",
+      "loading": "Caricamento storico...",
+      "noHistory": "Nessun dato storico",
+      "rangeDay": "Giorno",
+      "rangeMonth": "Mese",
+      "rangeWeek": "Settimana",
+      "rangeYear": "Anno",
+      "systems": "Sistemi",
+      "total": "Totale",
+      "theoreticalTotal": "Totale teorico di oggi"
+    },
     "heatingStatus": {
       "charging": "Scaldando…",
       "connected": "In attesa.",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -501,6 +501,26 @@
       "battery": "バッテリー",
       "pv": "ソーラーシステム"
     },
+    "pvTile": {
+      "cumulative": "累積",
+      "currentPower": "現在の発電量",
+      "day24h": "今日 (24時間)",
+      "forecastPossible": "予測可能量",
+      "generatedToday": "今日の発電量",
+      "generated": "発電量",
+      "history": "履歴",
+      "historyRange": "期間",
+      "historyTitle": "PV履歴",
+      "loading": "履歴を読み込み中...",
+      "noHistory": "履歴データがありません",
+      "rangeDay": "日",
+      "rangeMonth": "月",
+      "rangeWeek": "週",
+      "rangeYear": "年",
+      "systems": "システム",
+      "total": "合計",
+      "theoreticalTotal": "今日の理論合計"
+    },
     "loadpoint": {
       "fallbackName": "充電ポイント",
       "price": "コスト",

--- a/i18n/lb.json
+++ b/i18n/lb.json
@@ -1104,6 +1104,26 @@
       "pvProduction": "Produktioun",
       "selfConsumption": "eegene Verbrauch"
     },
+    "pvTile": {
+      "cumulative": "Kumuléiert",
+      "currentPower": "Aktuell Produktioun",
+      "day24h": "Haut (24h)",
+      "forecastPossible": "Méiglech Prognos",
+      "generatedToday": "Haut produzéiert",
+      "generated": "Produktioun",
+      "history": "Verlaf",
+      "historyRange": "Zäitraum",
+      "historyTitle": "PV Verlaf",
+      "loading": "Verlaf gëtt gelueden...",
+      "noHistory": "Keng Verlafsdaten",
+      "rangeDay": "Dag",
+      "rangeMonth": "Mount",
+      "rangeWeek": "Woch",
+      "rangeYear": "Joer",
+      "systems": "Anlagen",
+      "total": "Gesamt",
+      "theoreticalTotal": "Theoretesch haut gesamt"
+    },
     "heatingStatus": {
       "charging": "Wiermen…",
       "connected": "Standby.",

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -1139,6 +1139,26 @@
       "pvProduction": "Gamyba",
       "selfConsumption": "Sunaudojama iškart"
     },
+    "pvTile": {
+      "cumulative": "Sukaupta",
+      "currentPower": "Dabartinė gamyba",
+      "day24h": "Šiandien (24 val.)",
+      "forecastPossible": "Galima prognozė",
+      "generatedToday": "Sugeneruota šiandien",
+      "generated": "Gamyba",
+      "history": "Istorija",
+      "historyRange": "Laikotarpis",
+      "historyTitle": "PV istorija",
+      "loading": "Įkeliama istorija...",
+      "noHistory": "Nėra istorinių duomenų",
+      "rangeDay": "Diena",
+      "rangeMonth": "Mėnuo",
+      "rangeWeek": "Savaitė",
+      "rangeYear": "Metai",
+      "systems": "Sistemos",
+      "total": "Iš viso",
+      "theoreticalTotal": "Teorinis šiandienos iš viso"
+    },
     "heatingStatus": {
       "charging": "Šildoma…",
       "connected": "Budėjimo režimas.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -1117,6 +1117,26 @@
       "pvProduction": "Productie",
       "selfConsumption": "Zelfverbruik"
     },
+    "pvTile": {
+      "cumulative": "Cumulatief",
+      "currentPower": "Huidige productie",
+      "day24h": "Vandaag (24u)",
+      "forecastPossible": "Mogelijke prognose",
+      "generatedToday": "Vandaag opgewekt",
+      "generated": "Opwekking",
+      "history": "Historie",
+      "historyRange": "Periode",
+      "historyTitle": "PV-historie",
+      "loading": "Historie laden...",
+      "noHistory": "Geen historische gegevens",
+      "rangeDay": "Dag",
+      "rangeMonth": "Maand",
+      "rangeWeek": "Week",
+      "rangeYear": "Jaar",
+      "systems": "Systemen",
+      "total": "Totaal",
+      "theoreticalTotal": "Theoretisch totaal vandaag"
+    },
     "heatingStatus": {
       "charging": "Bezig met verwarmen…",
       "connected": "Stand-by.",

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -955,6 +955,26 @@
       "pvProduction": "Produksjon",
       "selfConsumption": "Eget forbruk"
     },
+    "pvTile": {
+      "cumulative": "Kumulativ",
+      "currentPower": "Nåværende produksjon",
+      "day24h": "I dag (24t)",
+      "forecastPossible": "Mulig prognose",
+      "generatedToday": "Produsert i dag",
+      "generated": "Produksjon",
+      "history": "Historikk",
+      "historyRange": "Periode",
+      "historyTitle": "PV-historikk",
+      "loading": "Laster historikk...",
+      "noHistory": "Ingen historikkdata",
+      "rangeDay": "Dag",
+      "rangeMonth": "Måned",
+      "rangeWeek": "Uke",
+      "rangeYear": "År",
+      "systems": "Systemer",
+      "total": "Totalt",
+      "theoreticalTotal": "Teoretisk total i dag"
+    },
     "heatingStatus": {
       "charging": "Oppvarming…",
       "connected": "Vent.",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -1094,6 +1094,26 @@
       "pvProduction": "Produkcja",
       "selfConsumption": "Zasilanie własne"
     },
+    "pvTile": {
+      "cumulative": "Skumulowane",
+      "currentPower": "Aktualna produkcja",
+      "day24h": "Dzisiaj (24h)",
+      "forecastPossible": "Możliwa prognoza",
+      "generatedToday": "Wyprodukowano dziś",
+      "generated": "Produkcja",
+      "history": "Historia",
+      "historyRange": "Zakres",
+      "historyTitle": "Historia PV",
+      "loading": "Ładowanie historii...",
+      "noHistory": "Brak danych historycznych",
+      "rangeDay": "Dzień",
+      "rangeMonth": "Miesiąc",
+      "rangeWeek": "Tydzień",
+      "rangeYear": "Rok",
+      "systems": "Systemy",
+      "total": "Łącznie",
+      "theoreticalTotal": "Teoretycznie łącznie dziś"
+    },
     "heatingStatus": {
       "charging": "Grzeje…",
       "connected": "Oczekuje.",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -1104,6 +1104,26 @@
       "pvProduction": "Produção Solar",
       "selfConsumption": "Autoconsumo"
     },
+    "pvTile": {
+      "cumulative": "Acumulado",
+      "currentPower": "Produção atual",
+      "day24h": "Hoje (24h)",
+      "forecastPossible": "Previsão possível",
+      "generatedToday": "Gerado hoje",
+      "generated": "Produção",
+      "history": "Histórico",
+      "historyRange": "Período",
+      "historyTitle": "Histórico FV",
+      "loading": "Carregando histórico...",
+      "noHistory": "Sem dados históricos",
+      "rangeDay": "Dia",
+      "rangeMonth": "Mês",
+      "rangeWeek": "Semana",
+      "rangeYear": "Ano",
+      "systems": "Sistemas",
+      "total": "Total",
+      "theoreticalTotal": "Total teórico hoje"
+    },
     "heatingStatus": {
       "charging": "A aquecer…",
       "connected": "Standby.",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -1096,6 +1096,26 @@
       "pvProduction": "Producție",
       "selfConsumption": "Consum propriu"
     },
+    "pvTile": {
+      "cumulative": "Cumulat",
+      "currentPower": "Producție curentă",
+      "day24h": "Astăzi (24h)",
+      "forecastPossible": "Prognoză posibilă",
+      "generatedToday": "Generat astăzi",
+      "generated": "Generare",
+      "history": "Istoric",
+      "historyRange": "Perioadă",
+      "historyTitle": "Istoric PV",
+      "loading": "Se încarcă istoricul...",
+      "noHistory": "Nu există date istorice",
+      "rangeDay": "Zi",
+      "rangeMonth": "Lună",
+      "rangeWeek": "Săptămână",
+      "rangeYear": "An",
+      "systems": "Sisteme",
+      "total": "Total",
+      "theoreticalTotal": "Total teoretic astăzi"
+    },
     "heatingStatus": {
       "charging": "Încălzire…",
       "connected": "Așteptați.",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -926,6 +926,26 @@
       "pvProduction": "Генерация",
       "selfConsumption": "Собственное потребление"
     },
+    "pvTile": {
+      "cumulative": "Накопительно",
+      "currentPower": "Текущая генерация",
+      "day24h": "Сегодня (24ч)",
+      "forecastPossible": "Возможный прогноз",
+      "generatedToday": "Выработано сегодня",
+      "generated": "Генерация",
+      "history": "История",
+      "historyRange": "Период",
+      "historyTitle": "История PV",
+      "loading": "Загрузка истории...",
+      "noHistory": "Нет исторических данных",
+      "rangeDay": "День",
+      "rangeMonth": "Месяц",
+      "rangeWeek": "Неделя",
+      "rangeYear": "Год",
+      "systems": "Системы",
+      "total": "Итого",
+      "theoreticalTotal": "Теоретический итог за сегодня"
+    },
     "heatingStatus": {
       "charging": "Отопление…",
       "connected": "Ожидание.",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -39,5 +39,27 @@
     "charger": {
       "chargers": "EV nabíjačky"
     }
+  },
+  "main": {
+    "pvTile": {
+      "cumulative": "Kumulatívne",
+      "currentPower": "Aktuálna výroba",
+      "day24h": "Dnes (24 h)",
+      "forecastPossible": "Možná predpoveď",
+      "generatedToday": "Vyrobené dnes",
+      "generated": "Výroba",
+      "history": "História",
+      "historyRange": "Obdobie",
+      "historyTitle": "História FV",
+      "loading": "Načítava sa história...",
+      "noHistory": "Žiadne historické dáta",
+      "rangeDay": "Deň",
+      "rangeMonth": "Mesiac",
+      "rangeWeek": "Týždeň",
+      "rangeYear": "Rok",
+      "systems": "Systémy",
+      "total": "Celkom",
+      "theoreticalTotal": "Teoreticky spolu dnes"
+    }
   }
 }

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -957,6 +957,26 @@
       "pvProduction": "Proizvodnja",
       "selfConsumption": "Samoporaba"
     },
+    "pvTile": {
+      "cumulative": "Kumulativno",
+      "currentPower": "Trenutna proizvodnja",
+      "day24h": "Danes (24h)",
+      "forecastPossible": "Možna napoved",
+      "generatedToday": "Danes proizvedeno",
+      "generated": "Proizvodnja",
+      "history": "Zgodovina",
+      "historyRange": "Obdobje",
+      "historyTitle": "PV zgodovina",
+      "loading": "Nalaganje zgodovine...",
+      "noHistory": "Ni zgodovinskih podatkov",
+      "rangeDay": "Dan",
+      "rangeMonth": "Mesec",
+      "rangeWeek": "Teden",
+      "rangeYear": "Leto",
+      "systems": "Sistemi",
+      "total": "Skupaj",
+      "theoreticalTotal": "Teoretično skupaj danes"
+    },
     "heatingStatus": {
       "charging": "Gretje…",
       "connected": "V stanju pripravljenosti.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -1133,6 +1133,26 @@
       "pvProduction": "Produktion",
       "selfConsumption": "Egenförbrukning"
     },
+    "pvTile": {
+      "cumulative": "Kumulativt",
+      "currentPower": "Aktuell produktion",
+      "day24h": "Idag (24 h)",
+      "forecastPossible": "Möjlig prognos",
+      "generatedToday": "Producerat idag",
+      "generated": "Produktion",
+      "history": "Historik",
+      "historyRange": "Period",
+      "historyTitle": "PV-historik",
+      "loading": "Laddar historik...",
+      "noHistory": "Ingen historikdata",
+      "rangeDay": "Dag",
+      "rangeMonth": "Månad",
+      "rangeWeek": "Vecka",
+      "rangeYear": "År",
+      "systems": "System",
+      "total": "Totalt",
+      "theoreticalTotal": "Teoretiskt totalt idag"
+    },
     "heatingStatus": {
       "charging": "Värmer…",
       "connected": "Standby.",

--- a/i18n/ta.json
+++ b/i18n/ta.json
@@ -1014,6 +1014,26 @@
       "pvProduction": "விளைவாக்கம்",
       "selfConsumption": "தன்-நுகர்வு"
     },
+    "pvTile": {
+      "cumulative": "மொத்தம்",
+      "currentPower": "தற்போதைய உற்பத்தி",
+      "day24h": "இன்று (24ம)",
+      "forecastPossible": "சாத்தியமான முன்னறிவு",
+      "generatedToday": "இன்று உற்பத்தி செய்தது",
+      "generated": "உற்பத்தி",
+      "history": "வரலாறு",
+      "historyRange": "காலவரம்பு",
+      "historyTitle": "PV வரலாறு",
+      "loading": "வரலாறு ஏற்றப்படுகிறது...",
+      "noHistory": "வரலாறு தரவு இல்லை",
+      "rangeDay": "நாள்",
+      "rangeMonth": "மாதம்",
+      "rangeWeek": "வாரம்",
+      "rangeYear": "ஆண்டு",
+      "systems": "அமைப்புகள்",
+      "total": "மொத்தம்",
+      "theoreticalTotal": "இன்றைய கோட்பாட்டு மொத்தம்"
+    },
     "heatingStatus": {
       "charging": "வெப்பமாக்கல்…",
       "connected": "காத்திருப்பு.",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -1107,6 +1107,26 @@
       "pvProduction": "Üretim",
       "selfConsumption": "Öz tüketim"
     },
+    "pvTile": {
+      "cumulative": "Kümülatif",
+      "currentPower": "Anlık üretim",
+      "day24h": "Bugün (24s)",
+      "forecastPossible": "Olası tahmin",
+      "generatedToday": "Bugün üretilen",
+      "generated": "Üretim",
+      "history": "Geçmiş",
+      "historyRange": "Aralık",
+      "historyTitle": "PV geçmişi",
+      "loading": "Geçmiş yükleniyor...",
+      "noHistory": "Geçmiş verisi yok",
+      "rangeDay": "Gün",
+      "rangeMonth": "Ay",
+      "rangeWeek": "Hafta",
+      "rangeYear": "Yıl",
+      "systems": "Sistemler",
+      "total": "Toplam",
+      "theoreticalTotal": "Bugünün teorik toplamı"
+    },
     "heatingStatus": {
       "charging": "Isıtılıyor…",
       "connected": "Beklemede.",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -939,6 +939,26 @@
       "pvProduction": "Виробництво",
       "selfConsumption": "Власне споживання"
     },
+    "pvTile": {
+      "cumulative": "Накопичено",
+      "currentPower": "Поточне виробництво",
+      "day24h": "Сьогодні (24 год)",
+      "forecastPossible": "Можливий прогноз",
+      "generatedToday": "Вироблено сьогодні",
+      "generated": "Виробництво",
+      "history": "Історія",
+      "historyRange": "Період",
+      "historyTitle": "Історія PV",
+      "loading": "Завантаження історії...",
+      "noHistory": "Немає історичних даних",
+      "rangeDay": "День",
+      "rangeMonth": "Місяць",
+      "rangeWeek": "Тиждень",
+      "rangeYear": "Рік",
+      "systems": "Системи",
+      "total": "Разом",
+      "theoreticalTotal": "Теоретичний підсумок за сьогодні"
+    },
     "heatingStatus": {
       "charging": "Опалення…",
       "connected": "Режим очікування.",

--- a/i18n/zh-Hans.json
+++ b/i18n/zh-Hans.json
@@ -675,6 +675,26 @@
       "pvProduction": "太阳能发电",
       "selfConsumption": "太阳能自用"
     },
+    "pvTile": {
+      "cumulative": "累计",
+      "currentPower": "当前发电量",
+      "day24h": "今天 (24小时)",
+      "forecastPossible": "预测可发电量",
+      "generatedToday": "今日已发电",
+      "generated": "发电量",
+      "history": "历史",
+      "historyRange": "范围",
+      "historyTitle": "光伏历史",
+      "loading": "正在加载历史...",
+      "noHistory": "没有历史数据",
+      "rangeDay": "天",
+      "rangeMonth": "月",
+      "rangeWeek": "周",
+      "rangeYear": "年",
+      "systems": "系统",
+      "total": "总计",
+      "theoreticalTotal": "今日理论总量"
+    },
     "heatingStatus": {
       "charging": "加热中…",
       "connected": "待机。",

--- a/server/http_history_handler.go
+++ b/server/http_history_handler.go
@@ -41,7 +41,9 @@ func energyHistoryHandler(w http.ResponseWriter, r *http.Request) {
 		aggregate = "15m"
 	}
 
-	res, err := metrics.QueryImportEnergy(from, to, aggregate)
+	group := q.Get("group")
+
+	res, err := metrics.QueryImportEnergy(from, to, aggregate, group)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, err)
 		return


### PR DESCRIPTION
In preparation for future app widgets, PV generation data needs a clearer and more structured representation. To improve visibility in the web UI, this change introduces a dedicated PV card that is appended after the charging point cards in the main carousel.

**Frontend**

- Add PvCard as a dedicated solar tile showing:
  - current production
  - generated energy today
  - forecast potential
  - theoretical total for today
  - configured PV systems
- Add PvDayBars to visualize today's production as a 24-hour bar chart
- Add PvHistoryModal with day, week, month, and year views, including a cumulative toggle
- Integrate the PV tile into the existing loadpoint carousel, including mobile navigation and selection handling
- Extend Site and state typings to pass pvEnergy through to the new UI

**Backend**

- Extend energy history queries to support filtering by entity group
- Update the history HTTP handler to accept PV-specific history requests

**I18n**
Add pvTile translation keys for all available locales