### PR TITLE
metrics: do not persist a partial first slot

### DIFF
--- a/core/metrics/collector.go
+++ b/core/metrics/collector.go
@@ -60,16 +60,13 @@ func (c *Collector) process(fun func()) error {
 
 	switch {
 	case c.started.IsZero():
-		// remember when collection started - the slot is only complete if it
-		// began exactly on a slot boundary (kept un-truncated on purpose)
+		// keep started un-truncated so a mid-slot start stays distinguishable
 		c.started = now
-		c.accu.Energy = 0
-		c.accu.ReturnEnergy = 0
 
 	case slotStart.After(c.started):
-		// persist the completed slot only if it was covered from its start,
-		// i.e. c.started is the immediately preceding slot boundary. The first
-		// (mid-slot) and any post-gap slot are skipped.
+		// persist the completed slot only if started is the immediately
+		// preceding slot boundary - false for the mid-slot first slot and
+		// for a slot reached after a data gap
 		if c.started.Equal(slotStart.Add(-tariff.SlotDuration)) {
 			if err := c.persist(); err != nil {
 				return err
@@ -77,9 +74,13 @@ func (c *Collector) process(fun func()) error {
 		}
 
 		c.started = slotStart
-		c.accu.Energy = 0
-		c.accu.ReturnEnergy = 0
+
+	default:
+		return nil
 	}
+
+	c.accu.Energy = 0
+	c.accu.ReturnEnergy = 0
 
 	return nil
 }

--- a/core/metrics/collector.go
+++ b/core/metrics/collector.go
@@ -56,9 +56,21 @@ func (c *Collector) process(fun func()) error {
 
 	fun()
 
-	if slotStart := now.Truncate(tariff.SlotDuration); slotStart.After(c.started) {
-		// skip incomplete first slot
-		if !c.started.IsZero() {
+	slotStart := now.Truncate(tariff.SlotDuration)
+
+	switch {
+	case c.started.IsZero():
+		// remember when collection started - the slot is only complete if it
+		// began exactly on a slot boundary (kept un-truncated on purpose)
+		c.started = now
+		c.accu.Energy = 0
+		c.accu.ReturnEnergy = 0
+
+	case slotStart.After(c.started):
+		// persist the completed slot only if it was covered from its start,
+		// i.e. c.started is the immediately preceding slot boundary. The first
+		// (mid-slot) and any post-gap slot are skipped.
+		if c.started.Equal(slotStart.Add(-tariff.SlotDuration)) {
 			if err := c.persist(); err != nil {
 				return err
 			}

--- a/core/metrics/collector_test.go
+++ b/core/metrics/collector_test.go
@@ -154,3 +154,40 @@ func TestCollectorSetImportAndExportMeterTotal(t *testing.T) {
 	require.InDelta(t, 0.3, col.accu.Imported(), 1e-10)
 	require.InDelta(t, 0.7, col.accu.Exported(), 1e-10)
 }
+
+// TestCollectorSkipsPartialFirstSlot verifies that the first slot, joined
+// mid-way after (re)start, is not persisted as a full 15min slot.
+func TestCollectorSkipsPartialFirstSlot(t *testing.T) {
+	clk := clock.NewMock() // 1970-01-01 00:00:00 UTC
+
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	col, err := NewCollector("partial", "partial", WithClock(clk))
+	require.NoError(t, err)
+
+	// first update mid-slot (00:05) - slot 00:00 is only partially covered
+	clk.Add(5 * time.Minute)
+	require.NoError(t, col.AddEnergy(nil, nil, 1e3))
+	clk.Add(5 * time.Minute) // 00:10
+	require.NoError(t, col.AddEnergy(nil, nil, 1e3))
+
+	// cross into slot 00:15 - the partial slot 00:00 must not be persisted
+	clk.Add(5 * time.Minute) // 00:15
+	require.NoError(t, col.AddEnergy(nil, nil, 1e3))
+
+	var count int64
+	require.NoError(t, db.Instance.Model(new(meter)).Count(&count).Error)
+	require.Zero(t, count, "partial first slot must not be persisted")
+
+	// cross into slot 00:30 - the fully covered slot 00:15 must be persisted
+	clk.Add(15 * time.Minute) // 00:30
+	require.NoError(t, col.AddEnergy(nil, nil, 1e3))
+
+	require.NoError(t, db.Instance.Model(new(meter)).Count(&count).Error)
+	require.EqualValues(t, 1, count, "first full slot must be persisted")
+
+	var m meter
+	require.NoError(t, db.Instance.First(&m).Error)
+	require.Equal(t, int64(15*60), m.Timestamp, "persisted slot should start at 00:15")
+}


### PR DESCRIPTION
## Problem

`metrics.Collector` persists energy in 15-minute slots aligned to `:00/:15/:30/:45`. On every evcc start/restart it wrote a **partial first slot** — a row covering less than the full 15 minutes — under-reporting that slot's energy.

## Root cause

`Collector.process()` had a `// skip incomplete first slot` comment, but the `if !c.started.IsZero()` guard only skipped the *zeroth* (non-existent) persist. It then set `c.started` to the truncated slot of the first update.

For a start at 10:07: update 1 sets `c.started = 10:00`; the collector accumulates into slot 10:00 but only joined at 10:07 (8 of 15 minutes). At the next boundary (≥ 10:15) `c.started` is no longer zero, so `persist()` runs and slot **10:00 is written with only 10:07–10:15 of energy**. `NewCollector` always starts with `started` zero, so this happened on every start/restart.

## Fix

Keep `c.started` **un-truncated** on the first update. A slot is then persisted only when `c.started` equals the immediately preceding slot boundary (`slotStart - SlotDuration`):

- regular slots — `c.started` was set to an aligned `slotStart` at the previous crossing → check passes → persisted;
- the mid-slot first slot — `c.started` is the raw first-update time, not a boundary → check fails → skipped;
- a slot reached after a data gap — `c.started` is not the *immediately* preceding boundary → skipped (avoids persisting a slot whose energy was distorted by the gap).

No helper field — the "is this slot complete" information is carried by whether `c.started` is slot-aligned.

## Verification

- New `TestCollectorSkipsPartialFirstSlot`: a collector first updated mid-slot writes **no** row for the partial slot and persists the next full slot at the correct boundary timestamp.
- Existing collector tests still pass (they assert the in-memory accumulator, which resets identically).
- `go build ./core/...`, `go vet`, `go test ./core/...`, `gofmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)