### PR TITLE
chore: keep the backport marker out of the release notes

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -168,7 +168,7 @@ jobs:
           url=$(gh pr create \
             --base "$TARGET" \
             --head "$BRANCH" \
-            --title "$TITLE ($line backport)" \
+            --title "$TITLE [$line backport]" \
             --label backport \
             --assignee "$ACTOR" \
             --body "")

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -162,11 +162,13 @@ jobs:
 
           # the pull request is authored by the deploy token, so assign the
           # requester. the body stays empty, squashing it would carry the text
-          # into the release branch as the commit description
+          # into the release branch as the commit description.
+          # the marker trails the title so the changelog filters and groups still
+          # see the original prefix, goreleaser strips it from the release notes
           url=$(gh pr create \
             --base "$TARGET" \
             --head "$BRANCH" \
-            --title "$line backport: $TITLE" \
+            --title "$TITLE ($line backport)" \
             --label backport \
             --assignee "$ACTOR" \
             --body "")

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,6 +67,8 @@ snapshot:
 
 changelog:
   sort: asc
+  # drop the marker the backport command appends to the pull request title
+  format: '{{ .SHA }} {{ reReplaceAll ` \(\d+\.\d+ backport\)` .Message "" }}'
   filters:
     exclude:
       - "^chore"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ snapshot:
 changelog:
   sort: asc
   # drop the marker the backport command appends to the pull request title
-  format: '{{ .SHA }} {{ reReplaceAll ` \(\d+\.\d+ backport\)` .Message "" }}'
+  format: '{{ .SHA }} {{ reReplaceAll ` \[\d+\.\d+ backport\]` .Message "" }}'
   filters:
     exclude:
       - "^chore"


### PR DESCRIPTION
In 0.313.1 every backport shows up as `0.313 backport: chore: pin clock in device colors test (#32387)`. goreleaser matches `filters.exclude` and the group regexps against the raw commit subject, so the leading marker also broke them: the `chore` backports were not excluded, and `chore: fix request cache warning` landed under Bug Fixes.

Moves the marker to the end of the pull request title, so the subject again starts with its original prefix and filtering and grouping work as on master. A `changelog.format` strips the marker from the notes.

The default format for the `git` changelog is `{{ .SHA }} {{ .Message }}`, so the output is otherwise unchanged. Note the regular expression needs a backquoted template string, a Go string literal rejects `\\(`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)