### PR TITLE
pv: reserve surplus for higher-priority loadpoints starting up (#31194)

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1027,6 +1027,21 @@ func (lp *Loadpoint) charging() bool {
 	return lp.GetStatus() == api.StatusC
 }
 
+// pvChargeStarting reports a PV loadpoint claiming surplus but not yet drawing it
+// (enable timer running, or enabled but not yet charging). See #31194.
+func (lp *Loadpoint) pvChargeStarting() bool {
+	if lp.GetMode() != api.ModePV || !lp.connected() {
+		return false
+	}
+
+	lp.RLock()
+	enabled, timer := lp.enabled, lp.pvTimer
+	lp.RUnlock()
+
+	// enable timer running (not yet enabled), or enabled but vehicle not yet charging
+	return (!enabled && !timer.IsZero()) || (enabled && !lp.charging())
+}
+
 // setStatus updates the internal charging state according to EV
 func (lp *Loadpoint) setStatus(status api.ChargeStatus) {
 	lp.Lock()

--- a/core/site.go
+++ b/core/site.go
@@ -1011,6 +1011,32 @@ func (site *Site) updateLoadpoints(rates api.Rates) float64 {
 	return sum
 }
 
+// reservedPVPower returns the anticipated surplus claimed by higher-priority PV loadpoints
+// that are starting up, so lower-priority loadpoints defer enabling against it (#31194).
+func (site *Site) reservedPVPower(lp updater) float64 {
+	if lp.GetMode() != api.ModePV {
+		return 0
+	}
+
+	prio := lp.EffectivePriority()
+
+	var reserved float64
+	for _, other := range site.loadpoints {
+		if any(other) == any(lp) {
+			continue
+		}
+		if other.EffectivePriority() > prio && other.pvChargeStarting() {
+			reserved += other.EffectiveMaxPower()
+		}
+	}
+
+	if reserved > 0 {
+		site.log.DEBUG.Printf("lp %s reserves %.0fW for higher-priority loadpoints starting up", lp.GetTitle(), reserved)
+	}
+
+	return reserved
+}
+
 func (site *Site) update(lp updater) {
 	site.log.DEBUG.Println("----")
 
@@ -1081,6 +1107,9 @@ func (site *Site) update(lp updater) {
 
 		// TODO
 		if lp != nil {
+			// reserve surplus claimed by higher-priority loadpoints that are starting up (#31194)
+			sitePower += site.reservedPVPower(lp)
+
 			lp.Update(
 				sitePower, max(0, site.battery.Power), consumption, feedin, batteryBuffered, batteryStart,
 				greenShareLoadpoints, site.effectivePrice(greenShareLoadpoints), site.effectiveCo2(greenShareLoadpoints),

--- a/core/site_prioritize_test.go
+++ b/core/site_prioritize_test.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/util"
+)
+
+func newPVLoadpoint(prio int, mode api.ChargeMode, status api.ChargeStatus, enabled bool, timer time.Time) *Loadpoint {
+	return &Loadpoint{
+		log:        util.NewLogger("lp"),
+		clock:      clock.NewMock(),
+		minCurrent: minA,
+		maxCurrent: maxA,
+		phases:     1,
+		mode:       mode,
+		status:     status,
+		enabled:    enabled,
+		pvTimer:    timer,
+		priority:   prio,
+	}
+}
+
+func TestPvChargeStarting(t *testing.T) {
+	now := clock.NewMock().Now()
+
+	tc := []struct {
+		name     string
+		lp       *Loadpoint
+		starting bool
+	}{
+		{"enable timer running", newPVLoadpoint(0, api.ModePV, api.StatusB, false, now), true},
+		{"enabled not charging", newPVLoadpoint(0, api.ModePV, api.StatusB, true, time.Time{}), true},
+		{"enabled and charging", newPVLoadpoint(0, api.ModePV, api.StatusC, true, time.Time{}), false},
+		{"disabled idle", newPVLoadpoint(0, api.ModePV, api.StatusB, false, time.Time{}), false},
+		{"disconnected", newPVLoadpoint(0, api.ModePV, api.StatusA, false, now), false},
+		{"not pv mode", newPVLoadpoint(0, api.ModeNow, api.StatusB, false, now), false},
+	}
+
+	for _, tc := range tc {
+		if got := tc.lp.pvChargeStarting(); got != tc.starting {
+			t.Errorf("%s: want %v, got %v", tc.name, tc.starting, got)
+		}
+	}
+}
+
+func TestReservedPVPower(t *testing.T) {
+	Voltage = 230
+
+	// higher-priority loadpoint (prio 1) starting up
+	high := newPVLoadpoint(1, api.ModePV, api.StatusB, false, clock.NewMock().Now())
+	// lower-priority loadpoint (prio 0) in PV mode
+	low := newPVLoadpoint(0, api.ModePV, api.StatusB, false, time.Time{})
+
+	site := &Site{
+		log:        util.NewLogger("site"),
+		loadpoints: []*Loadpoint{high, low},
+	}
+
+	// low reserves high's anticipated max power while high is starting up
+	if got, want := site.reservedPVPower(low), high.EffectiveMaxPower(); got != want {
+		t.Errorf("low: want %.0f, got %.0f", want, got)
+	}
+
+	// high (top priority) reserves nothing
+	if got := site.reservedPVPower(high); got != 0 {
+		t.Errorf("high: want 0, got %.0f", got)
+	}
+
+	// once high is charging it no longer reserves surplus from low
+	high.status = api.StatusC
+	high.enabled = true
+	high.pvTimer = time.Time{}
+	if got := site.reservedPVPower(low); got != 0 {
+		t.Errorf("low after high charging: want 0, got %.0f", got)
+	}
+}
+
+var _ loadpoint.API = (*Loadpoint)(nil)


### PR DESCRIPTION
Addresses #31194.

In PV mode with insufficient surplus for all loadpoints, each loadpoint arms its enable timer against the same total surplus and they all start simultaneously. The prioritizer then reclaims the lower-priority loadpoints' power for the higher-priority one and throttles them back down, producing relay chatter on the lower-priority charger (see the logs in the issue). Tuning the enable delays cannot fix this, since with equal delays both timers always cross zero together.

This reserves the anticipated max power of higher-priority PV loadpoints that are *starting up* — enable timer running, or enabled but the vehicle not yet drawing — from the surplus a lower-priority loadpoint sees. The lower-priority loadpoint then defers enabling until the higher-priority ones have settled. Once a higher-priority loadpoint is actually charging, its real draw is reflected in the grid meter and the reservation drops away, so steady-state behaviour and the existing flexible-power reclaim are unchanged.

This is a pragmatic step, not the full demand-planning strategy discussed in the issue; it only sequences PV startup by priority. Same-priority behaviour (#31071) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)