### PR TITLE
Optimizer: stop demanding charge once the vehicle is full

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -800,10 +800,30 @@ func (site *Site) loadpointRequest(lp loadpoint.API, minLen int, firstSlotDurati
 	}
 
 	if demand != nil {
-		bat.PDemand = prorate(demand, firstSlotDuration)
+		// after prorate, so the shortened first slot counts with the energy it really carries
+		bat.PDemand = clearDemandWhenFull(prorate(demand, firstSlotDuration), bat.SMax-bat.SInitial)
 	}
 
 	return bat, detail
+}
+
+// clearDemandWhenFull zeroes the charge demand from the slot the accumulated energy fills the
+// vehicle. The optimizer drops the demand at s_max anyway, but pays two binaries per slot to
+// detect it, so slots that cannot bind are worth not asking about. Losses are accounted for,
+// which places the cut no earlier than the vehicle can actually be full.
+func clearDemandWhenFull(demand []float32, headroom float32) []float32 {
+	res := slices.Clone(demand)
+
+	var acc float32
+	for i, d := range res {
+		if acc >= headroom {
+			res[i] = 0
+			continue
+		}
+		acc += d * eta
+	}
+
+	return res
 }
 
 func (site *Site) batteryRequest(dev config.Device[api.Meter], b types.Measurement, grid api.Rates, minLen int, firstSlotDuration time.Duration) (optimizer.BatteryConfig, batteryDetail) {

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -809,8 +809,11 @@ func (site *Site) loadpointRequest(lp loadpoint.API, minLen int, firstSlotDurati
 
 // clearDemandWhenFull zeroes the charge demand from the slot the accumulated energy fills the
 // vehicle. The optimizer drops the demand at s_max anyway, but pays two binaries per slot to
-// detect it, so slots that cannot bind are worth not asking about. Losses are accounted for,
-// which places the cut no earlier than the vehicle can actually be full.
+// detect it, so slots that cannot bind are worth not asking about. Losses are accounted for.
+//
+// The cut assumes the demand is met every slot. A grid import limit can throttle charging below
+// it, moving the real fill point later than the estimate - the next request corrects that from
+// the measured soc, and the near slots are never affected because the cut sits a full charge away.
 func clearDemandWhenFull(demand []float32, headroom float32) []float32 {
 	res := slices.Clone(demand)
 

--- a/core/site_optimizer_demand_test.go
+++ b/core/site_optimizer_demand_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClearDemandWhenFull(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		demand   []float32
+		headroom float32
+		expected []float32
+	}{
+		{
+			// 345Wh demanded per slot stores 310.5Wh, so 1000Wh of headroom is covered
+			// during the fourth slot- that slot still binds, the ones after it cannot
+			"cut once the accumulated energy fills the vehicle",
+			[]float32{345, 345, 345, 345, 345, 345},
+			1000,
+			[]float32{345, 345, 345, 345, 0, 0},
+		},
+		{
+			"headroom beyond the horizon leaves the demand untouched",
+			[]float32{345, 345, 345},
+			1e6,
+			[]float32{345, 345, 345},
+		},
+		{
+			// already at the soc limit: every slot is relaxed at s_max anyway
+			"no headroom clears the whole demand",
+			[]float32{345, 345, 345},
+			0,
+			[]float32{0, 0, 0},
+		},
+		{
+			// the shortened first slot carries less energy and must not pull the cut in
+			"partial first slot counts with its own energy",
+			[]float32{100, 345, 345, 345},
+			600,
+			[]float32{100, 345, 345, 0},
+		},
+		{
+			"empty demand stays empty",
+			[]float32{},
+			1000,
+			[]float32{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, clearDemandWhenFull(tc.demand, tc.headroom))
+		})
+	}
+}
+
+// the request contract requires every series to have the same length
+func TestClearDemandWhenFullKeepsLength(t *testing.T) {
+	demand := make([]float32, 96)
+	for i := range demand {
+		demand[i] = 345
+	}
+
+	assert.Len(t, clearDemandWhenFull(demand, 1000), len(demand))
+	assert.Len(t, clearDemandWhenFull(demand, 0), len(demand))
+}


### PR DESCRIPTION
In `minpv` and `now` mode the loadpoint sends `p_demand` at min/max power for **every** slot of the horizon, e.g. `[202.01668, 345, 345, … 345]` for 187 slots — 345Wh being exactly `c_min` × 15min. A vehicle with 12.2kWh of headroom is full after roughly ten of those slots, so the remaining ~180 carry a demand that cannot bind.

The optimizer already handles this: it drops the demand once `s_max` is reached. But it detects that with two binaries per slot per battery (`z_p_demand`, `z_s_max_reached`) plus a penalty variable, all of which it builds whether or not the slot can bind. Measured on a real 191-slot request, clearing the demand past the fill point drops 151 variables and 302 constraints for a bit-identical schedule — same 3551W export peak, same charge profile, same unmet demand.

Losses are accounted for, and the array keeps its length, since the API requires every series in a request to be the same length.

## Why here and not in the optimizer

The optimizer cannot derive the fill point. `p_demand` is soft, and its penalty variable is a feasibility valve rather than a choice: `prc_p_goal_pen` is 100× the largest real currency/Wh rate in the model, so it is never worth paying — it gets paid when charging is *impossible*. With `charge_from_grid: false` and no PV, `c` is pinned at 0 by the surplus constraint, the vehicle never fills, and the demand binds to the end of the horizon. Truncating there deletes real penalty terms: on a constructed 80-slot case of that shape it hid 13800Wh of genuine unmet demand and moved the objective from -1351.18 to -787.57.

So the fill point is a statement of caller intent — "stop asking once the car is full" — not something derivable from the request.

## Where this is approximate

The cut assumes the demand is met in every slot. It usually is, since loadpoints always request `charge_from_grid`, but a configured circuit limit is passed through as `p_max_imp` and can throttle charging below the demanded rate, putting the real fill point later than the estimate. Slots between the two would stop carrying the minpv floor.

Two things bound that. The request is reissued every cycle with the measured soc, so a wrong estimate is recomputed rather than committed to. And the cut always sits a full charge away from now, so the near slots — the only ones that are acted on — are never cleared unless the vehicle really is full.

Worth a second opinion on whether that is the right trade, or whether the cut should carry a margin.
