### PR TITLE
OpenEMS: add cache

### DIFF
--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -31,8 +31,6 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: host
-  - name: cache
-    default: 1s
   - name: password
     default: user
     advanced: true
@@ -56,6 +54,8 @@ params:
       de: FEMS/OpenEMS Standard 60s
       en: FEMS/OpenEMS standard 60s
     usages: ["battery"]
+  - name: cache
+    default: 1s
   - preset: battery-params
 render: |
   type: custom

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -63,7 +63,7 @@ render: |
   power:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/GridActivePower
-    cache: {{ .cache }} # collapse repeated reads of the same channel
+    cache: {{ .cache }}
     auth:
       type: basic
       user: x

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -54,9 +54,9 @@ params:
       de: FEMS/OpenEMS Standard 60s
       en: FEMS/OpenEMS standard 60s
     usages: ["battery"]
-- preset: battery-params
-- name: cache
-   default: 1s
+  - preset: battery-params
+  - name: cache
+     default: 1s
 render: |
   type: custom
   {{- if eq .usage "grid" }} 

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -31,6 +31,8 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: host
+  - name: cache
+    default: 1s
   - name: password
     default: user
     advanced: true
@@ -61,7 +63,7 @@ render: |
   power:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/GridActivePower
-    cache: 2s # collapse repeated reads of the same channel
+    cache: {{ .cache }} # collapse repeated reads of the same channel
     auth:
       type: basic
       user: x
@@ -70,7 +72,7 @@ render: |
   energy:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/GridBuyActiveEnergy
-    cache: 2s
+    cache: {{ .cache }}
     auth:
       type: basic
       user: x
@@ -81,7 +83,7 @@ render: |
   power:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/ProductionActivePower
-    cache: 2s
+    cache: {{ .cache }}
     auth:
       type: basic
       user: x
@@ -90,7 +92,7 @@ render: |
   energy:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/ProductionActiveEnergy
-    cache: 2s
+    cache: {{ .cache }}
     auth:
       type: basic
       user: x
@@ -102,7 +104,7 @@ render: |
   power:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/EssDischargePower
-    cache: 2s
+    cache: {{ .cache }}
     auth:
       type: basic
       user: x
@@ -111,7 +113,7 @@ render: |
   soc:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/EssSoc
-    cache: 2s
+    cache: {{ .cache }}
     auth:
       type: basic
       user: x

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -56,7 +56,7 @@ params:
     usages: ["battery"]
   - preset: battery-params
   - name: cache
-     default: 1s
+    default: 1s
 render: |
   type: custom
   {{- if eq .usage "grid" }} 

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -54,9 +54,9 @@ params:
       de: FEMS/OpenEMS Standard 60s
       en: FEMS/OpenEMS standard 60s
     usages: ["battery"]
-  - name: cache
-    default: 1s
-  - preset: battery-params
+- preset: battery-params
+- name: cache
+   default: 1s
 render: |
   type: custom
   {{- if eq .usage "grid" }} 

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -61,6 +61,7 @@ render: |
   power:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/GridActivePower
+    cache: 2s # collapse repeated reads of the same channel
     auth:
       type: basic
       user: x
@@ -69,6 +70,7 @@ render: |
   energy:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/GridBuyActiveEnergy
+    cache: 2s
     auth:
       type: basic
       user: x
@@ -79,6 +81,7 @@ render: |
   power:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/ProductionActivePower
+    cache: 2s
     auth:
       type: basic
       user: x
@@ -87,6 +90,7 @@ render: |
   energy:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/ProductionActiveEnergy
+    cache: 2s
     auth:
       type: basic
       user: x
@@ -98,6 +102,7 @@ render: |
   power:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/EssDischargePower
+    cache: 2s
     auth:
       type: basic
       user: x
@@ -106,6 +111,7 @@ render: |
   soc:
     source: http
     uri: http://{{ .host }}/rest/channel/_sum/EssSoc
+    cache: 2s
     auth:
       type: basic
       user: x


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/32393

Refs #32393. Each `site.update` reads every meter once, and `site.Run` updates both on the interval tick and on `lpUpdateChan`, which `requestUpdate` feeds on mode, limit and boost changes. Two updates landing within a second re-read every channel, which is what the reporter's log shows.

A short cache collapses those into one roundtrip. The interval is far longer than 2s, so a regular cycle still reads fresh values.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)