### PR TITLE
OCPP: handle firmware management events

### DIFF
--- a/charger/ocpp/cs_core.go
+++ b/charger/ocpp/cs_core.go
@@ -2,6 +2,7 @@ package ocpp
 
 import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/security"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
@@ -124,4 +125,14 @@ func (cs *CS) OnCertificateSigned(id string, request *security.CertificateSigned
 	return &security.CertificateSignedResponse{
 		Status: security.CertificateSignedStatusAccepted,
 	}, nil
+}
+
+func (cs *CS) OnFirmwareStatusNotification(id string, request *firmware.FirmwareStatusNotificationRequest) (*firmware.FirmwareStatusNotificationConfirmation, error) {
+	// Acknowledge any firmware status notification
+	return &firmware.FirmwareStatusNotificationConfirmation{}, nil
+}
+
+func (cs *CS) OnDiagnosticsStatusNotification(id string, request *firmware.DiagnosticsStatusNotificationRequest) (*firmware.DiagnosticsStatusNotificationConfirmation, error) {
+	// Acknowledge any diagnostics status notification
+	return &firmware.DiagnosticsStatusNotificationConfirmation{}, nil
 }

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp"
 	ocpp16 "github.com/lorenzodonini/ocpp-go/ocpp1.6"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/security"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
@@ -72,7 +73,7 @@ func Instance() *CS {
 		dispatcher := ocppj.NewDefaultServerDispatcher(ocppj.NewFIFOQueueMap(0))
 		dispatcher.SetTimeout(Timeout)
 
-		endpoint := ocppj.NewServer(server, dispatcher, nil, core.Profile, remotetrigger.Profile, smartcharging.Profile, security.Profile)
+		endpoint := ocppj.NewServer(server, dispatcher, nil, core.Profile, remotetrigger.Profile, smartcharging.Profile, security.Profile, firmware.Profile)
 		endpoint.SetInvalidMessageHook(func(client ws.Channel, err *ocpp.Error, rawMessage string, parsedFields []any) *ocpp.Error {
 			log.ERROR.Printf("%v (%s)", err, rawMessage)
 			return nil
@@ -92,6 +93,7 @@ func Instance() *CS {
 
 		cs.SetCoreHandler(instance)
 		cs.SetSecurityHandler(instance)
+		cs.SetFirmwareManagementHandler(instance)
 		cs.SetNewChargePointHandler(instance.NewChargePoint)
 		cs.SetChargePointDisconnectedHandler(instance.ChargePointDisconnected)
 


### PR DESCRIPTION
Adds the OCPP 1.6 `FirmwareManagement` profile and acknowledges `FirmwareStatusNotification` and `DiagnosticsStatusNotification` so chargers no longer trigger `NotSupported` errors when reporting firmware/diagnostics status (e.g. ABL Pulsar Plus on FW 6.11.25).

Same pattern as #23199 (security profile).

Closes #29495