### PR TITLE
Add Zendure 3CT meter

### DIFF
--- a/templates/definition/meter/zendure-3ct.yaml
+++ b/templates/definition/meter/zendure-3ct.yaml
@@ -1,0 +1,19 @@
+template: zendure-3ct
+products:
+  - brand: Zendure
+    description:
+      generic: 3CT
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: host
+  - name: cache
+    advanced: true
+    default: 1s
+render: |
+  type: custom
+  power:
+    source: http
+    uri: http://{{ .host }}/properties/report
+    jq: .total_power
+    cache: {{ .cache }}


### PR DESCRIPTION
## Summary

Adds a grid meter template for the **Zendure 3CT**, a 3-phase CT clamp meter.

- Reads the local HTTP API at `/properties/report`
- Uses the signed `total_power` field (negative = export, positive = import)
- Grid usage only

This is a fresh, slimmed-down rewrite of #27863. Per @andig's feedback there, the per-phase `powers` block has been removed. Verified against a real 3CT that the device exposes only `total_power` and **no** per-phase currents, so evcc would not use per-phase power anyway:

```json
{"a_aprt_power":-57,"b_aprt_power":40,"c_aprt_power":1,"total_power":-16}
```

## Test plan

- [x] Template renders / jq parses (`go test ./meter/ -run TestTemplates/zendure-3ct` passes)
- [x] Validated against live device hardware