### PR TITLE
Add GoodWe Wallbox (Gen2) charger

### DIFF
--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -52,7 +52,7 @@ const (
 	goodweRegPhaseSwEnabled = 10023 // U16 (0=Off, 1=On)
 	goodweRegMaxPower       = 10029 // U16 ×0.1 kW, raw range [14,220]
 	goodweRegChargeMode     = 10032 // U16 (0=fast, 1=PV, 2=PV+battery)
-	goodweRegSerial         = 10040 // 8 regs ASCII (16 bytes)
+	goodweRegRfid           = 10050 // 7 regs ASCII (14 bytes)
 	goodweRegPowerSpec      = 10058 // U16 (0=7kW, 1=11kW, 2=22kW)
 	goodweRegPhaseSpec      = 10059 // U16 (0=1p, 1=3p)
 	goodweRegChargeCommand  = 10060 // U16 (1=stop, 2=start)
@@ -263,7 +263,7 @@ var _ api.Identifier = (*GoodWe)(nil)
 
 // Identify implements api.Identifier
 func (wb *GoodWe) Identify() (string, error) {
-	b, err := wb.conn.ReadHoldingRegisters(goodweRegSerial, 8)
+	b, err := wb.conn.ReadHoldingRegisters(goodweRegRfid, 7)
 	if err != nil {
 		return "", err
 	}

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/modbus"
@@ -35,22 +36,28 @@ import (
 // Default device ID is 247 (0xF7); TCP Modbus must be enabled in SolarGo.
 
 type GoodWe struct {
-	lp   loadpoint.API
-	conn *modbus.Connection
+	implement.Caps
+	lp       loadpoint.API
+	conn     *modbus.Connection
+	current  float64
+	phases   int
+	maxPower int
 }
 
 const (
-	goodweRegVoltages      = 10009 // U16 ×0.1 V, 3 regs (L1/L2/L3)
-	goodweRegCurrents      = 10012 // U16 ×0.1 A, 3 regs (L1/L2/L3)
-	goodweRegActualPower   = 10015 // U16 ×0.1 kW
-	goodweRegSessionEnergy = 10016 // U16 ×0.1 kWh
-	goodweRegStatus        = 10017 // U16 enum (see status mapping)
-	goodweRegPhaseSwitch   = 10023 // U16 (1=single-phase, 0=three-phase)
-	goodweRegMaxPower      = 10029 // U16 ×0.1 kW, raw range [14,220]
-	goodweRegChargeMode    = 10032 // U16 (0=fast, 1=PV, 2=PV+battery)
-	goodweRegSerial        = 10040 // 8 regs ASCII (16 bytes)
-	goodweRegChargeCommand = 10060 // U16 (1=stop, 2=start)
-	goodweRegTotalEnergy   = 10065 // U32 ×0.1 kWh, 2 regs
+	goodweRegVoltages       = 10009 // U16 ×0.1 V, 3 regs (L1/L2/L3)
+	goodweRegCurrents       = 10012 // U16 ×0.1 A, 3 regs (L1/L2/L3)
+	goodweRegActualPower    = 10015 // U16 ×0.1 kW
+	goodweRegSessionEnergy  = 10016 // U16 ×0.1 kWh
+	goodweRegStatus         = 10017 // U16 enum (see status mapping)
+	goodweRegPhaseSwEnabled = 10023 // U16 (0=Off, 1=On)
+	goodweRegMaxPower       = 10029 // U16 ×0.1 kW, raw range [14,220]
+	goodweRegChargeMode     = 10032 // U16 (0=fast, 1=PV, 2=PV+battery)
+	goodweRegSerial         = 10040 // 8 regs ASCII (16 bytes)
+	goodweRegPowerSpec      = 10058 // U16 (0=7kW, 1=11kW, 2=22kW)
+	goodweRegPhaseSpec      = 10059 // U16 (0=1p, 1=3p)
+	goodweRegChargeCommand  = 10060 // U16 (1=stop, 2=start)
+	goodweRegTotalEnergy    = 10065 // U32 ×0.1 kWh, 2 regs
 
 	goodweChargeStop     = 1
 	goodweChargeStart    = 2
@@ -88,7 +95,45 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 	log := util.NewLogger("goodwe")
 	conn.Logger(log.TRACE)
 
-	wb := &GoodWe{conn: conn}
+	wb := &GoodWe{
+		Caps: implement.New(),
+		conn: conn,
+	}
+
+	// read hardware power spec (0=7kW, 1=11kW, 2=22kW)
+	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPowerSpec, 1); err == nil {
+		switch binary.BigEndian.Uint16(b) {
+		case 0:
+			wb.maxPower = 7000
+		case 1:
+			wb.maxPower = 11000
+		case 2:
+			wb.maxPower = 22000
+		}
+	} else {
+		return nil, fmt.Errorf("read power capability: %w", err)
+	}
+
+	// read hardware phase spec (0=1-phase, 1=3-phase)
+	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSpec, 1); err == nil {
+		if binary.BigEndian.Uint16(b) == 1 {
+			wb.phases = 3
+		} else {
+			wb.phases = 1
+		}
+	} else {
+		return nil, fmt.Errorf("read hw phase count: %w", err)
+	}
+
+	// conditionally register phase switching based on hardware capability
+	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
+		if binary.BigEndian.Uint16(b) == 1 {
+			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
+			implement.Has(wb, implement.PhaseGetter(wb.getPhases))
+		}
+	} else {
+		return nil, fmt.Errorf("read phase switch config: %w", err)
+	}
 
 	// force "fast" charging mode so evcc fully controls power setpoint
 	if _, err := wb.conn.WriteSingleRegister(goodweRegChargeMode, goodweChargeModeFast); err != nil {
@@ -96,6 +141,10 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 	}
 
 	return wb, nil
+}
+
+func (wb *GoodWe) calcPower(current float64, phases int) uint16 {
+	return uint16(min(max(230*float64(phases)*current, 1400), float64(wb.maxPower)) / 100) // 0.1 kW
 }
 
 // Status implements api.ChargeState
