### PR TITLE
chore: wait for apiReady before e2e assertions

### DIFF
--- a/tests/evcc.ts
+++ b/tests/evcc.ts
@@ -130,7 +130,10 @@ async function _start(config?: string, flags: string | string[] = []) {
     steamLog.end();
   });
   try {
-    await waitOn({ resources: [baseUrl()], log: LOG_ENABLED, timeout: 90000 });
+    // wait for apiReady so tests don't race a half-started backend
+    const jq = encodeURIComponent(".apiReady|select(.)");
+    const ready = `${baseUrl().replace(/^http/, "http-get")}/api/state?jq=${jq}`;
+    await waitOn({ resources: [ready], log: LOG_ENABLED, timeout: 90000 });
   } catch (error) {
     instance.kill("SIGKILL");
     console.error(logPrefix(), `evcc startup failed: ${error}`);


### PR DESCRIPTION
Fixes flaky `config-mqtt` e2e test (and latent races in other config tests).

- root cause: `_start` waited on the SPA `/` (ready ~2.5s), not the backend (`/api/state` ready ~17.5s when a slow MQTT broker delays boot). Assertions ran against a half-booted instance, config tiles still showed "Configured no", failing deterministically.
- not a broker-availability issue: reproduces with a reachable broker; the skip check works.
- fix: wait on `/api/state?jq=.apiReady|select(.)` (200 only when apiReady is true) via `http-get` (GET, not HEAD).

Supersedes the local-broker approach (#30923); keeps the existing public broker.