### PR TITLE
Easee: call Enable(false) before circuit-level DCC current change

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -733,6 +733,13 @@ func (c *Easee) Phases1p3p(phases int) error {
 			data.DynamicCircuitCurrentP3 = &max3
 		}
 
+		// Car must stop charging during a phase transition; loadpoint will
+		// re-enable via syncCharger, same as the charger-level path below.
+		c.log.TRACE.Printf("phase switch (circuit-level): pausing charger before switching to %dp", phases)
+		if err := c.Enable(false); err != nil {
+			return err
+		}
+
 		// Register before POST so the SignalR CommandResponse that the Easee
 		// cloud sends on HTTP 200 (sync) responses is silently consumed rather
 		// than logged as rogue. On error we undo the registration.

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -434,6 +434,7 @@ func TestEasee_Phases1p3p_registersExpectedOrphan(t *testing.T) {
 	e.charger = chargerID
 	e.site = siteID
 	e.circuit = circuitID
+	e.opMode = easee.ModeDisconnected // Enable(false) is a no-op when disconnected
 
 	httpmock.ActivateNonDefault(e.Client)
 	defer httpmock.DeactivateAndReset()


### PR DESCRIPTION
The circuit-level path of `Phases1p3p` (`c.circuit != 0`) is missing `Enable(false)` before posting new DCC circuit settings. The charger-level path has called it since #8320.                                                                                                                                                       

`Enable(false)` pauses the charger and waits for the car to acknowledge 0 A before the phase switch is sent. This gives the car the CP handshake (State B → C) it needs to actually switch phases.

Without it, the Easee firmware will trigger the phase switch internally once DCC circuit conditions are met, but the timing is non-deterministic.

Loadpoint re-enables via `syncCharger` as before.