### PR TITLE
OCPP: report zero charge power while idle

### DIFF
--- a/charger/ocpp/connector.go
+++ b/charger/ocpp/connector.go
@@ -307,6 +307,12 @@ func (conn *Connector) CurrentPower() (float64, error) {
 		}
 	}
 
+	// no power measurand: chargers that only report energy while idle (e.g. Mennekes ACU)
+	// never send power outside a transaction, so report zero as nothing is charging
+	if conn.txnId == 0 {
+		return 0, nil
+	}
+
 	return 0, api.ErrNotAvailable
 }
 

--- a/charger/ocpp/connector_test.go
+++ b/charger/ocpp/connector_test.go
@@ -112,6 +112,33 @@ func (suite *connTestSuite) TestConnectorMeasurementsNoTxn() {
 	suite.Equal(res3, 1.0, "Voltages")
 }
 
+func (suite *connTestSuite) TestConnectorEnergyOnlyNoTxn() {
+	// connected, no txn, only energy register reported (e.g. Mennekes ACU while idle)
+	suite.conn.measurements[types.MeasurandEnergyActiveImportRegister] = types.SampledValue{Value: "1000", Unit: types.UnitOfMeasureWh}
+	suite.conn.meterUpdated = suite.clock.Now()
+
+	// no power measurand but no running txn: report zero instead of ErrNotAvailable
+	res, err := suite.conn.CurrentPower()
+	suite.NoError(err, "CurrentPower")
+	suite.Equal(0.0, res, "CurrentPower")
+
+	// energy is still reported
+	res, err = suite.conn.TotalEnergy()
+	suite.NoError(err, "TotalEnergy")
+	suite.Equal(1.0, res, "TotalEnergy")
+}
+
+func (suite *connTestSuite) TestConnectorEnergyOnlyRunningTxn() {
+	// connected, running txn, only energy register reported and no power yet
+	suite.conn.measurements[types.MeasurandEnergyActiveImportRegister] = types.SampledValue{Value: "1000", Unit: types.UnitOfMeasureWh}
+	suite.conn.meterUpdated = suite.clock.Now()
+	suite.conn.txnId = 1
+
+	// missing power during an active txn must still surface as not available
+	_, err := suite.conn.CurrentPower()
+	suite.Equal(api.ErrNotAvailable, err, "CurrentPower")
+}
+
 func (suite *connTestSuite) TestConnectorMeasurementsRunningTxnOutdated() {
 	// connected, running txn, no meter update since 1 hour
 	suite.addMeasurements()


### PR DESCRIPTION
Chargers that only report `Energy.Active.Import.Register` in their `MeterValues` while idle (e.g. Mennekes ACU, `MeterValuesSampledDataMaxLength=1`) never send `Power.Active.Import` outside a transaction. With no power measurand present, `Connector.CurrentPower()` returned `ErrNotAvailable`, so loadpoints continuously logged `charge power: not available` after every restart until a car was connected to each connector.

This reports zero power when no transaction is running instead, mirroring the existing meter-timeout behavior (`txnId == 0` already returns 0 there). A missing power measurand during an active transaction still surfaces as `ErrNotAvailable`.

See #30650 — trace confirms the ACU only emits `Energy.Active.Import.Register` while idle despite being configured for `Power.Active.Import`.