### PR TITLE
fix(core): wake vehicle on ErrAsleep for vehicle-api charger

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1983,6 +1983,20 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	// read and publish status
 	welcomeCharge, err := lp.updateChargerStatus()
 	if err != nil {
+		// Vehicle-API charger surfaces "vehicle is asleep" as api.ErrAsleep
+		// via Status(). Without dedicated handling we'd early-return forever
+		// and the plan deadline would silently slip (evcc-io/evcc#28652).
+		// Drive the existing wake-up timer ourselves when a plan is active.
+		if errors.Is(err, api.ErrAsleep) && lp.planActive {
+			lp.startWakeUpTimer()
+			switch lp.wakeUpTimer.Elapsed() {
+			case WakeUpTimerElapsed:
+				lp.wakeUpVehicle()
+			case WakeUpTimerFinished:
+				lp.pushEvent(evVehicleAsleep)
+			}
+			return
+		}
 		lp.log.ERROR.Println(err)
 		return
 	}


### PR DESCRIPTION
## Description

With a vehicle-api charger (e.g. Tesla via Fleet API) the vehicle itself is
the source of charger status. When the vehicle sleeps,
`updateChargerStatus()` returns `api.ErrAsleep` and `Update()` logs the
error and early-returns — every cycle. The wake-up logic further down in
`Update()` is therefore never reached, so an active charging plan never
runs and its deadline silently slips. evcc just logs `charger status:
asleep` indefinitely.

See #28652 (includes a clear root-cause analysis).

## Fix

When `updateChargerStatus()` returns `api.ErrAsleep` and a plan is active,
drive the existing `wakeUpTimer` instead of bailing out. This reuses the
established 6×30s attempt schedule and the `evVehicleAsleep` push event, so
behaviour matches the wake-up path used elsewhere.

Closes #28652