### PR TITLE
chore: fix flaky aux meter e2e test

### DIFF
--- a/tests/config-grid-only.evcc.yaml
+++ b/tests/config-grid-only.evcc.yaml
@@ -1,3 +1,5 @@
+interval: 0.1s
+
 site:
   title: Hello World
   meters:


### PR DESCRIPTION
`config-aux.spec.ts` › `create and remove aux meter` is flaky, e.g. in the
nightly run [31350729262](https://github.com/evcc-io/evcc/actions/runs/31350729262):

```
Error: expect(locator).toContainText(expected) failed
Locator:  getByTestId('aux')
Expected substring: "1.2 kW"
  14 × locator resolved to <div data-testid="aux" …>
     - unexpected value "Water heater1200CurtailableyesPower0.0 kW"
```

The card is already rendered, only the power is still `0.0 kW`: aux power is
published by the site update loop, and `config-grid-only.evcc.yaml` is one of
the few test configs without an `interval`. Measured during a local run, site
updates land ~5s apart — the same order as the 5s expect timeout, so the
assertion sometimes loses the race.

`interval: 0.1s` is what the other test configs use. Site updates during the
same test go from 3 to 86, and the value is there long before the assertion.

All 7 specs using this config pass: 19 passed, 0 flaky.

Other `tests/config-*.evcc.yaml` files are missing `interval` as well and are
open to the same race, but none of them have shown up as flaky yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
