### PR TITLE
UI: close the bottom bar more menu on a second tab click

### DIFF
--- a/assets/js/components/BottomTabs/MoreItem.vue
+++ b/assets/js/components/BottomTabs/MoreItem.vue
@@ -98,9 +98,21 @@ export default defineComponent({
 			return "bg-darker-green";
 		},
 	},
+	mounted() {
+		document.addEventListener("click", this.closeOnClickOutside, true);
+	},
+	unmounted() {
+		document.removeEventListener("click", this.closeOnClickOutside, true);
+	},
 	methods: {
 		toggleMenu() {
 			this.open = !this.open;
+		},
+		// the tab item wraps both toggle and menu, clicks inside are handled by them
+		closeOnClickOutside(e: MouseEvent) {
+			if (this.open && !this.$el.contains(e.target as Node)) {
+				this.open = false;
+			}
 		},
 	},
 });

--- a/assets/js/components/BottomTabs/MoreMenu.vue
+++ b/assets/js/components/BottomTabs/MoreMenu.vue
@@ -115,10 +115,7 @@ export default defineComponent({
 	},
 	emits: ["close"],
 	data() {
-		return {
-			isApp: isApp(),
-			onClickOutside: undefined as ((e: MouseEvent) => void) | undefined,
-		};
+		return { isApp: isApp() };
 	},
 	computed: {
 		providers() {
@@ -167,19 +164,6 @@ export default defineComponent({
 		hasVehicles() {
 			return Object.keys(this.vehicles).length > 0;
 		},
-	},
-	mounted() {
-		this.onClickOutside = (e: MouseEvent) => {
-			if (this.open && !this.$el.contains(e.target as Node)) {
-				this.$emit("close");
-			}
-		};
-		document.addEventListener("click", this.onClickOutside, true);
-	},
-	unmounted() {
-		if (this.onClickOutside) {
-			document.removeEventListener("click", this.onClickOutside, true);
-		}
 	},
 	methods: {
 		handleAuthRequired() {

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -30,9 +30,16 @@ test.describe("bottom navigation", async () => {
     await expect(tabMore).toBeVisible();
     await expect(tabBattery).toHaveCount(0);
 
+    // more menu opens and closes on the same tab
+    const configLink = tabMore.getByRole("link", { name: "Configuration" });
+    await tabMore.click();
+    await expect(configLink).toBeVisible();
+    await tabMore.click();
+    await expect(configLink).not.toBeVisible();
+
     // navigate to config via More menu
     await tabMore.click();
-    await tabMore.getByRole("link", { name: "Configuration" }).click();
+    await configLink.click();
     await expect(page.getByRole("heading", { name: "Configuration" })).toBeVisible();
 
     // create battery meter


### PR DESCRIPTION
Clicking the "More" tab in the bottom bar while its menu is open left the menu open, so the entry could not be used to hide it again.

`MoreMenu` has two root nodes (the teleported backdrop and the menu itself), so `this.$el` resolves to the teleport anchor and `$el.contains(target)` is never true. Its capture-phase document listener therefore treated every click as an outside click, including the one on the tab that owns the menu: the listener closed the menu during capture, then the tab's own bubbling `toggleMenu` reopened it.

Moved the outside-click guard to `MoreItem`, which owns the `open` state and has a single root element wrapping both the toggle and the menu. Clicks inside stay with the handlers that already deal with them, everything else closes the menu.

Extended the existing bottom navigation test to open and close the menu from the same tab.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
