### PR TITLE
vzlogger: add option for meter reading uuid

### DIFF
--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -135,7 +135,7 @@ render: |
     scale: {{ .energyscale }}
     {{- end }}
   {{- end }}
-  {{ if and .l1currentuuid .l2currentuuid .l3currentuuid -}}
+  {{- if and .l1currentuuid .l2currentuuid .l3currentuuid }}
   currents:
   - source: http
     uri: http://{{ .host }}:{{ .port }}/
@@ -149,8 +149,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/
     jq: .data[] | select(.uuid=="{{ unquote .l3currentuuid }}") | .tuples[0][1]
     cache: {{ .cache }}
-  {{ end -}}
-  {{ if and .l1poweruuid .l2poweruuid .l3poweruuid -}}
+  {{- end }}
+  {{- if and .l1poweruuid .l2poweruuid .l3poweruuid }}
   powers:
   - source: http
     uri: http://{{ .host }}:{{ .port }}/
@@ -164,8 +164,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/
     jq: .data[] | select(.uuid=="{{ unquote .l3poweruuid }}") | .tuples[0][1]
     cache: {{ .cache }}
-  {{ end -}}
-  {{ if and .l1voltageuuid .l2voltageuuid .l3voltageuuid -}}
+  {{- end }}
+  {{- if and .l1voltageuuid .l2voltageuuid .l3voltageuuid }}
   voltages:
   - source: http
     uri: http://{{ .host }}:{{ .port }}/
@@ -179,4 +179,4 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/
     jq: .data[] | select(.uuid=="{{ unquote .l3voltageuuid }}") | .tuples[0][1]
     cache: {{ .cache }}
-  {{ end -}}
+  {{- end }}

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -11,6 +11,17 @@ params:
     default: 8081
   - name: uuid
     required: true
+    description:
+      de: Die vzlogger Kanal uuid für die Leistung
+      en: The vzlogger channel uuid for power
+  - name: energyuuid
+    advanced: true
+    description:
+      de: Zählerstand
+      en: Meter reading
+    help:
+      de: Die vzlogger Kanal uuid für den Zählerstand (OBIS Code 1.8.0, Strombezug)
+      en: The vzlogger channel uuid for the meter reading (OBIS Code 1.8.0, electricity consumption)
   - name: scale
     advanced: true
     default: 1
@@ -105,6 +116,16 @@ render: |
     {{- if .scale }}
     scale: {{ .scale }}
     {{- end }}
+  {{ if .energyuuid -}}
+  energy: # meter reading in kWh
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/
+    jq: .data[] | select(.uuid=="{{ unquote .energyuuid }}") | .tuples[0][1]
+    cache: {{ .cache }}
+    {{- if .scale }}
+    scale: {{ .scale }}
+    {{- end }}
+  {{ end -}}
   {{ if and .l1currentuuid .l2currentuuid .l3currentuuid -}}
   currents:
   - source: http

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -111,7 +111,7 @@ render: |
   power: # power reading
     source: http # use http plugin
     uri: http://{{ .host }}:{{ .port }}/
