### PR TITLE
Core: event-driven loadpoint actuation + observe/control split

### DIFF
--- a/core/actuationgate.go
+++ b/core/actuationgate.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// errActuationDeferred signals that an actuation was postponed by the settle
+// lock. It is not a failure: the loadpoint schedules a retry and re-decides on
+// the next pass. Callers treat it as a silent no-op.
+var errActuationDeferred = errors.New("actuation deferred by settle lock")
+
+// actuationGate enforces a minimum spacing ("settle lock") between
+// budget-increasing actuations across the whole site. It decouples how often
+// loadpoints are evaluated (fast, event-driven) from how often setpoints are
+// actually changed (spaced by the lock), preventing several loadpoints from
+// grabbing surplus before the meters reflect the previous change.
+type actuationGate struct {
+	mu    sync.Mutex
+	clock clock.Clock
+	lock  time.Duration
+	last  time.Time
+}
+
+// newActuationGate returns a gate spacing actuations by lock, driven by clk.
+func newActuationGate(clk clock.Clock, lock time.Duration) *actuationGate {
+	return &actuationGate{clock: clk, lock: lock}
+}
+
+// tryAcquire reports whether an actuation may proceed now. On success it stamps
+// the gate so subsequent actuations are held off for the lock duration; on
+// denial it returns the remaining lock so the caller can schedule a retry.
+func (g *actuationGate) tryAcquire() (bool, time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.lock <= 0 {
+		return true, 0
+	}
+
+	if !g.last.IsZero() {
+		if elapsed := g.clock.Now().Sub(g.last); elapsed < g.lock {
+			return false, g.lock - elapsed
+		}
+	}
+
+	g.last = g.clock.Now()
+	return true, 0
+}

