### PR TITLE
Revert "Huawei SUN2000: add curtail (#28549)"

### DIFF
--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -5,7 +5,7 @@ products:
     description:
       de: SUN2000 Hybrid-Wechselrichter
       en: SUN2000 Hybrid Inverter
-capabilities: ["battery-control", "curtail"]
+capabilities: ["battery-control"]
 requirements:
   description:
     de: |
@@ -39,12 +39,6 @@ params:
     default: 15s
   - name: maxacpower
     service: modbus/read?address=30075&type=holding&encoding=uint32&{modbus}
-  - name: curtailpercent
-    description:
-      de: Wirkleistungsbegrenzung in Prozent
-      en: Active power limit in percent
-    advanced: true
-    usages: ["pv"]
   - name: storageunit
   - name: forceaccharging
     default: false
@@ -138,47 +132,6 @@ render: |
       decode: uint32nan
     scale: 0.01
   maxacpower: {{ .maxacpower }}
-  curtail:
-    source: ifelse
-    if:
-      source: sequence
-      set:
-      - source: const
-        value: {{ .curtailpercent }}
-        set:
-          source: modbus
-          {{- include "modbus" . | indent 8 }}
-          register:
-            address: 47418 # Maximum Feed Grid Power (0-100 %)
-            type: writesingle
-            encoding: uint16
-          scale: 10
-      - source: const
-        value: 7 # Power-limited grid connection (%)
-        set:
-          source: modbus
-          {{- include "modbus" . | indent 8 }}
-          register:
-            address: 47415 # Active power control mode
-            type: writesingle
-            encoding: uint16
-    else:
-      source: const
-      value: 0 # Unlimited 
-      set:
-        source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 47415 # Active power control mode
-          type: writesingle
-          encoding: uint16
-  curtailed:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 47415 # Active power control mode (0=no curtailment)
-      type: holding
-      decode: uint16
   {{- end }}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
This reverts commit ef12393ffe1d09c32b86bc9d7c2d1a71d45e5860.

@andig If a static limit is set (like 60 or 70%) via inverter configuration, evcc shows `Feed-in limit=true` after starting up but immediately sets it to `false`, wiping the feed-in limitation on the Huawei PV system. This is super dangerous. Please revert.