### PR TITLE
site statistics: update every 15min instead of hourly

### DIFF
--- a/core/stats.go
+++ b/core/stats.go
@@ -29,7 +29,7 @@ func NewStats() *Stats {
 
 // Update publishes stats based on charging sessions
 func (s *Stats) Update(p publisher) {
-	if time.Since(s.updated) < time.Hour {
+	if time.Since(s.updated) < 15*time.Minute {
 		return
 	}
 


### PR DESCRIPTION
Site charging statistics (`evcc/site/statistics/*`, also the UI) were only recomputed once per hour, while everything else publishes at the configured interval. This made the MQTT `site/statistics/total/*` topics lag noticeably (#31085).

`Stats.Update` self-throttles to avoid running 16 session-table aggregation queries every tick. This lowers that gate from 1h to 15min — a better freshness/cost trade-off without making it user-configurable.

fixes #31085