### PR TITLE
Remote Access: improve back off behavior and error messages

### DIFF
--- a/server/remote/remote.go
+++ b/server/remote/remote.go
@@ -93,6 +93,11 @@ func (r *Remote) Enabled() bool {
 }
 
 func (r *Remote) connect() {
+	if !sponsor.IsAuthorizedForApi() {
+		r.log.WARN.Println("remote access requires a sponsor token")
+		return
+	}
+
 	r.mu.Lock()
 	token := r.settings.Token
 	r.mu.Unlock()

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -19,8 +19,6 @@ import (
 // bad registration token or sponsor token
 var errCredentialsRejected = errors.New("remote access rejected")
 
-const configRetryInterval = 15 * time.Minute
-
 const minUptime = 5 * time.Second
 
 // Tunnel manages a WebSocket+yamux tunnel to the cloud proxy.
@@ -70,23 +68,20 @@ func (t *Tunnel) run() {
 			t.log.ERROR.Printf("tunnel: %v", err)
 		}
 
+		// rejected credentials will not self-heal; a new token requires a restart
+		if errors.Is(err, errCredentialsRejected) {
+			return
+		}
+
 		// reset backoff only after a session that stayed connected
 		if ok {
 			bo.Reset()
 		}
 
-		var wait time.Duration
-		// rejected credentials will not self-heal; retry slowly
-		if errors.Is(err, errCredentialsRejected) {
-			wait = configRetryInterval
-		} else {
-			wait = bo.NextBackOff()
-		}
-
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(wait):
+		case <-time.After(bo.NextBackOff()):
 		}
 	}
 }

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -75,10 +75,12 @@ func (t *Tunnel) run() {
 			bo.Reset()
 		}
 
-		wait := bo.NextBackOff()
+		var wait time.Duration
 		// rejected credentials will not self-heal; retry slowly
 		if errors.Is(err, errCredentialsRejected) {
 			wait = configRetryInterval
+		} else {
+			wait = bo.NextBackOff()
 		}
 
 		select {

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -16,6 +16,13 @@ import (
 	"github.com/hashicorp/yamux"
 )
 
+// bad registration token or sponsor token
+var errCredentialsRejected = errors.New("remote access rejected")
+
+const configRetryInterval = 15 * time.Minute
+
+const minUptime = 5 * time.Second
+
 // Tunnel manages a WebSocket+yamux tunnel to the cloud proxy.
 type Tunnel struct {
 	tunnelURL     string
@@ -63,27 +70,44 @@ func (t *Tunnel) run() {
 			t.log.ERROR.Printf("tunnel: %v", err)
 		}
 
-		// reset backoff after successful connection
+		// reset backoff only after a session that stayed connected
 		if ok {
 			bo.Reset()
+		}
+
+		wait := bo.NextBackOff()
+		// rejected credentials will not self-heal; retry slowly
+		if errors.Is(err, errCredentialsRejected) {
+			wait = configRetryInterval
 		}
 
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(bo.NextBackOff()):
+		case <-time.After(wait):
 		}
 	}
 }
 
 func (t *Tunnel) connect(ctx context.Context) (bool, error) {
-	conn, _, err := websocket.Dial(ctx, t.tunnelURL, &websocket.DialOptions{
+	conn, resp, err := websocket.Dial(ctx, t.tunnelURL, &websocket.DialOptions{
 		HTTPHeader: http.Header{
 			"Authorization":   []string{"Bearer " + t.token},
 			"X-Sponsor-Token": []string{sponsor.Token},
 		},
 	})
 	if err != nil {
+		// rejected before the websocket upgrade; resp carries the HTTP status
+		if resp != nil {
+			switch resp.StatusCode {
+			case http.StatusConflict:
+				return false, errors.New("another evcc instance is already connected with these credentials")
+			case http.StatusUnauthorized:
+				return false, fmt.Errorf("%w (access revoked or sponsor token missing)", errCredentialsRejected)
+			case http.StatusForbidden:
+				return false, fmt.Errorf("%w (sponsor token invalid or expired)", errCredentialsRejected)
+			}
+		}
 		return false, fmt.Errorf("websocket dial: %w", err)
 	}
 
@@ -99,6 +123,7 @@ func (t *Tunnel) connect(ctx context.Context) (bool, error) {
 	}
 
 	t.changeState(session, nil)
+	start := time.Now()
 
 	// accept streams from the proxy
 	srv := &http.Server{
@@ -109,7 +134,8 @@ func (t *Tunnel) connect(ctx context.Context) (bool, error) {
 		t.changeState(nil, err)
 	}
 
-	return true, nil
+	// only a sustained connection resets backoff; an instant close keeps backing off
+	return time.Since(start) >= minUptime, nil
 }
 
 func (t *Tunnel) changeState(session *yamux.Session, err error) {


### PR DESCRIPTION
The tunnel client treated a rejected connection as a successful connect: it reset the backoff and reconnected about once a second, causing reconnect storms against the cloud proxy.

- A second evcc with the same credentials no longer reconnects every second; it waits and takes over once the first goes offline
- An expired sponsor token retries every 15 min with a clear log, instead of a tight loop
- A connection that drops instantly is no longer treated as healthy
- Only connect if valid sponsorship exists. Avoids api errors. Client only checked at setup time.