### PR TITLE
Color-code optimizer suggestion hint icons

### DIFF
--- a/assets/js/components/Battery/OptimizerInfo.vue
+++ b/assets/js/components/Battery/OptimizerInfo.vue
@@ -2,7 +2,7 @@
 	<div class="d-flex flex-column gap-2">
 		<div v-if="recommendation" class="d-flex justify-content-between gap-3">
 			<span class="d-flex align-items-center gap-2 fw-bold">
-				<Optimizer />
+				<Optimizer :class="actionClass" />
 				<router-link to="/optimize" class="evcc-default-text text-decoration-underline">
 					{{ $t("battery.optimizer.suggestion") }}
 				</router-link>
@@ -36,6 +36,7 @@ import formatter from "@/mixins/formatter";
 import type { BatteryForecast, BatteryForecastPoint, BatterySuggestion } from "@/types/evcc";
 import BatteryIcon from "../Energyflow/BatteryIcon.vue";
 import Optimizer from "../MaterialIcon/Optimizer.vue";
+import { optimizerActionClass } from "@/utils/optimizer";
 
 // Optimizer rows: suggestion plus the battery high/low soc forecast.
 // Simple bold-label / muted-value layout.
@@ -52,6 +53,9 @@ export default defineComponent({
 			const action = this.suggestion?.action;
 			if (!action) return null;
 			return this.$t(`battery.optimizer.action.${action}`);
+		},
+		actionClass(): string {
+			return optimizerActionClass(this.suggestion?.action);
 		},
 	},
 	methods: {

--- a/assets/js/components/Vehicles/Status.vue
+++ b/assets/js/components/Vehicles/Status.vue
@@ -68,6 +68,7 @@ import {
 	type VehicleStatus,
 	type Timeout,
 } from "@/types/evcc";
+import { optimizerActionClass } from "@/utils/optimizer";
 
 import ClimaterIcon from "../MaterialIcon/Climater.vue";
 import DynamicPriceIcon from "../MaterialIcon/DynamicPrice.vue";
@@ -373,6 +374,7 @@ export default defineComponent({
 						this.suggestion?.action === "charge"
 							? OptimizerChargeIcon
 							: OptimizerPauseIcon,
+					itemClass: optimizerActionClass(this.suggestion?.action),
 					testId: "vehicle-status-suggestion",
 					clickable: true,
 					clickHandler: () => this.$router.push("/optimize"),

--- a/assets/js/utils/optimizer.test.ts
+++ b/assets/js/utils/optimizer.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { optimizerActionClass } from "./optimizer";
+
+describe("optimizerActionClass", () => {
+  test("maps actions to semantic colors", () => {
+    expect(optimizerActionClass("charge")).toBe("text-success");
+    expect(optimizerActionClass("stop")).toBe("text-danger");
+    expect(optimizerActionClass("hold")).toBe("text-warning");
+    expect(optimizerActionClass("holdcharge")).toBe("text-warning");
+    expect(optimizerActionClass("normal")).toBe("");
+    expect(optimizerActionClass(null)).toBe("");
+    expect(optimizerActionClass()).toBe("");
+  });
+});

--- a/assets/js/utils/optimizer.ts
+++ b/assets/js/utils/optimizer.ts
@@ -1,0 +1,17 @@
+export type OptimizerAction = "normal" | "hold" | "charge" | "holdcharge" | "stop";
+
+// Maps an optimizer suggestion action to a semantic text-color class.
+// green = start charging, red = stop, yellow = hold, none = normal operation.
+export function optimizerActionClass(action?: OptimizerAction | null): string {
+  switch (action) {
+    case "charge":
+      return "text-success";
+    case "stop":
+      return "text-danger";
+    case "hold":
+    case "holdcharge":
+      return "text-warning";
+    default:
+      return "";
+  }
+}


### PR DESCRIPTION
Color-codes the optimizer suggestion hint icons so their meaning is readable at a glance:

- **green** (`text-success`) – start charging (`charge`)
- **red** (`text-danger`) – stop (`stop`)
- **yellow** (`text-warning`) – hold mode (`hold`, `holdcharge`)
- default – normal operation (`normal`)

A shared `optimizerActionClass` helper (`assets/js/utils/optimizer.ts`) maps a suggestion action to the semantic text-color class, used in both places a suggestion icon is shown:

- `Vehicles/Status.vue` – loadpoint/vehicle suggestion icon (`charge`/`stop`)
- `Battery/OptimizerInfo.vue` – battery optimizer icon (`normal`/`hold`/`charge`/`holdcharge`)

Unit test covers the mapping.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)