### PR TITLE
fix: keep vehicle coordinator ownership consistent on transfer

### DIFF
--- a/core/coordinator/adapter.go
+++ b/core/coordinator/adapter.go
@@ -32,7 +32,7 @@ func (a *adapter) Acquire(v api.Vehicle) {
 }
 
 func (a *adapter) Release(v api.Vehicle) {
-	a.c.release(v)
+	a.c.release(a.lp, v)
 }
 
 func (a *adapter) IdentifyVehicleByStatus() api.Vehicle {

--- a/core/coordinator/coordinator.go
+++ b/core/coordinator/coordinator.go
@@ -100,11 +100,18 @@ func (c *Coordinator) acquire(owner loadpoint.API, vehicle api.Vehicle) {
 	c.mu.Unlock()
 }
 
-func (c *Coordinator) release(vehicle api.Vehicle) {
+func (c *Coordinator) release(owner loadpoint.API, vehicle api.Vehicle) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	delete(c.tracked, vehicle)
+	// only release if the vehicle is still tracked by the releasing loadpoint.
+	// when a vehicle is transferred to another loadpoint, acquire() defers a
+	// SetVehicle(nil) on the previous owner; that owner's release must not wipe
+	// the entry the new owner just acquired (otherwise the vehicle ends up
+	// untracked and can be assigned to two loadpoints at once).
+	if o, ok := c.tracked[vehicle]; ok && o == owner {
+		delete(c.tracked, vehicle)
+	}
 }
 
 // availableDetectibleVehicles is the list of vehicles that are currently not

--- a/core/coordinator/coordinator_test.go
+++ b/core/coordinator/coordinator_test.go
@@ -69,7 +69,48 @@ func TestVehicleDetectByStatus(t *testing.T) {
 		if res != nil {
 			c.acquire(lp, res)
 		} else {
-			c.release(res)
+			c.release(lp, res)
 		}
+	}
+}
+
+// TestReleaseKeyedByOwner ensures that releasing a vehicle that has since been
+// transferred to another loadpoint does not wipe the new owner's tracking.
+//
+// acquire() transfers a vehicle by deferring SetVehicle(nil) on the previous
+// owner. That previous owner then releases the vehicle it still believes it
+// holds - but the vehicle is now owned by the new loadpoint. A non-owner
+// release must be a no-op, otherwise the vehicle ends up untracked and can be
+// acquired by two loadpoints at once.
+func TestReleaseKeyedByOwner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	v := api.NewMockVehicle(ctrl)
+	v.EXPECT().GetTitle().Return("v").AnyTimes()
+
+	c := New(util.NewLogger("foo"), []api.Vehicle{v})
+
+	lp1 := loadpoint.NewMockAPI(ctrl)
+	lp2 := loadpoint.NewMockAPI(ctrl)
+
+	a1 := NewAdapter(lp1, c)
+	a2 := NewAdapter(lp2, c)
+
+	// model setActiveVehicle(nil): a loadpoint asked to drop its vehicle releases
+	// the vehicle it still holds. lp1 holds v, so its SetVehicle(nil) releases v.
+	lp1.EXPECT().SetVehicle(nil).Do(func(api.Vehicle) { a1.Release(v) }).AnyTimes()
+
+	// lp1 acquires v
+	a1.Acquire(v)
+	if o := c.Owner(v); o != loadpoint.API(lp1) {
+		t.Fatalf("expected v owned by lp1, got %v", o)
+	}
+
+	// lp2 takes v (cross-owner transfer). acquire defers lp1.SetVehicle(nil),
+	// which releases v on lp1's behalf - this must not undo lp2's ownership.
+	a2.Acquire(v)
+
+	if o := c.Owner(v); o != loadpoint.API(lp2) {
+		t.Errorf("v must stay owned by lp2 after transfer, got %v", o)
 	}
 }

