### PR TITLE
chore: build Docker images on Depot builders

### DIFF
--- a/.github/workflows/command-pr-build.yml
+++ b/.github/workflows/command-pr-build.yml
@@ -115,6 +115,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       contents: read
+      id-token: write # depot OIDC
     steps:
       - uses: actions/checkout@v7
         with:
@@ -128,12 +129,13 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Setup Depot
+        uses: depot/setup-action@v1
 
       - name: Publish
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .
           platforms: ${{ needs.prep.outputs.platforms }}
           push: true

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -13,6 +13,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # depot OIDC
 
     steps:
       - uses: actions/checkout@v7
@@ -27,8 +28,8 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Setup Depot
+        uses: depot/setup-action@v1
 
       - name: Define tags
         id: meta
@@ -40,8 +41,9 @@ jobs:
             type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
 
       - name: Publish
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ vars.DEPOT_PROJECT_ID }}
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true


### PR DESCRIPTION
Stacked on #32684 — review that one first, this diff is against it.

> [!IMPORTANT]
> Draft: needs a Depot container build project before it can run. See *Setup* below.

## Why

From the profile in #32684, after removing the useless GHA cache the `Publish` step is ~430s, and cold Go compilation is nearly all of it:

| time | step |
|---|---|
| 274.5s | `make build` ×3 platforms, parallel |
| 92.7s | `make assets` (`go generate ./...`) |
| 34.2s | `make install` |
| 12.9s | `go mod download` |

All four are cold on every single run. `--mount=type=cache` (GOCACHE, GOMODCACHE, npm) is not exported by *any* buildkit cache exporter, and buildkit boots fresh on each runner (`#1 booting buildkit 3.3s`), so the mounts start empty no matter what layer cache is configured. That is a property of buildkit, not of how the cache is set up here — it cannot be fixed with `cache-from`/`cache-to`.

Depot builders keep the cache mounts on persistent NVMe between builds, so only changed packages recompile. They also offer native amd64 and arm64 builders. Since the runners are already `depot-ubuntu-24.04-arm`, this only moves where the build executes.

Expected: `make build` 274s → ~40-70s, `make assets` 93s → ~10s. Nightly docker job roughly **7m → 2m**.

The alternative, `reproducible-containers/buildkit-cache-dance`, shuttles the mounts through `actions/cache` — it works, but adds 30-60s of import/export per run and runs back into the 10 GB per-repo limit that already broke the old cache.

## Changes

- `nightly-docker.yml` and `command-pr-build.yml`: `docker/build-push-action` → `depot/build-push-action@v1`, `docker/setup-buildx-action` → `depot/setup-action@v1`, added `id-token: write` for OIDC auth.
- Project id comes from the `DEPOT_PROJECT_ID` repository variable, so it stays out of the workflow files and can be swapped without a PR.

## Setup required before merging

1. Create a **container build project** in the Depot org that already backs the runners (separate concept from the runner config).
2. Set repository variable `DEPOT_PROJECT_ID` to that project id.
3. In the Depot project settings, add the GitHub OIDC trust relationship for `evcc-io/evcc`. Alternatively drop a `DEPOT_TOKEN` secret in and pass `token:` instead — OIDC is Depot's recommendation.

Happy to flip it to `depot.json` + no repo variable if you prefer the project id committed; it isn't a secret.

## Not in this PR

`release.yml` still uses `docker/build-push-action`. Same change applies, but I would rather see a few nightlies produce an equivalent image before touching the release path.