### PR TITLE
Charger (Plugchoice): trim whitespace before parsing values

### DIFF
--- a/charger/plugchoice.go
+++ b/charger/plugchoice.go
@@ -247,12 +247,15 @@ func (c *Plugchoice) CurrentPower() (float64, error) {
 		return 0, err
 	}
 
+	// the API may return values with surrounding whitespace (e.g. " 0.0")
+	kwVal := strings.TrimSpace(res.KW)
+
 	// Handle the case where power value is "-"
-	if res.KW == "-" {
+	if kwVal == "-" {
 		return 0, nil
 	}
 
-	kw, err := strconv.ParseFloat(res.KW, 64)
+	kw, err := strconv.ParseFloat(kwVal, 64)
 	if err != nil {
 		return 0, err
 	}
@@ -271,6 +274,8 @@ func (c *Plugchoice) Currents() (float64, float64, float64, error) {
 
 	// Helper function to parse current values, handling "-" as 0
 	parsePhaseValue := func(val string, phase string) (float64, error) {
+		// the API may return values with surrounding whitespace (e.g. " 0.0")
+		val = strings.TrimSpace(val)
 		if val == "-" {
 			return 0, nil
 		}


### PR DESCRIPTION
fixes #30550

The Plugchoice API returns numeric values with a leading space (e.g. `" 0.0"`), which `strconv.ParseFloat` rejects. This flooded the log with phase current parse errors on every polling cycle (seen with a SolarEdge EV Charger Pro).

- trim surrounding whitespace before parsing phase currents and power, so the `"-"` sentinel and float values are handled regardless of padding