### PR TITLE
History UI: optimize production chart

### DIFF
--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -97,9 +97,7 @@ export default defineComponent({
 		valueFactor(): number {
 			return this.period === PERIODS.DAY ? 4 : 1;
 		},
-		// Peak absolute net power/energy per slot in the chart's display unit
-		// (kW for day, kWh for month/year). Absolute so export-dominant slots
-		// (battery discharge, grid export) count too.
+		// Peak per-slot stacked value in the display unit (kW for day, kWh otherwise).
 		axisPeak(): number {
 			const factor = this.valueFactor;
 			const slotSums = new Map<string, number>();
@@ -113,8 +111,6 @@ export default defineComponent({
 			for (const v of slotSums.values()) if (v > max) max = v;
 			return max;
 		},
-		// Day-only proxy used by useWatts; non-day reports Infinity so the W
-		// switch never triggers outside day view.
 		maxVisibleKw(): number {
 			return this.period === PERIODS.DAY ? this.axisPeak : Infinity;
 		},
@@ -122,10 +118,7 @@ export default defineComponent({
 		useWatts(): boolean {
 			return this.period === PERIODS.DAY && this.maxVisibleKw < 1;
 		},
-		// Use 1 decimal in the fractional zone (peak under 3 in the display
-		// unit) so echarts' 0.5-step splits don't render duplicates like
-		// "1, 1, 2, 2". Bidirectional sets an explicit integer interval and
-		// W unit means values are 0..900 W — both already render integers.
+		// 1 decimal when echarts may pick 0.5-step splits, else 0 — avoids "1, 1, 2, 2".
 		axisDigits(): number {
 			if (this.isBidirectional || this.useWatts) return 0;
 			return this.axisPeak < 3 ? 1 : 0;

--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -97,10 +97,10 @@ export default defineComponent({
 		valueFactor(): number {
 			return this.period === PERIODS.DAY ? 4 : 1;
 		},
-		// Peak absolute net power per slot in kW (day view only). Absolute so
-		// export-dominant slots (battery discharge, grid export) count too.
-		maxVisibleKw(): number {
-			if (this.period !== PERIODS.DAY) return Infinity;
+		// Peak absolute net power/energy per slot in the chart's display unit
+		// (kW for day, kWh for month/year). Absolute so export-dominant slots
+		// (battery discharge, grid export) count too.
+		axisPeak(): number {
 			const factor = this.valueFactor;
 			const slotSums = new Map<string, number>();
 			for (const s of this.visibleSeries) {
@@ -113,9 +113,22 @@ export default defineComponent({
 			for (const v of slotSums.values()) if (v > max) max = v;
 			return max;
 		},
+		// Day-only proxy used by useWatts; non-day reports Infinity so the W
+		// switch never triggers outside day view.
+		maxVisibleKw(): number {
+			return this.period === PERIODS.DAY ? this.axisPeak : Infinity;
+		},
 		// Switch to watts when the peak is below 1 kW so small values stay readable.
 		useWatts(): boolean {
 			return this.period === PERIODS.DAY && this.maxVisibleKw < 1;
+		},
+		// Use 1 decimal in the fractional zone (peak under 3 in the display
+		// unit) so echarts' 0.5-step splits don't render duplicates like
+		// "1, 1, 2, 2". Bidirectional sets an explicit integer interval and
+		// W unit means values are 0..900 W — both already render integers.
+		axisDigits(): number {
+			if (this.isBidirectional || this.useWatts) return 0;
+			return this.axisPeak < 3 ? 1 : 0;
 		},
 		unit(): "W" | "kW" | "kWh" {
 			if (this.period !== PERIODS.DAY) return "kWh";
@@ -607,9 +620,9 @@ export default defineComponent({
 										v * 1000,
 										this.useWatts ? POWER_UNIT.W : POWER_UNIT.KW,
 										false,
-										0
+										this.axisDigits
 									)
-								: this.fmtWh(v * 1000, POWER_UNIT.KW, false, 0),
+								: this.fmtWh(v * 1000, POWER_UNIT.KW, false, this.axisDigits),
 					},
 				}),
 				series: this.echartsSeries,

--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -53,37 +53,16 @@
 					class="history-tile mb-4"
 					:data-testid="`history-section-${group}`"
 				>
-					<div class="d-flex align-items-baseline gap-3">
-						<h3
-							class="fw-normal my-0 d-flex gap-3 flex-wrap align-items-baseline overflow-hidden history-tile-title flex-grow-1"
-						>
-							<span class="d-block no-wrap text-truncate">
-								{{ $t(`main.history.group.${group}`) }}
-							</span>
-							<small class="d-block no-wrap text-truncate">
-								{{ groupTotalLabel(group) }}
-							</small>
-						</h3>
-						<div
-							v-if="group === 'pv' && hasForecast && effectivePeriod === 'day'"
-							class="form-check form-switch mb-0 ms-auto forecast-toggle"
-							:style="{ '--forecast-color': groupColor('forecast') }"
-						>
-							<input
-								id="historyShowForecast"
-								v-model="showForecast"
-								class="form-check-input"
-								type="checkbox"
-								role="switch"
-							/>
-							<label
-								class="form-check-label text-muted ms-1"
-								for="historyShowForecast"
-							>
-								{{ $t("main.history.group.forecast") }}
-							</label>
-						</div>
-					</div>
+					<h3
+						class="fw-normal my-0 d-flex gap-3 flex-wrap align-items-baseline overflow-hidden history-tile-title"
+					>
+						<span class="d-block no-wrap text-truncate">
+							{{ $t(`main.history.group.${group}`) }}
+						</span>
+						<small class="d-block no-wrap text-truncate">
+							{{ groupTotalLabel(group) }}
+						</small>
+					</h3>
 					<GroupChart
 						v-if="displayFrom && displayTo && displayPeriod"
 						:group="group"
@@ -96,14 +75,19 @@
 						"
 						:overlayColor="groupColor('forecast')"
 						:overlayLabel="$t('main.history.group.forecast')"
-						:showOverlay="group === 'pv' && displayPeriod === 'day' && showForecast"
+						:showOverlay="
+							group === 'pv' &&
+							displayPeriod === 'day' &&
+							hasForecast &&
+							(focusedEntity[group] ?? null) === null
+						"
 						:focusedEntity="focusedEntity[group] ?? null"
 						:period="displayPeriod"
 						:from="displayFrom"
 						:to="displayTo"
 					/>
 					<ul
-						v-if="hasEntityLegend(group)"
+						v-if="hasEntityLegend(group) || hasForecastLegend(group)"
 						class="entity-legend p-0 mt-4 mb-0 d-flex flex-wrap column-gap-4 row-gap-2"
 					>
 						<li
@@ -125,6 +109,24 @@
 							></span>
 							<span class="text-nowrap">{{ legend.label }}</span>
 							<span class="text-muted text-nowrap">{{ legend.value }}</span>
+						</li>
+						<li
+							v-if="hasForecastLegend(group)"
+							class="entity-legend-item entity-legend-item--static d-flex align-items-baseline gap-2 no-wrap"
+							:class="{
+								'entity-legend-item--dim': (focusedEntity[group] ?? null) !== null,
+							}"
+						>
+							<span
+								class="entity-legend-dot entity-legend-dot--line align-self-center"
+								:style="{ backgroundColor: groupColor('forecast') }"
+							></span>
+							<span class="text-nowrap">
+								{{ $t("main.history.group.forecast") }}
+							</span>
+							<span class="text-muted text-nowrap">
+								{{ forecastTotalLabel }}
+							</span>
 						</li>
 					</ul>
 				</section>
@@ -193,7 +195,6 @@ export default defineComponent({
 			loading: true,
 			interval: null as ReturnType<typeof setInterval> | null,
 			startDate: new Date(2020, 0, 1),
-			showForecast: true,
 			focusedEntity: {} as Record<string, number | null>,
 		};
 	},
@@ -358,6 +359,14 @@ export default defineComponent({
 				s.data.some((slot) => slot.energy !== 0 || slot.returnEnergy !== 0)
 			);
 		},
+		forecastTotalLabel(): string {
+			const list = this.seriesByGroup["forecast"] || [];
+			let sum = 0;
+			for (const s of list) {
+				for (const slot of s.data) sum += slot.energy - slot.returnEnergy;
+			}
+			return this.fmtWh(Math.abs(sum) * 1000, POWER_UNIT.AUTO);
+		},
 		csvLink(): string {
 			const params = new URLSearchParams({
 				format: "csv",
@@ -405,6 +414,9 @@ export default defineComponent({
 			if (group === "loadpoint" || group === "meter") return true;
 			if (group === "pv" || group === "battery") return list.length > 1;
 			return false;
+		},
+		hasForecastLegend(group: string): boolean {
+			return group === "pv" && this.hasForecast && this.effectivePeriod === PERIODS.DAY;
 		},
 		entityLegends(group: string): (Legend & { entityIndex: number })[] {
 			const list = this.displaySeries(group);
@@ -594,13 +606,12 @@ export default defineComponent({
 	color: var(--evcc-default-text);
 	text-decoration: underline;
 }
-.forecast-toggle .form-check-input:checked {
-	background-color: var(--forecast-color);
-	border-color: var(--forecast-color);
+.entity-legend-dot--line {
+	height: 2px;
+	border-radius: 1px;
 }
-.forecast-toggle .form-check-input:focus {
-	border-color: var(--forecast-color);
-	box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--forecast-color) 25%, transparent);
+.entity-legend-item--static {
+	cursor: default;
 }
 .history-tile-title {
 	margin: 0 0 0.5rem;


### PR DESCRIPTION
🔮 replace forecast toggle with a line label (align with price/co2 line in sessions)
👁️ forecast line will disappear when focussing on a specific pv entity
🎚️ adaptive y-axis scale, add decimals when needed

below 1, W(h)
<img width="724" height="343" alt="below 1kw" src="https://github.com/user-attachments/assets/2e47671f-65f7-4661-9987-8a41bf8934d3" />

1-3, kW(h) with 1 decimal (focus on pv entity, forecast hidden)
<img width="738" height="343" alt="1-3kw" src="https://github.com/user-attachments/assets/0fa22be7-149b-43d9-b263-b9e8190ae699" />

above 3, kW(h) without decimals
<img width="752" height="340" alt="above 3kw" src="https://github.com/user-attachments/assets/8420f061-19fd-411a-b9fb-e2c051024baf" />
