### PR TITLE
EEBus: keep grid limits applied as the LPC/LPP spec requires (BC)

### DIFF
--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -58,6 +58,7 @@ type EEBus struct {
 const failsafeReleaseTimeout = 2 * time.Minute
 
 type Limits struct {
+	// contractual max power at the grid connection point, not the SteuVE Pmin
 	ContractualConsumptionNominalMax    float64
 	FailsafeConsumptionActivePowerLimit float64
 
@@ -76,12 +77,6 @@ func NewFromConfig(ctx context.Context, other map[string]any, site site.API) (*E
 		Interval    time.Duration
 	}{
 		Limits: Limits{
-			// contractual max power at the grid connection point reported to the control box
-			// (EEBus LPC, EMS device type). Default: standard 3x35A x 230V house connection.
-			// This is the connection capacity, not the SteuVE Pmin (see failsafe limit below).
-			ContractualConsumptionNominalMax:    24150, // 3 * 35A * 230V
-			FailsafeConsumptionActivePowerLimit: 4200,
-
 			ProductionNominalMax:               0,
 			FailsafeProductionActivePowerLimit: nil, // 0 is a valid limit
 
@@ -138,8 +133,10 @@ func NewEEBus(ctx context.Context, ski string, limits Limits, passthrough func(b
 	eebus.LogEntities(c.log.DEBUG, "CS LPP", c.cs.CsLPPInterface)
 
 	// set initial values
-	if err := c.cs.CsLPCInterface.SetConsumptionNominalMax(limits.ContractualConsumptionNominalMax); err != nil {
-		c.log.ERROR.Println("CS LPC SetConsumptionNominalMax:", err)
+	if limits.ContractualConsumptionNominalMax > 0 {
+		if err := c.cs.CsLPCInterface.SetConsumptionNominalMax(limits.ContractualConsumptionNominalMax); err != nil {
+			c.log.ERROR.Println("CS LPC SetConsumptionNominalMax:", err)
+		}
 	}
 	if c.failsafeConsumptionLimit > 0 {
 		if err := c.cs.CsLPCInterface.SetFailsafeConsumptionActivePowerLimit(c.failsafeConsumptionLimit, true); err != nil {

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -124,10 +124,6 @@ func NewEEBus(ctx context.Context, ski string, limits Limits, passthrough func(b
 		productionNominalMax:     limits.ProductionNominalMax,
 	}
 
-	// simulate a received heartbeat
-	// otherwise a heartbeat timeout is assumed when the state machine is called for the first time
-	c.heartbeat.Set(struct{}{})
-
 	if err := inst.RegisterDevice(ski, "", c); err != nil {
 		return nil, err
 	}
@@ -167,6 +163,11 @@ func NewEEBus(ctx context.Context, ski string, limits Limits, passthrough func(b
 		if err := c.cs.CsLPPInterface.SetFailsafeDurationMinimum(c.failsafeDuration, true); err != nil {
 			c.log.ERROR.Println("CS LPP SetFailsafeDurationMinimum:", err)
 		}
+	}
+
+	// LPC-TS-017: start out limited to the failsafe limit until the Energy Guard states one
+	if err := c.run(); err != nil {
+		c.log.ERROR.Println(err)
 	}
 
 	return c, nil
@@ -259,7 +260,7 @@ func (c *EEBus) run() error {
 		// LPC-918/919/920 / LPP-equivalent: leave failsafe. Fall through to the
 		// LPC-914/1 block below, which will apply whatever fresh limit the EG sent
 		// (or release the limit if the EG has not sent an active limit).
-		c.log.DEBUG.Println("leaving failsafe mode")
+		c.log.DEBUG.Println("heartbeat returned- leaving failsafe mode")
 		c.setStatus(StatusNormal)
 
 		c.setConsumptionLimit(0)

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -162,11 +162,6 @@ func NewEEBus(ctx context.Context, ski string, limits Limits, passthrough func(b
 		}
 	}
 
-	// LPC-TS-017: start out limited to the failsafe limit until the Energy Guard states one
-	if err := c.run(); err != nil {
-		c.log.ERROR.Println(err)
-	}
-
 	return c, nil
 }
 
@@ -197,7 +192,8 @@ func (c *EEBus) Connect(connected bool) {
 }
 
 func (c *EEBus) Run() {
-	for range time.Tick(c.interval) {
+	// LPC-TS-017: the first run applies the failsafe limit until the Energy Guard states one
+	for tick := time.Tick(c.interval); ; <-tick {
 		if err := c.run(); err != nil {
 			c.log.ERROR.Println(err)
 		}

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -63,7 +63,7 @@ type Limits struct {
 	FailsafeConsumptionActivePowerLimit float64
 
 	ProductionNominalMax               float64
-	FailsafeProductionActivePowerLimit *float64
+	FailsafeProductionActivePowerLimit *float64 // nil is unset, 0 is a valid limit
 
 	FailsafeDurationMinimum time.Duration
 }
@@ -77,9 +77,6 @@ func NewFromConfig(ctx context.Context, other map[string]any, site site.API) (*E
 		Interval    time.Duration
 	}{
 		Limits: Limits{
-			ProductionNominalMax:               0,
-			FailsafeProductionActivePowerLimit: nil, // 0 is a valid limit
-
 			FailsafeDurationMinimum: 2 * time.Hour,
 		},
 		Interval: 10 * time.Second,

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -218,11 +218,15 @@ func (c *EEBus) run() error {
 
 	_, heartbeatErr := c.heartbeat.Get()
 
+	// the LPC-921 release window only runs while the heartbeat is back
+	if heartbeatErr != nil {
+		c.heartbeatReturned = time.Time{}
+	}
+
 	// LPC-911 / LPP-911: heartbeat lost while operating, enter failsafe.
 	if heartbeatErr != nil && c.status != StatusFailsafe {
 		c.log.WARN.Println("missing heartbeat- entering failsafe mode")
 		c.setStatus(StatusFailsafe)
-		c.heartbeatReturned = time.Time{}
 
 		c.setConsumptionLimit(c.failsafeConsumptionLimit)
 
@@ -239,7 +243,6 @@ func (c *EEBus) run() error {
 			// LPC-921 / LPP-921: still no heartbeat - keep applying the failsafe
 			// limit. The failsafe limit is our self-determined protective default
 			// for the Unlimited-autonomous state.
-			c.heartbeatReturned = time.Time{}
 			return nil
 		}
 
@@ -394,8 +397,8 @@ func (c *EEBus) MaxConsumptionPower() *float64 {
 	return new(c.consumptionLimit.Value)
 }
 
-// MaxProductionPower implements api.HEMS. Scaffolding only — EEBus does not
-// publish a wattage-typed production cap yet.
+// MaxProductionPower implements api.HEMS: nil until first connected,
+// else failsafe limit in failsafe, else the active EG-supplied LPP limit, else 0.
 func (c *EEBus) MaxProductionPower() *float64 {
 	c.mux.RLock()
 	defer c.mux.RUnlock()

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -58,12 +58,11 @@ type EEBus struct {
 const failsafeReleaseTimeout = 2 * time.Minute
 
 type Limits struct {
-	// contractual max power at the grid connection point, not the SteuVE Pmin
 	ContractualConsumptionNominalMax    float64
 	FailsafeConsumptionActivePowerLimit float64
 
 	ProductionNominalMax               float64
-	FailsafeProductionActivePowerLimit *float64 // nil is unset, 0 is a valid limit
+	FailsafeProductionActivePowerLimit *float64
 
 	FailsafeDurationMinimum time.Duration
 }

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -47,9 +47,15 @@ type EEBus struct {
 	failsafeProductionLimit  *float64        // feed-in limit (NOT production despite its name)
 	productionNominalMax     float64
 
-	heartbeat *util.Value[struct{}]
-	interval  time.Duration
+	heartbeat         *util.Value[struct{}]
+	heartbeatReturned time.Time // heartbeat resumed while in failsafe
+	limitReceived     time.Time // last limit written by the Energy Guard
+	interval          time.Duration
 }
+
+// failsafeReleaseTimeout is how long the CS keeps the failsafe limit after the
+// heartbeat resumed but the Energy Guard has not stated a limit yet ([LPC-921]).
+const failsafeReleaseTimeout = 2 * time.Minute
 
 type Limits struct {
 	ContractualConsumptionNominalMax    float64
@@ -216,6 +222,7 @@ func (c *EEBus) run() error {
 	if heartbeatErr != nil && c.status != StatusFailsafe {
 		c.log.WARN.Println("missing heartbeat- entering failsafe mode")
 		c.setStatus(StatusFailsafe)
+		c.heartbeatReturned = time.Time{}
 
 		c.setConsumptionLimit(c.failsafeConsumptionLimit)
 
@@ -232,14 +239,24 @@ func (c *EEBus) run() error {
 			// LPC-921 / LPP-921: still no heartbeat - keep applying the failsafe
 			// limit. The failsafe limit is our self-determined protective default
 			// for the Unlimited-autonomous state.
+			c.heartbeatReturned = time.Time{}
 			return nil
 		}
 
-		// LPC-918/919/920 / LPP-equivalent: heartbeat returned - leave failsafe
-		// immediately. Fall through to the LPC-914/1 block below, which will
-		// apply whatever fresh limit the EG sent (or release the limit if the
-		// EG has not sent an active limit since the failsafe entry).
-		c.log.DEBUG.Println("heartbeat returned- leaving failsafe mode")
+		if c.heartbeatReturned.IsZero() {
+			c.heartbeatReturned = time.Now()
+		}
+
+		// LPC-916/LPP-916: the failsafe state is left on a heartbeat and a *following*
+		// limit write. Without one, LPC-921 grants 120s before going unlimited.
+		if c.limitReceived.Before(c.statusUpdated) && time.Since(c.heartbeatReturned) < failsafeReleaseTimeout {
+			return nil
+		}
+
+		// LPC-918/919/920 / LPP-equivalent: leave failsafe. Fall through to the
+		// LPC-914/1 block below, which will apply whatever fresh limit the EG sent
+		// (or release the limit if the EG has not sent an active limit).
+		c.log.DEBUG.Println("leaving failsafe mode")
 		c.setStatus(StatusNormal)
 
 		c.setConsumptionLimit(0)
@@ -257,7 +274,8 @@ func (c *EEBus) run() error {
 		case !c.consumptionLimit.IsActive:
 			c.log.DEBUG.Println("consumption limit released")
 			c.setConsumptionLimit(0)
-		case time.Since(*c.consumptionLimitActivated) > c.consumptionLimit.Duration:
+		// a limit stated without duration does not expire
+		case c.consumptionLimit.Duration > 0 && time.Since(*c.consumptionLimitActivated) > c.consumptionLimit.Duration:
 			c.log.DEBUG.Println("consumption limit duration exceeded")
 			c.setConsumptionLimit(0)
 			c.consumptionLimit.IsActive = false
@@ -279,7 +297,8 @@ func (c *EEBus) run() error {
 		case !c.productionLimit.IsActive:
 			c.log.DEBUG.Println("production limit released")
 			c.setProductionLimit(0, false)
-		case time.Since(*c.productionLimitActivated) > c.productionLimit.Duration:
+		// a limit stated without duration does not expire
+		case c.productionLimit.Duration > 0 && time.Since(*c.productionLimitActivated) > c.productionLimit.Duration:
 			c.log.DEBUG.Println("production limit duration exceeded")
 			c.setProductionLimit(0, false)
 			c.productionLimit.IsActive = false
@@ -389,5 +408,6 @@ func (c *EEBus) MaxProductionPower() *float64 {
 	if c.status == StatusFailsafe {
 		return c.failsafeProductionLimit
 	}
-	return new(c.productionLimit.Value)
+	// production limits are negative watts, the api.HEMS cap is positive
+	return new(-c.productionLimit.Value)
 }

--- a/hems/eebus/eebus_test.go
+++ b/hems/eebus/eebus_test.go
@@ -134,9 +134,8 @@ func TestRun_HeartbeatReturned_AppliesFreshLimit(t *testing.T) {
 	assertProductionLimit(t, c, false)
 }
 
-// TestRun_HeartbeatReturned_NoLimitWrite covers LPC-916/LPC-921: a returning
-// heartbeat alone does not end the failsafe state - the EG must state a limit.
-// Without one the failsafe limit is kept for another 120s before going unlimited.
+// TestRun_HeartbeatReturned_NoLimitWrite covers LPC-916/LPC-921: a returning heartbeat
+// alone does not end failsafe - without a following limit write it is kept for 120s.
 func TestRun_HeartbeatReturned_NoLimitWrite(t *testing.T) {
 	c := newTestEEBus(t)
 
@@ -158,6 +157,24 @@ func TestRun_HeartbeatReturned_NoLimitWrite(t *testing.T) {
 	assert.Equal(t, StatusNormal, c.status)
 	assertConsumptionLimit(t, c, 0)
 	assertProductionLimit(t, c, false)
+}
+
+// TestRun_FailsafeReentry covers LPC-921 on a second failsafe cycle: a heartbeat
+// that returned during an earlier cycle must not end the new one.
+func TestRun_FailsafeReentry(t *testing.T) {
+	c := newTestEEBus(t)
+	c.heartbeatReturned = time.Now().Add(-2 * failsafeReleaseTimeout) // stale, earlier cycle
+
+	// heartbeat missing -> failsafe
+	require.NoError(t, c.run())
+	require.Equal(t, StatusFailsafe, c.status)
+
+	// heartbeat back without a limit write -> the 120s window restarts
+	c.heartbeat.Set(struct{}{})
+
+	require.NoError(t, c.run())
+	assert.Equal(t, StatusFailsafe, c.status, "stale heartbeat return must not end the new cycle")
+	assertConsumptionLimit(t, c, testFailsafeConsumption)
 }
 
 // TestRun_ProductionLimitReleasedEarly verifies that an active production limit
@@ -221,9 +238,8 @@ func TestRun_ConsumptionLimitReleasedEarly(t *testing.T) {
 	assertConsumptionLimit(t, c, 0)
 }
 
-// TestRun_LimitWithoutDuration covers the APCL_DUR_02 message combination: a limit
-// stated without a duration does not expire. eebus-go reports Duration 0 when the EG
-// sends no time period, which used to expire the limit on the very next tick.
+// TestRun_LimitWithoutDuration covers APCL_DUR_02: a limit stated without a duration
+// does not expire - eebus-go reports Duration 0 when the EG sends no time period.
 func TestRun_LimitWithoutDuration(t *testing.T) {
 	c := newTestEEBus(t)
 	c.heartbeat.Set(struct{}{})
@@ -235,8 +251,7 @@ func TestRun_LimitWithoutDuration(t *testing.T) {
 	assertConsumptionLimit(t, c, 3000)
 	assertProductionLimit(t, c, true)
 
-	// still applied on the following ticks
-	require.NoError(t, c.run())
+	// still applied on the following tick
 	require.NoError(t, c.run())
 	assertConsumptionLimit(t, c, 3000)
 	assertProductionLimit(t, c, true)

--- a/hems/eebus/eebus_test.go
+++ b/hems/eebus/eebus_test.go
@@ -103,7 +103,7 @@ func TestRun_HeartbeatLost_EntersFailsafe(t *testing.T) {
 // unprotected until heartbeat returned.
 func TestRun_FailsafeStaysOnMissingHeartbeat(t *testing.T) {
 	c := newTestEEBus(t)
-	c.status = StatusFailsafe
+	c.setStatus(StatusFailsafe)
 	// statusUpdated set in the past beyond failsafeDuration to verify we do not
 	// exit failsafe based on the duration alone.
 	c.statusUpdated = time.Now().Add(-2 * testFailsafeDuration)
@@ -114,7 +114,7 @@ func TestRun_FailsafeStaysOnMissingHeartbeat(t *testing.T) {
 }
 
 // TestRun_HeartbeatReturned_AppliesFreshLimit covers LPC-918/919/920: when
-// heartbeat is restored and an EG limit is pending, evcc must leave failsafe
+// heartbeat is restored and the EG has written a limit, evcc must leave failsafe
 // immediately and apply the freshly received limit. The previous code waited
 // for failsafeDuration to elapse and then dropped to a zero limit, ignoring
 // the fresh value.
@@ -122,10 +122,10 @@ func TestRun_HeartbeatReturned_AppliesFreshLimit(t *testing.T) {
 	const freshLimit = 3000.0
 
 	c := newTestEEBus(t)
-	c.status = StatusFailsafe
-	c.statusUpdated = time.Now() // well within failsafeDuration
+	c.setStatus(StatusFailsafe)
 	c.heartbeat.Set(struct{}{})
 	c.consumptionLimit = ucapi.LoadLimit{Value: freshLimit, IsActive: true}
+	c.limitReceived = time.Now()
 
 	require.NoError(t, c.run())
 	assert.Equal(t, StatusNormal, c.status)
@@ -134,14 +134,25 @@ func TestRun_HeartbeatReturned_AppliesFreshLimit(t *testing.T) {
 	assertProductionLimit(t, c, false)
 }
 
-// TestRun_HeartbeatReturned_NoFreshLimit covers the LPC-918 release case:
-// heartbeat restored but EG has no active limit pending -> exit to normal,
-// no limit applied.
-func TestRun_HeartbeatReturned_NoFreshLimit(t *testing.T) {
+// TestRun_HeartbeatReturned_NoLimitWrite covers LPC-916/LPC-921: a returning
+// heartbeat alone does not end the failsafe state - the EG must state a limit.
+// Without one the failsafe limit is kept for another 120s before going unlimited.
+func TestRun_HeartbeatReturned_NoLimitWrite(t *testing.T) {
 	c := newTestEEBus(t)
-	c.status = StatusFailsafe
+
+	// heartbeat missing -> failsafe
+	require.NoError(t, c.run())
+	require.Equal(t, StatusFailsafe, c.status)
+
+	// heartbeat back, but the EG has not stated a limit
 	c.heartbeat.Set(struct{}{})
-	c.consumptionLimit = ucapi.LoadLimit{IsActive: false}
+
+	require.NoError(t, c.run())
+	assert.Equal(t, StatusFailsafe, c.status, "heartbeat without a following limit must not end failsafe")
+	assertConsumptionLimit(t, c, testFailsafeConsumption)
+
+	// LPC-921: no limit write within 120s -> unlimited
+	c.heartbeatReturned = time.Now().Add(-2 * failsafeReleaseTimeout)
 
 	require.NoError(t, c.run())
 	assert.Equal(t, StatusNormal, c.status)
@@ -208,6 +219,41 @@ func TestRun_ConsumptionLimitReleasedEarly(t *testing.T) {
 	c.consumptionLimit.IsActive = false
 	require.NoError(t, c.run())
 	assertConsumptionLimit(t, c, 0)
+}
+
+// TestRun_LimitWithoutDuration covers the APCL_DUR_02 message combination: a limit
+// stated without a duration does not expire. eebus-go reports Duration 0 when the EG
+// sends no time period, which used to expire the limit on the very next tick.
+func TestRun_LimitWithoutDuration(t *testing.T) {
+	c := newTestEEBus(t)
+	c.heartbeat.Set(struct{}{})
+
+	c.consumptionLimit = ucapi.LoadLimit{Value: 3000, IsActive: true}
+	c.productionLimit = ucapi.LoadLimit{Value: -1000, IsActive: true}
+
+	require.NoError(t, c.run())
+	assertConsumptionLimit(t, c, 3000)
+	assertProductionLimit(t, c, true)
+
+	// still applied on the following ticks
+	require.NoError(t, c.run())
+	require.NoError(t, c.run())
+	assertConsumptionLimit(t, c, 3000)
+	assertProductionLimit(t, c, true)
+}
+
+// TestMaxProductionPower verifies the api.HEMS export cap is a positive wattage,
+// while LPP states its limits as negative watts.
+func TestMaxProductionPower(t *testing.T) {
+	c := newTestEEBus(t)
+	c.heartbeat.Set(struct{}{})
+	c.productionLimit = ucapi.LoadLimit{Value: -1000, IsActive: true}
+
+	require.NoError(t, c.run())
+
+	power := c.MaxProductionPower()
+	require.NotNil(t, power)
+	assert.Equal(t, 1000.0, *power)
 }
 
 // TestEEBusEdgeTriggered verifies that applying a limit (passthrough) only

--- a/hems/eebus/eebus_test.go
+++ b/hems/eebus/eebus_test.go
@@ -159,6 +159,26 @@ func TestRun_HeartbeatReturned_NoLimitWrite(t *testing.T) {
 	assertProductionLimit(t, c, false)
 }
 
+// TestRun_StartsInFailsafe covers LPC-TS-017: with no Energy Guard heard from yet the
+// CS starts out limited to the failsafe limit and leaves once the EG states one.
+func TestRun_StartsInFailsafe(t *testing.T) {
+	c := newTestEEBus(t) // no heartbeat seeded, like a fresh NewEEBus
+
+	require.NoError(t, c.run())
+	require.Equal(t, StatusFailsafe, c.status)
+	assertConsumptionLimit(t, c, testFailsafeConsumption)
+	assertProductionLimit(t, c, true)
+
+	// the EG shows up and states a limit
+	c.heartbeat.Set(struct{}{})
+	c.consumptionLimit = ucapi.LoadLimit{Value: 3000, IsActive: true}
+	c.limitReceived = time.Now()
+
+	require.NoError(t, c.run())
+	assert.Equal(t, StatusNormal, c.status)
+	assertConsumptionLimit(t, c, 3000)
+}
+
 // TestRun_FailsafeReentry covers LPC-921 on a second failsafe cycle: a heartbeat
 // that returned during an earlier cycle must not end the new one.
 func TestRun_FailsafeReentry(t *testing.T) {

--- a/hems/eebus/events.go
+++ b/hems/eebus/events.go
@@ -1,6 +1,8 @@
 package eebus
 
 import (
+	"time"
+
 	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	"github.com/enbility/eebus-go/usecases/cs/lpc"
@@ -128,6 +130,7 @@ func (c *EEBus) updateConsumptionLimit() {
 	defer c.mux.Unlock()
 
 	c.consumptionLimit = limit
+	c.limitReceived = time.Now()
 }
 
 func (c *EEBus) updateProductionLimit() {
@@ -141,6 +144,7 @@ func (c *EEBus) updateProductionLimit() {
 	defer c.mux.Unlock()
 
 	c.productionLimit = limit
+	c.limitReceived = time.Now()
 }
 
 func (c *EEBus) consumptionWriteApprovalRequired() {
@@ -155,6 +159,7 @@ func (c *EEBus) consumptionWriteApprovalRequired() {
 
 		c.mux.Lock()
 		c.consumptionLimit = limit
+		c.limitReceived = time.Now()
 		c.mux.Unlock()
 	}
 }
@@ -170,6 +175,7 @@ func (c *EEBus) productionWriteApprovalRequired() {
 		c.cs.CsLPPInterface.ApproveOrDenyProductionLimit(msg, true, "")
 		c.mux.Lock()
 		c.productionLimit = limit
+		c.limitReceived = time.Now()
 		c.mux.Unlock()
 	}
 }

--- a/templates/definition/hems/fnn-eebus.yaml
+++ b/templates/definition/hems/fnn-eebus.yaml
@@ -16,8 +16,8 @@ params:
       en: Max. consumption power (grid connection)
       de: Max. Bezugsleistung (Netzanschluss)
     help:
-      en: Contractual maximum power of the grid connection point reported to the control box. This is the connection capacity agreed with the grid operator, NOT the minimum consumption power (Pmin) of the control box. Default 24.15 kVA (3x35A).
-      de: Vertragliche Gesamtmaximalleistung des Netzanschlusspunkts, die der Steuerbox gemeldet wird. Dies ist die mit dem Netzbetreiber vereinbarte Anschlusskapazität, NICHT die SteuVE-Mindestleistung (Pmin). Standard 24,15 kVA (3x35A).
+      en: Contractual maximum power of the grid connection point reported to the control box. This is the connection capacity agreed with the grid operator, NOT the minimum consumption power (Pmin) of the control box.
+      de: Vertragliche Gesamtmaximalleistung des Netzanschlusspunkts, die der Steuerbox gemeldet wird. Dies ist die mit dem Netzbetreiber vereinbarte Anschlusskapazität, NICHT die SteuVE-Mindestleistung (Pmin).
   - name: failsafeconsumptionpower
     type: float
     unit: W
@@ -26,8 +26,8 @@ params:
       en: Failsafe consumption limit (Pmin, LPC)
       de: Failsafe-Bezugsgrenze der SteuVE (Pmin)
     help:
-      en: Failsafe minimum consumption power (Pmin) for controllable loads applied when the heartbeat from the control box is lost; it is overwritten by the control box once it transmits its own failsafe values. (Default 4.2 kW)
-      de: Verbleibende Mindestbezugsleistung (Pmin) für steuerbare Verbrauchseinrichtungen, die bei ausbleibendem Heartbeat der Steuerbox angewendet wird. Dies ist die per GZF berechnete Mindestbezugsleistung nach BK6-22-300; wird von der Steuerbox überschrieben, sobald diese eigene Failsafe-Werte überträgt. (Standard 4,2 kW nach § 14a EnWG)
+      en: Failsafe minimum consumption power (Pmin) for controllable loads applied when the heartbeat from the control box is lost; it is overwritten by the control box once it transmits its own failsafe values.
+      de: Verbleibende Mindestbezugsleistung (Pmin) für steuerbare Verbrauchseinrichtungen, die bei ausbleibendem Heartbeat der Steuerbox angewendet wird. Dies ist die per GZF berechnete Mindestbezugsleistung nach BK6-22-300; wird von der Steuerbox überschrieben, sobald diese eigene Failsafe-Werte überträgt.
   - name: productionnominalmax
     type: float
     unit: Wp

--- a/templates/definition/hems/hemspro-eebus.yaml
+++ b/templates/definition/hems/hemspro-eebus.yaml
@@ -17,8 +17,8 @@ params:
       en: Max. consumption power (grid connection)
       de: Max. Bezugsleistung (Netzanschluss)
     help:
-      en: Contractual maximum power of the grid connection point reported to the control box. This is the connection capacity agreed with the grid operator, NOT the minimum consumption power (Pmin) of the control box. Default 24.15 kVA (3x35A).
-      de: Vertragliche Gesamtmaximalleistung des Netzanschlusspunkts, die der Steuerbox gemeldet wird. Dies ist die mit dem Netzbetreiber vereinbarte Anschlusskapazität, NICHT die SteuVE-Mindestleistung (Pmin). Standard 24,15 kVA (3x35A).
+      en: Contractual maximum power of the grid connection point reported to the control box. This is the connection capacity agreed with the grid operator, NOT the minimum consumption power (Pmin) of the control box.
+      de: Vertragliche Gesamtmaximalleistung des Netzanschlusspunkts, die der Steuerbox gemeldet wird. Dies ist die mit dem Netzbetreiber vereinbarte Anschlusskapazität, NICHT die SteuVE-Mindestleistung (Pmin).
   - name: failsafeconsumptionpower
     type: float
     unit: W
@@ -27,8 +27,8 @@ params:
       en: Failsafe consumption limit (Pmin, LPC)
       de: Failsafe-Bezugsgrenze der SteuVE (Pmin)
     help:
-      en: Failsafe minimum consumption power (Pmin) for controllable loads applied when the heartbeat from the control box is lost; it is overwritten by the control box once it transmits its own failsafe values. (Default 4.2 kW)
-      de: Verbleibende Mindestbezugsleistung (Pmin) für steuerbare Verbrauchseinrichtungen, die bei ausbleibendem Heartbeat der Steuerbox angewendet wird. Dies ist die per GZF berechnete Mindestbezugsleistung nach BK6-22-300; wird von der Steuerbox überschrieben, sobald diese eigene Failsafe-Werte überträgt. (Standard 4,2 kW nach § 14a EnWG)
+      en: Failsafe minimum consumption power (Pmin) for controllable loads applied when the heartbeat from the control box is lost; it is overwritten by the control box once it transmits its own failsafe values.
+      de: Verbleibende Mindestbezugsleistung (Pmin) für steuerbare Verbrauchseinrichtungen, die bei ausbleibendem Heartbeat der Steuerbox angewendet wird. Dies ist die per GZF berechnete Mindestbezugsleistung nach BK6-22-300; wird von der Steuerbox überschrieben, sobald diese eigene Failsafe-Werte überträgt.
   - name: productionnominalmax
     type: float
     unit: Wp


### PR DESCRIPTION
Four LPC/LPP conformance defects in the Controllable System role, found while checking evcc against the LPC HighLevel TestSpec V1.0.1 and the LPP UC TS V1.0.0.

**A limit stated without a duration expired on the next tick.** eebus-go reports `Duration: 0` when the Energy Guard sends no time period (`usecases/cs/lpc/public.go`, the duration is only read from `TimePeriod.EndTime`), which means the limit does not expire. `run()` read that as "already expired", released the limit ~10s after activation and cleared `IsActive` so it never came back — while the Energy Guard still believes its limit is applied. The test spec exercises exactly this case as message combination `APCL_DUR_02`, "The duration parameter shall be deleted".

**Failsafe was left on a returning heartbeat alone.**

> `[LPC-TS-012]` The CS SHALL remain in the "failsafe state" for at least the duration specified in the configuration value Failsafe Duration Minimum unless another rule permits or requires leaving this state.

The rules that permit leaving are `[LPC-916]` — a heartbeat **and a following limit write** — and `[LPC-921]`, which grants the Energy Guard 120 seconds to state that limit before the CS may go unlimited. evcc left the moment a heartbeat arrived and released the failsafe limit right there, so the house was unlimited for the whole window between the heartbeat and the next limit write. The failsafe state now ends on a limit written after entering it, or 120s after the heartbeat returned, whichever comes first.

**The CS started up unlimited.**

> `[LPC-TS-017]` After a restart the CS shall begin limited to the FCAPL.

evcc pre-seeded a heartbeat at construction so the state machine would not see a timeout on its first run, which meant a restart came up unlimited until the Energy Guard stated a limit. The seed is gone and the run loop no longer waits a full interval before its first pass, so evcc now boots into the failsafe state applying the configured failsafe consumption limit. The hard-coded defaults for that limit and for the contractual nominal max are gone with it — an unconfigured installation states no limit rather than a made-up 4.2 kW, and a restart no longer clobbers the failsafe value the Energy Guard wrote with it. The rules above end that state as soon as the Energy Guard is heard from — on its first limit write, or 120s after its first heartbeat. Without an Energy Guard the previous behaviour reached the same failsafe state anyway, just two minutes later, once the seeded heartbeat had aged out.

**`MaxProductionPower` returned a negative wattage.** LPP states its limits as negative watts; the failsafe branch returned a positive value and the normal branch returned the raw negative one. `core/site_optimizer.go` feeds it into `req.Grid.PMaxExp` and `hems/fnn` returns positive for the same interface, so an active EEBus curtailment handed the optimizer a negative export cap.

`TestRun_HeartbeatReturned_NoFreshLimit` asserted the old behaviour (leaving failsafe on the heartbeat alone) and is replaced by `TestRun_HeartbeatReturned_NoLimitWrite`, which covers both the wait and the 120s release.

Not addressed here, needing a decision rather than a fix: `[LPC-TS-035/1]` permits a 0 W limit, but `api.HEMS` defines `MaxConsumptionPower() == 0` as "no limit", so a 0 W limit reads as unlimited.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
