### PR TITLE
SunSpec: make curtail (model 123/704) optional (BC)

### DIFF
--- a/templates/definition/meter/sunspec-hybrid-curtailable.yaml
+++ b/templates/definition/meter/sunspec-hybrid-curtailable.yaml
@@ -1,0 +1,86 @@
+template: sunspec-hybrid-curtailable
+products:
+  - description:
+      de: SunSpec Hybridwechselrichter (abregelbar)
+      en: SunSpec Hybrid Inverter (curtailable)
+group: generic
+capabilities: ["curtail"]
+params:
+  - name: usage
+    choice: ["pv"]
+  - name: modbus
+    choice: ["tcpip", "rs485"]
+  - name: maxacpower
+render: |
+  type: custom
+  # sunspec model 203 (int+sf)/ 213 (float) meter
+  power:
+    source: calc
+    add:
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value: 160:1:DCW # mppt 1
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value: 160:2:DCW # mppt 2
+  energy:
+    source: calc
+    add:
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value: 160:1:DCWH # mppt 1
+        scale: 0.001
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value: 160:2:DCWH # mppt 2
+        scale: 0.001
+  curtail:
+    source: sequence
+    set:
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
+      - source: switch
+        switch:
+          - case: 100 # Uncurtailed
+            set:
+              source: const
+              value: 0 # Limit disabled
+              set:
+                source: sunspec
+                {{- include "modbus" . | indent 14 }}
+                value:
+                  - 704:WMaxLimPctEna
+                  - 123:WMaxLim_Ena
+        default:
+          source: const
+          value: 1 # Limit enabled
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value:
+              - 704:WMaxLimPctEna
+              - 123:WMaxLim_Ena
+  curtailed: # curtailed only while the limit is enabled and below nominal (< 100 %)
+    source: go
+    in:
+    - name: ena
+      type: bool
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPctEna
+          - 123:WMaxLim_Ena
+    - name: limit
+      type: float
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
+    script: ena && limit < 100
+  maxacpower: {{ .maxacpower }} # W

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -5,6 +5,7 @@ products:
       de: SunSpec Hybridwechselrichter
       en: SunSpec Hybrid Inverter
 group: generic
+capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -17,6 +17,7 @@ params:
       en: Curtailable
     type: bool
     advanced: true
+    default: true
     usages: ["pv"]
   - preset: battery-params
 render: |
@@ -113,7 +114,7 @@ render: |
         {{- include "modbus" . | indent 6 }}
         value: 160:2:DCWH # mppt 2
         scale: 0.001
-  {{- if .curtailable }}
+  {{- if eq .curtailable "true" }}
   curtail:
     source: sequence
     set:

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -5,21 +5,12 @@ products:
       de: SunSpec Hybridwechselrichter
       en: SunSpec Hybrid Inverter
 group: generic
-capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["tcpip", "rs485"]
   - name: maxacpower
-  - name: curtailable
-    description:
-      de: Abregelbar
-      en: Curtailable
-    type: bool
-    advanced: true
-    default: true
-    usages: ["pv"]
   - preset: battery-params
 render: |
   type: custom
@@ -115,57 +106,6 @@ render: |
         {{- include "modbus" . | indent 6 }}
         value: 160:2:DCWH # mppt 2
         scale: 0.001
