### PR TITLE
Cupra: fix vehicle list

### DIFF
--- a/vehicle/seat/cupra/api.go
+++ b/vehicle/seat/cupra/api.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
 	"golang.org/x/oauth2"
 )
 
@@ -29,9 +30,14 @@ func NewAPI(log *util.Logger, ts oauth2.TokenSource) *API {
 		Helper: request.NewHelper(log),
 	}
 
-	v.Client.Transport = &oauth2.Transport{
-		Source: ts,
-		Base:   v.Client.Transport,
+	v.Client.Transport = &transport.Decorator{
+		Base: &oauth2.Transport{
+			Source: ts,
+			Base:   v.Client.Transport,
+		},
+		Decorator: transport.DecorateHeaders(map[string]string{
+			"app-market": "android",
+		}),
 	}
 
 	return v


### PR DESCRIPTION
Adds the `app-market: android` request header to the Cupra OLA API client.

Without it, the backend now returns `403 Forbidden` on
`GET /v2/users/{userId}/garage/vehicles`, breaking integration startup.

Mirrors the upstream pycupra fix (https://github.com/WulfgarW/pycupra/commit/0296f58e, v0.2.30) and the workaround documented in https://github.com/WulfgarW/homeassistant-pycupra/issues/89.

Closes #30043