### PR TITLE
server: guard nil loadpoint instance in deleteDeviceHandler ref cleanup

### DIFF
--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -598,7 +598,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 			// cleanup references
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetChargerRef() == config.NameForID(id) {
+				if lp != nil && lp.GetChargerRef() == config.NameForID(id) {
 					lp.SetChargerRef("")
 				}
 			}
@@ -627,7 +627,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetMeterRef() == name {
+				if lp != nil && lp.GetMeterRef() == name {
 					lp.SetMeterRef("")
 				}
 			}
@@ -638,7 +638,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 			// cleanup references
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetDefaultVehicleRef() == config.NameForID(id) {
+				if lp != nil && lp.GetDefaultVehicleRef() == config.NameForID(id) {
 					lp.SetDefaultVehicleRef("")
 				}
 			}
@@ -649,7 +649,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 			// cleanup references
 			for _, dev := range h.Devices() {
 				lp := dev.Instance()
-				if lp.GetCircuitRef() == config.NameForID(id) {
+				if lp != nil && lp.GetCircuitRef() == config.NameForID(id) {
 					lp.SetCircuitRef("")
 				}
 			}


### PR DESCRIPTION
The charger/meter/vehicle/circuit reference-cleanup loops in `deleteDeviceHandler` call `GetXRef()` on `dev.Instance()` for every loadpoint, without a nil check. A disabled loadpoint (or one that failed to build, e.g. a broken meter after restart) registers a nil `loadpoint.API` instance, so the method call panics and the delete request 500s. In the config UI this surfaces as a device modal that never closes after pressing Delete.

Fix: skip loadpoints whose instance is nil in all four cleanup loops.

This unblocks the `config-fatals.spec.ts` › *broken loadpoint meter* e2e test, which fails at the meter-delete step once #31664 makes the disabled-loadpoint instance a true nil interface (on current master it is a typed nil `*core.Loadpoint`, so the guard is a no-op there). Verified locally: the e2e passes with #31664 + this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)