### PR TITLE
chore: fix the warmed Go cache key so fork builds match it

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -251,7 +251,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # setup-go puts ImageOS in the cache key, and GitHub's arm image reports
+      # ubuntu24-arm64 where Depot's reports ubuntu24. Without the override the
+      # warmed entry never matches the key a fork run looks for
       - uses: actions/setup-go@v7
+        env:
+          ImageOS: ubuntu24
         with:
           go-version-file: go.mod
         id: go


### PR DESCRIPTION
Follow-up to #32726. Two of the three warmed caches landed on the keys fork runs look for, the Go one did not.

From the first master run after the merge:

```
setup-go-Linux-arm64-ubuntu24-arm64-go-1.26.3-46e402…   written by the warm job
setup-go-Linux-arm64-ubuntu24-go-1.26.3-46e402…         what a fork run looks for
```

`setup-go` builds its key as `setup-go-${platform}-${arch}-${ImageOS}-go-${version}-${hash}`. GitHub's `ubuntu-24.04-arm` image reports `ImageOS=ubuntu24-arm64`, Depot's reports `ubuntu24`, so the warmed entry can never be hit and the 355 MB it occupies is dead weight until it expires.

Overriding `ImageOS` for that step lines the key back up. The restored contents are the module cache and the Go build cache, both of which are keyed on the Go version and `GOARCH`/`GOOS` rather than the image, so they stay valid across the two runners.

The other two keys need no change, they already match byte for byte:

```
vite-plus-Linux-arm64-npm-6e77082b9d74c49dc098aee34f51c0d43b9b3079e9206876edbb755e483abacd
Linux-playwright-1.62.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
