### PR TITLE
Add Kaco Blueplanet

### DIFF
--- a/templates/definition/meter/kaco-blueplanet.yaml
+++ b/templates/definition/meter/kaco-blueplanet.yaml
@@ -5,9 +5,6 @@ params:
     required: true
   - name: serial
     required: true
-    description:
-      en: The serial number of the inverter to query
-      de: Die Seriennummer des Kaco-Wechselrichters
     example: 8.0NX312001234
 render: |
   type: custom

--- a/templates/definition/meter/kaco-blueplanet.yaml
+++ b/templates/definition/meter/kaco-blueplanet.yaml
@@ -6,7 +6,7 @@ params:
     description:
       en: The IP address of the inverter to query
       de: Die IP-Adresse des Kaco-Wechselrichters
-    example: 192.168.0.123    
+    example: 192.168.0.123
   - name: sn
     required: true
     description:

--- a/templates/definition/meter/kaco-blueplanet.yaml
+++ b/templates/definition/meter/kaco-blueplanet.yaml
@@ -1,0 +1,20 @@
+params:
+  - name: usage
+    choice: ["pv"]
+  - name: host
+    required: true
+    description:
+      en: The IP address of the inverter to query
+      de: Die IP-Adresse des Kaco-Wechselrichters
+    example: 192.168.0.123    
+  - name: sn
+    required: true
+    description:
+      en: The serial number of the inverter to query
+      de: Die Seriennummer des Kaco-Wechselrichters
+    example: 8.0NX312001234Expand commentComment on lines R9 to R20Resolved
+render: |
+  type: custom
+  power:
+    source: http
+    uri: http://{{ .host }}/getdevdata.cgi?device=2&sn={{ .sn }}

--- a/templates/definition/meter/kaco-blueplanet.yaml
+++ b/templates/definition/meter/kaco-blueplanet.yaml
@@ -12,7 +12,7 @@ params:
     description:
       en: The serial number of the inverter to query
       de: Die Seriennummer des Kaco-Wechselrichters
-    example: 8.0NX312001234Expand commentComment on lines R9 to R20Resolved
+    example: 8.0NX312001234
 render: |
   type: custom
   power:

--- a/templates/definition/meter/kaco-blueplanet.yaml
+++ b/templates/definition/meter/kaco-blueplanet.yaml
@@ -3,11 +3,7 @@ params:
     choice: ["pv"]
   - name: host
     required: true
-    description:
-      en: The IP address of the inverter to query
-      de: Die IP-Adresse des Kaco-Wechselrichters
-    example: 192.168.0.123
-  - name: sn
+  - name: serial
     required: true
     description:
       en: The serial number of the inverter to query
@@ -17,4 +13,4 @@ render: |
   type: custom
   power:
     source: http
-    uri: http://{{ .host }}/getdevdata.cgi?device=2&sn={{ .sn }}
+    uri: http://{{ .host }}/getdevdata.cgi?device=2&sn={{ .serial }}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/30335

This add support for Kaco bluplanet NX via the http api.
It uses unsecure http request as the Kaco doesn't support https.
