### PR TITLE
Site: don't apply battery priority to loadpoints with battery boost active

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -925,9 +925,12 @@ func optimizerEnabled() bool {
 //   - the net power exported by the site minus a residual margin
 //     (negative values mean grid: export, battery: charging
 //   - if battery buffer can be used for charging
-func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, bool, bool, error) {
+//   - the adjustment applied to sitePower for battery priority below prioritySoc;
+//     adding it back restores the unadjusted site power for a loadpoint that
+//     takes priority over the battery (battery boost)
+func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, bool, bool, float64, error) {
 	if err := site.updateMeters(); err != nil {
-		return 0, false, false, err
+		return 0, false, false, 0, err
 	}
 
 	// allow using PV as estimate for grid power
@@ -936,10 +939,14 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 		site.publish(keys.Grid, types.Measurement{Power: site.gridPower})
 	}
 
+	// sitePower adjustment applied for battery priority
+	var priorityAdjustment float64
+
 	// ensure safe default for residual power
 	residualPower := site.GetResidualPower()
 	if len(site.batteryMeters) > 0 && site.battery.Soc < site.prioritySoc && residualPower <= 0 {
-		residualPower = 100 // Wsite.publish(keys.PvPower,
+		priorityAdjustment += residualPower - 100
+		residualPower = 100 // W
 	}
 
 	// allow using grid and charge as estimate for pv power
@@ -966,6 +973,7 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 		// if battery is charging below prioritySoc give it priority
 		if site.battery.Soc < site.prioritySoc && batteryPower < 0 {
 			site.log.DEBUG.Printf("battery has priority at soc %.0f%% (< %.0f%%)", site.battery.Soc, site.prioritySoc)
+			priorityAdjustment += batteryPower + excessDCPower
 			batteryPower = 0
 			excessDCPower = 0
 		} else {
@@ -985,7 +993,7 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 
 	site.log.DEBUG.Printf("site power: %.0fW"+flexStr, sitePower)
 
-	return sitePower, batteryBuffered, batteryStart, nil
+	return sitePower, batteryBuffered, batteryStart, priorityAdjustment, nil
 }
 
 // updateLoadpoints updates all loadpoints' charge power
@@ -1087,7 +1095,7 @@ func (site *Site) update(lp updater) {
 		flexiblePower = site.prioritizer.GetChargePowerFlexibility(lp)
 	}
 
