### PR TITLE
CI: fix /analyze command startup failure

### DIFF
--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -30,14 +30,8 @@ jobs:
   run:
     name: Issue agent
     runs-on: ubuntu-latest
-    # Superset of what either mode needs; the caller job scopes the token down
-    # (analyze grants only contents: read, so it cannot push or open PRs).
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
-      actions: read
+    # No permissions block: inherit the caller's grant (triage=write to push
+    # fixes, analyze=read). A reusable job can only reduce, never elevate.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
Every `Claude Analyze Command` run fails with `startup_failure` ("This run likely failed because of a workflow file issue"), e.g. [run 29259870659](https://github.com/evcc-io/evcc/actions/runs/29259870659).

Cause: the reusable `claude-issue-agent-run.yml` job hard-codes `contents: write`, but the `/analyze` caller (`command-analyze.yml`) intentionally grants only `contents: read`. A reusable workflow's permissions [can only be maintained or reduced — not elevated](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows) above the caller, so the read→write elevation is rejected at startup. The triage caller grants `contents: write`, matches, and works — which is why only `/analyze` broke.

Fix: drop the `permissions` block from the reusable job so it inherits each caller's grant (triage = write to push fixes, analyze = read). Both callers already grant every scope the steps need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)