### PR TITLE
Cardata: update container

### DIFF
--- a/vehicle/bmw/cardata/api.go
+++ b/vehicle/bmw/cardata/api.go
@@ -32,7 +32,7 @@ var requiredKeys = []string{
 	"vehicle.vehicle.travelledDistance",
 }
 
-const requiredVersion = "v4"
+const requiredVersion = "v5"
 
 type API struct {
 	*request.Helper


### PR DESCRIPTION
Follow-up to https://github.com/evcc-io/evcc/pull/29709

Did not know about the need to create a new container version to get the new datapoints through the rest API, so it's currently reusing older containers without the new datapoints. 

See also https://github.com/evcc-io/evcc/discussions/29446#discussioncomment-17249944.