### PR TITLE
Loadpoint: make custom surplus thresholds optional

### DIFF
--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -177,7 +177,6 @@
 											type="Float"
 											unit="W"
 											size="w-25 w-min-200"
-											required
 										/>
 									</FormRow>
 									<FormRow
@@ -240,7 +239,6 @@
 											type="Float"
 											unit="W"
 											size="w-25 w-min-200"
-											required
 										/>
 									</FormRow>
 									<FormRow


### PR DESCRIPTION
## Summary
- Drops the `required` attribute from the enable/disable threshold (W) inputs in the loadpoint modal
- Thresholds are not mandatory in custom surplus mode — delays alone are a valid configuration (per @andig in the issue thread)
- Also removes the un-localized native browser validation tooltip the user was seeing

Refs #28516

## Test plan
- [ ] Open a loadpoint, switch to custom surplus mode, clear the enable/disable threshold fields, and confirm the form saves
- [ ] Confirm thresholds set to non-zero values still apply correctly