### PR TITLE
Daheimladen: restore safe current limit after charger reset

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -197,8 +197,20 @@ func (wb *DaheimLaden) Status() (api.ChargeStatus, error) {
 // Enabled implements the api.Charger interface
 func (wb *DaheimLaden) Enabled() (bool, error) {
 	curr, err := wb.getCurrent()
+	if err != nil {
+		return false, err
+	}
 
-	return curr >= 60, err
+	// a charger restart resets the current limit to 0A which triggers
+	// unauthorised autostart. restore the safe disabled value.
+	if curr == 0 {
+		if err := wb.setCurrent(1); err != nil {
+			return false, err
+		}
+		curr = 1
+	}
+
+	return curr >= 60, nil
 }
 
 // Enable implements the api.Charger interface


### PR DESCRIPTION
fixes #30934

A charger power cycle resets register `91` (current limit) to `0A`. The hardware treats `0A` as unauthorised autostart at full power (the reason `Enable(false)` writes `0.1A` rather than `0A`, per #27510).

After such a reset evcc reads `0A` back as *disabled* and, since its own model already believes the charger is disabled, never rewrites the register. The box then charges uncontrolled until the next manual enable, and an evcc restart does not help.

`Enabled()` is polled every cycle, so it is the natural place to detect the reset: when the read current is `0A`, restore the safe `0.1A` disabled value before reporting state. This covers both remedies requested in the issue (continuous correction and correction on evcc restart) in one spot, and self-heals within one control cycle.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)