### PR TITLE
fix(server): don't wake the vehicle on config-UI status polling (Hyundai 12V drain)

### DIFF
--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -276,7 +276,12 @@ func deviceStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonWrite(w, testInstance(instance))
+	// Vehicle test results must be passive — every Soc/Range/Status/Odometer
+	// call wakes the car's telematics module and drains the 12V battery for
+	// APIs like Hyundai Bluelink. The config UI polls this endpoint every
+	// ~30s, so previously a single open browser tab could kill a 12V battery
+	// overnight (evcc-io/evcc#30006).
+	jsonWrite(w, testInstance(instance, class == templates.Vehicle))
 }
 
 func newDevice[T any](ctx context.Context, class templates.Class, req configReq, newFromConf newFromConfFunc[T], h config.Handler[T], force bool) (*config.Config, error) {

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -253,9 +253,18 @@ func hasFeature(instance any, f api.Feature) bool {
 	return ok && slices.Contains(fd.Features(), f)
 }
 
-// testInstance tests the given instance similar to dump
+// testInstance tests the given instance similar to dump.
+//
+// When passiveOnly is true (currently only for vehicle polling from the config
+// UI), every getter that triggers a remote API call is skipped — only static
+// capability markers are returned. This prevents the 30s background poll in
+// `Config.vue:updateValues()` from waking the car's telematics module on every
+// tick, which previously drained the 12V battery overnight for Hyundai/Kia
+// Bluelink users (evcc-io/evcc#30006).
+//
 // TODO refactor together with dump
-func testInstance(instance any) map[string]testResult {
+func testInstance(instance any, passiveOnly ...bool) map[string]testResult {
+	passive := len(passiveOnly) > 0 && passiveOnly[0]
 	res := make(map[string]testResult)
 
 	makeResult := func(key string, val any, err error) {
@@ -269,23 +278,36 @@ func testInstance(instance any) map[string]testResult {
 		res[key] = tr
 	}
 
+	// hot marks a capability that costs an upstream API call — skipped in passive mode.
+	hot := func(key string, val any, err error) {
+		if passive {
+			res[key] = testResult{Value: nil}
+			return
+		}
+		makeResult(key, val, err)
+	}
+
 	if dev, ok := api.Cap[api.Meter](instance); ok {
 		val, err := dev.CurrentPower()
-		makeResult("power", val, err)
+		hot("power", val, err)
 	}
 
 	if dev, ok := api.Cap[api.MeterEnergy](instance); ok {
 		val, err := dev.TotalEnergy()
-		makeResult("energy", val, err)
+		hot("energy", val, err)
 	}
 
 	if dev, ok := api.Cap[api.Battery](instance); ok {
-		val, err := dev.Soc()
 		key := "soc"
 		if hasFeature(instance, api.Heating) {
 			key = "temp"
 		}
-		makeResult(key, val, err)
+		if passive {
+			res[key] = testResult{Value: nil}
+		} else {
+			val, err := dev.Soc()
+			makeResult(key, val, err)
+		}
 	}
 
 	if api.HasCap[api.BatteryController](instance) {
@@ -294,7 +316,7 @@ func testInstance(instance any) map[string]testResult {
 
 	if dev, ok := api.Cap[api.VehicleOdometer](instance); ok {
 		val, err := dev.Odometer()
-		makeResult("odometer", val, err)
+		hot("odometer", val, err)
 	}
 
 	if dev, ok := api.Cap[api.BatteryCapacity](instance); ok {
@@ -304,32 +326,32 @@ func testInstance(instance any) map[string]testResult {
 
 	if dev, ok := api.Cap[api.PhaseCurrents](instance); ok {
 		i1, i2, i3, err := dev.Currents()
-		makeResult("phaseCurrents", []float64{i1, i2, i3}, err)
+		hot("phaseCurrents", []float64{i1, i2, i3}, err)
 	}
 
 	if dev, ok := api.Cap[api.PhaseVoltages](instance); ok {
 		u1, u2, u3, err := dev.Voltages()
-		makeResult("phaseVoltages", []float64{u1, u2, u3}, err)
+		hot("phaseVoltages", []float64{u1, u2, u3}, err)
 	}
 
 	if dev, ok := api.Cap[api.PhasePowers](instance); ok {
 		p1, p2, p3, err := dev.Powers()
-		makeResult("phasePowers", []float64{p1, p2, p3}, err)
+		hot("phasePowers", []float64{p1, p2, p3}, err)
 	}
 
 	if dev, ok := api.Cap[api.ChargeState](instance); ok {
 		val, err := dev.Status()
-		makeResult("chargeStatus", val, err)
+		hot("chargeStatus", val, err)
 	}
 
 	if dev, ok := api.Cap[api.Charger](instance); ok {
 		val, err := dev.Enabled()
-		makeResult("enabled", val, err)
+		hot("enabled", val, err)
 	}
 
 	if dev, ok := api.Cap[api.ChargeRater](instance); ok {
 		val, err := dev.ChargedEnergy()
-		makeResult("chargedEnergy", val, err)
+		hot("chargedEnergy", val, err)
 	}
 
 	if api.HasCap[api.PhaseSwitcher](instance) {
@@ -354,31 +376,35 @@ func testInstance(instance any) map[string]testResult {
 
 	if dev, ok := api.Cap[api.VehicleRange](instance); ok {
 		val, err := dev.Range()
-		makeResult("range", val, err)
+		hot("range", val, err)
 	}
 
 	if dev, ok := api.Cap[api.SocLimiter](instance); ok {
-		val, err := dev.GetLimitSoc()
 		key := "vehicleLimitSoc"
 		if hasFeature(instance, api.Heating) {
 			key = "heaterTempLimit"
 		}
-		makeResult(key, val, err)
+		if passive {
+			res[key] = testResult{Value: nil}
+		} else {
+			val, err := dev.GetLimitSoc()
+			makeResult(key, val, err)
+		}
 	}
 
 	if dev, ok := api.Cap[api.Dimmer](instance); ok {
 		val, err := dev.Dimmed()
-		makeResult("dimmed", val, err)
+		hot("dimmed", val, err)
 	}
 
 	if dev, ok := api.Cap[api.Curtailer](instance); ok {
 		val, err := dev.Curtailed()
-		makeResult("curtailed", val, err)
+		hot("curtailed", val, err)
 	}
 
 	if dev, ok := api.Cap[api.Identifier](instance); ok {
 		val, err := dev.Identify()
-		makeResult("identifier", val, err)
+		hot("identifier", val, err)
 	}
 
 	if dev, ok := api.Cap[api.Tariff](instance); ok {


### PR DESCRIPTION
## Description

The config UI polls `GET /api/config/devices/{class}/{name}/status` every
~30s for every device. For vehicles, `testInstance()` then calls Soc,
Range, Status, Odometer and LimitSoc — five getters. On Hyundai/Kia
Bluelink (older non-CCS2 API) each of those triggers `/vehicles/{id}/status`,
which wakes the car's telematics module. With a config tab left open this
drains the 12V auxiliary battery overnight — reported dead in 6-8h in
#30006 (and corroborated by other users in the thread who noticed the car
updating whenever the config page is open).

## Fix

Add a `passiveOnly` mode to `testInstance`, used for vehicle status polling
from the config UI. In this mode the capability markers are still reported
(so the UI knows the vehicle exposes SoC, range, etc.) but the getters that
hit the upstream API are skipped. The interactive "Test connection" path
used during device setup keeps the full behaviour.

Refs #30006