### PR TITLE
Remote Access: 1y default expiry

### DIFF
--- a/assets/js/components/Config/Remote/RemoteClientCreate.vue
+++ b/assets/js/components/Config/Remote/RemoteClientCreate.vue
@@ -60,6 +60,10 @@ import { defineComponent } from "vue";
 import FormRow from "../FormRow.vue";
 import formatter from "@/mixins/formatter";
 
+const HOUR = 60 * 60;
+const DAY = 24 * HOUR;
+const YEAR = 365 * DAY;
+
 export default defineComponent({
 	name: "RemoteClientCreate",
 	components: { FormRow },
@@ -68,18 +72,17 @@ export default defineComponent({
 	data() {
 		return {
 			username: "",
-			expiresIn: 0,
+			expiresIn: YEAR,
 		};
 	},
 	computed: {
 		expirationOptions() {
-			const HOUR = 60 * 60;
-			const DAY = 24 * HOUR;
 			return [
-				{ value: 0, name: this.$t("config.remote.expirationNone") },
 				{ value: HOUR, name: this.fmtDurationParts({ hours: 1 }) },
 				{ value: DAY, name: this.fmtDurationParts({ days: 1 }) },
 				{ value: 7 * DAY, name: this.fmtDurationParts({ weeks: 1 }) },
+				{ value: YEAR, name: this.fmtDurationParts({ years: 1 }) },
+				{ value: 0, name: this.$t("config.remote.expirationNone") },
 			];
 		},
 	},


### PR DESCRIPTION
addition to https://github.com/evcc-io/evcc/pull/28688

🔐 add "1 year" expiry option for remote access accounts and make it the default

"no expiry" can still be selected

<img width="681" height="623" alt="Bildschirmfoto 2026-04-25 um 17 52 32" src="https://github.com/user-attachments/assets/9a7a551e-258a-4566-adbe-56b86b372751" />

<img width="682" height="610" alt="Bildschirmfoto 2026-04-25 um 17 52 36" src="https://github.com/user-attachments/assets/0d75ee75-85bc-42cf-b1a4-628d7db48a20" />
