### PR TITLE
meter/anker-solix-x1: fix wrong Total PV Generation register address

### DIFF
--- a/templates/definition/meter/anker-solix-x1.yaml
+++ b/templates/definition/meter/anker-solix-x1.yaml
@@ -112,7 +112,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 10187 # Total PV Generation (kWh)
+      address: 10189 # Total PV Generation (kWh)
       type: input
       decode: uint32s
     scale: 0.1


### PR DESCRIPTION
fixes #31753

Per the vendor's own Anker SOLIX X1 Series Modbus Protocol (V1.0.0, 2025-08-07), "PCS - PV Information" table:

- `10187` = Daily PV Generation (uint32, gain 10)
- `10189` = Total PV Generation (uint32, gain 10)

The template's PV `energy` register read `10187` while commented/used as "Total PV Generation". Since that register is actually the daily counter and resets to 0 every night, treating it as the lifetime meter total made evcc's tracked "today" energy inflate over the course of the day instead of reflecting the real total — matching the ~9x-growing-through-the-day discrepancy reported in #31753 (86.7 vs 9.54 kWh, later 594.0 vs 62.93 kWh).

Fix: point the `energy` register at `10189` instead. Decode (`uint32s`) and scale (`0.1`) are unchanged — they already matched the vendor's gain=10 spec, only the address was off.

`go test ./meter/... -run TestTemplates` passes for `anker-solix-x1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)