### PR TITLE
cli/token: tolerate missing token credentials when generating them

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/spf13/cobra"
@@ -32,21 +36,18 @@ func runToken(cmd *cobra.Command, args []string) {
 		log.FATAL.Fatal(err)
 	}
 
-	if err := configureVehicles(conf.Vehicles, args...); err != nil {
+	vehicles, err := tokenVehicles(args...)
+	if err != nil {
 		log.FATAL.Fatal(err)
 	}
 
-	vehicles := config.Vehicles().Devices()
-
-	for _, dev := range vehicles {
-		vehicleConf := dev.Config()
-
+	for _, vehicleConf := range vehicles {
 		var token *oauth2.Token
 		var err error
 
 		isTemplate := strings.ToLower(vehicleConf.Type) == "template"
 		if isTemplate {
-			instance, err := templates.RenderInstance(templates.Vehicle, vehicleConf.Other)
+			instance, err := renderTokenInstance(vehicleConf.Other)
 			if err != nil {
 				log.FATAL.Fatalf("rendering template failed: %v", err)
 			}
@@ -88,4 +89,79 @@ func runToken(cmd *cobra.Command, args []string) {
 			fmt.Println("      refresh:", token.RefreshToken)
 		}
 	}
+}
+
+// tokenVehicles returns the configured vehicles (static config and database),
+// optionally filtered by name. Unlike configureVehicles it does not instantiate
+// the vehicles: the whole point of this command is to generate the very
+// credentials whose absence would make instantiation fail.
+func tokenVehicles(names ...string) ([]config.Named, error) {
+	var res []config.Named
+
+	for _, cc := range conf.Vehicles {
+		if len(names) == 0 || slices.Contains(names, cc.Name) {
+			res = append(res, cc)
+		}
+	}
+
+	configurable, err := config.ConfigurationsByClass(templates.Vehicle)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dev := range configurable {
+		if cc := dev.Named(); len(names) == 0 || slices.Contains(names, cc.Name) {
+			res = append(res, cc)
+		}
+	}
+
+	if len(res) == 0 {
+		if len(names) > 0 {
+			return nil, fmt.Errorf("vehicle not found: %s", strings.Join(names, ", "))
+		}
+		return nil, errors.New("no vehicles configured")
+	}
+
+	return res, nil
+}
+
+// renderTokenInstance renders a vehicle template instance, tolerating the missing
+// required credentials (the access/refresh tokens this command generates). When
+// the regular render fails validation, empty required params are stubbed so the
+// instance type can still be resolved. The stubbed params are exactly the empty
+// credentials, which the token generators do not read.
+func renderTokenInstance(other map[string]any) (*templates.Instance, error) {
+	instance, err := templates.RenderInstance(templates.Vehicle, other)
+	if err == nil {
+		return instance, nil
+	}
+
+	// only tolerate config (validation) errors, e.g. a missing required token
+	if _, ok := errors.AsType[*util.ConfigError](err); !ok {
+		return nil, err
+	}
+
+	var cc struct {
+		Template string
+		Other    map[string]any `mapstructure:",remain"`
+	}
+	if derr := util.DecodeOther(other, &cc); derr != nil {
+		return nil, err
+	}
+
+	tmpl, terr := templates.ByName(templates.Vehicle, cc.Template)
+	if terr != nil {
+		return nil, err
+	}
+
+	stub := maps.Clone(other)
+	for i := range tmpl.Params {
+		if p := &tmpl.Params[i]; p.IsRequired() {
+			if v, ok := stub[p.Name]; !ok || v == nil || v == "" {
+				stub[p.Name] = "unset"
+			}
+		}
+	}
+
+	return templates.RenderInstance(templates.Vehicle, stub)
 }


### PR DESCRIPTION
fixes #29864

`evcc token <name>` aborts with `cannot create vehicle type 'template': missing required accessToken` before it can generate anything. `cmd/token.go` calls `configureVehicles`, which fully instantiates and validates each vehicle in `RenderModeInstance`; the Peugeot/PSA templates mark `accessToken`/`refreshToken` as `required: true`, so validation rejects the empty tokens. This is a chicken-and-egg: the command exists to produce those tokens, but config validation refuses to run without them. Regression from #24716, which switched the command to `configureVehicles`. (Not reproducible in `go test` because required-field validation is skipped under `testing.Testing()`.)

Per the direction in the previous attempt (#30133): rather than resolving things through YAML, analyse the error and continue when it is the expected missing-credentials case.

- `tokenVehicles` gathers the vehicle configs (static + database) directly, without instantiating them, so the command works even while the credentials are missing
- `renderTokenInstance` resolves the template type via the normal `RenderInstance`; only when that returns a `ConfigError` does it retry with empty required params stubbed, so the instance type resolves. The stubbed params are exactly the empty credentials, which the token generators (PSA/ford/tronity) do not read — they perform a fresh OAuth flow

Verified against the real binary: on master `evcc token car` fatals with `missing required `+"`accessToken`"+`; with this change it proceeds into the PSA OAuth flow (country-code prompt) as expected.