### PR TITLE
Battery: hold above bufferSoc during fast charging

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1592,7 +1592,10 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	targetCurrent := max(effectiveCurrent+deltaCurrent, 0)
 
 	// in MinPV mode or under special conditions return at least minCurrent
-	if battery := batteryStart || batteryBuffered && lp.charging(); (mode == api.ModeMinPV || battery) && targetCurrent < minCurrent {
+	// MinPV only guarantees minCurrent when bufferSoc is not configured or battery is above bufferSoc
+	bufferActive := lp.site != nil && lp.site.GetBufferSoc() > 0
+	minPVGuarantee := mode == api.ModeMinPV && (!bufferActive || batteryBuffered)
+	if battery := batteryStart || batteryBuffered && lp.charging(); (minPVGuarantee || battery) && targetCurrent < minCurrent {
 		lp.log.DEBUG.Printf("pv charge current: min %.3gA > %.3gA (%.0fW @ %dp, battery: %t)", minCurrent, targetCurrent, sitePower, activePhases, battery)
 		return minCurrent
 	}

--- a/core/loadpoint_plan_test.go
+++ b/core/loadpoint_plan_test.go
@@ -1,0 +1,125 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	site "github.com/evcc-io/evcc/core/site"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// stubSite is a minimal implementation of site.API for testing
+type stubSite struct {
+	site.API
+	bufferSoc float64
+}
+
+func (s *stubSite) GetBufferSoc() float64 {
+	return s.bufferSoc
+}
+
+func TestMinPVRespectsBufferSoc(t *testing.T) {
+	Voltage = 230
+
+	ctrl := gomock.NewController(t)
+	clk := clock.NewMock()
+
+	tc := []struct {
+		name            string
+		bufferSoc       float64
+		batteryBuffered bool
+		sitePower       float64
+		expected        float64
+	}{
+		{
+			"no bufferSoc configured, no surplus - charges at min",
+			0, false, 500,
+			6,
+		},
+		{
+			"bufferSoc configured, battery above (buffered) - charges at min",
+			50, true, 500,
+			6,
+		},
+		{
+			"bufferSoc configured, battery below (not buffered), no surplus - stops",
+			50, false, 500,
+			0,
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			charger := api.NewMockCharger(ctrl)
+
+			lp := &Loadpoint{
+				log:            util.NewLogger("foo"),
+				clock:          clk,
+				charger:        charger,
+				minCurrent:     6,
+				maxCurrent:     16,
+				phases:         1,
+				measuredPhases: 1,
+				site:           &stubSite{bufferSoc: tc.bufferSoc},
+				Enable: loadpoint.ThresholdConfig{
+					Delay: 0,
+				},
+				Disable: loadpoint.ThresholdConfig{
+					Delay: 0,
+				},
+			}
+
+			lp.status = api.StatusC
+			lp.enabled = true
+
+			current := lp.pvMaxCurrent(api.ModeMinPV, tc.sitePower, 0, tc.batteryBuffered, false)
+			assert.Equal(t, tc.expected, current, tc.name)
+		})
+	}
+}
+
+func TestBufferSocHoldActive(t *testing.T) {
+	tc := []struct {
+		name       string
+		bufferSoc  float64
+		batterySoc float64
+		charging   bool
+		planActive bool
+		expected   bool
+	}{
+		{"no bufferSoc configured", 0, 40, true, true, false},
+		{"battery above bufferSoc", 65, 67, true, true, false},
+		{"battery below, plan active", 65, 63, true, true, true},
+		{"battery below, not charging", 65, 63, false, true, false},
+		{"battery below, charging but no plan", 65, 63, true, false, false},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			charger := api.NewMockCharger(ctrl)
+
+			lp := NewLoadpoint(util.NewLogger("foo"), nil)
+			lp.charger = charger
+			lp.planActive = tc.planActive
+			if tc.charging {
+				lp.status = api.StatusC
+			} else {
+				lp.status = api.StatusB
+			}
+
+			site := &Site{
+				log: util.NewLogger("foo"),
+			}
+			site.bufferSoc = tc.bufferSoc
+			site.battery.Soc = tc.batterySoc
+			site.loadpoints = []*Loadpoint{lp}
+
+			assert.Equal(t, tc.expected, site.bufferSocHoldActive(), tc.name)
+		})
+	}
+}

