### PR TITLE
Meter: fix spurious energy spikes (grid nonZeroEnergy + SolarEdge uint64snans)

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -844,8 +844,9 @@ func (site *Site) updateGridMeter() error {
 	}
 
 	// grid energy (import); nil when the device has no MeterEnergy capability or the read fails
+	// ignore spurious zero readings (NaN-derived or nightly reset, #30950)
 	if energyMeter, ok := api.Cap[api.MeterEnergy](site.gridMeter); ok {
-		if f, err := energyMeter.TotalEnergy(); err == nil {
+		if f, err := nonZeroEnergy(energyMeter.TotalEnergy()); err == nil {
 			mm.Energy = &f
 		} else if !errors.Is(err, api.ErrNotAvailable) {
 			site.log.ERROR.Printf("grid energy: %v", err)
@@ -853,8 +854,9 @@ func (site *Site) updateGridMeter() error {
 	}
 
 	// grid return energy (export); nil when the device has no MeterReturnEnergy capability or the read fails
+	// ignore spurious zero readings as above
 	if returnEnergyMeter, ok := api.Cap[api.MeterReturnEnergy](site.gridMeter); ok {
-		if f, err := returnEnergyMeter.ReturnEnergy(); err == nil {
+		if f, err := nonZeroEnergy(returnEnergyMeter.ReturnEnergy()); err == nil {
 			mm.ReturnEnergy = &f
 		} else if !errors.Is(err, api.ErrNotAvailable) {
 			site.log.ERROR.Printf("grid return energy: %v", err)

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -130,7 +130,7 @@ render: |
     register:
       address: 0xE176 # Battery 1 Lifetime Export Energy Counter (discharged)
       type: holding
-      decode: uint64s
+      decode: uint64snans
     scale: 0.001
   returnenergy:
     source: modbus
@@ -138,7 +138,7 @@ render: |
     register:
       address: 0xE17A # Battery 1 Lifetime Import Energy Counter (charged)
       type: holding
-      decode: uint64s
+      decode: uint64snans
     scale: 0.001
   batterymode:
     source: watchdog

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -130,7 +130,7 @@ render: |
     register:
       address: 0xE176 # Battery 1 Lifetime Export Energy Counter (discharged)
       type: holding
-      decode: uint64snans
+      decode: uint64snan
     scale: 0.001
   returnenergy:
     source: modbus
@@ -138,7 +138,7 @@ render: |
     register:
       address: 0xE17A # Battery 1 Lifetime Import Energy Counter (charged)
       type: holding
-      decode: uint64snans
+      decode: uint64snan
     scale: 0.001
   batterymode:
     source: watchdog

--- a/util/modbus/register.go
+++ b/util/modbus/register.go
@@ -125,7 +125,7 @@ func (r Register) DecodeFunc() (func([]byte) float64, error) {
 		return asFloat64(encoding.Uint64), nil
 	case "uint64s":
 		return asFloat64(uint64LswFirst), nil
-	case "uint64snans":
+	case "uint64snan":
 		return decodeNaN64(asFloat64(uint64LswFirst), 1<<64-1), nil
 	case "uint64nan":
 		return decodeNaN64(asFloat64(encoding.Uint64), 1<<64-1), nil

--- a/util/modbus/register.go
+++ b/util/modbus/register.go
@@ -125,6 +125,8 @@ func (r Register) DecodeFunc() (func([]byte) float64, error) {
 		return asFloat64(encoding.Uint64), nil
 	case "uint64s":
 		return asFloat64(uint64LswFirst), nil
+	case "uint64snans":
+		return decodeNaN64(asFloat64(uint64LswFirst), 1<<64-1), nil
 	case "uint64nan":
 		return decodeNaN64(asFloat64(encoding.Uint64), 1<<64-1), nil
 	case "float64":


### PR DESCRIPTION
fixes #31290

Two cleanly separated commits:

1. **Grid meter**: apply `nonZeroEnergy()` guard to `updateGridMeter()` — the same guard `collectMeters()` already uses for PV/battery/ext since #30950. A transient zero read was resetting the accumulator reference to 0, making the next valid read record the full lifetime counter value as a single slot’s delta.

2. **SolarEdge template**: add `uint64snans` decode variant (LSW-first uint64 with `0xFFFFFFFFFFFFFFFF` sentinel detection) and switch battery energy registers 0xE176/0xE17A to use it. SolarEdge returns all-F for uninitialised or briefly disconnected battery, which the existing `uint64s` decode passed through as ~1.8e16 kWh.

Generated with [Claude Code](https://claude.ai/code)