### PR TITLE
Tariffs: Add pvnode Solar Forecast API V2

### DIFF
--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -30,10 +30,10 @@ params:
       en: Forecast days
       de: Vorhersagetage
     help:
-      en: The free plan of pvnode only allows 2 forecast day.
-      de: Der kostenlose Plan von pvnode erlaubt nur 2 Vorhersagetag.
+      en: The free plan of pvnode only allows 1 forecast day (1 = today + tomorrow).
+      de: Der kostenlose Plan von pvnode erlaubt nur 1 Vorhersagetag (1 = heute + morgen).
     type: int
-    default: 2
+    default: 1
     advanced: true
 
 render: |
@@ -42,18 +42,15 @@ render: |
   features: ["cacheable"]
   forecast:
     source: http
-    uri: https://api.pvnode.com/v2/forecast/{{ .site_id }}?forecast_days={{ .forecast_days }}&past_days=0
+    uri: https://api.pvnode.com/v2/forecast/{{ .site_id }}?forecast_days={{ .forecast_days }}&past_days=0&timezone=utc
     auth:
       type: bearer
       token: {{ .apikey }}
     jq: |
-      def toEpoch: sub("\\.[0-9]+"; "") | strptime("%FT%T") | mktime;
-
       [.values[] |
-        (.timestamp | toEpoch) as $t |
         {
-          start: ($t | todateiso8601),
-          end:   ($t + 900 | todateiso8601),
-          value: (.pv_power | round)
+          start: (.timestamp),
+          end:   (.timestamp | fromdateiso8601 + 900 | todateiso8601 ),
+          value: (.pv_power | round )
         }
       ] | tostring

