### PR TITLE
fix: serialize concurrent POSTs to /api/vehicles/{id}/plan/strategy

### DIFF
--- a/server/http_vehicle_handler.go
+++ b/server/http_vehicle_handler.go
@@ -4,12 +4,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/site"
 	"github.com/gorilla/mux"
 )
+
+// vehicleWriteLocks serializes write+read-back sequences per vehicle name,
+// so concurrent POSTs do not observe each other's interleaved state.
+var vehicleWriteLocks sync.Map // vehicle name -> *sync.Mutex
+
+func vehicleWriteLock(name string) *sync.Mutex {
+	if m, ok := vehicleWriteLocks.Load(name); ok {
+		return m.(*sync.Mutex)
+	}
+	actual, _ := vehicleWriteLocks.LoadOrStore(name, &sync.Mutex{})
+	return actual.(*sync.Mutex)
+}
 
 // minSocHandler updates min soc
 func minSocHandler(site site.API) http.HandlerFunc {
@@ -129,6 +142,11 @@ func updatePlanStrategyHandler(site site.API) http.HandlerFunc {
 			jsonError(w, http.StatusBadRequest, err)
 			return
 		}
+
+		// serialize set+read-back so concurrent POSTs return their own writes
+		mu := vehicleWriteLock(vars["name"])
+		mu.Lock()
+		defer mu.Unlock()
 
 		if err := planStrategyHandlerSetter(r, v.SetPlanStrategy); err != nil {
 			jsonError(w, http.StatusBadRequest, err)


### PR DESCRIPTION
## Description

Concurrent `POST /api/vehicles/{id}/plan/strategy` requests race between
`SetPlanStrategy` and the read-back `GetPlanStrategy`, so a client can
receive a strategy value committed by a *different* concurrent request.

Reproduction (from #29922): firing two parallel POSTs with distinct
`precondition` values and reading back `effectivePlanStrategy.precondition`
yields 2nd-write-wins in ~7-9 of 10 iterations, with the occasional
1st-write-wins — i.e. the response a client gets does not reliably reflect
its own write.

## Fix

Add a per-vehicle `sync.Mutex` (keyed by vehicle name via `sync.Map`) around
the decode → set → read-back sequence in `updatePlanStrategyHandler`, so it is
atomic from a single vehicle's perspective without serializing writes to other
vehicles.

Closes #29922