### PR TITLE
Dependabot: disable gomod and npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,14 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # 0 disables version-update PRs; the entry still labels security updates
+    open-pull-requests-limit: 0
     labels:
       - "infrastructure"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
     labels:
       - "infrastructure"


### PR DESCRIPTION
Follow-up to #30806, which added `gomod`/`npm` entries (labeling their PRs `infrastructure`) and thereby enabled monthly version-update PRs for both.

This sets `open-pull-requests-limit: 0` on those two entries so they no longer open version-update PRs. Their Dependabot security updates are unaffected and keep the `infrastructure` label, so the default `dependencies` label is still never created.