### PR TITLE
Add Fixed property to Params and hide fixed params in the GUI

### DIFF
--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -343,7 +343,8 @@ export default defineComponent({
 		},
 		templateParams() {
 			const params = this.template?.Params || [];
-			const filtered = params.filter(
+			const editableParams = params.filter((p) => !p.Fixed);
+			const filtered = editableParams.filter(
 				(p) =>
 					!this.customFields.includes(p.Name) &&
 					(p.Usages ? p.Usages.includes(this.deviceType as any) : true)
@@ -351,7 +352,7 @@ export default defineComponent({
 
 			// Allow parent to customize parameter filtering (passes all params for full control)
 			if (this.filterTemplateParams) {
-				return this.filterTemplateParams(params);
+				return this.filterTemplateParams(editableParams);
 			}
 
 			return filtered;

--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -42,6 +42,7 @@ export type TemplateParam = {
   Choice?: string[];
   Service?: string;
   Usages?: TemplateParamUsage[];
+  Fixed?: boolean;
 };
 
 export type ParamService = {

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -228,6 +228,7 @@ type Param struct {
 	Choice      []string     `json:",omitempty"` // defines a set of choices, e.g. "grid", "pv", "battery", "charge" for "usage"
 	Service     string       `json:",omitempty"` // defines a service to provide choices
 	Pattern     *Pattern     `json:",omitempty"` // regex pattern and examples for input validation
+	Fixed       bool         `json:",omitempty"` // if the value is fixed and cannot be changed by the user
 
 	// TODO move somewhere else should not be part of the param definition
 	Baudrate int    `json:",omitempty"` // device specific default for modbus RS485 baudrate


### PR DESCRIPTION
parameters defined in a preset can be fixed in the template to a value and will then be hidden in the GUI.

idea was triggered by https://github.com/evcc-io/evcc/pull/31047#discussion_r3468644332

usage example in vehicle-template:
```
params:
  - preset: vehicle-base
  - preset: vehicle-features
  - name: streaming
    default: true
    fixed: true
```
(streaming is part of "vehicle-features", for this car it will be fixed to true and will not be shown in the GUI)