### PR TITLE
UI: fix missing general config tiles with battery configured

### DIFF
--- a/assets/js/components/Config/GeneralConfig.vue
+++ b/assets/js/components/Config/GeneralConfig.vue
@@ -104,7 +104,7 @@ export default {
 			return store.state?.telemetry === true;
 		},
 		batteryControllable() {
-			return (store.state?.battery ?? []).some((b) => b.controllable);
+			return (store.state?.battery?.devices ?? []).some((b) => b.controllable);
 		},
 		batteryGridDischarge() {
 			return store.state?.batteryGridDischarge === true;


### PR DESCRIPTION
fixes #32113

`batteryControllable` in `GeneralConfig.vue` treated `state.battery` as an array, but it is a `BatteryState` object whose meters live in `devices`. With a battery configured the computed threw `TypeError: (...).some is not a function`, which aborted rendering of the whole general settings group, so Control, Currency and the other tiles below disappeared. Without a battery `state.battery` is null and the `?? []` fallback hid the bug.

- read `state.battery?.devices` instead of `state.battery`
- regression from #32086; only the battery grid discharge entry used this shape

`GeneralConfig.vue` is a plain JS component, so `vue-tsc` could not catch the mismatch against the `Battery` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
