### PR TITLE
MQTT: publish one forecast message per key (BC)

### DIFF
--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"math"
 	"time"
 
@@ -13,12 +14,29 @@ import (
 	"github.com/samber/lo"
 )
 
+// forecastSeries and solarDetails implement BytesMarshaler so MQTT publishes one
+// json message per forecast key instead of decomposing every slot into its own
+// topic (several thousand messages per update).
+type forecastSeries [][]float64
+
+var _ api.BytesMarshaler = (*forecastSeries)(nil)
+
+func (s forecastSeries) MarshalBytes() ([]byte, error) {
+	return json.Marshal(s)
+}
+
 type solarDetails struct {
 	Scale            float64      `json:"scale"`                      // scale factor yield/forecasted today, 1 if unscaled
 	Today            dailyDetails `json:"today,omitempty"`            // tomorrow
 	Tomorrow         dailyDetails `json:"tomorrow,omitempty"`         // tomorrow
 	DayAfterTomorrow dailyDetails `json:"dayAfterTomorrow,omitempty"` // day after tomorrow
 	Timeseries       timeseries   `json:"timeseries,omitempty"`       // timeseries of forecasted energy
+}
+
+var _ api.BytesMarshaler = (*solarDetails)(nil)
+
+func (d solarDetails) MarshalBytes() ([]byte, error) {
+	return json.Marshal(d)
 }
 
 type dailyDetails struct {
@@ -29,7 +47,7 @@ type dailyDetails struct {
 // forecastRates publishes rates as [start, end, value] with the timestamps in
 // unix seconds. The forecast is the largest payload evcc sends and RFC3339
 // timestamps are two thirds of it.
-func forecastRates(rr api.Rates) [][]float64 {
+func forecastRates(rr api.Rates) forecastSeries {
 	// keep nil for empty rates: shards are published without omitempty
 	if len(rr) == 0 {
 		return nil
@@ -116,12 +134,12 @@ func (site *Site) publishTariffs(greenShareHome float64, greenShareLoadpoints fl
 	}
 
 	fc := struct {
-		Co2         [][]float64   `json:"co2,omitempty"`
-		FeedIn      [][]float64   `json:"feedin,omitempty"`
-		Grid        [][]float64   `json:"grid,omitempty"`
-		Planner     [][]float64   `json:"planner,omitempty"`
-		Solar       *solarDetails `json:"solar,omitempty"`
-		Temperature [][]float64   `json:"temperature,omitempty"`
+		Co2         forecastSeries `json:"co2,omitempty"`
+		FeedIn      forecastSeries `json:"feedin,omitempty"`
+		Grid        forecastSeries `json:"grid,omitempty"`
+		Planner     forecastSeries `json:"planner,omitempty"`
+		Solar       *solarDetails  `json:"solar,omitempty"`
+		Temperature forecastSeries `json:"temperature,omitempty"`
 	}{
 		Co2:         forecastRates(tariff.Rates(site.GetTariff(api.TariffUsageCo2))),
 		FeedIn:      forecastRates(tariff.Rates(site.GetTariff(api.TariffUsageFeedIn))),

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -89,6 +89,16 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload any) {
 		return
 	}
 
+	if mm, ok := payload.(api.StructMarshaler); ok {
+		d, err := mm.MarshalStruct()
+		if err != nil {
+			m.log.ERROR.Printf("marshal struct: %v", err)
+			return
+		}
+		payload = d
+		// fallthrough, the unwrapped value is still checked below
+	}
+
 	if mm, ok := payload.(api.BytesMarshaler); ok {
 		if b, err := mm.MarshalBytes(); err == nil {
 			m.publishSingleValue(topic, retained, string(b))
@@ -96,16 +106,6 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload any) {
 			m.log.ERROR.Printf("marshal bytes: %v", err)
 		}
 		return
-	}
-
-	if mm, ok := payload.(api.StructMarshaler); ok {
-		if d, err := mm.MarshalStruct(); err != nil {
-			m.log.ERROR.Printf("marshal struct: %v", err)
-			return
-		} else {
-			payload = d
-			// fallthrough
-		}
 	}
 
 	switch typ := reflect.TypeOf(payload); typ.Kind() {

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -89,16 +89,6 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload any) {
 		return
 	}
 
-	if mm, ok := payload.(api.StructMarshaler); ok {
-		d, err := mm.MarshalStruct()
-		if err != nil {
-			m.log.ERROR.Printf("marshal struct: %v", err)
-			return
-		}
-		payload = d
-		// fallthrough, the unwrapped value is still checked below
-	}
-
 	if mm, ok := payload.(api.BytesMarshaler); ok {
 		if b, err := mm.MarshalBytes(); err == nil {
 			m.publishSingleValue(topic, retained, string(b))
@@ -106,6 +96,16 @@ func (m *MQTT) publishComplex(topic string, retained bool, payload any) {
 			m.log.ERROR.Printf("marshal bytes: %v", err)
 		}
 		return
+	}
+
+	if mm, ok := payload.(api.StructMarshaler); ok {
+		if d, err := mm.MarshalStruct(); err != nil {
+			m.log.ERROR.Printf("marshal struct: %v", err)
+			return
+		} else {
+			payload = d
+			// fallthrough
+		}
 	}
 
 	switch typ := reflect.TypeOf(payload); typ.Kind() {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"math"
 	"slices"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/core/types"
+	"github.com/evcc-io/evcc/util"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -95,6 +97,26 @@ func (suite *mqttSuite) TestSlice() {
 	suite.Require().Len(suite.topics, 3)
 	suite.Equal([]string{"test", "test/1", "test/2"}, suite.topics, "topics")
 	suite.Equal([]string{"2", "10", "20"}, suite.payloads, "payloads")
+}
+
+type jsonSeries [][]float64
+
+func (s jsonSeries) MarshalBytes() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// a sharded struct publishes one message per key, BytesMarshaler fields as json
+func (suite *mqttSuite) TestSharderBytesMarshaler() {
+	p := struct {
+		Foo jsonSeries `json:"foo,omitempty"`
+		Bar jsonSeries `json:"bar,omitempty"`
+	}{
+		Foo: jsonSeries{{1, 2, 3}, {4, 5, 6}},
+	}
+
+	suite.publish("test", false, util.NewSharder("test", p))
+	suite.Equal([]string{"test/foo", "test/bar"}, suite.topics, "topics")
+	suite.Equal([]string{"[[1,2,3],[4,5,6]]", ""}, suite.payloads, "payloads")
 }
 
 func (suite *mqttSuite) TestNilInterface() {


### PR DESCRIPTION
fixes #32673

## What the log shows

From the trace attached to the issue:

```
send evcc/site/forecast/temperature/532:   '3'
send evcc/site/forecast/temperature/532/1: '1786193100'
send evcc/site/forecast/temperature/532/2: '1786194000'
send evcc/site/forecast/temperature/532/3: '30.7'
```

Each series is `[][]float64`, one `[start, end, value]` triple per slot. `publishComplex` publishes a slice as its length plus one message per element, recursively, so a series of *n* slots costs `1 + 4n` messages. With ~720 temperature slots that is ~2.900 for `temperature` alone, plus `grid`, `feedin` and `planner`. The reporter measured the 10.000 line ring buffer filling in about two seconds, which crowds every other area out of the log view — including the ones needed to pick a vehicle or a charger.

## Change

`forecastSeries` and `solarDetails` implement `api.BytesMarshaler`. The struct walk reaches each field of the unwrapped forecast and each field marshals itself, so every forecast key becomes one json message:

```
evcc/site/forecast/co2         [[1786193100,1786194000,412],...]
evcc/site/forecast/grid        [[1786193100,1786194000,0.28],...]
evcc/site/forecast/temperature [[1786193100,1786194000,30.7],...]
evcc/site/forecast/solar       {"scale":1,"today":{...},"timeseries":[...]}
```

One message per key rather than one for the whole forecast, so a subscriber can still watch a single series, and the topics match the shard boundaries the websocket already uses.

`server/mqtt.go` is untouched. This is the same mechanism `timeseries` (`core/solar.go`) and `optimizerResult` (`core/site_optimizer.go`) already rely on — `timeseries` sits inside `solarDetails`, which is why `forecast/solar/timeseries` was already a single json message while its siblings were not.

Empty series keep their existing behaviour: the struct walk publishes an empty payload for a zero field with `omitempty`, clearing the retained topic.

Websocket sharding is unaffected — `server/socket.go` type-asserts the `Sharder` before MQTT is involved.

## Breaking change

Subscribers reading `evcc/site/forecast/<series>/<slot>/<n>` need to parse the json array at `evcc/site/forecast/<series>` instead. Site params publish with `retained=true` (`server/mqtt.go:343`), so a broker keeps serving the old sub-topics until they are cleared — worth a release-note line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
