### PR TITLE
Log UI: sort the log area multiselect naturally

### DIFF
--- a/assets/js/views/Log.vue
+++ b/assets/js/views/Log.vue
@@ -171,7 +171,10 @@ export default defineComponent({
 			});
 		},
 		areaOptions() {
-			return this.availableAreas.map((area) => ({ name: area, value: area }));
+			return this.availableAreas
+				.slice()
+				.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+				.map((area) => ({ name: area, value: area }));
 		},
 		areasLabel() {
 			if (this.areas.length === 0) {


### PR DESCRIPTION
if more than nine loadpoints are configured, the log area select looks like:

- [ ] lp-1
- [ ] lp-10
- [ ] lp-11
- [ ] lp-2
- [ ] lp-3
- [ ] lp-4
- [ ] lp-5
- [ ] lp-6
- [ ] lp-7
- [ ] lp-8
- [ ] lp-9

After applying this patch, the checkboxes are naturally sorted:
- [ ] lp-1
- [ ] lp-2
- [ ] lp-3
- [ ] lp-4
- [ ] lp-5
- [ ] lp-6
- [ ] lp-7
- [ ] lp-8
- [ ] lp-9
- [ ] lp-10
- [ ] lp-11

Other objects like circuits will be sorted as well.