### PR TITLE
request: fix DoJSON error on empty-body 2xx response

### DIFF
--- a/util/request/helper.go
+++ b/util/request/helper.go
@@ -62,6 +62,7 @@ func decodeJSON(resp *http.Response, res any) error {
 		return err
 	}
 
+	// swallow io.EOF to allow empty response
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}

--- a/util/request/helper.go
+++ b/util/request/helper.go
@@ -3,6 +3,8 @@ package request
 import (
 	"encoding/json"
 	"encoding/xml"
+	"errors"
+	"io"
 	"net/http"
 	"time"
 
@@ -60,7 +62,11 @@ func decodeJSON(resp *http.Response, res any) error {
 		return err
 	}
 
-	return json.NewDecoder(resp.Body).Decode(&res)
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
 }
 
 // decodeXML reads HTTP response and decodes XML body if error is nil

--- a/util/request/helper_test.go
+++ b/util/request/helper_test.go
@@ -1,0 +1,55 @@
+package request
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func testHelper(status int, body string) *Helper {
+	return &Helper{
+		Client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: status,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+}
+
+func TestDoJSON(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	t.Run("empty body is not an error", func(t *testing.T) {
+		var res struct{ Code int }
+		err := testHelper(http.StatusOK, "").DoJSON(req, &res)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid body is decoded", func(t *testing.T) {
+		var res struct{ Code int }
+		err := testHelper(http.StatusOK, `{"Code":528}`).DoJSON(req, &res)
+		assert.NoError(t, err)
+		assert.Equal(t, 528, res.Code)
+	})
+
+	t.Run("truncated body is an error", func(t *testing.T) {
+		var res struct{ Code int }
+		err := testHelper(http.StatusOK, `{"Code":52`).DoJSON(req, &res)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
fixes #31793

`DoJSON` only recognized HTTP 204 as an empty-body success. A 2xx response with an empty body but a different status code (Zaptec's `sendCommand` returns 200 with no body) failed JSON decoding with `io.EOF`, surfacing as an error even though the request succeeded. This broke Zaptec's `Enable()`, which checks `err == nil || res.Code == 528` to detect a successful resume, leaving `c.enabled` unset until a later retry.

- `decodeJSON` now treats `io.EOF` as success (empty body), matching the documented "error only on non-2xx" contract, while `io.ErrUnexpectedEOF` (a genuinely truncated body) still errors
- added `util/request/helper_test.go` covering empty body, valid body, and truncated body cases