### PR TITLE
Solvis: add SolvisControl 2/3 heating template

### DIFF
--- a/templates/definition/charger/solvis.yaml
+++ b/templates/definition/charger/solvis.yaml
@@ -1,0 +1,150 @@
+template: solvis
+products:
+  - brand: Solvis
+    description:
+      generic: SolvisControl 2/3
+group: heating
+capabilities: ["meter"]
+requirements:
+  description:
+    de: |
+      Modbus TCP muss am SolvisControl unter „Einstellungen / Netzwerk“ aktiviert sein.
+      Die Ansteuerung erfolgt über die Warmwasser-Solltemperatur oder die Warmwasser-Nachheizung.
+      Eine Leistungsreduzierung (dim) unterstützt der Regler nicht.
+    en: |
+      Modbus TCP must be enabled at the SolvisControl under "Settings / Network".
+      Control is done via the hot water target temperature or the hot water reheat.
+      The controller does not support power reduction (dim).
+params:
+  - name: host
+  - name: port
+    default: 502
+  - name: control
+    type: choice
+    choice: ["temp", "reheat"]
+    default: temp
+    description:
+      de: Ansteuerung
+      en: Control
+    help:
+      de: Warmwasser-Solltemperatur (temp) oder Nachheizung (reheat)
+      en: Hot water target temperature (temp) or reheat (reheat)
+  - name: tempnormal
+    type: int
+    default: 48
+    description:
+      de: Solltemperatur Normalbetrieb
+      en: Target temperature normal mode
+  - name: tempboost
+    type: int
+    default: 60
+    description:
+      de: Solltemperatur Boost
+      en: Target temperature boost
+  - name: tempsource
+    type: choice
+    choice: ["warmwater", "buffer"]
+render: |
+  type: sgready
+  # The controller has no mode register, the mode is tracked by evcc.
+  # For control: temp it could be read back from 2305:
+  # getmode:
+  #   source: map
+  #   values:
+  #     {{ .tempnormal }}: 2
+  #     {{ .tempboost }}: 3
+  #   get:
+  #     source: modbus
+  #     uri: {{ joinHostPort .host .port }}
+  #     id: 1
+  #     register:
+  #       address: 2305
+  #       type: holding
+  #       encoding: uint16
+  setmode:
+    source: switch
+    switch:
+    {{- if eq .control "temp" }}
+    - case: 2 # normal
+      set:
+        source: const
+        value: {{ .tempnormal }}
+        set:
+          source: modbus
+          uri: {{ joinHostPort .host .port }}
+          id: 1
+          register:
+            address: 2305 # Warmwasser Solltemperatur
+            type: writesingle
+            encoding: uint16
+    - case: 3 # boost
+      set:
+        source: const
+        value: {{ .tempboost }}
+        set:
+          source: modbus
+          uri: {{ joinHostPort .host .port }}
+          id: 1
+          register:
+            address: 2305 # Warmwasser Solltemperatur
+            type: writesingle
+            encoding: uint16
+    {{- else }}
+    - case: 2 # normal
+      set:
+        source: const
+        value: 0
+        set:
+          source: modbus
+          uri: {{ joinHostPort .host .port }}
+          id: 1
+          register:
+            address: 2322 # Warmwasser Nachheizung
+            type: writesingle
+            encoding: uint16
+    - case: 3 # boost
+      set:
+        source: const
+        value: 1
+        set:
+          source: modbus
+          uri: {{ joinHostPort .host .port }}
+          id: 1
+          register:
+            address: 2322 # Warmwasser Nachheizung
+            type: writesingle
+            encoding: uint16
+    {{- end }}
+    - case: 1 # dim
+      set:
+        source: error
+        error: ErrNotAvailable
+  power:
+    source: modbus
+    uri: {{ joinHostPort .host .port }}
+    id: 1
+    register:
+      address: 33545 # Wärmepumpe Leistungsaufnahme elektrisch
+      type: holding
+      encoding: uint16
+    scale: 100 # 0.1 kW -> W
+  {{- if .tempsource }}
+  temp:
+    source: modbus
+    uri: {{ joinHostPort .host .port }}
+    id: 1
+    register:
+      address: {{ if eq .tempsource "warmwater" }}33025{{ else }}33024{{ end }} # 33025 Warmwasser S2, 33024 Warmwasserpuffer S1
+      type: input
+      encoding: int16
+    scale: 0.1
+  limittemp:
+    source: modbus
+    uri: {{ joinHostPort .host .port }}
+    id: 1
+    register:
+      address: 2305 # Warmwasser Solltemperatur
+      type: holding
+      encoding: uint16
+  {{- end }}
+  {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/solvis.yaml
+++ b/templates/definition/charger/solvis.yaml
@@ -9,26 +9,16 @@ requirements:
   description:
     de: |
       Modbus TCP muss am SolvisControl unter „Einstellungen / Netzwerk“ aktiviert sein.
-      Die Ansteuerung erfolgt über die Warmwasser-Solltemperatur oder die Warmwasser-Nachheizung.
+      Die Ansteuerung erfolgt über die Warmwasser-Solltemperatur.
       Eine Leistungsreduzierung (dim) unterstützt der Regler nicht.
     en: |
       Modbus TCP must be enabled at the SolvisControl under "Settings / Network".
-      Control is done via the hot water target temperature or the hot water reheat.
+      Control is done via the hot water target temperature.
       The controller does not support power reduction (dim).
 params:
   - name: host
   - name: port
     default: 502
-  - name: control
-    type: choice
-    choice: ["temp", "reheat"]
-    default: temp
-    description:
-      de: Ansteuerung
-      en: Control
-    help:
-      de: Warmwasser-Solltemperatur (temp) oder Nachheizung (reheat)
-      en: Hot water target temperature (temp) or reheat (reheat)
   - name: tempnormal
     type: int
     default: 48
@@ -49,7 +39,7 @@ params:
 render: |
   type: sgready
   # The controller has no mode register, the mode is tracked by evcc.
-  # For control: temp it could be read back from 2305:
+  # It could be read back from 2305:
   # getmode:
   #   source: map
   #   values:
@@ -69,25 +59,25 @@ render: |
     - case: 2 # normal
       set:
         source: const
-        value: {{ if eq .control "temp" }}{{ .tempnormal }}{{ else }}0{{ end }}
+        value: {{ .tempnormal }}
         set:
           source: modbus
           uri: {{ joinHostPort .host .port }}
           id: 1
           register:
-            address: {{ if eq .control "temp" }}2305{{ else }}2322{{ end }} # 2305 Warmwasser Solltemperatur, 2322 Warmwasser Nachheizung
+            address: 2305 # Warmwasser Solltemperatur
             type: writesingle
             encoding: uint16
     - case: 3 # boost
       set:
         source: const
-        value: {{ if eq .control "temp" }}{{ .tempboost }}{{ else }}1{{ end }}
+        value: {{ .tempboost }}
         set:
           source: modbus
           uri: {{ joinHostPort .host .port }}
           id: 1
           register:
-            address: {{ if eq .control "temp" }}2305{{ else }}2322{{ end }} # 2305 Warmwasser Solltemperatur, 2322 Warmwasser Nachheizung
+            address: 2305 # Warmwasser Solltemperatur
             type: writesingle
             encoding: uint16
     - case: 1 # dim

--- a/templates/definition/charger/solvis.yaml
+++ b/templates/definition/charger/solvis.yaml
@@ -42,8 +42,10 @@ params:
       de: Solltemperatur Boost
       en: Target temperature boost
   - name: tempsource
+    required: true
     type: choice
     choice: ["warmwater", "buffer"]
+    default: warmwater
 render: |
   type: sgready
   # The controller has no mode register, the mode is tracked by evcc.
@@ -64,57 +66,30 @@ render: |
   setmode:
     source: switch
     switch:
-    {{- if eq .control "temp" }}
     - case: 2 # normal
       set:
         source: const
-        value: {{ .tempnormal }}
+        value: {{ if eq .control "temp" }}{{ .tempnormal }}{{ else }}0{{ end }}
         set:
           source: modbus
           uri: {{ joinHostPort .host .port }}
           id: 1
           register:
-            address: 2305 # Warmwasser Solltemperatur
+            address: {{ if eq .control "temp" }}2305{{ else }}2322{{ end }} # 2305 Warmwasser Solltemperatur, 2322 Warmwasser Nachheizung
             type: writesingle
             encoding: uint16
     - case: 3 # boost
       set:
         source: const
-        value: {{ .tempboost }}
+        value: {{ if eq .control "temp" }}{{ .tempboost }}{{ else }}1{{ end }}
         set:
           source: modbus
           uri: {{ joinHostPort .host .port }}
           id: 1
           register:
-            address: 2305 # Warmwasser Solltemperatur
+            address: {{ if eq .control "temp" }}2305{{ else }}2322{{ end }} # 2305 Warmwasser Solltemperatur, 2322 Warmwasser Nachheizung
             type: writesingle
             encoding: uint16
-    {{- else }}
-    - case: 2 # normal
-      set:
-        source: const
-        value: 0
-        set:
-          source: modbus
-          uri: {{ joinHostPort .host .port }}
-          id: 1
-          register:
-            address: 2322 # Warmwasser Nachheizung
-            type: writesingle
-            encoding: uint16
-    - case: 3 # boost
-      set:
-        source: const
-        value: 1
-        set:
-          source: modbus
-          uri: {{ joinHostPort .host .port }}
-          id: 1
-          register:
-            address: 2322 # Warmwasser Nachheizung
-            type: writesingle
-            encoding: uint16
-    {{- end }}
     - case: 1 # dim
       set:
         source: error
@@ -128,7 +103,6 @@ render: |
       type: holding
       encoding: uint16
     scale: 100 # 0.1 kW -> W
-  {{- if .tempsource }}
   temp:
     source: modbus
     uri: {{ joinHostPort .host .port }}
@@ -146,5 +120,4 @@ render: |
       address: 2305 # Warmwasser Solltemperatur
       type: holding
       encoding: uint16
-  {{- end }}
   {{ include "heatpumpswitch" . }}


### PR DESCRIPTION
Adds a `sgready` template for Solvis heating systems with SolvisControl 2/3, based on the register set documented in [LarsK1/hass_solvis_control](https://github.com/LarsK1/hass_solvis_control).

The controller exposes no SG-Ready input and no power setpoint over Modbus TCP, so boost is applied by writing the hot water target temperature (`2305`), switching between `tempnormal` and `tempboost`.

Dim returns `ErrNotAvailable` — the controller cannot be throttled below normal operation, so the `dim` capability is not declared.

Readings: electrical heat pump input power (`33545`), hot water temperature (`33025`) or hot water buffer temperature (`33024`) per `tempsource`, and the target temperature as limit. Only thermal energy counters exist, so no `energy` is exposed.

`getmode` is left commented out: there is no mode register, so the mode is tracked by evcc and could at best be inferred by reading `2305` back.

Register addresses, types and scaling are taken from `hass_solvis_control` and have not been verified against hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)