### PR TITLE
Huawei SUN2000: treat two battery units as single battery (BC)

### DIFF
--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -39,6 +39,7 @@ params:
     usages: ["pv"]
     deprecated: true # curtailment now applies the HEMS-distributed percent directly
   - name: storageunit
+    deprecated: true
   - name: forceaccharging
     default: false
     advanced: true

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -298,11 +298,7 @@ render: |
     timeout: {{ .timeout }}
     connectdelay: 1s
     register:
-      {{- if eq .storageunit "2" }}
-      address: 37743
-      {{- else }}
-      address: 37001
-      {{- end }}
+      address: 37765
       type: holding
       decode: int32nan
     scale: -1
@@ -311,11 +307,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      {{- if eq .storageunit "2" }}
-      address: 37755 # [Energy storage unit 2] Total discharge
-      {{- else }}
-      address: 37068 # [Energy storage unit 1] Total discharge
-      {{- end }}
+      address: 37782 # Total discharge
       type: holding
       decode: uint32nan
     scale: 0.01
@@ -324,11 +316,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      {{- if eq .storageunit "2" }}
-      address: 37753 # [Energy storage unit 2] Total charge
-      {{- else }}
-      address: 37066 # [Energy storage unit 1] Total charge
-      {{- end }}
+      address: 37780 # Total charge
       type: holding
       decode: uint32nan
     scale: 0.01
@@ -337,11 +325,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      {{- if eq .storageunit "2" }}
-      address: 37738
-      {{- else }}
-      address: 37004
-      {{- end }}
+      address: 37760
       type: holding
       decode: uint16nan
     scale: 0.1

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -299,7 +299,7 @@ render: |
     timeout: {{ .timeout }}
     connectdelay: 1s
     register:
-      address: 37765
+      address: 37765 # overall power
       type: holding
       decode: int32nan
     scale: -1
@@ -308,7 +308,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      address: 37782 # Total discharge
+      address: 37782 # overall energy discharged
       type: holding
       decode: uint32nan
     scale: 0.01
@@ -317,7 +317,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      address: 37780 # Total charge
+      address: 37780 # overall energy charged
       type: holding
       decode: uint32nan
     scale: 0.01
@@ -326,7 +326,7 @@ render: |
     {{- include "modbus" . | indent 2 }}
     timeout: {{ .timeout }}
     register:
-      address: 37760
+      address: 37760 # overall SoC
       type: holding
       decode: uint16nan
     scale: 0.1


### PR DESCRIPTION
fixes #32028

`dim` and battery modes can only be applied per inverter, not per battery unit. `capacity` (`37758`), `maxchargepower` (`37046`) and `maxdischargepower` (`37048`) also represent the sums of both units. So it probably makes sense to depict two units as single battery.

/cc @Jim-beam-3000