### PR TITLE
Optimizer: send zero solar forecast when current forecast is empty

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -153,7 +153,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 
 	// allow empty solar forecast
 	ft := lo.RepeatBy(minLen, func(i int) float32 { return float32(0) })
-	if solarTariff != nil {
+	if solarTariff != nil && len(solar) > 0 {
 		solarEnergy, err := solarRatesToEnergy(solar)
 		if err != nil {
 			return err
@@ -771,7 +771,7 @@ func apiError(resp *optimizer.PostOptimizeChargeScheduleResponse) error {
 	}
 
 	if errObj == nil {
-		return fmt.Errorf("invalid status: %d", resp.StatusCode())
+		return fmt.Errorf("invalid status: %d: %s", resp.StatusCode(), resp.Body)
 	}
 
 	if len(errObj.Details) > 0 {


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/30632

When a solar tariff is configured but its current forecast is empty, the optimizer request sent an empty `ft` array while all other time series had the horizon length. The optimizer server rejects the length mismatch with a 400, disabling optimization.

- Skip the solar forecast branch when there are no current solar slots, leaving `ft` zero-filled to the horizon length (mirrors the existing horizon guard)
- Surface the raw response body in `apiError` so a non-decodable 400 no longer collapses to a bare `invalid status: 400`

Drop the second bullet if you want the PR scoped to the fix only.