### PR TITLE
E3DC: address session data request per wallbox index

### DIFF
--- a/charger/e3dc.go
+++ b/charger/e3dc.go
@@ -657,10 +657,9 @@ func (wb *E3dc) GetMaxCurrent() (float64, error) {
 // Returns all session-related messages (energy, time, RFID, etc.).
 // If no vehicle is connected, returns only WB_INDEX with no session data.
 //
-// The unscoped request always answers for wallbox 0, so this tries to pass the
-// wallbox index as payload first and falls back to the unscoped request.
-// WB_REQ_SESSION has no entry in go-rscp's datatype table, hence the explicit
-// message (https://github.com/evcc-io/evcc/issues/32112).
+// The request carries the wallbox index as payload- an unscoped request is always
+// answered for wallbox 0. WB_REQ_SESSION has no entry in go-rscp's datatype table,
+// hence the explicit message.
 func (wb *E3dc) getSessionData() ([]rscp.Message, error) {
 	res, err := wb.retrySend(rscp.Message{
 		Tag:      rscp.WB_REQ_SESSION,
@@ -668,18 +667,16 @@ func (wb *E3dc) getSessionData() ([]rscp.Message, error) {
 		Value:    wb.id,
 	})
 	if err == nil {
-		wb.log.DEBUG.Printf("session %d indexed: %v", wb.id, *res)
 		err = rscpError(*res)
 	}
 
+	// fall back to the unscoped request if the device rejects the index
 	if err != nil {
-		wb.log.DEBUG.Printf("session %d indexed failed: %v", wb.id, err)
+		wb.log.DEBUG.Printf("indexed session request failed: %v", err)
 
 		if res, err = wb.retrySend(*rscp.NewMessage(rscp.WB_REQ_SESSION, nil)); err != nil {
 			return nil, err
 		}
-
-		wb.log.DEBUG.Printf("session %d unscoped: %v", wb.id, *res)
 	}
 
 	return rscpContainer(*res, 1)

--- a/charger/e3dc.go
+++ b/charger/e3dc.go
@@ -656,10 +656,30 @@ func (wb *E3dc) GetMaxCurrent() (float64, error) {
 // getSessionData retrieves the session data container from WB_REQ_SESSION.
 // Returns all session-related messages (energy, time, RFID, etc.).
 // If no vehicle is connected, returns only WB_INDEX with no session data.
+//
+// The unscoped request always answers for wallbox 0, so this tries to pass the
+// wallbox index as payload first and falls back to the unscoped request.
+// WB_REQ_SESSION has no entry in go-rscp's datatype table, hence the explicit
+// message (https://github.com/evcc-io/evcc/issues/32112).
 func (wb *E3dc) getSessionData() ([]rscp.Message, error) {
-	res, err := wb.retrySend(*rscp.NewMessage(rscp.WB_REQ_SESSION, nil))
+	res, err := wb.retrySend(rscp.Message{
+		Tag:      rscp.WB_REQ_SESSION,
+		DataType: rscp.UChar8,
+		Value:    wb.id,
+	})
+	if err == nil {
+		wb.log.DEBUG.Printf("session %d indexed: %v", wb.id, *res)
+		err = rscpError(*res)
+	}
+
 	if err != nil {
-		return nil, err
+		wb.log.DEBUG.Printf("session %d indexed failed: %v", wb.id, err)
+
+		if res, err = wb.retrySend(*rscp.NewMessage(rscp.WB_REQ_SESSION, nil)); err != nil {
+			return nil, err
+		}
+
+		wb.log.DEBUG.Printf("session %d unscoped: %v", wb.id, *res)
 	}
 
 	return rscpContainer(*res, 1)


### PR DESCRIPTION
fixes #32112

`getSessionData()` was the only request in `charger/e3dc.go` sent without wallbox scoping, so `ChargedEnergy`, `ChargeDuration` and `Identify` returned the same session for every wallbox of an E3DC system — and vehicle detection always landed on wallbox 0.

The traces in #32112 show that the unscoped request is answered for wallbox 0 only: session data was present whenever wallbox 0 had a vehicle connected, absent in the `wb1-only` scenario, and both loadpoints reported the same RFID id.

Wrapping the request in a `WB_REQ_DATA` container with `WB_INDEX` (#32120) was answered with `ERR_UNKNOWN_TAG`. `WB_REQ_SESSION` takes the wallbox index as its own payload instead. The tag has no entry in go-rscp's datatype table, so `rscp.NewMessage` would encode `None` and drop the value — the message is therefore built explicitly with `UChar8`. If a device rejects the payload, the request falls back to the previous unscoped one.

@maikheinrich confirmed on a two-wallbox system that charged energy, charge duration, RFID id and vehicle assignment are now correct per wallbox. In his trace the indexed request was accepted every time, the reply echoes the requested `WB_INDEX` and the fallback never triggered.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
