### PR TITLE
UI: fix loadpoint value alignment on narrow screens (#31993)

### DIFF
--- a/assets/js/components/Loadpoints/SessionInfo.vue
+++ b/assets/js/components/Loadpoints/SessionInfo.vue
@@ -4,6 +4,7 @@
 			<template #label>
 				<CustomSelect
 					inline
+					class="labelSelect"
 					:selected="selectedKey"
 					:options="selectOptions"
 					data-testid="sessionInfoSelect"
@@ -200,6 +201,14 @@ export default defineComponent({
 .sessionInfo * {
 	user-select: none;
 	-webkit-user-select: none;
+}
+/* Truncation (overflow: hidden via .text-truncate-xs-only) moves the baseline of the
+   inline select to its bottom edge, growing the label's line box and pushing the value
+   below the other loadpoint values on narrow screens (#31993). Top-align the select to
+   keep the label at its normal line height. !important is needed to win over the
+   Bootstrap .align-baseline utility set by CustomSelect. */
+.sessionInfo :deep(.labelSelect) {
+	vertical-align: top !important;
 }
 .sessionInfo .value {
 	cursor: pointer;


### PR DESCRIPTION
Fixes #31993. On viewports below the sm breakpoint, .text-truncate-xs-only applies overflow: hidden to the label inside the session-info select on the loadpoint card.

Because a scroll container has no text baseline, the baseline of the surrounding inline-block select falls back to its bottom edge, which grows the label's line box and pushes the session value a few pixels below the other loadpoint values (power, charged energy). This happens at the same breakpoint where the loadpoint header wraps onto two lines, which is why the two effects appear linked. Top-aligning the select inside the label keeps the line box at its normal height, so all values stay on one line; rendering at larger viewports is unchanged.