### PR TITLE
fixes #31025 http plugin: honor cache when upstream sends no-store/max-age=0

### DIFF
--- a/plugin/http.go
+++ b/plugin/http.go
@@ -110,7 +110,7 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 	}
 
 	if cache > 0 {
-		// remove cache-busting response headers so the configured cache takes effect
+		// remove cache-busting response headers
 		base = &transport.Modifier{
 			Modifier: func(resp *http.Response) error {
 				dropCacheBusting(resp, "Cache-Control")

--- a/plugin/http.go
+++ b/plugin/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -109,11 +110,11 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 	}
 
 	if cache > 0 {
-		// remove no-cache response headers
+		// remove cache-busting response headers so the configured cache takes effect
 		base = &transport.Modifier{
 			Modifier: func(resp *http.Response) error {
-				dropNoCache(resp, "Cache-Control")
-				dropNoCache(resp, "Pragma")
+				dropCacheBusting(resp, "Cache-Control")
+				dropCacheBusting(resp, "Pragma")
 				return nil
 			},
 			Base: base,
@@ -148,21 +149,36 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 	return p
 }
 
-func dropNoCache(resp *http.Response, header string) {
-	if h := resp.Header.Get(header); h != "" {
-		var hh []string
+// dropCacheBusting removes response directives that defeat the cache layer
+// (no-cache, no-store and max-age=0) so a configured cache duration takes effect.
+func dropCacheBusting(resp *http.Response, header string) {
+	h := resp.Header.Get(header)
+	if h == "" {
+		return
+	}
 
-		for h := range strings.SplitSeq(h, ",") {
-			if s := strings.TrimSpace(h); strings.ToLower(s) != "no-cache" {
-				hh = append(hh, s)
+	var hh []string
+
+	for token := range strings.SplitSeq(h, ",") {
+		s := strings.TrimSpace(token)
+
+		name, value, _ := strings.Cut(s, "=")
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case "no-cache", "no-store":
+			continue
+		case "max-age":
+			if v, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && v <= 0 {
+				continue
 			}
 		}
 
-		if len(hh) == 0 {
-			resp.Header.Del(header)
-		} else {
-			resp.Header.Set(header, strings.Join(hh, ", "))
-		}
+		hh = append(hh, s)
+	}
+
+	if len(hh) == 0 {
+		resp.Header.Del(header)
+	} else {
+		resp.Header.Set(header, strings.Join(hh, ", "))
 	}
 }
 

--- a/plugin/http_test.go
+++ b/plugin/http_test.go
@@ -12,14 +12,19 @@ import (
 )
 
 type httpHandler struct {
-	val string
-	req *http.Request
-	cnt int
+	val          string
+	req          *http.Request
+	cnt          int
+	cacheBusting bool
 }
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.req = req
 	h.val = lo.RandomString(16, lo.LettersCharset)
+	if h.cacheBusting {
+		w.Header().Set("Cache-Control", "no-store, no-cache, max-age=0, must-revalidate")
+		w.Header().Set("Pragma", "no-cache")
+	}
 	_, _ = w.Write([]byte(h.val))
 	h.cnt++
 }
@@ -69,6 +74,30 @@ func (suite *httpTestSuite) TestCacheGet() {
 		suite.Require().Equal("/foo/bar?baz=1", suite.h.req.URL.String())
 		suite.Require().Equal(suite.h.val, res)
 		suite.Require().Equal(1, suite.h.cnt)
+	}
+}
+
+func (suite *httpTestSuite) TestCacheGetNoStore() {
+	// upstream sends cache-busting headers, cache must still take effect (#31025)
+	suite.h.cacheBusting = true
+	defer func() { suite.h.cacheBusting = false }()
+
+	uri := suite.srv.URL + "/foo/bar?baz=2"
+	p := NewHTTP(util.NewLogger("foo"), http.MethodGet, uri, false, time.Minute)
+
+	g, err := p.StringGetter()
+	suite.Require().NoError(err)
+
+	suite.h.cnt = 0
+	res, err := g()
+	suite.Require().NoError(err)
+	first := suite.h.cnt
+
+	for range 3 {
+		val, err := g()
+		suite.Require().NoError(err)
+		suite.Require().Equal(res, val)
+		suite.Require().Equal(first, suite.h.cnt)
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/31025

When a `cache:` duration is configured on an `http` plugin source, evcc tries to force caching by stripping cache-busting response headers. The helper only removed the `no-cache` token, so an upstream `Cache-Control: no-store` (or `max-age=0`) still defeated the cache layer and evcc refetched on every `interval` — silently, with no hint that `cache:` had no effect.

`no-store` makes the cache library's `canStore` return `false`, so the response is never stored at all.

`dropCacheBusting` (renamed from `dropNoCache`) now also strips `no-store` and `max-age=0` from the response `Cache-Control`/`Pragma` headers, so the configured cache duration takes effect even when the upstream forbids caching. The request-side `max-age` decorator already governs the effective freshness window.

Added a regression test where the stub upstream replies with `Cache-Control: no-store, no-cache, max-age=0, must-revalidate` + `Pragma: no-cache` and asserts only a single fetch across repeated reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)