### PR TITLE
Tesla BLE: add odometer

### DIFF
--- a/templates/definition/vehicle/tesla-ble.yaml
+++ b/templates/definition/vehicle/tesla-ble.yaml
@@ -70,6 +70,13 @@ render: |
     scale: 1.60934
     timeout: {{ .timeout }}
     cache: 1s
+  odometer:
+    source: http
+    uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=drive_state
+    jq: .response.response.drive_state.odometer
+    scale: 1.60934
+    timeout: {{ .timeout }}
+    cache: 1s
   status:
     source: http
     uri: {{ .url }}:{{ .port }}/api/1/vehicles/{{ .vin }}/vehicle_data?endpoints=charge_state


### PR DESCRIPTION
Adds an `odometer` source to the tesla-ble vehicle template so the odometer shows up in the UI and session log.

The backing proxy needs support for the `drive_state` endpoint: wimaha/TeslaBleHttpProxy#160. This PR should not be merged before that one.

The odometer is read via a separate `endpoints=drive_state` request, so all existing sources keep working unchanged against older proxy versions; on an old proxy only the odometer read fails, which surfaces as one error log line per vehicle identification, same as the other odometer-capable templates when their backend lacks the data.

Scale is 1.60934 (miles to km), matching the `range` source in the same template.

Tested with `go test ./vehicle/ -run TestTemplates` and end-to-end against a live proxy implementing the new endpoint: `Odometer()` returns the car's real odometer reading in km (verified against the vehicle's displayed value), `Soc()` and `Status()` unchanged.
