### PR TITLE
chore: fix vitest localStorage breakage on Node 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "evcc-io",
   "scripts": {
     "build": "vite build",
-    "test": "cross-env TZ=Europe/Berlin vitest",
+    "test": "cross-env TZ=Europe/Berlin NODE_OPTIONS=--no-experimental-webstorage vitest",
     "lint": "npm run lint:prettier && npm run lint:eslint && npm run lint:tsc && npm run lint:i18n",
     "lint:prettier": "prettier assets tests **/*.{yaml,sh} i18n/*.json --write",
     "lint:eslint": "eslint --fix --max-warnings=0",


### PR DESCRIPTION
On Node 26 (and Node 25+ where experimental Web Storage is enabled by default), `npm test` fails in 5 test files with `TypeError: Cannot read properties of undefined` from `window.localStorage` access in `settings.ts`.

Cause: Node defines a native `localStorage` global that evaluates to `undefined` unless `--localstorage-file` is provided. Vitest's happy-dom environment (`populateGlobal`) preserves existing Node globals rather than overriding them, so happy-dom's working `localStorage` is never installed — tests see Node's undefined one. Node 22/24 don't expose the global, which is why the suite passes there (and in CI).

Fix: disable Node's experimental webstorage for the test run via `NODE_OPTIONS=--no-experimental-webstorage` in the npm test script. The flag is accepted on Node 22+ — verified the full suite passes on both Node 22 and Node 26 with this change. Bumping happy-dom (20.10.6) or vitest (4.1.9) does not resolve it; arguably a vitest `populateGlobal` issue, but this keeps local runs working on current Node regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)