### PR TITLE
plugin: add state source to read published values in-process

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,6 +237,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 
 	// value cache
 	cache := util.NewParamCache()
+	util.SetDefaultParamCache(cache) // expose in-process for plugins (e.g. state source)
 	go cache.Run(pipe.NewDropper(ignoreLogs...).Pipe(tee.Attach()))
 
 	// create web server

--- a/plugin/state.go
+++ b/plugin/state.go
@@ -1,0 +1,135 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/evcc-io/evcc/plugin/pipeline"
+	"github.com/evcc-io/evcc/util"
+)
+
+// State reads a published value from the process-wide value cache (the same store
+// that backs /api/state) and forwards it to a nested setter. A jq filter navigates
+// nested values. This lets templates write a site-computed value to a device
+// register in-process, without an HTTP round-trip to the local API.
+type State struct {
+	ctx       context.Context
+	key       string
+	scale     float64
+	pipeline  *pipeline.Pipeline
+	setConfig *Config
+}
+
+func init() {
+	registry.AddCtx("state", NewStateFromConfig)
+}
+
+// NewStateFromConfig creates a state provider
+func NewStateFromConfig(ctx context.Context, other map[string]any) (Plugin, error) {
+	cc := struct {
+		Key               string
+		pipeline.Settings `mapstructure:",squash"`
+		Scale             float64
+		Set               *Config
+	}{
+		Scale: 1,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.Key == "" {
+		return nil, errors.New("missing key")
+	}
+
+	pipe, err := pipeline.New(util.ContextLoggerWithDefault(ctx, util.NewLogger("state")), cc.Settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return &State{
+		ctx:       ctx,
+		key:       cc.Key,
+		scale:     cc.Scale,
+		pipeline:  pipe,
+		setConfig: cc.Set,
+	}, nil
+}
+
+// value reads the cached value, applies the jq pipeline and returns it as float64.
+// Returns 0 when the key has not been published yet (the value source is absent).
+//
+// A null or empty jq result is surfaced as an error rather than silently mapped to
+// a value: defaulting is consumer policy, not transport behavior, and swallowing it
+// would hide a mistyped key/filter. Consumers that want a default must express it in
+// the jq, e.g. `(.foo) // 0`.
+func (p *State) value() (float64, error) {
+	v := util.DefaultParamCacheValue(p.key)
+	if v == nil {
+		return 0, nil
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0, err
+	}
+
+	if b, err = p.pipeline.Process(b); err != nil {
+		return 0, err
+	}
+
+	f, err := strconv.ParseFloat(strings.TrimSpace(string(b)), 64)
+	if err != nil {
+		return 0, err
+	}
+	return f * p.scale, nil
+}
+
+var _ FloatGetter = (*State)(nil)
+
+func (p *State) FloatGetter() (func() (float64, error), error) {
+	return p.value, nil
+}
+
+func (p *State) forward(param string) (func() error, error) {
+	if p.setConfig == nil {
+		return nil, errors.New("missing set config")
+	}
+	set, err := p.setConfig.FloatSetter(p.ctx, param)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		v, err := p.value()
+		if err != nil {
+			return err
+		}
+		return set(v)
+	}, nil
+}
+
+var _ IntSetter = (*State)(nil)
+
+// IntSetter ignores the input and forwards the cached value to the nested setter.
+func (p *State) IntSetter(param string) (func(int64) error, error) {
+	fwd, err := p.forward(param)
+	if err != nil {
+		return nil, err
+	}
+	return func(int64) error { return fwd() }, nil
+}
+
+var _ FloatSetter = (*State)(nil)
+
+// FloatSetter ignores the input and forwards the cached value to the nested setter.
+func (p *State) FloatSetter(param string) (func(float64) error, error) {
+	fwd, err := p.forward(param)
+	if err != nil {
+		return nil, err
+	}
+	return func(float64) error { return fwd() }, nil
+}

--- a/plugin/state_test.go
+++ b/plugin/state_test.go
@@ -1,0 +1,122 @@
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/require"
+)
+
+func setCache(t *testing.T, key string, val any) {
+	t.Helper()
+	c := util.NewParamCache()
+	c.Add(key, util.Param{Key: key, Val: val})
+	util.SetDefaultParamCache(c)
+	t.Cleanup(func() { util.SetDefaultParamCache(nil) })
+}
+
+func TestStateGetter(t *testing.T) {
+	// nested structure like evopt-batteries[i].suggestion.charge
+	setCache(t, "evopt-batteries", []map[string]any{
+		{"suggestion": map[string]any{"charge": 0.0}},
+		{"suggestion": map[string]any{"charge": 1500.0}},
+	})
+
+	for _, tc := range []struct {
+		jq    string
+		scale float64
+		want  float64
+	}{
+		{"[.[] | .suggestion.charge][0]", 1, 0},
+		{"[.[] | .suggestion.charge][1]", 1, 1500},
+		{"[.[] | .suggestion.charge][1]", 0.001, 1.5},
+	} {
+		other := map[string]any{"key": "evopt-batteries", "jq": tc.jq}
+		if tc.scale != 1 {
+			other["scale"] = tc.scale
+		}
+		p, err := NewStateFromConfig(t.Context(), other)
+		require.NoError(t, err)
+
+		g, err := p.(FloatGetter).FloatGetter()
+		require.NoError(t, err)
+		v, err := g()
+		require.NoError(t, err)
+		require.Equal(t, tc.want, v, "jq %q scale %v", tc.jq, tc.scale)
+	}
+}
+
+func TestStateGetterFlatAndMissing(t *testing.T) {
+	setCache(t, "arr", []int64{0, 1500, 3000})
+
+	p, err := NewStateFromConfig(t.Context(), map[string]any{"key": "arr", "jq": ".[2]"})
+	require.NoError(t, err)
+	g, _ := p.(FloatGetter).FloatGetter()
+	v, err := g()
+	require.NoError(t, err)
+	require.Equal(t, 3000.0, v)
+
+	// unknown key -> 0
+	p, err = NewStateFromConfig(t.Context(), map[string]any{"key": "missing", "jq": ".[0]"})
+	require.NoError(t, err)
+	g, _ = p.(FloatGetter).FloatGetter()
+	v, err = g()
+	require.NoError(t, err)
+	require.Equal(t, 0.0, v)
+
+	// jq resolving to null without a default -> error (surfaces a mistyped key/filter
+	// instead of silently returning a value)
+	setCache(t, "obj", []map[string]any{{"foo": 1.0}})
+	p, err = NewStateFromConfig(t.Context(), map[string]any{"key": "obj", "jq": ".[0].missing.charge"})
+	require.NoError(t, err)
+	g, _ = p.(FloatGetter).FloatGetter()
+	_, err = g()
+	require.Error(t, err, "null result without an explicit default must error")
+
+	// defaulting is consumer policy: express it in the jq -> 0
+	p, err = NewStateFromConfig(t.Context(), map[string]any{"key": "obj", "jq": ".[0].missing.charge // 0"})
+	require.NoError(t, err)
+	g, _ = p.(FloatGetter).FloatGetter()
+	v, err = g()
+	require.NoError(t, err)
+	require.Equal(t, 0.0, v)
+}
+
+// TestStateIntSetterForward verifies the nested-setter path: the incoming int is
+// ignored, the jq-selected cached value is read and forwarded to the nested setter.
+func TestStateIntSetterForward(t *testing.T) {
+	setCache(t, "evopt-batteries", []map[string]any{
+		{"suggestion": map[string]any{"charge": 1500.0}},
+	})
+
+	var mu sync.Mutex
+	var written string
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		written = r.URL.Query().Get("v")
+		mu.Unlock()
+	}))
+	defer srv.Close()
+
+	p, err := NewStateFromConfig(t.Context(), map[string]any{
+		"key": "evopt-batteries",
+		"jq":  ".[0].suggestion.charge",
+		"set": map[string]any{"source": "http", "uri": srv.URL + "/write?v={{.foo}}"},
+	})
+	require.NoError(t, err)
+
+	set, err := p.(IntSetter).IntSetter("foo")
+	require.NoError(t, err)
+
+	// incoming value (99) is ignored; cached suggestion.charge (1500) is forwarded
+	require.NoError(t, set(99))
+
+	mu.Lock()
+	got, _ := strconv.ParseFloat(written, 64)
+	mu.Unlock()
+	require.Equal(t, 1500.0, got)
+}