--- a/core/actuationgate_test.go
+++ b/core/actuationgate_test.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"go.uber.org/mock/gomock"
+)
+
+// TestActuationGate covers the gate in isolation: first acquire grants, a second
+// within the lock is denied with the remaining duration, and after the lock
+// expires it grants again. A non-positive lock always grants.
+func TestActuationGate(t *testing.T) {
+	clk := clock.NewMock()
+	g := newActuationGate(clk, time.Minute)
+
+	if granted, _ := g.tryAcquire(); !granted {
+		t.Fatal("first acquire must be granted")
+	}
+
+	clk.Add(20 * time.Second)
+	if granted, retryAfter := g.tryAcquire(); granted || retryAfter != 40*time.Second {
+		t.Fatalf("within lock: granted=%v retryAfter=%v, want false / 40s", granted, retryAfter)
+	}
+
+	clk.Add(40 * time.Second) // now exactly at the lock boundary
+	if granted, _ := g.tryAcquire(); !granted {
+		t.Fatal("acquire after lock expiry must be granted")
+	}
+
+	// non-positive lock disables gating
+	g0 := newActuationGate(clk, 0)
+	if granted, _ := g0.tryAcquire(); !granted {
+		t.Fatal("zero lock must always grant")
+	}
+}
+
+func newGateLoadpoint(t *testing.T, charger api.Charger, clk clock.Clock, gate *actuationGate) *Loadpoint {
+	t.Helper()
+	return &Loadpoint{
+		log:         util.NewLogger("foo"),
+		clock:       clk,
+		bus:         evbus.New(),
+		charger:     charger,
+		wakeUpTimer: NewTimer(),
+		minCurrent:  minA,
+		maxCurrent:  maxA,
+		gate:        gate,
+	}
+}
+
+// TestSetLimitGateDefersIncrease verifies that a budget-increasing actuation is
+// deferred while the settle lock is active and proceeds once it expires.
+func TestSetLimitGateDefersIncrease(t *testing.T) {
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := newGateLoadpoint(t, charger, clk, newActuationGate(clk, time.Minute))
+
+	// initial enable from disabled: grants (gate fresh)
+	charger.EXPECT().MaxCurrent(int64(minA)).Return(nil)
+	charger.EXPECT().Enable(true).Return(nil)
+	if err := lp.setLimit(minA); err != nil {
+		t.Fatalf("initial setLimit: %v", err)
+	}
+
+	// raise current immediately: within lock -> deferred, no charger calls
+	if err := lp.setLimit(maxA); err != nil {
+		t.Fatalf("deferred setLimit must be a silent no-op, got %v", err)
+	}
+	if lp.offeredCurrent != minA {
+		t.Fatalf("offeredCurrent changed despite deferral: %v", lp.offeredCurrent)
+	}
+	if !lp.pendingControl.Load() {
+		t.Fatal("deferral must mark the loadpoint pending")
+	}
+
+	// after the lock expires the raise proceeds
+	clk.Add(time.Minute)
+	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
+	if err := lp.setLimit(maxA); err != nil {
+		t.Fatalf("setLimit after lock: %v", err)
+	}
+	if lp.offeredCurrent != maxA {
+		t.Fatalf("offeredCurrent not raised: %v", lp.offeredCurrent)
+	}
+}
+
+// TestSetLimitGateBypassesDecrease verifies that reductions are never blocked by
+// the settle lock, even while it is active.
+func TestSetLimitGateBypassesDecrease(t *testing.T) {
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	gate := newActuationGate(clk, time.Minute)
+	gate.tryAcquire() // stamp: gate is now locked
+
+	lp := newGateLoadpoint(t, charger, clk, gate)
+	lp.enabled = true
+	lp.offeredCurrent = maxA
+
+	// decrease while the lock is active must go through immediately
+	charger.EXPECT().MaxCurrent(int64(minA)).Return(nil)
+	if err := lp.setLimit(minA); err != nil {
+		t.Fatalf("decrease setLimit: %v", err)
+	}
+	if lp.offeredCurrent != minA {
+		t.Fatalf("offeredCurrent not reduced: %v", lp.offeredCurrent)
+	}
+}
+
+// TestScalePhasesGateBothDirections verifies that phase switches acquire the gate
+// in both directions (a switch causes a charging pause that must hold off others).
+func TestScalePhasesGateBothDirections(t *testing.T) {
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+
+	phaseSwitcher := api.NewMockPhaseSwitcher(ctrl)
+	charger := struct {
+		*api.MockCharger
+		*api.MockPhaseSwitcher
+	}{
+		api.NewMockCharger(ctrl), phaseSwitcher,
+	}
+
+	gate := newActuationGate(clk, time.Minute)
+	gate.tryAcquire() // stamp: gate is now locked
+
+	lp := newGateLoadpoint(t, charger, clk, gate)
+	lp.phases = 1
+
+	// scale-up within lock -> deferred, no switch
+	if err := lp.scalePhases(3); !errors.Is(err, errActuationDeferred) {
+		t.Fatalf("scale-up within lock: want errActuationDeferred, got %v", err)
+	}
+
+	// after lock expiry the up-switch proceeds (and re-stamps the gate)
+	clk.Add(time.Minute)
+	phaseSwitcher.EXPECT().Phases1p3p(3).Return(nil)
+	if err := lp.scalePhases(3); err != nil {
+		t.Fatalf("scale-up after lock: %v", err)
+	}
+
+	// down-switch immediately after is gated too -> deferred, no Phases1p3p(1)
+	if err := lp.scalePhases(1); !errors.Is(err, errActuationDeferred) {
+		t.Fatalf("scale-down within lock: want errActuationDeferred, got %v", err)
+	}
+}
+
+// loopLoadpoints scheduler tests live in scheduler_test.go (the scheduler
+// outlives the actuation gate, which is removed in a later phase).

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -96,6 +96,11 @@ type Loadpoint struct {
 	retryMu        sync.Mutex     // guards retryTimer
 	retryTimer     *clock.Timer   // deferred actuation retry
 
+	controlMu     sync.Mutex // serialize observe (sense loop) vs control (control loop) per loadpoint
+	observed      bool       // set once observe has produced valid state; control must not actuate before
+	welcomeCharge bool       // latched by observe on connect, consumed+cleared by control
+	observeErr    error      // last charger status read error; control skips actuation while set
+
 	// exposed public configuration
 	CircuitRef string `mapstructure:"circuit"` // Circuit reference
 	ChargerRef string `mapstructure:"charger"` // Charger reference
@@ -1740,30 +1745,17 @@ func (lp *Loadpoint) getChargeCurrents() []float64 {
 	return lp.chargeCurrents
 }
 
-// Sense reads charger status and live measurements without mutating control
-// state or actuating. It publishes the results for snappy UI updates and
-// requests an immediate control pass when the charger status changed. Sense is
-// safe to call concurrently with the control loop and across loadpoints; it is
-// driven by the fast site sense loop (see Site.senseLoop), decoupling
-// observability latency from the number of loadpoints.
+// Sense runs one full sensing pass for the loadpoint: it refreshes live
+// measurements and then observes status, vehicle soc and the rest of the
+// sensing data. It performs no actuation. Driven by the fast site sense loop
+// (see Site.senseLoop), it decouples observability latency from the number of
+// loadpoints and requests a prompt control pass on a status change.
 func (lp *Loadpoint) Sense() {
 	// live measurements (parallel-safe, serialized per loadpoint via measureMu)
 	lp.UpdateChargePowerAndCurrents()
 
-	// charger status: compared against the authoritative status, which only the
-	// control pass updates. While they differ we keep requesting an update on
-	// every sense tick, which self-heals the cap(1) lpUpdateChan trigger drop.
-	status, err := lp.charger.Status()
-	if err != nil {
-		lp.log.DEBUG.Printf("sense: charger status: %v", err)
-		return
-	}
-
-	if status != lp.GetStatus() {
-		lp.publish(keys.Connected, status == api.StatusB || status == api.StatusC)
-		lp.publish(keys.Charging, status == api.StatusC)
-		lp.requestUpdate()
-	}
+	// status, vehicle soc and remaining sensing (serialized vs control)
+	lp.observe()
 }
 
 // phasesFromChargeCurrents uses PhaseCurrents interface to count phases with current >=1A
@@ -2035,80 +2027,55 @@ func (lp *Loadpoint) phaseSwitchCompleted() bool {
 	return time.Since(lp.phasesSwitched) > phaseSwitchDuration
 }
 
-// Update is the main control function. It reevaluates meters and charger state
+// Update runs a full observe + control pass under a single lock. It is retained
+// for tests and callers that want a synchronous read-decide-actuate cycle;
+// production drives observe (sense loop) and control (control loop) separately.
 func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
-	// auto-disable battery boost when SOC drops below limit
-	if lp.GetBatteryBoost() != boostDisabled {
-		if limit := lp.GetBatteryBoostLimit(); limit < 100 {
-			if batterySoc := lp.site.GetBatterySoc(); batterySoc < float64(limit) {
-				lp.log.DEBUG.Printf("battery boost disabled: soc below limit (%.0f%% < %d%%)", batterySoc, limit)
+	lp.controlMu.Lock()
+	defer lp.controlMu.Unlock()
 
-				if err := lp.SetBatteryBoost(false); err != nil {
-					lp.log.ERROR.Printf("set battery boost: %v", err)
-				}
-			}
-		}
+	lp.observeLocked()
+	lp.controlLocked(sitePower, batteryBoostPower, consumption, feedin, batteryBuffered, batteryStart, greenShare, effPrice, effCo2)
+}
+
+// observe reads and publishes all sensing data (meters, charger status, vehicle
+// soc) without mutating control output or actuating. Driven by the fast site
+// sense loop, it requests a prompt control pass on a status change. observe is
+// serialized against control per loadpoint.
+func (lp *Loadpoint) observe() {
+	lp.controlMu.Lock()
+	changed := lp.observeLocked()
+	lp.controlMu.Unlock()
+
+	if changed {
+		lp.requestUpdate()
 	}
+}
 
-	// smart cost
-	smartCostActive, smartCostNextStart := lp.checkSmartLimit(lp.GetSmartCostLimit(), consumption, true)
-	lp.publish(keys.SmartCostActive, smartCostActive)
-	lp.publish(keys.SmartCostNextStart, smartCostNextStart)
+// observeLocked performs the sensing work and reports whether the charger status
+// changed. The caller must hold controlMu.
+func (lp *Loadpoint) observeLocked() bool {
+	prevStatus := lp.GetStatus()
 
-	smartFeedInPriorityActive, smartFeedInPriorityNextStart := lp.checkSmartLimit(lp.GetSmartFeedInPriorityLimit(), feedin, false)
-	lp.publish(keys.SmartFeedInPriorityActive, smartFeedInPriorityActive)
-	lp.publish(keys.SmartFeedInPriorityNextStart, smartFeedInPriorityNextStart)
-
-	// long-running tasks
-	lp.processTasks()
-
-	// read and publish meters first- charge power and currents have already been updated by the site
+	// read and publish meters - charge power and currents are updated separately
 	lp.updateChargeVoltages()
 	lp.phasesFromChargeCurrents()
 
-	lp.energyMetrics.SetEnvironment(greenShare, effPrice, effCo2)
-
-	// update ChargeRater here to make sure initial meter update is caught
-	lp.bus.Publish(evChargeCurrent, lp.offeredCurrent)
-	lp.bus.Publish(evChargePower, lp.chargePower)
-
-	// update progress and soc before status is updated
-	lp.publishChargeProgress()
-	lp.PublishEffectiveValues()
-
-	// §14a
-	if dimmer, ok := api.Cap[api.Dimmer](lp.charger); ok {
-		dimmed, err := dimmer.Dimmed()
-		if err != nil {
-			lp.log.ERROR.Printf("dimmed: %v", err)
-			return
-		}
-
-		if dim := circuitDimmed(lp.circuit); dim != nil {
-			if *dim != dimmed {
-				if err := dimmer.Dim(*dim); err != nil {
-					lp.log.ERROR.Printf("dim: %v", err)
-					return
-				}
-
-				lp.publish(keys.Dimmed, *dim)
-				lp.log.INFO.Printf("§14a dim: %t", *dim)
-			}
-
-			if *dim {
-				return
-			}
-		}
-	}
-
 	// read and publish status
 	welcomeCharge, err := lp.updateChargerStatus()
+	lp.observeErr = err
 	if err != nil {
 		lp.log.ERROR.Println(err)
-		return
+		return lp.GetStatus() != prevStatus
+	}
+	// latch a welcome charge: updateChargerStatus only reports it on the connect
+	// tick, so keep it set until control consumes it (a faster sense loop would
+	// otherwise overwrite the edge with false before control runs)
+	if welcomeCharge {
+		lp.welcomeCharge = true
 	}
 
-	lp.publish(keys.VehicleWelcomeActive, welcomeCharge)
+	lp.publish(keys.VehicleWelcomeActive, lp.welcomeCharge)
 	lp.publish(keys.Connected, lp.connected())
 	lp.publish(keys.Charging, lp.charging())
 
@@ -2137,11 +2104,99 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	// initial update of connected state matches charger status
 	lp.publishSocAndRange()
 
+	// state is now valid; control may actuate
+	lp.observed = true
+
+	return lp.GetStatus() != prevStatus
+}
+
+// control evaluates the charging strategy and actuates the charger using the
+// state gathered by observe. It is serialized against observe per loadpoint.
+func (lp *Loadpoint) control(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+	lp.controlMu.Lock()
+	defer lp.controlMu.Unlock()
+
+	lp.controlLocked(sitePower, batteryBoostPower, consumption, feedin, batteryBuffered, batteryStart, greenShare, effPrice, effCo2)
+}
+
+// controlLocked is the decision and actuation half of the control loop. The
+// caller must hold controlMu and have run observe beforehand.
+func (lp *Loadpoint) controlLocked(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64) {
+	// auto-disable battery boost when SOC drops below limit
+	if lp.GetBatteryBoost() != boostDisabled {
+		if limit := lp.GetBatteryBoostLimit(); limit < 100 {
+			if batterySoc := lp.site.GetBatterySoc(); batterySoc < float64(limit) {
+				lp.log.DEBUG.Printf("battery boost disabled: soc below limit (%.0f%% < %d%%)", batterySoc, limit)
+
+				if err := lp.SetBatteryBoost(false); err != nil {
+					lp.log.ERROR.Printf("set battery boost: %v", err)
+				}
+			}
+		}
+	}
+
+	// smart cost
+	smartCostActive, smartCostNextStart := lp.checkSmartLimit(lp.GetSmartCostLimit(), consumption, true)
+	lp.publish(keys.SmartCostActive, smartCostActive)
+	lp.publish(keys.SmartCostNextStart, smartCostNextStart)
+
+	smartFeedInPriorityActive, smartFeedInPriorityNextStart := lp.checkSmartLimit(lp.GetSmartFeedInPriorityLimit(), feedin, false)
+	lp.publish(keys.SmartFeedInPriorityActive, smartFeedInPriorityActive)
+	lp.publish(keys.SmartFeedInPriorityNextStart, smartFeedInPriorityNextStart)
+
+	// long-running tasks
+	lp.processTasks()
+
+	lp.energyMetrics.SetEnvironment(greenShare, effPrice, effCo2)
+
+	// update ChargeRater here to make sure initial meter update is caught
+	lp.bus.Publish(evChargeCurrent, lp.offeredCurrent)
+	lp.bus.Publish(evChargePower, lp.chargePower)
+
+	// update progress and effective values
+	lp.publishChargeProgress()
+	lp.PublishEffectiveValues()
+
+	// §14a
+	if dimmer, ok := api.Cap[api.Dimmer](lp.charger); ok {
+		dimmed, err := dimmer.Dimmed()
+		if err != nil {
+			lp.log.ERROR.Printf("dimmed: %v", err)
+			return
+		}
+
+		if dim := circuitDimmed(lp.circuit); dim != nil {
+			if *dim != dimmed {
+				if err := dimmer.Dim(*dim); err != nil {
+					lp.log.ERROR.Printf("dim: %v", err)
+					return
+				}
+
+				lp.publish(keys.Dimmed, *dim)
+				lp.log.INFO.Printf("§14a dim: %t", *dim)
+			}
+
+			if *dim {
+				return
+			}
+		}
+	}
+
+	// do not actuate before observe has produced valid state, or if the last
+	// charger status read failed
+	if !lp.observed || lp.observeErr != nil {
+		return
+	}
+
 	// sync settings with charger
 	if err := lp.syncCharger(); err != nil {
 		lp.log.ERROR.Println(err)
 		return
 	}
+
+	// consume the latched welcome charge so it applies exactly once
+	welcomeCharge := lp.welcomeCharge
+	lp.welcomeCharge = false
 
 	mode := lp.GetMode()
 	lp.publish(keys.Mode, mode)
@@ -2154,6 +2209,7 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	lp.publish(keys.MinSocNotReached, minSocNotReached)
 
 	// execute loading strategy
+	var err error
 	switch {
 	case !lp.connected():
 		// always disable charger if not connected

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -901,8 +901,8 @@ func (lp *Loadpoint) setLimit(current float64) error {
 	// apply circuit limits
 	if lp.circuit != nil {
 		var actualCurrent float64
-		if lp.chargeCurrents != nil {
-			actualCurrent = max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
+		if cc := lp.getChargeCurrents(); cc != nil {
+			actualCurrent = max(cc[0], cc[1], cc[2])
 		} else if lp.charging() {
 			actualCurrent = lp.offeredCurrent
 		}
@@ -1642,8 +1642,10 @@ func (lp *Loadpoint) UpdateChargePowerAndCurrents() float64 {
 		lp.log.ERROR.Printf("charge power: %v", err)
 	}
 
-	// update charge currents
-	lp.chargeCurrents = nil
+	// update charge currents - compute into a local first, then publish the new
+	// value in a single locked assignment so concurrent readers (sense vs
+	// control loop) never observe a torn or transiently-nil slice
+	var currents []float64
 
 	if phaseMeter, ok := api.Cap[api.PhaseCurrents](lp.chargeMeter); ok {
 		if err := backoff.Retry(func() error {
@@ -1655,20 +1657,32 @@ func (lp *Loadpoint) UpdateChargePowerAndCurrents() float64 {
 				return err
 			}
 
-			lp.Lock()
-			lp.chargeCurrents = []float64{i1, i2, i3}
-			lp.Unlock()
-
-			lp.log.DEBUG.Printf("charge currents: %.3gA", lp.chargeCurrents)
-			lp.publish(keys.ChargeCurrents, lp.chargeCurrents)
-
+			currents = []float64{i1, i2, i3}
 			return nil
 		}, modbus.Backoff()); err != nil && !errors.Is(err, api.ErrNotAvailable) {
 			lp.log.ERROR.Printf("charge currents: %v", err)
 		}
 	}
 
+	lp.Lock()
+	lp.chargeCurrents = currents
+	lp.Unlock()
+
+	if currents != nil {
+		lp.log.DEBUG.Printf("charge currents: %.3gA", currents)
+		lp.publish(keys.ChargeCurrents, currents)
+	}
+
 	return power
+}
+
+// getChargeCurrents returns a consistent snapshot of the per-phase charge
+// currents. The slice is replaced wholesale (never mutated in place), so the
+// returned value is safe to read without further locking.
+func (lp *Loadpoint) getChargeCurrents() []float64 {
+	lp.RLock()
+	defer lp.RUnlock()
+	return lp.chargeCurrents
 }
 
 // Sense reads charger status and live measurements without mutating control
@@ -1699,13 +1713,14 @@ func (lp *Loadpoint) Sense() {
 
 // phasesFromChargeCurrents uses PhaseCurrents interface to count phases with current >=1A
 func (lp *Loadpoint) phasesFromChargeCurrents() {
-	if lp.chargeCurrents == nil {
+	chargeCurrents := lp.getChargeCurrents()
+	if chargeCurrents == nil {
 		return
 	}
 
 	if lp.charging() && lp.phaseSwitchCompleted() {
 		var phases int
-		for _, i := range lp.chargeCurrents {
+		for _, i := range chargeCurrents {
 			if i > minActiveCurrent {
 				phases++
 			}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -89,6 +89,7 @@ type Loadpoint struct {
 	rwMutex      atomic.Int64 // count reentrant RWMutex
 	sync.RWMutex              // guard status
 	vmu          sync.RWMutex // guard vehicle
+	measureMu    sync.Mutex   // serialize meter measurement reads across sense and control loops
 
 	// exposed public configuration
 	CircuitRef string `mapstructure:"circuit"` // Circuit reference
@@ -1617,6 +1618,10 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 
 // UpdateChargePowerAndCurrents updates charge meter power and currents for load management
 func (lp *Loadpoint) UpdateChargePowerAndCurrents() float64 {
+	// serialize concurrent reads from the sense and control loops
+	lp.measureMu.Lock()
+	defer lp.measureMu.Unlock()
+
 	power, err := backoff.RetryWithData(lp.chargeMeter.CurrentPower, modbus.Backoff())
 	if err == nil {
 		lp.Lock()
@@ -1664,6 +1669,32 @@ func (lp *Loadpoint) UpdateChargePowerAndCurrents() float64 {
 	}
 
 	return power
+}
+
+// Sense reads charger status and live measurements without mutating control
+// state or actuating. It publishes the results for snappy UI updates and
+// requests an immediate control pass when the charger status changed. Sense is
+// safe to call concurrently with the control loop and across loadpoints; it is
+// driven by the fast site sense loop (see Site.senseLoop), decoupling
+// observability latency from the number of loadpoints.
+func (lp *Loadpoint) Sense() {
+	// live measurements (parallel-safe, serialized per loadpoint via measureMu)
+	lp.UpdateChargePowerAndCurrents()
+
+	// charger status: compared against the authoritative status, which only the
+	// control pass updates. While they differ we keep requesting an update on
+	// every sense tick, which self-heals the cap(1) lpUpdateChan trigger drop.
+	status, err := lp.charger.Status()
+	if err != nil {
+		lp.log.DEBUG.Printf("sense: charger status: %v", err)
+		return
+	}
+
+	if status != lp.GetStatus() {
+		lp.publish(keys.Connected, status == api.StatusB || status == api.StatusC)
+		lp.publish(keys.Charging, status == api.StatusC)
+		lp.requestUpdate()
+	}
 }
 
 // phasesFromChargeCurrents uses PhaseCurrents interface to count phases with current >=1A

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -91,6 +91,11 @@ type Loadpoint struct {
 	vmu          sync.RWMutex // guard vehicle
 	measureMu    sync.Mutex   // serialize meter measurement reads across sense and control loops
 
+	gate           *actuationGate // site-wide settle lock for budget-increasing actuations (nil = disabled)
+	pendingControl atomic.Bool    // control re-evaluation requested (scheduler hint)
+	retryMu        sync.Mutex     // guards retryTimer
+	retryTimer     *clock.Timer   // deferred actuation retry
+
 	// exposed public configuration
 	CircuitRef string `mapstructure:"circuit"` // Circuit reference
 	ChargerRef string `mapstructure:"charger"` // Charger reference
@@ -397,10 +402,31 @@ func (lp *Loadpoint) restoreSettings() {
 
 // requestUpdate requests site to update this loadpoint
 func (lp *Loadpoint) requestUpdate() {
+	lp.pendingControl.Store(true) // persists even if the cap(1) channel send is dropped
 	select {
 	case lp.lpChan <- lp: // request loadpoint update
 	default:
 	}
+}
+
+// setActuationGate wires the site-wide settle lock into the loadpoint.
+func (lp *Loadpoint) setActuationGate(g *actuationGate) {
+	lp.gate = g
+}
+
+// deferActuation postpones a budget-increasing actuation until the settle lock
+// expires and schedules a re-evaluation. A single managed timer is reset on
+// each deferral to avoid stacking.
+func (lp *Loadpoint) deferActuation(d time.Duration) {
+	lp.pendingControl.Store(true)
+
+	lp.retryMu.Lock()
+	defer lp.retryMu.Unlock()
+
+	if lp.retryTimer != nil {
+		lp.retryTimer.Stop()
+	}
+	lp.retryTimer = lp.clock.AfterFunc(d, lp.requestUpdate)
 }
 
 // configureChargerType ensures that chargeMeter, Rate and Timer can use charger capabilities
@@ -922,6 +948,20 @@ func (lp *Loadpoint) setLimit(current float64) error {
 		return fmt.Errorf("invalid config: min current %.3gA exceeds max current %.3gA", effMinCurrent, effMaxCurrent)
 	}
 
+	// settle lock: space budget-increasing actuations site-wide. Reductions and
+	// disables bypass the gate (always safe and must stay immediate).
+	if lp.gate != nil {
+		willEnable := current >= effMinCurrent && !lp.enabled
+		willRaiseCurrent := current >= effMinCurrent && current > lp.offeredCurrent
+		if willEnable || willRaiseCurrent {
+			if granted, retryAfter := lp.gate.tryAcquire(); !granted {
+				lp.log.DEBUG.Printf("actuation deferred for %v (settle lock)", retryAfter.Round(time.Second))
+				lp.deferActuation(retryAfter)
+				return nil
+			}
+		}
+	}
+
 	// set current
 	if current != lp.offeredCurrent && current >= effMinCurrent {
 		var err error
@@ -1281,6 +1321,17 @@ func (lp *Loadpoint) scalePhases(phases int) error {
 	}
 
 	if lp.GetPhases() != phases {
+		// settle lock: a phase switch causes an implicit charging pause (zero
+		// draw) before the charger resumes on its own. Acquire (and stamp) the
+		// gate in both directions so no other loadpoint actuates during the
+		// pause, which could otherwise overshoot total power afterwards.
+		if lp.gate != nil {
+			if granted, retryAfter := lp.gate.tryAcquire(); !granted {
+				lp.deferActuation(retryAfter)
+				return errActuationDeferred
+			}
+		}
+
 		// switch phases
 		if err := cp.Phases1p3p(phases); err != nil {
 			return fmt.Errorf("switch phases: %w", err)
@@ -1377,8 +1428,10 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetDisableDelay() {
 			if err := lp.scalePhases(1); err != nil {
 				// a charger may report it cannot switch phases right now
-				// (api.ErrNotAvailable); assume a failed switch and stay silent
-				if !errors.Is(err, api.ErrNotAvailable) {
+				// (api.ErrNotAvailable), or the switch was postponed by the
+				// settle lock (errActuationDeferred); assume an incomplete
+				// switch and stay silent
+				if !errors.Is(err, api.ErrNotAvailable) && !errors.Is(err, errActuationDeferred) {
 					lp.log.ERROR.Println(err)
 				}
 				// switch did not complete - phase count is unchanged
@@ -1412,8 +1465,10 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		if elapsed := lp.clock.Since(lp.phaseTimer); elapsed >= lp.GetEnableDelay() {
 			if err := lp.scalePhases(3); err != nil {
 				// a charger may report it cannot switch phases right now
-				// (api.ErrNotAvailable); assume a failed switch and stay silent
-				if !errors.Is(err, api.ErrNotAvailable) {
+				// (api.ErrNotAvailable), or the switch was postponed by the
+				// settle lock (errActuationDeferred); assume an incomplete
+				// switch and stay silent
+				if !errors.Is(err, api.ErrNotAvailable) && !errors.Is(err, errActuationDeferred) {
 					lp.log.ERROR.Println(err)
 				}
 				// switch did not complete - phase count is unchanged
@@ -2200,8 +2255,8 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	// 	lp.publish(keys.RemoteDisabled, remoteDisabled)
 	// }
 
-	// log any error
-	if err != nil {
+	// log any error (a deferred actuation is a silent no-op that will retry)
+	if err != nil && !errors.Is(err, errActuationDeferred) {
 		lp.log.ERROR.Println(err)
 	}
 }

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -4,21 +4,14 @@ import (
 	"testing"
 	"time"
 
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/messenger"
 	"github.com/evcc-io/evcc/util"
 	"go.uber.org/mock/gomock"
 )
-
-// TestSenseInterval verifies the default sense cadence is a fixed 2s,
-// independent of the control interval.
-func TestSenseInterval(t *testing.T) {
-	for _, in := range []time.Duration{30 * time.Second, 10 * time.Second, 0} {
-		if got := senseInterval(in); got != 2*time.Second {
-			t.Errorf("senseInterval(%v) = %v, want 2s", in, got)
-		}
-	}
-}
 
 // drainParams collects all currently buffered published params keyed by name.
 func drainParams(ch chan util.Param) map[string]any {
@@ -33,101 +26,130 @@ func drainParams(ch chan util.Param) map[string]any {
 	}
 }
 
-func newSenseLoadpoint(charger api.Charger) (*Loadpoint, chan *Loadpoint, chan util.Param) {
-	lpChan := make(chan *Loadpoint, 1)  // mirrors production cap(1)
-	uiChan := make(chan util.Param, 16) // buffered so publish doesn't block
-
-	lp := &Loadpoint{
-		log:         util.NewLogger("foo"),
-		charger:     charger,
-		chargeMeter: &Null{}, // silence nil panics, returns zero power
-		lpChan:      lpChan,
-		uiChan:      uiChan,
+// TestSenseInterval verifies the default sense cadence is a fixed 2s,
+// independent of the control interval.
+func TestSenseInterval(t *testing.T) {
+	for _, in := range []time.Duration{30 * time.Second, 10 * time.Second, 0} {
+		if got := senseInterval(in); got != 2*time.Second {
+			t.Errorf("senseInterval(%v) = %v, want 2s", in, got)
+		}
 	}
-
-	return lp, lpChan, uiChan
 }
 
-// TestSenseTriggersOnStatusChange verifies that a sensed charger status which
-// differs from the authoritative status requests an immediate control pass and
-// publishes the derived connection state.
-func TestSenseTriggersOnStatusChange(t *testing.T) {
+func newObserveLoadpoint(charger api.Charger) *Loadpoint {
+	return &Loadpoint{
+		log:         util.NewLogger("foo"),
+		clock:       clock.NewMock(),
+		bus:         evbus.New(),
+		charger:     charger,
+		chargeMeter: &Null{}, // silence nil panics, returns zero power
+		uiChan:      make(chan util.Param, 32),
+		lpChan:      make(chan *Loadpoint, 1),
+		pushChan:    make(chan messenger.Event, 8),
+		minCurrent:  minA,
+		maxCurrent:  maxA,
+	}
+}
+
+// TestObserveTriggersOnStatusChange verifies that observe authoritatively updates
+// the status and requests a prompt control pass when it changed.
+func TestObserveTriggersOnStatusChange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	charger := api.NewMockCharger(ctrl)
 
-	lp, lpChan, uiChan := newSenseLoadpoint(charger)
-	lp.status = api.StatusA // authoritative: disconnected
+	lp := newObserveLoadpoint(charger)
+	lp.status = api.StatusA
 
-	charger.EXPECT().Status().Return(api.StatusB, nil) // sensed: connected, not charging
+	charger.EXPECT().Status().Return(api.StatusB, nil)
 
-	lp.Sense()
+	lp.observe()
 
-	select {
-	case got := <-lpChan:
-		if got != lp {
-			t.Fatalf("unexpected loadpoint on update channel")
-		}
-	default:
-		t.Fatal("expected update request on status change")
+	if lp.GetStatus() != api.StatusB {
+		t.Fatalf("status not updated: %v", lp.GetStatus())
 	}
+	if !lp.pendingControl.Load() {
+		t.Fatal("status change must request a control pass")
+	}
+}
+
+// TestObserveNoTriggerWithoutStatusChange verifies that an unchanged status does
+// not request a redundant control pass.
+func TestObserveNoTriggerWithoutStatusChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := newObserveLoadpoint(charger)
+	lp.status = api.StatusC // charging
+
+	charger.EXPECT().Status().Return(api.StatusC, nil) // unchanged
+
+	lp.observe()
+
+	if lp.pendingControl.Load() {
+		t.Fatal("unchanged status must not request a control pass")
+	}
+}
+
+// TestObservePublishesConnectionState verifies observe publishes the snappy-UI
+// connection state (the reason the sense loop exists).
+func TestObservePublishesConnectionState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	uiChan := make(chan util.Param, 32)
+	lp := newObserveLoadpoint(charger)
+	lp.uiChan = uiChan // bidirectional handle so the test can drain it
+	lp.status = api.StatusA
+
+	charger.EXPECT().Status().Return(api.StatusC, nil) // connected and charging
+
+	lp.observe()
 
 	published := drainParams(uiChan)
 	if v, ok := published[keys.Connected]; !ok || v != true {
 		t.Errorf("Connected: got %v (present=%v), want true", v, ok)
 	}
-	if v, ok := published[keys.Charging]; !ok || v != false {
-		t.Errorf("Charging: got %v (present=%v), want false", v, ok)
+	if v, ok := published[keys.Charging]; !ok || v != true {
+		t.Errorf("Charging: got %v (present=%v), want true", v, ok)
 	}
 }
 
-// TestSenseNoTriggerWithoutStatusChange verifies that an unchanged status does
-// not request a redundant control pass.
-func TestSenseNoTriggerWithoutStatusChange(t *testing.T) {
+// TestObserveSetsObserved verifies observe marks the loadpoint observed so
+// control may actuate (and that a fresh loadpoint is not yet observed).
+func TestObserveSetsObserved(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	charger := api.NewMockCharger(ctrl)
 
-	lp, lpChan, _ := newSenseLoadpoint(charger)
-	lp.status = api.StatusC // authoritative: charging
-
-	charger.EXPECT().Status().Return(api.StatusC, nil) // sensed: unchanged
-
-	lp.Sense()
-
-	select {
-	case <-lpChan:
-		t.Fatal("unexpected update request without status change")
-	default:
-	}
-}
-
-// TestSenseRetriggersUntilControlCatchesUp verifies the self-healing behavior:
-// while the authoritative status lags, a trigger stays pending even when an
-// individual re-trigger is dropped on the full cap(1) channel.
-func TestSenseRetriggersUntilControlCatchesUp(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	charger := api.NewMockCharger(ctrl)
-
-	lp, lpChan, _ := newSenseLoadpoint(charger)
+	lp := newObserveLoadpoint(charger)
 	lp.status = api.StatusA
 
-	charger.EXPECT().Status().Return(api.StatusB, nil).Times(2)
-
-	// first sense fills the cap(1) trigger channel
-	lp.Sense()
-	// the authoritative status still lags, so the second sense re-requests an
-	// update; its send is dropped on the full channel, but a trigger remains
-	// pending so control is not starved
-	lp.Sense()
-
-	if got := len(lpChan); got != 1 {
-		t.Fatalf("expected exactly one pending trigger after a dropped re-trigger, got %d", got)
+	if lp.observed {
+		t.Fatal("a fresh loadpoint must not be observed yet")
 	}
-	select {
-	case got := <-lpChan:
-		if got != lp {
-			t.Fatal("unexpected loadpoint on update channel")
-		}
-	default:
-		t.Fatal("expected a pending update request")
+
+	charger.EXPECT().Status().Return(api.StatusB, nil)
+	lp.observe()
+
+	if !lp.observed {
+		t.Fatal("observe must mark the loadpoint observed")
+	}
+}
+
+// TestObserveLatchesWelcomeCharge verifies a faster sense loop does not clobber
+// a latched welcome charge before control consumes it.
+func TestObserveLatchesWelcomeCharge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := newObserveLoadpoint(charger)
+	lp.status = api.StatusC
+	lp.welcomeCharge = true // latched on an earlier connect tick
+
+	// no status change -> updateChargerStatus reports welcomeCharge=false
+	charger.EXPECT().Status().Return(api.StatusC, nil)
+	lp.observe()
+
+	if !lp.welcomeCharge {
+		t.Fatal("observe clobbered the latched welcome charge before control consumed it")
 	}
 }

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -1,0 +1,138 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/util"
+	"go.uber.org/mock/gomock"
+)
+
+// TestSenseInterval verifies the sense cadence derived from the control interval.
+func TestSenseInterval(t *testing.T) {
+	tc := []struct {
+		in, want time.Duration
+	}{
+		{30 * time.Second, 3 * time.Second},
+		{10 * time.Second, 1 * time.Second},
+		{5 * time.Second, 1 * time.Second}, // clamped to 1s minimum
+		{0, 1 * time.Second},
+	}
+
+	for _, c := range tc {
+		if got := senseInterval(c.in); got != c.want {
+			t.Errorf("senseInterval(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// drainParams collects all currently buffered published params keyed by name.
+func drainParams(ch chan util.Param) map[string]any {
+	m := make(map[string]any)
+	for {
+		select {
+		case p := <-ch:
+			m[p.Key] = p.Val
+		default:
+			return m
+		}
+	}
+}
+
+func newSenseLoadpoint(charger api.Charger) (*Loadpoint, chan *Loadpoint, chan util.Param) {
+	lpChan := make(chan *Loadpoint, 1)  // mirrors production cap(1)
+	uiChan := make(chan util.Param, 16) // buffered so publish doesn't block
+
+	lp := &Loadpoint{
+		log:         util.NewLogger("foo"),
+		charger:     charger,
+		chargeMeter: &Null{}, // silence nil panics, returns zero power
+		lpChan:      lpChan,
+		uiChan:      uiChan,
+	}
+
+	return lp, lpChan, uiChan
+}
+
+// TestSenseTriggersOnStatusChange verifies that a sensed charger status which
+// differs from the authoritative status requests an immediate control pass and
+// publishes the derived connection state.
+func TestSenseTriggersOnStatusChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp, lpChan, uiChan := newSenseLoadpoint(charger)
+	lp.status = api.StatusA // authoritative: disconnected
+
+	charger.EXPECT().Status().Return(api.StatusB, nil) // sensed: connected, not charging
+
+	lp.Sense()
+
+	select {
+	case got := <-lpChan:
+		if got != lp {
+			t.Fatalf("unexpected loadpoint on update channel")
+		}
+	default:
+		t.Fatal("expected update request on status change")
+	}
+
+	published := drainParams(uiChan)
+	if v, ok := published[keys.Connected]; !ok || v != true {
+		t.Errorf("Connected: got %v (present=%v), want true", v, ok)
+	}
+	if v, ok := published[keys.Charging]; !ok || v != false {
+		t.Errorf("Charging: got %v (present=%v), want false", v, ok)
+	}
+}
+
+// TestSenseNoTriggerWithoutStatusChange verifies that an unchanged status does
+// not request a redundant control pass.
+func TestSenseNoTriggerWithoutStatusChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp, lpChan, _ := newSenseLoadpoint(charger)
+	lp.status = api.StatusC // authoritative: charging
+
+	charger.EXPECT().Status().Return(api.StatusC, nil) // sensed: unchanged
+
+	lp.Sense()
+
+	select {
+	case <-lpChan:
+		t.Fatal("unexpected update request without status change")
+	default:
+	}
+}
+
+// TestSenseRetriggersUntilControlCatchesUp verifies the self-healing behavior:
+// while the authoritative status lags, every sense tick re-requests an update,
+// covering a dropped cap(1) trigger.
+func TestSenseRetriggersUntilControlCatchesUp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp, lpChan, _ := newSenseLoadpoint(charger)
+	lp.status = api.StatusA
+
+	charger.EXPECT().Status().Return(api.StatusB, nil).Times(2)
+
+	// first sense triggers and fills the cap(1) channel
+	lp.Sense()
+	select {
+	case <-lpChan:
+	default:
+		t.Fatal("expected first update request")
+	}
+
+	// authoritative status still lags -> second sense triggers again
+	lp.Sense()
+	select {
+	case <-lpChan:
+	default:
+		t.Fatal("expected re-trigger while status still differs")
+	}
+}

--- a/core/loadpoint_sense_test.go
+++ b/core/loadpoint_sense_test.go
@@ -10,20 +10,12 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// TestSenseInterval verifies the sense cadence derived from the control interval.
+// TestSenseInterval verifies the default sense cadence is a fixed 2s,
+// independent of the control interval.
 func TestSenseInterval(t *testing.T) {
-	tc := []struct {
-		in, want time.Duration
-	}{
-		{30 * time.Second, 3 * time.Second},
-		{10 * time.Second, 1 * time.Second},
-		{5 * time.Second, 1 * time.Second}, // clamped to 1s minimum
-		{0, 1 * time.Second},
-	}
-
-	for _, c := range tc {
-		if got := senseInterval(c.in); got != c.want {
-			t.Errorf("senseInterval(%v) = %v, want %v", c.in, got, c.want)
+	for _, in := range []time.Duration{30 * time.Second, 10 * time.Second, 0} {
+		if got := senseInterval(in); got != 2*time.Second {
+			t.Errorf("senseInterval(%v) = %v, want 2s", in, got)
 		}
 	}
 }
@@ -109,8 +101,8 @@ func TestSenseNoTriggerWithoutStatusChange(t *testing.T) {
 }
 
 // TestSenseRetriggersUntilControlCatchesUp verifies the self-healing behavior:
-// while the authoritative status lags, every sense tick re-requests an update,
-// covering a dropped cap(1) trigger.
+// while the authoritative status lags, a trigger stays pending even when an
+// individual re-trigger is dropped on the full cap(1) channel.
 func TestSenseRetriggersUntilControlCatchesUp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	charger := api.NewMockCharger(ctrl)
@@ -120,19 +112,22 @@ func TestSenseRetriggersUntilControlCatchesUp(t *testing.T) {
 
 	charger.EXPECT().Status().Return(api.StatusB, nil).Times(2)
 
-	// first sense triggers and fills the cap(1) channel
+	// first sense fills the cap(1) trigger channel
 	lp.Sense()
-	select {
-	case <-lpChan:
-	default:
-		t.Fatal("expected first update request")
-	}
+	// the authoritative status still lags, so the second sense re-requests an
+	// update; its send is dropped on the full channel, but a trigger remains
+	// pending so control is not starved
+	lp.Sense()
 
-	// authoritative status still lags -> second sense triggers again
-	lp.Sense()
+	if got := len(lpChan); got != 1 {
+		t.Fatalf("expected exactly one pending trigger after a dropped re-trigger, got %d", got)
+	}
 	select {
-	case <-lpChan:
+	case got := <-lpChan:
+		if got != lp {
+			t.Fatal("unexpected loadpoint on update channel")
+		}
 	default:
-		t.Fatal("expected re-trigger while status still differs")
+		t.Fatal("expected a pending update request")
 	}
 }

--- a/core/scheduler_test.go
+++ b/core/scheduler_test.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+)
+
+// TestLoopLoadpointsPrefersPending verifies the scheduler hands out a pending
+// loadpoint before advancing the round-robin cursor.
+func TestLoopLoadpointsPrefersPending(t *testing.T) {
+	lp0 := &Loadpoint{log: util.NewLogger("lp0")}
+	lp1 := &Loadpoint{log: util.NewLogger("lp1")}
+
+	site := &Site{
+		log:        util.NewLogger("site"),
+		loadpoints: []*Loadpoint{lp0, lp1},
+	}
+
+	lp1.pendingControl.Store(true)
+
+	next := make(chan updater)
+	go site.loopLoadpoints(next)
+
+	if got := <-next; got != lp1 {
+		t.Fatalf("first dispatch: want pending lp1, got %v", got)
+	}
+	if lp1.pendingControl.Load() {
+		t.Fatal("pending flag must be cleared on dispatch")
+	}
+	if got := <-next; got != lp0 {
+		t.Fatalf("second dispatch: want round-robin lp0, got %v", got)
+	}
+}
+
+// TestLoopLoadpointsNoStarvation verifies a perpetually-pending loadpoint cannot
+// starve the round-robin sweep that keeps idle loadpoints regulated.
+func TestLoopLoadpointsNoStarvation(t *testing.T) {
+	lp0 := &Loadpoint{log: util.NewLogger("lp0")}
+	lp1 := &Loadpoint{log: util.NewLogger("lp1")}
+
+	site := &Site{
+		log:        util.NewLogger("site"),
+		loadpoints: []*Loadpoint{lp0, lp1},
+	}
+
+	lp0.pendingControl.Store(true)
+
+	next := make(chan updater)
+	go site.loopLoadpoints(next)
+
+	var seenLp1 bool
+	for i := 0; i < 6; i++ {
+		got := <-next
+		if got == lp1 {
+			seenLp1 = true
+		}
+		lp0.pendingControl.Store(true) // simulate a perpetual pending source
+	}
+
+	if !seenLp1 {
+		t.Fatal("round-robin starved: lp1 never dispatched while lp0 stayed pending")
+	}
+}

--- a/core/site.go
+++ b/core/site.go
@@ -1106,6 +1106,39 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 	}
 }
 
+// senseIntervalDivisor derives the fast sense cadence from the control interval.
+// Phase 1 has no dedicated config key; a fraction of the control interval keeps
+// sensing responsive while bounding charger/meter load.
+const senseIntervalDivisor = 10
+
+// senseInterval returns the fast sensing cadence derived from the control interval.
+func senseInterval(interval time.Duration) time.Duration {
+	if d := interval / senseIntervalDivisor; d >= time.Second {
+		return d
+	}
+	return time.Second
+}
+
+// senseLoop continuously polls all loadpoints in parallel for status and live
+// measurements, publishing them for snappy UI updates and triggering an
+// immediate control pass when a charger status change is detected. It runs
+// independently of the control loop so observability latency no longer scales
+// with the number of loadpoints.
+func (site *Site) senseLoop(stopC chan struct{}, interval time.Duration) {
+	for tick := time.Tick(interval); ; {
+		select {
+		case <-tick:
+			var wg sync.WaitGroup
+			for _, lp := range site.loadpoints {
+				wg.Go(lp.Sense)
+			}
+			wg.Wait()
+		case <-stopC:
+			return
+		}
+	}
+}
+
 // loopLoadpoints keeps iterating across loadpoints sending the next to the given channel
 func (site *Site) loopLoadpoints(next chan<- updater) {
 	var logOnce sync.Once
@@ -1134,6 +1167,11 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 	loadpointChan := make(chan updater)
 	if site.IsConfigured() {
 		go site.loopLoadpoints(loadpointChan)
+	}
+
+	// fast sense loop: decouple status/measurement latency from loadpoint count
+	if len(site.loadpoints) > 0 {
+		go site.senseLoop(stopC, senseInterval(interval))
 	}
 
 	site.update(<-loadpointChan) // start immediately

--- a/core/site.go
+++ b/core/site.go
@@ -46,7 +46,7 @@ const standbyPower = 10 // consider less than 10W as charger in standby
 // updater abstracts the Loadpoint implementation for testing
 type updater interface {
 	loadpoint.API
-	Update(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effectivePrice, effectiveCo2 *float64)
+	control(sitePower, batteryBoostPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effectivePrice, effectiveCo2 *float64)
 }
 
 var _ site.API = (*Site)(nil)
@@ -983,7 +983,9 @@ func (site *Site) update(lp updater) {
 
 		// TODO
 		if lp != nil {
-			lp.Update(
+			// control only: the sense loop runs observe() continuously to keep
+			// the loadpoint's sensed state fresh
+			lp.control(
 				sitePower, max(0, site.battery.Power), consumption, feedin, batteryBuffered, batteryStart,
 				greenShareLoadpoints, site.effectivePrice(greenShareLoadpoints), site.effectiveCo2(greenShareLoadpoints),
 			)

--- a/core/site.go
+++ b/core/site.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/cmd/shutdown"
@@ -1133,9 +1134,14 @@ func (site *Site) senseLoop(stopC chan struct{}, interval time.Duration) {
 	}
 }
 
-// loopLoadpoints keeps iterating across loadpoints sending the next to the given channel
+// loopLoadpoints feeds the next loadpoint to control to the given channel. It
+// prefers loadpoints with pending control work (events, deferred actuations) so
+// they are served promptly, but alternates with a round-robin sweep so neither
+// a pending loadpoint nor an idle one can starve the other.
 func (site *Site) loopLoadpoints(next chan<- updater) {
 	var logOnce sync.Once
+	var cursor int
+	var servedPending bool // alternate so pending work can't starve the round-robin
 
 	for {
 		if len(site.loadpoints) == 0 {
@@ -1143,11 +1149,32 @@ func (site *Site) loopLoadpoints(next chan<- updater) {
 				site.log.INFO.Println("no loadpoints configured, running in meter-only mode")
 			})
 			next <- nil
-		} else {
-			for _, lp := range site.loadpoints {
-				next <- lp
+			continue
+		}
+
+		// prefer a loadpoint with pending control work, but only every other
+		// dispatch so a perpetually-pending loadpoint cannot starve the
+		// round-robin sweep that keeps idle loadpoints regulated
+		var lp *Loadpoint
+		if !servedPending {
+			for _, cand := range site.loadpoints {
+				if cand.pendingControl.Load() {
+					lp = cand
+					break
+				}
 			}
 		}
+
+		if lp != nil {
+			servedPending = true
+		} else {
+			lp = site.loadpoints[cursor]
+			cursor = (cursor + 1) % len(site.loadpoints)
+			servedPending = false
+		}
+
+		lp.pendingControl.Store(false)
+		next <- lp
 	}
 }
 
@@ -1163,6 +1190,13 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 		go site.loopLoadpoints(loadpointChan)
 	}
 
+	// settle lock: minimum spacing between budget-increasing actuations site-wide,
+	// derived from the control interval (no dedicated config key)
+	gate := newActuationGate(clock.New(), interval)
+	for _, lp := range site.loadpoints {
+		lp.setActuationGate(gate)
+	}
+
 	// fast sense loop: decouple status/measurement latency from loadpoint count
 	if len(site.loadpoints) > 0 {
 		go site.senseLoop(stopC, senseInterval(interval))
@@ -1175,6 +1209,7 @@ func (site *Site) Run(stopC chan struct{}, interval time.Duration) {
 		case <-tick:
 			site.update(<-loadpointChan)
 		case lp := <-site.lpUpdateChan:
+			lp.pendingControl.Store(false)
 			site.update(lp)
 		case <-stopC:
 			return

--- a/core/site.go
+++ b/core/site.go
@@ -1106,17 +1106,11 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 	}
 }
 
-// senseIntervalDivisor derives the fast sense cadence from the control interval.
-// Phase 1 has no dedicated config key; a fraction of the control interval keeps
-// sensing responsive while bounding charger/meter load.
-const senseIntervalDivisor = 10
-
-// senseInterval returns the fast sensing cadence derived from the control interval.
-func senseInterval(interval time.Duration) time.Duration {
-	if d := interval / senseIntervalDivisor; d >= time.Second {
-		return d
-	}
-	return time.Second
+// senseInterval is the default fast sensing cadence. It is independent of the
+// control interval; loadpoints without a charger-specific preference
+// (api.IntervalGetter) sense at this fixed rate.
+func senseInterval(time.Duration) time.Duration {
+	return 2 * time.Second
 }
 
 // senseLoop continuously polls all loadpoints in parallel for status and live


### PR DESCRIPTION
Part of the loadpoint sense/control epic #30366.

**Phase 2 — event-driven actuation + sense/control split.**

- **Settle-lock + fair scheduler:** space budget-increasing actuations site-wide (enable/raise gated, reductions immediate; phase switches both directions) and add a pending-aware fair loadpoint scheduler so neither pending work nor the round-robin sweep starves.
- **observe/control split:** move reads to `observe()` (fast sense path) and actuation to `control()` on cached state, serialized per loadpoint by `controlMu`. `welcomeCharge` is latched and control is gated on the first `observe()` so startup never actuates on uninitialized state.

Stacked on #30367 (phase 1).
