### PR TITLE
Add Solinteg Modbus TCP meter template

### DIFF
--- a/templates/definition/meter/solinteg.yaml
+++ b/templates/definition/meter/solinteg.yaml
@@ -1,0 +1,59 @@
+template: solinteg
+products:
+  - brand: Solinteg
+capabilities: ["battery-control"]
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+  - name: modbus
+    choice: ["tcpip"]
+    port: 502
+    id: 255
+  - preset: battery-params
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power: # power (W)
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 11000  # Total Power on Meter
+      type: holding
+      decode: int32
+    scale: -1
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power: # power (W)
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 11028    # PV Input Total Power
+      type: holding
+      decode: uint32
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power: # power (W)
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 30258    # Battery power
+      type: holding
+      decode: int32
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    scale: 0.01
+    register:
+      address: 33000    # SOC
+      type: holding
+      decode: uint16
+  limitsoc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 52503 # min soc
+      type: writeholding
+      encoding: uint16
+    scale: 10
+  {{- include "battery-params" . }}
+  {{- end }}


### PR DESCRIPTION
Adds a dedicated Solinteg Modbus TCP meter template.

Solinteg inverters are currently grouped under the existing Wattsonic template, but that template is configured for RS485-style defaults. In my setup, Solinteg over Modbus TCP requires Modbus ID `255`, and the battery registers differ from the existing Wattsonic template.

This PR adds a separate `solinteg` template so the TCP configuration can work without changing the existing Wattsonic/RS485 behavior.

## Tested locally

Tested with evcc `0.306.0` using Modbus TCP against a Solinteg inverter at port `502`.

Working registers:

- Grid power: `11000`, holding, `int32`, scale `-1`
- PV power: `11028`, holding, `uint32`
- Battery power: `30258`, holding, `int32`
- Battery SoC: `33000`, holding, `uint16`, scale `0.01`
- Battery minimum SoC: `52503`, holding write, `uint16`, scale `10`

## Notes

The existing Wattsonic template is left unchanged to avoid affecting RS485 users.
