### PR TITLE
Battery UI: drop orphan grid charge headline on fresh installs

### DIFF
--- a/assets/js/views/Battery.vue
+++ b/assets/js/views/Battery.vue
@@ -62,7 +62,6 @@ export default defineComponent({
 			);
 		},
 		gridChargeLimit() {
-			// normalize undefined (never published) and null (explicitly unset)
 			return this.state.batteryGridChargeLimit ?? null;
 		},
 		gridChargeVisible() {

--- a/assets/js/views/Battery.vue
+++ b/assets/js/views/Battery.vue
@@ -61,8 +61,12 @@ export default defineComponent({
 				devices.some(({ controllable }) => controllable) && this.state.smartCostAvailable
 			);
 		},
+		gridChargeLimit() {
+			// normalize undefined (never published) and null (explicitly unset)
+			return this.state.batteryGridChargeLimit ?? null;
+		},
 		gridChargeVisible() {
-			return this.gridChargePossible || this.state.batteryGridChargeLimit !== null;
+			return this.gridChargePossible || this.gridChargeLimit !== null;
 		},
 		gridChargeTariff() {
 			const { forecast, smartCostType } = this.state;
@@ -70,7 +74,7 @@ export default defineComponent({
 		},
 		smartCostLimitProps() {
 			return {
-				currentLimit: this.state.batteryGridChargeLimit ?? null,
+				currentLimit: this.gridChargeLimit,
 				lastLimit: settings.lastBatterySmartCostLimit,
 				smartCostType: this.state.smartCostType,
 				currency: this.state.currency,


### PR DESCRIPTION
Only show grid charge if feature is available or an old values exists.

Cause: different `undefined` and `null` handling.