### PR TITLE
Add Voltcast tariff template

### DIFF
--- a/templates/definition/tariff/voltcast.yaml
+++ b/templates/definition/tariff/voltcast.yaml
@@ -1,0 +1,89 @@
+template: voltcast
+products:
+  - brand: Voltcast
+requirements:
+  description:
+    en: "Requires a Voltcast API key — free DE-LU tier, paid any-zone tiers at [voltcast.com](https://voltcast.com/register). Forecast accuracy is published daily at [voltcast.com/accuracy](https://voltcast.com/accuracy)."
+    de: "Benötigt einen Voltcast API-Schlüssel — kostenloser DE-LU-Tarif, kostenpflichtige Tarife für alle Zonen auf [voltcast.com](https://voltcast.com/register). Die Prognosegenauigkeit wird täglich unter [voltcast.com/accuracy](https://voltcast.com/accuracy) veröffentlicht."
+  evcc: ["skiptest"]
+group: price
+countries: ["EU"]
+params:
+  - name: apikey
+    required: true
+    help:
+      en: API key from https://voltcast.com/dashboard
+      de: API-Schlüssel von https://voltcast.com/dashboard
+  - name: zone
+    type: choice
+    default: DE-LU
+    example: DE-LU
+    description:
+      generic: Bidding zone
+    choice:
+      [
+        "AL",
+        "AT",
+        "BE",
+        "BG",
+        "CH",
+        "CZ",
+        "DE-LU",
+        "DK1",
+        "DK2",
+        "EE",
+        "ES",
+        "FI",
+        "FR",
+        "GR",
+        "HR",
+        "HU",
+        "IE-SEM",
+        "IT-CALA",
+        "IT-CNOR",
+        "IT-CSUD",
+        "IT-NORD",
+        "IT-SARD",
+        "IT-SICI",
+        "IT-SUD",
+        "LT",
+        "LV",
+        "ME",
+        "MK",
+        "NL",
+        "NO1",
+        "NO2",
+        "NO3",
+        "NO4",
+        "NO5",
+        "PL",
+        "PT",
+        "RO",
+        "RS",
+        "SE1",
+        "SE2",
+        "SE3",
+        "SE4",
+        "SI",
+        "SK",
+        "UA",
+        "XK",
+      ]
+  - preset: tariff-base
+  - preset: tariff-features
+render: |
+  type: custom
+  features: ["cacheable"]
+  {{ include "tariff-base" . }}
+  {{ include "tariff-features" . }}
+  forecast:
+    source: http
+    uri: https://voltcast.com/api/v1/forecasts/{{ .zone }}?horizon=48h
+    headers:
+      - Authorization: Bearer {{ .apikey }}
+    jq: |
+      [ .data[] | {
+          start: .target_start,
+          end: (.target_start | fromdate + 900 | todate),
+          value: (.p50 / 1000)
+        } ] | tostring


### PR DESCRIPTION
Adds `templates/definition/tariff/voltcast.yaml` — day-ahead price forecasts for 43 European bidding zones at native 15-minute resolution via the [Voltcast](https://voltcast.com) API.

**As discussed with Andreas by email** ("looks exactly like the correct way to do it. Please feel free to open PR with voltcast.yaml as filename.") — thank you for the quick green light.

Details:
- `type: custom` with the standard `http` + `jq` forecast source (mirrors the energyforecast/groupe-e pattern), `tariff-base` + `tariff-features` presets.
- 48h P50 forecast curve, 15-minute slots, mapped to EUR/kWh (`p50 / 1000`).
- `skiptest` because an API key is required; there is a free DE-LU tier (no card) at voltcast.com/register, and the forecast accuracy behind this template is published daily at [voltcast.com/accuracy](https://voltcast.com/accuracy) — losses included.
- jq mapping validated against the live API today (143 slots, correct start/end/value shape).

Happy to set up free full-access keys for core-team testing — mail hello@voltcast.com or say the word here.

Made with [Cursor](https://cursor.com)