### PR TITLE
Site: add experimental battery grid discharge setting

### DIFF
--- a/assets/js/components/Config/BatteryModal.vue
+++ b/assets/js/components/Config/BatteryModal.vue
@@ -45,12 +45,14 @@ export default defineComponent({
 	},
 	methods: {
 		async change(e: Event) {
+			const target = e.target as HTMLInputElement;
 			try {
 				this.error = null;
-				await api.post(`batterygriddischarge/${(e.target as HTMLInputElement).checked}`);
+				await api.post(`batterygriddischarge/${target.checked}`);
 			} catch (err) {
-				const e = err as AxiosError<{ error: string }>;
-				this.error = e.response?.data?.error || e.message;
+				target.checked = this.gridDischarge; // revert on failure to stay in sync with state
+				const axiosErr = err as AxiosError<{ error: string }>;
+				this.error = axiosErr.response?.data?.error || axiosErr.message;
 			}
 		},
 	},

--- a/assets/js/components/Config/BatteryModal.vue
+++ b/assets/js/components/Config/BatteryModal.vue
@@ -1,0 +1,58 @@
+<template>
+	<GenericModal
+		id="batteryModal"
+		:title="`${$t('config.battery.title')} 🧪`"
+		config-modal-name="battery"
+		data-testid="battery-modal"
+	>
+		<p>{{ $t("config.battery.description") }}</p>
+		<ErrorMessage :error="error" />
+		<div class="form-check form-switch my-3">
+			<input
+				id="batteryGridDischarge"
+				:checked="gridDischarge"
+				class="form-check-input"
+				type="checkbox"
+				role="switch"
+				@change="change"
+			/>
+			<div class="form-check-label">
+				<label for="batteryGridDischarge">
+					{{ $t("config.battery.gridDischarge") }}
+				</label>
+			</div>
+		</div>
+	</GenericModal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import GenericModal from "../Helper/GenericModal.vue";
+import ErrorMessage from "../Helper/ErrorMessage.vue";
+import api from "@/api";
+import type { AxiosError } from "axios";
+
+export default defineComponent({
+	name: "BatteryModal",
+	components: { GenericModal, ErrorMessage },
+	props: {
+		gridDischarge: Boolean,
+	},
+	data() {
+		return {
+			error: null as string | null,
+		};
+	},
+	methods: {
+		async change(e: Event) {
+			try {
+				this.error = null;
+				await api.post(`batterygriddischarge/${(e.target as HTMLInputElement).checked}`);
+			} catch (err) {
+				const e = err as AxiosError<{ error: string }>;
+				this.error = e.response?.data?.error || e.message;
+			}
+		},
+	},
+});
+</script>

--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -30,7 +30,7 @@
 		/>
 
 		<GeneralConfigEntry
-			v-if="batteryControllable"
+			v-if="experimental && batteryControllable"
 			test-id="generalconfig-battery"
 			:label="$t('config.battery.title')"
 			:text="$t(`config.general.${batteryGridDischarge ? 'on' : 'off'}`)"

--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -30,6 +30,14 @@
 		/>
 
 		<GeneralConfigEntry
+			v-if="batteryControllable"
+			test-id="generalconfig-battery"
+			:label="$t('config.battery.title')"
+			:text="$t(`config.general.${batteryGridDischarge ? 'on' : 'off'}`)"
+			@edit="openModal('battery')"
+		/>
+
+		<GeneralConfigEntry
 			test-id="generalconfig-sponsoring"
 			:label="$t('config.sponsor.title')"
 			:text="sponsorStatus.title"
@@ -94,6 +102,12 @@ export default {
 		},
 		telemetryEnabled() {
 			return store.state?.telemetry === true;
+		},
+		batteryControllable() {
+			return (store.state?.battery ?? []).some((b) => b.controllable);
+		},
+		batteryGridDischarge() {
+			return store.state?.batteryGridDischarge === true;
 		},
 		networkStatus() {
 			return `${store.state?.network?.port ?? ""}`;

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -262,6 +262,8 @@ export interface State {
   bufferStartSoc?: number;
   /** Home battery discharge is prevented during fast charging and planned charging. */
   batteryDischargeControl?: boolean;
+  /** Home battery is allowed to discharge to the grid (experimental). */
+  batteryGridDischarge?: boolean;
   solarAdjusted?: boolean;
   /** Price or emission limit for charging the home battery from grid. */
   batteryGridChargeLimit?: number | null;

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -481,6 +481,7 @@
 				<OptimizerModal :is-sponsor="isSponsor" />
 				<McpModal />
 				<ExperimentalModal :experimental="experimental" />
+				<BatteryModal :grid-discharge="batteryGridDischarge" />
 				<RemoteModal :remote="remote" :is-sponsor="isSponsor" :site-title="siteTitle" />
 				<TitleModal @changed="loadDirty" />
 				<ModbusProxyModal :is-sponsor="isSponsor" @changed="loadDirty" />
@@ -559,6 +560,7 @@ import TariffCard from "../components/Config/TariffCard.vue";
 import TariffModal from "../components/Config/TariffModal.vue";
 import TelemetryModal from "../components/Config/TelemetryModal.vue";
 import ExperimentalModal from "../components/Config/ExperimentalModal.vue";
+import BatteryModal from "../components/Config/BatteryModal.vue";
 import TitleModal from "../components/Config/TitleModal.vue";
 import Header from "../components/Top/Header.vue";
 import VehicleIcon from "../components/VehicleIcon";
@@ -648,6 +650,7 @@ export default defineComponent({
 		TariffModal,
 		TelemetryModal,
 		ExperimentalModal,
+		BatteryModal,
 		TitleModal,
 		TopHeader: Header,
 		VehicleIcon,
@@ -921,6 +924,9 @@ export default defineComponent({
 		},
 		experimental() {
 			return store.state?.experimental;
+		},
+		batteryGridDischarge() {
+			return store.state?.batteryGridDischarge === true;
 		},
 		eebus() {
 			return store.state?.eebus;

--- a/core/keys/site.go
+++ b/core/keys/site.go
@@ -45,6 +45,7 @@ const (
 	BatteryDischargeControl = "batteryDischargeControl"
 	BatteryGridChargeLimit  = "batteryGridChargeLimit"
 	BatteryGridChargeActive = "batteryGridChargeActive"
+	BatteryGridDischarge    = "batteryGridDischarge"
 	BufferSoc               = "bufferSoc"
 	BufferStartSoc          = "bufferStartSoc"
 

--- a/core/site.go
+++ b/core/site.go
@@ -86,6 +86,7 @@ type Site struct {
 	bufferStartSoc          float64  // start charging on battery above this Soc
 	batteryDischargeControl bool     // prevent battery discharge for fast and planned charging
 	batteryGridChargeLimit  *float64 // grid charging limit
+	batteryGridDischarge    bool     // allow battery discharge to grid (experimental)
 
 	// forecast settings
 	solarAdjusted bool // adjust solar forecast to real production data
@@ -380,6 +381,11 @@ func (site *Site) restoreSettings() error {
 	}
 	if v, err := settings.Bool(keys.BatteryDischargeControl); err == nil {
 		if err := site.SetBatteryDischargeControl(v); err != nil && !errors.Is(err, ErrBatteryControlNotAvailable) {
+			return err
+		}
+	}
+	if v, err := settings.Bool(keys.BatteryGridDischarge); err == nil {
+		if err := site.SetBatteryGridDischarge(v); err != nil && !errors.Is(err, ErrBatteryControlNotAvailable) {
 			return err
 		}
 	}
@@ -1210,6 +1216,7 @@ func (site *Site) prepare() {
 	site.publish(keys.BufferStartSoc, site.bufferStartSoc)
 	site.publish(keys.BatteryMode, site.batteryMode)
 	site.publish(keys.BatteryDischargeControl, site.batteryDischargeControl)
+	site.publish(keys.BatteryGridDischarge, site.batteryGridDischarge)
 	site.publish(keys.SolarAdjusted, site.solarAdjusted)
 	site.publish(keys.ResidualPower, site.GetResidualPower())
 	site.publish(keys.SmartCostAvailable, site.isDynamicTariff(api.TariffUsagePlanner))

--- a/core/site/api.go
+++ b/core/site/api.go
@@ -91,6 +91,8 @@ type API interface {
 
 	GetBatteryDischargeControl() bool
 	SetBatteryDischargeControl(bool) error
+	GetBatteryGridDischarge() bool
+	SetBatteryGridDischarge(bool) error
 
 	//
 	// battery control external

--- a/core/site_api.go
+++ b/core/site_api.go
@@ -370,6 +370,33 @@ func (site *Site) SetBatteryDischargeControl(val bool) error {
 	return nil
 }
 
+// GetBatteryGridDischarge returns whether the battery may discharge to grid (experimental)
+func (site *Site) GetBatteryGridDischarge() bool {
+	site.RLock()
+	defer site.RUnlock()
+	return site.batteryGridDischarge
+}
+
+// SetBatteryGridDischarge sets whether the battery may discharge to grid (experimental)
+func (site *Site) SetBatteryGridDischarge(val bool) error {
+	site.log.DEBUG.Println("set battery grid discharge:", val)
+
+	if !site.hasBatteryControl() {
+		return ErrBatteryControlNotAvailable
+	}
+
+	site.Lock()
+	defer site.Unlock()
+
+	if site.batteryGridDischarge != val {
+		site.batteryGridDischarge = val
+		settings.SetBool(keys.BatteryGridDischarge, val)
+		site.publish(keys.BatteryGridDischarge, val)
+	}
+
+	return nil
+}
+
 // GetSolarAdjusted returns if the solar forecast is adjusted to real production data
 func (site *Site) GetSolarAdjusted() bool {
 	site.RLock()

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -796,6 +796,7 @@ func (site *Site) batteryRequest(dev config.Device[api.Meter], b types.Measureme
 	controllable := api.HasCap[api.BatteryController](instance)
 	if controllable {
 		bat.ChargeFromGrid = true
+		bat.DischargeToGrid = site.GetBatteryGridDischarge()
 	}
 
 	if m, ok := api.Cap[api.BatteryPowerLimiter](instance); ok {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -118,6 +118,9 @@
       "titleEdit": "Edit Self-Regulating Consumer"
     },
     "battery": {
+      "description": "Experimental battery controls. These features are still being tested and may change or be removed in future versions.",
+      "gridDischarge": "Allow battery to discharge to the grid",
+      "title": "Battery",
       "titleAdd": "Add Battery",
       "titleEdit": "Edit Battery"
     },

--- a/server/http.go
+++ b/server/http.go
@@ -144,6 +144,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 		"buffersoc":               {"POST", "/buffersoc/{value:[0-9.]+}", floatHandler(site.SetBufferSoc, site.GetBufferSoc)},
 		"bufferstartsoc":          {"POST", "/bufferstartsoc/{value:[0-9.]+}", floatHandler(site.SetBufferStartSoc, site.GetBufferStartSoc)},
 		"batterydischargecontrol": {"POST", "/batterydischargecontrol/{value:[01truefalse]+}", boolHandler(site.SetBatteryDischargeControl, site.GetBatteryDischargeControl)},
+		"batterygriddischarge":    {"POST", "/batterygriddischarge/{value:[01truefalse]+}", boolHandler(site.SetBatteryGridDischarge, site.GetBatteryGridDischarge)},
 		"batterygridcharge":       {"POST", "/batterygridchargelimit/{value:-?[0-9.]+}", floatPtrHandler(site.SetBatteryGridChargeLimit, site.GetBatteryGridChargeLimit)},
 		"batterygridchargedelete": {"DELETE", "/batterygridchargelimit", floatPtrHandler(site.SetBatteryGridChargeLimit, site.GetBatteryGridChargeLimit)},
 		"batterymode":             {"POST", "/batterymode/{value:[a-z]+}", updateBatteryMode(site)},

--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -283,6 +283,29 @@
         }
       }
     },
+    "/batterygriddischarge/{enable}": {
+      "post": {
+        "operationId": "setBatteryGridDischarge",
+        "summary": "Control battery grid discharge",
+        "description": "Allow the home battery to discharge to the grid (experimental).",
+        "externalDocs": {
+          "url": "https://docs.evcc.io/en/features/battery"
+        },
+        "tags": [
+          "battery"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/enable"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/BooleanResult"
+          }
+        }
+      }
+    },
     "/batterygridchargelimit": {
       "delete": {
         "operationId": "removeBatteryGridChargeLimit",
@@ -4956,6 +4979,10 @@
           },
           "batteryDischargeControl": {
             "description": "Home battery discharge is prevented during fast charging and planned charging.",
+            "type": "boolean"
+          },
+          "batteryGridDischarge": {
+            "description": "Home battery is allowed to discharge to the grid (experimental).",
             "type": "boolean"
           },
           "solarAdjusted": {

--- a/server/mcp/openapi.md
+++ b/server/mcp/openapi.md
@@ -146,6 +146,26 @@ call setBatteryGridChargeLimit {
 }
 ```
 
+## setBatteryGridDischarge
+
+Allow the home battery to discharge to the grid (experimental).
+
+**Tags:** battery
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| enable | string | Charging mode. |
+
+**Example call:**
+
+```json
+call setBatteryGridDischarge {
+  "enable": "true"
+}
+```
+
 ## setBufferSoc
 
 Set battery buffer SoC.

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -215,6 +215,7 @@ func (m *MQTT) listenSiteSetters(topic string, site site.API) error {
 		{"bufferSoc", floatSetter(site.SetBufferSoc)},
 		{"bufferStartSoc", floatSetter(site.SetBufferStartSoc)},
 		{"batteryDischargeControl", boolSetter(site.SetBatteryDischargeControl)},
+		{"batteryGridDischarge", boolSetter(site.SetBatteryGridDischarge)},
 		{"prioritySoc", floatSetter(site.SetPrioritySoc)},
 		{"residualPower", floatSetter(site.SetResidualPower)},
 		{"solarAdjusted", boolSetter(pass(site.SetSolarAdjusted))},

--- a/server/openapi.state.yaml
+++ b/server/openapi.state.yaml
@@ -193,6 +193,9 @@ components:
         batteryDischargeControl:
           description: Home battery discharge is prevented during fast charging and planned charging.
           type: boolean
+        batteryGridDischarge:
+          description: Home battery is allowed to discharge to the grid (experimental).
+          type: boolean
         solarAdjusted:
           type: boolean
         batteryGridChargeLimit:

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -181,6 +181,20 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/BooleanResult"
+  /batterygriddischarge/{enable}:
+    post:
+      operationId: setBatteryGridDischarge
+      summary: Control battery grid discharge
+      description: "Allow the home battery to discharge to the grid (experimental)."
+      externalDocs:
+        url: https://docs.evcc.io/en/features/battery
+      tags:
+        - battery
+      parameters:
+        - $ref: "#/components/parameters/enable"
+      responses:
+        "200":
+          $ref: "#/components/responses/BooleanResult"
   /batterygridchargelimit:
     delete:
       operationId: removeBatteryGridChargeLimit


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/31971

Adds a global, experimental `batteryGridDischarge` site setting exposed in Configuration → General, wired into the optimizer.

## UI
- New **Battery** entry in Configuration → General, opening a small modal with an "Allow battery to discharge to the grid" toggle.
- The entry is shown only when experimental features are enabled and at least one configured battery is controllable (`battery[].controllable`).
- The toggle reverts to the current state if the API call fails.

## Backend
- New `batteryGridDischarge` site setting, mirroring `batteryDischargeControl` end-to-end: field, boot restore, `Get`/`Set` (guarded by `hasBatteryControl`), persistence, publish, REST (`POST /batterygriddischarge/{enable}`) and MQTT setter.

## Optimizer
- Wired into the evopt request: `BatteryConfig.DischargeToGrid` is set from the site setting for controllable batteries, permitting the optimizer to plan battery-to-grid export.

## Generated
- `openapi.yaml` path + `evcc.ts` state type; `openapi.state.yaml`, `mcp/openapi.json`, `mcp/openapi.md` regenerated via `npm run openapi` + `go generate`.

Verified: `go build`/`vet`/`test` (core, server), `prettier`, `eslint`, `vue-tsc`, i18n check, `vitest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)