### PR TITLE
core: apply dim/curtail to devices that cannot report their state

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -7,8 +7,16 @@ import (
 	"github.com/cenkalti/backoff/v4"
 )
 
+var errNotAvailable = errors.New("not available")
+
 // ErrNotAvailable indicates that a feature is not available
-var ErrNotAvailable = backoff.Permanent(errors.New("not available"))
+var ErrNotAvailable = backoff.Permanent(errNotAvailable)
+
+// NotAvailable reports whether err is ErrNotAvailable. It also matches the
+// unwrapped error returned by backoff for permanent errors.
+func NotAvailable(err error) bool {
+	return errors.Is(err, errNotAvailable)
+}
 
 // ErrUnsupportedPlatform indicates unsupported hardware platform
 var ErrUnsupportedPlatform error = backoff.Permanent(errors.New("unsupported platform"))

--- a/core/site_circuits.go
+++ b/core/site_circuits.go
@@ -73,20 +73,19 @@ func (site *Site) dimMeters(dim bool) error {
 			continue
 		}
 
-		if dimmed, err := backoff.RetryWithData(m.Dimmed, modbus.Backoff()); err == nil {
-			if dim == dimmed {
-				continue
-			}
-		} else {
-			if !errors.Is(err, api.ErrNotAvailable) {
-				errs = errors.Join(errs, fmt.Errorf("%s dimmed: %w", deviceTitleOrName(dev), err))
-			}
+		// a device that cannot report its state is written unconditionally
+		dimmed, err := backoff.RetryWithData(m.Dimmed, modbus.Backoff())
+		if err != nil && !api.NotAvailable(err) {
+			errs = errors.Join(errs, fmt.Errorf("%s dimmed: %w", deviceTitleOrName(dev), err))
+			continue
+		}
+		if err == nil && dim == dimmed {
 			continue
 		}
 
 		if err := m.Dim(dim); err == nil {
 			site.log.DEBUG.Printf("%s dim: %t", deviceTitleOrName(dev), dim)
-		} else if !errors.Is(err, api.ErrNotAvailable) {
+		} else if !api.NotAvailable(err) {
 			errs = errors.Join(errs, fmt.Errorf("%s dim: %w", deviceTitleOrName(dev), err))
 		}
 	}
@@ -115,20 +114,19 @@ func (site *Site) curtailPV(percent *int) error {
 			continue
 		}
 
-		if curtailed, err := backoff.RetryWithData(m.CurtailedPercent, modbus.Backoff()); err == nil {
-			if curtailed == *percent {
-				continue
-			}
-		} else {
-			if !errors.Is(err, api.ErrNotAvailable) {
-				errs = errors.Join(errs, fmt.Errorf("%s curtailed: %w", deviceTitleOrName(dev), err))
-			}
+		// a device that cannot report its state is written unconditionally
+		curtailed, err := backoff.RetryWithData(m.CurtailedPercent, modbus.Backoff())
+		if err != nil && !api.NotAvailable(err) {
+			errs = errors.Join(errs, fmt.Errorf("%s curtailed: %w", deviceTitleOrName(dev), err))
+			continue
+		}
+		if err == nil && curtailed == *percent {
 			continue
 		}
 
 		if err := m.SetCurtailPercent(*percent); err == nil {
 			site.log.DEBUG.Printf("%s curtail: %d%%", deviceTitleOrName(dev), *percent)
-		} else if !errors.Is(err, api.ErrNotAvailable) {
+		} else if !api.NotAvailable(err) {
 			errs = errors.Join(errs, fmt.Errorf("%s curtail: %w", deviceTitleOrName(dev), err))
 		}
 	}

--- a/core/site_circuits.go
+++ b/core/site_circuits.go
@@ -73,7 +73,7 @@ func (site *Site) dimMeters(dim bool) error {
 			continue
 		}
 
