### PR TITLE
Vehicle (SAIC/MG): fix missing SoC for idle vehicles

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1806,9 +1806,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 		var socErr error
 
 		if battery, ok := api.Cap[api.Battery](dev); ok {
-			soc, err := soc.Guard(battery.Soc())
-			socErr = err
-			if err == nil {
+			if soc, err := soc.Guard(battery.Soc()); err == nil {
 				socR = &soc
 
 				// don't publish here in case it needs be updated by the estimator
@@ -1825,8 +1823,12 @@ func (lp *Loadpoint) publishSocAndRange() {
 						lp.log.ERROR.Printf("%s soc limit: %v", typ, err)
 					}
 				}
-			} else if !loadpoint.AcceptableError(err) {
-				lp.log.ERROR.Printf("charger soc: %v", err)
+			} else {
+				socErr = err
+
+				if !loadpoint.AcceptableError(err) {
+					lp.log.ERROR.Printf("charger soc: %v", err)
+				}
 			}
 		}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1806,9 +1806,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 		var socErr error
 
 		if battery, ok := api.Cap[api.Battery](dev); ok {
-			soc, err := soc.Guard(battery.Soc())
-			socErr = err
-			if err == nil {
+			if soc, err := soc.Guard(battery.Soc()); err == nil {
 				socR = &soc
 
 				// don't publish here in case it needs be updated by the estimator
@@ -1826,6 +1824,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 					}
 				}
 			} else if !loadpoint.AcceptableError(err) {
+				socErr = err
 				lp.log.ERROR.Printf("charger soc: %v", err)
 			}
 		}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1806,7 +1806,9 @@ func (lp *Loadpoint) publishSocAndRange() {
 		var socErr error
 
 		if battery, ok := api.Cap[api.Battery](dev); ok {
-			if soc, err := soc.Guard(battery.Soc()); err == nil {
+			soc, err := soc.Guard(battery.Soc())
+			socErr = err
+			if err == nil {
 				socR = &soc
 
 				// don't publish here in case it needs be updated by the estimator
@@ -1824,7 +1826,6 @@ func (lp *Loadpoint) publishSocAndRange() {
 					}
 				}
 			} else if !loadpoint.AcceptableError(err) {
-				socErr = err
 				lp.log.ERROR.Printf("charger soc: %v", err)
 			}
 		}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1800,12 +1800,15 @@ func (lp *Loadpoint) publishSocAndRange() {
 	// https://github.com/evcc-io/evcc/issues/16180
 	socEstimator := lp.socEstimator
 
-	socAndLimit := func(typ string, dev any) (*float64, *int64) {
+	socAndLimit := func(typ string, dev any) (*float64, *int64, error) {
 		var socR *float64
 		var limitR *int64
+		var socErr error
 
 		if battery, ok := api.Cap[api.Battery](dev); ok {
-			if soc, err := soc.Guard(battery.Soc()); err == nil {
+			soc, err := soc.Guard(battery.Soc())
+			socErr = err
+			if err == nil {
 				socR = &soc
 
 				// don't publish here in case it needs be updated by the estimator
@@ -1827,13 +1830,19 @@ func (lp *Loadpoint) publishSocAndRange() {
 			}
 		}
 
-		return socR, limitR
+		return socR, limitR, socErr
 	}
 
-	socR, limitR := socAndLimit("charger", lp.charger)
+	socR, limitR, _ := socAndLimit("charger", lp.charger)
 	if socR == nil && (lp.vehicleSocPollAllowed() || lp.chargerHasFeature(api.IntegratedDevice)) {
-		lp.socUpdated = lp.clock.Now()
-		socR, limitR = socAndLimit("vehicle", lp.GetVehicle())
+		var socErr error
+		socR, limitR, socErr = socAndLimit("vehicle", lp.GetVehicle())
+
+		// keep polling async vehicle APIs that return ErrMustRetry until a SoC
+		// arrives, instead of waiting for the next interval
+		if !errors.Is(socErr, api.ErrMustRetry) {
+			lp.socUpdated = lp.clock.Now()
+		}
 
 		// range
 		if vs, ok := api.Cap[api.VehicleRange](lp.GetVehicle()); ok {

--- a/vehicle/saic/api.go
+++ b/vehicle/saic/api.go
@@ -70,7 +70,7 @@ func (v *API) doRepeatedRequest(path string, event_id string) error {
 		return err
 	}
 
-	req, err := requests.CreateRequest(
+	req, _ := requests.CreateRequest(
 		v.identity.baseUrl,
 		path,
 		http.MethodGet,
@@ -78,9 +78,6 @@ func (v *API) doRepeatedRequest(path string, event_id string) error {
 		request.JSONContent,
 		token.AccessToken,
 		event_id)
-	if err != nil {
-		return err
-	}
 
 	var res requests.Answer[requests.ChargeStatus]
 	if _, err = doRequest(v, req, &res); err == nil {
@@ -195,7 +192,7 @@ func (v *API) Status(vin string) (requests.ChargeStatus, error) {
 
 	path := "vehicle/charging/mgmtData?vin=" + requests.Sha256(vin)
 	// get charging status of vehicle
-	req, err := requests.CreateRequest(
+	req, _ := requests.CreateRequest(
 		v.identity.baseUrl,
 		path,
 		http.MethodGet,
@@ -203,9 +200,6 @@ func (v *API) Status(vin string) (requests.ChargeStatus, error) {
 		request.JSONContent,
 		token.AccessToken,
 		"")
-	if err != nil {
-		return zero, err
-	}
 
 	var res requests.Answer[requests.ChargeStatus]
 	event_id, err := doRequest(v, req, &res)
@@ -218,7 +212,7 @@ func (v *API) Status(vin string) (requests.ChargeStatus, error) {
 		return v.last()
 	}
 
-	req, err = requests.CreateRequest(
+	req, _ = requests.CreateRequest(
 		v.identity.baseUrl,
 		path,
 		http.MethodGet,
@@ -226,9 +220,6 @@ func (v *API) Status(vin string) (requests.ChargeStatus, error) {
 		request.JSONContent,
 		token.AccessToken,
 		event_id)
-	if err != nil {
-		return zero, err
-	}
 
 	// answer not yet available, keep polling in the background
 	if _, err = doRequest(v, req, &res); err == api.ErrMustRetry {

--- a/vehicle/saic/api.go
+++ b/vehicle/saic/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -14,27 +15,20 @@ import (
 )
 
 const (
-	StatRunning = iota
-	StatValid
-	StatInvalid
-)
-
-const (
 	RegionEU = "https://gateway-mg-eu.soimt.com/api.app/v1/"
 	RegionAU = "https://gateway-mg-au.soimt.com/api.app/v1/"
 )
-
-type ConcurrentRequest struct {
-	Status int
-	Result requests.ChargeStatus
-}
 
 // API is an api.Vehicle implementation for SAIC cars
 type API struct {
 	*request.Helper
 	identity *Identity
-	request  ConcurrentRequest
 	log      *util.Logger
+
+	mu      sync.Mutex
+	running bool                  // background refresh in progress
+	valid   bool                  // result holds a valid response
+	result  requests.ChargeStatus // last valid response
 }
 
 // NewAPI creates a new vehicle
@@ -49,15 +43,30 @@ func NewAPI(log *util.Logger, identity *Identity) *API {
 		Decorator: requests.Decorate,
 		Base:      v.Client.Transport,
 	}
-	v.request.Status = StatInvalid
 
 	return v
+}
+
+// store saves a valid response and clears the running flag
+func (v *API) store(res requests.ChargeStatus) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.result, v.valid, v.running = res, true, false
+}
+
+// last returns the last valid response, or ErrMustRetry until one is available
+func (v *API) last() (requests.ChargeStatus, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.valid {
+		return v.result, nil
+	}
+	return v.result, api.ErrMustRetry
 }
 
 func (v *API) doRepeatedRequest(path string, event_id string) error {
 	token, err := v.identity.Token()
 	if err != nil {
-		v.request.Status = StatInvalid
 		return err
 	}
 
@@ -70,39 +79,31 @@ func (v *API) doRepeatedRequest(path string, event_id string) error {
 		token.AccessToken,
 		event_id)
 	if err != nil {
-		v.request.Status = StatInvalid
 		return err
 	}
 
 	var res requests.Answer[requests.ChargeStatus]
-	_, err = doRequest(v, req, &res)
-	if err == nil {
-		v.request = ConcurrentRequest{
-			Status: StatValid,
-			Result: res.Data,
-		}
-	} else if err != api.ErrMustRetry {
-		v.request.Status = StatInvalid
+	if _, err = doRequest(v, req, &res); err == nil {
+		v.store(res.Data)
 	}
 	return err
 }
 
-// This is running concurrently
+// repeatRequest polls for the deferred answer in the background
 func (v *API) repeatRequest(path string, event_id string) {
-	var count int
+	// always clear running so a future query can start
+	defer func() {
+		v.mu.Lock()
+		v.running = false
+		v.mu.Unlock()
+	}()
 
-	v.request.Status = StatRunning
-	for err := api.ErrMustRetry; err == api.ErrMustRetry && count < 20; {
+	for count := range 20 {
 		time.Sleep(2 * time.Second)
-		v.log.TRACE.Printf("Starting repeated query. Count: %d", count)
-		err = v.doRepeatedRequest(path, event_id)
-		count++
-	}
-
-	// Make sure that we don't exit here with status running (probably after 20 tries).
-	// This would not allow us to ever do a query again.
-	if v.request.Status == StatRunning {
-		v.request.Status = StatInvalid
+		v.log.TRACE.Printf("repeated query %d", count)
+		if err := v.doRepeatedRequest(path, event_id); err != api.ErrMustRetry {
+			return
+		}
 	}
 }
 
@@ -178,18 +179,14 @@ func (v *API) Wakeup(vin string) error {
 func (v *API) Status(vin string) (requests.ChargeStatus, error) {
 	var zero requests.ChargeStatus
 
-	// Check if we are already running in the background
-	if v.request.Status == StatValid {
-		v.request.Status = StatInvalid
-		v.log.TRACE.Printf("StatValid. Returning stored value")
-		// v.printAnswer()
-		return v.request.Result, nil
+	// refresh in progress, return last known value
+	v.mu.Lock()
+	running := v.running
+	v.mu.Unlock()
+	if running {
+		v.log.TRACE.Printf("query running")
+		return v.last()
 	}
-	if v.request.Status == StatRunning {
-		v.log.TRACE.Printf("StatRunning. Exiting")
-		return zero, api.ErrMustRetry
-	}
-	v.log.TRACE.Printf("StatInvalid. Starting query")
 
 	token, err := v.identity.Token()
 	if err != nil {
@@ -217,8 +214,8 @@ func (v *API) Status(vin string) (requests.ChargeStatus, error) {
 	}
 
 	if event_id == "" {
-		v.log.TRACE.Printf("Answer without event ID")
-		return zero, api.ErrMustRetry
+		v.log.TRACE.Printf("answer without event id")
+		return v.last()
 	}
 
 	req, err = requests.CreateRequest(
@@ -233,14 +230,18 @@ func (v *API) Status(vin string) (requests.ChargeStatus, error) {
 		return zero, err
 	}
 
-	_, err = doRequest(v, req, &res)
-
-	// Continue checking....
-	if err == api.ErrMustRetry {
-		v.request.Status = StatRunning
-		v.log.TRACE.Printf(" No answer yet. Continue status query in background")
+	// answer not yet available, keep polling in the background
+	if _, err = doRequest(v, req, &res); err == api.ErrMustRetry {
+		v.mu.Lock()
+		v.running = true
+		v.mu.Unlock()
+		v.log.TRACE.Printf("no answer yet, continuing in background")
 		go v.repeatRequest(path, event_id)
+		return v.last()
+	} else if err != nil {
+		return zero, err
 	}
 
-	return res.Data, err
+	v.store(res.Data)
+	return res.Data, nil
 }


### PR DESCRIPTION
fixes #30597

The MG/SAIC backend delivers the SoC asynchronously: the first request only returns an event id and the value arrives after several seconds of background polling. The loadpoint marked the vehicle as polled even when that first call returned ErrMustRetry, so for a connected but idle car (default poll mode) it never polled again and the value the background poller eventually fetched was discarded. The result was a permanent "--" SoC although the log shows the data being retrieved.

- Loadpoint: only set socUpdated once a SoC was actually read, so vehicles returning ErrMustRetry keep being polled until a value arrives
- SAIC/MG: retain the last known response and keep serving it between refreshes instead of discarding it after a single read
- SAIC/MG: guard the shared request state with a mutex to fix the data race between the foreground request and the background poller