### PR TITLE
feat(loadpoint): opt-in batteryBoostDefault to auto-enable battery boost on connect

### DIFF
--- a/assets/js/components/Loadpoints/SettingsBatteryBoost.vue
+++ b/assets/js/components/Loadpoints/SettingsBatteryBoost.vue
@@ -25,6 +25,33 @@
 				<small class="text-muted">{{ description }}</small>
 			</div>
 		</div>
+
+		<div v-if="selectedLimit < 100" class="mb-3 row" data-testid="battery-boost-default">
+			<label
+				:for="formId('batteryBoostDefault')"
+				class="col-sm-4 col-form-label pt-0 pt-sm-2"
+			>
+				{{ $t("main.loadpointSettings.batteryBoost.autoLabel") }}
+			</label>
+			<div class="col-sm-8 col-lg-4 pe-0 d-flex align-items-center">
+				<div class="form-check form-switch">
+					<input
+						:id="formId('batteryBoostDefault')"
+						v-model="selectedDefault"
+						class="form-check-input"
+						type="checkbox"
+						role="switch"
+						data-testid="battery-boost-default-toggle"
+						@change="handleDefaultChange"
+					/>
+				</div>
+			</div>
+			<div class="col-sm-8 offset-sm-4 mt-1">
+				<small class="text-muted">{{
+					$t("main.loadpointSettings.batteryBoost.autoDescription")
+				}}</small>
+			</div>
+		</div>
 	</div>
 </template>
 
@@ -46,11 +73,13 @@ export default defineComponent({
 			default: (s: string) => s,
 		},
 		batteryBoostLimit: { type: Number, default: 100 },
+		batteryBoostDefault: { type: Boolean, default: false },
 	},
-	emits: ["batteryboostlimit-updated"],
+	emits: ["batteryboostlimit-updated", "batteryboostdefault-updated"],
 	data() {
 		return {
 			selectedLimit: this.batteryBoostLimit,
+			selectedDefault: this.batteryBoostDefault,
 		};
 	},
 	computed: {
@@ -83,10 +112,16 @@ export default defineComponent({
 		batteryBoostLimit(newVal: number) {
 			this.selectedLimit = newVal;
 		},
+		batteryBoostDefault(newVal: boolean) {
+			this.selectedDefault = newVal;
+		},
 	},
 	methods: {
 		handleLimitChange() {
 			this.$emit("batteryboostlimit-updated", this.selectedLimit);
+		},
+		handleDefaultChange() {
+			this.$emit("batteryboostdefault-updated", this.selectedDefault);
 		},
 	},
 });

--- a/assets/js/components/Loadpoints/SettingsModal.vue
+++ b/assets/js/components/Loadpoints/SettingsModal.vue
@@ -36,6 +36,7 @@
 				v-bind="batteryBoostProps"
 				class="mt-2"
 				@batteryboostlimit-updated="setBatteryBoostLimit"
+				@batteryboostdefault-updated="setBatteryBoostDefault"
 			/>
 			<h6 v-if="heating">
 				{{ $t("main.loadpointSettings.heating") }}
