### PR TITLE
sqlite: enable WAL mode

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -52,8 +52,9 @@ func New(driver, dsn string) (*gorm.DB, error) {
 		// Store the expanded file path for later use
 		filePath = file
 
-		// TODO WAL mode "journal_mode(WAL)", "synchronous(NORMAL)"
-		for _, pragma := range []string{"busy_timeout(5000)", "foreign_keys(1)", "auto_vacuum(INCREMENTAL)"} {
+		// WAL mode keeps readers from blocking the single writer; it creates
+		// sidecar evcc.db-wal and evcc.db-shm files next to the database.
+		for _, pragma := range []string{"busy_timeout(5000)", "journal_mode(WAL)", "synchronous(NORMAL)", "foreign_keys(1)", "auto_vacuum(INCREMENTAL)"} {
 			// add pragma if not already present
 			if short, _, _ := strings.Cut(pragma, "("); strings.Contains(params, "_pragma="+short) {
 				continue


### PR DESCRIPTION
Draft, complementary to #30902 (single connection) and #30696 (busy_timeout); context: https://github.com/evcc-io/evcc/pull/30696#issuecomment-4711139543 and #30670.

Resolves the long-standing `// TODO WAL mode` in server/db/db.go by adding `journal_mode(WAL)` and `synchronous(NORMAL)` to the DSN pragmas. In the default rollback-journal mode readers and writers block each other, which is what produces the residual `SQLITE_BUSY` deadlock-avoidance errors under concurrent load. WAL lets readers run concurrently with the single writer.

Verified locally: a fresh DB created through `db.New` reports `PRAGMA journal_mode = wal` and the `evcc.db-wal` / `evcc.db-shm` sidecars are created next to the database. go build, go vet, go test ./server/db/..., gofmt all clean.

## Docker / persistence (the reason this is a draft)

WAL adds two sidecar files next to the database — `evcc.db-wal` (the most recent, not-yet-checkpointed transactions) and `evcc.db-shm` (shared-memory index). SQLite replays the `-wal` on the next open, so it must persist together with `evcc.db`. The practical consequence is that the database **directory** must be mounted, not the single `.db` file:

- A bind mount of just the file (`-v ./evcc.db:/root/.evcc/evcc.db`) leaves `-wal`/`-shm` in the container layer; on container recreation the `-wal` is lost together with the latest transactions.
- All in-repo deployment paths already use a directory and are unaffected: HA add-on `/data`, systemd `/var/lib/evcc`, gokrazy `/perm`, default `~/.evcc`.

### Prefer a named Docker volume

For Docker specifically, a **named volume** (`docker volume create evcc` → `-v evcc:/root/.evcc`) is the safest choice — and not only for persistence:

- It is inherently a directory mount, so `evcc.db` + `-wal` + `-shm` always persist together.
- It lives on the hosts native Linux filesystem (ext4/overlay2), which provides the POSIX file locking and shared-memory `-shm` mapping WAL requires.
- Bind mounts to a network filesystem (NFS/CIFS/SMB) or through the Docker Desktop virtualized FS on macOS/Windows (gRPC-FUSE/virtiofs) have a history of SQLite locking / `-shm` problems; today (rollback-journal) these mostly cause occasional lock errors, but WAL is more sensitive to them. A named volume sidesteps all of it.

The current docs `-v /home/user/.evcc:/root/.evcc` directory bind mount works on native Linux; the docs will get a named-volume recommendation (queued as a draft docs PR).

## Open item for discussion

A clean WAL checkpoint on normal shutdown. `db.Close()` is currently only called in the restore/reset handlers, not registered as a shutdown hook, and shutdown hooks run concurrently (`shutdown.Cleanup` uses `wg.Go`), so a graceful checkpoint that races `settings.Persist()` would need care. Without it, recent transactions still survive via `-wal` replay as long as the directory is persisted; a kill -9 with a single-file mount would not. Kept out of this draft on purpose.