--- a/core/loadpoint_plan_test.go
+++ b/core/loadpoint_plan_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evcc-io/evcc/core/loadpoint"
 	site "github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/config"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -85,17 +86,19 @@ func TestMinPVRespectsBufferSoc(t *testing.T) {
 func TestBufferSocHoldActive(t *testing.T) {
 	tc := []struct {
 		name       string
+		noBattery  bool
 		bufferSoc  float64
 		batterySoc float64
 		charging   bool
 		planActive bool
 		expected   bool
 	}{
-		{"no bufferSoc configured", 0, 40, true, true, false},
-		{"battery above bufferSoc", 65, 67, true, true, false},
-		{"battery below, plan active", 65, 63, true, true, true},
-		{"battery below, not charging", 65, 63, false, true, false},
-		{"battery below, charging but no plan", 65, 63, true, false, false},
+		{"no battery configured", true, 65, 0, true, true, false},
+		{"no bufferSoc configured", false, 0, 40, true, true, false},
+		{"battery above bufferSoc", false, 65, 67, true, true, false},
+		{"battery below, plan active", false, 65, 63, true, true, true},
+		{"battery below, not charging", false, 65, 63, false, true, false},
+		{"battery below, charging but no plan", false, 65, 63, true, false, false},
 	}
 
 	for _, tc := range tc {
@@ -118,6 +121,9 @@ func TestBufferSocHoldActive(t *testing.T) {
 			site.bufferSoc = tc.bufferSoc
 			site.battery.Soc = tc.batterySoc
 			site.loadpoints = []*Loadpoint{lp}
+			if !tc.noBattery {
+				site.batteryMeters = []config.Device[api.Meter]{nil}
+			}
 
 			assert.Equal(t, tc.expected, site.bufferSocHoldActive(), tc.name)
 		})

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -224,6 +224,10 @@ func (site *Site) dischargeControlActive(rate api.Rate) bool {
 // is fast charging (plan, mode=now, minSoc). This prevents the battery from being
 // drained during fast/plan charging beyond the configured buffer threshold.
 func (site *Site) bufferSocHoldActive() bool {
+	if !site.batteryConfigured() {
+		return false
+	}
+
 	bufferSoc := site.GetBufferSoc()
 	if bufferSoc <= 0 || site.battery.Soc >= bufferSoc {
 		return false

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -107,6 +107,8 @@ func (site *Site) requiredBatteryMode(batteryGridChargeActive bool, rate api.Rat
 		res = keepUnlessModified(api.BatteryCharge)
 	case site.dischargeControlActive(rate):
 		res = keepUnlessModified(api.BatteryHold)
+	case site.bufferSocHoldActive():
+		res = keepUnlessModified(api.BatteryHold)
 	case batteryModeModified(batMode):
 		res = api.BatteryNormal
 	}
@@ -211,6 +213,24 @@ func (site *Site) dischargeControlActive(rate api.Rate) bool {
 	for _, lp := range site.Loadpoints() {
 		smartCostActive := site.smartCostActive(lp, rate)
 		if lp.GetStatus() == api.StatusC && (smartCostActive || lp.IsFastChargingActive()) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// bufferSocHoldActive returns true when battery is below bufferSoc and a loadpoint
+// is fast charging (plan, mode=now, minSoc). This prevents the battery from being
+// drained during fast/plan charging beyond the configured buffer threshold.
+func (site *Site) bufferSocHoldActive() bool {
+	bufferSoc := site.GetBufferSoc()
+	if bufferSoc <= 0 || site.battery.Soc >= bufferSoc {
+		return false
+	}
+
+	for _, lp := range site.Loadpoints() {
+		if lp.GetStatus() == api.StatusC && lp.IsFastChargingActive() {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes #32217

When the house battery is below the configured bufferSoc, fast charging (Now mode, active charging plan, minSoc) discharges it into the vehicle, and Min+PV keeps guaranteeing minimum current from the battery as well. The buffer setting therefore only gates when battery-supported charging may start, but never stops it — see the issue for a deterministic reproduction against master (simulated meters, unmodified control loop).

Changes:

- new site-level `bufferSocHoldActive()`: returns `BatteryHold` while any loadpoint is actively fast-charging and the battery is below bufferSoc (hooked into `requiredBatteryMode` after discharge control)
- Min+PV no longer guarantees minCurrent while the battery is below bufferSoc, matching the hold behaviour (no change when no bufferSoc is configured)
- table-driven tests for both (`TestMinPVRespectsBufferSoc`, `TestBufferSocHoldActive`)

Running in production on my system since April.