### PR TITLE
OCPP: fix flaky TestOcpp (restore wait() timeout) + speed up

### DIFF
--- a/charger/ocpp/const.go
+++ b/charger/ocpp/const.go
@@ -4,10 +4,11 @@ import "time"
 
 var Timeout = time.Minute // default request / response timeout on protocol level
 
-// triggerBootDelay defines how long to wait after WebSocket connect before
+// TriggerBootDelay defines how long to wait after WebSocket connect before
 // proactively triggering a BootNotification. This allows the connection to
 // stabilize and gives the charger a chance to send a spontaneous BootNotification.
-const triggerBootDelay = 5 * time.Second
+// It is a var so tests can shorten it.
+var TriggerBootDelay = 5 * time.Second
 
 const (
 	// Core profile keys

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -159,7 +159,7 @@ func (cp *CP) onTransportConnect() {
 	// This helps chargers that don't send it spontaneously (e.g. Wallbox FW 6.x).
 	// The TriggerMessage is sent directly via the OCPP instance, bypassing the
 	// Connected() check which would fail at this point.
-	time.AfterFunc(triggerBootDelay, func() {
+	time.AfterFunc(TriggerBootDelay, func() {
 		cp.mu.RLock()
 		// If BootNotification already arrived or timer was cancelled (disconnect),
 		// there is nothing to do.

--- a/charger/ocpp/helper.go
+++ b/charger/ocpp/helper.go
@@ -18,6 +18,14 @@ func wait(err error, rc chan error) error {
 		select {
 		case err = <-rc:
 			close(rc)
+		case <-time.After(Timeout):
+			// The ocpp-go dispatcher applies its own per-request timeout, but
+			// shares a single timeout context per client: a concurrent
+			// CALL_RESULT (e.g. the CP's BootNotification reply) cancels that
+			// context, leaving an in-flight request with no timeout at all.
+			// Bound the wait here as defense in depth. rc is buffered, so a
+			// late response is absorbed and garbage-collected.
+			err = api.ErrTimeout
 		}
 
 		if oe, ok := errors.AsType[*ocpp.Error](err); ok && oe.Code == ocppj.GenericError {

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -40,6 +40,10 @@ type ocppTestSuite struct {
 func (suite *ocppTestSuite) SetupSuite() {
 	ocpp.Timeout = 5 * time.Second
 
+	// the simulated charge points never send a spontaneous BootNotification,
+	// so shorten the proactive-trigger delay to avoid waiting 5s per charge point
+	ocpp.TriggerBootDelay = 100 * time.Millisecond
+
 	// setup cs so we can overwrite logger afterwards
 	_ = ocpp.Instance()
 	suite.logger = &ocppLogger{t: suite.T()}
@@ -78,7 +82,9 @@ func (suite *ocppTestSuite) startChargePoint(id string, connectorId int) (ocpp16
 	// Cannot close triggerC because the async senders in ocpp_test_handler.go
 	// would panic on `send on closed channel`.
 	done := make(chan struct{})
+	finished := make(chan struct{})
 	go func() {
+		defer close(finished)
 		for {
 			select {
 			case <-done:
@@ -94,6 +100,10 @@ func (suite *ocppTestSuite) startChargePoint(id string, connectorId int) (ocpp16
 			cp.Stop()
 		}
 		close(done)
+		// wait for the drain goroutine to fully exit before the test method
+		// returns: handleTrigger logs via suite.T(), which panics if called
+		// after the test has completed.
+		<-finished
 	})
 
 	return cp, endpoint


### PR DESCRIPTION
## Problem

`TestOcpp` is flaky in CI (e.g. PR #29923, unrelated `dadapower.go` change still fails the `Test` job):

```
--- FAIL: TestOcpp (10.01s)
    disconnected from server websocket: close 1006 (abnormal closure): unexpected EOF
    --- FAIL: TestOcpp/TestAutoStart (10.00s)
        ocpp_test.go: timeout
    --- FAIL: TestOcpp/TestConnect (0.00s)
    --- FAIL: TestOcpp/TestTimeout (0.00s)
```

## Root cause

`wait()` (`charger/ocpp/helper.go`) — the chokepoint for **every** synchronous CS→CP request — lost its own `time.After(Timeout)` case in #16100. It was left relying solely on the ocpp-go dispatcher's per-request timeout.

But the ocpp-go dispatcher shares a **single timeout context per client**: a concurrent `CALL_RESULT` (e.g. the CP's `BootNotification` reply) cancels that context via the `messagePump` `readyForDispatch` branch, leaving an in-flight request with **no timeout at all**. `cp.Setup()` issues `ChangeAvailabilityRequest` as its first call, exactly while the CP is still emitting startup traffic — so `wait()` blocks unbounded. That is the flaky hang.

Captured goroutine dump of the hang:
```
goroutine [chan receive]:
  ocpp.wait()                       helper.go:19   <-- blocked, no timeout
  ocpp.(*CP).ChangeAvailabilityRequest  cp_requests.go:24
  ocpp.(*CP).Setup                  cp_setup.go:17
  charger.NewOCPP.func2             ocpp.go:161
```

Prior fixes (`#29838` async RemoteStartTransaction, `#28460` logger/clock race, `#28540`/`#27309` boot handshake) all targeted goroutine scheduling — none restored the missing `wait()` timeout, so the flake survived every one.

## Changes

- **`helper.go`** — restore the `case <-time.After(Timeout)` safety net in `wait()`. `rc` is buffered, so a late response is absorbed and GC'd.
- **`ocpp_test.go`** — make `startChargePoint`'s trigger-drain goroutine fully exit before the test method returns. `handleTrigger` logs via `suite.T()`, which panics ("Log in goroutine after Test completed") if it runs after the test — a second, rarer flake (~8%).
- **`const.go` / `cp.go` / `ocpp_test.go`** — make `TriggerBootDelay` a `var` and shorten it in tests. The simulated charge points never send a spontaneous `BootNotification`, so each one otherwise waits the full 5s delay.

## Verification

- `TestOcpp` run 30× in fresh processes: **30/30 pass** (was failing ~deterministically under the prior timeout).
- After the speed change: **20/20 pass, avg 5s/run** (down from ~30s/run).
- `go build ./charger/...`, `go vet ./charger/ocpp/`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)