### PR TITLE
Loadpoint: fix minSoc config error on restart

### DIFF
--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -31,6 +31,7 @@ type DynamicConfig struct {
 	BatteryBoostLimit        int       `json:"batteryBoostLimit"`
 	LimitEnergy              float64   `json:"limitEnergy"`
 	LimitSoc                 int       `json:"limitSoc"`
+	MinSoc                   int       `json:"minSoc"`
 
 	PlanStrategy api.PlanStrategy `json:"planStrategy"`
 
@@ -75,6 +76,7 @@ func (payload DynamicConfig) Apply(lp API) error {
 	lp.SetBatteryBoostLimit(payload.BatteryBoostLimit)
 	lp.SetLimitEnergy(payload.LimitEnergy)
 	lp.SetLimitSoc(payload.LimitSoc)
+	lp.SetMinSoc(payload.MinSoc)
 
 	// TODO mode warning
 	lp.SetSocConfig(payload.Soc)

--- a/tests/config-loadpoint.spec.ts
+++ b/tests/config-loadpoint.spec.ts
@@ -642,6 +642,25 @@ test.describe("heating loadpoint", async () => {
     await lpModal.getByRole("button", { name: "Save" }).click();
     await expectModalHidden(lpModal);
 
+    // set min temperature on main screen (stored in loadpoint device config)
+    await page.goto("/");
+    const settingsModal = page.getByTestId("loadpoint-settings-modal").first();
+    await page.getByTestId("loadpoint-settings-button").last().click();
+    await expectModalVisible(settingsModal);
+    await settingsModal.getByLabel("Min. temperature").selectOption("50.0°C");
+    await settingsModal.getByRole("button", { name: "Close" }).click();
+    await expectModalHidden(settingsModal);
+
+    // min temperature survives restart
+    await restart();
+    await page.reload();
+    await page.getByTestId("loadpoint-settings-button").last().click();
+    await expectModalVisible(settingsModal);
+    await expect(settingsModal.getByLabel("Min. temperature")).toHaveValue("50");
+    await settingsModal.getByRole("button", { name: "Close" }).click();
+    await expectModalHidden(settingsModal);
+    await page.goto("/#/config");
+
     // delete
     await lpEntry.getByRole("button", { name: "edit" }).click();
     await expectModalVisible(lpModal);

--- a/tests/heating.spec.ts
+++ b/tests/heating.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from "@playwright/test";
-import { start, stop, baseUrl } from "./evcc";
+import { start, stop, restart, baseUrl } from "./evcc";
 import { expectModalHidden, expectModalVisible } from "./utils";
+
+const CONFIG = "heating.evcc.yaml";
 
 test.use({ baseURL: baseUrl() });
 
 test.beforeAll(async () => {
-  await start("heating.evcc.yaml");
+  await start(CONFIG);
 });
 test.afterAll(async () => {
   await stop();
@@ -51,6 +53,16 @@ test.describe("integrated device", async () => {
     // temp 40 below minimum 50 -> forced heating indicator
     await expect(lp.getByTestId("vehicle-status-minsoc")).toContainText("50.0°C");
 
+    await page.reload();
+    await expect(lp.getByTestId("vehicle-status-minsoc")).toContainText("50.0°C");
+    await lp.getByTestId("loadpoint-settings-button").last().click();
+    await expectModalVisible(modal);
+    await expect(modal.getByLabel("Min. temperature")).toHaveValue("50");
+    await modal.getByRole("button", { name: "Close" }).click();
+    await expectModalHidden(modal);
+
+    // value survives restart
+    await restart(CONFIG);
     await page.reload();
     await expect(lp.getByTestId("vehicle-status-minsoc")).toContainText("50.0°C");
     await lp.getByTestId("loadpoint-settings-button").last().click();


### PR DESCRIPTION
fixes #31817
regression from #31749

Min soc/temp set via UI is persisted into the loadpoint device config, but `SplitConfig` did not know the key. On restart it leaked into the static config where strict decoding rejected it, failing startup.

- add `minSoc` to loadpoint `DynamicConfig` and apply it on boot
- extend heating loadpoint config test: set min temperature, verify it survives restart (failed before the fix)
- heating spec: verify min temperature survives restart for yaml loadpoints