### PR TITLE
drivesomethinggreater: debug warnings for stale portal data

### DIFF
--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -37,6 +37,7 @@ func NewProvider(log *util.Logger, api *API, vin string, cache time.Duration) *P
 	var cached util.Cacheable[map[string]point]
 	cached = util.ResettableCached(func() (map[string]point, error) {
 		ts, err := s.update(log.TRACE, vin)
+		s.recordResult(vin, err)
 		if err != nil {
 			log.ERROR.Println(err)
 		} else if !ts.IsZero() {

--- a/vehicle/vw/eudataact/store.go
+++ b/vehicle/vw/eudataact/store.go
@@ -15,6 +15,11 @@ import (
 // on the first poll of a session to seed the merged map.
 const maxBackfill = 8
 
+const (
+	staleThreshold    = 2 * time.Hour
+	staleErrThreshold = 3
+)
+
 // store holds the merged dataset state for all vehicles of a single portal
 // account consisting of username and brand
 type store struct {
@@ -30,6 +35,7 @@ type vehicleState struct {
 	data       map[string]point
 	after      time.Time
 	seq        uint64 // delivery counter, incremented per merged dataset
+	errCount   int    // consecutive update errors
 }
 
 var (
@@ -103,6 +109,12 @@ func (s *store) update(log *log.Logger, vin string) (time.Time, error) {
 	for _, d := range list {
 		if d.CreatedOn.After(newest) {
 			newest = d.CreatedOn
+		}
+	}
+
+	if !newest.IsZero() {
+		if age := time.Since(newest); age > staleThreshold {
+			s.api.log.DEBUG.Printf("data may be stale: newest dataset is %v old", age.Round(time.Minute))
 		}
 	}
 
@@ -187,6 +199,24 @@ func pending(content []dataset, after time.Time) []dataset {
 	}
 
 	return res
+}
+
+// recordResult tracks consecutive update errors for vin and logs a DEBUG
+// warning when the count reaches staleErrThreshold. Resets to zero on success.
+func (s *store) recordResult(vin string, err error) {
+	v := s.state(vin)
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if err != nil {
+		v.errCount++
+		if v.errCount == staleErrThreshold {
+			s.api.log.DEBUG.Printf("update failed %d times in a row, data may be stale", v.errCount)
+		}
+	} else {
+		v.errCount = 0
+	}
 }
 
 // merge lets src (the newer dataset) win per field and stamps each field with


### PR DESCRIPTION
The DriveSomethingGreater EU Data Act portal delivers datasets (when configured) at 15 minutes intervals, but the data seems awefully often stale. There is no new data available or the data given is old and therefore data displayd is old.

There are several issues being submitted due to this as there is no indication that anything is wrong.

Solution:
Two independent DEBUG-level triggers added to store.go:
- **Timestamp**: logs once per poll cycle if the newest dataset on the
  portal is older than 2 hours (`staleThreshold`). Skipped silently if
  the dataset carries no timestamp (some data export versions omit it).
- **Consecutive failures**: logs once when update errors reach 3 in a
  row (`staleErrThreshold`). No alteration to the possible error handling of network errors etc.

It could be argued that the output should be WARN-level.