### PR TITLE
Deye 3p hybrid: add feed-in curtailment (BC)

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -16,7 +16,7 @@ params:
     baudrate: 9600
     id: 1
   - name: maxacpower
-    example: 12000
+    required: true
   - name: storageunit
     choice: ["1", "2"]
   - preset: battery-params
@@ -279,7 +279,6 @@ render: |
       {{- end }}
     {{- end }}
   maxacpower: {{ .maxacpower }}
-  {{- if gt (atoi (printf "%v" .maxacpower)) 0 }}
   # Feed-in curtailment via "Max Sell Power" (register 143, watts). The register is the
   # device's always-active feed-in ceiling; there is no separate limit-enable register.
   # "Solar Sell" (register 145) is the owner's export on/off switch and left untouched.
@@ -335,7 +334,6 @@ render: |
         percent = (limit*100 + maxacpower/2) / maxacpower
       }
       percent
-  {{- end }}
   {{- end }}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -7,7 +7,7 @@ products:
   - brand: Sunsynk
     description:
       generic: 3p hybrid inverter
-capabilities: ["battery-control"]
+capabilities: ["battery-control", "curtail"]
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -16,6 +16,7 @@ params:
     baudrate: 9600
     id: 1
   - name: maxacpower
+    example: 12000
   - name: storageunit
     choice: ["1", "2"]
   - preset: battery-params
@@ -278,6 +279,63 @@ render: |
       {{- end }}
     {{- end }}
   maxacpower: {{ .maxacpower }}
+  {{- if .maxacpower }}
+  # Feed-in curtailment via "Max Sell Power" (register 143, watts). The register is the
+  # device's always-active feed-in ceiling; there is no separate limit-enable register.
+  # "Solar Sell" (register 145) is the owner's export on/off switch and left untouched.
+  # HV models use 10 W units for register 143 (LV: 1 W).
+  curtail: # limit feed-in to the given percent of nominal (100 % = nominal power)
+    source: go
+    in:
+      - name: maxacpower
+        type: int
+        config:
+          source: const
+          value: {{ .maxacpower }}
+    script: |
+      powerlimit := ( maxacpower * curtail ) / 100
+      powerlimit
+    out:
+      - name: powerlimit
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 143 # Max Sell Power (W)
+            type: writemultiple
+            decode: uint16
+          {{- if eq .batterytype "hv" }}
+          scale: 0.1
+          {{- end }}
+  curtailed: # allowed feed-in as percent of nominal, derived from Max Sell Power
+    source: go
+    in:
+      - name: limit
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 143 # Max Sell Power (W)
+            type: holding
+            decode: uint16
+          {{- if eq .batterytype "hv" }}
+          scale: 10
+          {{- end }}
+      - name: maxacpower
+        type: int
+        config:
+          source: const
+          value: {{ .maxacpower }}
+    script: |
+      percent := 100
+      if maxacpower > 0 && limit < maxacpower {
+        // round, the watt conversion does not reproduce the written percent exactly
+        percent = (limit*100 + maxacpower/2) / maxacpower
+      }
+      percent
+  {{- end }}
   {{- end }}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -279,7 +279,7 @@ render: |
       {{- end }}
     {{- end }}
   maxacpower: {{ .maxacpower }}
-  {{- if .maxacpower }}
+  {{- if gt (atoi (printf "%v" .maxacpower)) 0 }}
   # Feed-in curtailment via "Max Sell Power" (register 143, watts). The register is the
   # device's always-active feed-in ceiling; there is no separate limit-enable register.
   # "Solar Sell" (register 145) is the owner's export on/off switch and left untouched.


### PR DESCRIPTION
Adds `curtail` to the `deye-hybrid-3p` template (pv usage), as asked for in #31477.
Register documentation is in #19715.

| Register | Name | Unit | Use |
|---|---|---|---|
| 143 | Max Sell Power | W (LV: 1 W, HV: 10 W units) | written and read for curtailment |
| 145 | Solar Sell | 0/1 | left untouched |

Register 143 is the inverter's always-active feed-in ceiling, so there is no separate limit-enable register to toggle. `curtail` writes `maxacpower * percent / 100` watts to it, `curtailed` derives the percent back from the register. At 100 % the template writes nominal power, which overwrites a user-configured lower export limit - same trade-off as in kostal-plenticore-gen2 and atmoce.

I deliberately do not touch register 145. It is the owner's export on/off switch (think zero-export sites), and flipping it would change more than just curtailment.

HV models use 10 W units for register 143, handled with the template's existing `batterytype` conditional (per kellerza/sunsynk `three_phase_hv.py` and ha-solarman `deye_p3.yaml`). I could not test this on an HV device - testers welcome.

Curtailment needs `maxacpower`; without it the template renders as before. I added an `example` to that param so the template test actually renders the new blocks.

### Testing

On my SUN-15K-SG05LP3-EU (LV, Modbus TCP):

- register 143 follows the display 1:1 in watts: 8880 reads back as 8880, setting it to 9000 at the device reads back as 9000 (so 60 % of the 15 kW plant is accepted)
- register 145 toggles 1 <-> 0 with the Solar Sell switch
- writing over this connection is already proven by the template's existing battery-control registers

`go test ./meter -run TestTemplates/deye-hybrid-3p` passes. Since template go scripts are compiled lazily, I additionally ran the rendered lv/hv instances against a local modbus test server: SetCurtailPercent(60/0/100) writes 9000/0/15000 (lv) resp. 900/0/1500 (hv) to register 143, CurtailedPercent reads back 60/0/100.
