### PR TITLE
MQTT: lower parallelInflightLimit from 128 to 32

### DIFF
--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -20,7 +20,7 @@ import (
 // Instance is the paho Mqtt client singleton
 var Instance *Client
 
-const parallelInflightLimit int64 = 128
+const parallelInflightLimit int64 = 32
 
 // ClientID created unique mqtt client id
 func ClientID() string {


### PR DESCRIPTION
Related: #30086

## Problem

The publish path uses a 128-deep semaphore (`parallelInflightLimit`) to cap concurrent goroutines. But 128 simultaneous QoS 1 publishes from one client exceed mosquitto's per-client `max_inflight_messages` (default **20**) by ~6×. The broker queues internally, falls behind on PUBACKs, and under sustained burst RSTs the connection — exactly the reconnect storm reproduced in #30086.

Cleanup (already shipped in #30139) was the worst offender; the remaining cliff is normal startup + reconnect republishing.

## Fix

Drop the constant from 128 to 32. That stays a small margin above the default broker inflight cap so a healthy broker isn't unnecessarily throttled, while keeping the worst-case burst within an order of magnitude of what mosquitto expects.

QoS semantics are unchanged — at-least-once delivery is preserved for both state broadcasts and `/set` ACKs.

## Test plan

- [ ] Restart evcc against mosquitto with several loadpoints / vehicles configured — confirm no `connection reset by peer` cascade at boot.
- [ ] `mosquitto -v` and watch for the broker's internal queue not filling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)