-		// a device that cannot report its state is written unconditionally
+		// unreadable state: apply unconditionally
 		dimmed, err := backoff.RetryWithData(m.Dimmed, modbus.Backoff())
 		if err != nil && !api.NotAvailable(err) {
 			errs = errors.Join(errs, fmt.Errorf("%s dimmed: %w", deviceTitleOrName(dev), err))
@@ -114,7 +114,7 @@ func (site *Site) curtailPV(percent *int) error {
 			continue
 		}
 
-		// a device that cannot report its state is written unconditionally
+		// unreadable state: apply unconditionally
 		curtailed, err := backoff.RetryWithData(m.CurtailedPercent, modbus.Backoff())
 		if err != nil && !api.NotAvailable(err) {
 			errs = errors.Join(errs, fmt.Errorf("%s curtailed: %w", deviceTitleOrName(dev), err))

--- a/core/site_circuits_test.go
+++ b/core/site_circuits_test.go
@@ -15,6 +15,7 @@ import (
 type curtailableMeter struct {
 	api.Meter
 	percent  int
+	getErr   error
 	setErr   error
 	gets     int
 	sets     int
@@ -23,7 +24,7 @@ type curtailableMeter struct {
 
 func (m *curtailableMeter) CurtailedPercent() (int, error) {
 	m.gets++
-	return m.percent, nil
+	return m.percent, m.getErr
 }
 
 func (m *curtailableMeter) SetCurtailPercent(percent int) error {
@@ -93,10 +94,26 @@ func TestCurtailPVNoStatement(t *testing.T) {
 	assert.Equal(t, []int{60}, m.setCalls)
 }
 
+// A device that cannot report its state is written once, not on every cycle.
+func TestCurtailPVNotAvailable(t *testing.T) {
+	m := &curtailableMeter{percent: 100, getErr: api.ErrNotAvailable}
+	site := curtailSite(m)
+
+	for range 3 {
+		require.NoError(t, site.curtailPV(new(60)))
+	}
+	assert.Equal(t, []int{60}, m.setCalls)
+
+	// changed: applied again
+	require.NoError(t, site.curtailPV(new(30)))
+	assert.Equal(t, []int{60, 30}, m.setCalls)
+}
+
 // dimmableMeter counts device interactions to verify caching.
 type dimmableMeter struct {
 	api.Meter
 	dimmed   bool
+	getErr   error
 	dimErr   error
 	gets     int
 	dimCalls []bool
@@ -104,7 +121,7 @@ type dimmableMeter struct {
 
 func (m *dimmableMeter) Dimmed() (bool, error) {
 	m.gets++
-	return m.dimmed, nil
+	return m.dimmed, m.getErr
 }
 
 func (m *dimmableMeter) Dim(dim bool) error {
@@ -116,12 +133,16 @@ func (m *dimmableMeter) Dim(dim bool) error {
 	return nil
 }
 
+func dimSite(m api.Meter) *Site {
+	return &Site{
+		log:       util.NewLogger("foo"),
+		auxMeters: []config.Device[api.Meter]{config.NewStaticDevice(config.Named{}, m)},
+	}
+}
+
 func TestDimMetersCache(t *testing.T) {
 	m := &dimmableMeter{}
-	site := &Site{
-		log:       util.NewLogger("foo"),
-		auxMeters: []config.Device[api.Meter]{config.NewStaticDevice(config.Named{}, api.Meter(m))},
-	}
+	site := dimSite(m)
 
 	require.NoError(t, site.dimMeters(true))
 	assert.Equal(t, []bool{true}, m.dimCalls)
@@ -141,4 +162,18 @@ func TestDimMetersCache(t *testing.T) {
 	require.Error(t, site.dimMeters(true))
 	require.Error(t, site.dimMeters(true))
 	assert.Equal(t, []bool{true, false, true, true}, m.dimCalls)
+}
+
+// A device that cannot report its state is written once, not on every cycle.
+func TestDimMetersNotAvailable(t *testing.T) {
+	m := &dimmableMeter{getErr: api.ErrNotAvailable}
+	site := dimSite(m)
+
+	for range 3 {
+		require.NoError(t, site.dimMeters(true))
+	}
+	assert.Equal(t, []bool{true}, m.dimCalls)
+
+	require.NoError(t, site.dimMeters(false))
+	assert.Equal(t, []bool{true, false}, m.dimCalls)
 }

--- a/core/site_circuits_test.go
+++ b/core/site_circuits_test.go
@@ -18,7 +18,6 @@ type curtailableMeter struct {
 	getErr   error
 	setErr   error
 	gets     int
-	sets     int
 	setCalls []int
 }
 
@@ -28,7 +27,6 @@ func (m *curtailableMeter) CurtailedPercent() (int, error) {
 }
 
 func (m *curtailableMeter) SetCurtailPercent(percent int) error {
-	m.sets++
 	m.setCalls = append(m.setCalls, percent)
 	if m.setErr != nil {
 		return m.setErr
@@ -96,7 +94,7 @@ func TestCurtailPVNoStatement(t *testing.T) {
 
 // A device that cannot report its state is written once, not on every cycle.
 func TestCurtailPVNotAvailable(t *testing.T) {
-	m := &curtailableMeter{percent: 100, getErr: api.ErrNotAvailable}
+	m := &curtailableMeter{getErr: api.ErrNotAvailable}
 	site := curtailSite(m)
 
 	for range 3 {


### PR DESCRIPTION
`backoff.RetryWithData` returns the *unwrapped* error for permanent errors (retry.go:95), so `errors.Is(err, api.ErrNotAvailable)` never matched after a backoff call. In `dimMeters`/`curtailPV` that turned an unreadable state into a hard error, invalidating the cache and re-attempting on every cycle.

Second issue: a device that cannot report its dim/curtail state was skipped entirely rather than written. A write-only device could therefore never be dimmed or curtailed.

- add `api.NotAvailable` matching both the wrapped and the backoff-unwrapped sentinel
- read error `ErrNotAvailable` now falls through to the write; the existing cache keeps it to a single write per state change

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>