### PR TITLE
Powerwall: use Fleet API for battery control

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.36.0
 	github.com/basgys/goxml2json v1.1.0
 	github.com/benbjohnson/clock v1.3.5
-	github.com/bogosj/tesla v1.3.2-0.20250818120641-a31b7b6396c9
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cli/browser v1.3.0
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
-github.com/bogosj/tesla v1.3.2-0.20250818120641-a31b7b6396c9 h1:vAEi0OtVQbyRmnKXz8k350VfyoWYljOrlMDDuU1d/Ug=
-github.com/bogosj/tesla v1.3.2-0.20250818120641-a31b7b6396c9/go.mod h1:nQrPioMhF8Yf36iCtta01SUbsnGN25VhBYLN4DIMBPU=
 github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
 github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/andig/go-powerwall"
-	"github.com/bogosj/tesla"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/vehicle/tesla"
+	teslaclient "github.com/evcc-io/tesla-proxy-client"
 	"golang.org/x/oauth2"
 )
 
@@ -25,7 +26,7 @@ type PowerWall struct {
 	usage      string
 	client     *powerwall.Client
 	meterG     func() (map[string]powerwall.MeterAggregatesData, error)
-	energySite *tesla.EnergySite
+	energySite *teslaclient.EnergySite
 }
 
 func init() {
@@ -38,7 +39,9 @@ func NewPowerWallFromConfig(other map[string]any) (api.Meter, error) {
 	cc := struct {
 		URI, Usage, User, Password string
 		Cache                      time.Duration
-		RefreshToken               string
+		Credentials                struct{ ID, Secret string }
+		Tokens                     struct{ Access, Refresh string }
+		RefreshToken               string // deprecated
 		SiteId                     int64
 		batterySocLimits           `mapstructure:",squash"`
 		batteryPowerLimits         `mapstructure:",squash"`
@@ -66,6 +69,11 @@ func NewPowerWallFromConfig(other map[string]any) (api.Meter, error) {
 		return nil, errors.New("missing password")
 	}
 
+	// the owner api used by the refresh token has been retired by tesla
+	if cc.RefreshToken != "" {
+		return nil, errors.New("battery control requires tesla fleet api credentials, see https://docs.evcc.io/docs/devices/meters#tesla-powerwall")
+	}
+
 	// support default meter names
 	switch strings.ToLower(cc.Usage) {
 	case "grid":
@@ -74,19 +82,15 @@ func NewPowerWallFromConfig(other map[string]any) (api.Meter, error) {
 		cc.Usage = "solar"
 	}
 
-	return NewPowerWall(cc.URI, cc.Usage, cc.User, cc.Password, cc.Cache, cc.RefreshToken, cc.SiteId, cc.batterySocLimits, cc.batteryPowerLimits)
-}
-
-// NewPowerWall creates a Tesla PowerWall Meter
-func NewPowerWall(uri, usage, user, password string, cache time.Duration, refreshToken string, siteId int64, batterySocLimits batterySocLimits, batteryPowerLimits batteryPowerLimits) (api.Meter, error) {
-	log := util.NewLogger("powerwall").Redact(user, password, refreshToken)
+	log := util.NewLogger("powerwall").Redact(cc.User, cc.Password,
+		cc.Credentials.ID, cc.Credentials.Secret, cc.Tokens.Access, cc.Tokens.Refresh)
 
 	httpClient := &http.Client{
 		Transport: request.NewTripper(log, powerwall.DefaultTransport()),
 		Timeout:   time.Second * 2, // Timeout after 2 seconds
 	}
 
-	client := powerwall.NewClient(uri, user, password, powerwall.WithHttpClient(httpClient))
+	client := powerwall.NewClient(cc.URI, cc.User, cc.Password, powerwall.WithHttpClient(httpClient))
 	if _, err := client.GetStatus(); err != nil {
 		return nil, err
 	}
@@ -94,48 +98,22 @@ func NewPowerWall(uri, usage, user, password string, cache time.Duration, refres
 	m := &PowerWall{
 		Caps:   implement.New(),
 		client: client,
-		usage:  strings.ToLower(usage),
-		meterG: util.Cached(client.GetMetersAggregates, cache),
+		usage:  strings.ToLower(cc.Usage),
+		meterG: util.Cached(client.GetMetersAggregates, cc.Cache),
 	}
 
-	var batteryControl bool
-	if refreshToken != "" || siteId != 0 {
-		if refreshToken == "" {
-			return nil, errors.New("missing refresh token")
-		}
-		batteryControl = true
-	}
+	batteryControl := cc.Credentials.ID != "" || cc.Tokens.Access != "" || cc.Tokens.Refresh != ""
 
 	if batteryControl {
-		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, request.NewClient(log))
-
-		options := []tesla.ClientOption{tesla.WithToken(&oauth2.Token{
-			RefreshToken: refreshToken,
-			Expiry:       time.Now(),
-		})}
-
-		cloudClient, err := tesla.NewClient(ctx, options...)
-		if err != nil {
-			return nil, err
+		if cc.Credentials.ID == "" {
+			return nil, errors.New("missing client id")
 		}
 
-		if siteId == 0 {
-			// auto detect energy site ID, picking first
-			products, err := cloudClient.Products()
-			if err != nil {
-				return nil, err
-			}
-
-			for _, p := range products {
-				if p.EnergySiteId != 0 {
-					siteId = p.EnergySiteId
-					break
-				}
-			}
+		if cc.Tokens.Access == "" {
+			return nil, api.ErrMissingToken
 		}
 
-		log.Redact(strconv.FormatInt(siteId, 10))
-		energySite, err := cloudClient.EnergySite(siteId)
+		energySite, err := teslaEnergySite(log, cc.Credentials.ID, cc.Credentials.Secret, cc.Tokens.Access, cc.Tokens.Refresh, cc.SiteId)
 		if err != nil {
 			return nil, err
 		}
@@ -146,10 +124,10 @@ func NewPowerWall(uri, usage, user, password string, cache time.Duration, refres
 		implement.Has(m, implement.MeterEnergy(m.totalEnergy))
 	}
 
-	if usage == "battery" {
+	if m.usage == "battery" {
 		implement.Has(m, implement.Battery(m.batterySoc))
-		implement.May(m, implement.BatterySocLimiter(batterySocLimits.Decorator()))
-		implement.May(m, implement.BatteryPowerLimiter(batteryPowerLimits.Decorator()))
+		implement.May(m, implement.BatterySocLimiter(cc.batterySocLimits.Decorator()))
+		implement.May(m, implement.BatteryPowerLimiter(cc.batteryPowerLimits.Decorator()))
 
 		res, err := m.client.GetSystemStatus()
 		if err != nil {
@@ -162,7 +140,7 @@ func NewPowerWall(uri, usage, user, password string, cache time.Duration, refres
 	}
 
 	if batteryControl {
-		implement.May(m, implement.BatteryController(batterySocLimits.LimitController(m.socG, func(limit float64) error {
+		implement.May(m, implement.BatteryController(cc.batterySocLimits.LimitController(m.socG, func(limit float64) error {
 			// Handle Tesla firmware 25.18.4 restrictions:
 			// Values between 81-99% are not allowed, only ≤80% or exactly 100%
 			limitUint := uint64(limit)
@@ -175,6 +153,59 @@ func NewPowerWall(uri, usage, user, password string, cache time.Duration, refres
 	}
 
 	return m, nil
+}
+
+// teslaEnergySite creates the fleet api energy site used for battery control
+func teslaEnergySite(log *util.Logger, clientID, clientSecret, accessToken, refreshToken string, siteId int64) (*teslaclient.EnergySite, error) {
+	identity, err := tesla.NewIdentity(log, tesla.OAuth2Config(clientID, clientSecret), &oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		Expiry:       time.Now(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	hc := request.NewClient(log)
+	hc.Transport = &oauth2.Transport{
+		Source: identity,
+		Base:   hc.Transport,
+	}
+
+	tc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(hc))
+	if err != nil {
+		return nil, err
+	}
+
+	// validate base url
+	region, err := tc.UserRegion()
+	if err != nil {
+		return nil, err
+	}
+	tc.SetBaseUrl(region.FleetApiBaseUrl)
+
+	if siteId == 0 {
+		// auto detect energy site ID, picking first
+		products, err := tc.Products()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, p := range products {
+			if p.EnergySiteId != 0 {
+				siteId = p.EnergySiteId
+				break
+			}
+		}
+
+		if siteId == 0 {
+			return nil, errors.New("no energy site found")
+		}
+	}
+
+	log.Redact(strconv.FormatInt(siteId, 10))
+
+	return tc.EnergySite(siteId)
 }
 
 var _ api.Meter = (*PowerWall)(nil)
@@ -228,8 +259,7 @@ func (m *PowerWall) socG() (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// Fix for Tesla firmware 25.18.4: Remove the problematic +0.5 rounding logic
-	// that was interfering with exact 100% reserve settings. Simply return the
-	// actual current SOC rounded to nearest integer.
+	// Fix for Tesla firmware 25.18.4: no +0.5 rounding as it interferes
+	// with exact 100% reserve settings
 	return math.Round(ess.PercentageCharged), nil
 }

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -7,19 +7,19 @@ capabilities: ["battery-control"]
 requirements:
   description:
     de: |
-      Um die optionale Entladesteuerung der Battery zu nutzen wird ein `refresh` Token für die Kommunikation mit der Tesla API benötigt.
+      Für die optionale Batteriesteuerung wird die Tesla Fleet API verwendet.
+      Die frühere Owner API wurde von Tesla abgeschaltet, bestehende `refresh` Token funktionieren nicht mehr.
 
-      Folgende Apps ermöglichen das Erstellen des Tokens:
-      - [Auth app for Tesla (iOS)](https://apps.apple.com/us/app/auth-app-for-tesla/id1552058613#?platform=iphone)
-      - [Tesla Tokens (Android)](https://play.google.com/store/apps/details?id=net.leveugle.teslatokens)
-      - [Tesla Auth (macOS, Linux)](https://github.com/adriankumpf/tesla_auth)
+      Erstelle dir einen Tesla Developer Account auf [developer.tesla.com](https://developer.tesla.com/) und erhalte ein monatliches API-Guthaben von 10 €.
+      Die Anleitung von [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) erklärt den Prozess und generiert die benötigten Access- und Refresh-Token.
+      Die Token müssen die Berechtigungen `energy_device_data` und `energy_cmds` enthalten.
     en: |
-      To use the optional battery control you need to generate a `refresh` token for communicating with the Tesla API.
+      The optional battery control uses the Tesla Fleet API.
+      Tesla has retired the previous Owner API, existing `refresh` tokens will no longer work.
 
-      The following apps allow to create the token:
-      - [Auth app for Tesla (iOS)](https://apps.apple.com/us/app/auth-app-for-tesla/id1552058613#?platform=iphone)
-      - [Tesla Tokens (Android)](https://play.google.com/store/apps/details?id=net.leveugle.teslatokens)
-      - [Tesla Auth (macOS, Linux)](https://github.com/adriankumpf/tesla_auth)
+      Create a Tesla Developer Account at [developer.tesla.com](https://developer.tesla.com/) and receive a monthly API credit of $10.
+      The [myteslamate.com](https://www.myteslamate.com/tesla-api-application-registration/) guide explains the process and generates the required Access and Refresh Token.
+      The tokens must include the `energy_device_data` and `energy_cmds` scopes.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -29,7 +29,18 @@ params:
     help:
       en: Password of the user "customer". By default this is the last 5 characters of password stated on the Tesla Gateway.
       de: Passwort des Benutzers "Kunde". Default sind die letzten 5 Zeichen des auf dem Tesla Gateway genannten Passworts.
+  - name: clientId
+    help:
+      en: from [developer.tesla.com](https://developer.tesla.com/dashboard).
+      de: von [developer.tesla.com](https://developer.tesla.com/dashboard).
+  - name: accessToken
+    help:
+      en: from [myteslamate.com](https://app.myteslamate.com/).
+      de: von [myteslamate.com](https://app.myteslamate.com/).
   - name: refreshToken
+    help:
+      en: from [myteslamate.com](https://app.myteslamate.com/).
+      de: von [myteslamate.com](https://app.myteslamate.com/).
   - name: siteId
     description:
       generic: Site ID
@@ -48,7 +59,11 @@ render: |
   usage: {{ .usage }}
   user: customer
   password: {{ .password }} # for user 'customer'
-  refreshToken: {{ .refreshToken }}
+  credentials:
+    id: {{ .clientId }}
+  tokens:
+    access: {{ .accessToken }}
+    refresh: {{ .refreshToken }}
   siteId: {{ .siteId }}
   minsoc: {{ .minsoc }}
   maxsoc: {{ .maxsoc }}


### PR DESCRIPTION
Closes #32002

Tesla retired the owner api used for Powerwall battery control. Access tokens obtained from a refresh token now return `403 Forbidden`, which makes the whole meter (and hence the site) fail to boot.

Battery control now uses the Fleet API with the same auth setup as the Tesla vehicle:

- `vehicle/tesla.NewIdentity` / `OAuth2Config` for the token source (identity instances are shared with the vehicle when the same Tesla account is used)
- `evcc-io/tesla-proxy-client` instead of `bogosj/tesla`, base url from `users/region`
- config changed from top-level `refreshToken` to `credentials.id` + `tokens.access`/`tokens.refresh`
- a leftover `refreshToken` in the config now errors with a migration hint instead of failing with 403
- local gateway readings (power, soc, capacity) are unchanged, only the cloud part moved
- dropped the now unused `bogosj/tesla` dependency

Tokens need the `energy_device_data` and `energy_cmds` scopes.

Docs need a follow-up in evcc-io/docs (meters#tesla-powerwall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)