### PR TITLE
chore: trial setup-go's built-in cache

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
         id: go
 
       - name: Install tools
@@ -53,7 +52,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
         id: go
 
       - uses: voidzero-dev/setup-vp@v1
@@ -81,7 +79,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
         id: go
 
       - name: Test
@@ -102,7 +99,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
         id: go
 
       - run: mkdir dist && touch dist/empty
@@ -181,7 +177,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: true
         id: go
 
       - uses: voidzero-dev/setup-vp@v1

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false # avoid cache thrashing
+          cache: true
         id: go
 
       - name: Install tools
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
         id: go
 
       - uses: voidzero-dev/setup-vp@v1
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
         id: go
 
       - name: Test
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false # avoid cache thrashing
+          cache: true
         id: go
 
       - run: mkdir dist && touch dist/empty
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
         id: go
 
       - uses: voidzero-dev/setup-vp@v1


### PR DESCRIPTION
follows #32703

Drops the `cache: false` overrides so `default.yml` uses `actions/setup-go`'s cache, matching what `release.yml` and `nightly.yml` already do by not passing the input at all.

Result, against the #32703 baseline of 816s total / Build 97s: **706s total, Build 72s**.

Two things the run showed:

- there was no cold run to measure. The very first job hit `setup-go-Linux-arm64-ubuntu24-go-1.26.3-<go.sum>`, ~695 MB, restored in ~9.5s. `release.yml` and `nightly.yml` have been populating that key all along, because setup-go defaults `cache` to true and neither passes the input. Only `default.yml` opted out.
- on a hit the post step logs `Cache hit occurred on the primary key …, not saving cache`, so there are no per-PR writes. It saves only when the key misses, i.e. on a `go.sum` or Go version change — one entry per dependency set, not one per PR ref.

Note that this key does not appear in the repo's `/actions/caches` listing, so it seems to live outside GitHub's cache store and its budget. Worth confirming before drawing conclusions about cache size limits from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)