### PR TITLE
Tariff (Groupe E): cache rates to survive restart

### DIFF
--- a/templates/definition/tariff/groupe-e.yaml
+++ b/templates/definition/tariff/groupe-e.yaml
@@ -11,6 +11,7 @@ params:
   - preset: tariff-base
 render: |
   type: custom
+  features: ["cacheable"]
   {{ include "tariff-base" . }}
   forecast:
     source: http


### PR DESCRIPTION
Fix #31240

Groupe E rates only arrive from the next full UTC hour onward, so after a restart the planner has no rate for the current slot until the following fetch. Opting the template into the existing `cacheable` feature persists fetched rates to the database and restores them on startup, bridging the gap with data already known before the restart.

- add `features: ["cacheable"]` to the Groupe E template

Note: this resolves the restart case. A genuine cold first start still lacks the in-progress hour because the upstream API omits it — that is a separate API-shape limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)