### PR TITLE
Config: let templates override modbus param help texts

### DIFF
--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -138,6 +138,7 @@
 								:defaultBaudrate="modbus.Baudrate"
 								:defaultPort="modbus.Port"
 								:capabilities="modbusCapabilities"
+								:help-overrides="modbusHelpOverrides"
 							/>
 
 							<PropertyEntry
@@ -157,6 +158,7 @@
 										v-model:delay="values['delay']"
 										v-model:timeout="values['timeout']"
 										component-id="device"
+										:help-overrides="modbusHelpOverrides"
 									/>
 									<PropertyEntry
 										v-for="param in advancedParams"
@@ -243,6 +245,8 @@ import {
 	createDeviceUtils,
 	fetchServiceValues,
 	ADMIN_PASSWORD_REQUIRED,
+	MODBUS_FIELDS,
+	modbusHelpOverrides,
 } from "./index";
 import deepEqual from "@/utils/deepEqual";
 
@@ -365,6 +369,8 @@ export default defineComponent({
 			const filtered = params.filter(
 				(p) =>
 					!this.customFields.includes(p.Name) &&
+					// the modbus components render these themselves
+					!(this.modbus && MODBUS_FIELDS.includes(p.Name)) &&
 					(p.Usages ? p.Usages.includes(this.deviceType as any) : true)
 			);
 
@@ -400,6 +406,9 @@ export default defineComponent({
 		},
 		modbusCapabilities() {
 			return (this.modbus?.Choice || []) as ModbusCapability[];
+		},
+		modbusHelpOverrides(): Record<string, string> {
+			return modbusHelpOverrides((this.template?.Params || []) as TemplateParam[]);
 		},
 		modbusDefaults() {
 			return {

--- a/assets/js/components/Config/DeviceModal/Modbus.vue
+++ b/assets/js/components/Config/DeviceModal/Modbus.vue
@@ -38,7 +38,12 @@
 			</label>
 		</div>
 	</FormRow>
-	<FormRow v-if="!hideModbusId" id="modbusId" :label="$t('config.modbus.id')">
+	<FormRow
+		v-if="!hideModbusId"
+		id="modbusId"
+		:label="$t('config.modbus.id')"
+		:help="helpOverrides['id']"
+	>
 		<PropertyField
 			id="modbusId"
 			property="id"
@@ -53,7 +58,7 @@
 		<FormRow
 			:id="formId('modbusHost')"
 			:label="$t('config.modbus.host')"
-			:help="$t('config.modbus.hostHint')"
+			:help="helpOverrides['host'] || $t('config.modbus.hostHint')"
 		>
 			<PropertyField
 				:id="formId('modbusHost')"
@@ -65,7 +70,11 @@
 				@update:model-value="(v) => $emit('update:host', v)"
 			/>
 		</FormRow>
-		<FormRow :id="formId('modbusPort')" :label="$t('config.modbus.port')">
+		<FormRow
+			:id="formId('modbusPort')"
+			:label="$t('config.modbus.port')"
+			:help="helpOverrides['port']"
+		>
 			<PropertyField
 				:id="formId('modbusPort')"
 				property="port"
@@ -120,7 +129,7 @@
 		<FormRow
 			:id="formId('modbusDevice')"
 			:label="$t('config.modbus.device')"
-			:help="$t('config.modbus.deviceHint')"
+			:help="helpOverrides['device'] || $t('config.modbus.deviceHint')"
 			data-testid="modbus-device"
 		>
 			<PropertyField
@@ -133,7 +142,11 @@
 				:service-values="deviceServiceValues"
 			/>
 		</FormRow>
-		<FormRow :id="formId('modbusBaudrate')" :label="$t('config.modbus.baudrate')">
+		<FormRow
+			:id="formId('modbusBaudrate')"
+			:label="$t('config.modbus.baudrate')"
+			:help="helpOverrides['baudrate']"
+		>
 			<PropertyField
 				:id="formId('modbusBaudrate')"
 				property="baudrate"
@@ -145,7 +158,11 @@
 				@update:model-value="(v) => $emit('update:baudrate', parseInt(v))"
 			/>
 		</FormRow>
-		<FormRow :id="formId('modbusComset')" :label="$t('config.modbus.comset')">
+		<FormRow
+			:id="formId('modbusComset')"
+			:label="$t('config.modbus.comset')"
+			:help="helpOverrides['comset']"
+		>
 			<PropertyField
 				:id="formId('modbusComset')"
 				property="comset"
@@ -196,6 +213,8 @@ export default defineComponent({
 		defaultComset: String,
 		defaultBaudrate: Number,
 		hideModbusId: Boolean,
+		// per-field help texts a template overrides, keyed by modbus param name
+		helpOverrides: { type: Object as PropType<Record<string, string>>, default: () => ({}) },
 	},
 	emits: [
 		"update:modbus",

--- a/assets/js/components/Config/DeviceModal/ModbusAdvanced.vue
+++ b/assets/js/components/Config/DeviceModal/ModbusAdvanced.vue
@@ -2,7 +2,7 @@
 	<FormRow
 		:id="formId('modbusTimeout')"
 		:label="$t('config.modbus.timeout')"
-		:help="$t('config.modbus.timeoutHint')"
+		:help="helpOverrides['timeout'] || $t('config.modbus.timeoutHint')"
 	>
 		<PropertyField
 			:id="formId('modbusTimeout')"
@@ -16,7 +16,7 @@
 	<FormRow
 		:id="formId('modbusDelay')"
 		:label="$t('config.modbus.delay')"
-		:help="$t('config.modbus.delayHint')"
+		:help="helpOverrides['delay'] || $t('config.modbus.delayHint')"
 	>
 		<PropertyField
 			:id="formId('modbusDelay')"
@@ -31,6 +31,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import type { PropType } from "vue";
 import FormRow from "../FormRow.vue";
 import PropertyField from "../PropertyField.vue";
 
@@ -41,6 +42,8 @@ export default defineComponent({
 		componentId: { type: String, required: true },
 		delay: [Number, String],
 		timeout: [Number, String],
+		// per-field help texts a template overrides, keyed by modbus param name
+		helpOverrides: { type: Object as PropType<Record<string, string>>, default: () => ({}) },
 	},
 	emits: ["update:delay", "update:timeout"],
 	methods: {

--- a/assets/js/components/Config/DeviceModal/index.test.ts
+++ b/assets/js/components/Config/DeviceModal/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createServiceEndpoints, type TemplateParam } from "./index";
+import { createServiceEndpoints, modbusHelpOverrides, type TemplateParam } from "./index";
 
 const buildParam = (name: string, service?: string): TemplateParam => ({
   Name: name,
@@ -7,6 +7,27 @@ const buildParam = (name: string, service?: string): TemplateParam => ({
   Advanced: false,
   Deprecated: false,
   Service: service,
+});
+
+describe("modbusHelpOverrides", () => {
+  const withHelp = (name: string, help?: string): TemplateParam => ({
+    ...buildParam(name),
+    Help: help,
+  });
+
+  it("collects help for modbus fields only", () => {
+    expect(
+      modbusHelpOverrides([
+        withHelp("id", "unit id of the meter"),
+        withHelp("timeout", "be patient"),
+        withHelp("storageunit", "not a modbus field"),
+      ])
+    ).toEqual({ id: "unit id of the meter", timeout: "be patient" });
+  });
+
+  it("skips modbus fields without help", () => {
+    expect(modbusHelpOverrides([withHelp("id"), withHelp("host", "")])).toEqual({});
+  });
 });
 
 describe("createServiceEndpoints", () => {

--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -32,8 +32,29 @@ export type Template = {
 
 export type TemplateParamUsage = "vehicle" | "battery" | "grid" | "pv" | "charger" | "aux" | "ext";
 
+// modbus params the Modbus/ModbusAdvanced components render themselves. A
+// template may declare one to override its help text.
+export const MODBUS_FIELDS = [
+  "id",
+  "host",
+  "port",
+  "device",
+  "baudrate",
+  "comset",
+  "delay",
+  "timeout",
+];
+
+// modbusHelpOverrides collects the help texts a template provides for fields the
+// modbus components render themselves, keyed by param name
+export const modbusHelpOverrides = (params: TemplateParam[]): Record<string, string> =>
+  Object.fromEntries(
+    params.filter((p) => p.Help && MODBUS_FIELDS.includes(p.Name)).map((p) => [p.Name, p.Help!])
+  );
+
 export type TemplateParam = {
   Name: string;
+  Help?: string;
   Required: boolean;
   Advanced: boolean;
   Deprecated: boolean;

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -63,6 +63,16 @@ func (t *Template) UpdateModbusParamsWithDefaults() error {
 	}
 
 	t.Params[idx] = modbusParam
+
+	// a template may declare a modbus param itself to override its help text.
+	// Inherit the definition's default so it only has to state the override -
+	// the displayed label keeps coming from the UI's translations.
+	for _, def := range ConfigDefaults.Modbus.Definitions {
+		if i, own := t.ParamByName(def.Name); i >= 0 && own.Default == "" {
+			t.Params[i].Default = def.Default
+		}
+	}
+
 	return nil
 }
 

--- a/util/templates/template_modbus.go
+++ b/util/templates/template_modbus.go
@@ -25,12 +25,9 @@ func (t *Template) ModbusParams(modbusType string, values map[string]any) {
 		return
 	}
 
-	// check if the modbus params are already added
-	if index, _ := t.ParamByName("id"); index >= 0 {
-		return
-	}
-
-	// skip params the template already defines (e.g. deprecated delay, timeout)
+	// skip params the template already defines (deprecated delay and timeout, or
+	// one declared to override its help text). This also makes repeated calls
+	// idempotent, since everything appended below is found again.
 	modbusParams := slices.DeleteFunc(slices.Clone(ConfigDefaults.Modbus.Types[values[ParamModbus].(string)].Params), func(p Param) bool {
 		i, _ := t.ParamByName(p.Name)
 		return i >= 0

--- a/util/templates/template_modbus_test.go
+++ b/util/templates/template_modbus_test.go
@@ -51,6 +51,39 @@ func TestModbusTemplateUserIDOverridesTemplate(t *testing.T) {
 	}
 }
 
+// TestModbusParamHelpOverride verifies that a template may declare a modbus
+// param to override its help text: it keeps that help, still inherits the
+// definition's default, and does not suppress the remaining modbus params.
+func TestModbusParamHelpOverride(t *testing.T) {
+	ConfigDefaults.Load()
+
+	tmpl := &Template{
+		Params: []Param{
+			{Name: ParamModbus, Choice: []string{ModbusChoiceTCPIP}},
+			{Name: ModbusParamId, Help: TextLanguage{EN: "unit id of the meter"}},
+		},
+	}
+	require.NoError(t, tmpl.UpdateModbusParamsWithDefaults())
+
+	_, id := tmpl.ParamByName(ModbusParamId)
+	assert.Equal(t, "unit id of the meter", id.Help.EN, "template help must survive")
+	assert.Equal(t, "1", id.Default, "default must be inherited from the modbus definition")
+
+	// the declared id must not stop host/port from being added
+	values := map[string]any{ParamModbus: ModbusChoiceTCPIP}
+	tmpl.ModbusParams("", values)
+
+	for _, name := range []string{ModbusParamId, "host", ModbusParamPort} {
+		i, _ := tmpl.ParamByName(name)
+		assert.GreaterOrEqual(t, i, 0, "missing modbus param %s", name)
+	}
+
+	// adding is idempotent
+	before := len(tmpl.Params)
+	tmpl.ModbusParams("", values)
+	assert.Equal(t, before, len(tmpl.Params), "repeated call must not duplicate params")
+}
+
 // TestWallbeTemplateCoveredByPhoenix verifies the BC migration: a config that
 // still references the removed `wallbe` templates is transparently routed to
 // the phoenix-ev-eth template via the `covers:` directive, while still


### PR DESCRIPTION
## Problem

`Modbus.vue` and `ModbusAdvanced.vue` render the modbus fields (id, host, port, device, baudrate, comset, delay, timeout) themselves, taking labels and hints from the translations. A template has no way to attach device-specific guidance to one of them — e.g. "the meter's unit id is listed on the GX device under Settings / Integrations / Modbus TCP server".

Declaring the param in the template did not work either:

- `ModbusParams` used a declared `id` as its sentinel for "modbus params already added" and returned early, so `host` and `port` were never added
- the param was then also rendered a second time by the generic property loop, next to the modbus block's own field

That is why no shipped template combines `- name: modbus` with a modbus param declaration today; the only 12 that declare one (`delay`/`timeout`) are `deprecated: true` markers, which never hit the `id` sentinel.

## Change

A template may declare a modbus param to override its help text:

```yaml
params:
  - name: modbus
    choice: ["tcpip"]
  - name: id
    help:
      en: Found under Settings / Integrations / Modbus TCP server
```

- **`ModbusParams`** drops the `id` sentinel. The existing `DeleteFunc` already skips params the template defines, which keeps repeated calls idempotent on its own.
- **`UpdateModbusParamsWithDefaults`** inherits the definition's default into a template-declared param, so it only has to state the override. Without this the render emitted an empty `id:`.
- **`Modbus.vue` / `ModbusAdvanced.vue`** take a `helpOverrides` map and fall back to the existing `$t('config.modbus.*')` hints.
- **`DeviceModalBase`** builds that map and skips `MODBUS_FIELDS` in the generic loop when the template has a modbus param.

Only the help is overridable. Labels stay with the translations, so this cannot regress a language by pinning a field to a template's de/en text.

## Verification

- `TestModbusParamHelpOverride` locks all three parts (help survives, default inherited, host/port still added, idempotent). Verified failing on `master` with exactly those three assertions.
- `modbusHelpOverrides` unit-tested in `index.test.ts`; 173 frontend tests pass.
- `go test ./util/templates/... ./meter/ ./charger/`, `vue-tsc`, and eslint clean.

No template uses this yet — evcc-io/evcc#32411 is the intended first consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)