### PR TITLE
Tariff: add German §14a grid fee template with grid operator choice

### DIFF
--- a/tariff/template_test.go
+++ b/tariff/template_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util/templates"
 	"github.com/evcc-io/evcc/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var acceptable = []string{
@@ -16,6 +18,34 @@ var acceptable = []string{
 	"missing region",                                   // octopusenergy
 	"missing securitytoken",                            // entsoe
 	"cannot define region and postcode simultaneously", // ngeso
+}
+
+// TestGridFeesDE renders the grid fee template for each grid operator
+func TestGridFeesDE(t *testing.T) {
+	tmpl, err := templates.ByName(templates.Tariff, "grid-fees-de")
+	require.NoError(t, err)
+
+	_, param := tmpl.ParamByName("gridoperator")
+	require.NotEmpty(t, param.Choice)
+
+	for _, op := range param.Choice {
+		t.Run(op, func(t *testing.T) {
+			values := tmpl.Defaults(templates.RenderModeUnitTest)
+			values["template"] = tmpl.Template
+			values["gridoperator"] = op
+
+			tf, err := NewFromConfig(t.Context(), "template", values)
+			require.NoError(t, err)
+
+			rates, err := tf.Rates()
+			require.NoError(t, err)
+			require.NotEmpty(t, rates)
+
+			for _, r := range rates {
+				assert.Positive(t, r.Value, "%v", r)
+			}
+		})
+	}
 }
 
 func TestTemplates(t *testing.T) {

--- a/templates/definition/tariff/grid-fees-de.yaml
+++ b/templates/definition/tariff/grid-fees-de.yaml
@@ -1,0 +1,227 @@
+template: grid-fees-de
+products:
+  - description:
+      de: Netzentgelte §14a EnWG (Modul 3)
+      en: Grid fees §14a EnWG (module 3)
+requirements:
+  description:
+    de: |
+      Zeitvariable Netzentgelte nach §14a EnWG Modul 3, Netto-Preise der Preisblätter 2026.
+      Datenquelle: [github.com/ScumbagSteve/Grid-fees](https://github.com/ScumbagSteve/Grid-fees).
+    en: |
+      Time-variable grid fees according to §14a EnWG module 3, net prices of the 2026 price sheets.
+      Data source: [github.com/ScumbagSteve/Grid-fees](https://github.com/ScumbagSteve/Grid-fees).
+group: price
+countries: ["DE"]
+params:
+  - name: gridoperator
+    type: choice
+    required: true
+    default: Bayernwerk Netz GmbH
+    description:
+      de: Netzbetreiber
+      en: Grid operator
+    choice:
+      - Bayernwerk Netz GmbH
+      - E.DIS Netz GmbH
+      - ENERVIE Vernetzt GmbH
+      - Energienetze Offenbach GmbH
+      - Energieversorgung Halle Netz GmbH
+      - FairNetz GmbH
+      - N-ERGIE Netz GmbH
+      - Netze Duisburg GmbH
+      - Netze ODR GmbH
+      - Pfalzwerke Netz AG
+      - Regensburg Netz GmbH
+      - Schleswig-Holstein Netz AG
+      - Stadtwerke Bad Bramstedt Netz GmbH
+      - Stadtwerke Elmshorn
+      - Stadtwerke Husum Netz GmbH
+      - Stuttgart Netze GmbH
+      - WEMAG Netz GmbH
+      - badenovaNETZE GmbH
+      - e-netz Südhessen AG
+      - inetz GmbH
+      - swa Netze GmbH
+  - preset: tariff-base
+render: |
+  type: fixed
+  {{- if eq .gridoperator "Bayernwerk Netz GmbH" }}
+  price: 0.0472
+  zones:
+    - price: 0.0047
+      hours: 10-15
+      months: Apr-Sep
+    - price: 0.0903
+      hours: 17-22
+      months: Apr-Sep
+  {{- else if eq .gridoperator "E.DIS Netz GmbH" }}
+  price: 0.0547
+  zones:
+    - price: 0.0055
+      hours: 00:00-05:00,23:30-00:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.088
+      hours: 10:15-12:00,16:45-20:15
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "ENERVIE Vernetzt GmbH" }}
+  price: 0.0683
+  zones:
+    - price: 0.0273
+      hours: 00:00-04:00
+    - price: 0.0966
+      hours: 18:00-21:00
+  {{- else if eq .gridoperator "Energienetze Offenbach GmbH" }}
+  price: 0.0587
+  zones:
+    - price: 0.0235
+      hours: 02:00-06:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.081
+      hours: 17:00-20:00
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "Energieversorgung Halle Netz GmbH" }}
+  price: 0.0686
+  zones:
+    - price: 0.0172
+      hours: 01:45-07:00
+    - price: 0.095
+      hours: 16:45-19:45
+  {{- else if eq .gridoperator "FairNetz GmbH" }}
+  price: 0.0816
+  zones:
+    - price: 0.0204
+      hours: 00:00-04:00,10:00-14:00
+    - price: 0.1187
+      hours: 17:00-22:00
+  {{- else if eq .gridoperator "N-ERGIE Netz GmbH" }}
+  price: 0.0596
+  zones:
+    - price: 0.0238
+      hours: 00:00-06:00,12:00-14:15,23:00-00:00
+    - price: 0.1177
+      hours: 18:00-21:00
+  {{- else if eq .gridoperator "Netze Duisburg GmbH" }}
+  price: 0.0694
+  zones:
+    - price: 0.0209
+      hours: 00:00-06:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.0977
+      hours: 14:15-18:45
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "Netze ODR GmbH" }}
+  price: 0.0587
+  zones:
+    - price: 0.0235
+      hours: 11:00-17:00
+      months: Apr-Sep
+    - price: 0.1018
+      hours: 00:00-05:00,22:00-00:00
+      months: Apr-Sep
+  {{- else if eq .gridoperator "Pfalzwerke Netz AG" }}
+  price: 0.063
+  zones:
+    - price: 0.0252
+      hours: 01:00-05:00
+    - price: 0.0707
+      hours: 11:00-13:30,18:00-21:00
+  {{- else if eq .gridoperator "Regensburg Netz GmbH" }}
+  price: 0.0505
+  zones:
+    - price: 0.0202
+      hours: 02:15-05:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.0531
+      hours: 09:00-20:30
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "Schleswig-Holstein Netz AG" }}
+  price: 0.064
+  zones:
+    - price: 0.0064
+      hours: 00:00-05:00,22:00-00:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.0832
+      hours: 09:00-14:00,17:00-21:00
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "Stadtwerke Bad Bramstedt Netz GmbH" }}
+  price: 0.0664
+  zones:
+    - price: 0.0133
+      hours: 00:00-07:00,22:00-00:00
+    - price: 0.0982
+      hours: 18:00-22:00
+  {{- else if eq .gridoperator "Stadtwerke Elmshorn" }}
+  price: 0.0855
+  zones:
+    - price: 0.0342
+      hours: 01:00-05:00
+      months: Jul-Dec
+    - price: 0.121
+      hours: 17:00-19:30
+      months: Jul-Dec
+  {{- else if eq .gridoperator "Stadtwerke Husum Netz GmbH" }}
+  price: 0.0615
+  zones:
+    - price: 0.0123
+      hours: 01:00-07:00
+    - price: 0.1012
+      hours: 16:00-19:00
+  {{- else if eq .gridoperator "Stuttgart Netze GmbH" }}
+  price: 0.1016
+  zones:
+    - price: 0.0152
+      hours: 02:00-05:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.1481
+      hours: 17:00-21:15
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "WEMAG Netz GmbH" }}
+  price: 0.0513
+  zones:
+    - price: 0.0195
+      hours: 00:00-06:00,21:00-00:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.077
+      hours: 07:00-11:00,17:00-20:00
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "badenovaNETZE GmbH" }}
+  price: 0.0729
+  zones:
+    - price: 0.0251
+      hours: 00:00-07:30,22:30-00:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.0875
+      hours: 08:00-21:00
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "e-netz Südhessen AG" }}
+  price: 0.0563
+  zones:
+    - price: 0.0153
+      hours: 00:00-06:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.0738
+      hours: 18:00-22:00
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "inetz GmbH" }}
+  price: 0.0599
+  zones:
+    - price: 0.024
+      hours: 01:30-04:15
+      months: Jan-Mar,Oct-Dec
+    - price: 0.0756
+      hours: 17:00-19:00
+      months: Jan-Mar,Oct-Dec
+  {{- else if eq .gridoperator "swa Netze GmbH" }}
+  price: 0.0607
+  zones:
+    - price: 0.0243
+      hours: 01:30-05:00
+      months: Jan-Mar,Oct-Dec
+    - price: 0.094
+      hours: 17:00-19:00
+      months: Jan-Mar,Oct-Dec
+  {{- else }}
+  {{ fail (printf "unknown grid operator: %s" .gridoperator) }}
+  {{- end }}
+  {{ include "tariff-base" . }}

