### PR TITLE
chore: enforce release branch policy and add backport command

### DIFF
--- a/.github/scripts/release-tag.sh
+++ b/.github/scripts/release-tag.sh
@@ -16,6 +16,7 @@
 
 set -euo pipefail
 
+# overridden with the repository default branch by the workflow
 MASTER_REF="${MASTER_REF:-origin/master}"
 
 validate() {

--- a/.github/scripts/release-tag.sh
+++ b/.github/scripts/release-tag.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Validates a release tag and reports whether it is the newest release.
+#
+# Feature releases (patch level 0) must be tagged on master. Bugfix releases may
+# be tagged on any branch so an older release line can be serviced without
+# shipping everything that landed on master since.
+#
+# Prints `latest=<true|false>` for consumption as a GitHub step output. Only the
+# newest release may move the `latest` pointers (docker tag, homebrew formula,
+# GitHub latest release, hassio addon, demo instance).
+#
+# Run `release-tag.sh --self-test` to exercise the logic in a scratch repository.
+
+set -euo pipefail
+
+MASTER_REF="${MASTER_REF:-origin/master}"
+
+validate() {
+	local tag=$1
+
+	if [[ ! $tag =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+		echo "::error::invalid release tag '$tag', expected MAJOR.MINOR.PATCH" >&2
+		return 1
+	fi
+
+	if [[ ${BASH_REMATCH[3]} == 0 ]]; then
+		# a tag checkout does not necessarily carry the remote tracking branch
+		git rev-parse --verify --quiet "$MASTER_REF" >/dev/null ||
+			git fetch --quiet --no-tags origin "master:refs/remotes/$MASTER_REF"
+
+		if ! git merge-base --is-ancestor "$tag" "$MASTER_REF"; then
+			echo "::error::feature release '$tag' must be tagged on master" >&2
+			return 1
+		fi
+	fi
+
+	local newest
+	newest=$(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort --version-sort | tail -1) || true
+
+	if [[ $newest == "$tag" ]]; then
+		echo "latest=true"
+	else
+		echo "latest=false"
+	fi
+}
+
+self_test() {
+	dir=$(mktemp -d)
+	trap 'rm -rf "$dir"' EXIT
+	cd "$dir"
+
+	commit() { git -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "$1"; }
+
+	git init --quiet --initial-branch=master .
+	commit one
+	git tag 0.1.0
+	git checkout --quiet -b fix
+	commit two
+	git tag 0.1.1 # bugfix release off master
+	git tag 0.2.0 # feature release off master
+	git checkout --quiet master
+	commit three
+	git tag 0.3.0
+	git tag 9.9.9-fork # tags from forks must not count as a release
+
+	MASTER_REF=master
+
+	failed=0
+	expect() { # expect <tag> <expected output or FAIL>
+		local got
+		if ! got=$(validate "$1" 2>/dev/null); then got=FAIL; fi
+		if [[ $got != "$2" ]]; then
+			echo "FAIL: $1 -> $got, want $2" >&2
+			failed=1
+		fi
+	}
+
+	expect 0.1.0 latest=false # feature release on master, superseded
+	expect 0.1.1 latest=false # bugfix release off master, older line
+	expect 0.3.0 latest=true  # newest release
+	expect 0.2.0 FAIL         # feature release not on master
+	expect 0.1 FAIL           # not MAJOR.MINOR.PATCH
+	expect v0.1.0 FAIL        # no v prefix allowed
+
+	[[ $failed == 0 ]] && echo "self-test ok"
+	return $failed
+}
+
+if [[ ${1:-} == --self-test ]]; then
+	self_test
+else
+	validate "${1:?usage: release-tag.sh <tag>}"
+fi

--- a/.github/scripts/release-tag.sh
+++ b/.github/scripts/release-tag.sh
@@ -9,6 +9,9 @@
 # newest release may move the `latest` pointers (docker tag, homebrew formula,
 # GitHub latest release, hassio addon, demo instance).
 #
+# Expects a checkout with `fetch-depth: 0`, which populates both the remote
+# tracking branches and all tags.
+#
 # Run `release-tag.sh --self-test` to exercise the logic in a scratch repository.
 
 set -euo pipefail
@@ -23,15 +26,9 @@ validate() {
 		return 1
 	fi
 
-	if [[ ${BASH_REMATCH[3]} == 0 ]]; then
-		# a tag checkout does not necessarily carry the remote tracking branch
-		git rev-parse --verify --quiet "$MASTER_REF" >/dev/null ||
-			git fetch --quiet --no-tags origin "master:refs/remotes/$MASTER_REF"
-
-		if ! git merge-base --is-ancestor "$tag" "$MASTER_REF"; then
-			echo "::error::feature release '$tag' must be tagged on master" >&2
-			return 1
-		fi
+	if [[ ${BASH_REMATCH[3]} == 0 ]] && ! git merge-base --is-ancestor "$tag" "$MASTER_REF"; then
+		echo "::error::feature release '$tag' must be tagged on master" >&2
+		return 1
 	fi
 
 	local newest

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -1,0 +1,139 @@
+name: Backport Command
+
+# Triggered by a maintainer commenting `/backport <branch>` on a merged pull
+# request. Cherry-picks the merged commit onto the target branch and opens a
+# pull request against it, so a fix can ship as a bugfix release without
+# pulling in everything that landed on master since.
+#
+# The pull request is created with GITHUB_TOKEN, so its checks have to be
+# started manually (close and reopen) before merging.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  backport:
+    name: Backport
+    # on any PR comment starting with /backport, only from maintainers
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/backport') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: React to comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const target = context.payload.comment.body.trim().split(/\s+/)[1];
+            // the target ends up in a checkout ref, keep it to plain branch names
+            if (!target || !/^[\w.\-\/]+$/.test(target)) {
+              core.setFailed('usage: /backport <branch>');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            if (!pr.merged) {
+              core.setFailed(`pull request #${pr.number} is not merged`);
+              return;
+            }
+
+            core.setOutput('target', target);
+            core.setOutput('sha', pr.merge_commit_sha);
+            core.setOutput('title', pr.title);
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.target }}
+
+      - name: Cherry-pick
+        env:
+          BRANCH: backport/${{ github.event.issue.number }}-${{ steps.pr.outputs.target }}
+          SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git switch -c "$BRANCH"
+
+          # -m 1 picks the first-parent diff of a merge commit; squashed pull
+          # requests are ordinary commits and must not get the flag
+          mainline=""
+          if [ "$(git rev-list --parents -n1 "$SHA" | wc -w)" -gt 2 ]; then
+            mainline="-m 1"
+          fi
+
+          git cherry-pick $mainline "$SHA"
+          git push origin "$BRANCH"
+
+      - name: Create pull request
+        id: create
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: backport/${{ github.event.issue.number }}-${{ steps.pr.outputs.target }}
+          TARGET: ${{ steps.pr.outputs.target }}
+          TITLE: ${{ steps.pr.outputs.title }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          url=$(gh pr create \
+            --base "$TARGET" \
+            --head "$BRANCH" \
+            --title "$TITLE" \
+            --body "Backport of #$NUMBER to \`$TARGET\`.")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment result
+        if: always()
+        uses: actions/github-script@v8
+        env:
+          TARGET: ${{ steps.pr.outputs.target }}
+          URL: ${{ steps.create.outputs.url }}
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { TARGET, URL } = process.env;
+            const body = URL
+              ? `✅ Backported to \`${TARGET}\`: ${URL}`
+              : `❌ Backport failed, most likely a cherry-pick conflict. See the [run logs](${runUrl}).`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });
+
+      - name: Resolve command comment
+        if: steps.create.outputs.url
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // collapse the /backport comment as resolved now that the pull request exists
+            await github.graphql(
+              `mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}`,
+              { id: context.payload.comment.node_id }
+            );

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -8,8 +8,8 @@ name: Backport Command
 # Without an argument the branch of the current release line is used, e.g.
 # `release/0.313`. It is created at the newest tag of that line on first use.
 #
-# The pull request is created with GITHUB_TOKEN, so its checks are created but
-# wait for approval from the pull request page.
+# Pushing and opening the pull request use RELEASE_DEPLOY_TOKEN so its checks
+# start without approval. GITHUB_TOKEN would create them in a pending state.
 
 on:
   issue_comment:
@@ -121,6 +121,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ steps.pr.outputs.target }}
+          # persisted for the push below
+          token: ${{ secrets.RELEASE_DEPLOY_TOKEN }}
 
       - name: Cherry-pick
         env:
