### PR TITLE
UI Charts: show/hide tooltips on touch

### DIFF
--- a/assets/js/components/Battery/BatteryHistoryChart.vue
+++ b/assets/js/components/Battery/BatteryHistoryChart.vue
@@ -9,7 +9,7 @@ import {
 	FONT_FAMILY,
 	forecastXAxes,
 	forecastYAxis,
-	registerTouchTooltipReset,
+	registerTouchTooltip,
 	tooltipStyle,
 	tooltipTable,
 	type TooltipRow,
@@ -242,7 +242,7 @@ export default defineComponent({
 		const el = this.$refs["chartEl"] as HTMLElement;
 		this.chart = markRaw(echarts.init(el));
 		this.chart.setOption(this.chartOption);
-		registerTouchTooltipReset(this.chart, el);
+		registerTouchTooltip(this.chart, el);
 		this.$nextTick(() => this.updateGraphic());
 		window.addEventListener("resize", this.resize);
 		// initial render done here (not via the watcher), so paging animates from the first click

--- a/assets/js/components/Forecast/chartMixin.ts
+++ b/assets/js/components/Forecast/chartMixin.ts
@@ -1,5 +1,5 @@
 import { defineComponent, markRaw } from "vue";
-import { echarts, registerTouchTooltipReset } from "./echarts";
+import { echarts, registerTouchTooltip } from "./echarts";
 import "./chartStyles.css";
 
 // chartOption is provided by each consuming component's computed
@@ -63,7 +63,7 @@ export default defineComponent({
       this.chart.on("hideTip", () => {
         this.tooltipVisible = false;
       });
-      registerTouchTooltipReset(this.chart, el, () => (this.tooltipVisible = false));
+      registerTouchTooltip(this.chart, el, () => (this.tooltipVisible = false));
     },
   },
 });

--- a/assets/js/components/Forecast/echarts.ts
+++ b/assets/js/components/Forecast/echarts.ts
@@ -1,5 +1,6 @@
 import * as echarts from "echarts/core";
 import colors from "@/colors";
+import { attachTouchTooltipGate } from "@/utils/swipe";
 import escapeHtml from "@/utils/escapeHtml";
 import type { UiForecastSlot } from "@/types/evcc";
 import { BarChart, LineChart } from "echarts/charts";
@@ -117,18 +118,16 @@ export function tooltipStyle(
   };
 }
 
