### PR TITLE
EEBus OHPCF: don't report success when the compressor offers nothing to schedule

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -310,6 +310,7 @@ const (
 	ohpcfSchedule
 	ohpcfResume
 	ohpcfStop
+	ohpcfUnavailable
 )
 
 // ohpcfControlAction returns the command needed to reach the desired on/off
@@ -321,8 +322,12 @@ func ohpcfControlAction(state ucapi.CompressorPowerConsumptionStateType, enable 
 			return ohpcfSchedule
 		case ucapi.CompressorPowerConsumptionStatePaused:
 			return ohpcfResume
+		case ucapi.CompressorPowerConsumptionStateRunning,
+			ucapi.CompressorPowerConsumptionStateScheduled:
+			return ohpcfNone
 		}
-		return ohpcfNone
+		// completed or stopped: the compressor offers nothing to schedule
+		return ohpcfUnavailable
 	}
 
 	switch state {
@@ -415,6 +420,9 @@ func (c *EEBusOHPCF) apply() error {
 	state, err := c.cem.OHPCF.PowerConsumptionProcessState(entity)
 	if err != nil {
 		// no process state announced yet, nothing to control
+		if c.lastEnabled() {
+			return api.ErrNotAvailable
+		}
 		return nil
 	}
 
@@ -430,6 +438,9 @@ func (c *EEBusOHPCF) apply() error {
 		})
 	case ohpcfStop:
 		return c.stop(entity)
+	case ohpcfUnavailable:
+		// enabling cannot be carried out - don't report success (#32245)
+		return api.ErrNotAvailable
 	}
 
 	return nil

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -62,6 +62,8 @@ func TestOHPCFControlAction(t *testing.T) {
 		{ucapi.CompressorPowerConsumptionStatePaused, true, ohpcfResume},
 		{ucapi.CompressorPowerConsumptionStateScheduled, true, ohpcfNone},
 		{ucapi.CompressorPowerConsumptionStateRunning, true, ohpcfNone},
+		{ucapi.CompressorPowerConsumptionStateCompleted, true, ohpcfUnavailable},
+		{ucapi.CompressorPowerConsumptionStateStopped, true, ohpcfUnavailable},
 		{ucapi.CompressorPowerConsumptionStateRunning, false, ohpcfStop},
 		{ucapi.CompressorPowerConsumptionStateScheduled, false, ohpcfStop},
 		{ucapi.CompressorPowerConsumptionStateAvailable, false, ohpcfNone},


### PR DESCRIPTION
`Enable(true)` returned nil while sending nothing to the heat pump, so a boost looked like it had been applied when it could not be.

`apply()` resolves the compressor's process state and maps it to a command. Everything outside `available` / `paused` / `running` / `scheduled` fell through to `ohpcfNone` and then to `return nil`, and a failing `PowerConsumptionProcessState` returned nil as well. Both are correct while disabled, but while enabling they report a success that never happened.

`ohpcfControlAction` now distinguishes "already active, nothing to send" from "cannot be scheduled at all", and `apply()` returns `api.ErrNotAvailable` for the latter. Repeats on a running or scheduled process stay no-ops, so idempotency is unchanged.

Found while looking at #32245. That NIBE VVM S320 announces

```json
{"nodeScheduleInformation":[{"nodeRemoteControllable":true},{"supportsSingleSlotSchedulingOnly":true},
 {"alternativesCount":0},{"totalSequencesCountMax":1},{"supportsReselection":false}]}
```

with no `alternatives`, so eebus-go's `isDataAvailable` is false, `PowerConsumptionProcessState` reports `stopped`, and every boost was silently discarded with nothing in the log to explain it.

Worth deciding explicitly: the loadpoint calls `Enable` on each state transition and does not latch `lp.enabled` on error, so a heat pump that offers no flexibility for a while will now log this once per attempt instead of staying quiet. That is the intended trade — the retry also means the boost lands as soon as the compressor does announce something — but if the noise is not wanted, the alternative is to keep returning nil and log at debug inside the charger instead.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
