### PR TITLE
Metrics: export evcc state on /metrics

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,8 @@ import (
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/evcc-io/evcc/util/telemetry"
 	_ "github.com/joho/godotenv/autoload"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
@@ -46,13 +48,14 @@ const (
 )
 
 var (
-	log           = util.NewLogger("main")
-	cfgFile       string
-	cfgDatabase   string
-	customCssFile string
-	ignoreEmpty   = ""                                      // ignore empty keys
-	ignoreLogs    = []string{"log"}                         // ignore log messages, including warn/error
-	ignoreMqtt    = []string{"log", "auth", "releaseNotes"} // excessive size may crash certain brokers
+	log              = util.NewLogger("main")
+	cfgFile          string
+	cfgDatabase      string
+	customCssFile    string
+	ignoreEmpty      = ""                                                  // ignore empty keys
+	ignoreLogs       = []string{"log"}                                     // ignore log messages, including warn/error
+	ignoreMqtt       = []string{"log", "auth", "releaseNotes"}             // excessive size may crash certain brokers
+	ignorePrometheus = []string{"log", "auth", "releaseNotes", "forecast"} // avoid excessive metric/label cardinality
 
 	viper *vpr.Viper
 
@@ -267,8 +270,14 @@ func runRoot(cmd *cobra.Command, args []string) {
 	valueChan <- util.Param{Key: keys.ApiReady, Val: false}
 
 	// metrics
+	var promMetrics *server.Prometheus
 	if viper.GetBool("metrics") {
-		httpd.Router().Handle("/metrics", promhttp.Handler())
+		promRegistry := prometheus.NewRegistry()
+		promRegistry.MustRegister(collectors.NewGoCollector(), collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+
+		promMetrics = server.NewPrometheus(promRegistry)
+
+		httpd.Router().Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}))
 	}
 
 	// pprof
@@ -339,6 +348,11 @@ func runRoot(cmd *cobra.Command, args []string) {
 		if err == nil {
 			go mqtt.Run(site, pipe.NewDropper(append(ignoreMqtt, ignoreEmpty)...).Pipe(tee.Attach()))
 		}
+	}
+
+	// feed prometheus exporter with site state
+	if err == nil && promMetrics != nil {
+		go promMetrics.Run(site, pipe.NewDropper(append(ignorePrometheus, ignoreEmpty)...).Pipe(tee.Attach()))
 	}
 
 	// announce on mDNS

--- a/server/prometheus.go
+++ b/server/prometheus.go
@@ -1,0 +1,289 @@
+package server
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/site"
+	"github.com/evcc-io/evcc/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+)
+
+const prometheusPrefix = "evcc_"
+
+// invalidPrometheusChars matches runs of characters that are not valid in a
+// Prometheus metric name. Underscores are matched too so that separators from
+// snake_case conversion and nested-key flattening collapse into a single
+// underscore (e.g. "grid__power" -> "grid_power").
+var invalidPrometheusChars = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// promSample is the last known value for a single metric+label combination
+type promSample struct {
+	value  float64
+	labels prometheus.Labels
+}
+
+// Prometheus is a Prometheus exporter. It mirrors the internal evcc state
+// (the same values published via MQTT/InfluxDB) as an in-memory metric
+// snapshot that is served to Prometheus on scrape via /metrics.
+type Prometheus struct {
+	log *util.Logger
+
+	mu sync.Mutex
+	// samples maps metric name -> label signature -> sample
+	samples map[string]map[string]promSample
+}
+
+// NewPrometheus creates a Prometheus exporter and registers it with reg
+func NewPrometheus(reg prometheus.Registerer) *Prometheus {
+	p := &Prometheus{
+		log:     util.NewLogger("prometheus"),
+		samples: make(map[string]map[string]promSample),
+	}
+
+	reg.MustRegister(p)
+
+	return p
+}
+
+// metricName converts an evcc key such as "loadpoint_chargePower" into a
+// valid, idiomatic Prometheus metric name such as "evcc_loadpoint_charge_power"
+func metricName(key string) string {
+	var b strings.Builder
+	b.WriteString(prometheusPrefix)
+
+	for i, r := range key {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r - 'A' + 'a')
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	return invalidPrometheusChars.ReplaceAllString(b.String(), "_")
+}
+
+// labelSignature returns a stable string representation of a label set,
+// used as a map key to identify a unique metric+label combination
+func labelSignature(labels prometheus.Labels) string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(labels[k])
+		b.WriteByte(';')
+	}
+
+	return b.String()
+}
+
+// set stores/overwrites the current value for a metric+label combination
+func (p *Prometheus) set(name string, value float64, labels prometheus.Labels) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.samples[name] == nil {
+		p.samples[name] = make(map[string]promSample)
+	}
+
+	p.samples[name][labelSignature(labels)] = promSample{value: value, labels: labels}
+}
+
+// record flattens an arbitrary evcc value (as also produced for MQTT/InfluxDB)
+// into one or more numeric Prometheus samples. Strings are not exported as
+// metrics- their value has no useful numeric representation.
+func (p *Prometheus) record(key string, val any, labels prometheus.Labels) {
+	if val == nil || lo.IsNil(val) {
+		return
+	}
+
+	switch v := val.(type) {
+	case string:
+		return
+
+	case bool:
+		p.set(metricName(key), boolToFloat(v), labels)
+		return
+
+	case int:
+		p.set(metricName(key), float64(v), labels)
+		return
+
+	case int64:
+		p.set(metricName(key), float64(v), labels)
+		return
+
+	case float64:
+		p.set(metricName(key), v, labels)
+		return
+
+	case time.Time:
+		if !v.IsZero() {
+			p.set(metricName(key), float64(v.Unix()), labels)
+		}
+		return
+
+	case time.Duration:
+		p.set(metricName(key), v.Seconds(), labels)
+		return
+
+	case []float64:
+		p.recordPhases(key, v, labels)
+		return
+
+	case [3]float64:
+		p.recordPhases(key, v[:], labels)
+		return
+	}
+
+	if mm, ok := val.(api.StructMarshaler); ok {
+		if d, err := mm.MarshalStruct(); err == nil {
+			p.record(key, d, labels)
+		} else {
+			p.log.ERROR.Printf("marshal struct: %v", err)
+		}
+		return
+	}
+
+	// BytesMarshaler (raw/binary payloads) has no numeric representation
+	if _, ok := val.(api.BytesMarshaler); ok {
+		return
+	}
+
+	rv := reflect.ValueOf(val)
+
+	switch rv.Kind() {
+	case reflect.Pointer:
+		if !rv.IsNil() {
+			p.record(key, rv.Elem().Interface(), labels)
+		}
+
+	case reflect.Struct:
+		typ := rv.Type()
+		for i := range typ.NumField() {
+			if f := typ.Field(i); f.IsExported() {
+				p.record(key+"_"+f.Name, rv.Field(i).Interface(), labels)
+			}
+		}
+
+	case reflect.Slice, reflect.Array:
+		for i := range rv.Len() {
+			l := maps.Clone(labels)
+			l["id"] = strconv.Itoa(i + 1)
+			p.record(key, rv.Index(i).Interface(), l)
+		}
+
+	case reflect.Map:
+		for _, k := range rv.MapKeys() {
+			p.record(fmt.Sprintf("%s_%v", key, k.Interface()), rv.MapIndex(k).Interface(), labels)
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.set(metricName(key), float64(rv.Int()), labels)
+
+	case reflect.Float32, reflect.Float64:
+		p.set(metricName(key), rv.Float(), labels)
+
+	case reflect.Bool:
+		p.set(metricName(key), boolToFloat(rv.Bool()), labels)
+	}
+}
+
+// recordPhases records a 3-phase value both per-phase (with a "phase" label)
+// and as an aggregated sum, matching the MQTT/InfluxDB phase handling
+func (p *Prometheus) recordPhases(key string, phases []float64, labels prometheus.Labels) {
+	if len(phases) != 3 {
+		return
+	}
+
+	var total float64
+	for i, v := range phases {
+		total += v
+
+		l := maps.Clone(labels)
+		l["phase"] = strconv.Itoa(i + 1)
+		p.set(metricName(key), v, l)
+	}
+
+	p.set(metricName(key), total, labels)
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// Run starts the Prometheus exporter, consuming site state updates from in
+// and mirroring them into the in-memory metric snapshot
+func (p *Prometheus) Run(site site.API, in <-chan util.Param) {
+	for param := range in {
+		labels := prometheus.Labels{}
+
+		key := param.Key
+		if param.Loadpoint != nil {
+			if lps := site.Loadpoints(); *param.Loadpoint < len(lps) {
+				lp := lps[*param.Loadpoint]
+				labels["loadpoint"] = lp.GetTitle()
+				if v := lp.GetVehicle(); v != nil {
+					labels["vehicle"] = v.GetTitle()
+				}
+			}
+			key = "loadpoint_" + param.Key
+		}
+
+		p.record(key, param.Val, labels)
+	}
+}
+
+// Describe implements prometheus.Collector. Metrics are dynamic and
+// depend on the configured devices, so no fixed descriptors are provided
+// upfront- this registers Prometheus as an "unchecked" collector.
+func (p *Prometheus) Describe(chan<- *prometheus.Desc) {}
+
+// Collect implements prometheus.Collector
+func (p *Prometheus) Collect(ch chan<- prometheus.Metric) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for name, samples := range p.samples {
+		for _, s := range samples {
+			labelNames := make([]string, 0, len(s.labels))
+			labelValues := make([]string, 0, len(s.labels))
+			for k, v := range s.labels {
+				labelNames = append(labelNames, k)
+				labelValues = append(labelValues, v)
+			}
+
+			desc := prometheus.NewDesc(name, "evcc: "+name, labelNames, nil)
+
+			m, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, s.value, labelValues...)
+			if err != nil {
+				p.log.ERROR.Printf("collect %s: %v", name, err)
+				continue
+			}
+
+			ch <- m
+		}
+	}
+}

