### PR TITLE
Loadpoint: allow separate current limits for 1p charging

### DIFF
--- a/assets/js/components/Config/LoadpointModal.vue
+++ b/assets/js/components/Config/LoadpointModal.vue
@@ -397,6 +397,44 @@
 							</FormRow>
 						</div>
 
+						<div v-if="showCurrent1p" class="row ms-3 mb-5">
+							<FormRow
+								id="loadpointMinCurrent1p"
+								:label="$t('config.loadpoint.minCurrent1pLabel')"
+								class="col-sm-6 mb-sm-0"
+								:help="$t('config.loadpoint.current1pHelp')"
+							>
+								<PropertyField
+									id="loadpointMinCurrent1p"
+									v-model="values.minCurrent1p"
+									type="Float"
+									unit="A"
+									size="w-25 w-min-200"
+									class="me-2"
+								/>
+							</FormRow>
+
+							<FormRow
+								id="loadpointMaxCurrent1p"
+								:label="$t('config.loadpoint.maxCurrent1pLabel')"
+								class="col-sm-6 mb-sm-0"
+								:help="
+									invalidCurrent1p
+										? $t('config.loadpoint.maxCurrent1pHelp')
+										: undefined
+								"
+							>
+								<PropertyField
+									id="loadpointMaxCurrent1p"
+									v-model="values.maxCurrent1p"
+									type="Float"
+									unit="A"
+									size="w-25 w-min-200"
+									class="me-2"
+								/>
+							</FormRow>
+						</div>
+
 						<template v-if="!chargerIsSinglePhase">
 							<FormRow
 								v-if="chargerSupports1p3p"
