### PR TITLE
feat: Adjust power display unit by single unit instead of global shared unit

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -482,14 +482,7 @@ export default defineComponent({
 			return Math.max(0, this.gridPower * -1);
 		},
 		powerUnit() {
-			const watt = Math.max(this.gridImport, this.selfPv, this.selfBattery, this.pvExport);
-			if (watt >= 1_000_000) {
-				return POWER_UNIT.MW;
-			} else if (watt >= 1000) {
-				return POWER_UNIT.KW;
-			} else {
-				return POWER_UNIT.W;
-			}
+			return POWER_UNIT.AUTO;
 		},
 		inPower() {
 			return this.gridImport + this.pvProduction + this.batteryDischarge;


### PR DESCRIPTION
Each energy flow unit will now be displayed based on his current unit (W/KW/MW)
This is more convenient when there is devices will low consumption

fixes #29376