### PR TITLE
Fix broken command workflows: trim() isn't a valid Actions expression

### DIFF
--- a/.github/workflows/command-analyze.yml
+++ b/.github/workflows/command-analyze.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze on demand
-    if: startsWith(trim(github.event.comment.body), '/analyze')
+    if: startsWith(github.event.comment.body, '/analyze')
     permissions:
       contents: read # explore the codebase for the answer; no fix/PR in analyze mode
       issues: write # comment + minimize the calling comment

--- a/.github/workflows/command-fix.yml
+++ b/.github/workflows/command-fix.yml
@@ -12,7 +12,7 @@ jobs:
   fix:
     name: Fix on demand
     if: |
-      startsWith(trim(github.event.comment.body), '/fix') &&
+      startsWith(github.event.comment.body, '/fix') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     permissions:
       contents: write # create branch + push PR fix

--- a/.github/workflows/command-nightly.yml
+++ b/.github/workflows/command-nightly.yml
@@ -16,7 +16,7 @@ jobs:
     name: Nightly Build
     # on any issue/PR comment starting with /nightly, only from maintainers
     if: |
-      startsWith(trim(github.event.comment.body), '/nightly') &&
+      startsWith(github.event.comment.body, '/nightly') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: depot-ubuntu-24.04-arm
     permissions:

--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -21,7 +21,7 @@ jobs:
     # only on PR comments starting with /build, and only from maintainers
     if: |
       github.event.issue.pull_request &&
-      startsWith(trim(github.event.comment.body), '/build') &&
+      startsWith(github.event.comment.body, '/build') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: depot-ubuntu-24.04-arm
     permissions:


### PR DESCRIPTION
PR #31812 added \`trim(github.event.comment.body)\` to all four comment-command triggers (\`/analyze\`, \`/fix\`, \`/nightly\`, \`/build\`), but GitHub Actions expressions don't have a \`trim\` function (only \`contains\`/\`startsWith\`/\`endsWith\`/\`format\`/\`join\`/\`toJSON\`/\`fromJSON\`/\`hashFiles\` exist). All four workflows now fail to parse (see run https://github.com/evcc-io/evcc/actions/runs/29405492740), meaning none of the commands fire at all. Reverts to plain \`startsWith(comment.body, '/x')\`.