### PR TITLE
Huawei SUN2000: optimized timing

### DIFF
--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -31,7 +31,7 @@ params:
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["rs485", "tcpip"]
-    timeout: 10s
+    timeout: 7s
     delay: 50ms
   - name: timeout
     deprecated: true

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -31,7 +31,7 @@ params:
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["rs485", "tcpip"]
-    timeout: 15s
+    timeout: 10s
     delay: 50ms
   - name: timeout
     deprecated: true

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -88,7 +88,6 @@ render: |
       register: 37101
       count: 37
     scale: -1
-    delay: {{ .delay }}
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -100,7 +99,6 @@ render: |
       register: 37101
       count: 37
     scale: 0.01
-    delay: {{ .delay }}
   returnenergy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -112,7 +110,6 @@ render: |
       register: 37101
       count: 37
     scale: 0.01
-    delay: {{ .delay }}
   currents:
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -124,7 +121,6 @@ render: |
       register: 37101
       count: 37
     scale: -0.01
-    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -135,7 +131,6 @@ render: |
       register: 37101
       count: 37
     scale: -0.01
-    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -146,7 +141,6 @@ render: |
       register: 37101
       count: 37
     scale: -0.01
-    delay: {{ .delay }}
   voltages:
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -158,7 +152,6 @@ render: |
       register: 37101
       count: 37
     scale: 0.1
-    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -169,7 +162,6 @@ render: |
       register: 37101
       count: 37
     scale: 0.1
-    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -180,7 +172,6 @@ render: |
       register: 37101
       count: 37
     scale: 0.1
-    delay: {{ .delay }}
   powers:
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -192,7 +183,6 @@ render: |
       register: 37101
       count: 37
     scale: -1
-    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -203,7 +193,6 @@ render: |
       register: 37101
       count: 37
     scale: -1
-    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -214,7 +203,6 @@ render: |
       register: 37101
       count: 37
     scale: -1
-    delay: {{ .delay }}
   {{- end }}
   {{- if eq .usage "pv" }}
   power:
@@ -225,7 +213,6 @@ render: |
       address: 32064 # Input power DC
       type: holding
       decode: int32nan
-    delay: {{ .delay }}
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -234,7 +221,6 @@ render: |
       type: holding
       decode: uint32nan
     scale: 0.01
-    delay: {{ .delay }}
   maxacpower: {{ .maxacpower }}
   curtail:
     source: sequence
@@ -247,7 +233,6 @@ render: |
         type: writesingle
         encoding: uint16
       scale: 10
-      delay: {{ .delay }}
     # active power control mode: 7 = percentage limit while curtailed, 0 = unlimited at 100%
     - source: switch
       switch:
@@ -262,7 +247,6 @@ render: |
                 address: 47415 # Active power control mode
                 type: writesingle
                 encoding: uint16
-              delay: {{ .delay }}
       default:
         source: const
         value: 7 # Power-limited grid connection (%)
@@ -273,7 +257,6 @@ render: |
             address: 47415 # Active power control mode
             type: writesingle
             encoding: uint16
-          delay: {{ .delay }}
   curtailed:
     source: go
     in:
@@ -286,7 +269,6 @@ render: |
           address: 47415 # Active power control mode (0=no curtailment)
           type: holding
           decode: uint16
-        delay: {{ .delay }}
     - name: percent
       type: int
       config:
@@ -297,7 +279,6 @@ render: |
           type: holding
           decode: uint16
         scale: 0.1
-        delay: {{ .delay }}
     # the percentage register is only meaningful while a limit mode is active
     script: |
       limit := percent
@@ -316,7 +297,6 @@ render: |
       type: holding
       decode: int32nan
     scale: -1
-    delay: {{ .delay }}
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -325,7 +305,6 @@ render: |
       type: holding
       decode: uint32nan
     scale: 0.01
-    delay: {{ .delay }}
   returnenergy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -334,7 +313,6 @@ render: |
       type: holding
       decode: uint32nan
     scale: 0.01
-    delay: {{ .delay }}
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -343,7 +321,6 @@ render: |
       type: holding
       decode: uint16nan
     scale: 0.1
-    delay: {{ .delay }}
   dim:
     source: ifelse
     if:
@@ -359,7 +336,6 @@ render: |
             address: 47087 # Charge from grid
             type: writesingle
             encoding: uint16
-          delay: {{ .delay }}
     else:
       source: convert
       convert: bool2int
@@ -374,7 +350,6 @@ render: |
             address: 47087 # Charge from grid
             type: writesingle
             encoding: uint16
-          delay: {{ .delay }}
         {{- else }}
         source: sleep
         duration: 0s
@@ -391,7 +366,6 @@ render: |
           address: 47087 # Charge from grid (0=disabled → dimmed, 1=enabled → not dimmed)
           type: holding
           decode: uint16
