### PR TITLE
Sponsor: set gRPC client idle timeout

### DIFF
--- a/util/cloud/client.go
+++ b/util/cloud/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	_ "embed"
 	"net"
+	"time"
 
 	"github.com/evcc-io/evcc/util"
 	"google.golang.org/grpc"
@@ -29,7 +30,11 @@ func Connection() (*grpc.ClientConn, error) {
 	creds := credentials.NewTLS(&tls.Config{
 		ServerName: host,
 	})
-	conn, err = grpc.Dial(hostport, grpc.WithTransportCredentials(creds))
+	// quiesce idle connections instead of churning against the server's idle close
+	conn, err = grpc.NewClient(hostport,
+		grpc.WithTransportCredentials(creds),
+		grpc.WithIdleTimeout(60*time.Second),
+	)
 
 	return conn, err
 }

--- a/util/cloud/client.go
+++ b/util/cloud/client.go
@@ -30,10 +30,10 @@ func Connection() (*grpc.ClientConn, error) {
 	creds := credentials.NewTLS(&tls.Config{
 		ServerName: host,
 	})
-	// quiesce idle connections instead of churning against the server's idle close
+	// close idle connection shortly after startup auth instead of churning against the server's idle close
 	conn, err = grpc.NewClient(hostport,
 		grpc.WithTransportCredentials(creds),
-		grpc.WithIdleTimeout(60*time.Second),
+		grpc.WithIdleTimeout(5*time.Second),
 	)
 
 	return conn, err


### PR DESCRIPTION
Idle sponsor connections fought the server's 30s idle close with eager reconnects, flooding the proxy with TCP reset noise. The default client idle timeout is 30min, so churn ran for 30min per install before quiescing. A shorter timeout collapses that window.

- Add `WithIdleTimeout` (5s, down from the 30min default) so idle channels tear down until the next RPC
- Migrate `grpc.Dial` to `grpc.NewClient` (deprecation), also lazy-conne