### PR TITLE
Speed up Playwright CI by skipping install-deps on cache hit

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -257,11 +257,6 @@ jobs:
         run: npx playwright install --with-deps chromium
         timeout-minutes: 5
 
-      - name: Install Playwright (deps only)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-        timeout-minutes: 5
-
       - name: Run tests
         run: npx playwright test
         timeout-minutes: 20


### PR DESCRIPTION
The integration job ran `npx playwright install-deps chromium` on every browser-cache hit. That step runs `apt-get` and dominates setup time on the hot path.

The `depot-ubuntu-24.04-arm-32` runner already ships Chromium's library dependencies, and the cache-miss path still installs them via `playwright install --with-deps chromium`. Removing the per-run deps step makes the common cached run noticeably faster without changing behaviour.

Based on https://github.com/microsoft/playwright/issues/23388#issuecomment-4623018570