### PR TITLE
Vehicle (Nissan Ariya/Micra): expose expiry as advanced parameter

### DIFF
--- a/templates/definition/vehicle/nissan-ariya.yaml
+++ b/templates/definition/vehicle/nissan-ariya.yaml
@@ -8,7 +8,20 @@ products:
       generic: Micra
 params:
   - preset: vehicle-base
+  - name: expiry
+    description:
+      de: Ablauf
+      en: Expiry
+    help:
+      de: Maximales Alter der Daten vor erneuter Abfrage
+      en: Maximum data age before refresh
+    advanced: true
+    type: duration
+    example: 5m
 render: |
   type: nissan
   version: v2
   {{ include "vehicle-base" . }}
+  {{- if .expiry }}
+  expiry: {{ .expiry }}
+  {{- end }}

--- a/templates/definition/vehicle/nissan-ariya.yaml
+++ b/templates/definition/vehicle/nissan-ariya.yaml
@@ -22,6 +22,4 @@ render: |
   type: nissan
   version: v2
   {{ include "vehicle-base" . }}
-  {{- if .expiry }}
   expiry: {{ .expiry }}
-  {{- end }}


### PR DESCRIPTION
closes #30258

The nissan provider already accepts an `expiry` config that bounds how old the cached SOC reading can be before evcc forces a refresh. Stale readings from the Kamereon backend are common on the Ariya/Micra, so make the parameter editable in the UI as an advanced option (with the same 5m `type: duration` shape as `cache`) instead of requiring a hand-written YAML template.