### PR TITLE
OCPP: clean up charge point lifecycle between subtests

### DIFF
--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -54,9 +54,11 @@ func (suite *ocppTestSuite) TearDownSuite() {
 }
 
 func (suite *ocppTestSuite) startChargePoint(id string, connectorId int) (ocpp16.ChargePoint, *ocppj.Client) {
-	// set a handler for all callback functions
+	// Buffered generously: handlers in ocpp_test_handler.go dispatch sends via
+	// `go func() { triggerC <- … }()`, so a small buffer leaks one extra
+	// goroutine per concurrent trigger until the drain catches up.
 	handler := &ChargePointHandler{
-		triggerC: make(chan remotetrigger.MessageTrigger, 1),
+		triggerC: make(chan remotetrigger.MessageTrigger, 16),
 	}
 
 	// ocppj endpoint with handler
@@ -71,12 +73,28 @@ func (suite *ocppTestSuite) startChargePoint(id string, connectorId int) (ocpp16
 	cp.SetRemoteTriggerHandler(handler)
 	cp.SetSmartChargingHandler(handler)
 
-	// let cs handle the trigger messages
+	// let cs handle the trigger messages; exit on done so we do not leak a
+	// drain goroutine into subsequent subtests on the shared ocpp.Instance().
+	// Cannot close triggerC because the async senders in ocpp_test_handler.go
+	// would panic on `send on closed channel`.
+	done := make(chan struct{})
 	go func() {
-		for msg := range handler.triggerC {
-			suite.handleTrigger(cp, connectorId, msg)
+		for {
+			select {
+			case <-done:
+				return
+			case msg := <-handler.triggerC:
+				suite.handleTrigger(cp, connectorId, msg)
+			}
 		}
 	}()
+
+	suite.T().Cleanup(func() {
+		if cp.IsConnected() {
+			cp.Stop()
+		}
+		close(done)
+	})
 
 	return cp, endpoint
 }


### PR DESCRIPTION
## Summary

The OCPP test suite shares a singleton CS server across subtests via `ocpp.Instance()`, and the drain goroutine started in `startChargePoint` for `handler.triggerC` was never stopped — every call leaked one goroutine for the lifetime of the test process. The `triggerC` channel was also only `make(chan …, 1)`, so concurrent handler invocations spawned extra sender goroutines that piled up under CI CPU pressure.

This is the structural race that previous OCPP test/test-adjacent fixes did **not** address:

- 7a24dbd3f (#29725) — `OCPP: fix flaky test deadlock between trigger handler and WS read loop` — switched `defer triggerC <- …` to `go func() { triggerC <- … }()` so handlers no longer block the WS read loop.
- e07838bb8 (#29838) — `OCPP: dispatch RemoteStartTransaction asynchronously to avoid WebSocket deadlock` — fixed a related deadlock in `OnStatusNotification` → `RemoteStartTransactionRequest`.

Both removed specific blocking sends inside handlers, but the leaked drain goroutines and the capacity-1 buffer remained — visible as the intermittent `TestOcpp/TestAutoStart` 10s timeout (followed by `connection refused` on `TestConnect`/`TestTimeout`) seen on otherwise unrelated PRs (e.g. #29861, plus recent Solax / Huawei EMMA branches).

This PR:

- Increases `triggerC` buffer from 1 to 16 — handlers dispatch via `go func() { triggerC <- … }()`, so a tight buffer just multiplies blocked-sender goroutines.
- Registers a `t.Cleanup` per `startChargePoint` that calls `cp.Stop()` (if still connected) and signals the drain goroutine to exit via a `done` channel.
- Uses a `done` channel rather than `close(triggerC)`, because the handler senders would otherwise panic with `send on closed channel`.

## Test plan

- [x] `go build ./charger/...`
- [x] `go vet ./charger/`
- [x] `go test -run TestOcpp -count=1 -timeout 60s ./charger/` — 5 separate invocations, all pass (~26 s each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)