### PR TITLE
templates: add Anker SOLIX Wallbox V1 OCPP template

### DIFF
--- a/templates/definition/charger/anker-solix-v1.yaml
+++ b/templates/definition/charger/anker-solix-v1.yaml
@@ -1,0 +1,59 @@
+```yaml
+template: anker-solix-v1
+
+products:
+  - brand: Anker SOLIX
+    description:
+      generic: Wallbox V1
+
+capabilities: ["dim"]
+
+requirements:
+  description:
+    de: |
+      OCPP in der Anker-App aktivieren.
+
+      * OCPP-Backend: evcc
+      * URL: `ws://<evcc-host>:8887/`
+      * Protokoll: OCPP 1.6J / JSON / WebSocket im lokalen Netzwerk
+      * Keinen Pfad und keine Station-ID manuell an die URL anhängen.
+      * Die Wallbox registriert sich mit ihrer eigenen Station ID bei evcc.
+      * Diese Station ID wird in evcc als `stationid` verwendet.
+      * Anker Solar-/Smart-Charging in der App deaktivieren, damit evcc die Ladesteuerung übernimmt.
+      * Falls verfügbar, Autostart/Freies Laden am Ladepunkt aktivieren.
+
+    en: |
+      Enable OCPP in the Anker app.
+
+      * OCPP backend: evcc
+      * URL: `ws://<evcc-host>:8887/`
+      * Protocol: OCPP 1.6J / JSON / WebSocket on the local network
+      * Do not manually append a path or station ID to the URL.
+      * The charger registers with its own station ID in evcc.
+      * This station ID is used as `stationid` in evcc.
+      * Disable Anker solar/smart charging in the app so evcc controls charging.
+      * If available, enable autostart/free charging on the charger.
+
+  evcc: ["sponsorship", "skiptest"]
+
+caveats:
+  - description:
+      de: Dieses Template nutzt die bestehende generische OCPP-Unterstützung von evcc. Es ist keine native Anker-Cloud-Integration.
+      en: This template uses evcc's existing generic OCPP support. It is not a native Anker cloud integration.
+
+  - description:
+      de: Die OCPP-Stabilität hängt von der Anker-Firmware ab. Dieses Template überspringt das initiale ChangeAvailability-Kommando, da dieses bei einigen Anker SOLIX V1 Installationen Timeouts, Reconnects oder Reboots verursacht.
+      en: OCPP stability depends on Anker firmware. This template skips the initial ChangeAvailability command because it causes timeouts, reconnects, or reboots on some Anker SOLIX V1 installations.
+
+  - description:
+      de: Die Wallbox unterstützt nach aktuellem Teststand keine OCPP-gesteuerte Phasenumschaltung durch evcc. Einphasiges Laden kann abhängig von Firmware und Anker-Einstellung autonom durch die Wallbox erfolgen.
+      en: Based on current testing, the charger does not support OCPP-controlled phase switching by evcc. Single-phase charging may occur autonomously depending on firmware and Anker settings.
+
+params:
+  - preset: ocpp
+
+render: |
+  {{ include "ocpp" . }}
+  nochangeavailability: true
+  profilekindrelative: true
+```

--- a/templates/definition/charger/anker-solix-v1.yaml
+++ b/templates/definition/charger/anker-solix-v1.yaml
@@ -1,4 +1,3 @@
-```yaml
 template: anker-solix-v1
 
 products:
@@ -14,8 +13,9 @@ requirements:
       OCPP in der Anker-App aktivieren.
 
       * OCPP-Backend: evcc
-      * URL: `ws://<evcc-host>:8887/`
+      * Backend-URL / Central System: `ws://<evcc-host>:8887/`
       * Protokoll: OCPP 1.6J / JSON / WebSocket im lokalen Netzwerk
+      * Keine Verschlüsselung, keine Authentifizierung, kein Passwort
       * Keinen Pfad und keine Station-ID manuell an die URL anhängen.
       * Die Wallbox registriert sich mit ihrer eigenen Station ID bei evcc.
       * Diese Station ID wird in evcc als `stationid` verwendet.
