### PR TITLE
Cloud: preserve brand for EU Data Act vehicles

### DIFF
--- a/vehicle/config.go
+++ b/vehicle/config.go
@@ -35,7 +35,11 @@ func NewFromConfig(ctx context.Context, typ string, other map[string]any) (api.V
 	}
 
 	if cc.Cloud {
-		cc.Other["brand"] = typ
+		// keep an explicit brand (e.g. drivesomethinggreater's Audi/Seat/...);
+		// otherwise the type itself is the brand (legacy per-brand vehicles)
+		if _, ok := cc.Other["brand"]; !ok {
+			cc.Other["brand"] = typ
+		}
 		typ = "cloud"
 	}
 

--- a/vehicle/vw/eudataact/eudataact_test.go
+++ b/vehicle/vw/eudataact/eudataact_test.go
@@ -97,6 +97,12 @@ func TestResolveBrand(t *testing.T) {
 
 	_, ok := resolveBrand("nope")
 	assert.False(t, ok)
+
+	// IsBrand drives the cloud server's brand -> drivesomethinggreater routing
+	for _, name := range []string{"audi", "Volkswagen", "seat", "CUPRA", "skoda"} {
+		assert.True(t, IsBrand(name), "%q is a VW group brand", name)
+	}
+	assert.False(t, IsBrand("tesla"))
 }
 
 func TestPending(t *testing.T) {

--- a/vehicle/vw/eudataact/types.go
+++ b/vehicle/vw/eudataact/types.go
@@ -38,6 +38,12 @@ func resolveBrand(name string) (brand, bool) {
 	return brand{}, false
 }
 
+// IsBrand reports whether name is a known VW group brand (case-insensitive)
+func IsBrand(name string) bool {
+	_, ok := resolveBrand(name)
+	return ok
+}
+
 // Vehicle is a single entry of the portal vehicle list. VIN and name carry
 // several alternative field names depending on the response variant.
 type Vehicle struct {


### PR DESCRIPTION
VW group brands (Audi, Volkswagen, Seat, Cupra) moved to the shared drivesomethinggreater (EU Data Act) vehicle, where the brand is a config parameter instead of a dedicated vehicle type. The cloud SoC path still treated the brand as the type.

`NewFromConfig` unconditionally set `brand = type` for `cloud: true` vehicles, so an explicitly configured brand was dropped and the sponsor server logged in with the default (Volkswagen) identity client. This now keeps an explicit brand and only falls back to the type when none is given.

`IsBrand` is exported so the sponsor server can route a bare brand request onto the drivesomethinggreater vehicle (companion change in the sponsor repo).

Verified live against the EU Data Act portal: a cloud request for brand `audi` authenticates with the Audi client and returns a real SoC.

Ref: #30870