### PR TITLE
Config: 404 for status of deleted device

### DIFF
--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -272,6 +272,10 @@ func deviceStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			jsonError(w, http.StatusNotFound, err)
+			return
+		}
 		jsonError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/util/config/handler.go
+++ b/util/config/handler.go
@@ -19,6 +19,8 @@ const (
 	OpDelete Operation = "del"
 )
 
+var ErrNotFound = errors.New("not found")
+
 func (cp *handler[T]) Subscribe(fn func(Operation, Device[T])) {
 	if err := bus.Subscribe(cp.topic, fn); err != nil {
 		panic(err)
@@ -69,7 +71,7 @@ func (cp *handler[T]) Delete(name string) error {
 	}
 	cp.mu.Unlock()
 
-	return fmt.Errorf("not found: %s", name)
+	return fmt.Errorf("%w: %s", ErrNotFound, name)
 }
 
 // ByName provides device by name
@@ -83,5 +85,5 @@ func (cp *handler[T]) ByName(name string) (Device[T], error) {
 		}
 	}
 
-	return nil, fmt.Errorf("not found: %s", name)
+	return nil, fmt.Errorf("%w: %s", ErrNotFound, name)
 }


### PR DESCRIPTION
The config page polls device status on an interval. When a device is deleted mid-cycle, the in-flight status request returned 400 and surfaced as a global error toast.

- return 404 (not 400) for an unknown device, via a new `config.ErrNotFound` sentinel
- the frontend already ignores 404 for status polls, so the stale request resolves quietly