### PR TITLE
Meter (Home Assistant): grid charging via switch entities

### DIFF
--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -136,11 +136,8 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 // requested without a backing entity.
 func batteryModeController(conn *homeassistant.Connection, modes map[api.BatteryMode]string) func(api.BatteryMode) error {
 	return func(mode api.BatteryMode) error {
-		target, known := modes[mode]
-		if !known {
-			return fmt.Errorf("unsupported battery mode: %s", mode)
-		}
-		if target == "" {
+		target, ok := modes[mode]
+		if !ok || target == "" {
 			return api.ErrNotAvailable
 		}
 

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -34,6 +34,11 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 		batteryCapacity    `mapstructure:",squash"`
 		batterySocLimits   `mapstructure:",squash"`
 		batteryPowerLimits `mapstructure:",squash"`
+
+		// battery mode control - optional switch-like entities per mode
+		ModeNormal string
+		ModeHold   string
+		ModeCharge string
 	}{
 		batterySocLimits: batterySocLimits{
 			MinSoc: 20,
@@ -98,6 +103,21 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 		implement.May(m, implement.BatteryCapacity(cc.batteryCapacity.Decorator()))
 		implement.May(m, implement.BatterySocLimiter(cc.batterySocLimits.Decorator()))
 		implement.May(m, implement.BatteryPowerLimiter(cc.batteryPowerLimits.Decorator()))
+
+		if cc.ModeHold != "" || cc.ModeCharge != "" {
+			if cc.ModeNormal == "" {
+				return nil, errors.New("modeNormal is required when modeHold or modeCharge is configured")
+			}
+			modes := map[api.BatteryMode]string{
+				api.BatteryNormal: cc.ModeNormal,
+				api.BatteryHold:   cc.ModeHold,
+				api.BatteryCharge: cc.ModeCharge,
+			}
+			implement.Has(m, implement.BatteryController(batteryModeController(conn, modes)))
+		} else if cc.ModeNormal != "" {
+			return nil, errors.New("modeNormal alone has no effect; configure modeHold and/or modeCharge")
+		}
+
 		return m, nil
 	}
 
@@ -107,4 +127,33 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 	implement.May(m, implement.MaxACPowerGetter(cc.pvMaxACPower.Decorator()))
 
 	return m, nil
+}
+
+// batteryModeController returns a BatteryController function that toggles
+// switch-like Home Assistant entities to express the desired evcc battery mode.
+// modeNormal is guaranteed to be configured (enforced by the constructor);
+// modeHold and modeCharge are optional and return api.ErrNotAvailable when
+// requested without a backing entity.
+func batteryModeController(conn *homeassistant.Connection, modes map[api.BatteryMode]string) func(api.BatteryMode) error {
+	return func(mode api.BatteryMode) error {
+		target, known := modes[mode]
+		if !known {
+			return fmt.Errorf("unsupported battery mode: %s", mode)
+		}
+		if target == "" {
+			return api.ErrNotAvailable
+		}
+
+		// turn off the other configured entities first
+		for m, entity := range modes {
+			if m == mode || entity == "" || entity == target {
+				continue
+			}
+			if err := conn.CallSwitchService(entity, false); err != nil {
+				return err
+			}
+		}
+
+		return conn.CallSwitchService(target, true)
+	}
 }

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -3,6 +3,7 @@ package meter
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
@@ -112,6 +113,11 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 				api.BatteryNormal: cc.ModeNormal,
 				api.BatteryHold:   cc.ModeHold,
 				api.BatteryCharge: cc.ModeCharge,
+			}
+			for _, entity := range modes {
+				if entity != "" && !strings.HasPrefix(entity, "script.") {
+					return nil, fmt.Errorf("battery mode entity must be a script: %s", entity)
+				}
 			}
 			implement.Has(m, implement.BatteryController(batteryModeController(conn, modes)))
 		} else if cc.ModeNormal != "" {

--- a/meter/homeassistant.go
+++ b/meter/homeassistant.go
@@ -129,28 +129,18 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Meter, error) {
 	return m, nil
 }
 
