### PR TITLE
GoodWe: remove non-functional wallbox phase switching

### DIFF
--- a/charger/goodwe.go
+++ b/charger/goodwe.go
@@ -46,18 +46,17 @@ type GoodWe struct {
 }
 
 const (
-	goodweRegVoltages       = 10009 // U16 ×0.1 V, 3 regs (L1/L2/L3)
-	goodweRegCurrents       = 10012 // U16 ×0.1 A, 3 regs (L1/L2/L3)
-	goodweRegActualPower    = 10015 // U16 ×0.1 kW
-	goodweRegStatus         = 10017 // U16 enum (see status mapping)
-	goodweRegPhaseSwEnabled = 10023 // U16 (0=Off, 1=On)
-	goodweRegMaxPower       = 10029 // U16 ×0.1 kW, raw range [14,220]
-	goodweRegChargeMode     = 10032 // U16 (0=fast, 1=PV, 2=PV+battery)
-	goodweRegPowerSpec      = 10058 // U16 (0=7kW, 1=11kW, 2=22kW)
-	goodweRegPhaseSpec      = 10059 // U16 (0=3p, 1=1p)
-	goodweRegRfid           = 10500 // 7 regs ASCII (14-byte card UID)
-	goodweRegChargeCommand  = 10060 // U16 (1=stop, 2=start)
-	goodweRegTotalEnergy    = 10065 // U32 ×0.1 kWh, 2 regs
+	goodweRegVoltages      = 10009 // U16 ×0.1 V, 3 regs (L1/L2/L3)
+	goodweRegCurrents      = 10012 // U16 ×0.1 A, 3 regs (L1/L2/L3)
+	goodweRegActualPower   = 10015 // U16 ×0.1 kW
+	goodweRegStatus        = 10017 // U16 enum (see status mapping)
+	goodweRegMaxPower      = 10029 // U16 ×0.1 kW, raw range [14,220]
+	goodweRegChargeMode    = 10032 // U16 (0=fast, 1=PV, 2=PV+battery)
+	goodweRegPowerSpec     = 10058 // U16 (0=7kW, 1=11kW, 2=22kW)
+	goodweRegPhaseSpec     = 10059 // U16 (0=3p, 1=1p)
+	goodweRegRfid          = 10500 // 7 regs ASCII (14-byte card UID)
+	goodweRegChargeCommand = 10060 // U16 (1=stop, 2=start)
+	goodweRegTotalEnergy   = 10065 // U32 ×0.1 kWh, 2 regs
 
 	goodweChargeStop  = 1
 	goodweChargeStart = 2
@@ -133,18 +132,6 @@ func NewGoodWe(ctx context.Context, uri string, slaveID uint8) (api.Charger, err
 		}
 	} else {
 		log.WARN.Printf("read hw phase count failed, defaulting to 3-phase: %v", err)
-	}
-
-	// only 3-phase hardware can do 1p/3p switching; conditionally register phase switching
-	// based on hardware capability. On read error, fall back to fixed-phase operation.
-	if wb.phases == 3 {
-		if b, err := wb.conn.ReadHoldingRegisters(goodweRegPhaseSwEnabled, 1); err == nil {
-			if binary.BigEndian.Uint16(b) == 1 {
-				implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
-			}
-		} else {
-			log.WARN.Printf("read phase switch config failed, disabling dynamic phase switching: %v", err)
-		}
 	}
 
 	// force "fast" charging mode so evcc fully controls power setpoint
@@ -266,11 +253,6 @@ var _ api.PhaseVoltages = (*GoodWe)(nil)
 // Voltages implements api.PhaseVoltages
 func (wb *GoodWe) Voltages() (float64, float64, float64, error) {
 	return wb.phaseValues(goodweRegVoltages, 10)
-}
-
-func (wb *GoodWe) phases1p3p(phases int) error {
-	wb.phases = phases
-	return nil
 }
 
 var _ api.Identifier = (*GoodWe)(nil)

--- a/templates/definition/charger/goodwe-wallbox.yaml
+++ b/templates/definition/charger/goodwe-wallbox.yaml
@@ -3,7 +3,7 @@ products:
   - brand: GoodWe
     description:
       generic: HCA Wallbox (Gen2)
-capabilities: ["mA", "rfid", "1p3p", "meter"]
+capabilities: ["mA", "rfid", "meter"]
 requirements:
   evcc: ["sponsorship"]
   description:


### PR DESCRIPTION
follow-up to #29822, reported in #30651

The GoodWe wallbox registered a 1p/3p phase switcher whose handler was a no-op: it only updated the internal phase count used for the power setpoint and never wrote to the wallbox. Selecting 1-phase therefore left the box charging on 3 phases and produced a phase mismatch. The documented Gen2 protocol (and the Home Assistant integration this driver derives from) exposes no register to command a phase count, so the switcher cannot work on this hardware.

- drop the `phases1p3p` handler and the `PhaseSwitcher` registration
- remove the now-unused single/three-phase enable register read (it is an enable flag, not a phase selector)
- drop `1p3p` from the template capabilities; the charger runs fixed-phase per the detected hardware