### PR TITLE
EM24: drop kWh(-) export register, not available on all devices

### DIFF
--- a/templates/definition/meter/cg-em24.yaml
+++ b/templates/definition/meter/cg-em24.yaml
@@ -24,7 +24,8 @@ render: |
   {{- if ne .usage "pv" }}
   power: Power
   energy: Import
-  returnenergy: Export
+  # removed per https://github.com/evcc-io/evcc/issues/31143
+  # returnenergy: Export
   currents:
     - CurrentL1
     - CurrentL2
@@ -35,7 +36,8 @@ render: |
     - PowerL3
   {{- else }}
   power: -Power
-  energy: Export
+  # removed per https://github.com/evcc-io/evcc/issues/31143
+  # energy: Export
   returnenergy: Import
   currents:
     - -CurrentL1


### PR DESCRIPTION
fixes #31143

Since v0.309.2 (#30514 added returnEnergy), `cg-em24` reads the `Export` measurement (register 0x005C, kWh(-) TOT) every cycle. Per the CarloGavazzi EM24-DIN protocol the address is correct, but the negative-energy counters depend on the meter's measurement-system/application config and hardware variant. On devices where they're absent the meter answers Modbus exception 2 (illegal data address), spamming:

```
grid return energy: read failed: modbus: exception '2' (illegal data address), function '4'
```

A static template can't probe for the register, so drop the Export-register readings: `returnenergy` for grid usage and the inverted `energy` for pv usage. Import-side energy is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)