### PR TITLE
Update sungrow-hybrid.yaml

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -36,14 +36,14 @@ render: |
     {{- include "modbus" . | indent 2 }}
     register:
       type: input
-      address: 13009 # Export power
+      address: 13010 # Export power; alternative Meter Active Power (5601)
       decode: int32s
     scale: -1
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 13036 # Total Import Energy, 0.1kWh
+      address: 13037 # Total Import Energy, 0.1kWh
       type: input
       decode: uint32s
     scale: 0.1
@@ -54,13 +54,13 @@ render: |
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
-        address: 5602 # Meter Phase A Active Power, 1W
+        address: 5603 # Meter Phase A Active Power, 1W
         decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
-        address: 5018 # Phase A voltage, 0.1V
+        address: 5019 # Phase A voltage, 0.1V
         decode: uint16
       scale: 0.1
   - source: calc
@@ -69,13 +69,13 @@ render: |
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
-        address: 5604 # Meter Phase B Active Power, 1W
+        address: 5605 # Meter Phase B Active Power, 1W
         decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
-        address: 5019 # Phase b voltage, 0.1V
+        address: 5020 # Phase b voltage, 0.1V
         decode: uint16
       scale: 0.1
   - source: calc
@@ -84,13 +84,13 @@ render: |
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
-        address: 5606 # Meter Phase C Active Power, 1W
+        address: 5607 # Meter Phase C Active Power, 1W
         decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
-        address: 5020 # Phase C voltage, 0.1V
+        address: 5021 # Phase C voltage, 0.1V
         decode: uint16
       scale: 0.1
   {{- end }}


### PR DESCRIPTION
Update changed register for grid use of the sungrow hybrid inverter. 

Related to Communication Protocol of Residential Hybrid Inverter; Version: V1.1.9; Release Date: 2025-06-20; URL: https://github.com/bohdan-s/Sungrow-Inverter/blob/main/Modbus%20Information/TI_20250620_Communication%20Protocol%20of%20Residential%20Hybrid%20Inverter_V1.1.9_EN.pdf