### PR TITLE
Add AMTRON Professional Twincharge with infotext for modbus port 502/503

### DIFF
--- a/templates/definition/charger/bender-cc.yaml
+++ b/templates/definition/charger/bender-cc.yaml
@@ -12,6 +12,9 @@ products:
       generic: AMTRON Professional
   - brand: Mennekes
     description:
+      generic: AMTRON Professional Twincharge
+  - brand: Mennekes
+    description:
       generic: AMEDIO Professional
   - brand: Mennekes
     description:
@@ -67,11 +70,16 @@ requirements:
     de: |
       Der 'Modbus TCP Server für Energiemanagement-Systeme' muss aktiviert sein. 'Registersatz' darf NICHT auf 'Phoenix' oder 'TQ-DM100' eingestellt sein. Die dritte Auswahlmöglichkeit 'Ebee', 'Bender', 'MENNEKES' etc. ist richtig. 'UID Übertragung erlauben' muss aktiviert sein. 
 
-      Für Phasenumschaltung ist mindestens Firmware 5.33 notwendig. Das 'SEMP interface' muss aktiviert sein, der 'SEMP Charging Mode' muss auf 'Surplus Charging' stehen. 'Software function to use phase switching' muss auf SEMP konfiguriert sein.
+      Für Phasenumschaltung ist mindestens Firmware 5.33 notwendig. Das 'SEMP interface' muss aktiviert sein, der 'SEMP Charging Mode' muss auf 'Surplus Charging' stehen. 'Software function to use phase switching' muss auf SEMP konfiguriert sein. 
+
+      Bei Ladestationen mit zwei Ladepunkten (z.B. AMEDIO, Twincharge) sind die Ladepunkte separat anzulegen, wobei Ladepunkt 1 = Port 502 und Ladepunkt 2 = Port 503 zu setzen ist.
     en: |
       The 'Modbus TCP Server' must be enabled. The setting 'Register Address Set' must NOT be set to 'Phoenix' or 'TQ-DM100'. Use the third selection labeled 'Ebee', 'Bender', 'MENNEKES' etc. Set 'Allow UID Disclose' to On.
 
       Firmware 5.33 or higher is required for phase switching. The 'SEMP interface' must be enabled, the 'SEMP Charging Mode' must be set to 'Surplus Charging'. Set 'Software function to use phase switching' to SEMP.
+
+      For charging stations with two charging points (e.g. AMEDIO, Twincharge), each charging point must be configured separately. Set charging point 1 to Port 502 and charging point 2 to Port 503.
+
   evcc: ["sponsorship"]
 params:
   - name: modbus


### PR DESCRIPTION
Adds the charging station AMTRON Professional Twincharge with 2 charging points. Twincharge is technically identical to AMEDIO.
Also adds the description for modbus port 503 which has to be set up for the 2nd charging point.

Solves:
https://github.com/evcc-io/evcc/discussions/28295
https://github.com/evcc-io/evcc/discussions/31339