### PR TITLE
CI: exclude CI and Bump commits from release notes

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -63,7 +63,8 @@ changelog:
   filters:
     exclude:
       - "^chore"
-      - "^bump"
+      - "(?i)^bump"
+      - "(?i)^ci:"
       - "^docs:"
       - "^test:"
       - "^build"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,8 @@ changelog:
   filters:
     exclude:
       - "^chore"
-      - "^bump"
+      - "(?i)^bump"
+      - "(?i)^ci:"
       - "^docs:"
       - "^test:"
       - "^build"


### PR DESCRIPTION
`CI:`-prefixed commits were never excluded from goreleaser changelogs, and the existing `^bump` filter is case-sensitive so `Bump ...` dependabot commits (capital B, no colon) slipped through into release notes.

- Add `(?i)^ci:` to drop `CI:` commits.
- Change `^bump` to `(?i)^bump` to catch `Bump ...` as well as `bump ...`.

Applied to both `.goreleaser.yml` and `.goreleaser-nightly.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)