### PR TITLE
YamlEditor: fix dark-mode cursor visibility and selection contrast

### DIFF
--- a/assets/js/components/Config/YamlEditor.vue
+++ b/assets/js/components/Config/YamlEditor.vue
@@ -73,7 +73,7 @@ export default {
 	height: 100%;
 	font-size: 13px;
 	background-color: var(--evcc-box);
-	color: var(--bs-body-color);
+	color: var(--evcc-default-text);
 }
 .editor :global(.cm-editor.cm-focused) {
 	outline: none;
@@ -93,11 +93,11 @@ export default {
 	background-color: transparent;
 }
 .editor :global(.cm-cursor) {
-	border-left-color: var(--bs-body-color);
+	border-left-color: var(--evcc-default-text) !important;
 }
 .editor :global(.cm-selectionBackground),
 .editor :global(.cm-focused .cm-selectionBackground) {
-	background-color: var(--evcc-gray-50);
+	background-color: rgba(128, 128, 128, 0.4) !important;
 }
 .editor :global(.cm-errorLine) {
 	background-color: var(--bs-danger) !important;

--- a/assets/js/components/Config/codemirror.ts
+++ b/assets/js/components/Config/codemirror.ts
@@ -1,6 +1,13 @@
 // Separate module so YamlEditor.vue can dynamic-import it, keeping CodeMirror out of the main chunk.
 import { EditorState, Compartment, StateField, StateEffect } from "@codemirror/state";
-import { EditorView, lineNumbers, keymap, Decoration, type DecorationSet } from "@codemirror/view";
+import {
+  EditorView,
+  lineNumbers,
+  keymap,
+  drawSelection,
+  Decoration,
+  type DecorationSet,
+} from "@codemirror/view";
 import {
   indentOnInput,
   foldGutter,
@@ -71,6 +78,7 @@ export function createEditor(opts: EditorOptions): EditorController {
     extensions: [
       lineNumbers(),
       foldGutter(),
+      drawSelection(),
       history(),
       bracketMatching(),
       yaml(),


### PR DESCRIPTION
Fixes #30976

Render caret/selection via `drawSelection()` and theme them: visible cursor and a neutral, readable selection in light and dark.


dark selection
<img width="1011" height="219" alt="dark select" src="https://github.com/user-attachments/assets/332afb8a-4614-4f25-ad28-9a8c7b084e35" />

dark cursor
<img width="990" height="227" alt="dark cursor" src="https://github.com/user-attachments/assets/aa93f5d3-6445-41ee-95f2-73f239700859" />

light selection
<img width="1013" height="236" alt="light select" src="https://github.com/user-attachments/assets/3b6c9695-81d8-42d6-9fda-b6561f1dd84d" />

light cursor
<img width="999" height="244" alt="light cursor" src="https://github.com/user-attachments/assets/9df71346-bbf9-4008-a652-23e592dcbec3" />
