### PR TITLE
mercedes: remove odo, maxSoc and status APIs

### DIFF
--- a/vehicle/mercedes/api.go
+++ b/vehicle/mercedes/api.go
@@ -73,11 +73,6 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 		return res, err
 	}
 
-	if val, ok := message.Attributes["odo"]; ok {
-		res.VehicleInfo.Odometer.Value = int(val.GetIntValue())
-		res.VehicleInfo.Odometer.Unit = val.GetDistanceUnit().String()
-	}
-
 	if val, ok := message.Attributes["soc"]; ok {
 		res.EvInfo.Battery.StateOfCharge = float64(val.GetIntValue())
 	}
@@ -89,29 +84,6 @@ func (v *API) Status(vin string) (StatusResponse, error) {
 
 	if val, ok := message.Attributes["endofchargetime"]; ok {
 		res.EvInfo.Battery.EndOfChargeTime = int(val.GetIntValue())
-	}
-
-	if val, ok := message.Attributes["chargingstatus"]; ok {
-		res.EvInfo.Battery.ChargingStatus = int(val.GetIntValue())
-	} else {
-		res.EvInfo.Battery.ChargingStatus = 3
-	}
-
-	if val, ok := message.Attributes["maxSoc"]; ok && val != nil {
-		res.EvInfo.Battery.SocLimit = int(val.GetIntValue())
-	}
-
-	if val, ok := message.Attributes["selectedChargeProgram"]; ok && val != nil {
-		selectedChargeProgram := val.GetIntValue()
-		res.EvInfo.Battery.SelectedChargeProgram = int(selectedChargeProgram)
-
-		if cps, ok := message.Attributes["chargePrograms"]; ok && cps != nil {
-			if cpVal := cps.GetChargeProgramsValue(); cpVal != nil && res.EvInfo.Battery.SelectedChargeProgram < len(cpVal.ChargeProgramParameters) {
-				if chargeProgramParam := cpVal.ChargeProgramParameters[res.EvInfo.Battery.SelectedChargeProgram]; chargeProgramParam != nil {
-					res.EvInfo.Battery.SocLimit = int(chargeProgramParam.GetMaxSoc())
-				}
-			}
-		}
 	}
 
 	// There are two attributes for the proconditioning status, precondNow and precondActive

--- a/vehicle/mercedes/provider.go
+++ b/vehicle/mercedes/provider.go
@@ -34,36 +34,6 @@ func (v *Provider) Range() (int64, error) {
 	return int64(res.EvInfo.Battery.DistanceToEmpty.Value), err
 }
 
-var _ api.VehicleOdometer = (*Provider)(nil)
-
-// Odometer implements the api.VehicleOdometer interface
-func (v *Provider) Odometer() (float64, error) {
-	res, err := v.dataG()
-	return float64(res.VehicleInfo.Odometer.Value), err
-}
-
-var _ api.SocLimiter = (*Provider)(nil)
-
-// GetLimitSoc implements the api.SocLimiter interface
-func (v *Provider) GetLimitSoc() (int64, error) {
-	res, err := v.dataG()
-	return int64(res.EvInfo.Battery.SocLimit), err
-}
-
-var _ api.ChargeState = (*Provider)(nil)
-
-// Status implements the api.ChargeState interface
-func (v *Provider) Status() (api.ChargeStatus, error) {
-	status := api.StatusA // disconnected
-
-	res, err := v.dataG()
-	if err == nil {
-		status = MapChargeStatus(res.EvInfo.Battery.ChargingStatus)
-	}
-
-	return status, err
-}
-
 var _ api.VehicleClimater = (*Provider)(nil)
 
 // Climater implements the api.VehicleClimater interface
@@ -96,32 +66,4 @@ func (v *Provider) FinishTime() (time.Time, error) {
 		res = res.Add(24 * time.Hour)
 	}
 	return res, nil
-}
-
-// Charging Status
-// 0=CHARGING
-// 1=CHARGING_ENDS
-// 2=CHARGE_BREAK
-// 3=UNPLUGGED
-// 4=FAILURE
-// 5=SLOW
-// 6=FAST
-// 7=DISCHARGING
-// 8=NO_CHARGING
-// 9=SLOW_CHARGING_AFTER_REACHING_TRIP_TARGET
-// 10=CHARGING_AFTER_REACHING_TRIP_TARGET
-// 11=FAST_CHARGING_AFTER_REACHING_TRIP_TARGET
-// 12=COMMUNICATION_WITH_EVSE_ACTIVE_NO_ENERGY_FLOW
-// 13=AC_CHARGING_ACTIVE
-// 14=DC_CHARGING_ACTIVE
-// 15=SOH_BATTERY_CALIBRATION_ACTIVE
-// 16=UNKNOWN_STATUS
-func MapChargeStatus(lookup int) api.ChargeStatus {
-	switch lookup {
-	case 0, 5, 6, 9, 10, 11, 13, 14:
-		return api.StatusC
-	case 1, 2, 4, 7, 8, 12, 15:
-		return api.StatusB
-	}
-	return api.StatusA
 }

--- a/vehicle/mercedes/types.go
+++ b/vehicle/mercedes/types.go
@@ -31,25 +31,15 @@ type Vehicle struct {
 }
 
 type StatusResponse struct {
-	VehicleInfo struct {
-		Odometer struct {
-			Value int
-			Unit  string
-		}
-		Timestamp time.Time
-	}
 	EvInfo struct {
 		Battery struct {
-			ChargingStatus  int
 			DistanceToEmpty struct {
 				Value int
 				Unit  string
 			}
-			StateOfCharge         float64 // 75
-			EndOfChargeTime       int     // Minutes after midnight
-			TotalRange            int     // 17
-			SocLimit              int     // 50-100
-			SelectedChargeProgram int
+			StateOfCharge   float64 // 75
+			EndOfChargeTime int     // Minutes after midnight
+			TotalRange      int     // 17
 		}
 		Timestamp time.Time
 	}


### PR DESCRIPTION
fixes #32083

Mercedes-Benz removed the `odo`, `chargingstatus` and `maxSoc` attributes from the vehicle attributes API response (confirmed by the mbapi2020 maintainer in #32071). The `chargingstatus` fallback made `Status()` always report the vehicle as disconnected while plugged in, breaking vehicle recognition.

- Remove `Odometer()` (`api.VehicleOdometer`) — `odo` no longer sent
- Remove `GetLimitSoc()` (`api.SocLimiter`) — `maxSoc`/`selectedChargeProgram`/`chargePrograms` no longer sent
- Remove `Status()` (`api.ChargeState`) and `MapChargeStatus` — `chargingstatus` no longer sent, previously defaulted to always-disconnected
- SoC, range, preconditioning and finish time are unaffected and continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)