### PR TITLE
Kostal Plenticore: add holdcharge implementation

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -131,5 +131,16 @@ render: |
           source: error
           error: ErrNotAvailable
           {{- end }}
+      - case: 4 # holdcharge
+        set:
+          source: const
+          value: 0 # W
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1038 # Battery max. charge power limit, absolute [W]
+              type: writemultiple
+              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
This implementation adds the holdCharge feature to Kostal Plenticore devices, as introduced in #27906.
It utilizes register 1038 to set a charge power limit (in watts), effectively preventing charging while still allowing discharge if required.

From the Kostal Modbus documentation:

| Register | Reg. dec. | Description | Unit | Type | Lenth | Access | Mode |
|----------|-----------|-----------------------------------------------|------|-------|--------|--------|-------------|
| 0x40E | 1038 | Battery max. charge power limit, absolute  | W | Float | 2 | RW | 0x03/0x10 |
| 0x410 | 1040 | Battery max. discharge power limit, absolute | W | Float | 2 | RW | 0x03/0x10 |

The existing defer logic is used to ensure registers written are properly reset when switching modes.