### PR TITLE
fix: drag & drop stability

### DIFF
--- a/assets/js/components/Helper/DragDropItem.vue
+++ b/assets/js/components/Helper/DragDropItem.vue
@@ -8,12 +8,7 @@
 		:aria-label="$t('config.general.dragItem', { title })"
 		tabindex="0"
 	>
-		<div
-			class="drag-handle me-2"
-			:aria-label="$t('config.general.dragHandle')"
-			role="button"
-			tabindex="-1"
-		>
+		<div class="drag-handle me-2" aria-hidden="true">
 			<shopicon-regular-menu></shopicon-regular-menu>
 		</div>
 		<div class="flex-grow-1">
@@ -42,12 +37,16 @@ export default defineComponent({
 
 <style scoped>
 .drag-drop-item {
-	cursor: move;
+	cursor: grab;
 	user-select: none;
 	background-color: var(--evcc-box);
 	border-color: var(--bs-border-color-translucent) !important;
 	transition: all var(--evcc-transition-fast) ease-in-out;
 	transform: translate(0, 0);
+}
+
+.drag-drop-item:active {
+	cursor: grabbing;
 }
 
 .drag-drop-item--hidden {
@@ -58,11 +57,11 @@ export default defineComponent({
 	color: var(--bs-secondary);
 	opacity: 0.7;
 	transition: opacity var(--evcc-transition-fast) ease-in-out;
-	cursor: grab;
+	cursor: inherit;
 }
 
-.drag-handle:active {
-	cursor: grabbing;
+.drag-handle > * {
+	pointer-events: none;
 }
 
 .drag-drop-item:hover .drag-handle {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -109,11 +109,8 @@ export async function dragElement(
   sourceElement: Locator,
   targetElement: Locator
 ): Promise<void> {
-  // hover() runs Playwright's actionability checks — including the "stable"
-  // check that waits for animations to finish — before positioning the mouse.
-  // This avoids races with the Bootstrap modal slide-in: reading boundingBox()
-  // mid-animation would otherwise return stale coordinates and the subsequent
-  // mouse.down() would miss the draggable source.
+  // hover() waits for animations to settle before grabbing the source —
+  // avoids stale coordinates during the modal slide-in.
   await sourceElement.hover();
   await page.mouse.down();
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -109,22 +109,20 @@ export async function dragElement(
   sourceElement: Locator,
   targetElement: Locator
 ): Promise<void> {
-  // Get bounding boxes to calculate actual positions
-  const sourceBox = await sourceElement.boundingBox();
+  // hover() runs Playwright's actionability checks — including the "stable"
+  // check that waits for animations to finish — before positioning the mouse.
+  // This avoids races with the Bootstrap modal slide-in: reading boundingBox()
+  // mid-animation would otherwise return stale coordinates and the subsequent
+  // mouse.down() would miss the draggable source.
+  await sourceElement.hover();
+  await page.mouse.down();
+
   const targetBox = await targetElement.boundingBox();
-
-  if (sourceBox && targetBox) {
-    // Move from center of source item to center of target item
-    const startX = sourceBox.x + sourceBox.width / 2;
-    const startY = sourceBox.y + sourceBox.height / 2;
-    const endX = targetBox.x + targetBox.width / 2;
-    const endY = targetBox.y + targetBox.height / 2;
-
-    await page.mouse.move(startX, startY);
-    await page.mouse.down();
-    await page.mouse.move(endX, endY, { steps: 10 });
-    await page.mouse.up();
-  }
+  if (!targetBox) throw new Error("dragElement: target has no bounding box");
+  await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
+    steps: 10,
+  });
+  await page.mouse.up();
 }
 
 export async function getDatalistOptions(input: Locator): Promise<string[]> {


### PR DESCRIPTION
- improve drag zones (start drag from indicator)
- use drag cursor consistently thought the element (before icon/text split)
- stabilize flaky drag&drop e2e test
