### PR TITLE
HEMS: show external limit warning only when the limit binds

### DIFF
--- a/assets/js/components/HemsWarning.test.ts
+++ b/assets/js/components/HemsWarning.test.ts
@@ -1,0 +1,60 @@
+import { mount, config } from "@vue/test-utils";
+import { describe, expect, test } from "vite-plus/test";
+import HemsWarning from "./HemsWarning.vue";
+import type { HemsStatus } from "@/types/evcc";
+import en from "../../../i18n/en.json";
+
+// minimal $t that walks en.json so tests assert on real English text
+const lookup = (key: string): string | undefined => {
+  const v = key.split(".").reduce<any>((o, k) => o?.[k], en);
+  return typeof v === "string" ? v : undefined;
+};
+config.global.mocks["$t"] = (key: string) => lookup(key) ?? key;
+config.global.mocks["$i18n"] = { locale: "de-DE" };
+
+const banner = (status: HemsStatus, gridPower: number) => {
+  const wrapper = mount(HemsWarning, { props: { status, gridPower } });
+  return wrapper.find("[data-testid=hems-warning]");
+};
+
+const DIMMED: HemsStatus = { dimmed: true, maxConsumptionPower: 4200 };
+const CURTAILED: HemsStatus = { curtailed: 60, maxProductionPower: 6000 };
+
+describe("visibility", () => {
+  test("hidden without limits", () => {
+    expect(banner({ dimmed: false, curtailed: 100 }, 4000).exists()).eq(false);
+  });
+
+  test("hidden while the limit is not approached", () => {
+    expect(banner(DIMMED, 2939).exists()).eq(false); // 69%
+    expect(banner(CURTAILED, -4199).exists()).eq(false); // 69%
+  });
+
+  test("visible from 70% of the limit", () => {
+    expect(banner(DIMMED, 2940).text()).contains("Consumption");
+    expect(banner(CURTAILED, -4200).text()).contains("Feed-in");
+  });
+
+  test("only the approached limit is shown", () => {
+    const both = { ...DIMMED, ...CURTAILED };
+    expect(banner(both, 4000).text()).not.contains("Feed-in");
+    expect(banner(both, -6000).text()).not.contains("Consumption");
+  });
+
+  test("a zero limit is exhausted by any power in its direction", () => {
+    const full: HemsStatus = { curtailed: 0, maxProductionPower: 0 };
+    expect(banner(full, 0).exists()).eq(false);
+    expect(banner(full, -1).text()).contains("0,0 kW");
+  });
+});
+
+describe("severity", () => {
+  test("warning below 90% of the limit", () => {
+    expect(banner(DIMMED, 3779).classes()).not.contains("limit-stripe--critical");
+  });
+
+  test("critical from 90% of the limit", () => {
+    expect(banner(DIMMED, 3780).classes()).contains("limit-stripe--critical");
+    expect(banner(CURTAILED, -5400).classes()).contains("limit-stripe--critical");
+  });
+});

--- a/assets/js/components/HemsWarning.vue
+++ b/assets/js/components/HemsWarning.vue
@@ -1,20 +1,21 @@
 <template>
 	<div
-		v-if="consumptionLimit || feedInLimit"
+		v-if="limits.length"
 		class="limit-stripe small rounded-4 py-2 px-3 mb-3 d-sm-flex flex-wrap align-items-baseline justify-content-between gap-sm-2"
+		:class="{ 'limit-stripe--critical': critical }"
 		data-testid="hems-warning"
 	>
-		<div class="fw-bold text-uppercase text-warning mb-2 mb-sm-0">
+		<div class="limit-title fw-bold text-uppercase mb-2 mb-sm-0">
 			{{ $t("main.hemsWarning.title") }}
 		</div>
 		<div class="d-flex flex-column gap-1 flex-sm-row gap-sm-4">
-			<div v-if="consumptionLimit" class="d-flex align-items-baseline gap-2">
-				<span class="fw-medium">{{ $t("main.hemsWarning.consumption") }}</span>
-				<span class="fw-bold tabular text-nowrap">&le; {{ consumptionLimit }}</span>
-			</div>
-			<div v-if="feedInLimit" class="d-flex align-items-baseline gap-2">
-				<span class="fw-medium">{{ $t("main.hemsWarning.feedIn") }}</span>
-				<span class="fw-bold tabular text-nowrap">&le; {{ feedInLimit }}</span>
+			<div
+				v-for="limit in limits"
+				:key="limit.name"
+				class="d-flex align-items-baseline gap-2"
+			>
+				<span class="fw-medium">{{ $t(`main.hemsWarning.${limit.name}`) }}</span>
+				<span class="fw-bold tabular text-nowrap">&le; {{ limit.value }}</span>
 			</div>
 		</div>
 	</div>
@@ -25,23 +26,48 @@ import { defineComponent, type PropType } from "vue";
 import type { HemsStatus } from "@/types/evcc";
 import formatter, { POWER_UNIT } from "@/mixins/formatter";
 
