### PR TITLE
EEBus: scope remote entities to their use case

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -342,7 +342,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpc.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpc.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -432,7 +432,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpc.Get(), c.ma.MaMPCInterface.Power)
+	return c.mpc.Read(c.ma.MaMPCInterface, eebus.MPCPower, c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -440,7 +440,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhw.Get(),
+	return c.dhw.Read(c.ma.MaMDTInterface, eebus.MDTTemperature,
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -352,9 +352,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	if err := c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
-	}); err != nil {
+	if err := c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: 0, IsActive: dim}); err != nil {
 		return err
 	}
 
@@ -385,10 +383,8 @@ func (c *EEBusOHPCF) apply(enable bool) error {
 
 	switch action {
 	case ohpcfSchedule:
-		return c.ohpcf.Write(func(uc ucapi.CemOHPCFInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
-			return uc.SchedulePowerConsumptionProcess(entity, 0, cb)
-		})
+		// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
+		return c.ohpcf.WriteArg(ucapi.CemOHPCFInterface.SchedulePowerConsumptionProcess, 0)
 	case ohpcfResume:
 		return c.ohpcf.Write(ucapi.CemOHPCFInterface.ResumePowerConsumptionProcess)
 	case ohpcfStop:
@@ -431,8 +427,5 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.mdt.Read(
-		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
-			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
-		})
+	return c.mdt.ReadArg(ucapi.MaMDTInterface.Temperature, model.UnitOfMeasurementTypedegC)
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -27,9 +27,6 @@ import (
 // it pauses or aborts the running process.
 type EEBusOHPCF struct {
 	*embed
-	cem *eebus.CustomerEnergyManagement
-	eg  *eebus.EnergyGuard
-
 	ctx     context.Context
 	reboost time.Duration
 
@@ -87,8 +84,6 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 	c := &EEBusOHPCF{
 		embed:     embed,
 		log:       util.NewLogger("eebus-ohpcf"),
-		cem:       cem,
-		eg:        eg,
 		connector: eebus.NewConnector(),
 		ctx:       ctx,
 		reboost:   reboost,
@@ -303,17 +298,13 @@ func ohpcfControlAction(state ucapi.CompressorPowerConsumptionStateType, enable 
 
 // stop pauses the optional consumption if the compressor permits it, otherwise
 // it aborts the process.
-func (c *EEBusOHPCF) stop(entity spineapi.EntityRemoteInterface) error {
+func (c *EEBusOHPCF) stop() error {
 	if pausable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsPausable); err == nil && pausable {
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, cb)
-		})
+		return c.ohpcf.Write(ucapi.CemOHPCFInterface.PausePowerConsumptionProcess)
 	}
 
 	if stoppable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsStoppable); err == nil && stoppable {
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, cb)
-		})
+		return c.ohpcf.Write(ucapi.CemOHPCFInterface.AbortPowerConsumptionProcess)
 	}
 
 	return api.ErrNotAvailable
@@ -343,14 +334,9 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity, err := c.lpc.Available()
-	if err != nil {
-		return err
-	}
-
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
+	return c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
 	})
 }
 
@@ -372,24 +358,16 @@ func (c *EEBusOHPCF) apply() error {
 		return nil
 	}
 
-	// controlling the process is a separate scenario from monitoring it
-	entity, err := c.ohpcf.Required()
-	if err != nil {
-		return err
-	}
-
 	switch action {
 	case ohpcfSchedule:
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+		return c.ohpcf.Write(func(uc ucapi.CemOHPCFInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
 			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
-			return c.cem.OHPCF.SchedulePowerConsumptionProcess(entity, 0, cb)
+			return uc.SchedulePowerConsumptionProcess(entity, 0, cb)
 		})
 	case ohpcfResume:
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.ResumePowerConsumptionProcess(entity, cb)
-		})
+		return c.ohpcf.Write(ucapi.CemOHPCFInterface.ResumePowerConsumptionProcess)
 	case ohpcfStop:
-		return c.stop(entity)
+		return c.stop()
 	}
 
 	return nil

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -204,11 +204,11 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return api.StatusNone, err
 	}
 
-	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
+	state, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// connected but no flexibility announced yet: standby, not disconnected
 		return api.StatusB, nil
@@ -220,7 +220,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return false, err
 	}
 
@@ -347,7 +347,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := c.lpc.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -360,15 +360,15 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity, err := c.lpc.Available(eebus.LPCLimit)
+	entity, err := c.lpc.Available()
 	if err != nil {
 		return err
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
-	}); err != nil {
+	})); err != nil {
 		return err
 	}
 
@@ -382,11 +382,11 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply(enable bool) error {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return err
 	}
 
-	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
+	state, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// no process state announced yet, nothing to control
 		return nil
@@ -398,7 +398,7 @@ func (c *EEBusOHPCF) apply(enable bool) error {
 	}
 
 	// controlling the process is a separate scenario from monitoring it
-	entity, err := c.ohpcf.Required(eebus.OHPCFControl)
+	entity, err := c.ohpcf.Required()
 	if err != nil {
 		return err
 	}
@@ -425,15 +425,15 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return 0, 0, err
 	}
 
-	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerEstimate); power > 0 {
+	if power, _ := c.ohpcf.Read(ucapi.CemOHPCFInterface.RequestedPowerEstimate); power > 0 {
 		return power, power, nil
 	}
 
-	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerMax); power > 0 {
+	if power, _ := c.ohpcf.Read(ucapi.CemOHPCFInterface.RequestedPowerMax); power > 0 {
 		return power, power, nil
 	}
 
@@ -445,7 +445,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return c.mpc.Read(eebus.MPCPower, ucapi.MaMPCInterface.Power)
+	return c.mpc.Read(ucapi.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -453,7 +453,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.mdt.Read(eebus.MDTTemperature,
+	return c.mdt.Read(
 		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
 			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -360,18 +360,28 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply() error {
-	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
-	if err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return err
 	}
 
-	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
+	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// no process state announced yet, nothing to control
 		return nil
 	}
 
-	switch ohpcfControlAction(state, c.lastEnabled()) {
+	action := ohpcfControlAction(state, c.lastEnabled())
+	if action == ohpcfNone {
+		return nil
+	}
+
+	// controlling the process is a separate scenario from monitoring it
+	entity, err := c.ohpcf.Required(eebus.OHPCFControl)
+	if err != nil {
+		return err
+	}
+
+	switch action {
 	case ohpcfSchedule:
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -35,10 +35,10 @@ type EEBusOHPCF struct {
 	reboost time.Duration
 
 	log        *util.Logger
-	compressor *eebus.Entity
-	mpc        *eebus.Entity
-	dhw        *eebus.Entity
-	lpc        *eebus.Entity
+	compressor *eebus.Entity[ucapi.CemOHPCFInterface]
+	mpc        *eebus.Entity[ucapi.MaMPCInterface]
+	dhw        *eebus.Entity[ucapi.MaMDTInterface]
+	lpc        *eebus.Entity[ucapi.EgLPCInterface]
 
 	mu         sync.RWMutex
 	enabled    bool
@@ -333,7 +333,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := c.lpc.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -415,7 +415,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return c.mpc.Read(eebus.MPCPower, c.ma.MaMPCInterface.Power)
+	return c.mpc.Read(eebus.MPCPower, ucapi.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -424,7 +424,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
 	return c.dhw.Read(eebus.MDTTemperature,
-		func(entity spineapi.EntityRemoteInterface) (float64, error) {
-			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
+		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
+			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -366,9 +366,9 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	if err := eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
-	})); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -136,10 +136,21 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 
 	switch event {
-	case ohpcf.UseCaseSupportUpdate:
-		c.ohpcf.Update(entity)
+	// the compressor also emits data events without announcing the use case,
+	// so any OHPCF event records the entity
+	case ohpcf.UseCaseSupportUpdate,
+		ohpcf.DataUpdateRequestedPowerEstimate,
+		ohpcf.DataUpdateRequestedPowerMax,
+		ohpcf.DataUpdateConsumptionIsStoppable,
+		ohpcf.DataUpdateConsumptionIsPausable,
+		ohpcf.DataUpdateConsumptionStartTime,
+		ohpcf.DataUpdateMinimalRunDuration,
+		ohpcf.DataUpdateMinimalPauseDuration:
+		c.ohpcf.Set(entity)
 
 	case ohpcf.DataUpdateConsumptionState:
+		c.ohpcf.Set(entity)
+
 		// react immediately to a freshly announced schedule/resume opportunity
 		// instead of waiting for the next reboost tick, which may miss it (#31549)
 		if c.lastEnabled() {
@@ -152,9 +163,10 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	case mpc.UseCaseSupportUpdate:
 		c.mpc.Update(entity)
 
-	// Monitoring Appliance MDT provides the DHW temperature
-	case mdt.UseCaseSupportUpdate:
-		c.mdt.Update(entity)
+	// Monitoring Appliance MDT provides the DHW temperature, which lives on the
+	// deeper DHW sub-entity - record it as-is, without preferring the shallowest
+	case mdt.UseCaseSupportUpdate, mdt.DataUpdateTemperature:
+		c.mdt.Set(entity)
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
@@ -338,7 +350,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit, eebus.LPCLimit)
 	if err != nil {
 		return false, err
 	}
@@ -352,7 +364,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	if err := c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: 0, IsActive: dim}); err != nil {
+	if err := c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: 0, IsActive: dim}, eebus.LPCLimit); err != nil {
 		return err
 	}
 
@@ -376,12 +388,7 @@ func (c *EEBusOHPCF) apply(enable bool) error {
 		return nil
 	}
 
-	action := ohpcfControlAction(state, enable)
-	if action == ohpcfNone {
-		return nil
-	}
-
-	switch action {
+	switch ohpcfControlAction(state, enable) {
 	case ohpcfSchedule:
 		// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
 		return c.ohpcf.WriteArg(ucapi.CemOHPCFInterface.SchedulePowerConsumptionProcess, 0)
@@ -419,7 +426,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return c.mpc.Read(ucapi.MaMPCInterface.Power)
+	return c.mpc.Read(ucapi.MaMPCInterface.Power, eebus.MPCPower)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -427,5 +434,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.mdt.ReadArg(ucapi.MaMDTInterface.Temperature, model.UnitOfMeasurementTypedegC)
+	return c.mdt.Read(func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
+		return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
+	}, eebus.MDTTemperature)
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -34,14 +34,14 @@ type EEBusOHPCF struct {
 	ctx     context.Context
 	reboost time.Duration
 
-	mu          sync.RWMutex
-	log         *util.Logger
-	compressor  spineapi.EntityRemoteInterface
-	mpcEntity   spineapi.EntityRemoteInterface
-	dhwEntity   spineapi.EntityRemoteInterface
-	egLpcEntity spineapi.EntityRemoteInterface
-	enabled     bool
-	reboosting  bool
+	mu         sync.RWMutex
+	log        *util.Logger
+	compressor spineapi.EntityRemoteInterface
+	mpc        spineapi.EntityRemoteInterface
+	dhw        spineapi.EntityRemoteInterface
+	egLpc      spineapi.EntityRemoteInterface
+	enabled    bool
+	reboosting bool
 
 	connector *eebus.Connector
 }
@@ -123,9 +123,9 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 	defer c.mu.Unlock()
 
 	c.compressor = nil
-	c.mpcEntity = nil
-	c.dhwEntity = nil
-	c.egLpcEntity = nil
+	c.mpc = nil
+	c.dhw = nil
+	c.egLpc = nil
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -153,19 +153,19 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		c.mpcEntity = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpcEntity, entity)
+		c.mpc = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpc, entity)
 		c.mu.Unlock()
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
 		c.mu.Lock()
-		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
+		c.dhw = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhw, entity)
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
+		c.egLpc = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpc, entity)
 		c.mu.Unlock()
 	}
 }
@@ -176,7 +176,31 @@ func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) 
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return eebus.RequiredEntity(c.cem.OHPCF, c.compressor, eebus.OHPCFMonitor)
+	return eebus.RequiredEntity(c.cem.OHPCF, eebus.OHPCFMonitor, c.compressor)
+}
+
+// mpcEntity returns the entity providing the measured power consumption
+func (c *EEBusOHPCF) mpcEntity() spineapi.EntityRemoteInterface {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.mpc
+}
+
+// dhwEntity returns the entity providing the domestic hot water temperature
+func (c *EEBusOHPCF) dhwEntity() spineapi.EntityRemoteInterface {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.dhw
+}
+
+// egLpcEntity returns the entity carrying the §14a/LPC consumption limit
+func (c *EEBusOHPCF) egLpcEntity() spineapi.EntityRemoteInterface {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.egLpc
 }
 
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
@@ -344,11 +368,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	c.mu.RLock()
-	entity := c.egLpcEntity
-	c.mu.RUnlock()
-
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, entity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity(), c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -361,9 +381,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	c.mu.RLock()
-	entity := c.egLpcEntity
-	c.mu.RUnlock()
+	entity := c.egLpcEntity()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -432,11 +450,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	c.mu.RLock()
-	entity := c.mpcEntity
-	c.mu.RUnlock()
-
-	return eebus.ReadValue(c.ma.MaMPCInterface, entity, eebus.MPCPower, c.ma.MaMPCInterface.Power)
+	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpcEntity(), c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -444,11 +458,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	c.mu.RLock()
-	entity := c.dhwEntity
-	c.mu.RUnlock()
-
-	return eebus.ReadValue(c.ma.MaMDTInterface, entity, eebus.MDTTemperature,
+	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhwEntity(),
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -2,7 +2,6 @@ package charger
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -46,9 +45,6 @@ type EEBusOHPCF struct {
 
 	connector *eebus.Connector
 }
-
-// errNotConnected is returned whenever the compressor entity is not (yet) available.
-var errNotConnected = errors.New("not connected")
 
 func init() {
 	registry.AddCtx("eebus-ohpcf", NewEEBusOHPCFFromConfig)
@@ -194,11 +190,13 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 }
 
-func (c *EEBusOHPCF) connectedCompressor() (spineapi.EntityRemoteInterface, bool) {
+// compressorEntity returns the compressor entity or ErrNotConnected while the
+// OHPCF use case is not (yet) available at it.
+func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return c.compressor, c.compressor != nil
+	return eebus.RequiredEntity(c.cem.OHPCF, c.compressor, eebus.OHPCFMonitor)
 }
 
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
@@ -228,9 +226,9 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, ok := c.connectedCompressor()
-	if !ok {
-		return api.StatusNone, errNotConnected
+	entity, err := c.compressorEntity()
+	if err != nil {
+		return api.StatusNone, err
 	}
 
 	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
@@ -245,8 +243,8 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, ok := c.connectedCompressor(); !ok {
-		return false, errNotConnected
+	if _, err := c.compressorEntity(); err != nil {
+		return false, err
 	}
 
 	return c.lastEnabled(), nil
@@ -370,18 +368,8 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 	entity := c.egLpcEntity
 	c.mu.RUnlock()
 
-	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
-		return false, api.ErrNotAvailable
-	}
-
-	limit, err := c.eg.EgLPCInterface.ConsumptionLimit(entity)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, entity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
-		// scenario announced but no usable value yet
-		if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrDataInvalid) {
-			return false, api.ErrNotAvailable
-		}
 		return false, err
 	}
 
@@ -410,9 +398,9 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply() error {
-	entity, ok := c.connectedCompressor()
-	if !ok {
-		return errNotConnected
+	entity, err := c.compressorEntity()
+	if err != nil {
+		return err
 	}
 
 	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
@@ -443,9 +431,9 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, ok := c.connectedCompressor()
-	if !ok {
-		return 0, 0, errNotConnected
+	entity, err := c.compressorEntity()
+	if err != nil {
+		return 0, 0, err
 	}
 
 	if power, _ := c.cem.OHPCF.RequestedPowerEstimate(entity); power > 0 {
@@ -468,16 +456,7 @@ func (c *EEBusOHPCF) CurrentPower() (float64, error) {
 	entity := c.mpcEntity
 	c.mu.RUnlock()
 
-	if entity == nil || !c.ma.MaMPCInterface.IsScenarioAvailableAtEntity(entity, eebus.MPCPower) {
-		return 0, api.ErrNotAvailable
-	}
-
-	power, err := c.ma.MaMPCInterface.Power(entity)
-	if err != nil {
-		return 0, eebus.WrapError(err)
-	}
-
-	return power, nil
+	return eebus.ReadValue(c.ma.MaMPCInterface, entity, eebus.MPCPower, c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -489,14 +468,8 @@ func (c *EEBusOHPCF) Soc() (float64, error) {
 	entity := c.dhwEntity
 	c.mu.RUnlock()
 
-	if entity == nil || !c.ma.MaMDTInterface.IsScenarioAvailableAtEntity(entity, eebus.MDTTemperature) {
-		return 0, api.ErrNotAvailable
-	}
-
-	temp, err := c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
-	if err != nil {
-		return 0, eebus.WrapError(err)
-	}
-
-	return temp, nil
+	return eebus.ReadValue(c.ma.MaMDTInterface, entity, eebus.MDTTemperature,
+		func(entity spineapi.EntityRemoteInterface) (float64, error) {
+			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
+		})
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -34,11 +34,11 @@ type EEBusOHPCF struct {
 	ctx     context.Context
 	reboost time.Duration
 
-	log        *util.Logger
-	compressor *eebus.Entity[ucapi.CemOHPCFInterface]
-	mpc        *eebus.Entity[ucapi.MaMPCInterface]
-	mdt        *eebus.Entity[ucapi.MaMDTInterface]
-	lpc        *eebus.Entity[ucapi.EgLPCInterface]
+	log   *util.Logger
+	ohpcf *eebus.Entity[ucapi.CemOHPCFInterface]
+	mpc   *eebus.Entity[ucapi.MaMPCInterface]
+	mdt   *eebus.Entity[ucapi.MaMDTInterface]
+	lpc   *eebus.Entity[ucapi.EgLPCInterface]
 
 	mu         sync.RWMutex
 	enabled    bool
@@ -86,18 +86,18 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 	eg := inst.EnergyGuard()
 
 	c := &EEBusOHPCF{
-		embed:      embed,
-		log:        util.NewLogger("eebus-ohpcf"),
-		cem:        cem,
-		ma:         ma,
-		eg:         eg,
-		connector:  eebus.NewConnector(),
-		ctx:        ctx,
-		reboost:    reboost,
-		compressor: eebus.NewEntity(cem.OHPCF),
-		mpc:        eebus.NewEntity(ma.MaMPCInterface),
-		mdt:        eebus.NewEntity(ma.MaMDTInterface),
-		lpc:        eebus.NewEntity(eg.EgLPCInterface),
+		embed:     embed,
+		log:       util.NewLogger("eebus-ohpcf"),
+		cem:       cem,
+		ma:        ma,
+		eg:        eg,
+		connector: eebus.NewConnector(),
+		ctx:       ctx,
+		reboost:   reboost,
+		ohpcf:     eebus.NewEntity(cem.OHPCF),
+		mpc:       eebus.NewEntity(ma.MaMPCInterface),
+		mdt:       eebus.NewEntity(ma.MaMDTInterface),
+		lpc:       eebus.NewEntity(eg.EgLPCInterface),
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -128,7 +128,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 		return
 	}
 
-	c.compressor.Set(nil)
+	c.ohpcf.Set(nil)
 	c.mpc.Set(nil)
 	c.mdt.Set(nil)
 	c.lpc.Set(nil)
@@ -143,7 +143,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	switch event {
 	case ohpcf.UseCaseSupportUpdate:
-		c.compressor.Update(entity)
+		c.ohpcf.Update(entity)
 
 	case ohpcf.DataUpdateConsumptionState:
 		// react immediately to a freshly announced schedule/resume opportunity
@@ -195,7 +195,7 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
+	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return api.StatusNone, err
 	}
@@ -212,7 +212,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.compressor.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return false, err
 	}
 
@@ -361,7 +361,7 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply() error {
-	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
+	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return err
 	}
@@ -394,7 +394,7 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
+	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -160,12 +160,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 }
 
-// compressorEntity returns the compressor entity or ErrNotConnected while the
-// OHPCF use case is not (yet) available at it.
-func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) {
-	return c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
-}
-
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -193,7 +187,7 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.compressorEntity()
+	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 	if err != nil {
 		return api.StatusNone, err
 	}
@@ -210,7 +204,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.compressorEntity(); err != nil {
+	if _, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor); err != nil {
 		return false, err
 	}
 
@@ -359,7 +353,7 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply() error {
-	entity, err := c.compressorEntity()
+	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 	if err != nil {
 		return err
 	}
@@ -392,7 +386,7 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.compressorEntity()
+	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -35,10 +35,10 @@ type EEBusOHPCF struct {
 	reboost time.Duration
 
 	log        *util.Logger
-	compressor eebus.Entity
-	mpc        eebus.Entity
-	dhw        eebus.Entity
-	egLpc      eebus.Entity
+	compressor *eebus.Entity
+	mpc        *eebus.Entity
+	dhw        *eebus.Entity
+	lpc        *eebus.Entity
 
 	mu         sync.RWMutex
 	enabled    bool
@@ -82,15 +82,23 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		return nil, err
 	}
 
+	cem := inst.CustomerEnergyManagement()
+	ma := inst.MonitoringAppliance()
+	eg := inst.EnergyGuard()
+
 	c := &EEBusOHPCF{
-		embed:     embed,
-		log:       util.NewLogger("eebus-ohpcf"),
-		cem:       inst.CustomerEnergyManagement(),
-		ma:        inst.MonitoringAppliance(),
-		eg:        inst.EnergyGuard(),
-		connector: eebus.NewConnector(),
-		ctx:       ctx,
-		reboost:   reboost,
+		embed:      embed,
+		log:        util.NewLogger("eebus-ohpcf"),
+		cem:        cem,
+		ma:         ma,
+		eg:         eg,
+		connector:  eebus.NewConnector(),
+		ctx:        ctx,
+		reboost:    reboost,
+		compressor: eebus.NewEntity(cem.OHPCF),
+		mpc:        eebus.NewEntity(ma.MaMPCInterface),
+		dhw:        eebus.NewEntity(ma.MaMDTInterface),
+		lpc:        eebus.NewEntity(eg.EgLPCInterface),
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -124,7 +132,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 	c.compressor.Set(nil)
 	c.mpc.Set(nil)
 	c.dhw.Set(nil)
-	c.egLpc.Set(nil)
+	c.lpc.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -136,7 +144,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	switch event {
 	case ohpcf.UseCaseSupportUpdate:
-		c.compressor.Update(c.cem.OHPCF, entity)
+		c.compressor.Update(entity)
 
 	case ohpcf.DataUpdateConsumptionState:
 		// react immediately to a freshly announced schedule/resume opportunity
@@ -149,15 +157,15 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
-		c.mpc.Update(c.ma.MaMPCInterface, entity)
+		c.mpc.Update(entity)
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
-		c.dhw.Update(c.ma.MaMDTInterface, entity)
+		c.dhw.Update(entity)
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
-		if c.egLpc.Update(c.eg.EgLPCInterface, entity) {
+		if c.lpc.Update(entity) {
 			// [LPC-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}
@@ -198,7 +206,7 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
+	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return api.StatusNone, err
 	}
@@ -215,7 +223,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor); err != nil {
+	if _, err := c.compressor.Required(eebus.OHPCFMonitor); err != nil {
 		return false, err
 	}
 
@@ -342,7 +350,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := c.egLpc.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -355,7 +363,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity := c.egLpc.Get()
+	entity := c.lpc.Get()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -378,7 +386,7 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply(enable bool) error {
-	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
+	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return err
 	}
@@ -411,7 +419,7 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
+	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -432,7 +440,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return c.mpc.Read(c.ma.MaMPCInterface, eebus.MPCPower, c.ma.MaMPCInterface.Power)
+	return c.mpc.Read(eebus.MPCPower, c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -440,7 +448,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.dhw.Read(c.ma.MaMDTInterface, eebus.MDTTemperature,
+	return c.dhw.Read(eebus.MDTTemperature,
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -206,12 +206,11 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
-	if err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return api.StatusNone, err
 	}
 
-	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
+	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// connected but no flexibility announced yet: standby, not disconnected
 		return api.StatusB, nil
@@ -419,16 +418,15 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
-	if err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return 0, 0, err
 	}
 
-	if power, _ := c.cem.OHPCF.RequestedPowerEstimate(entity); power > 0 {
+	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerEstimate); power > 0 {
 		return power, power, nil
 	}
 
-	if power, _ := c.cem.OHPCF.RequestedPowerMax(entity); power > 0 {
+	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerMax); power > 0 {
 		return power, power, nil
 	}
 

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -35,10 +35,10 @@ type EEBusOHPCF struct {
 	reboost time.Duration
 
 	log        *util.Logger
-	compressor *eebus.Entity
-	mpc        *eebus.Entity
-	dhw        *eebus.Entity
-	lpc        *eebus.Entity
+	compressor *eebus.Entity[ucapi.CemOHPCFInterface]
+	mpc        *eebus.Entity[ucapi.MaMPCInterface]
+	dhw        *eebus.Entity[ucapi.MaMDTInterface]
+	lpc        *eebus.Entity[ucapi.EgLPCInterface]
 
 	mu         sync.RWMutex
 	enabled    bool
@@ -350,7 +350,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := c.lpc.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -440,7 +440,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return c.mpc.Read(eebus.MPCPower, c.ma.MaMPCInterface.Power)
+	return c.mpc.Read(eebus.MPCPower, ucapi.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -449,7 +449,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
 	return c.dhw.Read(eebus.MDTTemperature,
-		func(entity spineapi.EntityRemoteInterface) (float64, error) {
-			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
+		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
+			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -385,18 +385,28 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply(enable bool) error {
-	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
-	if err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return err
 	}
 
-	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
+	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// no process state announced yet, nothing to control
 		return nil
 	}
 
-	switch ohpcfControlAction(state, enable) {
+	action := ohpcfControlAction(state, enable)
+	if action == ohpcfNone {
+		return nil
+	}
+
+	// controlling the process is a separate scenario from monitoring it
+	entity, err := c.ohpcf.Required(eebus.OHPCFControl)
+	if err != nil {
+		return err
+	}
+
+	switch action {
 	case ohpcfSchedule:
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -37,7 +37,7 @@ type EEBusOHPCF struct {
 	log        *util.Logger
 	compressor *eebus.Entity[ucapi.CemOHPCFInterface]
 	mpc        *eebus.Entity[ucapi.MaMPCInterface]
-	dhw        *eebus.Entity[ucapi.MaMDTInterface]
+	mdt        *eebus.Entity[ucapi.MaMDTInterface]
 	lpc        *eebus.Entity[ucapi.EgLPCInterface]
 
 	mu         sync.RWMutex
@@ -96,7 +96,7 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		reboost:    reboost,
 		compressor: eebus.NewEntity(cem.OHPCF),
 		mpc:        eebus.NewEntity(ma.MaMPCInterface),
-		dhw:        eebus.NewEntity(ma.MaMDTInterface),
+		mdt:        eebus.NewEntity(ma.MaMDTInterface),
 		lpc:        eebus.NewEntity(eg.EgLPCInterface),
 	}
 
@@ -130,7 +130,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 
 	c.compressor.Set(nil)
 	c.mpc.Set(nil)
-	c.dhw.Set(nil)
+	c.mdt.Set(nil)
 	c.lpc.Set(nil)
 }
 
@@ -160,7 +160,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
-		c.dhw.Update(entity)
+		c.mdt.Update(entity)
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
@@ -423,7 +423,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.dhw.Read(eebus.MDTTemperature,
+	return c.mdt.Read(eebus.MDTTemperature,
 		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
 			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -34,11 +34,11 @@ type EEBusOHPCF struct {
 	ctx     context.Context
 	reboost time.Duration
 
-	log        *util.Logger
-	compressor *eebus.Entity[ucapi.CemOHPCFInterface]
-	mpc        *eebus.Entity[ucapi.MaMPCInterface]
-	mdt        *eebus.Entity[ucapi.MaMDTInterface]
-	lpc        *eebus.Entity[ucapi.EgLPCInterface]
+	log   *util.Logger
+	ohpcf *eebus.Entity[ucapi.CemOHPCFInterface]
+	mpc   *eebus.Entity[ucapi.MaMPCInterface]
+	mdt   *eebus.Entity[ucapi.MaMDTInterface]
+	lpc   *eebus.Entity[ucapi.EgLPCInterface]
 
 	mu         sync.RWMutex
 	enabled    bool
@@ -87,18 +87,18 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 	eg := inst.EnergyGuard()
 
 	c := &EEBusOHPCF{
-		embed:      embed,
-		log:        util.NewLogger("eebus-ohpcf"),
-		cem:        cem,
-		ma:         ma,
-		eg:         eg,
-		connector:  eebus.NewConnector(),
-		ctx:        ctx,
-		reboost:    reboost,
-		compressor: eebus.NewEntity(cem.OHPCF),
-		mpc:        eebus.NewEntity(ma.MaMPCInterface),
-		mdt:        eebus.NewEntity(ma.MaMDTInterface),
-		lpc:        eebus.NewEntity(eg.EgLPCInterface),
+		embed:     embed,
+		log:       util.NewLogger("eebus-ohpcf"),
+		cem:       cem,
+		ma:        ma,
+		eg:        eg,
+		connector: eebus.NewConnector(),
+		ctx:       ctx,
+		reboost:   reboost,
+		ohpcf:     eebus.NewEntity(cem.OHPCF),
+		mpc:       eebus.NewEntity(ma.MaMPCInterface),
+		mdt:       eebus.NewEntity(ma.MaMDTInterface),
+		lpc:       eebus.NewEntity(eg.EgLPCInterface),
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -129,7 +129,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 		return
 	}
 
-	c.compressor.Set(nil)
+	c.ohpcf.Set(nil)
 	c.mpc.Set(nil)
 	c.mdt.Set(nil)
 	c.lpc.Set(nil)
@@ -144,7 +144,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	switch event {
 	case ohpcf.UseCaseSupportUpdate:
-		c.compressor.Update(entity)
+		c.ohpcf.Update(entity)
 
 	case ohpcf.DataUpdateConsumptionState:
 		// react immediately to a freshly announced schedule/resume opportunity
@@ -206,7 +206,7 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
+	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return api.StatusNone, err
 	}
@@ -223,7 +223,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.compressor.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return false, err
 	}
 
@@ -386,7 +386,7 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply(enable bool) error {
-	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
+	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return err
 	}
@@ -419,7 +419,7 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
+	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -335,9 +335,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	return c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
-	})
+	return c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: 0, IsActive: dim})
 }
 
 // apply issues the command to align the optional consumption with the on/off
@@ -360,10 +358,8 @@ func (c *EEBusOHPCF) apply() error {
 
 	switch action {
 	case ohpcfSchedule:
-		return c.ohpcf.Write(func(uc ucapi.CemOHPCFInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
-			return uc.SchedulePowerConsumptionProcess(entity, 0, cb)
-		})
+		// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
+		return c.ohpcf.WriteArg(ucapi.CemOHPCFInterface.SchedulePowerConsumptionProcess, 0)
 	case ohpcfResume:
 		return c.ohpcf.Write(ucapi.CemOHPCFInterface.ResumePowerConsumptionProcess)
 	case ohpcfStop:
@@ -406,8 +402,5 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.mdt.Read(
-		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
-			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
-		})
+	return c.mdt.ReadArg(ucapi.MaMDTInterface.Temperature, model.UnitOfMeasurementTypedegC)
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -164,12 +164,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 }
 
-// compressorEntity returns the compressor entity or ErrNotConnected while the
-// OHPCF use case is not (yet) available at it.
-func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) {
-	return c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
-}
-
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -204,7 +198,7 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.compressorEntity()
+	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 	if err != nil {
 		return api.StatusNone, err
 	}
@@ -221,7 +215,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.compressorEntity(); err != nil {
+	if _, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor); err != nil {
 		return false, err
 	}
 
@@ -384,7 +378,7 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply(enable bool) error {
-	entity, err := c.compressorEntity()
+	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 	if err != nil {
 		return err
 	}
@@ -417,7 +411,7 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.compressorEntity()
+	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -34,12 +34,13 @@ type EEBusOHPCF struct {
 	ctx     context.Context
 	reboost time.Duration
 
-	mu         sync.RWMutex
 	log        *util.Logger
-	compressor spineapi.EntityRemoteInterface
-	mpc        spineapi.EntityRemoteInterface
-	dhw        spineapi.EntityRemoteInterface
-	egLpc      spineapi.EntityRemoteInterface
+	compressor eebus.Entity
+	mpc        eebus.Entity
+	dhw        eebus.Entity
+	egLpc      eebus.Entity
+
+	mu         sync.RWMutex
 	enabled    bool
 	reboosting bool
 	dimmed     bool // last limit written, re-stated on reconnect
@@ -120,13 +121,10 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.compressor = nil
-	c.mpc = nil
-	c.dhw = nil
-	c.egLpc = nil
+	c.compressor.Set(nil)
+	c.mpc.Set(nil)
+	c.dhw.Set(nil)
+	c.egLpc.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -138,9 +136,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	switch event {
 	case ohpcf.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
-		c.mu.Unlock()
+		c.compressor.Update(c.cem.OHPCF, entity)
 
 	case ohpcf.DataUpdateConsumptionState:
 		// react immediately to a freshly announced schedule/resume opportunity
@@ -153,65 +149,25 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.mpc = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpc, entity)
-		c.mu.Unlock()
+		c.mpc.Update(c.ma.MaMPCInterface, entity)
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.dhw = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhw, entity)
-		c.mu.Unlock()
+		c.dhw.Update(c.ma.MaMDTInterface, entity)
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
-		c.mu.Lock()
-		prev := c.egLpc
-		c.egLpc = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpc, entity)
-
-		if c.egLpc != nil && c.egLpc != prev {
+		if c.egLpc.Update(c.eg.EgLPCInterface, entity) {
 			// [LPC-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}
-		c.mu.Unlock()
 	}
 }
 
 // compressorEntity returns the compressor entity or ErrNotConnected while the
 // OHPCF use case is not (yet) available at it.
 func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	if c.compressor == nil {
-		return nil, eebus.ErrNotConnected
-	}
-
-	return eebus.RequiredEntity(c.cem.OHPCF, eebus.OHPCFMonitor, c.compressor)
-}
-
-// mpcEntity returns the entity providing the measured power consumption
-func (c *EEBusOHPCF) mpcEntity() spineapi.EntityRemoteInterface {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.mpc
-}
-
-// dhwEntity returns the entity providing the domestic hot water temperature
-func (c *EEBusOHPCF) dhwEntity() spineapi.EntityRemoteInterface {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.dhw
-}
-
-// egLpcEntity returns the entity carrying the §14a/LPC consumption limit
-func (c *EEBusOHPCF) egLpcEntity() spineapi.EntityRemoteInterface {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.egLpc
+	return c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 }
 
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
@@ -392,7 +348,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity(), c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpc.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -405,7 +361,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity := c.egLpcEntity()
+	entity := c.egLpc.Get()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -482,7 +438,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpcEntity(), c.ma.MaMPCInterface.Power)
+	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpc.Get(), c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -490,7 +446,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhwEntity(),
+	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhw.Get(),
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -134,7 +134,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 
 // UseCaseEvent implements the eebus.Device interface
 func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
-	// device/entity removal fires the use case update event with a nil entity
+	// device removal fires the use case update event with a nil entity
 	if entity == nil {
 		return
 	}
@@ -153,8 +153,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 			}
 		}
 
-	case ohpcf.UseCaseSupportUpdate,
-		ohpcf.DataUpdateRequestedPowerEstimate,
+	case ohpcf.DataUpdateRequestedPowerEstimate,
 		ohpcf.DataUpdateRequestedPowerMax,
 		ohpcf.DataUpdateConsumptionIsStoppable,
 		ohpcf.DataUpdateConsumptionIsPausable,
@@ -165,28 +164,32 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.compressor = entity
 		c.mu.Unlock()
 
+	case ohpcf.UseCaseSupportUpdate:
+		c.mu.Lock()
+		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
+		c.mu.Unlock()
+
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		// use most specific selector
-		if c.mpcEntity == nil || len(entity.Address().Entity) < len(c.mpcEntity.Address().Entity) {
-			c.mpcEntity = entity
-		}
+		c.mpcEntity = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpcEntity, entity)
 		c.mu.Unlock()
 
 	// Monitoring Appliance MDT provides the DHW temperature
-	case mdt.UseCaseSupportUpdate, mdt.DataUpdateTemperature:
+	case mdt.DataUpdateTemperature:
 		c.mu.Lock()
 		c.dhwEntity = entity
+		c.mu.Unlock()
+
+	case mdt.UseCaseSupportUpdate:
+		c.mu.Lock()
+		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		// use most specific selector
-		if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
-			c.egLpcEntity = entity
-		}
+		c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
 		c.mu.Unlock()
 	}
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -141,6 +141,11 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 
 	switch event {
+	case ohpcf.UseCaseSupportUpdate:
+		c.mu.Lock()
+		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
+		c.mu.Unlock()
+
 	case ohpcf.DataUpdateConsumptionState:
 		c.mu.Lock()
 		c.compressor = entity
@@ -165,11 +170,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.compressor = entity
 		c.mu.Unlock()
 
-	case ohpcf.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
-		c.mu.Unlock()
-
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
 		c.mu.Lock()
@@ -177,14 +177,14 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.mu.Unlock()
 
 	// Monitoring Appliance MDT provides the DHW temperature
-	case mdt.DataUpdateTemperature:
-		c.mu.Lock()
-		c.dhwEntity = entity
-		c.mu.Unlock()
-
 	case mdt.UseCaseSupportUpdate:
 		c.mu.Lock()
 		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
+		c.mu.Unlock()
+
+	case mdt.DataUpdateTemperature:
+		c.mu.Lock()
+		c.dhwEntity = entity
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -37,7 +37,7 @@ type EEBusOHPCF struct {
 	log        *util.Logger
 	compressor *eebus.Entity[ucapi.CemOHPCFInterface]
 	mpc        *eebus.Entity[ucapi.MaMPCInterface]
-	dhw        *eebus.Entity[ucapi.MaMDTInterface]
+	mdt        *eebus.Entity[ucapi.MaMDTInterface]
 	lpc        *eebus.Entity[ucapi.EgLPCInterface]
 
 	mu         sync.RWMutex
@@ -97,7 +97,7 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		reboost:    reboost,
 		compressor: eebus.NewEntity(cem.OHPCF),
 		mpc:        eebus.NewEntity(ma.MaMPCInterface),
-		dhw:        eebus.NewEntity(ma.MaMDTInterface),
+		mdt:        eebus.NewEntity(ma.MaMDTInterface),
 		lpc:        eebus.NewEntity(eg.EgLPCInterface),
 	}
 
@@ -131,7 +131,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 
 	c.compressor.Set(nil)
 	c.mpc.Set(nil)
-	c.dhw.Set(nil)
+	c.mdt.Set(nil)
 	c.lpc.Set(nil)
 }
 
@@ -161,7 +161,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
-		c.dhw.Update(entity)
+		c.mdt.Update(entity)
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
@@ -448,7 +448,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.dhw.Read(eebus.MDTTemperature,
+	return c.mdt.Read(eebus.MDTTemperature,
 		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
 			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -304,13 +304,13 @@ func ohpcfControlAction(state ucapi.CompressorPowerConsumptionStateType, enable 
 // stop pauses the optional consumption if the compressor permits it, otherwise
 // it aborts the process.
 func (c *EEBusOHPCF) stop(entity spineapi.EntityRemoteInterface) error {
-	if pausable, err := c.cem.OHPCF.ConsumptionIsPausable(entity); err == nil && pausable {
+	if pausable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsPausable); err == nil && pausable {
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, cb)
 		})
 	}
 
-	if stoppable, err := c.cem.OHPCF.ConsumptionIsStoppable(entity); err == nil && stoppable {
+	if stoppable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsStoppable); err == nil && stoppable {
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, cb)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -35,10 +35,10 @@ type EEBusOHPCF struct {
 	reboost time.Duration
 
 	log        *util.Logger
-	compressor eebus.Entity
-	mpc        eebus.Entity
-	dhw        eebus.Entity
-	egLpc      eebus.Entity
+	compressor *eebus.Entity
+	mpc        *eebus.Entity
+	dhw        *eebus.Entity
+	lpc        *eebus.Entity
 
 	mu         sync.RWMutex
 	enabled    bool
@@ -81,15 +81,23 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		return nil, err
 	}
 
+	cem := inst.CustomerEnergyManagement()
+	ma := inst.MonitoringAppliance()
+	eg := inst.EnergyGuard()
+
 	c := &EEBusOHPCF{
-		embed:     embed,
-		log:       util.NewLogger("eebus-ohpcf"),
-		cem:       inst.CustomerEnergyManagement(),
-		ma:        inst.MonitoringAppliance(),
-		eg:        inst.EnergyGuard(),
-		connector: eebus.NewConnector(),
-		ctx:       ctx,
-		reboost:   reboost,
+		embed:      embed,
+		log:        util.NewLogger("eebus-ohpcf"),
+		cem:        cem,
+		ma:         ma,
+		eg:         eg,
+		connector:  eebus.NewConnector(),
+		ctx:        ctx,
+		reboost:    reboost,
+		compressor: eebus.NewEntity(cem.OHPCF),
+		mpc:        eebus.NewEntity(ma.MaMPCInterface),
+		dhw:        eebus.NewEntity(ma.MaMDTInterface),
+		lpc:        eebus.NewEntity(eg.EgLPCInterface),
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -123,7 +131,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 	c.compressor.Set(nil)
 	c.mpc.Set(nil)
 	c.dhw.Set(nil)
-	c.egLpc.Set(nil)
+	c.lpc.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -135,7 +143,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	switch event {
 	case ohpcf.UseCaseSupportUpdate:
-		c.compressor.Update(c.cem.OHPCF, entity)
+		c.compressor.Update(entity)
 
 	case ohpcf.DataUpdateConsumptionState:
 		// react immediately to a freshly announced schedule/resume opportunity
@@ -148,15 +156,15 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
-		c.mpc.Update(c.ma.MaMPCInterface, entity)
+		c.mpc.Update(entity)
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
-		c.dhw.Update(c.ma.MaMDTInterface, entity)
+		c.dhw.Update(entity)
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
-		c.egLpc.Update(c.eg.EgLPCInterface, entity)
+		c.lpc.Update(entity)
 	}
 }
 
@@ -187,7 +195,7 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
+	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return api.StatusNone, err
 	}
@@ -204,7 +212,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor); err != nil {
+	if _, err := c.compressor.Required(eebus.OHPCFMonitor); err != nil {
 		return false, err
 	}
 
@@ -325,7 +333,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := c.egLpc.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -338,7 +346,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity := c.egLpc.Get()
+	entity := c.lpc.Get()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -353,7 +361,7 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply() error {
-	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
+	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return err
 	}
@@ -386,7 +394,7 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
+	entity, err := c.compressor.Required(eebus.OHPCFMonitor)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -407,7 +415,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return c.mpc.Read(c.ma.MaMPCInterface, eebus.MPCPower, c.ma.MaMPCInterface.Power)
+	return c.mpc.Read(eebus.MPCPower, c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -415,7 +423,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.dhw.Read(c.ma.MaMDTInterface, eebus.MDTTemperature,
+	return c.dhw.Read(eebus.MDTTemperature,
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -2,7 +2,6 @@ package charger
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -47,9 +46,6 @@ type EEBusOHPCF struct {
 
 	connector *eebus.Connector
 }
-
-// errNotConnected is returned whenever the compressor entity is not (yet) available.
-var errNotConnected = errors.New("not connected")
 
 func init() {
 	registry.AddCtx("eebus-ohpcf", NewEEBusOHPCFFromConfig)
@@ -201,11 +197,13 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 }
 
-func (c *EEBusOHPCF) connectedCompressor() (spineapi.EntityRemoteInterface, bool) {
+// compressorEntity returns the compressor entity or ErrNotConnected while the
+// OHPCF use case is not (yet) available at it.
+func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return c.compressor, c.compressor != nil
+	return eebus.RequiredEntity(c.cem.OHPCF, c.compressor, eebus.OHPCFMonitor)
 }
 
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
@@ -242,9 +240,9 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, ok := c.connectedCompressor()
-	if !ok {
-		return api.StatusNone, errNotConnected
+	entity, err := c.compressorEntity()
+	if err != nil {
+		return api.StatusNone, err
 	}
 
 	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
@@ -259,8 +257,8 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, ok := c.connectedCompressor(); !ok {
-		return false, errNotConnected
+	if _, err := c.compressorEntity(); err != nil {
+		return false, err
 	}
 
 	return c.lastEnabled(), nil
@@ -390,18 +388,8 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 	entity := c.egLpcEntity
 	c.mu.RUnlock()
 
-	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
-		return false, api.ErrNotAvailable
-	}
-
-	limit, err := c.eg.EgLPCInterface.ConsumptionLimit(entity)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, entity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
-		// scenario announced but no usable value yet
-		if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrDataInvalid) {
-			return false, api.ErrNotAvailable
-		}
 		return false, err
 	}
 
@@ -438,9 +426,9 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply(enable bool) error {
-	entity, ok := c.connectedCompressor()
-	if !ok {
-		return errNotConnected
+	entity, err := c.compressorEntity()
+	if err != nil {
+		return err
 	}
 
 	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
@@ -471,9 +459,9 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, ok := c.connectedCompressor()
-	if !ok {
-		return 0, 0, errNotConnected
+	entity, err := c.compressorEntity()
+	if err != nil {
+		return 0, 0, err
 	}
 
 	if power, _ := c.cem.OHPCF.RequestedPowerEstimate(entity); power > 0 {
@@ -496,16 +484,7 @@ func (c *EEBusOHPCF) CurrentPower() (float64, error) {
 	entity := c.mpcEntity
 	c.mu.RUnlock()
 
-	if entity == nil || !c.ma.MaMPCInterface.IsScenarioAvailableAtEntity(entity, eebus.MPCPower) {
-		return 0, api.ErrNotAvailable
-	}
-
-	power, err := c.ma.MaMPCInterface.Power(entity)
-	if err != nil {
-		return 0, eebus.WrapError(err)
-	}
-
-	return power, nil
+	return eebus.ReadValue(c.ma.MaMPCInterface, entity, eebus.MPCPower, c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -517,14 +496,8 @@ func (c *EEBusOHPCF) Soc() (float64, error) {
 	entity := c.dhwEntity
 	c.mu.RUnlock()
 
-	if entity == nil || !c.ma.MaMDTInterface.IsScenarioAvailableAtEntity(entity, eebus.MDTTemperature) {
-		return 0, api.ErrNotAvailable
-	}
-
-	temp, err := c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
-	if err != nil {
-		return 0, eebus.WrapError(err)
-	}
-
-	return temp, nil
+	return eebus.ReadValue(c.ma.MaMDTInterface, entity, eebus.MDTTemperature,
+		func(entity spineapi.EntityRemoteInterface) (float64, error) {
+			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
+		})
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -195,12 +195,11 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
-	if err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return api.StatusNone, err
 	}
 
-	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
+	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// connected but no flexibility announced yet: standby, not disconnected
 		return api.StatusB, nil
@@ -394,16 +393,15 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	entity, err := c.ohpcf.Required(eebus.OHPCFMonitor)
-	if err != nil {
+	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
 		return 0, 0, err
 	}
 
-	if power, _ := c.cem.OHPCF.RequestedPowerEstimate(entity); power > 0 {
+	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerEstimate); power > 0 {
 		return power, power, nil
 	}
 
-	if power, _ := c.cem.OHPCF.RequestedPowerMax(entity); power > 0 {
+	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerMax); power > 0 {
 		return power, power, nil
 	}
 

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -135,7 +135,7 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 
 // UseCaseEvent implements the eebus.Device interface
 func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
-	// device/entity removal fires the use case update event with a nil entity
+	// device removal fires the use case update event with a nil entity
 	if entity == nil {
 		return
 	}
@@ -154,8 +154,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 			}
 		}
 
-	case ohpcf.UseCaseSupportUpdate,
-		ohpcf.DataUpdateRequestedPowerEstimate,
+	case ohpcf.DataUpdateRequestedPowerEstimate,
 		ohpcf.DataUpdateRequestedPowerMax,
 		ohpcf.DataUpdateConsumptionIsStoppable,
 		ohpcf.DataUpdateConsumptionIsPausable,
@@ -166,28 +165,35 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.compressor = entity
 		c.mu.Unlock()
 
+	case ohpcf.UseCaseSupportUpdate:
+		c.mu.Lock()
+		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
+		c.mu.Unlock()
+
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		// use most specific selector
-		if c.mpcEntity == nil || len(entity.Address().Entity) < len(c.mpcEntity.Address().Entity) {
-			c.mpcEntity = entity
-		}
+		c.mpcEntity = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpcEntity, entity)
 		c.mu.Unlock()
 
 	// Monitoring Appliance MDT provides the DHW temperature
-	case mdt.UseCaseSupportUpdate, mdt.DataUpdateTemperature:
+	case mdt.DataUpdateTemperature:
 		c.mu.Lock()
 		c.dhwEntity = entity
+		c.mu.Unlock()
+
+	case mdt.UseCaseSupportUpdate:
+		c.mu.Lock()
+		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		// use most specific selector
-		if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
-			c.egLpcEntity = entity
+		prev := c.egLpcEntity
+		c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
 
+		if c.egLpcEntity != nil && c.egLpcEntity != prev {
 			// [LPC-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -349,9 +349,9 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	return eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
-	}))
+	})
 }
 
 // apply issues the command to align the optional consumption with the on/off

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -193,11 +193,11 @@ var _ api.Charger = (*EEBusOHPCF)(nil)
 
 // Status implements the api.Charger interface
 func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return api.StatusNone, err
 	}
 
-	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
+	state, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// connected but no flexibility announced yet: standby, not disconnected
 		return api.StatusB, nil
@@ -209,7 +209,7 @@ func (c *EEBusOHPCF) Status() (api.ChargeStatus, error) {
 // Enabled reports the commanded on/off intent; Status reflects the actual
 // compressor state.
 func (c *EEBusOHPCF) Enabled() (bool, error) {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return false, err
 	}
 
@@ -330,7 +330,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := c.lpc.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -343,25 +343,25 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity, err := c.lpc.Available(eebus.LPCLimit)
+	entity, err := c.lpc.Available()
 	if err != nil {
 		return err
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	return eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
-	})
+	}))
 }
 
 // apply issues the command to align the optional consumption with the on/off
 // intent. It is idempotent: ohpcfControlAction only acts on a state transition.
 func (c *EEBusOHPCF) apply() error {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return err
 	}
 
