### PR TITLE
Vehicle: test feature param consistency for shared include

### DIFF
--- a/templates/definition/vehicle/iso15118.yaml
+++ b/templates/definition/vehicle/iso15118.yaml
@@ -20,6 +20,8 @@ params:
   - preset: vehicle-common
   - name: climaterdisabled
     deprecated: true
+  - name: autodetectdisabled
+    deprecated: true
 render: |
   type: custom
   {{ include "vehicle-common" . }}

--- a/templates/definition/vehicle/offline.yaml
+++ b/templates/definition/vehicle/offline.yaml
@@ -14,6 +14,8 @@ params:
   - name: welcomecharge
   - name: climaterdisabled
     deprecated: true
+  - name: autodetectdisabled
+    deprecated: true
 render: |
   type: custom
   {{- include "vehicle-common" . }}

--- a/vehicle/template_test.go
+++ b/vehicle/template_test.go
@@ -1,6 +1,7 @@
 package vehicle
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/evcc-io/evcc/api"
@@ -39,4 +40,26 @@ func TestTemplates(t *testing.T) {
 			t.Error(err)
 		}
 	})
+}
+
+// universalVehicleFeatures render via the shared vehicle-features include, so a
+// stored config may carry them; dropping the param breaks reload (discussion #31291).
+var universalVehicleFeatures = []string{"climaterdisabled", "autodetectdisabled"}
+
+func TestVehicleFeatureParamsConsistent(t *testing.T) {
+	for _, tmpl := range templates.ByClass(templates.Vehicle, templates.WithDeprecated()) {
+		if !strings.Contains(tmpl.Render, "vehicle-features") {
+			continue
+		}
+
+		for _, feat := range universalVehicleFeatures {
+			values := tmpl.Defaults(templates.RenderModeUnitTest)
+			values["template"] = tmpl.Template
+			values[feat] = true
+
+			if _, _, err := tmpl.RenderResult(templates.RenderModeInstance, values); err != nil {
+				t.Errorf("%s: feature %q must stay a declared param: %v", tmpl.Template, feat, err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/31306

Online vehicles expose `climaterdisabled` and `autodetectdisabled` through the shared `vehicle-features` include, so a stored configuration can carry either key. When a template renders the include but no longer declares the matching param, reloading that configuration fails with `invalid key` and the vehicle no longer starts. DB-only setups are hit hardest, since the affected vehicles disappear from the UI. This is what broke offline vehicles in discussion #31291.

This adds a test asserting both toggles stay declared params on every vehicle template that renders the include. The test immediately surfaced that `autodetectdisabled` was still undeclared on the `offline` and `iso15118` templates, the same defect class that #31297 fixed for `climaterdisabled`. Both are restored as deprecated params so existing configurations keep validating, following the deprecate, never remove rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)