### PR TITLE
Config UI: allow custom device type override

### DIFF
--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -99,6 +99,7 @@ func wrapFatalError(err error) error {
 
 // customDevice promotes yaml type to top level type
 func customDevice(typ string, other map[string]any) (string, map[string]any, error) {
+	// no embedded yaml
 	customYaml, ok := other["yaml"].(string)
 	if !ok {
 		return typ, other, nil
@@ -109,10 +110,13 @@ func customDevice(typ string, other map[string]any) (string, map[string]any, err
 		return typ, nil, err
 	}
 
+	// type override
 	if typ := cast.ToString(res["type"]); typ != "" {
 		delete(res, "type")
+		return typ, res, nil
 	}
 
+	// no override
 	return typ, res, nil
 }
 

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
+	"github.com/spf13/cast"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -96,15 +97,24 @@ func wrapFatalError(err error) error {
 	return &FatalError{err}
 }
 
-func customDevice(other map[string]any) (map[string]any, error) {
+// customDevice promotes yaml type to top level type
+func customDevice(typ string, other map[string]any) (string, map[string]any, error) {
 	customYaml, ok := other["yaml"].(string)
 	if !ok {
-		return other, nil
+		return typ, other, nil
 	}
 
 	var res map[string]any
-	err := yaml.Unmarshal([]byte(customYaml), &res)
-	return res, err
+	if err := yaml.Unmarshal([]byte(customYaml), &res); err != nil {
+		return typ, nil, err
+	}
+
+	if typ := cast.ToString(res["type"]); typ != "" {
+		delete(res, "type")
+		return typ, res, nil
+	}
+
+	return typ, other, nil
 }
 
 func deviceHeader[T any](dev config.Device[T]) string {

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -111,10 +111,9 @@ func customDevice(typ string, other map[string]any) (string, map[string]any, err
 
 	if typ := cast.ToString(res["type"]); typ != "" {
 		delete(res, "type")
-		return typ, res, nil
 	}
 
-	return typ, other, nil
+	return typ, res, nil
 }
 
 func deviceHeader[T any](dev config.Device[T]) string {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -222,14 +222,14 @@ NEXT:
 			}
 		}
 
-		props, err := customDevice(cc.Other)
+		typ, other, err := customDevice(cc.Type, cc.Other)
 		if err != nil {
 			return fmt.Errorf("cannot decode custom circuit '%s': %w", cc.Name, err)
 		}
 
 		ctx := util.WithLogger(context.TODO(), log)
 
-		instance, err := circuit.NewFromConfig(ctx, cc.Type, props)
+		instance, err := circuit.NewFromConfig(ctx, typ, other)
 		if err != nil {
 			return fmt.Errorf("cannot create circuit '%s': %w", cc.Name, err)
 		}
@@ -327,14 +327,14 @@ func configurableInstance[T any](typ string, conf *config.Config, newFromConf ne
 	cc := conf.Named()
 	ctx, cancel := context.WithCancel(util.WithLogger(context.TODO(), loggerForConfig(conf))) //nolint:govet
 
-	props, err := customDevice(cc.Other)
+	typ, other, err := customDevice(cc.Type, cc.Other)
 	if err != nil {
 		err = &DeviceError{cc.Name, fmt.Errorf("cannot decode custom %s '%s': %w", typ, cc.Name, err)}
 	}
 
 	var instance T
 	if err == nil {
-		instance, err = newFromConf(ctx, cc.Type, props)
+		instance, err = newFromConf(ctx, typ, other)
 		if err != nil {
 			err = &DeviceError{cc.Name, fmt.Errorf("cannot create %s '%s': %w", typ, cc.Name, err)}
 		}
@@ -443,11 +443,11 @@ func configureChargers(static []config.Named, names ...string) error {
 func vehicleInstance(cc config.Named) (api.Vehicle, error) {
 	ctx := util.WithLogger(context.TODO(), util.NewLogger(cc.Name))
 
-	props, err := customDevice(cc.Other)
+	typ, other, err := customDevice(cc.Type, cc.Other)
 
 	var instance api.Vehicle
 	if err == nil {
-		instance, err = vehicle.NewFromConfig(ctx, cc.Type, props)
+		instance, err = vehicle.NewFromConfig(ctx, typ, other)
 	}
 
 	if err != nil {
@@ -791,12 +791,12 @@ func configureHEMS(conf *globalconfig.Hems, site *core.Site) (hemsapi.API, error
 		return nil, nil
 	}
 
-	props, err := customDevice(conf.Other)
+	typ, other, err := customDevice(conf.Type, conf.Other)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode custom hems '%s': %w", conf.Type, err)
 	}
 
-	hems, err := hems.NewFromConfig(context.TODO(), conf.Type, props, site)
+	hems, err := hems.NewFromConfig(context.TODO(), typ, other, site)
 	if err != nil {
 		return nil, fmt.Errorf("failed configuring hems: %w", err)
 	}
@@ -968,12 +968,12 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 func tariffInstance(name string, conf config.Typed) (api.Tariff, error) {
 	ctx := util.WithLogger(context.TODO(), util.NewLogger(name))
 
-	props, err := customDevice(conf.Other)
+	typ, other, err := customDevice(conf.Type, conf.Other)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode custom tariff '%s': %w", name, err)
 	}
 
-	instance, err := tariff.NewFromConfig(ctx, conf.Type, props)
+	instance, err := tariff.NewFromConfig(ctx, typ, other)
 	if err != nil {
 		if _, ok := errors.AsType[*util.ConfigError](err); ok {
 			return nil, err

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/samber/lo"
+	"github.com/spf13/cast"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -440,6 +441,7 @@ func (maskedTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Val
 	}
 }
 
+// decodeDeviceConfig extracts device configuration and yaml details plus type override
 func decodeDeviceConfig(r io.Reader) (configReq, error) {
 	var res configReq
 
@@ -463,6 +465,11 @@ func decodeDeviceConfig(r io.Reader) (configReq, error) {
 
 	if err := yaml.Unmarshal([]byte(res.Yaml), &res.Other); err != nil && err != io.EOF {
 		return configReq{}, err
+	}
+
+	if typ := cast.ToString(res.Other["type"]); typ != "" {
+		res.Type = typ
+		delete(res.Other, "type")
 	}
 
 	return res, nil

--- a/tests/config-custom-meter.spec.ts
+++ b/tests/config-custom-meter.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, restart, baseUrl } from "./evcc";
+import { startSimulator, stopSimulator, simulatorHost } from "./simulator";
+import { expectModalVisible, expectModalHidden, editorClear, editorPaste } from "./utils";
+
+test.use({ baseURL: baseUrl() });
+
+test.afterEach(async () => {
+  await stop();
+  await stopSimulator();
+});
+
+test.describe("custom meter type override", async () => {
+  test("user-defined grid meter with explicit shelly type", async ({ page }) => {
+    await startSimulator();
+    await start();
+
+    await page.goto("/#/config");
+
+    // add grid meter as user-defined device with explicit type: shelly
+    await page.getByRole("button", { name: "Add grid meter" }).click();
+    const meterModal = page.getByTestId("meter-modal");
+    await expectModalVisible(meterModal);
+    await meterModal.getByLabel("Manufacturer").selectOption("User-defined device");
+    await page.waitForLoadState("networkidle");
+
+    const editor = meterModal.getByTestId("yaml-editor");
+    await editorClear(editor, 20);
+    await editorPaste(
+      editor,
+      page,
+      `type: shelly
+uri: http://${simulatorHost()}`
+    );
+
+    // validate
+    const testResult = meterModal.getByTestId("test-result");
+    await expect(testResult).toContainText("Status: unknown");
+    await testResult.getByRole("link", { name: "validate" }).click();
+    await expect(testResult).toContainText("Status: successful");
+    await expect(testResult).toContainText(["Energy", "0.0 kWh"].join(""));
+
+    // save
+    await meterModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(meterModal);
+    await expect(page.getByTestId("grid")).toBeVisible();
+
+    // restart and verify no fatal error
+    await restart();
+    await page.reload();
+    await expect(page.getByTestId("fatal-error")).not.toBeVisible();
+    await expect(page.getByTestId("grid")).toBeVisible();
+    await expect(page.getByTestId("grid")).toContainText(["Energy", "0.0 kWh"].join(""));
+  });
+});

--- a/tests/config-fatals.spec.ts
+++ b/tests/config-fatals.spec.ts
@@ -83,7 +83,7 @@ test.describe("fatal config handling", async () => {
     // verify loadpoint still visible with error
     await expect(page.getByTestId("fatal-error")).toBeVisible();
     await expect(page.getByTestId("fatal-error")).toContainText(
-      /meter: .+? cannot create meter .+?: cannot create meter type 'template:shelly-1pm': cannot create meter type 'shelly'/
+      /meter: .+? cannot create template .+?: cannot create meter type 'template:shelly-1pm': cannot create meter type 'shelly'/
     );
     await expect(page.getByTestId("fatal-error")).toContainText(
       /loadpoint: .+? missing charge meter instance/


### PR DESCRIPTION
This PR allows to create taylored custom devices overriding the hard-coded `custom` type:

```yaml
type: mbmd
uri: addr:502
rtu: true
model: sdm
power: Power
# energy: Import
currents:
  - CurrentL1
  - CurrentL2
  - CurrentL3
```