### PR TITLE
Loadpoint: consider load management in phase scaling

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1466,6 +1466,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		waiting = true
 	}
 
+	// limit max current by circuit when scaling down
 	if lp.circuit != nil {
 		maxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), maxCurrent)
 	}
@@ -1474,6 +1475,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 	target1pCurrent := powerToCurrent(availablePower, 1)
 	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent
 
+	// limit max power by circuit when scaling up
 	if scalable && lp.circuit != nil {
 		scaledMinPower := currentToPower(minCurrent, maxPhases)
 		scaledMaxPower := lp.circuit.ValidatePower(lp.chargePower, scaledMinPower)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -931,8 +931,9 @@ func (lp *Loadpoint) roundedCurrent(current float64) float64 {
 	return current
 }
 
-// actualMaxPhaseCurrent returns the maximum of all phase currents
-func (lp *Loadpoint) actualMaxPhaseCurrent() float64 {
+// actualMaxChargeCurrent returns the maximum of all phase currents.
+// If currents not measured falls back to offered current.
+func (lp *Loadpoint) actualMaxChargeCurrent() float64 {
 	if lp.chargeCurrents != nil {
 		return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
 	}
@@ -948,7 +949,7 @@ func (lp *Loadpoint) setLimit(current float64) error {
 
 	// apply circuit limits
 	if lp.circuit != nil {
-		currentLimit := lp.circuit.ValidateCurrent(lp.actualMaxPhaseCurrent(), current)
+		currentLimit := lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), current)
 
 		activePhases := lp.ActivePhases()
 		powerLimit := lp.circuit.ValidatePower(lp.chargePower, currentToPower(current, activePhases))
@@ -1465,14 +1466,13 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		waiting = true
 	}
 
-	scaleMaxCurrent := maxCurrent
 	if lp.circuit != nil {
-		scaleMaxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxPhaseCurrent(), maxCurrent)
+		maxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), maxCurrent)
 	}
 
 	maxPhases := lp.MaxActivePhases()
 	target1pCurrent := powerToCurrent(availablePower, 1)