@@ -26,8 +26,9 @@ requirements:
       Enable OCPP in the Anker app.
 
       * OCPP backend: evcc
-      * URL: `ws://<evcc-host>:8887/`
+      * Backend URL / Central System: `ws://<evcc-host>:8887/`
       * Protocol: OCPP 1.6J / JSON / WebSocket on the local network
+      * No encryption, no authentication, no password
       * Do not manually append a path or station ID to the URL.
       * The charger registers with its own station ID in evcc.
       * This station ID is used as `stationid` in evcc.
@@ -51,9 +52,11 @@ caveats:
 
 params:
   - preset: ocpp
+  - name: metervalues
+    default: Energy.Active.Import.Register,Power.Active.Import,Current.Import
 
 render: |
   {{ include "ocpp" . }}
   nochangeavailability: true
   profilekindrelative: true
-```
+  remotestart: true

--- a/templates/definition/charger/anker-solix-v1.yaml
+++ b/templates/definition/charger/anker-solix-v1.yaml
@@ -52,6 +52,10 @@ caveats:
 
 params:
   - preset: ocpp
+  - name: connecttimeout
+    default: 10m
+  - name: meterinterval
+    default: 10s
   - name: metervalues
     default: Energy.Active.Import.Register,Power.Active.Import,Current.Import
 


### PR DESCRIPTION
````markdown
## Summary

Adds an Anker SOLIX Wallbox V1 charger template using evcc's existing generic OCPP charger implementation.

This is a template-only OCPP compatibility configuration. It does not add Anker-specific Go code and does not change the default behavior of the generic OCPP charger.

## Details

The new template:

- adds `Anker SOLIX Wallbox V1` as a selectable charger template
- uses the existing OCPP preset
- keeps the implementation based on the generic OCPP charger
- applies tested Anker-specific compatibility defaults

Rendered compatibility defaults:

```yaml
nochangeavailability: true
profilekindrelative: true
remotestart: true
````

The important device-specific setting is:

```yaml
nochangeavailability: true
```

This skips the initial OCPP `ChangeAvailability(0, Operative)` command during charge point setup. In my Anker SOLIX Wallbox V1 setup, this command causes the charger firmware to timeout, disconnect, or reboot repeatedly.

The template also sets tested OCPP defaults:

```yaml
connecttimeout: 10m
meterinterval: 10s
metervalues: Energy.Active.Import.Register,Power.Active.Import,Current.Import
```

These values provide a longer registration timeout and the relevant import energy, import power, and current measurements used for evcc-controlled charging.

## Tested with

* Charger: Anker SOLIX Wallbox V1
* evcc: 0.309.2
* Environment: Home Assistant Add-on
* Connection: OCPP 1.6J over local network
* Use case: PV surplus charging
* OCPP URL format in Anker app: `ws://<evcc-host>:8887/`

Observed behavior before applying the compatibility setting:

* charger connects to evcc
* evcc sends initial availability configuration
* charger times out / disconnects / reconnects
* repeated initialization loop

Observed behavior with this template configuration:

* stable OCPP connection
* charging transaction starts successfully
* import power and current values are received
* dynamic current control works
* PV surplus charging works

## Notes

This PR does not attempt to fix malformed OCPP `GetConfiguration` responses such as numeric `readonly` values from issue #26253.

This PR also does not introduce a native Anker cloud integration. The template uses the existing generic OCPP implementation only.

The template includes caveats explaining that:

* OCPP stability depends on Anker firmware
* the template skips the initial `ChangeAvailability` command for compatibility
* the charger does not currently provide evcc-controlled OCPP phase switching
* single-phase charging may happen autonomously depending on Anker firmware and app settings

## Scope

Template-only change.

No Go code changes.
No default behavior changes for other OCPP chargers.

```
```
