### PR TITLE
feat: user-selectable timezone for UI time display

### DIFF
--- a/assets/js/components/ChargingPlans/ChargingPlan.vue
+++ b/assets/js/components/ChargingPlans/ChargingPlan.vue
@@ -249,6 +249,9 @@ export default defineComponent({
 				this.updateTargetTimeLabel();
 			},
 		},
+		timezone(): void {
+			this.updateTargetTimeLabel();
+		},
 	},
 	mounted(): void {
 		this.updateTargetTimeLabel();

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -148,7 +148,7 @@
 </template>
 
 <script lang="ts">
-import { distanceUnit } from "@/units";
+import { distanceUnit, parseLocalTimeInTz } from "@/units";
 
 import formatter from "@/mixins/formatter";
 import { energyOptions } from "@/utils/energyOptions.ts";
@@ -183,7 +183,13 @@ export default defineComponent({
 	},
 	computed: {
 		selectedDate() {
-			return new Date(`${this.selectedDay}T${this.selectedTime || "00:00"}`);
+			const dateTimeStr = `${this.selectedDay}T${this.selectedTime || "00:00"}`;
+			const tz = this.timezone;
+			const browserTz = Intl?.DateTimeFormat?.().resolvedOptions?.().timeZone || "UTC";
+			if (tz === browserTz) {
+				return new Date(dateTimeStr);
+			}
+			return parseLocalTimeInTz(dateTimeStr, tz);
 		},
 		socOptions() {
 			// a list of entries from 5 to 100 with a step of 5
@@ -298,13 +304,16 @@ export default defineComponent({
 				this.$t("main.targetCharge.today"),
 				this.$t("main.targetCharge.tomorrow"),
 			];
+			const tz = this.timezone;
 			for (let i = 0; i < 7; i++) {
 				const dayNumber = date.toLocaleDateString(this.$i18n?.locale, {
 					day: "numeric",
 					month: "short",
+					timeZone: tz,
 				});
 				const dayName =
-					labels[i] || date.toLocaleDateString(this.$i18n?.locale, { weekday: "short" });
+					labels[i] ||
+					date.toLocaleDateString(this.$i18n?.locale, { weekday: "short", timeZone: tz });
 				options.push({
 					value: this.fmtDayString(date),
 					name: `${dayNumber} (${dayName})`,

--- a/assets/js/components/ChargingPlans/PlansRepeatingSettings.vue
+++ b/assets/js/components/ChargingPlans/PlansRepeatingSettings.vue
@@ -63,7 +63,7 @@ export default defineComponent({
 				time: DEFAULT_TARGET_TIME,
 				soc: DEFAULT_TARGET_SOC,
 				active: false,
-				tz: this.timezone(),
+				tz: this.timezone,
 			};
 
 			// update the plan without storing non-applied changes from other plans

--- a/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
+++ b/assets/js/components/GlobalSettings/UserInterfaceSettings.vue
@@ -59,6 +59,23 @@
 				equal-width
 			/>
 		</FormRow>
+		<FormRow id="settingsTimezone" :label="$t('settings.timezone.label')">
+			<select
+				id="settingsTimezone"
+				v-model="timezone"
+				class="form-select form-select-sm w-75"
+			>
+				<option value="">
+					{{ browserTimezone }} ({{ $t("settings.timezone.browser") }})
+				</option>
+				<option value="server">
+					{{ serverTimezone }} ({{ $t("settings.timezone.server") }})
+				</option>
+				<optgroup :label="$t('settings.timezone.custom')">
+					<option v-for="tz in allTimezones" :key="tz" :value="tz">{{ tz }}</option>
+				</optgroup>
+			</select>
+		</FormRow>
 		<FormRow v-if="loadpoints.length" :label="$t('settings.loadpoints.label')">
 			<LoadpointOrderSettings :loadpoints="loadpoints" />
 		</FormRow>
@@ -91,7 +108,8 @@ import {
 	removeLocalePreference,
 } from "@/i18n.ts";
 import { getThemePreference, setThemePreference } from "@/theme.ts";
-import { getUnits, setUnits, is12hFormat, set12hFormat } from "@/units";
+import { getUnits, setUnits, is12hFormat, set12hFormat, getTimezone, setTimezone } from "@/units";
+import store from "@/store";
 import { isApp } from "@/utils/native";
 import { defineComponent, type PropType } from "vue";
 import { LENGTH_UNIT, THEME, type UiLoadpoint } from "@/types/evcc";
@@ -111,6 +129,7 @@ export default defineComponent({
 			language: getLocalePreference() || "",
 			unit: getUnits(),
 			timeFormat: is12hFormat() ? TIME_12H : TIME_24H,
+			timezone: getTimezone(),
 			fullscreenActive: false,
 			THEMES: Object.values(THEME),
 			UNITS: Object.values(LENGTH_UNIT),
@@ -118,6 +137,19 @@ export default defineComponent({
 		};
 	},
 	computed: {
+		browserTimezone(): string {
+			return Intl?.DateTimeFormat?.().resolvedOptions?.().timeZone || "UTC";
+		},
+		serverTimezone(): string {
+			return store.state.timezone || "UTC";
+		},
+		allTimezones(): string[] {
+			try {
+				return Intl.supportedValuesOf("timeZone");
+			} catch {
+				return [];
+			}
+		},
 		languageOptions: () => {
 			const locales = Object.entries(LOCALES).map(([key, value]) => {
 				return { value: key, name: value[1] };
@@ -140,6 +172,9 @@ export default defineComponent({
 		},
 		timeFormat(value) {
 			set12hFormat(value === TIME_12H);
+		},
+		timezone(value: string) {
+			setTimezone(value);
 		},
 		theme(value) {
 			setThemePreference(value);

--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -1,6 +1,24 @@
 import { defineComponent } from "vue";
-import { is12hFormat } from "@/units";
+import { is12hFormat, resolveTimezone } from "@/units";
 import { CURRENCY } from "../types/evcc";
+import store from "@/store";
+import settings from "@/settings";
+
+// Returns a getter function for a specific part type from formatToParts output.
+function formatPartsInTz(date: Date, timeZone: string, options: Intl.DateTimeFormatOptions) {
+  const parts = new Intl.DateTimeFormat("en-CA", { timeZone, ...options }).formatToParts(date);
+  return (type: string, fallback = "00") => parts.find((p) => p.type === type)?.value ?? fallback;
+}
+
+// Formats a date with the given locale, timezone, and options.
+function formatInTz(
+  locale: string | undefined,
+  timeZone: string,
+  options: Intl.DateTimeFormatOptions,
+  date: Date
+) {
+  return new Intl.DateTimeFormat(locale, { ...options, timeZone }).format(date);
+}
 
 const CURRENCY_SYMBOLS: Record<CURRENCY, string> = {
   AUD: "$",
@@ -55,6 +73,11 @@ export default defineComponent({
       fmtLimit: 100,
       fmtDigits: 1,
     };
+  },
+  computed: {
+    timezone(): string {
+      return resolveTimezone(settings.timezone, store.state.timezone);
+    },
   },
   methods: {
     energyPriceSubunit(currency: CURRENCY): string | undefined {
@@ -185,81 +208,90 @@ export default defineComponent({
       return new Intl.DurationFormat(this.$i18n?.locale, { style: "long" }).format(parts);
     },
     fmtDayString(date: Date) {
-      const YY = `${date.getFullYear()}`;
-      const MM = `${date.getMonth() + 1}`.padStart(2, "0");
-      const DD = `${date.getDate()}`.padStart(2, "0");
-      return `${YY}-${MM}-${DD}`;
+      const get = formatPartsInTz(date, this.timezone, {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
+      return `${get("year")}-${get("month")}-${get("day")}`;
     },
     fmtTimeString(date: Date) {
-      const HH = `${date.getHours()}`.padStart(2, "0");
-      const mm = `${date.getMinutes()}`.padStart(2, "0");
-      return `${HH}:${mm}`;
+      const get = formatPartsInTz(date, this.timezone, {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
+      return `${get("hour").replace("24", "00")}:${get("minute")}`;
     },
     isToday(date: Date) {
-      const today = new Date();
-      return today.toDateString() === date.toDateString();
+      const fmt = (d: Date) =>
+        formatInTz(
+          "en-CA",
+          this.timezone,
+          { year: "numeric", month: "2-digit", day: "2-digit" },
+          d
+        );
+      return fmt(date) === fmt(new Date());
     },
     weekdayPrefix(date: Date) {
-      if (this.isToday(date)) {
-        return "";
-      }
-      return new Intl.DateTimeFormat(this.$i18n?.locale, {
-        weekday: "short",
-      }).format(date);
+      if (this.isToday(date)) return "";
+      return formatInTz(this.$i18n?.locale, this.timezone, { weekday: "short" }, date);
     },
     hourShort(date: Date) {
       const locale = this.$i18n?.locale;
-      // special: use shorter german format
-      if (locale === "de") return date.getHours();
-      return new Intl.DateTimeFormat(locale, {
-        hour: "numeric",
-        hour12: is12hFormat(),
-      }).format(date);
+      const tz = this.timezone;
+      // special: use shorter german format (numeric hour without AM/PM)
+      if (locale === "de") {
+        return Number(formatPartsInTz(date, tz, { hour: "numeric", hour12: false })("hour", "0"));
+      }
+      return formatInTz(locale, tz, { hour: "numeric", hour12: is12hFormat() }, date);
     },
     weekdayShort(date: Date) {
-      return new Intl.DateTimeFormat(this.$i18n?.locale, {
-        weekday: "short",
-      }).format(date);
+      return formatInTz(this.$i18n?.locale, this.timezone, { weekday: "short" }, date);
     },
     weekdayLong(date: Date) {
-      return new Intl.DateTimeFormat(this.$i18n?.locale, {
-        weekday: "long",
-      }).format(date);
+      return formatInTz(this.$i18n?.locale, this.timezone, { weekday: "long" }, date);
     },
     fmtAbsoluteDate(date: Date) {
       const weekday = this.weekdayPrefix(date);
-      const hour = new Intl.DateTimeFormat(this.$i18n?.locale, {
-        hour: "numeric",
-        minute: "numeric",
-        hour12: is12hFormat(),
-      }).format(date);
-
+      const hour = formatInTz(
+        this.$i18n?.locale,
+        this.timezone,
+        { hour: "numeric", minute: "numeric", hour12: is12hFormat() },
+        date
+      );
       return `${weekday} ${hour}`.trim();
     },
     fmtHourMinute(date: Date) {
-      return new Intl.DateTimeFormat(this.$i18n?.locale, {
-        hour: "numeric",
-        minute: "numeric",
-        hour12: is12hFormat(),
-      }).format(date);
+      return formatInTz(
+        this.$i18n?.locale,
+        this.timezone,
+        { hour: "numeric", minute: "numeric", hour12: is12hFormat() },
+        date
+      );
     },
     fmtFullDateTime(date: Date, short: boolean) {
-      return new Intl.DateTimeFormat(this.$i18n?.locale, {
-        weekday: short ? undefined : "short",
-        month: short ? "numeric" : "short",
-        day: "numeric",
-        hour: "numeric",
-        minute: "numeric",
-        hour12: is12hFormat(),
-      }).format(date);
+      return formatInTz(
+        this.$i18n?.locale,
+        this.timezone,
+        {
+          weekday: short ? undefined : "short",
+          month: short ? "numeric" : "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          hour12: is12hFormat(),
+        },
+        date
+      );
     },
     fmtWeekdayTime(date: Date) {
-      return new Intl.DateTimeFormat(this.$i18n?.locale, {
-        weekday: "short",
-        hour: "numeric",
-        minute: "numeric",
-        hour12: is12hFormat(),
-      }).format(date);
+      return formatInTz(
+        this.$i18n?.locale,
+        this.timezone,
+        { weekday: "short", hour: "numeric", minute: "numeric", hour12: is12hFormat() },
+        date
+      );
     },
     fmtMonthYear(date: Date) {
       return new Intl.DateTimeFormat(this.$i18n?.locale, {
@@ -323,9 +355,6 @@ export default defineComponent({
         return `${price} ${this.pricePerKWhUnit(currency, short)}`;
       }
       return price;
-    },
-    timezone() {
-      return Intl?.DateTimeFormat?.().resolvedOptions?.().timeZone || "UTC";
     },
     pricePerKWhUnit(currency = CURRENCY.EUR, short = false) {
       const unit = this.energyPriceSubunit(currency) || CURRENCY_SYMBOLS[currency] || currency;

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -23,6 +23,7 @@ const SETTINGS_SOLAR_ADJUSTED = "settings_solar_adjusted";
 const SETTINGS_PRICE_ZOOM = "settings_price_zoom";
 const SETTINGS_HIDE_FEEDIN = "settings_hide_feedin";
 const LAST_BATTERY_SMART_COST_LIMIT = "last_battery_smart_cost_limit";
+const SETTINGS_TIMEZONE = "settings_timezone";
 const LAST_TARGET_TIME = "last_target_time";
 const LAST_SOC_GOAL = "last_soc_goal";
 const LAST_ENERGY_GOAL = "last_energy_goal";
@@ -111,6 +112,7 @@ export interface Settings {
   theme: THEME | null;
   unit: string;
   is12hFormat: boolean;
+  timezone: string; // "" = browser, "server" = server IANA, or explicit IANA name
   energyflowDetails: boolean;
   energyflowCo2: boolean;
   energyflowPv: boolean;
@@ -139,6 +141,7 @@ const settings: Settings = reactive({
   theme: read(SETTINGS_THEME),
   unit: read(SETTINGS_UNIT),
   is12hFormat: readBool(SETTINGS_12H_FORMAT),
+  timezone: read(SETTINGS_TIMEZONE) || "",
   energyflowDetails: readBool(SETTINGS_ENERGYFLOW_DETAILS),
   energyflowCo2: readBool(SETTINGS_ENERGYFLOW_CO2),
   energyflowPv: readBool(SETTINGS_ENERGYFLOW_PV),
@@ -166,6 +169,7 @@ watch(() => settings.locale, save(SETTINGS_LOCALE));
 watch(() => settings.theme, save(SETTINGS_THEME));
 watch(() => settings.unit, save(SETTINGS_UNIT));
 watch(() => settings.is12hFormat, saveBool(SETTINGS_12H_FORMAT));
+watch(() => settings.timezone, save(SETTINGS_TIMEZONE));
 watch(() => settings.energyflowDetails, saveBool(SETTINGS_ENERGYFLOW_DETAILS));
 watch(() => settings.energyflowCo2, saveBool(SETTINGS_ENERGYFLOW_CO2));
 watch(() => settings.energyflowPv, saveBool(SETTINGS_ENERGYFLOW_PV));

--- a/assets/js/units.ts
+++ b/assets/js/units.ts
@@ -30,3 +30,59 @@ export function is12hFormat() {
 export function set12hFormat(value: boolean) {
   settings.is12hFormat = value;
 }
+
+export function getTimezone() {
+  return settings.timezone || "";
+}
+
+export function setTimezone(value: string) {
+  settings.timezone = value;
+}
+
+// resolveTimezone returns the effective IANA timezone string given the user
+// preference and the server-reported timezone.  Centralising this policy here
+// keeps formatter.ts focused on display logic and makes the rules easy to test.
+export function resolveTimezone(
+  userPref: string | undefined,
+  serverTz: string | undefined
+): string {
+  const pref = userPref || "";
+  const browserTz = Intl?.DateTimeFormat?.().resolvedOptions?.().timeZone || "UTC";
+  if (!pref) return browserTz;
+  if (pref === "server") return serverTz || browserTz;
+  return pref;
+}
+
+// Parse "YYYY-MM-DDTHH:mm" as a local time in the given IANA timezone,
+// returning the corresponding UTC Date.
+//
+// DST note: this implementation uses an Intl round-trip to find the UTC offset
+// for the given wall-clock time.  Around DST transitions, a local time that is
+// skipped (spring-forward gap) will be resolved to the post-transition offset,
+// and an ambiguous time (fall-back overlap) will be resolved to the
+// pre-transition (summer) offset — consistent with most calendar UIs.
+export function parseLocalTimeInTz(dateTimeStr: string, tz: string): Date {
+  // Parse the string as if it were UTC to get a reference point
+  const naiveUTC = new Date(dateTimeStr + "Z");
+
+  // Find what the target timezone says for this UTC moment
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(naiveUTC);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "00";
+  const h = get("hour").replace("24", "00");
+  const tzDate = new Date(
+    `${get("year")}-${get("month")}-${get("day")}T${h}:${get("minute")}:${get("second")}Z`
+  );
+
+  // The offset between the target timezone's local time and UTC
+  const offsetMs = naiveUTC.getTime() - tzDate.getTime();
+  return new Date(naiveUTC.getTime() + offsetMs);
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -165,6 +165,28 @@ func awaitShutdown(cmd *cobra.Command, args []string) {
 	<-shutdownDoneC()
 }
 
+// localIANATimezone returns the local timezone as an IANA name (e.g. "Europe/Berlin").
+// Go's time.Local.String() returns "Local" on many systems; this function resolves
+// the real name via the TZ env var or the /etc/localtime symlink as fallbacks.
+func localIANATimezone() string {
+	name := time.Now().Location().String()
+	if name != "Local" {
+		return name
+	}
+	if tz := os.Getenv("TZ"); tz != "" {
+		return tz
+	}
+	if link, err := os.Readlink("/etc/localtime"); err == nil {
+		const prefix = "zoneinfo/"
+		if i := strings.LastIndex(link, prefix); i >= 0 {
+			return link[i+len(prefix):]
+		}
+	}
+	// Cannot determine a real IANA name; fall back to UTC so the frontend
+	// always receives a valid timezone identifier.
+	return "UTC"
+}
+
 func runRoot(cmd *cobra.Command, args []string) {
 	runAsService = true
 
@@ -402,7 +424,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	valueChan <- util.Param{Key: keys.Config, Val: viper.ConfigFileUsed()}
 	valueChan <- util.Param{Key: keys.Database, Val: db.FilePath}
 	valueChan <- util.Param{Key: keys.System, Val: util.System()}
-	valueChan <- util.Param{Key: keys.Timezone, Val: time.Now().Format("MST -07:00")}
+	valueChan <- util.Param{Key: keys.Timezone, Val: localIANATimezone()}
 	valueChan <- util.Param{Key: keys.Experimental, Val: isExperimental()}
 	valueChan <- util.Param{Key: keys.Optimizer, Val: isOptimizer()}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1506,6 +1506,12 @@
       "24h": "24h",
       "label": "Time format"
     },
+    "timezone": {
+      "browser": "Browser",
+      "custom": "Custom",
+      "label": "Timezone",
+      "server": "Server"
+    },
     "title": "User Interface",
     "unit": {
       "km": "km",


### PR DESCRIPTION
Add a timezone selector (browser / server / custom IANA) to User Interface settings. All time displays — dashboard plan status, charging plan modal, forecast chart — now render in the chosen timezone without requiring a page refresh.

- formatter: promote `timezone` to computed (reads reactive settings directly), add timeZone option to all Intl.DateTimeFormat calls, rewrite fmtDayString/fmtTimeString/isToday to use Intl
- ChargingPlan: watch `timezone` to refresh imperative targetTimeLabel
- PlanStaticSettings: parse user-entered time in selected timezone via parseLocalTimeInTz; timezone-aware dayOptions labels
- settings/units: persist timezone preference to localStorage
- cmd/root.go: broadcast real IANA timezone name instead of "MST -07:00"