### PR TITLE
Config: fix loadpoint modal reusing previous charger on repeated add

### DIFF
--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -927,6 +927,9 @@ export default {
 				await api.post("config/loadpoints", this.values);
 				this.created = true;
 				this.emitChanged("added");
+				// the created response has no id to compare against on next open, so
+				// reset explicitly instead of relying on the isModalVisible watcher
+				this.reset();
 			} catch (e) {
 				handleError(e, "create failed");
 			}
@@ -943,8 +946,8 @@ export default {
 				await this.cleanupDevice("charger", this.values.charger, this.chargers);
 				await this.cleanupDevice("meter", this.values.meter, this.meters);
 				this.$emit("dismissed");
+				this.reset();
 			}
-			this.reset();
 		},
 		async cleanupDevice(type: DeviceType, name: string, list: { name: string; id: number }[]) {
 			const id = list.find((d) => d.name === name)?.id;

--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -943,8 +943,8 @@ export default {
 				await this.cleanupDevice("charger", this.values.charger, this.chargers);
 				await this.cleanupDevice("meter", this.values.meter, this.meters);
 				this.$emit("dismissed");
-				this.reset();
 			}
+			this.reset();
 		},
 		async cleanupDevice(type: DeviceType, name: string, list: { name: string; id: number }[]) {
 			const id = list.find((d) => d.name === name)?.id;

--- a/tests/config-loadpoint.spec.ts
+++ b/tests/config-loadpoint.spec.ts
@@ -186,6 +186,57 @@ test.describe("charging loadpoint", async () => {
     await expect(lpModal.getByLabel("Priority")).toHaveValue("0");
   });
 
+  test("second loadpoint gets its own charger, not the first one's", async ({ page }) => {
+    await start();
+    await page.goto("/#/config");
+
+    const lpModal = page.getByTestId("loadpoint-modal");
+    const chargerModal = page.getByTestId("charger-modal");
+
+    // first loadpoint with its own charger
+    await newLoadpoint(page, "Carport");
+    await lpModal.getByRole("button", { name: "Add charger" }).click();
+    await expectModalVisible(chargerModal);
+    await expect(chargerModal.getByRole("heading", { name: "Add Charger" })).toBeVisible();
+    await chargerModal.getByLabel("Manufacturer").selectOption("Demo charger");
+    await chargerModal.getByLabel("Power").fill("11000");
+    await chargerModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(chargerModal);
+    await expectModalVisible(lpModal);
+    await lpModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(lpModal);
+    await expect(page.getByTestId("loadpoint")).toHaveCount(1);
+    await expect(page.getByTestId("loadpoint")).toContainText("11.0 kW");
+
+    // second loadpoint, added right after without a page reload in between
+    await newLoadpoint(page, "Garage");
+    await lpModal.getByRole("button", { name: "Add charger" }).click();
+    await expectModalVisible(chargerModal);
+
+    // must open a fresh charger, not reopen the first one for editing
+    await expect(chargerModal.getByRole("heading", { name: "Add Charger" })).toBeVisible();
+
+    await chargerModal.getByLabel("Manufacturer").selectOption("Demo charger");
+    await chargerModal.getByLabel("Power").fill("22000");
+    await chargerModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(chargerModal);
+    await expectModalVisible(lpModal);
+    await lpModal.getByRole("button", { name: "Save" }).click();
+    await expectModalHidden(lpModal);
+
+    // two loadpoints, each with its own distinct charger
+    await expect(page.getByTestId("loadpoint")).toHaveCount(2);
+    await expect(page.getByTestId("loadpoint").nth(0)).toContainText("11.0 kW");
+    await expect(page.getByTestId("loadpoint").nth(1)).toContainText("22.0 kW");
+
+    // restart to confirm the persisted config really has two distinct charger devices
+    await restart();
+    await page.reload();
+    await expect(page.getByTestId("loadpoint")).toHaveCount(2);
+    await expect(page.getByTestId("loadpoint").nth(0)).toContainText("11.0 kW");
+    await expect(page.getByTestId("loadpoint").nth(1)).toContainText("22.0 kW");
+  });
+
   test("vehicle", async ({ page }) => {
     await start();
     await page.goto("/#/config");


### PR DESCRIPTION
fixes #31534

Two Easee chargers added back-to-back in the Config UI end up sharing one device: the loadpoint modal keeps stale form state after a successful save, so the next "Add Loadpoint" reopens the previous charger for editing instead of creating a new one.

- Reset the loadpoint form after every modal close, not only when the add was cancelled — cleanup of orphaned devices stays skipped for successful saves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
