### PR TITLE
goodwe-hybrid: introduce shared modbus block reading

### DIFF
--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -39,6 +39,9 @@ render: |
       address: 36025 # MTTotalActivepower Pmeter
       type: holding
       decode: int32
+    block: # 36017-36026
+      register: 36017
+      count: 10
     scale: -1
   energy:
     source: modbus
@@ -47,6 +50,9 @@ render: |
       address: 36017 # E-Total-Buy
       type: holding
       decode: float32
+    block: # 36017-36026
+      register: 36017
+      count: 10
     scale: 0.001
   powers:
     - source: modbus
@@ -55,6 +61,9 @@ render: |
         address: 36019 # Meter Active Power R, W
         type: holding
         decode: int32
+      block: # 36017-36026
+        register: 36017
+        count: 10
       scale: -1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -62,6 +71,9 @@ render: |
         address: 36021 # Meter Active Power S, W
         type: holding
         decode: int32
+      block: # 36017-36026
+        register: 36017
+        count: 10
       scale: -1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -69,6 +81,9 @@ render: |
         address: 36023 # Meter Active Power T, W
         type: holding
         decode: int32
+      block: # 36017-36026
+        register: 36017
+        count: 10
       scale: -1
   currents:
     - source: modbus
@@ -77,6 +92,9 @@ render: |
         address: 36055 # Meter Current R, A
         type: holding
         decode: uint16nan
+      block: # 36055-36057
+        register: 36055
+        count: 3
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -84,6 +102,9 @@ render: |
         address: 36056 # Meter Current S, A
         type: holding
         decode: uint16nan
+      block: # 36055-36057
+        register: 36055
+        count: 3
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -91,6 +112,9 @@ render: |
         address: 36057 # Meter Current T, A
         type: holding
         decode: uint16nan
+      block: # 36055-36057
+        register: 36055
+        count: 3
       scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}
@@ -103,24 +127,36 @@ render: |
         address: 35105 # Ppv1 PV1 Power
         type: holding
         decode: uint32nan
+      block: # 35105-35118
+        register: 35105
+        count: 14
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register: # manual non-sunspec register configuration
         address: 35109 # Ppv2 PV2 Power
         type: holding
         decode: uint32nan
+      block: # 35105-35118
+        register: 35105
+        count: 14
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register: # manual non-sunspec register configuration
         address: 35113 # Ppv3 PV3 Power
         type: holding
         decode: uint32nan
+      block: # 35105-35118
+        register: 35105
+        count: 14
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register: # manual non-sunspec register configuration
         address: 35117 # Ppv4 PV4 Power
         type: holding
         decode: uint32nan
+      block: # 35105-35118
+        register: 35105
+        count: 14
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
Following #30846 (shared modbus block reading) and #31096 (deye-hybrid-3p), this implements block reads for `goodwe-hybrid`.

Reads are split into dense, gap-free cached blocks so each value extracts from one shared block read per poll cycle instead of an individual modbus round-trip:

| usage | block | registers | reads → round-trips |
|-------|-------|-----------|---------------------|
| grid | `36017` count 10 | energy, 3× power, total power (contiguous, no gap) | 5 → shared |
| grid | `36055` count 3 | 3× current (contiguous) | 3 → shared |
| pv | `35105` count 14 | 4× PV string power | 4 → 1 |

Net: grid drops from 6 round-trips to 2, pv from 4 to 1.

All blocks stay within the 125-register cache limit, and the multi-word (`int32`/`float32`/`uint32nan`) reads each fit fully inside their block (block end = last address + word length). The `battery` usage is left unchanged — its registers (35182 / 37007) are too scattered to form a dense block.

Verified: `go test ./util/templates/...` (renders + parses every template/param combo) passes, and each block's `Contains` coverage was checked against `util/modbus.Block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
