### PR TITLE
CI: reset go-test build cache namespace to fix flaky EEBus conformance tests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -109,10 +109,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-test-v2-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-test-
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-test-v2-
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test


### PR DESCRIPTION
Stacked on #31384.

## Problem

The `Test` job on `#31384` deterministically fails two of the new EEBus conformance tests across **3 consecutive reruns**:

```
--- FAIL: TestOHPCF_LPC_Dimmed/active_zero   expected: false  actual: true
--- FAIL: TestLPC_Dimmed/active_zero          expected: false  actual: true
```

`active_zero` feeds a mocked limit of `{IsActive: true, Value: 0}` and asserts `IsActive && Value > 0 == false`. That expression **cannot** return `true` for `Value == 0` — so the compiled binary on the runner is not behaving like the source.

## Evidence it's the runner's build cache, not the tests

The identical source passes in **every** fresh build I could construct:

| Environment | Result |
|---|---|
| darwin/arm64 — isolated, full package, `-shuffle` ×50 | ✅ |
| linux/amd64 container — isolated + full package | ✅ |
| linux/arm64 + go 1.26.3 (runner's exact toolchain), `-tags=release`, `CGO_ENABLED=0` — isolated, full package, **and full `./...`** | ✅ |
| linux/arm64 under `-race` ×50 | ✅ (no race) |
| **depot Test runner ×3** | ❌ deterministic |

- `meter` and `charger` run in **separate test processes** yet fail identically → rules out a data race.
- Charger inlines the check; meter routes through the generic `eebusReadValue` → **different code paths, same impossible result.**
- The runner's cache step reports an **exact hit** (`Linux-go-test-<go.sum-hash>`), so go.sum is unchanged and no `restore-keys` fallback occurred. The restored `~/.cache/go-build` is the *only* thing that differs from the passing runs, and a Go cache hit is supposed to be behavior-equivalent to a fresh compile.

The most parsimonious explanation is a corrupt/poisoned `go-build` cache blob on the self-hosted runner.

## Fix

Move the Test job to a fresh cache namespace (`go-test-v2-`) and drop the broad `restore-keys` fallbacks so it can't restore the old (suspect) blob. The first run rebuilds from scratch; **this PR's own green Test job is the confirmation.**

If the Test job still fails here with a fresh cache, the cache theory is wrong and we look elsewhere — but nothing in the test logic accounts for the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)