### PR TITLE
CI: add /build and /nightly commands to build PR binaries and docker image

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,7 +1,11 @@
 name: PR Build
 
-# Triggered by a maintainer commenting `/build` on a pull request.
-# Builds the PR head, uploads downloadable binaries and publishes a docker image tagged pr-<number>.
+# Triggered by a maintainer commenting on a pull request:
+#   /build          binaries (amd64/arm64/arm) + multiarch docker
+#   /build amd      linux amd64 only
+#   /build arm      linux arm64 + arm/v6 only
+#   /build docker   multiarch docker image only, no binaries
+# Uploads downloadable binaries and publishes a docker image tagged pr-<number>.
 
 on:
   issue_comment:
@@ -24,6 +28,8 @@ jobs:
       pull-requests: write
     outputs:
       sha: ${{ steps.pr.outputs.sha }}
+      archs: ${{ steps.parse.outputs.archs }}
+      platforms: ${{ steps.parse.outputs.platforms }}
     steps:
       - name: React to comment
         uses: actions/github-script@v8
@@ -36,20 +42,39 @@ jobs:
               content: 'eyes',
             });
 
+      - name: Parse target
+        id: parse
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          arg=$(printf '%s' "$BODY" | awk '{print $2}' | tr '[:upper:]' '[:lower:]')
+          case "$arg" in
+            amd*)    archs='["amd64"]';              platforms='linux/amd64' ;;
+            arm*)    archs='["arm64","arm"]';        platforms='linux/arm64,linux/arm/v6' ;;
+            docker*) archs='[]';                     platforms='linux/amd64,linux/arm64,linux/arm/v6' ;;
+            *)       archs='["amd64","arm64","arm"]'; platforms='linux/amd64,linux/arm64,linux/arm/v6' ;;
+          esac
+          echo "archs=$archs" >> "$GITHUB_OUTPUT"
+          echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
+
       - name: Resolve PR head
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid -q .headRefOid)
-          echo "sha=$sha" >> $GITHUB_OUTPUT
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
   binaries:
     name: Binaries
     needs: prep