-	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > scaleMaxCurrent
+	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent
 
 	if scalable && lp.circuit != nil {
 		scaledMinPower := currentToPower(minCurrent, maxPhases)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1377,18 +1377,30 @@ func (lp *Loadpoint) scalePhases(phases int) error {
 	return nil
 }
 
+// circuitAllowsPhases checks if the circuit power limit allows charging at minCurrent on phases
+func (lp *Loadpoint) circuitAllowsPhases(phases int, minCurrent float64) bool {
+	if lp.circuit == nil {
+		return true
+	}
+
+	minPower := currentToPower(minCurrent, phases)
+	powerLimit := lp.circuit.ValidatePower(lp.chargePower, minPower)
+	if powerLimit < minPower {
+		lp.log.DEBUG.Printf("available circuit power %.0fW < %.0fW min %dp power", powerLimit, minPower, phases)
+		return false
+	}
+
+	return true
+}
+
 // fastCharging scales to 3p if available and sets maximum current
 func (lp *Loadpoint) fastCharging() error {
 	if lp.hasPhaseSwitching() {
 		phases := 3
 
 		// load management limit active
-		if lp.circuit != nil {
-			minPower3p := currentToPower(lp.effectiveMinCurrent(), 3)
-			if powerLimit := lp.circuit.ValidatePower(lp.chargePower, minPower3p); powerLimit < minPower3p {
-				phases = 1
-				lp.log.DEBUG.Printf("fast charging: scaled to 1p to match %.0fW available circuit power", powerLimit)
-			}
+		if !lp.circuitAllowsPhases(3, lp.effectiveMinCurrent()) {
+			phases = 1
 		}
 
 		// ignore api.ErrNotAvailable: the phase switch could not be performed
@@ -1433,12 +1445,20 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 	var waiting bool
 	activePhases := lp.ActivePhases()
 	availablePower := lp.chargePower - sitePower
-	scalable := (sitePower > 0 || !lp.enabled) && activePhases > 1 && lp.phasesConfigured < 3
+	scalable := activePhases > 1 && lp.phasesConfigured < 3
+
+	if scalable {
+		insufficient := (sitePower > 0 || !lp.enabled) && powerToCurrent(availablePower, activePhases) < minCurrent
+		if insufficient {
+			lp.log.DEBUG.Printf("available power %.0fW < %.0fW min %dp threshold", availablePower, float64(activePhases)*Voltage*minCurrent, activePhases)
+		}
+
+		// scaling down also frees load management headroom for min power on activePhases
+		scalable = insufficient || !lp.circuitAllowsPhases(activePhases, minCurrent)
+	}
 
 	// scale down phases
-	if targetCurrent := powerToCurrent(availablePower, activePhases); targetCurrent < minCurrent && scalable {
-		lp.log.DEBUG.Printf("available power %.0fW < %.0fW min %dp threshold", availablePower, float64(activePhases)*Voltage*minCurrent, activePhases)
-
+	if scalable {
 		if !lp.charging() { // scale immediately if not charging
 			lp.phaseTimer = elapsed
 		}
@@ -1466,23 +1486,17 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		waiting = true
 	}
 
-	// limit max current by circuit when scaling down
+	// limit max current by circuit before comparing against the 1p target
 	if lp.circuit != nil {
 		maxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), maxCurrent)
 	}
 
 	maxPhases := lp.MaxActivePhases()
 	target1pCurrent := powerToCurrent(availablePower, 1)
-	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent
 
-	// limit max power by circuit when scaling up
-	if scalable && lp.circuit != nil {
-		scaledMinPower := currentToPower(minCurrent, maxPhases)
-		scaledMaxPower := lp.circuit.ValidatePower(lp.chargePower, scaledMinPower)
-		if scaledMaxPower < scaledMinPower {
-			scalable = false
-		}
-	}
+	// scaling up is pointless unless load management allows min current and power on maxPhases
+	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent &&
+		maxCurrent >= minCurrent && lp.circuitAllowsPhases(maxPhases, minCurrent)
 
 	// scale up phases
 	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -931,20 +931,24 @@ func (lp *Loadpoint) roundedCurrent(current float64) float64 {
 	return current
 }
 
+// actualMaxPhaseCurrent returns the maximum of all phase currents
+func (lp *Loadpoint) actualMaxPhaseCurrent() float64 {
+	if lp.chargeCurrents != nil {
+		return max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
+	}
+	if lp.charging() {
+		return lp.offeredCurrent
+	}
+	return 0
+}
+
 // setLimit applies charger current limits and enables/disables accordingly
 func (lp *Loadpoint) setLimit(current float64) error {
 	current = lp.roundedCurrent(current)
 
 	// apply circuit limits
 	if lp.circuit != nil {
-		var actualCurrent float64
-		if lp.chargeCurrents != nil {
-			actualCurrent = max(lp.chargeCurrents[0], lp.chargeCurrents[1], lp.chargeCurrents[2])
-		} else if lp.charging() {
-			actualCurrent = lp.offeredCurrent
-		}
-
-		currentLimit := lp.circuit.ValidateCurrent(actualCurrent, current)
+		currentLimit := lp.circuit.ValidateCurrent(lp.actualMaxPhaseCurrent(), current)
 
 		activePhases := lp.ActivePhases()
 		powerLimit := lp.circuit.ValidatePower(lp.chargePower, currentToPower(current, activePhases))
@@ -1461,9 +1465,22 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		waiting = true
 	}
 
+	scaleMaxCurrent := maxCurrent
+	if lp.circuit != nil {
+		scaleMaxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxPhaseCurrent(), maxCurrent)
+	}
+
 	maxPhases := lp.MaxActivePhases()
 	target1pCurrent := powerToCurrent(availablePower, 1)
-	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent
+	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > scaleMaxCurrent
+
+	if scalable && lp.circuit != nil {
+		scaledMinPower := currentToPower(minCurrent, maxPhases)
+		scaledMaxPower := lp.circuit.ValidatePower(lp.chargePower, scaledMinPower)
+		if scaledMaxPower < scaledMinPower {
+			scalable = false
+		}
+	}
 
 	// scale up phases
 	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1486,7 +1486,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		waiting = true
 	}
 
-	// limit max current by circuit before comparing against the 1p target
+	// load management may cap the 1p current far below the theoretical maximum
 	if lp.circuit != nil {
 		maxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), maxCurrent)
 	}

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -695,5 +695,136 @@ func TestUpdatePhaseSwitchNotAvailable(t *testing.T) {
 
 	// second cycle must not attempt the switch again (Phases1p3p .Times(1))
 	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil)
