### PR TITLE
EEBus: accept comma-separated interfaces value

### DIFF
--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -167,7 +167,7 @@ func NewServer(other Config) (*EEBus, error) {
 	// for backward compatibility
 	configuration.SetAlternateMdnsServiceName(DeviceCode)
 	configuration.SetAlternateIdentifier(serial)
-	configuration.SetInterfaces(cc.Interfaces)
+	configuration.SetInterfaces(normalizeInterfaces(cc.Interfaces))
 
 	ski, err := SkiFromCert(certificate)
 	if err != nil {

--- a/server/eebus/types.go
+++ b/server/eebus/types.go
@@ -2,6 +2,7 @@ package eebus
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/machine"
@@ -45,6 +46,20 @@ func (c Config) Redacted() any {
 			Private: util.Masked(c.Certificate.Private),
 		},
 	}
+}
+
+// normalizeInterfaces splits comma-separated entries and trims whitespace,
+// so both a YAML list and a comma-separated string (e.g. EVCC_EEBUS_INTERFACES=eth0,eth1) work.
+func normalizeInterfaces(ifaces []string) []string {
+	var res []string
+	for _, s := range ifaces {
+		for p := range strings.SplitSeq(s, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				res = append(res, p)
+			}
+		}
+	}
+	return res
 }
 
 func createShipID() string {

--- a/server/eebus/types_test.go
+++ b/server/eebus/types_test.go
@@ -1,0 +1,17 @@
+package eebus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeInterfaces(t *testing.T) {
+	assert.Nil(t, normalizeInterfaces(nil))
+	assert.Equal(t, []string{"eth0"}, normalizeInterfaces([]string{"eth0"}))
+	assert.Equal(t, []string{"eth0", "eth1"}, normalizeInterfaces([]string{"eth0", "eth1"}))
+	// comma-separated single string (env var or YAML scalar)
+	assert.Equal(t, []string{"eth0", "eth1"}, normalizeInterfaces([]string{"eth0, eth1"}))
+	// mixed + empty entries dropped
+	assert.Equal(t, []string{"eth0", "eth1", "eth2"}, normalizeInterfaces([]string{" eth0 ,eth1", "", "eth2"}))
+}


### PR DESCRIPTION
`eebus.interfaces` pins the eebus service to specific network interfaces, which is the lever for multi-homed hosts (e.g. HA add-on with two NICs) where eebus would otherwise advertise/bind on the wrong interface and the SHIP/TLS handshake times out (see #31286).

Until now it only accepted a YAML list. This makes it also accept a comma-separated string, so an env var works too:

```
EVCC_EEBUS_INTERFACES=eth0,eth1
```

Normalization happens at the single point of use (right before `SetInterfaces`), so it is independent of the config path (file/UI/env): entries are split on commas, trimmed, and empty entries dropped. A YAML list keeps working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)