### PR TITLE
Solar forecast: switch from power at timestamp to energy during period

### DIFF
--- a/api/rates.go
+++ b/api/rates.go
@@ -6,7 +6,8 @@ import (
 	"time"
 )
 
-// Rate is a grid tariff rate
+// Rate is a grid tariff rate.
+// For solar tariffs, Value is the energy in Wh during [Start,End).
 type Rate struct {
 	Start time.Time `json:"start"`
 	End   time.Time `json:"end"`

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -437,13 +437,8 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 	// allow empty solar forecast
 	ft := lo.RepeatBy(minLen, func(i int) float32 { return float32(0) })
 	if solarTariff != nil && len(solar) > 0 {
-		solarEnergy, err := solarRatesToEnergy(solar)
-		if err != nil {
-			return err
-		}
-
 		scale := site.effectiveSolarScale()
-		ftSlots := scaleAndPrune(solarEnergy, scale, minLen)
+		ftSlots := scaleAndPrune(solar, scale, minLen)
 
 		// decay the scale derived from measured vs forecasted energy of the last completed slot
 		if pv, fcst := site.measuredSlotEnergy(site.Meters.PVMetersRef...), site.measuredSlotEnergy(metrics.Forecast)*scale; pv > 0 && fcst > 0 {
@@ -987,25 +982,6 @@ func prorate[T constraints.Float](slots []T, firstSlotDuration time.Duration) []
 	return lo.Map(res, func(f T, _ int) float32 {
 		return float32(f)
 	})
-}
-
-func solarRatesToEnergy(rr api.Rates) (api.Rates, error) {
-	res := make(api.Rates, 0, len(rr))
-
-	for _, r := range rr {
-		energy := solarEnergy(rr, r.Start, r.End)
-		if energy < 0 {
-			return nil, fmt.Errorf("negative solar energy from %v to %v: %.3f", r.Start, r.End, energy)
-		}
-
-		res = append(res, api.Rate{
-			Start: r.Start,
-			End:   r.End,
-			Value: energy,
-		})
-	}
-
-	return res, nil
 }
 
 func currentRates(tariff api.Tariff) api.Rates {

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -81,8 +81,8 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 	if v, err := tariff.Now(site.GetTariff(api.TariffUsageCo2)); err == nil {
 		site.publish(keys.TariffCo2, v)
 	}
-	if v, err := tariff.Now(site.GetTariff(api.TariffUsageSolar)); err == nil {
-		site.publish(keys.TariffSolar, v)
+	if r, err := tariff.At(site.GetTariff(api.TariffUsageSolar), time.Now()); err == nil {
+		site.publish(keys.TariffSolar, solarPower(r))
 	}
 	if v, err := tariff.Now(site.GetTariff(api.TariffUsageTemperature)); err == nil {
 		site.publish(keys.TariffTemperature, v)
@@ -184,7 +184,7 @@ func (site *Site) solarDetails(solar api.Rates) solarDetails {
 	}
 
 	if r, err := solar.At(time.Now()); err == nil {
-		if err := site.collectors[metrics.Forecast].AddEnergy(nil, nil, r.Value); err != nil {
+		if err := site.collectors[metrics.Forecast].AddEnergy(nil, nil, solarPower(r)); err != nil {
 			site.log.ERROR.Printf("solar forecast collector: %v", err)
 		}
 	}

--- a/core/solar.go
+++ b/core/solar.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
-	"github.com/samber/lo"
 )
 
 type timeseries []tsEntry
@@ -30,11 +29,21 @@ func solarPower(r api.Rate) float64 {
 	return r.Value / d
 }
 
-// solarTimeseries converts solar energy rates into power at timestamp
+// solarTimeseries converts solar energy rates into power at slot start. The average
+// power of a slot is centered, so the boundary power is interpolated from both slots.
 func solarTimeseries(rr api.Rates) []tsEntry {
-	return lo.Map(rr, func(r api.Rate, _ int) tsEntry {
-		return tsEntry{Timestamp: r.Start, Value: solarPower(r)}
-	})
+	res := make([]tsEntry, 0, len(rr))
+
+	for i, r := range rr {
+		power := solarPower(r)
+		if i > 0 {
+			power = (solarPower(rr[i-1]) + power) / 2
+		}
+
+		res = append(res, tsEntry{Timestamp: r.Start, Value: power})
+	}
+
+	return res
 }
 
 // solarEnergy sums the energy of all rates overlapping [from,to), prorating partial slots.

--- a/core/solar.go
+++ b/core/solar.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"encoding/json"
-	"slices"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -22,76 +21,49 @@ type tsEntry struct {
 	Value     float64   `json:"val"`
 }
 
+// solarPower converts the energy of a solar rate into average power in W
+func solarPower(r api.Rate) float64 {
+	d := r.End.Sub(r.Start).Hours()
+	if d <= 0 {
+		return 0
+	}
+	return r.Value / d
+}
+
+// solarTimeseries converts solar energy rates into power at timestamp
 func solarTimeseries(rr api.Rates) []tsEntry {
 	return lo.Map(rr, func(r api.Rate, _ int) tsEntry {
-		return tsEntry{Timestamp: r.Start, Value: r.Value}
+		return tsEntry{Timestamp: r.Start, Value: solarPower(r)}
 	})
 }
 
-func search(rr api.Rates, ts time.Time) (int, bool) {
-	return slices.BinarySearchFunc(rr, ts, func(v api.Rate, ts time.Time) int {
-		return v.Start.Compare(ts)
-	})
-}
-
-// interpolate returns the interpolated value where ts is between two entries and i is the index of the rate after ts
-func interpolate(rr api.Rates, i int, ts time.Time) float64 {
-	rp := &rr[i-1]
-	r := &rr[i]
-	return rp.Value + float64(ts.Sub(rp.Start))*(r.Value-rp.Value)/float64(r.Start.Sub(rp.Start))
-}
-
-// solarEnergy calculates the energy consumption between from and to,
-// assuming the rates containing the power at given timestamp.
+// solarEnergy sums the energy of all rates overlapping [from,to), prorating partial slots.
 // Result is in Wh
 func solarEnergy(rr api.Rates, from, to time.Time) float64 {
-	var energy float64
-
 	if from.After(to) {
 		panic("from cannot be after to")
 	}
 
-	// no rates- nothing to integrate
-	if len(rr) == 0 {
-		return 0
-	}
+	var energy float64
 
-	idx, ok := search(rr, from)
-	if !ok {
-		switch {
-		case idx >= len(rr):
-			// from is just before or after last entry
-			return 0
-		case idx == 0:
-			// from is before first entry- we ignore anything before the first entry
-			if !rr[0].Start.Before(to) {
-				// the whole interval is before the first entry
-				return 0
-			}
-		default:
-			// from is between two entries
-			r := &rr[idx]
-			vp := interpolate(rr, idx, from)
-
-			// to is before same entry as from
-			if r.Start.After(to) {
-				return (vp + interpolate(rr, idx, to)) / 2 * to.Sub(from).Hours()
-			}
-
-			energy += (vp + r.Value) / 2 * r.Start.Sub(from).Hours()
-		}
-	}
-
-	for ; idx < len(rr)-1; idx++ {
-		r := &rr[idx]
-		rn := &rr[idx+1]
-
-		if rn.Start.After(to) {
-			energy += (r.Value + interpolate(rr, idx+1, to)) / 2 * to.Sub(r.Start).Hours()
-			break
+	for _, r := range rr {
+		d := r.End.Sub(r.Start)
+		if d <= 0 {
+			continue
 		}
 
-		energy += (r.Value + rn.Value) / 2 * rn.Start.Sub(r.Start).Hours()
+		start, end := r.Start, r.End
+		if start.Before(from) {
+			start = from
+		}
+		if end.After(to) {
+			end = to
+		}
+		if !end.After(start) {
+			continue
+		}
+
+		energy += r.Value * float64(end.Sub(start)) / float64(d)
 	}
 
 	return energy

--- a/core/solar_test.go
+++ b/core/solar_test.go
@@ -84,17 +84,21 @@ func (t *solarTestSuite) TestShort() {
 }
 
 func (t *solarTestSuite) TestTimeseries() {
-	// energy per slot is converted back to average power
-	rr := api.Rates{t.rate(0, 500), {
-		Start: t.clock.Now().Add(time.Hour),
-		End:   t.clock.Now().Add(time.Hour + 15*time.Minute),
-		Value: 500,
-	}}
+	// slot energies 0/250/500Wh are average powers of 0/1000/2000W
+	var rr api.Rates
+	for i, v := range []float64{0, 250, 500} {
+		start := t.clock.Now().Add(time.Duration(i) * 15 * time.Minute)
+		rr = append(rr, api.Rate{Start: start, End: start.Add(15 * time.Minute), Value: v})
+	}
 
 	ts := solarTimeseries(rr)
-	t.Require().Len(ts, 2)
-	t.Equal(500.0, ts[0].Value)
-	t.Equal(2000.0, ts[1].Value)
+	t.Require().Len(ts, 3)
+
+	// boundary power is interpolated from the adjacent slots
+	for i, expected := range []float64{0, 500, 1500} {
+		t.Equal(rr[i].Start, ts[i].Timestamp, "%d. ts", i)
+		t.Equal(expected, ts[i].Value, "%d. value", i)
+	}
 }
 
 func TestSolarEnergyNoRates(t *testing.T) {

--- a/core/solar_test.go
+++ b/core/solar_test.go
@@ -35,25 +35,6 @@ func (t *solarTestSuite) SetupSuite() {
 	t.rr = api.Rates{t.rate(0, 0), t.rate(1, 1), t.rate(2, 2), t.rate(3, 3), t.rate(4, 4)}
 }
 
-func (t *solarTestSuite) TestIndex() {
-	for i, tc := range []struct {
-		ts  float64
-		idx int
-		ok  bool
-	}{
-		{-1, 0, false},
-		{0, 0, true},
-		{0.5, 1, false},
-		{1, 1, true},
-		{99, len(t.rr), false},
-	} {
-		ts := t.clock.Now().Add(time.Duration(float64(time.Hour) * tc.ts))
-		res, ok := search(t.rr, ts)
-		t.Equal(tc.idx, res, "%d. idx %+v", i+1, tc)
-		t.Equal(tc.ok, ok, "%d. ok %+v", i+1, tc)
-	}
-}
-
 func (t *solarTestSuite) TestEnergy() {
 	for i, tc := range []struct {
 		from, to float64
@@ -62,17 +43,15 @@ func (t *solarTestSuite) TestEnergy() {
 		{-1, 0, 0},
 		{-2, -1, 0},   // whole interval before first entry
 		{-1, -0.5, 0}, // whole interval before first entry
-		{-1, 1, 0.5},
-		{-1, 90, 8},
+		{-1, 1, 0},
+		{-1, 90, 10}, // all slots
 		{0, 0, 0},
-		{0, 0.5, 0.125},
-		{0, 1, 0.5},
-		{0, 1.5, 1.125},
-		{0, 2, 2},
-		{1, 2, 1.5},
-		{0.25, 0.75, 0.25},
-		{0.5, 1, 0.375},
-		{0.5, 3.5, 6},
+		{0, 2, 1},
+		{1, 2, 1},
+		{1.5, 2, 0.5},     // half of second slot
+		{1.25, 1.75, 0.5}, // middle of second slot
+		{1.5, 2.5, 1.5},   // half of second and third slot
+		{0.5, 3.5, 4.5},
 		{80, 90, 0},
 	} {
 		from := t.clock.Now().Add(time.Duration(float64(time.Hour) * tc.from))
@@ -88,22 +67,34 @@ func (t *solarTestSuite) TestShort() {
 	rr := api.Rates{t.rate(0, 0), t.rate(1, 1)}
 
 	for i, tc := range []struct {
-		from, to, energy, value float64
+		from, to, energy float64
 	}{
-		{-1, 0, 0, 0},
-		// {-1, 0.5, 0.125, 0.5},
-		// {-1, 2, 0.5, 0},
-		{0, 0, 0, 0},
-		{0, 0.5, 0.125, 0.5},
-		{0, 1, 0.5, 1},
-		{0, 1.5, 0.5, 0},
-		{1.5, 2, 0, 0},
+		{-1, 0, 0},
+		{0, 0, 0},
+		{0, 1, 0},
+		{0, 1.5, 0.5},
+		{1.5, 2, 0.5},
+		{2, 3, 0},
 	} {
 		from := t.clock.Now().Add(time.Duration(float64(time.Hour) * tc.from))
 		to := t.clock.Now().Add(time.Duration(float64(time.Hour) * tc.to))
 
 		t.Equal(tc.energy, solarEnergy(rr, from, to), "%d. energy %+v", i+1, tc)
 	}
+}
+
+func (t *solarTestSuite) TestTimeseries() {
+	// energy per slot is converted back to average power
+	rr := api.Rates{t.rate(0, 500), {
+		Start: t.clock.Now().Add(time.Hour),
+		End:   t.clock.Now().Add(time.Hour + 15*time.Minute),
+		Value: 500,
+	}}
+
+	ts := solarTimeseries(rr)
+	t.Require().Len(ts, 2)
+	t.Equal(500.0, ts[0].Value)
+	t.Equal(2000.0, ts[1].Value)
 }
 
 func TestSolarEnergyNoRates(t *testing.T) {

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -1,6 +1,7 @@
 package tariff
 
 import (
+	"slices"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -20,6 +21,10 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 	rates, err := t.Tariff.Rates()
 	if err != nil {
 		return nil, err
+	}
+
+	if t.Type() == api.TariffTypeSolar {
+		rates = aggregateEnergy(rates)
 	}
 
 	var res api.Rates
@@ -60,6 +65,47 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 	}
 
 	return res, nil
+}
+
+// aggregateEnergy merges sorted rates shorter than SlotDuration into aligned slots.
+// Longer rates are left to splitEnergy which preserves the forecast curve.
+func aggregateEnergy(rr api.Rates) api.Rates {
+	if !slices.ContainsFunc(rr, func(r api.Rate) bool {
+		d := r.End.Sub(r.Start)
+		return d > 0 && d < SlotDuration
+	}) {
+		return rr
+	}
+
+	res := make(api.Rates, 0, len(rr))
+
+	for _, r := range rr {
+		d := r.End.Sub(r.Start)
+		if d <= 0 {
+			continue
+		}
+
+		for start := r.Start.Truncate(SlotDuration); start.Before(r.End); start = start.Add(SlotDuration) {
+			from, to := start, start.Add(SlotDuration)
+			if from.Before(r.Start) {
+				from = r.Start
+			}
+			if to.After(r.End) {
+				to = r.End
+			}
+
+			val := r.Value * float64(to.Sub(from)) / float64(d)
+
+			if n := len(res); n > 0 && res[n-1].Start.Equal(start) {
+				res[n-1].Value += val
+				continue
+			}
+
+			res = append(res, api.Rate{Start: start, End: start.Add(SlotDuration), Value: val})
+		}
+	}
+
+	return res
 }
 
 // splitEnergy distributes the energy of rate i over numSlots sub-slots, shaped by

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -1,7 +1,6 @@
 package tariff
 
 import (
-	"slices"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -19,10 +18,6 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 	rates, err := t.Tariff.Rates()
 	if err != nil {
 		return nil, err
-	}
-
-	if t.Type() == api.TariffTypeSolar {
-		rates = aggregateEnergy(rates)
 	}
 
 	var res api.Rates
@@ -61,47 +56,6 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 	}
 
 	return res, nil
-}
-
-// aggregateEnergy merges sorted rates shorter than SlotDuration into aligned slots.
-// Longer rates are left to splitEnergy which preserves the forecast curve.
-func aggregateEnergy(rr api.Rates) api.Rates {
-	if !slices.ContainsFunc(rr, func(r api.Rate) bool {
-		d := r.End.Sub(r.Start)
-		return d > 0 && d < SlotDuration
-	}) {
-		return rr
-	}
-
-	res := make(api.Rates, 0, len(rr))
-
-	for _, r := range rr {
-		d := r.End.Sub(r.Start)
-		if d <= 0 {
-			continue
-		}
-
-		for start := r.Start.Truncate(SlotDuration); start.Before(r.End); start = start.Add(SlotDuration) {
-			from, to := start, start.Add(SlotDuration)
-			if from.Before(r.Start) {
-				from = r.Start
-			}
-			if to.After(r.End) {
-				to = r.End
-			}
-
-			val := r.Value * float64(to.Sub(from)) / float64(d)
-
-			if n := len(res); n > 0 && res[n-1].Start.Equal(start) {
-				res[n-1].Value += val
-				continue
-			}
-
-			res = append(res, api.Rate{Start: start, End: start.Add(SlotDuration), Value: val})
-		}
-	}
-
-	return res
 }
 
 // splitEnergy distributes the energy of rate i over its sub-slots, shaped by

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -13,10 +13,8 @@ type SlotWrapper struct {
 	api.Tariff
 }
 
-// Rates converts arbitrary slot lengths (e.g. 1h, 30m) to 15m slots.
-// Slot length must be multiple of SlotDuration.
-// For price tariffs, the value is constant over all sub-slots.
-// For solar, the slot energy is distributed over the sub-slots.
+// Rates converts arbitrary slot lengths (multiples of SlotDuration) to 15m slots.
+// Price sub-slots are constant, solar sub-slots share the energy of their slot.
 func (t *SlotWrapper) Rates() (api.Rates, error) {
 	rates, err := t.Tariff.Rates()
 	if err != nil {
@@ -42,15 +40,13 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 
 		numSlots := max(int(r.End.Sub(r.Start)/SlotDuration), 1)
 
-		var vals []float64
-		switch t.Type() {
-		case api.TariffTypeSolar:
-			vals = splitEnergy(rates, i, numSlots)
-		default:
-			vals = make([]float64, numSlots)
-			for j := range vals {
-				vals[j] = r.Value
-			}
+		vals := make([]float64, numSlots)
+		for j := range vals {
+			vals[j] = r.Value
+		}
+
+		if t.Type() == api.TariffTypeSolar {
+			splitEnergy(rates, i, vals)
 		}
 
 		for j := range numSlots {
@@ -108,13 +104,11 @@ func aggregateEnergy(rr api.Rates) api.Rates {
 	return res
 }
 
-// splitEnergy distributes the energy of rate i over numSlots sub-slots, shaped by
+// splitEnergy distributes the energy of rate i over its sub-slots, shaped by
 // linear interpolation against the neighbouring slots' average power.
-func splitEnergy(rates api.Rates, i, numSlots int) []float64 {
-	r := rates[i]
-
-	if numSlots <= 1 {
-		return []float64{r.Value}
+func splitEnergy(rates api.Rates, i int, vals []float64) {
+	if len(vals) < 2 {
+		return
 	}
 
 	power := func(k int) float64 {
@@ -134,29 +128,29 @@ func splitEnergy(rates api.Rates, i, numSlots int) []float64 {
 		next = power(i + 1)
 	}
 
-	res := make([]float64, numSlots)
-
 	var sum float64
-	for j := range res {
+	for j := range vals {
 		// sub-slot midpoint relative to the slot midpoint, [-0.5,0.5)
-		f := (float64(j)+0.5)/float64(numSlots) - 0.5
+		f := (float64(j)+0.5)/float64(len(vals)) - 0.5
 
 		v := cur + f*(next-cur)*2
 		if f < 0 {
 			v = cur + f*(cur-prev)*2
 		}
 
-		res[j] = max(v, 0)
-		sum += res[j]
+		vals[j] = max(v, 0)
+		sum += vals[j]
 	}
 
-	for j := range res {
-		if sum > 0 {
-			res[j] = r.Value * res[j] / sum
-		} else {
-			res[j] = r.Value / float64(numSlots)
+	energy := rates[i].Value
+	if sum <= 0 {
+		for j := range vals {
+			vals[j] = energy / float64(len(vals))
 		}
+		return
 	}
 
-	return res
+	for j := range vals {
+		vals[j] *= energy / sum
+	}
 }

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -15,7 +15,7 @@ type SlotWrapper struct {
 // Rates converts arbitrary slot lengths (e.g. 1h, 30m) to 15m slots.
 // Slot length must be multiple of SlotDuration.
 // For price tariffs, the value is constant over all sub-slots.
-// For solar/co2, linear interpolation is used between slot boundaries.
+// For solar, the slot energy is distributed over the sub-slots.
 func (t *SlotWrapper) Rates() (api.Rates, error) {
 	rates, err := t.Tariff.Rates()
 	if err != nil {
@@ -37,28 +37,80 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 
 		numSlots := max(int(r.End.Sub(r.Start)/SlotDuration), 1)
 
+		var vals []float64
+		switch t.Type() {
+		case api.TariffTypeSolar:
+			vals = splitEnergy(rates, i, numSlots)
+		default:
+			vals = make([]float64, numSlots)
+			for j := range vals {
+				vals[j] = r.Value
+			}
+		}
+
 		for j := range numSlots {
 			start := r.Start.Add(time.Duration(j) * SlotDuration)
-			end := start.Add(SlotDuration)
-			val := r.Value
-
-			switch t.Type() {
-			case api.TariffTypeSolar: //, api.TariffTypeCo2
-				if i+1 < len(rates) {
-					start0 := r.Start
-					start1 := rates[i+1].Start
-					frac := float64(start.Sub(start0)) / float64(start1.Sub(start0))
-					val = r.Value + frac*(rates[i+1].Value-r.Value)
-				}
-			}
 
 			res = append(res, api.Rate{
 				Start: start,
-				End:   end,
-				Value: val,
+				End:   start.Add(SlotDuration),
+				Value: vals[j],
 			})
 		}
 	}
 
 	return res, nil
+}
+
+// splitEnergy distributes the energy of rate i over numSlots sub-slots, shaped by
+// linear interpolation against the neighbouring slots' average power.
+func splitEnergy(rates api.Rates, i, numSlots int) []float64 {
+	r := rates[i]
+
+	if numSlots <= 1 {
+		return []float64{r.Value}
+	}
+
+	power := func(k int) float64 {
+		d := rates[k].End.Sub(rates[k].Start).Hours()
+		if d <= 0 {
+			return 0
+		}
+		return rates[k].Value / d
+	}
+
+	cur := power(i)
+	prev, next := cur, cur
+	if i > 0 {
+		prev = power(i - 1)
+	}
+	if i+1 < len(rates) {
+		next = power(i + 1)
+	}
+
+	res := make([]float64, numSlots)
+
+	var sum float64
+	for j := range res {
+		// sub-slot midpoint relative to the slot midpoint, [-0.5,0.5)
+		f := (float64(j)+0.5)/float64(numSlots) - 0.5
+
+		v := cur + f*(next-cur)*2
+		if f < 0 {
+			v = cur + f*(cur-prev)*2
+		}
+
+		res[j] = max(v, 0)
+		sum += res[j]
+	}
+
+	for j := range res {
+		if sum > 0 {
+			res[j] = r.Value * res[j] / sum
+		} else {
+			res[j] = r.Value / float64(numSlots)
+		}
+	}
+
+	return res
 }

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -141,6 +141,33 @@ func TestDropOldRates(t *testing.T) {
 	require.Len(t, res, 0)
 }
 
+// TestSolarShortSlots verifies that solar rates shorter than SlotDuration are
+// aggregated into full 15min slots
+func TestSolarShortSlots(t *testing.T) {
+	now := time.Now().Truncate(SlotDuration)
+
+	// six 5min rates of 10Wh each
+	rates := makeRates(now, 5*time.Minute, 6, 10)
+	for i := range rates {
+		rates[i].Value = 10
+	}
+
+	w := &SlotWrapper{&testTariff{
+		rates: rates,
+		typ:   api.TariffTypeSolar,
+	}}
+
+	res, err := w.Rates()
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	for i, r := range res {
+		assert.Equal(t, now.Add(time.Duration(i)*SlotDuration), r.Start, "slot %d", i)
+		assert.Equal(t, SlotDuration, r.End.Sub(r.Start), "slot %d", i)
+		assert.InDelta(t, 30.0, r.Value, 1e-9, "slot %d", i)
+	}
+}
+
 // TestSolarEnergySplit verifies that splitting an hourly solar rate into 15min
 // slots preserves the slot energy while following the neighbouring slots' shape
 func TestSolarEnergySplit(t *testing.T) {

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -146,11 +146,8 @@ func TestDropOldRates(t *testing.T) {
 func TestSolarShortSlots(t *testing.T) {
 	now := time.Now().Truncate(SlotDuration)
 
-	// six 5min rates of 10Wh each
+	// six 5min rates of 10..15Wh
 	rates := makeRates(now, 5*time.Minute, 6, 10)
-	for i := range rates {
-		rates[i].Value = 10
-	}
 
 	w := &SlotWrapper{&testTariff{
 		rates: rates,
@@ -164,8 +161,11 @@ func TestSolarShortSlots(t *testing.T) {
 	for i, r := range res {
 		assert.Equal(t, now.Add(time.Duration(i)*SlotDuration), r.Start, "slot %d", i)
 		assert.Equal(t, SlotDuration, r.End.Sub(r.Start), "slot %d", i)
-		assert.InDelta(t, 30.0, r.Value, 1e-9, "slot %d", i)
 	}
+
+	// energy of the source rates is summed, not averaged
+	assert.InDelta(t, 33.0, res[0].Value, 1e-9)
+	assert.InDelta(t, 42.0, res[1].Value, 1e-9)
 }
 
 // TestSolarEnergySplit verifies that splitting an hourly solar rate into 15min

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -141,46 +141,59 @@ func TestDropOldRates(t *testing.T) {
 	require.Len(t, res, 0)
 }
 
-// TestSolarAndCo2Interpolation
-//
-// For solar tariffs we expect power at time of interval start (see https://github.com/evcc-io/evcc/issues/23184 for changing this).
-// When converting to 15min slots, solar interpolation needs to take care of this
-func TestSolarAndCo2Interpolation(t *testing.T) {
+// TestSolarEnergySplit verifies that splitting an hourly solar rate into 15min
+// slots preserves the slot energy while following the neighbouring slots' shape
+func TestSolarEnergySplit(t *testing.T) {
 	now := time.Now().Truncate(SlotDuration)
 
-	// Two consecutive hourly solar rates: 0.0 in the first hour, 4.0 in the next
-	// With linear interpolation, the first hour's four 15m slots should have values 0,1,2,3
+	// two consecutive hourly solar rates: no energy in the first hour, 4Wh in the next
 	r0 := api.Rate{
 		Start: now,
-		End:   now.Add(1 * time.Hour),
+		End:   now.Add(time.Hour),
 		Value: 0.0,
 	}
 	r1 := api.Rate{
 		Start: r0.End,
-		End:   r0.End.Add(1 * time.Hour),
+		End:   r0.End.Add(time.Hour),
 		Value: 4.0,
 	}
 
-	for _, typ := range []api.TariffType{api.TariffTypeSolar} { //, api.TariffTypeCo2
-		w := &SlotWrapper{&testTariff{
-			rates: api.Rates{r0, r1},
-			typ:   typ,
-		}}
+	w := &SlotWrapper{&testTariff{
+		rates: api.Rates{r0, r1},
+		typ:   api.TariffTypeSolar,
+	}}
 
-		res, err := w.Rates()
-		require.NoError(t, err)
+	res, err := w.Rates()
+	require.NoError(t, err)
+	require.Len(t, res, 8)
 
-		// Build expected results: r0 interpolated into 4 slots (0..3), then r1 as four slots with value 4.0
-		expected := makeRates(now, SlotDuration, 4, 0)
+	for i, r := range res {
+		assert.Equal(t, now.Add(time.Duration(i)*SlotDuration), r.Start, "slot %d", i)
+		assert.Equal(t, SlotDuration, r.End.Sub(r.Start), "slot %d", i)
+	}
 
-		for j := range 4 {
-			expected = append(expected, api.Rate{
-				Start: r1.Start.Add(time.Duration(j) * SlotDuration),
-				End:   r1.Start.Add(time.Duration(j+1) * SlotDuration),
-				Value: 4.0,
-			})
+	// energy is conserved per source slot
+	var first, second float64
+	for i, r := range res {
+		if i < 4 {
+			first += r.Value
+		} else {
+			second += r.Value
 		}
+	}
+	assert.InDelta(t, r0.Value, first, 1e-9)
+	assert.InDelta(t, r1.Value, second, 1e-9)
 
-		assert.Equal(t, expected, res)
+	// ramping up from the empty hour, flat towards the missing successor
+	for _, tc := range []struct {
+		idx      int
+		expected float64
+	}{
+		{4, 4.0 / 12},
+		{5, 12.0 / 12},
+		{6, 16.0 / 12},
+		{7, 16.0 / 12},
+	} {
+		assert.InDelta(t, tc.expected, res[tc.idx].Value, 1e-9, "slot %d", tc.idx)
 	}
 }

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -141,33 +141,6 @@ func TestDropOldRates(t *testing.T) {
 	require.Len(t, res, 0)
 }
 
-// TestSolarShortSlots verifies that solar rates shorter than SlotDuration are
-// aggregated into full 15min slots
-func TestSolarShortSlots(t *testing.T) {
-	now := time.Now().Truncate(SlotDuration)
-
-	// six 5min rates of 10..15Wh
-	rates := makeRates(now, 5*time.Minute, 6, 10)
-
-	w := &SlotWrapper{&testTariff{
-		rates: rates,
-		typ:   api.TariffTypeSolar,
-	}}
-
-	res, err := w.Rates()
-	require.NoError(t, err)
-	require.Len(t, res, 2)
-
-	for i, r := range res {
-		assert.Equal(t, now.Add(time.Duration(i)*SlotDuration), r.Start, "slot %d", i)
-		assert.Equal(t, SlotDuration, r.End.Sub(r.Start), "slot %d", i)
-	}
-
-	// energy of the source rates is summed, not averaged
-	assert.InDelta(t, 33.0, res[0].Value, 1e-9)
-	assert.InDelta(t, 42.0, res[1].Value, 1e-9)
-}
-
 // TestSolarEnergySplit verifies that splitting an hourly solar rate into 15min
 // slots preserves the slot energy while following the neighbouring slots' shape
 func TestSolarEnergySplit(t *testing.T) {

--- a/tariff/solcast.go
+++ b/tariff/solcast.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/evcc-io/evcc/util/transport"
-	"github.com/jinzhu/now"
 )
 
 type Solcast struct {
@@ -104,23 +103,19 @@ func (t *Solcast) run(interval time.Duration, done chan error) {
 
 		data := make(api.Rates, 0, len(res.Forecasts))
 
-	NEXT:
 		for _, r := range res.Forecasts {
-			start := now.With(r.PeriodEnd).BeginningOfHour().Local()
-			rr := api.Rate{
+			// pv_estimate is the average power of the period ending at period_end
+			d := r.Period.Duration()
+			if d <= 0 {
+				continue
+			}
+
+			start := r.PeriodEnd.Add(-d).Local()
+			data = append(data, api.Rate{
 				Start: start,
-				End:   start.Add(time.Hour),
-				Value: r.PvEstimate * 1e3,
-			}
-			if r.Period.Duration() != time.Hour {
-				for i, r := range data {
-					if r.Start.Equal(rr.Start) {
-						data[i].Value = (r.Value + rr.Value) / 2
-						continue NEXT
-					}
-				}
-			}
-			data = append(data, rr)
+				End:   start.Add(d),
+				Value: r.PvEstimate * 1e3 * d.Hours(),
+			})
 		}
 
 		mergeRatesAfter(t.data, data, beginningOfDay())

--- a/templates/definition/tariff/demo-solar-forecast.yaml
+++ b/templates/definition/tariff/demo-solar-forecast.yaml
@@ -104,7 +104,8 @@ render: |
           rates.push({
             start: time.toISOString(),
             end: new Date(time.getTime() + slotDuration).toISOString(),
-            value: Math.round(Math.max(0, solarValue))
+            // energy of the slot
+            value: Math.round(Math.max(0, solarValue) * slotMinutes / 60)
           });
         }
       }

--- a/templates/definition/tariff/forecast-solar.yaml
+++ b/templates/definition/tariff/forecast-solar.yaml
@@ -31,9 +31,10 @@ render: |
     source: http
     uri: https://api.forecast.solar/{{ if .apikey }}{{ .apikey }}/{{ end }}estimate/{{ .lat }}/{{ .lon }}/{{ .dec }}/{{ .az }}/{{ .kwp }}?time=utc&full=1&resolution=60{{ if .horizon }}&horizon={{ unquote .horizon }}{{ end }}
     jq: |
-      [ .result.watts | to_entries.[] | {
-        "start": (.key | strptime("%FT%T%z") | strftime("%FT%TZ")),
-        "end":   (.key | strptime("%FT%T%z") | mktime+3600 | strftime("%FT%TZ")),
+      # watt_hours_period is the energy of the period ending at the timestamp
+      [ .result.watt_hours_period | to_entries.[] | {
+        "start": (.key | strptime("%FT%T%z") | mktime-3600 | strftime("%FT%TZ")),
+        "end":   (.key | strptime("%FT%T%z") | strftime("%FT%TZ")),
         "value": .value
       } ] | tostring
   interval: {{ .interval }}

--- a/templates/definition/tariff/open-meteo.yaml
+++ b/templates/definition/tariff/open-meteo.yaml
@@ -74,7 +74,7 @@ render: |
   tariff: solar
   forecast:
     source: http
-    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance_instant&daily=sunrise,sunset&forecast_days=5&timezone=GMT&timeformat=unixtime{{ if ne .model "best_match" }}&models={{ .model }}{{ end }}
+    uri: https://api.open-meteo.com/v1/forecast?latitude={{ .lat }}&longitude={{ .lon }}&azimuth={{ .az }}&tilt={{ .dec }}&minutely_15=temperature_2m,global_tilted_irradiance&daily=sunrise,sunset&forecast_days=5&timezone=GMT&timeformat=unixtime{{ if ne .model "best_match" }}&models={{ .model }}{{ end }}
     jq: |
       def alphatemp: {{ .alphatemp }}; # temperature coefficient
       def rossmodel: {{ .rossmodel }}; # cooling type
@@ -103,17 +103,18 @@ render: |
           | $h.time[$i] as $time
           | ($i / 96 | floor) as $day
           | {
-              start: ($time | todateiso8601),
-              end: (($time + 900) | todateiso8601),
-              value: (
+              # irradiance is the mean over the interval ending at the timestamp
+              start: (($time - 900) | todateiso8601),
+              end: ($time | todateiso8601),
+              value: ((
                 kwp
-                * ($h.global_tilted_irradiance_instant[$i] / 1000)
+                * ($h.global_tilted_irradiance[$i] / 1000)
                 * (1 + ( alphatemp *
                       (
                         ( ($h.temperature_2m[$i]
                             + ($h.temperature_2m[$i-1] // $h.temperature_2m[$i])
                           ) / 2)
-                        + $h.global_tilted_irradiance_instant[$i] * rossmodel - 25.0
+                        + $h.global_tilted_irradiance[$i] * rossmodel - 25.0
                       )
                     ))
                 * (1 - calculate_damping($time;
@@ -122,7 +123,7 @@ render: |
                       dm; de))
                 * eff
                 | clamp(0; .; ac)
-              )
+              ) / 4)
             }
         ]
       | tostring

--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -50,11 +50,12 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
+      # pv_power is the mean power of the 15min interval
       [.values[] |
         {
           start: (.timestamp),
           end:   (.timestamp | fromdateiso8601 + 900 | todateiso8601 ),
-          value: (.pv_power | round )
+          value: (.pv_power / 4 | round )
         }
       ] | tostring
   interval: {{ .interval }}

--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -54,11 +54,12 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
+      # pv_watts is the mean power of the 15min interval
       [.values[] |
         {
           start: (.dtm | sub(" "; "T") + "Z"),
           end:   (.dtm | sub(" "; "T") + "Z" | fromdateiso8601 + 900 | todateiso8601 ),
-          value: (.pv_watts | round )
+          value: (.pv_watts / 4 | round )
         }
       ] | tostring
   interval: {{ .interval }}


### PR DESCRIPTION
fixes #23184

Solar tariff rates now carry the energy in Wh during `[start,end)` instead of the production power at `start`. Providers deliver period means or period energy, so the point-sample contract forced every consumer to re-integrate the curve and silently misaligned the providers that label their timestamps with the period end. Charting keeps working on power at timestamp, reconstructed from the slot energies.

Per provider:

- Solcast: `pv_estimate` is the period mean labelled with `period_end`. The hourly bucketing keyed off `period_end` put each half-hour into the wrong hour, shifting the whole curve 30 minutes early. Slots now keep the native `PT30M` resolution
- forecast.solar: uses `watt_hours_period` instead of `watts`. Note that `watts` is an instantaneous sample despite the docs calling it a period average: `watt_hours_period` is exactly the trapezoid of two neighbouring `watts` values
- Open-Meteo: uses `global_tilted_irradiance` instead of `global_tilted_irradiance_instant`, which is the mean over the interval ending at the timestamp
- pvnode v1/v2: documented as 15 minute means
- Akkudoktor, Solarprognose, Victron: hourly values already match Wh per slot and stay numerically unchanged. The Victron mapping was previously wrong in the other direction, reading Wh per hour as W

Consumer side:

- Source slots are split into 15 minute slots with their energy distributed against the neighbouring slots' average power, so the curve stays smooth for hourly providers
- The published timeseries interpolates the power at the slot start from the adjacent slots. The slot average alone is centered in the slot, so labelling it with the slot start would shift the curve by half a slot
- `solarRatesToEnergy` in the optimizer path is gone, rates arrive as energy already

**TODO**
- [ ] pvnode does not document whether the timestamp marks the start or the end of the 15 minute interval, currently assumed to be the start
- [ ] Akkudoktor's hourly `power` tracks Open-Meteo's mean irradiance of the *following* hour, which suggests an off-by-one in the timestamp labelling. Template is deprecated, so left as is

---
🤖 Made with [Claude Code](https://claude.com/claude-code)
