### PR TITLE
Fix minimum marker for zero forecast values

### DIFF
--- a/assets/js/components/Forecast/echarts.ts
+++ b/assets/js/components/Forecast/echarts.ts
@@ -194,7 +194,7 @@ export function filterForecastSlots(
 }
 
 export function minSlotIndex(slots: ForecastSlot[]): number {
-  return slots.reduce((min, s, i) => (s.value < (slots[min]?.value || Infinity) ? i : min), 0);
+  return slots.reduce((min, s, i) => (s.value < (slots[min]?.value ?? Infinity) ? i : min), 0);
 }
 
 export function maxSlotIndex(slots: ForecastSlot[]): number {


### PR DESCRIPTION
Forecast charts used a fallback with `|| Infinity` when looking up the current minimum slot value. This accidentally treated `0` as missing so a forecast starting with a zero value would mark a higher value as the minimum during the wront interpretation.

Switching to `?? Infinity` keeps zero as a valid value while still handling missing slot values.