### PR TITLE
chore: fix flaky OCPP test bind on fixed port 8887

### DIFF
--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -28,8 +28,17 @@ var (
 	once        sync.Once
 	instance    *CS
 	port        = 8887
+	boundPort   int
 	externalUrl string
 )
+
+// Port returns the TCP port the central system is bound to. With the default
+// configuration this equals the configured port; when port 0 is configured
+// (as in tests) it is the OS-assigned ephemeral port. It returns 0 while the
+// server is not bound.
+func Port() int {
+	return boundPort
+}
 
 // GetStatus returns the OCPP runtime status
 func GetStatus() Status {
@@ -111,6 +120,8 @@ func Instance() *CS {
 				return
 			}
 		}
+
+		boundPort = server.Addr().Port
 	})
 
 	return instance

--- a/charger/ocpp/instance_test.go
+++ b/charger/ocpp/instance_test.go
@@ -1,8 +1,17 @@
 package ocpp
 
 import (
+	"os"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	// bind the central system to an ephemeral port so this test binary does not
+	// contend with the charger package test binary for the fixed default port
+	// when both run in parallel under `go test ./...`
+	Init(Config{Port: 0}, "")
+	os.Exit(m.Run())
+}
 
 func TestExternalUrl(t *testing.T) {
 	tests := []struct{ input, expected string }{

--- a/charger/ocpp_test.go
+++ b/charger/ocpp_test.go
@@ -2,6 +2,8 @@ package charger
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -22,10 +24,20 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	ocppTestUrl            = "ws://localhost:8887"
-	ocppTestConnectTimeout = 10 * time.Second
-)
+const ocppTestConnectTimeout = 10 * time.Second
+
+// ocppTestUrl is derived from the actual bound port in SetupSuite: the central
+// system binds an ephemeral port to avoid bind failures when the fixed default
+// port is already in use on the CI runner.
+var ocppTestUrl string
+
+func TestMain(m *testing.M) {
+	// bind the OCPP central system to an ephemeral port so this test binary
+	// does not contend with the charger/ocpp package test binary for the fixed
+	// default port when both run in parallel under `go test ./...`
+	ocpp.Init(ocpp.Config{Port: 0}, "")
+	os.Exit(m.Run())
+}
 
 func TestOcpp(t *testing.T) {
 	suite.Run(t, new(ocppTestSuite))
@@ -48,6 +60,9 @@ func (suite *ocppTestSuite) SetupSuite() {
 	_ = ocpp.Instance()
 	suite.logger = &ocppLogger{t: suite.T()}
 	ocppj.SetLogger(suite.logger)
+
+	suite.Require().NotZero(ocpp.Port(), "central system did not bind")
+	ocppTestUrl = fmt.Sprintf("ws://localhost:%d", ocpp.Port())
 
 	suite.clock = clock.NewMock()
 	suite.NotNil(ocpp.Instance())


### PR DESCRIPTION
Fixes the recurring `TestOcpp` flake where the central system reports `timeout waiting for server to bind` and every OCPP subtest then fails with connection errors, for example https://github.com/evcc-io/evcc/actions/runs/27082987465/job/79932150669.

Both the `charger` and `charger/ocpp` package test binaries call `ocpp.Instance()`, which binds the central system to the fixed default port 8887. Under `go test ./...` the two binaries run in parallel and race for that port. Whichever binds second fails with `EADDRINUSE`; in the fork's `server.Start` the listener error leaves the server address unset, so `Instance()` blocks for its full 10s bind timeout and returns a non-functional server. This is unrelated to the code under test, so it flakes any PR.

Both test binaries now bind an ephemeral port via `TestMain`, and the charge point connect URL is derived from the actual bound port (newly exposed via `ocpp.Port()`). The fixed port is gone from the test path, so the binaries can no longer contend.

- add `ocpp.Port()` returning the actual bound port
- bind port 0 in both `charger` and `charger/ocpp` test binaries
- derive the test connect URL from the bound port instead of hardcoding 8887
