### PR TITLE
Tariff (solar): center sub-slot interpolation on the source slot

### DIFF
--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -96,7 +96,8 @@ func shapeSolar(rates api.Rates, i int, vals []float64) {
 	}
 
 	// preserve the slot average
+	scale := cur * float64(len(vals)) / sum
 	for j := range vals {
-		vals[j] *= cur * float64(len(vals)) / sum
+		vals[j] *= scale
 	}
 }

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -58,8 +58,9 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 	return res, nil
 }
 
-// shapeSolar interpolates solar sub-slots against the neighbouring slots. The slot
-// value applies to the entire period, so sub-slots are centered and rescaled to it.
+// shapeSolar interpolates solar sub-slots between the slot centers. The slot value
+// applies to the entire period, so sub-slots are centered and rescaled to it. Slot
+// edges meet the average of both neighbouring values, keeping the curve continuous.
 func shapeSolar(rates api.Rates, i int, vals []float64) {
 	if len(vals) < 2 {
 		return
@@ -89,7 +90,7 @@ func shapeSolar(rates api.Rates, i int, vals []float64) {
 			delta = cur - prev
 		}
 
-		vals[j] = max(cur+2*f*delta, 0)
+		vals[j] = max(cur+f*delta, 0)
 		sum += vals[j]
 	}
 

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -84,12 +84,12 @@ func shapeSolar(rates api.Rates, i int, vals []float64) {
 		// sub-slot midpoint relative to the slot midpoint, [-0.5,0.5)
 		f := (float64(j)+0.5)/float64(len(vals)) - 0.5
 
-		v := cur + 2*f*(next-cur)
+		delta := next - cur
 		if f < 0 {
-			v = cur + 2*f*(cur-prev)
+			delta = cur - prev
 		}
 
-		vals[j] = max(v, 0)
+		vals[j] = max(cur+2*f*delta, 0)
 		sum += vals[j]
 	}
 

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -12,10 +12,8 @@ type SlotWrapper struct {
 	api.Tariff
 }
 
-// Rates converts arbitrary slot lengths (e.g. 1h, 30m) to 15m slots.
-// Slot length must be multiple of SlotDuration.
-// For price tariffs, the value is constant over all sub-slots.
-// For solar/co2, linear interpolation is used between slot boundaries.
+// Rates converts arbitrary slot lengths (multiples of SlotDuration) to 15m slots.
+// Price sub-slots are constant, solar sub-slots interpolated around the slot center.
 func (t *SlotWrapper) Rates() (api.Rates, error) {
 	rates, err := t.Tariff.Rates()
 	if err != nil {
@@ -37,28 +35,68 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 
 		numSlots := max(int(r.End.Sub(r.Start)/SlotDuration), 1)
 
+		vals := make([]float64, numSlots)
+		for j := range vals {
+			vals[j] = r.Value
+		}
+
+		if t.Type() == api.TariffTypeSolar {
+			shapeSolar(rates, i, vals)
+		}
+
 		for j := range numSlots {
 			start := r.Start.Add(time.Duration(j) * SlotDuration)
-			end := start.Add(SlotDuration)
-			val := r.Value
-
-			switch t.Type() {
-			case api.TariffTypeSolar: //, api.TariffTypeCo2
-				if i+1 < len(rates) {
-					start0 := r.Start
-					start1 := rates[i+1].Start
-					frac := float64(start.Sub(start0)) / float64(start1.Sub(start0))
-					val = r.Value + frac*(rates[i+1].Value-r.Value)
-				}
-			}
 
 			res = append(res, api.Rate{
 				Start: start,
-				End:   end,
-				Value: val,
+				End:   start.Add(SlotDuration),
+				Value: vals[j],
 			})
 		}
 	}
 
 	return res, nil
+}
+
+// shapeSolar interpolates solar sub-slots against the neighbouring slots. The slot
+// value applies to the entire period, so sub-slots are centered and rescaled to it.
+func shapeSolar(rates api.Rates, i int, vals []float64) {
+	if len(vals) < 2 {
+		return
+	}
+
+	cur := rates[i].Value
+	prev, next := cur, cur
+	if i > 0 {
+		prev = rates[i-1].Value
+	}
+	if i+1 < len(rates) {
+		next = rates[i+1].Value
+	}
+
+	var sum float64
+	for j := range vals {
+		// sub-slot midpoint relative to the slot midpoint, [-0.5,0.5)
+		f := (float64(j)+0.5)/float64(len(vals)) - 0.5
+
+		v := cur + 2*f*(next-cur)
+		if f < 0 {
+			v = cur + 2*f*(cur-prev)
+		}
+
+		vals[j] = max(v, 0)
+		sum += vals[j]
+	}
+
+	if sum <= 0 {
+		for j := range vals {
+			vals[j] = cur
+		}
+		return
+	}
+
+	// preserve the slot average
+	for j := range vals {
+		vals[j] *= cur * float64(len(vals)) / sum
+	}
 }

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -66,6 +66,11 @@ func shapeSolar(rates api.Rates, i int, vals []float64) {
 	}
 
 	cur := rates[i].Value
+	if cur <= 0 {
+		// empty slot stays empty, shaping a non-positive slot would flip signs when rescaling
+		return
+	}
+
 	prev, next := cur, cur
 	if i > 0 {
 		prev = rates[i-1].Value

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -141,6 +141,20 @@ func TestDropOldRates(t *testing.T) {
 	require.Len(t, res, 0)
 }
 
+// assertSourceAverages verifies that the sub-slots preserve the average of their source slot
+func assertSourceAverages(t *testing.T, rr, res api.Rates) {
+	t.Helper()
+
+	n := len(res) / len(rr)
+	for i, r := range rr {
+		var sum float64
+		for _, sub := range res[i*n : (i+1)*n] {
+			sum += sub.Value
+		}
+		assert.InDelta(t, r.Value, sum/float64(n), 1e-9, "rate %d", i)
+	}
+}
+
 // TestSolarInterpolation verifies that solar sub-slots follow the neighbouring
 // slots while preserving the average of the slot they originate from
 func TestSolarInterpolation(t *testing.T) {
@@ -169,7 +183,6 @@ func TestSolarInterpolation(t *testing.T) {
 
 	for i, r := range res {
 		assert.Equal(t, now.Add(time.Duration(i)*SlotDuration), r.Start, "slot %d", i)
-		assert.Equal(t, SlotDuration, r.End.Sub(r.Start), "slot %d", i)
 	}
 
 	// ramping up from the empty hour, flat towards the missing successor
@@ -177,14 +190,7 @@ func TestSolarInterpolation(t *testing.T) {
 		assert.InDelta(t, expected, res[i].Value, 1e-9, "slot %d", i)
 	}
 
-	// the average of each source slot is preserved
-	for i, expected := range []float64{r0.Value, r1.Value} {
-		var sum float64
-		for _, r := range res[i*4 : i*4+4] {
-			sum += r.Value
-		}
-		assert.InDelta(t, expected, sum/4, 1e-9, "rate %d", i)
-	}
+	assertSourceAverages(t, api.Rates{r0, r1}, res)
 }
 
 // TestSolarInterpolationInterior verifies an interior slot with both neighbours differing
@@ -208,14 +214,7 @@ func TestSolarInterpolationInterior(t *testing.T) {
 		assert.InDelta(t, expected, res[4+i].Value, 1e-9, "slot %d", i)
 	}
 
-	// the average of each source slot is preserved
-	for i, r := range rr {
-		var sum float64
-		for _, r := range res[i*4 : i*4+4] {
-			sum += r.Value
-		}
-		assert.InDelta(t, r.Value, sum/4, 1e-9, "rate %d", i)
-	}
+	assertSourceAverages(t, rr, res)
 }
 
 // TestSolarNegativeSlot verifies that a non-positive slot is not shaped

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -141,46 +141,48 @@ func TestDropOldRates(t *testing.T) {
 	require.Len(t, res, 0)
 }
 
-// TestSolarAndCo2Interpolation
-//
-// For solar tariffs we expect power at time of interval start (see https://github.com/evcc-io/evcc/issues/23184 for changing this).
-// When converting to 15min slots, solar interpolation needs to take care of this
-func TestSolarAndCo2Interpolation(t *testing.T) {
+// TestSolarInterpolation verifies that solar sub-slots follow the neighbouring
+// slots while preserving the average of the slot they originate from
+func TestSolarInterpolation(t *testing.T) {
 	now := time.Now().Truncate(SlotDuration)
 
-	// Two consecutive hourly solar rates: 0.0 in the first hour, 4.0 in the next
-	// With linear interpolation, the first hour's four 15m slots should have values 0,1,2,3
+	// two consecutive hourly solar rates: 0.0 in the first hour, 4.0 in the next
 	r0 := api.Rate{
 		Start: now,
-		End:   now.Add(1 * time.Hour),
+		End:   now.Add(time.Hour),
 		Value: 0.0,
 	}
 	r1 := api.Rate{
 		Start: r0.End,
-		End:   r0.End.Add(1 * time.Hour),
+		End:   r0.End.Add(time.Hour),
 		Value: 4.0,
 	}
 
-	for _, typ := range []api.TariffType{api.TariffTypeSolar} { //, api.TariffTypeCo2
-		w := &SlotWrapper{&testTariff{
-			rates: api.Rates{r0, r1},
-			typ:   typ,
-		}}
+	w := &SlotWrapper{&testTariff{
+		rates: api.Rates{r0, r1},
+		typ:   api.TariffTypeSolar,
+	}}
 
-		res, err := w.Rates()
-		require.NoError(t, err)
+	res, err := w.Rates()
+	require.NoError(t, err)
+	require.Len(t, res, 8)
 
-		// Build expected results: r0 interpolated into 4 slots (0..3), then r1 as four slots with value 4.0
-		expected := makeRates(now, SlotDuration, 4, 0)
+	for i, r := range res {
+		assert.Equal(t, now.Add(time.Duration(i)*SlotDuration), r.Start, "slot %d", i)
+		assert.Equal(t, SlotDuration, r.End.Sub(r.Start), "slot %d", i)
+	}
 
-		for j := range 4 {
-			expected = append(expected, api.Rate{
-				Start: r1.Start.Add(time.Duration(j) * SlotDuration),
-				End:   r1.Start.Add(time.Duration(j+1) * SlotDuration),
-				Value: 4.0,
-			})
+	// ramping up from the empty hour, flat towards the missing successor
+	for i, expected := range []float64{0, 0, 0, 0, 4.0 / 3, 4, 16.0 / 3, 16.0 / 3} {
+		assert.InDelta(t, expected, res[i].Value, 1e-9, "slot %d", i)
+	}
+
+	// the average of each source slot is preserved
+	for i, expected := range []float64{r0.Value, r1.Value} {
+		var sum float64
+		for _, r := range res[i*4 : i*4+4] {
+			sum += r.Value
 		}
-
-		assert.Equal(t, expected, res)
+		assert.InDelta(t, expected, sum/4, 1e-9, "rate %d", i)
 	}
 }

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -186,7 +186,7 @@ func TestSolarInterpolation(t *testing.T) {
 	}
 
 	// ramping up from the empty hour, flat towards the missing successor
-	for i, expected := range []float64{0, 0, 0, 0, 4.0 / 3, 4, 16.0 / 3, 16.0 / 3} {
+	for i, expected := range []float64{0, 0, 0, 0, 20.0 / 7, 4, 32.0 / 7, 32.0 / 7} {
 		assert.InDelta(t, expected, res[i].Value, 1e-9, "slot %d", i)
 	}
 
@@ -209,8 +209,8 @@ func TestSolarInterpolationInterior(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 12)
 
-	// interior slot ramps linearly from prev to next
-	for i, expected := range []float64{1, 3, 5, 7} {
+	// interior slot ramps linearly between the neighbouring slot centers
+	for i, expected := range []float64{2.5, 3.5, 4.5, 5.5} {
 		assert.InDelta(t, expected, res[4+i].Value, 1e-9, "slot %d", i)
 	}
 

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -186,3 +186,54 @@ func TestSolarInterpolation(t *testing.T) {
 		assert.InDelta(t, expected, sum/4, 1e-9, "rate %d", i)
 	}
 }
+
+// TestSolarInterpolationInterior verifies an interior slot with both neighbours differing
+func TestSolarInterpolationInterior(t *testing.T) {
+	now := time.Now().Truncate(SlotDuration)
+
+	rr := make(api.Rates, 3)
+	for i, v := range []float64{0, 4, 8} {
+		start := now.Add(time.Duration(i) * time.Hour)
+		rr[i] = api.Rate{Start: start, End: start.Add(time.Hour), Value: v}
+	}
+
+	w := &SlotWrapper{&testTariff{rates: rr, typ: api.TariffTypeSolar}}
+
+	res, err := w.Rates()
+	require.NoError(t, err)
+	require.Len(t, res, 12)
+
+	// interior slot ramps linearly from prev to next
+	for i, expected := range []float64{1, 3, 5, 7} {
+		assert.InDelta(t, expected, res[4+i].Value, 1e-9, "slot %d", i)
+	}
+
+	// the average of each source slot is preserved
+	for i, r := range rr {
+		var sum float64
+		for _, r := range res[i*4 : i*4+4] {
+			sum += r.Value
+		}
+		assert.InDelta(t, r.Value, sum/4, 1e-9, "rate %d", i)
+	}
+}
+
+// TestSolarNegativeSlot verifies that a non-positive slot is not shaped
+func TestSolarNegativeSlot(t *testing.T) {
+	now := time.Now().Truncate(SlotDuration)
+
+	rr := api.Rates{
+		{Start: now, End: now.Add(time.Hour), Value: -1},
+		{Start: now.Add(time.Hour), End: now.Add(2 * time.Hour), Value: 4},
+	}
+
+	w := &SlotWrapper{&testTariff{rates: rr, typ: api.TariffTypeSolar}}
+
+	res, err := w.Rates()
+	require.NoError(t, err)
+	require.Len(t, res, 8)
+
+	for i, r := range res[:4] {
+		assert.Equal(t, -1.0, r.Value, "slot %d", i)
+	}
+}


### PR DESCRIPTION
fixes #32099, alternative to #32114

Keeps the power at timestamp contract and only fixes the sub-slot split. When a source slot is divided into 15 minute sub-slots, the interpolation ramped away from the slot's own value towards the next slot, so the two sub-slots of a 30 minute Solcast slot no longer averaged to the value the source reported and energy moved between slots. Sub-slots are now placed around the slot center and rescaled to the slot value.

- The average of a source slot's sub-slots equals the source value again, for any slot length
- The forecast curve stays smooth, unlike repeating the source value per sub-slot which would step the curve and change the totals `solarEnergy` derives from it
- Negative interpolation results are clamped, an empty slot stays empty

This is the narrow fix discussed in #23184. It does not resolve the underlying question of which provider reports means, point samples or energy, which #32114 addresses by changing the contract itself.

---
🤖 Made with [Claude Code](https://claude.com/claude-code)
