### PR TITLE
EEBus: update eebus-go/ship-go, drop ship-go fork

### DIFF
--- a/charger/eebus-evse.go
+++ b/charger/eebus-evse.go
@@ -345,7 +345,7 @@ func (c *EEBus) writeCurrentLimitData(evEntity spineapi.EntityRemoteInterface, c
 	}
 
 	// always set overload protection limits (obligation)
-	if err := eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.cem.OpEV.WriteLoadControlLimits(evEntity, limits, cb)
 	}); err != nil {
 		return err
@@ -397,7 +397,7 @@ func (c *EEBus) writeOscevLimits(evEntity spineapi.EntityRemoteInterface, curren
 		limits = append(limits, limit)
 	}
 
-	if err := eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.cem.OscEV.WriteLoadControlLimits(evEntity, limits, cb)
 	}); err != nil {
 		c.log.DEBUG.Println("failed to write OSCEV limits:", err)

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -326,14 +326,14 @@ func ohpcfControlAction(state ucapi.CompressorPowerConsumptionStateType, enable 
 // it aborts the process.
 func (c *EEBusOHPCF) stop(entity spineapi.EntityRemoteInterface) error {
 	if pausable, err := c.cem.OHPCF.ConsumptionIsPausable(entity); err == nil && pausable {
-		return eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, cb)
+		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
 		})
 	}
 
 	if stoppable, err := c.cem.OHPCF.ConsumptionIsStoppable(entity); err == nil && stoppable {
-		return eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, cb)
+		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
 		})
 	}
 
@@ -387,7 +387,7 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	return eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
 	})
 }
@@ -408,13 +408,13 @@ func (c *EEBusOHPCF) apply() error {
 
 	switch ohpcfControlAction(state, c.lastEnabled()) {
 	case ohpcfSchedule:
-		return eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
-			return c.cem.OHPCF.SchedulePowerConsumptionProcess(entity, 0, cb)
+			return c.cem.OHPCF.SchedulePowerConsumptionProcess(entity, 0, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
 		})
 	case ohpcfResume:
-		return eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.ResumePowerConsumptionProcess(entity, cb)
+		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			return c.cem.OHPCF.ResumePowerConsumptionProcess(entity, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
 		})
 	case ohpcfStop:
 		return c.stop(entity)

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -327,13 +327,13 @@ func ohpcfControlAction(state ucapi.CompressorPowerConsumptionStateType, enable 
 func (c *EEBusOHPCF) stop(entity spineapi.EntityRemoteInterface) error {
 	if pausable, err := c.cem.OHPCF.ConsumptionIsPausable(entity); err == nil && pausable {
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
+			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, cb)
 		})
 	}
 
 	if stoppable, err := c.cem.OHPCF.ConsumptionIsStoppable(entity); err == nil && stoppable {
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
+			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, cb)
 		})
 	}
 
@@ -410,11 +410,11 @@ func (c *EEBusOHPCF) apply() error {
 	case ohpcfSchedule:
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
-			return c.cem.OHPCF.SchedulePowerConsumptionProcess(entity, 0, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
+			return c.cem.OHPCF.SchedulePowerConsumptionProcess(entity, 0, cb)
 		})
 	case ohpcfResume:
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.ResumePowerConsumptionProcess(entity, func(r model.ResultDataType) { cb(r, model.MsgCounterType(0)) })
+			return c.cem.OHPCF.ResumePowerConsumptionProcess(entity, cb)
 		})
 	case ohpcfStop:
 		return c.stop(entity)

