### PR TITLE
Fritz!: optional unit parameter for multi-unit smarthome devices (BC)

### DIFF
--- a/charger/fritzdect.go
+++ b/charger/fritzdect.go
@@ -38,17 +38,17 @@ func NewFritzDECTFromConfig(other map[string]any) (api.Charger, error) {
 		return nil, api.ErrMissingCredentials
 	}
 
-	return NewFritzDECT(cc.embed, cc.URI, cc.AIN, cc.User, cc.Password, cc.StandbyPower, cc.Firmware82)
+	return NewFritzDECT(cc.embed, cc.URI, cc.AIN, cc.User, cc.Password, cc.StandbyPower, cc.Firmware82, cc.Unit)
 }
 
 // NewFritzDECT creates a new connection with standbypower for charger
-func NewFritzDECT(embed embed, uri, ain, user, password string, standbypower float64, firmware82 bool) (*FritzDECT, error) {
+func NewFritzDECT(embed embed, uri, ain, user, password string, standbypower float64, firmware82 bool, unit int) (*FritzDECT, error) {
 	var conn fritz.Switch
 	var err error
 
 	// Use new REST API if firmware82 is set, otherwise use legacy LUA API
 	if firmware82 {
-		conn, err = smarthome.NewConnection(uri, ain, user, password)
+		conn, err = smarthome.NewConnection(uri, ain, user, password, unit)
 	} else {
 		conn, err = aha.NewConnection(uri, ain, user, password)
 	}

--- a/meter/fritz/smarthome/smarthome.go
+++ b/meter/fritz/smarthome/smarthome.go
@@ -22,7 +22,7 @@ type Connection struct {
 	*request.Helper
 	*fritz.Settings
 	SID     string
-	UID     string // device UID (AIN with space)
+	UID     string // unitUid resolved from /devices
 	updated time.Time
 	unitG   util.Cacheable[Unit]
 }
@@ -47,18 +47,22 @@ func NewConnection(uri, ain, user, password string, unit int) (*Connection, erro
 
 	log := util.NewLogger("fritzsmarthome").Redact(password)
 
-	uid := ainToUID(ain)
-	if unit > 0 {
-		uid = fmt.Sprintf("%s-%d", uid, unit)
-	}
-
 	conn := &Connection{
 		Helper:   request.NewHelper(log),
 		Settings: settings,
-		UID:      uid,
 	}
 
 	conn.Client.Transport = request.NewTripper(log, transport.Insecure())
+
+	if err := conn.refreshSession(); err != nil {
+		return nil, err
+	}
+
+	uid, err := conn.resolveUnitUID(unit)
+	if err != nil {
+		return nil, err
+	}
+	conn.UID = uid
 
 	// cache unit data for 2 seconds to avoid excessive API calls
 	conn.unitG = util.ResettableCached(func() (Unit, error) {
@@ -68,15 +72,33 @@ func NewConnection(uri, ain, user, password string, unit int) (*Connection, erro
 	return conn, nil
 }
 
-// ainToUID converts AIN format to UID format by adding space
-// AIN: "116300015376" -> UID: "11630 0015376"
-func ainToUID(ain string) string {
-	// Remove any existing spaces first
-	ain = strings.ReplaceAll(ain, " ", "")
-	if len(ain) >= 5 {
-		return ain[:5] + " " + ain[5:]
+// resolveUnitUID looks up the device by AIN and returns its unitUid at the given index
+func (c *Connection) resolveUnitUID(unit int) (string, error) {
+	uri := fmt.Sprintf("%s/api/v0/smarthome/overview/devices", c.URI)
+
+	req, _ := request.New("GET", uri, nil, map[string]string{
+		"Authorization": "AVM-SID " + c.SID,
+	}, request.AcceptJSON)
+
+	var devices []Device
+	if err := c.DoJSON(req, &devices); err != nil {
+		return "", err
 	}
-	return ain
+
+	for _, d := range devices {
+		if d.AIN != c.AIN {
+			continue
+		}
+		if len(d.UnitUids) == 0 {
+			return "", fmt.Errorf("device %s has no units", c.AIN)
+		}
+		if unit < 0 || unit >= len(d.UnitUids) {
+			return "", fmt.Errorf("unit %d out of range (device has %d unit(s))", unit, len(d.UnitUids))
+		}
+		return d.UnitUids[unit], nil
+	}
+
+	return "", fmt.Errorf("device not found: %s", c.AIN)
 }
 
 // getUnit fetches unit data from REST API
@@ -85,7 +107,6 @@ func (c *Connection) getUnit() (Unit, error) {
 		return Unit{}, err
 	}
 
-	// Try to get the specific unit first
 	uri := fmt.Sprintf("%s/api/v0/smarthome/overview/units/%s", c.URI, url.PathEscape(c.UID))
 
 	req, _ := request.New("GET", uri, nil, map[string]string{
@@ -94,8 +115,7 @@ func (c *Connection) getUnit() (Unit, error) {
 
 	var unit Unit
 	if err := c.DoJSON(req, &unit); err != nil {
-		// Fall back to getting all units and finding ours
-		return c.findUnit()
+		return Unit{}, err
 	}
 
 	if !unit.IsConnected {
@@ -103,36 +123,6 @@ func (c *Connection) getUnit() (Unit, error) {
 	}
 
 	return unit, nil
-}
-
-// findUnit searches for our unit in the list of all units
-func (c *Connection) findUnit() (Unit, error) {
-	uri := fmt.Sprintf("%s/api/v0/smarthome/overview/units", c.URI)
-
-	req, err := request.New("GET", uri, nil, map[string]string{
-		"Authorization": "AVM-SID " + c.SID,
-	}, request.AcceptJSON)
-	if err != nil {
-		return Unit{}, err
-	}
-
-	var units []Unit
-	if err := c.DoJSON(req, &units); err != nil {
-		return Unit{}, err
-	}
-
-	// Search for matching unit by UID or AIN
-	for _, unit := range units {
-		unitAIN := strings.ReplaceAll(unit.UID, " ", "")
-		if unit.UID == c.UID || unitAIN == c.AIN {
-			if !unit.IsConnected {
-				return unit, api.ErrNotAvailable
-			}
-			return unit, nil
-		}
-	}
-
-	return Unit{}, fmt.Errorf("unit not found: %s", c.AIN)
 }
 
 // CurrentPower implements the api.Meter interface

--- a/meter/fritz/smarthome/smarthome.go
+++ b/meter/fritz/smarthome/smarthome.go
@@ -28,7 +28,7 @@ type Connection struct {
 }
 
 // NewConnection creates a new REST API connection
-func NewConnection(uri, ain, user, password string) (*Connection, error) {
+func NewConnection(uri, ain, user, password string, unit int) (*Connection, error) {
 	if uri == "" {
 		uri = "https://fritz.box"
 	}
@@ -42,14 +42,20 @@ func NewConnection(uri, ain, user, password string) (*Connection, error) {
 		AIN:      ain,
 		User:     user,
 		Password: password,
+		Unit:     unit,
 	}
 
 	log := util.NewLogger("fritzsmarthome").Redact(password)
 
+	uid := ainToUID(ain)
+	if unit > 0 {
+		uid = fmt.Sprintf("%s-%d", uid, unit)
+	}
+
 	conn := &Connection{
 		Helper:   request.NewHelper(log),
 		Settings: settings,
-		UID:      ainToUID(ain),
+		UID:      uid,
 	}
 
 	conn.Client.Transport = request.NewTripper(log, transport.Insecure())

--- a/meter/fritz/smarthome/smarthome.go
+++ b/meter/fritz/smarthome/smarthome.go
@@ -89,11 +89,8 @@ func (c *Connection) resolveUnitUID(unit int) (string, error) {
 		if d.AIN != c.AIN {
 			continue
 		}
-		if len(d.UnitUids) == 0 {
-			return "", fmt.Errorf("device %s has no units", c.AIN)
-		}
-		if unit < 0 || unit >= len(d.UnitUids) {
-			return "", fmt.Errorf("unit %d out of range (device has %d unit(s))", unit, len(d.UnitUids))
+		if len(d.UnitUids) < unit+1 {
+			return "", fmt.Errorf("invalid unit %d, got %v", unit, d.UnitUids)
 		}
 		return d.UnitUids[unit], nil
 	}

--- a/meter/fritz/smarthome/smarthome.go
+++ b/meter/fritz/smarthome/smarthome.go
@@ -98,7 +98,7 @@ func (c *Connection) resolveUnitUID(unit int) (string, error) {
 		return d.UnitUids[unit], nil
 	}
 
-	return "", fmt.Errorf("device not found: %s", c.AIN)
+	return "", fmt.Errorf("ain not found: %s", c.AIN)
 }
 
 // getUnit fetches unit data from REST API

--- a/meter/fritz/smarthome/types.go
+++ b/meter/fritz/smarthome/types.go
@@ -2,12 +2,13 @@ package smarthome
 
 // Device represents a smarthome device from the /devices endpoint
 type Device struct {
-	UID             string `json:"UID"`
-	AIN             string `json:"ain"`
-	Name            string `json:"name"`
-	ProductName     string `json:"productName"`
-	ProductCategory string `json:"productCategory"`
-	IsConnected     bool   `json:"isConnected"`
+	UID             string   `json:"UID"`
+	AIN             string   `json:"ain"`
+	Name            string   `json:"name"`
+	ProductName     string   `json:"productName"`
+	ProductCategory string   `json:"productCategory"`
+	IsConnected     bool     `json:"isConnected"`
+	UnitUids        []string `json:"unitUids"`
 }
 
 // Unit represents a smarthome unit with its interfaces

--- a/meter/fritz/types.go
+++ b/meter/fritz/types.go
@@ -20,6 +20,7 @@ const SessionTimeout = 15 * time.Minute
 type Settings struct {
 	URI, AIN, User, Password string
 	Firmware82               bool // use new REST API (FritzOS 8.2+)
+	Unit                     int  // unit index for multi-unit devices (REST API only)
 }
 
 // Fritzbox helpers (credits to https://github.com/rsdk/ahago)

--- a/meter/fritzdect.go
+++ b/meter/fritzdect.go
@@ -29,7 +29,7 @@ func NewFritzDECTFromConfig(other map[string]any) (api.Meter, error) {
 
 	// Use new REST API if firmware82 is set, otherwise use legacy LUA API
 	if cc.Firmware82 {
-		return smarthome.NewConnection(cc.URI, cc.AIN, cc.User, cc.Password)
+		return smarthome.NewConnection(cc.URI, cc.AIN, cc.User, cc.Password, cc.Unit)
 	}
 
 	return aha.NewConnection(cc.URI, cc.AIN, cc.User, cc.Password)

--- a/templates/definition/charger/fritzdect.yaml
+++ b/templates/definition/charger/fritzdect.yaml
@@ -35,6 +35,15 @@ params:
     help:
       de: Verwende die neue REST-API für FritzOS ab Version 8.2
       en: Use the new REST API for FritzOS version 8.2 and later
+  - name: unit
+    advanced: true
+    type: int
+    description:
+      de: Einheit
+      en: Unit
+    help:
+      de: Index der Einheit für Geräte mit mehreren Einheiten (nur REST-API)
+      en: Unit index for multi-unit devices (REST API only)
   - preset: switchsocket
 render: |
   type: fritzdect
@@ -43,4 +52,5 @@ render: |
   password: {{ .password }}
   ain: {{ .ain }} # switch actor identification number without blanks (see AIN number on switch sticker)
   firmware82: {{ .firmware82 }}
+  unit: {{ .unit }}
   {{ include "switchsocket" . }}

--- a/templates/definition/meter/fritzdect.yaml
+++ b/templates/definition/meter/fritzdect.yaml
@@ -37,6 +37,15 @@ params:
     help:
       de: Verwende die neue REST-API für FritzOS ab Version 8.2
       en: Use the new REST API for FritzOS version 8.2 and later
+  - name: unit
+    advanced: true
+    type: int
+    description:
+      de: Einheit
+      en: Unit
+    help:
+      de: Index der Einheit für Geräte mit mehreren Einheiten (nur REST-API)
+      en: Unit index for multi-unit devices (REST API only)
 render: |
   type: fritzdect
   uri: {{ .uri }}
@@ -44,3 +53,4 @@ render: |
   password: {{ .password }}
   ain: {{ .ain }} # switch actor identification number without blanks (see AIN number on switch sticker)
   firmware82: {{ .firmware82 }}
+  unit: {{ .unit }}

--- a/templates/definition/meter/fritzgrid.yaml
+++ b/templates/definition/meter/fritzgrid.yaml
@@ -15,6 +15,15 @@ params:
   - name: ain
     required: true
     service: fritz/devices?uri={uri}&user={user}&password={password}
+  - name: unit
+    advanced: true
+    type: int
+    description:
+      de: Einheit
+      en: Unit
+    help:
+      de: Index der Einheit für Geräte mit mehreren Einheiten
+      en: Unit index for multi-unit devices
 render: |
   type: fritzdect
   uri: {{ .uri }}
@@ -22,3 +31,4 @@ render: |
   password: {{ .password }}
   ain: {{ .ain }} # switch actor identification number without blanks (see AIN number on switch sticker)
   firmware82: true
+  unit: {{ .unit }}


### PR DESCRIPTION
## Summary
Adds an optional integer \`unit\` parameter to the Fritz! templates so individual sockets of a multi-unit smarthome device (e.g. FRITZ!Powerline 546E) can be addressed when the FritzOS 8.2+ REST API is used.

## Details
- New \`Unit\` field on \`fritz.Settings\`.
- \`smarthome.NewConnection\` accepts the unit; when \`>0\` it appends \`-<unit>\` to the AIN-derived unit UID used by \`/api/v0/smarthome/overview/units/{uid}\`.
- Templates updated: \`charger/fritzdect\`, \`meter/fritzdect\`, \`meter/fritzgrid\` get an advanced \`unit\` int field. The legacy AHA path is unaffected.

## Test plan
- [ ] Configure a FRITZ!Powerline 546E (firmware 8.2+) with \`unit: 1\`, \`unit: 2\` etc. and confirm each socket reads/switches independently
- [ ] Confirm single-unit devices still work with \`unit\` left at 0
- [ ] Confirm legacy (pre-8.2) configurations are unchanged