### PR TITLE
chore: bump evcc-io/ocpp-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ tool (
 
 replace github.com/grid-x/modbus => github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea
 
-replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20260727074919-195c10b8758d
+replace github.com/lorenzodonini/ocpp-go => github.com/evcc-io/ocpp-go v0.0.0-20260812074841-a8aa5fef8a9e
 
 replace github.com/enbility/spine-go => github.com/andig/spine-go v0.7.1-0.20260804073026-f9a8d8e8fd18
 

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6 h1:XOYvxKtT1o
 github.com/enbility/zeroconf/v2 v2.0.0-20240920094356-be1cae74fda6/go.mod h1:BszP9qFV14mPXgyIREbgIdQtWxbAj3OKqvK02HihMoM=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea h1:F6eyC8V8wvc3ranlsR4coAls+OPBkVvxyX0a2VqdlPc=
 github.com/evcc-io/modbus v0.0.0-20250501165638-8b6f1fbdb7ea/go.mod h1:swrNGAVgI1r/3d/sEKE7qgujdRR9aHVPYKyc3gvpVTc=
-github.com/evcc-io/ocpp-go v0.0.0-20260727074919-195c10b8758d h1:UxgSUmwiuVURrmaFzBdYLobuRUwBIMRmH4sFjG0kemU=
-github.com/evcc-io/ocpp-go v0.0.0-20260727074919-195c10b8758d/go.mod h1:2kcukDdhui4u730VfnYVWuwzDLgw+mBRGDir/QAyBhg=
+github.com/evcc-io/ocpp-go v0.0.0-20260812074841-a8aa5fef8a9e h1:NHimNp7oIn4YERnF9ZL8LqYABq6nGU47LO0cNiyxgOQ=
+github.com/evcc-io/ocpp-go v0.0.0-20260812074841-a8aa5fef8a9e/go.mod h1:2kcukDdhui4u730VfnYVWuwzDLgw+mBRGDir/QAyBhg=
 github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4 h1:aGM3NwDsKbnmiaO10ptbvEolRAUThWJEsObiAWFDU/c=
 github.com/evcc-io/openapi-mcp v0.6.1-0.20260701153510-26c442199ef4/go.mod h1:YyOx4zwr6xVUcchAETHERZ+75cZMIrdcjVIZFwBlE1Q=
 github.com/evcc-io/optimizer v0.0.0-20260808185529-a50b33da38e5 h1:cwp3NABx+XDPoBji5Yk/H59ZDJxpDdzg+da9UvMFFUg=


### PR DESCRIPTION
Picks up evcc-io/ocpp-go#8, which guards `ws.server.addr` with a mutex. `Start` binds the listener on its own goroutine and assigns the field, while `CS.listen` (`charger/ocpp/instance.go`) polls `Addr()` to learn the ephemeral port — so every central system startup raced the bind:

```
WARNING: DATA RACE
Write at 0x00c000df71d8 by goroutine 32:
  ws.(*server).Start()      ws/server.go:288
Previous read at 0x00c000df71d8 by goroutine 27:
  ws.(*server).Addr()       ws/server.go:258
```

The bump carries that change only — `ws/server.go` is the sole file that differs between the two pseudo-versions.

`go test -race -run TestOcpp ./charger/` is clean afterwards, where it previously reported both that warning and a follow-on race on the `net.TCPAddr` contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)