### PR TITLE
Add eyes reaction to all command-invokable agents; fix claude.yml write perms

### DIFF
--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -35,6 +35,14 @@ jobs:
     # No permissions block: inherit the caller's grant (triage/fix=write to push
     # fixes, analyze=read). A reusable job can only reduce, never elevate.
     steps:
+      - name: React to invoking comment
+        if: inputs.comment_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ inputs.comment_id }}/reactions \
+            -f content=eyes
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,12 +19,36 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write # allow Claude to push fixes when asked
+      pull-requests: write # comment + open/edit PRs
+      issues: write # comment + react to the invoking comment/issue
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: React to invoking comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+
+      - name: React to invoking review comment
+        if: github.event_name == 'pull_request_review_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+
+      - name: React to invoking issue
+        if: github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/reactions \
+            -f content=eyes
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
\`/nightly\` and \`/build\` already react with 👀 the moment their workflow starts, giving the commenter immediate feedback the command was picked up. \`/analyze\`, \`/fix\`, and the \`@claude\` mention handler had no such signal. Adds the same eyes reaction to:
- the shared reusable workflow (\`claude-issue-agent-run.yml\`) that \`/analyze\` and \`/fix\` delegate to, gated on \`comment_id\` being set so triage mode (no invoking comment) is unaffected
- \`claude.yml\`, reacting on the issue comment, PR review comment, or issue depending on which event triggered it

Also fixes \`claude.yml\` running with read-only \`contents\`/\`pull-requests\`/\`issues\` permissions, meaning even a legitimate \`@claude fix this\` could never result in a pushed fix, comment, or label. \`claude-code-action\` already gates on the actor having write access before doing anything, so granting the token write permissions only changes what a trusted trigger can accomplish, not who can trigger it.