### PR TITLE
Fix comment-only yaml in device config validation

### DIFF
--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -466,9 +466,9 @@ func decodeDeviceConfig(r io.Reader) (configReq, error) {
 		return configReq{}, errors.New("invalid config: cannot mix yaml and other")
 	}
 
-	// validate yaml syntax
+	// validate yaml syntax; tolerate whitespace/comment-only input
 	var tmp map[string]any
-	if err := yaml.Unmarshal([]byte(res.Yaml), &tmp); err != nil && err != io.EOF {
+	if err := yaml.Unmarshal([]byte(res.Yaml), &tmp); err != nil && !strings.Contains(err.Error(), "no documents in stream") {
 		return configReq{}, err
 	}
 

--- a/util/error_test.go
+++ b/util/error_test.go
@@ -13,6 +13,21 @@ func TestYamlFloat(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal([]byte(b), &res))
 }
 
+func TestYamlEmpty(t *testing.T) {
+	var res map[string]any
+	err := yaml.Unmarshal([]byte(""), &res)
+	require.ErrorContains(t, err, "no documents in stream")
+}
+
+func TestYamlCommentsOnly(t *testing.T) {
+	b := `# just a comment
+# another comment
+`
+	var res map[string]any
+	err := yaml.Unmarshal([]byte(b), &res)
+	require.ErrorContains(t, err, "no documents in stream")
+}
+
 func TestYamlError(t *testing.T) {
 	b := `block:
   data: foo


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/29672

- The go-yaml v4 upgrade (#29052) changed the empty/comment-only document error from `io.EOF` to a `"no documents in stream"` error wrapped in `LoadErrors`. The tolerance check in `decodeDeviceConfig` (`server/http_config_helper.go`) still compared against `io.EOF`, so YAML payloads containing only whitespace/comments now fail validation instead of being accepted.
- Switch the guard to match the v4 error message and add unit tests in `util/error_test.go` pinning down the new behavior for empty and comment-only input.

## Test plan
- [x] `go test ./util/ ./server/`