### PR TITLE
core: release priority PV reservation when car reached charge goal

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1031,9 +1031,9 @@ func (lp *Loadpoint) charging() bool {
 	return lp.GetStatus() == api.StatusC
 }
 
-// pvChargeStarting reports a PV loadpoint that claimed surplus via a running
+// PvChargeStarting reports a PV loadpoint that claimed surplus via a running
 // enable timer but is not yet drawing it and has not reached its goal. See #31194, #31684.
-func (lp *Loadpoint) pvChargeStarting() bool {
+func (lp *Loadpoint) PvChargeStarting() bool {
 	if lp.GetMode() != api.ModePV || !lp.connected() || lp.chargeGoalReached() {
 		return false
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1031,39 +1031,33 @@ func (lp *Loadpoint) charging() bool {
 	return lp.GetStatus() == api.StatusC
 }
 
-// pvChargeStarting reports a PV loadpoint claiming surplus but not yet drawing it
-// (enable timer running, or enabled but not yet charging). See #31194.
+// pvChargeStarting reports a PV loadpoint that claimed surplus via a running
+// enable timer but is not yet drawing it and has not reached its goal. See #31194, #31684.
 func (lp *Loadpoint) pvChargeStarting() bool {
-	if lp.GetMode() != api.ModePV || !lp.connected() {
-		return false
-	}
-
-	// a loadpoint that reached its charge goal is no longer starting up, even
-	// while it stays enabled and connected but no longer draws current (#31684)
-	if lp.chargeGoalReached() {
+	if lp.GetMode() != api.ModePV || !lp.connected() || lp.chargeGoalReached() {
 		return false
 	}
 
 	lp.RLock()
-	enabled, timer := lp.enabled, lp.pvTimer
-	lp.RUnlock()
+	defer lp.RUnlock()
 
-	// enable timer running (not yet enabled), or enabled but vehicle not yet charging
-	return (!enabled && !timer.IsZero()) || (enabled && !lp.charging())
+	// enable timer running (not yet enabled)
+	return !lp.enabled && !lp.pvTimer.IsZero()
 }
 
-// chargeGoalReached reports whether the vehicle will not draw more, i.e. an
-// energy limit is reached or its soc is at/above the effective limit (#31684).
+// chargeGoalReached reports whether the loadpoint will not draw more: enabled
+// but not charging, an energy limit reached, or soc at/above the limit (#31684).
 func (lp *Loadpoint) chargeGoalReached() bool {
-	if lp.LimitEnergyReached() {
+	lp.RLock()
+	enabled, soc := lp.enabled, lp.vehicleSoc
+	lp.RUnlock()
+
+	// enabled but drawing nothing: it won't ramp up
+	if enabled && !lp.charging() {
 		return true
 	}
 
-	lp.RLock()
-	soc := lp.vehicleSoc
-	lp.RUnlock()
-
-	return soc > 0 && soc >= float64(lp.EffectiveLimitSoc())
+	return lp.LimitEnergyReached() || (soc > 0 && soc >= float64(lp.EffectiveLimitSoc()))
 }
 
 // setStatus updates the internal charging state according to EV

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1048,15 +1048,12 @@ func (lp *Loadpoint) pvChargeStarting() bool {
 // chargeGoalReached reports whether the loadpoint will not draw more: enabled
 // but not charging, an energy limit reached, or soc at/above the limit (#31684).
 func (lp *Loadpoint) chargeGoalReached() bool {
-	lp.RLock()
-	enabled, soc := lp.enabled, lp.vehicleSoc
-	lp.RUnlock()
-
 	// enabled but drawing nothing: it won't ramp up
-	if enabled && !lp.charging() {
+	if lp.IsEnabled() && !lp.charging() {
 		return true
 	}
 
+	soc := lp.GetSoc()
 	return lp.LimitEnergyReached() || (soc > 0 && soc >= float64(lp.EffectiveLimitSoc()))
 }
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1038,12 +1038,32 @@ func (lp *Loadpoint) pvChargeStarting() bool {
 		return false
 	}
 
+	// a loadpoint that reached its charge goal is no longer starting up, even
+	// while it stays enabled and connected but no longer draws current (#31684)
+	if lp.chargeGoalReached() {
+		return false
+	}
+
 	lp.RLock()
 	enabled, timer := lp.enabled, lp.pvTimer
 	lp.RUnlock()
 
 	// enable timer running (not yet enabled), or enabled but vehicle not yet charging
 	return (!enabled && !timer.IsZero()) || (enabled && !lp.charging())
+}
+
+// chargeGoalReached reports whether the vehicle will not draw more, i.e. an
+// energy limit is reached or its soc is at/above the effective limit (#31684).
+func (lp *Loadpoint) chargeGoalReached() bool {
+	if lp.LimitEnergyReached() {
+		return true
+	}
+
+	lp.RLock()
+	soc := lp.vehicleSoc
+	lp.RUnlock()
+
+	return soc > 0 && soc >= float64(lp.EffectiveLimitSoc())
 }
 
 // setStatus updates the internal charging state according to EV

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -112,6 +112,8 @@ type API interface {
 	EffectiveMinPower() float64
 	// EffectiveMaxPower returns the max charging power taking active phases into account
 	EffectiveMaxPower() float64
+	// PvChargeStarting reports a PV loadpoint claiming surplus but not yet drawing it
+	PvChargeStarting() bool
 	// EffectivePlanStrategy returns the effective plan strategy
 	EffectivePlanStrategy() api.PlanStrategy
 	// PublishEffectiveValues publishes effective values for currently attached vehicle

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -767,6 +767,20 @@ func (mr *MockAPIMockRecorder) PublishEffectiveValues() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishEffectiveValues", reflect.TypeOf((*MockAPI)(nil).PublishEffectiveValues))
 }
 
+// PvChargeStarting mocks base method.
+func (m *MockAPI) PvChargeStarting() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PvChargeStarting")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// PvChargeStarting indicates an expected call of PvChargeStarting.
+func (mr *MockAPIMockRecorder) PvChargeStarting() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PvChargeStarting", reflect.TypeOf((*MockAPI)(nil).PvChargeStarting))
+}
+
 // SetBatteryBoost mocks base method.
 func (m *MockAPI) SetBatteryBoost(enable bool) error {
 	m.ctrl.T.Helper()

--- a/core/site.go
+++ b/core/site.go
@@ -1025,7 +1025,7 @@ func (site *Site) reservedPVPower(lp updater) float64 {
 		if any(other) == any(lp) {
 			continue
 		}
-		if other.EffectivePriority() > prio && other.pvChargeStarting() {
+		if other.EffectivePriority() > prio && other.PvChargeStarting() {
 			reserved += other.EffectiveMaxPower()
 		}
 	}

--- a/core/site.go
+++ b/core/site.go
@@ -1022,7 +1022,7 @@ func (site *Site) reservedPVPower(lp updater) float64 {
 
 	var reserved float64
 	for _, other := range site.loadpoints {
-		if any(other) == any(lp) {
+		if other == lp {
 			continue
 		}
 		if other.EffectivePriority() > prio && other.PvChargeStarting() {

--- a/core/site_prioritize_test.go
+++ b/core/site_prioritize_test.go
@@ -28,9 +28,9 @@ func newPVLoadpoint(prio int, mode api.ChargeMode, status api.ChargeStatus, enab
 func TestPvChargeStarting(t *testing.T) {
 	now := clock.NewMock().Now()
 
-	// enabled and connected but car full (soc at default 100% limit): not starting up
-	goalReached := newPVLoadpoint(0, api.ModePV, api.StatusB, true, time.Time{})
-	goalReached.vehicleSoc = 100
+	// enable timer running but car already full (soc at default 100% limit): not starting up
+	enablePendingFull := newPVLoadpoint(0, api.ModePV, api.StatusB, false, now)
+	enablePendingFull.vehicleSoc = 100
 
 	tc := []struct {
 		name     string
@@ -38,12 +38,12 @@ func TestPvChargeStarting(t *testing.T) {
 		starting bool
 	}{
 		{"enable timer running", newPVLoadpoint(0, api.ModePV, api.StatusB, false, now), true},
-		{"enabled not charging", newPVLoadpoint(0, api.ModePV, api.StatusB, true, time.Time{}), true},
+		{"enabled not charging", newPVLoadpoint(0, api.ModePV, api.StatusB, true, time.Time{}), false},
 		{"enabled and charging", newPVLoadpoint(0, api.ModePV, api.StatusC, true, time.Time{}), false},
 		{"disabled idle", newPVLoadpoint(0, api.ModePV, api.StatusB, false, time.Time{}), false},
 		{"disconnected", newPVLoadpoint(0, api.ModePV, api.StatusA, false, now), false},
 		{"not pv mode", newPVLoadpoint(0, api.ModeNow, api.StatusB, false, now), false},
-		{"charge goal reached", goalReached, false},
+		{"enable pending but car full", enablePendingFull, false},
 	}
 
 	for _, tc := range tc {
@@ -84,11 +84,10 @@ func TestReservedPVPower(t *testing.T) {
 		t.Errorf("low after high charging: want 0, got %.0f", got)
 	}
 
-	// high stays enabled and connected but its car is full (goal reached): no reservation (#31684)
+	// high stays enabled and connected but no longer draws (car full): no reservation (#31684)
 	high.status = api.StatusB
-	high.vehicleSoc = 100
 	if got := site.reservedPVPower(low); got != 0 {
-		t.Errorf("low after high reached goal: want 0, got %.0f", got)
+		t.Errorf("low after high stopped drawing: want 0, got %.0f", got)
 	}
 }
 

--- a/core/site_prioritize_test.go
+++ b/core/site_prioritize_test.go
@@ -28,6 +28,10 @@ func newPVLoadpoint(prio int, mode api.ChargeMode, status api.ChargeStatus, enab
 func TestPvChargeStarting(t *testing.T) {
 	now := clock.NewMock().Now()
 
+	// enabled and connected but car full (soc at default 100% limit): not starting up
+	goalReached := newPVLoadpoint(0, api.ModePV, api.StatusB, true, time.Time{})
+	goalReached.vehicleSoc = 100
+
 	tc := []struct {
 		name     string
 		lp       *Loadpoint
@@ -39,6 +43,7 @@ func TestPvChargeStarting(t *testing.T) {
 		{"disabled idle", newPVLoadpoint(0, api.ModePV, api.StatusB, false, time.Time{}), false},
 		{"disconnected", newPVLoadpoint(0, api.ModePV, api.StatusA, false, now), false},
 		{"not pv mode", newPVLoadpoint(0, api.ModeNow, api.StatusB, false, now), false},
+		{"charge goal reached", goalReached, false},
 	}
 
 	for _, tc := range tc {
@@ -77,6 +82,13 @@ func TestReservedPVPower(t *testing.T) {
 	high.pvTimer = time.Time{}
 	if got := site.reservedPVPower(low); got != 0 {
 		t.Errorf("low after high charging: want 0, got %.0f", got)
+	}
+
+	// high stays enabled and connected but its car is full (goal reached): no reservation (#31684)
+	high.status = api.StatusB
+	high.vehicleSoc = 100
+	if got := site.reservedPVPower(low); got != 0 {
+		t.Errorf("low after high reached goal: want 0, got %.0f", got)
 	}
 }
 

--- a/core/site_prioritize_test.go
+++ b/core/site_prioritize_test.go
@@ -47,7 +47,7 @@ func TestPvChargeStarting(t *testing.T) {
 	}
 
 	for _, tc := range tc {
-		if got := tc.lp.pvChargeStarting(); got != tc.starting {
+		if got := tc.lp.PvChargeStarting(); got != tc.starting {
 			t.Errorf("%s: want %v, got %v", tc.name, tc.starting, got)
 		}
 	}


### PR DESCRIPTION
Follow-up to #31684 (surplus reservation for higher-priority loadpoints starting up).

Reported on #31684: when a prioritized car reaches its charge goal, the reservation is never released — the lower-priority loadpoint stays starved to minimum current even though all charge goals are met.

Root cause: `reservedPVPower` (`core/site.go`) reserves a higher-priority PV loadpoint's `EffectiveMaxPower` while `pvChargeStarting` is true, and `pvChargeStarting` returned true for `enabled && !charging()`. A connected car that is full (status `B`, drawing 0 W) sits in exactly that state indefinitely, so it was indistinguishable from a loadpoint genuinely ramping up — the reservation never cleared.

Fix: reservation is now claimed only during the enable-pending window (enable timer running, not yet enabled). Once a loadpoint is enabled but drawing nothing it is treated as goal-reached (`chargeGoalReached`), so it stops reserving surplus and releases it to lower-priority loadpoints. `chargeGoalReached` short-circuits on enabled-but-idle before the energy/soc target checks, so it also covers chargers without soc reporting.

Regression coverage in `core/site_prioritize_test.go` (`TestPvChargeStarting` enabled-not-charging → not starting, enable-pending-but-full; `TestReservedPVPower` enabled-idle release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)