### PR TITLE
E3DC: scope session data request to wallbox index

### DIFF
--- a/charger/e3dc.go
+++ b/charger/e3dc.go
@@ -654,15 +654,23 @@ func (wb *E3dc) GetMaxCurrent() (float64, error) {
 }
 
 // getSessionData retrieves the session data container from WB_REQ_SESSION.
-// Returns all session-related messages (energy, time, RFID, etc.).
-// If no vehicle is connected, returns only WB_INDEX with no session data.
+// Returns all session-related messages (energy, time, RFID, etc.) of this wallbox.
+// If no vehicle is connected, the container is empty.
 func (wb *E3dc) getSessionData() ([]rscp.Message, error) {
-	res, err := wb.retrySend(*rscp.NewMessage(rscp.WB_REQ_SESSION, nil))
+	res, err := wb.retrySend(*rscp.NewMessage(rscp.WB_REQ_DATA, []rscp.Message{
+		*rscp.NewMessage(rscp.WB_INDEX, wb.id),
+		*rscp.NewMessage(rscp.WB_REQ_SESSION, nil),
+	}))
 	if err != nil {
 		return nil, err
 	}
 
-	return rscpContainer(*res, 1)
+	wbData, err := rscpContainer(*res, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	return rscpContainer(wbData[1], 0)
 }
 
 // sessionMessage finds a specific tag in the WB_SESSION response data.


### PR DESCRIPTION
fixes #32112

`getSessionData()` was the only request in `charger/e3dc.go` sent without `WB_INDEX` scoping, so charged energy, charge duration and RFID id were the same for every wallbox on the same E3DC system.

`WB_REQ_SESSION` (`0x0E00002C`) belongs to the tag family that go-rscp documents as *"Kann nur innerhalb eines REQ_WB_DATA Container verwendet werden!"* — its direct neighbour `WB_REQ_FIRMWARE_VERSION` (`0x0E00002F`) is already used nested inside `WB_REQ_DATA` here. The request is now wrapped accordingly and the `WB_SESSION` container is unwrapped from the `WB_DATA` reply.

Cannot be verified without a two-wallbox E3DC system — @maikheinrich, please test a nightly build once this is merged, or a build of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
