### PR TITLE
chore: enable vp task caching

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -132,6 +132,15 @@ jobs:
       - name: Install
         run: make install-ui
 
+      - name: Restore vp task cache
+        id: vp-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-vp-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vp-
+
       - name: OpenAPI
         # backport release tags may not have the openapi target yet
         run: if grep -q '^openapi' Makefile; then make openapi; fi
@@ -147,6 +156,14 @@ jobs:
 
       - name: Build UI
         run: make ui
+
+      - name: Save vp task cache
+        # avoid cache thrashing by nightly and pull requests
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ steps.vp-cache.outputs.cache-primary-key }}
 
       - name: Cache dist
         # avoid cache thrashing by nightly

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,11 @@ const frontendPort = Number(process.env.VITE_PORT) || 7071;
 const backendUrl = `http://localhost:${Number(process.env.VITE_BACKEND_PORT) || 7070}`;
 
 export default defineConfig({
+  run: {
+    cache: {
+      scripts: true,
+    },
+  },
   staged: {
     "*": "vp check --fix",
   },


### PR DESCRIPTION
Vite+ does not cache `package.json` scripts by default, so every `vp run` in CI logs `cache disabled` and the UI job re-runs lint, type check and build from scratch on each commit. This turns script caching on and restores the task cache between CI runs.

- `run.cache.scripts: true` in `vite.config.ts`. A repeated `vp run lint` locally goes from 0/5 to 5/5 cache hit, `vp run build` replays and restores `dist/` from the archive
- the UI job restores `node_modules/.vite/task-cache` after install and saves it only on master pushes, so pull requests and nightly do not thrash the cache
- `vp run test` and `vp run openapi` stay uncached because both read and write their own inputs, vitest its `results.json` and the schema generator its output. Excluding those needs task definitions with an explicit `input`, left out here
- cross-run task caching is flagged experimental upstream, the fallback is a plain cache miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)
