### PR TITLE
refactor: centralize and group OBIS codes

### DIFF
--- a/charger/hardybarth-ecb1.go
+++ b/charger/hardybarth-ecb1.go
@@ -195,7 +195,7 @@ func (wb *HardyBarth) MaxCurrent(current int64) error {
 }
 
 // The eCB1 meter API exposes only demand/average (OBIS D=4) and energy (D=8)
-// registers — there are no instantaneous (D=7) registers on the device.
+// registers. There are no instantaneous (D=7) registers on the device.
 // See https://github.com/evcc-io/evcc/discussions/778
 var _ api.Meter = (*HardyBarth)(nil)
 

--- a/charger/hardybarth-ecb1.go
+++ b/charger/hardybarth-ecb1.go
@@ -194,6 +194,9 @@ func (wb *HardyBarth) MaxCurrent(current int64) error {
 	return wb.post(uri, data)
 }
 
+// The eCB1 meter API exposes only demand/average (OBIS D=4) and energy (D=8)
+// registers — there are no instantaneous (D=7) registers on the device.
+// See https://github.com/evcc-io/evcc/discussions/778
 var _ api.Meter = (*HardyBarth)(nil)
 
 // CurrentPower implements the api.Meter interface
@@ -203,7 +206,7 @@ func (wb *HardyBarth) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
-	return res.Data[obis.PowerConsumption], nil
+	return res.Data[obis.PowerImportDemand], nil
 }
 
 var _ api.MeterEnergy = (*HardyBarth)(nil)
@@ -215,7 +218,7 @@ func (wb *HardyBarth) TotalEnergy() (float64, error) {
 		return 0, err
 	}
 
-	return res.Data[obis.EnergyConsumption], nil
+	return res.Data[obis.EnergyImport], nil
 }
 
 var _ api.PhaseCurrents = (*HardyBarth)(nil)
@@ -227,7 +230,7 @@ func (wb *HardyBarth) Currents() (float64, float64, float64, error) {
 		return 0, 0, 0, err
 	}
 
-	return res.Data[obis.CurrentL1], res.Data[obis.CurrentL2], res.Data[obis.CurrentL3], nil
+	return res.Data[obis.CurrentDemandL1], res.Data[obis.CurrentDemandL2], res.Data[obis.CurrentDemandL3], nil
 }
 
 // var _ api.Identifier = (*HardyBarth)(nil)

--- a/meter/obis/obis.go
+++ b/meter/obis/obis.go
@@ -1,22 +1,69 @@
 package obis
 
+// OBIS codes for electricity meters.
 // https://www.kbr.de/de/obis-kennzeichen/elektrizitaet
+//
+// Names use Import (+A, OBIS channel 1/2x) and Export (-A, channel 2/2x) for
+// active power and energy. Energy registers carry an optional tariff suffix
+// T1/T2 (OBIS field E).
+//
+// The OBIS D field selects how the value is processed:
+//   - D=7  instantaneous    momentary sample ("now")               -> unqualified
+//   - D=4  current average  running mean over the ongoing demand   -> Demand suffix
+//                           period (a meter-configured window, e.g. 15 min)
+//   - D=5  last average     mean over the last completed period
+//   - D=8  time integral    cumulative energy                      -> Energy*
 
+// Active power (kW)
 const (
-	PowerConsumption  = "1-0:1.4.0"
-	EnergyConsumption = "1-0:1.8.0"
-	PowerFeedIn       = "1-0:2.4.0"
-	EnergyFeedIn      = "1-0:2.8.0"
+	PowerImport = "1-0:1.7.0" // instantaneous +A
+	PowerExport = "1-0:2.7.0" // instantaneous -A
 
-	PowerConsumptionL1  = "1-0:21.4.0"
-	EnergyConsumptionL1 = "1-0:21.8.0"
-	CurrentL1           = "1-0:31.4.0"
+	PowerImportL1 = "1-0:21.7.0"
+	PowerImportL2 = "1-0:41.7.0"
+	PowerImportL3 = "1-0:61.7.0"
 
-	PowerConsumptionL2  = "1-0:41.4.0"
-	EnergyConsumptionL2 = "1-0:41.8.0"
-	CurrentL2           = "1-0:51.4.0"
+	PowerExportL1 = "1-0:22.7.0"
+	PowerExportL2 = "1-0:42.7.0"
+	PowerExportL3 = "1-0:62.7.0"
 
-	PowerConsumptionL3  = "1-0:61.4.0"
-	EnergyConsumptionL3 = "1-0:61.8.0"
-	CurrentL3           = "1-0:71.4.0"
+	PowerImportDemand = "1-0:1.4.0" // current average +A
+	PowerExportDemand = "1-0:2.4.0" // current average -A
+
+	PowerImportDemandL1 = "1-0:21.4.0"
+	PowerImportDemandL2 = "1-0:41.4.0"
+	PowerImportDemandL3 = "1-0:61.4.0"
+)
+
+// Active energy (kWh)
+const (
+	EnergyImport   = "1-0:1.8.0" // +A, total
+	EnergyImportT1 = "1-0:1.8.1" // +A, tariff 1
+	EnergyImportT2 = "1-0:1.8.2" // +A, tariff 2
+
+	EnergyExport   = "1-0:2.8.0" // -A, total
+	EnergyExportT1 = "1-0:2.8.1" // -A, tariff 1
+	EnergyExportT2 = "1-0:2.8.2" // -A, tariff 2
+)
+
+// Current (A)
+const (
+	CurrentL1 = "1-0:31.7.0" // instantaneous
+	CurrentL2 = "1-0:51.7.0"
+	CurrentL3 = "1-0:71.7.0"
+
+	CurrentDemandL1 = "1-0:31.4.0" // current average
+	CurrentDemandL2 = "1-0:51.4.0"
+	CurrentDemandL3 = "1-0:71.4.0"
+)
+
+// Voltage (V)
+const (
+	VoltageL1 = "1-0:32.7.0" // instantaneous
+	VoltageL2 = "1-0:52.7.0"
+	VoltageL3 = "1-0:72.7.0"
+
+	VoltageDemandL1 = "1-0:32.4.0" // current average
+	VoltageDemandL2 = "1-0:52.4.0"
+	VoltageDemandL3 = "1-0:72.4.0"
 )


### PR DESCRIPTION
- Move the OBIS codes used across meters into the shared `obis` package and regroup them by quantity (power / energy / current / voltage).
- Harmonize naming: `Import`/`Export`, instantaneous as the unqualified default (OBIS `D=7`), `Demand` suffix for the last-average `.4.0` registers (`D=4`), tariff suffix `T1`/`T2` for energy.
- Add `VoltageDemand` codes (kept here for a follow-up PR that adds HardyBarth phase voltages).

## charger/hardybarth-ecb1
- Switch to the renamed shared constants. No functional change.
- Attention: The eCB1 meter API only exposes demand (`D=4`) and energy (`D=8`) registers, no instantaneous (`D=7`) values, so power/current use the `Demand` variants on purpose (see #778).