### PR TITLE
Add Shelly EM1

### DIFF
--- a/templates/definition/meter/shelly-em1-modbus.yaml
+++ b/templates/definition/meter/shelly-em1-modbus.yaml
@@ -42,27 +42,3 @@ render: |
       type: input
       decode: float32s
     scale: 0.001
-  currents:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: {{ $addr := add 2005 ( mul 20 .channel ) }}{{ $addr }} # Current (A)
-        type: input
-        decode: float32s
-      scale: 1
-    - source: const
-      value: 0
-    - source: const
-      value: 0
-  voltages:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: {{ $addr := add 2003 ( mul 20 .channel ) }}{{ $addr }} # Voltage (V)
-        type: input
-        decode: float32s
-      scale: 1
-    - source: const
-      value: 0
-    - source: const
-      value: 0

--- a/templates/definition/meter/shelly-em1-modbus.yaml
+++ b/templates/definition/meter/shelly-em1-modbus.yaml
@@ -1,0 +1,68 @@
+template: shelly-em1-modbus
+products:
+  - { brand: Shelly, description: { generic: EM1-based (Modbus) } }
+group: switchsockets
+requirements:
+  description:
+    de: |
+      Shelly EM1-basierte Geräte für einphasige Messungen.
+    en: |
+      Shelly EM1-based devices for single phase measurements.
+params:
+  - name: usage
+    choice: ["grid", "pv", "charge"]
+  - name: modbus
+    choice: ["tcpip"]
+    id: 1
+  - name: channel
+    default: 0
+render: |
+  type: custom
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: {{ $addr := add 2007 ( mul 20 .channel ) }}{{ $addr }} # Active Power (W)
+      type: input
+      decode: float32s
+    scale: 1
+  energy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: {{ $addr := add 2310 ( mul 20 .channel ) }}{{ $addr }} # Total Active Energy (Wh)
+      type: input
+      decode: float32s
+    scale: 0.001
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: {{ $addr := add 2312 ( mul 20 .channel ) }}{{ $addr }} # Total Active Returned Energy (Wh)
+      type: input
+      decode: float32s
+    scale: 0.001
+  currents:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: {{ $addr := add 2005 ( mul 20 .channel ) }}{{ $addr }} # Current (A)
+        type: input
+        decode: float32s
+      scale: 1
+    - source: const
+      value: 0
+    - source: const
+      value: 0
+  voltages:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: {{ $addr := add 2003 ( mul 20 .channel ) }}{{ $addr }} # Voltage (V)
+        type: input
+        decode: float32s
+      scale: 1
+    - source: const
+      value: 0
+    - source: const
+      value: 0


### PR DESCRIPTION
This PR adds modbus support for Shelly EM1-based devices.

The EM1 are 1-phase meters, so I set phase2/3 to 0 with const for currents and voltages, as I couldn't find how to only provide single phase. I reckon it's enough to always provide L1 data, right? Otherwise I can add a parameter with which you could set the phase it's measuring.