### PR TITLE
open-meteo-temperature: increase forecast to 5 days

### DIFF
--- a/templates/definition/tariff/open-meteo-temperature.yaml
+++ b/templates/definition/tariff/open-meteo-temperature.yaml
@@ -20,7 +20,7 @@ render: |
   tariff: temperature
   forecast:
     source: http
-    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&minutely_15=temperature_2m&past_days=7&forecast_days=3&timezone=UTC
+    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&minutely_15=temperature_2m&past_days=7&forecast_days=5&timezone=UTC
     jq: |
       [ .minutely_15.time as $times
         | .minutely_15.temperature_2m as $temps


### PR DESCRIPTION
The temperature forecast template only requests 3 days (forecast_days=3), while the solar forecast ([open-meteo.yaml](https://github.com/evcc-io/evcc/blob/master/templates/definition/tariff/open-meteo.yaml)) uses 5 days. This causes the last days of the forecast view to appear empty when the temperature tariff is configured.

Align with the solar forecast by requesting 5 days.