--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -5,12 +5,12 @@ requirements:
   description:
     en: |
       [pvnode V2 API](https://pvnode.com) provides 15-minute PV production forecasts via REST API Version 2 with site ID and easy configuration via web app.
-      An API key is required (free plan available with +1 day forecast).
-      **Attention**: The free plan only allows 40 queries per month. These queries must be from only one location (lat, lon). Location is saved on first request and can not be changed afterwards, otherwise a 403 response is sent.
+      An API key is required (free plan available).
+      **Attention**: The free plan only allows one fixed site with forecasts for today & tomorrow and only one update per day and 250 cached queries.
     de: |
       [pvnode V2 API](https://pvnode.com) liefert 15-Minuten PV Vorhersagen per REST API Version 2 mit Standort-ID und leichter Konfiguration über Web-App
-      Ein API-Key ist erforderlich (kostenloser Plan mit +1 Tag Vorhersage verfügbar).
-      **Achtung**: Mit dem kostenlosen Plan sind lediglich 40 Abfragen/Monat erlaubt. Diese Abfragen dürfen nur von einem Standort (lat, lon) sein. Der Standort wird bei der ersten Abfrage gespeichert und kann danach nicht mehr angepasst werden, andernfalls wird eine 403 Antwort gesendet.
+      Ein API-Key ist erforderlich (kostenloser Plan möglich)
+      **Achtung**: Mit dem kostenlosen Plan ist nur ein Standort (fest) möglich mit einer Prognose für Heute & Morgen und nur einem Update pro Tag und 250 gecached Abfragen.
   evcc: ["skiptest"]
 group: solar
 
@@ -27,10 +27,13 @@ params:
     required: true
   - name: forecast_days
     description:
-      en: Forecast days (free plan = 1).
-      de: Vorhersagetage (Free Plan = 1).
+      en: Forecast days
+      de: Vorhersagetage
+    help:
+      en: The free plan of pvnode only allows 2 forecast day.
+      de: Der kostenlose Plan von pvnode erlaubt nur 2 Vorhersagetag.
     type: int
-    default: 1
+    default: 2
     advanced: true
 
 render: |

--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -47,10 +47,17 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
+      def localTimeToIso8601:
+        # Removes fractional seconds if present, Parses YYYY-MM-DDTHH:MM:SS as local time, Converts via epoch, Formats as UTC ISO8601
+        sub("\\.[0-9]+"; "")
+        | strptime("%FT%T")
+        | mktime
+        | strftime("%Y-%m-%dT%H:%M:%SZ");
+
       [.values[] |
         {
-          start: (.timestamp + "Z"),
-          end:   (.timestamp + "Z" | fromdateiso8601 + 900 | todateiso8601 ),
+          start: (.timestamp | localTimeToIso8601),
+          end:   (.timestamp | localTimeToIso8601 | fromdateiso8601 + 900 | todateiso8601),
           value: (.pv_power | round )
         }
       ] | tostring

--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -1,0 +1,53 @@
+template: pvnode-v2
+products:
+  - brand: pvnode V2 API
+requirements:
+  description:
+    en: |
+      [pvnode V2 API](https://pvnode.com) provides 15-minute PV production forecasts via REST API Version 2 with site ID and easy configuration via web app.
+      An API key is required (free plan available with +1 day forecast).
+      **Attention**: The free plan only allows 40 queries per month. These queries must be from only one location (lat, lon). Location is saved on first request and can not be changed afterwards, otherwise a 403 response is sent.
+    de: |
+      [pvnode V2 API](https://pvnode.com) liefert 15-Minuten PV Vorhersagen per REST API Version 2 mit Standort-ID und leichter Konfiguration über Web-App
+      Ein API-Key ist erforderlich (kostenloser Plan mit +1 Tag Vorhersage verfügbar).
+      **Achtung**: Mit dem kostenlosen Plan sind lediglich 40 Abfragen/Monat erlaubt. Diese Abfragen dürfen nur von einem Standort (lat, lon) sein. Der Standort wird bei der ersten Abfrage gespeichert und kann danach nicht mehr angepasst werden, andernfalls wird eine 403 Antwort gesendet.
+  evcc: ["skiptest"]
+group: solar
+
+params:
+  - name: site_id
+    description:
+      en: Site ID
+      de: Standort-ID
+    required: true
+  - name: apikey
+    description:
+      en: pvnode API key
+      de: pvnode API Key
+    required: true
+  - name: forecast_days
+    description:
+      en: Forecast days (free plan = 1).
+      de: Vorhersagetage (Free Plan = 1).
+    type: int
+    default: 1
+    advanced: true
+
+render: |
+  type: custom
+  tariff: solar
+  features: ["cacheable"]
+  forecast:
+    source: http
+    uri: https://api.pvnode.com/v2/forecast/{{ .site_id }}?forecast_days={{ .forecast_days }}&past_days=0
+    auth:
+      type: bearer
+      token: {{ .apikey }}
+    jq: |
+      [.values[] |
+        {
+          start: (.timestamp + "Z"),
+          end:   (.timestamp + "Z" | fromdateiso8601 + 900 | todateiso8601 ),
+          value: (.pv_power | round )
+        }
+      ] | tostring

--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -47,17 +47,13 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
-      def localTimeToIso8601:
-        # Removes fractional seconds if present, Parses YYYY-MM-DDTHH:MM:SS as local time, Converts via epoch, Formats as UTC ISO8601
-        sub("\\.[0-9]+"; "")
-        | strptime("%FT%T")
-        | mktime
-        | strftime("%Y-%m-%dT%H:%M:%SZ");
+      def toEpoch: sub("\\.[0-9]+"; "") | strptime("%FT%T") | mktime;
 
       [.values[] |
+        (.timestamp | toEpoch) as $t |
         {
-          start: (.timestamp | localTimeToIso8601),
-          end:   (.timestamp | localTimeToIso8601 | fromdateiso8601 + 900 | todateiso8601),
-          value: (.pv_power | round )
+          start: ($t | todateiso8601),
+          end:   ($t + 900 | todateiso8601),
+          value: (.pv_power | round)
         }
       ] | tostring

--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -31,8 +31,11 @@ params:
     required: true
   - name: forecast_days
     description:
-      en: Forecast days (free plan = 1).
-      de: Vorhersagetage (Free Plan = 1).
+      en: Forecast days
+      de: Vorhersagetage
+    help:
+      en: The free plan of pvnode only allows 1 forecast day.
+      de: Der kostenlose Plan von pvnode erlaubt nur 1 Vorhersagetag.
     type: int
     default: 1
     advanced: true


### PR DESCRIPTION
New Tariff for pvnode Solar forecast API version 2 using a site ID instead of individual lat, lon, az, ... values and therefores easy to configure via Web UI.

Fix #31132 