### PR TITLE
Meter (Growatt TL-XH): write battery-first time slot atomically

### DIFF
--- a/templates/definition/meter/growatt-hybrid-tlxh.yaml
+++ b/templates/definition/meter/growatt-hybrid-tlxh.yaml
@@ -124,24 +124,19 @@ render: |
       set:
         source: sequence
         set:
+        # Time-1 "battery first" slot: start (3038) and end (3039) time words must be written
+        # in a single FC16 multi-register transaction. The firmware rejects a standalone write
+        # to the end-time register 3039 with modbus exception 0.
+        # value = (start << 16) | end = (8192 << 16) | 5947 = 0x2000173B; bit15=0 -> slot disabled
         - source: const
-          value: 8192
+          value: 536876859
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
               address: 3038
               type: writemultiple
-              decode: uint16
-        - source: const
-          value: 5947
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 3039
-              type: writemultiple
-              decode: uint16
+              decode: uint32
         - source: const
           value: 0
           set:
@@ -155,24 +150,16 @@ render: |
       set:
         source: sequence
         set:
+        # value = (start << 16) | end = (40960 << 16) | 5947 = 0xA000173B; bit15=1 -> slot enabled
         - source: const
-          value: 40960
+          value: 2684360507
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
               address: 3038
               type: writemultiple
-              decode: uint16
-        - source: const
-          value: 5947
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 3039
-              type: writemultiple
-              decode: uint16
+              decode: uint32
         - source: const
           value: 0
           set:
@@ -186,24 +173,16 @@ render: |
       set:
         source: sequence
         set:
+        # value = (start << 16) | end = (40960 << 16) | 5947 = 0xA000173B; bit15=1 -> slot enabled
         - source: const
-          value: 40960
+          value: 2684360507
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}
             register:
               address: 3038
               type: writemultiple
-              decode: uint16
-        - source: const
-          value: 5947
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 3039
-              type: writemultiple
-              decode: uint16
+              decode: uint32
         - source: const
           value: 1
           set:
@@ -212,6 +191,6 @@ render: |
             register:
               address: 3049
               type: writemultiple
-              decode: uint16 
+              decode: uint16
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
fixes #23300

The battery-mode switch wrote the "battery first" Time-1 slot as two separate single-register FC16 writes (start time 3038, then end time 3039). The TL-XH/MOD-XH firmware ACKs 3038 but rejects the standalone write to 3039 with modbus exception 0, so the `sequence` aborts before reaching 3049 and the requested hold never engages (battery keeps discharging into the car). The per-cycle retry also spams `battery mode: modbus: exception '0', function '16'`.

Per the Growatt protocol, 3038/3039 form one time-period pair and must be set together via write multiple, the same atomicity the existing MIX/SPH `growatt-hybrid` template documents.

- write start+end as a single FC16 transaction: one `uint32` write to 3038 (`0xA000173B` = `(40960 << 16) | 5947`), which evcc encodes big-endian as `[3038]=0xA000, [3039]=0x173B`
- AcChargeEnable (3049) still written separately

## TODO

- [ ] hardware validation: the fix is derived from the trace in the issue and the vendor protocol but not yet confirmed on-device. Waiting for the reporter to verify hold works without the exception.