### PR TITLE
Config: show vehicle asleep state instead of value errors

### DIFF
--- a/assets/js/components/Config/DeviceTags.vue
+++ b/assets/js/components/Config/DeviceTags.vue
@@ -100,16 +100,16 @@ export default {
 						!PHASE_TAGS.includes(name) &&
 						!FORECAST_TAGS.includes(name)
 				)
-				.map(([name, { value, error, warning, muted }]) => {
-					return { name, value, error, warning, muted };
+				.map(([name, { value, error, warning, muted, asleep }]) => {
+					return { name, value, error, warning, muted, asleep };
 				});
 		},
 		phaseEntries() {
 			return Object.entries(this.tags)
 				.filter(([name]) => PHASE_TAGS.includes(name))
 				.sort(([a], [b]) => a.localeCompare(b))
-				.map(([name, { value, error, warning, muted }]) => {
-					return { name, value, error, warning, muted };
+				.map(([name, { value, error, warning, muted, asleep }]) => {
+					return { name, value, error, warning, muted, asleep };
 				});
 		},
 		hasPhaseEntries() {
@@ -182,6 +182,9 @@ export default {
 				: "text-nowrap flex-shrink-0";
 		},
 		valueClasses(entry) {
+			if (entry.asleep) {
+				return "value--muted";
+			}
 			if (entry.error) {
 				return "value--error";
 			}
@@ -195,6 +198,9 @@ export default {
 		},
 		fmtDeviceValue(entry) {
 			const { name, value } = entry;
+			if (entry.asleep) {
+				return this.$t("config.deviceValue.asleep");
+			}
 			if (value === null || value === undefined) {
 				return "";
 			}

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -188,6 +188,7 @@
     "deviceValue": {
       "activeClients": "Aktive Clients",
       "amount": "Anzahl",
+      "asleep": "schläft",
       "broker": "Broker",
       "bucket": "Bucket",
       "capacity": "Kapazität",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -188,6 +188,7 @@
     "deviceValue": {
       "activeClients": "Active clients",
       "amount": "Amount",
+      "asleep": "sleeping",
       "broker": "Broker",
       "bucket": "Bucket",
       "capacity": "Capacity",

--- a/plugin/error.go
+++ b/plugin/error.go
@@ -7,6 +7,7 @@ import (
 )
 
 type errorPlugin struct {
+	*getter
 	err error
 }
 
@@ -32,8 +33,17 @@ func NewErrorFromConfig(other map[string]any) (Plugin, error) {
 	o := &errorPlugin{
 		err: err,
 	}
+	o.getter = defaultGetters(o, 1)
 
 	return o, nil
+}
+
+var _ StringGetter = (*errorPlugin)(nil)
+
+func (o *errorPlugin) StringGetter() (func() (string, error), error) {
+	return func() (string, error) {
+		return "", o.err
+	}, nil
 }
 
 var _ IntSetter = (*errorPlugin)(nil)

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -245,8 +245,9 @@ func deviceInstanceFromMergedConfig[T any](ctx context.Context, id int, class te
 }
 
 type testResult = struct {
-	Value any    `json:"value"`
-	Error string `json:"error"`
+	Value  any    `json:"value"`
+	Error  string `json:"error"`
+	Asleep bool   `json:"asleep,omitempty"`
 }
 
 func hasFeature(instance any, f api.Feature) bool {
@@ -266,7 +267,12 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 			if errors.Is(err, api.ErrNotAvailable) {
 				return
 			}
-			tr.Error = err.Error()
+			// asleep is a valid vehicle state, not an error
+			if errors.Is(err, api.ErrAsleep) {
+				tr.Asleep = true
+			} else {
+				tr.Error = err.Error()
+			}
 		}
 		resMu.Lock()
 		res[key] = tr

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/globalconfig"
 	"github.com/evcc-io/evcc/plugin/mqtt"
 	"github.com/evcc-io/evcc/util/config"
@@ -64,6 +65,24 @@ func TestInstanceParallelProbes(t *testing.T) {
 	res := testInstance(ctx, slowPowerMeter{done: done})
 	require.Contains(t, res, "energy", "fast getter must return despite a blocking sibling")
 	require.NotContains(t, res, "power", "blocking getter must be abandoned")
+}
+
+// asleepVehicle returns api.ErrAsleep from its getters.
+type asleepVehicle struct{}
+
+func (v asleepVehicle) Soc() (float64, error) {
+	return 0, api.ErrAsleep
+}
+
+func (v asleepVehicle) Range() (int64, error) {
+	return 0, api.ErrAsleep
+}
+
+// TestInstanceAsleep ensures asleep is flagged as state, not as error.
+func TestInstanceAsleep(t *testing.T) {
+	res := testInstance(context.Background(), asleepVehicle{})
+	assert.Equal(t, testResult{Value: 0.0, Asleep: true}, res["soc"])
+	assert.Equal(t, testResult{Value: int64(0), Asleep: true}, res["range"])
 }
 
 func TestConfigReqUnmarshal(t *testing.T) {

--- a/tests/vehicle-asleep.evcc.yaml
+++ b/tests/vehicle-asleep.evcc.yaml
@@ -1,0 +1,8 @@
+vehicles:
+  - name: sleepy
+    type: custom
+    title: Sleepy Car
+    capacity: 68
+    soc:
+      source: error
+      error: ErrAsleep

--- a/tests/vehicle-asleep.spec.ts
+++ b/tests/vehicle-asleep.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+
+test.use({ baseURL: baseUrl() });
+
+test.beforeEach(async () => {
+  await start("vehicle-asleep.evcc.yaml");
+});
+
+test.afterEach(async () => {
+  await stop();
+});
+
+test.describe("asleep vehicle", async () => {
+  test("config: values show sleeping state instead of errors", async ({ page }) => {
+    await page.goto("/#/config");
+
+    const vehicle = page.getByTestId("vehicle");
+    await expect(vehicle).toHaveCount(1);
+    await expect(vehicle).toContainText("Sleepy Car");
+    await expect(vehicle.getByTestId("device-tag-capacity")).toContainText("68.0 kWh");
+    await expect(vehicle.getByTestId("device-tag-soc")).toContainText("sleeping");
+    await expect(page.getByTestId("header")).toBeVisible();
+  });
+});


### PR DESCRIPTION
fixes #31852

Vehicles reporting `api.ErrAsleep` showed red error values in the config device tile, although asleep is a regular vehicle state.

- device status/test endpoint: flag asleep values with `asleep: true` instead of an error
- config tile: asleep values render as translated "sleeping" text, muted instead of red
- error plugin now also works as getter (docs already showed this usage)
- e2e test with asleep custom vehicle

<img width="332" height="249" alt="Bildschirmfoto 2026-07-17 um 08 35 05" src="https://github.com/user-attachments/assets/65f4f236-35d9-4c8a-9c99-591b98043c5f" />
