### PR TITLE
charger/warp-ws: fix PM topic filter dropping events on single-WS setup (WARP3)

### DIFF
--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -259,7 +259,7 @@ func (w *WarpWS) handleConnection(ctx context.Context, role wsRole, conn *websoc
 				return err
 			}
 
-			if role == wsRoleMain && isPmTopic(event.Topic) {
+			if role == wsRoleMain && w.pm != w.Connection && isPmTopic(event.Topic) {
 				continue
 			}
 

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -259,6 +259,8 @@ func (w *WarpWS) handleConnection(ctx context.Context, role wsRole, conn *websoc
 				return err
 			}
 
+			// only drop PM topics on the main WS when a dedicated PM connection exists;
+			// on single-WS setups (WARP3) PM events arrive here and must be processed
 			if role == wsRoleMain && w.pm != w.Connection && isPmTopic(event.Topic) {
 				continue
 			}


### PR DESCRIPTION
Follow-up to #30460.

## Problem

The `isPmTopic` filter introduced in #30460 suppressed all `power_manager/*` events on the main WebSocket connection unconditionally:

```go
if role == wsRoleMain && isPmTopic(event.Topic) {
    continue
}
```

On a single-WS setup (WARP3, no separate Energy Manager), only `wsRoleMain` runs — so `power_manager/state` and `power_manager/low_level_state` events were silently dropped. This meant `pmState` and `pmLowLevelState` were never updated from WebSocket events on WARP3, causing every `ensurePmState`/`ensurePmLowLevelState` call to fall back to an HTTP GET with a stale cached value.

## Fix

Gate the filter on whether a separate PM connection is in use:

```go
if role == wsRoleMain && w.pm != w.Connection && isPmTopic(event.Topic) {
    continue
}
```

This preserves the intended behaviour for WARP2+EM (two WebSocket connections, PM topics only processed on the PM connection) while letting PM events through on WARP3.