### PR TITLE
DriveSomethingGreater: log data point id before name

### DIFF
--- a/vehicle/vw/eudataact/store.go
+++ b/vehicle/vw/eudataact/store.go
@@ -161,7 +161,7 @@ func (s *store) snapshot(vin string) map[string]point {
 func logData(log *util.Logger, data map[string]point) {
 	for _, k := range slices.Sorted(maps.Keys(data)) {
 		p := data[k]
-		log.DEBUG.Printf("recv %s: %s (%s)", k, p.Value, p.Timestamp.Local().Format("2006-01-02 15:04:05"))
+		log.DEBUG.Printf("recv %s %s: %s (%s)", p.Key, p.Name, p.Value, p.Timestamp.Local().Format("2006-01-02 15:04:05"))
 	}
 }
 

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -84,9 +84,11 @@ type dataPoint struct {
 	TimestampUtc  *time.Time `json:"timestampUtc"`
 }
 
-// point is a decoded data point: its value, the time it was recorded and the
-// delivery sequence of the dataset it last arrived in (higher Seq is newer).
+// point is a decoded data point: its unique GUID (Key), delivered field Name,
+// value, record time and dataset delivery sequence (higher Seq is newer).
 type point struct {
+	Key       string
+	Name      string
 	Value     string
 	Timestamp time.Time
 	Seq       uint64
@@ -228,7 +230,7 @@ func points(data []dataPoint) map[string]point {
 		if p.TimestampUtc != nil {
 			ts = *p.TimestampUtc
 		}
-		pt := point{Value: p.Value, Timestamp: ts}
+		pt := point{Key: p.Key, Name: p.DataFieldName, Value: p.Value, Timestamp: ts}
 
 		set(p.DataFieldName, pt)
 		if _, ok := knownKeys[p.Key]; ok {


### PR DESCRIPTION
The eu-data-act store's debug log printed only the map index per data point. This logs the point's unique GUID (id) before its delivered field name, so points are identifiable in traces (`recv <id> <name>: <value> (<timestamp>)`).

`point` now carries its `Key` (id) and `Name`; populated in `points()`, used in `logData`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)