### PR TITLE
HEMS: fix gridcontrol init order

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/evcc-io/evcc/hems"
 	hemsapi "github.com/evcc-io/evcc/hems/hems"
 	"github.com/evcc-io/evcc/hems/shm"
+	"github.com/evcc-io/evcc/hems/smartgrid"
 	"github.com/evcc-io/evcc/messenger"
 	"github.com/evcc-io/evcc/meter"
 	"github.com/evcc-io/evcc/plugin/golang"
@@ -775,15 +776,17 @@ func configureGo(conf []globalconfig.Go) error {
 
 // setup HEMS
 func configureHEMS(conf *globalconfig.Hems, site *core.Site) (hemsapi.API, error) {
-	// use yaml if configured
+	if !hemsConfigured(*conf) {
+		return nil, nil
+	}
+
 	if conf.Type == "" {
-		if settings.Exists(keys.Hems) {
-			*conf = globalconfig.Hems{}
-			if err := settings.Yaml(keys.Hems, new(map[string]any), &conf); err != nil {
-				return nil, err
-			}
-			yamlSource.hems = globalconfig.YamlSourceDb
+		// yaml from db
+		*conf = globalconfig.Hems{}
+		if err := settings.Yaml(keys.Hems, new(map[string]any), &conf); err != nil {
+			return nil, err
 		}
+		yamlSource.hems = globalconfig.YamlSourceDb
 	} else {
 		yamlSource.hems = globalconfig.YamlSourceFile
 	}
@@ -1178,7 +1181,19 @@ func configureDevices(conf globalconfig.All) error {
 		errs = append(errs, &ClassError{ClassCircuit, err})
 	}
 
+	// auto-create the grid control root circuit so loadpoints can reference it
+	if hemsConfigured(conf.HEMS) {
+		if _, err := smartgrid.SetupCircuit(); err != nil {
+			errs = append(errs, &ClassError{ClassCircuit, err})
+		}
+	}
+
 	return joinErrors(errs...)
+}
+
+// hemsConfigured reports whether hems is configured via yaml file or db
+func hemsConfigured(conf globalconfig.Hems) bool {
+	return conf.Type != "" || settings.Exists(keys.Hems)
 }
 
 func configureModbusProxy(conf *[]globalconfig.ModbusProxy) error {

--- a/hems/smartgrid/circuit.go
+++ b/hems/smartgrid/circuit.go
@@ -2,6 +2,7 @@ package smartgrid
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -12,31 +13,44 @@ import (
 
 const GridControl = "gridcontrol"
 
-// SetupCircuit returns or registers the grid control circuit
+var (
+	mu      sync.Mutex
+	managed api.Circuit
+)
+
+// SetupCircuit returns or registers the grid control circuit.
+// Subsequent calls return the previously registered instance (idempotent).
 func SetupCircuit() (api.Circuit, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if managed != nil {
+		return managed, nil
+	}
+
 	if _, err := config.Circuits().ByName(GridControl); err == nil {
 		return nil, errors.New("gridcontrol is a reserved name and will be auto-created as root circuit when hems is configured")
 	}
 
 	root := circuit.Root()
 
-	// create new circuit
-	circuit, err := circuit.New(util.NewLogger(GridControl), "", 0, 0, nil, time.Minute)
+	c, err := circuit.New(util.NewLogger(GridControl), "", 0, 0, nil, time.Minute)
 	if err != nil {
 		return nil, err
 	}
 
-	dev := config.NewStaticDevice[api.Circuit](config.Named{Name: GridControl}, circuit)
+	dev := config.NewStaticDevice[api.Circuit](config.Named{Name: GridControl}, c)
 	if err := config.Circuits().Add(dev); err != nil {
 		return nil, err
 	}
 
 	// wrap old root with new grid control parent
 	if root != nil {
-		if err := root.Wrap(circuit); err != nil {
+		if err := root.Wrap(c); err != nil {
 			return nil, err
 		}
 	}
 
-	return circuit, nil
+	managed = c
+	return c, nil
 }

--- a/tests/hems.spec.ts
+++ b/tests/hems.spec.ts
@@ -7,6 +7,8 @@ import {
   editorPaste,
   enableAppContext,
   expectAppEvent,
+  newLoadpoint,
+  addDemoCharger,
 } from "./utils";
 import { startSimulator, stopSimulator, simulatorUrl, simulatorApply } from "./simulator";
 
@@ -188,5 +190,50 @@ limit:
         "0.0 kW",
       ].join("")
     );
+  });
+
+  test("loadpoint assigned to external limit circuit", async ({ page }) => {
+    const GRID_CONFIG = "hems-grid.evcc.yaml";
+    await start(GRID_CONFIG);
+    await page.goto("/#/config");
+
+    // configure hems relay with a const external limit
+    await page.getByTestId("hems").getByRole("button", { name: "edit" }).click();
+    const hemsModal = page.getByTestId("hems-modal");
+    await expectModalVisible(hemsModal);
+    const hemsEditor = hemsModal.getByTestId("yaml-editor");
+    await editorClear(hemsEditor);
+    await editorPaste(
+      hemsEditor,
+      page,
+      `type: relay
+maxPower: 4200
+interval: 0.1s
+limit:
+  source: const
+  value: true`
+    );
+    await hemsModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(hemsModal);
+
+    // restart so the gridcontrol circuit is auto-created
+    await restart(GRID_CONFIG);
+    await page.goto("/#/config");
+    await expect(page.getByTestId("circuits")).toContainText("External Limit");
+
+    // add loadpoint with demo charger and assign it to the external limit circuit
+    await newLoadpoint(page, "Carport");
+    await addDemoCharger(page);
+    const lpModal = page.getByTestId("loadpoint-modal");
+    await lpModal.getByLabel("Circuit").selectOption("gridcontrol");
+    await lpModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(lpModal);
+    await expect(page.getByTestId("loadpoint")).toContainText("Carport");
+
+    // restart and verify evcc does not crash with "circuit: not found: gridcontrol"
+    await restart(GRID_CONFIG);
+    await page.reload();
+    await expect(page.getByTestId("loadpoint")).toBeVisible();
+    await expect(page.getByTestId("fatal-error")).not.toBeVisible();
   });
 });


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/30380

reuses parts of https://github.com/evcc-io/evcc/pull/25832 (gridcontrol singleton)

A loadpoint assigned to the External Limit circuit crashed with circuit: `not found: gridcontrol` on restart, because the circuit was created after loadpoint setup.

- pre-create the gridcontrol circuit during device setup when HEMS is configured
- make SetupCircuit idempotent
- dedupe HEMS detection into a single hemsConfigured predicate
- add Playwright coverage for assigning a loadpoint to the external limit circuit