### PR TITLE
plugin: fix flaky TestCacheGetNoDate race

### DIFF
--- a/plugin/http_test.go
+++ b/plugin/http_test.go
@@ -31,9 +31,11 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			panic(err)
 		}
 		defer conn.Close()
+		// increment before flushing: the client returns as soon as it reads the body,
+		// so counting after the flush races with the test asserting on cnt
+		h.cnt++
 		fmt.Fprintf(buf, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %d\r\n\r\n%s", len(h.val), h.val)
 		buf.Flush()
-		h.cnt++
 		return
 	}
 


### PR DESCRIPTION
The `noDate` hijack branch in the http plugin test handler incremented the request counter *after* flushing the response body. The client returns from the getter as soon as it has read the body, so the test could reach the `cnt == 1` assertion (`plugin/http_test.go:134`) before the handler goroutine ran `cnt++` — a data race and a nondeterministic `cnt == 0` failure. The normal (non-hijack) path is unaffected because Go's http server only sends the body after `ServeHTTP` returns.

Fix: increment before flushing so the count is established before the client can observe the body.

Verified: `go test -race ./plugin/ -run TestHttp -count=20` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)