### PR TITLE
CI: claude code review only comments when issues found

### DIFF
--- a/.github/workflows/claude-code-review-run.yml
+++ b/.github/workflows/claude-code-review-run.yml
@@ -113,9 +113,16 @@ jobs:
           allowed_bots: "dependabot[bot]"
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          # --comment makes the plugin post its findings (or a "no issues" summary)
-          # to the PR; without it the review only prints to the hidden CI log.
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ needs.gate.outputs.number }} --comment"
+          # --comment lets the plugin post to the PR; without it the review only
+          # prints to the hidden CI log. By default the plugin also posts a "No
+          # issues found" summary on clean reviews - the override below drops that
+          # so a comment appears only when there are actual findings.
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ needs.gate.outputs.number }} --comment
+
+            Only post a PR comment if you find issues. If the review is clean with
+            no findings, do not post any comment - skip the "No issues found"
+            summary and stop silently.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The Claude Code Review job runs the `code-review` plugin with `--comment`. On a clean review that flag makes the plugin post a "No issues found" summary comment, and the plugin exposes no option to suppress it — so every PR gets a review comment even when there is nothing to report.

This adds a prompt override telling the review to comment only when it finds issues and to stop silently on a clean pass, so the review surfaces signal instead of noise. Behaviour when there are findings is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
