### PR TITLE
vehicle: add welcomecharge to tibber and octopus-de templates

### DIFF
--- a/templates/definition/vehicle/octopus-de.yaml
+++ b/templates/definition/vehicle/octopus-de.yaml
@@ -18,6 +18,8 @@ requirements:
 params:
   - preset: vehicle-common
   - preset: vehicle-online
+  - name: welcomecharge
+    advanced: true
   - name: email
     required: true
   - name: password

--- a/templates/definition/vehicle/tibber.yaml
+++ b/templates/definition/vehicle/tibber.yaml
@@ -17,6 +17,8 @@ requirements:
 params:
   - preset: vehicle-common
   - preset: vehicle-online
+  - name: welcomecharge
+    advanced: true
   - name: clientid
   - name: clientsecret
   - name: redirecturi


### PR DESCRIPTION
Add `welcomecharge` feature to Tibber and Octopus Energy Germany vehicle configuration cards in the UI.

The `climaterdisabled` option was already available via the `vehicle-online` preset.

Fixes #31215

Generated with [Claude Code](https://claude.ai/code)