### PR TITLE
Plan UI: prevent time watcher from clobbering in-flight edits

### DIFF
--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -243,10 +243,6 @@ export default defineComponent({
 	},
 	watch: {
 		time(newTime: Date | undefined, oldTime: Date | undefined) {
-			// the time prop is a Date object reassigned on every WS update,
-			// so reference equality always trips Vue's watcher even when the
-			// value hasn't changed. Compare timestamps to avoid clobbering
-			// the user's in-flight edits with a no-op re-init.
 			if (newTime && oldTime && newTime.getTime() === oldTime.getTime()) {
 				return;
 			}

--- a/assets/js/components/ChargingPlans/PlanStaticSettings.vue
+++ b/assets/js/components/ChargingPlans/PlanStaticSettings.vue
@@ -242,7 +242,14 @@ export default defineComponent({
 		},
 	},
 	watch: {
-		time() {
+		time(newTime: Date | undefined, oldTime: Date | undefined) {
+			// the time prop is a Date object reassigned on every WS update,
+			// so reference equality always trips Vue's watcher even when the
+			// value hasn't changed. Compare timestamps to avoid clobbering
+			// the user's in-flight edits with a no-op re-init.
+			if (newTime && oldTime && newTime.getTime() === oldTime.getTime()) {
+				return;
+			}
 			this.initInputFields();
 		},
 		soc() {


### PR DESCRIPTION
The soc/kwh plan preview e2e flakes because of a real component bug, not test timing. After Apply, the API round-trip results in a WebSocket push that hands `PlanStaticSettings` a *new* `Date` object with the same timestamp. Vue's prop watcher fires on reference inequality, runs `initInputFields`, and unconditionally overwrites `selectedDay`/`selectedTime` — so if the push lands after the test's next `fill()`, the typed value is reverted and the Apply button never reappears.

- compare timestamps in the `time` watcher and skip when nothing actually changed
- preserves user edits during no-op WS pushes
- restores the e2e test to its original form (no extra waits)