### PR TITLE
Fritz: provide AIN dropdown

### DIFF
--- a/meter/fritz/smarthome/service.go
+++ b/meter/fritz/smarthome/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/evcc-io/evcc/util/transport"
+	"github.com/samber/lo"
 )
 
 func init() {
@@ -51,9 +52,9 @@ func getDevices(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req, _ := request.New(http.MethodGet,
-		fmt.Sprintf("%s/api/v0/smarthome/overview/devices", uri), nil,
-		map[string]string{"Authorization": "AVM-SID " + sid},
-		request.AcceptJSON,
+		fmt.Sprintf("%s/api/v0/smarthome/overview/devices", uri), nil, map[string]string{
+			"Authorization": "AVM-SID " + sid,
+		}, request.AcceptJSON,
 	)
 
 	var devices []Device
@@ -62,20 +63,16 @@ func getDevices(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ains := make([]string, 0, len(devices))
-	for _, d := range devices {
-		if ain := strings.ReplaceAll(d.UID, " ", ""); ain != "" {
-			ains = append(ains, ain)
-		}
-	}
+	ains := lo.Map(devices, func(d Device, _ int) string {
+		return d.AIN
+	})
 	slices.Sort(ains)
-	ains = slices.Compact(ains)
 
-	w.Header().Set("Cache-control", "max-age=60")
 	jsonWrite(w, ains)
 }
 
 func jsonWrite(w http.ResponseWriter, data any) {
+	w.Header().Set("Cache-control", "max-age=60")
 	json.NewEncoder(w).Encode(data)
 }
 

--- a/meter/fritz/smarthome/service.go
+++ b/meter/fritz/smarthome/service.go
@@ -72,7 +72,7 @@ func getDevices(w http.ResponseWriter, r *http.Request) {
 }
 
 func jsonWrite(w http.ResponseWriter, data any) {
-	w.Header().Set("Cache-control", "max-age=60")
+	w.Header().Set("Cache-control", "max-age=300")
 	json.NewEncoder(w).Encode(data)
 }
 

--- a/meter/fritz/smarthome/service.go
+++ b/meter/fritz/smarthome/service.go
@@ -1,0 +1,85 @@
+package smarthome
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/evcc-io/evcc/meter/fritz"
+	"github.com/evcc-io/evcc/server/service"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
+)
+
+func init() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /devices", getDevices)
+
+	service.Register("fritz", mux)
+}
+
+func getDevices(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	uri := strings.TrimRight(q.Get("uri"), "/")
+	user := q.Get("user")
+	password := q.Get("password")
+
+	if uri == "" || user == "" || password == "" {
+		jsonError(w, http.StatusBadRequest, errors.New("missing uri, user or password"))
+		return
+	}
+
+	log := util.NewLogger("fritz").Redact(password)
+	helper := request.NewHelper(log)
+	helper.Client.Transport = request.NewTripper(log, transport.Insecure())
+
+	settings := fritz.Settings{URI: uri, User: user, Password: password}
+
+	sid, err := settings.GetSessionID(helper)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if sid == "0000000000000000" {
+		jsonError(w, http.StatusUnauthorized, errors.New("invalid user or password"))
+		return
+	}
+
+	req, _ := request.New(http.MethodGet,
+		fmt.Sprintf("%s/api/v0/smarthome/overview/devices", uri), nil,
+		map[string]string{"Authorization": "AVM-SID " + sid},
+		request.AcceptJSON,
+	)
+
+	var devices []Device
+	if err := helper.DoJSON(req, &devices); err != nil {
+		jsonError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	ains := make([]string, 0, len(devices))
+	for _, d := range devices {
+		if ain := strings.ReplaceAll(d.UID, " ", ""); ain != "" {
+			ains = append(ains, ain)
+		}
+	}
+	slices.Sort(ains)
+	ains = slices.Compact(ains)
+
+	w.Header().Set("Cache-control", "max-age=60")
+	jsonWrite(w, ains)
+}
+
+func jsonWrite(w http.ResponseWriter, data any) {
+	json.NewEncoder(w).Encode(data)
+}
+
+func jsonError(w http.ResponseWriter, status int, err error) {
+	w.WriteHeader(status)
+	jsonWrite(w, util.ErrorAsJson(err))
+}

--- a/meter/fritz/smarthome/service.go
+++ b/meter/fritz/smarthome/service.go
@@ -72,7 +72,7 @@ func getDevices(w http.ResponseWriter, r *http.Request) {
 }
 
 func jsonWrite(w http.ResponseWriter, data any) {
-	w.Header().Set("Cache-control", "max-age=300")
+	w.Header().Set("Cache-control", "max-age=60")
 	json.NewEncoder(w).Encode(data)
 }
 

--- a/meter/fritz/smarthome/service.go
+++ b/meter/fritz/smarthome/service.go
@@ -68,11 +68,12 @@ func getDevices(w http.ResponseWriter, r *http.Request) {
 	})
 	slices.Sort(ains)
 
