### PR TITLE
GoodWe Hybrid: remove battery mode watchdog

### DIFF
--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -157,77 +157,73 @@ render: |
     scale: 0.1
   {{- end }}
   batterymode:
-    source: watchdog
-    timeout: 30s
-    reset: 1 # reset watchdog on normal
-    set:
-      source: switch
-      switch:
-      - case: 1 # normal
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: sequence
         set:
-          source: sequence
+        - source: const
+          value: 1 # Normal operation mode
           set:
-          - source: const
-            value: 1 # Normal operation mode
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 47511 # EMSPowerMode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 0 # Maximum allowed power from Grid in W. 
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 47512 # EMSPowerSet [0-10000]
-                type: writemultiple
-                encoding: uint16
-      - case: 2 # discharge hold
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47511 # EMSPowerMode
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0 # Maximum allowed power from Grid in W. 
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47512 # EMSPowerSet [0-10000]
+              type: writemultiple
+              encoding: uint16
+    - case: 2 # discharge hold
+      set:
+        source: sequence
         set:
-          source: sequence
+        - source: const
+          value: 2 # EMSPowerMode 2 "Charge-PV"-Mode. If EMSPowerSet=0 only PV is used to charge. Value 6 "Conserve"-Mode can be alternatively used.
           set:
-          - source: const
-            value: 2 # EMSPowerMode 2 "Charge-PV"-Mode. If EMSPowerSet=0 only PV is used to charge. Value 6 "Conserve"-Mode can be alternatively used.
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 47511 # EMSPowerMode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: 0 # Maximum allowed power from Grid in W. If >0 battery will be charged also from Grid in Standby mode.
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 47512 # EMSPowerSet [0-10000]
-                type: writemultiple
-                encoding: uint16
-      - case: 3 # charge
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47511 # EMSPowerMode
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: 0 # Maximum allowed power from Grid in W. If >0 battery will be charged also from Grid in Standby mode.
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47512 # EMSPowerSet [0-10000]
+              type: writemultiple
+              encoding: uint16
+    - case: 3 # charge
+      set:
+        source: sequence
         set:
-          source: sequence
+        - source: const
+          value: 2 # Charge from PV+AC according to the EMSPowerSet below. PV-Preferred. "Import-AC"-Mode (Value: 4) would prefer Grid-Power and reduce PV-Power generated.
           set:
-          - source: const
-            value: 2 # Charge from PV+AC according to the EMSPowerSet below. PV-Preferred. "Import-AC"-Mode (Value: 4) would prefer Grid-Power and reduce PV-Power generated.
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 47511 # EMSPowerMode
-                type: writesingle
-                encoding: uint16
-          - source: const
-            value: {{ .maxchargepower }} # For charge battery mode: Maximum allowed power from Grid in W 
-            set:
-              source: modbus
-              {{- include "modbus" . | indent 12 }}
-              register:
-                address: 47512 # EMSPowerSet [0-10000]
-                type: writemultiple
-                encoding: uint16
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47511 # EMSPowerMode
+              type: writesingle
+              encoding: uint16
+        - source: const
+          value: {{ .maxchargepower }} # For charge battery mode: Maximum allowed power from Grid in W 
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 47512 # EMSPowerSet [0-10000]
+              type: writemultiple
+              encoding: uint16
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
Removes the `watchdog` wrapper (30s timeout, reset-to-normal) around the `batterymode` setter and promotes the inner `switch` to be the batterymode source directly. Pure structural change — the per-mode EMSPowerMode/EMSPowerSet writes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)