### PR TITLE
test: extend timeout for plan static-plan-apply flake

### DIFF
--- a/tests/plan.spec.ts
+++ b/tests/plan.spec.ts
@@ -364,7 +364,9 @@ test.describe("preview", async () => {
 
       await page.getByTestId("static-plan-time").fill("23:30");
       await expect(page.getByTestId("plan-preview-title")).toHaveText("Active plan");
-      await expect(page.getByTestId("static-plan-apply")).toBeVisible();
+      // reactivity from time change to apply-button reappearance can take
+      // longer than the default 5s timeout on slow CI runners
+      await expect(page.getByTestId("static-plan-apply")).toBeVisible({ timeout: 15000 });
 
       // deactivate
       await page.getByTestId("static-plan-active").click();


### PR DESCRIPTION
## Summary

- \`tests/plan.spec.ts:367\` was flaky on slow CI: after filling \`static-plan-time\` with \"23:30\", the test asserts the apply button becomes visible. The Vue reactivity chain from time-fill to apply-visible can exceed Playwright's default 5s timeout.
- Bump the timeout to 15s.

## Failure shape

\`\`\`
Locator: getByTestId('static-plan-apply')
Expected: visible
Timeout: 5000ms
Error: element(s) not found
\`\`\`

## Test plan

- [ ] Test passes locally
- [ ] No regression in the rest of the plan test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)