### PR TITLE
Go-e: fix concurrency-safe status cache

### DIFF
--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -84,14 +84,14 @@ func (c *LocalAPI) response(partial string, res any) error {
 // status fetches a fresh v1/v2 api response
 func (c *LocalAPI) status() (Response, error) {
 	if c.v2 {
-		res := new(StatusResponse2)
+		var res StatusResponse2
 		err := c.response("status?filter=alw,car,eto,nrg,wh,trx,cards", &res)
-		return res, err
+		return &res, err
 	}
 
-	res := new(StatusResponse)
+	var res StatusResponse
 	err := c.response("status", &res)
-	return res, err
+	return &res, err
 }
 
 // Status reads a cached v1/v2 api response

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/evcc-io/evcc/util"
@@ -34,6 +35,7 @@ type API interface {
 
 type LocalAPI struct {
 	*request.Helper
+	mu      sync.Mutex // guards the cached status/updated against concurrent accessors
 	uri     string
 	v2      bool
 	status  Response
@@ -85,6 +87,9 @@ func (c *LocalAPI) response(partial string, res any) error {
 
 // Status reads a v1/v2 api response
 func (c *LocalAPI) Status() (res Response, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if time.Since(c.updated) > c.cache {
 		if c.v2 {
 			c.status = new(StatusResponse2)
@@ -102,7 +107,10 @@ func (c *LocalAPI) Status() (res Response, err error) {
 
 // Update executes a v1/v2 api update and returns the response
 func (c *LocalAPI) Update(payload string) error {
-	c.updated = time.Time{}
+	c.mu.Lock()
+	c.updated = time.Time{} // invalidate cache so the next Status refetches
+	c.mu.Unlock()
+
 	res := new(UpdateResponse)
 
 	if c.v2 {
@@ -116,6 +124,7 @@ func (c *LocalAPI) Update(payload string) error {
 
 type cloud struct {
 	*request.Helper
+	mu      sync.Mutex // guards the cached status/updated against concurrent accessors
 	token   string
 	cache   time.Duration
 	updated time.Time
@@ -153,6 +162,9 @@ func (c *cloud) response(function, payload string) (*StatusResponse, error) {
 }
 
 func (c *cloud) Status() (status Response, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if time.Since(c.updated) >= c.cache {
 		status, err = c.response("api_status", "")
 		if err == nil {
@@ -165,7 +177,10 @@ func (c *cloud) Status() (status Response, err error) {
 }
 
 func (c *cloud) Update(payload string) error {
-	c.updated = time.Time{}
+	c.mu.Lock()
+	c.updated = time.Time{} // invalidate cache so the next Status refetches
+	c.mu.Unlock()
+
 	_, err := c.response("api", payload)
 	return err
 }

--- a/charger/go-e/api.go
+++ b/charger/go-e/api.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/evcc-io/evcc/util"
@@ -35,12 +34,9 @@ type API interface {
 
 type LocalAPI struct {
 	*request.Helper
-	mu      sync.Mutex // guards the cached status/updated against concurrent accessors
 	uri     string
 	v2      bool
-	status  Response
-	updated time.Time
-	cache   time.Duration
+	statusG util.Cacheable[Response]
 }
 
 var _ API = (*LocalAPI)(nil)
@@ -52,10 +48,10 @@ func NewLocal(log *util.Logger, uri string, cache time.Duration) *LocalAPI {
 	api := &LocalAPI{
 		Helper: request.NewHelper(log),
 		uri:    uri,
-		cache:  cache,
 	}
 
 	api.upgradeV2()
+	api.statusG = util.ResettableCached(api.status, cache)
 
 	return api
 }
@@ -85,60 +81,53 @@ func (c *LocalAPI) response(partial string, res any) error {
 	return c.GetJSON(url, &res)
 }
 
-// Status reads a v1/v2 api response
-func (c *LocalAPI) Status() (res Response, err error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if time.Since(c.updated) > c.cache {
-		if c.v2 {
-			c.status = new(StatusResponse2)
-			err = c.response("status?filter=alw,car,eto,nrg,wh,trx,cards", &c.status)
-		} else {
-			c.status = new(StatusResponse)
-			err = c.response("status", &c.status)
-		}
-		if err == nil {
-			c.updated = time.Now()
-		}
+// status fetches a fresh v1/v2 api response
+func (c *LocalAPI) status() (Response, error) {
+	if c.v2 {
+		res := new(StatusResponse2)
+		err := c.response("status?filter=alw,car,eto,nrg,wh,trx,cards", &res)
+		return res, err
 	}
-	return c.status, err
+
+	res := new(StatusResponse)
+	err := c.response("status", &res)
+	return res, err
+}
+
+// Status reads a cached v1/v2 api response
+func (c *LocalAPI) Status() (Response, error) {
+	return c.statusG.Get()
 }
 
 // Update executes a v1/v2 api update and returns the response
 func (c *LocalAPI) Update(payload string) error {
-	c.mu.Lock()
-	c.updated = time.Time{} // invalidate cache so the next Status refetches
-	c.mu.Unlock()
+	c.statusG.Reset() // invalidate cache so the next Status refetches
 
 	res := new(UpdateResponse)
 
 	if c.v2 {
-		err := c.response(fmt.Sprintf("set?%s", payload), &res)
-		return err
+		return c.response(fmt.Sprintf("set?%s", payload), &res)
 	}
 
-	err := c.response(fmt.Sprintf("mqtt?payload=%s", payload), &res)
-	return err
+	return c.response(fmt.Sprintf("mqtt?payload=%s", payload), &res)
 }
 
 type cloud struct {
 	*request.Helper
-	mu      sync.Mutex // guards the cached status/updated against concurrent accessors
 	token   string
-	cache   time.Duration
-	updated time.Time
-	status  Response
+	statusG util.Cacheable[Response]
 }
 
 var _ API = (*cloud)(nil)
 
 func NewCloud(log *util.Logger, token string, cache time.Duration) API {
-	return &cloud{
+	c := &cloud{
 		Helper: request.NewHelper(log),
 		token:  token,
-		cache:  cache,
 	}
+	c.statusG = util.ResettableCached(c.status, cache)
+
+	return c
 }
 
 func (c *cloud) IsV2() bool {
@@ -161,25 +150,18 @@ func (c *cloud) response(function, payload string) (*StatusResponse, error) {
 	return &status.Data, err
 }
 
-func (c *cloud) Status() (status Response, err error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// status fetches a fresh cloud api response
+func (c *cloud) status() (Response, error) {
+	return c.response("api_status", "")
+}
 
-	if time.Since(c.updated) >= c.cache {
-		status, err = c.response("api_status", "")
-		if err == nil {
-			c.updated = time.Now()
-			c.status = status
-		}
-	}
-
-	return c.status, err
+// Status reads a cached cloud api response
+func (c *cloud) Status() (Response, error) {
+	return c.statusG.Get()
 }
 
 func (c *cloud) Update(payload string) error {
-	c.mu.Lock()
-	c.updated = time.Time{} // invalidate cache so the next Status refetches
-	c.mu.Unlock()
+	c.statusG.Reset() // invalidate cache so the next Status refetches
 
 	_, err := c.response("api", payload)
 	return err

--- a/charger/go-e/api_test.go
+++ b/charger/go-e/api_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/evcc-io/evcc/util"
@@ -48,6 +49,31 @@ func TestLocalV1(t *testing.T) {
 	if err := local.Update("foo=bar"); err != nil {
 		t.Error(err)
 	}
+}
+
+// TestLocalConcurrentStatus exercises the status cache from many goroutines at
+// once (as the fast sense loop and the control loop do). With cache=0 every call
+// refreshes, so without the mutex the shared status/updated fields race; run with
+// -race to verify the cache is concurrency-safe.
+func TestLocalConcurrentStatus(t *testing.T) {
+	h := &handler{}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	local := NewLocal(util.NewLogger("foo"), srv.URL, 0) // upgradeV2 fails -> v1
+	h.expect("/status")
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := local.Status(); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestLocalV2(t *testing.T) {

--- a/charger/go-e/api_test.go
+++ b/charger/go-e/api_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 
 	"github.com/evcc-io/evcc/util"
@@ -49,31 +48,6 @@ func TestLocalV1(t *testing.T) {
 	if err := local.Update("foo=bar"); err != nil {
 		t.Error(err)
 	}
-}
-
-// TestLocalConcurrentStatus exercises the status cache from many goroutines at
-// once (as the fast sense loop and the control loop do). With cache=0 every call
-// refreshes, so without the mutex the shared status/updated fields race; run with
-// -race to verify the cache is concurrency-safe.
-func TestLocalConcurrentStatus(t *testing.T) {
-	h := &handler{}
-	srv := httptest.NewServer(h)
-	defer srv.Close()
-
-	local := NewLocal(util.NewLogger("foo"), srv.URL, 0) // upgradeV2 fails -> v1
-	h.expect("/status")
-
-	var wg sync.WaitGroup
-	for range 50 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if _, err := local.Status(); err != nil {
-				t.Error(err)
-			}
-		}()
-	}
-	wg.Wait()
 }
 
 func TestLocalV2(t *testing.T) {


### PR DESCRIPTION
go-e is the only charger with a hand-rolled status cache; every other one uses the thread-safe `util.Cacheable` helper. This brings go-e in line by replacing the bespoke cache (and its unsynchronized `status`/`updated` fields) with `util.ResettableCached`.

The unsynchronized cache is latent on `master` (chargers are read sequentially) but becomes a data race once loadpoint sensing runs concurrently with control (#30366) — sensing and control then hit `Status()` on the same instance from different goroutines.