### PR TITLE
chore: reuse the vp task cache in the integration job

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -201,8 +201,20 @@ jobs:
           node-version: "26"
           cache: true
 
+      - name: Install
+        run: make install-ui
+
+      - name: Restore vp task cache
+        # restore only, the UI job owns saving the cache
+        uses: actions/cache/restore@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-vp-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vp-
+
       - name: Build UI
-        run: make install-ui ui
+        run: make ui
 
       - name: Build Go
         run: make build


### PR DESCRIPTION
follows #32729, depends on #32733

The integration job builds the UI as well, but had no access to the task cache the UI job saves, so it rebuilds from scratch on every run. Splitting install from build lets the restore step sit between them, which is where the Vite+ docs want it because installing can recreate `node_modules`.

- restore only, the UI job stays the single writer so both jobs of a run cannot race for the same cache key
- saves the UI build on runs that do not touch the frontend, roughly 15s once #32733 makes the build fingerprint portable between jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
