### PR TITLE
charger/custom: support api.PhaseGetter via optional "getphases" field

### DIFF
--- a/charger/charger.go
+++ b/charger/charger.go
@@ -33,7 +33,7 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.C
 		embed                               `mapstructure:",squash"`
 		Status, Enable, Enabled, MaxCurrent plugin.Config
 		MaxCurrentMillis                    *plugin.Config
-		Identify, Phases1p3p                *plugin.Config
+		Identify, Phases1p3p, GetPhases     *plugin.Config
 		Wakeup                              *plugin.Config
 		Soc                                 *plugin.Config
 		LimitSoc                            *plugin.Config
@@ -97,6 +97,19 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.C
 
 		implement.Has(c, implement.PhaseSwitcher(func(phases int) error {
 			return phases1p3pS(int64(phases))
+		}))
+	}
+
+	// decorate phase getter
+	if cc.GetPhases != nil {
+		getPhasesG, err := cc.GetPhases.IntGetter(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getphases: %w", err)
+		}
+
+		implement.Has(c, implement.PhaseGetter(func() (int, error) {
+			v, err := getPhasesG()
+			return int(v), err
 		}))
 	}
 


### PR DESCRIPTION
### Problem

`type: custom` chargers currently only support `api.PhaseSwitcher` (`phases1p3p`) as a one-way *command* to the charger. For chargers that manage 1p/3p switching autonomously on their own firmware (i.e. evcc does not - and in some cases *cannot* - command the switch itself, only report a power target), evcc's internally tracked phase count (`lp.phases`) can drift from the charger's real, physical state whenever the charger changes phases on its own initiative (e.g. resetting to 1p at the start of every new charging session).

Since `pvScalePhases()` gates the scale-up decision on `phases := lp.GetPhases(); phases < maxPhases`, once `lp.phases` reaches the configured maximum it never re-attempts a scale-up, even when the charger has silently reverted to fewer phases and PV surplus would clearly justify 3p again. Because `syncCharger()`'s built-in mismatch correction only self-heals upward (`chargerPhases > phases`), this makes the loadpoint "stuck" on 1p indefinitely once this happens.

evcc already solves exactly this class of problem for native drivers like Easee and Zaptec, both of which implement `api.PhaseGetter` to let `syncCharger()` correct `lp.phases` in either direction from live charger state (see e.g. #17326 "Easee: fix PhaseGetter returning used, not configured, phases"). `type: custom`, however, has no config surface to expose this capability - only `Phases1p3p` (setter) exists.

### Use case

Schrack i-CHARGE CION with the "self-managing" `EMCIONHxxx` firmware variant: evcc only writes a power target (Watts) via Modbus; the charger's own firmware decides 1p vs. 3p internally and resets to 1p at the start of every new charging session. The charger exposes a live "Schütz-Status" (contactor state) register that reports the actually active phases in real time - exactly the kind of live status `api.PhaseGetter` is designed for, but with no way to wire it up through `type: custom` today.

### Change

Adds an optional `getphases` field to the custom charger config, mirroring the existing `phases1p3p` field almost 1:1, decorating `api.PhaseGetter` when configured:

```yaml
getphases:
  source: ...
  # returns int: currently active phase count (1-3)
```

No behavior changes for existing configs that don't set `getphases` - purely additive.