### PR TITLE
CI: claude code review posts results via --comment

### DIFF
--- a/.github/workflows/claude-code-review-run.yml
+++ b/.github/workflows/claude-code-review-run.yml
@@ -113,7 +113,9 @@ jobs:
           allowed_bots: "dependabot[bot]"
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ needs.gate.outputs.number }}"
+          # --comment makes the plugin post its findings (or a "no issues" summary)
+          # to the PR; without it the review only prints to the hidden CI log.
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ needs.gate.outputs.number }} --comment"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The two-stage Claude Code Review workflow ran successfully but never posted result comments to PRs.

**Cause:** the `code-review` plugin only posts to the PR when its command is passed `--comment` (per the plugin spec: *"If --comment argument was NOT provided, stop here. Do not post any GitHub comments."*). The workflow invoked it without the flag, so every review printed its findings to the CI log — which is hidden (`display_report: false`, `show_full_output: false`) — and posted nothing. No `claude[bot]` review comment had ever landed on any PR.

**Fix:** append `--comment` to the plugin invocation so it posts findings (or a "No issues found" summary via `gh pr comment`).

The interpolated PR number is `needs.gate.outputs.number`, already validated `^[0-9]+$` in the gate job, so no injection risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)