### PR TITLE
SunSpec: add curtail to generic hybrid/inverter templates

### DIFF
--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -5,6 +5,7 @@ products:
       de: SunSpec Hybridwechselrichter
       en: SunSpec Hybrid Inverter
 group: generic
+capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -106,6 +107,33 @@ render: |
         {{- include "modbus" . | indent 6 }}
         value: 160:2:DCWH # mppt 2
         scale: 0.001
+  curtail:
+    source: sequence
+    set:
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value: 704:WMaxLimPct
+      - source: switch
+        switch:
+          - case: 100 # Uncurtailed
+            set:
+              source: const
+              value: 0 # Limit disabled
+              set:
+                source: sunspec
+                {{- include "modbus" . | indent 14 }}
+                value: 704:WMaxLimPctEna
+        default:
+          source: const
+          value: 1 # Limit enabled
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 704:WMaxLimPctEna
+  curtailed:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 704:WMaxLimPctEna
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -4,6 +4,7 @@ products:
       de: SunSpec Wechselrichter
       en: SunSpec Inverter
 group: generic
+capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -153,6 +154,33 @@ render: |
       - 103:WH
       - 113:WH
     scale: 0.001
+  curtail:
+    source: sequence
+    set:
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value: 704:WMaxLimPct
+      - source: switch
+        switch:
+          - case: 100 # Uncurtailed
+            set:
+              source: const
+              value: 0 # Limit disabled
+              set:
+                source: sunspec
+                {{- include "modbus" . | indent 14 }}
+                value: 704:WMaxLimPctEna
+        default:
+          source: const
+          value: 1 # Limit enabled
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value: 704:WMaxLimPctEna
+  curtailed:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value: 704:WMaxLimPctEna
   {{- end }}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
Adds `curtail`/`curtailed` to `sunspec-hybrid` and `sunspec-inverter` (usage: pv), using SunSpec model 704 (DER AC Controls, `WMaxLimPct`/`WMaxLimPctEna`) — the same pattern just merged for the Enphase modbus template, now that `sunspec` supports a bool getter for enum16 points.

Model 704 is a generic SunSpec model rather than vendor-specific, so it fits the two generic reference templates. Deliberately left out the vendor-specific battery templates (Fronius `fronius-gen24`/`fronius-vertoplus`, `solaredge-hybrid`) — there's no confirmation their firmware actually exposes model 704, and claiming a capability that silently fails would be worse than not adding it.

Ref: https://github.com/evcc-io/evcc/pull/31460#issuecomment-4885787281