### PR TITLE
EEBus: drop redundant Scenario middle word from constant names

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -316,7 +316,7 @@ func (c *EEBus) Enable(enable bool) error {
 // send current charging power limits to the EV
 func (c *EEBus) writeCurrentLimitData(evEntity spineapi.EntityRemoteInterface, current float64) error {
 	// check if the EVSE supports overload protection limits
-	if !c.cem.OpEV.IsScenarioAvailableAtEntity(evEntity, eebus.OPEVScenarioObligationLimit) {
+	if !c.cem.OpEV.IsScenarioAvailableAtEntity(evEntity, eebus.OPEVObligationLimit) {
 		return api.ErrNotAvailable
 	}
 
@@ -362,7 +362,7 @@ func (c *EEBus) writeCurrentLimitData(evEntity spineapi.EntityRemoteInterface, c
 // An active recommendation triggers the EV to charge with surplus energy.
 // An inactive recommendation is equivalent to no recommendation existing.
 func (c *EEBus) writeOscevLimits(evEntity spineapi.EntityRemoteInterface, current float64) {
-	if !c.cem.OscEV.IsScenarioAvailableAtEntity(evEntity, eebus.OSCEVScenarioRecommendationLimit) {
+	if !c.cem.OscEV.IsScenarioAvailableAtEntity(evEntity, eebus.OSCEVRecommendationLimit) {
 		return
 	}
 
@@ -430,7 +430,7 @@ func (c *EEBus) currentPower() (float64, error) {
 
 	// does the EVSE provide power data?
 	var powers []float64
-	if c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMScenarioPowerTotal) {
+	if c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMPowerTotal) {
 		// is power data available for real? Elli Gen1 says it supports it, but doesn't provide any data
 		if powerData, err := c.cem.EvCem.PowerPerPhase(evEntity); err == nil {
 			powers = powerData
@@ -438,7 +438,7 @@ func (c *EEBus) currentPower() (float64, error) {
 	}
 
 	// if no power data is available, and currents are reported to be supported, use currents
-	if len(powers) == 0 && c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMScenarioPowerPerPhase) {
+	if len(powers) == 0 && c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMPowerPerPhase) {
 		// no power provided, calculate from current
 		if currents, err := c.cem.EvCem.CurrentPerPhase(evEntity); err == nil {
 			for _, current := range currents {
@@ -462,7 +462,7 @@ func (c *EEBus) chargedEnergy() (float64, error) {
 		return 0, nil
 	}
 
-	if !c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMScenarioEnergy) {
+	if !c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMEnergy) {
 		return 0, api.ErrNotAvailable
 	}
 
@@ -482,7 +482,7 @@ func (c *EEBus) currents() (float64, float64, float64, error) {
 	}
 
 	// check if the EVSE supports currents
-	if !c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMScenarioPowerPerPhase) {
+	if !c.cem.EvCem.IsScenarioAvailableAtEntity(evEntity, eebus.EVCEMPowerPerPhase) {
 		return 0, 0, 0, api.ErrNotAvailable
 	}
 
@@ -538,7 +538,7 @@ func (c *EEBus) Soc() (float64, error) {
 		return 0, api.ErrNotAvailable
 	}
 
-	if !c.cem.EvSoc.IsScenarioAvailableAtEntity(evEntity, eebus.EVSOCScenarioStateOfCharge) {
+	if !c.cem.EvSoc.IsScenarioAvailableAtEntity(evEntity, eebus.EVSOCStateOfCharge) {
 		return 0, api.ErrNotAvailable
 	}
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -49,16 +49,16 @@ type maScenarios struct {
 
 var (
 	mpcScenarios = maScenarios{
-		power:    eebus.MPCScenarioPower,
-		energy:   eebus.MPCScenarioEnergyConsumed,
-		currents: eebus.MPCScenarioCurrentPerPhase,
-		voltages: eebus.MPCScenarioVoltagePerPhase,
+		power:    eebus.MPCPower,
+		energy:   eebus.MPCEnergyConsumed,
+		currents: eebus.MPCCurrentPerPhase,
+		voltages: eebus.MPCVoltagePerPhase,
 	}
 	mgcpScenarios = maScenarios{
-		power:    eebus.MGCPScenarioPower,
-		energy:   eebus.MGCPScenarioEnergyConsumed,
-		currents: eebus.MGCPScenarioCurrentPerPhase,
-		voltages: eebus.MGCPScenarioVoltagePerPhase,
+		power:    eebus.MGCPPower,
+		energy:   eebus.MGCPEnergyConsumed,
+		currents: eebus.MGCPCurrentPerPhase,
+		voltages: eebus.MGCPVoltagePerPhase,
 	}
 )
 
@@ -229,7 +229,7 @@ func (c *EEBus) Dimmed() (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebusReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCScenarioLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebusReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -254,7 +254,7 @@ func (c *EEBus) Dim(dim bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.egLpcEntity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(c.egLpcEntity, eebus.LPCScenarioLimit) {
+	if c.egLpcEntity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(c.egLpcEntity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
 	}
 
@@ -273,7 +273,7 @@ func (c *EEBus) Curtailed() (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebusReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPScenarioLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := eebusReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -298,7 +298,7 @@ func (c *EEBus) Curtail(curtail bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.egLppEntity == nil || !c.eg.EgLPPInterface.IsScenarioAvailableAtEntity(c.egLppEntity, eebus.LPPScenarioLimit) {
+	if c.egLppEntity == nil || !c.eg.EgLPPInterface.IsScenarioAvailableAtEntity(c.egLppEntity, eebus.LPPLimit) {
 		return api.ErrNotAvailable
 	}
 

--- a/server/eebus/scenarios.go
+++ b/server/eebus/scenarios.go
@@ -11,62 +11,62 @@ package eebus
 
 // MGCP — Monitoring of Grid Connection Point (UC TS v1.0.0)
 const (
-	MGCPScenarioPowerFactor     uint = 1 // S1 power factor (cos phi)
-	MGCPScenarioPower           uint = 2 // S2 active power per phase + total
-	MGCPScenarioEnergyFeedIn    uint = 3 // S3 total feed-in energy
-	MGCPScenarioEnergyConsumed  uint = 4 // S4 total consumed energy
-	MGCPScenarioCurrentPerPhase uint = 5 // S5 phase-specific currents
-	MGCPScenarioVoltagePerPhase uint = 6 // S6 phase-specific voltages
-	MGCPScenarioFrequency       uint = 7 // S7 frequency
+	MGCPPowerFactor     uint = 1 // S1 power factor (cos phi)
+	MGCPPower           uint = 2 // S2 active power per phase + total
+	MGCPEnergyFeedIn    uint = 3 // S3 total feed-in energy
+	MGCPEnergyConsumed  uint = 4 // S4 total consumed energy
+	MGCPCurrentPerPhase uint = 5 // S5 phase-specific currents
+	MGCPVoltagePerPhase uint = 6 // S6 phase-specific voltages
+	MGCPFrequency       uint = 7 // S7 frequency
 )
 
 // MPC — Monitoring of Power Consumption (UC TS v1.0.0)
 const (
-	MPCScenarioPower           uint = 1 // S1 active power per phase + total
-	MPCScenarioEnergyConsumed  uint = 2 // S2 total consumed energy
-	MPCScenarioCurrentPerPhase uint = 3 // S3 phase-specific currents
-	MPCScenarioVoltagePerPhase uint = 4 // S4 phase-specific voltages
-	MPCScenarioFrequency       uint = 5 // S5 frequency
+	MPCPower           uint = 1 // S1 active power per phase + total
+	MPCEnergyConsumed  uint = 2 // S2 total consumed energy
+	MPCCurrentPerPhase uint = 3 // S3 phase-specific currents
+	MPCVoltagePerPhase uint = 4 // S4 phase-specific voltages
+	MPCFrequency       uint = 5 // S5 frequency
 )
 
 // LPC — Limitation of Power Consumption (UC TS v1.0.0). Same scenario layout for CS and EG roles.
 const (
-	LPCScenarioLimit                uint = 1 // S1 LoadControl: consumption limit
-	LPCScenarioFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
-	LPCScenarioHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
-	LPCScenarioElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
+	LPCLimit                uint = 1 // S1 LoadControl: consumption limit
+	LPCFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
+	LPCHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
+	LPCElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
 )
 
 // LPP — Limitation of Power Production (UC TS v1.0.0). Same scenario layout for CS and EG roles.
 const (
-	LPPScenarioLimit                uint = 1 // S1 LoadControl: production limit
-	LPPScenarioFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
-	LPPScenarioHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
-	LPPScenarioElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
+	LPPLimit                uint = 1 // S1 LoadControl: production limit
+	LPPFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
+	LPPHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
+	LPPElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
 )
 
 // OPEV — Overload Protection by EV Charging Current Curtailment (UC TS v1.0.1)
 const (
-	OPEVScenarioObligationLimit uint = 1 // S1 LoadControl + ElectricalConnection
-	OPEVScenarioChargingState   uint = 2 // S2 charging state
-	OPEVScenarioChargingPlan    uint = 3 // S3 charging plan
+	OPEVObligationLimit uint = 1 // S1 LoadControl + ElectricalConnection
+	OPEVChargingState   uint = 2 // S2 charging state
+	OPEVChargingPlan    uint = 3 // S3 charging plan
 )
 
 // OSCEV — Optimization of Self-Consumption during EV Charging (UC TS v1.0.1)
 const (
-	OSCEVScenarioRecommendationLimit uint = 1 // S1 LoadControl + ElectricalConnection
-	OSCEVScenarioChargingState       uint = 2 // S2 charging state
-	OSCEVScenarioChargingPlan        uint = 3 // S3 charging plan
+	OSCEVRecommendationLimit uint = 1 // S1 LoadControl + ElectricalConnection
+	OSCEVChargingState       uint = 2 // S2 charging state
+	OSCEVChargingPlan        uint = 3 // S3 charging plan
 )
 
 // EVCEM — Measurement of Electricity during EV Charging (UC TS v1.0.1)
 const (
-	EVCEMScenarioPowerPerPhase uint = 1 // S1 phase-specific active power + ElectricalConnection (currents)
-	EVCEMScenarioPowerTotal    uint = 2 // S2 total active power only
-	EVCEMScenarioEnergy        uint = 3 // S3 charging energy summary
+	EVCEMPowerPerPhase uint = 1 // S1 phase-specific active power + ElectricalConnection (currents)
+	EVCEMPowerTotal    uint = 2 // S2 total active power only
+	EVCEMEnergy        uint = 3 // S3 charging energy summary
 )
 
 // EVSOC — EV State of Charge (UC TS v1.0.0 RC1)
 const (
-	EVSOCScenarioStateOfCharge uint = 1 // S1 state of charge
+	EVSOCStateOfCharge uint = 1 // S1 state of charge
 )


### PR DESCRIPTION
## Summary

Follow-up to #29701. Constant names like `MGCPScenarioPower` and `EVCEMScenarioPowerPerPhase` repeat the word `Scenario` even though every constant in this package is a scenario number. Drop the middle word so call sites read more naturally:

- `eebus.MGCPScenarioPower` → `eebus.MGCPPower`
- `eebus.MPCScenarioCurrentPerPhase` → `eebus.MPCCurrentPerPhase`
- `eebus.LPCScenarioLimit` → `eebus.LPCLimit`
- `eebus.EVCEMScenarioPowerPerPhase` → `eebus.EVCEMPowerPerPhase`
- …etc for LPP, OPEV, OSCEV, EVSOC

The use-case prefix (`MGCP`, `MPC`, `LPC`, `LPP`, `OPEV`, `OSCEV`, `EVCEM`, `EVSOC`) keeps the namespace clear; the trailing word names the quantity. `Scenario` adds nothing because the type and the comment already say so.

No behavior change.

## Test plan

- [x] `go build ./charger/... ./meter/... ./server/eebus/...` passes
- [x] `go test ./charger/... ./meter/... ./server/eebus/...` passes
- [x] `gofmt -l` clean