### PR TITLE
EEBus: state the limit to a controllable system on connect

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -43,7 +43,7 @@ type EEBusOHPCF struct {
 	egLpcEntity spineapi.EntityRemoteInterface
 	enabled     bool
 	reboosting  bool
-	dimmed        bool // last limit written, re-stated on reconnect
+	dimmed      bool // last limit written, re-stated on reconnect
 
 	connector *eebus.Connector
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -43,7 +43,7 @@ type EEBusOHPCF struct {
 	egLpcEntity spineapi.EntityRemoteInterface
 	enabled     bool
 	reboosting  bool
-	// last limit written, re-stated when the device (re-)connects
+	// last limit written, re-stated on reconnect
 	dimmed bool
 
 	connector *eebus.Connector

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -43,6 +43,8 @@ type EEBusOHPCF struct {
 	egLpcEntity spineapi.EntityRemoteInterface
 	enabled     bool
 	reboosting  bool
+	// last limit written, re-stated when the device (re-)connects
+	dimmed bool
 
 	connector *eebus.Connector
 }
@@ -184,10 +186,17 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	case lpc.UseCaseSupportUpdate:
 		c.mu.Lock()
 		// use most specific selector
-		if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
+		adopted := c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity)
+		if adopted {
 			c.egLpcEntity = entity
 		}
+		dim := c.dimmed
 		c.mu.Unlock()
+
+		// [LPC-913]: state the limit to the newly available CS
+		if adopted {
+			eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
+		}
 	}
 }
 
@@ -405,9 +414,17 @@ func (c *EEBusOHPCF) Dim(dim bool) error {
 	}
 
 	// TODO: change api.Dimmer to make the limit configurable; use a fixed 0W safe limit for now
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: 0, IsActive: dim}, cb)
-	})
+	}); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.dimmed = dim
+	c.mu.Unlock()
+
+	return nil
 }
 
 // apply issues the command to align the optional consumption with the on/off

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -186,17 +186,14 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 	case lpc.UseCaseSupportUpdate:
 		c.mu.Lock()
 		// use most specific selector
-		adopted := c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity)
-		if adopted {
+		if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
 			c.egLpcEntity = entity
-		}
-		dim := c.dimmed
-		c.mu.Unlock()
 
-		// [LPC-913]: state the limit to the newly available CS
-		if adopted {
+			// [LPC-913]: state the limit to the newly available CS
+			dim := c.dimmed
 			eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
 		}
+		c.mu.Unlock()
 	}
 }
 

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -43,8 +43,7 @@ type EEBusOHPCF struct {
 	egLpcEntity spineapi.EntityRemoteInterface
 	enabled     bool
 	reboosting  bool
-	// last limit written, re-stated on reconnect
-	dimmed bool
+	dimmed        bool // last limit written, re-stated on reconnect
 
 	connector *eebus.Connector
 }

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -190,7 +190,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 
 			// [LPC-913]: state the limit to the newly available CS
 			dim := c.dimmed
-			eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
+			go eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
 		}
 		c.mu.Unlock()
 	}

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -189,8 +189,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 			c.egLpcEntity = entity
 
 			// [LPC-913]: state the limit to the newly available CS
-			dim := c.dimmed
-			go eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
+			go eebus.AssertLimit(c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}
 		c.mu.Unlock()
 	}
@@ -215,6 +214,13 @@ func (c *EEBusOHPCF) lastEnabled() bool {
 	defer c.mu.RUnlock()
 
 	return c.enabled
+}
+
+func (c *EEBusOHPCF) lastDimmed() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.dimmed
 }
 
 // ohpcfStatus maps the compressor process state to a charge status: running is

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -5,9 +5,11 @@ package charger
 
 import (
 	"testing"
+	"time"
 
 	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
 	egmocks "github.com/enbility/eebus-go/usecases/mocks"
 	spineapi "github.com/enbility/spine-go/api"
 	spinemocks "github.com/enbility/spine-go/mocks"
@@ -58,6 +60,32 @@ func TestOHPCF_LPC_EGMessages_ConsumptionLimit(t *testing.T) {
 
 			assert.NoError(t, c.Dim(tc.dim))
 		})
