### PR TITLE
chore: quote openapi responses

### DIFF
--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -587,7 +587,7 @@ paths:
             schema:
               $ref: "#/components/schemas/PlanStrategy"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
@@ -1275,7 +1275,7 @@ paths:
             schema:
               $ref: "#/components/schemas/PlanStrategy"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:


### PR DESCRIPTION
only two where not in `"`
see https://swagger.io/docs/specification/v3_0/describing-responses/#http-status-codes and https://swagger.io/specification/#fixed-fields-6