### PR TITLE
Add Modbus/TLS support for Kostal KSEM

### DIFF
--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -261,7 +261,15 @@ export default {
 			return (
 				this.rows ||
 				this.array ||
-				["accessToken", "refreshToken", "identifiers", "formula"].includes(this.property)
+				[
+					"accessToken",
+					"refreshToken",
+					"identifiers",
+					"formula",
+					"clientcert",
+					"clientkey",
+					"cacert",
+				].includes(this.property)
 			);
 		},
 		textareaRows() {

--- a/templates/definition/meter/kostal-ksem.yaml
+++ b/templates/definition/meter/kostal-ksem.yaml
@@ -9,6 +9,24 @@ params:
   - name: modbus
     choice: ["tcpip"]
     id: 71
+  - name: cert
+    description:
+      de: Client-Zertifikat (PEM) für Modbus über TLS
+      en: Client certificate (PEM) for Modbus over TLS
+    help:
+      de: Nur nötig, wenn im KSEM TLS aktiviert ist (Port 802). Das Zertifikat muss im KSEM akzeptiert werden.
+      en: Only needed if TLS is enabled in the KSEM (port 802). The certificate must be accepted in the KSEM.
+    advanced: true
+  - name: key
+    description:
+      de: Privater Schlüssel (PEM)
+      en: Private key (PEM)
+    advanced: true
+  - name: cacert
+    description:
+      de: Server-CA-Zertifikat (PEM, optional)
+      en: Server CA certificate (PEM, optional)
+    advanced: true
 render: |
   type: custom
   # sunspec model 203 (int+sf)/ 213 (float) meter

--- a/templates/definition/meter/kostal-ksem.yaml
+++ b/templates/definition/meter/kostal-ksem.yaml
@@ -9,24 +9,13 @@ params:
   - name: modbus
     choice: ["tcpip"]
     id: 71
-  - name: cert
-    description:
-      de: Client-Zertifikat (PEM) für Modbus über TLS
-      en: Client certificate (PEM) for Modbus over TLS
+  - name: clientcert
     help:
-      de: Nur nötig, wenn im KSEM TLS aktiviert ist (Port 802). Das Zertifikat muss im KSEM akzeptiert werden.
-      en: Only needed if TLS is enabled in the KSEM (port 802). The certificate must be accepted in the KSEM.
-    advanced: true
-  - name: key
-    description:
-      de: Privater Schlüssel (PEM)
-      en: Private key (PEM)
-    advanced: true
+      de: Nur nötig, wenn im KSEM Modbus/TLS aktiviert ist. Dann Port auf 802 setzen. Das Zertifikat wird beim ersten (fehlschlagenden) Verbindungsversuch im KSEM unter "Modbus Einstellungen" -> "Zertifikate" zur Freigabe angeboten.
+      en: Only needed if Modbus/TLS is enabled in the KSEM. Set the port to 802 in that case. The certificate is offered for approval in the KSEM under "Modbus Settings" -> "Certificates" after the first (failing) connection attempt.
+  - name: clientkey
   - name: cacert
-    description:
-      de: Server-CA-Zertifikat (PEM, optional)
-      en: Server CA certificate (PEM, optional)
-    advanced: true
+  - name: insecure
 render: |
   type: custom
   # sunspec model 203 (int+sf)/ 213 (float) meter

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -19,6 +19,7 @@ const (
 	Rtu
 	Ascii
 	Udp
+	Tls
 
 	CoilOn uint16 = 0xFF00
 )
@@ -59,6 +60,16 @@ type Settings struct {
 	RTU       *bool         `json:"rtu,omitempty" yaml:",omitempty"`
 	Delay     time.Duration `json:"delay,omitempty" yaml:",omitempty"`
 	Timeout   time.Duration `json:"timeout,omitempty" yaml:",omitempty"`
+	// TLS: when Cert and Key are set, the TCP connection is wrapped in TLS
+	// (Modbus over TLS). If unset, no TLS is used.
+	Cert   string `json:"cert,omitempty" yaml:",omitempty"`
+	Key    string `json:"key,omitempty" yaml:",omitempty"`
+	CACert string `json:"cacert,omitempty" yaml:",omitempty"`
+}
+
+// TLS reports whether TLS is configured (client certificate present)
+func (s Settings) TLS() bool {
+	return s.Cert != "" && s.Key != ""
 }
 
 // Connection creates a modbus connection from the settings, applying delay and timeout.
@@ -69,7 +80,7 @@ func (s Settings) Connection(ctx context.Context, proto ...Protocol) (*Connectio
 		p = proto[0]
 	}
 
-	conn, err := NewConnection(ctx, s.URI, s.Device, s.Comset, s.Baudrate, p, s.ID)
+	conn, err := NewConnectionFromSettings(ctx, s, p)
 	if err != nil {
 		return nil, err
 	}

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -60,16 +60,20 @@ type Settings struct {
 	RTU       *bool         `json:"rtu,omitempty" yaml:",omitempty"`
 	Delay     time.Duration `json:"delay,omitempty" yaml:",omitempty"`
 	Timeout   time.Duration `json:"timeout,omitempty" yaml:",omitempty"`
-	// TLS: when Cert and Key are set, the TCP connection is wrapped in TLS
-	// (Modbus over TLS). If unset, no TLS is used.
-	Cert   string `json:"cert,omitempty" yaml:",omitempty"`
-	Key    string `json:"key,omitempty" yaml:",omitempty"`
-	CACert string `json:"cacert,omitempty" yaml:",omitempty"`
+	// Modbus over TLS (mTLS): PEM-encoded client certificate/key. When set, the
+	// TCP connection is wrapped in TLS. CACert verifies the device certificate,
+	// Insecure skips that verification.
+	ClientCert string `json:"clientcert,omitempty" yaml:",omitempty"`
+	ClientKey  string `json:"clientkey,omitempty" yaml:",omitempty"`
+	CACert     string `json:"cacert,omitempty" yaml:",omitempty"`
+	Insecure   bool   `json:"insecure,omitempty" yaml:",omitempty"`
 }
 
-// TLS reports whether TLS is configured (client certificate present)
-func (s Settings) TLS() bool {
-	return s.Cert != "" && s.Key != ""
+// tlsConfigured reports whether any TLS setting is present. Completeness is
+// validated in tlsConfig, since setting a single field must not silently fall
+// back to an unencrypted connection.
+func (s Settings) tlsConfigured() bool {
+	return s.ClientCert != "" || s.ClientKey != "" || s.CACert != "" || s.Insecure
 }
 
 // Connection creates a modbus connection from the settings, applying delay and timeout.
@@ -80,9 +84,15 @@ func (s Settings) Connection(ctx context.Context, proto ...Protocol) (*Connectio
 		p = proto[0]
 	}
 
-	conn, err := NewConnectionFromSettings(ctx, s, p)
+	physical, err := physicalConnection(ctx, p, s)
 	if err != nil {
 		return nil, err
+	}
+
+	conn := &Connection{
+		slaveID:    s.ID,
+		Connection: physical.Clone(s.ID),
+		logger:     physical.logger,
 	}
 
 	conn.Timeout(s.Timeout)
@@ -195,6 +205,23 @@ func NewConnection(ctx context.Context, uri, device, comset string, baudrate int
 func physicalConnection(ctx context.Context, proto Protocol, cfg Settings) (*meterConnection, error) {
 	if (cfg.Device != "") == (cfg.URI != "") {
 		return nil, errors.New("invalid modbus configuration: must have either uri or device")
+	}
+
+	if cfg.tlsConfigured() {
+		// Modbus/TLS is only defined for MBAP-framed TCP
+		if cfg.Device != "" || proto != Tcp {
+			return nil, errors.New("invalid modbus configuration: tls requires tcp")
+		}
+
+		tlsConfig, err := cfg.tlsConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		// default port 802 (Modbus/TCP Security)
+		uri := util.DefaultPort(cfg.URI, 802)
+
+		return registeredConnection(ctx, uri, Tls, newTLSConn(uri, tlsConfig))
 	}
 
 	if cfg.Device != "" {

--- a/util/modbus/tls.go
+++ b/util/modbus/tls.go
@@ -1,52 +1,45 @@
 package modbus
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
-	"os"
 
-	"github.com/evcc-io/evcc/util"
 	gridx "github.com/grid-x/modbus"
 	"github.com/volkszaehler/mbmd/meters"
 )
 
-// TLSConfig builds a *tls.Config for Modbus over mutual TLS (mTLS).
+// tlsConfig builds a *tls.Config for Modbus over mutual TLS (mTLS) from the
+// PEM-encoded certificates in Settings.
 //
-// cert and key are required: they provide the client certificate used for
-// mTLS.
-//
-// ca is optional. When non-empty it is loaded as the trusted CA for server
-// certificate verification. When empty the server certificate is not verified
-// (InsecureSkipVerify), which is typical for devices that present a private-CA
-// or self-signed server certificate not in the system trust store.
-func TLSConfig(cert, key, ca string) (*tls.Config, error) {
-	if cert == "" || key == "" {
-		return nil, fmt.Errorf("modbus tls: client certificate (cert and key) required for mTLS")
+// ClientCert and ClientKey are required since Modbus/TLS mandates client
+// authentication. CACert verifies the device certificate. Devices typically
+// present a self-signed certificate, for which Insecure must be set instead.
+func (s Settings) tlsConfig() (*tls.Config, error) {
+	if s.ClientCert == "" || s.ClientKey == "" {
+		return nil, errors.New("modbus tls: clientcert and clientkey required")
 	}
 
-	clientCert, err := tls.LoadX509KeyPair(cert, key)
+	if s.CACert == "" && !s.Insecure {
+		return nil, errors.New("modbus tls: cacert required to verify the device certificate, use insecure to skip verification")
+	}
+
+	clientCert, err := tls.X509KeyPair([]byte(s.ClientCert), []byte(s.ClientKey))
 	if err != nil {
-		return nil, fmt.Errorf("modbus tls: loading client certificate: %w", err)
+		return nil, fmt.Errorf("modbus tls: client certificate: %w", err)
 	}
 
 	cfg := &tls.Config{
-		Certificates: []tls.Certificate{clientCert},
-		MinVersion:   tls.VersionTLS12,
+		Certificates:       []tls.Certificate{clientCert},
+		InsecureSkipVerify: s.Insecure,
+		MinVersion:         tls.VersionTLS12,
 	}
 
-	if ca == "" {
-		cfg.InsecureSkipVerify = true
-	} else {
-		pem, err := os.ReadFile(ca)
-		if err != nil {
-			return nil, fmt.Errorf("modbus tls: reading ca certificate: %w", err)
-		}
-
+	if s.CACert != "" {
 		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf("modbus tls: no certificates found in %s", ca)
+		if !pool.AppendCertsFromPEM([]byte(s.CACert)) {
+			return nil, errors.New("modbus tls: no certificate found in cacert")
 		}
 		cfg.RootCAs = pool
 	}
@@ -54,54 +47,16 @@ func TLSConfig(cert, key, ca string) (*tls.Config, error) {
 	return cfg, nil
 }
 
-// NewConnectionFromSettings creates a modbus connection from settings, using
-// TLS when a client certificate is configured (Settings.TLS) and the plain
-// transport otherwise.
-func NewConnectionFromSettings(ctx context.Context, cfg Settings, proto ...Protocol) (*Connection, error) {
-	if cfg.TLS() {
-		tlsConfig, err := TLSConfig(cfg.Cert, cfg.Key, cfg.CACert)
-		if err != nil {
-			return nil, err
-		}
-
-		return NewTLSConnection(ctx, cfg.URI, tlsConfig, cfg.ID)
-	}
-
-	p := cfg.Protocol()
-	if len(proto) > 0 {
-		p = proto[0]
-	}
-
-	return NewConnection(ctx, cfg.URI, cfg.Device, cfg.Comset, cfg.Baudrate, p, cfg.ID)
-}
-
-// NewTLSConnection creates a Modbus TCP connection secured with TLS. It
-// mirrors NewConnection but always uses the TCP transport wrapped in TLS
-// using the supplied tls.Config. The default port is 802 (Modbus/TCP Security).
-func NewTLSConnection(ctx context.Context, uri string, tlsConfig *tls.Config, slaveID uint8) (*Connection, error) {
-	conn, err := physicalTLSConnection(ctx, uri, tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Connection{
-		slaveID:    slaveID,
-		Connection: conn.Clone(slaveID),
-		logger:     conn.logger,
-	}, nil
-}
-
-func physicalTLSConnection(ctx context.Context, uri string, tlsConfig *tls.Config) (*meterConnection, error) {
-	uri = util.DefaultPort(uri, 802)
-
+// newTLSConn creates a Modbus TCP connection wrapped in TLS
+func newTLSConn(uri string, tlsConfig *tls.Config) *meters.TCP {
 	handler := gridx.NewTCPClientHandler(uri, gridx.WithTLSConfig(tlsConfig))
+
+	// use retry outside of grid-x/modbus
 	handler.LinkRecoveryTimeout = 0
 	handler.ProtocolRecoveryTimeout = 0
 
-	conn := &meters.TCP{
+	return &meters.TCP{
 		Client:  gridx.NewClient(handler),
 		Handler: handler,
 	}
-
-	return registeredConnection(ctx, uri, Tls, conn)
 }

--- a/util/modbus/tls.go
+++ b/util/modbus/tls.go
@@ -1,0 +1,107 @@
+package modbus
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/evcc-io/evcc/util"
+	gridx "github.com/grid-x/modbus"
+	"github.com/volkszaehler/mbmd/meters"
+)
+
+// TLSConfig builds a *tls.Config for Modbus over mutual TLS (mTLS).
+//
+// cert and key are required: they provide the client certificate used for
+// mTLS.
+//
+// ca is optional. When non-empty it is loaded as the trusted CA for server
+// certificate verification. When empty the server certificate is not verified
+// (InsecureSkipVerify), which is typical for devices that present a private-CA
+// or self-signed server certificate not in the system trust store.
+func TLSConfig(cert, key, ca string) (*tls.Config, error) {
+	if cert == "" || key == "" {
+		return nil, fmt.Errorf("modbus tls: client certificate (cert and key) required for mTLS")
+	}
+
+	clientCert, err := tls.LoadX509KeyPair(cert, key)
+	if err != nil {
+		return nil, fmt.Errorf("modbus tls: loading client certificate: %w", err)
+	}
+
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if ca == "" {
+		cfg.InsecureSkipVerify = true
+	} else {
+		pem, err := os.ReadFile(ca)
+		if err != nil {
+			return nil, fmt.Errorf("modbus tls: reading ca certificate: %w", err)
+		}
+
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("modbus tls: no certificates found in %s", ca)
+		}
+		cfg.RootCAs = pool
+	}
+
+	return cfg, nil
+}
+
+// NewConnectionFromSettings creates a modbus connection from settings, using
+// TLS when a client certificate is configured (Settings.TLS) and the plain
+// transport otherwise.
+func NewConnectionFromSettings(ctx context.Context, cfg Settings, proto ...Protocol) (*Connection, error) {
+	if cfg.TLS() {
+		tlsConfig, err := TLSConfig(cfg.Cert, cfg.Key, cfg.CACert)
+		if err != nil {
+			return nil, err
+		}
+
+		return NewTLSConnection(ctx, cfg.URI, tlsConfig, cfg.ID)
+	}
+
+	p := cfg.Protocol()
+	if len(proto) > 0 {
+		p = proto[0]
+	}
+
+	return NewConnection(ctx, cfg.URI, cfg.Device, cfg.Comset, cfg.Baudrate, p, cfg.ID)
+}
+
+// NewTLSConnection creates a Modbus TCP connection secured with TLS. It
+// mirrors NewConnection but always uses the TCP transport wrapped in TLS
+// using the supplied tls.Config. The default port is 802 (Modbus/TCP Security).
+func NewTLSConnection(ctx context.Context, uri string, tlsConfig *tls.Config, slaveID uint8) (*Connection, error) {
+	conn, err := physicalTLSConnection(ctx, uri, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Connection{
+		slaveID:    slaveID,
+		Connection: conn.Clone(slaveID),
+		logger:     conn.logger,
+	}, nil
+}
+
+func physicalTLSConnection(ctx context.Context, uri string, tlsConfig *tls.Config) (*meterConnection, error) {
+	uri = util.DefaultPort(uri, 802)
+
+	handler := gridx.NewTCPClientHandler(uri, gridx.WithTLSConfig(tlsConfig))
+	handler.LinkRecoveryTimeout = 0
+	handler.ProtocolRecoveryTimeout = 0
+
+	conn := &meters.TCP{
+		Client:  gridx.NewClient(handler),
+		Handler: handler,
+	}
+
+	return registeredConnection(ctx, uri, Tls, conn)
+}

--- a/util/modbus/tls_test.go
+++ b/util/modbus/tls_test.go
@@ -1,0 +1,130 @@
+package modbus
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testKeyPair creates a self-signed certificate and key in PEM format
+func testKeyPair(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "evcc"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDer, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDer})
+
+	return string(certPem), string(keyPem)
+}
+
+func TestSettingsTlsConfigured(t *testing.T) {
+	tc := []struct {
+		Settings
+		res bool
+	}{
+		{Settings{}, false},
+		{Settings{URI: "foo"}, false},
+		{Settings{ClientCert: "foo"}, true},
+		{Settings{ClientKey: "foo"}, true},
+		{Settings{CACert: "foo"}, true},
+		{Settings{Insecure: true}, true},
+	}
+
+	for _, tc := range tc {
+		require.Equal(t, tc.res, tc.tlsConfigured(), tc)
+	}
+}
+
+func TestTlsConfig(t *testing.T) {
+	cert, key := testKeyPair(t)
+
+	t.Run("insecure", func(t *testing.T) {
+		cfg, err := Settings{ClientCert: cert, ClientKey: key, Insecure: true}.tlsConfig()
+		require.NoError(t, err)
+		require.True(t, cfg.InsecureSkipVerify)
+		require.Nil(t, cfg.RootCAs)
+		require.Len(t, cfg.Certificates, 1)
+	})
+
+	t.Run("cacert", func(t *testing.T) {
+		cfg, err := Settings{ClientCert: cert, ClientKey: key, CACert: cert}.tlsConfig()
+		require.NoError(t, err)
+		require.False(t, cfg.InsecureSkipVerify)
+		require.NotNil(t, cfg.RootCAs)
+	})
+
+	// incomplete or invalid configuration must error instead of silently
+	// falling back to an unencrypted connection
+	t.Run("errors", func(t *testing.T) {
+		tc := []struct {
+			name string
+			Settings
+		}{
+			{"cert without key", Settings{ClientCert: cert, Insecure: true}},
+			{"key without cert", Settings{ClientKey: key, Insecure: true}},
+			{"cacert only", Settings{CACert: cert}},
+			{"insecure only", Settings{Insecure: true}},
+			{"neither cacert nor insecure", Settings{ClientCert: cert, ClientKey: key}},
+			{"invalid keypair", Settings{ClientCert: "foo", ClientKey: "bar", Insecure: true}},
+			{"invalid cacert", Settings{ClientCert: cert, ClientKey: key, CACert: "foo"}},
+		}
+
+		for _, tc := range tc {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := tc.tlsConfig()
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+// TestTlsRequiresTcp ensures tls settings are rejected for non-tcp transports
+// instead of being silently ignored
+func TestTlsRequiresTcp(t *testing.T) {
+	cert, key := testKeyPair(t)
+	tls := Settings{ClientCert: cert, ClientKey: key, Insecure: true}
+
+	tc := []struct {
+		name string
+		Settings
+	}{
+		{"serial device", Settings{Device: "/dev/ttyUSB0", Comset: "8N1", Baudrate: 9600}},
+		{"rtu over tcp", Settings{URI: "foo:502", RTU: new(true)}},
+		{"udp", Settings{URI: "foo:502", UDP: true}},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.Settings
+			cfg.ClientCert, cfg.ClientKey, cfg.Insecure = tls.ClientCert, tls.ClientKey, tls.Insecure
+
+			_, err := physicalConnection(context.Background(), cfg.Protocol(), cfg)
+			require.ErrorContains(t, err, "tls requires tcp")
+		})
+	}
+}

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -67,6 +67,40 @@ params:
       de: E-Mail-Adresse
       en: Email address
     example: "user@example.com"
+  - name: clientcert
+    description:
+      de: Client-Zertifikat
+      en: Client certificate
+    help:
+      de: PEM-kodiertes Zertifikat zur Authentisierung gegenüber dem Gerät (mTLS)
+      en: PEM encoded certificate used to authenticate against the device (mTLS)
+    advanced: true
+  - name: clientkey
+    description:
+      de: Privater Schlüssel
+      en: Private key
+    help:
+      de: PEM-kodierter privater Schlüssel zum Client-Zertifikat
+      en: PEM encoded private key matching the client certificate
+    advanced: true
+    mask: true
+  - name: cacert
+    description:
+      de: CA-Zertifikat
+      en: CA certificate
+    help:
+      de: PEM-kodiertes CA-Zertifikat zur Prüfung des Gerätezertifikats
+      en: PEM encoded CA certificate used to verify the device certificate
+    advanced: true
+  - name: insecure
+    description:
+      de: Zertifikatsprüfung überspringen
+      en: Skip certificate verification
+    help:
+      de: Gerätezertifikat nicht prüfen. Nötig bei selbstsignierten Zertifikaten.
+      en: Do not verify the device certificate. Required for self-signed certificates.
+    type: bool
+    advanced: true
   - name: capacity
     unit: kWh
     description:

--- a/util/templates/modbus.tpl
+++ b/util/templates/modbus.tpl
@@ -13,6 +13,14 @@ rtu: true
 # Modbus TCP
 uri: {{ joinHostPort .host .port }}
 rtu: false
+{{- if .cert }}
+# Modbus over TLS (client certificate)
+cert: {{ .cert }}
+key: {{ .key }}
+{{- if .cacert }}
+cacert: {{ .cacert }}
+{{- end }}
+{{- end }}
 {{- else if or (eq .modbus "udp") .udp }}
 # Modbus UDP
 uri: {{ joinHostPort .host .port }}

--- a/util/templates/modbus.tpl
+++ b/util/templates/modbus.tpl
@@ -13,12 +13,15 @@ rtu: true
 # Modbus TCP
 uri: {{ joinHostPort .host .port }}
 rtu: false
-{{- if .cert }}
-# Modbus over TLS (client certificate)
-cert: {{ .cert }}
-key: {{ .key }}
+{{- if .clientcert }}
+# Modbus over TLS (mTLS)
+clientcert: {{ .clientcert }}
+clientkey: {{ .clientkey }}
 {{- if .cacert }}
 cacert: {{ .cacert }}
+{{- end }}
+{{- if .insecure }}
+insecure: true
 {{- end }}
 {{- end }}
 {{- else if or (eq .modbus "udp") .udp }}

--- a/util/templates/template_modbus_test.go
+++ b/util/templates/template_modbus_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
 )
 
 var renderModeNames = map[int]string{
@@ -49,6 +50,41 @@ func TestModbusTemplateUserIDOverridesTemplate(t *testing.T) {
 			assert.Equal(t, "42", values["id"], "user-supplied modbus id must not be overwritten")
 		})
 	}
+}
+
+// TestModbusTemplateTls verifies that multi-line PEM certificates survive
+// rendering as valid yaml
+func TestModbusTemplateTls(t *testing.T) {
+	const clientcert = "-----BEGIN CERTIFICATE-----\nMIIB\nkeQ=\n-----END CERTIFICATE-----\n"
+	const clientkey = "-----BEGIN EC PRIVATE KEY-----\nMHcC\nAwEH\n-----END EC PRIVATE KEY-----\n"
+
+	tmpl, err := ByName(Meter, "kostal-ksem")
+	require.NoError(t, err)
+
+	b, _, err := tmpl.RenderResult(RenderModeInstance, map[string]any{
+		"usage":      "grid",
+		"host":       "192.168.0.8",
+		"port":       802,
+		"clientcert": clientcert,
+		"clientkey":  clientkey,
+		"insecure":   true,
+	})
+	require.NoError(t, err)
+
+	var res struct {
+		Power struct {
+			URI        string
+			ClientCert string
+			ClientKey  string
+			Insecure   bool
+		}
+	}
+	require.NoError(t, yaml.Unmarshal(b, &res))
+
+	assert.Equal(t, "192.168.0.8:802", res.Power.URI)
+	assert.Equal(t, clientcert, res.Power.ClientCert)
+	assert.Equal(t, clientkey, res.Power.ClientKey)
+	assert.True(t, res.Power.Insecure)
 }
 
 // TestWallbeTemplateCoveredByPhoenix verifies the BC migration: a config that


### PR DESCRIPTION
If you want to change certain parameters in Kostal Smart Energy Meter over Modbus, it requires that the meter is set to Modbus/TLS mode. When TLS is enabled, it automatically disables the standard Modbus port. 

When TLS is enabled in KSEM, it requires mutual TLS. The client must present a certificate to the KSEM. Access must be attempted with the certificate against the KSEM first and this will fail. Then in the KSEM, you'll need to go to "Modbus Settings" -> "Certificates" and select to authorize this certificate. Then subsequent accesses will be successful.

Example for creating the client certificate:
openssl req -x509 -newkey rsa:2048 \
  -keyout ~/.evcc/ksem-tls/client.key \
  -out ~/.evcc/ksem-tls/client.crt \
  -sha256 -days 3650 -nodes \
  -subj "/CN=evcc/OU=evcc"

Addresses the Modbus/TLS aspect in discussion https://github.com/evcc-io/evcc/discussions/6641