### PR TITLE
OCPP: fix flaky test deadlock between trigger handler and WS read loop

### DIFF
--- a/charger/ocpp_test_handler.go
+++ b/charger/ocpp_test_handler.go
@@ -14,7 +14,10 @@ type ChargePointHandler struct {
 // core
 
 func (handler *ChargePointHandler) OnChangeAvailability(request *core.ChangeAvailabilityRequest) (confirmation *core.ChangeAvailabilityConfirmation, err error) {
-	defer func() { handler.triggerC <- core.ChangeAvailabilityFeatureName }()
+	// dispatch asynchronously: the trigger handler issues synchronous CP→CS
+	// requests whose responses are read by this same goroutine, so a blocking
+	// send would deadlock the WebSocket read loop
+	go func() { handler.triggerC <- core.ChangeAvailabilityFeatureName }()
 	return core.NewChangeAvailabilityConfirmation(core.AvailabilityStatusAccepted), nil
 }
 
@@ -61,7 +64,8 @@ func (handler *ChargePointHandler) OnUnlockConnector(request *core.UnlockConnect
 }
 
 func (handler *ChargePointHandler) OnTriggerMessage(request *remotetrigger.TriggerMessageRequest) (confirmation *remotetrigger.TriggerMessageConfirmation, err error) {
-	defer func() { handler.triggerC <- request.RequestedMessage }()
+	// see OnChangeAvailability for why this is async
+	go func() { handler.triggerC <- request.RequestedMessage }()
 	return remotetrigger.NewTriggerMessageConfirmation(remotetrigger.TriggerMessageStatusAccepted), nil
 }
 


### PR DESCRIPTION
cc @nickveenhof — your proactive `BootNotification` trigger from #28540 is what tripped this latent test-harness deadlock.

## Summary
- `OnChangeAvailability` and `OnTriggerMessage` in `charger/ocpp_test_handler.go` deferred a synchronous send to `triggerC` (buffer 1).
- Both run inside the CP-side OCPP-J WebSocket read loop. The drainer that reads `triggerC` issues synchronous CP→CS requests whose responses return via that same read loop. A full buffer therefore blocks the read loop and deadlocks the in-flight roundtrip; ocpp-go's 30 s client default eventually surfaces as `"timeout"` out of `NewOCPP`.
- The proactive `BootNotification` trigger added in #28540 made the race trip in CI: with `Timeout=5s` (set in `SetupSuite`) and `triggerBootDelay=5s`, the proactive trigger and `Setup`'s own messages pile up on a single connect.

The smoking-gun signature in the failing job ([run 25481457477](https://github.com/evcc-io/evcc/actions/runs/25481457477/job/74766391109)) is a 30 s gap between server send and client receive of a single OCPP message:

```
07:12:46 sent JSON message to test-1: [3,"501509708",{...status:Accepted}]
07:13:16 received JSON message from server: [3,"501509708",{...}]
07:13:16 No previous request 501509708 sent. Discarding response message
```

Fix: dispatch the trigger send in its own goroutine so the OCPP read loop is never blocked. No timeouts adjusted.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -race -count=1 -run TestOcpp ./charger/` — 5/5 PASS at ~27 s each
- [x] Pre-fix `go test -race -count=10 ...` reproduced the deadlock locally (180 s timeout with goroutine dump showing blocked WS reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)