### PR TITLE
test: bump modal show/hide timeout to reduce flakes

### DIFF
--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -7,14 +7,19 @@ export async function openMoreMenu(page: Page): Promise<Locator> {
   return moreButton;
 }
 
+// Bootstrap modal show/hide animations can take ~300ms but on slow CI they
+// can stretch beyond Playwright's default 5s assertion timeout. Use a longer
+// timeout here so transitions don't cause flakes (#flake fix).
+const MODAL_TIMEOUT = 15000;
+
 export async function expectModalVisible(modal: Locator): Promise<void> {
-  await expect(modal).toBeVisible();
-  await expect(modal).toHaveAttribute("aria-hidden", "false");
+  await expect(modal).toBeVisible({ timeout: MODAL_TIMEOUT });
+  await expect(modal).toHaveAttribute("aria-hidden", "false", { timeout: MODAL_TIMEOUT });
 }
 
 export async function expectModalHidden(modal: Locator): Promise<void> {
-  await expect(modal).not.toBeVisible();
-  await expect(modal).toHaveAttribute("aria-hidden", "true");
+  await expect(modal).not.toBeVisible({ timeout: MODAL_TIMEOUT });
+  await expect(modal).toHaveAttribute("aria-hidden", "true", { timeout: MODAL_TIMEOUT });
 }
 
 export async function editorClear(editor: Locator, iterations = 10): Promise<void> {


### PR DESCRIPTION
## Summary

- Bump the timeout in \`expectModalVisible\` / \`expectModalHidden\` (tests/utils.ts) from Playwright's default 5s to 15s.
- Bootstrap modal transitions can stretch past 5s on slow CI runners, producing assertion failures even though the modal eventually closes.

## Affected flaky tests (last 3 days)

- \`tests/config-deeplink.spec.ts:46\` — \`vehicle-modal\` still visible after close
- \`tests/config-loadpoint.spec.ts:188\` — same pattern
- \`tests/statistics.spec.ts:14\` and \`:109\` — \`savings-modal\` still visible after Close click

All these failed with the same shape: locator resolved 9× during 5s polling, then timed out. Fix is centralized in the helper so no per-test changes.

## Test plan

- [ ] \`Integration\` job stays green across 3+ consecutive runs
- [ ] No regression in normal-speed runs (timeout only kicks in when needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)