### PR TITLE
Solcast: keep forecast alive outside active hours

### DIFF
--- a/tariff/helper_test.go
+++ b/tariff/helper_test.go
@@ -62,6 +62,33 @@ func TestMergeRatesAfter(t *testing.T) {
 	}
 }
 
+// TestMergeRatesAfterRefreshesTimestamp asserts that merging without new rates
+// keeps the cached rates and un-expires the monitor - this is how solcast keeps
+// its forecast alive while fetching is paused outside the from/to window.
+func TestMergeRatesAfterRefreshesTimestamp(t *testing.T) {
+	clock := clock.NewMock()
+	clock.Set(now.BeginningOfDay())
+
+	rates := api.Rates{{
+		Start: clock.Now().Add(time.Hour),
+		End:   clock.Now().Add(2 * time.Hour),
+		Value: 1,
+	}}
+
+	data := util.NewMonitor[api.Rates](time.Hour).WithClock(clock)
+	data.Set(rates)
+
+	clock.Add(2 * time.Hour)
+	_, err := data.Get()
+	require.ErrorIs(t, err, api.ErrOutdated)
+
+	mergeRatesAfter(data, nil, clock.Now().Add(-2*time.Hour))
+
+	res, err := data.Get()
+	require.NoError(t, err)
+	assert.Equal(t, rates, res)
+}
+
 type runner struct {
 	res error
 }

--- a/tariff/solcast.go
+++ b/tariff/solcast.go
@@ -82,6 +82,8 @@ func (t *Solcast) run(interval time.Duration, done chan error) {
 		select {
 		case <-t.data.Done():
 			if !t.fromTo.IsActive(time.Now().Hour()) {
+				// keep cached forecast alive while fetching is paused
+				mergeRatesAfter(t.data, nil, beginningOfDay())
 				continue
 			}
 		default:


### PR DESCRIPTION
fixes #32629

The Solcast monitor is created with a staleness timeout of `2 * interval`, but the `from`/`to` window can pause fetching for much longer than that. Once the timeout passes, `Rates()` returns `api.ErrOutdated` and the site drops the solar forecast until fetching resumes. Refreshing the monitor while paused keeps the cached forecast usable.

- refresh the monitor with the cached rates when skipping a fetch outside the active window, pruning rates older than the current day
- reuse `mergeRatesAfter` for the refresh instead of adding a dedicated touch API

🤖 Generated with [Claude Code](https://claude.com/claude-code)