--- a/templates/definition/tariff/grid-fees-de.yaml
+++ b/templates/definition/tariff/grid-fees-de.yaml
@@ -50,11 +50,11 @@ render: |
   price: 0.0472
   zones:
     - price: 0.0047
-      hours: 10-15
-      months: Apr-Sep
+      hours: 10:00-15:00
+      months: Apr-Jun,Jul-Sep
     - price: 0.0903
-      hours: 17-22
-      months: Apr-Sep
+      hours: 17:00-22:00
+      months: Apr-Jun,Jul-Sep
   {{- else if eq .gridoperator "E.DIS Netz GmbH" }}
   price: 0.0547
   zones:

--- a/templates/gridfees/grid-fees-de.tpl
+++ b/templates/gridfees/grid-fees-de.tpl
@@ -1,0 +1,46 @@
+template: grid-fees-de
+products:
+  - description:
+      de: Netzentgelte §14a EnWG (Modul 3)
+      en: Grid fees §14a EnWG (module 3)
+requirements:
+  description:
+    de: |
+      Zeitvariable Netzentgelte nach §14a EnWG Modul 3, Netto-Preise der Preisblätter [[ .Year ]].
+      Datenquelle: [github.com/ScumbagSteve/Grid-fees](https://github.com/ScumbagSteve/Grid-fees).
+    en: |
+      Time-variable grid fees according to §14a EnWG module 3, net prices of the [[ .Year ]] price sheets.
+      Data source: [github.com/ScumbagSteve/Grid-fees](https://github.com/ScumbagSteve/Grid-fees).
+group: price
+countries: ["DE"]
+params:
+  - name: gridoperator
+    type: choice
+    required: true
+    default: [[ (index .Operators 0).Name ]]
+    description:
+      de: Netzbetreiber
+      en: Grid operator
+    choice:
+[[- range .Operators ]]
+      - [[ .Name ]]
+[[- end ]]
+  - preset: tariff-base
+render: |
+  type: fixed
+[[- range $i, $o := .Operators ]]
+  {{- [[ if $i ]]else [[ end ]]if eq .gridoperator "[[ $o.Name ]]" }}
+  price: [[ $o.Price ]]
+  zones:
+  [[- range $o.Zones ]]
+    - price: [[ .Price ]]
+      hours: [[ .Hours ]]
+    [[- if .Months ]]
+      months: [[ .Months ]]
+    [[- end ]]
+  [[- end ]]
+[[- end ]]
+  {{- else }}
+  {{ fail (printf "unknown grid operator: %s" .gridoperator) }}
+  {{- end }}
+  {{ include "tariff-base" . }}

--- a/templates/gridfees/main.go
+++ b/templates/gridfees/main.go
@@ -1,0 +1,269 @@
+// Command gridfees generates the grid-fees-de tariff template from the
+// §14a EnWG grid fee data at https://github.com/ScumbagSteve/Grid-fees.
+//
+// Run from the repository root:
+//
+//	go run ./templates/gridfees
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"maps"
+	"net/http"
+	"os"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	_ "embed"
+)
+
+const (
+	sourceURL  = "https://codeload.github.com/ScumbagSteve/Grid-fees/tar.gz/refs/heads/main"
+	outputPath = "templates/definition/tariff/grid-fees-de.yaml"
+	unit       = "ct/kWh" // other units (e.g. percentage discounts) are not price zones
+)
+
+//go:embed grid-fees-de.tpl
+var tmpl string
+
+// source is the upstream per-operator file format
+type source struct {
+	GridOperator string `json:"grid_operator"`
+	ValueUnit    string `json:"value_unit"`
+	Years        map[string]struct {
+		Fallback struct {
+			Value *float64 `json:"value"`
+		} `json:"fallback"`
+		Periods []struct {
+			DateFrom string `json:"date_from"`
+			DateTo   string `json:"date_to"`
+			Times    []struct {
+				TimeFrom string   `json:"time_from"`
+				TimeTo   string   `json:"time_to"`
+				Value    *float64 `json:"value"`
+			} `json:"times"`
+		} `json:"periods"`
+	} `json:"years"`
+}
+
+type zone struct {
+	Price, Hours, Months string
+}
+
+type operator struct {
+	Name, Price string
+	Zones       []zone
+}
+
+func main() {
+	files, err := download(sourceURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var year int
+	operators := make(map[string]operator)
+
+	for _, name := range slices.Sorted(maps.Keys(files)) {
+		var src source
+		if err := json.Unmarshal(files[name], &src); err != nil {
+			log.Fatalf("%s: %v", name, err)
+		}
+
+		op, y, err := convert(src)
+		if err != nil {
+			log.Printf("skipping %s: %v", src.GridOperator, err)
+			continue
+		}
+
+		// upstream contains duplicate files per operator- keep the more detailed one
+		if prev, ok := operators[op.Name]; !ok || windows(prev) < windows(op) {
+			operators[op.Name] = op
+		}
+		year = max(year, y)
+	}
+
+	sorted := slices.SortedFunc(maps.Values(operators), func(i, j operator) int {
+		return strings.Compare(i.Name, j.Name)
+	})
+
+	out, err := os.Create(outputPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer out.Close()
+
+	t := template.Must(template.New("tpl").Delims("[[", "]]").Parse(tmpl))
+	if err := t.Execute(out, map[string]any{"Year": year, "Operators": sorted}); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("wrote %s: %d grid operators, %d", outputPath, len(sorted), year)
+}
+
+// windows counts the operator's time windows
+func windows(op operator) int {
+	var res int
+	for _, z := range op.Zones {
+		res += strings.Count(z.Hours, ",") + 1
+	}
+	return res
+}
+
+// download returns the json files of the source repo archive
+func download(uri string) (map[string][]byte, error) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %s", uri, resp.Status)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string][]byte)
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return res, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if path.Ext(hdr.Name) != ".json" {
+			continue
+		}
+
+		if res[path.Base(hdr.Name)], err = io.ReadAll(tr); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// convert converts the most recent year of a source file into template data
+func convert(src source) (operator, int, error) {
+	if src.ValueUnit != unit {
+		return operator{}, 0, fmt.Errorf("unsupported unit: %s", src.ValueUnit)
+	}
+
+	years := make([]int, 0, len(src.Years))
+	for y := range src.Years {
+		i, err := strconv.Atoi(y)
+		if err != nil {
+			return operator{}, 0, err
+		}
+		years = append(years, i)
+	}
+	if len(years) == 0 {
+		return operator{}, 0, fmt.Errorf("no years")
+	}
+
+	year := slices.Max(years)
+	data := src.Years[strconv.Itoa(year)]
+
+	if data.Fallback.Value == nil {
+		return operator{}, 0, fmt.Errorf("%d: missing fallback", year)
+	}
+	if len(data.Periods) == 0 {
+		return operator{}, 0, fmt.Errorf("%d: no periods", year)
+	}
+
+	// hours per price, months per identical set of price/hours
+	hours := make(map[string]map[float64][]string)
+	months := make(map[string][]string)
+	var keys []string
+
+	for _, p := range data.Periods {
+		m, err := monthRange(p.DateFrom, p.DateTo)
+		if err != nil {
+			return operator{}, 0, fmt.Errorf("%d: %w", year, err)
+		}
+
+		byPrice := make(map[float64][]string)
+		for _, t := range p.Times {
+			if t.Value == nil {
+				return operator{}, 0, fmt.Errorf("%d: missing value", year)
+			}
+			byPrice[*t.Value] = append(byPrice[*t.Value], t.TimeFrom+"-"+strings.Replace(t.TimeTo, "24:00", "00:00", 1))
+		}
+
+		key := fmt.Sprint(byPrice)
+		if _, ok := hours[key]; !ok {
+			hours[key] = byPrice
+			keys = append(keys, key)
+		}
+		if m != "" {
+			months[key] = append(months[key], m)
+		}
+	}
+
+	op := operator{
+		Name:  src.GridOperator,
+		Price: price(*data.Fallback.Value),
+	}
+
+	for _, key := range keys {
+		for _, p := range slices.Sorted(maps.Keys(hours[key])) {
+			h := hours[key][p]
+			slices.Sort(h)
+
+			op.Zones = append(op.Zones, zone{
+				Price:  price(p),
+				Hours:  strings.Join(h, ","),
+				Months: strings.Join(months[key], ","),
+			})
+		}
+	}
+
+	return op, year, nil
+}
+
+// price converts ct/kWh into currency/kWh
+func price(v float64) string {
+	return strings.TrimRight(strconv.FormatFloat(v/100, 'f', 6, 64), "0")
+}
+
+// monthRange converts a DD.MM. date range into a month range, empty for the entire year
+func monthRange(from, to string) (string, error) {
+	f, err := time.Parse("02.01.", from)
+	if err != nil {
+		return "", err
+	}
+
+	t, err := time.Parse("02.01.", to)
+	if err != nil {
+		return "", err
+	}
+
+	// zones are month- not day-based
+	if f.Day() != 1 || t.Day() != time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day() {
+		return "", fmt.Errorf("period is not month-aligned: %s-%s", from, to)
+	}
+
+	switch {
+	case f.Month() == time.January && t.Month() == time.December:
+		return "", nil
+	case f.Month() == t.Month():
+		return f.Format("Jan"), nil
+	default:
+		return f.Format("Jan") + "-" + t.Format("Jan"), nil
+	}
+}


### PR DESCRIPTION
Converts the data from [ScumbagSteve/Grid-fees](https://github.com/ScumbagSteve/Grid-fees) into a `grid-fees-de` tariff template: time-variable §14a EnWG module 3 grid fees rendered as a zoned `fixed` tariff, with the grid operator as a choice parameter.

- 21 grid operators, 2026 net price sheets (ct/kWh → EUR/kWh)
- `fallback` (ST) becomes the base price, NT/HT windows become zones
- date periods map cleanly to months (all upstream ranges are whole-month), times to `hours`
- skipped upstream files without usable data: NordNetz (no periods), Thüga (null values), Österreich SNAP (percentage discount, not representable as a price zone)
- Bad Bramstedt exists twice upstream; the superset variant is used

Test renders and instantiates the template for every operator and checks the resulting rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)