### PR TITLE
Request only next 5 days/120 hours of price forecast from epex-predictor

### DIFF
--- a/templates/definition/tariff/epex-predictor.yaml
+++ b/templates/definition/tariff/epex-predictor.yaml
@@ -30,7 +30,7 @@ render: |
   {{ include "tariff-features" . }}
   forecast:
     source: http
-    uri: {{ .uri }}/prices?region={{ .region }}&unit=EUR_PER_KWH&timezone=UTC
+    uri: {{ .uri }}/prices?hours=120&region={{ .region }}&unit=EUR_PER_KWH&timezone=UTC
     jq: |
       [.prices[] | {
         "start": .startsAt,


### PR DESCRIPTION
Reduces response data volume from ~34kB to ~24kb by omitting data that is not displayed at the moment.