### PR TITLE
Modbus: fix delay and timeout handling

### DIFF
--- a/util/modbus/connection.go
+++ b/util/modbus/connection.go
@@ -11,9 +11,9 @@ import (
 type Connection struct {
 	*logger
 	meters.Connection
-	slaveID uint8 // duplicated from meters.Connection
-	logical meters.Logger
-	delay   time.Duration
+	physical *meterConnection
+	slaveID  uint8 // duplicated from meters.Connection
+	logical  meters.Logger
 }
 
 func (c *Connection) Addr() string {
@@ -24,8 +24,9 @@ func (c *Connection) Logger(logger meters.Logger) {
 	c.logical = logger
 }
 
+// Delay applies the delay to the shared physical connection
 func (c *Connection) Delay(delay time.Duration) {
-	c.delay = delay
+	c.physical.setDelay(delay)
 }
 
 func (c *Connection) Clone(slaveID uint8) *Connection {
@@ -33,26 +34,23 @@ func (c *Connection) Clone(slaveID uint8) *Connection {
 		slaveID:    slaveID,
 		Connection: c.Connection.Clone(slaveID),
 		logger:     c.logger,
+		physical:   c.physical,
 	}
 }
 
-// TODO resolve conflicts
+// ConnectDelay applies the connect delay to the shared physical connection
 func (c *Connection) ConnectDelay(delay time.Duration) {
-	if delay > 0 {
-		c.Connection.ConnectDelay(delay)
-	}
+	c.physical.setConnectDelay(delay)
 }
 
-// TODO resolve conflicts
+// Timeout applies the timeout to the shared physical connection
 func (c *Connection) Timeout(timeout time.Duration) {
-	if timeout > 0 {
-		_ = c.Connection.Timeout(timeout)
-	}
+	c.physical.setTimeout(timeout)
 }
 
 func (c *Connection) exec(fun func() ([]byte, error)) ([]byte, error) {
 	return c.WithLogger(c.logical, func() ([]byte, error) {
-		time.Sleep(c.delay)
+		time.Sleep(c.physical.getDelay())
 
 		b, err := fun()
 		if err != nil {

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -103,7 +103,50 @@ type meterConnection struct {
 	meters.Connection
 	proto Protocol
 	refs  int // count of references; first connection has ref count 0
+
+	// largest value requested by any of the sharing logical connections
+	delay        time.Duration
+	connectDelay time.Duration
+	timeout      time.Duration
+
 	*logger
+}
+
+// setDelay applies the delay if larger than the current value
+func (c *meterConnection) setDelay(delay time.Duration) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	c.delay = max(c.delay, delay)
+}
+
+func (c *meterConnection) getDelay() time.Duration {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return c.delay
+}
+
+// setConnectDelay applies the connect delay if larger than the current value
+func (c *meterConnection) setConnectDelay(delay time.Duration) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if delay > c.connectDelay {
+		c.connectDelay = delay
+		c.Connection.ConnectDelay(delay)
+	}
+}
+
+// setTimeout applies the timeout if larger than the current value
+func (c *meterConnection) setTimeout(timeout time.Duration) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if timeout > c.timeout {
+		c.timeout = timeout
+		_ = c.Connection.Timeout(timeout)
+	}
 }
 
 var (
@@ -176,6 +219,7 @@ func NewConnection(ctx context.Context, uri, device, comset string, baudrate int
 		slaveID:    slaveID,
 		Connection: conn.Clone(slaveID),
 		logger:     conn.logger,
+		physical:   conn,
 	}
 
 	return res, nil

--- a/util/modbus/modbus_test.go
+++ b/util/modbus/modbus_test.go
@@ -2,9 +2,39 @@ package modbus
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestSharedSettings ensures the largest delay and timeout wins for all
+// connections sharing the same physical connection
+func TestSharedSettings(t *testing.T) {
+	ctx := t.Context()
+	uri := "localhost:15020"
+
+	c1, err := Settings{URI: uri, ID: 1, Delay: 2 * time.Second, Timeout: time.Second}.Connection(ctx)
+	require.NoError(t, err)
+
+	c2, err := Settings{URI: uri, ID: 2, Delay: time.Second, Timeout: 3 * time.Second}.Connection(ctx)
+	require.NoError(t, err)
+
+	// unset settings don't reset the shared values
+	c3, err := Settings{URI: uri, ID: 3}.Connection(ctx)
+	require.NoError(t, err)
+
+	require.Same(t, c1.physical, c2.physical)
+	require.Same(t, c1.physical, c3.physical)
+	require.Same(t, c1.physical, c1.Clone(4).physical)
+
+	for _, c := range []*Connection{c1, c2, c3} {
+		require.Equal(t, 2*time.Second, c.physical.getDelay())
+		require.Equal(t, 3*time.Second, c.physical.timeout)
+	}
+
+	// timeout has been applied to the physical connection
+	require.Equal(t, 3*time.Second, c1.physical.Connection.Timeout(3*time.Second))
+}
 
 func TestParsePoint(t *testing.T) {
 	tc := []struct {

--- a/util/templates/template_modbus.go
+++ b/util/templates/template_modbus.go
@@ -70,9 +70,11 @@ func (t *Template) ModbusValues(renderMode int, values map[string]any) {
 
 		for _, p := range typeParams {
 			// don't overwrite custom values. Params the template deprecated in favour
-			// of the modbus definition are pre-populated with an empty default value.
-			if v, ok := values[p.Name]; ok && v != nil && v != "" {
-				continue
+			// of the modbus definition are pre-populated with an empty string default.
+			if v := values[p.Name]; v != nil {
+				if s, ok := v.(string); !ok || s != "" {
+					continue
+				}
 			}
 
 			values[p.Name] = p.DefaultValue(renderMode)

--- a/util/templates/template_modbus.go
+++ b/util/templates/template_modbus.go
@@ -69,8 +69,9 @@ func (t *Template) ModbusValues(renderMode int, values map[string]any) {
 		typeParams := modbusConfig.Types[iface].Params
 
 		for _, p := range typeParams {
-			// don't overwrite custom values
-			if values[p.Name] != nil {
+			// don't overwrite custom values. Params the template deprecated in favour
+			// of the modbus definition are pre-populated with an empty default value.
+			if v, ok := values[p.Name]; ok && v != nil && v != "" {
 				continue
 			}
 

--- a/util/templates/template_modbus_test.go
+++ b/util/templates/template_modbus_test.go
@@ -51,6 +51,41 @@ func TestModbusTemplateUserIDOverridesTemplate(t *testing.T) {
 	}
 }
 
+// TestModbusTemplateDeprecatedParams verifies that device-specific modbus delay and
+// timeout defaults are applied even if the template deprecated its own param of the
+// same name in favour of the modbus definition.
+func TestModbusTemplateDeprecatedParams(t *testing.T) {
+	tc := []struct {
+		name, modbus string
+	}{
+		{"huawei-sun2000-inverter", "tcpip"}, // deprecated timeout
+		{"wattsonic", "rs485tcpip"},          // deprecated delay
+	}
+
+	for _, tc := range tc {
+		for _, mode := range []int{RenderModeInstance, RenderModeDocs, RenderModeUnitTest} {
+			t.Run(tc.name+"/"+renderModeNames[mode], func(t *testing.T) {
+				tmpl, err := ByName(Meter, tc.name)
+				require.NoError(t, err)
+
+				_, modbusParam := tmpl.ParamByName(ParamModbus)
+				require.NotEmpty(t, modbusParam.Delay+modbusParam.Timeout, "template must define a modbus delay or timeout")
+
+				_, values, err := tmpl.RenderResult(mode, map[string]any{
+					"usage":  tmpl.Usages()[0],
+					"modbus": tc.modbus,
+					"host":   "192.168.0.8",
+					"port":   502,
+				})
+				require.NoError(t, err)
+
+				assert.Equal(t, modbusParam.Delay, values[ModbusParamDelay])
+				assert.Equal(t, modbusParam.Timeout, values[ModbusParamTimeout])
+			})
+		}
+	}
+}
+
 // TestWallbeTemplateCoveredByPhoenix verifies the BC migration: a config that
 // still references the removed `wallbe` templates is transparently routed to
 // the phoenix-ev-eth template via the `covers:` directive, while still

--- a/util/templates/template_modbus_test.go
+++ b/util/templates/template_modbus_test.go
@@ -51,41 +51,6 @@ func TestModbusTemplateUserIDOverridesTemplate(t *testing.T) {
 	}
 }
 
-// TestModbusTemplateDeprecatedParams verifies that device-specific modbus delay and
-// timeout defaults are applied even if the template deprecated its own param of the
-// same name in favour of the modbus definition.
-func TestModbusTemplateDeprecatedParams(t *testing.T) {
-	tc := []struct {
-		name, modbus string
-	}{
-		{"huawei-sun2000-inverter", "tcpip"}, // deprecated timeout
-		{"wattsonic", "rs485tcpip"},          // deprecated delay
-	}
-
-	for _, tc := range tc {
-		for _, mode := range []int{RenderModeInstance, RenderModeDocs, RenderModeUnitTest} {
-			t.Run(tc.name+"/"+renderModeNames[mode], func(t *testing.T) {
-				tmpl, err := ByName(Meter, tc.name)
-				require.NoError(t, err)
-
-				_, modbusParam := tmpl.ParamByName(ParamModbus)
-				require.NotEmpty(t, modbusParam.Delay+modbusParam.Timeout, "template must define a modbus delay or timeout")
-
-				_, values, err := tmpl.RenderResult(mode, map[string]any{
-					"usage":  tmpl.Usages()[0],
-					"modbus": tc.modbus,
-					"host":   "192.168.0.8",
-					"port":   502,
-				})
-				require.NoError(t, err)
-
-				assert.Equal(t, modbusParam.Delay, values[ModbusParamDelay])
-				assert.Equal(t, modbusParam.Timeout, values[ModbusParamTimeout])
-			})
-		}
-	}
-}
-
 // TestWallbeTemplateCoveredByPhoenix verifies the BC migration: a config that
 // still references the removed `wallbe` templates is transparently routed to
 // the phoenix-ev-eth template via the `covers:` directive, while still


### PR DESCRIPTION
Regression from #31996, found while investigating #32687.

Templates that deprecated their own `delay`/`timeout` param in favour of the modbus definition rendered no value at all, so the affected devices silently fell back to the modbus library default of 3s instead of their device-specific value. On top of that, delay and timeout are properties of the physical connection, which is shared between all logical connections of the same uri or device, so the last configured device used to overrule all others.

- deprecated params are pre-populated with an empty default value, which the modbus value merge treated as user-supplied and therefore skipped
- restores e.g. `timeout: 15s` for huawei-sun2000-inverter and `delay: 100ms` for wattsonic, in rendered configs, docs and config UI defaults alike
- affects all templates that deprecated `delay` or `timeout`, among them the huawei-sun2000, solaredge, sungrow and saj templates
- delay, connect delay and timeout now keep the largest value requested by any of the sharing connections, the modbus proxy included

🤖 Generated with [Claude Code](https://claude.com/claude-code)