### PR TITLE
core: persist the soc estimate across restarts

### DIFF
--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -96,6 +96,9 @@ const (
 	PlanOverrun        = "planOverrun"        // charge plan goal not reachable in time
 	PlanStrategy       = "planStrategy"       // charge plan strategy (precondition, continuous)
 
+	// soc estimate
+	SocEstimate = "socEstimate" // persisted soc estimator anchor (per vehicle)
+
 	// repeating plans
 	RepeatingPlans = "repeatingPlans" // key to access all repeating plans in db
 

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -151,6 +151,9 @@ type Loadpoint struct {
 	coordinator    coordinator.API
 	socEstimator   *soc.Estimator
 
+	// name of the vehicle the persisted soc estimate belongs to
+	socEstimateVehicle string
+
 	// charge planning
 	planner          *planner.Planner
 	planTime         time.Time        // time goal
@@ -1992,6 +1995,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 		} else {
 			lp.vehicleSoc = socEstimator.Soc(socR, lp.GetChargedEnergy())
 			lp.log.DEBUG.Printf("vehicle soc (estimator): %.0f%%", lp.vehicleSoc)
+			lp.updateSocEstimate(socEstimator, lp.socEstimateVehicle)
 		}
 	}
 	lp.publish(keys.VehicleSoc, lp.vehicleSoc)

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1931,6 +1931,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 	// guard for socEstimator removed by api and keep a local copy in order to avoid race conditions
 	// https://github.com/evcc-io/evcc/issues/16180
 	socEstimator := lp.socEstimator
+	socEstimateVehicle := lp.socEstimateVehicle
 
 	socAndLimit := func(typ string, dev any) (*float64, *int64, error) {
 		var socR *float64
@@ -1995,7 +1996,7 @@ func (lp *Loadpoint) publishSocAndRange() {
 		} else {
 			lp.vehicleSoc = socEstimator.Soc(socR, lp.GetChargedEnergy())
 			lp.log.DEBUG.Printf("vehicle soc (estimator): %.0f%%", lp.vehicleSoc)
-			lp.updateSocEstimate(socEstimator, lp.socEstimateVehicle)
+			lp.updateSocEstimate(socEstimator, socEstimateVehicle)
 		}
 	}
 	lp.publish(keys.VehicleSoc, lp.vehicleSoc)

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -60,6 +60,11 @@ func (lp *Loadpoint) createSession() {
 
 	// energy
 	lp.energyMetrics.Reset()
+
+	// after the reset, never before: the persisted anchor is measured against
+	// this counter and setActiveVehicle always runs ahead of createSession
+	lp.restoreSocEstimate()
+
 	lp.energyMetrics.Publish("session", lp)
 	lp.publish(keys.ChargedEnergy, lp.GetChargedEnergy())
 }

