### PR TITLE
Phase switcher: switch back to 1p on disable

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1019,6 +1019,13 @@ func (lp *Loadpoint) setLimit(current float64) error {
 
 		lp.bus.Publish(evChargeCurrent, current)
 
+		// release the phase switch relay when disabling (https://github.com/evcc-io/evcc/discussions/32176)
+		if !enabled && lp.phasesConfigured == 0 && lp.hasPhaseSwitching() {
+			if err := lp.scalePhases(1); err != nil && !errors.Is(err, api.ErrNotAvailable) {
+				lp.log.ERROR.Println(err)
+			}
+		}
+
 		// start/stop vehicle wake-up timer
 		if enabled {
 			lp.startWakeUpTimer()

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -779,3 +779,44 @@ func TestPvScalePhasesCircuitLimits(t *testing.T) {
 		})
 	}
 }
+
+// TestScalePhasesOnDisable validates that disabling releases the phase switch relay
+func TestScalePhasesOnDisable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	plainCharger := api.NewMockCharger(ctrl)
+	phaseCharger := api.NewMockPhaseSwitcher(ctrl)
+
+	plainCharger.EXPECT().Enabled().Return(true, nil).AnyTimes()
+	plainCharger.EXPECT().MaxCurrent(gomock.Any()).Return(nil).AnyTimes()
+	plainCharger.EXPECT().Enable(false).Return(nil)
+	phaseCharger.EXPECT().Phases1p3p(1).Return(nil)
+
+	lp := &Loadpoint{
+		log:            util.NewLogger("foo"),
+		bus:            evbus.New(),
+		clock:          clock.NewMock(),
+		chargeMeter:    &Null{},
+		chargeRater:    &Null{},
+		chargeTimer:    &Null{},
+		progress:       NewProgress(0, 10),
+		wakeUpTimer:    NewTimer(),
+		mode:           api.ModePV,
+		minCurrent:     minA,
+		maxCurrent:     maxA,
+		phases:         3,
+		enabled:        true,
+		offeredCurrent: minA,
+		status:         api.StatusC,
+		charger: struct {
+			*api.MockCharger
+			*api.MockPhaseSwitcher
+		}{plainCharger, phaseCharger},
+	}
+
+	attachListeners(t, lp)
+
+	require.NoError(t, lp.setLimit(0))
+	require.Equal(t, 1, lp.GetPhases())
+}


### PR DESCRIPTION
Chargers with phase switching stay in 3p after charging ends, keeping the switching relay energized (~6W standby, https://github.com/evcc-io/evcc/discussions/32176).

Switch back to 1p when the charger is disabled, limited to automatic phase configuration (fixed 3p would be re-applied on the next cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)