### PR TITLE
Optimizer: increase timeout

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -230,7 +230,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 	}
 
 	httpClient := request.NewClient(site.log)
-	httpClient.Timeout = 30 * time.Second
+	httpClient.Timeout = 90 * time.Second
 
 	apiClient, err := optimizer.NewClientWithResponses(uri, optimizer.WithHTTPClient(httpClient))
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/evcc-io/optimizer/issues/66

Gives the optimizer service more time to respond before hanging up.
This added time allows better resource utilization (higher concurrency) in our infrastructure.

_Background: Avg. response time of optimizer.evcc.io is 1.1s. But we regularly receive requests that use the complete `OPTIMIZER_TIME_LIMIT` and thereby come close to the current 30s client timeout._

\cc @ekkea