### PR TITLE
History: scale chart axis to include forecast overlay

### DIFF
--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -110,9 +110,8 @@ export default defineComponent({
 		valueFactor(): number {
 			return this.period === PERIODS.DAY ? 4 : 1;
 		},
-		// Peak of stacked per-slot sums. Includes the forecast overlay (production,
-		// always positive) when shown so the dotted line is not clipped at the axis
-		// limit. Bidirectional: pos/neg separately.
+		// Peak of stacked per-slot sums, incl. overlay when shown so its line isn't
+		// clipped. Bidirectional: pos/neg separately.
 		axisPeak(): number {
 			const factor = this.valueFactor;
 			const peak = (series: HistorySeries[], pick: (slot: HistorySlot) => number) => {

--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -110,9 +110,9 @@ export default defineComponent({
 		valueFactor(): number {
 			return this.period === PERIODS.DAY ? 4 : 1;
 		},
-		// Peak of stacked per-slot sums, including the forecast overlay when shown
-		// so the dotted line is not clipped at the axis limit. Bidirectional:
-		// pos/neg separately.
+		// Peak of stacked per-slot sums. Includes the forecast overlay (production,
+		// always positive) when shown so the dotted line is not clipped at the axis
+		// limit. Bidirectional: pos/neg separately.
 		axisPeak(): number {
 			const factor = this.valueFactor;
 			const peak = (series: HistorySeries[], pick: (slot: HistorySlot) => number) => {
@@ -126,16 +126,17 @@ export default defineComponent({
 				for (const v of sums.values()) if (v > max) max = v;
 				return max;
 			};
-			const overlay = this.showOverlay ? this.overlay : [];
-			const net = (slot: HistorySlot) => Math.abs(slot.energy - slot.returnEnergy);
 			if (this.isBidirectional) {
 				return Math.max(
 					peak(this.visibleSeries, (slot) => Math.abs(slot.energy)),
-					peak(this.visibleSeries, (slot) => Math.abs(slot.returnEnergy)),
-					peak(overlay, net)
+					peak(this.visibleSeries, (slot) => Math.abs(slot.returnEnergy))
 				);
 			}
-			return Math.max(peak(this.visibleSeries, net), peak(overlay, net));
+			const overlay = this.showOverlay ? this.overlay : [];
+			return Math.max(
+				peak(this.visibleSeries, (slot) => Math.abs(slot.energy - slot.returnEnergy)),
+				peak(overlay, (slot) => slot.energy)
+			);
 		},
 		// W/Wh scale when peak below 1 kW(h). Zero data falls here too.
 		useSmallUnit(): boolean {

--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -110,12 +110,14 @@ export default defineComponent({
 		valueFactor(): number {
 			return this.period === PERIODS.DAY ? 4 : 1;
 		},
-		// Peak of stacked per-slot sums. Bidirectional: pos/neg separately.
+		// Peak of stacked per-slot sums, including the forecast overlay when shown
+		// so the dotted line is not clipped at the axis limit. Bidirectional:
+		// pos/neg separately.
 		axisPeak(): number {
 			const factor = this.valueFactor;
-			const peak = (pick: (slot: HistorySlot) => number) => {
+			const peak = (series: HistorySeries[], pick: (slot: HistorySlot) => number) => {
 				const sums = new Map<string, number>();
-				for (const s of this.visibleSeries) {
+				for (const s of series) {
 					for (const slot of s.data) {
 						sums.set(slot.start, (sums.get(slot.start) || 0) + pick(slot) * factor);
 					}
@@ -124,13 +126,16 @@ export default defineComponent({
 				for (const v of sums.values()) if (v > max) max = v;
 				return max;
 			};
+			const overlay = this.showOverlay ? this.overlay : [];
+			const net = (slot: HistorySlot) => Math.abs(slot.energy - slot.returnEnergy);
 			if (this.isBidirectional) {
 				return Math.max(
-					peak((slot) => Math.abs(slot.energy)),
-					peak((slot) => Math.abs(slot.returnEnergy))
+					peak(this.visibleSeries, (slot) => Math.abs(slot.energy)),
+					peak(this.visibleSeries, (slot) => Math.abs(slot.returnEnergy)),
+					peak(overlay, net)
 				);
 			}
-			return peak((slot) => Math.abs(slot.energy - slot.returnEnergy));
+			return Math.max(peak(this.visibleSeries, net), peak(overlay, net));
 		},
 		// W/Wh scale when peak below 1 kW(h). Zero data falls here too.
 		useSmallUnit(): boolean {


### PR DESCRIPTION
fixes #30707

The y-axis range of the history charts is derived from axisPeak, which only considered the bar series. The forecast overlay was excluded, so on days where actual production stayed well below the forecast the explicit axis max (set when the peak is below 1 kW, and for bidirectional groups) ended up lower than the forecast values and echarts clipped the dotted line at the top of the grid. That matches the report: it only happened on a single low-production day.

axisPeak now includes the overlay values when the overlay is shown, so the axis limit, the W/kW unit selection and the tick digits all account for the forecast and the line stays fully visible. With the overlay hidden the behavior is unchanged.