### PR TITLE
logstash: track ring length in O(1) instead of ring.Len() per write

### DIFF
--- a/util/logstash/log.go
+++ b/util/logstash/log.go
@@ -29,13 +29,19 @@ type logger struct {
 	mu   sync.RWMutex
 	data *ring.Ring
 	size int
+	// length mirrors data.Len() so Write avoids an O(n) ring.Len() call on every
+	// log line (see Write). Invariant: any code that changes the number of nodes
+	// in data must keep length in sync.
+	length int
 }
 
 func New(size int) *logger {
-	return &logger{
+	l := &logger{
 		data: ring.New(1),
 		size: size,
 	}
+	l.length = l.data.Len() // keep length in sync with the initial ring
+	return l
 }
 
 var _ io.Writer = (*logger)(nil)
@@ -47,9 +53,14 @@ func (l *logger) Write(p []byte) (n int, err error) {
 	if !strings.HasPrefix(string(p), "[cache ]") {
 		l.data.Value = element(string(p))
 
-		// dynamically grow the ring
-		if l.data.Len() < l.size {
+		// dynamically grow the ring until it reaches the configured size.
+		// Track the length in O(1) instead of calling ring.Len(), which walks
+		// the whole ring on every write — once the ring is full (size 10000)
+		// that is 10000 pointer chases per log line and dominates CPU on weak
+		// hardware (e.g. Victron Venus OS / ARMv7) under verbose trace logging.
+		if l.length < l.size {
 			l.data.Link(ring.New(1))
+			l.length++
 		}
 
 		l.data = l.data.Next()

--- a/util/logstash/log_test.go
+++ b/util/logstash/log_test.go
@@ -36,6 +36,55 @@ func TestLog(t *testing.T) {
 	assert.Equal(t, []string{"test1", "test2"}, log.Areas())
 }
 
+// TestRingGrowsThenCaps writes more lines than the configured size and verifies
+// the ring grows up to size and then keeps only the most recent size entries.
+// This guards the grow/cap accounting in Write (length tracked in O(1)).
+func TestRingGrowsThenCaps(t *testing.T) {
+	const size = 3
+	log := New(size)
+
+	lines := []string{
+		"[test ] TRACE line1",
+		"[test ] TRACE line2",
+		"[test ] TRACE line3",
+		"[test ] TRACE line4",
+		"[test ] TRACE line5",
+	}
+	for _, l := range lines {
+		log.Write([]byte(l))
+	}
+
+	// only the last `size` lines survive, in chronological order
+	got := log.All(nil, jww.LevelTrace, 0)
+	assert.Len(t, got, size, "ring must not exceed configured size")
+	assert.Equal(t, lines[len(lines)-size:], got)
+}
+
+// TestRingSkipCacheLinesDoesNotGrow verifies that "[cache ]" lines take the
+// early-return path: they are not stored and must neither grow the ring nor the
+// length counter, which has to stay in sync with data.Len().
+func TestRingSkipCacheLinesDoesNotGrow(t *testing.T) {
+	log := New(3)
+
+	// grow the ring past a single node first, so a stray cursor advance on the
+	// cache path would actually be observable (Next() on a 1-node ring is a no-op)
+	log.Write([]byte(s1))
+	log.Write([]byte(s2))
+
+	stored := log.All(nil, jww.LevelTrace, 0)
+	lenBefore := log.length
+	cursorBefore := log.data
+
+	for range 10 {
+		log.Write([]byte("[cache ] cache line"))
+	}
+
+	assert.Equal(t, stored, log.All(nil, jww.LevelTrace, 0), "cache lines must not change stored content")
+	assert.Equal(t, log.data.Len(), log.length, "length counter must stay in sync with the ring")
+	assert.Equal(t, lenBefore, log.length, "cache lines must not grow the ring")
+	assert.Same(t, cursorBefore, log.data, "cache lines must not advance the write cursor")
+}
+
 func BenchmarkLog(b *testing.B) {
 	log := New(10000)
 


### PR DESCRIPTION
### What

**TL;DR — removes an unnecessary O(n) loop (`ring.Len()`) that ran on every single log line and became the top CPU consumer on low-power hardware; replaced with an O(1) counter, behaviour-neutral.**

`util/logstash` keeps every log line in an in-memory `container/ring` buffer (`DefaultHandler = New(10000)`) so the WebUI log view can display them. The buffer captures **all** levels — the in-memory log buffer is independent of the configured log level (see #16960, #17768), so e.g. modbus trace lines flow into it on every transaction even when the console log level is `warn`.

On every `Write` the handler called `ring.Len()` to decide whether the ring should still grow towards its configured size:

```go
if l.data.Len() < l.size {     // O(n): walks the whole ring on every line
    l.data.Link(ring.New(1))
}
```

`(*Ring).Len()` walks the entire ring. Once the ring is full this is a 10000-node pointer chase **on every single log line**, forever — and the answer never changes again after the ring is full.

This commit tracks the current length in an `int` counter that is incremented exactly when a node is linked, making the per-write cost O(1).

### Why

On fast x86 hardware the walk is cheap and unnoticeable. On a weak, cache-constrained ARMv7 device (a Raspberry PI 2, where evcc is commonly deployed) chasing 10000 heap-scattered ring nodes per log line is expensive. Under normal modbus polling, CPU profiling showed `container/ring.(*Ring).Len` as the **single largest consumer at ~36% flat**:

```
flat  flat%   sum%        cum   cum%
3.95s 36.01% 36.01%      3.96s 36.10%  container/ring.(*Ring).Len
                                       └─ util/logstash.(*logger).Write
                                          └─ util.(*redactWriter).Write
                                             └─ modbus trace logging
```

After the change `ring.Len` disappears from the profile entirely; the evcc process CPU on that device dropped from ~54% of a core to ~18% of a core (the remainder is legitimate modbus I/O). No behaviour change — the buffer still grows to `size` and then retains the most recent `size` lines.

### How it's correct (behaviour-neutral)

The counter is in lock-step with what `ring.Len()` returned at the decision point:

- the ring starts as `ring.New(1)` (length 1); the counter is initialised to 1;
- both are gated by the same `< size` condition and incremented by exactly 1, only when a node is linked;
- the `"[cache ]"` early-skip path touches neither, in both old and new code;
- once `length == size` the ring stops growing and stays exactly `size` nodes.

`(*Ring).Len()` returns the total ring length regardless of which node the write cursor currently points at, which is exactly what the counter tracks.

### Tests

Two tests lock in the behaviour that must stay identical:

- `TestRingGrowsThenCaps`: writes more lines than `size` and asserts (via the public `All()`) that the buffer never exceeds `size` and keeps the most recent `size` lines in order.
- `TestRingSkipCacheLinesDoesNotGrow`: writes `"[cache ]"` lines and asserts they are not stored, do not grow the ring, keep `length` in sync with `data.Len()`, and do not advance the write cursor (the ring is first grown past one node so a stray advance is observable).

`go test ./util/logstash/ ./util/` passes; `go vet` and `gofmt` clean.

### Notes

- Two files: `util/logstash/log.go` (the fix) + `util/logstash/log_test.go` (two new tests). No new dependencies, no public API change.
- The `Size()`/`Areas()`/`All()` query methods still use `ring.Len()` — those run only on UI demand, not on the per-write hot path, and are intentionally left unchanged.
- Related context (not addressed here): the in-memory buffer capturing trace regardless of log level (#16960, #17768) is orthogonal; this PR only removes the per-write O(n) cost.
