### PR TITLE
Add DSMR API v2 support (Ethernet P1 Dongle Pro+)

### DIFF
--- a/templates/definition/meter/dsmrlogger-aandewiel.yaml
+++ b/templates/definition/meter/dsmrlogger-aandewiel.yaml
@@ -22,8 +22,8 @@ params:
         de: API Version
         en: API version
     help:
-        de: "API v1 für DSMR-logger API v1, API v2 für DSMR-logger API v2 (smarstuff P1 Dongle mit DSMR-logger API v2)"
-        en: "Use API v1 for DSMR-logger API v1, use API v2 for DSMR-logger API v2 (smarstuff P1 Dongle with DSMR-logger API v2)"
+        de: "API v1 für DSMR-logger API v1, API v2 für DSMR-logger API v2 (Smartstuff P1 Dongle mit DSMR-logger API v2)"
+        en: "Use API v1 for DSMR-logger API v1, use API v2 for DSMR-logger API v2 (Smartstuff P1 Dongle with DSMR-logger API v2)"
 render: |
   {{- define "uri" -}}
   http://{{ .host }}/api/{{ .apiversion }}/sm/actual

--- a/templates/definition/meter/dsmrlogger-aandewiel.yaml
+++ b/templates/definition/meter/dsmrlogger-aandewiel.yaml
@@ -3,6 +3,9 @@ products:
   - brand: Aandewiel
     description:
       generic: DSMR-logger API
+  - brand: Smartstuff DSMR-logger API
+    description:
+      generic: P1 Dongle with DSMR-logger API
 requirements:
   description:
     generic: "[DSMR-logger](https://github.com/mrWheel/DSMRloggerAPI) by Willem Aandewiel, REST-API version"
@@ -10,9 +13,20 @@ params:
   - name: usage
     choice: ["grid"]
   - name: host
+  - name: apiversion
+    choice: ["v1", "v2"]
+    default: "v1"
+    required: true
+    advanced: true
+    description:
+        de: API Version
+        en: API version
+    help:
+        de: "API v1 für DSMR-logger API v1, API v2 für DSMR-logger API v2 (smarstuff P1 Dongle mit DSMR-logger API v2)"
+        en: "Use API v1 for DSMR-logger API v1, use API v2 for DSMR-logger API v2 (smarstuff P1 Dongle with DSMR-logger API v2)"
 render: |
   {{- define "uri" -}}
-  http://{{ .host }}/api/v1/sm/actual
+  http://{{ .host }}/api/{{ .apiversion }}/sm/actual
   {{- end }}
   type: custom
   power:

--- a/templates/definition/meter/dsmrlogger-aandewiel.yaml
+++ b/templates/definition/meter/dsmrlogger-aandewiel.yaml
@@ -19,11 +19,11 @@ params:
     required: true
     advanced: true
     description:
-        de: API Version
-        en: API version
+      de: API Version
+      en: API version
     help:
-        de: "API v1 für DSMR-logger API v1, API v2 für DSMR-logger API v2 (Smartstuff P1 Dongle mit DSMR-logger API v2)"
-        en: "Use API v1 for DSMR-logger API v1, use API v2 for DSMR-logger API v2 (Smartstuff P1 Dongle with DSMR-logger API v2)"
+      de: "API v1 für DSMR-logger API v1, API v2 für DSMR-logger API v2 (Smartstuff P1 Dongle mit DSMR-logger API v2)"
+      en: "Use API v1 for DSMR-logger API v1, use API v2 for DSMR-logger API v2 (Smartstuff P1 Dongle with DSMR-logger API v2)"
 render: |
   {{- define "uri" -}}
   http://{{ .host }}/api/{{ .apiversion }}/sm/actual


### PR DESCRIPTION
This PR adds compatibility for DSMR API v2 endpoints used by Smartstuff Ethernet P1 Dongle Pro+ devices.

### Documentations

- https://docs.smart-stuff.nl/dsmr-api/geavanceerd/api-overzicht

### Suggested change

- Extend the dsmrlogger-aandewiel template to allow selecting the DSMR API version
- Add a new optional configuration parameter: apiversion
- Default to existing behavior (v1) for backward compatibility
- Use the selected version to build endpoint URLs dynamically