### PR TITLE
Config UI: add devices via plus button in section heading

### DIFF
--- a/assets/js/components/Config/AddDeviceButton.vue
+++ b/assets/js/components/Config/AddDeviceButton.vue
@@ -17,7 +17,7 @@ export default {
 	name: "AddDeviceButton",
 	components: { AddCircle },
 	props: {
-		title: String,
+		title: { type: String, required: true },
 	},
 	emits: ["click"],
 };

--- a/assets/js/components/Config/AddDeviceButton.vue
+++ b/assets/js/components/Config/AddDeviceButton.vue
@@ -1,20 +1,21 @@
 <template>
 	<button
 		type="button"
-		class="root d-inline-flex align-items-center justify-content-center rounded-circle"
+		class="root d-inline-flex align-items-center"
 		:title="title"
 		:aria-label="title"
 		@click="$emit('click')"
 	>
-		<shopicon-regular-plus size="s"></shopicon-regular-plus>
+		<AddCircle />
 	</button>
 </template>
 
 <script>
-import "@h2d2/shopicons/es/regular/plus";
+import AddCircle from "../MaterialIcon/AddCircle.vue";
 
 export default {
 	name: "AddDeviceButton",
+	components: { AddCircle },
 	props: {
 		title: String,
 	},
@@ -24,12 +25,10 @@ export default {
 
 <style scoped>
 .root {
-	width: 2rem;
-	height: 2rem;
 	padding: 0;
 	border: none;
-	background-color: var(--evcc-dark-green);
-	color: var(--evcc-background);
+	background: none;
+	color: var(--evcc-dark-green);
 	transition: opacity var(--evcc-transition-fast) linear;
 }
 .root:hover,

--- a/assets/js/components/Config/AddDeviceButton.vue
+++ b/assets/js/components/Config/AddDeviceButton.vue
@@ -1,0 +1,39 @@
+<template>
+	<button
+		type="button"
+		class="root d-inline-flex align-items-center justify-content-center rounded-circle"
+		:title="title"
+		:aria-label="title"
+		@click="$emit('click')"
+	>
+		<shopicon-regular-plus size="s"></shopicon-regular-plus>
+	</button>
+</template>
+
+<script>
+import "@h2d2/shopicons/es/regular/plus";
+
+export default {
+	name: "AddDeviceButton",
+	props: {
+		title: String,
+	},
+	emits: ["click"],
+};
+</script>
+
+<style scoped>
+.root {
+	width: 2rem;
+	height: 2rem;
+	padding: 0;
+	border: none;
+	background-color: var(--evcc-dark-green);
+	color: var(--evcc-background);
+	transition: opacity var(--evcc-transition-fast) linear;
+}
+.root:hover,
+.root:focus-visible {
+	opacity: 0.75;
+}
+</style>

--- a/assets/js/components/MaterialIcon/AddCircle.vue
+++ b/assets/js/components/MaterialIcon/AddCircle.vue
@@ -1,0 +1,24 @@
+<template>
+	<svg :style="svgStyle" viewBox="0 0 24 24">
+		<g
+			fill="none"
+			stroke="currentColor"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+		>
+			<circle cx="12" cy="12" r="9" />
+			<path d="M12 8v8M8 12h8" />
+		</g>
+	</svg>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import icon from "@/mixins/icon";
+
+export default defineComponent({
+	name: "AddCircle",
+	mixins: [icon],
+});
+</script>

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -1320,6 +1320,10 @@ export default defineComponent({
 }) as any;
 </script>
 <style scoped>
+/* sections without devices collapse to their heading */
+.config-list:empty {
+	display: none;
+}
 .config-list {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -23,7 +23,14 @@
 				/>
 
 				<WelcomeBanner v-if="setupRequired" />
-				<h2 class="my-4">{{ $t("config.section.loadpoints") }}</h2>
+				<h2 class="my-4 d-flex align-items-center gap-2">
+					{{ $t("config.section.loadpoints") }}
+					<AddDeviceButton
+						data-testid="add-loadpoint"
+						:title="$t('config.main.addLoadpoint')"
+						@click="openModal('loadpoint')"
+					/>
+				</h2>
 				<div class="p-0 config-list box-pull-out">
 					<DeviceCard
 						v-for="loadpoint in loadpoints"
@@ -47,15 +54,16 @@
 							<LoadpointIcon v-else />
 						</template>
 					</DeviceCard>
-
-					<NewDeviceButton
-						data-testid="add-loadpoint"
-						:title="$t('config.main.addLoadpoint')"
-						@click="openModal('loadpoint')"
-					/>
 				</div>
 
-				<h2 id="vehicles" class="my-4">{{ $t("config.section.vehicles") }}</h2>
+				<h2 id="vehicles" class="my-4 d-flex align-items-center gap-2">
+					{{ $t("config.section.vehicles") }}
+					<AddDeviceButton
+						data-testid="add-vehicle"
+						:title="$t('config.main.addVehicle')"
+						@click="openModal('vehicle')"
+					/>
+				</h2>
 				<div class="p-0 config-list box-pull-out">
 					<DeviceCard
 						v-for="vehicle in vehicles"
@@ -75,14 +83,16 @@
 							<DeviceTags :tags="deviceTags('vehicle', vehicle.name)" />
 						</template>
 					</DeviceCard>
-					<NewDeviceButton
-						data-testid="add-vehicle"
-						:title="$t('config.main.addVehicle')"
-						@click="openModal('vehicle')"
-					/>
 				</div>
 
-				<h2 class="my-4 mt-5">{{ $t("config.section.consumers") }}</h2>
+				<h2 class="my-4 mt-5 d-flex align-items-center gap-2">
+					{{ $t("config.section.consumers") }}
+					<AddDeviceButton
+						data-testid="add-consumer"
+						:title="$t('config.main.addConsumer')"
+						@click="openModal('meter', { choices: ['consumer', 'aux'] })"
+					/>
+				</h2>
 				<div class="p-0 config-list box-pull-out">
 					<MeterCard
 						v-for="meter in consumerMeters"
@@ -102,14 +112,17 @@
 						:tags="deviceTags('meter', meter.name)"
 						@edit="(type, id) => openModal('meter', { type, id })"
 					/>
-					<NewDeviceButton
-						data-testid="add-consumer"
-						:title="$t('config.main.addConsumer')"
-						@click="openModal('meter', { choices: ['consumer', 'aux'] })"
-					/>
 				</div>
 
-				<h2 class="my-4 mt-5">{{ $t("config.section.grid") }}</h2>
+				<h2 class="my-4 mt-5 d-flex align-items-center gap-2">
+					{{ $t("config.section.grid") }}
+					<AddDeviceButton
+						v-if="!gridMeter"
+						data-testid="add-grid"
+						:title="$t('config.main.addGrid')"
+						@click="openModal('meter', { type: 'grid' })"
+					/>
+				</h2>
 				<div class="p-0 config-list box-pull-out">
 					<MeterCard
 						v-if="gridMeter"
@@ -120,14 +133,14 @@
 						:tags="deviceTags('meter', gridMeter.name)"
 						@edit="(type, id) => openModal('meter', { type, id })"
 					/>
-					<NewDeviceButton
-						v-else
-						:title="$t('config.main.addGrid')"
-						data-testid="add-grid"
-						@click="openModal('meter', { type: 'grid' })"
-					/>
 				</div>
-				<h2 class="my-4 mt-5">{{ $t("config.section.meter") }}</h2>
+				<h2 class="my-4 mt-5 d-flex align-items-center gap-2">
+					{{ $t("config.section.meter") }}
+					<AddDeviceButton
+						:title="$t('config.main.addPvBattery')"
+						@click="openModal('meter', { choices: ['pv', 'battery'] })"
+					/>
+				</h2>
 				<div class="p-0 config-list box-pull-out">
 					<MeterCard
 						v-for="meter in pvMeters"
@@ -148,13 +161,16 @@
 						:tags="deviceTags('meter', meter.name)"
 						@edit="(type, id) => openModal('meter', { type, id })"
 					/>
-					<NewDeviceButton
-						:title="$t('config.main.addPvBattery')"
-						@click="openModal('meter', { choices: ['pv', 'battery'] })"
-					/>
 				</div>
 
-				<h2 class="my-4 mt-5">{{ $t("config.section.additionalMeter") }}</h2>
+				<h2 class="my-4 mt-5 d-flex align-items-center gap-2">
+					{{ $t("config.section.additionalMeter") }}
+					<AddDeviceButton
+						data-testid="add-additional"
+						:title="$t('config.main.addAdditional')"
+						@click="openModal('meter', { type: 'ext' })"
+					/>
+				</h2>
 				<div class="p-0 config-list box-pull-out">
 					<MeterCard
 						v-for="meter in extMeters"
@@ -165,14 +181,23 @@
 						:tags="deviceTags('meter', meter.name)"
 						@edit="(type, id) => openModal('meter', { type, id })"
 					/>
-					<NewDeviceButton
-						data-testid="add-additional"
-						:title="$t('config.main.addAdditional')"
-						@click="openModal('meter', { type: 'ext' })"
-					/>
 				</div>
 
-				<h2 id="tariffs" class="my-4 mt-5">{{ $t("config.tariff.title") }}</h2>
+				<h2 id="tariffs" class="my-4 mt-5 d-flex align-items-center gap-2">
+					{{ $t("config.tariff.title") }}
+					<template v-if="!tariffsYamlSource">
+						<AddDeviceButton
+							v-if="possibleTariffTypes.length"
+							:title="$t('config.tariff.addTariff')"
+							@click="openModal('tariff', { choices: possibleTariffTypes })"
+						/>
+						<AddDeviceButton
+							v-if="possibleForecastTypes.length"
+							:title="$t('config.tariff.addForecast')"
+							@click="openModal('tariff', { choices: possibleForecastTypes })"
+						/>
+					</template>
+				</h2>
 				<div v-if="!!tariffsYamlSource" class="p-0 config-list box-pull-out">
 					<DeviceCard
 						:title="$t('config.tariff.title')"
@@ -211,11 +236,6 @@
 						:currency="currency"
 						@edit="openModal('tariff', { type: 'feedIn', id: feedInTariff.id })"
 					/>
-					<NewDeviceButton
-						v-if="possibleTariffTypes.length"
-						:title="$t('config.tariff.addTariff')"
-						@click="openModal('tariff', { choices: possibleTariffTypes })"
-					/>
 					<TariffCard
 						v-if="co2Tariff"
 						:tariff="co2Tariff"
@@ -252,11 +272,6 @@
 						:tags="deviceTags('tariff', plannerTariff.name)"
 						:currency="currency"
 						@edit="openModal('tariff', { type: 'planner', id: plannerTariff.id })"
-					/>
-					<NewDeviceButton
-						v-if="possibleForecastTypes.length"
-						:title="$t('config.tariff.addForecast')"
-						@click="openModal('tariff', { choices: possibleForecastTypes })"
 					/>
 				</div>
 
@@ -507,7 +522,7 @@ import "@h2d2/shopicons/es/regular/sun";
 import "@h2d2/shopicons/es/regular/batterythreequarters";
 import "@h2d2/shopicons/es/regular/powersupply";
 import "@h2d2/shopicons/es/regular/receivepayment";
-import NewDeviceButton from "../components/Config/NewDeviceButton.vue";
+import AddDeviceButton from "../components/Config/AddDeviceButton.vue";
 import api from "../api";
 import ChargerModal from "../components/Config/ChargerModal.vue";
 import CircuitsIcon from "../components/MaterialIcon/Circuits.vue";
@@ -602,7 +617,7 @@ import AuthProvidersCard from "../components/Config/AuthProvidersCard.vue";
 export default defineComponent({
 	name: "Config",
 	components: {
-		NewDeviceButton,
+		AddDeviceButton,
 		BackupRestoreModal,
 		ChargerModal,
 		CircuitsIcon,


### PR DESCRIPTION
The config UI spent a full card row per section on empty "Add …" placeholders. That row is now a green outlined plus appended to the section heading, and sections without devices collapse to their heading.

- new `AddDeviceButton` (heading plus) + `MaterialIcon/AddCircle` (outlined circle, rounded plus, matches the existing icon style)
- visibility of each plus follows the card it replaces (grid plus only without grid meter, tariff/forecast plus only when types are left)
- accessible names unchanged, so existing e2e selectors keep working
- `NewDeviceButton` stays for the in-modal type choices

![config UI](https://gist.githubusercontent.com/andig/1742ce5c5bbda885eac60c34cc9757be/raw/38ff1a4ff38ce0c4d84a3e8fda89cc887a6cda68/config-after.png)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
