### PR TITLE
add offset as meter start value

### DIFF
--- a/plugin/getter.go
+++ b/plugin/getter.go
@@ -5,8 +5,9 @@ import (
 )
 
 type getter struct {
-	get   StringGetter
-	scale float64
+	get    StringGetter
+	scale  float64
+	offset float64
 }
 
 func defaultGetters(get StringGetter, scale float64) *getter {
@@ -33,7 +34,7 @@ func (p *getter) FloatGetter() (func() (float64, error), error) {
 			return 0, err
 		}
 
-		return f * p.scale, nil
+		return (f - p.offset) * p.scale, nil
 	}, err
 }
 

--- a/plugin/http.go
+++ b/plugin/http.go
@@ -42,6 +42,7 @@ func NewHTTPPluginFromConfig(ctx context.Context, other map[string]any) (Plugin,
 		Body              string
 		pipeline.Settings `mapstructure:",squash"`
 		Scale             float64
+		Offset            float64
 		Insecure          bool
 		Auth              Auth
 		Timeout           time.Duration
@@ -75,6 +76,7 @@ func NewHTTPPluginFromConfig(ctx context.Context, other map[string]any) (Plugin,
 	p.Client.Timeout = cc.Timeout
 
 	p.getter = defaultGetters(p, cc.Scale)
+	p.getter.offset = cc.Offset
 
 	if cc.Auth.Type != "" || cc.Auth.Source != "" {
 		transport, err := cc.Auth.Transport(ctx, log, p.Client.Transport)

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -11,6 +11,23 @@ params:
     default: 8081
   - name: uuid
     required: true
+  - name: energyuuid
+    advanced: true
+    description:
+      de: Energiezählerstand
+      en: Energy meter reading
+    help:
+      de: Die vzlogger Kanal uuid für den Energiezählerstand (OBIS Code 1.8.0)
+      en: The vzlogger channel uuid for the energy meter reading (OBIS Code 1.8.0)
+  - name: offset
+    advanced: true
+    default: 0
+    description:
+      de: Zählerstartwert (kWh)
+      en: Meter start value (kWh)
+    help:
+      de: Subtrahiere diesen Wert vom Energiezählerstand (z.B. Vorverbrauch des vorherigen Nutzers)
+      en: Subtract this value from the energy reading (e.g. previous customer's meter reading)
   - name: scale
     advanced: true
     default: 1
@@ -105,6 +122,19 @@ render: |
     {{- if .scale }}
     scale: {{ .scale }}
     {{- end }}
+  {{ if .energyuuid -}}
+  energy:
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/
+    jq: .data[] | select(.uuid=="{{ unquote .energyuuid }}") | .tuples[0][1]
+    cache: {{ .cache }}
+    {{- if .offset }}
+    offset: {{ .offset }}
+    {{- end }}
+    {{- if .scale }}
+    scale: {{ .scale }}
+    {{- end }}
+  {{ end -}}
   {{ if and .l1currentuuid .l2currentuuid .l3currentuuid -}}
   currents:
   - source: http


### PR DESCRIPTION
This PR implements an `offset` value for previous customer's meter reading and respects it in combination with `scale`. It is explicitly not implemented in JQ for reuse with other meters.

The `vzlogger` template is enhanced as an example.