### PR TITLE
Add api.CurrentLimiter to implement package

### DIFF
--- a/api/implement/implementations.go
+++ b/api/implement/implementations.go
@@ -173,6 +173,21 @@ func (i *iCurrentGetter) GetMaxCurrent() (float64, error) {
 	return i.currentGetter0()
 }
 
+func CurrentLimiter(currentLimiter0 func() (float64, float64, error)) api.CurrentLimiter {
+	if currentLimiter0 == nil {
+		return nil
+	}
+	return &iCurrentLimiter{currentLimiter0}
+}
+
+type iCurrentLimiter struct {
+	currentLimiter0 func() (float64, float64, error)
+}
+
+func (i *iCurrentLimiter) GetMinMaxCurrent() (float64, float64, error) {
+	return i.currentLimiter0()
+}
+
 func Curtailer(curtailer0 func() (int, error), curtailer1 func(int) error) api.Curtailer {
 	if curtailer0 == nil || curtailer1 == nil {
 		return nil

--- a/cmd/implement/implement.go
+++ b/cmd/implement/implement.go
@@ -69,6 +69,7 @@ func generate(out io.Writer) error {
 		reflect.TypeFor[api.ChargeState](),
 		reflect.TypeFor[api.CurrentController](),
 		reflect.TypeFor[api.CurrentGetter](),
+		reflect.TypeFor[api.CurrentLimiter](),
 		reflect.TypeFor[api.Curtailer](),
 		reflect.TypeFor[api.Dimmer](),
 		reflect.TypeFor[api.Identifier](),


### PR DESCRIPTION
`api.CurrentLimiter` was missing from the generator list in `cmd/implement/implement.go`, so a driver offering min/max current had to hand-roll an adapter type instead of registering it like any other capability:

```go
type voltieCurrentLimiter func() (float64, float64, error)

func (f voltieCurrentLimiter) GetMinMaxCurrent() (float64, float64, error) {
	return f()
}

implement.Has[api.CurrentLimiter](wb, voltieCurrentLimiter(wb.getMinMaxCurrent))
```

With the type added, that becomes the usual form:

```go
implement.Has(wb, implement.CurrentLimiter(wb.getMinMaxCurrent))
```

`api/implement/implementations.go` is regenerated with `go generate ./cmd/implement/...`; the only change is the new `CurrentLimiter` constructor and its `iCurrentLimiter` adapter.

Prompted by #32783, which needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
