### PR TITLE
Kostal Plenticore: add forced discharge

### DIFF
--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -172,13 +172,10 @@ render: |
               address: 1038 # Battery max. charge power limit, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
-      - case: 5 # discharge (forced feed-in arbitrage, see api.BatteryDischarge)
+      - case: 5 # discharge (forced feed-in arbitrage)
         set:
           {{- if .maxdischargepower }}
           source: const
-          # positive = discharge (mirrors case 3's charge, which negates via the minus
-          # sign above); the inverter itself enforces its AC rating and feed-in limit
-          # against this register, so no additional clamping is needed here
           value: {{ .maxdischargepower }} # W
           set:
             source: modbus

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -172,5 +172,24 @@ render: |
               address: 1038 # Battery max. charge power limit, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+      - case: 5 # discharge (forced feed-in arbitrage, see api.BatteryDischarge)
+        set:
+          {{- if .maxdischargepower }}
+          source: const
+          # positive = discharge (mirrors case 3's charge, which negates via the minus
+          # sign above); the inverter itself enforces its AC rating and feed-in limit
+          # against this register, so no additional clamping is needed here
+          value: {{ .maxdischargepower }} # W
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
+              type: writemultiple
+              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          {{- else }}
+          source: error
+          error: ErrNotAvailable
+          {{- end }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -125,15 +125,8 @@ render: |
       switch:
       - case: 1 # normal
         set:
-          source: const
-          value: 0 # W (set once to reset from forced charge)
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 1034 # Battery charge power (DC) setpoint, absolute [W]
-              type: writemultiple
-              encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+          source: sleep
+          duration: 0s # no-op
       - case: 2 # hold
         set:
           source: const


### PR DESCRIPTION
Adds case 5 (discharge, api.BatteryDischarge) to the batterymode switch: register 1034 accepts both charge and discharge, selected by sign - case 3 already writes it negated for charging, so discharge just writes the same register positive, at maxdischargepower. 

No clamping against the inverter's AC rating is needed: it enforces its own rating and feed-in limit against this register regardless of what is written here.

follow-up on #31995