### PR TITLE
Config: reference environment variables in configuration values

### DIFF
--- a/util/decoder.go
+++ b/util/decoder.go
@@ -1,13 +1,39 @@
 package util
 
 import (
+	"fmt"
+	"os"
 	"reflect"
+	"regexp"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/go-viper/mapstructure/v2"
 )
 
 var validate = validator.New()
+
+// envRef matches a configuration value that references an environment variable.
+// The `env:` prefix and full-value match avoid clashing with the ${var} plugin syntax.
+var envRef = regexp.MustCompile(`^\$\{env:(\w+)\}$`)
+
+// envHookFunc replaces ${env:NAME} values with the environment variable's content
+func envHookFunc(f reflect.Type, _ reflect.Type, data any) (any, error) {
+	if f.Kind() != reflect.String {
+		return data, nil
+	}
+
+	m := envRef.FindStringSubmatch(reflect.ValueOf(data).String())
+	if m == nil {
+		return data, nil
+	}
+
+	val, ok := os.LookupEnv(m[1])
+	if !ok {
+		return nil, fmt.Errorf("missing environment variable: %s", m[1])
+	}
+
+	return val, nil
+}
 
 // DecodeOther uses mapstructure to decode into target structure. Unused keys cause errors.
 func DecodeOther(other, cc any) error {
@@ -16,6 +42,7 @@ func DecodeOther(other, cc any) error {
 		ErrorUnused:      true,
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			envHookFunc,
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.TextUnmarshallerHookFunc(),
 		),

--- a/util/decoder_test.go
+++ b/util/decoder_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDecodeEnv(t *testing.T) {
+	t.Setenv("TEST_TOKEN", "secret")
+
+	var dst struct {
+		User, Password, Token string
+	}
+
+	require.NoError(t, DecodeOther(map[string]any{
+		"user":     "${env:TEST_TOKEN}suffix",
+		"password": "${maxcurrent}",
+		"token":    "${env:TEST_TOKEN}",
+	}, &dst))
+
+	assert.Equal(t, "${env:TEST_TOKEN}suffix", dst.User)
+	assert.Equal(t, "${maxcurrent}", dst.Password)
+	assert.Equal(t, "secret", dst.Token)
+
+	require.Error(t, DecodeOther(map[string]any{"token": "${env:TEST_MISSING}"}, &dst))
+}
+
 func TestDecodeNil(t *testing.T) {
 	var dst struct {
 		User, Password string


### PR DESCRIPTION
fixes #31880

Allows any configuration value to reference an environment variable instead of containing the secret inline. Entering `${env:SUPERVISOR_TOKEN}` into a form field resolves the value from the process environment when the device is created.

- resolution happens in `util.DecodeOther`, so it covers all device, plugin and global settings configuration, from both UI and yaml
- `${env:NAME}` is only substituted when it makes up the entire value, keeping it clear of the existing `${var}` plugin placeholder syntax
- an undefined variable is an error, surfaced like any other configuration error instead of silently configuring an empty credential
- values are resolved when the device is created, so a rotated variable requires a restart

**NOTE:** Global yaml settings parsed by viper are not covered, since yaml configuration is being retired anyway.