### PR TITLE
OCPP: don't treat SuspendedEVSE as disabled when schedule limit is set

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -256,9 +256,6 @@ func (c *OCPP) Enabled() (bool, error) {
 	if s, err := c.conn.Status(); err == nil {
 		switch s {
 		case
-			core.ChargePointStatusSuspendedEVSE:
-			return false, nil
-		case
 			core.ChargePointStatusCharging,
 			core.ChargePointStatusSuspendedEV:
 			return true, nil


### PR DESCRIPTION
Some chargers (e.g. Easee in OCPP mode) remain in SuspendedEVSE for several minutes after being enabled at minimum current before actually starting to charge. The hard-coded return false for SuspendedEVSE caused the loadpoint to detect a false "out of sync" after the 60s grace period, flipping the charger state to disabled.

Remove the SuspendedEVSE short-circuit so Enabled() falls through to the schedule limit / offered measurand checks, which correctly distinguish "limit 0 = truly disabled" from "limit > 0 = enabled but waiting for EV".