-    jq: .data[] | select(.uuid=="{{ unquote .uuid }}") | .tuples[0][1] # parse response json
+    jq: .data[] | select(.uuid=="{{ unquote .uuid }}") | (.tuples[0][1]? // 0) # parse response json
     cache: {{ .cache }}
     {{- if .scale }}
     scale: {{ .scale }}

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -17,8 +17,8 @@ params:
   - name: energyuuid
     advanced: true
     description:
-      de: Zählerstand
-      en: Meter reading
+      de: Die vzlogger Kanal uuid für den Zählerstand
+      en: The vzlogger channel uuid for the meter reading
     help:
       de: Die vzlogger Kanal uuid für den Zählerstand (OBIS Code 1.8.0, Strombezug)
       en: The vzlogger channel uuid for the meter reading (OBIS Code 1.8.0, electricity consumption)
@@ -116,7 +116,7 @@ render: |
     {{- if .scale }}
     scale: {{ .scale }}
     {{- end }}
-  {{ if .energyuuid -}}
+  {{- if .energyuuid }}
   energy: # meter reading in kWh
     source: http
     uri: http://{{ .host }}:{{ .port }}/
@@ -125,7 +125,7 @@ render: |
     {{- if .scale }}
     scale: {{ .scale }}
     {{- end }}
-  {{ end -}}
+  {{- end }}
   {{ if and .l1currentuuid .l2currentuuid .l3currentuuid -}}
   currents:
   - source: http

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -38,8 +38,8 @@ params:
       de: Skalierungsfaktor Energie
       en: Scale factor energy
     help:
-      de: Multipliziere Energie-Rohwert mit diesem Faktor (Standard 0.001 für Wh nach kWh).
-      en: Multiply energy raw value by this factor (default 0.001 for Wh to kWh).
+      de: Multipliziere Energie-Rohwert mit diesem Faktor
+      en: Multiply energy raw value by this factor
   - name: l1currentuuid
     advanced: true
     description:

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -14,14 +14,6 @@ params:
     description:
       de: Die vzlogger Kanal uuid für die Leistung
       en: The vzlogger channel uuid for power
-  - name: energyuuid
-    advanced: true
-    description:
-      de: Die vzlogger Kanal uuid für den Zählerstand
-      en: The vzlogger channel uuid for the meter reading
-    help:
-      de: Die vzlogger Kanal uuid für den Zählerstand (OBIS Code 1.8.0, Strombezug)
-      en: The vzlogger channel uuid for the meter reading (OBIS Code 1.8.0, electricity consumption)
   - name: scale
     advanced: true
     default: 1
@@ -31,6 +23,14 @@ params:
     help:
       de: Multipliziere Leistungs-Rohwert mit diesem Faktor
       en: Multiply power raw value by this factor
+  - name: energyuuid
+    advanced: true
+    description:
+      de: Die vzlogger Kanal uuid für den Zählerstand
+      en: The vzlogger channel uuid for the meter reading
+    help:
+      de: Die vzlogger Kanal uuid für den Zählerstand (OBIS Code 1.8.0, Strombezug)
+      en: The vzlogger channel uuid for the meter reading (OBIS Code 1.8.0, electricity consumption)
   - name: energyscale
     advanced: true
     default: 0.001

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -38,8 +38,8 @@ params:
       de: Skalierungsfaktor Energie
       en: Scale factor energy
     help:
-      de: Multipliziere Energie-Rohwert mit diesem Faktor (Standard 0.001 für Wh nach kWh). Bei Messwandlern ist zusätzlich der Wandlerfaktor zu berücksichtigen.
-      en: Multiply energy raw value by this factor (default 0.001 for Wh to kWh). For current transformers additionally the transformer factor needs to be considered.
+      de: Multipliziere Energie-Rohwert mit diesem Faktor (Standard 0.001 für Wh nach kWh).
+      en: Multiply energy raw value by this factor (default 0.001 for Wh to kWh).
   - name: l1currentuuid
     advanced: true
     description:

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -26,11 +26,20 @@ params:
     advanced: true
     default: 1
     description:
-      de: Skalierungsfaktor
-      en: Scale factor
+      de: Skalierungsfaktor Leistung
+      en: Scale factor power
     help:
-      de: Multipliziere Rohwert mit diesem Faktor
-      en: Multiply by this value
+      de: Multipliziere Leistungs-Rohwert mit diesem Faktor
+      en: Multiply power raw value by this factor
+  - name: energyscale
+    advanced: true
+    default: 0.001
+    description:
+      de: Skalierungsfaktor Energie
+      en: Scale factor energy
+    help:
+      de: Multipliziere Energie-Rohwert mit diesem Faktor (Standard 0.001 für Wh nach kWh). Bei Messwandlern ist zusätzlich der Wandlerfaktor zu berücksichtigen.
+      en: Multiply energy raw value by this factor (default 0.001 for Wh to kWh). For current transformers additionally the transformer factor needs to be considered.
   - name: l1currentuuid
     advanced: true
     description:
@@ -122,8 +131,8 @@ render: |
     uri: http://{{ .host }}:{{ .port }}/
     jq: .data[] | select(.uuid=="{{ unquote .energyuuid }}") | .tuples[0][1]
     cache: {{ .cache }}
-    {{- if .scale }}
-    scale: {{ .scale }}
+    {{- if .energyscale }}
+    scale: {{ .energyscale }}
     {{- end }}
   {{- end }}
   {{ if and .l1currentuuid .l2currentuuid .l3currentuuid -}}


### PR DESCRIPTION
Fixes #29491

The second commit fixes the error "power: strconv.ParseFloat: parsing "<nil>": invalid syntax" if there is no `tuples` field available in the JSON response. That could happen if the meter does not provide the power, i. e. if the PIN isn't available yet and hence the meter not unlocked.