### PR TITLE
Relay/FNN HEMS: don't read limit sources during startup

### DIFF
--- a/hems/fnn/fnn.go
+++ b/hems/fnn/fnn.go
@@ -78,24 +78,15 @@ func NewFnn(site site.API, maxDimPower, maxCurtailPower float64, w3G, s1G, s2G, 
 	}
 
 	c := &Fnn{
-		log:               util.NewLogger("fnn"),
-		site:              site,
-		maxDimPower:       maxDimPower,
-		maxCurtailPower:   maxCurtailPower,
-		s1:                s1G,
-		s2:                s2G,
-		w3:                w3G,
-		w4:                w4G,
-		productionPercent: 100,
-		interval:          interval,
-	}
-
-	// read the relays once synchronously so limits are valid as soon as NewFnn returns
-	if err := c.runCurtail(); err != nil {
-		return nil, err
-	}
-	if err := c.runDim(); err != nil {
-		return nil, err
+		log:             util.NewLogger("fnn"),
+		site:            site,
+		maxDimPower:     maxDimPower,
+		maxCurtailPower: maxCurtailPower,
+		s1:              s1G,
+		s2:              s2G,
+		w3:              w3G,
+		w4:              w4G,
+		interval:        interval,
 	}
 
 	return c, nil
@@ -117,8 +108,8 @@ type Fnn struct {
 	smartgridConsumptionID uint
 	smartgridProductionID  uint
 
-	consumptionLimit  *float64
-	productionPercent int // allowed feed-in percent (0..100), 100 = uncurtailed
+	consumptionLimit  *float64 // nil until first dim read
+	productionPercent *int     // allowed feed-in percent (0..100), 100 = uncurtailed, nil until first curtail read
 
 	interval time.Duration
 }
@@ -129,9 +120,9 @@ func (c *Fnn) SetUpdated(f func()) {
 	c.publishFunc = f
 }
 
