### PR TITLE
Core: split loadpoint update into observe + control

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -97,7 +97,8 @@ type Loadpoint struct {
 	retryTimer     *clock.Timer   // deferred actuation retry
 
 	controlMu     sync.Mutex // serialize observe (sense loop) vs control (control loop) per loadpoint
-	welcomeCharge bool       // set by observe, consumed by control
+	observed      bool       // set once observe has produced valid state; control must not actuate before
+	welcomeCharge bool       // latched by observe on connect, consumed+cleared by control
 	observeErr    error      // last charger status read error; control skips actuation while set
 
 	// exposed public configuration
@@ -2067,9 +2068,14 @@ func (lp *Loadpoint) observeLocked() bool {
 		lp.log.ERROR.Println(err)
 		return lp.GetStatus() != prevStatus
 	}
-	lp.welcomeCharge = welcomeCharge
+	// latch a welcome charge: updateChargerStatus only reports it on the connect
+	// tick, so keep it set until control consumes it (a faster sense loop would
+	// otherwise overwrite the edge with false before control runs)
+	if welcomeCharge {
+		lp.welcomeCharge = true
+	}
 
-	lp.publish(keys.VehicleWelcomeActive, welcomeCharge)
+	lp.publish(keys.VehicleWelcomeActive, lp.welcomeCharge)
 	lp.publish(keys.Connected, lp.connected())
 	lp.publish(keys.Charging, lp.charging())
 
@@ -2097,6 +2103,9 @@ func (lp *Loadpoint) observeLocked() bool {
 	// publish soc after updating charger status to make sure
 	// initial update of connected state matches charger status
 	lp.publishSocAndRange()
+
+	// state is now valid; control may actuate
+	lp.observed = true
 
 	return lp.GetStatus() != prevStatus
 }
@@ -2173,8 +2182,9 @@ func (lp *Loadpoint) controlLocked(sitePower, batteryBoostPower float64, consump
 		}
 	}
 
