### PR TITLE
Update ioBroker YAML with adapter configuration details

### DIFF
--- a/templates/definition/meter/iobroker.yaml
+++ b/templates/definition/meter/iobroker.yaml
@@ -6,12 +6,13 @@ requirements:
   evcc: ["skiptest"]
   description:
     de: |
-      Auf der verwendeten ioBroker Instanz muss der `rest-api` adapter (nicht `simple-api`) installiert sein. 
+      Auf der verwendeten ioBroker Instanz muss der `rest-api` adapter (nicht `simple-api`) installiert sein. Er muss als Extension eines Web adapters 
+      konfiguriert sein. 
       Authentifiziert werden kann nur mittels `basic` authentication. Wird kein Passwort angegeben, so wird keine Authentifizierung durchgeführt.
       Bei der Angabe der Entities für die einzelnen Messwerte ist darauf zu achten, dass diese korrekt URL-Encoded sind.
       So wird aus `shelly.0.SHEM-3#8CAAB561991E#1.Total.ConsumedPower  shelly.0.SHEM-3%238CAAB561991E%231.Total.ConsumedPower`
     en: |
-      The `rest-api` adapter (not `simple-api`) must be installed on the ioBroker instance being used.
+      The `rest-api` adapter (not `simple-api`) must be installed on the ioBroker instance being used. It must be configured as an extension of a web adapter.
       Authentication can only be performed using `basic` authentication. If no password is provided, no authentication will be performed. 
       When specifying the entities for the individual measured values, ensure that they are correctly URL-encoded.
       For example, `shelly.0.SHEM-3#8CAAB561991E#1.Total.ConsumedPower` becomes `shelly.0.SHEM-3%238CAAB561991E%231.Total.ConsumedPower`


### PR DESCRIPTION
Clarified installation and configuration requirements for the `rest-api` adapter in both German and English sections.