### PR TITLE
Meter (EcoFlow Stream): add battery control

### DIFF
--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -17,6 +17,7 @@ import (
 // EcoFlow represents the EcoFlow  meter
 type EcoFlow struct {
 	implement.Caps
+	log    *util.Logger
 	usage  string
 	serial string
 	cache  time.Duration
@@ -83,6 +84,7 @@ func NewEcoFlow(accessKey, secretKey, serial, usage, uri string,
 
 	m := &EcoFlow{
 		Caps:   implement.New(),
+		log:    log,
 		serial: serial,
 		usage:  usage,
 		cache:  cache,
@@ -170,13 +172,21 @@ func (m *EcoFlow) soc() (float64, error) {
 	return ecoflowValue(response.Data, m.batterySoc)
 }
 
+// ecoflowReserveLimit clamps the reserve above the discharge limit, which the device requires it
+// to exceed by 3
+func ecoflowReserveLimit(limit, lo float64) float64 {
+	return min(100, max(limit, lo+3))
+}
+
 func (m *EcoFlow) setBackupReserve(limit float64) error {
-	// the device requires the reserve to exceed its discharge limit by 3, so clamp rather than let
-	// the write fail: refusing normal mode would strand the battery at the previous, higher reserve
-	if res, err := m.dataG(); err == nil {
-		if lo, err := ecoflowValue(res.Data, "cmsMinDsgSoc"); err == nil {
-			limit = min(100, max(limit, lo+3))
-		}
+	// clamp rather than let the write fail: refusing normal mode would strand the battery at the
+	// previous, higher reserve. On a failed read the device rejects an invalid value itself.
+	if res, err := m.dataG(); err != nil {
+		m.log.WARN.Printf("backup reserve: %v", err)
+	} else if lo, err := ecoflowValue(res.Data, "cmsMinDsgSoc"); err != nil {
+		m.log.WARN.Printf("backup reserve: discharge limit: %v", err)
+	} else {
+		limit = ecoflowReserveLimit(limit, lo)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -191,11 +191,13 @@ func (m *EcoFlow) dischargeLimit() (float64, error) {
 }
 
 func (m *EcoFlow) setBackupReserve(limit float64) error {
-	// clamp rather than let the write fail: refusing normal mode would strand the battery at the
-	// previous, higher reserve. On a failed read the device rejects an invalid value itself.
-	if lo, err := m.limitG(); err != nil {
-		m.log.WARN.Printf("backup reserve: discharge limit: %v", err)
-	} else if clamped := ecoflowReserveLimit(limit, lo); clamped != limit {
+	lo, err := m.limitG()
+	if err != nil {
+		return fmt.Errorf("discharge limit: %w", err)
+	}
+
+	// device requires the reserve to exceed the discharge limit by 3
+	if clamped := ecoflowReserveLimit(limit, lo); clamped != limit {
 		m.log.DEBUG.Printf("backup reserve: raised %.0f to %.0f, below discharge limit %.0f", limit, clamped, lo)
 		limit = clamped
 	}
@@ -213,7 +215,7 @@ func (m *EcoFlow) setBackupReserve(limit float64) error {
 		return err
 	}
 	if res == nil {
-		return errors.New("empty response")
+		return api.ErrTimeout
 	}
 	if res.Code != "0" {
 		return fmt.Errorf("%s (%s)", res.Message, res.Code)

--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -24,6 +24,7 @@ type EcoFlow struct {
 	dataG  func() (*ecoflow.GetCmdResponse, error)
 
 	power, batterySoc string
+	controllable      bool
 }
 
 func init() {
@@ -72,12 +73,12 @@ func NewEcoFlowFromConfig(other map[string]any) (api.Meter, error) {
 		return nil, fmt.Errorf("invalid region: %s", cc.Region)
 	}
 
-	return NewEcoFlow(cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache, cc.batteryCapacity.Decorator(), cc.batterySocLimits.Decorator(), cc.batteryPowerLimits.Decorator())
+	return NewEcoFlow(cc.AccessKey, cc.SecretKey, cc.Serial, cc.Usage, uri, cc.Power, cc.Soc, cc.Cache, cc.batteryCapacity.Decorator(), cc.batterySocLimits, cc.batteryPowerLimits.Decorator())
 }
 
 // NewEcoFlow constructs the EcoFlow struct
 func NewEcoFlow(accessKey, secretKey, serial, usage, uri string,
-	power, soc string, cache time.Duration, capacity func() float64, batterySocLimits, batteryPowerLimits func() (float64, float64)) (*EcoFlow, error) {
+	power, soc string, cache time.Duration, capacity func() float64, batterySocLimits batterySocLimits, batteryPowerLimits func() (float64, float64)) (*EcoFlow, error) {
 	log := util.NewLogger("ecoflow").Redact(accessKey, secretKey, serial)
 
 	m := &EcoFlow{
@@ -98,8 +99,14 @@ func NewEcoFlow(accessKey, secretKey, serial, usage, uri string,
 	if usage == "battery" {
 		implement.Has(m, implement.Battery(m.soc))
 		implement.May(m, implement.BatteryCapacity(capacity))
-		implement.May(m, implement.BatterySocLimiter(batterySocLimits))
+		implement.May(m, implement.BatterySocLimiter(batterySocLimits.Decorator()))
 		implement.May(m, implement.BatteryPowerLimiter(batteryPowerLimits))
+
+		// the backup reserve command is Stream-specific, the PowerOcean template shares this meter type
+		if batterySocLimits.MinSoc > 0 && batterySocLimits.MaxSoc > 0 && soc == "cmsBattSoc" {
+			m.controllable = true
+			implement.Has(m, implement.BatteryController(batterySocLimits.LimitController(m.soc, m.setBackupReserve)))
+		}
 	}
 
 	return m, nil
@@ -114,6 +121,9 @@ func (m *EcoFlow) getData() (*ecoflow.GetCmdResponse, error) {
 
 	if m.usage == "battery" {
 		params = append(params, m.batterySoc)
+	}
+	if m.controllable {
+		params = append(params, "cmsMinDsgSoc")
 	}
 
 	return m.client.GetDeviceParameters(ctx, m.serial, params)
@@ -158,4 +168,31 @@ func (m *EcoFlow) soc() (float64, error) {
 	}
 
 	return ecoflowValue(response.Data, m.batterySoc)
+}
+
+func (m *EcoFlow) setBackupReserve(limit float64) error {
+	// the device requires the reserve to exceed its discharge limit by 3, so clamp rather than let
+	// the write fail: refusing normal mode would strand the battery at the previous, higher reserve
+	if res, err := m.dataG(); err == nil {
+		if lo, err := ecoflowValue(res.Data, "cmsMinDsgSoc"); err == nil {
+			limit = min(100, max(limit, lo+3))
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// cfgBackupReverseSoc is the vendor's spelling of the backup reserve
+	res, err := m.client.SetDeviceParameter(ctx, map[string]any{
+		"sn": m.serial, "cmdId": 17, "cmdFunc": 254,
+		"dirDest": 1, "dirSrc": 1, "dest": 2, "needAck": true,
+		"params": map[string]any{"cfgBackupReverseSoc": int(limit)},
+	})
+	if err != nil {
+		return err
+	}
+	if res.Code != "0" {
+		return fmt.Errorf("%s (%s)", res.Message, res.Code)
+	}
+	return nil
 }

--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -206,7 +207,7 @@ func (m *EcoFlow) setBackupReserve(limit float64) error {
 	res, err := m.client.SetDeviceParameter(ctx, map[string]any{
 		"sn": m.serial, "cmdId": 17, "cmdFunc": 254,
 		"dirDest": 1, "dirSrc": 1, "dest": 2, "needAck": true,
-		"params": map[string]any{"cfgBackupReverseSoc": int(limit)},
+		"params": map[string]any{"cfgBackupReverseSoc": int(math.Round(limit))},
 	})
 	if err != nil {
 		return err

--- a/meter/ecoflow.go
+++ b/meter/ecoflow.go
@@ -23,9 +23,9 @@ type EcoFlow struct {
 	cache  time.Duration
 	client *ecoflow.Client
 	dataG  func() (*ecoflow.GetCmdResponse, error)
+	limitG func() (float64, error)
 
 	power, batterySoc string
-	controllable      bool
 }
 
 func init() {
@@ -105,8 +105,8 @@ func NewEcoFlow(accessKey, secretKey, serial, usage, uri string,
 		implement.May(m, implement.BatteryPowerLimiter(batteryPowerLimits))
 
 		// the backup reserve command is Stream-specific, the PowerOcean template shares this meter type
-		if batterySocLimits.MinSoc > 0 && batterySocLimits.MaxSoc > 0 && soc == "cmsBattSoc" {
-			m.controllable = true
+		if soc == "cmsBattSoc" && batterySocLimits.MaxSoc > 0 {
+			m.limitG = util.Cached(m.dischargeLimit, cache)
 			implement.Has(m, implement.BatteryController(batterySocLimits.LimitController(m.soc, m.setBackupReserve)))
 		}
 	}
@@ -123,9 +123,6 @@ func (m *EcoFlow) getData() (*ecoflow.GetCmdResponse, error) {
 
 	if m.usage == "battery" {
 		params = append(params, m.batterySoc)
-	}
-	if m.controllable {
-		params = append(params, "cmsMinDsgSoc")
 	}
 
 	return m.client.GetDeviceParameters(ctx, m.serial, params)
@@ -178,15 +175,28 @@ func ecoflowReserveLimit(limit, lo float64) float64 {
 	return min(100, max(limit, lo+3))
 }
 
+// dischargeLimit reads the device's discharge limit (cmsMinDsgSoc), set in the EcoFlow app and
+// polled separately from getData so a rejected quota can't degrade the power and soc readings
+func (m *EcoFlow) dischargeLimit() (float64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := m.client.GetDeviceParameters(ctx, m.serial, []string{"cmsMinDsgSoc"})
+	if err != nil {
+		return 0, err
+	}
+
+	return ecoflowValue(res.Data, "cmsMinDsgSoc")
+}
+
 func (m *EcoFlow) setBackupReserve(limit float64) error {
 	// clamp rather than let the write fail: refusing normal mode would strand the battery at the
 	// previous, higher reserve. On a failed read the device rejects an invalid value itself.
-	if res, err := m.dataG(); err != nil {
-		m.log.WARN.Printf("backup reserve: %v", err)
-	} else if lo, err := ecoflowValue(res.Data, "cmsMinDsgSoc"); err != nil {
+	if lo, err := m.limitG(); err != nil {
 		m.log.WARN.Printf("backup reserve: discharge limit: %v", err)
-	} else {
-		limit = ecoflowReserveLimit(limit, lo)
+	} else if clamped := ecoflowReserveLimit(limit, lo); clamped != limit {
+		m.log.DEBUG.Printf("backup reserve: raised %.0f to %.0f, below discharge limit %.0f", limit, clamped, lo)
+		limit = clamped
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -200,6 +210,9 @@ func (m *EcoFlow) setBackupReserve(limit float64) error {
 	})
 	if err != nil {
 		return err
+	}
+	if res == nil {
+		return errors.New("empty response")
 	}
 	if res.Code != "0" {
 		return fmt.Errorf("%s (%s)", res.Message, res.Code)

--- a/meter/ecoflow_test.go
+++ b/meter/ecoflow_test.go
@@ -1,0 +1,30 @@
+package meter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEcoflowReserveLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit float64
+		lo    float64
+		want  float64
+	}{
+		{name: "above discharge limit", limit: 50, lo: 7, want: 50},
+		{name: "at required distance", limit: 10, lo: 7, want: 10},
+		{name: "below required distance", limit: 5, lo: 7, want: 10},
+		{name: "discharge limit raised", limit: 10, lo: 15, want: 18},
+		{name: "charge mode", limit: 100, lo: 7, want: 100},
+		{name: "distance exceeds full reserve", limit: 10, lo: 99, want: 100},
+		{name: "zero discharge limit", limit: 0, lo: 0, want: 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ecoflowReserveLimit(tc.limit, tc.lo))
+		})
+	}
+}

--- a/templates/definition/meter/ecoflow-stream.yaml
+++ b/templates/definition/meter/ecoflow-stream.yaml
@@ -14,10 +14,13 @@ requirements:
 
       Diese Credentials erhalten Sie über die EcoFlow Developer Console nach der Registrierung Ihrer Anwendung.
 
-      Zur Batteriesteuerung wird die Backup Reserve auf minsoc bzw. maxsoc gesetzt. Das Gerät
-      verlangt, dass die Backup Reserve das Entladelimit um 3 übersteigt. Der Standardwert
-      minsoc: 10 passt damit zu einem Entladelimit von 7 in der EcoFlow App. Setzen Sie entweder
-      das Entladelimit auf höchstens 7, oder minsoc auf Entladelimit plus 3.
+      Für die aktive Batteriesteuerung muss `maxsoc` gesetzt werden. Im Normalbetrieb wird die
+      Backup Reserve auf `minsoc` gesetzt, beim Netzladen auf `maxsoc`.
+
+      **Achtung**: Die aktive Batteriesteuerung überschreibt die in der EcoFlow App eingestellte
+      Backup Reserve. Das Gerät verlangt, dass die Backup Reserve das Entladelimit um 3 übersteigt,
+      niedrigere Werte für `minsoc` werden angehoben. Ohne `minsoc` entlädt die Batterie bis zum
+      Entladelimit des Geräts.
     en: |
       To use the EcoFlow Stream meter you need:
       - A valid Access Key from the EcoFlow Developer Console
@@ -26,10 +29,13 @@ requirements:
 
       These credentials can be obtained through the EcoFlow Developer Console after registering your application.
 
-      Battery control sets the Backup Reserve to minsoc or maxsoc. The device requires the Backup
-      Reserve to exceed the discharge limit by 3, so the minsoc: 10 default matches a discharge
-      limit of 7 in the EcoFlow app. Either keep the discharge limit at 7 or below, or set minsoc
-      to the discharge limit plus 3.
+      For active battery control, `maxsoc` must be set. In normal operation the Backup Reserve is
+      set to `minsoc`, for grid charging to `maxsoc`.
+
+      **Note**: Active battery control overwrites the Backup Reserve configured in the EcoFlow app.
+      The device requires the Backup Reserve to exceed the discharge limit by 3, lower `minsoc`
+      values are raised accordingly. Without `minsoc` the battery discharges down to the device's
+      own discharge limit.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -64,10 +70,6 @@ params:
   - name: cache
     default: 30s
   - preset: battery-params
-  - name: minsoc
-    default: 10
-  - name: maxsoc
-    default: 100
 render: |
   type: ecoflow
   accesskey: {{ .accesskey }}

--- a/templates/definition/meter/ecoflow-stream.yaml
+++ b/templates/definition/meter/ecoflow-stream.yaml
@@ -3,6 +3,7 @@ products:
   - brand: EcoFlow
     description:
       generic: Stream
+capabilities: ["battery-control"]
 requirements:
   description:
     de: |
@@ -12,6 +13,11 @@ requirements:
       - Die Seriennummer des Hauptgerätes Ihres Stream Systems
 
       Diese Credentials erhalten Sie über die EcoFlow Developer Console nach der Registrierung Ihrer Anwendung.
+
+      Zur Batteriesteuerung wird die Backup Reserve auf minsoc bzw. maxsoc gesetzt. Das Gerät
+      verlangt, dass die Backup Reserve das Entladelimit um 3 übersteigt. Der Standardwert
+      minsoc: 10 passt damit zu einem Entladelimit von 7 in der EcoFlow App. Setzen Sie entweder
+      das Entladelimit auf höchstens 7, oder minsoc auf Entladelimit plus 3.
     en: |
       To use the EcoFlow Stream meter you need:
       - A valid Access Key from the EcoFlow Developer Console
@@ -19,6 +25,11 @@ requirements:
       - The main device serial number of your Stream system
 
       These credentials can be obtained through the EcoFlow Developer Console after registering your application.
+
+      Battery control sets the Backup Reserve to minsoc or maxsoc. The device requires the Backup
+      Reserve to exceed the discharge limit by 3, so the minsoc: 10 default matches a discharge
+      limit of 7 in the EcoFlow app. Either keep the discharge limit at 7 or below, or set minsoc
+      to the discharge limit plus 3.
 params:
   - name: usage
     choice: ["grid", "pv", "battery"]
@@ -53,6 +64,10 @@ params:
   - name: cache
     default: 30s
   - preset: battery-params
+  - name: minsoc
+    default: 10
+  - name: maxsoc
+    default: 100
 render: |
   type: ecoflow
   accesskey: {{ .accesskey }}


### PR DESCRIPTION
refs #32589

The `ecoflow-stream` battery meter is read-only, so `hasBatteryControl()` stays false and the
Stream gets none of evcc's battery features - no grid charge limit, no discharge control, no
external battery mode, and the optimizer plans it as PV only.

This wires up `api.BatteryController` through evcc's own `batterySocLimits.LimitController`, the
same path `meter/powerwall_fleet.go` uses for a cloud meter with a single settable reserve soc. The three
modes map onto the Stream's backup reserve: normal sets it to `minsoc`, hold to the current soc,
charge to `maxsoc`. The write goes to the documented `cfgBackupReverseSoc` command and checks the
response code, since the client's `SetDeviceParameter` hands the response back without looking at
it. A nil response (a literal `null` body, which the client unmarshals cleanly into a nil pointer)
is now handled explicitly rather than dereferenced.

The device refuses a reserve that isn't at least 3 above its own discharge limit, and says so
itself: `8524 "The backup reserve needs to be higher than the discharge limit 3."`. So the writer
reads `cmsMinDsgSoc` and clamps to `lo+3`, same idea as `teslaReserveLimit` in that same file. A
failed read now returns the error, same as the other `BatteryController` implementations. The
discharge limit is read through its own cached getter rather than alongside the power/soc poll, so
a rejected quota degrades only the reserve write, not `CurrentPower()`/`Soc()`. A raised clamp is
now logged, since the site plans against `minsoc` while the device enforces `lo+3`, and those can
diverge silently otherwise. The charge limit is deliberately not a write bound: nothing establishes
it as one, and hold targets `min(100, max(soc, minsoc))`, which can legitimately exceed it.

Registration is gated on `maxsoc` and the Stream soc key: `maxsoc` because a zero value could turn
charge mode into a full discharge permit, and the soc key because `ecoflow-powerocean` shares this
meter type but not the backup reserve command. `minsoc` is not part of the gate: unset, normal mode
writes the device's own discharge-limit floor, which is a legitimate "discharge fully" setting
rather than a reason to disable control. The template ships no `minsoc`/`maxsoc` defaults, since
`RenderInstance` re-renders stored configs on every start and a default would retroactively enable
battery control (and overwrite the EcoFlow app's Backup Reserve) for existing installations that
never asked for it. Optimizer participation additionally needs `capacity`, which the template can't
default because it depends on how many batteries are stacked.

Tested on my own hardware: 2x Stream Ultra X + 1x Stream Ultra on separate phases behind an EcoFlow
smart meter, EU region. Normal, hold and charge each set the expected reserve through
`/api/batterymode/`, charge measurably pulled from grid (0 -> 3896 W, battery power -3436 W), and
an out-of-band write is rejected by the device rather than silently clamped. The clamp is covered
by a unit test and was verified end-to-end on the hardware: configured with `minsoc: 5` against a
device reporting `cmsMinDsgSoc: 7`, normal mode wrote `cfgBackupReverseSoc: 10` rather than 5, and
the device accepted it. Re-verified after review: `minsoc: 0` with `maxsoc` set still registers the
controller and writes the discharge-limit floor; a single-quota `cmsMinDsgSoc` read on the new
getter returns correctly; and a probe write went through the full `BatteryController` path and was
confirmed on an independent read surface with its own REST client, then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

