### PR TITLE
chore: speed up Docker builds — drop dead GHA cache, build on Depot

### DIFF
--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -138,8 +138,6 @@ jobs:
           platforms: ${{ needs.prep.outputs.platforms }}
           push: true
           tags: evcc/evcc:pr-${{ github.event.issue.number }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   report:
     name: Report

--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -130,10 +130,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Setup Depot
-        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+        uses: depot/setup-action@v1
 
       - name: Publish
-        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
+        uses: depot/build-push-action@v1
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .

--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -115,6 +115,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       contents: read
+      id-token: write # depot OIDC
     steps:
       - uses: actions/checkout@v7
         with:
@@ -128,12 +129,13 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Setup Depot
+        uses: depot/setup-action@v1
 
       - name: Publish
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .
           platforms: ${{ needs.prep.outputs.platforms }}
           push: true

--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -115,7 +115,6 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       contents: read
-      id-token: write # depot OIDC
     steps:
       - uses: actions/checkout@v7
         with:
@@ -129,13 +128,12 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Depot
-        uses: depot/setup-action@v1
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Publish
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
-          project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .
           platforms: ${{ needs.prep.outputs.platforms }}
           push: true

--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -130,10 +130,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Setup Depot
-        uses: depot/setup-action@v1
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
 
       - name: Publish
-        uses: depot/build-push-action@v1
+        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -13,7 +13,6 @@ jobs:
 
     permissions:
       contents: read
-      actions: read
 
     steps:
       - uses: actions/checkout@v7
@@ -21,13 +20,6 @@ jobs:
           ref: refs/heads/master # force master
           fetch-depth: 0
           persist-credentials: false
-
-      - name: Get dist from cache
-        uses: actions/cache/restore@v6
-        id: cache-dist
-        with:
-          path: dist
-          key: ${{ runner.os }}-${{ github.sha }}-dist
 
       - name: Login
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -54,8 +46,6 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Delete old nightly.* tags
         run: |

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Setup Depot
-        uses: depot/setup-action@v1
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
 
       - name: Define tags
         id: meta
@@ -41,7 +41,7 @@ jobs:
             type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
 
       - name: Publish
-        uses: depot/build-push-action@v1
+        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -13,6 +13,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # depot OIDC
 
     steps:
       - uses: actions/checkout@v7
@@ -27,8 +28,8 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Setup Depot
+        uses: depot/setup-action@v1
 
       - name: Define tags
         id: meta
@@ -40,8 +41,9 @@ jobs:
             type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
 
       - name: Publish
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -13,7 +13,6 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write # depot OIDC
 
     steps:
       - uses: actions/checkout@v7
@@ -28,8 +27,8 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Depot
-        uses: depot/setup-action@v1
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Define tags
         id: meta
@@ -41,9 +40,8 @@ jobs:
             type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
 
       - name: Publish
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
-          project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Setup Depot
-        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+        uses: depot/setup-action@v1
 
       - name: Define tags
         id: meta
@@ -41,7 +41,7 @@ jobs:
             type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
 
       - name: Publish
-        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1
+        uses: depot/build-push-action@v1
         with:
           project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .


### PR DESCRIPTION
The nightly Docker publish takes ~8m30s. Profiling job [93258555709](https://github.com/evcc-io/evcc/actions/runs/31318669359) — `Publish` is 498s of it:

| time | step |
|---|---|
| 274.5s | `make build` ×3 platforms, parallel |
| 92.7s | `make assets` (`go generate ./...`) |
| 69.8s | exporting to GitHub Actions Cache |
| 34.2s | `make install` |
| 13.0s | exporting to image |
| 12.9s | `go mod download` |

Two separate problems, one root cause.

## The GHA cache costs 70s and returns nothing

`--mount=type=cache` (GOCACHE, GOMODCACHE, npm) is **not exported by any buildkit cache exporter**. Buildkit boots fresh each run (`#1 booting buildkit 3.3s`), so every Go compile starts cold regardless of what the layer cache holds. On top of that, `COPY . .` changes every run and invalidates everything below it, and `mode=max` over three platforms exceeds the 10 GB per-repo GHA limit, evicting even the pre-`COPY` layers before the next nightly.

The log confirms it: 10 `CACHED` steps, all trivial (`WORKDIR`, `COPY go.mod`). `go mod download`, `make install`, `make assets` and `make build` all executed cold, while the cache export burned 69.8s.

Removed from `nightly-docker.yml` and `command-pr-build.yml`. `release.yml`'s docker job already builds without it, so this just makes the three consistent.

Also dropped the `Get dist from cache` step in `nightly-docker.yml`: `dist` is in `.dockerignore` and the Dockerfile builds the UI itself in the node stage (`COPY --from=node /build/dist`), so the restored artifact never reached the build context. Dropped the now-unused `actions: read` permission with it. Left `release.yml`'s dist cache alone — goreleaser builds outside Docker there and does consume it.
