### PR TITLE
Huawei: add Smart Dongle template with curtailment support

### DIFF
--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -3,8 +3,8 @@ covers: ["huawei-sun2000", "huawei-dongle-powersensor", "huawei-sun2000-rs485"]
 products:
   - brand: Huawei
     description:
-      de: SUN2000 Hybrid-Wechselrichter
-      en: SUN2000 Hybrid Inverter
+      de: SUN2000/LUNA2000
+      en: SUN2000/LUNA2000
 capabilities: ["battery-control", "dim"]
 requirements:
   description:

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -5,7 +5,7 @@ products:
     description:
       de: SUN2000 Hybrid-Wechselrichter
       en: SUN2000 Hybrid Inverter
-capabilities: ["battery-control", "curtail", "dim"]
+capabilities: ["battery-control", "dim"]
 requirements:
   description:
     de: |
@@ -147,53 +147,6 @@ render: |
       decode: uint32nan
     scale: 0.01
   maxacpower: {{ .maxacpower }}
-  curtail:
-    source: ifelse
-    if:
-      source: convert
-      convert: bool2int
-      set:
-        source: sequence
-        set:
-        - source: const
-          value: {{ .curtailpercent }}
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 47418 # Maximum Feed Grid Power (0-100 %)
-              type: writesingle
-              encoding: uint16
-            scale: 10
-        - source: const
-          value: 7 # Power-limited grid connection (%)
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 47415 # Active power control mode
-              type: writesingle
-              encoding: uint16
-    else:
-      source: convert
-      convert: bool2int
-      set:
-        source: const
-        value: 0 # Unlimited 
-        set:
-          source: modbus
-          {{- include "modbus" . | indent 8 }}
-          register:
-            address: 47415 # Active power control mode
-            type: writesingle
-            encoding: uint16
-  curtailed:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 47415 # Active power control mode (0=no curtailment)
-      type: holding
-      decode: uint16
   {{- end }}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/huawei-sun2000-sdongle.yaml
+++ b/templates/definition/meter/huawei-sun2000-sdongle.yaml
@@ -7,10 +7,8 @@ products:
 capabilities: ["curtail"]
 requirements:
   description:
-    de: |
-      Modbus TCP erfordert die Freischaltung in den Kommunikationseinstellungen des Wechselrichters via "Installateur Zugang", siehe [Modbus TCP Aktivierungs-Anleitung](https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264).
-    en: |
-      Modbus TCP requires activation within the communication settings of the inverter using an "installer account", see [Modbus TCP Activation Guide](https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264).
+    de: Modbus TCP erfordert die Freischaltung in den Kommunikationseinstellungen des Wechselrichters via "Installateur Zugang", siehe [Modbus TCP Aktivierungs-Anleitung](https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264).
+    en: Modbus TCP requires activation within the communication settings of the inverter using an "installer account", see [Modbus TCP Activation Guide](https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264).
 caveats:
   - description:
       de: |

