### PR TITLE
request: share Truncate helper between mqtt and http trace logs

### DIFF
--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -242,7 +242,7 @@ func (m *Client) Publish(topic string, retained bool, payload string) {
 			return
 		}
 
-		m.log.TRACE.Printf("send %s: '%v'", topic, truncate(payload))
+		m.log.TRACE.Printf("send %s: '%v'", topic, request.Truncate(payload))
 		token := m.client.Publish(topic, m.Qos, retained, payload)
 
 		select {
@@ -290,7 +290,7 @@ func (m *Client) ListenSetter(topic string, callback func(string) error) error {
 func (m *Client) listen(topic string) paho.Token {
 	token := m.client.Subscribe(topic, m.Qos, func(c paho.Client, msg paho.Message) {
 		payload := string(msg.Payload())
-		m.log.TRACE.Printf("recv %s: '%v'", topic, truncate(payload))
+		m.log.TRACE.Printf("recv %s: '%v'", topic, request.Truncate(payload))
 		if len(payload) > 0 {
 			m.mux.Lock()
 			callbacks := m.listener[topic]
@@ -302,12 +302,4 @@ func (m *Client) listen(topic string) paho.Token {
 		}
 	})
 	return token
-}
-
-// truncate limits payload length in trace logs, matching HTTP logging
-func truncate(s string) string {
-	if len(s) > request.LogMaxLen {
-		s = s[:request.LogMaxLen] + "..."
-	}
-	return s
 }

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -141,8 +141,8 @@ func dump(r io.ReadCloser, w *strings.Builder) error {
 	if w.Len() > 0 && len(body) > 0 {
 		w.WriteString("\n--\n")
 	}
-	w.WriteString(Truncate(strings.TrimSpace(string(body))))
-	return nil
+	_, err = w.WriteString(Truncate(strings.TrimSpace(string(body))))
+	return err
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/util/request/roundtrip.go
+++ b/util/request/roundtrip.go
@@ -124,6 +124,14 @@ func drainBody(b io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
 	return io.NopCloser(&buf), io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }
 
+// Truncate limits a string to LogMaxLen for trace logs, appending an ellipsis when cut
+func Truncate(s string) string {
+	if len(s) > LogMaxLen {
+		return s[:LogMaxLen] + "..."
+	}
+	return s
+}
+
 // dump http request/response body
 func dump(r io.ReadCloser, w *strings.Builder) error {
 	body, err := io.ReadAll(r)
@@ -133,8 +141,8 @@ func dump(r io.ReadCloser, w *strings.Builder) error {
 	if w.Len() > 0 && len(body) > 0 {
 		w.WriteString("\n--\n")
 	}
-	_, err = w.Write(bytes.TrimSpace(body[:min(LogMaxLen, len(body))]))
-	return err
+	w.WriteString(Truncate(strings.TrimSpace(string(body))))
+	return nil
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -155,7 +163,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		if LogHeaders {
 			if body, err := httputil.DumpRequestOut(req, true); err == nil {
 				bld.WriteString("\n")
-				bld.Write(bytes.TrimSpace(body[:min(LogMaxLen, len(body))]))
+				bld.WriteString(Truncate(strings.TrimSpace(string(body))))
 			}
 		} else {
 			if save, req.Body, err = drainBody(req.Body); err == nil {
@@ -187,7 +195,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			if LogHeaders {
 				if body, err := httputil.DumpResponse(resp, logBody); err == nil {
 					bld.WriteString("\n\n")
-					bld.Write(bytes.TrimSpace(body[:min(LogMaxLen, len(body))]))
+					bld.WriteString(Truncate(strings.TrimSpace(string(body))))
 				}
 			} else if logBody {
 				if save, resp.Body, err = drainBody(resp.Body); err == nil {


### PR DESCRIPTION
Follow-up to #31944 addressing the review request: extract the trace-log truncation into a single shared helper instead of the mqtt plugin duplicating the logic.

## Change

- Add `request.Truncate(s string) string` — caps at `LogMaxLen` and appends an ellipsis when cut.
- mqtt `send`/`recv` trace logs now call `request.Truncate` instead of a plugin-local copy.
- The http roundtrip body/header dumps use the same helper, so both paths truncate identically (single `LogMaxLen` cap + ellipsis).

No behavior change for mqtt. http trace dumps now gain the ellipsis marker when a body/header exceeds `LogMaxLen`, making the two logging paths consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
