### PR TITLE
open-meteo: use icon_seamless model

### DIFF
--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -62,7 +62,7 @@ render: |
   tariff: solar
   forecast:
     source: http
-    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=5&timezone=GMT&timeformat=unixtime
+    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&models=icon_seamless&forecast_days=5&timezone=GMT&timeformat=unixtime
     jq: |
       def alphatemp: {{ .alphatemp }}; # temperature coefficient
       def rossmodel: {{ .rossmodel }}; # cooling type

--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -57,12 +57,24 @@ params:
   - name: interval
     default: 1h
     advanced: true
+  - name: model
+    description:
+      en: Weather model
+      de: Wettermodell
+    help:
+      en: See [Open-Meteo API docs](https://open-meteo.com/en/docs/dwd-api)
+      de: Siehe [Open-Meteo API docs](https://open-meteo.com/en/docs/dwd-api)
+    type: choice
+    choice: ["best_match", "icon_seamless"]
+    default: best_match
+    required: true
+    advanced: true
 render: |
   type: custom
   tariff: solar
   forecast:
     source: http
-    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&models=icon_seamless&forecast_days=5&timezone=GMT&timeformat=unixtime
+    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=5&timezone=GMT&timeformat=unixtime{{ if ne .model "best_match" }}&models={{ .model }}{{ end }}
     jq: |
       def alphatemp: {{ .alphatemp }}; # temperature coefficient
       def rossmodel: {{ .rossmodel }}; # cooling type


### PR DESCRIPTION
Explicitly requests the `icon_seamless` model instead of the default `best_match`.

`best_match` is an opaque, non-deterministic blend of models. `icon_seamless` deterministically nests ICON-D2 (2 km) → ICON-EU → ICON-Global, giving the highest available resolution in the near term while keeping the full forecast horizon.

See [Open-Meteo API docs](https://open-meteo.com/en/docs/dwd-api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)