### PR TITLE
ci: skip openapi step for backport tags without openapi target

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -177,7 +177,8 @@ jobs:
         run: make install-ui
 
       - name: OpenAPI
-        run: make openapi
+        # backport release tags may not have the openapi target yet
+        run: if grep -q '^openapi' Makefile; then make openapi; fi
 
       - name: Lint
         run: make lint-ui


### PR DESCRIPTION
Release build for 0.313.2 failed in the UI job: the release workflow pins `default.yml@master`, and master's UI job unconditionally runs `make openapi` — a target that does not exist on the 0.313 line (`make: *** No rule to make target 'openapi'`, https://github.com/evcc-io/evcc/actions/runs/31079729554/job/92545550283). All other targets the workflow uses exist on 0.313; only `openapi` is new.

Guard the step so it is skipped when the checked-out ref's Makefile has no `openapi` target. After merging, re-pushing the 0.313.2 tag (branch `release/0.313.2`, 5b4b4a333) should build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
