### PR TITLE
Solis Hybrid S: fix power decoding

### DIFF
--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -110,12 +110,14 @@ render: |
   power:
     source: calc
     mul:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        type: input
-        address: 33149 # Battery power
-        decode: uint32
+    - source: calc
+      abs:
+        source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          type: input
+          address: 33149 # Battery power
+          decode: int32
     - source: calc
       add:
       - source: modbus


### PR DESCRIPTION
The battery `power` calculation was updated to correctly handle both firmware variants of the Solis Hybrid (S Series) inverter:

**Before:** Register 33149 was read as `uint32`. When the firmware reports a negative value as a signed 32-bit integer (e.g. `0xFFFFFC7C` = −900 W during discharge), this was misinterpreted as ~4,295 MW — a classic 32-bit unsigned overflow.

**After:** Register 33149 is now read as `int32`, and its absolute value is taken via `calc` + `abs`. The sign is then applied separately by multiplying with +1 or −1 derived from the direction register 33135.

```
power = abs(int32(reg 33149)) × ((reg 33135 × 2) − 1)
```

This handles both known firmware variants:
- Firmware that stores battery power as a plain `uint32` (always positive) with direction in register 33135 → `abs(uint32)` is identical to the raw value, sign applied via register 33135 ✓
- Firmware that stores battery power as a signed `int32` (negative = discharge, as seen in issue #28732) → `abs(int32)` strips the sign correctly, which is then re-applied from register 33135 ✓

Fixes #28732