### PR TITLE
Zaptec Go 2: warn on unequal installation phase current

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -156,7 +156,7 @@ func NewZaptec(_ context.Context, user, password, id string, priority bool, pass
 	// 1p->3p only works when all phases are set equal, so warn about an inconsistent setting
 	if err == nil && c.version == zaptec.ZaptecGo2 {
 		if p1, p2, p3 := inst.AvailableCurrentPhase1, inst.AvailableCurrentPhase2, inst.AvailableCurrentPhase3; p2 != p1 || p3 != p1 {
-			c.log.WARN.Printf("installation available current is unequal across phases (%.3gA/%.3gA/%.3gA); phase switching back to 3p requires equal available current on all phases in the Zaptec portal", p1, p2, p3)
+			c.log.WARN.Printf("installation available current is unequal across phases (%.3gA/%.3gA/%.3gA); phase switching back to 3p requires available current on all phases", p1, p2, p3)
 		}
 	}
 

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -147,8 +147,17 @@ func NewZaptec(_ context.Context, user, password, id string, priority bool, pass
 		return nil, err
 	}
 
-	if err := c.testInstallationPermission(); err == nil || c.version == zaptec.ZaptecGo1_Pro {
+	inst, err := c.installation()
+	if err == nil || c.version == zaptec.ZaptecGo1_Pro {
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
+	}
+
+	// the Zaptec Go 2 switches phases via the installation's per-phase available current;
+	// 1p->3p only works when all phases are set equal, so warn about an inconsistent setting
+	if err == nil && c.version == zaptec.ZaptecGo2 {
+		if p1, p2, p3 := inst.AvailableCurrentPhase1, inst.AvailableCurrentPhase2, inst.AvailableCurrentPhase3; p2 != p1 || p3 != p1 {
+			c.log.WARN.Printf("installation available current is unequal across phases (%.3gA/%.3gA/%.3gA); phase switching back to 3p requires equal available current on all phases in the Zaptec portal", p1, p2, p3)
+		}
 	}
 
 	return c, nil
@@ -415,11 +424,13 @@ func (c *Zaptec) Identify() (string, error) {
 	return "", nil
 }
 
-func (c *Zaptec) testInstallationPermission() error {
+func (c *Zaptec) installation() (zaptec.Installation, error) {
 	var res zaptec.Installation
 
 	uri := fmt.Sprintf("%s/api/installation/%s", zaptec.ApiURL, c.instance.InstallationId)
-	return c.GetJSON(uri, &res)
+	err := c.GetJSON(uri, &res)
+
+	return res, err
 }
 
 func (c *Zaptec) installationUpdate(data zaptec.UpdateInstallation) error {

--- a/charger/zaptec/types.go
+++ b/charger/zaptec/types.go
@@ -85,8 +85,11 @@ type SessionPriority struct {
 }
 
 type Installation struct {
-	Id         string  `json:"id"`
-	MaxCurrent float64 `json:"maxCurrent"`
+	Id                     string  `json:"id"`
+	MaxCurrent             float64 `json:"maxCurrent"`
+	AvailableCurrentPhase1 float64 `json:"availableCurrentPhase1"`
+	AvailableCurrentPhase2 float64 `json:"availableCurrentPhase2"`
+	AvailableCurrentPhase3 float64 `json:"availableCurrentPhase3"`
 }
 
 type UpdateInstallation struct {


### PR DESCRIPTION
Follow-up to #30554. On a Zaptec Go 2, evcc switches phases via the installation's `threeToOnePhaseSwitchCurrent`, but a 1p->3p switch only takes effect when the installation provides equal available current on all three phases. Users left in a `16/0/0` state (e.g. by older evcc versions that managed the available current directly) get a silent failure: evcc logs `switched phases: 3p` while the charger stays on a single phase.

This adds a startup warning so the misconfiguration is visible instead of silent.

- On Go 2, fetch the installation's `availableCurrentPhase1/2/3` (the existing installation GET already runs as the permission probe).
- Warn when P2 or P3 differ from P1, covering both the `16/0/0` case and any other unequal setting, while not false-warning on a single-value installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)