### PR TITLE
Loadpoint: keep vehicle SoC when re-assigning the same default vehicle

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -162,7 +162,14 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 
 	// re-publish vehicle settings
 	lp.publish(keys.PhasesActive, lp.ActivePhases())
-	lp.unpublishVehicle()
+
+	// only reset published vehicle data when the active vehicle actually changed.
+	// vehicleDefaultOrDetect re-assigns the same default vehicle on every reconnect
+	// to refresh the soc estimator (#27359); zeroing a still-valid soc there makes
+	// vehicleSoc/vehicleRange flap to 0 while charging until the next soc read.
+	if from != to {
+		lp.unpublishVehicle()
+	}
 
 	// publish effective values
 	lp.PublishEffectiveValues()

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -323,6 +323,44 @@ func TestDefaultVehicle(t *testing.T) {
 	assert.Nil(t, lp.vehicle, "expected no vehicle")
 }
 
+// TestReassignActiveVehicleKeepsSoc is a regression test for vehicleSoc dropping to
+// 0 while charging. vehicleDefaultOrDetect re-assigns the already-active default
+// vehicle on every (re)connect so the soc estimator is refreshed for the new session
+// (#27359, #27364). setActiveVehicle unconditionally calls unpublishVehicle, which
+// zeroes vehicleSoc and publishes 0. When the active vehicle does not actually
+// change, a known soc must be preserved - otherwise /api/state and messaging show 0
+// until the next successful soc read, which manifests as the soc flapping to 0 while
+// charging after an evcc restart mid-session.
+func TestReassignActiveVehicleKeepsSoc(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	v := api.NewMockVehicle(ctrl)
+	v.EXPECT().GetTitle().Return("default").AnyTimes()
+	v.EXPECT().Icon().Return("").AnyTimes()
+	v.EXPECT().Capacity().AnyTimes()
+	v.EXPECT().Phases().AnyTimes()
+	v.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
+
+	lp := NewLoadpoint(util.NewLogger("foo"), settings.NewDatabaseSettingsAdapter("foo"))
+	lp.defaultVehicle = v
+
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	// vehicle becomes active and a soc has been read and published
+	lp.setActiveVehicle(v)
+	lp.vehicleSoc = 71
+
+	// same default vehicle re-assigned (e.g. vehicleDefaultOrDetect on reconnect)
+	lp.setActiveVehicle(v)
+	assert.Equal(t, v, lp.vehicle, "expected same vehicle to stay active")
+	assert.Equal(t, 71.0, lp.vehicleSoc, "soc must be preserved when the active vehicle is unchanged")
+
+	// switching the active vehicle must still clear the stale soc
+	lp.setActiveVehicle(nil)
+	assert.Zero(t, lp.vehicleSoc, "soc must be cleared when the vehicle changes")
+}
+
 // integratedDeviceCharger is a minimal charger advertising the IntegratedDevice feature.
 type integratedDeviceCharger struct{}
 


### PR DESCRIPTION
## Problem

A loadpoint with a default `vehicle:` whose SoC is known (e.g. a `teslamate` vehicle reading SoC over MQTT) publishes `vehicleSoc = 0` to `/api/state` (and messaging) **while charging**, even though the per-cycle `vehicle soc: NN%` debug log shows the correct value every cycle. It recovers after a clean physical connect (charger status A→B→C) but gets stuck at `0` after an evcc restart that happens mid-charge. `vehicleRange`/`vehicleOdometer` are zeroed the same way.

## Root cause

`setActiveVehicle()` calls `unpublishVehicle()` **unconditionally** at the end of every invocation, which sets `lp.vehicleSoc = 0` and publishes `0` for soc/range/limit/odometer.

`vehicleDefaultOrDetect()` re-assigns the already-active default vehicle on every reconnect (introduced in #27364 to fix the estimator gradient on reconnect, #27359):

```go
// Always call setActiveVehicle even if defaultVehicle is already active.
// ... resets the estimator's initial values for the new charging session.
lp.setActiveVehicle(lp.defaultVehicle)
```

So when the active vehicle does **not** change, `unpublishVehicle()` still wipes a perfectly valid SoC. `publishSocAndRange()` only repopulates `vehicleSoc` on a cycle where a SoC is actually read, so whenever a same-vehicle re-assign lands without an immediately-following successful read (e.g. the repeated reconnect/`charger out of sync` churn after a mid-charge restart), the published value stays `0`.

## Fix

Only reset the published vehicle data when the active vehicle actually changes (`from != to`). The soc estimator is still rebuilt unconditionally for `v != nil` (lines just above), so the #27359 fresh-estimator-on-reconnect behaviour is unchanged. Switching to a different vehicle — or to none on disconnect — still clears the stale data as before.

```diff
-	lp.unpublishVehicle()
+	if from != to {
+		lp.unpublishVehicle()
+	}
```

This does not touch the vehicle-detection path: with a pinned default vehicle, `vehicleDefaultOrDetect` takes the `defaultVehicle != nil` branch and never runs detection.

## Test

Added `TestReassignActiveVehicleKeepsSoc`, which sets a known `vehicleSoc`, re-assigns the same active vehicle, and asserts the SoC is preserved — then asserts it is still cleared when the vehicle changes. It fails on `master` (`expected 71, actual 0`) and passes with the fix. Full `./core/...` suite passes; `gofmt`/`go vet`/`modernize` clean.

## Reproduction

- Loadpoint with a `teslamate` default vehicle (SoC via MQTT), actively charging.
- Restart evcc while the car is mid-charge.
- `/api/state` `loadpoints[].vehicleSoc` stays `0` while the logs show `vehicle soc: NN%` every cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)