### PR TITLE
fix(sponsor): use Happy Eyeballs dial for sponsor gRPC connection

### DIFF
--- a/util/cloud/client.go
+++ b/util/cloud/client.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"crypto/tls"
 	_ "embed"
 	"net"
@@ -30,9 +31,21 @@ func Connection() (*grpc.ClientConn, error) {
 	creds := credentials.NewTLS(&tls.Config{
 		ServerName: host,
 	})
+
+	// bypass grpc's own DNS resolution, which hands pick_first a single
+	// pre-resolved address per attempt with no dual-stack fallback if that
+	// address family is unreachable. Using a plain net.Dialer with the
+	// hostname instead enables Go's built-in Happy Eyeballs (RFC 6555),
+	// so a broken/absent IPv6 route no longer breaks the connection when
+	// IPv4 works fine (and vice versa).
+	dialer := &net.Dialer{}
+
 	// close idle connection shortly after startup auth instead of churning against the server's idle close
-	conn, err = grpc.NewClient(hostport,
+	conn, err = grpc.NewClient("passthrough:///"+hostport,
 		grpc.WithTransportCredentials(creds),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", addr)
+		}),
 		grpc.WithIdleTimeout(5*time.Second),
 	)
 


### PR DESCRIPTION
## Problem

The sponsor hardware/token check (`util/sponsor/hardware.go`, `util/sponsor/auth.go`) intermittently fails with errors such as:

```
rpc error: code = Unavailable desc = connection error: desc = "error reading server preface: EOF"
```
or
```
rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [2a09:8280:1::6:621]:8080: connect: network is unreachable"
```

This happens on networks where DNS resolution for `sponsor.evcc.io` returns both an A and a AAAA record, but the local network has no working IPv6 route (a very common situation with partial/misconfigured dual-stack ISPs/routers).

`grpc.NewClient(hostport, ...)` uses grpc-go's own DNS resolver, which resolves the hostname once and hands its `pick_first` balancer a list of addresses. Each connection attempt dials a single, already-resolved address - if that happens to be the unreachable IPv6 address, the attempt fails with no fallback to the working IPv4 address within the same call.

## Root cause, verified

On a device where `sponsor.evcc.io` resolves to `66.241.124.2` (IPv4, reachable) and `2a09:8280:1::6:621` (IPv6, no route on this network):

```
$ ip -6 route show default
(empty)

$ curl -6 -v --connect-timeout 3 "https://[2a09:8280:1::6:621]:8080/"
* Immediate connect fail for 2a09:8280:1::6:621: Network is unreachable

$ curl -4 -v --connect-timeout 3 https://sponsor.evcc.io:8080/
* Connected to sponsor.evcc.io (66.241.124.2) port 8080
* TLSv1.3 ... (handshake succeeds)
```

Added temporary debug logging in `checkHardware` confirmed the same pattern in evcc's own gRPC dial: depending on which address `pick_first` happened to try, the call either succeeded immediately (IPv4) or failed outright (IPv6), with no automatic retry/fallback.

## Fix

Bypass grpc-go's own DNS resolution via the `passthrough` scheme and dial through a plain `net.Dialer` using the hostname instead of a pre-resolved address. Go's standard `net.Dialer` implements Happy Eyeballs (RFC 6555) when given a hostname, racing IPv4/IPv6 and using whichever address family actually connects - so a broken/absent IPv6 (or IPv4) route no longer breaks the sponsor connection as long as the other family works.

No behavior change for networks where both families work, or where only IPv4 (or only IPv6) is available and DNS reflects that correctly.

## Testing

Reproduced and verified on a Raspberry Pi Zero 2 W running on a WiFi network with no IPv6 default route. Before the fix, the sponsor hardware check failed intermittently across reboots (roughly 2 out of 3 attempts in some boots). After the fix, multiple consecutive reboots all succeeded on the first attempt.