### PR TITLE
Config UI: manually convert additional meter to consumer

### DIFF
--- a/assets/js/components/Config/DeviceModal/Actions.vue
+++ b/assets/js/components/Config/DeviceModal/Actions.vue
@@ -8,6 +8,8 @@
 			@test="$emit('test')"
 		/>
 
+		<slot name="after-test"></slot>
+
 		<div class="mt-4 d-flex justify-content-between">
 			<button
 				v-if="isDeletable"

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -178,7 +178,11 @@
 					@save="handleSave"
 					@remove="handleRemove"
 					@test="testManually"
-				/>
+				>
+					<template #after-test>
+						<slot name="after-test" :values="values"></slot>
+					</template>
+				</DeviceModalActions>
 			</template>
 		</form>
 	</GenericModal>

--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -85,6 +85,18 @@
 				/>
 			</FormRow>
 		</template>
+
+		<template #after-test>
+			<button
+				v-if="canConvertToConsumer"
+				type="button"
+				class="btn btn-link text-muted"
+				tabindex="0"
+				@click="convertToConsumer"
+			>
+				{{ $t("config.meter.convertToConsumer.link") }}
+			</button>
+		</template>
 	</DeviceModalBase>
 </template>
 
@@ -105,7 +117,7 @@ import {
 } from "./DeviceModal";
 import { customTemplateOption, type TemplateGroup } from "./DeviceModal/TemplateSelector.vue";
 import defaultMeterYaml from "./defaultYaml/meter.yaml?raw";
