### PR TITLE
Cardata: delete obsolete streaming containers

### DIFF
--- a/vehicle/bmw/cardata/api.go
+++ b/vehicle/bmw/cardata/api.go
@@ -33,7 +33,10 @@ var requiredKeys = []string{
 	"vehicle.vehicle.travelledDistance",
 }
 
-const requiredVersion = "v6"
+const (
+	containerName   = "evcc.io"
+	requiredVersion = "v6"
+)
 
 type API struct {
 	*request.Helper

--- a/vehicle/bmw/cardata/mqtt.go
+++ b/vehicle/bmw/cardata/mqtt.go
@@ -205,7 +205,7 @@ func (v *MqttConnector) handler(_ mqtt.Client, m mqtt.Message) {
 		return
 	}
 
-	v.log.TRACE.Println("recv: " + string(m.Payload()))
+	v.log.TRACE.Printf("recv %s: %s", m.Topic(), string(m.Payload()))
 
 	v.mu.RLock()
 	defer v.mu.RUnlock()

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -71,19 +71,36 @@ func (v *Provider) findOrCreateContainer() (string, error) {
 		return "", err
 	}
 
+	// obsolete containers keep streaming, resulting in duplicate messages
+	defer v.deleteObsoleteContainers(containers)
+
 	if i := slices.IndexFunc(containers, func(c Container) bool {
-		return c.Name == "evcc.io" && c.Purpose == requiredVersion
+		return c.Name == containerName && c.Purpose == requiredVersion
 	}); i >= 0 {
 		return containers[i].ContainerId, nil
 	}
 
 	res, err := v.api.CreateContainer(CreateContainer{
-		Name:                 "evcc.io",
+		Name:                 containerName,
 		Purpose:              requiredVersion,
 		TechnicalDescriptors: requiredKeys,
 	})
 
 	return res.ContainerId, err
+}
+
+func (v *Provider) deleteObsoleteContainers(containers []Container) {
+	for _, c := range containers {
+		if c.Name != containerName || c.Purpose == requiredVersion {
+			continue
+		}
+
+		v.log.DEBUG.Printf("deleting obsolete container %s (%s)", c.ContainerId, c.Purpose)
+
+		if err := v.api.DeleteContainer(c.ContainerId); err != nil {
+			v.log.WARN.Printf("delete container %s: %v", c.ContainerId, err)
+		}
+	}
 }
 
 func (v *Provider) setupContainer() error {


### PR DESCRIPTION
Every evcc release that bumps the CarData container version creates a new container, but the previous ones stay ACTIVE and keep streaming. With six `evcc.io` containers on one account each telemetry burst arrives more than once, and the container quota fills up over time.

- delete leftover `evcc.io` containers whose purpose does not match the current version
- log the mqtt topic alongside the received payload so multiple streaming sources are visible in the trace log