-        delay: {{ .delay }}
     script: v == 0
   batterymode:
     source: sequence
@@ -418,7 +392,6 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
-                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -429,7 +402,6 @@ render: |
                         address: 47075 # Max. Charge Power
                         type: writemultiple
                         encoding: uint32
-                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -451,7 +423,6 @@ render: |
                           address: 37048 # [ESS] Maximum discharge power (RO)
                           type: holding
                           decode: uint32
-                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -462,7 +433,6 @@ render: |
                         address: 47077 # Max. Discharge Power
                         type: writemultiple
                         encoding: uint32
-                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxdischargepower }}
                   out := rated
@@ -488,7 +458,6 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
-                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -499,7 +468,6 @@ render: |
                         address: 47075 # Max. Charge Power
                         type: writemultiple
                         encoding: uint32
-                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -514,7 +482,6 @@ render: |
                     address: 47077 # Max. Discharge Power
                     type: writemultiple
                     encoding: uint32
-                  delay: {{ .delay }}
           - case: 3 # charge
             set:
               source: sequence
@@ -535,7 +502,6 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
-                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -546,7 +512,6 @@ render: |
                         address: 47075 # Max. Charge Power
                         type: writemultiple
                         encoding: uint32
-                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -568,7 +533,6 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
-                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -579,7 +543,6 @@ render: |
                         address: 47247 # Forcible charge power
                         type: writemultiple
                         encoding: uint32
-                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -594,7 +557,6 @@ render: |
                     address: 47083 # Forced charging and discharging period
                     type: writesingle
                     encoding: uint16
-                  delay: {{ .delay }}
               - source: const
                 value: 0 # duration
                 set:
@@ -604,7 +566,6 @@ render: |
                     address: 47246 # Forcible charge/discharge setting mode
                     type: writesingle
                     encoding: uint16
-                  delay: {{ .delay }}
           - case: 4 # holdcharge
             set:
               source: sequence
@@ -618,7 +579,6 @@ render: |
                     address: 47075 # Max. Charge Power
                     type: writemultiple
                     encoding: uint32
-                  delay: {{ .delay }}
               # register 47077 is range-checked: a maxdischargepower above the
               # inverter rated max (37048) is rejected, so clamp before writing
               - source: go
@@ -635,7 +595,6 @@ render: |
                           address: 37048 # [ESS] Maximum discharge power (RO)
                           type: holding
                           decode: uint32
-                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -646,7 +605,6 @@ render: |
                         address: 47077 # Max. Discharge Power
                         type: writemultiple
                         encoding: uint32
-                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxdischargepower }}
                   out := rated
@@ -670,7 +628,6 @@ render: |
                     address: 47100 # Forcible charge/discharge
                     type: writesingle
                     encoding: uint16
-                  delay: {{ .delay }}
           default:
             source: const
             value: 0 # stop
@@ -681,6 +638,5 @@ render: |
                 address: 47100 # Forcible charge/discharge
                 type: writesingle
                 encoding: uint16
