### PR TITLE
Loadpoint: allow optional fast push updates from chargers

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -419,10 +419,18 @@ func (c *Easee) ProductUpdate(i json.RawMessage) {
 			c.obsTime[easee.SESSION_ENERGY] = time.Now()
 		}
 
+		statusChanged := c.opMode != opMode
 		c.opMode = opMode
 
 		// startup completed
 		c.startDone()
+
+		// push: a status change is latency-sensitive (e.g. vehicle plugged in),
+		// so notify the loadpoint for an immediate sense instead of waiting for
+		// the next poll
+		if statusChanged && c.lp != nil {
+			c.lp.Notify()
+		}
 
 	case easee.REASON_FOR_NO_CURRENT:
 		c.reasonForNoCurrent = value.(int)

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -29,6 +29,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/charger/ocpp"
+	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
@@ -41,12 +42,22 @@ type OCPP struct {
 	implement.Caps
 	cp      *ocpp.CP
 	conn    *ocpp.Connector
+	lp      loadpoint.API // push notifications on status change
 	phases  int
 	enabled bool
 	current float64
 
 	stackLevelZero      bool
 	profileKindRelative bool
+}
+
+var _ loadpoint.Controller = (*OCPP)(nil)
+
+// LoadpointControl implements loadpoint.Controller, wiring the connector's
+// status-change notification to an immediate sense request.
+func (c *OCPP) LoadpointControl(lp loadpoint.API) {
+	c.lp = lp
+	c.conn.SetNotify(lp.Notify)
 }
 
 const defaultIdTag = "evcc" // RemoteStartTransaction only

