### PR TITLE
chore: skip Claude PR labeling for bot pull requests

### DIFF
--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -29,7 +29,9 @@ jobs:
 
   pr-label:
     name: PR labeling
-    if: github.event_name == 'pull_request_target'
+    # bot PRs (dependabot etc.) are skipped: the action rejects non-human actors
+    # unless allowlisted, and bots already label their own PRs
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read # read base repo for area classification


### PR DESCRIPTION
The `PR labeling` job fails on every dependabot PR:

```
Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Gate the job on `github.event.pull_request.user.type != 'Bot'` so bot PRs show up as skipped instead of red. Bots label their own PRs anyway, so there is nothing for the agent to do there.

Alternative would be `allowed_bots: "dependabot[bot]"` (as `claude-code-review-run.yml` already does), but that spends agent runs on PRs that are already labeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)