### PR TITLE
Vehicle: manual soc entry for offline vehicles

### DIFF
--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -176,6 +176,7 @@ export default defineComponent({
 		vehicleDetectionActive: Boolean,
 		vehicleRange: Number,
 		vehicleSoc: { type: Number, default: 0 },
+		vehicleSocManual: Boolean,
 		minSocNotReached: Boolean,
 		vehicleName: String,
 		vehicleIcon: String,

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -85,6 +85,7 @@
 			v-bind="vehicleProps"
 			:soc-per-kwh="socPerKwh"
 			@limit-soc-updated="setLimitSoc"
+			@vehicle-soc-updated="setVehicleSoc"
 			@limit-energy-updated="setLimitEnergy"
 			@change-vehicle="changeVehicle"
 			@remove-vehicle="removeVehicle"
@@ -363,6 +364,9 @@ export default defineComponent({
 		},
 		setLimitSoc(soc: number) {
 			api.post(this.apiPath("limitsoc") + "/" + soc);
+		},
+		setVehicleSoc(soc: number) {
+			api.post(this.apiPath("vehiclesoc") + "/" + soc);
 		},
 		setLimitEnergy(kWh: number) {
 			api.post(this.apiPath("limitenergy") + "/" + kWh);

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -31,7 +31,7 @@
 		</div>
 		<div class="details d-flex flex-wrap justify-content-between">
 			<LabelAndValue
-				v-if="socBasedCharging"
+				v-if="socBasedCharging && !manualSoc"
 				class="flex-grow-1"
 				:label="vehicleSocTitle"
 				:value="formattedSoc"
@@ -39,6 +39,29 @@
 				data-testid="current-soc"
 				align="start"
 			/>
+			<div v-else-if="manualSoc" class="flex-grow-1" data-testid="manual-soc">
+				<div class="d-flex align-items-center gap-1">
+					<input
+						v-model.number="manualSocValue"
+						type="number"
+						min="0"
+						max="100"
+						class="form-control form-control-sm"
+						style="width: 4.5rem"
+						:placeholder="$t('main.vehicle.setSoc')"
+						@keyup.enter="confirmManualSoc"
+					/>
+					<button
+						type="button"
+						class="btn btn-sm btn-outline-primary"
+						data-testid="manual-soc-confirm"
+						@click="confirmManualSoc"
+					>
+						%
+					</button>
+				</div>
+				<div class="root-font-color">{{ vehicleSocTitle }}</div>
+			</div>
 			<LabelAndValue
 				v-else
 				class="flex-grow-1"
@@ -185,6 +208,7 @@ export default defineComponent({
 		"open-loadpoint-settings",
 		"batteryboost-updated",
 		"open-modal",
+		"vehicle-soc-updated",
 	],
 	data() {
 		return {
@@ -193,6 +217,7 @@ export default defineComponent({
 			chargingPlanModal: this.$refs["chargingPlanModal"] as
 				| InstanceType<typeof ChargingPlanModal>
 				| undefined,
+			manualSocValue: null as number | null,
 		};
 	},
 	computed: {
@@ -222,6 +247,9 @@ export default defineComponent({
 		},
 		batteryBoostButtonProps() {
 			return this.collectProps(BatteryBoostButton);
+		},
+		manualSoc(): boolean {
+			return this.socBasedCharging && this.connected && !this.vehicleSoc;
 		},
 		formattedSoc() {
 			if (!this.vehicleSoc) {
@@ -285,6 +313,12 @@ export default defineComponent({
 		},
 		handleBoostStatus(status: VehicleStatus) {
 			this.statusOverride = status;
+		},
+		confirmManualSoc() {
+			const value = this.manualSocValue;
+			if (value == null || value < 0 || value > 100) return;
+			this.$emit("vehicle-soc-updated", value);
+			this.manualSocValue = null;
 		},
 	},
 });

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -40,27 +40,14 @@
 				align="start"
 			/>
 			<div v-else-if="manualSoc" class="flex-grow-1" data-testid="manual-soc">
-				<div class="d-flex align-items-center gap-1">
-					<input
-						v-model.number="manualSocValue"
-						type="number"
-						min="0"
-						max="100"
-						step="1"
-						class="form-control form-control-sm"
-						style="width: 4.5rem"
-						:placeholder="$t('main.vehicle.setSoc')"
-						@keyup.enter="confirmManualSoc"
-					/>
-					<button
-						type="button"
-						class="btn btn-sm btn-outline-primary"
-						data-testid="manual-soc-confirm"
-						@click="confirmManualSoc"
-					>
-						%
-					</button>
-				</div>
+				<button
+					type="button"
+					class="value-button p-0 m-0 d-block evcc-default-text"
+					data-testid="manual-soc-open"
+					@click="openVehicleSocModal"
+				>
+					{{ vehicleSocManual ? formattedSoc : $t("main.vehicle.setSoc") }}
+				</button>
 				<div class="root-font-color">{{ vehicleSocTitle }}</div>
 			</div>
 			<LabelAndValue
@@ -98,6 +85,12 @@
 				@limit-energy-updated="limitEnergyUpdated"
 			/>
 		</div>
+		<VehicleSocModal
+			ref="vehicleSocModal"
+			:vehicle-soc="vehicleSoc"
+			:vehicle-soc-manual="vehicleSocManual"
+			@vehicle-soc-updated="$emit('vehicle-soc-updated', $event)"
+		/>
 	</div>
 </template>
 
@@ -123,6 +116,7 @@ import {
 import type { PlanStrategy } from "@/components/ChargingPlans/types";
 import BatteryBoostButton from "../Loadpoints/BatteryBoostButton.vue";
 import type ChargingPlanModal from "../ChargingPlans/ChargingPlanModal.vue";
+import VehicleSocModal from "./VehicleSocModal.vue";
 
 export default defineComponent({
 	name: "Vehicle",
@@ -135,6 +129,7 @@ export default defineComponent({
 		LimitSocSelect,
 		LimitEnergySelect,
 		BatteryBoostButton,
+		VehicleSocModal,
 	},
 	mixins: [collector, formatter],
 	props: {
@@ -219,7 +214,6 @@ export default defineComponent({
 			chargingPlanModal: this.$refs["chargingPlanModal"] as
 				| InstanceType<typeof ChargingPlanModal>
 				| undefined,
-			manualSocValue: null as number | null,
 		};
 	},
 	computed: {
@@ -293,10 +287,6 @@ export default defineComponent({
 		effectiveLimitSoc() {
 			this.displayLimitSoc = this.effectiveLimitSoc;
 		},
-		manualSoc(active: boolean) {
-			this.manualSocValue =
-				active && this.vehicleSocManual ? Math.round(this.vehicleSoc) : null;
-		},
 	},
 	methods: {
 		limitSocDrag(limitSoc: number) {
@@ -324,11 +314,11 @@ export default defineComponent({
 		handleBoostStatus(status: VehicleStatus) {
 			this.statusOverride = status;
 		},
-		confirmManualSoc() {
-			const value = this.manualSocValue;
-			if (value == null || !Number.isFinite(value) || value < 0 || value > 100) return;
-			this.$emit("vehicle-soc-updated", Math.round(value));
-			this.manualSocValue = null;
+		openVehicleSocModal() {
+			const modalRef = this.$refs["vehicleSocModal"] as
+				| InstanceType<typeof VehicleSocModal>
+				| undefined;
+			modalRef?.open();
 		},
 	},
 });

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -329,4 +329,9 @@ export default defineComponent({
 	flex-grow: 1;
 	flex-basis: 0;
 }
+.value-button {
+	font-size: 18px;
+	border: none;
+	background: none;
+}
 </style>

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -46,6 +46,7 @@
 						type="number"
 						min="0"
 						max="100"
+						step="1"
 						class="form-control form-control-sm"
 						style="width: 4.5rem"
 						:placeholder="$t('main.vehicle.setSoc')"
@@ -316,8 +317,8 @@ export default defineComponent({
 		},
 		confirmManualSoc() {
 			const value = this.manualSocValue;
-			if (value == null || value < 0 || value > 100) return;
-			this.$emit("vehicle-soc-updated", value);
+			if (value == null || !Number.isFinite(value) || value < 0 || value > 100) return;
+			this.$emit("vehicle-soc-updated", Math.round(value));
 			this.manualSocValue = null;
 		},
 	},

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -193,6 +193,7 @@ export default defineComponent({
 		vehicleRange: { type: Number, default: 0 },
 		vehicles: Array,
 		vehicleSoc: { type: Number, default: 0 },
+		vehicleSocManual: Boolean,
 		vehicleLimitSoc: Number,
 		vehicleNotReachable: Boolean,
 		minSocNotReached: Boolean,
@@ -250,7 +251,11 @@ export default defineComponent({
 			return this.collectProps(BatteryBoostButton);
 		},
 		manualSoc(): boolean {
-			return this.socBasedCharging && this.connected && !this.vehicleSoc;
+			return (
+				this.socBasedCharging &&
+				this.connected &&
+				(!this.vehicleSoc || this.vehicleSocManual)
+			);
 		},
 		formattedSoc() {
 			if (!this.vehicleSoc) {
@@ -287,6 +292,10 @@ export default defineComponent({
 	watch: {
 		effectiveLimitSoc() {
 			this.displayLimitSoc = this.effectiveLimitSoc;
+		},
+		manualSoc(active: boolean) {
+			this.manualSocValue =
+				active && this.vehicleSocManual ? Math.round(this.vehicleSoc) : null;
 		},
 	},
 	methods: {

--- a/assets/js/components/Vehicles/VehicleSocModal.vue
+++ b/assets/js/components/Vehicles/VehicleSocModal.vue
@@ -1,0 +1,70 @@
+<template>
+	<GenericModal
+		id="vehicleSocModal"
+		ref="modal"
+		:title="$t('main.vehicle.setSocTitle')"
+		data-testid="vehicle-soc-modal"
+		@open="prefill"
+	>
+		<div class="mb-3">
+			<input
+				v-model.number="socValue"
+				type="number"
+				min="0"
+				max="100"
+				step="1"
+				class="form-control"
+				:placeholder="$t('main.vehicle.setSoc')"
+				@keyup.enter="confirm"
+			/>
+		</div>
+		<p class="text-muted small mb-3">{{ $t("main.vehicle.setSocHelp") }}</p>
+		<div class="d-flex justify-content-end">
+			<button
+				type="button"
+				class="btn btn-primary"
+				data-testid="vehicle-soc-confirm"
+				@click="confirm"
+			>
+				{{ $t("main.vehicle.setSoc") }}
+			</button>
+		</div>
+	</GenericModal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import GenericModal from "../Helper/GenericModal.vue";
+
+export default defineComponent({
+	name: "VehicleSocModal",
+	components: { GenericModal },
+	props: {
+		vehicleSoc: { type: Number, default: 0 },
+		vehicleSocManual: Boolean,
+	},
+	emits: ["vehicle-soc-updated"],
+	data() {
+		return {
+			socValue: null as number | null,
+		};
+	},
+	methods: {
+		open() {
+			const modalRef = this.$refs["modal"] as InstanceType<typeof GenericModal> | undefined;
+			modalRef?.open();
+		},
+		prefill() {
+			this.socValue =
+				this.vehicleSocManual && this.vehicleSoc ? Math.round(this.vehicleSoc) : null;
+		},
+		confirm() {
+			const v = this.socValue;
+			if (v == null || !Number.isFinite(v) || v < 0 || v > 100) return;
+			this.$emit("vehicle-soc-updated", Math.round(v));
+			const modalRef = this.$refs["modal"] as InstanceType<typeof GenericModal> | undefined;
+			modalRef?.close();
+		},
+	},
+});
+</script>

--- a/assets/js/components/Vehicles/VehicleSocModal.vue
+++ b/assets/js/components/Vehicles/VehicleSocModal.vue
@@ -26,7 +26,7 @@
 				data-testid="vehicle-soc-confirm"
 				@click="confirm"
 			>
-				{{ $t("main.vehicle.setSoc") }}
+				{{ $t("main.vehicle.setSocConfirm") }}
 			</button>
 		</div>
 	</GenericModal>

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -103,6 +103,7 @@ const (
 	VehicleOdometer        = "vehicleOdometer"        // vehicle odometer
 	VehicleRange           = "vehicleRange"           // vehicle range
 	VehicleSoc             = "vehicleSoc"             // vehicle soc
+	VehicleSocManual       = "vehicleSocManual"       // vehicle soc set manually
 	VehicleLimitSoc        = "vehicleLimitSoc"        // vehicle api soc limit
 	VehicleClimaterActive  = "vehicleClimaterActive"  // vehicle climater active
 	VehicleWelcomeActive   = "vehicleWelcomeActive"   // vehicle might need welcome charge

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1870,6 +1870,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 		}
 	}
 	lp.publish(keys.VehicleSoc, lp.vehicleSoc)
+	lp.publish(keys.VehicleSocManual, lp.socManual != nil)
 
 	apiLimitSoc := 100
 	if limitR != nil {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1852,7 +1852,9 @@ func (lp *Loadpoint) publishSocAndRange() {
 		// genuine soc available: real soc wins, drop any manual override
 		lp.socManual = nil
 	} else if lp.socManual != nil {
-		socR = lp.socManual
+		// seed the estimator with the manual soc so it interpolates from this point
+		v := *lp.socManual
+		socR = &v
 	}
 
 	if socR != nil {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1847,6 +1847,14 @@ func (lp *Loadpoint) publishSocAndRange() {
 		}
 	}
 
+	// manual soc override for offline vehicles or vehicles without soc (#30393)
+	if socR != nil && *socR > 0 {
+		// genuine soc available: real soc wins, drop any manual override
+		lp.socManual = nil
+	} else if lp.socManual != nil {
+		socR = lp.socManual
+	}
+
 	if socR != nil {
 		if socEstimator == nil {
 			lp.vehicleSoc = *socR

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1850,6 +1850,10 @@ func (lp *Loadpoint) publishSocAndRange() {
 	// manual soc override for offline vehicles or vehicles without soc (#30393)
 	if socR != nil && *socR > 0 {
 		// genuine soc available: real soc wins, drop any manual override
+		if lp.socManual != nil && socEstimator != nil {
+			// re-baseline to the real soc so the prior manual guess doesn't skew the gradient
+			socEstimator.SetSoc(*socR, lp.GetChargedEnergy())
+		}
 		lp.socManual = nil
 	} else if lp.socManual != nil {
 		// seed the estimator with the manual soc so it interpolates from this point

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -169,6 +169,7 @@ type Loadpoint struct {
 
 	// charge progress
 	vehicleSoc              float64       // Vehicle or charger soc
+	socManual               *float64      // manually entered vehicle soc, session-scoped (#30393)
 	chargeDuration          time.Duration // Charge duration
 	connectedDuration       time.Duration // Connection duration
 	energyMetrics           EnergyMetrics // Stats for charged energy by session

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -87,6 +87,10 @@ type API interface {
 	GetLimitSoc() int
 	// SetLimitSoc sets the session limit soc
 	SetLimitSoc(soc int)
+	// GetVehicleSoc returns the current vehicle soc
+	GetVehicleSoc() float64
+	// SetVehicleSoc manually sets the current vehicle soc
+	SetVehicleSoc(soc float64) error
 	// GetLimitEnergy returns the session limit energy
 	GetLimitEnergy() float64
 	// SetLimitEnergy sets the session limit energy

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -699,6 +699,20 @@ func (mr *MockAPIMockRecorder) GetVehicle() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVehicle", reflect.TypeOf((*MockAPI)(nil).GetVehicle))
 }
 
+// GetVehicleSoc mocks base method.
+func (m *MockAPI) GetVehicleSoc() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVehicleSoc")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// GetVehicleSoc indicates an expected call of GetVehicleSoc.
+func (mr *MockAPIMockRecorder) GetVehicleSoc() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVehicleSoc", reflect.TypeOf((*MockAPI)(nil).GetVehicleSoc))
+}
+
 // HasChargeMeter mocks base method.
 func (m *MockAPI) HasChargeMeter() bool {
 	m.ctrl.T.Helper()
@@ -1061,6 +1075,20 @@ func (m *MockAPI) SetVehicle(vehicle api.Vehicle) {
 func (mr *MockAPIMockRecorder) SetVehicle(vehicle any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVehicle", reflect.TypeOf((*MockAPI)(nil).SetVehicle), vehicle)
+}
+
+// SetVehicleSoc mocks base method.
+func (m *MockAPI) SetVehicleSoc(soc float64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetVehicleSoc", soc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetVehicleSoc indicates an expected call of SetVehicleSoc.
+func (mr *MockAPIMockRecorder) SetVehicleSoc(soc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVehicleSoc", reflect.TypeOf((*MockAPI)(nil).SetVehicleSoc), soc)
 }
 
 // SocBasedPlanning mocks base method.

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/settings"
+	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/core/wrapper"
 )
 
@@ -307,6 +308,38 @@ func (lp *Loadpoint) SetLimitSoc(soc int) {
 		lp.setLimitSoc(soc)
 		lp.requestUpdate()
 	}
+}
+
+// GetVehicleSoc returns the current vehicle soc
+func (lp *Loadpoint) GetVehicleSoc() float64 {
+	lp.RLock()
+	defer lp.RUnlock()
+	return lp.vehicleSoc
+}
+
+// SetVehicleSoc manually sets the current vehicle soc for offline vehicles or
+// vehicles that report no soc. It re-baselines the estimator so charged-energy
+// extrapolation restarts from the entered value (#30393).
+func (lp *Loadpoint) SetVehicleSoc(value float64) error {
+	value, err := soc.Guard(value, nil)
+	if err != nil {
+		return err
+	}
+
+	lp.Lock()
+	defer lp.Unlock()
+
+	lp.log.DEBUG.Printf("set manual vehicle soc: %.0f%%", value)
+
+	lp.socManual = &value
+	if lp.socEstimator != nil {
+		lp.socEstimator.SetSoc(value, lp.getChargedEnergy())
+	}
+	lp.vehicleSoc = value
+	lp.publish(keys.VehicleSoc, value)
+	lp.requestUpdate()
+
+	return nil
 }
 
 // GetLimitEnergy returns the session limit energy

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -337,6 +337,7 @@ func (lp *Loadpoint) SetVehicleSoc(value float64) error {
 	}
 	lp.vehicleSoc = value
 	lp.publish(keys.VehicleSoc, value)
+	lp.publish(keys.VehicleSocManual, true)
 	lp.requestUpdate()
 
 	return nil

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -863,3 +863,41 @@ func TestWelcomeChargeAppliedOnlyOnce(t *testing.T) {
 	welcomeCharge, _ = lp.updateChargerStatus()
 	assert.False(t, welcomeCharge)
 }
+
+func TestSetVehicleSoc(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	clck := clock.NewMock()
+
+	vehicle := api.NewMockVehicle(ctrl)
+	charger := api.NewMockCharger(ctrl)
+	vehicle.EXPECT().Capacity().Return(8.5).AnyTimes()
+
+	log := util.NewLogger("foo")
+	lp := &Loadpoint{
+		log:          log,
+		bus:          evbus.New(),
+		clock:        clck,
+		charger:      charger,
+		vehicle:      vehicle,
+		chargeMeter:  &Null{},
+		chargeRater:  &Null{},
+		chargeTimer:  &Null{},
+		socEstimator: soc.NewEstimator(log, charger, vehicle),
+		minCurrent:   minA,
+		maxCurrent:   maxA,
+		phases:       1,
+		mode:         api.ModeNow,
+	}
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	// invalid value rejected
+	assert.Error(t, lp.SetVehicleSoc(150))
+
+	// valid value seeds vehicleSoc and the manual override
+	assert.NoError(t, lp.SetVehicleSoc(55))
+	assert.Equal(t, 55.0, lp.GetVehicleSoc())
+	assert.NotNil(t, lp.socManual)
+	assert.Equal(t, 55.0, *lp.socManual)
+}

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -133,6 +133,9 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 	lp.vehicle = v
 	lp.vmu.Unlock()
 
+	// drop any manually entered soc when the vehicle changes/disconnects (#30393)
+	lp.socManual = nil
+
 	if from != to {
 		lp.log.INFO.Printf("vehicle updated: %s -> %s", from, to)
 	}

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -473,6 +473,7 @@ func TestPublishSocAndRangeManual(t *testing.T) {
 	vehicle.EXPECT().Soc().Return(0.0, nil)
 	lp.publishSocAndRange()
 	assert.Equal(t, 42.0, lp.vehicleSoc, "manual soc used when vehicle soc is zero")
+	assert.NotNil(t, lp.socManual, "manual soc retained while vehicle soc is zero")
 
 	// real soc>0 arrives -> real wins, manual cleared
 	vehicle.EXPECT().Soc().Return(73.0, nil)

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -480,4 +481,59 @@ func TestPublishSocAndRangeManual(t *testing.T) {
 	lp.publishSocAndRange()
 	assert.Equal(t, 73.0, lp.vehicleSoc, "real soc wins")
 	assert.Nil(t, lp.socManual, "manual soc cleared once real soc seen")
+}
+
+func TestPublishSocAndRangeManualToReal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	clck := clock.NewMock()
+
+	charger := api.NewMockCharger(ctrl)
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Capacity().Return(8.5).AnyTimes() // 100 Wh per soc %
+	expectVehiclePublish(vehicle)
+	vehicle.EXPECT().Features().AnyTimes()
+
+	// controllable vehicle soc reading
+	vehSoc, vehErr := 0.0, error(errors.New("offline"))
+	vehicle.EXPECT().Soc().DoAndReturn(func() (float64, error) { return vehSoc, vehErr }).AnyTimes()
+
+	log := util.NewLogger("foo")
+	lp := &Loadpoint{
+		log:          log,
+		bus:          evbus.New(),
+		clock:        clck,
+		charger:      charger,
+		vehicle:      vehicle,
+		chargeMeter:  &Null{},
+		chargeRater:  &Null{},
+		chargeTimer:  &Null{},
+		socEstimator: soc.NewEstimator(log, charger, vehicle),
+		minCurrent:   minA,
+		maxCurrent:   maxA,
+		phases:       1,
+		mode:         api.ModeNow,
+		status:       api.StatusC,
+	}
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	// manual phase: seed 20% (re-baselines estimator at 0 Wh)
+	require.NoError(t, lp.SetVehicleSoc(20))
+
+	// charge 1000 Wh -> manual extrapolates to 30%
+	lp.energyMetrics.Update(1.0) // 1 kWh = 1000 Wh
+	lp.publishSocAndRange()
+	assert.Equal(t, 30.0, lp.vehicleSoc, "manual extrapolation before real soc")
+
+	// real soc 80% arrives at 1000 Wh -> real wins, estimator re-baselined cleanly
+	vehSoc, vehErr = 80.0, nil
+	lp.publishSocAndRange()
+	assert.Equal(t, 80.0, lp.vehicleSoc, "real soc wins")
+	assert.Nil(t, lp.socManual, "manual cleared once real soc seen")
+
+	// charge another 500 Wh (total 1500) -> 80 + 500/100 = 85 with clean gradient
+	lp.energyMetrics.Update(1.5)
+	lp.publishSocAndRange()
+	assert.Equal(t, 85.0, lp.vehicleSoc, "clean default gradient after transition (not poisoned)")
 }

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -430,3 +430,53 @@ func TestReconnectVehicle(t *testing.T) {
 		})
 	}
 }
+
+func TestPublishSocAndRangeManual(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	clck := clock.NewMock()
+
+	charger := api.NewMockCharger(ctrl)
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Capacity().Return(8.5).AnyTimes()
+	expectVehiclePublish(vehicle)
+	vehicle.EXPECT().Features().AnyTimes()
+
+	log := util.NewLogger("foo")
+	lp := &Loadpoint{
+		log:          log,
+		bus:          evbus.New(),
+		clock:        clck,
+		charger:      charger,
+		vehicle:      vehicle,
+		chargeMeter:  &Null{},
+		chargeRater:  &Null{},
+		chargeTimer:  &Null{},
+		socEstimator: soc.NewEstimator(log, charger, vehicle),
+		minCurrent:   minA,
+		maxCurrent:   maxA,
+		phases:       1,
+		mode:         api.ModeNow,
+		status:       api.StatusC,
+	}
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	// vehicle reports no soc -> manual value is used
+	manual := 42.0
+	lp.socManual = &manual
+	vehicle.EXPECT().Soc().Return(0.0, errors.New("offline"))
+	lp.publishSocAndRange()
+	assert.Equal(t, 42.0, lp.vehicleSoc, "manual soc used when vehicle soc missing")
+
+	// vehicle reports 0 (valid-but-missing) -> manual value still used
+	vehicle.EXPECT().Soc().Return(0.0, nil)
+	lp.publishSocAndRange()
+	assert.Equal(t, 42.0, lp.vehicleSoc, "manual soc used when vehicle soc is zero")
+
+	// real soc>0 arrives -> real wins, manual cleared
+	vehicle.EXPECT().Soc().Return(73.0, nil)
+	lp.publishSocAndRange()
+	assert.Equal(t, 73.0, lp.vehicleSoc, "real soc wins")
+	assert.Nil(t, lp.socManual, "manual soc cleared once real soc seen")
+}

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -495,7 +495,8 @@ func TestPublishSocAndRangeManualToReal(t *testing.T) {
 	vehicle.EXPECT().Features().AnyTimes()
 
 	// controllable vehicle soc reading
-	vehSoc, vehErr := 0.0, error(errors.New("offline"))
+	vehSoc := 0.0
+	vehErr := errors.New("offline")
 	vehicle.EXPECT().Soc().DoAndReturn(func() (float64, error) { return vehSoc, vehErr }).AnyTimes()
 
 	log := util.NewLogger("foo")

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -130,3 +130,15 @@ func (s *Estimator) Soc(fetchedSoc *float64, chargedEnergy float64) float64 {
 
 	return s.vehicleSoc
 }
+
+// SetSoc seeds the estimator with a known soc at the given charged energy,
+// re-baselining the delta calculation so subsequent charged energy extrapolates
+// from this point. Used for manually entered soc on offline / no-soc vehicles.
+// The learned gradient (energyPerSocStep) and the session energy counter are preserved.
+func (s *Estimator) SetSoc(soc, chargedEnergy float64) {
+	s.vehicleSoc = soc
+	s.initialSoc = soc
+	s.initialEnergy = chargedEnergy
+	s.prevSoc = soc
+	s.prevChargedEnergy = max(chargedEnergy, 0)
+}

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -134,11 +134,11 @@ func (s *Estimator) Soc(fetchedSoc *float64, chargedEnergy float64) float64 {
 // SetSoc seeds the estimator with a known soc at the given charged energy,
 // re-baselining the delta calculation so subsequent charged energy extrapolates
 // from this point. Used for manually entered soc on offline / no-soc vehicles.
-// The learned gradient (energyPerSocStep) and the session energy counter are preserved.
+// The learned gradient and virtual capacity are preserved.
 func (s *Estimator) SetSoc(soc, chargedEnergy float64) {
 	s.vehicleSoc = soc
 	s.initialSoc = soc
-	s.initialEnergy = chargedEnergy
+	s.initialEnergy = max(chargedEnergy, 0)
 	s.prevSoc = soc
 	s.prevChargedEnergy = max(chargedEnergy, 0)
 }

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -88,6 +88,28 @@ func TestSocEstimation(t *testing.T) {
 	}
 }
 
+func TestSetSoc(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vehicle := api.NewMockVehicle(ctrl)
+	charger := api.NewMockCharger(ctrl)
+	// 8.5 kWh => 10 kWh virtual capacity => 100 Wh per soc %
+	vehicle.EXPECT().Capacity().Return(8.5).AnyTimes()
+
+	ce := NewEstimator(util.NewLogger("foo"), charger, vehicle)
+
+	// seed 50% with 2000 Wh already charged this session
+	ce.SetSoc(50, 2000)
+	s := 50.0
+	assert.Equal(t, 50.0, ce.Soc(&s, 2000)) // no energy since baseline
+	assert.Equal(t, 55.0, ce.Soc(&s, 2500)) // +500 Wh / 100 = +5%
+
+	// updating the manual soc restarts the delta from the new baseline
+	ce.SetSoc(60, 2500)
+	s = 60.0
+	assert.Equal(t, 60.0, ce.Soc(&s, 2500)) // delta reset
+	assert.Equal(t, 65.0, ce.Soc(&s, 3000)) // +500 Wh => +5% from 60
+}
+
 func TestImprovedEstimatorRemainingChargeDuration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	charger := api.NewMockCharger(ctrl)

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1334,6 +1334,8 @@
       "none": "Kein Fahrzeug",
       "notReachable": "Fahrzeug war nicht erreichbar. Versuche evcc neu zu starten.",
       "setSoc": "% setzen",
+      "setSocHelp": "Aktuellen Ladestand für Fahrzeuge eingeben, die ihn nicht melden.",
+      "setSocTitle": "Ladestand setzen",
       "targetSoc": "Ladelimit",
       "temp": "Temperatur",
       "tempLimit": "Temperaturlimit",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1334,6 +1334,7 @@
       "none": "Kein Fahrzeug",
       "notReachable": "Fahrzeug war nicht erreichbar. Versuche evcc neu zu starten.",
       "setSoc": "% setzen",
+      "setSocConfirm": "Speichern",
       "setSocHelp": "Aktuellen Ladestand für Fahrzeuge eingeben, die ihn nicht melden.",
       "setSocTitle": "Ladestand setzen",
       "targetSoc": "Ladelimit",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1333,6 +1333,7 @@
       "moreActions": "Weitere Aktionen",
       "none": "Kein Fahrzeug",
       "notReachable": "Fahrzeug war nicht erreichbar. Versuche evcc neu zu starten.",
+      "setSoc": "% setzen",
       "targetSoc": "Ladelimit",
       "temp": "Temperatur",
       "tempLimit": "Temperaturlimit",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1334,6 +1334,7 @@
       "none": "No vehicle",
       "notReachable": "Vehicle was not reachable. Try restarting evcc.",
       "setSoc": "Set %",
+      "setSocConfirm": "Save",
       "setSocHelp": "Enter the current charge level for vehicles that don't report it.",
       "setSocTitle": "Set charge level",
       "targetSoc": "Limit",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1334,6 +1334,8 @@
       "none": "No vehicle",
       "notReachable": "Vehicle was not reachable. Try restarting evcc.",
       "setSoc": "Set %",
+      "setSocHelp": "Enter the current charge level for vehicles that don't report it.",
+      "setSocTitle": "Set charge level",
       "targetSoc": "Limit",
       "temp": "Temp.",
       "tempLimit": "Temp. limit",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1333,6 +1333,7 @@
       "moreActions": "More actions",
       "none": "No vehicle",
       "notReachable": "Vehicle was not reachable. Try restarting evcc.",
+      "setSoc": "Set %",
       "targetSoc": "Limit",
       "temp": "Temp.",
       "tempLimit": "Temp. limit",

--- a/server/http.go
+++ b/server/http.go
@@ -197,6 +197,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 		routes := map[string]route{
 			"mode":                      {"POST", "/mode/{value:[a-z]+}", handler(eapi.ChargeModeString, pass(lp.SetMode), lp.GetMode)},
 			"limitsoc":                  {"POST", "/limitsoc/{value:[0-9]+}", intHandler(pass(lp.SetLimitSoc), lp.GetLimitSoc)},
+			"vehiclesoc":                {"POST", "/vehiclesoc/{value:[0-9.]+}", floatHandler(lp.SetVehicleSoc, lp.GetVehicleSoc)},
 			"limitenergy":               {"POST", "/limitenergy/{value:[0-9.]+}", floatHandler(pass(lp.SetLimitEnergy), lp.GetLimitEnergy)},
 			"mincurrent":                {"POST", "/mincurrent/{value:[0-9.]+}", floatHandler(lp.SetMinCurrent, lp.GetMinCurrent)},
 			"maxcurrent":                {"POST", "/maxcurrent/{value:[0-9.]+}", floatHandler(lp.SetMaxCurrent, lp.GetMaxCurrent)},


### PR DESCRIPTION
Allow manually entering the vehicle soc for offline vehicles or vehicles that report no soc (soc=0). The entered value seeds the soc estimator, which then extrapolates the live soc from charged energy as usual. Correcting the value re-bases the estimator so the delta calculation continues to track correctly, without resetting the session energy counter. A real soc reading always takes precedence and clears the manual value.

Backend adds a loadpoint SetVehicleSoc/GetVehicleSoc api with a POST /loadpoints/{id}/vehiclesoc/{value} route and publishes a vehicleSocManual flag. The frontend shows an input in the vehicle soc area when the soc is unknown or manually set, so it can also be corrected later.

<img width="520" height="720" alt="manual-soc-modal" src="https://github.com/user-attachments/assets/026718e9-afb1-434e-8dfc-f852ab737e0d" />
