### PR TITLE
Vehicle: restore streaming param on EU Data Act templates

### DIFF
--- a/templates/definition/vehicle/audi.yaml
+++ b/templates/definition/vehicle/audi.yaml
@@ -34,6 +34,8 @@ params:
   - name: welcomecharge
     advanced: true
     deprecated: true
+  - name: streaming
+    deprecated: true
   - preset: vehicle-online
 render: |
   type: drivesomethinggreater

--- a/templates/definition/vehicle/drivesomethinggreater.yaml
+++ b/templates/definition/vehicle/drivesomethinggreater.yaml
@@ -52,6 +52,8 @@ params:
   - name: welcomecharge
     advanced: true
     deprecated: true
+  - name: streaming
+    deprecated: true
   - preset: vehicle-online
 render: |
   type: drivesomethinggreater

--- a/templates/definition/vehicle/seat-cupra.yaml
+++ b/templates/definition/vehicle/seat-cupra.yaml
@@ -30,6 +30,8 @@ params:
   - name: welcomecharge
     advanced: true
     deprecated: true
+  - name: streaming
+    deprecated: true
   - preset: vehicle-online
 render: |
   type: drivesomethinggreater

--- a/templates/definition/vehicle/seat.yaml
+++ b/templates/definition/vehicle/seat.yaml
@@ -31,6 +31,8 @@ params:
   - name: welcomecharge
     advanced: true
     deprecated: true
+  - name: streaming
+    deprecated: true
   - preset: vehicle-online
 render: |
   type: drivesomethinggreater

--- a/templates/definition/vehicle/vw.yaml
+++ b/templates/definition/vehicle/vw.yaml
@@ -39,6 +39,8 @@ params:
   - name: welcomecharge
     advanced: true
     deprecated: true
+  - name: streaming
+    deprecated: true
   - preset: vehicle-online
 render: |
   type: drivesomethinggreater

--- a/vehicle/template_test.go
+++ b/vehicle/template_test.go
@@ -1,6 +1,7 @@
 package vehicle
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -44,7 +45,18 @@ func TestTemplates(t *testing.T) {
 
 // onlineVehicleFeatures render via the shared vehicle-features include, so a
 // stored config may carry them; dropping the param breaks reload (discussion #31291).
-var onlineVehicleFeatures = []string{"climaterdisabled", "autodetectdisabled", "wakeupdisabled"}
+var onlineVehicleFeatures = []string{"streaming", "coarsecurrent", "welcomecharge", "climaterdisabled", "autodetectdisabled", "wakeupdisabled"}
+
+// requiredFeatureParams lists features these templates once offered as user
+// params. Stored configs carry the key, so undeclaring it makes evcc fail to
+// boot on the next restart (#31962). Deprecate such params, never remove them.
+var requiredFeatureParams = map[string][]string{
+	"vw":                    {"streaming", "coarsecurrent", "welcomecharge"},
+	"audi":                  {"streaming", "coarsecurrent", "welcomecharge"},
+	"seat":                  {"streaming", "coarsecurrent", "welcomecharge"},
+	"seat-cupra":            {"streaming", "coarsecurrent", "welcomecharge"},
+	"drivesomethinggreater": {"streaming", "coarsecurrent", "welcomecharge"},
+}
 
 func TestVehicleFeatureParamsConsistent(t *testing.T) {
 	for _, tmpl := range templates.ByClass(templates.Vehicle, templates.WithDeprecated()) {
@@ -55,6 +67,9 @@ func TestVehicleFeatureParamsConsistent(t *testing.T) {
 		for _, feat := range onlineVehicleFeatures {
 			// not every template ever offered every feature (e.g. wakeupdisabled is new)
 			if i, _ := tmpl.ParamByName(feat); i < 0 {
+				if slices.Contains(requiredFeatureParams[tmpl.Template], feat) {
+					t.Errorf("%s: feature %q must stay a declared param", tmpl.Template, feat)
+				}
 				continue
 			}
 


### PR DESCRIPTION
fixes #31962, follow-up to #31047

#31047 replaced `preset: vehicle-features` with `preset: vehicle-online` on the drivesomethinggreater family. `vehicle-online` does not declare `streaming`, so an existing config that still carries the key is rejected on load: `cannot create vehicle type 'template': invalid key: streaming`. That is fatal at boot, so all vehicles disappear from the UI, not just the affected one.

- re-declare `streaming` as a deprecated param on vw, audi, seat, seat-cupra and drivesomethinggreater, so stored configs keep validating while the param is no longer offered
- the render already forces the feature via `basefeatures`, so behaviour is unchanged
- `TestVehicleFeatureParamsConsistent` skipped undeclared params and therefore could not catch a removal; it now fails for params these templates are known to have offered

Note that mazda2mqtt also forces `streaming` but never offered it as a param, so it is intentionally not listed.
