### PR TITLE
Easee: kickstart charges when at minA

### DIFF
--- a/charger/easee.go
+++ b/charger/easee.go
@@ -554,6 +554,28 @@ func (c *Easee) Enable(enable bool) (err error) {
 	}
 
 	if enable {
+		if c.current > 0 && c.current < 7 {
+			override := 7.0
+			chargerData := easee.ChargerSettings{
+				DynamicChargerCurrent: &override,
+			}
+			chargerURI := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
+			noop, sendErr := c.dispatcher.Send(chargerURI, chargerData)
+			if sendErr != nil {
+				c.log.WARN.Printf("enable: failed to set charger current override: %v", sendErr)
+			} else if !noop {
+				if waitErr := c.waitForDynamicChargerCurrent(override); waitErr != nil {
+					c.log.WARN.Printf("enable: charger current override confirmation timeout: %v", waitErr)
+				}
+			}
+
+			c.mux.Lock()
+			c.current = override
+			c.mux.Unlock()
+
+			return nil
+		}
+
 		// reset currents after enable, as easee automatically resets to maxA
 		return c.MaxCurrent(int64(c.current))
 	}

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -771,9 +771,10 @@ func (c *Easee) Phases1p3p(phases int) error {
 			c.dispatcher.CancelOrphan(easee.CIRCUIT_MAX_CURRENT_P1)
 		}
 
-		// Sending DCC:7 to skip charge pause after scaling down to 1p.
+		// Newer firmware delays ~5 min when charging starts at 6A.
+		// Send DCC:7 after any phase switch so the charger starts immediately.
 		// The loadpoint's next control interval will send the real target current.
