### PR TITLE
Updated the url of the GreenGrid-Compass API

### DIFF
--- a/templates/definition/tariff/green-grid-compass.yaml
+++ b/templates/definition/tariff/green-grid-compass.yaml
@@ -38,7 +38,7 @@ render: |
       clientsecret: {{ .clientsecret }}
       tokenurl: https://signin.energy/am/oauth2/realms/root/realms/difesp/access_token
       scopes: [esp]
-    uri: https://explore.traxes.io/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T" }}` }}00:00:00Z&end={{ `{{ addDate now 0 0 5 | date "2006-01-02T" }}` }}00:00:00Z&time-resolution=hourly&calculation-type=production&emission-type=operational&forecast-type=actual
+    uri: https://explore.traxes.io/explore/greengrid-compass/v1/co2-intensity-forecast?zone={{ .zone }}&start={{ `{{ now | date "2006-01-02T" }}` }}00:00:00Z&end={{ `{{ addDate now 0 0 5 | date "2006-01-02T" }}` }}00:00:00Z&time-resolution=hourly&calculation-type=production&emission-type=operational&forecast-type=actual
     jq: |
       .measurements[0].measurementValues |  map({ 
         "start": .timestamp,


### PR DESCRIPTION
**Action Required: Public API Base URL Change**
To align with the current public API structure on traXes, the base URL for users accessing the Green Grid Compass API via the public Explore environment has changed:
Old: https://explore.traxes.io/greengrid-compass/v1/
New: https://explore.traxes.io/explore/greengrid-compass/v1/

Thank you for your understanding and for your continued use of the Green Grid Compass API.