### PR TITLE
fix: update Dockerfile for cmd/decorate → cmd/implement rename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=${GOMODCACHE} go mod download
 
 # install tools
 COPY Makefile .
-COPY cmd/decorate/ cmd/decorate/
+COPY cmd/implement/ cmd/implement/
 COPY cmd/openapi/ cmd/openapi/
 COPY api/ api/
 RUN --mount=type=cache,target=${GOMODCACHE} make install


### PR DESCRIPTION
## Summary
- `cmd/decorate` was renamed to `cmd/implement` in #28576, but the Dockerfile still referenced the old path, breaking Docker builds

## Test plan
- `docker buildx build` completes the `builder` stage without the `"/cmd/decorate": not found` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)