### PR TITLE
Easee: reconcile session energy from charger meter at disconnect

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,6 +26,12 @@ type PhaseCurrents interface {
 	Currents() (float64, float64, float64, error)
 }
 
+// SessionStartMeter is an optional interface for chargers that can provide
+// an authoritative meter reading at the start of a charge session.
+type SessionStartMeter interface {
+	SessionStartMeter() float64
+}
+
 // PhaseVoltages provides per-phase voltage V
 type PhaseVoltages interface {
 	Voltages() (float64, float64, float64, error)

--- a/api/api.go
+++ b/api/api.go
@@ -26,12 +26,6 @@ type PhaseCurrents interface {
 	Currents() (float64, float64, float64, error)
 }
 
-// SessionStartMeter is an optional interface for chargers that can provide
-// an authoritative meter reading at the start of a charge session.
-type SessionStartMeter interface {
-	SessionStartMeter() float64
-}
-
 // PhaseVoltages provides per-phase voltage V
 type PhaseVoltages interface {
 	Voltages() (float64, float64, float64, error)

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -67,10 +67,9 @@ type Easee struct {
 	phaseMode             int
 	currentPower, sessionEnergy, totalEnergy,
 	currentL1, currentL2, currentL3 float64
-	currentSessionID  int
-	sessionStartMeter float64
-	rfid              string
-	lp                loadpoint.API
+	currentSessionID int
+	rfid             string
+	lp               loadpoint.API
 
 	dispatcher *easee.CommandDispatcher
 
@@ -391,7 +390,6 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 			break
 		}
 		c.currentSessionID = data.ID
-		c.sessionStartMeter = data.MeterValue
 		if data.MeterValue >= c.totalEnergy {
 			c.totalEnergy = data.MeterValue
 		}
@@ -418,7 +416,6 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 		if c.opMode <= easee.ModeDisconnected && opMode >= easee.ModeAwaitingStart {
 			c.sessionEnergy = 0
 			c.currentSessionID = 0
-			c.sessionStartMeter = 0
 			c.obsTime[easee.SESSION_ENERGY] = time.Now()
 		}
 
@@ -718,15 +715,6 @@ func (c *Easee) Currents() (float64, float64, float64, error) {
 	}
 
 	return c.currentL1, c.currentL2, c.currentL3, nil
-}
-
-var _ api.SessionStartMeter = (*Easee)(nil)
-
-// SessionStartMeter implements the api.SessionStartMeter interface
-func (c *Easee) SessionStartMeter() float64 {
-	c.mux.RLock()
-	defer c.mux.RUnlock()
-	return c.sessionStartMeter
 }
 
 var _ api.MeterEnergy = (*Easee)(nil)

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -67,8 +67,10 @@ type Easee struct {
 	phaseMode             int
 	currentPower, sessionEnergy, totalEnergy,
 	currentL1, currentL2, currentL3 float64
-	rfid string
-	lp   loadpoint.API
+	currentSessionID  int
+	sessionStartMeter float64
+	rfid              string
+	lp                loadpoint.API
 
 	dispatcher *easee.CommandDispatcher
 
@@ -361,7 +363,9 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 			c.sessionEnergy = value.(float64)
 		}
 	case easee.LIFETIME_ENERGY:
-		c.totalEnergy = value.(float64)
+		if v := value.(float64); v >= c.totalEnergy {
+			c.totalEnergy = v
+		}
 	case easee.INT_CURRENT_T3:
 		c.currentL1 = value.(float64)
 	case easee.INT_CURRENT_T4:
@@ -380,6 +384,32 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 		c.maxChargerCurrent = value.(float64)
 	case easee.DYNAMIC_CHARGER_CURRENT:
 		c.dynamicChargerCurrent = value.(float64)
+	case easee.CHARGE_SESSION_START:
+		var data easee.ChargingSessionStartData
+		if err := json.Unmarshal([]byte(res.Value), &data); err != nil {
+			c.log.ERROR.Printf("CHARGE_SESSION_START: %v", err)
+			break
+		}
+		c.currentSessionID = data.ID
+		c.sessionStartMeter = data.MeterValue
+		if data.MeterValue >= c.totalEnergy {
+			c.totalEnergy = data.MeterValue
+		}
+
+	case easee.CHARGING_SESSION:
+		var data easee.ChargingSessionData
+		if err := json.Unmarshal([]byte(res.Value), &data); err != nil {
+			c.log.ERROR.Printf("CHARGING_SESSION: %v", err)
+			break
+		}
+		if data.MeterValueStop >= c.totalEnergy {
+			c.totalEnergy = data.MeterValueStop
+		}
+		if data.ID != c.currentSessionID {
+			break
+		}
+		c.sessionEnergy = data.EnergyKwh
+
 	case easee.CHARGER_OP_MODE:
 		opMode := value.(int)
 
@@ -387,6 +417,8 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 		// This should be done in a proper way by the api, but it's not.
 		if c.opMode <= easee.ModeDisconnected && opMode >= easee.ModeAwaitingStart {
 			c.sessionEnergy = 0
+			c.currentSessionID = 0
+			c.sessionStartMeter = 0
 			c.obsTime[easee.SESSION_ENERGY] = time.Now()
 		}
 
@@ -686,6 +718,15 @@ func (c *Easee) Currents() (float64, float64, float64, error) {
 	}
 
 	return c.currentL1, c.currentL2, c.currentL3, nil
+}
+
+var _ api.SessionStartMeter = (*Easee)(nil)
+
+// SessionStartMeter implements the api.SessionStartMeter interface
+func (c *Easee) SessionStartMeter() float64 {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return c.sessionStartMeter
 }
 
 var _ api.MeterEnergy = (*Easee)(nil)

