### PR TITLE
Auth: coexist with reverse proxy Authorization header

### DIFF
--- a/server/http_auth.go
+++ b/server/http_auth.go
@@ -66,9 +66,13 @@ func updatePasswordHandler(authObject auth.Auth) http.HandlerFunc {
 	}
 }
 
-// apiKeyFromRequest returns the API key from the Authorization: Bearer header, or "" if absent
+// apiKeyFromRequest returns the API key from the Authorization: Bearer header, or "" if absent.
+// A non-Bearer Authorization header (e.g. Basic auth injected by a reverse proxy) is ignored.
 func apiKeyFromRequest(r *http.Request) string {
-	token, _ := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	token, found := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !found {
+		return ""
+	}
 	return token
 }
 
@@ -80,12 +84,17 @@ func jwtFromCookie(r *http.Request) string {
 	return ""
 }
 
-// validateAuth accepts a valid API key from the Authorization header, or a valid session JWT from the auth cookie
+// validateAuth accepts a valid API key from the Authorization header, or a valid session JWT from the auth cookie.
+// Any single valid credential grants access, so evcc coexists with a reverse proxy that injects its own
+// Authorization header or with clients that forward an unrelated bearer token.
 func validateAuth(authObject auth.Auth, r *http.Request) bool {
-	if key := apiKeyFromRequest(r); key != "" {
-		return authObject.ValidateApiKey(key)
+	if key := apiKeyFromRequest(r); key != "" && authObject.ValidateApiKey(key) {
+		return true
 	}
-	return authObject.ValidateJwtToken(jwtFromCookie(r))
+	if jwt := jwtFromCookie(r); jwt != "" && authObject.ValidateJwtToken(jwt) {
+		return true
+	}
+	return false
 }
 
 // requireAdminPassword passes when --disable-auth is set or the supplied password matches.


### PR DESCRIPTION
fixes #30716

A reverse proxy doing basic auth (Authentik, Caddy, Traefik) forwards an Authorization: Basic ... header to evcc. Since the long-lived API key landed in 0.309.0, that header was mistaken for a bearer token, failing api-key validation and blocking the valid session cookie. Login now coexists with proxy-injected credentials.

- ignore non-Bearer Authorization headers instead of treating them as an API key
- accept any single valid credential (api-key or session cookie), so a stray bearer token no longer blocks a valid cookie

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/evcc-io/evcc/pull/30757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

