### PR TITLE
Fix vehicle mode reset on RFID re-identification of already-active vehicle

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -77,7 +77,11 @@ func (lp *Loadpoint) identifyVehicle() {
 
 		if vehicle := lp.selectVehicleByID(id); vehicle != nil {
 			lp.stopVehicleDetection()
-			lp.setActiveVehicle(vehicle)
+
+			// already active via a different detection path - avoid reapplying its mode
+			if lp.GetVehicle() != vehicle {
+				lp.setActiveVehicle(vehicle)
+			}
 		}
 	}
 }

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -323,6 +323,51 @@ func TestDefaultVehicle(t *testing.T) {
 	assert.Nil(t, lp.vehicle, "expected no vehicle")
 }
 
+// idCharger is a minimal charger implementing api.Identifier for identifyVehicle tests.
+type idCharger struct {
+	id string
+}
+
+func (c *idCharger) Status() (api.ChargeStatus, error) { return api.StatusB, nil }
+func (c *idCharger) Enabled() (bool, error)            { return false, nil }
+func (c *idCharger) Enable(bool) error                 { return nil }
+func (c *idCharger) MaxCurrent(int64) error            { return nil }
+func (c *idCharger) Identify() (string, error)         { return c.id, nil }
+
+// TestReidentifyActiveVehicleKeepsMode is a regression test for #31499:
+// re-identifying the already-active vehicle must not reapply its default mode.
+func TestReidentifyActiveVehicleKeepsMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().GetTitle().Return("target").AnyTimes()
+	vehicle.EXPECT().Icon().Return("").AnyTimes()
+	vehicle.EXPECT().Capacity().AnyTimes()
+	vehicle.EXPECT().Phases().AnyTimes()
+	vehicle.EXPECT().Identifiers().Return([]string{"rfid-1"}).AnyTimes()
+	vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{
+		Mode: api.ModePV,
+	}).AnyTimes()
+
+	lp := NewLoadpoint(util.NewLogger("foo"), settings.NewDatabaseSettingsAdapter("foo"))
+	lp.charger = &idCharger{id: "rfid-1"}
+	lp.coordinator = coordinator.NewAdapter(lp, coordinator.New(util.NewLogger("foo"), []api.Vehicle{vehicle}))
+
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	// vehicle already active via a different detection path (e.g. SoC poll)
+	lp.setActiveVehicle(vehicle)
+	assert.Equal(t, api.ModePV, lp.GetMode(), "mode after first identification")
+
+	// user/system escalates to now in between
+	lp.SetMode(api.ModeNow)
+
+	// charger reports the same vehicle's RFID id - must not reapply default mode
+	lp.identifyVehicle()
+	assert.Equal(t, api.ModeNow, lp.GetMode(), "mode must not be reapplied for already-active vehicle")
+}
+
 // integratedDeviceCharger is a minimal charger advertising the IntegratedDevice feature.
 type integratedDeviceCharger struct{}
 


### PR DESCRIPTION
fixes #31499

Traced from the trace log attached to the issue (`evcc-20260710-093225-trace.log`):

- `08:00:23` vehicle auto-detected via SoC/API poll -> mode auto-set to `pv` (vehicle's configured default mode)
- `08:00:37` mode escalated to `now`, charger enabled, wake-up timer starts
- `08:00:50` charger reports the same vehicle's RFID id -> `identifyVehicle()` re-resolves the *same, already-active* vehicle and reapplies its default mode, silently reverting `now` back to `pv`
- `08:01:50` `pv` mode sees no solar surplus and disables the charger -> pause, car eventually times out into a charge error

Root cause: `identifyVehicle()` (`core/loadpoint_vehicle.go`) called `setActiveVehicle()` on every resolved id without checking whether that vehicle was already active. Two independent identification paths (SoC/API poll and charger RFID read) both resolve the same vehicle for one physical connection, and `setActiveVehicle()` unconditionally reapplies the vehicle's default mode.

Fix: skip `setActiveVehicle()` in `identifyVehicle()` when the resolved vehicle is already `lp.GetVehicle()`. `setActiveVehicle()` itself is left untouched since other callers (e.g. `vehicleDefaultOrDetect()`) intentionally call it repeatedly across connect/disconnect cycles to refresh the SoC estimator.

Added `TestReidentifyActiveVehicleKeepsMode` covering the scenario.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)