### PR TITLE
chore: narrow the vitest cache exclusion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This file provides guidance to AI coding agents when working with code in this r
 - `make lint-ui` - run frontend linting
 - `vp run dev` - start Vue dev server (http://127.0.0.1:7071)
 - `vp run playwright` - run integration tests
+- `build`, `openapi` and `test` are cached tasks in `vite.config.ts`, run them through `vp run` instead of adding `package.json` scripts
 - `evcc --config [file] --disable-auth` - run a throw-away instance for UI checks without password setup
 - `evcc --template-type [type] --template [file]` - test device templates
 - `make docs` - generate template documentation

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         command:
           "cross-env TZ=Europe/Berlin NODE_OPTIONS=--no-experimental-webstorage vp test",
         // vitest keeps its own result cache below node_modules
-        input: [{ auto: true }, "!**/node_modules/.vite/**"],
+        input: [{ auto: true }, "!**/node_modules/.vite/vitest/**"],
       },
     },
   },


### PR DESCRIPTION
follows #32733

Picks up the two review points from #32733, which was merged before the follow-up commit reached the branch.

- narrows the negated glob to the vitest cache directory so other `.vite` artifacts stay in the fingerprint, a repeated `vp run test` still replays
- notes in AGENTS.md that `build`, `openapi` and `test` are tasks now, so they are not reintroduced as `package.json` scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
