### PR TITLE
Tariff (Nordpool): add average by hour option

### DIFF
--- a/templates/definition/tariff/nordpool.yaml
+++ b/templates/definition/tariff/nordpool.yaml
@@ -43,9 +43,11 @@ params:
   - name: currency
     choice: ["DKK", "EUR", "NOK", "PLN", "RON", "SEK"]
   - preset: tariff-base
+  - preset: tariff-features
 render: |
   type: custom
   {{ include "tariff-base" . }}
+  {{ include "tariff-features" . }}
   forecast:
     source: go
     script: |


### PR DESCRIPTION
The Nordpool tariff provider is missing the ability to average.

Since I'm paying the average of the 4x15 minute time slots for each hour, I need to be able to average them.

This change was made with the help of Claude AI, verified by running the application.