### PR TITLE
Energyflow: fix invisible expand icon in dark mode

### DIFF
--- a/assets/js/components/Energyflow/Entry.vue
+++ b/assets/js/components/Energyflow/Entry.vue
@@ -21,7 +21,7 @@
 						<div class="flex-shrink-1 flex-grow-0 d-flex text-truncate">
 							<span class="text-truncate"> {{ name }} </span>
 						</div>
-						<shopicon-regular-arrowdropdown
+						<DropdownIcon
 							class="expand-icon flex-shrink-0 flex-grow-0"
 							:class="{ 'expand-icon--expanded': expanded }"
 						/>
@@ -73,18 +73,18 @@
 import "@h2d2/shopicons/es/regular/powersupply";
 import "@h2d2/shopicons/es/regular/sun";
 import "@h2d2/shopicons/es/regular/home";
-import "@h2d2/shopicons/es/regular/arrowdropdown";
 import Tooltip from "bootstrap/js/dist/tooltip";
 import BatteryIcon from "./BatteryIcon.vue";
 import formatter, { POWER_UNIT } from "@/mixins/formatter";
 import AnimatedNumber from "../Helper/AnimatedNumber.vue";
 import VehicleIcon from "../VehicleIcon";
 import ForecastIcon from "../MaterialIcon/Forecast.vue";
+import DropdownIcon from "../MaterialIcon/Dropdown.vue";
 import { defineComponent, type PropType } from "vue";
 
 export default defineComponent({
 	name: "EnergyflowEntry",
-	components: { BatteryIcon, AnimatedNumber, VehicleIcon, ForecastIcon },
+	components: { BatteryIcon, AnimatedNumber, VehicleIcon, ForecastIcon, DropdownIcon },
 	mixins: [formatter],
 	props: {
 		name: { type: String },


### PR DESCRIPTION
fixes #31006

The expand triangles in the energy flow disappeared in dark mode. The shopicon arrowdropdown SVG ships a hardcoded inline `fill:#000` that overrides the shopicons base `fill: currentColor` rule, so the icon stayed black and vanished on dark backgrounds.

- Replace the shopicon with the existing MaterialIcon Dropdown component (`fill="currentColor"`), already used for the same collapsible pattern.
- Same orientation and rotation, so light mode is unchanged.

<img width="580" height="213" alt="Bildschirmfoto 2026-06-19 um 15 23 06" src="https://github.com/user-attachments/assets/5e6d3e03-fb50-4f1a-9964-3e73267c5e68" />
<img width="579" height="221" alt="Bildschirmfoto 2026-06-19 um 15 22 59" src="https://github.com/user-attachments/assets/6ab3d200-89ba-44e2-b863-2eabe91611a9" />
