### PR TITLE
chore: drop the shared Go cache from CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,15 +26,6 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
       - name: Install tools
         run: make install
 
@@ -65,16 +56,6 @@ jobs:
           cache: false
         id: go
 
-      # single writer of the shared cache all other jobs restore from
-      - uses: actions/cache/restore@v6
-        id: go-cache
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: "26"
@@ -84,17 +65,6 @@ jobs:
 
       - name: Build
         run: make build
-
-      # PR caches are only visible to their own PR, so writing them wastes the
-      # repo cache budget and evicts the master entry every job falls back to
-      - name: Save Go cache
-        if: github.ref == 'refs/heads/master' && steps.go-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   test:
     name: Test
@@ -113,15 +83,6 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test
@@ -143,15 +104,6 @@ jobs:
           go-version-file: go.mod
           cache: false # avoid cache thrashing
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - run: mkdir dist && touch dist/empty
 
@@ -231,15 +183,6 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - uses: voidzero-dev/setup-vp@v1
         with:


### PR DESCRIPTION
Follow-up to #32701. Consolidating the five per-job Go caches into one shared entry made the caches actually hit — and that turned out to be slower than missing them.

## PR runs: cache miss vs cache hit

Same workflow, same runner type, two PR runs a few hours apart. The first predates #32701 and missed in every job; the second restores the shared 6.9 GB entry.

| job | cold (miss) | cached (hit) |
| --- | ---: | ---: |
| Clean | 168s | 294s |
| Build | 150s | 277s |
| Lint | 183s | 282s |
| Test | 216s | 299s |
| Integration | 248s | 330s |
| UI | 94s | 94s |
| **total** | **1059s** | **1576s** |

Step level, Build job:

```
cold                              cached
  10s  actions/setup-go            12s  actions/setup-go
   -   (no restore)               210s  actions/cache/restore
  95s  make build                  11s  make build
 125s  total steps                252s  total steps
```

The cache saves 84s of compilation and costs 210s to unpack. That is a net loss of ~127s in every Go job, five jobs per run.

## master is worse

The nightly Build job also writes the entry back:

```
206s  actions/cache/restore
310s  actions/cache/save
 27s  make build
601s  job total
```

86% of the job is cache I/O around 27s of work. Across the run, restore+save is ~1240s of runner time.

## The entry does not converge

`~/go/pkg/mod` is never trimmed, and each `go.sum` rotation restores the previous blob via `restore-keys`, adds to it and saves a larger one:

```
6 Aug   4457 MB
7 Aug   4457 MB
8 Aug   4457 MB
9 Aug   4582 MB
9 Aug   4595 MB
10 Aug  4595 MB
10 Aug  4624 MB
10 Aug  6934 MB
```

`go.sum` / `package-lock.json` move ~26x per 30 days on master, so this ratchets roughly daily. A clean `GOMODCACHE` for the current `go.sum` is 2.1 GB, so most of what is being shipped around is stale module versions.

## Side effect

Frees 6.9 GB of the 10 GiB repo cache budget. The Docker build-mount cache (#32700) and the Playwright browsers currently compete with it.

The Docker mount cache is unaffected by this change and stays: it costs 88s (20s restore + 68s inject) and saves 376s of build, which is the trade this one fails.

## If a Go cache is wanted later

It would have to stay small enough that unpacking beats recompiling — under roughly 2.5 GB at the ~33 MB/s effective restore rate observed here. That means `~/.cache/go-build` only, with a bounded key, not `~/go/pkg/mod`. Not attempted here; measuring first seemed better than guessing at a size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