--- a/charger/easee/signalr.go
+++ b/charger/easee/signalr.go
@@ -28,6 +28,25 @@ func (o *Observation) TypedValue() (any, error) {
 	}
 }
 
+type ChargingSessionStartData struct {
+	ID         int       `json:"Id"`
+	MeterValue float64   `json:"MeterValue"`
+	Start      time.Time `json:"Start"`
+	Auth       string    `json:"Auth"`
+	AuthReason int       `json:"AuthReason"`
+}
+
+type ChargingSessionData struct {
+	ID              int       `json:"Id"`
+	Start           time.Time `json:"Start"`
+	Stop            time.Time `json:"Stop"`
+	EnergyKwh       float64   `json:"EnergyKwh"`
+	MeterValueStart float64   `json:"MeterValueStart"`
+	MeterValueStop  float64   `json:"MeterValueStop"`
+	Auth            string    `json:"Auth"`
+	AuthReason      int       `json:"AuthReason"`
+}
+
 type SignalRCommandResponse struct {
 	SerialNumber string
 	ID           int

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -501,6 +501,109 @@ func TestLivenessCheck_freshObservations(t *testing.T) {
 	assert.Equal(t, float64(16), l3)
 }
 
+func TestChargeSessionStart_SetsFields(t *testing.T) {
+	e := newEasee()
+	e.totalEnergy = 9100.0
+
+	data := easee.ChargingSessionStartData{ID: 801, MeterValue: 9141.414622}
+	jsonData, _ := json.Marshal(data)
+	e.ProductUpdate(createPayload(easee.CHARGE_SESSION_START, time.Now(), easee.String, string(jsonData)))
+
+	assert.Equal(t, 801, e.currentSessionID)
+	assert.Equal(t, 9141.414622, e.sessionStartMeter)
+
+	assert.Equal(t, 9141.414622, e.SessionStartMeter())
+
+	total, err := e.TotalEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 9141.414622, total)
+}
+
+func TestChargingSession_UpdatesBothWhenIdMatches(t *testing.T) {
+	e := newEasee()
+	e.currentSessionID = 801
+	e.totalEnergy = 9100.0
+
+	data := easee.ChargingSessionData{ID: 801, EnergyKwh: 16.2, MeterValueStop: 9173.5}
+	jsonData, _ := json.Marshal(data)
+	e.ProductUpdate(createPayload(easee.CHARGING_SESSION, time.Now(), easee.String, string(jsonData)))
+
+	charged, err := e.ChargedEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 16.2, charged)
+
+	total, err := e.TotalEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 9173.5, total)
+}
+
+func TestChargingSession_MismatchedId_ProtectsSessionEnergy(t *testing.T) {
+	e := newEasee()
+	e.currentSessionID = 100
+	e.sessionEnergy = 5.0
+	e.totalEnergy = 9150.0
+
+	data := easee.ChargingSessionData{ID: 99, EnergyKwh: 7.5, MeterValueStop: 9173.5}
+	jsonData, _ := json.Marshal(data)
+	e.ProductUpdate(createPayload(easee.CHARGING_SESSION, time.Now(), easee.String, string(jsonData)))
+
+	charged, err := e.ChargedEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 5.0, charged) // sessionEnergy unchanged
+
+	total, err := e.TotalEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 9173.5, total) // totalEnergy updated
+}
+
+func TestChargingSession_AtStartup_ProtectsSessionEnergy(t *testing.T) {
+	e := newEasee()
+	// currentSessionId is 0 by default
+	e.sessionEnergy = 0
+	e.totalEnergy = 9150.0
+
+	data := easee.ChargingSessionData{ID: 803, EnergyKwh: 19.08, MeterValueStop: 9173.5}
+	jsonData, _ := json.Marshal(data)
+	e.ProductUpdate(createPayload(easee.CHARGING_SESSION, time.Now(), easee.String, string(jsonData)))
+
+	charged, err := e.ChargedEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, charged) // sessionEnergy protected (Id 803 != 0)
+
+	total, err := e.TotalEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 9173.5, total) // totalEnergy updated
+}
+
+func TestLifetimeEnergy_DoesNotDecreaseTotalEnergy(t *testing.T) {
+	e := newEasee()
+	e.totalEnergy = 9173.5
+
+	e.ProductUpdate(createPayload(easee.LIFETIME_ENERGY, time.Now(), easee.Double, "9170.0"))
+
+	total, err := e.TotalEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 9173.5, total)
+}
+
+func TestChargerOpMode_ConnectResetsSessionFields(t *testing.T) {
+	e := newEasee()
+	e.opMode = easee.ModeDisconnected
+	e.currentSessionID = 803
+	e.sessionStartMeter = 9157.3
+	e.sessionEnergy = 5.0
+
+	// Transition from disconnected to awaiting start
+	e.ProductUpdate(createPayload(easee.CHARGER_OP_MODE, time.Now(), easee.Integer, fmt.Sprintf("%d", easee.ModeAwaitingStart)))
+
+	assert.Equal(t, 0, e.currentSessionID)
+	assert.Equal(t, 0.0, e.SessionStartMeter())
+
+	charged, err := e.ChargedEnergy()
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, charged)
+}
+
 func TestIsTNGrid(t *testing.T) {
 	// TN grid types must return true
 	assert.True(t, isTNGrid(easee.PowerGridTN3Phase))

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -510,9 +510,6 @@ func TestChargeSessionStart_SetsFields(t *testing.T) {
 	e.ProductUpdate(createPayload(easee.CHARGE_SESSION_START, time.Now(), easee.String, string(jsonData)))
 
 	assert.Equal(t, 801, e.currentSessionID)
-	assert.Equal(t, 9141.414622, e.sessionStartMeter)
-
-	assert.Equal(t, 9141.414622, e.SessionStartMeter())
 
 	total, err := e.TotalEnergy()
 	assert.NoError(t, err)
@@ -590,14 +587,12 @@ func TestChargerOpMode_ConnectResetsSessionFields(t *testing.T) {
 	e := newEasee()
 	e.opMode = easee.ModeDisconnected
 	e.currentSessionID = 803
-	e.sessionStartMeter = 9157.3
 	e.sessionEnergy = 5.0
 
 	// Transition from disconnected to awaiting start
 	e.ProductUpdate(createPayload(easee.CHARGER_OP_MODE, time.Now(), easee.Integer, fmt.Sprintf("%d", easee.ModeAwaitingStart)))
 
 	assert.Equal(t, 0, e.currentSessionID)
-	assert.Equal(t, 0.0, e.SessionStartMeter())
 
 	charged, err := e.ChargedEnergy()
 	assert.NoError(t, err)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -546,6 +546,9 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 func (lp *Loadpoint) evVehicleDisconnectHandler() {
 	lp.log.INFO.Println("car disconnected")
 
+	// re-read energy from charger and re-persist session if values improved
+	lp.finalizeSessionEnergy()
+
 	// session is persisted during evChargeStopHandler which runs before
 	lp.clearSession()
 

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -64,6 +64,21 @@ func (lp *Loadpoint) createSession() {
 	lp.publish(keys.ChargedEnergy, lp.GetChargedEnergy())
 }
 
+// applyEnergyMetrics writes current energy metrics into the session and persists it.
+func (lp *Loadpoint) applyEnergyMetrics(s *session.Session) {
+	if meterStop := lp.chargeMeterTotal(); meterStop > 0 {
+		s.MeterStop = &meterStop
+	}
+
+	s.SolarPercentage = new(lp.energyMetrics.SolarPercentage())
+	s.Price = lp.energyMetrics.Price()
+	s.PricePerKWh = lp.energyMetrics.PricePerKWh()
+	s.Co2PerKWh = lp.energyMetrics.Co2PerKWh()
+	s.ChargedEnergy = lp.energyMetrics.TotalWh() / 1e3
+
+	lp.db.Persist(s)
+}
+
 // stopSession ends a charging session segment and persists the session.
 func (lp *Loadpoint) stopSession() {
 	s := lp.session
@@ -79,18 +94,9 @@ func (lp *Loadpoint) stopSession() {
 	}
 
 	s.Finished = lp.clock.Now()
-	if meterStop := lp.chargeMeterTotal(); meterStop > 0 {
-		s.MeterStop = &meterStop
-	}
-
-	s.SolarPercentage = new(lp.energyMetrics.SolarPercentage())
-	s.Price = lp.energyMetrics.Price()
-	s.PricePerKWh = lp.energyMetrics.PricePerKWh()
-	s.Co2PerKWh = lp.energyMetrics.Co2PerKWh()
-	s.ChargedEnergy = lp.energyMetrics.TotalWh() / 1e3
 	s.ChargeDuration = new(lp.chargeDuration.Abs())
 
-	lp.db.Persist(s)
+	lp.applyEnergyMetrics(s)
 }
 
 type sessionOption func(*session.Session)
@@ -119,6 +125,36 @@ func (lp *Loadpoint) clearSession() {
 	}
 
 	lp.session = nil
+}
+
+func (lp *Loadpoint) finalizeSessionEnergy() {
+	s := lp.session
+	if lp.db == nil || s == nil || s.Created.IsZero() {
+		return
+	}
+
+	f, err := lp.chargeRater.ChargedEnergy()
+	if err != nil {
+		return
+	}
+
+	chargedKWh := f - lp.chargedAtStartup
+	if chargedKWh <= s.ChargedEnergy {
+		lp.log.TRACE.Printf("session energy unchanged: %.3f <= %.3fkWh", chargedKWh, s.ChargedEnergy)
+		return
+	}
+
+	lp.log.DEBUG.Printf("session energy corrected: %.3f -> %.3fkWh", s.ChargedEnergy, chargedKWh)
+
+	lp.energyMetrics.Update(chargedKWh)
+
+	if sm, ok := api.Cap[api.SessionStartMeter](lp.chargeMeter); ok {
+		if meterStart := sm.SessionStartMeter(); meterStart > 0 && s.MeterStart != nil {
+			s.MeterStart = &meterStart
+		}
+	}
+
+	lp.applyEnergyMetrics(s)
 }
 
 func (lp *Loadpoint) resetHeatingSession() {

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -135,17 +135,16 @@ func (lp *Loadpoint) finalizeSessionEnergy() {
 
 	f, err := lp.chargeRater.ChargedEnergy()
 	if err != nil {
-		lp.log.DEBUG.Printf("session energy: %v", err)
+		lp.log.ERROR.Printf("session energy: %v", err)
 		return
 	}
 
 	chargedKWh := f - lp.chargedAtStartup
 	if chargedKWh <= s.ChargedEnergy {
-		lp.log.TRACE.Printf("session energy unchanged: %.3f <= %.3fkWh", chargedKWh, s.ChargedEnergy)
 		return
 	}
 
-	lp.log.DEBUG.Printf("session energy corrected: %.3f -> %.3fkWh", s.ChargedEnergy, chargedKWh)
+	lp.log.DEBUG.Printf("session energy: %.3f -> %.3fkWh", s.ChargedEnergy, chargedKWh)
 
 	lp.energyMetrics.Update(chargedKWh)
 

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -149,12 +149,6 @@ func (lp *Loadpoint) finalizeSessionEnergy() {
 
 	lp.energyMetrics.Update(chargedKWh)
 
-	if sm, ok := api.Cap[api.SessionStartMeter](lp.chargeMeter); ok {
-		if meterStart := sm.SessionStartMeter(); meterStart > 0 {
-			s.MeterStart = &meterStart
-		}
-	}
-
 	lp.applyEnergyMetrics(s)
 }
 

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -135,6 +135,7 @@ func (lp *Loadpoint) finalizeSessionEnergy() {
 
 	f, err := lp.chargeRater.ChargedEnergy()
 	if err != nil {
+		lp.log.DEBUG.Printf("session energy: %v", err)
 		return
 	}
 
@@ -149,7 +150,7 @@ func (lp *Loadpoint) finalizeSessionEnergy() {
 	lp.energyMetrics.Update(chargedKWh)
 
 	if sm, ok := api.Cap[api.SessionStartMeter](lp.chargeMeter); ok {
-		if meterStart := sm.SessionStartMeter(); meterStart > 0 && s.MeterStart != nil {
+		if meterStart := sm.SessionStartMeter(); meterStart > 0 {
 			s.MeterStart = &meterStart
 		}
 	}

--- a/core/loadpoint_session_test.go
+++ b/core/loadpoint_session_test.go
@@ -14,10 +14,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-type sessionStartMeterMock struct{ val float64 }
-
-func (m *sessionStartMeterMock) SessionStartMeter() float64 { return m.val }
-
 func sessionStart(lp *Loadpoint) func(session *session.Session) {
 	return func(session *session.Session) {
 		if session.Created.IsZero() {
@@ -264,12 +260,6 @@ func TestResetHeatingSession(t *testing.T) {
 }
 
 func TestFinalizeSessionEnergy(t *testing.T) {
-	type meterWithSSM struct {
-		api.Meter
-		api.MeterEnergy
-		*sessionStartMeterMock
-	}
-
 	setup := func(t *testing.T) (*Loadpoint, *api.MockMeterEnergy, *api.MockChargeRater) {
 		t.Helper()
 		var err error
@@ -283,10 +273,14 @@ func TestFinalizeSessionEnergy(t *testing.T) {
 		me := api.NewMockMeterEnergy(ctrl)
 		rater := api.NewMockChargeRater(ctrl)
 
-		cm := &meterWithSSM{
-			Meter:                 mm,
-			MeterEnergy:           me,
-			sessionStartMeterMock: &sessionStartMeterMock{val: 9157.3},
+		type EnergyDecorator struct {
+			api.Meter
+			api.MeterEnergy
+		}
+
+		cm := &EnergyDecorator{
+			Meter:       mm,
+			MeterEnergy: me,
 		}
 
 		lp := &Loadpoint{
@@ -302,7 +296,7 @@ func TestFinalizeSessionEnergy(t *testing.T) {
 	t.Run("corrects session when ChargedEnergy increased", func(t *testing.T) {
 		lp, me, rater := setup(t)
 
-		me.EXPECT().TotalEnergy().Return(9154.4, nil)
+		me.EXPECT().TotalEnergy().Return(9157.3, nil)
 		lp.createSession()
 		lp.session.Created = lp.clock.Now()
 

--- a/core/loadpoint_session_test.go
+++ b/core/loadpoint_session_test.go
@@ -14,6 +14,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+type sessionStartMeterMock struct{ val float64 }
+
+func (m *sessionStartMeterMock) SessionStartMeter() float64 { return m.val }
+
 func sessionStart(lp *Loadpoint) func(session *session.Session) {
 	return func(session *session.Session) {
 		if session.Created.IsZero() {
@@ -257,4 +261,91 @@ func TestResetHeatingSession(t *testing.T) {
 	assert.Equal(t, clock.Now(), lp.session.Finished)
 	assert.Equal(t, 1.0, *lp.session.MeterStart)
 	assert.Equal(t, 3.0, *lp.session.MeterStop)
+}
+
+func TestFinalizeSessionEnergy(t *testing.T) {
+	type meterWithSSM struct {
+		api.Meter
+		api.MeterEnergy
+		*sessionStartMeterMock
+	}
+
+	setup := func(t *testing.T) (*Loadpoint, *api.MockMeterEnergy, *api.MockChargeRater) {
+		t.Helper()
+		var err error
+		serverdb.Instance, err = serverdb.New("sqlite", ":memory:")
+		require.NoError(t, err)
+		db, err := session.NewStore("foo", serverdb.Instance)
+		require.NoError(t, err)
+
+		ctrl := gomock.NewController(t)
+		mm := api.NewMockMeter(ctrl)
+		me := api.NewMockMeterEnergy(ctrl)
+		rater := api.NewMockChargeRater(ctrl)
+
+		cm := &meterWithSSM{
+			Meter:                 mm,
+			MeterEnergy:           me,
+			sessionStartMeterMock: &sessionStartMeterMock{val: 9157.3},
+		}
+
+		lp := &Loadpoint{
+			log:         util.NewLogger("foo"),
+			clock:       clock.NewMock(),
+			db:          db,
+			chargeRater: rater,
+			chargeMeter: cm,
+		}
+		return lp, me, rater
+	}
+
+	t.Run("corrects session when ChargedEnergy increased", func(t *testing.T) {
+		lp, me, rater := setup(t)
+
+		me.EXPECT().TotalEnergy().Return(9154.4, nil)
+		lp.createSession()
+		lp.session.Created = lp.clock.Now()
+
+		lp.energyMetrics.Update(15.3)
+		me.EXPECT().TotalEnergy().Return(9164.0, nil)
+		lp.stopSession()
+		require.Equal(t, 15.3, lp.session.ChargedEnergy)
+
+		rater.EXPECT().ChargedEnergy().Return(16.2, nil)
+		me.EXPECT().TotalEnergy().Return(9173.5, nil)
+		lp.finalizeSessionEnergy()
+
+		assert.Equal(t, 16.2, lp.session.ChargedEnergy)
+		assert.Equal(t, 9173.5, *lp.session.MeterStop)
+		assert.Equal(t, 9157.3, *lp.session.MeterStart)
+	})
+
+	t.Run("no-op when ChargedEnergy unchanged", func(t *testing.T) {
+		lp, me, rater := setup(t)
+
+		me.EXPECT().TotalEnergy().Return(9154.4, nil)
+		lp.createSession()
+		lp.session.Created = lp.clock.Now()
+
+		lp.energyMetrics.Update(15.3)
+		me.EXPECT().TotalEnergy().Return(9164.0, nil)
+		lp.stopSession()
+		require.Equal(t, 15.3, lp.session.ChargedEnergy)
+
+		rater.EXPECT().ChargedEnergy().Return(15.3, nil)
+		lp.finalizeSessionEnergy()
+
+		assert.Equal(t, 15.3, lp.session.ChargedEnergy)
+		assert.Equal(t, 9164.0, *lp.session.MeterStop)
+	})
+
+	t.Run("no-op when session nil or uncreated", func(t *testing.T) {
+		lp, _, _ := setup(t)
+
+		lp.session = nil
+		assert.NotPanics(t, func() { lp.finalizeSessionEnergy() })
+
+		lp.session = &session.Session{}
+		assert.NotPanics(t, func() { lp.finalizeSessionEnergy() })
+	})
 }


### PR DESCRIPTION
## Summary

When a charging session ends, evcc's accumulated session energy can drift from the charger's authoritative meter readings. This is because evcc only samples `SESSION_ENERGY` on the polling interval, and the final observation may arrive before the charger has settled its internal accounting.

This PR adds a reconciliation step that runs at car disconnect: `finalizeSessionEnergy()` re-reads the charger's `ChargedEnergy` and, if it exceeds the previously persisted value, updates the session record with the corrected energy, meter start/stop, price, solar percentage, and CO2 metrics.

### Related issues

- #17644 — Meter display incorrect
- #7214 — Easee Home session transfer faulty
- #21734 — Solar percentage calculation wrong
- #7763 — Energy difference between Easee and evcc
- #14923 — Loadstatistic wrong calculated with Easee Wallbox
- #9884 — Session kWh incorrect

### Changes

- **`api.SessionStartMeter` interface** — optional capability for chargers that can provide an authoritative meter reading at the start of a session
- **Easee: parse `CHARGE_SESSION_START` / `CHARGING_SESSION` SignalR observations** — captures the charger's authoritative session ID, start meter value, session energy, and stop meter value
- **Easee: monotonicity guard on `totalEnergy`** — `LIFETIME_ENERGY` updates are only accepted if they don't decrease the meter, preventing stale SignalR replays from moving the total backwards
- **Easee: reset session fields on new connection** — `currentSessionID` and `sessionStartMeter` are cleared when the charger transitions from disconnected, so stale values from a previous session can't leak into the next one
- **Loadpoint: `finalizeSessionEnergy()`** — called just before `clearSession()` on disconnect; re-reads `ChargedEnergy`, and if it improved, updates `MeterStart` (via `SessionStartMeter`), `MeterStop`, `ChargedEnergy`, and derived metrics, then re-persists the session
- **Refactor: extract `applyEnergyMetrics()`** — shared by `stopSession()` and `finalizeSessionEnergy()` to avoid duplication