### PR TITLE
fix(cmd/token): allow token generation when the template requires the very tokens

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/evcc-io/evcc/util/config"
@@ -16,6 +17,10 @@ var tokenCmd = &cobra.Command{
 	Short: "Generate token credentials",
 	Run:   runToken,
 }
+
+// psaBrands lists the PSA group brands whose token flow needs only the brand
+// name — no rendered vehicle config — so it can run before any tokens exist.
+var psaBrands = []string{"citroen", "ds", "opel", "peugeot"}
 
 func init() {
 	rootCmd.AddCommand(tokenCmd)
@@ -32,29 +37,49 @@ func runToken(cmd *cobra.Command, args []string) {
 		log.FATAL.Fatal(err)
 	}
 
-	if err := configureVehicles(conf.Vehicles, args...); err != nil {
-		log.FATAL.Fatal(err)
+	if len(args) == 0 {
+		log.FATAL.Fatal("vehicle name required")
 	}
 
-	vehicles := config.Vehicles().Devices()
+	// resolve vehicle configs directly from YAML — configureVehicles would
+	// instantiate them and fail validation on the very accessToken/refreshToken
+	// fields we are about to generate (evcc-io/evcc#29864).
+	var targets []config.Named
+	for _, cc := range conf.Vehicles {
+		if slices.Contains(args, cc.Name) {
+			targets = append(targets, cc)
+		}
+	}
+	if len(targets) == 0 {
+		log.FATAL.Fatalf("no matching vehicle in config: %v", args)
+	}
 
-	for _, dev := range vehicles {
-		vehicleConf := dev.Config()
-
+	for _, vehicleConf := range targets {
 		var token *oauth2.Token
 		var err error
 
 		isTemplate := strings.ToLower(vehicleConf.Type) == "template"
-		if isTemplate {
-			instance, err := templates.RenderInstance(templates.Vehicle, vehicleConf.Other)
-			if err != nil {
-				log.FATAL.Fatalf("rendering template failed: %v", err)
-			}
-			vehicleConf.Type = instance.Type
-			vehicleConf.Other = instance.Other
-		}
-
 		typ := strings.ToLower(vehicleConf.Type)
+
+		if isTemplate {
+			tplName, _ := vehicleConf.Other["template"].(string)
+			tplLower := strings.ToLower(tplName)
+
+			// PSA token flow needs only the brand — skip template rendering so
+			// that missing accessToken/refreshToken (the values we are about
+			// to create) don't trip required-field validation.
+			if slices.Contains(psaBrands, tplLower) {
+				typ = tplLower
+			} else {
+				instance, errR := templates.RenderInstance(templates.Vehicle, vehicleConf.Other)
+				if errR != nil {
+					log.FATAL.Fatalf("rendering template failed: %v", errR)
+				}
+				vehicleConf.Type = instance.Type
+				vehicleConf.Other = instance.Other
+				typ = strings.ToLower(instance.Type)
+			}
+		}
 
 		switch typ {
 		case "ford", "ford-connect":


### PR DESCRIPTION
## Description

`evcc token <name>` fails for PSA brands (Peugeot/Citroën/DS/Opel) with
`missing required accessToken/refreshToken`. The command instantiates the
configured vehicle through the validating path, which rejects the missing
`accessToken`/`refreshToken` — the exact fields the user is running the
command to generate. Chicken-and-egg: you need the tokens to create the
vehicle, but you run the command to get the tokens.

See #29864.

## Fix

Resolve the target vehicles directly from the YAML config without going
through the validating instantiation. For PSA brands the brand name alone
is enough for the OAuth flow, so template rendering (which would validate
the missing tokens) is skipped; other providers keep their existing render
path.

Closes #29864