### PR TITLE
Add Eltako DSZ15DZMOD/DSZ16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/teslamotors/vehicle-command v0.4.1
 	github.com/tess1o/go-ecoflow v1.1.1-0.20251003083510-2ccc15a17e29
 	github.com/traefik/yaegi v0.16.1
-	github.com/volkszaehler/mbmd v0.0.0-20260609133612-a18fb7d50aeb
+	github.com/volkszaehler/mbmd v0.0.0-20260623211432-fb8f9c22f121
 	github.com/warthog618/go-gpiocdev v0.9.1
 	gitlab.com/bboehmke/sunny v0.17.0
 	go.bug.st/serial v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -543,8 +543,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/volkszaehler/mbmd v0.0.0-20260609133612-a18fb7d50aeb h1:qpSpkXp+U9oEbrBFMfbGwKLW4UE+XOWVEMm7ShrirP0=
-github.com/volkszaehler/mbmd v0.0.0-20260609133612-a18fb7d50aeb/go.mod h1:hx00iJeEiVti6jY7HwLIiShGWdjAAxY7vDdhx/Ys1ys=
+github.com/volkszaehler/mbmd v0.0.0-20260623211432-fb8f9c22f121 h1:eDW8HHhwxp1HQQu9uNPMs7TUKZQkTKhe5LkBfhQ+bZA=
+github.com/volkszaehler/mbmd v0.0.0-20260623211432-fb8f9c22f121/go.mod h1:hx00iJeEiVti6jY7HwLIiShGWdjAAxY7vDdhx/Ys1ys=
 github.com/warthog618/go-gpiocdev v0.9.1 h1:pwHPaqjJfhCipIQl78V+O3l9OKHivdRDdmgXYbmhuCI=
 github.com/warthog618/go-gpiocdev v0.9.1/go.mod h1:dN3e3t/S2aSNC+hgigGE/dBW8jE1ONk9bDSEYfoPyl8=
 github.com/warthog618/go-gpiosim v0.1.1 h1:MRAEv+T+itmw+3GeIGpQJBfanUVyg0l3JCTwHtwdre4=

--- a/templates/definition/meter/eltako-dsz.yaml
+++ b/templates/definition/meter/eltako-dsz.yaml
@@ -1,4 +1,4 @@
-template: eltako-dsz15dzmod
+template: eltako-dsz
 products:
   - brand: Eltako
     description:

--- a/templates/definition/meter/eltako-dsz15dzmod.yaml
+++ b/templates/definition/meter/eltako-dsz15dzmod.yaml
@@ -1,0 +1,46 @@
+template: eltako-dsz15dzmod
+products:
+  - brand: Eltako
+    description:
+      generic: DSZ15DZMOD
+  - brand: Eltako
+    description:
+      generic: DSZ16
+params:
+  - name: usage
+    choice: ["grid", "pv", "charge"]
+  - name: modbus
+    choice: ["rs485"]
+render: |
+  type: mbmd
+  {{- include "modbus" . }}
+  model: eltakodsz15
+  {{- if ne .usage "pv" }}
+  power: Power
+  energy: Import
+  returnenergy: Export
+  currents:
+    - CurrentL1
+    - CurrentL2
+    - CurrentL3
+  powers:
+    - PowerL1
+    - PowerL2
+    - PowerL3
+  {{- else }}
+  power: -Power
+  energy: Export
+  returnenergy: Import
+  currents:
+    - -CurrentL1
+    - -CurrentL2
+    - -CurrentL3
+  powers:
+    - -PowerL1
+    - -PowerL2
+    - -PowerL3
+  {{- end }}
+  voltages:
+    - VoltageL1
+    - VoltageL2
+    - VoltageL3


### PR DESCRIPTION
Adds a meter template for Eltako **DSZ15DZMOD** and **DSZ16** (integer data format) RS485 Modbus meters.

Uses the native mbmd `ELTAKODSZ15` producer added in volkszaehler/mbmd#390 (replacement for the generic Modbus template proposed in #31127). Bumps the `github.com/volkszaehler/mbmd` dependency to pull in that producer.