### PR TITLE
Energyflow UI: names instead of placeholders

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -99,7 +99,7 @@
 								<EnergyflowEntry
 									v-for="(p, index) in pv"
 									:key="index"
-									:name="p.title || genericPvTitle(index)"
+									:name="p.title || p.name"
 									:power="p.power"
 									:powerUnit="powerUnit"
 									:data-testid="`energyflow-entry-production-${index}`"
@@ -150,7 +150,7 @@
 									<EnergyflowEntry
 										v-for="(b, index) in batteryDevices"
 										:key="index"
-										:name="b.title || genericBatteryTitle(index)"
+										:name="b.title || b.name"
 										:details="b.soc"
 										:detailsFmt="batteryFmt"
 										:power="dischargePower(b.power)"
@@ -201,7 +201,7 @@
 									<EnergyflowEntry
 										v-for="(c, index) in consumers"
 										:key="index"
-										:name="c.title || genericConsumerTitle(index)"
+										:name="c.title || c.name"
 										:power="c.power"
 										:powerUnit="powerUnit"
 										icon="vehicle"
@@ -308,7 +308,7 @@
 									<EnergyflowEntry
 										v-for="(b, index) in batteryDevices"
 										:key="index"
-										:name="b.title || genericBatteryTitle(index)"
+										:name="b.title || b.name"
 										:details="b.soc"
 										:detailsFmt="batteryFmt"
 										:power="chargePower(b.power)"
@@ -678,15 +678,6 @@ export default defineComponent({
 		toggleConsumers() {
 			settings.energyflowConsumers = !settings.energyflowConsumers;
 			this.$nextTick(this.updateHeight);
-		},
-		genericBatteryTitle(index: number) {
-			return `${this.$t("config.devices.batteryStorage")} #${index + 1}`;
-		},
-		genericPvTitle(index: number) {
-			return `${this.$t("config.devices.solarSystem")} #${index + 1}`;
-		},
-		genericConsumerTitle(index: number) {
-			return `${this.$t("config.devices.consumer")} #${index + 1}`;
 		},
 	},
 });


### PR DESCRIPTION
In https://github.com/evcc-io/evcc/pull/29846 we published the `name` field for all meters. This PR replaced the generic `
Solar system #1`, `Battery storage #1`, ... entries for yaml configured meters and shows `name` instead. Establishing consistent naming between energyflow and history chart labels.

before (yaml + ui)
<img width="688" height="309" alt="Bildschirmfoto 2026-05-15 um 21 18 14" src="https://github.com/user-attachments/assets/2cde270f-08cc-46ab-a7c3-32b38f07077f" />

after (yaml + ui)
<img width="739" height="413" alt="Bildschirmfoto 2026-05-15 um 21 26 07" src="https://github.com/user-attachments/assets/ebc2bc5f-29f5-4758-ad19-e6d2ca773360" />
