### PR TITLE
Metrics: tolerate NULL energy buckets in importProfile

### DIFF
--- a/core/metrics/db_profile.go
+++ b/core/metrics/db_profile.go
@@ -18,7 +18,10 @@ func importProfile(entity entity, from time.Time) (*[96]float64, error) {
 		return nil, err
 	}
 
-	rows, err := db.Query(`SELECT min(ts) AS ts, avg(energy) AS energy
+	// COALESCE guards against legacy rows with NULL energy (e.g. left over from
+	// the import→energy rename in #29907). Without it avg() of an all-NULL
+	// bucket returns NULL and fails the float64 scan — see optimizer issue #73.
+	rows, err := db.Query(`SELECT min(ts) AS ts, COALESCE(avg(energy), 0) AS energy
 		FROM meters
 		WHERE meter = ? AND ts >= ?
 		GROUP BY strftime("%H:%M", ts, 'unixepoch', 'localtime')

--- a/core/metrics/db_profile.go
+++ b/core/metrics/db_profile.go
@@ -18,9 +18,7 @@ func importProfile(entity entity, from time.Time) (*[96]float64, error) {
 		return nil, err
 	}
 
-	// COALESCE guards against legacy rows with NULL energy (e.g. left over from
-	// the import→energy rename in #29907). Without it avg() of an all-NULL
-	// bucket returns NULL and fails the float64 scan — see optimizer issue #73.
+	// COALESCE guards against legacy rows with NULL energy
 	rows, err := db.Query(`SELECT min(ts) AS ts, COALESCE(avg(energy), 0) AS energy
 		FROM meters
 		WHERE meter = ? AND ts >= ?

--- a/core/metrics/db_test.go
+++ b/core/metrics/db_test.go
@@ -231,44 +231,6 @@ func TestUpdateProfile(t *testing.T) {
 	}
 }
 
-// TestImportProfileNullEnergy reproduces optimizer issue #73: a meter row
-// with NULL energy (left over from earlier schema migrations) made avg(energy)
-// return NULL for the entire HH:MM bucket, which then failed to scan into
-// float64 and aborted the optimizer with a fatal "converting NULL to float64
-// is unsupported". COALESCE in the query keeps the slot but treats it as zero.
-func TestImportProfileNullEnergy(t *testing.T) {
-	clock := clock.NewMock()
-	_, o := clock.Now().Zone()
-	clock.Add(-time.Duration(o) * time.Second)
-
-	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
-	require.NoError(t, SetupSchema())
-
-	entity := entity{Id: 2, Name: "home"}
-	require.NoError(t, db.Instance.FirstOrCreate(&entity).Error)
-
-	// 2 days of valid data, slot 0 of each day is a NULL-energy row inserted
-	// via raw SQL — simulates legacy migration debris.
-	sqldb, err := db.Instance.DB()
-	require.NoError(t, err)
-
-	for i := range 4 * 2 * 24 {
-		ts := clock.Now().Truncate(15 * time.Minute).Unix()
-		if i%96 == 0 {
-			_, err := sqldb.Exec(`INSERT INTO meters (meter, ts, energy, return_energy) VALUES (?, ?, NULL, NULL)`, entity.Id, ts)
-			require.NoError(t, err)
-		} else {
-			persist(entity, clock.Now(), float64(i), float64(i))
-		}
-		clock.Add(15 * time.Minute)
-	}
-
-	prof, err := importProfile(entity, clock.Now().AddDate(0, 0, -3))
-	require.NoError(t, err, "must not fail on NULL energy bucket")
-	require.Equal(t, float64(0), prof[0], "NULL-only bucket must be reported as 0")
-	require.NotZero(t, prof[1], "neighbouring non-NULL bucket must still be averaged correctly")
-}
-
 func TestTimeMigration(t *testing.T) {
 	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
 	mig := db.Instance.Migrator()

--- a/core/metrics/db_test.go
+++ b/core/metrics/db_test.go
@@ -231,6 +231,44 @@ func TestUpdateProfile(t *testing.T) {
 	}
 }
 
+// TestImportProfileNullEnergy reproduces optimizer issue #73: a meter row
+// with NULL energy (left over from earlier schema migrations) made avg(energy)
+// return NULL for the entire HH:MM bucket, which then failed to scan into
+// float64 and aborted the optimizer with a fatal "converting NULL to float64
+// is unsupported". COALESCE in the query keeps the slot but treats it as zero.
+func TestImportProfileNullEnergy(t *testing.T) {
+	clock := clock.NewMock()
+	_, o := clock.Now().Zone()
+	clock.Add(-time.Duration(o) * time.Second)
+
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	entity := entity{Id: 2, Name: "home"}
+	require.NoError(t, db.Instance.FirstOrCreate(&entity).Error)
+
+	// 2 days of valid data, slot 0 of each day is a NULL-energy row inserted
+	// via raw SQL — simulates legacy migration debris.
+	sqldb, err := db.Instance.DB()
+	require.NoError(t, err)
+
+	for i := range 4 * 2 * 24 {
+		ts := clock.Now().Truncate(15 * time.Minute).Unix()
+		if i%96 == 0 {
+			_, err := sqldb.Exec(`INSERT INTO meters (meter, ts, energy, return_energy) VALUES (?, ?, NULL, NULL)`, entity.Id, ts)
+			require.NoError(t, err)
+		} else {
+			persist(entity, clock.Now(), float64(i), float64(i))
+		}
+		clock.Add(15 * time.Minute)
+	}
+
+	prof, err := importProfile(entity, clock.Now().AddDate(0, 0, -3))
+	require.NoError(t, err, "must not fail on NULL energy bucket")
+	require.Equal(t, float64(0), prof[0], "NULL-only bucket must be reported as 0")
+	require.NotZero(t, prof[1], "neighbouring non-NULL bucket must still be averaged correctly")
+}
+
 func TestTimeMigration(t *testing.T) {
 	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
 	mig := db.Instance.Migrator()


### PR DESCRIPTION
## Summary

Fixes  https://github.com/evcc-io/evcc/issues/30166:

```
[site ] ERROR optimizer: sql: Scan error on column index 1, name "energy": converting NULL to float64 is unsupported
```

…and then logs `optimizer: meter profile incomplete` intermittently in steady state.

## Root cause

`core/metrics/db_profile.go` aggregates the meter table into 96 HH:MM buckets via `avg(energy)`. SQLite's `avg()` ignores NULLs, but if *every* row inside a bucket has `energy IS NULL` the result itself is NULL — and Go's `database/sql` cannot scan NULL into a plain `float64`.

NULL energy rows exist in real installs as migration debris (e.g. left over from the `import → energy` column rename in #29907). The optimizer's `homeProfile()` hits this first because the `home` entity is the longest-lived meter in most databases and the only one written via the `AddEnergy(nil, nil, power)` integration path.

## Fix

Wrap the aggregate in `COALESCE(avg(energy), 0)`. A fully-NULL bucket is reported as zero consumption, matching the existing semantics for buckets that contain a 0 reading. Two lines, no behavioural change for healthy data.

## Tests

- `TestImportProfileNullEnergy` — inserts NULL energy rows via raw SQL alongside normal `persist()` data and asserts the call no longer errors, the NULL-only bucket reads back as 0, and neighbouring non-NULL buckets average correctly. Verified the new test fails before the fix with the user's exact error message.
- Existing `TestUpdateProfile` continues to pass — no regression for the happy path.

## Test plan

- [x] `go test ./core/metrics/ ./core/`
- [x] `go vet ./core/metrics/`
- [ ] Reporter to confirm the optimizer activates without the scan error on next nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)