### PR TITLE
Deye-hybrid-3p: introduce shared modbus block reading

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -91,6 +91,9 @@ render: |
       address: 625 # Grid side total power
       type: holding
       decode: int16
+    block: # 588-625
+      register: 588
+      count: 38
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -98,6 +101,9 @@ render: |
       address: 522 # "Total_GridBuy_Power Wh"
       type: holding
       decode: uint32s
+    block: # 516-538
+      register: 516
+      count: 23
     {{- if not .firmware1098 }}
     scale: 0.1
     {{- end }}
@@ -108,6 +114,9 @@ render: |
       address: 524 # "Total_GridSell_Power Wh"
       type: holding
       decode: uint32s
+    block: # 516-538
+      register: 516
+      count: 23
     {{- if not .firmware1098 }}
     scale: 0.1
     {{- end }}
@@ -118,6 +127,9 @@ render: |
         address: 613 # "Out-of-grid - current A"
         type: holding
         decode: int16
+      block: # 588-625
+        register: 588
+        count: 38
       scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -125,6 +137,9 @@ render: |
         address: 614 # "Out-of-grid - current B"
         type: holding
         decode: int16
+      block: # 588-625
+        register: 588
+        count: 38
       scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -132,6 +147,9 @@ render: |
         address: 615 # "Out-of-grid - current C"
         type: holding
         decode: int16
+      block: # 588-625
+        register: 588
+        count: 38
       scale: 0.01
   voltages:
     - source: modbus
@@ -140,6 +158,9 @@ render: |
         address: 598 # Grid voltage L1
         type: holding
         decode: uint16
+      block: # 588-625
+        register: 588
+        count: 38
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -147,6 +168,9 @@ render: |
         address: 599 # Grid voltage L2
         type: holding
         decode: uint16
+      block: # 588-625
+        register: 588
+        count: 38
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -154,6 +178,9 @@ render: |
         address: 600 # Grid voltage L3
         type: holding
         decode: uint16
+      block: # 588-625
+        register: 588
+        count: 38
       scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
@@ -166,6 +193,9 @@ render: |
         address: 672 # "PV1 input power"
         type: holding
         decode: uint16
+      block: # 667-675
+        register: 667
+        count: 9
       {{- if eq .batterytype "hv" }}  
       scale: 10
       {{- end }}
@@ -175,6 +205,9 @@ render: |
         address: 673 # "PV2 input power"
         type: holding
         decode: uint16
+      block: # 667-675
+        register: 667
+        count: 9
       {{- if eq .batterytype "hv" }}  
       scale: 10
       {{- end }}
@@ -184,6 +217,9 @@ render: |
         address: 674 # "PV3 input power"
         type: holding
         decode: uint16
+      block: # 667-675
+        register: 667
+        count: 9
       {{- if eq .batterytype "hv" }}  
       scale: 10
       {{- end }}
@@ -193,6 +229,9 @@ render: |
         address: 675 # "PV4 input power"
         type: holding
         decode: uint16
+      block: # 667-675
+        register: 667
+        count: 9
       {{- if eq .batterytype "hv" }}  
       scale: 10
       {{- end }}
@@ -205,6 +244,9 @@ render: |
         decode: int16 # value is part of a signed 32-bit value; high word is at 671 but non-adjacent
                       # NOTE: Only the low 16 bits of GEN power are used here. This is sufficient up to ±32 kW,
                       # which covers existing inverter variants.
+      block: # 667-675
+        register: 667
+        count: 9
     {{- end }}
   energy:
     source: calc
@@ -215,6 +257,9 @@ render: |
         address: 534 # "Total_PV_Power_Wh"
         type: holding
         decode: uint32s
+      block: # 516-538
+        register: 516
+        count: 23
       {{- if not .firmware1098 }}
       scale: 0.1
       {{- end }}
@@ -225,6 +270,9 @@ render: |
         address: 537 # "Total_Gen_Power_Wh"
         type: holding
         decode: int32s
+      block: # 516-538
+        register: 516
+        count: 23
       {{- if not .firmware1098 }}
       scale: 0.1
       {{- end }}
@@ -244,6 +292,9 @@ render: |
       {{- end }}
       type: holding
       decode: int16
+    block: # 588-625
+      register: 588
+      count: 38
   {{- if eq .batterytype "hv" }}  
     scale: 10
   {{- end }}
@@ -254,6 +305,9 @@ render: |
       address: 518 # "Total discharge of the battery (Wh)"
       type: holding
       decode: uint32s
+    block: # 516-538
+      register: 516
+      count: 23
     {{- if not .firmware1098 }}
     scale: 0.1
     {{- end }}
@@ -264,6 +318,9 @@ render: |
       address: 516 # "Total charge of the battery (Wh)"
       type: holding
       decode: uint32s
+    block: # 516-538
+      register: 516
+      count: 23
     {{- if not .firmware1098 }}
     scale: 0.1
     {{- end }}
@@ -278,6 +335,9 @@ render: |
       {{- end }}
       type: holding
       decode: uint16
+    block: # 588-625
+      register: 588
+      count: 38
   batterymode:
     source: switch
     switch:


### PR DESCRIPTION
In revision 18609ee (#30846) shared modbus block reading was introduced.

This PR implements this feature for deye-hybrid-3p by splitting reads into 3 cached blocks (516-537, 588-625, 667-675).

A single block read is currently not possible as the cache range is limited to 125 registers and we have a span of 160 registers.

Alternatively we could extend the cache to allow reading more registers in one block read.