### PR TITLE
OCPP: per-connection BootNotification handshake on reconnect

### DIFF
--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -40,6 +40,11 @@ type CP struct {
 	bootNotificationRequestC chan *core.BootNotificationRequest
 	BootNotificationResult   *core.BootNotificationRequest
 
+	// bootTriggered is set while evcc has requested a BootNotification (via
+	// TriggerMessage) to complete the current connection handshake. The matching
+	// BootNotification must not be treated as a physical charger reboot.
+	bootTriggered bool
+
 	connectors map[int]*Connector
 }
 
@@ -153,21 +158,34 @@ func (cp *CP) onTransportConnect() {
 	defer cp.mu.Unlock()
 
 	cp.stopBootTimer()
-	cp.bootTimer = time.AfterFunc(Timeout, cp.onBootTimeout)
+	cp.bootTriggered = false
 
-	// Proactively trigger BootNotification after a short delay.
-	// This helps chargers that don't send it spontaneously (e.g. Wallbox FW 6.x).
-	// The TriggerMessage is sent directly via the OCPP instance, bypassing the
-	// Connected() check which would fail at this point.
+	// The timer pointer itself identifies this connection: stopBootTimer or a
+	// later onTransportConnect replaces it, so delayed callbacks below detect a
+	// stale connection by finding cp.bootTimer no longer equal to their timer.
+	var timer *time.Timer
+	timer = time.AfterFunc(Timeout, func() {
+		cp.onBootTimeout(timer)
+	})
+	cp.bootTimer = timer
+
+	// Proactively trigger BootNotification after a short delay. This helps
+	// chargers that don't send it spontaneously (e.g. Wallbox FW 6.x) or stay
+	// silent on a reconnect because they already consider themselves accepted
+	// (e.g. Webasto NEXT). The TriggerMessage is sent directly via the OCPP
+	// instance, bypassing the Connected() check which would fail at this point.
 	time.AfterFunc(TriggerBootDelay, func() {
-		cp.mu.RLock()
-		// If BootNotification already arrived or timer was cancelled (disconnect),
-		// there is nothing to do.
-		if cp.bootTimer == nil || cp.BootNotificationResult != nil {
-			cp.mu.RUnlock()
+		cp.mu.Lock()
+		// Nothing to do if this connection is gone (disconnect or new connect) or
+		// the BootNotification already arrived (both clear/replace bootTimer).
+		if cp.bootTimer != timer {
+			cp.mu.Unlock()
 			return
 		}
-		cp.mu.RUnlock()
+		// Mark the solicited BootNotification so OnBootNotification treats it as a
+		// handshake rather than a physical reboot.
+		cp.bootTriggered = true
+		cp.mu.Unlock()
 
 		cp.log.DEBUG.Printf("proactively triggering BootNotification")
 
@@ -187,14 +205,16 @@ func (cp *CP) onTransportConnect() {
 }
 
 // onBootTimeout is called when the BootNotification wait timer expires.
-func (cp *CP) onBootTimeout() {
+func (cp *CP) onBootTimeout(timer *time.Timer) {
 	cp.mu.Lock()
-	if cp.bootTimer == nil {
-		// timer was cancelled by disconnect or BootNotification
+	if cp.bootTimer != timer {
+		// timer was cancelled by disconnect/BootNotification or superseded by a
+		// newer connection
 		cp.mu.Unlock()
 		return
 	}
 	cp.bootTimer = nil
+	cp.bootTriggered = false
 	cp.mu.Unlock()
 
 	cp.log.DEBUG.Printf("boot notification timeout, proceeding")

--- a/charger/ocpp/cp.go
+++ b/charger/ocpp/cp.go
@@ -22,10 +22,11 @@ type CP struct {
 
 	id string
 
-	connected bool
-	bootTimer *time.Timer // timeout for BootNotification wait after WebSocket connect
-	connectC  chan struct{}
-	meterC    chan struct{}
+	connected     bool
+	bootTimer     *time.Timer // timeout for BootNotification wait after WebSocket connect
+	bootTriggered bool
+	connectC      chan struct{}
+	meterC        chan struct{}
 
 	// configuration properties
 	PhaseSwitching          bool
@@ -39,11 +40,6 @@ type CP struct {
 	meterValuesSample        string
 	bootNotificationRequestC chan *core.BootNotificationRequest
 	BootNotificationResult   *core.BootNotificationRequest
-
-	// bootTriggered is set while evcc has requested a BootNotification (via
-	// TriggerMessage) to complete the current connection handshake. The matching
-	// BootNotification must not be treated as a physical charger reboot.
-	bootTriggered bool
 
 	connectors map[int]*Connector
 }

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -22,25 +22,31 @@ func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.B
 
 	cp.mu.Lock()
 	cp.BootNotificationResult = request
+	// A BootNotification evcc solicited to complete the connection handshake is
+	// not a charger reboot and must not trigger setup reinitialization.
+	triggered := cp.bootTriggered
+	cp.bootTriggered = false
 	cp.stopBootTimer()
 	cp.mu.Unlock()
 
 	// mark charge point as ready for communication
 	cp.connect(true)
 
-	// Notify the reboot monitor (and the initial Setup). The channel is
-	// buffered (size 1) and coalescing: if an older notification is still
-	// queued, drop it so the consumer always re-initializes against the most
-	// recent BootNotification. This matters when a charge point reboot-loops
-	// (e.g. issue #30113) faster than the monitor consumes notifications, or
-	// before the monitor has started at all - the channel must never overflow.
-	select {
-	case <-cp.bootNotificationRequestC:
-	default:
-	}
-	select {
-	case cp.bootNotificationRequestC <- request:
-	default:
+	if !triggered {
+		// Notify the reboot monitor (and the initial Setup). The channel is
+		// buffered (size 1) and coalescing: if an older notification is still
+		// queued, drop it so the consumer always re-initializes against the most
+		// recent BootNotification. This matters when a charge point reboot-loops
+		// (e.g. issue #30113) faster than the monitor consumes notifications, or
+		// before the monitor has started at all - the channel must never overflow.
+		select {
+		case <-cp.bootNotificationRequestC:
+		default:
+		}
+		select {
+		case cp.bootNotificationRequestC <- request:
+		default:
+		}
 	}
 
 	return res, nil

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -22,8 +22,6 @@ func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.B
 
 	cp.mu.Lock()
 	cp.BootNotificationResult = request
-	// A BootNotification evcc solicited to complete the connection handshake is
-	// not a charger reboot and must not trigger setup reinitialization.
 	triggered := cp.bootTriggered
 	cp.bootTriggered = false
 	cp.stopBootTimer()

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -21,8 +21,12 @@ func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.B
 	}
 
 	cp.mu.Lock()
+	prev := cp.BootNotificationResult
 	cp.BootNotificationResult = request
-	triggered := cp.bootTriggered
+	// A BootNotification evcc solicited to complete the connection handshake is
+	// not a charger reboot - unless its content changed (e.g. a new firmware
+	// version), which means the charger actually restarted and setup must re-run.
+	triggered := cp.bootTriggered && prev != nil && *prev == *request
 	cp.bootTriggered = false
 	cp.stopBootTimer()
 	cp.mu.Unlock()

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -243,24 +243,56 @@ func TestMonitorRebootOnlyOnce(t *testing.T) {
 func TestTriggeredBootNotificationDoesNotNotifyRebootMonitor(t *testing.T) {
 	log := util.NewLogger("test")
 	cp := NewChargePoint(log, "test-cp")
-	// metadata from a previous connection plus a solicited (triggered) BootNotification
-	cp.BootNotificationResult = &core.BootNotificationRequest{ChargePointModel: "Cached"}
+	boot := core.BootNotificationRequest{
+		ChargePointModel:  "Model",
+		ChargePointVendor: "TestVendor",
+		FirmwareVersion:   "1.0.0",
+	}
+	// unchanged metadata from a previous connection plus a solicited boot
+	cached := boot
+	cp.BootNotificationResult = &cached
 	cp.bootTriggered = true
 
-	_, err := cp.OnBootNotification(&core.BootNotificationRequest{
-		ChargePointModel:  "Triggered",
-		ChargePointVendor: "TestVendor",
-	})
+	current := boot
+	_, err := cp.OnBootNotification(&current)
 	require.NoError(t, err)
 	assert.True(t, cp.Connected())
 	assert.False(t, cp.bootTriggered, "flag should be consumed")
-	require.NotNil(t, cp.BootNotificationResult)
-	assert.Equal(t, "Triggered", cp.BootNotificationResult.ChargePointModel, "cached metadata should be refreshed")
+	assert.Equal(t, &current, cp.BootNotificationResult, "metadata should be refreshed")
 
 	select {
 	case req := <-cp.bootNotificationRequestC:
-		t.Fatalf("triggered BootNotification should not notify reboot monitor, got %s", req.ChargePointModel)
+		t.Fatalf("unchanged triggered BootNotification should not notify reboot monitor, got %s", req.ChargePointModel)
 	default:
+	}
+}
+
+// TestTriggeredBootNotificationWithChangedIdentityNotifiesRebootMonitor covers a
+// charger that actually restarted (e.g. firmware update) but whose boot arrives as
+// a solicited one: the changed content must still trigger a setup re-initialization.
+func TestTriggeredBootNotificationWithChangedIdentityNotifiesRebootMonitor(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+	cp.BootNotificationResult = &core.BootNotificationRequest{
+		ChargePointModel:  "Model",
+		ChargePointVendor: "TestVendor",
+		FirmwareVersion:   "1.0.0",
+	}
+	cp.bootTriggered = true
+
+	_, err := cp.OnBootNotification(&core.BootNotificationRequest{
+		ChargePointModel:  "Model",
+		ChargePointVendor: "TestVendor",
+		FirmwareVersion:   "1.1.0", // updated firmware
+	})
+	require.NoError(t, err)
+	assert.True(t, cp.Connected())
+
+	select {
+	case req := <-cp.bootNotificationRequestC:
+		assert.Equal(t, "1.1.0", req.FirmwareVersion)
+	default:
+		t.Fatal("changed triggered BootNotification should notify reboot monitor")
 	}
 }
 

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -254,12 +254,30 @@ func TestTriggeredBootNotificationDoesNotNotifyRebootMonitor(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, cp.Connected())
 	assert.False(t, cp.bootTriggered, "flag should be consumed")
+	require.NotNil(t, cp.BootNotificationResult)
+	assert.Equal(t, "Triggered", cp.BootNotificationResult.ChargePointModel, "cached metadata should be refreshed")
 
 	select {
 	case req := <-cp.bootNotificationRequestC:
 		t.Fatalf("triggered BootNotification should not notify reboot monitor, got %s", req.ChargePointModel)
 	default:
 	}
+}
+
+// TestBootTimeoutClearsTriggeredFlag ensures a solicited BootNotification that never
+// arrives does not leak the bootTriggered flag past the connection: the boot timeout
+// must clear it so the next connection's spontaneous boot is treated as a reboot.
+func TestBootTimeoutClearsTriggeredFlag(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+	cp.bootTriggered = true
+
+	timer := time.AfterFunc(time.Hour, func() {})
+	cp.bootTimer = timer
+	cp.onBootTimeout(timer)
+
+	assert.False(t, cp.bootTriggered, "flag must be cleared on boot timeout")
+	assert.True(t, cp.Connected())
 }
 
 func TestSpontaneousBootNotificationNotifiesRebootMonitor(t *testing.T) {

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -239,3 +239,44 @@ func TestMonitorRebootOnlyOnce(t *testing.T) {
 	require.Eventually(t, func() bool { return callCount.Load() == 1 }, time.Second, 10*time.Millisecond,
 		"setup should be called exactly once")
 }
+
+func TestTriggeredBootNotificationDoesNotNotifyRebootMonitor(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+	// metadata from a previous connection plus a solicited (triggered) BootNotification
+	cp.BootNotificationResult = &core.BootNotificationRequest{ChargePointModel: "Cached"}
+	cp.bootTriggered = true
+
+	_, err := cp.OnBootNotification(&core.BootNotificationRequest{
+		ChargePointModel:  "Triggered",
+		ChargePointVendor: "TestVendor",
+	})
+	require.NoError(t, err)
+	assert.True(t, cp.Connected())
+	assert.False(t, cp.bootTriggered, "flag should be consumed")
+
+	select {
+	case req := <-cp.bootNotificationRequestC:
+		t.Fatalf("triggered BootNotification should not notify reboot monitor, got %s", req.ChargePointModel)
+	default:
+	}
+}
+
+func TestSpontaneousBootNotificationNotifiesRebootMonitor(t *testing.T) {
+	log := util.NewLogger("test")
+	cp := NewChargePoint(log, "test-cp")
+
+	_, err := cp.OnBootNotification(&core.BootNotificationRequest{
+		ChargePointModel:  "Rebooted",
+		ChargePointVendor: "TestVendor",
+	})
+	require.NoError(t, err)
+	assert.True(t, cp.Connected())
+
+	select {
+	case req := <-cp.bootNotificationRequestC:
+		assert.Equal(t, "Rebooted", req.ChargePointModel)
+	default:
+		t.Fatal("spontaneous BootNotification should notify reboot monitor")
+	}
+}

--- a/charger/ocpp/cp_setup.go
+++ b/charger/ocpp/cp_setup.go
@@ -107,30 +107,6 @@ func (cp *CP) Setup(ctx context.Context, meterValues string, meterInterval time.
 		}
 	}
 
-	// BootNotification is normally received before Setup runs (we wait for it
-	// after WebSocket connect). Only trigger it as fallback for chargers that
-	// didn't send it (e.g. timeout-based connection without reboot).
-	cp.mu.RLock()
-	hasBootResult := cp.BootNotificationResult != nil
-	cp.mu.RUnlock()
-
-	if !hasBootResult && cp.HasRemoteTriggerFeature {
-		if err := cp.TriggerMessageRequest(0, core.BootNotificationFeatureName); err != nil {
-			cp.log.DEBUG.Printf("failed triggering BootNotification: %v", err)
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(Timeout):
-			cp.log.DEBUG.Printf("BootNotification timeout")
-		case res := <-cp.bootNotificationRequestC:
-			cp.mu.Lock()
-			cp.BootNotificationResult = res
-			cp.mu.Unlock()
-		}
-	}
-
 	// autodetect measurands
 	if meterValues == "" && meterValuesSampledDataMaxLength > 0 {
 		sampledMeasurands := cp.tryMeasurands(desiredMeasurands, KeyMeterValuesSampledData)


### PR DESCRIPTION
## Problem

evcc waits for a BootNotification before treating a websocket session as ready and proactively triggers one (via `TriggerMessage`, added in #28540) if the charger stays silent. The proactive trigger was skipped whenever BootNotification metadata from an earlier session was already cached (`BootNotificationResult != nil`).

Some chargers (e.g. Webasto/Ampure NEXT) do not re-send BootNotification on a new websocket once they consider themselves accepted by the backend. With cached metadata present the trigger never fired, so the session stayed stuck until the full timeout fallback.

## Fix

BootNotification readiness is tracked **per websocket connection** instead of using cached metadata as a proxy:

- The proactive BootNotification trigger now fires based on the current connection's boot timer, independent of any cached `BootNotificationResult`, so a reconnect is handled even when earlier metadata exists.
- A BootNotification that evcc solicited this way is only a connection handshake, **not** a real charger reboot, and is no longer forwarded to the reboot monitor — so it no longer causes unnecessary setup reinitialization on every reconnect.

### Implementation

- The `*time.Timer` pointer itself identifies the connection. Delayed callbacks (trigger / timeout) capture their own timer and bail out once `cp.bootTimer` no longer equals it (replaced by `stopBootTimer` on disconnect or by a newer `onTransportConnect`).
- A single `bootTriggered` bool, set just before the `TriggerMessage` and consumed in `OnBootNotification`. Reset on every new connection and on boot timeout, so it cannot leak across connections.

## Reboot detection survives the suppression (content comparison)

Suppressing full setup run for solicited boots could otherwise hide a genuine restart whose BootNotification happens to arrive as the solicited one (e.g. a firmware update whose post-reboot boot lands after the proactive 5s trigger). To close this, a solicited BootNotification is only suppressed when its **content is unchanged**. If any identity field differs (firmware version, model, serial, …) the charger really restarted, so it is forwarded to the reboot monitor and setup re-runs — independent of timing.

| BootNotification | content vs. previous | result |
| --- | --- | --- |
| spontaneous | — | re-init (real reboot) |
| solicited | unchanged | suppressed (plain reconnect) |
| solicited | changed (e.g. new firmware) | re-init |

## Removed the redundant Setup BootNotification fallback

`Setup` contained a second BootNotification trigger+wait that only ran when `BootNotificationResult == nil`. That field is set on every BootNotification and never reset, so it can only be nil on the very first `Setup` *and* only if the per-connection handshake above already timed out without any BootNotification — every reconnect and reboot-driven re-run sees it non-nil and skipped the block anyway. The handshake now reliably obtains the BootNotification (spontaneous or proactively triggered) before `Setup` runs, so this fallback covered no real gap. Removed; the only observable effect of a nil result is the diagnostics dump omitting vendor/model on that rare first-connect timeout path.

Fixes part of #31158