--- a/core/loadpoint_coordinator_test.go
+++ b/core/loadpoint_coordinator_test.go
@@ -1,0 +1,160 @@
+package core
+
+import (
+	"testing"
+
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/coordinator"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/util"
+	"go.uber.org/mock/gomock"
+)
+
+// chargeStateVehicle is a vehicle that also reports a charge state, so it is
+// eligible for status-based detection by the coordinator.
+type chargeStateVehicle struct {
+	*api.MockVehicle
+	*api.MockChargeState
+}
+
+func newChargeStateVehicle(ctrl *gomock.Controller, title string, status api.ChargeStatus) *chargeStateVehicle {
+	v := api.NewMockVehicle(ctrl)
+	v.EXPECT().GetTitle().Return(title).AnyTimes()
+	v.EXPECT().Icon().Return("").AnyTimes()
+	v.EXPECT().Capacity().AnyTimes()
+	v.EXPECT().Phases().AnyTimes()
+	v.EXPECT().Features().Return(nil).AnyTimes()
+	v.EXPECT().Identifiers().Return(nil).AnyTimes()
+	v.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
+	v.EXPECT().Soc().Return(0.0, nil).AnyTimes()
+
+	cs := api.NewMockChargeState(ctrl)
+	cs.EXPECT().Status().Return(status, nil).AnyTimes()
+
+	return &chargeStateVehicle{v, cs}
+}
+
+// fixedStatusCharger is a charger reporting a constant status.
+type fixedStatusCharger struct{ status api.ChargeStatus }
+
+func (c *fixedStatusCharger) Status() (api.ChargeStatus, error) { return c.status, nil }
+func (c *fixedStatusCharger) Enabled() (bool, error)            { return true, nil }
+func (c *fixedStatusCharger) Enable(bool) error                 { return nil }
+func (c *fixedStatusCharger) MaxCurrent(int64) error            { return nil }
+
+func newCoordinatedLoadpoint(t *testing.T, clck clock.Clock, charger api.Charger, dflt api.Vehicle) *Loadpoint {
+	t.Helper()
+
+	lp := &Loadpoint{
+		log:            util.NewLogger("lp"),
+		bus:            evbus.New(),
+		clock:          clck,
+		charger:        charger,
+		chargeMeter:    &Null{},
+		chargeRater:    &Null{},
+		chargeTimer:    &Null{},
+		wakeUpTimer:    NewTimer(),
+		minCurrent:     minA,
+		maxCurrent:     maxA,
+		phases:         1,
+		mode:           api.ModeNow,
+		defaultVehicle: dflt,
+	}
+
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	return lp
+}
+
+// TestVehicleCoordinatorNoDoubleAssign is a regression test for the coordinator
+// losing its mutual-exclusion invariant.
+//
+// Setup mirrors the live two-wallbox/two-Tesla report:
+//
+//	LP1: charger status C, configured default vehicle Luna   (Luna charging,   status C)
+//	LP2: charger status B, configured default vehicle Calypso (Calypso idle,    status B)
+//
+// When a loadpoint transiently picks up the other loadpoint's vehicle via
+// status detection ("LP2: Calypso -> Luna" in the live log), the previous
+// owner's deferred SetVehicle(nil) used to wipe the freshly transferred
+// ownership entry (release was not keyed by owner). The vehicle then became
+// untracked, so the next default re-assignment on the original loadpoint
+// re-acquired it without releasing the other loadpoint - leaving the same
+// vehicle active on BOTH loadpoints and the configured default silently lost.
+//
+// The invariants asserted after every step:
+//  1. no single vehicle is active on two loadpoints at once, and
+//  2. a loadpoint never holds a vehicle the coordinator says is owned by a
+//     different loadpoint (i.e. a configured default is never replaced by a
+//     vehicle owned by another loadpoint).
+func TestVehicleCoordinatorNoDoubleAssign(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clck := clock.NewMock()
+
+	luna := newChargeStateVehicle(ctrl, "Luna", api.StatusC)       // charging
+	calypso := newChargeStateVehicle(ctrl, "Calypso", api.StatusB) // connected, idle
+
+	coord := coordinator.New(util.NewLogger("coord"), []api.Vehicle{luna, calypso})
+
+	lp1 := newCoordinatedLoadpoint(t, clck, &fixedStatusCharger{status: api.StatusC}, luna)
+	lp2 := newCoordinatedLoadpoint(t, clck, &fixedStatusCharger{status: api.StatusB}, calypso)
+	lp1.coordinator = coordinator.NewAdapter(lp1, coord)
+	lp2.coordinator = coordinator.NewAdapter(lp2, coord)
+
+	lps := map[*Loadpoint]string{lp1: "LP1", lp2: "LP2"}
+
+	ownerName := func(o loadpoint.API) string {
+		switch o {
+		case nil:
+			return "<untracked>"
+		case loadpoint.API(lp1):
+			return "LP1"
+		case loadpoint.API(lp2):
+			return "LP2"
+		}
+		return "?"
+	}
+
+	assertInvariants := func(label string) {
+		// (1) no shared vehicle across loadpoints
+		if v := lp1.GetVehicle(); v != nil && v == lp2.GetVehicle() {
+			t.Errorf("%s: vehicle %q active on both loadpoints at once", label, v.GetTitle())
+		}
+		// (2) every held vehicle is owned by the holding loadpoint
+		for lp, name := range lps {
+			if v := lp.GetVehicle(); v != nil {
+				if o := coord.Owner(v); o != loadpoint.API(lp) {
+					t.Errorf("%s: %s holds %q but coordinator owner is %s", label, name, v.GetTitle(), ownerName(o))
+				}
+			}
+		}
+	}
+
+	// defaults assigned on connect: Luna -> LP1, Calypso -> LP2
+	lp1.setActiveVehicle(luna)
+	lp2.setActiveVehicle(calypso)
+	assertInvariants("after defaults assigned")
+
+	// transient: LP2 picks up Luna via status detection (live log: "LP2: Calypso -> Luna").
+	// acquire() transfers Luna to LP2 and defers LP1.SetVehicle(nil); the previous
+	// owner LP1 must not wipe LP2's ownership when it releases its now-stale vehicle.
+	lp2.setActiveVehicle(luna)
+	assertInvariants("after LP2 transiently acquires Luna")
+
+	// LP1 re-asserts its configured default Luna on the next cycle (live log:
+	// "LP1: unknown -> Luna"). This must transfer Luna away from LP2, not clone it.
+	for cycle := 0; cycle < 3; cycle++ {
+		lp1.setActiveVehicle(lp1.defaultVehicle)
+		assertInvariants("after LP1 re-asserts default Luna")
+
+		// LP2 only re-detects while it has no vehicle; mirrors the guarded
+		// identifyVehicleByStatus call in the update loop.
+		if lp2.vehicleUnidentified() {
+			lp2.identifyVehicleByStatus()
+		}
+		assertInvariants("after LP2 status detection")
+	}
+}


