### PR TITLE
Keba modbus: release phase switch relay while disabled

### DIFF
--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -47,6 +47,7 @@ type Keba struct {
 	regEnable    uint16
 	energyFactor float64
 	state1p      uint32
+	phases       int // last requested phases, 0 if phase switching is unavailable
 }
 
 const (
@@ -145,6 +146,10 @@ func NewKebaFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 		if source := binary.BigEndian.Uint32(b); source == 3 {
 			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
 			implement.Has(wb, implement.PhaseGetter(wb.getPhases))
+
+			if wb.phases, err = wb.getPhases(); err != nil {
+				return nil, fmt.Errorf("phases: %w", err)
+			}
 		}
 	}
 
@@ -285,6 +290,13 @@ func (wb *Keba) Enabled() (bool, error) {
 
 // Enable implements the api.Charger interface
 func (wb *Keba) Enable(enable bool) error {
+	// restore the phase state before enabling
+	if enable && wb.phases != 0 {
+		if err := wb.writePhases(wb.phases); err != nil {
+			return err
+		}
+	}
+
 	var u uint16
 	if enable {
 		if wb.regEnable == kebaRegMaxCurrent {
@@ -296,8 +308,16 @@ func (wb *Keba) Enable(enable bool) error {
 		}
 	}
 
-	_, err := wb.conn.WriteSingleRegister(wb.regEnable, u)
-	return err
+	if _, err := wb.conn.WriteSingleRegister(wb.regEnable, u); err != nil {
+		return err
+	}
+
+	// release the external phase switch relay to save its standby power
+	if !enable && wb.phases != 0 {
+		return wb.writePhases(1)
+	}
+
+	return nil
 }
 
 // MaxCurrent implements the api.Charger interface
@@ -372,14 +392,23 @@ func (wb *Keba) identify() (string, error) {
 	return id, nil
 }
 
-// phases1p3p implements the api.PhaseSwitcher interface
-func (wb *Keba) phases1p3p(phases int) error {
+func (wb *Keba) writePhases(phases int) error {
 	var u uint16
 	if phases == 3 {
 		u = 1
 	}
 
 	_, err := wb.conn.WriteSingleRegister(kebaRegTriggerPhase, u)
+	return err
+}
+
+// phases1p3p implements the api.PhaseSwitcher interface
+func (wb *Keba) phases1p3p(phases int) error {
+	err := wb.writePhases(phases)
+	if err == nil {
+		wb.phases = phases
+	}
+
 	return err
 }
 

--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -146,10 +146,6 @@ func NewKebaFromConfig(ctx context.Context, other map[string]any) (api.Charger, 
 		if source := binary.BigEndian.Uint32(b); source == 3 {
 			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
 			implement.Has(wb, implement.PhaseGetter(wb.getPhases))
-
-			if wb.phases, err = wb.getPhases(); err != nil {
-				return nil, fmt.Errorf("phases: %w", err)
-			}
 		}
 	}
 
@@ -290,13 +286,6 @@ func (wb *Keba) Enabled() (bool, error) {
 
 // Enable implements the api.Charger interface
 func (wb *Keba) Enable(enable bool) error {
-	// restore the phase state before enabling
-	if enable && wb.phases != 0 {
-		if err := wb.writePhases(wb.phases); err != nil {
-			return err
-		}
-	}
-
 	var u uint16
 	if enable {
 		if wb.regEnable == kebaRegMaxCurrent {
@@ -313,7 +302,7 @@ func (wb *Keba) Enable(enable bool) error {
 	}
 
 	// release the external phase switch relay to save its standby power
-	if !enable && wb.phases != 0 {
+	if !enable && wb.phases == 3 {
 		return wb.writePhases(1)
 	}
 

--- a/charger/keba-modbus.go
+++ b/charger/keba-modbus.go
@@ -47,7 +47,6 @@ type Keba struct {
 	regEnable    uint16
 	energyFactor float64
 	state1p      uint32
-	phases       int // last requested phases, 0 if phase switching is unavailable
 }
 
 const (
@@ -302,8 +301,15 @@ func (wb *Keba) Enable(enable bool) error {
 	}
 
 	// release the external phase switch relay to save its standby power
-	if !enable && wb.phases == 3 {
-		return wb.writePhases(1)
+	if _, ok := api.Cap[api.PhaseSwitcher](wb); ok && !enable {
+		phases, err := wb.getPhases()
+		if err != nil {
+			return err
+		}
+
+		if phases == 3 {
+			return wb.phases1p3p(1)
+		}
 	}
 
 	return nil
@@ -381,23 +387,14 @@ func (wb *Keba) identify() (string, error) {
 	return id, nil
 }
 
-func (wb *Keba) writePhases(phases int) error {
+// phases1p3p implements the api.PhaseSwitcher interface
+func (wb *Keba) phases1p3p(phases int) error {
 	var u uint16
 	if phases == 3 {
 		u = 1
 	}
 
 	_, err := wb.conn.WriteSingleRegister(kebaRegTriggerPhase, u)
-	return err
-}
-
-// phases1p3p implements the api.PhaseSwitcher interface
-func (wb *Keba) phases1p3p(phases int) error {
-	err := wb.writePhases(phases)
-	if err == nil {
-		wb.phases = phases
-	}
-
 	return err
 }
 

--- a/charger/keba-modbus_test.go
+++ b/charger/keba-modbus_test.go
@@ -39,6 +39,12 @@ func (h *kebaHandler) HandleHoldingRegisters(req *mbserver.HoldingRegistersReque
 	return res, nil
 }
 
+func (h *kebaHandler) reg(addr uint16) uint16 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.regs[addr]
+}
+
 // shared mock server: mbserver.Stop() races its accept goroutine, so the server
 // is started once and never stopped; handler state is reset per test
 var (
@@ -47,8 +53,9 @@ var (
 	kebaSrvH = &kebaHandler{RequestHandler: new(mbserver.DummyHandler)}
 )
 
-// kebaTestCharger returns a P30 with external phase switching connected to the mock server
-func kebaTestCharger(t *testing.T, phases int) (*Keba, *kebaHandler) {
+// kebaTestCharger returns a P30 connected to the mock server, charging on the given
+// number of phases and optionally offering external phase switching
+func kebaTestCharger(t *testing.T, phases int, switchable bool) (*Keba, *kebaHandler) {
 	t.Helper()
 
 	kebaOnce.Do(func() {
@@ -62,6 +69,7 @@ func kebaTestCharger(t *testing.T, phases int) (*Keba, *kebaHandler) {
 		kebaURI = l.Addr().String()
 	})
 
+	// P30 reports 3p as 1 in the upper phase state register
 	var state uint16
 	if phases == 3 {
 		state = 1
@@ -81,45 +89,38 @@ func kebaTestCharger(t *testing.T, phases int) (*Keba, *kebaHandler) {
 		conn:         conn,
 		regEnable:    kebaRegEnable,
 		energyFactor: 1e4,
-		phases:       phases,
+	}
+
+	if switchable {
+		implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
+		implement.Has(wb, implement.PhaseGetter(wb.getPhases))
 	}
 
 	return wb, kebaSrvH
 }
 
-func (h *kebaHandler) reg(addr uint16) uint16 {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return h.regs[addr]
-}
-
 // TestKebaEnablePhases verifies that the external phase switch relay is released
-// while disabled and restored on enable, see discussion #32176
+// on disable, see discussion #32176
 func TestKebaEnablePhases(t *testing.T) {
-	wb, h := kebaTestCharger(t, 3)
+	tc := []struct {
+		name       string
+		phases     int
+		switchable bool
+		enable     bool
+		expected   uint16
+	}{
+		{"3p disable releases relay", 3, true, false, 0},
+		{"3p enable keeps relay", 3, true, true, 1},
+		{"1p disable is a no-op", 1, true, false, 0},
+		{"3p without phase switching is untouched", 3, false, false, 1},
+	}
 
-	require.NoError(t, wb.Enable(false))
-	require.Equal(t, uint16(0), h.reg(kebaRegTriggerPhase), "relay must be released on disable")
-	require.Equal(t, 3, wb.phases, "requested phases must be retained")
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			wb, h := kebaTestCharger(t, tc.phases, tc.switchable)
 
-	require.NoError(t, wb.Enable(true))
-	require.Equal(t, uint16(1), h.reg(kebaRegTriggerPhase), "relay must be restored on enable")
-
-	// a 1p charger stays 1p
-	wb, h = kebaTestCharger(t, 1)
-
-	require.NoError(t, wb.Enable(true))
-	require.Equal(t, uint16(0), h.reg(kebaRegTriggerPhase))
-	require.NoError(t, wb.Enable(false))
-	require.Equal(t, uint16(0), h.reg(kebaRegTriggerPhase))
-}
-
-// TestKebaEnableWithoutPhaseSwitching verifies the phase register is untouched
-// when the charger has no external phase switching
-func TestKebaEnableWithoutPhaseSwitching(t *testing.T) {
-	wb, h := kebaTestCharger(t, 0)
-	h.regs[kebaRegTriggerPhase] = 1
-
-	require.NoError(t, wb.Enable(false))
-	require.Equal(t, uint16(1), h.reg(kebaRegTriggerPhase))
+			require.NoError(t, wb.Enable(tc.enable))
+			require.Equal(t, tc.expected, h.reg(kebaRegTriggerPhase))
+		})
+	}
 }

--- a/charger/keba-modbus_test.go
+++ b/charger/keba-modbus_test.go
@@ -1,0 +1,125 @@
+package charger
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/andig/mbserver"
+	"github.com/evcc-io/evcc/api/implement"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/modbus"
+	"github.com/stretchr/testify/require"
+)
+
+// kebaHandler mocks the charger's holding register space
+type kebaHandler struct {
+	mbserver.RequestHandler
+	mu   sync.Mutex
+	regs map[uint16]uint16
+}
+
+func (h *kebaHandler) HandleHoldingRegisters(req *mbserver.HoldingRegistersRequest) ([]uint16, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if req.IsWrite {
+		for i, v := range req.Args {
+			h.regs[req.Addr+uint16(i)] = v
+		}
+		return req.Args, nil
+	}
+
+	res := make([]uint16, 0, req.Quantity)
+	for i := range req.Quantity {
+		res = append(res, h.regs[req.Addr+i])
+	}
+
+	return res, nil
+}
+
+// shared mock server: mbserver.Stop() races its accept goroutine, so the server
+// is started once and never stopped; handler state is reset per test
+var (
+	kebaOnce sync.Once
+	kebaURI  string
+	kebaSrvH = &kebaHandler{RequestHandler: new(mbserver.DummyHandler)}
+)
+
+// kebaTestCharger returns a P30 with external phase switching connected to the mock server
+func kebaTestCharger(t *testing.T, phases int) (*Keba, *kebaHandler) {
+	t.Helper()
+
+	kebaOnce.Do(func() {
+		l, err := net.Listen("tcp", "localhost:0")
+		require.NoError(t, err)
+
+		srv, err := mbserver.New(kebaSrvH)
+		require.NoError(t, err)
+		require.NoError(t, srv.Start(l))
+
+		kebaURI = l.Addr().String()
+	})
+
+	var state uint16
+	if phases == 3 {
+		state = 1
+	}
+	kebaSrvH.regs = map[uint16]uint16{
+		kebaRegPhaseState + 1: state,
+		kebaRegTriggerPhase:   state,
+	}
+
+	conn, err := modbus.NewConnection(context.Background(), kebaURI, "", "", 0, modbus.Tcp, 255)
+	require.NoError(t, err)
+
+	wb := &Keba{
+		embed:        new(embed),
+		Caps:         implement.New(),
+		log:          util.NewLogger("keba"),
+		conn:         conn,
+		regEnable:    kebaRegEnable,
+		energyFactor: 1e4,
+		phases:       phases,
+	}
+
+	return wb, kebaSrvH
+}
+
+func (h *kebaHandler) reg(addr uint16) uint16 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.regs[addr]
+}
+
+// TestKebaEnablePhases verifies that the external phase switch relay is released
+// while disabled and restored on enable, see discussion #32176
+func TestKebaEnablePhases(t *testing.T) {
+	wb, h := kebaTestCharger(t, 3)
+
+	require.NoError(t, wb.Enable(false))
+	require.Equal(t, uint16(0), h.reg(kebaRegTriggerPhase), "relay must be released on disable")
+	require.Equal(t, 3, wb.phases, "requested phases must be retained")
+
+	require.NoError(t, wb.Enable(true))
+	require.Equal(t, uint16(1), h.reg(kebaRegTriggerPhase), "relay must be restored on enable")
+
+	// a 1p charger stays 1p
+	wb, h = kebaTestCharger(t, 1)
+
+	require.NoError(t, wb.Enable(true))
+	require.Equal(t, uint16(0), h.reg(kebaRegTriggerPhase))
+	require.NoError(t, wb.Enable(false))
+	require.Equal(t, uint16(0), h.reg(kebaRegTriggerPhase))
+}
+
+// TestKebaEnableWithoutPhaseSwitching verifies the phase register is untouched
+// when the charger has no external phase switching
+func TestKebaEnableWithoutPhaseSwitching(t *testing.T) {
+	wb, h := kebaTestCharger(t, 0)
+	h.regs[kebaRegTriggerPhase] = 1
+
+	require.NoError(t, wb.Enable(false))
+	require.Equal(t, uint16(1), h.reg(kebaRegTriggerPhase))
+}

--- a/charger/keba-modbus_test.go
+++ b/charger/keba-modbus_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/andig/mbserver"
 	"github.com/evcc-io/evcc/api/implement"
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/modbus"
 	"github.com/stretchr/testify/require"
 )
@@ -82,13 +81,11 @@ func kebaTestCharger(t *testing.T, phases int, switchable bool) (*Keba, *kebaHan
 	conn, err := modbus.NewConnection(context.Background(), kebaURI, "", "", 0, modbus.Tcp, 255)
 	require.NoError(t, err)
 
+	// state1p stays 0, the P30 encoding of single phase
 	wb := &Keba{
-		embed:        new(embed),
-		Caps:         implement.New(),
-		log:          util.NewLogger("keba"),
-		conn:         conn,
-		regEnable:    kebaRegEnable,
-		energyFactor: 1e4,
+		Caps:      implement.New(),
+		conn:      conn,
+		regEnable: kebaRegEnable,
 	}
 
 	if switchable {


### PR DESCRIPTION
Implements https://github.com/evcc-io/evcc/discussions/32176#discussioncomment-17922403.

With an external phase switch box (KEBA S10, phase source `3`), the relay stays energised after a 3-phase session ends and draws ~6 W continuously. Today the only way out is to briefly select "1-phase" in the loadpoint settings before unplugging.

`Enable(false)` now reads the phase state from register 1552 and, if the charger is on 3p, writes register 5052 back to 1p. Chargers without external phase switching are untouched.

Open question from the discussion: in PV mode this cycles the relay on every enable/disable, bounded by the enable/disable delay. If that turns out to be worse than the 6 W, the alternative is to only release the relay once the vehicle is disconnected, or to put it behind a template option.

Note that the loadpoint keeps its own phase count while disabled, so the next enable logs one `phases mismatch` warning before `syncCharger` adopts the actual state and scales back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
