### PR TITLE
0.313 backport: chore: pin clock in device colors test (#32325)

### DIFF
--- a/tests/device-colors.spec.ts
+++ b/tests/device-colors.spec.ts
@@ -33,6 +33,10 @@ function chartSection(page: Page, heading: string): Locator {
 }
 
 test("device colors: autoassign, override, persistence", async ({ page }) => {
+  // fixture sessions are dated 2026-05. Sessions.vue ranks loadpoints by energy
+  // over the last three months relative to now, so pin the clock to keep them in range
+  await page.clock.setFixedTime(new Date("2026-05-15T12:00:00Z"));
+
   // ---------- Step 1 — Sessions, by-vehicle view ----------
   await page.goto("/#/sessions?year=2026&month=5");
   await expect(page.getByRole("heading", { name: "Charging Sessions" })).toBeVisible();


### PR DESCRIPTION
Backport of #32325.

`device-colors.spec.ts` fixture sessions are dated 2026-05. Sessions.vue ranks loadpoints by energy over the last three months relative to `now`, so from 2026-08-01 the fixtures fall out of range and loadpoint autoassign flips (Garage gets amber instead of blue). Pinning the clock fixes the Integration job on the release branch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)