### PR TITLE
Device Card: improve truncation

### DIFF
--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -176,7 +176,7 @@ export default {
 	},
 	methods: {
 		truncateClasses(entry) {
-			// dont truncate numeric values
+			// don't truncate numeric values
 			return typeof entry.value === "string"
 				? "overflow-hidden text-truncate"
 				: "text-nowrap flex-shrink-0";

--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -10,7 +10,7 @@
 				<div class="label overflow-hidden text-truncate flex-shrink-1 flex-grow-1">
 					{{ $t(`config.deviceValue.${entry.name}`) }}
 				</div>
-				<div class="value overflow-hidden text-truncate" :class="valueClasses(entry)">
+				<div class="value" :class="[valueClasses(entry), truncateClasses(entry)]">
 					{{ fmtDeviceValue(entry) }}
 				</div>
 			</span>
@@ -175,6 +175,12 @@ export default {
 		},
 	},
 	methods: {
+		truncateClasses(entry) {
+			// dont truncate numeric values
+			return typeof entry.value === "string"
+				? "overflow-hidden text-truncate"
+				: "text-nowrap flex-shrink-0";
+		},
 		valueClasses(entry) {
 			if (entry.error) {
 				return "value--error";

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,4 +3,9 @@ export default {
   printWidth: 100,
   trailingComma: "es5",
   plugins: ["prettier-plugin-sh"],
+  // mirror .editorconfig for editors that resolve prettier config without it (e.g. Zed)
+  overrides: [
+    { files: ["*.vue", "*.sh"], options: { useTabs: true, tabWidth: 4 } },
+    { files: "*.css", options: { useTabs: true, tabWidth: 2 } },
+  ],
 };


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/30523

Prevent CSS truncation of numeric values when space is tight. In this case value wins and label has to give. For text values (hostnames, ...) we stick to the 50/50 truncation rule.

<img width="369" height="313" alt="Bildschirmfoto 2026-06-05 um 11 22 52" src="https://github.com/user-attachments/assets/9eb852ba-81fb-4f59-9c88-cfb09353cc66" />
