### PR TITLE
Core: settle-lock actuation gate + pending scheduler

### DIFF
--- a/core/actuationgate.go
+++ b/core/actuationgate.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// errActuationDeferred signals that an actuation was postponed by the settle
+// lock. It is not a failure: the loadpoint schedules a retry and re-decides on
+// the next pass. Callers treat it as a silent no-op.
+var errActuationDeferred = errors.New("actuation deferred by settle lock")
+
+// actuationGate enforces a minimum spacing ("settle lock") between
+// budget-increasing actuations across the whole site. It decouples how often
+// loadpoints are evaluated (fast, event-driven) from how often setpoints are
+// actually changed (spaced by the lock), preventing several loadpoints from
+// grabbing surplus before the meters reflect the previous change.
+type actuationGate struct {
+	mu    sync.Mutex
+	clock clock.Clock
+	lock  time.Duration
+	last  time.Time
+}
+
+// newActuationGate returns a gate spacing actuations by lock, driven by clk.
+func newActuationGate(clk clock.Clock, lock time.Duration) *actuationGate {
+	return &actuationGate{clock: clk, lock: lock}
+}
+
+// tryAcquire reports whether an actuation may proceed now. On success it stamps
+// the gate so subsequent actuations are held off for the lock duration; on
+// denial it returns the remaining lock so the caller can schedule a retry.
+func (g *actuationGate) tryAcquire() (bool, time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.lock <= 0 {
+		return true, 0
+	}
+
+	if !g.last.IsZero() {
+		if elapsed := g.clock.Now().Sub(g.last); elapsed < g.lock {
+			return false, g.lock - elapsed
+		}
+	}
+
+	g.last = g.clock.Now()
+	return true, 0
+}

