### PR TITLE
battery: push Normal mode once on startup so a configured reserve reaches the device

### DIFF
--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -107,7 +107,11 @@ func (site *Site) requiredBatteryMode(batteryGridChargeActive bool, rate api.Rat
 		res = keepUnlessModified(api.BatteryCharge)
 	case site.dischargeControlActive(rate):
 		res = keepUnlessModified(api.BatteryHold)
-	case batteryModeModified(batMode):
+	case batteryModeModified(batMode) || batMode == api.BatteryUnknown:
+		// batMode == Unknown covers the not-yet-initialized case: site.batteryMode is
+		// runtime-only and starts at its zero value, so without this a site that never
+		// triggers grid charge or discharge control would never call applyBatteryMode and
+		// so never push a configured battery's reserve (minsoc) to the device.
 		res = api.BatteryNormal
 	}
 

--- a/core/site_battery_test.go
+++ b/core/site_battery_test.go
@@ -46,8 +46,10 @@ func TestApplyBatteryMode(t *testing.T) {
 	for _, tc := range []struct {
 		internal, expected api.BatteryMode
 	}{
-		{api.BatteryUnknown, api.BatteryUnknown}, // no change required
-		{api.BatteryNormal, api.BatteryUnknown},  // no change required
+		// not yet initialized: push Normal once so a configured reserve (minsoc) reaches
+		// the device even if grid charge/discharge control never activate (#32653)
+		{api.BatteryUnknown, api.BatteryNormal},
+		{api.BatteryNormal, api.BatteryUnknown}, // no change required
 		{api.BatteryHold, api.BatteryNormal},
 		{api.BatteryCharge, api.BatteryNormal},
 	} {
@@ -89,7 +91,8 @@ func TestRequiredExternalBatteryMode(t *testing.T) {
 	for _, tc := range []struct {
 		internal, external, new api.BatteryMode
 	}{
-		{api.BatteryUnknown, api.BatteryUnknown, api.BatteryUnknown},
+		// not yet initialized: push Normal once (#32653)
+		{api.BatteryUnknown, api.BatteryUnknown, api.BatteryNormal},
 		{api.BatteryUnknown, api.BatteryNormal, api.BatteryNormal},
 		{api.BatteryUnknown, api.BatteryCharge, api.BatteryCharge},
 
@@ -120,7 +123,8 @@ func TestExternalBatteryModeChange(t *testing.T) {
 	for _, tc := range []struct {
 		internal, external, expected api.BatteryMode
 	}{
-		{api.BatteryUnknown, api.BatteryUnknown, api.BatteryUnknown},
+		// not yet initialized: push Normal once (#32653)
+		{api.BatteryUnknown, api.BatteryUnknown, api.BatteryNormal},
 		{api.BatteryUnknown, api.BatteryNormal, api.BatteryNormal},
 		{api.BatteryUnknown, api.BatteryCharge, api.BatteryCharge},
 

--- a/core/site_test.go
+++ b/core/site_test.go
@@ -188,8 +188,11 @@ func TestRequiredBatteryMode(t *testing.T) {
 		gridChargeActive bool
 		mode, res        api.BatteryMode
 	}{
-		{false, api.BatteryUnknown, api.BatteryUnknown}, // ignore
-		{false, api.BatteryNormal, api.BatteryUnknown},  // ignore
+		// not yet initialized (runtime-only field, starts at zero value): push Normal once so
+		// a configured reserve (minsoc) reaches the device even if grid charge/discharge
+		// control never activate (#32653)
+		{false, api.BatteryUnknown, api.BatteryNormal},
+		{false, api.BatteryNormal, api.BatteryUnknown}, // ignore
 		{false, api.BatteryHold, api.BatteryNormal},
 		{false, api.BatteryCharge, api.BatteryNormal},
 


### PR DESCRIPTION
Fixes #32653

`site.batteryMode` is runtime-only and starts at its zero value (`BatteryUnknown`). `requiredBatteryMode`'s fallback case only fired for a *previously modified* mode returning to `Normal`:

```go
case batteryModeModified(batMode):
    res = api.BatteryNormal
```

`batteryModeModified` excludes `BatteryUnknown`, so on a site that never activates grid charge or discharge control, `requiredBatteryMode` keeps returning `BatteryUnknown` forever, `applyBatteryMode` is never called, and nothing is ever pushed to the battery.

For devices wired through the `limitsoc`/`BatteryController` pattern (`meter/usage_battery.go`'s `batterySocLimitsCtx.LimitController`, used by e.g. the Victron template), `BatteryNormal` already writes the configured `minsoc` to the device as its discharge reserve:

```go
case api.BatteryNormal:
    return limitSocS(floatOr0(minG))
```

So the mechanism to respect a configured minimum discharge reserve is fully wired already - it just never triggers without a first mode transition, which only happens today if grid charge or discharge control activate at least once.

Fix: also treat "never initialized" as needing a push to `Normal`:

```go
case batteryModeModified(batMode) || batMode == api.BatteryUnknown:
    res = api.BatteryNormal
```

Fires once (site.batteryMode becomes `Normal` after the first successful apply, so it doesn't re-fire every cycle - same pattern as the existing Charge/Hold transitions).

One thing worth calling out for review: `minsoc`/`maxsoc` default to 20/95 when unconfigured (`meter/meter.go`), so this makes evcc assert that default onto the device from the first cycle instead of only after the user first triggers grid-charge/discharge-control. Not a new risk - the same default already applies once those features activate - but it now fires unconditionally on every startup, so flagging it explicitly rather than let it surprise a reviewer.

Out of scope: extending other templates (e.g. Fronius) to read `minsoc` from a live register - the underlying plugin support already exists (`batterySocLimitsCtx.MinSoc any`), this is just a template-level addition someone else is already looking at per the issue thread.

Existing tests (`TestApplyBatteryMode`, `TestRequiredExternalBatteryMode`, `TestExternalBatteryModeChange`, `TestRequiredBatteryMode`) updated for the one row each affected (`{Unknown, Unknown} → Normal`), all other rows unaffected and traced by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)