### PR TITLE
OCPP: clear failed charge point registration on init error

### DIFF
--- a/charger/ocpp/cs.go
+++ b/charger/ocpp/cs.go
@@ -175,7 +175,17 @@ func (cs *CS) RegisterChargepoint(id string, newfun func() *CP, init func(*CP) e
 		cp.onTransportConnect()
 	}
 
-	return cp, init(cp)
+	err := init(cp)
+	if err != nil {
+		// allow retry on next call instead of permanently caching a failed setup
+		cs.mu.Lock()
+		if reg.cp == cp {
+			reg.cp = nil
+		}
+		cs.mu.Unlock()
+	}
+
+	return cp, err
 }
 
 // NewChargePoint implements ocpp16.ChargePointConnectionHandler

--- a/charger/ocpp/cs_test.go
+++ b/charger/ocpp/cs_test.go
@@ -1,0 +1,44 @@
+package ocpp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterChargepointClearsCacheOnInitFailure(t *testing.T) {
+	cs := &CS{
+		log:  util.NewLogger("foo"),
+		regs: make(map[string]*registration),
+	}
+
+	newfun := func() *CP { return NewChargePoint(util.NewLogger("foo"), cs, "test") }
+
+	// first attempt fails- must not leave a stale cp cached
+	_, err := cs.RegisterChargepoint("test", newfun, func(*CP) error {
+		return errors.New("boom")
+	})
+	require.Error(t, err)
+	assert.Nil(t, cs.regs["test"].cp, "failed init must not cache the charge point")
+
+	// retry must create a fresh charge point and succeed
+	var initialised *CP
+	cp, err := cs.RegisterChargepoint("test", newfun, func(cp *CP) error {
+		initialised = cp
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Same(t, initialised, cp)
+	assert.Same(t, cp, cs.regs["test"].cp, "successful init must cache the charge point")
+
+	// further calls must return the cached charge point without re-running init
+	cp2, err := cs.RegisterChargepoint("test", newfun, func(*CP) error {
+		t.Fatal("init must not be called again for an already registered charge point")
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Same(t, cp, cp2)
+}


### PR DESCRIPTION
Related to #31648 — while diagnosing that report I found this separate latent bug in the same code path.

`RegisterChargepoint` cached the charge point before running `init()` and never cleared it on failure. Once the first connection attempt failed (e.g. the wait for BootNotification timed out), every later Save/Test of the same station id hit the already-registered short-circuit and skipped the connection wait entirely, permanently serving a never-booted charge point.

- Clear `reg.cp` when `init()` returns an error, so a retry re-attempts the connection wait instead of reusing the failed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)