### PR TITLE
chore: fix dev version string in Docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHA ?= $(shell test -d .git && git rev-parse --short HEAD)
 GIT_TAG := $(shell test -d .git && git describe --abbrev=0 --tags)
 # commits since the latest tag, empty or 0 means the commit is tagged
 GIT_DIST := $(shell test -n "$(GIT_TAG)" && git rev-list --count $(GIT_TAG)..HEAD)
-NEXT_TAG = $(shell echo $(GIT_TAG) | awk -F. -v b='$(BUMP)' '{if (b == "patch") $$NF++; else {$$2++; $$3=0}} 1' OFS=.)
+NEXT_TAG = $(shell echo $(GIT_TAG) | awk -F. -v b='$(BUMP)' '{ if (b == "patch") { m = $$2; p = $$3 + 1 } else { m = $$2 + 1; p = 0 }; print $$1 "." m "." p }')
 # untagged builds are semver pre-releases of the upcoming version
 TAG_NAME ?= $(if $(filter-out 0,$(GIT_DIST)),$(NEXT_TAG)-dev+$(SHA),$(GIT_TAG))
 COMMIT := $(SHA)


### PR DESCRIPTION
Docker nightly reports `-dev+<sha>` instead of `0.314.0-dev+<sha>`:

```
$ docker run --rm evcc/evcc:nightly evcc -v
evcc version -dev+cc9bfc255
```

The `NEXT_TAG` awk program added in #32663 is rejected by busybox awk in the
alpine builder image:

```
awk: cmd. line:1: Unexpected token
```

`$(shell ...)` swallows the error, so `NEXT_TAG` is empty and `TAG_NAME`
collapses to `-dev+$(SHA)`. gawk/BSD awk accept the program, so local builds
and the goreleaser deb/nightly packages are unaffected — only the Docker image
is wrong.

Rewritten without the bare `1` pattern and the `OFS=` operand. Same results on
gawk, BSD awk and busybox awk:

| | old | new |
| --- | --- | --- |
| alpine (busybox awk) | `-dev+c1618f7` | `0.314.0-dev+c1618f7` |
| macOS (BSD awk) | `0.314.0-dev+c1618f7` | `0.314.0-dev+c1618f7` |
| `BUMP=patch` | | `0.313.1-dev+c1618f7` |
| HEAD on a tag | | `0.314.0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
