### PR TITLE
Tibber: add vehicle via Data API

### DIFF
--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -31,6 +31,7 @@ params:
     example: "https://evcc.example.org/providerauth/callback"
   - name: vin
     example: WVW...
+    service: tibber/vehicles?clientid={clientid}&clientsecret={clientsecret}&redirecturi={redirecturi}
     help:
       en: Optional, selects the vehicle when the account has more than one.
       de: Optional, wählt das Fahrzeug aus, wenn das Konto mehrere besitzt.

--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -5,12 +5,12 @@ requirements:
   description:
     de: |
       Liest Fahrzeugdaten (Ladestand, Reichweite) über die offizielle Tibber Data API.
-      Benötigt einen OAuth2-Client (Client-ID und Secret), der unter https://data-api.tibber.com/ angelegt wird.
+      Benötigt einen OAuth2-Client (Client-ID und Secret), der unter https://data-api.tibber.com/clients/manage angelegt wird.
       Die unten angezeigte Redirect-URI muss beim Anlegen des Clients hinterlegt werden.
       Ein Tibber-Stromvertrag ist nicht erforderlich, das Fahrzeug muss im Tibber-Konto verbunden sein.
     en: |
       Reads vehicle data (state of charge, range) via the official Tibber Data API.
-      Requires an OAuth2 client (client id and secret) created at https://data-api.tibber.com/.
+      Requires an OAuth2 client (client id and secret) created at https://data-api.tibber.com/clients/manage.
       Register the redirect URI shown below when creating the client.
       A Tibber energy contract is not required, the vehicle must be connected in the Tibber account.
 params:

--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -1,0 +1,49 @@
+template: tibber
+products:
+  - brand: Tibber
+requirements:
+  description:
+    de: |
+      Liest Fahrzeugdaten (Ladestand, Reichweite) über die offizielle Tibber Data API.
+      Benötigt einen OAuth2-Client (Client-ID und Secret), der unter https://data-api.tibber.com/ angelegt wird.
+      Die unten angezeigte Redirect-URI muss beim Anlegen des Clients hinterlegt werden.
+      Ein Tibber-Stromvertrag ist nicht erforderlich, das Fahrzeug muss im Tibber-Konto verbunden sein.
+    en: |
+      Reads vehicle data (state of charge, range) via the official Tibber Data API.
+      Requires an OAuth2 client (client id and secret) created at https://data-api.tibber.com/.
+      Register the redirect URI shown below when creating the client.
+      A Tibber energy contract is not required, the vehicle must be connected in the Tibber account.
+params:
+  - preset: vehicle-common
+  - name: clientid
+    required: true
+  - name: clientsecret
+    required: true
+    mask: true
+  - name: redirecturi
+    required: true
+    description:
+      generic: Redirect URI
+    help:
+      en: "Redirect URI of the evcc instance. Must match the redirect URI set in the Tibber Data API client."
+      de: "Redirect-URI der evcc-Instanz. Muss mit der im Tibber Data API Client hinterlegten Redirect URI übereinstimmen."
+    service: auth/redirecturi
+    example: "https://evcc.example.org/providerauth/callback"
+  - name: vin
+    example: WVW...
+    help:
+      en: Optional, selects the vehicle when the account has more than one.
+      de: Optional, wählt das Fahrzeug aus, wenn das Konto mehrere besitzt.
+  - name: cache
+    default: 15m
+auth:
+  type: tibber
+  params: [clientid, clientsecret, redirecturi]
+render: |
+  type: tibber
+  {{- include "vehicle-common" . }}
+  clientid: {{ .clientid }}
+  clientsecret: {{ .clientsecret }}
+  redirecturi: {{ .redirecturi }}
+  vin: {{ .vin }}
+  cache: {{ .cache }}

