### PR TITLE
Optimizer: hide battery forecast when already full or empty

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -680,7 +680,8 @@ type batteryForecastSlot struct {
 // The Limit flag indicates whether the SOC reached the configured SMax (for
 // the highest point) or SMin (for the lowest point) boundary - in which case
 // the battery is forecasted to become fully charged or empty.
-// Returns nil for either point when no home battery is present.
+// Returns nil for either point when no home battery is present or when the
+// battery already is at the respective limit.
 func batteryForecastSocExtremes(req []optimizer.BatteryConfig, resp []optimizer.BatteryResult) (*batteryForecastSlot, *batteryForecastSlot) {
 	homeIndices := lo.FilterMap(req, func(b optimizer.BatteryConfig, i int) (int, bool) {
 		return i, b.SCapacity > 0
@@ -708,6 +709,14 @@ func batteryForecastSocExtremes(req []optimizer.BatteryConfig, resp []optimizer.
 		if low == nil || (!low.limit && (soc < low.soc || emptyReached)) {
 			low = &batteryForecastSlot{slot: i, soc: soc, limit: emptyReached}
 		}
+	}
+
+	// battery is already at the limit - announcing it will become full/empty is pointless
+	if high != nil && high.limit && high.slot == 0 {
+		high = nil
+	}
+	if low != nil && low.limit && low.slot == 0 {
+		low = nil
 	}
 
 	return high, low

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -132,9 +132,23 @@ func TestBatteryForecastSocExtremes(t *testing.T) {
 		{
 			"first slot at SMax wins for highest",
 			[]optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000}},
+			[][]float32{{500, 1000, 1000}},
+			&batteryForecastSlot{slot: 1, soc: 100, limit: true},
+			&batteryForecastSlot{slot: 0, soc: 50, limit: false},
+		},
+		{
+			"already full — no highest",
+			[]optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000}},
 			[][]float32{{1000, 1000, 500}},
-			&batteryForecastSlot{slot: 0, soc: 100, limit: true},
+			nil,
 			&batteryForecastSlot{slot: 2, soc: 50, limit: false},
+		},
+		{
+			"already empty — no lowest",
+			[]optimizer.BatteryConfig{{SCapacity: 1000, SMax: 1000, SMin: 100}},
+			[][]float32{{100, 100, 500}},
+			&batteryForecastSlot{slot: 2, soc: 50, limit: false},
+			nil,
 		},
 		{
 			"near SMax is not full",


### PR DESCRIPTION
When the battery already sits at its SMax (or SMin) in the current slot, the forecast announced "highest (full) today 15:45" although the battery was full at 15:41 already. Slot 0 is the current slot and its timestamp is rounded, so it can be up to 7:30 min in the future and survives the "hide past points" filter.

`batteryForecastSocExtremes` now drops the point when the limit is hit in slot 0 — there is nothing to announce if the battery is at the limit right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
