### PR TITLE
Loadpoint: keep vehicle soc when re-assigning same vehicle

### DIFF
--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -123,6 +123,8 @@ func (lp *Loadpoint) selectVehicleByID(id string) api.Vehicle {
 func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 	lp.vmu.Lock()
 
+	prev := lp.vehicle
+
 	from := "unknown"
 	if lp.vehicle != nil {
 		lp.coordinator.Release(lp.vehicle)
@@ -171,7 +173,12 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 
 	// re-publish vehicle settings
 	lp.publish(keys.PhasesActive, lp.ActivePhases())
-	lp.unpublishVehicle()
+
+	// only reset published vehicle data when the active vehicle actually changes.
+	// re-assigning the same default vehicle on reconnect must keep a known soc.
+	if prev != v {
+		lp.unpublishVehicle()
+	}
 
 	// publish effective values
 	lp.PublishEffectiveValues()

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -368,6 +368,37 @@ func TestReidentifyActiveVehicleKeepsMode(t *testing.T) {
 	assert.Equal(t, api.ModeNow, lp.GetMode(), "mode must not be reapplied for already-active vehicle")
 }
 
+// TestReassignActiveVehicleKeepsSoc is a regression test for #31063:
+// re-assigning the already-active default vehicle on reconnect must not wipe a
+// known soc. Only a genuine vehicle change (or disconnect) clears it.
+func TestReassignActiveVehicleKeepsSoc(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().GetTitle().Return("target").AnyTimes()
+	vehicle.EXPECT().Icon().Return("").AnyTimes()
+	vehicle.EXPECT().Capacity().AnyTimes()
+	vehicle.EXPECT().Phases().AnyTimes()
+	vehicle.EXPECT().OnIdentified().AnyTimes()
+
+	lp := NewLoadpoint(util.NewLogger("foo"), settings.NewDatabaseSettingsAdapter("foo"))
+
+	x, y, z := createChannels(t)
+	attachChannels(lp, x, y, z)
+
+	// vehicle active, soc read from a prior cycle
+	lp.setActiveVehicle(vehicle)
+	lp.vehicleSoc = 71
+
+	// re-assign the same vehicle (reconnect churn) - soc must survive
+	lp.setActiveVehicle(vehicle)
+	assert.Equal(t, 71.0, lp.vehicleSoc, "soc must survive same-vehicle re-assign")
+
+	// switching to no vehicle still clears it
+	lp.setActiveVehicle(nil)
+	assert.Equal(t, 0.0, lp.vehicleSoc, "soc must clear on vehicle change")
+}
+
 // integratedDeviceCharger is a minimal charger advertising the IntegratedDevice feature.
 type integratedDeviceCharger struct{}
 


### PR DESCRIPTION
Follow-up to #31063 (closed, contributor fork), keeping the original analysis by @Alexxtheonly.

## Problem

A loadpoint with a pinned default `vehicle:` whose SoC is known (e.g. a `teslamate` vehicle reading SoC over MQTT) publishes `vehicleSoc = 0` to `/api/state` (and messaging) **while charging**, even though the per-cycle `vehicle soc: NN%` debug log shows the correct value every cycle. It gets stuck at `0` after an evcc restart that happens mid-charge; `vehicleRange`/`vehicleOdometer` are zeroed the same way.

## Root cause

`setActiveVehicle()` calls `unpublishVehicle()` unconditionally at the end of every invocation, zeroing `vehicleSoc` and publishing `0` for soc/range/limit/odometer.

`vehicleDefaultOrDetect()` re-assigns the already-active default vehicle on every reconnect (introduced in #27364 to reset the estimator gradient per session, #27359). So the repeated reconnect churn after a mid-charge restart re-assigns the *same* vehicle over and over, and each call wipes the freshly-read SoC back to `0`. `publishSocAndRange()` only repopulates `vehicleSoc` on a cycle that actually reads a SoC, so the published value stays `0`.

The initial post-restart assignment (from no vehicle to the default) correctly resets to `0` — evcc does not know the prior SoC yet. The bug is the *subsequent redundant re-assignments of the same vehicle* clearing a value that has since been read.

## Fix

Only reset published vehicle data when the active vehicle actually changes. The soc estimator is still rebuilt unconditionally for `v != nil`, so the #27359 fresh-estimator-on-reconnect behaviour is unchanged. Switching to a different vehicle — or to none on disconnect — still clears the stale data.

## Test

`TestReassignActiveVehicleKeepsSoc`: sets a known `vehicleSoc`, re-assigns the same active vehicle (SoC preserved), then switches away (SoC cleared). Fails on master, passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
