### PR TITLE
Forecast: re-enable solar adjustment

### DIFF
--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -153,7 +153,7 @@ const settings: Settings = reactive({
   savingsIndicator: read(SAVINGS_INDICATOR),
   sessionsGroup: read(SESSIONS_GROUP),
   sessionsType: read(SESSIONS_TYPE),
-  solarAdjusted: false, //readBool(SETTINGS_SOLAR_ADJUSTED), # temporarily disable, https://github.com/evcc-io/evcc/issues/29165
+  solarAdjusted: readBool(SETTINGS_SOLAR_ADJUSTED),
   priceZoom: readBool(SETTINGS_PRICE_ZOOM),
   hideFeedin: readBool(SETTINGS_HIDE_FEEDIN),
   loadpoints: readJSON(LOADPOINTS),

--- a/assets/js/views/Forecast.vue
+++ b/assets/js/views/Forecast.vue
@@ -243,8 +243,7 @@ export default defineComponent({
 			return true;
 		},
 		showSolarAdjust() {
-			// TODO fix https://github.com/evcc-io/evcc/issues/29165
-			return !!this.forecast.solar && this.experimental && false;
+			return !!this.forecast.solar && this.experimental;
 		},
 		solar() {
 			return this.showSolarAdjust && this.solarAdjusted


### PR DESCRIPTION
fixes #29165

Re-enables the experimental "real data adjust" toggle on the solar forecast, which was temporarily disabled in #29244/#29260. The toggle now relies on the metrics-derived scale factor added in #29784, which falls back to a neutral 1.0 ratio until enough same-day production and forecast energy is collected, avoiding the previous -100% adjustment.

- Restore `solarAdjusted` reading its persisted setting instead of being forced off
- Drop the `&& false` guard on `showSolarAdjust`, so the toggle reappears for experimental users when a solar forecast is present