### PR TITLE
feat(meter): add ecoflow-stream-mqtt with public-API MQTT and cascade discovery

### DIFF
--- a/meter/ecoflow_mqtt.go
+++ b/meter/ecoflow_mqtt.go
@@ -1,0 +1,292 @@
+package meter
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/evcc-io/evcc/plugin/mqtt"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+)
+
+// ecoflowMqttClient maintains a shared MQTT subscription to EcoFlow's public
+// IoT broker. The REST `quota/all` endpoint returns only a static subset of
+// parameters for Stream devices; live per-string PV power, per-second state
+// etc. are delivered exclusively via MQTT. Each configured EcoFlow meter
+// registers its device serial here and reads from the in-memory cache.
+//
+// Transport is delegated to evcc's shared `plugin/mqtt.Client` (which handles
+// the Paho options, TLS, reconnect, and automatic re-subscription of every
+// `Listen`ed topic on reconnect). The EcoFlow-specific parts that remain
+// here are the HMAC-signed HTTPS certification call, the stable
+// per-host client ID (to respect EcoFlow's 10-IDs/account/day quota) and
+// the flat-vs-envelope quota-payload parser.
+type ecoflowMqttClient struct {
+	log *util.Logger
+
+	accessKey string
+	secretKey string
+	uri       string // REST base, e.g. https://api-e.ecoflow.com
+	http      *http.Client
+
+	startMu  sync.Mutex // serializes the initial certification/connect
+	mu       sync.Mutex
+	state    map[string]map[string]any // sn -> key -> latest value
+	devices  map[string]struct{}       // serials for which Listen has been called
+	client   *mqtt.Client
+	username string // certificateAccount, used in quota topic
+}
+
+// ecoflowMqttClients caches one client per (accessKey, uri) pair so the HTTPS
+// certification call is made once per account, and so the resulting MQTT
+// connection (and its 1-of-10 daily client-ID slot) is shared across every
+// ecoflow meter for that account.
+var (
+	ecoflowMqttClientsMu sync.Mutex
+	ecoflowMqttClients   = map[string]*ecoflowMqttClient{}
+)
+
+func ecoflowMqttClientFor(accessKey, secretKey, uri string) *ecoflowMqttClient {
+	ecoflowMqttClientsMu.Lock()
+	defer ecoflowMqttClientsMu.Unlock()
+
+	key := accessKey + "|" + uri
+	if c, ok := ecoflowMqttClients[key]; ok {
+		return c
+	}
+	log := util.NewLogger("ecoflow-mqtt")
+	c := &ecoflowMqttClient{
+		log:       log,
+		accessKey: accessKey,
+		secretKey: secretKey,
+		uri:       uri,
+		http:      request.NewClient(log),
+		state:     make(map[string]map[string]any),
+		devices:   make(map[string]struct{}),
+	}
+	ecoflowMqttClients[key] = c
+	return c
+}
+
+// ecoflowCertResponse is the payload from GET /iot-open/sign/certification.
+type ecoflowCertResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		CertificateAccount  string `json:"certificateAccount"`
+		CertificatePassword string `json:"certificatePassword"`
+		URL                 string `json:"url"`
+		Port                string `json:"port"`
+		Protocol            string `json:"protocol"`
+	} `json:"data"`
+}
+
+// ecoflowSign builds the HMAC-SHA256 signature for a signed EcoFlow public
+// API request as documented in EcoFlow's developer portal.
+func ecoflowSign(accessKey, secretKey, nonce, timestamp, query string) string {
+	target := "accessKey=" + accessKey + "&nonce=" + nonce + "&timestamp=" + timestamp
+	if query != "" {
+		target = query + "&" + target
+	}
+	h := hmac.New(sha256.New, []byte(secretKey))
+	h.Write([]byte(target))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// certify fetches MQTT credentials from the public API.
+func (c *ecoflowMqttClient) certify(ctx context.Context) (*ecoflowCertResponse, error) {
+	nonce := strconv.Itoa(int(time.Now().UnixNano() % 1_000_000))
+	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	sign := ecoflowSign(c.accessKey, c.secretKey, nonce, timestamp, "")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.uri+"/iot-open/sign/certification", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("accessKey", c.accessKey)
+	req.Header.Set("nonce", nonce)
+	req.Header.Set("timestamp", timestamp)
+	req.Header.Set("sign", sign)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("certification: http %d: %s", resp.StatusCode, string(body))
+	}
+
+	var cert ecoflowCertResponse
+	if err := json.Unmarshal(body, &cert); err != nil {
+		return nil, fmt.Errorf("certification: %w (body=%s)", err, string(body))
+	}
+	if cert.Code != "0" {
+		return nil, fmt.Errorf("certification: code=%s message=%s", cert.Code, cert.Message)
+	}
+	return &cert, nil
+}
+
+// ensureStarted lazily performs the HTTPS certification and opens a shared
+// `plugin/mqtt.Client` on the first device registration. Subsequent calls
+// are no-ops.
+func (c *ecoflowMqttClient) ensureStarted(ctx context.Context) error {
+	c.startMu.Lock()
+	defer c.startMu.Unlock()
+
+	c.mu.Lock()
+	started := c.client != nil
+	c.mu.Unlock()
+	if started {
+		return nil
+	}
+
+	cert, err := c.certify(ctx)
+	if err != nil {
+		return err
+	}
+
+	port, err := strconv.Atoi(cert.Data.Port)
+	if err != nil {
+		return fmt.Errorf("invalid mqtt port %q: %w", cert.Data.Port, err)
+	}
+
+	// Stable client id that is also unique per host. EcoFlow's broker
+	// permits only a single concurrent connection per client id and imposes
+	// a 10 unique-ID/day limit per account. Hashing (accessKey + hostname)
+	// keeps the id stable across restarts while allowing multiple evcc
+	// instances (e.g. prod + dev) to coexist on the same access key.
+	hostname, _ := os.Hostname()
+	h := sha256.Sum256([]byte(c.accessKey + "|" + hostname))
+	clientID := "evcc-" + hex.EncodeToString(h[:6])
+
+	// EcoFlow's certification response uses the `ssl` scheme which is
+	// paho's alias for TLS. plugin/mqtt specifically recognises the
+	// `tls://` prefix and preserves it through its DefaultPort helper;
+	// normalise to that form here.
+	broker := fmt.Sprintf("tls://%s:%d", cert.Data.URL, port)
+
+	client, err := mqtt.NewClient(c.log, broker,
+		cert.Data.CertificateAccount, cert.Data.CertificatePassword,
+		clientID, 1, false, "", "", "")
+	if err != nil {
+		return fmt.Errorf("mqtt connect: %w", err)
+	}
+
+	c.mu.Lock()
+	c.client = client
+	c.username = cert.Data.CertificateAccount
+	c.mu.Unlock()
+
+	return nil
+}
+
+// Register subscribes the client to live updates for the given device serial.
+// Safe to call multiple times; extra calls are no-ops.
+//
+// Re-subscription on reconnect is handled automatically by `plugin/mqtt`'s
+// ConnectionHandler, which replays every `Listen`ed topic.
+func (c *ecoflowMqttClient) Register(ctx context.Context, sn string) error {
+	if err := c.ensureStarted(ctx); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	_, existed := c.devices[sn]
+	if !existed {
+		c.devices[sn] = struct{}{}
+	}
+	client := c.client
+	username := c.username
+	c.mu.Unlock()
+
+	if existed {
+		return nil
+	}
+
+	topic := fmt.Sprintf("/open/%s/%s/quota", username, sn)
+	return client.Listen(topic, func(payload string) {
+		c.handleMessage(sn, []byte(payload))
+	})
+}
+
+// handleMessage parses a quota payload and updates the cache. Payload shapes
+// observed on EcoFlow public MQTT:
+//
+//  1. Stream devices emit a flat JSON object with parameters at the top
+//     level, e.g. {"powGetPv2":214.14,"gridConnectionPower":283.99}.
+//  2. Other devices wrap updates in a {"params": {...}} (or "param") envelope
+//     and may include metadata like timestamp/typeCode at the top level.
+//
+// We accept both shapes: if "params"/"param" is present we take it, otherwise
+// we merge the top-level object as-is (ignoring a few well-known metadata
+// fields that are not quota parameters).
+func (c *ecoflowMqttClient) handleMessage(sn string, payload []byte) {
+	var raw map[string]any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		c.log.TRACE.Printf("ignoring non-JSON payload on %s: %v", sn, err)
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	dev := c.state[sn]
+	if dev == nil {
+		dev = make(map[string]any)
+		c.state[sn] = dev
+	}
+
+	var merged bool
+	if p, ok := raw["params"].(map[string]any); ok {
+		maps.Copy(dev, p)
+		merged = true
+	}
+	if p, ok := raw["param"].(map[string]any); ok {
+		maps.Copy(dev, p)
+		merged = true
+	}
+
+	if !merged {
+		// flat payload: treat top-level keys as parameters
+		for k, v := range raw {
+			switch k {
+			case "id", "version", "timestamp", "typeCode", "cmdFunc", "cmdId":
+				// skip message envelope fields
+				continue
+			}
+			dev[k] = v
+		}
+	}
+}
+
+// Lookup returns the most recently cached MQTT value for the given serial and
+// parameter name. The boolean is false if either the device has not been seen
+// yet or the key has not been reported.
+func (c *ecoflowMqttClient) Lookup(sn, key string) (any, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	dev, ok := c.state[sn]
+	if !ok {
+		return nil, false
+	}
+	v, ok := dev[key]
+	return v, ok
+}

