### PR TITLE
allow Claude issue agent to run on external issues

### DIFF
--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -25,6 +25,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Issues come from external users without write access; this workflow's
+          # token is scoped to labels/comments/PR only. Issue body is treated as
+          # untrusted data in the prompt.
+          allowed_non_write_users: '*'
           additional_permissions: |
             actions: read
           claude_args: '--allowed-tools "Bash(gh label list),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git status)"'


### PR DESCRIPTION
The Claude Issue Agent workflow failed on its first real trigger ([run 29111930701](https://github.com/evcc-io/evcc/actions/runs/29111930701)) with `User does not have write access on this repository`.

`claude-code-action` gates on the triggering actor having write access. Every external bug report is opened by a non-write user, so the triage agent never runs — the opposite of what the workflow is for.

Fix: pass `github_token` and set `allowed_non_write_users: '*'`. The token stays scoped to labels/comments/PR only, and the prompt already treats the issue body as untrusted data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
