### PR TITLE
Fix OpenAPI 3.1 spec validation errors

### DIFF
--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -269,8 +269,10 @@
               "properties": {
                 "result": {
                   "description": "Value is always null",
-                  "nullable": true,
-                  "type": "object"
+                  "type": [
+                    "object",
+                    "null"
+                  ]
                 }
               },
               "type": "object"
@@ -405,13 +407,17 @@
             },
             "meterStart": {
               "description": "Meter reading at start of charging session",
-              "nullable": true,
-              "type": "number"
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "meterStop": {
               "description": "Meter reading at end of charging session",
-              "nullable": true,
-              "type": "number"
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "odometer": {
               "$ref": "#/components/schemas/Odometer"
@@ -552,7 +558,9 @@
           "DEBUG",
           "TRACE"
         ],
-        "example": "DEBUG",
+        "examples": [
+          "DEBUG"
+        ],
         "externalDocs": {
           "url": "https://docs.evcc.io/en/docs/reference/configuration/log#log"
         },
@@ -570,8 +578,10 @@
       },
       "Odometer": {
         "description": "Vehicle odometer reading in kilometers",
-        "nullable": true,
-        "type": "number"
+        "type": [
+          "number",
+          "null"
+        ]
       },
       "Password": {
         "description": "Admin password",
@@ -584,7 +594,9 @@
           "1",
           "3"
         ],
-        "example": "3",
+        "examples": [
+          "3"
+        ],
         "type": "string"
       },
       "PlanRates": {

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -572,7 +572,7 @@ paths:
             schema:
               $ref: "#/components/schemas/PlanStrategy"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
@@ -1212,7 +1212,7 @@ paths:
             schema:
               $ref: "#/components/schemas/PlanStrategy"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
@@ -1401,12 +1401,10 @@ components:
           odometer:
             $ref: "#/components/schemas/Odometer"
           meterStart:
-            nullable: true
-            type: "number"
+            type: ["number", "null"]
             description: Meter reading at start of charging session
           meterStop:
-            nullable: true
-            type: "number"
+            type: ["number", "null"]
             description: Meter reading at end of charging session
           chargedEnergy:
             type: number
@@ -1504,7 +1502,8 @@ components:
       externalDocs:
         url: https://docs.evcc.io/en/docs/reference/configuration/log#log
       type: string
-      example: DEBUG
+      examples:
+        - DEBUG
       enum:
         - FATAL
         - ERROR
@@ -1521,8 +1520,7 @@ components:
         - "minpv"
         - "pv"
     Odometer:
-      nullable: true
-      type: "number"
+      type: ["number", "null"]
       description: Vehicle odometer reading in kilometers
     Password:
       description: Admin password
@@ -1530,7 +1528,8 @@ components:
     Phases:
       description: "Number of phases. (0: auto, 1: 1-phase, 3: 3-phase)"
       type: string
-      example: "3"
+      examples:
+        - "3"
       enum:
         - "0"
         - "1"
@@ -1869,8 +1868,7 @@ components:
             properties:
               result:
                 description: Value is always null
-                nullable: true
-                type: "object"
+                type: ["object", "null"]
     BlankResponse:
       description: Success - Blank response
     SuccessResult:


### PR DESCRIPTION
Fixes 14 spec validation errors flagged by `vacuum` lint (quality score 10→69; remaining items are warnings/infos only).

Changes in `server/openapi.yaml`:
- Quote `200` response keys (status codes must be string keys)
- Replace `nullable: true` + `type: X` with `type: ["X", "null"]` (×4) — `nullable` is removed in OpenAPI 3.1
- Use `examples` array instead of singular `example` on `LogLevel` and `Phases` — 3.1 schemas follow JSON Schema 2020-12; the singular `example` caused enum mis-validation

`server/mcp/openapi.json` regenerated via `go generate ./server/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)