### PR TITLE
chore: surface Claude Code Review result as a PR commit status

### DIFF
--- a/.github/workflows/claude-code-review-run.yml
+++ b/.github/workflows/claude-code-review-run.yml
@@ -69,10 +69,28 @@ jobs:
       pull-requests: write # post the review on the PR
       issues: read
       id-token: write
+      statuses: write # mirror the review result onto the PR head commit
     concurrency:
       group: claude-review-run-${{ needs.gate.outputs.number }}
       cancel-in-progress: true
     steps:
+      # workflow_run runs are detached and never show up in the PR's checks, so
+      # publish a commit status on the PR head SHA. This surfaces a "Claude Code
+      # Review" check next to the regular CI jobs.
+      - name: Report review pending
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              context: 'Claude Code Review',
+              state: 'pending',
+              description: 'Review in progress',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
       # Default checkout (base ref) only — do NOT check out the untrusted PR head.
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -80,6 +98,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        id: review
+        continue-on-error: true # always report status below, even on failure
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -96,3 +116,22 @@ jobs:
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ needs.gate.outputs.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Report review result
+        if: always()
+        env:
+          OUTCOME: ${{ steps.review.outcome }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ok = process.env.OUTCOME === 'success';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              context: 'Claude Code Review',
+              state: ok ? 'success' : 'failure',
+              description: ok ? 'Review complete' : 'Review failed',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+            if (!ok) core.setFailed('Claude Code Review failed');

--- a/.github/workflows/claude-code-review-run.yml
+++ b/.github/workflows/claude-code-review-run.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Check for PR-number artifact
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         with:
           script: |
             const { data } = await github.rest.actions.listWorkflowRunArtifacts({
@@ -42,7 +42,7 @@ jobs:
 
       - name: Download PR number
         if: steps.check.outputs.found == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: pr-number
           run-id: ${{ github.event.workflow_run.id }}
@@ -78,7 +78,7 @@ jobs:
       # publish a commit status on the PR head SHA. This surfaces a "Claude Code
       # Review" check next to the regular CI jobs.
       - name: Report review pending
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -93,7 +93,7 @@ jobs:
 
       # Default checkout (base ref) only — do NOT check out the untrusted PR head.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           fetch-depth: 1
 
@@ -121,7 +121,7 @@ jobs:
         if: always()
         env:
           OUTCOME: ${{ steps.review.outcome }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         with:
           script: |
             const ok = process.env.OUTCOME === 'success';


### PR DESCRIPTION
Follow-up to #30930. The Claude Code review runs in the privileged `Claude Code Review (run)` workflow via `workflow_run`. Those runs are **detached** — GitHub does not attach `workflow_run` runs to the originating PR — so the review’s pass/fail never appeared in the PR’s checks list (only stage-1 `prepare` showed up).

This mirrors the result back onto the PR by publishing a commit status on the PR head SHA:

- **pending** `Claude Code Review` status before the review starts,
- **success** / **failure** after it finishes, linked to the run.

The review step now uses `continue-on-error` so the status is reported even when the review fails, and the job is then marked failed via `core.setFailed`. Adds `statuses: write` to the job permissions.

Result: a `Claude Code Review` check shows up next to Build / Test / Lint on every PR, including forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)