### PR TITLE
Stabilize flaky limitSoc disconnect-reset e2e test

### DIFF
--- a/tests/limits.spec.ts
+++ b/tests/limits.spec.ts
@@ -76,6 +76,7 @@ test.describe("limitSoc", async () => {
     await simulatorApply(page);
 
     await page.goto("/");
+    await expect(page.getByTestId("vehicle-title")).toContainText("blauer e-Golf");
     await expect(page.getByTestId("vehicle-status")).toHaveText("Disconnected.");
     await expect(page.getByTestId("limit-soc-value")).toHaveText("100%");
 


### PR DESCRIPTION
The `limitSoc › limit soc should be resetted when vehicle gets disconnected` e2e test is flaky. On a recent CI run it failed with:

```
Locator: getByTestId('limit-soc-value')
Expected: "100%"
Received: "50%"
```

After triggering the disconnect and navigating to `/`, the test read `limit-soc-value` immediately. The reset to the default (100%) only lands once the loadpoint switches to the default vehicle on disconnect and the new state propagates over the websocket. Occasionally the assertion ran against the pre-disconnect `50%` before that update arrived.

The fix waits for the default vehicle title (`blauer e-Golf`) to appear before asserting the limit — the same gating the sibling test `can be set even if vehicle isn't connected yet` already uses for the disconnected state. No production code changes.