### PR TITLE
fix: reload website when version changes

### DIFF
--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -66,6 +66,7 @@ export default defineComponent({
 			reconnectTimeout: null as number | null,
 			ws: null as WebSocket | null,
 			authNotConfigured: false,
+			currentVersion: undefined as string | undefined,
 		};
 	},
 	head() {
@@ -116,9 +117,13 @@ export default defineComponent({
 		},
 	},
 	watch: {
-		version(now, prev) {
-			if (prev !== undefined && now !== prev) {
-				console.log("new version detected. reloading browser", { now, prev });
+		version(now) {
+			if (now !== undefined && now !== this.currentVersion) {
+				console.log("new version detected. reloading browser", {
+					now,
+					prev: this.currentVersion,
+				});
+				this.currentVersion = now;
 				this.reload();
 			}
 		},

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -117,7 +117,7 @@ export default defineComponent({
 	},
 	watch: {
 		version(now, prev) {
-			if (!!prev && !!now) {
+			if (prev !== undefined && now !== prev) {
 				console.log("new version detected. reloading browser", { now, prev });
 				this.reload();
 			}

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -118,7 +118,14 @@ export default defineComponent({
 	},
 	watch: {
 		version(now) {
-			if (now !== undefined && now !== this.currentVersion) {
+			if (now === undefined) return;
+
+			if (this.currentVersion === undefined) {
+				this.currentVersion = now;
+				return;
+			}
+
+			if (now !== this.currentVersion) {
 				console.log("new version detected. reloading browser", {
 					now,
 					prev: this.currentVersion,

--- a/assets/js/views/App.vue
+++ b/assets/js/views/App.vue
@@ -118,9 +118,9 @@ export default defineComponent({
 	},
 	watch: {
 		version(now) {
-			if (now === undefined) return;
+			if (!now) return;
 
-			if (this.currentVersion === undefined) {
+			if (!this.currentVersion) {
 				this.currentVersion = now;
 				return;
 			}
@@ -130,7 +130,6 @@ export default defineComponent({
 					now,
 					prev: this.currentVersion,
 				});
-				this.currentVersion = now;
 				this.reload();
 			}
 		},


### PR DESCRIPTION
Fix #29238
Ref https://github.com/evcc-io/evcc/issues/29238#issuecomment-4282820566

Fixes this bug:
```
> version: prev 0.0.0, now undefined
> version: prev undefined, now 1234
```