--- a/util/param.go
+++ b/util/param.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/evcc-io/evcc/util/encode"
 )
@@ -46,6 +47,33 @@ func NewParamCache() *ParamCache {
 	return &ParamCache{
 		val: make(map[string]Param),
 	}
+}
+
+// defaultParamCache is the process-wide value cache (the same store that backs
+// /api/state), registered once at startup in cmd/root.go.
+//
+// It is intentionally a package-level singleton rather than a threaded dependency:
+// the cache is a genuine process singleton, and its only in-process readers are
+// plugins (e.g. the state source) instantiated deep in the template/registry chain
+// - passing a reference down would touch every device constructor across all device
+// types for no functional gain. Access is lock-free and nil-safe (no value before
+// registration, e.g. in CLI subcommands or tests).
+var defaultParamCache atomic.Pointer[ParamCache]
+
+// SetDefaultParamCache registers the process-wide value cache. Called once at
+// startup; tests use it to set/reset the cache.
+func SetDefaultParamCache(c *ParamCache) {
+	defaultParamCache.Store(c)
+}
+
+// DefaultParamCacheValue returns the cached value for key, or nil if no cache is
+// registered or the key is unknown.
+func DefaultParamCacheValue(key string) any {
+	c := defaultParamCache.Load()
+	if c == nil {
+		return nil
+	}
+	return c.Get(key).Val
 }
 
 // Run adds input channel's values to cache


### PR DESCRIPTION
Adds a `state` plugin source that reads a value from the process-wide value cache (the store backing /api/state), navigates it with a jq filter and forwards it to a nested setter. This lets templates write a site-computed value to a device register in-process, without an HTTP round-trip to the local API.

- util: expose the ParamCache process-wide via SetDefaultParamCache / DefaultParamCacheValue
- cmd: register the cache at startup
- plugin/state: FloatGetter (key + jq + scale) plus nested Int/FloatSetter