--- a/core/loadpoint_soc_estimate.go
+++ b/core/loadpoint_soc_estimate.go
@@ -1,0 +1,143 @@
+package core
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/core/soc"
+	"github.com/evcc-io/evcc/server/db/settings"
+)
+
+const (
+	// socEstimateMaxAge discards a record that has not been updated recently.
+	// It guards against evcc having been down long enough for the world to have
+	// moved on, not against the anchor itself being old: while evcc runs, the
+	// energy since the anchor is re-derived from the charger's counter on every
+	// poll, so an old anchor is not by itself a reason to distrust the record.
+	socEstimateMaxAge = 24 * time.Hour
+
+	// socEstimateMaxOffset caps a restored offset, in percentage points
+	socEstimateMaxOffset = 50.0
+)
+
+// socEstimate is the persisted state of a vehicle's soc estimation.
+//
+// Kept per vehicle rather than per loadpoint because that is what it
+// describes: a state of charge belongs to a battery, and the coordinator
+// already moves vehicles between loadpoints. Per loadpoint, two vehicles
+// alternating at one charger would overwrite each other's estimate and a
+// vehicle moved to a second charger would arrive without one.
+type socEstimate struct {
+	AnchorSoc         float64   `json:"anchorSoc"`         // last soc the vehicle reported, in %
+	EnergySinceAnchor float64   `json:"energySinceAnchor"` // energy delivered at the charger since, in Wh
+	Updated           time.Time `json:"updated"`
+}
+
+// offset returns the estimate's distance above the anchor, in percentage
+// points. Derived from energy rather than from the estimate, which is clamped
+// at 100 and would hide an implausibly large offset.
+func (se socEstimate) offset(energyPerSocStep float64) float64 {
+	if energyPerSocStep <= 0 {
+		return 0
+	}
+	return se.EnergySinceAnchor / energyPerSocStep
+}
+
+// plausible reports whether the record may be restored.
+//
+// There is deliberately no check against the vehicle's current reading here:
+// at restore time none has been fetched yet, and none is needed. Restore()
+// seeds prevSoc with the anchor, so a first poll that reads a changed value
+// takes the estimator's rebase branch and drops the offset by itself.
+func (se socEstimate) plausible(energyPerSocStep float64, now time.Time) bool {
+	switch {
+	case se.EnergySinceAnchor <= 0:
+		return false
+	case now.Sub(se.Updated) > socEstimateMaxAge:
+		return false
+	case se.offset(energyPerSocStep) > socEstimateMaxOffset:
+		return false
+	default:
+		return true
+	}
+}
+
+func socEstimateKey(name string) string {
+	return fmt.Sprintf("vehicle.%s.%s", name, keys.SocEstimate)
+}
+
+func loadSocEstimate(name string) (socEstimate, bool) {
+	var se socEstimate
+	if err := settings.Json(socEstimateKey(name), &se); err != nil {
+		return socEstimate{}, false
+	}
+	return se, true
+}
+
+// saveSocEstimate stores the record. It only reaches the database when evcc's
+// settings ticker flushes dirty entries, which it does every minute and on
+// shutdown.
+func saveSocEstimate(name string, se socEstimate) error {
+	return settings.SetJson(socEstimateKey(name), se)
+}
+
+// updateSocEstimate mirrors the running estimator into the persisted record.
+//
+// estimator and vehicleName are the caller's snapshot rather than fields read
+// from lp: setActiveVehicle runs synchronously on the http and mqtt
+// goroutines, so re-reading either here could pair one vehicle's estimator
+// with another's name and write the first's energy into the second's record —
+// both records staying syntactically valid. Same reason publishSocAndRange
+// snapshots socEstimator, see #16180.
+func (lp *Loadpoint) updateSocEstimate(estimator *soc.Estimator, vehicleName string) {
+	if estimator == nil || vehicleName == "" {
+		return
+	}
+
+	a := estimator.Anchor()
+	if a.EnergySince <= 0 {
+		return
+	}
+
+	if err := saveSocEstimate(vehicleName, socEstimate{
+		AnchorSoc:         a.Soc,
+		EnergySinceAnchor: a.EnergySince,
+		Updated:           lp.clock.Now(),
+	}); err != nil {
+		lp.log.ERROR.Printf("soc estimate: %v", err)
+	}
+}
+
+// restoreSocEstimate seeds the estimator from the persisted record.
+//
+// Called from createSession, deliberately not from setActiveVehicle: the
+// anchor is measured against the session energy counter, and
+// evVehicleConnectHandler runs vehicleDefaultOrDetect — and with it
+// setActiveVehicle — before createSession resets that counter. Anchoring
+// before the reset yields an anchor relative to the previous session, which
+// looks correct at process start (the counter really is zero there) but
+// collapses the estimate to the vehicle's stale reading on every subsequent
+// connect. splitSession calls createSession too, so both paths are covered.
+func (lp *Loadpoint) restoreSocEstimate() {
+	estimator := lp.socEstimator
+	if estimator == nil || lp.socEstimateVehicle == "" {
+		return
+	}
+
+	se, ok := loadSocEstimate(lp.socEstimateVehicle)
+	if !ok {
+		return
+	}
+
+	if !se.plausible(estimator.EnergyPerSocStep(), lp.clock.Now()) {
+		return
+	}
+
+	estimator.Restore(soc.Anchor{
+		Soc:         se.AnchorSoc,
+		EnergySince: se.EnergySinceAnchor,
+	}, lp.GetChargedEnergy())
+
+	lp.log.DEBUG.Printf("soc estimate restored: anchor %.1f%%, %.0fWh since", se.AnchorSoc, se.EnergySinceAnchor)
+}

