### PR TITLE
Energyflow: apply forecast adjustment to remaining solar energy

### DIFF
--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -176,6 +176,9 @@ export default defineComponent({
 		gridPower() {
 			return this.grid?.power || 0;
 		},
+		experimental() {
+			return store.state?.experimental;
+		},
 		energyflow() {
 			return this.collectProps(Energyflow);
 		},


### PR DESCRIPTION
fixes #30898

The forecast-adjust toggle had no effect on the remaining produced energy shown in the energy flow card.

`Energyflow.vue` gates the solar scale factor on its `experimental` prop, but `Site.vue` (which feeds props via `collectProps`) never exposed `experimental`, so the prop was always undefined and the factor stayed 1. Regression from #27074, which switched the gate from `$hiddenFeatures()` to the prop without forwarding it.

Adds the missing `experimental` computed to `Site.vue`, matching the pattern already used in `Forecast.vue` and `Config.vue`.