### PR TITLE
fix nil instance panic in loadpoint config handlers for disabled loadpoints

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1432,17 +1432,19 @@ func configureLoadpoints(conf globalconfig.All) error {
 			return &DeviceError{cc.Name, err}
 		}
 
-		var instance *core.Loadpoint
+		var instance loadpoint.API
 		if !conf.Disable {
-			instance, err = newLoadpoint(idx, cc.Name, static, func(log *util.Logger) coresettings.Settings {
+			lp, e := newLoadpoint(idx, cc.Name, static, func(log *util.Logger) coresettings.Settings {
 				return coresettings.NewConfigSettingsAdapter(log, &conf)
 			})
-			if err != nil {
-				err = &DeviceError{cc.Name, err}
+			if e != nil {
+				err = &DeviceError{cc.Name, e}
+			} else {
+				instance = lp
 			}
 		}
 
-		dev := config.NewConfigurableDevice[loadpoint.API](&conf, instance)
+		dev := config.NewConfigurableDevice(&conf, instance)
 		if e := config.Loadpoints().Add(dev); e != nil && err == nil {
 			err = &DeviceError{cc.Name, e}
 		}

--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -598,7 +598,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 			// cleanup references
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetChargerRef() == config.NameForID(id) {
+				if lp != nil && lp.GetChargerRef() == config.NameForID(id) {
 					lp.SetChargerRef("")
 				}
 			}
@@ -627,7 +627,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetMeterRef() == name {
+				if lp != nil && lp.GetMeterRef() == name {
 					lp.SetMeterRef("")
 				}
 			}
@@ -638,7 +638,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 			// cleanup references
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetDefaultVehicleRef() == config.NameForID(id) {
+				if lp != nil && lp.GetDefaultVehicleRef() == config.NameForID(id) {
 					lp.SetDefaultVehicleRef("")
 				}
 			}
@@ -649,7 +649,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 			// cleanup references
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetCircuitRef() == config.NameForID(id) {
+				if lp != nil && lp.GetCircuitRef() == config.NameForID(id) {
 					lp.SetCircuitRef("")
 				}
 			}

--- a/server/http_config_loadpoint_handler.go
+++ b/server/http_config_loadpoint_handler.go
@@ -86,24 +86,21 @@ func loadpointConfig(dev config.Device[loadpoint.API]) loadpointFullConfig {
 
 	lp := dev.Instance()
 
-	// // missing instance due to error, decode config from database
-	// if lp == nil || reflect.ValueOf(lp).IsNil() {
-	// 	cc := dev.Config()
+	// disabled loadpoint has no live instance; decode static config from the database instead
+	if lp == nil {
+		dynamic, staticMap, _ := loadpoint.SplitConfig(dev.Config().Other)
 
-	// 	dynamic, staticMap, _ := loadpoint.SplitConfig(cc.Other)
+		var static loadpoint.StaticConfig
+		_ = util.DecodeOther(staticMap, &static)
 
-	// 	var static loadpoint.StaticConfig
-	// 	_ = util.DecodeOther(staticMap, &static)
-
-	// 	res := loadpointFullConfig{
-	// 		ID:            id,
-	// 		Name:          dev.Config().Name,
-	// 		StaticConfig:  static,
-	// 		DynamicConfig: dynamic,
-	// 	}
-
-	// 	return res
-	// }
+		return loadpointFullConfig{
+			ID:            id,
+			Name:          dev.Config().Name,
+			Disable:       disable,
+			StaticConfig:  static,
+			DynamicConfig: dynamic,
+		}
+	}
 
 	res := loadpointFullConfig{
 		ID:            id,
@@ -250,10 +247,12 @@ func updateLoadpointHandler() http.HandlerFunc {
 			return
 		}
 
-		// dynamic
-		if err := dynamic.Apply(instance); err != nil {
-			jsonError(w, http.StatusBadRequest, err)
-			return
+		// dynamic; instance is nil for a disabled loadpoint, takes effect on next restart
+		if instance != nil {
+			if err := dynamic.Apply(instance); err != nil {
+				jsonError(w, http.StatusBadRequest, err)
+				return
+			}
 		}
 
 		setConfigDirty()
@@ -283,6 +282,20 @@ func deleteLoadpointHandler() http.HandlerFunc {
 		}
 
 		instance := lp.Instance()
+
+		// disabled loadpoint has no live instance; delete it without ref cleanup
+		if instance == nil {
+			if err := deleteDevice(id, h); err != nil {
+				jsonError(w, http.StatusBadRequest, err)
+				return
+			}
+
+			jsonWrite(w, struct {
+				ID int `json:"id"`
+			}{ID: id})
+
+			return
+		}
 
 		if dev, err := configurableDevice(instance.GetChargerRef(), config.Chargers()); err == nil {
 			if err := deleteDevice(dev.ID(), config.Chargers()); err != nil {

--- a/server/http_config_loadpoint_handler.go
+++ b/server/http_config_loadpoint_handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/gorilla/mux"
-	"github.com/samber/lo"
 )
 
 func getLoadpointStaticConfig(lp loadpoint.API) loadpoint.StaticConfig {
@@ -74,7 +73,7 @@ func loadpointSplitConfig(r io.Reader) (loadpoint.DynamicConfig, map[string]any,
 }
 
 // loadpointConfig returns a single loadpoint's configuration
-func loadpointConfig(dev config.Device[loadpoint.API]) loadpointFullConfig {
+func loadpointConfig(dev config.Device[loadpoint.API]) (loadpointFullConfig, error) {
 	var (
 		id      int
 		disable bool
@@ -88,10 +87,15 @@ func loadpointConfig(dev config.Device[loadpoint.API]) loadpointFullConfig {
 
 	// disabled loadpoint has no live instance; decode static config from the database instead
 	if lp == nil {
-		dynamic, staticMap, _ := loadpoint.SplitConfig(dev.Config().Other)
+		dynamic, staticMap, err := loadpoint.SplitConfig(dev.Config().Other)
+		if err != nil {
+			return loadpointFullConfig{}, err
+		}
 
 		var static loadpoint.StaticConfig
-		_ = util.DecodeOther(staticMap, &static)
+		if err := util.DecodeOther(staticMap, &static); err != nil {
+			return loadpointFullConfig{}, err
+		}
 
 		return loadpointFullConfig{
 			ID:            id,
@@ -99,7 +103,7 @@ func loadpointConfig(dev config.Device[loadpoint.API]) loadpointFullConfig {
 			Disable:       disable,
 			StaticConfig:  static,
 			DynamicConfig: dynamic,
-		}
+		}, nil
 	}
 
 	res := loadpointFullConfig{
@@ -110,15 +114,24 @@ func loadpointConfig(dev config.Device[loadpoint.API]) loadpointFullConfig {
 		DynamicConfig: getLoadpointDynamicConfig(lp),
 	}
 
-	return res
+	return res, nil
 }
 
 // loadpointsConfigHandler returns a device configurations by class
 func loadpointsConfigHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		res := lo.Map(config.Loadpoints().Devices(), func(dev config.Device[loadpoint.API], _ int) loadpointFullConfig {
-			return loadpointConfig(dev)
-		})
+		devices := config.Loadpoints().Devices()
+
+		res := make([]loadpointFullConfig, 0, len(devices))
+		for _, dev := range devices {
+			c, err := loadpointConfig(dev)
+			if err != nil {
+				jsonError(w, http.StatusBadRequest, err)
+				return
+			}
+
+			res = append(res, c)
+		}
 
 		jsonWrite(w, res)
 	}
@@ -143,7 +156,11 @@ func loadpointConfigHandler() http.HandlerFunc {
 			return
 		}
 
-		res := loadpointConfig(dev)
+		res, err := loadpointConfig(dev)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
 
 		jsonWrite(w, res)
 	}

--- a/server/http_config_loadpoint_handler_test.go
+++ b/server/http_config_loadpoint_handler_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/evcc-io/evcc/util/templates"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadpointConfigDisabledNilInstance ensures loadpointConfig does not panic
+// for a disabled loadpoint whose instance was never created (nil loadpoint.API).
+func TestLoadpointConfigDisabledNilInstance(t *testing.T) {
+	conf := config.Config{
+		Class:      templates.Loadpoint,
+		Properties: config.Properties{Disable: true},
+		Data: map[string]any{
+			"charger": "wallbox",
+			"meter":   "lp-meter",
+			"title":   "Garage",
+		},
+	}
+
+	var instance loadpoint.API // nil: disabled loadpoint has no live instance
+	dev := config.NewConfigurableDevice(&conf, instance)
+
+	var res loadpointFullConfig
+	require.NotPanics(t, func() {
+		res = loadpointConfig(dev)
+	})
+
+	assert.True(t, res.Disable)
+	assert.Equal(t, "wallbox", res.Charger)
+	assert.Equal(t, "lp-meter", res.Meter)
+}
+
+// TestDeleteLoadpointDisabledNilInstance ensures deleteLoadpointHandler does not
+// dereference a nil instance when deleting a disabled loadpoint.
+func TestDeleteLoadpointDisabledNilInstance(t *testing.T) {
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+
+	conf, err := config.AddConfig(templates.Loadpoint,
+		map[string]any{"charger": "wallbox", "title": "Garage"},
+		config.WithProperties(config.Properties{Disable: true}),
+	)
+	require.NoError(t, err)
+
+	var instance loadpoint.API // nil: disabled loadpoint has no live instance
+	dev := config.NewConfigurableDevice(&conf, instance)
+	require.NoError(t, config.Loadpoints().Add(dev))
+	t.Cleanup(func() { _ = config.Loadpoints().Delete(config.NameForID(conf.ID)) })
+
+	req := httptest.NewRequest(http.MethodDelete, "/", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": strconv.Itoa(conf.ID)})
+	rec := httptest.NewRecorder()
+
+	require.NotPanics(t, func() {
+		deleteLoadpointHandler()(rec, req)
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/server/http_config_loadpoint_handler_test.go
+++ b/server/http_config_loadpoint_handler_test.go
@@ -33,7 +33,9 @@ func TestLoadpointConfigDisabledNilInstance(t *testing.T) {
 
 	var res loadpointFullConfig
 	require.NotPanics(t, func() {
-		res = loadpointConfig(dev)
+		var err error
+		res, err = loadpointConfig(dev)
+		require.NoError(t, err)
 	})
 
 	assert.True(t, res.Disable)


### PR DESCRIPTION
Disabled loadpoints are registered with a nil `loadpoint.API` instance. The config HTTP handlers dereferenced that instance unconditionally, so after a restart the config UI (GET), an update, or a delete of a disabled loadpoint panicked with a nil pointer dereference (the CI e2e failure on #29455).

Changes:
- `cmd/setup.go`: keep the disabled-loadpoint instance a true nil interface (`loadpoint.API`) instead of a typed-nil `*core.Loadpoint`, so `instance == nil` checks work.
- `loadpointConfig`: early-return decoding static/dynamic config from the database when no live instance exists.
- `updateLoadpointHandler`: skip `dynamic.Apply` when the instance is nil (takes effect on next restart).
- `deleteLoadpointHandler`: early-return deleting the loadpoint without charger/meter ref cleanup when the instance is nil.
- Regression tests for the config GET and delete paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
