### PR TITLE
enphase: fix battery_type parameter (BC)

### DIFF
--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -25,6 +25,7 @@ params:
     default: ac
     choice: ["ac", "iq"]
     advanced: true
+    usages: ["battery"]
   - preset: battery-params
   - name: cache
     advanced: true


### PR DESCRIPTION
The `battery_type` is only relevant for the battery integration. So added `usages: ["battery"]`.

@ Reviewer: Does this potentially break already added Enphase Batteries?