### PR TITLE
Shelly: PM1 Gen3 Improvements

### DIFF
--- a/meter/shelly.go
+++ b/meter/shelly.go
@@ -48,14 +48,13 @@ func NewShellyFromConfig(other map[string]any) (api.Meter, error) {
 	// Three-phase Shelly energy meters count each phase separately (non-balanced),
 	// making their totals unsuitable for bidirectional grid metering.
 	if !(c.usage == "grid" && c.conn.IsThreePhase()) {
+		total, ret := c.conn.TotalEnergy, c.conn.ReturnEnergy
 		if c.usage == "pv" {
 			// reverse direction
-			implement.Has(c, implement.MeterEnergy(c.conn.ReturnEnergy))
-			implement.Has(c, implement.MeterReturnEnergy(c.conn.TotalEnergy))
-		} else {
-			implement.Has(c, implement.MeterEnergy(c.conn.TotalEnergy))
-			implement.Has(c, implement.MeterReturnEnergy(c.conn.ReturnEnergy))
+			total, ret = ret, total
 		}
+		implement.Has(c, implement.MeterEnergy(total))
+		implement.Has(c, implement.MeterReturnEnergy(ret))
 	}
 
 	if phases, ok := c.conn.Generation.(shelly.Phases); ok {
@@ -89,19 +88,16 @@ func (c *Shelly) CurrentPower() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return c.currentPowerForUsage(power), nil
+	return c.currentPowerForUsage(power, c.conn.SignedPower()), nil
 }
 
-// Shelly PV usage uses absolute power for Gen1 and Gen2 switch-based devices, but switches the sign for Gen3.
-func (c *Shelly) currentPowerForUsage(power float64) float64 {
+// PV usage inverts directional power, otherwise the magnitude is used.
+func (c *Shelly) currentPowerForUsage(power float64, signed bool) float64 {
 	if c.usage != "pv" {
 		return power
 	}
-
-	switch c.conn.Gen() {
-	case 3:
+	if signed {
 		return -power
-	default:
-		return math.Abs(power)
 	}
+	return math.Abs(power)
 }

--- a/meter/shelly.go
+++ b/meter/shelly.go
@@ -92,7 +92,7 @@ func (c *Shelly) CurrentPower() (float64, error) {
 	return c.currentPowerForUsage(power), nil
 }
 
-// Shelly PV usage uses absolute power for Gen1 and Gen2 switch-based devices, but preserves the sign for Gen3.
+// Shelly PV usage uses absolute power for Gen1 and Gen2 switch-based devices, but switches the sign for Gen3.
 func (c *Shelly) currentPowerForUsage(power float64) float64 {
 	if c.usage != "pv" {
 		return power

--- a/meter/shelly.go
+++ b/meter/shelly.go
@@ -92,14 +92,16 @@ func (c *Shelly) CurrentPower() (float64, error) {
 	return c.currentPowerForUsage(power), nil
 }
 
+// Shelly PV usage uses absolute power for Gen1 and Gen2 switch-based devices, but preserves the sign for Gen3.
 func (c *Shelly) currentPowerForUsage(power float64) float64 {
 	if c.usage != "pv" {
 		return power
 	}
 
-	if c.conn.Generation.Gen() > 2 {
+	switch c.conn.Gen() {
+	case 3:
 		return -power
+	default:
+		return math.Abs(power)
 	}
-
-	return math.Abs(power)
 }

--- a/meter/shelly.go
+++ b/meter/shelly.go
@@ -48,8 +48,14 @@ func NewShellyFromConfig(other map[string]any) (api.Meter, error) {
 	// Three-phase Shelly energy meters count each phase separately (non-balanced),
 	// making their totals unsuitable for bidirectional grid metering.
 	if !(c.usage == "grid" && c.conn.IsThreePhase()) {
-		implement.Has(c, implement.MeterEnergy(c.conn.TotalEnergy))
-		implement.Has(c, implement.MeterReturnEnergy(c.conn.ReturnEnergy))
+		if c.usage == "pv" {
+			// reverse direction
+			implement.Has(c, implement.MeterEnergy(c.conn.ReturnEnergy))
+			implement.Has(c, implement.MeterReturnEnergy(c.conn.TotalEnergy))
+		} else {
+			implement.Has(c, implement.MeterEnergy(c.conn.TotalEnergy))
+			implement.Has(c, implement.MeterReturnEnergy(c.conn.ReturnEnergy))
+		}
 	}
 
 	if phases, ok := c.conn.Generation.(shelly.Phases); ok {
@@ -83,8 +89,17 @@ func (c *Shelly) CurrentPower() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if c.usage == "pv" {
-		power = math.Abs(power)
+	return c.currentPowerForUsage(power), nil
+}
+
+func (c *Shelly) currentPowerForUsage(power float64) float64 {
+	if c.usage != "pv" {
+		return power
 	}
-	return power, nil
+
+	if c.conn.Generation.Gen() > 2 {
+		return -power
+	}
+
+	return math.Abs(power)
 }

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -19,6 +19,7 @@ type Generation interface {
 	api.MeterEnergy
 	api.MeterReturnEnergy
 	IsThreePhase() bool
+	Gen() int
 }
 
 type Phases interface {
@@ -73,7 +74,7 @@ func NewConnection(uri, user, password string, channel int, cache time.Duration)
 		// https://shelly-api-docs.shelly.cloud/gen2/
 
 		var err error
-		gen, err = newGen2(client, uri, model, channel, user, password, cache)
+		gen, err = newGen2(client, uri, model, resp.Gen, channel, user, password, cache)
 		if err != nil {
 			return nil, err
 		}

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -27,14 +27,15 @@ type Phases interface {
 	api.PhasePowers
 }
 
-type generationInfo interface {
-	Gen() int
-}
-
 // Connection is the Shelly connection
 type Connection struct {
 	Generation
-	generation int
+	gen int
+}
+
+// SignedPower reports whether the device returns directional (signed) power.
+func (c *Connection) SignedPower() bool {
+	return c.gen >= 3
 }
 
 // NewConnection creates a new Shelly device connection.
@@ -78,20 +79,13 @@ func NewConnection(uri, user, password string, channel int, cache time.Duration)
 		// https://shelly-api-docs.shelly.cloud/gen2/
 
 		var err error
-		gen, err = newGen2(client, uri, model, resp.Gen, channel, user, password, cache)
+		gen, err = newGen2(client, uri, model, channel, user, password, cache)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	conn := &Connection{Generation: gen, generation: resp.Gen}
+	conn := &Connection{Generation: gen, gen: resp.Gen}
 
 	return conn, nil
-}
-
-func (c *Connection) Gen() int {
-	if gen, ok := c.Generation.(generationInfo); ok {
-		return gen.Gen()
-	}
-	return c.generation
 }

--- a/meter/shelly/connection.go
+++ b/meter/shelly/connection.go
@@ -19,7 +19,6 @@ type Generation interface {
 	api.MeterEnergy
 	api.MeterReturnEnergy
 	IsThreePhase() bool
-	Gen() int
 }
 
 type Phases interface {
@@ -28,9 +27,14 @@ type Phases interface {
 	api.PhasePowers
 }
 
+type generationInfo interface {
+	Gen() int
+}
+
 // Connection is the Shelly connection
 type Connection struct {
 	Generation
+	generation int
 }
 
 // NewConnection creates a new Shelly device connection.
@@ -80,7 +84,14 @@ func NewConnection(uri, user, password string, channel int, cache time.Duration)
 		}
 	}
 
-	conn := &Connection{gen}
+	conn := &Connection{Generation: gen, generation: resp.Gen}
 
 	return conn, nil
+}
+
+func (c *Connection) Gen() int {
+	if gen, ok := c.Generation.(generationInfo); ok {
+		return gen.Gen()
+	}
+	return c.generation
 }

--- a/meter/shelly/gen1.go
+++ b/meter/shelly/gen1.go
@@ -158,3 +158,7 @@ func (c *gen1) energy(energy float64) float64 {
 	}
 	return energy
 }
+
+func (c *gen1) Gen() int {
+	return 1
+}

--- a/meter/shelly/gen1.go
+++ b/meter/shelly/gen1.go
@@ -158,7 +158,3 @@ func (c *gen1) energy(energy float64) float64 {
 	}
 	return energy
 }
-
-func (c *gen1) Gen() int {
-	return 1
-}

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -83,6 +83,7 @@ type gen2 struct {
 	uri           string
 	switchchannel int
 	model         string
+	gen           int
 	methods       []string
 	switchstatus  util.Cacheable[Gen2SwitchStatus]
 	em1status     func() (Gen2EM1Status, error)
@@ -102,7 +103,7 @@ func apiCall[T any](c *gen2, id int, method string) func() (T, error) {
 }
 
 // gen2InitApi initializes the connection to the shelly gen2+ api and sets up the cached gen2SwitchStatus, gen2EM1Status and gen2EMStatus
-func newGen2(helper *request.Helper, uri, model string, channel int, user, password string, cache time.Duration) (*gen2, error) {
+func newGen2(helper *request.Helper, uri, model string, gen int, channel int, user, password string, cache time.Duration) (*gen2, error) {
 	// Shelly GEN 2+ API
 	// https://shelly-api-docs.shelly.cloud/gen2/
 	c := &gen2{
@@ -110,6 +111,7 @@ func newGen2(helper *request.Helper, uri, model string, channel int, user, passw
 		uri:           fmt.Sprintf("%s/rpc", util.DefaultScheme(uri, "http")),
 		switchchannel: channel,
 		model:         model,
+		gen:           gen,
 	}
 
 	// Shelly gen 2 rfc7616 authentication
@@ -232,7 +234,10 @@ func (c *gen2) TotalEnergy() (float64, error) {
 
 	case c.hasSwitchEndpoint():
 		res, err := c.switchstatus.Get()
-		return res.Aenergy.Total / 1000, err
+		// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Switch#status
+		// NOTE: ret_aenergy - the active energy added to this container is also added to aenergy container.
+		// All the consumed energy is collected in aenergy regardless of the direction(consumed or returned) of the active energy.
+		return (res.Aenergy.Total - res.Ret_Aenergy.Total) / 1000, err
 
 	default:
 		return 0, fmt.Errorf("unknown shelly model: %s", c.model)
@@ -360,4 +365,8 @@ func parseAddOnSwitchID(channel int, res Gen2ProAddOnGetPeripherals) int {
 
 	// if no switch ID is found, return the channel as default
 	return channel
+}
+
+func (c *gen2) Gen() int {
+	return c.gen
 }

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -83,7 +83,6 @@ type gen2 struct {
 	uri           string
 	switchchannel int
 	model         string
-	gen           int
 	methods       []string
 	switchstatus  util.Cacheable[Gen2SwitchStatus]
 	em1status     func() (Gen2EM1Status, error)
@@ -103,7 +102,7 @@ func apiCall[T any](c *gen2, id int, method string) func() (T, error) {
 }
 
 // gen2InitApi initializes the connection to the shelly gen2+ api and sets up the cached gen2SwitchStatus, gen2EM1Status and gen2EMStatus
-func newGen2(helper *request.Helper, uri, model string, gen int, channel int, user, password string, cache time.Duration) (*gen2, error) {
+func newGen2(helper *request.Helper, uri, model string, channel int, user, password string, cache time.Duration) (*gen2, error) {
 	// Shelly GEN 2+ API
 	// https://shelly-api-docs.shelly.cloud/gen2/
 	c := &gen2{
@@ -111,7 +110,6 @@ func newGen2(helper *request.Helper, uri, model string, gen int, channel int, us
 		uri:           fmt.Sprintf("%s/rpc", util.DefaultScheme(uri, "http")),
 		switchchannel: channel,
 		model:         model,
-		gen:           gen,
 	}
 
 	// Shelly gen 2 rfc7616 authentication
@@ -237,7 +235,7 @@ func (c *gen2) TotalEnergy() (float64, error) {
 		// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Switch#status
 		// NOTE: ret_aenergy - the active energy added to this container is also added to aenergy container.
 		// All the consumed energy is collected in aenergy regardless of the direction(consumed or returned) of the active energy.
-		return c.switchEnergyTotal(res) / 1000, err
+		return max(0, res.Aenergy.Total-res.Ret_Aenergy.Total) / 1000, err
 
 	default:
 		return 0, fmt.Errorf("unknown shelly model: %s", c.model)
@@ -365,16 +363,4 @@ func parseAddOnSwitchID(channel int, res Gen2ProAddOnGetPeripherals) int {
 
 	// if no switch ID is found, return the channel as default
 	return channel
-}
-
-func (c *gen2) switchEnergyTotal(res Gen2SwitchStatus) float64 {
-	netEnergy := res.Aenergy.Total - res.Ret_Aenergy.Total
-	if netEnergy < 0 {
-		return 0
-	}
-	return netEnergy
-}
-
-func (c *gen2) Gen() int {
-	return c.gen
 }

--- a/meter/shelly/gen2.go
+++ b/meter/shelly/gen2.go
@@ -237,7 +237,7 @@ func (c *gen2) TotalEnergy() (float64, error) {
 		// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Switch#status
 		// NOTE: ret_aenergy - the active energy added to this container is also added to aenergy container.
 		// All the consumed energy is collected in aenergy regardless of the direction(consumed or returned) of the active energy.
-		return (res.Aenergy.Total - res.Ret_Aenergy.Total) / 1000, err
+		return c.switchEnergyTotal(res) / 1000, err
 
 	default:
 		return 0, fmt.Errorf("unknown shelly model: %s", c.model)
@@ -365,6 +365,14 @@ func parseAddOnSwitchID(channel int, res Gen2ProAddOnGetPeripherals) int {
 
 	// if no switch ID is found, return the channel as default
 	return channel
+}
+
+func (c *gen2) switchEnergyTotal(res Gen2SwitchStatus) float64 {
+	netEnergy := res.Aenergy.Total - res.Ret_Aenergy.Total
+	if netEnergy < 0 {
+		return 0
+	}
+	return netEnergy
 }
 
 func (c *gen2) Gen() int {

--- a/meter/shelly/gen2_test.go
+++ b/meter/shelly/gen2_test.go
@@ -8,25 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeConnectionGeneration struct{ gen int }
-
-func (f fakeConnectionGeneration) Enabled() (bool, error)         { return false, nil }
-func (f fakeConnectionGeneration) Enable(bool) error              { return nil }
-func (f fakeConnectionGeneration) CurrentPower() (float64, error) { return 0, nil }
-func (f fakeConnectionGeneration) TotalEnergy() (float64, error)  { return 0, nil }
-func (f fakeConnectionGeneration) ReturnEnergy() (float64, error) { return 0, nil }
-func (f fakeConnectionGeneration) IsThreePhase() bool             { return false }
-func (f fakeConnectionGeneration) Gen() int                       { return f.gen }
-
-func TestConnectionGen(t *testing.T) {
-	c := &Connection{Generation: fakeConnectionGeneration{gen: 3}}
-	assert.Equal(t, 3, c.Gen())
-}
-
-func TestSwitchEnergyTotal(t *testing.T) {
-	c := &gen2{}
-	assert.Equal(t, 0.0, c.switchEnergyTotal(Gen2SwitchStatus{Aenergy: struct{ Total float64 }{Total: 10}, Ret_Aenergy: struct{ Total float64 }{Total: 20}}))
-	assert.Equal(t, 5.0, c.switchEnergyTotal(Gen2SwitchStatus{Aenergy: struct{ Total float64 }{Total: 15}, Ret_Aenergy: struct{ Total float64 }{Total: 10}}))
+func TestSignedPower(t *testing.T) {
+	assert.False(t, (&Connection{gen: 1}).SignedPower())
+	assert.False(t, (&Connection{gen: 2}).SignedPower())
+	assert.True(t, (&Connection{gen: 3}).SignedPower())
 }
 
 // Test Gen2+ status responses

--- a/meter/shelly/gen2_test.go
+++ b/meter/shelly/gen2_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeConnectionGeneration struct{ gen int }
+
+func (f fakeConnectionGeneration) Enabled() (bool, error)         { return false, nil }
+func (f fakeConnectionGeneration) Enable(bool) error              { return nil }
+func (f fakeConnectionGeneration) CurrentPower() (float64, error) { return 0, nil }
+func (f fakeConnectionGeneration) TotalEnergy() (float64, error)  { return 0, nil }
+func (f fakeConnectionGeneration) ReturnEnergy() (float64, error) { return 0, nil }
+func (f fakeConnectionGeneration) IsThreePhase() bool             { return false }
+func (f fakeConnectionGeneration) Gen() int                       { return f.gen }
+
+func TestConnectionGen(t *testing.T) {
+	c := &Connection{Generation: fakeConnectionGeneration{gen: 3}}
+	assert.Equal(t, 3, c.Gen())
+}
+
+func TestSwitchEnergyTotal(t *testing.T) {
+	c := &gen2{}
+	assert.Equal(t, 0.0, c.switchEnergyTotal(Gen2SwitchStatus{Aenergy: struct{ Total float64 }{Total: 10}, Ret_Aenergy: struct{ Total float64 }{Total: 20}}))
+	assert.Equal(t, 5.0, c.switchEnergyTotal(Gen2SwitchStatus{Aenergy: struct{ Total float64 }{Total: 15}, Ret_Aenergy: struct{ Total float64 }{Total: 10}}))
+}
+
 // Test Gen2+ status responses
 func TestUnmarshalGen2StatusResponse(t *testing.T) {
 	{

--- a/meter/shelly_test.go
+++ b/meter/shelly_test.go
@@ -1,0 +1,45 @@
+package meter
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/meter/shelly"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeShellyGeneration struct{ gen int }
+
+func (f fakeShellyGeneration) Enabled() (bool, error)         { return false, nil }
+func (f fakeShellyGeneration) Enable(bool) error              { return nil }
+func (f fakeShellyGeneration) CurrentPower() (float64, error) { return 0, nil }
+func (f fakeShellyGeneration) TotalEnergy() (float64, error)  { return 0, nil }
+func (f fakeShellyGeneration) ReturnEnergy() (float64, error) { return 0, nil }
+func (f fakeShellyGeneration) IsThreePhase() bool             { return false }
+func (f fakeShellyGeneration) Gen() int                       { return f.gen }
+
+func TestShellyCurrentPowerForUsage(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage string
+		gen   int
+		power float64
+		want  float64
+	}{
+		{name: "grid keeps sign", usage: "grid", gen: 1, power: -350, want: -350},
+		{name: "gen1 pv uses absolute value", usage: "pv", gen: 1, power: -350, want: 350},
+		{name: "gen2 pv uses absolute value for positive values", usage: "pv", gen: 2, power: 350, want: 350},
+		{name: "gen2 pv uses absolute value for negative values", usage: "pv", gen: 2, power: -350, want: 350},
+		{name: "gen3 pv turns the sign 1", usage: "pv", gen: 3, power: 350, want: -350},
+		{name: "gen3 pv turns the sign", usage: "pv", gen: 3, power: -350, want: 350},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Shelly{
+				usage: tc.usage,
+				conn:  &shelly.Connection{Generation: fakeShellyGeneration{gen: tc.gen}},
+			}
+			assert.Equal(t, tc.want, m.currentPowerForUsage(tc.power))
+		})
+	}
+}

--- a/meter/shelly_test.go
+++ b/meter/shelly_test.go
@@ -3,43 +3,28 @@ package meter
 import (
 	"testing"
 
-	"github.com/evcc-io/evcc/meter/shelly"
 	"github.com/stretchr/testify/assert"
 )
 
-type fakeShellyGeneration struct{ gen int }
-
-func (f fakeShellyGeneration) Enabled() (bool, error)         { return false, nil }
-func (f fakeShellyGeneration) Enable(bool) error              { return nil }
-func (f fakeShellyGeneration) CurrentPower() (float64, error) { return 0, nil }
-func (f fakeShellyGeneration) TotalEnergy() (float64, error)  { return 0, nil }
-func (f fakeShellyGeneration) ReturnEnergy() (float64, error) { return 0, nil }
-func (f fakeShellyGeneration) IsThreePhase() bool             { return false }
-func (f fakeShellyGeneration) Gen() int                       { return f.gen }
-
 func TestShellyCurrentPowerForUsage(t *testing.T) {
 	tests := []struct {
-		name  string
-		usage string
-		gen   int
-		power float64
-		want  float64
+		name   string
+		usage  string
+		signed bool
+		power  float64
+		want   float64
 	}{
-		{name: "grid keeps sign", usage: "grid", gen: 1, power: -350, want: -350},
-		{name: "gen1 pv uses absolute value", usage: "pv", gen: 1, power: -350, want: 350},
-		{name: "gen2 pv uses absolute value for positive values", usage: "pv", gen: 2, power: 350, want: 350},
-		{name: "gen2 pv uses absolute value for negative values", usage: "pv", gen: 2, power: -350, want: 350},
-		{name: "gen3 pv turns the sign 1", usage: "pv", gen: 3, power: 350, want: -350},
-		{name: "gen3 pv turns the sign 2", usage: "pv", gen: 3, power: -350, want: 350},
+		{name: "grid keeps sign", usage: "grid", power: -350, want: -350},
+		{name: "unsigned pv uses absolute value", usage: "pv", power: -350, want: 350},
+		{name: "unsigned pv keeps positive values", usage: "pv", power: 350, want: 350},
+		{name: "signed pv inverts positive values", usage: "pv", signed: true, power: 350, want: -350},
+		{name: "signed pv inverts negative values", usage: "pv", signed: true, power: -350, want: 350},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := &Shelly{
-				usage: tc.usage,
-				conn:  &shelly.Connection{Generation: fakeShellyGeneration{gen: tc.gen}},
-			}
-			assert.Equal(t, tc.want, m.currentPowerForUsage(tc.power))
+			m := &Shelly{usage: tc.usage}
+			assert.Equal(t, tc.want, m.currentPowerForUsage(tc.power, tc.signed))
 		})
 	}
 }

--- a/meter/shelly_test.go
+++ b/meter/shelly_test.go
@@ -30,7 +30,7 @@ func TestShellyCurrentPowerForUsage(t *testing.T) {
 		{name: "gen2 pv uses absolute value for positive values", usage: "pv", gen: 2, power: 350, want: 350},
 		{name: "gen2 pv uses absolute value for negative values", usage: "pv", gen: 2, power: -350, want: 350},
 		{name: "gen3 pv turns the sign 1", usage: "pv", gen: 3, power: 350, want: -350},
-		{name: "gen3 pv turns the sign", usage: "pv", gen: 3, power: -350, want: 350},
+		{name: "gen3 pv turns the sign 2", usage: "pv", gen: 3, power: -350, want: 350},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Refer to discussion based on PR #31878.

Test-Log for PM1 Gen 2 - pv usage:

```bash
thierolm@LAPTOP-KQMMVN3H:~/git-repos/evcc$ ./evcc -l trace -c ./evcc_shelly_test.yaml meter
...
[shelly] TRACE 2026/07/19 19:35:44 {"name":null,"id":"shellyplus1pm-441xxx","mac":"44179XXXX","slot":0,"model":"SNSW-001P16EU","gen":2,"fw_id":"20260311-095847/1.7.5-g9979d16","ver":"1.7.5","app":"Plus1PM","auth_en":false,"auth_domain":null,"provision":"complete"}
[shelly] TRACE 2026/07/19 19:35:44 POST http://192.168.XXX.XXX/rpc/Shelly.ListMethods
[shelly] TRACE 2026/07/19 19:35:44 {"id":0,"src":"evcc","method":"Shelly.ListMethods"}
...
{"id":0, "source":"switch", "output":true, "apower":28.4, "voltage":231.6, "current":0.127, "aenergy":{"total":688125.481,"by_minute":[955.540,1170.429,557.757],"minute_ts":1784482500},"temperature":{"tC":59.8, "tF":139.6}}
Power:           28W           29ms  
Energy:          0.0kWh              
Return Energy:   688.1kWh            
Current L1..L3:  0.127A 0A 0A        
Voltage L1..L3:  232V 0V 0V          
Power L1..L3:    28W 0W 0W           
                                     
Total time:                    29ms  
```

Test Log - charge usage:

```bash
...
{"id":0, "source":"switch", "output":true, "apower":53.6, "voltage":231.9, "current":0.229, "aenergy":{"total":688130.828,"by_minute":[354.328,355.761,359.581],"minute_ts":1784483220},"temperature":{"tC":59.8, "tF":139.7}}
Power:           54W           33ms  
Energy:          688.1kWh            
Return Energy:   0.0kWh              
Current L1..L3:  0.229A 0A 0A        
Voltage L1..L3:  232V 0V 0V          
Power L1..L3:    54W 0W 0W           
                                     
Total time:                    34ms  
```