### PR TITLE
MQTT: cleanup deletes at QoS 0, synchronously

### DIFF
--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -154,7 +154,11 @@ func (m *Client) Cleanup(topic string, retained bool) error {
 		}
 
 		m.log.TRACE.Printf("delete: %s", msg.Topic())
-		m.Publish(msg.Topic(), true, "")
+		// Delete synchronously at QoS 0 so the cleanup burst self-throttles
+		// to one in-flight message at a time and avoids overwhelming the
+		// broker (see #30086).
+		token := m.client.Publish(msg.Topic(), 0, true, "")
+		token.WaitTimeout(request.Timeout)
 
 		// reset timeout
 		timer.Reset(time.Second)


### PR DESCRIPTION
Related: #30086

## Problem

`Cleanup()` walks every retained topic under the evcc root and calls `m.Publish(topic, retained, \"\")` to delete it. `Publish()` is async: it spawns a goroutine per call and uses a 128-deep inflight semaphore. The publish QoS is hardcoded to **1** in evcc (see `cmd/setup.go`).

With a long-running install that has accumulated a few hundred retained topics under `evcc/...` — common when eebus, influx and several loadpoints/vehicles are configured — the cleanup burst overwhelms the broker with QoS 1 sends. The broker RSTs the connection, paho reconnects, evcc re-cleans on connect, and a reconnect storm follows. This is the trigger that #30086 hits.

## Fix

Publish deletes **synchronously** at **QoS 0** directly via paho:

\`\`\`go
token := m.client.Publish(msg.Topic(), 0, true, \"\")
token.WaitTimeout(request.Timeout)
\`\`\`

Because paho delivers subscribe callbacks in order (\`OrderMatters\` default = true), waiting inside the callback throttles deletes to one in-flight at a time. QoS 0 is fine here: deletes are idempotent and the next boot's cleanup catches any stragglers.

## Test plan

- [ ] Configure mosquitto, evcc, accumulate retained state (eebus + a few loadpoints + vehicles).
- [ ] Restart evcc — observe in mosquitto log that deletes arrive one at a time at QoS 0.
- [ ] Verify no \`write: broken pipe\` / \`connection reset by peer\` on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)