-	// skip actuation if the charger status could not be read by observe
-	if lp.observeErr != nil {
+	// do not actuate before observe has produced valid state, or if the last
+	// charger status read failed
+	if !lp.observed || lp.observeErr != nil {
 		return
 	}
 
@@ -2184,7 +2194,9 @@ func (lp *Loadpoint) controlLocked(sitePower, batteryBoostPower float64, consump
 		return
 	}
 
+	// consume the latched welcome charge so it applies exactly once
 	welcomeCharge := lp.welcomeCharge
+	lp.welcomeCharge = false
 
 	mode := lp.GetMode()
 	lp.publish(keys.Mode, mode)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -96,6 +96,10 @@ type Loadpoint struct {
 	retryMu        sync.Mutex     // guards retryTimer
 	retryTimer     *clock.Timer   // deferred actuation retry
 
+	controlMu     sync.Mutex // serialize observe (sense loop) vs control (control loop) per loadpoint
+	welcomeCharge bool       // set by observe, consumed by control
+	observeErr    error      // last charger status read error; control skips actuation while set
+
 	// exposed public configuration
 	CircuitRef string `mapstructure:"circuit"` // Circuit reference
 	ChargerRef string `mapstructure:"charger"` // Charger reference
@@ -1740,30 +1744,17 @@ func (lp *Loadpoint) getChargeCurrents() []float64 {
 	return lp.chargeCurrents
 }
 
-// Sense reads charger status and live measurements without mutating control
-// state or actuating. It publishes the results for snappy UI updates and
-// requests an immediate control pass when the charger status changed. Sense is
-// safe to call concurrently with the control loop and across loadpoints; it is
-// driven by the fast site sense loop (see Site.senseLoop), decoupling
-// observability latency from the number of loadpoints.
+// Sense runs one full sensing pass for the loadpoint: it refreshes live
+// measurements and then observes status, vehicle soc and the rest of the
+// sensing data. It performs no actuation. Driven by the fast site sense loop
+// (see Site.senseLoop), it decouples observability latency from the number of
+// loadpoints and requests a prompt control pass on a status change.
 func (lp *Loadpoint) Sense() {
 	// live measurements (parallel-safe, serialized per loadpoint via measureMu)
 	lp.UpdateChargePowerAndCurrents()
 
-	// charger status: compared against the authoritative status, which only the
-	// control pass updates. While they differ we keep requesting an update on
-	// every sense tick, which self-heals the cap(1) lpUpdateChan trigger drop.
-	status, err := lp.charger.Status()
-	if err != nil {
-		lp.log.DEBUG.Printf("sense: charger status: %v", err)
-		return
-	}
-
-	if status != lp.GetStatus() {
-		lp.publish(keys.Connected, status == api.StatusB || status == api.StatusC)
-		lp.publish(keys.Charging, status == api.StatusC)
-		lp.requestUpdate()
-	}
+	// status, vehicle soc and remaining sensing (serialized vs control)
+	lp.observe()
 }
 
 // phasesFromChargeCurrents uses PhaseCurrents interface to count phases with current >=1A
@@ -2035,78 +2026,48 @@ func (lp *Loadpoint) phaseSwitchCompleted() bool {
 	return time.Since(lp.phasesSwitched) > phaseSwitchDuration
 }
 
-// Update is the main control function. It reevaluates meters and charger state
+// Update runs a full observe + control pass under a single lock. It is retained
+// for tests and callers that want a synchronous read-decide-actuate cycle;
+// production drives observe (sense loop) and control (control loop) separately.
 func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
-	// auto-disable battery boost when SOC drops below limit
-	if lp.GetBatteryBoost() != boostDisabled {
-		if limit := lp.GetBatteryBoostLimit(); limit < 100 {
-			if batterySoc := lp.site.GetBatterySoc(); batterySoc < float64(limit) {
-				lp.log.DEBUG.Printf("battery boost disabled: soc below limit (%.0f%% < %d%%)", batterySoc, limit)
+	lp.controlMu.Lock()
+	defer lp.controlMu.Unlock()
 
-				if err := lp.SetBatteryBoost(false); err != nil {
-					lp.log.ERROR.Printf("set battery boost: %v", err)
-				}
-			}
-		}
+	lp.observeLocked()
+	lp.controlLocked(sitePower, batteryBoostPower, consumption, feedin, batteryBuffered, batteryStart, greenShare, effPrice, effCo2)
+}
+
+// observe reads and publishes all sensing data (meters, charger status, vehicle
+// soc) without mutating control output or actuating. Driven by the fast site
+// sense loop, it requests a prompt control pass on a status change. observe is
+// serialized against control per loadpoint.
+func (lp *Loadpoint) observe() {
+	lp.controlMu.Lock()
+	changed := lp.observeLocked()
+	lp.controlMu.Unlock()
+
+	if changed {
+		lp.requestUpdate()
 	}
+}
 
-	// smart cost
-	smartCostActive, smartCostNextStart := lp.checkSmartLimit(lp.GetSmartCostLimit(), consumption, true)
-	lp.publish(keys.SmartCostActive, smartCostActive)
-	lp.publish(keys.SmartCostNextStart, smartCostNextStart)
+// observeLocked performs the sensing work and reports whether the charger status
+// changed. The caller must hold controlMu.
+func (lp *Loadpoint) observeLocked() bool {
+	prevStatus := lp.GetStatus()
 
-	smartFeedInPriorityActive, smartFeedInPriorityNextStart := lp.checkSmartLimit(lp.GetSmartFeedInPriorityLimit(), feedin, false)
-	lp.publish(keys.SmartFeedInPriorityActive, smartFeedInPriorityActive)
-	lp.publish(keys.SmartFeedInPriorityNextStart, smartFeedInPriorityNextStart)
-
-	// long-running tasks
-	lp.processTasks()
-
-	// read and publish meters first- charge power and currents have already been updated by the site
+	// read and publish meters - charge power and currents are updated separately
 	lp.updateChargeVoltages()
 	lp.phasesFromChargeCurrents()
 
-	lp.energyMetrics.SetEnvironment(greenShare, effPrice, effCo2)
-
-	// update ChargeRater here to make sure initial meter update is caught
-	lp.bus.Publish(evChargeCurrent, lp.offeredCurrent)
-	lp.bus.Publish(evChargePower, lp.chargePower)
-
-	// update progress and soc before status is updated
-	lp.publishChargeProgress()
-	lp.PublishEffectiveValues()
-
-	// §14a
-	if dimmer, ok := api.Cap[api.Dimmer](lp.charger); ok {
-		dimmed, err := dimmer.Dimmed()
-		if err != nil {
-			lp.log.ERROR.Printf("dimmed: %v", err)
-			return
-		}
-
-		if dim := circuitDimmed(lp.circuit); dim != nil {
-			if *dim != dimmed {
-				if err := dimmer.Dim(*dim); err != nil {
-					lp.log.ERROR.Printf("dim: %v", err)
-					return
-				}
-
-				lp.publish(keys.Dimmed, *dim)
-				lp.log.INFO.Printf("§14a dim: %t", *dim)
-			}
-
-			if *dim {
-				return
-			}
-		}
-	}
-
 	// read and publish status
 	welcomeCharge, err := lp.updateChargerStatus()
+	lp.observeErr = err
 	if err != nil {
 		lp.log.ERROR.Println(err)
-		return
+		return lp.GetStatus() != prevStatus
 	}
+	lp.welcomeCharge = welcomeCharge
 
 	lp.publish(keys.VehicleWelcomeActive, welcomeCharge)
 	lp.publish(keys.Connected, lp.connected())
@@ -2137,11 +2098,93 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	// initial update of connected state matches charger status
 	lp.publishSocAndRange()
 
+	return lp.GetStatus() != prevStatus
+}
+
+// control evaluates the charging strategy and actuates the charger using the
+// state gathered by observe. It is serialized against observe per loadpoint.
+func (lp *Loadpoint) control(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+	lp.controlMu.Lock()
+	defer lp.controlMu.Unlock()
+
+	lp.controlLocked(sitePower, batteryBoostPower, consumption, feedin, batteryBuffered, batteryStart, greenShare, effPrice, effCo2)
+}
+
+// controlLocked is the decision and actuation half of the control loop. The
+// caller must hold controlMu and have run observe beforehand.
+func (lp *Loadpoint) controlLocked(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+	// auto-disable battery boost when SOC drops below limit
+	if lp.GetBatteryBoost() != boostDisabled {
+		if limit := lp.GetBatteryBoostLimit(); limit < 100 {
+			if batterySoc := lp.site.GetBatterySoc(); batterySoc < float64(limit) {
+				lp.log.DEBUG.Printf("battery boost disabled: soc below limit (%.0f%% < %d%%)", batterySoc, limit)
+
+				if err := lp.SetBatteryBoost(false); err != nil {
+					lp.log.ERROR.Printf("set battery boost: %v", err)
+				}
+			}
+		}
+	}
+
+	// smart cost
+	smartCostActive, smartCostNextStart := lp.checkSmartLimit(lp.GetSmartCostLimit(), consumption, true)
+	lp.publish(keys.SmartCostActive, smartCostActive)
+	lp.publish(keys.SmartCostNextStart, smartCostNextStart)
+
+	smartFeedInPriorityActive, smartFeedInPriorityNextStart := lp.checkSmartLimit(lp.GetSmartFeedInPriorityLimit(), feedin, false)
+	lp.publish(keys.SmartFeedInPriorityActive, smartFeedInPriorityActive)
+	lp.publish(keys.SmartFeedInPriorityNextStart, smartFeedInPriorityNextStart)
+
+	// long-running tasks
+	lp.processTasks()
+
+	lp.energyMetrics.SetEnvironment(greenShare, effPrice, effCo2)
+
+	// update ChargeRater here to make sure initial meter update is caught
+	lp.bus.Publish(evChargeCurrent, lp.offeredCurrent)
+	lp.bus.Publish(evChargePower, lp.chargePower)
+
+	// update progress and effective values
+	lp.publishChargeProgress()
+	lp.PublishEffectiveValues()
+
+	// §14a
+	if dimmer, ok := api.Cap[api.Dimmer](lp.charger); ok {
+		dimmed, err := dimmer.Dimmed()
+		if err != nil {
+			lp.log.ERROR.Printf("dimmed: %v", err)
+			return
+		}
+
+		if dim := circuitDimmed(lp.circuit); dim != nil {
+			if *dim != dimmed {
+				if err := dimmer.Dim(*dim); err != nil {
+					lp.log.ERROR.Printf("dim: %v", err)
+					return
+				}
+
+				lp.publish(keys.Dimmed, *dim)
+				lp.log.INFO.Printf("§14a dim: %t", *dim)
+			}
+
+			if *dim {
+				return
+			}
+		}
+	}
+
+	// skip actuation if the charger status could not be read by observe
+	if lp.observeErr != nil {
+		return
+	}
+
 	// sync settings with charger
 	if err := lp.syncCharger(); err != nil {
 		lp.log.ERROR.Println(err)
 		return
 	}
+
+	welcomeCharge := lp.welcomeCharge
 
 	mode := lp.GetMode()
 	lp.publish(keys.Mode, mode)
@@ -2154,6 +2197,7 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	lp.publish(keys.MinSocNotReached, minSocNotReached)
 
 	// execute loading strategy
+	var err error
 	switch {
 	case !lp.connected():
 		// always disable charger if not connected

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -7,10 +7,24 @@ import (
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/messenger"
 	"github.com/evcc-io/evcc/util"
 	"go.uber.org/mock/gomock"
 )
+
+// drainParams collects all currently buffered published params keyed by name.
+func drainParams(ch chan util.Param) map[string]any {
+	m := make(map[string]any)
+	for {
+		select {
+		case p := <-ch:
+			m[p.Key] = p.Val
+		default:
+			return m
+		}
+	}
+}
 
 // TestSenseInterval verifies the sense cadence derived from the control interval.
 func TestSenseInterval(t *testing.T) {
@@ -81,5 +95,69 @@ func TestObserveNoTriggerWithoutStatusChange(t *testing.T) {
 
 	if lp.pendingControl.Load() {
 		t.Fatal("unchanged status must not request a control pass")
+	}
+}
+
+// TestObservePublishesConnectionState verifies observe publishes the snappy-UI
+// connection state (the reason the sense loop exists).
+func TestObservePublishesConnectionState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	uiChan := make(chan util.Param, 32)
+	lp := newObserveLoadpoint(charger)
+	lp.uiChan = uiChan // bidirectional handle so the test can drain it
+	lp.status = api.StatusA
+
+	charger.EXPECT().Status().Return(api.StatusC, nil) // connected and charging
+
+	lp.observe()
+
+	published := drainParams(uiChan)
+	if v, ok := published[keys.Connected]; !ok || v != true {
+		t.Errorf("Connected: got %v (present=%v), want true", v, ok)
+	}
+	if v, ok := published[keys.Charging]; !ok || v != true {
+		t.Errorf("Charging: got %v (present=%v), want true", v, ok)
+	}
+}
+
+// TestObserveSetsObserved verifies observe marks the loadpoint observed so
+// control may actuate (and that a fresh loadpoint is not yet observed).
+func TestObserveSetsObserved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := newObserveLoadpoint(charger)
+	lp.status = api.StatusA
+
+	if lp.observed {
+		t.Fatal("a fresh loadpoint must not be observed yet")
+	}
+
+	charger.EXPECT().Status().Return(api.StatusB, nil)
+	lp.observe()
+
+	if !lp.observed {
+		t.Fatal("observe must mark the loadpoint observed")
+	}
+}
+
+// TestObserveLatchesWelcomeCharge verifies a faster sense loop does not clobber
+// a latched welcome charge before control consumes it.
+func TestObserveLatchesWelcomeCharge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := newObserveLoadpoint(charger)
+	lp.status = api.StatusC
+	lp.welcomeCharge = true // latched on an earlier connect tick
+
+	// no status change -> updateChargerStatus reports welcomeCharge=false
+	charger.EXPECT().Status().Return(api.StatusC, nil)
+	lp.observe()
+
+	if !lp.welcomeCharge {
+		t.Fatal("observe clobbered the latched welcome charge before control consumed it")
 	}
 }

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 	"time"
 
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
-	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/messenger"
 	"github.com/evcc-io/evcc/util"
 	"go.uber.org/mock/gomock"
 )
@@ -28,114 +30,56 @@ func TestSenseInterval(t *testing.T) {
 	}
 }
 
