### PR TITLE
Revert "Energy Flow UI: Chrome (Skia Graphite) rendering bug workaround"

### DIFF
--- a/assets/js/components/Energyflow/LabelBar.vue
+++ b/assets/js/components/Energyflow/LabelBar.vue
@@ -42,8 +42,6 @@ export default defineComponent({
 	padding: 10px 0;
 	opacity: 1;
 	overflow: hidden;
-	/* forces own compositor layer, works around a Chrome Skia Graphite paint-invalidation bug (#31341) */
-	will-change: transform;
 }
 .label-bar-scale--hidden {
 	opacity: 0;


### PR DESCRIPTION
Reverts evcc-io/evcc#31571
Workaround not working. see https://github.com/evcc-io/evcc/pull/31571#issuecomment-4913251404