### PR TITLE
History: merge duplicate single-entity history series

### DIFF
--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -102,7 +102,11 @@ import Card from "../components/Helper/Card.vue";
 import PeriodSelector from "../components/Sessions/PeriodSelector.vue";
 import DateNavigator from "../components/Sessions/DateNavigator.vue";
 import PeriodHeader from "../components/Sessions/PeriodHeader.vue";
-import GroupChart, { type HistorySeries, stepAlpha } from "../components/History/GroupChart.vue";
+import GroupChart, {
+	type HistorySeries,
+	type HistorySlot,
+	stepAlpha,
+} from "../components/History/GroupChart.vue";
 import type { Legend } from "../components/Sessions/types";
 import type { DeviceColors } from "@/types/evcc";
 import { PERIODS } from "../components/Sessions/types";
@@ -116,8 +120,30 @@ import store from "../store";
 
 const HISTORY_PERIODS = [PERIODS.DAY, PERIODS.MONTH, PERIODS.YEAR];
 
+// single logical entities: swapping the device ref creates a second entity
+// row that would otherwise show as a duplicate history series.
+const SINGLE_ENTITY_GROUPS = ["grid", "home", "forecast"];
+
 function daysInMonth(year: number, month: number) {
 	return new Date(year, month, 0).getDate();
+}
+
+// mergeSeries sums the slots of multiple series per timestamp into one series.
+function mergeSeries(list: HistorySeries[]): HistorySeries {
+	const slots = new Map<string, HistorySlot>();
+	for (const s of list) {
+		for (const slot of s.data) {
+			const cur = slots.get(slot.start);
+			if (cur) {
+				cur.energy += slot.energy;
+				cur.returnEnergy += slot.returnEnergy;
+			} else {
+				slots.set(slot.start, { ...slot });
+			}
+		}
+	}
+	const data = [...slots.values()].sort((a, b) => a.start.localeCompare(b.start));
+	return { ...list[0], data };
 }
 
 export default defineComponent({
@@ -236,6 +262,10 @@ export default defineComponent({
 			for (const s of this.rawSeries) {
 				if (!s.group) continue;
 				(map[s.group] ||= []).push(s);
+			}
+			// collapse duplicate rows of single-entity groups into one series
+			for (const g of SINGLE_ENTITY_GROUPS) {
+				if (map[g] && map[g].length > 1) map[g] = [mergeSeries(map[g])];
 			}
 			return map;
 		},


### PR DESCRIPTION
refs #30087 (the duplicate grid-meter entries in the monthly history, [reported here](https://github.com/evcc-io/evcc/issues/30087#issuecomment-4841567144))

## Problem

Changing a grid meter's device ref (e.g. `db:5` → `db:27` after swapping the physical meter) creates a **second** metrics entity row. Every history period that contains data from both refs then renders two `grid` series.

#30196 (store entity title) does not address this: the monthly view fetches `grouped: false`, so `QueryEnergy` keys one series per `COALESCE(NULLIF(title,''), name)`. The old ref is no longer in the live config, so its collector is never recreated and its `title` stays empty, falling back to `name` = `db:5`; the new ref labels as `db:27`. Two distinct labels → two series. Merge-by-title can only collapse rows that resolve to the *same* label, which these never do.

## Fix

`grid`, `home` and `forecast` are single logical entities, so multiple rows for the same group are always the same device across a ref change. `seriesByGroup` now collapses them into one series by summing slots per timestamp. Fixes past and future occurrences with no schema change or migration.

Multi-instance groups (`pv`, `battery`, `loadpoint`, `meter`) are untouched — they legitimately have several entities.

## Not covered

The other points in #30087 (tile corner radius, swipe-over-chart gesture, PV meter-reading energy import) are separate and left out. Opening as **draft** since the History UI is @naltatis's and this is one design choice among a few (alternatives: merge the orphaned rows in the DB, or key single-instance groups by group instead of ref).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)