### PR TITLE
docs: update openapi docs links

### DIFF
--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -528,13 +528,13 @@
       "LoadpointName": {
         "example": "Garage",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/loadpoints#title"
+          "url": "https://docs.evcc.io/en/reference/configuration/loadpoints#title"
         },
         "type": "string"
       },
       "LogArea": {
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/log#levels"
+          "url": "https://docs.evcc.io/en/reference/configuration/log#levels"
         },
         "type": "string"
       },
@@ -545,7 +545,7 @@
           "db"
         ],
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/log#levels"
+          "url": "https://docs.evcc.io/en/reference/configuration/log#levels"
         },
         "items": {
           "$ref": "#/components/schemas/LogArea"
@@ -563,7 +563,7 @@
         ],
         "example": "DEBUG",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/log#log"
+          "url": "https://docs.evcc.io/en/reference/configuration/log#log"
         },
         "type": "string"
       },
@@ -667,7 +667,7 @@
       },
       "RepeatingPlan": {
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans#repeating-plans"
+          "url": "https://docs.evcc.io/en/features/plans#repeating-plans"
         },
         "properties": {
           "active": {
@@ -702,7 +702,7 @@
       },
       "StaticEnergyPlan": {
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans#energy-amount-plan"
+          "url": "https://docs.evcc.io/en/features/plans#energy-amount-plan"
         },
         "properties": {
           "energy": {
@@ -716,7 +716,7 @@
       },
       "StaticSocPlan": {
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans#create-charging-plan"
+          "url": "https://docs.evcc.io/en/features/plans#create-charging-plan"
         },
         "properties": {
           "soc": {
@@ -742,7 +742,7 @@
       "VehicleName": {
         "example": "vehicle_1",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/vehicles#name"
+          "url": "https://docs.evcc.io/en/reference/configuration/vehicles#name"
         },
         "minLength": 1,
         "pattern": "[a-zA-Z0-9_.:-]+",
@@ -751,7 +751,7 @@
       "VehicleTitle": {
         "example": "blauer e-Golf",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/vehicles#title"
+          "url": "https://docs.evcc.io/en/reference/configuration/vehicles#title"
         },
         "type": "string"
       },
@@ -1015,7 +1015,7 @@
       "post": {
         "description": "Prevent home battery discharge during vehicle fast charging.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery"
+          "url": "https://docs.evcc.io/en/features/battery"
         },
         "operationId": "setBatteryDischargeControl",
         "parameters": [
@@ -1038,7 +1038,7 @@
       "delete": {
         "description": "Remove battery grid charge limit.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery"
+          "url": "https://docs.evcc.io/en/features/battery"
         },
         "operationId": "removeBatteryGridChargeLimit",
         "responses": {
@@ -1056,7 +1056,7 @@
       "post": {
         "description": "Charge home battery from grid when price or emissions are below the threshold. Uses price if a dynamic tariff exists. Uses emissions if a CO₂-tariff is configured. Ignored otherwise.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery"
+          "url": "https://docs.evcc.io/en/features/battery"
         },
         "operationId": "setBatteryGridChargeLimit",
         "parameters": [
@@ -1114,7 +1114,7 @@
       "post": {
         "description": "Set battery buffer SoC.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery"
+          "url": "https://docs.evcc.io/en/features/battery"
         },
         "operationId": "setBufferSoc",
         "parameters": [
@@ -1137,7 +1137,7 @@
       "post": {
         "description": "Set battery buffer start SoC.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery"
+          "url": "https://docs.evcc.io/en/features/battery"
         },
         "operationId": "setBufferStartSoc",
         "parameters": [
@@ -1492,7 +1492,7 @@
       "post": {
         "description": "Enable or disable battery boost. When active, the maximum available home battery power is added until the home battery is drained to configured SoC limit. Note: boost will not work while the battery is on hold (e.g. during fast charging or planned charging with discharge prevention enabled).",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery#battery-boost"
+          "url": "https://docs.evcc.io/en/features/battery#battery-boost"
         },
         "operationId": "setLoadpointBatteryBoost",
         "parameters": [
@@ -1518,7 +1518,7 @@
       "post": {
         "description": "Set the SoC limit for battery boost. Home battery will be used to support charging up to this SoC level. A value of 100 (default) disabled the boost feature in UI and API.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery#battery-boost"
+          "url": "https://docs.evcc.io/en/features/battery#battery-boost"
         },
         "operationId": "setLoadpointBatteryBoostLimit",
         "parameters": [
@@ -1544,7 +1544,7 @@
       "post": {
         "description": "Delay before charging stops in solar mode.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/loadpoints"
+          "url": "https://docs.evcc.io/en/reference/configuration/loadpoints"
         },
         "operationId": "setLoadpointDisableDelay",
         "parameters": [
@@ -1570,7 +1570,7 @@
       "post": {
         "description": "Specifies the grid draw power to stop charging in solar mode.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/loadpoints#threshold-1"
+          "url": "https://docs.evcc.io/en/reference/configuration/loadpoints#threshold-1"
         },
         "operationId": "setLoadpointDisableThreshold",
         "parameters": [
@@ -1596,7 +1596,7 @@
       "post": {
         "description": "Delay before charging starts in solar mode.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/loadpoints#delay"
+          "url": "https://docs.evcc.io/en/reference/configuration/loadpoints#delay"
         },
         "operationId": "setLoadpointEnableDelay",
         "parameters": [
@@ -1622,7 +1622,7 @@
       "post": {
         "description": "Specifies the available surplus power to start charging in solar mode.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/loadpoints#threshold"
+          "url": "https://docs.evcc.io/en/reference/configuration/loadpoints#threshold"
         },
         "operationId": "setLoadpointEnableThreshold",
         "parameters": [
@@ -1648,7 +1648,7 @@
       "post": {
         "description": "Updates the energy limit of the loadpoint. Only available for guest vehicles and vehicles with unknown SoC. Limit is removed on vehicle disconnect.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/limit"
+          "url": "https://docs.evcc.io/en/features/limits"
         },
         "operationId": "setLoadpointEnergyLimit",
         "parameters": [
@@ -1674,7 +1674,7 @@
       "post": {
         "description": "Sets the session SoC limit. Cleared on disconnect. Takes precedence over the vehicle's configured limit while set; once cleared (set to 0), the vehicle limit applies again.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/limit"
+          "url": "https://docs.evcc.io/en/features/limits"
         },
         "operationId": "setLoadpointSocLimit",
         "parameters": [
@@ -1746,7 +1746,7 @@
       "post": {
         "description": "Sets the minimum temperature for heating devices. The device is heated as fast as possible while below this value. Set to 0 to disable.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/limit"
+          "url": "https://docs.evcc.io/en/features/limits"
         },
         "operationId": "setLoadpointMinTemp",
         "parameters": [
@@ -1772,7 +1772,7 @@
       "post": {
         "description": "Changes the charging behavior of the loadpoint.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/solar-charging"
+          "url": "https://docs.evcc.io/en/features/solar-charging"
         },
         "operationId": "setLoadpointMode",
         "parameters": [
@@ -1810,7 +1810,7 @@
       "post": {
         "description": "Updates the allowed phases of the loadpoint. Selects the desired phase mode for chargers with automatic phase switching. For manual phase switching chargers (via cable or Lasttrennschalter) this value tells evcc the actual phases.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/loadpoints#phases"
+          "url": "https://docs.evcc.io/en/reference/configuration/loadpoints#phases"
         },
         "operationId": "setLoadpointPhases",
         "parameters": [
@@ -1839,7 +1839,7 @@
       "get": {
         "description": "Returns the current charging plan for this loadpoint.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "getLoadpointPlan",
         "parameters": [
@@ -1886,7 +1886,7 @@
       "delete": {
         "description": "Delete charging plan. Only available when a vehicle without SoC is connected.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "deleteLoadpointEnergyPlan",
         "parameters": [
@@ -1909,7 +1909,7 @@
       "post": {
         "description": "Create charging plan with fixed time and energy target. Only available when a vehicle without SoC is connected.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "setLoadpointEnergyPlan",
         "parameters": [
@@ -1950,7 +1950,7 @@
       "get": {
         "description": "Simulate repeating charging plan and return the result. Does not alter the actual charging plan.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "previewLoadpointRepeatingPlan",
         "parameters": [
@@ -1985,7 +1985,7 @@
       "get": {
         "description": "Simulate charging plan based on energy goal. Does not alter the actual charging plan.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "previewLoadpointEnergyPlan",
         "parameters": [
@@ -2014,7 +2014,7 @@
       "get": {
         "description": "Simulate charging plan based on SoC goal. Does not alter the actual charging plan.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "previewLoadpointSocPlan",
         "parameters": [
@@ -2043,7 +2043,7 @@
       "post": {
         "description": "Updates the charging plan strategy for the loadpoint.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "setLoadpointPlanStrategy",
         "parameters": [
@@ -2088,7 +2088,7 @@
       "post": {
         "description": "Set loadpoint priority.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/loadpoints#priority"
+          "url": "https://docs.evcc.io/en/reference/configuration/loadpoints#priority"
         },
         "operationId": "setLoadpointPriority",
         "parameters": [
@@ -2122,7 +2122,7 @@
       "delete": {
         "description": "Delete cost or emission limit for fast-charging with grid energy.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/dynamic-prices"
+          "url": "https://docs.evcc.io/en/features/dynamic-prices"
         },
         "operationId": "deleteLoadpointSmartCostLimit",
         "parameters": [
@@ -2145,7 +2145,7 @@
       "post": {
         "description": "Set cost or emission limit for fast-charging with grid energy.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/dynamic-prices"
+          "url": "https://docs.evcc.io/en/features/dynamic-prices"
         },
         "operationId": "setLoadpointSmartCostLimit",
         "parameters": [
@@ -2214,7 +2214,7 @@
       "delete": {
         "description": "Remove vehicle from loadpoint. Connected vehicle is treated as guest vehicle.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/vehicle"
+          "url": "https://docs.evcc.io/en/features/vehicle"
         },
         "operationId": "removeLoadpointVehicle",
         "parameters": [
@@ -2235,7 +2235,7 @@
       "patch": {
         "description": "Starts the automatic vehicle detection process.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/vehicle"
+          "url": "https://docs.evcc.io/en/features/vehicle"
         },
         "operationId": "startLoadpointVehicleDetection",
         "parameters": [
@@ -2258,7 +2258,7 @@
       "post": {
         "description": "Assigns vehicle to loadpoint.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/vehicle"
+          "url": "https://docs.evcc.io/en/features/vehicle"
         },
         "operationId": "assignLoadpointVehicle",
         "parameters": [
@@ -2301,7 +2301,7 @@
       "post": {
         "description": "Set battery priority SoC.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/battery"
+          "url": "https://docs.evcc.io/en/features/battery"
         },
         "operationId": "setPrioritySoc",
         "parameters": [
@@ -2324,7 +2324,7 @@
       "post": {
         "description": "Set grid connection operating point.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/site#residualpower"
+          "url": "https://docs.evcc.io/en/reference/configuration/site#residualpower"
         },
         "operationId": "setResidualPower",
         "parameters": [
@@ -2347,7 +2347,7 @@
       "delete": {
         "description": "Delete charging session.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/sessions"
+          "url": "https://docs.evcc.io/en/features/sessions"
         },
         "operationId": "deleteSession",
         "responses": {
@@ -2368,7 +2368,7 @@
       "put": {
         "description": "Update vehicle, loadpoint or odometer of a charging session. Only provided fields are changed; a null odometer clears the stored value.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/sessions"
+          "url": "https://docs.evcc.io/en/features/sessions"
         },
         "operationId": "updateSession",
         "requestBody": {
@@ -2407,7 +2407,7 @@
       "get": {
         "description": "Returns a list of charging sessions.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/sessions"
+          "url": "https://docs.evcc.io/en/features/sessions"
         },
         "operationId": "getSessions",
         "parameters": [
@@ -2486,7 +2486,7 @@
       "post": {
         "description": "Enable or disable telemetry. Note: Telemetry requires sponsorship.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/telemetry"
+          "url": "https://docs.evcc.io/en/reference/configuration/telemetry"
         },
         "operationId": "setTelemetryStatus",
         "parameters": [
@@ -2582,7 +2582,7 @@
       "get": {
         "description": "Returns the complete state of the system. This structure is used by the UI. It can be filtered by JQ to only return a subset of the data.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/state"
+          "url": "https://docs.evcc.io/integrations/rest-api"
         },
         "operationId": "getState",
         "parameters": [
@@ -2658,7 +2658,7 @@
       "get": {
         "description": "Returns the latest log lines.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/reference/configuration/log"
+          "url": "https://docs.evcc.io/en/reference/configuration/log"
         },
         "operationId": "getSystemLogs",
         "parameters": [
@@ -2801,7 +2801,7 @@
       "get": {
         "description": "Returns the prices or emission values for the upcoming hours",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/devices/tariffs"
+          "url": "https://docs.evcc.io/en/tariffs"
         },
         "operationId": "getTariffInfo",
         "parameters": [
@@ -2857,7 +2857,7 @@
       "post": {
         "description": "Charging will stop when this SoC is reached.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/limits"
+          "url": "https://docs.evcc.io/en/features/limits"
         },
         "operationId": "setVehicleSocLimit",
         "parameters": [
@@ -2883,7 +2883,7 @@
       "post": {
         "description": "Vehicle will be fast-charged until this SoC is reached.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/limits"
+          "url": "https://docs.evcc.io/en/features/limits"
         },
         "operationId": "setVehicleMinSoc",
         "parameters": [
@@ -2909,7 +2909,7 @@
       "delete": {
         "description": "Resets the vehicle charge mode to keep the last selected mode.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/solar-charging"
+          "url": "https://docs.evcc.io/en/features/solar-charging"
         },
         "operationId": "deleteVehicleMode",
         "parameters": [
@@ -2932,7 +2932,7 @@
       "post": {
         "description": "Sets the charge mode applied when this vehicle becomes active on a loadpoint.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/solar-charging"
+          "url": "https://docs.evcc.io/en/features/solar-charging"
         },
         "operationId": "setVehicleMode",
         "parameters": [
@@ -2970,7 +2970,7 @@
       "post": {
         "description": "Updates the repeating charging plan.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "updateVehicleRepeatingPlans",
         "parameters": [
@@ -3021,7 +3021,7 @@
       "delete": {
         "description": "Delete the charging plan",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "deleteVehicleSocPlan",
         "parameters": [
@@ -3044,7 +3044,7 @@
       "post": {
         "description": "Create charging plan with fixed time and SoC target.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "setVehicleSocPlan",
         "parameters": [
@@ -3093,7 +3093,7 @@
       "post": {
         "description": "Updates the charging plan strategy for the vehicle.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/en/docs/features/plans"
+          "url": "https://docs.evcc.io/en/features/plans"
         },
         "operationId": "setVehiclePlanStrategy",
         "parameters": [

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -172,7 +172,7 @@ paths:
       summary: Control battery-discharge
       description: "Prevent home battery discharge during vehicle fast charging."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -186,7 +186,7 @@ paths:
       summary: Remove battery grid charge limit
       description: "Remove battery grid charge limit."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       responses:
@@ -198,7 +198,7 @@ paths:
       summary: Set battery grid charge limit
       description: "Charge home battery from grid when price or emissions are below the threshold. Uses price if a dynamic tariff exists. Uses emissions if a CO₂-tariff is configured. Ignored otherwise."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -234,7 +234,7 @@ paths:
       summary: Set battery buffer SoC
       description: "Set battery buffer SoC."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -248,7 +248,7 @@ paths:
       summary: Set battery buffer start SoC
       description: "Set battery buffer start SoC."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -262,7 +262,7 @@ paths:
       summary: Set battery boost
       description: "Enable or disable battery boost. When active, the maximum available home battery power is added until the home battery is drained to configured SoC limit. Note: boost will not work while the battery is on hold (e.g. during fast charging or planned charging with discharge prevention enabled)."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery#battery-boost
+        url: https://docs.evcc.io/en/features/battery#battery-boost
       tags:
         - loadpoints
       parameters:
@@ -277,7 +277,7 @@ paths:
       summary: Set battery boost SoC limit
       description: "Set the SoC limit for battery boost. Home battery will be used to support charging up to this SoC level. A value of 100 (default) disabled the boost feature in UI and API."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery#battery-boost
+        url: https://docs.evcc.io/en/features/battery#battery-boost
       tags:
         - loadpoints
       parameters:
@@ -292,7 +292,7 @@ paths:
       summary: Disable threshold-delay
       description: "Delay before charging stops in solar mode."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints
       tags:
         - loadpoints
       parameters:
@@ -307,7 +307,7 @@ paths:
       summary: Disable threshold
       description: "Specifies the grid draw power to stop charging in solar mode."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#threshold-1
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#threshold-1
       tags:
         - loadpoints
       parameters:
@@ -322,7 +322,7 @@ paths:
       summary: Enable threshold-delay
       description: "Delay before charging starts in solar mode."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#delay
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#delay
       tags:
         - loadpoints
       parameters:
@@ -337,7 +337,7 @@ paths:
       summary: Enable threshold
       description: "Specifies the available surplus power to start charging in solar mode."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#threshold
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#threshold
       tags:
         - loadpoints
       parameters:
@@ -352,7 +352,7 @@ paths:
       summary: Update energy limit
       description: "Updates the energy limit of the loadpoint. Only available for guest vehicles and vehicles with unknown SoC. Limit is removed on vehicle disconnect."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limit
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - loadpoints
       parameters:
@@ -367,7 +367,7 @@ paths:
       summary: Update session SoC limit
       description: "Sets the session SoC limit. Cleared on disconnect. Takes precedence over the vehicle's configured limit while set; once cleared (set to 0), the vehicle limit applies again."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limit
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - loadpoints
       parameters:
@@ -408,7 +408,7 @@ paths:
       summary: Update minimum temperature
       description: "Sets the minimum temperature for heating devices. The device is heated as fast as possible while below this value. Set to 0 to disable."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limit
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - loadpoints
       parameters:
@@ -423,7 +423,7 @@ paths:
       summary: Update charge mode
       description: "Changes the charging behavior of the loadpoint."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/solar-charging
+        url: https://docs.evcc.io/en/features/solar-charging
       tags:
         - loadpoints
       parameters:
@@ -445,7 +445,7 @@ paths:
       summary: Update allowed phases
       description: "Updates the allowed phases of the loadpoint. Selects the desired phase mode for chargers with automatic phase switching. For manual phase switching chargers (via cable or Lasttrennschalter) this value tells evcc the actual phases."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#phases
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#phases
       tags:
         - loadpoints
       parameters:
@@ -462,7 +462,7 @@ paths:
       summary: Get charging plan
       description: "Returns the current charging plan for this loadpoint."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -488,7 +488,7 @@ paths:
       summary: Delete energy-based charging plan
       description: "Delete charging plan. Only available when a vehicle without SoC is connected."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -502,7 +502,7 @@ paths:
       summary: Set energy-based charging plan
       description: "Create charging plan with fixed time and energy target. Only available when a vehicle without SoC is connected."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -525,7 +525,7 @@ paths:
       summary: Repeating plan preview
       description: "Simulate repeating charging plan and return the result. Does not alter the actual charging plan."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -543,7 +543,7 @@ paths:
       summary: Simulate soc-based charging plan
       description: "Simulate charging plan based on SoC goal. Does not alter the actual charging plan."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -559,7 +559,7 @@ paths:
       summary: Simulate energy-based charging plan
       description: "Simulate charging plan based on energy goal. Does not alter the actual charging plan."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -575,7 +575,7 @@ paths:
       summary: Set plan strategy
       description: "Updates the charging plan strategy for the loadpoint."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -602,7 +602,7 @@ paths:
       summary: Set priority
       description: "Set loadpoint priority."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#priority
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#priority
       tags:
         - loadpoints
       parameters:
@@ -624,7 +624,7 @@ paths:
       summary: Delete smart charging cost limit
       description: "Delete cost or emission limit for fast-charging with grid energy."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/dynamic-prices
+        url: https://docs.evcc.io/en/features/dynamic-prices
       tags:
         - loadpoints
       parameters:
@@ -638,7 +638,7 @@ paths:
       summary: Set smart charging cost limit
       description: "Set cost or emission limit for fast-charging with grid energy."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/dynamic-prices
+        url: https://docs.evcc.io/en/features/dynamic-prices
       tags:
         - loadpoints
       parameters:
@@ -678,7 +678,7 @@ paths:
       summary: Remove vehicle
       description: "Remove vehicle from loadpoint. Connected vehicle is treated as guest vehicle."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/vehicle
+        url: https://docs.evcc.io/en/features/vehicle
       tags:
         - loadpoints
       parameters:
@@ -691,7 +691,7 @@ paths:
       summary: Start vehicle detection
       description: "Starts the automatic vehicle detection process."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/vehicle
+        url: https://docs.evcc.io/en/features/vehicle
       tags:
         - loadpoints
       parameters:
@@ -705,7 +705,7 @@ paths:
       summary: Assign vehicle
       description: "Assigns vehicle to loadpoint."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/vehicle
+        url: https://docs.evcc.io/en/features/vehicle
       tags:
         - loadpoints
       parameters:
@@ -730,7 +730,7 @@ paths:
       summary: Set battery priority SoC
       description: "Set battery priority SoC."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -744,7 +744,7 @@ paths:
       summary: Set grid residual power
       description: "Set grid connection operating point."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/site#residualpower
+        url: https://docs.evcc.io/en/reference/configuration/site#residualpower
       tags:
         - battery
       parameters:
@@ -782,7 +782,7 @@ paths:
       summary: Update charging session
       description: "Update vehicle, loadpoint or odometer of a charging session. Only provided fields are changed; a null odometer clears the stored value."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/sessions
+        url: https://docs.evcc.io/en/features/sessions
       tags:
         - sessions
       requestBody:
@@ -806,7 +806,7 @@ paths:
       summary: Delete charging session
       description: "Delete charging session."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/sessions
+        url: https://docs.evcc.io/en/features/sessions
       tags:
         - sessions
       responses:
@@ -854,7 +854,7 @@ paths:
       summary: Charging sessions
       description: "Returns a list of charging sessions."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/sessions
+        url: https://docs.evcc.io/en/features/sessions
       tags:
         - sessions
       parameters:
@@ -906,7 +906,7 @@ paths:
       summary: Enable/disable telemetry
       description: "Enable or disable telemetry. Note: Telemetry requires sponsorship."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/telemetry
+        url: https://docs.evcc.io/en/reference/configuration/telemetry
       tags:
         - system
       parameters:
@@ -944,7 +944,7 @@ paths:
       summary: System state
       description: "Returns the complete state of the system. This structure is used by the UI. It can be filtered by JQ to only return a subset of the data."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/state
+        url: https://docs.evcc.io/integrations/rest-api
       tags:
         - general
       parameters:
@@ -976,7 +976,7 @@ paths:
       summary: Logs
       description: "Returns the latest log lines."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log
+        url: https://docs.evcc.io/en/reference/configuration/log
       security:
         - cookieAuth: []
         - bearerAuth: []
@@ -1075,7 +1075,7 @@ paths:
       summary: Tariff information
       description: "Returns the prices or emission values for the upcoming hours"
       externalDocs:
-        url: https://docs.evcc.io/en/docs/devices/tariffs
+        url: https://docs.evcc.io/en/tariffs
       tags:
         - tariffs
       parameters:
@@ -1112,7 +1112,7 @@ paths:
       summary: Set SoC limit
       description: "Charging will stop when this SoC is reached."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limits
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - vehicles
       parameters:
@@ -1127,7 +1127,7 @@ paths:
       summary: Set minimum SoC
       description: "Vehicle will be fast-charged until this SoC is reached."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limits
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - vehicles
       parameters:
@@ -1142,7 +1142,7 @@ paths:
       summary: Reset charge mode
       description: "Resets the vehicle charge mode to keep the last selected mode."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/solar-charging
+        url: https://docs.evcc.io/en/features/solar-charging
       tags:
         - vehicles
       parameters:
@@ -1156,7 +1156,7 @@ paths:
       summary: Set charge mode
       description: "Sets the charge mode applied when this vehicle becomes active on a loadpoint."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/solar-charging
+        url: https://docs.evcc.io/en/features/solar-charging
       tags:
         - vehicles
       parameters:
@@ -1178,7 +1178,7 @@ paths:
       summary: Update repeating plans
       description: "Updates the repeating charging plan."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1209,7 +1209,7 @@ paths:
       summary: Delete a SoC-based charging plan
       description: "Delete the charging plan"
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1223,7 +1223,7 @@ paths:
       summary: Set a SoC-based charging plan
       description: "Create charging plan with fixed time and SoC target."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1251,7 +1251,7 @@ paths:
       summary: Set plan strategy
       description: "Updates the charging plan strategy for the vehicle."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1567,16 +1567,16 @@ components:
       minimum: 1
     LoadpointName:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#title
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#title
       type: string
       example: Garage
     LogArea:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log#levels
+        url: https://docs.evcc.io/en/reference/configuration/log#levels
       type: string
     LogAreas:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log#levels
+        url: https://docs.evcc.io/en/reference/configuration/log#levels
       type: array
       example:
         - lp-1
@@ -1586,7 +1586,7 @@ components:
         $ref: "#/components/schemas/LogArea"
     LogLevel:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log#log
+        url: https://docs.evcc.io/en/reference/configuration/log#log
       type: string
       example: DEBUG
       enum:
@@ -1673,7 +1673,7 @@ components:
           minimum: 0
     RepeatingPlan:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans#repeating-plans
+        url: https://docs.evcc.io/en/features/plans#repeating-plans
       type: object
       properties:
         active:
@@ -1703,7 +1703,7 @@ components:
       type: object
     StaticEnergyPlan:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans#energy-amount-plan
+        url: https://docs.evcc.io/en/features/plans#energy-amount-plan
       type: object
       properties:
         energy:
@@ -1712,7 +1712,7 @@ components:
           $ref: "#/components/schemas/Timestamp"
     StaticSocPlan:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans#create-charging-plan
+        url: https://docs.evcc.io/en/features/plans#create-charging-plan
       type: object
       properties:
         soc:
@@ -1725,14 +1725,14 @@ components:
       format: date-time
     VehicleName:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/vehicles#name
+        url: https://docs.evcc.io/en/reference/configuration/vehicles#name
       type: string
       minLength: 1
       pattern: "[a-zA-Z0-9_.:-]+"
       example: vehicle_1
     VehicleTitle:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/vehicles#title
+        url: https://docs.evcc.io/en/reference/configuration/vehicles#title
       type: string
       example: blauer e-Golf
     Weekdays:


### PR DESCRIPTION
Update links in openapi to match the update url pattern (starlight migration). They currently rely on redirects.