### PR TITLE
OCPP: use loadpoint phases for watts-based charging power

### DIFF
--- a/charger/ocpp.go
+++ b/charger/ocpp.go
@@ -29,6 +29,7 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/charger/ocpp"
+	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
@@ -43,6 +44,7 @@ type OCPP struct {
 	phases  int
 	enabled bool
 	current float64
+	lp      loadpoint.API
 
 	stackLevelZero      bool
 	profileKindRelative bool
@@ -318,6 +320,14 @@ func (c *OCPP) createTxDefaultChargingProfile(current float64) *types.ChargingPr
 	period := types.NewChargingSchedulePeriod(0, current)
 
 	if c.cp.ChargingRateUnit == types.ChargingRateUnitWatts {
+		// c.phases is only set via the phase switcher; fall back to the loadpoint phases
+		if phases == 0 && c.lp != nil {
+			phases = c.lp.GetPhases()
+		}
+		// OCPP assumes phases == 3 if not set
+		if phases == 0 {
+			phases = 3
+		}
 		period = types.NewChargingSchedulePeriod(0, math.Trunc(230.0*current*float64(phases)))
 	} else {
 		// OCPP assumes phases == 3 if not set
@@ -439,4 +449,11 @@ func (c *OCPP) Diagnose() {
 			fmt.Printf("\t\t%s (%s): %s\n", opt.Key, rw[opt.Readonly], *opt.Value)
 		}
 	}
+}
+
+var _ loadpoint.Controller = (*OCPP)(nil)
+
+// LoadpointControl implements loadpoint.Controller
+func (c *OCPP) LoadpointControl(lp loadpoint.API) {
+	c.lp = lp
 }

--- a/charger/ocpp_phases_test.go
+++ b/charger/ocpp_phases_test.go
@@ -1,0 +1,49 @@
+package charger
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/charger/ocpp"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestWattsProfilePhases checks the watts power target falls back to loadpoint
+// phases (then 3) when the phase switcher never set c.phases (issue #30998).
+func TestWattsProfilePhases(t *testing.T) {
+	const current = 16.0
+
+	for _, tc := range []struct {
+		name       string
+		phases     int // c.phases (0 = phase switcher never called)
+		lpPhases   int // loadpoint phases, -1 = no loadpoint
+		wantPhases int
+	}{
+		{"switcher set", 3, -1, 3},
+		{"from loadpoint 1p", 0, 1, 1},
+		{"from loadpoint 3p", 0, 3, 3},
+		{"no loadpoint fallback", 0, -1, 3},
+		{"loadpoint unknown fallback", 0, 0, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &OCPP{
+				cp:     &ocpp.CP{ChargingRateUnit: types.ChargingRateUnitWatts},
+				phases: tc.phases,
+			}
+
+			if tc.lpPhases >= 0 {
+				ctrl := gomock.NewController(t)
+				lp := loadpoint.NewMockAPI(ctrl)
+				lp.EXPECT().GetPhases().Return(tc.lpPhases).AnyTimes()
+				c.lp = lp
+			}
+
+			profile := c.createTxDefaultChargingProfile(current)
+			limit := profile.ChargingSchedule.ChargingSchedulePeriod[0].Limit
+
+			require.Equal(t, 230.0*current*float64(tc.wantPhases), limit)
+		})
+	}
+}


### PR DESCRIPTION
fixes #30998

Power-controlled OCPP chargers (`ChargingRateUnit=W`) compute the profile power as `230·current·phases`. `c.phases` is only ever set by the phase switcher, so a charger that reports watts but no phase switching (`PhaseSwitcher` not decorated) leaves `phases=0` and every power target collapses to 0 W — the charger never charges.

Fall back to the loadpoint's phase count via `loadpoint.Controller`, then to 3 (OCPP's default assumption) if still unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)