### PR TITLE
Session energy: latch baseline late if meter not ready at start

### DIFF
--- a/core/wrapper/chargerater.go
+++ b/core/wrapper/chargerater.go
@@ -16,13 +16,14 @@ import (
 // keeps track of consumed energy by regularly updating consumed power.
 type ChargeRater struct {
 	sync.Mutex
-	log           *util.Logger
-	clck          clock.Clock
-	meter         api.Meter
-	charging      bool
-	start         time.Time
-	startEnergy   float64
-	chargedEnergy float64
+	log              *util.Logger
+	clck             clock.Clock
+	meter            api.Meter
+	charging         bool
+	start            time.Time
+	startEnergy      float64
+	startEnergyValid bool
+	chargedEnergy    float64
 }
 
 // ChargeResetter resets the charging session
@@ -47,11 +48,13 @@ func (cr *ChargeRater) StartCharge(continued bool) {
 
 	// time is needed if MeterEnergy is not supported
 	cr.start = cr.clck.Now()
+	cr.startEnergyValid = false
 
 	// get end energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
 		if f, err := m.TotalEnergy(); err == nil {
 			cr.startEnergy = f
+			cr.startEnergyValid = true
 			cr.log.DEBUG.Printf("charge start energy: %.3fkWh", f)
 		} else if !loadpoint.AcceptableError(err) {
 			cr.log.ERROR.Printf("charge total import: %v", err)
@@ -76,7 +79,9 @@ func (cr *ChargeRater) StopCharge() {
 	// get end energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
 		if f, err := m.TotalEnergy(); err == nil {
-			cr.chargedEnergy += f - cr.startEnergy
+			if cr.startEnergyValid {
+				cr.chargedEnergy += f - cr.startEnergy
+			}
 			cr.log.DEBUG.Printf("charge final energy: %.3fkWh", cr.chargedEnergy)
 		} else if !loadpoint.AcceptableError(err) {
 			cr.log.ERROR.Printf("charge total import: %v", err)
@@ -94,10 +99,13 @@ func (cr *ChargeRater) ResetCharge() {
 	// get end energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
 		if f, err := m.TotalEnergy(); err == nil {
-			cr.chargedEnergy += f - cr.startEnergy
-			cr.log.DEBUG.Printf("charge final energy: %.3fkWh", cr.chargedEnergy)
+			if cr.startEnergyValid {
+				cr.chargedEnergy += f - cr.startEnergy
+				cr.log.DEBUG.Printf("charge final energy: %.3fkWh", cr.chargedEnergy)
+			}
 
 			cr.startEnergy = f
+			cr.startEnergyValid = true
 		} else if !loadpoint.AcceptableError(err) {
 			cr.log.ERROR.Printf("charge total import: %v", err)
 		}
@@ -139,11 +147,19 @@ func (cr *ChargeRater) ChargedEnergy() (float64, error) {
 	// get current energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
 		f, err := m.TotalEnergy()
-		if err == nil {
-			return cr.chargedEnergy + f - cr.startEnergy, nil
+		if err != nil {
+			return 0, fmt.Errorf("charge total import: %v", err)
 		}
 
-		return 0, fmt.Errorf("charge total import: %v", err)
+		// late-latch baseline if StartCharge could not read TotalEnergy
+		// (e.g. OCPP transaction recovery before first MeterValues frame)
+		if !cr.startEnergyValid {
+			cr.startEnergy = f
+			cr.startEnergyValid = true
+			cr.log.DEBUG.Printf("charge start energy: %.3fkWh", f)
+		}
+
+		return cr.chargedEnergy + f - cr.startEnergy, nil
 	}
 
 	// return charged energy sofar if meter is not used

--- a/core/wrapper/chargerater.go
+++ b/core/wrapper/chargerater.go
@@ -16,14 +16,13 @@ import (
 // keeps track of consumed energy by regularly updating consumed power.
 type ChargeRater struct {
 	sync.Mutex
-	log              *util.Logger
-	clck             clock.Clock
-	meter            api.Meter
-	charging         bool
-	start            time.Time
-	startEnergy      float64
-	startEnergyValid bool
-	chargedEnergy    float64
+	log           *util.Logger
+	clck          clock.Clock
+	meter         api.Meter
+	charging      bool
+	start         time.Time
+	startEnergy   *float64 // nil until baseline successfully read from meter
+	chargedEnergy float64
 }
 
 // ChargeResetter resets the charging session
@@ -48,13 +47,12 @@ func (cr *ChargeRater) StartCharge(continued bool) {
 
 	// time is needed if MeterEnergy is not supported
 	cr.start = cr.clck.Now()
-	cr.startEnergyValid = false
+	cr.startEnergy = nil
 
 	// get end energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
 		if f, err := m.TotalEnergy(); err == nil {
-			cr.startEnergy = f
-			cr.startEnergyValid = true
+			cr.startEnergy = &f
 			cr.log.DEBUG.Printf("charge start energy: %.3fkWh", f)
 		} else if !loadpoint.AcceptableError(err) {
 			cr.log.ERROR.Printf("charge total import: %v", err)
@@ -79,8 +77,8 @@ func (cr *ChargeRater) StopCharge() {
 	// get end energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
 		if f, err := m.TotalEnergy(); err == nil {
-			if cr.startEnergyValid {
-				cr.chargedEnergy += f - cr.startEnergy
+			if cr.startEnergy != nil {
+				cr.chargedEnergy += f - *cr.startEnergy
 			}
 			cr.log.DEBUG.Printf("charge final energy: %.3fkWh", cr.chargedEnergy)
 		} else if !loadpoint.AcceptableError(err) {
@@ -99,13 +97,12 @@ func (cr *ChargeRater) ResetCharge() {
 	// get end energy amount
 	if m, ok := api.Cap[api.MeterEnergy](cr.meter); ok {
 		if f, err := m.TotalEnergy(); err == nil {
-			if cr.startEnergyValid {
-				cr.chargedEnergy += f - cr.startEnergy
+			if cr.startEnergy != nil {
+				cr.chargedEnergy += f - *cr.startEnergy
 				cr.log.DEBUG.Printf("charge final energy: %.3fkWh", cr.chargedEnergy)
 			}
 
-			cr.startEnergy = f
-			cr.startEnergyValid = true
+			cr.startEnergy = &f
 		} else if !loadpoint.AcceptableError(err) {
 			cr.log.ERROR.Printf("charge total import: %v", err)
 		}
@@ -153,13 +150,12 @@ func (cr *ChargeRater) ChargedEnergy() (float64, error) {
 
 		// late-latch baseline if StartCharge could not read TotalEnergy
 		// (e.g. OCPP transaction recovery before first MeterValues frame)
-		if !cr.startEnergyValid {
-			cr.startEnergy = f
-			cr.startEnergyValid = true
+		if cr.startEnergy == nil {
+			cr.startEnergy = &f
 			cr.log.DEBUG.Printf("charge start energy: %.3fkWh", f)
 		}
 
-		return cr.chargedEnergy + f - cr.startEnergy, nil
+		return cr.chargedEnergy + f - *cr.startEnergy, nil
 	}
 
 	// return charged energy sofar if meter is not used

--- a/core/wrapper/chargerater_test.go
+++ b/core/wrapper/chargerater_test.go
@@ -1,6 +1,7 @@
 package wrapper
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -108,5 +109,62 @@ func TestWrappedMeter(t *testing.T) {
 
 	if f, err := cr.ChargedEnergy(); f != 3 || err != nil {
 		t.Errorf("energy: %.1f %v", f, err)
+	}
+}
+
+// TestDeferredBaseline covers the OCPP transaction-recovery case: the meter is
+// not yet readable when StartCharge fires, so the baseline must be latched on
+// the first successful TotalEnergy() read instead of defaulting to zero
+// (which would cause the lifetime register to be reported as session energy).
+func TestDeferredBaseline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mm := api.NewMockMeter(ctrl)
+	me := api.NewMockMeterEnergy(ctrl)
+
+	type EnergyDecorator struct {
+		api.Meter
+		api.MeterEnergy
+	}
+
+	cm := &EnergyDecorator{Meter: mm, MeterEnergy: me}
+
+	cr := NewChargeRater(util.NewLogger("foo"), cm)
+	clck := clock.NewMock()
+	cr.clck = clck
+
+	// meter not yet available at StartCharge — recovered transaction before first MeterValues
+	me.EXPECT().TotalEnergy().Return(0.0, errors.New("not available"))
+
+	cr.StartCharge(true)
+
+	// first read also fails — must surface the error, not a bogus delta
+	me.EXPECT().TotalEnergy().Return(0.0, errors.New("not available"))
+
+	if _, err := cr.ChargedEnergy(); err == nil {
+		t.Errorf("expected error while meter unavailable")
+	}
+
+	// first successful read latches the baseline (lifetime register, e.g. 939 kWh)
+	me.EXPECT().TotalEnergy().Return(939.080, nil)
+
+	if f, err := cr.ChargedEnergy(); f != 0 || err != nil {
+		t.Errorf("expected 0 on baseline-latch read, got %.3f %v", f, err)
+	}
+
+	// subsequent reads return delta against the latched baseline
+	me.EXPECT().TotalEnergy().Return(942.080, nil)
+
+	if f, err := cr.ChargedEnergy(); f != 3 || err != nil {
+		t.Errorf("expected 3kWh delta, got %.3f %v", f, err)
+	}
+
+	me.EXPECT().TotalEnergy().Return(944.080, nil)
+
+	cr.StopCharge()
+
+	if f, err := cr.ChargedEnergy(); f != 5 || err != nil {
+		t.Errorf("final energy: %.1f %v", f, err)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes a class of bugs where the lifetime energy register is reported as session energy after evcc restarts mid-session.
- `wrapper.ChargeRater` now tracks whether the baseline `TotalEnergy()` read succeeded and late-latches it on the first successful read instead of leaving `startEnergy` at zero.
- Affects any charger whose `MeterEnergy` is briefly unavailable around `evChargeStart`, but the visible trigger is OCPP transaction recovery (#29654 — FoxESS reported `~939 kWh` per session, equal to the lifetime register).

## Test plan
- [x] `go test ./core/wrapper/...` — new `TestDeferredBaseline` plus existing `TestNoMeter` / `TestWrappedMeter` pass
- [x] `go test ./core/...` — full core suite green
- [x] `go build ./...` — clean
- [ ] Reporter-driven verification: restart evcc during an active OCPP session and confirm `session.csv` reports a sensible session delta rather than the lifetime register

Closes #29654