### PR TITLE
Update hoymiles-opendtu.yaml

### DIFF
--- a/templates/definition/meter/hoymiles-opendtu.yaml
+++ b/templates/definition/meter/hoymiles-opendtu.yaml
@@ -13,7 +13,7 @@ render: |
     source: http
     uri: http://{{ .host }}/api/livedata/status
     jq: .total.Power.v
-energy:
-  source: http
-  uri: http://{{ .host }}/api/livedata/status
-  jq: 'if all(.inverters[]; .radio_stats.rssi > -127) then .total.YieldTotal.v else empty end'
+  energy:
+    source: http
+    uri: http://{{ .host }}/api/livedata/status
+    jq: 'if all(.inverters[]; .radio_stats.rssi > -127) then .total.YieldTotal.v else empty end'

--- a/templates/definition/meter/hoymiles-opendtu.yaml
+++ b/templates/definition/meter/hoymiles-opendtu.yaml
@@ -13,7 +13,7 @@ render: |
     source: http
     uri: http://{{ .host }}/api/livedata/status
     jq: .total.Power.v
-  energy:
-    source: http
-    uri: http://{{ .host }}/api/livedata/status
-    jq: .total.YieldTotal.v
+energy:
+  source: http
+  uri: http://{{ .host }}/api/livedata/status
+  jq: 'if all(.inverters[]; .radio_stats.rssi > -127) then .total.YieldTotal.v else empty end'


### PR DESCRIPTION
fix total_yield energy after connection loss/restart when not all inverters are connected to an OpenDTU instance and thus Total Yield is only a partial sum of partial inverters. Solution: Check RSSI of all registered inverters.

Fix: https://github.com/evcc-io/evcc/issues/30154

Tested against reconnects and works.