### PR TITLE
Optimizer: publish result before status check

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -551,16 +551,18 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 		return apiError(resp)
 	}
 
-	if resp.JSON200.Status != optimizer.Optimal {
-		return errors.New(string(resp.JSON200.Status))
-	}
-
+	// publish before the status check so the optimizer page stays available
+	// for diagnosing non-optimal results
 	site.publish("evopt", optimizerResult{
 		Updated: time.Now(),
 		Req:     req,
 		Res:     *resp.JSON200,
 		Details: details,
 	})
+
+	if resp.JSON200.Status != optimizer.Optimal {
+		return errors.New(string(resp.JSON200.Status))
+	}
 
 	slotHours := firstSlotDuration.Hours()
 	gridImporting := len(resp.JSON200.GridImport) > 0 && resp.JSON200.GridImport[0] > 0


### PR DESCRIPTION
re #32046

The optimizer result was only published once the solver returned `Optimal`. On `Infeasible` or `NotSolved` the run aborted before publishing, so `evopt` stayed empty and the Optimize page never appeared. Exactly the runs that need debugging left no way to inspect the request that caused them, and users asked to provide it had no way to obtain it.

- publish the optimizer result before the status check, so the Optimize page and its status indicator stay available for non-optimal results
- the request is now inspectable in the UI, which is the data needed to diagnose an infeasible constraint set
- suggestions, battery forecast and slot evaluation remain behind the status check, they depend on a battery result the solver does not return for non-optimal runs
