### PR TITLE
chore: add agent guidance for symbol navigation and SDK docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - Use `context.Context` for I/O, long-running, or cancelable operations
 - Organize code into logical packages with clear responsibilities
 - Prefer composition over inheritance, minimize external dependencies
+- Navigate Go symbols with go-to-definition and find-references rather than text search; reserve text search for comments and string literals
 
 ### File Patterns
 
@@ -264,6 +265,7 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - Define device capabilities and configuration in templates at `templates/definition/[type]/`
 - Test templates: `evcc --template-type [type] --template [file]`
 - Update docs after template changes: `make docs`
+- When implementing or debugging against a third-party device library (eebus-go/ship/spine-go, ocpp-go, modbus/SunSpec), consult the library's current upstream documentation before coding rather than relying on recalled API details
 
 ### Configuration
 


### PR DESCRIPTION
Adds two house-keeping rules to the agent guide so coding agents work more accurately on this codebase.

- Go: navigate symbols with go-to-definition/find-references rather than text search, reserving text search for comments and string literals
- Device integration: consult a third-party library's current upstream docs (eebus-go/ship/spine-go, ocpp-go, modbus/SunSpec) before coding rather than relying on recalled API details