### PR TITLE
Tariff: keep fixed tariff rates ordered when chargesZones markers are combined

### DIFF
--- a/tariff/fixed/zone.go
+++ b/tariff/fixed/zone.go
@@ -106,7 +106,8 @@ func (r Zones) TimeTableMarkers() []HourMin {
 
 	// 1hr intervals
 	for hour := range 24 {
-		if hm := (HourMin{Hour: hour}); !slices.Contains(res, hm) {
+		hm := HourMin{Hour: hour}
+		if !slices.Contains(res, hm) {
 			res = append(res, hm)
 		}
 	}

--- a/tariff/fixed/zone.go
+++ b/tariff/fixed/zone.go
@@ -104,25 +104,17 @@ func (r Zones) TimeTableMarkers() []HourMin {
 		}
 	}
 
-HOURS:
 	// 1hr intervals
 	for hour := range 24 {
-		for _, m := range res {
-			if m.Hour == hour && m.Min == 0 {
-				continue HOURS
-			}
+		if hm := (HourMin{Hour: hour}); !slices.Contains(res, hm) {
+			res = append(res, hm)
 		}
-
-		// hour is missing
-		for i, m := range res {
-			if m.Hour >= hour {
-				res = slices.Insert(res, i, HourMin{Hour: hour, Min: 0})
-				continue HOURS
-			}
-		}
-
-		res = append(res, HourMin{Hour: hour, Min: 0})
 	}
+
+	// zones may be unsorted, e.g. when price and charges zones are combined
+	slices.SortFunc(res, func(i, j HourMin) int {
+		return i.Minutes() - j.Minutes()
+	})
 
 	return res
 }

--- a/tariff/fixed/zone_test.go
+++ b/tariff/fixed/zone_test.go
@@ -81,3 +81,24 @@ func TestZonesTimeTableMarkers(t *testing.T) {
 
 	assert.Equal(t, expect, zones.TimeTableMarkers())
 }
+
+func TestZonesTimeTableMarkersUnsorted(t *testing.T) {
+	// price and charges zones are concatenated unsorted, see Fixed.Rates
+	zones := Zones{
+		{Hours: TimeRange{
+			From: HourMin{12, 0},
+			To:   HourMin{14, 0},
+		}},
+		{Hours: TimeRange{
+			From: HourMin{0, 0},
+			To:   HourMin{5, 30},
+		}},
+	}
+
+	expect := []HourMin{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {5, 30}}
+	for hour := 6; hour < 24; hour++ {
+		expect = append(expect, HourMin{hour, 0})
+	}
+
+	assert.Equal(t, expect, zones.TimeTableMarkers())
+}

--- a/tariff/fixed/zone_test.go
+++ b/tariff/fixed/zone_test.go
@@ -90,6 +90,14 @@ func TestZonesTimeTableMarkersUnsorted(t *testing.T) {
 			To:   HourMin{14, 0},
 		}},
 		{Hours: TimeRange{
+			From: HourMin{10, 15}, // minutes must not sort before the earlier hour's 9:45
+			To:   HourMin{11, 0},
+		}},
+		{Hours: TimeRange{
+			From: HourMin{9, 45},
+			To:   HourMin{10, 0},
+		}},
+		{Hours: TimeRange{
 			From: HourMin{0, 0},
 			To:   HourMin{5, 30},
 		}},
@@ -98,6 +106,12 @@ func TestZonesTimeTableMarkersUnsorted(t *testing.T) {
 	expect := []HourMin{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {5, 30}}
 	for hour := 6; hour < 24; hour++ {
 		expect = append(expect, HourMin{hour, 0})
+		switch hour {
+		case 9:
+			expect = append(expect, HourMin{9, 45})
+		case 10:
+			expect = append(expect, HourMin{10, 15})
+		}
 	}
 
 	assert.Equal(t, expect, zones.TimeTableMarkers())

--- a/tariff/fixed_test.go
+++ b/tariff/fixed_test.go
@@ -133,3 +133,36 @@ func TestFixedChargesZonesMarkers(t *testing.T) {
 	assert.Equal(t, dayStart.Add(5*time.Hour+30*time.Minute), rates[6].Start)
 	assert.Equal(t, 0.5, rates[6].Value)
 }
+
+func TestFixedChargesZonesOrder(t *testing.T) {
+	at, err := NewFixedFromConfig(map[string]any{
+		"price": 0.5,
+		"zones": []struct {
+			Price float64
+			Hours string
+		}{
+			{0.2, "12-14"},
+		},
+		"chargesZones": []struct {
+			Charges float64
+			Hours   string
+		}{
+			{0.1, "0-5:30"},
+		},
+	})
+	require.NoError(t, err)
+
+	tf := at.(*Fixed)
+	tf.clock = clock.NewMock()
+
+	rates, err := tf.Rates()
+	require.NoError(t, err)
+
+	// rates must stay ordered and contiguous even if charges zone markers don't align with price zones
+	for i, r := range rates {
+		require.True(t, r.End.After(r.Start), "invalid rate %d: %v", i, r)
+		if i > 0 {
+			require.Equal(t, rates[i-1].End, r.Start, "non-contiguous rate %d: %v", i, r)
+		}
+	}
+}


### PR DESCRIPTION
fixes #32142

Follow-up to #32143: `Fixed.Rates()` concatenates the price zones with the charges zones before calling `TimeTableMarkers()`. That combined slice is unsorted, and `TimeTableMarkers()` relied on ascending input — it inserted the missing full-hour markers at the first position with `Hour >= hour`. With a charges-zone marker sitting behind a later price-zone marker (e.g. `chargesZones` `00:00-05:30` plus a price zone `12-14`), the marker list ended up out of order, producing overlapping rates and a second series jumping back to `05:30`.

The marker list is now sorted by minutes before being returned, which also lets the full-hour fill loop drop its position-search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)