### PR TITLE
chore: always resolve the command comment

### DIFF
--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -65,7 +65,7 @@ jobs:
             actions: read
           # analyze mode gets read + comment + api tools only; triage/fix
           # additionally get Edit/Write + git/PR tools to actually make and push a
-          # fix (fix mode also gets gh api to resolve its invoking comment). Task
+          # fix (analyze/fix need gh api to read their invoking comment). Task
           # is blocked in all modes so the agent can't offload work to a
           # background sub-agent and exit before it returns. All modes get read-only
           # git log and gh pr view/diff to trace a regression to its pull request.
@@ -180,13 +180,20 @@ jobs:
 
             If MODE is "fix", do NOT label or edit issue metadata.
 
-            If MODE is "analyze" or "fix", always resolve the invoking comment by
-            minimizing it as resolved once you posted your reply in step 2, whatever
-            that reply says. An answer, a request for more information, or an
-            explanation why you could not analyze or fix it all count:
-            gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{classifier:RESOLVED,subjectId:$id}){minimizedComment{isMinimized}}}' -f id='${{ inputs.comment_node_id }}'
-            The command has been answered either way, so it must not stay open.
-            Only skip this if you posted no reply at all.
+            Do not minimize or otherwise touch the invoking comment, the workflow
+            resolves it once you are done.
 
             Follow the repository's AGENTS.md conventions for commit/PR style. Do not
             force-push and do not touch unrelated files.
+
+      # the agent posts its result as a comment, so the command has been answered
+      # whatever that result was. only a failed run leaves it open, there is no
+      # answer then
+      - name: Resolve invoking comment
+        if: inputs.comment_node_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_ID: ${{ inputs.comment_node_id }}
+        run: |
+          gh api graphql -f id="$NODE_ID" -f query='
+            mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}'

--- a/.github/workflows/claude-issue-agent-run.yml
+++ b/.github/workflows/claude-issue-agent-run.yml
@@ -176,17 +176,17 @@ jobs:
                cannot determine the correct change with confidence, do NOT open a
                PR — explain why in your step 2 comment instead.
 
-            If MODE is "analyze", do NOT label, edit, or open PRs. Instead, ONLY after
-            you posted a CONCLUSIVE answer in step 2 (not a request for more info),
-            resolve the invoking comment by minimizing it as resolved:
-            gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{classifier:RESOLVED,subjectId:$id}){minimizedComment{isMinimized}}}' -f id='${{ inputs.comment_node_id }}'
-            If you instead asked for more information, do NOT minimize it.
+            If MODE is "analyze", do NOT label, edit, or open PRs.
 
-            If MODE is "fix", do NOT label or edit issue metadata. Instead, ONLY
-            after you successfully opened a fix PR in step 5, resolve the invoking
-            comment the same way:
+            If MODE is "fix", do NOT label or edit issue metadata.
+
+            If MODE is "analyze" or "fix", always resolve the invoking comment by
+            minimizing it as resolved once you posted your reply in step 2, whatever
+            that reply says. An answer, a request for more information, or an
+            explanation why you could not analyze or fix it all count:
             gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{classifier:RESOLVED,subjectId:$id}){minimizedComment{isMinimized}}}' -f id='${{ inputs.comment_node_id }}'
-            If you did not open a PR, do NOT minimize it.
+            The command has been answered either way, so it must not stay open.
+            Only skip this if you posted no reply at all.
 
             Follow the repository's AGENTS.md conventions for commit/PR style. Do not
             force-push and do not touch unrelated files.

--- a/.github/workflows/command-analyze.yml
+++ b/.github/workflows/command-analyze.yml
@@ -6,8 +6,8 @@ on:
 
 # Triggered by a `/analyze` comment on any issue or PR conversation. Delegates to
 # the shared issue agent in analyze mode, which investigates, posts one answer
-# comment, then minimizes the calling `/analyze` comment as RESOLVED — but only
-# when it actually answered.
+# comment, then minimizes the calling `/analyze` comment as RESOLVED, whatever
+# the answer says.
 jobs:
   analyze:
     name: Analyze on demand

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -198,11 +198,12 @@ jobs:
             });
 
       - name: Resolve command comment
-        if: steps.create.outputs.url
+        if: always()
         uses: actions/github-script@v8
         with:
           script: |
-            // collapse the /backport comment as resolved now that the pull request exists
+            // collapse the /backport comment as resolved, the result was reported
+            // back as a comment either way
             await github.graphql(
               `mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}`,
               { id: context.payload.comment.node_id }

--- a/.github/workflows/command-fix.yml
+++ b/.github/workflows/command-fix.yml
@@ -7,7 +7,7 @@ on:
 # Triggered by a `/fix` comment on any issue or PR conversation, maintainers only.
 # Delegates to the shared issue agent in fix mode, which investigates, pushes a
 # fix branch, opens a PR, comments with the result, then minimizes the calling
-# `/fix` comment as RESOLVED — but only when it actually opened a PR.
+# `/fix` comment as RESOLVED, whether or not a PR was opened.
 jobs:
   fix:
     name: Fix on demand


### PR DESCRIPTION
`/backport` only minimized the invoking comment once it had opened a pull request, and the `/analyze` and `/fix` agent prompts only after a conclusive answer or a pushed PR. A run that replied with an error left its command comment open, which is how #32420 ended up with two unresolved `/backport` comments sitting next to their `❌` replies.

The result is reported back as a comment either way, so the command is now resolved whenever a reply was posted. For `/backport` that means gating the resolve step on `always()`, matching the `Comment result` step right above it, which needs the condition because the failure paths call `core.setFailed()` in-job and would otherwise skip every later step. `/nightly` and `/build` already behaved this way, their failures happen in other jobs and their report job is already `always()`.

For `/analyze` and `/fix` the minimize moves out of the agent prompt into a step after the agent ran, so it no longer depends on the model following the instruction. The step's default `success()` condition is exactly "the agent completed", and a failed run leaves the comment open because nothing was answered.

One known gap left as-is: `/build` reports nothing at all when its `prep` job fails.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)