### PR TITLE
OCPP: remove unused struct fields

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -29,7 +29,6 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/charger/ocpp"
-	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
@@ -40,17 +39,14 @@ import (
 // OCPP charger implementation
 type OCPP struct {
 	implement.Caps
-	log     *util.Logger
 	cp      *ocpp.CP
 	conn    *ocpp.Connector
 	phases  int
 	enabled bool
 	current float64
 
-	stackLevelZero       bool
-	profileKindRelative  bool
-	noChangeAvailability bool
-	lp                   loadpoint.API
+	stackLevelZero      bool
+	profileKindRelative bool
 }
 
 const defaultIdTag = "evcc" // RemoteStartTransaction only
@@ -182,13 +178,11 @@ func NewOCPP(ctx context.Context,
 	}
 
 	c := &OCPP{
-		Caps:                 implement.New(),
-		log:                  log,
-		cp:                   cp,
-		conn:                 conn,
-		stackLevelZero:       stackLevelZero,
-		profileKindRelative:  profileKindRelative,
-		noChangeAvailability: noChangeAvailability,
+		Caps:                implement.New(),
+		cp:                  cp,
+		conn:                conn,
+		stackLevelZero:      stackLevelZero,
+		profileKindRelative: profileKindRelative,
 	}
 
 	if cp.HasRemoteTriggerFeature {
@@ -443,9 +437,3 @@ func (c *OCPP) Diagnose() {
 	}
 }
 
-var _ loadpoint.Controller = (*OCPP)(nil)
-
-// LoadpointControl implements loadpoint.Controller
-func (c *OCPP) LoadpointControl(lp loadpoint.API) {
-	c.lp = lp
-}

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -436,4 +436,3 @@ func (c *OCPP) Diagnose() {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary
- Drops three write-only fields on the `OCPP` struct: `noChangeAvailability`, `log`, and `lp`. None of them were ever read.
- Removes the empty `LoadpointControl` method and the `loadpoint.Controller` interface assertion that only existed to satisfy the dead `lp` field.
- Behaviour is unchanged: the constructor uses the local `noChangeAvailability` closure variable, and the local `log` is still passed to `ocpp.NewChargePoint` / `ocpp.NewConnector`.

Follow-up to review feedback on #30217.

## Test plan
- [x] `go build ./...`
- [x] `go test ./charger/ -run TestOcpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)