### PR TITLE
OAuth: expose full upstream error

### DIFF
--- a/assets/js/components/Config/AuthSuccessBanner.vue
+++ b/assets/js/components/Config/AuthSuccessBanner.vue
@@ -8,7 +8,7 @@
 		<p v-if="isError">
 			<strong>{{ $t("authProviders.authorizationFailed") }}</strong
 			><br />
-			{{ errorMessage }}
+			<code class="user-select-all">{{ errorMessage }}</code>
 		</p>
 		<p v-else>
 			<strong>{{ $t("authProviders.authorizationSuccessful") }}</strong

--- a/server/providerauth/handler.go
+++ b/server/providerauth/handler.go
@@ -194,7 +194,7 @@ func (a *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	// Handle the callback
 	if err := provider.HandleCallback(r.URL.Query()); err != nil {
 		a.log.ERROR.Printf("callback for provider %s failed: %v", id, err)
-		a.redirectToError(w, r, "callback failed")
+		a.redirectToError(w, r, err.Error())
 		return
 	}
 


### PR DESCRIPTION
## Summary

Fixes #29870.

When `provider.HandleCallback()` fails (e.g. during the token exchange POST), `server/providerauth/handler.go` logged the real OAuth error but redirected the UI with a fixed `"callback failed"` string. The error banner therefore showed something useless to the user even though the log had the actionable text — e.g.:

```
oauth2: "invalid_client" "Invalid client or client credentials."
```

This PR:

- **`server/providerauth/handler.go:197`** — pass `err.Error()` to `redirectToError`, mirroring the existing branch at L162-164 that already surfaces provider-side `?error=…` query params.
- **`assets/js/components/Config/AuthSuccessBanner.vue`** — wrap the message in `<code class="user-select-all">` so structured errors are legible and one-click copyable.

The error is still logged at ERROR level so the existing operator-side diagnostics are unchanged.

## Test plan

- [x] `go build ./server/providerauth/...`, `go vet ./server/providerauth/...`
- [ ] Trigger an OAuth callback failure (wrong `clientID`/`clientSecret`) and confirm the banner now shows the upstream `oauth2: …` message
- [ ] Confirm the success-callback path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)