### PR TITLE
Fix wrong energy scaling for Deye LV inverters

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -98,7 +98,7 @@ render: |
       address: 522 # "Total_GridBuy_Power Wh"
       type: holding
       decode: uint32s
-    {{- if and (eq .batterytype "hv") (not .firmware1098) }}
+    {{- if not .firmware1098 }}
     scale: 0.1
     {{- end }}      
   currents:
@@ -183,7 +183,7 @@ render: |
         address: 534 # "Total_PV_Power_Wh"
         type: holding
         decode: uint32s
-      {{- if and (eq .batterytype "hv") (not .firmware1098) }}
+      {{- if not .firmware1098 }}
       scale: 0.1
       {{- end }}
     {{- if .includegenport }}
@@ -193,7 +193,7 @@ render: |
         address: 537 # "Total_Gen_Power_Wh"
         type: holding
         decode: int32s
-      {{- if and (eq .batterytype "hv") (not .firmware1098) }}
+      {{- if not .firmware1098 }}
       scale: 0.1
       {{- end }}
     {{- end }}
@@ -222,7 +222,7 @@ render: |
       address: 518 # "Total discharge of the battery (Wh)"
       type: holding
       decode: uint32s
-    {{- if and (eq .batterytype "hv") (not .firmware1098) }}
+    {{- if not .firmware1098 }}
     scale: 0.1
     {{- end }}
   soc:


### PR DESCRIPTION
Fixed wrong condition: Energy scaling factor 0.1 was only used for hv inverters with firmware version <1098, but not for lv inverters.