+// share of the limit that has to be used before the limit is shown at all
+const WARNING_DEGREE = 0.7;
+// share of the limit that makes it critical
+const CRITICAL_DEGREE = 0.9;
+
+interface Limit {
+	name: string;
+	value: string;
+	degree: number;
+}
+
 export default defineComponent({
 	name: "HemsWarning",
 	mixins: [formatter],
 	props: {
 		status: { type: Object as PropType<HemsStatus> },
+		gridPower: { type: Number, default: 0 },
 	},
 	computed: {
-		consumptionLimit(): string | null {
-			return this.status?.dimmed && this.status.maxConsumptionPower
-				? this.fmtW(this.status.maxConsumptionPower, POWER_UNIT.KW)
-				: null;
+		limits(): Limit[] {
+			const status = this.status;
+			if (!status) {
+				return [];
+			}
+			const result: Limit[] = [];
+			if (status.dimmed && status.maxConsumptionPower !== undefined) {
+				result.push(this.limit("consumption", status.maxConsumptionPower, this.gridPower));
+			}
+			if ((status.curtailed ?? 100) < 100 && status.maxProductionPower !== undefined) {
+				result.push(this.limit("feedIn", status.maxProductionPower, -this.gridPower));
+			}
+			return result.filter(({ degree }) => degree >= WARNING_DEGREE);
 		},
-		feedInLimit(): string | null {
-			return (this.status?.curtailed ?? 100) < 100 &&
-				this.status?.maxProductionPower !== undefined
-				? this.fmtW(this.status.maxProductionPower, POWER_UNIT.KW)
-				: null;
+		critical(): boolean {
+			return this.limits.some(({ degree }) => degree >= CRITICAL_DEGREE);
+		},
+	},
+	methods: {
+		limit(name: string, limit: number, power: number): Limit {
+			// a zero limit is fully used as soon as power flows in its direction
+			const degree = limit > 0 ? power / limit : Number(power > 0);
+			return { name, value: this.fmtW(limit, POWER_UNIT.KW), degree };
 		},
 	},
 });
@@ -50,13 +76,22 @@ export default defineComponent({
 <style scoped>
 /* animated throttle stripe, echoes the charging bar */
 .limit-stripe {
-	background-color: color-mix(in srgb, var(--evcc-orange) 9%, transparent);
+	--limit-color: var(--evcc-dark-yellow);
+	background-color: color-mix(in srgb, var(--limit-color) 9%, transparent);
 	background-image: repeating-linear-gradient(
 		-45deg,
-		color-mix(in srgb, var(--evcc-orange) 20%, transparent) 0 8px,
+		color-mix(in srgb, var(--limit-color) 20%, transparent) 0 8px,
 		transparent 8px 20px
 	);
 	background-size: 28.28px 28.28px;
+}
+
+.limit-stripe--critical {
+	--limit-color: var(--evcc-orange);
+}
+
+.limit-title {
+	color: var(--limit-color);
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/assets/js/components/Site/Site.vue
+++ b/assets/js/components/Site/Site.vue
@@ -2,7 +2,7 @@
 	<div class="d-flex flex-column site safe-area-inset">
 		<div class="container px-4 top-area">
 			<TopHeader :title="headerTitle" :notifications="notifications" />
-			<HemsWarning :status="hems?.status" />
+			<HemsWarning :status="hems?.status" :grid-power="gridPower" />
 			<Energyflow v-if="!setupRequired && !hasFatalError" v-bind="energyflow" />
 		</div>
 		<div class="d-flex flex-column justify-content-between content-area">

--- a/tests/hems.spec.ts
+++ b/tests/hems.spec.ts
@@ -289,9 +289,9 @@ w4:${signalSource("w4")}`
     await expect(hint).toHaveText("Consumption limited");
     await expect(pvBanner).not.toBeVisible();
 
-    // main screen shows the warning
+    // main screen stays quiet, the grid power is far below the limit
     await page.goto("/#/");
-    await expect(page.getByTestId("hems-warning")).toContainText("4.2 kW");
+    await expect(page.getByTestId("hems-warning")).not.toBeVisible();
     await page.goto("/#/config");
 
     // full curtailment (W3): feed-in limited to 0
@@ -307,12 +307,6 @@ w4:${signalSource("w4")}`
     await setSignal("w3", false);
     await setSignal("s1", true);
     await expect(hems).toContainText(["Feed-in limit", "6.0 kW"].join(""));
-
-    // main screen shows the production warning
-    await page.goto("/#/");
-    await expect(page.getByTestId("hems-warning")).toContainText(["Feed-in", "≤ 6.0 kW"].join(""));
-    await expect(page.getByTestId("hems-warning")).not.toContainText("Consumption");
-    await page.goto("/#/config");
 
     // partial curtailment (S2): 30% of 10 kW
     await setSignal("s1", false);


### PR DESCRIPTION
fixes #32345

The external limit banner was shown whenever a HEMS limit was configured, which is permanent for legally imposed limits. It now compares the grid power against the active limit and only appears once the limit is actually approached: hidden below 70 %, yellow from 70 %, orange from 90 %. Consumption and feed-in limits are evaluated separately, each row appears on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)