### PR TITLE
Rounds the session metrics to a reasonable precision

### DIFF
--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"math"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -11,6 +12,20 @@ import (
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/jinzhu/now"
 )
+
+func roundFloat64(value float64, digits int) float64 {
+	factor := math.Pow10(digits)
+	return math.Round(value*factor) / factor
+}
+
+func roundFloat64Ptr(value *float64, digits int) *float64 {
+	if value == nil {
+		return nil
+	}
+
+	rounded := roundFloat64(*value, digits)
+	return &rounded
+}
 
 func (lp *Loadpoint) chargeMeterTotal() float64 {
 	m, ok := api.Cap[api.MeterEnergy](lp.chargeMeter)
@@ -55,7 +70,9 @@ func (lp *Loadpoint) createSession() {
 
 	if lp.site != nil {
 		lp.session.ReferencePricePerKWh = tariff.AverageRate(lp.site.GetTariff(api.TariffUsageGrid), 24*time.Hour)
-		lp.session.ReferenceCo2PerKWh = tariff.AverageRate(lp.site.GetTariff(api.TariffUsageCo2), 24*time.Hour)
+		lp.session.ReferenceCo2PerKWh = roundFloat64Ptr(
+			tariff.AverageRate(lp.site.GetTariff(api.TariffUsageCo2), 24*time.Hour), 4,
+		)
 	}
 
 	// energy
@@ -70,11 +87,11 @@ func (lp *Loadpoint) applyEnergyMetrics(s *session.Session) {
 		s.MeterStop = &meterStop
 	}
 
-	s.SolarPercentage = new(lp.energyMetrics.SolarPercentage())
+	s.SolarPercentage = roundFloat64Ptr(new(lp.energyMetrics.SolarPercentage()), 4)
 	s.Price = lp.energyMetrics.Price()
-	s.PricePerKWh = lp.energyMetrics.PricePerKWh()
-	s.Co2PerKWh = lp.energyMetrics.Co2PerKWh()
-	s.ChargedEnergy = lp.energyMetrics.TotalWh() / 1e3
+	s.PricePerKWh = roundFloat64Ptr(lp.energyMetrics.PricePerKWh(), 5)
+	s.Co2PerKWh = roundFloat64Ptr(lp.energyMetrics.Co2PerKWh(), 4)
+	s.ChargedEnergy = roundFloat64(lp.energyMetrics.TotalWh()/1e3, 5)
 
 	lp.db.Persist(s)
 }

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -87,7 +87,8 @@ func (lp *Loadpoint) applyEnergyMetrics(s *session.Session) {
 		s.MeterStop = &meterStop
 	}
 
-	s.SolarPercentage = roundFloat64Ptr(new(lp.energyMetrics.SolarPercentage()), 4)
+	s.SolarPercentage = new(lp.energyMetrics.SolarPercentage())
+	s.SolarPercentage = roundFloat64Ptr(s.SolarPercentage, 4)
 	s.Price = lp.energyMetrics.Price()
 	s.PricePerKWh = roundFloat64Ptr(lp.energyMetrics.PricePerKWh(), 5)
 	s.Co2PerKWh = roundFloat64Ptr(lp.energyMetrics.Co2PerKWh(), 4)

--- a/core/session/db.go
+++ b/core/session/db.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"math"
+
 	"github.com/evcc-io/evcc/server/db"
 	"github.com/evcc-io/evcc/util"
 	"gorm.io/gorm"
@@ -88,7 +90,7 @@ func (s *DB) ClosePendingSessionsInHistory(chargeMeterTotal float64) error {
 		}
 
 		if session.MeterStart != nil && session.MeterStop != nil {
-			session.ChargedEnergy = *session.MeterStop - *session.MeterStart
+			session.ChargedEnergy = math.Round((*session.MeterStop-*session.MeterStart)*1e5) / 1e5
 			s.Persist(session)
 		}
 	}


