### PR TITLE
Wattsonic: remove wrong grid currents (inverter registers), publish g…

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -866,20 +866,20 @@ func (site *Site) updateGridMeter() error {
 		return fmt.Errorf("grid power: %v", err)
 	}
 
-	// grid phase powers
-	var p1, p2, p3 float64
-	if phaseMeter, ok := api.Cap[api.PhasePowers](site.gridMeter); ok {
-		var err error // phases needed for signed currents
-		if p1, p2, p3, err = phaseMeter.Powers(); err == nil {
-			mm.Powers = []float64{p1, p2, p3}
-			site.log.DEBUG.Printf("grid powers: %.0fW", mm.Powers)
-		} else if !errors.Is(err, api.ErrNotAvailable) {
-			site.log.ERROR.Printf("grid powers: %v", err)
-		}
-	}
-
 	// grid phase currents (signed)
 	if phaseMeter, ok := api.Cap[api.PhaseCurrents](site.gridMeter); ok {
+		// grid phase powers
+		var p1, p2, p3 float64
+		if phaseMeter, ok := api.Cap[api.PhasePowers](site.gridMeter); ok {
+			var err error // phases needed for signed currents
+			if p1, p2, p3, err = phaseMeter.Powers(); err == nil {
+				mm.Powers = []float64{p1, p2, p3}
+				site.log.DEBUG.Printf("grid powers: %.0fW", mm.Powers)
+			} else if !errors.Is(err, api.ErrNotAvailable) {
+				site.log.ERROR.Printf("grid powers: %v", err)
+			}
+		}
+
 		if i1, i2, i3, err := phaseMeter.Currents(); err == nil {
 			mm.Currents = []float64{util.SignFromPower(i1, p1), util.SignFromPower(i2, p2), util.SignFromPower(i3, p3)}
 			site.log.DEBUG.Printf("grid currents: %.3gA", mm.Currents)

--- a/core/site.go
+++ b/core/site.go
@@ -866,20 +866,20 @@ func (site *Site) updateGridMeter() error {
 		return fmt.Errorf("grid power: %v", err)
 	}
 
+	// grid phase powers
+	var p1, p2, p3 float64
+	if phaseMeter, ok := api.Cap[api.PhasePowers](site.gridMeter); ok {
+		var err error // phases needed for signed currents
+		if p1, p2, p3, err = phaseMeter.Powers(); err == nil {
+			mm.Powers = []float64{p1, p2, p3}
+			site.log.DEBUG.Printf("grid powers: %.0fW", mm.Powers)
+		} else if !errors.Is(err, api.ErrNotAvailable) {
+			site.log.ERROR.Printf("grid powers: %v", err)
+		}
+	}
+
 	// grid phase currents (signed)
 	if phaseMeter, ok := api.Cap[api.PhaseCurrents](site.gridMeter); ok {
-		// grid phase powers
-		var p1, p2, p3 float64
-		if phaseMeter, ok := api.Cap[api.PhasePowers](site.gridMeter); ok {
-			var err error // phases needed for signed currents
-			if p1, p2, p3, err = phaseMeter.Powers(); err == nil {
-				mm.Powers = []float64{p1, p2, p3}
-				site.log.DEBUG.Printf("grid powers: %.0fW", mm.Powers)
-			} else if !errors.Is(err, api.ErrNotAvailable) {
-				site.log.ERROR.Printf("grid powers: %v", err)
-			}
-		}
-
 		if i1, i2, i3, err := phaseMeter.Currents(); err == nil {
 			mm.Currents = []float64{util.SignFromPower(i1, p1), util.SignFromPower(i2, p2), util.SignFromPower(i3, p3)}
 			site.log.DEBUG.Printf("grid currents: %.3gA", mm.Currents)

--- a/templates/definition/meter/wattsonic-gen3.yaml
+++ b/templates/definition/meter/wattsonic-gen3.yaml
@@ -23,28 +23,6 @@ render: |
       type: holding   
       decode: int32
     scale: -1
-  currents:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 11010  # Grid Phase A Current
-        type: holding
-        decode: uint16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 11012  # Grid Phase B Current
-        type: holding
-        decode: uint16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 11014  # Grid Phase C Current
-        type: holding
-        decode: uint16
-      scale: 0.1
   powers:
     - source: modbus
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/wattsonic.yaml
+++ b/templates/definition/meter/wattsonic.yaml
@@ -29,31 +29,6 @@ render: |
       type: holding   
       decode: int32
     scale: -1
-  currents:
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      delay: {{ .delay }}
-      register:
-        address: 11010  # Grid Phase A Current
-        type: holding
-        decode: uint16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      delay: {{ .delay }}
-      register:
-        address: 11012  # Grid Phase B Current
-        type: holding
-        decode: uint16
-      scale: 0.1
-    - source: modbus
-      {{- include "modbus" . | indent 4 }}
-      delay: {{ .delay }}
-      register:
-        address: 11014  # Grid Phase C Current
-        type: holding
-        decode: uint16
-      scale: 0.1
   powers:
     - source: modbus
       {{- include "modbus" . | indent 4 }}


### PR DESCRIPTION
The grid usage of the wattsonic and wattsonic-gen3 templates reported registers 11010/11012/11014 as grid currents. Per the vendor register map these are the inverter's on-grid output currents, not grid smart-meter values — causing phantom currents (~4 A) at zero grid power. Wattsonic exposes no grid-meter current registers, so the currents: block is removed; the correct "on Meter" phase powers (10994/10996/10998) are kept.

Also, Site.updateGridMeter now publishes phase powers independently of the
PhaseCurrents capability, so powers-only grid meters still show per-phase data in
the UI.

Fixes #24868