### PR TITLE
SunSpec: add returnEnergy support

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -191,7 +191,8 @@ render: |
     scale: 0.001
   returnenergy:
     source: sunspec
-    {{- include "modbus" . | indent 2 }}
+    uri: {{ joinHostPort .host .port }}
+    id: 1
     value: 160:3:DCWH # mppt 3 (charge)
     scale: 0.001
   soc:

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -189,6 +189,11 @@ render: |
     id: 1
     value: 160:4:DCWH # mppt 4 (discharge)
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 160:3:DCWH # mppt 3 (charge)
+    scale: 0.001
   soc:
     source: sunspec
     uri: {{ joinHostPort .host .port }}

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -57,6 +57,16 @@ render: |
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: {{ .id }}
+    value:
+      - 201:TotWhExp
+      - 211:TotWhExp
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       uri: {{ joinHostPort .host .port }}

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -44,6 +44,16 @@ render: |
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: {{ .id }}
+    value:
+      - 201:TotWhExp
+      - 211:TotWhExp
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       uri: {{ joinHostPort .host .port }}

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -187,7 +187,8 @@ render: |
     scale: 0.001
   returnenergy:
     source: sunspec
-    {{- include "modbus" . | indent 2 }}
+    uri: {{ joinHostPort .host .port }}
+    id: 1
     value: 160:4:DCWH # mppt 4 (charge)
     scale: 0.001
   soc:

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -185,6 +185,11 @@ render: |
     id: 1
     value: 160:5:DCWH # mppt 5 (discharge)
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 160:4:DCWH # mppt 4 (charge)
+    scale: 0.001
   soc:
     source: sunspec
     uri: {{ joinHostPort .host .port }}

--- a/templates/definition/meter/keba-kecontact.yaml
+++ b/templates/definition/meter/keba-kecontact.yaml
@@ -26,6 +26,13 @@ render: |
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value:
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/kostal-ksem.yaml
+++ b/templates/definition/meter/kostal-ksem.yaml
@@ -25,6 +25,13 @@ render: |
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value:
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -44,6 +44,12 @@ render: |
     subdevice: 1 # Metering device
     value: 203:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    subdevice: 1 # Metering device
+    value: 203:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/solaredge-inverter.yaml
+++ b/templates/definition/meter/solaredge-inverter.yaml
@@ -33,6 +33,13 @@ render: |
     subdevice: 1 # Metering device
     value: 203:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
+    subdevice: 1 # Metering device
+    value: 203:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -124,6 +124,11 @@ render: |
     {{- include "modbus" . | indent 2 }}
     value: 160:4:DCWH # mppt 4 (discharge)
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 160:3:DCWH # mppt 3 (charge)
+    scale: 0.001
   soc:
     source: sunspec
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -29,6 +29,13 @@ render: |
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value:
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -35,6 +35,17 @@ render: |
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value:
+      - 201:TotWhExp
+      - 211:TotWhExp
+      - 202:TotWhExp
+      - 212:TotWhExp
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/sunspec-meter.yaml
+++ b/templates/definition/meter/sunspec-meter.yaml
@@ -39,6 +39,18 @@ render: |
       - 203:TotWhImp
       - 213:TotWhImp
     scale: 0.001
+  returnenergy:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: {{ .id }}
+    value:
+      - 201:TotWhExp
+      - 211:TotWhExp
+      - 202:TotWhExp
+      - 212:TotWhExp
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
   currents:
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
@@ -156,5 +168,17 @@ render: |
       - 212:TotWhExp
       - 203:TotWhExp
       - 213:TotWhExp
+    scale: 0.001
+  returnenergy:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: {{ .id }}
+    value:
+      - 201:TotWhImp
+      - 211:TotWhImp
+      - 202:TotWhImp
+      - 212:TotWhImp
+      - 203:TotWhImp
+      - 213:TotWhImp
     scale: 0.001
   {{- end }}


### PR DESCRIPTION
Introduce support for return energy metrics from the sunspec source, enhancing the data retrieval capabilities for energy monitoring.