### PR TITLE
Fronius: add Argeno and Smart Meter IP meter templates

### DIFF
--- a/templates/definition/meter/fronius-argeno.yaml
+++ b/templates/definition/meter/fronius-argeno.yaml
@@ -18,8 +18,8 @@ params:
   - name: maxacpower
 render: |
   type: custom
-  # Fronius Argeno: AC output via SunSpec inverter model 113 (float) on unit 1
-  # (103 int+sf listed for firmware variants). Unlike GEN24, PV must NOT be
+  # Fronius Argeno: AC output via SunSpec inverter model 113 (float, primary)
+  # on unit 1; 103 (int+sf) as fallback for potential firmware variants. Unlike GEN24, PV must NOT be
   # read from model 160 DC channels: the Argeno's modular power stages report
   # only a fraction of plant output there (verified on-site: 160-based read
   # showed 6.5 kW while actual AC output was 31.7 kW).
@@ -28,14 +28,14 @@ render: |
     uri: {{ joinHostPort .host .port }}
     id: 1
     value:
-      - 103:W
       - 113:W
+      - 103:W
   energy:
     source: sunspec
     uri: {{ joinHostPort .host .port }}
     id: 1
     value:
-      - 103:WH
       - 113:WH
+      - 103:WH
     scale: 0.001
   maxacpower: {{ .maxacpower }} # W

--- a/templates/definition/meter/fronius-argeno.yaml
+++ b/templates/definition/meter/fronius-argeno.yaml
@@ -1,0 +1,41 @@
+template: fronius-argeno
+products:
+  - brand: Fronius
+    description:
+      generic: Argeno
+requirements:
+  description:
+    de: |
+      Modbus TCP muss am Wechselrichter aktiviert sein (Konfiguration → Kommunikation → Ethernet → Modbus TCP/UDP). Für den Netzzähler siehe Template „Fronius Smart Meter IP" — der Argeno nutzt den Smart Meter IP als eigenständiges Netzwerkgerät.
+    en: |
+      Modbus TCP must be enabled on the inverter (Configuration → Communication → Ethernet → Modbus TCP/UDP). For the grid meter see the "Fronius Smart Meter IP" template — the Argeno uses the Smart Meter IP as a standalone network device.
+params:
+  - name: usage
+    choice: ["pv"]
+  - name: host
+  - name: port
+    default: 502
+  - name: maxacpower
+render: |
+  type: custom
+  # Fronius Argeno: AC output via SunSpec inverter model 113 (float) on unit 1
+  # (103 int+sf listed for firmware variants). Unlike GEN24, PV must NOT be
+  # read from model 160 DC channels: the Argeno's modular power stages report
+  # only a fraction of plant output there (verified on-site: 160-based read
+  # showed 6.5 kW while actual AC output was 31.7 kW).
+  power:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: 1
+    value:
+      - 103:W
+      - 113:W
+  energy:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: 1
+    value:
+      - 103:WH
+      - 113:WH
+    scale: 0.001
+  maxacpower: {{ .maxacpower }} # W

--- a/templates/definition/meter/fronius-smart-meter-ip.yaml
+++ b/templates/definition/meter/fronius-smart-meter-ip.yaml
@@ -1,0 +1,104 @@
+template: fronius-smart-meter-ip
+products:
+  - brand: Fronius
+    description:
+      generic: Smart Meter IP
+requirements:
+  description:
+    de: |
+      Modbus TCP muss in der Weboberfläche des Zählers aktiviert sein (Einstellungen → Datenschnittstellen → Modbus (TCP und RTU)). Der Zähler wird direkt über seine eigene IP-Adresse ausgelesen, nicht über den Wechselrichter.
+    en: |
+      Modbus TCP must be enabled in the meter's web interface (Settings → Data interfaces → Modbus (TCP and RTU)). The meter is read directly via its own IP address, not through the inverter.
+params:
+  - name: usage
+    choice: ["grid"]
+  - name: host
+  - name: port
+    default: 502
+  - name: id
+    default: 1
+    advanced: true
+render: |
+  type: custom
+  # Fronius Smart Meter IP (63A-1, 63A-3, 5kA-3): standalone LAN/WLAN meter.
+  # SunSpec model 213 (float) on unit 1; 203 (int+sf) listed for firmware variants.
+  power:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: {{ .id }}
+    value:
+      - 203:W
+      - 213:W
+  energy:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: {{ .id }}
+    value:
+      - 203:TotWhImp
+      - 213:TotWhImp
+    scale: 0.001
+  returnenergy:
+    source: sunspec
+    uri: {{ joinHostPort .host .port }}
+    id: {{ .id }}
+    value:
+      - 203:TotWhExp
+      - 213:TotWhExp
+    scale: 0.001
+  currents:
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:AphA
+        - 213:AphA
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:AphB
+        - 213:AphB
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:AphC
+        - 213:AphC
+  voltages:
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:PhVphA
+        - 213:PhVphA
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:PhVphB
+        - 213:PhVphB
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:PhVphC
+        - 213:PhVphC
+  powers:
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:WphA
+        - 213:WphA
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:WphB
+        - 213:WphB
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: {{ .id }}
+      value:
+        - 203:WphC
+        - 213:WphC