+	w.Header().Set("Cache-control", "max-age=60")
 	jsonWrite(w, ains)
 }
 
 func jsonWrite(w http.ResponseWriter, data any) {
-	w.Header().Set("Cache-control", "max-age=60")
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(data)
 }
 

--- a/meter/fritz/smarthome/types.go
+++ b/meter/fritz/smarthome/types.go
@@ -1,5 +1,15 @@
 package smarthome
 
+// Device represents a smarthome device from the /devices endpoint
+type Device struct {
+	UID             string `json:"UID"`
+	AIN             string `json:"ain"`
+	Name            string `json:"name"`
+	ProductName     string `json:"productName"`
+	ProductCategory string `json:"productCategory"`
+	IsConnected     bool   `json:"isConnected"`
+}
+
 // Unit represents a smarthome unit with its interfaces
 type Unit struct {
 	GroupUID    string      `json:"groupUid,omitempty"`

--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -83,6 +83,7 @@ func jsonHandler(h http.Handler) http.Handler {
 }
 
 func jsonWrite(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(data)
 }
 

--- a/templates/definition/charger/fritzdect.yaml
+++ b/templates/definition/charger/fritzdect.yaml
@@ -25,6 +25,7 @@ params:
     required: true
   - name: ain
     required: true
+    service: fritz/devices?uri={uri}&user={user}&password={password}
   - name: firmware82
     advanced: true
     type: bool

--- a/templates/definition/meter/fritzdect.yaml
+++ b/templates/definition/meter/fritzdect.yaml
@@ -27,6 +27,7 @@ params:
     required: true
   - name: ain
     required: true
+    service: fritz/devices?uri={uri}&user={user}&password={password}
   - name: firmware82
     advanced: true
     type: bool

--- a/templates/definition/meter/fritzgrid.yaml
+++ b/templates/definition/meter/fritzgrid.yaml
@@ -14,6 +14,7 @@ params:
     required: true
   - name: ain
     required: true
+    service: fritz/devices?uri={uri}&user={user}&password={password}
 render: |
   type: fritzdect
   uri: {{ .uri }}

--- a/util/homeassistant/service.go
+++ b/util/homeassistant/service.go
@@ -128,6 +128,7 @@ func getServices(w http.ResponseWriter, req *http.Request) {
 
 // jsonWrite writes a JSON response
 func jsonWrite(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(data)
 }
 


### PR DESCRIPTION
## Summary
- Adds a `fritz/devices` template service that queries the Fritz!Box smarthome REST API (`/api/v0/smarthome/overview/devices`) for the configured user and returns the AINs of available devices
- Wires the service into the AIN dropdown of the `charger/fritzdect`, `meter/fritzdect` and `meter/fritzgrid` templates so users can pick instead of copying AINs from the device sticker
- Modeled on the `homeassistant/instances` service pattern

Closes #29342

## Test plan
- [ ] Configure a Fritz!Box (FritzOS 8.2+) charger or meter via the web UI and confirm the AIN field offers a dropdown of detected devices
- [ ] Confirm that wrong credentials produce a clean error and the dropdown stays empty
- [ ] Confirm legacy (pre-8.2) configurations still work by typing the AIN manually