### PR TITLE
Vehicle: suppress climater error log when vehicle is asleep

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -372,7 +372,7 @@ func (lp *Loadpoint) vehicleClimateActive() bool {
 			return active
 		}
 
-		if !errors.Is(err, api.ErrNotAvailable) {
+		if !errors.Is(err, api.ErrNotAvailable) && !errors.Is(err, api.ErrAsleep) {
 			lp.log.ERROR.Printf("climater: %v", err)
 		}
 	}


### PR DESCRIPTION
fixes #30227

A sleeping vehicle is an expected state, but the climater poll currently logs it as ERROR every cycle. Treat `api.ErrAsleep` the same as `api.ErrNotAvailable` so the noise goes away while genuine failures keep surfacing.