--- a/vehicle/tibber.go
+++ b/vehicle/tibber.go
@@ -81,7 +81,9 @@ func (v *Tibber) resolve() error {
 		}
 
 		for _, d := range devices {
-			if v.vin == "" || strings.EqualFold(d.ExternalID, v.vin) {
+			// match the full external id (e.g. tesla:5YJ...) or a bare vin suffix
+			eid := strings.ToUpper(d.ExternalID)
+			if v.vin == "" || eid == v.vin || strings.HasSuffix(eid, ":"+v.vin) {
 				v.homeID = home.ID
 				v.devID = d.ID
 				return nil

--- a/vehicle/tibber.go
+++ b/vehicle/tibber.go
@@ -1,0 +1,142 @@
+package vehicle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/vehicle/tibber"
+)
+
+// Tibber is an api.Vehicle implementation for the Tibber Data API
+type Tibber struct {
+	*embed
+	*tibber.API
+	log    *util.Logger
+	vin    string
+	homeID string
+	devID  string
+	dataG  func() (tibber.DeviceDetail, error)
+}
+
+func init() {
+	registry.AddCtx("tibber", NewTibberFromConfig)
+}
+
+// NewTibberFromConfig creates a new vehicle
+func NewTibberFromConfig(ctx context.Context, other map[string]any) (api.Vehicle, error) {
+	cc := struct {
+		embed                               `mapstructure:",squash"`
+		ClientID, ClientSecret, RedirectURI string
+		VIN                                 string
+		Cache                               time.Duration
+	}{
+		Cache: interval,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.ClientID == "" || cc.ClientSecret == "" {
+		return nil, api.ErrMissingCredentials
+	}
+
+	log := util.NewLogger("tibber").Redact(cc.ClientID, cc.ClientSecret)
+
+	authCtx := util.WithLogger(context.Background(), log)
+	ts, err := tibber.NewOAuth(authCtx, cc.ClientID, cc.ClientSecret, cc.RedirectURI, cc.embed.GetTitle())
+	if err != nil {
+		return nil, err
+	}
+
+	v := &Tibber{
+		embed: &cc.embed,
+		API:   tibber.NewAPI(log, ts),
+		log:   log,
+		vin:   strings.ToUpper(cc.VIN),
+	}
+
+	v.dataG = util.Cached(v.status, cc.Cache)
+
+	return v, nil
+}
+
+// resolve discovers the home and device id of the configured vehicle. It is
+// deferred until first use because authorization happens interactively. With
+// only the vehicles scope granted, the devices endpoint returns vehicles only.
+func (v *Tibber) resolve() error {
+	homes, err := v.Homes()
+	if err != nil {
+		return err
+	}
+
+	for _, home := range homes {
+		devices, err := v.Devices(home.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, d := range devices {
+			if v.vin == "" || strings.EqualFold(d.ExternalID, v.vin) {
+				v.homeID = home.ID
+				v.devID = d.ID
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("vehicle not found: %s", v.vin)
+}
+
+func (v *Tibber) status() (tibber.DeviceDetail, error) {
+	if v.devID == "" {
+		if err := v.resolve(); err != nil {
+			return tibber.DeviceDetail{}, err
+		}
+	}
+
+	res, err := v.Device(v.homeID, v.devID)
+	if err == nil {
+		for _, c := range res.Capabilities {
+			v.log.TRACE.Printf("capability %s = %v %s (%s)", c.ID, c.Value, c.Unit, c.Description)
+		}
+	}
+
+	return res, err
+}
+
+// Soc implements the api.Vehicle interface
+func (v *Tibber) Soc() (float64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+
+	soc, ok := res.Soc()
+	if !ok {
+		return 0, api.ErrNotAvailable
+	}
+
+	return soc, nil
+}
+
+var _ api.VehicleRange = (*Tibber)(nil)
+
+// Range implements the api.VehicleRange interface
+func (v *Tibber) Range() (int64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+
+	rng, ok := res.Range()
+	if !ok {
+		return 0, api.ErrNotAvailable
+	}
+
+	return int64(rng), nil
+}

--- a/vehicle/tibber.go
+++ b/vehicle/tibber.go
@@ -81,9 +81,8 @@ func (v *Tibber) resolve() error {
 		}
 
 		for _, d := range devices {
-			// match the full external id (e.g. tesla:5YJ...) or a bare vin suffix
-			eid := strings.ToUpper(d.ExternalID)
-			if v.vin == "" || eid == v.vin || strings.HasSuffix(eid, ":"+v.vin) {
+			// match the bare vin or the full external id (e.g. tesla:5YJ...)
+			if v.vin == "" || strings.EqualFold(d.VIN(), v.vin) || strings.EqualFold(d.ExternalID, v.vin) {
 				v.homeID = home.ID
 				v.devID = d.ID
 				return nil

--- a/vehicle/tibber.go
+++ b/vehicle/tibber.go
@@ -15,7 +15,6 @@ import (
 type Tibber struct {
 	*embed
 	*tibber.API
-	log    *util.Logger
 	vin    string
 	homeID string
 	devID  string
@@ -56,7 +55,6 @@ func NewTibberFromConfig(ctx context.Context, other map[string]any) (api.Vehicle
 	v := &Tibber{
 		embed: &cc.embed,
 		API:   tibber.NewAPI(log, ts),
-		log:   log,
 		vin:   strings.ToUpper(cc.VIN),
 	}
 
@@ -100,14 +98,7 @@ func (v *Tibber) status() (tibber.DeviceDetail, error) {
 		}
 	}
 
-	res, err := v.Device(v.homeID, v.devID)
-	if err == nil {
-		for _, c := range res.Capabilities {
-			v.log.TRACE.Printf("capability %s = %v %s (%s)", c.ID, c.Value, c.Unit, c.Description)
-		}
-	}
-
-	return res, err
+	return v.Device(v.homeID, v.devID)
 }
 
 // Soc implements the api.Vehicle interface
@@ -123,6 +114,44 @@ func (v *Tibber) Soc() (float64, error) {
 	}
 
 	return soc, nil
+}
+
+var _ api.ChargeState = (*Tibber)(nil)
+
+// Status implements the api.ChargeState interface
+func (v *Tibber) Status() (api.ChargeStatus, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return api.StatusNone, err
+	}
+
+	status := api.StatusA // disconnected
+
+	if plug, ok := res.PlugStatus(); ok && plug == tibber.StatusConnected {
+		status = api.StatusB // connected, not charging
+	}
+	if charging, ok := res.ChargingStatus(); ok && charging == tibber.StatusCharging {
+		status = api.StatusC // charging
+	}
+
+	return status, nil
+}
+
+var _ api.SocLimiter = (*Tibber)(nil)
+
+// GetLimitSoc implements the api.SocLimiter interface
+func (v *Tibber) GetLimitSoc() (int64, error) {
+	res, err := v.dataG()
+	if err != nil {
+		return 0, err
+	}
+
+	soc, ok := res.TargetSoc()
+	if !ok {
+		return 0, api.ErrNotAvailable
+	}
+
+	return int64(soc), nil
 }
 
 var _ api.VehicleRange = (*Tibber)(nil)

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -156,7 +156,7 @@ func (d DeviceDetail) capability(match func(Capability) bool) (Capability, bool)
 // reporting a percentage value (the Tibber capability ids are not contractual).
 func (d DeviceDetail) Soc() (float64, bool) {
 	c, ok := d.capability(func(c Capability) bool {
-		return c.Unit == "%" && hint(c, "charge", "soc", "battery")
+		return c.Unit == "%" && hint(c, "charge", "soc", "battery") && !hint(c, "target", "limit")
 	})
 	if !ok {
 		return 0, false
@@ -165,17 +165,82 @@ func (d DeviceDetail) Soc() (float64, bool) {
 	return f, err == nil
 }
 
-// Range returns the estimated range in km. It matches the capability reporting
-// a distance value.
-func (d DeviceDetail) Range() (float64, bool) {
+// TargetSoc returns the configured charge limit in percent. It matches the
+// capability reporting a percentage value hinting at a target or limit.
+func (d DeviceDetail) TargetSoc() (float64, bool) {
 	c, ok := d.capability(func(c Capability) bool {
-		return (c.Unit == "km" || c.Unit == "mi") && hint(c, "range")
+		return c.Unit == "%" && hint(c, "target", "limit")
 	})
 	if !ok {
 		return 0, false
 	}
 	f, err := c.Float()
 	return f, err == nil
+}
+
+const kmPerMile = 1.609344
+
+// Range returns the estimated range in km. It matches the capability reporting
+// a distance value and converts m/mi to km as needed.
+func (d DeviceDetail) Range() (float64, bool) {
+	c, ok := d.capability(func(c Capability) bool {
+		return isDistanceUnit(c.Unit) && hint(c, "range")
+	})
+	if !ok {
+		return 0, false
+	}
+	f, err := c.Float()
+	if err != nil {
+		return 0, false
+	}
+	switch c.Unit {
+	case "m":
+		f /= 1000
+	case "mi", "mile", "miles":
+		f *= kmPerMile
+	}
+	return f, true
+}
+
+// isDistanceUnit reports whether the unit denotes a distance evcc can normalize to km.
+func isDistanceUnit(unit string) bool {
+	switch unit {
+	case "m", "km", "mi", "mile", "miles":
+		return true
+	default:
+		return false
+	}
+}
+
+// Status values reported by the connector.status and charging.status
+// capabilities of the Tibber Data API.
+const (
+	StatusConnected = "connected" // connector.status: connected/disconnected/unknown
+	StatusCharging  = "charging"  // charging.status: charging/idle/unknown
+)
+
+// PlugStatus returns the connector (plug) status value, e.g. connected,
+// disconnected or unknown.
+func (d DeviceDetail) PlugStatus() (string, bool) {
+	return d.statusValue("plug", "connector")
+}
+
+// ChargingStatus returns the charging status value, e.g. charging, idle or unknown.
+func (d DeviceDetail) ChargingStatus() (string, bool) {
+	return d.statusValue("charging")
+}
+
+// statusValue returns the string value of the first unitless capability matching
+// any of the keywords.
+func (d DeviceDetail) statusValue(keywords ...string) (string, bool) {
+	c, ok := d.capability(func(c Capability) bool {
+		return c.Unit == "" && hint(c, keywords...)
+	})
+	if !ok {
+		return "", false
+	}
+	s, ok := c.Value.(string)
+	return s, ok
 }
 
 // hint reports whether the capability id or description contains any of the keywords.

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -93,6 +93,34 @@ func (v *API) Devices(homeID string) ([]Device, error) {
 	return res.Devices, err
 }
 
+// Vehicles lists the vehicles across all homes, deduplicated. With only the
+// vehicles scope granted, the devices endpoint returns vehicles only.
+func (v *API) Vehicles() ([]Device, error) {
+	homes, err := v.Homes()
+	if err != nil {
+		return nil, err
+	}
+
+	var res []Device
+	seen := make(map[string]bool)
+
+	for _, home := range homes {
+		devices, err := v.Devices(home.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, d := range devices {
+			if !seen[d.ID] {
+				seen[d.ID] = true
+				res = append(res, d)
+			}
+		}
+	}
+
+	return res, nil
+}
+
 // Device returns the full state of a single device.
 func (v *API) Device(homeID, deviceID string) (DeviceDetail, error) {
 	var res DeviceDetail

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -76,7 +76,7 @@ func (v *API) Homes() ([]Home, error) {
 	var res struct {
 		Homes []Home
 	}
-	err := v.GetJSON(fmt.Sprintf("%s/homes", URI), &res)
+	err := v.GetJSON(fmt.Sprintf("%s/homes", ApiURI), &res)
 	return res.Homes, err
 }
 
@@ -85,7 +85,7 @@ func (v *API) Devices(homeID string) ([]Device, error) {
 	var res struct {
 		Devices []Device
 	}
-	err := v.GetJSON(fmt.Sprintf("%s/homes/%s/devices", URI, homeID), &res)
+	err := v.GetJSON(fmt.Sprintf("%s/homes/%s/devices", ApiURI, homeID), &res)
 	return res.Devices, err
 }
 
@@ -120,7 +120,7 @@ func (v *API) Vehicles() ([]Device, error) {
 // Device returns the full state of a single device.
 func (v *API) Device(homeID, deviceID string) (DeviceDetail, error) {
 	var res DeviceDetail
-	err := v.GetJSON(fmt.Sprintf("%s/homes/%s/devices/%s", URI, homeID, deviceID), &res)
+	err := v.GetJSON(fmt.Sprintf("%s/homes/%s/devices/%s", ApiURI, homeID, deviceID), &res)
 	return res, err
 }
 

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -3,11 +3,11 @@ package tibber
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
+	"github.com/spf13/cast"
 	"golang.org/x/oauth2"
 )
 
@@ -59,14 +59,7 @@ type Capability struct {
 
 // Float returns the capability value as a float, accepting both number and string encodings.
 func (c Capability) Float() (float64, error) {
-	switch v := c.Value.(type) {
-	case float64:
-		return v, nil
-	case string:
-		return strconv.ParseFloat(v, 64)
-	default:
-		return 0, fmt.Errorf("unexpected value type %T for capability %s", c.Value, c.ID)
-	}
+	return cast.ToFloat64E(c.Value)
 }
 
 // API is the Tibber Data API REST client.

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -2,7 +2,6 @@ package tibber
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/evcc-io/evcc/util"
@@ -121,12 +120,7 @@ func (v *API) Vehicles() ([]Device, error) {
 // Device returns the full state of a single device.
 func (v *API) Device(homeID, deviceID string) (DeviceDetail, error) {
 	var res DeviceDetail
-	uri := fmt.Sprintf("%s/homes/%s/devices/%s", URI, homeID, deviceID)
-	req, err := request.New(http.MethodGet, uri, nil, request.AcceptJSON)
-	if err != nil {
-		return res, err
-	}
-	err = v.DoJSON(req, &res)
+	err := v.GetJSON(fmt.Sprintf("%s/homes/%s/devices/%s", URI, homeID, deviceID), &res)
 	return res, err
 }
 

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -49,17 +49,12 @@ type DeviceDetail struct {
 }
 
 // Capability is a single device capability and its last-seen value. The value
-// is delivered as a JSON number or string; Float normalizes both.
+// is delivered as a JSON number or string.
 type Capability struct {
 	ID          string
 	Description string
 	Value       any
 	Unit        string
-}
-
-// Float returns the capability value as a float, accepting both number and string encodings.
-func (c Capability) Float() (float64, error) {
-	return cast.ToFloat64E(c.Value)
 }
 
 // API is the Tibber Data API REST client.
@@ -165,7 +160,7 @@ func (d DeviceDetail) Soc() (float64, bool) {
 	if !ok {
 		return 0, false
 	}
-	f, err := c.Float()
+	f, err := cast.ToFloat64E(c.Value)
 	return f, err == nil
 }
 
@@ -175,7 +170,7 @@ func (d DeviceDetail) TargetSoc() (float64, bool) {
 	if !ok {
 		return 0, false
 	}
-	f, err := c.Float()
+	f, err := cast.ToFloat64E(c.Value)
 	return f, err == nil
 }
 
@@ -185,7 +180,7 @@ func (d DeviceDetail) Range() (float64, bool) {
 	if !ok {
 		return 0, false
 	}
-	f, err := c.Float()
+	f, err := cast.ToFloat64E(c.Value)
 	if err != nil {
 		return 0, false
 	}

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -31,6 +31,15 @@ type DeviceInfo struct {
 	Model string
 }
 
+// VIN returns the vehicle identification number from the external id, which is
+// formatted as vendor:vin (e.g. tesla:5YJSA1E26MF1234567).
+func (d Device) VIN() string {
+	if _, vin, ok := strings.Cut(d.ExternalID, ":"); ok {
+		return vin
+	}
+	return d.ExternalID
+}
+
 // DeviceDetail is the full device state including capabilities.
 type DeviceDetail struct {
 	ID           string

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -142,22 +142,33 @@ func (v *API) Device(homeID, deviceID string) (DeviceDetail, error) {
 	return res, err
 }
 
-// capability returns the first capability matching the predicate.
-func (d DeviceDetail) capability(match func(Capability) bool) (Capability, bool) {
+// Tibber Data API capability ids and the enum values they report.
+const (
+	idSoc       = "storage.stateOfCharge"       // %
+	idTargetSoc = "storage.targetStateOfCharge" // %
+	idRange     = "range.remaining"             // distance, typically m
+	idConnector = "connector.status"            // connected/disconnected/unknown
+	idCharging  = "charging.status"             // charging/idle/unknown
+
+	StatusConnected = "connected" // connector.status
+	StatusCharging  = "charging"  // charging.status
+)
+
+const kmPerMile = 1.609344
+
+// capability returns the capability with the given id.
+func (d DeviceDetail) capability(id string) (Capability, bool) {
 	for _, c := range d.Capabilities {
-		if match(c) {
+		if c.ID == id {
 			return c, true
 		}
 	}
 	return Capability{}, false
 }
 
-// Soc returns the battery state of charge in percent. It matches the capability
-// reporting a percentage value (the Tibber capability ids are not contractual).
+// Soc returns the battery state of charge in percent.
 func (d DeviceDetail) Soc() (float64, bool) {
-	c, ok := d.capability(func(c Capability) bool {
-		return c.Unit == "%" && hint(c, "charge", "soc", "battery") && !hint(c, "target", "limit")
-	})
+	c, ok := d.capability(idSoc)
 	if !ok {
 		return 0, false
 	}
@@ -165,12 +176,9 @@ func (d DeviceDetail) Soc() (float64, bool) {
 	return f, err == nil
 }
 
-// TargetSoc returns the configured charge limit in percent. It matches the
-// capability reporting a percentage value hinting at a target or limit.
+// TargetSoc returns the configured charge limit in percent.
 func (d DeviceDetail) TargetSoc() (float64, bool) {
-	c, ok := d.capability(func(c Capability) bool {
-		return c.Unit == "%" && hint(c, "target", "limit")
-	})
+	c, ok := d.capability(idTargetSoc)
 	if !ok {
 		return 0, false
 	}
@@ -178,14 +186,9 @@ func (d DeviceDetail) TargetSoc() (float64, bool) {
 	return f, err == nil
 }
 
-const kmPerMile = 1.609344
-
-// Range returns the estimated range in km. It matches the capability reporting
-// a distance value and converts m/mi to km as needed.
+// Range returns the estimated range in km, converting m/mi to km as needed.
 func (d DeviceDetail) Range() (float64, bool) {
-	c, ok := d.capability(func(c Capability) bool {
-		return isDistanceUnit(c.Unit) && hint(c, "range")
-	})
+	c, ok := d.capability(idRange)
 	if !ok {
 		return 0, false
 	}
@@ -202,54 +205,23 @@ func (d DeviceDetail) Range() (float64, bool) {
 	return f, true
 }
 
-// isDistanceUnit reports whether the unit denotes a distance evcc can normalize to km.
-func isDistanceUnit(unit string) bool {
-	switch unit {
-	case "m", "km", "mi", "mile", "miles":
-		return true
-	default:
-		return false
-	}
-}
-
-// Status values reported by the connector.status and charging.status
-// capabilities of the Tibber Data API.
-const (
-	StatusConnected = "connected" // connector.status: connected/disconnected/unknown
-	StatusCharging  = "charging"  // charging.status: charging/idle/unknown
-)
-
 // PlugStatus returns the connector (plug) status value, e.g. connected,
 // disconnected or unknown.
 func (d DeviceDetail) PlugStatus() (string, bool) {
-	return d.statusValue("plug", "connector")
+	return d.statusValue(idConnector)
 }
 
 // ChargingStatus returns the charging status value, e.g. charging, idle or unknown.
 func (d DeviceDetail) ChargingStatus() (string, bool) {
-	return d.statusValue("charging")
+	return d.statusValue(idCharging)
 }
 
-// statusValue returns the string value of the first unitless capability matching
-// any of the keywords.
-func (d DeviceDetail) statusValue(keywords ...string) (string, bool) {
-	c, ok := d.capability(func(c Capability) bool {
-		return c.Unit == "" && hint(c, keywords...)
-	})
+// statusValue returns the string value of the capability with the given id.
+func (d DeviceDetail) statusValue(id string) (string, bool) {
+	c, ok := d.capability(id)
 	if !ok {
 		return "", false
 	}
 	s, ok := c.Value.(string)
 	return s, ok
-}
-
-// hint reports whether the capability id or description contains any of the keywords.
-func hint(c Capability, keywords ...string) bool {
-	hay := strings.ToLower(c.ID + " " + c.Description)
-	for _, k := range keywords {
-		if strings.Contains(hay, k) {
-			return true
-		}
-	}
-	return false
 }

--- a/vehicle/tibber/api.go
+++ b/vehicle/tibber/api.go
@@ -1,0 +1,153 @@
+package tibber
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	"golang.org/x/oauth2"
+)
+
+// Home is an entry of the customer's home list.
+type Home struct {
+	ID   string
+	Name string
+}
+
+// Device is a device list entry (identity only, no live values).
+type Device struct {
+	ID         string
+	ExternalID string
+	Info       DeviceInfo
+}
+
+// DeviceInfo holds static make/brand/model information.
+type DeviceInfo struct {
+	Name  string
+	Brand string
+	Model string
+}
+
+// DeviceDetail is the full device state including capabilities.
+type DeviceDetail struct {
+	ID           string
+	ExternalID   string
+	Info         DeviceInfo
+	Capabilities []Capability
+}
+
+// Capability is a single device capability and its last-seen value. The value
+// is delivered as a JSON number or string; Float normalizes both.
+type Capability struct {
+	ID          string
+	Description string
+	Value       any
+	Unit        string
+}
+
+// Float returns the capability value as a float, accepting both number and string encodings.
+func (c Capability) Float() (float64, error) {
+	switch v := c.Value.(type) {
+	case float64:
+		return v, nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	default:
+		return 0, fmt.Errorf("unexpected value type %T for capability %s", c.Value, c.ID)
+	}
+}
+
+// API is the Tibber Data API REST client.
+type API struct {
+	*request.Helper
+}
+
+// NewAPI creates a Tibber Data API client authenticated via the given token source.
+func NewAPI(log *util.Logger, ts oauth2.TokenSource) *API {
+	client := request.NewHelper(log)
+	client.Transport = &oauth2.Transport{
+		Source: ts,
+		Base:   client.Transport,
+	}
+	return &API{Helper: client}
+}
+
+// Homes lists the homes the user has access to.
+func (v *API) Homes() ([]Home, error) {
+	var res struct {
+		Homes []Home
+	}
+	err := v.GetJSON(fmt.Sprintf("%s/homes", URI), &res)
+	return res.Homes, err
+}
+
+// Devices lists the devices of a home.
+func (v *API) Devices(homeID string) ([]Device, error) {
+	var res struct {
+		Devices []Device
+	}
+	err := v.GetJSON(fmt.Sprintf("%s/homes/%s/devices", URI, homeID), &res)
+	return res.Devices, err
+}
+
+// Device returns the full state of a single device.
+func (v *API) Device(homeID, deviceID string) (DeviceDetail, error) {
+	var res DeviceDetail
+	uri := fmt.Sprintf("%s/homes/%s/devices/%s", URI, homeID, deviceID)
+	req, err := request.New(http.MethodGet, uri, nil, request.AcceptJSON)
+	if err != nil {
+		return res, err
+	}
+	err = v.DoJSON(req, &res)
+	return res, err
+}
+
+// capability returns the first capability matching the predicate.
+func (d DeviceDetail) capability(match func(Capability) bool) (Capability, bool) {
+	for _, c := range d.Capabilities {
+		if match(c) {
+			return c, true
+		}
+	}
+	return Capability{}, false
+}
+
+// Soc returns the battery state of charge in percent. It matches the capability
+// reporting a percentage value (the Tibber capability ids are not contractual).
+func (d DeviceDetail) Soc() (float64, bool) {
+	c, ok := d.capability(func(c Capability) bool {
+		return c.Unit == "%" && hint(c, "charge", "soc", "battery")
+	})
+	if !ok {
+		return 0, false
+	}
+	f, err := c.Float()
+	return f, err == nil
+}
+
+// Range returns the estimated range in km. It matches the capability reporting
+// a distance value.
+func (d DeviceDetail) Range() (float64, bool) {
+	c, ok := d.capability(func(c Capability) bool {
+		return (c.Unit == "km" || c.Unit == "mi") && hint(c, "range")
+	})
+	if !ok {
+		return 0, false
+	}
+	f, err := c.Float()
+	return f, err == nil
+}
+
+// hint reports whether the capability id or description contains any of the keywords.
+func hint(c Capability, keywords ...string) bool {
+	hay := strings.ToLower(c.ID + " " + c.Description)
+	for _, k := range keywords {
+		if strings.Contains(hay, k) {
+			return true
+		}
+	}
+	return false
+}

--- a/vehicle/tibber/oauth.go
+++ b/vehicle/tibber/oauth.go
@@ -13,8 +13,8 @@ const (
 	AuthURI = "https://thewall.tibber.com/connect/authorize"
 	// TokenURI is the Tibber Data API token endpoint.
 	TokenURI = "https://thewall.tibber.com/connect/token"
-	// URI is the Tibber Data API base URL.
-	URI = "https://data-api.tibber.com/v1"
+	// ApiURI is the Tibber Data API base URL.
+	ApiURI = "https://data-api.tibber.com/v1"
 )
 
 func init() {

--- a/vehicle/tibber/oauth.go
+++ b/vehicle/tibber/oauth.go
@@ -1,0 +1,58 @@
+package tibber
+
+import (
+	"context"
+
+	"github.com/evcc-io/evcc/plugin/auth"
+	"github.com/evcc-io/evcc/util"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// AuthURI is the Tibber Data API authorization endpoint.
+	AuthURI = "https://thewall.tibber.com/connect/authorize"
+	// TokenURI is the Tibber Data API token endpoint.
+	TokenURI = "https://thewall.tibber.com/connect/token"
+	// URI is the Tibber Data API base URL.
+	URI = "https://data-api.tibber.com/v1"
+)
+
+func init() {
+	auth.Register("tibber", func(other map[string]any) (oauth2.TokenSource, error) {
+		var cc struct {
+			ClientID, ClientSecret, RedirectURI string
+		}
+
+		if err := util.DecodeOther(other, &cc); err != nil {
+			return nil, err
+		}
+
+		log := util.NewLogger("tibber").Redact(cc.ClientID, cc.ClientSecret)
+		ctx := util.WithLogger(context.Background(), log)
+
+		return NewOAuth(ctx, cc.ClientID, cc.ClientSecret, cc.RedirectURI, "")
+	})
+}
+
+// OAuthConfig returns the Tibber Data API OAuth2 config.
+func OAuthConfig(clientID, clientSecret, redirectURI string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURI,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  AuthURI,
+			TokenURL: TokenURI,
+		},
+		Scopes: []string{
+			"openid", "profile", "email", "offline_access",
+			"data-api-user-read", "data-api-vehicles-read",
+		},
+	}
+}
+
+// NewOAuth creates the Tibber Data API token source using the authorization
+// code flow with PKCE. The user authorizes interactively via the evcc UI.
+func NewOAuth(ctx context.Context, clientID, clientSecret, redirectURI, title string) (oauth2.TokenSource, error) {
+	return auth.NewOAuth(ctx, "Tibber", title, OAuthConfig(clientID, clientSecret, redirectURI))
+}

--- a/vehicle/tibber/service.go
+++ b/vehicle/tibber/service.go
@@ -1,0 +1,53 @@
+package tibber
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+
+	"github.com/evcc-io/evcc/server/service"
+	"github.com/evcc-io/evcc/util"
+)
+
+func init() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /vehicles", getVehicles)
+
+	service.Register("tibber", mux)
+}
+
+// getVehicles lists the external ids of the vehicles in the account, driving
+// vehicle selection in the template. It reuses the OAuth instance created for
+// the same client, so results appear once the user has authorized via the UI.
+func getVehicles(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := req.URL.Query()
+	clientID, clientSecret, redirectURI := q.Get("clientid"), q.Get("clientsecret"), q.Get("redirecturi")
+
+	ids := []string{}
+	defer func() { _ = json.NewEncoder(w).Encode(ids) }()
+
+	if clientID == "" || clientSecret == "" {
+		return
+	}
+
+	log := util.NewLogger("tibber").Redact(clientID, clientSecret)
+
+	ts, err := NewOAuth(util.WithLogger(context.Background(), log), clientID, clientSecret, redirectURI, "")
+	if err != nil {
+		return
+	}
+
+	// no values until the user has authorized
+	vehicles, err := NewAPI(log, ts).Vehicles()
+	if err != nil {
+		return
+	}
+
+	for _, v := range vehicles {
+		ids = append(ids, v.ExternalID)
+	}
+	slices.Sort(ids)
+}

--- a/vehicle/tibber/service.go
+++ b/vehicle/tibber/service.go
@@ -47,7 +47,7 @@ func getVehicles(w http.ResponseWriter, req *http.Request) {
 	}
 
 	for _, v := range vehicles {
-		ids = append(ids, v.ExternalID)
+		ids = append(ids, v.VIN())
 	}
 	slices.Sort(ids)
 }


### PR DESCRIPTION
closes #30468

Adds a Tibber vehicle reading state of charge and range from the official Tibber Data API. Auth uses the OAuth2 authorization-code flow with PKCE via the existing provider-auth redirect (login button in the UI); the redirect URI is offered through the `auth/redirecturi` service like the Viessmann template. Works for any vehicle connected to a Tibber account and does not require a Tibber energy contract.

- `vehicle/tibber/oauth.go`: Data API OAuth2 config (`thewall.tibber.com`), registered as auth provider `tibber`
- `vehicle/tibber/api.go`: REST client for `data-api.tibber.com/v1` and capability extraction
- `vehicle/tibber.go`: `api.Vehicle` (Soc) and `api.VehicleRange`, lazy vehicle resolution across the account
- template with `clientid`, `clientsecret`, `redirecturi`, optional `vin`

Verified end-to-end against the live API: OAuth login, token refresh, `/homes` and `/homes/{id}/devices` all succeed. The Data API only lists a vehicle once an OEM-connected car is paired in the Tibber account, so SOC/range values could not yet be observed.

**TODO**
- [ ] confirm the SOC and range capability `id`/`unit` against a connected vehicle and replace the heuristic matching with exact ids (capabilities are TRACE-logged to support this)