--- a/templates/definition/meter/huawei-sun2000-sdongle.yaml
+++ b/templates/definition/meter/huawei-sun2000-sdongle.yaml
@@ -1,0 +1,116 @@
+template: huawei-sun2000-sdongle
+products:
+  - brand: Huawei
+    description:
+      de: SUN2000 Hybrid-Wechselrichter (Smart Dongle)
+      en: SUN2000 Hybrid Inverter (Smart Dongle)
+capabilities: ["curtail"]
+requirements:
+  description:
+    de: |
+      Modbus TCP erfordert die Freischaltung in den Kommunikationseinstellungen des Wechselrichters via "Installateur Zugang", siehe [Modbus TCP Aktivierungs-Anleitung](https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264).
+    en: |
+      Modbus TCP requires activation within the communication settings of the inverter using an "installer account", see [Modbus TCP Activation Guide](https://forum.huawei.com/enterprise/en/modbus-tcp-guide/thread/667250677153415168-667213868771979264).
+caveats:
+  - description:
+      de: |
+        Die folgenden Gegebenheiten können zu Fehlern in der Modbus-Kommunikation führen:
+        - veraltete Firmware
+        - Änderung von Wechselrichter/Speicher-Einstellungen über das Huawei FusionSolar-Portal
+        - weitere Anwendungen (z.B. Home Assistant) greifen über einen Modbus Proxy auf die Anlage zu (auch abhängig von der Anlagenkomplexität, z.B. Anzahl kaskadierter Wechselrichter)
+      en: |
+        Please be aware that the following circumstances may lead to Modbus communication errors:
+        - outdated firmware
+        - altering inverter/battery configuration settings via Huawei FusionSolar portal
+        - other applications (e.g. Home Assistant) accessing the inverter via Modbus Proxy (also depending on plant complexity, e.g. number of cascaded inverters)
+params:
+  - name: usage
+    choice: ["pv"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+  - name: timeout
+    default: 15s
+  - name: maxacpower
+    service: modbus/read?address=30075&type=holding&encoding=uint32&{modbus}
+  - name: curtailpercent
+    description:
+      de: Wirkleistungsbegrenzung in Prozent
+      en: Active power limit in percent
+    advanced: true
+    usages: ["pv"]
+    description:
+      en: Inverter cascade
+      de: Wechselrichterkaskade
+    help:
+      en: Keep AC charging active (except for when being dimmed) to charge the storage from other inverters via AC. May prevent standby with older firmware versions.
+      de: AC-Laden bleibt aktiv (außer bei einer aktiven Leistungsreduzierung) zum Laden des Speichers aus anderen AC Quellen für Wechselrichterkaskaden. Verhindert u.U. den Standby mit älteren Firmware-Versionen.
+render: |
+  type: custom
+  {{- if eq .usage "pv" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
+    connectdelay: 1s
+    register:
+      address: 32064 # Input power DC
+      type: holding
+      decode: int32nan
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    timeout: {{ .timeout }}
+    register:
+      address: 32108 # Total DC Input Energy
+      type: holding
+      decode: uint32nan
+    scale: 0.01
+  maxacpower: {{ .maxacpower }}
+  curtail:
+    source: ifelse
+    if:
+      source: convert
+      convert: bool2int
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: {{ .curtailpercent }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47418 # Maximum Feed Grid Power (0-100 %)
+              type: writesingle
+              encoding: uint16
+            scale: 10
+        - source: const
+          value: 7 # Power-limited grid connection (%)
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47415 # Active power control mode
+              type: writesingle
+              encoding: uint16
+    else:
+      source: convert
+      convert: bool2int
+      set:
+        source: const
+        value: 0 # Unlimited 
+        set:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 47415 # Active power control mode
+            type: writesingle
+            encoding: uint16
+  curtailed:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 47415 # Active power control mode (0=no curtailment)
+      type: holding
+      decode: uint16
+  {{- end }}

--- a/templates/definition/meter/huawei-sun2000-sdongle.yaml
+++ b/templates/definition/meter/huawei-sun2000-sdongle.yaml
@@ -36,12 +36,6 @@ params:
       en: Active power limit in percent
     advanced: true
     usages: ["pv"]
-    description:
-      en: Inverter cascade
-      de: Wechselrichterkaskade
-    help:
-      en: Keep AC charging active (except for when being dimmed) to charge the storage from other inverters via AC. May prevent standby with older firmware versions.
-      de: AC-Laden bleibt aktiv (außer bei einer aktiven Leistungsreduzierung) zum Laden des Speichers aus anderen AC Quellen für Wechselrichterkaskaden. Verhindert u.U. den Standby mit älteren Firmware-Versionen.
 render: |
   type: custom
   {{- if eq .usage "pv" }}

--- a/templates/definition/meter/huawei-sun2000-sdongle.yaml
+++ b/templates/definition/meter/huawei-sun2000-sdongle.yaml
@@ -2,8 +2,8 @@ template: huawei-sun2000-sdongle
 products:
   - brand: Huawei
     description:
-      de: SUN2000 Hybrid-Wechselrichter (Smart Dongle)
-      en: SUN2000 Hybrid Inverter (Smart Dongle)
+      de: SUN2000 Wechselrichter mit Smart Dongle
+      en: SUN2000 Inverter with Smart Dongle
 capabilities: ["curtail"]
 requirements:
   description:
@@ -12,9 +12,9 @@ requirements:
 caveats:
   - description:
       de: |
-        Bitte beachten, dass für dieses Gerät der SDongleA-05 mit Unterstützung für Echtzeitdaten in FusionSolar benötigt wird.
+        Bitte beachten, dass für dieses Gerät der SDongleA-05 mit Unterstützung für Echtzeitdaten in FusionSolar benötigt wird. Es wird nicht empfohlen, mit parallelen Clients wie Home Assistant auf den Smart Dongle zuzugreifen.
       en: |
-        Please be aware that this device requires the SDongleA-05 supporting Live Data in FusionSolar.
+        Please be aware that this device requires the SDongleA-05 supporting Live Data in FusionSolar. It is not advised to access the Smart Dongle with parallel clients like Home Assistant.
 params:
   - name: usage
     choice: ["pv"]

--- a/templates/definition/meter/huawei-sun2000-sdongle.yaml
+++ b/templates/definition/meter/huawei-sun2000-sdongle.yaml
@@ -12,15 +12,9 @@ requirements:
 caveats:
   - description:
       de: |
-        Die folgenden Gegebenheiten können zu Fehlern in der Modbus-Kommunikation führen:
-        - veraltete Firmware
-        - Änderung von Wechselrichter/Speicher-Einstellungen über das Huawei FusionSolar-Portal
-        - weitere Anwendungen (z.B. Home Assistant) greifen über einen Modbus Proxy auf die Anlage zu (auch abhängig von der Anlagenkomplexität, z.B. Anzahl kaskadierter Wechselrichter)
+        Bitte beachten, dass für dieses Gerät der SDongleA-05 mit Unterstützung für Echtzeitdaten in FusionSolar benötigt wird.
       en: |
-        Please be aware that the following circumstances may lead to Modbus communication errors:
-        - outdated firmware
-        - altering inverter/battery configuration settings via Huawei FusionSolar portal
-        - other applications (e.g. Home Assistant) accessing the inverter via Modbus Proxy (also depending on plant complexity, e.g. number of cascaded inverters)
+        Please be aware that this device requires the SDongleA-05 supporting Live Data in FusionSolar.
 params:
   - name: usage
     choice: ["pv"]


### PR DESCRIPTION
## Problem 1
For Huawei, _Active Power Control_ is typically a feature of the communication device as it also controls cascaded inverters. EMMA users typically do not use the respective EMMA template but use the SUN2000 template instead, bypassing the EMMA in order to gain Battery Control support. The curtailment implementation however does not seem to work in this case (see #30800). Curtailment for EMMA is in fact a different mechanism:
<img width="926" height="788" alt="image" src="https://github.com/user-attachments/assets/8f1d409f-682a-40ee-84ca-d6aa0b959b95" />

## Problem 2
Another problem is that the `curtailed` is a rather slow register (see [response time measurements](https://docs.google.com/document/d/1pCopCJ3HsOCmYLwUJZjzcpnZSOeC5v6yDGFRf6hBEi8/edit?tab=t.0#heading=h.1otbdcrwk2ki)) which seems to be pushing the slow SDongleA-05 without Live Data support over the cliff, see #30837.

## Solution
I therefore introduce a Smart Dongle template for which `curtailment` is implemented which should only be used with the **fast** SDongleA-05 (the one for which Live Data is available in FusionSolar).

Removing `curtailment` for the common huawei-sun2000-hybrid template fixes the problems with EMMA and slow SDongleA-05 setups. As for EMMA, `curtailment` has to be implemented in a different way. As for the slow SDongleA-05, we will have to see whether it can be sped up, see #30837.

/cc @Mungg1818 


## TODO

- [ ] remove curtailment in general huawei-sun2000-hybrid template