--- a/core/loadpoint_soc_estimate.go
+++ b/core/loadpoint_soc_estimate.go
@@ -44,22 +44,25 @@ func (se socEstimate) offset(energyPerSocStep float64) float64 {
 	return se.EnergySinceAnchor / energyPerSocStep
 }
 
-// plausible reports whether the record may be restored.
+// plausible reports whether the record may be restored, and why not if it may
+// not — the reason ends up in the log, where it is the difference between "the
+// estimate was never stored" and "it was stored and rejected" when someone
+// reports a soc jump after a restart.
 //
 // There is deliberately no check against the vehicle's current reading here:
 // at restore time none has been fetched yet, and none is needed. Restore()
 // seeds prevSoc with the anchor, so a first poll that reads a changed value
 // takes the estimator's rebase branch and drops the offset by itself.
-func (se socEstimate) plausible(energyPerSocStep float64, now time.Time) bool {
+func (se socEstimate) plausible(energyPerSocStep float64, now time.Time) (bool, string) {
 	switch {
 	case se.EnergySinceAnchor <= 0:
-		return false
+		return false, "no energy since the anchor"
 	case now.Sub(se.Updated) > socEstimateMaxAge:
-		return false
+		return false, fmt.Sprintf("last updated %v ago", now.Sub(se.Updated).Truncate(time.Minute))
 	case se.offset(energyPerSocStep) > socEstimateMaxOffset:
-		return false
+		return false, fmt.Sprintf("implied offset %.0f%% exceeds %.0f%%", se.offset(energyPerSocStep), socEstimateMaxOffset)
 	default:
-		return true
+		return true, ""
 	}
 }
 
@@ -127,10 +130,12 @@ func (lp *Loadpoint) restoreSocEstimate() {
 
 	se, ok := loadSocEstimate(lp.socEstimateVehicle)
 	if !ok {
+		lp.log.DEBUG.Printf("soc estimate: no record for %s", lp.socEstimateVehicle)
 		return
 	}
 
-	if !se.plausible(estimator.EnergyPerSocStep(), lp.clock.Now()) {
+	if ok, reason := se.plausible(estimator.EnergyPerSocStep(), lp.clock.Now()); !ok {
+		lp.log.DEBUG.Printf("soc estimate discarded: %s", reason)
 		return
 	}
 

--- a/core/loadpoint_soc_estimate_test.go
+++ b/core/loadpoint_soc_estimate_test.go
@@ -48,7 +48,16 @@ func TestSocEstimatePlausible(t *testing.T) {
 
 	for _, tc := range tc {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.plausible, tc.se.plausible(eps, now))
+			ok, reason := tc.se.plausible(eps, now)
+			assert.Equal(t, tc.plausible, ok)
+
+			// a rejection has to say why — the reason is what an operator sees
+			// when diagnosing a soc jump after a restart
+			if ok {
+				assert.Empty(t, reason)
+			} else {
+				assert.NotEmpty(t, reason)
+			}
 		})
 	}
 }

