### PR TITLE
IBC HomeOne: fix battery SoC scale and grid meter word order

### DIFF
--- a/templates/definition/meter/ibc-homeone.yaml
+++ b/templates/definition/meter/ibc-homeone.yaml
@@ -78,9 +78,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      # 31622 battery SOC (U16, whole %); vendor doc lists scale 0.01 but the device
-      # reports plain percent on the wire, confirmed against a real charge session (#31584)
-      address: 1621
+      address: 1621 # 31622 battery SOC (U16, %)
       type: input
       decode: uint16
   {{- include "battery-params" . }}

--- a/templates/definition/meter/ibc-homeone.yaml
+++ b/templates/definition/meter/ibc-homeone.yaml
@@ -32,22 +32,19 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        # 360039 external meter L1 power (S32, W, positive = import); word order is
-        # swapped on the wire vs. the vendor doc, confirmed against a reported
-        # misread of -14417.9kW for an actual -221W (#31584)
-        address: 60038
+        address: 60038 # 360039 external meter L1 power (S32, W, positive = import)
         type: input
         decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 60040 # 360041 external meter L2 power (S32, W), word order swapped
+        address: 60040 # 360041 external meter L2 power (S32, W)
         type: input
         decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 60042 # 360043 external meter L3 power (S32, W), word order swapped
+        address: 60042 # 360043 external meter L3 power (S32, W)
         type: input
         decode: int32s
   {{- end }}

--- a/templates/definition/meter/ibc-homeone.yaml
+++ b/templates/definition/meter/ibc-homeone.yaml
@@ -78,9 +78,10 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 1621 # 31622 battery SOC (U16, 0.01 %)
+      # 31622 battery SOC (U16, whole %); vendor doc lists scale 0.01 but the device
+      # reports plain percent on the wire, confirmed against a real charge session (#31584)
+      address: 1621
       type: input
       decode: uint16
-    scale: 0.01
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/ibc-homeone.yaml
+++ b/templates/definition/meter/ibc-homeone.yaml
@@ -32,21 +32,24 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 60038 # 360039 external meter L1 power (S32, W, positive = import)
+        # 360039 external meter L1 power (S32, W, positive = import); word order is
+        # swapped on the wire vs. the vendor doc, confirmed against a reported
+        # misread of -14417.9kW for an actual -221W (#31584)
+        address: 60038
         type: input
-        decode: int32
+        decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 60040 # 360041 external meter L2 power (S32, W)
+        address: 60040 # 360041 external meter L2 power (S32, W), word order swapped
         type: input
-        decode: int32
+        decode: int32s
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 60042 # 360043 external meter L3 power (S32, W)
+        address: 60042 # 360043 external meter L3 power (S32, W), word order swapped
         type: input
-        decode: int32
+        decode: int32s
   {{- end }}
   {{- if eq .usage "pv" }}
   power:


### PR DESCRIPTION
fixes #31584

Two independent register-decode bugs in the IBC Solar HomeOne template:

- **Battery SoC** (register 31622): the vendor Modbus doc lists a 0.01 scale, but a real device trace attached to the issue shows the register already reports whole percent on the wire. Applying the documented scale collapsed any real SoC (e.g. 39-46%) down to under 1%, always displaying as 0%, and made the derived "available energy" widget show 0 kWh regardless of actual charge level. Confirmed against the trace: raw SoC rose by 7 over 33 minutes while charging at ~1.4kW into a 10kWh pack, matching the ~7 percentage-point gain expected if unscaled.
- **Grid meter phase power** (registers 360039/41/43): a follow-up commenter reported "-14,417.9 kW" instead of an actual ~-220W. The two 16-bit words of these S32 registers arrive in swapped order on the wire; decoding as `int32` (word order per the vendor doc) instead of `int32s` misreads the value. An actual reading of exactly -221W, decoded with the wrong word order, reproduces the reported -14417.9kW exactly - not just approximately, confirming the word-swap as the cause without needing a raw trace from that reporter.

Both `battery power` (31619) and `pv` registers were cross-checked against the vendor PDF and don't show this word-order issue.