@@ -149,23 +198,7 @@ func (wb *GoodWe) MaxCurrentMillis(current float64) error {
 		return fmt.Errorf("invalid current %.1f", current)
 	}
 
-	phases := 3
-	if wb.lp != nil {
-		if p := wb.lp.ActivePhases(); p != 0 {
-			phases = p
-		}
-	}
-
-	// raw register unit is 0.1 kW; clamp to documented [14,220] range
-	raw := uint16(voltage * current * float64(phases) / 100)
-	switch {
-	case raw < 14:
-		raw = 14
-	case raw > 220:
-		raw = 220
-	}
-
-	_, err := wb.conn.WriteSingleRegister(goodweRegMaxPower, raw)
+	_, err := wb.conn.WriteSingleRegister(goodweRegMaxPower, wb.calcPower(current, wb.phases))
 	return err
 }
 
@@ -218,22 +251,13 @@ func (wb *GoodWe) Voltages() (float64, float64, float64, error) {
 	return wb.phaseValues(goodweRegVoltages, 10)
 }
 
-var _ api.PhaseSwitcher = (*GoodWe)(nil)
+func (wb *GoodWe) phases1p3p(phases int) error {
+	wb.phases = phases
+	return nil
+}
 
-// Phases1p3p implements api.PhaseSwitcher. Only meaningful on 3-phase models
-// (11/22 kW): single-phase mode allows charging down to 1.4 kW instead of 4.2 kW.
-func (wb *GoodWe) Phases1p3p(phases int) error {
-	var v uint16
-	switch phases {
-	case 1:
-		v = 1
-	case 3:
-		v = 0
-	default:
-		return fmt.Errorf("invalid phase count: %d", phases)
-	}
-	_, err := wb.conn.WriteSingleRegister(goodweRegPhaseSwitch, v)
-	return err
+func (wb *GoodWe) getPhases() (int, error) {
+	return wb.phases, nil
 }
 
 var _ api.Identifier = (*GoodWe)(nil)

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -117,21 +117,21 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSpec, 1); err == nil {
 		if binary.BigEndian.Uint16(b) == 1 {
 			wb.phases = 3
+
+			// conditionally register phase switching based on hardware capability
+			if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
+				if binary.BigEndian.Uint16(b) == 1 {
+					implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
+					implement.Has(wb, implement.PhaseGetter(wb.getPhases))
+				}
+			} else {
+				return nil, fmt.Errorf("read phase switch config: %w", err)
+			}
 		} else {
 			wb.phases = 1
 		}
 	} else {
 		return nil, fmt.Errorf("read hw phase count: %w", err)
-	}
-
-	// conditionally register phase switching based on hardware capability
-	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
-		if binary.BigEndian.Uint16(b) == 1 {
-			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
-			implement.Has(wb, implement.PhaseGetter(wb.getPhases))
-		}
-	} else {
-		return nil, fmt.Errorf("read phase switch config: %w", err)
 	}
 
 	// force "fast" charging mode so evcc fully controls power setpoint
