### PR TITLE
chore: stop caching dist on pull requests and warm the vp task cache for forks

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -166,8 +166,9 @@ jobs:
           key: ${{ steps.vp-cache.outputs.cache-primary-key }}
 
       - name: Cache dist
-        # avoid cache thrashing by nightly
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        # only the release and nightly builds consume this, both keyed by the
+        # master or tag sha. Pull request entries would never be restored
+        if: github.event_name == 'push'
         uses: actions/cache/save@v6
         id: cache-dist
         with:
@@ -302,6 +303,7 @@ jobs:
 
     permissions:
       contents: read
+      actions: write
 
     steps:
       - uses: actions/checkout@v7
@@ -323,7 +325,30 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
+      - name: Install
+        run: make install-ui
+
       - name: Install Playwright (browsers + deps)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: make install-ui && vpx playwright install --with-deps chromium
+        run: vpx playwright install --with-deps chromium
         timeout-minutes: 5
+
+      # the UI job saves its task cache on a Depot runner, so forks never see
+      # it. Run the same tasks here to seed the GitHub-hosted cache
+      - name: Restore vp task cache
+        id: vp-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-vp-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vp-
+
+      - name: Warm vp tasks
+        run: make openapi lint-ui test-ui ui
+
+      - name: Save vp task cache
+        uses: actions/cache/save@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ steps.vp-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
follows up #32733 and #32738

Two gaps found while auditing the Actions cache. Depot runners proxy the cache API, so the GitHub-hosted store only ever sees fork pull requests — which is where both of these bite.

- The dist cache is keyed by sha and only restored by the release and nightly builds. Pull request entries are written on every run and never read back, so the save is dropped for them.
- The UI job saves the vp task cache on a Depot runner, invisible to forks. The fork cache job now runs the same tasks and seeds the GitHub-hosted copy, so fork pull requests stop replaying `openapi`, `lint`, `test` and `build` from cold.

Also dropped the leftover CodeQL TRAP and overlay entries that #32702 and #32725 stopped producing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
