### PR TITLE
UI: fix rs485-only modbus templates

### DIFF
--- a/assets/js/components/Config/DeviceModal/Modbus.vue
+++ b/assets/js/components/Config/DeviceModal/Modbus.vue
@@ -259,7 +259,7 @@ export default defineComponent({
 		selectedModbus(newValue: MODBUS_TYPE) {
 			this.$emit("update:modbus", newValue);
 		},
-		options(newValue: ModbusCapability[]) {
+		capabilities(newValue: ModbusCapability[]) {
 			this.setProtocolByCapabilities(newValue);
 			this.$emit("update:modbus", this.selectedModbus);
 		},
@@ -288,7 +288,14 @@ export default defineComponent({
 	},
 	mounted() {
 		this.localDevice = this.device;
-		this.setConnectionAndProtocolByModbus(this.modbus);
+		if (this.modbus) {
+			this.setConnectionAndProtocolByModbus(this.modbus);
+		} else {
+			// new device: derive protocol from template capabilities so that
+			// rs485-only templates (e.g. evse-din via RS485/Ethernet adapter)
+			// default to Modbus RTU (rs485tcpip) instead of native Modbus TCP
+			this.setProtocolByCapabilities(this.capabilities);
+		}
 		this.$emit("update:modbus", this.selectedModbus);
 		this.updateServiceValues();
 	},

--- a/assets/js/components/Config/DeviceModal/Modbus.vue
+++ b/assets/js/components/Config/DeviceModal/Modbus.vue
@@ -291,9 +291,7 @@ export default defineComponent({
 		if (this.modbus) {
 			this.setConnectionAndProtocolByModbus(this.modbus);
 		} else {
-			// new device: derive protocol from template capabilities so that
-			// rs485-only templates (e.g. evse-din via RS485/Ethernet adapter)
-			// default to Modbus RTU (rs485tcpip) instead of native Modbus TCP
+			// new device: rs485-only templates default to RTU, not native TCP
 			this.setProtocolByCapabilities(this.capabilities);
 		}
 		this.$emit("update:modbus", this.selectedModbus);


### PR DESCRIPTION
The new Modbus device-config component defaulted the protocol to Modbus-TCP
for every TCP/IP connection, regardless of the template's capabilities. For
rs485-only templates (e.g. evse-din behind an RS485/Ethernet adapter) this
produced `modbus: tcpip` (rtu: false), so evcc opened a native Modbus-TCP
connection to an adapter that only speaks Modbus-RTU-over-TCP, failing with an
i/o timeout. The same device works via YAML because that explicitly sets
`modbus: rs485tcpip`.

setProtocolByCapabilities() already derives the correct protocol from the
template capabilities, but it was only wired to a watcher on a non-existent
`options` prop and was therefore never invoked. Fix by calling it for new
devices in mounted() and renaming the dead watcher to `capabilities`.

Fixes #30580

---

## Analyse / Genehmigter Plan

### Problem

Nutzer betreibt eine **EVSE-DIN** Wallbox über einen **Waveshare RS485↔Ethernet-Adapter** (`192.168.143.24:502`). Der Adapter spricht **Modbus-RTU über TCP** (RTU-Framing in einem TCP-Socket), *nicht* natives Modbus-TCP.

- **Per YAML funktioniert es** (seit Monaten, auch in v0.308.1):
  ```yaml
  chargers:
    - name: EVSE_WB
      type: template
      template: evse-din
      modbus: rs485tcpip   # <- erzwingt RTU-over-TCP
      id: 1
      host: 192.168.143.24
      port: 502
  ```
- **Per Web-UI angelegt → `i/o timeout`**:
  ```
  cannot create charger type 'template:evse-din':
  cannot create charger type 'evsedin':
  read tcp ...->192.168.143.24:502: i/o timeout
  ```
- Im laufenden Betrieb (YAML) zeigt das TRACE-Log erfolgreiche RTU-Kommunikation (`send 01 03 03 ea 00 01 a5 ba` — CRC am Ende = RTU-Framing). Hardware/Netz/Slave-ID sind in Ordnung. Das Problem liegt **ausschließlich im UI-Anlage-/Testpfad** — es ist **kein Netzwerkproblem**.

### Root Cause

Die UI erzeugt für die EVSE-DIN den **falschen Modbus-Verbindungstyp** `tcpip` (natives Modbus-TCP, `rtu: false`) statt `rs485tcpip` (RTU-over-TCP, `rtu: true`). Damit öffnet evcc eine native Modbus-TCP-Verbindung zum Waveshare-Adapter, der nur RTU-over-TCP versteht → keine/fehlerhafte Antwort → **i/o timeout**.

#### Genauer Mechanismus

Pfad: `assets/js/components/Config/DeviceModal/Modbus.vue`.

1. Template `templates/definition/charger/evse-din.yaml` hat `modbus.choice: ["rs485"]` → `DeviceModalBase.vue` `modbusCapabilities = ["rs485"]` (enthält **kein** `"tcpip"`).
2. `Modbus.vue` Default-State: `connection: TCPIP`, `protocol: TCP`.
3. `mounted()` ruft `setConnectionAndProtocolByModbus(this.modbus)`. Bei einem **neuen** Gerät ist `this.modbus` leer → `switch` trifft nichts → Default bleibt `TCPIP/TCP`.
4. `selectedModbus`: `TCPIP + TCP` → `MODBUS_TYPE.TCPIP` = **`"tcpip"`**, wird emittiert.
5. Backend `util/templates/modbus.tpl` rendert für `modbus: tcpip` → `rtu: false`.
6. `util/modbus/modbus.go` `Settings.Protocol()`: ohne `rtu:true` → **`Tcp`** → `meters.NewTCP()` statt `meters.NewRTUOverTCP()` → Timeout am Waveshare.

#### Der eigentliche Bug: tote Verdrahtung von `setProtocolByCapabilities`

`Modbus.vue` enthält bereits die Korrektur-Logik:

```js
setProtocolByCapabilities(capabilities) {
  this.protocol = capabilities.includes("tcpip") ? MODBUS_PROTOCOL.TCP : MODBUS_PROTOCOL.RTU;
}
```

Für ein rs485-only-Template (`capabilities = ["rs485"]`, kein `"tcpip"`) würde sie das Protokoll korrekt auf **RTU** setzen → `selectedModbus = rs485tcpip` → `rtu: true` → funktioniert.

**Aber sie wird nie aufgerufen.** Der einzige Aufrufer war der Watcher `options(newValue)` — und es gibt **keine Prop `options`** (die Prop heißt `capabilities`). Der Watcher feuert also nie; `mounted()` rief `setProtocolByCapabilities` ebenfalls nicht auf. Damit blieb der Protokoll-Default fälschlich bei `TCP`, unabhängig von den Template-Capabilities.

→ Für jede **rs485-only**-Vorlage (EVSE-DIN u. a.) lieferte die UI als Default `modbus: tcpip`. Der Nutzer hätte den Protokoll-Umschalter manuell von „Modbus TCP" auf „Modbus RTU" stellen müssen — was den Regress zu v0.308.0 erklärt (vor dem Refactor der Connection/Protocol-Umschaltung wurde der Choice-Wert `rs485tcpip` direkt verwendet). Warum YAML funktioniert: dort steht `modbus: rs485tcpip` explizit → `rtu: true`.

### Fix

In `assets/js/components/Config/DeviceModal/Modbus.vue`:

1. **`mounted()`**: wenn kein bestehender `modbus`-Wert vorliegt (neues Gerät), das Protokoll via `setProtocolByCapabilities(this.capabilities)` aus den Capabilities ableiten, bevor `selectedModbus` emittiert wird.
2. **Toten Watcher reparieren**: `options(newValue)` → `capabilities(newValue)` umbenennen.

Damit ist der Default für rs485-only-Vorlagen `rs485tcpip` (RTU-over-TCP) und entspricht dem funktionierenden YAML. Templates mit `tcpip`-Capability (z. B. keba-modbus) bleiben unverändert auf TCP, bereits konfigurierte Geräte werden weiter aus ihrem gespeicherten `modbus`-Wert abgeleitet.

### Verifikation

- **Manuell (UI)**: EVSE-DIN im Config-Assistenten anlegen, nur Host/Port/ID setzen, **ohne** den Protokoll-Toggle anzufassen → erzeugte Instanz muss `rtu: true` / `rs485tcpip` ergeben und der Test muss die Wallbox erreichen (kein Timeout).
- **Gegenprobe**: Vorlage mit `tcpip`-Capability (z. B. keba-modbus) muss weiterhin `tcpip` defaulten.
- `vue-tsc --noEmit` läuft sauber durch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)