### PR TITLE
EEBus OHPCF: react to consumption state events instead of polling

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -140,13 +140,25 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 
 	switch event {
+	case ohpcf.DataUpdateConsumptionState:
+		c.mu.Lock()
+		c.compressor = entity
+		c.mu.Unlock()
+
+		// react immediately to a freshly announced schedule/resume opportunity
+		// instead of waiting for the next reboost tick, which may miss it (#31549)
+		if c.lastEnabled() {
+			if err := c.apply(); err != nil {
+				c.log.DEBUG.Printf("apply: %v", err)
+			}
+		}
+
 	case ohpcf.UseCaseSupportUpdate,
 		ohpcf.DataUpdateRequestedPowerEstimate,
 		ohpcf.DataUpdateRequestedPowerMax,
 		ohpcf.DataUpdateConsumptionIsStoppable,
 		ohpcf.DataUpdateConsumptionIsPausable,
 		ohpcf.DataUpdateConsumptionStartTime,
-		ohpcf.DataUpdateConsumptionState,
 		ohpcf.DataUpdateMinimalRunDuration,
 		ohpcf.DataUpdateMinimalPauseDuration:
 		c.mu.Lock()

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	"github.com/enbility/eebus-go/usecases/cem/ohpcf"
+	spinemocks "github.com/enbility/spine-go/mocks"
 	"github.com/evcc-io/evcc/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,4 +71,17 @@ func TestOHPCFControlAction(t *testing.T) {
 	for _, tc := range tc {
 		assert.Equal(t, tc.want, ohpcfControlAction(tc.state, tc.enable), "%v enable=%v", tc.state, tc.enable)
 	}
+}
+
+// a consumption-state update always records the compressor entity; while
+// disabled it must not attempt to apply (avoids acting on a stale intent, #31549).
+func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
+	c := &EEBusOHPCF{}
+	entity := spinemocks.NewEntityRemoteInterface(t)
+
+	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
+
+	got, ok := c.connectedCompressor()
+	require.True(t, ok)
+	assert.Equal(t, entity, got)
 }


### PR DESCRIPTION
fixes #31549 (point 1)

`reboostLoop` only reschedules/resumes the optional consumption on a fixed 10-minute poll. `apply()` is idempotent and only acts on a state transition (`Available`/`Paused`), so if the compressor's opportunity window opens and closes between poll ticks, the loop silently no-ops and waits another 10 minutes - matching the reported symptom of the countdown restarting without boost ever triggering.

- `UseCaseEvent` already receives `ohpcf.DataUpdateConsumptionState` exactly when the compressor's process state changes, but previously only updated the cached entity reference
- It now also calls `apply()` immediately (when enabled), so schedule/resume reacts to the actual transition instead of hoping the next poll lands at the right moment
- `reboostLoop` remains as a fallback for opportunities the event stream might miss
- Added a test covering the guarded (disabled) path

🤖 Generated with [Claude Code](https://claude.com/claude-code)