### PR TITLE
HomeAssistant: simplify off-action error message

### DIFF
--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -247,7 +247,7 @@ func (c *Connection) CallSwitchService(entity string, turnOn bool) error {
 	case "button", "input_button":
 		// Buttons are stateless — they only have a press action.
 		if !turnOn {
-			return fmt.Errorf("entity %s (domain %s) has no off action", entity, domain)
+			return fmt.Errorf("entity %s has no off action", entity)
 		}
 		service = "press"
 	default:

--- a/util/homeassistant/connection_test.go
+++ b/util/homeassistant/connection_test.go
@@ -35,8 +35,8 @@ func TestCallSwitchService_DomainDispatch(t *testing.T) {
 		{"switch turn_off", "switch.foo", false, "/api/services/switch/turn_off", ""},
 		{"button press", "button.tesla_model_x_wake_up", true, "/api/services/button/press", ""},
 		{"input_button press", "input_button.bar", true, "/api/services/input_button/press", ""},
-		{"button no off", "button.foo", false, "", "entity button.foo (domain button) has no off action"},
-		{"input_button no off", "input_button.bar", false, "", "entity input_button.bar (domain input_button) has no off action"},
+		{"button no off", "button.foo", false, "", "entity button.foo has no off action"},
+		{"input_button no off", "input_button.bar", false, "", "entity input_button.bar has no off action"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Follow-up to #29706. The entity name already contains the domain prefix (`button.foo`), so the parenthetical `(domain button)` in the error is redundant.

Before: \`entity button.foo (domain button) has no off action\`
After:  \`entity button.foo has no off action\`

Test assertion updated to match.