### PR TITLE
Indicate cache hits in HTTP trace log

### DIFF
--- a/plugin/http.go
+++ b/plugin/http.go
@@ -101,37 +101,39 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 		method: method,
 	}
 
-	// override the transport to accept self-signed certificates
+	// build the cache stack without logging so the logging tripper
+	// can sit outside the cache and see cached responses too
+	var base http.RoundTripper = transport.Default()
 	if insecure {
-		p.Client.Transport = request.NewTripper(log, transport.Insecure())
+		base = transport.Insecure()
 	}
 
 	if cache > 0 {
 		// remove no-cache response headers
-		p.Client.Transport = &transport.Modifier{
+		base = &transport.Modifier{
 			Modifier: func(resp *http.Response) error {
 				dropNoCache(resp, "Cache-Control")
 				dropNoCache(resp, "Pragma")
 				return nil
 			},
-			Base: p.Client.Transport,
+			Base: base,
 		}
 	}
 
 	// http cache
-	p.Client.Transport = &httpcache.Transport{
+	base = &httpcache.Transport{
 		Cache:               mc,
 		MarkCachedResponses: true,
-		Transport:           p.Client.Transport,
+		Transport:           base,
 	}
 
 	if cache > 0 {
 		cacheHeader := fmt.Sprintf("max-age=%d, must-revalidate", int(cache.Seconds()))
-		p.Client.Transport = &transport.Decorator{
+		base = &transport.Decorator{
 			Decorator: transport.DecorateHeaders(map[string]string{
 				"Cache-Control": cacheHeader,
 			}),
-			Base: p.Client.Transport,
+			Base: base,
 		}
 
 		// for cached requests enforce single inflight GET
@@ -139,6 +141,9 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 			p.mu = muForKey(p.url)
 		}
 	}
+
+	// logging is outermost so cache hits are visible in the trace log
+	p.Client.Transport = request.NewTripper(log, base)
 
 	return p
 }

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -130,8 +130,6 @@ func dump(r io.ReadCloser, w *strings.Builder) error {
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	r.log.TRACE.Printf("%s %s", req.Method, req.URL.String())
-
 	// add evcc user agent
 	if req.Header.Get("User-Agent") == "" {
 		req = req.Clone(req.Context())
@@ -166,9 +164,11 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	reqMetric.WithLabelValues(req.URL.Hostname()).Observe(time.Since(startTime).Seconds())
 
+	suffix := ""
 	if err == nil && resp.Header.Get(httpcache.XFromCache) != "" {
-		r.log.TRACE.Println("(cached)")
+		suffix = " (cached)"
 	}
+	r.log.TRACE.Printf("%s %s%s", req.Method, req.URL.String(), suffix)
 
 	if err == nil {
 		resMetric.WithLabelValues(req.URL.Hostname(), strconv.Itoa(resp.StatusCode)).Add(1)

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sandrolain/httpcache"
 )
 
 type roundTripper struct {
@@ -164,6 +165,10 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := r.base.RoundTrip(req)
 
 	reqMetric.WithLabelValues(req.URL.Hostname()).Observe(time.Since(startTime).Seconds())
+
+	if err == nil && resp.Header.Get(httpcache.XFromCache) != "" {
+		r.log.TRACE.Println("(cached)")
+	}
 
 	if err == nil {
 		resMetric.WithLabelValues(req.URL.Hostname(), strconv.Itoa(resp.StatusCode)).Add(1)

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -164,11 +164,11 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	reqMetric.WithLabelValues(req.URL.Hostname()).Observe(time.Since(startTime).Seconds())
 
-	suffix := ""
+	var cached string
 	if err == nil && resp.Header.Get(httpcache.XFromCache) != "" {
-		suffix = " (cached)"
+		cached = " CACHED"
 	}
-	r.log.TRACE.Printf("%s %s%s", req.Method, req.URL.String(), suffix)
+	r.log.TRACE.Printf("%s%s %s", req.Method, cached, req.URL.String())
 
 	if err == nil {
 		resMetric.WithLabelValues(req.URL.Hostname(), strconv.Itoa(resp.StatusCode)).Add(1)


### PR DESCRIPTION
## Summary
- The HTTP plugin's response cache (`httpcache.Transport`) sat outside the logging round-tripper, so cache hits short-circuited before any log was emitted
- Restructure the plugin's transport stack so the logging round-tripper is the outermost layer
- In `util/request/roundtrip.go`, detect `X-From-Cache` (already enabled via `MarkCachedResponses: true`) and emit a `(cached)` trace line on cache hits

Trace output for a cache hit now looks like:
```
TRACE GET https://example.com/api/...
TRACE (cached)
TRACE <response body>
```

## Test plan
- [ ] Configure a templated meter/charger that uses the HTTP plugin with `cache:` set
- [ ] Run with `--log trace` and confirm repeated reads emit one `GET` followed by `(cached)` plus the body, while the first read (cache miss) does not show `(cached)`