### PR TITLE
UI: fix loadpoint value alignment on narrow screens

### DIFF
--- a/assets/js/components/Loadpoints/SessionInfo.vue
+++ b/assets/js/components/Loadpoints/SessionInfo.vue
@@ -4,6 +4,7 @@
 			<template #label>
 				<CustomSelect
 					inline
+					class="align-top"
 					:selected="selectedKey"
 					:options="selectOptions"
 					data-testid="sessionInfoSelect"


### PR DESCRIPTION
fixes #31993, replaces #32050

On narrow screens the session-info label gets truncated (overflow: hidden), which moves the baseline of the inline-block select to its bottom edge. This grows the label's line box and pushes the session value a few pixels below the other loadpoint values. Same root cause analysis as #32050, but fixed with an existing Bootstrap utility instead of scoped CSS.

- add `align-top` to the session-info select, wins over `align-baseline` by utility source order
