### PR TITLE
optimizer: fix pause suggestion for idle-but-enabled loadpoints

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1049,7 +1049,11 @@ func (lp *Loadpoint) PvChargeStarting() bool {
 // but not charging, an energy limit reached, or soc at/above the limit (#31684).
 func (lp *Loadpoint) chargeGoalReached() bool {
 	// enabled but drawing nothing: it won't ramp up
-	if lp.IsEnabled() && !lp.charging() {
+	lp.RLock()
+	enabled := lp.isEnabled()
+	lp.RUnlock()
+
+	if enabled && !lp.charging() {
 		return true
 	}
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1034,25 +1034,23 @@ func (lp *Loadpoint) charging() bool {
 // PvChargeStarting reports a PV loadpoint that claimed surplus via a running
 // enable timer but is not yet drawing it and has not reached its goal. See #31194, #31684.
 func (lp *Loadpoint) PvChargeStarting() bool {
-	if lp.GetMode() != api.ModePV || !lp.connected() || lp.chargeGoalReached() {
+	lp.RLock()
+	enabled := lp.enabled
+	pvTimerRunning := !lp.pvTimer.IsZero()
+	lp.RUnlock()
+
+	if lp.GetMode() != api.ModePV || !lp.connected() || lp.chargeGoalReached(enabled) {
 		return false
 	}
 
-	lp.RLock()
-	defer lp.RUnlock()
-
 	// enable timer running (not yet enabled)
-	return !lp.enabled && !lp.pvTimer.IsZero()
+	return !enabled && pvTimerRunning
 }
 
 // chargeGoalReached reports whether the loadpoint will not draw more: enabled
 // but not charging, an energy limit reached, or soc at/above the limit (#31684).
-func (lp *Loadpoint) chargeGoalReached() bool {
+func (lp *Loadpoint) chargeGoalReached(enabled bool) bool {
 	// enabled but drawing nothing: it won't ramp up
-	lp.RLock()
-	enabled := lp.isEnabled()
-	lp.RUnlock()
-
 	if enabled && !lp.charging() {
 		return true
 	}

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -142,10 +142,8 @@ func (lp *Loadpoint) GetStatus() api.ChargeStatus {
 	return lp.status
 }
 
-// IsEnabled returns the charger enabled state
-func (lp *Loadpoint) IsEnabled() bool {
-	lp.RLock()
-	defer lp.RUnlock()
+// isEnabled returns the charger enabled state; caller must hold the lock
+func (lp *Loadpoint) isEnabled() bool {
 	return lp.enabled
 }
 

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -142,11 +142,6 @@ func (lp *Loadpoint) GetStatus() api.ChargeStatus {
 	return lp.status
 }
 
-// isEnabled returns the charger enabled state; caller must hold the lock
-func (lp *Loadpoint) isEnabled() bool {
-	return lp.enabled
-}
-
 // GetMode returns loadpoint charge mode
 func (lp *Loadpoint) GetMode() api.ChargeMode {
 	lp.RLock()

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -163,10 +163,10 @@ func currentSlotSuggestion(detail batteryDetail, res optimizer.BatteryResult, gr
 // stopped instead of triggering a spurious pause suggestion.
 func loadpointCurrentAction(lp *Loadpoint) string {
 	lp.RLock()
-	enabled := lp.isEnabled()
+	enabled := lp.enabled
 	lp.RUnlock()
 
-	if enabled && !lp.chargeGoalReached() {
+	if enabled && !lp.chargeGoalReached(enabled) {
 		return actionCharge
 	}
 	return actionStop

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -162,7 +162,11 @@ func currentSlotSuggestion(detail batteryDetail, res optimizer.BatteryResult, gr
 // enabled while idle (e.g. vehicle finished at its limit) is treated as
 // stopped instead of triggering a spurious pause suggestion.
 func loadpointCurrentAction(lp *Loadpoint) string {
-	if lp.IsEnabled() && !lp.chargeGoalReached() {
+	lp.RLock()
+	enabled := lp.isEnabled()
+	lp.RUnlock()
+
+	if enabled && !lp.chargeGoalReached() {
 		return actionCharge
 	}
 	return actionStop

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -157,6 +157,17 @@ func currentSlotSuggestion(detail batteryDetail, res optimizer.BatteryResult, gr
 	return s
 }
 
+// loadpointCurrentAction returns the loadpoint's current operating mode for
+// suggestion comparison, reusing chargeGoalReached so a loadpoint left
+// enabled while idle (e.g. vehicle finished at its limit) is treated as
+// stopped instead of triggering a spurious pause suggestion.
+func loadpointCurrentAction(lp *Loadpoint) string {
+	if lp.IsEnabled() && !lp.chargeGoalReached() {
+		return actionCharge
+	}
+	return actionStop
+}
+
 // setBatterySuggestions replaces the suggestions applied on each battery publish
 func (site *Site) setBatterySuggestions(suggestions map[string]types.Suggestion) {
 	site.Lock()
@@ -425,11 +436,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 		if detail.Type == batteryTypeBattery {
 			current = site.GetBatteryMode().String()
 		} else if detail.loadpoint != nil {
-			if site.loadpoints[*detail.loadpoint].IsEnabled() {
-				current = actionCharge
-			} else {
-				current = actionStop
-			}
+			current = loadpointCurrentAction(site.loadpoints[*detail.loadpoint])
 		}
 
 		suggestion := currentSlotSuggestion(detail, batResp, gridImporting, gridExporting, slotHours, current)

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -27,6 +27,26 @@ func TestLoadpointProfile(t *testing.T) {
 	require.Equal(t, []float64{250, 250, 250, 250, 250, 250, 250, 50}, loadpointProfile(lp, 8))
 }
 
+func TestLoadpointCurrentAction(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		status  api.ChargeStatus
+		soc     float64
+		want    string
+	}{
+		{"charging", true, api.StatusC, 0, actionCharge},
+		{"enabled but idle (e.g. vehicle finished at limit)", true, api.StatusB, 0, actionStop},
+		{"disabled", false, api.StatusB, 0, actionStop},
+		{"charging at 100% soc with no explicit limit", true, api.StatusC, 100, actionStop},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lp := &Loadpoint{enabled: tc.enabled, status: tc.status, vehicleSoc: tc.soc}
+			assert.Equal(t, tc.want, loadpointCurrentAction(lp))
+		})
+	}
+}
+
 func TestAsTimestamps(t *testing.T) {
 	// now is 10 minutes into a 15-minute slot
 	now := time.Date(2025, 1, 1, 12, 10, 0, 0, time.UTC)


### PR DESCRIPTION
Follow-up to #31693: the actionable-suggestion comparison used the loadpoint's `enabled` flag alone as its "current mode". A loadpoint stays enabled while idle (e.g. vehicle finished charging at its limit, drawing no power), so the optimizer's correct "stop" verdict always differed from "charge" and the UI kept showing a "pause loadpoint" hint for a loadpoint that was already effectively finished.

`loadpointCurrentAction` now reuses the existing `chargeGoalReached` helper (added for #31684) so an enabled-but-idle loadpoint is treated as stopped for suggestion-comparison purposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
