### PR TITLE
pvnode: resample interval averages to power at slot start

### DIFF
--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -51,9 +51,10 @@ render: |
       token: {{ .apikey }}
     jq: |
       [.values[] |
+        # timestamp marks the end of the interval- values are the average power of the preceding 15 minutes
         {
-          start: (.timestamp),
-          end:   (.timestamp | fromdateiso8601 + 900 | todateiso8601 ),
+          start: (.timestamp | fromdateiso8601 - 900 | todateiso8601 ),
+          end:   (.timestamp),
           value: (.pv_power | round )
         }
       ] | tostring

--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -50,12 +50,15 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
-      [.values[] |
-        # timestamp marks the end of the interval- values are the average power of the preceding 15 minutes
-        {
-          start: (.timestamp | fromdateiso8601 - 900 | todateiso8601 ),
-          end:   (.timestamp),
-          value: (.pv_power | round )
-        }
-      ] | tostring
+      # values are the average power of the 15min interval ending at the timestamp.
+      # evcc expects the power at the timestamp, which is the mean of the intervals
+      # meeting there- the trailing interval is dropped as its successor is unknown.
+      [.values[] | {t: (.timestamp | fromdateiso8601), v: .pv_power}] as $s
+      | [ range(0; ($s|length)-1) |
+          {
+            start: ($s[.].t       | todateiso8601),
+            end:   ($s[.].t + 900 | todateiso8601),
+            value: ((($s[.].v + $s[.+1].v) / 2) | round)
+          }
+        ] | tostring
   interval: {{ .interval }}

--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -54,11 +54,15 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
-      [.values[] |
-        {
-          start: (.dtm | sub(" "; "T") + "Z"),
-          end:   (.dtm | sub(" "; "T") + "Z" | fromdateiso8601 + 900 | todateiso8601 ),
-          value: (.pv_watts | round )
-        }
-      ] | tostring
+      # values are the average power of the 15min interval ending at the timestamp.
+      # evcc expects the power at the timestamp, which is the mean of the intervals
+      # meeting there- the trailing interval is dropped as its successor is unknown.
+      [.values[] | {t: (.dtm | sub(" "; "T") + "Z" | fromdateiso8601), v: .pv_watts}] as $s
+      | [ range(0; ($s|length)-1) |
+          {
+            start: ($s[.].t       | todateiso8601),
+            end:   ($s[.].t + 900 | todateiso8601),
+            value: ((($s[.].v + $s[.+1].v) / 2) | round)
+          }
+        ] | tostring
   interval: {{ .interval }}

--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -55,9 +55,10 @@ render: |
       token: {{ .apikey }}
     jq: |
       [.values[] |
+        # timestamp marks the end of the interval- values are the average power of the preceding 15 minutes
         {
-          start: (.dtm | sub(" "; "T") + "Z"),
-          end:   (.dtm | sub(" "; "T") + "Z" | fromdateiso8601 + 900 | todateiso8601 ),
+          start: (.dtm | sub(" "; "T") + "Z" | fromdateiso8601 - 900 | todateiso8601 ),
+          end:   (.dtm | sub(" "; "T") + "Z"),
           value: (.pv_watts | round )
         }
       ] | tostring

--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -54,15 +54,11 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
-      # values are the average power of the 15min interval ending at the timestamp.
-      # evcc expects the power at the timestamp, which is the mean of the intervals
-      # meeting there- the trailing interval is dropped as its successor is unknown.
-      [.values[] | {t: (.dtm | sub(" "; "T") + "Z" | fromdateiso8601), v: .pv_watts}] as $s
-      | [ range(0; ($s|length)-1) |
-          {
-            start: ($s[.].t       | todateiso8601),
-            end:   ($s[.].t + 900 | todateiso8601),
-            value: ((($s[.].v + $s[.+1].v) / 2) | round)
-          }
-        ] | tostring
+      [.values[] |
+        {
+          start: (.dtm | sub(" "; "T") + "Z"),
+          end:   (.dtm | sub(" "; "T") + "Z" | fromdateiso8601 + 900 | todateiso8601 ),
+          value: (.pv_watts | round )
+        }
+      ] | tostring
   interval: {{ .interval }}

--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -54,12 +54,15 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
-      [.values[] |
-        # timestamp marks the end of the interval- values are the average power of the preceding 15 minutes
-        {
-          start: (.dtm | sub(" "; "T") + "Z" | fromdateiso8601 - 900 | todateiso8601 ),
-          end:   (.dtm | sub(" "; "T") + "Z"),
-          value: (.pv_watts | round )
-        }
-      ] | tostring
+      # values are the average power of the 15min interval ending at the timestamp.
+      # evcc expects the power at the timestamp, which is the mean of the intervals
+      # meeting there- the trailing interval is dropped as its successor is unknown.
+      [.values[] | {t: (.dtm | sub(" "; "T") + "Z" | fromdateiso8601), v: .pv_watts}] as $s
+      | [ range(0; ($s|length)-1) |
+          {
+            start: ($s[.].t       | todateiso8601),
+            end:   ($s[.].t + 900 | todateiso8601),
+            value: ((($s[.].v + $s[.+1].v) / 2) | round)
+          }
+        ] | tostring
   interval: {{ .interval }}


### PR DESCRIPTION
pvnode reports the **average power of the 15 minute interval ending at the timestamp**. Both templates read it as the power at the interval start (`start: ts`, `end: ts + 900`), so the whole forecast was shifted one quarter hour into the future.

Fixing the anchoring alone isn't enough: a period mean is the point value at the period *midpoint*, and evcc consumes `Value` as an instantaneous power sampled at `Start` (`core/solar.go` integrates trapezoidally between consecutive `Start`s). Shifting by half a slot would take the slots off the quarter-hour grid that `Rates.At()`, `persistTariffs` and the optimizer align to via `Truncate(SlotDuration)`.

The timestamps are already grid points though, and each one is the boundary between the interval ending there and the one starting there, so the power at that instant is the mean of the two:

```
p(t_k) = (V_k + V_{k+1}) / 2
```

A two-tap centred filter — exact for a linear signal, mildly smoothing on curvature, and stable (unlike exact deconvolution `p_k = 2*V_k - p_{k-1}`, which amplifies alternating error and goes negative on noise). Slots stay grid-aligned at 900s, so `SlotWrapper` passes them through untouched. Costs the trailing interval, whose successor is unknown — night for a solar forecast.

Energy is preserved: evcc's trapezoid over the resampled series gives `(V_k + 2*V_{k+1} + V_{k+2})/4` per slot, so a single peak slot is slightly clipped, but the kernel telescopes and the daily total is exact up to a boundary term that vanishes when the series starts and ends at zero. Checked against a `0,100,300,600,900` ramp: 475Wh either way.

Affects `pvnode` (v1, `.dtm`/`.pv_watts`) and `pvnode-v2` (`.timestamp`/`.pv_power`).