--- a/core/actuationgate_test.go
+++ b/core/actuationgate_test.go
@@ -1,0 +1,182 @@
+package core
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"go.uber.org/mock/gomock"
+)
+
+// TestActuationGate covers the gate in isolation: first acquire grants, a second
+// within the lock is denied with the remaining duration, and after the lock
+// expires it grants again. A non-positive lock always grants.
+func TestActuationGate(t *testing.T) {
+	clk := clock.NewMock()
+	g := newActuationGate(clk, time.Minute)
+
+	if granted, _ := g.tryAcquire(); !granted {
+		t.Fatal("first acquire must be granted")
+	}
+
+	clk.Add(20 * time.Second)
+	if granted, retryAfter := g.tryAcquire(); granted || retryAfter != 40*time.Second {
+		t.Fatalf("within lock: granted=%v retryAfter=%v, want false / 40s", granted, retryAfter)
+	}
+
+	clk.Add(40 * time.Second) // now exactly at the lock boundary
+	if granted, _ := g.tryAcquire(); !granted {
+		t.Fatal("acquire after lock expiry must be granted")
+	}
+
+	// non-positive lock disables gating
+	g0 := newActuationGate(clk, 0)
+	if granted, _ := g0.tryAcquire(); !granted {
+		t.Fatal("zero lock must always grant")
+	}
+}
+
+func newGateLoadpoint(t *testing.T, charger api.Charger, clk clock.Clock, gate *actuationGate) *Loadpoint {
+	t.Helper()
+	return &Loadpoint{
+		log:         util.NewLogger("foo"),
+		clock:       clk,
+		bus:         evbus.New(),
+		charger:     charger,
+		wakeUpTimer: NewTimer(),
+		minCurrent:  minA,
+		maxCurrent:  maxA,
+		gate:        gate,
+	}
+}
+
+// TestSetLimitGateDefersIncrease verifies that a budget-increasing actuation is
+// deferred while the settle lock is active and proceeds once it expires.
+func TestSetLimitGateDefersIncrease(t *testing.T) {
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := newGateLoadpoint(t, charger, clk, newActuationGate(clk, time.Minute))
+
+	// initial enable from disabled: grants (gate fresh)
+	charger.EXPECT().MaxCurrent(int64(minA)).Return(nil)
+	charger.EXPECT().Enable(true).Return(nil)
+	if err := lp.setLimit(minA); err != nil {
+		t.Fatalf("initial setLimit: %v", err)
+	}
+
+	// raise current immediately: within lock -> deferred, no charger calls
+	if err := lp.setLimit(maxA); err != nil {
+		t.Fatalf("deferred setLimit must be a silent no-op, got %v", err)
+	}
+	if lp.offeredCurrent != minA {
+		t.Fatalf("offeredCurrent changed despite deferral: %v", lp.offeredCurrent)
+	}
+	if !lp.pendingControl.Load() {
+		t.Fatal("deferral must mark the loadpoint pending")
+	}
+
+	// after the lock expires the raise proceeds
+	clk.Add(time.Minute)
+	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
+	if err := lp.setLimit(maxA); err != nil {
+		t.Fatalf("setLimit after lock: %v", err)
+	}
+	if lp.offeredCurrent != maxA {
+		t.Fatalf("offeredCurrent not raised: %v", lp.offeredCurrent)
+	}
+}
+
+// TestSetLimitGateBypassesDecrease verifies that reductions are never blocked by
+// the settle lock, even while it is active.
+func TestSetLimitGateBypassesDecrease(t *testing.T) {
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	gate := newActuationGate(clk, time.Minute)
+	gate.tryAcquire() // stamp: gate is now locked
+
+	lp := newGateLoadpoint(t, charger, clk, gate)
+	lp.enabled = true
+	lp.offeredCurrent = maxA
+
+	// decrease while the lock is active must go through immediately
+	charger.EXPECT().MaxCurrent(int64(minA)).Return(nil)
+	if err := lp.setLimit(minA); err != nil {
+		t.Fatalf("decrease setLimit: %v", err)
+	}
+	if lp.offeredCurrent != minA {
+		t.Fatalf("offeredCurrent not reduced: %v", lp.offeredCurrent)
+	}
+}
+
+// TestScalePhasesGateBothDirections verifies that phase switches acquire the gate
+// in both directions (a switch causes a charging pause that must hold off others).
+func TestScalePhasesGateBothDirections(t *testing.T) {
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+
+	phaseSwitcher := api.NewMockPhaseSwitcher(ctrl)
+	charger := struct {
+		*api.MockCharger
+		*api.MockPhaseSwitcher
+	}{
+		api.NewMockCharger(ctrl), phaseSwitcher,
+	}
+
+	gate := newActuationGate(clk, time.Minute)
+	gate.tryAcquire() // stamp: gate is now locked
+
+	lp := newGateLoadpoint(t, charger, clk, gate)
+	lp.phases = 1
+
+	// scale-up within lock -> deferred, no switch
+	if err := lp.scalePhases(3); !errors.Is(err, errActuationDeferred) {
+		t.Fatalf("scale-up within lock: want errActuationDeferred, got %v", err)
+	}
+
+	// after lock expiry the up-switch proceeds (and re-stamps the gate)
+	clk.Add(time.Minute)
+	phaseSwitcher.EXPECT().Phases1p3p(3).Return(nil)
+	if err := lp.scalePhases(3); err != nil {
+		t.Fatalf("scale-up after lock: %v", err)
+	}
+
+	// down-switch immediately after is gated too -> deferred, no Phases1p3p(1)
+	if err := lp.scalePhases(1); !errors.Is(err, errActuationDeferred) {
+		t.Fatalf("scale-down within lock: want errActuationDeferred, got %v", err)
+	}
+}
+
+// TestLoopLoadpointsPrefersPending verifies the scheduler hands out a pending
+// loadpoint before advancing the round-robin cursor.
+func TestLoopLoadpointsPrefersPending(t *testing.T) {
+	lp0 := &Loadpoint{log: util.NewLogger("lp0")}
+	lp1 := &Loadpoint{log: util.NewLogger("lp1")}
+
+	site := &Site{
+		log:        util.NewLogger("site"),
+		loadpoints: []*Loadpoint{lp0, lp1},
+	}
+
+	lp1.pendingControl.Store(true)
+
+	next := make(chan updater)
+	go site.loopLoadpoints(next)
+
+	if got := <-next; got != lp1 {
+		t.Fatalf("first dispatch: want pending lp1, got %v", got)
+	}
+	if lp1.pendingControl.Load() {
+		t.Fatal("pending flag must be cleared on dispatch")
+	}
+	if got := <-next; got != lp0 {
+		t.Fatalf("second dispatch: want round-robin lp0, got %v", got)
+	}
+}

