### PR TITLE
Tasmota: mask password in error messages

### DIFF
--- a/meter/tasmota/connection.go
+++ b/meter/tasmota/connection.go
@@ -43,7 +43,7 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 		used[c] = true
 	}
 
-	log := util.NewLogger("tasmota")
+	log := util.NewLogger("tasmota").Redact(user, password)
 	c := &Connection{
 		Helper:   request.NewHelper(log),
 		uri:      util.DefaultScheme(strings.TrimRight(uri, "/"), "http"),
@@ -55,28 +55,33 @@ func NewConnection(uri, user, password string, channels []int, cache time.Durati
 	c.Client.Transport = request.NewTripper(log, transport.Insecure())
 
 	c.statusSnsG = util.ResettableCached(func() (StatusSNSResponse, error) {
-		parameters := url.Values{
-			"user":     {c.user},
-			"password": {c.password},
-			"cmnd":     {"Status 8"},
-		}
 		var res StatusSNSResponse
-		err := c.GetJSON(fmt.Sprintf("%s/cm?%s", c.uri, parameters.Encode()), &res)
+		err := c.cmd("Status 8", &res)
 		return res, err
 	}, cache)
 
 	c.statusStsG = util.ResettableCached(func() (StatusSTSResponse, error) {
-		parameters := url.Values{
-			"user":     {c.user},
-			"password": {c.password},
-			"cmnd":     {"Status 0"},
-		}
 		var res StatusSTSResponse
-		err := c.GetJSON(fmt.Sprintf("%s/cm?%s", c.uri, parameters.Encode()), &res)
+		err := c.cmd("Status 0", &res)
 		return res, err
 	}, cache)
 
 	return c, nil
+}
+
+// cmd executes a Tasmota command, masking the password in returned errors
+func (c *Connection) cmd(cmnd string, res any) error {
+	parameters := url.Values{
+		"user":     {c.user},
+		"password": {c.password},
+		"cmnd":     {cmnd},
+	}
+
+	err := c.GetJSON(fmt.Sprintf("%s/cm?%s", c.uri, parameters.Encode()), res)
+	if err != nil && c.password != "" {
+		return errors.New(strings.ReplaceAll(err.Error(), url.QueryEscape(c.password), "***"))
+	}
+	return err
 }
 
 // channelExists checks the existence of the configured relay channel interface
@@ -123,14 +128,8 @@ func (c *Connection) Enable(enable bool) error {
 			cmd = fmt.Sprintf("Power%d on", channel)
 		}
 
-		parameters := url.Values{
-			"user":     {c.user},
-			"password": {c.password},
-			"cmnd":     {cmd},
-		}
-
 		var res PowerResponse
-		if err := c.GetJSON(fmt.Sprintf("%s/cm?%s", c.uri, parameters.Encode()), &res); err != nil {
+		if err := c.cmd(cmd, &res); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
<img width="992" height="286" alt="Bildschirmfoto 2026-08-09 um 10 56 42" src="https://github.com/user-attachments/assets/dbba1461-8369-4fcd-b5e0-5bcc9c9d961f" />

Transport errors from the Tasmota API include the full request URL. Since Tasmota authenticates via query parameters, the device password appeared in plain text in UI notifications, logs, and the config test result.

- Fold duplicated request building into a single `cmd()` helper that masks the password in returned errors
- Register user/password for log redaction, matching the vehicle implementations

@andig can/should we fix this (credentials in url) on a more fundamental level?