### PR TITLE
Metrics: don't double-count energy after a failed meter read

### DIFF
--- a/core/metrics/collector.go
+++ b/core/metrics/collector.go
@@ -118,27 +118,32 @@ func (c *Collector) SetReturnEnergyMeterTotal(v float64) error {
 	})
 }
 
-// AddEnergy adds energy using meter totals if available, falling back to power integration.
+// AddEnergy adds energy using meter totals if available, falling back to power
+// integration only for directions without an energy meter. A direction that has
+// reported a total before keeps using meter deltas even if a single read fails,
+// so a transient failure is recovered via the next delta and not double-counted.
 func (c *Collector) AddEnergy(energyTotal, returnEnergyTotal *float64, power float64) error {
 	return c.process(func() {
-		switch {
-		case energyTotal != nil && returnEnergyTotal != nil:
-			c.accu.SetEnergyMeterTotal(*energyTotal)
-			c.accu.SetReturnEnergyMeterTotal(*returnEnergyTotal)
-		case energyTotal != nil:
-			// return energy via power integration (before meter updates clock)
-			if power < 0 {
+		// a direction that ever reported a total is metered, so a nil read is a
+		// transient failure rather than a power-only meter
+		hasEnergyMeter := energyTotal != nil || c.accu.energyMeter != nil
+		hasReturnMeter := returnEnergyTotal != nil || c.accu.returnEnergyMeter != nil
+
+		// integrate power for the unmetered direction first, since applying a
+		// meter total advances the accumulator clock
+		if power >= 0 {
+			if !hasEnergyMeter {
 				c.accu.AddPower(power)
 			}
-			c.accu.SetEnergyMeterTotal(*energyTotal)
-		case returnEnergyTotal != nil:
-			// energy via power integration (before meter updates clock)
-			if power >= 0 {
-				c.accu.AddPower(power)
-			}
-			c.accu.SetReturnEnergyMeterTotal(*returnEnergyTotal)
-		default:
+		} else if !hasReturnMeter {
 			c.accu.AddPower(power)
+		}
+
+		if energyTotal != nil {
+			c.accu.SetEnergyMeterTotal(*energyTotal)
+		}
+		if returnEnergyTotal != nil {
+			c.accu.SetReturnEnergyMeterTotal(*returnEnergyTotal)
 		}
 	})
 }

--- a/core/metrics/collector_test.go
+++ b/core/metrics/collector_test.go
@@ -155,6 +155,80 @@ func TestCollectorSetEnergyAndReturnEnergyMeterTotal(t *testing.T) {
 	require.InDelta(t, 0.7, col.accu.ReturnEnergy, 1e-10)
 }
 
+// TestCollectorRecoversAfterFullMeterFailure verifies that a meter whose power
+// AND energy reads both fail for one cycle (collectMeters then passes power 0
+// and a nil energy total) recovers cleanly: the meter delta on the next good
+// read covers the gap and nothing is double-counted.
+func TestCollectorRecoversAfterFullMeterFailure(t *testing.T) {
+	clock := clock.NewMock()
+
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	col, err := NewCollector("full-fail", "full-fail", "", WithClock(clock))
+	require.NoError(t, err)
+
+	// seed energy meter at 10 kWh, constant 1 kW
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(new(10.0), nil, 1e3))
+	require.Equal(t, 0.0, col.accu.Energy)
+
+	// good read: meter advanced 0.05 kWh (3 min @ 1 kW)
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(new(10.05), nil, 1e3))
+	require.InDelta(t, 0.05, col.accu.Energy, 1e-9)
+
+	// both reads fail: power 0, energy nil -> AddPower(0) contributes nothing
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(nil, nil, 0))
+
+	// recovered read: meter advanced to 10.15 (real 0.10 kWh since last good read)
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(new(10.15), nil, 1e3))
+
+	// 9 min @ 1 kW = 0.15 kWh delivered; meter 10.00 -> 10.15 = 0.15 kWh
+	require.InDelta(t, 0.15, col.accu.Energy, 1e-9)
+}
+
+// TestCollectorRecoversAfterFailedEnergyRead verifies energy accounting when a
+// meter's energy total read fails for one cycle while power keeps reporting
+// (collectMeters passes a nil energy total but a valid power). A metered
+// direction skips power integration on the failed read and recovers the gap via
+// the next meter delta, so the failed interval is not double-counted.
+func TestCollectorRecoversAfterFailedEnergyRead(t *testing.T) {
+	clock := clock.NewMock()
+
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	col, err := NewCollector("energy-fail", "energy-fail", "", WithClock(clock))
+	require.NoError(t, err)
+
+	// seed energy meter at 10 kWh, constant 1 kW
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(new(10.0), nil, 1e3))
+	require.Equal(t, 0.0, col.accu.Energy)
+
+	// good read: meter advanced 0.05 kWh (3 min @ 1 kW)
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(new(10.05), nil, 1e3))
+	require.InDelta(t, 0.05, col.accu.Energy, 1e-9)
+
+	// energy read fails (nil) while power is still reported: the gap is not
+	// power-integrated because the meter has reported a total before
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(nil, nil, 1e3))
+	require.InDelta(t, 0.05, col.accu.Energy, 1e-9)
+
+	// recovered read: meter advanced to 10.15 (real 0.10 kWh since last good read)
+	clock.Add(3 * time.Minute)
+	require.NoError(t, col.AddEnergy(new(10.15), nil, 1e3))
+
+	// 9 min @ 1 kW = 0.15 kWh delivered (meter 10.00 -> 10.15). The recovery
+	// delta (10.15 - 10.05) captures the gap exactly, without double-counting.
+	require.InDelta(t, 0.15, col.accu.Energy, 1e-9)
+}
+
 // TestCollectorSkipsPartialFirstSlot verifies that the first slot, joined
 // mid-way after (re)start, is not persisted as a full 15min slot.
 func TestCollectorSkipsPartialFirstSlot(t *testing.T) {


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/30721

A meter that reports energy totals but fails a single read had that interval counted twice: collectMeters passes a nil total on a failed read, so the collector fell back to power integration for the cycle, and the next good read then re-added the same interval via the meter delta (the baseline is only advanced on a successful read). Meters whose power and energy reads both fail recover cleanly; only the energy-read-failed-while-power-still-reports case was affected.

- Treat a direction that has ever reported a total as metered, and skip power integration on a nil read for that direction, recovering the gap from the next meter delta
- Add collector tests for both intermittent-failure cases (full meter failure recovers cleanly; energy-only read failure no longer double-counts)