### PR TITLE
chore(vaillant): warn that DHW off disables native legionella protection

### DIFF
--- a/templates/definition/charger/vaillant.yaml
+++ b/templates/definition/charger/vaillant.yaml
@@ -7,8 +7,8 @@ group: heating
 requirements:
   # evcc: ["sponsorship"]
   description:
-    de: Die Boost Funktion erwärmt Warmwasser oder eine Boostzone. Die Boostzone wird durch die ID identifiziert. Die Boost Temperatur wird in Grad Celsius angegeben. Ist eine Boost Temperatur angegeben, wird die Boostzone aktiviert, anderenfalls Warmwasser.
-    en: The boost function heats hot water or a boost zone. The boost zone is identified by the ID. The boost temperature is specified in degrees Celsius. If boost temperature is specified, the boost zone is activated, otherwise hot water.
+    de: Die Boost Funktion erwärmt Warmwasser oder eine Boostzone. Die Boostzone wird durch die ID identifiziert. Die Boost Temperatur wird in Grad Celsius angegeben. Ist eine Boost Temperatur angegeben, wird die Boostzone aktiviert, anderenfalls Warmwasser. Achtung, wird der Warmwasser-Betriebsmodus der Anlage auf "Aus" gestellt, damit evcc das Warmwasser vollständig regelt, führt die Anlage ihren wöchentlichen Legionellenschutz nicht mehr aus. Sorge dann selbst für eine regelmäßige Aufheizung auf Desinfektionstemperatur (z. B. per Zeitprogramm oder erzwungenem Boost).
+    en: The boost function heats hot water or a boost zone. The boost zone is identified by the ID. The boost temperature is specified in degrees Celsius. If boost temperature is specified, the boost zone is activated, otherwise hot water. Note, if the appliance's DHW operation mode is set to "off" so that evcc fully controls hot water, the appliance no longer runs its weekly legionella protection. Make sure to periodically heat the water to disinfection temperature yourself (e.g. via time program or a forced boost).
 params:
   - name: user
   - name: password


### PR DESCRIPTION
Adds a note to the Vaillant (myVaillant/sensoNET) template help text.

When the appliance's DHW operation mode is set to OFF so that evcc fully controls hot water, the heat pump still *reports* legionella protection as scheduled but never executes it, since evcc boosts only target the normal setpoint. This is a silent, safety-relevant side effect.

As agreed with @andig in discussion #31395, this adds a one-line warning to the template so users know they must handle disinfection heating themselves in that configuration.

Ref discussion #31395