### PR TITLE
Meter (DSMR): accept binary WebSocket frames

### DIFF
--- a/meter/dsmr_test.go
+++ b/meter/dsmr_test.go
@@ -257,33 +257,43 @@ func TestDsmrTCP(t *testing.T) {
 }
 
 func TestDsmrWebSocket(t *testing.T) {
-	payload := dsmrFrame(dsmrTelegram50)
+	for _, tc := range []struct {
+		name    string
+		message websocket.MessageType
+	}{
+		{"text", websocket.MessageText},
+		{"binary", websocket.MessageBinary},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := dsmrFrame(dsmrTelegram50)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
-		if err != nil {
-			return
-		}
-		defer conn.CloseNow()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := websocket.Accept(w, r, nil)
+				if err != nil {
+					return
+				}
+				defer conn.CloseNow()
 
-		for {
-			if err := conn.Write(r.Context(), websocket.MessageText, payload); err != nil {
-				return
-			}
-			time.Sleep(50 * time.Millisecond)
-		}
-	}))
-	defer srv.Close()
+				for {
+					if err := conn.Write(r.Context(), tc.message, payload); err != nil {
+						return
+					}
+					time.Sleep(50 * time.Millisecond)
+				}
+			}))
+			defer srv.Close()
 
-	uri := "ws" + strings.TrimPrefix(srv.URL, "http")
+			uri := "ws" + strings.TrimPrefix(srv.URL, "http")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	m, err := NewDsmr(ctx, uri, time.Second)
-	require.NoError(t, err)
+			m, err := NewDsmr(ctx, uri, time.Second)
+			require.NoError(t, err)
 
-	assertReadings(t, m)
+			assertReadings(t, m)
+		})
+	}
 }
 
 // TestDsmrIgnoresGarbage verifies that leading garbage and a CRC-mismatched

--- a/meter/dsmr_ws.go
+++ b/meter/dsmr_ws.go
@@ -48,9 +48,9 @@ func (r *wsReader) Read(p []byte) (int, error) {
 			return 0, err
 		}
 
-		// The P1 telegram is streamed as text frames; skip any other frame
-		// type so metadata or binary frames are not fed to the DSMR parser.
-		if msgType != websocket.MessageText {
+		// The P1 telegram may be streamed as text or binary frames, depending on
+		// the dongle firmware. Skip control or metadata frames.
+		if msgType != websocket.MessageText && msgType != websocket.MessageBinary {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #31312.

## What changed

- Accept `websocket.MessageBinary` in the DSMR WebSocket reader in addition to `websocket.MessageText`.
- Extend `TestDsmrWebSocket` so the same DSMR payload is tested as both text and binary WebSocket frames.

## Why

The Homey Energy Dongle can send DSMR/P1 telegram payload bytes in binary WebSocket frames. The payload itself is still the same text DSMR telegram, but the current reader skips every non-text frame. That makes evcc connect successfully and then time out waiting for a text frame.

## Validation

```text
docker run --rm -v "$PWD":/src -w /src golang:1.26.3 go test ./meter
ok  	github.com/evcc-io/evcc/meter	1.519s
```

Also validated against a real Homey Energy Dongle with a patched Docker image:

```text
evcc meter db:8 --log trace --timeout 20s
[dsmr  ] TRACE ... read: /KFM5KAIFA-METER...
Power:           10964W
Energy:          3279.4kWh
Return Energy:   1919.4kWh
Current L1..L3:  17A 16A 13A
Voltage L1..L3:  231V 233V 232V
Power L1..L3:    3969W 3763W 3232W
```