@@ -142,6 +142,11 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 	return wb, nil
 }
 
+// calcPower converts a per-phase current target into the wallbox's 0.1 kW power setpoint.
+// The protocol exposes only a total power register; how the wallbox converts that back into
+// a per-phase current limit is unspecified — it may assume a fixed nominal voltage (e.g. 230 V)
+// or use its own live voltage measurement. 230 V is used here as a best-effort approximation;
+// actual delivered current may deviate accordingly until verified on hardware.
 func (wb *GoodWe) calcPower(current float64, phases int) uint16 {
 	return uint16(min(max(230*float64(phases)*current, 1400), float64(wb.maxPower)) / 100) // 0.1 kW
 }

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -39,7 +39,6 @@ type GoodWe struct {
 	implement.Caps
 	lp       loadpoint.API
 	conn     *modbus.Connection
-	current  float64
 	phases   int
 	maxPower int
 }

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -58,8 +58,9 @@ const (
 	goodweRegChargeCommand  = 10060 // U16 (1=stop, 2=start)
 	goodweRegTotalEnergy    = 10065 // U32 ×0.1 kWh, 2 regs
 
-	goodweChargeStop     = 1
-	goodweChargeStart    = 2
+	goodweChargeStop  = 1
+	goodweChargeStart = 2
+
 	goodweChargeModeFast = 0
 )
 
