### PR TITLE
Meter (Kostal Plenticore): read DC PV energy from register 1056

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -66,10 +66,13 @@ render: |
       {{- include "modbus" . | indent 4 }}
       value: 160:3:DCW # string 3
   energy:
-    source: sunspec
+    source: modbus
     {{- include "modbus" . | indent 2 }}
-    value: 103:WH # total yield
-    scale: 0.001
+    register:
+      address: 1056 # total DC PV energy (sum), Wh
+      type: holding
+      decode: float32s
+    scale: 0.001 # Wh -> kWh
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -60,10 +60,13 @@ render: |
       {{- include "modbus" . | indent 4 }}
       value: 160:3:DCW # string 3
   energy:
-    source: sunspec
+    source: modbus
     {{- include "modbus" . | indent 2 }}
-    value: 103:WH # total yield
-    scale: 0.001
+    register:
+      address: 1056 # total DC PV energy (sum), Wh
+      type: holding
+      decode: float32s
+    scale: 0.001 # Wh -> kWh
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}


### PR DESCRIPTION
replaces #29955

#29955 switched Kostal Plenticore PV energy from SunSpec 103:WH (AC yield, corrupted by battery charge/discharge) to 160:x:DCWH, but those DCWH registers read 0 on the Plenticore G3 hybrid and zeroed PV history (#30439), so it was reverted. This reads the true production energy from Kostal's proprietary holding register 1056 (total DC PV energy, sum) instead, which is both correct (DC production, unaffected by the battery) and populated on the G3.

- kostal-plenticore, kostal-plenticore-gen2: PV energy from Modbus register 1056 (float32s, Wh to kWh) instead of SunSpec 103:WH

Register suggested by @D4Ci0 in https://github.com/evcc-io/evcc/pull/29955#issuecomment-4643222385.