### PR TITLE
Config: probe device check capabilities in parallel

### DIFF
--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -282,7 +282,7 @@ func deviceStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// bound the value-probe phase so a blocking getter cannot stall the response
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
 	jsonWrite(w, testInstance(ctx, instance))
@@ -703,7 +703,7 @@ func testConfigHandler(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	// bound the value-probe phase so a blocking getter cannot stall the response
-	probeCtx, probeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	probeCtx, probeCancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer probeCancel()
 
 	jsonWrite(w, testInstance(probeCtx, instance))

--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"time"
 
 	"dario.cat/mergo"
 	"github.com/evcc-io/evcc/api/globalconfig"
@@ -280,7 +281,11 @@ func deviceStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonWrite(w, testInstance(instance))
+	// bound the value-probe phase so a blocking getter cannot stall the response
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	jsonWrite(w, testInstance(ctx, instance))
 }
 
 func newDevice[T any](ctx context.Context, class templates.Class, req configReq, newFromConf newFromConfFunc[T], h config.Handler[T], force bool) (*config.Config, error) {
@@ -697,5 +702,9 @@ func testConfigHandler(w http.ResponseWriter, r *http.Request) {
 	close(done)
 	defer cancel()
 
-	jsonWrite(w, testInstance(instance))
+	// bound the value-probe phase so a blocking getter cannot stall the response
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer probeCancel()
+
+	jsonWrite(w, testInstance(probeCtx, instance))
 }

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -274,38 +274,31 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 	}
 
 	var wg sync.WaitGroup
