### PR TITLE
Modbus: release shared connections on context cancellation

### DIFF
--- a/util/modbus/modbus.go
+++ b/util/modbus/modbus.go
@@ -176,31 +176,33 @@ func registeredConnection(ctx context.Context, key string, proto Protocol, newCo
 	mu.Lock()
 	defer mu.Unlock()
 
-	if conn, ok := connections[key]; ok {
-		if conn.proto != proto {
-			return nil, fmt.Errorf("connection already registered with different protocol: %s", key)
-		}
+	conn, ok := connections[key]
 
+	switch {
+	case ok && conn.proto != proto:
+		return nil, fmt.Errorf("connection already registered with different protocol: %s", key)
+
+	case ok:
 		conn.refs++
 
-		return conn, nil
+	default:
+		conn = &meterConnection{
+			Connection: newConn,
+			proto:      proto,
+			logger:     new(logger),
+		}
+
+		newConn.Logger(conn.logger)
+		connections[key] = conn
 	}
 
+	// release this reference when the caller's context is done
 	go func() {
 		<-ctx.Done()
 		unregisterConnection(key)
 	}()
 
-	connection := &meterConnection{
-		Connection: newConn,
-		proto:      proto,
-		logger:     new(logger),
-	}
-
-	newConn.Logger(connection.logger)
-	connections[key] = connection
-
-	return connection, nil
+	return conn, nil
 }
 
 // NewConnection creates physical modbus device from config

--- a/util/modbus/modbus_test.go
+++ b/util/modbus/modbus_test.go
@@ -1,11 +1,54 @@
 package modbus
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestConnectionRefs ensures the physical connection is kept until the context
+// of the last sharing connection is done
+func TestConnectionRefs(t *testing.T) {
+	key := "localhost:15021"
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	ctx2, cancel2 := context.WithCancel(t.Context())
+
+	for _, ctx := range []context.Context{ctx1, ctx2} {
+		_, err := Settings{URI: key, ID: 1}.Connection(ctx)
+		require.NoError(t, err)
+	}
+
+	refs := func() (int, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		conn, ok := connections[key]
+		if !ok {
+			return 0, false
+		}
+		return conn.refs, true
+	}
+
+	r, ok := refs()
+	require.True(t, ok)
+	require.Equal(t, 1, r)
+
+	// first context done releases its reference only
+	cancel1()
+	require.Eventually(t, func() bool {
+		r, ok := refs()
+		return ok && r == 0
+	}, time.Second, 10*time.Millisecond)
+
+	cancel2()
+	require.Eventually(t, func() bool {
+		_, ok := refs()
+		return !ok
+	}, time.Second, 10*time.Millisecond)
+}
 
 // TestSharedSettings ensures the largest delay and timeout wins for all
 // connections sharing the same physical connection


### PR DESCRIPTION
Follow-up to #32694.

Physical modbus connections are shared by uri or device and reference-counted, but the goroutine that releases a reference when the owning context is done was only started for the very first registration. Every additional device sharing the same connection incremented the counter without ever releasing it, so the connection was never closed and stayed in the registry.

- the release handler is now started for each registration, not just the first
- a shared connection is closed once the last sharing context is done

🤖 Generated with [Claude Code](https://claude.com/claude-code)