@@ -134,7 +135,6 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
 		if binary.BigEndian.Uint16(b) == 1 {
 			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
-			implement.Has(wb, implement.PhaseGetter(wb.getPhases))
 		}
 	} else {
 		log.WARN.Printf("read phase switch config failed, disabling dynamic phase switching: %v", err)
@@ -264,10 +264,6 @@ func (wb *GoodWe) Voltages() (float64, float64, float64, error) {
 func (wb *GoodWe) phases1p3p(phases int) error {
 	wb.phases = phases
 	return nil
-}
-
-func (wb *GoodWe) getPhases() (int, error) {
-	return wb.phases, nil
 }
 
 var _ api.Identifier = (*GoodWe)(nil)

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -180,17 +180,6 @@ func (wb *GoodWe) CurrentPower() (float64, error) {
 	return float64(binary.BigEndian.Uint16(b)) * 100, nil
 }
 
-var _ api.ChargeRater = (*GoodWe)(nil)
-
-// ChargedEnergy implements api.ChargeRater
-func (wb *GoodWe) ChargedEnergy() (float64, error) {
-	b, err := wb.conn.ReadHoldingRegisters(goodweRegSessionEnergy, 1)
-	if err != nil {
-		return 0, err
-	}
-	return float64(binary.BigEndian.Uint16(b)) / 10, nil
-}
-
 var _ api.MeterEnergy = (*GoodWe)(nil)
 
 // TotalEnergy implements api.MeterEnergy

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -1,0 +1,268 @@
+package charger
+
+// LICENSE
+
+// Copyright (c) evcc.io (andig, naltatis, premultiply)
+
+// This module is NOT covered by the MIT license. All rights reserved.
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/modbus"
+)
+
+// GoodWe AC EV Charger Gen2 (e.g. GW11K-HCA) — Modbus TCP.
+// Protocol reference: "AC EV Charger 2nd Gen Modbus Protocol v1.0.15"
+// derived from the Home Assistant integration on the gen2-modbus branch:
+//   https://github.com/pedrodivisez/goodwe-wallbox-sems-home-assistant/tree/gen2-modbus
+// Default device ID is 247 (0xF7); TCP Modbus must be enabled in SolarGo.
+
+type GoodWe struct {
+	lp   loadpoint.API
+	conn *modbus.Connection
+}
+
+const (
+	goodweRegVoltages      = 10009 // U16 ×0.1 V, 3 regs (L1/L2/L3)
+	goodweRegCurrents      = 10012 // U16 ×0.1 A, 3 regs (L1/L2/L3)
+	goodweRegActualPower   = 10015 // U16 ×0.1 kW
+	goodweRegSessionEnergy = 10016 // U16 ×0.1 kWh
+	goodweRegStatus        = 10017 // U16 enum (see status mapping)
+	goodweRegPhaseSwitch   = 10023 // U16 (1=single-phase, 0=three-phase)
+	goodweRegMaxPower      = 10029 // U16 ×0.1 kW, raw range [14,220]
+	goodweRegChargeMode    = 10032 // U16 (0=fast, 1=PV, 2=PV+battery)
+	goodweRegSerial        = 10040 // 8 regs ASCII (16 bytes)
+	goodweRegChargeCommand = 10060 // U16 (1=stop, 2=start)
+	goodweRegTotalEnergy   = 10065 // U32 ×0.1 kWh, 2 regs
+
+	goodweChargeStop     = 1
+	goodweChargeStart    = 2
+	goodweChargeModeFast = 0
+)
+
+func init() {
+	registry.AddCtx("goodwe-wallbox", NewGoodWeFromConfig)
+}
+
+// NewGoodWeFromConfig creates a GoodWe wallbox charger from generic config.
+func NewGoodWeFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
+	cc := struct {
+		modbus.TcpSettings `mapstructure:",squash"`
+	}{
+		TcpSettings: modbus.TcpSettings{ID: 247},
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	return NewGoodWe(ctx, cc.URI, cc.ID)
+}
+
+// NewGoodWe creates a GoodWe wallbox charger.
+func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, error) {
+	uri = util.DefaultPort(uri, 502)
+
+	conn, err := modbus.NewConnection(ctx, uri, "", "", 0, modbus.Tcp, slaveID)
+	if err != nil {
+		return nil, err
+	}
+
+	log := util.NewLogger("goodwe")
+	conn.Logger(log.TRACE)
+
+	wb := &GoodWe{conn: conn}
+
+	// force "fast" charging mode so evcc fully controls power setpoint
+	if _, err := wb.conn.WriteSingleRegister(goodweRegChargeMode, goodweChargeModeFast); err != nil {
+		return nil, fmt.Errorf("set charge mode: %w", err)
+	}
+
+	return wb, nil
+}
+
+// Status implements api.ChargeState
+func (wb *GoodWe) Status() (api.ChargeStatus, error) {
+	b, err := wb.conn.ReadHoldingRegisters(goodweRegStatus, 1)
+	if err != nil {
+		return api.StatusNone, err
+	}
+
+	switch s := binary.BigEndian.Uint16(b); s {
+	case 0: // idle, no plug
+		return api.StatusA, nil
+	case 1, 2, 4, 6, 10: // plugged, handshaking, completed, scheduled, interrupted
+		return api.StatusB, nil
+	case 3: // charging
+		return api.StatusC, nil
+	case 5, 7, 8, 9: // alarm, maintenance, start_failed, upgrading
+		return api.StatusNone, fmt.Errorf("wallbox in error state %d", s)
+	default:
+		return api.StatusNone, fmt.Errorf("invalid status: %d", s)
+	}
+}
+
+// Enabled implements api.Charger
+func (wb *GoodWe) Enabled() (bool, error) {
+	b, err := wb.conn.ReadHoldingRegisters(goodweRegChargeCommand, 1)
+	if err != nil {
+		return false, err
+	}
+	return binary.BigEndian.Uint16(b) == goodweChargeStart, nil
+}
+
+// Enable implements api.Charger
+func (wb *GoodWe) Enable(enable bool) error {
+	v := uint16(goodweChargeStop)
+	if enable {
+		v = goodweChargeStart
+	}
+	_, err := wb.conn.WriteSingleRegister(goodweRegChargeCommand, v)
+	return err
+}
+
+// MaxCurrent implements api.Charger
+func (wb *GoodWe) MaxCurrent(current int64) error {
+	return wb.MaxCurrentMillis(float64(current))
+}
+
+var _ api.ChargerEx = (*GoodWe)(nil)
+
+// MaxCurrentMillis implements api.ChargerEx
+func (wb *GoodWe) MaxCurrentMillis(current float64) error {
+	if current < 6 {
+		return fmt.Errorf("invalid current %.1f", current)
+	}
+
+	phases := 3
+	if wb.lp != nil {
+		if p := wb.lp.ActivePhases(); p != 0 {
+			phases = p
+		}
+	}
+
+	// raw register unit is 0.1 kW; clamp to documented [14,220] range
+	raw := uint16(voltage * current * float64(phases) / 100)
+	switch {
+	case raw < 14:
+		raw = 14
+	case raw > 220:
+		raw = 220
+	}
+
+	_, err := wb.conn.WriteSingleRegister(goodweRegMaxPower, raw)
+	return err
+}
+
+var _ api.Meter = (*GoodWe)(nil)
+
+// CurrentPower implements api.Meter
+func (wb *GoodWe) CurrentPower() (float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(goodweRegActualPower, 1)
+	if err != nil {
+		return 0, err
+	}
+	return float64(binary.BigEndian.Uint16(b)) * 100, nil
+}
+
+var _ api.ChargeRater = (*GoodWe)(nil)
+
+// ChargedEnergy implements api.ChargeRater
+func (wb *GoodWe) ChargedEnergy() (float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(goodweRegSessionEnergy, 1)
+	if err != nil {
+		return 0, err
+	}
+	return float64(binary.BigEndian.Uint16(b)) / 10, nil
+}
+
+var _ api.MeterEnergy = (*GoodWe)(nil)
+
+// TotalEnergy implements api.MeterEnergy
+func (wb *GoodWe) TotalEnergy() (float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(goodweRegTotalEnergy, 2)
+	if err != nil {
+		return 0, err
+	}
+	return float64(binary.BigEndian.Uint32(b)) / 10, nil
+}
+
+func (wb *GoodWe) phaseValues(reg uint16, divider float64) (float64, float64, float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(reg, 3)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	var v [3]float64
+	for i := range v {
+		v[i] = float64(binary.BigEndian.Uint16(b[2*i:])) / divider
+	}
+	return v[0], v[1], v[2], nil
+}
+
+var _ api.PhaseCurrents = (*GoodWe)(nil)
+
+// Currents implements api.PhaseCurrents
+func (wb *GoodWe) Currents() (float64, float64, float64, error) {
+	return wb.phaseValues(goodweRegCurrents, 10)
+}
+
+var _ api.PhaseVoltages = (*GoodWe)(nil)
+
+// Voltages implements api.PhaseVoltages
+func (wb *GoodWe) Voltages() (float64, float64, float64, error) {
+	return wb.phaseValues(goodweRegVoltages, 10)
+}
+
+var _ api.PhaseSwitcher = (*GoodWe)(nil)
+
+// Phases1p3p implements api.PhaseSwitcher. Only meaningful on 3-phase models
+// (11/22 kW): single-phase mode allows charging down to 1.4 kW instead of 4.2 kW.
+func (wb *GoodWe) Phases1p3p(phases int) error {
+	var v uint16
+	switch phases {
+	case 1:
+		v = 1
+	case 3:
+		v = 0
+	default:
+		return fmt.Errorf("invalid phase count: %d", phases)
+	}
+	_, err := wb.conn.WriteSingleRegister(goodweRegPhaseSwitch, v)
+	return err
+}
+
+var _ api.Identifier = (*GoodWe)(nil)
+
+// Identify implements api.Identifier
+func (wb *GoodWe) Identify() (string, error) {
+	b, err := wb.conn.ReadHoldingRegisters(goodweRegSerial, 8)
+	if err != nil {
+		return "", err
+	}
+	return bytesAsString(b), nil
+}
+
+var _ loadpoint.Controller = (*GoodWe)(nil)
+
+// LoadpointControl implements loadpoint.Controller
+func (wb *GoodWe) LoadpointControl(lp loadpoint.API) {
+	wb.lp = lp
+}

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -18,6 +18,7 @@ package charger
 // SOFTWARE.
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -47,7 +48,6 @@ const (
 	goodweRegVoltages       = 10009 // U16 ×0.1 V, 3 regs (L1/L2/L3)
 	goodweRegCurrents       = 10012 // U16 ×0.1 A, 3 regs (L1/L2/L3)
 	goodweRegActualPower    = 10015 // U16 ×0.1 kW
-	goodweRegSessionEnergy  = 10016 // U16 ×0.1 kWh
 	goodweRegStatus         = 10017 // U16 enum (see status mapping)
 	goodweRegPhaseSwEnabled = 10023 // U16 (0=Off, 1=On)
 	goodweRegMaxPower       = 10029 // U16 ×0.1 kW, raw range [14,220]
@@ -94,44 +94,50 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 	log := util.NewLogger("goodwe")
 	conn.Logger(log.TRACE)
 
+	// defaults if hardware capability registers can't be read:
+	// assume 3-phase wallbox without phase switching at typical 11 kW class.
 	wb := &GoodWe{
-		Caps: implement.New(),
-		conn: conn,
+		Caps:     implement.New(),
+		conn:     conn,
+		phases:   3,
+		maxPower: 11000,
 	}
 
-	// read hardware power spec (0=7kW, 1=11kW, 2=22kW)
+	// read hardware power spec (0=7kW, 1=11kW, 2=22kW); fall back to default on error/unknown
 	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPowerSpec, 1); err == nil {
-		switch binary.BigEndian.Uint16(b) {
+		switch v := binary.BigEndian.Uint16(b); v {
 		case 0:
+			wb.phases = 1
 			wb.maxPower = 7000
 		case 1:
 			wb.maxPower = 11000
 		case 2:
 			wb.maxPower = 22000
+		default:
+			log.WARN.Printf("unknown power spec %d, defaulting to %d W", v, wb.maxPower)
 		}
 	} else {
-		return nil, fmt.Errorf("read power capability: %w", err)
+		log.WARN.Printf("read power capability failed, defaulting to %d W: %v", wb.maxPower, err)
 	}
 
-	// read hardware phase spec (0=1-phase, 1=3-phase)
+	// read hardware phase spec (0=1-phase, 1=3-phase); fall back to 3-phase on error
 	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSpec, 1); err == nil {
-		if binary.BigEndian.Uint16(b) == 1 {
-			wb.phases = 3
-
-			// conditionally register phase switching based on hardware capability
-			if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
-				if binary.BigEndian.Uint16(b) == 1 {
-					implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
-					implement.Has(wb, implement.PhaseGetter(wb.getPhases))
-				}
-			} else {
-				return nil, fmt.Errorf("read phase switch config: %w", err)
-			}
-		} else {
+		if binary.BigEndian.Uint16(b) == 0 {
 			wb.phases = 1
 		}
 	} else {
-		return nil, fmt.Errorf("read hw phase count: %w", err)
+		log.WARN.Printf("read hw phase count failed, defaulting to 3-phase: %v", err)
+	}
+
+	// conditionally register phase switching based on hardware capability; on read error
+	// fall back to a fixed-phase charger without dynamic 1p/3p switching
+	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
+		if binary.BigEndian.Uint16(b) == 1 {
+			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
+			implement.Has(wb, implement.PhaseGetter(wb.getPhases))
+		}
+	} else {
+		log.WARN.Printf("read phase switch config failed, disabling dynamic phase switching: %v", err)
 	}
 
 	// force "fast" charging mode so evcc fully controls power setpoint