+	}
+}
+
+// ATC_COM_PT_EGMessages_002 (LPC-913): after initial connection the EG states a
+// limit to the CS - deactivated when nothing is being limited.
+func TestOHPCF_LPC_InitialLimit(t *testing.T) {
+	c, lpc, entity := newOHPCFEGCharger(t)
+	c.egLpcEntity = nil
+
+	written := make(chan ucapi.LoadLimit, 1)
+	lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
+	lpc.EXPECT().
+		WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
+		Run(func(_ spineapi.EntityRemoteInterface, limit ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
+			written <- limit
+			cb(model.ResultDataType{}, 0)
+		}).
+		Return(new(model.MsgCounterType), nil)
+
+	c.UseCaseEvent(nil, entity, eglpc.UseCaseSupportUpdate)
+
+	select {
+	case limit := <-written:
+		assert.Equal(t, ucapi.LoadLimit{Value: 0, IsActive: false}, limit)
+	case <-time.After(time.Second):
+		t.Fatal("no limit written after connect")
 	}
 }
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -36,7 +36,7 @@ type EEBus struct {
 	egLpcEntity spineapi.EntityRemoteInterface
 	egLppEntity spineapi.EntityRemoteInterface
 
-	// last limits written, re-stated when a device (re-)connects
+	// last limits written, re-stated on reconnect
 	dimmed         bool
 	curtailPercent int
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -36,8 +36,7 @@ type EEBus struct {
 	egLpcEntity spineapi.EntityRemoteInterface
 	egLppEntity spineapi.EntityRemoteInterface
 
-	// last limits written, re-stated on reconnect
-	dimmed         bool
+	dimmed         bool // last limits written, re-stated on reconnect// last limits written, re-stated on reconnect
 	curtailPercent int
 }
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -170,6 +170,20 @@ func eebusReadValue[T any](uc eebusapi.UseCaseBaseInterface, entity spineapi.Ent
 	return res, nil
 }
 
+func (c *EEBus) lastDimmed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.dimmed
+}
+
+func (c *EEBus) lastCurtailPercent() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.curtailPercent
+}
+
 func (c *EEBus) readValue(scenario uint, update func(entity spineapi.EntityRemoteInterface) (float64, error)) (float64, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -35,6 +35,10 @@ type EEBus struct {
 	maEntity    spineapi.EntityRemoteInterface
 	egLpcEntity spineapi.EntityRemoteInterface
 	egLppEntity spineapi.EntityRemoteInterface
+
+	// last limits written, re-stated when a device (re-)connects
+	dimmed         bool
+	curtailPercent int
 }
 
 // maScenarios holds the spec scenario numbers for the active monitoring use case.
@@ -111,12 +115,13 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	}
 
 	c := &EEBus{
-		log:       util.NewLogger("eebus-" + useCase),
-		ma:        ma,
-		eg:        inst.EnergyGuard(),
-		mm:        mm,
-		scenarios: scenarios,
-		connector: eebus.NewConnector(),
+		log:            util.NewLogger("eebus-" + useCase),
+		ma:             ma,
+		eg:             inst.EnergyGuard(),
+		mm:             mm,
+		scenarios:      scenarios,
+		connector:      eebus.NewConnector(),
+		curtailPercent: 100,
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -258,9 +263,17 @@ func (c *EEBus) Dim(dim bool) error {
 		return api.ErrNotAvailable
 	}
 
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPCInterface.WriteConsumptionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: dim}, cb)
-	})
+	}); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.dimmed = dim
+	c.mu.Unlock()
+
+	return nil
 }
 
 var _ api.Curtailer = (*EEBus)(nil)
@@ -311,7 +324,15 @@ func (c *EEBus) SetCurtailPercent(percent int) error {
 		}
 	}
 
-	return eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+	if err := eebus.Await(func(cb func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
 		return c.eg.EgLPPInterface.WriteProductionLimit(entity, ucapi.LoadLimit{Value: value, IsActive: curtail}, cb)
-	})
+	}); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.curtailPercent = percent
+	c.mu.Unlock()
+
+	return nil
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -74,11 +74,19 @@ func (c *EEBus) maUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 
 func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	// prefer the shallowest (device-level) entity
-	if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
+	adopted := c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity)
+	if adopted {
 		c.egLpcEntity = entity
+	}
+	dim := c.dimmed
+
+	c.mu.Unlock()
+
+	// [LPC-913]: state the limit to the newly available CS
+	if adopted {
+		eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
 	}
 }
 
