### PR TITLE
Shelly: fix energy measurements for PV usage

### DIFF
--- a/meter/shelly.go
+++ b/meter/shelly.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"math"
 	"strings"
 	"time"
 
@@ -48,8 +47,14 @@ func NewShellyFromConfig(other map[string]any) (api.Meter, error) {
 	// Three-phase Shelly energy meters count each phase separately (non-balanced),
 	// making their totals unsuitable for bidirectional grid metering.
 	if !(c.usage == "grid" && c.conn.IsThreePhase()) {
-		implement.Has(c, implement.MeterEnergy(c.conn.TotalEnergy))
-		implement.Has(c, implement.MeterReturnEnergy(c.conn.ReturnEnergy))
+		if c.usage == "pv" {
+			// reverse direction
+			implement.Has(c, implement.MeterEnergy(c.conn.ReturnEnergy))
+			implement.Has(c, implement.MeterReturnEnergy(c.conn.TotalEnergy))
+		} else {
+			implement.Has(c, implement.MeterEnergy(c.conn.TotalEnergy))
+			implement.Has(c, implement.MeterReturnEnergy(c.conn.ReturnEnergy))
+		}
 	}
 
 	if phases, ok := c.conn.Generation.(shelly.Phases); ok {
@@ -84,7 +89,7 @@ func (c *Shelly) CurrentPower() (float64, error) {
 		return 0, err
 	}
 	if c.usage == "pv" {
-		power = math.Abs(power)
+		power = -power
 	}
 	return power, nil
 }

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -232,7 +232,10 @@ func (c *gen2) TotalEnergy() (float64, error) {
 
 	case c.hasSwitchEndpoint():
 		res, err := c.switchstatus.Get()
-		return res.Aenergy.Total / 1000, err
+		// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Switch#status
+		// NOTE: ret_aenergy - the active energy added to this container is also added to aenergy container.
+		// All the consumed energy is collected in aenergy regardless of the direction(consumed or returned) of the active energy.
+		return (res.Aenergy.Total - res.Ret_Aenergy.Total) / 1000, err
 
 	default:
 		return 0, fmt.Errorf("unknown shelly model: %s", c.model)


### PR DESCRIPTION
A Shelly with relay having a switch endpoint collects the "returned energy" also in "energy". In case of usage of a Shelly as a meter in PV mode it leads to wrong values (in history). 

For PV mode the "returned energy" must be mapped to "normal" energy in evcc and the "returned energy" in evcc is usually zero.

Additionally the power sign reversal should be a true negation, not the absolute value, because in rare cases a PV can consume power and in this case a nagative power value is appropriate.

It fixes #31815.