### PR TITLE
Add REST API configuration module

### DIFF
--- a/assets/js/api.ts
+++ b/assets/js/api.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosResponse } from "axios";
 import { openLoginModal } from "./components/Auth/auth";
+import type { ApiEndpointManifest } from "./types/evcc";
 
 const { protocol, hostname, port, pathname } = window.location;
 
@@ -91,3 +92,8 @@ export function downloadFile(res: AxiosResponse) {
     window.URL.revokeObjectURL(url);
   }
 }
+
+export const getApiEndpoints = async (): Promise<ApiEndpointManifest> => {
+  const response = await api.get<ApiEndpointManifest>("endpoints");
+  return response.data;
+};

--- a/assets/js/components/Config/RestApiModal.vue
+++ b/assets/js/components/Config/RestApiModal.vue
@@ -30,6 +30,20 @@
 			/>
 			<CopyLink :text="apiUrl" />
 
+			<!-- Security alert -->
+			<div
+				class="alert mt-3 mb-0"
+				:class="authDisabled ? 'alert-warning' : 'alert-info'"
+				role="alert"
+			>
+				<strong>{{ $t("config.restapi.securityTitle") }}:</strong>
+				{{
+					authDisabled
+						? $t("config.restapi.securityNoPassword")
+						: $t("config.restapi.securityWithPassword")
+				}}
+			</div>
+
 			<!-- Public endpoints -->
 			<div class="mt-4">
 				<label class="label-sm">{{ $t("config.restapi.publicTitle") }}</label>
@@ -60,19 +74,6 @@
 				</ul>
 			</div>
 
-			<!-- Security alert -->
-			<div
-				class="alert mt-4 mb-0"
-				:class="authDisabled ? 'alert-warning' : 'alert-info'"
-				role="alert"
-			>
-				<strong>{{ $t("config.restapi.securityTitle") }}:</strong>
-				{{
-					authDisabled
-						? $t("config.restapi.securityNoPassword")
-						: $t("config.restapi.securityWithPassword")
-				}}
-			</div>
 		</div>
 	</GenericModal>
 </template>

--- a/assets/js/components/Config/RestApiModal.vue
+++ b/assets/js/components/Config/RestApiModal.vue
@@ -35,11 +35,7 @@
 				<label class="label-sm">{{ $t("config.restapi.publicTitle") }}</label>
 				<p class="text-muted small mb-2">{{ $t("config.restapi.publicDescription") }}</p>
 				<ul class="list-unstyled endpoint-list">
-					<li
-						v-for="endpoint in publicEndpoints"
-						:key="endpoint"
-						class="endpoint-row"
-					>
+					<li v-for="endpoint in publicEndpoints" :key="endpoint" class="endpoint-row">
 						<span class="badge bg-success badge-endpoint">{{
 							$t("config.restapi.public")
 						}}</span>
@@ -55,11 +51,7 @@
 					{{ $t("config.restapi.protectedDescription") }}
 				</p>
 				<ul class="list-unstyled endpoint-list">
-					<li
-						v-for="endpoint in protectedEndpoints"
-						:key="endpoint"
-						class="endpoint-row"
-					>
+					<li v-for="endpoint in protectedEndpoints" :key="endpoint" class="endpoint-row">
 						<span class="badge bg-warning text-dark badge-endpoint">{{
 							$t("config.restapi.protected")
 						}}</span>

--- a/assets/js/components/Config/RestApiModal.vue
+++ b/assets/js/components/Config/RestApiModal.vue
@@ -15,6 +15,7 @@
 						</a>
 					</template>
 				</i18n-t>
+
 			</p>
 
 			<!-- API base URL with copy -->

--- a/assets/js/components/Config/RestApiModal.vue
+++ b/assets/js/components/Config/RestApiModal.vue
@@ -83,12 +83,31 @@ import GenericModal from "../Helper/GenericModal.vue";
 import CopyLink from "../Helper/CopyLink.vue";
 import store from "@/store";
 import { docsPrefix } from "@/i18n";
