### PR TITLE
EEBus: apply §14a/LPC dimming to OHPCF heat pump

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -40,6 +40,7 @@ type EEBusOHPCF struct {
 	mpcEntity  spineapi.EntityRemoteInterface
 	dhwEntity  spineapi.EntityRemoteInterface
 	enabled    bool
+	dimmed     bool
 	reboosting bool
 
 	connector *eebus.Connector
@@ -184,6 +185,14 @@ func (c *EEBusOHPCF) lastEnabled() bool {
 	defer c.mu.RUnlock()
 
 	return c.enabled
+}
+
+// controlEnable is the effective on/off intent: a §14a/LPC dim overrides enable.
+func (c *EEBusOHPCF) controlEnable() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.enabled && !c.dimmed
 }
 
 // ohpcfStatus maps the compressor process state to a charge status: running is
@@ -360,6 +369,26 @@ func (c *EEBusOHPCF) MaxCurrent(int64) error {
 	return c.apply()
 }
 
+var _ api.Dimmer = (*EEBusOHPCF)(nil)
+
+// Dimmed implements the api.Dimmer interface, reporting the active §14a/LPC dim state.
+func (c *EEBusOHPCF) Dimmed() (bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.dimmed, nil
+}
+
+// Dim implements the api.Dimmer interface. A §14a/LPC consumption limit pauses
+// or aborts the optional consumption; releasing it resumes per the on/off intent.
+func (c *EEBusOHPCF) Dim(dim bool) error {
+	c.mu.Lock()
+	c.dimmed = dim
+	c.mu.Unlock()
+
+	return c.apply()
+}
+
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply() error {
@@ -374,7 +403,7 @@ func (c *EEBusOHPCF) apply() error {
 		return nil
 	}
 
-	switch ohpcfControlAction(state, c.lastEnabled()) {
+	switch ohpcfControlAction(state, c.controlEnable()) {
 	case ohpcfSchedule:
 		return c.await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
 			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -23,6 +23,21 @@ func TestEEBusOHPCFNotConnected(t *testing.T) {
 
 	require.ErrorIs(t, c.Enable(true), errNotConnected)
 	require.ErrorIs(t, c.MaxCurrent(16), errNotConnected)
+	require.ErrorIs(t, c.Dim(true), errNotConnected)
+}
+
+// a §14a/LPC dim overrides the on/off intent: the compressor is only driven on
+// when enabled and not dimmed.
+func TestOHPCFDimGate(t *testing.T) {
+	c := &EEBusOHPCF{enabled: true}
+	assert.True(t, c.controlEnable())
+
+	c.dimmed = true
+	assert.False(t, c.controlEnable(), "dim overrides enable")
+
+	dimmed, err := c.Dimmed()
+	require.NoError(t, err)
+	assert.True(t, dimmed)
 }
 
 // status mapping: running is C, every other connected state (incl. completed

--- a/templates/definition/charger/eebus-ohpcf.yaml
+++ b/templates/definition/charger/eebus-ohpcf.yaml
@@ -4,7 +4,7 @@ products:
       de: EEBUS Wärmepumpe (OHPCF)
       en: EEBUS heat pump (OHPCF)
 group: heating
-capabilities: ["meter"]
+capabilities: ["meter", "dim"]
 params:
   - preset: eebus
   - name: reboost


### PR DESCRIPTION
The OHPCF heat pump charger (#30636) ignored an active EnWG §14a / LPC consumption limit: it only honoured PV surplus, never the grid-side cap evcc receives as a controllable system.

This implements `api.Dimmer` on the OHPCF charger, the same hook the loadpoint already uses to push the HEMS dim state down to a charger:

- `Dim(true)` pauses (or aborts, if the compressor is not pausable) the optional consumption; `Dim(false)` releases it and resumes per the on/off intent.
- `Dimmed()` reports the current dim state.
- The control gate now drives the compressor on only when enabled and not dimmed (`controlEnable`), so a dim always wins over surplus.
- The template gains the `dim` capability.

`go build`, `go vet`, charger + template tests, gofmt and golangci-lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)