### PR TITLE
Vehicle: add autodetectdisabled feature

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -4,17 +4,18 @@ type Feature int
 
 //go:generate go tool enumer -type Feature -text
 const (
-	_                Feature = iota
-	CoarseCurrent            // charger
-	IntegratedDevice         // charger - always connected - no vehicle, no charging sessions
-	SwitchDevice             // charger - no current control - heat pumps or switch sockets
-	Heating                  // charger - heating device - soc ist temperature (°C)
-	Continuous               // charger - heating device where disabled means "normal operation"
-	Average                  // tariff
-	Cacheable                // tariff
-	Offline                  // vehicle
-	Retryable                // vehicle
-	Streaming                // vehicle
-	WelcomeCharge            // vehicle
-	ClimaterDisabled         // vehicle - ignore climater state for charge control
+	_                  Feature = iota
+	CoarseCurrent              // charger
+	IntegratedDevice           // charger - always connected - no vehicle, no charging sessions
+	SwitchDevice               // charger - no current control - heat pumps or switch sockets
+	Heating                    // charger - heating device - soc ist temperature (°C)
+	Continuous                 // charger - heating device where disabled means "normal operation"
+	Average                    // tariff
+	Cacheable                  // tariff
+	Offline                    // vehicle
+	Retryable                  // vehicle
+	Streaming                  // vehicle
+	WelcomeCharge              // vehicle
+	ClimaterDisabled           // vehicle - ignore climater state for charge control
+	AutodetectDisabled         // vehicle - do not try to identify vehicle by status
 )

--- a/api/feature_enumer.go
+++ b/api/feature_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _FeatureName = "CoarseCurrentIntegratedDeviceSwitchDeviceHeatingContinuousAverageCacheableOfflineRetryableStreamingWelcomeChargeClimaterDisabled"
+const _FeatureName = "CoarseCurrentIntegratedDeviceSwitchDeviceHeatingContinuousAverageCacheableOfflineRetryableStreamingWelcomeChargeClimaterDisabledAutodetectDisabled"
 
-var _FeatureIndex = [...]uint8{0, 13, 29, 41, 48, 58, 65, 74, 81, 90, 99, 112, 128}
+var _FeatureIndex = [...]uint8{0, 13, 29, 41, 48, 58, 65, 74, 81, 90, 99, 112, 128, 146}
 
