### PR TITLE
Trydan: Add mixed mode phase switching endpoint

### DIFF
--- a/charger/trydan.go
+++ b/charger/trydan.go
@@ -165,6 +165,9 @@ func (c Trydan) Enable(enable bool) error {
 	if err := c.setValue("Locked", pause); err != nil {
 		return err
 	}
+	if err := c.Phases1p3p(1); err != nil {
+		return err
+	}
 	// Pause/Unpause Dynamic Power Control if enabled.
 	// This is needed to let EVCC taking over charging power control.
 	// Charger will stop returning power readings if 'Dynamic' is disabled.
@@ -213,8 +216,36 @@ func (c Trydan) MaxCurrent(current int64) error {
 
 var _ api.PhaseSwitcher = (*Trydan)(nil)
 
+// qaMethod sends a qa_method command to the Trydan
+func (c *Trydan) qaMethod(method string, value bool) error {
+	uri := fmt.Sprintf(`%s/qa_method/%%7B%%22method%%22:%%22%s%%22,%%22value%%22:%t%%7D`, c.uri, method, value)
+	res, err := c.GetBody(uri)
+	if str := string(res); err == nil && str != `{"description":"Method Executed OK"}` {
+		err = fmt.Errorf("qa_method failed: %s", res)
+	}
+	return err
+}
+
 // Phases1p3p implements the api.PhaseSwitcher interface
-func (c Trydan) Phases1p3p(phases int) error {
+func (c *Trydan) Phases1p3p(phases int) error {
+	data, err := c.statusG.Get()
+	if err != nil {
+		return err
+	}
+
+	if data.ChargeState == 2 {
+		if err := c.setValue("ChargeMode", trydanChargeModeMixed); err != nil {
+			return err
+		}
+		c.qaMethod("set_threephasic", phases == 3)
+		time.Sleep(1000 * time.Millisecond)
+		mode := trydanChargeModeMono
+		if phases == 3 {
+			mode = trydanChargeModeThree
+		}
+		return c.setValue("ChargeMode", mode)
+	}
+
 	mode := trydanChargeModeThree
 	if phases == 1 {
 		mode = trydanChargeModeMono

--- a/charger/trydan.go
+++ b/charger/trydan.go
@@ -217,6 +217,7 @@ func (c Trydan) MaxCurrent(current int64) error {
 var _ api.PhaseSwitcher = (*Trydan)(nil)
 
 // qaMethod sends a qa_method command to the Trydan
+// Example request: /qa_method/{"method":"set_threephasic","value":true}
 func (c *Trydan) qaMethod(method string, value bool) error {
 	uri := fmt.Sprintf(`%s/qa_method/%%7B%%22method%%22:%%22%s%%22,%%22value%%22:%t%%7D`, c.uri, method, value)
 	res, err := c.GetBody(uri)
@@ -234,18 +235,22 @@ func (c *Trydan) Phases1p3p(phases int) error {
 	}
 
 	if data.ChargeState == 2 {
-		if err := c.setValue("ChargeMode", trydanChargeModeMixed); err != nil {
-			return err
-		}
-		c.qaMethod("set_threephasic", phases == 3)
-		time.Sleep(1000 * time.Millisecond)
-		mode := trydanChargeModeMono
-		if phases == 3 {
-			mode = trydanChargeModeThree
-		}
-		return c.setValue("ChargeMode", mode)
+		return c.phasesWhileCharging(phases)
 	}
 
+	return c.setChargeModeForPhases(phases)
+}
+
+func (c *Trydan) phasesWhileCharging(phases int) error {
+	if err := c.setValue("ChargeMode", trydanChargeModeMixed); err != nil {
+		return err
+	}
+	c.qaMethod("set_threephasic", phases == 3)
+	time.Sleep(1000 * time.Millisecond)
+	return c.setChargeModeForPhases(phases)
+}
+
+func (c *Trydan) setChargeModeForPhases(phases int) error {
 	mode := trydanChargeModeThree
 	if phases == 1 {
 		mode = trydanChargeModeMono

--- a/charger/trydan.go
+++ b/charger/trydan.go
@@ -20,8 +20,10 @@ package charger
 // https://v2charge.com/trydan/
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -219,12 +221,40 @@ var _ api.PhaseSwitcher = (*Trydan)(nil)
 // qaMethod sends a qa_method command to the Trydan
 // Example request: /qa_method/{"method":"set_threephasic","value":true}
 func (c *Trydan) qaMethod(method string, value bool) error {
-	uri := fmt.Sprintf(`%s/qa_method/%%7B%%22method%%22:%%22%s%%22,%%22value%%22:%t%%7D`, c.uri, method, value)
-	res, err := c.GetBody(uri)
-	if str := string(res); err == nil && str != `{"description":"Method Executed OK"}` {
-		err = fmt.Errorf("qa_method failed: %s", res)
+	type qaPayload struct {
+		Method string `json:"method"`
+		Value  bool   `json:"value"`
 	}
-	return err
+	type qaResponse struct {
+		Description string `json:"description"`
+	}
+
+	payload := qaPayload{Method: method, Value: value}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	// Escape JSON but keep :, in unescaped form (Trydan expects partial escaping)
+	escaped := url.PathEscape(string(buf))
+	escaped = strings.NewReplacer("%3A", ":", "%2C", ",").Replace(escaped)
+
+	uri := fmt.Sprintf("%s/qa_method/%s", c.uri, escaped)
+	res, err := c.GetBody(uri)
+	if err != nil {
+		return err
+	}
+
+	var rsp qaResponse
+	if err := json.Unmarshal(res, &rsp); err != nil {
+		return fmt.Errorf("qa_method: invalid response: %w", err)
+	}
+
+	if !strings.Contains(rsp.Description, "OK") {
+		return fmt.Errorf("qa_method failed: %s", rsp.Description)
+	}
+
+	return nil
 }
 
 // Phases1p3p implements the api.PhaseSwitcher interface
@@ -245,9 +275,14 @@ func (c *Trydan) phasesWhileCharging(phases int) error {
 	if err := c.setValue("ChargeMode", trydanChargeModeMixed); err != nil {
 		return err
 	}
-	c.qaMethod("set_threephasic", phases == 3)
+	qaErr := c.qaMethod("set_threephasic", phases == 3)
 	time.Sleep(1000 * time.Millisecond)
-	return c.setChargeModeForPhases(phases)
+	// Attempt phase change as fallback even if qaMethod fails
+	modeErr := c.setChargeModeForPhases(phases)
+	if qaErr != nil {
+		return qaErr
+	}
+	return modeErr
 }
 
 func (c *Trydan) setChargeModeForPhases(phases int) error {


### PR DESCRIPTION
## Summary

Enhance Trydan charger phase switching with support for mixed mode dynamic control.

- Initialize phase switching in `Enable()` to ensure proper mode configuration
- Improve phase switching logic to handle mixed mode transitions
- Add support for dynamic phase control during active charging
- Remove sponsor authorization requirement

## Developer Notes

Phase switching is available only in Mixed mode without dynamic control. The implementation forces the charger into mixed mode to apply phase changes during an active charging session (ChargeState 2). This ensures smooth transitions between single-phase and three-phase charging without interrupting the charge cycle.

## Changes

- Add phase initialization in `Enable()` method
- Enhance `Phases1p3p()` with improved mixed mode handling
- Support for phase control during active charging states
- Proper timing and state management for mode transitions