### PR TITLE
Assistant: stop the conversation scroll from moving the page behind it

### DIFF
--- a/assets/js/components/Assistant/AssistantWidget.vue
+++ b/assets/js/components/Assistant/AssistantWidget.vue
@@ -306,6 +306,10 @@ export default defineComponent({
 .head {
 	border-bottom: 1px solid var(--evcc-box-border);
 }
+.log {
+	/* prevent scroll chaining from the conversation to the page behind it */
+	overscroll-behavior: contain;
+}
 .foot {
 	border-top: 1px solid var(--evcc-box-border);
 }


### PR DESCRIPTION
Scrolling inside the assistant panel chained on to the page as soon as the conversation hit its first or last message, so the view behind the widget scrolled away instead of stopping.

`overscroll-behavior: contain` on the scrolling element, the same treatment `.modal` already gets in `assets/css/app.css`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
