### PR TITLE
Modbus: don't guard connection settings with the registry mutex

### DIFF
--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -104,8 +104,9 @@ type meterConnection struct {
 	proto Protocol
 	refs  int // count of references; first connection has ref count 0
 
-	// largest value requested by any of the sharing logical connections
-	settings     sync.Mutex
+	// mu guards the largest delay and timeout values requested by any of the
+	// sharing logical connections
+	mu           sync.Mutex
 	delay        time.Duration
 	connectDelay time.Duration
 	timeout      time.Duration
@@ -115,23 +116,23 @@ type meterConnection struct {
 
 // setDelay applies the delay if larger than the current value
 func (c *meterConnection) setDelay(delay time.Duration) {
-	c.settings.Lock()
-	defer c.settings.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	c.delay = max(c.delay, delay)
 }
 
 func (c *meterConnection) getDelay() time.Duration {
-	c.settings.Lock()
-	defer c.settings.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	return c.delay
 }
 
 // setConnectDelay applies the connect delay if larger than the current value
 func (c *meterConnection) setConnectDelay(delay time.Duration) {
-	c.settings.Lock()
-	defer c.settings.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if delay > c.connectDelay {
 		c.connectDelay = delay
@@ -141,8 +142,8 @@ func (c *meterConnection) setConnectDelay(delay time.Duration) {
 
 // setTimeout applies the timeout if larger than the current value
 func (c *meterConnection) setTimeout(timeout time.Duration) {
-	c.settings.Lock()
-	defer c.settings.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if timeout > c.timeout {
 		c.timeout = timeout

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -105,6 +105,7 @@ type meterConnection struct {
 	refs  int // count of references; first connection has ref count 0
 
 	// largest value requested by any of the sharing logical connections
+	settings     sync.Mutex
 	delay        time.Duration
 	connectDelay time.Duration
 	timeout      time.Duration
@@ -114,23 +115,23 @@ type meterConnection struct {
 
 // setDelay applies the delay if larger than the current value
 func (c *meterConnection) setDelay(delay time.Duration) {
-	mu.Lock()
-	defer mu.Unlock()
+	c.settings.Lock()
+	defer c.settings.Unlock()
 
 	c.delay = max(c.delay, delay)
 }
 
 func (c *meterConnection) getDelay() time.Duration {
-	mu.Lock()
-	defer mu.Unlock()
+	c.settings.Lock()
+	defer c.settings.Unlock()
 
 	return c.delay
 }
 
 // setConnectDelay applies the connect delay if larger than the current value
 func (c *meterConnection) setConnectDelay(delay time.Duration) {
-	mu.Lock()
-	defer mu.Unlock()
+	c.settings.Lock()
+	defer c.settings.Unlock()
 
 	if delay > c.connectDelay {
 		c.connectDelay = delay
@@ -140,8 +141,8 @@ func (c *meterConnection) setConnectDelay(delay time.Duration) {
 
 // setTimeout applies the timeout if larger than the current value
 func (c *meterConnection) setTimeout(timeout time.Duration) {
-	mu.Lock()
-	defer mu.Unlock()
+	c.settings.Lock()
+	defer c.settings.Unlock()
 
 	if timeout > c.timeout {
 		c.timeout = timeout

--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -104,8 +104,6 @@ type meterConnection struct {
 	proto Protocol
 	refs  int // count of references; first connection has ref count 0
 
-	// mu guards the largest delay and timeout values requested by any of the
-	// sharing logical connections
 	mu           sync.Mutex
 	delay        time.Duration
 	connectDelay time.Duration


### PR DESCRIPTION
Follow-up to #32694.

The shared delay, connect delay and timeout added in #32694 were guarded by the connection registry mutex. That mutex is held while a physical connection is closed, so unregistering one connection could block register access on every other modbus connection. They now use a dedicated mutex per physical connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)