--- a/templates/definition/meter/fronius-smart-meter-ip.yaml
+++ b/templates/definition/meter/fronius-smart-meter-ip.yaml
@@ -21,84 +21,85 @@ params:
 render: |
   type: custom
   # Fronius Smart Meter IP (63A-1, 63A-3, 5kA-3): standalone LAN/WLAN meter.
-  # SunSpec model 213 (float) on unit 1; 203 (int+sf) listed for firmware variants.
+  # SunSpec model 213 (float, primary) on unit 1; 203 (int+sf) as fallback
+  # for potential firmware variants.
   power:
     source: sunspec
     uri: {{ joinHostPort .host .port }}
     id: {{ .id }}
     value:
-      - 203:W
       - 213:W
+      - 203:W
   energy:
     source: sunspec
     uri: {{ joinHostPort .host .port }}
     id: {{ .id }}
     value:
-      - 203:TotWhImp
       - 213:TotWhImp
+      - 203:TotWhImp
     scale: 0.001
   returnenergy:
     source: sunspec
     uri: {{ joinHostPort .host .port }}
     id: {{ .id }}
     value:
-      - 203:TotWhExp
       - 213:TotWhExp
+      - 203:TotWhExp
     scale: 0.001
   currents:
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:AphA
         - 213:AphA
+        - 203:AphA
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:AphB
         - 213:AphB
+        - 203:AphB
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:AphC
         - 213:AphC
+        - 203:AphC
   voltages:
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:PhVphA
         - 213:PhVphA
+        - 203:PhVphA
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:PhVphB
         - 213:PhVphB
+        - 203:PhVphB
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:PhVphC
         - 213:PhVphC
+        - 203:PhVphC
   powers:
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:WphA
         - 213:WphA
+        - 203:WphA
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:WphB
         - 213:WphB
+        - 203:WphB
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: {{ .id }}
       value:
-        - 203:WphC
         - 213:WphC
+        - 203:WphC


### PR DESCRIPTION
# Add meter templates: Fronius Argeno (PV) and Fronius Smart Meter IP (grid)

## Motivation

We commissioned a **Fronius Argeno** inverter with a **Fronius Smart Meter IP 5kA-3** at a large PV installation and found that neither device is covered by the existing `fronius-gen24` template:

1. **PV power was wrong by ~5x.** The `fronius-gen24` template reads PV as the sum of SunSpec model 160 DC channels 1+2 (MPPT). On the Argeno (modular power stages), the model-160 channels report only a fraction of plant output: the template showed **6.5 kW while actual AC output was 31.7 kW** (verified against the inverter web UI and Solar.web simultaneously).
2. **The Smart Meter IP cannot be reached through the inverter.** It is a standalone LAN/WLAN device with its own Modbus TCP server (SunSpec model 213 on unit 1). The GEN24-style access via the inverter's unit 200 times out.

## Changes

- **`fronius-argeno.yaml`** (usage: `pv`): reads AC output from the SunSpec inverter model (113 float / 103 int) on unit 1 instead of model-160 DC channels. Energy from `WH`.
- **`fronius-smart-meter-ip.yaml`** (usage: `grid`): reads the standalone meter directly at its own IP, unit 1, SunSpec model 213 (float) with 203 (int) fallback. Power, import/export energy, per-phase currents/voltages/powers.

## Verification (live installation, 2026-07-30/31)

Fronius Argeno (SN 78002877), Smart Meter IP 5kA-3 (SN 96043619), firmware as shipped July 2026.

| Value | Solar.web / device UI | Template read (this PR) |
|---|---|---|
| Grid power (feed-in) | 29.3 kW / meter UI −29,136 W | 213:W = **−29,136 W** |
| Per-phase powers | −9,142 / −9,719 / −9,799 W | match to the watt |
| Grid frequency | 50 Hz | 49.99 Hz |
| Voltage L1-L3 | ~227 V | 227.05 / 226.91 / 227.24 V |
| PV AC power | 31.4 kW | 113:W = **31,757 W** |
| PV via model 160 ch 1+2 (old path) | — | 6,580 W (wrong, ~5x off) |
| Import/export energy counters | fresh since commissioning | 75.6 / 245.3 kWh (plausible) |

Sign convention confirmed: meter W positive = grid import, negative = export (matches evcc expectation).

## Notes

- The Argeno template is PV-only for now; we have no battery attached and did not want to guess model-124 behavior.
- The Smart Meter IP limits concurrent Modbus TCP connections; no template-level handling needed, but worth knowing for reviewers testing alongside other clients.
- I do not have access to additional Argeno/Smart Meter IP units — happy to adjust if the community reports variant firmware exposing int models (hence the 103/203 fallbacks).
