### PR TITLE
Tariff: qualify db device log names with the configured title

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -316,13 +316,19 @@ func staticInstance[T any](typ string, cc config.Named, newFromConf newFromConfF
 	return err
 }
 
-// loggerForConfig creates a logger with sensible name for (custom) configurable device
-func loggerForConfig(conf *config.Config) *util.Logger {
+// nameForConfig returns a sensible log name for a (custom) configurable device,
+// qualifying the generic db:<id> with the configured title where available
+func nameForConfig(conf *config.Config) string {
 	res := conf.Named().Name
 	if t := conf.Title; t != "" && t != res {
 		res += "-" + t
 	}
-	return util.NewLogger(res)
+	return res
+}
+
+// loggerForConfig creates a logger with sensible name for (custom) configurable device
+func loggerForConfig(conf *config.Config) *util.Logger {
+	return util.NewLogger(nameForConfig(conf))
 }
 
 func configurableInstance[T any](typ string, conf *config.Config, newFromConf newFromConfFunc[T], h config.Handler[T]) error {
@@ -1212,7 +1218,7 @@ func configureTariffs(conf *globalconfig.Tariffs, names ...string) (*tariff.Tari
 			var instance api.Tariff
 			if !conf.Disable {
 				var err error
-				instance, err = tariffInstance(cc.Name, config.Typed{Type: cc.Type, Other: cc.Other})
+				instance, err = tariffInstance(nameForConfig(&conf), config.Typed{Type: cc.Type, Other: cc.Other})
 				if err != nil {
 					return err
 				}

--- a/cmd/setup_name_test.go
+++ b/cmd/setup_name_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/util/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNameForConfig(t *testing.T) {
+	for _, tc := range []struct {
+		title    string
+		expected string
+	}{
+		{"", "db:8"},
+		{"Solar Forecast 1. Dachseite", "db:8-Solar Forecast 1. Dachseite"},
+		{"db:8", "db:8"}, // title equal to the generated name is not repeated
+	} {
+		conf := config.Config{ID: 8, Properties: config.Properties{Title: tc.title}}
+		assert.Equal(t, tc.expected, nameForConfig(&conf))
+	}
+}


### PR DESCRIPTION
fixes #32746

Tariff devices configured via the UI logged under the generic `db:<id>` area, so a log line could not be traced back to a device. Meters, chargers and vehicles already qualify that name with the configured title via `loggerForConfig`, but tariffs build their logger from the bare config name instead and never pick the title up.

- solar forecast and other db tariffs now log as `db:8-Solar Forecast 1. Dachseite`, matching meters and chargers
- the naming is factored out of `loggerForConfig` so both paths share it

The grid meter part of the issue is not addressed here- a device with no title set still falls back to `db:<id>`, which needs a separate decision on fixed names for single-instance usages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
