### PR TITLE
Deye: fix energy and power, add returnenergy and voltages

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -133,6 +133,28 @@ render: |
         type: holding
         decode: int16
       scale: 0.01
+  voltages:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 598 # Grid voltage L1
+        type: holding
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 599 # Grid voltage L2
+        type: holding
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 600 # Grid voltage L3
+        type: holding
+        decode: uint16
+      scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
   power:

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -100,7 +100,17 @@ render: |
       decode: uint32s
     {{- if not .firmware1098 }}
     scale: 0.1
-    {{- end }}      
+    {{- end }}
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 524 # "Total_GridSell_Power Wh"
+      type: holding
+      decode: uint32s
+    {{- if not .firmware1098 }}
+    scale: 0.1
+    {{- end }}
   currents:
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -220,6 +230,16 @@ render: |
     {{- include "modbus" . | indent 2 }}
     register:
       address: 518 # "Total discharge of the battery (Wh)"
+      type: holding
+      decode: uint32s
+    {{- if not .firmware1098 }}
+    scale: 0.1
+    {{- end }}
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 516 # "Total charge of the battery (Wh)"
       type: holding
       decode: uint32s
     {{- if not .firmware1098 }}

--- a/templates/definition/meter/deye-mi.yaml
+++ b/templates/definition/meter/deye-mi.yaml
@@ -29,7 +29,7 @@ render: |
     register:
       address: 86 # "Output active power"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   energy:
     source: modbus
@@ -37,6 +37,6 @@ render: |
     register:
       address: 63 # "Total_Active_PowerWh"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   {{- end }}

--- a/templates/definition/meter/deye-storage.yaml
+++ b/templates/definition/meter/deye-storage.yaml
@@ -76,7 +76,7 @@ render: |
     register:
       address: 96 # "historyPV PowerWh"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   {{- end }}
   {{- if eq .usage "battery" }}
@@ -93,7 +93,7 @@ render: |
     register:
       address: 74 # "Battery cumulative discharge"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   soc:
     source: modbus

--- a/templates/definition/meter/deye-storage.yaml
+++ b/templates/definition/meter/deye-storage.yaml
@@ -41,6 +41,14 @@ render: |
         type: holding
         decode: uint16
       scale: 6553.6
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 81 # "Total_GridSell_PowerWh" (low word, high word at 82)
+      type: holding
+      decode: uint32s
+    scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
   power:
@@ -92,6 +100,14 @@ render: |
     {{- include "modbus" . | indent 2 }}
     register:
       address: 74 # "Battery cumulative discharge"
+      type: holding
+      decode: uint32s
+    scale: 0.1
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 72 # "Battery cumulative charge"
       type: holding
       decode: uint32s
     scale: 0.1

--- a/templates/definition/meter/deye-string.yaml
+++ b/templates/definition/meter/deye-string.yaml
@@ -22,7 +22,7 @@ render: |
     register:
       address: 86 # "Output active power"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   energy:
     source: modbus
@@ -30,6 +30,6 @@ render: |
     register:
       address: 63 # "Total_Active_PowerWh"
       type: holding
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   {{- end }}


### PR DESCRIPTION
Fixes all Deye templates by cross-verification on other implementations.

Fixes `energy` register decoding.

Additionally adds
- `returnenergy` (grid, battery)
- `voltages` (grid)

Fixes evcc-io/evcc#30673