### PR TITLE
chore: upgrade gosunspec

### DIFF
--- a/cmd/sunspec.go
+++ b/cmd/sunspec.go
@@ -8,7 +8,7 @@ import (
 
 	sunspec "github.com/andig/gosunspec"
 	bus "github.com/andig/gosunspec/modbus"
-	"github.com/andig/gosunspec/smdx"
+	"github.com/andig/gosunspec/types"
 	"github.com/evcc-io/evcc/util"
 	"github.com/spf13/cobra"
 	"github.com/volkszaehler/mbmd/meters"
@@ -37,7 +37,7 @@ func pf(format string, v ...any) {
 }
 
 func modelName(m sunspec.Model) string {
-	model := smdx.GetModel(uint16(m.Id()))
+	model := types.GetModel(uint16(m.Id()))
 	if model == nil {
 		return ""
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/WulfgarW/sensonet v0.0.7
 	github.com/andig/go-powerwall v0.3.0
-	github.com/andig/gosunspec v0.0.0-20240918203654-860ce51d602b
+	github.com/andig/gosunspec v0.0.0-20260523122805-ffe05b4e20a9
 	github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e
 	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
 	github.com/aws/aws-sdk-go-v2 v1.41.5

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/WulfgarW/sensonet v0.0.7
 	github.com/andig/go-powerwall v0.3.0
-	github.com/andig/gosunspec v0.0.0-20260523122805-ffe05b4e20a9
+	github.com/andig/gosunspec v0.0.0-20260523124210-852310938891
 	github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e
 	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
 	github.com/aws/aws-sdk-go-v2 v1.41.5

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andig/go-powerwall v0.3.0 h1:6g50+8xEwxrnzoSaPsxNRpc2fld8gARk0X78NEexFGI=
 github.com/andig/go-powerwall v0.3.0/go.mod h1:Xk09mD+7RTCuuHMX5RxlqgEUeh9oZdIX0rL0qiY6l/4=
-github.com/andig/gosunspec v0.0.0-20260523122805-ffe05b4e20a9 h1:l+XjdFE4bHfabhZoQDhrO5l3EiXJ2kkdgmTpAA4vU1k=
-github.com/andig/gosunspec v0.0.0-20260523122805-ffe05b4e20a9/go.mod h1:c6P6szcR+ROkqZruOR4f6qbDKFjZX6OitPpj+yJ/r8k=
+github.com/andig/gosunspec v0.0.0-20260523124210-852310938891 h1:UpjccgGAJV7ce6SmNZn1hVvff3sZ7Fgc4v4TDjUXhkk=
+github.com/andig/gosunspec v0.0.0-20260523124210-852310938891/go.mod h1:c6P6szcR+ROkqZruOR4f6qbDKFjZX6OitPpj+yJ/r8k=
 github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e h1:m/NTP3JWpR7M0ljLxiQU4fzR25jjhe1LDtxLMNcoNJQ=
 github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e/go.mod h1:4VtYzTm//oUipwvO3yh0g/udTE7pYJM+U/kyAuFDsgM=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andig/go-powerwall v0.3.0 h1:6g50+8xEwxrnzoSaPsxNRpc2fld8gARk0X78NEexFGI=
 github.com/andig/go-powerwall v0.3.0/go.mod h1:Xk09mD+7RTCuuHMX5RxlqgEUeh9oZdIX0rL0qiY6l/4=
-github.com/andig/gosunspec v0.0.0-20240918203654-860ce51d602b h1:81UMfM949I7StrRay7YDUZazY8M1u/JHkzwcFEjiilQ=
-github.com/andig/gosunspec v0.0.0-20240918203654-860ce51d602b/go.mod h1:c6P6szcR+ROkqZruOR4f6qbDKFjZX6OitPpj+yJ/r8k=
+github.com/andig/gosunspec v0.0.0-20260523122805-ffe05b4e20a9 h1:l+XjdFE4bHfabhZoQDhrO5l3EiXJ2kkdgmTpAA4vU1k=
+github.com/andig/gosunspec v0.0.0-20260523122805-ffe05b4e20a9/go.mod h1:c6P6szcR+ROkqZruOR4f6qbDKFjZX6OitPpj+yJ/r8k=
 github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e h1:m/NTP3JWpR7M0ljLxiQU4fzR25jjhe1LDtxLMNcoNJQ=
 github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e/go.mod h1:4VtYzTm//oUipwvO3yh0g/udTE7pYJM+U/kyAuFDsgM=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
## Summary
- Bump `github.com/andig/gosunspec` from `860ce51d` (2024-09-18) to `ffe05b4e` (current master)
- Upstream renamed the SMDX model registry package from `smdx` to `types`; updated the single caller in `cmd/sunspec.go`

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./meter/... ./cmd/...` passes
- [ ] Manual `evcc sunspec <host>` dump against a SunSpec device

🤖 Generated with [Claude Code](https://claude.com/claude-code)