### PR TITLE
Config: persist settings immediately on site update

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -669,7 +669,7 @@ func configureDatabase(conf globalconfig.DB) error {
 	// persist unsaved settings on shutdown
 	shutdown.Register(persistSettings)
 
-	// persist unsaved settings every 30 minutes
+	// persist unsaved settings every minute
 	go func() {
 		for range time.Tick(time.Minute) {
 			persistSettings()

--- a/server/http_config_site_handler.go
+++ b/server/http_config_site_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/evcc-io/evcc/core/site"
+	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/util/config"
 )
 
@@ -116,6 +117,12 @@ func updateSiteHandler(site site.API) http.HandlerFunc {
 
 			site.SetConsumerMeterRefs(*payload.Consumer)
 			setConfigDirty()
+		}
+
+		// persist immediately to keep meter refs consistent with device config on unclean shutdown
+		if err := settings.Persist(); err != nil {
+			jsonError(w, http.StatusInternalServerError, err)
+			return
 		}
 
 		status := map[bool]int{false: http.StatusOK, true: http.StatusAccepted}


### PR DESCRIPTION
fixes #31698

Site meter references are stored in settings and only flushed to the database periodically or on clean shutdown. Device create/delete writes are immediate. An unclean shutdown (power cut, kill) in between leaves a stale meter reference that fails the next boot with "not found: db:N".

- persist settings immediately when site configuration changes
- fix stale comment on persist interval