### PR TITLE
feat(vehicle): add Genesis Europe bluelink brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Featured in [PV Magazine](https://www.pv-magazine.de/2022/01/14/mit-open-source-
   - **sunspec**-compatible inverter or home battery devices
   - **mbmd**-compatible devices, see [volkszaehler/mbmd](https://github.com/volkszaehler/mbmd#supported-devices) for a complete list
 - [vehicle](https://docs.evcc.io/en/docs/devices/vehicles) integrations (state of charge, remote charge, battery and preconditioning status):
-  - Aiways, Audi, BMW, Citroën, Dacia, DS, Fiat, Ford, Hyundai, Jeep, Kia, Mercedes-Benz, MG, Mini, Nissan, NIU, Opel, Peugeot, Polestar, Renault, Seat, Skoda, Smart, Subaru, Tesla, Toyota, Volkswagen, Volvo, Zero Motorcycles. [Read more.](https://docs.evcc.io/en/docs/devices/vehicles)
+  - Aiways, Audi, BMW, Citroën, Dacia, DS, Fiat, Ford, Genesis, Hyundai, Jeep, Kia, Mercedes-Benz, MG, Mini, Nissan, NIU, Opel, Peugeot, Polestar, Renault, Seat, Skoda, Smart, Subaru, Tesla, Toyota, Volkswagen, Volvo, Zero Motorcycles. [Read more.](https://docs.evcc.io/en/docs/devices/vehicles)
   - **services:** OVMS, Tronity, evNotify, ioBroker.bmw, mg2mqtt, mz2mqtt, TeslaLogger, TeslaMate, Tessi, volvo2mqtt
 - [plugins](https://docs.evcc.io/en/docs/devices/plugins) for integrating with any charger, smartswitch, heatpump, electric heater, meter, solar- / battery-inverter or vehicle:
   - Modbus, HTTP, MQTT, JavaScript, WebSocket, Go and shell scripts

--- a/templates/definition/vehicle/genesis.yaml
+++ b/templates/definition/vehicle/genesis.yaml
@@ -1,0 +1,18 @@
+template: genesis
+products:
+  - brand: Genesis
+    description:
+      generic: Bluelink
+requirements:
+  description:
+    en: |
+      Instead of your account's password, the password field needs to be filled with a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).
+    de: |
+      Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).
+params:
+  - preset: vehicle-base
+  - preset: vehicle-language
+render: |
+  type: genesis
+  {{ include "vehicle-base" . }}
+  {{ include "vehicle-language" . }}

--- a/vehicle/bluelink.go
+++ b/vehicle/bluelink.go
@@ -20,6 +20,7 @@ type Bluelink struct {
 func init() {
 	registry.Add("kia", NewKiaFromConfig)
 	registry.Add("hyundai", NewHyundaiFromConfig)
+	registry.Add("genesis", NewGenesisFromConfig)
 }
 
 // NewHyundaiFromConfig creates a new vehicle
@@ -54,6 +55,24 @@ func NewKiaFromConfig(other map[string]any) (api.Vehicle, error) {
 	}
 
 	return newBluelinkFromConfig("kia", other, settings)
+}
+
+// NewGenesisFromConfig creates a new vehicle
+// Constants sourced from hyundai_kia_connect_api (KiaUvoApiEU.py, BRAND_GENESIS, Europe)
+func NewGenesisFromConfig(other map[string]any) (api.Vehicle, error) {
+	settings := bluelink.Config{
+		URI:               "https://prd-eu-ccapi.genesis.com:443",
+		CCSPServiceID:     "3020afa2-30ff-412a-aa51-d28fbe901e10",
+		CCSPServiceSecret: "FKDdlef2ffdleFEweELFKERiLER2FED21sDdwdgQz6hFESE3",
+		CCSPApplicationID: "f11f2b86-e0e7-4851-90df-5600b01d8b70",
+		Cfb:               "RFtoRq/vDXJmRndoZaZQyYo3/qFLtVReW8P7utRPcc0ZxOzOELm9mexvviBk/qqIp4A=",
+		BasicToken:        "MzAyMGFmYTItMzBmZi00MTJhLWFhNTEtZDI4ZmJlOTAxZTEwOkZLRGRsZWYyZmZkbGVGRXdlRUxGS0VSaUxFUjJGRUQyMXNEZHdkZ1F6NmhGRVNFMw==",
+		PushType:          "GCM",
+		LoginFormHost:     "https://idpconnect-eu.genesis.com",
+		Brand:             "genesis",
+	}
+
+	return newBluelinkFromConfig("genesis", other, settings)
 }
 
 // newBluelinkFromConfig creates a new Vehicle

--- a/vehicle/bluelink/identity.go
+++ b/vehicle/bluelink/identity.go
@@ -140,6 +140,7 @@ func (v *Identity) Login(user, password, language, brand string) (err error) {
 	switch brand {
 	case "kia":
 	case "hyundai":
+	case "genesis":
 	default:
 		return fmt.Errorf("unknown brand (%s)", brand)
 	}


### PR DESCRIPTION
Adds `genesis` as a vehicle brand using the same Bluelink/CCS EU backend as Kia and Hyundai.

### What
- `vehicle/bluelink.go`: register `genesis` + `NewGenesisFromConfig` with the Genesis Europe CCS constants
- `vehicle/bluelink/identity.go`: allow `genesis` in the login brand switch
- `templates/definition/vehicle/genesis.yaml`: config UI template (Genesis · Bluelink)
- `README.md`: add Genesis to the supported vehicle list

### Notes
- Brand constants (host, ccsp service id/secret, app id, cfb, basic token, login form host, push type) are taken from `hyundai_kia_connect_api` (`KiaUvoApiEU.py`, `BRAND_GENESIS`, Europe).
- The existing refresh-token login path is reused unchanged — as with Kia/Hyundai (EU), the password field holds a `refresh_token` (see the wiki).

### Testing
- Verified live against a Genesis G80 Electrified (EU): auth, vehicle list and status (SoC, range, odometer) all OK.
- `go test ./vehicle/ -run TestTemplates/genesis` passes; gofmt/vet/build clean.
