### PR TITLE
chore: pin devEngines package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,12 @@
     "npm": ">=10.0.0",
     "node": ">=26.0.0"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=10.0.0"
+    }
+  },
   "license": "MIT",
   "repository": "github:evcc-io/evcc",
   "devDependencies": {


### PR DESCRIPTION
npm 12 writes a `devEngines.packageManager` block into `package.json` on install, which dirties the working tree and fails the UI Porcelain check on the release branch (0.313.1 release run, UI job).

Master already carries this block via #32297 (vite+); the release branch does not. Adds the same block so npm leaves `package.json` untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)