### PR TITLE
Atmoce: fix battery energy

### DIFF
--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -124,7 +124,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 60166 # Cumulative Energy Storage Charging Capacity (kWh * 100)
+      address: 60172 # Cumulative Energy Storage Discharging Capacity (kWh * 100)
       type: holding
       decode: uint64
     scale: 0.01


### PR DESCRIPTION
Battery energy was mistakenly configured for charged energy instead of discharged energy.