### PR TITLE
Vehicle: route climaterdisabled through vehicle-features include

### DIFF
--- a/templates/definition/vehicle/iso15118.yaml
+++ b/templates/definition/vehicle/iso15118.yaml
@@ -22,11 +22,7 @@ params:
 render: |
   type: custom
   {{- include "vehicle-common" . }}
-  features:
-  - offline
-  {{- if eq .climaterdisabled "true" }}
-  - climaterdisabled
-  {{- end }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "offline")) .) }}
   soc:
     source: const
     value: 0

--- a/templates/definition/vehicle/mazda2mqtt.yaml
+++ b/templates/definition/vehicle/mazda2mqtt.yaml
@@ -36,8 +36,4 @@ render: |
     source: mqtt
     topic: mazda2mqtt/{{ .vin }}/chargeInfo/drivingRangeKm
     timeout: {{ .timeout }}
-  features:
-  - streaming
-  {{- if eq .climaterdisabled "true" }}
-  - climaterdisabled
-  {{- end }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "streaming")) .) }}

--- a/templates/definition/vehicle/offline.yaml
+++ b/templates/definition/vehicle/offline.yaml
@@ -17,17 +17,7 @@ params:
 render: |
   type: custom
   {{- include "vehicle-common" . }}
-  features:
-  - offline
-  {{- if eq .coarsecurrent "true" }}
-  - coarsecurrent
-  {{- end }}
-  {{- if eq .welcomecharge "true" }}
-  - welcomecharge
-  {{- end }}
-  {{- if eq .climaterdisabled "true" }}
-  - climaterdisabled
-  {{- end }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "offline")) .) }}
   soc:
     source: const
     value: 0

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -91,9 +91,5 @@ render: |
   commandProxy: {{ .commandProxy }}
   proxyToken: {{ .proxyToken }}
   {{ include "vehicle-common" . }}
-  features:
-  - coarsecurrent
-  {{- if eq .climaterdisabled "true" }}
-  - climaterdisabled
-  {{- end }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "coarsecurrent")) .) }}
   cache: {{ .cache }}

--- a/templates/definition/vehicle/teslafi.yaml
+++ b/templates/definition/vehicle/teslafi.yaml
@@ -44,8 +44,4 @@ render: |
   limitsoc:
     {{- include "teslafi_source" . | indent 2 }}
     jq: .charge_limit_soc
-  features:
-  - coarsecurrent
-  {{- if eq .climaterdisabled "true" }}
-  - climaterdisabled
-  {{- end }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "coarsecurrent")) .) }}

--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -69,8 +69,4 @@ render: |
     source: mqtt
     topic: teslamate/cars/{{ .id }}/is_preconditioning
     timeout: {{ .timeout }}
-  features:
-  - coarsecurrent
-  {{- if eq .climaterdisabled "true" }}
-  - climaterdisabled
-  {{- end }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "coarsecurrent")) .) }}

--- a/templates/definition/vehicle/tessie.yaml
+++ b/templates/definition/vehicle/tessie.yaml
@@ -116,8 +116,4 @@ render: |
     headers:
       Authorization: Bearer {{ .token }}
     method: POST
-  features:
-  - coarsecurrent
-  {{- if eq .climaterdisabled "true" }}
-  - climaterdisabled
-  {{- end }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "coarsecurrent")) .) }}

--- a/util/templates/includes/vehicle-features.tpl
+++ b/util/templates/includes/vehicle-features.tpl
@@ -1,6 +1,9 @@
 {{ define "vehicle-features" }}
-{{- if or (eq .coarsecurrent "true") (eq .welcomecharge "true") (eq .streaming "true") (eq .climaterdisabled "true") }}
+{{- if or .basefeatures (eq .coarsecurrent "true") (eq .welcomecharge "true") (eq .streaming "true") (eq .climaterdisabled "true") }}
 features:
+{{- range .basefeatures }}
+- {{ . }}
+{{- end }}
 {{- if eq .coarsecurrent "true" }}
 - coarsecurrent
 {{- end }}


### PR DESCRIPTION
follows #30610

Several vehicle templates hand-rolled their `features` list (with the `climaterdisabled` conditional duplicated) because they carry a mandatory feature and the shared `vehicle-features` include emits its own `features` block. This consolidates that wiring.

- Extend the `vehicle-features` include with an optional `basefeatures` list so templates with an always-on feature can still reuse it
- Route `iso15118`, `mazda2mqtt`, `offline`, `tesla`, `teslafi`, `teslamate` and `tessie` through the include, removing the duplicated `climaterdisabled` handling

Rendered output is unchanged for all affected templates with the flag on and off.