### PR TITLE
Anker SOLIX X1: fix battery SOC/power register mapping and word order

### DIFF
--- a/templates/definition/meter/anker-solix-x1.yaml
+++ b/templates/definition/meter/anker-solix-x1.yaml
@@ -27,14 +27,14 @@ render: |
     register:
       address: 10644 # Meter Total Active Power (W, positive = import, negative = export)
       type: input
-      decode: int32
+      decode: int32s
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
       address: 10656 # Meter Total Forward Active Energy (kWh)
       type: input
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   powers:
     - source: modbus
@@ -42,19 +42,19 @@ render: |
       register:
         address: 10638 # Meter Phase A Active Power
         type: input
-        decode: int32
+        decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 10640 # Meter Phase B Active Power
         type: input
-        decode: int32
+        decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 10642 # Meter Phase C Active Power
         type: input
-        decode: int32
+        decode: int32s
   currents:
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -107,14 +107,14 @@ render: |
     register:
       address: 10183 # Total PV Power (W)
       type: input
-      decode: int32
+      decode: int32s
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 10026 # Total PV Generation (kWh)
+      address: 10187 # Total PV Generation (kWh)
       type: input
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   maxacpower: {{ .maxacpower }}
   {{- end }}
@@ -123,22 +123,22 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 10006 # Battery Power (W, positive = discharging, negative = charging)
+      address: 10008 # Battery Power (W, positive = discharging, negative = charging)
       type: input
-      decode: int32
+      decode: int32s
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
       address: 10264 # Battery Total Discharge Energy (kWh)
       type: input
-      decode: uint32
+      decode: uint32s
     scale: 0.1
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 10010 # SOC (%)
+      address: 10014 # SOC (%)
       type: input
       decode: uint16
   {{- include "battery-params" . }}


### PR DESCRIPTION
fixes #31101

The Anker SOLIX X1 template decoded all 32-bit values in MSW-first word order, but the inverter returns them LSW-first. Every reported value had a zero low word (e.g. battery `19464192 = 0x01290000`, grid `10878976 = 0x00A60000`), so powers and energies came out scaled by 65536. Switched all `int32`/`uint32` registers to the swapped `int32s`/`uint32s` variants; the 16-bit current/voltage registers were already correct and are unchanged.

Two register addresses were also wrong, verified against the official Modbus protocol doc and the reporter `mbpoll` readings:

- Battery Power was at `10006`, which is "Active Power (PCS AC Side)". Correct address is `10008`.
- SOC was at `10010`, which is "Load Power". Correct address is `10014` (the reporter confirmed 51/52/53 % map exactly).
- PV "Total PV Generation" was at `10026`, which is "Total Load Consumption Energy" on this firmware. Correct address is `10187` (PCS-PV section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)