### PR TITLE
EEBus: reconnect when monitoring data stalls

### DIFF
--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -24,6 +24,7 @@ import (
 // Additionally supports LPC (Limitation of Power Consumption) and LPP (Limitation of Power Production)
 type EEBus struct {
 	log *util.Logger
+	ski string
 
 	connector *eebus.Connector
 	ma        *eebus.MonitoringAppliance
@@ -35,6 +36,9 @@ type EEBus struct {
 	maEntity    spineapi.EntityRemoteInterface
 	egLpcEntity spineapi.EntityRemoteInterface
 	egLppEntity spineapi.EntityRemoteInterface
+
+	dataSeen      time.Time // last successful measurement read
+	lastReconnect time.Time // last forced reconnect
 }
 
 // maScenarios holds the spec scenario numbers for the active monitoring use case.
@@ -60,6 +64,11 @@ var (
 		currents: eebus.MGCPCurrentPerPhase,
 		voltages: eebus.MGCPVoltagePerPhase,
 	}
+)
+
+const (
+	dataStallTimeout  = 2 * time.Minute // supported-but-no-data grace before reconnect
+	reconnectCooldown = 5 * time.Minute // rate-limit for forced reconnects
 )
 
 type measurements interface {
@@ -112,6 +121,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 
 	c := &EEBus{
 		log:       util.NewLogger("eebus-" + useCase),
+		ski:       ski,
 		ma:        ma,
 		eg:        eebus.Instance.EnergyGuard(),
 		mm:        mm,
@@ -175,7 +185,33 @@ func (c *EEBus) readValue(scenario uint, update func(entity spineapi.EntityRemot
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.readValue(c.scenarios.power, c.mm.Power)
+	power, err := c.readValue(c.scenarios.power, c.mm.Power)
+	c.watchdog(err)
+	return power, err
+}
+
+// watchdog forces a reconnect when the monitoring use case stays supported but
+// keeps returning no data, recovering from a stalled remote (see #30889).
+func (c *EEBus) watchdog(err error) {
+	c.mu.Lock()
+	now := time.Now()
+
+	switch {
+	case err == nil:
+		c.dataSeen = now
+	case c.maEntity == nil:
+		// use case not (yet) supported: nothing to recover
+	case c.dataSeen.IsZero():
+		c.dataSeen = now // start grace window
+	case now.Sub(c.dataSeen) >= dataStallTimeout && now.Sub(c.lastReconnect) >= reconnectCooldown:
+		c.lastReconnect = now
+		c.mu.Unlock()
+		c.log.WARN.Printf("no measurement data for %v, reconnecting", dataStallTimeout)
+		eebus.Instance.Reconnect(c.ski, "no measurement data")
+		return
+	}
+
+	c.mu.Unlock()
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -1,6 +1,8 @@
 package meter
 
 import (
+	"time"
+
 	eebusapi "github.com/enbility/eebus-go/api"
 	"github.com/enbility/eebus-go/usecases/eg/lpc"
 	"github.com/enbility/eebus-go/usecases/eg/lpp"
@@ -30,6 +32,9 @@ func (c *EEBus) Connect(connected bool) {
 	c.maEntity = nil
 	c.egLpcEntity = nil
 	c.egLppEntity = nil
+
+	// restart the data-stall grace window for the next connection
+	c.dataSeen = time.Time{}
 }
 
 // UseCaseEvent implements the eebus.Device interface

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -259,6 +259,14 @@ func (c *EEBus) UnregisterDevice(ski string, device Device) {
 	c.mux.Unlock()
 }
 
+// Reconnect tears down the current SHIP session for the given ski so ship-go
+// re-dials cleanly, recovering from a stalled remote (see #30889).
+func (c *EEBus) Reconnect(ski, reason string) {
+	ski = shiputil.NormalizeSKI(ski)
+	c.log.DEBUG.Printf("reconnecting ski %s: %s", ski, reason)
+	c.service.DisconnectService(shipapi.NewServiceIdentity(ski, "", ""), reason)
+}
+
 func (c *EEBus) CustomerEnergyManagement() *CustomerEnergyManagement {
 	return &c.cem
 }

--- a/templates/definition/meter/goodwe-wifi-et.yaml
+++ b/templates/definition/meter/goodwe-wifi-et.yaml
@@ -28,6 +28,7 @@ render: |
     register:
       address: 35139     # grid power
       decode: int32
+    scale: -1
     delay: {{ .delay }}
   energy:
     source: aa55udp


### PR DESCRIPTION
fixes #30889

EEBus monitoring meters (MPC/MGCP) can stay registered with the use case
reported as supported while the remote stops delivering any measurement data,
so `CurrentPower()` returns `ErrNotAvailable` indefinitely and the loadpoint
logs `charge power: not available` on every cycle. This is triggered by a
SHIP double-connection teardown during startup (a Vaillant heat pump in #30889,
see the ship-go side): after the reconnect the device only sends heartbeats and
never re-answers the measurement reads. The user's workaround is to restart
evcc, which makes a fresh single connection.

This adds a watchdog to the EEBus meter: once the monitoring use case is
supported (`maEntity != nil`) but no usable measurement data has arrived for
`dataStallTimeout`, force one reconnect via the new `eebus.Reconnect(ski)`
(ship-go `DisconnectService`), so ship-go re-dials cleanly and re-runs
discovery. Reconnects are rate-limited by `reconnectCooldown`, and the grace
window restarts on every (re)connect.

The root cause is the ship-go double-connection race; this is the in-app
recovery so a stalled remote self-heals without a manual restart.
