### PR TITLE
History: fix scale for stack batteries

### DIFF
--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -110,31 +110,27 @@ export default defineComponent({
 		valueFactor(): number {
 			return this.period === PERIODS.DAY ? 4 : 1;
 		},
-		// Raw peak in display unit. Bidirectional: max of |either direction|.
-		// Unidirectional: max of stacked per-slot sum.
+		// Peak of stacked per-slot sums. Bidirectional: pos/neg separately.
 		axisPeak(): number {
 			const factor = this.valueFactor;
-			let max = 0;
-			if (this.isBidirectional) {
+			const peak = (pick: (slot: HistorySlot) => number) => {
+				const sums = new Map<string, number>();
 				for (const s of this.visibleSeries) {
 					for (const slot of s.data) {
-						const a = Math.abs(slot.energy) * factor;
-						const b = Math.abs(slot.returnEnergy) * factor;
-						if (a > max) max = a;
-						if (b > max) max = b;
+						sums.set(slot.start, (sums.get(slot.start) || 0) + pick(slot) * factor);
 					}
 				}
+				let max = 0;
+				for (const v of sums.values()) if (v > max) max = v;
 				return max;
+			};
+			if (this.isBidirectional) {
+				return Math.max(
+					peak((slot) => Math.abs(slot.energy)),
+					peak((slot) => Math.abs(slot.returnEnergy))
+				);
 			}
-			const slotSums = new Map<string, number>();
-			for (const s of this.visibleSeries) {
-				for (const slot of s.data) {
-					const v = Math.abs(slot.energy - slot.returnEnergy) * factor;
-					slotSums.set(slot.start, (slotSums.get(slot.start) || 0) + v);
-				}
-			}
-			for (const v of slotSums.values()) if (v > max) max = v;
-			return max;
+			return peak((slot) => Math.abs(slot.energy - slot.returnEnergy));
 		},
 		// W/Wh scale when peak below 1 kW(h). Zero data falls here too.
 		useSmallUnit(): boolean {

--- a/tests/energy-history.spec.ts
+++ b/tests/energy-history.spec.ts
@@ -130,6 +130,18 @@ test.describe("axis and units", () => {
     expect(await yAxis(chart(page, "battery"))).toEqual(["kW", "-6", "-3", "0", "3", "6"]);
   });
 
+  test("stacked batteries: axis follows stacked sum, not per-entity max", async ({ page }) => {
+    await gotoDay(page, 2026, 4, 8);
+    expect(await yAxis(chart(page, "battery"))).toEqual([
+      "kW",
+      "-3.0",
+      "-1.5",
+      "0.0",
+      "1.5",
+      "3.0",
+    ]);
+  });
+
   test("unidirectional axis stays positive", async ({ page }) => {
     await gotoDay(page, 2026, 4, 5);
     // Unidirectional groups use echarts auto-scale (min: 0). Peak 1.6 kW → ticks 0..2.

--- a/tests/energy-history.sql
+++ b/tests/energy-history.sql
@@ -24,6 +24,7 @@ INSERT INTO `entities` VALUES (6, 'meter', 'Office');
 INSERT INTO `entities` VALUES (7, 'pv', 'pv-east');
 INSERT INTO `entities` VALUES (8, 'pv', 'pv-west');
 INSERT INTO `entities` VALUES (9, 'forecast', 'forecast');
+INSERT INTO `entities` VALUES (10, 'battery', 'battery-2');
 
 -- =====================================================================
 -- API test data: 2026-03-24/25 (existing). Used by the JSON-shape tests.
@@ -134,6 +135,17 @@ INSERT INTO `meters` VALUES (9, 1777716000, 1.80, 0);
 INSERT INTO `meters` VALUES (9, 1777723200, 1.70, 0);
 INSERT INTO `meters` VALUES (9, 1777730400, 1.10, 0);
 INSERT INTO `meters` VALUES (9, 1777737600, 0.35, 0);
+
+-- 2026-04-08 → two stacked batteries. Charge 1.2 kW each (stacked 2.4 kW),
+-- discharge 0.8 kW each (stacked -1.6 kW). niceCeil(2.4) = 3.
+INSERT INTO `meters` VALUES (3, 1775642400, 0.3, 0);
+INSERT INTO `meters` VALUES (3, 1775643300, 0, 0.2);
+INSERT INTO `meters` VALUES (3, 1775644200, 0.3, 0);
+INSERT INTO `meters` VALUES (3, 1775645100, 0, 0.2);
+INSERT INTO `meters` VALUES (10, 1775642400, 0.3, 0);
+INSERT INTO `meters` VALUES (10, 1775643300, 0, 0.2);
+INSERT INTO `meters` VALUES (10, 1775644200, 0.3, 0);
+INSERT INTO `meters` VALUES (10, 1775645100, 0, 0.2);
 
 -- =====================================================================
 -- Month-aggregation case: 2026-06, three days with battery bidirectional


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/30022#issuecomment-4498838504

- fix peak calculated for stacked bidirectional series (batteries)
- add test case

<img width="1196" height="405" alt="Bildschirmfoto 2026-05-20 um 15 36 28" src="https://github.com/user-attachments/assets/ca696165-e793-4d67-92d3-84982cf41ae9" />