-  {{- if eq .curtailable "true" }}
-  curtail:
-    source: sequence
-    set:
-      - source: sunspec
-        {{- include "modbus" . | indent 6 }}
-        value:
-          - 704:WMaxLimPct
-          - 123:WMaxLimPct
-      - source: switch
-        switch:
-          - case: 100 # Uncurtailed
-            set:
-              source: const
-              value: 0 # Limit disabled
-              set:
-                source: sunspec
-                {{- include "modbus" . | indent 14 }}
-                value:
-                  - 704:WMaxLimPctEna
-                  - 123:WMaxLim_Ena
-        default:
-          source: const
-          value: 1 # Limit enabled
-          set:
-            source: sunspec
-            {{- include "modbus" . | indent 10 }}
-            value:
-              - 704:WMaxLimPctEna
-              - 123:WMaxLim_Ena
-  curtailed: # curtailed only while the limit is enabled and below nominal (< 100 %)
-    source: go
-    in:
-    - name: ena
-      type: bool
-      config:
-        source: sunspec
-        {{- include "modbus" . | indent 6 }}
-        value:
-          - 704:WMaxLimPctEna
-          - 123:WMaxLim_Ena
-    - name: limit
-      type: float
-      config:
-        source: sunspec
-        {{- include "modbus" . | indent 6 }}
-        value:
-          - 704:WMaxLimPct
-          - 123:WMaxLimPct
-    script: ena && limit < 100
-  {{- end }}
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -5,13 +5,19 @@ products:
       de: SunSpec Hybridwechselrichter
       en: SunSpec Hybrid Inverter
 group: generic
-capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["tcpip", "rs485"]
   - name: maxacpower
+  - name: curtailable
+    description:
+      de: Abregelbar
+      en: Curtailable
+    type: bool
+    advanced: true
+    usages: ["pv"]
   - preset: battery-params
 render: |
   type: custom
@@ -107,6 +113,7 @@ render: |
         {{- include "modbus" . | indent 6 }}
         value: 160:2:DCWH # mppt 2
         scale: 0.001
+  {{- if .curtailable }}
   curtail:
     source: sequence
     set:
@@ -142,6 +149,7 @@ render: |
     value:
       - 704:WMaxLimPctEna
       - 123:WMaxLim_Ena
+  {{- end }}
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/sunspec-inverter-curtailable.yaml
+++ b/templates/definition/meter/sunspec-inverter-curtailable.yaml
@@ -1,0 +1,84 @@
+template: sunspec-inverter-curtailable
+products:
+  - description:
+      de: SunSpec Wechselrichter (abregelbar)
+      en: SunSpec Inverter (curtailable)
+group: generic
+capabilities: ["curtail"]
+params:
+  - name: usage
+    choice: ["pv"]
+  - name: modbus
+    choice: ["tcpip", "rs485"]
+render: |
+  type: custom
+  power:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value:
+      - 101:W
+      - 111:W
+      - 102:W
+      - 112:W
+      - 103:W
+      - 113:W
+  energy:
+    source: sunspec
+    {{- include "modbus" . | indent 2 }}
+    value:
+      - 101:WH
+      - 111:WH
+      - 102:WH
+      - 112:WH
+      - 103:WH
+      - 113:WH
+    scale: 0.001
+  curtail:
+    source: sequence
+    set:
+      - source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
+      - source: switch
+        switch:
+          - case: 100 # Uncurtailed
+            set:
+              source: const
+              value: 0 # Limit disabled
+              set:
+                source: sunspec
+                {{- include "modbus" . | indent 14 }}
+                value:
+                  - 704:WMaxLimPctEna
+                  - 123:WMaxLim_Ena
+        default:
+          source: const
+          value: 1 # Limit enabled
+          set:
+            source: sunspec
+            {{- include "modbus" . | indent 10 }}
+            value:
+              - 704:WMaxLimPctEna
+              - 123:WMaxLim_Ena
+  curtailed: # curtailed only while the limit is enabled and below nominal (< 100 %)
+    source: go
+    in:
+    - name: ena
+      type: bool
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPctEna
+          - 123:WMaxLim_Ena
+    - name: limit
+      type: float
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
+    script: ena && limit < 100

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -4,20 +4,11 @@ products:
       de: SunSpec Wechselrichter
       en: SunSpec Inverter
 group: generic
-capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["tcpip", "rs485"]
-  - name: curtailable
-    description:
-      de: Abregelbar
-      en: Curtailable
-    type: bool
-    advanced: true
-    default: true
-    usages: ["pv"]
   - preset: battery-params
 render: |
   type: custom
