### PR TITLE
docs(openapi): remove result envelope reintroduced in #31530

### DIFF
--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -5287,12 +5287,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "integer"
-                }
-              }
+              "type": "integer"
             }
           }
         }
@@ -5302,12 +5297,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "number"
-                }
-              }
+              "type": "number"
             }
           }
         }
@@ -5317,12 +5307,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "integer"
-                }
-              }
+              "type": "integer"
             }
           }
         }
@@ -5334,13 +5319,8 @@
             "schema": {
               "type": "object",
               "properties": {
-                "result": {
-                  "type": "object",
-                  "properties": {
-                    "soc": {
-                      "$ref": "#/components/schemas/Soc"
-                    }
-                  }
+                "soc": {
+                  "$ref": "#/components/schemas/Soc"
                 }
               }
             }
@@ -5352,12 +5332,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "$ref": "#/components/schemas/PlanRates"
-                }
-              }
+              "$ref": "#/components/schemas/PlanRates"
             }
           }
         }
@@ -5367,12 +5342,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "boolean"
-                }
-              }
+              "type": "boolean"
             }
           }
         }
@@ -5382,14 +5352,9 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "description": "Value is always null",
-                  "nullable": true,
-                  "type": "object"
-                }
-              }
+              "description": "Value is always null",
+              "nullable": true,
+              "type": "object"
             }
           }
         }
@@ -5402,13 +5367,8 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "string",
-                  "example": "OK"
-                }
-              }
+              "type": "string",
+              "example": "OK"
             }
           }
         }
@@ -5441,15 +5401,10 @@
         "content": {
           "application/json": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "integer",
-                  "description": "Battery mode. 0: unknown, 1: normal, 2: hold, 3: charge, 4: holdcharge",
-                  "minimum": 0,
-                  "maximum": 4
-                }
-              }
+              "type": "integer",
+              "description": "Battery mode. 0: unknown, 1: normal, 2: hold, 3: charge, 4: holdcharge",
+              "minimum": 0,
+              "maximum": 4
             }
           }
         }

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1809,28 +1809,19 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: integer
+            type: integer
     NumberResult:
       description: Success - Number result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: number
+            type: number
     IntegerResult:
       description: Success - Integer result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: integer
+            type: integer
     SocResult:
       description: Success - Soc result
       content:
@@ -1838,40 +1829,28 @@ components:
           schema:
             type: object
             properties:
-              result:
-                type: object
-                properties:
-                  soc:
-                    $ref: "#/components/schemas/Soc"
+              soc:
+                $ref: "#/components/schemas/Soc"
     PlanRatesResult:
       description: Success - PlanRates result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                $ref: "#/components/schemas/PlanRates"
+            $ref: "#/components/schemas/PlanRates"
     BooleanResult:
       description: Success - Boolean result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: boolean
+            type: boolean
     NullResult:
       description: Success - Null result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                description: Value is always null
-                nullable: true
-                type: "object"
+            description: Value is always null
+            nullable: true
+            type: "object"
     BlankResponse:
       description: Success - Blank response
     SuccessResult:
@@ -1879,11 +1858,8 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: string
-                example: "OK"
+            type: string
+            example: "OK"
     EmptyResult:
       description: Success - Empty result
       content:
@@ -1903,13 +1879,10 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: integer
-                description: "Battery mode. 0: unknown, 1: normal, 2: hold, 3: charge, 4: holdcharge"
-                minimum: 0
-                maximum: 4
+            type: integer
+            description: "Battery mode. 0: unknown, 1: normal, 2: hold, 3: charge, 4: holdcharge"
+            minimum: 0
+            maximum: 4
   securitySchemes:
     cookieAuth:
       type: apiKey


### PR DESCRIPTION
As reported in https://github.com/evcc-io/evcc/pull/31530#issuecomment-5058386971 by @StefanSchoof.

#31530 regenerated `openapi.yaml` from a base that predated #31989 and re-added the `result: {...}` response envelope. That envelope was removed from all HTTP handlers in #22299, and #31989 had already fixed the spec to match (fixes #31988, `getLoadpointPlan` example).

This re-applies the unwrap on the reusable `*Result` response schemas (`NanoSecondsResult`, `NumberResult`, `IntegerResult`, `SocResult`, `PlanRatesResult`, `BooleanResult`, `NullResult`, `SuccessResult`, `BatteryModeResult`) so the generated REST docs again show the real response shape, and regenerates `mcp/openapi.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)