### PR TITLE
esphome dlms/slimmelezer-luxembourg: address sensors by name on firmware 2026.1+

### DIFF
--- a/templates/definition/meter/esphome-dlms-austria.yaml
+++ b/templates/definition/meter/esphome-dlms-austria.yaml
@@ -18,20 +18,30 @@ params:
   - name: timeout
     default: 10s
     advanced: true
+  - name: firmware
+    type: choice
+    choice: ["<2026.1", ">=2026.1"]
+    default: "<2026.1"
+    description:
+      de: ESPHome Firmware-Version
+      en: ESPHome firmware version
+    help:
+      de: ESPHome ab 2026.1 adressiert Sensoren über den Entitätsnamen. Die alten /sensor/<object_id> URLs sind veraltet und werden in ESPHome 2026.7.0 entfernt. Wähle '>=2026.1', wenn dein Gerät ESPHome 2026.1 oder neuer verwendet.
+      en: ESPHome 2026.1+ addresses sensors by entity name. The legacy /sensor/<object_id> URLs are deprecated and will be removed in ESPHome 2026.7.0. Choose '>=2026.1' if your device runs ESPHome 2026.1 or newer.
 render: |
   type: custom
   power: # Total power: positive for consumption, negative for production (Watts)
     source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/active_power_taken_from_grid # ESPHome sensor: name: "Active power taken from grid"
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Active power taken from grid{{ else }}active_power_taken_from_grid{{ end }}
       headers:
       - content-type: application/json
       timeout: {{ .timeout }}
       jq: .value
       # No scale: value is already in Watts
     - source: http
-      uri: http://{{ .host }}/sensor/active_power_put_into_grid # ESPHome sensor: name: "Active power put into grid"
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Active power put into grid{{ else }}active_power_put_into_grid{{ end }}
       headers:
       - content-type: application/json
       timeout: {{ .timeout }}
@@ -39,7 +49,7 @@ render: |
       scale: -1 # Invert for production, value is already in Watts
   energy: # Total imported energy (kWh)
     source: http
-    uri: http://{{ .host }}/sensor/active_energy_taken_from_grid # ESPHome sensor: name: "Active energy taken from grid"
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Active energy taken from grid{{ else }}active_energy_taken_from_grid{{ end }}
     headers:
     - content-type: application/json
     timeout: {{ .timeout }}
@@ -47,38 +57,38 @@ render: |
     jq: .value
   currents: # Phase currents (Amperes)
   - source: http
-    uri: http://{{ .host }}/sensor/current_l1 # ESPHome sensor: name: "Current L1"
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Current L1{{ else }}current_l1{{ end }}
     headers:
     - content-type: application/json
     timeout: {{ .timeout }}
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/current_l2 # ESPHome sensor: name: "Current L2"
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Current L2{{ else }}current_l2{{ end }}
     headers:
     - content-type: application/json
     timeout: {{ .timeout }}
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/current_l3 # ESPHome sensor: name: "Current L3"
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Current L3{{ else }}current_l3{{ end }}
     headers:
     - content-type: application/json
     timeout: {{ .timeout }}
     jq: .value
   voltages: # Phase voltages (Volts)
   - source: http
-    uri: http://{{ .host }}/sensor/voltage_l1 # ESPHome sensor: name: "Voltage L1"
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Voltage L1{{ else }}voltage_l1{{ end }}
     headers:
     - content-type: application/json
     timeout: {{ .timeout }}
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/voltage_l2 # ESPHome sensor: name: "Voltage L2"
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Voltage L2{{ else }}voltage_l2{{ end }}
     headers:
     - content-type: application/json
     timeout: {{ .timeout }}
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/voltage_l3 # ESPHome sensor: name: "Voltage L3"
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Voltage L3{{ else }}voltage_l3{{ end }}
     headers:
     - content-type: application/json
     timeout: {{ .timeout }}

--- a/templates/definition/meter/slimmelezer-luxembourg.yaml
+++ b/templates/definition/meter/slimmelezer-luxembourg.yaml
@@ -11,42 +11,52 @@ params:
   - name: usage
     choice: ["grid"]
   - name: host
