### PR TITLE
Config: add deviceValue.returnEnergy translation

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -167,6 +167,7 @@
       "powerRange": "Leistung",
       "price": "Preis",
       "range": "Reichweite",
+      "returnEnergy": "Rückenergie",
       "singlePhase": "Einphasig",
       "soc": "Ladestand",
       "solarForecast": "PV-Vorhersage",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -167,7 +167,7 @@
       "powerRange": "Leistung",
       "price": "Preis",
       "range": "Reichweite",
-      "returnEnergy": "Rückenergie",
+      "returnEnergy": "Energie (rückwärts)",
       "singlePhase": "Einphasig",
       "soc": "Ladestand",
       "solarForecast": "PV-Vorhersage",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -167,6 +167,7 @@
       "powerRange": "Power",
       "price": "Price",
       "range": "Range",
+      "returnEnergy": "Return Energy",
       "singlePhase": "Single phase",
       "soc": "Charge",
       "solarForecast": "Solar forecast",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -167,7 +167,7 @@
       "powerRange": "Power",
       "price": "Price",
       "range": "Range",
-      "returnEnergy": "Return Energy",
+      "returnEnergy": "Energy (reverse)",
       "singlePhase": "Single phase",
       "soc": "Charge",
       "solarForecast": "Solar forecast",


### PR DESCRIPTION
Fixes the raw i18n key (`config.deviceValue.returnEnergy`) shown for the `MeterReturnEnergy` device value at grid and battery (introduced in #29805, see https://github.com/evcc-io/evcc/pull/29805#issuecomment-4602249023).

Adds the missing `config.deviceValue.returnEnergy` key.

Wording proposal (to discuss): **"Return Energy"** / **"Rückenergie"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)