### PR TITLE
Solis Hybrid S: clear Allow Grid Charge bit in normal mode

### DIFF
--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -152,7 +152,7 @@ render: |
               type: writeholding
               decode: uint16
         - source: const
-          value: 49 # Bits 0+4+5: Self Use Mode (1) + Battery Reserve (16) + Allow Grid Charge (32)
+          value: 17 # Bits 0+4: Self Use Mode (1) + Battery Reserve (16)
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}


### PR DESCRIPTION
fixes #31281 (partial)

`normal` and `charge` mode both write value `49` to register 43110, which sets bit 5 ("Allow Grid Charge") in both. The only difference between the two modes is the Reserve SOC target (register 43024) - `normal` mode never actually clears the grid-charge-allowed bit, leaving it ambiguous whether the inverter may still draw from the grid.

- `normal` (case 1) now writes `17` (Self Use + Battery Reserve, no grid-charge bit), matching the value `hold` (case 2) already uses
- `charge` (case 3) is unchanged - it's the only mode that should have the bit set

This addresses the live template-level bug; it doesn't cover the separate restart-persistence issue also discussed on #31281 (`batteryMode` not surviving a crash/power-loss), which needs a core-level fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)