### PR TITLE
OCPP: add option to skip ChangeAvailability on initialization

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -47,9 +47,10 @@ type OCPP struct {
 	enabled bool
 	current float64
 
-	stackLevelZero      bool
-	profileKindRelative bool
-	lp                  loadpoint.API
+	stackLevelZero       bool
+	profileKindRelative  bool
+	noChangeAvailability bool
+	lp                   loadpoint.API
 }
 
 const defaultIdTag = "evcc" // RemoteStartTransaction only
@@ -75,10 +76,11 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 		AutoStart        bool                       // TODO deprecated
 		NoStop           bool                       // TODO deprecated
 
-		ForcePowerCtrl      bool
-		StackLevelZero      *bool
-		ProfileKindRelative bool
-		RemoteStart         bool
+		ForcePowerCtrl       bool
+		StackLevelZero       *bool
+		ProfileKindRelative  bool
+		RemoteStart          bool
+		NoChangeAvailability *bool
 	}{
 		Connector:      1,
 		MeterInterval:  10 * time.Second,
@@ -91,11 +93,12 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 
 	stackLevelZero := cc.StackLevelZero != nil && *cc.StackLevelZero
 	profileKindRelative := cc.ProfileKindRelative
+	noChangeAvailability := cc.NoChangeAvailability != nil && *cc.NoChangeAvailability
 
 	c, err := NewOCPP(ctx,
 		cc.StationId, cc.Connector, cc.IdTag,
 		cc.MeterValues, cc.MeterInterval,
-		cc.ForcePowerCtrl, stackLevelZero, profileKindRelative, cc.RemoteStart,
+		cc.ForcePowerCtrl, stackLevelZero, profileKindRelative, cc.RemoteStart, noChangeAvailability,
 		cc.ConnectTimeout)
 	if err != nil {
 		return c, err
@@ -138,7 +141,7 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 func NewOCPP(ctx context.Context,
 	id string, connector int, idTag string,
 	meterValues string, meterInterval time.Duration,
-	forcePowerCtrl, stackLevelZero, profileKindRelative, remoteStart bool,
+	forcePowerCtrl, stackLevelZero, profileKindRelative, remoteStart, noChangeAvailability bool,
 	connectTimeout time.Duration,
 ) (*OCPP, error) {
 	log := util.NewLogger(fmt.Sprintf("%s-%d", lo.CoalesceOrEmpty(id, "ocpp"), connector))
@@ -158,7 +161,7 @@ func NewOCPP(ctx context.Context,
 			case <-cp.HasConnected():
 			}
 
-			return cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl)
+			return cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl, noChangeAvailability)
 		},
 	)
 	if err != nil {
@@ -179,12 +182,13 @@ func NewOCPP(ctx context.Context,
 	}
 
 	c := &OCPP{
-		Caps:                implement.New(),
-		log:                 log,
-		cp:                  cp,
-		conn:                conn,
-		stackLevelZero:      stackLevelZero,
-		profileKindRelative: profileKindRelative,
+		Caps:                 implement.New(),
+		log:                  log,
+		cp:                   cp,
+		conn:                 conn,
+		stackLevelZero:       stackLevelZero,
+		profileKindRelative:  profileKindRelative,
+		noChangeAvailability: noChangeAvailability,
 	}
 
 	if cp.HasRemoteTriggerFeature {
@@ -193,7 +197,7 @@ func NewOCPP(ctx context.Context,
 
 	// monitor for charger reboots and re-run setup (once per CP, not per connector)
 	cp.MonitorReboot(ctx, func() error {
-		return c.cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl)
+		return c.cp.Setup(ctx, meterValues, meterInterval, forcePowerCtrl, noChangeAvailability)
 	})
 
 	return c, conn.Initialized()

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -13,9 +13,11 @@ import (
 	"github.com/samber/lo"
 )
 
-func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.Duration, forcePowerCtrl bool) error {
-	if err := cp.ChangeAvailabilityRequest(0, core.AvailabilityTypeOperative); err != nil {
-		cp.log.DEBUG.Printf("failed configuring availability: %v", err)
+func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.Duration, forcePowerCtrl, noChangeAvailability bool) error {
+	if !noChangeAvailability {
+		if err := cp.ChangeAvailabilityRequest(0, core.AvailabilityTypeOperative); err != nil {
+			cp.log.DEBUG.Printf("failed configuring availability: %v", err)
+		}
 	}
 
 	// auto configuration

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -150,7 +150,7 @@ func (suite *ocppTestSuite) TestConnect() {
 	suite.Require().True(cp1.IsConnected())
 
 	// 1st charge point- local
-	c1, err := NewOCPP(suite.T().Context(), "test-1", 1, "", "", 0, false, false, false, true, ocppTestConnectTimeout)
+	c1, err := NewOCPP(suite.T().Context(), "test-1", 1, "", "", 0, false, false, false, true, false, ocppTestConnectTimeout)
 	suite.Require().NoError(err)
 
 	// status and meter values
@@ -199,7 +199,7 @@ func (suite *ocppTestSuite) TestConnect() {
 	suite.Require().True(cp2.IsConnected())
 
 	// 2nd charge point - local
-	c2, err := NewOCPP(suite.T().Context(), "test-2", 1, "", "", 0, false, false, false, true, ocppTestConnectTimeout)
+	c2, err := NewOCPP(suite.T().Context(), "test-2", 1, "", "", 0, false, false, false, true, false, ocppTestConnectTimeout)
 	suite.Require().NoError(err)
 
 	{
@@ -241,7 +241,7 @@ func (suite *ocppTestSuite) TestAutoStart() {
 	suite.Require().True(cp1.IsConnected())
 
 	// 1st charge point- local
-	c1, err := NewOCPP(suite.T().Context(), "test-3", 1, "", "", 0, false, false, false, false, ocppTestConnectTimeout)
+	c1, err := NewOCPP(suite.T().Context(), "test-3", 1, "", "", 0, false, false, false, false, false, ocppTestConnectTimeout)
 	suite.Require().NoError(err)
 
 	// status and meter values
@@ -288,7 +288,7 @@ func (suite *ocppTestSuite) TestTimeout() {
 	})
 
 	// 1st charge point- local
-	_, err := NewOCPP(suite.T().Context(), "test-4", 1, "", "", 0, false, false, false, false, ocppTestConnectTimeout)
+	_, err := NewOCPP(suite.T().Context(), "test-4", 1, "", "", 0, false, false, false, false, false, ocppTestConnectTimeout)
 
 	suite.Require().NoError(err)
 }

--- a/templates/definition/charger/ocpp-enplus.yaml
+++ b/templates/definition/charger/ocpp-enplus.yaml
@@ -10,3 +10,4 @@ params:
   - preset: ocpp
 render: |
   {{ include "ocpp" . }}
+  nochangeavailability: true


### PR DESCRIPTION
## Summary
- Adds optional `nochangeavailability` (bool) parameter to the OCPP charger to skip the initial `ChangeAvailability` call during setup, for chargers that don't handle this command correctly.
- Enables this by default in the EN+ template.

Refs #30113

## Test plan
- [x] `go test ./charger/... ./util/templates/...` passes
- [ ] Verify with affected EN+ hardware that initialization no longer triggers `ChangeAvailability`

🤖 Generated with [Claude Code](https://claude.com/claude-code)