### PR TITLE
Sessions: show export dropdown above bottom tab bar

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -1,5 +1,6 @@
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../css/app.css";
+import Dropdown from "bootstrap/js/dist/dropdown";
 import { createApp, defineComponent, h } from "vue";
 import { VueHeadMixin, createHead } from "@unhead/vue/client";
 import App from "./views/App.vue";
@@ -10,6 +11,19 @@ import { applyUrlSettings } from "./urlSettings.ts";
 import { appDetection, sendToApp } from "./utils/native";
 import store from "./store";
 import type { Notification } from "./types/evcc";
+
+// keep dropdown menus out of the fixed bottom tab bar and safe-area inset
+Dropdown.Default.popperConfig = (defaultConfig) => {
+  const bottom = document.querySelector<HTMLElement>(".bottom-tab-bar")?.offsetHeight ?? 0;
+  return {
+    ...defaultConfig,
+    modifiers: [
+      ...(defaultConfig.modifiers ?? []),
+      { name: "flip", options: { padding: { bottom } } },
+      { name: "preventOverflow", options: { padding: { bottom } } },
+    ],
+  };
+};
 
 // lazy load smoothscroll polyfill. mainly for safari < 15.4
 if (!window.CSS.supports("scroll-behavior", "smooth")) {

--- a/assets/js/components/Helper/DownloadButton.vue
+++ b/assets/js/components/Helper/DownloadButton.vue
@@ -59,7 +59,5 @@ export default defineComponent({
 <style scoped>
 .dropdown-menu {
 	--bs-dropdown-min-width: 0;
-	/* above bottom tab bar (z-index 1030), else hidden behind footer */
-	z-index: 1031;
 }
 </style>

--- a/assets/js/components/Helper/DownloadButton.vue
+++ b/assets/js/components/Helper/DownloadButton.vue
@@ -59,5 +59,7 @@ export default defineComponent({
 <style scoped>
 .dropdown-menu {
 	--bs-dropdown-min-width: 0;
+	/* above bottom tab bar (z-index 1030), else hidden behind footer */
+	z-index: 1031;
 }
 </style>


### PR DESCRIPTION
Follow-up to #31690.

The dropdown algorithm needs to take bottom nav and(!) safe-area-inset into account when calculating the available space and deciding on opening direction. safe-area-inset is applied in homescreen-app (pwa) mode and in app context. This fix handles both cases in the global dropdown handler (popper).

before
<img width="568" height="1084" alt="before" src="https://github.com/user-attachments/assets/afe99b19-8510-49e6-96fb-85fc6ceb0006" />

after
<img width="568" height="1084" alt="after" src="https://github.com/user-attachments/assets/dcddd9fa-10d1-4033-afdf-81563f56bee5" />
