### PR TITLE
askoheat: add aux meter template

### DIFF
--- a/templates/definition/meter/askoheat.yaml
+++ b/templates/definition/meter/askoheat.yaml
@@ -12,13 +12,6 @@ params:
     default: 502
   - name: id
     default: 1
-  - name: tempsensor
-    type: choice
-    choice: ["0", "1", "2", "3", "4"]
-    default: "0"
-    description:
-      de: Temperatursensor
-      en: Temperature sensor
 render: |
   type: custom
   power:
@@ -29,11 +22,3 @@ render: |
       address: 317
       type: input
       encoding: uint16
-  soc:
-    source: modbus
-    uri: {{ .host }}:{{ .port }}
-    id: {{ .id }}
-    register:
-      address: {{ add 325 (mul (int .tempsensor) 2) }}
-      type: input
-      encoding: float32

--- a/templates/definition/meter/askoheat.yaml
+++ b/templates/definition/meter/askoheat.yaml
@@ -1,0 +1,39 @@
+template: askoheat
+products:
+  - brand: Askoma
+    description:
+      generic: ASKOHEAT+
+group: heating
+params:
+  - name: usage
+    choice: ["aux"]
+  - name: host
+  - name: port
+    default: 502
+  - name: id
+    default: 1
+  - name: tempsensor
+    type: choice
+    choice: ["0", "1", "2", "3", "4"]
+    default: "0"
+    description:
+      de: Temperatursensor
+      en: Temperature sensor
+render: |
+  type: custom
+  power:
+    source: modbus
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    register:
+      address: 317
+      type: input
+      encoding: uint16
+  soc:
+    source: modbus
+    uri: {{ .host }}:{{ .port }}
+    id: {{ .id }}
+    register:
+      address: {{ add 325 (mul (int .tempsensor) 2) }}
+      type: input
+      encoding: float32


### PR DESCRIPTION
Closes #31613

Adds an ASKOHEAT+ **aux meter** template so an autonomously-controlled unit can be integrated as a consumer (aux) meter for monitoring — consistent with the existing my-PV `ac-elwa-e` / `ac-elwa-2` meter templates and the Fronius Ohmpilot mentioned in the issue.

Users who run the ASKOHEAT+ on its own internal scheduling (e.g. midday-only heating) can now surface its power and water temperature on the evcc dashboard without letting evcc actively control it (the `askoheat` charger template covers the control case).

Reads via Modbus TCP:
- `power` — register 317 (uint16)
- `soc` (water temperature) — register 325 + selectable sensor offset (float32)

`go test ./meter/ -run TestTemplates` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)