### PR TITLE
SunSpec: curtailed false when limit is 100%

### DIFF
--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -136,12 +136,26 @@ render: |
             value:
               - 704:WMaxLimPctEna
               - 123:WMaxLim_Ena
-  curtailed:
-    source: sunspec
-    {{- include "modbus" . | indent 2 }}
-    value:
-      - 704:WMaxLimPctEna
-      - 123:WMaxLim_Ena
+  curtailed: # curtailed only while the limit is enabled and below nominal (< 100 %)
+    source: go
+    in:
+    - name: ena
+      type: bool
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPctEna
+          - 123:WMaxLim_Ena
+    - name: limit
+      type: float
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
+    script: ena && limit < 100
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -183,12 +183,26 @@ render: |
             value:
               - 704:WMaxLimPctEna
               - 123:WMaxLim_Ena
-  curtailed:
-    source: sunspec
-    {{- include "modbus" . | indent 2 }}
-    value:
-      - 704:WMaxLimPctEna
-      - 123:WMaxLim_Ena
+  curtailed: # curtailed only while the limit is enabled and below nominal (< 100 %)
+    source: go
+    in:
+    - name: ena
+      type: bool
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPctEna
+          - 123:WMaxLim_Ena
+    - name: limit
+      type: float
+      config:
+        source: sunspec
+        {{- include "modbus" . | indent 6 }}
+        value:
+          - 704:WMaxLimPct
+          - 123:WMaxLimPct
+    script: ena && limit < 100
   {{- end }}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
fixes #31535

Follow-up to the 123/704 fallback fix in that issue - see the [later comments](https://github.com/evcc-io/evcc/issues/31535#issuecomment-4922673197). Some inverters (confirmed on Kostal Plenticore Gen1) leave `WMaxLim_Ena` permanently at `1` and only ever change `WMaxLimPct`; "no limit" is expressed purely as a 100% value. Reading `curtailed` straight off the Ena register therefore always reported `curtailed=true` on these devices, even though nothing was actually curtailed.

- `curtailed` now combines both registers via a `go`-expression source (`ena && limit < 100`), matching the pattern `kostal-plenticore-gen2.yaml` already uses for the same problem.
- No change for inverters that do toggle the Ena flag correctly.