### PR TITLE
EU Data Act: prefer valid battery_level_HV.value for SoC

### DIFF
--- a/vehicle/vw/eudataact/eudataact_test.go
+++ b/vehicle/vw/eudataact/eudataact_test.go
@@ -142,21 +142,43 @@ func TestSocFreshestField(t *testing.T) {
 	// first datasets carry both SoC fields at 57, the high-priority field winning
 	deliver(map[string]point{
 		FieldBatteryStateReportSoc: {Value: "57"},
-		FieldHvBatteryLevel:        {Value: "57.0"},
+		FieldHvBatteryLevelValue:   {Value: "57.0"},
 	})
 	deliver(map[string]point{
 		FieldBatteryStateReportSoc: {Value: "57"},
-		FieldHvBatteryLevel:        {Value: "57.0"},
+		FieldHvBatteryLevelValue:   {Value: "57.0"},
 	})
 
 	// later datasets only refresh the fallback field as the car charges
 	for _, v := range []string{"58.0", "59.0", "61.0"} {
-		deliver(map[string]point{FieldHvBatteryLevel: {Value: v}})
+		deliver(map[string]point{FieldHvBatteryLevelValue: {Value: v}})
 	}
 
 	soc, err := testProvider(data).Soc()
 	require.NoError(t, err)
 	assert.Equal(t, 61.0, soc, "the still-updating fallback wins over the stale high-priority field")
+}
+
+// TestSocHvBatteryLevelValid reproduces #31084: battery_level_HV.value (74) is
+// preferred over ambiguous battery_state_report.soc (45) only when state is VALID.
+func TestSocHvBatteryLevelValid(t *testing.T) {
+	raw := []dataPoint{
+		{DataFieldName: FieldBatteryStateReportSoc, Value: "74"},
+		{DataFieldName: FieldBatteryStateReportSoc, Value: "45"},
+		{DataFieldName: FieldBatteryStateReportSoc, Value: "45"},
+		{DataFieldName: FieldHvBatteryLevelValue, Value: "74.0"},
+	}
+
+	// without a VALID flag the ambiguous battery_state_report.soc still wins (45)
+	soc, err := testProvider(points(raw)).Soc()
+	require.NoError(t, err)
+	assert.Equal(t, 45.0, soc, "prior behaviour kept when HV level is not flagged valid")
+
+	// with battery_level_HV.state VALID, battery_level_HV.value (74) is preferred
+	valid := append(raw, dataPoint{DataFieldName: FieldHvBatteryLevelState, Value: hvBatteryLevelValid})
+	soc, err = testProvider(points(valid)).Soc()
+	require.NoError(t, err)
+	assert.Equal(t, 74.0, soc, "battery_level_HV.value wins when flagged VALID")
 }
 
 // TestPoints guards that a data point with a generic field name ("value") is

--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -81,7 +81,14 @@ func (v *Provider) Soc() (float64, error) {
 		return 0, err
 	}
 
-	if p := lookup(data, FieldBatteryStateReportSoc, FieldSoc, FieldHvSoc, FieldHvBatteryLevel); p != nil {
+	// prefer battery_level_HV.value when the device flags it valid: a single
+	// dataset can carry conflicting battery_state_report.soc values
+	fields := []string{FieldBatteryStateReportSoc, FieldSoc, FieldHvSoc, FieldHvBatteryLevelValue}
+	if data[FieldHvBatteryLevelState].Value == hvBatteryLevelValid {
+		fields = []string{FieldHvBatteryLevelValue, FieldBatteryStateReportSoc, FieldSoc, FieldHvSoc}
+	}
+
+	if p := lookup(data, fields...); p != nil {
 		return strconv.ParseFloat(p.Value, 64)
 	}
 

--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -81,14 +81,15 @@ func (v *Provider) Soc() (float64, error) {
 		return 0, err
 	}
 
-	// prefer battery_level_HV.value when the device flags it valid: a single
-	// dataset can carry conflicting battery_state_report.soc values
-	fields := []string{FieldBatteryStateReportSoc, FieldSoc, FieldHvSoc, FieldHvBatteryLevelValue}
+	// battery_level_HV.value is authoritative when flagged valid; check it first
+	// as battery_state_report.soc can be ambiguous within a single dataset
 	if data[FieldHvBatteryLevelState].Value == hvBatteryLevelValid {
-		fields = []string{FieldHvBatteryLevelValue, FieldBatteryStateReportSoc, FieldSoc, FieldHvSoc}
+		if p, ok := data[FieldHvBatteryLevelValue]; ok {
+			return strconv.ParseFloat(p.Value, 64)
+		}
 	}
 
-	if p := lookup(data, fields...); p != nil {
+	if p := lookup(data, FieldBatteryStateReportSoc, FieldSoc, FieldHvSoc, FieldHvBatteryLevelValue); p != nil {
 		return strconv.ParseFloat(p.Value, 64)
 	}
 

--- a/vehicle/vw/eudataact/provider.go
+++ b/vehicle/vw/eudataact/provider.go
@@ -81,9 +81,8 @@ func (v *Provider) Soc() (float64, error) {
 		return 0, err
 	}
 
-	// battery_level_HV.value is authoritative when flagged valid; check it first
-	// as battery_state_report.soc can be ambiguous within a single dataset
-	if data[FieldHvBatteryLevelState].Value == hvBatteryLevelValid {
+	// use battery_level_HV.value when its state reports valid
+	if s, ok := data[FieldHvBatteryLevelState]; ok && s.Value == hvBatteryLevelValid {
 		if p, ok := data[FieldHvBatteryLevelValue]; ok {
 			return strconv.ParseFloat(p.Value, 64)
 		}

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -110,7 +110,8 @@ const (
 	FieldBatteryStateReportSoc = "battery_state_report.soc"
 	FieldSoc                   = "state_of_charge"
 	FieldHvSoc                 = "hv_soc"
-	FieldHvBatteryLevel        = "battery_level_HV.value"
+	FieldHvBatteryLevelValue   = "battery_level_HV.value"
+	FieldHvBatteryLevelState   = "battery_level_HV.state"
 
 	// target soc
 	FieldTargetSoc = "settings.target_soc"
@@ -128,6 +129,10 @@ const (
 	// time
 	FieldRemainingTime = "remaining_charging_time"
 )
+
+// hvBatteryLevelValid is the battery_level_HV.state value that marks
+// battery_level_HV.value as a trustworthy SoC reading
+const hvBatteryLevelValid = "VALID"
 
 // knownKeys lists data point GUIDs that are indexed by their key instead of the
 // generic, non-unique DataFieldName they are delivered with


### PR DESCRIPTION
fixes #31084

VW can deliver several conflicting `battery_state_report.soc` values within a single dataset, with nothing indicating which is current (here 74, 45, 45, collapsing to the wrong 45). When the vehicle reports `battery_level_HV.value` and flags `battery_level_HV.state: VALID`, that reading is authoritative, so it is now preferred for SoC. Falls back to the previous priority when the flag is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)