### PR TITLE
aa55 udp: dedupe concurrent block reads with single flight

### DIFF
--- a/plugin/aa55/aa55_test.go
+++ b/plugin/aa55/aa55_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"math"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -318,6 +320,63 @@ func TestCache_PutGet(t *testing.T) {
 	got, ok := c.get([]byte("k"))
 	require.True(t, ok)
 	assert.Equal(t, []byte{1, 2, 3}, got)
+}
+
+// TestCache_FetchSingleFlight verifies that concurrent fetches for the same key
+// collapse into a single load (one UDP exchange), all observe the same payload,
+// and the cache is left warm for subsequent reads.
+func TestCache_FetchSingleFlight(t *testing.T) {
+	c := newResponseCache()
+	key := []byte("10.0.0.1:8899/f703891c007d")
+	want := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	var calls atomic.Int32
+	var once sync.Once
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	load := func() ([]byte, error) {
+		calls.Add(1)
+		once.Do(func() { close(entered) })
+		<-release // hold the flight open while followers pile up
+		return want, nil
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	payloads := make([][]byte, n)
+
+	wg.Go(func() {
+		got, _, err := c.fetch(key, load)
+		assert.NoError(t, err)
+		payloads[0] = got
+	})
+
+	<-entered // ensure the flight is open before followers join
+
+	for i := 1; i < n; i++ {
+		wg.Go(func() {
+			got, _, err := c.fetch(key, load)
+			assert.NoError(t, err)
+			payloads[i] = got
+		})
+	}
+
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load(), "concurrent reads of the same block must share one exchange")
+	for i := range n {
+		assert.Equal(t, want, payloads[i])
+	}
+
+	// cache is now warm: a subsequent read hits without loading again
+	got, hit, err := c.fetch(key, func() ([]byte, error) {
+		t.Fatal("must not load on warm cache")
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, hit)
+	assert.Equal(t, want, got)
 }
 
 // ---------------------------------------------------------------------------

--- a/plugin/aa55/aa55_test.go
+++ b/plugin/aa55/aa55_test.go
@@ -370,12 +370,12 @@ func TestCache_FetchSingleFlight(t *testing.T) {
 	}
 
 	// cache is now warm: a subsequent read hits without loading again
-	got, hit, err := c.fetch(key, func() ([]byte, error) {
+	got, ok, err := c.fetch(key, func() ([]byte, error) {
 		t.Fatal("must not load on warm cache")
 		return nil, nil
 	})
 	require.NoError(t, err)
-	assert.True(t, hit)
+	assert.True(t, ok)
 	assert.Equal(t, want, got)
 }
 

--- a/plugin/aa55/aa55udp.go
+++ b/plugin/aa55/aa55udp.go
@@ -127,30 +127,36 @@ func (p *AA55UDP) query() (float64, error) {
 	return v * p.scale, nil
 }
 
-// fetch returns the response payload, using caching for block-read mode.
+// fetch returns the response payload. In block-read mode the shared cache
+// serves and de-duplicates requests: concurrent sources for the same
+// (host, pdu) share a single UDP exchange via single flight rather than each
+// issuing its own request.
 func (p *AA55UDP) fetch() ([]byte, error) {
-	if p.cacheKey != nil {
-		if payload, ok := cache.get(p.cacheKey); ok {
-			p.log.TRACE.Printf("cache hit for %s pdu=%x", p.conn.RemoteAddr(), p.pdu)
-			return payload, nil
-		}
+	// Register mode: single targeted read, no caching.
+	if p.cacheKey == nil {
+		return p.exchange()
 	}
 
+	payload, hit, err := cache.fetch(p.cacheKey, p.exchange)
+	if err != nil {
+		return nil, err
+	}
+	if hit {
+		p.log.TRACE.Printf("cache hit for %s pdu=%x", p.conn.RemoteAddr(), p.pdu)
+	}
+	return payload, nil
+}
+
+// exchange performs one request/response round trip and returns the response
+// payload with the AA55 header stripped. It is the cache-miss path shared by
+// single flight in block-read mode.
+func (p *AA55UDP) exchange() ([]byte, error) {
 	packet := append(p.pdu, modbusCRC16(p.pdu)...)
 	raw, err := p.sendRecv(packet)
 	if err != nil {
 		return nil, err
 	}
-
-	payload, err := stripHeader(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	if p.cacheKey != nil {
-		cache.put(p.cacheKey, payload)
-	}
-	return payload, nil
+	return stripHeader(raw)
 }
 
 // sendRecv sends packet over p.conn and returns the raw response bytes.

--- a/plugin/aa55/aa55udp.go
+++ b/plugin/aa55/aa55udp.go
@@ -135,11 +135,11 @@ func (p *AA55UDP) fetch() ([]byte, error) {
 		return p.exchange()
 	}
 
-	payload, hit, err := cache.fetch(p.cacheKey, p.exchange)
+	payload, ok, err := cache.fetch(p.cacheKey, p.exchange)
 	if err != nil {
 		return nil, err
 	}
-	if hit {
+	if ok {
 		p.log.TRACE.Printf("cache hit for %s pdu=%x", p.conn.RemoteAddr(), p.pdu)
 	}
 	return payload, nil

--- a/plugin/aa55/aa55udp.go
+++ b/plugin/aa55/aa55udp.go
@@ -128,9 +128,7 @@ func (p *AA55UDP) query() (float64, error) {
 }
 
 // fetch returns the response payload. In block-read mode the shared cache
-// serves and de-duplicates requests: concurrent sources for the same
-// (host, pdu) share a single UDP exchange via single flight rather than each
-// issuing its own request.
+// serves and de-duplicates requests.
 func (p *AA55UDP) fetch() ([]byte, error) {
 	// Register mode: single targeted read, no caching.
 	if p.cacheKey == nil {

--- a/plugin/aa55/cache.go
+++ b/plugin/aa55/cache.go
@@ -3,6 +3,8 @@ package aa55
 import (
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 const cacheTTL = 2 * time.Second
@@ -23,12 +25,43 @@ type cacheEntry struct {
 }
 
 type responseCache struct {
-	mu   sync.Mutex
-	data map[string]cacheEntry
+	mu     sync.Mutex
+	data   map[string]cacheEntry
+	flight singleflight.Group
 }
 
 func newResponseCache() *responseCache {
 	return &responseCache{data: make(map[string]cacheEntry)}
+}
+
+// fetch returns the cached payload for key if it is fresh. On a miss, load is
+// invoked exactly once across all concurrent callers sharing the same key
+// (single flight); the result is cached and returned to every caller. This
+// collapses the cache-miss stampede at the start of each poll cycle, where
+// several source blocks for the same (host, pdu) all miss simultaneously,
+// into a single UDP exchange. The returned bool reports a fresh cache hit.
+func (c *responseCache) fetch(key []byte, load func() ([]byte, error)) ([]byte, bool, error) {
+	if payload, ok := c.get(key); ok {
+		return payload, true, nil
+	}
+
+	payload, err, _ := c.flight.Do(string(key), func() (any, error) {
+		// re-check under the flight: a prior flight may have populated the
+		// cache between our miss above and acquiring the call.
+		if payload, ok := c.get(key); ok {
+			return payload, nil
+		}
+		payload, err := load()
+		if err != nil {
+			return nil, err
+		}
+		c.put(key, payload)
+		return payload, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return payload.([]byte), false, nil
 }
 
 // get returns the cached payload if it exists and is fresh, or (nil, false)

--- a/plugin/aa55/cache.go
+++ b/plugin/aa55/cache.go
@@ -35,11 +35,7 @@ func newResponseCache() *responseCache {
 }
 
 // fetch returns the cached payload for key if it is fresh. On a miss, load is
-// invoked exactly once across all concurrent callers sharing the same key
-// (single flight); the result is cached and returned to every caller. This
-// collapses the cache-miss stampede at the start of each poll cycle, where
-// several source blocks for the same (host, pdu) all miss simultaneously,
-// into a single UDP exchange. The returned bool reports a fresh cache hit.
+// invoked exactly once across all concurrent callers sharing the same key.
 func (c *responseCache) fetch(key []byte, load func() ([]byte, error)) ([]byte, bool, error) {
 	if payload, ok := c.get(key); ok {
 		return payload, true, nil


### PR DESCRIPTION
follow-up to #29095

The block-read cache added in #29095 de-duplicates requests by TTL but not under concurrency. The shared cache only guards its map operations, so the gap between the cache check and the UDP send is unprotected. At the start of each poll cycle the sources for one block all miss the cache at the same time and each issues its own request. Field traces on a GoodWe ET show the same block read going out two to three times within the same second before the first response populates the cache, after which the rest of the cycle resolves as cache hits.

This routes the cache-miss path through `singleflight`, so concurrent readers of the same `(host, pdu)` share a single UDP exchange instead of each sending their own. It addresses the residual point left open in #29095 ("impose a delay between sending messages") without slowing the poll the way a fixed inter-message delay would.

- collapse the per-cycle stampede to one request per block
- later same-cycle reads still hit the warm cache, so traffic stays minimal
- add a concurrency test asserting N simultaneous reads trigger a single exchange
