### PR TITLE
Planner fast mode

### DIFF
--- a/assets/js/components/ChargingPlans/Warnings.vue
+++ b/assets/js/components/ChargingPlans/Warnings.vue
@@ -3,7 +3,7 @@
 		<span v-if="targetIsAboveLimit" class="d-block evcc-gray mb-1">
 			{{ $t("main.targetCharge.targetIsAboveLimit", { limit: limitFmt }) }}
 		</span>
-		<span v-if="mode && ['off', 'now'].includes(mode)" class="d-block text-warning mb-1">
+		<span v-if="mode && mode === 'off'" class="d-block text-warning mb-1">
 			{{ $t("main.targetCharge.onlyInPvMode") }}
 		</span>
 		<span v-if="timeTooFarInTheFuture" class="d-block evcc-gray mb-1">

--- a/assets/js/components/Vehicles/Status.test.ts
+++ b/assets/js/components/Vehicles/Status.test.ts
@@ -154,7 +154,6 @@ describe("plan", () => {
         charging: true,
         connected: true,
         chargingPlanDisabled: true,
-        mode: "off",
       },
       { charger: "Charging…" }
     );
@@ -166,12 +165,11 @@ describe("plan", () => {
         enabled: true,
         connected: true,
         chargingPlanDisabled: true,
-        mode: "off",
       },
       { charger: "Ready. Waiting for vehicle…" }
     );
     expectEntries(
-      { effectivePlanTime, planProjectedStart, connected: true, chargingPlanDisabled: true, mode: "off" },
+      { effectivePlanTime, planProjectedStart, connected: true, chargingPlanDisabled: true },
       { charger: "Connected." }
     );
   });
@@ -185,7 +183,6 @@ describe("plan", () => {
         charging: true,
         connected: true,
         chargingPlanDisabled: false,
-        mode: "now",
       },
       { charger: "Charging…", planactive: "Mo 06:00" }
     );

--- a/assets/js/components/Vehicles/Status.test.ts
+++ b/assets/js/components/Vehicles/Status.test.ts
@@ -145,7 +145,7 @@ describe("plan", () => {
       { charger: "Connected.", planstart: "Mo 03:00" }
     );
   });