@@ -252,6 +253,9 @@ export default defineComponent({
 		batteryBoostLimit() {
 			return this.loadpoint?.batteryBoostLimit;
 		},
+		batteryBoostDefault() {
+			return this.loadpoint?.batteryBoostDefault;
+		},
 		phasesConfigured() {
 			return this.loadpoint?.phasesConfigured;
 		},
@@ -344,6 +348,9 @@ export default defineComponent({
 		},
 		setBatteryBoostLimit(limit: number) {
 			api.post(this.apiPath("batteryboostlimit") + "/" + limit);
+		},
+		setBatteryBoostDefault(value: boolean) {
+			api.post(this.apiPath("batteryboostdefault") + "/" + (value ? "1" : "0"));
 		},
 		currentOption(current: number, isDefault: boolean, phases?: number) {
 			const kw = this.fmtPhasePower(current, phases);

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -381,6 +381,7 @@ export interface Loadpoint {
   vehicleTitle: string;
   vehicleWelcomeActive: boolean;
   batteryBoostLimit: number;
+  batteryBoostDefault: boolean;
   ui?: LoadpointUi;
 }
 

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -2,30 +2,31 @@ package keys
 
 const (
 	// loadpoint settings
-	Name              = "name"             // loadpoint name (config identifier)
-	Title             = "title"            // loadpoint title
-	Mode              = "mode"             // charge mode
-	DefaultMode       = "defaultMode"      // default charge mode
-	Charger           = "charger"          // charger ref
-	Meter             = "meter"            // meter ref
-	Circuit           = "circuit"          // circuit ref
-	DefaultVehicle    = "vehicle"          // default vehicle ref
-	Priority          = "priority"         // priority
-	MinCurrent        = "minCurrent"       // min current
-	MaxCurrent        = "maxCurrent"       // max current
-	MinSoc            = "minSoc"           // min soc (heating: min temperature)
-	MinSocNotReached  = "minSocNotReached" // min soc not reached
-	LimitSoc          = "limitSoc"         // limit soc
-	LimitEnergy       = "limitEnergy"      // limit energy
-	Soc               = "soc"
-	Thresholds        = "thresholds"
-	UI                = "ui" // display-only ui settings (json)
-	EnableThreshold   = "enableThreshold"
-	DisableThreshold  = "disableThreshold"
-	EnableDelay       = "enableDelay"
-	DisableDelay      = "disableDelay"
-	BatteryBoost      = "batteryBoost"
-	BatteryBoostLimit = "batteryBoostLimit"
+	Name                = "name"             // loadpoint name (config identifier)
+	Title               = "title"            // loadpoint title
+	Mode                = "mode"             // charge mode
+	DefaultMode         = "defaultMode"      // default charge mode
+	Charger             = "charger"          // charger ref
+	Meter               = "meter"            // meter ref
+	Circuit             = "circuit"          // circuit ref
+	DefaultVehicle      = "vehicle"          // default vehicle ref
+	Priority            = "priority"         // priority
+	MinCurrent          = "minCurrent"       // min current
+	MaxCurrent          = "maxCurrent"       // max current
+	MinSoc              = "minSoc"           // min soc (heating: min temperature)
+	MinSocNotReached    = "minSocNotReached" // min soc not reached
+	LimitSoc            = "limitSoc"         // limit soc
+	LimitEnergy         = "limitEnergy"      // limit energy
+	Soc                 = "soc"
+	Thresholds          = "thresholds"
+	UI                  = "ui" // display-only ui settings (json)
+	EnableThreshold     = "enableThreshold"
+	DisableThreshold    = "disableThreshold"
+	EnableDelay         = "enableDelay"
+	DisableDelay        = "disableDelay"
+	BatteryBoost        = "batteryBoost"
+	BatteryBoostLimit   = "batteryBoostLimit"
+	BatteryBoostDefault = "batteryBoostDefault"
 
 	PhasesConfigured = "phasesConfigured" // desired phase mode (0/1/3, 0 = automatic), user selection
 	PhasesActive     = "phasesActive"     // expectedly active phases, taking vehicle into account (1/2/3)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -122,6 +122,7 @@ type Loadpoint struct {
 	smartFeedInPriorityLimit *float64 // prevent charging if feed-in cost is above this value
 	batteryBoost             int      // battery boost state
 	batteryBoostLimit        int      // battery boost soc limit (0-100, 100=disabled)
+	batteryBoostDefault      bool     // auto-enable battery boost on vehicle connect
 
 	mode                api.ChargeMode
 	enabled             bool      // Charger enabled state
@@ -376,6 +377,9 @@ func (lp *Loadpoint) restoreSettings() {
 	if v, err := lp.settings.Int(keys.BatteryBoostLimit); err == nil {
 		lp.SetBatteryBoostLimit(int(v))
 	}
+	if v, err := lp.settings.Bool(keys.BatteryBoostDefault); err == nil {
+		lp.SetBatteryBoostDefault(v)
+	}
 
 	var thresholds loadpoint.ThresholdsConfig
 	if err := lp.settings.Json(keys.Thresholds, &thresholds); err == nil {
@@ -563,6 +567,13 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 
 	// immediately allow pv mode activity
 	lp.elapsePVTimer()
+
+	// re-arm battery boost if configured as default (opt-in, PV modes only)
+	if lp.GetBatteryBoostDefault() {
+		if err := lp.SetBatteryBoost(true); err != nil {
+			lp.log.DEBUG.Printf("battery boost default: %v", err)
+		}
+	}
 
 	// create charging session
 	lp.createSession()
@@ -762,6 +773,7 @@ func (lp *Loadpoint) Prepare(site site.API, uiChan chan<- util.Param, pushChan c
 	// battery boost
 	lp.publish(keys.BatteryBoost, lp.batteryBoost != boostDisabled)
 	lp.publish(keys.BatteryBoostLimit, lp.batteryBoostLimit)
+	lp.publish(keys.BatteryBoostDefault, lp.batteryBoostDefault)
 
 	// read initial charger state to prevent immediately disabling charger
 	if enabled, err := lp.charger.Enabled(); err == nil {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -569,9 +569,10 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 	lp.elapsePVTimer()
 
 	// re-arm battery boost if configured as default (opt-in, PV modes only).
-	// Skip integrated devices: their "connect" is just the socket switching on,
-	// not a real vehicle plug-in, so boost must stay manual there.
-	if lp.GetBatteryBoostDefault() && !lp.chargerHasFeature(api.IntegratedDevice) {
+	// Only when boost is actually enabled for the loadpoint (limit < 100) and
+	// not an integrated device (heating, ...) whose "connect" is merely the
+	// socket switching on rather than a real vehicle plug-in.
+	if lp.GetBatteryBoostDefault() && lp.GetBatteryBoostLimit() < 100 && !lp.chargerHasFeature(api.IntegratedDevice) {
 		if err := lp.SetBatteryBoost(true); err != nil {
 			lp.log.DEBUG.Printf("battery boost default: %v", err)
 		}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -568,8 +568,10 @@ func (lp *Loadpoint) evVehicleConnectHandler() {
 	// immediately allow pv mode activity
 	lp.elapsePVTimer()
 
-	// re-arm battery boost if configured as default (opt-in, PV modes only)
-	if lp.GetBatteryBoostDefault() {
+	// re-arm battery boost if configured as default (opt-in, PV modes only).
+	// Skip integrated devices: their "connect" is just the socket switching on,
+	// not a real vehicle plug-in, so boost must stay manual there.
+	if lp.GetBatteryBoostDefault() && !lp.chargerHasFeature(api.IntegratedDevice) {
 		if err := lp.SetBatteryBoost(true); err != nil {
 			lp.log.DEBUG.Printf("battery boost default: %v", err)
 		}

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -182,6 +182,10 @@ type API interface {
 	GetBatteryBoostLimit() int
 	// SetBatteryBoostLimit sets the battery boost soc limit
 	SetBatteryBoostLimit(int)
+	// GetBatteryBoostDefault returns whether battery boost is auto-enabled on connect
+	GetBatteryBoostDefault() bool
+	// SetBatteryBoostDefault sets whether battery boost is auto-enabled on connect
+	SetBatteryBoostDefault(bool)
 
 	//
 	// smart grid charging

--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -29,6 +29,7 @@ type DynamicConfig struct {
 	PlanTime                 time.Time `json:"planTime"`
 	PlanPrecondition_        int64     `json:"planPrecondition" mapstructure:"planPrecondition"` // TODO deprecated, keep for compatibility
 	BatteryBoostLimit        int       `json:"batteryBoostLimit"`
+	BatteryBoostDefault      bool      `json:"batteryBoostDefault"`
 	LimitEnergy              float64   `json:"limitEnergy"`
 	LimitSoc                 int       `json:"limitSoc"`
 	MinSoc                   int       `json:"minSoc"`
@@ -74,6 +75,7 @@ func (payload DynamicConfig) Apply(lp API) error {
 	lp.SetPlanEnergy(payload.PlanTime, payload.PlanEnergy)
 	lp.SetPlanStrategy(payload.PlanStrategy)
 	lp.SetBatteryBoostLimit(payload.BatteryBoostLimit)
+	lp.SetBatteryBoostDefault(payload.BatteryBoostDefault)
 	lp.SetLimitEnergy(payload.LimitEnergy)
 	lp.SetLimitSoc(payload.LimitSoc)
 	lp.SetMinSoc(payload.MinSoc)

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -179,6 +179,20 @@ func (mr *MockAPIMockRecorder) GetBatteryBoost() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBatteryBoost", reflect.TypeOf((*MockAPI)(nil).GetBatteryBoost))
 }
 
+// GetBatteryBoostDefault mocks base method.
+func (m *MockAPI) GetBatteryBoostDefault() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBatteryBoostDefault")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetBatteryBoostDefault indicates an expected call of GetBatteryBoostDefault.
+func (mr *MockAPIMockRecorder) GetBatteryBoostDefault() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBatteryBoostDefault", reflect.TypeOf((*MockAPI)(nil).GetBatteryBoostDefault))
+}
+
 // GetBatteryBoostLimit mocks base method.
 func (m *MockAPI) GetBatteryBoostLimit() int {
 	m.ctrl.T.Helper()
@@ -793,6 +807,18 @@ func (m *MockAPI) SetBatteryBoost(enable bool) error {
 func (mr *MockAPIMockRecorder) SetBatteryBoost(enable any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBatteryBoost", reflect.TypeOf((*MockAPI)(nil).SetBatteryBoost), enable)
+}
+
+// SetBatteryBoostDefault mocks base method.
+func (m *MockAPI) SetBatteryBoostDefault(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetBatteryBoostDefault", arg0)
+}
+
+// SetBatteryBoostDefault indicates an expected call of SetBatteryBoostDefault.
+func (mr *MockAPIMockRecorder) SetBatteryBoostDefault(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBatteryBoostDefault", reflect.TypeOf((*MockAPI)(nil).SetBatteryBoostDefault), arg0)
 }
 
 // SetBatteryBoostLimit mocks base method.

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -694,6 +694,27 @@ func (lp *Loadpoint) SetBatteryBoostLimit(limit int) {
 	}
 }
 
+// GetBatteryBoostDefault returns whether battery boost is auto-enabled on connect
+func (lp *Loadpoint) GetBatteryBoostDefault() bool {
+	lp.RLock()
+	defer lp.RUnlock()
+	return lp.batteryBoostDefault
+}
+
+// SetBatteryBoostDefault sets whether battery boost is auto-enabled on connect
+func (lp *Loadpoint) SetBatteryBoostDefault(enable bool) {
+	lp.Lock()
+	defer lp.Unlock()
+
+	lp.log.DEBUG.Println("set battery boost default:", enable)
+
+	if lp.batteryBoostDefault != enable {
+		lp.batteryBoostDefault = enable
+		lp.settings.SetBool(keys.BatteryBoostDefault, enable)
+		lp.publish(keys.BatteryBoostDefault, enable)
+	}
+}
+
 // HasChargeMeter determines if a physical charge meter is attached
 func (lp *Loadpoint) HasChargeMeter() bool {
 	_, isWrapped := lp.chargeMeter.(*wrapper.ChargeMeter)

--- a/core/loadpoint_battery_boost_test.go
+++ b/core/loadpoint_battery_boost_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"testing"
+
+	evbus "github.com/asaskevich/EventBus"
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/settings"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestBatteryBoostDefault(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+
+	lp := &Loadpoint{
+		log:               util.NewLogger("foo"),
+		bus:               evbus.New(),
+		clock:             clock.NewMock(),
+		settings:          settings.NewDatabaseSettingsAdapter("test-battery-boost-default"),
+		charger:           charger,
+		chargeMeter:       &Null{},
+		chargeRater:       &Null{},
+		chargeTimer:       &Null{},
+		wakeUpTimer:       NewTimer(),
+		minCurrent:        minA,
+		maxCurrent:        maxA,
+		status:            api.StatusC,
+		batteryBoostLimit: 100,
+	}
+	attachListeners(t, lp)
+
+	// opt-in default is off
+	assert.False(t, lp.GetBatteryBoostDefault(), "default should be off initially")
+
+	// setter toggles the in-memory state
+	lp.SetBatteryBoostDefault(true)
+	assert.True(t, lp.GetBatteryBoostDefault(), "should be enabled after set")
+
+	lp.SetBatteryBoostDefault(false)
+	assert.False(t, lp.GetBatteryBoostDefault(), "should be disabled after unset")
+
+	// battery boost (which the default re-arms on connect) is only available in PV modes
+	lp.mode = api.ModeOff
+	assert.Error(t, lp.SetBatteryBoost(true), "boost must be rejected outside PV modes")
+
+	lp.mode = api.ModePV
+	assert.NoError(t, lp.SetBatteryBoost(true), "boost must be accepted in PV mode")
+	assert.NotEqual(t, boostDisabled, lp.GetBatteryBoost(), "boost should be active after enabling in PV mode")
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1365,6 +1365,8 @@
     },
     "loadpointSettings": {
       "batteryBoost": {
+        "autoDescription": "Automatically enable Battery Boost whenever a vehicle connects.",
+        "autoLabel": "Enable automatically on connect",
         "description": "Allow fast charging from home battery until it's drained to {limit}.",
         "descriptionDisabled": "Select a limit to allow fast charging from home battery.",
         "disabled": "Disabled",

--- a/server/http.go
+++ b/server/http.go
@@ -219,6 +219,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 			"priority":                  {"POST", "/priority/{value:[0-9]+}", intHandler(pass(lp.SetPriority), lp.GetPriority)},
 			"batteryBoost":              {"POST", "/batteryboost/{value:[01truefalse]+}", boolHandler(lp.SetBatteryBoost, func() bool { return lp.GetBatteryBoost() > 0 })},
 			"batteryBoostLimit":         {"POST", "/batteryboostlimit/{value:[0-9]+}", intHandler(pass(lp.SetBatteryBoostLimit), lp.GetBatteryBoostLimit)},
+			"batteryBoostDefault":       {"POST", "/batteryboostdefault/{value:[01truefalse]+}", boolHandler(pass(lp.SetBatteryBoostDefault), lp.GetBatteryBoostDefault)},
 		}
 
 		for _, r := range routes {


### PR DESCRIPTION
## Discussion
Follows up on #31822 (related: #30558, #29208).

## Problem
`batteryBoost` resets on vehicle disconnect and is not persisted, so it has to be toggled manually every charging session. For a common setup — a **read-only** house battery (no battery control) — `batteryBoost` is the only way to route PV surplus from the house battery to the vehicle (see #31822 for data), which makes the manual toggling painful.

## Change
Adds an **opt-in, persisted** `batteryBoostDefault` setting (default `false`, existing behaviour unchanged):
- when enabled, battery boost is **automatically re-armed whenever a vehicle connects** (PV modes only)
- **skips `integrateddevice` loadpoints** (heating, …) — their "connect" is just the socket switching on, not a real plug-in (per @naltatis review)
- the existing `batteryBoostLimit` still auto-disables boost once the home battery drops below the configured SoC, so draining stays bounded
- new API route `POST /api/loadpoints/{id}/batteryboostdefault/{0|1}`, wired through the loadpoint `API` interface, mock and `DynamicConfig`
- **UI:** a toggle in the loadpoint battery-boost settings, surfaced only when boost is enabled for the loadpoint (`limit < 100`), as suggested by @naltatis

## Status
- [x] Backend (settings persistence, connect hook, API route)
- [x] Skip integrated devices (review)
- [x] UI toggle (shown only when boost is enabled)
- [x] Test (getter/setter + PV-mode gating)
- [x] i18n (`en.json`; other languages via Weblate)

`go build ./core/... ./server/`, `go test ./core/`, `npm run lint` and `npm run build` all pass locally. Marking ready for review — happy to adjust the approach based on your feedback (cc @andig, @naltatis).