-	probe := func(f func()) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			f()
-		}()
-	}
 
 	// probes run concurrently so a responsive getter still returns when another
 	// blocks; slow getters are abandoned once ctx expires (see below)
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.Meter](instance); ok {
 			val, err := dev.CurrentPower()
 			makeResult("power", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.MeterEnergy](instance); ok {
 			val, err := dev.TotalEnergy()
 			makeResult("energy", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.MeterReturnEnergy](instance); ok {
 			val, err := dev.ReturnEnergy()
 			makeResult("returnEnergy", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.Battery](instance); ok {
 			val, err := dev.Soc()
 			key := "soc"
@@ -316,112 +309,112 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if api.HasCap[api.BatteryController](instance) {
 			makeResult("controllable", true, nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.VehicleOdometer](instance); ok {
 			val, err := dev.Odometer()
 			makeResult("odometer", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.BatteryCapacity](instance); ok {
 			val := dev.Capacity()
 			makeResult("capacity", val, nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.PhaseCurrents](instance); ok {
 			i1, i2, i3, err := dev.Currents()
 			makeResult("phaseCurrents", []float64{i1, i2, i3}, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.PhaseVoltages](instance); ok {
 			u1, u2, u3, err := dev.Voltages()
 			makeResult("phaseVoltages", []float64{u1, u2, u3}, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.PhasePowers](instance); ok {
 			p1, p2, p3, err := dev.Powers()
 			makeResult("phasePowers", []float64{p1, p2, p3}, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.ChargeState](instance); ok {
 			val, err := dev.Status()
 			makeResult("chargeStatus", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.Charger](instance); ok {
 			val, err := dev.Enabled()
 			makeResult("enabled", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.ChargeRater](instance); ok {
 			val, err := dev.ChargedEnergy()
 			makeResult("chargedEnergy", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if api.HasCap[api.PhaseSwitcher](instance) {
 			makeResult("phases1p3p", true, nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if hasFeature(instance, api.Heating) {
 			makeResult("heating", true, nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if hasFeature(instance, api.IntegratedDevice) {
 			makeResult("integratedDevice", true, nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if hasFeature(instance, api.SwitchDevice) {
 			makeResult("switchDevice", true, nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.IconDescriber](instance); ok && dev.Icon() != "" {
 			makeResult("icon", dev.Icon(), nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if cc, ok := api.Cap[api.PhaseDescriber](instance); ok && cc.Phases() == 1 {
 			makeResult("singlePhase", true, nil)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.VehicleRange](instance); ok {
 			val, err := dev.Range()
 			makeResult("range", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.SocLimiter](instance); ok {
 			val, err := dev.GetLimitSoc()
 			key := "vehicleLimitSoc"
@@ -432,14 +425,14 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.Dimmer](instance); ok {
 			val, err := dev.Dimmed()
 			makeResult("dimmed", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.Curtailer](instance); ok {
 			makeResult("curtailable", true, nil)
 			if val, err := dev.Curtailed(); err != nil || val {
@@ -448,14 +441,14 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.Identifier](instance); ok {
 			val, err := dev.Identify()
 			makeResult("identifier", val, err)
 		}
 	})
 
-	probe(func() {
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.Tariff](instance); ok {
 			rates, err := dev.Rates()
 

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -273,25 +273,39 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 		resMu.Unlock()
 	}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
+	var wg sync.WaitGroup
+	probe := func(f func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			f()
+		}()
+	}
 
+	// probes run concurrently so a responsive getter still returns when another
+	// blocks; slow getters are abandoned once ctx expires (see below)
+	probe(func() {
 		if dev, ok := api.Cap[api.Meter](instance); ok {
 			val, err := dev.CurrentPower()
 			makeResult("power", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.MeterEnergy](instance); ok {
 			val, err := dev.TotalEnergy()
 			makeResult("energy", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.MeterReturnEnergy](instance); ok {
 			val, err := dev.ReturnEnergy()
 			makeResult("returnEnergy", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.Battery](instance); ok {
 			val, err := dev.Soc()
 			key := "soc"
@@ -300,80 +314,114 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 			}
 			makeResult(key, val, err)
 		}
+	})
 
+	probe(func() {
 		if api.HasCap[api.BatteryController](instance) {
 			makeResult("controllable", true, nil)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.VehicleOdometer](instance); ok {
 			val, err := dev.Odometer()
 			makeResult("odometer", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.BatteryCapacity](instance); ok {
 			val := dev.Capacity()
 			makeResult("capacity", val, nil)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.PhaseCurrents](instance); ok {
 			i1, i2, i3, err := dev.Currents()
 			makeResult("phaseCurrents", []float64{i1, i2, i3}, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.PhaseVoltages](instance); ok {
 			u1, u2, u3, err := dev.Voltages()
 			makeResult("phaseVoltages", []float64{u1, u2, u3}, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.PhasePowers](instance); ok {
 			p1, p2, p3, err := dev.Powers()
 			makeResult("phasePowers", []float64{p1, p2, p3}, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.ChargeState](instance); ok {
 			val, err := dev.Status()
 			makeResult("chargeStatus", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.Charger](instance); ok {
 			val, err := dev.Enabled()
 			makeResult("enabled", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.ChargeRater](instance); ok {
 			val, err := dev.ChargedEnergy()
 			makeResult("chargedEnergy", val, err)
 		}
+	})
 
+	probe(func() {
 		if api.HasCap[api.PhaseSwitcher](instance) {
 			makeResult("phases1p3p", true, nil)
 		}
+	})
 
+	probe(func() {
 		if hasFeature(instance, api.Heating) {
 			makeResult("heating", true, nil)
 		}
+	})
 
+	probe(func() {
 		if hasFeature(instance, api.IntegratedDevice) {
 			makeResult("integratedDevice", true, nil)
 		}
+	})
 
+	probe(func() {
 		if hasFeature(instance, api.SwitchDevice) {
 			makeResult("switchDevice", true, nil)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.IconDescriber](instance); ok && dev.Icon() != "" {
 			makeResult("icon", dev.Icon(), nil)
 		}
+	})
 
+	probe(func() {
 		if cc, ok := api.Cap[api.PhaseDescriber](instance); ok && cc.Phases() == 1 {
 			makeResult("singlePhase", true, nil)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.VehicleRange](instance); ok {
 			val, err := dev.Range()
 			makeResult("range", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.SocLimiter](instance); ok {
 			val, err := dev.GetLimitSoc()
 			key := "vehicleLimitSoc"
@@ -382,24 +430,32 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 			}
 			makeResult(key, val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.Dimmer](instance); ok {
 			val, err := dev.Dimmed()
 			makeResult("dimmed", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.Curtailer](instance); ok {
 			makeResult("curtailable", true, nil)
 			if val, err := dev.Curtailed(); err != nil || val {
 				makeResult("curtailed", true, err)
 			}
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.Identifier](instance); ok {
 			val, err := dev.Identify()
 			makeResult("identifier", val, err)
 		}
+	})
 
+	probe(func() {
 		if dev, ok := api.Cap[api.Tariff](instance); ok {
 			rates, err := dev.Rates()
 
@@ -430,6 +486,12 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 				}
 			}
 		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
 	}()
 
 	// bound the probe phase: on ctx.Done return collected results so far. A leaked

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -255,7 +255,8 @@ func hasFeature(instance any, f api.Feature) bool {
 
 // testInstance tests the given instance similar to dump
 // TODO refactor together with dump
-func testInstance(instance any) map[string]testResult {
+func testInstance(ctx context.Context, instance any) map[string]testResult {
+	var resMu sync.Mutex
 	res := make(map[string]testResult)
 
 	makeResult := func(key string, val any, err error) {
@@ -266,164 +267,184 @@ func testInstance(instance any) map[string]testResult {
 			}
 			tr.Error = err.Error()
 		}
+		resMu.Lock()
 		res[key] = tr
+		resMu.Unlock()
 	}
 
-	if dev, ok := api.Cap[api.Meter](instance); ok {
-		val, err := dev.CurrentPower()
-		makeResult("power", val, err)
-	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
 
-	if dev, ok := api.Cap[api.MeterEnergy](instance); ok {
-		val, err := dev.TotalEnergy()
-		makeResult("energy", val, err)
-	}
-
-	if dev, ok := api.Cap[api.MeterReturnEnergy](instance); ok {
-		val, err := dev.ReturnEnergy()
-		makeResult("returnEnergy", val, err)
-	}
-
-	if dev, ok := api.Cap[api.Battery](instance); ok {
-		val, err := dev.Soc()
-		key := "soc"
-		if hasFeature(instance, api.Heating) {
-			key = "temp"
-		}
-		makeResult(key, val, err)
-	}
-
-	if api.HasCap[api.BatteryController](instance) {
-		makeResult("controllable", true, nil)
-	}
-
-	if dev, ok := api.Cap[api.VehicleOdometer](instance); ok {
-		val, err := dev.Odometer()
-		makeResult("odometer", val, err)
-	}
-
-	if dev, ok := api.Cap[api.BatteryCapacity](instance); ok {
-		val := dev.Capacity()
-		makeResult("capacity", val, nil)
-	}
-
-	if dev, ok := api.Cap[api.PhaseCurrents](instance); ok {
-		i1, i2, i3, err := dev.Currents()
-		makeResult("phaseCurrents", []float64{i1, i2, i3}, err)
-	}
-
-	if dev, ok := api.Cap[api.PhaseVoltages](instance); ok {
-		u1, u2, u3, err := dev.Voltages()
-		makeResult("phaseVoltages", []float64{u1, u2, u3}, err)
-	}
-
-	if dev, ok := api.Cap[api.PhasePowers](instance); ok {
-		p1, p2, p3, err := dev.Powers()
-		makeResult("phasePowers", []float64{p1, p2, p3}, err)
-	}
-
-	if dev, ok := api.Cap[api.ChargeState](instance); ok {
-		val, err := dev.Status()
-		makeResult("chargeStatus", val, err)
-	}
-
-	if dev, ok := api.Cap[api.Charger](instance); ok {
-		val, err := dev.Enabled()
-		makeResult("enabled", val, err)
-	}
-
-	if dev, ok := api.Cap[api.ChargeRater](instance); ok {
-		val, err := dev.ChargedEnergy()
-		makeResult("chargedEnergy", val, err)
-	}
-
-	if api.HasCap[api.PhaseSwitcher](instance) {
-		makeResult("phases1p3p", true, nil)
-	}
-
-	if hasFeature(instance, api.Heating) {
-		makeResult("heating", true, nil)
-	}
-
-	if hasFeature(instance, api.IntegratedDevice) {
-		makeResult("integratedDevice", true, nil)
-	}
-
-	if hasFeature(instance, api.SwitchDevice) {
-		makeResult("switchDevice", true, nil)
-	}
-
-	if dev, ok := api.Cap[api.IconDescriber](instance); ok && dev.Icon() != "" {
-		makeResult("icon", dev.Icon(), nil)
-	}
-
-	if cc, ok := api.Cap[api.PhaseDescriber](instance); ok && cc.Phases() == 1 {
-		makeResult("singlePhase", true, nil)
-	}
-
-	if dev, ok := api.Cap[api.VehicleRange](instance); ok {
-		val, err := dev.Range()
-		makeResult("range", val, err)
-	}
-
-	if dev, ok := api.Cap[api.SocLimiter](instance); ok {
-		val, err := dev.GetLimitSoc()
-		key := "vehicleLimitSoc"
-		if hasFeature(instance, api.Heating) {
-			key = "heaterTempLimit"
-		}
-		makeResult(key, val, err)
-	}
-
-	if dev, ok := api.Cap[api.Dimmer](instance); ok {
-		val, err := dev.Dimmed()
-		makeResult("dimmed", val, err)
-	}
-
-	if dev, ok := api.Cap[api.Curtailer](instance); ok {
-		makeResult("curtailable", true, nil)
-		if val, err := dev.Curtailed(); err != nil || val {
-			makeResult("curtailed", true, err)
-		}
-	}
-
-	if dev, ok := api.Cap[api.Identifier](instance); ok {
-		val, err := dev.Identify()
-		makeResult("identifier", val, err)
-	}
-
-	if dev, ok := api.Cap[api.Tariff](instance); ok {
-		rates, err := dev.Rates()
-
-		// Determine field names based on tariff type
-		var valueKey, ratesKey string
-		switch dev.Type() {
-		case api.TariffTypePriceDynamic, api.TariffTypePriceForecast:
-			valueKey = "price"
-			ratesKey = "priceRates"
-		case api.TariffTypeCo2:
-			valueKey = "co2"
-			ratesKey = "co2Rates"
-		case api.TariffTypeSolar:
-			valueKey = "power"
-			ratesKey = "solarRates"
-		default:
-			valueKey = "price"
+		if dev, ok := api.Cap[api.Meter](instance); ok {
+			val, err := dev.CurrentPower()
+			makeResult("power", val, err)
 		}
 
-		if err == nil && len(rates) > 0 {
-			// Get current rate value
-			if rate, err := rates.At(time.Now()); err == nil {
-				makeResult(valueKey, rate.Value, nil)
+		if dev, ok := api.Cap[api.MeterEnergy](instance); ok {
+			val, err := dev.TotalEnergy()
+			makeResult("energy", val, err)
+		}
+
+		if dev, ok := api.Cap[api.MeterReturnEnergy](instance); ok {
+			val, err := dev.ReturnEnergy()
+			makeResult("returnEnergy", val, err)
+		}
+
+		if dev, ok := api.Cap[api.Battery](instance); ok {
+			val, err := dev.Soc()
+			key := "soc"
+			if hasFeature(instance, api.Heating) {
+				key = "temp"
 			}
+			makeResult(key, val, err)
+		}
 
-			if ratesKey != "" {
-				makeResult(ratesKey, rates, nil)
+		if api.HasCap[api.BatteryController](instance) {
+			makeResult("controllable", true, nil)
+		}
+
+		if dev, ok := api.Cap[api.VehicleOdometer](instance); ok {
+			val, err := dev.Odometer()
+			makeResult("odometer", val, err)
+		}
+
+		if dev, ok := api.Cap[api.BatteryCapacity](instance); ok {
+			val := dev.Capacity()
+			makeResult("capacity", val, nil)
+		}
+
+		if dev, ok := api.Cap[api.PhaseCurrents](instance); ok {
+			i1, i2, i3, err := dev.Currents()
+			makeResult("phaseCurrents", []float64{i1, i2, i3}, err)
+		}
+
+		if dev, ok := api.Cap[api.PhaseVoltages](instance); ok {
+			u1, u2, u3, err := dev.Voltages()
+			makeResult("phaseVoltages", []float64{u1, u2, u3}, err)
+		}
+
+		if dev, ok := api.Cap[api.PhasePowers](instance); ok {
+			p1, p2, p3, err := dev.Powers()
+			makeResult("phasePowers", []float64{p1, p2, p3}, err)
+		}
+
+		if dev, ok := api.Cap[api.ChargeState](instance); ok {
+			val, err := dev.Status()
+			makeResult("chargeStatus", val, err)
+		}
+
+		if dev, ok := api.Cap[api.Charger](instance); ok {
+			val, err := dev.Enabled()
+			makeResult("enabled", val, err)
+		}
+
+		if dev, ok := api.Cap[api.ChargeRater](instance); ok {
+			val, err := dev.ChargedEnergy()
+			makeResult("chargedEnergy", val, err)
+		}
+
+		if api.HasCap[api.PhaseSwitcher](instance) {
+			makeResult("phases1p3p", true, nil)
+		}
+
+		if hasFeature(instance, api.Heating) {
+			makeResult("heating", true, nil)
+		}
+
+		if hasFeature(instance, api.IntegratedDevice) {
+			makeResult("integratedDevice", true, nil)
+		}
+
+		if hasFeature(instance, api.SwitchDevice) {
+			makeResult("switchDevice", true, nil)
+		}
+
+		if dev, ok := api.Cap[api.IconDescriber](instance); ok && dev.Icon() != "" {
+			makeResult("icon", dev.Icon(), nil)
+		}
+
+		if cc, ok := api.Cap[api.PhaseDescriber](instance); ok && cc.Phases() == 1 {
+			makeResult("singlePhase", true, nil)
+		}
+
+		if dev, ok := api.Cap[api.VehicleRange](instance); ok {
+			val, err := dev.Range()
+			makeResult("range", val, err)
+		}
+
+		if dev, ok := api.Cap[api.SocLimiter](instance); ok {
+			val, err := dev.GetLimitSoc()
+			key := "vehicleLimitSoc"
+			if hasFeature(instance, api.Heating) {
+				key = "heaterTempLimit"
+			}
+			makeResult(key, val, err)
+		}
+
+		if dev, ok := api.Cap[api.Dimmer](instance); ok {
+			val, err := dev.Dimmed()
+			makeResult("dimmed", val, err)
+		}
+
+		if dev, ok := api.Cap[api.Curtailer](instance); ok {
+			makeResult("curtailable", true, nil)
+			if val, err := dev.Curtailed(); err != nil || val {
+				makeResult("curtailed", true, err)
 			}
 		}
+
+		if dev, ok := api.Cap[api.Identifier](instance); ok {
+			val, err := dev.Identify()
+			makeResult("identifier", val, err)
+		}
+
+		if dev, ok := api.Cap[api.Tariff](instance); ok {
+			rates, err := dev.Rates()
+
+			// Determine field names based on tariff type
+			var valueKey, ratesKey string
+			switch dev.Type() {
+			case api.TariffTypePriceDynamic, api.TariffTypePriceForecast:
+				valueKey = "price"
+				ratesKey = "priceRates"
+			case api.TariffTypeCo2:
+				valueKey = "co2"
+				ratesKey = "co2Rates"
+			case api.TariffTypeSolar:
+				valueKey = "power"
+				ratesKey = "solarRates"
+			default:
+				valueKey = "price"
+			}
+
+			if err == nil && len(rates) > 0 {
+				// Get current rate value
+				if rate, err := rates.At(time.Now()); err == nil {
+					makeResult(valueKey, rate.Value, nil)
+				}
+
+				if ratesKey != "" {
+					makeResult(ratesKey, rates, nil)
+				}
+			}
+		}
+	}()
+
+	// bound the probe phase: on ctx.Done return collected results so far. A leaked
+	// getter goroutine keeps writing to res safely under resMu while we return a copy.
+	select {
+	case <-done:
+	case <-ctx.Done():
 	}
 
-	return res
+	resMu.Lock()
+	defer resMu.Unlock()
+	out := make(map[string]testResult, len(res))
+	for k, v := range res {
+		out[k] = v
+	}
+	return out
 }
 
 // mergeMaskedAny similar to mergeMasked but for interfaces

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -440,11 +441,7 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 
 	resMu.Lock()
 	defer resMu.Unlock()
-	out := make(map[string]testResult, len(res))
-	for k, v := range res {
-		out[k] = v
-	}
-	return out
+	return maps.Clone(res)
 }
 
 // mergeMaskedAny similar to mergeMasked but for interfaces

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -38,6 +38,34 @@ func TestInstanceBoundedByContext(t *testing.T) {
 	require.Less(t, time.Since(start), 500*time.Millisecond, "testInstance must not wait for blocking getter")
 }
 
+// slowPowerMeter blocks on CurrentPower but returns TotalEnergy immediately.
+type slowPowerMeter struct {
+	done chan struct{}
+}
+
+func (m slowPowerMeter) CurrentPower() (float64, error) {
+	<-m.done
+	return 0, nil
+}
+
+func (m slowPowerMeter) TotalEnergy() (float64, error) {
+	return 42, nil
+}
+
+// TestInstanceParallelProbes ensures a responsive getter returns even while a
+// sibling blocks; sequential probing would starve energy behind power.
+func TestInstanceParallelProbes(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	res := testInstance(ctx, slowPowerMeter{done: done})
+	require.Contains(t, res, "energy", "fast getter must return despite a blocking sibling")
+	require.NotContains(t, res, "power", "blocking getter must be abandoned")
+}
+
 func TestConfigReqUnmarshal(t *testing.T) {
 	var req configReq
 	require.NoError(t, json.Unmarshal([]byte(`{

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/evcc-io/evcc/api/globalconfig"
 	"github.com/evcc-io/evcc/plugin/mqtt"
@@ -11,6 +13,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// blockingMeter is an api.Meter whose CurrentPower blocks until the test ends.
+type blockingMeter struct {
+	done chan struct{}
+}
+
+func (m blockingMeter) CurrentPower() (float64, error) {
+	<-m.done
+	return 0, nil
+}
+
+// TestInstanceBoundedByContext ensures testInstance returns promptly when a
+// getter blocks, bounded by the context deadline rather than the getter itself.
+func TestInstanceBoundedByContext(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	testInstance(ctx, blockingMeter{done: done})
+	require.Less(t, time.Since(start), 500*time.Millisecond, "testInstance must not wait for blocking getter")
+}
 
 func TestConfigReqUnmarshal(t *testing.T) {
 	var req configReq


### PR DESCRIPTION
Builds on #31115 (base branch) — depends on it and should merge after.

#31115 bounds the device-check probe phase with a context, but the probes still run sequentially in one goroutine: if the *first* probe is the one that blocks (e.g. an `mqtt` `power` source awaiting its first message), every later probe is starved behind it and the check returns empty at the deadline. This fans each capability probe into its own goroutine joined by a `WaitGroup`, so every responsive getter returns and only the genuinely-stuck ones are abandoned when the context expires.

Note: probes now call methods on the same instance concurrently. The common getters are mutex-guarded (`util.Cached`, `util.Monitor`, modbus connections), but a bespoke provider with unguarded shared state would need a closer look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)