### PR TITLE
Sessions UI: fix grouped chart layout and legend styling

### DIFF
--- a/assets/js/colors.ts
+++ b/assets/js/colors.ts
@@ -27,6 +27,7 @@ const colors: {
   temperature: string | null;
   export: string | null;
   background: string | null;
+  box: string | null;
   light: string | null;
   selfPalette: string[];
   palette: string[];
@@ -44,6 +45,7 @@ const colors: {
   temperature: null,
   export: null,
   background: null,
+  box: null,
   light: null,
   selfPalette: ["#0FDE41", "#FFBD2F", "#FD6158", "#03C1EF", "#0F662D", "#FF922E"],
   palette: [
@@ -152,6 +154,7 @@ export function updateCssColors() {
   colors.temperature = style.getPropertyValue("--evcc-temperature");
   colors.export = style.getPropertyValue("--evcc-export-contrast");
   colors.background = style.getPropertyValue("--evcc-background");
+  colors.box = style.getPropertyValue("--evcc-box");
   colors.pricePerKWh = style.getPropertyValue("--bs-gray-medium");
   colors.co2PerKWh = style.getPropertyValue("--bs-gray-medium");
   colors.light = style.getPropertyValue("--bs-gray-light");

--- a/assets/js/components/Sessions/AvgCostGroupedChart.vue
+++ b/assets/js/components/Sessions/AvgCostGroupedChart.vue
@@ -1,9 +1,9 @@
 <template>
 	<div v-if="chartData.labels.length > 1" class="row">
-		<div class="col-12 col-md-6 mb-3">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 mb-3">
 			<PolarArea :data="chartData" :options="options" />
 		</div>
-		<div class="col-12 col-md-6 d-flex align-items-center py-0 py-md-3">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 d-flex align-items-center">
 			<LegendList :legends="legends" :device-colors="deviceColors" grid />
 		</div>
 	</div>
@@ -130,7 +130,7 @@ export default defineComponent({
 						beginAtZero: false,
 						ticks: {
 							color: colors.muted || "",
-							backdropColor: colors.background || "",
+							backdropColor: colors.box || "",
 							font: { size: 10 },
 							callback: this.formatValue,
 							maxTicksLimit: 6,

--- a/assets/js/components/Sessions/CostGroupedChart.vue
+++ b/assets/js/components/Sessions/CostGroupedChart.vue
@@ -1,9 +1,9 @@
 <template>
 	<div v-if="chartData.labels.length > 1" class="row">
-		<div class="col-12 col-md-6 mb-3">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 mb-3">
 			<Doughnut :data="chartData" :options="options" />
 		</div>
-		<div class="col-12 col-md-6 d-flex align-items-center">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 d-flex align-items-center">
 			<LegendList :legends="legends" :device-colors="deviceColors" grid />
 		</div>
 	</div>
@@ -94,7 +94,7 @@ export default defineComponent({
 				borderRadius: 10,
 				color: colors.text || "",
 				borderWidth: 3,
-				borderColor: colors.background || "",
+				borderColor: colors.box || "",
 				cutout: "70%",
 				radius: "95%",
 				animation: { duration: 250 },

--- a/assets/js/components/Sessions/EnergyGroupedChart.vue
+++ b/assets/js/components/Sessions/EnergyGroupedChart.vue
@@ -1,9 +1,9 @@
 <template>
 	<div v-if="chartData.labels.length > 1" class="row">
-		<div class="col-12 col-md-6 mb-3">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 mb-3">
 			<Doughnut :data="chartData" :options="options" />
 		</div>
-		<div class="col-12 col-md-6 d-flex align-items-center">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 d-flex align-items-center">
 			<LegendList :legends="legends" :device-colors="deviceColors" grid />
 		</div>
 	</div>
@@ -107,7 +107,7 @@ export default defineComponent({
 				borderRadius: 10,
 				color: colors.text,
 				borderWidth: 3,
-				borderColor: colors.background,
+				borderColor: colors.box,
 				cutout: "70%",
 				radius: "95%",
 				animation: { duration: 250 },

--- a/assets/js/components/Sessions/LegendList.vue
+++ b/assets/js/components/Sessions/LegendList.vue
@@ -1,6 +1,6 @@
 <template>
 	<ul
-		class="root p-0 d-flex flex-wrap column-gap-4 row-gap-2"
+		class="root p-0 m-0 d-flex flex-wrap column-gap-4 row-gap-2"
 		:class="{
 			'root--small-equal-widths': smallEqualWidths,
 			'root--grid': grid,
@@ -50,7 +50,7 @@
 			<div
 				v-for="value in valueList(legend.value)"
 				:key="value"
-				class="text-muted text-nowrap legend-value text-end"
+				class="text-muted text-nowrap legend-value text-end tabular"
 			>
 				{{ value }}
 			</div>

--- a/assets/js/components/Sessions/SessionTable.vue
+++ b/assets/js/components/Sessions/SessionTable.vue
@@ -174,7 +174,7 @@ const COLUMNS_PER_BREAKPOINT = {
 	sm: 3,
 	md: 4,
 	lg: 7,
-	xl: 8,
+	xl: 7,
 	xxl: 9,
 };
 

--- a/assets/js/components/Sessions/SolarGroupedChart.vue
+++ b/assets/js/components/Sessions/SolarGroupedChart.vue
@@ -1,9 +1,9 @@
 <template>
 	<div v-if="chartData.labels.length > 1" class="row">
-		<div class="col-12 col-md-6 mb-3">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 mb-3">
 			<PolarArea :data="chartData" :options="options" />
 		</div>
-		<div class="col-12 col-md-6 d-flex align-items-center py-0 py-md-3">
+		<div class="col-12 col-md-6 col-lg-12 col-xxl-6 d-flex align-items-center">
 			<LegendList :legends="legends" :device-colors="deviceColors" grid />
 		</div>
 	</div>
@@ -123,7 +123,7 @@ export default defineComponent({
 						ticks: {
 							stepSize: 25,
 							color: colors.muted,
-							backdropColor: colors.background,
+							backdropColor: colors.box,
 						},
 						grid: { color: colors.border },
 					},

--- a/assets/js/components/Sessions/SolarYearChart.vue
+++ b/assets/js/components/Sessions/SolarYearChart.vue
@@ -180,7 +180,7 @@ export default defineComponent({
 						ticks: {
 							stepSize: 20,
 							color: colors.muted,
-							backdropColor: colors.background,
+							backdropColor: colors.box,
 							font: { size: 10 },
 							callback: (value: number) => this.fmtPercentage(value, 0),
 						},

--- a/assets/js/views/Sessions.vue
+++ b/assets/js/views/Sessions.vue
@@ -86,9 +86,9 @@
 					/>
 				</Card>
 				<div v-if="showExtraCharts">
-					<div class="row align-items-start">
+					<div class="row">
 						<div class="col-12 col-lg-6 mb-4">
-							<Card :title="firstExtraTitle" edge-to-edge>
+							<Card :title="firstExtraTitle" edge-to-edge class="h-100">
 								<div v-if="activeType === types.SOLAR">
 									<SolarYearChart
 										v-if="showSolarYearChart"
@@ -116,7 +116,7 @@
 							</Card>
 						</div>
 						<div class="col-12 col-lg-6 mb-4">
-							<Card :title="secondExtraTitle" edge-to-edge>
+							<Card :title="secondExtraTitle" edge-to-edge class="h-100">
 								<EnergyGroupedChart
 									v-if="activeType === types.SOLAR"
 									:sessions="currentSessions"


### PR DESCRIPTION
fixes #32319

Fixes legend value clipping in the grouped session charts and cleans up related layout issues that show up now that charts live in white cards.

- stack chart above legend while the card is half width (lg/xl), side by side again at xxl
- equal card heights when side by side
- one column less in the session table at xl (dropped mileage) to avoid overflow
- use box color instead of page background for doughnut segment gaps and polar tick label backdrops
- align legends across cards: remove extra legend padding and default list margin
- tabular numerals for legend values



<img width="1647" height="701" alt="Bildschirmfoto 2026-07-31 um 13 01 17" src="https://github.com/user-attachments/assets/5f6afe4d-cc29-4ef2-9b70-2b58243eb91c" />

<img width="997" height="738" alt="Bildschirmfoto 2026-07-31 um 13 01 28" src="https://github.com/user-attachments/assets/e69e8883-788f-4887-a25c-0b407fe931fb" />

<img width="817" height="1009" alt="Bildschirmfoto 2026-07-31 um 13 01 33" src="https://github.com/user-attachments/assets/a9918d21-6b6a-4e1e-b3d3-2b6e9398b6e8" />

<img width="408" height="709" alt="Bildschirmfoto 2026-07-31 um 13 01 50" src="https://github.com/user-attachments/assets/f0097772-2db8-4756-8b8c-536a55df69d6" />