-		if err == nil && phases == 1 {
+		if err == nil {
 			override := 7.0
 			chargerData := easee.ChargerSettings{
 				DynamicChargerCurrent: &override,

--- a/charger/easee.go
+++ b/charger/easee.go
@@ -46,6 +46,10 @@ import (
 // time a user would expect stale data to linger.
 const observationTimeout = 20 * time.Minute
 
+// kickstartCurrent is the DCC value (7 A) sent to work around a firmware issue
+// where the Easee charger delays ~5 min when starting at 6 A or below.
+const kickstartCurrent = 7.0
+
 // Easee charger implementation
 type Easee struct {
 	*request.Helper
@@ -554,33 +558,47 @@ func (c *Easee) Enable(enable bool) (err error) {
 	}
 
 	if enable {
-		if c.current > 0 && c.current < 7 {
-			override := 7.0
-			chargerData := easee.ChargerSettings{
-				DynamicChargerCurrent: &override,
-			}
-			chargerURI := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
-			noop, sendErr := c.dispatcher.Send(chargerURI, chargerData)
-			if sendErr != nil {
-				c.log.WARN.Printf("enable: failed to set charger current override: %v", sendErr)
-			} else if !noop {
-				if waitErr := c.waitForDynamicChargerCurrent(override); waitErr != nil {
-					c.log.WARN.Printf("enable: charger current override confirmation timeout: %v", waitErr)
-				}
-			}
+		c.mux.RLock()
+		cur := c.current
+		c.mux.RUnlock()
 
-			c.mux.Lock()
-			c.current = override
-			c.mux.Unlock()
-
-			return nil
+		if cur > 0 && cur < kickstartCurrent {
+			if c.sendDCCKickstart("enable") {
+				return nil
+			}
 		}
 
 		// reset currents after enable, as easee automatically resets to maxA
-		return c.MaxCurrent(int64(c.current))
+		return c.MaxCurrent(int64(cur))
 	}
 
 	return nil
+}
+
+// sendDCCKickstart sets DynamicChargerCurrent to kickstartCurrent (7 A) to
+// bypass the slow-start firmware delay. On success it updates c.current and
+// returns true. On send failure it logs a warning and returns false without
+// modifying c.current.
+func (c *Easee) sendDCCKickstart(ctx string) bool {
+	override := kickstartCurrent
+	chargerData := easee.ChargerSettings{
+		DynamicChargerCurrent: &override,
+	}
+	chargerURI := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
+	noop, err := c.dispatcher.Send(chargerURI, chargerData)
+	if err != nil {
+		c.log.WARN.Printf("%s: failed to set charger current override: %v", ctx, err)
+		return false
+	}
+	if !noop {
+		if waitErr := c.waitForDynamicChargerCurrent(override); waitErr != nil {
+			c.log.WARN.Printf("%s: charger current override confirmation timeout: %v", ctx, waitErr)
+		}
+	}
+	c.mux.Lock()
+	c.current = override
+	c.mux.Unlock()
+	return true
 }
 
 func (c *Easee) inExpectedOpMode(enable bool) bool {
@@ -797,23 +815,7 @@ func (c *Easee) Phases1p3p(phases int) error {
 		// Send DCC:7 after any phase switch so the charger starts immediately.
 		// The loadpoint's next control interval will send the real target current.
 		if err == nil {
-			override := 7.0
-			chargerData := easee.ChargerSettings{
-				DynamicChargerCurrent: &override,
-			}
-			chargerURI := fmt.Sprintf("%s/chargers/%s/settings", easee.API, c.charger)
-			noop, sendErr := c.dispatcher.Send(chargerURI, chargerData)
-			if sendErr != nil {
-				c.log.WARN.Printf("phase switch: failed to set charger current override: %v", sendErr)
-			} else if !noop {
-				if waitErr := c.waitForDynamicChargerCurrent(override); waitErr != nil {
-					c.log.WARN.Printf("phase switch: charger current override confirmation timeout: %v", waitErr)
-				}
-			}
-
-			c.mux.Lock()
-			c.current = override
-			c.mux.Unlock()
+			c.sendDCCKickstart("phase switch")
 		}
 	} else {
 		// charger level

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -559,6 +559,93 @@ func TestEasee_Phases1p3p_scaleUp_sendsDCC7(t *testing.T) {
 	assert.Equal(t, 7.0, e.current, "c.current should be set to 7 after scale-up")
 }
 
+func TestEasee_Enable_kickstart_lowCurrent(t *testing.T) {
+	const chargerID = "TESTTEST"
+
+	e := newEasee()
+	e.charger = chargerID
+	e.current = 6
+	e.opMode = easee.ModeAwaitingStart
+	e.chargerEnabled = true
+
+	httpmock.ActivateNonDefault(e.Client)
+	defer httpmock.DeactivateAndReset()
+
+	// Mock ChargeResume command — 202 with empty object (noop)
+	resumeURI := fmt.Sprintf("%s/chargers/%s/commands/%s", easee.API, chargerID, easee.ChargeResume)
+	httpmock.RegisterResponder(http.MethodPost, resumeURI,
+		httpmock.NewStringResponder(202, "{}"))
+
+	// Simulate charger reaching enabled state + DCC=32 via background goroutine
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		e.mux.Lock()
+		e.opMode = easee.ModeCharging
+		e.mux.Unlock()
+		e.obsC <- easee.Observation{ID: easee.CHARGER_OP_MODE, Value: "3", DataType: easee.Integer}
+		time.Sleep(10 * time.Millisecond)
+		e.mux.Lock()
+		e.dynamicChargerCurrent = 32
+		e.mux.Unlock()
+		e.obsC <- easee.Observation{ID: easee.DYNAMIC_CHARGER_CURRENT, Value: "32", DataType: easee.Double}
+	}()
+
+	// Mock POST charger settings (DCC:7 kickstart) — return 202 noop
+	chargerURI := fmt.Sprintf("%s/chargers/%s/settings", easee.API, chargerID)
+	httpmock.RegisterResponder(http.MethodPost, chargerURI,
+		httpmock.NewStringResponder(202, "[]"))
+
+	err := e.Enable(true)
+	assert.NoError(t, err)
+
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, info["POST "+chargerURI], "expected DCC:7 kickstart POST to charger settings")
+	assert.Equal(t, 7.0, e.current, "c.current should be set to 7 after kickstart")
+}
+
+func TestEasee_Enable_noKickstart_highCurrent(t *testing.T) {
+	const chargerID = "TESTTEST"
+
+	e := newEasee()
+	e.charger = chargerID
+	e.current = 10
+	e.opMode = easee.ModeAwaitingStart
+	e.chargerEnabled = true
+	e.dynamicChargerCurrent = 10 // noop: already at target
+
+	httpmock.ActivateNonDefault(e.Client)
+	defer httpmock.DeactivateAndReset()
+
+	resumeURI := fmt.Sprintf("%s/chargers/%s/commands/%s", easee.API, chargerID, easee.ChargeResume)
+	httpmock.RegisterResponder(http.MethodPost, resumeURI,
+		httpmock.NewStringResponder(202, "{}"))
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		e.mux.Lock()
+		e.opMode = easee.ModeCharging
+		e.mux.Unlock()
+		// deliver observation for opMode change
+		e.obsC <- easee.Observation{ID: easee.CHARGER_OP_MODE, Value: "3", DataType: easee.Integer}
+		time.Sleep(10 * time.Millisecond)
+		e.mux.Lock()
+		e.dynamicChargerCurrent = 32
+		e.mux.Unlock()
+		// deliver observation for DCC=32
+		e.obsC <- easee.Observation{ID: easee.DYNAMIC_CHARGER_CURRENT, Value: "32", DataType: easee.Double}
+	}()
+
+	// Mock POST charger settings (MaxCurrent(10)) — return 202 noop
+	chargerURI := fmt.Sprintf("%s/chargers/%s/settings", easee.API, chargerID)
+	httpmock.RegisterResponder(http.MethodPost, chargerURI,
+		httpmock.NewStringResponder(202, "[]"))
+
+	err := e.Enable(true)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 10.0, e.current, "c.current should remain 10 (no kickstart)")
+}
+
 func TestLivenessCheck_staleObservations(t *testing.T) {
 	e := newEasee()
 	e.opMode = easee.ModeCharging

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -517,6 +517,48 @@ func TestEasee_Phases1p3p_scaleDown_resetsDCC(t *testing.T) {
 	assert.Equal(t, 7.0, e.current, "c.current should be set to 7 after scale-down")
 }
 
+func TestEasee_Phases1p3p_scaleUp_sendsDCC7(t *testing.T) {
+	const siteID = 12345
+	const circuitID = 67890
+	const chargerID = "TESTTEST"
+
+	e := newEasee()
+	e.charger = chargerID
+	e.site = siteID
+	e.circuit = circuitID
+	e.current = 6
+
+	httpmock.ActivateNonDefault(e.Client)
+	defer httpmock.DeactivateAndReset()
+
+	getURI := fmt.Sprintf("%s/sites/%d/circuits/%d/settings", easee.API, siteID, circuitID)
+	maxP1, maxP2, maxP3 := 32.0, 32.0, 32.0
+	getResp := easee.CircuitSettings{
+		MaxCircuitCurrentP1: &maxP1,
+		MaxCircuitCurrentP2: &maxP2,
+		MaxCircuitCurrentP3: &maxP3,
+	}
+	body, err := json.Marshal(getResp)
+	require.NoError(t, err)
+	httpmock.RegisterResponder(http.MethodGet, getURI,
+		httpmock.NewBytesResponder(200, body))
+
+	httpmock.RegisterResponder(http.MethodPost, getURI,
+		httpmock.NewStringResponder(200, ""))
+
+	chargerURI := fmt.Sprintf("%s/chargers/%s/settings", easee.API, chargerID)
+	httpmock.RegisterResponder(http.MethodPost, chargerURI,
+		httpmock.NewStringResponder(202, "[]"))
+
+	err = e.Phases1p3p(3)
+	assert.NoError(t, err)
+
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, info["POST "+chargerURI], "expected one POST to charger settings with DCC:7 on scale-up")
+
+	assert.Equal(t, 7.0, e.current, "c.current should be set to 7 after scale-up")
+}
+
 func TestLivenessCheck_staleObservations(t *testing.T) {
 	e := newEasee()
 	e.opMode = easee.ModeCharging

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -643,6 +643,9 @@ func TestEasee_Enable_noKickstart_highCurrent(t *testing.T) {
 	err := e.Enable(true)
 	assert.NoError(t, err)
 
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, info["POST "+resumeURI], "expected exactly one ChargeResume command")
+	assert.Equal(t, 1, info["POST "+chargerURI], "expected exactly one POST to charger settings (MaxCurrent, not DCC:7 kickstart)")
 	assert.Equal(t, 10.0, e.current, "c.current should remain 10 (no kickstart)")
 }
 


### PR DESCRIPTION
## Summary

- Remove `phases == 1` guard in `Phases1p3p` so DCC:7 kickstart fires on
  circuit-level scale-up (1p→3p) as well as scale-down (3p→1p)
- Add equivalent DCC:7 kickstart in `Enable(true)` when `c.current < 7`,
  covering welcome charge and any cold start at 6A
- Newer Easee firmware delays ~5 min when charging starts at 6A; 7A starts
  immediately. The loadpoint detects the mismatch via `syncCharger`/
  `GetMaxCurrent` and re-sends the real target on the next control interval.

fix #30417

## Test Plan

- [ ] `go test ./charger/ -run TestEasee_Phases1p3p` — scale-down, scale-up,
  orphan registration all pass
- [ ] `go test ./charger/ -run TestEasee_Enable` — kickstart (low current) and
  no-kickstart (high current) pass
- [ ] Full charger suite: 284 tests pass, no regressions