### PR TITLE
test: wait for validation success in config-pv flake

### DIFF
--- a/tests/config-pv.spec.ts
+++ b/tests/config-pv.spec.ts
@@ -32,6 +32,9 @@ test.describe("pv meter", async () => {
     await expect(meterModal.getByLabel("Maximum AC power of the hybrid inverter")).toBeVisible(); // pv usage only
     await expect(meterModal.getByRole("button", { name: "Validate & save" })).toBeVisible();
     await meterModal.getByRole("link", { name: "validate" }).click();
+    // wait for validation to complete before checking the result tag — backend
+    // can take longer than the default 5s assertion timeout on slow CI runners
+    await expect(meterModal.getByTestId("test-result")).toContainText("Status: successful");
     await expect(meterModal.getByTestId("device-tag-power")).toContainText("5.0 kW");
     await meterModal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(meterModal);


### PR DESCRIPTION
## Summary

- \`tests/config-pv.spec.ts:35\` was flaky on slow CI: after clicking the \`validate\` link, the test immediately checks \`device-tag-power\` for \`"5.0 kW"\`, but the backend validation can take longer than Playwright's 5s default assertion timeout.
- Wait for the test-result to display \`"Status: successful"\` first, then check the power tag — so the assertion only runs after validation has actually finished.

## Failure shape (real CI run)

\`\`\`
Locator: getByTestId('meter-modal').getByTestId('device-tag-power')
Expected substring: "5.0 kW"
Received string:    "Power0.0 kW"
Timeout: 5000ms
7 × locator resolved to ... unexpected value "Power0.0 kW"
\`\`\`

The locator was resolving to the (still pre-validation) \`"Power0.0 kW"\` for the entire 5s window.

## Test plan

- [ ] Existing 'create, edit and remove pv meter' test still passes locally
- [ ] No regression in 'create broken pv meter with validation failure' (which uses 'Status: failed')

🤖 Generated with [Claude Code](https://claude.com/claude-code)