### PR TITLE
Vaillant: add brand support for Saunier Duval, Bulex, Glow-worm, DemirDöküm

### DIFF
--- a/templates/definition/charger/vaillant-bulex.yaml
+++ b/templates/definition/charger/vaillant-bulex.yaml
@@ -1,0 +1,41 @@
+template: vaillant-bulex
+products:
+  - brand: Bulex
+    description:
+      generic: MiGo Link (API)
+group: heating
+requirements:
+  # evcc: ["sponsorship"]
+  description:
+    de: Die Boost Funktion erwärmt Warmwasser oder eine Boostzone. Die Boostzone wird durch die ID identifiziert. Die Boost Temperatur wird in Grad Celsius angegeben. Ist eine Boost Temperatur angegeben, wird die Boostzone aktiviert, anderenfalls Warmwasser.
+    en: The boost function heats hot water or a boost zone. The boost zone is identified by the ID. The boost temperature is specified in degrees Celsius. If boost temperature is specified, the boost zone is activated, otherwise hot water.
+params:
+  - name: user
+  - name: password
+  - name: zone
+    type: int
+    description:
+      de: ID der Boostzone
+      en: Boost zone ID
+  - name: setpoint
+    type: float
+    description:
+      de: Boost Temperatur
+      en: Boost temperature
+  - name: system
+    description:
+      de: Name der Anlage
+      en: Name of the system
+    help:
+      de: Notwendig falls mehrere Anlagen im Account vorhanden sind
+      en: Required if multiple systems are present in the account
+render: |
+  type: vaillant
+  user: {{ .user }}
+  password: {{ .password }}
+  realm: bulex-b2c
+  {{- if .system }}
+  system: {{ .system }}
+  {{- end }}
+  heatingzone: {{ .zone }}
+  heatingsetpoint: {{ .setpoint }}

--- a/templates/definition/charger/vaillant-demirdokum.yaml
+++ b/templates/definition/charger/vaillant-demirdokum.yaml
@@ -1,0 +1,41 @@
+template: vaillant-demirdokum
+products:
+  - brand: DemirDöküm
+    description:
+      generic: MyDemirDokum (API)
+group: heating
+requirements:
+  # evcc: ["sponsorship"]
+  description:
+    de: Die Boost Funktion erwärmt Warmwasser oder eine Boostzone. Die Boostzone wird durch die ID identifiziert. Die Boost Temperatur wird in Grad Celsius angegeben. Ist eine Boost Temperatur angegeben, wird die Boostzone aktiviert, anderenfalls Warmwasser.
+    en: The boost function heats hot water or a boost zone. The boost zone is identified by the ID. The boost temperature is specified in degrees Celsius. If boost temperature is specified, the boost zone is activated, otherwise hot water.
+params:
+  - name: user
+  - name: password
+  - name: zone
+    type: int
+    description:
+      de: ID der Boostzone
+      en: Boost zone ID
+  - name: setpoint
+    type: float
+    description:
+      de: Boost Temperatur
+      en: Boost temperature
+  - name: system
+    description:
+      de: Name der Anlage
+      en: Name of the system
+    help:
+      de: Notwendig falls mehrere Anlagen im Account vorhanden sind
+      en: Required if multiple systems are present in the account
+render: |
+  type: vaillant
+  user: {{ .user }}
+  password: {{ .password }}
+  realm: demirdokum-b2c
+  {{- if .system }}
+  system: {{ .system }}
+  {{- end }}
+  heatingzone: {{ .zone }}
+  heatingsetpoint: {{ .setpoint }}

--- a/templates/definition/charger/vaillant-glow-worm.yaml
+++ b/templates/definition/charger/vaillant-glow-worm.yaml
@@ -1,0 +1,41 @@
+template: vaillant-glow-worm
+products:
+  - brand: Glow-worm
+    description:
+      generic: MiGo Link (API)
+group: heating
+requirements:
+  # evcc: ["sponsorship"]
+  description:
+    de: Die Boost Funktion erwärmt Warmwasser oder eine Boostzone. Die Boostzone wird durch die ID identifiziert. Die Boost Temperatur wird in Grad Celsius angegeben. Ist eine Boost Temperatur angegeben, wird die Boostzone aktiviert, anderenfalls Warmwasser.
+    en: The boost function heats hot water or a boost zone. The boost zone is identified by the ID. The boost temperature is specified in degrees Celsius. If boost temperature is specified, the boost zone is activated, otherwise hot water.
+params:
+  - name: user
+  - name: password
+  - name: zone
+    type: int
+    description:
+      de: ID der Boostzone
+      en: Boost zone ID
+  - name: setpoint
+    type: float
+    description:
+      de: Boost Temperatur
+      en: Boost temperature
+  - name: system
+    description:
+      de: Name der Anlage
+      en: Name of the system
+    help:
+      de: Notwendig falls mehrere Anlagen im Account vorhanden sind
+      en: Required if multiple systems are present in the account
+render: |
+  type: vaillant
+  user: {{ .user }}
+  password: {{ .password }}
+  realm: glow-worm-b2c
+  {{- if .system }}
+  system: {{ .system }}
+  {{- end }}
+  heatingzone: {{ .zone }}
+  heatingsetpoint: {{ .setpoint }}

