### PR TITLE
cfos: expose temperature exceedance

### DIFF
--- a/charger/cfos.go
+++ b/charger/cfos.go
@@ -20,6 +20,7 @@ package charger
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/evcc-io/evcc/api"
@@ -123,7 +124,7 @@ func (wb *CfosPowerBrain) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 2: // laden
 		return api.StatusC, nil
-	case 5:
+	case 5: // Übertemperatur
 		return api.StatusNone, errors.New("temperature exceeded")
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])

--- a/charger/cfos.go
+++ b/charger/cfos.go
@@ -123,6 +123,8 @@ func (wb *CfosPowerBrain) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 2: // laden
 		return api.StatusC, nil
+	case 5: // Temperaturüberschreitung
+		return "Temperaturüberschreitung", nil
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])
 	}

--- a/charger/cfos.go
+++ b/charger/cfos.go
@@ -123,7 +123,7 @@ func (wb *CfosPowerBrain) Status() (api.ChargeStatus, error) {
 		return api.StatusB, nil
 	case 2: // laden
 		return api.StatusC, nil
-	case 5: // Temperaturüberschreitung
+	case 5:
 		return api.StatusNone, errors.New("temperature exceeded")
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])

--- a/charger/cfos.go
+++ b/charger/cfos.go
@@ -124,7 +124,7 @@ func (wb *CfosPowerBrain) Status() (api.ChargeStatus, error) {
 	case 2: // laden
 		return api.StatusC, nil
 	case 5: // Temperaturüberschreitung
-		return "Temperaturüberschreitung", nil
+		return api.StatusNone, errors.New("temperature exceeded")
 	default:
 		return api.StatusNone, fmt.Errorf("invalid status: %d", b[1])
 	}


### PR DESCRIPTION
Handle this error:
```
[lp-1 ] ERROR 2026/08/04 11:45:27 charger status: invalid status: 5
```

I'm not in the programming GO and the evcc project. I think it is missing translation and eventually an api state for this behavior.

Status 5 comes up if the temperature inside the wall box is over the threshold configured in cFos configuration. This blocks charging until temperature is 5 degrees under configured temperature.