### PR TITLE
EEBus: retry test server bind to survive freePort race

### DIFF
--- a/server/eebus/test/gridguard_test.go
+++ b/server/eebus/test/gridguard_test.go
@@ -28,17 +28,13 @@ func TestControlBoxGridGuardHeartbeat(t *testing.T) {
 	public, private, err := server.GetX509KeyPair(certificate)
 	require.NoError(t, err, "decode certificate")
 
-	_, err = server.NewServer(server.Config{
-		Port: freePort(t),
+	conf := server.Config{
 		Certificate: server.Certificate{
 			Public:  public,
 			Private: private,
 		},
-	})
-	require.NoError(t, err, "server")
-
-	inst, err := server.Instance()
-	require.NoError(t, err, "instance")
+	}
+	inst := newServerOnFreePort(t, &conf)
 	defer inst.Shutdown()
 
 	// the controlbox test double, like a real ControlBox, only exposes GridGuard

--- a/server/eebus/test/pairing_test.go
+++ b/server/eebus/test/pairing_test.go
@@ -30,6 +30,74 @@ func freePort(t *testing.T) int {
 	return l.Addr().(*net.TCPAddr).Port
 }
 
+// nextFreePort is overridable in tests to force the bind-race retry path.
+var nextFreePort = freePort
+
+// newServerOnFreePort starts the eebus server on a free port, retrying the rare
+// freePort race where the port is taken between probe and bind. Sets conf.Port.
+func newServerOnFreePort(t *testing.T, conf *server.Config) *server.EEBus {
+	t.Helper()
+
+	for range 5 {
+		conf.Port = nextFreePort(t)
+
+		inst, err := server.NewServer(*conf)
+		require.NoError(t, err, "server")
+
+		if _, err := server.Instance(); err == nil {
+			return inst
+		} else if !strings.Contains(err.Error(), "address already in use") {
+			require.NoError(t, err, "instance")
+		}
+
+		// bind race lost: tear down and retry with a new port
+		inst.Shutdown()
+	}
+
+	t.Fatal("eebus server could not bind a free port")
+	return nil
+}
+
+// TestNewServerOnFreePort_RetriesPastOccupiedPort: the helper must recover when
+// its first port is already bound (simulating the freePort probe/bind race).
+func TestNewServerOnFreePort_RetriesPastOccupiedPort(t *testing.T) {
+	util.LogLevel("error", map[string]string{"eebus": "trace"})
+
+	if inst, err := server.Instance(); err == nil {
+		inst.Shutdown()
+	}
+
+	// hold a port on the same wildcard address the server binds (":port"), so the
+	// first bind attempt fails with "address already in use"
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer l.Close()
+	occupied := l.Addr().(*net.TCPAddr).Port
+
+	calls := 0
+	orig := nextFreePort
+	nextFreePort = func(t *testing.T) int {
+		calls++
+		if calls == 1 {
+			return occupied
+		}
+		return orig(t)
+	}
+	defer func() { nextFreePort = orig }()
+
+	certificate, err := cert.CreateCertificate("Demo", "Demo", "DE", "Demo-FreePort-01")
+	require.NoError(t, err, "certificate")
+	public, private, err := server.GetX509KeyPair(certificate)
+	require.NoError(t, err, "decode certificate")
+
+	conf := server.Config{Certificate: server.Certificate{Public: public, Private: private}}
+	inst := newServerOnFreePort(t, &conf)
+	defer inst.Shutdown()
+
+	require.Greater(t, calls, 1, "helper should retry past the occupied port")
+	require.NotEqual(t, occupied, conf.Port, "server must not bind the occupied port")
+}
+
 // qrField extracts a field value from the SHIP QR code text
 func qrField(qr, key string) string {
 	for f := range strings.SplitSeq(qr, ";") {
@@ -127,7 +195,6 @@ func TestShipPairing(t *testing.T) {
 	require.NoError(t, err, "secret")
 
 	conf := server.Config{
-		Port:   freePort(t),
 		Secret: secret,
 		Certificate: server.Certificate{
 			Public:  public,
@@ -135,11 +202,7 @@ func TestShipPairing(t *testing.T) {
 		},
 	}
 
-	_, err = server.NewServer(conf)
-	require.NoError(t, err, "server")
-
-	inst, err := server.Instance()
-	require.NoError(t, err, "instance")
+	inst := newServerOnFreePort(t, &conf)
 
 	qr := serverQR(t)
 	require.Contains(t, qr, "SPSEC:", "expected SHIP Pairing Service QR")


### PR DESCRIPTION
follows #31617

`freePort()` in the eebus tests probes a free port (`listen :0`, read port, close) and hands it to the server, which binds it later. Another listener can take the port in that gap — a TOCTOU that surfaces as `bind: address already in use` and flakes `TestShipPairing` and `TestControlBoxGridGuardHeartbeat` (the now-dominant remaining flake in this package, ~1/55 locally).

An ephemeral port (`Port: 0`) isn't an option: ship-go announces the *configured* port via mDNS and rejects port 0, so the port has to be known up front.

- `newServerOnFreePort` retries `NewServer` on a fresh port when the bind loses the race; the initial server setups in both tests use it.
- Added `TestNewServerOnFreePort_RetriesPastOccupiedPort`: occupies the port first and asserts the helper retries past it (fails without the retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
