### PR TITLE
feat(homeassistant): add template-level status mapping for custom charging states

### DIFF
--- a/charger/homeassistant.go
+++ b/charger/homeassistant.go
@@ -116,7 +116,7 @@ var _ api.Charger = (*HomeAssistant)(nil)
 
 // Status implements the api.ChargeState interface
 func (c *HomeAssistant) Status() (api.ChargeStatus, error) {
-	return c.conn.GetChargeStatus(c.status)
+	return c.conn.GetChargeStatus(c.status, nil)
 }
 
 // Enabled implements the api.Charger interface

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -110,8 +110,8 @@ params:
     service: homeassistant/entities?uri={uri}&insecure={insecure}&domain=script,switch
     example: "script.vehicle_start_charge; switch.vehicle_charger"
     help:
-      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger). If a switch is provided, Service to stop charging must be left empty.
-      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger). Wenn ein Schalter angegeben wird, muss der Service zum Stoppen des Ladens leer bleiben.
+      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger). If a sw[...]
+      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger). [...]
   - name: stop_charging
     description:
       de: Service zum Laden stoppen
@@ -153,10 +153,9 @@ render: |
     soc: {{ .soc }}
     range: {{ .range }}
     status: {{ .status }}
-{{- if .statusMap }}
-    statusMap:
-{{ toYaml .statusMap | nindent 6 }}
-{{- end }}
+    {{- if .statusMap }}
+    statusMap: {{ toYaml .statusMap | nindent 8 }}
+    {{- end }}
     limitSoc: {{ .limitSoc }}
     odometer: {{ .odometer }}
     climater: {{ .climater }}

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -57,7 +57,7 @@ params:
   - name: statusMap
     description:
       de: Benutzerdefinierte Statuszuordnung
-      en: Custom mapping of charging status strings to EVCC states
+      en: Custom status mapping
     type: string
     default: "{}"
     example: |
@@ -65,8 +65,8 @@ params:
       charging_error: B
       instant_charging: C
     help:
-      en: Optional mapping of Home Assistant status strings to EVCC charge statuses A, B, or C. Values must be A, B, or C.
-      de: Optionale Zuordnung von Home Assistant-Statuswerten zu EVCC-Ladezuständen A, B oder C. Werte müssen A, B oder C sein.
+      en: Maps Home Assistant status strings to EVCC states A, B, or C. Values must be A, B, or C.
+      de: Ordnet Home Assistant-Statuswerte zu EVCC-Ladezuständen A, B oder C zu. Werte müssen A, B oder C sein.
   - name: limitSoc
     description:
       de: Ziel-Ladezustand [%]
@@ -110,8 +110,8 @@ params:
     service: homeassistant/entities?uri={uri}&insecure={insecure}&domain=script,switch
     example: "script.vehicle_start_charge; switch.vehicle_charger"
     help:
-      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger). If a sw[...]
-      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger). [...]
+      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger). If a switch is provided, Service to stop charging must be left empty.
+      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger). Wenn ein Schalter angegeben wird, muss der Service zum Stoppen des Ladens leer bleiben.
   - name: stop_charging
     description:
       de: Service zum Laden stoppen

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -54,6 +54,19 @@ params:
     help:
       en: Entity ID for charging status (A=disconnected, B=connected, C=charging)
       de: Entitäts-ID für Ladestatus (A=getrennt, B=verbunden, C=laden)
+  - name: statusMap
+    description:
+      de: Benutzerdefinierte Statuszuordnung
+      en: Custom mapping of charging status strings to EVCC states
+    type: string
+    default: "{}"
+    example: |
+      charging_stopped: B
+      charging_error: B
+      instant_charging: C
+    help:
+      en: Optional mapping of Home Assistant status strings to EVCC charge statuses A, B, or C. Values must be A, B, or C.
+      de: Optionale Zuordnung von Home Assistant-Statuswerten zu EVCC-Ladezuständen A, B oder C. Werte müssen A, B oder C sein.
   - name: limitSoc
     description:
       de: Ziel-Ladezustand [%]
@@ -140,6 +153,10 @@ render: |
     soc: {{ .soc }}
     range: {{ .range }}
     status: {{ .status }}
