### PR TITLE
Smart-hello: add Smart #5 support

### DIFF
--- a/vehicle/smart-hello.go
+++ b/vehicle/smart-hello.go
@@ -57,12 +57,11 @@ func NewSmartHelloFromConfig(other map[string]any) (api.Vehicle, error) {
 	if err != nil {
 		return v, err
 	}
-	cc.VIN = vehicle.VIN
 
 	log.DEBUG.Printf("vehicle %s: series %s, platform %d", vehicle.VIN, vehicle.SeriesCodeVs, vehicle.ProprietaryPlatform)
 	api.SetSeries(vehicle.SeriesCodeVs)
 
-	v.Provider = hello.NewProvider(log, api, cc.VIN, cc.Cache)
+	v.Provider = hello.NewProvider(log, api, vehicle.VIN, cc.Cache)
 
 	return v, nil
 }

--- a/vehicle/smart-hello.go
+++ b/vehicle/smart-hello.go
@@ -51,11 +51,18 @@ func NewSmartHelloFromConfig(other map[string]any) (api.Vehicle, error) {
 
 	api := hello.NewAPI(log, identity)
 
-	cc.VIN, err = ensureVehicle(cc.VIN, api.Vehicles)
-
-	if err == nil {
-		v.Provider = hello.NewProvider(log, api, cc.VIN, cc.Cache)
+	vehicle, err := ensureVehicleEx(cc.VIN, api.Vehicles, func(v hello.Vehicle) (string, error) {
+		return v.VIN, nil
+	})
+	if err != nil {
+		return v, err
 	}
+	cc.VIN = vehicle.VIN
 
-	return v, err
+	log.DEBUG.Printf("vehicle %s: series %s, platform %d", vehicle.VIN, vehicle.SeriesCodeVs, vehicle.ProprietaryPlatform)
+	api.SetSeries(vehicle.SeriesCodeVs)
+
+	v.Provider = hello.NewProvider(log, api, cc.VIN, cc.Cache)
+
+	return v, nil
 }

--- a/vehicle/smart-hello.go
+++ b/vehicle/smart-hello.go
@@ -58,7 +58,6 @@ func NewSmartHelloFromConfig(other map[string]any) (api.Vehicle, error) {
 		return v, err
 	}
 
-	log.DEBUG.Printf("vehicle %s: series %s, platform %d", vehicle.VIN, vehicle.SeriesCodeVs, vehicle.ProprietaryPlatform)
 	api.SetSeries(vehicle.SeriesCodeVs)
 
 	v.Provider = hello.NewProvider(log, api, vehicle.VIN, cc.Cache)

--- a/vehicle/smart/hello/api.go
+++ b/vehicle/smart/hello/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/evcc-io/evcc/util/transport"
-	"github.com/samber/lo"
 )
 
 // https://github.com/TA2k/ioBroker.smart-eq
