### PR TITLE
solar: return zero energy for a window entirely before the first forecast slot

### DIFF
--- a/core/solar.go
+++ b/core/solar.go
@@ -58,8 +58,11 @@ func solarEnergy(rr api.Rates, from, to time.Time) float64 {
 			// from is just before or after last entry
 			return 0
 		case idx == 0:
-			// from is before first entry
-			// do nothing- we ignore anything before the first entry
+			// from is before first entry- we ignore anything before the first entry
+			if !rr[0].Start.Before(to) {
+				// the whole interval is before the first entry
+				return 0
+			}
 		default:
 			// from is between two entries
 			r := &rr[idx]

--- a/core/solar.go
+++ b/core/solar.go
@@ -51,6 +51,11 @@ func solarEnergy(rr api.Rates, from, to time.Time) float64 {
 		panic("from cannot be after to")
 	}
 
+	// no rates- nothing to integrate
+	if len(rr) == 0 {
+		return 0
+	}
+
 	idx, ok := search(rr, from)
 	if !ok {
 		switch {

--- a/core/solar_test.go
+++ b/core/solar_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/jinzhu/now"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -103,4 +104,11 @@ func (t *solarTestSuite) TestShort() {
 
 		t.Equal(tc.energy, solarEnergy(rr, from, to), "%d. energy %+v", i+1, tc)
 	}
+}
+
+func TestSolarEnergyNoRates(t *testing.T) {
+	// empty rate series must not panic and yields no energy
+	now := time.Now()
+	assert.Equal(t, 0.0, solarEnergy(api.Rates{}, now, now.Add(time.Hour)))
+	assert.Equal(t, 0.0, solarEnergy(nil, now, now.Add(time.Hour)))
 }

--- a/core/solar_test.go
+++ b/core/solar_test.go
@@ -59,6 +59,8 @@ func (t *solarTestSuite) TestEnergy() {
 		expected float64
 	}{
 		{-1, 0, 0},
+		{-2, -1, 0},   // whole interval before first entry
+		{-1, -0.5, 0}, // whole interval before first entry
 		{-1, 1, 0.5},
 		{-1, 90, 8},
 		{0, 0, 0},


### PR DESCRIPTION
As discussed in #30458.

`solarEnergy` is meant to ignore the part of a window before the first rate entry, but the `idx == 0` branch only handled `from` being before the first slot, not `to`. When the **whole** `[from, to]` window is before the first forecast slot, it fell through into the integration loop and computed a trapezoid of negative width while extrapolating the first rate backwards - returning a spurious (often negative) value instead of `0`. The `default` branch already has the equivalent "to before same entry" guard; this adds it to `idx == 0`.

This is reachable from `solarDetails` (`core/site_tariffs.go`): e.g. in the evening, when the forecast first slot is tomorrow morning, the `remainingToday` window lies entirely before the first slot and would publish a bogus negative yield.

Two regression cases added to the existing `TestEnergy` table (`{-2, -1}` and `{-1, -0.5}`, expected `0`) - they fail before / pass after.

Closes #30458