### PR TITLE
Huawei SmartLogger: add returnenergy to grid

### DIFF
--- a/templates/definition/meter/huawei-smartlogger.yaml
+++ b/templates/definition/meter/huawei-smartlogger.yaml
@@ -34,6 +34,14 @@ render: |
       type: holding
       decode: int64
     scale: 0.01
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 32357 # Positive active electricity
+      type: holding
+      decode: int64
+    scale: 0.01
   currents:
   - source: modbus
     {{- include "modbus" . | indent 2 }}


### PR DESCRIPTION
<img width="757" height="261" alt="image" src="https://github.com/user-attachments/assets/3161d1f5-18b5-4de5-a2f6-0437d634f06a" />

I did not add `returnenergy` to the `battery` as it is an exact duplicate of an old version of the SUN2000 template. It makes more sense to extract the battery into a separate general LUNA2000 template, see [here](https://github.com/evcc-io/evcc/issues/32418#issuecomment-5189282662).