### PR TITLE
MQTT: remove stray debug println in struct publisher

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -136,8 +136,6 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload any) {
 				topic := topic
 				if !mqttTagAttribute("squash", f) {
 					topic = fmt.Sprintf("%s/%s", topic, strings.ToLower(f.Name[:1])+f.Name[1:])
-				} else {
-					println(1)
 				}
 
 				if val.Field(i).IsZero() && jsonOmitEmpty(f) {


### PR DESCRIPTION
## Summary

`publishComplex` in `server/mqtt.go` had a leftover debug statement:

```go
if !mqttTagAttribute("squash", f) {
    topic = fmt.Sprintf("%s/%s", topic, strings.ToLower(f.Name[:1])+f.Name[1:])
} else {
    println(1)
}
```

The `else` branch only wrote `1` to stderr for every squashed struct field on every publish. It has been there since #24887. This removes the dead `else` branch.

## Test plan

- `go build ./server/` ✓
- `go vet ./server/` ✓
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)