### PR TITLE
chore: fix the CodeQL overlay mode value so it takes effect

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     env:
       # we don't analyze pull requests, so the cached overlay base databases are never restored
-      CODEQL_OVERLAY_DATABASE_MODE: None
+      CODEQL_OVERLAY_DATABASE_MODE: none
     permissions:
       # required for all workflows
       security-events: write


### PR DESCRIPTION
Follows #32702, which had the right idea but a value the action silently ignores.

`codeql-action` compares the environment variable against `OverlayDatabaseMode`, and those values are lowercase:

```ts
// src/overlay/overlay-database-mode.ts
export enum OverlayDatabaseMode {
  Overlay = "overlay",
  OverlayBase = "overlay-base",
  None = "none",
}
```

`src/config-utils.ts:705` reads `process.env.CODEQL_OVERLAY_DATABASE_MODE` and matches it with strict `===` against those three. Its own comment states the consequence: *"Any unrecognized `CODEQL_OVERLAY_DATABASE_MODE` value will be ignored and treated as if the environment variable was not set."* `None` is unrecognized, so the setting never applied.

## Evidence from the first master run carrying #32702

Run [31415755848](https://github.com/evcc-io/evcc/actions/runs/31415755848), `Analyze (go)`:

```
Setting overlay database mode to overlay-base with caching because we are analyzing the default branch.
Using overlay database mode: overlay-base with caching.
Uploading overlay-base database to Actions cache with key
  codeql-overlay-base-database-1-afb37b2280877c56-go-2.26.2-1f9c762c...-31415755848-1
```

When the action does honour the variable it logs `Setting overlay database mode to ... from the CODEQL_OVERLAY_DATABASE_MODE environment variable`. That line appears **0 times** in the job log — it took the automatic-mode branch instead.

## Why this is worth fixing

The comment #32702 added is accurate: this workflow triggers on `push: [master]`, `schedule` and `workflow_dispatch` only. The action uses `Overlay` mode when analyzing a pull request and `OverlayBase` when analyzing the default branch, so with no `pull_request` trigger nothing ever restores these. Every master push wrote ~70 MB per language into the Actions cache to be read by nobody — 18 such entries had accumulated before today's cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
