### PR TITLE
HTTP plugin: warn on uncached repeated GET requests

### DIFF
--- a/plugin/http.go
+++ b/plugin/http.go
@@ -27,6 +27,7 @@ type HTTP struct {
 	body        string
 	pipeline    *pipeline.Pipeline
 	mu          *sync.Mutex
+	log         *util.Logger
 }
 
 func init() {
@@ -100,6 +101,7 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 		Helper: request.NewHelper(log),
 		url:    uri,
 		method: method,
+		log:    log,
 	}
 
 	// build the cache stack without logging so the logging tripper
@@ -219,6 +221,11 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 		return []byte{}, err
 	}
 
+	// warn on uncached GET polling: a configured cache would spare the roundtrip
+	if p.method == http.MethodGet && p.mu == nil && repeatedGet(url, time.Now()) {
+		p.log.WARN.Printf("uncached request repeated within 1s, please report at https://github.com/evcc-io/evcc/issues: %s", url)
+	}
+
 	val, err := p.DoBody(req)
 	if err != nil {
 		if err2 := knownErrors(val); err2 != nil {
@@ -227,6 +234,29 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 	}
 
 	return val, err
+}
+
+var (
+	httpSeenMu sync.Mutex
+	httpSeen   = make(map[string]time.Time)
+	httpWarned = make(map[string]struct{})
+)
+
+// repeatedGet reports the first time url is fetched again within a second, a sign
+// the response should be cached. It fires once per url to avoid log spam.
+func repeatedGet(url string, now time.Time) bool {
+	httpSeenMu.Lock()
+	defer httpSeenMu.Unlock()
+
+	last, seen := httpSeen[url]
+	httpSeen[url] = now
+
+	if _, warned := httpWarned[url]; warned || !seen || now.Sub(last) >= time.Second {
+		return false
+	}
+
+	httpWarned[url] = struct{}{}
+	return true
 }
 
 var _ Getters = (*HTTP)(nil)

--- a/plugin/http.go
+++ b/plugin/http.go
@@ -236,10 +236,14 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 	return val, err
 }
 
+type httpAccess struct {
+	last   time.Time
+	warned bool
+}
+
 var (
 	httpSeenMu sync.Mutex
-	httpSeen   = make(map[string]time.Time)
-	httpWarned = make(map[string]struct{})
+	httpSeen   = make(map[string]httpAccess)
 )
 
 // stripQuery drops the query and fragment so cache-busting params do not make
@@ -257,15 +261,10 @@ func repeatedGet(url string, now time.Time) bool {
 	httpSeenMu.Lock()
 	defer httpSeenMu.Unlock()
 
-	last, seen := httpSeen[url]
-	httpSeen[url] = now
-
-	if _, warned := httpWarned[url]; warned || !seen || now.Sub(last) >= time.Second {
-		return false
-	}
-
-	httpWarned[url] = struct{}{}
-	return true
+	a, seen := httpSeen[url]
+	warn := seen && !a.warned && now.Sub(a.last) < time.Second
+	httpSeen[url] = httpAccess{last: now, warned: a.warned || warn}
+	return warn
 }
 
 var _ Getters = (*HTTP)(nil)

--- a/plugin/http.go
+++ b/plugin/http.go
@@ -222,8 +222,8 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 	}
 
 	// warn on uncached GET polling: a configured cache would spare the roundtrip
-	if p.method == http.MethodGet && p.mu == nil && repeatedGet(url, time.Now()) {
-		p.log.WARN.Printf("uncached request repeated within 1s, please report at https://github.com/evcc-io/evcc/issues: %s", url)
+	if key := stripQuery(url); p.method == http.MethodGet && p.mu == nil && repeatedGet(key, time.Now()) {
+		p.log.WARN.Printf("uncached request repeated within 1s, please report at https://github.com/evcc-io/evcc/issues: %s", key)
 	}
 
 	val, err := p.DoBody(req)
@@ -241,6 +241,15 @@ var (
 	httpSeen   = make(map[string]time.Time)
 	httpWarned = make(map[string]struct{})
 )
+
+// stripQuery drops the query and fragment so cache-busting params do not make
+// each poll look like a distinct url.
+func stripQuery(url string) string {
+	if i := strings.IndexAny(url, "?#"); i >= 0 {
+		return url[:i]
+	}
+	return url
+}
 
 // repeatedGet reports the first time url is fetched again within a second, a sign
 // the response should be cached. It fires once per url to avoid log spam.

--- a/plugin/http_test.go
+++ b/plugin/http_test.go
@@ -175,4 +175,9 @@ func TestRepeatedGet(t *testing.T) {
 	spaced := "http://repeated.test/spaced"
 	require.False(t, repeatedGet(spaced, t0))
 	require.False(t, repeatedGet(spaced, t0.Add(2*time.Second))) // >1s apart: no warn
+
+	// query params are stripped before keying, so cache-busting still counts as a repeat
+	require.Equal(t, "http://q.test/path", stripQuery("http://q.test/path?ts=1&x=2#frag"))
+	require.False(t, repeatedGet(stripQuery("http://q.test/path?ts=1"), t0))
+	require.True(t, repeatedGet(stripQuery("http://q.test/path?ts=2"), t0.Add(300*time.Millisecond)))
 }

--- a/plugin/http_test.go
+++ b/plugin/http_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -161,4 +162,17 @@ func (suite *httpTestSuite) TestSetPath() {
 	suite.Require().NoError(err)
 	suite.Require().NoError(s("4711"))
 	suite.Require().Equal("/foo/bar/4711", suite.h.req.URL.String())
+}
+
+func TestRepeatedGet(t *testing.T) {
+	url := "http://repeated.test/uncached"
+	t0 := time.Now()
+
+	require.False(t, repeatedGet(url, t0))                           // first sighting
+	require.True(t, repeatedGet(url, t0.Add(500*time.Millisecond)))  // repeated within 1s: warn
+	require.False(t, repeatedGet(url, t0.Add(600*time.Millisecond))) // already warned: silent
+
+	spaced := "http://repeated.test/spaced"
+	require.False(t, repeatedGet(spaced, t0))
+	require.False(t, repeatedGet(spaced, t0.Add(2*time.Second))) // >1s apart: no warn
 }


### PR DESCRIPTION
Adds runtime autodetection of missing caching to the `http` plugin.

When a GET url is requested again within one second and no cache is configured (`cache:` unset), the plugin logs a warning once per url pointing to the issue tracker:

```
[http ] WARN uncached request repeated within 1s, please report at https://github.com/evcc-io/evcc/issues: http://device.local/api/status
```

This surfaces frequently-polled devices that would benefit from a `cache:` setting, without touching request behavior. Detection is gated to GET requests on plugins without a cache, so configured-cache paths never warn.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)