### PR TITLE
Core: warn when charge current is truncated below minimum

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -888,6 +888,7 @@ func (lp *Loadpoint) roundedCurrent(current float64) float64 {
 
 // setLimit applies charger current limits and enables/disables accordingly
 func (lp *Loadpoint) setLimit(current float64) error {
+	rawCurrent := current
 	current = lp.roundedCurrent(current)
 
 	// apply circuit limits
@@ -912,6 +913,10 @@ func (lp *Loadpoint) setLimit(current float64) error {
 	effMinCurrent := lp.effectiveMinCurrent()
 	if effMaxCurrent := lp.effectiveMaxCurrent(); effMinCurrent > effMaxCurrent {
 		return fmt.Errorf("invalid config: min current %.3gA exceeds max current %.3gA", effMinCurrent, effMaxCurrent)
+	}
+
+	if current < effMinCurrent && rawCurrent >= effMinCurrent {
+		lp.log.WARN.Printf("charge current %.3gA rounded to %.3gA (below %.3gA minimum), preventing enable", rawCurrent, current, effMinCurrent)
 	}
 
 	// set current


### PR DESCRIPTION
Motivation:
Prevent silent enablement failure when a charger truncates a fractional
target current below its effective minimum. This specifically affects
'custom' chargers which default to 'coarse' behavior (rounding to full
Amps). In PV mode, if a user sets a sub-amp minCurrent (e.g. 0.125A for
a small heater), the internal logic calculates this as 0A after
rounding. Since 0A < 0.125A, the enablement is silently aborted, causing
the PV timer to loop indefinitely without any log feedback to the user.

Design Choices:
Added a check in setLimit to detect if rounding/truncation specifically
dropped the current from above minimum to below minimum, and log a WARN
message in that case.

Benefits:
Provides clear visibility into why a charger might not be starting in
PV mode, significantly aiding troubleshooting for custom chargers and
non-EV loads like smart plugs and heaters.