### PR TITLE
Battery UI: show fully visible day as history window title

### DIFF
--- a/assets/js/components/Battery/BatteryHistoryCard.vue
+++ b/assets/js/components/Battery/BatteryHistoryCard.vue
@@ -50,6 +50,7 @@ import WindowNav from "./WindowNav.vue";
 import BatteryHistoryChart from "./BatteryHistoryChart.vue";
 
 const HOUR = 3600 * 1000;
+const DAY = 24 * HOUR;
 const MIN_OFFSET = -30; // page back ~30 days
 
 // History + forecast chart with its date navigation, unit toggle and legend. Presentation
@@ -92,17 +93,16 @@ export default defineComponent({
 		},
 		winStart(): Date {
 			const baseStartH = this.hasForecastData ? 24 : 48;
-			return new Date(this.now.getTime() - baseStartH * HOUR + this.dayOffset * 24 * HOUR);
+			return new Date(this.now.getTime() - baseStartH * HOUR + this.dayOffset * DAY);
 		},
 		winEnd(): Date {
 			const baseEndH = this.hasForecastData ? 24 : 0;
-			return new Date(this.now.getTime() + baseEndH * HOUR + this.dayOffset * 24 * HOUR);
+			return new Date(this.now.getTime() + baseEndH * HOUR + this.dayOffset * DAY);
 		},
 		windowLabel(): string {
-			// relative day name if close (e.g. "gestern – morgen"), else "Sa. 27."
-			const fmt = (d: Date) =>
-				this.relativeDayName(d) ?? `${this.weekdayShort(d)} ${d.getDate()}.`;
-			return `${fmt(this.winStart)} – ${fmt(this.winEnd)}`;
+			// day of "now" shifted by paging; this is the only fully visible day
+			const d = new Date(this.now.getTime() + this.dayOffset * DAY);
+			return this.relativeDayName(d) ?? `${this.weekdayShort(d)} ${d.getDate()}.`;
 		},
 		prevDisabled(): boolean {
 			return this.dayOffset <= MIN_OFFSET;

--- a/assets/js/components/Battery/WindowNav.vue
+++ b/assets/js/components/Battery/WindowNav.vue
@@ -6,7 +6,7 @@
 			:on-click="() => $emit('prev')"
 			data-testid="battery-chart-prev"
 		/>
-		<span class="text-center text-truncate evcc-default-text" style="width: 11em">{{
+		<span class="text-center text-truncate evcc-default-text" style="width: 6em">{{
 			label
 		}}</span>
 		<DateNavigatorButton


### PR DESCRIPTION
follow-up to https://github.com/evcc-io/evcc/pull/31661#issuecomment-4936811923

The 48h history window always contains exactly one full calendar day. Title that day instead of the start/end range.

- single day label: relative name ("today") or short weekday with date
- with forecast the window midpoint day, without the end day, both are now + offset
- narrower label width, prev/next move closer together

<img width="834" height="431" alt="Bildschirmfoto 2026-07-10 um 17 26 10" src="https://github.com/user-attachments/assets/e68edefc-de9f-4a5f-b8a8-46a4821452b7" />
