### PR TITLE
Loadpoint: add optional per-charger poll interval

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -70,6 +70,15 @@ type StatusReasoner interface {
 	StatusReason() (Reason, error)
 }
 
+// IntervalGetter is implemented by chargers that prefer a specific sensing
+// cadence: slower for rate-limited cloud APIs, or rarely for push-capable
+// chargers that report changes themselves. evcc senses such a charger at the
+// returned interval instead of the global default. A non-positive value means
+// no preference.
+type IntervalGetter interface {
+	GetInterval() time.Duration
+}
+
 // CurrentController provides settings charging maximum charging current
 type CurrentController interface {
 	MaxCurrent(current int64) error

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -84,7 +84,7 @@ type Loadpoint struct {
 	pushChan  chan<- messenger.Event // notifications
 	uiChan    chan<- util.Param      // client push messages
 	lpChan    chan<- *Loadpoint      // update requests
-	senseChan chan<- *Loadpoint      // immediate sense requests (push-capable chargers)
+	senseChan chan struct{}          // immediate sense requests (push-capable chargers)
 	log       *util.Logger
 
 	rwMutex      atomic.Int64 // count reentrant RWMutex
@@ -459,7 +459,7 @@ func (lp *Loadpoint) GetInflightPower() float64 {
 // observed at once instead of at the next sense tick. It is non-blocking.
 func (lp *Loadpoint) Notify() {
 	select {
-	case lp.senseChan <- lp:
+	case lp.senseChan <- struct{}{}:
 	default:
 	}
 }
@@ -1771,11 +1771,40 @@ func (lp *Loadpoint) getChargeCurrents() []float64 {
 	return lp.chargeCurrents
 }
 
+// senseLoop continuously senses this loadpoint at its own cadence and reacts
+// immediately to push notifications (Notify). Each loadpoint runs its own loop
+// so a slow, rate-limited charger does not throttle a fast local one.
+func (lp *Loadpoint) senseLoop(stopC chan struct{}, base time.Duration) {
+	for tick := time.Tick(lp.senseCadence(base)); ; {
+		select {
+		case <-tick:
+			lp.Sense()
+		case <-lp.senseChan:
+			// push-capable charger reported a change: sense it immediately
+			lp.Sense()
+		case <-stopC:
+			return
+		}
+	}
+}
+
+// senseCadence returns this loadpoint's sensing interval: a charger-provided
+// preference (e.g. slower for rate-limited cloud, rarely for push chargers) if
+// available, otherwise the derived default.
+func (lp *Loadpoint) senseCadence(base time.Duration) time.Duration {
+	if g, ok := api.Cap[api.IntervalGetter](lp.charger); ok {
+		if d := g.GetInterval(); d >= time.Second {
+			return d
+		}
+	}
+	return base
+}
+
 // Sense runs one full sensing pass for the loadpoint: it refreshes live
 // measurements and then observes status, vehicle soc and the rest of the
-// sensing data. It performs no actuation. Driven by the fast site sense loop
-// (see Site.senseLoop), it decouples observability latency from the number of
-// loadpoints and requests a prompt control pass on a status change.
+// sensing data. It performs no actuation. Driven by the per-loadpoint sense
+// loop, it decouples observability latency from the number of loadpoints and
+// requests a prompt control pass on a status change.
 func (lp *Loadpoint) Sense() {
 	// live measurements (parallel-safe, serialized per loadpoint via measureMu)
 	lp.UpdateChargePowerAndCurrents()

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -41,6 +41,42 @@ func newObserveLoadpoint(charger api.Charger) *Loadpoint {
 	}
 }
 
+type intervalStub struct{ d time.Duration }
+
+func (s intervalStub) GetInterval() time.Duration { return s.d }
+
+// chargerWithInterval combines a mock charger with an IntervalGetter hint.
+func chargerWithInterval(ctrl *gomock.Controller, d time.Duration) api.Charger {
+	return &struct {
+		*api.MockCharger
+		intervalStub
+	}{api.NewMockCharger(ctrl), intervalStub{d}}
+}
+
+// TestSenseCadence verifies the per-charger sense interval: a charger hint is
+// honoured (when >= 1s), otherwise the derived base is used.
+func TestSenseCadence(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	base := 3 * time.Second
+
+	tc := []struct {
+		name    string
+		charger api.Charger
+		want    time.Duration
+	}{
+		{"no hint -> base", api.NewMockCharger(ctrl), base},
+		{"slower hint -> hint", chargerWithInterval(ctrl, 30*time.Second), 30 * time.Second},
+		{"sub-second hint ignored -> base", chargerWithInterval(ctrl, 500*time.Millisecond), base},
+	}
+
+	for _, c := range tc {
+		lp := &Loadpoint{charger: c.charger}
+		if got := lp.senseCadence(base); got != c.want {
+			t.Errorf("%s: senseCadence = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 // TestObserveTriggersOnStatusChange verifies that observe authoritatively updates
 // the status and requests a prompt control pass when it changed.
 func TestObserveTriggersOnStatusChange(t *testing.T) {
@@ -65,22 +101,19 @@ func TestObserveTriggersOnStatusChange(t *testing.T) {
 // TestNotifyTriggersSense verifies that a push-capable charger's Notify requests
 // an immediate sense, and that it never blocks when the channel is full.
 func TestNotifyTriggersSense(t *testing.T) {
-	senseChan := make(chan *Loadpoint, 1)
+	senseChan := make(chan struct{}, 1)
 	lp := &Loadpoint{log: util.NewLogger("foo"), senseChan: senseChan}
 
 	lp.Notify()
 
 	select {
-	case got := <-senseChan:
-		if got != lp {
-			t.Fatal("unexpected loadpoint on sense channel")
-		}
+	case <-senseChan:
 	default:
 		t.Fatal("expected an immediate sense request")
 	}
 
 	// must not block when nobody is draining the channel
-	lp.senseChan = make(chan *Loadpoint) // unbuffered, no reader
+	lp.senseChan = make(chan struct{}) // unbuffered, no reader
 	done := make(chan struct{})
 	go func() { lp.Notify(); close(done) }()
 	select {

--- a/core/site.go
+++ b/core/site.go
@@ -54,7 +54,6 @@ var _ site.API = (*Site)(nil)
 type Site struct {
 	valueChan    chan<- util.Param // client push messages
 	lpUpdateChan chan *Loadpoint
-	senseTrigger chan *Loadpoint // immediate sense requests from push-capable chargers
 
 	sync.RWMutex
 	log *util.Logger
@@ -1085,9 +1084,6 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 
 	site.lpUpdateChan = make(chan *Loadpoint, 1) // 1 capacity to avoid deadlock
 
-	// buffered so push-capable chargers never block; the sense loop drains it
-	site.senseTrigger = make(chan *Loadpoint, max(1, len(site.loadpoints)))
-
 	site.prepare()
 
 	lpDevices := config.Loadpoints().Devices()
@@ -1115,7 +1111,7 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 			site.valueChan <- util.Param{Loadpoint: &id, Key: keys.Name, Val: lpDevices[id].Config().Name}
 		}
 
-		lp.senseChan = site.senseTrigger
+		lp.senseChan = make(chan struct{}, 1) // own sense trigger; push-capable chargers never block
 		lp.Prepare(site, lpUIChan, lpPushChan, site.lpUpdateChan)
 	}
 }
@@ -1124,29 +1120,6 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 // control interval; loadpoints without a charger-specific preference
 // (api.IntervalGetter) sense at this fixed rate.
 const senseInterval = 2 * time.Second
-
-// senseLoop continuously polls all loadpoints in parallel for status and live
-// measurements, publishing them for snappy UI updates and triggering an
-// immediate control pass when a charger status change is detected. It runs
-// independently of the control loop so observability latency no longer scales
-// with the number of loadpoints.
-func (site *Site) senseLoop(stopC chan struct{}, interval time.Duration) {
-	for tick := time.Tick(interval); ; {
-		select {
-		case <-tick:
-			var wg sync.WaitGroup
-			for _, lp := range site.loadpoints {
-				wg.Go(lp.Sense)
-			}
-			wg.Wait()
-		case lp := <-site.senseTrigger:
-			// push-capable charger reported a change: sense it immediately
-			lp.Sense()
-		case <-stopC:
-			return
-		}
-	}
-}
 
 // loopLoadpoints feeds the next loadpoint to control to the given channel. It
 // prefers loadpoints with pending control work (events, deferred actuations) so
@@ -1210,11 +1183,12 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 		go site.loopLoadpoints(loadpointChan)
 	}
 
-	// fast sense loop: decouple status/measurement latency from loadpoint count.
-	// never sense slower than the control loop (cap the 2s default at interval,
-	// relevant for very short intervals such as integration tests)
-	if len(site.loadpoints) > 0 {
-		go site.senseLoop(stopC, min(senseInterval, interval))
+	// per-loadpoint sense loops: each senses at its own cadence (charger hint or
+	// the fixed default) and reacts to push notifications, so a slow rate-limited
+	// charger does not throttle a fast local one. Never sense slower than the
+	// control loop (cap the 2s default at interval, e.g. integration tests).
+	for _, lp := range site.loadpoints {
+		go lp.senseLoop(stopC, min(senseInterval, interval))
 	}
 
 	site.update(<-loadpointChan) // start immediately


### PR DESCRIPTION
Follow-up from #30374

Replaces the single shared sense loop with **one sense goroutine per loadpoint**, so each senses at its own cadence — a slow, rate-limited cloud charger no longer throttles a fast local Modbus one (and vice versa).

No charger implements `IntervalGetter` yet, so behavior is unchanged by default (all loadpoints use the 2 s default update rate). Rate-limited/cloud chargers can opt in with a one-method `GetInterval()` in follow-ups.