### PR TITLE
EEBus: fix paired device not routed to consumer (flaky TestShipPairing)

### DIFF
--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -579,8 +579,8 @@ func (c *EEBus) ServiceAutoTrusted(service eebusapi.ServiceInterface, identity s
 	defer c.mux.Unlock()
 	c.upsertPairing(identity)
 
-	// the connection event may fire before trust is established, leaving consumers
-	// registered without ski unrouted; wake them now that the device is paired
+	// connect may run before trust is established, so clientsFor skips consumers
+	// registered without ski; wake them now that the device is paired
 	if c.connected[identity.SKI] {
 		for _, client := range c.clientsFor(identity.SKI) {
 			client.Connect(true)

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -578,6 +578,14 @@ func (c *EEBus) ServiceAutoTrusted(service eebusapi.ServiceInterface, identity s
 	c.mux.Lock()
 	defer c.mux.Unlock()
 	c.upsertPairing(identity)
+
+	// the connection event may fire before trust is established, leaving consumers
+	// registered without ski unrouted; wake them now that the device is paired
+	if c.connected[identity.SKI] {
+		for _, client := range c.clientsFor(identity.SKI) {
+			client.Connect(true)
+		}
+	}
 }
 
 func (c *EEBus) ServiceAutoTrustFailed(service eebusapi.ServiceInterface, identity shipapi.ServiceIdentity, reason error) {


### PR DESCRIPTION
Fixes the intermittent `TestShipPairing` CI failures ("paired device not routed to consumer", e.g. the 0.311.1 release run), and the underlying product bug behind them.

`ServiceAutoTrusted` (adds the newly paired device to `c.paired`) and `RemoteServiceConnected` → `connect` (routes connected devices to consumers) are independent ship-go callbacks with no guaranteed order. When the connection event wins the race and fires *before* trust is established:

- `connect` sets `connected[ski]=true`, but the device isn't in `c.paired` yet, so `clientsFor` doesn't include consumers registered without ski (the SHIP-paired consumers) - they are never woken
- `ServiceAutoTrusted` then adds the device to `c.paired`, but doesn't re-route

So the device pairs and connects but stays unrouted to the consumer until an evcc restart reloads it from persistence - matching reports of SHIP pairing needing a restart to take effect. In the test this surfaces as the ~1-in-3 "paired device not routed to consumer" timeout.

Fix: once trust is established, route any already-connected consumers. This closes the race in both callback orders (the other order is already handled by `connect`/`clientsFor`).

- test is unchanged; the fix is 8 lines in the server
- validated locally: 10/10 passing runs, all fast (~6s), with the previous full-timeout failure mode gone (was ~1 in 3)

Note: this is **not** ship-go's double-connection race (enbility/ship-go#85, already fixed upstream) - it is an evcc-side event-ordering bug.

Supersedes #31558, which treated the symptom with a connect retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)