+    if: needs.prep.outputs.archs != '[]'
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       contents: read
+    strategy:
+      matrix:
+        arch: ${{ fromJSON(needs.prep.outputs.archs) }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -70,22 +95,24 @@ jobs:
       - name: Build UI
         run: make install-ui ui
 
-      - name: Build binaries
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
-        with:
-          version: '~> v2'
-          args: --snapshot -f .goreleaser-nightly.yml --clean
+      - name: Build binary
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: ${{ matrix.arch }}
+          GOARM: 6
+          SHA: ${{ needs.prep.outputs.sha }}
+          NUM: ${{ github.event.issue.number }}
+        run: |
+          go build -trimpath -tags release \
+            -ldflags "-X github.com/evcc-io/evcc/util.Version=pr-${NUM}-${SHA:0:7} -X github.com/evcc-io/evcc/util.Commit=${SHA:0:7} -s -w" \
+            -o "evcc-linux-${{ matrix.arch }}" .
 
-      - name: Upload binaries
+      - name: Upload binary
         uses: actions/upload-artifact@v7
         with:
-          name: evcc-pr-${{ github.event.issue.number }}-binaries
-          path: |
-            release/*.tar.gz
-            release/*.zip
-            release/checksums.txt
+          name: evcc-pr-${{ github.event.issue.number }}-linux-${{ matrix.arch }}
+          path: evcc-linux-${{ matrix.arch }}
           retention-days: 14
 
   docker:
@@ -114,7 +141,7 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v6
+          platforms: ${{ needs.prep.outputs.platforms }}
           push: true
           tags: evcc/evcc:pr-${{ github.event.issue.number }}
           cache-from: type=gha
@@ -132,12 +159,20 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const ok = '${{ needs.binaries.result }}' === 'success' && '${{ needs.docker.result }}' === 'success';
+            const b = '${{ needs.binaries.result }}';
+            const d = '${{ needs.docker.result }}';
+            const ok = d === 'success' && (b === 'success' || b === 'skipped');
             const num = context.payload.issue.number;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = ok
-              ? `✅ Build finished.\n\n- Binaries: [download artifact](${runUrl}#artifacts)\n- Docker: \`docker pull evcc/evcc:pr-${num}\``
-              : `❌ Build failed. See the [run logs](${runUrl}).`;
+            let body;
+            if (ok) {
+              const lines = ['✅ Build finished.', ''];
+              if (b === 'success') lines.push(`- Binaries: [download artifacts](${runUrl}#artifacts)`);
+              lines.push(`- Docker: \`docker pull evcc/evcc:pr-${num}\``);
+              body = lines.join('\n');
+            } else {
+              body = `❌ Build failed. See the [run logs](${runUrl}).`;
+            }
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -245,6 +245,8 @@ jobs:
     if: always() && needs.prep.result == 'success' && needs.prep.outputs.cmd != 'help'
     runs-on: depot-ubuntu-24.04-arm
     permissions:
+      contents: read
+      issues: write
       pull-requests: write
     steps:
       - name: Comment result
@@ -253,30 +255,39 @@ jobs:
           script: |
             const cmd = '${{ needs.prep.outputs.cmd }}';
             const num = context.payload.issue.number;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            let body;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            // build a uniform (ok, artifacts) view for both commands
+            let ok, artifacts, label;
             if (cmd === 'nightly') {
-              if ('${{ needs.nightly.result }}' === 'success') {
-                body = ['✅ Nightly build finished.', '', `- Packages: [download artifacts](${runUrl}#artifacts)`].join('\n');
-              } else {
-                body = `❌ Nightly build failed. See the [run logs](${runUrl}).`;
-              }
+              ok = '${{ needs.nightly.result }}' === 'success';
+              artifacts = [`- Packages: [download artifacts](${runUrl}#artifacts)`];
+              label = 'Nightly packages';
             } else {
               const b = '${{ needs.binaries.result }}';
               const d = '${{ needs.docker.result }}';
-              const ok = d === 'success' && (b === 'success' || b === 'skipped');
-              if (ok) {
-                const lines = ['✅ Build finished.', ''];
-                if (b === 'success') lines.push(`- Binaries: [download artifacts](${runUrl}#artifacts)`);
-                lines.push(`- Docker: \`docker pull evcc/evcc:pr-${num}\``);
-                body = lines.join('\n');
-              } else {
-                body = `❌ Build failed. See the [run logs](${runUrl}).`;
-              }
+              ok = d === 'success' && (b === 'success' || b === 'skipped');
+              artifacts = [];
+              if (b === 'success') artifacts.push(`- Binaries: [download artifacts](${runUrl}#artifacts)`);
+              artifacts.push(`- Docker: \`docker pull evcc/evcc:pr-${num}\``);
+              label = 'Test binaries';
             }
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: num,
-              body,
-            });
+
+            const heading = cmd === 'nightly' ? 'Nightly build' : 'Build';
+            const prBody = ok
+              ? [`✅ ${heading} finished.`, '', ...artifacts].join('\n')
+              : `❌ ${heading} failed. See the [run logs](${runUrl}).`;
+            await github.rest.issues.createComment({ owner, repo, issue_number: num, body: prBody });
+
+            if (!ok) return;
+
+            // notify each issue this PR closes (via "fixes #N" keywords) that fresh builds exist
+            const q = `query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){closingIssuesReferences(first:20){nodes{number}}}}}`;
+            const res = await github.graphql(q, { owner, repo, num });
+            const issues = res.repository.pullRequest.closingIssuesReferences.nodes.map((n) => n.number);
+            for (const issue_number of issues) {
+              const body = [`${label} for the fix in #${num} are ready to test:`, '', ...artifacts].join('\n');
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -6,6 +6,7 @@ name: PR Build
 #   /build arm      linux arm64 + arm/v6 only
 #   /build docker   multiarch docker image only, no binaries
 #   /nightly        nightly packages (.deb/.tar.gz) built from the PR head
+#   /help           post the command reference as a comment, build nothing
 # Uploads downloadable binaries/packages and publishes a docker image tagged pr-<number>.
 
 on:
@@ -18,10 +19,10 @@ permissions:
 jobs:
   prep:
     name: Prepare
-    # only on PR comments starting with /build or /nightly, and only from maintainers
+    # only on PR comments starting with /build, /nightly or /help, and only from maintainers
     if: |
       github.event.issue.pull_request &&
-      (startsWith(github.event.comment.body, '/build') || startsWith(github.event.comment.body, '/nightly')) &&
+      (startsWith(github.event.comment.body, '/build') || startsWith(github.event.comment.body, '/nightly') || startsWith(github.event.comment.body, '/help')) &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: depot-ubuntu-24.04-arm
     permissions:
@@ -59,6 +60,7 @@ jobs:
           esac
           case "$cmd" in
             /nightly) echo "cmd=nightly" >> "$GITHUB_OUTPUT" ;;
+            /help)    echo "cmd=help"    >> "$GITHUB_OUTPUT" ;;
             *)        echo "cmd=build"   >> "$GITHUB_OUTPUT" ;;
           esac
           echo "archs=$archs" >> "$GITHUB_OUTPUT"
@@ -202,10 +204,45 @@ jobs:
             release/*.tar.gz
           retention-days: 14
 
+  help:
+    name: Help
+    needs: prep
+    if: needs.prep.outputs.cmd == 'help'
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment command reference
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = [
+              '### PR build commands',
+              '',
+              'Maintainer-only slash commands. All build from the PR head commit and reply with the result.',
+              '',
+              '| Comment | What it builds |',
+              '| --- | --- |',
+              '| `/build` | Linux binaries (amd64 + arm64 + arm/v6) **and** the multi-arch docker image |',
+              '| `/build amd` | linux amd64 binary only |',
+              '| `/build arm` | linux arm64 + arm/v6 binaries only |',
+              '| `/build docker` | multi-arch docker image only, no binaries |',
+              '| `/nightly` | nightly `.deb` / `.tar.gz` packages (goreleaser snapshot) |',
+              '| `/help` | this reference |',
+              '',
+              'Binaries and packages are uploaded as run artifacts (14-day retention); the docker image is pushed as `evcc/evcc:pr-<number>`.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });
+
   report:
     name: Report
     needs: [prep, binaries, docker, nightly]
-    if: always() && needs.prep.result == 'success'
+    if: always() && needs.prep.result == 'success' && needs.prep.outputs.cmd != 'help'
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,7 +5,8 @@ name: PR Build
 #   /build amd      linux amd64 only
 #   /build arm      linux arm64 + arm/v6 only
 #   /build docker   multiarch docker image only, no binaries
-# Uploads downloadable binaries and publishes a docker image tagged pr-<number>.
+#   /nightly        nightly packages (.deb/.tar.gz) built from the PR head
+# Uploads downloadable binaries/packages and publishes a docker image tagged pr-<number>.
 
 on:
   issue_comment:
@@ -17,10 +18,10 @@ permissions:
 jobs:
   prep:
     name: Prepare
-    # only on PR comments starting with /build, and only from maintainers
+    # only on PR comments starting with /build or /nightly, and only from maintainers
     if: |
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/build') &&
+      (startsWith(github.event.comment.body, '/build') || startsWith(github.event.comment.body, '/nightly')) &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: depot-ubuntu-24.04-arm
     permissions:
@@ -28,6 +29,7 @@ jobs:
       pull-requests: write
     outputs:
       sha: ${{ steps.pr.outputs.sha }}
+      cmd: ${{ steps.parse.outputs.cmd }}
       archs: ${{ steps.parse.outputs.archs }}
       platforms: ${{ steps.parse.outputs.platforms }}
     steps:
@@ -47,12 +49,17 @@ jobs:
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
+          cmd=$(printf '%s' "$BODY" | awk '{print $1}')
           arg=$(printf '%s' "$BODY" | awk '{print $2}' | tr '[:upper:]' '[:lower:]')
           case "$arg" in
             amd*)    archs='["amd64"]';              platforms='linux/amd64' ;;
             arm*)    archs='["arm64","arm"]';        platforms='linux/arm64,linux/arm/v6' ;;
             docker*) archs='[]';                     platforms='linux/amd64,linux/arm64,linux/arm/v6' ;;
             *)       archs='["amd64","arm64","arm"]'; platforms='linux/amd64,linux/arm64,linux/arm/v6' ;;
+          esac
+          case "$cmd" in
+            /nightly) echo "cmd=nightly" >> "$GITHUB_OUTPUT" ;;
+            *)        echo "cmd=build"   >> "$GITHUB_OUTPUT" ;;
           esac
           echo "archs=$archs" >> "$GITHUB_OUTPUT"
           echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
@@ -68,7 +75,7 @@ jobs:
   binaries:
     name: Binaries
     needs: prep
-    if: needs.prep.outputs.archs != '[]'
+    if: needs.prep.outputs.cmd == 'build' && needs.prep.outputs.archs != '[]'
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       contents: read
@@ -118,6 +125,7 @@ jobs:
   docker:
     name: Docker
     needs: prep
+    if: needs.prep.outputs.cmd == 'build'
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       contents: read
@@ -147,9 +155,56 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  nightly:
+    name: Nightly Packages
+    needs: prep
+    if: needs.prep.outputs.cmd == 'nightly'
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prep.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        id: go
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "26"
+          cache: "npm"
+
+      - name: Build UI
+        run: make install-ui ui
+
+      - name: Patch ASN1
+        run: make patch-asn1-sudo
+
+      - name: Create nightly build
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          version: "~> v2"
+          args: --snapshot -f .goreleaser-nightly.yml --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: evcc-nightly-pr-${{ github.event.issue.number }}
+          path: |
+            release/*.deb
+            release/*.tar.gz
+          retention-days: 14
+
   report:
     name: Report
-    needs: [prep, binaries, docker]
+    needs: [prep, binaries, docker, nightly]
     if: always() && needs.prep.result == 'success'
     runs-on: depot-ubuntu-24.04-arm
     permissions:
@@ -159,19 +214,28 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const b = '${{ needs.binaries.result }}';
-            const d = '${{ needs.docker.result }}';
-            const ok = d === 'success' && (b === 'success' || b === 'skipped');
+            const cmd = '${{ needs.prep.outputs.cmd }}';
             const num = context.payload.issue.number;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             let body;
-            if (ok) {
-              const lines = ['✅ Build finished.', ''];
-              if (b === 'success') lines.push(`- Binaries: [download artifacts](${runUrl}#artifacts)`);
-              lines.push(`- Docker: \`docker pull evcc/evcc:pr-${num}\``);
-              body = lines.join('\n');
+            if (cmd === 'nightly') {
+              if ('${{ needs.nightly.result }}' === 'success') {
+                body = ['✅ Nightly build finished.', '', `- Packages: [download artifacts](${runUrl}#artifacts)`].join('\n');
+              } else {
+                body = `❌ Nightly build failed. See the [run logs](${runUrl}).`;
+              }
             } else {
-              body = `❌ Build failed. See the [run logs](${runUrl}).`;
+              const b = '${{ needs.binaries.result }}';
+              const d = '${{ needs.docker.result }}';
+              const ok = d === 'success' && (b === 'success' || b === 'skipped');
+              if (ok) {
+                const lines = ['✅ Build finished.', ''];
+                if (b === 'success') lines.push(`- Binaries: [download artifacts](${runUrl}#artifacts)`);
+                lines.push(`- Docker: \`docker pull evcc/evcc:pr-${num}\``);
+                body = lines.join('\n');
+              } else {
+                body = `❌ Build failed. See the [run logs](${runUrl}).`;
+              }
             }
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -114,7 +114,7 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true
           tags: evcc/evcc:pr-${{ github.event.issue.number }}
           cache-from: type=gha

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,146 @@
+name: PR Build
+
+# Triggered by a maintainer commenting `/build` on a pull request.
+# Builds the PR head, uploads downloadable binaries and publishes a docker image tagged pr-<number>.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  prep:
+    name: Prepare
+    # only on PR comments starting with /build, and only from maintainers
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/build') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      sha: ${{ steps.pr.outputs.sha }}
+    steps:
+      - name: React to comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Resolve PR head
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid -q .headRefOid)
+          echo "sha=$sha" >> $GITHUB_OUTPUT
+
+  binaries:
+    name: Binaries
+    needs: prep
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prep.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        id: go
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "26"
+          cache: "npm"
+
+      - name: Build UI
+        run: make install-ui ui
+
+      - name: Build binaries
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          version: '~> v2'
+          args: --snapshot -f .goreleaser-nightly.yml --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: evcc-pr-${{ github.event.issue.number }}-binaries
+          path: |
+            release/*.tar.gz
+            release/*.zip
+            release/checksums.txt
+          retention-days: 14
+
+  docker:
+    name: Docker
+    needs: prep
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prep.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Login
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Publish
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: evcc/evcc:pr-${{ github.event.issue.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  report:
+    name: Report
+    needs: [prep, binaries, docker]
+    if: always() && needs.prep.result == 'success'
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment result
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const ok = '${{ needs.binaries.result }}' === 'success' && '${{ needs.docker.result }}' === 'success';
+            const num = context.payload.issue.number;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = ok
+              ? `✅ Build finished.\n\n- Binaries: [download artifact](${runUrl}#artifacts)\n- Docker: \`docker pull evcc/evcc:pr-${num}\``
+              : `❌ Build failed. See the [run logs](${runUrl}).`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+              body,
+            });


### PR DESCRIPTION
Adds maintainer-only slash commands usable on any pull request (author association `OWNER`/`MEMBER`/`COLLABORATOR`). Each command reacts with 👀, resolves the PR head commit, builds from that sha, and comments back with the result.

**`/build`** — Linux binaries + multi-arch docker image

- `/build` — binaries (amd64/arm64/arm) + docker
- `/build amd` — linux amd64 binary only
- `/build arm` — linux arm64 + arm/v6 binaries only
- `/build docker` — multi-arch docker image only, no binaries

Binaries are built with `go build` (version stamped `pr-<number>-<sha>`) and uploaded as run artifacts. The docker image is pushed as `evcc/evcc:pr-<number>`.

**`/nightly`** — nightly packages from the PR head

Runs goreleaser against `.goreleaser-nightly.yml --snapshot` on the PR head and uploads the resulting `.deb` / `.tar.gz` packages as run artifacts. Same pipeline as the scheduled nightly, minus the Cloudsmith/Docker publish.

**`/help`** — posts the command reference as a comment, builds nothing.

On a successful build, any issue the PR closes (via `fixes #N` keywords) also gets a comment pointing to the fresh artifacts, so reporters can grab a test build.

Injection-safe: only the integer PR number reaches any `run:` step; checkout uses the resolved head sha, the comment body is read from an env var, never interpolated into a script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)