### PR TITLE
Marstek Venus: add holdcharge battery mode

### DIFF
--- a/templates/definition/meter/marstek-venus-a.yaml
+++ b/templates/definition/meter/marstek-venus-a.yaml
@@ -98,6 +98,16 @@ render: |
       set:
         source: sequence
         set:
+        # Restore Max Charge Power
+        - source: const
+          value: {{ .maxchargepower }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
         # Enable RS485 Control Mode
         - source: const
           value: 21930
@@ -188,5 +198,49 @@ render: |
               type: writesingle
               decode: uint16
     # Do not disable RS485 Control Mode because it will reset the device and let it charge/discharge again
+    - case: 4 # holdcharge -> no charging, discharging allowed
+      set:
+        source: sequence
+        set:
+        # Set Max Charge Power to 0 to prevent charging
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
+        # Enable RS485 Control Mode
+        - source: const
+          value: 21930
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Enabled
+              type: writesingle
+              decode: uint16
+        # Set User Work Mode
+        - source: const
+          value: {{ .work_mode_normal }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 43000 # User Work Mode
+              type: writesingle
+              decode: uint16
+        # Disable RS485 Control Mode
+        - source: const
+          value: 21947
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Disabled
+              type: writesingle
+              decode: uint16
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/marstek-venus-d.yaml
+++ b/templates/definition/meter/marstek-venus-d.yaml
@@ -98,6 +98,16 @@ render: |
       set:
         source: sequence
         set:
+        # Restore Max Charge Power
+        - source: const
+          value: {{ .maxchargepower }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
         # Enable RS485 Control Mode
         - source: const
           value: 21930
@@ -188,5 +198,49 @@ render: |
               type: writesingle
               decode: uint16
     # Do not disable RS485 Control Mode because it will reset the device and let it charge/discharge again
+    - case: 4 # holdcharge -> no charging, discharging allowed
+      set:
+        source: sequence
+        set:
+        # Set Max Charge Power to 0 to prevent charging
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
+        # Enable RS485 Control Mode
+        - source: const
+          value: 21930
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Enabled
+              type: writesingle
+              decode: uint16
+        # Set User Work Mode
+        - source: const
+          value: {{ .work_mode_normal }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 43000 # User Work Mode
+              type: writesingle
+              decode: uint16
+        # Disable RS485 Control Mode
+        - source: const
+          value: 21947
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Disabled
+              type: writesingle
+              decode: uint16
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/marstek-venus-e-v3.yaml
+++ b/templates/definition/meter/marstek-venus-e-v3.yaml
@@ -62,6 +62,16 @@ render: |
       set:
         source: sequence
         set:
+        # Restore Max Charge Power
+        - source: const
+          value: {{ .maxchargepower }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
         # Enable RS485 Control Mode
         - source: const
           value: 21930
@@ -152,4 +162,48 @@ render: |
               type: writesingle
               decode: uint16
     # Do not disable RS485 Control Mode because it will reset the device and let it charge/discharge again
+    - case: 4 # holdcharge -> no charging, discharging allowed
+      set:
+        source: sequence
+        set:
+        # Set Max Charge Power to 0 to prevent charging
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
+        # Enable RS485 Control Mode
+        - source: const
+          value: 21930
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Enabled
+              type: writesingle
+              decode: uint16
+        # Set User Work Mode
+        - source: const
+          value: {{ .work_mode_normal }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 43000 # User Work Mode
+              type: writesingle
+              decode: uint16
+        # Disable RS485 Control Mode
+        - source: const
+          value: 21947
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Disabled
+              type: writesingle
+              decode: uint16
   {{- include "battery-params" . }}

--- a/templates/definition/meter/marstek-venus-e.yaml
+++ b/templates/definition/meter/marstek-venus-e.yaml
@@ -69,6 +69,16 @@ render: |
       set:
         source: sequence
         set:
+        # Restore Max Charge Power
+        - source: const
+          value: {{ .maxchargepower }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
         # Enable RS485 Control Mode
         - source: const
           value: 21930
@@ -159,4 +169,48 @@ render: |
               type: writesingle
               decode: uint16
     # Do not disable RS485 Control Mode because it will reset the device and let it charge/discharge again
+    - case: 4 # holdcharge -> no charging, discharging allowed
+      set:
+        source: sequence
+        set:
+        # Set Max Charge Power to 0 to prevent charging
+        - source: const
+          value: 0
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 44002 # Max Charge Power
+              type: writesingle
+              decode: uint16
+        # Enable RS485 Control Mode
+        - source: const
+          value: 21930
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Enabled
+              type: writesingle
+              decode: uint16
+        # Set User Work Mode
+        - source: const
+          value: {{ .work_mode_normal }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 43000 # User Work Mode
+              type: writesingle
+              decode: uint16
+        # Disable RS485 Control Mode
+        - source: const
+          value: 21947
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 42000 # RS485 Control Mode = Disabled
+              type: writesingle
+              decode: uint16
   {{- include "battery-params" . }}


### PR DESCRIPTION
Fixes #31829

Implements `holdcharge` (no charging, discharging allowed) for the Marstek Venus family (Venus E/C, E v3, A, D) via register `44002` (Max Charge Power), analogous to the atmoce (#31632) and Kostal implementations:

- `holdcharge`: write `44002 = 0`, then restore the user work mode via the proven RS485-control sequence (enable → work mode → disable), clearing any lingering force charge/discharge state. The device keeps operating its configured work mode but cannot charge. The limit is written first so there is no charge burst when transitioning out of a forced charge.
- `normal`: now restores `44002` from the existing `maxchargepower` param (default 2500 W) — without this the battery would stay charge-blocked after leaving holdcharge.
- `hold` and `charge` are unchanged.

## Verified on hardware

Tested on three Venus E units (Modbus, via external battery mode API):

1. `holdcharge` → all units ACK the `44002 = 0` write
2. force `charge` while `44002 = 0` → **no charging** (0 W sustained; the register even overrides the forcible charge command 42010/42020, so blocking autonomous work-mode charging holds a fortiori)
3. `normal` → limit restored
4. force `charge` again → immediate charging at ~2.4 kW per unit

Note: `44002` is a persistent device setting. If evcc terminates while holdcharge is active, the battery stays charge-blocked until `normal` is applied again — same tradeoff as the atmoce/Kostal implementations, mitigated by the restore in `normal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)