### PR TITLE
OCPP: survive mid-setup disconnect on buggy chargers (#30113)

### DIFF
--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
@@ -210,6 +211,27 @@ func (cp *CP) Connected() bool {
 
 func (cp *CP) HasConnected() <-chan struct{} {
 	return cp.connectC
+}
+
+// waitConnected blocks until the charge point is connected (i.e. a
+// BootNotification has been received after the most recent disconnect).
+// Returns immediately if already connected, otherwise waits for the next
+// BootNotification on the coalescing request channel, bounded by Timeout.
+func (cp *CP) waitConnected(ctx context.Context) error {
+	if cp.Connected() {
+		return nil
+	}
+
+	cp.log.DEBUG.Printf("charge point disconnected, waiting for reconnect")
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(Timeout):
+		return api.ErrTimeout
+	case <-cp.bootNotificationRequestC:
+		return nil
+	}
 }
 
 // MonitorReboot ensures the given function runs only once per CP instance.

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -239,3 +239,29 @@ func TestMonitorRebootOnlyOnce(t *testing.T) {
 	require.Eventually(t, func() bool { return callCount.Load() == 1 }, time.Second, 10*time.Millisecond,
 		"setup should be called exactly once")
 }
+
+func TestWaitConnectedReturnsImmediatelyWhenConnected(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	cp.connect(true)
+	require.NoError(t, cp.waitConnected(t.Context()))
+}
+
+func TestWaitConnectedResumesOnReconnectBoot(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	// not connected, simulates the CP having dropped mid-setup
+	require.False(t, cp.Connected())
+
+	// schedule a reconnect's BootNotification after a short delay
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_, _ = cp.OnBootNotification(&core.BootNotificationRequest{
+			ChargePointModel: "TestModel",
+		})
+	}()
+
+	require.NoError(t, cp.waitConnected(t.Context()))
+}

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -18,6 +18,13 @@ func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.
 		cp.log.DEBUG.Printf("failed configuring availability: %v", err)
 	}
 
+	// Some chargers (e.g. EN+/EVSEDO FW 1.1.805, issue #30113) hang on ChangeAvailability
+	// and drop the WebSocket. Without this, every subsequent request fails with
+	// "no client exists" and aborts charger creation fatally.
+	if err := cp.waitConnected(ctx); err != nil {
+		return err
+	}
+
 	// auto configuration
 	desiredMeasurands := "Power.Active.Import,Energy.Active.Import.Register,Current.Import,Voltage,Current.Offered,Power.Offered,SoC"
 

--- a/charger/ocpp/helper.go
+++ b/charger/ocpp/helper.go
@@ -31,6 +31,11 @@ func wait(err error, rc chan error) error {
 		if oe, ok := errors.AsType[*ocpp.Error](err); ok && oe.Code == ocppj.GenericError {
 			err = api.ErrTimeout
 		}
+	} else if strings.Contains(err.Error(), "no client") {
+		// The ocpp-go dispatcher returns "cannot send request ..., no client ... exists"
+		// when the CP disconnected before the request could be queued. Treat as transient
+		// timeout so callers can react to a reconnect instead of aborting setup fatally.
+		err = api.ErrTimeout
 	}
 	return err
 }

--- a/charger/ocpp/helper_test.go
+++ b/charger/ocpp/helper_test.go
@@ -1,12 +1,21 @@
 package ocpp
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestWaitMapsNoClientToTimeout(t *testing.T) {
+	// dispatcher returns this verbatim when the CP disconnected before the request could be queued
+	err := errors.New("cannot send request 4711, no client ABC123 exists")
+	got := wait(err, nil)
+	assert.ErrorIs(t, got, api.ErrTimeout)
+}
 
 func TestSortByAge(t *testing.T) {
 	assert.Equal(t, []types.MeterValue{


### PR DESCRIPTION
## Summary

Follow-up to #30137 — the boot-notification coalescing fix landed but did **not** address the actual root cause reported in #30113. The EN+ wallbox (FW 1.1.805) hangs on `ChangeAvailability(connectorId=0, Operative)` and drops the WebSocket after 31 s. evcc's `Setup()` then continued with `GetConfiguration`, which the ocpp-go dispatcher rejected with `cannot send request …, no client SN10052201194090 exists` because the client was already removed on disconnect. That error escaped `Setup()` as a fatal config error → `[main] FATAL` → 15-min restart loop.

The reporter confirmed the nightly with #30137 still fatals: https://github.com/evcc-io/evcc/issues/30113#issuecomment-4526040187

## Fix

Two small, independent changes make `Setup()` survive a mid-setup CP disconnect:

1. **`helper.go`** — map the dispatcher's `"no client … exists"` send-side error to `api.ErrTimeout`, matching the existing `GenericError → ErrTimeout` convention. The CP being gone is a transient condition, not a configuration failure.

2. **`cp_setup.go`** — after the (already non-fatal) `ChangeAvailability` call, if `cp.Connected()` is `false`, wait (bounded by `Timeout`) for the next `BootNotification` on the request channel before continuing. With #30137's coalescing this reliably picks up the post-crash reconnect's boot, so `Setup()` can finish instead of cascading to a fatal.

A small `waitConnected(ctx)` helper on `*CP` encapsulates the wait so it can be reused by any future site that needs the same semantics.

## Tests

- `TestWaitMapsNoClientToTimeout` — regression for the dispatcher error mapping.
- `TestWaitConnectedReturnsImmediatelyWhenConnected` — short-circuit path.
- `TestWaitConnectedResumesOnReconnectBoot` — wakes up on the next `BootNotification`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./charger/ocpp/`
- [x] `go test ./charger/ocpp/`
- [x] `go test ./charger/ -run TestOcpp`
- [ ] Reporter to confirm on next nightly that EN+ wallbox no longer triggers `FATAL … no client … exists` and proceeds past `ChangeAvailability` after the wallbox auto-reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)