### PR TITLE
Config: enforce required fields when forcing save past a failed test

### DIFF
--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -652,13 +652,12 @@ export default defineComponent({
 			await prepareAuthLogin(this.auth, authId);
 		},
 		async create(force = false) {
-			const form = this.$refs["form"] as HTMLFormElement | undefined;
-			// always enforce required fields, even when forcing past a failed test
-			if (form && !reportValidityInModal(form)) {
-				return;
-			}
 			if (this.test.isUnknown && !force) {
-				const success = await performTest(this.test, this.testDevice, form);
+				const success = await performTest(
+					this.test,
+					this.testDevice,
+					this.$refs["form"] as HTMLFormElement
+				);
 				if (!success) {
 					return;
 				}
@@ -689,13 +688,12 @@ export default defineComponent({
 			return this.device.test(this.id, this.apiData);
 		},
 		async update(force = false) {
-			const form = this.$refs["form"] as HTMLFormElement | undefined;
-			// always enforce required fields, even when forcing past a failed test
-			if (form && !reportValidityInModal(form)) {
-				return;
-			}
 			if (this.test.isUnknown && !force) {
-				const success = await performTest(this.test, this.testDevice, form);
+				const success = await performTest(
+					this.test,
+					this.testDevice,
+					this.$refs["form"] as HTMLFormElement
+				);
 				if (!success) {
 					return;
 				}

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -512,6 +512,11 @@ export default defineComponent({
 		},
 		values: {
 			handler() {
+				// a prior test result no longer matches the edited config:
+				// revert "Save anyway" back to "Validate & save"
+				if (this.test.isError || this.test.isSuccess) {
+					this.test = initialTestState();
+				}
 				this.updateServiceValues();
 			},
 			deep: true,
@@ -647,12 +652,13 @@ export default defineComponent({
 			await prepareAuthLogin(this.auth, authId);
 		},
 		async create(force = false) {
+			const form = this.$refs["form"] as HTMLFormElement | undefined;
+			// always enforce required fields, even when forcing past a failed test
+			if (form && !reportValidityInModal(form)) {
+				return;
+			}
 			if (this.test.isUnknown && !force) {
-				const success = await performTest(
-					this.test,
-					this.testDevice,
-					this.$refs["form"] as HTMLFormElement
-				);
+				const success = await performTest(this.test, this.testDevice, form);
 				if (!success) {
 					return;
 				}
@@ -683,13 +689,13 @@ export default defineComponent({
 			return this.device.test(this.id, this.apiData);
 		},
 		async update(force = false) {
+			const form = this.$refs["form"] as HTMLFormElement | undefined;
+			// always enforce required fields, even when forcing past a failed test
+			if (form && !reportValidityInModal(form)) {
+				return;
+			}
 			if (this.test.isUnknown && !force) {
-				const success = await performTest(
-					this.test,
-					this.testDevice,
-					this.$refs["form"] as HTMLFormElement
-				);
-				console.log("test result", success);
+				const success = await performTest(this.test, this.testDevice, form);
 				if (!success) {
 					return;
 				}

--- a/tests/config-required-field.spec.ts
+++ b/tests/config-required-field.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+import { expectModalVisible } from "./utils";
+
+test.use({ baseURL: baseUrl() });
+
+const templateFlags = [
+  "--disable-auth",
+  "--template-type",
+  "meter",
+  "--template",
+  "tests/config-required-field.tpl.yaml",
+];
+
+test.beforeEach(async () => {
+  await start(undefined, undefined, templateFlags);
+});
+test.afterEach(async () => {
+  await stop();
+});
+
+test.describe("required field validation", async () => {
+  // regression test for evcc-io/evcc#29919: clearing a required field after a
+  // failed connection test must not allow saving via the "Save anyway" button
+  test("cannot save with empty required field after failed test", async ({ page }) => {
+    await page.goto("/#/config");
+
+    await page.getByRole("button", { name: "Add grid meter" }).click();
+    const meterModal = page.getByTestId("meter-modal");
+    await expectModalVisible(meterModal);
+    await meterModal.getByLabel("Manufacturer").selectOption("Required Field Demo");
+
+    // fill the required field so the connection test runs (and then fails)
+    await meterModal.getByLabel("Secret").fill("some-secret");
+    await meterModal.getByRole("button", { name: "Validate & save" }).click();
+
+    // failed test exposes the "Save anyway" force-save button
+    const forceSave = meterModal.getByRole("button", { name: "Save anyway" });
+    await expect(forceSave).toBeVisible();
+
+    // clearing the field invalidates the stale test result: the button must
+    // revert to "Validate & save" instead of staying in force-save mode
+    await meterModal.getByLabel("Secret").fill("");
+    await expect(forceSave).not.toBeVisible();
+    const validateSave = meterModal.getByRole("button", { name: "Validate & save" });
+    await expect(validateSave).toBeVisible();
+
+    // attempting to save with the empty required field is blocked by validation
+    await validateSave.click();
+    await expectModalVisible(meterModal);
+    await expect(meterModal.getByLabel("Secret")).toHaveJSProperty("validity.valid", false);
+
+    // nothing was persisted
+    await expect(page.getByTestId("grid")).toHaveCount(0);
+  });
+});

--- a/tests/config-required-field.tpl.yaml
+++ b/tests/config-required-field.tpl.yaml
@@ -1,0 +1,20 @@
+template: required-field-demo
+group: generic
+products:
+  - description:
+      generic: Required Field Demo
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: secret
+    description:
+      generic: Secret
+    required: true
+
+# unreachable uri so the connection test always fails, exposing the
+# "Save anyway" button (see tests/config-required-field.spec.ts)
+render: |
+  type: custom
+  power:
+    source: http
+    uri: http://localhost:1/{{ .secret }}


### PR DESCRIPTION
## Summary

Fixes #29919 — the device config UI allowed saving a device with empty required fields.

The "Save anyway" button (shown after a failed connection test) bypassed required-field validation entirely. The HTML5 validity check (`reportValidityInModal`) only ran inside `performTest`, and the force-save path skips `performTest`. So this sequence saved an incomplete config:

1. Enter a wrong password → **Validate & save** → connection test fails
2. Button becomes **Save anyway** (`force = true`)
3. Clear the required field
4. Click **Save anyway** → device persisted with an empty required field

A vehicle saved this way then makes the backend fail hard on the next start (`FATAL ... missing required 'user'`), and the config UI no longer lists any vehicle — only an `evcc.db` edit recovers it.

## Changes

- **`create()` / `update()`** now always run `reportValidityInModal()` before saving, independent of the connection-test result. Required-field validity has nothing to do with whether the device connects, so it must never be bypassable.
- **`values` watcher** resets stale test state when the config is edited after a test ran. This reverts the button from **Save anyway** back to **Validate & save**, so a force-save can no longer be carried over onto a config that has since changed. (This also fixes the misleading case of offering "Save anyway" for a config different from the one that was tested.)

## Test

Adds `tests/config-required-field.spec.ts` (+ a minimal `config-required-field.tpl.yaml` template with a required field and an unreachable URI so the connection test always fails). The test reproduces the issue flow and verifies the empty required field can no longer be saved. Confirmed it fails without the fix and passes with it.

Note: this addresses bug (1) from the issue. The backend hard-fail on an already-broken DB record — bug (2) — is separate; preventing the bad save stops new occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)