### PR TITLE
plugin: cache http responses from devices that omit the Date header

### DIFF
--- a/plugin/http.go
+++ b/plugin/http.go
@@ -115,6 +115,11 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 			Modifier: func(resp *http.Response) error {
 				dropCacheBusting(resp, "Cache-Control")
 				dropCacheBusting(resp, "Pragma")
+				// httpcache derives freshness from the response Date; stamp one
+				// for devices that omit it, else every read is treated as stale
+				if resp.Header.Get("Date") == "" {
+					resp.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+				}
 				return nil
 			},
 			Base: base,

--- a/plugin/http_test.go
+++ b/plugin/http_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,11 +17,26 @@ type httpHandler struct {
 	req          *http.Request
 	cnt          int
 	cacheBusting bool
+	noDate       bool
 }
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.req = req
 	h.val = lo.RandomString(16, lo.LettersCharset)
+
+	// emulate a device that omits the Date header (e.g. Zendure Solarflow)
+	if h.noDate {
+		conn, buf, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			panic(err)
+		}
+		defer conn.Close()
+		fmt.Fprintf(buf, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n%s", len(h.val), h.val)
+		buf.Flush()
+		h.cnt++
+		return
+	}
+
 	if h.cacheBusting {
 		w.Header().Set("Cache-Control", "no-store, no-cache, max-age=0, must-revalidate")
 		w.Header().Set("Pragma", "no-cache")
@@ -98,6 +114,30 @@ func (suite *httpTestSuite) TestCacheGetNoStore() {
 		suite.Require().NoError(err)
 		suite.Require().Equal(res, val)
 		suite.Require().Equal(first, suite.h.cnt)
+	}
+}
+
+func (suite *httpTestSuite) TestCacheGetNoDate() {
+	// upstream omits the Date header, cache must still take effect via injected Date
+	suite.h.noDate = true
+	defer func() { suite.h.noDate = false }()
+
+	uri := suite.srv.URL + "/foo/bar?baz=3"
+	p := NewHTTP(util.NewLogger("foo"), http.MethodGet, uri, false, time.Minute)
+
+	g, err := p.StringGetter()
+	suite.Require().NoError(err)
+
+	suite.h.cnt = 0
+	res, err := g()
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, suite.h.cnt)
+
+	for range 3 {
+		val, err := g()
+		suite.Require().NoError(err)
+		suite.Require().Equal(res, val)
+		suite.Require().Equal(1, suite.h.cnt)
 	}
 }
 


### PR DESCRIPTION
HTTP responses without a `Date` header are treated as permanently stale by the httpcache layer: `getFreshness` returns `stale` as soon as `Date(respHeaders)` fails, before the configured `max-age` is ever applied. Devices like the Zendure Solarflow return only `Content-Type` + `Content-Length`, so `cache:` never takes effect and every getter round-trips to the device — for a battery meter reading power/soc/limits from one endpoint that means N requests per poll, and rapid keep-alive reuse against such devices surfaces as `EOF` / `connection reset by peer`.

Fix: stamp a `Date` header in the response modifier when the origin omits one, so the configured cache duration produces real hits.

Added `TestCacheGetNoDate` (hijacks the connection to emulate a device that sends no `Date`); it fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)