### PR TITLE
Password: fail loudly when settings cannot be saved

### DIFF
--- a/cmd/password.go
+++ b/cmd/password.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/spf13/cobra"
 )
 
@@ -11,4 +15,20 @@ var passwordCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(passwordCmd)
+}
+
+// fatalDatabase logs a database error and exits, hinting at file permissions
+// when the database is not writable by the current user.
+func fatalDatabase(err error) {
+	if strings.Contains(err.Error(), "readonly database") {
+		log.FATAL.Println("database is not writable; run this command as the user owning the database file, e.g. sudo -u evcc")
+	}
+	log.FATAL.Fatal(err)
+}
+
+// persistPasswordSettings writes pending settings to the database
+func persistPasswordSettings() {
+	if err := settings.Persist(); err != nil {
+		fatalDatabase(fmt.Errorf("cannot save settings: %w", err))
+	}
 }

--- a/cmd/password.go
+++ b/cmd/password.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/evcc-io/evcc/server/db"
 	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +20,7 @@ func init() {
 // fatalDatabase logs a database error and exits, hinting at file permissions
 // when the database is not writable by the current user.
 func fatalDatabase(err error) {
-	if strings.Contains(err.Error(), "readonly database") {
+	if db.IsReadonly(err) {
 		log.FATAL.Println("database is not writable; run this command as the user owning the database file, e.g. sudo -u evcc")
 	}
 	log.FATAL.Fatal(err)

--- a/cmd/password_reset.go
+++ b/cmd/password_reset.go
@@ -26,7 +26,7 @@ func runPasswordReset(cmd *cobra.Command, args []string) {
 
 	// setup persistence
 	if err := configureDatabase(conf.Database); err != nil {
-		log.FATAL.Fatal(err)
+		fatalDatabase(err)
 	}
 
 	confirm, _ := cmd.Flags().GetBool(flagForce)
@@ -44,5 +44,6 @@ func runPasswordReset(cmd *cobra.Command, args []string) {
 
 	if confirm {
 		auth.New().RemoveAdminPassword()
+		persistPasswordSettings()
 	}
 }

--- a/cmd/password_set.go
+++ b/cmd/password_set.go
@@ -25,7 +25,7 @@ func runPasswordSet(cmd *cobra.Command, args []string) {
 
 	// setup persistence
 	if err := configureDatabase(conf.Database); err != nil {
-		log.FATAL.Fatal(err)
+		fatalDatabase(err)
 	}
 
 	prompt := &survey.Password{
@@ -40,7 +40,9 @@ func runPasswordSet(cmd *cobra.Command, args []string) {
 
 	if password == "" {
 		log.FATAL.Fatal("password cannot be empty")
+	} else if err := auth.New().SetAdminPassword(password); err != nil {
+		log.FATAL.Fatal(err)
 	} else {
-		auth.New().SetAdminPassword(password)
+		persistPasswordSettings()
 	}
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"gorm.io/gorm"
 	sqlite3 "modernc.org/sqlite"
+	sqlite3lib "modernc.org/sqlite/lib"
 )
 
 var (
@@ -110,6 +111,13 @@ func Close() error {
 		return err
 	}
 	return db.Close()
+}
+
+// IsReadonly reports whether err indicates a database file that is not
+// writable by the current user. The code mask covers extended result codes.
+func IsReadonly(err error) bool {
+	var serr *sqlite3.Error
+	return errors.As(err, &serr) && serr.Code()&0xff == sqlite3lib.SQLITE_READONLY
 }
 
 type backuper interface {

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -116,8 +116,8 @@ func Close() error {
 // IsReadonly reports whether err indicates a database file that is not
 // writable by the current user. The code mask covers extended result codes.
 func IsReadonly(err error) bool {
-	var serr *sqlite3.Error
-	return errors.As(err, &serr) && serr.Code()&0xff == sqlite3lib.SQLITE_READONLY
+	serr, ok := errors.AsType[*sqlite3.Error](err)
+	return ok && serr.Code()&0xff == sqlite3lib.SQLITE_READONLY
 }
 
 type backuper interface {

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -116,8 +116,8 @@ func Close() error {
 // IsReadonly reports whether err indicates a database file that is not
 // writable by the current user. The code mask covers extended result codes.
 func IsReadonly(err error) bool {
-	serr, ok := errors.AsType[*sqlite3.Error](err)
-	return ok && serr.Code()&0xff == sqlite3lib.SQLITE_READONLY
+	var serr *sqlite3.Error
+	return errors.As(err, &serr) && serr.Code()&0xff == sqlite3lib.SQLITE_READONLY
 }
 
 type backuper interface {


### PR DESCRIPTION
fixes #30703, pairs with evcc-io/docs#1085

The password set/reset commands only updated the in-memory settings store; the database write happened later in the persist-on-shutdown hook, where a failure is logged as a plain ERROR line and the command still exits 0. When the database is not writable (typically because the command runs as the login user while /var/lib/evcc/evcc.db is owned by the evcc service user), the reset silently does not happen.

The commands now persist explicitly and exit non-zero on failure. Readonly database errors, whether from opening the database or from saving, additionally print an actionable hint to re-run the command as the user owning the database file. password set no longer ignores the error returned by SetAdminPassword.

Verified against a readonly sqlite file: the command prints the hint and exits 1; with a writable file it succeeds as before.

The companion docs PR fixes the FAQ commands to use sudo -u evcc with the --database flag.