### PR TITLE
Enphase: rename IQ Envoy to IQ Gateway

### DIFF
--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -2,7 +2,7 @@ template: enphase
 products:
   - brand: Enphase
     description:
-      generic: IQ Envoy
+      generic: IQ Gateway
 requirements:
 params:
   - name: usage


### PR DESCRIPTION
Enphase used to call them Envoy in the past, but current name is IQ Gateway.