+  - name: firmware
+    type: choice
+    choice: ["<2026.1", ">=2026.1"]
+    default: "<2026.1"
+    description:
+      de: ESPHome Firmware-Version
+      en: ESPHome firmware version
+    help:
+      de: ESPHome ab 2026.1 adressiert Sensoren über den Entitätsnamen. Die alten /sensor/<object_id> URLs sind veraltet und werden in ESPHome 2026.7.0 entfernt. Wähle '>=2026.1', wenn dein Gerät ESPHome 2026.1 oder neuer verwendet.
+      en: ESPHome 2026.1+ addresses sensors by entity name. The legacy /sensor/<object_id> URLs are deprecated and will be removed in ESPHome 2026.7.0. Choose '>=2026.1' if your device runs ESPHome 2026.1 or newer.
 render: |
   type: custom
   power:
     source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_consumed
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Consumed{{ else }}power_consumed{{ end }}
       headers:
       - content-type: application/json
       jq: .value
       scale: 1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_produced
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Produced{{ else }}power_produced{{ end }}
       headers:
       - content-type: application/json
       jq: .value
       scale: -1000
   energy:
     source: http
-    uri: http://{{ .host }}/sensor/energy_produced_luxembourg
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Energy Produced Luxembourg{{ else }}energy_produced_luxembourg{{ end }}
     headers:
     - content-type: application/json
     jq: .value
   currents:
   - source: http
-    uri: http://{{ .host }}/sensor/current_phase_1
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Current Phase 1{{ else }}current_phase_1{{ end }}
     headers:
     - content-type: application/json
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/current_phase_2
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Current Phase 2{{ else }}current_phase_2{{ end }}
     headers:
     - content-type: application/json
     jq: .value
   - source: http
-    uri: http://{{ .host }}/sensor/current_phase_3
+    uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Current Phase 3{{ else }}current_phase_3{{ end }}
     headers:
     - content-type: application/json
     jq: .value
@@ -54,13 +64,13 @@ render: |
   - source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_produced_phase_1
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Produced Phase 1{{ else }}power_produced_phase_1{{ end }}
       headers:
       - content-type: application/json
       jq: .value
       scale: -1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_consumed_phase_1
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Consumed Phase 1{{ else }}power_consumed_phase_1{{ end }}
       headers:
       - content-type: application/json
       jq: .value
@@ -68,13 +78,13 @@ render: |
   - source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_produced_phase_2
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Produced Phase 2{{ else }}power_produced_phase_2{{ end }}
       headers:
       - content-type: application/json
       jq: .value
       scale: -1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_consumed_phase_2
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Consumed Phase 2{{ else }}power_consumed_phase_2{{ end }}
       headers:
       - content-type: application/json
       jq: .value
@@ -82,13 +92,13 @@ render: |
   - source: calc
     add:
     - source: http
-      uri: http://{{ .host }}/sensor/power_produced_phase_3
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Produced Phase 3{{ else }}power_produced_phase_3{{ end }}
       headers:
       - content-type: application/json
       jq: .value
       scale: -1000
     - source: http
-      uri: http://{{ .host }}/sensor/power_consumed_phase_3
+      uri: http://{{ .host }}/sensor/{{ if eq .firmware ">=2026.1" }}Power Consumed Phase 3{{ else }}power_consumed_phase_3{{ end }}
       headers:
       - content-type: application/json
       jq: .value


### PR DESCRIPTION
fixes #31671

ESPHome 2026.1 exposes web-server sensors under their entity name; the legacy `/sensor/<object_id>` URLs are deprecated and removed in 2026.7.0. Templates hitting the old paths stop working after the update.

Adds a `firmware` choice param (`<2026.1` / `>=2026.1`, default `<2026.1`) that switches each sensor path between the old object_id and the entity name — same pattern already used by `slimmelezer-V2`. Default keeps existing (older-firmware) setups working unchanged.

- `esphome-dlms-austria.yaml` — entity names from the issue mapping / template comments (`Active power taken from grid`, `Current L1`, …)
- `slimmelezer-luxembourg.yaml` — entity names verified against the Zuidwijk `slimmelezer.yaml` config (`Power Consumed`, `Current Phase 1`, `Energy Produced Luxembourg`, …)

Plain `slimmelezer.yaml` left untouched: its object_ids match no known Zuidwijk config and the ESPHome `dsmr` component sets no default sensor names, so the 2026.1+ entity names are user-defined and can't be derived. Zuidwijk devices are already covered by `slimmelezer-V2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
