### PR TITLE
add lwt support for mqtt plugin

### DIFF
--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -146,7 +146,7 @@ func (m *Mqtt) newReceiver() (*msgHandler, error) {
 			m.lwtConfig.Topic,
 			h.availability.receive,
 		); err != nil {
-			return nil, err
+			return h, err
 		}
 
 		if !h.availability.Wait(m.lwtConfig.Timeout) {

--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/evcc-io/evcc/plugin/mqtt"
@@ -9,16 +10,23 @@ import (
 	"github.com/evcc-io/evcc/util"
 )
 
+type Lwt struct {
+	Topic    string
+	Expected string
+	Timeout  time.Duration
+}
+
 // Mqtt provider
 type Mqtt struct {
 	*getter
-	log      *util.Logger
-	client   *mqtt.Client
-	topic    string
-	retained bool
-	payload  string
-	timeout  time.Duration
-	pipeline *pipeline.Pipeline
+	log       *util.Logger
+	client    *mqtt.Client
+	topic     string
+	retained  bool
+	payload   string
+	timeout   time.Duration
+	lwtConfig *Lwt
+	pipeline  *pipeline.Pipeline
 }
 
 func init() {
@@ -28,14 +36,19 @@ func init() {
 // NewMqttPluginFromConfig creates Mqtt provider
 func NewMqttPluginFromConfig(ctx context.Context, other map[string]any) (Plugin, error) {
 	cc := struct {
-		mqtt.Config       `mapstructure:",squash"`
-		Topic, Payload    string // Payload only applies to setters
-		Retained          bool
-		Scale             float64
-		Timeout           time.Duration
+		mqtt.Config    `mapstructure:",squash"`
+		Topic, Payload string // Payload only applies to setters
+		Retained       bool
+		Scale          float64
+		Timeout        time.Duration
+		Lwt
 		pipeline.Settings `mapstructure:",squash"`
 	}{
 		Scale: 1,
+		Lwt: Lwt{
+			Expected: "online",
+			Timeout:  time.Second,
+		},
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -52,6 +65,10 @@ func NewMqttPluginFromConfig(ctx context.Context, other map[string]any) (Plugin,
 	m := NewMqtt(log, client, cc.Topic, cc.Timeout).WithScale(cc.Scale).WithPayload(cc.Payload)
 	if cc.Retained {
 		m = m.WithRetained()
+	}
+
+	if cc.Lwt.Topic != "" {
+		m = m.WithLwt(&cc.Lwt)
 	}
 
 	pipe, err := pipeline.New(log, cc.Settings)
@@ -100,6 +117,12 @@ func (p *Mqtt) WithPipeline(pipeline *pipeline.Pipeline) *Mqtt {
 	return p
 }
 
+// WithPipeline adds a processing pipeline
+func (p *Mqtt) WithLwt(lwt *Lwt) *Mqtt {
+	p.lwtConfig = lwt
+	return p
+}
+
 // newReceiver creates a msgHandler and subscribes it to the topic.
 func (m *Mqtt) newReceiver() (*msgHandler, error) {
 	h := &msgHandler{
@@ -109,6 +132,28 @@ func (m *Mqtt) newReceiver() (*msgHandler, error) {
 	}
 
 	err := m.client.Listen(m.topic, h.receive)
+	if err != nil {
+		return h, err
+	}
+
+	if m.lwtConfig != nil {
+		h.availability = &availabilityHandler{
+			expectedPayload: m.lwtConfig.Expected,
+			ready:           make(chan struct{}),
+		}
+
+		if err := m.client.Listen(
+			m.lwtConfig.Topic,
+			h.availability.receive,
+		); err != nil {
+			return nil, err
+		}
+
+		if !h.availability.Wait(m.lwtConfig.Timeout) {
+			return h, fmt.Errorf("Timeout waiting for LWT availability topic")
+		}
+	}
+
 	return h, err
 }
 

--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -117,7 +117,7 @@ func (p *Mqtt) WithPipeline(pipeline *pipeline.Pipeline) *Mqtt {
 	return p
 }
 
- // WithLwt configures the Last Will and Testament (LWT) settings for the MQTT client.
+// WithLwt configures the Last Will and Testament (LWT) settings for the MQTT client.
 func (p *Mqtt) WithLwt(lwt *Lwt) *Mqtt {
 	p.lwtConfig = lwt
 	return p

--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -117,7 +117,7 @@ func (p *Mqtt) WithPipeline(pipeline *pipeline.Pipeline) *Mqtt {
 	return p
 }
 
-// WithPipeline adds a processing pipeline
+ // WithLwt configures the Last Will and Testament (LWT) settings for the MQTT client.
 func (p *Mqtt) WithLwt(lwt *Lwt) *Mqtt {
 	p.lwtConfig = lwt
 	return p

--- a/plugin/mqtt_handler.go
+++ b/plugin/mqtt_handler.go
@@ -15,7 +15,6 @@ type msgHandler struct {
 }
 
 func (h *msgHandler) receive(payload string) {
-
 	h.val.Set(payload)
 }
 

--- a/plugin/mqtt_handler.go
+++ b/plugin/mqtt_handler.go
@@ -1,23 +1,35 @@
 package plugin
 
 import (
+	"fmt"
+
 	"github.com/evcc-io/evcc/plugin/pipeline"
 	"github.com/evcc-io/evcc/util"
 )
 
 type msgHandler struct {
-	topic    string
-	pipeline *pipeline.Pipeline
-	val      *util.Monitor[string]
+	topic        string
+	pipeline     *pipeline.Pipeline
+	val          *util.Monitor[string]
+	availability *availabilityHandler
 }
 
 func (h *msgHandler) receive(payload string) {
+
 	h.val.Set(payload)
 }
 
 // hasValue returned the received and processed payload as string
 func (h *msgHandler) hasValue() (string, error) {
 	payload, err := h.val.Get()
+
+	if h.availability != nil {
+		if !h.availability.AsExpected() {
+			return "", fmt.Errorf("mqtt source offline")
+		}
+		err = nil
+	}
+
 	if err != nil {
 		return "", err
 	}

--- a/plugin/mqtt_lwt.go
+++ b/plugin/mqtt_lwt.go
@@ -14,7 +14,6 @@ type availabilityHandler struct {
 }
 
 func (h *availabilityHandler) receive(payload string) {
-
 	h.asExpected.Store(payload == h.expectedPayload)
 
 	h.once.Do(func() {

--- a/plugin/mqtt_lwt.go
+++ b/plugin/mqtt_lwt.go
@@ -11,13 +11,9 @@ type availabilityHandler struct {
 	expectedPayload string
 	ready           chan struct{}
 	once            sync.Once
-	mu              sync.RWMutex
 }
 
 func (h *availabilityHandler) receive(payload string) {
-
-	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	h.asExpected.Store(payload == h.expectedPayload)
 

--- a/plugin/mqtt_lwt.go
+++ b/plugin/mqtt_lwt.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type availabilityHandler struct {
+	asExpected      atomic.Bool
+	expectedPayload string
+	ready           chan struct{}
+	once            sync.Once
+	mu              sync.RWMutex
+}
+
+func (h *availabilityHandler) receive(payload string) {
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.asExpected.Store(payload == h.expectedPayload)
+
+	h.once.Do(func() {
+		close(h.ready)
+	})
+}
+
+func (h *availabilityHandler) AsExpected() bool {
+	return h.asExpected.Load()
+}
+
+func (h *availabilityHandler) Wait(timeout time.Duration) bool {
+	select {
+	case <-h.ready:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}


### PR DESCRIPTION
The current implementation of the MQTT plugin expects values to keep updating in order to not be marked as stale. A common way to work with availability in MQTT is to use [Last Will and Testament (LWT)](https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament/).

This change introduces a config option for the MQTT source that enables a availability topic to be checked for the expected value. When the LWT value is as expected the timeout circuitry is ignored.

Example config

```yaml
...
enabled: # is charging enabled?
  source: mqtt
  topic: my_evse/charging_enable/state
  lwt:
    topic: my_evse/availability
...
```

This change was made to ease integration of [Wallbox MQTT Bridge](https://github.com/jagheterfredrik/wallbox-mqtt-bridge), an open source, in-charger enhancement to enable MQTT on Wallbox EVSEs. Multiple forks [[1]](https://github.com/sweber/wallbox-mqtt-bridge)[[2]](https://github.com/mbfoo/wallbox-mqtt-bridge-evcc) have been spawned to push values more often while I have stayed hesitant as I believe LWT is a better fit for the use case and is supported by [Home Assistant](https://www.home-assistant.io/integrations/mqtt/#birth-and-last-will-messages).
That said it is in no way specific to the Wallbox MQTT bridge but builds on common MQTT practice.