### PR TITLE
UI: apply 5% floor to vehicle limit slider

### DIFF
--- a/assets/js/components/Vehicles/Soc.vue
+++ b/assets/js/components/Vehicles/Soc.vue
@@ -324,7 +324,7 @@ export default defineComponent({
 		movedLimitSoc(e: Event) {
 			const value = parseInt((e.target as HTMLInputElement).value, 10);
 			e.stopPropagation();
-			const minLimit = this.heating ? this.lowerBound : 20;
+			const minLimit = this.heating ? this.lowerBound : 5;
 			if (value < minLimit) {
 				(e.target as HTMLInputElement).value = minLimit.toString();
 				this.selectedLimitSoc = value;


### PR DESCRIPTION
follow-up to #32460, refs #32388

The soc bar slider clamped dragging at 20% while the quick selector already allows 5%. Both inputs now share the same floor.

- slider drag floor lowered from 20% to 5%

🤖 Generated with [Claude Code](https://claude.com/claude-code)