### PR TITLE
Assistant: stream the thinking while the answer is worked on

### DIFF
--- a/assets/js/components/Assistant/AssistantWidget.vue
+++ b/assets/js/components/Assistant/AssistantWidget.vue
@@ -352,6 +352,10 @@ export default defineComponent({
 .head {
 	border-bottom: 1px solid var(--evcc-box-border);
 }
+.log {
+	/* prevent scroll chaining from the conversation to the page behind it */
+	overscroll-behavior: contain;
+}
 .foot {
 	border-top: 1px solid var(--evcc-box-border);
 }

--- a/assets/js/components/Assistant/AssistantWidget.vue
+++ b/assets/js/components/Assistant/AssistantWidget.vue
@@ -61,9 +61,12 @@
 					</template>
 					<span v-else>{{ m.content }}</span>
 				</div>
-				<div v-if="pending" class="text-muted d-flex align-items-center gap-2">
-					<span class="spinner-border spinner-border-sm" role="status"></span>
-					{{ $t("assistant.thinking") }}
+				<div v-if="pending">
+					<AssistantSteps v-if="showThinking" :steps="liveSteps" />
+					<div class="text-muted d-flex align-items-center gap-2">
+						<span class="spinner-border spinner-border-sm" role="status"></span>
+						{{ $t("assistant.thinking") }}
+					</div>
 				</div>
 				<p v-if="error" class="text-danger mb-0">{{ error }}</p>
 			</div>
@@ -102,8 +105,14 @@ import AssistantIcon from "../MaterialIcon/Assistant.vue";
 import AssistantSteps from "./AssistantSteps.vue";
 import Markdown from "../Config/Markdown.vue";
 import api from "@/api";
+import { openLoginModal } from "@/components/Auth/auth";
 import settings from "@/settings";
-import type { AssistantMessage } from "@/types/evcc";
+import type {
+	AssistantEvent,
+	AssistantMessage,
+	AssistantResult,
+	AssistantStep,
+} from "@/types/evcc";
 
 export default defineComponent({
 	name: "AssistantWidget",
@@ -119,6 +128,8 @@ export default defineComponent({
 			question: "",
 			error: "",
 			messages: [] as AssistantMessage[],
+			// steps of the running question, shown until the answer replaces them
+			liveSteps: [] as AssistantStep[],
 			// asked questions, oldest first, browsed with cursor up/down
 			history: [] as string[],
 			// position in history, -1 while editing the unsent draft
@@ -201,6 +212,26 @@ export default defineComponent({
 				if (log) log.scrollTop = log.scrollHeight;
 			});
 		},
+		// readEvents hands over each ndjson line as it arrives, a line may be split across chunks
+		async readEvents(body: ReadableStream<Uint8Array>, onEvent: (ev: AssistantEvent) => void) {
+			const reader = body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+
+			for (;;) {
+				const { done, value } = await reader.read();
+				if (done) return;
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				// the last piece is only complete once its newline arrives
+				buffer = lines.pop() || "";
+
+				for (const line of lines) {
+					if (line.trim()) onEvent(JSON.parse(line));
+				}
+			}
+		},
 		async submit() {
 			const content = this.question.trim();
 			if (!content || this.pending) return;
@@ -213,6 +244,7 @@ export default defineComponent({
 
 			this.question = "";
 			this.error = "";
+			this.liveSteps = [];
 			this.messages.push({ role: "user", content });
 			this.pending = true;
 			this.scrollDown();
@@ -222,27 +254,41 @@ export default defineComponent({
 			const conversation = this.messages;
 
 			try {
-				const res = await api.post(
-					"/assistant/chat",
+				const res = await fetch(`${api.defaults.baseURL}assistant/chat`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
 					// steps are display only, sending them back would bloat every request
-					{
+					body: JSON.stringify({
 						messages: this.messages.map(({ role, content }) => ({ role, content })),
 						context: this.context,
-					},
-					{
-						signal: controller.signal,
-						validateStatus: (code) => [200, 400, 412, 500, 502].includes(code),
-					}
-				);
-				if (res.status === 200) {
-					this.messages.push({
-						role: "assistant",
-						content: res.data.content,
-						steps: res.data.steps,
-					});
-					if (!this.open) this.unread = true;
+					}),
+					signal: controller.signal,
+				});
+
+				if (!res.ok || !res.body) {
+					if (res.status === 401) openLoginModal();
+					const data = await res.json().catch(() => null);
+					this.error = data?.error || res.statusText;
 				} else {
-					this.error = res.data?.error || res.statusText;
+					let result: AssistantResult | undefined;
+
+					await this.readEvents(res.body, (ev) => {
+						if (ev.step) {
+							this.liveSteps.push(ev.step);
+							this.scrollDown();
+						}
+						if (ev.error) this.error = ev.error;
+						if (ev.result) result = ev.result;
+					});
+
+					if (result) {
+						this.messages.push({
+							role: "assistant",
+							content: result.content,
+							steps: result.steps,
+						});
+						if (!this.open) this.unread = true;
+					}
 				}
 			} catch (e: any) {
 				if (controller.signal.aborted) {

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -165,6 +165,18 @@ export interface AssistantMessage {
   steps?: AssistantStep[];
 }
 
+export interface AssistantResult {
+  content: string;
+  steps?: AssistantStep[];
+}
+
+// AssistantEvent is one line of the streamed answer, steps arrive before the result
+export interface AssistantEvent {
+  step?: AssistantStep;
+  result?: AssistantResult;
+  error?: string;
+}
+
 export interface ConfigStatus<C, S> {
   config?: C;
   status?: S;

--- a/server/assistant/assistant.go
+++ b/server/assistant/assistant.go
@@ -68,6 +68,7 @@ type Assistant struct {
 	tools   []llms.Tool // offered to the model
 	catalog []llms.Tool // searchable through findTools
 	context string
+	onStep  func(Step) // reports a finished round while the answer is still being worked on
 }
 
 // New connects a language model to the given MCP server
@@ -118,6 +119,12 @@ func newAssistant(ctx context.Context, llm llms.Model, srv *mcpsdk.Server) (*Ass
 // WithContext adds situational context, e.g. the ui page the question was asked from
 func (a *Assistant) WithContext(s string) *Assistant {
 	a.context = s
+	return a
+}
+
+// WithSteps reports each round as it finishes, the caller can show the work before the answer
+func (a *Assistant) WithSteps(f func(Step)) *Assistant {
+	a.onStep = f
 	return a
 }
 
@@ -262,6 +269,9 @@ func (a *Assistant) Chat(ctx context.Context, history []Message) (Result, error)
 	addStep := func(step Step) {
 		if step.Reasoning != "" || len(step.Calls) > 0 {
 			steps = append(steps, step)
+			if a.onStep != nil {
+				a.onStep(step)
+			}
 		}
 	}
 

--- a/server/assistant/assistant_test.go
+++ b/server/assistant/assistant_test.go
@@ -78,6 +78,13 @@ func TestToolLoop(t *testing.T) {
 	assert.ElementsMatch(t, []string{findToolsName, callToolName}, toolNames(a.tools))
 	assert.ElementsMatch(t, []string{"getSoc", "failing"}, toolNames(a.catalog))
 
+	var streamed []Step
+	a.WithSteps(func(step Step) {
+		// the step is handed over while the answer is still being worked on
+		assert.Len(t, llm.responses, 1, "step reported after the last round")
+		streamed = append(streamed, step)
+	})
+
 	res, err := a.Chat(ctx, []Message{{Role: "user", Content: "what is the soc?"}})
 	require.NoError(t, err)
 	assert.Equal(t, "The vehicle is at 42%.", res.Content)
@@ -85,6 +92,7 @@ func TestToolLoop(t *testing.T) {
 	// the tool round is reported as intermediate work
 	require.Len(t, res.Steps, 1)
 	assert.Equal(t, []Call{{Name: "getSoc", Arguments: `{"loadpoint":1}`}}, res.Steps[0].Calls)
+	assert.Equal(t, res.Steps, streamed)
 
 	// second round trip contains the tool result
 	second := llm.seen[1]

--- a/server/assistant/handler.go
+++ b/server/assistant/handler.go
@@ -21,6 +21,14 @@ type chatRequest struct {
 	Context  string    `json:"context,omitempty"`
 }
 
+// chatEvent is a single line of the ndjson response. Steps are sent as they happen,
+// the result closes the stream. Errors before the first line keep their status code.
+type chatEvent struct {
+	Step   *Step   `json:"step,omitempty"`
+	Result *Result `json:"result,omitempty"`
+	Error  string  `json:"error,omitempty"`
+}
+
 // ChatHandler answers questions using the configured model and evcc's own MCP tools.
 // The MCP server is built lazily and reused, host serves the internal api requests.
 func ChatHandler(host http.Handler) http.HandlerFunc {
@@ -55,8 +63,10 @@ func ChatHandler(host http.Handler) http.HandlerFunc {
 		ctx, cancel := context.WithTimeout(r.Context(), chatTimeout)
 		defer cancel()
 
+		rc := http.NewResponseController(w)
+
 		// model responses outlive the server's default write timeout
-		_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(chatTimeout))
+		_ = rc.SetWriteDeadline(time.Now().Add(chatTimeout))
 
 		a, err := New(ctx, cfg, srv)
 		if err != nil {
@@ -65,13 +75,33 @@ func ChatHandler(host http.Handler) http.HandlerFunc {
 		}
 		defer a.Close()
 
-		res, err := a.WithContext(req.Context).Chat(ctx, req.Messages)
+		// the answer takes tool rounds to arrive, the steps are shown while it is worked on
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		enc := json.NewEncoder(w)
+
+		var streamed bool
+		send := func(ev chatEvent) {
+			streamed = true
+			_ = enc.Encode(ev)
+			_ = rc.Flush()
+		}
+
+		res, err := a.WithContext(req.Context).WithSteps(func(step Step) {
+			send(chatEvent{Step: &step})
+		}).Chat(ctx, req.Messages)
+
+		// a model that fails before the first step still gets its status code, afterwards
+		// the response is long committed and the error has to go into the stream
 		if err != nil {
-			jsonError(w, http.StatusBadGateway, err)
+			if !streamed {
+				jsonError(w, http.StatusBadGateway, err)
+				return
+			}
+			send(chatEvent{Error: err.Error()})
 			return
 		}
 
-		jsonWrite(w, res)
+		send(chatEvent{Result: &res})
 	}
 }
 


### PR DESCRIPTION
The steps of a question were only shown once the whole answer had arrived. A model that spends minutes on tool rounds left the widget with a spinner and nothing to look at, even though the rounds were already known to the backend.

`/api/assistant/chat` now answers `application/x-ndjson`, one JSON value per line:

```
{"step":{"reasoning":"…","calls":[{"name":"getState","arguments":"{\"jq\":\".loadpoints\"}"}]}}
{"step":{"calls":[…]}}
{"result":{"content":"…","steps":[…]}}
```

A step goes out and is flushed the moment its round finishes, so the widget can render it while the model works on the next one. A JSON array would have needed its closing bracket first, which is exactly the old behaviour.

- `Assistant.WithSteps(func(Step))` reports each round, called from the existing `addStep` — the tool loop itself is unchanged.
- An error before the first step still gets its status code (502, 412, …). Once the response is committed the error has to travel as `{"error":…}` in the stream.
- The widget swapped `axios.post` for `fetch`, since axios buffers the whole body. Login modal on 401 is kept, errors are reported in the panel as before.

Steps still ride along in the final result — they are what the message keeps for the conversation history.

The second commit is unrelated to the streaming but sits in the same component: the conversation log let its scroll chain to the page behind the panel once it hit top or bottom, fixed with `overscroll-behavior: contain`.

Unrelated, noticed while running the suite: `tests/config-assistant.spec.ts:90` expects `/connection refused/i`, but since ollama moved to the OpenAI-compatible endpoint (81e6bb3ce) langchaingo sanitizes network errors to `network error: failed to reach API server`. The spec fails on the branch tip without this change as well, so I left it alone.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
