### PR TITLE
EEBus meter: fix nil entity panic on device removal

### DIFF
--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -34,7 +34,7 @@ func (c *EEBus) Connect(connected bool) {
 
 // UseCaseEvent implements the eebus.Device interface
 func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
-	// device/entity removal fires support-update events with a nil entity
+	// deviceremoval fires support-update events with a nil entity
 	if entity == nil {
 		return
 	}

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -34,6 +34,11 @@ func (c *EEBus) Connect(connected bool) {
 
 // UseCaseEvent implements the eebus.Device interface
 func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+	// device/entity removal fires support-update events with a nil entity
+	if entity == nil {
+		return
+	}
+
 	switch event {
 	// Monitoring Appliance
 	case mpc.UseCaseSupportUpdate, mgcp.UseCaseSupportUpdate:


### PR DESCRIPTION
fixes #31040

On shutdown (and any remote EEBus device teardown) the eebus-go stack fires `removeDeviceFromAvailableEntityScenarios`, which publishes a `UseCaseSupportUpdate` event with a nil entity. Once a device was cached, the `||` short-circuit in `maUseCaseSupportUpdate` evaluates `len(entity.Address().Entity)` on that nil entity and panics with a SIGSEGV. The LPC/LPP handlers share the same dereference.

`UseCaseEvent` now returns early when the entity is nil. Stale cached references on real disconnect remain handled by `Connect(false)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)