### PR TITLE
Loadpoint: correct phase sync when measured phases fall below commanded

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -884,7 +884,7 @@ func (lp *Loadpoint) syncCharger() error {
 
 			// use measured phase currents for active phases as fallback if charger does not provide phases
 			if !isPg || errors.Is(err, api.ErrNotAvailable) {
-				if chargerPhases > phases {
+				if chargerPhases > 0 && chargerPhases != phases {
 					lp.log.WARN.Printf("charger logic error: phases mismatch (got %d measured, expected %d)", chargerPhases, phases)
 					lp.SetPhases(chargerPhases)
 				}

--- a/core/loadpoint_sync_test.go
+++ b/core/loadpoint_sync_test.go
@@ -186,7 +186,7 @@ func TestSyncChargerPhasesByMeasurement(t *testing.T) {
 		{1, 1, 1},
 		{1, 3, 3},
 		{3, 0, 3},
-		{3, 1, 3}, // ignore
+		{3, 1, 1}, // force
 		{3, 3, 3},
 	}
 


### PR DESCRIPTION
fixes #31491

The measured-phase fallback in `syncCharger` only corrected the mismatch in one direction: when the charger reports more active phases than expected. It never handled the opposite case, so when a 1p→3p switch is commanded but never physically takes effect (relay/vehicle doesn't actually engage the third phase), `measuredPhases` sticks at the lower value. Since `maxActivePhases()` is capped by `measuredPhases`, this permanently blocks any further scale-up attempt for the rest of the session, matching the reported symptom of 1p/3p switching "getting stuck" until a restart.

- `syncCharger` now corrects `lp.phases` whenever the measured phase count differs from the commanded one (not just when it's higher), restoring the self-healing loop that lets `pvScalePhases` retry 3p later
- Updated `TestSyncChargerPhasesByMeasurement` to assert the corrected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)