+import { getApiEndpoints } from "@/api";
+
+const fallbackPublicEndpoints = [
+	"/api/state",
+	"/api/loadpoints/{id}/mode",
+	"/api/loadpoints/{id}/limitsoc",
+	"/api/vehicles/{name}/minsoc",
+	"/api/sessions",
+	"/api/tariff/{type}",
+	"/api/auth/status",
+];
+
+const fallbackProtectedEndpoints = ["/api/config/…", "/api/system/…"];
 
 export default defineComponent({
 	name: "RestApiModal",
 	components: {
 		GenericModal,
 		CopyLink,
+	},
+	data() {
+		return {
+			publicEndpoints: [...fallbackPublicEndpoints] as string[],
+			protectedEndpoints: [...fallbackProtectedEndpoints] as string[],
+		};
 	},
 	computed: {
 		apiUrl(): string {
@@ -100,19 +119,23 @@ export default defineComponent({
 		docsUrl(): string {
 			return `${docsPrefix()}/docs/reference/api`;
 		},
-		publicEndpoints(): string[] {
-			return [
-				"/api/state",
-				"/api/loadpoints/{id}/mode",
-				"/api/loadpoints/{id}/limitsoc",
-				"/api/vehicles/{name}/minsoc",
-				"/api/sessions",
-				"/api/tariff/{type}",
-				"/api/auth/status",
-			];
-		},
-		protectedEndpoints(): string[] {
-			return ["/api/config/…", "/api/system/…"];
+	},
+	async mounted() {
+		await this.fetchEndpoints();
+	},
+	methods: {
+		async fetchEndpoints() {
+			try {
+				const endpointManifest = await getApiEndpoints();
+				if (endpointManifest.public.length) {
+					this.publicEndpoints = endpointManifest.public;
+				}
+				if (endpointManifest.protected.length) {
+					this.protectedEndpoints = endpointManifest.protected;
+				}
+			} catch {
+				// Fallback keeps modal functional against older backends without /api/endpoints.
+			}
 		},
 	},
 });

--- a/assets/js/components/Config/RestApiModal.vue
+++ b/assets/js/components/Config/RestApiModal.vue
@@ -15,7 +15,6 @@
 						</a>
 					</template>
 				</i18n-t>
-
 			</p>
 
 			<!-- API base URL with copy -->
@@ -74,7 +73,6 @@
 					</li>
 				</ul>
 			</div>
-
 		</div>
 	</GenericModal>
 </template>

--- a/assets/js/components/Config/RestApiModal.vue
+++ b/assets/js/components/Config/RestApiModal.vue
@@ -1,0 +1,166 @@
+<template>
+	<GenericModal
+		id="restApiModal"
+		config-modal-name="restapi"
+		:title="$t('config.restapi.title')"
+		data-testid="restapi-modal"
+	>
+		<div class="container">
+			<!-- Description with inline docs link -->
+			<p>
+				<i18n-t keypath="config.restapi.description" tag="span" scope="global">
+					<template #docs>
+						<a :href="docsUrl" target="_blank" rel="noopener noreferrer">
+							{{ $t("config.restapi.docsLink") }}
+						</a>
+					</template>
+				</i18n-t>
+			</p>
+
+			<!-- API base URL with copy -->
+			<label class="label-sm" for="restapiUrl">
+				{{ $t("config.restapi.labelUrl") }}
+			</label>
+			<input
+				id="restapiUrl"
+				type="text"
+				class="form-control border font-monospace"
+				:value="apiUrl"
+				readonly
+			/>
+			<CopyLink :text="apiUrl" />
+
+			<!-- Public endpoints -->
+			<div class="mt-4">
+				<label class="label-sm">{{ $t("config.restapi.publicTitle") }}</label>
+				<p class="text-muted small mb-2">{{ $t("config.restapi.publicDescription") }}</p>
+				<ul class="list-unstyled endpoint-list">
+					<li
+						v-for="endpoint in publicEndpoints"
+						:key="endpoint"
+						class="endpoint-row"
+					>
+						<span class="badge bg-success badge-endpoint">{{
+							$t("config.restapi.public")
+						}}</span>
+						<code>{{ endpoint }}</code>
+					</li>
+				</ul>
+			</div>
+
+			<!-- Protected endpoints -->
+			<div class="mt-3">
+				<label class="label-sm">{{ $t("config.restapi.protectedTitle") }}</label>
+				<p class="text-muted small mb-2">
+					{{ $t("config.restapi.protectedDescription") }}
+				</p>
+				<ul class="list-unstyled endpoint-list">
+					<li
+						v-for="endpoint in protectedEndpoints"
+						:key="endpoint"
+						class="endpoint-row"
+					>
+						<span class="badge bg-warning text-dark badge-endpoint">{{
+							$t("config.restapi.protected")
+						}}</span>
+						<code>{{ endpoint }}</code>
+					</li>
+				</ul>
+			</div>
+
+			<!-- Security alert -->
+			<div
+				class="alert mt-4 mb-0"
+				:class="authDisabled ? 'alert-warning' : 'alert-info'"
+				role="alert"
+			>
+				<strong>{{ $t("config.restapi.securityTitle") }}:</strong>
+				{{
+					authDisabled
+						? $t("config.restapi.securityNoPassword")
+						: $t("config.restapi.securityWithPassword")
+				}}
+			</div>
+		</div>
+	</GenericModal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import GenericModal from "../Helper/GenericModal.vue";
+import CopyLink from "../Helper/CopyLink.vue";
+import store from "@/store";
+import { docsPrefix } from "@/i18n";
+
+export default defineComponent({
+	name: "RestApiModal",
+	components: {
+		GenericModal,
+		CopyLink,
+	},
+	computed: {
+		apiUrl(): string {
+			return `${window.location.protocol}//${window.location.host}/api`;
+		},
+		authDisabled(): boolean {
+			return store.state?.authDisabled ?? false;
+		},
+		docsUrl(): string {
+			return `${docsPrefix()}/docs/reference/api`;
+		},
+		publicEndpoints(): string[] {
+			return [
+				"/api/state",
+				"/api/loadpoints/{id}/mode",
+				"/api/loadpoints/{id}/limitsoc",
+				"/api/vehicles/{name}/minsoc",
+				"/api/sessions",
+				"/api/tariff/{type}",
+				"/api/auth/status",
+			];
+		},
+		protectedEndpoints(): string[] {
+			return ["/api/config/…", "/api/system/…"];
+		},
+	},
+});
+</script>
+
+<style scoped>
+.container {
+	padding-right: 0;
+	padding-left: 0;
+}
+
+.label-sm {
+	display: block;
+	font-size: 0.875rem;
+	margin-bottom: 0.25rem;
+}
+
+.endpoint-list {
+	margin-bottom: 0;
+}
+
+.endpoint-row {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.3rem 0.5rem;
+	border-radius: 4px;
+}
+
+.endpoint-row:nth-child(odd) {
+	background-color: var(--bs-tertiary-bg, rgba(0, 0, 0, 0.03));
+}
+
+.badge-endpoint {
+	min-width: 5.5rem;
+	text-align: center;
+	flex-shrink: 0;
+}
+
+code {
+	font-size: 0.82rem;
+}
+</style>

--- a/assets/js/components/Config/RestApiModal.vue
+++ b/assets/js/components/Config/RestApiModal.vue
@@ -85,18 +85,6 @@ import store from "@/store";
 import { docsPrefix } from "@/i18n";
 import { getApiEndpoints } from "@/api";
 
-const fallbackPublicEndpoints = [
-	"/api/state",
-	"/api/loadpoints/{id}/mode",
-	"/api/loadpoints/{id}/limitsoc",
-	"/api/vehicles/{name}/minsoc",
-	"/api/sessions",
-	"/api/tariff/{type}",
-	"/api/auth/status",
-];
-
-const fallbackProtectedEndpoints = ["/api/config/…", "/api/system/…"];
-
 export default defineComponent({
 	name: "RestApiModal",
 	components: {
@@ -105,8 +93,8 @@ export default defineComponent({
 	},
 	data() {
 		return {
-			publicEndpoints: [...fallbackPublicEndpoints] as string[],
-			protectedEndpoints: [...fallbackProtectedEndpoints] as string[],
+			publicEndpoints: [] as string[],
+			protectedEndpoints: [] as string[],
 		};
 	},
 	computed: {
@@ -127,14 +115,11 @@ export default defineComponent({
 		async fetchEndpoints() {
 			try {
 				const endpointManifest = await getApiEndpoints();
-				if (endpointManifest.public.length) {
-					this.publicEndpoints = endpointManifest.public;
-				}
-				if (endpointManifest.protected.length) {
-					this.protectedEndpoints = endpointManifest.protected;
-				}
+				this.publicEndpoints = endpointManifest.public;
+				this.protectedEndpoints = endpointManifest.protected;
 			} catch {
-				// Fallback keeps modal functional against older backends without /api/endpoints.
+				this.publicEndpoints = [];
+				this.protectedEndpoints = [];
 			}
 		},
 	},

--- a/assets/js/components/MaterialIcon/RestApi.vue
+++ b/assets/js/components/MaterialIcon/RestApi.vue
@@ -1,0 +1,18 @@
+<template>
+	<svg :style="svgStyle" viewBox="0 0 24 24">
+		<path
+			fill="currentColor"
+			d="M5 15H3v4c0 1.1.9 2 2 2h4v-2H5v-4zM5 7h4V5H5c-1.1 0-2 .9-2 2v4h2V7zm14-2h-4v2h4v4h2V7c0-1.1-.9-2-2-2zm0 16h-4v2h4c1.1 0 2-.9 2-2v-4h-2v4zM12 9c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+		/>
+	</svg>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import icon from "@/mixins/icon";
+
+export default defineComponent({
+	name: "RestApi",
+	mixins: [icon],
+});
+</script>

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -24,6 +24,11 @@ declare global {
 
 export type AuthProviders = Record<string, { id: string; authenticated: boolean }>;
 
+export interface ApiEndpointManifest {
+  public: string[];
+  protected: string[];
+}
+
 export interface MqttConfig {
   broker: string;
   topic: string;

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -378,6 +378,14 @@
 					>
 						<template #icon><EebusIcon /></template>
 					</DeviceCard>
+					<DeviceCard
+						:title="$t('config.restapi.title')"
+						editable
+						data-testid="restapi"
+						@edit="openModal('restapi')"
+					>
+						<template #icon><RestApiIcon /></template>
+					</DeviceCard>
 				</div>
 
 				<hr class="my-5" />
@@ -440,6 +448,7 @@
 					@changed="loadDirty"
 				/>
 				<OcppModal :ocpp="ocpp" />
+				<RestApiModal />
 				<BackupRestoreModal v-bind="backupRestoreProps" />
 				<PasswordModal update-mode />
 				<SponsorModal :error="hasClassError('sponsorship')" @changed="loadDirty" />
@@ -490,6 +499,8 @@ import MqttModal from "../components/Config/MqttModal.vue";
 import RemoteAccessIcon from "../components/MaterialIcon/RemoteAccess.vue";
 import RemoteModal from "../components/Config/Remote/RemoteModal.vue";
 import { isRemoteClientActive } from "@/utils/remote";
+import RestApiIcon from "../components/MaterialIcon/RestApi.vue";
+import RestApiModal from "../components/Config/RestApiModal.vue";
 import NetworkModal from "../components/Config/NetworkModal.vue";
 import NotificationIcon from "../components/MaterialIcon/Notification.vue";
 import OptimizerIcon from "../components/MaterialIcon/Optimizer.vue";
@@ -575,6 +586,8 @@ export default defineComponent({
 		MqttModal,
 		RemoteAccessIcon,
 		RemoteModal,
+		RestApiIcon,
+		RestApiModal,
 		NetworkModal,
 		NotificationIcon,
 		OptimizerIcon,

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -668,6 +668,21 @@
       "url": "Öffentliche URL",
       "username": "Benutzername"
     },
+    "restapi": {
+      "description": "evcc stellt eine REST API bereit, die es externen Systemen ermöglicht, Daten zu lesen und das Ladeverhalten zu steuern. {docs}.",
+      "docsLink": "API-Dokumentation",
+      "labelUrl": "API-Basis-URL",
+      "protected": "geschützt",
+      "protectedDescription": "Diese Endpunkte erfordern eine Administratoranmeldung, wenn ein Passwort konfiguriert ist.",
+      "protectedTitle": "Geschützte Endpunkte",
+      "public": "öffentlich",
+      "publicDescription": "Diese Endpunkte sind immer ohne Authentifizierung zugänglich.",
+      "publicTitle": "Öffentliche Endpunkte",
+      "securityNoPassword": "Kein Passwort konfiguriert. Alle Endpunkte, auch normalerweise geschützte, sind ohne Authentifizierung zugänglich. Erwäge, ein Passwort im Abschnitt Allgemein zu setzen, wenn evcc aus nicht vertrauenswürdigen Netzwerken erreichbar ist.",
+      "securityTitle": "Sicherheit",
+      "securityWithPassword": "Ein Passwort ist konfiguriert. Öffentliche Endpunkte bleiben ohne Authentifizierung zugänglich. Geschützte Endpunkte erfordern eine Administratoranmeldung.",
+      "title": "REST API"
+    },
     "section": {
       "additionalMeter": "Zusätzliche Zähler",
       "general": "Allgemein",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -668,6 +668,21 @@
       "url": "Public URL",
       "username": "Username"
     },
+    "restapi": {
+      "description": "evcc provides a REST API that allows external systems to read data and control charging behavior. {docs}.",
+      "docsLink": "API documentation",
+      "labelUrl": "API base URL",
+      "protected": "protected",
+      "protectedDescription": "These endpoints require administrator login when a password is configured.",
+      "protectedTitle": "Protected endpoints",
+      "public": "public",
+      "publicDescription": "These endpoints are always accessible without authentication.",
+      "publicTitle": "Public endpoints",
+      "securityNoPassword": "No password is configured. All endpoints, including normally protected ones, are accessible without authentication. Consider setting a password in the General section if evcc is reachable from untrusted networks.",
+      "securityTitle": "Security",
+      "securityWithPassword": "A password is configured. Public endpoints remain accessible without authentication. Protected endpoints require administrator login.",
+      "title": "REST API"
+    },
     "section": {
       "additionalMeter": "Additional meters",
       "general": "General",

--- a/server/http.go
+++ b/server/http.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	eapi "github.com/evcc-io/evcc/api"
@@ -34,11 +37,81 @@ type route struct {
 	HandlerFunc http.HandlerFunc
 }
 
+type apiEndpointManifest struct {
+	Public    []string `json:"public"`
+	Protected []string `json:"protected"`
+}
+
+var pathPatternRegex = regexp.MustCompile(`\{([a-zA-Z0-9_]+):[^}]+\}`)
+var loadpointPathRegex = regexp.MustCompile(`^/api/loadpoints/[0-9]+`)
+
 func (r route) Methods() []string {
 	if r.Method == http.MethodGet {
 		return []string{r.Method}
 	}
 	return []string{r.Method, http.MethodOptions}
+}
+
+func normalizeEndpointPath(path string) string {
+	path = pathPatternRegex.ReplaceAllString(path, "{$1}")
+	path = loadpointPathRegex.ReplaceAllString(path, "/api/loadpoints/{id}")
+
+	return path
+}
+
+func isProtectedAPIPath(path string) bool {
+	return strings.HasPrefix(path, "/api/config") || strings.HasPrefix(path, "/api/system")
+}
+
+func listAPIEndpoints(router *mux.Router) (apiEndpointManifest, error) {
+	public := make(map[string]struct{})
+	protected := make(map[string]struct{})
+
+	err := router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		path, err := route.GetPathTemplate()
+		if err != nil || !strings.HasPrefix(path, "/api") {
+			return nil
+		}
+
+		endpoint := normalizeEndpointPath(path)
+		if isProtectedAPIPath(endpoint) {
+			protected[endpoint] = struct{}{}
+		} else {
+			public[endpoint] = struct{}{}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return apiEndpointManifest{}, err
+	}
+
+	toSortedList := func(m map[string]struct{}) []string {
+		res := make([]string, 0, len(m))
+		for endpoint := range m {
+			res = append(res, endpoint)
+		}
+		sort.Strings(res)
+		return res
+	}
+
+	return apiEndpointManifest{
+		Public:    toSortedList(public),
+		Protected: toSortedList(protected),
+	}, nil
+}
+
+func apiEndpointsHandler(router *mux.Router) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		manifest, err := listAPIEndpoints(router)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		jsonWrite(w, manifest)
+	}
 }
 
 // HTTPd wraps an http.Server and adds the root router
@@ -252,7 +325,8 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *uti
 
 	{ // /api
 		routes := map[string]route{
-			"state": {"GET", "/state", stateHandler(cache)},
+			"state":     {"GET", "/state", stateHandler(cache)},
+			"endpoints": {"GET", "/endpoints", apiEndpointsHandler(router)},
 		}
 
 		for _, r := range routes {

--- a/server/http_endpoints_test.go
+++ b/server/http_endpoints_test.go
@@ -100,4 +100,3 @@ func endpointOccurrences(endpoints []string, value string) int {
 	}
 	return count
 }
-

--- a/server/http_endpoints_test.go
+++ b/server/http_endpoints_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeEndpointPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "normalizes route params with regex",
+			path: "/api/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}",
+			want: "/api/vehicles/{name}/minsoc/{value}",
+		},
+		{
+			name: "normalizes numeric loadpoint id",
+			path: "/api/loadpoints/12/mode/{value:[a-z]+}",
+			want: "/api/loadpoints/{id}/mode/{value}",
+		},
+		{
+			name: "keeps already normalized path",
+			path: "/api/state",
+			want: "/api/state",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeEndpointPath(tc.path))
+		})
+	}
+}
+
+func TestIsProtectedAPIPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "config path is protected", path: "/api/config/templates/charger", want: true},
+		{name: "system path is protected", path: "/api/system/log", want: true},
+		{name: "auth path is public", path: "/api/auth/status", want: false},
+		{name: "state path is public", path: "/api/state", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isProtectedAPIPath(tc.path))
+		})
+	}
+}
+
+func TestListAPIEndpoints(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc("/health", func(http.ResponseWriter, *http.Request) {})
+
+	api := router.PathPrefix("/api").Subrouter()
+	api.HandleFunc("/state", func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodGet)
+	api.HandleFunc("/auth/status", func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodGet)
+	api.HandleFunc("/config/templates/{class:[a-z]+}", func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodGet)
+	api.HandleFunc("/system/log", func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodGet)
+	api.HandleFunc("/loadpoints/1/mode/{value:[a-z]+}", func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodPost)
+	api.HandleFunc("/loadpoints/2/mode/{value:[a-z]+}", func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodPost)
+	api.HandleFunc("/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodPost)
+
+	manifest, err := listAPIEndpoints(router)
+	require.NoError(t, err)
+
+	assert.True(t, sort.StringsAreSorted(manifest.Public))
+	assert.True(t, sort.StringsAreSorted(manifest.Protected))
+
+	assert.Contains(t, manifest.Public, "/api/state")
+	assert.Contains(t, manifest.Public, "/api/auth/status")
+	assert.Contains(t, manifest.Public, "/api/loadpoints/{id}/mode/{value}")
+	assert.Contains(t, manifest.Public, "/api/vehicles/{name}/minsoc/{value}")
+
+	assert.Contains(t, manifest.Protected, "/api/config/templates/{class}")
+	assert.Contains(t, manifest.Protected, "/api/system/log")
+
+	assert.NotContains(t, manifest.Public, "/health")
+	assert.NotContains(t, manifest.Protected, "/health")
+	assert.Equal(t, 1, endpointOccurrences(manifest.Public, "/api/loadpoints/{id}/mode/{value}"))
+}
+
+func endpointOccurrences(endpoints []string, value string) int {
+	count := 0
+	for _, endpoint := range endpoints {
+		if endpoint == value {
+			count++
+		}
+	}
+	return count
+}
+


### PR DESCRIPTION
This pull request adds a new REST API info modal to the configuration page. Users can now quickly view available API endpoints, check whether authentication is enabled, and access the API documentation directly from the UI.


- Added a new modal that provides an overview of the REST API, including:
  - API base URL
  - public and protected endpoints
  - authentication/security status
  - link to the API documentation
  - localized texts for all displayed information

- Integrated the modal into the configuration view with a dedicated REST API entry.

- Added new translations in German and English for all REST API related labels, descriptions, and warnings.


<img width="1280" height="300" alt="Bild" src="https://github.com/user-attachments/assets/e11dcd29-6d9e-4130-b97b-561e3dd7c57d" />

<img width="510" height="965" alt="image" src="https://github.com/user-attachments/assets/8649e01a-c1d6-4400-8731-66de9e3a6126" />

<img width="521" height="966" alt="image" src="https://github.com/user-attachments/assets/aaba4c78-5036-40e9-816d-74e637f2c8a0" />


<img width="512" height="992" alt="image" src="https://github.com/user-attachments/assets/73d2ce70-8f2a-4c12-86af-6c155af03cee" />