-// batteryModeController returns a BatteryController function that toggles
-// switch-like Home Assistant entities to express the desired evcc battery mode.
-// modeNormal is guaranteed to be configured (enforced by the constructor);
-// modeHold and modeCharge are optional and return api.ErrNotAvailable when
-// requested without a backing entity.
+// batteryModeController returns a BatteryController function that activates
+// the switch-like Home Assistant entity configured for the requested evcc
+// battery mode. Each mode is self-contained: evcc only triggers the matching
+// entity and never deactivates others - any mutual exclusion is the HA side's
+// responsibility. modeHold and modeCharge are optional and return
+// api.ErrNotAvailable when requested without a backing entity.
 func batteryModeController(conn *homeassistant.Connection, modes map[api.BatteryMode]string) func(api.BatteryMode) error {
 	return func(mode api.BatteryMode) error {
 		target, ok := modes[mode]
 		if !ok || target == "" {
 			return api.ErrNotAvailable
 		}
-
-		// turn off the other configured entities first
-		for m, entity := range modes {
-			if m == mode || entity == "" || entity == target {
-				continue
-			}
-			if err := conn.CallSwitchService(entity, false); err != nil {
-				return err
-			}
-		}
-
 		return conn.CallSwitchService(target, true)
 	}
 }

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -120,36 +120,36 @@ params:
   - name: modeNormal
     usages: ["battery"]
     description:
-      de: Normalbetrieb Entität
-      en: Normal Mode Entity
-    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean,button,scene,script
-    example: "switch.battery_normal"
+      de: Normalbetrieb Skript
+      en: Normal Mode Script
+    service: homeassistant/entities?uri={uri}&domain=script
+    example: "script.battery_normal"
     advanced: true
     help:
-      en: Entity that evcc triggers when the home battery should return to normal operation. Required when modeHold or modeCharge is set. The entity itself is responsible for any necessary state changes on the HA side.
-      de: Entität, die evcc auslöst, wenn die Heimbatterie in den Normalbetrieb zurückkehren soll. Erforderlich, wenn modeHold oder modeCharge gesetzt ist. Die Entität selbst ist verantwortlich für alle notwendigen Statusänderungen auf der HA-Seite.
+      en: Script that evcc runs when the home battery should return to normal operation. Required when modeHold or modeCharge is set. The script is responsible for any necessary state changes on the HA side.
+      de: Skript, das evcc ausführt, wenn die Heimbatterie in den Normalbetrieb zurückkehren soll. Erforderlich, wenn modeHold oder modeCharge gesetzt ist. Das Skript ist verantwortlich für alle notwendigen Statusänderungen auf der HA-Seite.
   - name: modeHold
     usages: ["battery"]
     description:
-      de: Halten Entität
-      en: Hold Mode Entity
-    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean,button,scene,script
-    example: "switch.battery_hold"
+      de: Halten Skript
+      en: Hold Mode Script
+    service: homeassistant/entities?uri={uri}&domain=script
+    example: "script.battery_hold"
     advanced: true
     help:
-      en: Optional entity that evcc triggers to prevent the home battery from charging or discharging.
-      de: Optionale Entität, die evcc auslöst, um Laden und Entladen der Heimbatterie zu verhindern.
+      en: Optional script that evcc runs to prevent the home battery from charging or discharging.
+      de: Optionales Skript, das evcc ausführt, um Laden und Entladen der Heimbatterie zu verhindern.
   - name: modeCharge
     usages: ["battery"]
     description:
-      de: Netzladung Entität
-      en: Grid Charge Mode Entity
-    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean,button,scene,script
-    example: "switch.battery_grid_charge"
+      de: Netzladung Skript
+      en: Grid Charge Mode Script
+    service: homeassistant/entities?uri={uri}&domain=script
+    example: "script.battery_grid_charge"
     advanced: true
     help:
-      en: Optional entity that evcc triggers to grid-charge the home battery (e.g. during low-tariff windows).
-      de: Optionale Entität, die evcc auslöst, um die Heimbatterie aus dem Netz zu laden (z.B. bei günstigem Tarif).
+      en: Optional script that evcc runs to grid-charge the home battery (e.g. during low-tariff windows).
+      de: Optionales Skript, das evcc ausführt, um die Heimbatterie aus dem Netz zu laden (z.B. bei günstigem Tarif).
   - name: maxacpower
   - preset: battery-params
 render: |

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -117,6 +117,39 @@ params:
     help:
       en: Entity ID for battery state of charge in percent
       de: Entitäts-ID für Batterieladestand in Prozent
