### PR TITLE
Charger: tag templates with meter capability

### DIFF
--- a/templates/definition/charger/abb.yaml
+++ b/templates/definition/charger/abb.yaml
@@ -3,7 +3,7 @@ products:
   - brand: ABB
     description:
       generic: Terra AC
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   description:
     de: Erfordert Firmware >= 1.6.5

--- a/templates/definition/charger/abl-em4.yaml
+++ b/templates/definition/charger/abl-em4.yaml
@@ -6,7 +6,7 @@ products:
   - brand: ABL
     description:
       generic: eM4 Twin (SBCx)
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/ac-elwa-2.yaml
+++ b/templates/definition/charger/ac-elwa-2.yaml
@@ -3,6 +3,7 @@ products:
   - brand: my-PV
     description:
       generic: AC ELWA 2
+capabilities: ["meter"]
 group: heating
 requirements:
   description:

--- a/templates/definition/charger/ac-elwa-e.yaml
+++ b/templates/definition/charger/ac-elwa-e.yaml
@@ -3,6 +3,7 @@ products:
   - brand: my-PV
     description:
       generic: AC ELWA-E
+capabilities: ["meter"]
 group: heating
 requirements:
   description:

--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -6,6 +6,7 @@ products:
   - brand: my-PV
     description:
       generic: AC•THOR 9s
+capabilities: ["meter"]
 group: heating
 requirements:
   description:

--- a/templates/definition/charger/alfen.yaml
+++ b/templates/definition/charger/alfen.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Alfen
     description:
       generic: Eve
-capabilities: ["1p3p", "mA", "meter"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   description:
     de: Die "Active load balancing" Lizenz wird benötigt um die Wallbox via Modbus extern zu steuern. In den Einstellungen muss "Active Load Balancing" aktiviert und "Energy Management System" als Data Source ausgewählt werden. Es wird empfohlen "ValidityTime" (Menu "TCP/IP EMS") auf 300s einzustellen. Falls die "Double"-Box verwendet wird müssen beide Ladepunkte getrennt voneinander hinzugefügt werden. Der erste Port (oder einzelne Port) ist unter ID 1 zugänglich, der zweite unter ID 2.

--- a/templates/definition/charger/alfen.yaml
+++ b/templates/definition/charger/alfen.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Alfen
     description:
       generic: Eve
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "meter"]
 requirements:
   description:
     de: Die "Active load balancing" Lizenz wird benötigt um die Wallbox via Modbus extern zu steuern. In den Einstellungen muss "Active Load Balancing" aktiviert und "Energy Management System" als Data Source ausgewählt werden. Es wird empfohlen "ValidityTime" (Menu "TCP/IP EMS") auf 300s einzustellen. Falls die "Double"-Box verwendet wird müssen beide Ladepunkte getrennt voneinander hinzugefügt werden. Der erste Port (oder einzelne Port) ist unter ID 1 zugänglich, der zweite unter ID 2.

--- a/templates/definition/charger/alpitronic.yaml
+++ b/templates/definition/charger/alpitronic.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Alpitronic
     description:
       generic: Hypercharger
