### PR TITLE
Meter (SunSpec): read battery power limits from device

### DIFF
--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -32,6 +32,10 @@ params:
     deprecated: true
   - name: maxacpower
   - preset: battery-params
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
   - name: maxchargerate
 render: |
   type: custom
@@ -330,5 +334,5 @@ render: |
             uri: {{ .host }}:{{ .port }}
             id: 1
             value: 124:0:InWRte
-  {{- include "battery-params" . }}
+  {{- include "battery-params-sunspec" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -20,6 +20,10 @@ params:
   - name: maxacpower
   - name: maxchargerate
   - preset: battery-params
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
 render: |
   type: custom
   # sunspec model 20x (int+sf)/ 21x (float) meter
@@ -277,5 +281,5 @@ render: |
             uri: {{ .host }}:{{ .port }}
             id: 1
             value: 124:0:InWRte
-  {{- include "battery-params" . }}
+  {{- include "battery-params-sunspec" . }}
   {{- end }}

--- a/templates/definition/meter/sunspec-battery-control.yaml
+++ b/templates/definition/meter/sunspec-battery-control.yaml
@@ -11,6 +11,10 @@ params:
   - name: modbus
     choice: ["tcpip", "rs485"]
   - preset: battery-params
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
 render: |
   {{- if eq .usage "battery" }}
   type: custom
@@ -26,5 +30,5 @@ render: |
     source: sunspec
     {{- include "modbus" . | indent 2 }}
     value: 802:SoCRsvMin
-  {{- include "battery-params" . }}
+  {{- include "battery-params-sunspec" . }}
   {{- end }}

--- a/templates/definition/meter/sunspec-hybrid.yaml
+++ b/templates/definition/meter/sunspec-hybrid.yaml
@@ -12,6 +12,10 @@ params:
     choice: ["tcpip", "rs485"]
   - name: maxacpower
   - preset: battery-params
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
 render: |
   type: custom
   # sunspec model 203 (int+sf)/ 213 (float) meter
@@ -135,5 +139,5 @@ render: |
     value:
       - 124:ChaState
       - 802:SoC
-  {{- include "battery-params" . }}
+  {{- include "battery-params-sunspec" . }}
   {{- end }}

--- a/templates/definition/meter/sunspec-inverter-control.yaml
+++ b/templates/definition/meter/sunspec-inverter-control.yaml
@@ -12,6 +12,10 @@ params:
     choice: ["tcpip", "rs485"]
   - name: maxchargerate
   - preset: battery-params
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
 render: |
   {{- if eq .usage "battery" }}
   type: custom
@@ -125,5 +129,5 @@ render: |
             source: sunspec
             {{- include "modbus" . | indent 10 }}
             value: 124:0:InOutWRte_RvrtTms
-  {{- include "battery-params" . }}
+  {{- include "battery-params-sunspec" . }}
   {{- end }}

--- a/templates/definition/meter/sunspec-inverter.yaml
+++ b/templates/definition/meter/sunspec-inverter.yaml
@@ -10,6 +10,10 @@ params:
   - name: modbus
     choice: ["tcpip", "rs485"]
   - preset: battery-params
+  - name: maxchargepower
+    deprecated: true
+  - name: maxdischargepower
+    deprecated: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -171,5 +175,5 @@ render: |
     value:
       - 124:ChaState
       - 802:SoC
-  {{- include "battery-params" . }}
+  {{- include "battery-params-sunspec" . }}
   {{- end }}

--- a/util/templates/includes/battery-params.tpl
+++ b/util/templates/includes/battery-params.tpl
@@ -12,8 +12,39 @@ maxchargepower: {{ .maxchargepower }} # W
 maxdischargepower: {{ .maxdischargepower }} # W
 {{- end }}
 
+{{/* connection for templates without the modbus preset, i.e. fixed sunspec device id 1 */}}
+{{ define "battery-sunspec-connection" }}
+{{- if .modbus }}
+{{- include "modbus" . }}
+{{- else }}
+uri: {{ joinHostPort .host .port }}
+id: 1
+{{- end }}
+{{- end }}
+
+{{ define "battery-power-sunspec" }}
+maxchargepower:
+  source: sunspec
+  {{- include "battery-sunspec-connection" . | indent 2 }}
+  value:
+    - 120:0:MaxChaRte
+    - 802:WChaRteMax
+maxdischargepower:
+  source: sunspec
+  {{- include "battery-sunspec-connection" . | indent 2 }}
+  value:
+    - 120:0:MaxDisChaRte
+    - 802:WDisChaRteMax
+{{- end }}
+
 {{ define "battery-params" }}
 {{- include "battery-capacity" . }}
 {{- include "battery-minmaxsoc" . }}
 {{- include "battery-power" . }}
+{{- end }}
+
+{{ define "battery-params-sunspec" }}
+{{- include "battery-capacity" . }}
+{{- include "battery-minmaxsoc" . }}
+{{- include "battery-power-sunspec" . }}
 {{- end }}


### PR DESCRIPTION
prepares #32848

SunSpec battery templates left `maxchargepower`/`maxdischargepower` empty unless the user typed them in, so `api.BatteryPowerLimiter` was never decorated. The nameplate models carry both values, so read them from the device instead.

- new `battery-params-sunspec` include, applied to `fronius-gen24`, `fronius-vertoplus`, `sunspec-battery-control`, `sunspec-hybrid`, `sunspec-inverter` and `sunspec-inverter-control`
- charge reads `120:0:MaxChaRte`, discharge reads `120:0:MaxDisChaRte`, both falling back to `802:WChaRteMax`/`802:WDisChaRteMax` for battery-only devices. Only read-only nameplate points, no setpoints, so a value evcc or another controller has written cannot be mistaken for the device rating
- `maxchargepower`/`maxdischargepower` are deprecated on these templates, following the Powerwall pattern: still accepted in existing configs, no longer offered or used

This also fixes the optimizer planning every SunSpec battery against the `batteryPower` default rather than the real device rating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
