### PR TITLE
Home Assistant: configurable charge status values (BC)

### DIFF
--- a/charger/homeassistant.go
+++ b/charger/homeassistant.go
@@ -16,6 +16,7 @@ type HomeAssistant struct {
 	implement.Caps
 	conn       *homeassistant.Connection
 	status     string
+	states     homeassistant.StatusMap
 	enabled    string
 	enable     string
 	maxcurrent string
@@ -30,6 +31,9 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 	var cc struct {
 		homeassistant.Config `mapstructure:",squash"`
 		Status               string   // required - sensor for charge status
+		StatusA              string   // optional - custom states mapped to status A
+		StatusB              string   // optional - custom states mapped to status B
+		StatusC              string   // optional - custom states mapped to status C
 		Enabled              string   // required - sensor for enabled state
 		Enable               string   // required - switch/input_boolean for enable/disable
 		MaxCurrent           string   // required - number entity for setting max current
@@ -57,6 +61,11 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 		return nil, errors.New("missing maxcurrent number entity")
 	}
 
+	states, err := homeassistant.NewStatusMap(cc.StatusA, cc.StatusB, cc.StatusC)
+	if err != nil {
+		return nil, err
+	}
+
 	log := util.NewLogger("ha-charger")
 
 	conn, err := cc.Config.NewConnection(log)
@@ -68,6 +77,7 @@ func NewHomeAssistantFromConfig(other map[string]any) (api.Charger, error) {
 		Caps:       implement.New(),
 		conn:       conn,
 		status:     cc.Status,
+		states:     states,
 		enabled:    cc.Enabled,
 		enable:     cc.Enable,
 		maxcurrent: cc.MaxCurrent,
@@ -116,7 +126,7 @@ var _ api.Charger = (*HomeAssistant)(nil)
 
 // Status implements the api.ChargeState interface
 func (c *HomeAssistant) Status() (api.ChargeStatus, error) {
-	return c.conn.GetChargeStatus(c.status)
+	return c.conn.GetChargeStatus(c.status, c.states)
 }
 
 // Enabled implements the api.Charger interface

--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -34,6 +34,33 @@ params:
     help:
       en: Entity ID for charging status (A=ready, B=connected, C=charging)
       de: Entitäts-ID für Ladestatus (A=bereit, B=verbunden, C=laden)
+  - name: statusA
+    description:
+      de: Zustände für Status A
+      en: States for status A
+    example: not_plugged, disconnected
+    advanced: true
+    help:
+      en: Comma-separated list of additional states meaning ready
+      de: Komma-getrennte Liste zusätzlicher Zustände für bereit
+  - name: statusB
+    description:
+      de: Zustände für Status B
+      en: States for status B
+    example: charging_stopped, charging_completed
+    advanced: true
+    help:
+      en: Comma-separated list of additional states meaning connected
+      de: Komma-getrennte Liste zusätzlicher Zustände für verbunden
+  - name: statusC
+    description:
+      de: Zustände für Status C
+      en: States for status C
+    example: instant_charging, fast_charging
+    advanced: true
+    help:
+      en: Comma-separated list of additional states meaning charging
+      de: Komma-getrennte Liste zusätzlicher Zustände für laden
   - name: enabled
     description:
       de: Aktivierungsstatus-Sensor
@@ -165,6 +192,9 @@ render: |
   uri: {{ .uri }}
   insecure: {{ .insecure }}
   status: {{ .status }}
+  statusA: {{ .statusA }}
+  statusB: {{ .statusB }}
+  statusC: {{ .statusC }}
   enabled: {{ .enabled }}
   enable: {{ .enable }}
   maxcurrent: {{ .setMaxCurrent }}

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -54,6 +54,33 @@ params:
     help:
       en: Entity ID for charging status (A=disconnected, B=connected, C=charging)
       de: Entitäts-ID für Ladestatus (A=getrennt, B=verbunden, C=laden)
+  - name: statusA
+    description:
+      de: Zustände für Status A
+      en: States for status A
+    example: not_plugged, disconnected
+    advanced: true
+    help:
+      en: Comma-separated list of additional states meaning disconnected
+      de: Komma-getrennte Liste zusätzlicher Zustände für getrennt
+  - name: statusB
+    description:
+      de: Zustände für Status B
+      en: States for status B
+    example: charging_stopped, charging_completed
+    advanced: true
+    help:
+      en: Comma-separated list of additional states meaning connected
+      de: Komma-getrennte Liste zusätzlicher Zustände für verbunden
+  - name: statusC
+    description:
+      de: Zustände für Status C
+      en: States for status C
+    example: instant_charging, fast_charging
+    advanced: true
+    help:
+      en: Comma-separated list of additional states meaning charging
+      de: Komma-getrennte Liste zusätzlicher Zustände für laden
   - name: limitSoc
     description:
       de: Ziel-Ladezustand [%]
@@ -144,6 +171,9 @@ render: |
     odometer: {{ .odometer }}
     climater: {{ .climater }}
     finishTime: {{ .finishTime }}
+  statusA: {{ .statusA }}
+  statusB: {{ .statusB }}
+  statusC: {{ .statusC }}
   services:
     start_charging: {{ .start_charging }}
     stop_charging: {{ .stop_charging }}

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -167,55 +167,63 @@ func (c *Connection) GetTimeState(entity string) (time.Time, error) {
 	return time.Parse(time.RFC3339, state.State)
 }
 
-// chargeStatusMap maps Home Assistant states to EVCC charge status
+// chargeStatusMap maps unambiguous Home Assistant states to evcc charge status.
+// Vendor-specific states are configured per device, see NewStatusMap.
 var chargeStatusMap = map[string]api.ChargeStatus{
-	// Status C - Charging
-	"c":        api.StatusC,
-	"charging": api.StatusC,
-	"on":       api.StatusC,
-	"true":     api.StatusC,
-	"active":   api.StatusC,
-	"1":        api.StatusC,
-
-	// Status B - Connected/Ready
-	"b":                  api.StatusB,
-	"connected":          api.StatusB,
-	"ready":              api.StatusB,
-	"plugged":            api.StatusB,
-	"charging_completed": api.StatusB,
-	"initialising":       api.StatusB,
-	"preparing":          api.StatusB,
-	"2":                  api.StatusB,
-	"no_power":           api.StatusB,
-	"complete":           api.StatusB,
-	"stopped":            api.StatusB,
-	"starting":           api.StatusB,
-	"paused":             api.StatusB,
-
-	// Status A - Disconnected
-	"a":                   api.StatusA,
-	"disconnected":        api.StatusA,
-	"off":                 api.StatusA,
-	"none":                api.StatusA,
-	"unavailable":         api.StatusA,
-	"unknown":             api.StatusA,
-	"notreadyforcharging": api.StatusA,
-	"not_plugged":         api.StatusA,
-	"0":                   api.StatusA,
+	"a":            api.StatusA,
+	"disconnected": api.StatusA,
+	"b":            api.StatusB,
+	"connected":    api.StatusB,
+	"c":            api.StatusC,
+	"charging":     api.StatusC,
 }
 
-// GetChargeStatus maps Home Assistant states to api.ChargeStatus
-func (c *Connection) GetChargeStatus(entity string) (api.ChargeStatus, error) {
+// StatusMap maps device-specific Home Assistant states to evcc charge status
+type StatusMap map[string]api.ChargeStatus
+
+// NewStatusMap creates a status map from comma-separated, case-insensitive lists of states
+func NewStatusMap(a, b, c string) (StatusMap, error) {
+	res := make(StatusMap)
+
+	for _, e := range []struct {
+		status api.ChargeStatus
+		states string
+	}{
+		{api.StatusA, a},
+		{api.StatusB, b},
+		{api.StatusC, c},
+	} {
+		for _, s := range strings.Split(e.states, ",") {
+			if s = strings.ToLower(strings.TrimSpace(s)); s != "" {
+				if status, ok := res[s]; ok {
+					return nil, fmt.Errorf("status %s: duplicate state '%s', already mapped to %s", e.status, s, status)
+				}
+				res[s] = e.status
+			}
+		}
+	}
+
+	return res, nil
+}
+
+// GetChargeStatus maps Home Assistant states to api.ChargeStatus. States from
+// the device-specific status map take precedence over the built-in mapping.
+func (c *Connection) GetChargeStatus(entity string, states StatusMap) (api.ChargeStatus, error) {
 	state, err := c.GetState(entity)
 	if err != nil {
 		return api.StatusNone, err
 	}
 
-	if status, ok := chargeStatusMap[strings.ToLower(strings.TrimSpace(state.State))]; ok {
+	s := strings.ToLower(strings.TrimSpace(state.State))
+
+	if status, ok := states[s]; ok {
+		return status, nil
+	}
+	if status, ok := chargeStatusMap[s]; ok {
 		return status, nil
 	}
 
-	return api.StatusNone, fmt.Errorf("unknown charge status: %s", state)
+	return api.StatusNone, fmt.Errorf("unknown charge status '%s' for entity %s", state.State, entity)
 }
 
 // CallService calls a Home Assistant service

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -188,7 +188,9 @@ var chargeStatusMap = map[string]api.ChargeStatus{
 // StatusMap maps device-specific Home Assistant states to evcc charge status
 type StatusMap map[string]api.ChargeStatus
 
-// NewStatusMap creates a status map from comma-separated, case-insensitive lists of states
+// NewStatusMap creates a status map from comma-separated, case-insensitive lists
+// of states. It extends the built-in mapping, overriding it only for states
+// explicitly mapped to a different status.
 func NewStatusMap(a, b, c string) (StatusMap, error) {
 	res := make(StatusMap)
 
@@ -213,8 +215,8 @@ func NewStatusMap(a, b, c string) (StatusMap, error) {
 	return res, nil
 }
 
-// GetChargeStatus maps Home Assistant states to api.ChargeStatus. States from
-// the device-specific status map take precedence over the built-in mapping.
+// GetChargeStatus maps Home Assistant states to api.ChargeStatus. The
+// device-specific status map extends the built-in mapping and takes precedence.
 func (c *Connection) GetChargeStatus(entity string, states StatusMap) (api.ChargeStatus, error) {
 	state, err := c.GetState(entity)
 	if err != nil {

--- a/util/homeassistant/connection.go
+++ b/util/homeassistant/connection.go
@@ -170,12 +170,19 @@ func (c *Connection) GetTimeState(entity string) (time.Time, error) {
 // chargeStatusMap maps unambiguous Home Assistant states to evcc charge status.
 // Vendor-specific states are configured per device, see NewStatusMap.
 var chargeStatusMap = map[string]api.ChargeStatus{
-	"a":            api.StatusA,
-	"disconnected": api.StatusA,
-	"b":            api.StatusB,
-	"connected":    api.StatusB,
-	"c":            api.StatusC,
-	"charging":     api.StatusC,
+	"a":                  api.StatusA,
+	"disconnected":       api.StatusA,
+	"not_plugged":        api.StatusA,
+	"b":                  api.StatusB,
+	"connected":          api.StatusB,
+	"plugged":            api.StatusB,
+	"starting":           api.StatusB,
+	"stopped":            api.StatusB,
+	"paused":             api.StatusB,
+	"complete":           api.StatusB,
+	"charging_completed": api.StatusB,
+	"c":                  api.StatusC,
+	"charging":           api.StatusC,
 }
 
 // StatusMap maps device-specific Home Assistant states to evcc charge status

--- a/util/homeassistant/connection_test.go
+++ b/util/homeassistant/connection_test.go
@@ -1,11 +1,13 @@
 package homeassistant
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +19,47 @@ func newTestConnection(baseURL string) *Connection {
 		Helper:   request.NewHelper(util.NewLogger("test")),
 		instance: &proxyInstance{uri: baseURL},
 	}
+}
+
+func TestGetChargeStatus(t *testing.T) {
+	states, err := NewStatusMap("not_plugged", "Charging_Stopped, charging_error", "instant_charging")
+	require.NoError(t, err)
+
+	tests := []struct {
+		state string
+		want  api.ChargeStatus
+	}{
+		{"A", api.StatusA},
+		{"connected", api.StatusB},
+		{" charging ", api.StatusC},
+		{"not_plugged", api.StatusA},
+		{"CHARGING_STOPPED", api.StatusB},
+		{"charging_error", api.StatusB},
+		{"instant_charging", api.StatusC},
+		{"paused", api.StatusNone}, // no longer built-in
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.state, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, `{"entity_id":"sensor.foo","state":%q}`, tc.state)
+			}))
+			defer srv.Close()
+
+			status, err := newTestConnection(srv.URL).GetChargeStatus("sensor.foo", states)
+			assert.Equal(t, tc.want, status)
+			if tc.want == api.StatusNone {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewStatusMapDuplicate(t *testing.T) {
+	_, err := NewStatusMap("foo", "foo", "")
+	assert.Error(t, err)
 }
 
 // TestCallSwitchService_DomainDispatch verifies that CallSwitchService picks

--- a/util/homeassistant/connection_test.go
+++ b/util/homeassistant/connection_test.go
@@ -36,7 +36,8 @@ func TestGetChargeStatus(t *testing.T) {
 		{"CHARGING_STOPPED", api.StatusB},
 		{"charging_error", api.StatusB},
 		{"instant_charging", api.StatusC},
-		{"paused", api.StatusNone}, // no longer built-in
+		{"paused", api.StatusB},
+		{"preparing", api.StatusNone}, // no longer built-in
 	}
 
 	for _, tc := range tests {

--- a/util/homeassistant/connection_test.go
+++ b/util/homeassistant/connection_test.go
@@ -55,7 +55,7 @@ func TestGetChargeStatus(t *testing.T) {
 			status, err := newStateConnection(t, tc.state).GetChargeStatus("sensor.foo", states)
 			assert.Equal(t, tc.want, status)
 			if tc.want == api.StatusNone {
-				assert.Error(t, err)
+				assert.ErrorContains(t, err, "unknown charge status '"+tc.state+"' for entity sensor.foo")
 			} else {
 				assert.NoError(t, err)
 			}

--- a/util/homeassistant/connection_test.go
+++ b/util/homeassistant/connection_test.go
@@ -21,6 +21,16 @@ func newTestConnection(baseURL string) *Connection {
 	}
 }
 
+// newStateConnection returns a connection serving state for any entity
+func newStateConnection(t *testing.T, state string) *Connection {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"entity_id":"sensor.foo","state":%q}`, state)
+	}))
+	t.Cleanup(srv.Close)
+
+	return newTestConnection(srv.URL)
+}
+
 func TestGetChargeStatus(t *testing.T) {
 	states, err := NewStatusMap("not_plugged", "Charging_Stopped, charging_error", "instant_charging")
 	require.NoError(t, err)
@@ -42,12 +52,7 @@ func TestGetChargeStatus(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.state, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprintf(w, `{"entity_id":"sensor.foo","state":%q}`, tc.state)
-			}))
-			defer srv.Close()
-
-			status, err := newTestConnection(srv.URL).GetChargeStatus("sensor.foo", states)
+			status, err := newStateConnection(t, tc.state).GetChargeStatus("sensor.foo", states)
 			assert.Equal(t, tc.want, status)
 			if tc.want == api.StatusNone {
 				assert.Error(t, err)
@@ -61,6 +66,31 @@ func TestGetChargeStatus(t *testing.T) {
 func TestNewStatusMapDuplicate(t *testing.T) {
 	_, err := NewStatusMap("foo", "foo", "")
 	assert.Error(t, err)
+}
+
+// TestStatusMapExtendsBuiltin verifies that configured states extend the
+// built-in mapping and only override the states they explicitly redefine.
+func TestStatusMapExtendsBuiltin(t *testing.T) {
+	states, err := NewStatusMap("", "charging", "instant_charging")
+	require.NoError(t, err)
+
+	tests := []struct {
+		state string
+		want  api.ChargeStatus
+	}{
+		{"charging", api.StatusB},         // redefined
+		{"paused", api.StatusB},           // built-in, untouched
+		{"c", api.StatusC},                // built-in, untouched
+		{"instant_charging", api.StatusC}, // added
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.state, func(t *testing.T) {
+			status, err := newStateConnection(t, tc.state).GetChargeStatus("sensor.foo", states)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, status)
+		})
+	}
 }
 
 // TestCallSwitchService_DomainDispatch verifies that CallSwitchService picks

--- a/vehicle/homeassistant.go
+++ b/vehicle/homeassistant.go
@@ -37,6 +37,9 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 			Climater   string // optional
 			FinishTime string // optional
 		}
+		StatusA  string // optional - custom states mapped to status A
+		StatusB  string // optional - custom states mapped to status B
+		StatusC  string // optional - custom states mapped to status C
 		Services struct {
 			Start         string `mapstructure:"start_charging"` // script.* or switch.* optional
 			Stop          string `mapstructure:"stop_charging"`  // script.* optional
@@ -74,7 +77,12 @@ func NewHomeAssistantVehicleFromConfig(other map[string]any) (api.Vehicle, error
 		}))
 	}
 	if cc.Sensors.Status != "" {
-		implement.Has(res, implement.ChargeState(func() (api.ChargeStatus, error) { return conn.GetChargeStatus(cc.Sensors.Status) }))
+		states, err := homeassistant.NewStatusMap(cc.StatusA, cc.StatusB, cc.StatusC)
+		if err != nil {
+			return nil, err
+		}
+
+		implement.Has(res, implement.ChargeState(func() (api.ChargeStatus, error) { return conn.GetChargeStatus(cc.Sensors.Status, states) }))
 	}
 	if cc.Sensors.Range != "" {
 		implement.Has(res, implement.VehicleRange(func() (int64, error) {


### PR DESCRIPTION
Replaces #32115.

Instead of growing the built-in Home Assistant charge status mapping with every vendor's wording, the mapping keeps only the states whose meaning is unambiguous and vendor-specific states become a per-device config option.

**Built-in mapping** (`util/homeassistant`):

| Status | States |
| --- | --- |
| A | `a`, `disconnected`, `not_plugged` |
| B | `b`, `connected`, `plugged`, `starting`, `stopped`, `paused`, `complete`, `charging_completed` |
| C | `c`, `charging` |

Removed (BC): `on`, `true`, `active`, `1`, `2`, `0`, `off`, `none`, `ready`, `initialising`, `preparing`, `no_power`, `notreadyforcharging`. `unknown`/`unavailable` were dead entries since `GetState` already returns `api.ErrNotAvailable` for them.

**New per-device option** for charger and vehicle, comma-separated and case-insensitive. It extends the built-in mapping and overrides it only for the states it explicitly redefines:

```yaml
type: homeassistant
status: sensor.porsche_charging_state
statusB: charging_stopped, charging_error
statusC: instant_charging
```

Templates get `statusA`/`statusB`/`statusC` as advanced params. Duplicate states across the three lists are rejected at config time, and an unmapped state now reports the raw value and entity so users know what to put into the lists.

One thing to decide: since `on`/`off`/`true`/`false`/`1`/`0` are gone, a `binary_sensor` used as status entity now needs `statusA: off` + `statusC: on`. The charger template still offers `binary_sensor` in the status entity picker. Happy to keep `on`/`off` built-in if that is too sharp an edge.

ioBroker is not affected: its charger template renders a `custom` charger, so status goes through `api.ChargeStatusString` and only ever accepted A/B/C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
