### PR TITLE
emsesp: use single cached bulk fetch to avoid firmware rate limiting

### DIFF
--- a/templates/definition/charger/emsesp.yaml
+++ b/templates/definition/charger/emsesp.yaml
@@ -93,36 +93,36 @@ render: |
   type: sgready
   power:
     source: http
-    uri: http://{{ .host }}/api/boiler/{{ .powersource }}
-    jq: .value // 0
+    uri: http://{{ .host }}/api/boiler
+    cache: {{ .cache }}
+    jq: .{{ .powersource }} // 0
     {{- if eq .powersource "hppower" }}
     scale: 1000
     {{- end}}
   getmode:
-    source: cached
-    cache: {{ .cache }}
-    value:
-      source: go
-      script: |
-        res := 2 // 0/0 Normal
-        switch {
-        case SG1 == "1" && SG4 == "0": res = 1 // 1/0 Frostschutz
-        case SG4 == "1": res = 3 // x/1 Forcierter Betrieb/Sofortige Ansteuerung
-        }
-        res
-      in:
-      - name: SG1
-        type: string
-        config:
-          source: http
-          uri: http://{{ .host }}/api/boiler/{{ .sg1 }}
-          jq: '.value[0:1]'
-      - name: SG4
-        type: string
-        config:
-          source: http
-          uri: http://{{ .host }}/api/boiler/{{ .sg4 }}
-          jq: '.value[0:1]'
+    source: go
+    script: |
+      res := 2 // 0/0 Normal
+      switch {
+      case SG1 == "1" && SG4 == "0": res = 1 // 1/0 Frostschutz
+      case SG4 == "1": res = 3 // x/1 Forcierter Betrieb/Sofortige Ansteuerung
+      }
+      res
+    in:
+    - name: SG1
+      type: string
+      config:
+        source: http
+        uri: http://{{ .host }}/api/boiler
+        cache: {{ .cache }}
+        jq: '.{{ .sg1 }}[0:1]'
+    - name: SG4
+      type: string
+      config:
+        source: http
+        uri: http://{{ .host }}/api/boiler
+        cache: {{ .cache }}
+        jq: '.{{ .sg4 }}[0:1]'
   setmode:
     source: switch
     switch:
@@ -191,11 +191,13 @@ render: |
   {{- if .tempsource }}
   temp:
     source: http
-    uri: http://{{ .host }}/api/boiler/dhw/curtemp
-    jq: .value 
+    uri: http://{{ .host }}/api/boiler
+    cache: {{ .cache }}
+    jq: .dhw.curtemp
   limittemp:
     source: http
-    uri: http://{{ .host }}/api/boiler/dhw/settemp
-    jq: .value
+    uri: http://{{ .host }}/api/boiler
+    cache: {{ .cache }}
+    jq: .dhw.settemp
   {{- end }}
   {{ include "heatpumpswitch" . }}


### PR DESCRIPTION
fixes #32290

Follow-up to #32291. Caching alone cannot prevent the 429s: `getmode` always fired its SG1/SG4 requests back-to-back within the same second, and power/temp/limittemp added three more uncached requests to the same burst — recent EMS-ESP firmware (3.8.3-dev.9+, rate limiting from emsesp/EMS-ESP32@193e5d5) rejects the second and later requests.

All read plugins now fetch the same bulk endpoint `GET /api/boiler` with the same cache duration. The http plugin's shared response cache and per-URL single-flight lock turn this into one device request per cache window, from which power (`hpcurrpower`/`hppower`), SG1/SG4 (`hpinXopt` bitmask first character) and the DHW temperatures (`dhw.curtemp`/`dhw.settemp`) are extracted via jq. Key names verified against the `/api/boiler` short-format response posted in https://github.com/evcc-io/evcc/pull/32291#issuecomment-5200426639.

Writes (`setmode`) are unchanged; the GET rate limiter does not apply to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)