### PR TITLE
core: publish vehicle soc and range once on attach

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -153,6 +153,7 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 		}
 
 		lp.addTask(lp.vehicleOdometer)
+		lp.addTask(lp.vehicleSocAndRange)
 
 		lp.progress.Reset()
 	} else {
@@ -314,6 +315,32 @@ func (lp *Loadpoint) vehicleOdometer() {
 			})
 		} else if !loadpoint.AcceptableError(err) {
 			lp.log.ERROR.Printf("vehicle odometer: %v", err)
+		}
+	}
+}
+
+// vehicleSocAndRange reads soc and range once on vehicle attach so consumers
+// (UI, MQTT) see populated values even when the recurring poll gate keeps them
+// from being refreshed in the regular Update loop.
+func (lp *Loadpoint) vehicleSocAndRange() {
+	v := lp.GetVehicle()
+
+	if battery, ok := api.Cap[api.Battery](v); ok {
+		if s, err := soc.Guard(battery.Soc()); err == nil {
+			lp.log.DEBUG.Printf("vehicle soc: %.0f%%", s)
+			lp.vehicleSoc = s
+			lp.publish(keys.VehicleSoc, s)
+		} else if !loadpoint.AcceptableError(err) {
+			lp.log.ERROR.Printf("vehicle soc: %v", err)
+		}
+	}
+
+	if vs, ok := api.Cap[api.VehicleRange](v); ok {
+		if rng, err := vs.Range(); err == nil {
+			lp.log.DEBUG.Printf("vehicle range: %dkm", rng)
+			lp.publish(keys.VehicleRange, rng)
+		} else if !loadpoint.AcceptableError(err) {
+			lp.log.ERROR.Printf("vehicle range: %v", err)
 		}
 	}
 }

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -316,7 +316,7 @@ func TestDefaultVehicle(t *testing.T) {
 	lp.tasks.Clear()
 	lp.evVehicleConnectHandler()
 	assert.Equal(t, dflt, lp.vehicle, "expected default vehicle")
-	assert.Equal(t, 1, lp.tasks.Size(), "task queue length")
+	assert.Equal(t, 2, lp.tasks.Size(), "task queue length")
 
 	// guest connected
 	lp.setActiveVehicle(nil)


### PR DESCRIPTION
## Summary
Mirror the existing one-shot odometer task at `setActiveVehicle` so vehicle SoC and Range are published once when the vehicle is attached, regardless of `vehicleSocPollAllowed()`. Previously, with `poll.mode: charging` and the car unplugged, the loadpoint never read SoC/Range from the vehicle Provider, so MQTT and the UI showed `0` while the config-check button (which bypasses the gate) showed the real values.

Fixes #30124

## Test plan
- [x] `go test ./core/...` passes (existing `TestDefaultVehicle` task-queue assertion updated from 1 to 2)
- [ ] Manual: configure a Bluelink vehicle with `poll.mode: charging`, leave it unplugged, restart evcc, confirm MQTT `vehicleSoc`/`vehicleRange` are populated within one Update cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)