### PR TITLE
History: reload data after backend restart

### DIFF
--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -154,6 +154,7 @@ export default defineComponent({
 		month: { type: Number, default: undefined },
 		year: { type: Number, default: undefined },
 		period: { type: String as PropType<PERIODS>, default: undefined },
+		offline: Boolean,
 	},
 	data() {
 		return {
@@ -340,6 +341,9 @@ export default defineComponent({
 		fetchKey() {
 			this.fetchData();
 		},
+		offline(offline) {
+			if (!offline) this.fetchData();
+		},
 		rawSeries() {
 			// Drop focused entries whose paletteIndex no longer matches any entity
 			// in the new data (e.g. a loadpoint was filtered out after a period
@@ -498,7 +502,7 @@ export default defineComponent({
 				this.displayPeriod = requestPeriod;
 			} catch (e) {
 				console.error("Failed to load energy history", e);
-				this.rawSeries = [];
+				// keep previous data on error
 			} finally {
 				this.loading = false;
 			}

--- a/tests/energy-history.spec.ts
+++ b/tests/energy-history.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page, type Locator } from "@playwright/test";
-import { start, stop, baseUrl } from "./evcc";
+import { start, stop, restart, baseUrl } from "./evcc";
 
 test.use({ baseURL: baseUrl() });
 
@@ -217,5 +217,16 @@ test.describe("consumption breakdown", () => {
     // Unfocus → axis returns to kW range, not stuck on 1000 W cap.
     await kitchen.click();
     await expect.poll(() => yAxis(meterChart)).toEqual(["kW", "0.0", "0.3", "0.6", "0.9", "1.2"]);
+  });
+});
+
+test.describe("reconnect", () => {
+  test("history still shows content after backend restart", async ({ page }) => {
+    await gotoDay(page, 2026, 3, 24);
+    await expect(chart(page, "grid")).toBeVisible();
+
+    await restart();
+
+    await expect(chart(page, "grid")).toBeVisible();
   });
 });


### PR DESCRIPTION
fixes #30968

The history view fetched only on mount and a 15-minute interval, so after a server restart it stayed empty until a manual browser reload.

- refetch when the api becomes available again (`offline` watcher)
- keep existing data on fetch errors instead of clearing the chart
- e2e: history content survives a real backend restart