### PR TITLE
chore: disable unused CodeQL overlay database cache

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,9 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    env:
+      # we don't analyze pull requests, so the cached overlay base databases are never restored
+      CODEQL_OVERLAY_DATABASE_MODE: None
     permissions:
       # required for all workflows
       security-events: write


### PR DESCRIPTION
The CodeQL workflow writes ~124 MB of overlay base databases to the Actions cache on every master push that nothing ever reads.

`codeql-action` picks the overlay mode from branch context (`checkOverlayEnablement` in `src/config-utils.ts`):

- default branch → `OverlayBase` + caching — *builds and uploads* the base database
- pull request → `Overlay` + caching — *restores* that base for incremental analysis

`codeql.yml` only runs on `push: master`, `schedule` and `workflow_dispatch`, never on pull requests. So the write side runs on every master push and the read side never runs at all. The cache key ends in `-${sha}-${runId}-${attemptId}`, so no entry can be reused even in principle.

Measured on the repo cache today: 18 `codeql-overlay-base-database-*` entries, 1.10 GB, all created within a few hours by 9 master pushes, 0 restores.

Setting `CODEQL_OVERLAY_DATABASE_MODE: None` disables overlay mode and, as a side effect, `useOverlayDatabaseCaching`. Analysis results are unaffected — overlay is an incremental-analysis optimization, not a query setting.

That frees ~1.1 GB against the 10 GB repo cache limit, which the Go and Playwright caches were competing with after #32701.

Alternative considered: add `pull_request` to the triggers so the base is actually used. That would make the cache pay off, but adds a full CodeQL run to every PR — happy to go that way instead if preferred.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
