### PR TITLE
Vehicle (flobz/PSA): fix climater detection when air conditioning is null

### DIFF
--- a/templates/definition/vehicle/flobz.yaml
+++ b/templates/definition/vehicle/flobz.yaml
@@ -49,7 +49,7 @@ render: |
     jq: .timed_odometer.mileage
   climater:
     {{- include "source" . | indent 2 }}
-    jq: .preconditionning.air_conditioning.status != "Disabled"
+    jq: (.preconditionning.air_conditioning.status // "Disabled") != "Disabled"
   wakeup:
     source: http
     {{- if .host }}


### PR DESCRIPTION
The flobz/PSA climater check returned true when the API reports `preconditionning.air_conditioning` as null, because `null.status` compares unequal to `"Disabled"`. A spuriously active climater kept charging past the SOC limit, so charging never stopped when the target was reached.

Defaulting the missing status to `"Disabled"` treats a null air_conditioning as inactive. Verified against gojq: null and `"Disabled"` both yield false, `"Enabled"` yields true.

fixes #30561