### PR TITLE
GoodWe: treat nightly 0xFFFF register sentinel as invalid

### DIFF
--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -76,21 +76,21 @@ render: |
       register:
         address: 36055 # Meter Current R, A
         type: holding
-        decode: uint16
+        decode: uint16nan
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 36056 # Meter Current S, A
         type: holding
-        decode: uint16
+        decode: uint16nan
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 36057 # Meter Current T, A  
+        address: 36057 # Meter Current T, A
         type: holding
-        decode: uint16
+        decode: uint16nan
       scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
@@ -127,7 +127,7 @@ render: |
     register: # manual non-sunspec register configuration
       address: 35191 # PV Energy-Total
       type: holding
-      decode: uint32
+      decode: uint32nan
     scale: 0.1
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
@@ -145,7 +145,7 @@ render: |
     register: # manual non-sunspec register configuration
       address: {{ if eq .battery "1" }}37007{{ else }}39005{{ end }} # Battery1/2 Soc
       type: holding
-      decode: uint16
+      decode: uint16nan
   {{- if eq .battery "1" }}
   energy:
     source: modbus
@@ -153,7 +153,7 @@ render: |
     register: # manual non-sunspec register configuration
       address: 35209 # Energy-Battery Discharge
       type: holding
-      decode: uint32
+      decode: uint32nan
     scale: 0.1
   {{- end }}
   batterymode:

--- a/templates/definition/meter/goodwe-wifi-et.yaml
+++ b/templates/definition/meter/goodwe-wifi-et.yaml
@@ -93,7 +93,7 @@ render: |
       count: 125
     register:
       address: 35191     # pv energy
-      decode: uint32
+      decode: uint32nan
     scale: 0.1
     delay: {{ .delay }}
   {{- end }}
@@ -118,7 +118,7 @@ render: |
       count: 125
     register:
       address: 35209     # battery discharge energy
-      decode: uint32
+      decode: uint32nan
     scale: 0.1
     delay: {{ .delay }}
   soc:
@@ -130,6 +130,6 @@ render: |
       count: 13
     register:
       address: 37007     # soc
-      decode: uint16
+      decode: uint16nan
     delay: {{ .delay }}
   {{- end }}


### PR DESCRIPTION
fixes #30721

The GoodWe Wifi Stick V2 firmware returns the `0xFFFF`/`0xFFFFFFFF` "no data" sentinel for many registers while the inverter sleeps at night (~02:37). The `goodwe-hybrid` and `goodwe-wifi-et` templates guarded the PV *power* registers with the `nan` decoders but left energy, current and soc registers on plain `uint16`/`uint32`, so the sentinel decoded as a huge real value and produced the nightly History peaks (and broke the optimizer). The trace in the issue shows register 35191 (PV Energy-Total) returning `ff ff ff ff` → `4294967295 × 0.1 ≈ 4.3e8 kWh`; grid current 36055 → `0xFFFF × 0.1 = 6553.5 A`.

Switch the affected registers to their `nan` variants, which map the sentinel to 0 (the same handling the PV power registers already use, and why PV power read 0 W rather than 4 GW in the trace):

- `goodwe-hybrid`: PV Energy-Total (35191), battery discharge energy (35209), grid currents (36055/56/57), battery soc (37007/39005)
- `goodwe-wifi-et`: PV Energy-Total (35191), battery discharge energy (35209), soc (37007)

Home Assistant does not show the peaks because its GoodWe integration (UDP protocol) already treats the sentinel as unavailable. The `nan` decoder maps a sentinel sample to 0, so an energy accumulator shows a brief notch for that sample rather than a billion-kWh spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