-import { getModal, replaceModal } from "@/configModal";
+import { getModal, replaceModal, closeModal } from "@/configModal";
 
 const initialValues = {
 	type: ConfigType.Template,
@@ -192,6 +204,9 @@ export default defineComponent({
 		isNew(): boolean {
 			return this.id === undefined;
 		},
+		canConvertToConsumer(): boolean {
+			return !this.isNew && this.selectedType === "ext" && this.extMeterUsage === "charge";
+		},
 		extMeterUsageOptions() {
 			return ["charge", "aux", "grid", "pv", "battery"].map((key) => ({
 				name: this.$t(`config.meter.usage.${key}`),
@@ -269,6 +284,11 @@ export default defineComponent({
 			const type = this.selectedType;
 			const result = { action, name, type };
 			this.$emit("changed", result);
+		},
+		async convertToConsumer() {
+			if (!window.confirm(this.$t("config.meter.convertToConsumer.confirm"))) return;
+			this.$emit("changed", { action: "converted", type: "ext", id: this.id });
+			await closeModal();
 		},
 		handleClose() {
 			this.extMeterUsage = "charge";

--- a/assets/js/configModal.ts
+++ b/assets/js/configModal.ts
@@ -11,7 +11,7 @@ export interface ModalEntry {
 }
 
 export interface ModalResult {
-  action: "added" | "updated" | "removed" | "cancelled";
+  action: "added" | "updated" | "removed" | "converted" | "cancelled";
   name?: string;
   id?: number;
   type?: string;

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -1097,6 +1097,17 @@ export default defineComponent({
 				}
 			}
 
+			// Converted: move ext meter to consumers (history is reconciled on restart)
+			if (result.action === "converted") {
+				const name = this.meters.find((m) => m.id === result.id)?.name;
+				if (name) {
+					const ext = (this.site.ext || []).filter((n) => n !== name);
+					const consumers = [...(this.site.consumers || []), name];
+					await api.put("/config/site", { ext, consumers });
+					await this.loadSite();
+				}
+			}
+
 			// Removed: reload site config
 			if (result.action === "removed") {
 				await this.loadSite();

--- a/core/metrics/collector.go
+++ b/core/metrics/collector.go
@@ -41,6 +41,14 @@ func NewCollector(group, name, title string, opt ...func(*Accumulator)) (*Collec
 
 // createEntity ensures the entity row exists and refreshes its title.
 func createEntity(group, name, title string) (entity, error) {
+	// keep history when a meter is regrouped "meter" -> "consumer" (aux, ext convert)
+	if group == Consumer {
+		var prev entity
+		if db.Instance.Where(`"group" = ? AND name = ?`, Meter, name).Limit(1).Find(&prev).RowsAffected > 0 {
+			db.Instance.Model(&prev).UpdateColumn("group", Consumer)
+		}
+	}
+
 	e := entity{Group: group, Name: name}
 
 	if err := db.Instance.Where(&e).Attrs(entity{Title: title}).FirstOrCreate(&e).Error; err != nil {

--- a/core/metrics/collector_test.go
+++ b/core/metrics/collector_test.go
@@ -309,3 +309,56 @@ func TestCreateEntityRefreshesTitle(t *testing.T) {
 	require.NoError(t, db.Instance.Model(new(entity)).Where("\"group\" = ? AND name = ?", "grid", "grid").Count(&count).Error)
 	require.EqualValues(t, 1, count, "must not duplicate existing rows")
 }
+
+// a meter regrouped to consumer keeps its id and history via in-place relabel
+func TestCreateEntityReconcilesExtToConsumer(t *testing.T) {
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	// ext meter with a persisted history slot
+	ext, err := createEntity(Meter, "db:5", "Fridge")
+	require.NoError(t, err)
+	require.NoError(t, persist(ext, time.Unix(15*60, 0), 0.3, 0))
+
+	// reconfigured as consumer: same row relabeled, history intact
+	con, err := createEntity(Consumer, "db:5", "Fridge")
+	require.NoError(t, err)
+	require.Equal(t, ext.Id, con.Id, "must reuse the existing row")
+	require.Equal(t, Consumer, con.Group)
+
+	var stored entity
+	require.NoError(t, db.Instance.First(&stored, ext.Id).Error)
+	require.Equal(t, Consumer, stored.Group, "group must be persisted")
+
+	// no duplicate entity for the name
+	var entities int64
+	require.NoError(t, db.Instance.Model(new(entity)).Where("name = ?", "db:5").Count(&entities).Error)
+	require.EqualValues(t, 1, entities)
+
+	// history row still attached to the (now consumer) entity
+	var meters int64
+	require.NoError(t, db.Instance.Model(new(meter)).Where("meter = ?", ext.Id).Count(&meters).Error)
+	require.EqualValues(t, 1, meters)
+}
+
+// an existing consumer row blocks the relabel, leaving the meter row untouched
+func TestCreateEntityReconcileGuard(t *testing.T) {
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	meterRow, err := createEntity(Meter, "db:7", "")
+	require.NoError(t, err)
+
+	// pre-existing consumer row blocks the in-place relabel
+	conRow := entity{Group: Consumer, Name: "db:7"}
+	require.NoError(t, db.Instance.Create(&conRow).Error)
+
+	got, err := createEntity(Consumer, "db:7", "")
+	require.NoError(t, err)
+	require.Equal(t, conRow.Id, got.Id, "must reuse existing consumer row")
+
+	// meter row untouched
+	var stored entity
+	require.NoError(t, db.Instance.First(&stored, meterRow.Id).Error)
+	require.Equal(t, Meter, stored.Group)
+}

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -535,6 +535,10 @@
     },
     "meter": {
       "cancel": "Abbrechen",
+      "convertToConsumer": {
+        "confirm": "Wandelt diesen \"zusätzlichen Zähler\" in einen \"Verbraucher\" um.",
+        "link": "In Verbraucher umwandeln"
+      },
       "delete": "Löschen",
       "generic": "Generische Integrationen",
       "option": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -534,6 +534,10 @@
     },
     "meter": {
       "cancel": "Cancel",
+      "convertToConsumer": {
+        "confirm": "Converts this \"additional meter\" to a \"consumer\".",
+        "link": "Convert to consumer"
+      },
       "delete": "Delete",
       "generic": "Generic integrations",
       "option": {

--- a/tests/config-ext-meter.spec.ts
+++ b/tests/config-ext-meter.spec.ts
@@ -86,6 +86,56 @@ test.describe("ext meter", async () => {
     await expect(page.getByTestId("fatal-error")).not.toBeVisible();
   });
 
+  test("convert charge ext meter to consumer", async ({ page }) => {
+    await page.goto("/#/config");
+    await expect(page.getByTestId("ext")).toHaveCount(0);
+    await expect(page.getByTestId("consumer")).toHaveCount(0);
+
+    // additional meter defaults to usage charge
+    await createAdditionalMeter(page, "Fridge", "150");
+    await expect(page.getByTestId("ext")).toHaveCount(1);
+
+    const meterModal = page.getByTestId("meter-modal");
+    await page.getByTestId("ext").getByRole("button", { name: "edit" }).click();
+    await expectModalVisible(meterModal);
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await meterModal.getByRole("button", { name: "Convert to consumer" }).click();
+    await expectModalHidden(meterModal);
+
+    // moved from additional meters into consumers
+    await expect(page.getByTestId("ext")).toHaveCount(0);
+    await expect(page.getByTestId("consumer")).toHaveCount(1);
+    await expect(page.getByTestId("consumer")).toContainText("Fridge");
+
+    // persists across restart (history reconciled on boot)
+    await restart(CONFIG_GRID_ONLY);
+    await page.reload();
+    await expect(page.getByTestId("ext")).toHaveCount(0);
+    await expect(page.getByTestId("consumer")).toHaveCount(1);
+    await expect(page.getByTestId("consumer")).toContainText("Fridge");
+    await expect(page.getByTestId("fatal-error")).not.toBeVisible();
+  });
+
+  test("convert option hidden for non-charge ext meter", async ({ page }) => {
+    await page.goto("/#/config");
+
+    await page.getByRole("button", { name: "Add additional meter" }).click();
+    const meterModal = page.getByTestId("meter-modal");
+    await expectModalVisible(meterModal);
+
+    await meterModal.getByLabel("Usage").selectOption("battery");
+    await meterModal.getByLabel("Manufacturer").selectOption("Demo battery");
+    await meterModal.getByLabel("Title").fill("House battery");
+    await meterModal.getByLabel("Charge").fill("75");
+    await meterModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(meterModal);
+
+    await page.getByTestId("ext").getByRole("button", { name: "edit" }).click();
+    await expectModalVisible(meterModal);
+    await expect(meterModal.getByRole("button", { name: "Convert to consumer" })).toHaveCount(0);
+  });
+
   test("switch from template to custom ext meter", async ({ page }) => {
     await page.goto("/#/config");
 


### PR DESCRIPTION
fixes #31083

Gives users a way back after #30243 split consumers from additional meters: additional (`ext`) meters dropped out of the energy flow and consumption breakdown, and many had been used as consumers. Adds an in-place conversion that also keeps the meter's recorded history.

- New "Convert to consumer" link in the edit dialog of an additional meter (usage charge). It moves the meter into the Consumers section, so it shows up in the energy flow and consumption breakdown again.
- The meter's existing history (consumption charts, exports) carries over to the consumer instead of being stranded under "Additional meters".
- Self-regulating consumers (`aux`) recover their previous history automatically on the next restart, no action needed (their group also changed from meter to consumer).
- Conversion takes effect after the usual config restart.

\cc @VolkerK62 @leon558 

**Screenshots**

existing ext meter with charge usage
<img width="677" height="1086" alt="Bildschirmfoto 2026-06-22 um 18 10 45" src="https://github.com/user-attachments/assets/9e7a3825-07a2-46f6-a166-8661220f6008" />

<img width="688" height="300" alt="Bildschirmfoto 2026-06-22 um 18 10 48" src="https://github.com/user-attachments/assets/60ad505f-37d6-4b73-a4f3-86b5a0eac688" />

<img width="931" height="373" alt="Bildschirmfoto 2026-06-22 um 18 10 54" src="https://github.com/user-attachments/assets/04786122-91d5-470b-a6a3-8764df0c3852" />
