### PR TITLE
core: pass grid feed-in cap to optimizer when curtailment active

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/metrics"
 	"github.com/evcc-io/evcc/core/types"
+	"github.com/evcc-io/evcc/hems/hems"
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/request"
@@ -332,9 +333,9 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 
 	// soft grid feed-in cap from active HEMS curtailment (e.g. German 70% rule):
 	// export is capped at this power, excess PV is curtailed instead of exported
-	if site.hems != nil {
-		if p := site.hems.MaxProductionPower(); p != nil && *p > 0 {
-			req.Grid.PMaxExp = float32(*p)
+	if curtailed := hems.Curtailed(site.hems); curtailed != nil && *curtailed {
+		if pMaxExp := site.hems.MaxProductionPower(); pMaxExp != nil {
+			req.Grid.PMaxExp = float32(*pMaxExp)
 		}
 	}
 

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -325,10 +325,16 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 
 	if site.circuit != nil {
 		if pMaxImp := site.circuit.GetMaxPower(); pMaxImp > 0 {
-			req.Grid = optimizer.GridConfig{
-				// hard grid import limit if no price penalty is set by PrcPExcImp
-				PMaxImp: float32(pMaxImp),
-			}
+			// hard grid import limit if no price penalty is set by PrcPExcImp
+			req.Grid.PMaxImp = float32(pMaxImp)
+		}
+	}
+
+	// soft grid feed-in cap from active HEMS curtailment (e.g. German 70% rule):
+	// export is capped at this power, excess PV is curtailed instead of exported
+	if site.hems != nil {
+		if p := site.hems.MaxProductionPower(); p != nil && *p > 0 {
+			req.Grid.PMaxExp = float32(*p)
 		}
 	}
 


### PR DESCRIPTION
part of evcc-io/evcc#23042

Feed the active HEMS production/feed-in limit (e.g. the German 70% rule) into the optimizer as the grid export cap, so it can schedule battery charging into the PV peak and recover energy that would otherwise be curtailed.

- `optimizerUpdate` now sets `req.Grid.PMaxExp` from `site.hems.MaxProductionPower()` when a limit is active (non-nil and > 0).
- Restructured the existing `PMaxImp` assignment to set the field in place so the import and export caps can coexist.

The optimizer already treats `p_max_exp` as a soft cap: excess PV is curtailed rather than exported, so this never makes the schedule infeasible. The optimizer-side behavior is pinned by a test case in evcc-io/optimizer#93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
