### PR TITLE
RCT: fix nil pointer panic on repeated/concurrent BatteryNormal

### DIFF
--- a/meter/rct.go
+++ b/meter/rct.go
@@ -24,7 +24,37 @@ type RCT struct {
 	conn          *rct.Connection // connection with the RCT device
 	usage         string          // grid, pv, battery
 	externalPower bool            // whether to query external power
-	rSocStrategy  *uint8          // remembers overwritten soc strategy value
+
+	mu           sync.Mutex
+	rSocStrategy *uint8 // remembers overwritten soc strategy value
+}
+
+// takeRSocStrategy atomically returns and clears the saved soc strategy, or nil
+// if none is saved (e.g. BatteryNormal applied twice in a row).
+func (m *RCT) takeRSocStrategy() *uint8 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s := m.rSocStrategy
+	m.rSocStrategy = nil
+	return s
+}
+
+// setRSocStrategyIfAbsent saves strategy unless a value is already saved.
+func (m *RCT) setRSocStrategyIfAbsent(strategy uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.rSocStrategy == nil {
+		m.rSocStrategy = &strategy
+	}
+}
+
+// hasRSocStrategy reports whether a soc strategy is currently saved
+func (m *RCT) hasRSocStrategy() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.rSocStrategy != nil
 }
 
 var (
@@ -161,12 +191,12 @@ func NewRCT(ctx context.Context, uri, usage string, batterySocLimits batterySocL
 				}
 
 				// read soc strategy to reset afterwards
-				if m.rSocStrategy == nil {
+				if !m.hasRSocStrategy() {
 					strategy, err := m.queryUint8(rct.PowerMngSocStrategy)
 					if err != nil {
 						return err
 					}
-					m.rSocStrategy = &strategy
+					m.setRSocStrategyIfAbsent(strategy)
 				}
 			}
 
@@ -174,11 +204,11 @@ func NewRCT(ctx context.Context, uri, usage string, batterySocLimits batterySocL
 
 			switch mode {
 			case api.BatteryNormal:
-				eg.Go(func() error {
-					err := m.conn.Write(rct.PowerMngSocStrategy, []byte{*m.rSocStrategy})
-					m.rSocStrategy = nil
-					return err
-				})
+				if strategy := m.takeRSocStrategy(); strategy != nil {
+					eg.Go(func() error {
+						return m.conn.Write(rct.PowerMngSocStrategy, []byte{*strategy})
+					})
+				}
 
 				eg.Go(func() error {
 					return m.conn.Write(rct.BatterySoCTargetMin, floatVal(batterySocLimits.MinSoc/100))

--- a/meter/rct_test.go
+++ b/meter/rct_test.go
@@ -1,0 +1,38 @@
+package meter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRCTTakeRSocStrategy verifies that a repeated BatteryNormal application
+// (no intervening non-normal mode) is a no-op instead of a nil dereference (#31471).
+func TestRCTTakeRSocStrategy(t *testing.T) {
+	m := &RCT{}
+
+	// nothing saved yet
+	assert.Nil(t, m.takeRSocStrategy())
+
+	m.setRSocStrategyIfAbsent(4)
+	strategy := m.takeRSocStrategy()
+	require.NotNil(t, strategy)
+	assert.Equal(t, uint8(4), *strategy)
+
+	// second take without an intervening set must not repeat the value or panic
+	assert.Nil(t, m.takeRSocStrategy())
+}
+
+// TestRCTSetRSocStrategyIfAbsent verifies the saved value is never overwritten
+// while still present, matching the original guard's intent.
+func TestRCTSetRSocStrategyIfAbsent(t *testing.T) {
+	m := &RCT{}
+
+	m.setRSocStrategyIfAbsent(4)
+	m.setRSocStrategyIfAbsent(7)
+
+	strategy := m.takeRSocStrategy()
+	require.NotNil(t, strategy)
+	assert.Equal(t, uint8(4), *strategy)
+}


### PR DESCRIPTION
fixes #31471

`m.rSocStrategy` was read/written without synchronization and dereferenced unconditionally in the `BatteryNormal` case:

```go
case api.BatteryNormal:
    eg.Go(func() error {
        err := m.conn.Write(rct.PowerMngSocStrategy, []byte{*m.rSocStrategy})
        m.rSocStrategy = nil
        return err
    })
```

Once one `BatteryNormal` application had cleared it, any further one — a second `updateBatteryMode` cycle, the external-mode watchdog, the shutdown hook, or a concurrent call racing the goroutine, as described in the issue — dereferenced a nil pointer and crashed evcc.

Fix: guard `rSocStrategy` with a mutex and extract the read/take into two small helpers:

- `setRSocStrategyIfAbsent` saves the queried strategy only if none is already saved (same behavior as the original `if m.rSocStrategy == nil` check, now race-safe).
- `takeRSocStrategy` atomically returns and clears the saved value, or nil if there's nothing to restore — `BatteryNormal` now skips the write entirely when nil rather than dereferencing it.

Added `meter/rct_test.go` covering both: a second take without an intervening save is a no-op instead of a crash, and an already-saved value is never overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
