### PR TITLE
loadpoint: fix phase detection for low current

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1745,7 +1745,7 @@ func (lp *Loadpoint) phasesFromChargeCurrents() {
 	if lp.charging() && lp.phaseSwitchCompleted() {
 		var phases int
 		for _, i := range lp.chargeCurrents {
-			if i > minActiveCurrent {
+			if i >= minActiveCurrent {
 				phases++
 			}
 		}


### PR DESCRIPTION
The effective phase current may be equal to the minActiveCurrent of 1.0A. Therefore compare with ">=" intstead of ">".

It fixes phase calculations, when the configured minimum current is 1.0A, but not if it is below that value. A future fix should probably retire the constant "minActiveCurrent" and compare against a value like "minCurrent".