### PR TITLE
Vehicle: manual SoC override for vehicles without SoC API

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -18,4 +18,5 @@ const (
 	WelcomeCharge              // vehicle
 	ClimaterDisabled           // vehicle - ignore climater state for charge control
 	AutodetectDisabled         // vehicle - do not try to identify vehicle by status
+	ManualSoc                  // vehicle - soc is manually set by user
 )

--- a/api/feature_enumer.go
+++ b/api/feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "CoarseCurrentIntegratedDeviceSwitchDeviceHeatingContinuousAverageCacheableOfflineRetryableStreamingWelcomeChargeClimaterDisabledAutodetectDisabled"
+const _FeatureName = "CoarseCurrentIntegratedDeviceSwitchDeviceHeatingContinuousAverageCacheableOfflineRetryableStreamingWelcomeChargeClimaterDisabledAutodetectDisabledManualSoc"
 
-var _FeatureIndex = [...]uint8{0, 13, 29, 41, 48, 58, 65, 74, 81, 90, 99, 112, 128, 146}
+var _FeatureIndex = [...]uint8{0, 13, 29, 41, 48, 58, 65, 74, 81, 90, 99, 112, 128, 146, 155}
 
-const _FeatureLowerName = "coarsecurrentintegrateddeviceswitchdeviceheatingcontinuousaveragecacheableofflineretryablestreamingwelcomechargeclimaterdisabledautodetectdisabled"
+const _FeatureLowerName = "coarsecurrentintegrateddeviceswitchdeviceheatingcontinuousaveragecacheableofflineretryablestreamingwelcomechargeclimaterdisabledautodetectdisabledmanualsoc"
 
 func (i Feature) String() string {
 	i -= 1
@@ -38,9 +38,10 @@ func _FeatureNoOp() {
 	_ = x[WelcomeCharge-(11)]
 	_ = x[ClimaterDisabled-(12)]
 	_ = x[AutodetectDisabled-(13)]
+	_ = x[ManualSoc-(14)]
 }
 
-var _FeatureValues = []Feature{CoarseCurrent, IntegratedDevice, SwitchDevice, Heating, Continuous, Average, Cacheable, Offline, Retryable, Streaming, WelcomeCharge, ClimaterDisabled, AutodetectDisabled}
+var _FeatureValues = []Feature{CoarseCurrent, IntegratedDevice, SwitchDevice, Heating, Continuous, Average, Cacheable, Offline, Retryable, Streaming, WelcomeCharge, ClimaterDisabled, AutodetectDisabled, ManualSoc}
 
 var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureName[0:13]:         CoarseCurrent,
@@ -69,6 +70,8 @@ var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureLowerName[112:128]: ClimaterDisabled,
 	_FeatureName[128:146]:      AutodetectDisabled,
 	_FeatureLowerName[128:146]: AutodetectDisabled,
+	_FeatureName[146:155]:      ManualSoc,
+	_FeatureLowerName[146:155]: ManualSoc,
 }
 
 var _FeatureNames = []string{
@@ -85,6 +88,7 @@ var _FeatureNames = []string{
 	_FeatureName[99:112],
 	_FeatureName[112:128],
 	_FeatureName[128:146],
+	_FeatureName[146:155],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/assets/js/components/Vehicles/Soc.vue
+++ b/assets/js/components/Vehicles/Soc.vue
@@ -116,7 +116,10 @@ export default defineComponent({
 				return this.vehicleSoc;
 			}
 			if (this.manualSoc > 0 && this.socPerKwh > 0) {
-				return Math.min(100, Math.round(this.manualSoc + this.socPerKwh * (this.chargedEnergy / 1e3)));
+				return Math.min(
+					100,
+					Math.round(this.manualSoc + this.socPerKwh * (this.chargedEnergy / 1e3))
+				);
 			}
 			return this.vehicleSoc;
 		},

--- a/assets/js/components/Vehicles/Soc.vue
+++ b/assets/js/components/Vehicles/Soc.vue
@@ -95,6 +95,8 @@ export default defineComponent({
 		chargedEnergy: { type: Number, default: 0 },
 		socBasedCharging: Boolean,
 		socBasedPlanning: Boolean,
+		manualSoc: { type: Number, default: 0 },
+		socPerKwh: { type: Number, default: 0 },
 	},
 	emits: ["limit-soc-drag", "limit-soc-updated", "plan-clicked"],
 	data() {
@@ -109,10 +111,19 @@ export default defineComponent({
 		step() {
 			return this.heating ? 1 : 5;
 		},
+		effectiveSoc(): number {
+			if (this.vehicleSoc > 0) {
+				return this.vehicleSoc;
+			}
+			if (this.manualSoc > 0 && this.socPerKwh > 0) {
+				return Math.min(100, Math.round(this.manualSoc + this.socPerKwh * (this.chargedEnergy / 1e3)));
+			}
+			return this.vehicleSoc;
+		},
 		vehicleSocDisplayWidth() {
 			if (this.socBasedCharging) {
-				if (this.vehicleSoc >= 0) {
-					return this.vehicleSoc;
+				if (this.effectiveSoc >= 0) {
+					return this.effectiveSoc;
 				}
 				return 100;
 			} else {
@@ -132,7 +143,7 @@ export default defineComponent({
 			return Math.max(this.planEnergy, this.limitEnergy, this.chargedEnergy / 1e3);
 		},
 		vehicleLimitSocActive() {
-			return this.vehicleLimitSoc > 0 && this.vehicleLimitSoc > this.vehicleSoc;
+			return this.vehicleLimitSoc > 0 && this.vehicleLimitSoc > this.effectiveSoc;
 		},
 		planMarkerPosition(): number {
 			if (this.socBasedPlanning) {
@@ -186,14 +197,14 @@ export default defineComponent({
 					return null;
 				}
 				if (this.minSocNotReached) {
-					return this.minSoc - this.vehicleSoc;
+					return this.minSoc - this.effectiveSoc;
 				}
 				const limit = Math.min(
 					this.vehicleLimitSoc || 100,
 					Math.max(this.visibleLimitSoc, this.effectivePlanSoc || 0)
 				);
-				if (limit > this.vehicleSoc) {
-					return limit - this.vehicleSoc;
+				if (limit > this.effectiveSoc) {
+					return limit - this.effectiveSoc;
 				}
 			} else {
 				return 100 - this.vehicleSocDisplayWidth;

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -40,8 +40,8 @@
 						max="100"
 						step="1"
 						:value="manualSocInput"
-						@change="updateManualSoc"
 						style="width: 4.5em"
+						@change="updateManualSoc"
 					/>
 					<span>%</span>
 					<button
@@ -53,8 +53,12 @@
 						✕
 					</button>
 				</div>
-				<small v-if="estimatedCurrentSoc" class="text-muted">{{ estimatedCurrentSoc }}</small>
-				<small v-if="range" class="text-muted"> · {{ fmtNumber(range, 0) }} {{ rangeUnit }}</small>
+				<small v-if="estimatedCurrentSoc" class="text-muted">{{
+					estimatedCurrentSoc
+				}}</small>
+				<small v-if="range" class="text-muted">
+					· {{ fmtNumber(range, 0) }} {{ rangeUnit }}</small
+				>
 			</div>
 			<LabelAndValue
 				v-else-if="socBasedCharging"

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -1,4 +1,4 @@
-ud<template>
+<template>
 	<div class="vehicle pt-4">
 		<VehicleTitle
 			v-if="!integratedDevice"

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -1,4 +1,4 @@
-<template>
+ud<template>
 	<div class="vehicle pt-4">
 		<VehicleTitle
 			v-if="!integratedDevice"
@@ -30,8 +30,34 @@
 			/>
 		</div>
 		<div class="details d-flex flex-wrap justify-content-between">
+			<div v-if="hasManualSoc" class="flex-grow-1" data-testid="manual-soc">
+				<small class="text-muted d-block">{{ $t("main.vehicle.manualSoc") }}</small>
+				<div class="d-flex align-items-center gap-1">
+					<input
+						type="number"
+						class="manual-soc-input form-control form-control-sm"
+						min="0"
+						max="100"
+						step="1"
+						:value="manualSocInput"
+						@change="updateManualSoc"
+						style="width: 4.5em"
+					/>
+					<span>%</span>
+					<button
+						v-if="vehicle?.manualSoc"
+						class="btn btn-sm btn-outline-secondary ms-1"
+						:title="$t('main.vehicle.manualSocClear')"
+						@click="clearManualSoc"
+					>
+						✕
+					</button>
+				</div>
+				<small v-if="estimatedCurrentSoc" class="text-muted">{{ estimatedCurrentSoc }}</small>
+				<small v-if="range" class="text-muted"> · {{ fmtNumber(range, 0) }} {{ rangeUnit }}</small>
+			</div>
 			<LabelAndValue
-				v-if="socBasedCharging"
+				v-else-if="socBasedCharging"
 				class="flex-grow-1"
 				:label="vehicleSocTitle"
 				:value="formattedSoc"
@@ -78,6 +104,7 @@
 </template>
 
 <script lang="ts">
+import api from "@/api";
 import collector from "@/mixins/collector.ts";
 import formatter, { POWER_UNIT } from "@/mixins/formatter";
 import LabelAndValue from "../Helper/LabelAndValue.vue";
@@ -189,6 +216,7 @@ export default defineComponent({
 	data() {
 		return {
 			displayLimitSoc: this.effectiveLimitSoc,
+			manualSocInput: this.vehicle?.manualSoc || 0,
 			statusOverride: undefined as VehicleStatus | undefined,
 			chargingPlanModal: this.$refs["chargingPlanModal"] as
 				| InstanceType<typeof ChargingPlanModal>
@@ -245,6 +273,12 @@ export default defineComponent({
 			const value = this.socPerKwh * (this.chargedEnergy / 1e3);
 			return value > 1 ? `+${this.fmtPercentage(value)}` : null;
 		},
+		estimatedCurrentSoc(): string | null {
+			if (!this.manualSocInput) return null;
+			const charged = this.socPerKwh * (this.chargedEnergy / 1e3);
+			const current = Math.min(100, Math.round(this.manualSocInput + charged));
+			return this.fmtPercentage(current);
+		},
 		chargingPlanDisabled() {
 			return this.mode && [CHARGE_MODE.OFF, CHARGE_MODE.NOW].includes(this.mode);
 		},
@@ -254,10 +288,19 @@ export default defineComponent({
 		smartFeedInPriorityDisabled() {
 			return this.chargingPlanDisabled;
 		},
+		manualSoc(): number {
+			return this.manualSocInput;
+		},
+		hasManualSoc(): boolean {
+			return this.vehicle?.features?.includes("ManualSoc") || false;
+		},
 	},
 	watch: {
 		effectiveLimitSoc() {
 			this.displayLimitSoc = this.effectiveLimitSoc;
+		},
+		"vehicle.manualSoc"(val: number) {
+			this.manualSocInput = val || 0;
 		},
 	},
 	methods: {
@@ -285,6 +328,20 @@ export default defineComponent({
 		},
 		handleBoostStatus(status: VehicleStatus) {
 			this.statusOverride = status;
+		},
+		updateManualSoc(e: Event) {
+			const target = e.target as HTMLInputElement;
+			const soc = Math.max(0, Math.min(100, parseFloat(target.value) || 0));
+			this.manualSocInput = soc;
+			if (this.vehicle?.name) {
+				api.post(`vehicles/${this.vehicle.name}/manualsoc/${soc}`);
+			}
+		},
+		clearManualSoc() {
+			this.manualSocInput = 0;
+			if (this.vehicle?.name) {
+				api.delete(`vehicles/${this.vehicle.name}/manualsoc`);
+			}
 		},
 	},
 });

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -360,6 +360,7 @@ export interface Loadpoint {
   vehicleSoc: number;
   vehicleTitle: string;
   vehicleWelcomeActive: boolean;
+  manualSoc: number;
   batteryBoostLimit: number;
 }
 
@@ -655,6 +656,7 @@ export interface Vehicle {
   name: string;
   minSoc?: number;
   limitSoc?: number;
+  manualSoc?: number;
   plan?: StaticPlan;
   repeatingPlans: RepeatingPlan[] | null;
   planStrategy: PlanStrategy;

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -106,5 +106,5 @@ const (
 	VehicleLimitSoc        = "vehicleLimitSoc"        // vehicle api soc limit
 	VehicleClimaterActive  = "vehicleClimaterActive"  // vehicle climater active
 	VehicleWelcomeActive   = "vehicleWelcomeActive"   // vehicle might need welcome charge
-	ManualSoc              = "manualSoc"               // manually set vehicle soc
+	ManualSoc              = "manualSoc"              // manually set vehicle soc
 )

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -106,4 +106,5 @@ const (
 	VehicleLimitSoc        = "vehicleLimitSoc"        // vehicle api soc limit
 	VehicleClimaterActive  = "vehicleClimaterActive"  // vehicle climater active
 	VehicleWelcomeActive   = "vehicleWelcomeActive"   // vehicle might need welcome charge
+	ManualSoc              = "manualSoc"               // manually set vehicle soc
 )

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1889,11 +1889,12 @@ func (lp *Loadpoint) publishSocAndRange() {
 
 	// apply manual SoC override if vehicle supports it
 	if v := lp.GetVehicle(); v != nil && lp.vehicleHasFeature(api.ManualSoc) {
-		if manualSoc := vehicle.Settings(lp.log, v).GetManualSoc(); manualSoc > 0 {
+		vs := vehicle.Settings(lp.log, v)
+		if manualSoc := vs.GetManualSoc(); manualSoc > 0 {
 			lp.vehicleSoc = manualSoc
 			lp.log.DEBUG.Printf("vehicle soc (manual): %.0f%%", lp.vehicleSoc)
 		}
-		lp.publish(keys.ManualSoc, vehicle.Settings(lp.log, v).GetManualSoc())
+		lp.publish(keys.ManualSoc, vs.GetManualSoc())
 	}
 
 	lp.publish(keys.VehicleSoc, lp.vehicleSoc)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -406,12 +406,8 @@ func (lp *Loadpoint) requestUpdate() {
 
 // configureChargerType ensures that chargeMeter, Rate and Timer can use charger capabilities
 func (lp *Loadpoint) configureChargerType(charger api.Charger) {
-	var integrated bool
-
 	// ensure charge meter exists
 	if lp.chargeMeter == nil {
-		integrated = true
-
 		if mt, ok := api.Cap[api.Meter](charger); ok {
 			// preserve charger's capability registry and static interface
 			// implementations so that subsequent capability checks on
@@ -429,9 +425,9 @@ func (lp *Loadpoint) configureChargerType(charger api.Charger) {
 	}
 
 	// ensure charge rater exists
-	// measurement are obtained from separate charge meter if defined
-	// (https://github.com/evcc-io/evcc/issues/2469)
-	if rt, ok := api.Cap[api.ChargeRater](charger); ok && integrated {
+	// prefer charger's own ChargeRater (e.g. Easee SESSION_ENERGY via SignalR)
+	// over wrapper that relies on external meter's TotalEnergy
+	if rt, ok := api.Cap[api.ChargeRater](charger); ok {
 		lp.chargeRater = rt
 
 		// when restarting in the middle of charging session, use this as negative offset
@@ -1770,7 +1766,7 @@ func (lp *Loadpoint) publishChargeProgress() {
 	if f, err := lp.chargeRater.ChargedEnergy(); err == nil {
 		// workaround for Go-E resetting during disconnect, see
 		// https://github.com/evcc-io/evcc/issues/5092
-		if f > lp.chargedAtStartup {
+		if f >= lp.chargedAtStartup {
 			added, addedGreen := lp.energyMetrics.Update(f - lp.chargedAtStartup)
 			if added > 0 {
 				lp.log.DEBUG.Printf("session energy: %.3fkWh", f)
@@ -1890,6 +1886,16 @@ func (lp *Loadpoint) publishSocAndRange() {
 			lp.log.DEBUG.Printf("vehicle soc (estimator): %.0f%%", lp.vehicleSoc)
 		}
 	}
+
+	// apply manual SoC override if vehicle supports it
+	if v := lp.GetVehicle(); v != nil && lp.vehicleHasFeature(api.ManualSoc) {
+		if manualSoc := vehicle.Settings(lp.log, v).GetManualSoc(); manualSoc > 0 {
+			lp.vehicleSoc = manualSoc
+			lp.log.DEBUG.Printf("vehicle soc (manual): %.0f%%", lp.vehicleSoc)
+		}
+		lp.publish(keys.ManualSoc, vehicle.Settings(lp.log, v).GetManualSoc())
+	}
+
 	lp.publish(keys.VehicleSoc, lp.vehicleSoc)
 
 	apiLimitSoc := 100

--- a/core/site_vehicles.go
+++ b/core/site_vehicles.go
@@ -24,6 +24,7 @@ type vehicleStruct struct {
 	Phases         int                 `json:"phases,omitempty"`
 	MinSoc         int                 `json:"minSoc,omitempty"`
 	LimitSoc       int                 `json:"limitSoc,omitempty"`
+	ManualSoc      float64             `json:"manualSoc,omitempty"`
 	MinCurrent     float64             `json:"minCurrent,omitempty"`
 	MaxCurrent     float64             `json:"maxCurrent,omitempty"`
 	Priority       int                 `json:"priority,omitempty"`
@@ -61,6 +62,7 @@ func (site *Site) publishVehicles() {
 			Phases:         instance.Phases(),
 			MinSoc:         v.GetMinSoc(),
 			LimitSoc:       v.GetLimitSoc(),
+			ManualSoc:      v.GetManualSoc(),
 			MinCurrent:     ac.MinCurrent,
 			MaxCurrent:     ac.MaxCurrent,
 			Priority:       ac.Priority,

--- a/core/vehicle/adapter.go
+++ b/core/vehicle/adapter.go
@@ -173,3 +173,18 @@ func (v *adapter) SetPlanStrategy(planStrategy api.PlanStrategy) error {
 
 	return nil
 }
+
+// GetManualSoc returns the manually set SoC (0 = not set)
+func (v *adapter) GetManualSoc() float64 {
+	if val, err := settings.Float(v.key() + keys.ManualSoc); err == nil {
+		return val
+	}
+	return 0
+}
+
+// SetManualSoc sets a manual SoC override (0 = clear)
+func (v *adapter) SetManualSoc(soc float64) {
+	v.log.DEBUG.Printf("set %s manual soc: %.1f", v.name, soc)
+	settings.SetFloat(v.key()+keys.ManualSoc, soc)
+	v.publish()
+}

--- a/core/vehicle/api.go
+++ b/core/vehicle/api.go
@@ -53,6 +53,11 @@ type API interface {
 	// SetPlanStrategy sets the plan strategy
 	SetPlanStrategy(api.PlanStrategy) error
 
+	// GetManualSoc returns the manually set SoC (0 = not set)
+	GetManualSoc() float64
+	// SetManualSoc sets a manual SoC override (0 = clear)
+	SetManualSoc(soc float64)
+
 	// // GetMinCurrent returns the min charging current
 	// GetMinCurrent() float64
 	// // SetMinCurrent sets the min charging current

--- a/core/vehicle/dummy.go
+++ b/core/vehicle/dummy.go
@@ -64,3 +64,12 @@ func (v *dummy) GetPlanStrategy() api.PlanStrategy {
 func (v *dummy) SetPlanStrategy(strategy api.PlanStrategy) error {
 	return nil
 }
+
+// GetManualSoc returns the manually set SoC (0 = not set)
+func (v *dummy) GetManualSoc() float64 {
+	return 0
+}
+
+// SetManualSoc sets a manual SoC override (0 = clear)
+func (v *dummy) SetManualSoc(soc float64) {
+}

--- a/core/vehicle/mock.go
+++ b/core/vehicle/mock.go
@@ -55,6 +55,20 @@ func (mr *MockAPIMockRecorder) GetLimitSoc() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLimitSoc", reflect.TypeOf((*MockAPI)(nil).GetLimitSoc))
 }
 
+// GetManualSoc mocks base method.
+func (m *MockAPI) GetManualSoc() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManualSoc")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// GetManualSoc indicates an expected call of GetManualSoc.
+func (mr *MockAPIMockRecorder) GetManualSoc() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManualSoc", reflect.TypeOf((*MockAPI)(nil).GetManualSoc))
+}
+
 // GetMinSoc mocks base method.
 func (m *MockAPI) GetMinSoc() int {
 	m.ctrl.T.Helper()
@@ -152,6 +166,18 @@ func (mr *MockAPIMockRecorder) SetLimitSoc(soc any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLimitSoc", reflect.TypeOf((*MockAPI)(nil).SetLimitSoc), soc)
 }
 
+// SetManualSoc mocks base method.
+func (m *MockAPI) SetManualSoc(soc float64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetManualSoc", soc)
+}
+
+// SetManualSoc indicates an expected call of SetManualSoc.
+func (mr *MockAPIMockRecorder) SetManualSoc(soc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetManualSoc", reflect.TypeOf((*MockAPI)(nil).SetManualSoc), soc)
+}
+
 // SetMinSoc mocks base method.
 func (m *MockAPI) SetMinSoc(soc int) {
 	m.ctrl.T.Helper()
@@ -204,30 +230,4 @@ func (m *MockAPI) SetRepeatingPlans(arg0 []api.RepeatingPlan) error {
 func (mr *MockAPIMockRecorder) SetRepeatingPlans(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepeatingPlans", reflect.TypeOf((*MockAPI)(nil).SetRepeatingPlans), arg0)
-}
-
-// GetManualSoc mocks base method.
-func (m *MockAPI) GetManualSoc() float64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetManualSoc")
-	ret0, _ := ret[0].(float64)
-	return ret0
-}
-
-// GetManualSoc indicates an expected call of GetManualSoc.
-func (mr *MockAPIMockRecorder) GetManualSoc() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManualSoc", reflect.TypeOf((*MockAPI)(nil).GetManualSoc))
-}
-
-// SetManualSoc mocks base method.
-func (m *MockAPI) SetManualSoc(soc float64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetManualSoc", soc)
-}
-
-// SetManualSoc indicates an expected call of SetManualSoc.
-func (mr *MockAPIMockRecorder) SetManualSoc(soc any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetManualSoc", reflect.TypeOf((*MockAPI)(nil).SetManualSoc), soc)
 }

--- a/core/vehicle/mock.go
+++ b/core/vehicle/mock.go
@@ -205,3 +205,29 @@ func (mr *MockAPIMockRecorder) SetRepeatingPlans(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepeatingPlans", reflect.TypeOf((*MockAPI)(nil).SetRepeatingPlans), arg0)
 }
+
+// GetManualSoc mocks base method.
+func (m *MockAPI) GetManualSoc() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManualSoc")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// GetManualSoc indicates an expected call of GetManualSoc.
+func (mr *MockAPIMockRecorder) GetManualSoc() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManualSoc", reflect.TypeOf((*MockAPI)(nil).GetManualSoc))
+}
+
+// SetManualSoc mocks base method.
+func (m *MockAPI) SetManualSoc(soc float64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetManualSoc", soc)
+}
+
+// SetManualSoc indicates an expected call of SetManualSoc.
+func (mr *MockAPIMockRecorder) SetManualSoc(soc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetManualSoc", reflect.TypeOf((*MockAPI)(nil).SetManualSoc), soc)
+}

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1379,6 +1379,8 @@
       "changeVehicle": "Fahrzeug ändern",
       "detectionActive": "Fahrzeugerkennung läuft …",
       "fallbackName": "Fahrzeug",
+      "manualSoc": "Manueller Ladestand",
+      "manualSocClear": "Manuellen Ladestand löschen",
       "moreActions": "Weitere Aktionen",
       "none": "Kein Fahrzeug",
       "notReachable": "Fahrzeug war nicht erreichbar. Versuche evcc neu zu starten.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1378,6 +1378,8 @@
       "changeVehicle": "Change vehicle",
       "detectionActive": "Detecting vehicle…",
       "fallbackName": "Vehicle",
+      "manualSoc": "Manual SoC",
+      "manualSocClear": "Clear manual SoC",
       "moreActions": "More actions",
       "none": "No vehicle",
       "notReachable": "Vehicle was not reachable. Try restarting evcc.",
@@ -1385,9 +1387,7 @@
       "temp": "Temp.",
       "tempLimit": "Temp. limit",
       "unknown": "Guest vehicle",
-      "vehicleSoc": "Charge",
-      "manualSoc": "Manual SoC",
-      "manualSocClear": "Clear manual SoC"
+      "vehicleSoc": "Charge"
     },
     "vehicleStatus": {
       "awaitingAuthorization": "Waiting for authorization.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1385,7 +1385,9 @@
       "temp": "Temp.",
       "tempLimit": "Temp. limit",
       "unknown": "Guest vehicle",
-      "vehicleSoc": "Charge"
+      "vehicleSoc": "Charge",
+      "manualSoc": "Manual SoC",
+      "manualSocClear": "Clear manual SoC"
     },
     "vehicleStatus": {
       "awaitingAuthorization": "Waiting for authorization.",

--- a/server/http.go
+++ b/server/http.go
@@ -173,14 +173,14 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 
 	// vehicle api
 	vehicles := map[string]route{
-		"minsoc":         {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
-		"limitsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
-		"manualsoc":      {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc/{value:[0-9.]+}", manualSocHandler(site)},
+		"minsoc":          {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
+		"limitsoc":        {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
+		"manualsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc/{value:[0-9.]+}", manualSocHandler(site)},
 		"manualsocDelete": {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc", manualSocRemoveHandler(site)},
-		"plan":           {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
-		"plan2":          {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
-		"repeatingPlans": {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},
-		"planStrategy":   {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/strategy", updatePlanStrategyHandler(site)},
+		"plan":            {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
+		"plan2":           {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
+		"repeatingPlans":  {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},
+		"planStrategy":    {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/strategy", updatePlanStrategyHandler(site)},
 
 		// config ui
 		// "mode":       {"POST", "/mode/{value:[a-z]+}", chargeModeHandler(v)},

--- a/server/http.go
+++ b/server/http.go
@@ -176,7 +176,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 		"minsoc":         {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
 		"limitsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
 		"manualsoc":      {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc/{value:[0-9.]+}", manualSocHandler(site)},
-		"manualsoc2":     {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc", manualSocRemoveHandler(site)},
+		"manualsocDelete": {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc", manualSocRemoveHandler(site)},
 		"plan":           {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
 		"plan2":          {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
 		"repeatingPlans": {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},

--- a/server/http.go
+++ b/server/http.go
@@ -173,12 +173,14 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 
 	// vehicle api
 	vehicles := map[string]route{
-		"minsoc":         {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
-		"limitsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
-		"plan":           {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
-		"plan2":          {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
-		"repeatingPlans": {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},
-		"planStrategy":   {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/strategy", updatePlanStrategyHandler(site)},
+		"minsoc":          {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
+		"limitsoc":        {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
+		"manualsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc/{value:[0-9.]+}", manualSocHandler(site)},
+		"manualsoc2":      {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc", manualSocRemoveHandler(site)},
+		"plan":            {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
+		"plan2":           {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
+		"repeatingPlans":  {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},
+		"planStrategy":    {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/strategy", updatePlanStrategyHandler(site)},
 
 		// config ui
 		// "mode":       {"POST", "/mode/{value:[a-z]+}", chargeModeHandler(v)},

--- a/server/http.go
+++ b/server/http.go
@@ -173,14 +173,14 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 
 	// vehicle api
 	vehicles := map[string]route{
-		"minsoc":          {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
-		"limitsoc":        {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
-		"manualsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc/{value:[0-9.]+}", manualSocHandler(site)},
-		"manualsoc2":      {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc", manualSocRemoveHandler(site)},
-		"plan":            {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
-		"plan2":           {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
-		"repeatingPlans":  {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},
-		"planStrategy":    {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/strategy", updatePlanStrategyHandler(site)},
+		"minsoc":         {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/minsoc/{value:[0-9]+}", minSocHandler(site)},
+		"limitsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
+		"manualsoc":      {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc/{value:[0-9.]+}", manualSocHandler(site)},
+		"manualsoc2":     {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/manualsoc", manualSocRemoveHandler(site)},
+		"plan":           {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
+		"plan2":          {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
+		"repeatingPlans": {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},
+		"planStrategy":   {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/strategy", updatePlanStrategyHandler(site)},
 
 		// config ui
 		// "mode":       {"POST", "/mode/{value:[a-z]+}", chargeModeHandler(v)},

--- a/server/http_vehicle_handler.go
+++ b/server/http_vehicle_handler.go
@@ -11,6 +11,52 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// manualSocHandler updates manual soc
+func manualSocHandler(site site.API) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		v, err := site.Vehicles().ByName(vars["name"])
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		soc, err := strconv.ParseFloat(vars["value"], 64)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		v.SetManualSoc(soc)
+
+		res := struct {
+			Soc float64 `json:"soc"`
+		}{
+			Soc: v.GetManualSoc(),
+		}
+
+		jsonWrite(w, res)
+	}
+}
+
+// manualSocRemoveHandler clears manual soc
+func manualSocRemoveHandler(site site.API) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		v, err := site.Vehicles().ByName(vars["name"])
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		v.SetManualSoc(0)
+
+		jsonWrite(w, struct{}{})
+	}
+}
+
 // minSocHandler updates min soc
 func minSocHandler(site site.API) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/server/http_vehicle_handler.go
+++ b/server/http_vehicle_handler.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -25,6 +26,11 @@ func manualSocHandler(site site.API) http.HandlerFunc {
 		soc, err := strconv.ParseFloat(vars["value"], 64)
 		if err != nil {
 			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		if soc < 0 || soc > 100 {
+			jsonError(w, http.StatusBadRequest, fmt.Errorf("soc must be between 0 and 100"))
 			return
 		}
 

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -287,6 +287,7 @@ func (m *MQTT) listenVehicleSetters(topic string, v vehicle.API) error {
 	for _, s := range []setter{
 		{"limitSoc", intSetter(pass(v.SetLimitSoc))},
 		{"minSoc", intSetter(pass(v.SetMinSoc))},
+		{"manualSoc", floatSetter(pass(v.SetManualSoc))},
 		{"planStrategy", planStrategySetter(v.SetPlanStrategy)},
 		{"planSoc", planGoalSetter(v.SetPlanSoc)},
 	} {

--- a/templates/definition/vehicle/offline.yaml
+++ b/templates/definition/vehicle/offline.yaml
@@ -16,7 +16,7 @@ params:
 render: |
   type: custom
   {{- include "vehicle-common" . }}
-  {{ include "vehicle-features" (merge (dict "basefeatures" (list "offline")) .) }}
+  {{ include "vehicle-features" (merge (dict "basefeatures" (list "offline" "manualsoc")) .) }}
   soc:
     source: const
     value: 0

--- a/tests/evcc.ts
+++ b/tests/evcc.ts
@@ -153,7 +153,7 @@ async function _stop(instance?: ChildProcess) {
   if (instance) {
     log("shutting down evcc hard", { port });
     instance.kill("SIGKILL");
-    await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED, timeout: 5000 });
+    await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED, timeout: 15000 });
     log("evcc is down", { port });
     return;
   }
@@ -181,7 +181,7 @@ async function _stop(instance?: ChildProcess) {
     }
   }
   log(`wait until port ${port} is closed`);
-  await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED, timeout: 5000 });
+  await waitOn({ resources: [`tcp:${port}`], reverse: true, log: LOG_ENABLED, timeout: 15000 });
   log("evcc is down", { port });
 }
 


### PR DESCRIPTION
Adds a manual SoC override for vehicles that don't report their state of charge (e.g. offline vehicles or those without an API integration). The user can set the SoC manually via the UI; the loadpoint uses this value instead of polling the vehicle.

- New `ManualSoc` feature flag in `api/feature.go`; vehicles opt in via the `offline` template
- `POST /api/vehicles/{name}/manualsoc/{value}` and `DELETE` endpoint to set/clear the override
- `vehicle.Settings` adapter stores the value persistently; loadpoint reads it in `publishSocAndRange`
- SoC bar in the UI (`Soc.vue`) shows an effective SoC that accounts for charged energy on top of the manual value
- `Vehicle.vue` exposes the manual SoC input when the `ManualSoc` feature flag is present

e.g. see #30336 