### PR TITLE
Powerwall: allow meter without Fleet credentials

### DIFF
--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -29,18 +29,27 @@ params:
     help:
       en: Password of the user "customer". By default this is the last 5 characters of password stated on the Tesla Gateway.
       de: Passwort des Benutzers "Kunde". Default sind die letzten 5 Zeichen des auf dem Tesla Gateway genannten Passworts.
-  - name: clientId
+  - name: fleetClientId
     required: false
+    mask: false
+    description:
+      generic: Fleet client ID
     help:
       en: from [developer.tesla.com](https://developer.tesla.com/dashboard).
       de: von [developer.tesla.com](https://developer.tesla.com/dashboard).
-  - name: accessToken
+  - name: fleetAccessToken
     required: false
+    mask: true
+    description:
+      generic: Fleet access token
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).
       de: von [myteslamate.com](https://app.myteslamate.com/).
-  - name: refreshToken
+  - name: fleetRefreshToken
     required: false
+    mask: true
+    description:
+      generic: Fleet refresh token
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).
       de: von [myteslamate.com](https://app.myteslamate.com/).
@@ -62,12 +71,12 @@ render: |
   usage: {{ .usage }}
   user: customer
   password: {{ .password }} # for user 'customer'
-  {{- if or .clientId .accessToken .refreshToken }}
+  {{- if or .fleetClientId .fleetAccessToken .fleetRefreshToken }}
   credentials:
-    id: {{ .clientId }}
+    id: {{ .fleetClientId }}
   tokens:
-    access: {{ .accessToken }}
-    refresh: {{ .refreshToken }}
+    access: {{ .fleetAccessToken }}
+    refresh: {{ .fleetRefreshToken }}
   {{- end }}
   siteId: {{ .siteId }}
   minsoc: {{ .minsoc }}

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -30,14 +30,17 @@ params:
       en: Password of the user "customer". By default this is the last 5 characters of password stated on the Tesla Gateway.
       de: Passwort des Benutzers "Kunde". Default sind die letzten 5 Zeichen des auf dem Tesla Gateway genannten Passworts.
   - name: clientId
+    required: false
     help:
       en: from [developer.tesla.com](https://developer.tesla.com/dashboard).
       de: von [developer.tesla.com](https://developer.tesla.com/dashboard).
   - name: accessToken
+    required: false
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).
       de: von [myteslamate.com](https://app.myteslamate.com/).
   - name: refreshToken
+    required: false
     help:
       en: from [myteslamate.com](https://app.myteslamate.com/).
       de: von [myteslamate.com](https://app.myteslamate.com/).
@@ -59,11 +62,13 @@ render: |
   usage: {{ .usage }}
   user: customer
   password: {{ .password }} # for user 'customer'
+  {{- if or .clientId .accessToken .refreshToken }}
   credentials:
     id: {{ .clientId }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
+  {{- end }}
   siteId: {{ .siteId }}
   minsoc: {{ .minsoc }}
   maxsoc: {{ .maxsoc }}

--- a/util/templates/powerwall_test.go
+++ b/util/templates/powerwall_test.go
@@ -10,6 +10,11 @@ import (
 func TestPowerwallTemplateOptionalFleetCredentials(t *testing.T) {
 	tmpl, err := ByName(Meter, "tesla-powerwall")
 	require.NoError(t, err)
+	for _, name := range []string{"fleetClientId", "fleetAccessToken", "fleetRefreshToken"} {
+		index, param := tmpl.ParamByName(name)
+		require.NotEqual(t, -1, index, "%s must be defined", name)
+		assert.False(t, param.IsRequired(), "%s must remain optional", name)
+	}
 
 	t.Run("local meter", func(t *testing.T) {
 		rendered, _, err := tmpl.RenderResult(RenderModeInstance, map[string]any{
@@ -23,7 +28,7 @@ func TestPowerwallTemplateOptionalFleetCredentials(t *testing.T) {
 	t.Run("Fleet battery control", func(t *testing.T) {
 		rendered, _, err := tmpl.RenderResult(RenderModeInstance, map[string]any{
 			"usage": "battery", "host": "powerwall.local", "password": "secret",
-			"clientId": "client", "accessToken": "access", "refreshToken": "refresh",
+			"fleetClientId": "client", "fleetAccessToken": "access", "fleetRefreshToken": "refresh",
 		})
 		require.NoError(t, err)
 		assert.Contains(t, string(rendered), "credentials:\n  id: client")

--- a/util/templates/powerwall_test.go
+++ b/util/templates/powerwall_test.go
@@ -1,0 +1,32 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPowerwallTemplateOptionalFleetCredentials(t *testing.T) {
+	tmpl, err := ByName(Meter, "tesla-powerwall")
+	require.NoError(t, err)
+
+	t.Run("local meter", func(t *testing.T) {
+		rendered, _, err := tmpl.RenderResult(RenderModeInstance, map[string]any{
+			"usage": "grid", "host": "powerwall.local", "password": "secret",
+		})
+		require.NoError(t, err)
+		assert.NotContains(t, string(rendered), "credentials:")
+		assert.NotContains(t, string(rendered), "tokens:")
+	})
+
+	t.Run("Fleet battery control", func(t *testing.T) {
+		rendered, _, err := tmpl.RenderResult(RenderModeInstance, map[string]any{
+			"usage": "battery", "host": "powerwall.local", "password": "secret",
+			"clientId": "client", "accessToken": "access", "refreshToken": "refresh",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, string(rendered), "credentials:\n  id: client")
+		assert.Contains(t, string(rendered), "tokens:\n  access: access\n  refresh: refresh")
+	})
+}


### PR DESCRIPTION
pairs with #32175

Keeps Powerwall local Gateway meter configuration independent of the optional Tesla Fleet API battery-control credentials.

- Makes the Powerwall Fleet inputs optional and template-specific
- Omits empty cloud credential mappings for local-only meters
- Retains existing validation for incomplete Fleet credentials