### PR TITLE
chore: warm the GitHub-scoped cache from master for fork PRs

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -234,3 +234,50 @@ jobs:
           name: playwright-test-results
           path: test-results/
           retention-days: 2
+
+  warm-fork-cache:
+    name: Warm fork cache
+    # fork pull requests cannot use Depot's cache and fall back to the GitHub one,
+    # which only master can seed for them. Must not run on a Depot runner, those
+    # write to Depot's cache instead
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+        id: go
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "26"
+          cache: true
+
+      - name: Build UI
+        run: make install-ui ui
+
+      - name: Build Go
+        run: make build
+
+      - name: Get Playwright version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: Install Playwright (browsers + deps)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: vpx playwright install --with-deps chromium
+        timeout-minutes: 5

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -235,11 +235,11 @@ jobs:
           path: test-results/
           retention-days: 2
 
-  warm-fork-cache:
-    name: Warm fork cache
-    # fork pull requests cannot use Depot's cache and fall back to the GitHub one,
-    # which only master can seed for them. Must not run on a Depot runner, those
-    # write to Depot's cache instead
+  # fork pull requests cannot use Depot's cache and fall back to the GitHub one,
+  # which only master can seed for them. Must not run on a Depot runner, those
+  # write to Depot's cache instead
+  warm-fork-cache-go:
+    name: Warm fork cache (Go)
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04-arm
 
@@ -256,16 +256,28 @@ jobs:
           go-version-file: go.mod
         id: go
 
+      # on a hit setup-go does not save again, so building would populate nothing
+      - name: Build
+        if: steps.go.outputs.cache-hit != 'true'
+        run: mkdir dist && touch dist/empty && make build
+
+  warm-fork-cache-ui:
+    name: Warm fork cache (UI)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: "26"
           cache: true
-
-      - name: Build UI
-        run: make install-ui ui
-
-      - name: Build Go
-        run: make build
 
       - name: Get Playwright version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
@@ -279,5 +291,5 @@ jobs:
 
       - name: Install Playwright (browsers + deps)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: vpx playwright install --with-deps chromium
+        run: make install-ui && vpx playwright install --with-deps chromium
         timeout-minutes: 5


### PR DESCRIPTION
Pull requests from forks cannot use Depot's cache, so `actions/cache`, `setup-go` and `setup-vp` fall back to GitHub's own cache in those runs. Nothing seeds that cache: every in-repo run writes to Depot instead, so a fork PR starts cold and then keeps a private copy scoped to its own `refs/pull/N/merge`.

Two effects, both measurable today:

- Playwright browsers are reinstalled on every fork PR run. In run `31405620828` (fork of a contributor) that took 157s of a 248s Integration job. `Save Playwright browsers` is gated to master, and master's save lands in Depot's cache, so a fork never restores it and never writes one either.
- Forks also run without Depot's remote Go build cache (`GOCACHEPROG=''` versus `GOCACHEPROG='/usr/local/bin/depot gocache'` in-repo), so every Go job recompiles from scratch.

Those private per-PR copies are also the bulk of the repository's Actions cache: 2.4 GB across six fork PRs, all duplicates of the same three entries.

This adds two master-only jobs that populate the GitHub-scoped cache with the same keys the fork runs look for. Fork PRs restore from the base branch instead of rebuilding, and because the keys then hit exactly, they stop saving duplicates of their own.

The two jobs are independent, so they run in parallel: the Go one only needs `go build` against a placeholder `dist`, the UI one only needs the Playwright browsers. Both skip their build step when the cache already hit, which costs nothing: on a hit `setup-go` and `actions/cache` do not save again, so the work would populate nothing.

The jobs deliberately run on `ubuntu-24.04-arm` rather than a Depot runner: on Depot the cache endpoint is transparently repointed, so the entries would go back to Depot's cache and never become visible to forks. `ubuntu-24.04-arm` matches what `setup-go` derives its key from (`RUNNER_OS`, `process.arch`, `ImageOS`), so the key is identical to the one the Depot runs produce: `setup-go-Linux-arm64-ubuntu24-go-<version>-<hash>`.

Master push rather than nightly, because two of the three keys hash `go.mod` and the lockfile. A nightly warm-up would go stale the moment a dependency bump lands, which is exactly when it is needed.

Worth confirming once this is on master: `gh cache list --json key,ref` should show these keys against `refs/heads/master`. If the key text differs from the fork-scoped ones, the warmed entries are dead weight and the jobs should go again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
