### PR TITLE
fix: render notifications from the state at event time

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -399,7 +399,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	// setup messaging
 	var pushChan chan messenger.Event
 	if err == nil {
-		pushChan, err = configureMessengers(&conf.Messaging, &conf.MessagingEvents, site.Vehicles(), valueChan, cache)
+		pushChan, err = configureMessengers(&conf.Messaging, &conf.MessagingEvents, site.Vehicles())
 		err = wrapErrorWithClass(ClassMessenger, err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -397,7 +397,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	}
 
 	// setup messaging
-	var pushChan chan messenger.Event
+	var pushChan chan<- messenger.Event
 	if err == nil {
 		pushChan, err = configureMessengers(&conf.Messaging, &conf.MessagingEvents, site.Vehicles())
 		err = wrapErrorWithClass(ClassMessenger, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -397,7 +397,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	}
 
 	// setup messaging
-	var pushChan chan<- messenger.Event
+	var pushChan chan messenger.Event
 	if err == nil {
 		pushChan, err = configureMessengers(&conf.Messaging, &conf.MessagingEvents, site.Vehicles())
 		err = wrapErrorWithClass(ClassMessenger, err)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -53,7 +53,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/libp2p/zeroconf/v2"
 	"github.com/samber/lo"
-	"github.com/smallnest/chanx"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	vpr "github.com/spf13/viper"
@@ -974,7 +973,7 @@ func configureEEBus(conf *eebus.Config) error {
 	return nil
 }
 
-func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *globalconfig.MessagingEvents, vehicles messenger.Vehicles) (chan<- messenger.Event, error) {
+func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *globalconfig.MessagingEvents, vehicles messenger.Vehicles) (chan messenger.Event, error) {
 	// yaml config from file
 	if len(confMessaging.Events) != 0 || len(confMessaging.Services) != 0 {
 		yamlSource.messaging = globalconfig.YamlSourceFile
@@ -1003,8 +1002,8 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 		}
 	}
 
-	// events are queued by the value cache, which must not block
-	messageChan := chanx.NewUnboundedChan[messenger.Event](context.Background(), 2)
+	// events are queued by the value cache, keep enough slack to not stall it
+	messageChan := make(chan messenger.Event, 16)
 
 	var eg errgroup.Group
 
@@ -1024,7 +1023,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 	// append devices from database
 	configurable, err := config.ConfigurationsByClass(templates.Messenger)
 	if err != nil {
-		return messageChan.In, err
+		return messageChan, err
 	}
 
 	for _, conf := range configurable {
@@ -1034,7 +1033,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 	}
 
 	if err := eg.Wait(); err != nil {
-		return messageChan.In, &ClassError{ClassMessenger, err}
+		return messageChan, &ClassError{ClassMessenger, err}
 	}
 
 	var events globalconfig.MessagingEvents
@@ -1048,7 +1047,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 	messageHub, err := messenger.NewHub(events, vehicles)
 
 	if err != nil {
-		return messageChan.In, fmt.Errorf("failed configuring push services: %w", err)
+		return messageChan, fmt.Errorf("failed configuring push services: %w", err)
 	}
 
 	for _, dev := range config.Messengers().Devices() {
@@ -1057,9 +1056,9 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 		}
 	}
 
-	go messageHub.Run(messageChan.Out)
+	go messageHub.Run(messageChan)
 
-	return messageChan.In, nil
+	return messageChan, nil
 }
 
 func tariffInstance(name string, conf config.Typed) (api.Tariff, error) {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -973,7 +973,7 @@ func configureEEBus(conf *eebus.Config) error {
 	return nil
 }
 
-func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *globalconfig.MessagingEvents, vehicles messenger.Vehicles, valueChan chan<- util.Param, cache *util.ParamCache) (chan messenger.Event, error) {
+func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *globalconfig.MessagingEvents, vehicles messenger.Vehicles) (chan messenger.Event, error) {
 	// yaml config from file
 	if len(confMessaging.Events) != 0 || len(confMessaging.Services) != 0 {
 		yamlSource.messaging = globalconfig.YamlSourceFile
@@ -1043,7 +1043,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 		events = confMessaging.Events
 	}
 
-	messageHub, err := messenger.NewHub(events, vehicles, cache)
+	messageHub, err := messenger.NewHub(events, vehicles)
 
 	if err != nil {
 		return messageChan, fmt.Errorf("failed configuring push services: %w", err)
@@ -1055,7 +1055,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 		}
 	}
 
