### PR TITLE
fix: use RemoteStart/RemoteStop for OCPP chargers with remoteStart

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -44,6 +44,7 @@ type OCPP struct {
 	enabled bool
 	current float64
 
+	remoteStart         bool
 	stackLevelZero      bool
 	profileKindRelative bool
 	lp                  loadpoint.API
@@ -190,6 +191,7 @@ func NewOCPP(ctx context.Context,
 		log:                 log,
 		cp:                  cp,
 		conn:                conn,
+		remoteStart:         remoteStart,
 		stackLevelZero:      stackLevelZero,
 		profileKindRelative: profileKindRelative,
 	}
@@ -269,6 +271,17 @@ func (c *OCPP) Enabled() (bool, error) {
 			core.ChargePointStatusCharging,
 			core.ChargePointStatusSuspendedEV:
 			return true, nil
+		case
+			core.ChargePointStatusPreparing:
+			if c.remoteStart {
+				// Return cached state to prevent "out of sync" flip-flop.
+				// Self-healing: if we should be enabled but there's no active
+				// transaction, re-send RemoteStartTransaction.
+				if c.enabled && c.conn.NeedsAuthentication() {
+					go c.conn.RemoteStartTransactionRequest(c.conn.RemoteIdTag())
+				}
+				return c.enabled, nil
+			}
 		}
 	}
 
