### PR TITLE
chore: serialize hassio changelog updates

### DIFF
--- a/.github/workflows/hassio-changelog.yml
+++ b/.github/workflows/hassio-changelog.yml
@@ -17,6 +17,10 @@ jobs:
     name: Update Hassio Changelog
     runs-on: depot-ubuntu-24.04-arm
 
+    # release asset uploads fire repeated `edited` events, serialize to avoid racing pushes
+    concurrency:
+      group: hassio-changelog-${{ inputs.addon_path }}
+
     permissions:
       contents: read # gh api calls to evcc repo; push to hassio-addon uses HASSIO_DEPLOY_TOKEN PAT
 


### PR DESCRIPTION
A release fires `edited` once per asset upload, so `Release - Create Hassio Addon Changelog` started 7 runs within 6 seconds for 0.313.1. They race each other pushing to `hassio-addon`; one lost with `! [rejected] main -> main (fetch first)`.

Adds a concurrency group keyed by addon path. Redundant queued runs are dropped, the last one still regenerates the full changelog from the releases API, so the result is unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)