### PR TITLE
Add Webasto NEXT OCPP compatibility

### DIFF
--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -40,6 +40,15 @@ type CP struct {
 	bootNotificationRequestC chan *core.BootNotificationRequest
 	BootNotificationResult   *core.BootNotificationRequest
 
+	// bootSession increments for every WebSocket transport connection. It lets
+	// delayed boot timers ignore stale work from prior connections.
+	bootSession uint64
+
+	// triggeredBootNotificationSession is set when evcc requested BootNotification
+	// only to complete the current transport-session handshake. The matching
+	// BootNotification must not be treated as a physical charger reboot.
+	triggeredBootNotificationSession uint64
+
 	connectors map[int]*Connector
 }
 
@@ -153,21 +162,21 @@ func (cp *CP) onTransportConnect() {
 	defer cp.mu.Unlock()
 
 	cp.stopBootTimer()
-	cp.bootTimer = time.AfterFunc(Timeout, cp.onBootTimeout)
+	cp.bootSession++
+	session := cp.bootSession
+	cp.triggeredBootNotificationSession = 0
+	cp.bootTimer = time.AfterFunc(Timeout, func() {
+		cp.onBootTimeout(session)
+	})
 
 	// Proactively trigger BootNotification after a short delay.
 	// This helps chargers that don't send it spontaneously (e.g. Wallbox FW 6.x).
 	// The TriggerMessage is sent directly via the OCPP instance, bypassing the
 	// Connected() check which would fail at this point.
 	time.AfterFunc(TriggerBootDelay, func() {
-		cp.mu.RLock()
-		// If BootNotification already arrived or timer was cancelled (disconnect),
-		// there is nothing to do.
-		if cp.bootTimer == nil || cp.BootNotificationResult != nil {
-			cp.mu.RUnlock()
+		if !cp.prepareTriggerBootNotification(session) {
 			return
 		}
-		cp.mu.RUnlock()
 
 		cp.log.DEBUG.Printf("proactively triggering BootNotification")
 
@@ -175,26 +184,56 @@ func (cp *CP) onTransportConnect() {
 			cp.id,
 			func(conf *remotetrigger.TriggerMessageConfirmation, err error) {
 				if err != nil {
+					cp.clearTriggeredBootNotification(session)
 					cp.log.ERROR.Printf("trigger BootNotification response error: %v", err)
+				} else if conf == nil || conf.Status != remotetrigger.TriggerMessageStatusAccepted {
+					cp.clearTriggeredBootNotification(session)
 				}
 			},
 			core.BootNotificationFeatureName,
 			func(request *remotetrigger.TriggerMessageRequest) {},
 		); err != nil {
+			cp.clearTriggeredBootNotification(session)
 			cp.log.ERROR.Printf("failed to trigger BootNotification: %v", err)
 		}
 	})
 }
 
-// onBootTimeout is called when the BootNotification wait timer expires.
-func (cp *CP) onBootTimeout() {
+// prepareTriggerBootNotification reports whether a TriggerMessage(BootNotification)
+// should be sent for the current transport session.
+func (cp *CP) prepareTriggerBootNotification(session uint64) bool {
 	cp.mu.Lock()
-	if cp.bootTimer == nil {
+	defer cp.mu.Unlock()
+
+	if cp.bootSession != session || cp.bootTimer == nil {
+		return false
+	}
+
+	// This BootNotification is used to establish readiness for the new transport
+	// session. It must not be interpreted as a physical reboot by MonitorReboot.
+	cp.triggeredBootNotificationSession = session
+	return true
+}
+
+func (cp *CP) clearTriggeredBootNotification(session uint64) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	if cp.triggeredBootNotificationSession == session {
+		cp.triggeredBootNotificationSession = 0
+	}
+}
+
+// onBootTimeout is called when the BootNotification wait timer expires.
+func (cp *CP) onBootTimeout(session uint64) {
+	cp.mu.Lock()
+	if cp.bootSession != session || cp.bootTimer == nil {
 		// timer was cancelled by disconnect or BootNotification
 		cp.mu.Unlock()
 		return
 	}
 	cp.bootTimer = nil
+	cp.triggeredBootNotificationSession = 0
 	cp.mu.Unlock()
 
 	cp.log.DEBUG.Printf("boot notification timeout, proceeding")

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -22,25 +22,31 @@ func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.B
 
 	cp.mu.Lock()
 	cp.BootNotificationResult = request
+	// BootNotifications requested by evcc to confirm the current transport session
+	// are not charger reboots and should not trigger setup reinitialization.
+	suppressEvent := cp.triggeredBootNotificationSession == cp.bootSession && cp.triggeredBootNotificationSession != 0
+	cp.triggeredBootNotificationSession = 0
 	cp.stopBootTimer()
 	cp.mu.Unlock()
 
 	// mark charge point as ready for communication
 	cp.connect(true)
 
-	// Notify the reboot monitor (and the initial Setup). The channel is
-	// buffered (size 1) and coalescing: if an older notification is still
-	// queued, drop it so the consumer always re-initializes against the most
-	// recent BootNotification. This matters when a charge point reboot-loops
-	// (e.g. issue #30113) faster than the monitor consumes notifications, or
-	// before the monitor has started at all - the channel must never overflow.
-	select {
-	case <-cp.bootNotificationRequestC:
-	default:
-	}
-	select {
-	case cp.bootNotificationRequestC <- request:
-	default:
+	if !suppressEvent {
+		// Notify the reboot monitor (and the initial Setup). The channel is
+		// buffered (size 1) and coalescing: if an older notification is still
+		// queued, drop it so the consumer always re-initializes against the most
+		// recent BootNotification. This matters when a charge point reboot-loops
+		// (e.g. issue #30113) faster than the monitor consumes notifications, or
+		// before the monitor has started at all - the channel must never overflow.
+		select {
+		case <-cp.bootNotificationRequestC:
+		default:
+		}
+		select {
+		case cp.bootNotificationRequestC <- request:
+		default:
+		}
 	}
 
 	return res, nil

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -239,3 +239,36 @@ func TestMonitorRebootOnlyOnce(t *testing.T) {
 	require.Eventually(t, func() bool { return callCount.Load() == 1 }, time.Second, 10*time.Millisecond,
 		"setup should be called exactly once")
 }
+
+func TestTriggerBootNotificationIgnoresCachedMetadata(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+	cp.BootNotificationResult = &core.BootNotificationRequest{ChargePointModel: "Cached"}
+	cp.bootSession = 1
+	cp.bootTimer = time.NewTimer(time.Hour)
+	require.True(t, cp.prepareTriggerBootNotification(1))
+	cp.bootTimer.Stop()
+}
+
+func TestTriggeredBootNotificationDoesNotNotifyRebootMonitor(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+	cp.BootNotificationResult = &core.BootNotificationRequest{ChargePointModel: "Cached"}
+	cp.bootSession = 1
+	cp.bootTimer = time.NewTimer(time.Hour)
+	require.True(t, cp.prepareTriggerBootNotification(1))
+	cp.bootTimer.Stop()
+
+	_, err := cp.OnBootNotification(&core.BootNotificationRequest{
+		ChargePointModel:  "Triggered",
+		ChargePointVendor: "TestVendor",
+	})
+	require.NoError(t, err)
+	assert.True(t, cp.Connected())
+
+	select {
+	case req := <-cp.bootNotificationRequestC:
+		t.Fatalf("triggered BootNotification should not notify reboot monitor, got %s", req.ChargePointModel)
+	default:
+	}
+}

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -16,12 +16,23 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/security"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/lorenzodonini/ocpp-go/ocppj"
 	"github.com/lorenzodonini/ocpp-go/ws"
 )
 
+const (
+	// DateTimeGranularitySeconds serializes OCPP dateTime values without fractional seconds.
+	DateTimeGranularitySeconds = "seconds"
+	// DateTimeGranularityMilliseconds serializes OCPP dateTime values with millisecond precision.
+	DateTimeGranularityMilliseconds = "milliseconds"
+)
+
+const dateTimeGranularityMillisecondsLayout = "2006-01-02T15:04:05.000Z"
+
 type Config struct {
-	Port int `json:"port"`
+	Port                int    `json:"port"`
+	DateTimeGranularity string `json:"dateTimeGranularity,omitempty" mapstructure:"dateTimeGranularity"`
 }
 
 // ForwarderRule maps a station ID (or "*" for all chargers) to an upstream OCPP server URL.
@@ -43,11 +54,12 @@ func (r ForwarderRule) Redacted() ForwarderRule {
 }
 
 var (
-	once        sync.Once
-	instance    *CS
-	port        = 8887
-	boundPort   int
-	externalUrl string
+	once                sync.Once
+	instance            *CS
+	port                = 8887
+	boundPort           int
+	dateTimeGranularity = DateTimeGranularitySeconds
+	externalUrl         string
 )
 
 // Forwarder hooks, nil unless the forwarder is built in (set once in init()
@@ -126,12 +138,28 @@ func ExternalUrl() string {
 
 // CurrentConfig returns the current runtime OCPP configuration.
 func CurrentConfig() Config {
-	return Config{Port: port}
+	return Config{Port: port, DateTimeGranularity: dateTimeGranularity}
+}
+
+func configureDateTimeGranularity(granularity string) {
+	switch strings.ToLower(granularity) {
+	case "", DateTimeGranularitySeconds:
+		dateTimeGranularity = DateTimeGranularitySeconds
+		types.DateTimeFormat = time.RFC3339
+	case DateTimeGranularityMilliseconds:
+		dateTimeGranularity = DateTimeGranularityMilliseconds
+		types.DateTimeFormat = dateTimeGranularityMillisecondsLayout
+	default:
+		dateTimeGranularity = DateTimeGranularitySeconds
+		types.DateTimeFormat = time.RFC3339
+		util.NewLogger("ocpp").WARN.Printf("unsupported dateTimeGranularity %q, using %s", granularity, DateTimeGranularitySeconds)
+	}
 }
 
 // Init initializes the OCPP server
 func Init(cfg Config, networkExternalUrl string) {
 	port = cfg.Port
+	configureDateTimeGranularity(cfg.DateTimeGranularity)
 	externalUrl = networkExternalUrl
 }
 

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -21,14 +21,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ws"
 )
 
-const (
-	// DateTimeGranularitySeconds serializes OCPP dateTime values without fractional seconds.
-	DateTimeGranularitySeconds = "seconds"
-	// DateTimeGranularityMilliseconds serializes OCPP dateTime values with millisecond precision.
-	DateTimeGranularityMilliseconds = "milliseconds"
-)
-
-const dateTimeGranularityMillisecondsLayout = "2006-01-02T15:04:05.000Z"
+const dateTimeFormatMilliseconds = "2006-01-02T15:04:05.000Z"
 
 type Config struct {
 	Port                int    `json:"port"`
@@ -58,7 +51,7 @@ var (
 	instance            *CS
 	port                = 8887
 	boundPort           int
-	dateTimeGranularity = DateTimeGranularitySeconds
+	dateTimeGranularity = "seconds"
 	externalUrl         string
 )
 
@@ -143,16 +136,16 @@ func CurrentConfig() Config {
 
 func configureDateTimeGranularity(granularity string) {
 	switch strings.ToLower(granularity) {
-	case "", DateTimeGranularitySeconds:
-		dateTimeGranularity = DateTimeGranularitySeconds
+	case "", "seconds":
+		dateTimeGranularity = "seconds"
 		types.DateTimeFormat = time.RFC3339
-	case DateTimeGranularityMilliseconds:
-		dateTimeGranularity = DateTimeGranularityMilliseconds
-		types.DateTimeFormat = dateTimeGranularityMillisecondsLayout
+	case "milliseconds":
+		dateTimeGranularity = "milliseconds"
+		types.DateTimeFormat = dateTimeFormatMilliseconds
 	default:
-		dateTimeGranularity = DateTimeGranularitySeconds
+		dateTimeGranularity = "seconds"
 		types.DateTimeFormat = time.RFC3339
-		util.NewLogger("ocpp").WARN.Printf("unsupported dateTimeGranularity %q, using %s", granularity, DateTimeGranularitySeconds)
+		util.NewLogger("ocpp").WARN.Printf("unsupported dateTimeGranularity %q, using seconds", granularity)
 	}
 }
 

--- a/charger/ocpp/instance_test.go
+++ b/charger/ocpp/instance_test.go
@@ -1,8 +1,13 @@
 package ocpp
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -27,4 +32,27 @@ func TestExternalUrl(t *testing.T) {
 			t.Errorf("ExternalUrl(%q) = %q, want %q", tt.input, result, tt.expected)
 		}
 	}
+}
+
+func TestConfigureDateTimeGranularity(t *testing.T) {
+	origGranularity := dateTimeGranularity
+	origTypeFormat := types.DateTimeFormat
+	t.Cleanup(func() {
+		dateTimeGranularity = origGranularity
+		types.DateTimeFormat = origTypeFormat
+	})
+
+	ts := types.NewDateTime(time.Date(2026, 6, 23, 12, 45, 9, 404_000_000, time.UTC))
+
+	configureDateTimeGranularity(DateTimeGranularitySeconds)
+	b, err := json.Marshal(ts)
+	require.NoError(t, err)
+	require.JSONEq(t, `"2026-06-23T12:45:09Z"`, string(b))
+	require.Equal(t, DateTimeGranularitySeconds, CurrentConfig().DateTimeGranularity)
+
+	configureDateTimeGranularity(DateTimeGranularityMilliseconds)
+	b, err = json.Marshal(ts)
+	require.NoError(t, err)
+	require.JSONEq(t, `"2026-06-23T12:45:09.404Z"`, string(b))
+	require.Equal(t, DateTimeGranularityMilliseconds, CurrentConfig().DateTimeGranularity)
 }

--- a/charger/ocpp/instance_test.go
+++ b/charger/ocpp/instance_test.go
@@ -44,15 +44,15 @@ func TestConfigureDateTimeGranularity(t *testing.T) {
 
 	ts := types.NewDateTime(time.Date(2026, 6, 23, 12, 45, 9, 404_000_000, time.UTC))
 
-	configureDateTimeGranularity(DateTimeGranularitySeconds)
+	configureDateTimeGranularity("seconds")
 	b, err := json.Marshal(ts)
 	require.NoError(t, err)
 	require.JSONEq(t, `"2026-06-23T12:45:09Z"`, string(b))
-	require.Equal(t, DateTimeGranularitySeconds, CurrentConfig().DateTimeGranularity)
+	require.Equal(t, "seconds", CurrentConfig().DateTimeGranularity)
 
-	configureDateTimeGranularity(DateTimeGranularityMilliseconds)
+	configureDateTimeGranularity("milliseconds")
 	b, err = json.Marshal(ts)
 	require.NoError(t, err)
 	require.JSONEq(t, `"2026-06-23T12:45:09.404Z"`, string(b))
-	require.Equal(t, DateTimeGranularityMilliseconds, CurrentConfig().DateTimeGranularity)
+	require.Equal(t, "milliseconds", CurrentConfig().DateTimeGranularity)
 }

--- a/evcc.dist.yaml
+++ b/evcc.dist.yaml
@@ -10,6 +10,14 @@ network:
 
 interval: 30s # control cycle interval. Interval <30s can lead to unexpected behavior, see https://docs.evcc.io/docs/reference/configuration/interval
 
+# OCPP server configuration
+# ocpp:
+#   port: 8887
+#   # dateTimeGranularity controls the precision of OCPP dateTime values sent by evcc.
+#   # Use milliseconds for chargers that require a fractional-second component.
+#   # Supported values: seconds, milliseconds
+#   dateTimeGranularity: seconds
+
 # database configuration for persisting charge sessions and settings
 # database:
 #   type: sqlite

--- a/templates/definition/charger/ocpp-webasto-next.yaml
+++ b/templates/definition/charger/ocpp-webasto-next.yaml
@@ -1,0 +1,40 @@
+template: ocpp-webasto-next
+products:
+  - brand: Ampure
+    description:
+      generic: NEXT (OCPP)
+  - brand: Webasto
+    description:
+      generic: NEXT (OCPP)
+capabilities: ["mA", "rfid", "dim"]
+requirements:
+  description:
+    de: |
+      Die Webasto/Ampure NEXT muss als OCPP 1.6J Ladepunkt konfiguriert werden.
+
+      Voraussetzungen:
+      * Modbus/HEMS in der Wallbox deaktivieren (ModBusMode = 0). Aktives Modbus/HEMS kann OCPP-Fehler CB26/CB27 verursachen.
+      * In der evcc OCPP-Serverkonfiguration `dateTimeGranularity: milliseconds` setzen, z.B.:
+        ```yaml
+        ocpp:
+          port: 8887
+          dateTimeGranularity: milliseconds
+        ```
+      * Backend-URL (Central System) in der Wallbox: `ws://<evcc-host>:8887/`
+    en: |
+      Configure the Webasto/Ampure NEXT as an OCPP 1.6J charge point.
+
+      Requirements:
+      * Disable Modbus/HEMS in the charger (ModBusMode = 0). Active Modbus/HEMS may cause OCPP errors CB26/CB27.
+      * Set `dateTimeGranularity: milliseconds` in the evcc OCPP server configuration, e.g.:
+        ```yaml
+        ocpp:
+          port: 8887
+          dateTimeGranularity: milliseconds
+        ```
+      * Backend URL (Central System) in the charger: `ws://<evcc-host>:8887/`
+  evcc: ["sponsorship", "skiptest"]
+params:
+  - preset: ocpp
+render: |
+  {{ include "ocpp" . }}


### PR DESCRIPTION
## Summary

A few independent changes were necessary to make Webasto/Ampure NEXT chargers work over OCPP with evcc. This adds a server-wide OCPP timestamp granularity setting, fixes BootNotification handling on websocket reconnects, and adds a dedicated Webasto/Ampure NEXT template documenting the required setup.

## OCPP timestamp granularity

The Webasto NEXT fails immediately after `BootNotificationResponse.currentTime` is accepted if the timestamp does not include a fractional-second component. Its vendor-specific `pyocppd` clock synchronization parses backend timestamps with a mandatory `.%f`, so evcc's default whole-second output makes it raise a `ValueError` and drop the connection.

This adds an `ocpp.dateTimeGranularity` server setting controlling how evcc serializes OCPP `dateTime` values. The default `seconds` preserves the current output; `milliseconds` emits a fixed fractional-second component. The setting is server-wide because `ocpp-go` exposes `dateTime` serialization through a package-global formatter.

## BootNotification on reconnect

evcc waits for a BootNotification before treating a websocket session as ready, and proactively triggers one if the charger stays silent. Previously this trigger was skipped whenever BootNotification metadata from an earlier session was already cached. The NEXT may not re-send BootNotification on a new websocket once it considers itself accepted by the backend, leaving the session stuck until the timeout fallback.

This refines the proactive BootNotification trigger added in #28540. That change fixed chargers that stay silent on initial connect, where no BootNotification metadata is cached yet. Its cached-metadata guard avoids duplicate triggers, but it also suppresses the trigger on later reconnects where the cached metadata is from a previous websocket connection rather than the current one.

BootNotification readiness is now tracked per websocket connection instead of using cached metadata as a proxy. evcc may trigger BootNotification for the current session even when metadata from a previous session exists. BootNotifications requested this way are treated as websocket-connection handshakes and are not forwarded to the reboot monitor, so they no longer cause unnecessary setup reinitialization.

## Webasto/Ampure NEXT template

A new `ocpp-webasto-next` charger template documents the required setup: disable Modbus/HEMS on the charger (active Modbus/HEMS surfaces as OCPP errors CB26/CB27), point the charger at evcc's OCPP backend URL, and set `ocpp.dateTimeGranularity: milliseconds`.
