### PR TITLE
Huawei SUN2000: fix energy yield

### DIFF
--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -123,14 +123,40 @@ render: |
       type: holding
       decode: int32nan
   energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    timeout: {{ .timeout }}
-    register:
-      address: 32106 # Accumulated energy yield
-      type: holding
-      decode: uint32nan
-    scale: 0.01
+    source: calc
+    add:
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        timeout: {{ .timeout }}
+        register:
+          address: 32212 # MPPT1 DC cumulative energy
+          type: holding
+          decode: uint32
+        scale: 0.01
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        timeout: {{ .timeout }}
+        register:
+          address: 32214 # MPPT2 DC cumulative energy
+          type: holding
+          decode: uint32
+        scale: 0.01
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        timeout: {{ .timeout }}
+        register:
+          address: 32216 # MPPT3 DC cumulative energy
+          type: holding
+          decode: uint32
+        scale: 0.01
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        timeout: {{ .timeout }}
+        register:
+          address: 32218 # MPPT4 DC cumulative energy
+          type: holding
+          decode: uint32
+        scale: 0.01
   maxacpower: {{ .maxacpower }}
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -123,40 +123,14 @@ render: |
       type: holding
       decode: int32nan
   energy:
-    source: calc
-    add:
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        timeout: {{ .timeout }}
-        register:
-          address: 32212 # MPPT1 DC cumulative energy
-          type: holding
-          decode: uint32nan
-        scale: 0.01
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        timeout: {{ .timeout }}
-        register:
-          address: 32214 # MPPT2 DC cumulative energy
-          type: holding
-          decode: uint32nan
-        scale: 0.01
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        timeout: {{ .timeout }}
-        register:
-          address: 32216 # MPPT3 DC cumulative energy
-          type: holding
-          decode: uint32nan
-        scale: 0.01
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        timeout: {{ .timeout }}
-        register:
-          address: 32218 # MPPT4 DC cumulative energy
-          type: holding
-          decode: uint32nan
-        scale: 0.01
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
+    register:
+      address: 32106 # Accumulated energy yield
+      type: holding
+      decode: uint32nan
+    scale: 0.01
   maxacpower: {{ .maxacpower }}
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -131,7 +131,7 @@ render: |
         register:
           address: 32212 # MPPT1 DC cumulative energy
           type: holding
-          decode: uint32
+          decode: uint32nan
         scale: 0.01
       - source: modbus
         {{- include "modbus" . | indent 6 }}
@@ -139,7 +139,7 @@ render: |
         register:
           address: 32214 # MPPT2 DC cumulative energy
           type: holding
-          decode: uint32
+          decode: uint32nan
         scale: 0.01
       - source: modbus
         {{- include "modbus" . | indent 6 }}
@@ -147,7 +147,7 @@ render: |
         register:
           address: 32216 # MPPT3 DC cumulative energy
           type: holding
-          decode: uint32
+          decode: uint32nan
         scale: 0.01
       - source: modbus
         {{- include "modbus" . | indent 6 }}
@@ -155,7 +155,7 @@ render: |
         register:
           address: 32218 # MPPT4 DC cumulative energy
           type: holding
-          decode: uint32
+          decode: uint32nan
         scale: 0.01
   maxacpower: {{ .maxacpower }}
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -127,7 +127,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      address: 32106 # Accumulated energy yield
+      address: 32108 # Total DC Input Power
       type: holding
       decode: uint32nan
     scale: 0.01

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -127,7 +127,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      address: 32108 # Total DC Input Power
+      address: 32108 # Total DC Input Energy
       type: holding
       decode: uint32nan
     scale: 0.01


### PR DESCRIPTION
fixes #30344

<img width="311" height="265" alt="image" src="https://github.com/user-attachments/assets/a7374ccf-77fb-42c9-ae29-fb066b7d90ad" />

(18.513,86+8.810,34+0+0=27.324,2)

/cc @SamJack357

Only documented for SUN2000MB, but also present for SUN2000MA:
<img width="542" height="410" alt="image" src="https://github.com/user-attachments/assets/1abcdd73-c4c3-4675-8fef-446abfa9a57f" />