### PR TITLE
Meter (FoxESS H3-Pro/Smart, H3): implement battery mode remote control

### DIFF
--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -115,5 +115,132 @@ render: |
         address: 46611 # Minimum SoC OnGrid
         type: writesingle
         decode: uint16
+  batterymode:
+    source: watchdog
+    timeout: 30s
+    reset: 1 # reset to normal mode
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal - disable remote control
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 0 # Disabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46001 # Remote Control
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Self Use
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ .minsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46609 # Minimum SoC
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ .maxsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46610 # Maximum SoC
+                type: writesingle
+                encoding: uint16
+      - case: 2 # hold - stop battery discharge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 2 # Feed-in First, fallback if the remote control watchdog expires
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 60 # Remote timeout 60 seconds
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46002 # Remote Timeout Set
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Enabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46001 # Remote Control
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
+                type: writemultiple
+                encoding: int32
+      - case: 3 # charge - force battery charge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 3 # Back-up, fallback if the remote control watchdog expires
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 60 # Remote timeout 60 seconds
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46002 # Remote Timeout Set
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Enabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46001 # Remote Control
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ mul .maxchargepower -1 }} # negative power means charging
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
+                type: writemultiple
+                encoding: int32
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fox-ess-h3.yaml
+++ b/templates/definition/meter/fox-ess-h3.yaml
@@ -97,5 +97,132 @@ render: |
         address: 41009 # limit soc
         type: writesingle
         decode: uint16
+  batterymode:
+    source: watchdog
+    timeout: 30s
+    reset: 1 # reset to normal mode
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal - disable remote control
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 0 # Disabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 44000 # Remote Enable
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # Self Use
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 41000 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ .minsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 41009 # Minimum SoC
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ .maxsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 41010 # Maximum SoC
+                type: writesingle
+                encoding: uint16
+      - case: 2 # hold - stop battery discharge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 1 # Feed-in First, fallback if the remote control watchdog expires
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 41000 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 60 # Remote timeout 60 seconds
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 44001 # Remote Timeout Set
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Enabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 44000 # Remote Enable
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 44002 # Remote Active Power, int32 across 44002 (high word) and 44003 (low word)
+                type: writemultiple
+                encoding: int32
+      - case: 3 # charge - force battery charge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 2 # Back-up, fallback if the remote control watchdog expires
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 41000 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 60 # Remote timeout 60 seconds
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 44001 # Remote Timeout Set
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Enabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 44000 # Remote Enable
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ mul .maxchargepower -1 }} # negative power means charging
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 44002 # Remote Active Power, int32 across 44002 (high word) and 44003 (low word)
+                type: writemultiple
+                encoding: int32
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
Both templates only exposed a limitsoc setter (a Minimum SoC floor
register), which raises the discharge floor to the current SoC. This
does not reliably stop discharge, so BatteryHold during fast/planned
charging was not effective, despite both templates advertising the
battery-control capability.

Add a batterymode block using each inverter's remote control registers,
cross-checked against the register spec PDF for the legacy H1/H3
generation and, for the H3-Pro/Smart (not covered by that PDF), against
the community foxess_modbus Home Assistant integration, which
separately documents and maintains the newer register map:

H3-Pro/Smart (46xxx/49xxx registers):
- 46001 remote control enable/disable (1/0)
- 46002 remote control watchdog timeout
- 46003/46004 active power setpoint, int32 across two registers
  (standard big-endian word order), negative value requests
  charge/import, positive requests discharge/export
- 49203 work mode, set as a fallback in case evcc's own watchdog fails
  to run (e.g. process crash) before the inverter's timeout fires
- 46609/46610 restore configured min/max SoC on return to normal mode

H3 (legacy, 41xxx/44xxx registers, same protocol, different addresses
and work mode values):
- 44000 remote control enable/disable
- 44001 remote control watchdog timeout
- 44002/44003 active power setpoint, int32, same sign convention
- 41000 work mode fallback
- 41009/41010 restore configured min/max SoC

Both are wrapped in a 30s watchdog that falls back to normal mode if
evcc stops refreshing the setpoint. The existing limitsoc setters are
kept as-is, they control a separate, persistent on-grid discharge
floor rather than the active hold/charge session.

H1 was not touched. It doesn't advertise battery-control today, and
its remote control registers differ by connection type (rs485 vs
tcpip) in ways that need separate verification before implementing.