### PR TITLE
UI: fix auto power unit for negative values

### DIFF
--- a/assets/js/mixins/formatter.test.ts
+++ b/assets/js/mixins/formatter.test.ts
@@ -30,6 +30,11 @@ describe("fmtW", () => {
     expect(fmt.fmtW(0, POWER_UNIT.W)).eq("0 W");
     expect(fmt.fmtW(1200000, POWER_UNIT.W)).eq("1.200.000 W");
   });
+  test("should format negative values", () => {
+    expect(fmt.fmtW(-5300, POWER_UNIT.AUTO)).eq("-5,3 kW");
+    expect(fmt.fmtW(-500, POWER_UNIT.AUTO)).eq("-500 W");
+    expect(fmt.fmtW(-12000000, POWER_UNIT.AUTO)).eq("-12,0 MW");
+  });
   test("should format without units", () => {
     expect(fmt.fmtW(0, POWER_UNIT.AUTO, false)).eq("0,0");
     expect(fmt.fmtW(1200000, POWER_UNIT.AUTO, false)).eq("1.200,0");

--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -74,7 +74,8 @@ export default defineComponent({
       return (Math.round(num * base) / base).toFixed(precision);
     },
     getPowerUnit(watt: number): POWER_UNIT {
-      return watt >= 10_000_000 ? POWER_UNIT.MW : watt >= 1000 ? POWER_UNIT.KW : POWER_UNIT.W;
+      const abs = Math.abs(watt);
+      return abs >= 10_000_000 ? POWER_UNIT.MW : abs >= 1000 ? POWER_UNIT.KW : POWER_UNIT.W;
     },
     fmtW(watt = 0, format = POWER_UNIT.KW, withUnit = true, digits?: number) {
       let unit = format;


### PR DESCRIPTION
follow-up to #32754, fixes https://github.com/evcc-io/evcc/pull/32754#issuecomment-5281838623

Negative powers like grid export or battery charging were always formatted in W (`-5.300 W`) because the auto unit selection compared the signed value. Pick the unit by magnitude instead, so `-5.300 W` becomes `-5,3 kW`.

- `getPowerUnit` compares `Math.abs(watt)`, covers all callers
- unit test for negative auto-formatted values

🤖 Generated with [Claude Code](https://claude.com/claude-code)