--- a/templates/definition/charger/vaillant-saunier-duval.yaml
+++ b/templates/definition/charger/vaillant-saunier-duval.yaml
@@ -1,0 +1,64 @@
+template: vaillant-saunier-duval
+products:
+  - brand: Saunier Duval
+    description:
+      generic: MiGo Link (API)
+group: heating
+requirements:
+  # evcc: ["sponsorship"]
+  description:
+    de: Die Boost Funktion erwärmt Warmwasser oder eine Boostzone. Die Boostzone wird durch die ID identifiziert. Die Boost Temperatur wird in Grad Celsius angegeben. Ist eine Boost Temperatur angegeben, wird die Boostzone aktiviert, anderenfalls Warmwasser.
+    en: The boost function heats hot water or a boost zone. The boost zone is identified by the ID. The boost temperature is specified in degrees Celsius. If boost temperature is specified, the boost zone is activated, otherwise hot water.
+params:
+  - name: user
+  - name: password
+  - name: realm
+    type: choice
+    choice:
+      [
+        "austria",
+        "czechrepublic",
+        "finland",
+        "france",
+        "greece",
+        "hungary",
+        "italy",
+        "lithuania",
+        "luxembourg",
+        "poland",
+        "portugal",
+        "romania",
+        "slovakia",
+        "spain",
+      ]
+    default: france
+    description:
+      de: Region
+      en: Region
+  - name: zone
+    type: int
+    description:
+      de: ID der Boostzone
+      en: Boost zone ID
+  - name: setpoint
+    type: float
+    description:
+      de: Boost Temperatur
+      en: Boost temperature
+  - name: system
+    description:
+      de: Name der Anlage
+      en: Name of the system
+    help:
+      de: Notwendig falls mehrere Anlagen im Account vorhanden sind
+      en: Required if multiple systems are present in the account
+render: |
+  type: vaillant
+  user: {{ .user }}
+  password: {{ .password }}
+  realm: sdbg-{{ .realm }}-b2c
+  {{- if .system }}
+  system: {{ .system }}
+  {{- end }}
+  heatingzone: {{ .zone }}
+  heatingsetpoint: {{ .setpoint }}


### PR DESCRIPTION
## Summary

All Vaillant Group brands share the same `identity.vaillant-group.com` Keycloak server, OAuth client (`myvaillant`), redirect URI (`enduservaillant.page.link://login`) and `api.vaillant-group.com/service-connected-control/end-user-app-api/v1` backend — only the Keycloak realm differs:

| Brand        | Realm                       | Countries |
|--------------|-----------------------------|-----------|
| Vaillant     | `vaillant-{country}-b2c`    | 39 (full list, unchanged) |
| Saunier Duval (`sdbg`, MiGo Link app) | `sdbg-{country}-b2c` | 14: austria, czechrepublic, finland, france, greece, hungary, italy, lithuania, luxembourg, poland, portugal, romania, slovakia, spain |
| Bulex        | `bulex-b2c`                 | — (no per-country realm) |
| Glow-worm    | `glow-worm-b2c`             | — |
| DemirDöküm   | `demirdokum-b2c`            | — |

Source: [`signalkraft/mypyllant-component`](https://github.com/signalkraft/mypyllant-component) → `myPyllant` Python lib (`const.py`, `utils.get_realm`).

Since `WulfgarW/sensonet@v0.0.7`'s `Oauth2ConfigForRealm(realm)` accepts any realm string and the Go side just passes it through, this is a **template-only** change.

Each brand gets its own template file (all rendering `type: vaillant`):

- `vaillant.yaml` — unchanged params, legacy `DE`/`AT` shortcuts preserved for backward compat.
- `vaillant-saunier-duval.yaml` — country dropdown limited to the 14 SDBG realms.
- `vaillant-bulex.yaml`, `vaillant-glow-worm.yaml`, `vaillant-demirdokum.yaml` — no country dropdown (those realms have no country segment).

## Related

May address #29844 — Belgian user gets `could not get code` against `vaillant-belgium-b2c`. Bulex historically is the Vaillant Group brand for BeNeLux; if their account was created via the MiGo / Bulex app, the correct realm is `bulex-b2c`, not `vaillant-belgium-b2c`. The new Bulex product exposes that path.

## Test plan

- [x] `go test ./util/templates/...`
- [ ] Render each brand in the UI; verify the resulting `realm:` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)