-	if sitePower, batteryBuffered, batteryStart, err := site.sitePower(totalChargePower, flexiblePower); err == nil {
+	if sitePower, batteryBuffered, batteryStart, priorityAdjustment, err := site.sitePower(totalChargePower, flexiblePower); err == nil {
 		// ignore negative pvPower values as that means it is not an energy source but consumption
 		homePower := site.gridPower + max(0, site.pvPower) + site.battery.Power - totalChargePower
 		homePower = max(homePower, 0)
@@ -1109,6 +1117,12 @@ func (site *Site) update(lp updater) {
 		if lp != nil {
 			// reserve surplus claimed by higher-priority loadpoints that are starting up (#31194)
 			sitePower += site.reservedPVPower(lp)
+
+			// battery boost deliberately drains the battery, hence battery priority
+			// below prioritySoc does not apply to the boosting loadpoint (#30541)
+			if lp.GetBatteryBoost() != boostDisabled {
+				sitePower += priorityAdjustment
+			}
 
 			lp.Update(
 				sitePower, max(0, site.battery.Power), consumption, feedin, batteryBuffered, batteryStart,

--- a/core/site_test.go
+++ b/core/site_test.go
@@ -5,9 +5,68 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/types"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
+
+// TestSitePowerPriorityAdjustment verifies that sitePower returns the adjustment
+// applied for battery priority below prioritySoc, such that adding it back yields
+// the unadjusted site power for loadpoints with battery boost active (#30541)
+func TestSitePowerPriorityAdjustment(t *testing.T) {
+	const prioritySoc = 50
+
+	for _, tc := range []struct {
+		name                        string
+		soc, power, excessDC        float64 // battery
+		expSitePower, expAdjustment float64
+		expReconstructed            float64 // sitePower + adjustment: the unadjusted site power a boost loadpoint sees
+	}{
+		// battery priority does not apply: no adjustment
+		{"charging above prioritySoc", 80, -2000, 0, -2000, 0, -2000},
+		// battery charge power hidden and residual power forced to 100W:
+		// adding the adjustment back restores the unadjusted -2000W
+		{"charging below prioritySoc", 30, -2000, 0, 100, -2100, -2000},
+		// battery not charging: only the forced residual power applies
+		{"discharging below prioritySoc", 30, 500, 0, 600, -100, 500},
+		// excess DC power can only reach the battery, never the (AC) vehicle, so it
+		// must stay netted out of the reconstructed surplus: of 2000W charging with
+		// 500W un-redirectable DC excess, only 1500W is available to a boost loadpoint
+		{"charging below prioritySoc with excess DC", 30, -2000, 500, 100, -1600, -1500},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			meter := api.NewMockMeter(ctrl)
+			meter.EXPECT().CurrentPower().Return(tc.power, nil).AnyTimes()
+
+			battery := api.NewMockBattery(ctrl)
+			battery.EXPECT().Soc().Return(tc.soc, nil).AnyTimes()
+
+			var bat api.Meter = &struct {
+				api.Meter
+				api.Battery
+			}{
+				Meter:   meter,
+				Battery: battery,
+			}
+
+			site := &Site{
+				log:           util.NewLogger("foo"),
+				batteryMeters: []config.Device[api.Meter]{config.NewStaticDevice(config.Named{}, bat)},
+				prioritySoc:   prioritySoc,
+			}
+			site.excessDCPower = tc.excessDC
+
+			sitePower, _, _, adjustment, err := site.sitePower(0, 0)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expSitePower, sitePower, "sitePower")
+			assert.Equal(t, tc.expAdjustment, adjustment, "priority adjustment")
+			assert.Equal(t, tc.expReconstructed, sitePower+adjustment, "reconstructed (unadjusted) site power")
+		})
+	}
+}
 
 func TestGreenShare(t *testing.T) {
 	tc := []struct {


### PR DESCRIPTION
Fixes #30541

## Desired behavior

Battery boost deliberately drains the home battery into the vehicle and has its own soc floor via `batteryBoostLimit` (boost auto-disables when the battery soc drops below it). Therefore battery priority (`prioritySoc`) does not apply to a loadpoint with boost active: it may claim the power currently charging the battery. All other loadpoints keep respecting battery priority unchanged.

## Problem

Below `prioritySoc`, `sitePower()` hides the power flowing into the battery (`batteryPower`, `excessDCPower` zeroed) and forces a 100W residual so loadpoints leave the surplus to the battery. This also starved boost-active loadpoints: with the battery charging at 2000W, the boosting loadpoint ramped at ~0.4A per cycle instead of ~9A and could stay stuck on 1 phase (see issue for the full calculation).

## Solution (contained, per https://github.com/evcc-io/evcc/issues/30541#issuecomment-4632527278)

- `sitePower()` additionally returns the priority adjustment it applied (zeroed `batteryPower + excessDCPower` plus the residual override delta). Adding it back exactly reconstructs the unadjusted site power; the `excessDCPower` term self-corrects, so DC-only excess that no loadpoint can claim stays reserved for the battery.
- `site.update` adds the adjustment back only for the loadpoint being updated when its boost is active. Loadpoints are updated one per cycle, so there is no double-counting with multiple boost loadpoints.

Covered by the new table-driven `TestSitePowerPriorityAdjustment` (charging above/below `prioritySoc`, discharging below), exercising the full `sitePower` path with mocked battery meters.

Known edge case: on the cycle where boost auto-disables (soc fell below `batteryBoostLimit`), the loadpoint may see one interval of unadjusted surplus before reverting — keeping the boost check out of `sitePower` is what keeps the change contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
