### PR TITLE
chore: mark generated openapi files as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+server/openapi.state.yaml linguist-generated=true
+server/mcp/openapi.json linguist-generated=true
+server/mcp/openapi.md linguist-generated=true


### PR DESCRIPTION
follow-up to #32431

#32431 added committed generated artifacts (openapi.state.yaml, mcp/openapi.json, mcp/openapi.md). Mark them as generated so GitHub collapses their diffs in pull requests and excludes them from language stats. Same mechanism already used for the workflow lock files.

- add linguist-generated for the three generated openapi files

🤖 Generated with [Claude Code](https://claude.com/claude-code)