### PR TITLE
Metrics: fix entity titles for db loadpoints

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1328,13 +1328,6 @@ func newLoadpoint(idx int, name string, other map[string]any, settingsFn func(*u
 		return lp, err
 	}
 
-	// lazily update entity title
-	if title := lp.GetTitle(); title != "" {
-		if err := collector.UpdateTitle(title); err != nil {
-			return lp, err
-		}
-	}
-
 	return lp, nil
 }
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -213,10 +213,6 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, collec
 		lp.mode = api.ModeOff
 	}
 
-	if lp.Title != "" {
-		lp.setTitle(lp.Title)
-	}
-
 	if lp.Priority > 0 {
 		lp.setPriority(lp.Priority)
 	}
@@ -272,6 +268,11 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, collec
 	// add collector
 	if lp.chargeMeter != nil {
 		lp.chargeEnergy = collector
+	}
+
+	// set title after collector is wired to refresh the metrics entity
+	if lp.Title != "" {
+		lp.setTitle(lp.Title)
 	}
 
 	// phase switching defaults based on charger capabilities

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -127,6 +127,12 @@ func (lp *Loadpoint) setTitle(title string) {
 	lp.title = title
 	lp.publish(keys.Title, lp.title)
 	lp.settings.SetString(keys.Title, lp.title)
+
+	if lp.chargeEnergy != nil {
+		if err := lp.chargeEnergy.UpdateTitle(title); err != nil {
+			lp.log.ERROR.Printf("update title: %v", err)
+		}
+	}
 }
 
 // GetStatus returns the charging status


### PR DESCRIPTION
fixes bug in https://github.com/evcc-io/evcc/pull/30196 where titles were not set correctly for ui-created loadpoints. Root cause is, that db loadpoint properties are assigned after creation (restore). Moved updating logic into setTitle.

<img width="443" height="384" alt="Bildschirmfoto 2026-06-08 um 14 10 48" src="https://github.com/user-attachments/assets/10b02d00-6ed7-4703-879f-67aea8c09399" />
