### PR TITLE
Sungrow: add caveat for coarse energy resolution

### DIFF
--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -3,6 +3,11 @@ products:
   - brand: Sungrow
     description:
       generic: SG Series Inverter
+caveats:
+  - description:
+      de: Der Wechselrichter meldet den PV-Ertrag nur in 1-kWh-Schritten. Statistische Daten werden dadurch grob dargestellt.
+      en: The inverter reports PV yield only in 1 kWh steps. This results in coarse statistical data.
+    link: https://github.com/evcc-io/evcc/issues/32711
 params:
   - name: usage
     choice: ["grid", "pv"]


### PR DESCRIPTION
relates to #32711

The SG series inverter reports total PV yield (register 5003) in whole 1 kWh steps, so 15-minute energy history advances in coarse chunks. This is a hardware register limitation, not something evcc can smooth out. Document it as a template caveat.

- add caveat with 1 kWh resolution note to `sungrow-inverter` template

🤖 Generated with [Claude Code](https://claude.com/claude-code)