### PR TITLE
Actions: pin claude-code-action to last working version

### DIFF
--- a/.github/workflows/claude-code-review-run.yml
+++ b/.github/workflows/claude-code-review-run.yml
@@ -100,7 +100,9 @@ jobs:
       - name: Run Claude Code Review
         id: review
         continue-on-error: true # always report status below, even on failure
-        uses: anthropics/claude-code-action@v1
+        # pinned: v1 (Claude Code 2.1.216) fails every Bash call with
+        # "bwrap: Can't create file at /home/.mcp.json: Permission denied"
+        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1 @ 2.1.215
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Provided explicitly so the review can post on fork PRs; also required

--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -49,7 +49,9 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        # pinned: v1 (Claude Code 2.1.216) fails every Bash call with
+        # "bwrap: Can't create file at /home/.mcp.json: Permission denied"
+        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1 @ 2.1.215
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -45,7 +45,9 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude PR Labeler
-        uses: anthropics/claude-code-action@v1
+        # pinned: v1 (Claude Code 2.1.216) fails every Bash call with
+        # "bwrap: Can't create file at /home/.mcp.json: Permission denied"
+        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1 @ 2.1.215
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since 2026-07-21 06:34 UTC every Claude workflow run is a silent no-op: the agent starts, but each Bash call fails with

```
Exit code 1
bwrap: Can't create file at /home/.mcp.json: Permission denied
```

Since `gh` is only reachable via Bash, the agent can neither read the issue nor comment, label or open a PR — and the job still exits 0. Example: [run 29844927911](https://github.com/evcc-io/evcc/actions/runs/29844927911) left #32022 with no comment and no label.

Cause is the floating `v1` tag moving to anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35 (`chore: bump Claude Code to 2.1.216`). Runs on the previous commit `af0559e` (Claude Code 2.1.215) worked.

This pins the action to `af0559e`. Revert to `@v1` once the sandbox regression is fixed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)