### PR TITLE
chore: trial a module-only CI cache

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,6 +26,12 @@ jobs:
           cache: false # avoid cache thrashing
         id: go
 
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
+
       - name: Install tools
         run: make install
 
@@ -56,6 +62,12 @@ jobs:
           cache: false
         id: go
 
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
+
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: "26"
@@ -65,6 +77,13 @@ jobs:
 
       - name: Build
         run: make build
+
+      - name: Save module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
   test:
     name: Test
@@ -83,6 +102,12 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
+
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
       - name: Test
         run: mkdir dist && touch dist/empty && make test
@@ -104,6 +129,12 @@ jobs:
           go-version-file: go.mod
           cache: false # avoid cache thrashing
         id: go
+
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
       - run: mkdir dist && touch dist/empty
 
@@ -183,6 +214,12 @@ jobs:
           go-version-file: go.mod
           cache: false
         id: go
+
+      - uses: actions/cache/restore@v6
+        id: go-mod-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
 
       - uses: voidzero-dev/setup-vp@v1
         with:


### PR DESCRIPTION
Sibling to #32707, both on top of the merged #32703. Splits one half of the cache that #32703 removed: modules only, no build cache.

`~/go/pkg/mod` is fully determined by `go.sum`, so this uses an exact key with **no `restore-keys` chain**. That is the structural difference from the cache #32703 removed: without prefix fallback there is no restore-add-resave cycle, so an entry cannot accumulate stale module versions. Each `go.sum` rotation starts a fresh entry at the true working-set size.

Baseline to beat, from #32703: 232s to green, 816s runner minutes, Build 97s.

## First run

Cold, saves the entry: **189 MB**, 4s to write.

That is the number that matters. The cache #32703 removed had grown to 6.9 GB, which turned out not to be the natural size of a module cache at all — it was the `restore-keys` ratchet accumulating every job's objects across every `go.sum` rotation. On an exact key the entry is ~1/40th of that.

(An earlier estimate of 2.1 GB in this description was wrong: it came from `go mod download all`, which fetches the whole module graph including test-only and transitive dependencies that `make build` never compiles.)

Second run measures the hit.

The trial saves whenever the exact key is missing, so the second run of this branch sees a hit. The guard would be tightened to master-only before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
