### PR TITLE
MQTT: cancel in-flight publishes on disconnect

### DIFF
--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -48,6 +48,10 @@ type Client struct {
 	Qos      byte
 	listener map[string][]func(string)
 	inflight *semaphore.Weighted
+
+	connMu     sync.Mutex
+	connCtx    context.Context
+	connCancel context.CancelFunc
 }
 
 type Option func(*paho.ClientOptions)
@@ -125,14 +129,45 @@ func NewClient(log *util.Logger, broker, user, password, clientID string, qos by
 	return mc, nil
 }
 
+// connContext returns a context that is cancelled on disconnect and replaced
+// on every reconnect. Pending publishes use it to bail out if the connection
+// that scheduled them has gone away.
+func (m *Client) connContext() context.Context {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	if m.connCtx == nil {
+		return context.Background()
+	}
+	return m.connCtx
+}
+
+func (m *Client) renewConnContext() {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	if m.connCancel != nil {
+		m.connCancel()
+	}
+	m.connCtx, m.connCancel = context.WithCancel(context.Background())
+}
+
+func (m *Client) cancelConnContext() {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	if m.connCancel != nil {
+		m.connCancel()
+	}
+}
+
 // ConnectionLostHandler logs cause of connection loss as warning
 func (m *Client) ConnectionLostHandler(client paho.Client, reason error) {
 	m.log.ERROR.Printf("%s connection lost: %v", m.broker, reason.Error())
+	m.cancelConnContext()
 }
 
 // ConnectionHandler restores listeners
 func (m *Client) ConnectionHandler(client paho.Client) {
 	m.log.DEBUG.Printf("%s connected", m.broker)
+	m.renewConnContext()
 
 	m.mux.Lock()
 	defer m.mux.Unlock()
@@ -178,24 +213,35 @@ func (m *Client) Cleanup(topic string, retained bool) error {
 
 // Publish asynchronously publishes payload using client qos
 func (m *Client) Publish(topic string, retained bool, payload any) {
+	connCtx := m.connContext()
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+		ctx, cancel := context.WithTimeout(connCtx, request.Timeout)
 		defer cancel()
 		if err := m.inflight.Acquire(ctx, 1); err != nil {
-			m.log.ERROR.Printf("send %s: %v", topic, err)
+			if connCtx.Err() == nil {
+				m.log.ERROR.Printf("send %s: %v", topic, err)
+			}
 			return
 		}
 		defer m.inflight.Release(1)
 
+		// Bail out if the connection that scheduled this publish has been lost.
+		if connCtx.Err() != nil {
+			return
+		}
+
 		m.log.TRACE.Printf("send %s: '%v'", topic, payload)
 		token := m.client.Publish(topic, m.Qos, retained, payload)
 
-		err := api.ErrTimeout
-		if token.WaitTimeout(request.Timeout) {
-			err = token.Error()
-		}
-		if err != nil {
-			m.log.ERROR.Printf("send: %s: %v", topic, err)
+		select {
+		case <-connCtx.Done():
+			return
+		case <-token.Done():
+			if err := token.Error(); err != nil {
+				m.log.ERROR.Printf("send: %s: %v", topic, err)
+			}
+		case <-time.After(request.Timeout):
+			m.log.ERROR.Printf("send: %s: timeout", topic)
 		}
 	}()
 }


### PR DESCRIPTION
Related: #30086

## Problem

`Client.Publish` spawns a goroutine per call, takes a slot on the 128-deep inflight semaphore, and waits up to `request.Timeout` for paho to deliver. When the connection drops, the goroutines started under the old connection keep running: they wake up, paho is mid-reconnect or already closed, and the publish fails with `use of closed network connection` / `broken pipe` / `connection reset by peer`. In the #30086 log this appears as a cascade of `[mqtt] ERROR send: ...` lines for every topic that was in flight at the moment of disconnect, even though nothing is actually wrong — those publishes simply lost their socket.

## Fix

Introduce a connection-scoped `context.Context`:
- renewed in `ConnectionHandler` on every reconnect,
- cancelled in `ConnectionLostHandler` on disconnect.

`Publish` captures the current context up front and observes it both while waiting for an inflight slot and while waiting for the paho token. Publishes scheduled under the old connection now bail out quickly without logging spurious socket errors. State will be republished by the main loop on the next interval anyway.

## Test plan

- [ ] Restart mosquitto while evcc is running — verify the disconnect produces a single `connection lost` line, not one error per topic in flight.
- [ ] Heavy publish load + repeated broker bounces — verify the inflight semaphore drains and steady-state resumes after each reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)