### PR TITLE
Loadpoint: stop re-attempting an unavailable phase switch

### DIFF
--- a/charger/ghosteebus.go
+++ b/charger/ghosteebus.go
@@ -198,7 +198,10 @@ func (wb *GhostEEBus) getPhases() (int, error) {
 		if res.LimitationReason != "" {
 			msg += fmt.Sprintf(" (%s)", res.LimitationReason)
 		}
-		return 0, errors.New(msg)
+		// the phase state cannot be read - signal api.ErrNotAvailable so
+		// callers treat it as a benign "not available" rather than an error
+		wb.log.TRACE.Println(msg)
+		return 0, api.ErrNotAvailable
 	}
 
 	switch res.CurrentState {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -2040,9 +2040,11 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 		err = lp.setLimit(0)
 
 	case lp.scalePhasesRequired():
-		// ignore api.ErrNotAvailable: the phase switch could not be performed
-		// right now and will be retried on the next cycle
 		if err = lp.scalePhases(lp.phasesConfigured); errors.Is(err, api.ErrNotAvailable) {
+			// the charger cannot switch phases right now (e.g. EEBus charger
+			// with an ISO 15118 vehicle). Adopt the configured phase count so
+			// the switch is not re-attempted on every cycle (issue #29974).
+			lp.SetPhases(lp.phasesConfigured)
 			err = nil
 		}
 

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -585,3 +585,58 @@ func TestFastChargingCircuitBasedPhaseScaling(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdatePhaseSwitchNotAvailable verifies that, with a fixed phasesConfigured
+// and a charger that refuses phase switching (api.ErrNotAvailable, e.g. an EEBus
+// charger with an ISO 15118 vehicle), the configured phase count is adopted so
+// the switch is not re-attempted on every update cycle (issue #29974).
+func TestUpdatePhaseSwitchNotAvailable(t *testing.T) {
+	clock := clock.NewMock()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	plainCharger := api.NewMockCharger(ctrl)
+	phaseCharger := api.NewMockPhaseSwitcher(ctrl)
+
+	plainCharger.EXPECT().Status().Return(api.StatusC, nil).AnyTimes()
+	plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
+	plainCharger.EXPECT().Enable(gomock.Any()).Return(nil).AnyTimes()
+	plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
+
+	// charger cannot switch phases - and must only be asked once
+	phaseCharger.EXPECT().Phases1p3p(3).Return(api.ErrNotAvailable).Times(1)
+
+	lp := &Loadpoint{
+		log:         util.NewLogger("foo"),
+		bus:         evbus.New(),
+		clock:       clock,
+		chargeMeter: &Null{},
+		chargeRater: &Null{},
+		chargeTimer: &Null{},
+		progress:    NewProgress(0, 10),
+		wakeUpTimer: NewTimer(),
+		mode:        api.ModeNow,
+		minCurrent:  minA,
+		maxCurrent:  maxA,
+		status:      api.StatusC,
+		charger: struct {
+			*api.MockCharger
+			*api.MockPhaseSwitcher
+		}{
+			plainCharger,
+			phaseCharger,
+		},
+		phasesConfigured: 3, // fixed 3p
+		phases:           0, // unknown
+	}
+
+	attachListeners(t, lp)
+
+	// first cycle attempts the switch, gets api.ErrNotAvailable, adopts 3p
+	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil)
+	require.Equal(t, 3, lp.GetPhases(), "configured phases should be adopted")
+
+	// second cycle must not attempt the switch again (Phases1p3p .Times(1))
+	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil)
+	require.Equal(t, 3, lp.GetPhases())
+}


### PR DESCRIPTION
Follow-up to #29975 / #29974 — addresses the remaining nuance: the phase switch is **re-attempted on every cycle** even with `phasesConfigured: 3`.

> Stacked on #29975 (`feat/phase-switch-notavailable`). Rebase onto master once that merges.

## Root cause

For a 1p3p-capable charger with a fixed `phasesConfigured` (1 or 3):

- `lp.phases` (the runtime physical phase count) initialises to `0` (unknown) and is **never persisted**.
- It only becomes non-zero via `SetPhases` after a *successful* `scalePhases`, or via `syncCharger`'s `getPhases()`.
- `scalePhasesRequired()` = `hasPhaseSwitching() && phasesConfigured != 0 && phasesConfigured != GetPhases()` → with `phases == 0` this is permanently true.
- So every `Update` cycle runs `scalePhases(phasesConfigured)` → `Phases1p3p(3)`.
- An EEBus charger with an ISO 15118 vehicle returns `api.ErrNotAvailable`, so `scalePhases` returns before `SetPhases` → `lp.phases` stays `0`.
- `syncCharger`'s phase-reading (which could correct `lp.phases`) is guarded by `phases > 0`, so with `lp.phases == 0` it never runs.

Result: a self-perpetuating loop — the switch can never succeed, so `lp.phases` stays unknown, so the switch stays "required", forever.

`phasesConfigured` is the *desired* value; evcc still drives `lp.phases` to match it. With a charger that cannot be switched, the drive loops.

## Change

1. **`core/loadpoint.go`** — when `scalePhases` toward a fixed `phasesConfigured` returns `api.ErrNotAvailable`, adopt the configured phase count (`SetPhases`). The user declared it and the charger cannot offer a better value; this breaks the loop and, by making `lp.phases` non-zero, also unblocks `syncCharger`'s phase reading.
2. **`charger/ghosteebus.go`** — `getPhases()` now returns `api.ErrNotAvailable` (instead of a plain error) for the not-possible/not-available relay states, consistent with `Phases1p3p`. `syncCharger` already treats `api.ErrNotAvailable` from `getPhases` as benign, so this prevents the spam from simply moving to a `charger get phases: …` message once `lp.phases` becomes non-zero.

## Design note

Adopting `phasesConfigured` when the switch is unavailable is a deliberate choice: it trusts the user's explicit fixed configuration as the operating phase count when evcc has no way to verify or change the physical state. This mirrors existing behaviour (`getChargerPhysicalPhases` defaults unknown → 3p). It does **not** apply to the auto-scaling path (`phasesConfigured == 0`), where `api.ErrNotAvailable` must not be mistaken for a completed scale.

## Verification

- New `TestUpdatePhaseSwitchNotAvailable`: a fixed-3p loadpoint with a charger returning `api.ErrNotAvailable` adopts 3p after the first `Update`, and `Phases1p3p` is asserted to be called **exactly once** across two cycles — proving the loop is broken.
- `go test ./core/`, `go vet`, `gofmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)