-	state, err := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
+	state, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.PowerConsumptionProcessState)
 	if err != nil {
 		// no process state announced yet, nothing to control
 		return nil
@@ -373,7 +373,7 @@ func (c *EEBusOHPCF) apply() error {
 	}
 
 	// controlling the process is a separate scenario from monitoring it
-	entity, err := c.ohpcf.Required(eebus.OHPCFControl)
+	entity, err := c.ohpcf.Required()
 	if err != nil {
 		return err
 	}
@@ -400,15 +400,15 @@ var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
 // GetMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
 func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
-	if _, err := c.ohpcf.Required(eebus.OHPCFMonitor); err != nil {
+	if _, err := c.ohpcf.Required(); err != nil {
 		return 0, 0, err
 	}
 
-	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerEstimate); power > 0 {
+	if power, _ := c.ohpcf.Read(ucapi.CemOHPCFInterface.RequestedPowerEstimate); power > 0 {
 		return power, power, nil
 	}
 
-	if power, _ := c.ohpcf.Read(eebus.OHPCFMonitor, ucapi.CemOHPCFInterface.RequestedPowerMax); power > 0 {
+	if power, _ := c.ohpcf.Read(ucapi.CemOHPCFInterface.RequestedPowerMax); power > 0 {
 		return power, power, nil
 	}
 
@@ -420,7 +420,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return c.mpc.Read(eebus.MPCPower, ucapi.MaMPCInterface.Power)
+	return c.mpc.Read(ucapi.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -428,7 +428,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return c.mdt.Read(eebus.MDTTemperature,
+	return c.mdt.Read(
 		func(uc ucapi.MaMDTInterface, entity spineapi.EntityRemoteInterface) (float64, error) {
 			return uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -140,6 +140,11 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	}
 
 	switch event {
+	case ohpcf.UseCaseSupportUpdate:
+		c.mu.Lock()
+		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
+		c.mu.Unlock()
+
 	case ohpcf.DataUpdateConsumptionState:
 		c.mu.Lock()
 		c.compressor = entity
@@ -164,11 +169,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.compressor = entity
 		c.mu.Unlock()
 
-	case ohpcf.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
-		c.mu.Unlock()
-
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
 		c.mu.Lock()
@@ -176,14 +176,14 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.mu.Unlock()
 
 	// Monitoring Appliance MDT provides the DHW temperature
-	case mdt.DataUpdateTemperature:
-		c.mu.Lock()
-		c.dhwEntity = entity
-		c.mu.Unlock()
-
 	case mdt.UseCaseSupportUpdate:
 		c.mu.Lock()
 		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
+		c.mu.Unlock()
+
+	case mdt.DataUpdateTemperature:
+		c.mu.Lock()
+		c.dhwEntity = entity
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -143,10 +143,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.mu.Unlock()
 
 	case ohpcf.DataUpdateConsumptionState:
-		c.mu.Lock()
-		c.compressor = entity
-		c.mu.Unlock()
-
 		// react immediately to a freshly announced schedule/resume opportunity
 		// instead of waiting for the next reboost tick, which may miss it (#31549)
 		if c.lastEnabled() {
@@ -154,17 +150,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 				c.log.DEBUG.Printf("apply: %v", err)
 			}
 		}
-
-	case ohpcf.DataUpdateRequestedPowerEstimate,
-		ohpcf.DataUpdateRequestedPowerMax,
-		ohpcf.DataUpdateConsumptionIsStoppable,
-		ohpcf.DataUpdateConsumptionIsPausable,
-		ohpcf.DataUpdateConsumptionStartTime,
-		ohpcf.DataUpdateMinimalRunDuration,
-		ohpcf.DataUpdateMinimalPauseDuration:
-		c.mu.Lock()
-		c.compressor = entity
-		c.mu.Unlock()
 
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
@@ -176,11 +161,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	case mdt.UseCaseSupportUpdate:
 		c.mu.Lock()
 		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
-		c.mu.Unlock()
-
-	case mdt.DataUpdateTemperature:
-		c.mu.Lock()
-		c.dhwEntity = entity
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -142,10 +142,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 		c.mu.Unlock()
 
 	case ohpcf.DataUpdateConsumptionState:
-		c.mu.Lock()
-		c.compressor = entity
-		c.mu.Unlock()
-
 		// react immediately to a freshly announced schedule/resume opportunity
 		// instead of waiting for the next reboost tick, which may miss it (#31549)
 		if c.lastEnabled() {
@@ -153,17 +149,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 				c.log.DEBUG.Printf("apply: %v", err)
 			}
 		}
-
-	case ohpcf.DataUpdateRequestedPowerEstimate,
-		ohpcf.DataUpdateRequestedPowerMax,
-		ohpcf.DataUpdateConsumptionIsStoppable,
-		ohpcf.DataUpdateConsumptionIsPausable,
-		ohpcf.DataUpdateConsumptionStartTime,
-		ohpcf.DataUpdateMinimalRunDuration,
-		ohpcf.DataUpdateMinimalPauseDuration:
-		c.mu.Lock()
-		c.compressor = entity
-		c.mu.Unlock()
 
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
@@ -175,11 +160,6 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	case mdt.UseCaseSupportUpdate:
 		c.mu.Lock()
 		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
-		c.mu.Unlock()
-
-	case mdt.DataUpdateTemperature:
-		c.mu.Lock()
-		c.dhwEntity = entity
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -27,9 +27,6 @@ import (
 // it pauses or aborts the running process.
 type EEBusOHPCF struct {
 	*embed
-	cem *eebus.CustomerEnergyManagement
-	eg  *eebus.EnergyGuard
-
 	ctx     context.Context
 	reboost time.Duration
 
@@ -88,8 +85,6 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 	c := &EEBusOHPCF{
 		embed:     embed,
 		log:       util.NewLogger("eebus-ohpcf"),
-		cem:       cem,
-		eg:        eg,
 		connector: eebus.NewConnector(),
 		ctx:       ctx,
 		reboost:   reboost,
@@ -320,17 +315,13 @@ func ohpcfControlAction(state ucapi.CompressorPowerConsumptionStateType, enable 
 
 // stop pauses the optional consumption if the compressor permits it, otherwise
 // it aborts the process.
-func (c *EEBusOHPCF) stop(entity spineapi.EntityRemoteInterface) error {
+func (c *EEBusOHPCF) stop() error {
 	if pausable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsPausable); err == nil && pausable {
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, cb)
-		})
+		return c.ohpcf.Write(ucapi.CemOHPCFInterface.PausePowerConsumptionProcess)
 	}
 
 	if stoppable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsStoppable); err == nil && stoppable {
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, cb)
-		})
+		return c.ohpcf.Write(ucapi.CemOHPCFInterface.AbortPowerConsumptionProcess)
 	}
 
 	return api.ErrNotAvailable
@@ -360,14 +351,9 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity, err := c.lpc.Available()
-	if err != nil {
-		return err
-	}
-
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
+	if err := c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
 	}); err != nil {
 		return err
 	}
@@ -397,24 +383,16 @@ func (c *EEBusOHPCF) apply(enable bool) error {
 		return nil
 	}
 
-	// controlling the process is a separate scenario from monitoring it
-	entity, err := c.ohpcf.Required()
-	if err != nil {
-		return err
-	}
-
 	switch action {
 	case ohpcfSchedule:
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+		return c.ohpcf.Write(func(uc ucapi.CemOHPCFInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
 			// 0 = start immediately (relative schedule, see SchedulePowerConsumptionProcess)
-			return c.cem.OHPCF.SchedulePowerConsumptionProcess(entity, 0, cb)
+			return uc.SchedulePowerConsumptionProcess(entity, 0, cb)
 		})
 	case ohpcfResume:
-		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-			return c.cem.OHPCF.ResumePowerConsumptionProcess(entity, cb)
-		})
+		return c.ohpcf.Write(ucapi.CemOHPCFInterface.ResumePowerConsumptionProcess)
 	case ohpcfStop:
-		return c.stop(entity)
+		return c.stop()
 	}
 
 	return nil

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -34,12 +34,13 @@ type EEBusOHPCF struct {
 	ctx     context.Context
 	reboost time.Duration
 
-	mu         sync.RWMutex
 	log        *util.Logger
-	compressor spineapi.EntityRemoteInterface
-	mpc        spineapi.EntityRemoteInterface
-	dhw        spineapi.EntityRemoteInterface
-	egLpc      spineapi.EntityRemoteInterface
+	compressor eebus.Entity
+	mpc        eebus.Entity
+	dhw        eebus.Entity
+	egLpc      eebus.Entity
+
+	mu         sync.RWMutex
 	enabled    bool
 	reboosting bool
 
@@ -119,13 +120,10 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.compressor = nil
-	c.mpc = nil
-	c.dhw = nil
-	c.egLpc = nil
+	c.compressor.Set(nil)
+	c.mpc.Set(nil)
+	c.dhw.Set(nil)
+	c.egLpc.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -137,9 +135,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	switch event {
 	case ohpcf.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.compressor = eebus.UpdateEntity(c.cem.OHPCF, c.compressor, entity)
-		c.mu.Unlock()
+		c.compressor.Update(c.cem.OHPCF, entity)
 
 	case ohpcf.DataUpdateConsumptionState:
 		// react immediately to a freshly announced schedule/resume opportunity
@@ -152,55 +148,22 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.mpc = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpc, entity)
-		c.mu.Unlock()
+		c.mpc.Update(c.ma.MaMPCInterface, entity)
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.dhw = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhw, entity)
-		c.mu.Unlock()
+		c.dhw.Update(c.ma.MaMDTInterface, entity)
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
-		c.mu.Lock()
-		c.egLpc = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpc, entity)
-		c.mu.Unlock()
+		c.egLpc.Update(c.eg.EgLPCInterface, entity)
 	}
 }
 
 // compressorEntity returns the compressor entity or ErrNotConnected while the
 // OHPCF use case is not (yet) available at it.
 func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return eebus.RequiredEntity(c.cem.OHPCF, eebus.OHPCFMonitor, c.compressor)
