### PR TITLE
Tariff: make Electricity Maps, Energy Price Forecast CO₂ cacheable

### DIFF
--- a/templates/definition/tariff/electricitymaps.yaml
+++ b/templates/definition/tariff/electricitymaps.yaml
@@ -25,6 +25,7 @@ params:
       en: "see [api.electricitymap.org](https://api.electricitymap.org/v3/zones)"
 render: |
   type: electricitymaps
+  features: ["cacheable"]
   uri: {{ .uri }}
   token: {{ .token }}
   zone: {{ .zone }}

--- a/templates/definition/tariff/energypriceforecast-co2.yaml
+++ b/templates/definition/tariff/energypriceforecast-co2.yaml
@@ -26,6 +26,7 @@ params:
     required: true
 render: |
   type: custom
+  features: ["cacheable"]
   tariff: co2
   forecast:
     source: http


### PR DESCRIPTION
fixes #31245
see also https://github.com/evcc-io/evcc/pull/31248

Opt the electricitymaps and energypriceforecast-co2 templates into the existing `cacheable` feature so fetched rates persist across restart. Bridges the missing current-slot gap that spams `planner: no matching rate` warnings.