### PR TITLE
MQTT: serialize resubscribe after reconnect

### DIFF
--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -135,12 +135,24 @@ func (m *Client) ConnectionHandler(client paho.Client) {
 	m.log.DEBUG.Printf("%s connected", m.broker)
 
 	m.mux.Lock()
-	defer m.mux.Unlock()
-
+	topics := make([]string, 0, len(m.listener))
 	for topic := range m.listener {
-		m.log.DEBUG.Printf("%s subscribe %s", m.broker, topic)
-		go m.listen(topic)
+		topics = append(topics, topic)
 	}
+	m.mux.Unlock()
+
+	// Resubscribe sequentially to avoid bursting the broker right after reconnect.
+	go func() {
+		for _, topic := range topics {
+			m.log.DEBUG.Printf("%s subscribe %s", m.broker, topic)
+			token := m.listen(topic)
+			if !token.WaitTimeout(request.Timeout) {
+				m.log.ERROR.Printf("subscribe %s: timeout", topic)
+			} else if err := token.Error(); err != nil {
+				m.log.ERROR.Printf("subscribe %s: %v", topic, err)
+			}
+		}
+	}()
 }
 
 // Cleanup recursively removes a topic


### PR DESCRIPTION
Related: #30086

## Problem

After every MQTT reconnect, `ConnectionHandler` fans out one goroutine per topic calling `client.Subscribe()`. In a typical multi-loadpoint configuration that's ~60 SUBSCRIBE packets fired simultaneously at the just-restored TCP connection. Combined with publish bursts also in flight, this can RST the link again under load and turn a one-off disconnect into a reconnect storm (see the log in #30086).

## Fix

Snapshot the listener set under the mutex, then resubscribe sequentially in a single goroutine so:

1. paho's connect callback returns quickly to its event loop.
2. The broker sees SUBSCRIBE packets one at a time.
3. Subscribe failures are surfaced instead of silently dropped.

## Test plan

- [ ] Restart evcc against a broker with many retained setter topics — log should show subscribes one per line without subsequent connection drops.
- [ ] Force a broker restart while evcc is running — verify a single, ordered resubscribe sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)