@@ -88,10 +96,18 @@ func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 
 func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	// prefer the shallowest (device-level) entity
-	if c.egLppEntity == nil || len(entity.Address().Entity) < len(c.egLppEntity.Address().Entity) {
+	adopted := c.egLppEntity == nil || len(entity.Address().Entity) < len(c.egLppEntity.Address().Entity)
+	if adopted {
 		c.egLppEntity = entity
+	}
+	percent := c.curtailPercent
+
+	c.mu.Unlock()
+
+	// [LPP-913]: state the limit to the newly available CS
+	if adopted {
+		eebus.AssertLimit(c.log, func() error { return c.SetCurtailPercent(percent) })
 	}
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -74,18 +74,14 @@ func (c *EEBus) maUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 
 func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// prefer the shallowest (device-level) entity
-	adopted := c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity)
-	if adopted {
+	if c.egLpcEntity == nil || len(entity.Address().Entity) < len(c.egLpcEntity.Address().Entity) {
 		c.egLpcEntity = entity
-	}
-	dim := c.dimmed
 
-	c.mu.Unlock()
-
-	// [LPC-913]: state the limit to the newly available CS
-	if adopted {
+		// [LPC-913]: state the limit to the newly available CS
+		dim := c.dimmed
 		eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
 	}
 }
@@ -96,18 +92,14 @@ func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 
 func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// prefer the shallowest (device-level) entity
-	adopted := c.egLppEntity == nil || len(entity.Address().Entity) < len(c.egLppEntity.Address().Entity)
-	if adopted {
+	if c.egLppEntity == nil || len(entity.Address().Entity) < len(c.egLppEntity.Address().Entity) {
 		c.egLppEntity = entity
-	}
-	percent := c.curtailPercent
 
-	c.mu.Unlock()
-
-	// [LPP-913]: state the limit to the newly available CS
-	if adopted {
+		// [LPP-913]: state the limit to the newly available CS
+		percent := c.curtailPercent
 		eebus.AssertLimit(c.log, func() error { return c.SetCurtailPercent(percent) })
 	}
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -81,8 +81,7 @@ func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 		c.egLpcEntity = entity
 
 		// [LPC-913]: state the limit to the newly available CS
-		dim := c.dimmed
-		go eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
+		go eebus.AssertLimit(c.log, func() error { return c.Dim(c.lastDimmed()) })
 	}
 }
 
@@ -99,7 +98,6 @@ func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 		c.egLppEntity = entity
 
 		// [LPP-913]: state the limit to the newly available CS
-		percent := c.curtailPercent
-		go eebus.AssertLimit(c.log, func() error { return c.SetCurtailPercent(percent) })
+		go eebus.AssertLimit(c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
 	}
 }

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -82,7 +82,7 @@ func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 
 		// [LPC-913]: state the limit to the newly available CS
 		dim := c.dimmed
-		eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
+		go eebus.AssertLimit(c.log, func() error { return c.Dim(dim) })
 	}
 }
 
@@ -100,6 +100,6 @@ func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 
 		// [LPP-913]: state the limit to the newly available CS
 		percent := c.curtailPercent
