### PR TITLE
docs: require AI attribution footer on comments, not commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,4 +307,14 @@ Structure PR descriptions in this order. No headlines. Be concise.
    - [ ] item b
    ```
 
-Avoid file paths, line numbers, or code listings reproduced from the diff. Include a code snippet only when it conveys the contract (event shape, API signature) more clearly than prose. No testing checklists, no co-author footers, no generator footers.
+Avoid file paths, line numbers, or code listings reproduced from the diff. Include a code snippet only when it conveys the contract (event shape, API signature) more clearly than prose. No testing checklists, no co-author footers.
+
+## AI Attribution
+
+End every GitHub comment, review, and PR/issue description authored by an AI agent with the attribution footer:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Omit the footer only from commit messages (and never add co-author trailers to commits).


### PR DESCRIPTION
Document the AI attribution policy so it is unambiguous: AI-authored GitHub comments, reviews and PR/issue descriptions carry the Claude Code footer, while commit messages stay clean. This replaces the previous blanket "no generator footers" note, which conflicted with it.

- new AGENTS.md § "AI Attribution"
- footer required on comments, reviews and PR/issue bodies
- commit messages omit it (and still carry no co-author trailers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
