### PR TITLE
OCPP: serialize dateTime with fractional seconds

### DIFF
--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -21,10 +21,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ws"
 )
 
-// dateTimeFormat fixes the OCPP dateTime serialization to RFC3339 with a
-// fractional-second component for all chargers. Sub-second precision is valid
-// RFC3339/ISO8601 and is required by some chargers (e.g. Webasto/Ampure NEXT)
-// that reject timestamps without it, while remaining compatible with all others.
+// dateTimeFormat sets the OCPP dateTime serialization to RFC3339 with fractional seconds
 const dateTimeFormat = "2006-01-02T15:04:05.000Z07:00"
 
 func init() {

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -16,9 +16,20 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/security"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/lorenzodonini/ocpp-go/ocppj"
 	"github.com/lorenzodonini/ocpp-go/ws"
 )
+
+// dateTimeFormat fixes the OCPP dateTime serialization to RFC3339 with a
+// fractional-second component for all chargers. Sub-second precision is valid
+// RFC3339/ISO8601 and is required by some chargers (e.g. Webasto/Ampure NEXT)
+// that reject timestamps without it, while remaining compatible with all others.
+const dateTimeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+func init() {
+	types.DateTimeFormat = dateTimeFormat
+}
 
 type Config struct {
 	Port int `json:"port"`

--- a/charger/ocpp/instance_test.go
+++ b/charger/ocpp/instance_test.go
@@ -1,8 +1,13 @@
 package ocpp
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -27,4 +32,13 @@ func TestExternalUrl(t *testing.T) {
 			t.Errorf("ExternalUrl(%q) = %q, want %q", tt.input, result, tt.expected)
 		}
 	}
+}
+
+func TestDateTimeFormatHasFractionalSeconds(t *testing.T) {
+	require.Equal(t, dateTimeFormat, types.DateTimeFormat)
+
+	ts := types.NewDateTime(time.Date(2026, 6, 23, 12, 45, 9, 404_000_000, time.UTC))
+	b, err := json.Marshal(ts)
+	require.NoError(t, err)
+	require.JSONEq(t, `"2026-06-23T12:45:09.404Z"`, string(b))
 }

--- a/charger/ocpp/instance_test.go
+++ b/charger/ocpp/instance_test.go
@@ -41,4 +41,9 @@ func TestDateTimeFormatHasFractionalSeconds(t *testing.T) {
 	b, err := json.Marshal(ts)
 	require.NoError(t, err)
 	require.JSONEq(t, `"2026-06-23T12:45:09.404Z"`, string(b))
+
+	// the emitted format must round-trip back to the same instant
+	var got types.DateTime
+	require.NoError(t, json.Unmarshal(b, &got))
+	require.True(t, ts.Equal(got.Time), "round-trip mismatch: %s != %s", ts, got)
 }


### PR DESCRIPTION
Changes the OCPP `dateTime` serialisation format to RFC3339 with fractional seconds (`2026-06-23T12:45:09.404Z`).

Previously, ocpp-go used the default `time.RFC3339` (second granularity, no fractional part).

Background: Some chargers (e.g. Webasto/Ampure NEXT) reject timestamps without a fractional part.

Fixes part of https://github.com/evcc-io/evcc/pull/31158