### PR TITLE
feat(homeassistant): add Porsche Connect charging status strings

### DIFF
--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -170,13 +170,13 @@ func (c *Connection) GetTimeState(entity string) (time.Time, error) {
 // chargeStatusMap maps Home Assistant states to EVCC charge status
 var chargeStatusMap = map[string]api.ChargeStatus{
 	// Status C - Charging
-	"c":        api.StatusC,
-	"charging": api.StatusC,
-	"on":       api.StatusC,
-	"true":     api.StatusC,
-	"active":   api.StatusC,
-	"1":        api.StatusC,
-	"instant_charging":   api.StatusC,
+	"c":                  api.StatusC,
+	"charging":           api.StatusC,
+	"on":                 api.StatusC,
+	"true":               api.StatusC,
+	"active":             api.StatusC,
+	"1":                  api.StatusC,
+	"instant_charging":   api.StatusC, // Porsche Connect
 
 	// Status B - Connected/Ready
 	"b":                  api.StatusB,
@@ -192,8 +192,8 @@ var chargeStatusMap = map[string]api.ChargeStatus{
 	"stopped":            api.StatusB,
 	"starting":           api.StatusB,
 	"paused":             api.StatusB,
-	"charging_stopped":   api.StatusB,
-    "charging_error":     api.StatusB,
+	"charging_stopped":   api.StatusB, // Porsche Connect
+	"charging_error":     api.StatusB, // Porsche Connect
 
 	// Status A - Disconnected
 	"a":                   api.StatusA,

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -170,30 +170,30 @@ func (c *Connection) GetTimeState(entity string) (time.Time, error) {
 // chargeStatusMap maps Home Assistant states to EVCC charge status
 var chargeStatusMap = map[string]api.ChargeStatus{
 	// Status C - Charging
-	"c":                  api.StatusC,
-	"charging":           api.StatusC,
-	"on":                 api.StatusC,
-	"true":               api.StatusC,
-	"active":             api.StatusC,
-	"1":                  api.StatusC,
-	"instant_charging":   api.StatusC, // Porsche Connect
+	"c":        		api.StatusC,
+	"charging": 		api.StatusC,
+	"on":       		api.StatusC,
+	"true":     		api.StatusC,
+	"active":   		api.StatusC,
+	"1":        		api.StatusC,
+	"instant_charging":	api.StatusC, // Porsche Connect
 
 	// Status B - Connected/Ready
-	"b":                  api.StatusB,
-	"connected":          api.StatusB,
-	"ready":              api.StatusB,
-	"plugged":            api.StatusB,
-	"charging_completed": api.StatusB,
-	"initialising":       api.StatusB,
-	"preparing":          api.StatusB,
-	"2":                  api.StatusB,
-	"no_power":           api.StatusB,
-	"complete":           api.StatusB,
-	"stopped":            api.StatusB,
-	"starting":           api.StatusB,
-	"paused":             api.StatusB,
-	"charging_stopped":   api.StatusB, // Porsche Connect
-	"charging_error":     api.StatusB, // Porsche Connect
+	"b":                  	api.StatusB,
+	"connected":          	api.StatusB,
+	"ready":              	api.StatusB,
+	"plugged":            	api.StatusB,
+	"charging_completed": 	api.StatusB,
+	"initialising":       	api.StatusB,
+	"preparing":          	api.StatusB,
+	"2":                  	api.StatusB,
+	"no_power":           	api.StatusB,
+	"complete":           	api.StatusB,
+	"stopped":            	api.StatusB,
+	"starting":           	api.StatusB,
+	"paused":             	api.StatusB,
+	"charging_stopped":		api.StatusB, // Porsche Connect
+	"charging_error":		api.StatusB, // Porsche Connect
 
 	// Status A - Disconnected
 	"a":                   api.StatusA,

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -176,6 +176,7 @@ var chargeStatusMap = map[string]api.ChargeStatus{
 	"true":     api.StatusC,
 	"active":   api.StatusC,
 	"1":        api.StatusC,
+	"instant_charging":   api.StatusC,
 
 	// Status B - Connected/Ready
 	"b":                  api.StatusB,
@@ -191,6 +192,8 @@ var chargeStatusMap = map[string]api.ChargeStatus{
 	"stopped":            api.StatusB,
 	"starting":           api.StatusB,
 	"paused":             api.StatusB,
+	"charging_stopped":   api.StatusB,
+    "charging_error":     api.StatusB,
 
 	// Status A - Disconnected
 	"a":                   api.StatusA,

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -170,30 +170,30 @@ func (c *Connection) GetTimeState(entity string) (time.Time, error) {
 // chargeStatusMap maps Home Assistant states to EVCC charge status
 var chargeStatusMap = map[string]api.ChargeStatus{
 	// Status C - Charging
-	"c":        		api.StatusC,
-	"charging": 		api.StatusC,
-	"on":       		api.StatusC,
-	"true":     		api.StatusC,
-	"active":   		api.StatusC,
-	"1":        		api.StatusC,
-	"instant_charging":	api.StatusC, // Porsche Connect
+	"c":                 api.StatusC,
+	"charging":          api.StatusC,
+	"on":                api.StatusC,
+	"true":              api.StatusC,
+	"active":            api.StatusC,
+	"1":                 api.StatusC,
+	"instant_charging":  api.StatusC, // Porsche Connect
 
 	// Status B - Connected/Ready
-	"b":                  	api.StatusB,
-	"connected":          	api.StatusB,
-	"ready":              	api.StatusB,
-	"plugged":            	api.StatusB,
-	"charging_completed": 	api.StatusB,
-	"initialising":       	api.StatusB,
-	"preparing":          	api.StatusB,
-	"2":                  	api.StatusB,
-	"no_power":           	api.StatusB,
-	"complete":           	api.StatusB,
-	"stopped":            	api.StatusB,
-	"starting":           	api.StatusB,
-	"paused":             	api.StatusB,
-	"charging_stopped":		api.StatusB, // Porsche Connect
-	"charging_error":		api.StatusB, // Porsche Connect
+	"b":                  api.StatusB,
+	"connected":          api.StatusB,
+	"ready":              api.StatusB,
+	"plugged":            api.StatusB,
+	"charging_completed": api.StatusB,
+	"initialising":       api.StatusB,
+	"preparing":          api.StatusB,
+	"2":                  api.StatusB,
+	"no_power":           api.StatusB,
+	"complete":           api.StatusB,
+	"stopped":            api.StatusB,
+	"starting":           api.StatusB,
+	"paused":             api.StatusB,
+	"charging_stopped":   api.StatusB, // Porsche Connect
+	"charging_error":     api.StatusB, // Porsche Connect
 
 	// Status A - Disconnected
 	"a":                   api.StatusA,


### PR DESCRIPTION
Porsche Connect (Home Assistant integration) outputs string-based charging status values that are not recognized by EVCC's Home Assistant charge status parser and are causing invalid states and invalid validation of the configuration when the vehicle is added. These are the raw string values returned by the Porsche Connect Home Assistant integration.

Missing States:
- `charging_stopped` — Charger stopped (e.g., scheduled end or external stop), car still connected
- `charging_error` — Charging fault, car still connected
- `instant_charging` — Immediate charging mode actively charging