### PR TITLE
Templates: consolidate shared param properties with defaults.yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,7 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - Device types: chargers, meters, vehicles, tariffs
 - Plugin protocols: Modbus, HTTP, MQTT, JavaScript, Go
 - Define device capabilities and configuration in templates at `templates/definition/[type]/`
+- Don't restate param properties that `util/templates/defaults.yaml` already defines for that param name. Properties (description, help, type, unit, default, example, required, advanced, mask, private, usages, …) are inherited from defaults; only specify a property in a template to give it a *different* value. Restating the same value is redundant duplication — reference the param by `name` alone.
 - Test templates: `evcc --template-type [type] --template [file]`
 - Update docs after template changes: `make docs`
 - When implementing or debugging against a third-party device library (eebus-go/ship/spine-go, ocpp-go, modbus/SunSpec), consult the library's current upstream documentation before coding rather than relying on recalled API details

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,7 +264,7 @@ Deep documentation on specific subsystems is available in `docs/agents/`. Load w
 - Device types: chargers, meters, vehicles, tariffs
 - Plugin protocols: Modbus, HTTP, MQTT, JavaScript, Go
 - Define device capabilities and configuration in templates at `templates/definition/[type]/`
-- Don't restate param properties that `util/templates/defaults.yaml` already defines for that param name. Properties (description, help, type, unit, default, example, required, advanced, mask, private, usages, …) are inherited from defaults; only specify a property in a template to give it a *different* value. Restating the same value is redundant duplication — reference the param by `name` alone.
+- Don't restate param properties that `util/templates/defaults.yaml` already defines for that param name. Properties (description, help, type, unit, default, example, required, advanced, mask, private, usages, …) are inherited from defaults; only specify a property in a template to give it a *different* value. Restating the same value is redundant duplication: reference the param by `name` alone.
 - Test templates: `evcc --template-type [type] --template [file]`
 - Update docs after template changes: `make docs`
 - When implementing or debugging against a third-party device library (eebus-go/ship/spine-go, ocpp-go, modbus/SunSpec), consult the library's current upstream documentation before coding rather than relying on recalled API details

--- a/templates/definition/charger/abl-em4.yaml
+++ b/templates/definition/charger/abl-em4.yaml
@@ -14,7 +14,6 @@ params:
     choice: ["tcpip"]
     id: 255
   - name: connector
-    default: 1
 render: |
   type: abl-em4
   {{- include "modbus" . }}

--- a/templates/definition/charger/alpitronic.yaml
+++ b/templates/definition/charger/alpitronic.yaml
@@ -10,7 +10,6 @@ params:
   - name: modbus
     choice: ["tcpip"]
   - name: connector
-    default: 1
 render: |
   type: alpitronic
   {{- include "modbus" . }}

--- a/templates/definition/charger/demo-charger.yaml
+++ b/templates/definition/charger/demo-charger.yaml
@@ -34,10 +34,7 @@ params:
     description:
       de: Maximale Stromstärke
       en: Maximum amperage
-    unit: A
     help:
-    example: 16
-    type: int
     advanced: true
   - name: phases1p3p
     description:

--- a/templates/definition/charger/demo-heatpump.yaml
+++ b/templates/definition/charger/demo-heatpump.yaml
@@ -50,10 +50,7 @@ params:
     description:
       de: Maximale Stromstärke
       en: Maximum amperage
-    unit: A
     help:
-    example: 16
-    type: int
     advanced: true
 
 render: |

--- a/templates/definition/charger/e3dc-rscp.yaml
+++ b/templates/definition/charger/e3dc-rscp.yaml
@@ -27,7 +27,6 @@ params:
     description:
       en: E3DC portal password
       de: E3DC Portal Passwort
-    mask: true
     required: true
   - name: key
     description:

--- a/templates/definition/charger/em2go-duo.yaml
+++ b/templates/definition/charger/em2go-duo.yaml
@@ -9,7 +9,6 @@ params:
     choice: ["tcpip"]
     id: 255
   - name: connector
-    default: 1
 render: |
   type: em2go-duo
   {{- include "modbus" . }}

--- a/templates/definition/charger/evecube.yaml
+++ b/templates/definition/charger/evecube.yaml
@@ -25,8 +25,6 @@ params:
       en: Password for admin API
       de: Passwort für Admin-API
   - name: connector
-    default: 1
-    advanced: true
     help:
       en: Connector number (1-4)
       de: Anschluss-Nummer (1-4)

--- a/templates/definition/charger/evsemaster-udp.yaml
+++ b/templates/definition/charger/evsemaster-udp.yaml
@@ -24,7 +24,6 @@ params:
       en: Found on the device label. Enter as a 16-character hex string (8 bytes).
   - name: password
     required: true
-    mask: true
     description:
       de: Passwort (wie in der EVSE Master App gesetzt)
       en: Password (set in the EVSE Master app)

--- a/templates/definition/charger/fritzdect.yaml
+++ b/templates/definition/charger/fritzdect.yaml
@@ -25,7 +25,6 @@ params:
   - name: password
     required: true
   - name: ain
-    required: true
     service: fritz/devices?uri={uri}&user={user}&password={password}
   - name: firmware82
     advanced: true

--- a/templates/definition/charger/hardybarth-ecb1.yaml
+++ b/templates/definition/charger/hardybarth-ecb1.yaml
@@ -15,8 +15,6 @@ requirements:
 params:
   - name: host
   - name: connector
-    default: 1
-    advanced: true
 render: |
   type: hardybarth-ecb1
   uri: http://{{ .host }}

--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -89,7 +89,6 @@ params:
       en: L1 current entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.charger_current_l1"
-    advanced: true
     help:
       en: Entity ID for L1 current measurement in amperes
       de: Entitäts-ID für L1 Strommessung in Ampere
@@ -99,7 +98,6 @@ params:
       en: L2 current entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.charger_current_l2"
-    advanced: true
     help:
       en: Entity ID for L2 current measurement in amperes
       de: Entitäts-ID für L2 Strommessung in Ampere
@@ -109,7 +107,6 @@ params:
       en: L3 current entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.charger_current_l3"
-    advanced: true
     help:
       en: Entity ID for L3 current measurement in amperes
       de: Entitäts-ID für L3 Strommessung in Ampere

