### PR TITLE
vehicle: mark climaterdisabled parameter as deprecated in iso15118 and offline templates

### DIFF
--- a/templates/definition/vehicle/iso15118.yaml
+++ b/templates/definition/vehicle/iso15118.yaml
@@ -18,6 +18,8 @@ requirements:
       Otherwise the vehicle cannot be put into sleep mode.
 params:
   - preset: vehicle-common
+  - name: climaterdisabled
+    deprecated: true
 render: |
   type: custom
   {{ include "vehicle-common" . }}

--- a/templates/definition/vehicle/offline.yaml
+++ b/templates/definition/vehicle/offline.yaml
@@ -12,6 +12,8 @@ params:
   - name: coarsecurrent
     advanced: true
   - name: welcomecharge
+  - name: climaterdisabled
+    deprecated: true
 render: |
   type: custom
   {{- include "vehicle-common" . }}


### PR DESCRIPTION
fixes #31291. Follow-up to https://github.com/evcc-io/evcc/pull/30610 and #30615