### PR TITLE
Add Afore Hybrid Inverter

### DIFF
--- a/templates/definition/meter/afore-hybrid.yaml
+++ b/templates/definition/meter/afore-hybrid.yaml
@@ -1,0 +1,52 @@
+template: afore-hybrid
+products:
+  - brand: Afore
+    description:
+      generic: Hybrid Inverter (Battery)
+requirements:
+  description:
+    en: |
+      Requires direct Modbus TCP access via an RS485-to-TCP gateway
+      (e.g. Waveshare, USR-TCP232, Elfin-EW11). Solarman logger sticks
+      in their default mode are NOT supported.
+      The inverter's RS485 port must be switched to "Modbus" protocol
+      in the inverter menu.
+    de: |
+      Benötigt direkten Modbus-TCP-Zugriff über ein RS485-zu-TCP-Gateway
+      (z.B. Waveshare, USR-TCP232, Elfin-EW11). Solarman-Logger-Sticks
+      im Standardmodus werden NICHT unterstützt.
+      Der RS485-Port des Wechselrichters muss im Wechselrichtermenü auf
+      das "Modbus"-Protokoll umgestellt werden.
+params:
+  - name: usage
+    choice: ["battery"]
+  - name: modbus
+    choice: ["tcpip"]
+    port: 502
+    id: 1
+  - preset: battery-params
+render: |
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 2007 # Battery total power (S32, W, positive = discharging)
+      type: input
+      decode: int32
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 2002 # Battery SoC (U16, %)
+      type: input
+      decode: uint16
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 2013 # Battery total discharge (U32, 0.1 kWh)
+      type: input
+      decode: uint32
+    scale: 0.1
+  {{- include "battery-params" . }}

--- a/templates/definition/meter/afore-hybrid.yaml
+++ b/templates/definition/meter/afore-hybrid.yaml
@@ -2,19 +2,13 @@ template: afore-hybrid
 products:
   - brand: Afore
     description:
-      generic: Hybrid Inverter (Battery)
+      generic: Hybrid Inverter
 requirements:
   description:
     en: |
-      Requires direct Modbus TCP access via an RS485-to-TCP gateway
-      (e.g. Waveshare, USR-TCP232, Elfin-EW11). Solarman logger sticks
-      in their default mode are NOT supported.
       The inverter's RS485 port must be switched to "Modbus" protocol
       in the inverter menu.
     de: |
-      Benötigt direkten Modbus-TCP-Zugriff über ein RS485-zu-TCP-Gateway
-      (z.B. Waveshare, USR-TCP232, Elfin-EW11). Solarman-Logger-Sticks
-      im Standardmodus werden NICHT unterstützt.
       Der RS485-Port des Wechselrichters muss im Wechselrichtermenü auf
       das "Modbus"-Protokoll umgestellt werden.
 params:


### PR DESCRIPTION
This pull request adds a new template definition for Afore hybrid inverters with battery support. The template specifies requirements for Modbus TCP access, configuration parameters, and the mapping of battery-related metrics via Modbus registers.

Most important changes:

**New template for Afore hybrid inverter:**

* Added `afore-hybrid` template in `templates/definition/meter/afore-hybrid.yaml` with product information for Afore hybrid inverters with batteries.

**Requirements and configuration:**

* Documented requirements for direct Modbus TCP access via RS485-to-TCP gateway and the need to set the inverter's RS485 port to Modbus protocol.
* Defined parameters for usage (`battery`), Modbus connection (`tcpip`, port 502, id 1), and included a preset for battery parameters.

**Modbus register mappings:**

* Configured Modbus register addresses for battery power, state of charge (SoC), and total discharge energy, including decoding and scaling instructions.