### PR TITLE
Easee: fix data race in charger state tests

### DIFF
--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -157,7 +157,11 @@ func TestEasee_waitForChargerEnabledState(t *testing.T) {
 
 		if tc.updateState { // simulate state changes
 			go func() {
+				// opMode is read under the lock by inExpectedOpMode
+				e.mux.Lock()
 				e.opMode = easee.ModeCharging // transition to charging
+				e.mux.Unlock()
+
 				if tc.sendObs {
 					e.obsC <- easee.Observation{
 						ID: easee.CHARGER_OP_MODE,
@@ -197,7 +201,11 @@ func TestEasee_waitForDynamicChargerCurrent(t *testing.T) {
 
 		if tc.updateState { // simulate state changes
 			go func() {
+				// dynamicChargerCurrent is read under the lock by waitForDynamicChargerCurrent
+				e.mux.Lock()
 				e.dynamicChargerCurrent = 32 // transition to 32A
+				e.mux.Unlock()
+
 				if tc.sendObs {
 					e.obsC <- easee.Observation{
 						ID:       easee.DYNAMIC_CHARGER_CURRENT,

--- a/charger/easee_test.go
+++ b/charger/easee_test.go
@@ -161,7 +161,6 @@ func TestEasee_waitForChargerEnabledState(t *testing.T) {
 				e.mux.Lock()
 				e.opMode = easee.ModeCharging // transition to charging
 				e.mux.Unlock()
-
 				if tc.sendObs {
 					e.obsC <- easee.Observation{
 						ID: easee.CHARGER_OP_MODE,
@@ -205,7 +204,6 @@ func TestEasee_waitForDynamicChargerCurrent(t *testing.T) {
 				e.mux.Lock()
 				e.dynamicChargerCurrent = 32 // transition to 32A
 				e.mux.Unlock()
-
 				if tc.sendObs {
 					e.obsC <- easee.Observation{
 						ID:       easee.DYNAMIC_CHARGER_CURRENT,


### PR DESCRIPTION
Both `TestEasee_waitForChargerEnabledState` and `TestEasee_waitForDynamicChargerCurrent` simulate a state change from a goroutine by assigning `opMode` / `dynamicChargerCurrent` directly, while the code under test reads those fields under `mux`:

```
WARNING: DATA RACE
Write at 0x00c0006cf340 by goroutine 52:
  charger.TestEasee_waitForChargerEnabledState.func1()
      charger/easee_test.go:160

Previous read at 0x00c0006cf340 by goroutine 51:
  charger.(*Easee).inExpectedOpMode()
      charger/easee.go:563
```

Take the write lock in the simulating goroutines. `go test -race -count=5 -run TestEasee ./charger/` is clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)