### PR TITLE
Hyundai Bluelink (US): expose required PIN in template (#30054)

### DIFF
--- a/templates/definition/vehicle/hyundai-us.yaml
+++ b/templates/definition/vehicle/hyundai-us.yaml
@@ -5,6 +5,12 @@ products:
       generic: Bluelink (US)
 params:
   - preset: vehicle-base
+  - name: pin
+    required: true
+    help:
+      en: Required by Bluelink (US) to authorize remote commands.
+      de: Wird von Bluelink (US) benötigt, um Fernkommandos zu autorisieren.
 render: |
   type: hyundai-us
   {{ include "vehicle-base" . }}
+  pin: {{ .pin }}

--- a/templates/definition/vehicle/hyundai-us.yaml
+++ b/templates/definition/vehicle/hyundai-us.yaml
@@ -13,4 +13,4 @@ params:
 render: |
   type: hyundai-us
   {{ include "vehicle-base" . }}
-  pin: {{ .pin }}
+  pin: {{ quote .pin }}


### PR DESCRIPTION
## Summary

Fixes #30054 — adding a Hyundai Bluelink (US) vehicle from the UI always fails with `PIN is required`, with no way to enter one.

## Root cause

Three-way mismatch:

- `vehicle/bluelink_us.go:39-41` unconditionally rejects an empty `Pin`.
- `templates/definition/vehicle/hyundai-us.yaml` only inherits `vehicle-base`.
- The `vehicle-base` preset (`util/templates/defaults.yaml:509-535`) has no `pin` field.

So the UI never renders a PIN input, and the Go-side validation always fires. The reporter's `configs` table confirms it — their stored row has no `pin` key.

## Fix

Declare `pin` as a required template param and render it. Mirrors the existing pattern in `templates/definition/vehicle/fiat.yaml` (optional there).

```yaml
params:
  - preset: vehicle-base
  - name: pin
    required: true
    help:
      en: Required by Bluelink (US) to authorize remote commands.
      de: Wird von Bluelink (US) benötigt, um Fernkommandos zu autorisieren.
render: |
  type: hyundai-us
  {{ include "vehicle-base" . }}
  pin: {{ .pin }}
```

`required: true` lets the form block submission with a field-level message, instead of bubbling up the generic Go error.

## Test plan

- [x] `go test ./util/templates/`
- [ ] Reporter to confirm next nightly: PIN field appears in the Hyundai Bluelink (US) form and vehicle creation succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)