### PR TITLE
MQTT: publish the forecast as a single JSON message

### DIFF
--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"math"
 	"time"
 
@@ -12,6 +13,24 @@ import (
 	"github.com/jinzhu/now"
 	"github.com/samber/lo"
 )
+
+// forecastDetails is the published forecast payload. It implements BytesMarshaler
+// so MQTT sends a single JSON message instead of decomposing every slot into an
+// individual topic (several thousand messages per update).
+type forecastDetails struct {
+	Co2         [][]float64   `json:"co2,omitempty"`
+	FeedIn      [][]float64   `json:"feedin,omitempty"`
+	Grid        [][]float64   `json:"grid,omitempty"`
+	Planner     [][]float64   `json:"planner,omitempty"`
+	Solar       *solarDetails `json:"solar,omitempty"`
+	Temperature [][]float64   `json:"temperature,omitempty"`
+}
+
+var _ api.BytesMarshaler = (*forecastDetails)(nil)
+
+func (fc forecastDetails) MarshalBytes() ([]byte, error) {
+	return json.Marshal(fc)
+}
 
 type solarDetails struct {
 	Scale            float64      `json:"scale"`                      // scale factor yield/forecasted today, 1 if unscaled
@@ -115,14 +134,7 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 		site.publish(keys.TariffCo2Loadpoints, v)
 	}
 
-	fc := struct {
-		Co2         [][]float64   `json:"co2,omitempty"`
-		FeedIn      [][]float64   `json:"feedin,omitempty"`
-		Grid        [][]float64   `json:"grid,omitempty"`
-		Planner     [][]float64   `json:"planner,omitempty"`
-		Solar       *solarDetails `json:"solar,omitempty"`
-		Temperature [][]float64   `json:"temperature,omitempty"`
-	}{
+	fc := forecastDetails{
 		Co2:         forecastRates(tariff.Rates(site.GetTariff(api.TariffUsageCo2))),
 		FeedIn:      forecastRates(tariff.Rates(site.GetTariff(api.TariffUsageFeedIn))),
 		Planner:     forecastRates(tariff.Rates(site.GetTariff(api.TariffUsagePlanner))),

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -89,6 +89,16 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload any) {
 		return
 	}
 
+	if mm, ok := payload.(api.StructMarshaler); ok {
+		d, err := mm.MarshalStruct()
+		if err != nil {
+			m.log.ERROR.Printf("marshal struct: %v", err)
+			return
+		}
+		payload = d
+		// fallthrough, the unwrapped value is still checked below
+	}
+
 	if mm, ok := payload.(api.BytesMarshaler); ok {
 		if b, err := mm.MarshalBytes(); err == nil {
 			m.publishSingleValue(topic, retained, string(b))
@@ -96,16 +106,6 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload any) {
 			m.log.ERROR.Printf("marshal bytes: %v", err)
 		}
 		return
-	}
-
-	if mm, ok := payload.(api.StructMarshaler); ok {
-		if d, err := mm.MarshalStruct(); err != nil {
-			m.log.ERROR.Printf("marshal struct: %v", err)
-			return
-		} else {
-			payload = d
-			// fallthrough
-		}
 	}
 
 	switch typ := reflect.TypeOf(payload); typ.Kind() {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"math"
 	"slices"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/core/types"
+	"github.com/evcc-io/evcc/util"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -95,6 +97,22 @@ func (suite *mqttSuite) TestSlice() {
 	suite.Require().Len(suite.topics, 3)
 	suite.Equal([]string{"test", "test/1", "test/2"}, suite.topics, "topics")
 	suite.Equal([]string{"2", "10", "20"}, suite.payloads, "payloads")
+}
+
+type jsonPayload struct {
+	Foo [][]float64 `json:"foo,omitempty"`
+}
+
+func (p jsonPayload) MarshalBytes() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+// a BytesMarshaler wrapped in a Sharder must still publish as a single message
+func (suite *mqttSuite) TestShardedBytesMarshaler() {
+	p := jsonPayload{Foo: [][]float64{{1, 2, 3}, {4, 5, 6}}}
+	suite.publish("test", false, util.NewSharder("test", p))
+	suite.Equal([]string{"test"}, suite.topics, "topics")
+	suite.Equal([]string{`{"foo":[[1,2,3],[4,5,6]]}`}, suite.payloads, "payloads")
 }
 
 func (suite *mqttSuite) TestNilInterface() {


### PR DESCRIPTION
fixes #32673

## What the log shows

From the trace log attached to the issue:

```
send evcc/site/forecast/temperature/532: '3'
send evcc/site/forecast/temperature/532/1: '1786193100'
send evcc/site/forecast/temperature/532/2: '1786194000'
send evcc/site/forecast/temperature/532/3: '30.7'
```

Each forecast series is `[][]float64`, one `[start, end, value]` triple per slot. `publishComplex` publishes a slice as its length plus one message per element, recursively — so a series of *n* slots costs `1 + 4n` messages. With ~720 temperature slots that is ~2.900 messages for `temperature` alone, and `grid`, `feedin` and `planner` add their own. The reporter measured the 10.000 line ring buffer filling in about two seconds, which crowds every other log area out of the view — including the areas needed to pick a vehicle or a charger.

## Why it decomposed

The forecast is published as a `util.Sharder` so the websocket can send only the changed series. `sharderImpl` implements `api.StructMarshaler`, and `publishComplex` checked the marshalers in this order:

1. `fmt.Stringer` / nil
2. `api.BytesMarshaler` → single JSON message
3. `api.StructMarshaler` → unwrap, then **fall through to reflection**

Because the unwrap happened last, whatever came out of it was never reconsidered for `BytesMarshaler` — it went straight into the recursive struct/slice walk.

## Change

Move the `BytesMarshaler` check behind the struct marshaler, and give the forecast payload a named type implementing `api.BytesMarshaler`. Both halves are needed: reordering alone would still reflect, and the marshaler alone would never be reached through the `Sharder`.

This is the same approach already used for `optimizerResult` (`core/site_optimizer.go`) and the solar `timeseries` (`core/solar.go`) — the latter sits inside this very payload, which is why `forecast/solar` was already a single JSON message while its siblings were not.

Reordering is safe: `sharderImpl` is the only `StructMarshaler` in the tree, and it does not also implement `BytesMarshaler`, so no type changes which branch it takes.

Websocket sharding is untouched — `server/socket.go` type-asserts the `Sharder` before MQTT is involved.

## Result

`evcc/site/forecast` becomes one retained JSON message:

```json
{"co2":[[1786193100,1786194000,412]],"temperature":[[1786193100,1786194000,30.7]],"solar":{...}}
```

## Breaking change

Subscribers reading `evcc/site/forecast/<series>/<slot>/<n>` need to parse the JSON instead. Note that the old sub-topics were published retained, so a broker will keep serving them until they are cleared — worth mentioning in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
