### PR TITLE
EVBox Elvi: disable buggy *.Offered and SoC measurands

### DIFF
--- a/templates/definition/charger/ocpp-evbox-elvi.yaml
+++ b/templates/definition/charger/ocpp-evbox-elvi.yaml
@@ -12,13 +12,13 @@ requirements:
 
 params:
   - preset: ocpp
+  - name: metervalues
+    default: -Current.Offered,Power.Offered,SoC
   - name: meter
     type: bool
     default: true
+    deprecated: true
   - name: meterinterval
     deprecated: true
 render: |
   {{ include "ocpp" . }}
-  {{- if eq .meter "false" }}
-  metervalues: Current.Offered
-  {{- end }}


### PR DESCRIPTION
## Summary
- The Elvi charger reports nonsensical values for `Current.Offered`, `Power.Offered` and `SoC`, causing repeating "current mismatch (got 90A, expected 6A)" warnings and "charger out of sync" errors.
- Remove these measurands from the desired OCPP set via `metervalues: -Current.Offered,Power.Offered,SoC`, matching the existing pattern used for the Wallbox FW5 template.
- Drop the `meter: false` render branch (which itself only configured the buggy `Current.Offered`) and mark the now-unused `meter` param `deprecated`.

Closes #29588 (per @premultiply's suggestion in https://github.com/evcc-io/evcc/issues/29588#issuecomment-4373084582).

## Test plan
- [ ] Run an Elvi with default config and confirm no more "current mismatch" / "out of sync" warnings.