### PR TITLE
Mqtt: limit trace log payload length like http logging

### DIFF
--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -242,7 +242,7 @@ func (m *Client) Publish(topic string, retained bool, payload any) {
 			return
 		}
 
-		m.log.TRACE.Printf("send %s: '%v'", topic, payload)
+		m.log.TRACE.Printf("send %s: '%v'", topic, truncate(payload))
 		token := m.client.Publish(topic, m.Qos, retained, payload)
 
 		select {
@@ -290,7 +290,7 @@ func (m *Client) ListenSetter(topic string, callback func(string) error) error {
 func (m *Client) listen(topic string) paho.Token {
 	token := m.client.Subscribe(topic, m.Qos, func(c paho.Client, msg paho.Message) {
 		payload := string(msg.Payload())
-		m.log.TRACE.Printf("recv %s: '%v'", topic, payload)
+		m.log.TRACE.Printf("recv %s: '%v'", topic, truncate(payload))
 		if len(payload) > 0 {
 			m.mux.Lock()
 			callbacks := m.listener[topic]
@@ -302,4 +302,13 @@ func (m *Client) listen(topic string) paho.Token {
 		}
 	})
 	return token
+}
+
+// truncate limits payload length in trace logs, matching HTTP logging
+func truncate(v any) string {
+	s := fmt.Sprint(v)
+	if len(s) > request.LogMaxLen {
+		s = s[:request.LogMaxLen] + "..."
+	}
+	return s
 }

--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -224,7 +224,7 @@ func (m *Client) Cleanup(topic string, retained bool) error {
 }
 
 // Publish asynchronously publishes payload using client qos
-func (m *Client) Publish(topic string, retained bool, payload any) {
+func (m *Client) Publish(topic string, retained bool, payload string) {
 	connCtx := m.connContext()
 	go func() {
 		ctx, cancel := context.WithTimeout(connCtx, request.Timeout)
@@ -305,8 +305,7 @@ func (m *Client) listen(topic string) paho.Token {
 }
 
 // truncate limits payload length in trace logs, matching HTTP logging
-func truncate(v any) string {
-	s := fmt.Sprint(v)
+func truncate(s string) string {
 	if len(s) > request.LogMaxLen {
 		s = s[:request.LogMaxLen] + "..."
 	}


### PR DESCRIPTION
MQTT `send`/`recv` trace logs dumped full payloads. Truncate at `request.LogMaxLen` (8 KiB), matching HTTP roundtrip logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)