### PR TITLE
Loadpoint UI: assign to real circuits only

### DIFF
--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -758,11 +758,11 @@ export default {
 			return circuit && !this.circuitOptions.some((c) => c.key === circuit);
 		},
 		circuitOptions() {
-			const options = this.circuits.map((c) => ({
+			// empty option is provided by PropertyField placeholder
+			return this.circuits.map((c) => ({
 				key: c.name,
 				name: `${c.config?.title || ""} [${c.name}]`.trim(),
 			}));
-			return [{ key: "", name: "unassigned" }, ...options];
 		},
 		invalidVehicle() {
 			const { vehicle } = this.values;

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -964,14 +964,8 @@ export default defineComponent({
 		},
 		async loadCircuits() {
 			const circuits = (await this.loadConfig("devices/circuit")) || [];
-			// set gridcontrol default title
-			circuits.forEach((c: ConfigCircuit) => {
-				if (c.name === GRID_CONTROL && !c.config?.title) {
-					c.config = c.config || {};
-					c.config.title = this.$t("config.hems.title");
-				}
-			});
-			this.circuits = circuits;
+			// gridcontrol is auto-created for hems and must not be user-assignable to loadpoints
+			this.circuits = circuits.filter((c: ConfigCircuit) => c.name !== GRID_CONTROL);
 		},
 		async loadTariffs() {
 			this.tariffs = (await this.loadConfig("devices/tariff")) || [];

--- a/tests/hems.spec.ts
+++ b/tests/hems.spec.ts
@@ -7,6 +7,8 @@ import {
   editorPaste,
   enableAppContext,
   expectAppEvent,
+  newLoadpoint,
+  addDemoCharger,
 } from "./utils";
 import { startSimulator, stopSimulator, simulatorUrl, simulatorApply } from "./simulator";
 
@@ -188,5 +190,13 @@ limit:
         "0.0 kW",
       ].join("")
     );
+
+    // a new loadpoint can only be assigned to the dedicated circuit, not gridcontrol
+    await newLoadpoint(page, "Carport");
+    await addDemoCharger(page);
+    const lpModal = page.getByTestId("loadpoint-modal");
+    await expectModalVisible(lpModal);
+    const circuitOptions = lpModal.getByLabel("Circuit").getByRole("option");
+    await expect(circuitOptions).toHaveText(["---", "House [main]"]);
   });
 });


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/30380
replaces https://github.com/evcc-io/evcc/pull/30415

Remove the option to assign a loadpoint to the `gridcontrol` circuit directly.

🧹 also removes redundant `unassigned` and `---` select options