@@ -821,6 +859,13 @@ export default {
 			// switch devices have no current control, so minpv does not apply
 			const modes = this.chargerIsSwitchDevice ? [OFF, PV, NOW] : [OFF, PV, MINPV, NOW];
 			return modes.map((key) => ({ key, name: this.$t(`main.mode.${key}`) }));
+		},
+		showCurrent1p() {
+			return this.chargerSupports1p3p && !this.chargerIsSwitchDevice;
+		},
+		invalidCurrent1p() {
+			const { minCurrent1p, maxCurrent1p } = this.values;
+			return !!minCurrent1p && !!maxCurrent1p && maxCurrent1p < minCurrent1p;
 		},
 		showCircuit() {
 			return this.circuits.length > 0 || !!this.values.circuit;

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -487,6 +487,8 @@ export interface ConfigLoadpoint {
   phasesConfigured: number;
   minCurrent: number;
   maxCurrent: number;
+  minCurrent1p?: number;
+  maxCurrent1p?: number;
   smartCostLimit: number | null;
   planEnergy?: number;
   planTime?: string;

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -13,6 +13,8 @@ const (
 	Priority          = "priority"         // priority
 	MinCurrent        = "minCurrent"       // min current
 	MaxCurrent        = "maxCurrent"       // max current
+	MinCurrent1p      = "minCurrent1p"     // min current, 1p override (0 = use minCurrent)
+	MaxCurrent1p      = "maxCurrent1p"     // max current, 1p override (0 = use maxCurrent)
 	MinSoc            = "minSoc"           // min soc (heating: min temperature)
 	MinSocNotReached  = "minSocNotReached" // min soc not reached
 	LimitSoc          = "limitSoc"         // limit soc

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -117,6 +117,8 @@ type Loadpoint struct {
 	priority                 int      // Priority
 	minCurrent               float64  // PV mode: start current	Min+PV mode: min current
 	maxCurrent               float64  // Max allowed current. Physically ensured by the charger
+	minCurrent1p             float64  // 1p override for minCurrent, 0 = use minCurrent
+	maxCurrent1p             float64  // 1p override for maxCurrent, 0 = use maxCurrent
 	phasesConfigured         int      // Charger configured phase mode 0/1/3
 	limitSoc                 int      // Session limit for soc
 	limitEnergy              float64  // Session limit for energy
@@ -360,6 +362,12 @@ func (lp *Loadpoint) restoreSettings() {
 	}
 	if v, err := lp.settings.Float(keys.MaxCurrent); err == nil && v > 0 {
 		lp.setMaxCurrent(v)
+	}
+	if v, err := lp.settings.Float(keys.MinCurrent1p); err == nil && v > 0 {
+		lp.setMinCurrent1p(v)
+	}
+	if v, err := lp.settings.Float(keys.MaxCurrent1p); err == nil && v > 0 {
+		lp.setMaxCurrent1p(v)
 	}
 	if v, err := lp.settings.Int(keys.LimitSoc); err == nil && v > 0 {
 		lp.setLimitSoc(int(v))
@@ -702,6 +710,9 @@ func (lp *Loadpoint) Prepare(site site.API, uiChan chan<- util.Param, pushChan c
 	lp.publish(keys.Priority, lp.GetPriority())
 	lp.publish(keys.MinCurrent, lp.GetMinCurrent())
 	lp.publish(keys.MaxCurrent, lp.GetMaxCurrent())
+	minCurrent1p, maxCurrent1p := lp.GetCurrents1p()
+	lp.publish(keys.MinCurrent1p, minCurrent1p)
+	lp.publish(keys.MaxCurrent1p, maxCurrent1p)
 
 	lp.publish(keys.EnableThreshold, lp.Enable.Threshold)
 	lp.publish(keys.DisableThreshold, lp.Disable.Threshold)
@@ -1399,7 +1410,7 @@ func (lp *Loadpoint) fastCharging() error {
 		phases := 3
 
 		// load management limit active
-		if !lp.circuitAllowsPhases(3, lp.effectiveMinCurrent()) {
+		if !lp.circuitAllowsPhases(3, lp.effectiveMinCurrentFor(3)) {
 			phases = 1
 		}
 
@@ -1427,7 +1438,7 @@ func (lp *Loadpoint) minCharging() error {
 }
 
 // pvScalePhases switches phases if necessary and returns number of phases switched to
-func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) int {
+func (lp *Loadpoint) pvScalePhases(sitePower float64) int {
 	phases := lp.GetPhases()
 
 	// observed phase state inconsistency
@@ -1446,6 +1457,8 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 	activePhases := lp.ActivePhases()
 	availablePower := lp.chargePower - sitePower
 	scalable := activePhases > 1 && lp.phasesConfigured < 3
+
+	minCurrent := lp.effectiveMinCurrentFor(activePhases)
 
 	if scalable {
 		insufficient := (sitePower > 0 || !lp.enabled) && powerToCurrent(availablePower, activePhases) < minCurrent
@@ -1486,21 +1499,25 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		waiting = true
 	}
 
+	// scaling up is only justified once the 1p limits are exhausted
+	max1pCurrent := lp.effectiveMaxCurrentFor(1)
+
 	// load management may cap the 1p current far below the theoretical maximum
 	if lp.circuit != nil {
-		maxCurrent = lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), maxCurrent)
+		max1pCurrent = lp.circuit.ValidateCurrent(lp.actualMaxChargeCurrent(), max1pCurrent)
 	}
 
 	maxPhases := lp.MaxActivePhases()
 	target1pCurrent := powerToCurrent(availablePower, 1)
+	minCurrentMaxPhases := lp.effectiveMinCurrentFor(maxPhases)
 
 	// scaling up is pointless unless load management allows min current and power on maxPhases
-	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > maxCurrent &&
-		maxCurrent >= minCurrent && lp.circuitAllowsPhases(maxPhases, minCurrent)
+	scalable = maxPhases > 1 && phases < maxPhases && target1pCurrent > max1pCurrent &&
+		max1pCurrent >= lp.effectiveMinCurrentFor(1) && lp.circuitAllowsPhases(maxPhases, minCurrentMaxPhases)
 
 	// scale up phases
-	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrent && scalable {
-		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, float64(maxPhases)*Voltage*minCurrent, maxPhases)
+	if targetCurrent := powerToCurrent(availablePower, maxPhases); targetCurrent >= minCurrentMaxPhases && scalable {
+		lp.log.DEBUG.Printf("available power %.0fW > %.0fW min %dp threshold", availablePower, float64(maxPhases)*Voltage*minCurrentMaxPhases, maxPhases)
 
 		if !lp.charging() { // scale immediately if not charging
 			lp.phaseTimer = elapsed
@@ -1607,7 +1624,13 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryBoostPo
 	// switch phases up/down
 	var scaledTo int
 	if lp.hasPhaseSwitching() && lp.phaseSwitchCompleted() {
-		scaledTo = lp.pvScalePhases(sitePower, minCurrent, maxCurrent)
+		scaledTo = lp.pvScalePhases(sitePower)
+
+		// limits are phase-dependent
+		if scaledTo > 0 {
+			minCurrent = lp.effectiveMinCurrentFor(scaledTo)
+			maxCurrent = lp.effectiveMaxCurrentFor(scaledTo)
+		}
 	}
 
 	// calculate target charge current from delta power and actual current

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -65,6 +65,10 @@ type API interface {
 	GetMaxCurrent() float64
 	// SetMaxCurrent sets the max charging current
 	SetMaxCurrent(float64) error
+	// GetCurrents1p returns the 1p min/max current overrides (0 = use min/max charging current)
+	GetCurrents1p() (float64, float64)
+	// SetCurrents1p sets the 1p min/max current overrides (0 = use min/max charging current)
+	SetCurrents1p(float64, float64) error
 
 	// GetMode returns the current charge mode
 	GetMode() api.ChargeMode

--- a/core/loadpoint/config.go
+++ b/core/loadpoint/config.go
@@ -23,6 +23,8 @@ type DynamicConfig struct {
 	PhasesConfigured         int       `json:"phasesConfigured"`
 	MinCurrent               float64   `json:"minCurrent"`
 	MaxCurrent               float64   `json:"maxCurrent"`
+	MinCurrent1p             float64   `json:"minCurrent1p"`
+	MaxCurrent1p             float64   `json:"maxCurrent1p"`
 	SmartCostLimit           *float64  `json:"smartCostLimit"`
 	SmartFeedInPriorityLimit *float64  `json:"smartFeedInPriorityLimit"`
 	PlanEnergy               float64   `json:"planEnergy"`
@@ -109,6 +111,10 @@ func (payload DynamicConfig) Apply(lp API) error {
 		case payload.MaxCurrent != 0:
 			err = lp.SetMaxCurrent(payload.MaxCurrent)
 		}
+	}
+
+	if err == nil {
+		err = lp.SetCurrents1p(payload.MinCurrent1p, payload.MaxCurrent1p)
 	}
 
 	return err

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -263,6 +263,21 @@ func (mr *MockAPIMockRecorder) GetCircuitRef() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCircuitRef", reflect.TypeOf((*MockAPI)(nil).GetCircuitRef))
 }
 
+// GetCurrents1p mocks base method.
+func (m *MockAPI) GetCurrents1p() (float64, float64) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrents1p")
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(float64)
+	return ret0, ret1
+}
+
+// GetCurrents1p indicates an expected call of GetCurrents1p.
+func (mr *MockAPIMockRecorder) GetCurrents1p() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrents1p", reflect.TypeOf((*MockAPI)(nil).GetCurrents1p))
+}
+
 // GetDefaultMode mocks base method.
 func (m *MockAPI) GetDefaultMode() api.ChargeMode {
 	m.ctrl.T.Helper()
@@ -829,6 +844,20 @@ func (m *MockAPI) SetCircuitRef(arg0 string) {
 func (mr *MockAPIMockRecorder) SetCircuitRef(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCircuitRef", reflect.TypeOf((*MockAPI)(nil).SetCircuitRef), arg0)
+}
+
+// SetCurrents1p mocks base method.
+func (m *MockAPI) SetCurrents1p(arg0, arg1 float64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetCurrents1p", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetCurrents1p indicates an expected call of SetCurrents1p.
+func (mr *MockAPIMockRecorder) SetCurrents1p(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrents1p", reflect.TypeOf((*MockAPI)(nil).SetCurrents1p), arg0, arg1)
 }
 
 // SetDefaultMode mocks base method.

--- a/core/loadpoint_api.go
+++ b/core/loadpoint_api.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"time"
@@ -750,6 +751,20 @@ func (lp *Loadpoint) getMinCurrent() float64 {
 	return lp.minCurrent
 }
 
+// getMinCurrentFor returns the min loadpoint current for the given phases
+func (lp *Loadpoint) getMinCurrentFor(phases int) float64 {
+	if lp.uses1pCurrent(phases) && lp.minCurrent1p > 0 {
+		return lp.minCurrent1p
+	}
+	return lp.minCurrent
+}
+
+// uses1pCurrent returns true if the 1p current overrides apply for the given phases
+func (lp *Loadpoint) uses1pCurrent(phases int) bool {
+	// without phase switching the regular limits are the 1p limits
+	return phases == 1 && lp.hasPhaseSwitching()
+}
+
 // setMinCurrent sets the min loadpoint current (no mutex)
 func (lp *Loadpoint) setMinCurrent(current float64) {
 	lp.minCurrent = current
@@ -786,6 +801,14 @@ func (lp *Loadpoint) getMaxCurrent() float64 {
 	return lp.maxCurrent
 }
 
+// getMaxCurrentFor returns the max loadpoint current for the given phases
+func (lp *Loadpoint) getMaxCurrentFor(phases int) float64 {
+	if lp.uses1pCurrent(phases) && lp.maxCurrent1p > 0 {
+		return lp.maxCurrent1p
+	}
+	return lp.maxCurrent
+}
+
 // setMaxCurrent sets the max loadpoint current
 func (lp *Loadpoint) setMaxCurrent(current float64) {
 	lp.maxCurrent = current
@@ -808,6 +831,53 @@ func (lp *Loadpoint) SetMaxCurrent(current float64) error {
 	}
 
 	return nil
+}
+
+// GetCurrents1p returns the 1p min/max current overrides (0 = use minCurrent/maxCurrent)
+func (lp *Loadpoint) GetCurrents1p() (float64, float64) {
+	lp.RLock()
+	defer lp.RUnlock()
+	return lp.minCurrent1p, lp.maxCurrent1p
+}
+
+// SetCurrents1p sets the 1p min/max current overrides (0 = use minCurrent/maxCurrent)
+func (lp *Loadpoint) SetCurrents1p(minCurrent, maxCurrent float64) error {
+	lp.Lock()
+	defer lp.Unlock()
+
+	if minCurrent < 0 || maxCurrent < 0 {
+		return errors.New("current must not be negative")
+	}
+
+	// unset values fall back to the regular limits
+	if cmp.Or(minCurrent, lp.minCurrent) > cmp.Or(maxCurrent, lp.maxCurrent) {
+		return errors.New("1p min current must be smaller or equal than 1p max current")
+	}
+
+	if minCurrent != lp.minCurrent1p {
+		lp.log.DEBUG.Println("set 1p min current:", minCurrent)
+		lp.setMinCurrent1p(minCurrent)
+	}
+	if maxCurrent != lp.maxCurrent1p {
+		lp.log.DEBUG.Println("set 1p max current:", maxCurrent)
+		lp.setMaxCurrent1p(maxCurrent)
+	}
+
+	return nil
+}
+
+// setMinCurrent1p sets the 1p min current override (no mutex)
+func (lp *Loadpoint) setMinCurrent1p(current float64) {
+	lp.minCurrent1p = current
+	lp.publish(keys.MinCurrent1p, lp.minCurrent1p)
+	lp.settings.SetFloat(keys.MinCurrent1p, lp.minCurrent1p)
+}
+
+// setMaxCurrent1p sets the 1p max current override (no mutex)
+func (lp *Loadpoint) setMaxCurrent1p(current float64) {
+	lp.maxCurrent1p = current
+	lp.publish(keys.MaxCurrent1p, lp.maxCurrent1p)
+	lp.settings.SetFloat(keys.MaxCurrent1p, lp.maxCurrent1p)
 }
 
 // IsFastChargingActive indicates if fast charging with maximum power is active

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -146,9 +146,14 @@ func (lp *Loadpoint) SocBasedPlanning() bool {
 	return lp.socBasedPlanning()
 }
 
-// effectiveMinCurrent returns the effective min current
+// effectiveMinCurrent returns the effective min current for the active phases
 func (lp *Loadpoint) effectiveMinCurrent() float64 {
-	lpMin := lp.getMinCurrent()
+	return lp.effectiveMinCurrentFor(lp.activePhases())
+}
+
+// effectiveMinCurrentFor returns the effective min current for the given phases
+func (lp *Loadpoint) effectiveMinCurrentFor(phases int) float64 {
+	lpMin := lp.getMinCurrentFor(phases)
 	var vehicleMin, chargerMin float64
 
 	if v := lp.GetVehicle(); v != nil {
@@ -186,9 +191,14 @@ func (lp *Loadpoint) effectiveMinCurrent() float64 {
 	}
 }
 
-// effectiveMaxCurrent returns the effective max current
+// effectiveMaxCurrent returns the effective max current for the active phases
 func (lp *Loadpoint) effectiveMaxCurrent() float64 {
-	maxCurrent := lp.getMaxCurrent()
+	return lp.effectiveMaxCurrentFor(lp.activePhases())
+}
+
+// effectiveMaxCurrentFor returns the effective max current for the given phases
+func (lp *Loadpoint) effectiveMaxCurrentFor(phases int) float64 {
+	maxCurrent := lp.getMaxCurrentFor(phases)
 
 	if v := lp.GetVehicle(); v != nil {
 		if res, ok := v.OnIdentified().GetMaxCurrent(); ok && res > 0 {
@@ -269,7 +279,8 @@ func (lp *Loadpoint) EffectiveStepPower() float64 {
 func (lp *Loadpoint) EffectiveMinPower() float64 {
 	lp.RLock()
 	defer lp.RUnlock()
-	return Voltage * lp.effectiveMinCurrent() * float64(lp.minActivePhases())
+	phases := lp.minActivePhases()
+	return Voltage * lp.effectiveMinCurrentFor(phases) * float64(phases)
 }
 
 // EffectiveMaxPower returns the effective max power taking vehicle capabilities,
@@ -287,7 +298,8 @@ func (lp *Loadpoint) EffectiveMaxPower() float64 {
 
 // effectiveMaxPower returns the effective max power taking vehicle capabilities and phase scaling into account
 func (lp *Loadpoint) effectiveMaxPower() float64 {
-	res := Voltage * lp.effectiveMaxCurrent() * float64(lp.maxActivePhases())
+	phases := lp.maxActivePhases()
+	res := Voltage * lp.effectiveMaxCurrentFor(phases) * float64(phases)
 	if lp.vehicle != nil {
 		if maxPower, ok := lp.vehicle.OnIdentified().GetMaxPower(); ok {
 			return min(maxPower, res)

--- a/core/loadpoint_effective_test.go
+++ b/core/loadpoint_effective_test.go
@@ -99,6 +99,7 @@ func TestEffectiveMinMaxCurrent(t *testing.T) {
 				MaxCurrent: tc.vehicleMax,
 			}
 			vehicle.EXPECT().OnIdentified().Return(ac).AnyTimes()
+			vehicle.EXPECT().Phases().Return(0).AnyTimes()
 
 			lp.vehicle = vehicle
 		}
@@ -106,6 +107,29 @@ func TestEffectiveMinMaxCurrent(t *testing.T) {
 		assert.Equal(t, tc.effectiveMin, lp.effectiveMinCurrent(), "min")
 		assert.Equal(t, tc.effectiveMax, lp.effectiveMaxCurrent(), "max")
 	}
+}
+
+func TestEffectiveCurrent1p(t *testing.T) {
+	Voltage = 230
+	ctrl := gomock.NewController(t)
+
+	lp := NewLoadpoint(util.NewLogger("foo"), nil)
+	lp.charger = struct {
+		*api.MockCharger
+		*api.MockPhaseSwitcher
+	}{api.NewMockCharger(ctrl), api.NewMockPhaseSwitcher(ctrl)}
+
+	lp.minCurrent1p = 10
+	lp.maxCurrent1p = 20
+
+	assert.Equal(t, 10.0, lp.effectiveMinCurrentFor(1), "1p min")
+	assert.Equal(t, 20.0, lp.effectiveMaxCurrentFor(1), "1p max")
+	assert.Equal(t, 6.0, lp.effectiveMinCurrentFor(3), "3p min")
+	assert.Equal(t, 16.0, lp.effectiveMaxCurrentFor(3), "3p max")
+
+	// min power uses the 1p limit, max power the 3p limit
+	assert.Equal(t, 230*10.0, lp.EffectiveMinPower(), "min power")
+	assert.Equal(t, 3*230*16.0, lp.EffectiveMaxPower(), "max power")
 }
 
 func TestEffectivePowerLimiter(t *testing.T) {

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -178,7 +178,11 @@ func testScale(t *testing.T, lp *Loadpoint, sitePower float64, direction string,
 		// scale-up should only execute when the 1p max current is exceeded
 		// we're testing this here and remove the upscale expectation for the following test below 1p max current
 		if maxAmp := -sitePower / Voltage; maxAmp < maxA {
-			if scaled := lp.pvScalePhases(sitePower, minA, maxAmp-0.0001); scaled != 3 {
+			lp.maxCurrent = maxAmp - 0.0001
+			scaled := lp.pvScalePhases(sitePower)
+			lp.maxCurrent = maxA
+
+			if scaled != 3 {
 				t.Errorf("%v act=%d max=%d missing scale %s at reduced max current %.1fA", tc, act, max, direction, maxAmp)
 			}
 
@@ -187,7 +191,7 @@ func testScale(t *testing.T, lp *Loadpoint, sitePower float64, direction string,
 		}
 	}
 
-	scaled := lp.pvScalePhases(sitePower, minA, maxA)
+	scaled := lp.pvScalePhases(sitePower)
 
 	if strings.Contains(testExpectation, testDirection) {
 		if scaled == 0 {
@@ -425,7 +429,7 @@ func TestPvScalePhasesTimer(t *testing.T) {
 			charger.MockPhaseSwitcher.EXPECT().Phases1p3p(tc.toPhases).Return(nil)
 		}
 
-		res := lp.pvScalePhases(tc.sitePower, minA, maxA)
+		res := lp.pvScalePhases(tc.sitePower)
 
 		require.Equal(t, tc.res, res, tc.desc)
 		require.Equal(t, tc.toPhases, lp.phases, tc.desc)
@@ -698,6 +702,60 @@ func TestUpdatePhaseSwitchNotAvailable(t *testing.T) {
 	require.Equal(t, 3, lp.GetPhases())
 }
 
+func TestPvScalePhases1pMaxCurrent(t *testing.T) {
+	Voltage = 230
+
+	for _, tc := range []struct {
+		desc           string
+		maxCurrent1p   float64
+		sitePower      float64
+		expectedPhases int
+	}{
+		// 4600W available equals 20A on 1p, 5060W equals 22A
+		{"1p limit not exceeded", 20, -4600, 0},
+		{"1p limit exceeded", 20, -5060, 3},
+		{"no 1p limit", 0, -5060, 0},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			plainCharger := api.NewMockCharger(ctrl)
+			plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
+			plainCharger.EXPECT().Enable(gomock.Any()).Return(nil).AnyTimes()
+			plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
+
+			phaseCharger := api.NewMockPhaseSwitcher(ctrl)
+			phaseCharger.EXPECT().Phases1p3p(gomock.Any()).Return(nil).AnyTimes()
+
+			lp := &Loadpoint{
+				log:            util.NewLogger("foo"),
+				bus:            evbus.New(),
+				clock:          clock.NewMock(),
+				chargeMeter:    &Null{},
+				chargeRater:    &Null{},
+				chargeTimer:    &Null{},
+				progress:       NewProgress(0, 10),
+				wakeUpTimer:    NewTimer(),
+				mode:           api.ModeNow,
+				minCurrent:     6,
+				maxCurrent:     32,
+				maxCurrent1p:   tc.maxCurrent1p,
+				phases:         1,
+				measuredPhases: 1,
+				status:         api.StatusC,
+				charger: struct {
+					*api.MockCharger
+					*api.MockPhaseSwitcher
+				}{plainCharger, phaseCharger},
+			}
+
+			require.Equal(t, tc.expectedPhases, lp.pvScalePhases(tc.sitePower))
+
+			ctrl.Finish()
+		})
+	}
+}
+
 func TestPvScalePhasesCircuitLimits(t *testing.T) {
 	Voltage = 230
 
@@ -773,7 +831,7 @@ func TestPvScalePhasesCircuitLimits(t *testing.T) {
 				}{plainCharger, phaseCharger},
 			}
 
-			require.Equal(t, tc.expectedPhases, lp.pvScalePhases(tc.sitePower, lp.minCurrent, lp.maxCurrent))
+			require.Equal(t, tc.expectedPhases, lp.pvScalePhases(tc.sitePower))
 
 			ctrl.Finish()
 		})

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -441,6 +441,7 @@
         "charging": "Wallbox gespeichert. Ladepunkt wird erstellt …",
         "heating": "Heizgerät gespeichert. Heizung wird erstellt …"
       },
+      "current1pHelp": "Optionale Grenzwerte für einphasiges Laden. Leer lassen, um den regulären Strombereich zu verwenden.",
       "defaultModeHelp": {
         "charging": "Lademodus beim Anschließen des Fahrzeugs.",
         "heating": "Wird beim Systemstart gesetzt."
@@ -454,10 +455,13 @@
       "energyMeterHelp": "Zusätzlicher Zähler, wenn die Wallbox keinen integrierten hat.",
       "energyMeterLabel": "Energiezähler",
       "estimateLabel": "Ladestand zwischen API-Updates interpolieren",
+      "maxCurrent1pHelp": "Muss größer als der einphasige Mindeststrom sein.",
+      "maxCurrent1pLabel": "Maximaler Strom (1-phasig)",
       "maxCurrentHelp": "Muss größer als der Mindeststrom sein.",
       "maxCurrentLabel": "Maximaler Strom",
       "maxTempHelp": "Muss größer als die Mindesttemperatur sein.",
       "maxTempLabel": "Maximaltemperatur",
+      "minCurrent1pLabel": "Minimaler Strom (1-phasig)",
       "minCurrentHelp": "Gehe nur unter 6 A, wenn du weißt, was du tust.",
       "minCurrentLabel": "Minimaler Strom",
       "minTempLabel": "Mindesttemperatur",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -441,6 +441,7 @@
         "charging": "Charger saved. Creating charging point …",
         "heating": "Heating device saved. Creating heater …"
       },
+      "current1pHelp": "Optional limits while charging on one phase. Leave empty to use the regular current range.",
       "defaultModeHelp": {
         "charging": "Charging mode when connecting the vehicle.",
         "heating": "Is set when on system start."
@@ -454,10 +455,13 @@
       "energyMeterHelp": "Additional meter if the charger doesn't have an integrated one.",
       "energyMeterLabel": "Energy meter",
       "estimateLabel": "Interpolate charge level between API updates",
+      "maxCurrent1pHelp": "Must be greater than 1-phase minimum current.",
+      "maxCurrent1pLabel": "Maximum current (1-phase)",
       "maxCurrentHelp": "Must be greater than minimum current.",
       "maxCurrentLabel": "Maximum current",
       "maxTempHelp": "Must be greater than minimum temperature.",
       "maxTempLabel": "Maximum temperature",
+      "minCurrent1pLabel": "Minimum current (1-phase)",
       "minCurrentHelp": "Only go below 6 A if you know what you're doing.",
       "minCurrentLabel": "Minimum current",
       "minTempLabel": "Minimum temperature",

--- a/server/http_config_loadpoint_handler.go
+++ b/server/http_config_loadpoint_handler.go
@@ -28,6 +28,7 @@ func getLoadpointStaticConfig(lp loadpoint.API) loadpoint.StaticConfig {
 
 func getLoadpointDynamicConfig(lp loadpoint.API) loadpoint.DynamicConfig {
 	planTime, planEnergy := lp.GetPlanEnergy()
+	minCurrent1p, maxCurrent1p := lp.GetCurrents1p()
 	return loadpoint.DynamicConfig{
 		Title:                    lp.GetTitle(),
 		DefaultMode:              string(lp.GetDefaultMode()),
@@ -35,6 +36,8 @@ func getLoadpointDynamicConfig(lp loadpoint.API) loadpoint.DynamicConfig {
 		PhasesConfigured:         lp.GetPhasesConfigured(),
 		MinCurrent:               lp.GetMinCurrent(),
 		MaxCurrent:               lp.GetMaxCurrent(),
+		MinCurrent1p:             minCurrent1p,
+		MaxCurrent1p:             maxCurrent1p,
 		SmartCostLimit:           lp.GetSmartCostLimit(),
 		SmartFeedInPriorityLimit: lp.GetSmartFeedInPriorityLimit(),
 		Thresholds:               lp.GetThresholds(),


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/14661
relates to https://github.com/evcc-io/evcc/issues/13355

Loadpoints with phase switching get optional 1p current limits. The regular min/max current stay the 3p limits, the new values only apply while charging on one phase. This covers the recurring cases from #14661: unbalanced load rules (20A 1p vs 16A 3p), vehicles that accept more current on 1p than on 3p, and the 1p/3p gap that causes constant switching in PV mode.

- effective min/max current and power are resolved per phase count, so PV phase scaling, load management and the charge planner all use the limits that actually apply. `effectiveMaxPower` now reports the 3p maximum instead of extrapolating the 1p current to three phases
- scale-up decisions compare available power against the 1p maximum, scale-down and 3p checks against the 3p minimum
- config ui only, shown for 1p3p chargers, empty means "use the regular range"
- api: `GetCurrents1p`/`SetCurrents1p` plus `minCurrent1p`/`maxCurrent1p` in the loadpoint config payload. Existing single-value endpoints and published keys are unchanged; `effectiveMinCurrent`/`effectiveMaxCurrent` stay scalars and follow the active phases
- overrides are ignored without phase switching, where the regular limits already are the 1p limits

**TODO**
- [ ] main ui settings still offer the full current range, that is the remaining part of #13355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