--- a/server/prometheus_test.go
+++ b/server/prometheus_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+)
+
+// TestPrometheus exercises the exporter end-to-end through a real registry
+// Gather() and text encoding, covering scalar, bool, string (ignored) and
+// 3-phase values. It also confirms that mixed label dimensions under the same
+// metric name (per-phase values plus the aggregated sum) are exported without
+// tripping the client_golang consistency checks.
+func TestPrometheus(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	p := NewPrometheus(reg)
+
+	// scalar
+	p.record("gridPower", 1543, prometheus.Labels{})
+
+	// 3-phase value -> per-phase (phase label) + aggregated sum (no phase label),
+	// both under the SAME metric name evcc_loadpoint_charge_power
+	p.record("loadpoint_chargePower", [3]float64{2453.3, 2000, 1900}, prometheus.Labels{"loadpoint": "Garage"})
+
+	// bool + string(ignored)
+	p.record("loadpoint_charging", true, prometheus.Labels{"loadpoint": "Garage"})
+	p.record("loadpoint_mode", "pv", prometheus.Labels{"loadpoint": "Garage"})
+
+	// nested struct field -> flattened key "battery_Soc"; separators must
+	// collapse into a single underscore (evcc_battery_soc, not evcc_battery__soc)
+	p.record("battery", struct{ Soc float64 }{Soc: 92}, prometheus.Labels{})
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() returned error (consistency check failed): %v", err)
+	}
+
+	var b strings.Builder
+	enc := expfmt.NewEncoder(&b, expfmt.NewFormat(expfmt.TypeTextPlain))
+	for _, mf := range mfs {
+		if err := enc.Encode(mf); err != nil {
+			t.Fatalf("encode %s: %v", mf.GetName(), err)
+		}
+	}
+	out := b.String()
+
+	// strings must not be exported
+	if strings.Contains(out, "evcc_loadpoint_mode") {
+		t.Error("string value was exported but should be skipped")
+	}
+
+	for _, want := range []string{
+		`evcc_grid_power 1543`,
+		`evcc_battery_soc 92`,
+		`evcc_loadpoint_charging{loadpoint="Garage"} 1`,
+		`evcc_loadpoint_charge_power{loadpoint="Garage",phase="1"} 2453.3`,
+		`evcc_loadpoint_charge_power{loadpoint="Garage",phase="2"} 2000`,
+		`evcc_loadpoint_charge_power{loadpoint="Garage",phase="3"} 1900`,
+		`evcc_loadpoint_charge_power{loadpoint="Garage"} 6353.3`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing expected metric line:\n  %s\n--- full output ---\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
The "--metrics" endpoint so far only exposed Go runtime metrics. This adds
evcc metrics (grid/pv/battery power, SoC, loadpoint values, ...) to
the same endpoint.

Addressing the earlier concerns in #467:
- reuses the existing "--metrics" flag, no new config
- everything is a gauge (unchecked collector), so no per-metric type maintenance
- off by default

Example: ( full example: [metrics.txt](https://github.com/user-attachments/files/29812648/metrics.txt) )
    evcc_grid_power -705
    evcc_pv_power 1341
    evcc_battery_soc 100
    evcc_loadpoint_charge_power{loadpoint="Garage"} 0
    evcc_grid_currents{phase="1"} 2.3

All values are gauges, including monotonic ones like "charged_energy" — a

Tested against a real setup (AlphaESS inverter + battery, Juice ChargeMe
charger), a second run on a different setup would be welcome.