### PR TITLE
Huawei SmartLogger: fix PV energy yield

### DIFF
--- a/templates/definition/meter/huawei-smartlogger.yaml
+++ b/templates/definition/meter/huawei-smartlogger.yaml
@@ -63,7 +63,7 @@ render: |
     id: 0
     uri: {{ joinHostPort .host .port }}
     register:
-      address: 40521 # Active power
+      address: 40521 # Input power
       type: holding
       decode: int32
   energy:
@@ -71,10 +71,10 @@ render: |
     id: 0
     uri: {{ joinHostPort .host .port }}
     register:
-      address: 40560 # E-Total
+      address: 40446 # Accumulated PV energy yield
       type: holding
-      decode: uint32
-    scale: 0.1
+      decode: int64
+    scale: 0.01
   maxacpower: {{ .maxacpower }}
   {{- end }}
   {{- if eq .usage "battery" }}


### PR DESCRIPTION
From the SmartLogger Modbus Definitions:

| Address | Description | Type | Gain |
| ------------- | ------------- | ------------- | ------------- |
| 40560 | Total energy yield | U32 | 10 |
| 40446 | Accumulated PV energy yield | I64 | 100 |

_Total energy yield_ is typically AC for Huawei and includes battery discharge, like in #30353 and #30352.

[SmartLogger Modbus Definitions (V300R025C10SPC220).pdf](https://github.com/user-attachments/files/30824601/SmartLogger.Modbus.Definitions.V300R025C10SPC220.pdf)

/cc @TW2A @premultiply 