-capabilities: ["mA", "rfid", "iso151182", "meter"]
+capabilities: ["iso151182", "mA", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/alpitronic.yaml
+++ b/templates/definition/charger/alpitronic.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Alpitronic
     description:
       generic: Hypercharger
-capabilities: ["mA", "rfid", "iso151182"]
+capabilities: ["mA", "rfid", "iso151182", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/amperfied-solar.yaml
+++ b/templates/definition/charger/amperfied-solar.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Amperfied
     description:
       generic: Wallbox connect.solar
-capabilities: ["mA", "rfid", "1p3p"]
+capabilities: ["mA", "rfid", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/amperfied.yaml
+++ b/templates/definition/charger/amperfied.yaml
@@ -6,7 +6,7 @@ products:
   - brand: Amperfied
     description:
       generic: Wallbox connect.business
-capabilities: ["mA", "rfid"]
+capabilities: ["mA", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/askoheat.yaml
+++ b/templates/definition/charger/askoheat.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Askoma
     description:
       generic: ASKOHEAT+
+capabilities: ["meter"]
 group: heating
 requirements:
   description:

--- a/templates/definition/charger/bender-icc.yaml
+++ b/templates/definition/charger/bender-icc.yaml
@@ -12,7 +12,7 @@ products:
   - brand: Mennekes
     description:
       generic: AMTRON 4Business 700
-capabilities: ["rfid", "mA", "1p3p"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   description:
     de: Die Konfigurationsoption 'Externes Energiemanagement' muss aktiviert sein.

--- a/templates/definition/charger/chargex.yaml
+++ b/templates/definition/charger/chargex.yaml
@@ -6,7 +6,7 @@ products:
   - brand: ChargeX
     description:
       generic: Connect
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/compleo-duo.yaml
+++ b/templates/definition/charger/compleo-duo.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Compleo
     description:
       generic: Duo
-capabilities: ["mA", "rfid", "1p3p"]
+capabilities: ["mA", "rfid", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/compleo-solo.yaml
+++ b/templates/definition/charger/compleo-solo.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Compleo
     description:
       generic: Solo
-capabilities: ["mA", "rfid"]
+capabilities: ["mA", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/dadapower.yaml
+++ b/templates/definition/charger/dadapower.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Dadapower
     description:
       generic: Premium Wallbox
-capabilities: ["1p3p", "mA", "rfid"]
+capabilities: ["1p3p", "mA", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/dadapower.yaml
+++ b/templates/definition/charger/dadapower.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Dadapower
     description:
       generic: Premium Wallbox
-capabilities: ["1p3p", "mA", "rfid", "meter"]
+capabilities: ["mA", "rfid", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/daheimladen-pro.yaml
+++ b/templates/definition/charger/daheimladen-pro.yaml
@@ -6,7 +6,7 @@ requirements:
   description:
     de: Firmware-Anforderungen= Smart/Touch Pro ab "M3W_3.11STP", Business ab "M3W_4.03PTB". Während der Phasen-Umschaltung pausiert die Ladung für zwei Minuten. Informationen zur Ladefreigabe (AutoStart, App, RFID, Button), bitte der Wallbox Dokumentation von DaheimLaden entnehmen.
     en: Firmware requirements= Smart/Touch Pro from "M3W_3.11STP", Business from "M3W_4.03PTB". Charging pauses for two minutes during phase switching. For information regarding charging authorization (AutoStart, App, RFID, Button), please refer to the DaheimLaden wallbox documentation.
-capabilities: ["1p3p", "mA", "rfid"]
+capabilities: ["1p3p", "mA", "rfid", "meter"]
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/daheimladen-pro.yaml
+++ b/templates/definition/charger/daheimladen-pro.yaml
@@ -6,7 +6,7 @@ requirements:
   description:
     de: Firmware-Anforderungen= Smart/Touch Pro ab "M3W_3.11STP", Business ab "M3W_4.03PTB". Während der Phasen-Umschaltung pausiert die Ladung für zwei Minuten. Informationen zur Ladefreigabe (AutoStart, App, RFID, Button), bitte der Wallbox Dokumentation von DaheimLaden entnehmen.
     en: Firmware requirements= Smart/Touch Pro from "M3W_3.11STP", Business from "M3W_4.03PTB". Charging pauses for two minutes during phase switching. For information regarding charging authorization (AutoStart, App, RFID, Button), please refer to the DaheimLaden wallbox documentation.
-capabilities: ["1p3p", "mA", "rfid", "meter"]
+capabilities: ["mA", "rfid", "1p3p", "meter"]
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/daheimladen.yaml
+++ b/templates/definition/charger/daheimladen.yaml
@@ -8,7 +8,7 @@ requirements:
   description:
     de: Erfordert Firmware "3.21" (Smart) bzw. "1.24" (Touch). In den Einstellungen muss "Nachladen" (Smart) bzw. "RSDA" (Touch) aktiviert sein.
     en: Requires firmware "3.21" for Smart and "1.24" for Touch. "Nachladen" (Smart) or "RSDA" (Touch) must be activated in settings.
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 params:
   - name: host
   - name: port

--- a/templates/definition/charger/delta.yaml
+++ b/templates/definition/charger/delta.yaml
@@ -12,7 +12,7 @@ products:
   - brand: Delta
     description:
       generic: Ultra Fast Charger
-capabilities: ["mA", "rfid"]
+capabilities: ["mA", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/e3dc-rscp.yaml
+++ b/templates/definition/charger/e3dc-rscp.yaml
@@ -3,7 +3,7 @@ products:
   - brand: E3/DC
     description:
       generic: Multi Connect II Wallbox
-capabilities: ["1p3p", "rfid", "meter"]
+capabilities: ["rfid", "1p3p", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/e3dc-rscp.yaml
+++ b/templates/definition/charger/e3dc-rscp.yaml
@@ -3,7 +3,7 @@ products:
   - brand: E3/DC
     description:
       generic: Multi Connect II Wallbox
-capabilities: ["1p3p", "rfid"]
+capabilities: ["1p3p", "rfid", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -12,7 +12,7 @@ products:
   - brand: Easee
     description:
       generic: Charge Core
-capabilities: ["1p3p", "rfid"]
+capabilities: ["1p3p", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -12,7 +12,7 @@ products:
   - brand: Easee
     description:
       generic: Charge Core
-capabilities: ["1p3p", "rfid", "meter"]
+capabilities: ["rfid", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/eebus.yaml
+++ b/templates/definition/charger/eebus.yaml
@@ -4,7 +4,7 @@ products:
       de: EEBUS kompatibel
       en: EEBUS compatible
 group: generic
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["eebus"]
 params:

--- a/templates/definition/charger/elli-2.yaml
+++ b/templates/definition/charger/elli-2.yaml
@@ -36,7 +36,7 @@ products:
   - brand: Cupra
     description:
       generic: Charger Pro Eichrecht 2
-capabilities: ["iso151182", "1p3p", "rfid", "mA"]
+capabilities: ["iso151182", "1p3p", "rfid", "mA", "meter"]
 requirements:
   evcc: ["eebus"]
   description:

--- a/templates/definition/charger/elli-2.yaml
+++ b/templates/definition/charger/elli-2.yaml
@@ -36,7 +36,7 @@ products:
   - brand: Cupra
     description:
       generic: Charger Pro Eichrecht 2
-capabilities: ["iso151182", "1p3p", "rfid", "mA", "meter"]
+capabilities: ["iso151182", "mA", "rfid", "1p3p", "meter"]
 requirements:
   evcc: ["eebus"]
   description:

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -15,7 +15,7 @@ products:
   - brand: Audi
     description:
       generic: Wallbox pro
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["eebus"]
   description:

--- a/templates/definition/charger/em2go-duo.yaml
+++ b/templates/definition/charger/em2go-duo.yaml
@@ -3,6 +3,7 @@ products:
   - brand: EM2GO
     description:
       generic: Duo Power
+capabilities: ["meter"]
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/em2go-home.yaml
+++ b/templates/definition/charger/em2go-home.yaml
@@ -3,7 +3,7 @@ products:
   - brand: EM2GO
     description:
       generic: Home
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "meter"]
 requirements:
   description:
     de: "Benötigt FW version >= E3C_V1.1. mA Regelung benötigt FW version >= E3C_V1.3."

--- a/templates/definition/charger/em2go-home.yaml
+++ b/templates/definition/charger/em2go-home.yaml
@@ -3,7 +3,7 @@ products:
   - brand: EM2GO
     description:
       generic: Home
-capabilities: ["1p3p", "mA", "meter"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   description:
     de: "Benötigt FW version >= E3C_V1.1. mA Regelung benötigt FW version >= E3C_V1.3."

--- a/templates/definition/charger/em2go.yaml
+++ b/templates/definition/charger/em2go.yaml
@@ -3,7 +3,7 @@ products:
   - brand: EM2GO
     description:
       generic: Pro Power (OCPP/ONC)
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   description:
     de: "Aktuelle Firmware mit Modbus-Unterstützung notwendig (Pro Power: 1.01 bzw. OCPP/ONC: 3.15)"

--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -9,6 +9,7 @@ products:
   - brand: Junkers
     description:
       generic: SG Ready
+capabilities: ["meter"]
 group: heating
 requirements:
   description:

--- a/templates/definition/charger/eprowallbox.yaml
+++ b/templates/definition/charger/eprowallbox.yaml
@@ -6,7 +6,7 @@ products:
   - brand: Free2Move
     description:
       generic: eProWallbox Move
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/etrel-duo.yaml
+++ b/templates/definition/charger/etrel-duo.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Etrel
     description:
       generic: INCH Duo
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/etrel.yaml
+++ b/templates/definition/charger/etrel.yaml
@@ -6,7 +6,7 @@ products:
   - brand: Sonnen
     description:
       generic: sonnenCharger
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/evecube.yaml
+++ b/templates/definition/charger/evecube.yaml
@@ -3,7 +3,7 @@ products:
   - brand: EV Expert
     description:
       generic: EVECUBE
-capabilities: ["1p3p", "rfid"]
+capabilities: ["1p3p", "rfid", "meter"]
 requirements:
   description:
     en: Requires HTTP API access.

--- a/templates/definition/charger/evecube.yaml
+++ b/templates/definition/charger/evecube.yaml
@@ -3,7 +3,7 @@ products:
   - brand: EV Expert
     description:
       generic: EVECUBE
-capabilities: ["1p3p", "rfid", "meter"]
+capabilities: ["rfid", "1p3p", "meter"]
 requirements:
   description:
     en: Requires HTTP API access.

--- a/templates/definition/charger/evsemaster-udp.yaml
+++ b/templates/definition/charger/evsemaster-udp.yaml
@@ -1,4 +1,5 @@
 template: evsemaster-udp
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship", "skiptest"]
   description:

--- a/templates/definition/charger/fritzdect.yaml
+++ b/templates/definition/charger/fritzdect.yaml
@@ -15,6 +15,7 @@ products:
   - brand: "FRITZ!"
     description:
       generic: "FRITZ!Smart Energy 210"
+capabilities: ["meter"]
 group: switchsockets
 params:
   - name: uri

--- a/templates/definition/charger/fronius-wattpilot.yaml
+++ b/templates/definition/charger/fronius-wattpilot.yaml
@@ -4,7 +4,7 @@ products:
   - brand: Fronius
     description:
       generic: Wattpilot
-capabilities: ["1p3p", "rfid"]
+capabilities: ["1p3p", "rfid", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/fronius-wattpilot.yaml
+++ b/templates/definition/charger/fronius-wattpilot.yaml
@@ -4,7 +4,7 @@ products:
   - brand: Fronius
     description:
       generic: Wattpilot
-capabilities: ["1p3p", "rfid", "meter"]
+capabilities: ["rfid", "1p3p", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/ghost.yaml
+++ b/templates/definition/charger/ghost.yaml
@@ -6,7 +6,7 @@ products:
   - brand: Kontron Solar
     description:
       generic: Charger
-capabilities: ["iso151182", "1p3p", "rfid", "mA", "meter"]
+capabilities: ["iso151182", "mA", "rfid", "1p3p", "meter"]
 requirements:
   evcc: ["eebus"]
   description:

--- a/templates/definition/charger/ghost.yaml
+++ b/templates/definition/charger/ghost.yaml
@@ -6,7 +6,7 @@ products:
   - brand: Kontron Solar
     description:
       generic: Charger
-capabilities: ["iso151182", "1p3p", "rfid", "mA"]
+capabilities: ["iso151182", "1p3p", "rfid", "mA", "meter"]
 requirements:
   evcc: ["eebus"]
   description:

--- a/templates/definition/charger/go-e-v3.yaml
+++ b/templates/definition/charger/go-e-v3.yaml
@@ -10,7 +10,7 @@ products:
   - brand: go-e
     description:
       generic: Charger V3
-capabilities: ["1p3p", "rfid"]
+capabilities: ["rfid", "1p3p"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/hardybarth-ecb1.yaml
+++ b/templates/definition/charger/hardybarth-ecb1.yaml
@@ -6,6 +6,7 @@ products:
   - brand: echarge
     description:
       generic: cPH1
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/heidelberg.yaml
+++ b/templates/definition/charger/heidelberg.yaml
@@ -12,7 +12,7 @@ products:
   - brand: Amperfied
     description:
       generic: Wallbox Energy Control
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   description:
     de: Bitte das Handbuch zur Verkabelung und Konfiguration genau lesen. Alle Boxen müssen für die externe Steuerung auf Follower-Modus konfiguriert sein (DIP S5/4 OFF). Jede Box braucht eine individuelle Modbus-ID (DIP S4). Auf korrekte RS485-Verkabelung inkl. Busterminierung (DIP S6/2) achten.

--- a/templates/definition/charger/hesotec.yaml
+++ b/templates/definition/charger/hesotec.yaml
@@ -6,6 +6,7 @@ products:
   - brand: Hesotec
     description:
       generic: eBox
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/homematic.yaml
+++ b/templates/definition/charger/homematic.yaml
@@ -1,6 +1,7 @@
 template: homematic
 products:
   - brand: Homematic IP
+capabilities: ["meter"]
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/homewizard.yaml
+++ b/templates/definition/charger/homewizard.yaml
@@ -1,6 +1,7 @@
 template: homewizard
 products:
   - brand: HomeWizard
+capabilities: ["meter"]
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/idm.yaml
+++ b/templates/definition/charger/idm.yaml
@@ -1,6 +1,7 @@
 template: idm
 products:
   - brand: IDM
+capabilities: ["meter"]
 group: heating
 requirements:
   # evcc: ["sponsorship"]

--- a/templates/definition/charger/innogy-ebox.yaml
+++ b/templates/definition/charger/innogy-ebox.yaml
@@ -9,7 +9,7 @@ products:
   - brand: Compleo
     description:
       generic: eBox
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/kathrein.yaml
+++ b/templates/definition/charger/kathrein.yaml
@@ -18,7 +18,7 @@ products:
   - brand: Kathrein
     description:
       generic: KWB-AC60 E
-capabilities: ["1p3p", "mA", "rfid", "meter"]
+capabilities: ["mA", "rfid", "1p3p", "meter"]
 requirements:
   description:
     de: Der Modbus-Server (TCP-Port 502) muss über die Weboberfläche der Wallbox aktiviert werden. Getestet mit Firmware-Version v2.7.0

--- a/templates/definition/charger/kathrein.yaml
+++ b/templates/definition/charger/kathrein.yaml
@@ -18,7 +18,7 @@ products:
   - brand: Kathrein
     description:
       generic: KWB-AC60 E
-capabilities: ["1p3p", "mA", "rfid"]
+capabilities: ["1p3p", "mA", "rfid", "meter"]
 requirements:
   description:
     de: Der Modbus-Server (TCP-Port 502) muss über die Weboberfläche der Wallbox aktiviert werden. Getestet mit Firmware-Version v2.7.0

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -15,7 +15,7 @@ products:
   - brand: SolarEdge
     description:
       generic: Home EV Charger
-capabilities: ["1p3p", "mA", "rfid"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/kermi.yaml
+++ b/templates/definition/charger/kermi.yaml
@@ -6,6 +6,7 @@ products:
   - brand: Kermi
     description:
       generic: x-center pro
+capabilities: ["meter"]
 group: heating
 # requirements:
 #   evcc: ["sponsorship"]

--- a/templates/definition/charger/kse.yaml
+++ b/templates/definition/charger/kse.yaml
@@ -3,7 +3,7 @@ products:
   - brand: KSE
     description:
       generic: wBX16
-capabilities: ["rfid", "1p3p"]
+capabilities: ["rfid", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -8,6 +8,7 @@ products:
     description:
       de: EU-L Serie
       en: EU-L Series
+capabilities: ["meter"]
 group: heating
 requirements:
   # evcc: ["sponsorship"]

--- a/templates/definition/charger/lektrico.yaml
+++ b/templates/definition/charger/lektrico.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Lektrico
     description:
       generic: 1P7K / 3P22K Charging Station
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/mennekes-compact.yaml
+++ b/templates/definition/charger/mennekes-compact.yaml
@@ -10,7 +10,7 @@ products:
   - brand: Kostal
     description:
       generic: Enector
-capabilities: ["1p3p", "mA", "meter"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/mennekes-compact.yaml
+++ b/templates/definition/charger/mennekes-compact.yaml
@@ -10,7 +10,7 @@ products:
   - brand: Kostal
     description:
       generic: Enector
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/mennekes-hcc3.yaml
+++ b/templates/definition/charger/mennekes-hcc3.yaml
@@ -1,4 +1,5 @@
 template: mennekes-hcc3
+capabilities: ["meter"]
 covers: ["amtron", "menneckes-hcc3"]
 products:
   - brand: Mennekes

--- a/templates/definition/charger/mtec.yaml
+++ b/templates/definition/charger/mtec.yaml
@@ -1,6 +1,7 @@
 template: MTec
 products:
   - brand: M-Tec
+capabilities: ["meter"]
 group: heating
 requirements:
   # evcc: ["sponsorship"]

--- a/templates/definition/charger/mystrom.yaml
+++ b/templates/definition/charger/mystrom.yaml
@@ -3,6 +3,7 @@ products:
   - brand: myStrom
     description:
       generic: Switch
+capabilities: ["meter"]
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/neoom-n-plus.yaml
+++ b/templates/definition/charger/neoom-n-plus.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Neoom
     description:
       generic: N+
-capabilities: ["mA", "1p3p"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/neoom-n.yaml
+++ b/templates/definition/charger/neoom-n.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Neoom
     description:
       generic: N
-capabilities: ["mA", "1p3p"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/nexblue.yaml
+++ b/templates/definition/charger/nexblue.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Nexblue
     description:
       generic: Edge 2
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/nrggen2.yaml
+++ b/templates/definition/charger/nrggen2.yaml
@@ -5,7 +5,7 @@ products:
       generic: Gen2
 requirements:
   evcc: ["sponsorship"]
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "meter"]
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/nrggen2.yaml
+++ b/templates/definition/charger/nrggen2.yaml
@@ -5,7 +5,7 @@ products:
       generic: Gen2
 requirements:
   evcc: ["sponsorship"]
-capabilities: ["1p3p", "mA", "meter"]
+capabilities: ["mA", "1p3p", "meter"]
 params:
   - name: modbus
     choice: ["tcpip"]

--- a/templates/definition/charger/nrgkick-bluetooth.yaml
+++ b/templates/definition/charger/nrgkick-bluetooth.yaml
@@ -4,6 +4,7 @@ products:
   - brand: NRGkick
     description:
       generic: Bluetooth
+capabilities: ["meter"]
 requirements:
   description:
     de: NRGkick Ladeeinheit via Bluetooth (älter als 2022/2023)

--- a/templates/definition/charger/nrgkick-connect.yaml
+++ b/templates/definition/charger/nrgkick-connect.yaml
@@ -3,6 +3,7 @@ products:
   - brand: NRGkick
     description:
       generic: Connect
+capabilities: ["meter"]
 requirements:
   description:
     de: NRGkick Ladeeinheit via HTTP (älter als 2022/2023)

--- a/templates/definition/charger/openevse.yaml
+++ b/templates/definition/charger/openevse.yaml
@@ -1,6 +1,7 @@
 template: openevse
 products:
   - brand: OpenEVSE
+capabilities: ["meter"]
 requirements:
   description:
     en: Requires firmware 7.0 or later.

--- a/templates/definition/charger/openwb-2.0.yaml
+++ b/templates/definition/charger/openwb-2.0.yaml
@@ -3,7 +3,7 @@ products:
   - brand: openWB
     description:
       generic: Software 2.x
-capabilities: ["1p3p", "mA", "rfid"]
+capabilities: ["1p3p", "mA", "rfid", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/openwb-2.0.yaml
+++ b/templates/definition/charger/openwb-2.0.yaml
@@ -3,7 +3,7 @@ products:
   - brand: openWB
     description:
       generic: Software 2.x
-capabilities: ["1p3p", "mA", "rfid", "meter"]
+capabilities: ["mA", "rfid", "1p3p", "meter"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/openwb-native.yaml
+++ b/templates/definition/charger/openwb-native.yaml
@@ -3,7 +3,7 @@ products:
   - brand: openWB
     description:
       generic: Embedded software replacement
-capabilities: ["1p3p", "rfid", "mA"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   description:
     de: |

--- a/templates/definition/charger/openwb-pro.yaml
+++ b/templates/definition/charger/openwb-pro.yaml
@@ -3,7 +3,7 @@ products:
   - brand: openWB
     description:
       generic: Pro
-capabilities: ["1p3p", "mA", "iso151182", "meter"]
+capabilities: ["iso151182", "mA", "1p3p", "meter"]
 params:
   - name: host
 render: |

--- a/templates/definition/charger/openwb-pro.yaml
+++ b/templates/definition/charger/openwb-pro.yaml
@@ -3,7 +3,7 @@ products:
   - brand: openWB
     description:
       generic: Pro
-capabilities: ["1p3p", "mA", "iso151182"]
+capabilities: ["1p3p", "mA", "iso151182", "meter"]
 params:
   - name: host
 render: |

--- a/templates/definition/charger/openwb.yaml
+++ b/templates/definition/charger/openwb.yaml
@@ -3,6 +3,7 @@ products:
   - brand: openWB
     description:
       generic: series2
+capabilities: ["meter"]
 requirements:
   description:
     en: The wallbox has to be configured as loadpoint.

--- a/templates/definition/charger/pantabox.yaml
+++ b/templates/definition/charger/pantabox.yaml
@@ -3,6 +3,7 @@ products:
   - brand: INRO
     description:
       generic: Pantabox
+capabilities: ["meter"]
 params:
   - name: host
 render: |

--- a/templates/definition/charger/peblar.yaml
+++ b/templates/definition/charger/peblar.yaml
@@ -15,7 +15,7 @@ products:
   - brand: ChargeLine
     description:
       generic: Business Wallbox
-capabilities: ["1p3p", "mA", "meter"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/peblar.yaml
+++ b/templates/definition/charger/peblar.yaml
@@ -15,7 +15,7 @@ products:
   - brand: ChargeLine
     description:
       generic: Business Wallbox
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/plugchoice.yaml
+++ b/templates/definition/charger/plugchoice.yaml
@@ -1,6 +1,7 @@
 template: plugchoice
 products:
   - brand: Plugchoice
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship", "skiptest"]
   description:

--- a/templates/definition/charger/porsche-pmcc.yaml
+++ b/templates/definition/charger/porsche-pmcc.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Porsche
     description:
       generic: Mobile Charger Connect
-capabilities: ["iso151182", "mA"]
+capabilities: ["iso151182", "mA", "meter"]
 requirements:
   evcc: ["eebus"]
 params:

--- a/templates/definition/charger/porsche-pmcp.yaml
+++ b/templates/definition/charger/porsche-pmcp.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Porsche
     description:
       generic: Mobile Charger Plus
+capabilities: ["meter"]
 requirements:
   evcc: ["eebus"]
 params:

--- a/templates/definition/charger/porsche-wallbox.yaml
+++ b/templates/definition/charger/porsche-wallbox.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Porsche
     description:
       generic: Wallbox
-capabilities: ["iso151182", "1p3p", "rfid", "mA"]
+capabilities: ["iso151182", "1p3p", "rfid", "mA", "meter"]
 requirements:
   evcc: ["eebus"]
   description:

--- a/templates/definition/charger/porsche-wallbox.yaml
+++ b/templates/definition/charger/porsche-wallbox.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Porsche
     description:
       generic: Wallbox
-capabilities: ["iso151182", "1p3p", "rfid", "mA", "meter"]
+capabilities: ["iso151182", "mA", "rfid", "1p3p", "meter"]
 requirements:
   evcc: ["eebus"]
   description:

--- a/templates/definition/charger/pulsatrix.yaml
+++ b/templates/definition/charger/pulsatrix.yaml
@@ -1,6 +1,7 @@
 template: pulsatrix
 products:
   - brand: Pulsatrix
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/raedian.yaml
+++ b/templates/definition/charger/raedian.yaml
@@ -6,7 +6,7 @@ products:
   - brand: RAEDIAN
     description:
       generic: NEX AC Wallbox
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "meter"]
 params:
   - name: modbus
     choice: ["rs485", "tcpip"]

--- a/templates/definition/charger/raedian.yaml
+++ b/templates/definition/charger/raedian.yaml
@@ -6,7 +6,7 @@ products:
   - brand: RAEDIAN
     description:
       generic: NEX AC Wallbox
-capabilities: ["1p3p", "mA", "meter"]
+capabilities: ["mA", "1p3p", "meter"]
 params:
   - name: modbus
     choice: ["rs485", "tcpip"]

--- a/templates/definition/charger/scheider-evlink-v3.yaml
+++ b/templates/definition/charger/scheider-evlink-v3.yaml
@@ -1,4 +1,5 @@
 template: schneider-evlink-v3
+capabilities: ["meter"]
 covers: ["schneider-evlink"]
 products:
   - brand: Schneider

--- a/templates/definition/charger/semp-sma.yaml
+++ b/templates/definition/charger/semp-sma.yaml
@@ -6,7 +6,7 @@ products:
   - brand: SMA
     description:
       generic: eCharger (SEMP)
-capabilities: ["mA", "1p3p"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship", "skiptest"]
   description:

--- a/templates/definition/charger/semp.yaml
+++ b/templates/definition/charger/semp.yaml
@@ -4,7 +4,7 @@ products:
       de: SEMP kompatibel
       en: SEMP compatible
 group: generic
-capabilities: ["mA", "1p3p"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship", "skiptest"]
   description:

--- a/templates/definition/charger/senec-plus.yaml
+++ b/templates/definition/charger/senec-plus.yaml
@@ -3,7 +3,7 @@ products:
   - brand: SENEC
     description:
       generic: Plus
-capabilities: ["mA", "1p3p"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/senec-premium.yaml
+++ b/templates/definition/charger/senec-premium.yaml
@@ -3,7 +3,7 @@ products:
   - brand: SENEC
     description:
       generic: Premium
-capabilities: ["mA", "rfid", "1p3p"]
+capabilities: ["mA", "rfid", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/shelly-topac.yaml
+++ b/templates/definition/charger/shelly-topac.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Shelly
     description:
       generic: Top AC Portable EV Charger
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   description:
     de: "'auto_charge' muss auf false gesetzt werden."

--- a/templates/definition/charger/shelly.yaml
+++ b/templates/definition/charger/shelly.yaml
@@ -4,6 +4,7 @@ products:
   - { brand: Shelly, description: { generic: Plus 1 } }
   - { brand: Shelly, description: { generic: Pro 1 } }
   - { brand: Shelly, description: { generic: Plug S } }
+capabilities: ["meter"]
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/sigenergy.yaml
+++ b/templates/definition/charger/sigenergy.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Sigenergy
     description:
       generic: EVAC series
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/smaevcharger.yaml
+++ b/templates/definition/charger/smaevcharger.yaml
@@ -7,7 +7,7 @@ products:
   - brand: SMA
     description:
       generic: eCharger (HTTP)
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/smartevse.yaml
+++ b/templates/definition/charger/smartevse.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Edgetech
     description:
       generic: Smart EVSE
-capabilities: ["1p3p"]
+capabilities: ["1p3p", "meter"]
 params:
   - name: modbus
     choice: ["rs485"]

--- a/templates/definition/charger/smartwb.yaml
+++ b/templates/definition/charger/smartwb.yaml
@@ -2,6 +2,7 @@ template: smartwb
 products:
   - description:
       generic: smartWB
+capabilities: ["meter"]
 params:
   - name: host
 render: |

--- a/templates/definition/charger/solax-g2.yaml
+++ b/templates/definition/charger/solax-g2.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Solax
     description:
       generic: X3-HAC
-capabilities: ["1p3p", "mA", "meter"]
+capabilities: ["mA", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/solax-g2.yaml
+++ b/templates/definition/charger/solax-g2.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Solax
     description:
       generic: X3-HAC
-capabilities: ["1p3p", "mA"]
+capabilities: ["1p3p", "mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/solax.yaml
+++ b/templates/definition/charger/solax.yaml
@@ -9,7 +9,7 @@ products:
   - brand: Qcells
     description:
       generic: Q.HOME EDRIVE A
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/sungrow.yaml
+++ b/templates/definition/charger/sungrow.yaml
@@ -6,7 +6,7 @@ products:
   - brand: Sungrow
     description:
       generic: AC22E-01
-capabilities: ["mA", "1p3p"]
+capabilities: ["mA", "1p3p", "meter"]
 params:
   - name: modbus
     choice: ["rs485", "tcpip"]

--- a/templates/definition/charger/tapo.yaml
+++ b/templates/definition/charger/tapo.yaml
@@ -3,6 +3,7 @@ products:
   - brand: TP-Link
     description:
       generic: Tapo P-Series Smart Plug
+capabilities: ["meter"]
 group: switchsockets
 requirements:
   description:

--- a/templates/definition/charger/tasmota.yaml
+++ b/templates/definition/charger/tasmota.yaml
@@ -4,6 +4,7 @@ products:
     description:
       de: einphasig
       en: single phase
+capabilities: ["meter"]
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/tessie.yaml
+++ b/templates/definition/charger/tessie.yaml
@@ -2,6 +2,7 @@ template: tessie
 products:
   - description:
       generic: Tessie
+capabilities: ["meter"]
 requirements:
   description:
     en: Charger connected via the Tessie API. Allows control of charging state and configuration of maximum current.

--- a/templates/definition/charger/tinkerforge-warp-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp-ws.yaml
@@ -6,7 +6,7 @@ products:
   - { brand: TinkerForge, description: { generic: WARP2 Pro } }
   - { brand: TinkerForge, description: { generic: WARP1 Smart } }
   - { brand: TinkerForge, description: { generic: WARP1 Pro } }
-capabilities: ["mA", "1p3p", "rfid"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   description:
     de: Falls notwendig wird die WARP-eigene automatische Phasenumschaltung von EVCC beim Verbinden mit der Wallbox deaktiviert. Siehe [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).

--- a/templates/definition/charger/tinkerforge-warp.yaml
+++ b/templates/definition/charger/tinkerforge-warp.yaml
@@ -9,7 +9,7 @@ products:
   - brand: TinkerForge
     description:
       generic: WARP Charger Pro
-capabilities: ["mA", "1p3p", "rfid"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   description:
     en: WARP Firmware v2 required. Automatic phase switching requires the additional WARP Energy Manager.

--- a/templates/definition/charger/tinkerforge-warp2-em-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp2-em-ws.yaml
@@ -2,7 +2,7 @@ template: tinkerforge-warp2-em-ws
 products:
   - { brand: TinkerForge, description: { generic: WARP2 Smart + Energy Manager } }
   - { brand: TinkerForge, description: { generic: WARP2 Pro + Energy Manager } }
-capabilities: ["mA", "1p3p", "rfid"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   description:
     de: Firmware v2 erforderlich. Die WARP-eigene automatische Phasenumschaltung wird von EVCC beim Verbinden mit der Wallbox deaktiviert. Siehe [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).

--- a/templates/definition/charger/tinkerforge-warp3-smart.yaml
+++ b/templates/definition/charger/tinkerforge-warp3-smart.yaml
@@ -4,7 +4,7 @@ products:
   - brand: TinkerForge
     description:
       generic: WARP3 Charger Smart
-capabilities: ["mA", "1p3p", "rfid"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   evcc: ["skiptest"]
 params:

--- a/templates/definition/charger/tinkerforge-warp3.yaml
+++ b/templates/definition/charger/tinkerforge-warp3.yaml
@@ -4,7 +4,7 @@ products:
   - brand: TinkerForge
     description:
       generic: WARP3 Charger Pro
-capabilities: ["mA", "1p3p", "rfid"]
+capabilities: ["mA", "rfid", "1p3p"]
 requirements:
   description:
     de: Die automatische Phasenumschaltung bei 1p Fahrzeugen muss deaktiviert sein. Siehe [docs.warp-charger.com](https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_phase_auto_switch_warp3).

--- a/templates/definition/charger/tplink.yaml
+++ b/templates/definition/charger/tplink.yaml
@@ -3,6 +3,7 @@ products:
   - brand: TP-Link
     description:
       generic: H-Series Smart Plug
+capabilities: ["meter"]
 group: switchsockets
 params:
   - name: host

--- a/templates/definition/charger/twc3.yaml
+++ b/templates/definition/charger/twc3.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Tesla
     description:
       generic: Wall Connector (Gen 3)
+capabilities: ["meter"]
 requirements:
   description:
     en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be selected at the TWC3 loadpoint. At this time only Tesla vehicles listed on [docs.evcc.io](https://docs.evcc.io/en/docs/devices/vehicles#tesla) are supported.

--- a/templates/definition/charger/v2c.yaml
+++ b/templates/definition/charger/v2c.yaml
@@ -1,4 +1,5 @@
 template: v2c
+capabilities: ["meter"]
 covers: ["trydan"]
 products:
   - brand: V2C

--- a/templates/definition/charger/versicharge.yaml
+++ b/templates/definition/charger/versicharge.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Siemens
     description:
       generic: Versicharge GEN3
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:

--- a/templates/definition/charger/vestel.yaml
+++ b/templates/definition/charger/vestel.yaml
@@ -16,7 +16,7 @@ products:
   - brand: E.ON Drive
     description:
       generic: vBox
-capabilities: ["rfid", "1p3p"]
+capabilities: ["rfid", "1p3p", "meter"]
 requirements:
   description:
     de: 1P3P erfordert Firmware 3.187.0 oder neuer, RFID erfordert 3.156.0 oder neuer.

--- a/templates/definition/charger/victron-evcs.yaml
+++ b/templates/definition/charger/victron-evcs.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Victron
     description:
       generic: EV Charging Station
-capabilities: ["1p3p"]
+capabilities: ["1p3p", "meter"]
 requirements:
   description:
     en: |

--- a/templates/definition/charger/victron.yaml
+++ b/templates/definition/charger/victron.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Victron
     description:
       generic: EV Charging Station (via GX)
+capabilities: ["meter"]
 requirements:
   description:
     en: Enter the host of the GX device (not the charger). The charger has to be in manual mode and Modbus has to be configured for ID 100.

--- a/templates/definition/charger/voltie.yaml
+++ b/templates/definition/charger/voltie.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Voltie
     description:
       generic: Charger
-capabilities: ["mA"]
+capabilities: ["mA", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/volttime.yaml
+++ b/templates/definition/charger/volttime.yaml
@@ -12,6 +12,7 @@ products:
   - brand: Volt Time
     description:
       generic: One
+capabilities: ["meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/wallbe-meter.yaml
+++ b/templates/definition/charger/wallbe-meter.yaml
@@ -9,6 +9,7 @@ products:
     description:
       de: Pro (ohne Strommessgerät)
       en: Pro (without meter)
+capabilities: ["meter"]
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.

--- a/templates/definition/charger/wallbe-pre2019-meter.yaml
+++ b/templates/definition/charger/wallbe-pre2019-meter.yaml
@@ -9,6 +9,7 @@ products:
     description:
       de: Pro (vor ~2019, ohne Strommessgerät)
       en: Pro (pre ~2019, without meter)
+capabilities: ["meter"]
 requirements:
   description:
     en: DIP switch 10 must be set to 'ON'.

--- a/templates/definition/charger/webasto-next.yaml
+++ b/templates/definition/charger/webasto-next.yaml
@@ -6,7 +6,7 @@ products:
   - brand: Webasto
     description:
       generic: NEXT
-capabilities: ["rfid"]
+capabilities: ["rfid", "meter"]
 requirements:
   description:
     de: Modus "HEMS activated" muss aktiviert sein. RFID-Tags können durch evcc nur gelesen werden.

--- a/templates/definition/charger/weidmüller.yaml
+++ b/templates/definition/charger/weidmüller.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Weidmüller
     description:
       generic: AC Smart
-capabilities: ["1p3p", "rfid", "meter"]
+capabilities: ["rfid", "1p3p", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/weidmüller.yaml
+++ b/templates/definition/charger/weidmüller.yaml
@@ -3,7 +3,7 @@ products:
   - brand: Weidmüller
     description:
       generic: AC Smart
-capabilities: ["1p3p", "rfid"]
+capabilities: ["1p3p", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/templates/definition/charger/zaptec.yaml
+++ b/templates/definition/charger/zaptec.yaml
@@ -9,7 +9,7 @@ products:
   - brand: Zaptec
     description:
       generic: Pro
-capabilities: ["rfid"]
+capabilities: ["rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
 params:

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -64,9 +64,10 @@ const (
 	CapabilityRFID           = "rfid"            // RFID support
 	Capability1p3p           = "1p3p"            // 1P/3P phase switching support
 	CapabilityBatteryControl = "battery-control" // Battery control support
+	CapabilityMeter          = "meter"           // Built-in energy meter support
 )
 
-var ValidCapabilities = []string{CapabilityISO151182, CapabilityMilliAmps, CapabilityRFID, Capability1p3p, CapabilityBatteryControl}
+var ValidCapabilities = []string{CapabilityISO151182, CapabilityMilliAmps, CapabilityRFID, Capability1p3p, CapabilityBatteryControl, CapabilityMeter}
 
 const (
 	RequirementEEBUS       = "eebus"       // EEBUS Setup is required


### PR DESCRIPTION
## Summary
- Introduces a new `meter` template capability (`util/templates/types.go`)
- Tags 99 charger templates whose Go implementation **unconditionally** exposes `CurrentPower()` — either via a direct struct method or a decorator that is always wired with a non-nil `currentPower` argument
- Chargers that only conditionally provide CurrentPower (e.g., feature/register-detection, optional `power:` block, sponsor-gated, optional URL) are intentionally **not** tagged

Closes #11692

## Categories of touched templates
- Direct struct method: abb, abl-em4, alfen, alpitronic, amperfied, chargex, compleo (+ senec/neoom variants), dadapower, daheimladen (+ pro), delta, e3dc-rscp, easee, em2go (+ home/duo), eprowallbox, etrel (+ duo), evecube, evsemaster-udp, fronius-wattpilot, hardybarth-ecb1, heidelberg, hesotec, innogy-ebox, kathrein, kse, lektrico, mennekes-compact, mennekes-hcc3, mypv (ac-elwa-2/ac-thor/ac-elwa-e), nexblue, nrggen2, nrgkick (bluetooth/connect), openevse, openwb (+ 2.0/pro), pantabox, peblar, plugchoice, pulsatrix, raedian, schneider-evlink-v3, semp (+ semp-sma), shelly-topac, sigenergy, smaevcharger, smartevse, solax (+ g2), sungrow, tessie, twc3, v2c, versicharge, vestel, victron (+ evcs), voltie, volttime, webasto-next, weidmüller, zaptec
- Switchsocket pattern with always-bound CurrentPower: fritzdect, homematic, homewizard, mystrom, shelly, tasmota, tapo, tplink, shelly-topac
- EEBus chargers that always render `meter: true`: eebus, elli-2, elli-charger-pro, ghost, porsche-pmcc/pmcp/wallbox
- Heatpump templates with always-rendered `power:` block: askoheat, idm, kermi, lambda-zewotherm, mtec
- sgready: emsesp
- Wallbe variants with `meter.power: true` always set: wallbe-meter, wallbe-pre2019-meter
- smartwb (renders `evsewifi` with `meter.power: true`)

## Skipped (conditional CurrentPower)
- All OCPP variants (`powerG` only set on `HasMeasurement(PowerActiveImport)`)
- abl, bender (cc/icc), cfos, etek, hardybarth-salia, keba-modbus (+p40), keba-udp, pcelectric (+ garo), phoenix-charx/em-eth/ev-eth, smart-evse, vanilla wallbe.yaml/wallbe-pre2019, warp-* (tinkerforge/warp-ws/warp2/warp3), evsewifi
- vaillant (depends on remote API response)
- sgready templates without `power:` (daikin-homehub-air2air, daikin-homehub, glen-dimplex, lg-therma, luxtronik, nibe-s-series, stiebel-lwa, stiebel-wpm, viessmann, weishaupt-wpm), heatpump templates without `power:` (ochsner-bwwp, xtherma)
- homeassistant.yaml (`power` is optional/advanced), homeassistant-switch (`standbypower<0` disables it)

## Skipped (no CurrentPower at all)
- alphatec, evsedin, obo, openwb-native, phoenix-ev-ser, pracht-alpha, pulsares, sgready-relay, vehicle-api, switchsocket (generic), demo-charger, demo-heatpump, icharge-cion

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./util/templates/...` passes (capability validation lints all entries)
- [ ] Verify the docs site picks up the new `meter` capability tag for filtering once `make docs` regenerates