### PR TITLE
chore: document required AC Thor firmware version for setups <9kW to official build

### DIFF
--- a/templates/definition/charger/ac-thor.yaml
+++ b/templates/definition/charger/ac-thor.yaml
@@ -16,7 +16,7 @@ requirements:
       Hat der Heizstab am geregelten Ausgang < 9 kW muss der Skalierungsfaktor wie folgt berechnet und gesetzt werden: `scale = 9000 / Nennleistung` des angeschlossenen Heizstabs. 
 
       Die Betriebsart M3: 9 + 9 kW mit einem zusätzlichen Heizstab am Relais-Ausgang wird unterstützt. Ohne Lastmessung mittels my-PV Meter muss "Last am Relais" im lokalen Webinterface des AC•THOR passend zur Nennleistung des Heizstabs am Relais gesetzt werden.
-      Hat der Heizstab am geregelten Ausgang < 9 kW ist AC•THOR Firmware a0022200 oder höher erforderlich und der Wert für "Last am Relais" muss folgendermaßen mit dem Skalierungsfaktor umgerechnet werden:
+      Hat der Heizstab am geregelten Ausgang < 9 kW ist AC•THOR Firmware a0022401 oder höher erforderlich und der Wert für "Last am Relais" muss folgendermaßen mit dem Skalierungsfaktor umgerechnet werden:
       Last am Relais = Nennleistung des Heizstabs am Relais * Skalierungsfaktor
     en: |
       Use the local web interface of AC•THOR to set the value "Power timeout" to a value slightly higher (e.g. + 5s) than the interval time of evcc.
@@ -24,7 +24,7 @@ requirements:
       If the heating element at the controlled output has < 9 kW, the scaling factor has to be calculated as follows: `scale = 9000 / nominal power` of the connected heater.
 
       Operation mode M3: 9 + 9 kW with an additional heater connected to the relay output is supported. Without load measurement using my-PV meter, the "Load at relay" setting in the local web interface of the AC•THOR must be set to match the nominal power of the heating element at the relay.
-      If the heater at the controlled output has < 9 kW, AC•THOR firmware a0022200 or higher is required and the value for "Load at relay" must be converted using the scaling factor as follows:
+      If the heater at the controlled output has < 9 kW, AC•THOR firmware a0022401 or higher is required and the value for "Load at relay" must be converted using the scaling factor as follows:
       Load at relay = nominal power of the heater at the relay * scale factor
   evcc: ["sponsorship"]
 params:


### PR DESCRIPTION
Offical firmware version a0022401 added, that allows setting of relay power as needed for setups with controlled power <9kW.
Ref https://github.com/evcc-io/evcc/discussions/23708