--- a/charger/eebus_test.go
+++ b/charger/eebus_test.go
@@ -134,8 +134,8 @@ func opevLimits3p(min, max, def float64) ([]float64, []float64, []float64, error
 
 // ackWrite makes a mocked WriteLoadControlLimits invoke its result callback with a
 // success result, as the real eebus-go does, so eebus.Await completes.
-func ackWrite(_ spineapi.EntityRemoteInterface, _ []ucapi.LoadLimitsPhase, resultCB func(model.ResultDataType)) {
-	resultCB(model.ResultDataType{})
+func ackWrite(_ spineapi.EntityRemoteInterface, _ []ucapi.LoadLimitsPhase, resultCB func(model.ResultDataType, model.MsgCounterType)) {
+	resultCB(model.ResultDataType{}, model.MsgCounterType(0))
 }
 
 func TestWriteCurrentLimitData_OpevOnly(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dylanmei/iso8601 v0.1.0
 	github.com/eclipse/paho.mqtt.golang v1.5.1
-	github.com/enbility/eebus-go v0.7.1-0.20260608105936-abdcf864d0cf
-	github.com/enbility/ship-go v0.6.1-0.20260518113001-134687068e3c
+	github.com/enbility/eebus-go v0.7.1-0.20260706105148-69719d143633
+	github.com/enbility/ship-go v0.6.1-0.20260706134013-3abd41d19f41
 	github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323
 	github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4
 	github.com/evcc-io/optimizer v0.0.0-20260613102250-473d3906e657
@@ -262,6 +262,4 @@ replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165
 
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b
 
-replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260627085352-933afd2a4ea6
-
-replace github.com/enbility/ship-go => github.com/evcc-io/ship-go v0.6.1-0.20260705143036-943556b69307
+replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260707082901-12140d9ad576

--- a/go.mod
+++ b/go.mod
@@ -262,4 +262,4 @@ replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165
 
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b
 
-replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260707082901-12140d9ad576
+replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260707085304-6939a96c368f

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323 h1:bLsMlyRamUg
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323/go.mod h1:ddWZU5BQGyzRGF20Z7rUKFFzbCp+cfu9mZgYtOMW/fM=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6 h1:XOYvxKtT1oxT37w/5oEiRLuPbm9FuJPt3fiYhX0h8Po=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6/go.mod h1:BszP9qFV14mPXgyIREbgIdQtWxbAj3OKqvK02HihMoM=
-github.com/evcc-io/eebus-go v0.0.0-20260707082901-12140d9ad576 h1:+Sc1cZlGN9OBvN62M3NaS4KtgCAr8/3Zi/ZV27Yp90E=
-github.com/evcc-io/eebus-go v0.0.0-20260707082901-12140d9ad576/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
+github.com/evcc-io/eebus-go v0.0.0-20260707085304-6939a96c368f h1:4qTrzQ1yUs0FrTMXf9OTSIshdFi7Blq5TErrsF7Karg=
+github.com/evcc-io/eebus-go v0.0.0-20260707085304-6939a96c368f/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea h1:F6eyC8V8wvc3ranlsR4coAls+OPBkVvxyX0a2VqdlPc=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea/go.mod h1:swrNGAVgI1r/3d/sEKE7qgujdRR9aHVPYKyc3gvpVTc=
 github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b h1:5vFr7wOwoi5ylybUnxxBk1U3FRF2+3Sf0sKx8thxw18=

--- a/go.sum
+++ b/go.sum
@@ -138,12 +138,14 @@ github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2I
 github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a h1:foChWb8lhzqa6lWDRs6COYMdp649YlUirFP8GqoT0JQ=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a/go.mod h1:H64mhYcAQUGUUnVqMdZQf93kPecH4M79xwH95Lddt3U=
+github.com/enbility/ship-go v0.6.1-0.20260706134013-3abd41d19f41 h1:Uzs5tsH+eh7IveFrtnumh36DKFaPS8nHZgBW/xbz9zw=
+github.com/enbility/ship-go v0.6.1-0.20260706134013-3abd41d19f41/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323 h1:bLsMlyRamUgDNz6PNiKa1ukPebvs3pplrVGNdHo1JMI=
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323/go.mod h1:ddWZU5BQGyzRGF20Z7rUKFFzbCp+cfu9mZgYtOMW/fM=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6 h1:XOYvxKtT1oxT37w/5oEiRLuPbm9FuJPt3fiYhX0h8Po=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6/go.mod h1:BszP9qFV14mPXgyIREbgIdQtWxbAj3OKqvK02HihMoM=
-github.com/evcc-io/eebus-go v0.0.0-20260627085352-933afd2a4ea6 h1:ax+dfxmeF/hN3IIUXFnDw3y3BE7pr0m/699k08+Q9sM=
-github.com/evcc-io/eebus-go v0.0.0-20260627085352-933afd2a4ea6/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
+github.com/evcc-io/eebus-go v0.0.0-20260707082901-12140d9ad576 h1:+Sc1cZlGN9OBvN62M3NaS4KtgCAr8/3Zi/ZV27Yp90E=
+github.com/evcc-io/eebus-go v0.0.0-20260707082901-12140d9ad576/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea h1:F6eyC8V8wvc3ranlsR4coAls+OPBkVvxyX0a2VqdlPc=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea/go.mod h1:swrNGAVgI1r/3d/sEKE7qgujdRR9aHVPYKyc3gvpVTc=
 github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b h1:5vFr7wOwoi5ylybUnxxBk1U3FRF2+3Sf0sKx8thxw18=
@@ -154,8 +156,6 @@ github.com/evcc-io/optimizer v0.0.0-20260613102250-473d3906e657 h1:pZW9CGsXsJNHQ
 github.com/evcc-io/optimizer v0.0.0-20260613102250-473d3906e657/go.mod h1:cHMeq6GfoXQ8LxqY4LH1wn/hrgYEn+ka5RPI1CF37SY=
 github.com/evcc-io/rct v0.2.0 h1:qjXKI7NKwW5YpEKEb27MwLMBaR4ne2Kd2cPV2PYTKn4=
 github.com/evcc-io/rct v0.2.0/go.mod h1:n6MTBU36QOadGlxxiADu86VaT5l0eYdbmFBHF14AD/s=
-github.com/evcc-io/ship-go v0.6.1-0.20260705143036-943556b69307 h1:vSYO9pNyjpiuxpUF8rdUR7fAvjnEqnkJaSdd2qLWSgk=
-github.com/evcc-io/ship-go v0.6.1-0.20260705143036-943556b69307/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
 github.com/evcc-io/tesla-proxy-client v0.0.0-20260324063928-151fe10796ae h1:0ihqBMBjkekSlwD3ZYQIiYite6ZAln9ze60evOE6FkQ=
 github.com/evcc-io/tesla-proxy-client v0.0.0-20260324063928-151fe10796ae/go.mod h1:L8AR3E7/MbbvCgnrtzsT6YsgQJtN5gk/LumR1gDBeJM=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -257,7 +257,7 @@ func (c *EEBus) Dim(dim bool) error {
 		return api.ErrNotAvailable
 	}
 
-	return eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
 	})
 }
