### PR TITLE
EEBus: accept an inactive §14a limit without a value

### DIFF
--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -105,6 +105,9 @@ func TestOHPCF_LPC_Dimmed(t *testing.T) {
 		{"active_positive", ucapi.LoadLimit{IsActive: true, Value: 4000}, true},
 		{"active_zero", ucapi.LoadLimit{IsActive: true, Value: 0}, true},
 		{"inactive", ucapi.LoadLimit{IsActive: false, Value: 4000}, false},
+		// a heat pump that is not being limited reports the limit as inactive without
+		// stating a value (#32125); that is a valid answer, not missing data
+		{"inactive_without_value", ucapi.LoadLimit{IsActive: false, IsChangeable: true}, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, lpc, entity := newOHPCFEGCharger(t)

--- a/go.mod
+++ b/go.mod
@@ -269,3 +269,5 @@ replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165
 replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20251212212612-b7f92ee0443b
 
 replace github.com/enbility/spine-go => github.com/andig/spine-go v0.7.1-0.20260725155511-6f83690e6238
+
+replace github.com/enbility/eebus-go => github.com/andig/eebus-go v0.0.0-20260725155950-e735091ff165

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/WulfgarW/sensonet v0.0.7 h1:WkrZF7UNoQVyQIvpaUPqZfKTvHfFXTRmSF/zMQKJo+Q=
 github.com/WulfgarW/sensonet v0.0.7/go.mod h1:GNOik1nTPswwtZ4bLpIRglEn9dNgEG79iOhVUq4IKgA=
+github.com/andig/eebus-go v0.0.0-20260725155950-e735091ff165 h1:mgx3N1XD29NtCtvbm1CEMJpz8lBUgMiSdH0Ku72pDP4=
+github.com/andig/eebus-go v0.0.0-20260725155950-e735091ff165/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
 github.com/andig/go-powerwall v0.3.0 h1:6g50+8xEwxrnzoSaPsxNRpc2fld8gARk0X78NEexFGI=
 github.com/andig/go-powerwall v0.3.0/go.mod h1:Xk09mD+7RTCuuHMX5RxlqgEUeh9oZdIX0rL0qiY6l/4=
 github.com/andig/gosunspec v0.0.0-20260705113727-6d585e133512 h1:1y8dS4GaBB9WUu/r8rInTaxdZhHG5GuwOfllzDAZXL8=
@@ -138,8 +140,6 @@ github.com/eclipse/paho.golang v0.23.0 h1:KHgl2wz6EJo7cMBmkuhpt7C576vP+kpPv7jjvS
 github.com/eclipse/paho.golang v0.23.0/go.mod h1:nQRhTkoZv8EAiNs5UU0/WdQIx2NrnWUpL9nsGJTQN04=
 github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2ISgCl2W7nE=
 github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
-github.com/enbility/eebus-go v0.7.1-0.20260720111250-363db3c5c262 h1:E95yAg0mxQSQ6qfSm2GGObz0DfhZKUqiHoO5tvuHPgg=
-github.com/enbility/eebus-go v0.7.1-0.20260720111250-363db3c5c262/go.mod h1:L1nBEy/dBASQRoz/9JF7KEmqFdnXHLbZqDpxiA0ezr4=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a h1:foChWb8lhzqa6lWDRs6COYMdp649YlUirFP8GqoT0JQ=
 github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a/go.mod h1:H64mhYcAQUGUUnVqMdZQf93kPecH4M79xwH95Lddt3U=
 github.com/enbility/ship-go v0.6.1-0.20260720110450-0aa90f64ac76 h1:gDrV6vBG3luAgsyX4sXYShITT41CDKXrtyluLeRmglE=


### PR DESCRIPTION
Addresses the `dimmed: not available` half of #32125.

A Wolf Link heat pump announces `limitationOfPowerConsumption` with `scenarioSupport [1,2,3,4]` and answers the limit read with

```json
{"loadControlLimitData":[[{"limitId":1},{"isLimitChangeable":true},{"isLimitActive":false}]]}
```

No limit is in effect, so no value is stated. eebus-go discarded the whole structure on the missing value and returned `ErrDataNotAvailable`, which `Dimmed()` maps to `api.ErrNotAvailable` — so evcc could not tell "no §14a limit active" from "no data at all", and the loadpoint aborted every update cycle.

Fixed upstream in https://github.com/enbility/eebus-go/pull/255: an inactive limit may omit its value, an active one may not. Same change in `eg/lpc`, `eg/lpp`, `cs/lpc` and `cs/lpp`. Until that is merged the module points at the branch via `replace`.

This is the root cause behind #32126, which suppressed the error in `Loadpoint.Update()` instead.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