+{{- if .statusMap }}
+    statusMap:
+{{ toYaml .statusMap | nindent 6 }}
+{{- end }}
     limitSoc: {{ .limitSoc }}
     odometer: {{ .odometer }}
     climater: {{ .climater }}

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -219,8 +219,8 @@ func NormalizeChargeStatus(status string) (api.ChargeStatus, error) {
 	}
 }
 
-// NormalizeStatusMap validates and normalizes a statusMap, removing invalid entries and logging warnings.
-func NormalizeStatusMap(log *util.Logger, statusMap map[string]string) map[string]string {
+// NormalizeStatusMap validates and normalizes a statusMap for runtime lookup.
+func NormalizeStatusMap(statusMap map[string]string) map[string]string {
 	if len(statusMap) == 0 {
 		return nil
 	}
@@ -228,21 +228,15 @@ func NormalizeStatusMap(log *util.Logger, statusMap map[string]string) map[strin
 	normalized := make(map[string]string, len(statusMap))
 	for key, value := range statusMap {
 		trimmedKey := strings.TrimSpace(key)
+		trimmedValue := strings.TrimSpace(value)
 		if trimmedKey == "" {
-			if log != nil {
-				log.WARN.Printf("ignoring empty status map key")
-			}
+			continue
+		}
+		if _, err := NormalizeChargeStatus(trimmedValue); err != nil {
 			continue
 		}
 
-		if _, err := NormalizeChargeStatus(value); err != nil {
-			if log != nil {
-				log.WARN.Printf("invalid status mapping for %q: %q, falling back to global mapping", trimmedKey, value)
-			}
-			continue
-		}
-
-		normalized[strings.ToLower(trimmedKey)] = strings.ToUpper(strings.TrimSpace(value))
+		normalized[strings.ToLower(trimmedKey)] = strings.ToUpper(trimmedValue)
 	}
 
 	if len(normalized) == 0 {
@@ -260,7 +254,7 @@ func (c *Connection) GetChargeStatus(entity string, statusMap map[string]string)
 	}
 
 	normalizedState := strings.ToLower(strings.TrimSpace(state.State))
-	statusMap = NormalizeStatusMap(c.log, statusMap)
+	statusMap = NormalizeStatusMap(statusMap)
 	if statusMap != nil {
 		for key, value := range statusMap {
 			if strings.EqualFold(strings.TrimSpace(key), normalizedState) {

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -21,6 +21,7 @@ import (
 type Connection struct {
 	*request.Helper
 	instance *proxyInstance
+	log      *util.Logger
 }
 
 // NewConnection creates a new Home Assistant connection
@@ -41,6 +42,8 @@ func NewConnection(log *util.Logger, uri, home string, insecure bool) (*Connecti
 			insecure: insecure,
 		},
 	}
+
+	c.log = log
 
 	// override the transport to accept self-signed certificates
 	if insecure {
@@ -204,14 +207,69 @@ var chargeStatusMap = map[string]api.ChargeStatus{
 	"0":                   api.StatusA,
 }
 
+// NormalizeChargeStatus validates a charge status literal and returns its normalized form.
+func NormalizeChargeStatus(status string) (api.ChargeStatus, error) {
+	s := strings.ToUpper(strings.TrimSpace(status))
+
+	switch s {
+	case "A", "B", "C":
+		return api.ChargeStatus(s), nil
+	default:
+		return api.StatusNone, fmt.Errorf("invalid charge status mapping %q: must be one of A, B, C", status)
+	}
+}
+
+// NormalizeStatusMap validates and normalizes a statusMap, removing invalid entries and logging warnings.
+func NormalizeStatusMap(log *util.Logger, statusMap map[string]string) map[string]string {
+	if len(statusMap) == 0 {
+		return nil
+	}
+
+	normalized := make(map[string]string, len(statusMap))
+	for key, value := range statusMap {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			if log != nil {
+				log.WARN.Printf("ignoring empty status map key")
+			}
+			continue
+		}
+
+		if _, err := NormalizeChargeStatus(value); err != nil {
+			if log != nil {
+				log.WARN.Printf("invalid status mapping for %q: %q, falling back to global mapping", trimmedKey, value)
+			}
+			continue
+		}
+
+		normalized[strings.ToLower(trimmedKey)] = strings.ToUpper(strings.TrimSpace(value))
+	}
+
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	return normalized
+}
+
 // GetChargeStatus maps Home Assistant states to api.ChargeStatus
-func (c *Connection) GetChargeStatus(entity string) (api.ChargeStatus, error) {
+func (c *Connection) GetChargeStatus(entity string, statusMap map[string]string) (api.ChargeStatus, error) {
 	state, err := c.GetState(entity)
 	if err != nil {
 		return api.StatusNone, err
 	}
 
-	if status, ok := chargeStatusMap[strings.ToLower(strings.TrimSpace(state.State))]; ok {
+	normalizedState := strings.ToLower(strings.TrimSpace(state.State))
+	statusMap = NormalizeStatusMap(c.log, statusMap)
+	if statusMap != nil {
+		for key, value := range statusMap {
+			if strings.EqualFold(strings.TrimSpace(key), normalizedState) {
+				return api.ChargeStatus(value), nil
+			}
+		}
+	}
+
+	if status, ok := chargeStatusMap[normalizedState]; ok {
 		return status, nil
 	}
 

--- a/util/homeassistant/connection_test.go
+++ b/util/homeassistant/connection_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,46 @@ func TestCallSwitchService_DomainDispatch(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantPath, gotPath)
 			assert.Contains(t, gotBody, `"entity_id":"`+tc.entity+`"`)
+		})
+	}
+}
+
+func TestGetChargeStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     string
+		statusMap map[string]string
+		want      api.ChargeStatus
+		wantErr   string
+	}{
+		{"standard mapping", "charging", nil, api.StatusC, ""},
+		{"empty mapping falls back", "stopped", map[string]string{}, api.StatusB, ""},
+		{"custom mapping", "charging_stopped", map[string]string{"charging_stopped": "B", "instant_charging": "C"}, api.StatusB, ""},
+		{"case insensitive mapping", "Instant_Charging", map[string]string{"instant_charging": "C"}, api.StatusC, ""},
+		{"fallback to global map", "stopped", map[string]string{"charging_stopped": "B"}, api.StatusB, ""},
+		{"invalid mapping value falls back", "stopped", map[string]string{"charging_stopped": "D"}, api.StatusB, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/states/sensor.vehicle_status", r.URL.Path)
+				_, _ = io.WriteString(w, `{"state":"`+tc.state+`"}`)
+			}))
+			defer srv.Close()
+
+			conn := newTestConnection(srv.URL)
+			got, err := conn.GetChargeStatus("sensor.vehicle_status", tc.statusMap)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Equal(t, api.StatusNone, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/util/templates/funcmap.go
+++ b/util/templates/funcmap.go
@@ -44,6 +44,19 @@ func quote(value string) string {
 	return fmt.Sprintf("'%s'", quoted)
 }
 
+func toYaml(value any) string {
+	if value == nil {
+		return ""
+	}
+
+	b, err := yaml.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+
+	return strings.TrimSpace(string(b))
+}
+
 func trimLines(s string) string {
 	lines := strings.Split(s, "\n")
 	for i, line := range lines {
@@ -81,6 +94,7 @@ func FuncMap(tmpl *template.Template) *template.Template {
 		"urlEncode":       url.QueryEscape,
 		"unquote":         unquote,
 		"quote":           yamlQuote,
+		"toYaml":          toYaml,
 		"asDuration":      asDuration,
 		"durationSeconds": durationSeconds,
 	}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -378,6 +378,16 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 				res[out] = list
 			}
 
+		case map[string]string:
+			if res[out] == nil || len(typed) == 0 {
+				res[out] = typed
+			}
+
+		case map[string]any:
+			if res[out] == nil || len(typed) == 0 {
+				res[out] = typed
+			}
+
 		default:
 			if res[out] == nil || res[out].(string) == "" {
 				// prevent rendering nil interfaces as "<nil>" string

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -2,6 +2,7 @@ package vehicle
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -14,8 +15,9 @@ import (
 type HomeAssistant struct {
 	*embed
 	implement.Caps
-	conn *homeassistant.Connection
-	soc  string
+	conn      *homeassistant.Connection
+	soc       string
+	statusMap map[string]string
 }
 
 // Register on startup
@@ -24,14 +26,34 @@ func init() {
 }
 
 // Constructor from YAML config
+func validateStatusMap(statusMap map[string]string) (map[string]string, error) {
+	if len(statusMap) == 0 {
+		return nil, nil
+	}
+
+	for key, value := range statusMap {
+		trimmedKey := strings.TrimSpace(key)
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey == "" {
+			return nil, fmt.Errorf("contains an empty key")
+		}
+		if _, err := homeassistant.NormalizeChargeStatus(trimmedValue); err != nil {
+			return nil, fmt.Errorf("%q has invalid value %q: must be one of A, B, C", trimmedKey, trimmedValue)
+		}
+	}
+
+	return statusMap, nil
+}
+
 func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error) {
 	var cc struct {
 		embed                `mapstructure:",squash"`
 		homeassistant.Config `mapstructure:",squash"`
-		Sensors              struct {
+		Sensors struct {
 			Soc        string // required
 			Range      string // optional
 			Status     string // optional
+			StatusMap  map[string]string `mapstructure:"statusMap"` // optional
 			LimitSoc   string // optional
 			Odometer   string // optional
 			Climater   string // optional
@@ -49,6 +71,12 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		return nil, err
 	}
 
+	if cc.Sensors.StatusMap != nil {
+		if _, err := validateStatusMap(cc.Sensors.StatusMap); err != nil {
+			return nil, fmt.Errorf("sensors.statusMap: %w", err)
+		}
+	}
+
 	if cc.Sensors.Soc == "" {
 		return nil, errors.New("missing soc sensor")
 	}
@@ -60,11 +88,14 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		return nil, err
 	}
 
+	statusMap := homeassistant.NormalizeStatusMap(log, cc.Sensors.StatusMap)
+
 	res := &HomeAssistant{
-		embed: &cc.embed,
-		Caps:  implement.New(),
-		conn:  conn,
-		soc:   cc.Sensors.Soc,
+		embed:     &cc.embed,
+		Caps:      implement.New(),
+		conn:      conn,
+		soc:       cc.Sensors.Soc,
+		statusMap: statusMap,
 	}
 
 	if cc.Sensors.LimitSoc != "" {
@@ -74,7 +105,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		}))
 	}
 	if cc.Sensors.Status != "" {
-		implement.Has(res, implement.ChargeState(func() (api.ChargeStatus, error) { return conn.GetChargeStatus(cc.Sensors.Status) }))
+		implement.Has(res, implement.ChargeState(func() (api.ChargeStatus, error) { return conn.GetChargeStatus(cc.Sensors.Status, res.statusMap) }))
 	}
 	if cc.Sensors.Range != "" {
 		implement.Has(res, implement.VehicleRange(func() (int64, error) {

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -88,7 +88,7 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		return nil, err
 	}
 
-	statusMap := homeassistant.NormalizeStatusMap(log, cc.Sensors.StatusMap)
+	statusMap := homeassistant.NormalizeStatusMap(cc.Sensors.StatusMap)
 
 	res := &HomeAssistant{
 		embed:     &cc.embed,

--- a/vehicle/homeassistant_test.go
+++ b/vehicle/homeassistant_test.go
@@ -1,0 +1,37 @@
+package vehicle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateStatusMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		statusMap map[string]string
+		wantErr   string
+	}{
+		{"nil map", nil, ""},
+		{"empty map", map[string]string{}, ""},
+		{"valid map", map[string]string{"charging_stopped": "B", "instant_charging": "C"}, ""},
+		{"invalid value", map[string]string{"charging_stopped": "D"}, `"charging_stopped" has invalid value "D"`},
+		{"empty key", map[string]string{"": "B"}, "contains an empty key"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateStatusMap(tc.statusMap)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.statusMap, got)
+		})
+	}
+}


### PR DESCRIPTION
As #32115 turned out to not be scalable, here is a suggestion on how to solve it:

Adds support for template-level status mapping for Home Assistant vehicles. This allows custom charging state strings from vendor-specific integrations to be mapped to EVCC charge states without changing the shared Home Assistant status mapping.

The change introduces an optional statusMap configuration for Home Assistant vehicle templates, validates entries early, and keeps matching case-insensitive. Invalid custom mappings are rejected with clear configuration errors, while the existing global mapping remains the fallback for unconfigured states. The mapping is also rendered into generated configs so templates can use it directly.

Not quite sure how to present this in the UI, for the yaml an example could be:
```
vehicles:
  - name: macan
    type: template
    template: homeassistant
    status: sensor.macan_turbo_charging_status
    statusMap:
      charging_stopped: B
      charging_error: B
      instant_charging: C

```