@@ -299,7 +299,7 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	return eebus.Await(func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
 	})
 }

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -23,10 +23,10 @@ const WriteTimeout = 10 * time.Second
 
 // Await runs a control write and waits for the remote device's result, returning
 // an error if the write is rejected or no result arrives within WriteTimeout.
-func Await(write func(func(model.ResultDataType)) (*model.MsgCounterType, error)) error {
+func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error)) error {
 	res := make(chan model.ResultDataType, 1)
 
-	if _, err := write(func(r model.ResultDataType) { res <- r }); err != nil {
+	if _, err := write(func(r model.ResultDataType, _ model.MsgCounterType) { res <- r }); err != nil {
 		return err
 	}
 

--- a/server/eebus/test/cs_test.go
+++ b/server/eebus/test/cs_test.go
@@ -62,7 +62,7 @@ func TestEEBus(t *testing.T) {
 	_, err = box.uclpc.WriteConsumptionLimit(srvEntity, ucapi.LoadLimit{
 		IsActive: true,
 		Value:    1,
-	}, func(result model.ResultDataType) {
+	}, func(result model.ResultDataType, _ model.MsgCounterType) {
 		t.Logf("lpc result: %v", result)
 	})
 


### PR DESCRIPTION
Updates the vendored EEBus libraries to their current upstream state.

- `ship-go`: the fork's SHIP-pairing/dial-dedup/write-teardown work (PRs #85, #86) is now fully merged into `enbility/ship-go@dev`, so the `evcc-io/ship-go` fork replace is no longer needed — dropped it and bumped straight to upstream.
- `eebus-go`: still needs a fork, since MDT (Monitoring of DHW Temperature, `enbility/eebus-go#226`) hasn't landed upstream yet. Rebased the MDT patch onto the current upstream `dev` (which meanwhile got its own OHPCF fixes independently of the stale fork commit), and adapted MDT's `AddFeatures`/`NewUseCaseBase` calls to the signatures every other usecase now uses (`AddFeatures() error`, extra `allEntityTypesValid bool` param).
- Upstream also added a `msgCounter` parameter to all write-result callbacks, but missed OHPCF's `Pause/Abort/Schedule/ResumePowerConsumptionProcess` (PR #210 left that inconsistent). Filed enbility/eebus-go#231 to fix it upstream and pulled that fix into the fork commit, so evcc's `eebus.Await` call sites use the new signature natively with no adapter workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)