### PR TITLE
Atmoce: fix curtailed for battery

### DIFF
--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -425,7 +425,7 @@ render: |
               address: 60324 # Grid Maximum Export Power (kW * 1000)
               type: writemultiple
               encoding: uint32
-  curtailed:
+  curtailed: # the power limit is expressed as percent of nominal discharge power
     source: go
     in:
       - name: limit
@@ -437,7 +437,18 @@ render: |
             address: 60324 # Grid Maximum Export Power (kW * 1000)
             type: holding
             decode: uint32
-    script: limit != 0xFFFFFFFF
+      - name: maxdischargepower
+        type: int
+        config:
+          source: const
+          value: {{ .maxdischargepower }}
+    script: |
+      percent := 100
+      if limit != 0xFFFFFFFF && maxdischargepower > 0 {
+        // round, the watt conversion does not reproduce the written percent exactly
+        percent = (limit*100 + maxdischargepower/2) / maxdischargepower
+      }
+      percent
   dim:
     source: ifelse
     if:


### PR DESCRIPTION
Bugfix related to https://github.com/evcc-io/evcc/pull/32010.

Since then, when validating Atmoce battery template, the error `curtailed: not a int: false` was shown.

This PR fixes the issue by returning percentage instead of boolean on `curtailed`.