### PR TITLE
core: expose device name to its template for self-referencing

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
 	"slices"
@@ -295,10 +296,29 @@ func validateConfigurableCircuits(children []config.Config) error {
 
 type newFromConfFunc[T any] func(context.Context, string, map[string]any) (T, error)
 
+// withDeviceName exposes the device's own name to its template via the predefined
+// "name" property, so a template can self-reference instead of requiring a manual
+// index/reference - e.g. select its own entry from a published state array. Returns
+// a copy; the input map is not modified.
+//
+// Only applied to template devices: native/custom device configs are decoded
+// strictly (ErrorUnused), so an extra key would be rejected as invalid.
+func withDeviceName(typ string, other map[string]any, name string) map[string]any {
+	if typ != "template" {
+		return other
+	}
+	res := maps.Clone(other)
+	if res == nil {
+		res = make(map[string]any)
+	}
+	res["name"] = name
+	return res
+}
+
 func staticInstance[T any](typ string, cc config.Named, newFromConf newFromConfFunc[T], h config.Handler[T]) error {
 	ctx, cancel := context.WithCancel(util.WithLogger(context.TODO(), util.NewLogger(cc.Name)))
 
-	instance, err := newFromConf(ctx, cc.Type, cc.Other)
+	instance, err := newFromConf(ctx, cc.Type, withDeviceName(cc.Type, cc.Other, cc.Name))
 	if err != nil {
 		err = &DeviceError{cc.Name, fmt.Errorf("cannot create %s '%s': %w", typ, cc.Name, err)}
 	}
@@ -344,7 +364,7 @@ func configurableInstance[T any](typ string, conf *config.Config, newFromConf ne
 
 	var instance T
 	if err == nil {
-		instance, err = newFromConf(ctx, typ, other)
+		instance, err = newFromConf(ctx, typ, withDeviceName(typ, other, cc.Name))
 		if err != nil {
 			err = &DeviceError{cc.Name, fmt.Errorf("cannot create %s '%s': %w", typ, cc.Name, err)}
 		}

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -8,7 +8,27 @@ import (
 	"github.com/evcc-io/evcc/api/globalconfig"
 	"github.com/evcc-io/evcc/core"
 	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestWithDeviceName(t *testing.T) {
+	// template device: injects the name, preserves other keys, input untouched
+	in := map[string]any{"host": "localhost"}
+	out := withDeviceName("template", in, "db:42")
+	assert.Equal(t, "db:42", out["name"])
+	assert.Equal(t, "localhost", out["host"])
+	_, mutated := in["name"]
+	assert.False(t, mutated, "input map must not be modified")
+
+	// nil input is handled
+	assert.Equal(t, "db:7", withDeviceName("template", nil, "db:7")["name"])
+
+	// non-template device: must NOT inject (custom configs decode strictly)
+	custom := map[string]any{"host": "localhost"}
+	out = withDeviceName("custom", custom, "db:42")
+	_, injected := out["name"]
+	assert.False(t, injected, "custom device must not get a name key")
+}
 
 func TestYamlOff(t *testing.T) {
 	var conf globalconfig.All

--- a/util/templates/template_test.go
+++ b/util/templates/template_test.go
@@ -32,6 +32,22 @@ func TestPresets(t *testing.T) {
 	}, tmpl.Params)
 }
 
+func TestPredefinedNameRendered(t *testing.T) {
+	// "name" is a predefined template property, so a template can self-reference
+	// its own device name (e.g. to select its entry from a published state array)
+	// without a manual index/reference. Lock this contract.
+	tmpl := &Template{Render: "key: {{ .name }}"}
+
+	b, _, err := tmpl.RenderResult(RenderModeInstance, map[string]any{"name": "mydevice"})
+	require.NoError(t, err)
+	assert.Equal(t, "key: mydevice", string(b))
+
+	// real-world device name (db:ID) flows through too
+	b, _, err = tmpl.RenderResult(RenderModeInstance, map[string]any{"name": "db:42"})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "db:42")
+}
+
 func TestRequiredString(t *testing.T) {
 	tmpl := &Template{
 		Params: []Param{


### PR DESCRIPTION
Templates that read from a shared published-state array (state plugin) currently need a manually configured index/reference to pick their own entry - fragile, since array order is not stable and the index is opaque to users.

The device's own name is known at instantiation (db:ID for configured devices, the configured name for yaml), and "name" is already a predefined template property. Populate it so a template can self-reference, e.g.:

  jq: '.[] | select(.name == "{{ .name }}").value'

No new param, no template changes required (opt-in per template), no core interface change. Wired centrally via a small helper used by both the static and configurable device paths; the helper returns a copy and does not mutate the caller's params.