### PR TITLE
EEBus: fix GridGuard entity type removed from LPC/LPP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -262,4 +262,4 @@ replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165
 
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b
 
-replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260707085304-6939a96c368f
+replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260707170747-eb60ff7e2025

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323 h1:bLsMlyRamUg
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323/go.mod h1:ddWZU5BQGyzRGF20Z7rUKFFzbCp+cfu9mZgYtOMW/fM=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6 h1:XOYvxKtT1oxT37w/5oEiRLuPbm9FuJPt3fiYhX0h8Po=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6/go.mod h1:BszP9qFV14mPXgyIREbgIdQtWxbAj3OKqvK02HihMoM=
-github.com/evcc-io/eebus-go v0.0.0-20260707085304-6939a96c368f h1:4qTrzQ1yUs0FrTMXf9OTSIshdFi7Blq5TErrsF7Karg=
-github.com/evcc-io/eebus-go v0.0.0-20260707085304-6939a96c368f/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
+github.com/evcc-io/eebus-go v0.0.0-20260707170747-eb60ff7e2025 h1:hXZTTduvtyv4NxC6T4tBsKOniqC7f5nhvaIxQBvmyjg=
+github.com/evcc-io/eebus-go v0.0.0-20260707170747-eb60ff7e2025/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea h1:F6eyC8V8wvc3ranlsR4coAls+OPBkVvxyX0a2VqdlPc=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea/go.mod h1:swrNGAVgI1r/3d/sEKE7qgujdRR9aHVPYKyc3gvpVTc=
 github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b h1:5vFr7wOwoi5ylybUnxxBk1U3FRF2+3Sf0sKx8thxw18=

--- a/server/eebus/test/gridguard_test.go
+++ b/server/eebus/test/gridguard_test.go
@@ -1,0 +1,54 @@
+package eebus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/enbility/ship-go/cert"
+	"github.com/evcc-io/evcc/hems/eebus"
+	hems "github.com/evcc-io/evcc/hems/eebus"
+	server "github.com/evcc-io/evcc/server/eebus"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestControlBoxGridGuardHeartbeat covers issue #31561: a real ControlBox exposes LPC/LPP
+// only on a GridGuard entity; if eebus-go's cs/lpc validEntityTypes ever drops it again, the heartbeat subscription silently never happens and the LPC failsafe eventually trips.
+func TestControlBoxGridGuardHeartbeat(t *testing.T) {
+	util.LogLevel("error", map[string]string{"eebus": "trace"})
+
+	// tear down a server instance left over from other tests in this package
+	if inst, err := server.Instance(); err == nil {
+		inst.Shutdown()
+	}
+
+	certificate, err := cert.CreateCertificate("Demo", "Demo", "DE", "Demo-GridGuard-01")
+	require.NoError(t, err, "certificate")
+
+	public, private, err := server.GetX509KeyPair(certificate)
+	require.NoError(t, err, "decode certificate")
+
+	_, err = server.NewServer(server.Config{
+		Port: freePort(t),
+		Certificate: server.Certificate{
+			Public:  public,
+			Private: private,
+		},
+	})
+	require.NoError(t, err, "server")
+
+	inst, err := server.Instance()
+	require.NoError(t, err, "instance")
+
+	// the controlbox test double, like a real ControlBox, only exposes GridGuard
+	box, err := createControlbox(t.Context(), inst.Ski(), freePort(t))
+	require.NoError(t, err, "controlbox")
+
+	// no hems.Run(): the run loop applies limits via the nil site and is not needed here
+	_, err = hems.NewEEBus(t.Context(), box.ski, eebus.Limits{}, nil, nil, time.Second)
+	require.NoError(t, err, "hems")
+
+	require.Eventually(t, inst.ControllableSystem().CsLPCInterface.IsHeartbeatWithinDuration,
+		10*time.Second, 100*time.Millisecond,
+		"CsLPC never subscribed to the ControlBox's GridGuard heartbeat")
+}


### PR DESCRIPTION
fixes #31561

Bumps the `enbility/eebus-go` replace to a new `evcc-io/eebus-go` branch (`rollup-gridguard`) that adds enbility/eebus-go#235 on top of the current pin. That upstream PR restores `EntityTypeTypeGridGuard` to the `CsLPC`/`CsLPP` valid entity types, which enbility/eebus-go#224 (pulled in via #31550) had accidentally dropped. Without it, a ControlBox's GridGuard entity was silently discarded, CsLPC never bound to it, HEMS never received a heartbeat, and the LPC failsafe tripped deterministically about two minutes after boot.

- `go.mod`/`go.sum`: `enbility/eebus-go` replace now points at `evcc-io/eebus-go@rollup-gridguard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)