### PR TITLE
Warn on repeated requests from different plugins only

### DIFF
--- a/plugin/http.go
+++ b/plugin/http.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/evcc-io/evcc/plugin/pipeline"
@@ -28,6 +29,7 @@ type HTTP struct {
 	pipeline    *pipeline.Pipeline
 	mu          *sync.Mutex
 	log         *util.Logger
+	id          uint64
 }
 
 func init() {
@@ -102,6 +104,7 @@ func NewHTTP(log *util.Logger, method, uri string, insecure bool, cache time.Dur
 		url:    uri,
 		method: method,
 		log:    log,
+		id:     httpID.Add(1),
 	}
 
 	// build the cache stack without logging so the logging tripper
@@ -229,7 +232,7 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 	// warn on uncached GET polling: a repeated roundtrip means neither a configured
 	// cache nor the device's own response headers spared it. cache hits are exempt.
 	if p.method == http.MethodGet && p.mu == nil && resp.Header.Get(httpcache.XFromCache) == "" {
-		if repeatedGet(url, time.Now()) {
+		if repeatedGet(p.id, url, time.Now()) {
 			p.log.WARN.Printf("uncached request repeated within 1s, please report at https://github.com/evcc-io/evcc/issues: %s", url)
 		}
 	}
@@ -246,23 +249,27 @@ func (p *HTTP) request(url string, body string) ([]byte, error) {
 
 type httpAccess struct {
 	last   time.Time
+	id     uint64
 	warned bool
 }
 
 var (
+	httpID     atomic.Uint64
 	httpSeenMu sync.Mutex
 	httpSeen   = make(map[string]httpAccess)
 )
 
-// repeatedGet reports the first time url is fetched again within a second, a sign
-// the response should be cached. It fires once per url to avoid log spam.
-func repeatedGet(url string, now time.Time) bool {
+// repeatedGet reports the first time url is fetched again within a second by a
+// different plugin, a sign the response should be cached. Repeats from the same
+// plugin are its polling cadence or a retry, not a configuration smell.
+// It fires once per url to avoid log spam.
+func repeatedGet(id uint64, url string, now time.Time) bool {
 	httpSeenMu.Lock()
 	defer httpSeenMu.Unlock()
 
 	a, seen := httpSeen[url]
-	warn := seen && !a.warned && now.Sub(a.last) < time.Second
-	httpSeen[url] = httpAccess{last: now, warned: a.warned || warn}
+	warn := seen && !a.warned && a.id != id && now.Sub(a.last) < time.Second
+	httpSeen[url] = httpAccess{last: now, id: id, warned: a.warned || warn}
 	return warn
 }
 

--- a/plugin/http_test.go
+++ b/plugin/http_test.go
@@ -168,15 +168,20 @@ func TestRepeatedGet(t *testing.T) {
 	url := "http://repeated.test/uncached"
 	t0 := time.Now()
 
-	require.False(t, repeatedGet(url, t0))                           // first sighting
-	require.True(t, repeatedGet(url, t0.Add(500*time.Millisecond)))  // repeated within 1s: warn
-	require.False(t, repeatedGet(url, t0.Add(600*time.Millisecond))) // already warned: silent
+	require.False(t, repeatedGet(1, url, t0))                           // first sighting
+	require.True(t, repeatedGet(2, url, t0.Add(500*time.Millisecond)))  // other plugin within 1s: warn
+	require.False(t, repeatedGet(3, url, t0.Add(600*time.Millisecond))) // already warned: silent
+
+	// the same plugin polling twice is its cadence or a retry, not a missing cache
+	same := "http://repeated.test/same"
+	require.False(t, repeatedGet(1, same, t0))
+	require.False(t, repeatedGet(1, same, t0.Add(500*time.Millisecond)))
 
 	spaced := "http://repeated.test/spaced"
-	require.False(t, repeatedGet(spaced, t0))
-	require.False(t, repeatedGet(spaced, t0.Add(2*time.Second))) // >1s apart: no warn
+	require.False(t, repeatedGet(1, spaced, t0))
+	require.False(t, repeatedGet(2, spaced, t0.Add(2*time.Second))) // >1s apart: no warn
 
 	// query params are part of the key, so cache-busting urls are distinct requests
-	require.False(t, repeatedGet("http://q.test/path?ts=1", t0))
-	require.False(t, repeatedGet("http://q.test/path?ts=2", t0.Add(300*time.Millisecond)))
+	require.False(t, repeatedGet(1, "http://q.test/path?ts=1", t0))
+	require.False(t, repeatedGet(2, "http://q.test/path?ts=2", t0.Add(300*time.Millisecond)))
 }


### PR DESCRIPTION
Fixes #32393.

The uncached-repeat warning fires on any two roundtrips of the same url within a second, regardless of who made them. Two paths replay a url from the same plugin:

- `site.Run` updates on the interval tick *and* on `lpUpdateChan`, and each `site.update` reads every meter once. `requestUpdate` feeds that channel on `SetMode`, `SetLimitSoc`, `SetBatteryBoost` and friends, which a vehicle disconnect triggers on its own via `defaultMode()`. A cycle takes well under a second, so both reads fall inside the window.
- `collectMeters` wraps the power read in `backoff.RetryWithData` with a 20ms initial interval, so one failed read re-requests the same url immediately.

Both are polling cadence, not a missing cache — the reporter's OpenEMS meters each have their own url and nothing to deduplicate.

The smell the warning was added for is several plugins sharing one url, where a `cache:` would collapse the reads. Keying the sighting on the plugin instance keeps that and drops the cadence and retry false positives.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)