### PR TITLE
Sponsor: fix machine id panic on startup with plant config

### DIFF
--- a/util/sponsor/auth.go
+++ b/util/sponsor/auth.go
@@ -36,8 +36,11 @@ var (
 	mu                            sync.RWMutex
 	Subject, Token, ActivationKey string
 	ExpiresAt                     time.Time
-	machineID                     = machine.ProtectedID("evcc-sponsor")
 )
+
+func machineID() string {
+	return machine.ProtectedID("evcc-sponsor")
+}
 
 const unavailable = "sponsorship unavailable"
 
@@ -68,7 +71,7 @@ func ActivateSponsorship(licenseKey, email string) (string, error) {
 	res, err := client.Activate(ctx, &pb.ActivateRequest{
 		Key:       licenseKey,
 		Email:     email,
-		MachineId: machineID,
+		MachineId: machineID(),
 	})
 
 	if err != nil {

--- a/util/sponsor/hardware.go
+++ b/util/sponsor/hardware.go
@@ -39,7 +39,7 @@ func checkHardware(vendor string, metadata map[string]string) string {
 
 	client := pb.NewAuthClient(conn)
 	res, err := client.IsAuthorizedHardware(ctx, &pb.HardwareRequest{
-		MachineId: machineID,
+		MachineId: machineID(),
 		Vendor:    vendor,
 		Metadata:  metadata,
 	})


### PR DESCRIPTION
Fixes #29541

## Summary
- `util/sponsor/auth.go` initialized `machineID = machine.ProtectedID("evcc-sponsor")` at package level, which calls `machine.ID()` during program startup and sets the cached `id` in `util/machine`.
- Later, `cmd.configureEnvironment` calls `machine.CustomID(conf.Plant)` for users with `plant:` set in their config, which panics because `id != ""` is now always true at that point.
- Make `machineID` a function so the protected id is computed lazily, after `CustomID` has run.

Regression introduced in 0.306.0 by #29043.

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./util/sponsor/... ./util/machine/... ./cmd/...`
- [ ] Start evcc with a `plant:` set in `evcc.yaml` — no panic.