### PR TITLE
Site: consumer meter config key singular (BC)

### DIFF
--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -94,6 +94,7 @@ export interface State {
   pv?: Meter[];
   aux?: Meter[];
   ext?: Meter[];
+  consumers?: Meter[];
   tariffs?: ConfigStatus<unknown, unknown>;
   tariffGrid?: number;
   tariffFeedIn?: number;
@@ -755,7 +756,7 @@ export interface SiteConfig {
   title: string;
   aux: string[] | null;
   ext: string[] | null;
-  consumers: string[] | null;
+  consumer: string[] | null;
 }
 
 export type ValueOf<T> = T[keyof T];

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -679,7 +679,7 @@ export default defineComponent({
 				title: "",
 				aux: null as string[] | null,
 				ext: null as string[] | null,
-				consumers: null as string[] | null,
+				consumer: null as string[] | null,
 			} as SiteConfig,
 			deviceValueTimeout: null as Timeout,
 			deviceValues: {
@@ -737,7 +737,7 @@ export default defineComponent({
 			return this.getMetersByNames(names);
 		},
 		consumerMeters() {
-			return this.getMetersByNames(this.site?.consumers);
+			return this.getMetersByNames(this.site?.consumer);
 		},
 		gridTariff() {
 			const name = this.tariffRefs?.grid;
@@ -1111,20 +1111,20 @@ export default defineComponent({
 						this.saveSite(type);
 						break;
 					case "consumer":
-						if (!this.site.consumers) this.site.consumers = [];
-						this.site.consumers.push(name);
-						this.saveSite("consumers");
+						if (!this.site.consumer) this.site.consumer = [];
+						this.site.consumer.push(name);
+						this.saveSite("consumer");
 						break;
 				}
 			}
 
-			// Converted: move ext meter to consumers (history is reconciled on restart)
+			// Converted: move ext meter to consumer (history is reconciled on restart)
 			if (result.action === "converted") {
 				const name = this.meters.find((m) => m.id === result.id)?.name;
 				if (name) {
 					const ext = (this.site.ext || []).filter((n) => n !== name);
-					const consumers = [...(this.site.consumers || []), name];
-					await api.put("/config/site", { ext, consumers });
+					const consumer = [...(this.site.consumer || []), name];
+					await api.put("/config/site", { ext, consumer });
 					await this.loadSite();
 				}
 			}

--- a/core/site.go
+++ b/core/site.go
@@ -105,12 +105,12 @@ type Site struct {
 
 // MetersConfig contains the site's meter configuration
 type MetersConfig struct {
-	GridMeterRef      string   `mapstructure:"grid"`      // Grid usage meter
-	PVMetersRef       []string `mapstructure:"pv"`        // PV meter
-	BatteryMetersRef  []string `mapstructure:"battery"`   // Battery charging meter
-	ExtMetersRef      []string `mapstructure:"ext"`       // Meters used only for monitoring
-	AuxMetersRef      []string `mapstructure:"aux"`       // Auxiliary meters
-	ConsumerMetersRef []string `mapstructure:"consumers"` // Consumer meters
+	GridMeterRef      string   `mapstructure:"grid"`     // Grid usage meter
+	PVMetersRef       []string `mapstructure:"pv"`       // PV meter
+	BatteryMetersRef  []string `mapstructure:"battery"`  // Battery charging meter
+	ExtMetersRef      []string `mapstructure:"ext"`      // Meters used only for monitoring
+	AuxMetersRef      []string `mapstructure:"aux"`      // Auxiliary meters
+	ConsumerMetersRef []string `mapstructure:"consumer"` // Consumer meters
 }
 
 // NewSiteFromConfig creates a new site

--- a/server/http_config_site_handler.go
+++ b/server/http_config_site_handler.go
@@ -11,21 +11,21 @@ import (
 func siteHandler(site site.API) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		res := struct {
-			Title     string   `json:"title"`
-			Grid      string   `json:"grid"`
-			PV        []string `json:"pv"`
-			Battery   []string `json:"battery"`
-			Aux       []string `json:"aux"`
-			Ext       []string `json:"ext"`
-			Consumers []string `json:"consumers"`
+			Title    string   `json:"title"`
+			Grid     string   `json:"grid"`
+			PV       []string `json:"pv"`
+			Battery  []string `json:"battery"`
+			Aux      []string `json:"aux"`
+			Ext      []string `json:"ext"`
+			Consumer []string `json:"consumer"`
 		}{
-			Title:     site.GetTitle(),
-			Grid:      site.GetGridMeterRef(),
-			PV:        site.GetPVMeterRefs(),
-			Battery:   site.GetBatteryMeterRefs(),
-			Aux:       site.GetAuxMeterRefs(),
-			Ext:       site.GetExtMeterRefs(),
-			Consumers: site.GetConsumerMeterRefs(),
+			Title:    site.GetTitle(),
+			Grid:     site.GetGridMeterRef(),
+			PV:       site.GetPVMeterRefs(),
+			Battery:  site.GetBatteryMeterRefs(),
+			Aux:      site.GetAuxMeterRefs(),
+			Ext:      site.GetExtMeterRefs(),
+			Consumer: site.GetConsumerMeterRefs(),
 		}
 
 		jsonWrite(w, res)
@@ -46,13 +46,13 @@ func validateRefs(w http.ResponseWriter, refs []string) bool {
 func updateSiteHandler(site site.API) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var payload struct {
-			Title     *string
-			Grid      *string
-			PV        *[]string
-			Battery   *[]string
-			Aux       *[]string
-			Ext       *[]string
-			Consumers *[]string
+			Title    *string
+			Grid     *string
+			PV       *[]string
+			Battery  *[]string
+			Aux      *[]string
+			Ext      *[]string
+			Consumer *[]string
 		}
 
 		if err := jsonDecoder(r.Body).Decode(&payload); err != nil {
@@ -109,12 +109,12 @@ func updateSiteHandler(site site.API) http.HandlerFunc {
 			setConfigDirty()
 		}
 
-		if payload.Consumers != nil {
-			if !validateRefs(w, *payload.Consumers) {
+		if payload.Consumer != nil {
+			if !validateRefs(w, *payload.Consumer) {
 				return
 			}
 
-			site.SetConsumerMeterRefs(*payload.Consumers)
+			site.SetConsumerMeterRefs(*payload.Consumer)
 			setConfigDirty()
 		}
 

--- a/tests/energyflow-consumers.evcc.yaml
+++ b/tests/energyflow-consumers.evcc.yaml
@@ -2,7 +2,7 @@ site:
   title: Hello World
   meters:
     grid: grid
-    consumers:
+    consumer:
       - fridge
     aux:
       - heater


### PR DESCRIPTION
fixes #31513
supersedes evcc-io/docs#1108

`site.meters` keys (`grid`, `pv`, `battery`, `aux`, `ext`) are all singular even where the value is a list. `consumers` was the only plural exception, which is also what made the key ambiguous enough to end up wrongly documented as `consumer` in the first place. This aligns it with its siblings and only changes the config key, not the runtime behavior.

- `site.meters.consumer` replaces `site.meters.consumers` in YAML config and the `/api/config/site` payload
- Publishing keeps `consumers` (plural), matching `loadpoints`/`vehicles`
- Settings/DB persistence key (`consumerMeters`) and internal Go identifiers unchanged

**Breaking change**

Anyone with `site.meters.consumers:` in `evcc.yaml` must rename it to `site.meters.consumer:`, otherwise those meters silently stop being recognized as consumers.

```yaml
site:
  meters:
    consumer: # was: consumers
      - myconsumer1
```