### PR TITLE
chore: remove leftover Prettier and ESLint references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@
 
 ### Development environment
 
-Developing evcc requires [Go][1] [Node][2] and [Vite+][3]. We recommend VSCode with the [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go), [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extensions.
+Developing evcc requires [Go][1] [Node][2] and [Vite+][3]. We recommend VSCode with the [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go), [Oxc](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) and [Vue](https://marketplace.visualstudio.com/items?itemName=Vue.volar) extensions.
 
 Alternatively, if you use VS Code and [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers), you can use the "Dev containers: Clone repository in container volume" action. This will create a devcontainer with the required toolchain and install the prerequisites as explained below. Wait until the startup log says "Done. Press any key to close the terminal." and check for any errors.
 
-We use linters (golangci-lint, Prettier) to keep a coherent source code formatting. It's recommended to use the format-on-save feature of your editor. You can manually reformat your code by running:
+We use linters (golangci-lint, oxlint/oxfmt via Vite+) to keep a coherent source code formatting. It's recommended to use the format-on-save feature of your editor. You can manually reformat your code by running:
 
 ```sh
 make lint

--- a/assets/js/components/AboutModal.vue
+++ b/assets/js/components/AboutModal.vue
@@ -73,9 +73,9 @@
 			<template v-if="newVersionAvailable">
 				<hr />
 				<h6>{{ $t("footer.version.modalNextRelease") }}</h6>
-				<!-- eslint-disable vue/no-v-html -->
+				<!-- oxlint-disable vue/no-v-html -->
 				<div v-if="releaseNotes" class="release-notes" v-html="cleanedReleaseNotes"></div>
-				<!-- eslint-enable vue/no-v-html -->
+				<!-- oxlint-enable vue/no-v-html -->
 				<p v-else>
 					{{ $t("footer.version.modalNoReleaseNotes") }}
 					<a :href="releaseNotesUrl(availableVersion)">GitHub</a>.

--- a/assets/js/components/Config/EebusModal.vue
+++ b/assets/js/components/Config/EebusModal.vue
@@ -186,7 +186,7 @@
 import type { PropType } from "vue";
 import QRCode from "qrcode";
 import "@h2d2/shopicons/es/regular/trash";
-// oxlint-disable-next-line @typescript-eslint/no-unused-vars
+// oxlint-disable-next-line typescript/no-unused-vars
 import type { EebusConfig, EebusPairing, EebusStatus, YamlSource } from "@/types/evcc";
 import api from "@/api";
 import JsonModal from "./JsonModal.vue";

--- a/assets/js/components/Config/FormRow.vue
+++ b/assets/js/components/Config/FormRow.vue
@@ -1,4 +1,4 @@
-<!-- eslint-disable vue/no-v-html -->
+<!-- oxlint-disable vue/no-v-html -->
 <template>
 	<div class="mb-4">
 		<label :for="id">

--- a/assets/js/components/Config/Markdown.vue
+++ b/assets/js/components/Config/Markdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<!-- eslint-disable-next-line vue/no-v-html -->
+	<!-- oxlint-disable-next-line vue/no-v-html -->
 	<div class="root" v-html="compiledMarkdown"></div>
 </template>
 

--- a/assets/js/components/Forecast/Chart.vue
+++ b/assets/js/components/Forecast/Chart.vue
@@ -246,7 +246,7 @@ export default defineComponent({
 			return Math.round(Math.min(maxWidth, Math.max(minWidth, scale * maxWidth)));
 		},
 		options() {
-			// oxlint-disable-next-line @typescript-eslint/no-this-alias
+			// oxlint-disable-next-line typescript/no-this-alias
 			const vThis = this;
 			return {
 				...commonOptions,

--- a/assets/js/components/Forecast/PriceChart.vue
+++ b/assets/js/components/Forecast/PriceChart.vue
@@ -89,7 +89,7 @@ export default defineComponent({
 			const priceColor = colors.price || "";
 			const exportColor = colors.export || "";
 
-			// oxlint-disable-next-line @typescript-eslint/no-this-alias
+			// oxlint-disable-next-line typescript/no-this-alias
 			const vThis = this;
 			return {
 				animationDuration: 0,

--- a/assets/js/components/Forecast/ValueChart.vue
+++ b/assets/js/components/Forecast/ValueChart.vue
@@ -77,7 +77,7 @@ export default defineComponent({
 		chartOption(): Record<string, unknown> {
 			const color = this.color;
 
-			// oxlint-disable-next-line @typescript-eslint/no-this-alias
+			// oxlint-disable-next-line typescript/no-this-alias
 			const vThis = this;
 			return {
 				animationDuration: 0,

--- a/assets/js/components/Sessions/CostHistoryChart.vue
+++ b/assets/js/components/Sessions/CostHistoryChart.vue
@@ -249,7 +249,7 @@ export default defineComponent({
 		},
 		options() {
 			// capture vue component this to be used in chartjs callbacks
-			// oxlint-disable-next-line @typescript-eslint/no-this-alias
+			// oxlint-disable-next-line typescript/no-this-alias
 			const vThis = this;
 			return {
 				...commonOptions,

--- a/assets/js/components/Sessions/EnergyHistoryChart.vue
+++ b/assets/js/components/Sessions/EnergyHistoryChart.vue
@@ -163,7 +163,7 @@ export default defineComponent({
 		},
 		options() {
 			// capture vue component this to be used in chartjs callbacks
-			// oxlint-disable-next-line @typescript-eslint/no-this-alias
+			// oxlint-disable-next-line typescript/no-this-alias
 			const vThis = this;
 			return {
 				...commonOptions,

--- a/assets/js/types/vue.d.ts
+++ b/assets/js/types/vue.d.ts
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line @typescript-eslint/no-unused-vars
+// oxlint-disable-next-line typescript/no-unused-vars
 import type { ComponentCustomProperties } from "vue";
 
 declare module "vue" {

--- a/i18n/.prettierrc
+++ b/i18n/.prettierrc
@@ -1,4 +1,0 @@
-{
-	"jsonRecursiveSort": true,
-	"plugins": ["prettier-plugin-sort-json"]
-}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,0 @@
-import { Config } from "@jest/types";
-
-export default {
-  preset: "@vue/cli-plugin-unit-jest/presets/no-babel",
-  testMatch: ["**/*.spec.ts"],
-} satisfies Config.InitialOptions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "vue-router": "^5.2.0"
       },
       "devDependencies": {
-        "@jest/types": "^30.4.1",
         "@playwright/test": "^1.62.0",
         "@storybook/vue3": "^10.4.4",
         "@storybook/vue3-vite": "^10.5.5",
@@ -2343,52 +2342,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4110,13 +4063,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.52",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
-      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4388,33 +4334,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
@@ -4495,23 +4414,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@unhead/vue": {
       "version": "2.1.16",
@@ -7747,16 +7649,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/joi": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "license": "MIT",
   "repository": "github:evcc-io/evcc",
   "devDependencies": {
-    "@jest/types": "^30.4.1",
     "@playwright/test": "^1.62.0",
     "@storybook/vue3": "^10.4.4",
     "@storybook/vue3-vite": "^10.5.5",


### PR DESCRIPTION
Cleanup after the Vite+ migration. Prettier and ESLint are no longer part of the toolchain, but references remained in the codebase.

- Remove obsolete `i18n/.prettierrc` and `jest.config.ts`, drop unused `@jest/types` dependency
- Rename `eslint-disable` comments to `oxlint-disable`, normalize `@typescript-eslint/` rule prefix to `typescript/`
- Update CONTRIBUTING.md editor extension recommendations (Oxc, Vue) and linter mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)