### PR TITLE
chore: open backport pull requests without a body

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -155,20 +155,21 @@ jobs:
           BRANCH: ${{ steps.pr.outputs.branch }}
           TARGET: ${{ steps.pr.outputs.target }}
           TITLE: ${{ steps.pr.outputs.title }}
-          NUMBER: ${{ github.event.issue.number }}
           ACTOR: ${{ github.event.comment.user.login }}
         run: |
           # the release line the branch was cut from, 0.313 for release/0.313.1
           line=$(echo "${TARGET#release/}" | cut -d. -f1,2)
 
-          # the pull request is authored by the deploy token, so name the requester
+          # the pull request is authored by the deploy token, so assign the
+          # requester. the body stays empty, squashing it would carry the text
+          # into the release branch as the commit description
           url=$(gh pr create \
             --base "$TARGET" \
             --head "$BRANCH" \
             --title "$line backport: $TITLE" \
             --label backport \
             --assignee "$ACTOR" \
-            --body "Backport of #$NUMBER to \`$TARGET\`, requested by @$ACTOR.")
+            --body "")
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Comment result


### PR DESCRIPTION
follows #32381

Squashing a backport pull request prefills the extended description from the pull request body, so `Backport of #32342 to release/0.313.1, requested by @andig` ends up as the commit description on the release branch. The release branch history should read like master.

- backport pull requests are opened without a body

The source pull request is still discoverable: it is named in the `backport/<number>-<branch>` head branch, and the `/backport` command reports the new pull request back on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
