### PR TITLE
i18n: add Latvian to language selector

### DIFF
--- a/assets/js/i18n.ts
+++ b/assets/js/i18n.ts
@@ -25,6 +25,7 @@ export const LOCALES = {
   ja: ["Japanese", "日本語"],
   lb: ["Luxembourgish", "Lëtzebuergesch"],
   lt: ["Lithuanian", "Lietuvių"],
+  lv: ["Latvian", "Latviešu"],
   nl: ["Dutch", "Nederlands"],
   no: ["Norwegian", "Norsk"],
   pl: ["Polish", "Polski"],


### PR DESCRIPTION
Latvian (`lv.json`) was translated but missing from the language selector. Add it to `LOCALES`.

- show Latvian (Latviešu) in UI language picker