--- a/core/actuationgate_test.go
+++ b/core/actuationgate_test.go
@@ -154,29 +154,5 @@ func TestScalePhasesGateBothDirections(t *testing.T) {
 	}
 }
 
-// TestLoopLoadpointsPrefersPending verifies the scheduler hands out a pending
-// loadpoint before advancing the round-robin cursor.
-func TestLoopLoadpointsPrefersPending(t *testing.T) {
-	lp0 := &Loadpoint{log: util.NewLogger("lp0")}
-	lp1 := &Loadpoint{log: util.NewLogger("lp1")}
-
-	site := &Site{
-		log:        util.NewLogger("site"),
-		loadpoints: []*Loadpoint{lp0, lp1},
-	}
-
-	lp1.pendingControl.Store(true)
-
-	next := make(chan updater)
-	go site.loopLoadpoints(next)
-
-	if got := <-next; got != lp1 {
-		t.Fatalf("first dispatch: want pending lp1, got %v", got)
-	}
-	if lp1.pendingControl.Load() {
-		t.Fatal("pending flag must be cleared on dispatch")
-	}
-	if got := <-next; got != lp0 {
-		t.Fatalf("second dispatch: want round-robin lp0, got %v", got)
-	}
-}
+// loopLoadpoints scheduler tests live in scheduler_test.go (the scheduler
+// outlives the actuation gate, which is removed in a later phase).

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -91,6 +91,11 @@ type Loadpoint struct {
 	vmu          sync.RWMutex // guard vehicle
 	measureMu    sync.Mutex   // serialize meter measurement reads across sense and control loops
 
+	gate           *actuationGate // site-wide settle lock for budget-increasing actuations (nil = disabled)
+	pendingControl atomic.Bool    // control re-evaluation requested (scheduler hint)
+	retryMu        sync.Mutex     // guards retryTimer
+	retryTimer     *clock.Timer   // deferred actuation retry
+
 	// exposed public configuration
 	CircuitRef string `mapstructure:"circuit"` // Circuit reference
 	ChargerRef string `mapstructure:"charger"` // Charger reference
@@ -397,10 +402,31 @@ func (lp *Loadpoint) restoreSettings() {
 
 // requestUpdate requests site to update this loadpoint
 func (lp *Loadpoint) requestUpdate() {
+	lp.pendingControl.Store(true) // persists even if the cap(1) channel send is dropped
 	select {
 	case lp.lpChan <- lp: // request loadpoint update
 	default:
 	}
+}
+
+// setActuationGate wires the site-wide settle lock into the loadpoint.
+func (lp *Loadpoint) setActuationGate(g *actuationGate) {
+	lp.gate = g
+}
+
+// deferActuation postpones a budget-increasing actuation until the settle lock
+// expires and schedules a re-evaluation. A single managed timer is reset on
+// each deferral to avoid stacking.
+func (lp *Loadpoint) deferActuation(d time.Duration) {
+	lp.pendingControl.Store(true)
+
+	lp.retryMu.Lock()
+	defer lp.retryMu.Unlock()
+
+	if lp.retryTimer != nil {
+		lp.retryTimer.Stop()
+	}
+	lp.retryTimer = lp.clock.AfterFunc(d, lp.requestUpdate)
 }
 
 // configureChargerType ensures that chargeMeter, Rate and Timer can use charger capabilities
@@ -922,6 +948,20 @@ func (lp *Loadpoint) setLimit(current float64) error {
 		return fmt.Errorf("invalid config: min current %.3gA exceeds max current %.3gA", effMinCurrent, effMaxCurrent)
 	}
 
+	// settle lock: space budget-increasing actuations site-wide. Reductions and
+	// disables bypass the gate (always safe and must stay immediate).
+	if lp.gate != nil {
+		willEnable := current >= effMinCurrent && !lp.enabled
+		willRaiseCurrent := current >= effMinCurrent && current > lp.offeredCurrent
+		if willEnable || willRaiseCurrent {
+			if granted, retryAfter := lp.gate.tryAcquire(); !granted {
+				lp.log.DEBUG.Printf("actuation deferred for %v (settle lock)", retryAfter.Round(time.Second))
+				lp.deferActuation(retryAfter)
+				return nil
+			}
+		}
+	}
+
 	// set current
 	if current != lp.offeredCurrent && current >= effMinCurrent {
 		var err error
@@ -1281,6 +1321,17 @@ func (lp *Loadpoint) scalePhases(phases int) error {
 	}
 
 	if lp.GetPhases() != phases {
+		// settle lock: a phase switch causes an implicit charging pause (zero
+		// draw) before the charger resumes on its own. Acquire (and stamp) the
+		// gate in both directions so no other loadpoint actuates during the
+		// pause, which could otherwise overshoot total power afterwards.
+		if lp.gate != nil {
+			if granted, retryAfter := lp.gate.tryAcquire(); !granted {
+				lp.deferActuation(retryAfter)
+				return errActuationDeferred
+			}
+		}
+
 		// switch phases
 		if err := cp.Phases1p3p(phases); err != nil {
 			return fmt.Errorf("switch phases: %w", err)
@@ -1377,8 +1428,10 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetDisableDelay() {
 			if err := lp.scalePhases(1); err != nil {
 				// a charger may report it cannot switch phases right now
-				// (api.ErrNotAvailable); assume a failed switch and stay silent
-				if !errors.Is(err, api.ErrNotAvailable) {
+				// (api.ErrNotAvailable), or the switch was postponed by the
+				// settle lock (errActuationDeferred); assume an incomplete
+				// switch and stay silent
+				if !errors.Is(err, api.ErrNotAvailable) && !errors.Is(err, errActuationDeferred) {
 					lp.log.ERROR.Println(err)
 				}
 				// switch did not complete - phase count is unchanged
@@ -1412,8 +1465,10 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetEnableDelay() {
 			if err := lp.scalePhases(3); err != nil {
 				// a charger may report it cannot switch phases right now
-				// (api.ErrNotAvailable); assume a failed switch and stay silent
-				if !errors.Is(err, api.ErrNotAvailable) {
+				// (api.ErrNotAvailable), or the switch was postponed by the
+				// settle lock (errActuationDeferred); assume an incomplete
+				// switch and stay silent
+				if !errors.Is(err, api.ErrNotAvailable) && !errors.Is(err, errActuationDeferred) {
 					lp.log.ERROR.Println(err)
 				}
 				// switch did not complete - phase count is unchanged
@@ -2200,8 +2255,8 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	// 	lp.publish(keys.RemoteDisabled, remoteDisabled)
 	// }
 
-	// log any error
-	if err != nil {
+	// log any error (a deferred actuation is a silent no-op that will retry)
+	if err != nil && !errors.Is(err, errActuationDeferred) {
 		lp.log.ERROR.Println(err)
 	}
 }

--- a/core/scheduler_test.go
+++ b/core/scheduler_test.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+)
+
+// TestLoopLoadpointsPrefersPending verifies the scheduler hands out a pending
+// loadpoint before advancing the round-robin cursor.
+func TestLoopLoadpointsPrefersPending(t *testing.T) {
+	lp0 := &Loadpoint{log: util.NewLogger("lp0")}
+	lp1 := &Loadpoint{log: util.NewLogger("lp1")}
+
+	site := &Site{
+		log:        util.NewLogger("site"),
+		loadpoints: []*Loadpoint{lp0, lp1},
+	}
+
+	lp1.pendingControl.Store(true)
+
+	next := make(chan updater)
+	go site.loopLoadpoints(next)
+
+	if got := <-next; got != lp1 {
+		t.Fatalf("first dispatch: want pending lp1, got %v", got)
+	}
+	if lp1.pendingControl.Load() {
+		t.Fatal("pending flag must be cleared on dispatch")
+	}
+	if got := <-next; got != lp0 {
+		t.Fatalf("second dispatch: want round-robin lp0, got %v", got)
+	}
+}
+
+// TestLoopLoadpointsNoStarvation verifies a perpetually-pending loadpoint cannot
+// starve the round-robin sweep that keeps idle loadpoints regulated.
+func TestLoopLoadpointsNoStarvation(t *testing.T) {
+	lp0 := &Loadpoint{log: util.NewLogger("lp0")}
+	lp1 := &Loadpoint{log: util.NewLogger("lp1")}
+
+	site := &Site{
+		log:        util.NewLogger("site"),
+		loadpoints: []*Loadpoint{lp0, lp1},
+	}
+
+	lp0.pendingControl.Store(true)
+
+	next := make(chan updater)
+	go site.loopLoadpoints(next)
+
+	var seenLp1 bool
+	for i := 0; i < 6; i++ {
+		got := <-next
+		if got == lp1 {
+			seenLp1 = true
+		}
+		lp0.pendingControl.Store(true) // simulate a perpetual pending source
+	}
+
+	if !seenLp1 {
+		t.Fatal("round-robin starved: lp1 never dispatched while lp0 stayed pending")
+	}
+}

--- a/core/site.go
+++ b/core/site.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/cmd/shutdown"
@@ -1139,9 +1140,13 @@ func (site *Site) senseLoop(stopC chan struct{}, interval time.Duration) {
 	}
 }
 
-// loopLoadpoints keeps iterating across loadpoints sending the next to the given channel
+// loopLoadpoints feeds the next loadpoint to control to the given channel. It
+// prefers loadpoints with pending control work (events, deferred actuations)
+// over the round-robin cursor, so a loadpoint needing attention is no longer
+// starved by idle ones.
 func (site *Site) loopLoadpoints(next chan<- updater) {
 	var logOnce sync.Once
+	var cursor int
 
 	for {
 		if len(site.loadpoints) == 0 {
@@ -1149,11 +1154,24 @@ func (site *Site) loopLoadpoints(next chan<- updater) {
 				site.log.INFO.Println("no loadpoints configured, running in meter-only mode")
 			})
 			next <- nil
-		} else {
-			for _, lp := range site.loadpoints {
-				next <- lp
+			continue
+		}
+
+		// prefer a loadpoint with pending control work, else advance round-robin
+		var lp *Loadpoint
+		for _, cand := range site.loadpoints {
+			if cand.pendingControl.Load() {
+				lp = cand
+				break
 			}
 		}
+		if lp == nil {
+			lp = site.loadpoints[cursor]
+			cursor = (cursor + 1) % len(site.loadpoints)
+		}
+
+		lp.pendingControl.Store(false)
+		next <- lp
 	}
 }
 
@@ -1169,6 +1187,13 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 		go site.loopLoadpoints(loadpointChan)
 	}
 
+	// settle lock: minimum spacing between budget-increasing actuations site-wide,
+	// derived from the control interval (no dedicated config key)
+	gate := newActuationGate(clock.New(), interval)
+	for _, lp := range site.loadpoints {
+		lp.setActuationGate(gate)
+	}
+
 	// fast sense loop: decouple status/measurement latency from loadpoint count
 	if len(site.loadpoints) > 0 {
 		go site.senseLoop(stopC, senseInterval(interval))
@@ -1181,6 +1206,7 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 		case <-tick:
 			site.update(<-loadpointChan)
 		case lp := <-site.lpUpdateChan:
+			lp.pendingControl.Store(false)
 			site.update(lp)
 		case <-stopC:
 			return

--- a/core/site.go
+++ b/core/site.go
@@ -1141,12 +1141,13 @@ func (site *Site) senseLoop(stopC chan struct{}, interval time.Duration) {
 }
 
 // loopLoadpoints feeds the next loadpoint to control to the given channel. It
-// prefers loadpoints with pending control work (events, deferred actuations)
-// over the round-robin cursor, so a loadpoint needing attention is no longer
-// starved by idle ones.
+// prefers loadpoints with pending control work (events, deferred actuations) so
+// they are served promptly, but alternates with a round-robin sweep so neither
+// a pending loadpoint nor an idle one can starve the other.
 func (site *Site) loopLoadpoints(next chan<- updater) {
 	var logOnce sync.Once
 	var cursor int
+	var servedPending bool // alternate so pending work can't starve the round-robin
 
 	for {
 		if len(site.loadpoints) == 0 {
@@ -1157,17 +1158,25 @@ func (site *Site) loopLoadpoints(next chan<- updater) {
 			continue
 		}
 
-		// prefer a loadpoint with pending control work, else advance round-robin
+		// prefer a loadpoint with pending control work, but only every other
+		// dispatch so a perpetually-pending loadpoint cannot starve the
+		// round-robin sweep that keeps idle loadpoints regulated
 		var lp *Loadpoint
-		for _, cand := range site.loadpoints {
-			if cand.pendingControl.Load() {
-				lp = cand
-				break
+		if !servedPending {
+			for _, cand := range site.loadpoints {
+				if cand.pendingControl.Load() {
+					lp = cand
+					break
+				}
 			}
 		}
-		if lp == nil {
+
+		if lp != nil {
+			servedPending = true
+		} else {
 			lp = site.loadpoints[cursor]
 			cursor = (cursor + 1) % len(site.loadpoints)
+			servedPending = false
 		}
 
 		lp.pendingControl.Store(false)


### PR DESCRIPTION
## Phase 2a of #30366 — settle-lock (actuation gate)

> Stacked on #30367 (Phase 1). Base branch is `feature/lp-update-phase1`, so this diff shows only the 2a changes.

Decouples *how often loadpoints are evaluated* (fast, event-driven — already true after Phase 1) from *how often setpoints actually change* (spaced by a site-wide **settle lock**) — the user's "Lock-Zeit, die verhindert dass die nächste Sollwertänderung bei einem beliebigen Loadpoint zu schnell nacheinander erfolgt."

### Key idea: no `Update()` rewrite
All budget-affecting actuation funnels through `setLimit()` and `scalePhases()`, so the gate lives at those two choke points. `Update()` stays structurally intact → the 25 existing `Update()`-driven tests are untouched.

### What this does
- **`actuationGate`** — site-wide minimum spacing between budget-increasing actuations. Lock is **derived from the control `interval`** (no new config key), mockable clock. `tryAcquire()` grants + stamps, or denies with the remaining duration.
- **`setLimit` gates increases only** (enable `false→true`, `MaxCurrent` raise). **Reductions and disables bypass** the gate — delaying a load reduction would be a safety regression.
- **`scalePhases` gates both directions.** A phase switch causes an implicit charging pause (zero draw) before the charger resumes on its own; holding the gate across the pause prevents another loadpoint from overshooting total power afterwards. Deferral is signalled via the `errActuationDeferred` sentinel and treated as a silent retry at every call site.
- **`deferActuation`** re-evaluates after the lock expires via `clock.AfterFunc` + `requestUpdate` (single managed timer, reset on re-deferral).
- **Pending-aware scheduler:** `loopLoadpoints` prefers loadpoints with pending control work over the round-robin cursor, so an attention-needing loadpoint is no longer starved by idle ones. `requestUpdate` sets the pending flag, so a dropped `cap(1)` trigger self-heals.

### Effect
- Single loadpoint: unchanged (already ≥ `interval` between steps).
- Multi-loadpoint: improves from `N × interval` per loadpoint to a global `interval` spacing, with the active loadpoint no longer starved by idle ones.

### Safety
The gate is `nil` unless wired in `Site.Run`, so existing `Update()`-driven tests are unaffected.

### Tests
- Gate unit: grant / deny-within-lock / grant-after-expiry / zero-lock.
- `setLimit`: increase deferred within lock then proceeds; decrease bypasses an active lock.
- `scalePhases`: both directions deferred within lock; up-switch proceeds after expiry.
- Scheduler: `loopLoadpoints` dispatches a pending loadpoint before the round-robin cursor.

Full suite green incl. `-race`.

### Roadmap (see #30366)
- Phase 1 (#30367): fast sensing trigger.
- **Phase 2a (this PR):** settle-lock / actuation gate.
- Phase 2b: `observe()`/`control()` split + per-charger mutex.
- Phase 3: surplus/circuit ledger, per-charger sense intervals, push chargers.
