### PR TITLE
test: extend timeout for config-shm form populate flake

### DIFF
--- a/tests/config-shm.spec.ts
+++ b/tests/config-shm.spec.ts
@@ -61,7 +61,9 @@ test.describe("SHM", () => {
 
     await shmCard.getByRole("button", { name: "edit" }).click();
     await expectModalVisible(modal);
-    await expect(vendor).toHaveValue(VALID_VENDOR_ID);
+    // form fields are populated asynchronously after the modal is shown — give
+    // the API roundtrip room before asserting (default 5s is too tight on slow CI)
+    await expect(vendor).toHaveValue(VALID_VENDOR_ID, { timeout: 15000 });
     await expect(device).toHaveValue(VALID_DEVICE_ID);
     await expect(serial).toHaveValue(VALID_DEVICE_SERIAL);
 


### PR DESCRIPTION
## Summary

- \`tests/config-shm.spec.ts:64\` was flaky on slow CI: after restart the modal re-opens and asserts that the \`Vendor ID\` field has the saved value, but the form is populated asynchronously from an API call. Default 5s assertion timeout sometimes isn't enough.
- Bump the first toHaveValue assertion to 15s so the API roundtrip has room. Subsequent fields land alongside it.

## Failure shape (real CI run)

\`\`\`
Locator: getByTestId('shm-modal').getByLabel('Vendor ID')
Expected: "ABCD1234"
Received: ""
Timeout: 5000ms
9 × locator resolved to <input ... id="shmVendorid" .../>
   - unexpected value ""
\`\`\`

The input element existed throughout, but stayed empty for the entire 5s window.

## Test plan

- [ ] Test passes locally
- [ ] No regression in the rest of the SHM persistence flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)