### PR TITLE
Easee: Use `OUTPUT_PHASE` for actual phase detection

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -800,9 +800,25 @@ func outputPhaseToPhases(outputPhase int) int {
 
 // clearOutputPhase invalidates the cached OUTPUT_PHASE state and advances its
 // observation timestamp so stale replay from a previous session gets ignored.
+// The fence must move forward even if the clearing event carries an old or
+// zero timestamp.
 func (c *Easee) clearOutputPhase(timestamp time.Time) {
 	c.outputPhase = 0
-	c.obsTime[easee.OUTPUT_PHASE] = timestamp
+
+	fence := timestamp
+	if fence.IsZero() {
+		fence = time.Now()
+	}
+
+	if prev, ok := c.obsTime[easee.OUTPUT_PHASE]; ok && !fence.After(prev) {
+		if now := time.Now(); now.After(prev) {
+			fence = now
+		} else {
+			fence = prev.Add(time.Nanosecond)
+		}
+	}
+
+	c.obsTime[easee.OUTPUT_PHASE] = fence
 }
 
 // outputPhases returns the current OUTPUT_PHASE-derived phase count if the

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -383,10 +383,21 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 		c.dynamicChargerCurrent = value.(float64)
 	case easee.CHARGER_OP_MODE:
 		opMode := value.(int)
+		prevOpMode := c.opMode
+
+		disconnected := opMode <= easee.ModeDisconnected
+		sessionStarted := prevOpMode <= easee.ModeDisconnected && opMode >= easee.ModeAwaitingStart
+
+		// OUTPUT_PHASE belongs to a specific charging session. Invalidate it
+		// both when the charger becomes disconnected/offline and when a new
+		// session starts, so replayed cloud state cannot leak across sessions.
+		if disconnected || sessionStarted {
+			c.clearOutputPhase(res.Timestamp)
+		}
 
 		// New charging session pending, reset internal value of SESSION_ENERGY to 0, and its observation timestamp to "now".
 		// This should be done in a proper way by the api, but it's not.
-		if c.opMode <= easee.ModeDisconnected && opMode >= easee.ModeAwaitingStart {
+		if sessionStarted {
 			c.sessionEnergy = 0
 			c.obsTime[easee.SESSION_ENERGY] = time.Now()
 		}
@@ -787,6 +798,25 @@ func outputPhaseToPhases(outputPhase int) int {
 	}
 }
 
+// clearOutputPhase invalidates the cached OUTPUT_PHASE state and advances its
+// observation timestamp so stale replay from a previous session gets ignored.
+func (c *Easee) clearOutputPhase(timestamp time.Time) {
+	c.outputPhase = 0
+	c.obsTime[easee.OUTPUT_PHASE] = timestamp
+}
+
+// outputPhases returns the current OUTPUT_PHASE-derived phase count if the
+// observation is fresh enough to trust. Replayed cloud state on reconnect can
+// otherwise describe an old charging session.
+func (c *Easee) outputPhases() int {
+	timestamp, ok := c.obsTime[easee.OUTPUT_PHASE]
+	if !ok || time.Since(timestamp) > observationTimeout {
+		return 0
+	}
+
+	return outputPhaseToPhases(c.outputPhase)
+}
+
 // GetPhases implements the api.PhaseGetter interface
 func (c *Easee) GetPhases() (int, error) {
 	c.mux.RLock()
@@ -795,7 +825,7 @@ func (c *Easee) GetPhases() (int, error) {
 	// Use OUTPUT_PHASE observation which reports the actual active output
 	// phase(s) to the EV, rather than configuration state like DCC limits
 	// or PhaseMode which may not reflect reality.
-	if phases := outputPhaseToPhases(c.outputPhase); phases > 0 {
+	if phases := c.outputPhases(); phases > 0 {
 		return phases, nil
 	}
 

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -65,6 +65,7 @@ type Easee struct {
 	pilotMode             string
 	reasonForNoCurrent    int
 	phaseMode             int
+	outputPhase           int
 	currentPower, sessionEnergy, totalEnergy,
 	currentL1, currentL2, currentL3 float64
 	rfid string
@@ -395,6 +396,8 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 		// startup completed
 		c.startDone()
 
+	case easee.OUTPUT_PHASE:
+		c.outputPhase = value.(int)
 	case easee.REASON_FOR_NO_CURRENT:
 		c.reasonForNoCurrent = value.(int)
 	case easee.PILOT_MODE:
@@ -768,10 +771,35 @@ func (c *Easee) Phases1p3p(phases int) error {
 
 var _ api.PhaseGetter = (*Easee)(nil)
 
+// outputPhaseToPhases converts the Easee OUTPUT_PHASE observation value
+// to the number of active phases. See the "output phase type table" in
+// the Easee API documentation.
+func outputPhaseToPhases(outputPhase int) int {
+	switch {
+	case outputPhase >= 30:
+		return 3
+	case outputPhase >= 20:
+		return 2
+	case outputPhase >= 10:
+		return 1
+	default:
+		return 0 // unassigned
+	}
+}
+
 // GetPhases implements the api.PhaseGetter interface
 func (c *Easee) GetPhases() (int, error) {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
+
+	// Use OUTPUT_PHASE observation which reports the actual active output
+	// phase(s) to the EV, rather than configuration state like DCC limits
+	// or PhaseMode which may not reflect reality.
+	if phases := outputPhaseToPhases(c.outputPhase); phases > 0 {
+		return phases, nil
+	}
+
+	// Fall back to configuration state when OUTPUT_PHASE is not yet available
 	var phases int
 	if c.circuit != 0 {
 		// circuit level controlled charger

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -425,6 +425,146 @@ func TestEasee_CommandResponse_matchedByID(t *testing.T) {
 	<-errCh
 }
 
+func TestOutputPhaseToPhases(t *testing.T) {
+	testCases := []struct {
+		outputPhase    int
+		expectedPhases int
+	}{
+		{0, 0},  // UNASSIGNED
+		{10, 1}, // P1_T2_T3_TN
+		{11, 1}, // P1_T2_T3_IT
+		{14, 1}, // P1_T2_T5_TN
+		{15, 1}, // P1_T3_T4_IT
+		{20, 2}, // P2_T2_T3_T4_TN
+		{21, 2}, // P2_T2_T4_T5_TN
+		{22, 2}, // P2_T2_T3_T4_IT
+		{30, 3}, // P3_T2_T3_T4_T5_TN
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("outputPhase_%d", tc.outputPhase), func(t *testing.T) {
+			assert.Equal(t, tc.expectedPhases, outputPhaseToPhases(tc.outputPhase))
+		})
+	}
+}
+
+func TestEasee_GetPhases(t *testing.T) {
+	testCases := []struct {
+		name           string
+		outputPhase    int
+		circuit        int
+		phaseMode      int
+		dcc            [3]float64
+		expectedPhases int
+	}{
+		// --- OUTPUT_PHASE available: takes precedence ---
+		{
+			name:           "OUTPUT_PHASE 1p overrides DCC all non-zero",
+			outputPhase:    10, // P1_T2_T3_TN
+			circuit:        1,
+			dcc:            [3]float64{16, 16, 16},
+			expectedPhases: 1,
+		},
+		{
+			name:           "OUTPUT_PHASE 3p",
+			outputPhase:    30, // P3_T2_T3_T4_T5_TN
+			circuit:        1,
+			dcc:            [3]float64{16, 0, 0},
+			expectedPhases: 3,
+		},
+		{
+			name:           "OUTPUT_PHASE 1p overrides PhaseMode auto",
+			outputPhase:    14, // P1_T2_T5_TN
+			circuit:        0,
+			phaseMode:      2, // auto
+			expectedPhases: 1,
+		},
+		{
+			name:           "OUTPUT_PHASE 2p",
+			outputPhase:    20, // P2_T2_T3_T4_TN
+			circuit:        1,
+			dcc:            [3]float64{16, 16, 16},
+			expectedPhases: 2,
+		},
+		// --- OUTPUT_PHASE unassigned: fallback to config ---
+		{
+			name:           "unassigned — DCC circuit path returns 3",
+			outputPhase:    0,
+			circuit:        1,
+			dcc:            [3]float64{16, 16, 16},
+			expectedPhases: 3,
+		},
+		{
+			name:           "unassigned — DCC 1p returns 1",
+			outputPhase:    0,
+			circuit:        1,
+			dcc:            [3]float64{16, 0, 0},
+			expectedPhases: 1,
+		},
+		{
+			name:           "unassigned — PhaseMode auto maps to 3",
+			outputPhase:    0,
+			circuit:        0,
+			phaseMode:      2, // auto
+			expectedPhases: 3,
+		},
+		{
+			name:           "unassigned — PhaseMode 1 returns 1",
+			outputPhase:    0,
+			circuit:        0,
+			phaseMode:      1,
+			expectedPhases: 1,
+		},
+		{
+			name:           "unassigned — PhaseMode 3 returns 3",
+			outputPhase:    0,
+			circuit:        0,
+			phaseMode:      3,
+			expectedPhases: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEasee()
+			e.outputPhase = tc.outputPhase
+			e.circuit = tc.circuit
+			e.phaseMode = tc.phaseMode
+			e.dynamicCircuitCurrent = tc.dcc
+
+			phases, err := e.GetPhases()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedPhases, phases)
+		})
+	}
+}
+
+func TestEasee_GetPhases_outputPhaseObservation(t *testing.T) {
+	e := newEasee()
+	e.circuit = 1
+	e.dynamicCircuitCurrent = [3]float64{16, 16, 16}
+
+	// Before OUTPUT_PHASE observation arrives, falls back to DCC
+	phases, err := e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, phases)
+
+	// Simulate receiving OUTPUT_PHASE observation for 1p charging
+	now := time.Now().UTC().Truncate(0)
+	e.ProductUpdate(createPayload(easee.OUTPUT_PHASE, now, easee.Integer, "10"))
+
+	phases, err = e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, phases, "OUTPUT_PHASE should override DCC-based detection")
+
+	// Simulate phase switch to 3p
+	e.ProductUpdate(createPayload(easee.OUTPUT_PHASE, now.Add(time.Second), easee.Integer, "30"))
+
+	phases, err = e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, phases)
+}
+
 func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
 	const siteID = 12345
 	const circuitID = 67890

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -450,41 +450,53 @@ func TestOutputPhaseToPhases(t *testing.T) {
 
 func TestEasee_GetPhases(t *testing.T) {
 	testCases := []struct {
-		name           string
-		outputPhase    int
-		circuit        int
-		phaseMode      int
-		dcc            [3]float64
-		expectedPhases int
+		name             string
+		outputPhase      int
+		freshOutputPhase bool
+		circuit          int
+		phaseMode        int
+		dcc              [3]float64
+		expectedPhases   int
 	}{
 		// --- OUTPUT_PHASE available: takes precedence ---
 		{
-			name:           "OUTPUT_PHASE 1p overrides DCC all non-zero",
-			outputPhase:    10, // P1_T2_T3_TN
-			circuit:        1,
-			dcc:            [3]float64{16, 16, 16},
-			expectedPhases: 1,
+			name:             "OUTPUT_PHASE 1p overrides DCC all non-zero",
+			outputPhase:      10, // P1_T2_T3_TN
+			freshOutputPhase: true,
+			circuit:          1,
+			dcc:              [3]float64{16, 16, 16},
+			expectedPhases:   1,
 		},
 		{
-			name:           "OUTPUT_PHASE 3p",
-			outputPhase:    30, // P3_T2_T3_T4_T5_TN
+			name:             "OUTPUT_PHASE 3p",
+			outputPhase:      30, // P3_T2_T3_T4_T5_TN
+			freshOutputPhase: true,
+			circuit:          1,
+			dcc:              [3]float64{16, 0, 0},
+			expectedPhases:   3,
+		},
+		{
+			name:             "OUTPUT_PHASE 1p overrides PhaseMode auto",
+			outputPhase:      14, // P1_T2_T5_TN
+			freshOutputPhase: true,
+			circuit:          0,
+			phaseMode:        2, // auto
+			expectedPhases:   1,
+		},
+		{
+			name:             "OUTPUT_PHASE 2p",
+			outputPhase:      20, // P2_T2_T3_T4_TN
+			freshOutputPhase: true,
+			circuit:          1,
+			dcc:              [3]float64{16, 16, 16},
+			expectedPhases:   2,
+		},
+		{
+			name:           "stale OUTPUT_PHASE falls back to DCC",
+			outputPhase:    10,
 			circuit:        1,
-			dcc:            [3]float64{16, 0, 0},
+			dcc:            [3]float64{16, 16, 16},
 			expectedPhases: 3,
-		},
-		{
-			name:           "OUTPUT_PHASE 1p overrides PhaseMode auto",
-			outputPhase:    14, // P1_T2_T5_TN
-			circuit:        0,
-			phaseMode:      2, // auto
-			expectedPhases: 1,
-		},
-		{
-			name:           "OUTPUT_PHASE 2p",
-			outputPhase:    20, // P2_T2_T3_T4_TN
-			circuit:        1,
-			dcc:            [3]float64{16, 16, 16},
-			expectedPhases: 2,
 		},
 		// --- OUTPUT_PHASE unassigned: fallback to config ---
 		{
@@ -528,6 +540,9 @@ func TestEasee_GetPhases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			e := newEasee()
 			e.outputPhase = tc.outputPhase
+			if tc.freshOutputPhase {
+				e.obsTime[easee.OUTPUT_PHASE] = time.Now()
+			}
 			e.circuit = tc.circuit
 			e.phaseMode = tc.phaseMode
 			e.dynamicCircuitCurrent = tc.dcc
@@ -563,6 +578,50 @@ func TestEasee_GetPhases_outputPhaseObservation(t *testing.T) {
 	phases, err = e.GetPhases()
 	assert.NoError(t, err)
 	assert.Equal(t, 3, phases)
+}
+
+func TestEasee_GetPhases_staleOutputPhaseFallsBack(t *testing.T) {
+	e := newEasee()
+	e.circuit = 1
+	e.dynamicCircuitCurrent = [3]float64{16, 16, 16}
+	e.outputPhase = 10
+	e.obsTime[easee.OUTPUT_PHASE] = time.Now().Add(-(observationTimeout + time.Minute))
+
+	phases, err := e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, phases)
+}
+
+func TestEasee_GetPhases_outputPhaseResetOnSessionStart(t *testing.T) {
+	e := newEasee()
+	e.circuit = 1
+	e.dynamicCircuitCurrent = [3]float64{16, 16, 16}
+	e.outputPhase = 10
+	e.obsTime[easee.OUTPUT_PHASE] = time.Now().UTC().Truncate(0)
+	e.opMode = easee.ModeDisconnected
+
+	now := time.Now().UTC().Truncate(0)
+
+	// Starting a new session must invalidate the previous session's OUTPUT_PHASE state.
+	e.ProductUpdate(createPayload(easee.CHARGER_OP_MODE, now, easee.Integer, "2"))
+
+	phases, err := e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, phases, "new session should not inherit previous OUTPUT_PHASE")
+
+	// A replay older than the session start must be ignored.
+	e.ProductUpdate(createPayload(easee.OUTPUT_PHASE, now.Add(-time.Second), easee.Integer, "10"))
+
+	phases, err = e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, phases, "stale OUTPUT_PHASE replay should be ignored after session reset")
+
+	// Fresh OUTPUT_PHASE from the current session should be used.
+	e.ProductUpdate(createPayload(easee.OUTPUT_PHASE, now.Add(time.Second), easee.Integer, "10"))
+
+	phases, err = e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, phases)
 }
 
 func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -624,6 +624,41 @@ func TestEasee_GetPhases_outputPhaseResetOnSessionStart(t *testing.T) {
 	assert.Equal(t, 1, phases)
 }
 
+func TestEasee_GetPhases_outputPhaseResetAdvancesFence(t *testing.T) {
+	e := newEasee()
+	e.circuit = 1
+	e.dynamicCircuitCurrent = [3]float64{16, 16, 16}
+	e.outputPhase = 10
+	e.opMode = easee.ModeDisconnected
+
+	previousOutputPhase := time.Now().UTC().Truncate(0)
+	e.obsTime[easee.OUTPUT_PHASE] = previousOutputPhase
+
+	// Use an older CHARGER_OP_MODE timestamp to simulate replay / out-of-order delivery.
+	e.ProductUpdate(createPayload(easee.CHARGER_OP_MODE, previousOutputPhase.Add(-time.Second), easee.Integer, "2"))
+
+	assert.True(t, e.obsTime[easee.OUTPUT_PHASE].After(previousOutputPhase), "session reset should advance the OUTPUT_PHASE fence")
+
+	// The stale OUTPUT_PHASE from the previous session must remain ignored.
+	e.ProductUpdate(createPayload(easee.OUTPUT_PHASE, previousOutputPhase, easee.Integer, "10"))
+
+	phases, err := e.GetPhases()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, phases)
+}
+
+func TestEasee_ClearOutputPhase_zeroTimestampUsesLocalFence(t *testing.T) {
+	e := newEasee()
+	previousOutputPhase := time.Now().UTC().Truncate(0)
+	e.outputPhase = 10
+	e.obsTime[easee.OUTPUT_PHASE] = previousOutputPhase
+
+	e.clearOutputPhase(time.Time{})
+
+	assert.Zero(t, e.outputPhase)
+	assert.True(t, e.obsTime[easee.OUTPUT_PHASE].After(previousOutputPhase), "zero timestamp should still advance the OUTPUT_PHASE fence")
+}
+
 func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
 	const siteID = 12345
 	const circuitID = 67890


### PR DESCRIPTION
## Summary

Use Easee's `OUTPUT_PHASE` observation as the primary source for `GetPhases()`.

## Problem

`GetPhases()` currently derives the phase count from configuration state:

- Circuit path: `dynamicCircuitCurrent`
- Charger path: `phaseMode`

On Easee, both can report `3p` even while the charger is physically charging on `1p`. That leaves evcc with a stale internal phase state (`lp.phases=3`), so the loadpoint never starts the `1p -> 3p` scale-up path although measured currents and available power clearly show a `1p` session.

In affected logs this often shows up as two phases carrying only a tiny residual current (for example `~0.01A`) while evcc still treats the charger as already being in `3p`. That small current is only a symptom of the mismatch, not the cause of it.

## Fix

- Consume the existing Easee `OUTPUT_PHASE` observation (ID `110`)
- Map the documented Easee output phase types to `1`, `2`, or `3` phases
- Make `GetPhases()` prefer `OUTPUT_PHASE`
- Keep the current `dynamicCircuitCurrent` / `phaseMode` logic as a fallback while `OUTPUT_PHASE` is still `UNASSIGNED` (`0`)
- Invalidate cached `OUTPUT_PHASE` state on disconnect / new session start and only trust fresh `OUTPUT_PHASE` observations, so stale cloud replay from an older session cannot leak into `GetPhases()`

## Why this approach

According to the Easee API docs:

- [Charger Observation Ids](https://developer.easee.com/docs/charger-observation-ids) documents observation `110 OUTPUT PHASE` as **"Active output phase(s) to EV according to output phase type table."**
- [Set Phase Mode](https://developer.easee.com/reference/charger_set_phase_mode) documents `phaseMode` as a charger setting/command, which is different from the actual active output phase reported by `OUTPUT_PHASE`
- [Current Limits and Control](https://developer.easee.com/docs/current-limits-and-control) documents dynamic circuit currents as current limits, not as the actual active output phase to the EV

That makes `OUTPUT_PHASE` the correct signal for `GetPhases()`, and it matches how other chargers in evcc expose actual switching/output state rather than inferred configuration state, for example:

- [Sungrow `GetPhases()`](https://github.com/evcc-io/evcc/blob/bd9f6901076a1c596e6c2a1c4b4f68cb0fe1f1ac/charger/sungrow.go#L275-L284)
- [Keba `getPhases()`](https://github.com/evcc-io/evcc/blob/bd9f6901076a1c596e6c2a1c4b4f68cb0fe1f1ac/charger/keba-modbus.go#L396-L405)
- [Alfen `getPhases()`](https://github.com/evcc-io/evcc/blob/bd9f6901076a1c596e6c2a1c4b4f68cb0fe1f1ac/charger/alfen.go#L269-L274)
- [WarpWS `getPhases()`](https://github.com/evcc-io/evcc/blob/bd9f6901076a1c596e6c2a1c4b4f68cb0fe1f1ac/charger/warp-ws.go#L430-L438)

This avoids heuristics based on measured current and avoids trusting configuration values that may not match the real charging state.

## Prior discussion

This change is based on earlier Easee discussions in:

- Issue #4116
- Issue #14387
- Issue #15061
- Issue #14996

Most importantly, in #4116 the maintainer explicitly suggested that evcc should adapt its internal phase state when Easee drops from `3p` to `1p` outside of evcc control. This PR implements that using Easee's documented `OUTPUT_PHASE` signal.

## Validation

- Added unit tests for `OUTPUT_PHASE` -> phase count mapping
- Added unit tests for `GetPhases()` precedence and fallback behavior
- Added a test covering transition from fallback state to `OUTPUT_PHASE`-driven state
- Added tests for stale `OUTPUT_PHASE` fallback and session-reset invalidation

I have been running this patch on my own Easee charger for a few weeks now, and it noticeably improved phase switching behavior in daily use.

## Scope

This PR only changes phase detection. It does not change phase switching commands or `phaseMode` semantics.
