### PR TITLE
EEBus: abort run loop and limit assertion on context cancellation

### DIFF
--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -189,7 +189,7 @@ func (c *EEBusOHPCF) UseCaseEvent(_ spineapi.DeviceRemoteInterface, entity spine
 			c.egLpcEntity = entity
 
 			// [LPC-913]: state the limit to the newly available CS
-			go eebus.AssertLimit(c.log, func() error { return c.Dim(c.lastDimmed()) })
+			go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 		}
 		c.mu.Unlock()
 	}

--- a/charger/eebus-ohpcf_lpc_test.go
+++ b/charger/eebus-ohpcf_lpc_test.go
@@ -29,6 +29,7 @@ func newOHPCFEGCharger(t *testing.T) (*EEBusOHPCF, *egmocks.EgLPCInterface, spin
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBusOHPCF{
+		ctx:         t.Context(),
 		log:         util.NewLogger("eebus-ohpcf-test"),
 		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc},
 		egLpcEntity: entity,

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -22,6 +22,7 @@ func init() {
 
 type EEBus struct {
 	mux sync.RWMutex
+	ctx context.Context // device lifetime, aborts Run
 	log *util.Logger
 
 	*eebus.Connector
@@ -104,6 +105,7 @@ func NewEEBus(ctx context.Context, ski string, limits Limits, passthrough func(b
 	}
 
 	c := &EEBus{
+		ctx:         ctx,
 		log:         util.NewLogger("eebus"),
 		site:        site,
 		passthrough: passthrough,
@@ -192,8 +194,18 @@ func (c *EEBus) Connect(connected bool) {
 	}
 }
 
+// Run applies limits until the device context is cancelled
 func (c *EEBus) Run() {
-	for range time.Tick(c.interval) {
+	tick := time.NewTicker(c.interval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-tick.C:
+		}
+
 		if err := c.run(); err != nil {
 			c.log.ERROR.Println(err)
 		}

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -196,22 +196,19 @@ func (c *EEBus) Connect(connected bool) {
 
 // Run applies limits until the device context is cancelled
 func (c *EEBus) Run() {
-	tick := time.NewTicker(c.interval)
-	defer tick.Stop()
-
-	for {
+	for tick := time.Tick(c.interval); ; {
 		select {
+		case <-tick:
+			if err := c.run(); err != nil {
+				c.log.ERROR.Println(err)
+			}
+
+			if c.publishFunc != nil {
+				c.publishFunc()
+			}
+
 		case <-c.ctx.Done():
 			return
-		case <-tick.C:
-		}
-
-		if err := c.run(); err != nil {
-			c.log.ERROR.Println(err)
-		}
-
-		if c.publishFunc != nil {
-			c.publishFunc()
 		}
 	}
 }

--- a/hems/eebus/eebus_test.go
+++ b/hems/eebus/eebus_test.go
@@ -1,6 +1,7 @@
 package eebus
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -40,7 +41,9 @@ func newTestEEBus(t *testing.T) *EEBus {
 
 	failsafeProduction := testFailsafeProduction
 	return &EEBus{
+		ctx:                      t.Context(),
 		log:                      util.NewLogger("test"),
+		interval:                 time.Millisecond,
 		site:                     &stubSite{},
 		Connector:                eebus.NewConnector(),
 		heartbeat:                util.NewValue[struct{}](time.Hour),
@@ -226,4 +229,28 @@ func TestEEBusEdgeTriggered(t *testing.T) {
 
 	require.Equal(t, 1, calls, "passthrough must fire once on the edge, not every tick")
 	assertConsumptionLimit(t, c, 3000)
+}
+
+// TestRunAborts verifies the run loop terminates when the device context is
+// cancelled instead of ticking for the lifetime of the process.
+func TestRunAborts(t *testing.T) {
+	c := newTestEEBus(t)
+	c.interval = time.Hour // only the context can end the loop
+
+	ctx, cancel := context.WithCancel(t.Context())
+	c.ctx = ctx
+
+	done := make(chan struct{})
+	go func() {
+		c.Run()
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return on cancelled context")
+	}
 }

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -23,6 +23,7 @@ import (
 // Uses MPC (Monitoring & Power Consumption) for all other cases (default)
 // Additionally supports LPC (Limitation of Power Consumption) and LPP (Limitation of Power Production)
 type EEBus struct {
+	ctx context.Context // device lifetime, aborts limit retries
 	log *util.Logger
 
 	connector *eebus.Connector
@@ -114,6 +115,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	}
 
 	c := &EEBus{
+		ctx:            ctx,
 		log:            util.NewLogger("eebus-" + useCase),
 		ma:             ma,
 		eg:             inst.EnergyGuard(),

--- a/meter/eebus_events.go
+++ b/meter/eebus_events.go
@@ -81,7 +81,7 @@ func (c *EEBus) egLpcUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 		c.egLpcEntity = entity
 
 		// [LPC-913]: state the limit to the newly available CS
-		go eebus.AssertLimit(c.log, func() error { return c.Dim(c.lastDimmed()) })
+		go eebus.AssertLimit(c.ctx, c.log, func() error { return c.Dim(c.lastDimmed()) })
 	}
 }
 
@@ -98,6 +98,6 @@ func (c *EEBus) egLppUseCaseSupportUpdate(entity spineapi.EntityRemoteInterface)
 		c.egLppEntity = entity
 
 		// [LPP-913]: state the limit to the newly available CS
-		go eebus.AssertLimit(c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
+		go eebus.AssertLimit(c.ctx, c.log, func() error { return c.SetCurtailPercent(c.lastCurtailPercent()) })
 	}
 }

--- a/meter/eebus_lpc_lpp_test.go
+++ b/meter/eebus_lpc_lpp_test.go
@@ -30,6 +30,7 @@ func newEGMeter(t *testing.T) (*EEBus, *egmocks.EgLPCInterface, *egmocks.EgLPPIn
 	entity := spinemocks.NewEntityRemoteInterface(t)
 
 	c := &EEBus{
+		ctx:         t.Context(),
 		log:         util.NewLogger("eebus-eg-test"),
 		eg:          &eebus.EnergyGuard{EgLPCInterface: lpc, EgLPPInterface: lpp},
 		egLpcEntity: entity,

--- a/server/eebus/helper.go
+++ b/server/eebus/helper.go
@@ -1,6 +1,7 @@
 package eebus
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -52,10 +53,11 @@ const limitTimeout = 50 * time.Second
 
 // AssertLimit states the current limit to a newly available Controllable System
 // ([LPC-913]/[LPP-913]). Blocks while retrying- the CS ignores writes that do not
-// follow a heartbeat and may reject them while still in state "init".
-func AssertLimit(log *util.Logger, write func() error) {
+// follow a heartbeat and may reject them while still in state "init". Retrying
+// stops when ctx is cancelled, i.e. when the device is gone.
+func AssertLimit(ctx context.Context, log *util.Logger, write func() error) {
 	bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(limitTimeout))
-	if err := backoff.Retry(write, bo); err != nil {
+	if err := backoff.Retry(write, backoff.WithContext(bo, ctx)); err != nil && ctx.Err() == nil {
 		log.DEBUG.Printf("assert limit: %v", err)
 	}
 }


### PR DESCRIPTION
Two long-running EEBus routines outlived the device they belong to:

- `hems/eebus`: `Run()` looped on `time.Tick` for the lifetime of the process — the ticker was never stopped and the goroutine of a replaced HEMS device kept running. It now keeps the device context handed to `NewEEBus` and returns once it is cancelled, using a stoppable `time.NewTicker`.
- `server/eebus.AssertLimit`: the [LPC-913]/[LPP-913] limit write retried for up to 50s in a goroutine, continuing against a device that was already unregistered. The backoff is now bound to the device context, so it stops with the device (`EEBusOHPCF` charger and the EEBus meter call sites).

Note: `cmd/setup.go` still constructs HEMS devices with `context.TODO()`, so nothing cancels the HEMS loop today — this makes it abortable so the call sites can move to a per-device cancellable context like `staticInstance`/`configurableInstance` already do. The charger/meter call sites already have a real device context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)