### PR TITLE
Versicharge: fix power reading (#31359)

### DIFF
--- a/charger/versicharge.go
+++ b/charger/versicharge.go
@@ -160,7 +160,7 @@ func (wb *Versicharge) CurrentPower() (float64, error) {
 	var sum float64
 	for i := range 3 {
 		if u := binary.BigEndian.Uint16(b[2*i:]); u != 0xFFFF {
-			sum += float64(u)
+			sum += float64(int16(u))
 		}
 	}
 


### PR DESCRIPTION
fixes #31359

The Siemens Versicharge reports small negative power values at charge start (e.g. register `0xFFE4` = -28W), which were summed as `uint16` and surfaced as ~65500W until the next read corrected it.

Decode the power registers as signed `int16`. The existing `0xFFFF` sentinel guard is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)