### PR TITLE
charger/twc3: optional vehicle-independent on/off via Tesla Fleet API

### DIFF
--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -1,23 +1,42 @@
 package charger
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/jq"
 	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/vehicle"
+	"github.com/evcc-io/evcc/vehicle/tesla"
+	teslaclient "github.com/evcc-io/tesla-proxy-client"
+	"github.com/itchyny/gojq"
+	"golang.org/x/oauth2"
 )
 
-// Twc3 is an api.Vehicle implementation for Twc3 cars
+// Twc3 is an api.Charger implementation for the Tesla Wall Connector Gen 3
 type Twc3 struct {
-	lp      loadpoint.API
-	vitalsG func() (Vitals, error)
-	enabled bool
+	lp              loadpoint.API
+	vitalsG         func() (Vitals, error)
+	enabled         bool
+	fleet           *twc3Fleet // nil without tesla block
+	switchCurrent   float64    // on/off threshold current, only used in switch mode
+	lockMaybeActive bool       // schedule may be gating the contactor (true = unknown/locked)
+}
+
+// twc3Fleet sends vehicle-independent on/off commands via the Tesla Fleet API
+type twc3Fleet struct {
+	client     *request.Helper // with oauth2 transport
+	commandURL string          // fleetBaseURL + /api/1/energy_sites/{id}/command
+	din        string
 }
 
 func init() {
@@ -57,8 +76,13 @@ type Vitals struct {
 // NewTwc3FromConfig creates a new charger
 func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 	cc := struct {
-		URI   string
-		Cache time.Duration
+		URI           string
+		Cache         time.Duration
+		SwitchCurrent float64 // on/off current override; 0 = read from wall connector
+		Tesla         *struct {
+			Credentials vehicle.ClientCredentials // ID (secret only needed for initial token mint, not for evcc's refresh)
+			Tokens      vehicle.Tokens            // Access, Refresh
+		}
 	}{
 		Cache: time.Second,
 	}
@@ -67,18 +91,311 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 		return nil, err
 	}
 
-	c := &Twc3{}
+	c := &Twc3{
+		lockMaybeActive: true, // unknown at startup -> first enable clears any stale lock once
+	}
 
-	client := request.NewHelper(util.NewLogger("twc3"))
-	uri := fmt.Sprintf("%s/api/1/vitals", util.DefaultScheme(strings.TrimSuffix(cc.URI, "/"), "http"))
+	log := util.NewLogger("twc3")
+	client := request.NewHelper(log)
+	baseURI := util.DefaultScheme(strings.TrimSuffix(cc.URI, "/"), "http")
 
 	c.vitalsG = util.Cached(func() (Vitals, error) {
 		var res Vitals
-		err := client.GetJSON(uri, &res)
+		err := client.GetJSON(baseURI+"/api/1/vitals", &res)
 		return res, err
 	}, cc.Cache)
 
+	// optional vehicle-independent on/off via Tesla Fleet API
+	if cc.Tesla != nil {
+		// switchCurrent override only takes effect in this on/off fallback mode
+		if cc.SwitchCurrent != 0 && (cc.SwitchCurrent < 1 || cc.SwitchCurrent > 32) {
+			return nil, fmt.Errorf("switchCurrent must be between 1 and 32 A, got %g", cc.SwitchCurrent)
+		}
+
+		token, err := cc.Tesla.Tokens.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		log := util.NewLogger("twc3").Redact(
+			cc.Tesla.Tokens.Access, cc.Tesla.Tokens.Refresh,
+			cc.Tesla.Credentials.ID, cc.Tesla.Credentials.Secret,
+		)
+
+		identity, err := tesla.NewIdentity(log, tesla.OAuth2Config(cc.Tesla.Credentials.ID, cc.Tesla.Credentials.Secret), token)
+		if err != nil {
+			return nil, err
+		}
+
+		hc := request.NewClient(log)
+		hc.Transport = &oauth2.Transport{
+			Source: identity,
+			Base:   hc.Transport,
+		}
+		fleetClient := &request.Helper{Client: hc}
+
+		// fleet base url: auto-detect the account's region (same as the tesla vehicle)
+		tc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(hc))
+		if err != nil {
+			return nil, err
+		}
+		region, err := tc.UserRegion()
+		if err != nil {
+			return nil, err
+		}
+		fleetBaseURL := strings.TrimRight(region.FleetApiBaseUrl, "/")
+
+		// derive the wall connector DIN locally from this box (works per-uri, also with multiple TWC3s)
+		din, err := localDIN(client, baseURI)
+		if err != nil {
+			return nil, err
+		}
+
+		// find the energy site containing this wall connector
+		energySiteID, err := discoverEnergySite(fleetClient, fleetBaseURL, din)
+		if err != nil {
+			return nil, err
+		}
+
+		c.fleet = &twc3Fleet{
+			client:     fleetClient,
+			commandURL: fmt.Sprintf("%s/api/1/energy_sites/%d/command", fleetBaseURL, energySiteID),
+			din:        din,
+		}
+
+		// determine the on/off current: explicit override, else the wall connector's
+		// commissioned maximum (read once at startup - it does not change). On read
+		// failure there is no fallback; the on/off mode stays unavailable (logged below).
+		if cc.SwitchCurrent != 0 {
+			c.switchCurrent = cc.SwitchCurrent
+		} else if a, err := c.fleet.maxOutputCurrent(); err != nil {
+			log.WARN.Printf("could not read max output current, on/off mode disabled (set switchCurrent to enable): %v", err)
+		} else {
+			c.switchCurrent = a
+		}
+	}
+
 	return c, nil
