### PR TITLE
chore: delete the release branch after a bugfix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,3 +204,38 @@ jobs:
           git config user.email github-actions@github.com
           git commit -am "Mirror evcc release"
           git push
+
+  cleanup:
+    name: Delete Release Branch
+    needs:
+      - docker
+      - apt
+    runs-on: depot-ubuntu-24.04-arm
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      # a bugfix release consumes its release branch, e.g. tag 0.313.1 is the tip
+      # of release/0.313.1. Feature releases have no such branch.
+      - env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          branch="release/$TAG"
+
+          head=$(git rev-parse --verify --quiet "origin/$branch") || {
+            echo "::notice::no $branch to delete"
+            exit 0
+          }
+
+          if [ "$head" != "$(git rev-parse "$TAG^{commit}")" ]; then
+            echo "::notice::$branch moved past $TAG, keeping it"
+            exit 0
+          fi
+
+          git push origin --delete "$branch"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,10 @@ The commit is cherry-picked onto the branch of the next bugfix release, e.g.
 created at the newest tag of that line if it does not exist yet. Pass a branch
 name, `/backport release/0.312.2`, to service an older line.
 
+Releasing a bugfix deletes its release branch, since the tag is the branch tip
+and everything on it has shipped. A branch that received further backports after
+the tag is kept.
+
 ## Debugging in VS Code
 
 ### evcc Core


### PR DESCRIPTION
follows #32381

A release branch has served its purpose once the bugfix release is tagged from it, but it stays around and shows up in the branch list forever.

- releasing a bugfix deletes its release branch, e.g. tagging `0.313.1` removes `release/0.313.1`
- the branch is only deleted when the tag is its tip, so a branch that received further backports after tagging is kept
- feature releases are unaffected, they have no release branch

The step runs after the docker and package jobs, so a failed release keeps the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
