### PR TITLE
CI: sync .github/actions from master in /build binaries job

### DIFF
--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -83,6 +83,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # PR branches older than the composite action itself won't have it on disk,
+      # so pull .github/actions from master regardless of how stale the PR is.
+      - uses: actions/checkout@v7
+        with:
+          path: .base-actions
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - run: |
+          rm -rf .github/actions
+          cp -r .base-actions/.github/actions .github/actions
+          rm -rf .base-actions
+
       - uses: ./.github/actions/build-toolchain
         with:
           cache-scope: pr # isolated cache, cannot poison the nightly/main cache


### PR DESCRIPTION
The `/build` command's `binaries` job checks out the PR head and then runs `uses: ./.github/actions/build-toolchain`. PR branches older than #31726 (which added that composite action) don't have `.github/actions/build-toolchain` on disk at all, so the step fails with "Can't find 'action.yml'".

Example failure: https://github.com/evcc-io/evcc/actions/runs/29275242013/job/86902700074 (PR head `bf5999eb7`, predates the composite action).

Fix: after checking out the PR head, sparse-checkout `.github/actions` from master into a scratch dir and copy it over, so the local action always resolves regardless of how stale the PR branch is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)