### PR TITLE
Solarmax MAX.STORAGE: implement grid charging

### DIFF
--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -6,8 +6,8 @@ products:
 capabilities: ["battery-control"]
 requirements:
   description:
-    de: Für Batteriesteuerung muss über den Solarmax Support die Funktion "Connectivity+" freigeschaltet werden. Verfügbar ab Software 3.4.4. Ohne Freischaltung bleibt die Funktion ohne Wirkung. Netzladung ist generell nicht verfügbar.
-    en: For batter control, the "Connectivity+" function must be activated via the Solarmax support. Available from software version 3.4.4. Without activation, the function remains without effect. Grid charging is generally not available.
+    de: Für Batteriesteuerung muss über den Solarmax Support die Funktion "Connectivity+" freigeschaltet werden. Verfügbar ab Software 3.4.4. Ohne Freischaltung bleibt die Funktion ohne Wirkung.
+    en: For batter control, the "Connectivity+" function must be activated via the Solarmax support. Available from software version 3.4.4. Without activation, the function remains without effect.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -16,6 +16,9 @@ params:
     id: 1
   - name: maxacpower
   - preset: battery-params
+  - name: maxchargepower
+    service: modbus/read?address=130&type=input&encoding=uint32&{modbus}
+    required: true
   # battery control
   - name: watchdog
     default: 60s
@@ -132,9 +135,26 @@ render: |
                 address: 142
                 type: writemultiple
                 decode: int16
-      - case: 3 # charge (not implemented)
+      - case: 3 # charge
         set:
-          source: error
-          error: ErrNotAvailable
+          source: sequence
+          set:
+          - source: const
+            value: {{ .maxchargepower }} # W, positive = charge (Vorgabe Batterieleistung)
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 140
+                type: writemultiple
+                encoding: int32s
+          - source: random
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 142
+                type: writemultiple
+                decode: int16
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -140,14 +140,23 @@ render: |
           source: sequence
           set:
           - source: const
-            value: {{ .maxchargepower }} # W, positive = charge (Vorgabe Batterieleistung)
+            value: {{ .maxchargepower }} # W, max charge power
             set:
               source: modbus
               {{- include "modbus" . | indent 12 }}
               register:
                 address: 140
                 type: writemultiple
-                encoding: int32s
+                decode: int16
+          - source: const
+            value: 0 # W, block discharge while forcing charge
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 141
+                type: writemultiple
+                decode: int16
           - source: random
             set:
               source: modbus


### PR DESCRIPTION
fixes #31474

Implements the "charge" battery-control case (grid charging) for the SolarMax MAX.STORAGE / MAX.STORAGE Ultimate template, per the register map confirmed on the issue.

- Registers 140/141 (holding) are two independent 16-bit setpoints, same as the existing "normal"/"hold" cases: 140 sets the max charge power (from the `maxchargepower` param), 141 is zeroed to block discharge while forcing charge.
- Register 142 stays the shared watchdog, refreshed with a random value exactly like the existing "hold" case.
- `maxchargepower` now defaults to the device's own max charge power (input register 130), matching the pattern used in other battery-control templates (e.g. Huawei SUN2000).
- Removed the now-outdated "grid charging is generally not available" line from the template's requirements text.

Not hardware-tested (no device access) — validated via `go test ./meter/...` (`TestTemplates/solarmax-maxstorage/battery`) and a local dry-run render/instantiate against a mock host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)