### PR TITLE
Remote: delete client via path parameter

### DIFF
--- a/assets/js/components/Config/Remote/RemoteModal.vue
+++ b/assets/js/components/Config/Remote/RemoteModal.vue
@@ -196,7 +196,7 @@ export default defineComponent({
 			}
 			try {
 				this.error = null;
-				await api.delete("config/remote/clients", { params: { username } });
+				await api.delete(`config/remote/clients/${encodeURIComponent(username)}`);
 				await this.loadClients();
 			} catch (err) {
 				this.handleError(err);

--- a/server/http.go
+++ b/server/http.go
@@ -311,7 +311,7 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *uti
 			"remote":             {"POST", "/remote/{value:[01truefalse]+}", boolHandler(remoteAccess.Enable, remoteAccess.Enabled)},
 			"remoteclients":      {"GET", "/remote/clients", remoteClientsHandler(remoteAccess)},
 			"createremoteclient": {"POST", "/remote/clients", createRemoteClientHandler(remoteAccess)},
-			"deleteremoteclient": {"DELETE", "/remote/clients", deleteRemoteClientHandler(remoteAccess)},
+			"deleteremoteclient": {"DELETE", "/remote/clients/{username}", deleteRemoteClientHandler(remoteAccess)},
 		}
 
 		// yaml handlers

--- a/server/http_remote_handler.go
+++ b/server/http_remote_handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/server/remote"
+	"github.com/gorilla/mux"
 )
 
 // remoteClientsHandler returns the list of remote tunnel clients.
@@ -49,10 +50,9 @@ func createRemoteClientHandler(r *remote.Remote) http.HandlerFunc {
 }
 
 // deleteRemoteClientHandler removes a tunnel client by username.
-// Username is passed as a query parameter to allow arbitrary characters.
 func deleteRemoteClientHandler(r *remote.Remote) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		username := req.URL.Query().Get("username")
+		username := mux.Vars(req)["username"]
 		if err := r.DeleteClient(username); err != nil {
 			jsonError(w, http.StatusNotFound, err)
 			return

--- a/server/remote/clients.go
+++ b/server/remote/clients.go
@@ -77,9 +77,10 @@ func (r *Remote) CreateClient(username string, expiresIn time.Duration) (Client,
 	if username == "" {
 		return Client{}, "", errors.New("username required")
 	}
-	// RFC 7617: ":" is the basic-auth separator; reject control chars too.
+	// RFC 7617: ":" is the basic-auth separator; "/" would break the DELETE
+	// route's path parameter; reject control chars too.
 	for _, r := range username {
-		if r == ':' || r < 0x20 || r == 0x7f {
+		if r == ':' || r == '/' || r < 0x20 || r == 0x7f {
 			return Client{}, "", errors.New("username contains invalid characters")
 		}
 	}


### PR DESCRIPTION
Deleting a remote client used a `username` query parameter while the rest of the config API addresses resources via path parameters (`DELETE /config/devices/{class}/{id}`, `DELETE /config/service/eebus/pairings/{id}`). This aligns the remote-clients endpoint: `DELETE /api/config/remote/clients/{username}`.

Since usernames previously allowed arbitrary characters (the reason for the query parameter), `CreateClient` now additionally rejects `/`, which would break the path parameter. `:` and control characters were already rejected per RFC 7617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
