### PR TITLE
Batteries: track energy metrics

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -88,6 +88,7 @@ type Site struct {
 	pvEnergy    map[string]*metrics.Accumulator
 
 	homeEnergy, gridEnergy *metrics.Collector
+	batteryEnergy          map[string]*metrics.Collector // per-battery, keyed by meter ref
 
 	// cached state
 	gridPower                float64            // Grid power
@@ -216,6 +217,12 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 			return err
 		}
 		site.batteryMeters = append(site.batteryMeters, dev)
+
+		me, err := metrics.NewCollector(metrics.Battery, ref)
+		if err != nil {
+			return err
+		}
+		site.batteryEnergy[ref] = me
 	}
 
 	// meters used only for monitoring
@@ -251,10 +258,11 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 // NewSite creates a Site with sane defaults
 func NewSite() *Site {
 	site := &Site{
-		log:        util.NewLogger("site"),
-		Voltage:    230, // V
-		pvEnergy:   make(map[string]*metrics.Accumulator),
-		fcstEnergy: metrics.NewAccumulator(),
+		log:           util.NewLogger("site"),
+		Voltage:       230, // V
+		pvEnergy:      make(map[string]*metrics.Accumulator),
+		batteryEnergy: make(map[string]*metrics.Collector),
+		fcstEnergy:    metrics.NewAccumulator(),
 	}
 
 	return site
@@ -670,6 +678,22 @@ func (site *Site) updateBatteryMeters() {
 	}
 
 	site.battery.Devices = mm
+
+	// accumulate per-battery energy (charging = import, discharging = export — from battery POV toward grid root)
+	for i, dev := range site.batteryMeters {
+		ref := dev.Config().Name
+		c, ok := site.batteryEnergy[ref]
+		if !ok {
+			continue
+		}
+		var exportEnergy *float64
+		if mm[i].Energy > 0 {
+			exportEnergy = &mm[i].Energy
+		}
+		if err := c.AddEnergy(nil, exportEnergy, -mm[i].Power); err != nil {
+			site.log.ERROR.Printf("persist battery %d energy: %v", i+1, err)
+		}
+	}
 
 	site.publish(keys.Battery, site.battery)
 }


### PR DESCRIPTION
## Summary

Adds per-battery energy tracking to `site.go`, mirroring the existing pattern used for grid, home, PV and loadpoints.


> Sign convention follows `Accumulator.AddPower`: discharging (`Power > 0`) counts as **import**, charging (`Power < 0`) counts as **export** — battery is treated as an energy source from the home's perspective

@premultiply could you check if this is correct? Should we use the `import` column for import to home or import to device? For grid it's import to home, i.e. "from a grid device", so this could be justified. We'd still need to make sure that a potential battery import energy reading matches that definition which would be odd!

/cc @naltatis wanna update History here?