### PR TITLE
Optimizer: add feasible status

### DIFF
--- a/assets/js/components/Config/StatusIndicator.vue
+++ b/assets/js/components/Config/StatusIndicator.vue
@@ -16,7 +16,7 @@
 import { defineComponent, type PropType } from "vue";
 import Tooltip from "bootstrap/js/dist/tooltip";
 
-type Variant = "success" | "warning" | "muted";
+type Variant = "success" | "warning" | "danger" | "muted";
 
 export default defineComponent({
 	name: "StatusIndicator",
@@ -34,6 +34,8 @@ export default defineComponent({
 					return "bg-success";
 				case "warning":
 					return "bg-warning";
+				case "danger":
+					return "bg-danger";
 				default:
 					return "border border-secondary";
 			}

--- a/assets/js/components/Optimize/OptimizeHeader.stories.ts
+++ b/assets/js/components/Optimize/OptimizeHeader.stories.ts
@@ -41,6 +41,10 @@ Payment.args = { ...base, status: OptimizationStatus.OPTIMAL, netCost: 12.4 };
 export const Credit = Template.bind({});
 Credit.args = { ...base, status: OptimizationStatus.OPTIMAL, netCost: -3.8 };
 
+// usable but not proven optimal plan
+export const Feasible = Template.bind({});
+Feasible.args = { ...base, status: OptimizationStatus.FEASIBLE, netCost: 12.4 };
+
 // solver could not produce a plan
 export const Infeasible = Template.bind({});
 Infeasible.args = { ...base, status: OptimizationStatus.INFEASIBLE, netCost: 0 };

--- a/assets/js/components/Optimize/OptimizeHeader.vue
+++ b/assets/js/components/Optimize/OptimizeHeader.vue
@@ -5,13 +5,19 @@
 			<!-- Primary goal -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div class="field-label small text-uppercase fw-bold evcc-gray">
+					<div
+						class="field-label small text-uppercase fw-bold evcc-gray"
+					>
 						Primary goal
 					</div>
-					<div class="field-caption small evcc-gray mt-1">always, fixed</div>
+					<div class="field-caption small evcc-gray mt-1">
+						always, fixed
+					</div>
 				</div>
 				<div class="field-value gap-2">
-					<span class="large fw-bold text-lowercase evcc-default-text">Lowest cost</span>
+					<span class="large fw-bold text-lowercase evcc-default-text"
+						>Lowest cost</span
+					>
 					<LockIcon class="value-icon" />
 				</div>
 			</div>
@@ -19,10 +25,14 @@
 			<!-- Secondary goal (only interactive setting) -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div class="field-label small text-uppercase fw-bold evcc-gray">
+					<div
+						class="field-label small text-uppercase fw-bold evcc-gray"
+					>
 						Secondary goal
 					</div>
-					<div class="field-caption small evcc-gray mt-1">only on a tie</div>
+					<div class="field-caption small evcc-gray mt-1">
+						only on a tie
+					</div>
 				</div>
 				<div class="field-value gap-2">
 					<CustomSelect
@@ -42,10 +52,18 @@
 			<!-- Result -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div class="field-label small text-uppercase fw-bold evcc-gray">Result</div>
+					<div
+						class="field-label small text-uppercase fw-bold evcc-gray"
+					>
+						Result
+					</div>
 					<div class="field-caption small evcc-gray mt-1">
-						<span v-if="relativeTime" class="tabular">{{ relativeTime }}, </span>
-						<span v-if="pending" class="updating fw-bold text-decoration-underline"
+						<span v-if="relativeTime" class="tabular"
+							>{{ relativeTime }},
+						</span>
+						<span
+							v-if="pending"
+							class="updating fw-bold text-decoration-underline"
 							>updating…</span
 						>
 						<button
@@ -60,9 +78,10 @@
 				</div>
 				<div class="field-value gap-2">
 					<StatusIndicator :variant="statusVariant">
-						<span class="large fw-bold text-lowercase evcc-default-text">{{
-							status
-						}}</span>
+						<span
+							class="large fw-bold text-lowercase evcc-default-text"
+							>{{ status }}</span
+						>
 					</StatusIndicator>
 					<span
 						ref="statusInfo"
@@ -79,7 +98,9 @@
 			<!-- Net grid cost -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div class="field-label small text-uppercase fw-bold evcc-gray">
+					<div
+						class="field-label small text-uppercase fw-bold evcc-gray"
+					>
 						Net grid cost
 					</div>
 					<div class="field-caption small evcc-gray mt-1">
@@ -150,11 +171,17 @@ export default defineComponent({
 	mixins: [formatter, minuteTicker],
 	props: {
 		updated: { type: String, default: "" },
-		status: { type: String as PropType<OptimizationStatus>, default: undefined },
+		status: {
+			type: String as PropType<OptimizationStatus>,
+			default: undefined,
+		},
 		netCost: { type: Number, default: 0 },
 		horizonHours: { type: Number, default: 0 },
 		currency: { type: String as PropType<CURRENCY>, default: CURRENCY.EUR },
-		chargingStrategies: { type: Array as PropType<string[]>, default: () => [] },
+		chargingStrategies: {
+			type: Array as PropType<string[]>,
+			default: () => [],
+		},
 		selectedStrategy: { type: String, default: "" },
 		pending: { type: Boolean, default: false },
 	},
@@ -172,17 +199,21 @@ export default defineComponent({
 			}));
 		},
 		secondaryGoalLabel(): string {
-			return STRATEGY_LABELS[this.selectedStrategy] || this.selectedStrategy;
+			return (
+				STRATEGY_LABELS[this.selectedStrategy] || this.selectedStrategy
+			);
 		},
 		relativeTime(): string {
 			if (!this.updated) return "";
-			const elapsed = new Date(this.updated).getTime() - this.everyMinute.getTime();
+			const elapsed =
+				new Date(this.updated).getTime() - this.everyMinute.getTime();
 			if (Math.abs(elapsed) < 60 * 1000) return "just now";
 			return this.fmtTimeAgo(elapsed);
 		},
 		statusVariant(): "success" | "warning" | "muted" {
 			switch (this.status) {
 				case OptimizationStatus.OPTIMAL:
+				case OptimizationStatus.FEASIBLE:
 					return "success";
 				case OptimizationStatus.INFEASIBLE:
 				case OptimizationStatus.UNBOUNDED:
@@ -206,11 +237,17 @@ export default defineComponent({
 	},
 	methods: {
 		onStrategyChange(e: Event) {
-			this.$emit("change-strategy", (e.target as HTMLSelectElement).value);
+			this.$emit(
+				"change-strategy",
+				(e.target as HTMLSelectElement).value,
+			);
 		},
 		initTooltips() {
 			const items: [Element | undefined, string][] = [
-				[this.$refs["statusInfo"] as Element | undefined, STATUS_TOOLTIP],
+				[
+					this.$refs["statusInfo"] as Element | undefined,
+					STATUS_TOOLTIP,
+				],
 				[this.$refs["costInfo"] as Element | undefined, COST_TOOLTIP],
 			];
 			for (const [el, title] of items) {
@@ -220,7 +257,7 @@ export default defineComponent({
 						new Tooltip(el, {
 							title: `<div class="text-start">${title}</div>`,
 							html: true,
-						})
+						}),
 					);
 				}
 			}

--- a/assets/js/components/Optimize/OptimizeHeader.vue
+++ b/assets/js/components/Optimize/OptimizeHeader.vue
@@ -132,6 +132,7 @@ const STRATEGY_LABELS: Record<string, string> = {
 const STATUS_TOOLTIP =
 	"The optimizer result:<br><br>" +
 	"<strong>Optimal</strong>: the best plan was found.<br>" +
+	"<strong>Feasible</strong>: a usable plan was found, but not proven optimal.<br>" +
 	"<strong>Infeasible</strong>: the constraints cannot all be met.<br>" +
 	"<strong>Not solved</strong>: optimization hasn't finished yet.";
 

--- a/assets/js/components/Optimize/OptimizeHeader.vue
+++ b/assets/js/components/Optimize/OptimizeHeader.vue
@@ -11,7 +11,9 @@
 					<div class="field-caption small evcc-gray mt-1">always, fixed</div>
 				</div>
 				<div class="field-value gap-2">
-					<span class="large fw-bold text-lowercase evcc-default-text">Lowest cost</span>
+					<span class="value-text fw-bold text-lowercase evcc-default-text"
+						>Lowest cost</span
+					>
 					<LockIcon class="value-icon" />
 				</div>
 			</div>
@@ -32,7 +34,7 @@
 						@change="onStrategyChange"
 					>
 						<span
-							class="large fw-bold text-lowercase evcc-default-text secondary-goal"
+							class="value-text fw-bold text-lowercase evcc-default-text secondary-goal"
 							>{{ secondaryGoalLabel }}</span
 						>
 					</CustomSelect>
@@ -60,7 +62,7 @@
 				</div>
 				<div class="field-value gap-2">
 					<StatusIndicator :variant="statusVariant">
-						<span class="large fw-bold text-lowercase evcc-default-text">{{
+						<span class="value-text fw-bold text-lowercase evcc-default-text">{{
 							status
 						}}</span>
 					</StatusIndicator>
@@ -88,7 +90,7 @@
 				</div>
 				<div class="field-value gap-2">
 					<span
-						class="fs-4 fw-bold tabular"
+						class="value-text fw-bold tabular"
 						:class="isCredit ? 'text-primary' : 'evcc-default-text'"
 					>
 						{{ netCostDisplay }}
@@ -181,14 +183,15 @@ export default defineComponent({
 			if (Math.abs(elapsed) < 60 * 1000) return "just now";
 			return this.fmtTimeAgo(elapsed);
 		},
-		statusVariant(): "success" | "warning" | "muted" {
+		statusVariant(): "success" | "warning" | "danger" | "muted" {
 			switch (this.status) {
 				case OptimizationStatus.OPTIMAL:
-				case OptimizationStatus.FEASIBLE:
 					return "success";
+				case OptimizationStatus.FEASIBLE:
+					return "warning";
 				case OptimizationStatus.INFEASIBLE:
 				case OptimizationStatus.UNBOUNDED:
-					return "warning";
+					return "danger";
 				default:
 					return "muted";
 			}
@@ -278,18 +281,20 @@ export default defineComponent({
 .info-icon {
 	cursor: help;
 }
+/* body size on small screens, larger from md up; bold carries the emphasis */
+.value-text {
+	font-size: 1rem;
+	line-height: 1.2;
+}
+@media (min-width: 768px) {
+	.value-text {
+		font-size: 1.25rem;
+	}
+}
 .secondary-goal {
 	text-decoration: underline;
 	text-decoration-color: var(--evcc-gray);
 	text-underline-offset: 3px;
-}
-
-/* small: slightly reduced value size, rows are tighter */
-@media (max-width: 767.98px) {
-	.field-value .large,
-	.field-value .fs-4 {
-		font-size: 1.125rem !important;
-	}
 }
 
 /* md and up: each field a vertical stack (label, value, caption); columns via Bootstrap grid */

--- a/assets/js/components/Optimize/OptimizeHeader.vue
+++ b/assets/js/components/Optimize/OptimizeHeader.vue
@@ -5,19 +5,13 @@
 			<!-- Primary goal -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div
-						class="field-label small text-uppercase fw-bold evcc-gray"
-					>
+					<div class="field-label small text-uppercase fw-bold evcc-gray">
 						Primary goal
 					</div>
-					<div class="field-caption small evcc-gray mt-1">
-						always, fixed
-					</div>
+					<div class="field-caption small evcc-gray mt-1">always, fixed</div>
 				</div>
 				<div class="field-value gap-2">
-					<span class="large fw-bold text-lowercase evcc-default-text"
-						>Lowest cost</span
-					>
+					<span class="large fw-bold text-lowercase evcc-default-text">Lowest cost</span>
 					<LockIcon class="value-icon" />
 				</div>
 			</div>
@@ -25,14 +19,10 @@
 			<!-- Secondary goal (only interactive setting) -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div
-						class="field-label small text-uppercase fw-bold evcc-gray"
-					>
+					<div class="field-label small text-uppercase fw-bold evcc-gray">
 						Secondary goal
 					</div>
-					<div class="field-caption small evcc-gray mt-1">
-						only on a tie
-					</div>
+					<div class="field-caption small evcc-gray mt-1">only on a tie</div>
 				</div>
 				<div class="field-value gap-2">
 					<CustomSelect
@@ -52,18 +42,10 @@
 			<!-- Result -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div
-						class="field-label small text-uppercase fw-bold evcc-gray"
-					>
-						Result
-					</div>
+					<div class="field-label small text-uppercase fw-bold evcc-gray">Result</div>
 					<div class="field-caption small evcc-gray mt-1">
-						<span v-if="relativeTime" class="tabular"
-							>{{ relativeTime }},
-						</span>
-						<span
-							v-if="pending"
-							class="updating fw-bold text-decoration-underline"
+						<span v-if="relativeTime" class="tabular">{{ relativeTime }}, </span>
+						<span v-if="pending" class="updating fw-bold text-decoration-underline"
 							>updating…</span
 						>
 						<button
@@ -78,10 +60,9 @@
 				</div>
 				<div class="field-value gap-2">
 					<StatusIndicator :variant="statusVariant">
-						<span
-							class="large fw-bold text-lowercase evcc-default-text"
-							>{{ status }}</span
-						>
+						<span class="large fw-bold text-lowercase evcc-default-text">{{
+							status
+						}}</span>
 					</StatusIndicator>
 					<span
 						ref="statusInfo"
@@ -98,9 +79,7 @@
 			<!-- Net grid cost -->
 			<div class="field col-12 col-md-6 col-lg-3">
 				<div class="field-head">
-					<div
-						class="field-label small text-uppercase fw-bold evcc-gray"
-					>
+					<div class="field-label small text-uppercase fw-bold evcc-gray">
 						Net grid cost
 					</div>
 					<div class="field-caption small evcc-gray mt-1">
@@ -171,17 +150,11 @@ export default defineComponent({
 	mixins: [formatter, minuteTicker],
 	props: {
 		updated: { type: String, default: "" },
-		status: {
-			type: String as PropType<OptimizationStatus>,
-			default: undefined,
-		},
+		status: { type: String as PropType<OptimizationStatus>, default: undefined },
 		netCost: { type: Number, default: 0 },
 		horizonHours: { type: Number, default: 0 },
 		currency: { type: String as PropType<CURRENCY>, default: CURRENCY.EUR },
-		chargingStrategies: {
-			type: Array as PropType<string[]>,
-			default: () => [],
-		},
+		chargingStrategies: { type: Array as PropType<string[]>, default: () => [] },
 		selectedStrategy: { type: String, default: "" },
 		pending: { type: Boolean, default: false },
 	},
@@ -199,14 +172,11 @@ export default defineComponent({
 			}));
 		},
 		secondaryGoalLabel(): string {
-			return (
-				STRATEGY_LABELS[this.selectedStrategy] || this.selectedStrategy
-			);
+			return STRATEGY_LABELS[this.selectedStrategy] || this.selectedStrategy;
 		},
 		relativeTime(): string {
 			if (!this.updated) return "";
-			const elapsed =
-				new Date(this.updated).getTime() - this.everyMinute.getTime();
+			const elapsed = new Date(this.updated).getTime() - this.everyMinute.getTime();
 			if (Math.abs(elapsed) < 60 * 1000) return "just now";
 			return this.fmtTimeAgo(elapsed);
 		},
@@ -237,17 +207,11 @@ export default defineComponent({
 	},
 	methods: {
 		onStrategyChange(e: Event) {
-			this.$emit(
-				"change-strategy",
-				(e.target as HTMLSelectElement).value,
-			);
+			this.$emit("change-strategy", (e.target as HTMLSelectElement).value);
 		},
 		initTooltips() {
 			const items: [Element | undefined, string][] = [
-				[
-					this.$refs["statusInfo"] as Element | undefined,
-					STATUS_TOOLTIP,
-				],
+				[this.$refs["statusInfo"] as Element | undefined, STATUS_TOOLTIP],
 				[this.$refs["costInfo"] as Element | undefined, COST_TOOLTIP],
 			];
 			for (const [el, title] of items) {
@@ -257,7 +221,7 @@ export default defineComponent({
 						new Tooltip(el, {
 							title: `<div class="text-start">${title}</div>`,
 							html: true,
-						}),
+						})
 					);
 				}
 			}

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -1429,6 +1429,7 @@ export interface TimeSeries {
 // Solver status enum
 export enum OptimizationStatus {
   OPTIMAL = "Optimal",
+  FEASIBLE = "Feasible",
   INFEASIBLE = "Infeasible",
   UNBOUNDED = "Unbounded",
   UNDEFINED = "Undefined",

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -577,8 +577,9 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 		Details: details,
 	})
 
-	if resp.JSON200.Status != optimizer.Optimal {
-		return errors.New(string(resp.JSON200.Status))
+	// feasible results are usable, they are just not proven optimal
+	if status := resp.JSON200.Status; status != optimizer.Optimal && status != optimizer.Feasible {
+		return errors.New(string(status))
 	}
 
 	slotHours := firstSlotDuration.Hours()


### PR DESCRIPTION
Implements https://github.com/evcc-io/optimizer/pull/124

@naltatis VSCode reformatted the file. Are any additional settings required now with Vite+?

**Screenshots**

optimal
<img width="983" height="163" alt="optimal" src="https://github.com/user-attachments/assets/e7f2fc77-145d-4718-be90-411f56d416e1" />

feasible
<img width="993" height="166" alt="feasible" src="https://github.com/user-attachments/assets/e57bdfb7-40c8-4948-b404-40178d78f0bc" />

infeasible
<img width="997" height="134" alt="infeasible" src="https://github.com/user-attachments/assets/32372e63-1318-45f3-8770-37bf5db7a3f8" />

improved mobile, smaller right column text, less wraps
<img width="329" height="344" alt="improved mobile" src="https://github.com/user-attachments/assets/de925bdf-42d4-40fb-8f69-520379b563c2" />
