### PR TITLE
Zaptec: propagate Enable errors other than 528

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -241,13 +241,16 @@ func (c *Zaptec) Enable(enable bool) error {
 		Code int
 	}
 
+	err := c.DoJSON(req, &res)
+
 	// ignore 528: Charging is not Paused nor Scheduled; Resume command cannot be sent
-	if err := c.DoJSON(req, &res); err == nil || res.Code == 528 {
+	if err == nil || res.Code == 528 {
 		c.enabled = enable
 		c.statusG.Reset()
+		return nil
 	}
 
-	return nil
+	return err
 }
 
 func (c *Zaptec) chargerUpdate(data zaptec.Update) error {


### PR DESCRIPTION
Follow-up to #31801, found while investigating #31793.

PR #21594 ("Zaptec: ignore double-enable errors") changed `Enable()` to unconditionally `return nil`, intending to ignore only the 528 "already resumed" case. In practice this swallows every `DoJSON` error (network failures, auth failures, other API errors), hiding real problems from the caller.

- `Enable()` now returns the underlying error unless it's `nil` or the 528 double-enable case