### PR TITLE
Site: drop stale battery grid charge limit without a dynamic tariff

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -351,6 +351,23 @@ func (site *Site) restoreSettings() error {
 		}
 	}
 
+	// smart charging cost / feed-in limits require a dynamic tariff; drop
+	// stale loadpoint limits left over from a previous dynamic tariff (#29961)
+	if !site.isDynamicTariff(api.TariffUsagePlanner) {
+		for _, lp := range site.loadpoints {
+			if lp.GetSmartCostLimit() != nil {
+				lp.SetSmartCostLimit(nil)
+			}
+		}
+	}
+	if !site.isDynamicTariff(api.TariffUsageFeedIn) {
+		for _, lp := range site.loadpoints {
+			if lp.GetSmartFeedInPriorityLimit() != nil {
+				lp.SetSmartFeedInPriorityLimit(nil)
+			}
+		}
+	}
+
 	// drop legacy accumulator-based forecast settings (now stored via metrics collector)
 	settings.Delete("solarAccForecast")
 	settings.Delete("solarAccYield")

--- a/core/site.go
+++ b/core/site.go
@@ -342,7 +342,11 @@ func (site *Site) restoreSettings() error {
 		}
 	}
 	if v, err := settings.Float(keys.BatteryGridChargeLimit); err == nil {
-		if err := site.SetBatteryGridChargeLimit(&v); err != nil && !errors.Is(err, ErrBatteryControlNotAvailable) {
+		// a grid charge limit requires a dynamic tariff; drop a stale limit
+		// left over from a previous dynamic tariff configuration (#29961)
+		if !site.isDynamicTariff(api.TariffUsagePlanner) {
+			settings.SetString(keys.BatteryGridChargeLimit, "")
+		} else if err := site.SetBatteryGridChargeLimit(&v); err != nil && !errors.Is(err, ErrBatteryControlNotAvailable) {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #29961

## Problem

A user switched from a dynamic electricity tariff to a static one and could no longer remove the battery grid-charge price cap — it stayed visible with no way to clear it.

## Root cause

Three settings depend on a dynamic tariff but are persisted and restored unconditionally at boot, while their UI editors are gated on `smartCostAvailable` / `smartFeedInPriorityAvailable` (= a dynamic tariff). After switching to a static tariff the editor — and its remove control — is hidden, leaving a stale limit that the user cannot clear:

| Setting | Requires |
|---------|----------|
| `batteryGridChargeLimit` (site) | dynamic planner tariff |
| `smartCostLimit` (loadpoint) | dynamic planner tariff |
| `smartFeedInPriorityLimit` (loadpoint) | dynamic feed-in tariff |

Beyond the UI, a stale `batteryGridChargeLimit` / `smartCostLimit` can still actively drive grid/loadpoint charging against a configured fixed price.

## Fix

In the site's settings restore, once tariff availability is known:
- only reapply the persisted `batteryGridChargeLimit` when the planner tariff is dynamic, otherwise clear the stale value;
- clear stale loadpoint `smartCostLimit` / `smartFeedInPriorityLimit` when the respective tariff is not dynamic.

The loadpoint restore runs before the loadpoint has any tariff context, so the loadpoint limits are reconciled from the site.

## Verification

- `go build ./core/...`, `go vet ./core/`, `go test ./core/`, `gofmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)