### PR TITLE
EEBus: release §14a/LPC limit when it expires

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -369,7 +369,9 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 		return false, err
 	}
 
-	return limit.IsActive && limit.Value > 0, nil
+	// an active limit means dimmed; the applied §14a limit value is 0W, so a
+	// value-based check would never report the dimmed state and never release it
+	return limit.IsActive, nil
 }
 
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -231,8 +231,9 @@ func (c *EEBus) Dimmed() (bool, error) {
 		return false, err
 	}
 
-	// Check if limit is active and has a valid power value
-	return limit.IsActive && limit.Value > 0, nil
+	// an active limit means dimmed; the applied limit value is 0W, so a
+	// value-based check would never report the dimmed state and never release it
+	return limit.IsActive, nil
 }
 
 // Dim implements the api.Dimmer interface


### PR DESCRIPTION
fixes #31387

The OHPCF charger and the EEBus meter apply a §14a/LPC consumption limit as a fixed **0 W** value (`Dim()` writes `LoadLimit{Value: 0, IsActive: dim}`), but `Dimmed()` reported the dimmed state as `limit.IsActive && limit.Value > 0`. Because the applied value is always 0, `Dimmed()` never returned `true`.

The loadpoint / `dimMeters` change-detection only writes on a state change (`*dim != dimmed`), so:
- while dimmed it re-wrote `Dim(true)` every cycle (redundant), and
- when the control-box limit expired and evcc wanted to release, `dimmed` was already `false`, so `Dim(false)` was **never sent** — leaving the heat pump curtailed to 0 W indefinitely.

Report the dimmed state from `limit.IsActive` alone. The HEMS-side duration expiry already worked; this makes the release actually reach the device.

Verified against the reporter's log: HEMS logs `consumption limit duration exceeded` at the 5-minute mark, but no `§14a dim: false` was ever written to the heat pump afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)