### PR TITLE
Fix: allow host names with tapo plugs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/hasura/go-graphql-client v0.16.0
 	github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
-	github.com/insomniacslk/tapo v1.0.2
+	github.com/insomniacslk/tapo v1.0.3
 	github.com/itchyny/gojq v0.12.19
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/jeremywohl/flatten v1.0.1
@@ -184,7 +184,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // indirect
-	github.com/insomniacslk/xjson v0.0.0-20231023101448-2249e546a131 // indirect
+	github.com/insomniacslk/xjson v0.0.0-20240821125711-1236daaf6808 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -409,10 +409,10 @@ github.com/influxdata/influxdb-client-go/v2 v2.14.0/go.mod h1:Ahpm3QXKMJslpXl3If
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf h1:7JTmneyiNEwVBOHSjoMxiWAqB992atOeepeFYegn5RU=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/insomniacslk/tapo v1.0.2 h1:o2Bz941/Kp3LEjO5kvBbAE9Z4z9BcQMXRols3QkTnI0=
-github.com/insomniacslk/tapo v1.0.2/go.mod h1:1wuMYu0+alZ4oE4BIzxAwQNveZgbb2tRqiIUwIe7SZE=
-github.com/insomniacslk/xjson v0.0.0-20231023101448-2249e546a131 h1:bVGPuMhjgFtxVdQGfYnFq+EnCqArOAjLNciow/nArwE=
-github.com/insomniacslk/xjson v0.0.0-20231023101448-2249e546a131/go.mod h1:Z4EVr4bVv9LZbbje9xyZEyOLpdCOmCvr5S9BJtrdTfw=
+github.com/insomniacslk/tapo v1.0.3 h1:k5S/aNvrZ7SrLiVe+y0KhT05UPiVywZTfo6VJYHnt2A=
+github.com/insomniacslk/tapo v1.0.3/go.mod h1:1wuMYu0+alZ4oE4BIzxAwQNveZgbb2tRqiIUwIe7SZE=
+github.com/insomniacslk/xjson v0.0.0-20240821125711-1236daaf6808 h1:BVD0pRpDWgbzkPYACLLPomriAnUGVfFdFoxs7aCLJkY=
+github.com/insomniacslk/xjson v0.0.0-20240821125711-1236daaf6808/go.mod h1:Z4EVr4bVv9LZbbje9xyZEyOLpdCOmCvr5S9BJtrdTfw=
 github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
 github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
 github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=

--- a/meter/tapo/connection.go
+++ b/meter/tapo/connection.go
@@ -2,7 +2,6 @@ package tapo
 
 import (
 	"fmt"
-	"net/netip"
 	"net/url"
 	"strings"
 
@@ -28,18 +27,16 @@ func NewConnection(uri, user, password string) (*Connection, error) {
 		return nil, fmt.Errorf("invalid url: %s", uri)
 	}
 
-	addr, err := netip.ParseAddr(url.Hostname())
-	if err != nil {
-		return nil, fmt.Errorf("invalid ip address: %s", uri)
-	}
-
 	if user == "" || password == "" {
 		return nil, api.ErrMissingCredentials
 	}
 
 	log := util.NewLogger("tapo").Redact(user, password)
 
-	plug := tapo.NewPlug(addr, nil)
+	plug, err := tapo.NewPlugFromString(url.Hostname(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tapo device for %q: %w", url.Hostname(), err)
+	}
 	if err := plug.Handshake(user, password); err != nil {
 		return nil, fmt.Errorf("login failed: %w", err)
 	}


### PR DESCRIPTION
The Tapo plug UI mentions hostnames alongside IP addresses, however when using a host name for a Tapo plug, it returns an error (see screenshot):

<img width="552" height="1107" alt="Screenshot from 2026-05-08 23-03-17" src="https://github.com/user-attachments/assets/44f1ed68-e637-4da2-9c3e-b6aa835deadc" />

This patch enables both IP addresses and host names for Tapo plugs. Tested manually with a local, patched instance (see screenshot). Please let me know if there's a better way to test this.

<img width="538" height="1177" alt="Screenshot from 2026-05-08 23-05-45" src="https://github.com/user-attachments/assets/eef05e54-7364-44a3-80f5-316cfcd8ca7b" />
