### PR TITLE
HardyBarth: add phase voltages

### DIFF
--- a/charger/hardybarth-ecb1.go
+++ b/charger/hardybarth-ecb1.go
@@ -233,6 +233,18 @@ func (wb *HardyBarth) Currents() (float64, float64, float64, error) {
 	return res.Data[obis.CurrentDemandL1], res.Data[obis.CurrentDemandL2], res.Data[obis.CurrentDemandL3], nil
 }
 
+var _ api.PhaseVoltages = (*HardyBarth)(nil)
+
+// Voltages implements the api.PhaseVoltages interface
+func (wb *HardyBarth) Voltages() (float64, float64, float64, error) {
+	res, err := wb.meterG()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return res.Data[obis.VoltageDemandL1], res.Data[obis.VoltageDemandL2], res.Data[obis.VoltageDemandL3], nil
+}
+
 // var _ api.Identifier = (*HardyBarth)(nil)
 
 // // Identify implements the api.Identifier interface


### PR DESCRIPTION
Stacked on #30489 (which adds the `VoltageDemand` OBIS codes).

Implement `api.PhaseVoltages` for the Hardy Barth eCB1 using the demand voltage registers (`1-0:32/52/72.4.0`) the meter API exposes. The eCB1 provides only demand (`D=4`) values, so this mirrors how `Currents` already reads the `.4.0` registers.

Once #30489 merges, this PR re-targets to `master` automatically.