### PR TITLE
chore: bump ship-go to fork commit fixing trusted-reconnect mDNS cancel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -263,3 +263,5 @@ replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b
 
 replace github.com/enbility/eebus-go => github.com/evcc-io/eebus-go v0.0.0-20260707170747-eb60ff7e2025
+
+replace github.com/enbility/ship-go => github.com/andig/ship-go v0.6.1-0.20260709121012-4d894c2162d3

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/andig/gosunspec v0.0.0-20260705113727-6d585e133512 h1:1y8dS4GaBB9WUu/
 github.com/andig/gosunspec v0.0.0-20260705113727-6d585e133512/go.mod h1:c6P6szcR+ROkqZruOR4f6qbDKFjZX6OitPpj+yJ/r8k=
 github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e h1:m/NTP3JWpR7M0ljLxiQU4fzR25jjhe1LDtxLMNcoNJQ=
 github.com/andig/mbserver v0.0.0-20230310211055-1d29cbb5820e/go.mod h1:4VtYzTm//oUipwvO3yh0g/udTE7pYJM+U/kyAuFDsgM=
+github.com/andig/ship-go v0.6.1-0.20260709121012-4d894c2162d3 h1:x92AWbzIDa88b/YHTgO+0RyaPpjgUpVYDXEzK6n/XtU=
+github.com/andig/ship-go v0.6.1-0.20260709121012-4d894c2162d3/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
@@ -138,8 +140,6 @@ github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2I
 github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a h1:foChWb8lhzqa6lWDRs6COYMdp649YlUirFP8GqoT0JQ=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a/go.mod h1:H64mhYcAQUGUUnVqMdZQf93kPecH4M79xwH95Lddt3U=
-github.com/enbility/ship-go v0.6.1-0.20260706134013-3abd41d19f41 h1:Uzs5tsH+eh7IveFrtnumh36DKFaPS8nHZgBW/xbz9zw=
-github.com/enbility/ship-go v0.6.1-0.20260706134013-3abd41d19f41/go.mod h1:EvRFx83phCwPQrOuWw2CX5t0c6mcFVzIk6gQEz4Lijg=
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323 h1:bLsMlyRamUgDNz6PNiKa1ukPebvs3pplrVGNdHo1JMI=
 github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323/go.mod h1:ddWZU5BQGyzRGF20Z7rUKFFzbCp+cfu9mZgYtOMW/fM=
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6 h1:XOYvxKtT1oxT37w/5oEiRLuPbm9FuJPt3fiYhX0h8Po=


### PR DESCRIPTION
pairs with enbility/ship-go#89

Points at `andig/ship-go@4d894c216`: a trusted/paired device's pending reconnect no longer gets cancelled by a transient mDNS drop, which stranded EEBus reconnects after a controller restart and was one of the causes behind the flaky `TestShipPairing` (#31534, #31570).

- Interim fork pin until enbility/ship-go#89 merges to `dev`, at which point this should be flipped to the clean upstream pseudo-version.
- `TestShipPairing` restart/reconnect: 5/5 clean with this bump, vs a ~3/8 baseline failure rate before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
