### PR TITLE
Optimizer: fix grid price chart unit scaling

### DIFF
--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -196,7 +196,7 @@ export default defineComponent({
 						position: "left",
 						title: {
 							display: true,
-							text: `Price (${this.pricePerKWhUnit(this.currency, false)})`,
+							text: this.pricePerKWhUnit(this.currency, false),
 						},
 						grid: {
 							drawOnChartArea: true,
@@ -225,8 +225,9 @@ export default defineComponent({
 		getPriceDatasets() {
 			const datasets: any[] = [];
 
-			// Convert prices from raw format (€/Wh) to proper format (€/kWh) - same as table
-			const convertPrice = (price: number): number => price * 1000;
+			// Convert raw price (currency/Wh) to the display unit per kWh (e.g. ct/kWh)
+			const factor = this.pricePerKWhDisplayFactor(this.currency);
+			const convertPrice = (price: number): number => price * 1000 * factor;
 
 			// Grid Import Price (solid line, price color)
 			datasets.push({
@@ -267,12 +268,10 @@ export default defineComponent({
 			return datasets;
 		},
 		formatPrice(price: number): string {
-			// Use the exact same logic as the data table: fmtPricePerKWh(value * 1000, currency, false, false)
-			// But since we already multiplied by 1000 in the dataset, we use the value directly
-			// and add the unit manually to match the tooltip format
-			const formattedValue = this.fmtPricePerKWh(price, this.currency, false, false);
-			const unit = this.pricePerKWhUnit(this.currency, false);
-			return `${formattedValue} ${unit}`;
+			// price is already in display unit (see convertPrice); undo the factor so the
+			// formatter re-applies it and appends the matching unit
+			const factor = this.pricePerKWhDisplayFactor(this.currency);
+			return this.fmtPricePerKWh(price / factor, this.currency);
 		},
 
 		formatTimeRange(index: number): string {


### PR DESCRIPTION
fixes #31122

The grid price chart plotted values in currency/kWh while its axis label and tooltip used the subunit, so a 0.31 axis point showed as 31.3 ct/kWh in the tooltip.

- apply the per-kWh display factor to the plotted import/export prices so the axis matches the ct/kWh label
- drop the redundant `Price (...)` axis title, already covered by the chart heading

EUR, subunit
<img width="508" height="298" alt="Bildschirmfoto 2026-06-22 um 16 42 17" src="https://github.com/user-attachments/assets/7f903a74-c484-4971-8433-22364e415872" />

YEN, no subunit
<img width="463" height="235" alt="Bildschirmfoto 2026-06-22 um 16 45 01" src="https://github.com/user-attachments/assets/a1a8f59a-69f6-4b2a-8d3b-ddc04ac43d40" />