--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -24,6 +24,7 @@ type Connector struct {
 
 	status  *core.StatusNotificationRequest
 	statusC chan struct{}
+	notify  func() // optional: called when the charge point status changes
 
 	meterUpdated time.Time
 	measurements map[types.Measurand]types.SampledValue
@@ -83,6 +84,14 @@ func (conn *Connector) TestClock(clock clock.Clock) {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	conn.clock = clock
+}
+
+// SetNotify registers a callback invoked when the charge point status changes,
+// so the charger can request an immediate sense instead of waiting for a poll.
+func (conn *Connector) SetNotify(notify func()) {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	conn.notify = notify
 }
 
 func (conn *Connector) ID() int {

--- a/charger/ocpp/connector_core.go
+++ b/charger/ocpp/connector_core.go
@@ -28,6 +28,11 @@ func (conn *Connector) OnStatusNotification(request *core.StatusNotificationRequ
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
+	var prev core.ChargePointStatus
+	if conn.status != nil {
+		prev = conn.status.Status
+	}
+
 	if conn.status == nil {
 		conn.status = request
 		close(conn.statusC) // signal initial status received
@@ -35,6 +40,12 @@ func (conn *Connector) OnStatusNotification(request *core.StatusNotificationRequ
 		conn.status = request
 	} else {
 		conn.log.TRACE.Printf("ignoring status: %s < %s", request.Timestamp.Time, conn.status.Timestamp)
+	}
+
+	// status change is latency-sensitive (e.g. vehicle plugged in): request an
+	// immediate sense instead of waiting for the next poll
+	if conn.notify != nil && conn.status.Status != prev {
+		conn.notify()
 	}
 
 	if conn.isWaitingForAuth() {
@@ -77,6 +88,7 @@ func (conn *Connector) OnMeterValues(request *core.MeterValuesRequest) (*core.Me
 		conn.txnId = *request.TransactionId
 	}
 
+	var updated bool
 	for _, meterValue := range sortByAge(request.MeterValue) {
 		if meterValue.Timestamp == nil {
 			// this should be done before the sorting, but lets assume either all or no sample has a timestamp
@@ -89,8 +101,15 @@ func (conn *Connector) OnMeterValues(request *core.MeterValuesRequest) (*core.Me
 				sample.Value = strings.TrimSpace(sample.Value)
 				conn.measurements[getSampleKey(sample)] = sample
 				conn.meterUpdated = meterValue.Timestamp.Time
+				updated = true
 			}
 		}
+	}
+
+	// push: fresh meter values arrived. OCPP sends these at MeterValueSampleInterval
+	// (bounded), so request an immediate sense to publish the new measurements instead of waiting for the next poll.
+	if updated && conn.notify != nil {
+		conn.notify()
 	}
 
 	return new(core.MeterValuesConfirmation), nil

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/charger/warp"
+	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 )
@@ -30,6 +31,8 @@ type WarpWS struct {
 	// config
 	log        *util.Logger
 	meterIndex uint
+
+	lp loadpoint.API // push notifications on status change
 
 	mu sync.RWMutex
 
@@ -247,7 +250,11 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 	case "evse/user_enabled":
 		err = json.Unmarshal(payload, &w.evse.UserEnabled)
 	case "evse/state":
-		err = json.Unmarshal(payload, &w.evse.State)
+		prev := w.evse.State.Iec61851State
+		if err = json.Unmarshal(payload, &w.evse.State); err == nil && w.evse.State.Iec61851State != prev && w.lp != nil {
+			// status change is latency-sensitive: sense immediately
+			w.lp.Notify()
+		}
 	case "meter/all_values":
 		if !w.hasFeature(warp.FeatureMeterAllValues) || w.hasFeature(warp.FeatureMeters) {
 			return nil
@@ -472,4 +479,14 @@ func (w *WarpWS) getWarpType() (string, error) {
 	uri := fmt.Sprintf("%s/info/name", w.URI)
 	err := w.GetJSON(uri, &res)
 	return res.WarpType, err
+}
+
+var _ loadpoint.Controller = (*WarpWS)(nil)
+
+// LoadpointControl implements loadpoint.Controller, storing the loadpoint
+// reference so status changes from the WebSocket can be pushed immediately.
+func (w *WarpWS) LoadpointControl(lp loadpoint.API) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lp = lp
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -78,13 +78,14 @@ type Task = func()
 // Loadpoint is responsible for controlling charge depending on
 // Soc needs and power availability.
 type Loadpoint struct {
-	clock    clock.Clock // mockable time
-	bus      evbus.Bus   // event bus
-	site     site.API
-	pushChan chan<- messenger.Event // notifications
-	uiChan   chan<- util.Param      // client push messages
-	lpChan   chan<- *Loadpoint      // update requests
-	log      *util.Logger
+	clock     clock.Clock // mockable time
+	bus       evbus.Bus   // event bus
+	site      site.API
+	pushChan  chan<- messenger.Event // notifications
+	uiChan    chan<- util.Param      // client push messages
+	lpChan    chan<- *Loadpoint      // update requests
+	senseChan chan<- *Loadpoint      // immediate sense requests (push-capable chargers)
+	log       *util.Logger
 
 	rwMutex      atomic.Int64 // count reentrant RWMutex
 	sync.RWMutex              // guard status
@@ -451,6 +452,16 @@ func (lp *Loadpoint) GetInflightPower() float64 {
 	}
 
 	return max(0, intended-lp.chargePower)
+}
+
+// Notify requests an immediate sensing pass for this loadpoint. Push-capable
+// chargers call it (via loadpoint.API) when their state changes so the change is
+// observed at once instead of at the next sense tick. It is non-blocking.
+func (lp *Loadpoint) Notify() {
+	select {
+	case lp.senseChan <- lp:
+	default:
+	}
 }
 
 // configureChargerType ensures that chargeMeter, Rate and Timer can use charger capabilities

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -22,6 +22,11 @@ type API interface {
 	// GetStatus returns the charging status
 	GetStatus() api.ChargeStatus
 
+	// Notify requests an immediate sensing pass for this loadpoint. Push-capable
+	// chargers call it when their state changes so the change is picked up at
+	// once instead of at the next sense tick.
+	Notify()
+
 	//
 	// references
 	//

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -727,6 +727,18 @@ func (mr *MockAPIMockRecorder) IsFastChargingActive() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFastChargingActive", reflect.TypeOf((*MockAPI)(nil).IsFastChargingActive))
 }
 
+// Notify mocks base method.
+func (m *MockAPI) Notify() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Notify")
+}
+
+// Notify indicates an expected call of Notify.
+func (mr *MockAPIMockRecorder) Notify() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockAPI)(nil).Notify))
+}
+
 // PublishEffectiveValues mocks base method.
 func (m *MockAPI) PublishEffectiveValues() {
 	m.ctrl.T.Helper()

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -61,6 +61,34 @@ func TestObserveTriggersOnStatusChange(t *testing.T) {
 	}
 }
 
+// TestNotifyTriggersSense verifies that a push-capable charger's Notify requests
+// an immediate sense, and that it never blocks when the channel is full.
+func TestNotifyTriggersSense(t *testing.T) {
+	senseChan := make(chan *Loadpoint, 1)
+	lp := &Loadpoint{log: util.NewLogger("foo"), senseChan: senseChan}
+
+	lp.Notify()
+
+	select {
+	case got := <-senseChan:
+		if got != lp {
+			t.Fatal("unexpected loadpoint on sense channel")
+		}
+	default:
+		t.Fatal("expected an immediate sense request")
+	}
+
+	// must not block when nobody is draining the channel
+	lp.senseChan = make(chan *Loadpoint) // unbuffered, no reader
+	done := make(chan struct{})
+	go func() { lp.Notify(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Notify blocked")
+	}
+}
+
 // TestObserveNoTriggerWithoutStatusChange verifies that an unchanged status does
 // not request a redundant control pass.
 func TestObserveNoTriggerWithoutStatusChange(t *testing.T) {

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"testing"
+	"time"
 
 	evbus "github.com/asaskevich/EventBus"
 	"github.com/benbjohnson/clock"

--- a/core/site.go
+++ b/core/site.go
@@ -54,6 +54,7 @@ var _ site.API = (*Site)(nil)
 type Site struct {
 	valueChan    chan<- util.Param // client push messages
 	lpUpdateChan chan *Loadpoint
+	senseTrigger chan *Loadpoint // immediate sense requests from push-capable chargers
 
 	sync.RWMutex
 	log *util.Logger
@@ -1084,6 +1085,9 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 
 	site.lpUpdateChan = make(chan *Loadpoint, 1) // 1 capacity to avoid deadlock
 
+	// buffered so push-capable chargers never block; the sense loop drains it
+	site.senseTrigger = make(chan *Loadpoint, max(1, len(site.loadpoints)))
+
 	site.prepare()
 
 	lpDevices := config.Loadpoints().Devices()
@@ -1111,6 +1115,7 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 			site.valueChan <- util.Param{Loadpoint: &id, Key: keys.Name, Val: lpDevices[id].Config().Name}
 		}
 
+		lp.senseChan = site.senseTrigger
 		lp.Prepare(site, lpUIChan, lpPushChan, site.lpUpdateChan)
 	}
 }
@@ -1134,6 +1139,9 @@ func (site *Site) senseLoop(stopC chan struct{}, interval time.Duration) {
 				wg.Go(lp.Sense)
 			}
 			wg.Wait()
+		case lp := <-site.senseTrigger:
+			// push-capable charger reported a change: sense it immediately
+			lp.Sense()
 		case <-stopC:
 			return
 		}


