### PR TITLE
CI: mark /build and /nightly command comment resolved when done

### DIFF
--- a/.github/workflows/command-nightly.yml
+++ b/.github/workflows/command-nightly.yml
@@ -76,3 +76,13 @@ jobs:
               ? '✅ Nightly build from master finished.'
               : `❌ Nightly build from master failed. See the [run logs](${runUrl}).`;
             await github.rest.issues.createComment({ owner, repo, issue_number: num, body });
+
+      - name: Resolve command comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // collapse the /nightly comment as resolved now that the build is done
+            await github.graphql(
+              `mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}`,
+              { id: context.payload.comment.node_id }
+            );

--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -181,3 +181,13 @@ jobs:
               const body = [`Test binaries for the fix in #${num} are ready to test:`, '', ...artifacts].join('\n');
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
+
+      - name: Resolve command comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // collapse the /build comment as resolved now that the build is done
+            await github.graphql(
+              `mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}`,
+              { id: context.payload.comment.node_id }
+            );


### PR DESCRIPTION
The `/build` and `/nightly` command workflows react with 👀 on the triggering comment but never clear it. After the report comment is posted, collapse the command comment via GraphQL `minimizeComment` (classifier `RESOLVED`) so serviced commands don't linger expanded.

Injection-safe: the comment `node_id` is passed as a GraphQL variable, no shell interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)