### PR TITLE
Polestar: handle removed chargingStatus field

### DIFF
--- a/vehicle/polestar/provider.go
+++ b/vehicle/polestar/provider.go
@@ -48,10 +48,9 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		return res, nil
 	}
 
-	if status.Battery[0].ChargingStatus == "CHARGER_CONNECTION_STATUS_CONNECTED" {
-		res = api.StatusB
-	}
-	if status.Battery[0].ChargingStatus == "CHARGING_STATUS_CHARGING" {
+	// chargingStatus was removed from carTelematicsV2 — infer from remaining time;
+	// StatusB (connected, not charging) cannot be distinguished anymore
+	if status.Battery[0].EstimatedChargingTimeToFullMinutes > 0 {
 		res = api.StatusC
 	}
 

--- a/vehicle/polestar/types.go
+++ b/vehicle/polestar/types.go
@@ -24,7 +24,6 @@ type HealthData struct {
 type BatteryData struct {
 	VIN                                string
 	BatteryChargeLevelPercentage       float64
-	ChargingStatus                     string
 	EstimatedChargingTimeToFullMinutes int64
 	EstimatedDistanceToEmptyKm         int64
 	Timestamp                          Timestamp


### PR DESCRIPTION
Polestar removed chargingStatus from carTelematicsV2. Infer charging state from estimatedChargingTimeToFullMinutes; StatusB cannot be distinguished anymore.