### PR TITLE
chore: distinguish backport pull requests by title and label

### DIFF
--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -30,8 +30,12 @@ jobs:
   pr-label:
     name: PR labeling
     # bot PRs (dependabot etc.) are skipped: the action rejects non-human actors
-    # unless allowlisted, and bots already label their own PRs
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.user.type != 'Bot'
+    # unless allowlisted, and bots already label their own PRs. backports are
+    # skipped as well, they carry the backport label and nothing else
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.type != 'Bot' &&
+      !startsWith(github.event.pull_request.head.ref, 'backport/')
     runs-on: ubuntu-latest
     permissions:
       contents: read # read base repo for area classification

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -163,6 +163,7 @@ jobs:
             --base "$TARGET" \
             --head "$BRANCH" \
             --title "${TARGET#release/} backport: $TITLE" \
+            --label backport \
             --assignee "$ACTOR" \
             --body "Backport of #$NUMBER to \`$TARGET\`, requested by @$ACTOR.")
           echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -162,7 +162,7 @@ jobs:
           url=$(gh pr create \
             --base "$TARGET" \
             --head "$BRANCH" \
-            --title "$TITLE" \
+            --title "${TARGET#release/} backport: $TITLE" \
             --assignee "$ACTOR" \
             --body "Backport of #$NUMBER to \`$TARGET\`, requested by @$ACTOR.")
           echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -158,11 +158,14 @@ jobs:
           NUMBER: ${{ github.event.issue.number }}
           ACTOR: ${{ github.event.comment.user.login }}
         run: |
+          # the release line the branch was cut from, 0.313 for release/0.313.1
+          line=$(echo "${TARGET#release/}" | cut -d. -f1,2)
+
           # the pull request is authored by the deploy token, so name the requester
           url=$(gh pr create \
             --base "$TARGET" \
             --head "$BRANCH" \
-            --title "${TARGET#release/} backport: $TITLE" \
+            --title "$line backport: $TITLE" \
             --label backport \
             --assignee "$ACTOR" \
             --body "Backport of #$NUMBER to \`$TARGET\`, requested by @$ACTOR.")


### PR DESCRIPTION
follows #32375

A backport pull request carries the original title and gets labelled like the pull request it was picked from, #32373 came out as "Cardata: delete obsolete streaming containers" with `bug` and `vehicles`. That makes it indistinguishable from the original in a list.

- backport pull request titles are prefixed with the release line they belong to, e.g. `0.313 backport: Cardata: delete obsolete streaming containers`
- backports are created with the `backport` label and nothing else, the Claude PR labeler skips `backport/*` branches

The prefix is the target branch stripped of `release/` and cut to the line, so a backport onto a branch that does not follow the convention still gets a usable prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
