### PR TITLE
Remove battery flag site tests (for #29288)

### DIFF
--- a/core/site_test.go
+++ b/core/site_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/core/types"
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util"
@@ -161,41 +160,4 @@ func TestRequiredBatteryMode(t *testing.T) {
 		res := s.requiredBatteryMode(tc.gridChargeActive, api.Rate{})
 		assert.Equal(t, tc.res, res, "expected %s, got %s", tc.res, res)
 	}
-}
-
-func TestPreparePublishesBatteryFlags(t *testing.T) {
-	site := NewSite()
-	site.tariffs = &tariff.Tariffs{}
-	valueChan := make(chan util.Param, 256)
-	site.valueChan = valueChan
-
-	site.prepare()
-
-	params := make(map[string]any)
-	for len(valueChan) > 0 {
-		p := <-valueChan
-		params[p.Key] = p.Val
-	}
-
-	assert.False(t, params[keys.BatteryBuffered].(bool))
-	assert.False(t, params[keys.BatteryStart].(bool))
-}
-
-func TestUpdatePublishesBatteryFlags(t *testing.T) {
-	site := NewSite()
-	site.tariffs = &tariff.Tariffs{}
-	site.stats = &Stats{updated: time.Now()}
-	valueChan := make(chan util.Param, 256)
-	site.valueChan = valueChan
-
-	site.update(nil)
-
-	params := make(map[string]any)
-	for len(valueChan) > 0 {
-		p := <-valueChan
-		params[p.Key] = p.Val
-	}
-
-	assert.False(t, params[keys.BatteryBuffered].(bool))
-	assert.False(t, params[keys.BatteryStart].(bool))
 }


### PR DESCRIPTION
Addresses [@andig](https://github.com/andig)'s review on [#29288](https://github.com/evcc-io/evcc/pull/29288): removes `TestPreparePublishesBatteryFlags` and `TestUpdatePublishesBatteryFlags` from `core/site_test.go` and drops the now-unused `keys` import.

Production changes in #29288 are unchanged; this branch only strips the added tests so the PR can be merged as requested.

Made with [Cursor](https://cursor.com)