-// Run starts the FNN control loop. NewFnn already ran the first pass.
 func (c *Fnn) Run() {
-	for range time.Tick(c.interval) {
+	// run immediately, then on every tick
+	for tick := time.Tick(c.interval); ; <-tick {
 		if err := c.runCurtail(); err != nil {
 			c.log.ERROR.Println(err)
 		}
@@ -207,7 +198,7 @@ func (c *Fnn) setProductionLimit(percent int) error {
 	defer c.mu.Unlock()
 
 	active := percent < 100
-	c.productionPercent = percent
+	c.productionPercent = new(percent)
 
 	limit := 0.0
 	if active {
@@ -227,10 +218,7 @@ func (c *Fnn) setConsumptionLimit(limit float64) error {
 	defer c.mu.Unlock()
 
 	active := limit > 0
-	c.consumptionLimit = nil
-	if active {
-		c.consumptionLimit = &limit
-	}
+	c.consumptionLimit = new(limit)
 
 	if err := smartgrid.UpdateSession(&c.smartgridConsumptionID, smartgrid.Dim, c.site.GetGridPower(), limit, active); err != nil {
 		c.log.ERROR.Printf("smartgrid session: %v", err)
@@ -242,6 +230,7 @@ func (c *Fnn) setConsumptionLimit(limit float64) error {
 var _ api.HEMS = (*Fnn)(nil)
 
 // CurtailedPercent implements api.HEMS, returning the allowed production percent.
+// nil until the relays have been read for the first time.
 func (c *Fnn) CurtailedPercent() *int {
 	if c.w3 == nil {
 		return nil
@@ -249,11 +238,14 @@ func (c *Fnn) CurtailedPercent() *int {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	return new(c.productionPercent)
+	if c.productionPercent == nil {
+		return nil
+	}
+	return new(*c.productionPercent)
 }
 
 // MaxConsumptionPower implements api.HEMS.
+// nil until the relays have been read for the first time.
 func (c *Fnn) MaxConsumptionPower() *float64 {
 	if c.w4 == nil {
 		return nil
@@ -262,12 +254,13 @@ func (c *Fnn) MaxConsumptionPower() *float64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.consumptionLimit == nil {
-		return new(0.0)
+		return nil
 	}
 	return new(*c.consumptionLimit)
 }
 
 // MaxProductionPower implements api.HEMS.
+// nil until the relays have been read for the first time.
 func (c *Fnn) MaxProductionPower() *float64 {
 	if c.w3 == nil {
 		return nil
@@ -275,9 +268,12 @@ func (c *Fnn) MaxProductionPower() *float64 {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.productionPercent >= 100 {
+	if c.productionPercent == nil {
+		return nil
+	}
+	if *c.productionPercent >= 100 {
 		return new(0.0)
 	}
 
-	return new(float64(c.productionPercent) / 100 * c.maxCurtailPower)
+	return new(float64(*c.productionPercent) / 100 * c.maxCurtailPower)
 }

--- a/hems/fnn/fnn_test.go
+++ b/hems/fnn/fnn_test.go
@@ -3,6 +3,7 @@ package fnn
 import (
 	"testing"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/hems/hems"
 	"github.com/evcc-io/evcc/server/db"
@@ -21,6 +22,18 @@ func boolG(v bool) func() (bool, error) {
 	return func() (bool, error) { return v, nil }
 }
 
+// TestNewFnnDoesNotReadRelays verifies that construction does not read the
+// relay sources. Blocking or failing here would stall startup, see #31999.
+func TestNewFnnDoesNotReadRelays(t *testing.T) {
+	relay := func() (bool, error) { return false, api.ErrOutdated }
+
+	fnn, err := NewFnn(nil, 1e3, 1e3, relay, nil, nil, relay, 0)
+	require.NoError(t, err)
+	assert.Nil(t, fnn.MaxConsumptionPower())
+	assert.Nil(t, fnn.CurtailedPercent())
+	assert.Nil(t, fnn.MaxProductionPower())
+}
+
 // TestCurtailmentNotConfigured verifies that without W3 no curtailment
 // statement is made, while dimming via W4 remains available.
 func TestCurtailmentNotConfigured(t *testing.T) {
@@ -33,6 +46,11 @@ func TestCurtailmentNotConfigured(t *testing.T) {
 	assert.Nil(t, fnn.MaxProductionPower())
 	assert.Nil(t, hems.Curtailed(fnn))
 
+	// no statement before the relays have been read
+	assert.Nil(t, fnn.MaxConsumptionPower())
+	assert.Nil(t, hems.Dimmed(fnn))
+
+	require.NoError(t, fnn.runDim())
 	assert.NotNil(t, fnn.MaxConsumptionPower())
 	assert.NotNil(t, hems.Dimmed(fnn))
 }
@@ -46,6 +64,11 @@ func TestDimmingNotConfigured(t *testing.T) {
 	assert.Nil(t, fnn.MaxConsumptionPower())
 	assert.Nil(t, hems.Dimmed(fnn))
 
+	// no statement before the relays have been read
+	assert.Nil(t, fnn.CurtailedPercent())
+	assert.Nil(t, hems.Curtailed(fnn))
+
+	require.NoError(t, fnn.runCurtail())
 	assert.NotNil(t, fnn.CurtailedPercent())
 	assert.NotNil(t, hems.Curtailed(fnn))
 }

--- a/hems/relay/relay.go
+++ b/hems/relay/relay.go
@@ -78,11 +78,6 @@ func NewRelay(site site.API, w1 func() (bool, error), passthrough func(bool) err
 		return nil, errors.New("missing power limit")
 	}
 
-	// read the relay once synchronously so the limit is valid as soon as NewRelay returns
-	if err := c.run(); err != nil {
-		return nil, err
-	}
-
 	return c, nil
 }
 
@@ -92,9 +87,9 @@ func (c *Relay) SetUpdated(f func()) {
 	c.publishFunc = f
 }
 
-// Run starts the relay control loop. NewRelay already ran the first pass.
 func (c *Relay) Run() {
-	for range time.Tick(c.interval) {
+	// run immediately, then on every tick
+	for tick := time.Tick(c.interval); ; <-tick {
 		if err := c.run(); err != nil {
 			c.log.ERROR.Println(err)
 		}
@@ -131,10 +126,7 @@ func (c *Relay) setConsumptionLimit(limit float64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.limit = nil
-	if limit > 0 {
-		c.limit = new(limit)
-	}
+	c.limit = new(limit)
 
 	if c.passthrough != nil {
 		if err := c.passthrough(limit > 0); err != nil {
@@ -154,11 +146,12 @@ func (c *Relay) CurtailedPercent() *int {
 }
 
 // MaxConsumptionPower implements api.HEMS, returning the active wattage cap.
+// nil until the relay has been read for the first time.
 func (c *Relay) MaxConsumptionPower() *float64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.limit == nil {
-		return new(0.0)
+		return nil
 	}
 	return new(*c.limit)
 }

--- a/hems/relay/relay_test.go
+++ b/hems/relay/relay_test.go
@@ -2,11 +2,23 @@ package relay
 
 import (
 	"testing"
+	"time"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/hems/hems"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNewRelayDoesNotReadLimit verifies that construction does not read the limit
+// source. Blocking or failing here would stall startup, see #31999.
+func TestNewRelayDoesNotReadLimit(t *testing.T) {
+	limit := func() (bool, error) { return false, api.ErrOutdated }
+
+	c, err := NewRelay(nil, limit, nil, 1e3, time.Second)
+	require.NoError(t, err)
+	assert.Nil(t, c.MaxConsumptionPower())
+}
 
 // TestCurtailmentNotConfigured verifies that relay never makes a curtailment
 // statement, and that an active relay dims to maxPower.
@@ -17,6 +29,15 @@ func TestCurtailmentNotConfigured(t *testing.T) {
 	assert.Nil(t, c.CurtailedPercent())
 	assert.Nil(t, c.MaxProductionPower())
 	assert.Nil(t, hems.Curtailed(c))
+
+	// no statement before the relay has been read
+	assert.Nil(t, c.MaxConsumptionPower())
+	assert.Nil(t, hems.Dimmed(c))
+
+	// inactive relay is read and not dimmed
+	require.NoError(t, c.setConsumptionLimit(0))
+	assert.Equal(t, new(0.0), c.MaxConsumptionPower())
+	assert.Equal(t, new(false), hems.Dimmed(c))
 
 	// active relay dims to maxPower
 	c.maxPower = 1e3


### PR DESCRIPTION
fixes #31999, fix https://github.com/evcc-io/evcc/issues/32001

`NewRelay` reads the limit source synchronously since #31428. With an mqtt limit source and no retained message, `util.Monitor.Get` blocks for the configured timeout on first call, so `configureHEMS` never returns, `apiReady` is never published and the UI stays at "no connection to server". A read error is equally fatal — it aborts hems configuration.

The relay control loop already reads on its first tick, so construction doesn't need to. `MaxConsumptionPower` now reports nil until that first read, matching the `api.HEMS` contract (nil = undefined), and returns 0 for an inactive relay instead of nil so `Dimmed` stays false rather than unknown.

FNN has the same synchronous startup reads and gets the same treatment: no reads during construction, first pass on the first loop tick, and `CurtailedPercent`/`MaxConsumptionPower`/`MaxProductionPower` report nil until the relays have been read.

Also addresses https://github.com/evcc-io/evcc/discussions/31997 (relay + mqtt without `timeout` aborted with `cannot create hems type 'relay': outdated`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)