### PR TITLE
chore: fix flaky pv meter and soc range tests

### DIFF
--- a/assets/js/components/Helper/GenericModal.vue
+++ b/assets/js/components/Helper/GenericModal.vue
@@ -96,8 +96,12 @@ export default defineComponent({
 			this.$emit("opened");
 			if (this.autofocus) {
 				this.$nextTick(() => {
-					const firstInput =
-						this.$refs["modalBody"]?.querySelector("input, select, button");
+					const modalBody = this.$refs["modalBody"];
+					// don't steal focus if user already interacts with the modal content
+					if (modalBody?.contains(document.activeElement)) {
+						return;
+					}
+					const firstInput = modalBody?.querySelector("input, select, button");
 					if (firstInput instanceof HTMLElement) {
 						firstInput.focus();
 					}

--- a/tests/simulator.ts
+++ b/tests/simulator.ts
@@ -49,7 +49,8 @@ export function simulatorConfig() {
   const input = "./tests/simulator.evcc.yaml";
   const content = fs.readFileSync(input, "utf8");
   const result = content.replace(/localhost:7072/g, simulatorHost());
-  const resultName = "simulator.evcc.generated.yaml";
+  // per-worker file name, multiple workers write their own port concurrently
+  const resultName = `simulator-${workerPort()}.evcc.generated.yaml`;
   const resultPath = path.join(os.tmpdir(), resultName);
   fs.writeFileSync(resultPath, result);
   return resultPath;


### PR DESCRIPTION
follow-up to #30567

Stabilizes two flaky Playwright tests. Both failures were real races, not too-tight timings.

- meter modal: delayed Bootstrap `shown` event stole focus while typing, power value ended up in the title field. Autofocus now skipped when focus is already inside the modal (config-pv)
- simulator: generated evcc config is now written per worker. Parallel workers overwrote the shared file and evcc started against another worker's simulator port (session-soc)