### PR TITLE
EVBox Elvi: Add UnlockCableOnEVSideDisconnect config option

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -53,6 +53,7 @@ func NewOCPPFromConfig(other map[string]interface{}) (api.Charger, error) {
 		BootNotification *bool
 		GetConfiguration *bool
 		ChargingRateUnit string
+		UnlockCable      *bool
 	}{
 		Connector:        1,
 		IdTag:            defaultIdTag,
@@ -74,6 +75,12 @@ func NewOCPPFromConfig(other map[string]interface{}) (api.Charger, error) {
 		cc.ConnectTimeout, cc.Timeout, cc.ChargingRateUnit)
 	if err != nil {
 		return c, err
+	}
+
+	if cc.UnlockCable != nil {
+		if err := c.configure(ocpp.KeyEVBoxUnlockCableOnEVSideDisconnect, strconv.FormatBool(*cc.UnlockCable)); err != nil {
+			return nil, err
+		}
 	}
 
 	var powerG func() (float64, error)

--- a/charger/ocpp/const.go
+++ b/charger/ocpp/const.go
@@ -17,4 +17,7 @@ const (
 
 	// Alfen specific keys
 	KeyAlfenPlugAndChargeIdentifier = "PlugAndChargeIdentifier"
+
+	// EVBox specific keys
+	KeyEVBoxUnlockCableOnEVSideDisconnect = "UnlockCableOnEVSideDisconnect"
 )

--- a/templates/definition/charger/ocpp-elvi.yaml
+++ b/templates/definition/charger/ocpp-elvi.yaml
@@ -21,9 +21,18 @@ params:
       de: Zählerwerte im Intervall anfordern
       en: Interval for requesting metering values
     default: 4s
+  - name: unlockcable
+    advanced: true
+    type: bool
+    description:
+      de: Kabel bei fahrzeugseitiger Trennung entriegeln (UnlockCableOnEVSideDisconnect)
+      en: Unlock cable on EV-side disconnect (UnlockCableOnEVSideDisconnect)
 render: |
   {{ include "ocpp" . }}
   {{- if ne .meter "false" }}
   metervalues: Current.Import.L1,Current.Import.L2,Current.Import.L3,Energy.Active.Import.Register,Power.Active.Import,Voltage.L1,Voltage.L2,Voltage.L3
   meterinterval: {{ .meterinterval }}
+  {{- end }}
+  {{- if .unlockcable }}
+  unlockcable: {{ .unlockcable }}
   {{- end }}


### PR DESCRIPTION
Closes #29580

## What this does

Adds an optional `unlockcable` advanced parameter to the EVBox Elvi OCPP template. When set, evcc sends a `ChangeConfiguration` request for `UnlockCableOnEVSideDisconnect` to the charger during initialization.

## Usage

```yaml
chargers:
  - type: template
    template: elvi
    stationid: your-station-id
    unlockcable: false   # keep cable permanently attached

The parameter is optional — if omitted, no ChangeConfiguration is sent and the charger keeps its current value.