@@ -162,57 +153,6 @@ render: |
       - 103:WH
       - 113:WH
     scale: 0.001
-  {{- if eq .curtailable "true" }}
-  curtail:
-    source: sequence
-    set:
-      - source: sunspec
-        {{- include "modbus" . | indent 6 }}
-        value:
-          - 704:WMaxLimPct
-          - 123:WMaxLimPct
-      - source: switch
-        switch:
-          - case: 100 # Uncurtailed
-            set:
-              source: const
-              value: 0 # Limit disabled
-              set:
-                source: sunspec
-                {{- include "modbus" . | indent 14 }}
-                value:
-                  - 704:WMaxLimPctEna
-                  - 123:WMaxLim_Ena
-        default:
-          source: const
-          value: 1 # Limit enabled
-          set:
-            source: sunspec
-            {{- include "modbus" . | indent 10 }}
-            value:
-              - 704:WMaxLimPctEna
-              - 123:WMaxLim_Ena
-  curtailed: # curtailed only while the limit is enabled and below nominal (< 100 %)
-    source: go
-    in:
-    - name: ena
-      type: bool
-      config:
-        source: sunspec
-        {{- include "modbus" . | indent 6 }}
-        value:
-          - 704:WMaxLimPctEna
-          - 123:WMaxLim_Ena
-    - name: limit
-      type: float
-      config:
-        source: sunspec
-        {{- include "modbus" . | indent 6 }}
-        value:
-          - 704:WMaxLimPct
-          - 123:WMaxLimPct
-    script: ena && limit < 100
-  {{- end }}
   {{- end }}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -4,12 +4,18 @@ products:
       de: SunSpec Wechselrichter
       en: SunSpec Inverter
 group: generic
-capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["tcpip", "rs485"]
+  - name: curtailable
+    description:
+      de: Abregelbar
+      en: Curtailable
+    type: bool
+    advanced: true
+    usages: ["pv"]
   - preset: battery-params
 render: |
   type: custom
@@ -154,6 +160,7 @@ render: |
       - 103:WH
       - 113:WH
     scale: 0.001
+  {{- if .curtailable }}
   curtail:
     source: sequence
     set:
@@ -189,6 +196,7 @@ render: |
     value:
       - 704:WMaxLimPctEna
       - 123:WMaxLim_Ena
+  {{- end }}
   {{- end }}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -4,6 +4,7 @@ products:
       de: SunSpec Wechselrichter
       en: SunSpec Inverter
 group: generic
+capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -15,6 +15,7 @@ params:
       en: Curtailable
     type: bool
     advanced: true
+    default: true
     usages: ["pv"]
   - preset: battery-params
 render: |
@@ -160,7 +161,7 @@ render: |
       - 103:WH
       - 113:WH
     scale: 0.001
-  {{- if .curtailable }}
+  {{- if eq .curtailable "true" }}
   curtail:
     source: sequence
     set:


### PR DESCRIPTION
fixes #31594

Model 123 (Immediate Controls) and model 704 (DER AC Controls) are both optional in the SunSpec spec. Some inverters (e.g. Kaco Blueplanet 6.5 TL3, confirmed via `evcc sunspec` in #31594) implement neither, so the generic `sunspec-inverter`/`sunspec-hybrid` templates failed meter creation outright as soon as `usage: pv` was configured, even though power/energy readings work fine on these devices.

- `sunspec-inverter`/`sunspec-hybrid` go back to their pre-#31492 form: no curtail block, no `capabilities: ["curtail"]`, so they work for inverters without model 123/704.
- Added `sunspec-inverter-curtailable`/`sunspec-hybrid-curtailable`- PV-only duplicates that always render `curtail`/`curtailed` and declare the capability, for users who know their inverter supports it.
- Breaking change: curtail support for the generic templates has been live on master since #31492, so any existing `sunspec-inverter`/`sunspec-hybrid` config relying on curtailment loses it on next render- affected users need to reconfigure the device on the `-curtailable` template to keep it.