### PR TITLE
tariff: sort rates before partitioning in combined tariff

### DIFF
--- a/tariff/combined.go
+++ b/tariff/combined.go
@@ -29,6 +29,8 @@ func (t *combined) Rates() (api.Rates, error) {
 		rates = append(rates, rr...)
 	}
 
+	rates.Sort()
+
 	var res api.Rates
 
 	partitions := lo.PartitionBy(rates, func(r api.Rate) time.Time {

--- a/tariff/combined_test.go
+++ b/tariff/combined_test.go
@@ -41,6 +41,38 @@ func TestCombined(t *testing.T) {
 	assert.Equal(t, api.Rates{rate(1, 1), rate(2, 4), rate(3, 3)}, rr)
 }
 
+// TestCombinedNonAdjacent verifies that rates are correctly summed
+// even when tariffs cover different but overlapping time ranges,
+// causing identical timestamps to be non-adjacent after concatenation.
+func TestCombinedNonAdjacent(t *testing.T) {
+	clock := clock.NewMock()
+	rate := func(start int, val float64) api.Rate {
+		return api.Rate{
+			Start: clock.Now().Add(time.Duration(start) * time.Hour),
+			End:   clock.Now().Add(time.Duration(start+1) * time.Hour),
+			Value: val,
+		}
+	}
+
+	// tariff a covers hours 1-3, tariff b covers hours 2-4
+	// after append: [h1a, h2a, h3a, h2b, h3b, h4b]
+	// without sort: PartitionBy sees h2a and h2b as separate groups
+	a := &tariff{api.Rates{rate(1, 100), rate(2, 200), rate(3, 300)}}
+	b := &tariff{api.Rates{rate(2, 20), rate(3, 30), rate(4, 40)}}
+	c := &combined{[]api.Tariff{a, b}}
+
+	rr, err := c.Rates()
+	require.NoError(t, err)
+
+	expected := api.Rates{
+		rate(1, 100),
+		rate(2, 220),
+		rate(3, 330),
+		rate(4, 40),
+	}
+	assert.Equal(t, expected, rr)
+}
+
 func BenchmarkCombined(bench *testing.B) {
 	clock := clock.NewMock()
 	rate := func(start int, val float64) api.Rate {


### PR DESCRIPTION
Fixes #32092.

lo.PartitionBy groups consecutive elements with the same key. When multiple tariffs cover different but overlapping time ranges, rates with identical start timestamps end up non-adjacent after concatenation and are not summed.

This affects setups with multiple solar tariff sources (e.g. two Solcast forecasts plus Forecast.Solar) where each source covers a different time range.