@@ -266,13 +272,13 @@ func (wb *GoodWe) getPhases() (int, error) {
 
 var _ api.Identifier = (*GoodWe)(nil)
 
-// Identify implements api.Identifier
+// Identify implements api.Identifier (RFID UID, 14-byte NUL-padded ASCII).
 func (wb *GoodWe) Identify() (string, error) {
 	b, err := wb.conn.ReadHoldingRegisters(goodweRegRfid, 7)
 	if err != nil {
 		return "", err
 	}
-	return bytesAsString(b), nil
+	return bytesAsString(bytes.Trim(b, "\x00")), nil
 }
 
 var _ loadpoint.Controller = (*GoodWe)(nil)

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -130,14 +130,16 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 		log.WARN.Printf("read hw phase count failed, defaulting to 3-phase: %v", err)
 	}
 
-	// conditionally register phase switching based on hardware capability; on read error
-	// fall back to a fixed-phase charger without dynamic 1p/3p switching
-	if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
-		if binary.BigEndian.Uint16(b) == 1 {
-			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
+	// only 3-phase hardware can do 1p/3p switching; conditionally register phase switching
+	// based on hardware capability. On read error, fall back to fixed-phase operation.
+	if wb.phases == 3 {
+		if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
+			if binary.BigEndian.Uint16(b) == 1 {
+				implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
+			}
+		} else {
+			log.WARN.Printf("read phase switch config failed, disabling dynamic phase switching: %v", err)
 		}
-	} else {
-		log.WARN.Printf("read phase switch config failed, disabling dynamic phase switching: %v", err)
 	}
 
 	// force "fast" charging mode so evcc fully controls power setpoint

