### PR TITLE
HEMS EEBus: expose connected and failsafe state via API/MQTT

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -362,17 +362,31 @@ func runRoot(cmd *cobra.Command, args []string) {
 		} else if hemsInstance != nil {
 			// republish when HEMS state updates
 			hemsInstance.SetUpdated(func() {
+				// connection/failsafe are an optional EEBus-specific capability;
+				// other HEMS implementations omit them
+				var connected, failsafe *bool
+				if s, ok := hemsInstance.(interface {
+					Connected() *bool
+					Failsafe() *bool
+				}); ok {
+					connected, failsafe = s.Connected(), s.Failsafe()
+				}
+
 				valueChan <- util.Param{Key: keys.Hems, Val: globalconfig.ConfigStatus{
 					Config: struct {
 						Configured bool `json:"configured"`
 					}{hemsInstance != nil},
 					YamlSource: yamlSource.hems,
 					Status: struct {
+						Connected           *bool    `json:"connected,omitempty"`
+						Failsafe            *bool    `json:"failsafe,omitempty"`
 						Dimmed              *bool    `json:"dimmed,omitempty"`
 						Curtailed           *int     `json:"curtailed,omitempty"`
 						MaxConsumptionPower float64  `json:"maxConsumptionPower,omitempty"`
 						MaxProductionPower  *float64 `json:"maxProductionPower,omitempty"`
 					}{
+						Connected:           connected,
+						Failsafe:            failsafe,
 						Dimmed:              hemsInstance.Dimmed(),
 						Curtailed:           hemsInstance.CurtailedPercent(),
 						MaxConsumptionPower: hemsInstance.MaxConsumptionPower(),

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -31,6 +31,7 @@ type EEBus struct {
 	passthrough func(bool) error
 	publishFunc func()
 
+	connected     bool
 	status        status
 	statusUpdated time.Time
 
@@ -306,7 +307,36 @@ func (c *EEBus) setProductionLimit(limit float64, active bool) {
 	}
 }
 
+// Connect tracks the live connection state and signals the connector so that
+// Wait() unblocks on the first connect. It shadows the embedded Connector's
+// promoted method.
+func (c *EEBus) Connect(connected bool) {
+	c.mux.Lock()
+	c.connected = connected
+	c.mux.Unlock()
+
+	if c.Connector != nil {
+		c.Connector.Connect(connected)
+	}
+}
+
 var _ api.HEMS = (*EEBus)(nil)
+
+// Connected is an optional EEBus-specific capability,
+// reporting whether the connection to the Steuerbox is currently active.
+func (c *EEBus) Connected() *bool {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return new(c.connected)
+}
+
+// Failsafe is an optional EEBus-specific capability,
+// reporting whether evcc is currently operating in failsafe mode.
+func (c *EEBus) Failsafe() *bool {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return new(c.status == StatusFailsafe)
+}
 
 // Dimmed implements api.HEMS, derived from consumptionLimitActivated.
 func (c *EEBus) Dimmed() *bool {

--- a/hems/eebus/eebus_test.go
+++ b/hems/eebus/eebus_test.go
@@ -63,6 +63,39 @@ func assertProductionLimit(t *testing.T, c *EEBus, active bool) {
 	assert.Equal(t, active, *percent < 100)
 }
 
+// TestConnected verifies the api.HEMS Connected() statement tracks the
+// connect/disconnect callbacks. The embedded connector is left nil here;
+// Connect is nil-safe and the real connector path is covered end-to-end by
+// the controlbox test in server/eebus.
+func TestConnected(t *testing.T) {
+	c := newTestEEBus(t)
+
+	assert.Equal(t, new(false), c.Connected(), "not connected initially")
+
+	c.Connect(true)
+	assert.Equal(t, new(true), c.Connected(), "connected after Connect(true)")
+
+	c.Connect(false)
+	assert.Equal(t, new(false), c.Connected(), "disconnected after Connect(false)")
+}
+
+// TestFailsafe verifies the api.HEMS Failsafe() statement tracks the internal
+// status as it transitions across run().
+func TestFailsafe(t *testing.T) {
+	c := newTestEEBus(t)
+
+	assert.Equal(t, new(false), c.Failsafe(), "normal initially")
+
+	// heartbeat never Set -> missing heartbeat enters failsafe
+	require.NoError(t, c.run())
+	assert.Equal(t, new(true), c.Failsafe(), "failsafe on missing heartbeat")
+
+	// heartbeat returns -> leaves failsafe
+	c.heartbeat.Set(struct{}{})
+	require.NoError(t, c.run())
+	assert.Equal(t, new(false), c.Failsafe(), "normal after heartbeat returns")
+}
+
 // TestRun_HeartbeatLost_EntersFailsafe verifies the LPC-911/LPP-911 transition:
 // a missing heartbeat in the normal state must apply the configured failsafe
 // consumption and production limits.

--- a/server/eebus/test/cs_test.go
+++ b/server/eebus/test/cs_test.go
@@ -48,8 +48,11 @@ func TestEEBus(t *testing.T) {
 	box.remoteEventC = eventC
 
 	// no hems.Run(): the run loop applies limits via the nil site and is not needed here
-	_, err = hems.NewEEBus(t.Context(), box.ski, eebus.Limits{}, nil, nil, time.Second)
+	hems, err := hems.NewEEBus(t.Context(), box.ski, eebus.Limits{}, nil, nil, time.Second)
 	require.NoError(t, err, "hems")
+
+	// NewEEBus only returns after the connection is established
+	require.Equal(t, new(true), hems.Connected(), "hems connected")
 
 	// wait for DataUpdateLimit which signals that limit descriptions and data are available
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
Exposes two EEBus HEMS runtime states through the API/MQTT,
so they can be observed externally (I use Home Assistant to alert me, for example):

- **connected** - is the EEBus connection to the Steuerbox currently active?
- **failsafe** - is evcc currently operating in failsafe mode?

Both are surfaced under `hems.status`.

These states were already tracked internally, but weren't observable from
the outside.

## Implementation

- I added `Connected()` and `Failsafe()` added to the `api.HEMS` interface,
  returning `*bool` (nil = no statement), consistent with the existing
  `Dimmed()` / `Curtailed()` (I thought it would fit best there, happy to change it if we want to keep it our of the FNN/Relay interfaces).
- `failsafe` reads the existing `StatusFailsafe` state.
- `connected` is newly tracked: the shared connector only captured the
  first connect (for `Wait()`), so the EEBus HEMS now records live
  connect/disconnect via a `Connect()` shadow.
- FNN and Relay return `nil` (as they have no connection / failsafe concept), so
  the fields are omitted in the API/MQTT for those HEMS types, though they are in the interfaces returning `nil`.

## Testing

- I added unit tests for `Connected()` (connect/disconnect) and `Failsafe()`
  (heartbeat loss/return) in `hems/eebus`.
- Extended the controlbox integration test to assert `Connected()` over a
  real SHIP connection.
- Verified end-to-end against an EEBus Steuerbox simulator: both values
  appear in MQTT, and `failsafe` flips after the ~2 min heartbeat timeout
  when the simulator is stopped.

This is my first time contributing to evcc - so let me know if I should change anything (or if I missed something) :)