-}
-
-// mpcEntity returns the entity providing the measured power consumption
-func (c *EEBusOHPCF) mpcEntity() spineapi.EntityRemoteInterface {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.mpc
-}
-
-// dhwEntity returns the entity providing the domestic hot water temperature
-func (c *EEBusOHPCF) dhwEntity() spineapi.EntityRemoteInterface {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.dhw
-}
-
-// egLpcEntity returns the entity carrying the §14a/LPC consumption limit
-func (c *EEBusOHPCF) egLpcEntity() spineapi.EntityRemoteInterface {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.egLpc
+	return c.compressor.Required(c.cem.OHPCF, eebus.OHPCFMonitor)
 }
 
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
@@ -368,7 +331,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity(), c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpc.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -381,7 +344,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity := c.egLpcEntity()
+	entity := c.egLpc.Get()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -450,7 +413,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpcEntity(), c.ma.MaMPCInterface.Power)
+	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpc.Get(), c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -458,7 +421,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhwEntity(),
+	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhw.Get(),
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -325,7 +325,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpc.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpc.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -407,7 +407,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpc.Get(), c.ma.MaMPCInterface.Power)
+	return c.mpc.Read(c.ma.MaMPCInterface, eebus.MPCPower, c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -415,7 +415,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhw.Get(),
+	return c.dhw.Read(c.ma.MaMDTInterface, eebus.MDTTemperature,
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -321,13 +321,13 @@ func ohpcfControlAction(state ucapi.CompressorPowerConsumptionStateType, enable 
 // stop pauses the optional consumption if the compressor permits it, otherwise
 // it aborts the process.
 func (c *EEBusOHPCF) stop(entity spineapi.EntityRemoteInterface) error {
-	if pausable, err := c.cem.OHPCF.ConsumptionIsPausable(entity); err == nil && pausable {
+	if pausable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsPausable); err == nil && pausable {
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			return c.cem.OHPCF.PausePowerConsumptionProcess(entity, cb)
 		})
 	}
 
-	if stoppable, err := c.cem.OHPCF.ConsumptionIsStoppable(entity); err == nil && stoppable {
+	if stoppable, err := c.ohpcf.Read(ucapi.CemOHPCFInterface.ConsumptionIsStoppable); err == nil && stoppable {
 		return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 			return c.cem.OHPCF.AbortPowerConsumptionProcess(entity, cb)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -34,15 +34,15 @@ type EEBusOHPCF struct {
 	ctx     context.Context
 	reboost time.Duration
 
-	mu          sync.RWMutex
-	log         *util.Logger
-	compressor  spineapi.EntityRemoteInterface
-	mpcEntity   spineapi.EntityRemoteInterface
-	dhwEntity   spineapi.EntityRemoteInterface
-	egLpcEntity spineapi.EntityRemoteInterface
-	enabled     bool
-	reboosting  bool
-	dimmed      bool // last limit written, re-stated on reconnect
+	mu         sync.RWMutex
+	log        *util.Logger
+	compressor spineapi.EntityRemoteInterface
+	mpc        spineapi.EntityRemoteInterface
+	dhw        spineapi.EntityRemoteInterface
+	egLpc      spineapi.EntityRemoteInterface
+	enabled    bool
+	reboosting bool
+	dimmed     bool // last limit written, re-stated on reconnect
 
 	connector *eebus.Connector
 }
@@ -124,9 +124,9 @@ func (c *EEBusOHPCF) Connect(connected bool) {
 	defer c.mu.Unlock()
 
 	c.compressor = nil
-	c.mpcEntity = nil
-	c.dhwEntity = nil
-	c.egLpcEntity = nil
+	c.mpc = nil
+	c.dhw = nil
+	c.egLpc = nil
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -154,22 +154,22 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	// Monitoring Appliance MPC provides the measured power consumption
 	case mpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		c.mpcEntity = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpcEntity, entity)
+		c.mpc = eebus.UpdateEntity(c.ma.MaMPCInterface, c.mpc, entity)
 		c.mu.Unlock()
 
 	// Monitoring Appliance MDT provides the DHW temperature
 	case mdt.UseCaseSupportUpdate:
 		c.mu.Lock()
-		c.dhwEntity = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhwEntity, entity)
+		c.dhw = eebus.UpdateEntity(c.ma.MaMDTInterface, c.dhw, entity)
 		c.mu.Unlock()
 
 	// Energy Guard LPC carries the §14a/LPC consumption limit
 	case lpc.UseCaseSupportUpdate:
 		c.mu.Lock()
-		prev := c.egLpcEntity
-		c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
+		prev := c.egLpc
+		c.egLpc = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpc, entity)
 
-		if c.egLpcEntity != nil && c.egLpcEntity != prev {
+		if c.egLpc != nil && c.egLpc != prev {
 			// [LPC-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}
@@ -183,7 +183,35 @@ func (c *EEBusOHPCF) compressorEntity() (spineapi.EntityRemoteInterface, error) 
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return eebus.RequiredEntity(c.cem.OHPCF, c.compressor, eebus.OHPCFMonitor)
+	if c.compressor == nil {
+		return nil, eebus.ErrNotConnected
+	}
+
+	return eebus.RequiredEntity(c.cem.OHPCF, eebus.OHPCFMonitor, c.compressor)
+}
+
+// mpcEntity returns the entity providing the measured power consumption
+func (c *EEBusOHPCF) mpcEntity() spineapi.EntityRemoteInterface {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.mpc
+}
+
+// dhwEntity returns the entity providing the domestic hot water temperature
+func (c *EEBusOHPCF) dhwEntity() spineapi.EntityRemoteInterface {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.dhw
+}
+
+// egLpcEntity returns the entity carrying the §14a/LPC consumption limit
+func (c *EEBusOHPCF) egLpcEntity() spineapi.EntityRemoteInterface {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.egLpc
 }
 
 func (c *EEBusOHPCF) setEnabled(enabled bool) {
@@ -364,11 +392,7 @@ var _ api.Dimmer = (*EEBusOHPCF)(nil)
 // Dimmed implements the api.Dimmer interface, reporting whether a §14a/LPC
 // consumption limit is currently active on the heat pump.
 func (c *EEBusOHPCF) Dimmed() (bool, error) {
-	c.mu.RLock()
-	entity := c.egLpcEntity
-	c.mu.RUnlock()
-
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, entity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity(), c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -381,9 +405,7 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	c.mu.RLock()
-	entity := c.egLpcEntity
-	c.mu.RUnlock()
+	entity := c.egLpcEntity()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -460,11 +482,7 @@ var _ api.Meter = (*EEBusOHPCF)(nil)
 // CurrentPower implements the api.Meter interface and reports the heat pump's
 // measured power consumption via the MPC use case.
 func (c *EEBusOHPCF) CurrentPower() (float64, error) {
-	c.mu.RLock()
-	entity := c.mpcEntity
-	c.mu.RUnlock()
-
-	return eebus.ReadValue(c.ma.MaMPCInterface, entity, eebus.MPCPower, c.ma.MaMPCInterface.Power)
+	return eebus.ReadValue(c.ma.MaMPCInterface, eebus.MPCPower, c.mpcEntity(), c.ma.MaMPCInterface.Power)
 }
 
 var _ api.Battery = (*EEBusOHPCF)(nil)
@@ -472,11 +490,7 @@ var _ api.Battery = (*EEBusOHPCF)(nil)
 // Soc implements the api.Battery interface and reports the heat pump's domestic
 // hot water temperature in °C via the MDT use case.
 func (c *EEBusOHPCF) Soc() (float64, error) {
-	c.mu.RLock()
-	entity := c.dhwEntity
-	c.mu.RUnlock()
-
-	return eebus.ReadValue(c.ma.MaMDTInterface, entity, eebus.MDTTemperature,
+	return eebus.ReadValue(c.ma.MaMDTInterface, eebus.MDTTemperature, c.dhwEntity(),
 		func(entity spineapi.EntityRemoteInterface) (float64, error) {
 			return c.ma.MaMDTInterface.Temperature(entity, model.UnitOfMeasurementTypedegC)
 		})

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -28,7 +28,6 @@ import (
 type EEBusOHPCF struct {
 	*embed
 	cem *eebus.CustomerEnergyManagement
-	ma  *eebus.MonitoringAppliance
 	eg  *eebus.EnergyGuard
 
 	ctx     context.Context
@@ -89,7 +88,6 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		embed:     embed,
 		log:       util.NewLogger("eebus-ohpcf"),
 		cem:       cem,
-		ma:        ma,
 		eg:        eg,
 		connector: eebus.NewConnector(),
 		ctx:       ctx,
@@ -345,10 +343,9 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity := c.lpc.Get()
-
-	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
-		return api.ErrNotAvailable
+	entity, err := c.lpc.Available(eebus.LPCLimit)
+	if err != nil {
+		return err
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -28,7 +28,6 @@ import (
 type EEBusOHPCF struct {
 	*embed
 	cem *eebus.CustomerEnergyManagement
-	ma  *eebus.MonitoringAppliance
 	eg  *eebus.EnergyGuard
 
 	ctx     context.Context
@@ -90,7 +89,6 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		embed:     embed,
 		log:       util.NewLogger("eebus-ohpcf"),
 		cem:       cem,
-		ma:        ma,
 		eg:        eg,
 		connector: eebus.NewConnector(),
 		ctx:       ctx,
@@ -362,10 +360,9 @@ func (c *EEBusOHPCF) Dimmed() (bool, error) {
 // Dim implements the api.Dimmer interface. It writes a §14a/LPC consumption
 // limit (fixed 0W safe limit) to the heat pump while dimmed, releasing it otherwise.
 func (c *EEBusOHPCF) Dim(dim bool) error {
-	entity := c.lpc.Get()
-
-	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
-		return api.ErrNotAvailable
+	entity, err := c.lpc.Available(eebus.LPCLimit)
+	if err != nil {
+		return err
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -27,9 +27,9 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBusOHPCF{
-		log:         util.NewLogger("eebus-ohpcf-test"),
-		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc},
-		egLpcEntity: entity,
+		log:   util.NewLogger("eebus-ohpcf-test"),
+		eg:    &eebus.EnergyGuard{EgLPCInterface: lpc},
+		egLpc: entity,
 	}
 
 	return c, lpc, entity
@@ -87,7 +87,7 @@ func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpcEntity = nil
+		c.egLpc = nil
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -133,7 +133,7 @@ func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpcEntity = nil
+		c.egLpc = nil
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -29,7 +29,7 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	c := &EEBusOHPCF{
 		log: util.NewLogger("eebus-ohpcf-test"),
 		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
-		lpc: eebus.NewEntity(lpc),
+		lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
 	}
 	c.lpc.Set(entity)
 

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -31,7 +31,6 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	c := &EEBusOHPCF{
 		ctx: t.Context(),
 		log: util.NewLogger("eebus-ohpcf-test"),
-		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
 		lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
 	}
 	c.lpc.Set(entity)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -77,14 +77,6 @@ func TestOHPCF_LPC_Dim_WriteRejected(t *testing.T) {
 
 // Dim is gated: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
-			Return(nil, eebusapi.ErrNoCompatibleEntity)
-
-		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
 		c.lpc.Set(nil)
@@ -122,14 +114,6 @@ func TestOHPCF_LPC_Dimmed(t *testing.T) {
 
 // Dimmed is gated like Dim: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().ConsumptionLimit(entity).Return(ucapi.LoadLimit{}, eebusapi.ErrNoCompatibleEntity)
-
-		_, err := c.Dimmed()
-		assert.ErrorIs(t, err, api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
 		c.lpc.Set(nil)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -32,7 +32,7 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 		ctx: t.Context(),
 		log: util.NewLogger("eebus-ohpcf-test"),
 		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
-		lpc: eebus.NewEntity(lpc),
+		lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
 	}
 	c.lpc.Set(entity)
 

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -106,14 +106,6 @@ func TestOHPCF_LPC_Dim_WriteRejected(t *testing.T) {
 
 // Dim is gated: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
-			Return(nil, eebusapi.ErrNoCompatibleEntity)
-
-		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
 		c.lpc.Set(nil)
@@ -151,14 +143,6 @@ func TestOHPCF_LPC_Dimmed(t *testing.T) {
 
 // Dimmed is gated like Dim: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().ConsumptionLimit(entity).Return(ucapi.LoadLimit{}, eebusapi.ErrNoCompatibleEntity)
-
-		_, err := c.Dimmed()
-		assert.ErrorIs(t, err, api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
 		c.lpc.Set(nil)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -27,10 +27,10 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBusOHPCF{
-		log:   util.NewLogger("eebus-ohpcf-test"),
-		eg:    &eebus.EnergyGuard{EgLPCInterface: lpc},
-		egLpc: entity,
+		log: util.NewLogger("eebus-ohpcf-test"),
+		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
 	}
+	c.egLpc.Set(entity)
 
 	return c, lpc, entity
 }
@@ -87,7 +87,7 @@ func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc = nil
+		c.egLpc.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -133,7 +133,7 @@ func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc = nil
+		c.egLpc.Set(nil)
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -49,7 +49,6 @@ func TestOHPCF_LPC_EGMessages_ConsumptionLimit(t *testing.T) {
 	} {
 		t.Run("ATC_COM_PT_EGMessages_001_"+tc.name, func(t *testing.T) {
 			c, lpc, entity := newOHPCFEGCharger(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().
 				WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: tc.active}, mock.Anything).
 				Run(func(_ spineapi.EntityRemoteInterface, _ ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
@@ -65,7 +64,6 @@ func TestOHPCF_LPC_EGMessages_ConsumptionLimit(t *testing.T) {
 // A rejected write (NACK) must surface as an error, not silent success.
 func TestOHPCF_LPC_Dim_WriteRejected(t *testing.T) {
 	c, lpc, entity := newOHPCFEGCharger(t)
-	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 	lpc.EXPECT().
 		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 		Run(func(_ spineapi.EntityRemoteInterface, _ ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
@@ -79,9 +77,10 @@ func TestOHPCF_LPC_Dim_WriteRejected(t *testing.T) {
 
 // Dim is gated: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
+			Return(nil, eebusapi.ErrNoCompatibleEntity)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -112,7 +111,6 @@ func TestOHPCF_LPC_Dimmed(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, lpc, entity := newOHPCFEGCharger(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().ConsumptionLimit(entity).Return(tc.limit, nil)
 
 			got, err := c.Dimmed()
@@ -124,9 +122,9 @@ func TestOHPCF_LPC_Dimmed(t *testing.T) {
 
 // Dimmed is gated like Dim: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+		lpc.EXPECT().ConsumptionLimit(entity).Return(ucapi.LoadLimit{}, eebusapi.ErrNoCompatibleEntity)
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
@@ -146,7 +144,6 @@ func TestOHPCF_LPC_Dimmed_Discard(t *testing.T) {
 	for _, badErr := range []error{eebusapi.ErrDataInvalid, eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable} {
 		t.Run(badErr.Error(), func(t *testing.T) {
 			c, lpc, entity := newOHPCFEGCharger(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().ConsumptionLimit(entity).Return(ucapi.LoadLimit{}, badErr)
 
 			_, err := c.Dimmed()

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -32,8 +32,9 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 		ctx: t.Context(),
 		log: util.NewLogger("eebus-ohpcf-test"),
 		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
+		lpc: eebus.NewEntity(lpc),
 	}
-	c.egLpc.Set(entity)
+	c.lpc.Set(entity)
 
 	return c, lpc, entity
 }
@@ -68,7 +69,7 @@ func TestOHPCF_LPC_EGMessages_ConsumptionLimit(t *testing.T) {
 // limit to the CS - deactivated when nothing is being limited.
 func TestOHPCF_LPC_InitialLimit(t *testing.T) {
 	c, lpc, entity := newOHPCFEGCharger(t)
-	c.egLpc.Set(nil)
+	c.lpc.Set(nil)
 
 	written := make(chan ucapi.LoadLimit, 1)
 	lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
@@ -117,7 +118,7 @@ func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc.Set(nil)
+		c.lpc.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -163,7 +164,7 @@ func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc.Set(nil)
+		c.lpc.Set(nil)
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -73,7 +73,7 @@ func TestOHPCF_LPC_InitialLimit(t *testing.T) {
 	c.lpc.Set(nil)
 
 	written := make(chan ucapi.LoadLimit, 1)
-	lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{1})
+	lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
 	lpc.EXPECT().
 		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 		Run(func(_ spineapi.EntityRemoteInterface, limit ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -29,10 +29,10 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBusOHPCF{
-		ctx:         t.Context(),
-		log:         util.NewLogger("eebus-ohpcf-test"),
-		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc},
-		egLpcEntity: entity,
+		ctx:   t.Context(),
+		log:   util.NewLogger("eebus-ohpcf-test"),
+		eg:    &eebus.EnergyGuard{EgLPCInterface: lpc},
+		egLpc: entity,
 	}
 
 	return c, lpc, entity
@@ -68,9 +68,10 @@ func TestOHPCF_LPC_EGMessages_ConsumptionLimit(t *testing.T) {
 // limit to the CS - deactivated when nothing is being limited.
 func TestOHPCF_LPC_InitialLimit(t *testing.T) {
 	c, lpc, entity := newOHPCFEGCharger(t)
-	c.egLpcEntity = nil
+	c.egLpc = nil
 
 	written := make(chan ucapi.LoadLimit, 1)
+	lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
 	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 	lpc.EXPECT().
 		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
@@ -116,7 +117,7 @@ func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpcEntity = nil
+		c.egLpc = nil
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -162,7 +163,7 @@ func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpcEntity = nil
+		c.egLpc = nil
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -35,6 +35,9 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	}
 	c.lpc.Set(entity)
 
+	// entity announces every scenario unless a test overrides it
+	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, mock.Anything).Return(true).Maybe()
+
 	return c, lpc, entity
 }
 
@@ -162,4 +165,33 @@ func TestOHPCF_LPC_Dimmed_Discard(t *testing.T) {
 			assert.ErrorIs(t, err, api.ErrNotAvailable)
 		})
 	}
+}
+
+// Dim/Dimmed are gated: no announced LPC scenario, or no connected entity →
+// ErrNotAvailable.
+func TestOHPCF_LPC_Gating(t *testing.T) {
+	t.Run("scenario_not_announced", func(t *testing.T) {
+		// own mocks: the shared helper announces every scenario
+		lpc := egmocks.NewEgLPCInterface(t)
+		entity := spinemocks.NewEntityRemoteInterface(t)
+		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+
+		c := &EEBusOHPCF{
+			log: util.NewLogger("eebus-ohpcf-test"),
+			lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
+		}
+		c.lpc.Set(entity)
+
+		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
+
+		_, err := c.Dimmed()
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
+	t.Run("entity_not_connected", func(t *testing.T) {
+		c, _, _ := newOHPCFEGCharger(t)
+		c.lpc.Set(nil)
+
+		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
+	})
 }

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -29,11 +29,11 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBusOHPCF{
-		ctx:   t.Context(),
-		log:   util.NewLogger("eebus-ohpcf-test"),
-		eg:    &eebus.EnergyGuard{EgLPCInterface: lpc},
-		egLpc: entity,
+		ctx: t.Context(),
+		log: util.NewLogger("eebus-ohpcf-test"),
+		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
 	}
+	c.egLpc.Set(entity)
 
 	return c, lpc, entity
 }
@@ -68,7 +68,7 @@ func TestOHPCF_LPC_EGMessages_ConsumptionLimit(t *testing.T) {
 // limit to the CS - deactivated when nothing is being limited.
 func TestOHPCF_LPC_InitialLimit(t *testing.T) {
 	c, lpc, entity := newOHPCFEGCharger(t)
-	c.egLpc = nil
+	c.egLpc.Set(nil)
 
 	written := make(chan ucapi.LoadLimit, 1)
 	lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
@@ -117,7 +117,7 @@ func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc = nil
+		c.egLpc.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -163,7 +163,7 @@ func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc = nil
+		c.egLpc.Set(nil)
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -28,7 +28,6 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 
 	c := &EEBusOHPCF{
 		log: util.NewLogger("eebus-ohpcf-test"),
-		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
 		lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
 	}
 	c.lpc.Set(entity)

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -52,7 +52,6 @@ func TestOHPCF_LPC_EGMessages_ConsumptionLimit(t *testing.T) {
 	} {
 		t.Run("ATC_COM_PT_EGMessages_001_"+tc.name, func(t *testing.T) {
 			c, lpc, entity := newOHPCFEGCharger(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().
 				WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: tc.active}, mock.Anything).
 				Run(func(_ spineapi.EntityRemoteInterface, _ ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
@@ -72,8 +71,7 @@ func TestOHPCF_LPC_InitialLimit(t *testing.T) {
 	c.lpc.Set(nil)
 
 	written := make(chan ucapi.LoadLimit, 1)
-	lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
-	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
+	lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{1})
 	lpc.EXPECT().
 		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 		Run(func(_ spineapi.EntityRemoteInterface, limit ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
@@ -95,7 +93,6 @@ func TestOHPCF_LPC_InitialLimit(t *testing.T) {
 // A rejected write (NACK) must surface as an error, not silent success.
 func TestOHPCF_LPC_Dim_WriteRejected(t *testing.T) {
 	c, lpc, entity := newOHPCFEGCharger(t)
-	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 	lpc.EXPECT().
 		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 		Run(func(_ spineapi.EntityRemoteInterface, _ ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
@@ -109,9 +106,10 @@ func TestOHPCF_LPC_Dim_WriteRejected(t *testing.T) {
 
 // Dim is gated: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
+			Return(nil, eebusapi.ErrNoCompatibleEntity)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -142,7 +140,6 @@ func TestOHPCF_LPC_Dimmed(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, lpc, entity := newOHPCFEGCharger(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().ConsumptionLimit(entity).Return(tc.limit, nil)
 
 			got, err := c.Dimmed()
@@ -154,9 +151,9 @@ func TestOHPCF_LPC_Dimmed(t *testing.T) {
 
 // Dimmed is gated like Dim: no announced LPC scenario, or no connected entity → ErrNotAvailable.
 func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, lpc, entity := newOHPCFEGCharger(t)
-		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+		lpc.EXPECT().ConsumptionLimit(entity).Return(ucapi.LoadLimit{}, eebusapi.ErrNoCompatibleEntity)
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
@@ -176,7 +173,6 @@ func TestOHPCF_LPC_Dimmed_Discard(t *testing.T) {
 	for _, badErr := range []error{eebusapi.ErrDataInvalid, eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable} {
 		t.Run(badErr.Error(), func(t *testing.T) {
 			c, lpc, entity := newOHPCFEGCharger(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().ConsumptionLimit(entity).Return(ucapi.LoadLimit{}, badErr)
 
 			_, err := c.Dimmed()

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -29,8 +29,9 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	c := &EEBusOHPCF{
 		log: util.NewLogger("eebus-ohpcf-test"),
 		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc},
+		lpc: eebus.NewEntity(lpc),
 	}
-	c.egLpc.Set(entity)
+	c.lpc.Set(entity)
 
 	return c, lpc, entity
 }
@@ -87,7 +88,7 @@ func TestOHPCF_LPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc.Set(nil)
+		c.lpc.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -133,7 +134,7 @@ func TestOHPCF_LPC_Dimmed_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newOHPCFEGCharger(t)
-		c.egLpc.Set(nil)
+		c.lpc.Set(nil)
 
 		_, err := c.Dimmed()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -87,8 +87,9 @@ func TestOHPCFControlAction(t *testing.T) {
 	}
 }
 
-// a consumption-state update always records the compressor entity; while
-// disabled it must not attempt to apply (avoids acting on a stale intent, #31549).
+// while disabled a consumption-state update must not attempt to apply (avoids
+// acting on a stale intent, #31549). The compressor entity is recorded by the
+// use case support update, not by data events.
 func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 	c := &EEBusOHPCF{}
 	entity := spinemocks.NewEntityRemoteInterface(t)
@@ -98,5 +99,5 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	assert.Equal(t, entity, c.compressor)
+	assert.Nil(t, c.compressor)
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -25,7 +25,7 @@ func newTestOHPCF() *EEBusOHPCF {
 		eg:         eg,
 		compressor: eebus.NewEntity(cem.OHPCF),
 		mpc:        eebus.NewEntity(ma.MaMPCInterface),
-		dhw:        eebus.NewEntity(ma.MaMDTInterface),
+		mdt:        eebus.NewEntity(ma.MaMDTInterface),
 		lpc:        eebus.NewEntity(eg.EgLPCInterface),
 	}
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -109,5 +109,6 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	assert.Nil(t, c.ohpcf.Get())
+	_, err := c.ohpcf.Required()
+	assert.ErrorIs(t, err, eebus.ErrNotConnected)
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -52,7 +52,7 @@ func TestEEBusOHPCFNotConnected(t *testing.T) {
 // a failed enable must not persist the intent, otherwise Enabled() reports a
 // state the compressor never accepted and the loadpoint runs out of sync (#32252).
 func TestOHPCFEnableFailureKeepsState(t *testing.T) {
-	c := &EEBusOHPCF{compressor: eebus.NewEntity(nil)}
+	c := &EEBusOHPCF{compressor: eebus.NewEntity[ucapi.CemOHPCFInterface](nil)}
 
 	require.ErrorIs(t, c.Enable(true), eebus.ErrNotConnected)
 	assert.False(t, c.lastEnabled())

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -40,7 +40,7 @@ func TestEEBusOHPCFNotConnected(t *testing.T) {
 func TestOHPCFEnableFailureKeepsState(t *testing.T) {
 	c := &EEBusOHPCF{}
 
-	require.ErrorIs(t, c.Enable(true), errNotConnected)
+	require.ErrorIs(t, c.Enable(true), eebus.ErrNotConnected)
 	assert.False(t, c.lastEnabled())
 }
 

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -78,8 +78,9 @@ func TestOHPCFControlAction(t *testing.T) {
 	}
 }
 
-// a consumption-state update always records the compressor entity; while
-// disabled it must not attempt to apply (avoids acting on a stale intent, #31549).
+// while disabled a consumption-state update must not attempt to apply (avoids
+// acting on a stale intent, #31549). The compressor entity is recorded by the
+// use case support update, not by data events.
 func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 	c := &EEBusOHPCF{}
 	entity := spinemocks.NewEntityRemoteInterface(t)
@@ -89,5 +90,5 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	assert.Equal(t, entity, c.compressor)
+	assert.Nil(t, c.compressor)
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -13,8 +13,11 @@ import (
 )
 
 // newTestOHPCF returns a charger without any use case implementation, so all
-// entities remain empty
-func newTestOHPCF() *EEBusOHPCF {
+// entities remain empty. eebus-go ships no CemOHPCFInterface mock, so reaching
+// a use case call panics rather than failing an expectation.
+func newTestOHPCF(t *testing.T) *EEBusOHPCF {
+	t.Helper()
+
 	cem := new(eebus.CustomerEnergyManagement)
 	ma := new(eebus.MonitoringAppliance)
 	eg := new(eebus.EnergyGuard)
@@ -30,7 +33,7 @@ func newTestOHPCF() *EEBusOHPCF {
 // methods accessing the compressor entity must error when it is absent,
 // so a missing compressor is not mistaken for an idle device.
 func TestEEBusOHPCFNotConnected(t *testing.T) {
-	c := newTestOHPCF()
+	c := newTestOHPCF(t)
 
 	status, err := c.Status()
 	require.ErrorIs(t, err, eebus.ErrNotConnected)
@@ -98,15 +101,17 @@ func TestOHPCFControlAction(t *testing.T) {
 	}
 }
 
-// while disabled a consumption-state update must not attempt to apply (avoids
-// acting on a stale intent, #31549). The compressor entity is recorded by the
-// use case support update, not by data events.
+// the compressor entity is latched from data events too: heat pumps stream
+// flexibility data without necessarily announcing the use case with scenarios.
+// While disabled the event must still not apply (stale intent, #31549) - an
+// apply would call the mocked use case and fail the test.
 func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
-	c := newTestOHPCF()
+	c := newTestOHPCF(t)
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	_, err := c.ohpcf.Required()
-	assert.ErrorIs(t, err, eebus.ErrNotConnected)
+	recorded, err := c.ohpcf.Required()
+	require.NoError(t, err)
+	assert.Equal(t, entity, recorded)
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -100,5 +100,6 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	assert.Nil(t, c.ohpcf.Get())
+	_, err := c.ohpcf.Required()
+	assert.ErrorIs(t, err, eebus.ErrNotConnected)
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -87,8 +87,5 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	assert.Nil(t, c.compressor)
+	assert.Nil(t, c.compressor.Get())
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/enbility/eebus-go/usecases/cem/ohpcf"
 	spinemocks "github.com/enbility/spine-go/mocks"
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,17 +15,21 @@ import (
 // methods accessing the compressor entity must error when it is absent,
 // so a missing compressor is not mistaken for an idle device.
 func TestEEBusOHPCFNotConnected(t *testing.T) {
-	c := &EEBusOHPCF{}
+	c := &EEBusOHPCF{
+		cem: &eebus.CustomerEnergyManagement{},
+		ma:  &eebus.MonitoringAppliance{},
+		eg:  &eebus.EnergyGuard{},
+	}
 
 	status, err := c.Status()
-	require.ErrorIs(t, err, errNotConnected)
+	require.ErrorIs(t, err, eebus.ErrNotConnected)
 	assert.Equal(t, api.StatusNone, status)
 
 	_, err = c.Enabled()
-	require.ErrorIs(t, err, errNotConnected)
+	require.ErrorIs(t, err, eebus.ErrNotConnected)
 
-	require.ErrorIs(t, c.Enable(true), errNotConnected)
-	require.ErrorIs(t, c.MaxCurrent(16), errNotConnected)
+	require.ErrorIs(t, c.Enable(true), eebus.ErrNotConnected)
+	require.ErrorIs(t, c.MaxCurrent(16), eebus.ErrNotConnected)
 
 	// dimming uses EG LPC, which is unavailable without an LPC entity
 	require.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
@@ -90,7 +95,8 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	got, ok := c.connectedCompressor()
-	require.True(t, ok)
-	assert.Equal(t, entity, got)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	assert.Equal(t, entity, c.compressor)
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -12,14 +12,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newTestOHPCF returns a charger without any use case implementation, so all
+// entities remain empty
+func newTestOHPCF() *EEBusOHPCF {
+	cem := new(eebus.CustomerEnergyManagement)
+	ma := new(eebus.MonitoringAppliance)
+	eg := new(eebus.EnergyGuard)
+
+	return &EEBusOHPCF{
+		cem:        cem,
+		ma:         ma,
+		eg:         eg,
+		compressor: eebus.NewEntity(cem.OHPCF),
+		mpc:        eebus.NewEntity(ma.MaMPCInterface),
+		dhw:        eebus.NewEntity(ma.MaMDTInterface),
+		lpc:        eebus.NewEntity(eg.EgLPCInterface),
+	}
+}
+
 // methods accessing the compressor entity must error when it is absent,
 // so a missing compressor is not mistaken for an idle device.
 func TestEEBusOHPCFNotConnected(t *testing.T) {
-	c := &EEBusOHPCF{
-		cem: &eebus.CustomerEnergyManagement{},
-		ma:  &eebus.MonitoringAppliance{},
-		eg:  &eebus.EnergyGuard{},
-	}
+	c := newTestOHPCF()
 
 	status, err := c.Status()
 	require.ErrorIs(t, err, eebus.ErrNotConnected)
@@ -38,7 +52,7 @@ func TestEEBusOHPCFNotConnected(t *testing.T) {
 // a failed enable must not persist the intent, otherwise Enabled() reports a
 // state the compressor never accepted and the loadpoint runs out of sync (#32252).
 func TestOHPCFEnableFailureKeepsState(t *testing.T) {
-	c := &EEBusOHPCF{cem: new(eebus.CustomerEnergyManagement)}
+	c := &EEBusOHPCF{compressor: eebus.NewEntity(nil)}
 
 	require.ErrorIs(t, c.Enable(true), eebus.ErrNotConnected)
 	assert.False(t, c.lastEnabled())
@@ -91,7 +105,7 @@ func TestOHPCFControlAction(t *testing.T) {
 // acting on a stale intent, #31549). The compressor entity is recorded by the
 // use case support update, not by data events.
 func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
-	c := &EEBusOHPCF{}
+	c := newTestOHPCF()
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -21,7 +21,6 @@ func newTestOHPCF() *EEBusOHPCF {
 
 	return &EEBusOHPCF{
 		cem:   cem,
-		ma:    ma,
 		eg:    eg,
 		ohpcf: eebus.NewEntity(cem.OHPCF),
 		mpc:   eebus.NewEntity(ma.MaMPCInterface),

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -20,13 +20,13 @@ func newTestOHPCF() *EEBusOHPCF {
 	eg := new(eebus.EnergyGuard)
 
 	return &EEBusOHPCF{
-		cem:        cem,
-		ma:         ma,
-		eg:         eg,
-		compressor: eebus.NewEntity(cem.OHPCF),
-		mpc:        eebus.NewEntity(ma.MaMPCInterface),
-		mdt:        eebus.NewEntity(ma.MaMDTInterface),
-		lpc:        eebus.NewEntity(eg.EgLPCInterface),
+		cem:   cem,
+		ma:    ma,
+		eg:    eg,
+		ohpcf: eebus.NewEntity(cem.OHPCF),
+		mpc:   eebus.NewEntity(ma.MaMPCInterface),
+		mdt:   eebus.NewEntity(ma.MaMDTInterface),
+		lpc:   eebus.NewEntity(eg.EgLPCInterface),
 	}
 }
 
@@ -52,7 +52,7 @@ func TestEEBusOHPCFNotConnected(t *testing.T) {
 // a failed enable must not persist the intent, otherwise Enabled() reports a
 // state the compressor never accepted and the loadpoint runs out of sync (#32252).
 func TestOHPCFEnableFailureKeepsState(t *testing.T) {
-	c := &EEBusOHPCF{compressor: eebus.NewEntity[ucapi.CemOHPCFInterface](nil)}
+	c := &EEBusOHPCF{ohpcf: eebus.NewEntity[ucapi.CemOHPCFInterface](nil)}
 
 	require.ErrorIs(t, c.Enable(true), eebus.ErrNotConnected)
 	assert.False(t, c.lastEnabled())
@@ -110,5 +110,5 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	assert.Nil(t, c.compressor.Get())
+	assert.Nil(t, c.ohpcf.Get())
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -20,8 +20,6 @@ func newTestOHPCF() *EEBusOHPCF {
 	eg := new(eebus.EnergyGuard)
 
 	return &EEBusOHPCF{
-		cem:   cem,
-		eg:    eg,
 		ohpcf: eebus.NewEntity(cem.OHPCF),
 		mpc:   eebus.NewEntity(ma.MaMPCInterface),
 		mdt:   eebus.NewEntity(ma.MaMDTInterface),

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -12,14 +12,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newTestOHPCF returns a charger without any use case implementation, so all
+// entities remain empty
+func newTestOHPCF() *EEBusOHPCF {
+	cem := new(eebus.CustomerEnergyManagement)
+	ma := new(eebus.MonitoringAppliance)
+	eg := new(eebus.EnergyGuard)
+
+	return &EEBusOHPCF{
+		cem:        cem,
+		ma:         ma,
+		eg:         eg,
+		compressor: eebus.NewEntity(cem.OHPCF),
+		mpc:        eebus.NewEntity(ma.MaMPCInterface),
+		dhw:        eebus.NewEntity(ma.MaMDTInterface),
+		lpc:        eebus.NewEntity(eg.EgLPCInterface),
+	}
+}
+
 // methods accessing the compressor entity must error when it is absent,
 // so a missing compressor is not mistaken for an idle device.
 func TestEEBusOHPCFNotConnected(t *testing.T) {
-	c := &EEBusOHPCF{
-		cem: &eebus.CustomerEnergyManagement{},
-		ma:  &eebus.MonitoringAppliance{},
-		eg:  &eebus.EnergyGuard{},
-	}
+	c := newTestOHPCF()
 
 	status, err := c.Status()
 	require.ErrorIs(t, err, eebus.ErrNotConnected)
@@ -82,7 +96,7 @@ func TestOHPCFControlAction(t *testing.T) {
 // acting on a stale intent, #31549). The compressor entity is recorded by the
 // use case support update, not by data events.
 func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
-	c := &EEBusOHPCF{}
+	c := newTestOHPCF()
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/enbility/eebus-go/usecases/cem/ohpcf"
 	spinemocks "github.com/enbility/spine-go/mocks"
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,17 +15,21 @@ import (
 // methods accessing the compressor entity must error when it is absent,
 // so a missing compressor is not mistaken for an idle device.
 func TestEEBusOHPCFNotConnected(t *testing.T) {
-	c := &EEBusOHPCF{}
+	c := &EEBusOHPCF{
+		cem: &eebus.CustomerEnergyManagement{},
+		ma:  &eebus.MonitoringAppliance{},
+		eg:  &eebus.EnergyGuard{},
+	}
 
 	status, err := c.Status()
-	require.ErrorIs(t, err, errNotConnected)
+	require.ErrorIs(t, err, eebus.ErrNotConnected)
 	assert.Equal(t, api.StatusNone, status)
 
 	_, err = c.Enabled()
-	require.ErrorIs(t, err, errNotConnected)
+	require.ErrorIs(t, err, eebus.ErrNotConnected)
 
-	require.ErrorIs(t, c.Enable(true), errNotConnected)
-	require.ErrorIs(t, c.MaxCurrent(16), errNotConnected)
+	require.ErrorIs(t, c.Enable(true), eebus.ErrNotConnected)
+	require.ErrorIs(t, c.MaxCurrent(16), eebus.ErrNotConnected)
 
 	// dimming uses EG LPC, which is unavailable without an LPC entity
 	require.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
@@ -81,7 +86,8 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	got, ok := c.connectedCompressor()
-	require.True(t, ok)
-	assert.Equal(t, entity, got)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	assert.Equal(t, entity, c.compressor)
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -38,7 +38,7 @@ func TestEEBusOHPCFNotConnected(t *testing.T) {
 // a failed enable must not persist the intent, otherwise Enabled() reports a
 // state the compressor never accepted and the loadpoint runs out of sync (#32252).
 func TestOHPCFEnableFailureKeepsState(t *testing.T) {
-	c := &EEBusOHPCF{}
+	c := &EEBusOHPCF{cem: new(eebus.CustomerEnergyManagement)}
 
 	require.ErrorIs(t, c.Enable(true), eebus.ErrNotConnected)
 	assert.False(t, c.lastEnabled())
@@ -96,8 +96,5 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	assert.Nil(t, c.compressor)
+	assert.Nil(t, c.compressor.Get())
 }

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -20,13 +20,13 @@ func newTestOHPCF() *EEBusOHPCF {
 	eg := new(eebus.EnergyGuard)
 
 	return &EEBusOHPCF{
-		cem:        cem,
-		ma:         ma,
-		eg:         eg,
-		compressor: eebus.NewEntity(cem.OHPCF),
-		mpc:        eebus.NewEntity(ma.MaMPCInterface),
-		mdt:        eebus.NewEntity(ma.MaMDTInterface),
-		lpc:        eebus.NewEntity(eg.EgLPCInterface),
+		cem:   cem,
+		ma:    ma,
+		eg:    eg,
+		ohpcf: eebus.NewEntity(cem.OHPCF),
+		mpc:   eebus.NewEntity(ma.MaMPCInterface),
+		mdt:   eebus.NewEntity(ma.MaMDTInterface),
+		lpc:   eebus.NewEntity(eg.EgLPCInterface),
 	}
 }
 
@@ -101,5 +101,5 @@ func TestOHPCFUseCaseEventConsumptionStateDisabled(t *testing.T) {
 
 	c.UseCaseEvent(nil, entity, ohpcf.DataUpdateConsumptionState)
 
-	assert.Nil(t, c.compressor.Get())
+	assert.Nil(t, c.ohpcf.Get())
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -191,9 +191,9 @@ func (c *EEBus) Dim(dim bool) error {
 		return err
 	}
 
-	return eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
-	}))
+	})
 }
 
 var _ api.Curtailer = (*EEBus)(nil)
@@ -238,7 +238,7 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	return eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
-	}))
+	})
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -31,9 +31,9 @@ type EEBus struct {
 	mm        measurements
 	scenarios maScenarios
 
-	maEntity    *eebus.Entity
-	egLpcEntity *eebus.Entity
-	egLppEntity *eebus.Entity
+	maEntity    *eebus.Entity[measurements]
+	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
+	egLppEntity *eebus.Entity[ucapi.EgLPPInterface]
 
 	mu             sync.Mutex
 	dimmed         bool // last limits written, re-stated on reconnect
@@ -169,23 +169,23 @@ func (c *EEBus) lastCurtailPercent() int {
 	return c.curtailPercent
 }
 
-func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+func (c *EEBus) readValue[T any](scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	return c.maEntity.Read(scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.readValue(c.scenarios.power, c.mm.Power)
+	return c.readValue(c.scenarios.power, measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.readValue(c.scenarios.energy, c.mm.EnergyConsumed)
+	return c.readValue(c.scenarios.energy, measurements.EnergyConsumed)
 }
 
-func (c *EEBus) readPhases(scenario uint, update func(entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
+func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
 	res, err := c.readValue(scenario, update)
 	if err != nil {
 		return 0, 0, 0, err
@@ -209,20 +209,20 @@ func (c *EEBus) readPhases(scenario uint, update func(entity spineapi.EntityRemo
 var _ api.PhaseCurrents = (*EEBus)(nil)
 
 func (c *EEBus) Currents() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.currents, c.mm.CurrentPerPhase)
+	return c.readPhases(c.scenarios.currents, measurements.CurrentPerPhase)
 }
 
 var _ api.PhaseVoltages = (*EEBus)(nil)
 
 func (c *EEBus) Voltages() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.voltages, c.mm.VoltagePerPhase)
+	return c.readPhases(c.scenarios.voltages, measurements.VoltagePerPhase)
 }
 
 var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -268,7 +268,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(eebus.LPPLimit, ucapi.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -25,37 +25,11 @@ type EEBus struct {
 
 	connector *eebus.Connector
 	eg        *eebus.EnergyGuard
-	scenarios maScenarios
 
 	maEntity    *eebus.Entity[measurements]
 	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
 	egLppEntity *eebus.Entity[ucapi.EgLPPInterface]
 }
-
-// maScenarios holds the spec scenario numbers for the active monitoring use case.
-// MGCP and MPC use different scenario numbers for the same physical quantity, so
-// IsScenarioAvailableAtEntity must be called with the per-UC value.
-type maScenarios struct {
-	power    uint
-	energy   uint
-	currents uint
-	voltages uint
-}
-
-var (
-	mpcScenarios = maScenarios{
-		power:    eebus.MPCPower,
-		energy:   eebus.MPCEnergyConsumed,
-		currents: eebus.MPCCurrentPerPhase,
-		voltages: eebus.MPCVoltagePerPhase,
-	}
-	mgcpScenarios = maScenarios{
-		power:    eebus.MGCPPower,
-		energy:   eebus.MGCPEnergyConsumed,
-		currents: eebus.MGCPCurrentPerPhase,
-		voltages: eebus.MGCPVoltagePerPhase,
-	}
-)
 
 type measurements interface {
 	eebusapi.UseCaseBaseInterface
@@ -97,12 +71,10 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	// Use MGCP only for explicit grid usage, MPC for everything else (default)
 	useCase := "mpc"
 	mm := measurements(ma.MaMPCInterface)
-	scenarios := mpcScenarios
 
 	if usage != nil && *usage == templates.UsageGrid {
 		useCase = "mgcp"
 		mm = ma.MaMGCPInterface
-		scenarios = mgcpScenarios
 	}
 
 	eg := inst.EnergyGuard()
@@ -110,7 +82,6 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	c := &EEBus{
 		log:         util.NewLogger("eebus-" + useCase),
 		eg:          eg,
-		scenarios:   scenarios,
 		connector:   eebus.NewConnector(),
 		maEntity:    eebus.NewEntity(mm),
 		egLpcEntity: eebus.NewEntity(eg.EgLPCInterface),
@@ -146,17 +117,17 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.maEntity.Read(c.scenarios.power, measurements.Power)
+	return c.maEntity.Read(measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.maEntity.Read(c.scenarios.energy, measurements.EnergyConsumed)
+	return c.maEntity.Read(measurements.EnergyConsumed)
 }
 
-func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
-	res, err := c.maEntity.Read(scenario, update)
+func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
+	res, err := c.maEntity.Read(update)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -179,20 +150,20 @@ func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity sp
 var _ api.PhaseCurrents = (*EEBus)(nil)
 
 func (c *EEBus) Currents() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.currents, measurements.CurrentPerPhase)
+	return c.readPhases(measurements.CurrentPerPhase)
 }
 
 var _ api.PhaseVoltages = (*EEBus)(nil)
 
 func (c *EEBus) Voltages() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.voltages, measurements.VoltagePerPhase)
+	return c.readPhases(measurements.VoltagePerPhase)
 }
 
 var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -215,21 +186,21 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	entity, err := c.egLpcEntity.Available(eebus.LPCLimit)
+	entity, err := c.egLpcEntity.Available()
 	if err != nil {
 		return err
 	}
 
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	return eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
-	})
+	}))
 }
 
 var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(eebus.LPPLimit, ucapi.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -240,7 +211,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax)
+	nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -253,7 +224,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	entity, err := c.egLppEntity.Available(eebus.LPPLimit)
+	entity, err := c.egLppEntity.Available()
 	if err != nil {
 		return err
 	}
@@ -262,12 +233,12 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
 	if curtail {
-		if nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
+		if nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
 			value = -float64(percent) / 100 * nominal
 		}
 	}
 
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	return eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
-	})
+	}))
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -10,7 +10,6 @@ import (
 	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	spineapi "github.com/enbility/spine-go/api"
-	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/evcc-io/evcc/util"
@@ -206,9 +205,7 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	if err := c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
-	}); err != nil {
+	if err := c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: value, IsActive: dim}); err != nil {
 		return err
 	}
 
@@ -256,9 +253,7 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	if err := c.lpp.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-		return uc.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
-	}); err != nil {
+	if err := c.lpp.WriteArg(ucapi.EgLPPInterface.WriteProductionLimit, ucapi.LoadLimit{Value: value, IsActive: curtail}); err != nil {
 		return err
 	}
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -26,9 +26,7 @@ type EEBus struct {
 	log *util.Logger
 
 	connector *eebus.Connector
-	ma        *eebus.MonitoringAppliance
 	eg        *eebus.EnergyGuard
-	mm        measurements
 	scenarios maScenarios
 
 	maEntity    *eebus.Entity[measurements]
@@ -118,9 +116,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	c := &EEBus{
 		ctx:            ctx,
 		log:            util.NewLogger("eebus-" + useCase),
-		ma:             ma,
 		eg:             eg,
-		mm:             mm,
 		scenarios:      scenarios,
 		connector:      eebus.NewConnector(),
 		maEntity:       eebus.NewEntity(mm),
@@ -145,8 +141,8 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	}()
 
 	// monitoring appliance
-	eebus.LogEntities(c.log.DEBUG, "MA MPC", c.ma.MaMPCInterface)
-	eebus.LogEntities(c.log.DEBUG, "MA MGCP", c.ma.MaMGCPInterface)
+	eebus.LogEntities(c.log.DEBUG, "MA MPC", ma.MaMPCInterface)
+	eebus.LogEntities(c.log.DEBUG, "MA MGCP", ma.MaMGCPInterface)
 
 	// energy guard
 	eebus.LogEntities(c.log.DEBUG, "EG LPC", c.eg.EgLPCInterface)
@@ -241,10 +237,9 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	entity := c.egLpcEntity.Get()
-
-	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
-		return api.ErrNotAvailable
+	entity, err := c.egLpcEntity.Available(eebus.LPCLimit)
+	if err != nil {
+		return err
 	}
 
 	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
@@ -288,10 +283,9 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	entity := c.egLppEntity.Get()
-
-	if entity == nil || !c.eg.EgLPPInterface.IsScenarioAvailableAtEntity(entity, eebus.LPPLimit) {
-		return api.ErrNotAvailable
+	entity, err := c.egLppEntity.Available(eebus.LPPLimit)
+	if err != nil {
+		return err
 	}
 
 	// derive a proportional feed-in limit from the producer's nominal power

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -143,7 +143,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 }
 
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	return eebus.ReadValue(c.mm, scenario, c.maEntity.Get(), update)
+	return c.maEntity.Read(c.mm, scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -195,7 +195,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -233,9 +233,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	entity := c.egLppEntity.Get()
-
-	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, entity, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(c.eg.EgLPPInterface, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -246,7 +244,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(entity)
+	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(c.egLppEntity.Get())
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -245,7 +245,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(c.egLppEntity.Get())
+	nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -268,7 +268,7 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
 	if curtail {
-		if nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(entity); err == nil && nominal > 0 {
+		if nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
 			value = -float64(percent) / 100 * nominal
 		}
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -147,7 +147,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return eebus.ReadValue(c.mm, c.maEntity, scenario, update)
+	return eebus.ReadValue(c.mm, scenario, c.maEntity, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -202,7 +202,7 @@ func (c *EEBus) Dimmed() (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -245,7 +245,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, c.egLppEntity, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -2,7 +2,6 @@ package meter
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -145,31 +144,10 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	return c, nil
 }
 
-func eebusReadValue[T any](uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	var zero T
-
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return zero, api.ErrNotAvailable
-	}
-
-	res, err := update(entity)
-	if err != nil {
-		// scenario announced but no usable value yet
-		if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrDataInvalid) {
-			err = api.ErrNotAvailable
-		}
-		return zero, err
-	}
-
-	return res, nil
-}
-
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return eebusReadValue(c.mm, c.maEntity, scenario, update)
+	return eebus.ReadValue(c.mm, c.maEntity, scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -224,7 +202,7 @@ func (c *EEBus) Dimmed() (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebusReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -267,7 +245,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebusReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -2,7 +2,6 @@ package meter
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -151,27 +150,6 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	return c, nil
 }
 
-func eebusReadValue[T any](uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	var zero T
-
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return zero, api.ErrNotAvailable
-	}
-
-	res, err := update(entity)
-	if err != nil {
-		// scenario announced but no usable value yet
-		if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-			errors.Is(err, eebusapi.ErrDataInvalid) {
-			err = api.ErrNotAvailable
-		}
-		return zero, err
-	}
-
-	return res, nil
-}
-
 func (c *EEBus) lastDimmed() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -189,7 +167,7 @@ func (c *EEBus) lastCurtailPercent() int {
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return eebusReadValue(c.mm, c.maEntity, scenario, update)
+	return eebus.ReadValue(c.mm, c.maEntity, scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -244,7 +222,7 @@ func (c *EEBus) Dimmed() (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebusReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -295,7 +273,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebusReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -29,9 +29,9 @@ type EEBus struct {
 	mm        measurements
 	scenarios maScenarios
 
-	maEntity    eebus.Entity
-	egLpcEntity eebus.Entity
-	egLppEntity eebus.Entity
+	maEntity    *eebus.Entity
+	egLpcEntity *eebus.Entity
+	egLppEntity *eebus.Entity
 }
 
 // maScenarios holds the spec scenario numbers for the active monitoring use case.
@@ -107,13 +107,18 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 		scenarios = mgcpScenarios
 	}
 
+	eg := inst.EnergyGuard()
+
 	c := &EEBus{
-		log:       util.NewLogger("eebus-" + useCase),
-		ma:        ma,
-		eg:        inst.EnergyGuard(),
-		mm:        mm,
-		scenarios: scenarios,
-		connector: eebus.NewConnector(),
+		log:         util.NewLogger("eebus-" + useCase),
+		ma:          ma,
+		eg:          eg,
+		mm:          mm,
+		scenarios:   scenarios,
+		connector:   eebus.NewConnector(),
+		maEntity:    eebus.NewEntity(mm),
+		egLpcEntity: eebus.NewEntity(eg.EgLPCInterface),
+		egLppEntity: eebus.NewEntity(eg.EgLPPInterface),
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -143,7 +148,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 }
 
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	return c.maEntity.Read(c.mm, scenario, update)
+	return c.maEntity.Read(scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -195,7 +200,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -233,7 +238,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(c.eg.EgLPPInterface, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -169,24 +169,21 @@ func (c *EEBus) lastCurtailPercent() int {
 	return c.curtailPercent
 }
 
-func (c *EEBus) readValue[T any](scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	return c.maEntity.Read(scenario, update)
-}
 
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.readValue(c.scenarios.power, measurements.Power)
+	return c.maEntity.Read(c.scenarios.power, measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.readValue(c.scenarios.energy, measurements.EnergyConsumed)
+	return c.maEntity.Read(c.scenarios.energy, measurements.EnergyConsumed)
 }
 
 func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
-	res, err := c.readValue(scenario, update)
+	res, err := c.maEntity.Read(scenario, update)
 	if err != nil {
 		return 0, 0, 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -275,7 +275,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(c.egLppEntity.Get())
+	nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -298,7 +298,7 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
 	if curtail {
-		if nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(entity); err == nil && nominal > 0 {
+		if nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
 			value = -float64(percent) / 100 * nominal
 		}
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -213,9 +213,9 @@ func (c *EEBus) Dim(dim bool) error {
 		return err
 	}
 
-	if err := eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
-	})); err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -268,9 +268,9 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	if err := eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
-	})); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -9,7 +9,6 @@ import (
 	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	spineapi "github.com/enbility/spine-go/api"
-	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/evcc-io/evcc/util"
@@ -184,9 +183,7 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	return c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
-	})
+	return c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: value, IsActive: dim})
 }
 
 var _ api.Curtailer = (*EEBus)(nil)
@@ -226,7 +223,5 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	return c.lpp.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
-		return uc.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
-	})
+	return c.lpp.WriteArg(ucapi.EgLPPInterface.WriteProductionLimit, ucapi.LoadLimit{Value: value, IsActive: curtail})
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -116,8 +116,8 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	eebus.LogEntities(c.log.DEBUG, "MA MGCP", ma.MaMGCPInterface)
 
 	// energy guard
-	eebus.LogEntities(c.log.DEBUG, "EG LPC", c.eg.EgLPCInterface)
-	eebus.LogEntities(c.log.DEBUG, "EG LPP", c.eg.EgLPPInterface)
+	eebus.LogEntities(c.log.DEBUG, "EG LPC", eg.EgLPCInterface)
+	eebus.LogEntities(c.log.DEBUG, "EG LPP", eg.EgLPPInterface)
 
 	return c, nil
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -108,8 +108,8 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	eebus.LogEntities(c.log.DEBUG, "MA MGCP", ma.MaMGCPInterface)
 
 	// energy guard
-	eebus.LogEntities(c.log.DEBUG, "EG LPC", c.eg.EgLPCInterface)
-	eebus.LogEntities(c.log.DEBUG, "EG LPP", c.eg.EgLPPInterface)
+	eebus.LogEntities(c.log.DEBUG, "EG LPC", eg.EgLPCInterface)
+	eebus.LogEntities(c.log.DEBUG, "EG LPP", eg.EgLPPInterface)
 
 	return c, nil
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -25,9 +25,9 @@ type EEBus struct {
 
 	connector *eebus.Connector
 
-	maEntity    *eebus.Entity[measurements]
-	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
-	egLppEntity *eebus.Entity[ucapi.EgLPPInterface]
+	ma  *eebus.Entity[measurements]
+	lpc *eebus.Entity[ucapi.EgLPCInterface]
+	lpp *eebus.Entity[ucapi.EgLPPInterface]
 }
 
 type measurements interface {
@@ -79,11 +79,11 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	eg := inst.EnergyGuard()
 
 	c := &EEBus{
-		log:         util.NewLogger("eebus-" + useCase),
-		connector:   eebus.NewConnector(),
-		maEntity:    eebus.NewEntity(mm),
-		egLpcEntity: eebus.NewEntity(eg.EgLPCInterface),
-		egLppEntity: eebus.NewEntity(eg.EgLPPInterface),
+		log:       util.NewLogger("eebus-" + useCase),
+		connector: eebus.NewConnector(),
+		ma:        eebus.NewEntity(mm),
+		lpc:       eebus.NewEntity(eg.EgLPCInterface),
+		lpp:       eebus.NewEntity(eg.EgLPPInterface),
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -115,17 +115,17 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.maEntity.Read(measurements.Power)
+	return c.ma.Read(measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.maEntity.Read(measurements.EnergyConsumed)
+	return c.ma.Read(measurements.EnergyConsumed)
 }
 
 func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
-	res, err := c.maEntity.Read(update)
+	res, err := c.ma.Read(update)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -161,7 +161,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -184,7 +184,7 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	return c.egLpcEntity.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+	return c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
 		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
 	})
 }
@@ -193,7 +193,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionLimit)
+	limit, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -204,7 +204,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax)
+	nominal, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionNominalMax)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -221,12 +221,12 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
 	if curtail {
-		if nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
+		if nominal, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
 			value = -float64(percent) / 100 * nominal
 		}
 	}
 
-	return c.egLppEntity.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+	return c.lpp.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
 		return uc.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
 	})
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -29,9 +29,9 @@ type EEBus struct {
 	mm        measurements
 	scenarios maScenarios
 
-	maEntity    *eebus.Entity
-	egLpcEntity *eebus.Entity
-	egLppEntity *eebus.Entity
+	maEntity    *eebus.Entity[measurements]
+	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
+	egLppEntity *eebus.Entity[ucapi.EgLPPInterface]
 }
 
 // maScenarios holds the spec scenario numbers for the active monitoring use case.
@@ -147,23 +147,23 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	return c, nil
 }
 
-func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+func (c *EEBus) readValue[T any](scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	return c.maEntity.Read(scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.readValue(c.scenarios.power, c.mm.Power)
+	return c.readValue(c.scenarios.power, measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.readValue(c.scenarios.energy, c.mm.EnergyConsumed)
+	return c.readValue(c.scenarios.energy, measurements.EnergyConsumed)
 }
 
-func (c *EEBus) readPhases(scenario uint, update func(entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
+func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
 	res, err := c.readValue(scenario, update)
 	if err != nil {
 		return 0, 0, 0, err
@@ -187,20 +187,20 @@ func (c *EEBus) readPhases(scenario uint, update func(entity spineapi.EntityRemo
 var _ api.PhaseCurrents = (*EEBus)(nil)
 
 func (c *EEBus) Currents() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.currents, c.mm.CurrentPerPhase)
+	return c.readPhases(c.scenarios.currents, measurements.CurrentPerPhase)
 }
 
 var _ api.PhaseVoltages = (*EEBus)(nil)
 
 func (c *EEBus) Voltages() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.voltages, c.mm.VoltagePerPhase)
+	return c.readPhases(c.scenarios.voltages, measurements.VoltagePerPhase)
 }
 
 var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -238,7 +238,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(eebus.LPPLimit, ucapi.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -169,7 +169,6 @@ func (c *EEBus) lastCurtailPercent() int {
 	return c.curtailPercent
 }
 
-
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	eebusapi "github.com/enbility/eebus-go/api"
@@ -30,10 +29,9 @@ type EEBus struct {
 	mm        measurements
 	scenarios maScenarios
 
-	mu          sync.Mutex
-	maEntity    spineapi.EntityRemoteInterface
-	egLpcEntity spineapi.EntityRemoteInterface
-	egLppEntity spineapi.EntityRemoteInterface
+	maEntity    eebus.Entity
+	egLpcEntity eebus.Entity
+	egLppEntity eebus.Entity
 }
 
 // maScenarios holds the spec scenario numbers for the active monitoring use case.
@@ -145,9 +143,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 }
 
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return eebus.ReadValue(c.mm, scenario, c.maEntity, update)
+	return eebus.ReadValue(c.mm, scenario, c.maEntity.Get(), update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -199,10 +195,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -225,9 +218,7 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	c.mu.Lock()
-	entity := c.egLpcEntity
-	c.mu.Unlock()
+	entity := c.egLpcEntity.Get()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -242,10 +233,9 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	entity := c.egLppEntity.Get()
 
-	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, c.egLppEntity, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, entity, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -256,7 +246,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(c.egLppEntity)
+	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(entity)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -269,9 +259,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	c.mu.Lock()
-	entity := c.egLppEntity
-	c.mu.Unlock()
+	entity := c.egLppEntity.Get()
 
 	if entity == nil || !c.eg.EgLPPInterface.IsScenarioAvailableAtEntity(entity, eebus.LPPLimit) {
 		return api.ErrNotAvailable

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -26,7 +26,6 @@ type EEBus struct {
 	log *util.Logger
 
 	connector *eebus.Connector
-	eg        *eebus.EnergyGuard
 
 	maEntity    *eebus.Entity[measurements]
 	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
@@ -88,7 +87,6 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	c := &EEBus{
 		ctx:            ctx,
 		log:            util.NewLogger("eebus-" + useCase),
-		eg:             eg,
 		connector:      eebus.NewConnector(),
 		maEntity:       eebus.NewEntity(mm),
 		egLpcEntity:    eebus.NewEntity(eg.EgLPCInterface),
@@ -208,13 +206,8 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	entity, err := c.egLpcEntity.Available()
-	if err != nil {
-		return err
-	}
-
-	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
+	if err := c.egLpcEntity.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
 	}); err != nil {
 		return err
 	}
@@ -254,11 +247,6 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	entity, err := c.egLppEntity.Available()
-	if err != nil {
-		return err
-	}
-
 	// derive a proportional feed-in limit from the producer's nominal power
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
@@ -268,8 +256,8 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
+	if err := c.egLppEntity.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+		return uc.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
 	}); err != nil {
 		return err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -27,7 +27,6 @@ type EEBus struct {
 
 	connector *eebus.Connector
 	eg        *eebus.EnergyGuard
-	scenarios maScenarios
 
 	maEntity    *eebus.Entity[measurements]
 	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
@@ -37,31 +36,6 @@ type EEBus struct {
 	dimmed         bool // last limits written, re-stated on reconnect
 	curtailPercent int
 }
-
-// maScenarios holds the spec scenario numbers for the active monitoring use case.
-// MGCP and MPC use different scenario numbers for the same physical quantity, so
-// IsScenarioAvailableAtEntity must be called with the per-UC value.
-type maScenarios struct {
-	power    uint
-	energy   uint
-	currents uint
-	voltages uint
-}
-
-var (
-	mpcScenarios = maScenarios{
-		power:    eebus.MPCPower,
-		energy:   eebus.MPCEnergyConsumed,
-		currents: eebus.MPCCurrentPerPhase,
-		voltages: eebus.MPCVoltagePerPhase,
-	}
-	mgcpScenarios = maScenarios{
-		power:    eebus.MGCPPower,
-		energy:   eebus.MGCPEnergyConsumed,
-		currents: eebus.MGCPCurrentPerPhase,
-		voltages: eebus.MGCPVoltagePerPhase,
-	}
-)
 
 type measurements interface {
 	eebusapi.UseCaseBaseInterface
@@ -103,12 +77,10 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	// Use MGCP only for explicit grid usage, MPC for everything else (default)
 	useCase := "mpc"
 	mm := measurements(ma.MaMPCInterface)
-	scenarios := mpcScenarios
 
 	if usage != nil && *usage == templates.UsageGrid {
 		useCase = "mgcp"
 		mm = ma.MaMGCPInterface
-		scenarios = mgcpScenarios
 	}
 
 	eg := inst.EnergyGuard()
@@ -117,7 +89,6 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 		ctx:            ctx,
 		log:            util.NewLogger("eebus-" + useCase),
 		eg:             eg,
-		scenarios:      scenarios,
 		connector:      eebus.NewConnector(),
 		maEntity:       eebus.NewEntity(mm),
 		egLpcEntity:    eebus.NewEntity(eg.EgLPCInterface),
@@ -168,17 +139,17 @@ func (c *EEBus) lastCurtailPercent() int {
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.maEntity.Read(c.scenarios.power, measurements.Power)
+	return c.maEntity.Read(measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.maEntity.Read(c.scenarios.energy, measurements.EnergyConsumed)
+	return c.maEntity.Read(measurements.EnergyConsumed)
 }
 
-func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
-	res, err := c.maEntity.Read(scenario, update)
+func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
+	res, err := c.maEntity.Read(update)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -201,20 +172,20 @@ func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity sp
 var _ api.PhaseCurrents = (*EEBus)(nil)
 
 func (c *EEBus) Currents() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.currents, measurements.CurrentPerPhase)
+	return c.readPhases(measurements.CurrentPerPhase)
 }
 
 var _ api.PhaseVoltages = (*EEBus)(nil)
 
 func (c *EEBus) Voltages() (float64, float64, float64, error) {
-	return c.readPhases(c.scenarios.voltages, measurements.VoltagePerPhase)
+	return c.readPhases(measurements.VoltagePerPhase)
 }
 
 var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -237,14 +208,14 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	entity, err := c.egLpcEntity.Available(eebus.LPCLimit)
+	entity, err := c.egLpcEntity.Available()
 	if err != nil {
 		return err
 	}
 
-	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
-	}); err != nil {
+	})); err != nil {
 		return err
 	}
 
@@ -259,7 +230,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(eebus.LPPLimit, ucapi.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -270,7 +241,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax)
+	nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -283,7 +254,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	entity, err := c.egLppEntity.Available(eebus.LPPLimit)
+	entity, err := c.egLppEntity.Available()
 	if err != nil {
 		return err
 	}
@@ -292,14 +263,14 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
 	if curtail {
-		if nominal, err := c.egLppEntity.Read(eebus.LPPElectricalConnection, ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
+		if nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
 			value = -float64(percent) / 100 * nominal
 		}
 	}
 
-	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.WrapError(eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
-	}); err != nil {
+	})); err != nil {
 		return err
 	}
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -167,7 +167,7 @@ func (c *EEBus) lastCurtailPercent() int {
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return eebus.ReadValue(c.mm, c.maEntity, scenario, update)
+	return eebus.ReadValue(c.mm, scenario, c.maEntity, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -222,7 +222,7 @@ func (c *EEBus) Dimmed() (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, c.egLpcEntity, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -273,7 +273,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, c.egLppEntity, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, c.egLppEntity, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -31,12 +31,12 @@ type EEBus struct {
 	mm        measurements
 	scenarios maScenarios
 
-	mu          sync.Mutex
-	maEntity    spineapi.EntityRemoteInterface
-	egLpcEntity spineapi.EntityRemoteInterface
-	egLppEntity spineapi.EntityRemoteInterface
+	maEntity    eebus.Entity
+	egLpcEntity eebus.Entity
+	egLppEntity eebus.Entity
 
-	dimmed         bool // last limits written, re-stated on reconnect// last limits written, re-stated on reconnect
+	mu             sync.Mutex
+	dimmed         bool // last limits written, re-stated on reconnect
 	curtailPercent int
 }
 
@@ -165,9 +165,7 @@ func (c *EEBus) lastCurtailPercent() int {
 }
 
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return eebus.ReadValue(c.mm, scenario, c.maEntity, update)
+	return eebus.ReadValue(c.mm, scenario, c.maEntity.Get(), update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -219,10 +217,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -245,9 +240,7 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	c.mu.Lock()
-	entity := c.egLpcEntity
-	c.mu.Unlock()
+	entity := c.egLpcEntity.Get()
 
 	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
 		return api.ErrNotAvailable
@@ -270,10 +263,9 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	entity := c.egLppEntity.Get()
 
-	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, c.egLppEntity, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, entity, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -284,7 +276,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(c.egLppEntity)
+	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(entity)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -297,9 +289,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	c.mu.Lock()
-	entity := c.egLppEntity
-	c.mu.Unlock()
+	entity := c.egLppEntity.Get()
 
 	if entity == nil || !c.eg.EgLPPInterface.IsScenarioAvailableAtEntity(entity, eebus.LPPLimit) {
 		return api.ErrNotAvailable

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -24,7 +24,6 @@ type EEBus struct {
 	log *util.Logger
 
 	connector *eebus.Connector
-	eg        *eebus.EnergyGuard
 
 	maEntity    *eebus.Entity[measurements]
 	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
@@ -81,7 +80,6 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 
 	c := &EEBus{
 		log:         util.NewLogger("eebus-" + useCase),
-		eg:          eg,
 		connector:   eebus.NewConnector(),
 		maEntity:    eebus.NewEntity(mm),
 		egLpcEntity: eebus.NewEntity(eg.EgLPCInterface),
@@ -186,13 +184,8 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	entity, err := c.egLpcEntity.Available()
-	if err != nil {
-		return err
-	}
-
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
+	return c.egLpcEntity.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
 	})
 }
 
@@ -224,11 +217,6 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	entity, err := c.egLppEntity.Available()
-	if err != nil {
-		return err
-	}
-
 	// derive a proportional feed-in limit from the producer's nominal power
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
@@ -238,7 +226,7 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
-		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
+	return c.egLppEntity.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+		return uc.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
 	})
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -26,14 +26,39 @@ type EEBus struct {
 
 	connector *eebus.Connector
 
-	ma  *eebus.Entity[measurements]
-	lpc *eebus.Entity[ucapi.EgLPCInterface]
-	lpp *eebus.Entity[ucapi.EgLPPInterface]
+	ma        *eebus.Entity[measurements]
+	lpc       *eebus.Entity[ucapi.EgLPCInterface]
+	lpp       *eebus.Entity[ucapi.EgLPPInterface]
+	scenarios maScenarios
 
 	mu             sync.Mutex
 	dimmed         bool // last limits written, re-stated on reconnect
 	curtailPercent int
 }
+
+// maScenarios holds the spec scenario numbers for the active monitoring use case.
+// MGCP and MPC use different scenario numbers for the same physical quantity.
+type maScenarios struct {
+	power    uint
+	energy   uint
+	currents uint
+	voltages uint
+}
+
+var (
+	mpcScenarios = maScenarios{
+		power:    eebus.MPCPower,
+		energy:   eebus.MPCEnergyConsumed,
+		currents: eebus.MPCCurrentPerPhase,
+		voltages: eebus.MPCVoltagePerPhase,
+	}
+	mgcpScenarios = maScenarios{
+		power:    eebus.MGCPPower,
+		energy:   eebus.MGCPEnergyConsumed,
+		currents: eebus.MGCPCurrentPerPhase,
+		voltages: eebus.MGCPVoltagePerPhase,
+	}
+)
 
 type measurements interface {
 	eebusapi.UseCaseBaseInterface
@@ -75,10 +100,12 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	// Use MGCP only for explicit grid usage, MPC for everything else (default)
 	useCase := "mpc"
 	mm := measurements(ma.MaMPCInterface)
+	scenarios := mpcScenarios
 
 	if usage != nil && *usage == templates.UsageGrid {
 		useCase = "mgcp"
 		mm = ma.MaMGCPInterface
+		scenarios = mgcpScenarios
 	}
 
 	eg := inst.EnergyGuard()
@@ -90,6 +117,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 		ma:             eebus.NewEntity(mm),
 		lpc:            eebus.NewEntity(eg.EgLPCInterface),
 		lpp:            eebus.NewEntity(eg.EgLPPInterface),
+		scenarios:      scenarios,
 		curtailPercent: 100,
 	}
 
@@ -136,17 +164,17 @@ func (c *EEBus) lastCurtailPercent() int {
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.ma.Read(measurements.Power)
+	return c.ma.Read(measurements.Power, c.scenarios.power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.ma.Read(measurements.EnergyConsumed)
+	return c.ma.Read(measurements.EnergyConsumed, c.scenarios.energy)
 }
 
-func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
-	res, err := c.ma.Read(update)
+func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error), scenario uint) (float64, float64, float64, error) {
+	res, err := c.ma.Read(update, scenario)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -169,20 +197,20 @@ func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRe
 var _ api.PhaseCurrents = (*EEBus)(nil)
 
 func (c *EEBus) Currents() (float64, float64, float64, error) {
-	return c.readPhases(measurements.CurrentPerPhase)
+	return c.readPhases(measurements.CurrentPerPhase, c.scenarios.currents)
 }
 
 var _ api.PhaseVoltages = (*EEBus)(nil)
 
 func (c *EEBus) Voltages() (float64, float64, float64, error) {
-	return c.readPhases(measurements.VoltagePerPhase)
+	return c.readPhases(measurements.VoltagePerPhase, c.scenarios.voltages)
 }
 
 var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit, eebus.LPCLimit)
 	if err != nil {
 		return false, err
 	}
@@ -205,7 +233,7 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	if err := c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: value, IsActive: dim}); err != nil {
+	if err := c.lpc.WriteArg(ucapi.EgLPCInterface.WriteConsumptionLimit, ucapi.LoadLimit{Value: value, IsActive: dim}, eebus.LPCLimit); err != nil {
 		return err
 	}
 
@@ -220,7 +248,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionLimit)
+	limit, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionLimit, eebus.LPPLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -253,7 +281,7 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	if err := c.lpp.WriteArg(ucapi.EgLPPInterface.WriteProductionLimit, ucapi.LoadLimit{Value: value, IsActive: curtail}); err != nil {
+	if err := c.lpp.WriteArg(ucapi.EgLPPInterface.WriteProductionLimit, ucapi.LoadLimit{Value: value, IsActive: curtail}, eebus.LPPLimit); err != nil {
 		return err
 	}
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -147,24 +147,20 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	return c, nil
 }
 
-func (c *EEBus) readValue[T any](scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	return c.maEntity.Read(scenario, update)
-}
-
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.readValue(c.scenarios.power, measurements.Power)
+	return c.maEntity.Read(c.scenarios.power, measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.readValue(c.scenarios.energy, measurements.EnergyConsumed)
+	return c.maEntity.Read(c.scenarios.energy, measurements.EnergyConsumed)
 }
 
 func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
-	res, err := c.readValue(scenario, update)
+	res, err := c.maEntity.Read(scenario, update)
 	if err != nil {
 		return 0, 0, 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -31,9 +31,9 @@ type EEBus struct {
 	mm        measurements
 	scenarios maScenarios
 
-	maEntity    eebus.Entity
-	egLpcEntity eebus.Entity
-	egLppEntity eebus.Entity
+	maEntity    *eebus.Entity
+	egLpcEntity *eebus.Entity
+	egLppEntity *eebus.Entity
 
 	mu             sync.Mutex
 	dimmed         bool // last limits written, re-stated on reconnect
@@ -113,14 +113,19 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 		scenarios = mgcpScenarios
 	}
 
+	eg := inst.EnergyGuard()
+
 	c := &EEBus{
 		ctx:            ctx,
 		log:            util.NewLogger("eebus-" + useCase),
 		ma:             ma,
-		eg:             inst.EnergyGuard(),
+		eg:             eg,
 		mm:             mm,
 		scenarios:      scenarios,
 		connector:      eebus.NewConnector(),
+		maEntity:       eebus.NewEntity(mm),
+		egLpcEntity:    eebus.NewEntity(eg.EgLPCInterface),
+		egLppEntity:    eebus.NewEntity(eg.EgLPPInterface),
 		curtailPercent: 100,
 	}
 
@@ -165,7 +170,7 @@ func (c *EEBus) lastCurtailPercent() int {
 }
 
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	return c.maEntity.Read(c.mm, scenario, update)
+	return c.maEntity.Read(scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -217,7 +222,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -263,7 +268,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(c.eg.EgLPPInterface, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -165,7 +165,7 @@ func (c *EEBus) lastCurtailPercent() int {
 }
 
 func (c *EEBus) readValue[T any](scenario uint, update func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	return eebus.ReadValue(c.mm, scenario, c.maEntity.Get(), update)
+	return c.maEntity.Read(c.mm, scenario, update)
 }
 
 var _ api.Meter = (*EEBus)(nil)
@@ -217,7 +217,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := eebus.ReadValue(c.eg.EgLPCInterface, eebus.LPCLimit, c.egLpcEntity.Get(), c.eg.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.egLpcEntity.Read(c.eg.EgLPCInterface, eebus.LPCLimit, c.eg.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -263,9 +263,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	entity := c.egLppEntity.Get()
-
-	limit, err := eebus.ReadValue(c.eg.EgLPPInterface, eebus.LPPLimit, entity, c.eg.EgLPPInterface.ProductionLimit)
+	limit, err := c.egLppEntity.Read(c.eg.EgLPPInterface, eebus.LPPLimit, c.eg.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -276,7 +274,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(entity)
+	nominal, err := c.eg.EgLPPInterface.ProductionNominalMax(c.egLppEntity.Get())
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -173,7 +173,7 @@ func (c *EEBus) TotalEnergy() (float64, error) {
 	return c.ma.Read(measurements.EnergyConsumed, c.scenarios.energy)
 }
 
-func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error), scenario uint) (float64, float64, float64, error) {
+func (c *EEBus) readPhases(scenario uint, update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
 	res, err := c.ma.Read(update, scenario)
 	if err != nil {
 		return 0, 0, 0, err
@@ -197,13 +197,13 @@ func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRe
 var _ api.PhaseCurrents = (*EEBus)(nil)
 
 func (c *EEBus) Currents() (float64, float64, float64, error) {
-	return c.readPhases(measurements.CurrentPerPhase, c.scenarios.currents)
+	return c.readPhases(c.scenarios.currents, measurements.CurrentPerPhase)
 }
 
 var _ api.PhaseVoltages = (*EEBus)(nil)
 
 func (c *EEBus) Voltages() (float64, float64, float64, error) {
-	return c.readPhases(measurements.VoltagePerPhase, c.scenarios.voltages)
+	return c.readPhases(c.scenarios.voltages, measurements.VoltagePerPhase)
 }
 
 var _ api.Dimmer = (*EEBus)(nil)

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -24,9 +24,7 @@ type EEBus struct {
 	log *util.Logger
 
 	connector *eebus.Connector
-	ma        *eebus.MonitoringAppliance
 	eg        *eebus.EnergyGuard
-	mm        measurements
 	scenarios maScenarios
 
 	maEntity    *eebus.Entity[measurements]
@@ -111,9 +109,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 
 	c := &EEBus{
 		log:         util.NewLogger("eebus-" + useCase),
-		ma:          ma,
 		eg:          eg,
-		mm:          mm,
 		scenarios:   scenarios,
 		connector:   eebus.NewConnector(),
 		maEntity:    eebus.NewEntity(mm),
@@ -137,8 +133,8 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	}()
 
 	// monitoring appliance
-	eebus.LogEntities(c.log.DEBUG, "MA MPC", c.ma.MaMPCInterface)
-	eebus.LogEntities(c.log.DEBUG, "MA MGCP", c.ma.MaMGCPInterface)
+	eebus.LogEntities(c.log.DEBUG, "MA MPC", ma.MaMPCInterface)
+	eebus.LogEntities(c.log.DEBUG, "MA MGCP", ma.MaMGCPInterface)
 
 	// energy guard
 	eebus.LogEntities(c.log.DEBUG, "EG LPC", c.eg.EgLPCInterface)
@@ -219,10 +215,9 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	entity := c.egLpcEntity.Get()
-
-	if entity == nil || !c.eg.EgLPCInterface.IsScenarioAvailableAtEntity(entity, eebus.LPCLimit) {
-		return api.ErrNotAvailable
+	entity, err := c.egLpcEntity.Available(eebus.LPCLimit)
+	if err != nil {
+		return err
 	}
 
 	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
@@ -258,10 +253,9 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 func (c *EEBus) SetCurtailPercent(percent int) error {
 	curtail := percent < 100
 
-	entity := c.egLppEntity.Get()
-
-	if entity == nil || !c.eg.EgLPPInterface.IsScenarioAvailableAtEntity(entity, eebus.LPPLimit) {
-		return api.ErrNotAvailable
+	entity, err := c.egLppEntity.Available(eebus.LPPLimit)
+	if err != nil {
+		return err
 	}
 
 	// derive a proportional feed-in limit from the producer's nominal power

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -27,9 +27,9 @@ type EEBus struct {
 
 	connector *eebus.Connector
 
-	maEntity    *eebus.Entity[measurements]
-	egLpcEntity *eebus.Entity[ucapi.EgLPCInterface]
-	egLppEntity *eebus.Entity[ucapi.EgLPPInterface]
+	ma  *eebus.Entity[measurements]
+	lpc *eebus.Entity[ucapi.EgLPCInterface]
+	lpp *eebus.Entity[ucapi.EgLPPInterface]
 
 	mu             sync.Mutex
 	dimmed         bool // last limits written, re-stated on reconnect
@@ -88,9 +88,9 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 		ctx:            ctx,
 		log:            util.NewLogger("eebus-" + useCase),
 		connector:      eebus.NewConnector(),
-		maEntity:       eebus.NewEntity(mm),
-		egLpcEntity:    eebus.NewEntity(eg.EgLPCInterface),
-		egLppEntity:    eebus.NewEntity(eg.EgLPPInterface),
+		ma:             eebus.NewEntity(mm),
+		lpc:            eebus.NewEntity(eg.EgLPCInterface),
+		lpp:            eebus.NewEntity(eg.EgLPPInterface),
 		curtailPercent: 100,
 	}
 
@@ -137,17 +137,17 @@ func (c *EEBus) lastCurtailPercent() int {
 var _ api.Meter = (*EEBus)(nil)
 
 func (c *EEBus) CurrentPower() (float64, error) {
-	return c.maEntity.Read(measurements.Power)
+	return c.ma.Read(measurements.Power)
 }
 
 var _ api.MeterEnergy = (*EEBus)(nil)
 
 func (c *EEBus) TotalEnergy() (float64, error) {
-	return c.maEntity.Read(measurements.EnergyConsumed)
+	return c.ma.Read(measurements.EnergyConsumed)
 }
 
 func (c *EEBus) readPhases(update func(mm measurements, entity spineapi.EntityRemoteInterface) ([]float64, error)) (float64, float64, float64, error) {
-	res, err := c.maEntity.Read(update)
+	res, err := c.ma.Read(update)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -183,7 +183,7 @@ var _ api.Dimmer = (*EEBus)(nil)
 
 // Dimmed implements the api.Dimmer interface
 func (c *EEBus) Dimmed() (bool, error) {
-	limit, err := c.egLpcEntity.Read(ucapi.EgLPCInterface.ConsumptionLimit)
+	limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit)
 	if err != nil {
 		return false, err
 	}
@@ -206,7 +206,7 @@ func (c *EEBus) Dim(dim bool) error {
 		value = limit
 	}
 
-	if err := c.egLpcEntity.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+	if err := c.lpc.Write(func(uc ucapi.EgLPCInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
 		return uc.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
 	}); err != nil {
 		return err
@@ -223,7 +223,7 @@ var _ api.Curtailer = (*EEBus)(nil)
 
 // CurtailedPercent implements the api.Curtailer interface
 func (c *EEBus) CurtailedPercent() (int, error) {
-	limit, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionLimit)
+	limit, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionLimit)
 	if err != nil {
 		return 0, err
 	}
@@ -234,7 +234,7 @@ func (c *EEBus) CurtailedPercent() (int, error) {
 	}
 
 	// without a nominal reference the limit cannot be expressed as a percent
-	nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax)
+	nominal, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionNominalMax)
 	if err != nil || nominal <= 0 {
 		return 0, api.ErrNotAvailable
 	}
@@ -251,12 +251,12 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 	// (limits are negative watts); fall back to a safe 0W limit if unavailable
 	var value float64
 	if curtail {
-		if nominal, err := c.egLppEntity.Read(ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
+		if nominal, err := c.lpp.Read(ucapi.EgLPPInterface.ProductionNominalMax); err == nil && nominal > 0 {
 			value = -float64(percent) / 100 * nominal
 		}
 	}
 
-	if err := c.egLppEntity.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
+	if err := c.lpp.Write(func(uc ucapi.EgLPPInterface, entity spineapi.EntityRemoteInterface, cb eebus.ResultCB) (*model.MsgCounterType, error) {
 		return uc.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
 	}); err != nil {
 		return err

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -39,14 +39,14 @@ func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.E
 	switch event {
 	// Monitoring Appliance
 	case mpc.UseCaseSupportUpdate, mgcp.UseCaseSupportUpdate:
-		c.maEntity.Update(c.mm, entity)
+		c.maEntity.Update(entity)
 
 	// Energy Guard - LPC
 	case lpc.UseCaseSupportUpdate:
-		c.egLpcEntity.Update(c.eg.EgLPCInterface, entity)
+		c.egLpcEntity.Update(entity)
 
 	// Energy Guard - LPP
 	case lpp.UseCaseSupportUpdate:
-		c.egLppEntity.Update(c.eg.EgLPPInterface, entity)
+		c.egLppEntity.Update(entity)
 	}
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -24,9 +24,9 @@ func (c *EEBus) Connect(connected bool) {
 		return
 	}
 
-	c.maEntity.Set(nil)
-	c.egLpcEntity.Set(nil)
-	c.egLppEntity.Set(nil)
+	c.ma.Set(nil)
+	c.lpc.Set(nil)
+	c.lpp.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -39,14 +39,14 @@ func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.E
 	switch event {
 	// Monitoring Appliance
 	case mpc.UseCaseSupportUpdate, mgcp.UseCaseSupportUpdate:
-		c.maEntity.Update(entity)
+		c.ma.Update(entity)
 
 	// Energy Guard - LPC
 	case lpc.UseCaseSupportUpdate:
-		c.egLpcEntity.Update(entity)
+		c.lpc.Update(entity)
 
 	// Energy Guard - LPP
 	case lpp.UseCaseSupportUpdate:
-		c.egLppEntity.Update(entity)
+		c.lpp.Update(entity)
 	}
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -34,7 +34,7 @@ func (c *EEBus) Connect(connected bool) {
 
 // UseCaseEvent implements the eebus.Device interface
 func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
-	// deviceremoval fires support-update events with a nil entity
+	// device removal fires support-update events with a nil entity
 	if entity == nil {
 		return
 	}
@@ -62,10 +62,7 @@ func (c *EEBus) maUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// prefer the shallowest (device-level) entity
-	if c.maEntity == nil || len(entity.Address().Entity) < len(c.maEntity.Address().Entity) {
-		c.maEntity = entity
-	}
+	c.maEntity = eebus.UpdateEntity(c.mm, c.maEntity, entity)
 }
 
 //
@@ -76,10 +73,7 @@ func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// prefer the shallowest (device-level) entity
-	if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
-		c.egLpcEntity = entity
-	}
+	c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
 }
 
 //
@@ -90,8 +84,5 @@ func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// prefer the shallowest (device-level) entity
-	if c.egLppEntity == nil || len(entity.Address().Entity) < len(c.egLppEntity.Address().Entity) {
-		c.egLppEntity = entity
-	}
+	c.egLppEntity = eebus.UpdateEntity(c.eg.EgLPPInterface, c.egLppEntity, entity)
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -24,12 +24,9 @@ func (c *EEBus) Connect(connected bool) {
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.maEntity = nil
-	c.egLpcEntity = nil
-	c.egLppEntity = nil
+	c.maEntity.Set(nil)
+	c.egLpcEntity.Set(nil)
+	c.egLppEntity.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -42,59 +39,20 @@ func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.E
 	switch event {
 	// Monitoring Appliance
 	case mpc.UseCaseSupportUpdate, mgcp.UseCaseSupportUpdate:
-		c.maUseCaseSupportUpdate(entity)
+		c.maEntity.Update(c.mm, entity)
 
 	// Energy Guard - LPC
 	case lpc.UseCaseSupportUpdate:
-		c.egLpcUseCaseSupportUpdate(entity)
+		if c.egLpcEntity.Update(c.eg.EgLPCInterface, entity) {
+			// [LPC-913]: state the limit to the newly available CS
+			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
+		}
 
 	// Energy Guard - LPP
 	case lpp.UseCaseSupportUpdate:
-		c.egLppUseCaseSupportUpdate(entity)
-	}
-}
-
-//
-// Monitoring Appliance - MPC/MGPC
-//
-
-func (c *EEBus) maUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.maEntity = eebus.UpdateEntity(c.mm, c.maEntity, entity)
-}
-
-//
-// Energy Guard - LPC
-//
-
-func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	prev := c.egLpcEntity
-	c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
-
-	if c.egLpcEntity != nil && c.egLpcEntity != prev {
-		// [LPC-913]: state the limit to the newly available CS
-		go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
-	}
-}
-
-//
-// Energy Guard - LPP
-//
-
-func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	prev := c.egLppEntity
-	c.egLppEntity = eebus.UpdateEntity(c.eg.EgLPPInterface, c.egLppEntity, entity)
-
-	if c.egLppEntity != nil && c.egLppEntity != prev {
-		// [LPP-913]: state the limit to the newly available CS
-		go eebus.AssertLimit(c.ctx, c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
+		if c.egLppEntity.Update(c.eg.EgLPPInterface, entity) {
+			// [LPP-913]: state the limit to the newly available CS
+			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
+		}
 	}
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -24,9 +24,9 @@ func (c *EEBus) Connect(connected bool) {
 		return
 	}
 
-	c.maEntity.Set(nil)
-	c.egLpcEntity.Set(nil)
-	c.egLppEntity.Set(nil)
+	c.ma.Set(nil)
+	c.lpc.Set(nil)
+	c.lpp.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -39,18 +39,18 @@ func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.E
 	switch event {
 	// Monitoring Appliance
 	case mpc.UseCaseSupportUpdate, mgcp.UseCaseSupportUpdate:
-		c.maEntity.Update(entity)
+		c.ma.Update(entity)
 
 	// Energy Guard - LPC
 	case lpc.UseCaseSupportUpdate:
-		if c.egLpcEntity.Update(entity) {
+		if c.lpc.Update(entity) {
 			// [LPC-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}
 
 	// Energy Guard - LPP
 	case lpp.UseCaseSupportUpdate:
-		if c.egLppEntity.Update(entity) {
+		if c.lpp.Update(entity) {
 			// [LPP-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
 		}

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -34,7 +34,7 @@ func (c *EEBus) Connect(connected bool) {
 
 // UseCaseEvent implements the eebus.Device interface
 func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
-	// deviceremoval fires support-update events with a nil entity
+	// device removal fires support-update events with a nil entity
 	if entity == nil {
 		return
 	}
@@ -62,10 +62,7 @@ func (c *EEBus) maUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// prefer the shallowest (device-level) entity
-	if c.maEntity == nil || len(entity.Address().Entity) < len(c.maEntity.Address().Entity) {
-		c.maEntity = entity
-	}
+	c.maEntity = eebus.UpdateEntity(c.mm, c.maEntity, entity)
 }
 
 //
@@ -76,10 +73,10 @@ func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// prefer the shallowest (device-level) entity
-	if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
-		c.egLpcEntity = entity
+	prev := c.egLpcEntity
+	c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
 
+	if c.egLpcEntity != nil && c.egLpcEntity != prev {
 		// [LPC-913]: state the limit to the newly available CS
 		go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 	}
@@ -93,10 +90,10 @@ func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// prefer the shallowest (device-level) entity
-	if c.egLppEntity == nil || len(entity.Address().Entity) < len(c.egLppEntity.Address().Entity) {
-		c.egLppEntity = entity
+	prev := c.egLppEntity
+	c.egLppEntity = eebus.UpdateEntity(c.eg.EgLPPInterface, c.egLppEntity, entity)
 
+	if c.egLppEntity != nil && c.egLppEntity != prev {
 		// [LPP-913]: state the limit to the newly available CS
 		go eebus.AssertLimit(c.ctx, c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
 	}

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -39,18 +39,18 @@ func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.E
 	switch event {
 	// Monitoring Appliance
 	case mpc.UseCaseSupportUpdate, mgcp.UseCaseSupportUpdate:
-		c.maEntity.Update(c.mm, entity)
+		c.maEntity.Update(entity)
 
 	// Energy Guard - LPC
 	case lpc.UseCaseSupportUpdate:
-		if c.egLpcEntity.Update(c.eg.EgLPCInterface, entity) {
+		if c.egLpcEntity.Update(entity) {
 			// [LPC-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}
 
 	// Energy Guard - LPP
 	case lpp.UseCaseSupportUpdate:
-		if c.egLppEntity.Update(c.eg.EgLPPInterface, entity) {
+		if c.egLppEntity.Update(entity) {
 			// [LPP-913]: state the limit to the newly available CS
 			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
 		}

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -24,12 +24,9 @@ func (c *EEBus) Connect(connected bool) {
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.maEntity = nil
-	c.egLpcEntity = nil
-	c.egLppEntity = nil
+	c.maEntity.Set(nil)
+	c.egLpcEntity.Set(nil)
+	c.egLppEntity.Set(nil)
 }
 
 // UseCaseEvent implements the eebus.Device interface
@@ -42,47 +39,14 @@ func (c *EEBus) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spineapi.E
 	switch event {
 	// Monitoring Appliance
 	case mpc.UseCaseSupportUpdate, mgcp.UseCaseSupportUpdate:
-		c.maUseCaseSupportUpdate(entity)
+		c.maEntity.Update(c.mm, entity)
 
 	// Energy Guard - LPC
 	case lpc.UseCaseSupportUpdate:
-		c.egLpcUseCaseSupportUpdate(entity)
+		c.egLpcEntity.Update(c.eg.EgLPCInterface, entity)
 
 	// Energy Guard - LPP
 	case lpp.UseCaseSupportUpdate:
-		c.egLppUseCaseSupportUpdate(entity)
+		c.egLppEntity.Update(c.eg.EgLPPInterface, entity)
 	}
-}
-
-//
-// Monitoring Appliance - MPC/MGPC
-//
-
-func (c *EEBus) maUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.maEntity = eebus.UpdateEntity(c.mm, c.maEntity, entity)
-}
-
-//
-// Energy Guard - LPC
-//
-
-func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.egLpcEntity = eebus.UpdateEntity(c.eg.EgLPCInterface, c.egLpcEntity, entity)
-}
-
-//
-// Energy Guard - LPP
-//
-
-func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.egLppEntity = eebus.UpdateEntity(c.eg.EgLPPInterface, c.egLppEntity, entity)
 }

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -38,6 +38,10 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	c.lpc.Set(entity)
 	c.lpp.Set(entity)
 
+	// entity announces every scenario unless a test overrides it
+	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, mock.Anything).Return(true).Maybe()
+	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, mock.Anything).Return(true).Maybe()
+
 	return c, lpc, lpp, entity
 }
 
@@ -300,4 +304,63 @@ func TestLPC_LPP_NonCoverage(t *testing.T) {
 			t.Skip("not applicable: covered by eebus-go or the evcc HEMS/charger, not the grid meter")
 		})
 	}
+}
+
+// Dim/Dimmed are gated: no announced LPC scenario, or no connected entity →
+// ErrNotAvailable. A compatible entity type does not imply limit support.
+func TestLPC_Gating(t *testing.T) {
+	t.Run("scenario_not_announced", func(t *testing.T) {
+		// own mocks: the shared helper announces every scenario
+		lpc := egmocks.NewEgLPCInterface(t)
+		entity := spinemocks.NewEntityRemoteInterface(t)
+		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+
+		c := &EEBus{
+			log: util.NewLogger("eebus-eg-test"),
+			lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
+		}
+		c.lpc.Set(entity)
+
+		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
+
+		_, err := c.Dimmed()
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
+	t.Run("entity_not_connected", func(t *testing.T) {
+		c, _, _, _ := newEGMeter(t)
+		c.lpc.Set(nil)
+
+		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
+	})
+}
+
+// SetCurtailPercent/CurtailedPercent are gated the same way as Dim.
+func TestLPP_Gating(t *testing.T) {
+	t.Run("scenario_not_announced", func(t *testing.T) {
+		// own mocks: the shared helper announces every scenario
+		lpp := egmocks.NewEgLPPInterface(t)
+		entity := spinemocks.NewEntityRemoteInterface(t)
+		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(false)
+
+		c := &EEBus{
+			log: util.NewLogger("eebus-eg-test"),
+			lpp: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
+		}
+		c.lpp.Set(entity)
+
+		// 100 = release, so the write is reached without first reading the
+		// (ungated) nominal max the proportional limit would need
+		assert.ErrorIs(t, c.SetCurtailPercent(100), api.ErrNotAvailable)
+
+		_, err := c.CurtailedPercent()
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
+	t.Run("entity_not_connected", func(t *testing.T) {
+		c, _, _, _ := newEGMeter(t)
+		c.lpp.Set(nil)
+
+		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
+	})
 }

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -33,8 +33,8 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 		ctx:         t.Context(),
 		log:         util.NewLogger("eebus-eg-test"),
 		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
-		egLpcEntity: eebus.NewEntity(lpc),
-		egLppEntity: eebus.NewEntity(lpp),
+		egLpcEntity: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
+		egLppEntity: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
 	}
 	c.egLpcEntity.Set(entity)
 	c.egLppEntity.Set(entity)

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -30,13 +30,13 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		ctx:         t.Context(),
-		log:         util.NewLogger("eebus-eg-test"),
-		egLpcEntity: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
-		egLppEntity: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
+		ctx: t.Context(),
+		log: util.NewLogger("eebus-eg-test"),
+		lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
+		lpp: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
 	}
-	c.egLpcEntity.Set(entity)
-	c.egLppEntity.Set(entity)
+	c.lpc.Set(entity)
+	c.lpp.Set(entity)
 
 	return c, lpc, lpp, entity
 }
@@ -111,7 +111,7 @@ func TestLPC_Dim_WriteRejected(t *testing.T) {
 func TestLPC_Dim_Gating(t *testing.T) {
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLpcEntity.Set(nil)
+		c.lpc.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -190,7 +190,7 @@ func TestLPP_Curtail_WriteRejected(t *testing.T) {
 func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLppEntity.Set(nil)
+		c.lpp.Set(nil)
 
 		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
 	})
@@ -255,7 +255,7 @@ func TestLPP_CurtailedPercent_NoNominal(t *testing.T) {
 func TestLPC_LPP_InitialLimit(t *testing.T) {
 	t.Run("consumption", func(t *testing.T) {
 		c, lpc, _, entity := newEGMeter(t)
-		c.egLpcEntity.Set(nil)
+		c.lpc.Set(nil)
 
 		written := make(chan ucapi.LoadLimit, 1)
 		lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{1})
@@ -271,7 +271,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 
 	t.Run("production", func(t *testing.T) {
 		c, _, lpp, entity := newEGMeter(t)
-		c.egLppEntity.Set(nil)
+		c.lpp.Set(nil)
 		c.curtailPercent = 100
 
 		written := make(chan ucapi.LoadLimit, 1)

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -28,7 +28,6 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 
 	c := &EEBus{
 		log:         util.NewLogger("eebus-eg-test"),
-		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
 		egLpcEntity: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
 		egLppEntity: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
 	}

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -29,8 +29,8 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	c := &EEBus{
 		log:         util.NewLogger("eebus-eg-test"),
 		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
-		egLpcEntity: eebus.NewEntity(lpc),
-		egLppEntity: eebus.NewEntity(lpp),
+		egLpcEntity: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
+		egLppEntity: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
 	}
 	c.egLpcEntity.Set(entity)
 	c.egLppEntity.Set(entity)

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -27,8 +27,10 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log: util.NewLogger("eebus-eg-test"),
-		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
+		log:         util.NewLogger("eebus-eg-test"),
+		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
+		egLpcEntity: eebus.NewEntity(lpc),
+		egLppEntity: eebus.NewEntity(lpp),
 	}
 	c.egLpcEntity.Set(entity)
 	c.egLppEntity.Set(entity)

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -262,7 +262,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 		c.lpc.Set(nil)
 
 		written := make(chan ucapi.LoadLimit, 1)
-		lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{1})
+		lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
 		lpc.EXPECT().
 			WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 			Run(captureWrite(written)).
@@ -279,7 +279,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 		c.curtailPercent = 100
 
 		written := make(chan ucapi.LoadLimit, 1)
-		lpp.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{1})
+		lpp.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPPLimit})
 		lpp.EXPECT().
 			WriteProductionLimit(entity, mock.Anything, mock.Anything).
 			Run(captureWrite(written)).

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -169,6 +169,7 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 			c, _, lpp, entity := newEGMeter(t)
 			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			if tc.active {
+				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 			}
 			lpp.EXPECT().
@@ -187,6 +188,7 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 func TestLPP_Curtail_WriteRejected(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
 	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
+	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 	lpp.EXPECT().
 		WriteProductionLimit(entity, mock.Anything, mock.Anything).
@@ -234,6 +236,7 @@ func TestLPP_CurtailedPercent(t *testing.T) {
 			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			lpp.EXPECT().ProductionLimit(entity).Return(tc.limit, nil)
 			if tc.want != 100 {
+				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(5000.0, nil)
 			}
 
@@ -254,6 +257,7 @@ func TestLPP_CurtailedPercent_RoundTrip(t *testing.T) {
 		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 		lpp.EXPECT().ProductionLimit(entity).
 			Return(ucapi.LoadLimit{IsActive: true, Value: -float64(percent) / 100 * nominal}, nil)
+		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 		lpp.EXPECT().ProductionNominalMax(entity).Return(nominal, nil)
 
 		got, err := c.CurtailedPercent()
@@ -267,6 +271,7 @@ func TestLPP_CurtailedPercent_NoNominal(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
 	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 	lpp.EXPECT().ProductionLimit(entity).Return(ucapi.LoadLimit{IsActive: true, Value: -2000}, nil)
+	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 
 	_, err := c.CurtailedPercent()

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -32,7 +32,6 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	c := &EEBus{
 		ctx:         t.Context(),
 		log:         util.NewLogger("eebus-eg-test"),
-		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
 		egLpcEntity: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
 		egLppEntity: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
 	}

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -279,6 +279,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 		c.egLpcEntity = nil
 
 		written := make(chan ucapi.LoadLimit, 1)
+		lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
 		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 		lpc.EXPECT().
 			WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
@@ -296,6 +297,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 		c.curtailPercent = 100
 
 		written := make(chan ucapi.LoadLimit, 1)
+		lpp.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPPLimit})
 		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 		lpp.EXPECT().
 			WriteProductionLimit(entity, mock.Anything, mock.Anything).

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -27,12 +27,12 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log:         util.NewLogger("eebus-eg-test"),
-		egLpcEntity: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
-		egLppEntity: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
+		log: util.NewLogger("eebus-eg-test"),
+		lpc: eebus.NewEntity[ucapi.EgLPCInterface](lpc),
+		lpp: eebus.NewEntity[ucapi.EgLPPInterface](lpp),
 	}
-	c.egLpcEntity.Set(entity)
-	c.egLppEntity.Set(entity)
+	c.lpc.Set(entity)
+	c.lpp.Set(entity)
 
 	return c, lpc, lpp, entity
 }
@@ -86,7 +86,7 @@ func TestLPC_Dim_WriteRejected(t *testing.T) {
 func TestLPC_Dim_Gating(t *testing.T) {
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLpcEntity.Set(nil)
+		c.lpc.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -165,7 +165,7 @@ func TestLPP_Curtail_WriteRejected(t *testing.T) {
 func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLppEntity.Set(nil)
+		c.lpp.Set(nil)
 
 		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
 	})

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
 	eglpp "github.com/enbility/eebus-go/usecases/eg/lpp"
@@ -111,14 +110,6 @@ func TestLPC_Dim_WriteRejected(t *testing.T) {
 
 // Dim is gated: no LPC use case at the entity, or no connected entity → ErrNotAvailable.
 func TestLPC_Dim_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, lpc, _, entity := newEGMeter(t)
-		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
-			Return(nil, eebusapi.ErrNoCompatibleEntity)
-
-		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
 		c.egLpcEntity.Set(nil)
@@ -198,15 +189,6 @@ func TestLPP_Curtail_WriteRejected(t *testing.T) {
 
 // SetCurtailPercent is gated the same way as Dim.
 func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, _, lpp, entity := newEGMeter(t)
-		lpp.EXPECT().ProductionNominalMax(entity).Return(0, eebusapi.ErrNoCompatibleEntity).Maybe()
-		lpp.EXPECT().WriteProductionLimit(entity, mock.Anything, mock.Anything).
-			Return(nil, eebusapi.ErrNoCompatibleEntity)
-
-		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
 		c.egLppEntity.Set(nil)

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -30,9 +30,11 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		ctx: t.Context(),
-		log: util.NewLogger("eebus-eg-test"),
-		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
+		ctx:         t.Context(),
+		log:         util.NewLogger("eebus-eg-test"),
+		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
+		egLpcEntity: eebus.NewEntity(lpc),
+		egLppEntity: eebus.NewEntity(lpp),
 	}
 	c.egLpcEntity.Set(entity)
 	c.egLppEntity.Set(entity)

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -27,11 +27,11 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log:         util.NewLogger("eebus-eg-test"),
-		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
-		egLpcEntity: entity,
-		egLppEntity: entity,
+		log: util.NewLogger("eebus-eg-test"),
+		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
 	}
+	c.egLpcEntity.Set(entity)
+	c.egLppEntity.Set(entity)
 
 	return c, lpc, lpp, entity
 }
@@ -94,7 +94,7 @@ func TestLPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLpcEntity = nil
+		c.egLpcEntity.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -183,7 +183,7 @@ func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLppEntity = nil
+		c.egLppEntity.Set(nil)
 
 		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
 	})

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -6,6 +6,7 @@ package meter
 import (
 	"testing"
 
+	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	egmocks "github.com/enbility/eebus-go/usecases/mocks"
 	spineapi "github.com/enbility/spine-go/api"
@@ -59,7 +60,6 @@ func TestLPC_EGMessages_ConsumptionLimit(t *testing.T) {
 	} {
 		t.Run("ATC_COM_PT_EGMessages_001_"+tc.name, func(t *testing.T) {
 			c, lpc, _, entity := newEGMeter(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().
 				WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: tc.active}, mock.Anything).
 				Run(ackWrite).
@@ -73,7 +73,6 @@ func TestLPC_EGMessages_ConsumptionLimit(t *testing.T) {
 // A rejected write (NACK) must surface as an error, not silent success.
 func TestLPC_Dim_WriteRejected(t *testing.T) {
 	c, lpc, _, entity := newEGMeter(t)
-	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 	lpc.EXPECT().
 		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 		Run(func(_ spineapi.EntityRemoteInterface, _ ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
@@ -85,11 +84,12 @@ func TestLPC_Dim_WriteRejected(t *testing.T) {
 	assert.Error(t, c.Dim(true))
 }
 
-// Dim is gated: no announced LPC scenario, or no connected entity → ErrNotAvailable.
+// Dim is gated: no LPC use case at the entity, or no connected entity → ErrNotAvailable.
 func TestLPC_Dim_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, lpc, _, entity := newEGMeter(t)
-		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
+			Return(nil, eebusapi.ErrNoCompatibleEntity)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -117,7 +117,6 @@ func TestLPC_Dimmed(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, lpc, _, entity := newEGMeter(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().ConsumptionLimit(entity).Return(tc.limit, nil)
 
 			got, err := c.Dimmed()
@@ -142,9 +141,7 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 	} {
 		t.Run("ATC_COM_PT_EGMessages_001_"+tc.name, func(t *testing.T) {
 			c, _, lpp, entity := newEGMeter(t)
-			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			if tc.active {
-				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 			}
 			lpp.EXPECT().
@@ -162,8 +159,6 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 // A rejected write (NACK) must surface as an error, not silent success.
 func TestLPP_Curtail_WriteRejected(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 	lpp.EXPECT().
 		WriteProductionLimit(entity, mock.Anything, mock.Anything).
@@ -178,9 +173,11 @@ func TestLPP_Curtail_WriteRejected(t *testing.T) {
 
 // SetCurtailPercent is gated the same way as Dim.
 func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, _, lpp, entity := newEGMeter(t)
-		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(false)
+		lpp.EXPECT().ProductionNominalMax(entity).Return(0, eebusapi.ErrNoCompatibleEntity).Maybe()
+		lpp.EXPECT().WriteProductionLimit(entity, mock.Anything, mock.Anything).
+			Return(nil, eebusapi.ErrNoCompatibleEntity)
 
 		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
 	})
@@ -208,10 +205,8 @@ func TestLPP_CurtailedPercent(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, _, lpp, entity := newEGMeter(t)
-			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			lpp.EXPECT().ProductionLimit(entity).Return(tc.limit, nil)
 			if tc.want != 100 {
-				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(5000.0, nil)
 			}
 
@@ -229,10 +224,8 @@ func TestLPP_CurtailedPercent_RoundTrip(t *testing.T) {
 
 	for percent := range 101 {
 		c, _, lpp, entity := newEGMeter(t)
-		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 		lpp.EXPECT().ProductionLimit(entity).
 			Return(ucapi.LoadLimit{IsActive: true, Value: -float64(percent) / 100 * nominal}, nil)
-		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 		lpp.EXPECT().ProductionNominalMax(entity).Return(nominal, nil)
 
 		got, err := c.CurtailedPercent()
@@ -244,9 +237,7 @@ func TestLPP_CurtailedPercent_RoundTrip(t *testing.T) {
 // Without a nominal reference the watt limit cannot be expressed as a percent.
 func TestLPP_CurtailedPercent_NoNominal(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 	lpp.EXPECT().ProductionLimit(entity).Return(ucapi.LoadLimit{IsActive: true, Value: -2000}, nil)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 
 	_, err := c.CurtailedPercent()

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
 	eglpp "github.com/enbility/eebus-go/usecases/eg/lpp"
@@ -84,7 +85,6 @@ func TestLPC_EGMessages_ConsumptionLimit(t *testing.T) {
 	} {
 		t.Run("ATC_COM_PT_EGMessages_001_"+tc.name, func(t *testing.T) {
 			c, lpc, _, entity := newEGMeter(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().
 				WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: tc.active}, mock.Anything).
 				Run(ackWrite).
@@ -98,7 +98,6 @@ func TestLPC_EGMessages_ConsumptionLimit(t *testing.T) {
 // A rejected write (NACK) must surface as an error, not silent success.
 func TestLPC_Dim_WriteRejected(t *testing.T) {
 	c, lpc, _, entity := newEGMeter(t)
-	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 	lpc.EXPECT().
 		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 		Run(func(_ spineapi.EntityRemoteInterface, _ ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
@@ -110,11 +109,12 @@ func TestLPC_Dim_WriteRejected(t *testing.T) {
 	assert.Error(t, c.Dim(true))
 }
 
-// Dim is gated: no announced LPC scenario, or no connected entity → ErrNotAvailable.
+// Dim is gated: no LPC use case at the entity, or no connected entity → ErrNotAvailable.
 func TestLPC_Dim_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, lpc, _, entity := newEGMeter(t)
-		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(false)
+		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
+			Return(nil, eebusapi.ErrNoCompatibleEntity)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -142,7 +142,6 @@ func TestLPC_Dimmed(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, lpc, _, entity := newEGMeter(t)
-			lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
 			lpc.EXPECT().ConsumptionLimit(entity).Return(tc.limit, nil)
 
 			got, err := c.Dimmed()
@@ -167,9 +166,7 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 	} {
 		t.Run("ATC_COM_PT_EGMessages_001_"+tc.name, func(t *testing.T) {
 			c, _, lpp, entity := newEGMeter(t)
-			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			if tc.active {
-				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 			}
 			lpp.EXPECT().
@@ -187,8 +184,6 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 // A rejected write (NACK) must surface as an error, not silent success.
 func TestLPP_Curtail_WriteRejected(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 	lpp.EXPECT().
 		WriteProductionLimit(entity, mock.Anything, mock.Anything).
@@ -203,9 +198,11 @@ func TestLPP_Curtail_WriteRejected(t *testing.T) {
 
 // SetCurtailPercent is gated the same way as Dim.
 func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, _, lpp, entity := newEGMeter(t)
-		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(false)
+		lpp.EXPECT().ProductionNominalMax(entity).Return(0, eebusapi.ErrNoCompatibleEntity).Maybe()
+		lpp.EXPECT().WriteProductionLimit(entity, mock.Anything, mock.Anything).
+			Return(nil, eebusapi.ErrNoCompatibleEntity)
 
 		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
 	})
@@ -233,10 +230,8 @@ func TestLPP_CurtailedPercent(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c, _, lpp, entity := newEGMeter(t)
-			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			lpp.EXPECT().ProductionLimit(entity).Return(tc.limit, nil)
 			if tc.want != 100 {
-				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(5000.0, nil)
 			}
 
@@ -254,10 +249,8 @@ func TestLPP_CurtailedPercent_RoundTrip(t *testing.T) {
 
 	for percent := range 101 {
 		c, _, lpp, entity := newEGMeter(t)
-		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 		lpp.EXPECT().ProductionLimit(entity).
 			Return(ucapi.LoadLimit{IsActive: true, Value: -float64(percent) / 100 * nominal}, nil)
-		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 		lpp.EXPECT().ProductionNominalMax(entity).Return(nominal, nil)
 
 		got, err := c.CurtailedPercent()
@@ -269,9 +262,7 @@ func TestLPP_CurtailedPercent_RoundTrip(t *testing.T) {
 // Without a nominal reference the watt limit cannot be expressed as a percent.
 func TestLPP_CurtailedPercent_NoNominal(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 	lpp.EXPECT().ProductionLimit(entity).Return(ucapi.LoadLimit{IsActive: true, Value: -2000}, nil)
-	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 
 	_, err := c.CurtailedPercent()
@@ -286,8 +277,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 		c.egLpcEntity.Set(nil)
 
 		written := make(chan ucapi.LoadLimit, 1)
-		lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
-		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
+		lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{1})
 		lpc.EXPECT().
 			WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
 			Run(captureWrite(written)).
@@ -304,8 +294,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 		c.curtailPercent = 100
 
 		written := make(chan ucapi.LoadLimit, 1)
-		lpp.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPPLimit})
-		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
+		lpp.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{1})
 		lpp.EXPECT().
 			WriteProductionLimit(entity, mock.Anything, mock.Anything).
 			Run(captureWrite(written)).

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -144,6 +144,7 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 			c, _, lpp, entity := newEGMeter(t)
 			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			if tc.active {
+				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 			}
 			lpp.EXPECT().
@@ -162,6 +163,7 @@ func TestLPP_EGMessages_ProductionLimit(t *testing.T) {
 func TestLPP_Curtail_WriteRejected(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
 	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
+	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 	lpp.EXPECT().
 		WriteProductionLimit(entity, mock.Anything, mock.Anything).
@@ -209,6 +211,7 @@ func TestLPP_CurtailedPercent(t *testing.T) {
 			lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 			lpp.EXPECT().ProductionLimit(entity).Return(tc.limit, nil)
 			if tc.want != 100 {
+				lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 				lpp.EXPECT().ProductionNominalMax(entity).Return(5000.0, nil)
 			}
 
@@ -229,6 +232,7 @@ func TestLPP_CurtailedPercent_RoundTrip(t *testing.T) {
 		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 		lpp.EXPECT().ProductionLimit(entity).
 			Return(ucapi.LoadLimit{IsActive: true, Value: -float64(percent) / 100 * nominal}, nil)
+		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 		lpp.EXPECT().ProductionNominalMax(entity).Return(nominal, nil)
 
 		got, err := c.CurtailedPercent()
@@ -242,6 +246,7 @@ func TestLPP_CurtailedPercent_NoNominal(t *testing.T) {
 	c, _, lpp, entity := newEGMeter(t)
 	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
 	lpp.EXPECT().ProductionLimit(entity).Return(ucapi.LoadLimit{IsActive: true, Value: -2000}, nil)
+	lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPElectricalConnection).Return(true)
 	lpp.EXPECT().ProductionNominalMax(entity).Return(0.0, api.ErrNotAvailable)
 
 	_, err := c.CurtailedPercent()

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -30,12 +30,12 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		ctx:         t.Context(),
-		log:         util.NewLogger("eebus-eg-test"),
-		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
-		egLpcEntity: entity,
-		egLppEntity: entity,
+		ctx: t.Context(),
+		log: util.NewLogger("eebus-eg-test"),
+		eg:  &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
 	}
+	c.egLpcEntity.Set(entity)
+	c.egLppEntity.Set(entity)
 
 	return c, lpc, lpp, entity
 }
@@ -119,7 +119,7 @@ func TestLPC_Dim_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLpcEntity = nil
+		c.egLpcEntity.Set(nil)
 
 		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 	})
@@ -208,7 +208,7 @@ func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
-		c.egLppEntity = nil
+		c.egLppEntity.Set(nil)
 
 		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
 	})
@@ -276,7 +276,7 @@ func TestLPP_CurtailedPercent_NoNominal(t *testing.T) {
 func TestLPC_LPP_InitialLimit(t *testing.T) {
 	t.Run("consumption", func(t *testing.T) {
 		c, lpc, _, entity := newEGMeter(t)
-		c.egLpcEntity = nil
+		c.egLpcEntity.Set(nil)
 
 		written := make(chan ucapi.LoadLimit, 1)
 		lpc.EXPECT().AvailableScenariosForEntity(entity).Return([]uint{eebus.LPCLimit})
@@ -293,7 +293,7 @@ func TestLPC_LPP_InitialLimit(t *testing.T) {
 
 	t.Run("production", func(t *testing.T) {
 		c, _, lpp, entity := newEGMeter(t)
-		c.egLppEntity = nil
+		c.egLppEntity.Set(nil)
 		c.curtailPercent = 100
 
 		written := make(chan ucapi.LoadLimit, 1)

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -6,7 +6,6 @@ package meter
 import (
 	"testing"
 
-	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	egmocks "github.com/enbility/eebus-go/usecases/mocks"
 	spineapi "github.com/enbility/spine-go/api"
@@ -86,14 +85,6 @@ func TestLPC_Dim_WriteRejected(t *testing.T) {
 
 // Dim is gated: no LPC use case at the entity, or no connected entity → ErrNotAvailable.
 func TestLPC_Dim_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, lpc, _, entity := newEGMeter(t)
-		lpc.EXPECT().WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
-			Return(nil, eebusapi.ErrNoCompatibleEntity)
-
-		assert.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
 		c.egLpcEntity.Set(nil)
@@ -173,15 +164,6 @@ func TestLPP_Curtail_WriteRejected(t *testing.T) {
 
 // SetCurtailPercent is gated the same way as Dim.
 func TestLPP_SetCurtailPercent_Gating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, _, lpp, entity := newEGMeter(t)
-		lpp.EXPECT().ProductionNominalMax(entity).Return(0, eebusapi.ErrNoCompatibleEntity).Maybe()
-		lpp.EXPECT().WriteProductionLimit(entity, mock.Anything, mock.Anything).
-			Return(nil, eebusapi.ErrNoCompatibleEntity)
-
-		assert.ErrorIs(t, c.SetCurtailPercent(0), api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _, _ := newEGMeter(t)
 		c.egLppEntity.Set(nil)

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -26,9 +26,8 @@ func newMGCPMeter(t *testing.T) (*EEBus, *mgcpmocks.MaMGCPInterface, spineapi.En
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log:       util.NewLogger("eebus-mgcp-test"),
-		maEntity:  eebus.NewEntity[measurements](mm),
-		scenarios: mgcpScenarios,
+		log:      util.NewLogger("eebus-mgcp-test"),
+		maEntity: eebus.NewEntity[measurements](mm),
 	}
 	c.maEntity.Set(entity)
 
@@ -56,7 +55,6 @@ func TestMGCP_SCE2_TotalActivePower(t *testing.T) {
 		} {
 			t.Run(tc.dir, func(t *testing.T) {
 				c, mm, entity := newMGCPMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPPower).Return(true)
 				mm.EXPECT().Power(entity).Return(tc.value, nil)
 
 				got, err := c.CurrentPower()
@@ -71,7 +69,6 @@ func TestMGCP_SCE2_TotalActivePower(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMGCPMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPPower).Return(true)
 				mm.EXPECT().Power(entity).Return(0, badErr)
 
 				_, err := c.CurrentPower()
@@ -86,7 +83,6 @@ func TestMGCP_SCE4_TotalConsumedEnergy(t *testing.T) {
 	// PT_001: state "normal" while consuming; positive value per MGCP-TS-010.
 	t.Run("ATC_SCE4_PT_MATotalConsumedEnergy_001", func(t *testing.T) {
 		c, mm, entity := newMGCPMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPEnergyConsumed).Return(true)
 		mm.EXPECT().EnergyConsumed(entity).Return(12345.6, nil)
 
 		got, err := c.TotalEnergy()
@@ -99,7 +95,6 @@ func TestMGCP_SCE4_TotalConsumedEnergy(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMGCPMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPEnergyConsumed).Return(true)
 				mm.EXPECT().EnergyConsumed(entity).Return(0, badErr)
 
 				_, err := c.TotalEnergy()
@@ -123,7 +118,6 @@ func TestMGCP_SCE5_ActiveACCurrent(t *testing.T) {
 		} {
 			t.Run(tc.dir, func(t *testing.T) {
 				c, mm, entity := newMGCPMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPCurrentPerPhase).Return(true)
 				mm.EXPECT().CurrentPerPhase(entity).Return([]float64{tc.a, tc.b, tc.cc}, nil)
 
 				l1, l2, l3, err := c.Currents()
@@ -138,7 +132,6 @@ func TestMGCP_SCE5_ActiveACCurrent(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMGCPMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPCurrentPerPhase).Return(true)
 				mm.EXPECT().CurrentPerPhase(entity).Return(nil, badErr)
 
 				_, _, _, err := c.Currents()
@@ -150,7 +143,6 @@ func TestMGCP_SCE5_ActiveACCurrent(t *testing.T) {
 	// MGCP-TS-006/7: only connected phases delivered; evcc pads to three phases.
 	t.Run("partial_phases_padded", func(t *testing.T) {
 		c, mm, entity := newMGCPMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPCurrentPerPhase).Return(true)
 		mm.EXPECT().CurrentPerPhase(entity).Return([]float64{7.5}, nil)
 
 		l1, l2, l3, err := c.Currents()
@@ -161,7 +153,6 @@ func TestMGCP_SCE5_ActiveACCurrent(t *testing.T) {
 	// Malformed data (>3 phases) must not be surfaced as a reading.
 	t.Run("too_many_phases_rejected", func(t *testing.T) {
 		c, mm, entity := newMGCPMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPCurrentPerPhase).Return(true)
 		mm.EXPECT().CurrentPerPhase(entity).Return([]float64{1, 2, 3, 4}, nil)
 
 		_, _, _, err := c.Currents()
@@ -174,7 +165,6 @@ func TestMGCP_SCE6_ACVoltage(t *testing.T) {
 	// PT_*: state "normal"; MGCP-TS-011 voltages independent of energy direction.
 	t.Run("ATC_SCE6_PT_MAACVoltage", func(t *testing.T) {
 		c, mm, entity := newMGCPMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPVoltagePerPhase).Return(true)
 		mm.EXPECT().VoltagePerPhase(entity).Return([]float64{230.1, 229.8, 231.0}, nil)
 
 		u1, u2, u3, err := c.Voltages()
@@ -187,7 +177,6 @@ func TestMGCP_SCE6_ACVoltage(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMGCPMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPVoltagePerPhase).Return(true)
 				mm.EXPECT().VoltagePerPhase(entity).Return(nil, badErr)
 
 				_, _, _, err := c.Voltages()
@@ -200,9 +189,9 @@ func TestMGCP_SCE6_ACVoltage(t *testing.T) {
 // Availability gating: an unannounced scenario or unconnected entity yields
 // ErrNotAvailable — the MA must not invent a value for an unsupported data point.
 func TestMGCP_ScenarioGating(t *testing.T) {
-	t.Run("scenario_not_announced", func(t *testing.T) {
+	t.Run("use_case_not_supported", func(t *testing.T) {
 		c, mm, entity := newMGCPMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPPower).Return(false)
+		mm.EXPECT().Power(entity).Return(0, eebusapi.ErrNoCompatibleEntity)
 
 		_, err := c.CurrentPower()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,10 +27,14 @@ func newMGCPMeter(t *testing.T) (*EEBus, *mgcpmocks.MaMGCPInterface, spineapi.En
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log: util.NewLogger("eebus-mgcp-test"),
-		ma:  eebus.NewEntity[measurements](mm),
+		log:       util.NewLogger("eebus-mgcp-test"),
+		ma:        eebus.NewEntity[measurements](mm),
+		scenarios: mgcpScenarios,
 	}
 	c.ma.Set(entity)
+
+	// entity announces every scenario unless a test overrides it
+	mm.EXPECT().IsScenarioAvailableAtEntity(entity, mock.Anything).Return(true).Maybe()
 
 	return c, mm, entity
 }
@@ -189,6 +194,23 @@ func TestMGCP_SCE6_ACVoltage(t *testing.T) {
 // Availability gating: an unannounced scenario or unconnected entity yields
 // ErrNotAvailable — the MA must not invent a value for an unsupported data point.
 func TestMGCP_ScenarioGating(t *testing.T) {
+	t.Run("scenario_not_announced", func(t *testing.T) {
+		// own mocks: the shared helper announces every scenario
+		mm := mgcpmocks.NewMaMGCPInterface(t)
+		entity := spinemocks.NewEntityRemoteInterface(t)
+		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MGCPPower).Return(false)
+
+		c := &EEBus{
+			log:       util.NewLogger("eebus-mgcp-test"),
+			ma:        eebus.NewEntity[measurements](mm),
+			scenarios: mgcpScenarios,
+		}
+		c.ma.Set(entity)
+
+		_, err := c.CurrentPower()
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newMGCPMeter(t)
 		c.ma.Set(nil) // GCP not (yet) connected

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -28,6 +28,7 @@ func newMGCPMeter(t *testing.T) (*EEBus, *mgcpmocks.MaMGCPInterface, spineapi.En
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mgcp-test"),
 		mm:        mm,
+		maEntity:  eebus.NewEntity(mm),
 		scenarios: mgcpScenarios,
 	}
 	c.maEntity.Set(entity)

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -189,14 +189,6 @@ func TestMGCP_SCE6_ACVoltage(t *testing.T) {
 // Availability gating: an unannounced scenario or unconnected entity yields
 // ErrNotAvailable — the MA must not invent a value for an unsupported data point.
 func TestMGCP_ScenarioGating(t *testing.T) {
-	t.Run("use_case_not_supported", func(t *testing.T) {
-		c, mm, entity := newMGCPMeter(t)
-		mm.EXPECT().Power(entity).Return(0, eebusapi.ErrNoCompatibleEntity)
-
-		_, err := c.CurrentPower()
-		assert.ErrorIs(t, err, api.ErrNotAvailable)
-	})
-
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newMGCPMeter(t)
 		c.maEntity.Set(nil) // GCP not (yet) connected

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -26,10 +26,10 @@ func newMGCPMeter(t *testing.T) (*EEBus, *mgcpmocks.MaMGCPInterface, spineapi.En
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log:      util.NewLogger("eebus-mgcp-test"),
-		maEntity: eebus.NewEntity[measurements](mm),
+		log: util.NewLogger("eebus-mgcp-test"),
+		ma:  eebus.NewEntity[measurements](mm),
 	}
-	c.maEntity.Set(entity)
+	c.ma.Set(entity)
 
 	return c, mm, entity
 }
@@ -191,7 +191,7 @@ func TestMGCP_SCE6_ACVoltage(t *testing.T) {
 func TestMGCP_ScenarioGating(t *testing.T) {
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newMGCPMeter(t)
-		c.maEntity.Set(nil) // GCP not (yet) connected
+		c.ma.Set(nil) // GCP not (yet) connected
 
 		_, err := c.CurrentPower()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -28,9 +28,9 @@ func newMGCPMeter(t *testing.T) (*EEBus, *mgcpmocks.MaMGCPInterface, spineapi.En
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mgcp-test"),
 		mm:        mm,
-		maEntity:  entity,
 		scenarios: mgcpScenarios,
 	}
+	c.maEntity.Set(entity)
 
 	return c, mm, entity
 }
@@ -210,7 +210,7 @@ func TestMGCP_ScenarioGating(t *testing.T) {
 
 	t.Run("entity_not_connected", func(t *testing.T) {
 		c, _, _ := newMGCPMeter(t)
-		c.maEntity = nil // GCP not (yet) connected
+		c.maEntity.Set(nil) // GCP not (yet) connected
 
 		_, err := c.CurrentPower()
 		assert.ErrorIs(t, err, api.ErrNotAvailable)

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -28,7 +28,7 @@ func newMGCPMeter(t *testing.T) (*EEBus, *mgcpmocks.MaMGCPInterface, spineapi.En
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mgcp-test"),
 		mm:        mm,
-		maEntity:  eebus.NewEntity(mm),
+		maEntity:  eebus.NewEntity[measurements](mm),
 		scenarios: mgcpScenarios,
 	}
 	c.maEntity.Set(entity)

--- a/meter/eebus_mgcp_test.go
+++ b/meter/eebus_mgcp_test.go
@@ -27,7 +27,6 @@ func newMGCPMeter(t *testing.T) (*EEBus, *mgcpmocks.MaMGCPInterface, spineapi.En
 
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mgcp-test"),
-		mm:        mm,
 		maEntity:  eebus.NewEntity[measurements](mm),
 		scenarios: mgcpScenarios,
 	}

--- a/meter/eebus_mpc_test.go
+++ b/meter/eebus_mpc_test.go
@@ -25,6 +25,7 @@ func newMPCMeter(t *testing.T) (*EEBus, *mpcmocks.MaMPCInterface, spineapi.Entit
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mpc-test"),
 		mm:        mm,
+		maEntity:  eebus.NewEntity(mm),
 		scenarios: mpcScenarios,
 	}
 	c.maEntity.Set(entity)

--- a/meter/eebus_mpc_test.go
+++ b/meter/eebus_mpc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,10 +24,14 @@ func newMPCMeter(t *testing.T) (*EEBus, *mpcmocks.MaMPCInterface, spineapi.Entit
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log: util.NewLogger("eebus-mpc-test"),
-		ma:  eebus.NewEntity[measurements](mm),
+		log:       util.NewLogger("eebus-mpc-test"),
+		ma:        eebus.NewEntity[measurements](mm),
+		scenarios: mpcScenarios,
 	}
 	c.ma.Set(entity)
+
+	// entity announces every scenario unless a test overrides it
+	mm.EXPECT().IsScenarioAvailableAtEntity(entity, mock.Anything).Return(true).Maybe()
 
 	return c, mm, entity
 }

--- a/meter/eebus_mpc_test.go
+++ b/meter/eebus_mpc_test.go
@@ -23,10 +23,10 @@ func newMPCMeter(t *testing.T) (*EEBus, *mpcmocks.MaMPCInterface, spineapi.Entit
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log:      util.NewLogger("eebus-mpc-test"),
-		maEntity: eebus.NewEntity[measurements](mm),
+		log: util.NewLogger("eebus-mpc-test"),
+		ma:  eebus.NewEntity[measurements](mm),
 	}
-	c.maEntity.Set(entity)
+	c.ma.Set(entity)
 
 	return c, mm, entity
 }

--- a/meter/eebus_mpc_test.go
+++ b/meter/eebus_mpc_test.go
@@ -23,9 +23,8 @@ func newMPCMeter(t *testing.T) (*EEBus, *mpcmocks.MaMPCInterface, spineapi.Entit
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
-		log:       util.NewLogger("eebus-mpc-test"),
-		maEntity:  eebus.NewEntity[measurements](mm),
-		scenarios: mpcScenarios,
+		log:      util.NewLogger("eebus-mpc-test"),
+		maEntity: eebus.NewEntity[measurements](mm),
 	}
 	c.maEntity.Set(entity)
 
@@ -45,7 +44,6 @@ func TestMPC_SCE1_TotalActivePower(t *testing.T) {
 		} {
 			t.Run(tc.dir, func(t *testing.T) {
 				c, mm, entity := newMPCMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCPower).Return(true)
 				mm.EXPECT().Power(entity).Return(tc.value, nil)
 
 				got, err := c.CurrentPower()
@@ -60,7 +58,6 @@ func TestMPC_SCE1_TotalActivePower(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMPCMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCPower).Return(true)
 				mm.EXPECT().Power(entity).Return(0, badErr)
 
 				_, err := c.CurrentPower()
@@ -74,7 +71,6 @@ func TestMPC_SCE1_TotalActivePower(t *testing.T) {
 func TestMPC_SCE2_TotalConsumedEnergy(t *testing.T) {
 	t.Run("ATC_SCE2_PT_MATotalConsumedEnergy_001", func(t *testing.T) {
 		c, mm, entity := newMPCMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCEnergyConsumed).Return(true)
 		mm.EXPECT().EnergyConsumed(entity).Return(9876.5, nil)
 
 		got, err := c.TotalEnergy()
@@ -86,7 +82,6 @@ func TestMPC_SCE2_TotalConsumedEnergy(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMPCMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCEnergyConsumed).Return(true)
 				mm.EXPECT().EnergyConsumed(entity).Return(0, badErr)
 
 				_, err := c.TotalEnergy()
@@ -101,7 +96,6 @@ func TestMPC_SCE3_ActiveACCurrent(t *testing.T) {
 	// PT_001/003/005 (phase A/B/C, "normal") in one Currents() call.
 	t.Run("ATC_SCE3_PT_MAActiveACCurrent_001_003_005", func(t *testing.T) {
 		c, mm, entity := newMPCMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCCurrentPerPhase).Return(true)
 		mm.EXPECT().CurrentPerPhase(entity).Return([]float64{5.1, 5.2, 5.3}, nil)
 
 		l1, l2, l3, err := c.Currents()
@@ -114,7 +108,6 @@ func TestMPC_SCE3_ActiveACCurrent(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMPCMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCCurrentPerPhase).Return(true)
 				mm.EXPECT().CurrentPerPhase(entity).Return(nil, badErr)
 
 				_, _, _, err := c.Currents()
@@ -128,7 +121,6 @@ func TestMPC_SCE3_ActiveACCurrent(t *testing.T) {
 func TestMPC_SCE4_ACVoltage(t *testing.T) {
 	t.Run("ATC_SCE4_PT_MAACVoltage", func(t *testing.T) {
 		c, mm, entity := newMPCMeter(t)
-		mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCVoltagePerPhase).Return(true)
 		mm.EXPECT().VoltagePerPhase(entity).Return([]float64{230.0, 230.5, 229.5}, nil)
 
 		u1, u2, u3, err := c.Voltages()
@@ -140,7 +132,6 @@ func TestMPC_SCE4_ACVoltage(t *testing.T) {
 		for _, badErr := range nonNormalErrors {
 			t.Run(badErr.Error(), func(t *testing.T) {
 				c, mm, entity := newMPCMeter(t)
-				mm.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.MPCVoltagePerPhase).Return(true)
 				mm.EXPECT().VoltagePerPhase(entity).Return(nil, badErr)
 
 				_, _, _, err := c.Voltages()

--- a/meter/eebus_mpc_test.go
+++ b/meter/eebus_mpc_test.go
@@ -24,7 +24,6 @@ func newMPCMeter(t *testing.T) (*EEBus, *mpcmocks.MaMPCInterface, spineapi.Entit
 
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mpc-test"),
-		mm:        mm,
 		maEntity:  eebus.NewEntity[measurements](mm),
 		scenarios: mpcScenarios,
 	}

--- a/meter/eebus_mpc_test.go
+++ b/meter/eebus_mpc_test.go
@@ -25,9 +25,9 @@ func newMPCMeter(t *testing.T) (*EEBus, *mpcmocks.MaMPCInterface, spineapi.Entit
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mpc-test"),
 		mm:        mm,
-		maEntity:  entity,
 		scenarios: mpcScenarios,
 	}
+	c.maEntity.Set(entity)
 
 	return c, mm, entity
 }

--- a/meter/eebus_mpc_test.go
+++ b/meter/eebus_mpc_test.go
@@ -25,7 +25,7 @@ func newMPCMeter(t *testing.T) (*EEBus, *mpcmocks.MaMPCInterface, spineapi.Entit
 	c := &EEBus{
 		log:       util.NewLogger("eebus-mpc-test"),
 		mm:        mm,
-		maEntity:  eebus.NewEntity(mm),
+		maEntity:  eebus.NewEntity[measurements](mm),
 		scenarios: mpcScenarios,
 	}
 	c.maEntity.Set(entity)

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -103,6 +103,13 @@ func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInte
 	return res, nil
 }
 
+// ReadArg is Read for a use case reader taking an additional argument.
+func (e *Entity[U]) ReadArg[T, A any](read func(uc U, entity spineapi.EntityRemoteInterface, arg A) (T, error), arg A) (T, error) {
+	return e.Read(func(uc U, entity spineapi.EntityRemoteInterface) (T, error) {
+		return read(uc, entity, arg)
+	})
+}
+
 // Write runs a control write against the remote entity and waits for its result.
 func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error)) error {
 	entity, err := e.Available()
@@ -112,5 +119,12 @@ func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface
 
 	return Await(func(cb ResultCB) (*model.MsgCounterType, error) {
 		return write(e.uc, entity, cb)
+	})
+}
+
+// WriteArg is Write for a control write taking an additional argument.
+func (e *Entity[U]) WriteArg[A any](write func(uc U, entity spineapi.EntityRemoteInterface, arg A, cb ResultCB) (*model.MsgCounterType, error), arg A) error {
+	return e.Write(func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error) {
+		return write(uc, entity, arg, cb)
 	})
 }

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -64,10 +64,10 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) bool {
 	return e.entity != prev
 }
 
-// Available returns the remote entity, ErrNotAvailable if the use case has none
+// available returns the remote entity, ErrNotAvailable if the use case has none
 // or the entity does not announce all of the given scenarios. Use case methods
 // only validate the entity type, so the scenarios must be checked here.
-func (e *Entity[U]) Available(scenarios ...uint) (spineapi.EntityRemoteInterface, error) {
+func (e *Entity[U]) available(scenarios ...uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.get()
 	if entity == nil {
 		return nil, api.ErrNotAvailable
@@ -97,7 +97,7 @@ func (e *Entity[U]) Required() (spineapi.EntityRemoteInterface, error) {
 func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInterface) (T, error), scenarios ...uint) (T, error) {
 	var zero T
 
-	entity, err := e.Available(scenarios...)
+	entity, err := e.available(scenarios...)
 	if err != nil {
 		return zero, err
 	}
@@ -112,7 +112,7 @@ func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInte
 
 // Write runs a control write against the remote entity and waits for its result.
 func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error), scenarios ...uint) error {
-	entity, err := e.Available(scenarios...)
+	entity, err := e.available(scenarios...)
 	if err != nil {
 		return err
 	}

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -1,0 +1,64 @@
+package eebus
+
+import (
+	"sync"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+)
+
+// Entity is the remote entity a use case is available at. It guards its own
+// access, the zero value is ready to use.
+type Entity struct {
+	mu     sync.RWMutex
+	entity spineapi.EntityRemoteInterface
+}
+
+// Get returns the remote entity, nil if the use case has none (yet)
+func (e *Entity) Get() spineapi.EntityRemoteInterface {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.entity
+}
+
+// Set records the remote entity, use nil to drop it e.g. on disconnect
+func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.entity = entity
+}
+
+// Update records the remote entity reported by a use case support update. Removal
+// emits the same event with the entity set, so a recorded entity is dropped once
+// its scenarios are gone; otherwise the shallowest entity wins.
+func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.entity != nil && len(uc.AvailableScenariosForEntity(e.entity)) == 0 {
+		e.entity = nil
+	}
+
+	// removal, or an entity that doesn't support any scenario of the use case
+	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
+		return
+	}
+
+	if e.entity == nil || len(entity.Address().Entity) < len(e.entity.Address().Entity) {
+		e.entity = entity
+	}
+}
+
+// Required returns the remote entity while the use case scenario is available at
+// it, ErrNotConnected otherwise. Optional data uses ReadValue.
+func (e *Entity) Required(uc eebusapi.UseCaseBaseInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+	entity := e.Get()
+
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return nil, ErrNotConnected
+	}
+
+	return entity, nil
+}

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -8,11 +8,18 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-// Entity is the remote entity a use case is available at. It guards its own
-// access, the zero value is ready to use.
+// Entity is the remote entity a use case is available at. It knows its use case
+// and guards its own access.
 type Entity struct {
+	uc eebusapi.UseCaseBaseInterface
+
 	mu     sync.RWMutex
 	entity spineapi.EntityRemoteInterface
+}
+
+// NewEntity creates the remote entity of a use case
+func NewEntity(uc eebusapi.UseCaseBaseInterface) *Entity {
+	return &Entity{uc: uc}
 }
 
 // Get returns the remote entity, nil if the use case has none (yet)
@@ -31,19 +38,18 @@ func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
 	e.entity = entity
 }
 
-// Update records the remote entity reported by a use case support update. Removal
-// emits the same event with the entity set, so a recorded entity is dropped once
-// its scenarios are gone; otherwise the shallowest entity wins.
-func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface) {
+// Update records the remote entity of a use case support update. Removal emits the
+// same event with the entity set, so it is dropped once its scenarios are gone.
+func (e *Entity) Update(entity spineapi.EntityRemoteInterface) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if e.entity != nil && len(uc.AvailableScenariosForEntity(e.entity)) == 0 {
+	if e.entity != nil && len(e.uc.AvailableScenariosForEntity(e.entity)) == 0 {
 		e.entity = nil
 	}
 
 	// removal, or an entity that doesn't support any scenario of the use case
-	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
+	if entity == nil || len(e.uc.AvailableScenariosForEntity(entity)) == 0 {
 		return
 	}
 
@@ -52,14 +58,13 @@ func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.Entity
 	}
 }
 
-// Read reads a use case value from the remote entity. It reports ErrNotAvailable
-// while the scenario is unavailable at the entity or the value has not been
-// received yet.
-func (e *Entity) Read[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+// Read reads a use case value from the remote entity, reporting ErrNotAvailable
+// while the scenario is unavailable or the value has not been received yet.
+func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
 	entity := e.Get()
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
 		return zero, api.ErrNotAvailable
 	}
 
@@ -73,10 +78,10 @@ func (e *Entity) Read[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, re
 
 // Required returns the remote entity while the use case scenario is available at
 // it, ErrNotConnected otherwise. Optional data uses Read.
-func (e *Entity) Required(uc eebusapi.UseCaseBaseInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+func (e *Entity) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
 
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
 		return nil, ErrNotConnected
 	}
 

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -58,22 +58,21 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) {
 	}
 }
 
-// Available returns the remote entity while the use case scenario is available
-// at it, ErrNotAvailable otherwise.
-func (e *Entity[U]) Available(scenario uint) (spineapi.EntityRemoteInterface, error) {
+// Available returns the remote entity, ErrNotAvailable if the use case has none.
+// Use case methods validate the entity themselves, so no scenario check is needed.
+func (e *Entity[U]) Available() (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
-
-	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
+	if entity == nil {
 		return nil, api.ErrNotAvailable
 	}
 
 	return entity, nil
 }
 
-// Required is Available for a scenario the device cannot operate without
-func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
-	entity, err := e.Available(scenario)
-	if err != nil {
+// Required is Available for a use case the device cannot operate without
+func (e *Entity[U]) Required() (spineapi.EntityRemoteInterface, error) {
+	entity := e.Get()
+	if entity == nil {
 		return nil, ErrNotConnected
 	}
 
@@ -81,11 +80,11 @@ func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, err
 }
 
 // Read reads a use case value from the remote entity, reporting ErrNotAvailable
-// while the scenario is unavailable or the value has not been received yet.
-func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+// while the use case is unavailable or the value has not been received yet.
+func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
-	entity, err := e.Available(scenario)
+	entity, err := e.Available()
 	if err != nil {
 		return zero, err
 	}

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -22,8 +22,8 @@ func NewEntity[U eebusapi.UseCaseBaseInterface](uc U) *Entity[U] {
 	return &Entity[U]{uc: uc}
 }
 
-// Get returns the remote entity, nil if the use case has none (yet)
-func (e *Entity[U]) Get() spineapi.EntityRemoteInterface {
+// get returns the remote entity, nil if the use case has none (yet)
+func (e *Entity[U]) get() spineapi.EntityRemoteInterface {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -61,7 +61,7 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) {
 // Available returns the remote entity, ErrNotAvailable if the use case has none.
 // Use case methods validate the entity themselves, so no scenario check is needed.
 func (e *Entity[U]) Available() (spineapi.EntityRemoteInterface, error) {
-	entity := e.Get()
+	entity := e.get()
 	if entity == nil {
 		return nil, api.ErrNotAvailable
 	}
@@ -71,7 +71,7 @@ func (e *Entity[U]) Available() (spineapi.EntityRemoteInterface, error) {
 
 // Required is Available for a use case the device cannot operate without
 func (e *Entity[U]) Required() (spineapi.EntityRemoteInterface, error) {
-	entity := e.Get()
+	entity := e.get()
 	if entity == nil {
 		return nil, ErrNotConnected
 	}

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -63,14 +63,36 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) bool {
 	return e.entity != nil && e.entity != prev
 }
 
+// Available returns the remote entity while the use case scenario is available
+// at it, ErrNotAvailable otherwise.
+func (e *Entity[U]) Available(scenario uint) (spineapi.EntityRemoteInterface, error) {
+	entity := e.Get()
+
+	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return nil, api.ErrNotAvailable
+	}
+
+	return entity, nil
+}
+
+// Required is Available for a scenario the device cannot operate without
+func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
+	entity, err := e.Available(scenario)
+	if err != nil {
+		return nil, ErrNotConnected
+	}
+
+	return entity, nil
+}
+
 // Read reads a use case value from the remote entity, reporting ErrNotAvailable
 // while the scenario is unavailable or the value has not been received yet.
 func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
-	entity := e.Get()
-	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return zero, api.ErrNotAvailable
+	entity, err := e.Available(scenario)
+	if err != nil {
+		return zero, err
 	}
 
 	res, err := read(e.uc, entity)
@@ -79,16 +101,4 @@ func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.E
 	}
 
 	return res, nil
-}
-
-// Required returns the remote entity while the use case scenario is available at
-// it, ErrNotConnected otherwise. Optional data uses Read.
-func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
-	entity := e.Get()
-
-	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return nil, ErrNotConnected
-	}
-
-	return entity, nil
 }

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -5,6 +5,7 @@ import (
 
 	eebusapi "github.com/enbility/eebus-go/api"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/evcc-io/evcc/api"
 )
 
 // Entity is the remote entity a use case is available at. It guards its own
@@ -51,8 +52,27 @@ func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.Entity
 	}
 }
 
+// Read reads a use case value from the remote entity. It reports ErrNotAvailable
+// while the scenario is unavailable at the entity or the value has not been
+// received yet.
+func (e *Entity) Read[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+	var zero T
+
+	entity := e.Get()
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return zero, api.ErrNotAvailable
+	}
+
+	res, err := read(entity)
+	if err != nil {
+		return zero, WrapError(err)
+	}
+
+	return res, nil
+}
+
 // Required returns the remote entity while the use case scenario is available at
-// it, ErrNotConnected otherwise. Optional data uses ReadValue.
+// it, ErrNotConnected otherwise. Optional data uses Read.
 func (e *Entity) Required(uc eebusapi.UseCaseBaseInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
 

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -61,7 +61,7 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) bool {
 		e.entity = entity
 	}
 
-	return e.entity != nil && e.entity != prev
+	return e.entity != prev
 }
 
 // Available returns the remote entity, ErrNotAvailable if the use case has none

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -22,8 +22,8 @@ func NewEntity[U eebusapi.UseCaseBaseInterface](uc U) *Entity[U] {
 	return &Entity[U]{uc: uc}
 }
 
-// Get returns the remote entity, nil if the use case has none (yet)
-func (e *Entity[U]) Get() spineapi.EntityRemoteInterface {
+// get returns the remote entity, nil if the use case has none (yet)
+func (e *Entity[U]) get() spineapi.EntityRemoteInterface {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -66,7 +66,7 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) bool {
 // Available returns the remote entity, ErrNotAvailable if the use case has none.
 // Use case methods validate the entity themselves, so no scenario check is needed.
 func (e *Entity[U]) Available() (spineapi.EntityRemoteInterface, error) {
-	entity := e.Get()
+	entity := e.get()
 	if entity == nil {
 		return nil, api.ErrNotAvailable
 	}
@@ -76,7 +76,7 @@ func (e *Entity[U]) Available() (spineapi.EntityRemoteInterface, error) {
 
 // Required is Available for a use case the device cannot operate without
 func (e *Entity[U]) Required() (spineapi.EntityRemoteInterface, error) {
-	entity := e.Get()
+	entity := e.get()
 	if entity == nil {
 		return nil, ErrNotConnected
 	}

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -10,20 +10,20 @@ import (
 
 // Entity is the remote entity a use case is available at. It knows its use case
 // and guards its own access.
-type Entity struct {
-	uc eebusapi.UseCaseBaseInterface
+type Entity[U eebusapi.UseCaseBaseInterface] struct {
+	uc U
 
 	mu     sync.RWMutex
 	entity spineapi.EntityRemoteInterface
 }
 
 // NewEntity creates the remote entity of a use case
-func NewEntity(uc eebusapi.UseCaseBaseInterface) *Entity {
-	return &Entity{uc: uc}
+func NewEntity[U eebusapi.UseCaseBaseInterface](uc U) *Entity[U] {
+	return &Entity[U]{uc: uc}
 }
 
 // Get returns the remote entity, nil if the use case has none (yet)
-func (e *Entity) Get() spineapi.EntityRemoteInterface {
+func (e *Entity[U]) Get() spineapi.EntityRemoteInterface {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -31,7 +31,7 @@ func (e *Entity) Get() spineapi.EntityRemoteInterface {
 }
 
 // Set records the remote entity, use nil to drop it e.g. on disconnect
-func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
+func (e *Entity[U]) Set(entity spineapi.EntityRemoteInterface) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -40,7 +40,7 @@ func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
 
 // Update records the remote entity of a use case support update. Removal emits the
 // same event with the entity set, so it is dropped once its scenarios are gone.
-func (e *Entity) Update(entity spineapi.EntityRemoteInterface) {
+func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -60,7 +60,7 @@ func (e *Entity) Update(entity spineapi.EntityRemoteInterface) {
 
 // Read reads a use case value from the remote entity, reporting ErrNotAvailable
 // while the scenario is unavailable or the value has not been received yet.
-func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
 	entity := e.Get()
@@ -68,7 +68,7 @@ func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemo
 		return zero, api.ErrNotAvailable
 	}
 
-	res, err := read(entity)
+	res, err := read(e.uc, entity)
 	if err != nil {
 		return zero, WrapError(err)
 	}
@@ -78,7 +78,7 @@ func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemo
 
 // Required returns the remote entity while the use case scenario is available at
 // it, ErrNotConnected otherwise. Optional data uses Read.
-func (e *Entity) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
+func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
 
 	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -64,12 +64,19 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) bool {
 	return e.entity != nil && e.entity != prev
 }
 
-// Available returns the remote entity, ErrNotAvailable if the use case has none.
-// Use case methods validate the entity themselves, so no scenario check is needed.
-func (e *Entity[U]) Available() (spineapi.EntityRemoteInterface, error) {
+// Available returns the remote entity, ErrNotAvailable if the use case has none
+// or the entity does not announce all of the given scenarios. Use case methods
+// only validate the entity type, so the scenarios must be checked here.
+func (e *Entity[U]) Available(scenarios ...uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.get()
 	if entity == nil {
 		return nil, api.ErrNotAvailable
+	}
+
+	for _, scenario := range scenarios {
+		if !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
+			return nil, api.ErrNotAvailable
+		}
 	}
 
 	return entity, nil
@@ -86,11 +93,11 @@ func (e *Entity[U]) Required() (spineapi.EntityRemoteInterface, error) {
 }
 
 // Read reads a use case value from the remote entity, reporting ErrNotAvailable
-// while the use case is unavailable or the value has not been received yet.
-func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+// while the scenario is unannounced or the value has not been received yet.
+func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInterface) (T, error), scenarios ...uint) (T, error) {
 	var zero T
 
-	entity, err := e.Available()
+	entity, err := e.Available(scenarios...)
 	if err != nil {
 		return zero, err
 	}
@@ -103,28 +110,21 @@ func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInte
 	return res, nil
 }
 
-// ReadArg is Read for a use case reader taking an additional argument.
-func (e *Entity[U]) ReadArg[T, A any](read func(uc U, entity spineapi.EntityRemoteInterface, arg A) (T, error), arg A) (T, error) {
-	return e.Read(func(uc U, entity spineapi.EntityRemoteInterface) (T, error) {
-		return read(uc, entity, arg)
-	})
-}
-
 // Write runs a control write against the remote entity and waits for its result.
-func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error)) error {
-	entity, err := e.Available()
+func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error), scenarios ...uint) error {
+	entity, err := e.Available(scenarios...)
 	if err != nil {
 		return err
 	}
 
-	return Await(func(cb ResultCB) (*model.MsgCounterType, error) {
+	return WrapError(Await(func(cb ResultCB) (*model.MsgCounterType, error) {
 		return write(e.uc, entity, cb)
-	})
+	}))
 }
 
 // WriteArg is Write for a control write taking an additional argument.
-func (e *Entity[U]) WriteArg[A any](write func(uc U, entity spineapi.EntityRemoteInterface, arg A, cb ResultCB) (*model.MsgCounterType, error), arg A) error {
+func (e *Entity[U]) WriteArg[A any](write func(uc U, entity spineapi.EntityRemoteInterface, arg A, cb ResultCB) (*model.MsgCounterType, error), arg A, scenarios ...uint) error {
 	return e.Write(func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error) {
 		return write(uc, entity, arg, cb)
-	})
+	}, scenarios...)
 }

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -5,6 +5,7 @@ import (
 
 	eebusapi "github.com/enbility/eebus-go/api"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 )
 
@@ -100,4 +101,16 @@ func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInte
 	}
 
 	return res, nil
+}
+
+// Write runs a control write against the remote entity and waits for its result.
+func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error)) error {
+	entity, err := e.Available()
+	if err != nil {
+		return err
+	}
+
+	return Await(func(cb ResultCB) (*model.MsgCounterType, error) {
+		return write(e.uc, entity, cb)
+	})
 }

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -8,11 +8,18 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
-// Entity is the remote entity a use case is available at. It guards its own
-// access, the zero value is ready to use.
+// Entity is the remote entity a use case is available at. It knows its use case
+// and guards its own access.
 type Entity struct {
+	uc eebusapi.UseCaseBaseInterface
+
 	mu     sync.RWMutex
 	entity spineapi.EntityRemoteInterface
+}
+
+// NewEntity creates the remote entity of a use case
+func NewEntity(uc eebusapi.UseCaseBaseInterface) *Entity {
+	return &Entity{uc: uc}
 }
 
 // Get returns the remote entity, nil if the use case has none (yet)
@@ -31,22 +38,21 @@ func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
 	e.entity = entity
 }
 
-// Update records the remote entity reported by a use case support update. Removal
-// emits the same event with the entity set, so a recorded entity is dropped once
-// its scenarios are gone; otherwise the shallowest entity wins. It reports whether
-// the use case became available at a new entity.
-func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface) bool {
+// Update records the remote entity of a use case support update. Removal emits the
+// same event with the entity set, so it is dropped once its scenarios are gone. It
+// reports whether the use case became available at a new entity.
+func (e *Entity) Update(entity spineapi.EntityRemoteInterface) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	prev := e.entity
 
-	if e.entity != nil && len(uc.AvailableScenariosForEntity(e.entity)) == 0 {
+	if e.entity != nil && len(e.uc.AvailableScenariosForEntity(e.entity)) == 0 {
 		e.entity = nil
 	}
 
 	// removal, or an entity that doesn't support any scenario of the use case
-	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
+	if entity == nil || len(e.uc.AvailableScenariosForEntity(entity)) == 0 {
 		return false
 	}
 
@@ -57,14 +63,13 @@ func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.Entity
 	return e.entity != nil && e.entity != prev
 }
 
-// Read reads a use case value from the remote entity. It reports ErrNotAvailable
-// while the scenario is unavailable at the entity or the value has not been
-// received yet.
-func (e *Entity) Read[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+// Read reads a use case value from the remote entity, reporting ErrNotAvailable
+// while the scenario is unavailable or the value has not been received yet.
+func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
 	entity := e.Get()
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
 		return zero, api.ErrNotAvailable
 	}
 
@@ -78,10 +83,10 @@ func (e *Entity) Read[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, re
 
 // Required returns the remote entity while the use case scenario is available at
 // it, ErrNotConnected otherwise. Optional data uses Read.
-func (e *Entity) Required(uc eebusapi.UseCaseBaseInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+func (e *Entity) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
 
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
 		return nil, ErrNotConnected
 	}
 

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -5,6 +5,7 @@ import (
 
 	eebusapi "github.com/enbility/eebus-go/api"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/evcc-io/evcc/api"
 )
 
 // Entity is the remote entity a use case is available at. It guards its own
@@ -56,8 +57,27 @@ func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.Entity
 	return e.entity != nil && e.entity != prev
 }
 
+// Read reads a use case value from the remote entity. It reports ErrNotAvailable
+// while the scenario is unavailable at the entity or the value has not been
+// received yet.
+func (e *Entity) Read[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+	var zero T
+
+	entity := e.Get()
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return zero, api.ErrNotAvailable
+	}
+
+	res, err := read(entity)
+	if err != nil {
+		return zero, WrapError(err)
+	}
+
+	return res, nil
+}
+
 // Required returns the remote entity while the use case scenario is available at
-// it, ErrNotConnected otherwise. Optional data uses ReadValue.
+// it, ErrNotConnected otherwise. Optional data uses Read.
 func (e *Entity) Required(uc eebusapi.UseCaseBaseInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
 

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -63,22 +63,21 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) bool {
 	return e.entity != nil && e.entity != prev
 }
 
-// Available returns the remote entity while the use case scenario is available
-// at it, ErrNotAvailable otherwise.
-func (e *Entity[U]) Available(scenario uint) (spineapi.EntityRemoteInterface, error) {
+// Available returns the remote entity, ErrNotAvailable if the use case has none.
+// Use case methods validate the entity themselves, so no scenario check is needed.
+func (e *Entity[U]) Available() (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
-
-	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
+	if entity == nil {
 		return nil, api.ErrNotAvailable
 	}
 
 	return entity, nil
 }
 
-// Required is Available for a scenario the device cannot operate without
-func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
-	entity, err := e.Available(scenario)
-	if err != nil {
+// Required is Available for a use case the device cannot operate without
+func (e *Entity[U]) Required() (spineapi.EntityRemoteInterface, error) {
+	entity := e.Get()
+	if entity == nil {
 		return nil, ErrNotConnected
 	}
 
@@ -86,11 +85,11 @@ func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, err
 }
 
 // Read reads a use case value from the remote entity, reporting ErrNotAvailable
-// while the scenario is unavailable or the value has not been received yet.
-func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+// while the use case is unavailable or the value has not been received yet.
+func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
-	entity, err := e.Available(scenario)
+	entity, err := e.Available()
 	if err != nil {
 		return zero, err
 	}

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -58,14 +58,36 @@ func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) {
 	}
 }
 
+// Available returns the remote entity while the use case scenario is available
+// at it, ErrNotAvailable otherwise.
+func (e *Entity[U]) Available(scenario uint) (spineapi.EntityRemoteInterface, error) {
+	entity := e.Get()
+
+	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return nil, api.ErrNotAvailable
+	}
+
+	return entity, nil
+}
+
+// Required is Available for a scenario the device cannot operate without
+func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
+	entity, err := e.Available(scenario)
+	if err != nil {
+		return nil, ErrNotConnected
+	}
+
+	return entity, nil
+}
+
 // Read reads a use case value from the remote entity, reporting ErrNotAvailable
 // while the scenario is unavailable or the value has not been received yet.
 func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
-	entity := e.Get()
-	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return zero, api.ErrNotAvailable
+	entity, err := e.Available(scenario)
+	if err != nil {
+		return zero, err
 	}
 
 	res, err := read(e.uc, entity)
@@ -74,16 +96,4 @@ func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.E
 	}
 
 	return res, nil
-}
-
-// Required returns the remote entity while the use case scenario is available at
-// it, ErrNotConnected otherwise. Optional data uses Read.
-func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
-	entity := e.Get()
-
-	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return nil, ErrNotConnected
-	}
-
-	return entity, nil
 }

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -98,6 +98,13 @@ func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInte
 	return res, nil
 }
 
+// ReadArg is Read for a use case reader taking an additional argument.
+func (e *Entity[U]) ReadArg[T, A any](read func(uc U, entity spineapi.EntityRemoteInterface, arg A) (T, error), arg A) (T, error) {
+	return e.Read(func(uc U, entity spineapi.EntityRemoteInterface) (T, error) {
+		return read(uc, entity, arg)
+	})
+}
+
 // Write runs a control write against the remote entity and waits for its result.
 func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error)) error {
 	entity, err := e.Available()
@@ -107,5 +114,12 @@ func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface
 
 	return Await(func(cb ResultCB) (*model.MsgCounterType, error) {
 		return write(e.uc, entity, cb)
+	})
+}
+
+// WriteArg is Write for a control write taking an additional argument.
+func (e *Entity[U]) WriteArg[A any](write func(uc U, entity spineapi.EntityRemoteInterface, arg A, cb ResultCB) (*model.MsgCounterType, error), arg A) error {
+	return e.Write(func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error) {
+		return write(uc, entity, arg, cb)
 	})
 }

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -5,6 +5,7 @@ import (
 
 	eebusapi "github.com/enbility/eebus-go/api"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 )
 
@@ -95,4 +96,16 @@ func (e *Entity[U]) Read[T any](read func(uc U, entity spineapi.EntityRemoteInte
 	}
 
 	return res, nil
+}
+
+// Write runs a control write against the remote entity and waits for its result.
+func (e *Entity[U]) Write(write func(uc U, entity spineapi.EntityRemoteInterface, cb ResultCB) (*model.MsgCounterType, error)) error {
+	entity, err := e.Available()
+	if err != nil {
+		return err
+	}
+
+	return Await(func(cb ResultCB) (*model.MsgCounterType, error) {
+		return write(e.uc, entity, cb)
+	})
 }

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -10,20 +10,20 @@ import (
 
 // Entity is the remote entity a use case is available at. It knows its use case
 // and guards its own access.
-type Entity struct {
-	uc eebusapi.UseCaseBaseInterface
+type Entity[U eebusapi.UseCaseBaseInterface] struct {
+	uc U
 
 	mu     sync.RWMutex
 	entity spineapi.EntityRemoteInterface
 }
 
 // NewEntity creates the remote entity of a use case
-func NewEntity(uc eebusapi.UseCaseBaseInterface) *Entity {
-	return &Entity{uc: uc}
+func NewEntity[U eebusapi.UseCaseBaseInterface](uc U) *Entity[U] {
+	return &Entity[U]{uc: uc}
 }
 
 // Get returns the remote entity, nil if the use case has none (yet)
-func (e *Entity) Get() spineapi.EntityRemoteInterface {
+func (e *Entity[U]) Get() spineapi.EntityRemoteInterface {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -31,7 +31,7 @@ func (e *Entity) Get() spineapi.EntityRemoteInterface {
 }
 
 // Set records the remote entity, use nil to drop it e.g. on disconnect
-func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
+func (e *Entity[U]) Set(entity spineapi.EntityRemoteInterface) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -41,7 +41,7 @@ func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
 // Update records the remote entity of a use case support update. Removal emits the
 // same event with the entity set, so it is dropped once its scenarios are gone. It
 // reports whether the use case became available at a new entity.
-func (e *Entity) Update(entity spineapi.EntityRemoteInterface) bool {
+func (e *Entity[U]) Update(entity spineapi.EntityRemoteInterface) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -65,7 +65,7 @@ func (e *Entity) Update(entity spineapi.EntityRemoteInterface) bool {
 
 // Read reads a use case value from the remote entity, reporting ErrNotAvailable
 // while the scenario is unavailable or the value has not been received yet.
-func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+func (e *Entity[U]) Read[T any](scenario uint, read func(uc U, entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
 	entity := e.Get()
@@ -73,7 +73,7 @@ func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemo
 		return zero, api.ErrNotAvailable
 	}
 
-	res, err := read(entity)
+	res, err := read(e.uc, entity)
 	if err != nil {
 		return zero, WrapError(err)
 	}
@@ -83,7 +83,7 @@ func (e *Entity) Read[T any](scenario uint, read func(entity spineapi.EntityRemo
 
 // Required returns the remote entity while the use case scenario is available at
 // it, ErrNotConnected otherwise. Optional data uses Read.
-func (e *Entity) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
+func (e *Entity[U]) Required(scenario uint) (spineapi.EntityRemoteInterface, error) {
 	entity := e.Get()
 
 	if entity == nil || !e.uc.IsScenarioAvailableAtEntity(entity, scenario) {

--- a/server/eebus/entity.go
+++ b/server/eebus/entity.go
@@ -1,0 +1,69 @@
+package eebus
+
+import (
+	"sync"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+)
+
+// Entity is the remote entity a use case is available at. It guards its own
+// access, the zero value is ready to use.
+type Entity struct {
+	mu     sync.RWMutex
+	entity spineapi.EntityRemoteInterface
+}
+
+// Get returns the remote entity, nil if the use case has none (yet)
+func (e *Entity) Get() spineapi.EntityRemoteInterface {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.entity
+}
+
+// Set records the remote entity, use nil to drop it e.g. on disconnect
+func (e *Entity) Set(entity spineapi.EntityRemoteInterface) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.entity = entity
+}
+
+// Update records the remote entity reported by a use case support update. Removal
+// emits the same event with the entity set, so a recorded entity is dropped once
+// its scenarios are gone; otherwise the shallowest entity wins. It reports whether
+// the use case became available at a new entity.
+func (e *Entity) Update(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	prev := e.entity
+
+	if e.entity != nil && len(uc.AvailableScenariosForEntity(e.entity)) == 0 {
+		e.entity = nil
+	}
+
+	// removal, or an entity that doesn't support any scenario of the use case
+	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
+		return false
+	}
+
+	if e.entity == nil || len(entity.Address().Entity) < len(e.entity.Address().Entity) {
+		e.entity = entity
+	}
+
+	return e.entity != nil && e.entity != prev
+}
+
+// Required returns the remote entity while the use case scenario is available at
+// it, ErrNotConnected otherwise. Optional data uses ReadValue.
+func (e *Entity) Required(uc eebusapi.UseCaseBaseInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+	entity := e.Get()
+
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return nil, ErrNotConnected
+	}
+
+	return entity, nil
+}

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -86,19 +86,7 @@ func TestEntityRequired(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 		e := NewEntity(uc)
 
-		_, err := e.Required(MPCPower)
-		assert.ErrorIs(t, err, ErrNotConnected)
-	})
-
-	t.Run("scenario not announced", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-		e := NewEntity(uc)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
-
-		e.Set(entity)
-
-		_, err := e.Required(MPCPower)
+		_, err := e.Required()
 		assert.ErrorIs(t, err, ErrNotConnected)
 	})
 
@@ -106,11 +94,10 @@ func TestEntityRequired(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 		e := NewEntity(uc)
 		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
 		e.Set(entity)
 
-		res, err := e.Required(MPCPower)
+		res, err := e.Required()
 		require.NoError(t, err)
 		assert.Equal(t, entity, res)
 	})
@@ -121,38 +108,27 @@ func TestEntityRead(t *testing.T) {
 		return func(*ucmocks.MaMPCInterface, spineapi.EntityRemoteInterface) (float64, error) { return res, err }
 	}
 
+	// the use case rejects an absent entity itself
 	t.Run("entity missing", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 		e := NewEntity(uc)
 
-		_, err := e.Read(MPCPower, read(1, nil))
-		assert.ErrorIs(t, err, api.ErrNotAvailable)
-	})
-
-	t.Run("scenario not announced", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-		e := NewEntity(uc)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
-
-		e.Set(entity)
-
-		_, err := e.Read(MPCPower, read(1, nil))
+		_, err := e.Read(read(0, eebusapi.ErrNoCompatibleEntity))
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
 	})
 
 	// data not received yet is not an error condition
-	for _, tc := range []error{eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable, eebusapi.ErrDataInvalid} {
+	for _, tc := range []error{
+		eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable,
+		eebusapi.ErrDataInvalid, eebusapi.ErrNoCompatibleEntity,
+	} {
 		t.Run(tc.Error(), func(t *testing.T) {
 			uc := ucmocks.NewMaMPCInterface(t)
 			e := NewEntity(uc)
 
-			entity := testEntity(t, 1)
-			uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+			e.Set(testEntity(t, 1))
 
-			e.Set(entity)
-
-			_, err := e.Read(MPCPower, read(0, tc))
+			_, err := e.Read(read(0, tc))
 			assert.ErrorIs(t, err, api.ErrNotAvailable)
 		})
 	}
@@ -160,24 +136,20 @@ func TestEntityRead(t *testing.T) {
 	t.Run("other error passes through", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 		e := NewEntity(uc)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		e.Set(entity)
+		e.Set(testEntity(t, 1))
 
-		_, err := e.Read(MPCPower, read(0, errors.New("boom")))
+		_, err := e.Read(read(0, errors.New("boom")))
 		assert.EqualError(t, err, "boom")
 	})
 
 	t.Run("value", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 		e := NewEntity(uc)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		e.Set(entity)
+		e.Set(testEntity(t, 1))
 
-		res, err := e.Read(MPCPower, read(4711, nil))
+		res, err := e.Read(read(4711, nil))
 		require.NoError(t, err)
 		assert.Equal(t, 4711.0, res)
 	})

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -33,12 +33,13 @@ func TestEntityUpdate(t *testing.T) {
 		cachedScenarios          []uint
 		entityScenarios          []uint
 		want                     string // "cached", "entity" or "nil"
+		newlyAvailable           bool
 	}{
-		{"first entity is recorded", 0, 1, nil, []uint{1}, "entity"},
-		{"entity without scenarios is ignored", 0, 1, nil, nil, "nil"},
-		{"shallower entity wins", 2, 1, []uint{1}, []uint{1}, "entity"},
-		{"deeper entity loses", 1, 2, []uint{1}, []uint{1}, "cached"},
-		{"removal drops the recorded entity", 1, 1, nil, nil, "nil"},
+		{"first entity is recorded", 0, 1, nil, []uint{1}, "entity", true},
+		{"entity without scenarios is ignored", 0, 1, nil, nil, "nil", false},
+		{"shallower entity wins", 2, 1, []uint{1}, []uint{1}, "entity", true},
+		{"deeper entity loses", 1, 2, []uint{1}, []uint{1}, "cached", false},
+		{"removal drops the recorded entity", 1, 1, nil, nil, "nil", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			uc := ucmocks.NewMaMPCInterface(t)
@@ -58,7 +59,8 @@ func TestEntityUpdate(t *testing.T) {
 				"cached": cached, "entity": entity, "nil": nil,
 			}[tc.want]
 
-			e.Update(entity)
+			// the result gates re-stating the limit to a newly available CS
+			assert.Equal(t, tc.newlyAvailable, e.Update(entity))
 			assert.Equal(t, want, e.get())
 		})
 	}
@@ -77,7 +79,7 @@ func TestEntityUpdateRemovalOfOtherEntity(t *testing.T) {
 	e := NewEntity(uc)
 	e.Set(cached)
 
-	e.Update(removed)
+	assert.False(t, e.Update(removed))
 	assert.Equal(t, cached, e.get())
 }
 

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -108,19 +108,17 @@ func TestEntityRead(t *testing.T) {
 		return func(*ucmocks.MaMPCInterface, spineapi.EntityRemoteInterface) (float64, error) { return res, err }
 	}
 
-	// the use case rejects an absent entity itself
 	t.Run("entity missing", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 		e := NewEntity(uc)
 
-		_, err := e.Read(read(0, eebusapi.ErrNoCompatibleEntity))
+		_, err := e.Read(read(1, nil))
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
 	})
 
 	// data not received yet is not an error condition
 	for _, tc := range []error{
-		eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable,
-		eebusapi.ErrDataInvalid, eebusapi.ErrNoCompatibleEntity,
+		eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable, eebusapi.ErrDataInvalid,
 	} {
 		t.Run(tc.Error(), func(t *testing.T) {
 			uc := ucmocks.NewMaMPCInterface(t)

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -1,0 +1,114 @@
+package eebus
+
+import (
+	"testing"
+
+	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testEntity returns a remote entity mock with an address of the given depth
+func testEntity(t *testing.T, depth int) spineapi.EntityRemoteInterface {
+	t.Helper()
+
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	entity.EXPECT().Address().Return(&model.EntityAddressType{
+		Entity: make([]model.AddressEntityType, depth),
+	}).Maybe()
+
+	return entity
+}
+
+func TestEntityUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		cachedDepth, entityDepth int
+		cachedScenarios          []uint
+		entityScenarios          []uint
+		want                     string // "cached", "entity" or "nil"
+	}{
+		{"first entity is recorded", 0, 1, nil, []uint{1}, "entity"},
+		{"entity without scenarios is ignored", 0, 1, nil, nil, "nil"},
+		{"shallower entity wins", 2, 1, []uint{1}, []uint{1}, "entity"},
+		{"deeper entity loses", 1, 2, []uint{1}, []uint{1}, "cached"},
+		{"removal drops the recorded entity", 1, 1, nil, nil, "nil"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			uc := ucmocks.NewMaMPCInterface(t)
+
+			var e Entity
+			var cached spineapi.EntityRemoteInterface
+			if tc.cachedDepth > 0 {
+				cached = testEntity(t, tc.cachedDepth)
+				uc.EXPECT().AvailableScenariosForEntity(cached).Return(tc.cachedScenarios).Maybe()
+				e.Set(cached)
+			}
+
+			entity := testEntity(t, tc.entityDepth)
+			uc.EXPECT().AvailableScenariosForEntity(entity).Return(tc.entityScenarios).Maybe()
+
+			want := map[string]spineapi.EntityRemoteInterface{
+				"cached": cached, "entity": entity, "nil": nil,
+			}[tc.want]
+
+			e.Update(uc, entity)
+			assert.Equal(t, want, e.Get())
+		})
+	}
+}
+
+// removing the use case at another entity must not drop the recorded one
+func TestEntityUpdateRemovalOfOtherEntity(t *testing.T) {
+	uc := ucmocks.NewMaMPCInterface(t)
+
+	cached := testEntity(t, 1)
+	uc.EXPECT().AvailableScenariosForEntity(cached).Return([]uint{1})
+
+	removed := testEntity(t, 2)
+	uc.EXPECT().AvailableScenariosForEntity(removed).Return(nil)
+
+	var e Entity
+	e.Set(cached)
+
+	e.Update(uc, removed)
+	assert.Equal(t, cached, e.Get())
+}
+
+func TestEntityRequired(t *testing.T) {
+	t.Run("entity missing", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+
+		var e Entity
+		_, err := e.Required(uc, MPCPower)
+		assert.ErrorIs(t, err, ErrNotConnected)
+	})
+
+	t.Run("scenario not announced", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
+
+		var e Entity
+		e.Set(entity)
+
+		_, err := e.Required(uc, MPCPower)
+		assert.ErrorIs(t, err, ErrNotConnected)
+	})
+
+	t.Run("available", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+		var e Entity
+		e.Set(entity)
+
+		res, err := e.Required(uc, MPCPower)
+		require.NoError(t, err)
+		assert.Equal(t, entity, res)
+	})
+}

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -1,12 +1,15 @@
 package eebus
 
 import (
+	"errors"
 	"testing"
 
+	eebusapi "github.com/enbility/eebus-go/api"
 	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
 	spineapi "github.com/enbility/spine-go/api"
 	spinemocks "github.com/enbility/spine-go/mocks"
 	"github.com/enbility/spine-go/model"
+	"github.com/evcc-io/evcc/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,5 +113,71 @@ func TestEntityRequired(t *testing.T) {
 		res, err := e.Required(uc, MPCPower)
 		require.NoError(t, err)
 		assert.Equal(t, entity, res)
+	})
+}
+
+func TestEntityRead(t *testing.T) {
+	read := func(res float64, err error) func(spineapi.EntityRemoteInterface) (float64, error) {
+		return func(spineapi.EntityRemoteInterface) (float64, error) { return res, err }
+	}
+
+	t.Run("entity missing", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+
+		var e Entity
+		_, err := e.Read(uc, MPCPower, read(1, nil))
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
+	t.Run("scenario not announced", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
+
+		var e Entity
+		e.Set(entity)
+
+		_, err := e.Read(uc, MPCPower, read(1, nil))
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
+	// data not received yet is not an error condition
+	for _, tc := range []error{eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable, eebusapi.ErrDataInvalid} {
+		t.Run(tc.Error(), func(t *testing.T) {
+			uc := ucmocks.NewMaMPCInterface(t)
+			entity := testEntity(t, 1)
+			uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+			var e Entity
+			e.Set(entity)
+
+			_, err := e.Read(uc, MPCPower, read(0, tc))
+			assert.ErrorIs(t, err, api.ErrNotAvailable)
+		})
+	}
+
+	t.Run("other error passes through", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+		var e Entity
+		e.Set(entity)
+
+		_, err := e.Read(uc, MPCPower, read(0, errors.New("boom")))
+		assert.EqualError(t, err, "boom")
+	})
+
+	t.Run("value", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+		var e Entity
+		e.Set(entity)
+
+		res, err := e.Read(uc, MPCPower, read(4711, nil))
+		require.NoError(t, err)
+		assert.Equal(t, 4711.0, res)
 	})
 }

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -59,7 +59,7 @@ func TestEntityUpdate(t *testing.T) {
 			}[tc.want]
 
 			e.Update(entity)
-			assert.Equal(t, want, e.Get())
+			assert.Equal(t, want, e.get())
 		})
 	}
 }
@@ -78,7 +78,7 @@ func TestEntityUpdateRemovalOfOtherEntity(t *testing.T) {
 	e.Set(cached)
 
 	e.Update(removed)
-	assert.Equal(t, cached, e.Get())
+	assert.Equal(t, cached, e.get())
 }
 
 func TestEntityRequired(t *testing.T) {

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -42,8 +42,8 @@ func TestEntityUpdate(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			uc := ucmocks.NewMaMPCInterface(t)
+			e := NewEntity(uc)
 
-			var e Entity
 			var cached spineapi.EntityRemoteInterface
 			if tc.cachedDepth > 0 {
 				cached = testEntity(t, tc.cachedDepth)
@@ -58,7 +58,7 @@ func TestEntityUpdate(t *testing.T) {
 				"cached": cached, "entity": entity, "nil": nil,
 			}[tc.want]
 
-			e.Update(uc, entity)
+			e.Update(entity)
 			assert.Equal(t, want, e.Get())
 		})
 	}
@@ -74,43 +74,43 @@ func TestEntityUpdateRemovalOfOtherEntity(t *testing.T) {
 	removed := testEntity(t, 2)
 	uc.EXPECT().AvailableScenariosForEntity(removed).Return(nil)
 
-	var e Entity
+	e := NewEntity(uc)
 	e.Set(cached)
 
-	e.Update(uc, removed)
+	e.Update(removed)
 	assert.Equal(t, cached, e.Get())
 }
 
 func TestEntityRequired(t *testing.T) {
 	t.Run("entity missing", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
+		e := NewEntity(uc)
 
-		var e Entity
-		_, err := e.Required(uc, MPCPower)
+		_, err := e.Required(MPCPower)
 		assert.ErrorIs(t, err, ErrNotConnected)
 	})
 
 	t.Run("scenario not announced", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
+		e := NewEntity(uc)
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
 
-		var e Entity
 		e.Set(entity)
 
-		_, err := e.Required(uc, MPCPower)
+		_, err := e.Required(MPCPower)
 		assert.ErrorIs(t, err, ErrNotConnected)
 	})
 
 	t.Run("available", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
+		e := NewEntity(uc)
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		var e Entity
 		e.Set(entity)
 
-		res, err := e.Required(uc, MPCPower)
+		res, err := e.Required(MPCPower)
 		require.NoError(t, err)
 		assert.Equal(t, entity, res)
 	})
@@ -123,21 +123,21 @@ func TestEntityRead(t *testing.T) {
 
 	t.Run("entity missing", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
+		e := NewEntity(uc)
 
-		var e Entity
-		_, err := e.Read(uc, MPCPower, read(1, nil))
+		_, err := e.Read(MPCPower, read(1, nil))
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
 	})
 
 	t.Run("scenario not announced", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
+		e := NewEntity(uc)
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
 
-		var e Entity
 		e.Set(entity)
 
-		_, err := e.Read(uc, MPCPower, read(1, nil))
+		_, err := e.Read(MPCPower, read(1, nil))
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
 	})
 
@@ -145,38 +145,39 @@ func TestEntityRead(t *testing.T) {
 	for _, tc := range []error{eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable, eebusapi.ErrDataInvalid} {
 		t.Run(tc.Error(), func(t *testing.T) {
 			uc := ucmocks.NewMaMPCInterface(t)
+			e := NewEntity(uc)
+
 			entity := testEntity(t, 1)
 			uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-			var e Entity
 			e.Set(entity)
 
-			_, err := e.Read(uc, MPCPower, read(0, tc))
+			_, err := e.Read(MPCPower, read(0, tc))
 			assert.ErrorIs(t, err, api.ErrNotAvailable)
 		})
 	}
 
 	t.Run("other error passes through", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
+		e := NewEntity(uc)
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		var e Entity
 		e.Set(entity)
 
-		_, err := e.Read(uc, MPCPower, read(0, errors.New("boom")))
+		_, err := e.Read(MPCPower, read(0, errors.New("boom")))
 		assert.EqualError(t, err, "boom")
 	})
 
 	t.Run("value", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
+		e := NewEntity(uc)
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		var e Entity
 		e.Set(entity)
 
-		res, err := e.Read(uc, MPCPower, read(4711, nil))
+		res, err := e.Read(MPCPower, read(4711, nil))
 		require.NoError(t, err)
 		assert.Equal(t, 4711.0, res)
 	})

--- a/server/eebus/entity_test.go
+++ b/server/eebus/entity_test.go
@@ -117,8 +117,8 @@ func TestEntityRequired(t *testing.T) {
 }
 
 func TestEntityRead(t *testing.T) {
-	read := func(res float64, err error) func(spineapi.EntityRemoteInterface) (float64, error) {
-		return func(spineapi.EntityRemoteInterface) (float64, error) { return res, err }
+	read := func(res float64, err error) func(*ucmocks.MaMPCInterface, spineapi.EntityRemoteInterface) (float64, error) {
+		return func(*ucmocks.MaMPCInterface, spineapi.EntityRemoteInterface) (float64, error) { return res, err }
 	}
 
 	t.Run("entity missing", func(t *testing.T) {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -18,7 +18,8 @@ var ErrNotConnected = errors.New("not connected")
 func WrapError(err error) error {
 	if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
 		errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-		errors.Is(err, eebusapi.ErrDataInvalid) {
+		errors.Is(err, eebusapi.ErrDataInvalid) ||
+		errors.Is(err, eebusapi.ErrNoCompatibleEntity) {
 		return api.ErrNotAvailable
 	}
 	return err

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -18,8 +18,7 @@ var ErrNotConnected = errors.New("not connected")
 func WrapError(err error) error {
 	if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
 		errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-		errors.Is(err, eebusapi.ErrDataInvalid) ||
-		errors.Is(err, eebusapi.ErrNoCompatibleEntity) {
+		errors.Is(err, eebusapi.ErrDataInvalid) {
 		return api.ErrNotAvailable
 	}
 	return err
@@ -30,12 +29,11 @@ const WriteTimeout = 10 * time.Second
 
 // Await runs a control write and waits for the remote device's result, returning
 // an error if the write is rejected or no result arrives within WriteTimeout.
-// An unavailable use case is reported as ErrNotAvailable.
 func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error)) error {
 	res := make(chan model.ResultDataType, 1)
 
 	if _, err := write(func(r model.ResultDataType, _ model.MsgCounterType) { res <- r }); err != nil {
-		return WrapError(err)
+		return err
 	}
 
 	select {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -28,17 +28,6 @@ func WrapError(err error) error {
 	return err
 }
 
-// RequiredEntity returns the remote entity while the use case scenario is
-// available at it and ErrNotConnected otherwise. Use for entities the device
-// cannot operate without; optional data uses ReadValue.
-func RequiredEntity(uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface) (spineapi.EntityRemoteInterface, error) {
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return nil, ErrNotConnected
-	}
-
-	return entity, nil
-}
-
 // ReadValue reads a use case value from the remote entity. It reports
 // ErrNotAvailable while the scenario is unavailable at the entity or the value
 // has not been received yet.
@@ -55,27 +44,6 @@ func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, entity sp
 	}
 
 	return res, nil
-}
-
-// UpdateEntity returns the remote entity to cache for a use case after a use case
-// support update. Removing a use case from an entity emits the same event with the
-// entity still set, so the cached entity is dropped once its scenarios are gone.
-// Of the remaining candidates the least specific (shallowest) entity wins.
-func UpdateEntity(uc eebusapi.UseCaseBaseInterface, cached, entity spineapi.EntityRemoteInterface) spineapi.EntityRemoteInterface {
-	if cached != nil && len(uc.AvailableScenariosForEntity(cached)) == 0 {
-		cached = nil
-	}
-
-	// removal, or an entity that doesn't support any scenario of the use case
-	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
-		return cached
-	}
-
-	if cached == nil || len(entity.Address().Entity) < len(cached.Address().Entity) {
-		return entity
-	}
-
-	return cached
 }
 
 // WriteTimeout bounds how long an awaited eebus write waits for its result.

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	eebusapi "github.com/enbility/eebus-go/api"
+	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -19,6 +20,27 @@ func WrapError(err error) error {
 		return api.ErrNotAvailable
 	}
 	return err
+}
+
+// UpdateEntity returns the remote entity to cache for a use case after a use case
+// support update. Removing a use case from an entity emits the same event with the
+// entity still set, so the cached entity is dropped once its scenarios are gone.
+// Of the remaining candidates the least specific (shallowest) entity wins.
+func UpdateEntity(uc eebusapi.UseCaseBaseInterface, cached, entity spineapi.EntityRemoteInterface) spineapi.EntityRemoteInterface {
+	if cached != nil && len(uc.AvailableScenariosForEntity(cached)) == 0 {
+		cached = nil
+	}
+
+	// removal, or an entity that doesn't support any scenario of the use case
+	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
+		return cached
+	}
+
+	if cached == nil || len(entity.Address().Entity) < len(cached.Address().Entity) {
+		return entity
+	}
+
+	return cached
 }
 
 // WriteTimeout bounds how long an awaited eebus write waits for its result.

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -33,11 +33,12 @@ const WriteTimeout = 10 * time.Second
 
 // Await runs a control write and waits for the remote device's result, returning
 // an error if the write is rejected or no result arrives within WriteTimeout.
+// An unavailable use case is reported as ErrNotAvailable.
 func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error)) error {
 	res := make(chan model.ResultDataType, 1)
 
 	if _, err := write(func(r model.ResultDataType, _ model.MsgCounterType) { res <- r }); err != nil {
-		return err
+		return WrapError(err)
 	}
 
 	select {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	eebusapi "github.com/enbility/eebus-go/api"
-	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 )
@@ -23,24 +22,6 @@ func WrapError(err error) error {
 		return api.ErrNotAvailable
 	}
 	return err
-}
-
-// ReadValue reads a use case value from the remote entity. It reports
-// ErrNotAvailable while the scenario is unavailable at the entity or the value
-// has not been received yet.
-func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	var zero T
-
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return zero, api.ErrNotAvailable
-	}
-
-	res, err := read(entity)
-	if err != nil {
-		return zero, WrapError(err)
-	}
-
-	return res, nil
 }
 
 // WriteTimeout bounds how long an awaited eebus write waits for its result.

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -12,11 +12,46 @@ import (
 	"github.com/evcc-io/evcc/api"
 )
 
+// ErrNotConnected is returned while a remote entity required to operate the
+// device is not (yet) available.
+var ErrNotConnected = errors.New("not connected")
+
 func WrapError(err error) error {
-	if errors.Is(err, eebusapi.ErrDataNotAvailable) || errors.Is(err, eebusapi.ErrDataInvalid) {
+	if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
+		errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
+		errors.Is(err, eebusapi.ErrDataInvalid) {
 		return api.ErrNotAvailable
 	}
 	return err
+}
+
+// RequiredEntity returns the remote entity while the use case scenario is
+// available at it and ErrNotConnected otherwise. Use for entities the device
+// cannot operate without; optional data uses ReadValue.
+func RequiredEntity(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return nil, ErrNotConnected
+	}
+
+	return entity, nil
+}
+
+// ReadValue reads a use case value from the remote entity. It reports
+// ErrNotAvailable while the scenario is unavailable at the entity or the value
+// has not been received yet.
+func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+	var zero T
+
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return zero, api.ErrNotAvailable
+	}
+
+	res, err := read(entity)
+	if err != nil {
+		return zero, WrapError(err)
+	}
+
+	return res, nil
 }
 
 // UpdateEntity returns the remote entity to cache for a use case after a use case

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	eebusapi "github.com/enbility/eebus-go/api"
-	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -26,24 +25,6 @@ func WrapError(err error) error {
 		return api.ErrNotAvailable
 	}
 	return err
-}
-
-// ReadValue reads a use case value from the remote entity. It reports
-// ErrNotAvailable while the scenario is unavailable at the entity or the value
-// has not been received yet.
-func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
-	var zero T
-
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return zero, api.ErrNotAvailable
-	}
-
-	res, err := read(entity)
-	if err != nil {
-		return zero, WrapError(err)
-	}
-
-	return res, nil
 }
 
 // WriteTimeout bounds how long an awaited eebus write waits for its result.

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -15,11 +15,46 @@ import (
 	"github.com/evcc-io/evcc/util"
 )
 
+// ErrNotConnected is returned while a remote entity required to operate the
+// device is not (yet) available.
+var ErrNotConnected = errors.New("not connected")
+
 func WrapError(err error) error {
-	if errors.Is(err, eebusapi.ErrDataNotAvailable) || errors.Is(err, eebusapi.ErrDataInvalid) {
+	if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
+		errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
+		errors.Is(err, eebusapi.ErrDataInvalid) {
 		return api.ErrNotAvailable
 	}
 	return err
+}
+
+// RequiredEntity returns the remote entity while the use case scenario is
+// available at it and ErrNotConnected otherwise. Use for entities the device
+// cannot operate without; optional data uses ReadValue.
+func RequiredEntity(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return nil, ErrNotConnected
+	}
+
+	return entity, nil
+}
+
+// ReadValue reads a use case value from the remote entity. It reports
+// ErrNotAvailable while the scenario is unavailable at the entity or the value
+// has not been received yet.
+func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+	var zero T
+
+	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
+		return zero, api.ErrNotAvailable
+	}
+
+	res, err := read(entity)
+	if err != nil {
+		return zero, WrapError(err)
+	}
+
+	return res, nil
 }
 
 // UpdateEntity returns the remote entity to cache for a use case after a use case

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -31,7 +31,7 @@ func WrapError(err error) error {
 // RequiredEntity returns the remote entity while the use case scenario is
 // available at it and ErrNotConnected otherwise. Use for entities the device
 // cannot operate without; optional data uses ReadValue.
-func RequiredEntity(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+func RequiredEntity(uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface) (spineapi.EntityRemoteInterface, error) {
 	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
 		return nil, ErrNotConnected
 	}
@@ -42,7 +42,7 @@ func RequiredEntity(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemo
 // ReadValue reads a use case value from the remote entity. It reports
 // ErrNotAvailable while the scenario is unavailable at the entity or the value
 // has not been received yet.
-func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
 	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -25,17 +25,6 @@ func WrapError(err error) error {
 	return err
 }
 
-// RequiredEntity returns the remote entity while the use case scenario is
-// available at it and ErrNotConnected otherwise. Use for entities the device
-// cannot operate without; optional data uses ReadValue.
-func RequiredEntity(uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface) (spineapi.EntityRemoteInterface, error) {
-	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
-		return nil, ErrNotConnected
-	}
-
-	return entity, nil
-}
-
 // ReadValue reads a use case value from the remote entity. It reports
 // ErrNotAvailable while the scenario is unavailable at the entity or the value
 // has not been received yet.
@@ -52,27 +41,6 @@ func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, entity sp
 	}
 
 	return res, nil
-}
-
-// UpdateEntity returns the remote entity to cache for a use case after a use case
-// support update. Removing a use case from an entity emits the same event with the
-// entity still set, so the cached entity is dropped once its scenarios are gone.
-// Of the remaining candidates the least specific (shallowest) entity wins.
-func UpdateEntity(uc eebusapi.UseCaseBaseInterface, cached, entity spineapi.EntityRemoteInterface) spineapi.EntityRemoteInterface {
-	if cached != nil && len(uc.AvailableScenariosForEntity(cached)) == 0 {
-		cached = nil
-	}
-
-	// removal, or an entity that doesn't support any scenario of the use case
-	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
-		return cached
-	}
-
-	if cached == nil || len(entity.Address().Entity) < len(cached.Address().Entity) {
-		return entity
-	}
-
-	return cached
 }
 
 // WriteTimeout bounds how long an awaited eebus write waits for its result.

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -27,12 +27,15 @@ func WrapError(err error) error {
 	return err
 }
 
+// ResultCB receives the remote device's result for a control write.
+type ResultCB = func(model.ResultDataType, model.MsgCounterType)
+
 // WriteTimeout bounds how long an awaited eebus write waits for its result.
 const WriteTimeout = 10 * time.Second
 
 // Await runs a control write and waits for the remote device's result, returning
 // an error if the write is rejected or no result arrives within WriteTimeout.
-func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error)) error {
+func Await(write func(ResultCB) (*model.MsgCounterType, error)) error {
 	res := make(chan model.ResultDataType, 1)
 
 	if _, err := write(func(r model.ResultDataType, _ model.MsgCounterType) { res <- r }); err != nil {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -21,7 +21,8 @@ var ErrNotConnected = errors.New("not connected")
 func WrapError(err error) error {
 	if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
 		errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-		errors.Is(err, eebusapi.ErrDataInvalid) {
+		errors.Is(err, eebusapi.ErrDataInvalid) ||
+		errors.Is(err, eebusapi.ErrNoCompatibleEntity) {
 		return api.ErrNotAvailable
 	}
 	return err

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	eebusapi "github.com/enbility/eebus-go/api"
+	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 )
@@ -16,6 +17,27 @@ func WrapError(err error) error {
 		return api.ErrNotAvailable
 	}
 	return err
+}
+
+// UpdateEntity returns the remote entity to cache for a use case after a use case
+// support update. Removing a use case from an entity emits the same event with the
+// entity still set, so the cached entity is dropped once its scenarios are gone.
+// Of the remaining candidates the least specific (shallowest) entity wins.
+func UpdateEntity(uc eebusapi.UseCaseBaseInterface, cached, entity spineapi.EntityRemoteInterface) spineapi.EntityRemoteInterface {
+	if cached != nil && len(uc.AvailableScenariosForEntity(cached)) == 0 {
+		cached = nil
+	}
+
+	// removal, or an entity that doesn't support any scenario of the use case
+	if entity == nil || len(uc.AvailableScenariosForEntity(entity)) == 0 {
+		return cached
+	}
+
+	if cached == nil || len(entity.Address().Entity) < len(cached.Address().Entity) {
+		return entity
+	}
+
+	return cached
 }
 
 // WriteTimeout bounds how long an awaited eebus write waits for its result.

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -21,8 +21,7 @@ var ErrNotConnected = errors.New("not connected")
 func WrapError(err error) error {
 	if errors.Is(err, eebusapi.ErrDataNotAvailable) ||
 		errors.Is(err, eebusapi.ErrMetadataNotAvailable) ||
-		errors.Is(err, eebusapi.ErrDataInvalid) ||
-		errors.Is(err, eebusapi.ErrNoCompatibleEntity) {
+		errors.Is(err, eebusapi.ErrDataInvalid) {
 		return api.ErrNotAvailable
 	}
 	return err
@@ -33,12 +32,11 @@ const WriteTimeout = 10 * time.Second
 
 // Await runs a control write and waits for the remote device's result, returning
 // an error if the write is rejected or no result arrives within WriteTimeout.
-// An unavailable use case is reported as ErrNotAvailable.
 func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error)) error {
 	res := make(chan model.ResultDataType, 1)
 
 	if _, err := write(func(r model.ResultDataType, _ model.MsgCounterType) { res <- r }); err != nil {
-		return WrapError(err)
+		return err
 	}
 
 	select {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -30,11 +30,12 @@ const WriteTimeout = 10 * time.Second
 
 // Await runs a control write and waits for the remote device's result, returning
 // an error if the write is rejected or no result arrives within WriteTimeout.
+// An unavailable use case is reported as ErrNotAvailable.
 func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error)) error {
 	res := make(chan model.ResultDataType, 1)
 
 	if _, err := write(func(r model.ResultDataType, _ model.MsgCounterType) { res <- r }); err != nil {
-		return err
+		return WrapError(err)
 	}
 
 	select {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -28,7 +28,7 @@ func WrapError(err error) error {
 // RequiredEntity returns the remote entity while the use case scenario is
 // available at it and ErrNotConnected otherwise. Use for entities the device
 // cannot operate without; optional data uses ReadValue.
-func RequiredEntity(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint) (spineapi.EntityRemoteInterface, error) {
+func RequiredEntity(uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface) (spineapi.EntityRemoteInterface, error) {
 	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {
 		return nil, ErrNotConnected
 	}
@@ -39,7 +39,7 @@ func RequiredEntity(uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemo
 // ReadValue reads a use case value from the remote entity. It reports
 // ErrNotAvailable while the scenario is unavailable at the entity or the value
 // has not been received yet.
-func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, entity spineapi.EntityRemoteInterface, scenario uint, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
+func ReadValue[T any](uc eebusapi.UseCaseBaseInterface, scenario uint, entity spineapi.EntityRemoteInterface, read func(entity spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 
 	if entity == nil || !uc.IsScenarioAvailableAtEntity(entity, scenario) {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -24,12 +24,15 @@ func WrapError(err error) error {
 	return err
 }
 
+// ResultCB receives the remote device's result for a control write.
+type ResultCB = func(model.ResultDataType, model.MsgCounterType)
+
 // WriteTimeout bounds how long an awaited eebus write waits for its result.
 const WriteTimeout = 10 * time.Second
 
 // Await runs a control write and waits for the remote device's result, returning
 // an error if the write is rejected or no result arrives within WriteTimeout.
-func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error)) error {
+func Await(write func(ResultCB) (*model.MsgCounterType, error)) error {
 	res := make(chan model.ResultDataType, 1)
 
 	if _, err := write(func(r model.ResultDataType, _ model.MsgCounterType) { res <- r }); err != nil {

--- a/server/eebus/helper_test.go
+++ b/server/eebus/helper_test.go
@@ -5,62 +5,16 @@ import (
 	"testing"
 
 	eebusapi "github.com/enbility/eebus-go/api"
-	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
-	spineapi "github.com/enbility/spine-go/api"
 	"github.com/evcc-io/evcc/api"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestReadValue(t *testing.T) {
-	read := func(res float64, err error) func(spineapi.EntityRemoteInterface) (float64, error) {
-		return func(spineapi.EntityRemoteInterface) (float64, error) { return res, err }
-	}
-
-	t.Run("entity missing", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-
-		_, err := ReadValue(uc, MPCPower, nil, read(1, nil))
-		assert.ErrorIs(t, err, api.ErrNotAvailable)
-	})
-
-	t.Run("scenario not announced", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
-
-		_, err := ReadValue(uc, MPCPower, entity, read(1, nil))
-		assert.ErrorIs(t, err, api.ErrNotAvailable)
-	})
-
+func TestWrapError(t *testing.T) {
 	// data not received yet is not an error condition
 	for _, tc := range []error{eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable, eebusapi.ErrDataInvalid} {
-		t.Run(tc.Error(), func(t *testing.T) {
-			uc := ucmocks.NewMaMPCInterface(t)
-			entity := testEntity(t, 1)
-			uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
-
-			_, err := ReadValue(uc, MPCPower, entity, read(0, tc))
-			assert.ErrorIs(t, err, api.ErrNotAvailable)
-		})
+		assert.ErrorIs(t, WrapError(tc), api.ErrNotAvailable, tc.Error())
 	}
 
-	t.Run("other error passes through", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
-
-		_, err := ReadValue(uc, MPCPower, entity, read(0, errors.New("boom")))
-		assert.EqualError(t, err, "boom")
-	})
-
-	t.Run("value", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
-
-		res, err := ReadValue(uc, MPCPower, entity, read(4711, nil))
-		require.NoError(t, err)
-		assert.Equal(t, 4711.0, res)
-	})
+	assert.EqualError(t, WrapError(errors.New("boom")), "boom")
+	assert.NoError(t, WrapError(nil))
 }

--- a/server/eebus/helper_test.go
+++ b/server/eebus/helper_test.go
@@ -1,0 +1,71 @@
+package eebus
+
+import (
+	"testing"
+
+	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// testEntity returns a remote entity mock with an address of the given depth
+func testEntity(t *testing.T, depth int) spineapi.EntityRemoteInterface {
+	t.Helper()
+
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	entity.EXPECT().Address().Return(&model.EntityAddressType{
+		Entity: make([]model.AddressEntityType, depth),
+	}).Maybe()
+
+	return entity
+}
+
+func TestUpdateEntity(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		cachedDepth, entityDepth int
+		cachedScenarios          []uint
+		entityScenarios          []uint
+		want                     string // "cached", "entity" or "nil"
+	}{
+		{"first entity is cached", 0, 1, nil, []uint{1}, "entity"},
+		{"entity without scenarios is ignored", 0, 1, nil, nil, "nil"},
+		{"shallower entity wins", 2, 1, []uint{1}, []uint{1}, "entity"},
+		{"deeper entity loses", 1, 2, []uint{1}, []uint{1}, "cached"},
+		{"removal drops the cached entity", 1, 1, nil, nil, "nil"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			uc := ucmocks.NewMaMPCInterface(t)
+
+			var cached spineapi.EntityRemoteInterface
+			if tc.cachedDepth > 0 {
+				cached = testEntity(t, tc.cachedDepth)
+				uc.EXPECT().AvailableScenariosForEntity(cached).Return(tc.cachedScenarios).Maybe()
+			}
+
+			entity := testEntity(t, tc.entityDepth)
+			uc.EXPECT().AvailableScenariosForEntity(entity).Return(tc.entityScenarios).Maybe()
+
+			want := map[string]spineapi.EntityRemoteInterface{
+				"cached": cached, "entity": entity, "nil": nil,
+			}[tc.want]
+
+			assert.Equal(t, want, UpdateEntity(uc, cached, entity))
+		})
+	}
+}
+
+// removing the use case at another entity must not drop the cached one
+func TestUpdateEntityRemovalOfOtherEntity(t *testing.T) {
+	uc := ucmocks.NewMaMPCInterface(t)
+
+	cached := testEntity(t, 1)
+	uc.EXPECT().AvailableScenariosForEntity(cached).Return([]uint{1})
+
+	removed := testEntity(t, 2)
+	uc.EXPECT().AvailableScenariosForEntity(removed).Return(nil)
+
+	assert.Equal(t, cached, UpdateEntity(uc, cached, removed))
+}

--- a/server/eebus/helper_test.go
+++ b/server/eebus/helper_test.go
@@ -1,13 +1,17 @@
 package eebus
 
 import (
+	"errors"
 	"testing"
 
+	eebusapi "github.com/enbility/eebus-go/api"
 	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
 	spineapi "github.com/enbility/spine-go/api"
 	spinemocks "github.com/enbility/spine-go/mocks"
 	"github.com/enbility/spine-go/model"
+	"github.com/evcc-io/evcc/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // testEntity returns a remote entity mock with an address of the given depth
@@ -68,4 +72,85 @@ func TestUpdateEntityRemovalOfOtherEntity(t *testing.T) {
 	uc.EXPECT().AvailableScenariosForEntity(removed).Return(nil)
 
 	assert.Equal(t, cached, UpdateEntity(uc, cached, removed))
+}
+
+func TestRequiredEntity(t *testing.T) {
+	t.Run("entity missing", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+
+		_, err := RequiredEntity(uc, nil, MPCPower)
+		assert.ErrorIs(t, err, ErrNotConnected)
+	})
+
+	t.Run("scenario not announced", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
+
+		_, err := RequiredEntity(uc, entity, MPCPower)
+		assert.ErrorIs(t, err, ErrNotConnected)
+	})
+
+	t.Run("available", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+		res, err := RequiredEntity(uc, entity, MPCPower)
+		require.NoError(t, err)
+		assert.Equal(t, entity, res)
+	})
+}
+
+func TestReadValue(t *testing.T) {
+	read := func(res float64, err error) func(spineapi.EntityRemoteInterface) (float64, error) {
+		return func(spineapi.EntityRemoteInterface) (float64, error) { return res, err }
+	}
+
+	t.Run("entity missing", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+
+		_, err := ReadValue(uc, nil, MPCPower, read(1, nil))
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
+	t.Run("scenario not announced", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
+
+		_, err := ReadValue(uc, entity, MPCPower, read(1, nil))
+		assert.ErrorIs(t, err, api.ErrNotAvailable)
+	})
+
+	// data not received yet is not an error condition
+	for _, tc := range []error{eebusapi.ErrDataNotAvailable, eebusapi.ErrMetadataNotAvailable, eebusapi.ErrDataInvalid} {
+		t.Run(tc.Error(), func(t *testing.T) {
+			uc := ucmocks.NewMaMPCInterface(t)
+			entity := testEntity(t, 1)
+			uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+			_, err := ReadValue(uc, entity, MPCPower, read(0, tc))
+			assert.ErrorIs(t, err, api.ErrNotAvailable)
+		})
+	}
+
+	t.Run("other error passes through", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+		_, err := ReadValue(uc, entity, MPCPower, read(0, errors.New("boom")))
+		assert.EqualError(t, err, "boom")
+	})
+
+	t.Run("value", func(t *testing.T) {
+		uc := ucmocks.NewMaMPCInterface(t)
+		entity := testEntity(t, 1)
+		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
+
+		res, err := ReadValue(uc, entity, MPCPower, read(4711, nil))
+		require.NoError(t, err)
+		assert.Equal(t, 4711.0, res)
+	})
 }

--- a/server/eebus/helper_test.go
+++ b/server/eebus/helper_test.go
@@ -78,7 +78,7 @@ func TestRequiredEntity(t *testing.T) {
 	t.Run("entity missing", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 
-		_, err := RequiredEntity(uc, nil, MPCPower)
+		_, err := RequiredEntity(uc, MPCPower, nil)
 		assert.ErrorIs(t, err, ErrNotConnected)
 	})
 
@@ -87,7 +87,7 @@ func TestRequiredEntity(t *testing.T) {
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
 
-		_, err := RequiredEntity(uc, entity, MPCPower)
+		_, err := RequiredEntity(uc, MPCPower, entity)
 		assert.ErrorIs(t, err, ErrNotConnected)
 	})
 
@@ -96,7 +96,7 @@ func TestRequiredEntity(t *testing.T) {
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		res, err := RequiredEntity(uc, entity, MPCPower)
+		res, err := RequiredEntity(uc, MPCPower, entity)
 		require.NoError(t, err)
 		assert.Equal(t, entity, res)
 	})
@@ -110,7 +110,7 @@ func TestReadValue(t *testing.T) {
 	t.Run("entity missing", func(t *testing.T) {
 		uc := ucmocks.NewMaMPCInterface(t)
 
-		_, err := ReadValue(uc, nil, MPCPower, read(1, nil))
+		_, err := ReadValue(uc, MPCPower, nil, read(1, nil))
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
 	})
 
@@ -119,7 +119,7 @@ func TestReadValue(t *testing.T) {
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
 
-		_, err := ReadValue(uc, entity, MPCPower, read(1, nil))
+		_, err := ReadValue(uc, MPCPower, entity, read(1, nil))
 		assert.ErrorIs(t, err, api.ErrNotAvailable)
 	})
 
@@ -130,7 +130,7 @@ func TestReadValue(t *testing.T) {
 			entity := testEntity(t, 1)
 			uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-			_, err := ReadValue(uc, entity, MPCPower, read(0, tc))
+			_, err := ReadValue(uc, MPCPower, entity, read(0, tc))
 			assert.ErrorIs(t, err, api.ErrNotAvailable)
 		})
 	}
@@ -140,7 +140,7 @@ func TestReadValue(t *testing.T) {
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		_, err := ReadValue(uc, entity, MPCPower, read(0, errors.New("boom")))
+		_, err := ReadValue(uc, MPCPower, entity, read(0, errors.New("boom")))
 		assert.EqualError(t, err, "boom")
 	})
 
@@ -149,7 +149,7 @@ func TestReadValue(t *testing.T) {
 		entity := testEntity(t, 1)
 		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
 
-		res, err := ReadValue(uc, entity, MPCPower, read(4711, nil))
+		res, err := ReadValue(uc, MPCPower, entity, read(4711, nil))
 		require.NoError(t, err)
 		assert.Equal(t, 4711.0, res)
 	})

--- a/server/eebus/helper_test.go
+++ b/server/eebus/helper_test.go
@@ -7,100 +7,10 @@ import (
 	eebusapi "github.com/enbility/eebus-go/api"
 	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
 	spineapi "github.com/enbility/spine-go/api"
-	spinemocks "github.com/enbility/spine-go/mocks"
-	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// testEntity returns a remote entity mock with an address of the given depth
-func testEntity(t *testing.T, depth int) spineapi.EntityRemoteInterface {
-	t.Helper()
-
-	entity := spinemocks.NewEntityRemoteInterface(t)
-	entity.EXPECT().Address().Return(&model.EntityAddressType{
-		Entity: make([]model.AddressEntityType, depth),
-	}).Maybe()
-
-	return entity
-}
-
-func TestUpdateEntity(t *testing.T) {
-	for _, tc := range []struct {
-		name                     string
-		cachedDepth, entityDepth int
-		cachedScenarios          []uint
-		entityScenarios          []uint
-		want                     string // "cached", "entity" or "nil"
-	}{
-		{"first entity is cached", 0, 1, nil, []uint{1}, "entity"},
-		{"entity without scenarios is ignored", 0, 1, nil, nil, "nil"},
-		{"shallower entity wins", 2, 1, []uint{1}, []uint{1}, "entity"},
-		{"deeper entity loses", 1, 2, []uint{1}, []uint{1}, "cached"},
-		{"removal drops the cached entity", 1, 1, nil, nil, "nil"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			uc := ucmocks.NewMaMPCInterface(t)
-
-			var cached spineapi.EntityRemoteInterface
-			if tc.cachedDepth > 0 {
-				cached = testEntity(t, tc.cachedDepth)
-				uc.EXPECT().AvailableScenariosForEntity(cached).Return(tc.cachedScenarios).Maybe()
-			}
-
-			entity := testEntity(t, tc.entityDepth)
-			uc.EXPECT().AvailableScenariosForEntity(entity).Return(tc.entityScenarios).Maybe()
-
-			want := map[string]spineapi.EntityRemoteInterface{
-				"cached": cached, "entity": entity, "nil": nil,
-			}[tc.want]
-
-			assert.Equal(t, want, UpdateEntity(uc, cached, entity))
-		})
-	}
-}
-
-// removing the use case at another entity must not drop the cached one
-func TestUpdateEntityRemovalOfOtherEntity(t *testing.T) {
-	uc := ucmocks.NewMaMPCInterface(t)
-
-	cached := testEntity(t, 1)
-	uc.EXPECT().AvailableScenariosForEntity(cached).Return([]uint{1})
-
-	removed := testEntity(t, 2)
-	uc.EXPECT().AvailableScenariosForEntity(removed).Return(nil)
-
-	assert.Equal(t, cached, UpdateEntity(uc, cached, removed))
-}
-
-func TestRequiredEntity(t *testing.T) {
-	t.Run("entity missing", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-
-		_, err := RequiredEntity(uc, MPCPower, nil)
-		assert.ErrorIs(t, err, ErrNotConnected)
-	})
-
-	t.Run("scenario not announced", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(false)
-
-		_, err := RequiredEntity(uc, MPCPower, entity)
-		assert.ErrorIs(t, err, ErrNotConnected)
-	})
-
-	t.Run("available", func(t *testing.T) {
-		uc := ucmocks.NewMaMPCInterface(t)
-		entity := testEntity(t, 1)
-		uc.EXPECT().IsScenarioAvailableAtEntity(entity, MPCPower).Return(true)
-
-		res, err := RequiredEntity(uc, MPCPower, entity)
-		require.NoError(t, err)
-		assert.Equal(t, entity, res)
-	})
-}
 
 func TestReadValue(t *testing.T) {
 	read := func(res float64, err error) func(spineapi.EntityRemoteInterface) (float64, error) {

--- a/server/eebus/scenarios.go
+++ b/server/eebus/scenarios.go
@@ -9,53 +9,6 @@ package eebus
 // Each block mirrors the scenarios registered in the corresponding eebus-go usecase, which
 // in turn matches the EEBus UC TS document.
 
-// MGCP — Monitoring of Grid Connection Point (UC TS v1.0.0)
-const (
-	MGCPPowerFactor     uint = 1 // S1 power factor (cos phi)
-	MGCPPower           uint = 2 // S2 active power per phase + total
-	MGCPEnergyFeedIn    uint = 3 // S3 total feed-in energy
-	MGCPEnergyConsumed  uint = 4 // S4 total consumed energy
-	MGCPCurrentPerPhase uint = 5 // S5 phase-specific currents
-	MGCPVoltagePerPhase uint = 6 // S6 phase-specific voltages
-	MGCPFrequency       uint = 7 // S7 frequency
-)
-
-// MPC — Monitoring of Power Consumption (UC TS v1.0.0)
-const (
-	MPCPower           uint = 1 // S1 active power per phase + total
-	MPCEnergyConsumed  uint = 2 // S2 total consumed energy
-	MPCCurrentPerPhase uint = 3 // S3 phase-specific currents
-	MPCVoltagePerPhase uint = 4 // S4 phase-specific voltages
-	MPCFrequency       uint = 5 // S5 frequency
-)
-
-// OHPCF — Optimization of Self-Consumption by Heat Pump Compressor Flexibility (UC TS v1.0.0)
-const (
-	OHPCFMonitor uint = 1 // S1 monitor the compressor's power consumption flexibility
-	OHPCFControl uint = 2 // S2 control the compressor's power consumption flexibility
-)
-
-// MDT — Monitoring of Domestic Hot Water Temperature (UC TS v1.0.0)
-const (
-	MDTTemperature uint = 1 // S1 DHW temperature
-)
-
-// LPC — Limitation of Power Consumption (UC TS v1.0.0). Same scenario layout for CS and EG roles.
-const (
-	LPCLimit                uint = 1 // S1 LoadControl: consumption limit
-	LPCFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
-	LPCHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
-	LPCElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
-)
-
-// LPP — Limitation of Power Production (UC TS v1.0.0). Same scenario layout for CS and EG roles.
-const (
-	LPPLimit                uint = 1 // S1 LoadControl: production limit
-	LPPFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
-	LPPHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
-	LPPElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
-)
-
 // OPEV — Overload Protection by EV Charging Current Curtailment (UC TS v1.0.1)
 const (
 	OPEVObligationLimit uint = 1 // S1 LoadControl + ElectricalConnection

--- a/server/eebus/scenarios.go
+++ b/server/eebus/scenarios.go
@@ -1,7 +1,54 @@
 package eebus
 
 // EEBUS use case scenario numbers per the respective Use Case Technical Specifications.
-// Each block mirrors the scenarios registered in the corresponding eebus-go usecase.
+//
+// Spec scenario numbers diverge between use cases (e.g. MPC scenario 1 = active power,
+// MGCP scenario 1 = power factor; MPC scenario 2 = energy, MGCP scenario 2 = active power).
+// Passing the wrong number to IsScenarioAvailableAtEntity gates reads on the wrong feature.
+//
+// Each block mirrors the scenarios registered in the corresponding eebus-go usecase, which
+// in turn matches the EEBus UC TS document.
+
+// MGCP — Monitoring of Grid Connection Point (UC TS v1.0.0)
+const (
+	MGCPPowerFactor     uint = 1 // S1 power factor (cos phi)
+	MGCPPower           uint = 2 // S2 active power per phase + total
+	MGCPEnergyFeedIn    uint = 3 // S3 total feed-in energy
+	MGCPEnergyConsumed  uint = 4 // S4 total consumed energy
+	MGCPCurrentPerPhase uint = 5 // S5 phase-specific currents
+	MGCPVoltagePerPhase uint = 6 // S6 phase-specific voltages
+	MGCPFrequency       uint = 7 // S7 frequency
+)
+
+// MPC — Monitoring of Power Consumption (UC TS v1.0.0)
+const (
+	MPCPower           uint = 1 // S1 active power per phase + total
+	MPCEnergyConsumed  uint = 2 // S2 total consumed energy
+	MPCCurrentPerPhase uint = 3 // S3 phase-specific currents
+	MPCVoltagePerPhase uint = 4 // S4 phase-specific voltages
+	MPCFrequency       uint = 5 // S5 frequency
+)
+
+// MDT — Monitoring of Domestic Hot Water Temperature (UC TS v1.0.0)
+const (
+	MDTTemperature uint = 1 // S1 DHW temperature
+)
+
+// LPC — Limitation of Power Consumption (UC TS v1.0.0). Same scenario layout for CS and EG roles.
+const (
+	LPCLimit                uint = 1 // S1 LoadControl: consumption limit
+	LPCFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
+	LPCHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
+	LPCElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
+)
+
+// LPP — Limitation of Power Production (UC TS v1.0.0). Same scenario layout for CS and EG roles.
+const (
+	LPPLimit                uint = 1 // S1 LoadControl: production limit
+	LPPFailsafe             uint = 2 // S2 DeviceConfiguration: failsafe values
+	LPPHeartbeat            uint = 3 // S3 DeviceDiagnosis: heartbeat
+	LPPElectricalConnection uint = 4 // S4 ElectricalConnection (optional)
+)
 
 // OPEV — Overload Protection by EV Charging Current Curtailment (UC TS v1.0.1)
 const (

--- a/server/eebus/scenarios.go
+++ b/server/eebus/scenarios.go
@@ -1,13 +1,7 @@
 package eebus
 
 // EEBUS use case scenario numbers per the respective Use Case Technical Specifications.
-//
-// Spec scenario numbers diverge between use cases (e.g. MPC scenario 1 = active power,
-// MGCP scenario 1 = power factor; MPC scenario 2 = energy, MGCP scenario 2 = active power).
-// Passing the wrong number to IsScenarioAvailableAtEntity gates reads on the wrong feature.
-//
-// Each block mirrors the scenarios registered in the corresponding eebus-go usecase, which
-// in turn matches the EEBus UC TS document.
+// Each block mirrors the scenarios registered in the corresponding eebus-go usecase.
 
 // OPEV — Overload Protection by EV Charging Current Curtailment (UC TS v1.0.1)
 const (

--- a/server/eebus/scenarios.go
+++ b/server/eebus/scenarios.go
@@ -29,6 +29,12 @@ const (
 	MPCFrequency       uint = 5 // S5 frequency
 )
 
+// OHPCF — Optimization of Self-Consumption by Heat Pump Compressor Flexibility (UC TS v1.0.0)
+const (
+	OHPCFMonitor uint = 1 // S1 monitor the compressor's power consumption flexibility
+	OHPCFControl uint = 2 // S2 control the compressor's power consumption flexibility
+)
+
 // MDT — Monitoring of Domestic Hot Water Temperature (UC TS v1.0.0)
 const (
 	MDTTemperature uint = 1 // S1 DHW temperature


### PR DESCRIPTION
Rebased onto master now that #30601 has landed: the remote entity is typed by its use case and read through a generic method, which needs Go 1.27.

## The bug

`UseCaseSupportUpdate` is emitted both when a use case becomes available at a remote entity and when it disappears from one. Only whole-*device* removal passes a nil entity (`usecases/usecase/usecase.go:237`); removing a single entity re-emits the event with the entity still set (`usecase.go:248`), and the very first update for an entity fires even when its scenario list is empty (`usecase.go:205`, `events.go:129`).

Both consumers treated every non-nil entity as "available" and recorded it, so a removed entity stayed recorded until the next SHIP disconnect, and an entity supporting no scenario at all could be recorded in the first place:

- `meter/eebus_events.go` — MA (MPC/MGCP), EG LPC, EG LPP
- `charger/eebus-ohpcf.go` — OHPCF compressor, MA MPC, MA MDT, EG LPC

The `hems/eebus` controllable system records no entity and `charger/eebus-evse.go` tracks the EV via its own `EvConnected`/`EvDisconnected` events, so neither is affected.

## eebus.Entity

`Entity[U]` owns a recorded remote entity together with its use case and its lock:

- `Update` re-validates against the use case on every support update and drops the entity once its scenarios are gone, keeping the existing preference for the least specific (shallowest) entity. Only support updates record an entity — data updates cannot signal removal, so they no longer assign one. It reports whether the use case became available at a *new* entity, which is what drives re-stating the limit to a newly available CS (LPC-913/LPP-913).
- `Required` returns the entity, or `ErrNotConnected` for use cases the device cannot operate without (was charger-private `errNotConnected`).
- `Read`, `Write` and `WriteArg` resolve the entity, validate the scenarios they are given, run the use case method and map "not received yet" to `ErrNotAvailable`.

Because `Entity` is generic over the use case interface, a reader is a method expression and the call site names neither the use case nor the entity:

```go
limit, err := c.lpc.Read(ucapi.EgLPCInterface.ConsumptionLimit, eebus.LPCLimit)
return c.mpc.Read(ucapi.MaMPCInterface.Power, eebus.MPCPower)
```

Pairing a use case with the wrong entity is a compile error rather than a silent misread.

## Scenario checks move into the entity

Reads and writes used to call `IsScenarioAvailableAtEntity` at each call site, which meant every one of them had to name the right scenario number — twice a wrong one slipped in during review. The check now lives in one place: `Read`, `Write` and `WriteArg` take the scenarios as variadic arguments and validate them before the use case is touched. The scenario constants in `scenarios.go` and the meter's MPC/MGCP scenario table are unchanged.

`WrapError` maps only the "data isn't there yet" sentinels (`ErrDataNotAvailable`, `ErrMetadataNotAvailable`, `ErrDataInvalid`). An entity is recorded only after its use case is announced, so a write reporting no compatible entity is a fault and now surfaces as one instead of being masked as `ErrNotAvailable`.

## Side effects

- the meter's mutex no longer serialises whole use case reads. Entity access is guarded per entity, so concurrent `CurrentPower`/`Currents` calls no longer wait on each other and no lock is held across a use case read. What is left of the mutex only guards the last written dim/curtail state.
- OHPCF entity fields are named after their use case (`ohpcf`, `mpc`, `mdt`, `lpc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
