### PR TITLE
Huawei EMMA: add curtailment

### DIFF
--- a/templates/definition/meter/huawei-emma.yaml
+++ b/templates/definition/meter/huawei-emma.yaml
@@ -186,7 +186,7 @@ render: |
     # the percentage register is only meaningful while a limit mode is active
     script: |
       limit := percent
-      if mode == 0 {
+      if mode != 7 {
         limit = 100
       }
       limit

--- a/templates/definition/meter/huawei-emma.yaml
+++ b/templates/definition/meter/huawei-emma.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Huawei
     description:
       generic: EMMA
+capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -120,6 +121,75 @@ render: |
       type: holding
       decode: uint64nan
     scale: 0.01
+  curtail:
+    source: sequence
+    set:
+    # allowed feed-in power as percent of nominal (0-100 %)
+    - source: modbus
+      id: 0
+      uri: {{ joinHostPort .host .port }}
+      register:
+        address: 40109 # Maximum grid feed-in power (0-100 %)
+        type: writesingle
+        encoding: uint16
+      scale: 10
+    # power control mode at grid connection point: 7 = percentage limit while curtailed, 0 = unlimited at 100%
+    - source: switch
+      switch:
+        - case: 100 # uncurtailed
+          set:
+            source: const
+            value: 0 # Unlimited
+            set:
+              source: modbus
+              id: 0
+              uri: {{ joinHostPort .host .port }}
+              register:
+                address: 40100 # Power control mode at grid connection point
+                type: writesingle
+                encoding: uint16
+      default:
+        source: const
+        value: 7 # Power-limited grid connection (%)
+        set:
+          source: modbus
+          id: 0
+          uri: {{ joinHostPort .host .port }}
+          register:
+            address: 40100 # Power control mode at grid connection point
+            type: writesingle
+            encoding: uint16
+  curtailed:
+    source: go
+    in:
+    - name: mode
+      type: int
+      config:
+        source: modbus
+        id: 0
+        uri: {{ joinHostPort .host .port }}
+        register:
+          address: 40100 # Power control mode at grid connection point (0=no curtailment)
+          type: holding
+          decode: uint16
+    - name: percent
+      type: int
+      config:
+        source: modbus
+        id: 0
+        uri: {{ joinHostPort .host .port }}
+        register:
+          address: 40109 # Maximum grid feed-in power (0-100 %)
+          type: holding
+          decode: uint16
+        scale: 0.1
+    # the percentage register is only meaningful while a limit mode is active
+    script: |
+      limit := percent
+      if mode == 0 {
+        limit = 100
+      }
+      limit
   {{- end }}
   {{- if eq .usage "battery" }}
   power:


### PR DESCRIPTION
fixes #31959

Adds EEG §9 curtailment to the Huawei EMMA meter template. EMMA is the master gateway, so the limit has to be written to EMMA itself (unit ID 0) rather than to the underlying inverters. Its registers mirror the SUN2000 semantics, so this reuses the existing `curtail`/`curtailed` pattern with EMMA addresses.

- `curtail` writes the feed-in percentage to register 40109 (gain 10) and switches register 40100 between mode 7 (power-limited grid connection, %) and mode 0 (unlimited) at 100%
- `curtailed` reports curtailment unless mode is 0, or mode 7 at 100%
- adds the `curtail` capability to the template

Register addresses and encodings are taken from the SmartHEMS V100R024C00 MODBUS Interface Definitions (section 3.1, "Limited feed-in"), attached to the issue. They have not been verified against hardware.

**TODO**
- [ ] @linuxstony please confirm on your EMMA that curtailment engages and releases as expected, and that it does not conflict with EMMA's own control loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
