### PR TITLE
chore: add firmware requirements

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -9,9 +9,9 @@ covers: ["kostal-plenticore-hw0200", "kostal-plenticore"]
 caveats:
   - description:
       de: |
-        Nur ein System kann und darf auf den Wechselrichter zugreifen!
+        Nur ein System kann und darf auf den Wechselrichter zugreifen! Plenticore G1 erfordert mindestens Firmware UI 01.16.05025 (04.11.2020, MC >=01.44). 
       en: |
-        Only a single system may access the inverter!
+        Only a single system may access the inverter! Plenticore G1 requires at least firmware UI 01.16.05025 (04.11.2020, MC >=01.44).
     link: https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore
 requirements:
   description:

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -9,7 +9,7 @@ covers: ["kostal-plenticore-hw0200", "kostal-plenticore"]
 caveats:
   - description:
       de: |
-        Nur ein System kann und darf auf den Wechselrichter zugreifen! Plenticore G1 erfordert mindestens Firmware UI 01.16.05025 (04.11.2020, MC >=01.44). 
+        Nur ein System kann und darf auf den Wechselrichter zugreifen! Plenticore G1 erfordert mindestens Firmware UI 01.16.05025 (04.11.2020, MC >=01.44).
       en: |
         Only a single system may access the inverter! Plenticore G1 requires at least firmware UI 01.16.05025 (04.11.2020, MC >=01.44).
     link: https://github.com/evcc-io/evcc/wiki/Kostal-Plenticore


### PR DESCRIPTION
## Description

Updated the `kostal-plenticore-gen2` template caveats to document the minimum firmware requirement for feed-in curtailment (SunSpec model 123) on Plenticore G1 devices.

## Background

Users on older G1 firmware reported `curtail: sunspec model not found: [{123 0 WMaxLimPct}]` errors (see [discussion #32122](https://github.com/evcc-io/evcc/discussions/32122#discussioncomment-17771160)). Cross-referencing the Kostal Modbus/SunSpec interface documentation and release notes, support for model 123 is confirmed from UI 01.16.05025 (2020-11-04) onward; earlier versions are unverified.

## Changes

- Added a caveat noting the minimum G1 firmware version for feed-in curtailment support.
- No functional/code changes.