### PR TITLE
core: retry optimizer when battery measurements are not yet ready

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -110,6 +110,10 @@ type requestDetails struct {
 
 const slotsPerHour = float64(time.Hour / tariff.SlotDuration)
 
+// errOptimizerNotReady means battery measurements aren't available yet (e.g. at
+// startup); the slot gate is left open so the next cycle retries.
+var errOptimizerNotReady = errors.New("battery measurements not ready")
+
 func (site *Site) optimizerUpdateAsync() {
 	if !mu.TryLock() {
 		return
@@ -123,11 +127,16 @@ func (site *Site) optimizerUpdateAsync() {
 	var err error
 
 	defer func() {
-		optimizerUpdated = time.Now()
-
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic %v", r)
 		}
+
+		// not ready yet: keep the gate open for an immediate retry next cycle
+		if errors.Is(err, errOptimizerNotReady) {
+			return
+		}
+
+		optimizerUpdated = time.Now()
 
 		if err != nil {
 			site.log.ERROR.Println("optimizer:", err)
@@ -258,9 +267,13 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 		add(site.batteryRequest(dev, b, grid, minLen, firstSlotDuration))
 	}
 
-	// empty request- all loadpoints disabled
 	if len(req.Batteries) == 0 {
-		return nil
+		// meters configured but measurements not in yet: retry instead of
+		// consuming the slot gate
+		if len(site.batteryMeters) > 0 {
+			return errOptimizerNotReady
+		}
+		return nil // nothing to optimize
 	}
 
 	httpClient := request.NewClient(site.log)


### PR DESCRIPTION
## Why

Right after startup, battery `Soc`/`Capacity` aren't available yet, so the
per-battery loop skips them and `req.Batteries` is empty. `optimizerUpdate()`
then returned `nil` **silently**, while the deferred handler still stamped
`optimizerUpdated` — consuming the full slot gate (~15 min). So the first
`evopt` (and the UI Optimize entry) was delayed by a whole slot, even though
measurements arrive within seconds. No error was logged.

## How

Return a sentinel `errOptimizerNotReady` when the request is empty **and**
battery meters are configured; the deferred handler then leaves `optimizerUpdated`
untouched, so the next cycle retries immediately. Without battery meters it still
returns `nil` (no busy loop).

Preferred over a "trigger once at startup" hack: fixes the root cause without
guessing timing, and also covers other transient measurement lags.

## Result

First run now happens within ~1–2 measurement cycles instead of ~15 min. Other
first-run failures now surface as `ERROR` instead of being swallowed.

Closes #31275