### PR TITLE
chore: update ocpp-go with client dispatcher deadlock fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -260,4 +260,4 @@ tool (
 
 replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea
 
-replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b
+replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20260608073623-93d61739ab34

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6 h1:XOYvxKtT1o
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6/go.mod h1:BszP9qFV14mPXgyIREbgIdQtWxbAj3OKqvK02HihMoM=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea h1:F6eyC8V8wvc3ranlsR4coAls+OPBkVvxyX0a2VqdlPc=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea/go.mod h1:swrNGAVgI1r/3d/sEKE7qgujdRR9aHVPYKyc3gvpVTc=
-github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b h1:5vFr7wOwoi5ylybUnxxBk1U3FRF2+3Sf0sKx8thxw18=
-github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b/go.mod h1:2kcukDdhui4u730VfnYVWuwzDLgw+mBRGDir/QAyBhg=
+github.com/evcc-io/ocpp-go v0.0.0-20260608073623-93d61739ab34 h1:jY9O/T6mFDs3ihBFvnBHtZoufXSvOSzDTkT+Ey0nuqw=
+github.com/evcc-io/ocpp-go v0.0.0-20260608073623-93d61739ab34/go.mod h1:2kcukDdhui4u730VfnYVWuwzDLgw+mBRGDir/QAyBhg=
 github.com/evcc-io/openapi-mcp v0.6.1-0.20260503092507-6199c7ad3baf h1:rnObcCvSoPJpYVJoHAxFAtzy/lMLsPN1TgK3yq6nWrU=
 github.com/evcc-io/openapi-mcp v0.6.1-0.20260503092507-6199c7ad3baf/go.mod h1:YyOx4zwr6xVUcchAETHERZ+75cZMIrdcjVIZFwBlE1Q=
 github.com/evcc-io/optimizer v0.0.0-20260531165648-b5cbfebdaa65 h1:W6swNuLZBpLBXNxMuVwHo4b/MwrWhrQ2BSK8t+Fchic=

--- a/templates/definition/vehicle/flobz.yaml
+++ b/templates/definition/vehicle/flobz.yaml
@@ -49,7 +49,7 @@ render: |
     jq: .timed_odometer.mileage
   climater:
     {{- include "source" . | indent 2 }}
-    jq: .preconditionning.air_conditioning.status != "Disabled"
+    jq: (.preconditionning.air_conditioning.status // "Disabled") != "Disabled"
   wakeup:
     source: http
     {{- if .host }}


### PR DESCRIPTION
Bumps the `evcc-io/ocpp-go` replace to pick up evcc-io/ocpp-go#6.

That PR fixes the root cause of the intermittent 10-minute `TestOcpp` timeout in CI: `DefaultClientDispatcher.SendRequest` does a blocking send on the notification channel while the caller holds the callback-queue mutex (via `chargePoint.SendRequestAsync` → `callbackqueue.TryQueue`). Once the message pump stops draining the channel during teardown, that send blocks forever, the callbacks mutex is never released, and `clearCallbacks` on stop deadlocks on the same mutex. The fix makes the doorbell send non-blocking and adds a stop signal so `SendRequest` bails out instead of blocking or sending on a closed channel.

Depends on evcc-io/ocpp-go#6. The replace currently points at that PR's branch commit (`93d61739`); it should be re-pointed to the `master` commit once #6 is merged.

Verified locally: `TestOcpp` passes repeatedly, and the new dispatcher regression test in #6 hangs without the fix and passes with it.