### PR TITLE
EEBus OHPCF: keep enabled state in sync when enable fails

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -252,13 +252,21 @@ func (c *EEBusOHPCF) Enabled() (bool, error) {
 // Enable schedules/resumes the optional consumption when on, pauses/aborts it
 // when off; while on a reboost loop reschedules newly announced consumption.
 func (c *EEBusOHPCF) Enable(enable bool) error {
+	prev := c.lastEnabled()
 	c.setEnabled(enable)
 
 	if enable {
 		c.startReboost()
 	}
 
-	return c.apply()
+	if err := c.apply(); err != nil {
+		// restore the previous intent, else Enabled() keeps reporting a state the
+		// compressor never reached and the loadpoint adopts it instead of retrying
+		c.setEnabled(prev)
+		return err
+	}
+
+	return nil
 }
 
 // startReboost launches the reboost loop, unless one is already running or no

--- a/charger/eebus-ohpcf_test.go
+++ b/charger/eebus-ohpcf_test.go
@@ -26,6 +26,9 @@ func TestEEBusOHPCFNotConnected(t *testing.T) {
 	require.ErrorIs(t, c.Enable(true), errNotConnected)
 	require.ErrorIs(t, c.MaxCurrent(16), errNotConnected)
 
+	// a failed enable must not leave the charger reporting enabled
+	assert.False(t, c.lastEnabled())
+
 	// dimming uses EG LPC, which is unavailable without an LPC entity
 	require.ErrorIs(t, c.Dim(true), api.ErrNotAvailable)
 }


### PR DESCRIPTION
`Enable` commits the intent to `c.enabled` before `apply()` runs, so a command that never reaches the heat pump still flips the charger to "enabled".

From the trace in #32252:

```
09:10:34 ERROR charger enable: The remote data structure is in an invalid state (...)
09:11:34 WARN  charger out of sync: expected disabled, got enabled
```

The enable failed, so the loadpoint keeps `lp.enabled=false`, but `Enabled()` now answers true. One minute later `syncCharger` reports the mismatch and its deferred `setAndPublishEnabled` makes the loadpoint adopt the charger's phantom state. From then on evcc believes the compressor is boosting — the reporter saw "Boost requested" with nothing running — and never retries, because as far as the loadpoint is concerned it is already enabled. Only the 10-minute reboost loop retries, and it logs at debug.

Restoring the previous intent on error keeps `Enabled()` truthful, so the loadpoint stays consistent and issues the enable again on the next cycle.

This does not fix the underlying `OptionalPowerConsumption` failure in #32252 (that one sits in eebus-go's OHPCF control path, which validates `operatingConstraintsInterrupt` although scheduling only needs the sequence id) — it stops a failed command from silently desyncing evcc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)