### PR TITLE
EU Data Act: identify ID.3 cruising range by data point key

### DIFF
--- a/vehicle/vw/eudataact/eudataact_test.go
+++ b/vehicle/vw/eudataact/eudataact_test.go
@@ -1,11 +1,7 @@
 package eudataact
 
 import (
-	"archive/zip"
-	"bytes"
 	"fmt"
-	"io"
-	"log"
 	"testing"
 	"time"
 
@@ -133,43 +129,15 @@ func TestMergeDeliveryOrder(t *testing.T) {
 	assert.Equal(t, "75", data[FieldSoc].Value, "the newest delivered SoC wins")
 }
 
-// zipDataset wraps a dataset JSON document in a zip archive as delivered by the portal
-func zipDataset(t *testing.T, json string) []byte {
-	t.Helper()
+// TestPoints guards that a data point with a generic field name ("value") is
+// indexed by its unique key while the name stays indexed (and thus logged).
+func TestPoints(t *testing.T) {
+	data := points([]dataPoint{
+		{Key: KeyRangeID3, DataFieldName: "value", Value: "317"},
+		{DataFieldName: FieldOdometer, Value: "22164"},
+	})
 
-	var buf bytes.Buffer
-	zw := zip.NewWriter(&buf)
-	w, err := zw.Create("dataset.json")
-	require.NoError(t, err)
-	_, err = io.WriteString(w, json)
-	require.NoError(t, err)
-	require.NoError(t, zw.Close())
-
-	return buf.Bytes()
-}
-
-// TestParseDatasetKey guards that a data point with a generic, non-unique
-// dataFieldName ("value") is indexed by its unique key, not the name.
-func TestParseDatasetKey(t *testing.T) {
-	b := zipDataset(t, `{"vin":"WVWZZZ","Data":[
-		{"key":"`+KeyRangeID3+`","dataFieldName":"value","value":"317"},
-		{"key":"other-guid","dataFieldName":"mileage","value":"22164"}
-	]}`)
-
-	data, err := parseDataset(log.New(io.Discard, "", 0), b)
-	require.NoError(t, err)
-
-	assert.Equal(t, "317", data[KeyRangeID3].Value, "ID.3 range is indexed by key")
-	assert.NotContains(t, data, "value", "generic field name is not indexed")
-	assert.Equal(t, "22164", data[FieldOdometer].Value, "named field is indexed by name")
-}
-
-// TestRangeByKey guards that Range falls back to the ID.3 cruising range
-// delivered under its key when the named range fields are absent.
-func TestRangeByKey(t *testing.T) {
-	p := testProvider(map[string]point{KeyRangeID3: {Value: "317"}})
-
-	rng, err := p.Range()
-	require.NoError(t, err)
-	assert.Equal(t, int64(317), rng)
+	assert.Equal(t, "317", data[KeyRangeID3].Value, "ID.3 range indexed by key")
+	assert.Equal(t, "317", data["value"].Value, "field name remains indexed")
+	assert.Equal(t, "22164", data[FieldOdometer].Value, "named field indexed by name")
 }

--- a/vehicle/vw/eudataact/eudataact_test.go
+++ b/vehicle/vw/eudataact/eudataact_test.go
@@ -1,7 +1,11 @@
 package eudataact
 
 import (
+	"archive/zip"
+	"bytes"
 	"fmt"
+	"io"
+	"log"
 	"testing"
 	"time"
 
@@ -127,4 +131,45 @@ func TestMergeDeliveryOrder(t *testing.T) {
 	}
 
 	assert.Equal(t, "75", data[FieldSoc].Value, "the newest delivered SoC wins")
+}
+
+// zipDataset wraps a dataset JSON document in a zip archive as delivered by the portal
+func zipDataset(t *testing.T, json string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("dataset.json")
+	require.NoError(t, err)
+	_, err = io.WriteString(w, json)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	return buf.Bytes()
+}
+
+// TestParseDatasetKey guards that a data point with a generic, non-unique
+// dataFieldName ("value") is indexed by its unique key, not the name.
+func TestParseDatasetKey(t *testing.T) {
+	b := zipDataset(t, `{"vin":"WVWZZZ","Data":[
+		{"key":"`+KeyRangeID3+`","dataFieldName":"value","value":"317"},
+		{"key":"other-guid","dataFieldName":"mileage","value":"22164"}
+	]}`)
+
+	data, err := parseDataset(log.New(io.Discard, "", 0), b)
+	require.NoError(t, err)
+
+	assert.Equal(t, "317", data[KeyRangeID3].Value, "ID.3 range is indexed by key")
+	assert.NotContains(t, data, "value", "generic field name is not indexed")
+	assert.Equal(t, "22164", data[FieldOdometer].Value, "named field is indexed by name")
+}
+
+// TestRangeByKey guards that Range falls back to the ID.3 cruising range
+// delivered under its key when the named range fields are absent.
+func TestRangeByKey(t *testing.T) {
+	p := testProvider(map[string]point{KeyRangeID3: {Value: "317"}})
+
+	rng, err := p.Range()
+	require.NoError(t, err)
+	assert.Equal(t, int64(317), rng)
 }

--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -95,7 +95,7 @@ func (v *Provider) Range() (int64, error) {
 		return 0, err
 	}
 
-	if p := lookup(data, FieldRangeSecondary, FieldRangePrimary, FieldRangeCombined); p != nil {
+	if p := lookup(data, FieldRangeSecondary, FieldRangePrimary, FieldRangeCombined, KeyRangeID3); p != nil {
 		f, err := strconv.ParseFloat(p.Value, 64)
 		return int64(f), err
 	}

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -123,8 +123,7 @@ const (
 	FieldRangeCombined  = "cruising_range_combined"
 	FieldRangePrimary   = "cruising_range_primary_engine"
 	FieldRangeSecondary = "cruising_range_secondary_engine"
-	// KeyRangeID3 identifies the VW ID.3 cruising range, delivered as "value"
-	KeyRangeID3 = "0ca40e18-0564-3eda-bcc0-7aee9ef44f04"
+	KeyRangeID3 = "0ca40e18-0564-3eda-bcc0-7aee9ef44f04" // VW ID.3 cruising range, delivered as "value"
 
 	// odo
 	FieldOdometer      = "mileage"

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -123,7 +123,7 @@ const (
 	FieldRangeCombined  = "cruising_range_combined"
 	FieldRangePrimary   = "cruising_range_primary_engine"
 	FieldRangeSecondary = "cruising_range_secondary_engine"
-	KeyRangeID3 = "0ca40e18-0564-3eda-bcc0-7aee9ef44f04" // VW ID.3 cruising range, delivered as "value"
+	KeyRangeID3         = "0ca40e18-0564-3eda-bcc0-7aee9ef44f04" // VW ID.3 cruising range, delivered as "value"
 
 	// odo
 	FieldOdometer      = "mileage"
@@ -201,15 +201,26 @@ func parseDataset(log *log.Logger, b []byte) (map[string]point, error) {
 		return nil, err
 	}
 
-	res := make(map[string]point, len(ds.Data))
-	for _, p := range ds.Data {
-		// index known data points by their unique key, others by field name
-		name := p.DataFieldName
-		if _, ok := knownKeys[p.Key]; ok {
-			name = p.Key
-		}
+	return points(ds.Data), nil
+}
 
-		if name == "" || p.Value == "" {
+// points indexes data points by field name (newest timestamp wins), and known
+// data points additionally by their unique key, as their name is not unique.
+func points(data []dataPoint) map[string]point {
+	res := make(map[string]point, len(data))
+
+	set := func(name string, p point) {
+		if name == "" {
+			return
+		}
+		if cur, ok := res[name]; ok && cur.Timestamp.After(p.Timestamp) {
+			return
+		}
+		res[name] = p
+	}
+
+	for _, p := range data {
+		if p.Value == "" {
 			continue
 		}
 
@@ -217,13 +228,13 @@ func parseDataset(log *log.Logger, b []byte) (map[string]point, error) {
 		if p.TimestampUtc != nil {
 			ts = *p.TimestampUtc
 		}
+		pt := point{Value: p.Value, Timestamp: ts}
 
-		if cur, ok := res[name]; ok && cur.Timestamp.After(ts) {
-			continue
+		set(p.DataFieldName, pt)
+		if _, ok := knownKeys[p.Key]; ok {
+			set(p.Key, pt)
 		}
-
-		res[name] = point{Value: p.Value, Timestamp: ts}
 	}
 
-	return res, nil
+	return res
 }

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -81,8 +81,10 @@ type dataset struct {
 	CreatedOn time.Time `json:"createdOn"`
 }
 
-// dataPoint is a single data point as delivered in the dataset JSON document
+// dataPoint is a single data point as delivered in the dataset JSON document.
+// Key is the data point's unique GUID, used when DataFieldName is generic (e.g. "value").
 type dataPoint struct {
+	Key           string     `json:"key"`
 	DataFieldName string     `json:"dataFieldName"`
 	Value         string     `json:"value"`
 	TimestampUtc  *time.Time `json:"timestampUtc"`
@@ -121,6 +123,8 @@ const (
 	FieldRangeCombined  = "cruising_range_combined"
 	FieldRangePrimary   = "cruising_range_primary_engine"
 	FieldRangeSecondary = "cruising_range_secondary_engine"
+	// KeyRangeID3 identifies the VW ID.3 cruising range, delivered as "value"
+	KeyRangeID3 = "0ca40e18-0564-3eda-bcc0-7aee9ef44f04"
 
 	// odo
 	FieldOdometer      = "mileage"
@@ -129,6 +133,12 @@ const (
 	// time
 	FieldRemainingTime = "remaining_charging_time"
 )
+
+// knownKeys lists data point GUIDs that are indexed by their key instead of the
+// generic, non-unique DataFieldName they are delivered with
+var knownKeys = map[string]struct{}{
+	KeyRangeID3: {},
+}
 
 // contentDatasets returns the datasets that actually carry content, with their
 // delivery time parsed into Timestamp and sorted from oldest to newest. The
@@ -194,7 +204,13 @@ func parseDataset(log *log.Logger, b []byte) (map[string]point, error) {
 
 	res := make(map[string]point, len(ds.Data))
 	for _, p := range ds.Data {
-		if p.DataFieldName == "" || p.Value == "" {
+		// index known data points by their unique key, others by field name
+		name := p.DataFieldName
+		if _, ok := knownKeys[p.Key]; ok {
+			name = p.Key
+		}
+
+		if name == "" || p.Value == "" {
 			continue
 		}
 
@@ -203,11 +219,11 @@ func parseDataset(log *log.Logger, b []byte) (map[string]point, error) {
 			ts = *p.TimestampUtc
 		}
 
-		if cur, ok := res[p.DataFieldName]; ok && cur.Timestamp.After(ts) {
+		if cur, ok := res[name]; ok && cur.Timestamp.After(ts) {
 			continue
 		}
 
-		res[p.DataFieldName] = point{Value: p.Value, Timestamp: ts}
+		res[name] = point{Value: p.Value, Timestamp: ts}
 	}
 
 	return res, nil


### PR DESCRIPTION
fixes #30849

The EU Data Act portal identifies some data points only by their unique GUID `key`: the VW ID.3 cruising range is delivered with the generic, non-unique `dataFieldName` "value" (key `0ca40e18-0564-3eda-bcc0-7aee9ef44f04`), so looking it up by name does not work and the range stays empty.

Data points are now indexed by their key instead of the field name when the key is in a small known set, and `Range` falls back to the ID.3 key when the named range fields are absent.