### PR TITLE
GoodWe Wifi ET: correct grid power sign

### DIFF
--- a/templates/definition/meter/goodwe-wifi-et.yaml
+++ b/templates/definition/meter/goodwe-wifi-et.yaml
@@ -28,6 +28,7 @@ render: |
     register:
       address: 35139     # grid power
       decode: int32
+    scale: -1
     delay: {{ .delay }}
   energy:
     source: aa55udp


### PR DESCRIPTION
The goodwe-wifi-et grid power reads register 35139 (int32) without the sign inversion that every other GoodWe grid implementation applies, so import/export is flipped: export shows up as import and house consumption is inflated.

The legacy goodwe-wifi Go device negates this exact register (meter/goodwe/server.go: NetPower = -int32(buf[83:]), payload offset 78 = register 35139), and goodwe-hybrid (Modbus) uses scale: -1 on its grid power register. The custom template dropped it during the per-family template split.

Verified against a user trace (https://github.com/evcc-io/evcc/pull/29095#issuecomment-4706791029): decoding PV, battery and grid from the block reads matches the logged values exactly, so block reads and caching are fine. Reconstructing house load = PV + grid + battery only stays stable (~3.4 kW across cycles) with the grid sign inverted; without it the house load swings 3.5 -> 6.5 -> 2.8 kW and grid reads import while PV surplus is exported.

Fix: add scale: -1 to the grid power. PV, battery and grid energy are unaffected.