### PR TITLE
Metrics: add soc and total row to battery command

### DIFF
--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -22,12 +22,14 @@ import formatter, { POWER_UNIT } from "@/mixins/formatter";
 import { PERIODS } from "../Sessions/types";
 import { is12hFormat } from "@/units";
 import { hasColorPicker } from "./groups";
+import { batteryCapacities, totalSocByStart } from "./soc";
 
 export interface HistorySlot {
 	start: string;
 	end: string;
 	energy: number;
 	returnEnergy: number;
+	socTemp?: number | null;
 }
 
 export interface HistorySeries {
@@ -58,6 +60,10 @@ const BIDIRECTIONAL_GROUPS: ReadonlySet<string> = new Set(["grid", "battery"]);
 
 // Multiple entities stack into one bar; grid and meter render side-by-side.
 const STACKED_GROUPS: ReadonlySet<string> = new Set(["loadpoint", "consumer", "pv", "battery"]);
+
+// Hidden percentage axis the battery soc line is drawn against. Empty maps onto
+// the zero line, full onto the top of the symmetric energy axis.
+const SOC_AXIS = { type: "value", min: -100, max: 100, show: false };
 
 // Round up to a nice number (5-tick symmetric axis: -L, -L/2, 0, L/2, L).
 function niceCeil(v: number): number {
@@ -229,6 +235,22 @@ export default defineComponent({
 				}
 			}
 			return has;
+		},
+		// Combined soc of the visible batteries, mapped onto the category slots.
+		socValues(): (number | null)[] {
+			const values: (number | null)[] = Array.from(
+				{ length: this.categoryKeys.length },
+				() => null
+			);
+			if (this.group !== "battery") return values;
+
+			const capacities = batteryCapacities(store.state.battery?.devices ?? []);
+			const index = new Map(this.categoryKeys.map((k, i) => [k, i]));
+			for (const [start, soc] of totalSocByStart(this.visibleSeries, capacities)) {
+				const idx = index.get(this.timestampKey(new Date(start).getTime()));
+				if (idx !== undefined) values[idx] = soc;
+			}
+			return values;
 		},
 		entryColors(): string[] {
 			// Picker groups color per entity; pv/battery use darker steps of the group color.
@@ -408,6 +430,23 @@ export default defineComponent({
 				});
 			});
 
