### PR TITLE
Planner: log the rate window and fallback triggers used for planning

### DIFF
--- a/core/planner/planner.go
+++ b/core/planner/planner.go
@@ -124,11 +124,16 @@ func (t *Planner) Plan(requiredDuration, precondition time.Duration, targetTime 
 
 	// treat like normal target charging if we don't have rates
 	if len(rates) == 0 || err != nil {
+		t.log.DEBUG.Printf("planner: no rates available (count=%d, err=%v)- falling back to simple plan", len(rates), err)
 		return simplePlan
 	}
 
+	t.log.TRACE.Printf("planner: %d rates available from %v to %v",
+		len(rates), rates[0].Start.Local(), rates[len(rates)-1].End.Local())
+
 	// consume remaining time
 	if t.clock.Until(targetTime) <= requiredDuration {
+		t.log.DEBUG.Printf("planner: insufficient time until target- charging continuously from now")
 		return continuousPlan(rates, latestStart, targetTime)
 	}
 
@@ -156,6 +161,8 @@ func (t *Planner) Plan(requiredDuration, precondition time.Duration, targetTime 
 
 	// check if rate coverage is sufficient for planning
 	if len(rates) == 0 || rates[len(rates)-1].End.Sub(rates[0].Start) < requiredDuration {
+		t.log.DEBUG.Printf("planner: rate coverage in [%v,%v] insufficient for required duration %v- falling back to simple plan",
+			now.Local(), targetTime.Local(), requiredDuration.Round(time.Second))
 		return simplePlan
 	}
 


### PR DESCRIPTION
pairs with #31618

The original "charging started immediately despite the target being days away" report from #31576 isn't explained by #31618's fix - reproducing it in isolation with the exact logged duration/target consistently picks the correct late slot, so the planner algorithm itself isn't at fault given those inputs. The remaining suspect is what \`tariff.Rates()\` actually returned on that specific tick, which wasn't visible in the existing logs.

- Log the fetched rate window (count, first/last timestamp) at trace level.
- Log the previously-silent fallback branches that anchor a plan to \`now\`/short-notice charging instead of the target: no/insufficient rates, and insufficient time until target (continuous/emergency charging).