### PR TITLE
UI: use consistent vehicle wording in messaging events (#31938)

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -553,18 +553,18 @@
           "titleDefault": "Fahrzeug schläft"
         },
         "connect": {
-          "messageDefault": "Auto verbunden bei {pvPower}kW PV",
-          "title": "Wenn ein Auto verbunden wird",
-          "titleDefault": "Auto verbunden"
+          "messageDefault": "Fahrzeug verbunden bei {pvPower}kW PV",
+          "title": "Wenn ein Fahrzeug verbunden wird",
+          "titleDefault": "Fahrzeug verbunden"
         },
         "disconnect": {
-          "messageDefault": "Auto getrennt nach {connectedDuration}",
-          "title": "Wenn ein Auto getrennt wird",
-          "titleDefault": "Auto getrennt"
+          "messageDefault": "Fahrzeug getrennt nach {connectedDuration}",
+          "title": "Wenn ein Fahrzeug getrennt wird",
+          "titleDefault": "Fahrzeug getrennt"
         },
         "guest": {
           "messageDefault": "Unbekanntes Fahrzeug, Gast verbunden?",
-          "title": "Wenn ein unbekanntes Auto verbunden wird",
+          "title": "Wenn ein unbekanntes Fahrzeug verbunden wird",
           "titleDefault": "Unbekanntes Fahrzeug"
         },
         "planoverrun": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -552,18 +552,18 @@
           "titleDefault": "Vehicle asleep"
         },
         "connect": {
-          "messageDefault": "Car connected at {pvPower}kW PV",
-          "title": "When a car connects",
-          "titleDefault": "Car connected"
+          "messageDefault": "Vehicle connected at {pvPower}kW PV",
+          "title": "When a vehicle connects",
+          "titleDefault": "Vehicle connected"
         },
         "disconnect": {
-          "messageDefault": "Car disconnected after {connectedDuration}",
-          "title": "When a car disconnects",
-          "titleDefault": "Car disconnected"
+          "messageDefault": "Vehicle disconnected after {connectedDuration}",
+          "title": "When a vehicle disconnects",
+          "titleDefault": "Vehicle disconnected"
         },
         "guest": {
           "messageDefault": "Unknown vehicle, guest connected?",
-          "title": "When an unknown car connects",
+          "title": "When an unknown vehicle connects",
           "titleDefault": "Unknown vehicle"
         },
         "planoverrun": {


### PR DESCRIPTION
The connect, disconnect, and guest messaging events used "car" while asleep,  planoverrun, soc, and the rest of the app use "vehicle". This aligns all config.messaging.event.* strings to "vehicle" in en.json and "Fahrzeug" (instead of  "Auto") in de.json. Other locales are maintained via Weblate and will pick up the changed source strings.

Fixes #31938
  