--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -89,6 +89,7 @@ params:
       en: L1 current entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.charger_current_l1"
+    advanced: true
     help:
       en: Entity ID for L1 current measurement in amperes
       de: Entitäts-ID für L1 Strommessung in Ampere
@@ -98,6 +99,7 @@ params:
       en: L2 current entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.charger_current_l2"
+    advanced: true
     help:
       en: Entity ID for L2 current measurement in amperes
       de: Entitäts-ID für L2 Strommessung in Ampere
@@ -107,6 +109,7 @@ params:
       en: L3 current entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.charger_current_l3"
+    advanced: true
     help:
       en: Entity ID for L3 current measurement in amperes
       de: Entitäts-ID für L3 Strommessung in Ampere

--- a/templates/definition/charger/homematic.yaml
+++ b/templates/definition/charger/homematic.yaml
@@ -48,7 +48,6 @@ params:
       de: Kanalnummer der schaltbaren Steckdose, wie im CCU Webfrontend angezeigt.
     example: HMIP-PSM=3, HMIP-FSM+HMIP-FSM16=2, HM=1
   - name: cache
-    advanced: true
     default: 1s
     description:
       en: XML-RPC API cache duration

--- a/templates/definition/charger/iobroker.yaml
+++ b/templates/definition/charger/iobroker.yaml
@@ -55,7 +55,6 @@ params:
     description:
       de: Setze maximale Stromstärke
       en: Set maximum amperage
-    unit: A
     type: string
   - name: maxcurrentmillis
     description:

--- a/templates/definition/charger/keba-modbus-p40.yaml
+++ b/templates/definition/charger/keba-modbus-p40.yaml
@@ -25,7 +25,6 @@ params:
     choice: ["tcpip"]
     id: 255
   - name: welcomecharge
-    advanced: true
 render: |
   type: keba-modbus
   {{- include "modbus" . }}

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -26,7 +26,6 @@ params:
     choice: ["tcpip"]
     id: 255
   - name: welcomecharge
-    advanced: true
 render: |
   type: keba-modbus
   {{- include "modbus" . }}

--- a/templates/definition/charger/kermi.yaml
+++ b/templates/definition/charger/kermi.yaml
@@ -16,9 +16,7 @@ params:
     type: choice
     choice: ["warmwater", "buffer"]
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
 render: |
   type: heatpump
   setmaxpower:

--- a/templates/definition/charger/lambda-zewotherm.yaml
+++ b/templates/definition/charger/lambda-zewotherm.yaml
@@ -41,9 +41,7 @@ params:
       de: veraltet, bei neg. E-Überschuss auf minus
       en: deprecated, set for neg. e-excess to minus
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
   - name: firmware
     type: choice
     choice: ["<1.1.3", ">=1.1.3"]

--- a/templates/definition/charger/openwb-2.0.yaml
+++ b/templates/definition/charger/openwb-2.0.yaml
@@ -30,7 +30,6 @@ params:
     port: 1502
     id: 1
   - name: connector
-    default: 1
   - name: phases1p3p
     type: bool
     description:

--- a/templates/definition/charger/openwb-native.yaml
+++ b/templates/definition/charger/openwb-native.yaml
@@ -137,7 +137,6 @@ params:
     advanced: true
   - name: connector
     type: int
-    default: 1
 render: |
   type: openwb-native
   phases1p3p: {{ .phases1p3p }}

--- a/templates/definition/charger/openwb-native.yaml
+++ b/templates/definition/charger/openwb-native.yaml
@@ -136,7 +136,6 @@ params:
     default: 10s
     advanced: true
   - name: connector
-    type: int
 render: |
   type: openwb-native
   phases1p3p: {{ .phases1p3p }}

--- a/templates/definition/charger/plugchoice.yaml
+++ b/templates/definition/charger/plugchoice.yaml
@@ -37,7 +37,6 @@ params:
     example: AA123456
   - name: connector
     required: true
-    default: 1
     description:
       de: Anschluss-ID
       en: Connector ID

--- a/templates/definition/charger/pulsatrix.yaml
+++ b/templates/definition/charger/pulsatrix.yaml
@@ -6,7 +6,6 @@ requirements:
   evcc: ["sponsorship"]
 params:
   - name: host #IP address or hostname (can be found on 3rd page of SECC display)
-    required: true
     help:
       en: Shown on 3rd page of SECC display
       de: Wird auf der dritten Displayseite des SECC angezeigt

--- a/templates/definition/charger/shelly-topac.yaml
+++ b/templates/definition/charger/shelly-topac.yaml
@@ -11,7 +11,6 @@ requirements:
   evcc: ["sponsorship"]
 params:
   - name: host
-    required: true
   - name: user
   - name: password
 render: |

--- a/templates/definition/charger/smart-evse.yaml
+++ b/templates/definition/charger/smart-evse.yaml
@@ -16,7 +16,6 @@ params:
   - name: host
   - name: cache
     default: 1s
-    advanced: true
   - name: chargeMode
     default: normal
     advanced: true

--- a/templates/definition/charger/tasmota.yaml
+++ b/templates/definition/charger/tasmota.yaml
@@ -14,7 +14,6 @@ params:
       en: admin is default
   - name: password
   - name: channel
-    type: int
     default: 1
     required: true
     description:

