### PR TITLE
Forecast: temporarily remove adjustment (2)

### DIFF
--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -151,7 +151,7 @@ const settings: Settings = reactive({
   savingsIndicator: read(SAVINGS_INDICATOR),
   sessionsGroup: read(SESSIONS_GROUP),
   sessionsType: read(SESSIONS_TYPE),
-  solarAdjusted: readBool(SETTINGS_SOLAR_ADJUSTED),
+  solarAdjusted: false, //readBool(SETTINGS_SOLAR_ADJUSTED), # temporarily disable, https://github.com/evcc-io/evcc/issues/29165
   priceZoom: readBool(SETTINGS_PRICE_ZOOM),
   hideFeedin: readBool(SETTINGS_HIDE_FEEDIN),
   loadpoints: readJSON(LOADPOINTS),

--- a/assets/js/views/Forecast.vue
+++ b/assets/js/views/Forecast.vue
@@ -243,7 +243,8 @@ export default defineComponent({
 			return true;
 		},
 		showSolarAdjust() {
-			return !!this.forecast.solar && this.experimental;
+			// TODO fix https://github.com/evcc-io/evcc/issues/29165
+			return !!this.forecast.solar && this.experimental && false;
 		},
 		solar() {
 			return this.showSolarAdjust && this.solarAdjusted


### PR DESCRIPTION
addition to https://github.com/evcc-io/evcc/pull/29244
fixes https://github.com/evcc-io/evcc/issues/29165

The previous fix removed the button only in the (soon to be removed) forecast modal, not in the forecast page.
This PR also adjusted the settings read so that instances with enabled adjust don't use this value (relevant for the forecast number in the energy flow overview).