### PR TITLE
Metrics: ignore meter rollback to avoid spurious energy spike

### DIFF
--- a/core/metrics/accumulator.go
+++ b/core/metrics/accumulator.go
@@ -60,36 +60,42 @@ func (m *Accumulator) Exported() float64 {
 	return m.ReturnEnergy
 }
 
-// SetImportMeterTotal adds the difference to the last total meter value in kWh
+// SetImportMeterTotal adds the difference to the last total meter value in kWh.
+// A reading below the last seen total is treated as a transient bad sample and
+// ignored. Otherwise a single low/zero read would become the new baseline and
+// the next valid read would book the entire lifetime total as a single delta.
 func (m *Accumulator) SetImportMeterTotal(v float64) {
-	defer func() {
-		m.updated = m.clock.Now()
-		m.importMeter = new(v)
-	}()
+	m.updated = m.clock.Now()
 
 	if m.importMeter == nil {
+		m.importMeter = new(v)
 		return
 	}
 
-	if v >= *m.importMeter {
-		m.Energy += v - *m.importMeter
+	if v < *m.importMeter {
+		return
 	}
+
+	m.Energy += v - *m.importMeter
+	m.importMeter = new(v)
 }
 
-// SetExportMeterTotal adds the difference to the last total meter value in kWh
+// SetExportMeterTotal adds the difference to the last total meter value in kWh.
+// See SetImportMeterTotal for the rollback handling rationale.
 func (m *Accumulator) SetExportMeterTotal(v float64) {
-	defer func() {
-		m.updated = m.clock.Now()
-		m.exportMeter = new(v)
-	}()
+	m.updated = m.clock.Now()
 
 	if m.exportMeter == nil {
+		m.exportMeter = new(v)
 		return
 	}
 
-	if v >= *m.exportMeter {
-		m.ReturnEnergy += v - *m.exportMeter
+	if v < *m.exportMeter {
+		return
 	}
+
+	m.ReturnEnergy += v - *m.exportMeter
+	m.exportMeter = new(v)
 }
 
 // AddImportEnergy adds the given energy in kWh to the positive meter

--- a/core/metrics/accumulator.go
+++ b/core/metrics/accumulator.go
@@ -65,10 +65,9 @@ func (m *Accumulator) Exported() float64 {
 // ignored. Otherwise a single low/zero read would become the new baseline and
 // the next valid read would book the entire lifetime total as a single delta.
 func (m *Accumulator) SetImportMeterTotal(v float64) {
-	m.updated = m.clock.Now()
-
 	if m.importMeter == nil {
 		m.importMeter = new(v)
+		m.updated = m.clock.Now()
 		return
 	}
 
@@ -78,15 +77,15 @@ func (m *Accumulator) SetImportMeterTotal(v float64) {
 
 	m.Energy += v - *m.importMeter
 	m.importMeter = new(v)
+	m.updated = m.clock.Now()
 }
 
 // SetExportMeterTotal adds the difference to the last total meter value in kWh.
 // See SetImportMeterTotal for the rollback handling rationale.
 func (m *Accumulator) SetExportMeterTotal(v float64) {
-	m.updated = m.clock.Now()
-
 	if m.exportMeter == nil {
 		m.exportMeter = new(v)
+		m.updated = m.clock.Now()
 		return
 	}
 
@@ -96,6 +95,7 @@ func (m *Accumulator) SetExportMeterTotal(v float64) {
 
 	m.ReturnEnergy += v - *m.exportMeter
 	m.exportMeter = new(v)
+	m.updated = m.clock.Now()
 }
 
 // AddImportEnergy adds the given energy in kWh to the positive meter

--- a/core/metrics/accumulator_test.go
+++ b/core/metrics/accumulator_test.go
@@ -23,6 +23,32 @@ func TestMeterEnergyMeterTotal(t *testing.T) {
 	assert.Equal(t, 1.0, me.Imported())
 }
 
+// A transient low/zero meter reading (Modbus glitch) must not become the new
+// baseline. Regression test for evcc-io/evcc#29286.
+func TestMeterEnergyMeterTotalRollback(t *testing.T) {
+	clock := clock.NewMock()
+	clock.Set(now.BeginningOfDay())
+
+	me := &Accumulator{clock: clock}
+
+	me.SetImportMeterTotal(25567.546)
+	assert.Equal(t, 0.0, me.Imported())
+	me.SetImportMeterTotal(25567.548)
+	assert.InDelta(t, 0.002, me.Imported(), 1e-9)
+	me.SetImportMeterTotal(0) // transient bad read
+	assert.InDelta(t, 0.002, me.Imported(), 1e-9)
+	me.SetImportMeterTotal(25567.550) // baseline preserved, delta is +0.002
+	assert.InDelta(t, 0.004, me.Imported(), 1e-9)
+
+	me.SetExportMeterTotal(100)
+	me.SetExportMeterTotal(101)
+	assert.Equal(t, 1.0, me.Exported())
+	me.SetExportMeterTotal(0)
+	assert.Equal(t, 1.0, me.Exported())
+	me.SetExportMeterTotal(102)
+	assert.Equal(t, 2.0, me.Exported())
+}
+
 func TestMeterEnergyAddPower(t *testing.T) {
 	clock := clock.NewMock()
 	clock.Set(now.BeginningOfDay())

--- a/core/metrics/accumulator_test.go
+++ b/core/metrics/accumulator_test.go
@@ -35,10 +35,17 @@ func TestMeterEnergyMeterTotalRollback(t *testing.T) {
 	assert.Equal(t, 0.0, me.Imported())
 	me.SetImportMeterTotal(25567.548)
 	assert.InDelta(t, 0.002, me.Imported(), 1e-9)
+
+	good := me.Updated()
+	clock.Add(time.Second)
 	me.SetImportMeterTotal(0) // transient bad read
 	assert.InDelta(t, 0.002, me.Imported(), 1e-9)
+	assert.Equal(t, good, me.Updated(), "updated must not advance on rejected rollback")
+
+	clock.Add(time.Second)
 	me.SetImportMeterTotal(25567.550) // baseline preserved, delta is +0.002
 	assert.InDelta(t, 0.004, me.Imported(), 1e-9)
+	assert.True(t, me.Updated().After(good), "updated must advance on accepted reading")
 
 	me.SetExportMeterTotal(100)
 	me.SetExportMeterTotal(101)


### PR DESCRIPTION
fixes #29286

A transient low/zero reading from the meter (Modbus glitch, brief disconnect) silently became the new baseline because the `defer` in `SetImportMeterTotal` / `SetExportMeterTotal` rebased the cached total even when the rollback branch was taken. The next valid reading then booked the entire lifetime total as a single slot delta, surfacing as a >100 GW spike in the new history view.

Repro from the issue: TotWhImp reads 25567.548 kWh at both 22:45:07 and 23:00:07; the 23:00:07 row persisted as `energy=25567.548` while a healthy 15-minute slot is ~0.002 kWh. Some intermediate poll must have returned a low value, which the defer accepted as the new baseline.

Skip the update on rollback so the prior good baseline is retained, and add a regression test covering the bad-read sequence.