--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -112,8 +112,6 @@ func (wb *GoodWe) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 3: // charging
 		return api.StatusC, nil
-	case 5, 7, 8, 9: // alarm, maintenance, start_failed, upgrading
-		return api.StatusNone, fmt.Errorf("wallbox in error state %d", s)
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", s)
 	}

--- a/templates/definition/charger/goodwe-wallbox.yaml
+++ b/templates/definition/charger/goodwe-wallbox.yaml
@@ -1,0 +1,24 @@
+template: goodwe-wallbox
+products:
+  - brand: GoodWe
+    description:
+      generic: HCA Wallbox (Gen2)
+capabilities: ["mA", "rfid", "1p3p", "meter"]
+requirements:
+  description:
+    de: |
+      Modbus TCP muss in der SolarGo App im Menü „Kommunikation → Wallbox" aktiviert werden.
+      Standard-Geräte-ID ist 247 (0xF7).
+      Hinweis: Die Implementierung wurde anhand der Home Assistant Integration (gen2-modbus Branch) erstellt und ist nicht herstellerseitig verifiziert.
+    en: |
+      Enable Modbus TCP in the SolarGo app via "Communication → Wallbox".
+      Default device ID is 247 (0xF7).
+      Note: Implementation is derived from the Home Assistant integration (gen2-modbus branch) and is not vendor-verified.
+params:
+  - name: modbus
+    choice: ["tcpip"]
+    id: 247
+    port: 502
+render: |
+  type: goodwe-wallbox
+  {{- include "modbus" . }}

