### PR TITLE
Update HemsModal.vue with correct link to external control documentation

### DIFF
--- a/assets/js/components/Config/HemsModal.vue
+++ b/assets/js/components/Config/HemsModal.vue
@@ -3,7 +3,7 @@
 		name="hems"
 		:title="$t('config.hems.title')"
 		:description="$t('config.hems.description')"
-		docs="/docs/features/14a-enwg-steuve"
+		docs="/docs/features/external-control"
 		:defaultYaml="defaultYaml"
 		endpoint="/config/hems"
 		removeKey="hems"


### PR DESCRIPTION
Fixes https://github.com/evcc-io/evcc/issues/29409 by correcting the link to the external control documentation.