### PR TITLE
Mqtt: wait for retained message after subscribe before first read

### DIFF
--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -118,6 +118,14 @@ func (m *Mqtt) newReceiver() (*msgHandler, error) {
 	}
 
 	err := m.client.Listen(m.topic, h.receive)
+
+	// without timeout, wait for a pending retained message before first read
+	if err == nil && m.timeout == 0 {
+		if err := m.client.Barrier(m.ctx); err != nil {
+			m.log.WARN.Printf("sync %s: %v", m.topic, err)
+		}
+	}
+
 	return h, err
 }
 

--- a/plugin/mqtt.go
+++ b/plugin/mqtt.go
@@ -119,10 +119,12 @@ func (m *Mqtt) newReceiver() (*msgHandler, error) {
 
 	err := m.client.Listen(m.topic, h.receive)
 
-	// without timeout, wait for a pending retained message before first read
+	// without timeout, wait briefly for a retained message- it arrives right after suback
 	if err == nil && m.timeout == 0 {
-		if err := m.client.Barrier(m.ctx); err != nil {
-			m.log.WARN.Printf("sync %s: %v", m.topic, err)
+		select {
+		case <-h.val.Done():
+		case <-m.ctx.Done():
+		case <-time.After(100 * time.Millisecond):
 		}
 	}
 

--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -1,7 +1,6 @@
 package mqtt
 
 import (
-	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -50,11 +49,6 @@ type Client struct {
 	listener map[string][]func(string)
 	inflight *semaphore.Weighted
 
-	syncTopic string
-	syncOnce  sync.Once
-	syncMu    sync.Mutex
-	syncWait  map[string]chan struct{}
-
 	connMu     sync.Mutex
 	connCtx    context.Context
 	connCancel context.CancelFunc
@@ -75,12 +69,10 @@ func NewClient(log *util.Logger, broker, user, password, clientID string, qos by
 	}
 
 	mc := &Client{
-		log:       log,
-		Qos:       qos,
-		listener:  make(map[string][]func(string)),
-		inflight:  semaphore.NewWeighted(parallelInflightLimit),
-		syncTopic: cmp.Or(clientID, ClientID()) + "/sync",
-		syncWait:  make(map[string]chan struct{}),
+		log:      log,
+		Qos:      qos,
+		listener: make(map[string][]func(string)),
+		inflight: semaphore.NewWeighted(parallelInflightLimit),
 	}
 
 	options := paho.NewClientOptions()
@@ -264,45 +256,6 @@ func (m *Client) Publish(topic string, retained bool, payload string) {
 			m.log.ERROR.Printf("send: %s: timeout", topic)
 		}
 	}()
-}
-
-// Barrier waits until pending retained messages of prior subscriptions have been
-// delivered. It publishes a marker to a client-private sync topic and waits for
-// its echo, relying on the broker delivering a connection's messages in order.
-func (m *Client) Barrier(ctx context.Context) error {
-	var err error
-	m.syncOnce.Do(func() {
-		err = m.Listen(m.syncTopic, func(payload string) {
-			m.syncMu.Lock()
-			defer m.syncMu.Unlock()
-
-			if ch, ok := m.syncWait[payload]; ok {
-				close(ch)
-				delete(m.syncWait, payload)
-			}
-		})
-	})
-	if err != nil {
-		return err
-	}
-
-	nonce := fmt.Sprintf("%d", rand.Int64())
-	ch := make(chan struct{})
-
-	m.syncMu.Lock()
-	m.syncWait[nonce] = ch
-	m.syncMu.Unlock()
-
-	m.client.Publish(m.syncTopic, m.Qos, false, nonce)
-
-	select {
-	case <-ch:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(request.Timeout):
-		return fmt.Errorf("sync %s: %w", m.syncTopic, api.ErrTimeout)
-	}
 }
 
 // Listen attaches listener to slice of listeners for given topic

--- a/plugin/mqtt/client.go
+++ b/plugin/mqtt/client.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -49,6 +50,11 @@ type Client struct {
 	listener map[string][]func(string)
 	inflight *semaphore.Weighted
 
+	syncTopic string
+	syncOnce  sync.Once
+	syncMu    sync.Mutex
+	syncWait  map[string]chan struct{}
+
 	connMu     sync.Mutex
 	connCtx    context.Context
 	connCancel context.CancelFunc
@@ -69,10 +75,12 @@ func NewClient(log *util.Logger, broker, user, password, clientID string, qos by
 	}
 
 	mc := &Client{
-		log:      log,
-		Qos:      qos,
-		listener: make(map[string][]func(string)),
-		inflight: semaphore.NewWeighted(parallelInflightLimit),
+		log:       log,
+		Qos:       qos,
+		listener:  make(map[string][]func(string)),
+		inflight:  semaphore.NewWeighted(parallelInflightLimit),
+		syncTopic: cmp.Or(clientID, ClientID()) + "/sync",
+		syncWait:  make(map[string]chan struct{}),
 	}
 
 	options := paho.NewClientOptions()
@@ -256,6 +264,45 @@ func (m *Client) Publish(topic string, retained bool, payload string) {
 			m.log.ERROR.Printf("send: %s: timeout", topic)
 		}
 	}()
+}
+
+// Barrier waits until pending retained messages of prior subscriptions have been
+// delivered. It publishes a marker to a client-private sync topic and waits for
+// its echo, relying on the broker delivering a connection's messages in order.
+func (m *Client) Barrier(ctx context.Context) error {
+	var err error
+	m.syncOnce.Do(func() {
+		err = m.Listen(m.syncTopic, func(payload string) {
+			m.syncMu.Lock()
+			defer m.syncMu.Unlock()
+
+			if ch, ok := m.syncWait[payload]; ok {
+				close(ch)
+				delete(m.syncWait, payload)
+			}
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	nonce := fmt.Sprintf("%d", rand.Int64())
+	ch := make(chan struct{})
+
+	m.syncMu.Lock()
+	m.syncWait[nonce] = ch
+	m.syncMu.Unlock()
+
+	m.client.Publish(m.syncTopic, m.Qos, false, nonce)
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(request.Timeout):
+		return fmt.Errorf("sync %s: %w", m.syncTopic, api.ErrTimeout)
+	}
 }
 
 // Listen attaches listener to slice of listeners for given topic


### PR DESCRIPTION
Mqtt getters without `timeout` returned `outdated` on first read when a retained message had not yet arrived — retained delivery is asynchronous, queued by the broker right after suback.

Since `Listen` already waits for the suback, the receiver now simply waits up to 100ms for the first value before returning when no `timeout` is configured. A retained message resolves the wait immediately; topics without retained value fall through after the grace period with unchanged behavior.

Refs https://github.com/evcc-io/evcc/issues/32001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
