### PR TITLE
UI Charts: swipe on charts to switch time range

### DIFF
--- a/assets/js/components/Battery/BatteryHistoryCard.vue
+++ b/assets/js/components/Battery/BatteryHistoryCard.vue
@@ -5,6 +5,8 @@
 				:label="windowLabel"
 				:prev-disabled="prevDisabled"
 				:next-disabled="nextDisabled"
+				:highlight-prev="highlightPrev"
+				:highlight-next="highlightNext"
 				@prev="changeOffset(-1)"
 				@next="changeOffset(1)"
 			/>
@@ -44,6 +46,8 @@ import { batteryColor } from "@/colors";
 import type { Legend } from "../Sessions/types";
 import type { BatterySeries } from "./types";
 import Card from "../Helper/Card.vue";
+import { attachSwipeHandler } from "@/utils/swipe";
+import { hapticFeedback } from "@/utils/haptic";
 import SelectGroup from "../Helper/SelectGroup.vue";
 import LegendList from "../Sessions/LegendList.vue";
 import WindowNav from "./WindowNav.vue";
@@ -71,6 +75,10 @@ export default defineComponent({
 			dayOffset: 0,
 			focusedBattery: null as number | null,
 			selectedUnit: (settings.batteryUnit || "soc") as "soc" | "energy",
+			highlightPrev: false,
+			highlightNext: false,
+			highlightTimer: null as ReturnType<typeof setTimeout> | null,
+			detachSwipe: null as (() => void) | null,
 		};
 	},
 	computed: {
@@ -145,7 +153,32 @@ export default defineComponent({
 			}
 		},
 	},
