### PR TITLE
feat(core): per-circuit in-flight accounting (lp-update phase 3b)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -253,6 +253,10 @@ type CsvWriter interface {
 type CircuitMeasurements interface {
 	GetChargePower() float64
 	GetMaxPhaseCurrent() float64
+	// GetInflightPower returns power actuated but not yet reflected by the meters
+	GetInflightPower() float64
+	// GetInflightCurrent returns max phase current actuated but not yet reflected by the meters
+	GetInflightCurrent() float64
 }
 
 // CircuitLoad represents a loadpoint attached to a circuit

--- a/api/mock.go
+++ b/api/mock.go
@@ -922,6 +922,34 @@ func (mr *MockCircuitMockRecorder) GetChargePower() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChargePower", reflect.TypeOf((*MockCircuit)(nil).GetChargePower))
 }
 
+// GetInflightCurrent mocks base method.
+func (m *MockCircuit) GetInflightCurrent() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInflightCurrent")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// GetInflightCurrent indicates an expected call of GetInflightCurrent.
+func (mr *MockCircuitMockRecorder) GetInflightCurrent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInflightCurrent", reflect.TypeOf((*MockCircuit)(nil).GetInflightCurrent))
+}
+
+// GetInflightPower mocks base method.
+func (m *MockCircuit) GetInflightPower() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInflightPower")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// GetInflightPower indicates an expected call of GetInflightPower.
+func (mr *MockCircuitMockRecorder) GetInflightPower() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInflightPower", reflect.TypeOf((*MockCircuit)(nil).GetInflightPower))
+}
+
 // GetMaxCurrent mocks base method.
 func (m *MockCircuit) GetMaxCurrent() float64 {
 	m.ctrl.T.Helper()

--- a/core/circuit/circuit.go
+++ b/core/circuit/circuit.go
@@ -327,9 +327,7 @@ func (c *Circuit) Update(loadpoints []api.CircuitLoad) (err error) {
 
 	// metered power/current, else aggregated from loadpoints and children
 	if c.meter != nil {
-		if err := c.updateMeters(); err != nil {
-			return err
-		}
+		err = c.updateMeters()
 	} else {
 		c.updateLoadpoints(loadpoints)
 		for _, ch := range c.children {
@@ -340,7 +338,8 @@ func (c *Circuit) Update(loadpoints []api.CircuitLoad) (err error) {
 
 	// aggregate in-flight reserves (actuations not yet reflected by the meters)
 	// so ValidateCurrent/ValidatePower account for parallel actuations that the
-	// metered power/current does not yet include
+	// metered power/current does not yet include. Run this even on a meter error
+	// so the reserve never goes stale (and stays conservative).
 	c.inflightCurrent, c.inflightPower = 0, 0
 	for _, lp := range loadpoints {
 		if lp.GetCircuit() == c {
@@ -353,7 +352,7 @@ func (c *Circuit) Update(loadpoints []api.CircuitLoad) (err error) {
 		c.inflightPower += ch.GetInflightPower()
 	}
 
-	return nil
+	return err
 }
 
 // GetChargePower returns the actual power

--- a/core/circuit/circuit.go
+++ b/core/circuit/circuit.go
@@ -39,6 +39,9 @@ type Circuit struct {
 	dimmed    *bool
 	curtailed *bool
 
+	inflightCurrent float64 // current actuated but not yet reflected by the meters
+	inflightPower   float64 // power actuated but not yet reflected by the meters
+
 	currentUpdated time.Time
 	powerUpdated   time.Time
 }
@@ -322,16 +325,32 @@ func (c *Circuit) Update(loadpoints []api.CircuitLoad) (err error) {
 		}
 	}
 
-	// meter available
+	// metered power/current, else aggregated from loadpoints and children
 	if c.meter != nil {
-		return c.updateMeters()
+		if err := c.updateMeters(); err != nil {
+			return err
+		}
+	} else {
+		c.updateLoadpoints(loadpoints)
+		for _, ch := range c.children {
+			c.power += ch.GetChargePower()
+			c.current += ch.GetMaxPhaseCurrent()
+		}
 	}
 
-	// no meter available
-	c.updateLoadpoints(loadpoints)
+	// aggregate in-flight reserves (actuations not yet reflected by the meters)
+	// so ValidateCurrent/ValidatePower account for parallel actuations that the
+	// metered power/current does not yet include
+	c.inflightCurrent, c.inflightPower = 0, 0
+	for _, lp := range loadpoints {
+		if lp.GetCircuit() == c {
+			c.inflightCurrent += lp.GetInflightCurrent()
+			c.inflightPower += lp.GetInflightPower()
+		}
+	}
 	for _, ch := range c.children {
-		c.power += ch.GetChargePower()
-		c.current += ch.GetMaxPhaseCurrent()
+		c.inflightCurrent += ch.GetInflightCurrent()
+		c.inflightPower += ch.GetInflightPower()
 	}
 
 	return nil
@@ -347,15 +366,27 @@ func (c *Circuit) GetMaxPhaseCurrent() float64 {
 	return c.current
 }
 
+// GetInflightPower returns the aggregated in-flight power of this circuit's
+// loadpoints and child circuits (actuated but not yet metered).
+func (c *Circuit) GetInflightPower() float64 {
+	return c.inflightPower
+}
+
+// GetInflightCurrent returns the aggregated in-flight current of this circuit's
+// loadpoints and child circuits (actuated but not yet metered).
+func (c *Circuit) GetInflightCurrent() float64 {
+	return c.inflightCurrent
+}
+
 // ValidatePower validates power request
 func (c *Circuit) ValidatePower(old, new float64) float64 {
 	if maxPower := c.GetMaxPower(); maxPower != 0 {
 		delta := max(0, new-old)
-		potential := maxPower - c.power
+		potential := maxPower - (c.power + c.inflightPower)
 
 		if delta > potential {
 			capped := min(new, max(0, old+potential))
-			c.log.DEBUG.Printf("validate power: %.0fW + (%.0fW -> %.0fW) > %.0fW capped at %.0fW", c.power, old, new, maxPower, capped)
+			c.log.DEBUG.Printf("validate power: %.0fW + (%.0fW -> %.0fW) > %.0fW capped at %.0fW", c.power+c.inflightPower, old, new, maxPower, capped)
 			new = capped
 		} else {
 			c.log.TRACE.Printf("validate power: %.0fW + (%.0fW -> %.0fW) <= %.0fW ok", c.power, old, new, maxPower)
@@ -373,11 +404,11 @@ func (c *Circuit) ValidatePower(old, new float64) float64 {
 func (c *Circuit) ValidateCurrent(old, new float64) float64 {
 	if maxCurrent := c.GetMaxCurrent(); maxCurrent != 0 {
 		delta := max(0, new-old)
-		potential := maxCurrent - c.current
+		potential := maxCurrent - (c.current + c.inflightCurrent)
 
 		if delta > potential {
 			capped := min(new, max(0, old+potential))
-			c.log.DEBUG.Printf("validate current: %.3gA + (%.3gA -> %.3gA) > %.3gA capped at %.3gA", c.current, old, new, maxCurrent, capped)
+			c.log.DEBUG.Printf("validate current: %.3gA + (%.3gA -> %.3gA) > %.3gA capped at %.3gA", c.current+c.inflightCurrent, old, new, maxCurrent, capped)
 			new = capped
 		} else {
 			c.log.TRACE.Printf("validate current: %.3gA + (%.3gA -> %.3gA) <= %.3gA ok", c.current, old, new, maxCurrent)

--- a/core/circuit/inflight_test.go
+++ b/core/circuit/inflight_test.go
@@ -1,0 +1,74 @@
+package circuit
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// circuitLoadStub is a minimal api.CircuitLoad for in-flight tests.
+type circuitLoadStub struct {
+	circuit                                        api.Circuit
+	power, current, inflightPower, inflightCurrent float64
+}
+
+func (s *circuitLoadStub) GetChargePower() float64     { return s.power }
+func (s *circuitLoadStub) GetMaxPhaseCurrent() float64 { return s.current }
+func (s *circuitLoadStub) GetInflightPower() float64   { return s.inflightPower }
+func (s *circuitLoadStub) GetInflightCurrent() float64 { return s.inflightCurrent }
+func (s *circuitLoadStub) GetCircuit() api.Circuit     { return s.circuit }
+
+// TestCircuitInflightCurrent verifies that a loadpoint's in-flight (un-metered)
+// current reduces the headroom another actuation may take, preventing a
+// transient overshoot of the circuit limit.
+func TestCircuitInflightCurrent(t *testing.T) {
+	c, err := New(util.NewLogger("foo"), "foo", 10, 0, nil, 0) // maxCurrent 10, no meter
+	require.NoError(t, err)
+
+	lp := &circuitLoadStub{circuit: c, current: 4, inflightCurrent: 3}
+	require.NoError(t, c.Update([]api.CircuitLoad{lp}))
+
+	// metered 4 + in-flight 3 = 7 used -> headroom 3
+	assert.Equal(t, 3.0, c.ValidateCurrent(0, 5), "should cap to remaining headroom")
+	assert.Equal(t, 2.0, c.ValidateCurrent(0, 2), "within headroom -> unchanged")
+
+	// once the reserve clears, the full metered headroom (10-4=6) returns
+	lp.inflightCurrent = 0
+	require.NoError(t, c.Update([]api.CircuitLoad{lp}))
+	assert.Equal(t, 5.0, c.ValidateCurrent(0, 5), "no reserve -> full headroom")
+}
+
+// TestCircuitInflightPower mirrors the current test for power-limited circuits.
+func TestCircuitInflightPower(t *testing.T) {
+	c, err := New(util.NewLogger("foo"), "foo", 0, 10000, nil, 0) // maxPower 10kW, no meter
+	require.NoError(t, err)
+
+	lp := &circuitLoadStub{circuit: c, power: 4000, inflightPower: 3000}
+	require.NoError(t, c.Update([]api.CircuitLoad{lp}))
+
+	assert.Equal(t, 3000.0, c.ValidatePower(0, 5000), "should cap to remaining headroom")
+
+	lp.inflightPower = 0
+	require.NoError(t, c.Update([]api.CircuitLoad{lp}))
+	assert.Equal(t, 5000.0, c.ValidatePower(0, 5000), "no reserve -> full headroom")
+}
+
+// TestCircuitInflightHierarchy verifies in-flight reserves propagate to parents.
+func TestCircuitInflightHierarchy(t *testing.T) {
+	log := util.NewLogger("foo")
+	parent, err := New(log, "parent", 10, 0, nil, 0)
+	require.NoError(t, err)
+	child, err := New(log, "child", 10, 0, nil, 0)
+	require.NoError(t, err)
+	require.NoError(t, child.Wrap(parent))
+
+	lp := &circuitLoadStub{circuit: child, current: 4, inflightCurrent: 3}
+	require.NoError(t, parent.Update([]api.CircuitLoad{lp}))
+
+	// parent must see the child's in-flight reserve too
+	assert.Equal(t, 3.0, parent.GetInflightCurrent())
+	assert.Equal(t, 3.0, parent.ValidateCurrent(0, 5), "parent caps to child headroom")
+}

--- a/core/circuit/inflight_test.go
+++ b/core/circuit/inflight_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 // circuitLoadStub is a minimal api.CircuitLoad for in-flight tests.
@@ -71,4 +72,24 @@ func TestCircuitInflightHierarchy(t *testing.T) {
 	// parent must see the child's in-flight reserve too
 	assert.Equal(t, 3.0, parent.GetInflightCurrent())
 	assert.Equal(t, 3.0, parent.ValidateCurrent(0, 5), "parent caps to child headroom")
+}
+
+// TestCircuitInflightMetered verifies that for a circuit with its own (lagging)
+// meter, the loadpoints' in-flight reserves are still added on top of the
+// metered value.
+func TestCircuitInflightMetered(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	meter := api.NewMockMeter(ctrl)
+
+	c, err := New(util.NewLogger("foo"), "foo", 0, 10000, meter, 0) // maxPower 10kW, metered
+	require.NoError(t, err)
+
+	lp := &circuitLoadStub{circuit: c, inflightPower: 3000}
+
+	// metered 4kW + in-flight 3kW = 7kW used -> headroom 3kW
+	meter.EXPECT().CurrentPower().Return(4000.0, nil)
+	require.NoError(t, c.Update([]api.CircuitLoad{lp}))
+
+	assert.Equal(t, 3000.0, c.GetInflightPower(), "in-flight aggregated on a metered circuit")
+	assert.Equal(t, 3000.0, c.ValidatePower(0, 5000), "metered + in-flight headroom")
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -420,10 +420,11 @@ func (lp *Loadpoint) inflightActive() bool {
 
 // GetInflightPower returns the charge power actuated but not yet reflected by the
 // meters (max(0, intended - measured)) during the settle window, else 0. The
-// site discounts the surplus by the sum across loadpoints so a just-actuated
-// loadpoint is not re-counted as available surplus until the meters catch up.
-// It is self-correcting: the reserve collapses to zero as soon as the metered
-// power reaches the intended draw.
+// site discounts the surplus by the sum across loadpoints, and circuits add it
+// to their metered power, so a just-actuated loadpoint is not re-counted as
+// available surplus / circuit headroom until the meters catch up. It is
+// self-correcting: the reserve collapses to zero as soon as the metered power
+// reaches the intended draw.
 func (lp *Loadpoint) GetInflightPower() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
@@ -937,17 +938,18 @@ func (lp *Loadpoint) setLimit(current float64) error {
 
 	// apply circuit limits
 	if lp.circuit != nil {
-		var actualCurrent float64
-		if cc := lp.getChargeCurrents(); cc != nil {
-			actualCurrent = max(cc[0], cc[1], cc[2])
-		} else if lp.charging() {
-			actualCurrent = lp.offeredCurrent
-		}
+		// validate against this loadpoint's full contribution to the circuit
+		// (metered draw + its own in-flight reserve), exactly as the circuit
+		// aggregates c.current/c.power. Using only the metered value would let
+		// this loadpoint's own reserve cap it back down, oscillating on a circuit
+		// sized for a single charger.
+		actualCurrent := lp.GetMaxPhaseCurrent() + lp.GetInflightCurrent()
+		actualPower := lp.GetChargePower() + lp.GetInflightPower()
 
 		currentLimit := lp.circuit.ValidateCurrent(actualCurrent, current)
 
 		activePhases := lp.ActivePhases()
-		powerLimit := lp.circuit.ValidatePower(lp.chargePower, currentToPower(current, activePhases))
+		powerLimit := lp.circuit.ValidatePower(actualPower, currentToPower(current, activePhases))
 		currentLimitViaPower := powerToCurrent(powerLimit, activePhases)
 
 		current = lp.roundedCurrent(min(currentLimit, currentLimitViaPower))

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -681,6 +681,32 @@ func (lp *Loadpoint) GetMaxPhaseCurrent() float64 {
 	return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
 }
 
+// GetInflightCurrent returns the max phase current actuated but not yet reflected
+// by the meters (max(0, intended - measured)) during the settle window, else 0.
+// Circuits add it to their metered current so parallel actuation cannot overshoot
+// a circuit limit before the meters catch up. (inflightActive/GetInflightPower
+// live in loadpoint.go alongside the surplus reserve.)
+func (lp *Loadpoint) GetInflightCurrent() float64 {
+	lp.RLock()
+	defer lp.RUnlock()
+
+	if !lp.inflightActive() {
+		return 0
+	}
+
+	var intended float64
+	if lp.enabled {
+		intended = lp.offeredCurrent
+	}
+
+	measured := intended
+	if lp.chargeCurrents != nil {
+		measured = max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
+	}
+
+	return max(0, intended-measured)
+}
+
 // GetMinCurrent returns the min loadpoint current
 func (lp *Loadpoint) GetMinCurrent() float64 {
 	lp.RLock()

--- a/core/loadpoint_circuit_test.go
+++ b/core/loadpoint_circuit_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"testing"
+
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/circuit"
+	"github.com/evcc-io/evcc/util"
+	"go.uber.org/mock/gomock"
+)
+
+// TestSetLimitNoSelfCapFromOwnReserve verifies a loadpoint is not capped down by
+// its own in-flight reserve: while it ramps toward a higher setpoint, the
+// circuit holds the reserve (intended - measured), but re-applying the same
+// setpoint must not treat that reserve as foreign headroom and cap back to the
+// metered draw (which oscillates on a circuit sized for a single charger).
+func TestSetLimitNoSelfCapFromOwnReserve(t *testing.T) {
+	Voltage = 230
+
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	circ, err := circuit.New(util.NewLogger("circ"), "test", maxA, 0, nil, 0) // maxCurrent 16A, no meter
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lp := &Loadpoint{
+		log:         util.NewLogger("foo"),
+		clock:       clk,
+		bus:         evbus.New(),
+		charger:     charger,
+		chargeMeter: &Null{},
+		wakeUpTimer: NewTimer(),
+		circuit:     circ,
+		minCurrent:  minA,
+		maxCurrent:  maxA,
+		phases:      1,
+	}
+	lp.status = api.StatusC
+	lp.enabled = true
+	lp.offeredCurrent = maxA                        // already actuated to 16A
+	lp.chargeCurrents = []float64{minA, minA, minA} // car still ramping (6A)
+	lp.chargePower = currentToPower(minA, 1)
+	lp.actuatedAt = clk.Now() // reserve active: intended 16A - measured 6A = 10A
+
+	// the circuit sees metered 6A + this loadpoint's own 10A reserve = 16A
+	if err := circ.Update([]api.CircuitLoad{lp}); err != nil {
+		t.Fatal(err)
+	}
+
+	// re-applying 16A must be a no-op (no charger write): the reserve is this
+	// loadpoint's own contribution, not foreign headroom. A capped-down value
+	// would call MaxCurrent(6) -> an unexpected mock call fails the test.
+	if err := lp.setLimit(maxA); err != nil {
+		t.Fatalf("setLimit: %v", err)
+	}
+
+	if lp.offeredCurrent != maxA {
+		t.Fatalf("loadpoint capped itself via its own reserve: offeredCurrent=%v, want %v", lp.offeredCurrent, maxA)
+	}
+}

--- a/core/loadpoint_inflight_test.go
+++ b/core/loadpoint_inflight_test.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLoadpointInflight verifies the un-metered reserve a loadpoint exposes to
+// its circuit: max(0, intended - measured) during the settle window, then 0.
+func TestLoadpointInflight(t *testing.T) {
+	Voltage = 230
+
+	clk := clock.NewMock()
+	lp := &Loadpoint{
+		log:    util.NewLogger("foo"),
+		clock:  clk,
+		phases: 1,
+	}
+	lp.enabled = true
+	lp.offeredCurrent = 16                 // just raised the setpoint to 16A
+	lp.chargeCurrents = []float64{6, 6, 6} // car still ramping, only drawing 6A
+	lp.chargePower = currentToPower(6, 1)
+	lp.actuatedAt = clk.Now()
+
+	// within the settle window the un-metered part is reserved
+	assert.Equal(t, 10.0, lp.GetInflightCurrent(), "current reserve = 16 - 6")
+	assert.Equal(t, currentToPower(16, 1)-currentToPower(6, 1), lp.GetInflightPower())
+
+	// after the settle window the meters are trusted again
+	clk.Add(chargerSwitchDuration)
+	assert.Zero(t, lp.GetInflightCurrent(), "reserve cleared after settle")
+	assert.Zero(t, lp.GetInflightPower())
+}
+
+// TestLoadpointInflightDecrease verifies a reduction reserves nothing (the still
+// higher metered draw is the conservative value the circuit already sees).
+func TestLoadpointInflightDecrease(t *testing.T) {
+	Voltage = 230
+
+	clk := clock.NewMock()
+	lp := &Loadpoint{
+		log:    util.NewLogger("foo"),
+		clock:  clk,
+		phases: 1,
+	}
+	lp.enabled = true
+	lp.offeredCurrent = 6                     // just lowered the setpoint to 6A
+	lp.chargeCurrents = []float64{16, 16, 16} // still drawing 16A
+	lp.chargePower = currentToPower(16, 1)
+	lp.actuatedAt = clk.Now()
+
+	assert.Zero(t, lp.GetInflightCurrent(), "decrease reserves nothing")
+	assert.Zero(t, lp.GetInflightPower())
+}


### PR DESCRIPTION
## Phase 3b of #30366 — per-circuit in-flight accounting (safety prerequisite for 3a)

> Stacked on #30372 (Phase 3a). Base branch is `feature/lp-update-phase3a`, so this diff shows only the 3b changes.

**Closes the circuit-overshoot gap 3a opened.** With the settle-lock gate removed in 3a, two loadpoints on the same circuit could both pass `ValidateCurrent`/`ValidatePower` against **metered (lagging)** `c.current`/`c.power` and transiently exceed the circuit limit until the meters catch up — a breaker-trip risk. This makes circuit validation in-flight-aware.

### How it works
- Each loadpoint exposes an **in-flight reserve** = `max(0, intended − measured)` for current and power, valid only during a **settle window** (`chargerSwitchDuration`, 60 s) after its last actuation — the un-metered part of a just-actuated increase. After the window it reverts to 0 (meters trusted again).
- These are added to **`api.CircuitMeasurements`** (shared by loadpoints and circuits) so they **propagate up the circuit hierarchy**.
- **`circuit.Update`** aggregates the reserves of its loadpoints and child circuits into `c.inflightCurrent`/`c.inflightPower` (both the metered and meter-less paths).
- **`ValidateCurrent`/`ValidatePower`** use `c.current + inflight` / `c.power + inflight` for the headroom.

### Why this design
- **Conservative but not wasteful:** the reserve only applies during the transition; after the settle window the accurate metered value is used again, so no circuit headroom is permanently reserved (preserving the existing measured-based utilisation).
- **Decrease-safe:** a reduction reserves nothing (the still-higher metered draw is the conservative value the circuit already sees).
- Works for **metered and meter-less circuits** and **across the hierarchy** (verified by tests).

### API change
`api.CircuitMeasurements` gains `GetInflightPower()` / `GetInflightCurrent()`; `MockCircuit` regenerated. `loadpoint.API` is unaffected (it lists its measurement methods separately).

### Tests
- Circuit: in-flight current/power reduces the validated headroom; clears after the reserve expires; propagates to a parent circuit.
- Loadpoint: reserve = `intended − measured` within the settle window, 0 after; a decrease reserves nothing.
- Full suite green incl. `-race`.

### Roadmap (see #30366)
- Phase 1 (#30367) → 2a (#30369) → 2b (#30370) → 3a (#30372) → **3b (this PR)** → 3c per-charger sense intervals → 3d push chargers.
- With 3b, the 3a parallel-actuation safety prerequisite for circuit-limited sites is satisfied.
