### PR TITLE
EEBus: ignore IEC61851 default current limits, honor loadpoint minCurrent

### DIFF
--- a/charger/eebus-evse.go
+++ b/charger/eebus-evse.go
@@ -566,6 +566,16 @@ func (c *EEBus) minMax() (minMax, error) {
 		return zero, nil
 	}
 
+	// IEC61851 EVs can't report their current range, so the EVSE sends generic
+	// defaults (6/16A) that would override the loadpoint config; trust ISO only (#14418)
+	switch comStandard, err := c.cem.EvCC.CommunicationStandard(evEntity); {
+	case err != nil:
+		return zero, eebus.WrapError(err)
+	case comStandard != model.DeviceConfigurationKeyValueStringTypeISO151182ED1 &&
+		comStandard != model.DeviceConfigurationKeyValueStringTypeISO151182ED2:
+		return zero, api.ErrNotAvailable
+	}
+
 	minLimits, maxLimits, _, err := c.cem.OpEV.CurrentLimits(evEntity)
 	if err != nil {
 		return zero, eebus.WrapError(err)

--- a/charger/eebus_test.go
+++ b/charger/eebus_test.go
@@ -442,3 +442,48 @@ func TestEEBusCurrentPower_Elli(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 4002.0, power)
 }
+
+// minMax must only trust EV current limits under ISO15118; IEC61851 EVs
+// report EVSE defaults that would override the loadpoint config (#14418).
+func TestEEBusMinMaxCommunicationStandard(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		standard model.DeviceConfigurationKeyValueStringType
+		iso      bool
+	}{
+		{"iec", model.DeviceConfigurationKeyValueStringTypeIEC61851, false},
+		{"unknown", model.DeviceConfigurationKeyValueStringType("unknown"), false},
+		{"iso", model.DeviceConfigurationKeyValueStringTypeISO151182ED2, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evcc := mocks.NewCemEVCCInterface(t)
+			opev := mocks.NewCemOPEVInterface(t)
+			evEntity := spinemocks.NewEntityRemoteInterface(t)
+
+			eebus := &EEBus{
+				cem: &eebus.CustomerEnergyManagement{
+					EvCC: evcc,
+					OpEV: opev,
+				},
+				ev:  evEntity,
+				log: util.NewLogger("test"),
+			}
+
+			evcc.EXPECT().EVConnected(evEntity).Return(true)
+			evcc.EXPECT().CommunicationStandard(evEntity).Return(tc.standard, nil)
+
+			if tc.iso {
+				opev.EXPECT().CurrentLimits(evEntity).Return(opevLimits3p(6, 16, 0))
+			}
+
+			mm, err := eebus.minMax()
+			if tc.iso {
+				require.NoError(t, err)
+				assert.Equal(t, 6.0, mm.min)
+				assert.Equal(t, 16.0, mm.max)
+			} else {
+				require.ErrorIs(t, err, api.ErrNotAvailable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #14418

For IEC61851 vehicles (no ISO15118 comms, e.g. Elli + Twingo/Kia/Elroq with PLC off) the EV cannot report its current range, so the EVSE hands back generic defaults (6/16A). evcc treated those as authoritative EV limits, and `effectiveMinCurrent` lets a reported charger min override the loadpoint's configured `minCurrent` — so it always charged at 6A regardless of the setting.

Gate the reported limits on the EEBus communication standard: only trust `OpEV.CurrentLimits` under ISO15118, where they actually originate from the vehicle. Under IEC61851 (or unknown) `minMax` returns `api.ErrNotAvailable`, so the loadpoint falls back to its configured min/max. This matches the direction @andig proposed in the thread.

The 1s cache on the limits refreshes the IEC→ISO transition after handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)