### PR TITLE
Config UI: fix product selection for multi-product templates

### DIFF
--- a/assets/js/components/Config/DeviceModal/TemplateSelector.test.ts
+++ b/assets/js/components/Config/DeviceModal/TemplateSelector.test.ts
@@ -1,0 +1,49 @@
+import { mount, config } from "@vue/test-utils";
+import { describe, expect, test } from "vitest";
+import TemplateSelector, { type TemplateGroup } from "./TemplateSelector.vue";
+
+config.global.mocks["$t"] = (key: string) => key;
+
+// mirrors the vestel template: multiple products sharing one template
+const groups: TemplateGroup[] = [
+  {
+    label: "generic",
+    options: [
+      { name: "Ampure Unite", template: "vestel" },
+      { name: "Vestel EVC04 Home Smart", template: "vestel" },
+      { name: "Webasto Unite", template: "vestel" },
+      { name: "Other Box", template: "other" },
+    ],
+  },
+];
+
+function mountSelector(modelValue: string | null = null) {
+  return mount(TemplateSelector, {
+    props: { deviceType: "charger", isNew: true, modelValue, groups },
+  });
+}
+
+describe("TemplateSelector", () => {
+  test("keeps the chosen product when multiple products share a template", async () => {
+    const wrapper = mountSelector();
+
+    await wrapper.find("select").setValue("vestel\tVestel EVC04 Home Smart");
+    expect(wrapper.emitted("update:modelValue")).toEqual([["vestel"]]);
+
+    // parent writes the template back via v-model; selection must not snap to "Ampure Unite"
+    await wrapper.setProps({ modelValue: "vestel" });
+    const select = wrapper.find("select").element as HTMLSelectElement;
+    expect(select.selectedOptions[0]?.text.trim()).toBe("Vestel EVC04 Home Smart");
+    expect((wrapper.vm as any).getProductName()).toBe("Vestel EVC04 Home Smart");
+  });
+
+  test("selects the first matching product when template is set externally", () => {
+    const wrapper = mountSelector("vestel");
+    expect((wrapper.vm as any).getProductName()).toBe("Ampure Unite");
+  });
+
+  test("returns empty product name without selection", () => {
+    const wrapper = mountSelector();
+    expect((wrapper.vm as any).getProductName()).toBe("");
+  });
+});

--- a/assets/js/components/Config/DeviceModal/TemplateSelector.vue
+++ b/assets/js/components/Config/DeviceModal/TemplateSelector.vue
@@ -17,7 +17,7 @@
 					<option
 						v-for="option in group.options"
 						:key="option.name"
-						:value="option.template"
+						:value="optionKey(option)"
 					>
 						{{ option.name }}
 					</option>
@@ -69,23 +69,41 @@ export default defineComponent({
 		disabled: Boolean,
 	},
 	emits: ["update:modelValue", "change"],
+	data() {
+		return {
+			// product-level selection (`template\tname`); the template alone is ambiguous
+			// since multiple products may share the same template
+			selection: null as string | null,
+		};
+	},
 	computed: {
 		modelProxy: {
-			get() {
-				return this.modelValue;
+			get(): string | null {
+				if (this.selection?.split("\t")[0] === this.modelValue) {
+					return this.selection;
+				}
+				// template set externally: select its first product
+				const match = this.allOptions.find((o) => o.template === this.modelValue);
+				return match ? this.optionKey(match) : null;
 			},
 			set(value: string) {
-				this.$emit("update:modelValue", value);
+				this.selection = value;
+				this.$emit("update:modelValue", value.split("\t")[0]);
 			},
+		},
+		allOptions(): TemplateOption[] {
+			return (this.groups ?? []).flatMap((g) => g.options ?? []);
 		},
 	},
 	methods: {
+		optionKey(option: TemplateOption): string {
+			return `${option.template}\t${option.name}`;
+		},
 		changed(e: Event) {
 			this.$emit("change", e);
 		},
 		getProductName() {
-			const select = this.$refs["select"] as HTMLSelectElement;
-			return select.options[select.selectedIndex]?.text || "";
+			return this.modelProxy?.split("\t")[1] || "";
 		},
 	},
 });


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/31481

When adding a device whose template covers multiple products (e.g. vestel: Ampure Unite, Vestel EVC04 Home Smart, Webasto Unite, …), the manufacturer dropdown bound options by template name. All products of one template shared the same option value, so after selection the browser resolved the value back to the first matching option — the UI visibly snapped to the alphabetically first product ("Ampure Unite") and, worse, `create()` read the displayed option text from the DOM and persisted the wrong `deviceProduct`. Reported for Vestel EVC04 in the discussion of #31323.

Fix: options now carry a product-unique `template\tname` value tracked as internal selection state. The component still exposes the template via `v-model` (parent API unchanged), and `getProductName()` derives the name from the selection instead of reading `selectedIndex` from the DOM. Presetting a template externally (`defaultTemplate`) still resolves to its first product as before.

Includes a component regression test; e2e specs are unaffected since they select by product label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)