@@ -144,7 +146,7 @@ jobs:
       - name: Create pull request
         id: create
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_DEPLOY_TOKEN }}
           BRANCH: backport/${{ github.event.issue.number }}-${{ steps.pr.outputs.target }}
           TARGET: ${{ steps.pr.outputs.target }}
           TITLE: ${{ steps.pr.outputs.title }}

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -70,6 +70,11 @@ jobs:
               fail(`pull request #${pr.number} is not labelled \`bug\`, only bugfixes are backported`);
               return;
             }
+            // same marker the changelog uses to group breaking changes
+            if (/\(BC\)/i.test(pr.title)) {
+              fail(`pull request #${pr.number} is a breaking change, it must not go into a bugfix release`);
+              return;
+            }
 
             const compare = (a, b) => {
               const [x, y] = [a, b].map((v) => v.split('.').map(Number));

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -136,7 +136,7 @@ jobs:
           # -m 1 picks the first-parent diff of a merge commit; squashed pull
           # requests are ordinary commits and must not get the flag
           mainline=""
-          if [ "$(git rev-list --parents -n1 "$SHA" | wc -w)" -gt 2 ]; then
+          if git rev-parse --quiet --verify "$SHA^2" >/dev/null; then
             mainline="-m 1"
           fi
 

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -114,6 +114,7 @@ jobs:
             }
 
             core.setOutput('target', target);
