### PR TITLE
fix: remove wrong controller finish calls in TestDisableAndEnableAtTargetSoc

### DIFF
--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -429,7 +429,6 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
 	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil)
-	ctrl.Finish()
 
 	t.Log("charging above target - soc deactivates charger")
 	clock.Add(5 * time.Minute)
@@ -438,7 +437,6 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Enable(false).Return(nil)
 	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil)
-	ctrl.Finish()
 
 	t.Log("deactivated charger changes status to B")
 	clock.Add(5 * time.Minute)
@@ -446,14 +444,12 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil)
-	ctrl.Finish()
 
 	t.Log("soc has risen below target - soc update prevented by timer")
 	clock.Add(5 * time.Minute)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil)
-	ctrl.Finish()
 
 	t.Log("soc has fallen below target - soc update timer expired")
 	clock.Add(pollInterval)


### PR DESCRIPTION
From gomock documentation: "Finish checks to see if all the methods that were expected to be called were called. It is not idempotent and therefore can only be invoked once." https://pkg.go.dev/go.uber.org/mock@v0.6.0/gomock#Controller.Finish

errors after the first ctrl.Finish() call are not reported atm without this fix.