### PR TITLE
EU Data Act: remove stray trace dump of raw dataset bytes

### DIFF
--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -36,7 +36,7 @@ func NewProvider(log *util.Logger, api *API, vin string, cache time.Duration) *P
 
 	var cached util.Cacheable[map[string]point]
 	cached = util.ResettableCached(func() (map[string]point, error) {
-		ts, err := s.update(log.TRACE, vin)
+		ts, err := s.update(vin)
 		if err != nil {
 			log.ERROR.Println(err)
 		} else if !ts.IsZero() {

--- a/vehicle/vw/eudataact/store.go
+++ b/vehicle/vw/eudataact/store.go
@@ -1,7 +1,6 @@
 package eudataact
 
 import (
-	"log"
 	"maps"
 	"slices"
 	"sync"
@@ -75,7 +74,7 @@ func (s *store) state(vin string) *vehicleState {
 // merged and merges them into the vehicle's map oldest to newest. It returns the
 // newest dataset's delivery time (used to schedule the next poll).
 // On first poll latest maxBackfill content datasets are downloaded.
-func (s *store) update(log *log.Logger, vin string) (time.Time, error) {
+func (s *store) update(vin string) (time.Time, error) {
 	v := s.state(vin)
 
 	v.mu.Lock()
@@ -117,7 +116,7 @@ func (s *store) update(log *log.Logger, vin string) (time.Time, error) {
 			return newest, err
 		}
 
-		data, err := parseDataset(log, b)
+		data, err := parseDataset(b)
 		if err != nil {
 			return newest, err
 		}

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"log"
 	"slices"
 	"strings"
 	"time"
@@ -168,7 +167,7 @@ func contentDatasets(list []dataset) ([]dataset, error) {
 // data field name. On duplicate field names the entry with the newest timestamp
 // wins. The VIN is returned so the caller can drop datasets that do not belong
 // to the requested vehicle.
-func parseDataset(log *log.Logger, b []byte) (map[string]point, error) {
+func parseDataset(b []byte) (map[string]point, error) {
 	zr, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
 	if err != nil {
 		return nil, err
@@ -195,8 +194,6 @@ func parseDataset(log *log.Logger, b []byte) (map[string]point, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	log.Println(raw)
 
 	var ds datasetFile
 	if err := json.Unmarshal(raw, &ds); err != nil {


### PR DESCRIPTION
When running with `--log trace --log-headers`, the EU Data Act provider dumped the unzipped dataset as a raw `[]byte` (`log.Println(raw)` in `parseDataset`), printing the decoded archive content as a long decimal byte slice in the trace log.

The HTTP transport already suppresses binary `application/octet-stream` response bodies (`binaryContent` in `util/request/roundtrip.go`), so the only remaining noise was this leftover debug line. Each data point is already logged individually via `logData`, so the dump is redundant.

Removes the stray `log.Println(raw)` and the now-unused `log` parameter threaded through `parseDataset` and `store.update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)