### PR TITLE
Use register 1012 for Lambda Zewotherm power (FW >= 1.1.3)

### DIFF
--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -71,7 +71,7 @@ render: |
     uri: {{ joinHostPort .host .port }}
     id: 1
     register:
-      address: 103 # aktuelle Aufnahmeleistung [E] der WP
+      address: {{ if eq .firmware "<1.1.3" }}103{{ else }}1012{{ end }} # aktuelle Aufnahmeleistung [E] der WP
       type: holding
       decode: int16
   energy:


### PR DESCRIPTION
For Lambda Zewotherm heat pumps with firmware version >= 1.1.3, the correct Modbus register for permanent reading of electrical power is 1012 instead of 103. Register 103 returns invalid values (0 W) when E-Manager in Lambda UI is disabled.

This change updates the template to use register 1012 accordingly for FW >=1.1.3.

Fix #30778 