### PR TITLE
chore: trial a module-only CI cache

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,6 +26,12 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
+
       - name: Install tools
         run: make install
 
@@ -56,6 +62,12 @@ jobs:
           cache: false
         id: go
 
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
+
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: "26"
@@ -65,6 +77,13 @@ jobs:
 
       - name: Build
         run: make build
+
+      - name: Save module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
   test:
     name: Test
@@ -83,6 +102,12 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
+
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test
@@ -104,6 +129,12 @@ jobs:
           go-version-file: go.mod
           cache: false # avoid cache thrashing
         id: go
+
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
       - run: mkdir dist && touch dist/empty
 
@@ -183,6 +214,12 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
+
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
       - uses: voidzero-dev/setup-vp@v1
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,15 +26,6 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
       - name: Install tools
         run: make install
 
@@ -65,16 +56,6 @@ jobs:
           cache: false
         id: go
 
-      # single writer of the shared cache all other jobs restore from
-      - uses: actions/cache/restore@v6
-        id: go-cache
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: "26"
@@ -84,17 +65,6 @@ jobs:
 
       - name: Build
         run: make build
-
-      # PR caches are only visible to their own PR, so writing them wastes the
-      # repo cache budget and evicts the master entry every job falls back to
-      - name: Save Go cache
-        if: github.ref == 'refs/heads/master' && steps.go-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   test:
     name: Test
@@ -113,15 +83,6 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test
@@ -143,15 +104,6 @@ jobs:
           go-version-file: go.mod
           cache: false # avoid cache thrashing
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - run: mkdir dist && touch dist/empty
 
@@ -231,15 +183,6 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
-
-      # shared cache, written by the Build job on master only
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
 
       - uses: voidzero-dev/setup-vp@v1
         with:


### PR DESCRIPTION
Stacked on #32703, sibling to #32704. Splits the other half of the cache that #32703 removes: modules only, no build cache.

`~/go/pkg/mod` is fully determined by `go.sum`, so this uses an exact key with **no `restore-keys` chain**. That is the difference from the cache #32703 removes: without prefix fallback there is no restore-add-resave cycle, so an entry cannot accumulate stale module versions. Each `go.sum` rotation starts a fresh entry at the true working-set size — measured at 2.1 GB for the current `go.sum`.

Baseline to beat, from #32703: 232s to green, 816s runner minutes, Build 97s.

## Expectation

Honestly, this one looks marginal before it runs. At the ~33 MB/s effective restore rate observed on these runners, 2.1 GB is roughly 65s to unpack, against a proxy fetch that took 16s in the Docker build. If that holds it is a net loss and the PR should be closed rather than merged — but the combined-cache measurements were surprising enough in both directions that guessing seemed worse than measuring.

The trial saves whenever the exact key is missing, so the second run of this branch sees a hit. The guard would be tightened to master-only before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
