### PR TITLE
Meter: add Quatt heat pump template

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,6 +26,11 @@ type MeterReturnEnergy interface {
 	ReturnEnergy() (float64, error)
 }
 
+// MeterDetails provides additional read-only meter information for display.
+type MeterDetails interface {
+	Details() ([]string, error)
+}
+
 // PhaseCurrents provides per-phase current A
 type PhaseCurrents interface {
 	Currents() (float64, float64, float64, error)

--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -14,6 +14,16 @@
 					{{ fmtDeviceValue(entry) }}
 				</div>
 			</span>
+			<div v-if="detailsEntries.length" class="details">
+				<div
+					v-for="(entry, index) in detailsEntries"
+					:key="index"
+					:data-testid="`device-tag-details-${index}`"
+					class="small evcc-gray"
+				>
+					{{ entry }}
+				</div>
+			</div>
 			<table v-if="hasPhaseEntries" class="table table-borderless table-sm my-0">
 				<thead>
 					<tr>
@@ -76,6 +86,8 @@ const HIDDEN_TAGS = ["icon", "heating", "integratedDevice"];
 
 const PHASE_TAGS = ["phaseCurrents", "phaseVoltages", "phasePowers"];
 
+const DETAIL_TAGS = ["details"];
+
 const FORECAST_TAGS = ["priceRates", "co2Rates", "solarRates"];
 
 export default {
@@ -98,6 +110,7 @@ export default {
 					([name]) =>
 						!HIDDEN_TAGS.includes(name) &&
 						!PHASE_TAGS.includes(name) &&
+						!DETAIL_TAGS.includes(name) &&
 						!FORECAST_TAGS.includes(name)
 				)
 				.map(([name, { value, error, warning, muted }]) => {
@@ -114,6 +127,10 @@ export default {
 		},
 		hasPhaseEntries() {
 			return this.phaseEntries.length > 0;
+		},
+		detailsEntries() {
+			const details = this.tags?.details?.value;
+			return Array.isArray(details) ? details : [];
 		},
 		ratesEntry() {
 			if (!this.tags) return null;
@@ -298,6 +315,11 @@ export default {
 	display: grid;
 	grid-template-columns: 1fr;
 	grid-gap: 0.5rem;
+}
+.details {
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-gap: 0.25rem;
 }
 .label {
 	min-width: 4rem;

--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -225,17 +225,22 @@ export default defineComponent({
 			replaceModal("meter", { id: this.id, type: type as MeterType });
 		},
 		provideTemplateOptions(products: Product[]): TemplateGroup[] {
+			const visibleProducts =
+				this.selectedType === "ext"
+					? products.filter((p) => p.template !== "quatt")
+					: products;
+
 			return [
 				{
 					label: "generic",
 					options: [
-						...products.filter((p) => p.group === "generic"),
+						...visibleProducts.filter((p) => p.group === "generic"),
 						customTemplateOption(this.$t("config.general.customOption")),
 					],
 				},
 				{
 					label: "specific",
-					options: products.filter((p) => p.group !== "generic"),
+					options: visibleProducts.filter((p) => p.group !== "generic"),
 				},
 			];
 		},

--- a/meter/quatt.go
+++ b/meter/quatt.go
@@ -1,0 +1,200 @@
+package meter
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+)
+
+func init() {
+	registry.Add("quatt", NewQuattFromConfig)
+}
+
+type quattMeter struct {
+	*request.Helper
+	uri  string
+	unit string
+	data func() (quattFeed, error)
+}
+
+type quattFeed struct {
+	Boiler struct {
+		FlameOn *bool `json:"otFbFlameOn"`
+	} `json:"boiler"`
+	FlowMeter struct {
+		WaterSupplyTemperature *float64 `json:"waterSupplyTemperature"`
+	} `json:"flowMeter"`
+	HP1    *quattHeatPump `json:"hp1"`
+	HP2    *quattHeatPump `json:"hp2"`
+	QC     quattQC        `json:"qc"`
+	System struct {
+		MaxWaterTemperature *float64 `json:"chMaxWaterTemperature"`
+	} `json:"system"`
+}
+
+type quattHeatPump struct {
+	PowerInput          float64  `json:"powerInput"`
+	TemperatureOutside  *float64 `json:"temperatureOutside"`
+	TemperatureWaterIn  *float64 `json:"temperatureWaterIn"`
+	TemperatureWaterOut *float64 `json:"temperatureWaterOut"`
+}
+
+type quattQC struct {
+	SupervisoryControlMode *int `json:"supervisoryControlMode"`
+}
+
+func NewQuattFromConfig(other map[string]any) (api.Meter, error) {
+	cc := struct {
+		URI       string
+		Host      string
+		Port      int
+		Unit      string
+		HeatPumps int
+		Cache     time.Duration
+	}{
+		Port:  8080,
+		Cache: time.Second,
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	uri := cc.URI
+	if uri == "" {
+		if cc.Host == "" {
+			return nil, fmt.Errorf("missing host")
+		}
+		uri = fmt.Sprintf("http://%s:%d/beta/feed/data.json", cc.Host, cc.Port)
+	}
+
+	m := &quattMeter{
+		Helper: request.NewHelper(util.NewLogger("quatt")),
+		uri:    uri,
+		unit:   cc.Unit,
+	}
+	m.data = util.Cached(m.feed, cc.Cache)
+
+	return m, nil
+}
+
+var _ api.Meter = (*quattMeter)(nil)
+
+func (m *quattMeter) feed() (quattFeed, error) {
+	var res quattFeed
+	err := m.GetJSON(m.uri, &res)
+	return res, err
+}
+
+func (m *quattMeter) CurrentPower() (float64, error) {
+	feed, err := m.data()
+	if err != nil {
+		return 0, err
+	}
+
+	switch m.unit {
+	case "hp1":
+		return heatPumpPower(feed.HP1), nil
+	case "hp2":
+		return heatPumpPower(feed.HP2), nil
+	case "total":
+		return heatPumpPower(feed.HP1) + heatPumpPower(feed.HP2), nil
+	default:
+		if feed.HP2 != nil {
+			return heatPumpPower(feed.HP1) + heatPumpPower(feed.HP2), nil
+		}
+		return heatPumpPower(feed.HP1), nil
+	}
+}
+
+var _ api.MeterDetails = (*quattMeter)(nil)
+
+func (m *quattMeter) Details() ([]string, error) {
+	feed, err := m.data()
+	if err != nil {
+		return nil, err
+	}
+
+	hp := feed.HP1
+	if m.unit == "hp2" {
+		hp = feed.HP2
+	}
+
+	details := []string{
+		"Mode: " + supervisoryMode(feed.QC.SupervisoryControlMode),
+	}
+
+	if feed.System.MaxWaterTemperature != nil {
+		details = append(details, fmt.Sprintf("Max water temp: %.0f °C", *feed.System.MaxWaterTemperature))
+	}
+	if feed.Boiler.FlameOn != nil {
+		details = append(details, "Flame: "+flameStatus(feed.Boiler.FlameOn))
+	}
+
+	if m.unit == "total" || feed.HP2 != nil {
+		details = appendHeatPumpDetails(details, "HP1", feed.HP1)
+		details = appendHeatPumpDetails(details, "HP2", feed.HP2)
+		return details, nil
+	}
+
+	details = appendHeatPumpDetails(details, "", hp)
+	return details, nil
+}
+
+func heatPumpPower(hp *quattHeatPump) float64 {
+	if hp == nil {
+		return 0
+	}
+	return hp.PowerInput * 1000
+}
+
+func appendHeatPumpDetails(details []string, label string, hp *quattHeatPump) []string {
+	prefix := ""
+	if label != "" {
+		prefix = label + " "
+	}
+	if hp == nil {
+		return append(details, prefix+"not available")
+	}
+	if hp.TemperatureWaterIn != nil {
+		details = append(details, fmt.Sprintf("%swater in: %.1f °C", prefix, round1(*hp.TemperatureWaterIn)))
+	}
+	if hp.TemperatureWaterOut != nil {
+		details = append(details, fmt.Sprintf("%swater out: %.1f °C", prefix, round1(*hp.TemperatureWaterOut)))
+	}
+	if hp.TemperatureOutside != nil {
+		details = append(details, fmt.Sprintf("%soutside: %.1f °C", prefix, round1(*hp.TemperatureOutside)))
+	}
+	return details
+}
+
+func supervisoryMode(mode *int) string {
+	if mode == nil {
+		return "unknown"
+	}
+
+	switch *mode {
+	case 0:
+		return "standby"
+	default:
+		return fmt.Sprintf("mode %d", *mode)
+	}
+}
+
+func flameStatus(flame *bool) string {
+	if flame == nil {
+		return "unknown"
+	}
+	if *flame {
+		return "on"
+	}
+	return "off"
+}
+
+func round1(v float64) float64 {
+	return math.Round(v*10) / 10
+}

--- a/meter/quatt.go
+++ b/meter/quatt.go
@@ -21,6 +21,13 @@ type quattMeter struct {
 	data func() (quattFeed, error)
 }
 
+const (
+	quattUnitAuto  = ""
+	quattUnitHP1   = "hp1"
+	quattUnitHP2   = "hp2"
+	quattUnitTotal = "total"
+)
+
 type quattFeed struct {
 	Boiler struct {
 		FlameOn *bool `json:"otFbFlameOn"`
@@ -49,12 +56,11 @@ type quattQC struct {
 
 func NewQuattFromConfig(other map[string]any) (api.Meter, error) {
 	cc := struct {
-		URI       string
-		Host      string
-		Port      int
-		Unit      string
-		HeatPumps int
-		Cache     time.Duration
+		URI   string
+		Host  string
+		Port  int
+		Unit  string
+		Cache time.Duration
 	}{
 		Port:  8080,
 		Cache: time.Second,
@@ -62,6 +68,10 @@ func NewQuattFromConfig(other map[string]any) (api.Meter, error) {
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
+	}
+
+	if cc.Unit != quattUnitAuto && cc.Unit != quattUnitHP1 && cc.Unit != quattUnitHP2 && cc.Unit != quattUnitTotal {
+		return nil, fmt.Errorf("invalid unit: %s", cc.Unit)
 	}
 
 	uri := cc.URI
@@ -97,11 +107,11 @@ func (m *quattMeter) CurrentPower() (float64, error) {
 	}
 
 	switch m.unit {
-	case "hp1":
+	case quattUnitHP1:
 		return heatPumpPower(feed.HP1), nil
-	case "hp2":
+	case quattUnitHP2:
 		return heatPumpPower(feed.HP2), nil
-	case "total":
+	case quattUnitTotal:
 		return heatPumpPower(feed.HP1) + heatPumpPower(feed.HP2), nil
 	default:
 		if feed.HP2 != nil {
@@ -120,7 +130,7 @@ func (m *quattMeter) Details() ([]string, error) {
 	}
 
 	hp := feed.HP1
-	if m.unit == "hp2" {
+	if m.unit == quattUnitHP2 {
 		hp = feed.HP2
 	}
 
@@ -135,7 +145,7 @@ func (m *quattMeter) Details() ([]string, error) {
 		details = append(details, "Flame: "+flameStatus(feed.Boiler.FlameOn))
 	}
 
-	if m.unit == "total" || feed.HP2 != nil {
+	if m.unit == quattUnitTotal || feed.HP2 != nil {
 		details = appendHeatPumpDetails(details, "HP1", feed.HP1)
 		details = appendHeatPumpDetails(details, "HP2", feed.HP2)
 		return details, nil

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -285,6 +285,13 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 	})
 
 	wg.Go(func() {
+		if dev, ok := api.Cap[api.MeterDetails](instance); ok {
+			val, err := dev.Details()
+			makeResult("details", val, err)
+		}
+	})
+
+	wg.Go(func() {
 		if dev, ok := api.Cap[api.MeterEnergy](instance); ok {
 			val, err := dev.TotalEnergy()
 			makeResult("energy", val, err)

--- a/templates/definition/meter/quatt.yaml
+++ b/templates/definition/meter/quatt.yaml
@@ -1,0 +1,26 @@
+template: quatt
+products:
+  - brand: Quatt
+    description:
+      generic: Hybrid Heat Pump
+group: heating
+params:
+  - name: usage
+    choice: ["charge"]
+  - name: host
+  - name: port
+    default: 8080
+  - name: heatpumps
+    deprecated: true
+  - name: unit
+    deprecated: true
+render: |
+  type: quatt
+  host: {{ .host }}
+  port: {{ .port }}
+  {{- if .heatpumps }}
+  heatpumps: {{ .heatpumps }}
+  {{- end }}
+  {{- if .unit }}
+  unit: {{ .unit }}
+  {{- end }}

--- a/templates/definition/meter/quatt.yaml
+++ b/templates/definition/meter/quatt.yaml
@@ -10,17 +10,12 @@ params:
   - name: host
   - name: port
     default: 8080
-  - name: heatpumps
-    deprecated: true
   - name: unit
     deprecated: true
 render: |
   type: quatt
   host: {{ .host }}
   port: {{ .port }}
-  {{- if .heatpumps }}
-  heatpumps: {{ .heatpumps }}
-  {{- end }}
   {{- if .unit }}
   unit: {{ .unit }}
   {{- end }}


### PR DESCRIPTION
## Summary
- add a Quatt hybrid heat pump meter template using the local HTTP API
- expose the heat pump as a read-only home consumer, not as an additional meter
- auto-detect one or two heat pumps from the Quatt feed and show runtime details

## Testing
- `go test ./api ./util/templates ./meter ./server -run "^$"`
- `npm run lint:prettier -- --check assets/js/components/Config/DeviceTags.vue assets/js/components/Config/MeterModal.vue`
- `npm run lint:tsc`
