### PR TITLE
chore: trial a go-build-only CI cache

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,6 +26,12 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
+      - uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-gobuild-
+
       - name: Install tools
         run: make install
 
@@ -56,6 +62,12 @@ jobs:
           cache: false
         id: go
 
+      - uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-gobuild-
+
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: "26"
@@ -65,6 +77,13 @@ jobs:
 
       - name: Build
         run: make build
+
+      # trial: unconditional save so the second run of this branch sees a hit
+      - name: Save Go build cache
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ github.sha }}
 
   test:
     name: Test
@@ -83,6 +102,12 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
+
+      - uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-gobuild-
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test
@@ -104,6 +129,12 @@ jobs:
           go-version-file: go.mod
           cache: false # avoid cache thrashing
         id: go
+
+      - uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-gobuild-
 
       - run: mkdir dist && touch dist/empty
 
@@ -183,6 +214,12 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
+
+      - uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-gobuild-
 
       - uses: voidzero-dev/setup-vp@v1
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,15 +26,6 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
       - name: Install tools
         run: make install
 
@@ -65,16 +56,6 @@ jobs:
           cache: false
         id: go
 
-      # single writer of the shared cache all other jobs restore from
-      - uses: actions/cache/restore@v6
-        id: go-cache
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: "26"
@@ -84,17 +65,6 @@ jobs:
 
       - name: Build
         run: make build
-
-      # PR caches are only visible to their own PR, so writing them wastes the
-      # repo cache budget and evicts the master entry every job falls back to
-      - name: Save Go cache
-        if: github.ref == 'refs/heads/master' && steps.go-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   test:
     name: Test
@@ -113,15 +83,6 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test
@@ -143,15 +104,6 @@ jobs:
           go-version-file: go.mod
           cache: false # avoid cache thrashing
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - run: mkdir dist && touch dist/empty
 
@@ -231,15 +183,6 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - uses: voidzero-dev/setup-vp@v1
         with:


### PR DESCRIPTION
Experiment on top of #32703, not for merge as-is.

Measures whether a `~/.cache/go-build`-only cache (no `~/go/pkg/mod`) restores fast enough to beat recompiling. Saves unconditionally so the second run of this branch sees a hit.

Baseline to beat, from #32703: 816s total, Build 97s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)