### PR TITLE
Fix details height on reload with expanded loadpoints

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -616,7 +616,7 @@ export default defineComponent({
 		batteryMode() {
 			this.$nextTick(this.updateHeight);
 		},
-		activeLoadpointsCount() {
+		loadpoints() {
 			this.$nextTick(this.updateHeight);
 		},
 	},


### PR DESCRIPTION
Hi there,

when energyflow details and loadpoints are expanded and the page reloads,
the details panel height can be too small if loadpoints data arrives via
WebSocket after the initial mount. The height is measured once in the
mounted hook, but may not include loadpoint entries that arrive later.

My fix:
- Replace activeLoadpointsCount watcher with loadpoints watcher so the
  panel height is recalculated whenever loadpoints data updates, not
  only when the count of actively-charging loadpoints changes

I added short video to show the problem:

[Screencast_20260701_090852.webm](https://github.com/user-attachments/assets/398bb0cb-94b9-4386-a3d0-5e40b9ef31c0)
