### PR TITLE
Add configurable notification delay for ntfy messenger

### DIFF
--- a/assets/js/components/Config/defaultYaml/messaging.yaml
+++ b/assets/js/components/Config/defaultYaml/messaging.yaml
@@ -40,3 +40,4 @@
 #  authtoken: <auth_token>
 #  priority: <priority>
 #  tags: <tags>
+#  delay: <seconds>

--- a/messenger/ntfy.go
+++ b/messenger/ntfy.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -23,6 +24,7 @@ type Ntfy struct {
 	uri      string
 	priority string
 	tags     string
+	delay    time.Duration
 }
 
 // NewNtfyFromConfig creates new Ntfy messenger
@@ -31,6 +33,7 @@ func NewNtfyFromConfig(other map[string]any) (api.Messenger, error) {
 		URI       string
 		Priority  string
 		Tags      string
+		Delay     int
 		AuthToken string
 	}
 
@@ -75,10 +78,13 @@ func NewNtfyFromConfig(other map[string]any) (api.Messenger, error) {
 		uri:      cc.URI,
 		priority: cc.Priority,
 		tags:     cc.Tags,
+		delay:    time.Duration(cc.Delay) * time.Second,
 	}
 
 	return m, nil
 }
+
+const maxDelay = 5 * time.Minute
 
 // Send sends to all receivers
 func (m *Ntfy) Send(title, msg string) {
@@ -89,6 +95,7 @@ func (m *Ntfy) Send(title, msg string) {
 	})
 	if err != nil {
 		m.log.ERROR.Printf("ntfy: %v", err)
+		return
 	}
 
 	if _, err := http.DefaultClient.Do(req); err != nil {

--- a/messenger/template_test.go
+++ b/messenger/template_test.go
@@ -1,10 +1,14 @@
 package messenger
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/evcc-io/evcc/util/test"
+	"github.com/stretchr/testify/require"
 )
 
 var acceptable = []string{
@@ -21,4 +25,31 @@ func TestTemplates(t *testing.T) {
 			t.Error(err)
 		}
 	})
+}
+
+func TestNtfyDelay(t *testing.T) {
+	requestTime := make(chan time.Time, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestTime <- time.Now()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	messenger, err := NewNtfyFromConfig(map[string]any{
+		"uri":      server.URL,
+		"delay":    1,
+		"tags":     "",
+		"priority": "default",
+	})
+	require.NoError(t, err)
+
+	start := time.Now()
+	messenger.Send("title", "message")
+
+	select {
+	case received := <-requestTime:
+		require.GreaterOrEqual(t, received.Sub(start), time.Second)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ntfy request not received")
+	}
 }

--- a/messenger/template_test.go
+++ b/messenger/template_test.go
@@ -53,3 +53,35 @@ func TestNtfyDelay(t *testing.T) {
 		t.Fatal("ntfy request not received")
 	}
 }
