### PR TITLE
Volvo Connected: verify vehicle identity against account

### DIFF
--- a/templates/definition/vehicle/volvo-connected.yaml
+++ b/templates/definition/vehicle/volvo-connected.yaml
@@ -49,7 +49,6 @@ params:
     service: auth/redirecturi
   - name: vin
     example: WF0FXX...
-    required: true
   - name: accessToken
     deprecated: true
   - name: refreshToken

--- a/vehicle/volvo-connected.go
+++ b/vehicle/volvo-connected.go
@@ -41,10 +41,6 @@ func NewVolvoConnectedFromConfig(ctx context.Context, other map[string]any) (api
 		return nil, errors.New("missing vccapikey")
 	}
 
-	if cc.VIN == "" {
-		return nil, errors.New("missing vin")
-	}
-
 	if err := cc.Credentials.Error(); err != nil {
 		return nil, err
 	}
@@ -59,10 +55,15 @@ func NewVolvoConnectedFromConfig(ctx context.Context, other map[string]any) (api
 
 	api := connected.NewAPI(log, cc.VccApiKey, ts)
 
+	cc.VIN, err = ensureVehicle(cc.VIN, api.Vehicles)
+
 	v := &VolvoConnected{
-		embed:    &cc.embed,
-		Provider: connected.NewProvider(api, ts, cc.VIN, cc.Cache),
+		embed: &cc.embed,
 	}
 
-	return v, nil
+	if err == nil {
+		v.Provider = connected.NewProvider(api, ts, cc.VIN, cc.Cache)
+	}
+
+	return v, err
 }


### PR DESCRIPTION
The Volvo Connected integration required a `vin` but never verified it, and its `API.Vehicles()` (which lists the account's VINs) was unused.

This wires it into the canonical `ensureVehicle` helper used by fiat, mercedes, nissan and others, which:
- validates the configured VIN actually belongs to the account, and
- auto-selects the vehicle when exactly one exists and no VIN is given.

`vin` therefore becomes optional in the template, consistent with the other vehicles that use this pattern.

`go build ./...`, `go vet`, `gofmt`, `golangci-lint`, `TestTemplates`, and the `vehicle` package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)