### PR TITLE
Cupra: add missing OLA API request headers

### DIFF
--- a/vehicle/seat/cupra/api.go
+++ b/vehicle/seat/cupra/api.go
@@ -36,7 +36,11 @@ func NewAPI(log *util.Logger, ts oauth2.TokenSource) *API {
 			Base:   v.Client.Transport,
 		},
 		Decorator: transport.DecorateHeaders(map[string]string{
-			"app-market": "android",
+			"app-market":  "android",
+			"app-brand":   "cupra",
+			"app-version": "2.15.0",
+			"User-Agent":  "OLACupra/2.15.0 (Android 12; sdk_gphone64_x86_64; Google) Mobile",
+			"origin":      "app",
 		}),
 	}
 

--- a/vehicle/seat/cupra/api.go
+++ b/vehicle/seat/cupra/api.go
@@ -17,6 +17,9 @@ const (
 	ActionCharge      = "charging"
 	ActionChargeStart = "start"
 	ActionChargeStop  = "stop"
+
+	// appVersion is the Cupra app version mirrored in request headers
+	appVersion = "2.15.0"
 )
 
 // API is an api.Vehicle implementation for Seat Cupra cars
@@ -35,11 +38,13 @@ func NewAPI(log *util.Logger, ts oauth2.TokenSource) *API {
 			Source: ts,
 			Base:   v.Client.Transport,
 		},
+		// These headers mirror the official Cupra app and are required to avoid
+		// 403 Forbidden from the OLA backend (verified against pycupra v0.2.30).
 		Decorator: transport.DecorateHeaders(map[string]string{
 			"app-market":  "android",
 			"app-brand":   "cupra",
-			"app-version": "2.15.0",
-			"User-Agent":  "OLACupra/2.15.0 (Android 12; sdk_gphone64_x86_64; Google) Mobile",
+			"app-version": appVersion,
+			"User-Agent":  "OLACupra/" + appVersion + " (Android 12; sdk_gphone64_x86_64; Google) Mobile",
 			"origin":      "app",
 		}),
 	}


### PR DESCRIPTION
## Problem

Fix https://github.com/evcc-io/evcc/issues/30043

The previous fix (#30047) added only `app-market: android`, but the Cupra OLA API still returns `403 Forbidden` on `GET /v2/users/{userId}/garage/vehicles` without the full set of headers used by the official Cupra app.

## Fix

Add the remaining headers required by the OLA API backend:

- `app-brand: cupra`
- `app-version: 2.15.0`
- `User-Agent: OLACupra/2.15.0 (Android 12; sdk_gphone64_x86_64; Google) Mobile`
- `origin: app`

## References

- Mirrors the full header set from the [pycupra reference implementation](https://github.com/WulfgarW/pycupra/commit/0296f58e) (v0.2.30)
- Related: https://github.com/WulfgarW/homeassistant-pycupra/issues/89
- Follows up on #30047