-  test("dont show plan status if plan is disabled (e.g. off, fast mode)", () => {
+  test("dont show plan status if plan is disabled (off mode)", () => {
     expectEntries(
       {
         effectivePlanTime,
@@ -154,6 +154,7 @@ describe("plan", () => {
         charging: true,
         connected: true,
         chargingPlanDisabled: true,
+        mode: "off",
       },
       { charger: "Charging…" }
     );
@@ -165,12 +166,28 @@ describe("plan", () => {
         enabled: true,
         connected: true,
         chargingPlanDisabled: true,
+        mode: "off",
       },
       { charger: "Ready. Waiting for vehicle…" }
     );
     expectEntries(
-      { effectivePlanTime, planProjectedStart, connected: true, chargingPlanDisabled: true },
+      { effectivePlanTime, planProjectedStart, connected: true, chargingPlanDisabled: true, mode: "off" },
       { charger: "Connected." }
+    );
+  });
+  test("show plan status in fast mode", () => {
+    expectEntries(
+      {
+        effectivePlanTime,
+        planProjectedEnd,
+        planActive: true,
+        enabled: true,
+        charging: true,
+        connected: true,
+        chargingPlanDisabled: false,
+        mode: "now",
+      },
+      { charger: "Charging…", planactive: "Mo 06:00" }
     );
   });
 });

--- a/assets/js/components/Vehicles/Vehicle.vue
+++ b/assets/js/components/Vehicles/Vehicle.vue
@@ -254,13 +254,13 @@ export default defineComponent({
 			return value > 1 ? `+${this.fmtPercentage(value)}` : null;
 		},
 		chargingPlanDisabled() {
-			return this.mode && [CHARGE_MODE.OFF, CHARGE_MODE.NOW].includes(this.mode);
+			return this.mode && this.mode === CHARGE_MODE.OFF;
 		},
 		smartCostDisabled() {
-			return this.chargingPlanDisabled;
+			return this.mode && [CHARGE_MODE.OFF, CHARGE_MODE.NOW].includes(this.mode);
 		},
 		smartFeedInPriorityDisabled() {
-			return this.chargingPlanDisabled;
+			return this.mode && [CHARGE_MODE.OFF, CHARGE_MODE.NOW].includes(this.mode);
 		},
 	},
 	watch: {

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -2242,7 +2242,12 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 
 	// immediate charging- must be placed after limits are evaluated
 	case mode == api.ModeNow:
-		err = lp.fastCharging()
+		// with a tariff-based plan, charge only during planned slots
+		if lp.planner != nil && !lp.EffectivePlanTime().IsZero() && !plannerActive {
+			err = lp.setLimit(0)
+		} else {
+			err = lp.fastCharging()
+		}
 
 	case mode == api.ModeMinPV || mode == api.ModePV:
 		// cheap tariff

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/core/planner"
 	"github.com/evcc-io/evcc/core/settings"
 	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/messenger"
@@ -33,6 +34,22 @@ func (n *Null) ChargedEnergy() (float64, error) {
 
 func (n *Null) ChargeDuration() (time.Duration, error) {
 	return 0, nil
+}
+
+// rates creates hourly tariff rates starting at start
+func rates(prices []float64, start time.Time) api.Rates {
+	res := make(api.Rates, 0, len(prices))
+
+	for i, v := range prices {
+		slotStart := start.Add(time.Duration(i) * time.Hour)
+		res = append(res, api.Rate{
+			Start: slotStart,
+			End:   slotStart.Add(time.Hour),
+			Value: v,
+		})
+	}
+
+	return res
 }
 
 func createChannels(t *testing.T) (chan util.Param, chan messenger.Event, chan *Loadpoint) {
@@ -464,6 +481,109 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Enable(true).Return(nil)
 	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil)
 	ctrl.Finish()
+}
+
+func TestNowModeWithPlan(t *testing.T) {
+	const planEnergy = 6 // kWh, ~30min at 16A/3p
+
+	tc := []struct {
+		desc    string
+		prices  []float64 // hourly tariff rates starting at now
+		plan    bool      // set an energy-based plan
+		planner bool      // create the planner from the tariff
+		expect  func(h *api.MockCharger)
+	}{
+		{
+			desc:    "no plan charges at max",
+			prices:  []float64{10, 20, 20},
+			planner: true,
+			expect: func(h *api.MockCharger) {
+				h.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
+			},
+		},
+		{
+			desc:    "plan outside slot does not charge",
+			prices:  []float64{20, 10, 20}, // cheap slot starts in 1h
+			plan:    true,
+			planner: true,
+			expect: func(h *api.MockCharger) {
+				h.EXPECT().Enable(false).Return(nil)
+			},
+		},
+		{
+			desc:    "plan inside slot charges at max",
+			prices:  []float64{10, 20, 20}, // cheap slot starts immediately
+			plan:    true,
+			planner: true,
+			expect: func(h *api.MockCharger) {
+				h.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
+			},
+		},
+		{
+			desc:    "plan without planner charges at max",
+			prices:  []float64{10, 20, 20},
+			plan:    true,
+			planner: false,
+			expect: func(h *api.MockCharger) {
+				h.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
+			},
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.desc, func(t *testing.T) {
+			now := time.Now()
+
+			clock := clock.NewMock()
+			clock.Set(now.Add(time.Minute))
+
+			ctrl := gomock.NewController(t)
+			charger := api.NewMockCharger(ctrl)
+			vehicle := api.NewMockVehicle(ctrl)
+			expectVehiclePublish(vehicle)
+
+			lp := &Loadpoint{
+				log:         util.NewLogger("foo"),
+				bus:         evbus.New(),
+				clock:       clock,
+				settings:    settings.NewDatabaseSettingsAdapter("foo"),
+				charger:     charger,
+				chargeMeter: &Null{},            // silence nil panics
+				chargeRater: &Null{},            // silence nil panics
+				chargeTimer: &Null{},            // silence nil panics
+				progress:    NewProgress(0, 10), // silence nil panics
+				wakeUpTimer: NewTimer(),         // silence nil panics
+				minCurrent:  minA,
+				maxCurrent:  maxA,
+				vehicle:     vehicle,
+				mode:        api.ModeNow,
+			}
+
+			if tc.planner {
+				trf := api.NewMockTariff(ctrl)
+				trf.EXPECT().Rates().AnyTimes().Return(rates(tc.prices, now), nil)
+				lp.planner = planner.New(lp.log, trf)
+			}
+
+			attachListeners(t, lp)
+
+			lp.enabled = true
+			lp.offeredCurrent = minA
+			lp.status = api.StatusC
+
+			if tc.plan {
+				lp.setPlanEnergy(now.Add(3*time.Hour), planEnergy)
+			}
+
+			vehicle.EXPECT().Soc().Return(85.0, nil)
+			charger.EXPECT().Status().Return(api.StatusC, nil)
+			charger.EXPECT().Enabled().Return(lp.enabled, nil)
+			tc.expect(charger)
+			lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil)
+
+			ctrl.Finish()
+		})
+	}
 }
 
 func TestSetModeAndSocAtDisconnect(t *testing.T) {

--- a/docs/agents/core-domain.md
+++ b/docs/agents/core-domain.md
@@ -46,7 +46,7 @@ Site (orchestrator — core/site.go)
 | Mode | Behavior |
 |------|----------|
 | `OFF` | Disabled (unless welcome charge) |
-| `NOW` | Max current immediately |
+| `NOW` | Max current immediately (with a tariff-based plan: only during planned slots) |
 | `MINPV` | Min current when PV surplus; fast if cheap tariff |
 | `PV` | Ramp current proportional to available solar |
 
@@ -134,6 +134,7 @@ Types: `TariffUsageGrid`, `TariffUsageFeedIn`, `TariffUsageCo2`, `TariffUsagePla
 - **Planner** (`core/planner/planner.go`) — finds cheapest time slots for target SOC/energy by deadline
   - `optimalPlan()` — cheapest non-contiguous slots
   - `continuousPlan()` — cheapest continuous window (fallback)
+  - In `NOW` mode with a tariff-based plan, charging is restricted to planned slots; outside them the loadpoint does not charge
 
 ## Key File Locations
 

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1456,7 +1456,7 @@
       "inactiveLabel": "Zielzeit",
       "nextPlan": "Nächster Plan",
       "notReachableInTime": "Zielzeit wird {overrun} später erreicht.",
-      "onlyInPvMode": "Ladeplanung ist nur im PV-Modus aktiv.",
+      "onlyInPvMode": "Die Ladeplanung ist nur aktiv, wenn das Laden aktiviert ist.",
       "planDuration": "Ladedauer",
       "planPeriodLabel": "Zeitraum",
       "planPeriodValue": "{start} bis {end}",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1456,7 +1456,7 @@
       "inactiveLabel": "Target time",
       "nextPlan": "Next plan",
       "notReachableInTime": "Goal will be reached {overrun} later.",
-      "onlyInPvMode": "Charging plan only works in solar mode.",
+      "onlyInPvMode": "Charging plan is only active when charging is enabled.",
       "planDuration": "Charging time",
       "planPeriodLabel": "Period",
       "planPeriodValue": "{start} to {end}",


### PR DESCRIPTION
Fast (NOW) mode currently ignores any charging plan and always charges at max power immediately. This means users who want to combine a fixed charging speed with a scheduled, tariff-optimized start time (e.g. "car ready by 8am, charge only during the cheapest hours overnight") have no way to do so, since a plan set while in Fast mode has no effect. This change makes plans mode-agnostic in NOW mode too, mirroring how they already behave in PV/MinPV mode.

- Fast mode now suppresses charging outside an active plan slot when a tariff-based plan exists, and continues charging at max power once inside a planned slot, so it charges only during the cheapest hours instead of immediately.
- The minSoC (arrival) guarantee and Fast mode's normal behavior remain unchanged when no plan or no planner tariff is configured.
- Unhides the charging plan UI for Fast mode and reworded the "only works in solar mode" warning, since it no longer applies.

Fixes #32473

🤖 Generated with Claude Code (https://claude.com/claude-code)