### PR TITLE
Ecoflow: use evcc HTTP client for logging

### DIFF
--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -71,9 +71,7 @@ func NewEcoFlowFromConfig(ctx context.Context, other map[string]any) (api.Meter,
 		return nil, fmt.Errorf("invalid region: %s", cc.Region)
 	}
 
-	log := util.NewLogger("ecoflow").Redact(cc.AccessKey, cc.SecretKey, cc.Serial)
-
-	m, err := NewEcoFlow(ctx, log, cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache)
+	m, err := NewEcoFlow(ctx, cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +87,10 @@ func NewEcoFlowFromConfig(ctx context.Context, other map[string]any) (api.Meter,
 }
 
 // NewEcoFlow constructs the EcoFlow struct
-func NewEcoFlow(ctx context.Context, log *util.Logger, accessKey, secretKey, serial, usage, uri string,
+func NewEcoFlow(ctx context.Context, accessKey, secretKey, serial, usage, uri string,
 	power, soc string, cache time.Duration) (*EcoFlow, error) {
+	log := util.NewLogger("ecoflow").Redact(accessKey, secretKey, serial)
+
 	m := &EcoFlow{
 		ctx:    ctx,
 		serial: serial,

--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -15,7 +15,6 @@ import (
 
 // EcoFlow represents the EcoFlow  meter
 type EcoFlow struct {
-	ctx    context.Context
 	usage  string
 	serial string
 	cache  time.Duration
@@ -26,11 +25,11 @@ type EcoFlow struct {
 }
 
 func init() {
-	registry.AddCtx("ecoflow", NewEcoFlowFromConfig)
+	registry.Add("ecoflow", NewEcoFlowFromConfig)
 }
 
 // NewEcoFlowFromConfig creates an EcoFlow  meter from generic config
-func NewEcoFlowFromConfig(ctx context.Context, other map[string]any) (api.Meter, error) {
+func NewEcoFlowFromConfig(other map[string]any) (api.Meter, error) {
 	cc := struct {
 		batteryCapacity                      `mapstructure:",squash"`
 		batteryPowerLimits                   `mapstructure:",squash"`
@@ -71,7 +70,7 @@ func NewEcoFlowFromConfig(ctx context.Context, other map[string]any) (api.Meter,
 		return nil, fmt.Errorf("invalid region: %s", cc.Region)
 	}
 
-	m, err := NewEcoFlow(ctx, cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache)
+	m, err := NewEcoFlow(cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache)
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +86,11 @@ func NewEcoFlowFromConfig(ctx context.Context, other map[string]any) (api.Meter,
 }
 
 // NewEcoFlow constructs the EcoFlow struct
-func NewEcoFlow(ctx context.Context, accessKey, secretKey, serial, usage, uri string,
+func NewEcoFlow(accessKey, secretKey, serial, usage, uri string,
 	power, soc string, cache time.Duration) (*EcoFlow, error) {
 	log := util.NewLogger("ecoflow").Redact(accessKey, secretKey, serial)
 
 	m := &EcoFlow{
-		ctx:    ctx,
 		serial: serial,
 		usage:  usage,
 		cache:  cache,
@@ -111,7 +109,7 @@ func NewEcoFlow(ctx context.Context, accessKey, secretKey, serial, usage, uri st
 
 // getData retrieves device parameters from EcoFlow API
 func (m *EcoFlow) getData() (*ecoflow.GetCmdResponse, error) {
-	ctx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	params := []string{m.power}

--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
 	"github.com/spf13/cast"
 	"github.com/tess1o/go-ecoflow"
 )
@@ -70,7 +71,9 @@ func NewEcoFlowFromConfig(ctx context.Context, other map[string]any) (api.Meter,
 		return nil, fmt.Errorf("invalid region: %s", cc.Region)
 	}
 
-	m, err := NewEcoFlow(ctx, cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache)
+	log := util.NewLogger("ecoflow").Redact(cc.AccessKey, cc.SecretKey, cc.Serial)
+
+	m, err := NewEcoFlow(ctx, log, cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache)
 	if err != nil {
 		return nil, err
 	}
@@ -86,14 +89,17 @@ func NewEcoFlowFromConfig(ctx context.Context, other map[string]any) (api.Meter,
 }
 
 // NewEcoFlow constructs the EcoFlow struct
-func NewEcoFlow(ctx context.Context, accessKey, secretKey, serial, usage, uri string,
+func NewEcoFlow(ctx context.Context, log *util.Logger, accessKey, secretKey, serial, usage, uri string,
 	power, soc string, cache time.Duration) (*EcoFlow, error) {
 	m := &EcoFlow{
-		ctx:        ctx,
-		serial:     serial,
-		usage:      usage,
-		cache:      cache,
-		client:     ecoflow.NewEcoflowClient(accessKey, secretKey, ecoflow.WithBaseUrl(uri)),
+		ctx:    ctx,
+		serial: serial,
+		usage:  usage,
+		cache:  cache,
+		client: ecoflow.NewEcoflowClient(accessKey, secretKey,
+			ecoflow.WithBaseUrl(uri),
+			ecoflow.WithHttpClient(request.NewClient(log)),
+		),
 		power:      power,
 		batterySoc: soc,
 	}


### PR DESCRIPTION
## Summary
- Pass an evcc-built `*http.Client` (via `request.NewClient`) into the go-ecoflow SDK using `ecoflow.WithHttpClient`
- Trace and request logs from the Ecoflow integration now flow through evcc's standard logger
- AccessKey, SecretKey and Serial are redacted in log output

Closes #29523

## Test plan
- [ ] Configure an Ecoflow meter and confirm `--log trace` shows the request/response traffic
- [ ] Confirm credentials and serial do not appear in log output (they should be replaced with the redaction marker)