### PR TITLE
Huawei SUN2000: read all ESS registers at once

### DIFF
--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -292,6 +292,9 @@ render: |
       address: 37765 # overall power
       type: holding
       decode: int32nan
+    block: # 37760-37783
+      register: 37760
+      count: 24
     scale: -1
   energy:
     source: modbus
@@ -300,6 +303,9 @@ render: |
       address: 37782 # overall energy discharged
       type: holding
       decode: uint32nan
+    block: # 37760-37783
+      register: 37760
+      count: 24
     scale: 0.01
   returnenergy:
     source: modbus
@@ -308,6 +314,9 @@ render: |
       address: 37780 # overall energy charged
       type: holding
       decode: uint32nan
+    block: # 37760-37783
+      register: 37760
+      count: 24
     scale: 0.01
   soc:
     source: modbus
@@ -316,6 +325,9 @@ render: |
       address: 37760 # overall SoC
       type: holding
       decode: uint16nan
+    block: # 37760-37783
+      register: 37760
+      count: 24
     scale: 0.1
   dim:
     source: ifelse


### PR DESCRIPTION
[SUN2000/SDongle Modbus Primer](https://docs.google.com/document/d/1pCopCJ3HsOCmYLwUJZjzcpnZSOeC5v6yDGFRf6hBEi8/edit)

After moving to the ESS registers (instead of per-ESU registers, see [#32034](https://github.com/evcc-io/evcc/pull/32034)), all battery registers can now be read via a single block in 1 request instead of 4 (1 ESU)/8 (2 ESU), reducing the crucial TCP overhead for slow devices such as the Huawei SDongle which especially helps in multi-client environments.

Registers 37760-37783 are a cached block which do not require additional RS485 roundtrips internally:
```
modbus 192.168.1.12:502 -s 1 -v h@37760/24H
→ < f2 f5 00 00 00 06 01 03 93 80 00 18 >
← < f2 f5 00 00 00 33 01 03 30 03 d4 00 00 00 02 1e 85 00 40 00 00 13 77 00 00 27 10 00 00 27 10 00 00 27 10 00 00 27 10 00 00 00 00 00 00 00 00 00 00 00 07 17 e0 00 06 e2 76 > 57 bytes
← [980, 0, 2, 7813, 64, 0, 4983, 0, 10000, 0, 10000, 0, 10000, 0, 10000, 0, 0, 0, 0, 0, 7, 6112, 6, 57974]
37760: (980, 0, 2, 7813, 64, 0, 4983, 0, 10000, 0, 10000, 0, 10000, 0, 10000, 0, 0, 0, 0, 0, 7, 6112, 6, 57974)
Duration: 8 ms
```

We are now down to 4 requests (down from 18) to read the whole Huawei hybrid solar system (meter+inverter+battery).