### PR TITLE
senec: Option to force charge on hold

### DIFF
--- a/templates/definition/meter/senec-home.yaml
+++ b/templates/definition/meter/senec-home.yaml
@@ -14,6 +14,15 @@ params:
   - name: host
   - name: schema
   - preset: battery-params
+  - name: chargeonhold
+    type: bool
+    default: false
+    description:
+      de: Laden im Haltemodus erzwingen
+      en: Force charging in hold mode
+    help:
+      de: Erzwingt das Laden der Batterie im Haltemodus um das Entladen zu verhindern.
+      en: Forces charging the battery in hold mode to prevent discharging.
 render: |
   type: custom
   power:
@@ -62,10 +71,20 @@ render: |
         headers:
         - content-type: application/json
         body: '{"ENERGY":{"SAFE_CHARGE_PROHIBIT":"u8_01"}}'  # self consumption
-    - case: 2 # hold (not implemented)
+    - case: 2 # hold (true hold not possible with SENEC, but we can prevent discharging by forcing charging)
       set:
-        source: error
-        error: ErrNotAvailable
+        {{- if .chargeonhold }}
+          source: http
+          uri: {{ .schema }}://{{ .host }}/lala.cgi
+          insecure: true
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"ENERGY":{"SAFE_CHARGE_FORCE":"u8_01"}}'  # force charging to prevent discharging
+        {{- else }}
+          source: error
+          error: ErrNotAvailable
+        {{- end }}
     - case: 3 # charge
       set:
         source: http


### PR DESCRIPTION
SENEC battery owners have the problem that senec batteries do not support the hold mode. The battery gets discharged during fast charge and planned charging, even if the prevention of this is set to active.

In the scenario of fast charging during low electricity prices it makes much more sense to charge the senec battery alongside the vehicle, and have the battery not a completely discharged state during the following period with high electricity prices.

This PR adds a bool option to the GUI: "Force charge on Hold" for senec batteries. If activated, the senec battery charges alongside the vehicle to prevent discharging if the battery is set to "hold" by evcc.

I tested this template with my senec hybdrid duo (v3).