### PR TITLE
fix(tariff): clamp configurable tariff interval to a safe floor

### DIFF
--- a/tariff/tariff.go
+++ b/tariff/tariff.go
@@ -24,6 +24,17 @@ type Tariff struct {
 
 var _ api.Tariff = (*Tariff)(nil)
 
+// Safety floors for the configurable tariff loop. Some providers (pvnode,
+// solcast) enforce strict monthly quotas (e.g. 1000 req / month). A
+// misconfigured interval — say 1m instead of 1h — has previously generated
+// thousands of requests within seconds and locked accounts out for the rest
+// of the month (evcc-io/evcc#29682). These constants enforce a hard minimum
+// and a warning threshold regardless of user input.
+const (
+	minTariffInterval  = 1 * time.Minute
+	warnTariffInterval = 15 * time.Minute
+)
+
 func init() {
 	registry.AddCtx(api.Custom, NewConfigurableFromConfig)
 }
@@ -47,6 +58,16 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.T
 
 	if (cc.Price != nil) == (cc.Forecast != nil) {
 		return nil, fmt.Errorf("must have either price or forecast")
+	}
+
+	// guard against accidental misconfiguration that can exhaust a provider's
+	// monthly quota in seconds — see comment on minTariffInterval above.
+	log := util.NewLogger("tariff")
+	if cc.Interval > 0 && cc.Interval < minTariffInterval {
+		log.ERROR.Printf("interval %s is below the safety floor %s — clamping; tighten only after confirming your provider's rate limit", cc.Interval, minTariffInterval)
+		cc.Interval = minTariffInterval
+	} else if cc.Interval > 0 && cc.Interval < warnTariffInterval {
+		log.WARN.Printf("interval %s is short — rate-limited providers (pvnode, solcast) may lock you out", cc.Interval)
 	}
 
 	if err := cc.init(); err != nil {


### PR DESCRIPTION
## Description

A misconfigured `interval` on the configurable tariff loop (e.g. a few
minutes instead of hours) can exhaust a rate-limited provider's monthly
quota within seconds. pvnode/solcast then lock the account for the rest of
the month. Reported in #29682 (changing the solar-forecast interval and
restarting produced a flood of "too many requests" errors).

## Fix

Enforce a hard minimum interval of 1m on the configurable tariff loop, and
warn when below 15m. This is defence in depth against the misuse pattern —
it does not address the underlying request-burst behaviour in the HTTP
plugin layer, which warrants separate investigation.

Refs #29682