### PR TITLE
test: extend timeout for sponsor token validation flake

### DIFF
--- a/tests/sponsor.spec.ts
+++ b/tests/sponsor.spec.ts
@@ -71,8 +71,10 @@ test.describe("sponsor token", () => {
     await textarea.fill(EXPIRED_TOKEN);
     // Try to save to trigger validation
     await modal.getByRole("button", { name: "Save" }).click();
+    // backend token validation can take longer than the default 5s on slow CI
     await expect(modal).toContainText(
-      "token is expired - get a fresh one from https://sponsor.evcc.io"
+      "token is expired - get a fresh one from https://sponsor.evcc.io",
+      { timeout: 15000 }
     );
   });
 });


### PR DESCRIPTION
## Summary

- \`tests/sponsor.spec.ts:58\` was flaky on slow CI: the test fills an expired token, clicks Save, and asserts the modal shows \"token is expired\". The backend validation roundtrip can take longer than Playwright's default 5s.
- Bump the assertion timeout to 15s.

## Failure shape

\`\`\`
Locator: getByTestId('sponsor-modal')
Expected substring: "token is expired - get a fresh one from https://sponsor.evcc.io"
Received string: "Sponsorship 💚 ... Save"
Timeout: 5000ms
\`\`\`

## Test plan

- [ ] Test passes locally
- [ ] No regression in the other sponsor tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)