### PR TITLE
Sessions: relabel solar/total toggle buttons

### DIFF
--- a/assets/js/views/Sessions.vue
+++ b/assets/js/views/Sessions.vue
@@ -187,6 +187,7 @@ import "@h2d2/shopicons/es/regular/cablecharge";
 import "@h2d2/shopicons/es/regular/car3";
 import "@h2d2/shopicons/es/regular/eco1";
 import "@h2d2/shopicons/es/regular/sun";
+import "@h2d2/shopicons/es/regular/lightning";
 import formatter, { POWER_UNIT } from "../mixins/formatter";
 import api from "../api";
 import store from "../store";
@@ -212,7 +213,6 @@ import DateNavigator from "../components/Sessions/DateNavigator.vue";
 import PeriodHeader from "../components/Sessions/PeriodHeader.vue";
 import { handleDownloadClick } from "@/utils/native";
 import DynamicPriceIcon from "../components/MaterialIcon/DynamicPrice.vue";
-import TotalIcon from "../components/MaterialIcon/Total.vue";
 import { TYPES, GROUPS, PERIODS, type Session } from "../components/Sessions/types";
 import { defineComponent, type PropType } from "vue";
 import { CURRENCY, type Notification } from "@/types/evcc";
@@ -565,14 +565,14 @@ export default defineComponent({
 		},
 		groupIcons() {
 			return {
-				[GROUPS.NONE]: TotalIcon,
+				[GROUPS.NONE]: "shopicon-regular-sun",
 				[GROUPS.LOADPOINT]: "shopicon-regular-cablecharge",
 				[GROUPS.VEHICLE]: "shopicon-regular-car3",
 			};
 		},
 		typeIcons() {
 			return {
-				[TYPES.SOLAR]: "shopicon-regular-sun",
+				[TYPES.SOLAR]: "shopicon-regular-lightning",
 				[TYPES.PRICE]: DynamicPriceIcon,
 				[TYPES.CO2]: "shopicon-regular-eco1",
 			};

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1525,7 +1525,7 @@
     },
     "groupBy": {
       "loadpoint": "Ladepunkt",
-      "none": "Gesamt",
+      "none": "Sonne",
       "vehicle": "Fahrzeug"
     },
     "loadpoint": "Ladepunkt",
@@ -1547,7 +1547,7 @@
     "type": {
       "co2": "CO₂",
       "price": "Kosten",
-      "solar": "Sonne"
+      "solar": "Energie"
     },
     "vehicle": "Fahrzeug"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1524,7 +1524,7 @@
     },
     "groupBy": {
       "loadpoint": "Charging point",
-      "none": "Total",
+      "none": "Solar",
       "vehicle": "Vehicle"
     },
     "loadpoint": "Charging point",
@@ -1546,7 +1546,7 @@
     "type": {
       "co2": "CO₂",
       "price": "Cost",
-      "solar": "Solar"
+      "solar": "Energy"
     },
     "vehicle": "Vehicle"
   },


### PR DESCRIPTION
fixes #30772

- type toggle: ☀️ Sonne/Solar → ⚡ Energie/Energy
- group toggle: ∑ Gesamt/Total → ☀️ Sonne/Solar

<img width="1043" height="819" alt="Bildschirmfoto 2026-06-15 um 12 02 50" src="https://github.com/user-attachments/assets/89fbdf89-1e58-4073-b670-e80954d605f5" />

