### PR TITLE
fix: keep permanent error sentinels identifiable after backoff

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -7,11 +7,36 @@ import (
 	"github.com/cenkalti/backoff/v4"
 )
 
+// permanentError is a sentinel that backoff treats as permanent without being
+// wrapped. backoff.Retry returns PermanentError.Err, so a backoff.Permanent
+// sentinel loses its identity on the way out and errors.Is stops matching.
+type permanentError struct {
+	msg string
+}
+
+func (e *permanentError) Error() string {
+	return e.msg
+}
+
+// As reports the sentinel as *backoff.PermanentError wrapping itself, so
+// backoff stops retrying and returns the sentinel unchanged.
+func (e *permanentError) As(target any) bool {
+	p, ok := target.(**backoff.PermanentError)
+	if ok {
+		*p = &backoff.PermanentError{Err: e}
+	}
+	return ok
+}
+
+func permanent(msg string) error {
+	return &permanentError{msg}
+}
+
 // ErrNotAvailable indicates that a feature is not available
-var ErrNotAvailable = backoff.Permanent(errors.New("not available"))
+var ErrNotAvailable = permanent("not available")
 
 // ErrUnsupportedPlatform indicates unsupported hardware platform
-var ErrUnsupportedPlatform error = backoff.Permanent(errors.New("unsupported platform"))
+var ErrUnsupportedPlatform = permanent("unsupported platform")
 
 // ErrMustRetry indicates that a rate-limited operation should be retried
 var ErrMustRetry = errors.New("must retry")
@@ -20,10 +45,10 @@ var ErrMustRetry = errors.New("must retry")
 var ErrSponsorRequired = errors.New("sponsorship required, see https://docs.evcc.io/docs/sponsorship")
 
 // ErrMissingCredentials indicates that user/password are missing
-var ErrMissingCredentials = backoff.Permanent(errors.New("missing user/password credentials"))
+var ErrMissingCredentials = permanent("missing user/password credentials")
 
 // ErrMissingToken indicates that access/refresh tokens are missing
-var ErrMissingToken = backoff.Permanent(errors.New("missing token credentials"))
+var ErrMissingToken = permanent("missing token credentials")
 
 // ErrOutdated indicates that result is outdated
 var ErrOutdated = errors.New("outdated")

--- a/api/error_test.go
+++ b/api/error_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPermanentSentinelSurvivesBackoff ensures permanent sentinels stay
+// identifiable after backoff.Retry, which returns PermanentError.Err.
+func TestPermanentSentinelSurvivesBackoff(t *testing.T) {
+	for _, sentinel := range []error{ErrNotAvailable, ErrUnsupportedPlatform, ErrMissingCredentials, ErrMissingToken} {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			var calls int
+
+			_, err := backoff.RetryWithData(func() (float64, error) {
+				calls++
+				return 0, sentinel
+			}, backoff.NewExponentialBackOff())
+
+			require.Equal(t, 1, calls, "must not retry")
+			require.ErrorIs(t, err, sentinel)
+		})
+	}
+}
+
+// TestPermanentSentinelWrapped ensures a wrapped sentinel is still permanent.
+func TestPermanentSentinelWrapped(t *testing.T) {
+	var calls int
+
+	_, err := backoff.RetryWithData(func() (float64, error) {
+		calls++
+		return 0, fmt.Errorf("add[2]: %w", ErrNotAvailable)
+	}, backoff.NewExponentialBackOff())
+
+	require.Equal(t, 1, calls, "must not retry")
+	require.ErrorIs(t, err, ErrNotAvailable)
+}
+
+// TestPermanentSentinelDistinct ensures sentinels don't match each other.
+func TestPermanentSentinelDistinct(t *testing.T) {
+	require.False(t, errors.Is(ErrNotAvailable, ErrMissingToken))
+}


### PR DESCRIPTION
follow-up to #31011

`api.ErrNotAvailable` and the other permanent sentinels are created via `backoff.Permanent(...)`. `backoff.Retry` returns `PermanentError.Err`, so every consumer that retries receives the inner error instead of the sentinel and `errors.Is(err, api.ErrNotAvailable)` is false. Since #31011 made Modbus NaN sentinels return `ErrNotAvailable`, this surfaces as an error logged every cycle for meters that legitimately report no value, e.g. an SMA hybrid with an unused MPPT input.

- sentinels are now a small `permanentError` type whose `As` reports it as `*backoff.PermanentError` wrapping itself, so backoff still stops retrying but hands the sentinel back unchanged
- applies to `ErrNotAvailable`, `ErrUnsupportedPlatform`, `ErrMissingCredentials` and `ErrMissingToken`
- consumers guarding with `errors.Is` (site meter collection, loadpoint phase switching, vehicle polling) start working as intended, no call site changes needed

The remaining half of the SMA report is separate: `calc/add` aborts the whole sum when one summand is unavailable, so an unpopulated string still zeroes out PV power rather than contributing 0.
