### PR TITLE
Config: persist settings immediately on device delete

### DIFF
--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -680,6 +680,12 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 			site.Publish(keys.Hems, HemsStatus(false))
 		}
 
+		// persist immediately to keep cleaned-up refs consistent with device config on unclean shutdown
+		if err := settings.Persist(); err != nil {
+			jsonError(w, http.StatusInternalServerError, err)
+			return
+		}
+
 		res := struct {
 			ID int `json:"id"`
 		}{

--- a/server/http_config_device_handler.go
+++ b/server/http_config_device_handler.go
@@ -621,6 +621,7 @@ func deleteDeviceHandler(site site.API) func(w http.ResponseWriter, r *http.Requ
 				{site.GetBatteryMeterRefs, site.SetBatteryMeterRefs},
 				{site.GetAuxMeterRefs, site.SetAuxMeterRefs},
 				{site.GetExtMeterRefs, site.SetExtMeterRefs},
+				{site.GetConsumerMeterRefs, site.SetConsumerMeterRefs},
 			} {
 				cleanupSiteMeterRef(name, fun.get, fun.set)
 			}


### PR DESCRIPTION
follow-up to #31754

Device delete cleans up meter/charger/vehicle refs via settings, which are only flushed periodically. Persist immediately so cleaned-up refs stay consistent with device config on unclean shutdown. Consumer meter refs were missing from the cleanup entirely.

- persist settings immediately after device delete ref cleanup
- clean up consumer meter refs on meter delete