-	require.Equal(t, 3, lp.GetPhases())
+}
+
+func TestPvScalePhases_CircuitLimit(t *testing.T) {
+	Voltage = 230
+	clock := clock.NewMock()
+	ctrl := gomock.NewController(t)
+
+	// A charger that can switch phases and has a max current of 32A
+	plainCharger := api.NewMockCharger(ctrl)
+	plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
+	plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
+
+	phaseCharger := api.NewMockPhaseSwitcher(ctrl)
+	phaseCharger.EXPECT().Phases1p3p(gomock.Any()).Return(nil).AnyTimes()
+
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Phases().Return(3).AnyTimes()
+	vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
+	vehicle.EXPECT().Features().Return(nil).AnyTimes()
+
+	// Circuit with 20A limit
+	circuit := api.NewMockCircuit(ctrl)
+	circuit.EXPECT().ValidateCurrent(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, current float64) float64 {
+		return min(current, 20.0)
+	}).AnyTimes()
+	circuit.EXPECT().ValidatePower(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, power float64) float64 {
+		return power // no power limit
+	}).AnyTimes()
+
+	lp := &Loadpoint{
+		log:              util.NewLogger("foo"),
+		bus:              evbus.New(),
+		clock:            clock,
+		chargeMeter:      &Null{},
+		chargeRater:      &Null{},
+		chargeTimer:      &Null{},
+		progress:         NewProgress(0, 10),
+		wakeUpTimer:      NewTimer(),
+		mode:             api.ModeNow,
+		minCurrent:       6,
+		maxCurrent:       32,
+		vehicle:          vehicle,
+		phasesConfigured: 0,
+		phases:           3,
+		measuredPhases:   0,
+		status:           api.StatusC,
+		circuit:          circuit,
+	}
+
+	lp.charger = struct {
+		api.Charger
+		api.PhaseSwitcher
+	}{
+		plainCharger, phaseCharger,
+	}
+
+	// Currently at 1 phase
+	lp.phases = 1
+	lp.measuredPhases = 1
+
+	// PV power is available to reach e.g. 24A on 1 phase
+	// availablePower = chargePower - sitePower
+	// Let's set chargePower = 0, sitePower = -5520W -> availablePower = 5520W
+	// target1pCurrent = 5520W / 230V = 24A
+	// The loadpoint maxCurrent is 32A. But the circuit limit is 20A.
+	// Since 24 > 20, it should scale up to 3 phases!
+	
+	// We want to verify `pvScalePhases` returns 3.
+	scaledTo := lp.pvScalePhases(-5520.0, 6, 32.0)
+	require.Equal(t, 3, scaledTo, "should scale up because available power exceeds circuit limit")
+}
+
+func TestPvScalePhases_CircuitPowerLimit(t *testing.T) {
+	Voltage = 230
+	clock := clock.NewMock()
+	ctrl := gomock.NewController(t)
+
+	plainCharger := api.NewMockCharger(ctrl)
+	plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
+	plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
+
+	phaseCharger := api.NewMockPhaseSwitcher(ctrl)
+	phaseCharger.EXPECT().Phases1p3p(gomock.Any()).Return(nil).AnyTimes()
+
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Phases().Return(3).AnyTimes()
+	vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
+	vehicle.EXPECT().Features().Return(nil).AnyTimes()
+
+	// Circuit with 16A limit and 4000W limit
+	circuit := api.NewMockCircuit(ctrl)
+	circuit.EXPECT().ValidateCurrent(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, current float64) float64 {
+		return min(current, 16.0)
+	}).AnyTimes()
+	circuit.EXPECT().ValidatePower(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, power float64) float64 {
+		return min(power, 4000.0)
+	}).AnyTimes()
+
+	lp := &Loadpoint{
+		log:              util.NewLogger("foo"),
+		bus:              evbus.New(),
+		clock:            clock,
+		chargeMeter:      &Null{},
+		chargeRater:      &Null{},
+		chargeTimer:      &Null{},
+		progress:         NewProgress(0, 10),
+		wakeUpTimer:      NewTimer(),
+		mode:             api.ModeNow,
+		minCurrent:       6,
+		maxCurrent:       32,
+		vehicle:          vehicle,
+		phasesConfigured: 0,
+		phases:           1,
+		measuredPhases:   1,
+		status:           api.StatusC,
+		circuit:          circuit,
+	}
+
+	lp.charger = struct {
+		api.Charger
+		api.PhaseSwitcher
+	}{
+		plainCharger, phaseCharger,
+	}
+
+	// PV power is available to reach 5520W (24A on 1p).
+	// Current limit is 16A, so target1pCurrent (24A) > scaleMaxCurrent (16A), which makes it want to scale up.
+	// BUT circuit max power is 4000W, which is less than 3p min power (4140W).
+	// So it should NOT scale up.
+	
+	scaledTo := lp.pvScalePhases(-5520.0, 6, 32.0)
+	require.Equal(t, 0, scaledTo, "should not scale up because circuit power limit restricts 3p min current")
 }

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -761,7 +761,7 @@ func TestPvScalePhases_CircuitLimit(t *testing.T) {
 	// target1pCurrent = 5520W / 230V = 24A
 	// The loadpoint maxCurrent is 32A. But the circuit limit is 20A.
 	// Since 24 > 20, it should scale up to 3 phases!
-	
+
 	// We want to verify `pvScalePhases` returns 3.
 	scaledTo := lp.pvScalePhases(-5520.0, 6, 32.0)
 	require.Equal(t, 3, scaledTo, "should scale up because available power exceeds circuit limit")
@@ -824,7 +824,7 @@ func TestPvScalePhases_CircuitPowerLimit(t *testing.T) {
 	// Current limit is 16A, so target1pCurrent (24A) > scaleMaxCurrent (16A), which makes it want to scale up.
 	// BUT circuit max power is 4000W, which is less than 3p min power (4140W).
 	// So it should NOT scale up.
-	
+
 	scaledTo := lp.pvScalePhases(-5520.0, 6, 32.0)
 	require.Equal(t, 0, scaledTo, "should not scale up because circuit power limit restricts 3p min current")
 }

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -695,136 +695,87 @@ func TestUpdatePhaseSwitchNotAvailable(t *testing.T) {
 
 	// second cycle must not attempt the switch again (Phases1p3p .Times(1))
 	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil)
+	require.Equal(t, 3, lp.GetPhases())
 }
 
