### PR TITLE
Dockerfile: fix vite+ installer failing in the ui build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # STEP 1 build ui
 FROM --platform=$BUILDPLATFORM node:26-alpine AS node
 
-RUN apk update && apk add --no-cache make && curl -fsSL https://vite.plus | bash
+RUN apk update && apk add --no-cache make curl bash && curl -fsSL https://vite.plus | bash
+
+# the installer only wires vp into interactive shell rc files, which RUN steps don't source
+ENV PATH="/root/.vite-plus/bin:${PATH}"
 
 WORKDIR /build
 


### PR DESCRIPTION
The node:26-alpine base image ships neither curl nor bash, so the "curl -fsSL https://vite.plus | bash" installer failed immediately with exit code 127. Adding curl and bash to the apk install list fixes that, but the installer only wires the vp binary into interactive shell rc files (~/.bashrc etc.), which Docker RUN steps never source, so vp still wasn't found by the later "make ui" step. Explicitly adding /root/.vite-plus/bin to PATH fixes that too.

This was introduced in d07a0741ecb8481ad7a7405bcf34664703950981 (chore: use vite+ (#32297)), which replaced the plain npm-based UI toolchain with vite+ but only updated the Dockerfile to install it, without accounting for the base image missing curl/bash or the installer not persisting PATH across Docker layers.

Fixes #32405