+			// Soc line on top of the bars, against the hidden percentage axis.
+			if (this.group === "battery") {
+				const socColor = colors.text || this.color;
+				result.push({
+					id: "soc",
+					name: this.$t("main.history.soc"),
+					type: "line",
+					yAxisIndex: 1,
+					data: this.socValues,
+					smooth: true,
+					symbol: "none",
+					lineStyle: { color: socColor, width: 2, type: "dashed" },
+					itemStyle: { color: socColor },
+					z: 3,
+				});
+			}
+
 			return result;
 		},
 		labelForTimestamp(): (t: number) => string {
@@ -451,6 +490,50 @@ export default defineComponent({
 				return (t) => this.fmtDayMonth(new Date(t));
 			}
 			return (t) => this.fmtMonthYear(new Date(t));
+		},
+		energyYAxis(): Record<string, unknown> {
+			return forecastYAxis({
+				...(this.isBidirectional && this.axisLimit > 0
+					? {
+							min: -this.axisLimit,
+							max: this.axisLimit,
+							interval: this.axisLimit / 2,
+						}
+					: this.useSmallUnit
+						? { max: this.axisLimit, interval: this.axisLimit / 4 }
+						: {}),
+				position: "right",
+				splitNumber: 3,
+				splitLine: {
+					showMinLine: true,
+					showMaxLine: true,
+					lineStyle: { color: colors.border || "" },
+				},
+				name: this.unit,
+				nameLocation: "end",
+				nameGap: 18,
+				nameTextStyle: {
+					color: colors.muted || "",
+					fontFamily: FONT_FAMILY,
+					fontSize: 10,
+					opacity: 0.75,
+					align: "left",
+					// Axis name anchors at the axis line; axis labels have a default
+					// 8px margin, so shift the name right by the same amount to land
+					// flush with the value labels' left edge.
+					padding: [0, 0, 0, 8],
+				},
+				axisLabel: {
+					color: colors.muted || "",
+					hideOverlap: true,
+					formatter: (v: number): string => {
+						const unit = this.useSmallUnit ? POWER_UNIT.W : POWER_UNIT.KW;
+						return this.period === PERIODS.DAY
+							? this.fmtW(v * 1000, unit, false, this.axisDigits)
+							: this.fmtWh(v * 1000, unit, false, this.axisDigits);
+					},
+				},
+			});
 		},
 		chartOption(): Record<string, unknown> {
 			const cats = this.categoryTimestamps;
@@ -561,7 +644,10 @@ export default defineComponent({
 						const nameByIdx = new Map(
 							this.series.map((s, i) => [s.paletteIndex ?? i, s.title])
 						);
-						const showName = this.series.length > 1 && this.focusedEntity === null;
+						const soc = this.socValues[first.dataIndex] ?? null;
+						const showTotal = this.series.length > 1 && this.focusedEntity === null;
+						// a soc row without names would be indistinguishable from an energy row
+						const showName = showTotal || soc != null;
 
 						// one unit for all rows, based on the largest individual value (not the total)
 						const rowValues = indices.map(
@@ -594,7 +680,7 @@ export default defineComponent({
 								values,
 							};
 						});
-						if (showName) {
+						if (showTotal) {
 							const sum = (key: "energy" | "returnEnergy") =>
 								rowValues.reduce((acc, t) => acc + t[key], 0);
 							rows.push({
@@ -602,6 +688,13 @@ export default defineComponent({
 								values: this.isBidirectional
 									? [formatValue(sum("energy")), formatValue(sum("returnEnergy"))]
 									: [formatValue(sum("energy") + sum("returnEnergy"))],
+								total: true,
+							});
+						}
+						if (soc != null) {
+							rows.push({
+								name: this.$t("main.history.soc"),
+								values: [this.fmtPercentage(soc)],
 								total: true,
 							});
 						}
@@ -631,48 +724,7 @@ export default defineComponent({
 						formatter: (_value: string, index: number) => formatLabel(cats[index] ?? 0),
 					},
 				},
-				yAxis: forecastYAxis({
-					...(this.isBidirectional && this.axisLimit > 0
-						? {
-								min: -this.axisLimit,
-								max: this.axisLimit,
-								interval: this.axisLimit / 2,
-							}
-						: this.useSmallUnit
-							? { max: this.axisLimit, interval: this.axisLimit / 4 }
-							: {}),
-					position: "right",
-					splitNumber: 3,
-					splitLine: {
-						showMinLine: true,
-						showMaxLine: true,
-						lineStyle: { color: colors.border || "" },
-					},
-					name: this.unit,
-					nameLocation: "end",
-					nameGap: 18,
-					nameTextStyle: {
-						color: colors.muted || "",
-						fontFamily: FONT_FAMILY,
-						fontSize: 10,
-						opacity: 0.75,
-						align: "left",
-						// Axis name anchors at the axis line; axis labels have a default
-						// 8px margin, so shift the name right by the same amount to land
-						// flush with the value labels' left edge.
-						padding: [0, 0, 0, 8],
-					},
-					axisLabel: {
-						color: colors.muted || "",
-						hideOverlap: true,
-						formatter: (v: number): string => {
-							const unit = this.useSmallUnit ? POWER_UNIT.W : POWER_UNIT.KW;
-							return this.period === PERIODS.DAY
-								? this.fmtW(v * 1000, unit, false, this.axisDigits)
-								: this.fmtWh(v * 1000, unit, false, this.axisDigits);
-						},
-					},
-				}),
+				yAxis: this.group === "battery" ? [this.energyYAxis, SOC_AXIS] : this.energyYAxis,
 				series: this.echartsSeries,
 			};
 		},

--- a/assets/js/components/History/soc.test.ts
+++ b/assets/js/components/History/soc.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vite-plus/test";
+import { batteryCapacities, totalSocByStart } from "./soc";
+import type { HistorySeries } from "./GroupChart.vue";
+import type { BatteryMeter } from "@/types/evcc";
+
+const t0 = "2026-01-01T00:00:00Z";
+const t1 = "2026-01-01T00:15:00Z";
+
+function series(title: string, socs: (number | null)[]): HistorySeries {
+  return {
+    title,
+    group: "battery",
+    data: socs.map((soc, i) => ({
+      start: i === 0 ? t0 : t1,
+      end: t1,
+      energy: 0,
+      returnEnergy: 0,
+      socTemp: soc,
+    })),
+  };
+}
+
+const devices = [
+  { title: "Home", capacity: 10 },
+  { name: "garage", capacity: 5 },
+] as BatteryMeter[];
+
+describe("totalSocByStart", () => {
+  it("weighs soc by capacity", () => {
+    const res = totalSocByStart(
+      [series("Home", [50, 40]), series("garage", [80, 60])],
+      batteryCapacities(devices)
+    );
+    // (50%*10 + 80%*5) / 15 = 60%, (40%*10 + 60%*5) / 15 = ~46.7%
+    expect(res.get(t0)).toBeCloseTo(60);
+    expect(res.get(t1)).toBeCloseTo(46.67, 1);
+  });
+
+  it("skips slots not reported by every battery", () => {
+    const res = totalSocByStart(
+      [series("Home", [50, 40]), series("garage", [80, null])],
+      batteryCapacities(devices)
+    );
+    expect(res.get(t0)).toBeCloseTo(60);
+    expect(res.has(t1)).toBe(false);
+  });
+
+  it("is empty without a capacity for every battery", () => {
+    const res = totalSocByStart(
+      [series("Home", [50]), series("unknown", [80])],
+      batteryCapacities(devices)
+    );
+    expect(res.size).toBe(0);
+  });
+});

--- a/assets/js/components/History/soc.ts
+++ b/assets/js/components/History/soc.ts
@@ -1,0 +1,43 @@
+// Combined battery soc from the history series, shared by the chart line and the legend.
+
+import type { BatteryMeter } from "@/types/evcc";
+import type { HistorySeries } from "./GroupChart.vue";
+
+// Configured capacity per battery, keyed like the history series title.
+export function batteryCapacities(devices: BatteryMeter[]): Map<string, number> {
+  const res = new Map<string, number>();
+  for (const d of devices) {
+    res.set(d.title || d.name || "", d.capacity || 0);
+  }
+  return res;
+}
+
+// Combined soc per slot start: stored energy over total capacity. Empty when a
+// capacity is missing, slots without soc for every battery are omitted.
+export function totalSocByStart(
+  series: HistorySeries[],
+  capacities: Map<string, number>
+): Map<string, number> {
+  const res = new Map<string, number>();
+  if (!series.length || series.some((s) => !capacities.get(s.title))) return res;
+
+  const acc = new Map<string, { stored: number; capacity: number; count: number }>();
+  for (const s of series) {
+    const capacity = capacities.get(s.title) || 0;
+    for (const slot of s.data) {
+      if (slot.socTemp == null) continue;
+      const e = acc.get(slot.start) ?? { stored: 0, capacity: 0, count: 0 };
+      e.stored += (slot.socTemp / 100) * capacity;
+      e.capacity += capacity;
+      e.count++;
+      acc.set(slot.start, e);
+    }
+  }
+
+  for (const [start, e] of acc) {
+    if (e.count === series.length && e.capacity > 0) {
+      res.set(start, (e.stored / e.capacity) * 100);
+    }
+  }
+  return res;
+}

--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -80,7 +80,11 @@
 						:to="displayTo"
 					/>
 					<LegendList
-						v-if="hasEntityLegend(group) || hasForecastLegend(group)"
+						v-if="
+							hasEntityLegend(group) ||
+							hasForecastLegend(group) ||
+							hasSocLegend(group)
+						"
 						class="mt-4 mb-0"
 						:legends="legendsForGroup(group)"
 						:device-colors="deviceColors"
@@ -107,6 +111,7 @@ import type { Legend } from "../components/Sessions/types";
 import type { DeviceColors } from "@/types/evcc";
 import { PERIODS } from "../components/Sessions/types";
 import { GROUP_ORDER, groupColor, hasColorPicker } from "../components/History/groups";
+import { batteryCapacities, totalSocByStart } from "../components/History/soc";
 import colors, { resolveColors, deviceColorMap, darken, batteryColor } from "../colors";
 import LegendList from "../components/Sessions/LegendList.vue";
 import DownloadButton from "../components/Helper/DownloadButton.vue";
@@ -301,6 +306,15 @@ export default defineComponent({
 				s.data.some((slot) => slot.energy !== 0 || slot.returnEnergy !== 0)
 			);
 		},
+		// Mean combined soc over the period, null when it cannot be derived.
+		batterySoc(): number | null {
+			const capacities = batteryCapacities(store.state.battery?.devices ?? []);
+			const values = [
+				...totalSocByStart(this.seriesByGroup["battery"] || [], capacities).values(),
+			];
+			if (!values.length) return null;
+			return values.reduce((acc, v) => acc + v, 0) / values.length;
+		},
 		forecastTotalLabel(): string {
 			const list = this.seriesByGroup["forecast"] || [];
 			let sum = 0;
@@ -369,6 +383,14 @@ export default defineComponent({
 					dim: focused !== null,
 				});
 			}
+			if (this.batterySoc !== null && group === "battery") {
+				list.push({
+					label: this.$t("main.history.soc") as string,
+					color: colors.text || groupColor(group),
+					value: this.fmtPercentage(this.batterySoc),
+					type: "line",
+				});
+			}
 			return list;
 		},
 		onLegendFocus(group: string, legend: Legend) {
@@ -385,6 +407,9 @@ export default defineComponent({
 		},
 		hasForecastLegend(group: string): boolean {
 			return group === "pv" && this.hasForecast && this.effectivePeriod === PERIODS.DAY;
+		},
+		hasSocLegend(group: string): boolean {
+			return group === "battery" && this.batterySoc !== null;
 		},
 		entityLegends(group: string): (Legend & { entityIndex: number })[] {
 			const list = this.displaySeries(group);

--- a/cmd/metrics_battery.go
+++ b/cmd/metrics_battery.go
@@ -7,6 +7,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/evcc-io/evcc/core/metrics"
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/evcc-io/evcc/util/templates"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -64,16 +67,66 @@ func runMetricsBattery(cmd *cobra.Command, args []string) {
 		log.FATAL.Fatal(err)
 	}
 
-	metricsWriteBatteryTable(os.Stdout, selected, metricsBatteryTotals(series))
+	socs, err := metrics.QuerySoc(metrics.Battery, from, to)
+	if err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	totals := metricsBatteryTotals(series)
+	capacities := metricsBatteryCapacities()
+
+	for _, e := range selected {
+		label := metricsEntityLabel(e)
+
+		t := totals[label]
+		if soc, ok := socs[label]; ok {
+			t.soc = &soc
+		}
+		t.capacity = capacities[e.Name]
+		totals[label] = t
+	}
+
+	metricsWriteBatteryTable(os.Stdout, selected, totals)
 	fmt.Fprintln(os.Stderr, "\nvalues in kWh")
 }
 
-// batteryTotals holds the accumulated charge and discharge energy of a battery.
+// metricsBatteryCapacities returns the statically configured capacity in kWh per
+// meter name, from the config file and the database. Plugin-provided capacities
+// cannot be resolved without connecting to the device and remain unknown.
+func metricsBatteryCapacities() map[string]float64 {
+	res := make(map[string]float64)
+
+	add := func(name string, other map[string]any) {
+		if v, err := cast.ToFloat64E(other["capacity"]); err == nil && v > 0 {
+			res[name] = v
+		}
+	}
+
+	for _, cc := range conf.Meters {
+		add(cc.Name, cc.Other)
+	}
+
+	configurable, err := config.ConfigurationsByClass(templates.Meter)
+	if err != nil {
+		log.FATAL.Fatal(err)
+	}
+
+	for _, cc := range configurable {
+		add(config.NameForID(cc.ID), cc.Data)
+	}
+
+	return res
+}
+
+// batteryTotals holds the accumulated charge and discharge energy of a battery
+// plus its last known soc and configured capacity.
 // For a battery entity charge is stored as import energy, discharge as export
 // energy (see core/site.go updateBatteryMeters).
 type batteryTotals struct {
 	charge    float64
 	discharge float64
+	soc       *float64 // last known soc, nil if not recorded
+	capacity  float64  // kWh, zero if not configured
 }
 
 // metricsBatteryTotals sums charge and discharge energy per battery title.
@@ -93,23 +146,60 @@ func metricsBatteryTotals(series []metrics.Series) map[string]batteryTotals {
 	return res
 }
 
+// metricsBatteryEfficiency formats the discharge/charge ratio, blank without charge.
+func metricsBatteryEfficiency(t batteryTotals) string {
+	if t.charge <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.1f%%", t.discharge/t.charge*100)
+}
+
+// metricsFormatSoc formats a soc value, blank when unknown.
+func metricsFormatSoc(soc *float64) string {
+	if soc == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.1f%%", *soc)
+}
+
 // metricsWriteBatteryTable renders one row per battery comparing charge and
-// discharge energy. Efficiency is the discharge/charge ratio, left blank when
-// no energy was charged.
+// discharge energy plus the last known soc. Efficiency is the discharge/charge
+// ratio, left blank when no energy was charged. For multiple batteries a total
+// row is added where soc is total stored energy over total capacity, left blank
+// unless soc and capacity are known for all of them.
 func metricsWriteBatteryTable(w io.Writer, selected []metrics.EntityInfo, totals map[string]batteryTotals) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "name\ttitle\tcharge\tdischarge\tefficiency")
+	fmt.Fprintln(tw, "name\ttitle\tcharge\tdischarge\tefficiency\tsoc")
+
+	var total batteryTotals
+	var stored float64
+	complete := true
 
 	for _, e := range selected {
 		t := totals[metricsEntityLabel(e)]
 
-		efficiency := ""
-		if t.charge > 0 {
-			efficiency = fmt.Sprintf("%.1f%%", t.discharge/t.charge*100)
+		total.charge += t.charge
+		total.discharge += t.discharge
+
+		if t.soc != nil && t.capacity > 0 {
+			stored += *t.soc / 100 * t.capacity
+			total.capacity += t.capacity
+		} else {
+			complete = false
 		}
 
-		fmt.Fprintf(tw, "%s\t%s\t%.3f\t%.3f\t%s\n",
-			e.Name, metricsEntityLabel(e), t.charge, t.discharge, efficiency)
+		fmt.Fprintf(tw, "%s\t%s\t%.3f\t%.3f\t%s\t%s\n",
+			e.Name, metricsEntityLabel(e), t.charge, t.discharge, metricsBatteryEfficiency(t), metricsFormatSoc(t.soc))
+	}
+
+	if len(selected) > 1 {
+		if complete && total.capacity > 0 {
+			soc := stored / total.capacity * 100
+			total.soc = &soc
+		}
+
+		fmt.Fprintf(tw, "total\t\t%.3f\t%.3f\t%s\t%s\n",
+			total.charge, total.discharge, metricsBatteryEfficiency(total), metricsFormatSoc(total.soc))
 	}
 
 	tw.Flush()

--- a/cmd/metrics_battery.go
+++ b/cmd/metrics_battery.go
@@ -67,11 +67,6 @@ func runMetricsBattery(cmd *cobra.Command, args []string) {
 		log.FATAL.Fatal(err)
 	}
 
-	socs, err := metrics.QuerySoc(metrics.Battery, from, to)
-	if err != nil {
-		log.FATAL.Fatal(err)
-	}
-
 	totals := metricsBatteryTotals(series)
 	capacities := metricsBatteryCapacities()
 
@@ -79,9 +74,6 @@ func runMetricsBattery(cmd *cobra.Command, args []string) {
 		label := metricsEntityLabel(e)
 
 		t := totals[label]
-		if soc, ok := socs[label]; ok {
-			t.soc = &soc
-		}
 		t.capacity = capacities[e.Name]
 		totals[label] = t
 	}
@@ -119,17 +111,28 @@ func metricsBatteryCapacities() map[string]float64 {
 }
 
 // batteryTotals holds the accumulated charge and discharge energy of a battery
-// plus its last known soc and configured capacity.
+// plus its recorded soc and configured capacity.
 // For a battery entity charge is stored as import energy, discharge as export
 // energy (see core/site.go updateBatteryMeters).
 type batteryTotals struct {
 	charge    float64
 	discharge float64
-	soc       *float64 // last known soc, nil if not recorded
-	capacity  float64  // kWh, zero if not configured
+	socSum    float64
+	socCount  int
+	capacity  float64 // kWh, zero if not configured
 }
 
-// metricsBatteryTotals sums charge and discharge energy per battery title.
+// soc returns the mean soc over the queried slots, nil if none was recorded.
+func (t batteryTotals) soc() *float64 {
+	if t.socCount == 0 {
+		return nil
+	}
+	soc := t.socSum / float64(t.socCount)
+	return &soc
+}
+
+// metricsBatteryTotals sums charge and discharge energy per battery title and
+// collects the soc of each slot.
 func metricsBatteryTotals(series []metrics.Series) map[string]batteryTotals {
 	res := make(map[string]batteryTotals)
 	for _, s := range series {
@@ -140,6 +143,10 @@ func metricsBatteryTotals(series []metrics.Series) map[string]batteryTotals {
 		for _, slot := range s.Data {
 			t.charge += slot.Energy
 			t.discharge += slot.ReturnEnergy
+			if slot.SocTemp != nil {
+				t.socSum += *slot.SocTemp
+				t.socCount++
+			}
 		}
 		res[s.Title] = t
 	}
@@ -163,10 +170,10 @@ func metricsFormatSoc(soc *float64) string {
 }
 
 // metricsWriteBatteryTable renders one row per battery comparing charge and
-// discharge energy plus the last known soc. Efficiency is the discharge/charge
-// ratio, left blank when no energy was charged. For multiple batteries a total
-// row is added where soc is total stored energy over total capacity, left blank
-// unless soc and capacity are known for all of them.
+// discharge energy plus the mean soc. Efficiency is the discharge/charge ratio,
+// left blank when no energy was charged. For multiple batteries a total row is
+// added where soc is total stored energy over total capacity, left blank unless
+// soc and capacity are known for all of them.
 func metricsWriteBatteryTable(w io.Writer, selected []metrics.EntityInfo, totals map[string]batteryTotals) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "name\ttitle\tcharge\tdischarge\tefficiency\tsoc")
@@ -181,25 +188,26 @@ func metricsWriteBatteryTable(w io.Writer, selected []metrics.EntityInfo, totals
 		total.charge += t.charge
 		total.discharge += t.discharge
 
-		if t.soc != nil && t.capacity > 0 {
-			stored += *t.soc / 100 * t.capacity
+		if soc := t.soc(); soc != nil && t.capacity > 0 {
+			stored += *soc / 100 * t.capacity
 			total.capacity += t.capacity
 		} else {
 			complete = false
 		}
 
 		fmt.Fprintf(tw, "%s\t%s\t%.3f\t%.3f\t%s\t%s\n",
-			e.Name, metricsEntityLabel(e), t.charge, t.discharge, metricsBatteryEfficiency(t), metricsFormatSoc(t.soc))
+			e.Name, metricsEntityLabel(e), t.charge, t.discharge, metricsBatteryEfficiency(t), metricsFormatSoc(t.soc()))
 	}
 
 	if len(selected) > 1 {
+		var totalSoc *float64
 		if complete && total.capacity > 0 {
 			soc := stored / total.capacity * 100
-			total.soc = &soc
+			totalSoc = &soc
 		}
 
 		fmt.Fprintf(tw, "total\t\t%.3f\t%.3f\t%s\t%s\n",
-			total.charge, total.discharge, metricsBatteryEfficiency(total), metricsFormatSoc(total.soc))
+			total.charge, total.discharge, metricsBatteryEfficiency(total), metricsFormatSoc(totalSoc))
 	}
 
 	tw.Flush()

--- a/cmd/metrics_battery_test.go
+++ b/cmd/metrics_battery_test.go
@@ -34,8 +34,8 @@ func TestMetricsWriteBatteryTable(t *testing.T) {
 		{Group: metrics.Battery, Name: "db:3"},
 	}
 	totals := map[string]batteryTotals{
-		"Home":      {charge: 10.0, discharge: 9.0},
-		"Hyper2000": {charge: 4.0, discharge: 3.0},
+		"Home":      {charge: 10.0, discharge: 9.0, soc: new(50.0), capacity: 10},
+		"Hyper2000": {charge: 4.0, discharge: 3.0, soc: new(80.0), capacity: 5},
 		// db:3 deliberately absent: no data in the timeframe
 	}
 
@@ -43,9 +43,10 @@ func TestMetricsWriteBatteryTable(t *testing.T) {
 	metricsWriteBatteryTable(&buf, selected, totals)
 
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	require.Len(t, lines, 4) // header + 3 rows
+	require.Len(t, lines, 5) // header + 3 rows + total
 
 	require.Contains(t, lines[0], "efficiency")
+	require.Contains(t, lines[0], "soc")
 
 	// db:1: stored title, efficiency = discharge/charge
 	require.Contains(t, lines[1], "Home")
@@ -65,4 +66,32 @@ func TestMetricsWriteBatteryTable(t *testing.T) {
 	require.Equal(t, "db:3", f[1]) // title column falls back to name
 	require.Contains(t, lines[3], "0.000")
 	require.NotContains(t, lines[3], "%")
+
+	// total: energy summed, soc blank as db:3 has neither soc nor capacity
+	require.Contains(t, lines[4], "total")
+	require.Contains(t, lines[4], "14.000")
+	require.Contains(t, lines[4], "12.000")
+	require.Contains(t, lines[4], "85.7%")
+	require.Equal(t, 1, strings.Count(lines[4], "%")) // efficiency only, no soc
+}
+
+func TestMetricsWriteBatteryTableTotalSoc(t *testing.T) {
+	selected := []metrics.EntityInfo{
+		{Group: metrics.Battery, Name: "db:1", Title: "Home"},
+		{Group: metrics.Battery, Name: "db:2", Title: "Garage"},
+	}
+	totals := map[string]batteryTotals{
+		"Home":   {soc: new(50.0), capacity: 10}, // 5 kWh
+		"Garage": {soc: new(80.0), capacity: 5},  // 4 kWh
+	}
+
+	var buf bytes.Buffer
+	metricsWriteBatteryTable(&buf, selected, totals)
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 4) // header + 2 rows + total
+
+	// stored energy over total capacity: 9 kWh / 15 kWh
+	require.Contains(t, lines[3], "total")
+	require.Contains(t, lines[3], "60.0%")
 }

--- a/cmd/metrics_battery_test.go
+++ b/cmd/metrics_battery_test.go
@@ -12,8 +12,8 @@ import (
 func TestMetricsBatteryTotals(t *testing.T) {
 	series := []metrics.Series{
 		{Group: metrics.Battery, Title: "bat", Data: []metrics.Slot{
-			{Energy: 1.0, ReturnEnergy: 0.4},
-			{Energy: 2.0, ReturnEnergy: 1.6},
+			{Energy: 1.0, ReturnEnergy: 0.4, SocTemp: new(40.0)},
+			{Energy: 2.0, ReturnEnergy: 1.6, SocTemp: new(70.0)},
 		}},
 		// non-battery series must be ignored
 		{Group: metrics.Grid, Title: "grid", Data: []metrics.Slot{
@@ -25,6 +25,7 @@ func TestMetricsBatteryTotals(t *testing.T) {
 	require.Len(t, totals, 1)
 	require.InDelta(t, 3.0, totals["bat"].charge, 0.001)
 	require.InDelta(t, 2.0, totals["bat"].discharge, 0.001)
+	require.InDelta(t, 55.0, *totals["bat"].soc(), 0.001) // mean of both slots
 }
 
 func TestMetricsWriteBatteryTable(t *testing.T) {
@@ -34,8 +35,8 @@ func TestMetricsWriteBatteryTable(t *testing.T) {
 		{Group: metrics.Battery, Name: "db:3"},
 	}
 	totals := map[string]batteryTotals{
-		"Home":      {charge: 10.0, discharge: 9.0, soc: new(50.0), capacity: 10},
-		"Hyper2000": {charge: 4.0, discharge: 3.0, soc: new(80.0), capacity: 5},
+		"Home":      {charge: 10.0, discharge: 9.0, socSum: 50, socCount: 1, capacity: 10},
+		"Hyper2000": {charge: 4.0, discharge: 3.0, socSum: 80, socCount: 1, capacity: 5},
 		// db:3 deliberately absent: no data in the timeframe
 	}
 
@@ -81,8 +82,8 @@ func TestMetricsWriteBatteryTableTotalSoc(t *testing.T) {
 		{Group: metrics.Battery, Name: "db:2", Title: "Garage"},
 	}
 	totals := map[string]batteryTotals{
-		"Home":   {soc: new(50.0), capacity: 10}, // 5 kWh
-		"Garage": {soc: new(80.0), capacity: 5},  // 4 kWh
+		"Home":   {socSum: 40 + 60, socCount: 2, capacity: 10}, // mean 50%, 5 kWh
+		"Garage": {socSum: 80, socCount: 1, capacity: 5},       // 4 kWh
 	}
 
 	var buf bytes.Buffer

--- a/core/metrics/db_history.go
+++ b/core/metrics/db_history.go
@@ -91,8 +91,8 @@ func QueryEnergy(from, to time.Time, aggregate string, grouped bool, filter ...E
 		IsTemp       bool
 	}
 
-	// soc_temp reports the bucket's first slot; omitted for grouped sums
-	socCols := `, m.soc_temp AS soc_temp, e.is_temp AS is_temp`
+	// soc_temp is averaged over the bucket; omitted for grouped sums
+	socCols := `, AVG(m.soc_temp) AS soc_temp, e.is_temp AS is_temp`
 	if grouped {
 		socCols = ``
 	}
@@ -145,42 +145,6 @@ func QueryEnergy(from, to time.Time, aggregate string, grouped bool, filter ...E
 			ReturnEnergy: roundEnergy(r.ReturnEnergy),
 			SocTemp:      r.SocTemp,
 		})
-	}
-
-	return res, nil
-}
-
-// QuerySoc returns the last stored soc per entity title of the given group in
-// the given timeframe. Entities without soc data are omitted.
-func QuerySoc(group string, from, to time.Time) (map[string]float64, error) {
-	type row struct {
-		Title string
-		Soc   float64
-	}
-
-	// bare soc_temp column belongs to the MAX(m.ts) row (sqlite bare column rule)
-	tx := db.Instance.Table("meters m").
-		Select(`COALESCE(NULLIF(e.title,''), e.name) AS title, MAX(m.ts), m.soc_temp AS soc`).
-		Joins("JOIN entities e ON m.meter = e.id").
-		Where(`e."group" = ?`, group).
-		Where("m.soc_temp IS NOT NULL").
-		Group("e.id")
-
-	if !from.IsZero() {
-		tx = tx.Where("m.ts >= ?", from.Unix())
-	}
-	if !to.IsZero() {
-		tx = tx.Where("m.ts < ?", to.Unix())
-	}
-
-	var rows []row
-	if err := tx.Scan(&rows).Error; err != nil {
-		return nil, err
-	}
-
-	res := make(map[string]float64, len(rows))
-	for _, r := range rows {
-		res[r.Title] = r.Soc
 	}
 
 	return res, nil

--- a/core/metrics/db_history.go
+++ b/core/metrics/db_history.go
@@ -150,6 +150,42 @@ func QueryEnergy(from, to time.Time, aggregate string, grouped bool, filter ...E
 	return res, nil
 }
 
+// QuerySoc returns the last stored soc per entity title of the given group in
+// the given timeframe. Entities without soc data are omitted.
+func QuerySoc(group string, from, to time.Time) (map[string]float64, error) {
+	type row struct {
+		Title string
+		Soc   float64
+	}
+
+	// bare soc_temp column belongs to the MAX(m.ts) row (sqlite bare column rule)
+	tx := db.Instance.Table("meters m").
+		Select(`COALESCE(NULLIF(e.title,''), e.name) AS title, MAX(m.ts), m.soc_temp AS soc`).
+		Joins("JOIN entities e ON m.meter = e.id").
+		Where(`e."group" = ?`, group).
+		Where("m.soc_temp IS NOT NULL").
+		Group("e.id")
+
+	if !from.IsZero() {
+		tx = tx.Where("m.ts >= ?", from.Unix())
+	}
+	if !to.IsZero() {
+		tx = tx.Where("m.ts < ?", to.Unix())
+	}
+
+	var rows []row
+	if err := tx.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]float64, len(rows))
+	for _, r := range rows {
+		res[r.Title] = r.Soc
+	}
+
+	return res, nil
+}
+
 // hasReturnEnergy reports whether a group's CSV export includes a returnEnergy
 // column. Only the bidirectional groups (grid, battery) do; the rest emit a
 // single energy column.

--- a/core/metrics/db_history_test.go
+++ b/core/metrics/db_history_test.go
@@ -177,16 +177,26 @@ func TestQueryEnergySoc(t *testing.T) {
 	base := time.Date(2026, 4, 15, 16, 0, 0, 0, time.Now().Location())
 	require.NoError(t, persist(e, base, 1, 0, new(80.0), false))
 	require.NoError(t, persist(e, base.Add(15*time.Minute), 1, 0, new(70.0), false))
+	require.NoError(t, persist(e, base.Add(30*time.Minute), 1, 0, nil, false)) // excluded from the average
 
 	from := base.Add(-time.Hour).UTC()
 	to := base.Add(time.Hour).UTC()
 
-	// hourly bucket reports the first slot's snapshot, not an average
-	res, err := QueryEnergy(from, to, "hour", false)
+	// 15m buckets report the slot snapshot
+	res, err := QueryEnergy(from, to, "15m", false)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Len(t, res[0].Data, 3)
+	require.Equal(t, 80.0, *res[0].Data[0].SocTemp)
+	require.Equal(t, 70.0, *res[0].Data[1].SocTemp)
+	require.Nil(t, res[0].Data[2].SocTemp)
+
+	// coarser buckets report the average of the slots reporting soc
+	res, err = QueryEnergy(from, to, "hour", false)
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	require.Len(t, res[0].Data, 1)
-	require.Equal(t, 80.0, *res[0].Data[0].SocTemp)
+	require.Equal(t, 75.0, *res[0].Data[0].SocTemp)
 	require.False(t, res[0].IsTemp) // battery: value is soc
 
 	// grouped sums omit the per-entity snapshot

--- a/core/metrics/db_test.go
+++ b/core/metrics/db_test.go
@@ -70,39 +70,6 @@ func TestQueryEnergyUTCFilter(t *testing.T) {
 	require.InDelta(t, 2, res[0].Data[1].ReturnEnergy, 0.001)
 }
 
-func TestQuerySoc(t *testing.T) {
-	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
-	require.NoError(t, SetupSchema())
-
-	bat := entity{Id: 2, Name: "db:12", Group: Battery, Title: "Home"}
-	require.NoError(t, db.Instance.Create(&bat).Error)
-	grid := entity{Id: 3, Name: Grid, Group: Grid}
-	require.NoError(t, db.Instance.Create(&grid).Error)
-
-	loc := time.Now().Location()
-	base := time.Date(2026, 4, 15, 16, 0, 0, 0, loc)
-
-	require.NoError(t, persist(bat, base, 1, 0, new(30.0), false))
-	require.NoError(t, persist(bat, base.Add(time.Hour), 1, 0, new(70.0), false))
-	require.NoError(t, persist(bat, base.Add(2*time.Hour), 1, 0, nil, false)) // no soc: must not win
-	require.NoError(t, persist(grid, base, 1, 0, nil, false))
-
-	// last soc in range
-	res, err := QuerySoc(Battery, base.Add(-time.Hour), base.Add(3*time.Hour))
-	require.NoError(t, err)
-	require.Equal(t, map[string]float64{"Home": 70}, res)
-
-	// range excluding the later slot
-	res, err = QuerySoc(Battery, base.Add(-time.Hour), base.Add(time.Hour))
-	require.NoError(t, err)
-	require.Equal(t, map[string]float64{"Home": 30}, res)
-
-	// other group without soc
-	res, err = QuerySoc(Grid, base.Add(-time.Hour), base.Add(3*time.Hour))
-	require.NoError(t, err)
-	require.Empty(t, res)
-}
-
 func TestQueryEnergyGrouped(t *testing.T) {
 	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
 	require.NoError(t, SetupSchema())

--- a/core/metrics/db_test.go
+++ b/core/metrics/db_test.go
@@ -70,6 +70,39 @@ func TestQueryEnergyUTCFilter(t *testing.T) {
 	require.InDelta(t, 2, res[0].Data[1].ReturnEnergy, 0.001)
 }
 
+func TestQuerySoc(t *testing.T) {
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	bat := entity{Id: 2, Name: "db:12", Group: Battery, Title: "Home"}
+	require.NoError(t, db.Instance.Create(&bat).Error)
+	grid := entity{Id: 3, Name: Grid, Group: Grid}
+	require.NoError(t, db.Instance.Create(&grid).Error)
+
+	loc := time.Now().Location()
+	base := time.Date(2026, 4, 15, 16, 0, 0, 0, loc)
+
+	require.NoError(t, persist(bat, base, 1, 0, new(30.0), false))
+	require.NoError(t, persist(bat, base.Add(time.Hour), 1, 0, new(70.0), false))
+	require.NoError(t, persist(bat, base.Add(2*time.Hour), 1, 0, nil, false)) // no soc: must not win
+	require.NoError(t, persist(grid, base, 1, 0, nil, false))
+
+	// last soc in range
+	res, err := QuerySoc(Battery, base.Add(-time.Hour), base.Add(3*time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, map[string]float64{"Home": 70}, res)
+
+	// range excluding the later slot
+	res, err = QuerySoc(Battery, base.Add(-time.Hour), base.Add(time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, map[string]float64{"Home": 30}, res)
+
+	// other group without soc
+	res, err = QuerySoc(Grid, base.Add(-time.Hour), base.Add(3*time.Hour))
+	require.NoError(t, err)
+	require.Empty(t, res)
+}
+
 func TestQueryEnergyGrouped(t *testing.T) {
 	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
 	require.NoError(t, SetupSchema())

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1362,6 +1362,7 @@
         "pv": "Erzeugung"
       },
       "otherConsumers": "Andere",
+      "soc": "Ladestand",
       "title": "Historie"
     },
     "loadpoint": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1372,6 +1372,7 @@
         "pv": "Production"
       },
       "otherConsumers": "Others",
+      "soc": "SoC",
       "title": "History"
     },
     "loadpoint": {


### PR DESCRIPTION
fixes #32336

Adds soc to the battery history, in the UI and in `evcc metrics battery`. Where more than one battery is involved the combined soc is stored energy over total capacity, as the site computes it at runtime.

`QueryEnergy` now averages `soc_temp` over the bucket instead of taking the first slot's snapshot. At 15m resolution that is the slot value as before, coarser buckets get the mean.

- history battery chart draws the combined soc as a line, with the period mean in the legend and the slot value in the tooltip
- `metrics battery` gains a `soc` column plus a `total` row summing charge and discharge with its own efficiency
- soc stays blank unless soc and capacity are known for every battery. The CLI reads capacity from the static configuration, so plugin-provided capacities remain unknown

![battery history, day](https://gist.githubusercontent.com/andig/2e7969489f60a9f243d0da139898d05f/raw/d4aa977d99e42a64f103a6b2359c8c4c79fce94b/history-battery-day.png)

![battery history, month](https://gist.githubusercontent.com/andig/2e7969489f60a9f243d0da139898d05f/raw/1a8773851cc5eb5d58d5e705db26ea3e1b376d64/history-battery-month.png)

![evcc metrics battery](https://gist.githubusercontent.com/andig/2e7969489f60a9f243d0da139898d05f/raw/3663ec8a92bd287d8b6e1ad94c18aadbbc40d474/metrics-battery-soc.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
