### PR TITLE
OCPP: tolerate GetConfiguration timeout on buggy chargers (#30113)

### DIFF
--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -2,10 +2,12 @@ package ocpp
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
@@ -38,7 +40,14 @@ func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.
 
 	resp, err := cp.GetConfigurationRequest()
 	if err != nil {
-		return err
+		if !errors.Is(err, api.ErrTimeout) {
+			return err
+		}
+		// Some chargers (e.g. EN+/EVSEDO FW 1.1.805, issue #30113) silently
+		// swallow CSMS requests after BootNotification. Proceed with built-in
+		// defaults instead of aborting charger creation fatally.
+		cp.log.WARN.Printf("GetConfiguration timeout, proceeding with defaults")
+		resp = &core.GetConfigurationConfirmation{}
 	}
 
 	for _, opt := range resp.ConfigurationKey {


### PR DESCRIPTION
## Summary

Follow-up to #30165. The dispatcher `no client … exists` mapping landed and works (the reporter's latest trace no longer shows that error), but `Setup()` still fatals on EN+/EVSEDO FW 1.1.805 — now with a plain `timeout`. See https://github.com/evcc-io/evcc/issues/30113#issuecomment-4528327441.

## Why the previous fix wasn't enough

The new trace shows the wallbox hangs on **every** CSMS-initiated request after BootNotification, not just `ChangeAvailability`:

```
T+0s  connect
T+1s  recv BootNotification → Accepted
      send ChangeAvailability(0, Operative)
T+2s  recv MeterValues (CP-initiated, no reply needed)
T+32s disconnect ← classic 30s hang on ChangeAvailability
T+36s reconnect
T+37s recv BootNotification #2 → Accepted (waitConnected returns ✓)
T+38s recv MeterValues again
T+68s disconnect ← same 30s hang, this time on GetConfiguration
      → fatal: "timeout"
```

`waitConnected` in #30165 buys one reconnect cycle, but `cp_setup.go` then calls `GetConfigurationRequest()`, the CP swallows it, the WebSocket times out, and the `return err` aborts charger creation fatally.

## Fix

If `GetConfigurationRequest()` returns `api.ErrTimeout`, log a WARN and continue with a zero-value `GetConfigurationConfirmation`. The downstream loop over `resp.ConfigurationKey` is a no-op in that case, every subsequent call in `Setup()` already logs warnings instead of returning errors, and the charger comes up with built-in defaults.

Non-timeout errors (real configuration failures) still propagate as before.

## Caveats

- This brings the charger to a *creatable* state but does not make it functional. Runtime CSMS requests (`SetChargingProfile`, `RemoteStartTransaction`, etc.) will continue to be swallowed by FW 1.1.805. Real fix has to come from EN+/EVSEDO.
- Scope intentionally minimal: only the one fatal return path in `Setup()` is changed. No tests added — the cp_setup.go path has no existing unit-test scaffolding and the change is a textbook `errors.Is` guard.

## Test plan

- [x] `go build ./charger/ocpp/...`
- [x] `go vet ./charger/ocpp/...`
- [x] `go test ./charger/ocpp/...` (existing tests still pass)
- [ ] Reporter @networxnet to confirm on next nightly that EN+ wallbox no longer triggers `[main] FATAL … timeout` and proceeds past `GetConfiguration`. Reporter indicated they won't have access to the wallbox again until next weekend, so this stays draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)