### PR TITLE
SMA hybrid: add battery mode 4 (holdcharge)

### DIFF
--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -366,5 +366,63 @@ render: |
                 address: 40801 # CmpBMS.GridWSpt - Sollwert der Netzaustauschleistung
                 type: writemultiple
                 decode: uint32
+      - case: 4 # holdcharge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 2424 # Voreinstellung (Dft)
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 40236 # CmpBMS.OpMod - Betriebsart des BMS
+                type: writemultiple
+                decode: uint32
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 40793 # CmpBMS.BatChaMinW - Minimale Batterieladeleistung
+                type: writemultiple
+                decode: uint32
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 40795 # CmpBMS.BatChaMaxW - Maximale Batterieladeleistung
+                type: writemultiple
+                decode: uint32
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 40797 # CmpBMS.BatDschMinW - Minimale Batterieentladeleistung
+                type: writemultiple
+                decode: uint32
+          - source: const
+            value: {{ .maxdischargepower }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 40799 # CmpBMS.BatDschMaxW - Maximale Batterieentladeleistung
+                type: writemultiple
+                decode: uint32
+          - source: const
+            value: 0
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 40801 # CmpBMS.GridWSpt - Sollwert der Netzaustauschleistung
+                type: writemultiple
+                decode: uint32
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
Implementation of evcc-io/evcc#27906 for SMA hybrid inverter.

**Tests:**
I run this successfully. I use a custom external rule (OpenHAB/mqtt), that did set the batterymode to holdcharge until noon, where the feed-in price turned negative. The loading of battery was delayed as expected:
<img width="691" height="655" alt="grafik" src="https://github.com/user-attachments/assets/5aeca936-1cb1-485a-b931-830666405638" />
