### PR TITLE
Autodetection improvements

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -154,6 +154,7 @@ type Vehicle interface {
 	SetTitle(string)
 	Identifiers() []string
 	OnIdentified() ActionConfig
+	ExcludedFromAutoDiscovery() bool
 }
 
 // VehicleFinishTimer provides estimated charge cycle finish time.

--- a/core/coordinator/adapter.go
+++ b/core/coordinator/adapter.go
@@ -37,5 +37,5 @@ func (a *adapter) Release(v api.Vehicle) {
 
 func (a *adapter) IdentifyVehicleByStatus() api.Vehicle {
 	available := a.c.availableDetectibleVehicles(a.lp)
-	return a.c.identifyVehicleByStatus(available)
+	return a.c.identifyVehicleByStatus(available, a.lp)
 }

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -128,7 +128,7 @@ func (c *Coordinator) availableDetectibleVehicles(owner loadpoint.API) []api.Veh
 }
 
 // identifyVehicleByStatus finds active vehicle by charge state
-func (c *Coordinator) identifyVehicleByStatus(available []api.Vehicle) api.Vehicle {
+func (c *Coordinator) identifyVehicleByStatus(available []api.Vehicle, lp loadpoint.API) api.Vehicle {
 	var res api.Vehicle
 
 	c.mu.RLock()
@@ -146,8 +146,8 @@ func (c *Coordinator) identifyVehicleByStatus(available []api.Vehicle) api.Vehic
 
 			c.log.DEBUG.Printf("vehicle status: %s (%s)", status, vehicle.GetTitle())
 
-			// vehicle is plugged or charging, so it should be the right one
-			if status == api.StatusB || status == api.StatusC {
+			// vehicle is plugged or charging and has the same state as the charger, so it should be the right one
+			if (status == api.StatusB || status == api.StatusC) && status == lp.GetStatus() {
 				if res != nil {
 					c.log.WARN.Println("vehicle status: >1 matches, giving up")
 					return nil

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -116,7 +116,7 @@ func (c *Coordinator) availableDetectibleVehicles(owner loadpoint.API) []api.Veh
 
 	for _, vv := range c.vehicles {
 		// status api available
-		if api.HasCap[api.ChargeState](vv) {
+		if api.HasCap[api.ChargeState](vv) && !vv.ExcludedFromAutoDiscovery() {
 			// available or associated to current loadpoint
 			if o, ok := c.tracked[vv]; o == owner || !ok {
 				res = append(res, vv)

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -191,6 +191,11 @@ params:
       de: "Kann meist erst später eingetragen werden, siehe: https://docs.evcc.io/docs/features/vehicle"
       en: "Mostly this can be added later, see: https://docs.evcc.io/en/docs/features/vehicle"
     type: list
+  - name: ExcludedFromAutoDiscovery
+    type: bool
+    description:
+      de: Von automatischer Erkennung ausschließen
+      en: Exclude from auto discovery
   - name: priority
     description:
       de: Priorität
@@ -513,6 +518,12 @@ presets:
       advanced: true
     - name: identifiers
       advanced: true
+    - name: ExcludedFromAutoDiscovery
+      advanced: true
+      type: bool
+      description:
+        de: Von automatischer Erkennung ausschließen
+        en: Exclude from auto discovery
     - name: priority
       advanced: true
     - name: cache
@@ -536,6 +547,12 @@ presets:
       advanced: true
     - name: identifiers
       advanced: true
+    - name: ExcludedFromAutoDiscovery
+      advanced: true
+      type: bool
+      description:
+        de: Von automatischer Erkennung ausschließen
+        en: Exclude from auto discovery
     - name: priority
       advanced: true
   vehicle-features:

--- a/util/templates/includes/vehicle-common.tpl
+++ b/util/templates/includes/vehicle-common.tpl
@@ -38,4 +38,8 @@ identifiers:
 {{- end }}
 {{- end }}
 
+{{- if .ExcludedFromAutoDiscovery }}
+ExcludedFromAutoDiscovery: {{.ExcludedFromAutoDiscovery}}
+{{- end }}
+
 {{- end }}

--- a/vehicle/embed.go
+++ b/vehicle/embed.go
@@ -6,13 +6,14 @@ import (
 
 // TODO align phases with OnIdentify
 type embed struct {
-	Title_       string           `mapstructure:"title"`
-	Icon_        string           `mapstructure:"icon"`
-	Capacity_    float64          `mapstructure:"capacity"`
-	Phases_      int              `mapstructure:"phases"`
-	Identifiers_ []string         `mapstructure:"identifiers"`
-	Features_    []api.Feature    `mapstructure:"features"`
-	OnIdentify   api.ActionConfig `mapstructure:"onIdentify"`
+	Title_                     string           `mapstructure:"title"`
+	Icon_                      string           `mapstructure:"icon"`
+	Capacity_                  float64          `mapstructure:"capacity"`
+	Phases_                    int              `mapstructure:"phases"`
+	Identifiers_               []string         `mapstructure:"identifiers"`
+	Features_                  []api.Feature    `mapstructure:"features"`
+	OnIdentify                 api.ActionConfig `mapstructure:"onIdentify"`
+	ExcludedFromAutoDiscovery_ bool             `mapstructure:"ExcludedFromAutoDiscovery"`
 }
 
 // Title implements the api.Vehicle interface
@@ -69,4 +70,9 @@ var _ api.FeatureDescriber = (*embed)(nil)
 // Features implements the api.FeatureDescriber interface
 func (v *embed) Features() []api.Feature {
 	return v.Features_
+}
+
+// ExcludedFromAutoDiscovery implements the api.ExcludedFromAutoDiscovery interface
+func (v *embed) ExcludedFromAutoDiscovery() bool {
+	return v.ExcludedFromAutoDiscovery_
 }


### PR DESCRIPTION
Changes with fokus on improving the vehicle autodetection feature:
* exactly compare charger status with vehicle status for identifying candidates instead of selecting all vehicles in states B and C
* add an advanced option to cars for excluding a car from autodetection. Helpful e.g if a car is charging only seldom at the managed site but often at other places.

marked as draft as the Features are not yet tested with real cars and chargers, only in the evcc-demo with demo vehicles on my laptop.