@@ -295,18 +308,35 @@ func (c *OCPP) Enabled() (bool, error) {
 
 // Enable implements the api.Charger interface
 func (c *OCPP) Enable(enable bool) error {
+	if c.remoteStart && enable {
+		// ensure transaction is active
+		if c.conn.NeedsAuthentication() {
+			if err := c.conn.RemoteStartTransactionRequest(c.conn.RemoteIdTag()); err != nil {
+				return err
+			}
+		}
+	}
+
 	var current float64
 	if enable {
 		current = c.current
 	}
 
-	err := c.setCurrent(current)
-	if err == nil {
-		// cache enabled state as last fallback option
-		c.enabled = enable
+	// For remoteStart chargers, skip setCurrent(0) since some chargers
+	// (e.g. Huawei SCharger) interpret a 0W profile as "stop transaction".
+	if c.remoteStart && current == 0 {
+		// stop transaction instead of sending 0W profile
+		c.conn.RemoteStopTransactionRequest()
+	} else {
+		if err := c.setCurrent(current); err != nil {
+			return err
+		}
 	}
 
-	return err
+	// cache enabled state as last fallback option
+	c.enabled = enable
+
+	return nil
 }
 
 // setCurrent sets the TxDefaultChargingProfile with given current

--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -95,6 +95,11 @@ func (conn *Connector) IdTag() string {
 	return conn.idTag
 }
 
+// RemoteIdTag returns the configured remote start ID tag
+func (conn *Connector) RemoteIdTag() string {
+	return conn.remoteIdTag
+}
+
 // getScheduleLimit queries the current or power limit the charge point is currently set to offer
 func (conn *Connector) GetScheduleLimit(duration int) (float64, error) {
 	schedule, err := conn.cp.GetCompositeScheduleRequest(conn.id, duration)

--- a/charger/ocpp/connector_requests.go
+++ b/charger/ocpp/connector_requests.go
@@ -19,6 +19,18 @@ func (conn *Connector) RemoteStartTransactionRequest(idTag string) error {
 	return conn.cp.RemoteStartTransactionRequest(conn.id, idTag)
 }
 
+func (conn *Connector) RemoteStopTransactionRequest() error {
+	conn.mu.Lock()
+	txnId := conn.txnId
+	conn.mu.Unlock()
+
+	if txnId == 0 {
+		return nil
+	}
+
+	return conn.cp.RemoteStopTransactionRequest(txnId)
+}
+
 func (conn *Connector) SetChargingProfileRequest(profile *types.ChargingProfile) error {
 	return conn.cp.SetChargingProfileRequest(conn.id, profile)
 }

--- a/charger/ocpp/cp_requests.go
+++ b/charger/ocpp/cp_requests.go
@@ -58,6 +58,19 @@ func (cp *CP) RemoteStartTransactionRequest(connectorId int, idTag string) error
 	return wait(err, rc)
 }
 
+func (cp *CP) RemoteStopTransactionRequest(transactionId int) error {
+	rc := make(chan error, 1)
+	err := Instance().RemoteStopTransaction(cp.id, func(request *core.RemoteStopTransactionConfirmation, err error) {
+		if err == nil && request != nil && request.Status != types.RemoteStartStopStatusAccepted {
+			err = errors.New(string(request.Status))
+		}
+
+		rc <- err
+	}, transactionId)
+
+	return wait(err, rc)
+}
+
 func (cp *CP) SetChargingProfileRequest(connectorId int, profile *types.ChargingProfile) error {
 	rc := make(chan error, 1)
 


### PR DESCRIPTION
 **Summary**                                                                                                                                                                                                                                                                                                    
  - For OCPP chargers with remoteStart: true, use RemoteStartTransaction/RemoteStopTransaction to control charging instead of sending a 0W charging profile
  - Fixes Huawei SCharger getting permanently stuck in "waiting for authorization"
  - Related issue: #29272
  - Related discussion: #10262                                                                                                                             
                                                                                                                                                         
**Problem**                                                                                                                                  
  Some OCPP chargers (confirmed on Huawei SCharger-7KS-S0) interpret SetChargingProfile with limit: 0W as "stop the transaction" rather than suspending.   
  This causes a permanent "waiting for authorization" state because:                                                                                     
                                                                                                                                                           
  1. Enable(false) → setCurrent(0) → SetChargingProfile(0W) → charger sends StopTransaction                                                                
  2. Charger returns to Preparing but never sends a new StatusNotification
  3. evcc never re-sends RemoteStartTransaction → charger is stuck forever                                                                                 
                                                                                                                                                           
  Additionally, Enabled() returns false in Preparing state (falls through to measurand-based detection), causing an "out of sync" cycle that repeatedly    
  sends 0W profiles.                                                                                                                                       
                                                                                                                                                           
**Changes**                                                                                                                                                                               
  - Enable(true) with remoteStart: sends RemoteStartTransaction if connector needs auth, then sets current
  - Enable(false) with remoteStart: sends RemoteStopTransaction instead of setCurrent(0), avoiding the 0W profile entirely                                 
  - Enabled(): for Preparing status with remoteStart, returns cached c.enabled state instead of falling through to measurand detection. Includes self-healing: if c.enabled is true but no active transaction, re-sends RemoteStartTransaction in background                                                            
  - Adds RemoteStopTransactionRequest()                                                                                                                                                                                                                                          
  - Adds RemoteStopTransactionRequest() following the same pattern as RemoteStartTransactionRequest
                                                                                                                                                           
 **Scope and limitations**                                                                                                                                                    
  - All changes are gated behind c.remoteStart — chargers without remoteStart: true are completely unaffected                                              
  - Tested on Huawei SCharger-7KS-S0 with a Tesla vehicle. Other OCPP chargers with remoteStart may behave differently — feedback from users with other charger models would be valuable                                                                                                                         
  - The Huawei charger has a ~3s internal timeout after StartTransaction if the vehicle doesn't draw current. The self-healing mechanism (re-sending RemoteStartTransaction every ~30s) handles this until the vehicle wakes up                                                                               
                                                        
 **Test plan**                                                                                                                                                                             
  - All existing tests pass (go test ./charger/... ./charger/ocpp/... and go test ./core/...)                                                              
  - Verified on Huawei SCharger-7KS-S0: no more "waiting for authorization", charging starts and stops correctly
  - Verified mode transitions: off → minpv → now → off all work correctly                                                                                  
  - Needs testing with other OCPP chargers that use remoteStart  