### PR TITLE
chore: round evopt-batteries forecast timestamps to seconds

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -672,7 +672,7 @@ func matchSoc(ts []float32, fun func(float32) bool) time.Time {
 	for i, soc := range ts {
 		if fun(soc) {
 			// TODO first slot
-			return time.Now().Add(time.Duration(i+1) * tariff.SlotDuration)
+			return time.Now().Add(time.Duration(i+1) * tariff.SlotDuration).Round(time.Second)
 		}
 	}
 


### PR DESCRIPTION
`matchSoc` derives the battery forecast `Full`/`Empty` timestamps from `time.Now()`, which carries sub-second precision and gets serialized as fractional-second JSON in the `evopt-batteries` topic. Round to the nearest second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)