+}
+
+// localDIN derives the wall connector DIN (part_number--serial_number) from the
+// local /api/1/version endpoint, so it never has to be configured manually.
+func localDIN(client *request.Helper, baseURI string) (string, error) {
+	var res struct {
+		PartNumber   string `json:"part_number"`
+		SerialNumber string `json:"serial_number"`
+	}
+	if err := client.GetJSON(baseURI+"/api/1/version", &res); err != nil {
+		return "", fmt.Errorf("reading wall connector version: %w", err)
+	}
+	if res.PartNumber == "" || res.SerialNumber == "" {
+		return "", errors.New("wall connector version: missing part/serial number")
+	}
+	return res.PartNumber + "--" + res.SerialNumber, nil
+}
+
+// discoverEnergySite returns the energy_site_id whose site_info lists the given
+// wall connector DIN, so the site id never has to be configured manually.
+func discoverEnergySite(client *request.Helper, fleetBaseURL, din string) (int64, error) {
+	var products struct {
+		Response []struct {
+			EnergySiteID int64 `json:"energy_site_id"`
+		} `json:"response"`
+	}
+	if err := client.GetJSON(fleetBaseURL+"/api/1/products", &products); err != nil {
+		return 0, fmt.Errorf("listing energy sites: %w", err)
+	}
+
+	seen := make(map[int64]bool)
+	for _, p := range products.Response {
+		if p.EnergySiteID == 0 || seen[p.EnergySiteID] {
+			continue
+		}
+		seen[p.EnergySiteID] = true
+
+		var info struct {
+			Response struct {
+				Components struct {
+					WallConnectors []struct {
+						DIN string `json:"din"`
+					} `json:"wall_connectors"`
+				} `json:"components"`
+			} `json:"response"`
+		}
+		if err := client.GetJSON(fmt.Sprintf("%s/api/1/energy_sites/%d/site_info", fleetBaseURL, p.EnergySiteID), &info); err != nil {
+			continue // skip sites we cannot read
+		}
+		for _, wc := range info.Response.Components.WallConnectors {
+			if wc.DIN == din {
+				return p.EnergySiteID, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("wall connector %s not found in any energy site (token energy scope correct?)", din)
+}
+
+// utcTimeZone is the minimal time_zone the wall connector accepts (verified against
+// real hardware): UTC with a single zero-offset transition. Sending only time_zone_id,
+// or an empty transitions list, is rejected with error 4.
+var utcTimeZone = json.RawMessage(`{"time_zone_id":"UTC","time_zone_info":{"transitions":[{"local_time_utc_offset":0,"timestamp":{"nanos":0,"seconds":0}}]}}`)
+
+type wcTimePeriod struct {
+	StartSeconds int `json:"start_seconds"`
+	EndSeconds   int `json:"end_seconds"`
+}
+
+type wcDayTimePeriod struct {
+	DayBitmask  int            `json:"day_bitmask"`
+	TimePeriods []wcTimePeriod `json:"time_periods"`
+}
+
+// wcScheduleCmd is the configure_charge_schedule_request payload sent to the wall connector.
+type wcScheduleCmd struct {
+	CommandType       string `json:"command_type"`
+	CommandProperties struct {
+		Message struct {
+			Wc struct {
+				ConfigureChargeScheduleRequest struct {
+					Config struct {
+						Schedule struct {
+							DayTimePeriods []wcDayTimePeriod `json:"day_time_periods"`
+						} `json:"schedule"`
+						Delay struct {
+							MaxDelaySeconds int `json:"max_delay_seconds"`
+						} `json:"delay"`
+						EnableSchedule bool `json:"enable_schedule"`
+					} `json:"config"`
+					TimeZone json.RawMessage `json:"time_zone"`
+				} `json:"configure_charge_schedule_request"`
+			} `json:"wc"`
+		} `json:"message"`
+		IdentifierType int    `json:"identifier_type"`
+		TargetID       string `json:"target_id"`
+	} `json:"command_properties"`
+}
+
+// switchSchedule sends a configure_charge_schedule command: enable=true allows charging
+// (schedule off), enable=false locks the contactor via an active past-window schedule.
+func (f *twc3Fleet) switchSchedule(enable bool) error {
+	var cmd wcScheduleCmd
+	cmd.CommandType = "grpc_command"
+	cmd.CommandProperties.TargetID = f.din
+	cmd.CommandProperties.IdentifierType = 4
+
+	ccsr := &cmd.CommandProperties.Message.Wc.ConfigureChargeScheduleRequest
+	ccsr.TimeZone = utcTimeZone
+
+	// charging blocked -> active schedule; charging allowed -> schedule disabled.
+	ccsr.Config.EnableSchedule = !enable
+
+	// The wall connector rejects an empty day_time_periods (error 4) even when the
+	// schedule is disabled, so always send one valid window. Its only allowed slot is
+	// the last elapsed half hour, so "now" is never inside it (relevant only while the
+	// schedule is enabled). Computed in UTC to match the schedule's UTC time_zone, so
+	// blocking works in any local time zone.
+	s, e := offWindow(time.Now().UTC())
+	ccsr.Config.Schedule.DayTimePeriods = []wcDayTimePeriod{{
+		DayBitmask:  127,
+		TimePeriods: []wcTimePeriod{{StartSeconds: s, EndSeconds: e}},
+	}}
+
+	req, err := request.New(http.MethodPost, f.commandURL, request.MarshalJSON(cmd), request.JSONEncoding)
+	if err != nil {
+		return err
+	}
+
+	body, err := f.client.DoBody(req)
+	if err != nil {
+		return err
+	}
+
+	// Success is signalled by ConfigureChargeScheduleResponse.error == 1 (same as the
+	// Tesla app); anything else (e.g. 4) means rejected despite HTTP 200. The code sits
+	// deep in a non-contractual envelope, so anchor on the unique response key with jq.
+	query, err := gojq.Parse(".. | .ConfigureChargeScheduleResponse? | .error? | numbers")
+	if err != nil {
+		return err
+	}
+	if v, err := jq.Query(query, body); err == nil {
+		if code, ok := v.(float64); ok && code == 1 {
+			return nil
+		}
+		return fmt.Errorf("wall connector rejected schedule command (error %v)", v)
+	}
+
+	// no schedule response in the reply -> surface the top-level Fleet API error
+	var res struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &res); err == nil && res.Error != "" {
+		return errors.New(res.Error)
+	}
+	return errors.New("wall connector returned no schedule response")
+}
+
+// maxOutputCurrent reads the wall connector's commissioned maximum output current (A)
+// via the get_config command - the same value the Tesla app shows under "max output current".
+func (f *twc3Fleet) maxOutputCurrent() (float64, error) {
+	var cmd struct {
+		CommandType       string `json:"command_type"`
+		CommandProperties struct {
+			Message struct {
+				Wc struct {
+					GetConfigRequest struct{} `json:"get_config_request"`
+				} `json:"wc"`
+			} `json:"message"`
+			IdentifierType int    `json:"identifier_type"`
+			TargetID       string `json:"target_id"`
+		} `json:"command_properties"`
+	}
+	cmd.CommandType = "grpc_command"
+	cmd.CommandProperties.IdentifierType = 4
+	cmd.CommandProperties.TargetID = f.din
+
+	req, err := request.New(http.MethodPost, f.commandURL, request.MarshalJSON(cmd), request.JSONEncoding)
+	if err != nil {
+		return 0, err
+	}
+
+	body, err := f.client.DoBody(req)
+	if err != nil {
+		return 0, err
+	}
+
+	// the response is deeply nested in a non-contractual gRPC envelope; extract the
+	// unique max_output_current_amps key with jq instead of mirroring the structure.
+	query, err := gojq.Parse(".. | .max_output_current_amps? | numbers")
+	if err != nil {
+		return 0, err
+	}
+	v, err := jq.Query(query, body)
+	if err != nil {
+		return 0, err
+	}
+	if a, ok := v.(float64); ok && a > 0 {
+		return a, nil
+	}
+	return 0, errors.New("wall connector returned no max_output_current_amps")
+}
+
+// offWindow returns the last full, already-elapsed half hour as seconds-of-day
+// (with midnight wrap), guaranteeing now is never inside [start,end). The caller
+// passes UTC so the window matches the schedule's UTC time_zone.
+func offWindow(now time.Time) (start, end int) {
+	sec := now.Hour()*3600 + now.Minute()*60 + now.Second()
+	end = (sec / 1800) * 1800 // start of the current half hour
+	start = end - 1800
+	if start < 0 { // before 00:30 -> wrap to 23:30-24:00
+		start, end = 24*3600-1800, 24*3600
+	}
+	return
+}
+
+// switchMode reports whether the on/off fallback is in effect:
+// fleet configured AND the connected vehicle cannot control current.
+func (c *Twc3) switchMode() bool {
+	return c.fleet != nil && c.lp != nil && !api.HasCap[api.CurrentController](c.lp.GetVehicle())
 }
 
 // Status implements the api.Charger interface
@@ -107,7 +424,7 @@ func (c *Twc3) Enable(enable bool) error {
 		return ErrLoadpointNotInitialized
 	}
 
-	// ignore disabling when vehicle is already disconnected
+	// ignore disabling when the vehicle is already disconnected
 	// https://github.com/evcc-io/evcc/issues/10213
 	status, err := c.Status()
 	if err != nil {
@@ -118,17 +435,43 @@ func (c *Twc3) Enable(enable bool) error {
 		return nil
 	}
 
-	v, ok := api.Cap[api.ChargeController](c.lp.GetVehicle())
-	if !ok {
-		return errors.New("vehicle not capable of start/stop")
+	if err := c.setCharging(enable); err != nil {
+		return err
+	}
+	c.enabled = enable
+	return nil
+}
+
+// setCharging starts/stops charging via the vehicle when it can, otherwise via the
+// wall connector schedule (guest / non-Tesla / no vehicle).
+func (c *Twc3) setCharging(enable bool) error {
+	// 1. vehicle can start/stop (Tesla) -> control via vehicle
+	if v, ok := api.Cap[api.ChargeController](c.lp.GetVehicle()); ok {
+		// a guest may have locked the contactor via the schedule; clear it before
+		// handing control back to the vehicle, but only when a lock may actually be
+		// active - avoids a redundant Fleet API call on every enable. Disabling needs
+		// no schedule change - the vehicle stops charging itself.
+		if c.fleet != nil && enable && c.lockMaybeActive {
+			if err := c.fleet.switchSchedule(true); err != nil {
+				return err
+			}
+			c.lockMaybeActive = false
+		}
+		return v.ChargeEnable(enable)
 	}
 
-	err = v.ChargeEnable(enable)
-	if err == nil {
-		c.enabled = enable
+	// 2. fallback: vehicle cannot -> wall connector schedule
+	if c.fleet != nil {
+		if err := c.fleet.switchSchedule(enable); err != nil {
+			return err
+		}
+		// the schedule now gates the contactor iff we disabled charging
+		c.lockMaybeActive = !enable
+		return nil
 	}
 
-	return err
+	// 3. neither
+	return errors.New("vehicle not capable of start/stop and no wall connector fallback configured")
 }
 
 // MaxCurrent implements the api.Charger interface
@@ -139,21 +482,33 @@ func (c *Twc3) MaxCurrent(current int64) error {
 
 	v, ok := api.Cap[api.CurrentController](c.lp.GetVehicle())
 	if !ok {
-		if c.lp.GetMode() == api.ModeNow {
-			// vehicle does not support current control- ignore silently
-			// since TWC3 cannot limit current on its own
-			return nil
-		}
-		return errors.New("vehicle not capable of current control")
+		// hardware cannot set amps; on/off full load. Tolerate in all modes.
+		return nil
 	}
 
 	return v.MaxCurrent(current)
+}
+
+var _ api.CurrentLimiter = (*Twc3)(nil)
+
+// GetMinMaxCurrent implements the api.CurrentLimiter interface
+func (c *Twc3) GetMinMaxCurrent() (float64, float64, error) {
+	if c.switchMode() && c.switchCurrent > 0 {
+		// min=max -> on/off only at full power
+		return c.switchCurrent, c.switchCurrent, nil
+	}
+	// Tesla/classic, or unknown switch current: vehicle/loadpoint range applies
+	return 0, 0, api.ErrNotAvailable
 }
 
 var _ api.CurrentGetter = (*Twc3)(nil)
 
 // GetMaxCurrent implements the api.CurrentGetter interface
 func (c *Twc3) GetMaxCurrent() (float64, error) {
+	if c.lp == nil {
+		return 0, ErrLoadpointNotInitialized
+	}
+
 	v, ok := api.Cap[api.CurrentGetter](c.lp.GetVehicle())
 	if !ok {
 		return 0, api.ErrNotAvailable

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -14,12 +14,11 @@ import (
 
 // Twc3 is an api.Charger implementation for the Tesla Wall Connector Gen 3
 type Twc3 struct {
-	lp              loadpoint.API
-	vitalsG         func() (Vitals, error)
-	enabled         bool
-	fleet           *twc3Fleet // nil without tesla block
-	switchCurrent   float64    // on/off threshold current, only used in switch mode
-	lockMaybeActive bool       // schedule may be gating the contactor (true = unknown/locked)
+	lp            loadpoint.API
+	vitalsG       func() (Vitals, error)
+	enabled       bool
+	fleet         *twc3Fleet // nil without tesla block
+	switchCurrent float64    // on/off threshold current, only used in switch mode
 }
 
 func init() {
@@ -71,9 +70,7 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 		return nil, err
 	}
 
-	c := &Twc3{
-		lockMaybeActive: true, // unknown at startup -> first enable clears any stale lock once
-	}
+	c := &Twc3{}
 
 	log := util.NewLogger("twc3")
 	client := request.NewHelper(log)
@@ -154,26 +151,19 @@ func (c *Twc3) setCharging(enable bool) error {
 	// 1. vehicle can start/stop (Tesla) -> control via vehicle
 	if v, ok := api.Cap[api.ChargeController](c.lp.GetVehicle()); ok {
 		// a guest may have locked the contactor via the schedule; clear it before
-		// handing control back to the vehicle, but only when a lock may actually be
-		// active - avoids a redundant Fleet API call on every enable. Disabling needs
-		// no schedule change - the vehicle stops charging itself.
-		if c.fleet != nil && enable && c.lockMaybeActive {
-			if err := c.fleet.switchSchedule(true); err != nil {
+		// handing control back to the vehicle. Disabling needs no schedule change -
+		// the vehicle stops charging itself.
+		if c.fleet != nil && enable {
+			if err := c.fleet.clearLock(); err != nil {
 				return err
 			}
-			c.lockMaybeActive = false
 		}
 		return v.ChargeEnable(enable)
 	}
 
 	// 2. fallback: vehicle cannot -> wall connector schedule
 	if c.fleet != nil {
-		if err := c.fleet.switchSchedule(enable); err != nil {
-			return err
-		}
-		// the schedule now gates the contactor iff we disabled charging
-		c.lockMaybeActive = !enable
-		return nil
+		return c.fleet.setCharging(enable)
 	}
 
 	// 3. neither

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -14,11 +14,10 @@ import (
 
 // Twc3 is an api.Charger implementation for the Tesla Wall Connector Gen 3
 type Twc3 struct {
-	lp            loadpoint.API
-	vitalsG       func() (Vitals, error)
-	enabled       bool
-	fleet         *twc3Fleet // nil without tesla block
-	switchCurrent float64    // on/off threshold current, only used in switch mode
+	lp      loadpoint.API
+	vitalsG func() (Vitals, error)
+	enabled bool
+	fleet   *twc3Fleet // nil without tesla block
 }
 
 func init() {
@@ -84,12 +83,11 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 
 	// optional vehicle-independent on/off via Tesla Fleet API
 	if cc.Tesla != nil {
-		fleet, switchCurrent, err := newTwc3Fleet(log, client, baseURI, cc.Tesla, cc.SwitchCurrent)
+		fleet, err := newTwc3Fleet(log, client, baseURI, cc.Tesla, cc.SwitchCurrent)
 		if err != nil {
 			return nil, err
 		}
 		c.fleet = fleet
-		c.switchCurrent = switchCurrent
 	}
 
 	return c, nil
@@ -189,9 +187,9 @@ var _ api.CurrentLimiter = (*Twc3)(nil)
 
 // GetMinMaxCurrent implements the api.CurrentLimiter interface
 func (c *Twc3) GetMinMaxCurrent() (float64, float64, error) {
-	if c.switchMode() && c.switchCurrent > 0 {
+	if c.switchMode() && c.fleet.switchCurrent > 0 {
 		// min=max -> on/off only at full power
-		return c.switchCurrent, c.switchCurrent, nil
+		return c.fleet.switchCurrent, c.fleet.switchCurrent, nil
 	}
 	// Tesla/classic, or unknown switch current: vehicle/loadpoint range applies
 	return 0, 0, api.ErrNotAvailable

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -122,6 +122,12 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 
 	// optional vehicle-independent on/off via Tesla Fleet API
 	if cc.Tesla != nil {
+		// the template renders the tesla block as soon as any field is set, so a
+		// partial config surfaces here instead of being silently ignored
+		if cc.Tesla.Credentials.ID == "" || cc.Tesla.Tokens.Access == "" || cc.Tesla.Tokens.Refresh == "" {
+			return nil, errors.New("tesla: clientId, accessToken and refreshToken are all required")
+		}
+
 		// switchCurrent override only takes effect in this on/off fallback mode
 		if cc.SwitchCurrent != 0 && (cc.SwitchCurrent < 1 || cc.SwitchCurrent > 32) {
 			return nil, fmt.Errorf("switchCurrent must be between 1 and 32 A, got %g", cc.SwitchCurrent)

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -128,6 +128,12 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 			return nil, errors.New("tesla: clientId, accessToken and refreshToken are all required")
 		}
 
+		// redact the tesla secrets on the shared logger before any token handling
+		log.Redact(
+			cc.Tesla.Tokens.Access, cc.Tesla.Tokens.Refresh,
+			cc.Tesla.Credentials.ID, cc.Tesla.Credentials.Secret,
+		)
+
 		// switchCurrent override only takes effect in this on/off fallback mode
 		if cc.SwitchCurrent != 0 && (cc.SwitchCurrent < 1 || cc.SwitchCurrent > 32) {
 			return nil, fmt.Errorf("switchCurrent must be between 1 and 32 A, got %g", cc.SwitchCurrent)
@@ -137,11 +143,6 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		log := util.NewLogger("twc3").Redact(
-			cc.Tesla.Tokens.Access, cc.Tesla.Tokens.Refresh,
-			cc.Tesla.Credentials.ID, cc.Tesla.Credentials.Secret,
-		)
 
 		identity, err := tesla.NewIdentity(log, tesla.OAuth2Config(cc.Tesla.Credentials.ID, cc.Tesla.Credentials.Secret), token)
 		if err != nil {

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -43,6 +43,21 @@ func init() {
 	registry.Add("twc3", NewTwc3FromConfig)
 }
 
+// jq queries for the deeply-nested, non-contractual Fleet responses, compiled
+// once - a bad query then panics at init instead of failing per request.
+var (
+	twc3ScheduleErrQuery   = jqMustParse(".. | .ConfigureChargeScheduleResponse? | .error? | numbers")
+	twc3MaxOutputAmpsQuery = jqMustParse(".. | .max_output_current_amps? | numbers")
+)
+
+func jqMustParse(s string) *gojq.Query {
+	q, err := gojq.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return q
+}
+
 // Vitals is the /api/1/vitals response
 type Vitals struct {
 	ContactorClosed   bool    `json:"contactor_closed"`    // false
@@ -313,11 +328,7 @@ func (f *twc3Fleet) switchSchedule(enable bool) error {
 	// Success is signalled by ConfigureChargeScheduleResponse.error == 1 (same as the
 	// Tesla app); anything else (e.g. 4) means rejected despite HTTP 200. The code sits
 	// deep in a non-contractual envelope, so anchor on the unique response key with jq.
-	query, err := gojq.Parse(".. | .ConfigureChargeScheduleResponse? | .error? | numbers")
-	if err != nil {
-		return err
-	}
-	if v, err := jq.Query(query, body); err == nil {
+	if v, err := jq.Query(twc3ScheduleErrQuery, body); err == nil {
 		if code, ok := v.(float64); ok && code == 1 {
 			return nil
 		}
@@ -365,11 +376,7 @@ func (f *twc3Fleet) maxOutputCurrent() (float64, error) {
 
 	// the response is deeply nested in a non-contractual gRPC envelope; extract the
 	// unique max_output_current_amps key with jq instead of mirroring the structure.
-	query, err := gojq.Parse(".. | .max_output_current_amps? | numbers")
-	if err != nil {
-		return 0, err
-	}
-	v, err := jq.Query(query, body)
+	v, err := jq.Query(twc3MaxOutputAmpsQuery, body)
 	if err != nil {
 		return 0, err
 	}

--- a/charger/twc3.go
+++ b/charger/twc3.go
@@ -1,25 +1,15 @@
 package charger
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"math"
-	"net/http"
 	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/jq"
 	"github.com/evcc-io/evcc/util/request"
-	"github.com/evcc-io/evcc/vehicle"
-	"github.com/evcc-io/evcc/vehicle/tesla"
-	teslaclient "github.com/evcc-io/tesla-proxy-client"
-	"github.com/itchyny/gojq"
-	"golang.org/x/oauth2"
 )
 
 // Twc3 is an api.Charger implementation for the Tesla Wall Connector Gen 3
@@ -32,30 +22,8 @@ type Twc3 struct {
 	lockMaybeActive bool       // schedule may be gating the contactor (true = unknown/locked)
 }
 
-// twc3Fleet sends vehicle-independent on/off commands via the Tesla Fleet API
-type twc3Fleet struct {
-	client     *request.Helper // with oauth2 transport
-	commandURL string          // fleetBaseURL + /api/1/energy_sites/{id}/command
-	din        string
-}
-
 func init() {
 	registry.Add("twc3", NewTwc3FromConfig)
-}
-
-// jq queries for the deeply-nested, non-contractual Fleet responses, compiled
-// once - a bad query then panics at init instead of failing per request.
-var (
-	twc3ScheduleErrQuery   = jqMustParse(".. | .ConfigureChargeScheduleResponse? | .error? | numbers")
-	twc3MaxOutputAmpsQuery = jqMustParse(".. | .max_output_current_amps? | numbers")
-)
-
-func jqMustParse(s string) *gojq.Query {
-	q, err := gojq.Parse(s)
-	if err != nil {
-		panic(err)
-	}
-	return q
 }
 
 // Vitals is the /api/1/vitals response
@@ -93,11 +61,8 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 	cc := struct {
 		URI           string
 		Cache         time.Duration
-		SwitchCurrent float64 // on/off current override; 0 = read from wall connector
-		Tesla         *struct {
-			Credentials vehicle.ClientCredentials // ID (secret only needed for initial token mint, not for evcc's refresh)
-			Tokens      vehicle.Tokens            // Access, Refresh
-		}
+		SwitchCurrent float64          // on/off current override; 0 = read from wall connector
+		Tesla         *twc3TeslaConfig // optional vehicle-independent on/off
 	}{
 		Cache: time.Second,
 	}
@@ -122,288 +87,15 @@ func NewTwc3FromConfig(other map[string]any) (api.Charger, error) {
 
 	// optional vehicle-independent on/off via Tesla Fleet API
 	if cc.Tesla != nil {
-		// the template renders the tesla block as soon as any field is set, so a
-		// partial config surfaces here instead of being silently ignored
-		if cc.Tesla.Credentials.ID == "" || cc.Tesla.Tokens.Access == "" || cc.Tesla.Tokens.Refresh == "" {
-			return nil, errors.New("tesla: clientId, accessToken and refreshToken are all required")
-		}
-
-		// redact the tesla secrets on the shared logger before any token handling
-		log.Redact(
-			cc.Tesla.Tokens.Access, cc.Tesla.Tokens.Refresh,
-			cc.Tesla.Credentials.ID, cc.Tesla.Credentials.Secret,
-		)
-
-		// switchCurrent override only takes effect in this on/off fallback mode
-		if cc.SwitchCurrent != 0 && (cc.SwitchCurrent < 1 || cc.SwitchCurrent > 32) {
-			return nil, fmt.Errorf("switchCurrent must be between 1 and 32 A, got %g", cc.SwitchCurrent)
-		}
-
-		token, err := cc.Tesla.Tokens.Token()
+		fleet, switchCurrent, err := newTwc3Fleet(log, client, baseURI, cc.Tesla, cc.SwitchCurrent)
 		if err != nil {
 			return nil, err
 		}
-
-		identity, err := tesla.NewIdentity(log, tesla.OAuth2Config(cc.Tesla.Credentials.ID, cc.Tesla.Credentials.Secret), token)
-		if err != nil {
-			return nil, err
-		}
-
-		hc := request.NewClient(log)
-		hc.Transport = &oauth2.Transport{
-			Source: identity,
-			Base:   hc.Transport,
-		}
-		fleetClient := &request.Helper{Client: hc}
-
-		// fleet base url: auto-detect the account's region (same as the tesla vehicle)
-		tc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(hc))
-		if err != nil {
-			return nil, err
-		}
-		region, err := tc.UserRegion()
-		if err != nil {
-			return nil, err
-		}
-		fleetBaseURL := strings.TrimRight(region.FleetApiBaseUrl, "/")
-
-		// derive the wall connector DIN locally from this box (works per-uri, also with multiple TWC3s)
-		din, err := localDIN(client, baseURI)
-		if err != nil {
-			return nil, err
-		}
-
-		// find the energy site containing this wall connector
-		energySiteID, err := discoverEnergySite(fleetClient, fleetBaseURL, din)
-		if err != nil {
-			return nil, err
-		}
-
-		c.fleet = &twc3Fleet{
-			client:     fleetClient,
-			commandURL: fmt.Sprintf("%s/api/1/energy_sites/%d/command", fleetBaseURL, energySiteID),
-			din:        din,
-		}
-
-		// determine the on/off current: explicit override, else the wall connector's
-		// commissioned maximum (read once at startup - it does not change). On read
-		// failure there is no fallback; the on/off mode stays unavailable (logged below).
-		if cc.SwitchCurrent != 0 {
-			c.switchCurrent = cc.SwitchCurrent
-		} else if a, err := c.fleet.maxOutputCurrent(); err != nil {
-			log.WARN.Printf("could not read max output current, on/off mode disabled (set switchCurrent to enable): %v", err)
-		} else {
-			c.switchCurrent = a
-		}
+		c.fleet = fleet
+		c.switchCurrent = switchCurrent
 	}
 
 	return c, nil
-}
-
-// localDIN derives the wall connector DIN (part_number--serial_number) from the
-// local /api/1/version endpoint, so it never has to be configured manually.
-func localDIN(client *request.Helper, baseURI string) (string, error) {
-	var res struct {
-		PartNumber   string `json:"part_number"`
-		SerialNumber string `json:"serial_number"`
-	}
-	if err := client.GetJSON(baseURI+"/api/1/version", &res); err != nil {
-		return "", fmt.Errorf("reading wall connector version: %w", err)
-	}
-	if res.PartNumber == "" || res.SerialNumber == "" {
-		return "", errors.New("wall connector version: missing part/serial number")
-	}
-	return res.PartNumber + "--" + res.SerialNumber, nil
-}
-
-// discoverEnergySite returns the energy_site_id whose site_info lists the given
-// wall connector DIN, so the site id never has to be configured manually.
-func discoverEnergySite(client *request.Helper, fleetBaseURL, din string) (int64, error) {
-	var products struct {
-		Response []struct {
-			EnergySiteID int64 `json:"energy_site_id"`
-		} `json:"response"`
-	}
-	if err := client.GetJSON(fleetBaseURL+"/api/1/products", &products); err != nil {
-		return 0, fmt.Errorf("listing energy sites: %w", err)
-	}
-
-	seen := make(map[int64]bool)
-	for _, p := range products.Response {
-		if p.EnergySiteID == 0 || seen[p.EnergySiteID] {
-			continue
-		}
-		seen[p.EnergySiteID] = true
-
-		var info struct {
-			Response struct {
-				Components struct {
-					WallConnectors []struct {
-						DIN string `json:"din"`
-					} `json:"wall_connectors"`
-				} `json:"components"`
-			} `json:"response"`
-		}
-		if err := client.GetJSON(fmt.Sprintf("%s/api/1/energy_sites/%d/site_info", fleetBaseURL, p.EnergySiteID), &info); err != nil {
-			continue // skip sites we cannot read
-		}
-		for _, wc := range info.Response.Components.WallConnectors {
-			if wc.DIN == din {
-				return p.EnergySiteID, nil
-			}
-		}
-	}
-
-	return 0, fmt.Errorf("wall connector %s not found in any energy site (token energy scope correct?)", din)
-}
-
-// utcTimeZone is the minimal time_zone the wall connector accepts (verified against
-// real hardware): UTC with a single zero-offset transition. Sending only time_zone_id,
-// or an empty transitions list, is rejected with error 4.
-var utcTimeZone = json.RawMessage(`{"time_zone_id":"UTC","time_zone_info":{"transitions":[{"local_time_utc_offset":0,"timestamp":{"nanos":0,"seconds":0}}]}}`)
-
-type wcTimePeriod struct {
-	StartSeconds int `json:"start_seconds"`
-	EndSeconds   int `json:"end_seconds"`
-}
-
-type wcDayTimePeriod struct {
-	DayBitmask  int            `json:"day_bitmask"`
-	TimePeriods []wcTimePeriod `json:"time_periods"`
-}
-
-// wcScheduleCmd is the configure_charge_schedule_request payload sent to the wall connector.
-type wcScheduleCmd struct {
-	CommandType       string `json:"command_type"`
-	CommandProperties struct {
-		Message struct {
-			Wc struct {
-				ConfigureChargeScheduleRequest struct {
-					Config struct {
-						Schedule struct {
-							DayTimePeriods []wcDayTimePeriod `json:"day_time_periods"`
-						} `json:"schedule"`
-						Delay struct {
-							MaxDelaySeconds int `json:"max_delay_seconds"`
-						} `json:"delay"`
-						EnableSchedule bool `json:"enable_schedule"`
-					} `json:"config"`
-					TimeZone json.RawMessage `json:"time_zone"`
-				} `json:"configure_charge_schedule_request"`
-			} `json:"wc"`
-		} `json:"message"`
-		IdentifierType int    `json:"identifier_type"`
-		TargetID       string `json:"target_id"`
-	} `json:"command_properties"`
-}
-
-// switchSchedule sends a configure_charge_schedule command: enable=true allows charging
-// (schedule off), enable=false locks the contactor via an active past-window schedule.
-func (f *twc3Fleet) switchSchedule(enable bool) error {
-	var cmd wcScheduleCmd
-	cmd.CommandType = "grpc_command"
-	cmd.CommandProperties.TargetID = f.din
-	cmd.CommandProperties.IdentifierType = 4
-
-	ccsr := &cmd.CommandProperties.Message.Wc.ConfigureChargeScheduleRequest
-	ccsr.TimeZone = utcTimeZone
-
-	// charging blocked -> active schedule; charging allowed -> schedule disabled.
-	ccsr.Config.EnableSchedule = !enable
-
-	// The wall connector rejects an empty day_time_periods (error 4) even when the
-	// schedule is disabled, so always send one valid window. Its only allowed slot is
-	// the last elapsed half hour, so "now" is never inside it (relevant only while the
-	// schedule is enabled). Computed in UTC to match the schedule's UTC time_zone, so
-	// blocking works in any local time zone.
-	s, e := offWindow(time.Now().UTC())
-	ccsr.Config.Schedule.DayTimePeriods = []wcDayTimePeriod{{
-		DayBitmask:  127,
-		TimePeriods: []wcTimePeriod{{StartSeconds: s, EndSeconds: e}},
-	}}
-
-	req, err := request.New(http.MethodPost, f.commandURL, request.MarshalJSON(cmd), request.JSONEncoding)
-	if err != nil {
-		return err
-	}
-
-	body, err := f.client.DoBody(req)
-	if err != nil {
-		return err
-	}
-
-	// Success is signalled by ConfigureChargeScheduleResponse.error == 1 (same as the
-	// Tesla app); anything else (e.g. 4) means rejected despite HTTP 200. The code sits
-	// deep in a non-contractual envelope, so anchor on the unique response key with jq.
-	if v, err := jq.Query(twc3ScheduleErrQuery, body); err == nil {
-		if code, ok := v.(float64); ok && code == 1 {
-			return nil
-		}
-		return fmt.Errorf("wall connector rejected schedule command (error %v)", v)
-	}
-
-	// no schedule response in the reply -> surface the top-level Fleet API error
-	var res struct {
-		Error string `json:"error"`
-	}
-	if err := json.Unmarshal(body, &res); err == nil && res.Error != "" {
-		return errors.New(res.Error)
-	}
-	return errors.New("wall connector returned no schedule response")
-}
-
-// maxOutputCurrent reads the wall connector's commissioned maximum output current (A)
-// via the get_config command - the same value the Tesla app shows under "max output current".
-func (f *twc3Fleet) maxOutputCurrent() (float64, error) {
-	var cmd struct {
-		CommandType       string `json:"command_type"`
-		CommandProperties struct {
-			Message struct {
-				Wc struct {
-					GetConfigRequest struct{} `json:"get_config_request"`
-				} `json:"wc"`
-			} `json:"message"`
-			IdentifierType int    `json:"identifier_type"`
-			TargetID       string `json:"target_id"`
-		} `json:"command_properties"`
-	}
-	cmd.CommandType = "grpc_command"
-	cmd.CommandProperties.IdentifierType = 4
-	cmd.CommandProperties.TargetID = f.din
-
-	req, err := request.New(http.MethodPost, f.commandURL, request.MarshalJSON(cmd), request.JSONEncoding)
-	if err != nil {
-		return 0, err
-	}
-
-	body, err := f.client.DoBody(req)
-	if err != nil {
-		return 0, err
-	}
-
-	// the response is deeply nested in a non-contractual gRPC envelope; extract the
-	// unique max_output_current_amps key with jq instead of mirroring the structure.
-	v, err := jq.Query(twc3MaxOutputAmpsQuery, body)
-	if err != nil {
-		return 0, err
-	}
-	if a, ok := v.(float64); ok && a > 0 {
-		return a, nil
-	}
-	return 0, errors.New("wall connector returned no max_output_current_amps")
-}
-
-// offWindow returns the last full, already-elapsed half hour as seconds-of-day
-// (with midnight wrap), guaranteeing now is never inside [start,end). The caller
-// passes UTC so the window matches the schedule's UTC time_zone.
-func offWindow(now time.Time) (start, end int) {
-	sec := now.Hour()*3600 + now.Minute()*60 + now.Second()
-	end = (sec / 1800) * 1800 // start of the current half hour
-	start = end - 1800
-	if start < 0 { // before 00:30 -> wrap to 23:30-24:00
-		start, end = 24*3600-1800, 24*3600
-	}
-	return
 }
 
 // switchMode reports whether the on/off fallback is in effect:

--- a/charger/twc3_fleet.go
+++ b/charger/twc3_fleet.go
@@ -30,7 +30,8 @@ type twc3Fleet struct {
 	client          *request.Helper // with oauth2 transport
 	commandURL      string          // fleetBaseURL + /api/1/energy_sites/{id}/command
 	din             string
-	lockMaybeActive bool // schedule may be gating the contactor (true = unknown/locked)
+	switchCurrent   float64 // on/off full-load current (0 = unavailable)
+	lockMaybeActive bool    // schedule may be gating the contactor (true = unknown/locked)
 }
 
 // setCharging allows (enable) or blocks (disable) charging via the wall connector
@@ -77,13 +78,13 @@ func jqMustParse(s string) *gojq.Query {
 // newTwc3Fleet sets up the optional Tesla Fleet on/off control: it validates the
 // tesla block, builds the authenticated fleet client, auto-discovers region, wall
 // connector DIN and energy site, and resolves the on/off current (explicit override
-// or the box's commissioned maximum). It returns the fleet and that current; a
-// max-current read failure is non-fatal (current 0 -> on/off mode stays unavailable).
-func newTwc3Fleet(log *util.Logger, local *request.Helper, baseURI string, cfg *twc3TeslaConfig, switchCurrentOverride float64) (*twc3Fleet, float64, error) {
+// or the box's commissioned maximum). A max-current read failure is non-fatal
+// (switchCurrent stays 0 -> on/off mode reports no current range).
+func newTwc3Fleet(log *util.Logger, local *request.Helper, baseURI string, cfg *twc3TeslaConfig, switchCurrentOverride float64) (*twc3Fleet, error) {
 	// the template renders the tesla block as soon as any field is set, so a
 	// partial config surfaces here instead of being silently ignored
 	if cfg.Credentials.ID == "" || cfg.Tokens.Access == "" || cfg.Tokens.Refresh == "" {
-		return nil, 0, errors.New("tesla: clientId, accessToken and refreshToken are all required")
+		return nil, errors.New("tesla: clientId, accessToken and refreshToken are all required")
 	}
 
 	// redact the tesla secrets on the shared logger before any token handling
@@ -94,17 +95,17 @@ func newTwc3Fleet(log *util.Logger, local *request.Helper, baseURI string, cfg *
 
 	// switchCurrent override only takes effect in this on/off fallback mode
 	if switchCurrentOverride != 0 && (switchCurrentOverride < 1 || switchCurrentOverride > 32) {
-		return nil, 0, fmt.Errorf("switchCurrent must be between 1 and 32 A, got %g", switchCurrentOverride)
+		return nil, fmt.Errorf("switchCurrent must be between 1 and 32 A, got %g", switchCurrentOverride)
 	}
 
 	token, err := cfg.Tokens.Token()
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	identity, err := tesla.NewIdentity(log, tesla.OAuth2Config(cfg.Credentials.ID, cfg.Credentials.Secret), token)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	hc := request.NewClient(log)
@@ -117,46 +118,46 @@ func newTwc3Fleet(log *util.Logger, local *request.Helper, baseURI string, cfg *
 	// fleet base url: auto-detect the account's region (same as the tesla vehicle)
 	tc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(hc))
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	region, err := tc.UserRegion()
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	fleetBaseURL := strings.TrimRight(region.FleetApiBaseUrl, "/")
 
 	// derive the wall connector DIN locally from this box (works per-uri, also with multiple TWC3s)
 	din, err := localDIN(local, baseURI)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	// find the energy site containing this wall connector
 	energySiteID, err := discoverEnergySite(fleetClient, fleetBaseURL, din)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	f := &twc3Fleet{
 		client:          fleetClient,
 		commandURL:      fmt.Sprintf("%s/api/1/energy_sites/%d/command", fleetBaseURL, energySiteID),
 		din:             din,
+		switchCurrent:   switchCurrentOverride,
 		lockMaybeActive: true, // unknown at startup -> first enable clears any stale lock once
 	}
 
 	// determine the on/off current: explicit override, else the wall connector's
 	// commissioned maximum (read once at startup - it does not change). On read
 	// failure there is no fallback; the on/off mode stays unavailable (logged here).
-	switchCurrent := switchCurrentOverride
-	if switchCurrent == 0 {
+	if f.switchCurrent == 0 {
 		if a, err := f.maxOutputCurrent(); err != nil {
 			log.WARN.Printf("could not read max output current, on/off mode disabled (set switchCurrent to enable): %v", err)
 		} else {
-			switchCurrent = a
+			f.switchCurrent = a
 		}
 	}
 
-	return f, switchCurrent, nil
+	return f, nil
 }
 
 // localDIN derives the wall connector DIN (part_number--serial_number) from the

--- a/charger/twc3_fleet.go
+++ b/charger/twc3_fleet.go
@@ -27,9 +27,36 @@ type twc3TeslaConfig struct {
 
 // twc3Fleet sends vehicle-independent on/off commands via the Tesla Fleet API
 type twc3Fleet struct {
-	client     *request.Helper // with oauth2 transport
-	commandURL string          // fleetBaseURL + /api/1/energy_sites/{id}/command
-	din        string
+	client          *request.Helper // with oauth2 transport
+	commandURL      string          // fleetBaseURL + /api/1/energy_sites/{id}/command
+	din             string
+	lockMaybeActive bool // schedule may be gating the contactor (true = unknown/locked)
+}
+
+// setCharging allows (enable) or blocks (disable) charging via the wall connector
+// schedule. It always re-asserts the schedule so the desired state is restored even
+// if it was changed externally; evcc only calls this on state transitions, so this
+// adds no redundant Fleet calls.
+func (f *twc3Fleet) setCharging(enable bool) error {
+	if err := f.switchSchedule(enable); err != nil {
+		return err
+	}
+	f.lockMaybeActive = !enable
+	return nil
+}
+
+// clearLock lifts a possibly-active guest lock before charge control is handed back
+// to the vehicle. It only calls out when a lock may actually be active, avoiding a
+// redundant Fleet API call on every enable.
+func (f *twc3Fleet) clearLock() error {
+	if !f.lockMaybeActive {
+		return nil
+	}
+	if err := f.switchSchedule(true); err != nil {
+		return err
+	}
+	f.lockMaybeActive = false
+	return nil
 }
 
 // jq queries for the deeply-nested, non-contractual Fleet responses, compiled
@@ -111,9 +138,10 @@ func newTwc3Fleet(log *util.Logger, local *request.Helper, baseURI string, cfg *
 	}
 
 	f := &twc3Fleet{
-		client:     fleetClient,
-		commandURL: fmt.Sprintf("%s/api/1/energy_sites/%d/command", fleetBaseURL, energySiteID),
-		din:        din,
+		client:          fleetClient,
+		commandURL:      fmt.Sprintf("%s/api/1/energy_sites/%d/command", fleetBaseURL, energySiteID),
+		din:             din,
+		lockMaybeActive: true, // unknown at startup -> first enable clears any stale lock once
 	}
 
 	// determine the on/off current: explicit override, else the wall connector's

--- a/charger/twc3_fleet.go
+++ b/charger/twc3_fleet.go
@@ -1,0 +1,338 @@
+package charger
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/jq"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/vehicle"
+	"github.com/evcc-io/evcc/vehicle/tesla"
+	teslaclient "github.com/evcc-io/tesla-proxy-client"
+	"github.com/itchyny/gojq"
+	"golang.org/x/oauth2"
+)
+
+// twc3TeslaConfig is the optional tesla block enabling vehicle-independent on/off.
+type twc3TeslaConfig struct {
+	Credentials vehicle.ClientCredentials // ID (secret only needed for initial token mint, not for evcc's refresh)
+	Tokens      vehicle.Tokens            // Access, Refresh
+}
+
+// twc3Fleet sends vehicle-independent on/off commands via the Tesla Fleet API
+type twc3Fleet struct {
+	client     *request.Helper // with oauth2 transport
+	commandURL string          // fleetBaseURL + /api/1/energy_sites/{id}/command
+	din        string
+}
+
+// jq queries for the deeply-nested, non-contractual Fleet responses, compiled
+// once - a bad query then panics at init instead of failing per request.
+var (
+	twc3ScheduleErrQuery   = jqMustParse(".. | .ConfigureChargeScheduleResponse? | .error? | numbers")
+	twc3MaxOutputAmpsQuery = jqMustParse(".. | .max_output_current_amps? | numbers")
+)
+
+func jqMustParse(s string) *gojq.Query {
+	q, err := gojq.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return q
+}
+
+// newTwc3Fleet sets up the optional Tesla Fleet on/off control: it validates the
+// tesla block, builds the authenticated fleet client, auto-discovers region, wall
+// connector DIN and energy site, and resolves the on/off current (explicit override
+// or the box's commissioned maximum). It returns the fleet and that current; a
+// max-current read failure is non-fatal (current 0 -> on/off mode stays unavailable).
+func newTwc3Fleet(log *util.Logger, local *request.Helper, baseURI string, cfg *twc3TeslaConfig, switchCurrentOverride float64) (*twc3Fleet, float64, error) {
+	// the template renders the tesla block as soon as any field is set, so a
+	// partial config surfaces here instead of being silently ignored
+	if cfg.Credentials.ID == "" || cfg.Tokens.Access == "" || cfg.Tokens.Refresh == "" {
+		return nil, 0, errors.New("tesla: clientId, accessToken and refreshToken are all required")
+	}
+
+	// redact the tesla secrets on the shared logger before any token handling
+	log.Redact(
+		cfg.Tokens.Access, cfg.Tokens.Refresh,
+		cfg.Credentials.ID, cfg.Credentials.Secret,
+	)
+
+	// switchCurrent override only takes effect in this on/off fallback mode
+	if switchCurrentOverride != 0 && (switchCurrentOverride < 1 || switchCurrentOverride > 32) {
+		return nil, 0, fmt.Errorf("switchCurrent must be between 1 and 32 A, got %g", switchCurrentOverride)
+	}
+
+	token, err := cfg.Tokens.Token()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	identity, err := tesla.NewIdentity(log, tesla.OAuth2Config(cfg.Credentials.ID, cfg.Credentials.Secret), token)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	hc := request.NewClient(log)
+	hc.Transport = &oauth2.Transport{
+		Source: identity,
+		Base:   hc.Transport,
+	}
+	fleetClient := &request.Helper{Client: hc}
+
+	// fleet base url: auto-detect the account's region (same as the tesla vehicle)
+	tc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(hc))
+	if err != nil {
+		return nil, 0, err
+	}
+	region, err := tc.UserRegion()
+	if err != nil {
+		return nil, 0, err
+	}
+	fleetBaseURL := strings.TrimRight(region.FleetApiBaseUrl, "/")
+
+	// derive the wall connector DIN locally from this box (works per-uri, also with multiple TWC3s)
+	din, err := localDIN(local, baseURI)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// find the energy site containing this wall connector
+	energySiteID, err := discoverEnergySite(fleetClient, fleetBaseURL, din)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	f := &twc3Fleet{
+		client:     fleetClient,
+		commandURL: fmt.Sprintf("%s/api/1/energy_sites/%d/command", fleetBaseURL, energySiteID),
+		din:        din,
+	}
+
+	// determine the on/off current: explicit override, else the wall connector's
+	// commissioned maximum (read once at startup - it does not change). On read
+	// failure there is no fallback; the on/off mode stays unavailable (logged here).
+	switchCurrent := switchCurrentOverride
+	if switchCurrent == 0 {
+		if a, err := f.maxOutputCurrent(); err != nil {
+			log.WARN.Printf("could not read max output current, on/off mode disabled (set switchCurrent to enable): %v", err)
+		} else {
+			switchCurrent = a
+		}
+	}
+
+	return f, switchCurrent, nil
+}
+
+// localDIN derives the wall connector DIN (part_number--serial_number) from the
+// local /api/1/version endpoint, so it never has to be configured manually.
+func localDIN(client *request.Helper, baseURI string) (string, error) {
+	var res struct {
+		PartNumber   string `json:"part_number"`
+		SerialNumber string `json:"serial_number"`
+	}
+	if err := client.GetJSON(baseURI+"/api/1/version", &res); err != nil {
+		return "", fmt.Errorf("reading wall connector version: %w", err)
+	}
+	if res.PartNumber == "" || res.SerialNumber == "" {
+		return "", errors.New("wall connector version: missing part/serial number")
+	}
+	return res.PartNumber + "--" + res.SerialNumber, nil
+}
+
+// discoverEnergySite returns the energy_site_id whose site_info lists the given
+// wall connector DIN, so the site id never has to be configured manually.
+func discoverEnergySite(client *request.Helper, fleetBaseURL, din string) (int64, error) {
+	var products struct {
+		Response []struct {
+			EnergySiteID int64 `json:"energy_site_id"`
+		} `json:"response"`
+	}
+	if err := client.GetJSON(fleetBaseURL+"/api/1/products", &products); err != nil {
+		return 0, fmt.Errorf("listing energy sites: %w", err)
+	}
+
+	seen := make(map[int64]bool)
+	for _, p := range products.Response {
+		if p.EnergySiteID == 0 || seen[p.EnergySiteID] {
+			continue
+		}
+		seen[p.EnergySiteID] = true
+
+		var info struct {
+			Response struct {
+				Components struct {
+					WallConnectors []struct {
+						DIN string `json:"din"`
+					} `json:"wall_connectors"`
+				} `json:"components"`
+			} `json:"response"`
+		}
+		if err := client.GetJSON(fmt.Sprintf("%s/api/1/energy_sites/%d/site_info", fleetBaseURL, p.EnergySiteID), &info); err != nil {
+			continue // skip sites we cannot read
+		}
+		for _, wc := range info.Response.Components.WallConnectors {
+			if wc.DIN == din {
+				return p.EnergySiteID, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("wall connector %s not found in any energy site (token energy scope correct?)", din)
+}
+
+// utcTimeZone is the minimal time_zone the wall connector accepts (verified against
+// real hardware): UTC with a single zero-offset transition. Sending only time_zone_id,
+// or an empty transitions list, is rejected with error 4.
+var utcTimeZone = json.RawMessage(`{"time_zone_id":"UTC","time_zone_info":{"transitions":[{"local_time_utc_offset":0,"timestamp":{"nanos":0,"seconds":0}}]}}`)
+
+type wcTimePeriod struct {
+	StartSeconds int `json:"start_seconds"`
+	EndSeconds   int `json:"end_seconds"`
+}
+
+type wcDayTimePeriod struct {
+	DayBitmask  int            `json:"day_bitmask"`
+	TimePeriods []wcTimePeriod `json:"time_periods"`
+}
+
+// wcScheduleCmd is the configure_charge_schedule_request payload sent to the wall connector.
+type wcScheduleCmd struct {
+	CommandType       string `json:"command_type"`
+	CommandProperties struct {
+		Message struct {
+			Wc struct {
+				ConfigureChargeScheduleRequest struct {
+					Config struct {
+						Schedule struct {
+							DayTimePeriods []wcDayTimePeriod `json:"day_time_periods"`
+						} `json:"schedule"`
+						Delay struct {
+							MaxDelaySeconds int `json:"max_delay_seconds"`
+						} `json:"delay"`
+						EnableSchedule bool `json:"enable_schedule"`
+					} `json:"config"`
+					TimeZone json.RawMessage `json:"time_zone"`
+				} `json:"configure_charge_schedule_request"`
+			} `json:"wc"`
+		} `json:"message"`
+		IdentifierType int    `json:"identifier_type"`
+		TargetID       string `json:"target_id"`
+	} `json:"command_properties"`
+}
+
+// switchSchedule sends a configure_charge_schedule command: enable=true allows charging
+// (schedule off), enable=false locks the contactor via an active past-window schedule.
+func (f *twc3Fleet) switchSchedule(enable bool) error {
+	var cmd wcScheduleCmd
+	cmd.CommandType = "grpc_command"
+	cmd.CommandProperties.TargetID = f.din
+	cmd.CommandProperties.IdentifierType = 4
+
+	ccsr := &cmd.CommandProperties.Message.Wc.ConfigureChargeScheduleRequest
+	ccsr.TimeZone = utcTimeZone
+
+	// charging blocked -> active schedule; charging allowed -> schedule disabled.
+	ccsr.Config.EnableSchedule = !enable
+
+	// The wall connector rejects an empty day_time_periods (error 4) even when the
+	// schedule is disabled, so always send one valid window. Its only allowed slot is
+	// the last elapsed half hour, so "now" is never inside it (relevant only while the
+	// schedule is enabled). Computed in UTC to match the schedule's UTC time_zone, so
+	// blocking works in any local time zone.
+	s, e := offWindow(time.Now().UTC())
+	ccsr.Config.Schedule.DayTimePeriods = []wcDayTimePeriod{{
+		DayBitmask:  127,
+		TimePeriods: []wcTimePeriod{{StartSeconds: s, EndSeconds: e}},
+	}}
+
+	req, err := request.New(http.MethodPost, f.commandURL, request.MarshalJSON(cmd), request.JSONEncoding)
+	if err != nil {
+		return err
+	}
+
+	body, err := f.client.DoBody(req)
+	if err != nil {
+		return err
+	}
+
+	// Success is signalled by ConfigureChargeScheduleResponse.error == 1 (same as the
+	// Tesla app); anything else (e.g. 4) means rejected despite HTTP 200. The code sits
+	// deep in a non-contractual envelope, so anchor on the unique response key with jq.
+	if v, err := jq.Query(twc3ScheduleErrQuery, body); err == nil {
+		if code, ok := v.(float64); ok && code == 1 {
+			return nil
+		}
+		return fmt.Errorf("wall connector rejected schedule command (error %v)", v)
+	}
+
+	// no schedule response in the reply -> surface the top-level Fleet API error
+	var res struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &res); err == nil && res.Error != "" {
+		return errors.New(res.Error)
+	}
+	return errors.New("wall connector returned no schedule response")
+}
+
+// maxOutputCurrent reads the wall connector's commissioned maximum output current (A)
+// via the get_config command - the same value the Tesla app shows under "max output current".
+func (f *twc3Fleet) maxOutputCurrent() (float64, error) {
+	var cmd struct {
+		CommandType       string `json:"command_type"`
+		CommandProperties struct {
+			Message struct {
+				Wc struct {
+					GetConfigRequest struct{} `json:"get_config_request"`
+				} `json:"wc"`
+			} `json:"message"`
+			IdentifierType int    `json:"identifier_type"`
+			TargetID       string `json:"target_id"`
+		} `json:"command_properties"`
+	}
+	cmd.CommandType = "grpc_command"
+	cmd.CommandProperties.IdentifierType = 4
+	cmd.CommandProperties.TargetID = f.din
+
+	req, err := request.New(http.MethodPost, f.commandURL, request.MarshalJSON(cmd), request.JSONEncoding)
+	if err != nil {
+		return 0, err
+	}
+
+	body, err := f.client.DoBody(req)
+	if err != nil {
+		return 0, err
+	}
+
+	// the response is deeply nested in a non-contractual gRPC envelope; extract the
+	// unique max_output_current_amps key with jq instead of mirroring the structure.
+	v, err := jq.Query(twc3MaxOutputAmpsQuery, body)
+	if err != nil {
+		return 0, err
+	}
+	if a, ok := v.(float64); ok && a > 0 {
+		return a, nil
+	}
+	return 0, errors.New("wall connector returned no max_output_current_amps")
+}
+
+// offWindow returns the last full, already-elapsed half hour as seconds-of-day
+// (with midnight wrap), guaranteeing now is never inside [start,end). The caller
+// passes UTC so the window matches the schedule's UTC time_zone.
+func offWindow(now time.Time) (start, end int) {
+	sec := now.Hour()*3600 + now.Minute()*60 + now.Second()
+	end = (sec / 1800) * 1800 // start of the current half hour
+	start = end - 1800
+	if start < 0 { // before 00:30 -> wrap to 23:30-24:00
+		start, end = 24*3600-1800, 24*3600
+	}
+	return
+}

--- a/charger/twc3_fleet_test.go
+++ b/charger/twc3_fleet_test.go
@@ -1,0 +1,119 @@
+package charger
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+)
+
+// newTestFleet wires a twc3Fleet to a stub Fleet command server that always reports
+// success, and returns a pointer to the recorded enable_schedule values sent. Note:
+// enable_schedule == true means the schedule is active (charging blocked), false
+// means the schedule is off (charging allowed) - the inverse of "enable charging".
+func newTestFleet(t *testing.T, lockMaybeActive bool) (*twc3Fleet, *[]bool) {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		sent []bool
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var cmd wcScheduleCmd
+		if err := json.NewDecoder(r.Body).Decode(&cmd); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		mu.Lock()
+		sent = append(sent, cmd.CommandProperties.Message.Wc.ConfigureChargeScheduleRequest.Config.EnableSchedule)
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"response":{"ConfigureChargeScheduleResponse":{"error":1}}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	f := &twc3Fleet{
+		client:          request.NewHelper(util.NewLogger("test")),
+		commandURL:      srv.URL,
+		din:             "test-din",
+		lockMaybeActive: lockMaybeActive,
+	}
+	return f, &sent
+}
+
+func TestTwc3FleetSetCharging(t *testing.T) {
+	// variant B: setCharging always re-asserts the schedule, even on repeated enable,
+	// so evcc's corrective sync calls actually reach the hardware.
+	t.Run("always re-asserts", func(t *testing.T) {
+		f, sent := newTestFleet(t, false)
+		if err := f.setCharging(true); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.setCharging(true); err != nil {
+			t.Fatal(err)
+		}
+		// two enable calls -> two Fleet requests, both "schedule off" (charging allowed)
+		if want := []bool{false, false}; !slices.Equal(*sent, want) {
+			t.Errorf("enable_schedule sent = %v, want %v", *sent, want)
+		}
+	})
+
+	t.Run("disable then enable tracks lock state", func(t *testing.T) {
+		f, sent := newTestFleet(t, false)
+
+		if err := f.setCharging(false); err != nil {
+			t.Fatal(err)
+		}
+		if !f.lockMaybeActive {
+			t.Error("lockMaybeActive should be true after disable")
+		}
+
+		if err := f.setCharging(true); err != nil {
+			t.Fatal(err)
+		}
+		if f.lockMaybeActive {
+			t.Error("lockMaybeActive should be false after enable")
+		}
+
+		// disable -> schedule active (true); enable -> schedule off (false)
+		if want := []bool{true, false}; !slices.Equal(*sent, want) {
+			t.Errorf("enable_schedule sent = %v, want %v", *sent, want)
+		}
+	})
+}
+
+func TestTwc3FleetClearLock(t *testing.T) {
+	t.Run("clears once when locked", func(t *testing.T) {
+		f, sent := newTestFleet(t, true)
+
+		if err := f.clearLock(); err != nil {
+			t.Fatal(err)
+		}
+		if f.lockMaybeActive {
+			t.Error("lockMaybeActive should be false after clearLock")
+		}
+
+		// second call is a no-op (no redundant Fleet request)
+		if err := f.clearLock(); err != nil {
+			t.Fatal(err)
+		}
+		if want := []bool{false}; !slices.Equal(*sent, want) {
+			t.Errorf("enable_schedule sent = %v, want %v", *sent, want)
+		}
+	})
+
+	t.Run("no-op when not locked", func(t *testing.T) {
+		f, sent := newTestFleet(t, false)
+
+		if err := f.clearLock(); err != nil {
+			t.Fatal(err)
+		}
+		if len(*sent) != 0 {
+			t.Errorf("expected no Fleet request, got %v", *sent)
+		}
+	})
+}

--- a/templates/definition/charger/twc3.yaml
+++ b/templates/definition/charger/twc3.yaml
@@ -6,10 +6,67 @@ products:
 capabilities: ["meter", "dim"]
 requirements:
   description:
-    en: The TWC wallbox cannot be controlled directly. Control is via the vehicle. The vehicle must be selected at the TWC3 loadpoint. At this time only Tesla vehicles listed on [docs.evcc.io](https://docs.evcc.io/en/docs/devices/vehicles#tesla) are supported.
-    de: Die TWC Wallbox ist nicht direkt regelbar. Die Regelung erfolgt über das Fahrzeug. Das Fahrzeug muss am TWC3 Ladepunkt ausgewählt sein. Aktuell ausschließlich mit [docs.evcc.io](https://docs.evcc.io/docs/devices/vehicles#tesla) unterstützten Tesla Fahrzeugen nutzbar.
+    en: |
+      The TWC3 is read out locally (status, power, energy). Fine-grained current control is only available when a controllable Tesla vehicle is selected at the loadpoint.
+
+      With the optional Tesla Fleet block the wallbox can additionally be switched on/off vehicle-independently (e.g. for guests or non-Tesla vehicles) — no Tesla vehicle in evcc required.
+
+      The token setup is the same as for the Tesla vehicle integration: create a Tesla Developer account at [developer.tesla.com](https://developer.tesla.com/) and generate an Access and Refresh token (e.g. via the [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) guide), then enter them together with your Client ID. The only difference: the token must carry the energy scope (energy_device_data, energy_cmds) instead of the vehicle scope.
+
+      More information and alternatives can be found at [docs.evcc.io/blog](https://docs.evcc.io/en/blog/2025/01/20/tesla-api-update).
+    de: |
+      Der TWC3 wird lokal ausgelesen (Status, Leistung, Energie). Eine feine Strom-Regelung gibt es nur, wenn ein steuerbares Tesla-Fahrzeug am Ladepunkt ausgewählt ist.
+
+      Mit dem optionalen Tesla-Fleet-Block lässt sich die Wallbox zusätzlich fahrzeugunabhängig an/aus schalten (z. B. für Gäste oder Nicht-Tesla-Fahrzeuge) — kein Tesla-Fahrzeug in evcc nötig.
+
+      Die Einrichtung der Token ist identisch zur Tesla-Fahrzeug-Integration: Tesla Developer Account auf [developer.tesla.com](https://developer.tesla.com/) erstellen und Access- sowie Refresh-Token erzeugen (z. B. über die Anleitung von [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/)), dann zusammen mit der Client ID eintragen. Einziger Unterschied: Der Token muss den Energie-Scope (energy_device_data, energy_cmds) statt des Fahrzeug-Scopes haben.
+
+      Weitere Informationen und Alternativen findest du unter [docs.evcc.io/blog](https://docs.evcc.io/blog/2025/01/20/tesla-api-update).
 params:
   - name: host
+  - name: clientId
+    advanced: true
+    description:
+      generic: Client ID
+    help:
+      en: from [developer.tesla.com](https://developer.tesla.com/dashboard).
+      de: von [developer.tesla.com](https://developer.tesla.com/dashboard).
+  - name: accessToken
+    advanced: true
+    mask: true
+    help:
+      en: Fleet API token with energy scope (energy_device_data, energy_cmds). evcc only needs to refresh it, so no client secret is required.
+      de: Fleet-API-Token mit Energie-Scope (energy_device_data, energy_cmds). evcc muss ihn nur erneuern, daher ist kein Client Secret nötig.
+  - name: refreshToken
+    advanced: true
+    mask: true
+    help:
+      en: matching refresh token; evcc refreshes the access token automatically and persists it.
+      de: passender Refresh Token; evcc erneuert den Access Token automatisch und speichert ihn.
+  - name: switchCurrent
+    type: int
+    unit: A
+    advanced: true
+    pattern:
+      regex: ^([1-9]|[12][0-9]|3[0-2])?$
+      examples: ["16", "32"]
+    description:
+      en: Switch current
+      de: Schaltstrom
+    help:
+      en: On/off current (1-32 A) for PV mode, since the wall connector does not support direct ampere control. Default is the wall connector's configured max output current.
+      de: An/Aus-Strom (1-32 A) für den PV-Modus, da die Wallbox keine direkte Ampere-Regelung unterstützt. Standard ist der konfigurierte Maximalstrom der Wallbox.
 render: |
   type: twc3
   uri: http://{{ .host }}
+  {{- if .clientId }}
+  tesla:
+    credentials:
+      id: {{ .clientId }}
+    tokens:
+      access: {{ .accessToken }}
+      refresh: {{ .refreshToken }}
+  {{- end }}
+  {{- if .switchCurrent }}
+  switchCurrent: {{ .switchCurrent }}
+  {{- end }}

--- a/templates/definition/charger/twc3.yaml
+++ b/templates/definition/charger/twc3.yaml
@@ -59,7 +59,7 @@ params:
 render: |
   type: twc3
   uri: http://{{ .host }}
-  {{- if .clientId }}
+  {{- if or .clientId .accessToken .refreshToken }}
   tesla:
     credentials:
       id: {{ .clientId }}


### PR DESCRIPTION
The Tesla Wall Connector Gen 3 (`twc3`) charger today can only be controlled
through a controllable Tesla vehicle selected at the loadpoint. This PR adds an
**optional** Tesla Fleet API block that lets the wallbox be switched
**on/off vehicle-independently** — e.g. for guests or non-Tesla vehicles —
with no Tesla vehicle configured in evcc.

### How it works

The wall connector has no direct start/stop command, so on/off is implemented
via the `configure_charge_schedule` command: an active schedule whose only
allowed window lies in the past (computed in UTC) blocks charging; disabling the
schedule allows it. Region, wall-connector DIN and energy-site-id are
auto-discovered; auth mirrors the Tesla vehicle setup (client id + access/refresh
token with energy scope, no client secret). The on/off current defaults to the
box's configured `max_output_current` (read via `get_config`).

This is not a documented Fleet API capability — I derived the
`configure_charge_schedule` and `get_config` commands by capturing the traffic of
Tesla's own iOS app and confirmed them against real hardware (same `error: 1`
success reply the app receives).

### Backward compatibility

Without the optional `tesla:` block the template behaves exactly as before
(local read-out only). Existing `twc3` configs (only `host`) are unchanged.

### Config example

```yaml
chargers:
  - name: wallbox
    type: template
    template: twc3
    host: 192.168.x.y
    # optional — vehicle-independent on/off:
    clientId: <tesla developer client id>
    accessToken: <fleet token, energy scope>
    refreshToken: <matching refresh token>
    # optional override; default = wall connector's configured max output current:
    # switchCurrent: 16
```

### Scope / limitations

- On/off at full load only — no current modulation without a Tesla vehicle
  (the API doesn't support it), so for fine-grained PV surplus charging it
  brings little benefit. The win is price/time-based charging (planner, target
  time, dynamic tariffs) for *any* car at a TWC3.

### Hardware verification (2026-06-13)

CI can't exercise the Fleet paths (no Tesla credentials), so verified live against
a real TWC3 + energy token:

- `configure_charge_schedule` → HTTP 200, `error == 1` (success); `error == 4`
  (rejection, HTTP still 200) is now treated as an error.
- `day_time_periods` must never be empty/`null` (else error 4) → always one window sent.
- `time_zone` minimal accepted: UTC + one transition (offset 0); `end_seconds = 86400`
  (midnight wrap) accepted.
- `get_config` → `settings.max_output_current_amps` (= app value "max output current").
- `/users/region` works with the energy token (no user scope needed).

### Changed files

- `charger/twc3.go`
- `templates/definition/charger/twc3.yaml`
```