+  - name: modeNormal
+    usages: ["battery"]
+    description:
+      de: Normalbetrieb Entität
+      en: Normal Mode Entity
+    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean
+    example: "switch.battery_normal"
+    advanced: true
+    help:
+      en: Optional switch-like entity that evcc activates for normal battery operation (e.g. switch, input_boolean). Other configured mode entities are deactivated first.
+      de: Optionale schaltbare Entität, die evcc für den Normalbetrieb der Batterie aktiviert (z.B. switch, input_boolean). Andere konfigurierte Modus-Entitäten werden zuvor deaktiviert.
+  - name: modeHold
+    usages: ["battery"]
+    description:
+      de: Halten Entität
+      en: Hold Mode Entity
+    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean
+    example: "switch.battery_hold"
+    advanced: true
+    help:
+      en: Optional switch-like entity that evcc activates to prevent the home battery from charging or discharging.
+      de: Optionale schaltbare Entität, die evcc aktiviert, um Laden und Entladen der Heimbatterie zu verhindern.
+  - name: modeCharge
+    usages: ["battery"]
+    description:
+      de: Netzladung Entität
+      en: Grid Charge Mode Entity
+    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean
+    example: "switch.battery_grid_charge"
+    advanced: true
+    help:
+      en: Optional switch-like entity that evcc activates to grid-charge the home battery (e.g. during low-tariff windows).
+      de: Optionale schaltbare Entität, die evcc aktiviert, um die Heimbatterie aus dem Netz zu laden (z.B. bei günstigem Tarif).
   - name: maxacpower
   - preset: battery-params
 render: |
@@ -136,5 +169,8 @@ render: |
   maxacpower: {{ .maxacpower }} # W
   {{- if eq .usage "battery" }}
   soc: {{ .soc }} # W
