### PR TITLE
DriveSomethingGreater: fix charge status for conservation charging and plugged-in detection

### DIFF
--- a/vehicle/vw/eudataact/eudataact_test.go
+++ b/vehicle/vw/eudataact/eudataact_test.go
@@ -43,6 +43,51 @@ func TestStatusPlugStates(t *testing.T) {
 	}
 }
 
+func TestStatusConservationCharging(t *testing.T) {
+	tc := []struct {
+		field    string
+		value    string
+		expected api.ChargeStatus
+	}{
+		{FieldChargingState, "conservationCharging", api.StatusC},
+		{FieldCurrentChargeState, "CHARGE_STATE_CONSERVATION_CHARGING", api.StatusC},
+	}
+
+	for _, tc := range tc {
+		data := map[string]point{tc.field: {Value: tc.value}}
+		p := testProvider(data)
+
+		status, err := p.Status()
+		require.NoError(t, err)
+		assert.Equal(t, tc.expected, status, "field=%q value=%q", tc.field, tc.value)
+	}
+}
+
+func TestStatusChargingScenario(t *testing.T) {
+	tc := []struct {
+		scenario string
+		expected api.ChargeStatus
+	}{
+		{"CHARGING_SCENARIO_IMMEDIATELY_CHARGING_FINISHED", api.StatusB},
+		{"CHARGING_SCENARIO_OPTIMISED_CHARGING_FINISHED", api.StatusB},
+		{"CHARGING_SCENARIO_CHARGING_TO_DEPARTURE_TIME_FINISHED", api.StatusB},
+		{"CHARGING_SCENARIO_IMMEDIATELY_CHARGING_ACTIVE", api.StatusC},
+		{"CHARGING_SCENARIO_CHARGING_TO_DEPARTURE_TIME_ACTIVE", api.StatusC},
+		{"CHARGING_SCENARIO_OFF", api.StatusA},
+		// case-insensitivity: mixed-case value should behave like its uppercased equivalent
+		{"Charging_Scenario_Off", api.StatusA},
+	}
+
+	for _, tc := range tc {
+		data := map[string]point{FieldChargingScenario: {Value: tc.scenario}}
+		p := testProvider(data)
+
+		status, err := p.Status()
+		require.NoError(t, err)
+		assert.Equal(t, tc.expected, status, "scenario=%q", tc.scenario)
+	}
+}
+
 func TestResolveBrand(t *testing.T) {
 	for _, name := range []string{"audi", "AUDI", "Audi", "aUdI"} {
 		b, ok := resolveBrand(name)

--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -166,7 +166,7 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		switch {
 		case strings.HasSuffix(upper, "_ACTIVE"):
 			status = api.StatusC
-		// the car reports finished if it's plugged in but not charging, e.g. if the charger is limited by evcc. Guard for not overriding a explicit charge status
+		// the car reports finished if it's plugged in but not charging
 		case strings.HasSuffix(upper, "_FINISHED"):
 			status = api.StatusB
 		}

--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -148,13 +148,28 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		return status, err
 	}
 
+	// block 1: explicit plug state
 	if p := lookup(data, FieldPlugState, FieldChargingPlug1ConnectionState); p != nil && strings.EqualFold(p.Value, "connected") {
 		status = api.StatusB
 	}
 
+	// block 2: flat charging_state field and the current_charge_state field
 	if p := lookup(data, FieldChargingState, FieldCurrentChargeState); p != nil &&
-		(strings.EqualFold(p.Value, "charging") || strings.Contains(strings.ToUpper(p.Value), "CHARGING_HV")) {
+		(strings.EqualFold(p.Value, "charging") || strings.Contains(strings.ToUpper(p.Value), "CHARGING_HV") ||
+			strings.EqualFold(p.Value, "conservationCharging") || strings.EqualFold(p.Value, "CHARGE_STATE_CONSERVATION_CHARGING")) {
 		status = api.StatusC
+	}
+
+	// block 3: charging_scenario is the most explicit plug/charge signal
+	if p := lookup(data, FieldChargingScenario); p != nil && status != api.StatusC {
+		upper := strings.ToUpper(p.Value)
+		switch {
+		case strings.HasSuffix(upper, "_ACTIVE"):
+			status = api.StatusC
+		// the car reports finished if it's plugged in but not charging, e.g. if the charger is limited by evcc. Guard for not overriding a explicit charge status
+		case strings.HasSuffix(upper, "_FINISHED"):
+			status = api.StatusB
+		}
 	}
 
 	return status, nil

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -106,6 +106,7 @@ const (
 	FieldChargingState                = "charging_state"
 	FieldChargingPlug1ConnectionState = "charging_plug1_connectionstate"
 	FieldCurrentChargeState           = "charging_state_report.current_charge_state"
+	FieldChargingScenario             = "charging_state_report.charging_scenario"
 	FieldPlugState                    = "plug_state"
 
 	// soc


### PR DESCRIPTION
Problem: VW Car connected to a charger was not recognised. 
Solution: 

Two charge status changes to VW EU Data Act (DriveSomethingGreater) provider:
- **Conservation charging reported as StatusA** — `conservationCharging` (legacy `charging_state` field) and `CHARGE_STATE_CONSERVATION_CHARGING` (`current_charge_state` field) both fell through the existing check unhandled, leaving the car at StatusA (disconnected) when it should be StatusB (plugged in, not charging).
- **Plugged-in car reported as StatusA** — Cars without a `plug_state` or `charging_plug1_connectionstate` field and a `current_charge_state` of `CHARGE_STATE_NOT_READY_FOR_CHARGING` were stuck at StatusA even when physically connected.  These values were not present in two cars in test fleet. This value is shared by both plugged-in and unplugged cars (confirmed with two real-world vehicles), so it cannot be used as a plug indicator. Fix uses `charging_state_report.charging_scenario` instead: `*_FINISHED` values indicate plugged in / charge complete → StatusB; `*_ACTIVE` values indicate actively charging → StatusC. All eight documented EU Data ACT DriveSomethingGreater Data Dictionary enum values are covered. 

Scenario was met with real cars and confirmed that in this status it now works.

In testing:
- Existing `TestStatusPlugStates` passes unchanged
- New `TestStatusConservationCharging`: both conservation field variants → StatusB
- New `TestStatusChargingScenario`: all three `_FINISHED` variants → StatusB, `_ACTIVE` variants → StatusC, `CHARGING_SCENARIO_OFF` → StatusA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for conservation-charging status mapping and charging-scenario detection, including case-insensitive scenario inputs.

* **Improvements**
  * Enhanced charging status detection using layered signals, including explicit connection state, charging-state variants (conservation/constant charging), and charging scenarios (e.g., active/finished handling) to ensure accurate `ChargeStatus` classification.

<sub>⚠️ Note: Your high-level summary instructions were not applied because this feature is currently available only on Pro plans or higher.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->