### PR TITLE
Circuit: apply HEMS consumption limit even without configured maxPower

### DIFF
--- a/core/circuit/circuit.go
+++ b/core/circuit/circuit.go
@@ -218,6 +218,11 @@ func (c *Circuit) effectiveMaxPower() float64 {
 		return maxPower
 	}
 
+	// unconfigured maxPower means unlimited, so the HEMS limit applies alone
+	if maxPower <= 0 {
+		return hemsLimit
+	}
+
 	return min(hemsLimit, maxPower)
 }
 

--- a/core/circuit/circuit_test.go
+++ b/core/circuit/circuit_test.go
@@ -156,9 +156,7 @@ func TestHEMSConsumptionClamp(t *testing.T) {
 		{"no hems, max set", 5000, 0, 9000, 5000},
 		{"hems below max", 5000, 4200, 9000, 4200},
 		{"hems above max", 5000, 9000, 9000, 5000},
-		// when the user has no circuit max, the HEMS limit is not enforced
-		// — strictly preserve user intent (no clamp without an explicit user-side cap).
-		{"hems but no user max", 0, 4200, 9000, 9000},
+		{"hems but no user max", 0, 4200, 9000, 4200},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := New(log, "root", 0, tc.maxPower, nil, 0)


### PR DESCRIPTION
Reported in discussion #31740: §14a external control shows as active and displays the limit, but an actively charging vehicle keeps drawing full power. Users found that defining `maxPower` on the root circuit is required for the limit to take effect — which should not be necessary.

## Root cause

`core/circuit/circuit.go` `effectiveMaxPower()`:

```go
maxPower := c.GetMaxPower()                // 0 when maxPower not configured (= unlimited)
hemsLimit := c.hems.MaxConsumptionPower()  // e.g. 8400
if hemsLimit <= 0 { return maxPower }
return min(hemsLimit, maxPower)            // min(8400, 0) = 0
```

Unconfigured `maxPower` is `0`, meaning unlimited, but `min(hemsLimit, 0)` collapses to `0`. `ValidatePower` then guards the clamp on `maxPower != 0`, so the HEMS limit is silently dropped. Configuring an explicit root `maxPower` keeps `min(hemsLimit, maxPower)` non-zero and the clamp fires — matching the reported workaround.

## Fix

Treat `maxPower <= 0` as "no config ceiling" so the HEMS limit applies on its own.

## Note

This reverses the intent added in #30284, whose `TestHEMSConsumptionClamp/hems_but_no_user_max` case expected no clamp without a user-side circuit cap. That case is updated here: for a regulatory §14a cap the grid-operator limit should apply regardless of whether the user configured a circuit `maxPower`. Flagging explicitly in case that tradeoff was deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)