### PR TITLE
Dependabot: manage gomod and npm updates with infrastructure label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,19 @@ updates:
       interval: "monthly"
     labels:
       - "infrastructure"
+  # gomod and npm: version updates disabled (limit 0); the entries only label
+  # Dependabot security PRs as infrastructure instead of the default dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels:
+      - "infrastructure"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels:
+      - "infrastructure"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,19 +12,15 @@ updates:
       interval: "monthly"
     labels:
       - "infrastructure"
-  # gomod and npm: version updates disabled (limit 0); the entries only label
-  # Dependabot security PRs as infrastructure instead of the default dependencies
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 0
     labels:
       - "infrastructure"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 0
     labels:
       - "infrastructure"


### PR DESCRIPTION
Dependabot had no `gomod`/`npm` entries, so their PRs fell back to the default `dependencies` label (which Dependabot recreates). This adds entries that label them `infrastructure` like the existing github-actions and docker ecosystems.

- add `gomod` and `npm` entries with `labels: ["infrastructure"]`
- enables monthly Dependabot version updates for both, and labels their security updates `infrastructure` so the default `dependencies` label is never created