### PR TITLE
Meter (Solis Hybrid): drop coarse pv and battery energy registers

### DIFF
--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -97,13 +97,9 @@ render: |
       type: input
       address: 33057 # Total DC output power (PV Power)
       decode: uint32
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 33029 # Total energy generation
-      type: input
-      decode: uint32
+  # energy (33029 Total energy generation) intentionally omitted: the register
+  # has 1 kWh resolution, so the 15min energy history quantizes to 4 kW steps.
+  # History is integrated from power instead (see issue #30407).
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -129,13 +125,9 @@ render: |
         scale: 2
       - source: const
         value: -1
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 33165 # Battery total discharge energy
-      type: input
-      decode: uint32
+  # energy (33165 Battery total discharge energy) intentionally omitted: the
+  # register has 1 kWh resolution, so the 15min energy history quantizes to 4 kW
+  # steps. History is integrated from power instead (see issue #30407).
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/solis-hybrid.yaml
+++ b/templates/definition/meter/solis-hybrid.yaml
@@ -84,13 +84,9 @@ render: |
       type: input
       address: 33057 # Total DC output power (PV Power)
       decode: uint32
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 33029 # Total energy generation
-      type: input
-      decode: uint32
+  # energy (33029 Total energy generation) intentionally omitted: the register
+  # has 1 kWh resolution, so the 15min energy history quantizes to 4 kW steps.
+  # History is integrated from power instead (see issue #30407).
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -102,13 +98,9 @@ render: |
       address: 33149 # Battery power
       decode: int32
     scale: -1
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 33165 # Battery total discharge energy
-      type: input
-      decode: uint32
+  # energy (33165 Battery total discharge energy) intentionally omitted: the
+  # register has 1 kWh resolution, so the 15min energy history quantizes to 4 kW
+  # steps. History is integrated from power instead (see issue #30407).
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
fixes #30407

The history showed PV generation and battery discharge only in 4 kW steps, while the live power view was smooth. The 15min energy history derives each slot from the cumulative meter energy delta (`Collector.AddEnergy`), falling back to integrating power only when a meter exposes no energy reading. The Solis "Total energy generation" (33029) and "Battery total discharge energy" (33165) registers have 1 kWh resolution, so a 1 kWh delta over a 15min slot quantizes to exactly 1 kWh / 0.25 h = 4 kW. Grid energy (33283) is unaffected because it is read with `scale: 0.01` (10 Wh resolution).

- drop the `energy` reading from the `pv` and `battery` sections of `solis-hybrid-s` and `solis-hybrid`, so the history integrates the smooth power values instead
- grid energy is left unchanged (fine resolution)

Note: `solis.yaml` (string inverter) reads PV total energy from register 3008 without scaling and likely has the same 1 kWh resolution, but it is a different product line and no issue was reported against it, so it is left untouched here.