### PR TITLE
Sponsor: send config hash with token verification

### DIFF
--- a/api/proto/auth.proto
+++ b/api/proto/auth.proto
@@ -14,6 +14,7 @@ service Auth {
 
 message AuthRequest {
 	string token = 1;
+	string config_hash = 2;
 }
 
 message AuthReply {

--- a/api/proto/pb/auth.pb.go
+++ b/api/proto/pb/auth.pb.go
@@ -7,13 +7,12 @@
 package pb
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -26,6 +25,7 @@ const (
 type AuthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	ConfigHash    string                 `protobuf:"bytes,2,opt,name=config_hash,json=configHash,proto3" json:"config_hash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -63,6 +63,13 @@ func (*AuthRequest) Descriptor() ([]byte, []int) {
 func (x *AuthRequest) GetToken() string {
 	if x != nil {
 		return x.Token
+	}
+	return ""
+}
+
+func (x *AuthRequest) GetConfigHash() string {
+	if x != nil {
+		return x.ConfigHash
 	}
 	return ""
 }
@@ -363,9 +370,11 @@ var File_proto_auth_proto protoreflect.FileDescriptor
 
 const file_proto_auth_proto_rawDesc = "" +
 	"\n" +
-	"\x10proto/auth.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"#\n" +
+	"\x10proto/auth.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"D\n" +
 	"\vAuthRequest\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\tR\x05token\"\xa7\x01\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12\x1f\n" +
+	"\vconfig_hash\x18\x02 \x01(\tR\n" +
+	"configHash\"\xa7\x01\n" +
 	"\tAuthReply\x12\x1e\n" +
 	"\n" +
 	"authorized\x18\x01 \x01(\bR\n" +

--- a/cmd/confighash.go
+++ b/cmd/confighash.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/evcc-io/evcc/api/globalconfig"
+	"github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/evcc-io/evcc/util/templates"
+)
+
+// deviceKind returns the template name for template devices, otherwise the type
+func deviceKind(typ string, other map[string]any) string {
+	if strings.EqualFold(typ, "template") {
+		for k, v := range other {
+			if strings.EqualFold(k, "template") {
+				if s, ok := v.(string); ok && s != "" {
+					return s
+				}
+			}
+		}
+	}
+	return typ
+}
+
+// dbKinds returns the device kinds configured in the database for a class
+func dbKinds(class templates.Class) []string {
+	if db.Instance == nil {
+		return nil
+	}
+	configs, err := config.ConfigurationsByClass(class)
+	if err != nil {
+		return nil
+	}
+	kinds := make([]string, 0, len(configs))
+	for _, c := range configs {
+		n := c.Named()
+		kinds = append(kinds, deviceKind(n.Type, n.Other))
+	}
+	return kinds
+}
+
+// classKinds collects the sorted device kinds for a class from both the static
+// (yaml) config and the database
+func classKinds(static []config.Named, class templates.Class) []string {
+	kinds := make([]string, 0, len(static))
+	for _, n := range static {
+		kinds = append(kinds, deviceKind(n.Type, n.Other))
+	}
+	kinds = append(kinds, dbKinds(class)...)
+	sort.Strings(kinds)
+	return kinds
+}
+
+// configHash computes a deterministic fingerprint over the number and kind of
+// configured meters, chargers, loadpoints and tariffs
+func configHash(conf *globalconfig.All) string {
+	tariffs := make([]string, 0)
+	for _, t := range []config.Typed{conf.Tariffs.Grid, conf.Tariffs.FeedIn, conf.Tariffs.Co2, conf.Tariffs.Planner} {
+		if t.Type != "" {
+			tariffs = append(tariffs, deviceKind(t.Type, t.Other))
+		}
+	}
+	for _, t := range conf.Tariffs.Solar {
+		if t.Type != "" {
+			tariffs = append(tariffs, deviceKind(t.Type, t.Other))
+		}
+	}
+	tariffs = append(tariffs, dbKinds(templates.Tariff)...)
+	sort.Strings(tariffs)
+
+	data := map[string]any{
+		"meters":     classKinds(conf.Meters, templates.Meter),
+		"chargers":   classKinds(conf.Chargers, templates.Charger),
+		"loadpoints": classKinds(conf.Loadpoints, templates.Loadpoint),
+		"tariffs":    tariffs,
+	}
+
+	b, _ := json.Marshal(data)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/confighash_test.go
+++ b/cmd/confighash_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api/globalconfig"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigHash(t *testing.T) {
+	conf := &globalconfig.All{
+		Meters: []config.Named{
+			{Name: "m1", Type: "template", Other: map[string]any{"template": "sma"}},
+			{Name: "m2", Type: "custom"},
+		},
+		Chargers:   []config.Named{{Name: "c1", Type: "template", Other: map[string]any{"template": "keba"}}},
+		Loadpoints: []config.Named{{Name: "lp1"}},
+		Tariffs:    globalconfig.Tariffs{Grid: config.Typed{Type: "template", Other: map[string]any{"template": "tibber"}}},
+	}
+
+	hash := configHash(conf)
+	assert.NotEmpty(t, hash)
+	assert.Equal(t, hash, configHash(conf), "must be deterministic")
+
+	// order of devices must not change the hash
+	reordered := *conf
+	reordered.Meters = []config.Named{conf.Meters[1], conf.Meters[0]}
+	assert.Equal(t, hash, configHash(&reordered), "must be order-independent")
+
+	// an additional device must change the hash
+	added := *conf
+	added.Chargers = append(append([]config.Named{}, conf.Chargers...), config.Named{Name: "c2", Type: "easee"})
+	assert.NotEqual(t, hash, configHash(&added), "different config must differ")
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -619,6 +619,7 @@ func configureEnvironment(cmd *cobra.Command, conf *globalconfig.All) error {
 
 	// setup sponsorship (allow env override)
 	if err == nil {
+		sponsor.SetConfigHash(configHash(conf))
 		err = wrapErrorWithClass(ClassSponsorship, configureSponsorship(conf.SponsorToken))
 	}
 

--- a/util/sponsor/auth.go
+++ b/util/sponsor/auth.go
@@ -38,7 +38,15 @@ var (
 	mu                            sync.RWMutex
 	Subject, Token, ActivationKey string
 	ExpiresAt                     time.Time
+	configHash                    string // fingerprint of the static configuration
 )
+
+// SetConfigHash sets the static configuration fingerprint sent with token verification.
+func SetConfigHash(hash string) {
+	mu.Lock()
+	defer mu.Unlock()
+	configHash = hash
+}
 
 func machineID() string {
 	return machine.ProtectedID("evcc-sponsor")
@@ -130,7 +138,7 @@ func ConfigureSponsorship(token string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	res, err := client.IsAuthorized(ctx, &pb.AuthRequest{Token: token})
+	res, err := client.IsAuthorized(ctx, &pb.AuthRequest{Token: token, ConfigHash: configHash})
 	if err == nil && res.Authorized {
 		Subject = res.Subject
 		ActivationKey = res.ActivationKey


### PR DESCRIPTION
Include a fingerprint of the static configuration with the sponsor token verification request so sponsorship can be related to the kind of setup in use. The hash is derived only from device kinds and counts, not from any credentials or addresses.

- `configHash` computes a deterministic SHA-256 over the number and kind of configured meters, chargers, loadpoints and tariffs, covering both yaml and database devices (template devices are identified by template name)
- new `config_hash` field on the `AuthRequest` proto, sent in `ConfigureSponsorship`
- `sponsor.SetConfigHash` is called before sponsorship setup in `configureEnvironment`, after the database is available so db-configured devices are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)