-const _FeatureLowerName = "coarsecurrentintegrateddeviceswitchdeviceheatingcontinuousaveragecacheableofflineretryablestreamingwelcomechargeclimaterdisabled"
+const _FeatureLowerName = "coarsecurrentintegrateddeviceswitchdeviceheatingcontinuousaveragecacheableofflineretryablestreamingwelcomechargeclimaterdisabledautodetectdisabled"
 
 func (i Feature) String() string {
 	i -= 1
@@ -37,9 +37,10 @@ func _FeatureNoOp() {
 	_ = x[Streaming-(10)]
 	_ = x[WelcomeCharge-(11)]
 	_ = x[ClimaterDisabled-(12)]
+	_ = x[AutodetectDisabled-(13)]
 }
 
-var _FeatureValues = []Feature{CoarseCurrent, IntegratedDevice, SwitchDevice, Heating, Continuous, Average, Cacheable, Offline, Retryable, Streaming, WelcomeCharge, ClimaterDisabled}
+var _FeatureValues = []Feature{CoarseCurrent, IntegratedDevice, SwitchDevice, Heating, Continuous, Average, Cacheable, Offline, Retryable, Streaming, WelcomeCharge, ClimaterDisabled, AutodetectDisabled}
 
 var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureName[0:13]:         CoarseCurrent,
@@ -66,6 +67,8 @@ var _FeatureNameToValueMap = map[string]Feature{
 	_FeatureLowerName[99:112]:  WelcomeCharge,
 	_FeatureName[112:128]:      ClimaterDisabled,
 	_FeatureLowerName[112:128]: ClimaterDisabled,
+	_FeatureName[128:146]:      AutodetectDisabled,
+	_FeatureLowerName[128:146]: AutodetectDisabled,
 }
 
 var _FeatureNames = []string{
@@ -81,6 +84,7 @@ var _FeatureNames = []string{
 	_FeatureName[90:99],
 	_FeatureName[99:112],
 	_FeatureName[112:128],
+	_FeatureName[128:146],
 }
 
 // FeatureString retrieves an enum value from the enum constants string name.

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/evcc-io/evcc/api"
@@ -116,7 +117,7 @@ func (c *Coordinator) availableDetectibleVehicles(owner loadpoint.API) []api.Veh
 
 	for _, vv := range c.vehicles {
 		// status api available
-		if api.HasCap[api.ChargeState](vv) {
+		if api.HasCap[api.ChargeState](vv) && !slices.Contains(vv.Features(), api.AutodetectDisabled) {
 			// available or associated to current loadpoint
 			if o, ok := c.tracked[vv]; o == owner || !ok {
 				res = append(res, vv)

--- a/core/coordinator/coordinator_test.go
+++ b/core/coordinator/coordinator_test.go
@@ -22,27 +22,23 @@ func TestVehicleDetectByStatus(t *testing.T) {
 
 	type testcase struct {
 		string
-		v1, v2                      api.ChargeStatus
-		v2ExcludedFromAutoDiscovery bool
-		res                         api.Vehicle
+		v1, v2 api.ChargeStatus
+		res    api.Vehicle
 	}
 	tc := []testcase{
-		{"A/A, v2 not excluded from AutoDiscovery ->0", api.StatusA, api.StatusA, false, nil},
-		{"B/A, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusA, false, v1},
-		{"B/A, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusA, false, v1},
-		{"A/B, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, false, v2},
-		{"A/B, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, false, v2},
-		{"A/B, v2     excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, true, nil},
-		{"A/B, v2     excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, true, nil},
-		{"A/C, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusC, false, v2},
-		{"A/C, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusC, false, v2},
-		{"B/B, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusB, false, nil},
-		{"B/B, v2     excluded from AutoDiscovery ->1", api.StatusB, api.StatusB, true, v1},
-		{"B/C, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusC, false, v1},
-		{"B/C, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusC, false, v1},
-		{"C/B, v2 not excluded from AutoDiscovery ->2", api.StatusC, api.StatusB, false, v2},
-		{"C/B, v2 not excluded from AutoDiscovery ->2", api.StatusC, api.StatusB, false, v2},
-		{"C/C, v2 not excluded from AutoDiscovery ->1", api.StatusC, api.StatusC, false, nil},
+		{"A/A->0", api.StatusA, api.StatusA, nil},
+		{"B/A->1", api.StatusB, api.StatusA, v1},
+		{"B/A->1", api.StatusB, api.StatusA, v1},
+		{"A/B->2", api.StatusA, api.StatusB, v2},
+		{"A/B->2", api.StatusA, api.StatusB, v2},
+		{"A/C->2", api.StatusA, api.StatusC, v2},
+		{"A/C->2", api.StatusA, api.StatusC, v2},
+		{"B/B->1", api.StatusB, api.StatusB, nil},
+		{"B/C->1", api.StatusB, api.StatusC, v1},
+		{"B/C->1", api.StatusB, api.StatusC, v1},
+		{"C/B->2", api.StatusC, api.StatusB, v2},
+		{"C/B->2", api.StatusC, api.StatusB, v2},
+		{"C/C->1", api.StatusC, api.StatusC, nil},
 	}
 
 	log := util.NewLogger("foo")
@@ -53,6 +49,7 @@ func TestVehicleDetectByStatus(t *testing.T) {
 	v1.MockVehicle.EXPECT().Identifiers().Return(nil).AnyTimes()
 	v2.MockVehicle.EXPECT().Identifiers().Return([]string{"it's me"}).AnyTimes()
 	v1.MockVehicle.EXPECT().Features().Return(nil).AnyTimes()
+	v2.MockVehicle.EXPECT().Features().Return(nil).AnyTimes()
 
 	var lp loadpoint.API
 	c := New(log, vehicles)
@@ -61,12 +58,7 @@ func TestVehicleDetectByStatus(t *testing.T) {
 		t.Logf("%+v", tc)
 
 		v1.MockChargeState.EXPECT().Status().Return(tc.v1, nil)
-		if tc.v2ExcludedFromAutoDiscovery {
-			v2.MockVehicle.EXPECT().Features().Return([]api.Feature{api.AutodetectDisabled})
-		} else {
-			v2.MockVehicle.EXPECT().Features().Return(nil)
-			v2.MockChargeState.EXPECT().Status().Return(tc.v2, nil)
-		}
+		v2.MockChargeState.EXPECT().Status().Return(tc.v2, nil)
 
 		available := c.availableDetectibleVehicles(lp) // include id-able vehicles
 		res := c.identifyVehicleByStatus(available, api.StatusB)

--- a/core/coordinator/coordinator_test.go
+++ b/core/coordinator/coordinator_test.go
@@ -22,23 +22,27 @@ func TestVehicleDetectByStatus(t *testing.T) {
 
 	type testcase struct {
 		string
-		v1, v2 api.ChargeStatus
-		res    api.Vehicle
+		v1, v2                      api.ChargeStatus
+		v2ExcludedFromAutoDiscovery bool
+		res                         api.Vehicle
 	}
 	tc := []testcase{
-		{"A/A->0", api.StatusA, api.StatusA, nil},
-		{"B/A->1", api.StatusB, api.StatusA, v1},
-		{"B/A->1", api.StatusB, api.StatusA, v1},
-		{"A/B->2", api.StatusA, api.StatusB, v2},
-		{"A/B->2", api.StatusA, api.StatusB, v2},
-		{"A/C->2", api.StatusA, api.StatusC, v2},
-		{"A/C->2", api.StatusA, api.StatusC, v2},
-		{"B/B->1", api.StatusB, api.StatusB, nil},
-		{"B/C->1", api.StatusB, api.StatusC, v1},
-		{"B/C->1", api.StatusB, api.StatusC, v1},
-		{"C/B->2", api.StatusC, api.StatusB, v2},
-		{"C/B->2", api.StatusC, api.StatusB, v2},
-		{"C/C->1", api.StatusC, api.StatusC, nil},
+		{"A/A, v2 not excluded from AutoDiscovery ->0", api.StatusA, api.StatusA, false, nil},
+		{"B/A, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusA, false, v1},
+		{"B/A, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusA, false, v1},
+		{"A/B, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, false, v2},
+		{"A/B, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, false, v2},
+		{"A/B, v2     excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, true, nil},
+		{"A/B, v2     excluded from AutoDiscovery ->2", api.StatusA, api.StatusB, true, nil},
+		{"A/C, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusC, false, v2},
+		{"A/C, v2 not excluded from AutoDiscovery ->2", api.StatusA, api.StatusC, false, v2},
+		{"B/B, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusB, false, nil},
+		{"B/B, v2     excluded from AutoDiscovery ->1", api.StatusB, api.StatusB, true, v1},
+		{"B/C, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusC, false, v1},
+		{"B/C, v2 not excluded from AutoDiscovery ->1", api.StatusB, api.StatusC, false, v1},
+		{"C/B, v2 not excluded from AutoDiscovery ->2", api.StatusC, api.StatusB, false, v2},
+		{"C/B, v2 not excluded from AutoDiscovery ->2", api.StatusC, api.StatusB, false, v2},
+		{"C/C, v2 not excluded from AutoDiscovery ->1", api.StatusC, api.StatusC, false, nil},
 	}
 
 	log := util.NewLogger("foo")
@@ -48,6 +52,7 @@ func TestVehicleDetectByStatus(t *testing.T) {
 	v2.MockVehicle.EXPECT().GetTitle().Return("v2").AnyTimes()
 	v1.MockVehicle.EXPECT().Identifiers().Return(nil).AnyTimes()
 	v2.MockVehicle.EXPECT().Identifiers().Return([]string{"it's me"}).AnyTimes()
+	v1.MockVehicle.EXPECT().Features().Return(nil).AnyTimes()
 
 	var lp loadpoint.API
 	c := New(log, vehicles)
@@ -56,7 +61,12 @@ func TestVehicleDetectByStatus(t *testing.T) {
 		t.Logf("%+v", tc)
 
 		v1.MockChargeState.EXPECT().Status().Return(tc.v1, nil)
-		v2.MockChargeState.EXPECT().Status().Return(tc.v2, nil)
+		if tc.v2ExcludedFromAutoDiscovery {
+			v2.MockVehicle.EXPECT().Features().Return([]api.Feature{api.AutodetectDisabled})
+		} else {
+			v2.MockVehicle.EXPECT().Features().Return(nil)
+			v2.MockChargeState.EXPECT().Status().Return(tc.v2, nil)
+		}
 
 		available := c.availableDetectibleVehicles(lp) // include id-able vehicles
 		res := c.identifyVehicleByStatus(available, api.StatusB)

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -329,6 +329,14 @@ params:
     help:
       en: Ignore the vehicle's climater state for charge control, so charging stops at the SoC or energy limit even when the vehicle signals an active climater request.
       de: Klimatisierungsstatus des Fahrzeugs für die Ladesteuerung ignorieren, sodass der Ladevorgang am SoC- oder Energielimit endet, auch wenn das Fahrzeug einen aktiven Klimatisierungswunsch signalisiert.
+  - name: autodetectdisabled
+    type: bool
+    description:
+      en: Exclude from auto discovery
+      de: Von automatischer Erkennung ausschließen
+    help:
+      en: Ignore the vehicle for auto discovery of connected vehicles
+      de: Das Fahrzeug von der automatischen Erkennung beim Anschließen eines Fahrzeugs ausschließen
   - name: heating
     type: bool
     description:
@@ -589,6 +597,8 @@ presets:
     - name: welcomecharge
       advanced: true
     - name: climaterdisabled
+      advanced: true
+    - name: autodetectdisabled
       advanced: true
   vehicle-climater:
     - name: climaterdisabled

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -332,10 +332,10 @@ params:
   - name: autodetectdisabled
     type: bool
     description:
-      en: Exclude from auto discovery
+      en: Exclude from auto detection
       de: Von automatischer Erkennung ausschließen
     help:
-      en: Ignore the vehicle for auto discovery of connected vehicles
+      en: Ignore the vehicle for auto detection of connected vehicles
       de: Das Fahrzeug von der automatischen Erkennung beim Anschließen eines Fahrzeugs ausschließen
   - name: heating
     type: bool

--- a/util/templates/includes/vehicle-features.tpl
+++ b/util/templates/includes/vehicle-features.tpl
@@ -1,5 +1,5 @@
 {{ define "vehicle-features" }}
-{{- if or .basefeatures (eq .coarsecurrent "true") (eq .welcomecharge "true") (eq .streaming "true") (eq .climaterdisabled "true") }}
+{{- if or .basefeatures (eq .coarsecurrent "true") (eq .welcomecharge "true") (eq .streaming "true") (eq .climaterdisabled "true") (eq .autodetectdisabled "true") }}
 features:
 {{- range .basefeatures }}
 - {{ . }}
@@ -15,6 +15,9 @@ features:
 {{- end }}
 {{- if eq .climaterdisabled "true" }}
 - climaterdisabled
+{{- end }}
+{{- if eq .autodetectdisabled "true" }}
+- autodetectdisabled
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
fixes #21701
replaces #29592

Adds a autodetectdisabled vehicle feature that makes evcc ignore the vehicle for the autodetection of new connected vehicles. Helpful e.g if a vehicle is charging only seldom at the managed site but often at other places.