### PR TITLE
SolarEdge Hybrid: add battery energy metering support

### DIFF
--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -108,13 +108,6 @@ render: |
           address: 62836 # Battery 1 Instantaneous Power
           type: holding
           decode: float32nans
-  energy:
-    source: sunspec
-    {{- include "modbus" . | indent 2 }}
-    value:
-      - 101:WH
-      - 103:WH
-    scale: 0.001
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -133,6 +126,22 @@ render: |
       address: 0xE184 # Battery 1 State of Energy (SOE)
       type: holding
       decode: float32nans
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0xE176 # Battery 1 Lifetime Export Energy Counter (discharged)
+      type: holding
+      decode: uint64
+    scale: 0.001
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 0xE17A # Battery 1 Lifetime Import Energy Counter (charged)
+      type: holding
+      decode: uint64
+    scale: 0.001
   batterymode:
     source: watchdog
     timeout: {{ .watchdog }}


### PR DESCRIPTION
Introduce energy and return energy metrics for the battery using Modbus registers, enhancing energy monitoring capabilities.

Replaces https://github.com/evcc-io/evcc/pull/29955
Follow-up to https://github.com/evcc-io/evcc/pull/30607