### PR TITLE
Templates: keep large numeric params parseable

### DIFF
--- a/util/templates/formatvalue_test.go
+++ b/util/templates/formatvalue_test.go
@@ -1,0 +1,38 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// JSON numbers arrive as float64. Large integers must not be rendered in
+// exponential notation, which would no longer parse as an integer.
+func TestFormatValue(t *testing.T) {
+	for _, tc := range []struct {
+		in   any
+		want string
+	}{
+		{float64(3), "3"},
+		{float64(8899), "8899"},
+		{float64(3493601102), "3493601102"}, // ten digit device serial
+		{float64(1.5), "1.5"},
+		{int(42), "42"},
+		{"text", "text"},
+	} {
+		assert.Equal(t, tc.want, formatValue(tc.in))
+	}
+}
+
+// end-to-end: a required int param supplied as a JSON number must satisfy the
+// required check, e.g. a ten digit device serial
+func TestRequiredLargeNumber(t *testing.T) {
+	tmpl := &Template{
+		Params: []Param{{Name: "serial", Type: TypeInt, Required: true}},
+	}
+
+	_, _, err := tmpl.RenderResult(RenderModeUnitTest, map[string]any{
+		"serial": float64(3493601102),
+	})
+	assert.NoError(t, err, "large serial supplied as JSON number")
+}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -274,6 +274,8 @@ func (t *Template) RenderProxyWithValues(values map[string]any, lang string) ([]
 				t.Params[index].Value = p.yamlQuote(v)
 			case int:
 				t.Params[index].Value = strconv.Itoa(v)
+			case float64, float32:
+				t.Params[index].Value = formatValue(v)
 			}
 		}
 	}
@@ -306,6 +308,20 @@ func (t *Template) RenderProxyWithValues(values map[string]any, lang string) ([]
 	err = tmpl.Execute(out, data)
 
 	return bytes.TrimSpace(out.Bytes()), err
+}
+
+// formatValue renders a parameter value for yaml. JSON numbers arrive as float64,
+// which %v would render in exponential notation for large values, e.g. a ten digit
+// serial number. Those are no longer parseable as integers.
+func formatValue(val any) string {
+	switch v := val.(type) {
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
 }
 
 // RenderResult renders the result template to instantiate the proxy
@@ -383,7 +399,7 @@ func (t *Template) RenderResult(renderMode int, other map[string]any) ([]byte, m
 				// prevent rendering nil interfaces as "<nil>" string
 				var s string
 				if val != nil {
-					s = p.yamlQuote(fmt.Sprintf("%v", val))
+					s = p.yamlQuote(formatValue(val))
 				}
 
 				// validate required fields from yaml


### PR DESCRIPTION
A required int template param with a large value is rejected as missing.

JSON numbers reach the config API as float64. `RenderResult` formats them with
`%v`, which switches to exponential notation above roughly a million, so
`3493601102` becomes `3.493601102e+09`. `IsZero` parses that as 0 and the
required check fails:

```
float64(3)           -> "3"                -> ToInt64 = 3
float64(8899)        -> "8899"             -> ToInt64 = 8899
float64(3493601102)  -> "3.493601102e+09"  -> ToInt64 = 0
```

Smaller values like a port or a phase count are unaffected, which is probably
why this went unnoticed. I ran into it with a ten digit device serial as a
template param.

Formats floats with `strconv.FormatFloat(v, 'f', -1, 64)` instead and handles
float in the `Defaults` switch. Two tests cover the formatting and the
end-to-end required check:

```go
tmpl := &Template{Params: []Param{{Name: "serial", Type: TypeInt, Required: true}}}
_, _, err := tmpl.RenderResult(RenderModeUnitTest, map[string]any{
	"serial": float64(3493601102),
})
// before: missing required `serial`
```