### PR TITLE
fix: swap charging/discharging label on battery status card

### DIFF
--- a/assets/js/components/Battery/BatteryStatusCard.stories.ts
+++ b/assets/js/components/Battery/BatteryStatusCard.stories.ts
@@ -10,7 +10,7 @@ export default {
   argTypes: {
     title: { control: "text" },
     soc: { control: { type: "range", min: 0, max: 100 } },
-    power: { control: "number", description: "W, + charging / - discharging" },
+    power: { control: "number", description: "W, + discharging / - charging" },
     capacity: { control: "number", description: "kWh, 0 = unspecified" },
     color: { control: "color" },
   },
@@ -28,7 +28,7 @@ const Narrow: StoryFn<typeof BatteryStatusCard> = (args) => ({
 const base = { title: "Sungrow", capacity: 13.5, color: "#0BA631" };
 
 export const Charging = Narrow.bind({});
-Charging.args = { ...base, soc: 76, power: 800 };
+Charging.args = { ...base, soc: 76, power: -800 };
 
 export const Discharging = Narrow.bind({});
 Discharging.args = {
@@ -37,7 +37,7 @@ Discharging.args = {
   capacity: 7.5,
   color: "#7FC41B",
   soc: 40,
-  power: -1200,
+  power: 1200,
 };
 
 export const Idle = Narrow.bind({});

--- a/assets/js/components/Battery/BatteryStatusCard.vue
+++ b/assets/js/components/Battery/BatteryStatusCard.vue
@@ -52,7 +52,7 @@ export default defineComponent({
 	props: {
 		title: { type: String, default: "" },
 		soc: { type: Number, default: 0 },
-		power: { type: Number, default: 0 }, // W, + charging / - discharging
+		power: { type: Number, default: 0 }, // W, + discharging / - charging
 		capacity: { type: Number, default: 0 }, // kWh, 0 = unspecified
 		color: { type: String, default: "" },
 		suggestion: { type: Object as PropType<BatterySuggestion | null>, default: null },
@@ -79,7 +79,7 @@ export default defineComponent({
 			if (abs < 50) {
 				return { label: this.$t("battery.card.power"), value };
 			}
-			return this.power > 0
+			return this.power < 0
 				? { label: this.$t("battery.card.charging"), value }
 				: { label: this.$t("battery.card.discharging"), value };
 		},

--- a/tests/battery-experimental.spec.ts
+++ b/tests/battery-experimental.spec.ts
@@ -28,11 +28,11 @@ test.describe("experimental battery page", async () => {
 
     // per-battery: soc, charge/discharge state and energy of total
     const charging = cards.filter({ hasText: "76%" });
-    await expect(charging).toContainText("Discharging"); // battery1 power -800 W
+    await expect(charging).toContainText("Charging"); // battery1 power -800 W
     await expect(charging).toContainText("13.5 kWh"); // of total capacity
 
     const discharging = cards.filter({ hasText: "40%" });
-    await expect(discharging).toContainText("Charging"); // battery2 power 1200 W
+    await expect(discharging).toContainText("Discharging"); // battery2 power 1200 W
   });
 
   test("history chart: unit toggle persists and window pages", async ({ page }) => {


### PR DESCRIPTION
Fixes #31403

`power` sign on the new `BatteryStatusCard` (#31383) was inverted vs. the rest of the app, so charging showed as discharging and vice versa.

- Battery overview now uses the app-wide convention: `+` discharging / `-` charging (matches `Energyflow.vue`'s `chargePower`/`dischargePower`)
- Fixed matching Storybook fixtures and prop description