### PR TITLE
deye-hybrid-3p: fix energy scaling for LV with firmware1098

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -104,7 +104,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if not .firmware1098 }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -117,7 +117,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if not .firmware1098 }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   currents:
@@ -260,7 +260,7 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if not .firmware1098 }}
+      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
       scale: 0.1
       {{- end }}
     {{- if .includegenport }}
@@ -273,7 +273,7 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if not .firmware1098 }}
+      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
       scale: 0.1
       {{- end }}
     {{- end }}
@@ -308,7 +308,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if not .firmware1098 }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -321,7 +321,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if not .firmware1098 }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   soc:


### PR DESCRIPTION
fixes #31520

The firmware1098 option is documented as HV-only ("Firmware 1098 or newer (only for HV versions)"), but the energy/returnenergy scale condition ignored `batterytype` and applied to LV too. This regressed in #30482, which fixed LV scaling for the default (firmware1098 unchecked) case but didn't account for LV users who also enable that HV-only option.

- LV inverters with `firmware1098: true` were skipping the 0.1 scale on grid/PV/battery energy and returnenergy, reporting values 10x too high on the History and Config pages
- Scale now applies whenever `batterytype` is `lv`, regardless of `firmware1098`, matching the documented HV-only scope of that option

🤖 Generated with [Claude Code](https://claude.com/claude-code)