### PR TITLE
Metrics: keep history slots plausible for coarse energy meters

### DIFF
--- a/core/metrics/accumulator.go
+++ b/core/metrics/accumulator.go
@@ -13,9 +13,14 @@ type Accumulator struct {
 	updated           time.Time
 	energyMeter       *float64 // kWh
 	returnEnergyMeter *float64 // kWh
-	Energy            float64  `json:"energy"`       // kWh
-	ReturnEnergy      float64  `json:"returnEnergy"` // kWh
-	SocTemp           *float64 `json:"socTemp,omitempty"`
+	// power-integrated energy the meter counter has not confirmed yet. A counter
+	// coarser than a slot's energy would otherwise leave slots empty and dump the
+	// whole jump into the slot it happens to tick in
+	pendingEnergy       float64  // kWh
+	pendingReturnEnergy float64  // kWh
+	Energy              float64  `json:"energy"`       // kWh
+	ReturnEnergy        float64  `json:"returnEnergy"` // kWh
+	SocTemp             *float64 `json:"socTemp,omitempty"`
 }
 
 // AccumulatorState is the resumable meter-reading checkpoint of an Accumulator.
@@ -92,11 +97,17 @@ func (m *Accumulator) SetEnergyMeterTotal(v float64) {
 	}()
 
 	if m.energyMeter == nil {
+		// the counter's history starts here, earlier integration is not its business
+		m.pendingEnergy = 0
 		return
 	}
 
 	if v >= *m.energyMeter {
-		m.Energy += v - *m.energyMeter
+		// the counter is the truth - book only what integration has not booked
+		// already and carry the rest into the following slots
+		delta := v - *m.energyMeter
+		m.Energy += max(0, delta-m.pendingEnergy)
+		m.pendingEnergy = max(0, m.pendingEnergy-delta)
 	}
 }
 
@@ -108,11 +119,14 @@ func (m *Accumulator) SetReturnEnergyMeterTotal(v float64) {
 	}()
 
 	if m.returnEnergyMeter == nil {
+		m.pendingReturnEnergy = 0
 		return
 	}
 
 	if v >= *m.returnEnergyMeter {
-		m.ReturnEnergy += v - *m.returnEnergyMeter
+		delta := v - *m.returnEnergyMeter
+		m.ReturnEnergy += max(0, delta-m.pendingReturnEnergy)
+		m.pendingReturnEnergy = max(0, m.pendingReturnEnergy-delta)
 	}
 }
 
@@ -138,12 +152,21 @@ func (m *Accumulator) AddReturnEnergy(v float64) {
 	m.ReturnEnergy += v
 }
 
-// AddPower adds the given power in W, calculating the energy based on the time since the last update
+// AddPower adds the given power in W, calculating the energy based on the time
+// since the last update. For a metered direction the energy is provisional and
+// gets netted against the next counter delta.
 func (m *Accumulator) AddPower(v float64) {
+	if m.updated.IsZero() {
+		m.updated = m.clock.Now()
+		return
+	}
+
 	since := v * m.clock.Since(m.updated).Hours() / 1e3
 	if v >= 0 {
 		m.AddEnergy(since)
+		m.pendingEnergy += since
 	} else {
 		m.AddReturnEnergy(-since)
+		m.pendingReturnEnergy -= since
 	}
 }

--- a/core/metrics/collector.go
+++ b/core/metrics/collector.go
@@ -195,26 +195,16 @@ func (c *Collector) SetReturnEnergyMeterTotal(v float64) error {
 	})
 }
 