@@ -19,12 +18,14 @@ import (
 type API struct {
 	*request.Helper
 	identity *Identity
+	baseURI  string
 }
 
 func NewAPI(log *util.Logger, identity *Identity) *API {
 	v := &API{
 		Helper:   request.NewHelper(log),
 		identity: identity,
+		baseURI:  ApiURI,
 	}
 
 	v.Client.Transport = &transport.Decorator{
@@ -55,7 +56,15 @@ func NewAPI(log *util.Logger, identity *Identity) *API {
 	return v
 }
 
-func (v *API) request(method, path string, params url.Values, body io.Reader) (*http.Request, error) {
+// SetSeries selects the API host for the vehicle's platform.
+// Smart #5 (series HY) is served by the V2 host; #1/#3 (HX/HC) use V1.
+func (v *API) SetSeries(series string) {
+	if strings.HasPrefix(series, "HY") {
+		v.baseURI = ApiURIV2
+	}
+}
+
+func (v *API) request(base, method, path string, params url.Values, body io.Reader) (*http.Request, error) {
 	if body != nil {
 		b, err := io.ReadAll(body)
 		if err != nil {
@@ -75,7 +84,7 @@ func (v *API) request(method, path string, params url.Values, body io.Reader) (*
 		body.(*bytes.Reader).Seek(0, io.SeekStart)
 	}
 
-	uri := fmt.Sprintf("%s/%s?%s", ApiURI, strings.TrimPrefix(path, "/"), params.Encode())
+	uri := fmt.Sprintf("%s/%s?%s", base, strings.TrimPrefix(path, "/"), params.Encode())
 	req, err := request.New(method, uri, body, map[string]string{
 		"x-api-signature-nonce": nonce,
 		"x-signature":           sign,
@@ -85,7 +94,7 @@ func (v *API) request(method, path string, params url.Values, body io.Reader) (*
 	return req, err
 }
 
-func (v *API) Vehicles() ([]string, error) {
+func (v *API) Vehicles() ([]Vehicle, error) {
 	var res struct {
 		Code    Int
 		Message string
@@ -105,8 +114,9 @@ func (v *API) Vehicles() ([]string, error) {
 		"userId":        {userID},
 	}
 
+	// vehicle list is fetched on V1 before the platform is known
 	path := "/device-platform/user/vehicle/secure"
-	req, err := v.request(http.MethodGet, path, params, nil)
+	req, err := v.request(ApiURI, http.MethodGet, path, params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -116,11 +126,7 @@ func (v *API) Vehicles() ([]string, error) {
 		return nil, err
 	}
 
-	vehicles := lo.Map(res.Data.List, func(v Vehicle, _ int) string {
-		return v.VIN
-	})
-
-	return vehicles, err
+	return res.Data.List, err
 }
 
 func (v *API) UpdateSession(vin string) error {
@@ -140,7 +146,7 @@ func (v *API) UpdateSession(vin string) error {
 	}
 
 	path := "/device-platform/user/session/update"
-	req, err := v.request(http.MethodPost, path, params, request.MarshalJSON(data))
+	req, err := v.request(v.baseURI, http.MethodPost, path, params, request.MarshalJSON(data))
 	if err != nil {
 		return err
 	}
@@ -181,7 +187,7 @@ func (v *API) Status(vin string) (VehicleStatus, error) {
 	}
 
 	path := "/remote-control/vehicle/status/" + vin
-	req, err := v.request(http.MethodGet, path, params, nil)
+	req, err := v.request(v.baseURI, http.MethodGet, path, params, nil)
 	if err != nil {
 		return VehicleStatus{}, err
 	}

--- a/vehicle/smart/hello/api.go
+++ b/vehicle/smart/hello/api.go
@@ -64,7 +64,7 @@ func (v *API) SetSeries(series string) {
 	}
 }
 
-func (v *API) request(base, method, path string, params url.Values, body io.Reader) (*http.Request, error) {
+func (v *API) request(method, path string, params url.Values, body io.Reader) (*http.Request, error) {
 	if body != nil {
 		b, err := io.ReadAll(body)
 		if err != nil {
@@ -84,7 +84,7 @@ func (v *API) request(base, method, path string, params url.Values, body io.Read
 		body.(*bytes.Reader).Seek(0, io.SeekStart)
 	}
 
-	uri := fmt.Sprintf("%s/%s?%s", base, strings.TrimPrefix(path, "/"), params.Encode())
+	uri := fmt.Sprintf("%s/%s?%s", v.baseURI, strings.TrimPrefix(path, "/"), params.Encode())
 	req, err := request.New(method, uri, body, map[string]string{
 		"x-api-signature-nonce": nonce,
 		"x-signature":           sign,
@@ -114,9 +114,9 @@ func (v *API) Vehicles() ([]Vehicle, error) {
 		"userId":        {userID},
 	}
 
-	// vehicle list is fetched on V1 before the platform is known
+	// vehicle list is fetched on V1: SetSeries runs only after this call
 	path := "/device-platform/user/vehicle/secure"
-	req, err := v.request(ApiURI, http.MethodGet, path, params, nil)
+	req, err := v.request(http.MethodGet, path, params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (v *API) UpdateSession(vin string) error {
 	}
 
 	path := "/device-platform/user/session/update"
-	req, err := v.request(v.baseURI, http.MethodPost, path, params, request.MarshalJSON(data))
+	req, err := v.request(http.MethodPost, path, params, request.MarshalJSON(data))
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (v *API) Status(vin string) (VehicleStatus, error) {
 	}
 
 	path := "/remote-control/vehicle/status/" + vin
-	req, err := v.request(v.baseURI, http.MethodGet, path, params, nil)
+	req, err := v.request(http.MethodGet, path, params, nil)
 	if err != nil {
 		return VehicleStatus{}, err
 	}

--- a/vehicle/smart/hello/const.go
+++ b/vehicle/smart/hello/const.go
@@ -1,8 +1,9 @@
 package hello
 
 const (
-	ApiURI = "https://api.ecloudeu.com"
-	ApiKey = "3_L94eyQ-wvJhWm7Afp1oBhfTGXZArUfSHHW9p9Pncg513hZELXsxCfMWHrF8f5P5a"
+	ApiURI   = "https://api.ecloudeu.com"   // Smart #1/#3 (series HX/HC)
+	ApiURIV2 = "https://apiv2.ecloudeu.com" // Smart #5 (series HY)
+	ApiKey   = "3_L94eyQ-wvJhWm7Afp1oBhfTGXZArUfSHHW9p9Pncg513hZELXsxCfMWHrF8f5P5a"
 
 	appID        = "SmartAPPEU"
 	operatorCode = "SMART"

--- a/vehicle/smart/hello/types.go
+++ b/vehicle/smart/hello/types.go
@@ -50,7 +50,10 @@ type AppToken struct {
 }
 
 type Vehicle struct {
-	VIN string
+	VIN                 string
+	SeriesCodeVs        string `json:"seriesCodeVs"`        // "HC11" (legacy), "HY11" (newer platform)
+	ModelName           string `json:"modelName"`           // e.g. "HY11_EUL_Pro+_RWD_000"
+	ProprietaryPlatform Int    `json:"proprietaryPlatform"` // 0: legacy tsp backend (supported), 1: newer platform (status endpoint returns 8063)
 }
 
 type VehicleStatus struct {


### PR DESCRIPTION
fixes #31014

Smart #5 (series `HY`, `proprietaryPlatform` 1) is served by a separate V2 API host (`apiv2.ecloudeu.com`). The existing provider sent every request to the V1 host (`api.ecloudeu.com`), so `session/update` returned `8063: No vehicle information for this VIN` for #5, breaking all status reads. Smart #1/#3 (series `HX`/`HC`) are unaffected.

Changes:
- capture `seriesCodeVs` / `proprietaryPlatform` from the vehicle list response
- route the per-vehicle `session/update` and status calls to the V2 host for `HY` vehicles
- keep the vehicle list and login bootstrap on V1, where the platform is not yet known

Host routing by series code follows the approach in [pySmartHashtag](https://github.com/DasBasti/pySmartHashtag). Verified with build, vet, lint and the package tests; live verification against a Smart #5 account is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)