### PR TITLE
Sponsor: wait for network to settle during startup check

### DIFF
--- a/util/sponsor/auth.go
+++ b/util/sponsor/auth.go
@@ -30,6 +30,7 @@ import (
 	"github.com/evcc-io/evcc/util/cloud"
 	"github.com/evcc-io/evcc/util/machine"
 	"github.com/golang-jwt/jwt/v5"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -45,6 +46,9 @@ func machineID() string {
 }
 
 const unavailable = "sponsorship unavailable"
+
+// startupTimeout leaves the network time to settle at boot; grpc retries dialing with backoff until deadline
+const startupTimeout = 30 * time.Second
 
 func IsAuthorized() bool {
 	mu.RLock()
@@ -98,10 +102,10 @@ func ConfigureSponsorship(token string) error {
 
 	client := pb.NewAuthClient(conn)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), startupTimeout)
 	defer cancel()
 
-	res, err := client.IsAuthorized(ctx, &pb.AuthRequest{Token: token, MachineId: machineID()})
+	res, err := client.IsAuthorized(ctx, &pb.AuthRequest{Token: token, MachineId: machineID()}, grpc.WaitForReady(true))
 	if err == nil && res.Authorized {
 		Subject = res.Subject
 		ExpiresAt = res.ExpiresAt.AsTime()

--- a/util/sponsor/hardware.go
+++ b/util/sponsor/hardware.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/evcc-io/evcc/api/proto/pb"
 	"github.com/evcc-io/evcc/util/cloud"
-	"github.com/evcc-io/evcc/util/request"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -34,7 +34,7 @@ func checkHardware(vendor string, metadata map[string]string) string {
 		return unavailable
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), startupTimeout)
 	defer cancel()
 
 	client := pb.NewAuthClient(conn)
@@ -42,7 +42,7 @@ func checkHardware(vendor string, metadata map[string]string) string {
 		MachineId: machineID(),
 		Vendor:    vendor,
 		Metadata:  metadata,
-	})
+	}, grpc.WaitForReady(true))
 
 	if err == nil && res.Authorized {
 		return res.Subject


### PR DESCRIPTION
replaces https://github.com/evcc-io/evcc/pull/32312

## Problem

The startup sponsor check (both token `IsAuthorized` and hardware `IsAuthorizedHardware`) is one-shot and fail-fast. On WLAN-only devices, evcc starts 1–2s after `network-online.target`, while DHCP/routing/upstream connectivity is often still settling. Any transient gRPC dial error (`connection error: EOF`, `network is unreachable`) maps to `codes.Unavailable` → `Subject = "sponsorship unavailable"` — permanently, until the service is restarted. 

Reproduced deterministically on a RPi Zero 2, WLAN: block outbound `tcp/8080` during evcc start, lift the block after 15s → stock binary stays "sponsorship unavailable" forever; patched binary comes up with the correct subject.

## Fix

Use gRPC's built-in wait-for-ready mechanism: `grpc.WaitForReady(true)` call option plus a 30s deadline (instead of the fail-fast default with 10s). While the channel is in transient failure, gRPC keeps reconnecting with backoff and iterates over all resolved addresses (IPv6 → IPv4) until the deadline — no hand-rolled retry loop, no dialer changes. Outages longer than 30s still degrade to the existing grace mode.

Tested on device: survives 15s boot-time network flake; 40s outage falls back to "sponsorship unavailable" as before.