### PR TITLE
Solcast: request 96h forecast horizon

### DIFF
--- a/tariff/solcast.go
+++ b/tariff/solcast.go
@@ -90,7 +90,7 @@ func (t *Solcast) run(interval time.Duration, done chan error) {
 		var res solcast.Forecasts
 
 		if err := backoff.Retry(func() error {
-			uri := fmt.Sprintf("https://api.solcast.com.au/rooftop_sites/%s/forecasts?period=PT30M&format=json", t.site)
+			uri := fmt.Sprintf("https://api.solcast.com.au/rooftop_sites/%s/forecasts?period=PT30M&format=json&hours=96", t.site)
 			return backoffPermanentError(t.GetJSON(uri, &res))
 		}, bo()); err != nil {
 			if reportError(&once, done, err) {


### PR DESCRIPTION
fixes #31453

The Solcast API defaults to 48 hours of forecast data when the `hours` parameter is omitted. The forecast view can display up to 96 hours, so Solcast users saw a shorter forecast than other providers like Open-Meteo.

- request 96 hours of forecast data, matching the maximum UI window