-	go messageHub.Run(messageChan, valueChan)
+	go messageHub.Run(messageChan)
 
 	return messageChan, nil
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/libp2p/zeroconf/v2"
 	"github.com/samber/lo"
+	"github.com/smallnest/chanx"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	vpr "github.com/spf13/viper"
@@ -973,7 +974,7 @@ func configureEEBus(conf *eebus.Config) error {
 	return nil
 }
 
-func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *globalconfig.MessagingEvents, vehicles messenger.Vehicles) (chan messenger.Event, error) {
+func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *globalconfig.MessagingEvents, vehicles messenger.Vehicles) (chan<- messenger.Event, error) {
 	// yaml config from file
 	if len(confMessaging.Events) != 0 || len(confMessaging.Services) != 0 {
 		yamlSource.messaging = globalconfig.YamlSourceFile
@@ -1002,7 +1003,8 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 		}
 	}
 
-	messageChan := make(chan messenger.Event, 1)
+	// events are queued by the value cache, which must not block
+	messageChan := chanx.NewUnboundedChan[messenger.Event](context.Background(), 2)
 
 	var eg errgroup.Group
 
@@ -1022,7 +1024,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 	// append devices from database
 	configurable, err := config.ConfigurationsByClass(templates.Messenger)
 	if err != nil {
-		return messageChan, err
+		return messageChan.In, err
 	}
 
 	for _, conf := range configurable {
@@ -1032,7 +1034,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 	}
 
 	if err := eg.Wait(); err != nil {
-		return messageChan, &ClassError{ClassMessenger, err}
+		return messageChan.In, &ClassError{ClassMessenger, err}
 	}
 
 	var events globalconfig.MessagingEvents
@@ -1046,7 +1048,7 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 	messageHub, err := messenger.NewHub(events, vehicles)
 
 	if err != nil {
-		return messageChan, fmt.Errorf("failed configuring push services: %w", err)
+		return messageChan.In, fmt.Errorf("failed configuring push services: %w", err)
 	}
 
 	for _, dev := range config.Messengers().Devices() {
@@ -1055,9 +1057,9 @@ func configureMessengers(confMessaging *globalconfig.Messaging, confEvents *glob
 		}
 	}
 
-	go messageHub.Run(messageChan)
+	go messageHub.Run(messageChan.Out)
 
-	return messageChan, nil
+	return messageChan.In, nil
 }
 
 func tariffInstance(name string, conf config.Typed) (api.Tariff, error) {

--- a/core/site.go
+++ b/core/site.go
@@ -1234,19 +1234,19 @@ func (site *Site) prepare() {
 	vehicle.ClearPlanLocks = site.clearPlanLocks
 }
 
-// pushEvent attaches the cache state to the event and sends it to the messenger
-// hub. The snapshot travels the value stream, so it contains exactly the values
-// published before the event was raised.
+// pushEvent queues the event in the value stream. The cache attaches its state
+// when the event reaches its position, so the message renders exactly the
+// values published before the event was raised.
 func (site *Site) pushEvent(ev messenger.Event) {
-	if site.pushChan == nil {
+	pushChan := site.pushChan
+	if pushChan == nil {
 		return
 	}
 
-	snapshot := make(util.Snapshot, 1)
-	site.valueChan <- util.Param{Val: snapshot}
-	ev.State = <-snapshot
-
-	site.pushChan <- ev
+	site.valueChan <- util.Param{Val: util.Snapshot(func(state []util.Param) {
+		ev.State = state
+		pushChan <- ev
+	})}
 }
 
 // Prepare attaches communication channels to site and loadpoints

--- a/core/site.go
+++ b/core/site.go
@@ -1234,6 +1234,21 @@ func (site *Site) prepare() {
 	vehicle.ClearPlanLocks = site.clearPlanLocks
 }
 
+// pushEvent attaches the cache state to the event and sends it to the messenger
+// hub. The snapshot travels the value stream, so it contains exactly the values
+// published before the event was raised.
+func (site *Site) pushEvent(ev messenger.Event) {
+	if site.pushChan == nil {
+		return
+	}
+
+	snapshot := make(util.Snapshot, 1)
+	site.valueChan <- util.Param{Val: snapshot}
+	ev.State = <-snapshot
+
+	site.pushChan <- ev
+}
+
 // Prepare attaches communication channels to site and loadpoints
 func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger.Event) {
 	site.pushChan = pushChan
@@ -1272,7 +1287,7 @@ func (site *Site) Prepare(valueChan chan<- util.Param, pushChan chan<- messenger
 					site.valueChan <- param
 				case ev := <-lpPushChan:
 					ev.Loadpoint = &id
-					pushChan <- ev
+					site.pushEvent(ev)
 				}
 			}
 		}(id)

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -627,10 +627,8 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 	site.publishSuggestions()
 
 	// notify on actionable suggestion changes (advisory only, see #31903)
