### PR TITLE
IDM: remove thermal energy register

### DIFF
--- a/templates/definition/charger/idm.yaml
+++ b/templates/definition/charger/idm.yaml
@@ -31,13 +31,6 @@ render: |
       type: holding
       decode: float32s
     scale: 1000
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 4128
-      type: holding
-      decode: float32s
   {{- if .tempsource }}
   temp:
     source: modbus


### PR DESCRIPTION
The IDM heat pump template read Modbus register `4128` as `energy`, but per the iDM Modbus documentation `4128` is **thermal** energy, not electrical. This made the evcc history show thermal energy in place of the electrical consumption (#28717).

iDM heat pumps expose no electrical-energy register, so `energy` is removed. The electrical `power` reading (register `4122`, "aktuelle Aufnahmeleistung") is kept, so evcc can derive/accumulate electrical energy from power itself.

fixes #28717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
