### PR TITLE
OCPP: clear stale transaction state on Available status

### DIFF
--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -37,6 +37,18 @@ func (conn *Connector) OnStatusNotification(request *core.StatusNotificationRequ
 		conn.log.TRACE.Printf("ignoring status: %s < %s", request.Timestamp.Time, conn.status.Timestamp)
 	}
 
+	// defensive cleanup: returning to Available means the cable is unplugged
+	// and any prior transaction is stale. Some chargers (e.g. Zaptec Go 2 in
+	// local OCPP mode) skip StopTransaction or send it with an unknown
+	// TransactionId, which would otherwise leave txnId set across sessions
+	// and block the RemoteStartTransaction dispatch below.
+	if conn.status != nil && conn.status.Status == core.ChargePointStatusAvailable && conn.txnId != 0 {
+		conn.log.DEBUG.Printf("clearing stale transaction %d on Available status", conn.txnId)
+		conn.txnId = 0
+		conn.idTag = ""
+		conn.assumeMeterStopped()
+	}
+
 	if conn.isWaitingForAuth() {
 		if conn.remoteIdTag != "" {
 			// dispatch asynchronously: RemoteStartTransactionRequest issues a

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -28,21 +28,24 @@ func (conn *Connector) OnStatusNotification(request *core.StatusNotificationRequ
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
+	var applied bool
 	if conn.status == nil {
 		conn.status = request
 		close(conn.statusC) // signal initial status received
+		applied = true
 	} else if request.Timestamp == nil || conn.timestampValid(request.Timestamp.Time) {
 		conn.status = request
+		applied = true
 	} else {
 		conn.log.TRACE.Printf("ignoring status: %s < %s", request.Timestamp.Time, conn.status.Timestamp)
 	}
 
-	// defensive cleanup: returning to Available means the cable is unplugged
-	// and any prior transaction is stale. Some chargers (e.g. Zaptec Go 2 in
-	// local OCPP mode) skip StopTransaction or send it with an unknown
-	// TransactionId, which would otherwise leave txnId set across sessions
-	// and block the RemoteStartTransaction dispatch below.
-	if conn.status != nil && conn.status.Status == core.ChargePointStatusAvailable && conn.txnId != 0 {
+	// defensive cleanup: transitioning to Available means the cable is
+	// unplugged and any prior transaction is stale. Some chargers (e.g.
+	// Zaptec Go 2 in local OCPP mode) skip StopTransaction or send it with
+	// an unknown TransactionId, which would otherwise leave txnId set across
+	// sessions and block the RemoteStartTransaction dispatch below.
+	if applied && request.Status == core.ChargePointStatusAvailable && conn.txnId != 0 {
 		conn.log.DEBUG.Printf("clearing stale transaction %d on Available status", conn.txnId)
 		conn.txnId = 0
 		conn.idTag = ""

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -40,11 +40,7 @@ func (conn *Connector) OnStatusNotification(request *core.StatusNotificationRequ
 		conn.log.TRACE.Printf("ignoring status: %s < %s", request.Timestamp.Time, conn.status.Timestamp)
 	}
 
-	// defensive cleanup: transitioning to Available means the cable is
-	// unplugged and any prior transaction is stale. Some chargers (e.g.
-	// Zaptec Go 2 in local OCPP mode) skip StopTransaction or send it with
-	// an unknown TransactionId, which would otherwise leave txnId set across
-	// sessions and block the RemoteStartTransaction dispatch below.
+	// Available means cable unplugged and any prior transaction is stale
 	if applied && request.Status == core.ChargePointStatusAvailable && conn.txnId != 0 {
 		conn.log.DEBUG.Printf("clearing stale transaction %d on Available status", conn.txnId)
 		conn.txnId = 0

--- a/charger/ocpp/connector_test.go
+++ b/charger/ocpp/connector_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/suite"
 )
@@ -150,6 +151,60 @@ func (suite *connTestSuite) TestConnectorMeasurementsRunningTxn() {
 	suite.NoError(err, "Currents")
 	_, _, _, err = suite.conn.Voltages()
 	suite.NoError(err, "Voltages")
+}
+
+// TestOnStatusNotificationClearsStaleTxn ensures that a transaction left over
+// from a previous session (e.g. because the charger never sent StopTransaction,
+// like the Zaptec Go 2 in local OCPP mode) is cleared when the connector
+// returns to Available, so the next Preparing can trigger RemoteStartTransaction.
+func (suite *connTestSuite) TestOnStatusNotificationClearsStaleTxn() {
+	suite.conn.txnId = 42
+	suite.conn.idTag = "stale"
+
+	_, err := suite.conn.OnStatusNotification(&core.StatusNotificationRequest{
+		ConnectorId: 1,
+		Status:      core.ChargePointStatusAvailable,
+		ErrorCode:   core.NoError,
+		Timestamp:   types.NewDateTime(suite.clock.Now()),
+	})
+	suite.NoError(err)
+	suite.Equal(0, suite.conn.txnId, "txnId should be cleared on Available")
+	suite.Equal("", suite.conn.idTag, "idTag should be cleared on Available")
+
+	// next Preparing notification must now satisfy isWaitingForAuth
+	_, err = suite.conn.OnStatusNotification(&core.StatusNotificationRequest{
+		ConnectorId: 1,
+		Status:      core.ChargePointStatusPreparing,
+		ErrorCode:   core.NoError,
+		Timestamp:   types.NewDateTime(suite.clock.Now().Add(time.Second)),
+	})
+	suite.NoError(err)
+	suite.True(suite.conn.isWaitingForAuth(), "Preparing after Available should trigger waiting-for-auth")
+}
+
+// TestOnStatusNotificationKeepsActiveTxn ensures that an active transaction is
+// not cleared by transient status notifications other than Available.
+func (suite *connTestSuite) TestOnStatusNotificationKeepsActiveTxn() {
+	suite.conn.txnId = 42
+	suite.conn.idTag = "active"
+
+	for _, status := range []core.ChargePointStatus{
+		core.ChargePointStatusCharging,
+		core.ChargePointStatusSuspendedEV,
+		core.ChargePointStatusSuspendedEVSE,
+		core.ChargePointStatusFinishing,
+	} {
+		_, err := suite.conn.OnStatusNotification(&core.StatusNotificationRequest{
+			ConnectorId: 1,
+			Status:      status,
+			ErrorCode:   core.NoError,
+			Timestamp:   types.NewDateTime(suite.clock.Now()),
+		})
+		suite.NoError(err)
+		suite.Equal(42, suite.conn.txnId, "txnId must survive %s", status)
+		suite.Equal("active", suite.conn.idTag, "idTag must survive %s", status)
+		suite.clock.Add(time.Second)
+	}
 }
 
 func (suite *connTestSuite) TestOnStopTransactionResetsReportedPower() {

--- a/charger/ocpp/connector_test.go
+++ b/charger/ocpp/connector_test.go
@@ -158,6 +158,7 @@ func (suite *connTestSuite) TestConnectorMeasurementsRunningTxn() {
 // like the Zaptec Go 2 in local OCPP mode) is cleared when the connector
 // returns to Available, so the next Preparing can trigger RemoteStartTransaction.
 func (suite *connTestSuite) TestOnStatusNotificationClearsStaleTxn() {
+	suite.conn.remoteIdTag = "evcc"
 	suite.conn.txnId = 42
 	suite.conn.idTag = "stale"
 
@@ -171,7 +172,7 @@ func (suite *connTestSuite) TestOnStatusNotificationClearsStaleTxn() {
 	suite.Equal(0, suite.conn.txnId, "txnId should be cleared on Available")
 	suite.Equal("", suite.conn.idTag, "idTag should be cleared on Available")
 
-	// next Preparing notification must now satisfy isWaitingForAuth
+	// next Preparing notification must now satisfy NeedsAuthentication
 	_, err = suite.conn.OnStatusNotification(&core.StatusNotificationRequest{
 		ConnectorId: 1,
 		Status:      core.ChargePointStatusPreparing,
@@ -179,7 +180,7 @@ func (suite *connTestSuite) TestOnStatusNotificationClearsStaleTxn() {
 		Timestamp:   types.NewDateTime(suite.clock.Now().Add(time.Second)),
 	})
 	suite.NoError(err)
-	suite.True(suite.conn.isWaitingForAuth(), "Preparing after Available should trigger waiting-for-auth")
+	suite.True(suite.conn.NeedsAuthentication(), "Preparing after Available should require authentication")
 }
 
 // TestOnStatusNotificationKeepsActiveTxn ensures that an active transaction is
@@ -201,10 +202,38 @@ func (suite *connTestSuite) TestOnStatusNotificationKeepsActiveTxn() {
 			Timestamp:   types.NewDateTime(suite.clock.Now()),
 		})
 		suite.NoError(err)
-		suite.Equal(42, suite.conn.txnId, "txnId must survive %s", status)
-		suite.Equal("active", suite.conn.idTag, "idTag must survive %s", status)
+		suite.Equalf(42, suite.conn.txnId, "txnId must survive %s", status)
+		suite.Equalf("active", suite.conn.idTag, "idTag must survive %s", status)
 		suite.clock.Add(time.Second)
 	}
+}
+
+// TestOnStatusNotificationKeepsTxnOnIgnoredAvailable ensures we do not clear
+// transaction state when an Available notification is rejected due to an
+// outdated timestamp (i.e. the cached status remains the current one).
+func (suite *connTestSuite) TestOnStatusNotificationKeepsTxnOnIgnoredAvailable() {
+	// prime with a recent Charging status
+	_, err := suite.conn.OnStatusNotification(&core.StatusNotificationRequest{
+		ConnectorId: 1,
+		Status:      core.ChargePointStatusCharging,
+		ErrorCode:   core.NoError,
+		Timestamp:   types.NewDateTime(suite.clock.Now()),
+	})
+	suite.NoError(err)
+	suite.conn.txnId = 42
+	suite.conn.idTag = "active"
+
+	// out-of-order Available with an older timestamp must be ignored
+	// and must not clear the running transaction
+	_, err = suite.conn.OnStatusNotification(&core.StatusNotificationRequest{
+		ConnectorId: 1,
+		Status:      core.ChargePointStatusAvailable,
+		ErrorCode:   core.NoError,
+		Timestamp:   types.NewDateTime(suite.clock.Now().Add(-time.Minute)),
+	})
+	suite.NoError(err)
+	suite.Equal(42, suite.conn.txnId, "txnId must survive ignored Available")
+	suite.Equal("active", suite.conn.idTag, "idTag must survive ignored Available")
 }
 
 func (suite *connTestSuite) TestOnStopTransactionResetsReportedPower() {


### PR DESCRIPTION
## Summary

Fixes #29190 — Zaptec Go 2 (and likely other chargers) in local OCPP mode skip `StopTransaction` at the end of a session, or send it with a `TransactionId` that evcc cannot route. The connector's `txnId` then stays non-zero across sessions, so on the next plug-in `isWaitingForAuth()` (status `Preparing` && `txnId == 0`) returns false and the `RemoteStartTransaction` dispatch in `OnStatusNotification` never fires. The user sees an empty RFID identifier in the UI and charging only resumes after restarting evcc.

The reporter's OCPP trace confirms it: a clean `StatusNotification(Preparing)` arrives on reconnect, but evcc never sends `RemoteStartTransaction` — only `TriggerMessage`/`SetChargingProfile` traffic.

## Fix

When the charge point transitions to `Available`, the cable is unplugged and any prior transaction is by definition stale. Reset `txnId`/`idTag` and zero the meter (mirroring `OnStopTransaction`) so the next `Preparing` correctly triggers the remote start. The cleanup runs only when the incoming `StatusNotification` was actually applied (i.e. not rejected as out-of-order by `timestampValid`), and is gated on `request.Status` rather than the cached `conn.status.Status`:

```go
if applied && request.Status == core.ChargePointStatusAvailable && conn.txnId != 0 {
    conn.log.DEBUG.Printf("clearing stale transaction %d on Available status", conn.txnId)
    conn.txnId = 0
    conn.idTag = ""
    conn.assumeMeterStopped()
}
```

The cleanup is defensive — when the charger does send `StopTransaction`, `txnId` is already 0 and the branch is a no-op.

## Tests

- `TestOnStatusNotificationClearsStaleTxn` — simulates the Zaptec scenario: leftover `txnId`/`idTag`, an `Available` notification clears them, the following `Preparing` satisfies `NeedsAuthentication()`.
- `TestOnStatusNotificationKeepsActiveTxn` — guards against over-reach: `Charging`/`SuspendedEV`/`SuspendedEVSE`/`Finishing` must not clear an active transaction.
- `TestOnStatusNotificationKeepsTxnOnIgnoredAvailable` — an out-of-order `Available` whose timestamp is older than the cached status is ignored and must not clear a running transaction.

## Test plan

- [x] `go test ./charger/ocpp/ -count=1 -race`
- [x] `go test ./charger/ -run TestOcpp -count=1`
- [ ] Field test by issue reporter (Zaptec Go 2, repeated plug/unplug cycles without evcc restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)