### PR TITLE
UI: fix failed api calls after restart

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -7,6 +7,7 @@ import setupRouter from "./router.ts";
 import setupI18n from "./i18n.ts";
 import { watchThemeChanges } from "./theme.ts";
 import { appDetection, sendToApp } from "./utils/native";
+import store from "./store";
 import type { Notification } from "./types/evcc";
 
 // lazy load smoothscroll polyfill. mainly for safari < 15.4
@@ -20,7 +21,12 @@ if (!window.CSS.supports("scroll-behavior", "smooth")) {
 const app = createApp(
   defineComponent({
     data() {
-      return { notifications: [] as Notification[], offline: false };
+      return { notifications: [] as Notification[], wsOffline: false };
+    },
+    computed: {
+      offline(): boolean {
+        return this.wsOffline || store.state.apiReady !== true;
+      },
     },
     watch: {
       offline(value) {
@@ -54,11 +60,11 @@ const app = createApp(
         this.notifications = [];
       },
       setOnline() {
-        this.offline = false;
+        this.wsOffline = false;
         sendToApp({ type: "online" });
       },
       setOffline() {
-        this.offline = true;
+        this.wsOffline = true;
         sendToApp({ type: "offline" });
       },
     },

--- a/assets/js/components/Auth/auth.ts
+++ b/assets/js/components/Auth/auth.ts
@@ -116,8 +116,8 @@ watch(
   (offline) => offline && debounedUpdateAuthStatus()
 );
 watch(
-  () => store.state.startupCompleted,
-  (startupCompleted) => startupCompleted && debounedUpdateAuthStatus()
+  () => store.state.apiReady,
+  (ready) => ready && debounedUpdateAuthStatus()
 );
 
 export default auth;

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -71,6 +71,7 @@ export interface State {
   experimental?: boolean;
   setupRequired?: boolean;
   startupCompleted?: boolean;
+  apiReady?: boolean;
   loadpoints: Loadpoint[];
   forecast: Forecast;
   currency?: CURRENCY;

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -244,6 +244,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 	// signal ui listening
 	valueChan <- util.Param{Key: keys.StartupCompleted, Val: false}
+	valueChan <- util.Param{Key: keys.ApiReady, Val: false}
 
 	// metrics
 	if viper.GetBool("metrics") {
@@ -463,6 +464,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 			site.Run(stopC, conf.Interval)
 		}()
 	}
+
+	// signal HTTP API ready
+	valueChan <- util.Param{Key: keys.ApiReady, Val: true}
 
 	if err != nil {
 		if uw, ok := err.(interface{ Unwrap() []error }); ok {

--- a/core/keys/global.go
+++ b/core/keys/global.go
@@ -25,6 +25,7 @@ const (
 	Timezone           = "timezone"
 	Fatal              = "fatal"
 	StartupCompleted   = "startupCompleted" // false: starting, true: started
+	ApiReady           = "apiReady"         // http handlers are registered
 	SetupRequired      = "setupRequired"    // initial setup is required (lp = 0), fresh installation
 	Plant              = "plant"
 	Telemetry          = "telemetry"


### PR DESCRIPTION
fixes #30173

Adds an `apiReady` signal that fires after all HTTP handlers are registered. The frontend folds it into the existing offline state, so config requests wait until the API is actually reachable. Also fixes 404 auth api errors after reboot.