### PR TITLE
Socomec Countis E3x/E4x meter template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/teslamotors/vehicle-command v0.4.1
 	github.com/tess1o/go-ecoflow v1.1.1-0.20251003083510-2ccc15a17e29
 	github.com/traefik/yaegi v0.16.1
-	github.com/volkszaehler/mbmd v0.0.0-20260803093438-96221ccf34be
+	github.com/volkszaehler/mbmd v0.0.0-20260812141656-4304ad77c56f
 	github.com/warthog618/go-gpiocdev v0.9.1
 	github.com/xuri/excelize/v2 v2.11.0
 	gitlab.com/bboehmke/sunny v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/volkszaehler/mbmd v0.0.0-20260803093438-96221ccf34be h1:q0kgjSngsgSWiKGhLNOfUJDO76+Ctx31f5Y50MO3Bf4=
-github.com/volkszaehler/mbmd v0.0.0-20260803093438-96221ccf34be/go.mod h1:hx00iJeEiVti6jY7HwLIiShGWdjAAxY7vDdhx/Ys1ys=
+github.com/volkszaehler/mbmd v0.0.0-20260812141656-4304ad77c56f h1:R7By5B362tuEUTxImAyq5oUoH9kBIO1coIk94dNW2BI=
+github.com/volkszaehler/mbmd v0.0.0-20260812141656-4304ad77c56f/go.mod h1:hx00iJeEiVti6jY7HwLIiShGWdjAAxY7vDdhx/Ys1ys=
 github.com/warthog618/go-gpiocdev v0.9.1 h1:pwHPaqjJfhCipIQl78V+O3l9OKHivdRDdmgXYbmhuCI=
 github.com/warthog618/go-gpiocdev v0.9.1/go.mod h1:dN3e3t/S2aSNC+hgigGE/dBW8jE1ONk9bDSEYfoPyl8=
 github.com/warthog618/go-gpiosim v0.1.1 h1:MRAEv+T+itmw+3GeIGpQJBfanUVyg0l3JCTwHtwdre4=

--- a/templates/definition/meter/socomec.yaml
+++ b/templates/definition/meter/socomec.yaml
@@ -1,0 +1,43 @@
+template: socomec
+products:
+  - brand: Socomec
+    description:
+      generic: Countis E3x/E4x
+params:
+  - name: usage
+    choice: ["grid", "pv", "charge"]
+  - name: modbus
+    choice: ["rs485"]
+render: |
+  type: mbmd
+  {{- include "modbus" . }}
+  model: socomec
+  {{- if ne .usage "pv" }}
+  power: Power
+  energy: Import
+  returnenergy: Export
+  currents:
+    - CurrentL1
+    - CurrentL2
+    - CurrentL3
+  powers:
+    - PowerL1
+    - PowerL2
+    - PowerL3
+  {{- else }}
+  power: -Power
+  energy: Export
+  returnenergy: Import
+  currents:
+    - -CurrentL1
+    - -CurrentL2
+    - -CurrentL3
+  powers:
+    - -PowerL1
+    - -PowerL2
+    - -PowerL3
+  {{- end }}
+  voltages:
+    - VoltageL1
+    - VoltageL2
+    - VoltageL3


### PR DESCRIPTION
fixes #32771
pairs with volkszaehler/mbmd#395

Meter template for the Socomec Countis E3x/E4x, which the linked mbmd PR added as `SOCOMEC` based on the JBUS common table spec attached to the issue.

- rs485 only, grid/pv/charge usages, same shape as the other mbmd meter templates
- bumps `github.com/volkszaehler/mbmd` to pick up the new device

Untested against hardware — the register map comes from the spec alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
