### PR TITLE
Battery UI: clarify 100% buffersoc

### DIFF
--- a/assets/js/components/Battery/BatteryUsageSettings.vue
+++ b/assets/js/components/Battery/BatteryUsageSettings.vue
@@ -98,12 +98,7 @@
 				></shopicon-regular-lightning>
 				<span class="d-block">
 					{{ $t("batterySettings.legendTopName") }}
-					<i18n-t
-						:keypath="topSublineKeypath"
-						tag="small"
-						class="d-block"
-						scope="global"
-					>
+					<i18n-t :keypath="topSublineKeypath" tag="small" class="d-block" scope="global">
 						<template #soc>
 							<CustomSelect
 								id="batterySettingsBufferTop"

--- a/assets/js/components/Battery/BatteryUsageSettings.vue
+++ b/assets/js/components/Battery/BatteryUsageSettings.vue
@@ -99,7 +99,7 @@
 				<span class="d-block">
 					{{ $t("batterySettings.legendTopName") }}
 					<i18n-t
-						keypath="batterySettings.legendTopSubline"
+						:keypath="topSublineKeypath"
 						tag="small"
 						class="d-block"
 						scope="global"
@@ -108,18 +108,18 @@
 							<CustomSelect
 								id="batterySettingsBufferTop"
 								class="custom-select-inline"
-								:options="bufferOptions"
+								:options="legendBufferOptions"
 								:selected="selectedBufferSoc"
 								@change="changeBufferSoc"
 							>
 								<span class="text-decoration-underline">
-									{{ fmtSoc(selectedBufferSoc) }}
+									{{ topSublineValue }}
 								</span>
 							</CustomSelect>
 						</template>
 					</i18n-t>
 
-					<small class="d-block">
+					<small v-if="selectedBufferSoc < 100" class="d-block">
 						{{ $t("batterySettings.legendTopAutostart") }}
 						<CustomSelect
 							id="batterySettingsBufferStart"
@@ -265,6 +265,17 @@ export default defineComponent({
 			}
 			return options;
 		},
+		legendBufferOptions() {
+			return this.bufferOptions.map((option) => ({
+				...option,
+				name:
+					option.value === 100
+						? this.$t("batterySettings.legendTopSublineDisabledState")
+						: this.$t("batterySettings.legendTopSublineAbove", {
+								soc: this.fmtSoc(option.value),
+							}),
+			}));
+		},
 		bufferStartTop() {
 			if (!this.selectedBufferStartSoc) return 0;
 			return 100 - this.selectedBufferStartSoc;
@@ -285,6 +296,16 @@ export default defineComponent({
 		},
 		selectedBufferStartName() {
 			return this.getBufferStartName(this.selectedBufferStartSoc);
+		},
+		topSublineKeypath() {
+			return this.selectedBufferSoc < 100
+				? "batterySettings.legendTopSubline"
+				: "batterySettings.legendTopSublineDisabled";
+		},
+		topSublineValue() {
+			return this.selectedBufferSoc < 100
+				? this.fmtSoc(this.selectedBufferSoc)
+				: this.$t("batterySettings.legendTopSublineDisabledState");
 		},
 		topHeight() {
 			return 100 - (this.bufferSoc || 100);

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -39,6 +39,9 @@
     "legendTopAutostart": "Starte automatisch",
     "legendTopName": "Batterieunterstütztes Fahrzeugladen",
     "legendTopSubline": "wenn Hausbatterie über {soc} ist.",
+    "legendTopSublineAbove": "wenn über {soc}",
+    "legendTopSublineDisabled": "ist {soc}.",
+    "legendTopSublineDisabledState": "deaktiviert",
     "modalTitle": "Hausbatterie",
     "noBattery": "Keine Batterien konfiguriert.",
     "usageTab": "Batterienutzung"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -39,6 +39,9 @@
     "legendTopAutostart": "Start automatically",
     "legendTopName": "Battery-supported vehicle charging",
     "legendTopSubline": "when home battery is above {soc}.",
+    "legendTopSublineAbove": "when above {soc}",
+    "legendTopSublineDisabled": "is {soc}.",
+    "legendTopSublineDisabledState": "disabled",
     "modalTitle": "Home Battery",
     "noBattery": "No batteries configured.",
     "usageTab": "Battery usage"

--- a/tests/battery-settings.spec.ts
+++ b/tests/battery-settings.spec.ts
@@ -28,9 +28,26 @@ test.describe("battery settings", async () => {
     await page.locator("#batterySettingsPriority").selectOption({ label: "50%" });
     await expect(page.locator("label[for=batterySettingsPriorityMiddle] span")).toHaveText("50%");
     await expect(page.locator("label[for=batterySettingsPriorityBottom] span")).toHaveText("50%");
-    await page.locator("#batterySettingsBufferTop").selectOption({ label: "80%" });
+    await page.locator("#batterySettingsBufferTop").selectOption({ label: "when above 80%" });
     await page.locator("#batterySettingsBufferStart").selectOption({ label: "when above 90%." });
     await expect(page.locator("label[for=batterySettingsBuffer] span")).toHaveText("80%");
+  });
+
+  test("buffer 100% disables battery-supported charging", async ({ page }) => {
+    await page.goto("/#/battery");
+
+    const topRow = page.getByText("Battery-supported vehicle charging");
+    const bufferSoc = topRow.getByRole("combobox").filter({ hasText: "disabled" });
+
+    await expect(bufferSoc).toHaveValue("100");
+    await expect(page.getByText("Start automatically")).toBeHidden();
+
+    await bufferSoc.selectOption({ label: "when above 80%" });
+    await expect(bufferSoc).toHaveValue("80");
+    await expect(page.getByText("Start automatically")).toBeVisible();
+
+    await bufferSoc.selectOption({ label: "disabled" });
+    await expect(page.getByText("Start automatically")).toBeHidden();
   });
 
   test("grid charging", async ({ page }) => {


### PR DESCRIPTION
adresses https://github.com/evcc-io/evcc/issues/29630

improve communication for "battery supported charging" in battery settings

- show buffersoc=100 as disabled
- hide bufferstart if buffersoc is 100

disabled state
<img width="966" height="409" alt="Bildschirmfoto 2026-05-05 um 12 33 29" src="https://github.com/user-attachments/assets/3f182ff0-82e6-40e8-8982-80f2cb776cc7" />

video

[buffer.webm](https://github.com/user-attachments/assets/e9765f49-0fcb-43d5-92d0-5a00ed52a2c6)


\cc @MPW1412