-// drainParams collects all currently buffered published params keyed by name.
-func drainParams(ch chan util.Param) map[string]any {
-	m := make(map[string]any)
-	for {
-		select {
-		case p := <-ch:
-			m[p.Key] = p.Val
-		default:
-			return m
-		}
-	}
-}
-
-func newSenseLoadpoint(charger api.Charger) (*Loadpoint, chan *Loadpoint, chan util.Param) {
-	lpChan := make(chan *Loadpoint, 1)  // mirrors production cap(1)
-	uiChan := make(chan util.Param, 16) // buffered so publish doesn't block
-
-	lp := &Loadpoint{
+func newObserveLoadpoint(charger api.Charger) *Loadpoint {
+	return &Loadpoint{
 		log:         util.NewLogger("foo"),
+		clock:       clock.NewMock(),
+		bus:         evbus.New(),
 		charger:     charger,
 		chargeMeter: &Null{}, // silence nil panics, returns zero power
-		lpChan:      lpChan,
-		uiChan:      uiChan,
-	}
-
-	return lp, lpChan, uiChan
-}
-
-// TestSenseTriggersOnStatusChange verifies that a sensed charger status which
-// differs from the authoritative status requests an immediate control pass and
-// publishes the derived connection state.
-func TestSenseTriggersOnStatusChange(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	charger := api.NewMockCharger(ctrl)
-
-	lp, lpChan, uiChan := newSenseLoadpoint(charger)
-	lp.status = api.StatusA // authoritative: disconnected
-
-	charger.EXPECT().Status().Return(api.StatusB, nil) // sensed: connected, not charging
-
-	lp.Sense()
-
-	select {
-	case got := <-lpChan:
-		if got != lp {
-			t.Fatalf("unexpected loadpoint on update channel")
-		}
-	default:
-		t.Fatal("expected update request on status change")
-	}
-
-	published := drainParams(uiChan)
-	if v, ok := published[keys.Connected]; !ok || v != true {
-		t.Errorf("Connected: got %v (present=%v), want true", v, ok)
-	}
-	if v, ok := published[keys.Charging]; !ok || v != false {
-		t.Errorf("Charging: got %v (present=%v), want false", v, ok)
+		uiChan:      make(chan util.Param, 32),
+		lpChan:      make(chan *Loadpoint, 1),
+		pushChan:    make(chan messenger.Event, 8),
+		minCurrent:  minA,
+		maxCurrent:  maxA,
 	}
 }
 
-// TestSenseNoTriggerWithoutStatusChange verifies that an unchanged status does
-// not request a redundant control pass.
-func TestSenseNoTriggerWithoutStatusChange(t *testing.T) {
+// TestObserveTriggersOnStatusChange verifies that observe authoritatively updates
+// the status and requests a prompt control pass when it changed.
+func TestObserveTriggersOnStatusChange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	charger := api.NewMockCharger(ctrl)
 
-	lp, lpChan, _ := newSenseLoadpoint(charger)
-	lp.status = api.StatusC // authoritative: charging
-
-	charger.EXPECT().Status().Return(api.StatusC, nil) // sensed: unchanged
-
-	lp.Sense()
-
-	select {
-	case <-lpChan:
-		t.Fatal("unexpected update request without status change")
-	default:
-	}
-}
-
-// TestSenseRetriggersUntilControlCatchesUp verifies the self-healing behavior:
-// while the authoritative status lags, a trigger stays pending even when an
-// individual re-trigger is dropped on the full cap(1) channel.
-func TestSenseRetriggersUntilControlCatchesUp(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	charger := api.NewMockCharger(ctrl)
-
-	lp, lpChan, _ := newSenseLoadpoint(charger)
+	lp := newObserveLoadpoint(charger)
 	lp.status = api.StatusA
 
-	charger.EXPECT().Status().Return(api.StatusB, nil).Times(2)
+	charger.EXPECT().Status().Return(api.StatusB, nil)
 
-	// first sense fills the cap(1) trigger channel
-	lp.Sense()
-	// the authoritative status still lags, so the second sense re-requests an
-	// update; its send is dropped on the full channel, but a trigger remains
-	// pending so control is not starved
-	lp.Sense()
+	lp.observe()
 
-	if got := len(lpChan); got != 1 {
-		t.Fatalf("expected exactly one pending trigger after a dropped re-trigger, got %d", got)
+	if lp.GetStatus() != api.StatusB {
+		t.Fatalf("status not updated: %v", lp.GetStatus())
 	}
-	select {
-	case got := <-lpChan:
-		if got != lp {
-			t.Fatal("unexpected loadpoint on update channel")
-		}
-	default:
-		t.Fatal("expected a pending update request")
+	if !lp.pendingControl.Load() {
+		t.Fatal("status change must request a control pass")
+	}
+}
+
+// TestObserveNoTriggerWithoutStatusChange verifies that an unchanged status does
+// not request a redundant control pass.
+func TestObserveNoTriggerWithoutStatusChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := newObserveLoadpoint(charger)
+	lp.status = api.StatusC // charging
+
+	charger.EXPECT().Status().Return(api.StatusC, nil) // unchanged
+
+	lp.observe()
+
+	if lp.pendingControl.Load() {
+		t.Fatal("unchanged status must not request a control pass")
 	}
 }

--- a/core/site.go
+++ b/core/site.go
@@ -46,7 +46,7 @@ const standbyPower = 10 // consider less than 10W as charger in standby
 // updater abstracts the Loadpoint implementation for testing
 type updater interface {
 	loadpoint.API
-	Update(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effectivePrice, effectiveCo2 *float64)
+	control(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effectivePrice, effectiveCo2 *float64)
 }
 
 var _ site.API = (*Site)(nil)
@@ -983,7 +983,9 @@ func (site *Site) update(lp updater) {
 
 		// TODO
 		if lp != nil {
-			lp.Update(
+			// control only: the sense loop runs observe() continuously to keep
+			// the loadpoint's sensed state fresh
+			lp.control(
 				sitePower, max(0, site.battery.Power), consumption, feedin, batteryBuffered, batteryStart,
 				greenShareLoadpoints, site.effectivePrice(greenShareLoadpoints), site.effectiveCo2(greenShareLoadpoints),
 			)


### PR DESCRIPTION
## Phase 2b of #30366 — split `Update()` into `observe()` + `control()`

> Stacked on #30369 (Phase 2a). Base branch is `feature/lp-update-phase2a`, so this diff shows only the 2b changes.

Decouples sensing from control on the loadpoint: `observe()` does all the reads/publishes (meters, charger status + connect/disconnect, vehicle soc); `control()` does the decision + actuation using the state `observe()` gathered. The fast **sense loop** now drives `observe()` so the sensed state stays fresh continuously, while the **control loop** drives `control()` only.

### Safety / how the risk was contained
- **Per-loadpoint `controlMu`** serializes `observe()` (sense goroutine) vs. `control()` (control goroutine), so the two never touch the same charger concurrently — this closes the charger-concurrency hazard the Phase 1 sense loop opened. Loadpoints stay parallel.
- **`Update()` is kept as a thin `observe()+control()` wrapper** under one lock, so the **25 existing `Update()`-driven tests pass unchanged** — no risky mass test migration.
- **Cross-boundary state via fields** (`welcomeCharge`, `observeErr`): `observe()` stores them, `control()` consumes them. `control()` skips actuation while the status read is failing, preserving the previous early-return semantics.
- **Order-sensitive energy accounting** (`SetEnvironment` → `evChargePower` → charge progress) is kept together in `control()` in its original relative order.
- The **§14a dimmer** moved into `control()` after the observe reads — verified safe (no test drives a loadpoint `Dimmer` charger through `Update()`; the only dimmer test exercises site aux-meter `dimMeters`).
- **`syncCharger`** naturally bypasses the settle-lock gate (it calls `charger.Enable` directly, not via `setLimit`).

### Wiring
- `site.update` now calls `control()` (the `updater` interface exposes `control`).
- `Sense()` runs `UpdateChargePowerAndCurrents()` + `observe()` and requests a prompt control pass on a status change.

### Tests
- Full suite green incl. `-race`; vet + full build clean.
- Phase 1 sense tests retargeted to `observe()` (status change → authoritative status update + control request; unchanged status → no request).

### Roadmap (see #30366)
- Phase 1 (#30367) → Phase 2a (#30369) → **Phase 2b (this PR)** → Phase 3 (ledger, per-charger sense intervals, push chargers).
