### PR TITLE
AGENTS.md: writing/comment style and posting-on-behalf rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 ## Comment Style
 
 - Prefer self-documenting code over comments; comment the *why*, not the *what*
-- Default to no comment. Only add one for a non-obvious constraint, invariant, workaround, or surprising behavior. Then one line, two if necessary
+- Default to no comment. Only add one for a non-obvious constraint, invariant, workaround, or surprising behavior. Keep it to one line, two if necessary
 - Skip refs to the current task, PR, issue, or caller ("added for X flow", "see #1234"). Git history covers that
 - Exception: Go exported identifiers follow godoc convention. Short `// FuncName does X` summary starting with the identifier name
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,10 +284,6 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - Implement proper caching strategies and connection pooling
 - Avoid blocking operations in main application loop
 
-## Posting on the User's Behalf
-
-- Never impersonate the user when posting on their behalf. PR/issue comments, review replies, and other messages should read as the agent speaking; do not adopt first-person framing or sign-off as if the user themselves wrote it
-
 ## Pull Request Descriptions
 
 Structure PR descriptions in this order. No headlines. Be concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,20 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - **tests/** contains Playwright integration tests and test configuration files
 - **dist/** contains built frontend assets (generated)
 
+## Writing Style
+
+- No em dashes (—) in comments, commit messages, or docs. Use periods, commas, or colons
+- Project name is `evcc`, always lowercase
+- Acronyms uppercase in prose: OCPP, MQTT, HEMS, SoC
+- Commit subjects: `Component: short description`, no trailing period. Sub-scope in parens: `Meter (Home Assistant): ...`. Use `chore:`/`fix:`/`docs:` only for non-feature changes
+
+## Comment Style
+
+- Prefer self-documenting code over comments; comment the *why*, not the *what*
+- Default to no comment. Only add one for a non-obvious constraint, invariant, workaround, or surprising behavior. Then one line, two if necessary
+- Skip refs to the current task, PR, issue, or caller ("added for X flow", "see #1234"). Git history covers that
+- Exception: Go exported identifiers follow godoc convention. Short `// FuncName does X` summary starting with the identifier name
+
 ## Go Coding Standards
 
 ### Core Principles
@@ -269,7 +283,10 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - Handle concurrent operations safely with Go's concurrency primitives
 - Implement proper caching strategies and connection pooling
 - Avoid blocking operations in main application loop
-- Include appropriate comments for complex business logic
+
+## Posting on the User's Behalf
+
+- Never impersonate the user when posting on their behalf. PR/issue comments, review replies, and other messages should read as the agent speaking; do not adopt first-person framing or sign-off as if the user themselves wrote it
 
 ## Pull Request Descriptions
 


### PR DESCRIPTION
split from #30196

Hoist the writing-style and comment-style guidance out of the metrics PR so it can land independently, and add a rule that agents must not impersonate the user when posting on their behalf (PR/issue comments, review replies, etc).

- new Writing Style section (em dashes, casing, commit subjects)
- new Comment Style section (default to no comment, godoc exception)
- new Posting on the User's Behalf section (no impersonation)
- drop the now-superseded "Include appropriate comments for complex business logic" bullet