### PR TITLE
Forecast: make solar adjustment a server-side setting

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -334,6 +334,7 @@ export default defineComponent({
 	props: {
 		gridConfigured: Boolean,
 		experimental: Boolean,
+		solarAdjusted: Boolean,
 		gridPower: { type: Number, default: 0 },
 		homePower: { type: Number, default: 0 },
 		pvConfigured: Boolean,
@@ -523,7 +524,7 @@ export default defineComponent({
 				return undefined;
 			}
 			const { today, scale } = this.forecast.solar || {};
-			const factor = this.experimental && settings.solarAdjusted && scale ? scale : 1;
+			const factor = this.experimental && this.solarAdjusted && scale ? scale : 1;
 			const energy = today?.energy || 0;
 			return energy * factor;
 		},

--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -120,6 +120,7 @@ export default defineComponent({
 		ext: { type: Array as PropType<Meter[]>, default: () => [] },
 		consumers: { type: Array as PropType<Meter[]>, default: () => [] },
 		batteryDischargeControl: Boolean,
+		solarAdjusted: Boolean,
 		batteryGridChargeLimit: { type: [Number, null] as PropType<number | null>, default: null },
 		batteryGridChargeActive: Boolean,
 		batteryMode: String as PropType<BATTERY_MODE>,

--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -20,7 +20,6 @@ const SAVINGS_INDICATOR = "savings_indicator";
 const SESSIONS_GROUP = "sessions_group";
 const SESSIONS_TYPE = "sessions_type";
 const BATTERY_UNIT = "battery_unit";
-const SETTINGS_SOLAR_ADJUSTED = "settings_solar_adjusted";
 const SETTINGS_PRICE_ZOOM = "settings_price_zoom";
 const SETTINGS_HIDE_FEEDIN = "settings_hide_feedin";
 const LAST_BATTERY_SMART_COST_LIMIT = "last_battery_smart_cost_limit";
@@ -126,7 +125,6 @@ export interface Settings {
   sessionsGroup: string;
   sessionsType: string;
   batteryUnit: string;
-  solarAdjusted: boolean;
   priceZoom: boolean;
   hideFeedin: boolean;
   loadpoints: Record<string, LoadpointSettings>;
@@ -156,7 +154,6 @@ const settings: Settings = reactive({
   sessionsGroup: read(SESSIONS_GROUP),
   sessionsType: read(SESSIONS_TYPE),
   batteryUnit: read(BATTERY_UNIT),
-  solarAdjusted: readBool(SETTINGS_SOLAR_ADJUSTED),
   priceZoom: readBool(SETTINGS_PRICE_ZOOM),
   hideFeedin: readBool(SETTINGS_HIDE_FEEDIN),
   loadpoints: readJSON(LOADPOINTS),
@@ -185,7 +182,6 @@ watch(() => settings.savingsIndicator, save(SAVINGS_INDICATOR));
 watch(() => settings.sessionsGroup, save(SESSIONS_GROUP));
 watch(() => settings.sessionsType, save(SESSIONS_TYPE));
 watch(() => settings.batteryUnit, save(BATTERY_UNIT));
-watch(() => settings.solarAdjusted, saveBool(SETTINGS_SOLAR_ADJUSTED));
 watch(() => settings.priceZoom, saveBool(SETTINGS_PRICE_ZOOM));
 watch(() => settings.hideFeedin, saveBool(SETTINGS_HIDE_FEEDIN));
 watch(() => settings.loadpoints, saveJSON(LOADPOINTS), { deep: true });

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -116,6 +116,7 @@ export interface State {
   prioritySoc?: number;
   bufferStartSoc?: number;
   batteryDischargeControl?: boolean;
+  solarAdjusted?: boolean;
   batteryGridChargeLimit?: number | null;
   smartCostAvailable?: boolean;
   smartCostType?: SMART_COST_TYPE;

--- a/assets/js/views/Forecast.vue
+++ b/assets/js/views/Forecast.vue
@@ -156,6 +156,7 @@ import GridDetails from "../components/Forecast/GridDetails.vue";
 import Co2Chart from "../components/Forecast/Co2Chart.vue";
 import Co2Details from "../components/Forecast/Co2Details.vue";
 import formatter from "@/mixins/formatter";
+import api from "@/api";
 import settings from "@/settings";
 import store from "../store";
 import { adjustedSolar, ForecastType, isStaticTariff } from "@/utils/forecast";
@@ -234,7 +235,7 @@ export default defineComponent({
 			return store.state?.experimental;
 		},
 		solarAdjusted() {
-			return settings.solarAdjusted;
+			return store.state?.solarAdjusted;
 		},
 		priceZoom() {
 			return settings.priceZoom;
@@ -271,8 +272,14 @@ export default defineComponent({
 		},
 	},
 	methods: {
-		changeAdjusted() {
-			settings.solarAdjusted = !settings.solarAdjusted;
+		async changeAdjusted(e: Event) {
+			try {
+				await api.post(
+					`solaradjusted/${(e.target as HTMLInputElement).checked ? "true" : "false"}`
+				);
+			} catch (err) {
+				console.error(err);
+			}
 		},
 		togglePriceZoom() {
 			settings.priceZoom = !settings.priceZoom;

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -47,6 +47,9 @@ const (
 	BufferSoc               = "bufferSoc"
 	BufferStartSoc          = "bufferStartSoc"
 
+	// forecast settings
+	SolarAdjusted = "solarAdjusted"
+
 	// optimizer
 	OptimizerChargingStrategy   = "optimizerChargingStrategy"
 	OptimizerChargingStrategies = "optimizerChargingStrategies"

--- a/core/site.go
+++ b/core/site.go
@@ -81,6 +81,9 @@ type Site struct {
 	batteryDischargeControl bool     // prevent battery discharge for fast and planned charging
 	batteryGridChargeLimit  *float64 // grid charging limit
 
+	// forecast settings
+	solarAdjusted bool // adjust solar forecast to real production data
+
 	// optimizer settings
 	optimizerChargingStrategy string // optimizer grid charging strategy
 
@@ -373,6 +376,9 @@ func (site *Site) restoreSettings() error {
 		if err := site.SetBatteryGridChargeLimit(&v); err != nil && !errors.Is(err, ErrBatteryControlNotAvailable) {
 			return err
 		}
+	}
+	if v, err := settings.Bool(keys.SolarAdjusted); err == nil {
+		site.SetSolarAdjusted(v)
 	}
 	if v, err := settings.String(keys.OptimizerChargingStrategy); err == nil && v != "" {
 		if err := site.SetOptimizerChargingStrategy(v); err != nil {
@@ -1167,6 +1173,7 @@ func (site *Site) prepare() {
 	site.publish(keys.BufferStartSoc, site.bufferStartSoc)
 	site.publish(keys.BatteryMode, site.batteryMode)
 	site.publish(keys.BatteryDischargeControl, site.batteryDischargeControl)
+	site.publish(keys.SolarAdjusted, site.solarAdjusted)
 	site.publish(keys.ResidualPower, site.GetResidualPower())
 	site.publish(keys.SmartCostAvailable, site.isDynamicTariff(api.TariffUsagePlanner))
 	site.publish(keys.SmartFeedInPriorityAvailable, site.isDynamicTariff(api.TariffUsageFeedIn))

--- a/core/site/api.go
+++ b/core/site/api.go
@@ -77,6 +77,15 @@ type API interface {
 	GetTariff(api.TariffUsage) api.Tariff
 
 	//
+	// forecast
+	//
+
+	// GetSolarAdjusted returns if the solar forecast is adjusted to real production data
+	GetSolarAdjusted() bool
+	// SetSolarAdjusted sets if the solar forecast is adjusted to real production data
+	SetSolarAdjusted(bool)
+
+	//
 	// battery control
 	//
 

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -370,6 +370,27 @@ func (site *Site) SetBatteryDischargeControl(val bool) error {
 	return nil
 }
 
+// GetSolarAdjusted returns if the solar forecast is adjusted to real production data
+func (site *Site) GetSolarAdjusted() bool {
+	site.RLock()
+	defer site.RUnlock()
+	return site.solarAdjusted
+}
+
+// SetSolarAdjusted sets if the solar forecast is adjusted to real production data
+func (site *Site) SetSolarAdjusted(val bool) {
+	site.log.DEBUG.Println("set solar adjusted:", val)
+
+	site.Lock()
+	defer site.Unlock()
+
+	if site.solarAdjusted != val {
+		site.solarAdjusted = val
+		settings.SetBool(keys.SolarAdjusted, val)
+		site.publish(keys.SolarAdjusted, val)
+	}
+}
+
 func (site *Site) GetBatteryGridChargeLimit() *float64 {
 	site.RLock()
 	defer site.RUnlock()

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -297,7 +297,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 			return err
 		}
 
-		ft = prorate(scaleAndPrune(solarEnergy, site.solarScale(), minLen), firstSlotDuration)
+		ft = prorate(scaleAndPrune(solarEnergy, site.effectiveSolarScale(), minLen), firstSlotDuration)
 	}
 
 	req := optimizer.OptimizationInput{

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -13,7 +13,7 @@ import (
 )
 
 type solarDetails struct {
-	Scale            *float64     `json:"scale,omitempty"`            // scale factor yield/forecasted today
+	Scale            float64      `json:"scale"`                      // scale factor yield/forecasted today, 1 if unscaled
 	Today            dailyDetails `json:"today,omitempty"`            // tomorrow
 	Tomorrow         dailyDetails `json:"tomorrow,omitempty"`         // tomorrow
 	DayAfterTomorrow dailyDetails `json:"dayAfterTomorrow,omitempty"` // day after tomorrow
@@ -152,11 +152,18 @@ func (site *Site) solarDetails(solar api.Rates) solarDetails {
 		}
 	}
 
-	if scale := site.solarScale(); scale != 1 {
-		res.Scale = &scale
-	}
+	res.Scale = site.solarScale()
 
 	return res
+}
+
+// effectiveSolarScale returns the solar forecast scale if forecast adjustment
+// is enabled, 1 otherwise.
+func (site *Site) effectiveSolarScale() float64 {
+	if !site.GetSolarAdjusted() {
+		return 1
+	}
+	return site.solarScale()
 }
 
 // solarScale returns the ratio of produced solar energy to forecasted solar

--- a/server/http.go
+++ b/server/http.go
@@ -150,6 +150,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 		"batterymodedelete":       {"DELETE", "/batterymode", updateBatteryMode(site)},
 		"prioritysoc":             {"POST", "/prioritysoc/{value:[0-9.]+}", floatHandler(site.SetPrioritySoc, site.GetPrioritySoc)},
 		"residualpower":           {"POST", "/residualpower/{value:-?[0-9.]+}", floatHandler(site.SetResidualPower, site.GetResidualPower)},
+		"solaradjusted":           {"POST", "/solaradjusted/{value:[01truefalse]+}", boolHandler(pass(site.SetSolarAdjusted), site.GetSolarAdjusted)},
 		"smartcost":               {"POST", "/smartcostlimit/{value:-?[0-9.]+}", updateSmartCostLimit(site, smartCostLimit)},
 		"smartcostdelete":         {"DELETE", "/smartcostlimit", updateSmartCostLimit(site, smartCostLimit)},
 		"smartfeedin":             {"POST", "/smartfeedinprioritylimit/{value:-?[0-9.]+}", updateSmartCostLimit(site, smartFeedInPriorityLimit)},

--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -2578,6 +2578,26 @@
         ]
       }
     },
+    "/solaradjusted/{enable}": {
+      "post": {
+        "description": "Adjust the solar forecast to real production data of the current day.",
+        "operationId": "setSolarAdjusted",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/enable"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/BooleanResult"
+          }
+        },
+        "summary": "Adjust solar forecast",
+        "tags": [
+          "experimental"
+        ]
+      }
+    },
     "/state": {
       "get": {
         "description": "Returns the complete state of the system. This structure is used by the UI. It can be filtered by JQ to only return a subset of the data.",

--- a/server/mcp/openapi.md
+++ b/server/mcp/openapi.md
@@ -344,6 +344,26 @@ call getEnergyHistory {
 }
 ```
 
+## setSolarAdjusted
+
+Adjust the solar forecast to real production data of the current day.
+
+**Tags:** experimental
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enable | string | Charging mode. |
+
+**Example call:**
+
+```json
+call setSolarAdjusted {
+  "enable": "true"
+}
+```
+
 ## getState
 
 Returns the complete state of the system. This structure is used by the UI. It can be filtered by JQ to only return a subset of the data.

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -217,6 +217,7 @@ func (m *MQTT) listenSiteSetters(topic string, site site.API) error {
 		{"batteryDischargeControl", boolSetter(site.SetBatteryDischargeControl)},
 		{"prioritySoc", floatSetter(site.SetPrioritySoc)},
 		{"residualPower", floatSetter(site.SetResidualPower)},
+		{"solarAdjusted", boolSetter(pass(site.SetSolarAdjusted))},
 		{"smartCostLimit", floatPtrSetter(pass(func(limit *float64) {
 			for _, lp := range site.Loadpoints() {
 				lp.SetSmartCostLimit(limit)

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -752,6 +752,18 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/NumberResult"
+  /solaradjusted/{enable}:
+    post:
+      operationId: setSolarAdjusted
+      summary: Adjust solar forecast
+      description: "Adjust the solar forecast to real production data of the current day."
+      tags:
+        - experimental
+      parameters:
+        - $ref: "#/components/parameters/enable"
+      responses:
+        "200":
+          $ref: "#/components/responses/BooleanResult"
   /smartfeedinprioritylimit:
     delete:
       operationId: removeGlobalSmartFeedInPriorityLimit


### PR DESCRIPTION
fixes #31832

Promotes the solar forecast adjustment from a browser-local UI preference to a server-side setting, per @naltatis' suggestion in the issue.

The "adjust to real production data" switch was stored only in `localStorage` (`settings_solar_adjusted`), so it silently reset whenever a browser dropped site storage, and it was per-client rather than per-installation. Meanwhile the optimizer applied the scale factor unconditionally, so the switch never matched what the optimizer actually did.

- new `solarAdjusted` site setting, persisted in the settings table and published to the UI
- `POST /api/solaradjusted/{enable}` plus a `solarAdjusted` MQTT setter
- optimizer applies the scale factor only when the setting is enabled (`effectiveSolarScale`)
- frontend reads the setting from the store instead of `localStorage`

`forecast.solar.scale` is still published unconditionally and is now always present, carrying `1` when unscaled. This keeps the percentage label on the toggle meaningful while the setting is off.

Default is off, matching the previous UI default. Note this changes optimizer behaviour: it no longer scales the solar forecast unless the setting is enabled.

Per-forecast granularity (as raised in the issue) is not included, since the scale value is calculated on totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)