### PR TITLE
Daheimladen: fix misleading sponsorship error on station id read

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -20,6 +20,7 @@ package charger
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"time"
 
@@ -93,8 +94,11 @@ func NewDaheimLaden(ctx context.Context, uri string, id uint8, phases bool) (api
 	}
 
 	c, err := conn.ReadHoldingRegisters(dlRegStationId, 16)
-	if s, _ := utf16BEBytesAsString(c); err != nil || s == "" {
-		return nil, api.ErrSponsorRequired
+	if err != nil {
+		return nil, fmt.Errorf("station id: %w", err)
+	}
+	if s, _ := utf16BEBytesAsString(c); s == "" {
+		return nil, errors.New("station id not found, device may not be a DaheimLaden")
 	}
 
 	log := util.NewLogger("daheimladen")


### PR DESCRIPTION
`NewDaheimLaden` reads the station id register right after connecting and returned `api.ErrSponsorRequired` whenever that read failed or came back empty:

```go
c, err := conn.ReadHoldingRegisters(dlRegStationId, 16)
if s, _ := utf16BEBytesAsString(c); err != nil || s == "" {
    return nil, api.ErrSponsorRequired
}
```

This driver has no sponsor gate at all (no `sponsor.IsAuthorized()` check, unlike `alfen.go`, `vestel.go`, etc.), so an active Trial is irrelevant here — the "sponsorship required" message came purely from a failed/empty register read. Users on emulators/bridges (e.g. HeidelBridge) that don't expose register 38 hit this and get a misleading error.

Report the real read error, and a clear "not a DaheimLaden" message for an empty station id.

fixes #31952

🤖 Generated with [Claude Code](https://claude.com/claude-code)