### PR TITLE
History: show loadpoint titles instead of internal names

### DIFF
--- a/assets/js/components/History/EnergyChart.vue
+++ b/assets/js/components/History/EnergyChart.vue
@@ -66,6 +66,7 @@ export default defineComponent({
 
 			this.series.forEach((s, i) => {
 				const color = colors.palette[i % colors.palette.length];
+				const seriesLabel = s.name || s.group;
 
 				// index data by day
 				const byDay: Record<string, { import: number; export: number }> = {};
@@ -79,7 +80,7 @@ export default defineComponent({
 				const exportData = dayKeys.map((key) => -(byDay[key]?.export ?? 0));
 				const hasExport = exportData.some((v) => v !== 0);
 
-				const importLabel = hasExport ? `${s.group} (import)` : s.group;
+				const importLabel = hasExport ? `${seriesLabel} (import)` : seriesLabel;
 
 				datasets.push({
 					label: importLabel,
@@ -90,7 +91,7 @@ export default defineComponent({
 
 				if (hasExport) {
 					datasets.push({
-						label: `${s.group} (export)`,
+						label: `${seriesLabel} (export)`,
 						data: exportData,
 						backgroundColor: lighterColor(color),
 						stack: `s${i}`,
@@ -151,13 +152,14 @@ export default defineComponent({
 			const result: Legend[] = [];
 			this.series.forEach((s, i) => {
 				const color = colors.palette[i % colors.palette.length];
+				const seriesLabel = s.name || s.group;
 				const hasExport = s.data.some((slot) => slot.export > 0);
 
-				const importLabel = hasExport ? `${s.group} (import)` : s.group;
+				const importLabel = hasExport ? `${seriesLabel} (import)` : seriesLabel;
 				result.push({ label: importLabel, color, value: "" });
 				if (hasExport) {
 					result.push({
-						label: `${s.group} (export)`,
+						label: `${seriesLabel} (export)`,
 						color: lighterColor(color),
 						value: "",
 					});

--- a/assets/js/components/History/PowerChart.vue
+++ b/assets/js/components/History/PowerChart.vue
@@ -83,7 +83,7 @@ export default defineComponent({
 				});
 
 				return {
-					label: s.group,
+					label: s.name || s.group,
 					data: points,
 					borderColor: color,
 					backgroundColor: fill,
@@ -172,7 +172,7 @@ export default defineComponent({
 		},
 		legends(): Legend[] {
 			return this.series.map((s, i) => ({
-				label: s.group,
+				label: s.name || s.group,
 				color: colors.palette[i % colors.palette.length],
 				value: "",
 			}));

--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -32,9 +32,10 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import Header from "../components/Top/Header.vue";
-import PowerChart from "../components/History/PowerChart.vue";
+import PowerChart, { type SeriesData } from "../components/History/PowerChart.vue";
 import EnergyChart from "../components/History/EnergyChart.vue";
 import api from "../api";
+import store from "../store";
 
 export default defineComponent({
 	name: "History",
@@ -45,8 +46,8 @@ export default defineComponent({
 	},
 	data() {
 		return {
-			powerSeries: [] as any[],
-			energySeries: [] as any[],
+			powerSeries: [] as SeriesData[],
+			energySeries: [] as SeriesData[],
 			powerFrom: new Date(),
 			powerTo: new Date(),
 			energyFrom: new Date(),
@@ -83,7 +84,6 @@ export default defineComponent({
 						params: {
 							from: this.powerFrom.toISOString(),
 							to: this.powerTo.toISOString(),
-							grouped: true,
 						},
 					}),
 					api.get("history/energy", {
@@ -91,18 +91,25 @@ export default defineComponent({
 							from: this.energyFrom.toISOString(),
 							to: this.powerTo.toISOString(),
 							aggregate: "day",
-							grouped: true,
 						},
 					}),
 				]);
 
-				this.powerSeries = powerRes.data || [];
-				this.energySeries = energyRes.data || [];
+				this.powerSeries = (powerRes.data || []).map(this.applyDisplayName);
+				this.energySeries = (energyRes.data || []).map(this.applyDisplayName);
 			} catch (e) {
 				console.error("Failed to load energy history", e);
 			} finally {
 				this.loading = false;
 			}
+		},
+		applyDisplayName(s: SeriesData): SeriesData {
+			if (s.group === "loadpoint" && s.name) {
+				const idx = parseInt(s.name.replace(/^lp-/, ""), 10) - 1;
+				const title = (store.state.loadpoints || [])[idx]?.title;
+				if (title) return { ...s, name: title };
+			}
+			return { ...s, name: "" };
 		},
 	},
 });


### PR DESCRIPTION
## Summary
- The history page currently aggregates all loadpoints into a single \`loadpoint\` series and labels other entities by their internal group name. With multiple loadpoints, you can't tell them apart.
- Drop \`grouped=true\` on the \`history/energy\` requests so each loadpoint entity comes back individually.
- Resolve the \`lp-N\` entity name to the loadpoint title from \`store.state.loadpoints\`. Non-loadpoint entries (grid, home) fall back to the group label, matching today's appearance.

## Notes
- Only \`home\`, \`grid\`, and \`loadpoint\` are persisted as collectors today (see \`core/site.go\` / \`cmd/setup.go\`), so non-loadpoint groups still produce one series each — visual output for them is unchanged.

## Test plan
- [x] \`npm run lint\` (vue-tsc + i18n check) — clean
- [x] \`npx eslint\` on changed files — clean
- [ ] Visual check: open the History view with multiple loadpoints and confirm each appears with its configured title