### PR TITLE
Add CHINT ECH10K-TH-EU inverter

### DIFF
--- a/templates/definition/meter/chint-ech-hybrid.yaml
+++ b/templates/definition/meter/chint-ech-hybrid.yaml
@@ -11,6 +11,8 @@ requirements:
     en: Tested with CHINT ECH10K-TH-EU and CPS ECD500 battery system via the EMS RS485 interface.
 
 params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
   - name: modbus
     choice: ["rs485"]
     baudrate: 9600
@@ -19,6 +21,50 @@ params:
 render: |
   type: custom
 
+  {{- if eq .usage "grid" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      type: input
+      address: 1793 # 0x0701 Total grid power, 1 W
+      decode: int16
+
+  currents:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        type: input
+        address: 2095 # 0x082F L1 current, 0.01 A
+        decode: uint16
+      scale: 0.01
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        type: input
+        address: 2096 # 0x0830 L2 current, 0.01 A
+        decode: uint16
+      scale: 0.01
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        type: input
+        address: 2097 # 0x0831 L3 current, 0.01 A
+        decode: uint16
+      scale: 0.01
+  {{- end }}
+
+  {{- if eq .usage "pv" }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      type: input
+      address: 1801 # 0x0709 PV power, 1 W
+      decode: uint16
+  {{- end }}
+
+  {{- if eq .usage "battery" }}
   power:
     source: calc
     mul:
@@ -45,3 +91,4 @@ render: |
       type: input
       address: 1539 # 0x0603 Battery SOC, %
       decode: uint16
+  {{- end }}

--- a/templates/definition/meter/chint-ech-hybrid.yaml
+++ b/templates/definition/meter/chint-ech-hybrid.yaml
@@ -1,0 +1,47 @@
+template: chint-ech-hybrid
+
+products:
+  - brand: CHINT
+    description:
+      generic: ECH10K-TH-EU Hybrid Inverter
+
+requirements:
+  description:
+    de: Getestet mit CHINT ECH10K-TH-EU und CPS ECD500 Batteriesystem über die EMS-RS485-Schnittstelle.
+    en: Tested with CHINT ECH10K-TH-EU and CPS ECD500 battery system via the EMS RS485 interface.
+
+params:
+  - name: modbus
+    choice: ["rs485"]
+    baudrate: 9600
+    id: 1
+
+render: |
+  type: custom
+
+  power:
+    source: calc
+    mul:
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        type: input
+        address: 1536 # 0x0600 Battery voltage, 0.1 V
+        decode: uint16
+      scale: 0.1
+
+    - source: modbus
+      {{- include "modbus" . | indent 4 }}
+      register:
+        type: input
+        address: 1537 # 0x0601 Battery current, 0.1 A
+        decode: int16
+      scale: 0.1
+
+  soc:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      type: input
+      address: 1539 # 0x0603 Battery SOC, %
+      decode: uint16

--- a/templates/definition/meter/chint-ech-hybrid.yaml
+++ b/templates/definition/meter/chint-ech-hybrid.yaml
@@ -27,30 +27,29 @@ render: |
     {{- include "modbus" . | indent 2 }}
     register:
       type: input
-      address: 1793 # 0x0701 Total grid power, 1 W
-      decode: int16
-
+      address: 1792 # 0x0700 Total grid power, 1 W
+      decode: int32
   currents:
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
         address: 2095 # 0x082F L1 current, 0.01 A
-        decode: uint16
+        decode: int16
       scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
         address: 2096 # 0x0830 L2 current, 0.01 A
-        decode: uint16
+        decode: int16
       scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         type: input
         address: 2097 # 0x0831 L3 current, 0.01 A
-        decode: uint16
+        decode: int16
       scale: 0.01
   {{- end }}
 


### PR DESCRIPTION
Dieses Template wurde auf echter Hardware mit einem CHINT ECH10K-TH-EU getestet.

Es nutzt Modbus RTU/RS485 über die zweite vorhandene EMS-Schnittstelle am CONN-Anschluss des Wechselrichters (Push-in-Klemmenleiste). Ausgelesen werden aktuell die Batterieleistung (power) und der Ladezustand (soc).

Die Kommunikation wurde direkt mit evcc gegen die EMS-Schnittstelle getestet, also ohne eine zusätzliche Software-Bridge. Dabei wurden sowohl power als auch soc erfolgreich und mit plausiblen Werten ausgelesen. Laden und Entladen werden mit der von evcc erwarteten Vorzeichenkonvention korrekt dargestellt.

Derzeit werden ausschließlich die Batteriedaten direkt aus dem Wechselrichter ausgelesen. Die Daten des externen CHINT DTSU666-Netzzählers sind noch nicht Bestandteil dieses Templates.

Der DTSU666 kommuniziert über eine separate RS485-Verbindung mit dem Wechselrichter. Diese Kommunikation wird in meiner derzeitigen Installation passiv mitgelesen und die Zählerdaten werden darüber bereits erfolgreich in evcc verwendet. Eine direkte Integration dieser Zählerdaten in das CHINT-Template ist jedoch noch nicht umgesetzt. 