### PR TITLE
UI: suppress API error toasts during restart

### DIFF
--- a/assets/js/api.ts
+++ b/assets/js/api.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosResponse } from "axios";
 import { openLoginModal } from "./components/Auth/auth";
+import restart from "./restart";
 
 const { protocol, hostname, port, pathname } = window.location;
 
@@ -29,6 +30,11 @@ const api = axios.create({
 });
 
 const errorInterceptor = (error: any) => {
+  // backend is expected to be unreachable during restart, don't alert
+  if (restart.restarting) {
+    return Promise.reject(error);
+  }
+
   // handle unauthorized errors
   if (error.response?.status === 401) {
     openLoginModal();


### PR DESCRIPTION
During a restart with a remote connection, polling requests (e.g. `/config/devices/tariff/*/status`) fail with 502 from the cloud proxy and each failure raises an error toast.

- skip the global error toast in the axios interceptor while a restart is in flight (`restart.restarting`)
- covers all endpoints and status codes during the restart window; requests still reject so callers can handle errors