+	mounted() {
+		this.detachSwipe = attachSwipeHandler(this.$el as HTMLElement, {
+			onSwipeLeft: () => this.swipe(1),
+			onSwipeRight: () => this.swipe(-1),
+		});
+	},
+	unmounted() {
+		this.detachSwipe?.();
+		if (this.highlightTimer) clearTimeout(this.highlightTimer);
+	},
 	methods: {
+		swipe(dir: number) {
+			if (dir < 0 ? this.prevDisabled : this.nextDisabled) return;
+			this.changeOffset(dir);
+			this.flashHighlight(dir < 0 ? "prev" : "next");
+			hapticFeedback("medium");
+		},
+		flashHighlight(dir: "prev" | "next") {
+			if (this.highlightTimer) clearTimeout(this.highlightTimer);
+			this.highlightPrev = dir === "prev";
+			this.highlightNext = dir === "next";
+			this.highlightTimer = setTimeout(() => {
+				this.highlightPrev = false;
+				this.highlightNext = false;
+			}, 300);
+		},
 		updateUnit(value: string | number | boolean | null) {
 			this.selectedUnit = value === "energy" ? "energy" : "soc";
 			settings.batteryUnit = this.selectedUnit;

--- a/assets/js/components/Battery/BatteryHistoryChart.vue
+++ b/assets/js/components/Battery/BatteryHistoryChart.vue
@@ -9,7 +9,7 @@ import {
 	FONT_FAMILY,
 	forecastXAxes,
 	forecastYAxis,
-	registerTouchTooltipReset,
+	registerTouchTooltip,
 	tooltipStyle,
 	tooltipTable,
 	type TooltipRow,
@@ -242,7 +242,7 @@ export default defineComponent({
 		const el = this.$refs["chartEl"] as HTMLElement;
 		this.chart = markRaw(echarts.init(el));
 		this.chart.setOption(this.chartOption);
-		registerTouchTooltipReset(this.chart, el);
+		registerTouchTooltip(this.chart, el);
 		this.$nextTick(() => this.updateGraphic());
 		window.addEventListener("resize", this.resize);
 		// initial render done here (not via the watcher), so paging animates from the first click

--- a/assets/js/components/Battery/WindowNav.vue
+++ b/assets/js/components/Battery/WindowNav.vue
@@ -3,6 +3,7 @@
 		<DateNavigatorButton
 			prev
 			:disabled="prevDisabled"
+			:highlight="highlightPrev"
 			:on-click="() => $emit('prev')"
 			data-testid="battery-chart-prev"
 		/>
@@ -12,6 +13,7 @@
 		<DateNavigatorButton
 			next
 			:disabled="nextDisabled"
+			:highlight="highlightNext"
 			:on-click="() => $emit('next')"
 			data-testid="battery-chart-next"
 		/>
@@ -29,6 +31,8 @@ export default defineComponent({
 		label: { type: String, default: "" },
 		prevDisabled: Boolean,
 		nextDisabled: Boolean,
+		highlightPrev: Boolean,
+		highlightNext: Boolean,
 	},
 	emits: ["prev", "next"],
 });

--- a/assets/js/components/Forecast/chartMixin.ts
+++ b/assets/js/components/Forecast/chartMixin.ts
@@ -1,5 +1,5 @@
 import { defineComponent, markRaw } from "vue";
-import { echarts, registerTouchTooltipReset } from "./echarts";
+import { echarts, registerTouchTooltip } from "./echarts";
 import "./chartStyles.css";
 
 // chartOption is provided by each consuming component's computed
@@ -63,7 +63,7 @@ export default defineComponent({
       this.chart.on("hideTip", () => {
         this.tooltipVisible = false;
       });
-      registerTouchTooltipReset(this.chart, el, () => (this.tooltipVisible = false));
+      registerTouchTooltip(this.chart, el, () => (this.tooltipVisible = false));
     },
   },
 });

--- a/assets/js/components/Forecast/echarts.ts
+++ b/assets/js/components/Forecast/echarts.ts
@@ -1,5 +1,6 @@
 import * as echarts from "echarts/core";
 import colors from "@/colors";
+import { attachTouchTooltipGate } from "@/utils/swipe";
 import escapeHtml from "@/utils/escapeHtml";
 import type { UiForecastSlot } from "@/types/evcc";
 import { BarChart, LineChart } from "echarts/charts";
@@ -117,18 +118,16 @@ export function tooltipStyle(
   };
 }
 
-// hide tooltip when finger lifts; mouse hover unchanged
-export function registerTouchTooltipReset(
+// touch tooltips: show on dwell, follow the finger, hide when it lifts; mouse hover unchanged
+export function registerTouchTooltip(
   chart: Pick<echarts.ECharts, "dispatchAction">,
   el: HTMLElement,
   onReset?: () => void
 ) {
-  const reset = () => {
+  attachTouchTooltipGate(el, () => {
     chart.dispatchAction({ type: "hideTip" });
     onReset?.();
-  };
-  el.addEventListener("touchend", reset);
-  el.addEventListener("touchcancel", reset);
+  });
 }
 
 export interface TooltipRow {

--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -11,7 +11,7 @@ import {
 	FONT_FAMILY,
 	forecastGrid,
 	forecastYAxis,
-	registerTouchTooltipReset,
+	registerTouchTooltip,
 	tooltipStyle,
 	tooltipTable,
 	xAxisLabelStyle,
@@ -720,7 +720,7 @@ export default defineComponent({
 		const zr = this.chart.getZr();
 		zr.on("mousemove", this.onChartMouseMove);
 		zr.on("globalout", this.clearHighlight);
-		registerTouchTooltipReset(this.chart, el, this.clearHighlight);
+		registerTouchTooltip(this.chart, el, this.clearHighlight);
 		this.mediaQuery = window.matchMedia("(max-width: 575.98px)");
 		this.isMobile = this.mediaQuery.matches;
 		this.mediaQuery.addEventListener("change", this.onMediaChange);

--- a/assets/js/components/Optimize/ChargeChart.vue
+++ b/assets/js/components/Optimize/ChargeChart.vue
@@ -37,7 +37,7 @@ import formatter from "@/mixins/formatter";
 import colors from "@/colors";
 import LegendList from "../Sessions/LegendList.vue";
 import type { Legend } from "../Sessions/types";
-import { touchDismissPlugin } from "../Sessions/chartConfig";
+import "../Sessions/chartConfig";
 
 ChartJS.register(
 	CategoryScale,
@@ -49,8 +49,7 @@ ChartJS.register(
 	PointElement,
 	Title,
 	Tooltip,
-	ChartLegendPlugin,
-	touchDismissPlugin
+	ChartLegendPlugin
 );
 
 export default defineComponent({

--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -35,7 +35,7 @@ import formatter from "@/mixins/formatter";
 import colors from "@/colors";
 import LegendList from "../Sessions/LegendList.vue";
 import type { Legend } from "../Sessions/types";
-import { touchDismissPlugin } from "../Sessions/chartConfig";
+import "../Sessions/chartConfig";
 
 const tension = 0;
 
@@ -47,8 +47,7 @@ ChartJS.register(
 	PointElement,
 	Title,
 	Tooltip,
-	ChartLegendPlugin,
-	touchDismissPlugin
+	ChartLegendPlugin
 );
 
 export default defineComponent({

--- a/assets/js/components/Optimize/SocChart.vue
+++ b/assets/js/components/Optimize/SocChart.vue
@@ -41,17 +41,9 @@ import type { EvoptData } from "./TimeSeriesDataTable.vue";
 import type { CURRENCY, BatteryDetail } from "@/types/evcc";
 import formatter from "@/mixins/formatter";
 import colors from "@/colors";
-import { touchDismissPlugin } from "../Sessions/chartConfig";
+import "../Sessions/chartConfig";
 
-ChartJS.register(
-	CategoryScale,
-	LinearScale,
-	BarElement,
-	Title,
-	Tooltip,
-	ChartLegendPlugin,
-	touchDismissPlugin
-);
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, ChartLegendPlugin);
 
 export default defineComponent({
 	name: "SocChart",

--- a/assets/js/components/Sessions/DateNavigator.vue
+++ b/assets/js/components/Sessions/DateNavigator.vue
@@ -146,6 +146,7 @@ import DateNavigatorButton from "./DateNavigatorButton.vue";
 import formatter from "@/mixins/formatter";
 import type { SelectOption } from "@/types/evcc";
 import { attachSwipeHandler } from "@/utils/swipe";
+import { hapticFeedback } from "@/utils/haptic";
 
 function daysInMonth(year: number, month: number) {
 	return new Date(year, month, 0).getDate();
@@ -279,7 +280,6 @@ export default defineComponent({
 		this.detachSwipe = attachSwipeHandler(document.body, {
 			onSwipeLeft: () => this.swipeNext(),
 			onSwipeRight: () => this.swipePrev(),
-			ignoreSelector: "canvas, [_echarts_instance_]",
 		});
 	},
 	unmounted() {
@@ -393,6 +393,7 @@ export default defineComponent({
 			else if (this.showYear && this.hasPrevYear) this.emitPrevYear();
 			else return;
 			this.flashHighlight("prev");
+			hapticFeedback("medium");
 		},
 		swipeNext() {
 			if (this.showDay && this.hasNextDay) this.emitNextDay();
@@ -400,6 +401,7 @@ export default defineComponent({
 			else if (this.showYear && this.hasNextYear) this.emitNextYear();
 			else return;
 			this.flashHighlight("next");
+			hapticFeedback("medium");
 		},
 	},
 });

--- a/assets/js/components/Sessions/chartConfig.ts
+++ b/assets/js/components/Sessions/chartConfig.ts
@@ -8,6 +8,7 @@ import {
   type TooltipItem,
 } from "chart.js";
 import colors from "@/colors";
+import { attachTouchTooltipGate } from "@/utils/swipe";
 import type { Context } from "chartjs-plugin-datalabels";
 // Register common components
 export function registerChartComponents(components: ChartComponentLike[]) {
@@ -21,18 +22,16 @@ Chart.defaults.font.family = window
 Chart.defaults.font.size = 14;
 Chart.defaults.layout.padding = 0;
 
-// hide tooltip when finger lifts; mouse hover unchanged
-export const touchDismissPlugin: Plugin = {
+// touch tooltips: show on dwell, follow the finger, hide when it lifts; mouse hover unchanged
+const touchDismissPlugin: Plugin = {
   id: "touchDismiss",
   afterInit(chart) {
-    const dismiss = () => {
+    attachTouchTooltipGate(chart.canvas.parentElement ?? chart.canvas, () => {
       if (!chart.ctx) return; // destroyed
       chart.setActiveElements([]);
       chart.tooltip?.setActiveElements([], { x: 0, y: 0 });
       chart.update();
-    };
-    chart.canvas.addEventListener("touchend", dismiss);
-    chart.canvas.addEventListener("touchcancel", dismiss);
+    });
   },
 };
 Chart.register(touchDismissPlugin);

--- a/assets/js/utils/haptic.ts
+++ b/assets/js/utils/haptic.ts
@@ -1,3 +1,4 @@
-export function hapticFeedback(): void {
-  navigator.vibrate?.(5);
+// the native app shims navigator.vibrate; duration maps to impact strength (<=50 light, <=100 medium)
+export function hapticFeedback(style: "light" | "medium" = "light"): void {
+  navigator.vibrate?.(style === "medium" ? 60 : 5);
 }

--- a/assets/js/utils/swipe.ts
+++ b/assets/js/utils/swipe.ts
@@ -6,6 +6,106 @@ interface SwipeOptions {
   maxDuration?: number;
 }
 
+const DWELL_MS = 100;
+const DWELL_SLOP_PX = 10;
+
+// Touch tooltip gate: the chart never sees raw touch events (zrender would otherwise
+// ignore mouse events for 700ms after every touchend). The tooltip appears only after
+// the finger rests for a moment, then follows it; fast movement (swipes, scrolling)
+// keeps it hidden and a pause re-arms it. The tooltip is driven by a synthetic
+// mousemove at the finger position, which both chart libs handle natively.
+export function attachTouchTooltipGate(el: HTMLElement, hide: () => void): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let shown = false;
+  let latched = false;
+  let x = 0;
+  let y = 0;
+  let anchorX = 0;
+  let anchorY = 0;
+  let gestureX = 0;
+  let gestureY = 0;
+
+  const show = () => {
+    const target = document.elementFromPoint(x, y);
+    if (!target || !el.contains(target)) return;
+    shown = true;
+    const event = new MouseEvent("mousemove", { clientX: x, clientY: y, bubbles: true });
+    // WebKit computes offsetX/Y of synthetic events against the wrong base element,
+    // and both chart libs read them; provide correct values relative to the chart
+    const rect = el.getBoundingClientRect();
+    Object.defineProperty(event, "offsetX", { value: x - rect.left });
+    Object.defineProperty(event, "offsetY", { value: y - rect.top });
+    target.dispatchEvent(event);
+  };
+
+  const restartDwell = () => {
+    if (timer) clearTimeout(timer);
+    anchorX = x;
+    anchorY = y;
+    timer = setTimeout(show, DWELL_MS);
+  };
+
+  const onTouchStart = (e: TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    e.stopPropagation();
+    shown = false;
+    latched = false;
+    x = touch.clientX;
+    y = touch.clientY;
+    gestureX = x;
+    gestureY = y;
+    restartDwell();
+  };
+
+  const onTouchMove = (e: TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    e.stopPropagation();
+    x = touch.clientX;
+    y = touch.clientY;
+    // large displacement before the tooltip ever showed = scroll or swipe,
+    // no tooltip for the rest of this gesture (scroll deceleration would
+    // otherwise pass the dwell check while the page is still moving)
+    if (!shown && !latched && Math.hypot(x - gestureX, y - gestureY) > 30) {
+      latched = true;
+      if (timer) clearTimeout(timer);
+    }
+    if (latched) return;
+    if (shown) {
+      show();
+    } else if (Math.hypot(x - anchorX, y - anchorY) > DWELL_SLOP_PX) {
+      restartDwell();
+    }
+  };
+
+  const onTouchEnd = (e: TouchEvent) => {
+    e.stopPropagation();
+    // suppress compat mouse events after touch, they would re-trigger the tooltip
+    if (e.cancelable) e.preventDefault();
+    if (timer) clearTimeout(timer);
+    shown = false;
+    hide();
+  };
+
+  // long-press must not start text selection of chart or tooltip content
+  el.classList.add("user-select-none");
+
+  el.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
+  el.addEventListener("touchmove", onTouchMove, { capture: true, passive: true });
+  el.addEventListener("touchend", onTouchEnd, { capture: true });
+  el.addEventListener("touchcancel", onTouchEnd, { capture: true });
+
+  return () => {
+    if (timer) clearTimeout(timer);
+    el.classList.remove("user-select-none");
+    el.removeEventListener("touchstart", onTouchStart, { capture: true });
+    el.removeEventListener("touchmove", onTouchMove, { capture: true });
+    el.removeEventListener("touchend", onTouchEnd, { capture: true });
+    el.removeEventListener("touchcancel", onTouchEnd, { capture: true });
+  };
+}
+
 export function attachSwipeHandler(el: HTMLElement, options: SwipeOptions): () => void {
   const minDistance = options.minDistance ?? 60;
   const maxDuration = options.maxDuration ?? 600;

--- a/assets/js/utils/swipe.ts
+++ b/assets/js/utils/swipe.ts
@@ -1,7 +1,6 @@
 interface SwipeOptions {
   onSwipeLeft?: () => void;
   onSwipeRight?: () => void;
-  ignoreSelector?: string;
   minDistance?: number;
   maxDuration?: number;
 }
@@ -119,8 +118,7 @@ export function attachSwipeHandler(el: HTMLElement, options: SwipeOptions): () =
       ignored = true;
       return;
     }
-    const target = e.target as Element | null;
-    ignored = !!(options.ignoreSelector && target?.closest(options.ignoreSelector));
+    ignored = false;
     startX = e.touches[0].clientX;
     startY = e.touches[0].clientY;
     startTime = Date.now();
@@ -139,11 +137,13 @@ export function attachSwipeHandler(el: HTMLElement, options: SwipeOptions): () =
     else options.onSwipeRight?.();
   };
 
-  el.addEventListener("touchstart", onTouchStart, { passive: true });
-  el.addEventListener("touchend", onTouchEnd, { passive: true });
+  // capture phase, so the touch tooltip gate's stopPropagation on chart elements
+  // cannot starve the swipe detection
+  el.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
+  el.addEventListener("touchend", onTouchEnd, { capture: true, passive: true });
 
   return () => {
-    el.removeEventListener("touchstart", onTouchStart);
-    el.removeEventListener("touchend", onTouchEnd);
+    el.removeEventListener("touchstart", onTouchStart, { capture: true });
+    el.removeEventListener("touchend", onTouchEnd, { capture: true });
   };
 }


### PR DESCRIPTION
Builds on #32613 (stacked PR, merge that one first). Switching the time range by swipe now works where your finger actually is: on the charts.

👉 Swipe left/right directly on history and sessions charts to change day, month or year; previously only the area outside the charts reacted, which felt broken.
🔋 Battery page: swipe on the chart card to page through days; the nav arrows nudge as confirmation.
📳 Every successful switch triggers medium haptic feedback in the app (uses the existing vibrate bridge, no app update needed).
🔭 Forecast and optimizer keep their horizontal chart scrolling; no new gestures there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)