-              delay: {{ .delay }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -32,7 +32,6 @@ params:
   - name: modbus
     choice: ["rs485", "tcpip"]
     timeout: 5s
-    delay: 50ms
   - name: timeout
     deprecated: true
   - name: maxacpower

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -32,7 +32,10 @@ params:
   - name: modbus
     choice: ["rs485", "tcpip"]
     timeout: 10s
-    delay: 50ms
+  - name: delay
+    type: duration
+    default: 50ms
+    advanced: true
   - name: timeout
     deprecated: true
   - name: maxacpower
@@ -85,6 +88,7 @@ render: |
       register: 37101
       count: 37
     scale: -1
+    delay: {{ .delay }}
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -96,6 +100,7 @@ render: |
       register: 37101
       count: 37
     scale: 0.01
+    delay: {{ .delay }}
   returnenergy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -107,6 +112,7 @@ render: |
       register: 37101
       count: 37
     scale: 0.01
+    delay: {{ .delay }}
   currents:
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -118,6 +124,7 @@ render: |
       register: 37101
       count: 37
     scale: -0.01
+    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -128,6 +135,7 @@ render: |
       register: 37101
       count: 37
     scale: -0.01
+    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -138,6 +146,7 @@ render: |
       register: 37101
       count: 37
     scale: -0.01
+    delay: {{ .delay }}
   voltages:
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -149,6 +158,7 @@ render: |
       register: 37101
       count: 37
     scale: 0.1
+    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -159,6 +169,7 @@ render: |
       register: 37101
       count: 37
     scale: 0.1
+    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -169,6 +180,7 @@ render: |
       register: 37101
       count: 37
     scale: 0.1
+    delay: {{ .delay }}
   powers:
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -180,6 +192,7 @@ render: |
       register: 37101
       count: 37
     scale: -1
+    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -190,6 +203,7 @@ render: |
       register: 37101
       count: 37
     scale: -1
+    delay: {{ .delay }}
   - source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -200,6 +214,7 @@ render: |
       register: 37101
       count: 37
     scale: -1
+    delay: {{ .delay }}
   {{- end }}
   {{- if eq .usage "pv" }}
   power:
@@ -210,6 +225,7 @@ render: |
       address: 32064 # Input power DC
       type: holding
       decode: int32nan
+    delay: {{ .delay }}
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -218,6 +234,7 @@ render: |
       type: holding
       decode: uint32nan
     scale: 0.01
+    delay: {{ .delay }}
   maxacpower: {{ .maxacpower }}
   curtail:
     source: sequence
@@ -230,6 +247,7 @@ render: |
         type: writesingle
         encoding: uint16
       scale: 10
+      delay: {{ .delay }}
     # active power control mode: 7 = percentage limit while curtailed, 0 = unlimited at 100%
     - source: switch
       switch:
@@ -244,6 +262,7 @@ render: |
                 address: 47415 # Active power control mode
                 type: writesingle
                 encoding: uint16
+              delay: {{ .delay }}
       default:
         source: const
         value: 7 # Power-limited grid connection (%)
@@ -254,6 +273,7 @@ render: |
             address: 47415 # Active power control mode
             type: writesingle
             encoding: uint16
+          delay: {{ .delay }}
   curtailed:
     source: go
     in:
@@ -266,6 +286,7 @@ render: |
           address: 47415 # Active power control mode (0=no curtailment)
           type: holding
           decode: uint16
+        delay: {{ .delay }}
     - name: percent
       type: int
       config:
@@ -276,6 +297,7 @@ render: |
           type: holding
           decode: uint16
         scale: 0.1
+        delay: {{ .delay }}
     # the percentage register is only meaningful while a limit mode is active
     script: |
       limit := percent
@@ -294,6 +316,7 @@ render: |
       type: holding
       decode: int32nan
     scale: -1
+    delay: {{ .delay }}
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -302,6 +325,7 @@ render: |
       type: holding
       decode: uint32nan
     scale: 0.01
+    delay: {{ .delay }}
   returnenergy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -310,6 +334,7 @@ render: |
       type: holding
       decode: uint32nan
     scale: 0.01
+    delay: {{ .delay }}
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -318,6 +343,7 @@ render: |
       type: holding
       decode: uint16nan
     scale: 0.1
+    delay: {{ .delay }}
   dim:
     source: ifelse
     if:
@@ -333,6 +359,7 @@ render: |
             address: 47087 # Charge from grid
             type: writesingle
             encoding: uint16
+          delay: {{ .delay }}
     else:
       source: convert
       convert: bool2int
@@ -347,6 +374,7 @@ render: |
             address: 47087 # Charge from grid
             type: writesingle
             encoding: uint16
+          delay: {{ .delay }}
         {{- else }}
         source: sleep
         duration: 0s
@@ -363,6 +391,7 @@ render: |
           address: 47087 # Charge from grid (0=disabled → dimmed, 1=enabled → not dimmed)
           type: holding
           decode: uint16
+        delay: {{ .delay }}
     script: v == 0
   batterymode:
     source: sequence
@@ -389,6 +418,7 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
+                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -399,6 +429,7 @@ render: |
                         address: 47075 # Max. Charge Power
                         type: writemultiple
                         encoding: uint32
+                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -420,6 +451,7 @@ render: |
                           address: 37048 # [ESS] Maximum discharge power (RO)
                           type: holding
                           decode: uint32
+                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -430,6 +462,7 @@ render: |
                         address: 47077 # Max. Discharge Power
                         type: writemultiple
                         encoding: uint32
+                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxdischargepower }}
                   out := rated
@@ -455,6 +488,7 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
+                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -465,6 +499,7 @@ render: |
                         address: 47075 # Max. Charge Power
                         type: writemultiple
                         encoding: uint32
+                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -479,6 +514,7 @@ render: |
                     address: 47077 # Max. Discharge Power
                     type: writemultiple
                     encoding: uint32
+                  delay: {{ .delay }}
           - case: 3 # charge
             set:
               source: sequence
@@ -499,6 +535,7 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
+                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -509,6 +546,7 @@ render: |
                         address: 47075 # Max. Charge Power
                         type: writemultiple
                         encoding: uint32
+                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -530,6 +568,7 @@ render: |
                           address: 37046 # [ESS] Maximum charge power (RO)
                           type: holding
                           decode: uint32
+                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -540,6 +579,7 @@ render: |
                         address: 47247 # Forcible charge power
                         type: writemultiple
                         encoding: uint32
+                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxchargepower }}
                   out := rated
