### PR TITLE
Drop unused eebus and mqtt requirement values

### DIFF
--- a/templates/definition/charger/eebus.yaml
+++ b/templates/definition/charger/eebus.yaml
@@ -5,8 +5,6 @@ products:
       en: EEBUS compatible
 group: generic
 capabilities: ["mA"]
-requirements:
-  evcc: ["eebus"]
 params:
   - preset: eebus
 render: |

--- a/templates/definition/charger/elli-2.yaml
+++ b/templates/definition/charger/elli-2.yaml
@@ -38,7 +38,6 @@ products:
       generic: Charger Pro Eichrecht 2
 capabilities: ["iso151182", "1p3p", "rfid", "mA"]
 requirements:
-  evcc: ["eebus"]
   description:
     de: |
       Das PV-Überschussladen der Wallbox muss deaktiviert sein (Ladeverwaltung -> Ladeeinstellungen -> PV-Überschussladen aus).

--- a/templates/definition/charger/elli-charger-connect.yaml
+++ b/templates/definition/charger/elli-charger-connect.yaml
@@ -17,7 +17,6 @@ products:
       generic: Wallbox plus
 capabilities: ["mA"]
 requirements:
-  evcc: ["eebus"]
   description:
     de: |
       Dem Gerät muss eine feste IP Adresse zugewiesen sein (Manuell oder per DHCP).

--- a/templates/definition/charger/elli-charger-pro.yaml
+++ b/templates/definition/charger/elli-charger-pro.yaml
@@ -17,7 +17,6 @@ products:
       generic: Wallbox pro
 capabilities: ["mA"]
 requirements:
-  evcc: ["eebus"]
   description:
     de: |
       Dem Gerät muss eine feste IP Adresse zugewiesen sein (Manuell oder per DHCP).

--- a/templates/definition/charger/evbox-livo.yaml
+++ b/templates/definition/charger/evbox-livo.yaml
@@ -4,7 +4,6 @@ products:
     description:
       generic: Livo
 requirements:
-  evcc: ["eebus"]
   description:
     de: Das Gerät benötigt eine feste IP Adresse. Es ist wichtig, zuerst EEBus einzurichten. Danach erkennt das Ladegerät evcc als HEMS-Gerät im Netzwerk. Verwende das Installationstool, um evcc als HEMS auszuwählen. Kopiere anschließend den angegebenen SKI aus der Installations-App und füge ihn zur Konfiguration hinzu.
     en: The device requires a fixed IP address. It's important to set up EEBus first. After setting up EEBus the charger will recognize evcc as a HEMS device on the network. Please use the installer tool to select evcc as HEMS. After this has been done, copy the given SKI from the Install app and add it to the configuration.

--- a/templates/definition/charger/ghost.yaml
+++ b/templates/definition/charger/ghost.yaml
@@ -8,7 +8,6 @@ products:
       generic: Charger
 capabilities: ["iso151182", "1p3p", "rfid", "mA"]
 requirements:
-  evcc: ["eebus"]
   description:
     de: |
       Das PV-Überschussladen der Wallbox muss deaktiviert sein (Ladeverwaltung -> Ladeeinstellungen -> PV-Überschussladen aus).

--- a/templates/definition/charger/porsche-pmcc.yaml
+++ b/templates/definition/charger/porsche-pmcc.yaml
@@ -4,8 +4,6 @@ products:
     description:
       generic: Mobile Charger Connect
 capabilities: ["iso151182", "mA"]
-requirements:
-  evcc: ["eebus"]
 params:
   - preset: eebus
 render: |

--- a/templates/definition/charger/porsche-pmcp.yaml
+++ b/templates/definition/charger/porsche-pmcp.yaml
@@ -3,8 +3,6 @@ products:
   - brand: Porsche
     description:
       generic: Mobile Charger Plus
-requirements:
-  evcc: ["eebus"]
 params:
   - preset: eebus
 render: |

--- a/templates/definition/charger/porsche-wallbox.yaml
+++ b/templates/definition/charger/porsche-wallbox.yaml
@@ -5,7 +5,6 @@ products:
       generic: Wallbox
 capabilities: ["iso151182", "1p3p", "rfid", "mA"]
 requirements:
-  evcc: ["eebus"]
   description:
     de: |
       Das PV-Überschussladen der Wallbox muss deaktiviert sein (Ladeverwaltung -> Ladeeinstellungen -> PV-Überschussladen aus).

--- a/templates/definition/meter/eebus-mgcp.yaml
+++ b/templates/definition/meter/eebus-mgcp.yaml
@@ -8,7 +8,6 @@ requirements:
   description:
     de: EEBus-Messstelle am Netzanschlusspunkt mit dem Use Case MGCP (Monitoring of Grid Connection Point).
     en: EEBus metering device at the grid connection point using use case MGCP (Monitoring of Grid Connection Point).
-  evcc: ["eebus"]
 params:
   - name: usage
     choice: ["grid"]

--- a/templates/definition/meter/eebus-mpc.yaml
+++ b/templates/definition/meter/eebus-mpc.yaml
@@ -9,7 +9,6 @@ requirements:
   description:
     de: EEBus-Verbraucher im Hausnetz mit den Use Cases MPC (Monitoring & Power Consumption) und LPC (Limitation of Power Consumption). Kompatbibel mit steuerbaren Verbrauchseinrichtungen (SteuVE) gemäß §14a EnWG.
     en: EEBus consumer in the home network using use cases MPC (Monitoring & Power Consumption) and LPC (Limitation of Power Consumption).
-  evcc: ["eebus"]
 params:
   - name: usage
     choice: ["charge"]

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -69,13 +69,11 @@ const (
 var ValidCapabilities = []string{CapabilityISO151182, CapabilityMilliAmps, CapabilityRFID, Capability1p3p, CapabilityBatteryControl}
 
 const (
-	RequirementEEBUS       = "eebus"       // EEBUS Setup is required
-	RequirementMQTT        = "mqtt"        // MQTT Setup is required
 	RequirementSponsorship = "sponsorship" // Sponsorship is required
 	RequirementSkipTest    = "skiptest"    // Template should be rendered but not tested
 )
 
-var ValidRequirements = []string{RequirementEEBUS, RequirementMQTT, RequirementSponsorship, RequirementSkipTest}
+var ValidRequirements = []string{RequirementSponsorship, RequirementSkipTest}
 
 var predefinedTemplateProperties = slices.Concat(
 	[]string{"type", "template", "name"}, ModbusParams, ModbusConnectionTypes,


### PR DESCRIPTION
## Summary
- The `eebus` and `mqtt` entries of the template `requirements.evcc` array were only validated against `ValidRequirements` (`util/templates/template.go:96`); no runtime code branched on them
- Drops `RequirementEEBUS` / `RequirementMQTT` constants and trims them from `ValidRequirements`
- Removes the now-orphan `evcc: ["eebus"]` line from 11 templates (charger/eebus, elli-2, elli-charger-connect, elli-charger-pro, evbox-livo, ghost, porsche-pmcc, porsche-pmcp, porsche-wallbox; meter/eebus-mgcp, eebus-mpc); no template still uses `["mqtt"]`

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./util/templates/...` passes (template validation now refuses any leftover eebus/mqtt usage)