### PR TITLE
Vehicle: add climaterdisabled feature

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -16,4 +16,5 @@ const (
 	Retryable                // vehicle
 	Streaming                // vehicle
 	WelcomeCharge            // vehicle
+	ClimaterDisabled         // vehicle - ignore climater state for charge control
 )

--- a/api/feature_enumer.go
+++ b/api/feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "CoarseCurrentIntegratedDeviceSwitchDeviceHeatingContinuousAverageCacheableOfflineRetryableStreamingWelcomeCharge"
+const _FeatureName = "CoarseCurrentIntegratedDeviceSwitchDeviceHeatingContinuousAverageCacheableOfflineRetryableStreamingWelcomeChargeClimaterDisabled"
 
-var _FeatureIndex = [...]uint8{0, 13, 29, 41, 48, 58, 65, 74, 81, 90, 99, 112}
+var _FeatureIndex = [...]uint8{0, 13, 29, 41, 48, 58, 65, 74, 81, 90, 99, 112, 128}
 
-const _FeatureLowerName = "coarsecurrentintegrateddeviceswitchdeviceheatingcontinuousaveragecacheableofflineretryablestreamingwelcomecharge"
+const _FeatureLowerName = "coarsecurrentintegrateddeviceswitchdeviceheatingcontinuousaveragecacheableofflineretryablestreamingwelcomechargeclimaterdisabled"
 
 func (i Feature) String() string {
 	i -= 1
@@ -36,33 +36,36 @@ func _FeatureNoOp() {
 	_ = x[Retryable-(9)]
 	_ = x[Streaming-(10)]
 	_ = x[WelcomeCharge-(11)]
+	_ = x[ClimaterDisabled-(12)]
 }
 
-var _FeatureValues = []Feature{CoarseCurrent, IntegratedDevice, SwitchDevice, Heating, Continuous, Average, Cacheable, Offline, Retryable, Streaming, WelcomeCharge}
+var _FeatureValues = []Feature{CoarseCurrent, IntegratedDevice, SwitchDevice, Heating, Continuous, Average, Cacheable, Offline, Retryable, Streaming, WelcomeCharge, ClimaterDisabled}
 
 var _FeatureNameToValueMap = map[string]Feature{
-	_FeatureName[0:13]:        CoarseCurrent,
-	_FeatureLowerName[0:13]:   CoarseCurrent,
-	_FeatureName[13:29]:       IntegratedDevice,
-	_FeatureLowerName[13:29]:  IntegratedDevice,
-	_FeatureName[29:41]:       SwitchDevice,
-	_FeatureLowerName[29:41]:  SwitchDevice,
-	_FeatureName[41:48]:       Heating,
-	_FeatureLowerName[41:48]:  Heating,
-	_FeatureName[48:58]:       Continuous,
-	_FeatureLowerName[48:58]:  Continuous,
-	_FeatureName[58:65]:       Average,
-	_FeatureLowerName[58:65]:  Average,
-	_FeatureName[65:74]:       Cacheable,
-	_FeatureLowerName[65:74]:  Cacheable,
-	_FeatureName[74:81]:       Offline,
-	_FeatureLowerName[74:81]:  Offline,
-	_FeatureName[81:90]:       Retryable,
-	_FeatureLowerName[81:90]:  Retryable,
-	_FeatureName[90:99]:       Streaming,
-	_FeatureLowerName[90:99]:  Streaming,
-	_FeatureName[99:112]:      WelcomeCharge,
-	_FeatureLowerName[99:112]: WelcomeCharge,
+	_FeatureName[0:13]:         CoarseCurrent,
+	_FeatureLowerName[0:13]:    CoarseCurrent,
+	_FeatureName[13:29]:        IntegratedDevice,
+	_FeatureLowerName[13:29]:   IntegratedDevice,
+	_FeatureName[29:41]:        SwitchDevice,
+	_FeatureLowerName[29:41]:   SwitchDevice,
+	_FeatureName[41:48]:        Heating,
+	_FeatureLowerName[41:48]:   Heating,
+	_FeatureName[48:58]:        Continuous,
+	_FeatureLowerName[48:58]:   Continuous,
+	_FeatureName[58:65]:        Average,
+	_FeatureLowerName[58:65]:   Average,
+	_FeatureName[65:74]:        Cacheable,
+	_FeatureLowerName[65:74]:   Cacheable,
+	_FeatureName[74:81]:        Offline,
+	_FeatureLowerName[74:81]:   Offline,
+	_FeatureName[81:90]:        Retryable,
+	_FeatureLowerName[81:90]:   Retryable,
+	_FeatureName[90:99]:        Streaming,
+	_FeatureLowerName[90:99]:   Streaming,
+	_FeatureName[99:112]:       WelcomeCharge,
+	_FeatureLowerName[99:112]:  WelcomeCharge,
+	_FeatureName[112:128]:      ClimaterDisabled,
+	_FeatureLowerName[112:128]: ClimaterDisabled,
 }
 
 var _FeatureNames = []string{
@@ -77,6 +80,7 @@ var _FeatureNames = []string{
 	_FeatureName[81:90],
 	_FeatureName[90:99],
 	_FeatureName[99:112],
+	_FeatureName[112:128],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -361,6 +361,11 @@ func (lp *Loadpoint) vehicleSocPollAllowed() bool {
 
 // vehicleClimateActive checks if vehicle has active climate request
 func (lp *Loadpoint) vehicleClimateActive() bool {
+	// skip climater detection entirely if the vehicle opts out
+	if lp.vehicleHasFeature(api.ClimaterDisabled) {
+		return false
+	}
+
 	if cl, ok := api.Cap[api.VehicleClimater](lp.GetVehicle()); ok && lp.vehicleClimatePollAllowed() {
 		active, err := cl.Climater()
 		if err == nil {

--- a/templates/definition/vehicle/aiways.yaml
+++ b/templates/definition/vehicle/aiways.yaml
@@ -3,8 +3,10 @@ products:
   - brand: Aiways
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - name: vin
     required: true
 render: |
   type: aiways
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/carwings.yaml
+++ b/templates/definition/vehicle/carwings.yaml
@@ -5,6 +5,8 @@ products:
       generic: Leaf (pre 2019)
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
 render: |
   type: carwings
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -9,6 +9,7 @@ requirements:
       Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: password
@@ -32,3 +33,4 @@ render: |
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/connected-cars.yaml
+++ b/templates/definition/vehicle/connected-cars.yaml
@@ -31,6 +31,7 @@ params:
       de: Der Namespace dient zur Identifizierung der Organisation innerhalb von Connected Cars. Er kann ermittelt werden, indem man sich beim Connected Cars GraphiQL-Tool (https://api.connectedcars.io/graphql/graphiql/) anmeldet, das entsprechende Land auswählt und den automatisch festgelegten Header „X-Organization-Namespace“ anzeigt.
   - name: vin
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: cache
     default: 15m
 render: |
@@ -41,3 +42,4 @@ render: |
   vin: {{ .vin }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -9,6 +9,7 @@ requirements:
       Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: password
@@ -32,3 +33,4 @@ render: |
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/evnotify.yaml
+++ b/templates/definition/vehicle/evnotify.yaml
@@ -11,6 +11,7 @@ params:
   - name: token
     required: true
   - preset: vehicle-common
+  - preset: vehicle-climater
 render: |
   type: custom
   {{ include "vehicle-common" . }}
@@ -28,3 +29,4 @@ render: |
       source: http
       uri: https://app.evnotify.de/extended?akey={{ urlEncode .akey }}&token={{ urlEncode .token }}
       jq: .charging
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/flobz.yaml
+++ b/templates/definition/vehicle/flobz.yaml
@@ -13,6 +13,7 @@ params:
   - name: vin
     required: true
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: host
     deprecated: true
   - name: port
@@ -72,3 +73,4 @@ render: |
   uri: {{ trimSuffix "/" .url }}/get_vehicleinfo/{{ .vin }}?from_cache=1
   {{- end }}
   {{- end }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/ford-connect-query.yaml
+++ b/templates/definition/vehicle/ford-connect-query.yaml
@@ -5,6 +5,7 @@ products:
       generic: FordConnect Query
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: clientid
     description:
       generic: FordConnect Query Client ID
@@ -43,3 +44,4 @@ render: |
   redirecturi: {{ .redirecturi }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/ford-connect.yaml
+++ b/templates/definition/vehicle/ford-connect.yaml
@@ -6,6 +6,7 @@ products:
       generic: FordConnect (Legacy)
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: clientid
     description:
       generic: FordConnect API Client ID
@@ -41,3 +42,4 @@ render: |
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/genesis.yaml
+++ b/templates/definition/vehicle/genesis.yaml
@@ -11,8 +11,10 @@ requirements:
       Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - preset: vehicle-language
 render: |
   type: genesis
   {{ include "vehicle-base" . }}
   {{ include "vehicle-language" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/hyundai-us.yaml
+++ b/templates/definition/vehicle/hyundai-us.yaml
@@ -5,6 +5,7 @@ products:
       generic: Bluelink (US)
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - name: pin
     required: true
     help:
@@ -14,3 +15,4 @@ render: |
   type: hyundai-us
   {{ include "vehicle-base" . }}
   pin: {{ quote .pin }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/hyundai.yaml
+++ b/templates/definition/vehicle/hyundai.yaml
@@ -15,6 +15,7 @@ requirements:
       Manche Modelle (z.B. Kona) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - preset: vehicle-language
   - name: region
     default: Europe
@@ -27,3 +28,4 @@ render: |
   region: {{ .region }}
   {{ include "vehicle-base" . }}
   {{ include "vehicle-language" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/iso15118.yaml
+++ b/templates/definition/vehicle/iso15118.yaml
@@ -18,10 +18,15 @@ requirements:
       Otherwise the vehicle cannot be put into sleep mode.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
 render: |
   type: custom
   {{- include "vehicle-common" . }}
-  features: ["offline"]
+  features:
+  - offline
+  {{- if eq .climaterdisabled "true" }}
+  - climaterdisabled
+  {{- end }}
   soc:
     source: const
     value: 0

--- a/templates/definition/vehicle/jaguar-landrover.yaml
+++ b/templates/definition/vehicle/jaguar-landrover.yaml
@@ -5,6 +5,8 @@ products:
   - brand: Land Rover
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
 render: |
   type: jaguar
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -15,8 +15,10 @@ requirements:
       Manche Modelle (z.B. Niro EV) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - preset: vehicle-language
 render: |
   type: kia
   {{ include "vehicle-base" . }}
   {{ include "vehicle-language" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/lexus.yaml
+++ b/templates/definition/vehicle/lexus.yaml
@@ -9,6 +9,7 @@ requirements:
       Requires Lexus Link+ Connected Services Account.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: password
@@ -24,3 +25,4 @@ render: |
   password: {{ .password }}
   vin: {{ .vin }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -10,6 +10,7 @@ requirements:
     de: Voraussetzung ist ein konfigurierter MQTT Broker und eine mazda2mqtt Installation [github.com/C64Axel/mazda2mqtt](https://github.com/C64Axel/mazda2mqtt).
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: vin
     required: true
   - name: timeout
@@ -35,4 +36,8 @@ render: |
     source: mqtt
     topic: mazda2mqtt/{{ .vin }}/chargeInfo/drivingRangeKm
     timeout: {{ .timeout }}
-  features: ["streaming"]
+  features:
+  - streaming
+  {{- if eq .climaterdisabled "true" }}
+  - climaterdisabled
+  {{- end }}

--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -9,6 +9,7 @@ requirements:
       Requires `access` and `refresh` tokens. Documentation here: https://tinyurl.com/mbapi2020helptoken.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: region
@@ -35,3 +36,4 @@ render: |
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/mg.yaml
+++ b/templates/definition/vehicle/mg.yaml
@@ -3,6 +3,7 @@ products:
   - brand: MG
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - name: vin
     required: true
   - name: region
@@ -18,3 +19,4 @@ render: |
   type: mg
   {{ include "vehicle-base" . }}
   region: {{ .region }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/mg2mqtt.yaml
+++ b/templates/definition/vehicle/mg2mqtt.yaml
@@ -13,6 +13,7 @@ params:
   - name: vin
     required: true
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: timeout
     default: 1h
 render: |
@@ -62,3 +63,4 @@ render: |
           source: mqtt
           topic: saic/{{ .user }}/vehicles/{{ .vin }}/refresh/mode/set
           timeout: {{ .timeout }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/mz2mqtt.yaml
+++ b/templates/definition/vehicle/mz2mqtt.yaml
@@ -10,6 +10,7 @@ requirements:
     de: myMazda zu MQTT. Voraussetzung ist ein konfigurierter MQTT Broker und eine mz2mqtt Installation [github.com/C64Axel/mz2mqtt](https://github.com/C64Axel/mz2mqtt).
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: vin
     required: true
   - name: timeout
@@ -36,3 +37,4 @@ render: |
     source: mqtt
     topic: mz2mqtt/{{ .vin }}/chargeInfo/drivingRangeKm
     timeout: {{ .timeout }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/nissan-ariya.yaml
+++ b/templates/definition/vehicle/nissan-ariya.yaml
@@ -8,6 +8,7 @@ products:
       generic: Micra
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - name: expiry
     description:
       de: Ablauf
@@ -23,3 +24,4 @@ render: |
   version: v2
   {{ include "vehicle-base" . }}
   expiry: {{ .expiry }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/nissan.yaml
+++ b/templates/definition/vehicle/nissan.yaml
@@ -5,6 +5,8 @@ products:
       generic: Leaf
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
 render: |
   type: nissan
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/niu-e-scooter.yaml
+++ b/templates/definition/vehicle/niu-e-scooter.yaml
@@ -5,6 +5,7 @@ products:
       generic: E-Scooter
 group: scooter
 params:
+  - preset: vehicle-climater
   - name: title
   - name: icon
     default: scooter
@@ -31,3 +32,4 @@ render: |
   password: {{ .password }} # NIU app password
   serial: {{ .serial }} # NIU E-Scooter serial number like shown in app
   capacity: {{ .capacity }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/offline.yaml
+++ b/templates/definition/vehicle/offline.yaml
@@ -9,6 +9,7 @@ requirements:
 group: generic
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: coarsecurrent
     advanced: true
   - name: welcomecharge
@@ -23,6 +24,9 @@ render: |
   {{- end }}
   {{- if eq .welcomecharge "true" }}
   - welcomecharge
+  {{- end }}
+  {{- if eq .climaterdisabled "true" }}
+  - climaterdisabled
   {{- end }}
   soc:
     source: const

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -9,6 +9,7 @@ requirements:
       Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: password
@@ -32,3 +33,4 @@ render: |
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/outlanderphev.yaml
+++ b/templates/definition/vehicle/outlanderphev.yaml
@@ -9,6 +9,7 @@ requirements:
     de: Unterstützung für Mitsubishi Outlander PHEV über [github.com/buxtronix/phev2mqtt](https://github.com/buxtronix/phev2mqtt). MQTT-Broker erforderlich.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: timeout
     default: 600s
     advanced: true
@@ -37,3 +38,4 @@ render: |
     topic: phev/climate/status
     timeout: {{ .timeout }}
     jq: (. != "off")
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/ovms.yaml
+++ b/templates/definition/vehicle/ovms.yaml
@@ -9,6 +9,7 @@ requirements:
     en: Support for all vehicles via ODB2 adapter in the vehicle. More info at [api.openvehicles.com](http://api.openvehicles.com/).
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: password
@@ -33,3 +34,4 @@ render: |
   vehicleid: {{ .vehicleid }}
   server: {{ .server }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -9,6 +9,7 @@ requirements:
       Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: password
@@ -32,3 +33,4 @@ render: |
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/polestar.yaml
+++ b/templates/definition/vehicle/polestar.yaml
@@ -5,8 +5,10 @@ requirements:
   evcc: ["skiptest"]
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - name: vin
     example: LPSVS...
 render: |
   type: polestar-grpc
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/porsche.yaml
+++ b/templates/definition/vehicle/porsche.yaml
@@ -4,6 +4,8 @@ products:
   - brand: Porsche
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
 render: |
   type: porsche
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/seat.yaml
+++ b/templates/definition/vehicle/seat.yaml
@@ -5,6 +5,8 @@ products:
       generic: CupraConnect Gen3 (Ateca, Leon, Formentor, Tarraco)
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
 render: |
   type: seat
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/skoda.yaml
+++ b/templates/definition/vehicle/skoda.yaml
@@ -6,8 +6,10 @@ products:
       generic: MyŠkoda
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - name: timeout
 render: |
   type: skoda
   {{ include "vehicle-base" . }}
   timeout: {{ .timeout }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/smart.yaml
+++ b/templates/definition/vehicle/smart.yaml
@@ -12,6 +12,7 @@ requirements:
       Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`. On December 31, 2024, Mercedes disabled the online access and the app for the Smart EQ. Therefore, integration into EVCC is no longer possible.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: region
@@ -37,3 +38,4 @@ render: |
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
   {{ include "vehicle-common" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/subaru.yaml
+++ b/templates/definition/vehicle/subaru.yaml
@@ -7,8 +7,10 @@ requirements:
     en: Requires Subaru Connected Services Account
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
   - name: vin
     example: JF...
 render: |
   type: subaru
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/tesla-ble.yaml
+++ b/templates/definition/vehicle/tesla-ble.yaml
@@ -9,6 +9,7 @@ requirements:
     en: Open Source Tesla BLE HTTP Proxy [github.com/wimaha/TeslaBleHttpProxy](https://github.com/wimaha/TeslaBleHttpProxy)
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: vin
     required: true
     example: W...
@@ -80,3 +81,4 @@ render: |
       else "A" end)
     timeout: {{ .timeout }}
     cache: 1s
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -37,6 +37,7 @@ requirements:
       More information and alternatives can be found at [docs.evcc.io/blog](https://docs.evcc.io/en/blog/2025/01/20/tesla-api-update).
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: clientId
     description:
       generic: Client ID
@@ -90,5 +91,9 @@ render: |
   commandProxy: {{ .commandProxy }}
   proxyToken: {{ .proxyToken }}
   {{ include "vehicle-common" . }}
-  features: ["coarsecurrent"]
+  features:
+  - coarsecurrent
+  {{- if eq .climaterdisabled "true" }}
+  - climaterdisabled
+  {{- end }}
   cache: {{ .cache }}

--- a/templates/definition/vehicle/teslafi.yaml
+++ b/templates/definition/vehicle/teslafi.yaml
@@ -9,6 +9,7 @@ requirements:
     de: Verbinden Sie Ihr Tesla-Fahrzeug über die TeslaFi-API. TeslaFi ist ein Tesla-Datenlogger-Service, der HTTP-API-Zugriff auf Fahrzeugdaten bietet. Holen Sie sich Ihren API-Schlüssel aus den TeslaFi-Kontoeinstellungen.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: apikey
     required: true
   - name: vin
@@ -43,4 +44,8 @@ render: |
   limitsoc:
     {{- include "teslafi_source" . | indent 2 }}
     jq: .charge_limit_soc
-  features: ["coarsecurrent"]
+  features:
+  - coarsecurrent
+  {{- if eq .climaterdisabled "true" }}
+  - climaterdisabled
+  {{- end }}

--- a/templates/definition/vehicle/teslalogger.yaml
+++ b/templates/definition/vehicle/teslalogger.yaml
@@ -9,6 +9,7 @@ requirements:
     en: Open source Tesla data logger [github.com/bassmaster187/TeslaLogger](https://github.com/bassmaster187/TeslaLogger)
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: id
     description:
       de: TeslaLogger CarID
@@ -65,3 +66,4 @@ render: |
   maxcurrent:
     source: http
     uri: {{ .url }}:{{ .port }}/command/{{ .id }}/set_charging_amps?${maxcurrent}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -9,6 +9,7 @@ requirements:
     de: Open Source Tesla Datenlogger [github.com/adriankumpf/teslamate](https://github.com/adriankumpf/teslamate). Voraussetzung ist konfigurierter MQTT Broker.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: id
     description:
       de: Fahrzeug-ID
@@ -68,4 +69,8 @@ render: |
     source: mqtt
     topic: teslamate/cars/{{ .id }}/is_preconditioning
     timeout: {{ .timeout }}
-  features: ["coarsecurrent"]
+  features:
+  - coarsecurrent
+  {{- if eq .climaterdisabled "true" }}
+  - climaterdisabled
+  {{- end }}

--- a/templates/definition/vehicle/tessie.yaml
+++ b/templates/definition/vehicle/tessie.yaml
@@ -9,6 +9,7 @@ requirements:
     en: Connect your Tesla using the Tessie API. This will never wake up the car, polling can be set to "always" and interval "1M". If the vehicle is awake, the data is usually less than 15 seconds old. If the vehicle is asleep, the data is from the time the vehicle went to sleep. Get your token at [dash.tessie.com](https://dash.tessie.com/settings/api)
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: vin
     description:
       de: Fahrzeug-VIN
@@ -115,4 +116,8 @@ render: |
     headers:
       Authorization: Bearer {{ .token }}
     method: POST
-  features: ["coarsecurrent"]
+  features:
+  - coarsecurrent
+  {{- if eq .climaterdisabled "true" }}
+  - climaterdisabled
+  {{- end }}

--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -16,6 +16,7 @@ requirements:
       A Tibber energy contract is not required, the vehicle must be connected in the Tibber account.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: clientid
     required: true
   - name: clientsecret
@@ -48,3 +49,4 @@ render: |
   redirecturi: {{ .redirecturi }}
   vin: {{ .vin }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/toyota.yaml
+++ b/templates/definition/vehicle/toyota.yaml
@@ -9,6 +9,7 @@ requirements:
       Requires Toyota Connected Services Account.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: user
     required: true
   - name: password
@@ -24,3 +25,4 @@ render: |
   password: {{ .password }}
   vin: {{ .vin }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/tronity.yaml
+++ b/templates/definition/vehicle/tronity.yaml
@@ -7,6 +7,7 @@ requirements:
   evcc: ["sponsorship"]
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: clientid
     description:
       generic: Tronity API Client ID
@@ -33,3 +34,4 @@ render: |
     secret: {{ .clientsecret }}
   {{ include "vehicle-common" . }}
   cache: {{ .cache }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/volvo-connected.yaml
+++ b/templates/definition/vehicle/volvo-connected.yaml
@@ -26,6 +26,7 @@ requirements:
       **NOTE:** Volvo enforces re-login every 7 days. Use "hamburger" menu logout/login.
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: vccapikey
     required: true
     description:
@@ -70,3 +71,4 @@ render: |
   redirecturi: {{ .redirectUri }}
   vin: {{ .vin }}
   {{ include "vehicle-common" . }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/volvo2mqtt.yaml
+++ b/templates/definition/vehicle/volvo2mqtt.yaml
@@ -10,6 +10,7 @@ requirements:
     de: Erforderlich ist eine konfigurierte MQTT Broker-Konfiguration und eine volvo2mqtt-Installation [github.com/Dielee/volvo2mqtt](https://github.com/Dielee/volvo2mqtt).
 params:
   - preset: vehicle-common
+  - preset: vehicle-climater
   - name: vin
     required: true
   - name: timeout
@@ -25,3 +26,4 @@ render: |
     source: mqtt
     topic: homeassistant/sensor/{{ .vin }}_electric_range/state
     timeout: {{ .timeout }}
+  {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/zero.yaml
+++ b/templates/definition/vehicle/zero.yaml
@@ -3,6 +3,8 @@ products:
   - brand: Zero Motorcycles
 params:
   - preset: vehicle-base
+  - preset: vehicle-climater
 render: |
   type: zero
   {{ include "vehicle-base" . }}
+  {{ include "vehicle-features" . }}

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -318,6 +318,14 @@ params:
     help:
       en: Charger will enable charging for short time when vehicle is connected, irrespective of configured charge mode. This is useful for vehicles that require power supply when connecting.
       de: Wallbox gibt kurzzeitige Ladefreigabe bei Fahrzeugverbindung. Das ermöglicht es Fahrzeugen, die eine Stromversorgung beim Anschließen benötigen, einen Fehlerzustand zu vermeiden.
+  - name: climaterdisabled
+    type: bool
+    description:
+      en: Disable climater detection
+      de: Klimatisierungserkennung deaktivieren
+    help:
+      en: Ignore the vehicle's climater state for charge control, so charging stops at the SoC or energy limit even when the vehicle signals an active climater request.
+      de: Klimatisierungsstatus des Fahrzeugs für die Ladesteuerung ignorieren, sodass der Ladevorgang am SoC- oder Energielimit endet, auch wenn das Fahrzeug einen aktiven Klimatisierungswunsch signalisiert.
   - name: heating
     type: bool
     description:
@@ -560,6 +568,11 @@ presets:
     - name: streaming
       advanced: true
     - name: welcomecharge
+      advanced: true
+    - name: climaterdisabled
+      advanced: true
+  vehicle-climater:
+    - name: climaterdisabled
       advanced: true
   charger-features:
     - name: heating

--- a/util/templates/includes/vehicle-features.tpl
+++ b/util/templates/includes/vehicle-features.tpl
@@ -1,5 +1,5 @@
 {{ define "vehicle-features" }}
-{{- if or (eq .coarsecurrent "true") (eq .welcomecharge "true") (eq .streaming "true") }}
+{{- if or (eq .coarsecurrent "true") (eq .welcomecharge "true") (eq .streaming "true") (eq .climaterdisabled "true") }}
 features:
 {{- if eq .coarsecurrent "true" }}
 - coarsecurrent
@@ -9,6 +9,9 @@ features:
 {{- end }}
 {{- if eq .streaming "true" }}
 - streaming
+{{- end }}
+{{- if eq .climaterdisabled "true" }}
+- climaterdisabled
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
fixes #29720
replaces #30029

Adds a `climaterdisabled` vehicle feature that makes evcc ignore the vehicle climater state for charge control. The climater keep-alive otherwise holds charging on at min current after the SoC or energy limit is reached, and in PV mode it can stick when a vehicle reports a false-positive climater request (see #30301). This opt-out lets affected vehicles skip climater detection entirely.

- `vehicleClimateActive()` returns false immediately when the vehicle has the `climaterdisabled` feature, before any climater poll
- exposed as an advanced toggle on all vehicle templates via the shared `vehicle-features` include and a `vehicle-climater` preset
- the flag is a no-op for vehicles without a climater, so universal exposure is harmless

Less invasive alternative to #30029, which added a hand-rolled feature block to ~40 templates: this reuses the existing shared `vehicle-features` include and adds a single `vehicle-climater` preset.