### PR TITLE
Site: base solar forecast scale on produced energy

### DIFF
--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -185,7 +185,7 @@ func (site *Site) solarScale() float64 {
 	}
 
 	const minEnergy = 0.5 // kWh
-	if fcst <= 0 || pv+fcst <= minEnergy {
+	if fcst <= 0 || pv <= minEnergy {
 		return 1
 	}
 


### PR DESCRIPTION
fixes #31583, see also #31502

Without a PV meter, measured production is always 0, so the solar forecast scale (`produced / forecasted`) collapsed to 0. The optimizer then received a zeroed solar forecast while the main forecast still showed the raw values, causing the "no PV forecast in Optimize Debug" mismatch. Guard on measured production instead of the produced+forecast sum, so no scaling is applied until real production is observed.

- Solar forecast passes to the battery optimizer unscaled when no PV meter is configured or the day is still too young to have measurable production.
