### PR TITLE
Config UI: list chargers no loadpoint uses

### DIFF
--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -57,6 +57,29 @@
 					/>
 				</div>
 
+				<template v-if="unusedChargers.length">
+					<h2 class="my-4 mt-5">{{ $t("config.section.unusedChargers") }}</h2>
+					<div class="p-0 config-list box-pull-out">
+						<DeviceCard
+							v-for="charger in unusedChargers"
+							:id="`charger_${charger.name}`"
+							:key="charger.name"
+							:title="charger.config?.title || charger.name"
+							:name="charger.name"
+							editable
+							:error="hasDeviceError('charger', charger.name)"
+							data-testid="unused-charger"
+							@edit="
+								openModal('charger', { id: charger.id, type: chargerType(charger) })
+							"
+						>
+							<template #tags>
+								<DeviceTags :tags="deviceTags('charger', charger.name)" />
+							</template>
+						</DeviceCard>
+					</div>
+				</template>
+
 				<h2 id="vehicles" class="my-4">{{ $t("config.section.vehicles") }}</h2>
 				<div class="p-0 config-list box-pull-out">
 					<DeviceCard
@@ -610,7 +633,7 @@ import type {
 	Notification,
 	Remote,
 } from "@/types/evcc";
-import { ConfigType, CURRENCY } from "@/types/evcc";
+import { ConfigType, CURRENCY, LOADPOINT_TYPE } from "@/types/evcc";
 import { circuitTree, type CircuitNode } from "@/utils/circuits";
 
 type DeviceValuesMap = Record<DeviceType, Record<string, any>>;
@@ -968,6 +991,14 @@ export default defineComponent({
 				return { amount: { value: config.length } };
 			}
 			return { configured: { value: false } };
+		},
+		// chargers no loadpoint uses; leftovers of an interrupted loadpoint setup,
+		// only reachable here since chargers are otherwise edited from their loadpoint
+		unusedChargers(): ConfigCharger[] {
+			return this.chargers.filter(
+				(charger) =>
+					charger.id >= 0 && !this.loadpoints.some((lp) => lp.charger === charger.name)
+			);
 		},
 		// maps an OCPP station id to its loadpoint title (fallback: charger title)
 		stationTitles(): Record<string, string> {
@@ -1349,6 +1380,9 @@ export default defineComponent({
 		hasClassError(className: string) {
 			const fatals = store.state?.fatal || [];
 			return fatals.some((fatal) => fatal.class === className);
+		},
+		chargerType(charger: ConfigCharger) {
+			return charger.config?.["heating"] ? LOADPOINT_TYPE.HEATING : LOADPOINT_TYPE.CHARGING;
 		},
 		chargerIcon(chargerName: string) {
 			const charger = this.chargers.find((c) => c.name === chargerName);

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -846,6 +846,7 @@
       "meter": "PV & Batterie",
       "services": "Dienste",
       "system": "System",
+      "unusedChargers": "Ungenutzte Wallboxen & Heizgeräte",
       "vehicles": "Fahrzeuge"
     },
     "security": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -846,6 +846,7 @@
       "meter": "Solar & Battery",
       "services": "Services",
       "system": "System",
+      "unusedChargers": "Unused Chargers & Heating Devices",
       "vehicles": "Vehicles"
     },
     "security": {

--- a/tests/config-unused-charger.spec.ts
+++ b/tests/config-unused-charger.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+import { expectModalVisible, expectModalHidden } from "./utils";
+
+test.use({ baseURL: baseUrl() });
+test.describe.configure({ mode: "parallel" });
+
+test.afterEach(async () => {
+  await stop();
+});
+
+test.describe("unused charger", async () => {
+  test("is listed and can be deleted", async ({ page }) => {
+    await start();
+    await page.goto("/#/config");
+
+    await expect(page.getByTestId("unused-charger")).toHaveCount(0);
+
+    // a charger no loadpoint references, as left behind when a loadpoint setup is
+    // interrupted after the charger was saved
+    const res = await page.request.post("./api/config/devices/charger", {
+      data: { type: "template", template: "demo-charger", status: "C", power: 11000 },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await page.reload();
+
+    const card = page.getByTestId("unused-charger");
+    await expect(card).toHaveCount(1);
+
+    // deleting it is only possible from here, no loadpoint leads to it
+    await card.getByRole("button", { name: "edit" }).click();
+    const modal = page.getByTestId("charger-modal");
+    await expectModalVisible(modal);
+    await modal.getByRole("button", { name: "Delete" }).click();
+    await expectModalHidden(modal);
+
+    await expect(page.getByTestId("unused-charger")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
fixes #32765

Chargers are created and edited from inside the loadpoint modal, and `Config.vue` never opens `ChargerModal` on its own. A charger that ends up referenced by no loadpoint is therefore unreachable: it still appears in the loadpoint charger dropdown, but nothing leads to its own modal, so it can only be removed with `evcc config delete <id>` on the CLI.

`LoadpointModal.onDismiss` already deletes a charger created during the flow, but only while the loadpoint is still new (`!values.id && !autoCreate`) and only the one currently selected in `values.charger`. Anything that interrupts the flow in between — a reload, a closed tab, a failed loadpoint create — leaves the row behind, and no amount of extra client-side cleanup can cover a browser that never comes back. The reachable-from-the-UI part is what is missing.

A section listing chargers no loadpoint references now appears above "Vehicles", and only when there is something to show. The cards reuse `DeviceCard`, so editing and deleting work exactly as they do for a charger reached through its loadpoint. Only db-configured chargers are listed — a yaml-defined one has nothing to offer here.

Note the originally reported startup impact does not apply: `cmd/setup.go` skips unreferenced db devices, as established in the issue thread. These rows are dead config, not a boot delay.

Two things deliberately not done here:
- no `stationId` uniqueness check. `ocpp.CS.RegisterChargepoint` hands out the same `CP` for a repeated station id on purpose, and `CP.RegisterConnector` already rejects a genuine collision with `connector already registered: <n>`. One station with several connectors driving several loadpoints is a supported setup that such a check would break.
- deleting a *disabled* loadpoint still orphans its charger: `deleteLoadpointHandler` reads the charger reference off the live instance, which a disabled loadpoint does not have. Worth fixing separately by reading the reference from the stored config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)