### PR TITLE
Cupra: keep plugged "NotReadyForCharging" as connected status

### DIFF
--- a/vehicle/seat/cupra/provider.go
+++ b/vehicle/seat/cupra/provider.go
@@ -66,16 +66,24 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		return api.StatusNone, err
 	}
 
+	// BatteryCardStatus is the authoritative disconnect signal — the Cupra API
+	// only emits "notConnected" when the cable is unplugged. When the car is
+	// plugged the field is omitted and Status alone is unreliable: it reports
+	// "NotReadyForCharging" both for an unplugged car and for a plugged car
+	// whose charging is paused (e.g. chargeMode=off), so treating that value
+	// as disconnected breaks vehicle identification when several cars are in
+	// one account.
 	// https://github.com/evcc-io/evcc/issues/30045
+	// https://github.com/evcc-io/evcc/issues/30118
 	if strings.ToLower(res.Services.Charging.BatteryCardStatus) == "notconnected" {
 		return api.StatusA, nil
 	}
 
 	switch strings.ToLower(res.Services.Charging.Status) {
-	case "connected", "readyforcharging", "error":
-		return api.StatusB, nil
 	case "charging":
 		return api.StatusC, nil
+	case "connected", "readyforcharging", "notreadyforcharging", "error":
+		return api.StatusB, nil
 	}
 
 	return api.StatusA, nil

--- a/vehicle/seat/cupra/provider.go
+++ b/vehicle/seat/cupra/provider.go
@@ -74,16 +74,15 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	// as disconnected breaks vehicle identification when several cars are in
 	// one account.
 	// https://github.com/evcc-io/evcc/issues/30045
-	// https://github.com/evcc-io/evcc/issues/30118
 	if strings.ToLower(res.Services.Charging.BatteryCardStatus) == "notconnected" {
 		return api.StatusA, nil
 	}
 
 	switch strings.ToLower(res.Services.Charging.Status) {
-	case "charging":
-		return api.StatusC, nil
 	case "connected", "readyforcharging", "notreadyforcharging", "error":
 		return api.StatusB, nil
+	case "charging":
+		return api.StatusC, nil
 	}
 
 	return api.StatusA, nil

--- a/vehicle/seat/cupra/provider.go
+++ b/vehicle/seat/cupra/provider.go
@@ -69,10 +69,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 	// BatteryCardStatus is the authoritative disconnect signal — the Cupra API
 	// only emits "notConnected" when the cable is unplugged. When the car is
 	// plugged the field is omitted and Status alone is unreliable: it reports
-	// "NotReadyForCharging" both for an unplugged car and for a plugged car
-	// whose charging is paused (e.g. chargeMode=off), so treating that value
-	// as disconnected breaks vehicle identification when several cars are in
-	// one account.
+	// "NotReadyForCharging" both for an unplugged car.
 	// https://github.com/evcc-io/evcc/issues/30045
 	if strings.ToLower(res.Services.Charging.BatteryCardStatus) == "notconnected" {
 		return api.StatusA, nil

--- a/vehicle/seat/cupra/provider_test.go
+++ b/vehicle/seat/cupra/provider_test.go
@@ -1,0 +1,53 @@
+package cupra
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProviderStatus covers the Cupra v5 charging-status payload variants
+// captured in issues #30045 and #30118.
+func TestProviderStatus(t *testing.T) {
+	cases := []struct {
+		name              string
+		statusField       string
+		batteryCardStatus string
+		want              api.ChargeStatus
+	}{
+		// cable not plugged in: API emits batteryCardStatus=notConnected
+		{"unplugged", "NotReadyForCharging", "notConnected", api.StatusA},
+		// charging: API omits batteryCardStatus
+		{"charging", "Charging", "", api.StatusC},
+		// plugged but not charging (e.g. chargeMode=off): API omits
+		// batteryCardStatus, Status reports NotReadyForCharging — must NOT be
+		// misread as disconnected (#30118)
+		{"plugged_paused", "NotReadyForCharging", "", api.StatusB},
+		// plugged, ready to charge but not yet started
+		{"ready", "ReadyForCharging", "", api.StatusB},
+		// already-connected pre-v5 payload
+		{"connected", "Connected", "", api.StatusB},
+		// fault / error while plugged
+		{"error", "error", "", api.StatusB},
+		// unknown future status with no card info defaults to disconnected
+		{"unknown", "SomethingNew", "", api.StatusA},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Status
+			s.Services.Charging.Status = tc.statusField
+			s.Services.Charging.BatteryCardStatus = tc.batteryCardStatus
+
+			v := &Provider{
+				statusG: func() (Status, error) { return s, nil },
+			}
+
+			got, err := v.Status()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/30118

## Cupra status mapping

Fixes the vehicle-identification loop reported in #30118: when several Cupras share one account and one is plugged, evcc returns 0 matches and never assigns a vehicle.

### Root cause

In the Cupra v5 `mycar` payload, `batteryCardStatus` is **only emitted as `"notConnected"` when the cable is unplugged** — when the car is plugged in the field is omitted. The `Status` field alone is unreliable: it reports `"NotReadyForCharging"` both for an unplugged car _and_ for a plugged car whose charging is paused (e.g. `chargeMode=off`).

Payloads (from #30045):

| state | `status` | `batteryCardStatus` |
|---|---|---|
| unplugged | `NotReadyForCharging` | `notConnected` |
| charging | `Charging` | _omitted_ |
| plugged, paused | `NotReadyForCharging` | _omitted_ |

The previous fix (#30046) maps the third row to `StatusA`, so vehicle identification can never distinguish the plugged car from the unplugged ones — both look disconnected — and the loadpoint stays at "Fahrzeug wird identifiziert…" forever.

### Fix

Treat `batteryCardStatus == "notConnected"` as the authoritative disconnect signal and add `notreadyforcharging` to the connected-status switch so a plugged-but-paused car is reported as `StatusB`.

`Status.Charging` is checked first so an active charging session still produces `StatusC` even if `batteryCardStatus` ever starts appearing as `"connected"` in future API revisions.

### Test coverage

New `vehicle/seat/cupra/provider_test.go` exercises the three observed payloads plus a few neighbouring states (Connected / ReadyForCharging / error / unknown).

### Caveat

Per @andig's comment on #30118, the 403 Forbidden on the OLA garage endpoint reported in the issue thread is a separate concern (the missing-headers fix shipped in #30105 may need follow-up). This PR is just the status-mapping correction — it does not address the 403.

Refs #30118

🤖 Generated with [Claude Code](https://claude.com/claude-code)