### PR TITLE
chore: surface Claude issue agent errors via show_full_output

### DIFF
--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # surface the underlying API error when a run fails on the first turn
+          show_full_output: true
           # Issues come from external users without write access; this workflow's
           # token is scoped to labels/comments/PR only. Issue body is treated as
           # untrusted data in the prompt.


### PR DESCRIPTION
The Claude issue agent produces no comment/label/PR when a run fails on the first API turn. In [run 29145433199](https://github.com/evcc-io/evcc/actions/runs/29145433199/job/86526071286) the SDK reported only:

```json
{ "type":"result", "is_error":true, "num_turns":1, "total_cost_usd":0, "duration_ms":2108 }
```

No assistant output, \$0 billed — the very first API request was rejected — but the real error is suppressed (`Running Claude Code via SDK (full output hidden for security)`). Auth is fine: the same `CLAUDE_CODE_OAUTH_TOKEN` succeeded in `claude-code-review-run.yml` ~2h earlier, so this is not an expired token.

`show_full_output: true` makes the underlying API error visible in the job log so the actual cause (rate/usage limit, model entitlement, etc.) can be diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)