+            core.setOutput('branch', `backport/${pr.number}-${target}`);
             core.setOutput('sha', pr.merge_commit_sha);
             core.setOutput('title', pr.title);
 
@@ -126,7 +127,7 @@ jobs:
 
       - name: Cherry-pick
         env:
-          BRANCH: backport/${{ github.event.issue.number }}-${{ steps.pr.outputs.target }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
           SHA: ${{ steps.pr.outputs.sha }}
         run: |
           git config user.name github-actions
@@ -147,7 +148,7 @@ jobs:
         id: create
         env:
           GH_TOKEN: ${{ secrets.RELEASE_DEPLOY_TOKEN }}
-          BRANCH: backport/${{ github.event.issue.number }}-${{ steps.pr.outputs.target }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
           TARGET: ${{ steps.pr.outputs.target }}
           TITLE: ${{ steps.pr.outputs.title }}
           NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -1,9 +1,12 @@
 name: Backport Command
 
-# Triggered by a maintainer commenting `/backport <branch>` on a merged pull
+# Triggered by a maintainer commenting `/backport [branch]` on a merged pull
 # request. Cherry-picks the merged commit onto the target branch and opens a
 # pull request against it, so a fix can ship as a bugfix release without
 # pulling in everything that landed on master since.
+#
+# Without an argument the branch of the current release line is used, e.g.
+# `release/0.313`. It is created at the newest tag of that line on first use.
 #
 # The pull request is created with GITHUB_TOKEN, so its checks have to be
 # started manually (close and reopen) before merging.
@@ -41,26 +44,68 @@ jobs:
               content: 'eyes',
             });
 
-      - name: Resolve pull request
+      - name: Resolve target branch
         id: pr
         uses: actions/github-script@v8
         with:
           script: |
