### PR TITLE
OCPP: dispatch RemoteStartTransaction asynchronously to avoid WebSocket deadlock

### DIFF
--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -39,7 +39,15 @@ func (conn *Connector) OnStatusNotification(request *core.StatusNotificationRequ
 
 	if conn.isWaitingForAuth() {
 		if conn.remoteIdTag != "" {
-			conn.RemoteStartTransactionRequest(conn.remoteIdTag)
+			// dispatch asynchronously: RemoteStartTransactionRequest issues a
+			// synchronous CS→CP request whose response is read by this same
+			// goroutine, so a blocking call would deadlock the WebSocket read
+			// loop (cf. ocpp_test_handler.go).
+			go func(idTag string) {
+				if err := conn.RemoteStartTransactionRequest(idTag); err != nil {
+					conn.log.ERROR.Printf("RemoteStartTransaction: %v", err)
+				}
+			}(conn.remoteIdTag)
 		} else {
 			conn.log.DEBUG.Printf("waiting for local authentication")
 		}


### PR DESCRIPTION
## Background

PR #28460 fixed a flaky `TestOcpp` deadlock by changing two **test-side** OCPP handlers (`OnChangeAvailability`, `OnTriggerMessage` in `charger/ocpp_test_handler.go`) from a blocking \`defer\` channel send to \`go func() { ... }()\` — the reasoning being that those handlers issue a synchronous CP→CS request whose response is read by the same WebSocket-reader goroutine, so a blocking call deadlocks the reader.

The same shape exists in **production** code: \`OnStatusNotification\` (\`charger/ocpp/connector_core.go:42\`) calls \`RemoteStartTransactionRequest\` synchronously, while still holding \`conn.mu\`, from within the same WebSocket reader goroutine. \`RemoteStartTransactionRequest\` waits on a response that has to come back on the very goroutine it just blocked.

Under amd64 CI this rarely surfaces; on arm64 runners with less CPU headroom it produces the cascade seen in [job 75358958105](https://github.com/evcc-io/evcc/actions/runs/25671862356/job/75358958105):

```
--- FAIL: TestOcpp (10.01s)
    disconnected from server websocket: close 1006 (abnormal closure)
    --- FAIL: TestOcpp/TestAutoStart (10.00s) — NewOCPP timed out
    --- FAIL: TestOcpp/TestConnect (0.00s)    — dial :8887 connection refused
    --- FAIL: TestOcpp/TestTimeout (0.00s)    — dial :8887 connection refused
```

## Fix

Apply the same async-dispatch pattern PR #28460 used on the test handlers, to this production handler:

\`\`\`go
go func(idTag string) {
    if err := conn.RemoteStartTransactionRequest(idTag); err != nil {
        conn.log.ERROR.Printf(\"RemoteStartTransaction: %v\", err)
    }
}(conn.remoteIdTag)
\`\`\`

The handler returns immediately, the reader keeps draining the websocket, and the synchronous CS→CP roundtrip happens on its own goroutine. The caller already discarded the error; we now surface it as a log line instead.

## Verification

- \`go vet ./charger/...\` clean
- \`go build ./...\` clean
- \`go test ./charger/ -run TestOcpp -count=1 -timeout 120s\` — passes (~26 s)
- Behaviour change: \`RemoteStartTransaction\` errors that happen as a side-effect of \`OnStatusNotification\` are now logged instead of swallowed silently. No call site checked the return value, so no caller changes are needed.

DRAFT — would appreciate a sanity check from someone familiar with the OCPP timing semantics on whether firing-and-forgetting the RemoteStartTransaction here is acceptable (I believe it is, since the only effect of the prior synchronous wait was to block the reader; nothing downstream depended on completion).