--- a/core/loadpoint_soc_estimate_test.go
+++ b/core/loadpoint_soc_estimate_test.go
@@ -1,0 +1,150 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/session"
+	"github.com/evcc-io/evcc/core/soc"
+	serverdb "github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSocEstimatePlausible(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	const eps = 964.7 // Wh per point for an 82 kWh vehicle
+
+	tc := []struct {
+		name      string
+		se        socEstimate
+		plausible bool
+	}{
+		{
+			"fresh record",
+			socEstimate{AnchorSoc: 15, EnergySinceAnchor: 6800, Updated: now.Add(-time.Hour)},
+			true,
+		},
+		{
+			"not updated for more than a day",
+			socEstimate{AnchorSoc: 15, EnergySinceAnchor: 6800, Updated: now.Add(-25 * time.Hour)},
+			false,
+		},
+		{
+			"offset beyond the cap",
+			socEstimate{AnchorSoc: 15, EnergySinceAnchor: 60000, Updated: now.Add(-time.Hour)},
+			false,
+		},
+		{
+			"no energy since the anchor",
+			socEstimate{AnchorSoc: 15, EnergySinceAnchor: 0, Updated: now.Add(-time.Hour)},
+			false,
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.plausible, tc.se.plausible(eps, now))
+		})
+	}
+}
+
+func TestUpdateSocEstimateStoresAnchor(t *testing.T) {
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Capacity().Return(8.5).AnyTimes()
+
+	lp := &Loadpoint{log: util.NewLogger("foo"), clock: clk}
+	estimator := soc.NewEstimator(lp.log, api.NewMockCharger(ctrl), vehicle)
+
+	source := 15.0
+	estimator.Soc(&source, 0)   // anchor at 15
+	estimator.Soc(&source, 300) // 300 Wh since
+
+	lp.updateSocEstimate(estimator, "test:anchor")
+
+	se, ok := loadSocEstimate("test:anchor")
+	require.True(t, ok)
+	assert.Equal(t, 15.0, se.AnchorSoc)
+	assert.Equal(t, 300.0, se.EnergySinceAnchor)
+}
+
+// TestRestoreSocEstimateSurvivesSessionCounterReset drives the connect path in
+// production order. evVehicleConnectHandler runs vehicleDefaultOrDetect — and
+// with it setActiveVehicle — first, and createSession second; createSession is
+// what resets the session energy counter the anchor is measured against.
+//
+// Restoring in setActiveVehicle therefore anchors against the *previous*
+// session's counter, which is zeroed one call later. That looks correct at
+// process start, where the counter genuinely is zero, but collapses the
+// estimate onto the vehicle's stale reading on every subsequent connect — and
+// updateSocEstimate then overwrites the stored record, destroying the history
+// rather than just mis-displaying it.
+//
+// Both halves have to be driven through lp.energyMetrics and lp.createSession
+// rather than through ad-hoc numbers, or the test silently models an order
+// production never takes.
+func TestRestoreSocEstimateSurvivesSessionCounterReset(t *testing.T) {
+	var err error
+	serverdb.Instance, err = serverdb.New("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	store, err := session.NewStore("foo", serverdb.Instance)
+	require.NoError(t, err)
+
+	clk := clock.NewMock()
+	ctrl := gomock.NewController(t)
+
+	mm := api.NewMockMeter(ctrl)
+	me := api.NewMockMeterEnergy(ctrl)
+	me.EXPECT().TotalEnergy().Return(0.0, nil).AnyTimes()
+
+	type energyDecorator struct {
+		api.Meter
+		api.MeterEnergy
+	}
+
+	lp := &Loadpoint{
+		log:         util.NewLogger("foo"),
+		clock:       clk,
+		db:          store,
+		chargeMeter: &energyDecorator{Meter: mm, MeterEnergy: me},
+	}
+
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Capacity().Return(8.5).AnyTimes()
+
+	require.NoError(t, saveSocEstimate("test:counterreset", socEstimate{
+		AnchorSoc: 15, EnergySinceAnchor: 500, Updated: clk.Now(),
+	}))
+	lp.socEstimateVehicle = "test:counterreset"
+
+	// at connect time the counter still holds the previous session's total;
+	// energyMetrics is only ever reset from createSession
+	lp.energyMetrics.Update(0.5)
+	require.Equal(t, 500.0, lp.GetChargedEnergy())
+
+	// setActiveVehicle builds a fresh estimator
+	lp.socEstimator = soc.NewEstimator(lp.log, api.NewMockCharger(ctrl), vehicle)
+
+	// createSession zeroes the counter and re-anchors against it
+	lp.createSession()
+	require.Equal(t, 0.0, lp.GetChargedEnergy(), "createSession must have reset the counter")
+
+	// the first poll of the new session still sees the stale vehicle value
+	source := 15.0
+	assert.Equal(t, 20.0, lp.socEstimator.Soc(&source, lp.GetChargedEnergy()),
+		"estimate must survive the counter reset, not collapse onto the stale source value")
+
+	// and the record must not have been flattened
+	lp.updateSocEstimate(lp.socEstimator, lp.socEstimateVehicle)
+	se, ok := loadSocEstimate("test:counterreset")
+	require.True(t, ok)
+	assert.Equal(t, 500.0, se.EnergySinceAnchor, "history must not be overwritten with zero")
+}

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -149,6 +149,10 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 		// resolve optional config
 		if v.Capacity() > 0 && (lp.Soc.Estimate == nil || *lp.Soc.Estimate) {
 			lp.socEstimator = soc.NewEstimator(lp.log, lp.charger, v)
+			lp.socEstimateVehicle = vehicle.Settings(lp.log, v).Name()
+		} else {
+			lp.socEstimator = nil
+			lp.socEstimateVehicle = ""
 		}
 
 		lp.publish(keys.VehicleName, vehicle.Settings(lp.log, v).Name())
@@ -168,6 +172,7 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 		lp.progress.Reset()
 	} else {
 		lp.socEstimator = nil
+		lp.socEstimateVehicle = ""
 		lp.unpublishVehicleIdentity()
 	}
 

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -32,6 +32,8 @@ type Estimator struct {
 	prevSoc           float64 // previous vehicle Soc in %
 	prevChargedEnergy float64 // previous charged energy in Wh
 	energyPerSocStep  float64 // Energy per Soc percent in Wh
+	fetchedSoc        float64 // last soc received from the vehicle
+	chargedEnergy     float64 // last charged energy seen, in Wh
 }
 
 // NewEstimator creates new estimator
