### PR TITLE
Meter (Quatt): add heat pump power template

### DIFF
--- a/templates/definition/meter/quatt.yaml
+++ b/templates/definition/meter/quatt.yaml
@@ -1,0 +1,18 @@
+template: quatt
+products:
+  - brand: Quatt
+    description:
+      generic: Hybrid Heat Pump
+group: heating
+params:
+  - name: usage
+    choice: ["aux"]
+  - name: host
+  - name: port
+    default: 8080
+render: |
+  type: custom
+  power:
+    source: http
+    uri: http://{{ .host }}:{{ .port }}/beta/feed/data.json
+    jq: ((.hp1.powerInput // 0) + (.hp2.powerInput // 0)) * 1000


### PR DESCRIPTION
## What changed

- Add a Quatt Hybrid Heat Pump meter template.
- Read current electrical input power from the local Quatt Controller API.
- Support both single and dual heat pump setups by summing `hp1.powerInput` and `hp2.powerInput` when present.

## Why

Quatt systems expose local live data at `/beta/feed/data.json`. The electrical heat pump input power is reported in kW as `powerInput`. This template makes the device selectable from the UI instead of requiring a custom HTTP meter configuration.

Example equivalent custom configuration currently used:

```yaml
meters:
  - name: quatt_power
    type: custom
    power:
      source: http
      uri: http://<host>:8080/beta/feed/data.json
      jq: "(.hp1.powerInput // 0) * 1000"
```

The template renders this as an auxiliary power meter and additionally accounts for optional `hp2`:

```jq
((.hp1.powerInput // 0) + (.hp2.powerInput // 0)) * 1000
```

## Validation

```text
docker run --rm -v "$PWD":/src -w /src golang:1.26.3 go test ./util/templates ./meter
ok  	github.com/evcc-io/evcc/util/templates	1.119s
ok  	github.com/evcc-io/evcc/meter	1.485s
```

Validated against a real Quatt Controller response:

```text
curl http://192.168.1.126:8080/beta/feed/data.json | jq '((.hp1.powerInput // 0) + (.hp2.powerInput // 0)) * 1000'
5930
```
