### PR TITLE
Tinkerforge WARP: correct 1p3p/rfid capabilities per generation

### DIFF
--- a/templates/definition/charger/tinkerforge-warp-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp-ws.yaml
@@ -2,10 +2,6 @@ template: tinkerforge-warp-ws
 products:
   - { brand: TinkerForge, description: { generic: WARP3 Smart } }
   - { brand: TinkerForge, description: { generic: WARP3 Pro } }
-  - { brand: TinkerForge, description: { generic: WARP2 Smart } }
-  - { brand: TinkerForge, description: { generic: WARP2 Pro } }
-  - { brand: TinkerForge, description: { generic: WARP1 Smart } }
-  - { brand: TinkerForge, description: { generic: WARP1 Pro } }
 capabilities: ["mA", "rfid", "1p3p", "dim"]
 requirements:
   description:

--- a/templates/definition/charger/tinkerforge-warp1-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp1-ws.yaml
@@ -1,0 +1,29 @@
+template: tinkerforge-warp1-ws
+products:
+  - { brand: TinkerForge, description: { generic: WARP1 Smart } }
+  - { brand: TinkerForge, description: { generic: WARP1 Pro } }
+capabilities: ["mA", "dim"]
+requirements:
+  description:
+    de: Phasenumschaltung (1p/3p) ist beim WARP1 nicht möglich, auch nicht mit einem WARP Energy Manager, da keine CP-Trennung unterstützt wird. RFID steht nur zur Verfügung, wenn zusätzlich ein NFC Bricklet nachgerüstet wurde.
+    en: Phase switching (1p/3p) is not possible on the WARP1, not even with a WARP Energy Manager, since it does not support CP separation. RFID is only available if an NFC Bricklet has been retrofitted.
+  evcc: ["skiptest"]
+params:
+  - name: uri
+    required: true
+  - name: user
+  - name: password
+  - name: energyMeterIndex
+    advanced: true
+    default: 0
+    description:
+      generic: Energy Meter Index
+    help:
+      de: Index des in der Warp konfigurierten Meters dessen Werte genutzt werden sollen.
+      en: Index of the meter configured in the WARP charger whose values should be used.
+render: |
+  type: warp-ws
+  uri: {{ .uri }}
+  user: {{ .user }}
+  password: {{ .password }}
+  energyMeterIndex: {{ .energyMeterIndex }}

--- a/templates/definition/charger/tinkerforge-warp2-ws.yaml
+++ b/templates/definition/charger/tinkerforge-warp2-ws.yaml
@@ -1,0 +1,29 @@
+template: tinkerforge-warp2-ws
+products:
+  - { brand: TinkerForge, description: { generic: WARP2 Smart } }
+  - { brand: TinkerForge, description: { generic: WARP2 Pro } }
+capabilities: ["mA", "rfid", "dim"]
+requirements:
+  description:
+    de: Phasenumschaltung (1p/3p) ist beim WARP2 nur mit einem zusätzlichen WARP Energy Manager möglich.
+    en: Phase switching (1p/3p) is only possible on the WARP2 with an additional WARP Energy Manager.
+  evcc: ["skiptest"]
+params:
+  - name: uri
+    required: true
+  - name: user
+  - name: password
+  - name: energyMeterIndex
+    advanced: true
+    default: 0
+    description:
+      generic: Energy Meter Index
+    help:
+      de: Index des in der Warp konfigurierten Meters dessen Werte genutzt werden sollen.
+      en: Index of the meter configured in the WARP charger whose values should be used.
+render: |
+  type: warp-ws
+  uri: {{ .uri }}
+  user: {{ .user }}
+  password: {{ .password }}
+  energyMeterIndex: {{ .energyMeterIndex }}


### PR DESCRIPTION
The combined `tinkerforge-warp-ws` template listed WARP1, WARP2, and WARP3 together under one `capabilities: ["mA", "rfid", "1p3p", "dim"]`, which overstates what WARP1 and WARP2 (without an Energy Manager) actually support and has confused customers.

- WARP1 can never do 1p/3p phase switching, even with a WARP Energy Manager, since it lacks CP separation; also only has RFID if an NFC Bricklet has been retrofitted. Split into a new `tinkerforge-warp1-ws` template without `1p3p`/`rfid`, with requirements text explaining both limitations.
- WARP2 without an Energy Manager can't do phase switching either (that case is already covered separately by `tinkerforge-warp2-em-ws`). Split into a new `tinkerforge-warp2-ws` template without `1p3p`.
- `tinkerforge-warp-ws` now only covers WARP3, which has built-in phase switching; its template ID is unchanged so existing configs keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)