### PR TITLE
Charger (Phoenix EV-ETH): add millicurrentsupported option

### DIFF
--- a/charger/phoenix-ev-eth.go
+++ b/charger/phoenix-ev-eth.go
@@ -66,19 +66,24 @@ func init() {
 
 // NewPhoenixEVEthFromConfig creates a PhoenixEVEth charger from generic config
 func NewPhoenixEVEthFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
-	cc := modbus.TcpSettings{
-		ID: 255,
+	cc := struct {
+		modbus.TcpSettings    `mapstructure:",squash"`
+		MilliCurrentSupported bool
+	}{
+		TcpSettings: modbus.TcpSettings{
+			ID: 255,
+		},
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
-	return NewPhoenixEVEth(ctx, cc.URI, cc.ID)
+	return NewPhoenixEVEth(ctx, cc.URI, cc.ID, cc.MilliCurrentSupported)
 }
 
 // NewPhoenixEVEth creates a PhoenixEVEth charger
-func NewPhoenixEVEth(ctx context.Context, uri string, slaveID uint8) (api.Charger, error) {
+func NewPhoenixEVEth(ctx context.Context, uri string, slaveID uint8, milliCurrentSupported bool) (api.Charger, error) {
 	conn, err := modbus.NewConnection(ctx, uri, "", "", 0, modbus.Tcp, slaveID)
 	if err != nil {
 		return nil, err
@@ -110,7 +115,12 @@ func NewPhoenixEVEth(ctx context.Context, uri string, slaveID uint8) (api.Charge
 	}
 
 	// check presence of extended Wallbe firmware
-	if b, err := wb.conn.ReadHoldingRegisters(phxRegMaxCurrent, 1); err == nil && encoding.Uint16(b) >= 60 {
+	if !milliCurrentSupported {
+		b, err := wb.conn.ReadHoldingRegisters(phxRegMaxCurrent, 1)
+		milliCurrentSupported = err == nil && encoding.Uint16(b) >= 60
+	}
+
+	if milliCurrentSupported {
 		wb.isWallbe = true
 		implement.May(wb, implement.ChargerEx(wb.maxCurrentMillis))
 	}

--- a/templates/definition/charger/phoenix-ev-eth.yaml
+++ b/templates/definition/charger/phoenix-ev-eth.yaml
@@ -54,6 +54,6 @@ params:
 render: |
   type: phoenix-ev-eth
   {{- include "modbus" . }}
-  {{- if ne .millicurrentsupported "false" }}
+  {{- if eq .millicurrentsupported "true" }}
   millicurrentsupported: true
   {{- end }}

--- a/templates/definition/charger/phoenix-ev-eth.yaml
+++ b/templates/definition/charger/phoenix-ev-eth.yaml
@@ -41,6 +41,19 @@ params:
   - name: modbus
     choice: ["tcpip"]
     id: 255
+  - name: millicurrentsupported
+    type: bool
+    default: false
+    advanced: true
+    description:
+      de: mA-Regelung unterstützt
+      en: mA regulation supported
+    help:
+      de: Erzwingt die mA-Regelung der erweiterten Wallbe-Firmware, falls die automatische Erkennung fehlschlägt.
+      en: Forces mA regulation of the extended Wallbe firmware in case autodetection fails.
 render: |
   type: phoenix-ev-eth
   {{- include "modbus" . }}
+  {{- if ne .millicurrentsupported "false" }}
+  millicurrentsupported: true
+  {{- end }}


### PR DESCRIPTION
fixes #31844

The Wallbe/extended-firmware detection reads `phxRegMaxCurrent` and treats a raw value `>= 60` as "supports 0.1A steps". If the register was last written with a value `< 60` (e.g. an E3/DC main system re-configuring the wallbox while evcc is offline), evcc misdetects the firmware and then writes plain amperes (6-16) instead of decimal amps (60-160), limiting the charger to 0.6-1.6A. The misdetection persists until the register is manually corrected.

Adds an advanced `millicurrentsupported` bool that skips the heuristic and forces mA regulation. Unset/false keeps the existing autodetection, so no behaviour change for existing configs.

Only the false-negative direction is overridable: OEM firmware never leaves a value `>= 60` in that register, so autodetection cannot falsely report support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)