### PR TITLE
Vehicle API charger: trigger wakeup when vehicle is asleep

### DIFF
--- a/charger/vehicle-api.go
+++ b/charger/vehicle-api.go
@@ -82,6 +82,11 @@ func (c *VehicleApi) Status() (api.ChargeStatus, error) {
 	// Check if vehicle is at the charger (trying to use geofencing)
 	atHome, err := c.isVehicleAtHome(vehicle)
 	if err != nil {
+		// vehicle asleep: position unavailable, assume previously known location is still valid
+		// and report as connected so loadpoint can trigger wake-up via Enable()
+		if errors.Is(err, api.ErrAsleep) {
+			return api.StatusB, nil
+		}
 		return api.StatusA, err
 	}
 
@@ -104,6 +109,11 @@ func (c *VehicleApi) Status() (api.ChargeStatus, error) {
 
 	status, err := v.Status()
 	if err != nil {
+		// vehicle asleep: report as connected (StatusB) so loadpoint's setLimit/Enable
+		// path can trigger wake-up via the existing Resurrector logic
+		if errors.Is(err, api.ErrAsleep) {
+			return api.StatusB, nil
+		}
 		return api.StatusNone, err
 	}
 


### PR DESCRIPTION
Closes #28652

## Summary

The `vehicle-api` charger propagated `api.ErrAsleep` from `Status()`, causing loadpoint `Update()` to early-return at `core/loadpoint.go:1962` before reaching `setLimit`/`Enable`. The existing wake-up plumbing in `setLimit` (`loadpoint.go:951` — calls `vv.WakeUp()` on `ErrAsleep`) was therefore never triggered, so a Tesla using the Vehicle-API charger could fall asleep and never wake up again, even with an active plan or `mode: now`.

## Fix

Treat `ErrAsleep` in `VehicleApi.Status()` as **connected, not charging** (`StatusB`) instead of propagating the error. This lets the rest of `Update()` run; the existing wake-up path then handles the sleeping vehicle:

```
setLimit() → charger.Enable(true) → vehicle.ChargeEnable(true)
           → returns ErrAsleep
           → setLimit() catches and calls vv.WakeUp()  (loadpoint.go:951)
```

For Tesla Fleet API, `StartCharging()` is one of the calls that **wakes the vehicle implicitly**, so in many cases the implicit wake is enough; the explicit `WakeUp()` only fires as the rate-limited retry on the next cycle if needed.

## Why this approach over patching `Update()`

The issue body suggests handling `ErrAsleep` directly in `Update()`. That works but:
- bypasses the existing rate-limited wake-up timer (`wakeupAttempts = 6`, `wakeupTimeout = 30s` from `core/timer.go`),
- only covers `planActive()` — would still skip `mode == now`, welcome-charge, SOC-driven charging,
- duplicates wake-up logic that already exists in `setLimit`.

Re-using the existing path keeps semantics consistent across charger types.

## Edge cases

- **`mode == off`, no plan, vehicle asleep**: `Status()` reports `StatusB`, strategy switch runs `setLimit(0)` → `Enable(false)` → Tesla controller's `StopCharging()` swallows `ErrAsleep` (`vehicle/tesla/controller.go:48`). No spurious wake-up.
- **Geofence enabled, vehicle away and asleep**: `isVehicleAtHome` would normally fail because `Position()` requires the vehicle to be awake. With the patch, that path also returns `StatusB`. The next `Enable(true)` call goes to Tesla, the implicit wake fires, and the *next* `Status()` call gets a real position — if it's outside the geofence, `Status()` correctly returns `StatusA`. Worst case: one unnecessary wake before the geofence kicks back in.
- **Geofence disabled, Tesla asleep**: wakes on first `Update`, treated as connected. Matches user expectation since they have no other connection signal.

## Test plan

- [ ] Tesla asleep + plan active → wakes within one `Update` cycle, plan executes
- [ ] Tesla asleep + `mode = now` → wakes within one `Update` cycle
- [ ] Tesla asleep + `mode = off`, no plan → no wake-up calls, no log spam
- [ ] Tesla awake but disconnected (geofence enabled, away) → still `StatusA`, no behaviour change
- [ ] Geofence disabled + Tesla asleep → wakes on first `Update` (treated as connected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)