### PR TITLE
Energy Flow UI: Chrome (Skia Graphite) rendering bug workaround

### DIFF
--- a/assets/js/components/Energyflow/LabelBar.vue
+++ b/assets/js/components/Energyflow/LabelBar.vue
@@ -42,6 +42,8 @@ export default defineComponent({
 	padding: 10px 0;
 	opacity: 1;
 	overflow: hidden;
+	/* forces own compositor layer, works around a Chrome Skia Graphite paint-invalidation bug (#31341) */
+	will-change: transform;
 }
 .label-bar-scale--hidden {
 	opacity: 0;


### PR DESCRIPTION
fixes #31341

Chrome's Skia Graphite / Dawn D3D11 GPU backend fails to repaint `.label-bar` after its `flex-basis`-driven layout change on initial mount, so the top/bottom label bar stays invisible until the window is resized and forces a reflow.

- Promote `.label-bar` to its own compositor layer via `will-change: transform` to work around the paint-invalidation bug