### PR TITLE
sqlite: restore busy_timeout pragma

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -52,18 +52,17 @@ func New(driver, dsn string) (*gorm.DB, error) {
 		filePath = file
 
 		// TODO WAL mode "journal_mode(WAL)", "synchronous(NORMAL)"
-		for _, pragma := range []string{"foreign_keys(1)", "auto_vacuum(INCREMENTAL)"} {
-			// Add busy_timeout pragma if not already present
+		for _, pragma := range []string{"busy_timeout(5000)", "foreign_keys(1)", "auto_vacuum(INCREMENTAL)"} {
+			// add pragma if not already present
 			if short, _, _ := strings.Cut(pragma, "("); strings.Contains(params, "_pragma="+short) {
 				continue
 			}
 
-			// Append '&' if there are existing connection parameters
+			// append '&' if there are existing connection parameters
 			if len(params) > 0 {
 				params += "&"
 			}
 
-			// Add busy_timeout pragma to connection parameters
 			params += "_pragma=" + pragma
 		}
 


### PR DESCRIPTION
fixes #30670

The DSN pragma rewrite in #29511 dropped the default `busy_timeout(5000)` that evcc has applied since the glebarez era. modernc.org/sqlite sets no default busy timeout, so since 0.307.0 any concurrent write hitting a locked database fails immediately with `database is locked (5) (SQLITE_BUSY)` instead of waiting.

Notes:

- `synchronous(NORMAL)` was also dropped in #29511; left out here as the TODO defers it to the WAL change.
- `_time_format=sqlite` (libtnb/sqlite#15 workaround, added in #29493) was dropped as well — possibly worth a separate look.
- `foreign_keys(1)` in the DSN reverses #29697 (which moved it into the metrics migrator); unchanged here.