### PR TITLE
Meter (FoxESS H3-Pro/Smart): add battery control

### DIFF
--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -115,5 +115,132 @@ render: |
         address: 46611 # Minimum SoC OnGrid
         type: writesingle
         decode: uint16
+  batterymode:
+    source: watchdog
+    timeout: 30s
+    reset: 1 # reset to normal mode
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal - disable remote control
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 0 # Disabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46001 # Remote Control
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Self Use
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ .minsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46609 # Minimum SoC
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ .maxsoc }}
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46610 # Maximum SoC
+                type: writesingle
+                encoding: uint16
+      - case: 2 # hold - stop battery discharge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 2 # Feed-in First, fallback if the remote control watchdog expires
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 60 # Remote timeout 60 seconds
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46002 # Remote Timeout Set
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Enabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46001 # Remote Control
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 0 # W
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
+                type: writemultiple
+                encoding: int32
+      - case: 3 # charge - force battery charge
+        set:
+          source: sequence
+          set:
+          - source: const
+            value: 3 # Back-up, fallback if the remote control watchdog expires
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 49203 # Work Mode
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 60 # Remote timeout 60 seconds
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46002 # Remote Timeout Set
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: 1 # Enabled
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46001 # Remote Control
+                type: writesingle
+                encoding: uint16
+          - source: const
+            value: {{ mul .maxchargepower -1 }} # negative power means charging
+            set:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
+                type: writemultiple
+                encoding: int32
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -12,6 +12,8 @@ params:
     id: 247
   - name: maxacpower
   - preset: battery-params
+  - name: maxchargepower
+    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}


### PR DESCRIPTION
The template only exposed a limitsoc setter (a Minimum SoC floor register), which raises the discharge floor to the current SoC. This does not reliably stop discharge, so BatteryHold during fast/planned charging was not effective, despite the template advertising the battery-control capability.

Add a batterymode block using the inverter's remote control registers (46xxx/49xxx range, not covered by the legacy H1/H3 register spec PDF), cross-checked against the community foxess_modbus Home Assistant integration, which separately documents and maintains this newer register map:

- 46001 remote control enable/disable (1/0)
- 46002 remote control watchdog timeout
- 46003/46004 active power setpoint, int32 across two registers (standard big-endian word order), negative value requests charge/import, positive requests discharge/export
- 49203 work mode, set as a fallback in case evcc's own watchdog fails to run (e.g. process crash) before the inverter's timeout fires
- 46609/46610 restore configured min/max SoC on return to normal mode

Wrapped in a 30s watchdog that falls back to normal mode if evcc stops refreshing the setpoint. The existing limitsoc setter is kept as-is, it controls a separate, persistent on-grid discharge floor rather than the active hold/charge session.