### PR TITLE
Forecast: only adjust today's solar forecast to real production

### DIFF
--- a/assets/js/utils/forecast.test.ts
+++ b/assets/js/utils/forecast.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vite-plus/test";
-import { expandForecast, findLowestSumSlotIndex, isStaticTariff } from "./forecast";
+import { adjustedSolar, expandForecast, findLowestSumSlotIndex, isStaticTariff } from "./forecast";
 
 describe("expandForecast", () => {
   test("expands slots to milliseconds", () => {
@@ -106,5 +106,40 @@ describe("isStaticTariff", () => {
       { start: 1735691400000, end: 1735692300000, value: 0.25 },
     ];
     expect(isStaticTariff(slots)).toBe(false);
+  });
+});
+
+describe("adjustedSolar", () => {
+  test("returns input unchanged when scale is missing", () => {
+    const solar = { today: { energy: 100, complete: true } };
+    expect(adjustedSolar(solar)).toEqual(solar);
+  });
+
+  test("scales today but leaves tomorrow/dayAfterTomorrow untouched", () => {
+    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    const solar = {
+      scale: 2,
+      today: { energy: 100, complete: true },
+      tomorrow: { energy: 200, complete: true },
+      dayAfterTomorrow: { energy: 300, complete: true },
+      timeseries: [
+        { ts: today.getTime(), val: 10 },
+        { ts: tomorrow.getTime(), val: 20 },
+      ],
+    };
+
+    const result = adjustedSolar(solar);
+
+    expect(result?.today?.energy).toBe(200);
+    expect(result?.tomorrow?.energy).toBe(200);
+    expect(result?.dayAfterTomorrow?.energy).toBe(300);
+    expect(result?.timeseries).toEqual([
+      { ts: today.getTime(), val: 20 },
+      { ts: tomorrow.getTime(), val: 20 },
+    ]);
+    expect(result?.scale).toBe(0.5);
   });
 });

--- a/assets/js/utils/forecast.ts
+++ b/assets/js/utils/forecast.ts
@@ -100,7 +100,9 @@ export function adjustedSolar(solar?: UiSolarDetails): UiSolarDetails | undefine
     });
   }
 
-  result.scale = 1 / scale; // invert to allow back-adjustment
+  // invert to allow back-adjustment - only valid for today's data, since
+  // tomorrow/dayAfterTomorrow were never scaled in the first place
+  result.scale = 1 / scale;
 
   return result;
 }

--- a/assets/js/utils/forecast.ts
+++ b/assets/js/utils/forecast.ts
@@ -81,18 +81,22 @@ export function highestSlotIndexByDay(entries: UiTimeseriesEntry[], day: number 
   return entries.findIndex((entry) => entry.ts === highestEntry.ts);
 }
 
+// scale is derived from today's actual production vs. forecast, so it's only
+// applied to today - extrapolating it to tomorrow/day-after would assume
+// today's over/under-performance carries over, which isn't a given.
 export function adjustedSolar(solar?: UiSolarDetails): UiSolarDetails | undefined {
   if (!solar?.scale) return solar;
 
   const { scale } = solar;
   const result = deepCopy(solar);
+  const todayString = dayStringByOffset(0);
 
   if (result.today) result.today.energy *= scale;
-  if (result.tomorrow) result.tomorrow.energy *= scale;
-  if (result.dayAfterTomorrow) result.dayAfterTomorrow.energy *= scale;
   if (result.timeseries) {
     result.timeseries.forEach((entry) => {
-      entry.val *= scale;
+      if (toDayString(new Date(entry.ts)) === todayString) {
+        entry.val *= scale;
+      }
     });
   }
 


### PR DESCRIPTION
Small improvement to the solar forecast "adjust to real data" toggle.

Adjusting means scaling the forecast by how today's actual production compares to today's forecast. That comparison only exists for today (there's no measured production for tomorrow or the day after yet), so applying the same scale factor to future days doesn't make sense - it just assumes today's over/under-performance carries forward, which isn't a given.

- `adjustedSolar()` now only scales `today`'s energy total and today's timeseries slots; `tomorrow`/`dayAfterTomorrow` stay as raw forecast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)