### PR TITLE
goodwe-hybrid: add grid voltage measurements

### DIFF
--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -85,6 +85,37 @@ render: |
         register: 36017
         count: 10
       scale: -1
+  voltages:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 36052 # Meter Voltage R, V
+        type: holding
+        decode: uint16nan
+      block: # 36052-36057
+        register: 36052
+        count: 6
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 36053 # Meter Voltage S, V
+        type: holding
+        decode: uint16nan
+      block: # 36052-36057
+        register: 36052
+        count: 6
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 36054 # Meter Voltage T, V
+        type: holding
+        decode: uint16nan
+      block: # 36052-36057
+        register: 36052
+        count: 6
+      scale: 0.1
   currents:
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -92,9 +123,9 @@ render: |
         address: 36055 # Meter Current R, A
         type: holding
         decode: uint16nan
-      block: # 36055-36057
-        register: 36055
-        count: 3
+      block: # 36052-36057
+        register: 36052
+        count: 6
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -102,9 +133,9 @@ render: |
         address: 36056 # Meter Current S, A
         type: holding
         decode: uint16nan
-      block: # 36055-36057
-        register: 36055
-        count: 3
+      block: # 36052-36057
+        register: 36052
+        count: 6
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -112,9 +143,9 @@ render: |
         address: 36057 # Meter Current T, A
         type: holding
         decode: uint16nan
-      block: # 36055-36057
-        register: 36055
-        count: 3
+      block: # 36052-36057
+        register: 36052
+        count: 6
       scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}


### PR DESCRIPTION
**Summary**

Add support for reading L1/L2/L3 grid voltages from GoodWe hybrid inverters.

The following meter registers are exposed through the voltages field:

36052 - Meter L1 Voltage
36053 - Meter L2 Voltage
36054 - Meter L3 Voltage

**Implementation**

The existing current block read has been extended from:

register: 36055
count: 3

to:

register: 36052
count: 6

This allows voltage and current values to be retrieved using a single Modbus request:

**Benefits**

Adds per-phase grid voltage reporting.
No additional Modbus requests are required.
Reuses the existing block read mechanism already used for phase currents.