-            const target = context.payload.comment.body.trim().split(/\s+/)[1];
-            // the target ends up in a checkout ref, keep it to plain branch names
-            if (!target || !/^[\w.\-\/]+$/.test(target)) {
-              core.setFailed('usage: /backport <branch>');
-              return;
-            }
+            const { owner, repo } = context.repo;
+
+            // reported back as a comment, so the reason is visible on the pull request
+            const fail = (message) => {
+              core.setOutput('error', message);
+              core.setFailed(message);
+            };
 
             const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               pull_number: context.payload.issue.number,
             });
             if (!pr.merged) {
-              core.setFailed(`pull request #${pr.number} is not merged`);
+              fail(`pull request #${pr.number} is not merged`);
               return;
+            }
+            if (!pr.labels.some((l) => l.name === 'bug')) {
+              fail(`pull request #${pr.number} is not labelled \`bug\`, only bugfixes are backported`);
+              return;
+            }
+
+            const compare = (a, b) => {
+              const [x, y] = [a, b].map((v) => v.split('.').map(Number));
+              return x[0] - y[0] || x[1] - y[1] || x[2] - y[2];
+            };
+            const tags = await github.paginate(github.rest.repos.listTags, { owner, repo, per_page: 100 });
+            const releases = tags.map((t) => t.name).filter((n) => /^\d+\.\d+\.\d+$/.test(n)).sort(compare);
+
+            let target = context.payload.comment.body.trim().split(/\s+/)[1];
+            if (target) {
+              // the target ends up in a checkout ref, keep it to plain branch names
+              if (!/^[\w.\-\/]+$/.test(target)) {
+                fail('usage: /backport [branch]');
+                return;
+              }
+            } else {
+              const line = releases[releases.length - 1].split('.').slice(0, 2).join('.');
+              target = `release/${line}`;
+            }
+
+            // branch off the newest tag of the release line on first backport
+            try {
+              await github.rest.repos.getBranch({ owner, repo, branch: target });
+            } catch (err) {
+              if (err.status !== 404) throw err;
+
+              const line = target.replace(/^release\//, '');
+              const base = releases.filter((n) => n.startsWith(`${line}.`)).pop();
+              if (!base) {
+                fail(`branch \`${target}\` does not exist and no release matches it`);
+                return;
+              }
+
+              const { data: commit } = await github.rest.repos.getCommit({ owner, repo, ref: base });
+              await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${target}`, sha: commit.sha });
+              core.notice(`created ${target} at ${base}`);
             }
 
             core.setOutput('target', target);
@@ -113,13 +158,16 @@ jobs:
         env:
           TARGET: ${{ steps.pr.outputs.target }}
           URL: ${{ steps.create.outputs.url }}
+          ERROR: ${{ steps.pr.outputs.error }}
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const { TARGET, URL } = process.env;
+            const { TARGET, URL, ERROR } = process.env;
             const body = URL
               ? `✅ Backported to \`${TARGET}\`: ${URL}`
-              : `❌ Backport failed, most likely a cherry-pick conflict. See the [run logs](${runUrl}).`;
+              : ERROR
+                ? `❌ ${ERROR}`
+                : `❌ Backport failed, most likely a cherry-pick conflict. See the [run logs](${runUrl}).`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -8,8 +8,8 @@ name: Backport Command
 # Without an argument the branch of the current release line is used, e.g.
 # `release/0.313`. It is created at the newest tag of that line on first use.
 #
-# The pull request is created with GITHUB_TOKEN, so its checks have to be
-# started manually (close and reopen) before merging.
+# The pull request is created with GITHUB_TOKEN, so its checks are created but
+# wait for approval from the pull request page.
 
 on:
   issue_comment:
@@ -86,7 +86,7 @@ jobs:
             let target = context.payload.comment.body.trim().split(/\s+/)[1];
             if (target) {
               // the target ends up in a checkout ref, keep it to plain branch names
-              if (!/^[\w.\-\/]+$/.test(target)) {
+              if (!/^[\w.\-\/]+$/.test(target) || target.includes('..')) {
                 fail('usage: /backport [branch]');
                 return;
               }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,31 @@ permissions:
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
+  guard:
+    name: Validate Tag
+    runs-on: depot-ubuntu-24.04-arm
+    permissions:
+      contents: read
+    outputs:
+      latest: ${{ steps.tag.outputs.latest }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # feature releases must come from master, bugfix releases may come from any
+      # branch. only the newest release moves the latest pointers.
+      - id: tag
+        run: .github/scripts/release-tag.sh "${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+
   call-build-workflow:
-    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - guard
     uses: evcc-io/evcc/.github/workflows/default.yml@master
     permissions:
       contents: read
@@ -19,6 +39,7 @@ jobs:
   docker:
     name: Publish Docker :release
     needs:
+      - guard
       - call-build-workflow
     runs-on: depot-ubuntu-24.04-arm
     permissions:
@@ -45,6 +66,9 @@ jobs:
         with:
           images: |
             evcc/evcc
+          # a bugfix release of an older line must not move :latest
+          flavor: |
+            latest=${{ needs.guard.outputs.latest }}
 
       - name: Publish
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -59,6 +83,7 @@ jobs:
   apt:
     name: Github & APT
     needs:
+      - guard
       - call-build-workflow
     runs-on: depot-ubuntu-24.04-arm
 
@@ -110,6 +135,9 @@ jobs:
         env:
           # use RELEASE_DEPLOY_TOKEN for access to evcc-io/homebrew-tap
           GITHUB_TOKEN: ${{ secrets.RELEASE_DEPLOY_TOKEN }}
+          # a bugfix release of an older line must not move the homebrew formula
+          # or the Github latest release marker
+          MAKE_LATEST: ${{ needs.guard.outputs.latest }}
 
       - uses: actions/setup-python@v6
         with:
@@ -126,7 +154,9 @@ jobs:
   demo:
     name: Demo
     needs:
+      - guard
       - docker
+    if: needs.guard.outputs.latest == 'true'
     runs-on: depot-ubuntu-24.04-arm
 
     permissions:
@@ -144,7 +174,9 @@ jobs:
   hassio:
     name: Hassio Addon
     needs:
+      - guard
       - docker
+    if: needs.guard.outputs.latest == 'true'
     runs-on: depot-ubuntu-24.04-arm
 
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
       # feature releases must come from master, bugfix releases may come from any
       # branch. only the newest release moves the latest pointers.
       - id: tag
+        env:
+          MASTER_REF: origin/${{ github.event.repository.default_branch }}
         run: .github/scripts/release-tag.sh "${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
 
   call-build-workflow:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ release:
     owner: evcc-io
     name: evcc
   mode: replace
+  # bugfix releases of an older line are published, but do not become "latest"
+  make_latest: '{{ envOrDefault "MAKE_LATEST" "true" }}'
 
 builds:
   - id: evcc
@@ -119,7 +121,8 @@ nfpms:
       postremove: ./packaging/scripts/postremove.sh
 
 brews:
-  - repository:
+  - skip_upload: '{{ if eq (envOrDefault "MAKE_LATEST" "true") "true" }}false{{ else }}true{{ end }}'
+    repository:
       owner: evcc-io
       name: homebrew-tap
     commit_author:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,24 @@ GOOS=linux GOARCH=arm GOARM=6 make
 make docker DOCKER_IMAGE=my/docker DOCKER_TAG=0815
 ```
 
+## Releases
+
+Releases are cut by pushing a `MAJOR.MINOR.PATCH` tag. Any other tag is ignored.
+
+Feature releases (`0.313.0`) must be tagged on `master`. The release workflow
+rejects a feature tag that is not reachable from `master`.
+
+Bugfix releases (`0.313.1`) may be tagged on any branch. That allows servicing
+an older release line without shipping everything that has landed on `master`
+since. Only the newest release moves the `latest` pointers, so a bugfix release
+of an older line publishes its artifacts, but leaves the `evcc/evcc:latest`
+docker tag, the homebrew formula, the GitHub latest release, the hassio addon
+and the demo instance untouched.
+
+To move a merged pull request onto a release branch, comment `/backport <branch>`
+on it. The commit is cherry-picked onto the target branch and a pull request is
+opened against it.
+
 ## Debugging in VS Code
 
 ### evcc Core

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,8 @@ docker tag, the homebrew formula, the GitHub latest release, the hassio addon
 and the demo instance untouched.
 
 To move a merged pull request onto a release branch, comment `/backport` on it.
-The pull request has to carry the `bug` label, only bugfixes are backported.
+The pull request has to carry the `bug` label and must not be marked `(BC)`,
+only non-breaking bugfixes are backported.
 The commit is cherry-picked onto the branch of the current release line, e.g.
 `release/0.313`, and a pull request is opened against it. The branch is created
 at the newest tag of that line if it does not exist yet. Pass a branch name,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,12 @@ of an older line publishes its artifacts, but leaves the `evcc/evcc:latest`
 docker tag, the homebrew formula, the GitHub latest release, the hassio addon
 and the demo instance untouched.
 
-To move a merged pull request onto a release branch, comment `/backport <branch>`
-on it. The commit is cherry-picked onto the target branch and a pull request is
-opened against it.
+To move a merged pull request onto a release branch, comment `/backport` on it.
+The pull request has to carry the `bug` label, only bugfixes are backported.
+The commit is cherry-picked onto the branch of the current release line, e.g.
+`release/0.313`, and a pull request is opened against it. The branch is created
+at the newest tag of that line if it does not exist yet. Pass a branch name,
+`/backport release/0.312`, to service an older line.
 
 ## Debugging in VS Code
 


### PR DESCRIPTION
Releases are currently cut by pushing any tag, from any commit, and every release unconditionally moves all "latest" pointers. This makes the release branch policy implicit and rules out servicing an older release line. This proposal makes the policy explicit in the workflow and enables bugfix releases off a branch.

- release workflow only triggers on `MAJOR.MINOR.PATCH` tags, no longer on `*`
- new `guard` job rejects a feature release (`x.y.0`) whose tag is not reachable from master
- bugfix releases (`x.y.z`, z > 0) are allowed from any branch, so an older line can be serviced without shipping everything that landed on master since
- only the newest release moves the latest pointers: `evcc/evcc:latest`, homebrew formula, GitHub latest release, hassio addon and demo instance are skipped for a bugfix release of an older line, artifacts and the APT package are still published
- new `/backport` command cherry-picks a merged pull request onto the branch of the current release line, e.g. `release/0.313`, creating it at the newest tag of that line on first use. An explicit `/backport release/0.312` services an older line
- backporting requires the `bug` label and refuses a title marked `(BC)`, commenting the reason on the pull request
- release policy documented in CONTRIBUTING.md

The tag validation is a shell script rather than inline workflow YAML so it can be exercised locally: `.github/scripts/release-tag.sh --self-test`.

The backport job pushes and opens its pull request with the existing `RELEASE_DEPLOY_TOKEN`, so the checks start without approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
