### PR TITLE
WARP-WS: don't report zero phase currents on power-only meters

### DIFF
--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -49,8 +49,9 @@ type WarpWS struct {
 	maxCurrent int64 // input from evcc
 
 	// meter
-	meter    warp.MeterValues
-	meterMap map[int]int
+	meter                    warp.MeterValues
+	meterMap                 map[int]int
+	hasCurrents, hasVoltages bool // meter actually reports per-phase currents/voltages
 
 	// nfc
 	chargeTracker warp.ChargeTrackerCurrentCharge
@@ -311,6 +312,7 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 		if len(w.meter.TmpValues) > 5 {
 			copy(w.meter.Voltages[:], w.meter.TmpValues[:3])
 			copy(w.meter.Currents[:], w.meter.TmpValues[3:6])
+			w.hasVoltages, w.hasCurrents = true, true
 		}
 	case "meter/values":
 		if !w.hasFeature(warp.FeatureMeter) || w.hasFeature(warp.FeatureMeters) {
@@ -348,9 +350,11 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 		for p, ids := range s.Phases {
 			if v, ok := get(ids.CurrentID); ok {
 				w.meter.Currents[p] = v
+				w.hasCurrents = true
 			}
 			if v, ok := get(ids.VoltageID); ok {
 				w.meter.Voltages[p] = v
+				w.hasVoltages = true
 			}
 		}
 	case "power_manager/state":
@@ -435,12 +439,18 @@ func (w *WarpWS) totalEnergy() (float64, error) {
 func (w *WarpWS) currents() (float64, float64, float64, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
+	if !w.hasCurrents {
+		return 0, 0, 0, api.ErrNotAvailable
+	}
 	return w.meter.Currents[0], w.meter.Currents[1], w.meter.Currents[2], nil
 }
 
 func (w *WarpWS) voltages() (float64, float64, float64, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
+	if !w.hasVoltages {
+		return 0, 0, 0, api.ErrNotAvailable
+	}
 	return w.meter.Voltages[0], w.meter.Voltages[1], w.meter.Voltages[2], nil
 }
 

--- a/charger/warp-ws.go
+++ b/charger/warp-ws.go
@@ -308,10 +308,10 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 		if !w.hasFeature(warp.FeatureMeterAllValues) || w.hasFeature(warp.FeatureMeters) {
 			return nil
 		}
-		err = json.Unmarshal(payload, &w.meter.TmpValues)
-		if len(w.meter.TmpValues) > 5 {
-			copy(w.meter.Voltages[:], w.meter.TmpValues[:3])
-			copy(w.meter.Currents[:], w.meter.TmpValues[3:6])
+		var values []float64
+		if err = json.Unmarshal(payload, &values); err == nil && len(values) > 5 {
+			copy(w.meter.Voltages[:], values[:3])
+			copy(w.meter.Currents[:], values[3:6])
 			w.hasVoltages, w.hasCurrents = true, true
 		}
 	case "meter/values":
@@ -329,13 +329,14 @@ func (w *WarpWS) handleEvent(topic string, payload json.RawMessage) error {
 			w.meterMap[id] = i
 		}
 	case metersValuesTopic:
-		if err := json.Unmarshal(payload, &w.meter.TmpValues); err != nil {
+		var values []float64
+		if err := json.Unmarshal(payload, &values); err != nil {
 			return err
 		}
 
 		get := func(id int) (float64, bool) {
-			if idx, ok := w.meterMap[id]; ok && idx < len(w.meter.TmpValues) {
-				return w.meter.TmpValues[idx], true
+			if idx, ok := w.meterMap[id]; ok && idx < len(values) {
+				return values[idx], true
 			}
 			return 0, false
 		}

--- a/charger/warp/types.go
+++ b/charger/warp/types.go
@@ -36,7 +36,6 @@ type MeterValues struct {
 	EnergyAbs float64 `json:"energy_abs"`
 	Currents  [3]float64
 	Voltages  [3]float64
-	TmpValues []float64
 }
 
 type Name struct {


### PR DESCRIPTION
fixes #32089

WARP wallboxes with a power-only built-in meter (e.g. WARP1 Pro) advertise the `PhaseCurrents`/`PhaseVoltages` capability but never populate per-phase values, so `currents()` returned `[0, 0, 0]A`. The loadpoint treated those zeros as a real measurement: `effectiveCurrent()` collapsed to ~2A (the Zoe `max(currents)+2` branch), the PV surplus loop under-commanded, the charger dropped to minimum current, and several kW were exported while the car was charging.

This tracks whether the meter actually delivered per-phase currents/voltages and returns `api.ErrNotAvailable` until it does. The loadpoint then leaves `chargeCurrents` nil and falls back to `offeredCurrent` as the PV baseline, matching the pre-migration MQTT behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
