### PR TITLE
Loadpoint: keep mode on integrated device disconnect

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -572,7 +572,11 @@ func (lp *Loadpoint) evVehicleDisconnectHandler() {
 	lp.stopVehicleDetection()
 
 	// set default mode on disconnect
-	lp.defaultMode()
+	// skip for integrated devices: the "disconnect" here is just the socket
+	// being switched off, not a vehicle being unplugged - keep the user's mode (#30187)
+	if !lp.chargerHasFeature(api.IntegratedDevice) {
+		lp.defaultMode()
+	}
 
 	// set default vehicle (may be nil)
 	lp.setActiveVehicle(lp.defaultVehicle)

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -323,6 +323,36 @@ func TestDefaultVehicle(t *testing.T) {
 	assert.Nil(t, lp.vehicle, "expected no vehicle")
 }
 
+// integratedDeviceCharger is a minimal charger advertising the IntegratedDevice feature.
+type integratedDeviceCharger struct{}
+
+func (c *integratedDeviceCharger) Status() (api.ChargeStatus, error) { return api.StatusA, nil }
+func (c *integratedDeviceCharger) Enabled() (bool, error)            { return false, nil }
+func (c *integratedDeviceCharger) Enable(bool) error                 { return nil }
+func (c *integratedDeviceCharger) MaxCurrent(int64) error            { return nil }
+func (c *integratedDeviceCharger) Features() []api.Feature {
+	return []api.Feature{api.IntegratedDevice}
+}
+
+// TestDisconnectIntegratedDeviceKeepsMode is a regression test for #30187:
+// switching an integrated-device loadpoint to "off" makes a switch socket report
+// StatusA (disconnect). The disconnect handler must NOT reset the mode to the
+// configured DefaultMode in that case, otherwise the loadpoint immediately flips
+// back to pv and the socket re-enables.
+func TestDisconnectIntegratedDeviceKeepsMode(t *testing.T) {
+	lp := NewLoadpoint(util.NewLogger("foo"), settings.NewDatabaseSettingsAdapter("foo"))
+	lp.charger = &integratedDeviceCharger{}
+	lp.DefaultMode = api.ModePV
+	lp.setMode(api.ModeOff)
+
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	lp.evVehicleDisconnectHandler()
+
+	assert.Equal(t, api.ModeOff, lp.GetMode(), "integrated device disconnect must not reset mode")
+}
+
 func TestReconnectVehicle(t *testing.T) {
 	tc := []struct {
 		name      string


### PR DESCRIPTION
## Summary

Fixes #30187 (regression of #18876).

Switching an integrated-device loadpoint (Tapo plug, Shelly, FRITZ!DECT, HomeWizard, MyStrom, …) to **off** disables the underlying switch socket. The socket then reports `StatusA`, which the loadpoint interprets as a vehicle disconnect. The disconnect handler unconditionally calls `defaultMode()`, which resets the loadpoint to the configured `DefaultMode` (typically `pv`). PV mode immediately re-enables the socket — and the user's "off" intent is lost in a tight ~6 s loop:

```
set charge mode: off
charger status: A
car disconnected
set charge mode: pv      ← unwanted reset
charger status: B
car connected
…
```

The connect side already guards `vehicleDefaultOrDetect()` with `!chargerHasFeature(api.IntegratedDevice)` (`core/loadpoint.go:529`). Apply the same guard to `defaultMode()` on disconnect.

## Test plan

- [x] New regression test `TestDisconnectIntegratedDeviceKeepsMode` in `core/loadpoint_vehicle_test.go` — passes with the fix, fails without it (`expected "off", actual "pv"`).
- [x] `go test ./core/...` green.
- [x] `gofmt`, `go vet` clean.
- [ ] Manual confirmation on a Tapo plug loadpoint: setting to **off** stays off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)