### PR TITLE
UI: allow vehicle charging limit below 20%, include api-set values

### DIFF
--- a/assets/js/components/Vehicles/LimitSocSelect.vue
+++ b/assets/js/components/Vehicles/LimitSocSelect.vue
@@ -40,11 +40,15 @@ export default defineComponent({
 		},
 		options() {
 			const result = [];
-			const start = this.rangeActive ? this.minTemp : 20;
+			const start = this.rangeActive ? this.minTemp : 5;
 			const end = this.rangeActive ? this.maxTemp : 100;
 			for (let soc = start; soc <= end; soc += this.step) {
-				const name = this.fmtSocOption(soc, this.rangePerSoc, distanceUnit(), this.heating);
-				result.push({ value: soc, name });
+				result.push(this.socOption(soc));
+			}
+			// include current value if it's not in the list
+			if (this.limitSoc && !result.some((o) => o.value === this.limitSoc)) {
+				result.push(this.socOption(this.limitSoc));
+				result.sort((a, b) => a.value - b.value);
 			}
 			return result;
 		},
@@ -61,6 +65,10 @@ export default defineComponent({
 		},
 	},
 	methods: {
+		socOption(soc: number) {
+			const name = this.fmtSocOption(soc, this.rangePerSoc, distanceUnit(), this.heating);
+			return { value: soc, name };
+		},
 		change(e: Event) {
 			return this.$emit(
 				"limit-soc-updated",

--- a/tests/limits.spec.ts
+++ b/tests/limits.spec.ts
@@ -44,6 +44,17 @@ test.describe("limitSoc", async () => {
     await expect(page.getByTestId("limit-soc-value")).toHaveText("50%");
   });
 
+  test("starts at 5% and includes api-set values", async ({ page, request }) => {
+    await page.goto("/");
+
+    const combobox = page.getByTestId("limit-soc").getByRole("combobox");
+    await expect(combobox.getByRole("option").first()).toHaveText("5%");
+
+    await request.post("/api/loadpoints/1/limitsoc/42");
+    await expect(page.getByTestId("limit-soc-value")).toHaveText("42%");
+    await expect(combobox.getByRole("option", { name: "42%" })).toHaveCount(1);
+  });
+
   test("can be set even if vehicle isn't connected yet", async ({ page }) => {
     await page.goto(simulatorUrl());
     await page.getByTestId("loadpoint0").getByText("A (disconnected)").click();


### PR DESCRIPTION
fixes #32388

Aligns the quick limit selector on the vehicle card with the range offered in the vehicle settings modal.

- limit selector now starts at 5% instead of 20%
- values set via API that are not part of the 5% steps appear as an extra option

🤖 Generated with [Claude Code](https://claude.com/claude-code)