+  modeNormal: {{ .modeNormal }}
+  modeHold: {{ .modeHold }}
+  modeCharge: {{ .modeCharge }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -122,34 +122,34 @@ params:
     description:
       de: Normalbetrieb Entität
       en: Normal Mode Entity
-    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean
+    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean,button,scene,script
     example: "switch.battery_normal"
     advanced: true
     help:
-      en: Optional switch-like entity that evcc activates for normal battery operation (e.g. switch, input_boolean). Other configured mode entities are deactivated first.
-      de: Optionale schaltbare Entität, die evcc für den Normalbetrieb der Batterie aktiviert (z.B. switch, input_boolean). Andere konfigurierte Modus-Entitäten werden zuvor deaktiviert.
+      en: Entity that evcc triggers when the home battery should return to normal operation. Required when modeHold or modeCharge is set. The entity itself is responsible for any necessary state changes on the HA side.
+      de: Entität, die evcc auslöst, wenn die Heimbatterie in den Normalbetrieb zurückkehren soll. Erforderlich, wenn modeHold oder modeCharge gesetzt ist. Die Entität selbst ist verantwortlich für alle notwendigen Statusänderungen auf der HA-Seite.
   - name: modeHold
     usages: ["battery"]
     description:
       de: Halten Entität
       en: Hold Mode Entity
-    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean
+    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean,button,scene,script
     example: "switch.battery_hold"
     advanced: true
     help:
-      en: Optional switch-like entity that evcc activates to prevent the home battery from charging or discharging.
-      de: Optionale schaltbare Entität, die evcc aktiviert, um Laden und Entladen der Heimbatterie zu verhindern.
+      en: Optional entity that evcc triggers to prevent the home battery from charging or discharging.
+      de: Optionale Entität, die evcc auslöst, um Laden und Entladen der Heimbatterie zu verhindern.
   - name: modeCharge
     usages: ["battery"]
     description:
       de: Netzladung Entität
       en: Grid Charge Mode Entity
-    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean
+    service: homeassistant/entities?uri={uri}&domain=switch,input_boolean,button,scene,script
     example: "switch.battery_grid_charge"
     advanced: true
     help:
-      en: Optional switch-like entity that evcc activates to grid-charge the home battery (e.g. during low-tariff windows).
-      de: Optionale schaltbare Entität, die evcc aktiviert, um die Heimbatterie aus dem Netz zu laden (z.B. bei günstigem Tarif).
+      en: Optional entity that evcc triggers to grid-charge the home battery (e.g. during low-tariff windows).
+      de: Optionale Entität, die evcc auslöst, um die Heimbatterie aus dem Netz zu laden (z.B. bei günstigem Tarif).
   - name: maxacpower
   - preset: battery-params
 render: |

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -126,8 +126,8 @@ params:
     example: "script.battery_normal"
     advanced: true
     help:
-      en: Script that evcc runs when the home battery should return to normal operation. Required when modeHold or modeCharge is set. The script is responsible for any necessary state changes on the HA side.
-      de: Skript, das evcc ausführt, wenn die Heimbatterie in den Normalbetrieb zurückkehren soll. Erforderlich, wenn modeHold oder modeCharge gesetzt ist. Das Skript ist verantwortlich für alle notwendigen Statusänderungen auf der HA-Seite.
+      en: Script to put home battery to normal operation. Required when modeHold or modeCharge is set. The script is responsible for any necessary state changes on the HA side.
+      de: Skript um die Heimbatterie in den Normalbetrieb zu versetzen. Erforderlich, wenn modeHold oder modeCharge gesetzt ist. Das Skript ist verantwortlich für alle notwendigen Statusänderungen auf der HA-Seite.
   - name: modeHold
     usages: ["battery"]
     description:
@@ -137,8 +137,8 @@ params:
     example: "script.battery_hold"
     advanced: true
     help:
-      en: Optional script that evcc runs to prevent the home battery from charging or discharging.
-      de: Optionales Skript, das evcc ausführt, um Laden und Entladen der Heimbatterie zu verhindern.
+      en: Optional script to prevent the home battery from discharging.
+      de: Optionales Skript um Entladen der Heimbatterie zu verhindern.
   - name: modeCharge
     usages: ["battery"]
     description:
@@ -148,8 +148,8 @@ params:
     example: "script.battery_grid_charge"
     advanced: true
     help:
-      en: Optional script that evcc runs to grid-charge the home battery (e.g. during low-tariff windows).
-      de: Optionales Skript, das evcc ausführt, um die Heimbatterie aus dem Netz zu laden (z.B. bei günstigem Tarif).
+      en: Optional script to grid-charge the home battery.
+      de: Optionales Skript um die Heimbatterie aus dem Netz zu laden.
   - name: maxacpower
   - preset: battery-params
 render: |


### PR DESCRIPTION
Closes #30179.

## Summary

Wires `api.BatteryController` into the Home Assistant battery meter so the grid-charging feature works with HA-integrated home batteries. The reporter (and the broader "HA-only" setup audience) can now expose three switch-like helper entities and let evcc flip them as it changes mode.

## How it works

Three optional entity params under `usage: battery`:

| Param | Maps to |
|---|---|
| `modeNormal` | `api.BatteryNormal` |
| `modeHold` | `api.BatteryHold` |
| `modeCharge` | `api.BatteryCharge` |

Each may point at any switchable HA entity — `switch.*`, `input_boolean.*`, etc. — reusing the existing `Connection.CallSwitchService` helper (`turn_on` / `turn_off` via the entity's domain).

On a mode change, evcc:
1. Turns off all other configured mode entities.
2. Turns on the entity for the requested mode.

### Validation rules

- `modeNormal` is **required** when `modeHold` or `modeCharge` is set, so there is always an explicit "return to default" target.
- `modeHold` and `modeCharge` are optional. Requesting an unconfigured mode returns `api.ErrNotAvailable`, matching the contract other meters honor.
- Setting `modeNormal` alone has no effect and errors at startup to flag the misconfiguration.

## Example config

```yaml
meters:
  - name: home_battery
    type: template
    template: homeassistant
    usage: battery
    uri: http://homeassistant.local:8123
    power: sensor.battery_power
    soc:   sensor.battery_soc
    modeNormal: switch.battery_normal
    modeHold:   switch.battery_hold
    modeCharge: switch.battery_grid_charge
```

## Status: draft

Marked draft because there are open design choices the maintainers may want to weigh in on:

- **Entity domain.** Limited to switch-like domains (anything `CallSwitchService` accepts). `input_select` / `select` were considered (single entity, one option per mode) but rejected for matching the issue's exact ask (`switch.charge_home_battery`).
- **Validation strictness.** Currently rejects `modeNormal`-only configs. Could downgrade to a runtime warning if maintainers prefer.
- **No unit test for the controller.** The HA `Connection` has package-private internals; testing through `NewHomeAssistantFromConfig` would require an OAuth-aware httptest server. Skipped to keep the patch small.

## Test plan

- [x] `go build ./meter/...`, `go vet ./meter/...`, `gofmt` clean.
- [x] `go test ./meter/...` green.
- [x] `make docs` regenerates without diff (no doc YAML for HA meter).
- [ ] Manual smoke test against an HA instance with three dummy switch entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)