### PR TITLE
Loadpoint: respect battery discharge power limit when starting solar charging with battery as charging buffer

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1616,6 +1616,22 @@ func (lp *Loadpoint) boostPower(batteryPower float64) float64 {
 	return res
 }
 
+// batteryCoversStart checks if the battery can supply the power still missing to reach
+// minCurrent. Without a discharge limit the battery is assumed to cover any demand.
+func (lp *Loadpoint) batteryCoversStart(sitePower, minCurrent, effectiveCurrent float64, activePhases int) bool {
+	limit := lp.site.GetBatteryMaxDischargePower()
+	if limit == nil {
+		return true
+	}
+
+	if batteryModeModified(lp.site.GetBatteryMode()) {
+		return false
+	}
+
+	// sitePower nets out the battery and already contains what the loadpoint draws
+	return currentToPower(minCurrent-effectiveCurrent, activePhases)+sitePower <= *limit
+}
+
 // pvMaxCurrent calculates the maximum target current for PV mode
 func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryPower float64, batteryBuffered, batteryStart bool) float64 {
 	// read only once to simplify testing
@@ -1644,6 +1660,11 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryPower f
 	}
 	deltaCurrent := powerToCurrent(-sitePower, activePhases)
 	targetCurrent := max(effectiveCurrent+deltaCurrent, 0)
+
+	// battery assist only decides whether to start, it does not revoke a running session
+	if boost := lp.GetBatteryBoost(); batteryStart && !lp.enabled && (boost == boostDisabled || boost == boostHold) {
+		batteryStart = lp.batteryCoversStart(sitePower, minCurrent, effectiveCurrent, activePhases)
+	}
 
 	// in MinPV mode or under special conditions return at least minCurrent
 	if battery := batteryStart || batteryBuffered && lp.charging() || lp.GetBatteryBoost() == boostContinue; (mode == api.ModeMinPV || battery) && targetCurrent < minCurrent {

--- a/core/loadpoint_assist_test.go
+++ b/core/loadpoint_assist_test.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatteryCoversStart(t *testing.T) {
+	Voltage = 230 // 3p at 6A needs 4140W
+
+	for _, tc := range []struct {
+		name             string
+		sitePower        float64
+		effectiveCurrent float64
+		limit            *float64
+		batteryMode      api.BatteryMode
+		expected         bool
+	}{
+		{"no limit configured", -2000, 0, nil, api.BatteryNormal, true},
+		{"empty battery", -4000, 0, new(0.0), api.BatteryNormal, false},
+		{"site deficit adds to the gap", 500, 0, new(4200.0), api.BatteryNormal, false},
+		{"existing draw reduces the gap", 0, 5, new(800.0), api.BatteryNormal, true},
+		{"uncontrolled battery discharges", -4000, 0, new(800.0), api.BatteryUnknown, true},
+		{"held battery does not discharge", -4000, 0, new(800.0), api.BatteryHold, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lp := &Loadpoint{
+				log:  util.NewLogger("foo"),
+				site: &mockSite{maxDischargePower: tc.limit, batteryMode: tc.batteryMode},
+			}
+
+			assert.Equal(t, tc.expected, lp.batteryCoversStart(tc.sitePower, minA, tc.effectiveCurrent, 3))
+		})
+	}
+}
+
+// newAssistLoadpoint returns a loadpoint where 3p at 6A needs 1800W
+func newAssistLoadpoint(limit float64) *Loadpoint {
+	Voltage = 100
+
+	return &Loadpoint{
+		log:            util.NewLogger("foo"),
+		clock:          clock.NewMock(),
+		site:           &mockSite{maxDischargePower: &limit},
+		minCurrent:     minA,
+		maxCurrent:     maxA,
+		phases:         3,
+		measuredPhases: 3,
+		status:         api.StatusB,
+	}
+}
+
+// a refused start must reach the caller as zero, not fall through to min current
+func TestPvBatteryStartLimited(t *testing.T) {
+	lp := newAssistLoadpoint(800)
+
+	// 600W surplus leaves 1200W missing
+	assert.Equal(t, 0.0, lp.pvMaxCurrent(api.ModePV, -600, 0, false, true))
+}
+
+func TestPvBatteryStartBoost(t *testing.T) {
+	// an active boost owns the battery budget and is not second-guessed
+	t.Run("boost bypasses the check", func(t *testing.T) {
+		lp := newAssistLoadpoint(300)
+		lp.batteryBoost = boostStart
+
+		assert.Equal(t, minA, lp.pvMaxCurrent(api.ModePV, -600, 0, false, true))
+	})
+
+	// a held boost does not drain the battery, so the check still applies
+	t.Run("hold is checked", func(t *testing.T) {
+		lp := newAssistLoadpoint(800)
+		lp.batteryBoost = boostHold
+
+		assert.Equal(t, 0.0, lp.pvMaxCurrent(api.ModePV, -600, 0, false, true))
+	})
+}
+
+// the check gates the start only, an enabled loadpoint is left to pv hysteresis
+func TestPvBatteryStartEnabled(t *testing.T) {
+	lp := newAssistLoadpoint(500)
+	lp.status = api.StatusC
+	lp.enabled = true
+	lp.offeredCurrent = minA
+	lp.Disable = loadpoint.ThresholdConfig{}
+
+	assert.Equal(t, minA, lp.pvMaxCurrent(api.ModePV, 600, 0, false, true))
+}

--- a/core/loadpoint_boost_test.go
+++ b/core/loadpoint_boost_test.go
@@ -13,6 +13,7 @@ type mockSite struct {
 	site.API
 	maxDischargePower *float64
 	residualPower     float64
+	batteryMode       api.BatteryMode
 	optimized         int
 }
 
@@ -26,6 +27,10 @@ func (m *mockSite) GetBatteryMaxDischargePower() *float64 {
 
 func (m *mockSite) GetResidualPower() float64 {
 	return m.residualPower
+}
+
+func (m *mockSite) GetBatteryMode() api.BatteryMode {
+	return m.batteryMode
 }
 
 func TestBoostPower(t *testing.T) {

--- a/core/site/api.go
+++ b/core/site/api.go
@@ -48,6 +48,7 @@ type API interface {
 
 	GetBatterySoc() float64
 	GetBatteryMaxDischargePower() *float64
+	GetBatteryMode() api.BatteryMode
 	GetPrioritySoc() float64
 	SetPrioritySoc(float64) error
 	GetBufferSoc() float64


### PR DESCRIPTION
Implements #32554

"Battery as charging buffer" decides to start solar charging on soc only. It does not check whether the battery can actually supply the power the loadpoint needs, so with a battery that is small relative to the loadpoint minimum the shortfall is imported from the grid, which is not what is expected for solar mode. 

The shortfall is now compared against the aggregated battery discharge limit and minCurrent is only forced when the battery can cover it. MinPV is exempt since it accepts grid import by definition, and where no discharge limit is configured behaviour is unchanged, so existing setups are unaffected.

The limit is the plain sum and is deliberately not reduced by current battery power: sitePower already nets that out, and  ubtracting it twice cuts charging short whilethe battery is still within its limit.