### PR TITLE
Messaging: forward events to companion app as native notifications

### DIFF
--- a/assets/js/store.ts
+++ b/assets/js/store.ts
@@ -3,6 +3,7 @@ import type { State } from "./types/evcc";
 import { convertToUiLoadpoints } from "./uiLoadpoints";
 import { useDebouncedComputed } from "./utils/useDebouncedComputed";
 import settings from "./settings";
+import { dispatchNotification } from "./utils/native";
 
 function setProperty(obj: object, props: string[], value: any) {
   const prop = props.shift();
@@ -61,6 +62,8 @@ const store: Store = {
     Object.keys(msg).forEach(function (k) {
       if (k === "log") {
         window.app.raise(msg[k]);
+      } else if (k === "message") {
+        dispatchNotification(msg[k].title, msg[k].message);
       } else {
         setProperty(state, k.split("."), msg[k]);
       }

--- a/assets/js/utils/native.ts
+++ b/assets/js/utils/native.ts
@@ -40,7 +40,8 @@ export function hasAppCapability(capability: string): boolean {
 
 type ToAppMessage =
   | { type: "online" | "offline" | "settings" }
-  | { type: "download"; url: string; headers?: Record<string, string> };
+  | { type: "download"; url: string; headers?: Record<string, string> }
+  | { type: "notification"; title?: string; message: string };
 
 export function sendToApp(data: ToAppMessage) {
   window.ReactNativeWebView?.postMessage(JSON.stringify(data));
@@ -56,5 +57,11 @@ export function dispatchDownload(url: string, headers?: Record<string, string>):
   if (!hasAppCapability("download")) return false;
   const absolute = new URL(url, window.location.href).toString();
   sendToApp({ type: "download", url: absolute, headers });
+  return true;
+}
+
+export function dispatchNotification(title: string, message: string): boolean {
+  if (!hasAppCapability("notification")) return false;
+  sendToApp({ type: "notification", title, message });
   return true;
 }

--- a/messenger/hub.go
+++ b/messenger/hub.go
@@ -112,10 +112,6 @@ func (h *Hub) Run(events <-chan Event, valueChan chan<- util.Param) {
 	log := util.NewLogger("push")
 
 	for ev := range events {
-		if len(h.sender) == 0 {
-			continue
-		}
-
 		definition, ok := h.definitions[ev.Event]
 		if !ok {
 			continue
@@ -141,6 +137,12 @@ func (h *Hub) Run(events <-chan Event, valueChan chan<- util.Param) {
 		if strings.TrimSpace(msg) == "" {
 			continue
 		}
+
+		// forward to connected UIs, e.g. the app routes this to native notifications
+		valueChan <- util.Param{Key: "message", Val: struct {
+			Title   string `json:"title"`
+			Message string `json:"message"`
+		}{title, msg}}
 
 		for _, sender := range h.sender {
 			go sender.Send(title, msg)


### PR DESCRIPTION
pairs with evcc-io/app#230, refs evcc-io/app#16

Routes configured messaging events to the companion app, which shows them as native system notifications. The push hub now also publishes each rendered message to connected UIs over the websocket; the web UI forwards it to the app when running inside the app with the `notification` capability. Browsers ignore it.

- push hub publishes `{ title, message }` under the `message` socket key alongside the existing messenger sends
- events are now rendered and forwarded even when no push service is configured, as long as messaging events are set up
- new `dispatchNotification` in `native.ts`, gated on `hasAppCapability("notification")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)