### PR TITLE
Config (Remote): add title to app deep-link QR code

### DIFF
--- a/assets/js/components/Config/Remote/RemoteClientReveal.vue
+++ b/assets/js/components/Config/Remote/RemoteClientReveal.vue
@@ -81,6 +81,7 @@ export default defineComponent({
 	props: {
 		client: { type: Object as PropType<RemoteClientCreated>, required: true },
 		serverUrl: { type: String, required: true },
+		siteTitle: String,
 	},
 	emits: ["done"],
 	data() {
@@ -95,6 +96,7 @@ export default defineComponent({
 				url: this.serverUrl,
 				username: this.client.username,
 				password: this.client.password,
+				title: this.siteTitle || "",
 			});
 			return `evcc://server?${params.toString()}`;
 		},

--- a/assets/js/components/Config/Remote/RemoteModal.vue
+++ b/assets/js/components/Config/Remote/RemoteModal.vue
@@ -75,6 +75,7 @@
 			v-else-if="view === 'reveal' && createdClient && status.url"
 			:client="createdClient"
 			:server-url="status.url"
+			:site-title="siteTitle"
 			@done="finishReveal"
 		/>
 	</GenericModal>
@@ -115,6 +116,7 @@ export default defineComponent({
 	props: {
 		remote: { type: Object as () => Remote | undefined, default: undefined },
 		isSponsor: Boolean,
+		siteTitle: String,
 	},
 	data() {
 		return {

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -472,7 +472,7 @@
 				<OptimizerModal :is-sponsor="isSponsor" />
 				<McpModal />
 				<ExperimentalModal :experimental="experimental" />
-				<RemoteModal :remote="remote" :is-sponsor="isSponsor" />
+				<RemoteModal :remote="remote" :is-sponsor="isSponsor" :site-title="siteTitle" />
 				<TitleModal @changed="loadDirty" />
 				<ModbusProxyModal :is-sponsor="isSponsor" @changed="loadDirty" />
 				<CircuitsModal :gridMeter="gridMeter" :extMeters="extMeters" @changed="loadDirty" />


### PR DESCRIPTION
Adds `title` param to the `evcc://server?...` deep-link/QR code shown in remote-access setup, per https://docs.evcc.io/de/reference/app/. Empty string if `site.title` unset.