### PR TITLE
Battery (experimental): batteryicon: visualize actual percentages

### DIFF
--- a/assets/js/components/Battery/OptimizerInfo.vue
+++ b/assets/js/components/Battery/OptimizerInfo.vue
@@ -14,7 +14,7 @@
 		</div>
 		<div v-if="forecast?.highest" class="d-flex justify-content-between gap-3">
 			<span class="d-flex align-items-center gap-2 fw-bold">
-				<BatteryIcon :soc="95" />
+				<BatteryIcon :soc="forecast.highest.soc" />
 				{{ pointLabel(forecast.highest, true) }}
 			</span>
 			<span class="text-muted text-end">{{
@@ -23,7 +23,7 @@
 		</div>
 		<div v-if="forecast?.lowest" class="d-flex justify-content-between gap-3">
 			<span class="d-flex align-items-center gap-2 fw-bold">
-				<BatteryIcon :soc="10" />
+				<BatteryIcon :soc="forecast.lowest.soc" />
 				{{ pointLabel(forecast.lowest, false) }}
 			</span>
 			<span class="text-muted text-end">{{


### PR DESCRIPTION
Before: either full or low
<img width="1054" height="267" alt="grafik" src="https://github.com/user-attachments/assets/82a84094-5fed-442f-95ec-2a24d06a4d42" />


After: actual forecasted percentage
<img width="1072" height="270" alt="grafik" src="https://github.com/user-attachments/assets/22c1b2f2-1e8c-4958-97f4-50ccd7f3be2c" />