--- a/templates/definition/charger/goodwe-wallbox.yaml
+++ b/templates/definition/charger/goodwe-wallbox.yaml
@@ -9,10 +9,12 @@ requirements:
     de: |
       Modbus TCP muss in der SolarGo App im Menü „Kommunikation → Wallbox" aktiviert werden.
       Standard-Geräte-ID ist 247 (0xF7).
+      Die Wallbox erlaubt nur 2 gleichzeitige Modbus-TCP-Sitzungen (1× SEMS-Cloud, 1× Client). Bei aktiver Cloud-Verbindung konkurriert evcc um den zweiten Slot.
       Hinweis: Die Implementierung wurde anhand der Home Assistant Integration (gen2-modbus Branch) erstellt und ist nicht herstellerseitig verifiziert.
     en: |
       Enable Modbus TCP in the SolarGo app via "Communication → Wallbox".
       Default device ID is 247 (0xF7).
+      The wallbox only accepts 2 concurrent Modbus TCP sessions (1× SEMS cloud, 1× client). If the cloud is active, evcc competes for the second slot.
       Note: Implementation is derived from the Home Assistant integration (gen2-modbus branch) and is not vendor-verified.
 params:
   - name: modbus


### PR DESCRIPTION
## Summary

Draft charger driver for the GoodWe AC EV Charger Gen2 (e.g. **GW11K-HCA**) via Modbus TCP, requested in discussion #13970.