--- a/meter/ecoflow_stream_mqtt.go
+++ b/meter/ecoflow_stream_mqtt.go
@@ -1,0 +1,410 @@
+package meter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/spf13/cast"
+	"github.com/tess1o/go-ecoflow"
+)
+
+// EcoFlowStreamMqtt is a dedicated meter type for the EcoFlow Stream family
+// that uses the public MQTT API for live data.
+//
+// Unlike other EcoFlow devices (Delta, Powerstream, ...) the Stream series
+// only publishes live per-string PV power, per-second battery state etc.
+// over MQTT. The legacy `ecoflow` meter (used by the original
+// `ecoflow-stream` template) still works but is limited to the stale REST
+// subset of parameters exposed by `quota/all`. This type
+// adds:
+//
+//   - subscription to the public MQTT broker for live quota updates;
+//   - optional auto-discovery of sibling devices on the same account with
+//     aggregated readings (cascade mode);
+//   - fixed evcc-usage -> EcoFlow param mapping (grid / pv / battery);
+//   - SoC as the cascade average and battery power as inputWatts -
+//     outputWatts (then inverted to evcc's sign convention).
+type EcoFlowStreamMqtt struct {
+	ctx     context.Context
+	log     *util.Logger
+	usage   string
+	primary string   // originally configured serial (used for filter prefix)
+	serials []string // every serial this meter aggregates (>= 1)
+	cache   time.Duration
+	client  *ecoflow.Client
+	dataGs  map[string]func() (*ecoflow.GetCmdResponse, error) // per-serial cached REST getter
+	mqtt    *ecoflowMqttClient
+
+	// param keys mapped from usage (see usageParams)
+	powerKeys    []string // summed into power
+	powerNegKeys []string // subtracted from power
+	socKey       string   // battery state-of-charge key
+}
+
+func init() {
+	registry.AddCtx("ecoflow-stream-mqtt", NewEcoFlowStreamMqttFromConfig)
+}
+
+// usageParams returns the EcoFlow MQTT parameter keys for the given evcc
+// meter usage. These are the keys that Stream devices publish on the
+// `/open/<user>/<sn>/quota` topic; the REST `quota/all` endpoint returns a
+// largely disjoint (and often stale) subset, so REST is only a fallback.
+func usageParams(usage string) (power, powerNeg []string, soc string, err error) {
+	switch usage {
+	case "grid":
+		return []string{"powGetSysGrid"}, nil, "", nil
+	case "pv":
+		return []string{"powGetPv", "powGetPv2", "powGetPv3", "powGetPv4"}, nil, "", nil
+	case "battery":
+		return []string{"inputWatts"}, []string{"outputWatts"}, "f32ShowSoc", nil
+	default:
+		return nil, nil, "", fmt.Errorf("invalid usage: %s", usage)
+	}
+}
+
+// NewEcoFlowStreamMqttFromConfig creates a Stream meter from generic config.
+func NewEcoFlowStreamMqttFromConfig(ctx context.Context, other map[string]any) (api.Meter, error) {
+	cc := struct {
+		batteryCapacity                      `mapstructure:",squash"`
+		batteryPowerLimits                   `mapstructure:",squash"`
+		batterySocLimits                     `mapstructure:",squash"`
+		Usage                                string
+		AccessKey, SecretKey, Serial, Region string
+		Serials                              []string
+		Discover                             bool
+		Cache                                time.Duration
+	}{
+		Cache:    30 * time.Second,
+		Discover: true,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+	if cc.AccessKey == "" {
+		return nil, errors.New("missing access key")
+	}
+	if cc.SecretKey == "" {
+		return nil, errors.New("missing secret key")
+	}
+	if cc.Serial == "" {
+		return nil, errors.New("missing serial")
+	}
+	if cc.Usage == "" {
+		return nil, errors.New("missing usage")
+	}
+
+	var uri string
+	switch cc.Region {
+	case "", "auto":
+		uri = "https://api.ecoflow.com"
+	case "europe":
+		uri = "https://api-e.ecoflow.com"
+	case "america":
+		uri = "https://api-a.ecoflow.com"
+	default:
+		return nil, fmt.Errorf("invalid region: %s", cc.Region)
+	}
+
+	m, err := NewEcoFlowStreamMqtt(ctx, cc.AccessKey, cc.SecretKey, cc.Serial, cc.Serials, cc.Discover, cc.Usage, uri, cc.Cache)
+	if err != nil {
+		return nil, err
+	}
+
+	if cc.Usage == "battery" {
+		return decorateMeterBattery(
+			m, nil, m.soc, cc.batteryCapacity.Decorator(),
+			cc.batterySocLimits.Decorator(), cc.batteryPowerLimits.Decorator(), nil,
+		), nil
+	}
+
+	return m, nil
+}
+
+// NewEcoFlowStream constructs the Stream meter. If discover is true the
+// EcoFlow device list is queried and every device whose serial shares the
+// primary serial's 2-char prefix (e.g. "BK" for the Stream family) is added
+// as a sibling so cascade systems appear as one aggregated meter.
+func NewEcoFlowStreamMqtt(ctx context.Context, accessKey, secretKey, serial string, serials []string, discover bool,
+	usage, uri string, cache time.Duration,
+) (*EcoFlowStreamMqtt, error) {
+	power, powerNeg, soc, err := usageParams(usage)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &EcoFlowStreamMqtt{
+		ctx:          ctx,
+		log:          util.NewLogger("ecoflow-stream-mqtt"),
+		primary:      serial,
+		usage:        usage,
+		cache:        cache,
+		client:       ecoflow.NewEcoflowClient(accessKey, secretKey, ecoflow.WithBaseUrl(uri)),
+		dataGs:       make(map[string]func() (*ecoflow.GetCmdResponse, error)),
+		powerKeys:    power,
+		powerNegKeys: powerNeg,
+		socKey:       soc,
+	}
+
+	set := make(map[string]struct{})
+	add := func(sn string) {
+		if sn == "" {
+			return
+		}
+		if _, ok := set[sn]; ok {
+			return
+		}
+		set[sn] = struct{}{}
+		m.serials = append(m.serials, sn)
+	}
+	add(serial)
+	for _, sn := range serials {
+		add(sn)
+	}
+
+	if discover {
+		// Fail soft: if discovery fails we continue with whatever was
+		// configured explicitly so a broker or network outage doesn't
+		// prevent evcc from starting.
+		dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		resp, dErr := m.client.GetDeviceList(dctx)
+		cancel()
+		switch {
+		case dErr != nil:
+			m.log.WARN.Printf("discover: device list failed: %v", dErr)
+		case resp == nil:
+			m.log.WARN.Printf("discover: empty device list response")
+		default:
+			// discover adds slaves: every device that shares the
+			// primary serial's 2-char family prefix (e.g. "BK" for
+			// Stream) is treated as a sibling.
+			if len(m.primary) >= 2 {
+				prefix := m.primary[:2]
+				for _, d := range resp.Devices {
+					if !strings.HasPrefix(d.SN, prefix) {
+						continue
+					}
+					add(d.SN)
+				}
+			}
+			m.log.INFO.Printf("discover: tracking %d device(s): %s", len(m.serials), strings.Join(m.serials, ","))
+		}
+	}
+
+	for _, sn := range m.serials {
+		m.dataGs[sn] = util.Cached(func() (*ecoflow.GetCmdResponse, error) {
+			return m.fetchData(sn)
+		}, cache)
+	}
+
+	// Subscribe to live MQTT updates for every serial. Registration runs in
+	// a goroutine so that a broker outage doesn't block evcc from starting.
+	m.mqtt = ecoflowMqttClientFor(accessKey, secretKey, uri)
+	go func() {
+		for _, sn := range m.serials {
+			if err := m.mqtt.Register(ctx, sn); err != nil {
+				m.log.WARN.Printf("mqtt register %s: %v", sn, err)
+			}
+		}
+	}()
+
+	return m, nil
+}
+
+// fetchData retrieves the configured parameters for a single serial.
+func (m *EcoFlowStreamMqtt) fetchData(sn string) (*ecoflow.GetCmdResponse, error) {
+	ctx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
+	defer cancel()
+
+	params := append([]string(nil), m.powerKeys...)
+	params = append(params, m.powerNegKeys...)
+	if m.socKey != "" {
+		params = append(params, m.socKey)
+	}
+	return m.client.GetDeviceParameters(ctx, sn, params)
+}
+
+var _ api.Meter = (*EcoFlowStreamMqtt)(nil)
+
+// CurrentPower implements the api.Meter interface. Per-serial it sums the
+// powerKeys and subtracts the powerNegKeys; the per-serial nets are then
+// summed across all tracked devices to produce the total. Battery power is
+// finally inverted to match evcc's convention (negative = charging).
+//
+// A REST failure on one device (e.g. a transient cloud hiccup for a single
+// cascade unit) is logged and skipped so the aggregate meter keeps
+// reporting from the healthy devices. Only when every device is
+// unreachable is the last error surfaced.
+func (m *EcoFlowStreamMqtt) CurrentPower() (float64, error) {
+	var (
+		total    float64
+		anyFound bool
+		lastErr  error
+	)
+
+	for _, sn := range m.serials {
+		pos, neg, found, err := m.devicePower(sn)
+		if err != nil {
+			m.log.WARN.Printf("%s: %v", sn, err)
+			lastErr = err
+			continue
+		}
+		total += pos - neg
+		if found {
+			anyFound = true
+		}
+	}
+
+	if !anyFound {
+		if lastErr != nil {
+			return 0, lastErr
+		}
+		// For a single positive key on a single device (simple grid) we
+		// preserve strict ErrNotAvailable propagation. With multi-key
+		// sums (per-string PV, input/output split) or multiple devices,
+		// an empty response means 0 W.
+		totalKeys := len(m.powerKeys) + len(m.powerNegKeys)
+		if totalKeys == 1 && len(m.serials) == 1 {
+			return 0, api.ErrNotAvailable
+		}
+	}
+
+	if m.usage == "battery" {
+		total = -total // ecoflow reports charging as positive
+	}
+
+	return total, nil
+}
+
+// devicePower resolves the net power for a single serial. Both key lists
+// share one REST round-trip (via an inner closure) to minimise API load.
+func (m *EcoFlowStreamMqtt) devicePower(sn string) (pos, neg float64, found bool, err error) {
+	var restData map[string]any
+	getRest := func() (map[string]any, error) {
+		if restData != nil {
+			return restData, nil
+		}
+		response, err := m.dataGs[sn]()
+		if err != nil {
+			return nil, err
+		}
+		restData = response.Data
+		if restData == nil {
+			restData = map[string]any{}
+		}
+		return restData, nil
+	}
+
+	pos, posFound, err := m.sumKeys(sn, m.powerKeys, getRest)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	neg, negFound, err := m.sumKeys(sn, m.powerNegKeys, getRest)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	return pos, neg, posFound || negFound, nil
+}
+
+// sumKeys resolves each key via MQTT (preferred) or REST for the given
+// serial and returns the running sum. Keys missing from both sources are
+// skipped silently so a device that doesn't expose every optional key
+// doesn't abort the whole reading.
+func (m *EcoFlowStreamMqtt) sumKeys(sn string, keys []string, getRest func() (map[string]any, error)) (float64, bool, error) {
+	var sum float64
+	var found bool
+	for _, key := range keys {
+		if v, ok := m.mqttValue(sn, key); ok {
+			sum += v
+			found = true
+			continue
+		}
+
+		data, err := getRest()
+		if err != nil {
+			return 0, false, err
+		}
+
+		v, err := ecoflowValue(data, key)
+		if errors.Is(err, api.ErrNotAvailable) {
+			continue
+		}
+		if err != nil {
+			return 0, false, err
+		}
+		sum += v
+		found = true
+	}
+	return sum, found, nil
+}
+
+// mqttValue returns the live MQTT-cached value for the given serial/key,
+// if available.
+func (m *EcoFlowStreamMqtt) mqttValue(sn, key string) (float64, bool) {
+	if m.mqtt == nil {
+		return 0, false
+	}
+	v, ok := m.mqtt.Lookup(sn, key)
+	if !ok {
+		return 0, false
+	}
+	f, err := cast.ToFloat64E(v)
+	if err != nil {
+		return 0, false
+	}
+	return f, true
+}
+
+// soc returns the battery state of charge, averaged across all tracked
+// serials (each contributing serial weighted equally, matching the EcoFlow
+// app's cascade view). Per-device REST failures are logged and skipped so
+// one failing unit doesn't hide the SoC of the remaining devices.
+func (m *EcoFlowStreamMqtt) soc() (float64, error) {
+	if m.socKey == "" {
+		return 0, api.ErrNotAvailable
+	}
+
+	var (
+		sum     float64
+		count   int
+		lastErr error
+	)
+	for _, sn := range m.serials {
+		if v, ok := m.mqttValue(sn, m.socKey); ok {
+			sum += v
+			count++
+			continue
+		}
+
+		response, err := m.dataGs[sn]()
+		if err != nil {
+			m.log.WARN.Printf("%s: %v", sn, err)
+			lastErr = err
+			continue
+		}
+		v, err := ecoflowValue(response.Data, m.socKey)
+		if errors.Is(err, api.ErrNotAvailable) {
+			continue
+		}
+		if err != nil {
+			m.log.WARN.Printf("%s: %v", sn, err)
+			lastErr = err
+			continue
+		}
+		sum += v
+		count++
+	}
+
+	if count == 0 {
+		if lastErr != nil {
+			return 0, lastErr
+		}
+		return 0, api.ErrNotAvailable
+	}
+	return sum / float64(count), nil
+}

--- a/templates/definition/meter/ecoflow-stream-mqtt.yaml
+++ b/templates/definition/meter/ecoflow-stream-mqtt.yaml
@@ -1,0 +1,86 @@
+template: ecoflow-stream-mqtt
+products:
+  - brand: EcoFlow
+    description:
+      generic: Stream (MQTT)
+requirements:
+  description:
+    de: |
+      Diese Variante des EcoFlow Stream Meters verwendet die offizielle MQTT
+      API und liefert dadurch Live-Daten (z. B. PV pro String, Batterie
+      Ein-/Ausgangsleistung, SoC je Sekunde). Sie benötigen:
+      - Einen gültigen Access Key von der EcoFlow Developer Console
+      - Den entsprechenden Secret Key
+      - Die Seriennummer des Hauptgeräts Ihres Stream Systems
+
+      Der MQTT-Client ist pro Account gemeinsam genutzt (eine Verbindung
+      für alle Stream-Meter). EcoFlow erlaubt pro Konto 10 unterschiedliche
+      Client-IDs pro Tag; evcc nutzt deshalb eine stabile ID pro Host.
+    en: |
+      This variant of the EcoFlow Stream meter uses the official MQTT API
+      for live data (per-string PV, battery in/out power, per-second SoC,
+      etc.). You need:
+      - A valid Access Key from the EcoFlow Developer Console
+      - The corresponding Secret Key
+      - The main device serial number of your Stream system
+
+      A single shared MQTT client is used for the whole account (one
+      connection for all Stream meters). EcoFlow allows 10 unique client
+      IDs per account per day; evcc therefore uses one stable ID per host.
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+  - name: accesskey
+    required: true
+    description:
+      generic: Access Key
+    help:
+      en: Access Key from EcoFlow Developer Console
+      de: Access Key aus der EcoFlow Developer Console
+  - name: secretkey
+    required: true
+    description:
+      generic: Secret Key
+    help:
+      en: Secret Key from EcoFlow Developer Console
+      de: Secret Key aus der EcoFlow Developer Console
+  - name: serial
+    required: true
+    help:
+      en: Serial number of the main (master) device of your Stream system
+      de: Seriennummer des Hauptgeräts (Master) Ihres Stream Systems
+  - name: discover
+    type: bool
+    default: true
+    advanced: true
+    description:
+      en: Auto-discover siblings
+      de: Andere Geräte automatisch erkennen
+    help:
+      en: When enabled, all Stream devices on the same account (sharing the same 2-char serial prefix) are aggregated into this meter. Their power is summed and SoC is averaged, matching the cascade view shown in the EcoFlow app.
+      de: Wenn aktiviert, werden alle Stream-Geräte des Kontos (mit gleichem 2-Zeichen-Seriennummern-Präfix) zu diesem Zähler aggregiert. Leistungen werden summiert, SoC wird gemittelt – entsprechend der Kaskadenansicht in der EcoFlow App.
+  - name: region
+    choice: ["auto", "europe", "america"]
+    default: auto
+    advanced: true
+    description:
+      generic: "API Region"
+    help:
+      en: "If you sometimes see error code 8513, like for example Starlink users do, automatic region detection fails. Here, you can set the API region manually. Possible values: auto (default), europe, or america."
+      de: 'Manche Nutzer, z.B. mit Starlink-Internet, sehen gelegentlich in den Logs den "error code 8513". Das passiert, wenn die API Region nicht korrekt erkannt wird. Um das zu beheben, kann man die API Region manuell setzen. Mögliche Werte: auto (Standard), europe oder america.'
+  - name: cache
+    default: 30s
+    advanced: true
+  - preset: battery-params
+render: |
+  type: ecoflow-stream-mqtt
+  accesskey: {{ .accesskey }}
+  secretkey: {{ .secretkey }}
+  serial: {{ or .serial .deviceid }}
+  discover: {{ .discover }}
+  usage: {{ .usage }}
+  cache: {{ .cache }}
+  region: {{ .region }}
+  {{- if eq .usage "battery" }}
+  {{- include "battery-params" . }}
+  {{- end }}


### PR DESCRIPTION
## Summary

Adds a dedicated device template for the EcoFlow Stream family that uses EcoFlow's public-API MQTT broker for live data. The existing `ecoflow-stream` template (REST-only via the generic `ecoflow` meter) is kept untouched so no existing configuration changes behaviour.

## Why

The REST `quota/all` endpoint returns a stale, largely aggregated snapshot for Stream devices. Notably:

- individual PV string power (`powGetPv`..`powGetPv4`) is never populated, only `powGetPvSum`, which can include output from unrelated PV sources connected to the same cloud meter;
- battery power on the CMS level (`powGetBpCms`) is `0` for Stream AC Hybrid installations;
- `cmsBattSoc` is always `0`; the real per-module SoC lives in `f32ShowSoc`;
- in cascade/multi-unit setups only the master's view is reachable via REST, so the SoC shown by evcc differs from the app's cascade average.

Home Assistant's [`tolwi/hassio-ecoflow-cloud`](https://github.com/tolwi/hassio-ecoflow-cloud) integration gets these values by subscribing to EcoFlow's public MQTT broker. evcc now does the same.

## What

- **`meter/ecoflow_mqtt.go`** — shared public-API MQTT client, one per `(accessKey, region)`.
  - HMAC-SHA256 signed certification call to `/iot-open/sign/certification`, TLS connection, subscribe to `/open/<certificateAccount>/<sn>/quota`.
  - The client is reused across every `ecoflow-stream-mqtt` meter so only one of EcoFlow's 10 unique-client-ID/day slots is consumed per account.
  - Client ID is hashed from `accessKey + hostname` so dev and prod instances on the same account can coexist without disconnecting each other.
  - Parser handles both the flat top-level JSON payload Stream devices emit and the `{"params": {...}}` / `{"param": {...}}` envelopes used by other device families.

- **`meter/ecoflow_stream_mqtt.go`** — new meter type `ecoflow-stream-mqtt`.
  - Maps evcc usage → EcoFlow param keys: `grid` → `powGetSysGrid`; `pv` → `powGetPv..powGetPv4`; `battery` → `inputWatts - outputWatts` with `f32ShowSoc`.
  - Optional sibling auto-discovery via `/iot-open/sign/device/list`, matching by the 2-char serial prefix so cascade systems (e.g. two Stream AC Hybrids linked as master + slave) appear as one aggregated meter.
  - Subscribes each discovered serial on the shared MQTT client and caches the latest values.
  - Reads prefer the MQTT cache, fall back to per-serial REST with `util.Cached`.
  - `CurrentPower` is the sum across devices; `Soc` is the plain average, matching the EcoFlow app's cascade view.

- **`templates/definition/meter/ecoflow-stream-mqtt.yaml`** — new device entry listed as *EcoFlow Stream (MQTT)*. Exposes the same access key / secret key / serial / usage inputs as the existing `ecoflow-stream` template, plus an advanced `discover` toggle (default `true`).

## Backwards compatibility

Purely additive: no existing files are modified. The legacy `ecoflow-stream` template and the generic `ecoflow` meter remain byte-for-byte identical to master.

## Verification

Live-tested against a cascade of two EcoFlow Stream AC Hybrid units on one account. With a single configured master serial and `discover: true`, evcc reports:

```
[ecoflow-stream-mqtt] INFO  discover: tracking 2 device(s): BK11...,BK31...
[ecoflow-mqtt]        DEBUG subscribe /open/<user>/BK11.../quota
[ecoflow-mqtt]        DEBUG subscribe /open/<user>/BK31.../quota
[site]                pv 1 power: 593W
[site]                battery 1 power: -1067W
[site]                battery 1 soc: 37%
```

Values match the EcoFlow mobile-app cascade view within the usual smoothing lag.

## Test plan

- [x] `make test` — all Go tests pass, including the `meter` package.
- [x] `make lint` — no new lint findings in the added files (the handful of warnings on master pre-date this PR).
- [x] `go vet ./meter/...` — clean.
- [x] `make docs` — regenerates `templates/docs/{de,en}/meter/ecoflow-stream-mqtt.yaml` (gitignored path, matching repo convention).
- [x] `go build ./...` — binary built.
- [x] Live end-to-end test on a 2-unit Stream AC Hybrid cascade: PV sum, battery `inputWatts - outputWatts` (negated), and averaged SoC all match the app.