### PR DESCRIPTION
## Description

Fixes a loss of mutual exclusion in the vehicle coordinator. When two loadpoints each have a configured **default vehicle** and the loadpoints have asymmetric charger status, the same vehicle could end up active on **both** loadpoints at once.

Closes #31068.

### The bug

Observed on a 2-wallbox + 2-Tesla setup (LP1 default = Luna, charging; LP2 default = Calypso, idle):

```
LP1: unknown -> Luna      LP2: unknown -> Calypso     (defaults assigned correctly)
LP1: Luna -> unknown      LP2: Calypso -> Luna        (LP2 picks up Luna)
LP1: unknown -> Luna
```

Steady state: both loadpoints report Luna.

### Root cause (double-assignment)

`Coordinator.release(vehicle)` deleted the tracking entry unconditionally. `acquire` transfers a vehicle by setting `tracked[vehicle] = newOwner` and deferring `SetVehicle(nil)` on the previous owner. That deferred call runs `previousOwner.setActiveVehicle(nil)`, which — because the previous owner still references the transferred vehicle — calls `Release(vehicle)`, deleting the entry `acquire` had just set to the new owner.

The vehicle is then left **untracked** while the new owner still holds it. On the next cycle the original loadpoint re-asserts its default and re-acquires the untracked vehicle cleanly (no transfer away from the new owner) → the same vehicle is active on two loadpoints. The untracked vehicle also defeats the exclusion in `availableDetectibleVehicles`, so status detection can hand an already-owned vehicle to another loadpoint.

### The fix

**Coordinator** — Key `release` by owner and only delete when the vehicle is still tracked by the releasing loadpoint, so a previous owner's stale `SetVehicle(nil)` cannot undo a newer `acquire`. This restores the invariant that every tracked vehicle has exactly one live owner, and re-enables `availableDetectibleVehicles`' exclusion.

The public `coordinator.API` / `loadpoint.API` interfaces are unchanged (only the unexported `release` signature changes), so no mocks need regenerating.

### Tests (repro)

- `TestReleaseKeyedByOwner` (core/coordinator): a non-owner release after a transfer must not untrack the vehicle.
- `TestVehicleCoordinatorNoDoubleAssign` (core): two loadpoints, two `ChargeState`-capable vehicles with asymmetric status (C / B), each with its own configured default. Asserts, after a transient cross-loadpoint transfer, that (1) no single vehicle is active on two loadpoints, and (2) a loadpoint never holds a vehicle owned by another loadpoint.

On stock upstream/master this scenario fails (double-assignment — Luna active on both loadpoints) and passes with the coordinator release fix. `go test ./core/... ./core/coordinator/...` and `go vet ./core/...` are green; `gofmt` clean.

### Note on process

Per CONTRIBUTING I opened #31068 first; there is no prior discussion of this specific defect. Opening this PR for maintainer review — happy to convert it to a draft or move the discussion to #31068 / a Discussion if you'd prefer to align on the approach before merging.
