### PR TITLE
meter: sunspec curtail falls back to model 123

### DIFF
--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -112,7 +112,9 @@ render: |
     set:
       - source: sunspec
         {{- include "modbus" . | indent 6 }}
-        value: 704:WMaxLimPct
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
       - source: switch
         switch:
           - case: 100 # Uncurtailed
@@ -122,18 +124,24 @@ render: |
               set:
                 source: sunspec
                 {{- include "modbus" . | indent 14 }}
-                value: 704:WMaxLimPctEna
+                value:
+                  - 704:WMaxLimPctEna
+                  - 123:WMaxLim_Ena
         default:
           source: const
           value: 1 # Limit enabled
           set:
             source: sunspec
             {{- include "modbus" . | indent 10 }}
-            value: 704:WMaxLimPctEna
+            value:
+              - 704:WMaxLimPctEna
+              - 123:WMaxLim_Ena
   curtailed:
     source: sunspec
     {{- include "modbus" . | indent 2 }}
-    value: 704:WMaxLimPctEna
+    value:
+      - 704:WMaxLimPctEna
+      - 123:WMaxLim_Ena
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -159,7 +159,9 @@ render: |
     set:
       - source: sunspec
         {{- include "modbus" . | indent 6 }}
-        value: 704:WMaxLimPct
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
       - source: switch
         switch:
           - case: 100 # Uncurtailed
@@ -169,18 +171,24 @@ render: |
               set:
                 source: sunspec
                 {{- include "modbus" . | indent 14 }}
-                value: 704:WMaxLimPctEna
+                value:
+                  - 704:WMaxLimPctEna
+                  - 123:WMaxLim_Ena
         default:
           source: const
           value: 1 # Limit enabled
           set:
             source: sunspec
             {{- include "modbus" . | indent 10 }}
-            value: 704:WMaxLimPctEna
+            value:
+              - 704:WMaxLimPctEna
+              - 123:WMaxLim_Ena
   curtailed:
     source: sunspec
     {{- include "modbus" . | indent 2 }}
-    value: 704:WMaxLimPctEna
+    value:
+      - 704:WMaxLimPctEna
+      - 123:WMaxLim_Ena
   {{- end }}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
fixes #31535

PR #31492 added `curtail`/`curtailed` to the generic `sunspec-inverter`/`sunspec-hybrid` templates using SunSpec model 704 (DER AC Controls) unconditionally. Model 704 is optional and not implemented by many inverters (e.g. classic Fronius Symo), so meter creation now fails hard for them instead of just lacking curtailment.

- Both templates try model 704 first, then fall back to model 123 (Immediate Controls), which carries the same `WMaxLimPct` point (mandatory in the SunSpec spec) and an equivalent `WMaxLim_Ena` enable point.
- No change for inverters that already support model 704.