### PR TITLE
fix: keep Portuguese placeholder names untranslated

### DIFF
--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -57,8 +57,8 @@
       },
       "empty": "vazio",
       "full": "cheio",
-      "highest": "Mais elevado ({valor})",
-      "lowest": "Mais baixo ({valor})",
+      "highest": "Mais elevado ({value})",
+      "lowest": "Mais baixo ({value})",
       "suggestion": "Sugestão"
     }
   },
@@ -1311,7 +1311,7 @@
         "label": "Carga tardia",
         "optionAll": "tudo",
         "optionNo": "não",
-        "summary": "{pré-condição} antes de"
+        "summary": "{precondition} antes de"
       },
       "remove": "Apagar",
       "repeating": "recorrente",


### PR DESCRIPTION
Placeholder names are identifiers, not translatable text. In `i18n/pt.json` three of them were localized, which breaks `i18n/check.ts` and the runtime interpolation:

- `battery.optimizer.highest` / `.lowest`: `{valor}` -> `{value}`
- `main.chargingPlan.precondition.summary`: `{pré-condição}` -> `{precondition}`

Blocks every PR whose checks run against `weblate-translation`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)