### PR TITLE
EEBus: fix test cleanup regression breaking TestShipPairing

### DIFF
--- a/server/eebus/test/gridguard_test.go
+++ b/server/eebus/test/gridguard_test.go
@@ -39,10 +39,12 @@ func TestControlBoxGridGuardHeartbeat(t *testing.T) {
 
 	inst, err := server.Instance()
 	require.NoError(t, err, "instance")
+	defer inst.Shutdown()
 
 	// the controlbox test double, like a real ControlBox, only exposes GridGuard
 	box, err := createControlbox(t.Context(), inst.Ski(), freePort(t))
 	require.NoError(t, err, "controlbox")
+	defer box.myService.Shutdown()
 
 	// no hems.Run(): the run loop applies limits via the nil site and is not needed here
 	_, err = hems.NewEEBus(t.Context(), box.ski, eebus.Limits{}, nil, nil, time.Second)


### PR DESCRIPTION
`TestControlBoxGridGuardHeartbeat` (#31568) never shuts down its `server.Instance()` or controlbox, relying only on the next test in the package to tear down a leftover instance and on async context cancellation for the controlbox. That was harmless while it was the last test in the package, but it now runs before `TestShipPairing` (alphabetical file order: cs_test.go, gridguard_test.go, pairing_test.go) — so `TestShipPairing` can start while the GridGuard test's server/controlbox is still shutting down.

This explains the "paired device not routed to consumer" CI failures on #31570: they started right after a "merge master" commit pulled in #31568, and master itself has been consistently green (nothing else runs after `TestControlBoxGridGuardHeartbeat` there).

- Shut down the GridGuard test's server and controlbox explicitly before it returns, instead of leaving cleanup to chance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
