### PR TITLE
Planner: don't force grid charging to finish a stale slot when the plan moved far out

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -214,6 +214,10 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 		// remember last active plan's slot end time
 		lp.planSlotEnd = activeSlot.End
 	} else if lp.planActive {
+		// the freshly computed plan restarts soon- bridging gaps here avoids stop/restart flapping.
+		// if the next slot is far out (e.g. plan moved to a future day), there's no such urgency.
+		imminentRestart := lp.clock.Until(planStart) < tariff.SlotDuration-time.Minute
+
 		// planner was active (any slot, not necessarily previous slot) and charge goal has not yet been met
 		switch {
 		case lp.clock.Now().After(planTime) && !planTime.IsZero():
@@ -221,14 +225,14 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 			// TODO check when schedule is implemented
 			lp.log.DEBUG.Println("plan: continuing after target time")
 			return true
-		case lp.clock.Now().Before(lp.planSlotEnd) && !lp.planSlotEnd.IsZero() && requiredDuration > strategy.Precondition:
+		case lp.clock.Now().Before(lp.planSlotEnd) && !lp.planSlotEnd.IsZero() && requiredDuration > strategy.Precondition && imminentRestart:
 			// don't stop an already running slot if goal was not met
 			lp.log.DEBUG.Printf("plan: continuing until end of slot at %s", lp.planSlotEnd.Round(time.Second).Local())
 			return true
-		case requiredDuration < tariff.SlotDuration && requiredDuration > strategy.Precondition:
+		case requiredDuration < tariff.SlotDuration && requiredDuration > strategy.Precondition && imminentRestart:
 			lp.log.DEBUG.Printf("plan: continuing for remaining %v", requiredDuration.Round(time.Second))
 			return true
-		case lp.clock.Until(planStart) < tariff.SlotDuration-time.Minute:
+		case imminentRestart:
 			lp.log.DEBUG.Printf("plan: avoid re-start within %v, continuing for remaining %v", tariff.SlotDuration, lp.clock.Until(planStart).Round(time.Second))
 			return true
 		case strategy.Continuous && requiredDuration > strategy.Precondition:

--- a/core/loadpoint_plan_test.go
+++ b/core/loadpoint_plan_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/planner"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// regression test for https://github.com/evcc-io/evcc/issues/31576
+func TestPlannerActiveStopsWhenPlanMovedFarOut(t *testing.T) {
+	Voltage = 230
+
+	ctrl := gomock.NewController(t)
+	now := time.Now()
+
+	// flat tariff- every 15m slot has the same cost
+	var rates api.Rates
+	for start := now.Add(-time.Hour); start.Before(now.Add(6 * 24 * time.Hour)); start = start.Add(15 * time.Minute) {
+		rates = append(rates, api.Rate{Start: start, End: start.Add(15 * time.Minute), Value: 0.29})
+	}
+
+	tariff := api.NewMockTariff(ctrl)
+	tariff.EXPECT().Rates().AnyTimes().Return(rates, nil)
+
+	lp := NewLoadpoint(util.NewLogger("foo"), nil)
+	lp.status = api.StatusC
+	lp.planner = planner.New(lp.log, tariff)
+
+	// flat tariff -> planner prefers the latest slot, right before the target
+	lp.planTime = now.Add(5 * 24 * time.Hour)
+	lp.planEnergy = 5 // kWh, ~27min at 11kW
+
+	// simulate a previously active slot (e.g. from PV surplus) that is about to end
+	lp.planActive = true
+	lp.planSlotEnd = now.Add(2 * time.Minute)
+
+	assert.False(t, lp.plannerActive(), "must not force continuation once the plan has moved days into the future")
+}


### PR DESCRIPTION
fixes #31576

`plannerActive()`'s continuation grace periods (continuing until end of slot / continuing for remaining / avoid re-start) only checked that the goal wasn't met yet, not whether the freshly recomputed plan still needed to run soon. Once solar surplus dropped mid-slot and the planner pushed the required charging window out to a future day (still ample time, so it prefers a later - e.g. solar - slot), these grace periods kept charging on grid power anyway to "finish" the now-obsolete slot.

- Gate the "continuing until end of slot" and "continuing for remaining" cases on the same imminent-restart window already used by "avoid re-start within slot duration", so they only bridge genuinely short gaps instead of bridging all the way to a plan that has moved days away.