### PR TITLE
HEMS: use Wp unit for installed generator power

### DIFF
--- a/templates/definition/hems/fnn-eebus.yaml
+++ b/templates/definition/hems/fnn-eebus.yaml
@@ -30,12 +30,12 @@ params:
       de: Verbleibende Mindestbezugsleistung (Pmin) für steuerbare Verbrauchseinrichtungen, die bei ausbleibendem Heartbeat der Steuerbox angewendet wird. Dies ist die per GZF berechnete Mindestbezugsleistung nach BK6-22-300; wird von der Steuerbox überschrieben, sobald diese eigene Failsafe-Werte überträgt. (Standard 4,2 kW nach § 14a EnWG)
   - name: productionnominalmax
     type: float
-    unit: W
+    unit: Wp
     description:
-      en: Installed generator power (Wp)
-      de: Installierte Generatorleistung (Wp)
+      en: Installed generator power
+      de: Installierte Generatorleistung
     help:
-      en: Rated generator/module power (Wp) of the installation.
+      en: Rated generator/module power of the installation (reference value according to § 9 EEG).
       de: Gesamtnennleistung bzw. Modul- oder Generatorleistung der Anlage (Bezugsgröße nach § 9 EEG).
   - name: failsafeproductionpower
     type: float

--- a/templates/definition/hems/fnn-gpio.yaml
+++ b/templates/definition/hems/fnn-gpio.yaml
@@ -24,12 +24,12 @@ params:
       de: Eingangspin für das W4-Signal (Dimmen der steuerbaren Verbrauchseinrichtungen)
   - name: productionnominalmax
     type: float
-    unit: W
+    unit: Wp
     description:
-      en: Installed generator power (Wp)
-      de: Installierte Generatorleistung (Wp)
+      en: Installed generator power
+      de: Installierte Generatorleistung
     help:
-      en: Rated generator/module power (Wp) of the installation.
+      en: Rated generator/module power of the installation (reference value according to § 9 EEG).
       de: Gesamtnennleistung bzw. Modul- oder Generatorleistung der Anlage (Bezugsgröße nach § 9 EEG).
   - name: maxproductionpower
     deprecated: true

--- a/templates/definition/hems/hemspro-eebus.yaml
+++ b/templates/definition/hems/hemspro-eebus.yaml
@@ -31,12 +31,12 @@ params:
       de: Verbleibende Mindestbezugsleistung (Pmin) für steuerbare Verbrauchseinrichtungen, die bei ausbleibendem Heartbeat der Steuerbox angewendet wird. Dies ist die per GZF berechnete Mindestbezugsleistung nach BK6-22-300; wird von der Steuerbox überschrieben, sobald diese eigene Failsafe-Werte überträgt. (Standard 4,2 kW nach § 14a EnWG)
   - name: productionnominalmax
     type: float
-    unit: W
+    unit: Wp
     description:
-      en: Installed generator power (Wp)
-      de: Installierte Generatorleistung (Wp)
+      en: Installed generator power
+      de: Installierte Generatorleistung
     help:
-      en: Rated generator/module power (Wp) of the installation.
+      en: Rated generator/module power of the installation (reference value according to § 9 EEG).
       de: Gesamtnennleistung bzw. Modul- oder Generatorleistung der Anlage (Bezugsgröße nach § 9 EEG).
   - name: failsafeproductionpower
     type: float

--- a/templates/definition/hems/hemspro-gpio.yaml
+++ b/templates/definition/hems/hemspro-gpio.yaml
@@ -16,12 +16,12 @@ params:
       de: Leistungsbegrenzung des Hauptstromkreises während die Limitierung aktiv ist.
   - name: productionnominalmax
     type: float
-    unit: W
+    unit: Wp
     description:
-      en: Installed generator power (Wp)
-      de: Installierte Generatorleistung (Wp)
+      en: Installed generator power
+      de: Installierte Generatorleistung
     help:
-      en: Rated generator/module power (Wp) of the installation.
+      en: Rated generator/module power of the installation (reference value according to § 9 EEG).
       de: Gesamtnennleistung bzw. Modul- oder Generatorleistung der Anlage (Bezugsgröße nach § 9 EEG).
   - name: maxproductionpower
     deprecated: true


### PR DESCRIPTION
fixes #32082

Keeps the § 9 EEG installed-generator convention as the § 14a curtailment reference and makes it explicit in the UI: `productionnominalmax` now carries `unit: Wp` instead of `W`, so the unit is shown by the input field rather than glued into the label.

- `unit: Wp` for `productionnominalmax` in all four FNN/HEMSpro templates
- dropped the now redundant `(Wp)` from labels and help texts
- english help mentions the § 9 EEG reference value, matching the german text

🤖 Generated with [Claude Code](https://claude.com/claude-code)