-		eebus.AssertLimit(c.log, func() error { return c.SetCurtailPercent(percent) })
+		go eebus.AssertLimit(c.log, func() error { return c.SetCurtailPercent(percent) })
 	}
 }

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -5,8 +5,11 @@ package meter
 
 import (
 	"testing"
+	"time"
 
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
+	eglpp "github.com/enbility/eebus-go/usecases/eg/lpp"
 	egmocks "github.com/enbility/eebus-go/usecases/mocks"
 	spineapi "github.com/enbility/spine-go/api"
 	spinemocks "github.com/enbility/spine-go/mocks"
@@ -40,6 +43,27 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 // so eebus.Await completes.
 func ackWrite(_ spineapi.EntityRemoteInterface, _ ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
 	cb(model.ResultDataType{}, 0)
+}
+
+// captureWrite acks a mocked write and reports the limit it carried.
+func captureWrite(written chan<- ucapi.LoadLimit) func(spineapi.EntityRemoteInterface, ucapi.LoadLimit, func(model.ResultDataType, model.MsgCounterType)) {
+	return func(entity spineapi.EntityRemoteInterface, limit ucapi.LoadLimit, cb func(model.ResultDataType, model.MsgCounterType)) {
+		written <- limit
+		ackWrite(entity, limit, cb)
+	}
+}
+
+// awaitLimit waits for a limit written by the background AssertLimit retry.
+func awaitLimit(t *testing.T, written <-chan ucapi.LoadLimit) ucapi.LoadLimit {
+	t.Helper()
+
+	select {
+	case limit := <-written:
+		return limit
+	case <-time.After(time.Second):
+		t.Fatal("no limit written after connect")
+		return ucapi.LoadLimit{}
+	}
 }
 
 // --- LPC: Dim/Dimmed (Active Power Consumption Limit) -------------------------
@@ -246,6 +270,43 @@ func TestLPP_CurtailedPercent_NoNominal(t *testing.T) {
 	assert.ErrorIs(t, err, api.ErrNotAvailable)
 }
 
+// ATC_COM_PT_EGMessages_002 (LPC-913/LPP-913): after initial connection the EG
+// states a limit to the CS - deactivated when nothing is being limited.
+func TestLPC_LPP_InitialLimit(t *testing.T) {
+	t.Run("consumption", func(t *testing.T) {
+		c, lpc, _, entity := newEGMeter(t)
+		c.egLpcEntity = nil
+
+		written := make(chan ucapi.LoadLimit, 1)
+		lpc.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPCLimit).Return(true)
+		lpc.EXPECT().
+			WriteConsumptionLimit(entity, mock.Anything, mock.Anything).
+			Run(captureWrite(written)).
+			Return(new(model.MsgCounterType), nil)
+
+		c.UseCaseEvent(nil, entity, eglpc.UseCaseSupportUpdate)
+
+		assert.Equal(t, ucapi.LoadLimit{Value: 0, IsActive: false}, awaitLimit(t, written))
+	})
+
+	t.Run("production", func(t *testing.T) {
+		c, _, lpp, entity := newEGMeter(t)
+		c.egLppEntity = nil
+		c.curtailPercent = 100
+
+		written := make(chan ucapi.LoadLimit, 1)
+		lpp.EXPECT().IsScenarioAvailableAtEntity(entity, eebus.LPPLimit).Return(true)
+		lpp.EXPECT().
+			WriteProductionLimit(entity, mock.Anything, mock.Anything).
+			Run(captureWrite(written)).
+			Return(new(model.MsgCounterType), nil)
+
+		c.UseCaseEvent(nil, entity, eglpp.UseCaseSupportUpdate)
+
+		assert.Equal(t, ucapi.LoadLimit{Value: 0, IsActive: false}, awaitLimit(t, written))
+	})
+}
+
 // TestLPC_LPP_NonCoverage records the Controllable-System and connection/heartbeat
 // abstract test cases that belong to eebus-go and the evcc HEMS/charger, not the meter.
 func TestLPC_LPP_NonCoverage(t *testing.T) {
@@ -254,7 +315,6 @@ func TestLPC_LPP_NonCoverage(t *testing.T) {
 		"ATC_COM_PT_CSFS_001",         // failsafe values → hems/eebus + eebus-go
 		"ATC_COM_PT_EGHeartbeat_001",  // heartbeat cadence → eebus-go
 		"ATC_COM_PT_EGConnection_001", // connection setup → eebus-go
-		"ATC_COM_PT_EGMessages_002",   // resend-after-reboot/NACK → eebus-go
 	} {
 		t.Run(atc, func(t *testing.T) {
 			t.Skip("not applicable: covered by eebus-go or the evcc HEMS/charger, not the grid meter")

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -53,6 +53,7 @@ const limitTimeout = 50 * time.Second
 // AssertLimit states the current limit to a newly available Controllable System
 // ([LPC-913]/[LPP-913]). Retried in the background: the CS ignores writes that do
 // not follow a heartbeat and may reject them while still in state "init".
+// Returns immediately, so it may be called while holding the caller's lock.
 func AssertLimit(log *util.Logger, write func() error) {
 	go func() {
 		bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(limitTimeout))

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -47,15 +47,12 @@ func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.
 	}
 }
 
-// limitTimeout bounds the retry window for stating a limit to a Controllable
-// System, staying inside the 60s the spec grants the Energy Guard.
+// limitTimeout keeps the retries inside the 60s the spec grants the Energy Guard.
 const limitTimeout = 50 * time.Second
 
-// AssertLimit states the current limit to a Controllable System that just became
-// available. [LPC-913]/[LPP-913] require the Energy Guard to send a heartbeat and a
-// following limit within 60s of connecting. The write runs in the background and is
-// retried: the CS ignores writes not following a heartbeat and may reject them while
-// still in state "init".
+// AssertLimit states the current limit to a newly available Controllable System
+// ([LPC-913]/[LPP-913]). Retried in the background: the CS ignores writes that do
+// not follow a heartbeat and may reject them while still in state "init".
 func AssertLimit(log *util.Logger, write func() error) {
 	go func() {
 		bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(limitTimeout))

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -6,9 +6,11 @@ import (
 	"log"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	eebusapi "github.com/enbility/eebus-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
 )
 
 func WrapError(err error) error {
@@ -43,6 +45,24 @@ func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.
 	case <-time.After(WriteTimeout):
 		return errors.New("write result timeout")
 	}
+}
+
+// limitTimeout bounds the retry window for stating a limit to a Controllable
+// System, staying inside the 60s the spec grants the Energy Guard.
+const limitTimeout = 50 * time.Second
+
+// AssertLimit states the current limit to a Controllable System that just became
+// available. [LPC-913]/[LPP-913] require the Energy Guard to send a heartbeat and a
+// following limit within 60s of connecting. The write runs in the background and is
+// retried: the CS ignores writes not following a heartbeat and may reject them while
+// still in state "init".
+func AssertLimit(log *util.Logger, write func() error) {
+	go func() {
+		bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(limitTimeout))
+		if err := backoff.Retry(write, bo); err != nil {
+			log.DEBUG.Printf("assert limit: %v", err)
+		}
+	}()
 }
 
 func LogEntities(log *log.Logger, actor string, uc eebusapi.UseCaseInterface) {

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -51,16 +51,13 @@ func Await(write func(func(model.ResultDataType, model.MsgCounterType)) (*model.
 const limitTimeout = 50 * time.Second
 
 // AssertLimit states the current limit to a newly available Controllable System
-// ([LPC-913]/[LPP-913]). Retried in the background: the CS ignores writes that do
-// not follow a heartbeat and may reject them while still in state "init".
-// Returns immediately, so it may be called while holding the caller's lock.
+// ([LPC-913]/[LPP-913]). Blocks while retrying- the CS ignores writes that do not
+// follow a heartbeat and may reject them while still in state "init".
 func AssertLimit(log *util.Logger, write func() error) {
-	go func() {
-		bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(limitTimeout))
-		if err := backoff.Retry(write, bo); err != nil {
-			log.DEBUG.Printf("assert limit: %v", err)
-		}
-	}()
+	bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(limitTimeout))
+	if err := backoff.Retry(write, bo); err != nil {
+		log.DEBUG.Printf("assert limit: %v", err)
+	}
 }
 
 func LogEntities(log *log.Logger, actor string, uc eebusapi.UseCaseInterface) {


### PR DESCRIPTION
As Energy Guard, evcc sends heartbeats but never states a limit until it actually wants to dim or curtail. LPC/LPP require the opposite:

> After initial connection or restoration of communication, the EG SHALL send a heartbeat and a following APCL within 60 seconds to the CS after having determined that the communication is possible again — LPC HighLevel TestSpec V1.0.1, Ref No: `[LPC-913]` (`[LPP-913]` for production)

A deactivated limit satisfies this: "Within the write command the Energy Guard MAY also deactivate the Active Power Production Limit if there is no need for setting a limit on the Controllable System at this time" (`[LPP-916]`).

Until that write arrives the Controllable System sits in state "init" and, per `[LPC-906]`, may fall back to "unlimited/autonomous" after 120s — evcc silently loses control of a device it believes it manages. It also leaves the CS free to report a limit that carries no value at all (evcc-io/evcc#32126, enbility/eebus-go#255).

When the LPC/LPP use case becomes available on a remote entity, the current limit is now written to it — deactivated unless something is being dimmed or curtailed. The write runs in the background and is retried for up to 50s, since the CS ignores writes that do not follow a heartbeat and may reject them while still in "init". `Dim`/`SetCurtailPercent` remember what was last applied, so a reconnect re-states an active limit instead of silently releasing it.

Covers both Energy Guard roles: the OHPCF heat pump charger (LPC) and the EEBus meter (LPC + LPP).

Incidentally fixes https://github.com/evcc-io/evcc/issues/32125

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
