### PR TITLE
Smart-hello: add SocLimiter support

### DIFF
--- a/vehicle/smart/hello/api.go
+++ b/vehicle/smart/hello/api.go
@@ -212,13 +212,8 @@ func (v *API) SocStatus(vin string) (VehicleSocStatus, error) {
 		Data    VehicleSocStatus
 	}
 
-	userID, err := v.identity.UserID()
-	if err != nil {
-		return VehicleSocStatus{}, err
-	}
-
 	params := url.Values{
-		"userId": {userID},
+		"setting": {"charging"},
 	}
 
 	path := "/remote-control/vehicle/status/soc/" + vin

--- a/vehicle/smart/hello/api.go
+++ b/vehicle/smart/hello/api.go
@@ -199,3 +199,38 @@ func (v *API) Status(vin string) (VehicleStatus, error) {
 
 	return res.Data.VehicleStatus, err
 }
+
+func (v *API) SocStatus(vin string) (VehicleSocStatus, error) {
+	if err := v.UpdateSession(vin); err != nil {
+		return VehicleSocStatus{}, fmt.Errorf("update session failed: %w", err)
+	}
+
+	var res struct {
+		Code    Int
+		Message string
+		Error   Error
+		Data    VehicleSocStatus
+	}
+
+	userID, err := v.identity.UserID()
+	if err != nil {
+		return VehicleSocStatus{}, err
+	}
+
+	params := url.Values{
+		"userId": {userID},
+	}
+
+	path := "/remote-control/vehicle/status/soc/" + vin
+	req, err := v.request(http.MethodGet, path, params, nil)
+	if err != nil {
+		return VehicleSocStatus{}, err
+	}
+
+	err = v.DoJSON(req, &res)
+	if err := responseError(err, res.Code, res.Message, res.Error); err != nil {
+		return VehicleSocStatus{}, err
+	}
+
+	return res.Data, err
+}

--- a/vehicle/smart/hello/provider.go
+++ b/vehicle/smart/hello/provider.go
@@ -86,5 +86,5 @@ var _ api.SocLimiter = (*Provider)(nil)
 // GetLimitSoc implements the api.SocLimiter interface
 func (v *Provider) GetLimitSoc() (int64, error) {
 	res, err := v.socStatusG()
-	return int64(res.VehicleChargingRatioLimit), err
+	return int64(res.Soc) / 10, err
 }

--- a/vehicle/smart/hello/provider.go
+++ b/vehicle/smart/hello/provider.go
@@ -10,13 +10,17 @@ import (
 // https://github.com/TA2k/ioBroker.smart-eq
 
 type Provider struct {
-	statusG func() (VehicleStatus, error)
+	statusG    func() (VehicleStatus, error)
+	socStatusG func() (VehicleSocStatus, error)
 }
 
 func NewProvider(log *util.Logger, api *API, vin string, cache time.Duration) *Provider {
 	v := &Provider{
 		statusG: util.Cached(func() (VehicleStatus, error) {
 			return api.Status(vin)
+		}, cache),
+		socStatusG: util.Cached(func() (VehicleSocStatus, error) {
+			return api.SocStatus(vin)
 		}, cache),
 	}
 
@@ -75,4 +79,12 @@ var _ api.VehicleClimater = (*Provider)(nil)
 func (v *Provider) Climater() (bool, error) {
 	res, err := v.statusG()
 	return bool(res.AdditionalVehicleStatus.ClimateStatus.PreClimateActive || res.AdditionalVehicleStatus.ClimateStatus.Defrost), err
+}
+
+var _ api.SocLimiter = (*Provider)(nil)
+
+// GetLimitSoc implements the api.SocLimiter interface
+func (v *Provider) GetLimitSoc() (int64, error) {
+	res, err := v.socStatusG()
+	return int64(res.VehicleChargingRatioLimit), err
 }

--- a/vehicle/smart/hello/types.go
+++ b/vehicle/smart/hello/types.go
@@ -57,7 +57,7 @@ type Vehicle struct {
 }
 
 type VehicleSocStatus struct {
-	VehicleChargingRatioLimit Int `json:"vehicleChargingRatioLimit"`
+	Soc Int `json:"soc"` // charging target soc in tenths of a percent, e.g. 800 = 80%
 }
 
 type VehicleStatus struct {

--- a/vehicle/smart/hello/types.go
+++ b/vehicle/smart/hello/types.go
@@ -56,6 +56,10 @@ type Vehicle struct {
 	ProprietaryPlatform Int    `json:"proprietaryPlatform"` // 0: legacy tsp backend (supported), 1: newer platform (status endpoint returns 8063)
 }
 
+type VehicleSocStatus struct {
+	VehicleChargingRatioLimit Int `json:"vehicleChargingRatioLimit"`
+}
+
 type VehicleStatus struct {
 	BasicVehicleStatus struct {
 		UsageMode    Int    `json:"usageMode"`    // "0",


### PR DESCRIPTION
Add GetLimitSoc() to the Smart #1/#3 provider, calling the separate `/remote-control/vehicle/status/soc/{vin}` endpoint to retrieve the vehicle-set charging SOC limit.

Closes #31062

Generated with [Claude Code](https://claude.ai/code)