### PR TITLE
Docs: mention --disable-auth for local UI checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This file provides guidance to AI coding agents when working with code in this r
 - `make lint-ui` - run frontend linting
 - `vp run dev` - start Vue dev server (http://127.0.0.1:7071)
 - `vp run playwright` - run integration tests
+- `evcc --config [file] --disable-auth` - run a throw-away instance for UI checks without password setup
 - `evcc --template-type [type] --template [file]` - test device templates
 - `make docs` - generate template documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,13 @@ vp install
 vp run dev
 ```
 
+Start the backend with `--disable-auth` when checking the configuration UI of a
+throw-away instance. Without it the UI asks for an administrator password first.
+
+```sh
+./evcc --config tests/config-with-tariffs.evcc.yaml --disable-auth
+```
+
 ### Storybook
 
 We're using storybook to develop and visualize UI components in different states. Running the command below will open your browser at http://127.0.0.1:6006/.


### PR DESCRIPTION
Manually opening the config UI of a freshly started instance drops you on the "Set Administrator Password" gate first, which is easy to trip over when all you want is a quick visual check. The e2e harness already avoids it via `--disable-auth`, so document the flag next to the UI development docs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
