### PR TITLE
UI: fix sessions table covering heading in app

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -2,13 +2,15 @@
 <html lang="[[.DefaultLang]]">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
+    />
     <meta name="description" content="evcc - Sonne tanken ☀️🚘" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="evcc" />
     <meta name="application-name" content="evcc" />
-    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
 
     <link rel="apple-touch-icon" sizes="180x180" href="meta/apple-touch-icon.png?[[.Version]]" />
     <link rel="icon" type="image/png" sizes="32x32" href="meta/favicon-32x32.png?[[.Version]]" />

--- a/assets/js/components/Sessions/SessionTable.vue
+++ b/assets/js/components/Sessions/SessionTable.vue
@@ -506,19 +506,19 @@ export default defineComponent({
 	z-index: 1;
 }
 .sticky-top {
-	top: 7rem;
+	top: calc(7rem + var(--safe-area-inset-top));
 }
 @media (--lg-and-up) {
 	.sticky-top {
-		top: 4.5rem;
+		top: calc(4.5rem + var(--safe-area-inset-top));
 	}
 }
 .sticky-top th {
-	padding-top: max(0.5rem, env(safe-area-inset-top));
+	padding-top: 0.5rem;
 }
 .table-outer {
 	position: relative;
-	top: calc(max(0.5rem, env(safe-area-inset-top)) * -1);
+	top: -0.5rem;
 }
 .month-header {
 	position: relative;


### PR DESCRIPTION
fixes evcc-io/app#251

The sessions table used `env(safe-area-inset-top)` to size the sticky `thead` mask. In the browser that inset is 0, but in the app WebView (`viewport-fit=cover`) it is 24px on iPad and up to 59px on iPhone portrait — the table was pulled up by that amount and its header background covered the "Overview" card title.

- move the safe-area offset into the sticky `top` position where it belongs; keep the header mask at a constant 0.5rem
- use `var(--safe-area-inset-top)` instead of `env()` so the app-injected values also work on Android
- merge the duplicate `<meta name="viewport">` tags (the second one dropped `width=device-width`, causing horizontal overflow in the app WebView on iPad)