### PR TITLE
ci: manage waiting for feedback label

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -20,5 +20,17 @@ jobs:
         with:
           days-before-stale: 7
           days-before-close: 5
-          exempt-issue-labels: "pinned,security,backlog,bug"
+          exempt-issue-labels: "pinned,security,backlog,bug,waiting for feedback"
           exempt-pr-labels: "pinned,security,backlog,bug"
+
+      # issues without the requested feedback close after a week
+      - uses: actions/stale@v11
+        id: waiting
+        with:
+          only-issue-labels: "waiting for feedback"
+          days-before-issue-stale: 7
+          days-before-issue-close: 0
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: "pinned,security,backlog"
+          close-issue-message: "Closing since the requested feedback was not provided. Please comment if you can still provide it and we'll reopen."

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -33,4 +33,4 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           exempt-issue-labels: "pinned,security,backlog"
-          close-issue-message: "Closing since the requested feedback was not provided. Please comment if you can still provide it and we'll reopen."
+          close-issue-message: "Closing since the requested feedback was not provided. You can still comment with requested feedback and we'll reopen."

--- a/.github/workflows/waiting-feedback.yml
+++ b/.github/workflows/waiting-feedback.yml
@@ -1,0 +1,36 @@
+name: Waiting Feedback
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  reset-label:
+    name: Reset Waiting Label
+    runs-on: ubuntu-latest
+    # only when the opener replies
+    if: github.event.comment.user.login == (github.event.issue.user.login || github.event.pull_request.user.login)
+
+    steps:
+      - uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const number = (context.payload.issue || context.payload.pull_request).number;
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                name: 'waiting for feedback',
+              });
+            } catch (err) {
+              // label not present
+              if (err.status !== 404) throw err;
+            }


### PR DESCRIPTION
Makes the `waiting for feedback` label self-managing in both directions.

**Reset when the opener replies** — a new workflow removes the label as soon as the person who opened the issue or PR comments, so the label always reflects who is actually being waited on. `issue_comment` covers issues and PR conversation comments, `pull_request_review_comment` covers the opener replying inline in a review thread. The author check runs as a job condition, so comments from anyone else do not start a job. A missing label is ignored.

**Close when they don't** — a second `actions/stale` step closes issues that still carry the label after a week of silence. It leaves PRs alone (`days-before-pr-stale: -1`), and the label is now exempt from the general stale policy so the two do not overlap. Note this exempt list drops `bug`: an unreproducible bug report is exactly the case the label is for. Currently none of the labelled issues carry it.

Pushes to a PR are deliberately not treated as a reply — that would need `pull_request_target` for fork PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
