### PR TITLE
Add Deye/Sunsynk 1P hybrid inverter template

### DIFF
--- a/templates/definition/meter/deye-hybrid-1p.yaml
+++ b/templates/definition/meter/deye-hybrid-1p.yaml
@@ -1,0 +1,247 @@
+template: deye-hybrid-1p
+products:
+  - brand: Deye
+    description:
+      generic: 1p hybrid inverter
+  - brand: Sunsynk
+    description:
+      generic: 1p hybrid inverter
+capabilities: ["battery-control", "curtail"]
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+    baudrate: 9600
+    id: 1
+  - name: maxacpower
+    required: true
+    usages: ["pv"]
+  - preset: battery-params
+  - name: maxdischargecurrent
+    required: true
+    default: 100
+    usages: ["battery"]
+    advanced: true
+    description:
+      en: Max Discharge Current
+      de: Max Entladestrom
+    help:
+      en: |
+        Maximum battery discharge current in Amperes (A) for normal mode.
+        Set via modbus register 211. Typical range depends on battery and inverter capacity.
+      de: |
+        Maximaler Batterieentladestrom in Ampere (A) für Normalmodus.
+        Wird über Modbus-Register 211 gesetzt. Typischer Bereich abhängig von Batterie- und Wechselrichterkapazität.
+  - name: gridchargecurrent
+    required: true
+    default: 60
+    usages: ["battery"]
+    advanced: true
+    description:
+      en: Grid Charge Current
+      de: Netzladestrom
+    help:
+      en: |
+        Battery charging current in Amperes (A) from grid for charge mode.
+        Set via modbus register 230. Typical range 0-185A.
+      de: |
+        Batterieladestrom in Ampere (A) aus dem Netz für Lademodus.
+        Wird über Modbus-Register 230 gesetzt. Typischer Bereich 0-185A.
+  - name: includegenport
+    type: bool
+    advanced: true
+    description:
+      de: GEN/AUX-Anschluss als Solar-Eingang nutzen
+      en: Treat GEN/AUX port as additional solar input
+    help:
+      de: |
+        Wenn aktiviert, wird die Leistung des GEN/AUX-Anschlusses (Register 166)
+        zur gesamten PV-Leistung addiert.
+      en: |
+        When enabled, the GEN/AUX port power (register 166) is added to the total PV power.
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 169 # Grid power (W)
+      type: holding
+      decode: int16
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 186 # PV1 power (W)
+        type: holding
+        decode: int16
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 187 # PV2 power (W)
+        type: holding
+        decode: int16
+    {{- if eq .includegenport "true" }}
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 166 # GEN/AUX power (W)
+        type: holding
+        decode: int16
+    {{- end }}
+  maxacpower: {{ .maxacpower }}
+  # Feed-in curtailment via "Max Sell Power" (register 245, watts).
+  # The register is the device's always-active feed-in ceiling.
+  # "Solar Export" (register 247) is the owner's export on/off switch
+  # and left untouched.
+  curtail: # limit feed-in to the given percent of nominal (100 % = nominal power)
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 245 # Max Sell Power (W)
+      type: writemultiple
+      decode: uint16
+    scale: {{ divf (maxf .maxacpower 1) 100 }} # % to W
+  curtailed: # allowed feed-in as percent of nominal, derived from Max Sell Power
+    source: go
+    in:
+      - name: limit
+        type: float
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 245 # Max Sell Power (W)
+            type: holding
+            decode: uint16
+    script: |
+      // round, the watt conversion does not reproduce the written percent exactly
+      p := int(limit*100/{{ maxf .maxacpower 1 }} + 0.5)
+      if p > 100 {
+        p = 100
+      }
+      p
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 190 # Battery power (W)
+      type: holding
+      decode: int16
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 184 # Battery SOC (%)
+      type: holding
+      decode: uint16
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 255 # enable Use Timer
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 248 # Use Timer
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: {{ .maxdischargecurrent }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 211 # Battery Max Discharge Current
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0 # disable grid charging
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 230 # Grid Charge Battery Current
+              type: writemultiple
+              decode: uint16
+    - case: 2 # hold - prevent discharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 0 # disable Use Timer
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 248 # Use Timer
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0 # zero discharge
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 211 # Battery Max Discharge Current
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0 # disable grid charging
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 230 # Grid Charge Battery Current
+              type: writemultiple
+              decode: uint16
+    - case: 3 # charge - enable grid charging
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 0 # disable Use Timer (ignore TOU schedule)
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 248 # Use Timer
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: {{ .gridchargecurrent }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 230 # Grid Charge Battery Current
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: {{ .maxdischargecurrent }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 211 # Battery Max Discharge Current
+              type: writemultiple
+              decode: uint16
+    - case: 4 # holdcharge
+      set:
+        source: error
+        error: ErrNotAvailable
+  {{- include "battery-params" . }}
+  {{- end }}

--- a/templates/definition/meter/deye-hybrid-1p.yaml
+++ b/templates/definition/meter/deye-hybrid-1p.yaml
@@ -50,7 +50,7 @@ params:
     type: bool
     advanced: true
     description:
-      de: GEN/AUX-Anschluss als zusätzlichen Solar-Eingang verwenden
+      de: GEN/AUX-Anschluss als Solar-Eingang nutzen
       en: Treat GEN/AUX port as additional solar input
     help:
       de: |

--- a/templates/definition/meter/deye-hybrid-1p.yaml
+++ b/templates/definition/meter/deye-hybrid-1p.yaml
@@ -72,7 +72,21 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 150 # Grid voltage (V)
+        address: 150 # Grid voltage L1 (V)
+        type: holding
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 150 # Grid voltage L2 (V)
+        type: holding
+        decode: uint16
+      scale: 0.1
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 150 # Grid voltage L3 (V)
         type: holding
         decode: uint16
       scale: 0.1
@@ -80,7 +94,21 @@ render: |
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
-        address: 160 # Grid current (A)
+        address: 160 # Grid current L1 (A)
+        type: holding
+        decode: int16
+      scale: 0.01
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 160 # Grid current L2 (A)
+        type: holding
+        decode: int16
+      scale: 0.01
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 160 # Grid current L3 (A)
         type: holding
         decode: int16
       scale: 0.01

--- a/templates/definition/meter/deye-hybrid-1p.yaml
+++ b/templates/definition/meter/deye-hybrid-1p.yaml
@@ -68,14 +68,14 @@ render: |
       address: 169 # Grid power (W)
       type: holding
       decode: int16
-  voltage:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 150 # Grid voltage (V)
-      type: holding
-      decode: uint16
-    scale: 0.1
+  voltages:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 150 # Grid voltage (V)
+        type: holding
+        decode: uint16
+      scale: 0.1
   currents:
     - source: modbus
       {{- include "modbus" . | indent 4 }}

--- a/templates/definition/meter/deye-hybrid-1p.yaml
+++ b/templates/definition/meter/deye-hybrid-1p.yaml
@@ -1,0 +1,275 @@
+template: deye-hybrid-1p
+covers: ["deye-hybrid-1p", "deye-hybrid-hp1"]
+products:
+  - brand: Deye
+    description:
+      generic: 1p hybrid inverter
+  - brand: Sunsynk
+    description:
+      generic: 1p hybrid inverter
+capabilities: ["battery-control", "curtail"]
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+  - name: modbus
+    choice: ["rs485", "tcpip"]
+    baudrate: 9600
+    id: 1
+  - name: maxacpower
+    required: true
+  - preset: battery-params
+  - name: maxdischargecurrent
+    required: true
+    default: 100
+    advanced: true
+    description:
+      en: Max Discharge Current
+      de: Max Entladestrom
+    help:
+      en: |
+        Maximum battery discharge current in Amperes (A) for normal mode.
+        Set via modbus register 211. Typical range depends on battery and inverter capacity.
+      de: |
+        Maximaler Batterieentladestrom in Ampere (A) für Normalmodus.
+        Wird über Modbus-Register 211 gesetzt. Typischer Bereich abhängig von Batterie- und Wechselrichterkapazität.
+  - name: gridchargecurrent
+    required: true
+    default: 60
+    advanced: true
+    description:
+      en: Grid Charge Current
+      de: Netzladestrom
+    help:
+      en: |
+        Battery charging current in Amperes (A) from grid for charge mode.
+        Set via modbus register 230. Typical range 0-185A.
+      de: |
+        Batterieladestrom in Ampere (A) aus dem Netz für Lademodus.
+        Wird über Modbus-Register 230 gesetzt. Typischer Bereich 0-185A.
+  - name: includegenport
+    type: bool
+    advanced: true
+    description:
+      de: GEN/AUX-Anschluss als zusätzlichen Solar-Eingang verwenden
+      en: Treat GEN/AUX port as additional solar input
+    help:
+      de: |
+        Wenn aktiviert, wird die Leistung des GEN/AUX-Anschlusses (Register 166)
+        zur gesamten PV-Leistung addiert.
+      en: |
+        When enabled, the GEN/AUX port power (register 166) is added to the total PV power.
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 169 # Grid power (W)
+      type: holding
+      decode: int16
+  voltage:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 150 # Grid voltage (V)
+      type: holding
+      decode: uint16
+    scale: 0.1
+  currents:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 160 # Grid current (A)
+        type: holding
+        decode: int16
+      scale: 0.01
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power:
+    source: calc
+    add:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 186 # PV1 power (W)
+        type: holding
+        decode: int16
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 187 # PV2 power (W)
+        type: holding
+        decode: int16
+    {{- if .includegenport }}
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        address: 166 # GEN/AUX power (W)
+        type: holding
+        decode: int16
+    {{- end }}
+  maxacpower: {{ .maxacpower }}
+  # Feed-in curtailment via "Max Sell Power" (register 245, watts).
+  # The register is the device's always-active feed-in ceiling.
+  # "Solar Export" (register 247) is the owner's export on/off switch
+  # and left untouched.
+  curtail: # limit feed-in to the given percent of nominal (100 % = nominal power)
+    source: go
+    in:
+      - name: maxacpower
+        type: int
+        config:
+          source: const
+          value: {{ .maxacpower }}
+    script: |
+      powerlimit := ( maxacpower * curtail ) / 100
+      powerlimit
+    out:
+      - name: powerlimit
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 245 # Max Sell Power (W)
+            type: writemultiple
+            decode: uint16
+  curtailed: # allowed feed-in as percent of nominal, derived from Max Sell Power
+    source: go
+    in:
+      - name: limit
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 245 # Max Sell Power (W)
+            type: holding
+            decode: uint16
+      - name: maxacpower
+        type: int
+        config:
+          source: const
+          value: {{ .maxacpower }}
+    script: |
+      percent := 100
+      if maxacpower > 0 && limit < maxacpower {
+        // round, the watt conversion does not reproduce the written percent exactly
+        percent = (limit*100 + maxacpower/2) / maxacpower
+      }
+      percent
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 190 # Battery power (W)
+      type: holding
+      decode: int16
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 184 # Battery SOC (%)
+      type: holding
+      decode: uint16
+  batterymode:
+    source: switch
+    switch:
+    - case: 1 # normal
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 255 # enable Use Timer
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 248 # Use Timer
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: {{ .maxdischargecurrent }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 211 # Battery Max Discharge Current
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0 # disable grid charging
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 230 # Grid Charge Battery Current
+              type: writemultiple
+              decode: uint16
+    - case: 2 # hold - prevent discharge
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 0 # disable Use Timer
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 248 # Use Timer
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0 # zero discharge
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 211 # Battery Max Discharge Current
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: 0 # disable grid charging
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 230 # Grid Charge Battery Current
+              type: writemultiple
+              decode: uint16
+    - case: 3 # charge - enable grid charging
+      set:
+        source: sequence
+        set:
+        - source: const
+          value: 0 # disable Use Timer (ignore TOU schedule)
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 248 # Use Timer
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: {{ .gridchargecurrent }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 230 # Grid Charge Battery Current
+              type: writemultiple
+              decode: uint16
+        - source: const
+          value: {{ .maxdischargecurrent }}
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 211 # Battery Max Discharge Current
+              type: writemultiple
+              decode: uint16
+  {{- include "battery-params" . }}
+  {{- end }}

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -105,7 +105,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -118,7 +118,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   currents:
@@ -236,7 +236,7 @@ render: |
       {{- if eq .batterytype "hv" }}  
       scale: 10
       {{- end }}
-    {{- if .includegenport }}
+    {{- if eq .includegenport "true" }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -261,10 +261,10 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+      {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
       scale: 0.1
       {{- end }}
-    {{- if .includegenport }}
+    {{- if eq .includegenport "true" }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -274,7 +274,7 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+      {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
       scale: 0.1
       {{- end }}
     {{- end }}
@@ -364,7 +364,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -377,7 +377,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   soc:

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -284,34 +284,22 @@ render: |
   # "Solar Sell" (register 145) is the owner's export on/off switch and left untouched.
   # HV models use 10 W units for register 143 (LV: 1 W).
   curtail: # limit feed-in to the given percent of nominal (100 % = nominal power)
-    source: go
-    in:
-      - name: maxacpower
-        type: int
-        config:
-          source: const
-          value: {{ .maxacpower }}
-    script: |
-      powerlimit := ( maxacpower * curtail ) / 100
-      powerlimit
-    out:
-      - name: powerlimit
-        type: int
-        config:
-          source: modbus
-          {{- include "modbus" . | indent 8 }}
-          register:
-            address: 143 # Max Sell Power (W)
-            type: writemultiple
-            decode: uint16
-          {{- if eq .batterytype "hv" }}
-          scale: 0.1
-          {{- end }}
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 143 # Max Sell Power (W)
+      type: writemultiple
+      decode: uint16
+    {{- if eq .batterytype "hv" }}
+    scale: {{ divf (maxf .maxacpower 1) 1000 }} # % to 10 W units
+    {{- else }}
+    scale: {{ divf (maxf .maxacpower 1) 100 }} # % to W
+    {{- end }}
   curtailed: # allowed feed-in as percent of nominal, derived from Max Sell Power
     source: go
     in:
       - name: limit
-        type: int
+        type: float
         config:
           source: modbus
           {{- include "modbus" . | indent 8 }}
@@ -322,18 +310,14 @@ render: |
           {{- if eq .batterytype "hv" }}
           scale: 10
           {{- end }}
-      - name: maxacpower
-        type: int
-        config:
-          source: const
-          value: {{ .maxacpower }}
     script: |
-      percent := 100
-      if maxacpower > 0 && limit < maxacpower {
-        // round, the watt conversion does not reproduce the written percent exactly
-        percent = (limit*100 + maxacpower/2) / maxacpower
+      // float64 is required: a whole-number input arrives as an int literal
+      // round, the watt conversion does not reproduce the written percent exactly
+      p := int(float64(limit)*100/{{ maxf .maxacpower 1 }} + 0.5)
+      if p > 100 {
+        p = 100
       }
-      percent
+      p
   {{- end }}
   {{- if eq .usage "battery" }}
   power:
@@ -625,5 +609,8 @@ render: |
               address: 109 # Battery Max Discharging Current
               type: writemultiple
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
Add Deye/Sunsynk 1P hybrid inverter template

Adds a new template for single-phase Deye and Sunsynk hybrid inverters
(models like SUN-3K/5K/8K-SG01LP1).

The 1P inverters use a different modbus register family (79-275 range)
compared to the 3P models (516-708 range used by deye-hybrid-3p), so a
separate template is required.

Key differences from the 3P template:
- Grid: single voltage (150) and current (160) vs three-phase
- PV: two MPPT inputs (186, 187) vs four
- Battery: SOC at 184, power at 190
- Battery control: Use Timer (248), Max Discharge (211), Grid Charge (230)
- Curtailment: Max Sell Power at 245 (vs 143 on 3P)
- No energy registers, no HV support, no dual battery

Register definitions verified against the kellerza/sunsynk
single_phase.py definitions and community sources.

Closes #10663

## Note on deye-hybrid-3p.yaml

The `deye-hybrid-3p.yaml` changes in this PR only realign the 3P template
with current upstream master. They pull in upstream's already-merged
fixes — #32798 (curtailment scaling), #33074 (HV pre-1098 energy
scaling), #33161 (curtailed whole-number handling), and the batterymode
`default` case — and are a no-op when this PR merges. No independent
functional change to the 3P template is intended.
