### PR TITLE
HTTP plugin: skip uncached warning on cache hits

### DIFF
--- a/plugin/http.go
+++ b/plugin/http.go
@@ -221,12 +221,20 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	// warn on uncached GET polling: a configured cache would spare the roundtrip
-	if key := stripQuery(url); p.method == http.MethodGet && p.mu == nil && repeatedGet(key, time.Now()) {
-		p.log.WARN.Printf("uncached request repeated within 1s, please report at https://github.com/evcc-io/evcc/issues: %s", key)
+	resp, err := p.Do(req)
+	if err != nil {
+		return nil, err
 	}
 
-	val, err := p.DoBody(req)
+	// warn on uncached GET polling: a repeated roundtrip means neither a configured
+	// cache nor the device's own response headers spared it. cache hits are exempt.
+	if p.method == http.MethodGet && p.mu == nil && resp.Header.Get(httpcache.XFromCache) == "" {
+		if key := stripQuery(url); repeatedGet(key, time.Now()) {
+			p.log.WARN.Printf("uncached request repeated within 1s, please report at https://github.com/evcc-io/evcc/issues: %s", key)
+		}
+	}
+
+	val, err := request.ReadBody(resp)
 	if err != nil {
 		if err2 := knownErrors(val); err2 != nil {
 			err = err2


### PR DESCRIPTION
Follow-up to #31932.

The uncached-GET warning added in #31932 fires whenever a GET repeats within a second without an evcc-configured cache. But `httpcache.Transport` is always in the stack, so a device that sends sufficient cache headers (`Cache-Control: max-age`, `Expires`) already has its repeats served from cache — no real roundtrip, nothing to warn about.

This checks the response for httpcache's `X-From-Cache` marker before warning, exempting those cache hits. The request is now read via `Do` + `ReadBody` so the response headers are available.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)