### PR TITLE
Battery UI: 100% buffersoc resets bufferstart

### DIFF
--- a/assets/js/components/Battery/BatteryUsageSettings.vue
+++ b/assets/js/components/Battery/BatteryUsageSettings.vue
@@ -379,7 +379,9 @@ export default defineComponent({
 		},
 		async changeBufferSoc($event: Event) {
 			const soc = parseInt(($event.target as HTMLInputElement).value, 10);
-			if (soc > this.bufferStartSoc && this.bufferStartSoc > 0) {
+			if (soc === 100) {
+				await this.setBufferStartSoc(0);
+			} else if (soc > this.bufferStartSoc && this.bufferStartSoc > 0) {
 				await this.setBufferStartSoc(soc);
 			}
 			await this.saveBufferSoc(soc);

--- a/tests/battery-settings.spec.ts
+++ b/tests/battery-settings.spec.ts
@@ -44,11 +44,9 @@ test.describe("battery settings", async () => {
     await expect(page.getByText("Start automatically")).toBeHidden();
 
     await bufferSoc.selectOption({ label: "when above 80%" });
-    await expect(topRow).toContainText("when above 80%");
     await expect(page.getByText("Start automatically")).toBeVisible();
 
     await bufferStart.selectOption({ label: "when above 90%." });
-    await expect(topRow).toContainText("when above 90%.");
 
     await bufferSoc.selectOption({ label: "disabled" });
     await expect(page.getByText("Start automatically")).toBeHidden();

--- a/tests/battery-settings.spec.ts
+++ b/tests/battery-settings.spec.ts
@@ -38,16 +38,23 @@ test.describe("battery settings", async () => {
 
     const topRow = page.getByText("Battery-supported vehicle charging");
     const bufferSoc = topRow.getByRole("combobox").filter({ hasText: "disabled" });
+    const bufferStart = page.locator("#batterySettingsBufferStart");
 
     await expect(bufferSoc).toHaveValue("100");
     await expect(page.getByText("Start automatically")).toBeHidden();
 
     await bufferSoc.selectOption({ label: "when above 80%" });
-    await expect(bufferSoc).toHaveValue("80");
+    await expect(topRow).toContainText("when above 80%");
     await expect(page.getByText("Start automatically")).toBeVisible();
+
+    await bufferStart.selectOption({ label: "when above 90%." });
+    await expect(topRow).toContainText("when above 90%.");
 
     await bufferSoc.selectOption({ label: "disabled" });
     await expect(page.getByText("Start automatically")).toBeHidden();
+
+    await bufferSoc.selectOption({ label: "when above 80%" });
+    await expect(topRow).toContainText("only with enough surplus.");
   });
 
   test("grid charging", async ({ page }) => {


### PR DESCRIPTION
follow-up to https://github.com/evcc-io/evcc/pull/29658

see https://github.com/evcc-io/evcc/pull/29658#issuecomment-4379311968

Setting `buffersoc` to 100 via ui now clears `bufferstart` (set to `0`, `" only with enough surplus."`). Before value was set to `100` and UI was hidden.