@@ -97,12 +99,14 @@ func remainingChargeEnergy(targetSoc int, vehicleSoc, virtualCapacity float64) f
 func (s *Estimator) Soc(fetchedSoc *float64, chargedEnergy float64) float64 {
 	if fetchedSoc != nil {
 		s.vehicleSoc = *fetchedSoc
+		s.fetchedSoc = *fetchedSoc
 	} else {
 		s.log.WARN.Printf("missing vehicle soc- ignored by estimator")
 	}
 
 	socDelta := s.vehicleSoc - s.prevSoc
-	energyDelta := max(chargedEnergy, 0) - s.prevChargedEnergy
+	s.chargedEnergy = max(chargedEnergy, 0)
+	energyDelta := s.chargedEnergy - s.prevChargedEnergy
 
 	if socDelta != 0 || energyDelta < 0 { // soc value change or unexpected energy reset
 		if s.initialSoc == 0 {

--- a/core/soc/estimator_state.go
+++ b/core/soc/estimator_state.go
@@ -1,0 +1,57 @@
+package soc
+
+// Anchor is the estimator's reference point: the last soc the vehicle itself
+// reported, and the energy delivered at the charger since then.
+//
+// It is the anchor rather than the estimate that has to survive a restart.
+// Soc() recomputes vehicleSoc from the anchor on every poll, so a restored
+// vehicleSoc would be overwritten by the next call, while a restored anchor
+// reproduces the same estimate for as long as the vehicle keeps reporting the
+// value it was measured against.
+type Anchor struct {
+	Soc         float64 // vehicle-reported soc in %
+	EnergySince float64 // energy delivered since, in Wh
+}
+
+// Anchor returns the estimator's current reference point.
+func (s *Estimator) Anchor() Anchor {
+	return Anchor{
+		Soc:         s.prevSoc,
+		EnergySince: s.chargedEnergy - s.prevChargedEnergy,
+	}
+}
+
+// EnergyPerSocStep returns the estimator's Wh per soc percentage point.
+func (s *Estimator) EnergyPerSocStep() float64 {
+	return s.energyPerSocStep
+}
+
+// Restore seeds the estimator from a persisted anchor.
+//
+// chargedEnergy is the loadpoint's session counter the anchor is measured
+// against. It is not necessarily zero: evcc may have restarted mid-session.
+//
+// Setting prevSoc is what makes this work at all. A fresh estimator has
+// prevSoc 0, so the first poll would see socDelta != 0, take the rebase branch
+// and discard everything restored here. With prevSoc seeded, a poll that still
+// reads the same vehicle value takes the estimating branch and reproduces the
+// stored estimate — and a poll that reads a genuinely changed value rebases,
+// which is exactly the wanted behaviour: a real reading always wins.
+//
+// initialSoc and initialEnergy are deliberately left untouched; they anchor
+// the in-session gradient learner, which is per-session by design.
+func (s *Estimator) Restore(a Anchor, chargedEnergy float64) {
+	s.prevSoc = a.Soc
+	s.fetchedSoc = a.Soc
+	s.chargedEnergy = max(chargedEnergy, 0)
+	s.prevChargedEnergy = s.chargedEnergy - a.EnergySince
+
+	// without a usable gradient there is no Wh/% to convert the energy into an
+	// offset. Dividing by zero would yield +Inf, which min(_, 100) silently
+	// turns into a plausible-looking full battery.
+	if s.energyPerSocStep > 0 {
+		s.vehicleSoc = min(a.Soc+a.EnergySince/s.energyPerSocStep, 100)
+	} else {
+		s.vehicleSoc = a.Soc
+	}
+}

--- a/core/soc/estimator_state_test.go
+++ b/core/soc/estimator_state_test.go
@@ -1,0 +1,92 @@
+package soc
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// newAnchorTestEstimator builds an estimator for an 8.5 kWh vehicle, which at
+// the default 85% efficiency yields a 10 kWh virtual capacity and 100 Wh per
+// soc point — round numbers that keep the expectations readable.
+func newAnchorTestEstimator(t *testing.T, capacity float64) *Estimator {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Capacity().Return(capacity).AnyTimes()
+
+	return NewEstimator(util.NewLogger("foo"), api.NewMockCharger(ctrl), vehicle)
+}
+
+func TestAnchorReportsReferencePoint(t *testing.T) {
+	ce := newAnchorTestEstimator(t, 8.5)
+
+	source := 20.0
+	ce.Soc(&source, 0)   // rebase branch, anchors prevSoc at 20
+	ce.Soc(&source, 500) // estimating branch
+
+	a := ce.Anchor()
+	assert.Equal(t, 20.0, a.Soc)
+	assert.Equal(t, 500.0, a.EnergySince)
+}
+
+func TestRestoreSeedsEstimate(t *testing.T) {
+	ce := newAnchorTestEstimator(t, 8.5)
+
+	// 500 Wh above a 15% anchor is 5 points at 100 Wh per point
+	ce.Restore(Anchor{Soc: 15, EnergySince: 500}, 0)
+
+	assert.Equal(t, 20.0, ce.vehicleSoc)
+	assert.Equal(t, 15.0, ce.prevSoc, "prevSoc must be seeded with the anchor")
+}
+
+// TestRestoreFirstPollDoesNotRebase is the reason Restore seeds prevSoc at all.
+// A fresh estimator has prevSoc 0, so without that the first poll produces
+// socDelta != 0, takes the rebase branch and discards the restored anchor —
+// the estimate would silently fall back to the vehicle's stale reading.
+func TestRestoreFirstPollDoesNotRebase(t *testing.T) {
+	ce := newAnchorTestEstimator(t, 8.5)
+	ce.Restore(Anchor{Soc: 15, EnergySince: 500}, 0)
+
+	source := 15.0
+	assert.Equal(t, 20.0, ce.Soc(&source, 0), "restored estimate must survive the first poll")
+	assert.InDelta(t, 22.0, ce.Soc(&source, 200), 0.001, "and keep accumulating")
+}
+
+// A real reading always wins: once the vehicle reports something other than
+// the anchor, the estimator's own rebase branch drops the restored offset. No
+// expiry logic is needed for that.
+func TestRestoreExpiresOnChangedSourceValue(t *testing.T) {
+	ce := newAnchorTestEstimator(t, 8.5)
+	ce.Restore(Anchor{Soc: 15, EnergySince: 500}, 0)
+
+	fresh := 42.0
+	assert.Equal(t, 42.0, ce.Soc(&fresh, 0))
+	assert.Equal(t, 42.0, ce.Soc(&fresh, 0))
+}
+
+// evcc may restart mid-session, so the anchor is relative to whatever the
+// session counter happens to hold — not necessarily zero.
+func TestRestoreWithRunningSessionEnergy(t *testing.T) {
+	ce := newAnchorTestEstimator(t, 8.5)
+
+	ce.Restore(Anchor{Soc: 15, EnergySince: 500}, 800)
+
+	source := 15.0
+	assert.Equal(t, 20.0, ce.Soc(&source, 800))
+}
+
+// A vehicle without configured capacity has no Wh/% to convert the stored
+// energy into an offset. Dividing by that zero would produce +Inf, which
+// min(_, 100) turns into a plausible-looking full battery.
+func TestRestoreWithoutGradientKeepsAnchor(t *testing.T) {
+	ce := newAnchorTestEstimator(t, 0)
+
+	ce.Restore(Anchor{Soc: 15, EnergySince: 500}, 0)
+
+	assert.Equal(t, 15.0, ce.vehicleSoc)
+}


### PR DESCRIPTION

## Problem

`soc.Estimator` holds all state in memory. On restart a fresh estimator is built and `vehicleSoc`
falls back to whatever the vehicle API reports.

For vehicles reporting a **live** SoC that is harmless. But `estimate: true` exists because many
vehicles report **sparsely** — they sleep while plugged in, sit out of mobile coverage, or are behind
a cloud API that only refreshes when the car is awake. For those the API returns the same cached
value all session, and the estimator's accumulated correction is silently discarded.

That is not just a display reset. `minSocNotReached()` compares `lp.vehicleSoc` against `minSoc`, and
`Update()` forces full-power charging on `case minSocNotReached || plannerActive:`. So after a
restart evcc charges from the grid towards a `minSoc` the car has long exceeded.

Reproduced here on a power cut: a vehicle whose cloud SoC is frozen at 15 % while plugged in inside
a garage without reception, `minSoc` 20 %, estimator at 20.3 % after 5.1 kWh. evcc restarted, showed
15 % again and pulled 10.5 kW from the grid towards a level the car already had.

## Solution

Persist the estimator's **anchor** — the last vehicle-reported soc and the energy delivered since —
per vehicle under the existing `vehicle.<name>.<key>` settings scheme, and restore it into the fresh
estimator.

**Anchor rather than estimate.** `Soc()` recomputes `vehicleSoc = fetchedSoc +
energyDelta/energyPerSocStep` on every poll, so a restored estimate would be overwritten by the next
call. Restoring `prevChargedEnergy` reproduces the same estimate for as long as the vehicle keeps
reporting the value it was measured against.

It also expires by itself: a genuinely changed vehicle reading makes `socDelta != 0`, the estimator's
own rebase branch resets the anchor, and the offset is gone. A real reading always wins, with no
expiry logic and no stale-value handling.

**Per vehicle rather than per loadpoint**, because that is what it describes — and because the
coordinator already moves vehicles between loadpoints. Keyed per loadpoint, two cars at one charger
would overwrite each other and a car at a second charger would arrive empty. It also matches
`minSoc`, `limitSoc` and `planSoc`, which already live under `vehicle.<name>.*`.

No new persistence machinery: the settings ticker already flushes to SQLite every minute and on
shutdown.

## The subtle part, and the reason for the test

The restore runs in `createSession`, deliberately **not** in `setActiveVehicle`.

`evVehicleConnectHandler` runs `vehicleDefaultOrDetect()` — and with it `setActiveVehicle` — first,
and `createSession()` second. `createSession` is what calls `energyMetrics.Reset()`, zeroing the
session counter the anchor is measured against. Anchoring before that reset yields an anchor relative
to the *previous* session's counter.

The symptom is easy to miss: it looks correct at process start, where the counter genuinely is zero,
so a plain restart test passes. But it collapses the estimate onto the stale reading on every
**subsequent** connect, and the stored record is then overwritten with a zero offset — the history is
destroyed, not just mis-displayed. `splitSession` calls `createSession` too, so both paths are
covered by the same placement.

`TestRestoreSocEstimateSurvivesSessionCounterReset` drives the connect path in production order
through `lp.energyMetrics` and `lp.createSession()` rather than through ad-hoc numbers, precisely so
it cannot silently model an order production never takes.

## Scope

Deliberately not part of this: any UI, any manual SoC entry, any change to how the loadpoint chooses
between kWh- and SoC-based behaviour. This only makes an already-computed value survive a restart.

| | |
|---|---|
| Changes to existing files | **20 added lines across 5 files** |
| New files | 200 lines (record, persistence, estimator anchor/restore) |
| Tests | 242 lines |
| UI / dependencies / config changes | none |

`go test ./core/... ./server/` and `gofmt` are clean. Behaviour is unchanged for vehicles that report
a live SoC.

## One change that goes slightly beyond persistence

`setActiveVehicle` now clears `socEstimator` when the new vehicle has no capacity or has
`estimate: false`. Previously the estimator of the *previous* vehicle stayed in place in that
branch.

It is needed here so the persisted record cannot be attributed to the wrong vehicle, but it is
arguably a separate fix. No existing test changes behaviour because of it. Happy to split it out if
you would rather have it on its own.

## Open question

Whether you want the plausibility guards in the restore path (record age, sanity bound on the
implied offset) at all, or would rather rely purely on the rebase branch to discard a stale offset.
Happy to drop them if you prefer the smaller surface.
