### PR TITLE
Remote Access: user agent and status display fixes

### DIFF
--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -243,6 +243,7 @@ export default {
 				case "dimmed":
 				case "curtailed":
 				case "loginBlocked":
+				case "remoteEnabled":
 					return value
 						? this.$t("config.deviceValue.yes")
 						: this.$t("config.deviceValue.no");

--- a/assets/js/components/Config/Remote/RemoteModal.vue
+++ b/assets/js/components/Config/Remote/RemoteModal.vue
@@ -31,7 +31,10 @@
 						<span v-if="status.connected" class="text-primary">
 							{{ $t("config.remote.connected") }}
 						</span>
-						<span v-else class="text-muted small">
+						<span
+							v-else
+							:class="config.enabled ? 'text-danger' : 'small'"
+						>
 							{{ $t("config.remote.disconnected") }}
 						</span>
 					</div>

--- a/assets/js/components/Config/Remote/RemoteModal.vue
+++ b/assets/js/components/Config/Remote/RemoteModal.vue
@@ -31,10 +31,7 @@
 						<span v-if="status.connected" class="text-primary">
 							{{ $t("config.remote.connected") }}
 						</span>
-						<span
-							v-else
-							:class="config.enabled ? 'text-danger' : 'small'"
-						>
+						<span v-else :class="config.enabled ? 'text-danger' : 'small'">
 							{{ $t("config.remote.disconnected") }}
 						</span>
 					</div>

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -868,8 +868,11 @@ export default defineComponent({
 				return { configured: { value: false } };
 			}
 			const tags: DeviceTags = {
-				enabled: { value: remote.config?.enabled },
-				connected: { value: remote.status?.connected },
+				remoteEnabled: { value: remote.config?.enabled },
+				connected: {
+					value: remote.status?.connected,
+					error: remote.config?.enabled && !remote.status?.connected,
+				},
 			};
 			if (remote.status?.loginBlocked) {
 				tags["loginBlocked"] = { value: true, error: true };

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -877,7 +877,7 @@ export default defineComponent({
 			if (remote.status?.loginBlocked) {
 				tags["loginBlocked"] = { value: true, error: true };
 			}
-			if (remote.status?.connected) {
+			if (remote.config?.enabled) {
 				const lastSeen = remote.status?.lastSeen;
 				const count = lastSeen
 					? Object.keys(lastSeen).filter((u) => isRemoteClientActive(lastSeen, u)).length

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -235,6 +235,7 @@
       "price": "Preis",
       "productionLimited": "Erzeugung begrenzt",
       "range": "Reichweite",
+      "remoteEnabled": "Aktiviert",
       "returnEnergy": "Energie (rückwärts)",
       "singlePhase": "Einphasig",
       "soc": "Ladestand",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -235,6 +235,7 @@
       "price": "Price",
       "productionLimited": "Production limited",
       "range": "Range",
+      "remoteEnabled": "Enabled",
       "returnEnergy": "Energy (reverse)",
       "singlePhase": "Single phase",
       "soc": "Charge",

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -91,6 +91,7 @@ func (t *Tunnel) connect(ctx context.Context) (bool, error) {
 		HTTPHeader: http.Header{
 			"Authorization":   []string{"Bearer " + t.token},
 			"X-Sponsor-Token": []string{sponsor.Token},
+			"User-Agent":      []string{"evcc/" + util.FormattedVersion()},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
relates to #31604

Debugging findings from the linked issue: tunnel connects were not attributable to evcc versions in server logs, and the config card was misleading. "Ladebereit" label for the enabled state, no visual signal when the tunnel is down, and "Verbunden" was easy to misread as client connections.

- send `evcc/<version>` user agent on tunnel connect
- config card: own `remoteEnabled` label ("Enabled"/"Aktiviert") instead of charger-context "Ladebereit"
- config card: show "connected: no" in error style when remote access is enabled
- config card: always show active clients row when enabled, clarifies that "connected" means the server connection - modal: "not connected" in red when remote access is enabled

always show clients (even if 0)
<img width="466" height="363" alt="Bildschirmfoto 2026-07-10 um 18 30 10" src="https://github.com/user-attachments/assets/aa52d0e2-f1b9-44fb-87f0-fb8e1c8f50b6" />

not connected > red
<img width="451" height="333" alt="Bildschirmfoto 2026-07-10 um 18 28 54" src="https://github.com/user-attachments/assets/91477e8e-e874-462b-ab92-55f13e309a84" />

better enabled but not connected visual in modal
<img width="622" height="695" alt="Bildschirmfoto 2026-07-10 um 18 26 18" src="https://github.com/user-attachments/assets/2a430235-cadf-421d-8212-49218c395f0a" />
<img width="659" height="779" alt="Bildschirmfoto 2026-07-10 um 18 28 47" src="https://github.com/user-attachments/assets/6c7ec0ca-0dd2-4ef2-8baa-8350a25a3b36" />
