### PR TITLE
SolarMax SMT: drop the whole-kWh energy register

### DIFF
--- a/templates/definition/meter/solarmax-inverter-smt.yaml
+++ b/templates/definition/meter/solarmax-inverter-smt.yaml
@@ -19,6 +19,4 @@ render: |
       type: holding
       decode: uint32
     scale: 0.1
-  # no energy: register 4129 (Total) only resolves whole kWh. Below 4 kW that is
-  # coarser than a 15min history slot, leaving slots empty while the counter
-  # jumps in the next one. Power integration is more accurate here. See #32324
+  # energy removed: register 4129 (Total) only resolves whole kWh (#32497)

--- a/templates/definition/meter/solarmax-inverter-smt.yaml
+++ b/templates/definition/meter/solarmax-inverter-smt.yaml
@@ -19,10 +19,6 @@ render: |
       type: holding
       decode: uint32
     scale: 0.1
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 4129 # Total
-      type: holding
-      decode: uint32
+  # no energy: register 4129 (Total) only resolves whole kWh. Below 4 kW that is
+  # coarser than a 15min history slot, leaving slots empty while the counter
+  # jumps in the next one. Power integration is more accurate here. See #32324


### PR DESCRIPTION
Fixes #32324

Register 4129 (Total) is `uint32` with no scale — the device reports whole kWh:

```
Power:  8091W        Energy: 53740.0kWh   11:53
Power:  8494W        Energy: 53740.0kWh   12:08
Power:  8686W        Energy: 53743.0kWh   12:23
```

History slots are 15min, so below 4 kW a slot's energy is under 1 kWh and the counter does not move at all. That slot is stored as 0 and the next one absorbs the whole jump — the reporter sees only every other slot plotted while the daily sum in the footer stays correct.

Dropping `energy` makes it a power-only meter, so evcc integrates power for the history. A comment in its place records why, so the register does not get added back.

## Trade-off

The meter no longer contributes to the lifetime PV energy total — that reading was whole-kWh anyway. Per-slot and per-day energy now come from power integration at the configured update interval.

Left `solarmax-maxstorage.yaml` alone: different device, different register (150, `int32s`), and no evidence its resolution is coarse.

## Verification

`go test ./util/templates/... ./meter/...` — the meter template suite renders and instantiates every template, so this covers the edited render block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)