### PR TITLE
OCPP: wait for listener to bind before returning from Instance

### DIFF
--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -110,13 +110,12 @@ func Instance() *CS {
 		defer ticker.Stop()
 
 		timeout := time.After(10 * time.Second)
-	wait:
 		for server.Addr() == nil {
 			select {
 			case <-ticker.C:
 			case <-timeout:
 				log.ERROR.Println("timeout waiting for server to bind")
-				break wait
+				return
 			}
 		}
 	})

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -106,13 +106,11 @@ func Instance() *CS {
 		// immediately (notably the test suite) then see "connection refused".
 		// server.Addr() is only set once net.Listen succeeds, so it is the correct
 		// readiness signal. Bounded so a failed bind cannot hang startup.
-		ticker := time.NewTicker(10 * time.Millisecond)
-		defer ticker.Stop()
-
+		tick := time.Tick(10 * time.Millisecond)
 		timeout := time.After(10 * time.Second)
 		for server.Addr() == nil {
 			select {
-			case <-ticker.C:
+			case <-tick:
 			case <-timeout:
 				log.ERROR.Println("timeout waiting for server to bind")
 				return

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -100,10 +100,23 @@ func Instance() *CS {
 		go instance.errorHandler(cs.Errors())
 		go cs.Start(port, "/{ws}")
 
-		// wait for server to start
-		for range time.Tick(10 * time.Millisecond) {
-			if dispatcher.IsRunning() {
-				break
+		// Wait for the listener to bind before returning. cs.Start runs
+		// dispatcher.Start() before binding the TCP socket, so dispatcher.IsRunning()
+		// flips while the port is not yet accepting connections. Callers that dial
+		// immediately (notably the test suite) then see "connection refused".
+		// server.Addr() is only set once net.Listen succeeds, so it is the correct
+		// readiness signal. Bounded so a failed bind cannot hang startup.
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+
+		timeout := time.After(10 * time.Second)
+	wait:
+		for server.Addr() == nil {
+			select {
+			case <-ticker.C:
+			case <-timeout:
+				log.ERROR.Println("timeout waiting for server to bind")
+				break wait
 			}
 		}
 	})

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -100,12 +100,7 @@ func Instance() *CS {
 		go instance.errorHandler(cs.Errors())
 		go cs.Start(port, "/{ws}")
 
-		// Wait for the listener to bind before returning. cs.Start runs
-		// dispatcher.Start() before binding the TCP socket, so dispatcher.IsRunning()
-		// flips while the port is not yet accepting connections. Callers that dial
-		// immediately (notably the test suite) then see "connection refused".
-		// server.Addr() is only set once net.Listen succeeds, so it is the correct
-		// readiness signal. Bounded so a failed bind cannot hang startup.
+		// wait for server to start
 		tick := time.Tick(10 * time.Millisecond)
 		timeout := time.After(10 * time.Second)
 		for server.Addr() == nil {


### PR DESCRIPTION
follow-up to #29941, #29873

`TestOcpp` still fails intermittently in CI with `dial tcp [::1]:8887: connect: connection refused` (e.g. on the run for #29483). The readiness gate in `Instance()` waits on `dispatcher.IsRunning()`, but inside `cs.Start` the dispatcher is started one step before the TCP listener binds the port, so the gate opens while nothing is yet accepting connections. Callers that dial immediately then race the bind and lose. Prior flaky-test fixes addressed deadlocks, lifecycle and client timeouts, but not this server-readiness race because the gate looks correct at a glance.

- gate on `server.Addr()` (set only after `net.Listen` succeeds) instead of `dispatcher.IsRunning()`
- bound the wait with a timeout so a failed bind logs and returns rather than hanging startup