-// hide tooltip when finger lifts; mouse hover unchanged
-export function registerTouchTooltipReset(
+// touch tooltips: show on dwell, follow the finger, hide when it lifts; mouse hover unchanged
+export function registerTouchTooltip(
   chart: Pick<echarts.ECharts, "dispatchAction">,
   el: HTMLElement,
   onReset?: () => void
 ) {
-  const reset = () => {
+  attachTouchTooltipGate(el, () => {
     chart.dispatchAction({ type: "hideTip" });
     onReset?.();
-  };
-  el.addEventListener("touchend", reset);
-  el.addEventListener("touchcancel", reset);
+  });
 }
 
 export interface TooltipRow {

--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -11,7 +11,7 @@ import {
 	FONT_FAMILY,
 	forecastGrid,
 	forecastYAxis,
-	registerTouchTooltipReset,
+	registerTouchTooltip,
 	tooltipStyle,
 	tooltipTable,
 	xAxisLabelStyle,
@@ -720,7 +720,7 @@ export default defineComponent({
 		const zr = this.chart.getZr();
 		zr.on("mousemove", this.onChartMouseMove);
 		zr.on("globalout", this.clearHighlight);
-		registerTouchTooltipReset(this.chart, el, this.clearHighlight);
+		registerTouchTooltip(this.chart, el, this.clearHighlight);
 		this.mediaQuery = window.matchMedia("(max-width: 575.98px)");
 		this.isMobile = this.mediaQuery.matches;
 		this.mediaQuery.addEventListener("change", this.onMediaChange);

--- a/assets/js/components/Optimize/ChargeChart.vue
+++ b/assets/js/components/Optimize/ChargeChart.vue
@@ -37,7 +37,7 @@ import formatter from "@/mixins/formatter";
 import colors from "@/colors";
 import LegendList from "../Sessions/LegendList.vue";
 import type { Legend } from "../Sessions/types";
-import { touchDismissPlugin } from "../Sessions/chartConfig";
+import "../Sessions/chartConfig";
 
 ChartJS.register(
 	CategoryScale,
@@ -49,8 +49,7 @@ ChartJS.register(
 	PointElement,
 	Title,
 	Tooltip,
-	ChartLegendPlugin,
-	touchDismissPlugin
+	ChartLegendPlugin
 );
 
 export default defineComponent({

--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -35,7 +35,7 @@ import formatter from "@/mixins/formatter";
 import colors from "@/colors";
 import LegendList from "../Sessions/LegendList.vue";
 import type { Legend } from "../Sessions/types";
-import { touchDismissPlugin } from "../Sessions/chartConfig";
+import "../Sessions/chartConfig";
 
 const tension = 0;
 
@@ -47,8 +47,7 @@ ChartJS.register(
 	PointElement,
 	Title,
 	Tooltip,
-	ChartLegendPlugin,
-	touchDismissPlugin
+	ChartLegendPlugin
 );
 
 export default defineComponent({

--- a/assets/js/components/Optimize/SocChart.vue
+++ b/assets/js/components/Optimize/SocChart.vue
@@ -41,17 +41,9 @@ import type { EvoptData } from "./TimeSeriesDataTable.vue";
 import type { CURRENCY, BatteryDetail } from "@/types/evcc";
 import formatter from "@/mixins/formatter";
 import colors from "@/colors";
-import { touchDismissPlugin } from "../Sessions/chartConfig";
+import "../Sessions/chartConfig";
 
-ChartJS.register(
-	CategoryScale,
-	LinearScale,
-	BarElement,
-	Title,
-	Tooltip,
-	ChartLegendPlugin,
-	touchDismissPlugin
-);
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, ChartLegendPlugin);
 
 export default defineComponent({
 	name: "SocChart",

--- a/assets/js/components/Sessions/chartConfig.ts
+++ b/assets/js/components/Sessions/chartConfig.ts
@@ -8,6 +8,7 @@ import {
   type TooltipItem,
 } from "chart.js";
 import colors from "@/colors";
+import { attachTouchTooltipGate } from "@/utils/swipe";
 import type { Context } from "chartjs-plugin-datalabels";
 // Register common components
 export function registerChartComponents(components: ChartComponentLike[]) {
@@ -21,18 +22,16 @@ Chart.defaults.font.family = window
 Chart.defaults.font.size = 14;
 Chart.defaults.layout.padding = 0;
 
-// hide tooltip when finger lifts; mouse hover unchanged
-export const touchDismissPlugin: Plugin = {
+// touch tooltips: show on dwell, follow the finger, hide when it lifts; mouse hover unchanged
+const touchDismissPlugin: Plugin = {
   id: "touchDismiss",
   afterInit(chart) {
-    const dismiss = () => {
+    attachTouchTooltipGate(chart.canvas.parentElement ?? chart.canvas, () => {
       if (!chart.ctx) return; // destroyed
       chart.setActiveElements([]);
       chart.tooltip?.setActiveElements([], { x: 0, y: 0 });
       chart.update();
-    };
-    chart.canvas.addEventListener("touchend", dismiss);
-    chart.canvas.addEventListener("touchcancel", dismiss);
+    });
   },
 };
 Chart.register(touchDismissPlugin);

--- a/assets/js/utils/swipe.ts
+++ b/assets/js/utils/swipe.ts
@@ -6,6 +6,106 @@ interface SwipeOptions {
   maxDuration?: number;
 }
 
+const DWELL_MS = 100;
+const DWELL_SLOP_PX = 10;
+
+// Touch tooltip gate: the chart never sees raw touch events (zrender would otherwise
+// ignore mouse events for 700ms after every touchend). The tooltip appears only after
+// the finger rests for a moment, then follows it; fast movement (swipes, scrolling)
+// keeps it hidden and a pause re-arms it. The tooltip is driven by a synthetic
+// mousemove at the finger position, which both chart libs handle natively.
+export function attachTouchTooltipGate(el: HTMLElement, hide: () => void): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let shown = false;
+  let latched = false;
+  let x = 0;
+  let y = 0;
+  let anchorX = 0;
+  let anchorY = 0;
+  let gestureX = 0;
+  let gestureY = 0;
+
+  const show = () => {
+    const target = document.elementFromPoint(x, y);
+    if (!target || !el.contains(target)) return;
+    shown = true;
+    const event = new MouseEvent("mousemove", { clientX: x, clientY: y, bubbles: true });
+    // WebKit computes offsetX/Y of synthetic events against the wrong base element,
+    // and both chart libs read them; provide correct values relative to the chart
+    const rect = el.getBoundingClientRect();
+    Object.defineProperty(event, "offsetX", { value: x - rect.left });
+    Object.defineProperty(event, "offsetY", { value: y - rect.top });
+    target.dispatchEvent(event);
+  };
+
+  const restartDwell = () => {
+    if (timer) clearTimeout(timer);
+    anchorX = x;
+    anchorY = y;
+    timer = setTimeout(show, DWELL_MS);
+  };
+
+  const onTouchStart = (e: TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    e.stopPropagation();
+    shown = false;
+    latched = false;
+    x = touch.clientX;
+    y = touch.clientY;
+    gestureX = x;
+    gestureY = y;
+    restartDwell();
+  };
+
+  const onTouchMove = (e: TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    e.stopPropagation();
+    x = touch.clientX;
+    y = touch.clientY;
+    // large displacement before the tooltip ever showed = scroll or swipe,
+    // no tooltip for the rest of this gesture (scroll deceleration would
+    // otherwise pass the dwell check while the page is still moving)
+    if (!shown && !latched && Math.hypot(x - gestureX, y - gestureY) > 30) {
+      latched = true;
+      if (timer) clearTimeout(timer);
+    }
+    if (latched) return;
+    if (shown) {
+      show();
+    } else if (Math.hypot(x - anchorX, y - anchorY) > DWELL_SLOP_PX) {
+      restartDwell();
+    }
+  };
+
+  const onTouchEnd = (e: TouchEvent) => {
+    e.stopPropagation();
+    // suppress compat mouse events after touch, they would re-trigger the tooltip
+    if (e.cancelable) e.preventDefault();
+    if (timer) clearTimeout(timer);
+    shown = false;
+    hide();
+  };
+
+  // long-press must not start text selection of chart or tooltip content
+  el.classList.add("user-select-none");
+
+  el.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
+  el.addEventListener("touchmove", onTouchMove, { capture: true, passive: true });
+  el.addEventListener("touchend", onTouchEnd, { capture: true });
+  el.addEventListener("touchcancel", onTouchEnd, { capture: true });
+
+  return () => {
+    if (timer) clearTimeout(timer);
+    el.classList.remove("user-select-none");
+    el.removeEventListener("touchstart", onTouchStart, { capture: true });
+    el.removeEventListener("touchmove", onTouchMove, { capture: true });
+    el.removeEventListener("touchend", onTouchEnd, { capture: true });
+    el.removeEventListener("touchcancel", onTouchEnd, { capture: true });
+  };
+}
+
 export function attachSwipeHandler(el: HTMLElement, options: SwipeOptions): () => void {
   const minDistance = options.minDistance ?? 60;
   const maxDuration = options.maxDuration ?? 600;


### PR DESCRIPTION
Follow-up to #32603. Chart tooltips on touch devices now behave like a native scrubber (history, battery, sessions, optimizer, forecast).

📊 Rest your finger on a chart and the tooltip appears; slide slowly to inspect values; lift to dismiss.
🚫 No more tooltip flashing when swiping or scrolling across a chart.
🧹 No more stale tooltips or stuck bar highlights when touching several charts in a row.
📱 Fixes tooltips not appearing in the iOS app (WebKit reports wrong coordinates for synthetic events).
✋ Long-press no longer selects chart or tooltip text.

Sessions and optimizer still render with chart.js (legacy, to be replaced by echarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)