### PR TITLE
chore: consolidate CI Go and Playwright caches

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,15 +26,14 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
-      - uses: actions/cache@v6
+      # shared cache, written by the Build job on master only
+      - uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-clean-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-clean-
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - name: Install tools
         run: make install
@@ -66,15 +65,15 @@ jobs:
           cache: false
         id: go
 
-      - uses: actions/cache@v6
+      # single writer of the shared cache all other jobs restore from
+      - uses: actions/cache/restore@v6
+        id: go-cache
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-build-
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -85,6 +84,17 @@ jobs:
 
       - name: Build
         run: make build
+
+      # PR caches are only visible to their own PR, so writing them wastes the
+      # repo cache budget and evicts the master entry every job falls back to
+      - name: Save Go cache
+        if: github.ref == 'refs/heads/master' && steps.go-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   test:
     name: Test
@@ -104,15 +114,14 @@ jobs:
           cache: false
         id: go
 
-      - uses: actions/cache@v6
+      # shared cache, written by the Build job on master only
+      - uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-test-
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test
@@ -135,15 +144,14 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
-      - uses: actions/cache@v6
+      # shared cache, written by the Build job on master only
+      - uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-lint-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-lint-
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - run: mkdir dist && touch dist/empty
 
@@ -224,15 +232,14 @@ jobs:
           cache: false
         id: go
 
-      - uses: actions/cache@v6
+      # shared cache, written by the Build job on master only
+      - uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-integration-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-integration-
-            ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -250,7 +257,7 @@ jobs:
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -260,6 +267,13 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: vpx playwright install --with-deps chromium
         timeout-minutes: 5
+
+      - name: Save Playwright browsers
+        if: github.ref == 'refs/heads/master' && steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Run tests
         run: vpx playwright test


### PR DESCRIPTION
pairs with #32700

The five Go jobs in `default.yml` cache the identical paths — `~/.cache/go-build` and `~/go/pkg/mod` — under five different keys, so the same content is stored up to five times per ref. That is 7.5 of the 9.5 GiB currently sitting in a 10 GiB repo budget, which keeps the shared master entry every job's `restore-keys` falls back to evicted: the API shows zero `Linux-go-*` caches on `refs/heads/master`, and `last_accessed_at` equals `created_at` on every Go cache, i.e. none was ever read back.

Caches written on a PR ref are also only visible to that PR, so for a PR that runs once they cannot be read at all.

- all Go jobs restore one shared `${{ runner.os }}-go-<go.sum>` key
- the Build job is the single writer, and only on master
- Playwright browsers get the same restore-everywhere, save-on-master treatment
- expected footprint: ~7.5 GiB of Go caches down to ~0.5 GiB, ~876 MB of Playwright down to ~292 MB

`build-toolchain` still writes `pr`-scoped caches; it is only used by the on-demand build commands and is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)