@@ -554,6 +594,7 @@ render: |
                     address: 47083 # Forced charging and discharging period
                     type: writesingle
                     encoding: uint16
+                  delay: {{ .delay }}
               - source: const
                 value: 0 # duration
                 set:
@@ -563,6 +604,7 @@ render: |
                     address: 47246 # Forcible charge/discharge setting mode
                     type: writesingle
                     encoding: uint16
+                  delay: {{ .delay }}
           - case: 4 # holdcharge
             set:
               source: sequence
@@ -576,6 +618,7 @@ render: |
                     address: 47075 # Max. Charge Power
                     type: writemultiple
                     encoding: uint32
+                  delay: {{ .delay }}
               # register 47077 is range-checked: a maxdischargepower above the
               # inverter rated max (37048) is rejected, so clamp before writing
               - source: go
@@ -592,6 +635,7 @@ render: |
                           address: 37048 # [ESS] Maximum discharge power (RO)
                           type: holding
                           decode: uint32
+                        delay: {{ .delay }}
                 out:
                   - name: power
                     type: int
@@ -602,6 +646,7 @@ render: |
                         address: 47077 # Max. Discharge Power
                         type: writemultiple
                         encoding: uint32
+                      delay: {{ .delay }}
                 script: |
                   limit := {{ .maxdischargepower }}
                   out := rated
@@ -625,6 +670,7 @@ render: |
                     address: 47100 # Forcible charge/discharge
                     type: writesingle
                     encoding: uint16
+                  delay: {{ .delay }}
           default:
             source: const
             value: 0 # stop
@@ -635,5 +681,6 @@ render: |
                 address: 47100 # Forcible charge/discharge
                 type: writesingle
                 encoding: uint16
+              delay: {{ .delay }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -32,10 +32,7 @@ params:
   - name: modbus
     choice: ["rs485", "tcpip"]
     timeout: 10s
-  - name: delay
-    type: duration
-    default: 50ms
-    advanced: true
+    delay: 50ms
   - name: timeout
     deprecated: true
   - name: maxacpower

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -32,6 +32,7 @@ params:
   - name: modbus
     choice: ["rs485", "tcpip"]
     timeout: 15s
+    delay: 50ms
   - name: timeout
     deprecated: true
   - name: maxacpower
@@ -545,7 +546,7 @@ render: |
                   if limit < rated { out = limit }
                   out
               - source: const
-                value: 1 # Minute
+                value: 2 # Minutes (watchdog*2 for redundancy reasons)
                 set:
                   source: modbus
                   {{- include "modbus" . | indent 16 }}
@@ -608,7 +609,7 @@ render: |
                   out
       # single watchdog wraps the ENTIRE 47100 lifecycle, not just case 3
       - source: watchdog
-        timeout: 30s
+        timeout: 60s # re-write every timeout/2
         reset: [1, 2, 4]
         set:
           source: switch

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -31,7 +31,7 @@ params:
     choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["rs485", "tcpip"]
-    timeout: 7s
+    timeout: 5s
     delay: 50ms
   - name: timeout
     deprecated: true


### PR DESCRIPTION
[SUN2000/SDongle Modbus Primer](https://docs.google.com/document/d/1pCopCJ3HsOCmYLwUJZjzcpnZSOeC5v6yDGFRf6hBEi8/edit)

# Description

The watchdog timeout has been increased from `30s` to `60s`. Since registers are effectively being written every `timeout/2`, the `charge` period is set to 2 minutes so that we can afford to lose one cycle without `charge` being interrupted.

~~A default cooldown `delay` of `50ms` has been added (as proposed by [huawei-solar-lib](https://github.com/wlcrs/huawei-solar-lib/blob/c1a3cbe070d0701562b08b49daf4a7125c1d0677/src/huawei_solar/modbus_client.py#L43)). Beware that when using the `modbusproxy`, requests via external clients do not inherit this delay. I recommend using [mbproxy](https://github.com/tma/mbproxy) in a multi-client environment and setting `MODBUS_REQUEST_DELAY` to `50ms`, effectively equalizing all traffic to the SUN2000. The `delay` parameter is configurable so that a double delay (evcc+proxy) can be prevented.~~

The default Modbus timeout has been reduced to `5s` as per Huawei's own Best Practices. The retry budget in evcc is hardcoded to `10s`: 
https://github.com/evcc-io/evcc/blob/9300e158672e315e0ae38bf44a8b93070832849b/util/modbus/functions.go#L17

A Modbus timeout >= `10s` already consumes the whole budget, resulting in no retry. Huawei these days typically either returns early with a slave device error or never (request swallowed).

# Open Points
- [x] Is #3914 still a thing? Ping @RTTTC
- [x] Clarify Modbus TCP Best Practices with Huawei