### PR TITLE
Add OVUM MIRA heat pump support

### DIFF
--- a/templates/definition/charger/ovum-mira.yaml
+++ b/templates/definition/charger/ovum-mira.yaml
@@ -1,0 +1,115 @@
+template: ovum-mira
+products:
+  - brand: OVUM
+    description:
+      generic: MIRA
+group: heating
+capabilities: ["meter", "dim"]
+requirements:
+  description:
+    de: |
+      Der Modbus-TCP-Server muss am Display unter „Einstellungen / Netzwerk“ aktiviert und der Modbus Login-Code deaktiviert (Wert 1) werden, da evcc die Login-Sequenz nicht durchführt.
+      Die PV-Statusquelle muss am Display auf „EMS“ und die PV-Datenquelle auf die Leistungsvorgabe gestellt werden.
+      Benötigt MIRA-Regler ab Softwareversion V1.1.3.
+    en: |
+      The Modbus TCP server must be enabled at the display under "Settings / Network" and the Modbus login code must be disabled (value 1) since evcc does not perform the login sequence.
+      The PV status source must be set to "EMS" and the PV data source to the power setpoint at the display.
+      Requires MIRA controller software V1.1.3 or later.
+params:
+  - name: host
+  - name: tempsource
+    type: choice
+    choice: ["warmwater", "buffer"]
+  - name: wpmid
+    type: int
+    default: 111
+    advanced: true
+    description:
+      de: Slave-ID Wärmepumpenmodul
+      en: Heat pump module slave id
+    help:
+      de: Modbus Slave-ID des Wärmepumpenmoduls (WPM 1 = 111 … WPM 8 = 118)
+      en: Modbus slave id of the heat pump module (WPM 1 = 111 … WPM 8 = 118)
+render: |
+  type: sgready
+  getmode:
+    source: map
+    values:
+      0: 2 # Neutral -> normal
+      1: 3 # Erhöhen -> boost
+      2: 1 # Reduzieren -> dim
+    get:
+      source: modbus
+      uri: {{ joinHostPort .host "502" }}
+      id: 110 # HSM
+      register:
+        address: 55070 # HSM_EMS_PVSTATUS
+        type: holding
+        encoding: int16
+  setmode:
+    source: map
+    values:
+      1: 2 # dim -> Reduzieren
+      2: 0 # normal -> Neutral
+      3: 1 # boost -> Erhöhen
+    set:
+      source: modbus
+      uri: {{ joinHostPort .host "502" }}
+      id: 110 # HSM
+      register:
+        address: 55070 # HSM_EMS_PVSTATUS
+        type: writesingle
+        encoding: int16
+  setmaxpower:
+    source: modbus
+    uri: {{ joinHostPort .host "502" }}
+    id: 110 # HSM
+    register:
+      address: 55076 # HSM_EMS_SOLLPOWER
+      type: writemultiple
+      encoding: int32
+  power:
+    source: modbus
+    uri: {{ joinHostPort .host "502" }}
+    id: {{ .wpmid }} # WPM
+    register:
+      address: 56021 # WPM_WP_PWR
+      type: holding
+      encoding: float32
+    scale: 1000 # kW -> W
+  {{- if eq .tempsource "warmwater" }}
+  temp:
+    source: modbus
+    uri: {{ joinHostPort .host "502" }}
+    id: 110 # HSM
+    register:
+      address: 55007 # WW_ACTUALTEMPO
+      type: holding
+      encoding: float32
+  limittemp:
+    source: modbus
+    uri: {{ joinHostPort .host "502" }}
+    id: 110 # HSM
+    register:
+      address: 55002 # WW_SOLL_PV
+      type: holding
+      encoding: int16
+  {{- end }}
+  {{- if eq .tempsource "buffer" }}
+  temp:
+    source: modbus
+    uri: {{ joinHostPort .host "502" }}
+    id: 110 # HSM
+    register:
+      address: 55026 # HPUF_PUOT
+      type: holding
+      encoding: float32
+  limittemp:
+    source: modbus
+    uri: {{ joinHostPort .host "502" }}
+    id: 110 # HSM
+    register:
+      address: 55021 # PUFFER_SOLL_PV
+      type: holding
+      encoding: int16
+  {{- end }}


### PR DESCRIPTION
fixes #28372

Adds an `sgready` charger template for OVUM heat pumps with the new MIRA controller (software V1.1.3+), based on the Modbus documentation posted in https://github.com/evcc-io/evcc/issues/28372#issuecomment-4673922549.

The template maps evcc's SG Ready modes to the EMS PV status register 55070 (`HSM_EMS_PVSTATUS`: 0 = neutral, 1 = raise, 2 = reduce) and uses register 55076 (`HSM_EMS_SOLLPOWER`, W) as power envelope during boost — per OVUM's documentation the power setpoint is only honored while PV status is 1, which matches the sgready semantics exactly. Both are non-persistent process registers; the flash-backed `P_` parameters are only ever read (PV setpoint as `limittemp`), respecting OVUM's warning that cyclic parameter writes destroy the controller's flash.

Power readout comes from `WPM_WP_PWR` (56021, kW) on the heat pump module slave id (default 111, configurable for cascades). Temperature source is selectable between warm water (55007/55002) and heating buffer (55026/55021), all on the HSM slave id 110.

Requirements note that the Modbus TCP server must be enabled at the display, the Modbus login code disabled (evcc does not perform the FC16 login handshake), and the PV status source set to EMS.

Untested against real hardware — @SnejPro offered to verify with their installation.