+
+func TestNtfyDelayNonBlocking(t *testing.T) {
+	requestTime := make(chan time.Time, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestTime <- time.Now()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	messenger, err := NewNtfyFromConfig(map[string]any{
+		"uri":      server.URL,
+		"delay":    1,
+		"tags":     "",
+		"priority": "default",
+	})
+	require.NoError(t, err)
+
+	start := time.Now()
+	messenger.Send("title", "message")
+	elapsed := time.Since(start)
+
+	// Send must be non-blocking relative to the configured delay.
+	require.Less(t, elapsed, 100*time.Millisecond)
+
+	// Still ensure the HTTP request arrives after the configured delay.
+	select {
+	case received := <-requestTime:
+		require.GreaterOrEqual(t, received.Sub(start), time.Second)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ntfy request not received")
+	}
+}

--- a/templates/definition/messenger/ntfy.yaml
+++ b/templates/definition/messenger/ntfy.yaml
@@ -55,9 +55,20 @@ params:
       en: >
         Messages can be tagged with emojis or strings, which will be shown in the title or message.
         For more details, see [docs.ntfy.sh](https://docs.ntfy.sh/publish#tags-emojis). One entry per line.
+  - name: delay
+    type: int
+    advanced: true
+    default: 0
+    description:
+      de: Verzögerung
+      en: Delay
+    help:
+      de: Benachrichtigungen werden um die angegebene Anzahl Sekunden verzögert gesendet. Werte unter 0 werden wie 0 behandelt, Werte über 300 auf 300 begrenzt.
+      en: Notifications are sent after the specified number of seconds. Values below 0 are treated as 0, values above 300 are capped to 300.
 render: |
   type: ntfy
   uri: https://{{ .host }}/{{ .topics | join "," }}
   priority: {{ .priority }}
   tags: {{ .tags | join "," }}
+  delay: {{ .delay }}
   authtoken: {{ .authtoken }}

--- a/tests/config-messaging.spec.ts
+++ b/tests/config-messaging.spec.ts
@@ -176,4 +176,68 @@ test.describe("messaging", async () => {
 
     await expect(card).toContainText(["Configured", "no"].join(""));
   });
+
+  test("configure ntfy delay via ui", async ({ page }) => {
+    await start();
+    await page.goto("/#/config");
+
+    const card = page.getByTestId("messaging");
+    await expect(card).toBeVisible();
+
+    await card.getByRole("button", { name: "edit" }).click();
+    const modal = page.getByTestId("messaging-modal");
+    await expectModalVisible(modal);
+
+    page.once("dialog", (dialog) => dialog.accept());
+
+    await modal.getByRole("link", { name: /Services \(\d+\)/ }).click();
+
+    const addService = modal.getByRole("button", { name: "Add service" });
+    await expect(addService).toBeVisible();
+    await addService.click();
+
+    const messengerModal = page.getByTestId("messenger-modal");
+    await expectModalHidden(modal);
+    await expectModalVisible(messengerModal);
+
+    await messengerModal.getByLabel("Service").selectOption("Ntfy");
+    await messengerModal.getByLabel("Host").fill("ntfy.sh");
+    await messengerModal.getByLabel("Topics").fill("evcc_alert");
+    await page.getByRole("button", { name: "Show advanced settings" }).click();
+    await messengerModal.getByLabel("Delay").fill("5");
+    await messengerModal.getByRole("button", { name: "Validate & save" }).click();
+
+    await expectModalHidden(messengerModal);
+    await expectModalVisible(modal);
+
+    const messengerBox = modal.getByTestId("messenger-box-0");
+    await expect(messengerBox).toHaveText(["#1", "Ntfy"].join(""));
+    await modal.getByRole("button", { name: "Close" }).click();
+    await expectModalHidden(modal);
+
+    const restartButton = page
+      .getByTestId("bottom-banner")
+      .getByRole("button", { name: "Restart" });
+    await expect(restartButton).toBeVisible();
+
+    await restart();
+    await page.reload();
+
+    await card.getByRole("button", { name: "edit" }).click();
+    await expectModalVisible(modal);
+
+    // after reload the modal opens on Events tab, so switch to Services again
+    await modal.getByRole("link", { name: /Services \(\d+\)/ }).click();
+
+    const reloadedMessengerBox = modal.getByTestId("messenger-box-0");
+    await expect(reloadedMessengerBox).toBeVisible();
+
+    await reloadedMessengerBox.getByRole("button", { name: "edit" }).click();
+
+    await expectModalHidden(modal);
+    await expectModalVisible(messengerModal);
+
+    await page.getByRole("button", { name: "Show advanced settings" }).click();
+    await expect(messengerModal.getByLabel("Delay")).toHaveValue("5");
+  });
 });


### PR DESCRIPTION
Add an optional notification delay setting to the ntfy messenger
configuration. The delay can be configured from the UI under
Notifications → Show advanced settings.

This helps vehicles with delayed API wake-up or identification,
preventing notifications from being sent before EVCC has determined
the connected vehicle and updated its state.

Changes include:
- Add delay field to ntfy messenger configuration
- Persist delay in YAML configuration
- Apply delay before notification delivery
- Make delayed notifications non-blocking
- Add Playwright UI test coverage
- Add template and backend tests
- Validate delay values and cap excessive delays