### PR TITLE
Powerwall: add dynamic battery parameters

### DIFF
--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -1,6 +1,7 @@
 package meter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -27,17 +28,14 @@ type powerWallConfig struct {
 	Cache                      time.Duration
 	SiteId                     int64  // Fleet API only, deprecated for the local meter
 	RefreshToken_              string `mapstructure:"refreshToken"` // TODO deprecated
-	batterySocLimits           `mapstructure:",squash"`
-	batteryPowerLimits         `mapstructure:",squash"`
+	batteryCapacityCtx         `mapstructure:",squash"`
+	batterySocLimitsCtx        `mapstructure:",squash"`
+	batteryPowerLimitsCtx      `mapstructure:",squash"`
 }
 
 func defaultPowerWallConfig() powerWallConfig {
 	return powerWallConfig{
-		batterySocLimits: batterySocLimits{
-			MinSoc: 20,
-			MaxSoc: 95,
-		},
-		batteryPowerLimits: batteryPowerLimits{
+		batteryPowerLimitsCtx: batteryPowerLimitsCtx{
 			MaxChargePower:    4600,
 			MaxDischargePower: 4600,
 		},
@@ -67,12 +65,12 @@ func (cc *powerWallConfig) validate() error {
 }
 
 func init() {
-	registry.Add("tesla", NewPowerWallFromConfig)
-	registry.Add("powerwall", NewPowerWallFromConfig)
+	registry.AddCtx("tesla", NewPowerWallFromConfig)
+	registry.AddCtx("powerwall", NewPowerWallFromConfig)
 }
 
 // NewPowerWallFromConfig creates a PowerWall Powerwall Meter from generic config
-func NewPowerWallFromConfig(other map[string]any) (api.Meter, error) {
+func NewPowerWallFromConfig(ctx context.Context, other map[string]any) (api.Meter, error) {
 	cc := defaultPowerWallConfig()
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -88,10 +86,10 @@ func NewPowerWallFromConfig(other map[string]any) (api.Meter, error) {
 		log.WARN.Println("refreshToken is deprecated, use the Powerwall (Fleet API) template for battery control")
 	}
 
-	return newPowerWall(log, cc)
+	return newPowerWall(ctx, log, cc)
 }
 
-func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
+func newPowerWall(ctx context.Context, log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 	httpClient := &http.Client{
 		Transport: request.NewTripper(log, powerwall.DefaultTransport()),
 		Timeout:   time.Second * 2, // Timeout after 2 seconds
@@ -114,18 +112,56 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 	}
 
 	if m.usage == "battery" {
-		implement.Has(m, implement.Battery(m.batterySoc))
-		implement.May(m, implement.BatterySocLimiter(cc.batterySocLimits.Decorator()))
-		implement.May(m, implement.BatteryPowerLimiter(cc.batteryPowerLimits.Decorator()))
-
-		res, err := m.client.GetSystemStatus()
+		capacity, err := cc.batteryCapacityCtx.Decorator(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		implement.Has(m, implement.BatteryCapacity(func() float64 {
-			return res.NominalFullPackEnergy / 1e3
-		}))
+		minG, maxG, err := cc.batterySocLimitsCtx.getters(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if minG == nil {
+			opG := util.Cached(client.GetOperation, cc.Cache)
+			minG = func() float64 {
+				op, err := opG()
+				if err != nil {
+					return 0
+				}
+				return op.BackupReservePercent
+			}
+		}
+
+		if maxG == nil {
+			maxG = func() float64 { return 100 }
+		}
+
+		socLimiter := func() (float64, float64) {
+			return minG(), maxG()
+		}
+
+		powerLimiter, err := cc.batteryPowerLimitsCtx.Decorator(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		implement.Has(m, implement.Battery(m.batterySoc))
+		implement.May(m, implement.BatterySocLimiter(socLimiter))
+		implement.May(m, implement.BatteryPowerLimiter(powerLimiter))
+
+		if capacity != nil {
+			implement.Has(m, implement.BatteryCapacity(capacity))
+		} else {
+			res, err := m.client.GetSystemStatus()
+			if err != nil {
+				return nil, err
+			}
+
+			implement.Has(m, implement.BatteryCapacity(func() float64 {
+				return res.NominalFullPackEnergy / 1e3
+			}))
+		}
 	}
 
 	return m, nil

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -124,7 +124,6 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 
 		implement.Has(m, implement.Battery(m.batterySoc))
 
-		// capacity only degrades over time, reading it once is enough
 		implement.Has(m, implement.BatteryCapacity(func() float64 {
 			return status.NominalFullPackEnergy / 1e3
 		}))

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -127,6 +127,7 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 		implement.Has(m, implement.BatteryCapacity(func() float64 {
 			res, err := statusG()
 			if err != nil {
+				log.ERROR.Println("battery capacity:", err)
 				return 0
 			}
 			return res.NominalFullPackEnergy / 1e3
@@ -136,6 +137,7 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 		implement.Has(m, implement.BatterySocLimiter(func() (float64, float64) {
 			op, err := opG()
 			if err != nil {
+				log.ERROR.Println("battery soc limits:", err)
 				return 0, 100
 			}
 			return op.BackupReservePercent, 100
@@ -146,6 +148,7 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 			implement.Has(m, implement.BatteryPowerLimiter(func() (float64, float64) {
 				res, err := statusG()
 				if err != nil {
+					log.ERROR.Println("battery power limits:", err)
 					return 0, 0
 				}
 				return res.MaxApparentPower, res.MaxApparentPower

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -35,10 +35,6 @@ type powerWallConfig struct {
 
 func defaultPowerWallConfig() powerWallConfig {
 	return powerWallConfig{
-		batteryPowerLimitsCtx: batteryPowerLimitsCtx{
-			MaxChargePower:    4600,
-			MaxDischargePower: 4600,
-		},
 		Cache: time.Second,
 	}
 }
@@ -146,22 +142,29 @@ func newPowerWall(ctx context.Context, log *util.Logger, cc powerWallConfig) (*P
 			return nil, err
 		}
 
-		implement.Has(m, implement.Battery(m.batterySoc))
-		implement.May(m, implement.BatterySocLimiter(socLimiter))
-		implement.May(m, implement.BatteryPowerLimiter(powerLimiter))
-
-		if capacity != nil {
-			implement.Has(m, implement.BatteryCapacity(capacity))
-		} else {
+		if capacity == nil || powerLimiter == nil {
 			res, err := m.client.GetSystemStatus()
 			if err != nil {
 				return nil, err
 			}
 
-			implement.Has(m, implement.BatteryCapacity(func() float64 {
-				return res.NominalFullPackEnergy / 1e3
-			}))
+			if capacity == nil {
+				capacity = func() float64 {
+					return res.NominalFullPackEnergy / 1e3
+				}
+			}
+
+			if powerLimiter == nil && res.MaxApparentPower > 0 {
+				powerLimiter = func() (float64, float64) {
+					return res.MaxApparentPower, res.MaxApparentPower
+				}
+			}
 		}
+
+		implement.Has(m, implement.Battery(m.batterySoc))
+		implement.May(m, implement.BatterySocLimiter(socLimiter))
+		implement.May(m, implement.BatteryPowerLimiter(powerLimiter))
+		implement.Has(m, implement.BatteryCapacity(capacity))
 	}
 
 	return m, nil

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -26,16 +25,18 @@ type PowerWall struct {
 type powerWallConfig struct {
 	URI, Usage, User, Password string
 	Cache                      time.Duration
-	SiteId                     int64  // Fleet API only, deprecated for the local meter
-	RefreshToken_              string `mapstructure:"refreshToken"` // TODO deprecated
-	batteryCapacityCtx         `mapstructure:",squash"`
-	batterySocLimitsCtx        `mapstructure:",squash"`
-	batteryPowerLimitsCtx      `mapstructure:",squash"`
+	SiteId                     int64   // Fleet API only, deprecated for the local meter
+	RefreshToken_              string  `mapstructure:"refreshToken"` // TODO deprecated
+	MinSoc                     float64 // Fleet API only, backup reserve restored in normal mode
+	MaxSoc_                    any     `mapstructure:"maxsoc"`            // TODO deprecated
+	MaxChargePower_            any     `mapstructure:"maxchargepower"`    // TODO deprecated
+	MaxDischargePower_         any     `mapstructure:"maxdischargepower"` // TODO deprecated
 }
 
 func defaultPowerWallConfig() powerWallConfig {
 	return powerWallConfig{
-		Cache: time.Second,
+		Cache:  time.Second,
+		MinSoc: 20,
 	}
 }
 
@@ -61,12 +62,12 @@ func (cc *powerWallConfig) validate() error {
 }
 
 func init() {
-	registry.AddCtx("tesla", NewPowerWallFromConfig)
-	registry.AddCtx("powerwall", NewPowerWallFromConfig)
+	registry.Add("tesla", NewPowerWallFromConfig)
+	registry.Add("powerwall", NewPowerWallFromConfig)
 }
 
 // NewPowerWallFromConfig creates a PowerWall Powerwall Meter from generic config
-func NewPowerWallFromConfig(ctx context.Context, other map[string]any) (api.Meter, error) {
+func NewPowerWallFromConfig(other map[string]any) (api.Meter, error) {
 	cc := defaultPowerWallConfig()
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -82,10 +83,14 @@ func NewPowerWallFromConfig(ctx context.Context, other map[string]any) (api.Mete
 		log.WARN.Println("refreshToken is deprecated, use the Powerwall (Fleet API) template for battery control")
 	}
 
-	return newPowerWall(ctx, log, cc)
+	return newPowerWall(log, cc)
 }
 
-func newPowerWall(ctx context.Context, log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
+func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
+	if cc.MaxSoc_ != nil || cc.MaxChargePower_ != nil || cc.MaxDischargePower_ != nil {
+		log.WARN.Println("maxsoc, maxchargepower and maxdischargepower are deprecated, values are read from the device")
+	}
+
 	httpClient := &http.Client{
 		Transport: request.NewTripper(log, powerwall.DefaultTransport()),
 		Timeout:   time.Second * 2, // Timeout after 2 seconds
@@ -108,74 +113,44 @@ func newPowerWall(ctx context.Context, log *util.Logger, cc powerWallConfig) (*P
 	}
 
 	if m.usage == "battery" {
-		capacity, err := cc.batteryCapacityCtx.Decorator(ctx)
+		statusG := util.Cached(client.GetSystemStatus, cc.Cache)
+		opG := util.Cached(client.GetOperation, cc.Cache)
+
+		// validate connectivity and gate power limiter capability
+		status, err := statusG()
 		if err != nil {
 			return nil, err
-		}
-
-		minG, maxG, err := cc.batterySocLimitsCtx.getters(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		if minG == nil {
-			opG := util.Cached(client.GetOperation, cc.Cache)
-			minG = func() float64 {
-				op, err := opG()
-				if err != nil {
-					return 0
-				}
-				return op.BackupReservePercent
-			}
-		}
-
-		if maxG == nil {
-			maxG = func() float64 { return 100 }
-		}
-
-		socLimiter := func() (float64, float64) {
-			return minG(), maxG()
-		}
-
-		powerLimiter, err := cc.batteryPowerLimitsCtx.Decorator(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		if capacity == nil || powerLimiter == nil {
-			statusG := util.Cached(client.GetSystemStatus, cc.Cache)
-
-			// validate connectivity and gate power limiter capability
-			res, err := statusG()
-			if err != nil {
-				return nil, err
-			}
-
-			if capacity == nil {
-				capacity = func() float64 {
-					res, err := statusG()
-					if err != nil {
-						return 0
-					}
-					return res.NominalFullPackEnergy / 1e3
-				}
-			}
-
-			if powerLimiter == nil && res.MaxApparentPower > 0 {
-				powerLimiter = func() (float64, float64) {
-					res, err := statusG()
-					if err != nil {
-						return 0, 0
-					}
-					return res.MaxApparentPower, res.MaxApparentPower
-				}
-			}
 		}
 
 		implement.Has(m, implement.Battery(m.batterySoc))
-		implement.May(m, implement.BatterySocLimiter(socLimiter))
-		implement.May(m, implement.BatteryPowerLimiter(powerLimiter))
-		implement.Has(m, implement.BatteryCapacity(capacity))
+
+		implement.Has(m, implement.BatteryCapacity(func() float64 {
+			res, err := statusG()
+			if err != nil {
+				return 0
+			}
+			return res.NominalFullPackEnergy / 1e3
+		}))
+
+		// backup reserve is the lower discharge limit, the powerwall has no upper soc limit
+		implement.Has(m, implement.BatterySocLimiter(func() (float64, float64) {
+			op, err := opG()
+			if err != nil {
+				return 0, 100
+			}
+			return op.BackupReservePercent, 100
+		}))
+
+		if status.MaxApparentPower > 0 {
+			// inverter apparent power applies to charging and discharging alike
+			implement.Has(m, implement.BatteryPowerLimiter(func() (float64, float64) {
+				res, err := statusG()
+				if err != nil {
+					return 0, 0
+				}
+				return res.MaxApparentPower, res.MaxApparentPower
+			}))
+		}
 	}
 
 	return m, nil

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -124,13 +124,9 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 
 		implement.Has(m, implement.Battery(m.batterySoc))
 
+		// capacity only degrades over time, reading it once is enough
 		implement.Has(m, implement.BatteryCapacity(func() float64 {
-			res, err := statusG()
-			if err != nil {
-				log.ERROR.Println("battery capacity:", err)
-				return 0
-			}
-			return res.NominalFullPackEnergy / 1e3
+			return status.NominalFullPackEnergy / 1e3
 		}))
 
 		// backup reserve is the lower discharge limit, the powerwall has no upper soc limit

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -87,10 +87,6 @@ func NewPowerWallFromConfig(other map[string]any) (api.Meter, error) {
 }
 
 func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
-	if cc.MaxSoc_ != nil || cc.MaxChargePower_ != nil || cc.MaxDischargePower_ != nil {
-		log.WARN.Println("maxsoc, maxchargepower and maxdischargepower are deprecated, values are read from the device")
-	}
-
 	httpClient := &http.Client{
 		Transport: request.NewTripper(log, powerwall.DefaultTransport()),
 		Timeout:   time.Second * 2, // Timeout after 2 seconds

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -113,11 +113,10 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 	}
 
 	if m.usage == "battery" {
-		statusG := util.Cached(client.GetSystemStatus, cc.Cache)
 		opG := util.Cached(client.GetOperation, cc.Cache)
 
-		// validate connectivity and gate power limiter capability
-		status, err := statusG()
+		// capacity and power limits are static, reading them validates connectivity
+		status, err := client.GetSystemStatus()
 		if err != nil {
 			return nil, err
 		}
@@ -141,12 +140,7 @@ func newPowerWall(log *util.Logger, cc powerWallConfig) (*PowerWall, error) {
 		if status.MaxApparentPower > 0 {
 			// inverter apparent power applies to charging and discharging alike
 			implement.Has(m, implement.BatteryPowerLimiter(func() (float64, float64) {
-				res, err := statusG()
-				if err != nil {
-					log.ERROR.Println("battery power limits:", err)
-					return 0, 0
-				}
-				return res.MaxApparentPower, res.MaxApparentPower
+				return status.MaxApparentPower, status.MaxApparentPower
 			}))
 		}
 	}

--- a/meter/powerwall.go
+++ b/meter/powerwall.go
@@ -143,19 +143,30 @@ func newPowerWall(ctx context.Context, log *util.Logger, cc powerWallConfig) (*P
 		}
 
 		if capacity == nil || powerLimiter == nil {
-			res, err := m.client.GetSystemStatus()
+			statusG := util.Cached(client.GetSystemStatus, cc.Cache)
+
+			// validate connectivity and gate power limiter capability
+			res, err := statusG()
 			if err != nil {
 				return nil, err
 			}
 
 			if capacity == nil {
 				capacity = func() float64 {
+					res, err := statusG()
+					if err != nil {
+						return 0
+					}
 					return res.NominalFullPackEnergy / 1e3
 				}
 			}
 
 			if powerLimiter == nil && res.MaxApparentPower > 0 {
 				powerLimiter = func() (float64, float64) {
+					res, err := statusG()
+					if err != nil {
+						return 0, 0
+					}
 					return res.MaxApparentPower, res.MaxApparentPower
 				}
 			}

--- a/meter/powerwall_fleet.go
+++ b/meter/powerwall_fleet.go
@@ -1,6 +1,7 @@
 package meter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -19,11 +20,11 @@ type fleetConfig struct {
 }
 
 func init() {
-	registry.Add("powerwall-fleet", NewPowerWallFleetFromConfig)
+	registry.AddCtx("powerwall-fleet", NewPowerWallFleetFromConfig)
 }
 
 // NewPowerWallFleetFromConfig creates a PowerWall meter with Fleet API battery control
-func NewPowerWallFleetFromConfig(other map[string]any) (api.Meter, error) {
+func NewPowerWallFleetFromConfig(ctx context.Context, other map[string]any) (api.Meter, error) {
 	cc := fleetConfig{powerWallConfig: defaultPowerWallConfig()}
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -45,7 +46,7 @@ func NewPowerWallFleetFromConfig(other map[string]any) (api.Meter, error) {
 		cc.Tokens.Access,
 		cc.Tokens.Refresh,
 	)
-	m, err := newPowerWall(log, cc.powerWallConfig)
+	m, err := newPowerWall(ctx, log, cc.powerWallConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func NewPowerWallFleetFromConfig(other map[string]any) (api.Meter, error) {
 		return nil, err
 	}
 
-	implement.May(m, implement.BatteryController(cc.batterySocLimits.LimitController(func() (float64, error) {
+	controller, err := cc.batterySocLimitsCtx.LimitController(ctx, func() (float64, error) {
 		ess, err := energySite.EnergySiteStatus()
 		if err != nil {
 			return 0, fmt.Errorf("get energy site status: %w", err)
@@ -64,7 +65,12 @@ func NewPowerWallFleetFromConfig(other map[string]any) (api.Meter, error) {
 		return math.Round(ess.PercentageCharged), nil
 	}, func(limit float64) error {
 		return energySite.SetBatteryReserve(teslaReserveLimit(limit))
-	})))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	implement.May(m, implement.BatteryController(controller))
 
 	return m, nil
 }

--- a/meter/powerwall_fleet.go
+++ b/meter/powerwall_fleet.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -20,11 +19,11 @@ type fleetConfig struct {
 }
 
 func init() {
-	registry.AddCtx("powerwall-fleet", NewPowerWallFleetFromConfig)
+	registry.Add("powerwall-fleet", NewPowerWallFleetFromConfig)
 }
 
 // NewPowerWallFleetFromConfig creates a PowerWall meter with Fleet API battery control
-func NewPowerWallFleetFromConfig(ctx context.Context, other map[string]any) (api.Meter, error) {
+func NewPowerWallFleetFromConfig(other map[string]any) (api.Meter, error) {
 	cc := fleetConfig{powerWallConfig: defaultPowerWallConfig()}
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
@@ -46,7 +45,7 @@ func NewPowerWallFleetFromConfig(ctx context.Context, other map[string]any) (api
 		cc.Tokens.Access,
 		cc.Tokens.Refresh,
 	)
-	m, err := newPowerWall(ctx, log, cc.powerWallConfig)
+	m, err := newPowerWall(log, cc.powerWallConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +55,10 @@ func NewPowerWallFleetFromConfig(ctx context.Context, other map[string]any) (api
 		return nil, err
 	}
 
-	controller, err := cc.batterySocLimitsCtx.LimitController(ctx, func() (float64, error) {
+	// charge mode raises the reserve to full, normal mode restores the configured minimum
+	limits := batterySocLimits{MinSoc: cc.MinSoc, MaxSoc: 100}
+
+	implement.Has(m, implement.BatteryController(limits.LimitController(func() (float64, error) {
 		ess, err := energySite.EnergySiteStatus()
 		if err != nil {
 			return 0, fmt.Errorf("get energy site status: %w", err)
@@ -65,12 +67,7 @@ func NewPowerWallFleetFromConfig(ctx context.Context, other map[string]any) (api
 		return math.Round(ess.PercentageCharged), nil
 	}, func(limit float64) error {
 		return energySite.SetBatteryReserve(teslaReserveLimit(limit))
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	implement.May(m, implement.BatteryController(controller))
+	})))
 
 	return m, nil
 }

--- a/meter/powerwall_test.go
+++ b/meter/powerwall_test.go
@@ -70,7 +70,36 @@ func TestPowerWallConfigDeprecatedParams(t *testing.T) {
 	decodePowerWallConfig(t, map[string]any{
 		"usage": "battery", "password": "secret",
 		"refreshToken": "token", "siteId": 123,
+		"maxsoc": 95, "maxchargepower": 4600, "maxdischargepower": 4600,
 	})
+}
+
+// battery control must fall back to the default reserve, not to zero
+func TestPowerWallFleetReserve(t *testing.T) {
+	cc := decodePowerWallConfig(t, map[string]any{"usage": "battery", "password": "secret"})
+	limits := batterySocLimits{MinSoc: cc.MinSoc, MaxSoc: 100}
+
+	var reserve float64
+	ctrl := limits.LimitController(
+		func() (float64, error) { return 50, nil },
+		func(limit float64) error { reserve = limit; return nil },
+	)
+
+	tests := []struct {
+		mode api.BatteryMode
+		want float64
+	}{
+		{mode: api.BatteryNormal, want: 20},
+		{mode: api.BatteryHold, want: 50},
+		{mode: api.BatteryCharge, want: 100},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.mode.String(), func(t *testing.T) {
+			require.NoError(t, ctrl(tc.mode))
+			assert.Equal(t, tc.want, reserve)
+		})
+	}
 }
 
 func TestNewPowerWallFleetFromConfigValidation(t *testing.T) {

--- a/meter/powerwall_test.go
+++ b/meter/powerwall_test.go
@@ -29,7 +29,7 @@ func TestNewPowerWallFromConfigValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewPowerWallFromConfig(t.Context(), tc.config)
+			_, err := NewPowerWallFromConfig(tc.config)
 			assert.ErrorContains(t, err, tc.want)
 		})
 	}
@@ -103,7 +103,7 @@ func TestNewPowerWallFleetFromConfigValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewPowerWallFleetFromConfig(t.Context(), tc.config)
+			_, err := NewPowerWallFleetFromConfig(tc.config)
 			if tc.wantSentinel != nil {
 				assert.ErrorIs(t, err, tc.wantSentinel)
 				return

--- a/meter/powerwall_test.go
+++ b/meter/powerwall_test.go
@@ -29,7 +29,7 @@ func TestNewPowerWallFromConfigValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewPowerWallFromConfig(tc.config)
+			_, err := NewPowerWallFromConfig(t.Context(), tc.config)
 			assert.ErrorContains(t, err, tc.want)
 		})
 	}
@@ -103,7 +103,7 @@ func TestNewPowerWallFleetFromConfigValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewPowerWallFleetFromConfig(tc.config)
+			_, err := NewPowerWallFleetFromConfig(t.Context(), tc.config)
 			if tc.wantSentinel != nil {
 				assert.ErrorIs(t, err, tc.wantSentinel)
 				return

--- a/templates/definition/meter/tesla-powerwall-fleet.yaml
+++ b/templates/definition/meter/tesla-powerwall-fleet.yaml
@@ -46,12 +46,7 @@ params:
     help:
       en: optional product identifier of the energy site, use to override autodetection
       de: optionale Product ID dieser Energy Site, zum Übersteuern der automatischen Erkennung
-  - name: minsoc
-    advanced: true
-  - name: maxsoc
-    advanced: true
-  - name: maxchargepower
-  - name: maxdischargepower
+  - preset: battery-params
 render: |
   type: powerwall-fleet
   uri: {{ .host }}
@@ -64,7 +59,4 @@ render: |
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
   siteId: {{ .siteId }}
-  minsoc: {{ .minsoc }}
-  maxsoc: {{ .maxsoc }}
-  maxchargepower: {{ .maxchargepower }}
-  maxdischargepower: {{ .maxdischargepower }}
+  {{- include "battery-params" . }}

--- a/templates/definition/meter/tesla-powerwall-fleet.yaml
+++ b/templates/definition/meter/tesla-powerwall-fleet.yaml
@@ -46,7 +46,18 @@ params:
     help:
       en: optional product identifier of the energy site, use to override autodetection
       de: optionale Product ID dieser Energy Site, zum Übersteuern der automatischen Erkennung
-  - preset: battery-params
+  - name: minsoc
+    default: 20
+    advanced: true
+    help:
+      de: Backup-Reserve, die evcc im Normalbetrieb wiederherstellt
+      en: Backup reserve evcc restores in normal operation
+  - name: maxsoc
+    deprecated: true
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
 render: |
   type: powerwall-fleet
   uri: {{ .host }}
@@ -59,4 +70,4 @@ render: |
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}
   siteId: {{ .siteId }}
-  {{- include "battery-params" . }}
+  minsoc: {{ .minsoc }}

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -16,11 +16,17 @@ params:
     deprecated: true
   - name: siteId
     deprecated: true
-  - preset: battery-params
+  - name: minsoc
+    deprecated: true
+  - name: maxsoc
+    deprecated: true
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
 render: |
   type: powerwall
   uri: {{ .host }}
   usage: {{ .usage }}
   user: customer
   password: {{ .password }} # for user 'customer'
-  {{- include "battery-params" . }}

--- a/templates/definition/meter/tesla-powerwall.yaml
+++ b/templates/definition/meter/tesla-powerwall.yaml
@@ -16,19 +16,11 @@ params:
     deprecated: true
   - name: siteId
     deprecated: true
-  - name: minsoc
-    advanced: true
-  - name: maxsoc
-    advanced: true
-  - name: maxchargepower
-  - name: maxdischargepower
+  - preset: battery-params
 render: |
   type: powerwall
   uri: {{ .host }}
   usage: {{ .usage }}
   user: customer
   password: {{ .password }} # for user 'customer'
-  minsoc: {{ .minsoc }}
-  maxsoc: {{ .maxsoc }}
-  maxchargepower: {{ .maxchargepower }}
-  maxdischargepower: {{ .maxdischargepower }}
+  {{- include "battery-params" . }}


### PR DESCRIPTION
This is an attempt to use the dynamic battery parameters introduced by https://github.com/evcc-io/evcc/pull/31668 for the tesla powerwall to get `minSoc`, `maxChargePower` and `maxDischargePower`. `maxSoc` is always 100%, afaik, it cannot be changed. `capacity` is also dynamic now, since it can change during runtime of evcc.

Currently, it's still possible to define the parameters in the configuration, then, evcc won't use the API and instead, use the configured values. Not sure if user configuration could be completely removed to simplify configuration for the use.

Tested with my Powerwall 2.