### PR TITLE
EEBus: error on missing productionNominalMax (BC)

### DIFF
--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -2,6 +2,7 @@ package eebus
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -246,6 +247,10 @@ func (c *EEBus) run() error {
 	// LPP
 	if c.productionLimitActivated.IsZero() {
 		if c.productionLimit.IsActive {
+			if c.productionNominalMax <= 0 {
+				return errors.New("production limit received but productionNominalMax is not configured")
+			}
+
 			c.log.WARN.Println("activating production limit")
 			c.setProductionLimit(c.productionLimit.Value, true)
 		}

--- a/hems/eebus/eebus_test.go
+++ b/hems/eebus/eebus_test.go
@@ -150,6 +150,18 @@ func TestRun_ProductionLimitReleasedEarly(t *testing.T) {
 	assertProductionLimit(t, c, false)
 }
 
+// TestRun_ProductionLimitWithoutNominalMax verifies an incoming LPP limit
+// errors instead of being silently ignored when productionNominalMax is unset (#31469).
+func TestRun_ProductionLimitWithoutNominalMax(t *testing.T) {
+	c := newTestEEBus(t)
+	c.heartbeat.Set(struct{}{})
+	c.productionNominalMax = 0
+
+	c.productionLimit = ucapi.LoadLimit{Value: -2200, IsActive: true, Duration: time.Hour}
+	require.Error(t, c.run())
+	assert.Nil(t, c.CurtailedPercent())
+}
+
 // TestRun_ConsumptionLimitReleasedEarly is the LPC mirror of the LPP early-release
 // case: an active consumption limit must drop as soon as the EG deactivates it.
 func TestRun_ConsumptionLimitReleasedEarly(t *testing.T) {

--- a/templates/definition/hems/fnn-eebus.yaml
+++ b/templates/definition/hems/fnn-eebus.yaml
@@ -31,7 +31,6 @@ params:
   - name: productionnominalmax
     type: float
     unit: W
-    advanced: true
     description:
       en: Installed generator power (Wp)
       de: Installierte Generatorleistung (Wp)

--- a/templates/definition/hems/hemspro-eebus.yaml
+++ b/templates/definition/hems/hemspro-eebus.yaml
@@ -32,7 +32,6 @@ params:
   - name: productionnominalmax
     type: float
     unit: W
-    advanced: true
     description:
       en: Installed generator power (Wp)
       de: Installierte Generatorleistung (Wp)


### PR DESCRIPTION
fixes #31469

PR #31390 turned the EEBus HEMS's `CurtailedPercent()` into a percent derived from `productionNominalMax`, but left the field defaulting to 0 and hidden behind `advanced: true` in the FNN/HEMS-PRO templates. When it's unset, an incoming LPP production limit is silently dropped: `core/site_circuits.go:curtailPV` receives `nil` and returns without ever calling a device's `SetCurtailPercent`, with no log output at all.

- `hems/eebus/eebus.go`: `run()` now returns an error when an LPP production limit arrives while `productionNominalMax <= 0`, so the misconfiguration is visible in the logs instead of being silently ignored.
- `templates/definition/hems/fnn-eebus.yaml` and `hemspro-eebus.yaml`: `productionnominalmax` is no longer `advanced: true`, so it's visible by default when configuring these HEMS types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)