### PR DESCRIPTION
Some session metrices are stored as raw float64 with unnecessary precision sometimes caused by multiplication/division. These values can/should be rounded to a reasonable precision (four or five digits after decimal point).:

Find out those values:
```sql
SELECT id, meter_start_kwh, meter_end_kwh, charged_kwh, ROUND(charged_kwh, 5) new_kwh, price, ROUND(ROUND(charged_kwh, 5) * price_per_kwh, 5) new_price FROM sessions WHERE charged_kwh * 1000. - FLOOR(charged_kwh * 1000.) > .0000;
```
|  id | meter_start_kwh | meter_end_kwh |       charged_kwh | new_kwh |              price | new_price |
|----:|----------------:|--------------:|------------------:|--------:|-------------------:|----------:|
|  65 |          435.44 |        449.44 |  17.0300006866455 |   17.03 |   4.79224219322205 |   4.79224 |
|  82 |          638.08 |        660.45 |  27.7600002288818 |   27.76 |   7.81166406440735 |   7.81166 |
|  93 |          304.25 |        325.57 |  25.5599994659424 |   25.56 |   7.19258384971619 |   7.19258 |
|  94 |            0.26 |         25.55 |  25.1599998474121 |   25.16 |   7.08002395706177 |   7.08002 |
| 101 |          539.68 |        546.96 |  17.1599998474121 |   17.16 |   5.15657995414734 |   5.15658 |
| 103 |          838.97 |        864.31 |  36.4300003051758 |   36.43 |   10.9472150917053 |  10.94722 |
| 106 |           21.26 |         24.02 |   7.6399998664856 |    7.64 |   2.29581995987892 |   2.29582 |
| 110 |            0.26 |         18.08 |  17.5499992370605 |   17.55 |   5.27377477073669 |   5.27377 |
| 115 |           915.3 |        936.59 |  21.2900009155273 |   21.29 |   6.39764527511597 |   6.39764 |
| 142 |          926.53 |        931.63 |  11.6800003051758 |   11.68 |   3.50984009170532 |   3.50984 |
| 144 |          347.86 |        369.81 |  22.3999996185303 |    22.4 |   6.73119988536834 |    6.7312 |
| 151 |         1025.38 |       1041.12 |  20.5599994659424 |   20.56 |   6.17827983951569 |   6.17828 |
| 177 |         1194.34 |       1196.28 |  9.27000045776367 |    9.27 |   2.78563513755798 |   2.78563 |
| 182 |         1459.75 |       1479.57 |  23.2399997711182 |   23.24 |   6.98361993122101 |   6.98362 |
| 192 |           156.9 |        210.79 |  54.0800018310547 |   54.08 |   16.2510405502319 |  16.25104 |
| 199 |          757.94 |         773.3 |  15.7700004577637 |   15.77 |   3.76272210922241 |   3.76272 |
| 202 |         1611.02 |       1630.97 |  21.2199993133545 |   21.22 |   5.06309183616638 |   5.06309 |
| 206 |          116.21 |        119.35 |  13.6700000762939 |   13.67 |   3.26166201820374 |   3.26166 |
| 212 |          129.88 |        138.74 |  15.7600002288818 |   15.76 |   3.76033605461121 |   3.76034 |
| 241 |          949.52 |        949.63 | 0.150000005960464 |    0.15 | 0.0357900014221668 |   0.03579 |
| 258 |          1000.6 |       1058.13 |  66.4300003051758 |   66.43 |   15.8501980728149 |   15.8502 |
| 272 |         1073.69 |       1082.36 |  10.1599998474121 |   10.16 |   2.42417596359253 |   2.42418 |
| 284 |         2047.93 |       2053.06 |  5.13000011444092 |    5.13 |    1.2240180273056 |   1.22402 |
| 318 |         1988.66 |       2000.75 |  21.3299999237061 |   21.33 |   5.08933798179627 |   5.08934 |

This PR rounds `session.ReferenceCo2PerKWh` , `SolarPercentage`, `PricePerKWh`, `Co2PerKWh` and `ChargedEnergy`.