### PR TITLE
Clarify description for nibe-s-series

### DIFF
--- a/templates/definition/charger/nibe-s-series.yaml
+++ b/templates/definition/charger/nibe-s-series.yaml
@@ -7,7 +7,7 @@ group: heating
 requirements:
   description:
     de: |
-      Modbus Verbindung zur NIBE S Wärmepumpe. 
+      Modbus Verbindung zur NIBE S Wärmepumpe.
       Firmware 4.7.5 oder neuer benötigt.
       Benötigte Einstellung in der Steuereinheit:
       - In der Inneneinheit muss im Menü 7.5.9 Modbus aktiviert sein.

--- a/templates/definition/charger/nibe-s-series.yaml
+++ b/templates/definition/charger/nibe-s-series.yaml
@@ -9,7 +9,8 @@ requirements:
     de: |
       Modbus Verbindung zur NIBE S Wärmepumpe. Firmware 4.7.5 oder neuer benötigt.
       In der Inneneinheit muss im Menü 7.5.9 Modbus aktiviert sein.
-      Zur Verwendung der Leistungssteuerung muss im Menü 7.4 unter dem Punkt AUX von Modbus ext. Leistungsbegrenzung ausgewählt sein.
+      Zur Verwendung der Leistungssteuerung muss im Menü 7.4 unter dem Punkt AUX von Modbus ext. Leistungsbegrenzung ausgewählt sein. In den Ladepunkteinstellungen muss eine minimale Leistung von 1,2kW eingestellt werden. Sollte der Normalverbrauch höher sein, muss dieser als minimale Leistung eingestellt werden.
+      Im Menü 7.4 dürfen die Optionen SG-Ready A und SG-Ready B nicht vergeben sein.
       Es muss einmalig im Holding Register 3032 der Wert `1` (uint8) geschrieben werden.
     en: |
       Modbus connection to the NIBE S heat pump.

--- a/templates/definition/charger/nibe-s-series.yaml
+++ b/templates/definition/charger/nibe-s-series.yaml
@@ -9,7 +9,7 @@ requirements:
     de: |
       Modbus Verbindung zur NIBE S Wärmepumpe.
       Firmware 4.7.5 oder neuer benötigt.
-      Benötigte Einstellung in der Steuereinheit:
+      Benötigte Einstellungen in der Steuereinheit:
       - In der Inneneinheit muss im Menü 7.5.9 Modbus aktiviert sein.
       - Zur Verwendung der Leistungssteuerung muss im Menü 7.4 unter dem Punkt AUX von Modbus ext. Leistungsbegrenzung ausgewählt sein. In den Ladepunkteinstellungen muss eine minimale Leistung von 1,2kW (1-phasig) eingestellt werden. Sollte der Normalverbrauch höher sein, muss dieser als minimale Leistung eingestellt werden.
       - Im Menü 7.4 dürfen die Optionen SG-Ready A und SG-Ready B nicht vergeben sein.
@@ -17,7 +17,7 @@ requirements:
     en: |
       Modbus connection to the NIBE S heat pump.
       Firmware version 4.7.5 or newer is required.
-      Required setting in the control unit:
+      Required settings in the control unit:
       - In the indoor unit, Modbus must be enabled in menu 7.5.9
       - To use power control, “external power limitation via Modbus” must be selected under AUX in menu 7.4. In the charging point settings, a minimum power of 1.2 kW (single-phase) must be configured. If the base load is higher, it must be set as the minimum power.
       - In menu 7.4, the options “SG-Ready A” and “SG-Ready B” must not be assigned.

--- a/templates/definition/charger/nibe-s-series.yaml
+++ b/templates/definition/charger/nibe-s-series.yaml
@@ -7,17 +7,21 @@ group: heating
 requirements:
   description:
     de: |
-      Modbus Verbindung zur NIBE S Wärmepumpe. Firmware 4.7.5 oder neuer benötigt.
-      In der Inneneinheit muss im Menü 7.5.9 Modbus aktiviert sein.
-      Zur Verwendung der Leistungssteuerung muss im Menü 7.4 unter dem Punkt AUX von Modbus ext. Leistungsbegrenzung ausgewählt sein. In den Ladepunkteinstellungen muss eine minimale Leistung von 1,2kW eingestellt werden. Sollte der Normalverbrauch höher sein, muss dieser als minimale Leistung eingestellt werden.
-      Im Menü 7.4 dürfen die Optionen SG-Ready A und SG-Ready B nicht vergeben sein.
-      Es muss einmalig im Holding Register 3032 der Wert `1` (uint8) geschrieben werden.
+      Modbus Verbindung zur NIBE S Wärmepumpe. 
+      Firmware 4.7.5 oder neuer benötigt.
+      Benötigte Einstellung in der Steuereinheit:
+      - In der Inneneinheit muss im Menü 7.5.9 Modbus aktiviert sein.
+      - Zur Verwendung der Leistungssteuerung muss im Menü 7.4 unter dem Punkt AUX von Modbus ext. Leistungsbegrenzung ausgewählt sein. In den Ladepunkteinstellungen muss eine minimale Leistung von 1,2kW (1-phasig) eingestellt werden. Sollte der Normalverbrauch höher sein, muss dieser als minimale Leistung eingestellt werden.
+      - Im Menü 7.4 dürfen die Optionen SG-Ready A und SG-Ready B nicht vergeben sein.
+      - Es muss einmalig im Holding Register 3032 der Wert `1` (uint8) geschrieben werden.
     en: |
       Modbus connection to the NIBE S heat pump.
       Firmware version 4.7.5 or newer is required.
-      In the indoor unit, Modbus must be enabled in menu 7.5.9
-      To use the power control function, external power limitation must be selected under Menu 7.4, item AUX from modbus.
-      The value `1` (uint8) must be written once to holding register 3032.
+      Required setting in the control unit:
+      - In the indoor unit, Modbus must be enabled in menu 7.5.9
+      - To use power control, “external power limitation via Modbus” must be selected under AUX in menu 7.4. In the charging point settings, a minimum power of 1.2 kW (single-phase) must be configured. If the base load is higher, it must be set as the minimum power.
+      - In menu 7.4, the options “SG-Ready A” and “SG-Ready B” must not be assigned.
+      - The value `1` (uint8) must be written once to holding register 3032.
 params:
   - name: modbus
     choice: ["tcpip"]


### PR DESCRIPTION
in den aktuellen Firmwares wurde geändert, dass Hardwareeingänge nicht an die SG Schnittstelle gekoppelt werden dürfen. Andernfalls ist die Schnittstelle für Modbus gesperrt. U.a. dies wurde dokumentiert. 

Refs https://github.com/evcc-io/evcc/issues/28919#issuecomment-4286879361