### PR TITLE
Browser quirk: skip duplicate customElements.define

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -1,3 +1,4 @@
+import "./utils/customElementsGuard"; // must be first — protects against double-define
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../css/app.css";
 import { createApp, defineComponent, h } from "vue";

--- a/assets/js/utils/customElementsGuard.ts
+++ b/assets/js/utils/customElementsGuard.ts
@@ -1,0 +1,47 @@
+// Side-effect module: must be imported BEFORE any code that defines custom
+// elements (e.g. before shopicons-style web-component imports).
+//
+// Some browsers re-execute the page's scripts a second time after stripping
+// HTTP Basic Auth credentials from a `https://user:pw@host/...` URL (observed
+// in Brave/Chromium and the Tesla MCU built-in browser). The same bundle is
+// fetched and run twice in the same document, which means every
+// `customElements.define(...)` call from the second execution throws a
+// `NotSupportedError: "<name>" has already been used with this registry`.
+// That uncaught error aborts framework initialization and the UI never renders
+// past the static shell.
+//
+// Wrap the registry's `define` to silently skip names that are already
+// registered. The first registration wins; further definitions of the same
+// name are no-ops. Behaviour for new names is unchanged.
+
+const WRAPPED = Symbol.for("evcc.customElementsGuard.wrapped");
+
+if (
+  typeof window !== "undefined" &&
+  "customElements" in window &&
+  !(customElements as unknown as Record<symbol, boolean>)[WRAPPED]
+) {
+  const originalDefine = customElements.define.bind(customElements);
+  let warned = false;
+
+  customElements.define = function (
+    name: string,
+    constructor: CustomElementConstructor,
+    options?: ElementDefinitionOptions
+  ): void {
+    if (customElements.get(name)) {
+      if (!warned) {
+        console.warn(
+          `customElementsGuard: suppressed duplicate registration of "${name}". ` +
+            "Likely cause: browser re-executed scripts after stripping URL credentials. " +
+            "Further duplicates silenced."
+        );
+        warned = true;
+      }
+      return;
+    }
+    originalDefine(name, constructor, options);
+  };
+
+  (customElements as unknown as Record<symbol, boolean>)[WRAPPED] = true;
+}


### PR DESCRIPTION
  ### What

  Tiny defensive guard around `customElements.define` that turns a duplicate registration into a no-op (with a one-time `console.warn` for diagnostics).

  ### Why

  When evcc is opened via a URL with Basic Auth credentials like `https://user:pw@evcc.example.com/`, some browsers (Brave/Chromium and the Tesla MCU  built-in browser) fetch and execute the page bundle twice in the same document — the second execution after stripping the URL credentials. The second  execution throws `NotSupportedError` on `customElements.define` for the already-registered shopicon web components, which aborts Vue init. Result: only
  the bottom tab bar renders, the dashboard area is blank.

  I hit this on my own Tesla bookmark and could reproduce it on desktop Brave. The bundle on the network tab is visibly requested twice (200 then 304). The  guard makes the SPA tolerate the second run.

  Related (closed/discussion) — same observable symptom, different attributed cause at the time:
  - #27447
  - #18095

  ### Scope

  - 1 new file: `assets/js/utils/customElementsGuard.ts`
  - 1 import in `assets/js/app.ts` (must run first)

  No new config, no UA sniffing, no behaviour change on browsers that load the bundle once. Browsers that don't, get a single `console.warn` and a working  UI.