### PR TITLE
Fronius: fix Verto battery/PV readings in fronius-gen24 template (mppt3 param)

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -6,6 +6,9 @@ products:
   - brand: Fronius
     description:
       generic: Primo GEN24 Plus
+  - brand: Fronius
+    description:
+      generic: Verto Plus
 capabilities: ["battery-control"]
 requirements:
   description:
@@ -31,6 +34,15 @@ params:
       generic: Integer
     deprecated: true
   - name: maxacpower
+  - name: mppt3
+    type: bool
+    default: false
+    description:
+      de: Dritter PV-Eingang
+      en: Third PV input
+    help:
+      de: "Wechselrichter mit drei PV-Eingängen (z. B. Verto): Speicher liegt auf SunSpec-Modul 4/5 statt 3/4."
+      en: "Inverters with three PV inputs (e.g. Verto): storage is at SunSpec module 4/5 instead of 3/4."
   - preset: battery-params
   - name: maxchargerate
 render: |
@@ -154,6 +166,12 @@ render: |
       uri: {{ joinHostPort .host .port }}
       id: 1
       value: 160:2:DCW # mppt 2
+    {{- if eq .mppt3 "true" }}
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: 1
+      value: 160:3:DCW # mppt 3
+    {{- end }}
   energy:
     source: calc
     add:
@@ -167,32 +185,42 @@ render: |
       id: 1
       value: 160:2:DCWH # mppt 2
       scale: 0.001
+    {{- if eq .mppt3 "true" }}
+    - source: sunspec
+      uri: {{ joinHostPort .host .port }}
+      id: 1
+      value: 160:3:DCWH # mppt 3
+      scale: 0.001
+    {{- end }}
   maxacpower: {{ .maxacpower }} # W
   {{- end }}
   {{- if eq .usage "battery" }}
+  {{- /* storage modules follow the PV inputs: charge/discharge at 3/4 (two MPPTs) or 4/5 (three MPPTs, e.g. Verto) */}}
+  {{- $cha := "3" }}{{- $dis := "4" }}
+  {{- if eq .mppt3 "true" }}{{- $cha = "4" }}{{- $dis = "5" }}{{- end }}
   power:
     source: calc
     add:
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: 1
-      value: 160:3:DCW # mppt 3 charge
+      value: 160:{{ $cha }}:DCW # storage charge
       scale: -1
     - source: sunspec
       uri: {{ joinHostPort .host .port }}
       id: 1
-      value: 160:4:DCW # mppt 4 discharge
+      value: 160:{{ $dis }}:DCW # storage discharge
   energy:
     source: sunspec
     uri: {{ joinHostPort .host .port }}
     id: 1
-    value: 160:4:DCWH # mppt 4 (discharge)
+    value: 160:{{ $dis }}:DCWH # storage (discharge)
     scale: 0.001
   returnenergy:
     source: sunspec
     uri: {{ joinHostPort .host .port }}
     id: 1
-    value: 160:3:DCWH # mppt 3 (charge)
+    value: 160:{{ $cha }}:DCWH # storage (charge)
     scale: 0.001
   soc:
     source: sunspec


### PR DESCRIPTION
## Problem

The `fronius-gen24` template assumes two PV inputs and hardcodes the SunSpec model 160 storage modules at indices 3/4. **Fronius Verto** inverters have **three PV inputs**, which shifts the storage modules to 4/5. On a Verto the template therefore:

- reads **PV string 3 as battery charge power** — evcc showed `battery.power = -492 W` ("charging") while the inverter was actually discharging **16,577 W** through `StDisCha`
- **misses the third PV string** entirely in pv power/energy

SOC (model 124, model-addressed) and battery *control* (model 124 points) are position-independent and work fine — which masks the bug: charging commands succeed, SOC looks plausible, only the power/energy numbers are silently wrong. Likely the root cause of #22591 (closed as not planned), related to #18479 / discussion #22598.

## Evidence

Raw model-160 walk on a Verto 17.5 Plus (FW 1.39.5-1, 2× Reserva, unit 1) while evcc reported −492 W:

```
[1] MPPT 1        366 W    8178.0 kWh
[2] MPPT 2        359 W    8181.7 kWh
[3] MPPT 3        360 W    8170.5 kWh   <- template reads this as "battery charge"
[4] StCha 4         0 W    9964.0 kWh   <- template reads this as "battery discharge"
[5] StDisCha 5  16577 W    9338.3 kWh   <- actual discharge, never read
```

evcc's `battery.energy` equaled module 4's lifetime counter (9964.03 kWh) exactly, confirming the off-by-one binding.

## Fix

New bool param `mppt3` (default `false`, same pattern as `solax.yaml`):

- `pv`: adds `160:3` DCW/DCWH
- `battery`: storage charge/discharge at `160:4`/`160:5` (DCW + DCWH)
- products: adds **Fronius Verto Plus**

Default rendering is byte-identical to before — no behavior change for existing GEN24/Primo/Tauro configs. Battery control block unchanged.

## Verification

Live installation (Verto 17.5 Plus + 2× Reserva, 2026-08-07/08): the `mppt3: true` battery rendering matches the raw registers to within 0.5 % (16,440 W vs 16,529 W sampled seconds apart, SOC 20.6 % vs 20.40 %), sign convention correct (positive = discharge), `capacity`/`controllable` intact, battery control (external batterymode incl. grid charge) verified working. Grid meter values on the same site were cross-checked against the DSO's metering data by the operator. Template test suite passes; `mppt3` unset renders unchanged.

Closes #22591