### PR TITLE
Loadpoint: adapt UI for integrated and switch devices

### DIFF
--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -220,6 +220,9 @@ export default {
 					return `${this.fmtNumber(distanceValue(value), 0)} ${distanceUnit()}`;
 				case "chargeStatus":
 					return value ? this.$t(`config.deviceValue.chargeStatus${value}`) : "-";
+				case "switchDevice":
+					// switch device means no current control
+					return this.$t(`config.deviceValue.${value ? "no" : "yes"}`);
 				case "price":
 				case "gridPrice":
 				case "feedinPrice":

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -114,13 +114,7 @@
 								v-model="values.defaultMode"
 								type="Choice"
 								class="w-100"
-								:choice="[
-									{ key: '', name: '---' },
-									{ key: 'off', name: $t('main.mode.off') },
-									{ key: 'pv', name: $t('main.mode.pv') },
-									{ key: 'minpv', name: $t('main.mode.minpv') },
-									{ key: 'now', name: $t('main.mode.now') },
-								]"
+								:choice="defaultModeOptions"
 							/>
 						</FormRow>
 
@@ -306,7 +300,7 @@
 							/>
 						</FormRow>
 
-						<h6>
+						<h6 v-if="!chargerIsSwitchDevice">
 							{{ $t("config.loadpoint.electricalTitle") }}
 							<small class="text-muted">{{
 								$t("config.loadpoint.electricalSubtitle")
@@ -314,6 +308,7 @@
 						</h6>
 
 						<FormRow
+							v-if="!chargerIsSwitchDevice"
 							id="chargerPower"
 							:label="$t('config.loadpoint.chargerTypeLabel')"
 							:help="
@@ -346,7 +341,10 @@
 							/>
 						</FormRow>
 
-						<div v-if="chargerPower === 'other'" class="row ms-3 mb-5">
+						<div
+							v-if="!chargerIsSwitchDevice && chargerPower === 'other'"
+							class="row ms-3 mb-5"
+						>
 							<FormRow
 								id="loadpointMinCurrent"
 								:label="$t('config.loadpoint.minCurrentLabel')"
@@ -591,6 +589,7 @@ import InvalidReferenceAlert from "./InvalidReferenceAlert.vue";
 import { handleError, customChargerName, createDeviceUtils } from "./DeviceModal";
 import { getModal, openModal, replaceModal, closeModal } from "@/configModal";
 import {
+	CHARGE_MODE,
 	LOADPOINT_TYPE,
 	type DeviceType,
 	type LoadpointType,
@@ -602,6 +601,8 @@ import {
 } from "@/types/evcc";
 
 const nsPerMin = 60 * 1e9;
+
+const { OFF, PV, MINPV, NOW } = CHARGE_MODE;
 
 const defaultValues = {
 	id: undefined,
@@ -716,6 +717,9 @@ export default {
 		chargerIsIntegratedDevice() {
 			return this.chargerStatus.integratedDevice?.value || false;
 		},
+		chargerIsSwitchDevice() {
+			return this.chargerStatus.switchDevice?.value || false;
+		},
 		chargerIsHeating() {
 			return this.chargerStatus.heating?.value === true;
 		},
@@ -749,6 +753,12 @@ export default {
 				{ value: 1, name: this.$t("config.loadpoint.phases1p") },
 				{ value: 3, name: this.$t("config.loadpoint.phases3p") },
 			];
+		},
+		defaultModeOptions(): { key: CHARGE_MODE; name: string }[] {
+			// empty option is provided by PropertyField placeholder
+			// switch devices have no current control, so minpv does not apply
+			const modes = this.chargerIsSwitchDevice ? [OFF, PV, NOW] : [OFF, PV, MINPV, NOW];
+			return modes.map((key) => ({ key, name: this.$t(`main.mode.${key}`) }));
 		},
 		showCircuit() {
 			return this.circuits.length > 0 || !!this.values.circuit;

--- a/assets/js/components/Config/defaultYaml/switchsocketCharger.yaml
+++ b/assets/js/components/Config/defaultYaml/switchsocketCharger.yaml
@@ -12,6 +12,7 @@ power: # charge power reading in W
 standbypower: 20 # in W, below values will be treaded as inactive
 
 features:
+  - switchdevice # on/off only, no current control
   - integrateddevice # no charging sessions, no connected vehicles
 
 

--- a/assets/js/components/Config/defaultYaml/switchsocketHeater.yaml
+++ b/assets/js/components/Config/defaultYaml/switchsocketHeater.yaml
@@ -12,6 +12,7 @@ power: # charge power reading in W
 standbypower: 20 # in W, below values will be treaded as inactive
 
 features:
+  - switchdevice # on/off only, no current control
   - heating # treat as a heating device
   - integrateddevice # no charging sessions, no connected vehicles
 

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -71,7 +71,8 @@
 				/>
 			</div>
 			<LabelAndValue
-				v-show="socBasedCharging"
+				v-show="socBasedCharging && !integratedDevice"
+				data-testid="charged"
 				:label="$t('main.loadpoint.charged')"
 				:value="chargedEnergy"
 				:valueFmt="fmtEnergy"
@@ -166,6 +167,7 @@ export default defineComponent({
 		chargerFeatureIntegratedDevice: Boolean,
 		chargerFeatureHeating: Boolean,
 		chargerFeatureContinuous: Boolean,
+		chargerFeatureSwitchDevice: Boolean,
 		chargerIcon: String as PropType<string | null>,
 
 		// vehicle
@@ -276,6 +278,9 @@ export default defineComponent({
 		},
 		continuous() {
 			return this.chargerFeatureContinuous;
+		},
+		switchDevice() {
+			return this.chargerFeatureSwitchDevice;
 		},
 		phasesProps() {
 			return this.collectProps(Phases);

--- a/assets/js/components/Loadpoints/Loadpoint.vue
+++ b/assets/js/components/Loadpoints/Loadpoint.vue
@@ -71,8 +71,7 @@
 				/>
 			</div>
 			<LabelAndValue
-				v-show="socBasedCharging && !integratedDevice"
-				data-testid="charged"
+				v-show="socBasedCharging"
 				:label="$t('main.loadpoint.charged')"
 				:value="chargedEnergy"
 				:valueFmt="fmtEnergy"

--- a/assets/js/components/Loadpoints/Mode.vue
+++ b/assets/js/components/Loadpoints/Mode.vue
@@ -33,7 +33,6 @@ export default defineComponent({
 	computed: {
 		modes(): CHARGE_MODE[] {
 			if (this.pvPossible) {
-				// switch devices have no current control, so Min+PV does not apply
 				return this.switchDevice ? [OFF, PV, NOW] : [OFF, PV, MINPV, NOW];
 			}
 			if (this.smartCostAvailable) {

--- a/assets/js/components/Loadpoints/Mode.vue
+++ b/assets/js/components/Loadpoints/Mode.vue
@@ -26,13 +26,15 @@ export default defineComponent({
 		mode: String,
 		pvPossible: Boolean,
 		smartCostAvailable: Boolean,
+		switchDevice: Boolean,
 	},
 	emits: ["updated"],
 
 	computed: {
 		modes(): CHARGE_MODE[] {
 			if (this.pvPossible) {
-				return [OFF, PV, MINPV, NOW];
+				// switch devices have no current control, so Min+PV does not apply
+				return this.switchDevice ? [OFF, PV, NOW] : [OFF, PV, MINPV, NOW];
 			}
 			if (this.smartCostAvailable) {
 				return [OFF, PV, NOW];

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -37,97 +37,93 @@
 				class="mt-2"
 				@batteryboostlimit-updated="setBatteryBoostLimit"
 			/>
-			<template v-if="!switchDevice">
-				<h6>
-					{{ $t("main.loadpointSettings.currents") }}
-				</h6>
-				<div v-if="phasesOptions.length" class="mb-3 row">
-					<label
-						:for="formId(`phases_${phasesOptions[0]}`)"
-						class="col-sm-4 col-form-label pt-0"
-					>
-						{{ $t("main.loadpointSettings.phasesConfigured.label") }}
-					</label>
-					<div class="col-sm-8 pe-0">
-						<p v-if="!loadpoint?.chargerPhases1p3p" class="mt-0 mb-2">
-							<small>
+			<h6>
+				{{ $t("main.loadpointSettings.currents") }}
+			</h6>
+			<div v-if="phasesOptions.length" class="mb-3 row">
+				<label
+					:for="formId(`phases_${phasesOptions[0]}`)"
+					class="col-sm-4 col-form-label pt-0"
+				>
+					{{ $t("main.loadpointSettings.phasesConfigured.label") }}
+				</label>
+				<div class="col-sm-8 pe-0">
+					<p v-if="!loadpoint?.chargerPhases1p3p" class="mt-0 mb-2">
+						<small>
+							{{ $t("main.loadpointSettings.phasesConfigured.no1p3pSupport") }}</small
+						>
+					</p>
+					<div v-for="phases in phasesOptions" :key="phases" class="form-check">
+						<input
+							:id="formId(`phases_${phases}`)"
+							v-model.number="selectedPhases"
+							class="form-check-input"
+							type="radio"
+							:name="formId('phases')"
+							:value="phases"
+							@change="setPhasesConfigured"
+						/>
+						<label class="form-check-label" :for="formId(`phases_${phases}`)">
+							{{ $t(`main.loadpointSettings.phasesConfigured.phases_${phases}`) }}
+							<small v-if="phases > 0">
 								{{
-									$t("main.loadpointSettings.phasesConfigured.no1p3pSupport")
-								}}</small
-							>
-						</p>
-						<div v-for="phases in phasesOptions" :key="phases" class="form-check">
-							<input
-								:id="formId(`phases_${phases}`)"
-								v-model.number="selectedPhases"
-								class="form-check-input"
-								type="radio"
-								:name="formId('phases')"
-								:value="phases"
-								@change="setPhasesConfigured"
-							/>
-							<label class="form-check-label" :for="formId(`phases_${phases}`)">
-								{{ $t(`main.loadpointSettings.phasesConfigured.phases_${phases}`) }}
-								<small v-if="phases > 0">
-									{{
-										$t(
-											`main.loadpointSettings.phasesConfigured.phases_${phases}_hint`,
-											{
-												min: fmtPhasePower(minCurrent, phases),
-												max: fmtPhasePower(maxCurrent, phases),
-											}
-										)
-									}}
-								</small>
-							</label>
-						</div>
+									$t(
+										`main.loadpointSettings.phasesConfigured.phases_${phases}_hint`,
+										{
+											min: fmtPhasePower(minCurrent, phases),
+											max: fmtPhasePower(maxCurrent, phases),
+										}
+									)
+								}}
+							</small>
+						</label>
 					</div>
 				</div>
+			</div>
 
-				<div class="mb-3 row">
-					<label :for="formId('maxcurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
-						{{ $t("main.loadpointSettings.maxCurrent.label") }}
-					</label>
-					<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
-						<select
-							:id="formId('maxcurrent')"
-							v-model.number="selectedMaxCurrent"
-							class="form-select form-select-sm"
-							@change="setMaxCurrent"
+			<div v-if="!switchDevice" class="mb-3 row">
+				<label :for="formId('maxcurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
+					{{ $t("main.loadpointSettings.maxCurrent.label") }}
+				</label>
+				<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
+					<select
+						:id="formId('maxcurrent')"
+						v-model.number="selectedMaxCurrent"
+						class="form-select form-select-sm"
+						@change="setMaxCurrent"
+					>
+						<option
+							v-for="{ value, name } in maxCurrentOptions"
+							:key="value"
+							:value="value"
 						>
-							<option
-								v-for="{ value, name } in maxCurrentOptions"
-								:key="value"
-								:value="value"
-							>
-								{{ name }}
-							</option>
-						</select>
-					</div>
+							{{ name }}
+						</option>
+					</select>
 				</div>
+			</div>
 
-				<div class="mb-3 row">
-					<label :for="formId('mincurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
-						{{ $t("main.loadpointSettings.minCurrent.label") }}
-					</label>
-					<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
-						<select
-							:id="formId('mincurrent')"
-							v-model.number="selectedMinCurrent"
-							class="form-select form-select-sm"
-							@change="setMinCurrent"
+			<div class="mb-3 row">
+				<label :for="formId('mincurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
+					{{ $t("main.loadpointSettings.minCurrent.label") }}
+				</label>
+				<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
+					<select
+						:id="formId('mincurrent')"
+						v-model.number="selectedMinCurrent"
+						class="form-select form-select-sm"
+						@change="setMinCurrent"
+					>
+						<option
+							v-for="{ value, name } in minCurrentOptions"
+							:key="value"
+							:value="value"
 						>
-							<option
-								v-for="{ value, name } in minCurrentOptions"
-								:key="value"
-								:value="value"
-							>
-								{{ name }}
-							</option>
-						</select>
-					</div>
+							{{ name }}
+						</option>
+					</select>
 				</div>
-			</template>
+			</div>
 		</div>
 	</GenericModal>
 </template>

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -37,93 +37,97 @@
 				class="mt-2"
 				@batteryboostlimit-updated="setBatteryBoostLimit"
 			/>
-			<h6>
-				{{ $t("main.loadpointSettings.currents") }}
-			</h6>
-			<div v-if="phasesOptions.length" class="mb-3 row">
-				<label
-					:for="formId(`phases_${phasesOptions[0]}`)"
-					class="col-sm-4 col-form-label pt-0"
-				>
-					{{ $t("main.loadpointSettings.phasesConfigured.label") }}
-				</label>
-				<div class="col-sm-8 pe-0">
-					<p v-if="!loadpoint?.chargerPhases1p3p" class="mt-0 mb-2">
-						<small>
-							{{ $t("main.loadpointSettings.phasesConfigured.no1p3pSupport") }}</small
-						>
-					</p>
-					<div v-for="phases in phasesOptions" :key="phases" class="form-check">
-						<input
-							:id="formId(`phases_${phases}`)"
-							v-model.number="selectedPhases"
-							class="form-check-input"
-							type="radio"
-							:name="formId('phases')"
-							:value="phases"
-							@change="setPhasesConfigured"
-						/>
-						<label class="form-check-label" :for="formId(`phases_${phases}`)">
-							{{ $t(`main.loadpointSettings.phasesConfigured.phases_${phases}`) }}
-							<small v-if="phases > 0">
+			<template v-if="!switchDevice">
+				<h6>
+					{{ $t("main.loadpointSettings.currents") }}
+				</h6>
+				<div v-if="phasesOptions.length" class="mb-3 row">
+					<label
+						:for="formId(`phases_${phasesOptions[0]}`)"
+						class="col-sm-4 col-form-label pt-0"
+					>
+						{{ $t("main.loadpointSettings.phasesConfigured.label") }}
+					</label>
+					<div class="col-sm-8 pe-0">
+						<p v-if="!loadpoint?.chargerPhases1p3p" class="mt-0 mb-2">
+							<small>
 								{{
-									$t(
-										`main.loadpointSettings.phasesConfigured.phases_${phases}_hint`,
-										{
-											min: fmtPhasePower(minCurrent, phases),
-											max: fmtPhasePower(maxCurrent, phases),
-										}
-									)
-								}}
-							</small>
-						</label>
+									$t("main.loadpointSettings.phasesConfigured.no1p3pSupport")
+								}}</small
+							>
+						</p>
+						<div v-for="phases in phasesOptions" :key="phases" class="form-check">
+							<input
+								:id="formId(`phases_${phases}`)"
+								v-model.number="selectedPhases"
+								class="form-check-input"
+								type="radio"
+								:name="formId('phases')"
+								:value="phases"
+								@change="setPhasesConfigured"
+							/>
+							<label class="form-check-label" :for="formId(`phases_${phases}`)">
+								{{ $t(`main.loadpointSettings.phasesConfigured.phases_${phases}`) }}
+								<small v-if="phases > 0">
+									{{
+										$t(
+											`main.loadpointSettings.phasesConfigured.phases_${phases}_hint`,
+											{
+												min: fmtPhasePower(minCurrent, phases),
+												max: fmtPhasePower(maxCurrent, phases),
+											}
+										)
+									}}
+								</small>
+							</label>
+						</div>
 					</div>
 				</div>
-			</div>
 
-			<div class="mb-3 row">
-				<label :for="formId('maxcurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
-					{{ $t("main.loadpointSettings.maxCurrent.label") }}
-				</label>
-				<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
-					<select
-						:id="formId('maxcurrent')"
-						v-model.number="selectedMaxCurrent"
-						class="form-select form-select-sm"
-						@change="setMaxCurrent"
-					>
-						<option
-							v-for="{ value, name } in maxCurrentOptions"
-							:key="value"
-							:value="value"
+				<div class="mb-3 row">
+					<label :for="formId('maxcurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
+						{{ $t("main.loadpointSettings.maxCurrent.label") }}
+					</label>
+					<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
+						<select
+							:id="formId('maxcurrent')"
+							v-model.number="selectedMaxCurrent"
+							class="form-select form-select-sm"
+							@change="setMaxCurrent"
 						>
-							{{ name }}
-						</option>
-					</select>
+							<option
+								v-for="{ value, name } in maxCurrentOptions"
+								:key="value"
+								:value="value"
+							>
+								{{ name }}
+							</option>
+						</select>
+					</div>
 				</div>
-			</div>
 
-			<div class="mb-3 row">
-				<label :for="formId('mincurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
-					{{ $t("main.loadpointSettings.minCurrent.label") }}
-				</label>
-				<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
-					<select
-						:id="formId('mincurrent')"
-						v-model.number="selectedMinCurrent"
-						class="form-select form-select-sm"
-						@change="setMinCurrent"
-					>
-						<option
-							v-for="{ value, name } in minCurrentOptions"
-							:key="value"
-							:value="value"
+				<div class="mb-3 row">
+					<label :for="formId('mincurrent')" class="col-sm-4 col-form-label pt-0 pt-sm-2">
+						{{ $t("main.loadpointSettings.minCurrent.label") }}
+					</label>
+					<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
+						<select
+							:id="formId('mincurrent')"
+							v-model.number="selectedMinCurrent"
+							class="form-select form-select-sm"
+							@change="setMinCurrent"
 						>
-							{{ name }}
-						</option>
-					</select>
+							<option
+								v-for="{ value, name } in minCurrentOptions"
+								:key="value"
+								:value="value"
+							>
+								{{ name }}
+							</option>
+						</select>
+					</div>
 				</div>
-			</div>
+			</template>
 		</div>
 	</GenericModal>
 </template>
@@ -193,6 +197,9 @@ export default defineComponent({
 		},
 		minCurrent() {
 			return this.loadpoint?.minCurrent;
+		},
+		switchDevice() {
+			return this.loadpoint?.chargerFeatureSwitchDevice;
 		},
 		batteryBoostLimit() {
 			return this.loadpoint?.batteryBoostLimit;

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -188,6 +188,7 @@
       "singlePhase": "Einphasig",
       "soc": "Ladestand",
       "solarForecast": "PV-Vorhersage",
+      "switchDevice": "Stromregelung",
       "temp": "Temperatur",
       "topic": "Thema",
       "url": "URL",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -188,6 +188,7 @@
       "singlePhase": "Single phase",
       "soc": "Charge",
       "solarForecast": "Solar forecast",
+      "switchDevice": "Current control",
       "temp": "Temperature",
       "topic": "Topic",
       "url": "URL",

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -349,6 +349,10 @@ func testInstance(instance any) map[string]testResult {
 		makeResult("integratedDevice", true, nil)
 	}
 
+	if hasFeature(instance, api.SwitchDevice) {
+		makeResult("switchDevice", true, nil)
+	}
+
 	if dev, ok := api.Cap[api.IconDescriber](instance); ok && dev.Icon() != "" {
 		makeResult("icon", dev.Icon(), nil)
 	}

--- a/tests/config-loadpoint.spec.ts
+++ b/tests/config-loadpoint.spec.ts
@@ -508,6 +508,45 @@ power:
     await expect(chargerEditor).toContainText("value: 'C'");
     await expect(chargerEditor).toContainText("value: 11000");
   });
+
+  test("user-defined switch socket (pool pump)", async ({ page }) => {
+    await start();
+    await page.goto("/#/config");
+
+    // add loadpoint
+    await newLoadpoint(page, "Pool pump");
+    const lpModal = page.getByTestId("loadpoint-modal");
+    await lpModal.getByRole("button", { name: "Add charger" }).click();
+
+    const chargerModal = page.getByTestId("charger-modal");
+    await expectModalVisible(chargerModal);
+    await chargerModal.getByLabel("Manufacturer").selectOption("User-defined switch socket");
+    await page.waitForLoadState("networkidle");
+    await expect(chargerModal.getByTestId("yaml-editor")).toContainText("switchdevice");
+
+    const result = chargerModal.getByTestId("test-result");
+    await result.getByRole("link", { name: "validate" }).click();
+    await expect(result).toContainText("Status: successful");
+    await expect(result).toContainText(["Power", "11.0 kW"].join(""));
+    await expect(result).toContainText(["Current control", "no"].join(""));
+
+    await chargerModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(chargerModal);
+    await expectModalVisible(lpModal);
+
+    const modeSelect = lpModal.getByLabel("Default mode");
+    await expect(modeSelect.getByRole("option", { name: "Solar", exact: true })).toHaveCount(1);
+    await expect(modeSelect.getByRole("option", { name: "Min+Solar" })).toHaveCount(0);
+
+    await expect(lpModal.getByText("Electrics")).toHaveCount(0);
+    await expect(lpModal.getByText("Charger type", { exact: true })).toHaveCount(0);
+
+    // create
+    await lpModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(lpModal);
+    await expect(page.getByTestId("loadpoint")).toHaveCount(1);
+    await expect(page.getByTestId("loadpoint")).toContainText("Pool pump");
+  });
 });
 
 test.describe("heating loadpoint", async () => {

--- a/tests/heating.evcc.yaml
+++ b/tests/heating.evcc.yaml
@@ -48,4 +48,4 @@ chargers:
       source: js
       script: |
         55
-    features: [integrateddevice, heating]
+    features: [integrateddevice, heating, switchdevice]

--- a/tests/heating.spec.ts
+++ b/tests/heating.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { start, stop, baseUrl } from "./evcc";
+import { expectModalVisible } from "./utils";
 
 test.use({ baseURL: baseUrl() });
 
@@ -25,5 +26,25 @@ test.describe("loadpoint", async () => {
     await expect(page.getByTestId("limit-soc")).toContainText("69.0°C");
     await page.reload();
     await expect(page.getByTestId("limit-soc")).toContainText("69.0°C");
+  });
+});
+
+test.describe("integrated device", async () => {
+  test("no charged energy and no Min+Solar mode", async ({ page }) => {
+    const lp = page.getByTestId("loadpoint").first();
+    // integrated device has no charging session, so charged energy is hidden
+    await expect(lp.getByTestId("charged")).not.toBeVisible();
+    // switch device has no current control, so Min+Solar mode is not offered
+    const mode = lp.getByTestId("mode");
+    await expect(mode.getByRole("button", { name: "Solar", exact: true })).toBeVisible();
+    await expect(mode.getByRole("button", { name: "Min+Solar" })).toHaveCount(0);
+  });
+
+  test("no current settings in loadpoint settings", async ({ page }) => {
+    const lp = page.getByTestId("loadpoint").first();
+    await lp.getByTestId("loadpoint-settings-button").last().click();
+    const modal = page.getByTestId("loadpoint-settings-modal").first();
+    await expectModalVisible(modal);
+    await expect(modal.getByText("Charging Current")).toHaveCount(0);
   });
 });

--- a/tests/heating.spec.ts
+++ b/tests/heating.spec.ts
@@ -30,21 +30,21 @@ test.describe("loadpoint", async () => {
 });
 
 test.describe("integrated device", async () => {
-  test("no charged energy and no Min+Solar mode", async ({ page }) => {
+  test("no Min+Solar mode for switch device", async ({ page }) => {
     const lp = page.getByTestId("loadpoint").first();
-    // integrated device has no charging session, so charged energy is hidden
-    await expect(lp.getByTestId("charged")).not.toBeVisible();
-    // switch device has no current control, so Min+Solar mode is not offered
     const mode = lp.getByTestId("mode");
     await expect(mode.getByRole("button", { name: "Solar", exact: true })).toBeVisible();
     await expect(mode.getByRole("button", { name: "Min+Solar" })).toHaveCount(0);
   });
 
-  test("no current settings in loadpoint settings", async ({ page }) => {
+  test("min current and phases but no max current for switch device", async ({ page }) => {
     const lp = page.getByTestId("loadpoint").first();
     await lp.getByTestId("loadpoint-settings-button").last().click();
     const modal = page.getByTestId("loadpoint-settings-modal").first();
     await expectModalVisible(modal);
-    await expect(modal.getByText("Charging Current")).toHaveCount(0);
+    // min current and phases feed the solar switch-on threshold and stay
+    await expect(modal.getByText("Min. Current")).toBeVisible();
+    await expect(modal.getByText("Phases")).toBeVisible();
+    await expect(modal.getByText("Max. Current")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
fixes #30897
see docs https://github.com/evcc-io/docs/pull/1091

Integrated devices (e.g. a heat pump on a switch socket) reused the regular charger UI, which exposed controls that do not apply to them. This adapts the loadpoint UI to the charger feature flags that the backend already publishes.

- ~hide the charged energy value for integrated devices (no charging session)~ We swap with metrics data once stable (energy today, ...).
- drop the Min+Solar mode for switch devices (no current control)
- hide the charging ~current settings~ max current setting in loadpoint settings for switch devices. min current and phases are still required to calculate min power (pv mode)
- extend the heating Playwright test to cover the above
- drop min/max current block (charger type) from config ui loadpoint modal (see settings)
- introduce **Current control: no** label to indicate this behavior in config ui

**Screenshots**

Config UI: switch device > no current control
<img width="395" height="330" alt="no current control" src="https://github.com/user-attachments/assets/2cb20b66-47a6-458d-b61f-05951e0b451d" />

Config UI: drop min/max current, charger type section
<img width="727" height="1055" alt="config reduced modes" src="https://github.com/user-attachments/assets/c49aa241-a6df-40c6-a6d7-cf9732220195" />

Main UI: no minpv mode for switch devices
<img width="781" height="482" alt="reduced modes" src="https://github.com/user-attachments/assets/23402fca-8a3c-49f9-9e7b-ef3f61949281" />

Loadpoint Settings: drop max current
<img width="1218" height="1084" alt="no max current" src="https://github.com/user-attachments/assets/a144ea51-826d-4654-b3aa-8e587571696d" />

_👮 Note:_ Dropping max current setting will force `minCurrent` to stay under 16A (`maxCurrent` default, removed from UI). Still changeable via API.

**TODO**

- [x] check if this really helpful or in conflict with the mini loadpoint approach

**Out of scope**

- Consider replacing `minCurrent` (+ `phases`?) by something like `minPower`. @andig 