### PR TITLE
chore: state that the backport pull request was opened

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -34,17 +34,15 @@ jobs:
 
     steps:
       - name: React to comment
-        id: react
         uses: actions/github-script@v8
         with:
           script: |
-            const { data } = await github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: 'eyes',
             });
-            core.setOutput('id', data.id);
 
       - name: Resolve target branch
         id: pr
@@ -169,35 +167,20 @@ jobs:
           TARGET: ${{ steps.pr.outputs.target }}
           URL: ${{ steps.create.outputs.url }}
           ERROR: ${{ steps.pr.outputs.error }}
-          REACTION: ${{ steps.react.outputs.id }}
         with:
           script: |
-            const { owner, repo } = context.repo;
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const { TARGET, URL, ERROR, REACTION } = process.env;
-
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { TARGET, URL, ERROR } = process.env;
             const body = URL
               ? `✅ Opened backport pull request on \`${TARGET}\`: ${URL}`
               : ERROR
                 ? `❌ ${ERROR}`
                 : `❌ Backport failed, most likely a cherry-pick conflict. See the [run logs](${runUrl}).`;
             await github.rest.issues.createComment({
-              owner,
-              repo,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               issue_number: context.payload.issue.number,
               body,
-            });
-
-            // swap the acknowledgement for the outcome
-            const comment_id = context.payload.comment.id;
-            if (REACTION) {
-              await github.rest.reactions.deleteForIssueComment({ owner, repo, comment_id, reaction_id: Number(REACTION) });
-            }
-            await github.rest.reactions.createForIssueComment({
-              owner,
-              repo,
-              comment_id,
-              content: URL ? 'rocket' : 'confused',
             });
 
       - name: Resolve command comment

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -34,15 +34,17 @@ jobs:
 
     steps:
       - name: React to comment
+        id: react
         uses: actions/github-script@v8
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
+            const { data } = await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: 'eyes',
             });
+            core.setOutput('id', data.id);
 
       - name: Resolve target branch
         id: pr
@@ -167,20 +169,35 @@ jobs:
           TARGET: ${{ steps.pr.outputs.target }}
           URL: ${{ steps.create.outputs.url }}
           ERROR: ${{ steps.pr.outputs.error }}
+          REACTION: ${{ steps.react.outputs.id }}
         with:
           script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const { TARGET, URL, ERROR } = process.env;
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const { TARGET, URL, ERROR, REACTION } = process.env;
+
             const body = URL
               ? `✅ Backported to \`${TARGET}\`: ${URL}`
               : ERROR
                 ? `❌ ${ERROR}`
                 : `❌ Backport failed, most likely a cherry-pick conflict. See the [run logs](${runUrl}).`;
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               issue_number: context.payload.issue.number,
               body,
+            });
+
+            // swap the acknowledgement for the outcome
+            const comment_id = context.payload.comment.id;
+            if (REACTION) {
+              await github.rest.reactions.deleteForIssueComment({ owner, repo, comment_id, reaction_id: Number(REACTION) });
+            }
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id,
+              content: URL ? 'rocket' : 'confused',
             });
 
       - name: Resolve command comment

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -177,7 +177,7 @@ jobs:
             const { TARGET, URL, ERROR, REACTION } = process.env;
 
             const body = URL
-              ? `✅ Backported to \`${TARGET}\`: ${URL}`
+              ? `✅ Opened backport pull request on \`${TARGET}\`: ${URL}`
               : ERROR
                 ? `❌ ${ERROR}`
                 : `❌ Backport failed, most likely a cherry-pick conflict. See the [run logs](${runUrl}).`;


### PR DESCRIPTION
follows #32369

`/backport` reports success as "Backported to", which reads as if the fix has landed on the release branch. It has not, the backport pull request still has to be reviewed and merged.

- the success comment says a backport pull request was opened, and links it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
