### PR TITLE
Atmoce: remove modbus rs485/rtu

### DIFF
--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -14,8 +14,7 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: modbus
-    choice: ["rs485", "tcpip"]
-    baudrate: 9600
+    choice: ["tcpip"]
     id: 1
   - name: maxacpower
     advanced: true


### PR DESCRIPTION
Turned out the rs485 connection on MG100 is only for use between Atmoce components, so removed from template.