### PR TITLE
Change scale value from 0.1 to 0.01 in solax.yaml

### DIFF
--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -47,7 +47,7 @@ render: |
       address: 74 # 0x004A consum_energy_total(meter)
       type: input
       decode: uint32s
-    scale: 0.1
+    scale: 0.01
   currents:
     - source: modbus
       {{- include "modbus" . | indent 4 }}


### PR DESCRIPTION
Solax X3 Gen4 energy registers use 0.01 kWh resolution.
Current template uses scale: 0.1 which results in values 10× too high.
Changing scale to 0.01 fixes the incorrect consum_energy_total reading.

Verified by manually adding configuration for add-on:
    energy:
      source: modbus
      uri: 192.168.x.x:502
      id: 1
      register:
        address: 74 # 0x004A consum_energy_total
        type: input
        decode: uint32s
      scale: 0.01

Fixes #29422