### PR TITLE
VW/Audi: migrate token endpoint to /auth/v1/idk/oidc/token

### DIFF
--- a/vehicle/vag/idkproxy/endpoint.go
+++ b/vehicle/vag/idkproxy/endpoint.go
@@ -22,7 +22,7 @@ const WellKnown = cariad.BaseURL + "/login/v1/idk/openid-configuration"
 
 var Config = &oidc.ProviderConfig{
 	AuthURL:  "https://identity.vwgroup.io/oidc/v1/authorize",
-	TokenURL: cariad.BaseURL + "/login/v1/idk/token",
+	TokenURL: cariad.BaseURL + "/auth/v1/idk/oidc/token",
 }
 
 var _ vag.TokenExchanger = (*Service)(nil)

--- a/vehicle/vag/loginapps/endpoint.go
+++ b/vehicle/vag/loginapps/endpoint.go
@@ -62,7 +62,7 @@ func (v *Service) Refresh(token *Token) (*Token, error) {
 
 	req, err := request.New(
 		http.MethodPost,
-		cariad.BaseURL+"/login/v1/idk/token",
+		cariad.BaseURL+"/auth/v1/idk/oidc/token",
 		strings.NewReader(body.Encode()),
 		request.URLEncoding,
 		map[string]string{


### PR DESCRIPTION
VW migrated the OIDC token endpoint on the cariad BFF from `/login/v1/idk/token` to `/auth/v1/idk/oidc/token` (per Volkswagen 3.61.0 APK, `ProductionEnvironment.smali`).

Affects:
- Audi (`idkproxy`) initial exchange and refresh
- VW WeConnect (`loginapps`) refresh

Refs:
- https://github.com/TA2k/ioBroker.vw-connect/commit/54f448262 (VW)
- https://github.com/TA2k/ioBroker.vw-connect/commit/feed25020 (Audi)
- evcc-io/evcc#30236

Untested against live accounts.