### PR TITLE
chore: disable the unused CodeQL TRAP cache

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          # we don't analyze pull requests, so the uploaded TRAP caches are never downloaded
+          trap-caching: false
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
follows #32709

`CODEQL_OVERLAY_DATABASE_MODE: none` only turned off the overlay base database cache. TRAP caching is a separate feature and is still active, so every push to master uploads a TRAP cache that nothing ever downloads, because the workflow analyzes the default branch only.

- disable TRAP caching in `github/codeql-action/init`
- stops a 12 MB Actions cache entry from being written per push to master

From the most recent CodeQL run:

```
Analyzing default branch. Skipping downloading of TRAP caches.
Uploading TRAP cache to Actions cache with key codeql-trap-1-2.26.2-javascript-<sha>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
