### PR TITLE
Revert "Add DSMR API v2 support (Ethernet P1 Dongle Pro+) (#29871)"

### DIFF
--- a/templates/definition/meter/dsmrlogger-aandewiel.yaml
+++ b/templates/definition/meter/dsmrlogger-aandewiel.yaml
@@ -3,9 +3,6 @@ products:
   - brand: Aandewiel
     description:
       generic: DSMR-logger API
-  - brand: Smartstuff DSMR-logger API
-    description:
-      generic: P1 Dongle with DSMR-logger API
 requirements:
   description:
     generic: "[DSMR-logger](https://github.com/mrWheel/DSMRloggerAPI) by Willem Aandewiel, REST-API version"
@@ -13,20 +10,9 @@ params:
   - name: usage
     choice: ["grid"]
   - name: host
-  - name: apiversion
-    choice: ["v1", "v2"]
-    default: "v1"
-    required: true
-    advanced: true
-    description:
-      de: API Version
-      en: API version
-    help:
-      de: "API v1 für DSMR-logger API v1, API v2 für DSMR-logger API v2 (Smartstuff P1 Dongle mit DSMR-logger API v2)"
-      en: "Use API v1 for DSMR-logger API v1, use API v2 for DSMR-logger API v2 (Smartstuff P1 Dongle with DSMR-logger API v2)"
 render: |
   {{- define "uri" -}}
-  http://{{ .host }}/api/{{ .apiversion }}/sm/actual
+  http://{{ .host }}/api/v1/sm/actual
   {{- end }}
   type: custom
   power:

--- a/templates/definition/meter/smartstuff-dsmr.yaml
+++ b/templates/definition/meter/smartstuff-dsmr.yaml
@@ -1,8 +1,8 @@
 template: dsmrlogger-v2
 products:
-  - brand: Smartstuff DSMR-API
+  - brand: Smartstuff
     description:
-      generic: P1 Dongle
+      generic: DSMR P1 Dongle
 requirements:
   description:
     generic: "[Smartstuff API](https://docs.smart-stuff.nl/dsmr-api/geavanceerd/api-overzicht) REST-API version"

--- a/templates/definition/meter/smartstuff-dsmr.yaml
+++ b/templates/definition/meter/smartstuff-dsmr.yaml
@@ -1,0 +1,82 @@
+template: dsmrlogger-v2
+products:
+  - brand: Smartstuff DSMR-API
+    description:
+      generic: P1 Dongle
+requirements:
+  description:
+    generic: "[Smartstuff API](https://docs.smart-stuff.nl/dsmr-api/geavanceerd/api-overzicht) REST-API version"
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: host
+render: |
+  {{- define "uri" -}}
+  http://{{ .host }}/api/v2/sm/actual
+  {{- end }}
+  type: custom
+  power:
+    source: http
+    uri: {{ include "uri" . }}
+    headers:
+      - content-type: application/json
+    jq: >
+      ((.power_delivered | .value // 0) * 1000)
+      - ((.power_returned | .value // 0) * 1000)
+
+  voltages: # phase voltages in V
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: .voltage_l1 | .value
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: .voltage_l2 | .value
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: .voltage_l3 | .value
+
+  currents: # phase currents in A
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: .current_l1 | .value
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: .current_l2 | .value
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: .current_l3 | .value
+
+  powers:
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: >
+        ((.power_delivered_l1 | .value) * 1000)
+        - ((.power_returned_l1 | .value) * 1000)
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: >
+        ((.power_delivered_l2 | .value) * 1000)
+        - ((.power_returned_l2 | .value) * 1000)
+    - source: http
+      uri: {{ include "uri" . }}
+      headers:
+        - content-type: application/json
+      jq: >
+        ((.power_delivered_l3 | .value) * 1000)
+        - ((.power_returned_l3 | .value) * 1000)


### PR DESCRIPTION
This reverts commit 726bea60760cff9889cb30341fc4561082f4dd4f.

After deeper testing, I discovered the API changed too much to use v1 as the template of v2 api. 

Adding a new template to support DSMR API v2