### PR TITLE
Docs: point getState externalDocs to API State reference page

### DIFF
--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -1565,7 +1565,7 @@
         "summary": "System state",
         "description": "Returns the complete state of the system. This structure is used by the UI and also published via websocket and MQTT. It can be filtered by JQ to only return a subset of the data. Note: the response mirrors the internal UI state and carries no compatibility promise. Fields may change or disappear between releases.",
         "externalDocs": {
-          "url": "https://docs.evcc.io/integrations/rest-api"
+          "url": "https://docs.evcc.io/en/reference/state"
         },
         "tags": [
           "state"

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -950,7 +950,7 @@ paths:
       summary: System state
       description: "Returns the complete state of the system. This structure is used by the UI and also published via websocket and MQTT. It can be filtered by JQ to only return a subset of the data. Note: the response mirrors the internal UI state and carries no compatibility promise. Fields may change or disappear between releases."
       externalDocs:
-        url: https://docs.evcc.io/integrations/rest-api
+        url: https://docs.evcc.io/en/reference/state
       tags:
         - state
       parameters:


### PR DESCRIPTION
pairs with evcc-io/docs#1145

Points the `getState` externalDocs link to the new dedicated API State reference page instead of the generic REST API page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)