--- a/templates/definition/charger/viessmann.yaml
+++ b/templates/definition/charger/viessmann.yaml
@@ -22,8 +22,6 @@ params:
       de: Konfigurieren in [app.developer.viessmann-climatesolutions.com](https://app.developer.viessmann-climatesolutions.com)
       en: Configure at [app.developer.viessmann-climatesolutions.com](https://app.developer.viessmann-climatesolutions.com)
   - name: redirecturi
-    description:
-      generic: Redirect URI
     help:
       en: "Redirect URI of the evcc instance. Must match the redirect URI set in the Viessmann developer portal."
       de: "Redirect-URI der evcc-Instanz. Muss mit der Redirect URI übereinstimmen, die im Viessmann Developer Portal konfiguriert ist."

--- a/templates/definition/charger/viessmann.yaml
+++ b/templates/definition/charger/viessmann.yaml
@@ -18,12 +18,10 @@ params:
   - name: password
     deprecated: true
   - name: clientid
-    required: true
     help:
       de: Konfigurieren in [app.developer.viessmann-climatesolutions.com](https://app.developer.viessmann-climatesolutions.com)
       en: Configure at [app.developer.viessmann-climatesolutions.com](https://app.developer.viessmann-climatesolutions.com)
   - name: redirecturi
-    required: true
     description:
       generic: Redirect URI
     help:

--- a/templates/definition/messenger/email.yaml
+++ b/templates/definition/messenger/email.yaml
@@ -5,7 +5,6 @@ products:
       de: E-Mail
 params:
   - name: host
-    required: true
     example: smtp.example.com
   - name: port
     required: true

--- a/templates/definition/messenger/ntfy.yaml
+++ b/templates/definition/messenger/ntfy.yaml
@@ -3,7 +3,6 @@ products:
   - brand: Ntfy
 params:
   - name: host
-    required: true
     example: ntfy.sh
     default: ntfy.sh
   - name: topics
@@ -30,9 +29,6 @@ params:
     type: choice
     choice: ["max", "high", "default", "low", "min"]
     default: default
-    description:
-      de: Priorität
-      en: Priority
     help:
       de: >
         Nachrichten haben eine Prioritätsstufe, die bestimmt, wie dringend dein Telefon dich benachrichtigt.

--- a/templates/definition/messenger/shoutrrr.yaml
+++ b/templates/definition/messenger/shoutrrr.yaml
@@ -10,7 +10,6 @@ params:
   - name: uri
     required: true
     example: gotify://gotify.example.com:443/secr3t/?priority=1
-    private: true
     help:
       en: See [shoutrrr.nickfedor.com](https://shoutrrr.nickfedor.com/latest/usage/) for possible formats.
       de: Übersicht unter [shoutrrr.nickfedor.com](https://shoutrrr.nickfedor.com/latest/usage/) für mögliche Formate.

--- a/templates/definition/messenger/telegram.yaml
+++ b/templates/definition/messenger/telegram.yaml
@@ -6,7 +6,6 @@ requirements:
 params:
   - name: token
     required: true
-    mask: true
     example: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
     description:
       de: Token

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -17,7 +17,6 @@ params:
     choice: ["tcpip"]
     id: 1
   - name: maxacpower
-    advanced: true
   - preset: battery-params
   - name: capacity
     service: modbus/read?address=60031&type=holding&encoding=uint32&scale=0.001&resulttype=int&{modbus}

--- a/templates/definition/meter/cozify.yaml
+++ b/templates/definition/meter/cozify.yaml
@@ -11,9 +11,7 @@ params:
   - name: usage
     choice: ["grid"]
   - name: host
-    required: true
   - name: cache
-    advanced: true
     default: 5s
 render: |
   type: custom

--- a/templates/definition/meter/demo-battery.yaml
+++ b/templates/definition/meter/demo-battery.yaml
@@ -40,9 +40,7 @@ params:
   - name: maxsoc
     advanced: true
   - name: maxchargepower
-    advanced: true
   - name: maxdischargepower
-    advanced: true
   - name: energy
     description:
       de: Zählerstand

--- a/templates/definition/meter/demo-battery.yaml
+++ b/templates/definition/meter/demo-battery.yaml
@@ -56,18 +56,21 @@ params:
       en: L1 current
     unit: A
     type: int
+    advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke
       en: L2 current
     unit: A
     type: int
+    advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke
       en: L3 current
     unit: A
     type: int
+    advanced: true
   - name: maxacpower # ignored on battery, for e2e test only
 
 render: |

--- a/templates/definition/meter/demo-battery.yaml
+++ b/templates/definition/meter/demo-battery.yaml
@@ -56,21 +56,18 @@ params:
       en: L1 current
     unit: A
     type: int
-    advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke
       en: L2 current
     unit: A
     type: int
-    advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke
       en: L3 current
     unit: A
     type: int
-    advanced: true
   - name: maxacpower # ignored on battery, for e2e test only
 
 render: |

--- a/templates/definition/meter/demo-meter.yaml
+++ b/templates/definition/meter/demo-meter.yaml
@@ -37,21 +37,18 @@ params:
       en: L1 current
     unit: A
     type: int
-    advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke
       en: L2 current
     unit: A
     type: int
-    advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke
       en: L3 current
     unit: A
     type: int
-    advanced: true
   - name: minsoc # ignored, only relevant for battery meter, for e2e test only
   - name: maxacpower
 

--- a/templates/definition/meter/demo-meter.yaml
+++ b/templates/definition/meter/demo-meter.yaml
@@ -37,18 +37,21 @@ params:
       en: L1 current
     unit: A
     type: int
+    advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke
       en: L2 current
     unit: A
     type: int
+    advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke
       en: L3 current
     unit: A
     type: int
+    advanced: true
   - name: minsoc # ignored, only relevant for battery meter, for e2e test only
   - name: maxacpower
 

--- a/templates/definition/meter/ecoflow-powerocean.yaml
+++ b/templates/definition/meter/ecoflow-powerocean.yaml
@@ -51,7 +51,6 @@ params:
       de: 'Manche Nutzer, z.B. mit Starlink-Internet, sehen gelegentlich in den Logs den "error code 8513". Das passiert, wenn die API Region nicht korrekt erkannt wird. Um das zu beheben, kann man die API Region manuell setzen. Mögliche Werte: auto (Standard), europe oder america.'
   - name: cache
     default: 30s
-    advanced: true
   - preset: battery-params
 render: |
   type: ecoflow

--- a/templates/definition/meter/ecoflow-stream.yaml
+++ b/templates/definition/meter/ecoflow-stream.yaml
@@ -52,7 +52,6 @@ params:
       de: 'Manche Nutzer, z.B. mit Starlink-Internet, sehen gelegentlich in den Logs den "error code 8513". Das passiert, wenn die API Region nicht korrekt erkannt wird. Um das zu beheben, kann man die API Region manuell setzen. Mögliche Werte: auto (Standard), europe oder america.'
   - name: cache
     default: 30s
-    advanced: true
   - preset: battery-params
 render: |
   type: ecoflow

--- a/templates/definition/meter/enphase.yaml
+++ b/templates/definition/meter/enphase.yaml
@@ -9,7 +9,6 @@ params:
     choice: ["grid", "pv", "battery"]
   - name: host
   - name: schema
-    default: https
     advanced: true
   - name: token
     help:
@@ -28,7 +27,6 @@ params:
     usages: ["battery"]
   - preset: battery-params
   - name: cache
-    advanced: true
     default: 1s
   - name: timeout
     advanced: true

--- a/templates/definition/meter/esphome-dlms-austria.yaml
+++ b/templates/definition/meter/esphome-dlms-austria.yaml
@@ -15,7 +15,6 @@ params:
   - name: usage
     choice: ["grid"]
   - name: host
-    required: true
   - name: timeout
     default: 10s
     advanced: true

--- a/templates/definition/meter/fritzdect.yaml
+++ b/templates/definition/meter/fritzdect.yaml
@@ -26,7 +26,6 @@ params:
   - name: password
     required: true
   - name: ain
-    required: true
     service: fritz/devices?uri={uri}&user={user}&password={password}
   - name: firmware82
     advanced: true

--- a/templates/definition/meter/fritzgrid.yaml
+++ b/templates/definition/meter/fritzgrid.yaml
@@ -13,7 +13,6 @@ params:
   - name: password
     required: true
   - name: ain
-    required: true
     service: fritz/devices?uri={uri}&user={user}&password={password}
   - name: unit
     advanced: true

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -33,7 +33,6 @@ params:
   - name: maxacpower
   - preset: battery-params
   - name: maxchargerate
-    advanced: true
 render: |
   type: custom
   # sunspec model 20x (int+sf)/ 21x (float) meter

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -19,7 +19,6 @@ params:
     usages: ["grid"]
   - name: maxacpower
   - name: maxchargerate
-    advanced: true
   - preset: battery-params
 render: |
   type: custom

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -52,6 +52,7 @@ params:
       en: L1 Current Entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l1"
+    advanced: true
     help:
       en: Entity ID for L1 current measurement in amperes
       de: Entitäts-ID für L1 Strommessung in Ampere
@@ -61,6 +62,7 @@ params:
       en: L2 Current Entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l2"
+    advanced: true
     help:
       en: Entity ID for L2 current measurement in amperes
       de: Entitäts-ID für L2 Strommessung in Ampere
@@ -70,6 +72,7 @@ params:
       en: L3 Current Entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l3"
+    advanced: true
     help:
       en: Entity ID for L3 current measurement in amperes
       de: Entitäts-ID für L3 Strommessung in Ampere

--- a/templates/definition/meter/homeassistant.yaml
+++ b/templates/definition/meter/homeassistant.yaml
@@ -52,7 +52,6 @@ params:
       en: L1 Current Entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l1"
-    advanced: true
     help:
       en: Entity ID for L1 current measurement in amperes
       de: Entitäts-ID für L1 Strommessung in Ampere
@@ -62,7 +61,6 @@ params:
       en: L2 Current Entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l2"
-    advanced: true
     help:
       en: Entity ID for L2 current measurement in amperes
       de: Entitäts-ID für L2 Strommessung in Ampere
@@ -72,7 +70,6 @@ params:
       en: L3 Current Entity
     service: homeassistant/entities?uri={uri}&domain=sensor
     example: "sensor.house_current_l3"
-    advanced: true
     help:
       en: Entity ID for L3 current measurement in amperes
       de: Entitäts-ID für L3 Strommessung in Ampere

--- a/templates/definition/meter/homematic.yaml
+++ b/templates/definition/meter/homematic.yaml
@@ -30,7 +30,6 @@ params:
       de: Kanalnummer des Messwertkanals, wie im CCU Webfrontend mit Doppelpunkt getrennt nach der Geräte Id angezeigt.
     example: HMIP-PSM=6, HMIP-FSM+HMIP-FSM16=5, HM-ES-TX-WM=1
   - name: cache
-    advanced: true
     default: 1s
     description:
       en: XML-RPC API cache duration

--- a/templates/definition/meter/hoymiles-dtu-mb.yaml
+++ b/templates/definition/meter/hoymiles-dtu-mb.yaml
@@ -16,7 +16,6 @@ params:
   - name: modbus
     choice: ["tcpip"]
   - name: maxacpower
-    advanced: true
     default: "0"
     description:
       de: "Gesamtleistung der Wechselrichter"

--- a/templates/definition/meter/iammeter-1p.yaml
+++ b/templates/definition/meter/iammeter-1p.yaml
@@ -8,7 +8,6 @@ params:
     choice: ["grid", "pv", "charge"]
   - name: host
   - name: cache
-    advanced: true
     default: 2s
 render: |
   type: custom

--- a/templates/definition/meter/iammeter-2p.yaml
+++ b/templates/definition/meter/iammeter-2p.yaml
@@ -8,14 +8,12 @@ params:
     choice: ["grid", "pv", "charge"]
   - name: host
   - name: channel
-    type: int
     default: 1
     required: true
     description:
       de: Messkanal (1-2)
       en: Meter channel (1-2)
   - name: cache
-    advanced: true
     default: 2s
 render: |
   type: custom

--- a/templates/definition/meter/iammeter-3p.yaml
+++ b/templates/definition/meter/iammeter-3p.yaml
@@ -20,7 +20,6 @@ params:
     choice: ["grid", "pv", "charge"]
   - name: host
   - name: cache
-    advanced: true
     default: 2s
 render: |
   type: custom

--- a/templates/definition/meter/indevolt-battery.yaml
+++ b/templates/definition/meter/indevolt-battery.yaml
@@ -38,7 +38,6 @@ params:
     advanced: true
   - name: password
     advanced: true
-    mask: true
   - name: cache
     default: 5s
   - preset: battery-params

--- a/templates/definition/meter/indevolt-hybrid.yaml
+++ b/templates/definition/meter/indevolt-hybrid.yaml
@@ -44,7 +44,6 @@ params:
     advanced: true
   - name: password
     advanced: true
-    mask: true
   - name: cache
     default: 5s
   - preset: battery-params

--- a/templates/definition/meter/iobroker.yaml
+++ b/templates/definition/meter/iobroker.yaml
@@ -52,18 +52,21 @@ params:
       en: L1 current
     unit: A
     type: string
+    advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke
       en: L2 current
     unit: A
     type: string
+    advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke
       en: L3 current
     unit: A
     type: string
+    advanced: true
   - preset: battery-params
   - name: capacity
   - name: minsoc

--- a/templates/definition/meter/iobroker.yaml
+++ b/templates/definition/meter/iobroker.yaml
@@ -52,21 +52,18 @@ params:
       en: L1 current
     unit: A
     type: string
-    advanced: true
   - name: currentL2
     description:
       de: L2 Stromstärke
       en: L2 current
     unit: A
     type: string
-    advanced: true
   - name: currentL3
     description:
       de: L3 Stromstärke
       en: L3 current
     unit: A
     type: string
-    advanced: true
   - preset: battery-params
   - name: capacity
   - name: minsoc

--- a/templates/definition/meter/iotawatt.yaml
+++ b/templates/definition/meter/iotawatt.yaml
@@ -46,7 +46,6 @@ params:
       de: "Serienname für Phase L3. Für einphasig leer lassen."
   - name: cache
     default: 2s
-    advanced: true
 render: |
   type: custom
   {{- if and .seriesL2 .seriesL3 }}

--- a/templates/definition/meter/kaco-blueplanet.yaml
+++ b/templates/definition/meter/kaco-blueplanet.yaml
@@ -2,7 +2,6 @@ params:
   - name: usage
     choice: ["pv"]
   - name: host
-    required: true
   - name: serial
     required: true
     example: 8.0NX312001234

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -47,9 +47,7 @@ params:
   - name: maxchargerate
     deprecated: true
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
 render: |
   {{- if eq .usage "pv" }}
   type: custom

--- a/templates/definition/meter/kostal-plenticore.yaml
+++ b/templates/definition/meter/kostal-plenticore.yaml
@@ -41,9 +41,7 @@ params:
   - name: maxdischargepower
     service: modbus/read?address=1040&type=holding&encoding=float32s&resulttype=int&{modbus}
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
 render: |
   {{- if eq .usage "pv" }}
   type: custom

--- a/templates/definition/meter/openems-modbus.yaml
+++ b/templates/definition/meter/openems-modbus.yaml
@@ -115,13 +115,11 @@ params:
       en: active battery control (Modbus/TCP Write Access)
     usages: ["battery"]
   - name: watchdog
-    type: duration
     default: 60s
     description:
       de: Batteriesteuerung API-Timeout
       en: battery control API timeout
     usages: ["battery"]
-    advanced: true
   - preset: battery-params
 render: |
   type: custom

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -46,7 +46,6 @@ params:
     usages: ["battery"]
     advanced: true
   - name: watchdog
-    type: duration
     default: 60s
     description:
       de: FEMS/OpenEMS Batteriesteuerung API-Timeout
@@ -55,7 +54,6 @@ params:
       de: FEMS/OpenEMS Standard 60s
       en: FEMS/OpenEMS standard 60s
     usages: ["battery"]
-    advanced: true
   - preset: battery-params
 render: |
   type: custom

--- a/templates/definition/meter/pstryk.yaml
+++ b/templates/definition/meter/pstryk.yaml
@@ -9,7 +9,6 @@ params:
     choice: ["grid"]
   - name: host
   - name: cache
-    advanced: true
     default: 1s
 
 render: |

--- a/templates/definition/meter/rct-power.yaml
+++ b/templates/definition/meter/rct-power.yaml
@@ -37,7 +37,6 @@ params:
     type: float
     usages: ["battery"]
   - name: cache
-    advanced: true
     default: 30s
 render: |
   type: rct

--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -16,7 +16,6 @@ params:
   - preset: battery-params
   # battery control
   - name: defaultmode
-    usages: ["battery"]
     default: 2
     advanced: true
 render: |

--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -18,7 +18,6 @@ params:
   - name: defaultmode
     usages: ["battery"]
     default: 2
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/sax.yaml
+++ b/templates/definition/meter/sax.yaml
@@ -19,9 +19,7 @@ params:
     id: 64
   - preset: battery-params
   - name: watchdog
-    type: duration
     default: 240s
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -26,9 +26,7 @@ params:
   - name: maxdischargepower
     default: 4200
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
     usages: ["battery"]
   - name: chargepower
     deprecated: true

--- a/templates/definition/meter/sma-sbs-15-25-modbus.yaml
+++ b/templates/definition/meter/sma-sbs-15-25-modbus.yaml
@@ -19,9 +19,7 @@ params:
     default: 4200
     required: true
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
   - name: chargepower
     deprecated: true
 render: |

--- a/templates/definition/meter/sma-sbs-modbus.yaml
+++ b/templates/definition/meter/sma-sbs-modbus.yaml
@@ -19,9 +19,7 @@ params:
     default: 4200
     required: true
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
   - name: chargepower
     deprecated: true
 render: |

--- a/templates/definition/meter/sma-si-modbus.yaml
+++ b/templates/definition/meter/sma-si-modbus.yaml
@@ -19,9 +19,7 @@ params:
     default: 4200
     required: true
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
   - name: chargepower
     deprecated: true
 render: |

--- a/templates/definition/meter/smartfox-em2.yaml
+++ b/templates/definition/meter/smartfox-em2.yaml
@@ -26,7 +26,6 @@ params:
     choice: ["grid", "pv", "aux"]
   - name: host
   - name: cache
-    advanced: true
     default: 1s
 render: |
   {{- define "uri" -}}

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -36,7 +36,6 @@ params:
       de: Gültige Werte sind 0 (Eigenbedarfsmodus), 1 (Nutzungszeitmodus), 2 (Zeitmodus), 4 (Peak-shaving Modus)
       en: Valid values are 0 (self use), 1 (time of use), 2 (timing mode), 4 (peak-shaving mode)
     default: 0 # self use
-    advanced: true
   - name: externalpower
     type: bool
     description:

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -24,9 +24,7 @@ params:
   - name: maxdischargepower
     default: 5000
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
   - name: timeout
     deprecated: true
 render: |

--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -18,9 +18,7 @@ params:
   - preset: battery-params
   # battery control
   - name: watchdog
-    type: duration
     default: 60s
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -28,7 +28,6 @@ params:
   - preset: battery-params
   - name: defaultmode
     default: 0 # "SelfUse"
-    advanced: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -34,7 +34,6 @@ params:
     choice: ["self-consumption", "time-of-use"]
     default: self-consumption
     required: true
-    advanced: true
     usages: ["battery"]
   - name: chargepower
     deprecated: true

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -35,7 +35,6 @@ params:
     default: self-consumption
     required: true
     advanced: true
-    usages: ["battery"]
   - name: chargepower
     deprecated: true
 render: |

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -20,7 +20,6 @@ params:
     default: 7979
   - preset: battery-params
   - name: cache
-    advanced: true
     default: 5s
 render: |
   type: custom

--- a/templates/definition/meter/sunspec-inverter-control.yaml
+++ b/templates/definition/meter/sunspec-inverter-control.yaml
@@ -11,7 +11,6 @@ params:
   - name: modbus
     choice: ["tcpip", "rs485"]
   - name: maxchargerate
-    advanced: true
   - preset: battery-params
 render: |
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/tasmota.yaml
+++ b/templates/definition/meter/tasmota.yaml
@@ -14,7 +14,6 @@ params:
       en: admin is default
   - name: password
   - name: channel
-    type: int
     default: 1
     required: true
     description:

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -37,10 +37,8 @@ params:
       en: optional product identifier of the energy site, use to override autodectction
       de: optionale Product ID dieser Energy Site, zum Übersteuern der automatischen Erkennung
   - name: minsoc
-    type: int
     advanced: true
   - name: maxsoc
-    type: int
     advanced: true
   - name: maxchargepower
   - name: maxdischargepower

--- a/templates/definition/meter/varta.yaml
+++ b/templates/definition/meter/varta.yaml
@@ -27,10 +27,8 @@ params:
   - name: maxdischargepower
     default: 4000
   - name: watchdog
-    type: duration
     default: 120s
     usages: ["battery"]
-    advanced: true
 render: |
   type: custom
   power:

--- a/templates/definition/meter/victron-vrm.yaml
+++ b/templates/definition/meter/victron-vrm.yaml
@@ -15,7 +15,6 @@ params:
     choice: ["battery"]
   - name: token
     required: true
-    mask: true
     description:
       de: VRM Token
       en: VRM token

--- a/templates/definition/meter/vzlogger.yaml
+++ b/templates/definition/meter/vzlogger.yaml
@@ -121,7 +121,6 @@ params:
       de: Die vzlogger Kanal uuid für Spannung in Phase 3 (OBIS Code 72.7.0)
       en: The vzlogger channel uuid for voltage on phase 3 (OBIS Code 72.7.0)
   - name: cache
-    advanced: true
     default: 1s
 render: |
   type: custom

--- a/templates/definition/meter/zendure-solarflow-ac.yaml
+++ b/templates/definition/meter/zendure-solarflow-ac.yaml
@@ -8,10 +8,8 @@ params:
   - name: usage
     choice: ["battery"]
   - name: host
-    required: true
   - preset: battery-params
   - name: cache
-    advanced: true
     default: 1s
 render: |
   type: custom

--- a/templates/definition/meter/zendure-solarflow-pro.yaml
+++ b/templates/definition/meter/zendure-solarflow-pro.yaml
@@ -13,7 +13,6 @@ params:
   - name: capacity
     default: 1.92 # kWh
   - name: cache
-    advanced: true
     default: 1s
 render: |
   type: custom

--- a/templates/definition/tariff/energypriceforecast.yaml
+++ b/templates/definition/tariff/energypriceforecast.yaml
@@ -17,13 +17,7 @@ params:
     choice: ["DE", "NL", "BE", "DK1", "DK2", "FR"]
     required: true
   - name: currency
-    default: EUR
-    type: choice
-    description:
-      en: Currency
-      de: Währung
     choice: ["EUR", "DKK"]
-    required: true
   - name: horizon
     default: 120
     type: int

--- a/templates/definition/tariff/esios.yaml
+++ b/templates/definition/tariff/esios.yaml
@@ -25,8 +25,6 @@ params:
     choice: [1001, 1739]
     required: true
   - name: region
-    description:
-      generic: "Region"
     example: Península
     type: choice
     choice: ["Península", "Canarias", "Baleares", "Ceuta", "Melilla"]

--- a/templates/definition/tariff/ews.yaml
+++ b/templates/definition/tariff/ews.yaml
@@ -14,7 +14,6 @@ params:
   - name: apiKey
     type: string
     required: true
-    mask: true
     example: pub_dpa_8476c477d8a039529478ebd690d35ddd80e3308ffc
 render: |
   type: custom

--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -18,9 +18,7 @@ params:
   - name: apiKey
     deprecated: true
   - name: clientid
-    required: true
   - name: clientsecret
-    required: true
   - name: zone
     description:
       de: Zonencode

--- a/templates/definition/tariff/nordpool.yaml
+++ b/templates/definition/tariff/nordpool.yaml
@@ -41,13 +41,7 @@ params:
         "SYS",
       ]
   - name: currency
-    default: EUR
-    type: choice
-    description:
-      en: Currency
-      de: Währung
     choice: ["DKK", "EUR", "NOK", "PLN", "RON", "SEK"]
-    required: true
   - preset: tariff-base
 render: |
   type: custom

--- a/templates/definition/tariff/octopus-de.yaml
+++ b/templates/definition/tariff/octopus-de.yaml
@@ -22,11 +22,7 @@ params:
   - name: password
     type: string
     required: true
-    mask: true
     example: "secret"
-    description:
-      en: Password
-      de: Passwort
     help:
       de: "Das Passwort Ihres Octopus Energy Kontos."
       en: "The password of your Octopus Energy account."

--- a/templates/definition/tariff/ostrom.yaml
+++ b/templates/definition/tariff/ostrom.yaml
@@ -11,10 +11,8 @@ countries: ["DE"]
 params:
   - name: clientid
     example: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4
-    required: true
   - name: clientsecret
     example: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4a
-    required: true
   - name: contract
     example: 100523456
     description:

--- a/templates/definition/tariff/stroomprijsprognose.yaml
+++ b/templates/definition/tariff/stroomprijsprognose.yaml
@@ -16,13 +16,7 @@ params:
     choice: ["DE", "NL", "BE", "DK1", "DK2", "FR"]
     required: true
   - name: currency
-    default: EUR
-    type: choice
-    description:
-      en: Currency
-      de: Währung
     choice: ["EUR", "DKK"]
-    required: true
   - name: horizon
     default: 120
     type: int

--- a/templates/definition/vehicle/cardata.yaml
+++ b/templates/definition/vehicle/cardata.yaml
@@ -57,7 +57,6 @@ params:
     required: true
     example: WBMW...
   - name: clientid
-    required: true
   - preset: vehicle-features
   - name: streaming
     help:

--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -16,10 +16,8 @@ params:
     deprecated: true
   - name: accessToken
     required: true
-    mask: true
   - name: refreshToken
     required: true
-    mask: true
   - name: vin
     example: V...
   - name: cache

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -16,10 +16,8 @@ params:
     deprecated: true
   - name: accessToken
     required: true
-    mask: true
   - name: refreshToken
     required: true
-    mask: true
   - name: vin
     example: V...
   - name: cache

--- a/templates/definition/vehicle/ford-connect-query.yaml
+++ b/templates/definition/vehicle/ford-connect-query.yaml
@@ -12,14 +12,12 @@ params:
     help:
       de: Einrichtung unter [developer.ford.com](https://developer.ford.com/developer-eu)
       en: Setup at [developer.ford.com](https://developer.ford.com/developer-eu)
-    required: true
   - name: clientsecret
     description:
       generic: FordConnect Query Client Secret
     help:
       de: Einrichtung unter [developer.ford.com](https://developer.ford.com/developer-eu)
       en: Setup at [developer.ford.com](https://developer.ford.com/developer-eu)
-    required: true
   - name: redirecturi
     description:
       generic: FordConnect Query Redirect URL
@@ -27,7 +25,6 @@ params:
       de: Einrichtung unter [developer.ford.com](https://developer.ford.com/developer-eu)
       en: Setup at [developer.ford.com](https://developer.ford.com/developer-eu)
     service: auth/redirecturi
-    required: true
   - name: vin
     example: WF0FXX...
   - name: cache

--- a/templates/definition/vehicle/ford-connect.yaml
+++ b/templates/definition/vehicle/ford-connect.yaml
@@ -13,14 +13,12 @@ params:
     help:
       de: Einrichtung unter [developer.ford.com](https://developer.ford.com)
       en: Setup at [developer.ford.com](https://developer.ford.com)
-    required: true
   - name: clientsecret
     description:
       generic: FordConnect API Client Secret
     help:
       de: Einrichtung unter [developer.ford.com](https://developer.ford.com)
       en: Setup at [developer.ford.com](https://developer.ford.com)
-    required: true
   - name: accessToken
     required: true
     mask: true

--- a/templates/definition/vehicle/ford-connect.yaml
+++ b/templates/definition/vehicle/ford-connect.yaml
@@ -23,10 +23,8 @@ params:
     required: true
   - name: accessToken
     required: true
-    mask: true
   - name: refreshToken
     required: true
-    mask: true
   - name: vin
     example: WF0FXX...
   - name: cache

--- a/templates/definition/vehicle/mercedes.yaml
+++ b/templates/definition/vehicle/mercedes.yaml
@@ -19,10 +19,8 @@ params:
     default: EMEA
   - name: accessToken
     required: true
-    mask: true
   - name: refreshToken
     required: true
-    mask: true
   - name: vin
     example: V...
   - name: cache

--- a/templates/definition/vehicle/offline.yaml
+++ b/templates/definition/vehicle/offline.yaml
@@ -13,7 +13,6 @@ params:
   - name: coarsecurrent
     advanced: true
   - name: welcomecharge
-    advanced: true
 render: |
   type: custom
   {{- include "vehicle-common" . }}

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -16,10 +16,8 @@ params:
     deprecated: true
   - name: accessToken
     required: true
-    mask: true
   - name: refreshToken
     required: true
-    mask: true
   - name: vin
     example: V...
   - name: cache

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -16,10 +16,8 @@ params:
     deprecated: true
   - name: accessToken
     required: true
-    mask: true
   - name: refreshToken
     required: true
-    mask: true
   - name: vin
     example: V...
   - name: cache

--- a/templates/definition/vehicle/smart.yaml
+++ b/templates/definition/vehicle/smart.yaml
@@ -21,10 +21,8 @@ params:
     default: EMEA
   - name: accessToken
     required: true
-    mask: true
   - name: refreshToken
     required: true
-    mask: true
   - name: vin
     example: V...
   - name: cache

--- a/templates/definition/vehicle/tesla-ble.yaml
+++ b/templates/definition/vehicle/tesla-ble.yaml
@@ -12,7 +12,6 @@ params:
   - preset: vehicle-climater
   - name: vin
     required: true
-    example: W...
     help:
       de: Erforderlich für BLE-Verbindung
       en: Required for BLE connection

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -44,7 +44,6 @@ params:
     help:
       en: from [developer.tesla.com](https://developer.tesla.com/dashboard).
       de: von [developer.tesla.com](https://developer.tesla.com/dashboard).
-    required: true
   - name: accessToken
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -39,8 +39,6 @@ params:
   - preset: vehicle-common
   - preset: vehicle-climater
   - name: clientId
-    description:
-      generic: Client ID
     help:
       en: from [developer.tesla.com](https://developer.tesla.com/dashboard).
       de: von [developer.tesla.com](https://developer.tesla.com/dashboard).
@@ -50,15 +48,12 @@ params:
       en: from [myteslamate.com](https://app.myteslamate.com/).
       de: von [myteslamate.com](https://app.myteslamate.com/).
     required: true
-    mask: true
   - name: refreshToken
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).
       de: von [myteslamate.com](https://app.myteslamate.com/).
     required: true
-    mask: true
   - name: vin
-    example: W...
   - name: control
     description:
       generic: Control

--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -21,7 +21,6 @@ params:
     required: true
   - name: clientsecret
     required: true
-    mask: true
   - name: redirecturi
     required: true
     description:

--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -18,12 +18,9 @@ params:
   - preset: vehicle-common
   - preset: vehicle-climater
   - name: clientid
-    required: true
   - name: clientsecret
-    required: true
     mask: true
   - name: redirecturi
-    required: true
     description:
       generic: Redirect URI
     help:

--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -21,8 +21,6 @@ params:
   - name: clientsecret
     mask: true
   - name: redirecturi
-    description:
-      generic: Redirect URI
     help:
       en: "Redirect URI of the evcc instance. Must match the redirect URI set in the Tibber Data API client."
       de: "Redirect-URI der evcc-Instanz. Muss mit der im Tibber Data API Client hinterlegten Redirect URI übereinstimmen."

--- a/templates/definition/vehicle/tronity.yaml
+++ b/templates/definition/vehicle/tronity.yaml
@@ -14,14 +14,12 @@ params:
     help:
       de: Einrichtung unter [app.tronity.tech](https://app.tronity.tech)
       en: Setup at [app.tronity.tech](https://app.tronity.tech)
-    required: true
   - name: clientsecret
     description:
       generic: Tronity API Client Secret
     help:
       de: Einrichtung unter [app.tronity.tech](https://app.tronity.tech)
       en: Setup at [app.tronity.tech](https://app.tronity.tech)
-    required: true
   - name: vin
     example: W...
   - name: cache

--- a/templates/definition/vehicle/tronity.yaml
+++ b/templates/definition/vehicle/tronity.yaml
@@ -23,7 +23,6 @@ params:
       en: Setup at [app.tronity.tech](https://app.tronity.tech)
     required: true
   - name: vin
-    example: W...
   - name: cache
     default: 15m
 render: |

--- a/templates/definition/vehicle/volvo-connected.yaml
+++ b/templates/definition/vehicle/volvo-connected.yaml
@@ -35,17 +35,14 @@ params:
       en: "from [Volvo Developer App](https://developer.volvocars.com/)."
       de: "aus [Volvo Developer App](https://developer.volvocars.com/)."
   - name: clientId
-    required: true
     help:
       en: "from [Volvo Developer App](https://developer.volvocars.com/)."
       de: "aus [Volvo Developer App](https://developer.volvocars.com/)."
   - name: clientSecret
-    required: true
     help:
       en: "from [Volvo Developer App](https://developer.volvocars.com/)."
       de: "aus [Volvo Developer App](https://developer.volvocars.com/)."
   - name: redirectUri
-    required: true
     description:
       generic: Redirect URI
     help:

--- a/templates/definition/vehicle/volvo-connected.yaml
+++ b/templates/definition/vehicle/volvo-connected.yaml
@@ -43,8 +43,6 @@ params:
       en: "from [Volvo Developer App](https://developer.volvocars.com/)."
       de: "aus [Volvo Developer App](https://developer.volvocars.com/)."
   - name: redirectUri
-    description:
-      generic: Redirect URI
     help:
       en: "Redirect URI of your evcc instance. Must match the redirect URI set in your Volvo Developer App."
       de: "Redirect-URI deiner evcc-Instanz. Muss mit der Redirect-URI übereinstimmen, die in deiner Volvo Developer App festgelegt ist."

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -519,12 +519,6 @@ params:
       en: Typical values are 9600, 19200, 38400, 57600, 115200
     default: 9600
     type: int
-  - name: currentl1
-    advanced: true
-  - name: currentl2
-    advanced: true
-  - name: currentl3
-    advanced: true
   - name: currency
     type: choice
     default: EUR
@@ -534,6 +528,8 @@ params:
       de: Währung
   - name: redirecturi
     required: true
+    description:
+      generic: Redirect URI
 
 presets:
   vehicle-base:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -99,6 +99,7 @@ params:
     type: choice
     choice: ["1", "2", "3"]
   - name: connector
+    type: int
     description:
       en: Connector number
       de: Anschlussnummer

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -287,6 +287,7 @@ params:
       generic: URL
   - name: ain
     private: true
+    required: true
     example: "307788992233"
     description:
       en: Actor Identification Number (AIN)
@@ -312,6 +313,7 @@ params:
       de: Streaming Datenempfang erfolgt asynchron
   - name: welcomecharge
     type: bool
+    advanced: true
     description:
       en: Charge on connection
       de: Laden bei Verbindung
@@ -344,6 +346,7 @@ params:
       de: Fest angeschlossenes Gerät. Keine Ladevorgänge
   - name: defaultmode
     type: int
+    advanced: true
     usages: ["battery"]
     description:
       de: Standardmodus für die aktive Batteriesteuerung
@@ -408,10 +411,12 @@ params:
       de: Kanal
     type: int
   - name: clientid
+    required: true
     description:
       generic: Client ID
   - name: clientsecret
     mask: true
+    required: true
     description:
       generic: Client Secret
   - name: token
@@ -432,6 +437,8 @@ params:
     description:
       generic: PIN
   - name: watchdog
+    type: duration
+    advanced: true
     description:
       generic: Watchdog
   - name: uuid
@@ -512,6 +519,21 @@ params:
       en: Typical values are 9600, 19200, 38400, 57600, 115200
     default: 9600
     type: int
+  - name: currentl1
+    advanced: true
+  - name: currentl2
+    advanced: true
+  - name: currentl3
+    advanced: true
+  - name: currency
+    type: choice
+    default: EUR
+    required: true
+    description:
+      en: Currency
+      de: Währung
+  - name: redirecturi
+    required: true
 
 presets:
   vehicle-base:


### PR DESCRIPTION
Two complementary, semantics-preserving cleanups of the device templates against `util/templates/defaults.yaml`. Template params inherit their properties from the matching defaults entry via `OverwriteProperties` (mergo fills only empty fields), so both directions leave the rendered config and param metadata unchanged.

**1. Drop properties that duplicate defaults**
Removes ~91 property overrides across ~67 templates where the value already matched the defaults definition and was inherited anyway (e.g. `connector` `default: 1`/`advanced: true`, OAuth token `mask`, `host`/`cache` flags, `maxcurrent` type/unit, …).

**2. Promote properties that every user sets identically**
Adds uniformly-set properties to the defaults definitions and drops the now-inherited copies:
- `watchdog`: `type: duration` + `advanced: true`
- `clientid`, `clientsecret`, `ain`: `required: true`
- `defaultmode`, `welcomecharge`: `advanced: true`
- new shared entries `currency` (type/default/required/description; per-template `choice` stays local) and `redirecturi` (`required: true` + description; ford-connect-query keeps its specific override)

The `service` property intentionally stays in the templates since it carries behaviour, and the per-phase `current*`/`voltage*` params are left defined locally.

Only properties that already resolved identically across every instance were promoted: a dump of the resolved params for all 531 templates is byte-identical before and after. `go test ./util/templates/` passes.

Also adds an AGENTS.md note to reference params by name and only set a property to give it a different value.