### PR TITLE
History UI: fix consumption with no ext/aux meters

### DIFF
--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -282,7 +282,7 @@ export default defineComponent({
 				const activeMeters = meters
 					.map((s, i) => ({ ...s, paletteIndex: i }))
 					.filter(hasEnergy);
-				if (!home || activeMeters.length === 0) return activeMeters;
+				if (!home) return activeMeters;
 				const meterTotals = new Map<string, number>();
 				// Net per slot is computed from all meters (incl. inactive ones), so
 				// dropping inactive entries from the display doesn't shift the
@@ -394,7 +394,8 @@ export default defineComponent({
 		hasEntityLegend(group: string): boolean {
 			const list = this.displaySeries(group);
 			if (!list.length) return false;
-			if (group === "loadpoint" || group === "meter") return true;
+			// Without explicit consumers an "Others"-only legend is meaningless.
+			if (group === "loadpoint" || group === "meter") return list.some((s) => !s.virtual);
 			if (group === "pv" || group === "battery") return list.length > 1;
 			return false;
 		},

--- a/tests/energy-history.spec.ts
+++ b/tests/energy-history.spec.ts
@@ -190,6 +190,17 @@ test.describe("consumption breakdown", () => {
     await expect(consumption.getByRole("button", { name: "Office 300 Wh" })).toBeVisible();
   });
 
+  // 2026-03-24: home = 0.4 kWh, no meter entities with data.
+  test("home without meters shows chart without legend", async ({ page }) => {
+    await gotoDay(page, 2026, 3, 24);
+    const consumption = section(page, "meter");
+    await expect(consumption).toBeVisible();
+
+    await expect(consumption.getByRole("heading")).toContainText("0.4 kWh");
+    // No explicit consumers, no entity legend.
+    await expect(consumption.getByRole("button")).toHaveCount(0);
+  });
+
   test("entity focus rescales axis and resets on unfocus", async ({ page }) => {
     await gotoDay(page, 2026, 4, 7);
     const consumption = section(page, "meter");


### PR DESCRIPTION
fixes #30677

Regression from #30196: the consumption section rendered empty when home had data but no consumer meters were active in the selected period.

- restore virtual "Others" series so household consumption shows again
- hide entity legend when "Others" would be the only entry, the label is meaningless without explicit consumers