Implements the full `api.Charger` surface plus optional capabilities:
- `Status`, `Enable`/`Enabled`, `MaxCurrent`
- `api.ChargerEx` — `MaxCurrentMillis` (current → power conversion via `230 V × phases × current`, clamped to **[1400 W, hardware max]**; rejects currents below 6 A)
- `api.Meter` / `api.MeterEnergy`
- `api.PhaseCurrents`, `api.PhaseVoltages`
- `api.PhaseSwitcher` / `api.PhaseGetter` — **dynamically registered** at startup via `implement.Caps` only when register 10023 (phase-switch enabled) = 1
- `api.Identifier` — RFID UID (14-byte ASCII, NUL-padded, from reg 10050)
- `loadpoint.Controller` (`LoadpointControl`)

The constructor reads hardware capabilities from three registers before registering capabilities:
- **10058** (`goodweRegPowerSpec`): hardware power class (0=7 kW, 1=11 kW, 2=22 kW) — used to clamp the power setpoint
- **10059** (`goodweRegPhaseSpec`): hardware phase count (0=1-phase, 1=3-phase) — initialises `phases`
- **10023** (`goodweRegPhaseSwEnabled`): whether 1p/3p switching is available on this unit — `PhaseSwitcher`/`PhaseGetter` are only registered via `implement.Caps` when this is 1

The constructor also forces `charging_mode = fast` (register 10032 = 0) so evcc fully owns the PV-surplus logic — the discussion notes that the wallbox's internal PV mode still draws from the grid when insufficient PV is available.

Status mapping (register 10017): `0` → A (idle, no plug); `1,2,4,6,10` → B (plugged/handshaking/completed/scheduled/interrupted); `3` → C (charging).

### Open question: current → power conversion

The Modbus interface exposes only a **total power setpoint** (`goodweRegMaxPower`, reg 10029, 0.1 kW), but evcc controls current per phase. The driver currently scales with `230 V × phases × current`. It is **unclear from the protocol documentation** whether the wallbox internally converts that power setpoint back into a per-phase current limit using a fixed nominal voltage (e.g. 230 V) or using its own live voltage measurement. Depending on which assumption the firmware uses, the actually delivered current may deviate from the requested target — this needs to be verified on hardware.

## Template

`templates/definition/charger/goodwe-wallbox.yaml` advertises capabilities `mA`, `rfid`, `1p3p`, `meter` and defaults Modbus to device ID 247 / port 502.

## Protocol source

Register map and write semantics were derived from the Home Assistant integration on the [`gen2-modbus` branch](https://github.com/pedrodivisez/goodwe-wallbox-sems-home-assistant/tree/gen2-modbus) (`wallbox_modbus.py`), which documents itself as "AC EV Charger 2nd Gen Modbus Protocol v1.0.15".

## ⚠️ Not vendor-verified

This implementation has **not** been validated on physical hardware. Marked as draft pending a hardware test by someone with the device. The discussion author may be willing to test.

Connection prerequisites (also captured in the template description):
- Modbus TCP enabled in SolarGo (Communication → Wallbox)
- Default device ID **247** (0xF7), port **502**
- The wallbox only accepts 2 concurrent TCP sessions (1 cloud, 1 client) — if SEMS cloud is active, evcc may compete for the second slot

## Test plan
- [x] `go build ./...`
- [x] `go test ./charger/`
- [x] `go vet ./charger/`
- [x] `gofmt -l charger/goodwe.go`
- [ ] Live test against GW11K-HCA hardware
- [ ] Verify whether internal current limit derives from nominal or measured voltage