### PR TITLE
Huawei EMMA: fix phase currents

### DIFF
--- a/templates/definition/meter/huawei-emma.yaml
+++ b/templates/definition/meter/huawei-emma.yaml
@@ -54,6 +54,31 @@ render: |
       type: holding
       decode: int32
     scale: 0.1
+  voltages:
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31639 # Huawei phase A grid voltage
+      type: holding
+      decode: uint32
+    scale: 0.01
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31641 # Huawei phase B grid voltage
+      type: holding
+      decode: uint32
+    scale: 0.01
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31643 # Huawei phase C grid voltage
+      type: holding
+      decode: uint32
+    scale: 0.01
   powers:
   - source: modbus
     id: 0

--- a/templates/definition/meter/huawei-emma.yaml
+++ b/templates/definition/meter/huawei-emma.yaml
@@ -30,63 +30,52 @@ render: |
       decode: int64
     scale: 0.01
   currents:
-  - source: calc
-    mul:
-      - source: modbus
-        id: 0
-        uri: {{ joinHostPort .host .port }}
-        register:
-          address: 31651 # Huawei phase A grid current
-          type: holding
-          decode: int32
-        scale: 0.1
-      - source: calc
-        sign:
-          - source: modbus
-            id: 0
-            uri: {{ joinHostPort .host .port }}
-            register:
-              address: 31665 # Huawei phase A grid power
-              type: holding
-              decode: int32
-  - source: calc
-    mul:
-      - source: modbus
-        id: 0
-        uri: {{ joinHostPort .host .port }}
-        register:
-          address: 31653 # Huawei phase B grid current
-          type: holding
-          decode: int32
-        scale: 0.1
-      - source: calc
-        sign:
-          - source: modbus
-            id: 0
-            uri: {{ joinHostPort .host .port }}
-            register:
-              address: 31667 # Huawei phase B grid power
-              type: holding
-              decode: int32
-  - source: calc
-    mul:
-      - source: modbus
-        id: 0
-        uri: {{ joinHostPort .host .port }}
-        register:
-          address: 31655 # Huawei phase C grid current
-          type: holding
-          decode: int32
-        scale: 0.1
-      - source: calc
-        sign:
-          - source: modbus
-            id: 0
-            uri: {{ joinHostPort .host .port }}
-            register:
-              address: 31669 # Huawei phase C grid power
-              type: holding
-              decode: int32
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31651 # Huawei phase A grid current
+      type: holding
+      decode: int32
+    scale: 0.1
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31653 # Huawei phase B grid current
+      type: holding
+      decode: int32
+    scale: 0.1
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31655 # Huawei phase C grid current
+      type: holding
+      decode: int32
+    scale: 0.1
+  powers:
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31665 # Huawei phase A grid power
+      type: holding
+      decode: int32
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31667 # Huawei phase B grid power
+      type: holding
+      decode: int32
+  - source: modbus
+    id: 0
+    uri: {{ joinHostPort .host .port }}
+    register:
+      address: 31669 # Huawei phase C grid power
+      type: holding
+      decode: int32
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/huawei-emma.yaml
+++ b/templates/definition/meter/huawei-emma.yaml
@@ -30,30 +30,63 @@ render: |
       decode: int64
     scale: 0.01
   currents:
-  - source: modbus
-    id: 0
-    uri: {{ joinHostPort .host .port }}
-    register:
-      address: 31651 # Huawei phase A grid current
-      type: holding
-      decode: int32
-    scale: 0.1
-  - source: modbus
-    id: 0
-    uri: {{ joinHostPort .host .port }}
-    register:
-      address: 31653 # Huawei phase B grid current
-      type: holding
-      decode: int32
-    scale: 0.1
-  - source: modbus
-    id: 0
-    uri: {{ joinHostPort .host .port }}
-    register:
-      address: 31655 # Huawei phase C grid current
-      type: holding
-      decode: int32
-    scale: 0.1
+  - source: calc
+    mul:
+      - source: modbus
+        id: 0
+        uri: {{ joinHostPort .host .port }}
+        register:
+          address: 31651 # Huawei phase A grid current
+          type: holding
+          decode: int32
+        scale: 0.1
+      - source: calc
+        sign:
+          - source: modbus
+            id: 0
+            uri: {{ joinHostPort .host .port }}
+            register:
+              address: 31665 # Huawei phase A grid power
+              type: holding
+              decode: int32
+  - source: calc
+    mul:
+      - source: modbus
+        id: 0
+        uri: {{ joinHostPort .host .port }}
+        register:
+          address: 31653 # Huawei phase B grid current
+          type: holding
+          decode: int32
+        scale: 0.1
+      - source: calc
+        sign:
+          - source: modbus
+            id: 0
+            uri: {{ joinHostPort .host .port }}
+            register:
+              address: 31667 # Huawei phase B grid power
+              type: holding
+              decode: int32
+  - source: calc
+    mul:
+      - source: modbus
+        id: 0
+        uri: {{ joinHostPort .host .port }}
+        register:
+          address: 31655 # Huawei phase C grid current
+          type: holding
+          decode: int32
+        scale: 0.1
+      - source: calc
+        sign:
+          - source: modbus
+            id: 0
+            uri: {{ joinHostPort .host .port }}
+            register:
+              address: 31669 # Huawei phase C grid power
+              type: holding
+              decode: int32
   {{- end }}
   {{- if eq .usage "pv" }}
   power:


### PR DESCRIPTION
Added voltages and powers to the Huawei EMMA template. The currents were always positiv and therefore the loadmanagement wasn't working properly.
See Lastmanagement limitiert mit Huawei EMMA trotz Überschuss #29821