### PR TITLE
Charger (OCPP): declare CurrentGetter as static capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - `_enumer.go` - generated enum code
 - `*_decorators.go` - generated decorator pattern implementations
 - Validate interface implementations: `var _ Interface = (*Type)(nil)`
+- Capabilities: register via `implement.Has`/`May` only when a capability is *conditional* (runtime/config detection, e.g. `if cp.PhaseSwitching { implement.Has(...) }`). For capabilities present on every code path, declare a plain exported method plus `var _ api.Interface = (*Type)(nil)` instead. `api.Cap` resolves static methods via direct type assertion, so unconditional `implement.Has` is redundant. A type with no conditional capabilities needs neither the `implement.Caps` embed nor `implement.New()`
 
 ### Error Handling
 

--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -128,8 +128,6 @@ func NewOCPPFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
 	}
 
-	implement.Has(c, implement.CurrentGetter(c.getMaxCurrent))
-
 	return c, nil
 }
 
@@ -348,9 +346,11 @@ func (c *OCPP) createTxDefaultChargingProfile(current float64) *types.ChargingPr
 	return res
 }
 
-// getMaxCurrent returns the current the charge point is set to offer.
+var _ api.CurrentGetter = (*OCPP)(nil)
+
+// GetMaxCurrent returns the current the charge point is set to offer.
 // Prefers the Current.Offered measurand, falls back to the last confirmed charging profile limit.
-func (c *OCPP) getMaxCurrent() (float64, error) {
+func (c *OCPP) GetMaxCurrent() (float64, error) {
 	if c.cp.HasMeasurement(types.MeasurandCurrentOffered) {
 		if v, err := c.conn.GetMaxCurrent(); err == nil || !errors.Is(err, api.ErrNotAvailable) {
 			return v, err


### PR DESCRIPTION
Surveyed `implement.Has` usage across `charger/`, `meter/`, and `vehicle/`. The dynamic capability registry (`implement.Has`/`May` + `api.Cap`) is meant for *conditional* capabilities detected at runtime or from config. A capability registered on every code path is redundant, since `api.Cap` resolves statically-implemented interfaces via a direct type assertion (its fast path).

Only one such unconditional registration exists on a device struct: OCPP `CurrentGetter`. This converts it to the idiomatic static form and documents the convention so new drivers follow it.

- `charger/ocpp.go`: rename `getMaxCurrent` to exported `GetMaxCurrent`, add `var _ api.CurrentGetter` assertion, drop the unconditional `implement.Has`. The six remaining registrations are genuinely conditional and unchanged
- `AGENTS.md`: document when to use `implement.Has`/`May` (conditional only) versus a static method plus interface assertion