### PR TITLE
EEBus: log rejected EVSE load control writes

### DIFF
--- a/charger/eebus.go
+++ b/charger/eebus.go
@@ -11,6 +11,7 @@ import (
 	"github.com/enbility/eebus-go/usecases/cem/evcc"
 	"github.com/enbility/eebus-go/usecases/cem/evcem"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/core/loadpoint"
@@ -344,7 +345,7 @@ func (c *EEBus) writeCurrentLimitData(evEntity spineapi.EntityRemoteInterface, c
 	}
 
 	// always set overload protection limits (obligation)
-	if _, err := c.cem.OpEV.WriteLoadControlLimits(evEntity, limits, nil); err != nil {
+	if _, err := c.cem.OpEV.WriteLoadControlLimits(evEntity, limits, c.callbackResult("opEV limits")); err != nil {
 		return err
 	}
 
@@ -394,8 +395,24 @@ func (c *EEBus) writeOscevLimits(evEntity spineapi.EntityRemoteInterface, curren
 		limits = append(limits, limit)
 	}
 
-	if _, err := c.cem.OscEV.WriteLoadControlLimits(evEntity, limits, nil); err != nil {
+	if _, err := c.cem.OscEV.WriteLoadControlLimits(evEntity, limits, c.callbackResult("oscEV limits")); err != nil {
 		c.log.DEBUG.Println("failed to write OSCEV limits:", err)
+	}
+}
+
+// callbackResult logs a rejected eebus write; a successful result is ignored.
+func (c *EEBus) callbackResult(msg string) func(model.ResultDataType) {
+	return func(result model.ResultDataType) {
+		if result.ErrorNumber == nil || *result.ErrorNumber == 0 {
+			return
+		}
+
+		if result.Description != nil {
+			c.log.ERROR.Printf("%s: write rejected: %d (%s)", msg, *result.ErrorNumber, *result.Description)
+			return
+		}
+
+		c.log.ERROR.Printf("%s: write rejected: %d", msg, *result.ErrorNumber)
 	}
 }
 


### PR DESCRIPTION
The EVSE OpEV (overload protection) and OscEV (self-consumption) load control limit writes passed a `nil` result callback, so only the synchronous send error was checked. The heat pump/EVSE's asynchronous write result was dropped, meaning a rejected limit write (e.g. `errorNumber != 0`) was completely invisible.

Pass a result callback that logs rejections, mirroring the existing pattern in `meter/eebus.go`. Successful writes are ignored; only rejections are logged.

`go build`, `go vet`, `gofmt`, charger tests, and golangci-lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
