### PR TITLE
Metrics: ignore spurious backward meter totals

### DIFF
--- a/core/metrics/accumulator.go
+++ b/core/metrics/accumulator.go
@@ -62,34 +62,42 @@ func (m *Accumulator) Exported() float64 {
 
 // SetImportMeterTotal adds the difference to the last total meter value in kWh
 func (m *Accumulator) SetImportMeterTotal(v float64) {
-	defer func() {
-		m.updated = m.clock.Now()
-		m.importMeter = new(v)
-	}()
+	defer func() { m.updated = m.clock.Now() }()
 
 	if m.importMeter == nil {
+		m.importMeter = new(v)
 		return
 	}
 
-	if v >= *m.importMeter {
-		m.Energy += v - *m.importMeter
+	// A cumulative energy counter cannot run backwards. Ignore spurious drops
+	// (e.g. a momentary zero while the meter times out or restarts) without
+	// rebasing the last value, so the recovery to the real total is not counted
+	// as one huge spike. https://github.com/evcc-io/evcc/discussions/30555
+	if v < *m.importMeter {
+		return
 	}
+
+	m.Energy += v - *m.importMeter
+	m.importMeter = new(v)
 }
 
 // SetExportMeterTotal adds the difference to the last total meter value in kWh
 func (m *Accumulator) SetExportMeterTotal(v float64) {
-	defer func() {
-		m.updated = m.clock.Now()
-		m.exportMeter = new(v)
-	}()
+	defer func() { m.updated = m.clock.Now() }()
 
 	if m.exportMeter == nil {
+		m.exportMeter = new(v)
 		return
 	}
 
-	if v >= *m.exportMeter {
-		m.ReturnEnergy += v - *m.exportMeter
+	// see SetImportMeterTotal: ignore spurious backward values instead of
+	// rebasing, so a momentary drop does not produce a spike on recovery
+	if v < *m.exportMeter {
+		return
 	}
+
+	m.ReturnEnergy += v - *m.exportMeter
+	m.exportMeter = new(v)
 }
 
 // AddImportEnergy adds the given energy in kWh to the positive meter

--- a/core/metrics/accumulator_test.go
+++ b/core/metrics/accumulator_test.go
@@ -23,6 +23,83 @@ func TestMeterEnergyMeterTotal(t *testing.T) {
 	assert.Equal(t, 1.0, me.Imported())
 }
 
+// TestMeterEnergyMeterTotalIntermittentZero covers a grid meter that briefly
+// reports 0 (e.g. an inverter timeout/restart) before recovering to its real
+// cumulative value. The spurious drop must be ignored so the recovery is not
+// counted as a spike. https://github.com/evcc-io/evcc/discussions/30555
+func TestMeterEnergyMeterTotalIntermittentZero(t *testing.T) {
+	clock := clock.NewMock()
+	clock.Set(now.BeginningOfDay())
+
+	me := &Accumulator{clock: clock}
+
+	me.SetImportMeterTotal(13422.7)
+	assert.Equal(t, 0.0, me.Imported())
+
+	clock.Add(15 * time.Minute)
+	me.SetImportMeterTotal(13423.7)
+	assert.Equal(t, 1.0, me.Imported())
+
+	// meter drops out and reports 0 for one slot
+	clock.Add(15 * time.Minute)
+	me.SetImportMeterTotal(0)
+	assert.Equal(t, 1.0, me.Imported(), "spurious zero must not change energy")
+
+	// meter recovers: difference is taken against the last valid value, not 0
+	clock.Add(15 * time.Minute)
+	me.SetImportMeterTotal(13424.7)
+	assert.Equal(t, 2.0, me.Imported(), "recovery must not produce a spike")
+}
+
+// TestMeterEnergyExportMeterTotalIntermittentZero mirrors the import case for
+// the export meter total.
+func TestMeterEnergyExportMeterTotalIntermittentZero(t *testing.T) {
+	clock := clock.NewMock()
+	clock.Set(now.BeginningOfDay())
+
+	me := &Accumulator{clock: clock}
+
+	me.SetExportMeterTotal(500)
+	assert.Equal(t, 0.0, me.Exported())
+
+	me.SetExportMeterTotal(501)
+	assert.Equal(t, 1.0, me.Exported())
+
+	// spurious drop to 0 must be ignored, not rebased
+	me.SetExportMeterTotal(0)
+	assert.Equal(t, 1.0, me.Exported())
+
+	me.SetExportMeterTotal(502)
+	assert.Equal(t, 2.0, me.Exported())
+}
+
+// TestMeterEnergyAddPowerIntermittentZero verifies the power-integration path
+// is robust to a missing/zero intermediate reading: it simply adds no energy
+// for that interval rather than corrupting the accumulated total.
+func TestMeterEnergyAddPowerIntermittentZero(t *testing.T) {
+	clock := clock.NewMock()
+	clock.Set(now.BeginningOfDay())
+
+	me := &Accumulator{clock: clock}
+
+	clock.Add(60 * time.Minute)
+	me.AddPower(1e3)
+	assert.Equal(t, 0.0, me.Imported())
+
+	clock.Add(60 * time.Minute)
+	me.AddPower(1e3)
+	assert.Equal(t, 1.0, me.Imported())
+
+	// power reads 0 (missing value): no energy added for this interval
+	clock.Add(60 * time.Minute)
+	me.AddPower(0)
+	assert.Equal(t, 1.0, me.Imported())
+
+	clock.Add(60 * time.Minute)
+	me.AddPower(1e3)
+	assert.Equal(t, 2.0, me.Imported())
+}
+
 func TestMeterEnergyAddPower(t *testing.T) {
 	clock := clock.NewMock()
 	clock.Set(now.BeginningOfDay())


### PR DESCRIPTION
Addresses the grid history spikes reported in https://github.com/evcc-io/evcc/discussions/30555 (and the same symptom in #30474).

15-minute energy is derived from the difference of the cumulative meter total. When a meter briefly reports a value below the last one, e.g. a momentary `0` while it times out or restarts, the accumulator skipped the negative difference but still rebased its stored total to the spurious value. The recovery to the real total was then counted as one huge spike: the reporter saw a 53.7 MWh grid slot on a 5 kW system, which is exactly `4 × 13423.7 kWh` (the meter total, scaled from a 15-minute delta to an hourly rate).

A cumulative energy counter cannot run backwards, so values below the last valid one are now ignored without rebasing. The recovery is measured against the last valid total and produces no spike.

- ignore backward import/export meter totals instead of rebasing to them
- the read clock still advances, so power integration for the other direction is unaffected
- add tests for an intermittent zero on the import total, export total, and power-integration paths

Note: a genuine permanent meter reset (counter truly restarts at zero) would be ignored until it climbs back above the previous value. Real cumulative meters do not do this, and the alternative (rebasing on every drop) is what produced the spikes.
