### PR TITLE
teslamate: use usable_battery_level instead of battery_level

### DIFF
--- a/templates/definition/vehicle/teslamate.yaml
+++ b/templates/definition/vehicle/teslamate.yaml
@@ -22,7 +22,7 @@ render: |
   {{- include "vehicle-common" . }}
   soc:
     source: mqtt
-    topic: teslamate/cars/{{ .id }}/battery_level
+    topic: teslamate/cars/{{ .id }}/usable_battery_level
     timeout: {{ .timeout }}
   status:
     source: combined


### PR DESCRIPTION
Use `usable_battery_level` MQTT topic in the teslamate vehicle template so evcc displays the net usable SoC matching the Tesla app, not the raw value including non-accessible buffer zones.

Fixes #31227

Generated with [Claude Code](https://claude.ai/code)