### PR TITLE
History UI: add prefetch and caching

### DIFF
--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -120,6 +120,18 @@ function daysInMonth(year: number, month: number) {
 	return new Date(year, month, 0).getDate();
 }
 
+function shiftPeriod(period: PERIODS, from: Date, offset: number): Date {
+	switch (period) {
+		case PERIODS.DAY:
+			return new Date(from.getFullYear(), from.getMonth(), from.getDate() + offset);
+		case PERIODS.YEAR:
+			return new Date(from.getFullYear() + offset, 0, 1);
+		case PERIODS.MONTH:
+		default:
+			return new Date(from.getFullYear(), from.getMonth() + offset, 1);
+	}
+}
+
 export default defineComponent({
 	name: "History",
 	components: {
@@ -204,18 +216,7 @@ export default defineComponent({
 			}
 		},
 		to(): Date {
-			switch (this.effectivePeriod) {
-				case PERIODS.DAY: {
-					const d = new Date(this.from);
-					d.setDate(d.getDate() + 1);
-					return d;
-				}
-				case PERIODS.YEAR:
-					return new Date(this.effectiveYear + 1, 0, 1);
-				case PERIODS.MONTH:
-				default:
-					return new Date(this.effectiveYear, this.effectiveMonth, 1);
-			}
+			return shiftPeriod(this.effectivePeriod, this.from, 1);
 		},
 		aggregate(): string {
 			switch (this.effectivePeriod) {
@@ -466,27 +467,43 @@ export default defineComponent({
 		},
 		async fetchData() {
 			this.loading = true;
+			const requestKey = this.fetchKey;
 			const requestFrom = this.from;
 			const requestTo = this.to;
 			const requestPeriod = this.effectivePeriod;
 			try {
-				const res = await api.get("history/energy", {
-					params: {
-						from: requestFrom.toISOString(),
-						to: requestTo.toISOString(),
-						aggregate: this.aggregate,
-						grouped: false,
-					},
-				});
+				const res = await this.fetchEnergy(requestFrom, requestTo);
+				// a newer request superseded this one
+				if (requestKey !== this.fetchKey) return;
 				this.rawSeries = res.data || [];
 				this.displayFrom = requestFrom;
 				this.displayTo = requestTo;
 				this.displayPeriod = requestPeriod;
+				this.prefetchAdjacent();
 			} catch (e) {
 				console.error("Failed to load energy history", e);
 				// keep previous data on error
 			} finally {
-				this.loading = false;
+				if (requestKey === this.fetchKey) this.loading = false;
+			}
+		},
+		fetchEnergy(from: Date, to: Date) {
+			return api.get("history/energy", {
+				params: {
+					from: from.toISOString(),
+					to: to.toISOString(),
+					aggregate: this.aggregate,
+					grouped: false,
+				},
+			});
+		},
+		// warm the browser http cache for the prev/next period
+		prefetchAdjacent() {
+			for (const offset of [-1, 1]) {
+				const from = shiftPeriod(this.effectivePeriod, this.from, offset);
+				const to = shiftPeriod(this.effectivePeriod, this.from, offset + 1);
+				if (from > new Date() || to <= this.startDate) continue;
+				this.fetchEnergy(from, to).catch(() => {});
 			}
 		},
 		buildBaseQuery(): Record<string, string | undefined> {

--- a/server/http_history_handler.go
+++ b/server/http_history_handler.go
@@ -3,11 +3,13 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/evcc-io/evcc/core/metrics"
 	"github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util/locale"
 	"golang.org/x/text/language"
 )
@@ -76,6 +78,14 @@ func energyHistoryHandler(w http.ResponseWriter, r *http.Request) {
 		exportResult(ctx, w, format, metrics.SeriesExport(res), historyFilename(from, aggregate))
 		return
 	}
+
+	// past periods are immutable; current period only changes at the next slot
+	slot := time.Now().Truncate(tariff.SlotDuration)
+	maxAge := time.Until(slot.Add(tariff.SlotDuration))
+	if !to.IsZero() && to.Before(slot) {
+		maxAge = time.Hour
+	}
+	w.Header().Set("Cache-Control", fmt.Sprintf("private, max-age=%d", int(maxAge.Seconds())))
 
 	jsonWrite(w, res)
 }

--- a/server/http_history_handler.go
+++ b/server/http_history_handler.go
@@ -79,12 +79,8 @@ func energyHistoryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// past periods are immutable; current period only changes at the next slot
-	slot := time.Now().Truncate(tariff.SlotDuration)
-	maxAge := time.Until(slot.Add(tariff.SlotDuration))
-	if !to.IsZero() && to.Before(slot) {
-		maxAge = time.Hour
-	}
+	// data only changes at the next slot boundary
+	maxAge := time.Until(time.Now().Truncate(tariff.SlotDuration).Add(tariff.SlotDuration))
 	w.Header().Set("Cache-Control", fmt.Sprintf("private, max-age=%d", int(maxAge.Seconds())))
 
 	jsonWrite(w, res)


### PR DESCRIPTION
Switching periods in the History view always refetched from scratch, making prev/next navigation and swiping feel sluggish. This uses the browser HTTP cache as the only cache layer instead of adding client-side state.

- `history/energy` responses send `Cache-Control` with `max-age` expiring at the next 15 minute slot boundary (`tariff.SlotDuration`), when new data can land
- after each load the adjacent prev/next period is prefetched to warm the cache, so date switching renders instantly
- stale responses from rapid swiping are dropped instead of overwriting newer data

🤖 Generated with [Claude Code](https://claude.com/claude-code)