### PR DESCRIPTION
Let push-capable chargers (WebSocket/event based) report **status changes immediately** instead of waiting for the next sense tick — and, for OCPP, **fresh meter values too**. Such chargers already keep their state fresh in the background, but evcc only read it on the periodic poll — so a plug-in (or a new measurement) was noticed up to one sense interval late.

### How it works
- **`loadpoint.API` gains `Notify()`.** A charger that holds the loadpoint reference (via the existing `loadpoint.Controller` / `LoadpointControl(API)` mechanism) calls it when something relevant changes.
- **`Loadpoint.Notify()`** does a non-blocking send on a per-loadpoint sense channel.
- **The site sense loop** selects on a buffered `senseTrigger` channel and immediately runs `Sense()` (observe) for the pushed loadpoint at once. The periodic tick stays as the **poll fallback** for non-push chargers.

### Chargers wired (all via the existing `LoadpointControl`)
- **Easee** — `lp.Notify()` on an `opMode` (status) change.
- **Warp-WS** — added `LoadpointControl`; `lp.Notify()` when the evse `Iec61851State` (A/B/C) changes in the WebSocket handler.
- **OCPP** — added `LoadpointControl`; the connector gets a `SetNotify` callback fired from **`OnStatusNotification`** (charge-point status change) **and from `OnMeterValues`** (fresh meter values). The status/measurements live on the connector, not the charger, hence the small callback bridge.

All guard against a nil loadpoint and reuse the existing background WebSocket goroutines.

### Design note — status-only vs. metering push
`Notify()` should fire **on a charge-status change** (plug-in/-out, charging↔suspended) or on a **bulk metering update**, **not on single power/current/energy/voltage measurand updates**:
1. **Flooding:** Easee/Warp stream *single* measurands continuously from the WebSocket; a `Notify()` per sample would trigger a full `Sense()` (status + metering + soc + identify — all I/O) on every reading. → those stay **status-only**.
2. **OCPP is different:** a `MeterValues` message is a *bulk* sample of all measurands at once, sent at the bounded `MeterValueSampleInterval` (default 10s) — not a continuous stream. Pushing on it keeps charger power/energy fresh in the UI/session at the rate the data actually arrives, without flooding. → OCPP pushes **status + metering**.
3. **No control benefit either way:** the PV/surplus decision uses the **site grid meter**, not the charger's own meter, so this is about observability/UI freshness, not control reaction.

### API change
`loadpoint.API` gains `Notify()`; `MockAPI` regenerated.

### Tests
- `Notify()` queues an immediate sense and never blocks when the channel is full.
- Full suite green incl. `-race` (incl. the ocpp package); vet, fmt, full build clean.

Follow-up from #30367