### PR TITLE
Remote access: show tunnel connect errors, self-recover after offline boot

### DIFF
--- a/assets/js/components/Config/Remote/RemoteModal.vue
+++ b/assets/js/components/Config/Remote/RemoteModal.vue
@@ -35,6 +35,11 @@
 							{{ $t("config.remote.disconnected") }}
 						</span>
 					</div>
+					<ErrorMessage
+						v-if="config.enabled"
+						:error="status.error ?? null"
+						class="mt-2 mb-0"
+					/>
 				</div>
 			</div>
 

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -963,6 +963,8 @@ export type RemoteStatus = {
   loginBlocked: boolean;
   /** Last remote activity per client, keyed by username. RFC3339 timestamps. */
   lastSeen?: Record<string, string>;
+  /** Last connection error. */
+  error?: string;
 };
 
 export type RemoteClient = {

--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -4127,6 +4127,10 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "error": {
+            "description": "Last connection error.",
+            "type": "string"
           }
         },
         "required": [

--- a/server/openapi.state.yaml
+++ b/server/openapi.state.yaml
@@ -1586,6 +1586,9 @@ components:
           type: object
           additionalProperties:
             type: string
+        error:
+          description: Last connection error.
+          type: string
       required:
         - connected
         - loginBlocked

--- a/server/remote/remote.go
+++ b/server/remote/remote.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -34,6 +35,7 @@ type Remote struct {
 	publisher   chan<- util.Param
 	lastSeen    map[string]time.Time // persisted: username → last activity
 	connected   map[string]int       // in-memory: active connection count per user
+	lastError   string               // last connect/registration error, published to UI
 }
 
 // New creates a new Remote manager, loads persisted settings, and connects if enabled.
@@ -93,8 +95,10 @@ func (r *Remote) Enabled() bool {
 }
 
 func (r *Remote) connect() {
-	if !sponsor.IsAuthorizedForApi() {
-		r.log.WARN.Println("remote access requires a sponsor token")
+	if sponsor.Token == "" {
+		msg := "remote access requires a sponsor token"
+		r.log.WARN.Println(msg)
+		r.setError(errors.New(msg))
 		return
 	}
 
@@ -105,9 +109,12 @@ func (r *Remote) connect() {
 	if token == "" {
 		if err := r.register(); err != nil {
 			r.log.ERROR.Printf("registration failed: %v", err)
+			r.setError(fmt.Errorf("registration failed: %w", err))
 			return
 		}
 	}
+
+	r.setError(nil)
 
 	r.log.INFO.Printf("remote access via %s", r.settings.URL)
 
@@ -129,6 +136,19 @@ func (r *Remote) disconnect() {
 		r.tunnel.Close()
 		r.tunnel = nil
 	}
+	r.lastError = ""
+}
+
+// setError records a connect error and publishes it to the UI.
+func (r *Remote) setError(err error) {
+	r.mu.Lock()
+	r.lastError = ""
+	if err != nil {
+		r.lastError = err.Error()
+	}
+	r.mu.Unlock()
+
+	r.publish()
 }
 
 type registerRequest struct {
@@ -192,6 +212,11 @@ func (r *Remote) ConfigStatus() globalconfig.ConfigStatus {
 	connected := r.tunnel != nil && r.tunnel.IsConnected()
 	loginBlocked := r.tunnel != nil && r.tunnel.LoginBlocked()
 
+	errMsg := r.lastError
+	if errMsg == "" && r.tunnel != nil {
+		errMsg = r.tunnel.Error()
+	}
+
 	return globalconfig.ConfigStatus{
 		Config: struct {
 			Enabled bool `json:"enabled"`
@@ -203,11 +228,13 @@ func (r *Remote) ConfigStatus() globalconfig.ConfigStatus {
 			URL          string               `json:"url,omitempty"`
 			LoginBlocked bool                 `json:"loginBlocked"`
 			LastSeen     map[string]time.Time `json:"lastSeen,omitempty"`
+			Error        string               `json:"error,omitempty"`
 		}{
 			Connected:    connected,
 			URL:          r.settings.URL,
 			LoginBlocked: loginBlocked,
 			LastSeen:     r.lastSeen,
+			Error:        errMsg,
 		},
 	}
 }

--- a/server/remote/remote.go
+++ b/server/remote/remote.go
@@ -35,7 +35,7 @@ type Remote struct {
 	publisher   chan<- util.Param
 	lastSeen    map[string]time.Time // persisted: username → last activity
 	connected   map[string]int       // in-memory: active connection count per user
-	lastError   string               // last connect/registration error, published to UI
+	lastError   error                // last connect/registration error, published to UI
 }
 
 // New creates a new Remote manager, loads persisted settings, and connects if enabled.
@@ -136,16 +136,13 @@ func (r *Remote) disconnect() {
 		r.tunnel.Close()
 		r.tunnel = nil
 	}
-	r.lastError = ""
+	r.lastError = nil
 }
 
 // setError records a connect error and publishes it to the UI.
 func (r *Remote) setError(err error) {
 	r.mu.Lock()
-	r.lastError = ""
-	if err != nil {
-		r.lastError = err.Error()
-	}
+	r.lastError = err
 	r.mu.Unlock()
 
 	r.publish()
@@ -212,9 +209,14 @@ func (r *Remote) ConfigStatus() globalconfig.ConfigStatus {
 	connected := r.tunnel != nil && r.tunnel.IsConnected()
 	loginBlocked := r.tunnel != nil && r.tunnel.LoginBlocked()
 
-	errMsg := r.lastError
-	if errMsg == "" && r.tunnel != nil {
-		errMsg = r.tunnel.Error()
+	lastErr := r.lastError
+	if lastErr == nil && r.tunnel != nil {
+		lastErr = r.tunnel.Error()
+	}
+
+	var errMsg string
+	if lastErr != nil {
+		errMsg = lastErr.Error()
 	}
 
 	return globalconfig.ConfigStatus{

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -35,6 +35,7 @@ type Tunnel struct {
 
 	mu      sync.Mutex
 	session *yamux.Session
+	lastErr error
 }
 
 // NewTunnel creates a new tunnel client.
@@ -66,6 +67,7 @@ func (t *Tunnel) run() {
 		ok, err := t.connect(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			t.log.ERROR.Printf("tunnel: %v", err)
+			t.setError(err)
 		}
 
 		// rejected credentials will not self-heal; a new token requires a restart
@@ -139,6 +141,9 @@ func (t *Tunnel) connect(ctx context.Context) (bool, error) {
 func (t *Tunnel) changeState(session *yamux.Session, err error) {
 	t.mu.Lock()
 	t.session = session
+	if session != nil {
+		t.lastErr = nil
+	}
 	t.mu.Unlock()
 
 	if t.onStateChange != nil {
@@ -154,6 +159,26 @@ func (t *Tunnel) changeState(session *yamux.Session, err error) {
 			t.log.INFO.Println("tunnel disconnected:", err)
 		}
 	}
+}
+
+func (t *Tunnel) setError(err error) {
+	t.mu.Lock()
+	t.lastErr = err
+	t.mu.Unlock()
+
+	if t.onStateChange != nil {
+		t.onStateChange()
+	}
+}
+
+// Error returns the last connection error, if any.
+func (t *Tunnel) Error() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.lastErr != nil {
+		return t.lastErr.Error()
+	}
+	return ""
 }
 
 // IsConnected returns whether the tunnel is currently connected.

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -172,13 +172,10 @@ func (t *Tunnel) setError(err error) {
 }
 
 // Error returns the last connection error, if any.
-func (t *Tunnel) Error() string {
+func (t *Tunnel) Error() error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.lastErr != nil {
-		return t.lastErr.Error()
-	}
-	return ""
+	return t.lastErr
 }
 
 // IsConnected returns whether the tunnel is currently connected.


### PR DESCRIPTION
Booting without internet left remote access permanently down: the local sponsor check failed once ("sponsorship unavailable") and the tunnel was never attempted, with no visible error. Remote access now always attempts the tunnel when a sponsor token is configured and keeps retrying, so it recovers on its own once connectivity returns. Connect errors are shown in the remote access modal.

- self-recover after offline boot: connect requires only a configured sponsor token; the cloud proxy performs the authoritative check and the existing backoff keeps retrying
- publish last tunnel/registration error via `status.error`, cleared on successful connect or disable
- show error in remote access modal below the enable toggle
- credential rejections (401/403) still stop retrying but are now visible

<img width="669" height="495" alt="Bildschirmfoto 2026-08-04 um 11 09 20" src="https://github.com/user-attachments/assets/7e3063c5-84a2-419b-aa39-16b838037079" />
