### PR TITLE
Fix flaky TestShipPairing: patched ship-go fork for double-connection race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -263,3 +263,5 @@ replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b
 
 replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260627085352-933afd2a4ea6
+
+replace github.com/enbility/ship-go => github.com/evcc-io/ship-go v0.6.1-0.20260705131745-4344b9692368

--- a/go.mod
+++ b/go.mod
@@ -264,4 +264,4 @@ replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20
 
 replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260627085352-933afd2a4ea6
 
-replace github.com/enbility/ship-go => github.com/evcc-io/ship-go v0.6.1-0.20260705131745-4344b9692368
+replace github.com/enbility/ship-go => github.com/evcc-io/ship-go v0.6.1-0.20260705143036-943556b69307

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/evcc-io/optimizer v0.0.0-20260613102250-473d3906e657 h1:pZW9CGsXsJNHQ
 github.com/evcc-io/optimizer v0.0.0-20260613102250-473d3906e657/go.mod h1:cHMeq6GfoXQ8LxqY4LH1wn/hrgYEn+ka5RPI1CF37SY=
 github.com/evcc-io/rct v0.2.0 h1:qjXKI7NKwW5YpEKEb27MwLMBaR4ne2Kd2cPV2PYTKn4=
 github.com/evcc-io/rct v0.2.0/go.mod h1:n6MTBU36QOadGlxxiADu86VaT5l0eYdbmFBHF14AD/s=
-github.com/evcc-io/ship-go v0.6.1-0.20260705131745-4344b9692368 h1:a3FD3XOj9hNJPypUdkJahAehSN6lIEgreDW5cNNLv68=
-github.com/evcc-io/ship-go v0.6.1-0.20260705131745-4344b9692368/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
+github.com/evcc-io/ship-go v0.6.1-0.20260705143036-943556b69307 h1:vSYO9pNyjpiuxpUF8rdUR7fAvjnEqnkJaSdd2qLWSgk=
+github.com/evcc-io/ship-go v0.6.1-0.20260705143036-943556b69307/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
 github.com/evcc-io/tesla-proxy-client v0.0.0-20260324063928-151fe10796ae h1:0ihqBMBjkekSlwD3ZYQIiYite6ZAln9ze60evOE6FkQ=
 github.com/evcc-io/tesla-proxy-client v0.0.0-20260324063928-151fe10796ae/go.mod h1:L8AR3E7/MbbvCgnrtzsT6YsgQJtN5gk/LumR1gDBeJM=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2I
 github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a h1:foChWb8lhzqa6lWDRs6COYMdp649YlUirFP8GqoT0JQ=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a/go.mod h1:H64mhYcAQUGUUnVqMdZQf93kPecH4M79xwH95Lddt3U=
-github.com/enbility/ship-go v0.6.1-0.20260518113001-134687068e3c h1:ZNYyr/SDaAMHi6ubJqWuoId8QUu5V4xXWCIRf7VnfCY=
-github.com/enbility/ship-go v0.6.1-0.20260518113001-134687068e3c/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323 h1:bLsMlyRamUgDNz6PNiKa1ukPebvs3pplrVGNdHo1JMI=
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323/go.mod h1:ddWZU5BQGyzRGF20Z7rUKFFzbCp+cfu9mZgYtOMW/fM=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6 h1:XOYvxKtT1oxT37w/5oEiRLuPbm9FuJPt3fiYhX0h8Po=
@@ -156,6 +154,8 @@ github.com/evcc-io/optimizer v0.0.0-20260613102250-473d3906e657 h1:pZW9CGsXsJNHQ
 github.com/evcc-io/optimizer v0.0.0-20260613102250-473d3906e657/go.mod h1:cHMeq6GfoXQ8LxqY4LH1wn/hrgYEn+ka5RPI1CF37SY=
 github.com/evcc-io/rct v0.2.0 h1:qjXKI7NKwW5YpEKEb27MwLMBaR4ne2Kd2cPV2PYTKn4=
 github.com/evcc-io/rct v0.2.0/go.mod h1:n6MTBU36QOadGlxxiADu86VaT5l0eYdbmFBHF14AD/s=
+github.com/evcc-io/ship-go v0.6.1-0.20260705131745-4344b9692368 h1:a3FD3XOj9hNJPypUdkJahAehSN6lIEgreDW5cNNLv68=
+github.com/evcc-io/ship-go v0.6.1-0.20260705131745-4344b9692368/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
 github.com/evcc-io/tesla-proxy-client v0.0.0-20260324063928-151fe10796ae h1:0ihqBMBjkekSlwD3ZYQIiYite6ZAln9ze60evOE6FkQ=
 github.com/evcc-io/tesla-proxy-client v0.0.0-20260324063928-151fe10796ae/go.mod h1:L8AR3E7/MbbvCgnrtzsT6YsgQJtN5gk/LumR1gDBeJM=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=


### PR DESCRIPTION
fixes flaky CI failures in TestShipPairing, e.g. https://github.com/evcc-io/evcc/actions/runs/28740106700. Should fix https://github.com/evcc-io/evcc/issues/31465.

CI intermittently fails with "paired device not routed to consumer" after the test's 1-minute connect timeout. Traced to two compounding bugs in `enbility/ship-go`'s connection handling, reproduced locally by stress-running the test under a noisier network than CI (100% failure rate before either fix, 10/10 passes after both, with the original timeouts left untouched):

- Two concurrent outgoing dials to the same SKI can both pass the `isSkiConnected` check before either registers as connected, establish, and then abort each other in a loop — this is enbility/ship-go#85 (open upstream, unmerged).
- `sendSpineData` only tore down a connection when the writer already reported it closed. A write failing for any other reason (e.g. the remote closed it first) left the connection registered as alive, so every subsequent send silently failed and the SKI was never freed for reconnect — a second, previously-unreported bug found while investigating the first, now also filed upstream as enbility/ship-go#86.

Both are fixed in `evcc-io/ship-go` (fork, branch `fix/double-connection-outgoing-dedup`, based on our exact currently-pinned commit): the first is enbility/ship-go#85's fix cherry-picked as-is, the second is enbility/ship-go#86 alongside it. This PR only changes `go.mod`/`go.sum` to point at that fork via a `replace` directive, mirroring the existing `eebus-go` fork pattern already in this repo.

No timeouts were changed — verified the fix holds under the original 1-minute per-connect timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
