### PR TITLE
feat: add evnotify v3 support, default to v2

### DIFF
--- a/templates/definition/vehicle/evnotify.yaml
+++ b/templates/definition/vehicle/evnotify.yaml
@@ -10,11 +10,26 @@ params:
       generic: API Key
   - name: token
     required: true
+  - name: version
+    type: choice
+    choice: ["2", "3"]
+    default: "2"
+    description:
+      en: API version
+      de: API-Version
   - preset: vehicle-common
   - preset: vehicle-climater
 render: |
   type: custom
   {{ include "vehicle-common" . }}
+  {{- if eq .version "3" }}
+  soc:
+    source: http
+    uri: https://api.evnotify.de/logs/{{ urlEncode .akey }}/last-sync
+    headers:
+      Authorization: {{ .akey }} {{ .token }}
+    jq: .socDisplay
+  {{- else }}
   soc:
     source: http
     uri: https://app.evnotify.de/soc?akey={{ urlEncode .akey }}&token={{ urlEncode .token }}
@@ -29,4 +44,5 @@ render: |
       source: http
       uri: https://app.evnotify.de/extended?akey={{ urlEncode .akey }}&token={{ urlEncode .token }}
       jq: .charging
+  {{- end }}
   {{ include "vehicle-features" . }}

--- a/templates/definition/vehicle/evnotify.yaml
+++ b/templates/definition/vehicle/evnotify.yaml
@@ -10,7 +10,7 @@ params:
       generic: API Key
   - name: token
     required: true
-  - name: version
+  - name: apiversion
     type: choice
     choice: ["2", "3"]
     default: "2"
@@ -22,7 +22,7 @@ params:
 render: |
   type: custom
   {{ include "vehicle-common" . }}
-  {{- if eq .version "3" }}
+  {{- if eq .apiversion "3" }}
   soc:
     source: http
     uri: https://api.evnotify.de/logs/{{ urlEncode .akey }}/last-sync


### PR DESCRIPTION
I've recently switched to a BLE OBD dongle which means I can no longer use evnotify v2. v3 supports BLE, but it uses a different API (doco at https://api.evnotify.de/)

Unfortunately it doesn't seem possible to get plugged or charging status with v3, though the latter is possible with a premium subscription. I don't think we can assume everyone will have one though. Hopefully it doesn't make too much of a difference, other than the vehicle auto detection perhaps?

Default to v2 (original) for backward compatibility reasons