### PR TITLE
tariff: deprecate solarprognose tariff (service shut down)

### DIFF
--- a/templates/definition/tariff/solarprognose.yaml
+++ b/templates/definition/tariff/solarprognose.yaml
@@ -1,4 +1,5 @@
 template: solarprognose
+deprecated: true
 products:
   - brand: Solarprognose
 requirements:


### PR DESCRIPTION
Deprecate template, closes #31767.
Service permanently shut down.