-func TestPvScalePhases_CircuitLimit(t *testing.T) {
+func TestPvScalePhasesCircuitLimits(t *testing.T) {
 	Voltage = 230
-	clock := clock.NewMock()
-	ctrl := gomock.NewController(t)
 
-	// A charger that can switch phases and has a max current of 32A
-	plainCharger := api.NewMockCharger(ctrl)
-	plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
-	plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
-
-	phaseCharger := api.NewMockPhaseSwitcher(ctrl)
-	phaseCharger.EXPECT().Phases1p3p(gomock.Any()).Return(nil).AnyTimes()
-
-	vehicle := api.NewMockVehicle(ctrl)
-	vehicle.EXPECT().Phases().Return(3).AnyTimes()
-	vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
-	vehicle.EXPECT().Features().Return(nil).AnyTimes()
-
-	// Circuit with 20A limit
-	circuit := api.NewMockCircuit(ctrl)
-	circuit.EXPECT().ValidateCurrent(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, current float64) float64 {
-		return min(current, 20.0)
-	}).AnyTimes()
-	circuit.EXPECT().ValidatePower(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, power float64) float64 {
-		return power // no power limit
-	}).AnyTimes()
-
-	lp := &Loadpoint{
-		log:              util.NewLogger("foo"),
-		bus:              evbus.New(),
-		clock:            clock,
-		chargeMeter:      &Null{},
-		chargeRater:      &Null{},
-		chargeTimer:      &Null{},
-		progress:         NewProgress(0, 10),
-		wakeUpTimer:      NewTimer(),
-		mode:             api.ModeNow,
-		minCurrent:       6,
-		maxCurrent:       32,
-		vehicle:          vehicle,
-		phasesConfigured: 0,
-		phases:           3,
-		measuredPhases:   0,
-		status:           api.StatusC,
-		circuit:          circuit,
-	}
-
-	lp.charger = struct {
-		api.Charger
-		api.PhaseSwitcher
+	tc := []struct {
+		desc           string
+		phases         int
+		sitePower      float64
+		circuitCurrent float64 // ValidateCurrent cap, 0 = unlimited
+		circuitPower   float64 // ValidatePower cap, 0 = unlimited
+		expectedPhases int
 	}{
-		plainCharger, phaseCharger,
+		// 5520W available equals 24A on 1p, below the 32A loadpoint limit
+		{desc: "no circuit limit", phases: 1, sitePower: -5520, expectedPhases: 0},
+		{desc: "current limit below 1p target", phases: 1, sitePower: -5520, circuitCurrent: 20, expectedPhases: 3},
+		{desc: "power limit below 3p minimum", phases: 1, sitePower: -5520, circuitCurrent: 16, circuitPower: 4000, expectedPhases: 0},
+		{desc: "current limit below minimum", phases: 1, sitePower: -5520, circuitCurrent: 2, expectedPhases: 0},
+		// 11040W available equals 16A on 3p, 4140W required for 3p minimum
+		{desc: "3p, no circuit limit", phases: 3, sitePower: -11040, expectedPhases: 0},
+		{desc: "3p, power limit below 3p minimum", phases: 3, sitePower: -11040, circuitPower: 3000, expectedPhases: 1},
 	}
 
-	// Currently at 1 phase
-	lp.phases = 1
-	lp.measuredPhases = 1
+	for _, tc := range tc {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
 
-	// PV power is available to reach e.g. 24A on 1 phase
-	// availablePower = chargePower - sitePower
-	// Let's set chargePower = 0, sitePower = -5520W -> availablePower = 5520W
-	// target1pCurrent = 5520W / 230V = 24A
-	// The loadpoint maxCurrent is 32A. But the circuit limit is 20A.
-	// Since 24 > 20, it should scale up to 3 phases!
+			plainCharger := api.NewMockCharger(ctrl)
+			plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
+			plainCharger.EXPECT().Enable(gomock.Any()).Return(nil).AnyTimes()
+			plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
 
-	// We want to verify `pvScalePhases` returns 3.
-	scaledTo := lp.pvScalePhases(-5520.0, 6, 32.0)
-	require.Equal(t, 3, scaledTo, "should scale up because available power exceeds circuit limit")
-}
+			phaseCharger := api.NewMockPhaseSwitcher(ctrl)
+			phaseCharger.EXPECT().Phases1p3p(gomock.Any()).Return(nil).AnyTimes()
 
-func TestPvScalePhases_CircuitPowerLimit(t *testing.T) {
-	Voltage = 230
-	clock := clock.NewMock()
-	ctrl := gomock.NewController(t)
+			vehicle := api.NewMockVehicle(ctrl)
+			vehicle.EXPECT().Phases().Return(3).AnyTimes()
+			vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
+			vehicle.EXPECT().Features().Return(nil).AnyTimes()
 
-	plainCharger := api.NewMockCharger(ctrl)
-	plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
-	plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
+			circuit := api.NewMockCircuit(ctrl)
+			circuit.EXPECT().ValidateCurrent(gomock.Any(), gomock.Any()).DoAndReturn(func(_, current float64) float64 {
+				if tc.circuitCurrent == 0 {
+					return current
+				}
+				return min(current, tc.circuitCurrent)
+			}).AnyTimes()
+			circuit.EXPECT().ValidatePower(gomock.Any(), gomock.Any()).DoAndReturn(func(_, power float64) float64 {
+				if tc.circuitPower == 0 {
+					return power
+				}
+				return min(power, tc.circuitPower)
+			}).AnyTimes()
 
-	phaseCharger := api.NewMockPhaseSwitcher(ctrl)
-	phaseCharger.EXPECT().Phases1p3p(gomock.Any()).Return(nil).AnyTimes()
+			lp := &Loadpoint{
+				log:            util.NewLogger("foo"),
+				bus:            evbus.New(),
+				clock:          clock.NewMock(),
+				chargeMeter:    &Null{},
+				chargeRater:    &Null{},
+				chargeTimer:    &Null{},
+				progress:       NewProgress(0, 10),
+				wakeUpTimer:    NewTimer(),
+				mode:           api.ModeNow,
+				minCurrent:     6,
+				maxCurrent:     32,
+				vehicle:        vehicle,
+				phases:         tc.phases,
+				measuredPhases: tc.phases,
+				status:         api.StatusC,
+				circuit:        circuit,
+				charger: struct {
+					*api.MockCharger
+					*api.MockPhaseSwitcher
+				}{plainCharger, phaseCharger},
+			}
 
-	vehicle := api.NewMockVehicle(ctrl)
-	vehicle.EXPECT().Phases().Return(3).AnyTimes()
-	vehicle.EXPECT().OnIdentified().Return(api.ActionConfig{}).AnyTimes()
-	vehicle.EXPECT().Features().Return(nil).AnyTimes()
+			require.Equal(t, tc.expectedPhases, lp.pvScalePhases(tc.sitePower, lp.minCurrent, lp.maxCurrent))
 
-	// Circuit with 16A limit and 4000W limit
-	circuit := api.NewMockCircuit(ctrl)
-	circuit.EXPECT().ValidateCurrent(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, current float64) float64 {
-		return min(current, 16.0)
-	}).AnyTimes()
-	circuit.EXPECT().ValidatePower(gomock.Any(), gomock.Any()).DoAndReturn(func(actual, power float64) float64 {
-		return min(power, 4000.0)
-	}).AnyTimes()
-
-	lp := &Loadpoint{
-		log:              util.NewLogger("foo"),
-		bus:              evbus.New(),
-		clock:            clock,
-		chargeMeter:      &Null{},
-		chargeRater:      &Null{},
-		chargeTimer:      &Null{},
-		progress:         NewProgress(0, 10),
-		wakeUpTimer:      NewTimer(),
-		mode:             api.ModeNow,
-		minCurrent:       6,
-		maxCurrent:       32,
-		vehicle:          vehicle,
-		phasesConfigured: 0,
-		phases:           1,
-		measuredPhases:   1,
-		status:           api.StatusC,
-		circuit:          circuit,
+			ctrl.Finish()
+		})
 	}
-
-	lp.charger = struct {
-		api.Charger
-		api.PhaseSwitcher
-	}{
-		plainCharger, phaseCharger,
-	}
-
-	// PV power is available to reach 5520W (24A on 1p).
-	// Current limit is 16A, so target1pCurrent (24A) > scaleMaxCurrent (16A), which makes it want to scale up.
-	// BUT circuit max power is 4000W, which is less than 3p min power (4140W).
-	// So it should NOT scale up.
-
-	scaledTo := lp.pvScalePhases(-5520.0, 6, 32.0)
-	require.Equal(t, 0, scaledTo, "should not scale up because circuit power limit restricts 3p min current")
 }


### PR DESCRIPTION
Fixes https://github.com/evcc-io/evcc/issues/32350

Considers circuit current and power limits when making a phase scaling decision in PV / minPV mode (in fast mode, it's already considered). Now decides to scale up when the calculated current for 1p exeeds max current allowed by load management and the minimum resulting power with 2p / 3p will not exeed the power limit. 

Previously, it did not consider load management, thus stayed on 1p in this case and wasted available power for charging. In addition, power limits were not taken into consideration.

Extracted the duplicated logic for max phase current calculation and added tests.