### PR TITLE
Huawei: use correct maximum power

### DIFF
--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -24,7 +24,7 @@ params:
   - name: timeout
     default: 15s
   - name: maxacpower
-    service: modbus/read?address=30073&type=holding&encoding=uint32&{modbus}
+    service: modbus/read?address=30075&type=holding&encoding=uint32&{modbus}
   - name: storageunit
   - name: forceaccharging
     default: false


### PR DESCRIPTION
Huawei offers 3 registers for determining power capabilities of the inverter:

| Register | Funktion | Wert |
| ------------- | ------------- | ------------- |
| 30073 | Rated power (Pn) | 8000 |
| 30075 | Maximum active power (Pmax) | 8800 |
| 30077 | Maximum apparent power (Smax) | 8800 |

This is an important change for the curtailment API as percentage is not calculated from rated power but from maximum active power.