### PR TITLE
Optimizer: split grid peak shaping into demand, feed-in and combined strategies

### DIFF
--- a/assets/js/components/Optimize/OptimizeHeader.stories.ts
+++ b/assets/js/components/Optimize/OptimizeHeader.stories.ts
@@ -14,7 +14,13 @@ const base = {
   updated: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
   horizonHours: 47,
   currency: CURRENCY.EUR,
-  chargingStrategies: ["charge_before_export", "attenuate_grid_peaks", "none"],
+  chargingStrategies: [
+    "charge_before_export",
+    "attenuate_demand_peaks",
+    "attenuate_feedin_peaks",
+    "attenuate_grid_peaks",
+    "none",
+  ],
   selectedStrategy: "charge_before_export",
   pending: false,
 };

--- a/assets/js/components/Optimize/OptimizeHeader.vue
+++ b/assets/js/components/Optimize/OptimizeHeader.vue
@@ -123,6 +123,8 @@ import "@h2d2/shopicons/es/regular/info";
 // themselves come from backend state to avoid drift if the enum changes
 const STRATEGY_LABELS: Record<string, string> = {
 	charge_before_export: "fill battery first",
+	attenuate_demand_peaks: "reduce grid import peaks",
+	attenuate_feedin_peaks: "reduce grid feed-in peaks",
 	attenuate_grid_peaks: "reduce grid peaks",
 	none: "no preference",
 };

--- a/core/optimizer.md
+++ b/core/optimizer.md
@@ -6,7 +6,7 @@ Optimizer uses mixed integer linear programming (MILP) to minize a cost function
 - solar forecast
 - base load (aka home) energy demand
 - end of forecast commercial value
-- strategy- either "charge before export" (charge loads as soon as possible) or "attenuate grid peaks"
+- strategy- either "charge before export" (charge loads as soon as possible) or attenuating grid peaks on the demand side, the feed-in side or both
 - home battery or loadpoint/vehicle...
   - capacity, soc and charge goals
   - charge/discharge power limits and efficiency

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -42,6 +42,8 @@ var (
 // entry is the default and preserves the previous hard-coded behavior.
 var optimizerChargingStrategies = []string{
 	string(optimizer.OptimizerStrategyChargingStrategyChargeBeforeExport),
+	string(optimizer.OptimizerStrategyChargingStrategyAttenuateDemandPeaks),
+	string(optimizer.OptimizerStrategyChargingStrategyAttenuateFeedinPeaks),
 	string(optimizer.OptimizerStrategyChargingStrategyAttenuateGridPeaks),
 	string(optimizer.OptimizerStrategyChargingStrategyNone),
 }

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/enbility/ship-go v0.6.1-0.20260720110450-0aa90f64ac76
 	github.com/enbility/spine-go v0.7.1-0.20260629113257-b3bcc643f323
 	github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4
-	github.com/evcc-io/optimizer v0.0.0-20260719151136-b6c835a178a3
+	github.com/evcc-io/optimizer v0.0.0-20260724075549-cce0c41d9489
 	github.com/evcc-io/rct v0.2.0
 	github.com/evcc-io/tesla-proxy-client v0.0.0-20260722070723-f3604323d820
 	github.com/fatih/structs v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4 h1:aGM3NwDsK
 github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4/go.mod h1:YyOx4zwr6xVUcchAETHERZ+75cZMIrdcjVIZFwBlE1Q=
 github.com/evcc-io/optimizer v0.0.0-20260719151136-b6c835a178a3 h1:QXk6AKYrYWQ+PxXhJS/LcHnegKFCCClUQ/BlCuqbs9Y=
 github.com/evcc-io/optimizer v0.0.0-20260719151136-b6c835a178a3/go.mod h1:cHMeq6GfoXQ8LxqY4LH1wn/hrgYEn+ka5RPI1CF37SY=
+github.com/evcc-io/optimizer v0.0.0-20260724075549-cce0c41d9489 h1:iM7XzdAI07Ff9uJtu7MS8wg2q0hH/84JtrQNbgGn1oo=
+github.com/evcc-io/optimizer v0.0.0-20260724075549-cce0c41d9489/go.mod h1:cHMeq6GfoXQ8LxqY4LH1wn/hrgYEn+ka5RPI1CF37SY=
 github.com/evcc-io/rct v0.2.0 h1:qjXKI7NKwW5YpEKEb27MwLMBaR4ne2Kd2cPV2PYTKn4=
 github.com/evcc-io/rct v0.2.0/go.mod h1:n6MTBU36QOadGlxxiADu86VaT5l0eYdbmFBHF14AD/s=
 github.com/evcc-io/tesla-proxy-client v0.0.0-20260722070723-f3604323d820 h1:qpLoOYEJ6dgD+UBEgwzsIiQ3WLPmi3Xb7EN4wFIypQY=

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,6 @@ github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b h1:5vFr7wOwoi5ylyb
 github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b/go.mod h1:2kcukDdhui4u730VfnYVWuwzDLgw+mBRGDir/QAyBhg=
 github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4 h1:aGM3NwDsKbnmiaO10ptbvEolRAUThWJEsObiAWFDU/c=
 github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4/go.mod h1:YyOx4zwr6xVUcchAETHERZ+75cZMIrdcjVIZFwBlE1Q=
-github.com/evcc-io/optimizer v0.0.0-20260719151136-b6c835a178a3 h1:QXk6AKYrYWQ+PxXhJS/LcHnegKFCCClUQ/BlCuqbs9Y=
-github.com/evcc-io/optimizer v0.0.0-20260719151136-b6c835a178a3/go.mod h1:cHMeq6GfoXQ8LxqY4LH1wn/hrgYEn+ka5RPI1CF37SY=
 github.com/evcc-io/optimizer v0.0.0-20260724075549-cce0c41d9489 h1:iM7XzdAI07Ff9uJtu7MS8wg2q0hH/84JtrQNbgGn1oo=
 github.com/evcc-io/optimizer v0.0.0-20260724075549-cce0c41d9489/go.mod h1:cHMeq6GfoXQ8LxqY4LH1wn/hrgYEn+ka5RPI1CF37SY=
 github.com/evcc-io/rct v0.2.0 h1:qjXKI7NKwW5YpEKEb27MwLMBaR4ne2Kd2cPV2PYTKn4=


### PR DESCRIPTION
Picks up evcc-io/optimizer#96, which reworks the `attenuate_grid_peaks` secondary goal. Peak shaping is now a penalty on the horizon maximum of the grid power, so charging spreads over several slots at partial power instead of running a single slot at full power, and the metered side it applies to is selectable:

| strategy | levels |
| --- | --- |
| `attenuate_demand_peaks` | grid import profile |
| `attenuate_feedin_peaks` | grid export profile |
| `attenuate_grid_peaks` | both |

`attenuate_grid_peaks` keeps its name and now means "both sides", so existing settings keep peak shaping on the side they expected plus the feed-in side.

Both new strategies are added to the accepted list and therefore show up in the secondary goal selector on the optimize page.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
