### PR TITLE
chore: cc the authors of a regression-causing pull request

### DIFF
--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -67,8 +67,9 @@ jobs:
           # additionally get Edit/Write + git/PR tools to actually make and push a
           # fix (fix mode also gets gh api to resolve its invoking comment). Task
           # is blocked in all modes so the agent can't offload work to a
-          # background sub-agent and exit before it returns.
-          claude_args: ${{ inputs.mode == 'analyze' && '--allowed-tools "Read,Grep,Glob,Bash(gh label list),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*)" --disallowed-tools "Task"' || (inputs.mode == 'fix' && '--allowed-tools "Read,Grep,Glob,Edit,Write,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git status),Bash(gh api:*)" --disallowed-tools "Task"' || '--allowed-tools "Read,Grep,Glob,Edit,Write,Bash(gh label list),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git status)" --disallowed-tools "Task"') }}
+          # background sub-agent and exit before it returns. All modes get read-only
+          # git log and gh pr view/diff to trace a regression to its pull request.
+          claude_args: ${{ inputs.mode == 'analyze' && '--allowed-tools "Read,Grep,Glob,Bash(gh label list),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(git log:*)" --disallowed-tools "Task"' || (inputs.mode == 'fix' && '--allowed-tools "Read,Grep,Glob,Edit,Write,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git log:*),Bash(git status),Bash(gh api:*)" --disallowed-tools "Task"' || '--allowed-tools "Read,Grep,Glob,Edit,Write,Bash(gh label list),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git log:*),Bash(git status)" --disallowed-tools "Task"') }}
           prompt: |
             You are the issue triage, analysis and fix agent for the evcc repository.
             MODE = "${{ inputs.mode }}". Work on issue/PR #${{ inputs.issue_number }}.
@@ -85,6 +86,16 @@ jobs:
             1. INVESTIGATE: Read the issue/PR and explore the relevant code
                (Read/Grep/Glob) until you understand the most likely root cause or
                affected files, or can conclude the cause is unknown.
+               If the report reads like a regression, meaning it worked in an
+               earlier release or a recent change touches the code path you
+               identified, look for the pull request that caused it:
+               `git log --oneline -20 -- <affected paths>` lists the candidates,
+               `gh pr view <number>` and `gh pr diff <number>` let you check them.
+               Only accept a pull request as the cause when the evidence is strong:
+               its change is in the failing code path AND the reported behavior
+               started with the release that shipped it. A change that merely
+               touches the same file is not enough. If you cannot establish that,
+               name no culprit.
                In "analyze" or "fix" mode you were invoked by a `/analyze` or
                `/fix` comment (id ${{ inputs.comment_id }}). Fetch it with
                `gh api repos/${{ github.repository }}/issues/comments/${{ inputs.comment_id }} --jq .body`
@@ -103,6 +114,13 @@ jobs:
                  cause. Ask the user for the specific missing details instead. When in
                  doubt whether you have enough to conclude, always err toward asking
                  rather than guessing.
+               - If, and only if, you identified a causing pull request with high
+                 certainty, name it as `#<number>` and notify the people who worked
+                 on it. Read their logins with
+                 `gh pr view <number> --json author,comments,reviews` and put a
+                 single `cc @author @commenter ...` line right above the footer.
+                 Skip bots, duplicates and the issue author. Never cc anyone when
+                 the cause is uncertain.
                Format the comment as valid GitHub-flavored Markdown. Use GitHub's
                autolink forms: `#<number>` for issues/PRs in this repo,
                `owner/repo#<number>` across repos, a bare 7–40 char SHA for commits in


### PR DESCRIPTION
When the issue agent traces a bug to a recent pull request, the people who wrote and reviewed that change currently never learn about it.

The agent now looks for the causing pull request during investigation (`git log` on the affected paths, then `gh pr view`/`gh pr diff` on the candidates) and, when it can attribute the regression with high certainty, names the pull request in its comment and adds a `cc` line for its author and commenters. Bots, duplicates and the issue author are skipped, and nothing is cc'd when the cause is uncertain, in line with the existing "never guess" rule.

The three modes gain read-only `git log` plus, for triage, `gh pr view`/`gh pr diff`. No new write capability.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)