-	if site.pushChan != nil {
-		for _, ev := range site.diffSuggestions(site.pendingSuggestions(details.BatteryDetails)) {
-			site.pushChan <- ev
-		}
+	for _, ev := range site.diffSuggestions(site.pendingSuggestions(details.BatteryDetails)) {
+		site.pushEvent(ev)
 	}
 
 	return nil

--- a/docs/agents/core-domain.md
+++ b/docs/agents/core-domain.md
@@ -122,7 +122,7 @@ effectivePrice = gridPrice * (1 - greenShare) + feedInPrice * greenShare
 |---------|-------|--------|---------|
 | `valueChan` | Site | Unbounded (`chanx.NewUnboundedChan`) | State changes -> DB + UI (ordering) |
 | `lpUpdateChan` | Site | 1 | Early loadpoint update requests |
-| `pushChan` | Loadpoint | Buffered | User notifications, queued via `valueChan` so the message renders the state at event time |
+| `pushChan` | Loadpoint | Unbounded (`chanx.NewUnboundedChan`) | User notifications, queued via `valueChan` so the message renders the state at event time |
 
 ## Tariff Integration
 

--- a/docs/agents/core-domain.md
+++ b/docs/agents/core-domain.md
@@ -122,7 +122,7 @@ effectivePrice = gridPrice * (1 - greenShare) + feedInPrice * greenShare
 |---------|-------|--------|---------|
 | `valueChan` | Site | Unbounded (`chanx.NewUnboundedChan`) | State changes -> DB + UI (ordering) |
 | `lpUpdateChan` | Site | 1 | Early loadpoint update requests |
-| `pushChan` | Loadpoint | Buffered | User notifications |
+| `pushChan` | Loadpoint | Buffered | User notifications, queued via `valueChan` so the message renders the state at event time |
 
 ## Tariff Integration
 

--- a/docs/agents/core-domain.md
+++ b/docs/agents/core-domain.md
@@ -122,7 +122,7 @@ effectivePrice = gridPrice * (1 - greenShare) + feedInPrice * greenShare
 |---------|-------|--------|---------|
 | `valueChan` | Site | Unbounded (`chanx.NewUnboundedChan`) | State changes -> DB + UI (ordering) |
 | `lpUpdateChan` | Site | 1 | Early loadpoint update requests |
-| `pushChan` | Loadpoint | Unbounded (`chanx.NewUnboundedChan`) | User notifications, queued via `valueChan` so the message renders the state at event time |
+| `pushChan` | Loadpoint | 16 | User notifications, queued via `valueChan` so the message renders the state at event time |
 
 ## Tariff Integration
 

--- a/messenger/hub.go
+++ b/messenger/hub.go
@@ -18,6 +18,7 @@ type Event struct {
 	Loadpoint  *int // optional loadpoint id
 	Event      string
 	Attributes map[string]any // optional event-specific template attributes
+	State      []util.Param   // cache state at the time the event was raised
 }
 
 type Vehicles interface {
@@ -29,12 +30,11 @@ type Vehicles interface {
 type Hub struct {
 	definitions globalconfig.MessagingEvents
 	sender      []api.Messenger
-	cache       *util.ParamCache
 	vehicles    Vehicles
 }
 
 // NewHub creates push hub with definitions and receiver
-func NewHub(cc globalconfig.MessagingEvents, vv Vehicles, cache *util.ParamCache) (*Hub, error) {
+func NewHub(cc globalconfig.MessagingEvents, vv Vehicles) (*Hub, error) {
 	// keep only enabled events
 	filtered := make(globalconfig.MessagingEvents, len(cc))
 
@@ -56,7 +56,6 @@ func NewHub(cc globalconfig.MessagingEvents, vv Vehicles, cache *util.ParamCache
 
 	h := &Hub{
 		definitions: filtered,
-		cache:       cache,
 		vehicles:    vv,
 	}
 
@@ -77,8 +76,8 @@ func (h *Hub) apply(ev Event, tmpl string) (string, error) {
 		attr["loadpoint"] = *ev.Loadpoint + 1
 	}
 
-	// get all values from cache
-	for _, p := range h.cache.All() {
+	// get all values from the event's cache state
+	for _, p := range ev.State {
 		if p.Loadpoint == nil || ev.Loadpoint == p.Loadpoint {
 			val := p.Val
 
@@ -114,7 +113,7 @@ func (h *Hub) apply(ev Event, tmpl string) (string, error) {
 }
 
 // Run is the Hub's main publishing loop
-func (h *Hub) Run(events <-chan Event, valueChan chan<- util.Param) {
+func (h *Hub) Run(events <-chan Event) {
 	log := util.NewLogger("push")
 
 	for ev := range events {
@@ -126,11 +125,6 @@ func (h *Hub) Run(events <-chan Event, valueChan chan<- util.Param) {
 		if !ok {
 			continue
 		}
-
-		// let cache catch up, refs https://github.com/evcc-io/evcc/pull/445
-		flushC := util.Flusher()
-		valueChan <- util.Param{Val: flushC}
-		<-flushC
 
 		title, err := h.apply(ev, definition.Title)
 		if err != nil {

--- a/util/param.go
+++ b/util/param.go
@@ -31,10 +31,8 @@ type ParamCache struct {
 	val map[string]Param
 }
 
-// Snapshot is the value type used for requesting a copy of the cache state.
-// The cache invokes it once it reaches the parameter's position in the stream,
-// so the copy contains exactly the values published before it. It must not
-// block, the cache cannot stall without backing up the whole value stream.
+// Snapshot requests a copy of the cache state at the parameter's position in
+// the stream. It runs on the cache's goroutine and must not block.
 type Snapshot func([]Param)
 
 // NewCache creates cache

--- a/util/param.go
+++ b/util/param.go
@@ -31,15 +31,10 @@ type ParamCache struct {
 	val map[string]Param
 }
 
-// flush is the value type used as parameter for flushing the cache.
-// Flushing is implemented by closing the channel. At this time, it is guaranteed
-// that the cache has catched up processing all pending messages.
-type flush chan struct{}
-
-// Flusher returns a new flush channel
-func Flusher() flush {
-	return make(flush)
-}
+// Snapshot is the value type used for requesting a copy of the cache state.
+// The cache responds once it reaches the parameter's position in the stream,
+// so the copy contains exactly the values published before it.
+type Snapshot chan []Param
 
 // NewCache creates cache
 func NewParamCache() *ParamCache {
@@ -51,8 +46,8 @@ func NewParamCache() *ParamCache {
 // Run adds input channel's values to cache
 func (c *ParamCache) Run(in <-chan Param) {
 	for p := range in {
-		if flushC, ok := p.Val.(flush); ok {
-			close(flushC)
+		if snapshot, ok := p.Val.(Snapshot); ok {
+			snapshot <- c.All()
 			continue
 		}
 

--- a/util/param.go
+++ b/util/param.go
@@ -32,9 +32,10 @@ type ParamCache struct {
 }
 
 // Snapshot is the value type used for requesting a copy of the cache state.
-// The cache responds once it reaches the parameter's position in the stream,
-// so the copy contains exactly the values published before it.
-type Snapshot chan []Param
+// The cache invokes it once it reaches the parameter's position in the stream,
+// so the copy contains exactly the values published before it. It must not
+// block, the cache cannot stall without backing up the whole value stream.
+type Snapshot func([]Param)
 
 // NewCache creates cache
 func NewParamCache() *ParamCache {
@@ -47,7 +48,7 @@ func NewParamCache() *ParamCache {
 func (c *ParamCache) Run(in <-chan Param) {
 	for p := range in {
 		if snapshot, ok := p.Val.(Snapshot); ok {
-			snapshot <- c.All()
+			snapshot(c.All())
 			continue
 		}
 

--- a/util/param.go
+++ b/util/param.go
@@ -32,7 +32,7 @@ type ParamCache struct {
 }
 
 // Snapshot requests a copy of the cache state at the parameter's position in
-// the stream. It runs on the cache's goroutine and must not block.
+// the stream. It runs on the cache's goroutine and must not block for long.
 type Snapshot func([]Param)
 
 // NewCache creates cache

--- a/util/param_test.go
+++ b/util/param_test.go
@@ -21,3 +21,20 @@ func TestParam(t *testing.T) {
 func TestParamCache(t *testing.T) {
 	NewParamCache().Add("foo", Param{})
 }
+
+func TestParamCacheSnapshot(t *testing.T) {
+	in := make(chan Param)
+	go NewParamCache().Run(in)
+
+	in <- Param{Key: "before", Val: 1}
+
+	snapshot := make(Snapshot, 1)
+	in <- Param{Val: snapshot}
+
+	// published after the snapshot request, must not be included
+	in <- Param{Key: "after", Val: 2}
+
+	state := <-snapshot
+	assert.Len(t, state, 1)
+	assert.Equal(t, "before", state[0].Key)
+}

--- a/util/param_test.go
+++ b/util/param_test.go
@@ -28,13 +28,13 @@ func TestParamCacheSnapshot(t *testing.T) {
 
 	in <- Param{Key: "before", Val: 1}
 
-	snapshot := make(Snapshot, 1)
-	in <- Param{Val: snapshot}
+	res := make(chan []Param, 1)
+	in <- Param{Val: Snapshot(func(state []Param) { res <- state })}
 
 	// published after the snapshot request, must not be included
 	in <- Param{Key: "after", Val: 2}
 
-	state := <-snapshot
+	state := <-res
 	assert.Len(t, state, 1)
 	assert.Equal(t, "before", state[0].Key)
 }


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/7193

Notification messages were rendered from whatever the cache happened to hold when the hub got around to the event, not from the state at the time it was raised.

The hub asked the cache to catch up by sending a flush marker into `valueChan` and waiting for it. That marker enters the stream *downstream* of the unbounded queue every site and loadpoint value passes through (`core/site.go`), while the event itself takes a shortcut straight to `pushChan`. Values still queued therefore reach the cache after the marker, so the barrier missed exactly the values the message is about — and it only ever misses them under load, which is the case it was added for in #445. In the other direction it drained too much: publishes made after the event, such as the loadpoint state being reset on disconnect, were pulled in and overwrote what the message should have described.

Events now travel the value stream themselves. `site.pushEvent()` queues a snapshot callback; the cache invokes it when the event reaches its position and the callback forwards the event, with that state attached, to the hub. Nothing waits — the loadpoint hands the event over and carries on. The callback runs on the cache's goroutine, so the hub's channel gets some slack to keep short renders from stalling it; the hub itself cannot wedge, it only reads two short mutexes and already spawns `Send` per messenger.

The flush marker, the hub's write-back into `valueChan` and its reference to the cache are all gone; the hub renders from `Event.State`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)