### PR TITLE
Revert "loadpoint: fix phase detection for low current"

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1745,7 +1745,7 @@ func (lp *Loadpoint) phasesFromChargeCurrents() {
 	if lp.charging() && lp.phaseSwitchCompleted() {
 		var phases int
 		for _, i := range lp.chargeCurrents {
-			if i >= minActiveCurrent {
+			if i > minActiveCurrent {
 				phases++
 			}
 		}


### PR DESCRIPTION
Reverts evcc-io/evcc#31930

The condition was right due to measurement noise.