### PR TITLE
Auth: fix OAuth online-status send deadlocking the control loop

### DIFF
--- a/plugin/auth/demo.go
+++ b/plugin/auth/demo.go
@@ -71,9 +71,20 @@ func NewDemo(server, method, redirectUri, secret string) (oauth2.TokenSource, er
 	demoInstance.onlineC = onlineC
 
 	// Send initial auth status
-	demoInstance.onlineC <- false
+	demoInstance.setOnline(false)
 
 	return demoInstance, nil
+}
+
+// setOnline notifies the auth handler without blocking; see OAuth.setOnline.
+func (o *demo) setOnline(online bool) {
+	if o.onlineC == nil {
+		return
+	}
+	select {
+	case o.onlineC <- online:
+	default:
+	}
 }
 
 func (o *demo) Token() (*oauth2.Token, error) {
@@ -116,9 +127,7 @@ func (o *demo) Login(state string) (string, *oauth2.DeviceAuthResponse, error) {
 
 func (o *demo) Logout() error {
 	o.token = nil
-	if o.onlineC != nil {
-		o.onlineC <- false
-	}
+	o.setOnline(false)
 	return nil
 }
 
@@ -136,9 +145,7 @@ func (o *demo) HandleCallback(params url.Values) error {
 	}
 
 	// Notify that authentication succeeded
-	if o.onlineC != nil {
-		o.onlineC <- true
-	}
+	o.setOnline(true)
 
 	return nil
 }

--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -202,20 +202,8 @@ func (o *OAuth) updateToken(token *oauth2.Token) {
 	o.setOnline(token.Valid())
 }
 
-// setOnline notifies the auth handler of the current online state without ever
-// blocking the caller.
-//
-// The online channel is only a signal: the handler re-reads the live state of
-// every provider when it fires (see server/providerauth), so coalescing - i.e.
-// dropping a notification when one is already queued - is lossless.
-//
-// A blocking send here would deadlock: callers such as updateToken/Token hold
-// o.mu, and the handler re-enters this provider via Authenticated() -> Token(),
-// which also takes o.mu. If the handler is momentarily not draining the channel
-// (e.g. startup races or back-pressure on the UI param channel), a blocking
-// send under o.mu wedges the token refresh indefinitely. Because metering and
-// other plugins read through the OAuth http transport on the synchronous site
-// update loop, that single stuck Token() call freezes the whole control loop.
+// setOnline signals the auth handler without blocking; the value is only a
+// wakeup. A blocking send under o.mu would deadlock via Authenticated()->Token().
 func (o *OAuth) setOnline(online bool) {
 	select {
 	case o.onlineC <- online:

--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -146,7 +146,7 @@ func NewOAuth(ctx context.Context, name, device string, oc *oauth2.Config, opts 
 	}
 	o.onlineC = onlineC
 
-	o.onlineC <- token.Valid()
+	o.setOnline(token.Valid())
 
 	// add instance
 	addInstance(o.subject, o)
@@ -172,7 +172,7 @@ func (o *OAuth) Token() (*oauth2.Token, error) {
 		// force logout
 		if strings.Contains(err.Error(), "invalid_") && settings.Exists(o.subject) {
 			o.token = nil
-			o.onlineC <- false
+			o.setOnline(false)
 			settings.Delete(o.subject)
 		}
 
@@ -199,7 +199,28 @@ func (o *OAuth) updateToken(token *oauth2.Token) {
 
 	o.token = token
 
-	o.onlineC <- token.Valid()
+	o.setOnline(token.Valid())
+}
+
+// setOnline notifies the auth handler of the current online state without ever
+// blocking the caller.
+//
+// The online channel is only a signal: the handler re-reads the live state of
+// every provider when it fires (see server/providerauth), so coalescing - i.e.
+// dropping a notification when one is already queued - is lossless.
+//
+// A blocking send here would deadlock: callers such as updateToken/Token hold
+// o.mu, and the handler re-enters this provider via Authenticated() -> Token(),
+// which also takes o.mu. If the handler is momentarily not draining the channel
+// (e.g. startup races or back-pressure on the UI param channel), a blocking
+// send under o.mu wedges the token refresh indefinitely. Because metering and
+// other plugins read through the OAuth http transport on the synchronous site
+// update loop, that single stuck Token() call freezes the whole control loop.
+func (o *OAuth) setOnline(online bool) {
+	select {
+	case o.onlineC <- online:
+	default:
+	}
 }
 
 // HandleCallback implements api.AuthProvider.
@@ -272,7 +293,7 @@ func (o *OAuth) Logout() error {
 	defer o.mu.Unlock()
 
 	o.token = nil
-	o.onlineC <- false
+	o.setOnline(false)
 
 	return nil
 }

--- a/plugin/auth/oauth_test.go
+++ b/plugin/auth/oauth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -31,4 +32,26 @@ func TestOAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, token.Valid())
 	require.Equal(t, 1, storerCalled)
+}
+
+// TestSetOnlineNonBlocking guards against the deadlock where a stalled auth
+// handler (not draining the online channel) wedges a token refresh that holds
+// o.mu, freezing every caller that reads through the OAuth http transport.
+// setOnline must coalesce instead of blocking, even when the buffer is full.
+func TestSetOnlineNonBlocking(t *testing.T) {
+	o := &OAuth{onlineC: make(chan bool, 1)}
+	o.setOnline(true) // fill the buffer; nobody is draining it
+
+	done := make(chan struct{})
+	go func() {
+		o.setOnline(false) // would block forever on a full unbuffered/direct send
+		o.setOnline(true)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("setOnline blocked while the online channel was not drained")
+	}
 }

--- a/plugin/auth/oauth_test.go
+++ b/plugin/auth/oauth_test.go
@@ -34,10 +34,8 @@ func TestOAuth(t *testing.T) {
 	require.Equal(t, 1, storerCalled)
 }
 
-// TestSetOnlineNonBlocking guards against the deadlock where a stalled auth
-// handler (not draining the online channel) wedges a token refresh that holds
-// o.mu, freezing every caller that reads through the OAuth http transport.
-// setOnline must coalesce instead of blocking, even when the buffer is full.
+// TestSetOnlineNonBlocking ensures setOnline coalesces instead of blocking when
+// the channel isn't drained, guarding the token-refresh deadlock.
 func TestSetOnlineNonBlocking(t *testing.T) {
 	o := &OAuth{onlineC: make(chan bool, 1)}
 	o.setOnline(true) // fill the buffer; nobody is draining it

--- a/server/providerauth/providerauth.go
+++ b/server/providerauth/providerauth.go
@@ -52,7 +52,11 @@ func Register(name string, handler api.AuthProvider) (chan<- bool, error) {
 		return nil, err
 	}
 
-	onlineC := make(chan bool)
+	// buffered so providers can signal a status change without blocking; the
+	// value is unused (it is only a signal) and the handler re-reads the live
+	// provider state when it fires, so a coalesced send from the provider is
+	// lossless. See OAuth.setOnline for why a blocking send would deadlock.
+	onlineC := make(chan bool, 1)
 
 	go func() {
 		for range onlineC {

--- a/server/providerauth/providerauth.go
+++ b/server/providerauth/providerauth.go
@@ -52,10 +52,8 @@ func Register(name string, handler api.AuthProvider) (chan<- bool, error) {
 		return nil, err
 	}
 
-	// buffered so providers can signal a status change without blocking; the
-	// value is unused (it is only a signal) and the handler re-reads the live
-	// provider state when it fires, so a coalesced send from the provider is
-	// lossless. See OAuth.setOnline for why a blocking send would deadlock.
+	// buffered + non-blocking send (see OAuth.setOnline): the value is only a
+	// signal and the handler re-reads live state, so coalescing is lossless.
 	onlineC := make(chan bool, 1)
 
 	go func() {


### PR DESCRIPTION
## Problem

The OAuth auth provider can deadlock evcc's **synchronous site update loop**, freezing all metering, PV logic and charging until the process is restarted. The HTTP API stays up (so the docker healthcheck still reports *healthy*), which masks the freeze.

Observed in the wild with a **Home Assistant grid meter** (which authenticates via the OAuth token transport): after a restart the control loop ran exactly one iteration, then hung for ~6 hours straight through the solar peak — no `grid power` updates, no charging — and only recovered on its own later. Repeated restarts re-froze within one second each time.

## Root cause

`OAuth` notifies the auth handler of online-status changes with a **blocking send on an unbuffered channel while holding `o.mu`** — in `updateToken`, the `Token()` force-logout path, `Logout`, and construction:

```go
o.onlineC <- token.Valid()   // blocking send, under o.mu
```

That send can block indefinitely because the consumer chain can stall or re-enter the same lock:

- `server/providerauth` `Handler.run` re-reads provider state by calling `provider.Authenticated()` → `OAuth.Token()`, which re-takes `o.mu`.
- `Handler.run` then forwards to the UI `paramC`, which can back-pressure.
- `updateC` has capacity 1.

If the handler is momentarily not draining `onlineC` (startup race, `paramC` back-pressure, or the re-entrant `Token()` above), the send under `o.mu` never completes → the token refresh never releases `o.mu` → every caller reading through the OAuth HTTP transport blocks. Since meters are polled on the single-threaded site loop, one stuck `Token()` freezes the entire loop.

## Fix

The channel value is only ever used as a **signal** — the forwarder discards it (`for range onlineC`) and `Handler.run` re-reads live provider state — so a coalesced, non-blocking send is lossless.

- Buffer the channel: `make(chan bool, 1)` in `providerauth.Register`.
- Send via a non-blocking `setOnline` helper (`select { case onlineC <- v: default: }`) in both the `OAuth` and `demo` providers, replacing every direct send.

This removes the only blocking operation performed under `o.mu`, so a stalled or re-entrant handler can no longer wedge token handling or the control loop.

## Testing

- `go build ./...` on the changed packages, `go vet`, `gofmt` clean.
- `go test -race ./plugin/auth/` passes, including the existing `TestOAuth`.
- Added `TestSetOnlineNonBlocking`, which fills the buffer and asserts further `setOnline` calls do not block when the channel is not drained (fails on a blocking send, passes with the coalescing helper).