### PR TITLE
chore: pin clock in device colors test

### DIFF
--- a/tests/device-colors.spec.ts
+++ b/tests/device-colors.spec.ts
@@ -33,6 +33,10 @@ function chartSection(page: Page, heading: string): Locator {
 }
 
 test("device colors: autoassign, override, persistence", async ({ page }) => {
+  // fixture sessions are dated 2026-05. Sessions.vue ranks loadpoints by energy
+  // over the last three months relative to now, so pin the clock to keep them in range
+  await page.clock.setFixedTime(new Date("2026-05-15T12:00:00Z"));
+
   // ---------- Step 1 — Sessions, by-vehicle view ----------
   await page.goto("/#/sessions?year=2026&month=5");
   await expect(page.getByRole("heading", { name: "Charging Sessions" })).toBeVisible();


### PR DESCRIPTION
Surfaced as a red Integration job on unrelated PRs, e.g. #32308.

The `device-colors` fixture has static session dates in 2026-05, but the sessions view ranks loadpoints by energy over the last three months relative to the wall clock. From 2026-07-31 onwards that window stops covering the fixture, the highest energy loadpoint drops out of the ranking, and the palette assignment shifts by one. Pinning the page clock decouples the test from the current date.

- pins the browser clock to a fixed date inside the fixture range
- leaves the three month ranking window in `Sessions.vue` untouched, it is product behaviour rather than a bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)