### PR TITLE
chore: allow Dependabot PRs in Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,6 +42,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # review dependency bumps opened by Dependabot
+          allowed_bots: 'dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
`anthropics/claude-code-action` rejects PRs opened by non-human actors unless they are allowlisted, so the Claude Code Review job failed on every Dependabot bump (e.g. #30917) with `Workflow initiated by non-human actor: dependabot`. Add `dependabot[bot]` to `allowed_bots` so dependency PRs are reviewed instead of erroring.

The action normalizes both the actor and the list (lowercased, `[bot]` suffix stripped), so `dependabot[bot]` matches the `dependabot[bot]` actor.

Note: because this PR edits the review workflow itself, the action's workflow-integrity check will (expectedly) fail the `claude-review` job on this PR until it is merged to the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
