### PR TITLE
ocpp: fall back to confirmed profile limit for GetMaxCurrent

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -20,6 +20,7 @@ package charger
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -128,9 +129,7 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
 	}
 
-	if c.cp.HasMeasurement(types.MeasurandCurrentOffered) {
-		implement.Has(c, implement.CurrentGetter(c.conn.GetMaxCurrent))
-	}
+	implement.Has(c, implement.CurrentGetter(c.getMaxCurrent))
 
 	return c, nil
 }
@@ -349,6 +348,22 @@ func (c *OCPP) createTxDefaultChargingProfile(current float64) *types.ChargingPr
 	}
 
 	return res
+}
+
+// getMaxCurrent returns the current the charge point is set to offer.
+// Prefers the Current.Offered measurand, falls back to the last confirmed charging profile limit.
+func (c *OCPP) getMaxCurrent() (float64, error) {
+	if c.cp.HasMeasurement(types.MeasurandCurrentOffered) {
+		if v, err := c.conn.GetMaxCurrent(); err == nil || !errors.Is(err, api.ErrNotAvailable) {
+			return v, err
+		}
+	}
+
+	if c.current > 0 {
+		return c.current, nil
+	}
+
+	return 0, api.ErrNotAvailable
 }
 
 // MaxCurrent implements the api.Charger interface


### PR DESCRIPTION
When the charger does not report Current.Offered in its meter values, GetMaxCurrent now returns the last **_confirmed_** SetChargingProfile limit instead of ErrNotAvailable. This prevents syncCharger from falling through to potentially stale measured phase currents, as these can cause a runaway oscillation where the control loop would escalate charging current to max on every other cycle.

@andig I am no expert in ocpp protocol. What I understand is that having the Current.Offered measurand would be the official way and that's why it was built as is. For me it seems nevertheless OK to fallback to the confirmed limit (i.e. the response to setting the TxProfile), as it would be strange for that value and Current.Offered to differ. But maybe I am missing something?

(In case you are wondering why - so far Easee does not report the Current.Offered measurand.)

Marking WIP/draft, as I am still testing locally, but wanted to have your input early.