### PR TITLE
Easee: clarify energy delay caveat

### DIFF
--- a/templates/definition/charger/easee.yaml
+++ b/templates/definition/charger/easee.yaml
@@ -17,8 +17,8 @@ requirements:
   evcc: ["sponsorship"]
 caveats:
   - description:
-      de: Seltene Energie-Updates können Ladehistorie und Sitzungsstatistik verfälschen.
-      en: Infrequent energy updates can distort charging history and session statistics.
+      de: Geladene Energie wird teils stark verzögert gemeldet. Das kann Ladehistorie, Sonnenanteil und Sitzungsstatistik verfälschen.
+      en: Charged energy is reported with significant delay. This can distort charging history, solar share and session statistics.
     link: https://github.com/evcc-io/evcc/issues/20594
   - description:
       de: Bei mehreren Ladepunkten in einem Easee-Circuit wirkt die Phasenumschaltung auf alle Ladepunkte.


### PR DESCRIPTION
relates to #32721

Easee reports charged energy with significant delay, sometimes an hour late. Since solar share is calculated when the meter delta arrives, delayed data can yield implausible values (e.g. 0% solar for a PV-charged session). Lead the existing caveat with the actual shortcoming and mention solar share explicitly.

- reword energy update caveat in `easee` template

🤖 Generated with [Claude Code](https://claude.com/claude-code)