### PR TITLE
Chart: sorted color picker

### DIFF
--- a/assets/js/colors.ts
+++ b/assets/js/colors.ts
@@ -38,25 +38,27 @@ const colors: {
   light: null,
   selfPalette: ["#0FDE41", "#FFBD2F", "#FD6158", "#03C1EF", "#0F662D", "#FF922E"],
   palette: [
-    // Dynamic palette (vehicles, loadpoints, …): optimized for neighbor contrast, avoids overlap with system colors (solar, battery, grid, …).
-    "#0EA5E9", // Sky
-    "#EC4899", // Pink
-    "#34D399", // Mint
-    "#F97316", // Orange
-    "#7C3AED", // Violet
-    "#84CC16", // Lime
-    "#F43F5E", // Rose
-    "#2563EB", // Blue
-    "#FACC15", // Yellow
-    "#D946EF", // Magenta
-    "#10B981", // Emerald
-    "#1E40AF", // Royal
-    "#BE185D", // Crimson
-    "#F59E0B", // Marigold
-    "#6366F1", // Indigo
-    "#14B8A6", // Teal
-    "#A855F7", // Lavender
-    "#DC2626", // Red
+    // light
+    "#60A5FA", // blue
+    "#FBBF24", // amber
+    "#22D3EE", // cyan
+    "#F472B6", // pink
+    "#34D399", // green
+    "#A78BFA", // violet
+    // mid
+    "#2563EB", // blue
+    "#F59E0B", // amber
+    "#06B6D4", // cyan
+    "#EC4899", // pink
+    "#10B981", // green
+    "#8B5CF6", // violet
+    // dark
+    "#1E40AF", // blue
+    "#B45309", // amber
+    "#0E7490", // cyan
+    "#BE185D", // pink
+    "#047857", // green
+    "#6D28D9", // violet
   ],
 });
 

--- a/assets/js/components/Helper/ColorPickerPopover.vue
+++ b/assets/js/components/Helper/ColorPickerPopover.vue
@@ -99,13 +99,23 @@ export default defineComponent({
 	emits: ["update:modelValue", "update:color"],
 	data() {
 		return {
-			palette: colors.palette,
 			popper: null as PopperInstance | null,
 			hexInputValue: "",
 			hexFocused: false,
 		};
 	},
 	computed: {
+		palette(): string[] {
+			// de-interleave warm/cool palette into 3×6 grid (rows: light/mid/dark, cols: hue)
+			const grid: string[][] = Array.from({ length: 3 }, () => Array(6).fill(""));
+			colors.palette.forEach((hex, i) => {
+				const row = Math.floor(i / 6);
+				const step = i % 6;
+				const col = Math.floor(step / 2) + (step % 2) * 3;
+				grid[row][col] = hex;
+			});
+			return grid.flat();
+		},
 		customHex(): string {
 			return normalizeHex(this.color);
 		},

--- a/tests/device-colors.spec.ts
+++ b/tests/device-colors.spec.ts
@@ -4,8 +4,8 @@ import { start, stop, baseUrl } from "./evcc";
 test.use({ baseURL: baseUrl() });
 
 // from assets/js/colors.ts palette
-const SKY = "rgb(14, 165, 233)"; // #0EA5E9 — palette[0]
-const PINK = "rgb(236, 72, 153)"; // #EC4899 — palette[1]
+const BLUE = "rgb(96, 165, 250)"; // #60A5FA — palette[0]
+const AMBER = "rgb(251, 191, 36)"; // #FBBF24 — palette[1]
 const CUSTOM_HEX = "FF0080";
 const CUSTOM_RGB = "rgb(255, 0, 128)";
 
@@ -31,25 +31,25 @@ test("device colors: autoassign, override, persistence", async ({ page }) => {
   await page.goto("/#/sessions?year=2026&month=5");
   await expect(page.getByRole("heading", { name: "Charging Sessions" })).toBeVisible();
   await page.getByRole("button", { name: "Vehicle", exact: true }).click();
-  await expectLegendColor(page, "Honda", SKY);
+  await expectLegendColor(page, "Honda", BLUE);
 
   // ---------- Step 2 — Sessions, by-loadpoint + override ----------
   await page.getByRole("button", { name: "Charging point", exact: true }).click();
   // initial autoassign — Garage (more energy) → palette[0], Carport → palette[1]
-  await expectLegendColor(page, "Garage", SKY);
-  await expectLegendColor(page, "Carport", PINK);
+  await expectLegendColor(page, "Garage", BLUE);
+  await expectLegendColor(page, "Carport", AMBER);
 
-  // open picker on Garage badge; second palette swatch = PINK
+  // open picker on Garage badge; second palette swatch = AMBER
   await legendBadge(page, "Garage").click();
   const popover = page.getByRole("dialog");
   await expect(popover).toBeVisible();
   // palette swatches have title=hex
-  await popover.getByTitle("#EC4899").click();
+  await popover.getByTitle("#FBBF24").click();
   await page.keyboard.press("Escape");
 
-  await expectLegendColor(page, "Garage", PINK);
-  // non-collision: Carport must shift off PINK to the first free entry (SKY)
-  await expectLegendColor(page, "Carport", SKY);
+  await expectLegendColor(page, "Garage", AMBER);
+  // non-collision: Carport must shift off AMBER to the first free entry (BLUE)
+  await expectLegendColor(page, "Carport", BLUE);
 
   // ---------- Step 3 — History view, same colors ----------
   await page.goto("/#/history?period=day&year=2026&month=5&day=15");
@@ -57,8 +57,8 @@ test("device colors: autoassign, override, persistence", async ({ page }) => {
     .locator("section")
     .filter({ has: page.getByRole("heading", { name: "Charging & Heating" }) });
   await expect(lpSection).toBeVisible({ timeout: 10000 });
-  await expectLegendColor(lpSection, "Garage", PINK);
-  await expectLegendColor(lpSection, "Carport", SKY);
+  await expectLegendColor(lpSection, "Garage", AMBER);
+  await expectLegendColor(lpSection, "Carport", BLUE);
 
   // ---------- Step 4 — Custom hex on ext meter, reload ----------
   const meterSection = page


### PR DESCRIPTION
improves https://github.com/evcc-io/evcc/pull/30021

🎨 color picker: shop options in a sorted grid (cols = hues, rows = brightness)
🤖 auto assign: colors are picked with hue gap of 3 (improve neighbor contrast) and from light to dark (18 distinct colors)
💈 color selection more similar to the original (before history) device colors

**Screenshots**

on light
<img width="816" height="904" alt="light" src="https://github.com/user-attachments/assets/f9be564e-51cb-41af-8c6b-6c472bdaef57" />

on dark
<img width="774" height="893" alt="dark" src="https://github.com/user-attachments/assets/fb6e43e1-1aa5-4606-8bb0-eaf745f32215" />
