### PR TITLE
Nightly: publish docker image from /nightly command

### DIFF
--- a/.github/workflows/command-nightly.yml
+++ b/.github/workflows/command-nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly Command
 
 # Triggered by a maintainer commenting `/nightly` on an issue or pull request.
-# Builds the nightly packages from master (goreleaser snapshot) to check the
-# nightly pipeline is green, then replies with the result. No download artifacts.
+# Builds the nightly packages from master (goreleaser snapshot), publishes
+# evcc/evcc:nightly, then replies with the result. No APT or Hassio release.
 
 on:
   issue_comment:
@@ -54,9 +54,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  docker:
+    needs: nightly
+    uses: ./.github/workflows/nightly-docker.yml
+    permissions:
+      contents: read
+      actions: read
+    secrets: inherit
+
   report:
     name: Report
-    needs: nightly
+    needs:
+      - nightly
+      - docker
     if: always() && needs.nightly.result != 'skipped'
     runs-on: depot-ubuntu-24.04-arm
     permissions:
@@ -71,9 +81,9 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const ok = '${{ needs.nightly.result }}' === 'success';
+            const ok = '${{ needs.docker.result }}' === 'success';
             const body = ok
-              ? '✅ Nightly build from master finished.'
+              ? '✅ Nightly build from master finished, `evcc/evcc:nightly` updated.'
               : `❌ Nightly build from master failed. See the [run logs](${runUrl}).`;
             await github.rest.issues.createComment({ owner, repo, issue_number: num, body });
 

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -1,0 +1,66 @@
+name: Nightly Docker
+
+# Publishes evcc/evcc:nightly from master. Called by the scheduled nightly build
+# and by the /nightly command.
+
+on:
+  workflow_call:
+
+jobs:
+  docker:
+    name: Publish Docker :nightly
+    runs-on: depot-ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: refs/heads/master # force master
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Get dist from cache
+        uses: actions/cache/restore@v6
+        id: cache-dist
+        with:
+          path: dist
+          key: ${{ runner.os }}-${{ github.sha }}-dist
+
+      - name: Login
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Define tags
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: evcc/evcc
+          tags: |
+            type=raw,value=nightly
+            type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
+
+      - name: Publish
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v6
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Delete old nightly.* tags
+        run: |
+          old_tags=$(curl -s "https://hub.docker.com/v2/repositories/evcc/evcc/tags/?page_size=100" | jq -r '.results | map(select(.name | startswith("nightly."))) | sort_by(.last_updated) | reverse | .[1:] | .[].name')
+          for tag in $old_tags; do
+            echo "Deleting tag: $tag"
+            curl -s -H "Authorization: Bearer ${{ secrets.DOCKER_PASS }}" -X DELETE "https://hub.docker.com/v2/repositories/evcc/evcc/tags/$tag/"
+          done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,64 +42,13 @@ jobs:
       actions: write
 
   docker:
-    name: Publish Docker :nightly
     needs:
       - call-build-workflow
-    runs-on: depot-ubuntu-24.04-arm
-
+    uses: ./.github/workflows/nightly-docker.yml
     permissions:
       contents: read
       actions: read
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: refs/heads/master # force master
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Get dist from cache
-        uses: actions/cache/restore@v6
-        id: cache-dist
-        with:
-          path: dist
-          key: ${{ runner.os }}-${{ github.sha }}-dist
-
-      - name: Login
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Define tags
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
-        with:
-          images: evcc/evcc
-          tags: |
-            type=raw,value=nightly
-            type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
-
-      - name: Publish
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v6
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Delete old nightly.* tags
-        run: |
-          old_tags=$(curl -s "https://hub.docker.com/v2/repositories/evcc/evcc/tags/?page_size=100" | jq -r '.results | map(select(.name | startswith("nightly."))) | sort_by(.last_updated) | reverse | .[1:] | .[].name')
-          for tag in $old_tags; do
-            echo "Deleting tag: $tag"
-            curl -s -H "Authorization: Bearer ${{ secrets.DOCKER_PASS }}" -X DELETE "https://hub.docker.com/v2/repositories/evcc/evcc/tags/$tag/"
-          done
+    secrets: inherit
 
   hassio:
     name: Hassio Addon :nightly


### PR DESCRIPTION
`/nightly` only ran the goreleaser snapshot from master. That proves the pipeline builds, but publishes nothing — as came up in #32252, a tester asked for a nightly image and there was none to pull until the 2 AM UTC schedule.

The `docker` job of `nightly.yml` moves verbatim into a reusable `nightly-docker.yml`, called by both the scheduled nightly and the command. So `/nightly` now updates `evcc/evcc:nightly` (plus the dated `nightly.<date>-<sha>` tag and the old-tag cleanup), while APT and the Hassio addon stay exclusive to the schedule.

The command's report comment keys off the docker job now: a failed image push no longer reports ✅, and the success text names the tag that was updated.
```
✅ Nightly build from master finished, `evcc/evcc:nightly` updated.
```

Noticed while moving it, not changed here: the `Get dist from cache` step in the docker job looks dead — the Dockerfile builds the UI itself in its node stage and `dist` is in `.dockerignore`, so the restored directory never reaches the image. Left in place to keep the extraction a pure move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
