### PR TITLE
Site: drop dangling meter references on boot

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -186,6 +187,10 @@ func (site *Site) Boot(log *util.Logger, loadpoints []*Loadpoint, tariffs *tarif
 		site.circuit = c
 	}
 
+	// drop references to meters that no longer exist (e.g. deleted via UI) to
+	// avoid an unrecoverable boot failure, see #31698
+	site.dropMissingMeterRefs()
+
 	// grid meter
 	if site.Meters.GridMeterRef != "" {
 		dev, err := config.Meters().ByName(site.Meters.GridMeterRef)
@@ -336,6 +341,43 @@ func (site *Site) restoreMetersAndTitle() {
 	}
 	if v, err := settings.String(keys.ConsumerMeters); err == nil && v != "" {
 		site.Meters.ConsumerMetersRef = append(site.Meters.ConsumerMetersRef, filterConfigurable(strings.Split(v, ","))...)
+	}
+}
+
+// dropMissingMeterRefs removes meter references pointing to devices that no longer
+// exist (e.g. deleted via UI) and persists the cleanup, see #31698
+func (site *Site) dropMissingMeterRefs() {
+	exists := func(ref string) bool {
+		_, err := config.Meters().ByName(ref)
+		return err == nil
+	}
+
+	if ref := site.GetGridMeterRef(); ref != "" && !exists(ref) {
+		site.log.WARN.Printf("grid meter %s not found, removing reference", ref)
+		site.SetGridMeterRef("")
+	}
+
+	for _, m := range []struct {
+		get func() []string
+		set func([]string)
+	}{
+		{site.GetPVMeterRefs, site.SetPVMeterRefs},
+		{site.GetBatteryMeterRefs, site.SetBatteryMeterRefs},
+		{site.GetExtMeterRefs, site.SetExtMeterRefs},
+		{site.GetAuxMeterRefs, site.SetAuxMeterRefs},
+		{site.GetConsumerMeterRefs, site.SetConsumerMeterRefs},
+	} {
+		refs := m.get()
+		valid := slices.DeleteFunc(slices.Clone(refs), func(ref string) bool {
+			if exists(ref) {
+				return false
+			}
+			site.log.WARN.Printf("meter %s not found, removing reference", ref)
+			return true
+		})
+		if len(valid) != len(refs) {
+			m.set(valid)
+		}
 	}
 }
 

--- a/core/site_meterref_test.go
+++ b/core/site_meterref_test.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDropMissingMeterRefs verifies that references to meters which no longer
+// exist are removed so the site can boot instead of crashing (see #31698).
+func TestDropMissingMeterRefs(t *testing.T) {
+	config.Reset()
+
+	// register a single existing meter
+	require.NoError(t, config.Meters().Add(
+		config.NewStaticDevice(config.Named{Name: "db:1"}, api.Meter(nil)),
+	))
+
+	site := &Site{log: util.NewLogger("site")}
+	site.Meters.GridMeterRef = "db:99"                  // missing
+	site.Meters.PVMetersRef = []string{"db:1", "db:98"} // one existing, one missing
+	site.Meters.BatteryMetersRef = []string{"db:1"}     // existing
+
+	site.dropMissingMeterRefs()
+
+	assert.Empty(t, site.Meters.GridMeterRef, "missing grid ref should be dropped")
+	assert.Equal(t, []string{"db:1"}, site.Meters.PVMetersRef, "missing pv ref should be dropped")
+	assert.Equal(t, []string{"db:1"}, site.Meters.BatteryMetersRef, "existing ref should be kept")
+}


### PR DESCRIPTION
fixes #31698

Deleting or replacing a grid meter in the UI could leave a stale meter reference in the settings (e.g. `gridMeter=db:13` pointing to a device that no longer exists). On the next boot `config.Meters().ByName` fails and the site aborts with `failed booting site: not found: db:13`, dropping evcc into a restart loop with no UI to recover from — the only fix was hand-editing `evcc.db`.

Boot now validates every meter reference (grid, pv, battery, ext, aux, consumer) against the configured devices and drops the dangling ones, logging a warning and persisting the cleanup. The site boots normally and the user can reassign the meter in the UI.

Adds `TestDropMissingMeterRefs` covering the drop/keep behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)