-// AddEnergy adds energy using meter totals if available, falling back to power
-// integration only for directions without an energy meter. A direction that has
-// reported a total before keeps using meter deltas even if a single read fails,
-// so a transient failure is recovered via the next delta and not double-counted.
+// AddEnergy integrates power and reconciles it against the meter totals. A
+// metered direction books integrated energy provisionally, so its 15min slots
+// follow the power curve even when the counter resolution is coarser than a
+// slot's energy, while the total stays counter-exact. A failed or missing
+// energy read needs no special case: the next delta nets out what integration
+// already booked, so nothing is double-counted.
 func (c *Collector) AddEnergy(energyTotal, returnEnergyTotal *float64, power float64) error {
 	return c.process(func() {
-		// a direction that ever reported a total is metered, so a nil read is a
-		// transient failure rather than a power-only meter
-		hasEnergyMeter := energyTotal != nil || c.accu.energyMeter != nil
-		hasReturnMeter := returnEnergyTotal != nil || c.accu.returnEnergyMeter != nil
-
-		// integrate power for the unmetered direction first, since applying a
-		// meter total advances the accumulator clock
-		if power >= 0 {
-			if !hasEnergyMeter {
-				c.accu.AddPower(power)
-			}
-		} else if !hasReturnMeter {
-			c.accu.AddPower(power)
-		}
+		// integrate first, since applying a meter total advances the accumulator clock
+		c.accu.AddPower(power)
 
 		if energyTotal != nil {
 			c.accu.SetEnergyMeterTotal(*energyTotal)

--- a/core/metrics/collector_test.go
+++ b/core/metrics/collector_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -192,9 +193,9 @@ func TestCollectorRecoversAfterFullMeterFailure(t *testing.T) {
 
 // TestCollectorRecoversAfterFailedEnergyRead verifies energy accounting when a
 // meter's energy total read fails for one cycle while power keeps reporting
-// (collectMeters passes a nil energy total but a valid power). A metered
-// direction skips power integration on the failed read and recovers the gap via
-// the next meter delta, so the failed interval is not double-counted.
+// (collectMeters passes a nil energy total but a valid power). The failed
+// interval is integrated from power and netted against the next meter delta,
+// so it is neither lost nor double-counted.
 func TestCollectorRecoversAfterFailedEnergyRead(t *testing.T) {
 	clock := clock.NewMock()
 
@@ -214,11 +215,11 @@ func TestCollectorRecoversAfterFailedEnergyRead(t *testing.T) {
 	require.NoError(t, col.AddEnergy(new(10.05), nil, 1e3))
 	require.InDelta(t, 0.05, col.accu.Energy, 1e-9)
 
-	// energy read fails (nil) while power is still reported: the gap is not
-	// power-integrated because the meter has reported a total before
+	// energy read fails (nil) while power is still reported: the gap is
+	// integrated provisionally
 	clock.Add(3 * time.Minute)
 	require.NoError(t, col.AddEnergy(nil, nil, 1e3))
-	require.InDelta(t, 0.05, col.accu.Energy, 1e-9)
+	require.InDelta(t, 0.10, col.accu.Energy, 1e-9)
 
 	// recovered read: meter advanced to 10.15 (real 0.10 kWh since last good read)
 	clock.Add(3 * time.Minute)
@@ -227,6 +228,39 @@ func TestCollectorRecoversAfterFailedEnergyRead(t *testing.T) {
 	// 9 min @ 1 kW = 0.15 kWh delivered (meter 10.00 -> 10.15). The recovery
 	// delta (10.15 - 10.05) captures the gap exactly, without double-counting.
 	require.InDelta(t, 0.15, col.accu.Energy, 1e-9)
+}
+
+// TestCollectorCoarseEnergyMeter verifies that a meter whose energy counter is
+// coarser than a slot's energy still yields one plausible value per slot rather
+// than alternating empty and double slots.
+// https://github.com/evcc-io/evcc/issues/32324
+func TestCollectorCoarseEnergyMeter(t *testing.T) {
+	clk := clock.NewMock() // 1970-01-01 00:00:00 UTC, on a slot boundary
+
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	require.NoError(t, SetupSchema())
+
+	col, err := NewCollector(PV, "coarse", "", WithClock(clk))
+	require.NoError(t, err)
+
+	// 2 kW constant is 0.5 kWh per slot, below the counter's full-kWh
+	// resolution: it only ticks every other slot
+	const power = 2e3
+	const base = 53740.0
+
+	for range 8 * 15 { // 8 slots at 1min interval
+		total := base + math.Trunc(power*float64(clk.Now().Unix())/3600/1e3)
+		clk.Add(time.Minute)
+		require.NoError(t, col.AddEnergy(&total, nil, power))
+	}
+
+	var slots []meter
+	require.NoError(t, db.Instance.Where("meter = ?", col.entity.Id).Order("ts").Find(&slots).Error)
+	require.NotEmpty(t, slots)
+
+	for _, s := range slots {
+		require.InDelta(t, 0.5, s.Energy, 0.15, "slot %d must carry a plausible energy", s.Timestamp)
+	}
 }
 
 // TestCollectorSkipsPartialFirstSlot verifies that the first slot, joined


### PR DESCRIPTION
Fixes #32324

## Problem

The reporter's SolarMax SMT reports its energy counter in whole kWh:

```
Power:  8091W        Energy: 53740.0kWh   11:53
Power:  8494W        Energy: 53740.0kWh   12:08
Power:  8686W        Energy: 53743.0kWh   12:23
```

`Collector.AddEnergy` chose one source per direction: a direction with an energy counter used counter deltas only and never integrated power. When the counter resolution is coarser than a slot's energy, some 15min slots see a delta of 0 and the next one absorbs the whole jump — the chart plots only every other slot, while the daily sum in the footer stays correct.

Not device-specific: any meter whose counter granularity exceeds the slot energy hits this, and the same meter hits it only at low power. At 2 kW a full-kWh counter ticks once per two slots.

## Change

Integrate power for every direction, and treat a metered direction's integrated energy as provisional: the next counter delta books only what integration has not booked already, carrying the remainder forward.

- slots follow the power curve
- the running total still converges on the counter, so sums stay counter-exact
- integration that runs ahead of the counter is suppressed by the carry, so it cannot drift upward

This subsumes the `hasEnergyMeter`/`hasReturnMeter` special case for failed energy reads — a nil read is now integrated provisionally and netted by the next delta, rather than skipped. `TestCollectorRecoversAfterFailedEnergyRead` keeps its end-state assertion (0.15 kWh over 9 min @ 1 kW); only the mid-gap value changes from 0.05 to 0.10, which is the energy that was actually delivered.

## Verification

`TestCollectorCoarseEnergyMeter` models 2 kW constant against a full-kWh counter over 8 slots. Without the change the first persisted slot holds 0 kWh; with it every slot holds ~0.5 kWh.

`go test ./core/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)