### PR TITLE
Kia/Hyundai EU: add OneApp/CCI login to fix new-login WAF block

### DIFF
--- a/templates/definition/vehicle/hyundai.yaml
+++ b/templates/definition/vehicle/hyundai.yaml
@@ -6,11 +6,11 @@ products:
 requirements:
   description:
     en: |
-      The password field accepts either a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) or, since generating a fresh `refresh_token` may currently be blocked, your account's actual password — evcc will then log in automatically. Automatic password login is only available for the Europe region.
+      The password field accepts either a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) or, for the Europe region, your account's password.
 
       Some models (e.g. Kona) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: |
-      In das Passwort-Feld kann entweder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) oder, da die Erzeugung eines neuen `refresh_token` derzeit blockiert sein kann, das tatsächliche Passwort deines Kontos eingetragen werden — evcc meldet sich dann automatisch an. Die automatische Passwort-Anmeldung ist nur für die Region Europa verfügbar.
+      In das Passwort-Feld kann entweder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) oder, für die Region Europa, das Passwort deines Kontos eingetragen werden.
 
       Manche Modelle (z.B. Kona) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:

--- a/templates/definition/vehicle/hyundai.yaml
+++ b/templates/definition/vehicle/hyundai.yaml
@@ -6,12 +6,12 @@ products:
 requirements:
   description:
     en: |
-      Instead of your account's password, the password field needs to be filled with a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).  
-        
+      The password field accepts either a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) or, since generating a fresh `refresh_token` may currently be blocked, your account's actual password — evcc will then log in automatically. Automatic password login is only available for the Europe region.
+
       Some models (e.g. Kona) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: |
-      Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).  
-        
+      In das Passwort-Feld kann entweder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) oder, da die Erzeugung eines neuen `refresh_token` derzeit blockiert sein kann, das tatsächliche Passwort deines Kontos eingetragen werden — evcc meldet sich dann automatisch an. Die automatische Passwort-Anmeldung ist nur für die Region Europa verfügbar.
+
       Manche Modelle (z.B. Kona) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:
   - preset: vehicle-base

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -6,11 +6,11 @@ products:
 requirements:
   description:
     en: |
-      The password field accepts either a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) or, since generating a fresh `refresh_token` may currently be blocked, your account's actual password — evcc will then log in automatically. Automatic password login is only available for the Europe region.
+      The password field accepts either your account's password or a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).
 
       Some models (e.g. Niro EV) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: |
-      In das Passwort-Feld kann entweder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) oder, da die Erzeugung eines neuen `refresh_token` derzeit blockiert sein kann, das tatsächliche Passwort deines Kontos eingetragen werden — evcc meldet sich dann automatisch an. Die automatische Passwort-Anmeldung ist nur für die Region Europa verfügbar.
+      In das Passwort-Feld kann entweder das Passwort deines Kontos oder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) eingetragen werden.
 
       Manche Modelle (z.B. Niro EV) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -6,12 +6,12 @@ products:
 requirements:
   description:
     en: |
-      Instead of your account's password, the password field needs to be filled with a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).  
-        
+      The password field accepts either a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) or, since generating a fresh `refresh_token` may currently be blocked, your account's actual password — evcc will then log in automatically.
+
       Some models (e.g. Niro EV) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: |
-      Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)).  
-        
+      In das Passwort-Feld kann entweder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) oder, da die Erzeugung eines neuen `refresh_token` derzeit blockiert sein kann, das tatsächliche Passwort deines Kontos eingetragen werden — evcc meldet sich dann automatisch an.
+
       Manche Modelle (z.B. Niro EV) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:
   - preset: vehicle-base

--- a/templates/definition/vehicle/kia.yaml
+++ b/templates/definition/vehicle/kia.yaml
@@ -6,11 +6,11 @@ products:
 requirements:
   description:
     en: |
-      The password field accepts either a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) or, since generating a fresh `refresh_token` may currently be blocked, your account's actual password — evcc will then log in automatically.
+      The password field accepts either a `refresh_token` ([instructions](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) or, since generating a fresh `refresh_token` may currently be blocked, your account's actual password — evcc will then log in automatically. Automatic password login is only available for the Europe region.
 
       Some models (e.g. Niro EV) switch internally to 2 phases at low charging currents (< 8A). In cases where the wallbox also measures the phase currents, this leads to undesirable fluctuations in the charging power. The remedy here is to set the minimum charging current to 8A.
     de: |
-      In das Passwort-Feld kann entweder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) oder, da die Erzeugung eines neuen `refresh_token` derzeit blockiert sein kann, das tatsächliche Passwort deines Kontos eingetragen werden — evcc meldet sich dann automatisch an.
+      In das Passwort-Feld kann entweder ein `refresh_token` ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh-Token)) oder, da die Erzeugung eines neuen `refresh_token` derzeit blockiert sein kann, das tatsächliche Passwort deines Kontos eingetragen werden — evcc meldet sich dann automatisch an. Die automatische Passwort-Anmeldung ist nur für die Region Europa verfügbar.
 
       Manche Modelle (z.B. Niro EV) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 params:

--- a/vehicle/bluelink.go
+++ b/vehicle/bluelink.go
@@ -50,6 +50,17 @@ func NewHyundaiFromConfig(other map[string]any) (api.Vehicle, error) {
 			PushType:          "GCM",
 			LoginFormHost:     "https://idpconnect-eu.hyundai.com",
 			Brand:             "hyundai",
+			// OneApp/CCI login (bypasses the IDPConnect WAF block on the legacy
+			// authorize endpoint, see vehicle/bluelink/cci.go)
+			CCI: &bluelink.CCIConfig{
+				OneAppClientID:       "4f4953b5-02e1-4dbc-8599-87e983ee1be5",
+				OneAppRedirectURI:    "https://oneapp.hyundai.com/redirect",
+				APIURL:               "https://cci-api-eu.hyundai.com",
+				PackageID:            "com.hyundai.oneapp.eu",
+				ClientName:           "hyundai",
+				OSVersion:            "18.7",
+				NotificationProvider: "APNS",
+			},
 		}
 	case "australia", "new zealand":
 		settings = bluelink.Config{
@@ -84,6 +95,17 @@ func NewKiaFromConfig(other map[string]any) (api.Vehicle, error) {
 		LoginFormHost:     "https://idpconnect-eu.kia.com",
 		PushType:          "APNS",
 		Brand:             "kia",
+		// OneApp/CCI login (bypasses the IDPConnect WAF block on the legacy
+		// authorize endpoint, see vehicle/bluelink/cci.go)
+		CCI: &bluelink.CCIConfig{
+			OneAppClientID:       "01b36c86-79e8-486c-8009-15f2ad88d670",
+			OneAppRedirectURI:    "https://oneapp.kia.com/redirect",
+			APIURL:               "https://cci-api-eu.kia.com",
+			PackageID:            "com.kia.oneapp.eu",
+			ClientName:           "kia",
+			OSVersion:            "27",
+			NotificationProvider: "IOS_APPSTORE",
+		},
 	}
 
 	return newBluelinkFromConfig("kia", other, settings)

--- a/vehicle/bluelink/cci.go
+++ b/vehicle/bluelink/cci.go
@@ -1,0 +1,667 @@
+package bluelink
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/google/uuid"
+	"golang.org/x/oauth2"
+)
+
+// CCIConfig holds the OneApp/CCI login parameters for brands where the
+// legacy IDPConnect authorize endpoint is blocked by Hyundai's WAF (as of
+// 2026-08, see https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1273).
+// It is only set for EU Kia/Hyundai — Genesis EU and Hyundai AU are not
+// WAF-affected and keep using the legacy authorize/refresh flow unchanged
+// (Config.CCI == nil for those brands).
+type CCIConfig struct {
+	OneAppClientID       string // OneApp OAuth2 client_id (not on the WAF block list)
+	OneAppRedirectURI    string
+	APIURL               string // e.g. https://cci-api-eu.kia.com
+	PackageID            string // "client-id" header value (mobile app bundle id)
+	ClientName           string // "client-name" header value
+	OSVersion            string // "client-os-version" header value
+	NotificationProvider string // "client-notification-provider-type" header value
+}
+
+const (
+	cciClientVersion    = "1.3.3"
+	cciMobileUserAgent  = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19_CCS_APP_AOS"
+	cciBundlePrefix     = "cci1:" // marks a compound CCI token bundle in the config `password` field
+	cciSettingsKeyFmt   = "bluelink-cci.%s.%s"
+	cciTimezoneLocation = "Europe/Berlin"
+)
+
+// cciBundle is the full CCI/CCS token state needed to authenticate against the
+// legacy ccapi:8080 vehicle/control endpoints (AccessToken) and to refresh
+// without repeating the full password login (all other fields). It is used
+// both as the persistence format (server/db/settings, keyed per brand+user)
+// and as the wire format for a compound bundle string that a user can paste
+// directly into the `password` config field (see decodeCCIBundle).
+type cciBundle struct {
+	AccessToken              string    `json:"access_token"`  // CCS token (no "Bearer " prefix) — used for the legacy vehicle API
+	RefreshToken             string    `json:"refresh_token"` // CCI refresh token
+	Expiry                   time.Time `json:"expiry"`        // CCS token expiry
+	DeviceID                 string    `json:"device_id"`     // stable client-device-id used for all CCI calls of this session
+	CCIAccessToken           string    `json:"cci_access_token"`
+	ExchangeableToken        string    `json:"exchangeable_token"`
+	ExchangeableRefreshToken string    `json:"exchangeable_refresh_token"`
+	NonCcsToken              string    `json:"non_ccs_token"`
+	NonCcsRefreshToken       string    `json:"non_ccs_refresh_token"`
+	IDToken                  string    `json:"id_token"`
+}
+
+// extra keys used to carry the cciBundle fields through oauth2.Token.Extra,
+// so the existing oauth.RefreshTokenSource (which only knows about
+// AccessToken/RefreshToken/Expiry) can be reused unchanged for the CCI flow.
+const (
+	extraDeviceID                 = "device_id"
+	extraCCIAccessToken           = "cci_access_token"
+	extraExchangeableToken        = "exchangeable_token"
+	extraExchangeableRefreshToken = "exchangeable_refresh_token"
+	extraNonCcsToken              = "non_ccs_token"
+	extraNonCcsRefreshToken       = "non_ccs_refresh_token"
+	extraIDToken                  = "id_token"
+)
+
+// token converts the bundle into an oauth2.Token, carrying the CCI-specific
+// fields in Extra so they survive a round-trip through oauth.RefreshTokenSource.
+func (b cciBundle) token() *oauth2.Token {
+	t := &oauth2.Token{
+		AccessToken:  b.AccessToken,
+		RefreshToken: b.RefreshToken,
+		Expiry:       b.Expiry,
+	}
+
+	return t.WithExtra(map[string]any{
+		extraDeviceID:                 b.DeviceID,
+		extraCCIAccessToken:           b.CCIAccessToken,
+		extraExchangeableToken:        b.ExchangeableToken,
+		extraExchangeableRefreshToken: b.ExchangeableRefreshToken,
+		extraNonCcsToken:              b.NonCcsToken,
+		extraNonCcsRefreshToken:       b.NonCcsRefreshToken,
+		extraIDToken:                  b.IDToken,
+	})
+}
+
+func cciExtraString(token *oauth2.Token, key string) string {
+	s, _ := token.Extra(key).(string)
+	return s
+}
+
+// bundleFromToken is the inverse of cciBundle.token().
+func bundleFromToken(token *oauth2.Token) cciBundle {
+	return cciBundle{
+		AccessToken:              token.AccessToken,
+		RefreshToken:             token.RefreshToken,
+		Expiry:                   token.Expiry,
+		DeviceID:                 cciExtraString(token, extraDeviceID),
+		CCIAccessToken:           cciExtraString(token, extraCCIAccessToken),
+		ExchangeableToken:        cciExtraString(token, extraExchangeableToken),
+		ExchangeableRefreshToken: cciExtraString(token, extraExchangeableRefreshToken),
+		NonCcsToken:              cciExtraString(token, extraNonCcsToken),
+		NonCcsRefreshToken:       cciExtraString(token, extraNonCcsRefreshToken),
+		IDToken:                  cciExtraString(token, extraIDToken),
+	}
+}
+
+// decodeCCIBundle decodes a compound CCI token bundle from the config
+// `password` field. Wire format: "cci1:" + base64url(json(cciBundle)) with no
+// padding. This lets a user who has already obtained a CCI token set with an
+// external tool configure evcc without ever storing their live account
+// password, mirroring how the pre-existing legacy refresh_token worked.
+func decodeCCIBundle(s string) (cciBundle, bool) {
+	if !strings.HasPrefix(s, cciBundlePrefix) {
+		return cciBundle{}, false
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(s, cciBundlePrefix))
+	if err != nil {
+		return cciBundle{}, false
+	}
+
+	var b cciBundle
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return cciBundle{}, false
+	}
+
+	return b, true
+}
+
+// legacyRefreshTokenPattern matches the shape evcc has always accepted here:
+// an opaque legacy IDPConnect refresh_token, historically 48 uppercase
+// letters/digits (hyundai_kia_connect_api uses the exact `^[A-Z0-9]{48}$`);
+// widened slightly to 40-60 chars to tolerate minor length variance across
+// brands/regions. Note this is a *character-class* check, not just a length
+// check: a real account password virtually always contains lowercase letters
+// and/or symbols, which this pattern rejects, so it is never misclassified
+// as a legacy token merely for being short.
+var legacyRefreshTokenPattern = regexp.MustCompile(`^[A-Z0-9]{40,60}$`)
+
+// looksLikeLegacyRefreshToken reports whether password has the shape of a
+// legacy IDPConnect refresh_token (see legacyRefreshTokenPattern). This keeps
+// the behaviour for every user who still holds a valid pre-block legacy
+// refresh_token completely unchanged, while routing anything else (a real
+// account password, or a cci1: bundle) to the CCI-capable path.
+func looksLikeLegacyRefreshToken(password string) bool {
+	return legacyRefreshTokenPattern.MatchString(password)
+}
+
+// settingsKey returns the server/db/settings key under which the CCI token
+// bundle for this identity is persisted, mirroring the pattern used by e.g.
+// vehicle/tesla and vehicle/mercedes for their OAuth2 tokens.
+func (v *Identity) settingsKey() string {
+	return fmt.Sprintf(cciSettingsKeyFmt, v.config.Brand, v.user)
+}
+
+// loginCCI obtains a usable CCS access token for EU Kia/Hyundai via the
+// OneApp/CCI flow. Priority order:
+//  1. a token bundle persisted from a prior login/refresh (server/db/settings) —
+//     avoids hitting the login endpoint (and its stricter rate limiting/WAF)
+//     on every evcc restart.
+//  2. a CCI token bundle supplied directly in the password field (see
+//     decodeCCIBundle) — lets users who don't want evcc to hold their live
+//     account password generate the bundle once with an external tool.
+//  3. a full interactive username+password login.
+func (v *Identity) loginCCI(password string) (*oauth2.Token, error) {
+	var persisted cciBundle
+	if err := settings.Json(v.settingsKey(), &persisted); err == nil {
+		if token, err := v.tokenOrRefresh(persisted); err == nil {
+			v.log.DEBUG.Println("cci: using persisted token from database")
+			return token, nil
+		} else {
+			v.log.WARN.Printf("cci: persisted token invalid or refresh failed, falling back: %v", err)
+		}
+	}
+
+	if bundle, ok := decodeCCIBundle(password); ok {
+		token, err := v.tokenOrRefresh(bundle)
+		if err != nil {
+			return nil, fmt.Errorf("cci token bundle in config is invalid or expired: %w", err)
+		}
+		return token, nil
+	}
+
+	return v.loginCCIPassword(password)
+}
+
+// tokenOrRefresh returns the bundle's token directly if still valid, otherwise
+// refreshes it.
+func (v *Identity) tokenOrRefresh(bundle cciBundle) (*oauth2.Token, error) {
+	token := bundle.token()
+	if token.Valid() {
+		return token, nil
+	}
+	if token.RefreshToken == "" {
+		return nil, errors.New("no refresh token available")
+	}
+	return v.refreshCCI(token)
+}
+
+// loginCCIPassword performs the OneApp/CCI headless password login (EU
+// Kia/Hyundai). It bypasses the legacy IDPConnect authorize endpoint, which
+// is WAF-blocked for the legacy client_id. Steps:
+//  1. GET  {LoginFormHost}/auth/api/v2/user/oauth2/authorize (OneApp client_id — not WAF-blocked)
+//  2. GET  {LoginFormHost}/auth/api/v1/accounts/certs        (RSA public key for password encryption)
+//  3. POST {LoginFormHost}/auth/account/signin                (RSA-encrypted password, redirect not followed)
+//  4. POST {CCI.APIURL}/domain/api/v1/auth/token              (auth code -> CCI token set)
+//  5. POST {CCI.APIURL}/domain/api/v1/auth/token-exchange     (CCI token -> CCS token, usable on legacy ccapi:8080)
+func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
+	c := v.config.CCI
+	deviceID := uuid.NewString()
+
+	v.log.INFO.Println("cci: logging in via OneApp/CCI password login")
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+	v.Client.Jar = jar
+	defer func() {
+		v.Client.Jar = nil
+		v.Client.CheckRedirect = nil
+	}()
+
+	// Step 1: authorize. The OneApp client_id is not on the WAF block list, so
+	// this succeeds where the legacy client_id's authorize is rejected.
+	authURL := fmt.Sprintf(
+		"%s/auth/api/v2/user/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&lang=en&state=ccsp&country=de",
+		v.config.LoginFormHost, c.OneAppClientID, c.OneAppRedirectURI,
+	)
+	authReq, err := request.New(http.MethodGet, authURL, nil, map[string]string{
+		"User-Agent": cciMobileUserAgent,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	authResp, err := v.Client.Do(authReq)
+	if err != nil {
+		return nil, err
+	}
+	authBody, _ := io.ReadAll(authResp.Body)
+	authResp.Body.Close()
+
+	if strings.Contains(strings.ToLower(string(authBody)), "abusing") ||
+		strings.Contains(authResp.Request.URL.String(), "/error?status=400") {
+		return nil, errors.New("login blocked: IDPConnect authorize rejected the request ('abusing request'). " +
+			"This is a server-side WAF block, not a credentials problem")
+	}
+
+	// Step 2: RSA public key used to encrypt the password for signin.
+	certReq, err := request.New(http.MethodGet, v.config.LoginFormHost+"/auth/api/v1/accounts/certs", nil, map[string]string{
+		"User-Agent": cciMobileUserAgent,
+		"Accept":     request.JSONContent,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var certRes struct {
+		RetValue struct {
+			Kid string
+			N   string
+			E   string
+		}
+	}
+	if err := v.DoJSON(certReq, &certRes); err != nil {
+		return nil, fmt.Errorf("fetching rsa certs failed: %w", err)
+	}
+
+	encryptedPassword, err := encryptCCIPassword(certRes.RetValue.N, certRes.RetValue.E, password)
+	if err != nil {
+		return nil, fmt.Errorf("encrypting password failed: %w", err)
+	}
+
+	// Step 3: signin with the RSA-encrypted password. The auth code arrives in
+	// the Location header of the 302 response, so redirects must not be followed.
+	data := url.Values{
+		"client_id":             {c.OneAppClientID},
+		"encryptedPassword":     {"true"},
+		"password":              {encryptedPassword},
+		"redirect_uri":          {c.OneAppRedirectURI},
+		"scope":                 {""},
+		"nonce":                 {""},
+		"state":                 {"ccsp"},
+		"username":              {v.user},
+		"connector_session_key": {""},
+		"kid":                   {certRes.RetValue.Kid},
+		"_csrf":                 {""},
+	}
+	signinReq, err := request.New(http.MethodPost, v.config.LoginFormHost+"/auth/account/signin", strings.NewReader(data.Encode()), map[string]string{
+		"Content-Type": request.FormContent,
+		"User-Agent":   cciMobileUserAgent,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	v.Client.CheckRedirect = request.DontFollow
+	signinResp, err := v.Client.Do(signinReq)
+	if err != nil {
+		return nil, err
+	}
+	signinBody, _ := io.ReadAll(signinResp.Body)
+	signinResp.Body.Close()
+
+	if signinResp.StatusCode != http.StatusFound {
+		return nil, fmt.Errorf("signin failed: HTTP %d — check username and password (%s)",
+			signinResp.StatusCode, truncate(string(signinBody), 200))
+	}
+
+	location := signinResp.Header.Get("Location")
+	loc, err := url.Parse(location)
+	if err != nil {
+		return nil, fmt.Errorf("signin returned unparseable redirect: %w", err)
+	}
+
+	code := loc.Query().Get("code")
+	if code == "" {
+		switch {
+		case strings.Contains(strings.ToLower(location), "error"):
+			desc := loc.Query().Get("error_description")
+			if desc == "" {
+				desc = "unknown"
+			}
+			return nil, fmt.Errorf("authentication rejected: %s — check username and password", desc)
+		case strings.Contains(location, "/web/v1/user/authorization"):
+			return nil, errors.New("account consent required: please log in via the manufacturer app or browser once to accept the terms, then retry")
+		case strings.Contains(location, "authorize"):
+			return nil, errors.New("authentication failed — returned to login page, check username and password")
+		default:
+			return nil, fmt.Errorf("unexpected redirect after signin: %s", truncate(location, 250))
+		}
+	}
+
+	// Step 4: exchange the authorization code for the CCI token set.
+	bundle, err := v.exchangeCCIToken(deviceID, code)
+	if err != nil {
+		return nil, err
+	}
+	bundle.DeviceID = deviceID
+
+	// Step 5: exchange the CCI access token for a CCS token, accepted by the
+	// legacy ccapi:8080 vehicle/control endpoints.
+	ccsToken, ccsValidUntil, err := v.exchangeCCSToken(deviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken)
+	if err != nil {
+		return nil, err
+	}
+	bundle.AccessToken = ccsToken
+	bundle.Expiry = ccsValidUntil
+
+	if err := settings.SetJson(v.settingsKey(), bundle); err != nil {
+		v.log.WARN.Printf("cci: persisting token failed: %v", err)
+	}
+
+	v.log.INFO.Println("cci: login successful")
+
+	return bundle.token(), nil
+}
+
+// refreshCCI refreshes the CCI token set via cci-api-eu/.../v2/auth/token-refresh
+// (the full CCI token set is required in the request body), then re-exchanges
+// the CCS token. Called automatically by oauth.RefreshTokenSource whenever the
+// current CCS token has expired.
+func (v *Identity) refreshCCI(token *oauth2.Token) (*oauth2.Token, error) {
+	v.log.DEBUG.Println("cci: refreshing token")
+
+	bundle := bundleFromToken(token)
+
+	c := v.config.CCI
+	headers := v.cciHeaders(bundle.DeviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken, request.JSONContent)
+
+	body := map[string]string{
+		"accessToken":              bundle.CCIAccessToken,
+		"refreshToken":             bundle.RefreshToken,
+		"exchangeableAccessToken":  bundle.ExchangeableToken,
+		"exchangeableRefreshToken": bundle.ExchangeableRefreshToken,
+		"nonCcsToken":              bundle.NonCcsToken,
+		"nonCcsRefreshToken":       bundle.NonCcsRefreshToken,
+		"idToken":                  bundle.IDToken,
+	}
+
+	uri := c.APIURL + "/domain/api/v2/auth/token-refresh"
+	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(body), headers)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		AccessToken              string `json:"accessToken"`
+		RefreshToken             string `json:"refreshToken"`
+		NonCcsToken              string `json:"nonCcsToken"`
+		ExchangeableAccessToken  string `json:"exchangeableAccessToken"`
+		ExchangeableRefreshToken string `json:"exchangeableRefreshToken"`
+		NonCcsRefreshToken       string `json:"nonCcsRefreshToken"`
+		IDToken                  string `json:"idToken"`
+	}
+	if err := v.DoJSON(req, &res); err != nil {
+		return nil, fmt.Errorf("cci token refresh failed: %w", err)
+	}
+
+	if res.AccessToken != "" {
+		bundle.CCIAccessToken = res.AccessToken
+	}
+	if res.RefreshToken != "" {
+		bundle.RefreshToken = res.RefreshToken
+	}
+	if res.NonCcsToken != "" {
+		bundle.NonCcsToken = res.NonCcsToken
+	}
+	if res.ExchangeableAccessToken != "" {
+		bundle.ExchangeableToken = res.ExchangeableAccessToken
+	}
+	if res.ExchangeableRefreshToken != "" {
+		bundle.ExchangeableRefreshToken = res.ExchangeableRefreshToken
+	}
+	if res.NonCcsRefreshToken != "" {
+		bundle.NonCcsRefreshToken = res.NonCcsRefreshToken
+	}
+	if res.IDToken != "" {
+		bundle.IDToken = res.IDToken
+	}
+
+	// Note: the upstream reference implementation additionally inspects a
+	// Set-Cookie: t=<token> response header for an updated exchangeable
+	// token. That is a supplementary/optional signal (the JSON body above is
+	// the primary source) and is intentionally not replicated here to keep
+	// this port simple; revisit if refreshes are observed to go stale despite
+	// a 200 response.
+
+	ccsToken, ccsValidUntil, err := v.exchangeCCSToken(bundle.DeviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken)
+	if err != nil {
+		return nil, err
+	}
+	bundle.AccessToken = ccsToken
+	bundle.Expiry = ccsValidUntil
+
+	if err := settings.SetJson(v.settingsKey(), bundle); err != nil {
+		v.log.WARN.Printf("cci: persisting refreshed token failed: %v", err)
+	}
+
+	v.log.DEBUG.Println("cci: refresh successful")
+
+	return bundle.token(), nil
+}
+
+// exchangeCCIToken exchanges an authorization code for the CCI token set
+// (step 4 of the login flow).
+func (v *Identity) exchangeCCIToken(deviceID, code string) (cciBundle, error) {
+	c := v.config.CCI
+
+	uri := c.APIURL + "/domain/api/v1/auth/token?code=" + url.QueryEscape(code)
+	headers := v.cciHeaders(deviceID, "", "", "", "")
+
+	req, err := request.New(http.MethodPost, uri, nil, headers)
+	if err != nil {
+		return cciBundle{}, err
+	}
+
+	var res struct {
+		AccessToken              string `json:"accessToken"`
+		RefreshToken             string `json:"refreshToken"`
+		NonCcsToken              string `json:"nonCcsToken"`
+		ExchangeableAccessToken  string `json:"exchangeableAccessToken"`
+		ExchangeableRefreshToken string `json:"exchangeableRefreshToken"`
+		NonCcsRefreshToken       string `json:"nonCcsRefreshToken"`
+		IDToken                  string `json:"idToken"`
+	}
+	if err := v.DoJSON(req, &res); err != nil {
+		return cciBundle{}, fmt.Errorf("cci token exchange failed: %w", err)
+	}
+
+	return cciBundle{
+		RefreshToken:             res.RefreshToken,
+		CCIAccessToken:           res.AccessToken,
+		ExchangeableToken:        res.ExchangeableAccessToken,
+		ExchangeableRefreshToken: res.ExchangeableRefreshToken,
+		NonCcsToken:              res.NonCcsToken,
+		NonCcsRefreshToken:       res.NonCcsRefreshToken,
+		IDToken:                  res.IDToken,
+	}, nil
+}
+
+// exchangeCCSToken exchanges a CCI access token for a CCS token (step 5 of
+// the login flow, and the final step of every refresh). The CCS token is
+// accepted by the legacy ccapi:8080 vehicle/control endpoints as the Bearer
+// access_token, unchanged from how evcc has always used it.
+func (v *Identity) exchangeCCSToken(deviceID, cciAccessToken, nonCcsToken, exchangeableToken string) (string, time.Time, error) {
+	c := v.config.CCI
+
+	uri := c.APIURL + "/domain/api/v1/auth/token-exchange?serviceType=CCS"
+	headers := v.cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, "")
+
+	req, err := request.New(http.MethodPost, uri, nil, headers)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	var res struct {
+		AccessToken    string `json:"accessToken"`
+		CcsAccessToken string `json:"ccsAccessToken"`
+		ExpiresTime    int64  `json:"expiresTime"` // epoch, unit unconfirmed - see parseCCSExpiry
+	}
+	if err := v.DoJSON(req, &res); err != nil {
+		return "", time.Time{}, fmt.Errorf("ccs token exchange failed: %w", err)
+	}
+
+	token := res.AccessToken
+	if token == "" {
+		token = res.CcsAccessToken
+	}
+	if token == "" {
+		return "", time.Time{}, errors.New("ccs token exchange returned no access token")
+	}
+
+	return token, parseCCSExpiry(res.ExpiresTime), nil
+}
+
+// ccsExpiryFallback is used whenever expiresTime is absent or doesn't parse to
+// a plausible near-future timestamp.
+const ccsExpiryFallback = time.Hour
+
+// ccsExpiryPlausibleWindow bounds what counts as a "plausible" expiry: far
+// enough in the future to not immediately trigger a refresh, but not
+// absurdly far out (which would indicate a unit/parsing error rather than a
+// genuinely long-lived token).
+const ccsExpiryPlausibleWindow = 24 * time.Hour
+
+// parseCCSExpiry interprets the token-exchange response's expiresTime field.
+// The upstream hyundai_kia_connect_api reference treats it as a millisecond
+// epoch, but a live test against the real Kia backend showed a token
+// considered immediately expired right after a fresh login - i.e. every
+// subsequent API call triggered a full refresh round-trip instead of roughly
+// one per hour. That symptom is consistent with expiresTime actually being a
+// *second* epoch (interpreting ~10-digit second values as milliseconds lands
+// in January 1970). To be robust either way - and to never again let a
+// units mismatch silently produce an always-expired token - this tries the
+// millisecond interpretation first, falls back to seconds, and if neither
+// lands in a plausible near-future window, ignores the field entirely and
+// uses a safe fixed default instead of risking a refresh storm.
+func parseCCSExpiry(expiresTime int64) time.Time {
+	if expiresTime <= 0 {
+		return time.Now().Add(ccsExpiryFallback)
+	}
+
+	now := time.Now()
+	plausible := func(t time.Time) bool {
+		return t.After(now) && t.Before(now.Add(ccsExpiryPlausibleWindow))
+	}
+
+	if ms := time.UnixMilli(expiresTime); plausible(ms) {
+		return ms
+	}
+	if sec := time.Unix(expiresTime, 0); plausible(sec) {
+		return sec
+	}
+
+	return now.Add(ccsExpiryFallback)
+}
+
+// cciHeaders builds the headers required by the CCI API
+// (cci-api-eu.{hyundai,kia}.com). cciAccessToken/nonCcsToken/exchangeableToken
+// are optional (pass "" when not yet available, e.g. for the initial code
+// exchange); contentType selects a JSON body vs. the bodyless requests that
+// carry all state via query parameters and headers.
+func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, contentType string) map[string]string {
+	c := v.config.CCI
+
+	headers := map[string]string{
+		"client-id":                         c.PackageID,
+		"client-name":                       c.ClientName,
+		"client-version":                    cciClientVersion,
+		"client-os-code":                    "ios",
+		"client-os-version":                 c.OSVersion,
+		"client-device-id":                  deviceID,
+		"client-device-model":               "iPhone",
+		"client-notification-provider-type": c.NotificationProvider,
+		"locale":                            strings.ToUpper(v.language),
+		"timezone":                          cciTimezoneOffset(),
+		"Accept":                            request.JSONContent,
+		"Accept-Language":                   v.language,
+		"User-Agent":                        cciMobileUserAgent,
+	}
+
+	if nonCcsToken != "" {
+		headers["Authentication"] = nonCcsToken
+	}
+	if cciAccessToken != "" {
+		headers["authorization"] = "Bearer " + strings.TrimPrefix(strings.TrimSpace(cciAccessToken), "Bearer ")
+	}
+	if exchangeableToken != "" {
+		headers["exchangeable-token"] = exchangeableToken
+		headers["non-ccs-token"] = nonCcsToken
+	}
+	if contentType != "" {
+		headers["Content-Type"] = contentType
+	} else {
+		headers["Content-Length"] = "0"
+	}
+
+	return headers
+}
+
+// cciTimezoneOffset returns the current UTC offset of the CCI home region
+// (Central Europe) as "+HH:MM"/"-HH:MM", falling back to the local system
+// timezone if the tzdata for Europe/Berlin is unavailable.
+func cciTimezoneOffset() string {
+	loc, err := time.LoadLocation(cciTimezoneLocation)
+	if err != nil {
+		loc = time.Local
+	}
+	return time.Now().In(loc).Format("-07:00")
+}
+
+// encryptCCIPassword RSA/PKCS1v15-encrypts password using the JWK public key
+// (base64url-encoded modulus/exponent, as returned by the CCI
+// /accounts/certs endpoint) and returns the ciphertext as a lowercase hex
+// string, as required by the signin endpoint's encryptedPassword=true mode.
+func encryptCCIPassword(nb64, eb64, password string) (string, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(nb64, "="))
+	if err != nil {
+		return "", fmt.Errorf("invalid rsa modulus: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(eb64, "="))
+	if err != nil {
+		return "", fmt.Errorf("invalid rsa exponent: %w", err)
+	}
+
+	e := 0
+	for _, b := range eBytes {
+		e = e<<8 | int(b)
+	}
+
+	pub := &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: e,
+	}
+
+	ciphertext, err := rsa.EncryptPKCS1v15(rand.Reader, pub, []byte(password))
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(ciphertext), nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/vehicle/bluelink/cci.go
+++ b/vehicle/bluelink/cci.go
@@ -94,7 +94,7 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 	c := v.config.CCI
 	deviceID := uuid.NewString()
 
-	v.log.INFO.Println("cci: logging in via OneApp/CCI password login")
+	v.log.DEBUG.Println("cci: logging in via OneApp/CCI password login")
 
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -224,7 +224,7 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 	}
 
 	v.persistBundle(bundle)
-	v.log.INFO.Println("cci: login successful")
+	v.log.DEBUG.Println("cci: login successful")
 
 	return bundle.token(), nil
 }
@@ -372,7 +372,7 @@ func parseCCSExpiry(expiresTime int64) time.Time {
 }
 
 // cciHeaders builds the headers required by the CCI API. The token parameters
-// are empty before the initial code exchange, contentType for bodyless requests.
+// are empty before the initial code exchange, contentType for bodyless requests
 func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, contentType string) map[string]string {
 	c := v.config.CCI
 
@@ -405,8 +405,6 @@ func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeabl
 
 	if contentType != "" {
 		headers["Content-Type"] = contentType
-	} else {
-		headers["Content-Length"] = "0"
 	}
 
 	return headers

--- a/vehicle/bluelink/cci.go
+++ b/vehicle/bluelink/cci.go
@@ -194,21 +194,20 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 		return nil, fmt.Errorf("signin failed: HTTP %d (%s)", signinResp.StatusCode, request.Truncate(string(signinBody)))
 	}
 
-	location := signinResp.Header.Get("Location")
-	loc, err := url.Parse(location)
+	loc, err := signinResp.Location()
 	if err != nil {
-		return nil, fmt.Errorf("signin returned unparseable redirect: %w", err)
+		return nil, fmt.Errorf("signin returned no valid redirect: %w", err)
 	}
 
 	code := loc.Query().Get("code")
 	if code == "" {
 		switch {
-		case strings.Contains(location, "/web/v1/user/authorization"):
+		case strings.Contains(loc.Path, "/web/v1/user/authorization"):
 			return nil, errors.New("account consent required: log in via the manufacturer app once to accept the terms, then retry")
 		case loc.Query().Get("error_description") != "":
 			return nil, fmt.Errorf("signin rejected: %s", loc.Query().Get("error_description"))
 		default:
-			return nil, fmt.Errorf("unexpected redirect after signin: %s", request.Truncate(location))
+			return nil, fmt.Errorf("unexpected redirect after signin: %s", request.Truncate(loc.String()))
 		}
 	}
 

--- a/vehicle/bluelink/cci.go
+++ b/vehicle/bluelink/cci.go
@@ -340,23 +340,18 @@ func (v *Identity) exchangeCCSToken(deviceID, cciAccessToken, nonCcsToken, excha
 	}
 
 	var res struct {
-		AccessToken    string `json:"accessToken"`
-		CcsAccessToken string `json:"ccsAccessToken"`
-		ExpiresTime    int64  `json:"expiresTime"` // unix seconds
+		AccessToken string `json:"accessToken"`
+		ExpiresTime int64  `json:"expiresTime"` // unix seconds
 	}
 	if err := v.DoJSON(req, &res); err != nil {
 		return "", time.Time{}, fmt.Errorf("ccs token exchange failed: %w", err)
 	}
 
-	token := res.AccessToken
-	if token == "" {
-		token = res.CcsAccessToken
-	}
-	if token == "" {
+	if res.AccessToken == "" {
 		return "", time.Time{}, errors.New("ccs token exchange returned no access token")
 	}
 
-	return token, parseCCSExpiry(res.ExpiresTime), nil
+	return res.AccessToken, parseCCSExpiry(res.ExpiresTime), nil
 }
 
 const (

--- a/vehicle/bluelink/cci.go
+++ b/vehicle/bluelink/cci.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,7 +12,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
@@ -23,12 +21,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// CCIConfig holds the OneApp/CCI login parameters for brands where the
-// legacy IDPConnect authorize endpoint is blocked by Hyundai's WAF (as of
-// 2026-08, see https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1273).
-// It is only set for EU Kia/Hyundai — Genesis EU and Hyundai AU are not
-// WAF-affected and keep using the legacy authorize/refresh flow unchanged
-// (Config.CCI == nil for those brands).
+// CCIConfig holds the OneApp/CCI login parameters. Only set for EU Kia/Hyundai,
+// where the legacy IDPConnect authorize endpoint is WAF-blocked.
 type CCIConfig struct {
 	OneAppClientID       string // OneApp OAuth2 client_id (not on the WAF block list)
 	OneAppRedirectURI    string
@@ -40,24 +34,18 @@ type CCIConfig struct {
 }
 
 const (
-	cciClientVersion    = "1.3.3"
-	cciMobileUserAgent  = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19_CCS_APP_AOS"
-	cciBundlePrefix     = "cci1:" // marks a compound CCI token bundle in the config `password` field
-	cciSettingsKeyFmt   = "bluelink-cci.%s.%s"
-	cciTimezoneLocation = "Europe/Berlin"
+	cciClientVersion   = "1.3.3"
+	cciMobileUserAgent = "Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19_CCS_APP_AOS"
+	cciSettingsKeyFmt  = "bluelink-cci.%s.%s"
 )
 
-// cciBundle is the full CCI/CCS token state needed to authenticate against the
-// legacy ccapi:8080 vehicle/control endpoints (AccessToken) and to refresh
-// without repeating the full password login (all other fields). It is used
-// both as the persistence format (server/db/settings, keyed per brand+user)
-// and as the wire format for a compound bundle string that a user can paste
-// directly into the `password` config field (see decodeCCIBundle).
+// cciBundle is the CCI/CCS token state. AccessToken is the CCS token used on
+// the legacy ccapi endpoints, the remaining fields are required to refresh it.
 type cciBundle struct {
-	AccessToken              string    `json:"access_token"`  // CCS token (no "Bearer " prefix) — used for the legacy vehicle API
+	AccessToken              string    `json:"access_token"`  // CCS token (no "Bearer " prefix)
 	RefreshToken             string    `json:"refresh_token"` // CCI refresh token
 	Expiry                   time.Time `json:"expiry"`        // CCS token expiry
-	DeviceID                 string    `json:"device_id"`     // stable client-device-id used for all CCI calls of this session
+	DeviceID                 string    `json:"device_id"`     // client-device-id used for all CCI calls
 	CCIAccessToken           string    `json:"cci_access_token"`
 	ExchangeableToken        string    `json:"exchangeable_token"`
 	ExchangeableRefreshToken string    `json:"exchangeable_refresh_token"`
@@ -66,161 +54,42 @@ type cciBundle struct {
 	IDToken                  string    `json:"id_token"`
 }
 
-// extra keys used to carry the cciBundle fields through oauth2.Token.Extra,
-// so the existing oauth.RefreshTokenSource (which only knows about
-// AccessToken/RefreshToken/Expiry) can be reused unchanged for the CCI flow.
-const (
-	extraDeviceID                 = "device_id"
-	extraCCIAccessToken           = "cci_access_token"
-	extraExchangeableToken        = "exchangeable_token"
-	extraExchangeableRefreshToken = "exchangeable_refresh_token"
-	extraNonCcsToken              = "non_ccs_token"
-	extraNonCcsRefreshToken       = "non_ccs_refresh_token"
-	extraIDToken                  = "id_token"
-)
-
-// token converts the bundle into an oauth2.Token, carrying the CCI-specific
-// fields in Extra so they survive a round-trip through oauth.RefreshTokenSource.
 func (b cciBundle) token() *oauth2.Token {
-	t := &oauth2.Token{
+	return &oauth2.Token{
 		AccessToken:  b.AccessToken,
 		RefreshToken: b.RefreshToken,
 		Expiry:       b.Expiry,
 	}
-
-	return t.WithExtra(map[string]any{
-		extraDeviceID:                 b.DeviceID,
-		extraCCIAccessToken:           b.CCIAccessToken,
-		extraExchangeableToken:        b.ExchangeableToken,
-		extraExchangeableRefreshToken: b.ExchangeableRefreshToken,
-		extraNonCcsToken:              b.NonCcsToken,
-		extraNonCcsRefreshToken:       b.NonCcsRefreshToken,
-		extraIDToken:                  b.IDToken,
-	})
 }
 
-func cciExtraString(token *oauth2.Token, key string) string {
-	s, _ := token.Extra(key).(string)
-	return s
-}
-
-// bundleFromToken is the inverse of cciBundle.token().
-func bundleFromToken(token *oauth2.Token) cciBundle {
-	return cciBundle{
-		AccessToken:              token.AccessToken,
-		RefreshToken:             token.RefreshToken,
-		Expiry:                   token.Expiry,
-		DeviceID:                 cciExtraString(token, extraDeviceID),
-		CCIAccessToken:           cciExtraString(token, extraCCIAccessToken),
-		ExchangeableToken:        cciExtraString(token, extraExchangeableToken),
-		ExchangeableRefreshToken: cciExtraString(token, extraExchangeableRefreshToken),
-		NonCcsToken:              cciExtraString(token, extraNonCcsToken),
-		NonCcsRefreshToken:       cciExtraString(token, extraNonCcsRefreshToken),
-		IDToken:                  cciExtraString(token, extraIDToken),
-	}
-}
-
-// decodeCCIBundle decodes a compound CCI token bundle from the config
-// `password` field. Wire format: "cci1:" + base64url(json(cciBundle)) with no
-// padding. This lets a user who has already obtained a CCI token set with an
-// external tool configure evcc without ever storing their live account
-// password, mirroring how the pre-existing legacy refresh_token worked.
-func decodeCCIBundle(s string) (cciBundle, bool) {
-	if !strings.HasPrefix(s, cciBundlePrefix) {
-		return cciBundle{}, false
-	}
-
-	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(s, cciBundlePrefix))
-	if err != nil {
-		return cciBundle{}, false
-	}
-
-	var b cciBundle
-	if err := json.Unmarshal(raw, &b); err != nil {
-		return cciBundle{}, false
-	}
-
-	return b, true
-}
-
-// legacyRefreshTokenPattern matches the shape evcc has always accepted here:
-// an opaque legacy IDPConnect refresh_token, historically 48 uppercase
-// letters/digits (hyundai_kia_connect_api uses the exact `^[A-Z0-9]{48}$`);
-// widened slightly to 40-60 chars to tolerate minor length variance across
-// brands/regions. Note this is a *character-class* check, not just a length
-// check: a real account password virtually always contains lowercase letters
-// and/or symbols, which this pattern rejects, so it is never misclassified
-// as a legacy token merely for being short.
-var legacyRefreshTokenPattern = regexp.MustCompile(`^[A-Z0-9]{40,60}$`)
-
-// looksLikeLegacyRefreshToken reports whether password has the shape of a
-// legacy IDPConnect refresh_token (see legacyRefreshTokenPattern). This keeps
-// the behaviour for every user who still holds a valid pre-block legacy
-// refresh_token completely unchanged, while routing anything else (a real
-// account password, or a cci1: bundle) to the CCI-capable path.
-func looksLikeLegacyRefreshToken(password string) bool {
-	return legacyRefreshTokenPattern.MatchString(password)
-}
-
-// settingsKey returns the server/db/settings key under which the CCI token
-// bundle for this identity is persisted, mirroring the pattern used by e.g.
-// vehicle/tesla and vehicle/mercedes for their OAuth2 tokens.
+// settingsKey returns the settings key the CCI token bundle is persisted under
 func (v *Identity) settingsKey() string {
 	return fmt.Sprintf(cciSettingsKeyFmt, v.config.Brand, v.user)
 }
 
-// loginCCI obtains a usable CCS access token for EU Kia/Hyundai via the
-// OneApp/CCI flow. Priority order:
-//  1. a token bundle persisted from a prior login/refresh (server/db/settings) —
-//     avoids hitting the login endpoint (and its stricter rate limiting/WAF)
-//     on every evcc restart.
-//  2. a CCI token bundle supplied directly in the password field (see
-//     decodeCCIBundle) — lets users who don't want evcc to hold their live
-//     account password generate the bundle once with an external tool.
-//  3. a full interactive username+password login.
+// loginCCI obtains a CCS access token via the OneApp/CCI flow, preferring a
+// bundle persisted from an earlier login over a fresh password login
 func (v *Identity) loginCCI(password string) (*oauth2.Token, error) {
-	var persisted cciBundle
-	if err := settings.Json(v.settingsKey(), &persisted); err == nil {
-		if token, err := v.tokenOrRefresh(persisted); err == nil {
-			v.log.DEBUG.Println("cci: using persisted token from database")
+	if err := settings.Json(v.settingsKey(), &v.bundle); err == nil {
+		if token := v.bundle.token(); token.Valid() {
+			v.log.DEBUG.Println("cci: using persisted token")
 			return token, nil
-		} else {
-			v.log.WARN.Printf("cci: persisted token invalid or refresh failed, falling back: %v", err)
 		}
-	}
 
-	if bundle, ok := decodeCCIBundle(password); ok {
-		token, err := v.tokenOrRefresh(bundle)
-		if err != nil {
-			return nil, fmt.Errorf("cci token bundle in config is invalid or expired: %w", err)
+		if v.bundle.RefreshToken != "" {
+			token, err := v.refreshCCI(nil)
+			if err == nil {
+				return token, nil
+			}
+			v.log.WARN.Printf("cci: refreshing persisted token failed: %v", err)
 		}
-		return token, nil
 	}
 
 	return v.loginCCIPassword(password)
 }
 
-// tokenOrRefresh returns the bundle's token directly if still valid, otherwise
-// refreshes it.
-func (v *Identity) tokenOrRefresh(bundle cciBundle) (*oauth2.Token, error) {
-	token := bundle.token()
-	if token.Valid() {
-		return token, nil
-	}
-	if token.RefreshToken == "" {
-		return nil, errors.New("no refresh token available")
-	}
-	return v.refreshCCI(token)
-}
-
-// loginCCIPassword performs the OneApp/CCI headless password login (EU
-// Kia/Hyundai). It bypasses the legacy IDPConnect authorize endpoint, which
-// is WAF-blocked for the legacy client_id. Steps:
-//  1. GET  {LoginFormHost}/auth/api/v2/user/oauth2/authorize (OneApp client_id — not WAF-blocked)
-//  2. GET  {LoginFormHost}/auth/api/v1/accounts/certs        (RSA public key for password encryption)
-//  3. POST {LoginFormHost}/auth/account/signin                (RSA-encrypted password, redirect not followed)
-//  4. POST {CCI.APIURL}/domain/api/v1/auth/token              (auth code -> CCI token set)
-//  5. POST {CCI.APIURL}/domain/api/v1/auth/token-exchange     (CCI token -> CCS token, usable on legacy ccapi:8080)
+// loginCCIPassword performs the headless OneApp/CCI password login: authorize,
+// fetch RSA cert, signin, exchange the auth code for CCI and then CCS tokens
 func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 	c := v.config.CCI
 	deviceID := uuid.NewString()
@@ -237,8 +106,7 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 		v.Client.CheckRedirect = nil
 	}()
 
-	// Step 1: authorize. The OneApp client_id is not on the WAF block list, so
-	// this succeeds where the legacy client_id's authorize is rejected.
+	// the OneApp client_id is not on the WAF block list
 	authURL := fmt.Sprintf(
 		"%s/auth/api/v2/user/oauth2/authorize?response_type=code&client_id=%s&redirect_uri=%s&lang=en&state=ccsp&country=de",
 		v.config.LoginFormHost, c.OneAppClientID, c.OneAppRedirectURI,
@@ -259,11 +127,14 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 
 	if strings.Contains(strings.ToLower(string(authBody)), "abusing") ||
 		strings.Contains(authResp.Request.URL.String(), "/error?status=400") {
-		return nil, errors.New("login blocked: IDPConnect authorize rejected the request ('abusing request'). " +
-			"This is a server-side WAF block, not a credentials problem")
+		return nil, errors.New("authorize rejected as 'abusing request' — server-side WAF block, not a credentials problem")
 	}
 
-	// Step 2: RSA public key used to encrypt the password for signin.
+	if authResp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("authorize failed: HTTP %d (%s)", authResp.StatusCode, request.Truncate(string(authBody)))
+	}
+
+	// rsa public key used to encrypt the password for signin
 	certReq, err := request.New(http.MethodGet, v.config.LoginFormHost+"/auth/api/v1/accounts/certs", nil, map[string]string{
 		"User-Agent": cciMobileUserAgent,
 		"Accept":     request.JSONContent,
@@ -288,8 +159,6 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 		return nil, fmt.Errorf("encrypting password failed: %w", err)
 	}
 
-	// Step 3: signin with the RSA-encrypted password. The auth code arrives in
-	// the Location header of the 302 response, so redirects must not be followed.
 	data := url.Values{
 		"client_id":             {c.OneAppClientID},
 		"encryptedPassword":     {"true"},
@@ -311,8 +180,10 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 		return nil, err
 	}
 
+	// the auth code arrives in the Location header, so redirects must not be followed
 	v.Client.CheckRedirect = request.DontFollow
 	signinResp, err := v.Client.Do(signinReq)
+	v.Client.CheckRedirect = nil
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +191,7 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 	signinResp.Body.Close()
 
 	if signinResp.StatusCode != http.StatusFound {
-		return nil, signinFailureError(signinResp.StatusCode, string(signinBody))
+		return nil, fmt.Errorf("signin failed: HTTP %d (%s)", signinResp.StatusCode, request.Truncate(string(signinBody)))
 	}
 
 	location := signinResp.Header.Get("Location")
@@ -332,59 +203,38 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 	code := loc.Query().Get("code")
 	if code == "" {
 		switch {
-		case strings.Contains(strings.ToLower(location), "error"):
-			desc := loc.Query().Get("error_description")
-			if desc == "" {
-				desc = "unknown"
-			}
-			if looksCredentialRelated(desc) {
-				return nil, fmt.Errorf("authentication rejected: %s — check username and password", desc)
-			}
-			return nil, fmt.Errorf("authentication rejected: %s — this may indicate a server-side issue rather than incorrect credentials", desc)
 		case strings.Contains(location, "/web/v1/user/authorization"):
-			return nil, errors.New("account consent required: please log in via the manufacturer app or browser once to accept the terms, then retry")
-		case strings.Contains(location, "authorize"):
-			return nil, errors.New("authentication failed — returned to login page, check username and password")
+			return nil, errors.New("account consent required: log in via the manufacturer app once to accept the terms, then retry")
+		case loc.Query().Get("error_description") != "":
+			return nil, fmt.Errorf("signin rejected: %s", loc.Query().Get("error_description"))
 		default:
-			return nil, fmt.Errorf("unexpected redirect after signin: %s", truncate(location, 250))
+			return nil, fmt.Errorf("unexpected redirect after signin: %s", request.Truncate(location))
 		}
 	}
 
-	// Step 4: exchange the authorization code for the CCI token set.
 	bundle, err := v.exchangeCCIToken(deviceID, code)
 	if err != nil {
 		return nil, err
 	}
 	bundle.DeviceID = deviceID
 
-	// Step 5: exchange the CCI access token for a CCS token, accepted by the
-	// legacy ccapi:8080 vehicle/control endpoints.
-	ccsToken, ccsValidUntil, err := v.exchangeCCSToken(deviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken)
+	bundle.AccessToken, bundle.Expiry, err = v.exchangeCCSToken(deviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken)
 	if err != nil {
 		return nil, err
 	}
-	bundle.AccessToken = ccsToken
-	bundle.Expiry = ccsValidUntil
 
-	if err := settings.SetJson(v.settingsKey(), bundle); err != nil {
-		v.log.WARN.Printf("cci: persisting token failed: %v", err)
-	}
-
+	v.persistBundle(bundle)
 	v.log.INFO.Println("cci: login successful")
 
 	return bundle.token(), nil
 }
 
-// refreshCCI refreshes the CCI token set via cci-api-eu/.../v2/auth/token-refresh
-// (the full CCI token set is required in the request body), then re-exchanges
-// the CCS token. Called automatically by oauth.RefreshTokenSource whenever the
-// current CCS token has expired.
-func (v *Identity) refreshCCI(token *oauth2.Token) (*oauth2.Token, error) {
+// refreshCCI refreshes the CCI token set and re-exchanges the CCS token. The
+// token set lives on the Identity, so the passed oauth2 token is ignored.
+func (v *Identity) refreshCCI(_ *oauth2.Token) (*oauth2.Token, error) {
 	v.log.DEBUG.Println("cci: refreshing token")
 
-	bundle := bundleFromToken(token)
-
-	c := v.config.CCI
+	bundle := v.bundle
 	headers := v.cciHeaders(bundle.DeviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken, request.JSONContent)
 
 	body := map[string]string{
@@ -397,115 +247,91 @@ func (v *Identity) refreshCCI(token *oauth2.Token) (*oauth2.Token, error) {
 		"idToken":                  bundle.IDToken,
 	}
 
-	uri := c.APIURL + "/domain/api/v2/auth/token-refresh"
+	uri := v.config.CCI.APIURL + "/domain/api/v2/auth/token-refresh"
 	req, err := request.New(http.MethodPost, uri, request.MarshalJSON(body), headers)
 	if err != nil {
 		return nil, err
 	}
 
-	var res struct {
-		AccessToken              string `json:"accessToken"`
-		RefreshToken             string `json:"refreshToken"`
-		NonCcsToken              string `json:"nonCcsToken"`
-		ExchangeableAccessToken  string `json:"exchangeableAccessToken"`
-		ExchangeableRefreshToken string `json:"exchangeableRefreshToken"`
-		NonCcsRefreshToken       string `json:"nonCcsRefreshToken"`
-		IDToken                  string `json:"idToken"`
-	}
+	var res cciTokenResponse
 	if err := v.DoJSON(req, &res); err != nil {
 		return nil, fmt.Errorf("cci token refresh failed: %w", err)
 	}
 
-	if res.AccessToken != "" {
-		bundle.CCIAccessToken = res.AccessToken
-	}
-	if res.RefreshToken != "" {
-		bundle.RefreshToken = res.RefreshToken
-	}
-	if res.NonCcsToken != "" {
-		bundle.NonCcsToken = res.NonCcsToken
-	}
-	if res.ExchangeableAccessToken != "" {
-		bundle.ExchangeableToken = res.ExchangeableAccessToken
-	}
-	if res.ExchangeableRefreshToken != "" {
-		bundle.ExchangeableRefreshToken = res.ExchangeableRefreshToken
-	}
-	if res.NonCcsRefreshToken != "" {
-		bundle.NonCcsRefreshToken = res.NonCcsRefreshToken
-	}
-	if res.IDToken != "" {
-		bundle.IDToken = res.IDToken
-	}
+	res.apply(&bundle)
 
-	// Note: the upstream reference implementation additionally inspects a
-	// Set-Cookie: t=<token> response header for an updated exchangeable
-	// token. That is a supplementary/optional signal (the JSON body above is
-	// the primary source) and is intentionally not replicated here to keep
-	// this port simple; revisit if refreshes are observed to go stale despite
-	// a 200 response.
-
-	ccsToken, ccsValidUntil, err := v.exchangeCCSToken(bundle.DeviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken)
+	bundle.AccessToken, bundle.Expiry, err = v.exchangeCCSToken(bundle.DeviceID, bundle.CCIAccessToken, bundle.NonCcsToken, bundle.ExchangeableToken)
 	if err != nil {
 		return nil, err
 	}
-	bundle.AccessToken = ccsToken
-	bundle.Expiry = ccsValidUntil
 
-	if err := settings.SetJson(v.settingsKey(), bundle); err != nil {
-		v.log.WARN.Printf("cci: persisting refreshed token failed: %v", err)
-	}
-
+	v.persistBundle(bundle)
 	v.log.DEBUG.Println("cci: refresh successful")
 
 	return bundle.token(), nil
 }
 
+func (v *Identity) persistBundle(bundle cciBundle) {
+	v.bundle = bundle
+	if err := settings.SetJson(v.settingsKey(), bundle); err != nil {
+		v.log.WARN.Printf("cci: persisting token failed: %v", err)
+	}
+}
+
+// cciTokenResponse is the response of the CCI token and token-refresh endpoints
+type cciTokenResponse struct {
+	AccessToken              string `json:"accessToken"`
+	RefreshToken             string `json:"refreshToken"`
+	NonCcsToken              string `json:"nonCcsToken"`
+	ExchangeableAccessToken  string `json:"exchangeableAccessToken"`
+	ExchangeableRefreshToken string `json:"exchangeableRefreshToken"`
+	NonCcsRefreshToken       string `json:"nonCcsRefreshToken"`
+	IDToken                  string `json:"idToken"`
+}
+
+// apply copies the non-empty response fields into bundle, keeping unchanged ones
+func (res cciTokenResponse) apply(bundle *cciBundle) {
+	for _, f := range []struct {
+		val string
+		dst *string
+	}{
+		{res.AccessToken, &bundle.CCIAccessToken},
+		{res.RefreshToken, &bundle.RefreshToken},
+		{res.NonCcsToken, &bundle.NonCcsToken},
+		{res.ExchangeableAccessToken, &bundle.ExchangeableToken},
+		{res.ExchangeableRefreshToken, &bundle.ExchangeableRefreshToken},
+		{res.NonCcsRefreshToken, &bundle.NonCcsRefreshToken},
+		{res.IDToken, &bundle.IDToken},
+	} {
+		if f.val != "" {
+			*f.dst = f.val
+		}
+	}
+}
+
 // exchangeCCIToken exchanges an authorization code for the CCI token set
-// (step 4 of the login flow).
 func (v *Identity) exchangeCCIToken(deviceID, code string) (cciBundle, error) {
-	c := v.config.CCI
-
-	uri := c.APIURL + "/domain/api/v1/auth/token?code=" + url.QueryEscape(code)
-	headers := v.cciHeaders(deviceID, "", "", "", "")
-
-	req, err := request.New(http.MethodPost, uri, nil, headers)
+	uri := v.config.CCI.APIURL + "/domain/api/v1/auth/token?code=" + url.QueryEscape(code)
+	req, err := request.New(http.MethodPost, uri, nil, v.cciHeaders(deviceID, "", "", "", ""))
 	if err != nil {
 		return cciBundle{}, err
 	}
 
-	var res struct {
-		AccessToken              string `json:"accessToken"`
-		RefreshToken             string `json:"refreshToken"`
-		NonCcsToken              string `json:"nonCcsToken"`
-		ExchangeableAccessToken  string `json:"exchangeableAccessToken"`
-		ExchangeableRefreshToken string `json:"exchangeableRefreshToken"`
-		NonCcsRefreshToken       string `json:"nonCcsRefreshToken"`
-		IDToken                  string `json:"idToken"`
-	}
+	var res cciTokenResponse
 	if err := v.DoJSON(req, &res); err != nil {
 		return cciBundle{}, fmt.Errorf("cci token exchange failed: %w", err)
 	}
 
-	return cciBundle{
-		RefreshToken:             res.RefreshToken,
-		CCIAccessToken:           res.AccessToken,
-		ExchangeableToken:        res.ExchangeableAccessToken,
-		ExchangeableRefreshToken: res.ExchangeableRefreshToken,
-		NonCcsToken:              res.NonCcsToken,
-		NonCcsRefreshToken:       res.NonCcsRefreshToken,
-		IDToken:                  res.IDToken,
-	}, nil
+	var bundle cciBundle
+	res.apply(&bundle)
+
+	return bundle, nil
 }
 
-// exchangeCCSToken exchanges a CCI access token for a CCS token (step 5 of
-// the login flow, and the final step of every refresh). The CCS token is
-// accepted by the legacy ccapi:8080 vehicle/control endpoints as the Bearer
-// access_token, unchanged from how evcc has always used it.
+// exchangeCCSToken exchanges a CCI access token for a CCS token, which the
+// legacy ccapi vehicle/control endpoints accept as Bearer access_token
 func (v *Identity) exchangeCCSToken(deviceID, cciAccessToken, nonCcsToken, exchangeableToken string) (string, time.Time, error) {
-	c := v.config.CCI
-
-	uri := c.APIURL + "/domain/api/v1/auth/token-exchange?serviceType=CCS"
+	uri := v.config.CCI.APIURL + "/domain/api/v1/auth/token-exchange?serviceType=CCS"
 	headers := v.cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, "")
 
 	req, err := request.New(http.MethodPost, uri, nil, headers)
@@ -516,7 +342,7 @@ func (v *Identity) exchangeCCSToken(deviceID, cciAccessToken, nonCcsToken, excha
 	var res struct {
 		AccessToken    string `json:"accessToken"`
 		CcsAccessToken string `json:"ccsAccessToken"`
-		ExpiresTime    int64  `json:"expiresTime"` // epoch, unit unconfirmed - see parseCCSExpiry
+		ExpiresTime    int64  `json:"expiresTime"` // unix seconds
 	}
 	if err := v.DoJSON(req, &res); err != nil {
 		return "", time.Time{}, fmt.Errorf("ccs token exchange failed: %w", err)
@@ -533,61 +359,29 @@ func (v *Identity) exchangeCCSToken(deviceID, cciAccessToken, nonCcsToken, excha
 	return token, parseCCSExpiry(res.ExpiresTime), nil
 }
 
-// ccsExpiryFallback is used whenever expiresTime is absent or doesn't parse to
-// a plausible near-future timestamp.
-const ccsExpiryFallback = time.Hour
+const (
+	ccsExpiryFallback    = time.Hour      // used when expiresTime is missing or implausible
+	ccsExpiryMaxValidity = 24 * time.Hour // upper bound of a plausible expiry
+)
 
-// ccsExpiryPlausibleWindow bounds what counts as a "plausible" expiry: far
-// enough in the future to not immediately trigger a refresh, but not
-// absurdly far out (which would indicate a unit/parsing error rather than a
-// genuinely long-lived token).
-const ccsExpiryPlausibleWindow = 24 * time.Hour
-
-// isPlausibleCCSExpiry reports whether t is far enough in the future to not
-// immediately trigger a refresh, but not absurdly far out (which would
-// indicate a unit/parsing error rather than a genuinely long-lived token).
-// Kept separate from parseCCSExpiry so "is this plausible" (policy) stays
-// decoupled from "which unit is this" (unit detection).
-func isPlausibleCCSExpiry(now, t time.Time) bool {
-	return t.After(now) && t.Before(now.Add(ccsExpiryPlausibleWindow))
-}
-
-// parseCCSExpiry interprets the token-exchange response's expiresTime field.
-// The upstream hyundai_kia_connect_api reference treats it as a millisecond
-// epoch, but a live test against the real Kia backend showed a token
-// considered immediately expired right after a fresh login - i.e. every
-// subsequent API call triggered a full refresh round-trip instead of roughly
-// one per hour. That symptom is consistent with expiresTime actually being a
-// *second* epoch (interpreting ~10-digit second values as milliseconds lands
-// in January 1970). To be robust either way - and to never again let a
-// units mismatch silently produce an always-expired token - this tries the
-// millisecond interpretation first, falls back to seconds, and if neither
-// lands in a plausible near-future window, ignores the field entirely and
-// uses a safe fixed default instead of risking a refresh storm.
+// parseCCSExpiry interprets the token-exchange expiresTime, falling back to a
+// fixed lifetime rather than risking an always-expired token
 func parseCCSExpiry(expiresTime int64) time.Time {
-	if expiresTime <= 0 {
-		return time.Now().Add(ccsExpiryFallback)
-	}
-
 	now := time.Now()
 
-	if ms := time.UnixMilli(expiresTime); isPlausibleCCSExpiry(now, ms) {
-		return ms
-	}
-	if sec := time.Unix(expiresTime, 0); isPlausibleCCSExpiry(now, sec) {
-		return sec
+	if t := time.Unix(expiresTime, 0); t.After(now) && t.Before(now.Add(ccsExpiryMaxValidity)) {
+		return t
 	}
 
 	return now.Add(ccsExpiryFallback)
 }
 
-// cciBaseHeaders builds the static per-device/per-client headers required by
-// the CCI API (cci-api-eu.{hyundai,kia}.com) - everything that doesn't depend
-// on the current auth/exchange state.
-func (v *Identity) cciBaseHeaders(deviceID string) map[string]string {
+// cciHeaders builds the headers required by the CCI API. The token parameters
+// are empty before the initial code exchange, contentType for bodyless requests.
+func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, contentType string) map[string]string {
 	c := v.config.CCI
 
-	return map[string]string{
+	headers := map[string]string{
 		"client-id":                         c.PackageID,
 		"client-name":                       c.ClientName,
 		"client-version":                    cciClientVersion,
@@ -597,66 +391,34 @@ func (v *Identity) cciBaseHeaders(deviceID string) map[string]string {
 		"client-device-model":               "iPhone",
 		"client-notification-provider-type": c.NotificationProvider,
 		"locale":                            strings.ToUpper(v.language),
-		"timezone":                          cciTimezoneOffset(),
+		"timezone":                          time.Now().Format("-07:00"),
 		"Accept":                            request.JSONContent,
 		"Accept-Language":                   v.language,
 		"User-Agent":                        cciMobileUserAgent,
 	}
-}
 
-// cciAuthHeaders adds the auth-token headers to h, when available.
-// cciAccessToken/nonCcsToken/exchangeableToken are optional (pass "" when not
-// yet available, e.g. for the initial code exchange).
-func cciAuthHeaders(h map[string]string, cciAccessToken, nonCcsToken, exchangeableToken string) {
 	if nonCcsToken != "" {
-		h["Authentication"] = nonCcsToken
+		headers["Authentication"] = nonCcsToken
 	}
 	if cciAccessToken != "" {
-		h["authorization"] = "Bearer " + strings.TrimPrefix(strings.TrimSpace(cciAccessToken), "Bearer ")
+		headers["authorization"] = "Bearer " + strings.TrimPrefix(strings.TrimSpace(cciAccessToken), "Bearer ")
 	}
 	if exchangeableToken != "" {
-		h["exchangeable-token"] = exchangeableToken
-		h["non-ccs-token"] = nonCcsToken
+		headers["exchangeable-token"] = exchangeableToken
+		headers["non-ccs-token"] = nonCcsToken
 	}
-}
 
-// cciBodyHeaders adds the content-type/content-length header to h: a JSON
-// body when contentType is given, or the bodyless requests that carry all
-// state via query parameters and headers otherwise.
-func cciBodyHeaders(h map[string]string, contentType string) {
 	if contentType != "" {
-		h["Content-Type"] = contentType
+		headers["Content-Type"] = contentType
 	} else {
-		h["Content-Length"] = "0"
+		headers["Content-Length"] = "0"
 	}
-}
-
-// cciHeaders builds the full set of headers required by the CCI API,
-// combining the static client headers with the auth and body headers for the
-// current request.
-func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, contentType string) map[string]string {
-	headers := v.cciBaseHeaders(deviceID)
-	cciAuthHeaders(headers, cciAccessToken, nonCcsToken, exchangeableToken)
-	cciBodyHeaders(headers, contentType)
 
 	return headers
 }
 
-// cciTimezoneOffset returns the current UTC offset of the CCI home region
-// (Central Europe) as "+HH:MM"/"-HH:MM", falling back to the local system
-// timezone if the tzdata for Europe/Berlin is unavailable.
-func cciTimezoneOffset() string {
-	loc, err := time.LoadLocation(cciTimezoneLocation)
-	if err != nil {
-		loc = time.Local
-	}
-	return time.Now().In(loc).Format("-07:00")
-}
-
 // encryptCCIPassword RSA/PKCS1v15-encrypts password using the JWK public key
-// (base64url-encoded modulus/exponent, as returned by the CCI
-// /accounts/certs endpoint) and returns the ciphertext as a lowercase hex
-// string, as required by the signin endpoint's encryptedPassword=true mode.
+// returned by the /accounts/certs endpoint and hex-encodes the ciphertext
 func encryptCCIPassword(nb64, eb64, password string) (string, error) {
 	nBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(nb64, "="))
 	if err != nil {
@@ -683,41 +445,4 @@ func encryptCCIPassword(nb64, eb64, password string) (string, error) {
 	}
 
 	return hex.EncodeToString(ciphertext), nil
-}
-
-func truncate(s string, n int) string {
-	if len(s) > n {
-		return s[:n]
-	}
-	return s
-}
-
-// looksCredentialRelated reports whether a signin error message actually
-// talks about credentials, as opposed to some other kind of failure.
-func looksCredentialRelated(s string) bool {
-	s = strings.ToLower(s)
-	for _, kw := range []string{"password", "credential", "invalid_grant", "invalid_user", "username", "login"} {
-		if strings.Contains(s, kw) {
-			return true
-		}
-	}
-	return false
-}
-
-// signinFailureError phrases a non-302 signin response. Unlike the "302 to
-// an error location" case handled by the caller (which is how a real Kia/
-// Hyundai wrong-password rejection is normally surfaced), a raw non-302
-// status at this stage is structurally different and more often indicates a
-// transport/server-side problem - rate limiting, a WAF layer other than the
-// one checked in step 1, or an API change - than incorrect credentials. Only
-// blame credentials when the response actually looks like an auth rejection
-// (HTTP 401, or a body that explicitly talks about credentials); otherwise
-// phrase it as an unexpected response so users/operators don't waste time
-// re-checking a password that was never the problem.
-func signinFailureError(statusCode int, body string) error {
-	body = truncate(body, 200)
-	if statusCode == http.StatusUnauthorized || looksCredentialRelated(body) {
-		return fmt.Errorf("signin failed: HTTP %d — check username and password (%s)", statusCode, body)
-	}
-	return fmt.Errorf("signin failed: unexpected HTTP %d response (%s) — this may indicate a server-side issue or API change rather than incorrect credentials", statusCode, body)
 }

--- a/vehicle/bluelink/cci.go
+++ b/vehicle/bluelink/cci.go
@@ -320,8 +320,7 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 	signinResp.Body.Close()
 
 	if signinResp.StatusCode != http.StatusFound {
-		return nil, fmt.Errorf("signin failed: HTTP %d — check username and password (%s)",
-			signinResp.StatusCode, truncate(string(signinBody), 200))
+		return nil, signinFailureError(signinResp.StatusCode, string(signinBody))
 	}
 
 	location := signinResp.Header.Get("Location")
@@ -338,7 +337,10 @@ func (v *Identity) loginCCIPassword(password string) (*oauth2.Token, error) {
 			if desc == "" {
 				desc = "unknown"
 			}
-			return nil, fmt.Errorf("authentication rejected: %s — check username and password", desc)
+			if looksCredentialRelated(desc) {
+				return nil, fmt.Errorf("authentication rejected: %s — check username and password", desc)
+			}
+			return nil, fmt.Errorf("authentication rejected: %s — this may indicate a server-side issue rather than incorrect credentials", desc)
 		case strings.Contains(location, "/web/v1/user/authorization"):
 			return nil, errors.New("account consent required: please log in via the manufacturer app or browser once to accept the terms, then retry")
 		case strings.Contains(location, "authorize"):
@@ -541,6 +543,15 @@ const ccsExpiryFallback = time.Hour
 // genuinely long-lived token).
 const ccsExpiryPlausibleWindow = 24 * time.Hour
 
+// isPlausibleCCSExpiry reports whether t is far enough in the future to not
+// immediately trigger a refresh, but not absurdly far out (which would
+// indicate a unit/parsing error rather than a genuinely long-lived token).
+// Kept separate from parseCCSExpiry so "is this plausible" (policy) stays
+// decoupled from "which unit is this" (unit detection).
+func isPlausibleCCSExpiry(now, t time.Time) bool {
+	return t.After(now) && t.Before(now.Add(ccsExpiryPlausibleWindow))
+}
+
 // parseCCSExpiry interprets the token-exchange response's expiresTime field.
 // The upstream hyundai_kia_connect_api reference treats it as a millisecond
 // epoch, but a live test against the real Kia backend showed a token
@@ -559,29 +570,24 @@ func parseCCSExpiry(expiresTime int64) time.Time {
 	}
 
 	now := time.Now()
-	plausible := func(t time.Time) bool {
-		return t.After(now) && t.Before(now.Add(ccsExpiryPlausibleWindow))
-	}
 
-	if ms := time.UnixMilli(expiresTime); plausible(ms) {
+	if ms := time.UnixMilli(expiresTime); isPlausibleCCSExpiry(now, ms) {
 		return ms
 	}
-	if sec := time.Unix(expiresTime, 0); plausible(sec) {
+	if sec := time.Unix(expiresTime, 0); isPlausibleCCSExpiry(now, sec) {
 		return sec
 	}
 
 	return now.Add(ccsExpiryFallback)
 }
 
-// cciHeaders builds the headers required by the CCI API
-// (cci-api-eu.{hyundai,kia}.com). cciAccessToken/nonCcsToken/exchangeableToken
-// are optional (pass "" when not yet available, e.g. for the initial code
-// exchange); contentType selects a JSON body vs. the bodyless requests that
-// carry all state via query parameters and headers.
-func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, contentType string) map[string]string {
+// cciBaseHeaders builds the static per-device/per-client headers required by
+// the CCI API (cci-api-eu.{hyundai,kia}.com) - everything that doesn't depend
+// on the current auth/exchange state.
+func (v *Identity) cciBaseHeaders(deviceID string) map[string]string {
 	c := v.config.CCI
 
-	headers := map[string]string{
+	return map[string]string{
 		"client-id":                         c.PackageID,
 		"client-name":                       c.ClientName,
 		"client-version":                    cciClientVersion,
@@ -596,22 +602,42 @@ func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeabl
 		"Accept-Language":                   v.language,
 		"User-Agent":                        cciMobileUserAgent,
 	}
+}
 
+// cciAuthHeaders adds the auth-token headers to h, when available.
+// cciAccessToken/nonCcsToken/exchangeableToken are optional (pass "" when not
+// yet available, e.g. for the initial code exchange).
+func cciAuthHeaders(h map[string]string, cciAccessToken, nonCcsToken, exchangeableToken string) {
 	if nonCcsToken != "" {
-		headers["Authentication"] = nonCcsToken
+		h["Authentication"] = nonCcsToken
 	}
 	if cciAccessToken != "" {
-		headers["authorization"] = "Bearer " + strings.TrimPrefix(strings.TrimSpace(cciAccessToken), "Bearer ")
+		h["authorization"] = "Bearer " + strings.TrimPrefix(strings.TrimSpace(cciAccessToken), "Bearer ")
 	}
 	if exchangeableToken != "" {
-		headers["exchangeable-token"] = exchangeableToken
-		headers["non-ccs-token"] = nonCcsToken
+		h["exchangeable-token"] = exchangeableToken
+		h["non-ccs-token"] = nonCcsToken
 	}
+}
+
+// cciBodyHeaders adds the content-type/content-length header to h: a JSON
+// body when contentType is given, or the bodyless requests that carry all
+// state via query parameters and headers otherwise.
+func cciBodyHeaders(h map[string]string, contentType string) {
 	if contentType != "" {
-		headers["Content-Type"] = contentType
+		h["Content-Type"] = contentType
 	} else {
-		headers["Content-Length"] = "0"
+		h["Content-Length"] = "0"
 	}
+}
+
+// cciHeaders builds the full set of headers required by the CCI API,
+// combining the static client headers with the auth and body headers for the
+// current request.
+func (v *Identity) cciHeaders(deviceID, cciAccessToken, nonCcsToken, exchangeableToken, contentType string) map[string]string {
+	headers := v.cciBaseHeaders(deviceID)
+	cciAuthHeaders(headers, cciAccessToken, nonCcsToken, exchangeableToken)
+	cciBodyHeaders(headers, contentType)
 
 	return headers
 }
@@ -664,4 +690,34 @@ func truncate(s string, n int) string {
 		return s[:n]
 	}
 	return s
+}
+
+// looksCredentialRelated reports whether a signin error message actually
+// talks about credentials, as opposed to some other kind of failure.
+func looksCredentialRelated(s string) bool {
+	s = strings.ToLower(s)
+	for _, kw := range []string{"password", "credential", "invalid_grant", "invalid_user", "username", "login"} {
+		if strings.Contains(s, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// signinFailureError phrases a non-302 signin response. Unlike the "302 to
+// an error location" case handled by the caller (which is how a real Kia/
+// Hyundai wrong-password rejection is normally surfaced), a raw non-302
+// status at this stage is structurally different and more often indicates a
+// transport/server-side problem - rate limiting, a WAF layer other than the
+// one checked in step 1, or an API change - than incorrect credentials. Only
+// blame credentials when the response actually looks like an auth rejection
+// (HTTP 401, or a body that explicitly talks about credentials); otherwise
+// phrase it as an unexpected response so users/operators don't waste time
+// re-checking a password that was never the problem.
+func signinFailureError(statusCode int, body string) error {
+	body = truncate(body, 200)
+	if statusCode == http.StatusUnauthorized || looksCredentialRelated(body) {
+		return fmt.Errorf("signin failed: HTTP %d — check username and password (%s)", statusCode, body)
+	}
+	return fmt.Errorf("signin failed: unexpected HTTP %d response (%s) — this may indicate a server-side issue or API change rather than incorrect credentials", statusCode, body)
 }

--- a/vehicle/bluelink/cci_test.go
+++ b/vehicle/bluelink/cci_test.go
@@ -397,3 +397,74 @@ func TestLoginCCIUsesBundleFromConfigPassword(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "config-bundle-ccs", token.AccessToken)
 }
+
+// TestLoginCCIFallsBackToPasswordLoginWhenPersistedBundleUnusable covers a
+// persisted bundle that is both expired and has no refresh token (so
+// tokenOrRefresh cannot recover it): loginCCI must not get stuck on that
+// stale settings-DB state, but fall back to the full password login instead.
+// Note this is a genuinely fresh login, not a refresh - so, unlike
+// TestRefreshCCI, the device id is NOT carried over from the stale bundle;
+// loginCCIPassword always generates a new one for a fresh interactive login.
+func TestLoginCCIFallsBackToPasswordLoginWhenPersistedBundleUnusable(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	const password = "s3cret-Passw0rd!"
+
+	loginMux := http.NewServeMux()
+	loginMux.HandleFunc("/auth/api/v2/user/oauth2/authorize", okHandler)
+	loginMux.HandleFunc("/auth/api/v1/accounts/certs", certsHandler(priv))
+	loginMux.HandleFunc("/auth/account/signin", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		ciphertext, err := hex.DecodeString(r.FormValue("password"))
+		require.NoError(t, err)
+		plain, err := rsa.DecryptPKCS1v15(rand.Reader, priv, ciphertext)
+		require.NoError(t, err)
+		assert.Equal(t, password, string(plain))
+
+		w.Header().Set("Location", "https://oneapp.kia.com/redirect?code=testcode&state=ccsp")
+		w.WriteHeader(http.StatusFound)
+	})
+	loginSrv := httptest.NewServer(loginMux)
+	defer loginSrv.Close()
+
+	cciMux := http.NewServeMux()
+	cciMux.HandleFunc("/domain/api/v1/auth/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "fresh-cci-access", "refreshToken": "fresh-cci-refresh",
+			"nonCcsToken": "fresh-non-ccs", "exchangeableAccessToken": "fresh-exch-access",
+			"exchangeableRefreshToken": "fresh-exch-refresh", "nonCcsRefreshToken": "fresh-non-ccs-refresh",
+			"idToken": "fresh-id", "expiresIn": 3599,
+		})
+	})
+	cciMux.HandleFunc("/domain/api/v1/auth/token-exchange", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "fresh-ccs-token",
+			"expiresTime": time.Now().Add(time.Hour).UnixMilli(),
+		})
+	})
+	cciSrv := httptest.NewServer(cciMux)
+	defer cciSrv.Close()
+
+	identity := newTestIdentity(t, loginSrv.URL, cciSrv.URL)
+
+	// Persist a bundle that is both expired and unrefreshable (no
+	// RefreshToken), simulating stale/corrupted settings-DB state.
+	stale := cciBundle{
+		AccessToken:  "stale-ccs-token",
+		RefreshToken: "", // tokenOrRefresh must fail here rather than attempt a refresh
+		Expiry:       time.Now().Add(-time.Hour),
+		DeviceID:     "stale-device-id",
+	}
+	require.NoError(t, settings.SetJson(identity.settingsKey(), stale))
+
+	token, err := identity.loginCCI(password)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-ccs-token", token.AccessToken)
+	assert.NotEqual(t, "stale-ccs-token", token.AccessToken)
+
+	var persisted cciBundle
+	require.NoError(t, settings.Json(identity.settingsKey(), &persisted))
+	assert.Equal(t, "fresh-ccs-token", persisted.AccessToken)
+	assert.NotEqual(t, "stale-device-id", persisted.DeviceID, "a fresh login must not carry over the stale bundle's device id")
+}

--- a/vehicle/bluelink/cci_test.go
+++ b/vehicle/bluelink/cci_test.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -60,13 +59,6 @@ func newTestIdentity(t *testing.T, loginURL, cciURL string) *Identity {
 	return identity
 }
 
-func encodeCCIBundleForTest(t *testing.T, b cciBundle) string {
-	t.Helper()
-	raw, err := json.Marshal(b)
-	require.NoError(t, err)
-	return cciBundlePrefix + base64.RawURLEncoding.EncodeToString(raw)
-}
-
 func jwkParam(b []byte) string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
@@ -85,35 +77,8 @@ func certsHandler(priv *rsa.PrivateKey) http.HandlerFunc {
 	}
 }
 
-func TestLooksLikeLegacyRefreshToken(t *testing.T) {
-	tests := []struct {
-		name     string
-		password string
-		want     bool
-	}{
-		{"legacy 48-char token", strings.Repeat("A", 48), true},
-		{"empty", "", false},
-		{"cci bundle prefix", cciBundlePrefix + "abc", false},
-		{"cci-style 87-char refresh token", strings.Repeat("a", 87), false},
-		// Regression: a real account password is often short too (legacy
-		// tokens are ~48 chars), so length alone is not a safe discriminator
-		// - it must also fail on character class (lowercase/symbols).
-		{"short real-world password", "s3cret-Passw0rd!", false},
-		{"short real-world password 2", "MyKiaPassword123", false},
-		{"lowercase-only short string", strings.Repeat("a", 48), false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, looksLikeLegacyRefreshToken(tt.password))
-		})
-	}
-}
-
-// TestParseCCSExpiry is a regression test for a bug found in a live test
-// against the real Kia backend: a fresh CCS token was treated as already
-// expired immediately after login, causing a refresh round-trip on every
-// single API call instead of roughly once an hour. Root cause was
-// interpreting expiresTime as milliseconds when it may actually be seconds.
+// TestParseCCSExpiry is a regression test for a bug found against the real Kia
+// backend: an expiresTime read in the wrong unit makes every token look expired
 func TestParseCCSExpiry(t *testing.T) {
 	now := time.Now()
 
@@ -124,8 +89,8 @@ func TestParseCCSExpiry(t *testing.T) {
 	}{
 		{"zero falls back to default", 0, ccsExpiryFallback + time.Minute},
 		{"negative falls back to default", -1, ccsExpiryFallback + time.Minute},
-		{"plausible millisecond epoch", now.Add(time.Hour).UnixMilli(), 2 * time.Hour},
-		{"plausible second epoch (the bug)", now.Add(time.Hour).Unix(), 2 * time.Hour},
+		{"second epoch", now.Add(time.Hour).Unix(), 2 * time.Hour},
+		{"millisecond epoch falls back to default", now.Add(time.Hour).UnixMilli(), ccsExpiryFallback + time.Minute},
 		{"implausible value falls back to default", 123, ccsExpiryFallback + time.Minute},
 	}
 	for _, tt := range tests {
@@ -135,44 +100,6 @@ func TestParseCCSExpiry(t *testing.T) {
 			assert.True(t, got.Before(now.Add(tt.wantWithin)), "expiry too far out, got %v", got)
 		})
 	}
-}
-
-func TestCCIBundleTokenRoundTrip(t *testing.T) {
-	b := cciBundle{
-		AccessToken:              "ccs-access",
-		RefreshToken:             "cci-refresh",
-		Expiry:                   time.Now().Add(time.Hour).Truncate(time.Second),
-		DeviceID:                 "device-123",
-		CCIAccessToken:           "cci-access",
-		ExchangeableToken:        "exch-token",
-		ExchangeableRefreshToken: "exch-refresh",
-		NonCcsToken:              "non-ccs",
-		NonCcsRefreshToken:       "non-ccs-refresh",
-		IDToken:                  "id-token",
-	}
-
-	token := b.token()
-	assert.Equal(t, b.AccessToken, token.AccessToken)
-	assert.Equal(t, b.RefreshToken, token.RefreshToken)
-	assert.True(t, b.Expiry.Equal(token.Expiry))
-
-	got := bundleFromToken(token)
-	assert.Equal(t, b, got)
-}
-
-func TestDecodeCCIBundle(t *testing.T) {
-	b := cciBundle{AccessToken: "a", RefreshToken: "r", DeviceID: "d"}
-	s := encodeCCIBundleForTest(t, b)
-
-	got, ok := decodeCCIBundle(s)
-	require.True(t, ok)
-	assert.Equal(t, b, got)
-
-	_, ok = decodeCCIBundle("not-a-bundle")
-	assert.False(t, ok)
-
-	_, ok = decodeCCIBundle(cciBundlePrefix + "!!!not-base64!!!")
-	assert.False(t, ok)
 }
 
 func TestLoginCCIPasswordSuccess(t *testing.T) {
@@ -226,7 +153,7 @@ func TestLoginCCIPasswordSuccess(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"accessToken": "ccs-token-1",
-			"expiresTime": time.Now().Add(time.Hour).UnixMilli(),
+			"expiresTime": time.Now().Add(time.Hour).Unix(),
 		})
 	})
 	cciSrv := httptest.NewServer(cciMux)
@@ -240,10 +167,10 @@ func TestLoginCCIPasswordSuccess(t *testing.T) {
 	assert.Equal(t, "ccs-token-1", token.AccessToken)
 	assert.Equal(t, "cci-refresh-1", token.RefreshToken)
 	assert.True(t, token.Valid())
-	assert.Equal(t, "cci-access-1", cciExtraString(token, extraCCIAccessToken))
-	assert.Equal(t, "exch-access-1", cciExtraString(token, extraExchangeableToken))
-	assert.Equal(t, "non-ccs-1", cciExtraString(token, extraNonCcsToken))
-	assert.NotEmpty(t, cciExtraString(token, extraDeviceID))
+	assert.Equal(t, "cci-access-1", identity.bundle.CCIAccessToken)
+	assert.Equal(t, "exch-access-1", identity.bundle.ExchangeableToken)
+	assert.Equal(t, "non-ccs-1", identity.bundle.NonCcsToken)
+	assert.NotEmpty(t, identity.bundle.DeviceID)
 
 	// persisted so a restart can reuse/refresh it instead of logging in again
 	var persisted cciBundle
@@ -333,7 +260,7 @@ func TestRefreshCCI(t *testing.T) {
 		assert.Equal(t, "Bearer cci-access-2", r.Header.Get("authorization"))
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"accessToken": "ccs-token-2",
-			"expiresTime": time.Now().Add(time.Hour).UnixMilli(),
+			"expiresTime": time.Now().Add(time.Hour).Unix(),
 		})
 	})
 	cciSrv := httptest.NewServer(cciMux)
@@ -354,7 +281,9 @@ func TestRefreshCCI(t *testing.T) {
 		IDToken:                  "old-id",
 	}
 
-	newToken, err := identity.refreshCCI(old.token())
+	identity.bundle = old
+
+	newToken, err := identity.refreshCCI(nil)
 	require.NoError(t, err)
 	assert.Equal(t, "ccs-token-2", newToken.AccessToken)
 	assert.Equal(t, "cci-refresh-2", newToken.RefreshToken)
@@ -382,29 +311,9 @@ func TestLoginCCIUsesPersistedBundleWithoutContactingServer(t *testing.T) {
 	assert.Equal(t, "still-valid-ccs", token.AccessToken)
 }
 
-func TestLoginCCIUsesBundleFromConfigPassword(t *testing.T) {
-	identity := newTestIdentity(t, unreachable, unreachable)
-
-	valid := cciBundle{
-		AccessToken:  "config-bundle-ccs",
-		RefreshToken: "config-bundle-refresh",
-		Expiry:       time.Now().Add(time.Hour),
-		DeviceID:     "device-config",
-	}
-	password := encodeCCIBundleForTest(t, valid)
-
-	token, err := identity.loginCCI(password)
-	require.NoError(t, err)
-	assert.Equal(t, "config-bundle-ccs", token.AccessToken)
-}
-
 // TestLoginCCIFallsBackToPasswordLoginWhenPersistedBundleUnusable covers a
-// persisted bundle that is both expired and has no refresh token (so
-// tokenOrRefresh cannot recover it): loginCCI must not get stuck on that
-// stale settings-DB state, but fall back to the full password login instead.
-// Note this is a genuinely fresh login, not a refresh - so, unlike
-// TestRefreshCCI, the device id is NOT carried over from the stale bundle;
-// loginCCIPassword always generates a new one for a fresh interactive login.
+// persisted bundle that is expired and unrefreshable: loginCCI must not get
+// stuck on that stale state but fall back to the full password login
 func TestLoginCCIFallsBackToPasswordLoginWhenPersistedBundleUnusable(t *testing.T) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
@@ -440,7 +349,7 @@ func TestLoginCCIFallsBackToPasswordLoginWhenPersistedBundleUnusable(t *testing.
 	cciMux.HandleFunc("/domain/api/v1/auth/token-exchange", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"accessToken": "fresh-ccs-token",
-			"expiresTime": time.Now().Add(time.Hour).UnixMilli(),
+			"expiresTime": time.Now().Add(time.Hour).Unix(),
 		})
 	})
 	cciSrv := httptest.NewServer(cciMux)
@@ -448,13 +357,11 @@ func TestLoginCCIFallsBackToPasswordLoginWhenPersistedBundleUnusable(t *testing.
 
 	identity := newTestIdentity(t, loginSrv.URL, cciSrv.URL)
 
-	// Persist a bundle that is both expired and unrefreshable (no
-	// RefreshToken), simulating stale/corrupted settings-DB state.
+	// stale/corrupted settings state: expired and no refresh token
 	stale := cciBundle{
-		AccessToken:  "stale-ccs-token",
-		RefreshToken: "", // tokenOrRefresh must fail here rather than attempt a refresh
-		Expiry:       time.Now().Add(-time.Hour),
-		DeviceID:     "stale-device-id",
+		AccessToken: "stale-ccs-token",
+		Expiry:      time.Now().Add(-time.Hour),
+		DeviceID:    "stale-device-id",
 	}
 	require.NoError(t, settings.SetJson(identity.settingsKey(), stale))
 

--- a/vehicle/bluelink/cci_test.go
+++ b/vehicle/bluelink/cci_test.go
@@ -1,0 +1,399 @@
+package bluelink
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unreachable is a host nobody listens on, used to prove that a code path
+// does not perform any HTTP call (fast-failing rather than a slow DNS lookup).
+const unreachable = "http://127.0.0.1:1"
+
+// newTestIdentity creates an Identity for the given test, using the test name
+// as the settings key discriminator (identity.user) so that parallel/repeated
+// test runs never share a server/db/settings entry with one another.
+func newTestIdentity(t *testing.T, loginURL, cciURL string) *Identity {
+	t.Helper()
+
+	config := Config{
+		// Brand carries the test name so each (sub)test gets its own
+		// server/db/settings key (see settingsKey), without changing the
+		// username actually sent in login requests.
+		Brand:         "kia-test:" + t.Name(),
+		LoginFormHost: loginURL,
+		CCI: &CCIConfig{
+			OneAppClientID:       "test-client-id",
+			OneAppRedirectURI:    "https://oneapp.kia.com/redirect",
+			APIURL:               cciURL,
+			PackageID:            "com.kia.oneapp.eu",
+			ClientName:           "kia",
+			OSVersion:            "27",
+			NotificationProvider: "IOS_APPSTORE",
+		},
+	}
+
+	identity := NewIdentity(util.NewLogger("test"), config)
+	identity.user = "test@example.com"
+	identity.language = "en"
+
+	// server/db/settings.Delete requires an initialised gorm DB, which these
+	// unit tests don't set up. SetString only ever touches the in-memory
+	// cache (see server/db/settings/setting.go), so blanking the key this way
+	// is enough to keep tests isolated without needing a real database.
+	t.Cleanup(func() { settings.SetString(identity.settingsKey(), "") })
+
+	return identity
+}
+
+func encodeCCIBundleForTest(t *testing.T, b cciBundle) string {
+	t.Helper()
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+	return cciBundlePrefix + base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func jwkParam(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func okHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("<html>login</html>"))
+}
+
+func certsHandler(priv *rsa.PrivateKey) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		n := jwkParam(priv.PublicKey.N.Bytes())
+		e := jwkParam(big.NewInt(int64(priv.PublicKey.E)).Bytes())
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"retValue":{"kid":"test-kid","n":%q,"e":%q}}`, n, e)
+	}
+}
+
+func TestLooksLikeLegacyRefreshToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		want     bool
+	}{
+		{"legacy 48-char token", strings.Repeat("A", 48), true},
+		{"empty", "", false},
+		{"cci bundle prefix", cciBundlePrefix + "abc", false},
+		{"cci-style 87-char refresh token", strings.Repeat("a", 87), false},
+		// Regression: a real account password is often short too (legacy
+		// tokens are ~48 chars), so length alone is not a safe discriminator
+		// - it must also fail on character class (lowercase/symbols).
+		{"short real-world password", "s3cret-Passw0rd!", false},
+		{"short real-world password 2", "MyKiaPassword123", false},
+		{"lowercase-only short string", strings.Repeat("a", 48), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeLegacyRefreshToken(tt.password))
+		})
+	}
+}
+
+// TestParseCCSExpiry is a regression test for a bug found in a live test
+// against the real Kia backend: a fresh CCS token was treated as already
+// expired immediately after login, causing a refresh round-trip on every
+// single API call instead of roughly once an hour. Root cause was
+// interpreting expiresTime as milliseconds when it may actually be seconds.
+func TestParseCCSExpiry(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name        string
+		expiresTime int64
+		wantWithin  time.Duration // expected to be within [now, now+wantWithin]
+	}{
+		{"zero falls back to default", 0, ccsExpiryFallback + time.Minute},
+		{"negative falls back to default", -1, ccsExpiryFallback + time.Minute},
+		{"plausible millisecond epoch", now.Add(time.Hour).UnixMilli(), 2 * time.Hour},
+		{"plausible second epoch (the bug)", now.Add(time.Hour).Unix(), 2 * time.Hour},
+		{"implausible value falls back to default", 123, ccsExpiryFallback + time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCCSExpiry(tt.expiresTime)
+			assert.True(t, got.After(now), "expiry must be in the future, got %v", got)
+			assert.True(t, got.Before(now.Add(tt.wantWithin)), "expiry too far out, got %v", got)
+		})
+	}
+}
+
+func TestCCIBundleTokenRoundTrip(t *testing.T) {
+	b := cciBundle{
+		AccessToken:              "ccs-access",
+		RefreshToken:             "cci-refresh",
+		Expiry:                   time.Now().Add(time.Hour).Truncate(time.Second),
+		DeviceID:                 "device-123",
+		CCIAccessToken:           "cci-access",
+		ExchangeableToken:        "exch-token",
+		ExchangeableRefreshToken: "exch-refresh",
+		NonCcsToken:              "non-ccs",
+		NonCcsRefreshToken:       "non-ccs-refresh",
+		IDToken:                  "id-token",
+	}
+
+	token := b.token()
+	assert.Equal(t, b.AccessToken, token.AccessToken)
+	assert.Equal(t, b.RefreshToken, token.RefreshToken)
+	assert.True(t, b.Expiry.Equal(token.Expiry))
+
+	got := bundleFromToken(token)
+	assert.Equal(t, b, got)
+}
+
+func TestDecodeCCIBundle(t *testing.T) {
+	b := cciBundle{AccessToken: "a", RefreshToken: "r", DeviceID: "d"}
+	s := encodeCCIBundleForTest(t, b)
+
+	got, ok := decodeCCIBundle(s)
+	require.True(t, ok)
+	assert.Equal(t, b, got)
+
+	_, ok = decodeCCIBundle("not-a-bundle")
+	assert.False(t, ok)
+
+	_, ok = decodeCCIBundle(cciBundlePrefix + "!!!not-base64!!!")
+	assert.False(t, ok)
+}
+
+func TestLoginCCIPasswordSuccess(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	const password = "s3cret-Passw0rd!"
+
+	loginMux := http.NewServeMux()
+	loginMux.HandleFunc("/auth/api/v2/user/oauth2/authorize", okHandler)
+	loginMux.HandleFunc("/auth/api/v1/accounts/certs", certsHandler(priv))
+	loginMux.HandleFunc("/auth/account/signin", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+
+		ciphertext, err := hex.DecodeString(r.FormValue("password"))
+		require.NoError(t, err)
+		plain, err := rsa.DecryptPKCS1v15(rand.Reader, priv, ciphertext)
+		require.NoError(t, err)
+
+		assert.Equal(t, password, string(plain))
+		assert.Equal(t, "true", r.FormValue("encryptedPassword"))
+		assert.Equal(t, "test@example.com", r.FormValue("username"))
+
+		w.Header().Set("Location", "https://oneapp.kia.com/redirect?code=testcode&state=ccsp")
+		w.WriteHeader(http.StatusFound)
+	})
+	loginSrv := httptest.NewServer(loginMux)
+	defer loginSrv.Close()
+
+	cciMux := http.NewServeMux()
+	cciMux.HandleFunc("/domain/api/v1/auth/token", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "testcode", r.URL.Query().Get("code"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken":              "cci-access-1",
+			"refreshToken":             "cci-refresh-1",
+			"nonCcsToken":              "non-ccs-1",
+			"exchangeableAccessToken":  "exch-access-1",
+			"exchangeableRefreshToken": "exch-refresh-1",
+			"nonCcsRefreshToken":       "non-ccs-refresh-1",
+			"idToken":                  "id-1",
+			"expiresIn":                3599,
+		})
+	})
+	cciMux.HandleFunc("/domain/api/v1/auth/token-exchange", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "CCS", r.URL.Query().Get("serviceType"))
+		assert.Equal(t, "Bearer cci-access-1", r.Header.Get("authorization"))
+		assert.Equal(t, "non-ccs-1", r.Header.Get("Authentication"))
+		assert.Equal(t, "exch-access-1", r.Header.Get("exchangeable-token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "ccs-token-1",
+			"expiresTime": time.Now().Add(time.Hour).UnixMilli(),
+		})
+	})
+	cciSrv := httptest.NewServer(cciMux)
+	defer cciSrv.Close()
+
+	identity := newTestIdentity(t, loginSrv.URL, cciSrv.URL)
+
+	token, err := identity.loginCCIPassword(password)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ccs-token-1", token.AccessToken)
+	assert.Equal(t, "cci-refresh-1", token.RefreshToken)
+	assert.True(t, token.Valid())
+	assert.Equal(t, "cci-access-1", cciExtraString(token, extraCCIAccessToken))
+	assert.Equal(t, "exch-access-1", cciExtraString(token, extraExchangeableToken))
+	assert.Equal(t, "non-ccs-1", cciExtraString(token, extraNonCcsToken))
+	assert.NotEmpty(t, cciExtraString(token, extraDeviceID))
+
+	// persisted so a restart can reuse/refresh it instead of logging in again
+	var persisted cciBundle
+	require.NoError(t, settings.Json(identity.settingsKey(), &persisted))
+	assert.Equal(t, "ccs-token-1", persisted.AccessToken)
+	assert.Equal(t, "cci-refresh-1", persisted.RefreshToken)
+}
+
+func TestLoginCCIPasswordWAFBlocked(t *testing.T) {
+	loginMux := http.NewServeMux()
+	loginMux.HandleFunc("/auth/api/v2/user/oauth2/authorize", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Your request looks like abusing our system"))
+	})
+	loginSrv := httptest.NewServer(loginMux)
+	defer loginSrv.Close()
+
+	identity := newTestIdentity(t, loginSrv.URL, unreachable)
+
+	_, err := identity.loginCCIPassword("whatever")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WAF")
+}
+
+func TestLoginCCIPasswordSigninRejected(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	loginMux := http.NewServeMux()
+	loginMux.HandleFunc("/auth/api/v2/user/oauth2/authorize", okHandler)
+	loginMux.HandleFunc("/auth/api/v1/accounts/certs", certsHandler(priv))
+	loginMux.HandleFunc("/auth/account/signin", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("invalid credentials"))
+	})
+	loginSrv := httptest.NewServer(loginMux)
+	defer loginSrv.Close()
+
+	identity := newTestIdentity(t, loginSrv.URL, unreachable)
+
+	_, err = identity.loginCCIPassword("wrong-password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signin failed")
+}
+
+func TestLoginCCIPasswordConsentRequired(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	loginMux := http.NewServeMux()
+	loginMux.HandleFunc("/auth/api/v2/user/oauth2/authorize", okHandler)
+	loginMux.HandleFunc("/auth/api/v1/accounts/certs", certsHandler(priv))
+	loginMux.HandleFunc("/auth/account/signin", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://idpconnect-eu.kia.com/web/v1/user/authorization?foo=bar")
+		w.WriteHeader(http.StatusFound)
+	})
+	loginSrv := httptest.NewServer(loginMux)
+	defer loginSrv.Close()
+
+	identity := newTestIdentity(t, loginSrv.URL, unreachable)
+
+	_, err = identity.loginCCIPassword("whatever")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "consent")
+}
+
+func TestRefreshCCI(t *testing.T) {
+	cciMux := http.NewServeMux()
+	cciMux.HandleFunc("/domain/api/v2/auth/token-refresh", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "old-cci-refresh", body["refreshToken"])
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken":              "cci-access-2",
+			"refreshToken":             "cci-refresh-2",
+			"nonCcsToken":              "non-ccs-2",
+			"exchangeableAccessToken":  "exch-access-2",
+			"exchangeableRefreshToken": "exch-refresh-2",
+			"nonCcsRefreshToken":       "non-ccs-refresh-2",
+			"idToken":                  "id-2",
+		})
+	})
+	cciMux.HandleFunc("/domain/api/v1/auth/token-exchange", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer cci-access-2", r.Header.Get("authorization"))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "ccs-token-2",
+			"expiresTime": time.Now().Add(time.Hour).UnixMilli(),
+		})
+	})
+	cciSrv := httptest.NewServer(cciMux)
+	defer cciSrv.Close()
+
+	identity := newTestIdentity(t, unreachable, cciSrv.URL)
+
+	old := cciBundle{
+		AccessToken:              "ccs-token-1",
+		RefreshToken:             "old-cci-refresh",
+		Expiry:                   time.Now().Add(-time.Hour), // expired
+		DeviceID:                 "device-abc",
+		CCIAccessToken:           "old-cci-access",
+		ExchangeableToken:        "old-exch",
+		ExchangeableRefreshToken: "old-exch-refresh",
+		NonCcsToken:              "old-non-ccs",
+		NonCcsRefreshToken:       "old-non-ccs-refresh",
+		IDToken:                  "old-id",
+	}
+
+	newToken, err := identity.refreshCCI(old.token())
+	require.NoError(t, err)
+	assert.Equal(t, "ccs-token-2", newToken.AccessToken)
+	assert.Equal(t, "cci-refresh-2", newToken.RefreshToken)
+	assert.True(t, newToken.Valid())
+
+	var persisted cciBundle
+	require.NoError(t, settings.Json(identity.settingsKey(), &persisted))
+	assert.Equal(t, "ccs-token-2", persisted.AccessToken)
+	assert.Equal(t, "device-abc", persisted.DeviceID) // device id carried over unchanged
+}
+
+func TestLoginCCIUsesPersistedBundleWithoutContactingServer(t *testing.T) {
+	identity := newTestIdentity(t, unreachable, unreachable)
+
+	valid := cciBundle{
+		AccessToken:  "still-valid-ccs",
+		RefreshToken: "still-valid-refresh",
+		Expiry:       time.Now().Add(time.Hour),
+		DeviceID:     "device-xyz",
+	}
+	require.NoError(t, settings.SetJson(identity.settingsKey(), valid))
+
+	token, err := identity.loginCCI("irrelevant-password-value")
+	require.NoError(t, err)
+	assert.Equal(t, "still-valid-ccs", token.AccessToken)
+}
+
+func TestLoginCCIUsesBundleFromConfigPassword(t *testing.T) {
+	identity := newTestIdentity(t, unreachable, unreachable)
+
+	valid := cciBundle{
+		AccessToken:  "config-bundle-ccs",
+		RefreshToken: "config-bundle-refresh",
+		Expiry:       time.Now().Add(time.Hour),
+		DeviceID:     "device-config",
+	}
+	password := encodeCCIBundleForTest(t, valid)
+
+	token, err := identity.loginCCI(password)
+	require.NoError(t, err)
+	assert.Equal(t, "config-bundle-ccs", token.AccessToken)
+}

--- a/vehicle/bluelink/identity.go
+++ b/vehicle/bluelink/identity.go
@@ -44,6 +44,11 @@ type Config struct {
 	Brand             string
 	TokenURL          string
 	UseBasicAuth      bool
+	// CCI holds the OneApp/CCI login parameters for brands affected by the
+	// IDPConnect WAF block on the legacy authorize endpoint (EU Kia/Hyundai).
+	// nil for brands that still use the legacy authorize/refresh flow
+	// unchanged (Genesis EU, Hyundai AU).
+	CCI *CCIConfig
 }
 
 // Identity implements the Kia/Hyundai bluelink identity.
@@ -53,6 +58,8 @@ type Identity struct {
 	log      *util.Logger
 	config   Config
 	deviceID string
+	user     string
+	language string
 	oauth2.TokenSource
 }
 
@@ -168,11 +175,29 @@ func (v *Identity) Login(user, password, language, brand string) (err error) {
 		return fmt.Errorf("unknown brand (%s)", brand)
 	}
 
-	token, err := v.refreshToken(&oauth2.Token{RefreshToken: password})
-	if err != nil {
-		return fmt.Errorf("login failed: %w", err)
+	v.user = user
+	v.language = language
+
+	var token *oauth2.Token
+
+	// CCI-capable brands (EU Kia/Hyundai) additionally accept a plaintext
+	// account password or a compound CCI token bundle in the password field
+	// (see loginCCI). Everyone else — and anyone still holding a legacy
+	// refresh_token shaped password, even on a CCI-capable brand — keeps
+	// using exactly the pre-existing legacy refresh_token-only flow below.
+	if v.config.CCI != nil && !looksLikeLegacyRefreshToken(password) {
+		token, err = v.loginCCI(password)
+		if err != nil {
+			return fmt.Errorf("login failed: %w", err)
+		}
+		v.TokenSource = oauth.RefreshTokenSource(token, v.refreshCCI)
+	} else {
+		token, err = v.refreshToken(&oauth2.Token{RefreshToken: password})
+		if err != nil {
+			return fmt.Errorf("login failed: %w", err)
+		}
+		v.TokenSource = oauth.RefreshTokenSource(token, v.refreshToken)
 	}
-	v.TokenSource = oauth.RefreshTokenSource(token, v.refreshToken)
 
 	v.deviceID, err = v.getDeviceID()
 	if err != nil {

--- a/vehicle/bluelink/identity.go
+++ b/vehicle/bluelink/identity.go
@@ -44,10 +44,8 @@ type Config struct {
 	Brand             string
 	TokenURL          string
 	UseBasicAuth      bool
-	// CCI holds the OneApp/CCI login parameters for brands affected by the
-	// IDPConnect WAF block on the legacy authorize endpoint (EU Kia/Hyundai).
-	// nil for brands that still use the legacy authorize/refresh flow
-	// unchanged (Genesis EU, Hyundai AU).
+	// CCI is set for brands affected by the IDPConnect WAF block on the legacy
+	// authorize endpoint (EU Kia/Hyundai), nil for Genesis EU and Hyundai AU
 	CCI *CCIConfig
 }
 
@@ -60,6 +58,7 @@ type Identity struct {
 	deviceID string
 	user     string
 	language string
+	bundle   cciBundle
 	oauth2.TokenSource
 }
 
@@ -162,7 +161,7 @@ func (v *Identity) refreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 	return util.TokenWithExpiry(&res), err
 }
 
-func (v *Identity) Login(user, password, language, brand string) (err error) {
+func (v *Identity) Login(user, password, language, brand string) error {
 	if user == "" || password == "" {
 		return api.ErrMissingCredentials
 	}
@@ -178,33 +177,32 @@ func (v *Identity) Login(user, password, language, brand string) (err error) {
 	v.user = user
 	v.language = language
 
-	var token *oauth2.Token
+	refresher := v.refreshToken
 
-	// CCI-capable brands (EU Kia/Hyundai) additionally accept a plaintext
-	// account password or a compound CCI token bundle in the password field
-	// (see loginCCI). Everyone else — and anyone still holding a legacy
-	// refresh_token shaped password, even on a CCI-capable brand — keeps
-	// using exactly the pre-existing legacy refresh_token-only flow below.
-	if v.config.CCI != nil && !looksLikeLegacyRefreshToken(password) {
-		token, err = v.loginCCI(password)
-		if err != nil {
-			return fmt.Errorf("login failed: %w", err)
-		}
-		v.TokenSource = oauth.RefreshTokenSource(token, v.refreshCCI)
-	} else {
-		token, err = v.refreshToken(&oauth2.Token{RefreshToken: password})
-		if err != nil {
-			return fmt.Errorf("login failed: %w", err)
-		}
-		v.TokenSource = oauth.RefreshTokenSource(token, v.refreshToken)
+	token, err := v.refreshToken(&oauth2.Token{RefreshToken: password})
+	if err == nil && !token.Valid() {
+		err = errors.New("no access token")
 	}
+
+	// CCI-capable brands (EU Kia/Hyundai) additionally accept the account
+	// password, as generating a legacy refresh_token is WAF-blocked
+	if err != nil && v.config.CCI != nil {
+		refresher = v.refreshCCI
+		token, err = v.loginCCI(password)
+	}
+
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	v.TokenSource = oauth.RefreshTokenSource(token, refresher)
 
 	v.deviceID, err = v.getDeviceID()
 	if err != nil {
 		return fmt.Errorf("error getting device id: %w", err)
 	}
 
-	return err
+	return nil
 }
 
 // Request decorates requests with authorization headers

--- a/vehicle/bluelink/identity_test.go
+++ b/vehicle/bluelink/identity_test.go
@@ -78,9 +78,7 @@ func testCCIConfig() *CCIConfig {
 }
 
 // TestLoginUsesLegacyWhenCCIIsNil covers brands without CCI support (Genesis
-// EU, Hyundai AU): Login must always use the unmodified legacy refreshToken
-// path, regardless of whether the password happens to look like a legacy
-// token or a real account password.
+// EU, Hyundai AU): Login must always use the unmodified legacy refreshToken path
 func TestLoginUsesLegacyWhenCCIIsNil(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
@@ -109,14 +107,10 @@ func TestLoginUsesLegacyWhenCCIIsNil(t *testing.T) {
 	}
 }
 
-// TestLoginUsesLegacyWhenPasswordLooksLikeLegacyToken covers a CCI-capable
-// brand (Kia/Hyundai EU) where the configured password still has the shape
-// of a legacy refresh_token: this must keep using the unmodified legacy
-// path, not the CCI one, for users who still hold a valid pre-block token.
-// The CCI endpoint is deliberately left unreachable - if the code mistakenly
-// routed there, this test would fail with a connection error instead of the
-// expected legacy access token.
-func TestLoginUsesLegacyWhenPasswordLooksLikeLegacyToken(t *testing.T) {
+// TestLoginPrefersLegacyToken covers a CCI-capable brand whose configured
+// password is still a valid legacy refresh_token: the CCI path must not be used
+// (its endpoint is left unreachable, so routing there would fail the test)
+func TestLoginPrefersLegacyToken(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/auth/api/v2/user/oauth2/token", legacyTokenHandler("legacy-access-2", "legacy-refresh-2"))
 	loginSrv := httptest.NewServer(mux)
@@ -134,14 +128,8 @@ func TestLoginUsesLegacyWhenPasswordLooksLikeLegacyToken(t *testing.T) {
 	assert.Equal(t, "legacy-access-2", token.AccessToken)
 }
 
-// TestLoginUsesCCIAndWiresRefreshCCI covers a CCI-capable brand with a real
-// account password: Login must perform the full CCI login and wire
-// TokenSource to refreshCCI (not the legacy refreshToken) for subsequent
-// refreshes. The mock CCS exchange deliberately returns a token that expires
-// in 5s, which lands inside oauth2's default 10s expiry buffer - so the very
-// next Token() call is guaranteed to trigger exactly one refresh, and
-// asserting it hit the CCI refresh endpoint (rather than the legacy one, or
-// none at all) confirms the wiring without needing internal hooks.
+// TestLoginUsesCCIAndWiresRefreshCCI covers a CCI-capable brand with an account
+// password: Login must fall back to the CCI login and wire TokenSource to refreshCCI
 func TestLoginUsesCCIAndWiresRefreshCCI(t *testing.T) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
@@ -174,15 +162,12 @@ func TestLoginUsesCCIAndWiresRefreshCCI(t *testing.T) {
 		})
 	})
 	cciMux.HandleFunc("/domain/api/v1/auth/token-exchange", func(w http.ResponseWriter, _ *http.Request) {
-		// The first (login) exchange deliberately returns a token that
-		// expires in 5s - inside oauth2's default 10s expiry buffer, so it's
-		// already considered invalid by the time the test asks for it. Every
-		// later (post-refresh) exchange returns a long-lived token instead,
-		// so refreshing settles after exactly one round-trip.
-		resp := map[string]any{"accessToken": "ccs-token-2", "expiresTime": time.Now().Add(time.Hour).UnixMilli()}
+		// the first (login) exchange returns a token expiring inside oauth2's
+		// 10s buffer, so the next Token() call triggers exactly one refresh
+		resp := map[string]any{"accessToken": "ccs-token-2", "expiresTime": time.Now().Add(time.Hour).Unix()}
 		if atomic.AddInt32(&exchangeCalls, 1) == 1 {
 			resp["accessToken"] = "ccs-token-1"
-			resp["expiresTime"] = time.Now().Add(5 * time.Second).UnixMilli()
+			resp["expiresTime"] = time.Now().Add(5 * time.Second).Unix()
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	})
@@ -202,10 +187,8 @@ func TestLoginUsesCCIAndWiresRefreshCCI(t *testing.T) {
 
 	require.NoError(t, identity.Login("user@example.com", "s3cret-Passw0rd!", "en", "kia"))
 
-	// The freshly issued token is already inside the expiry buffer, so this
-	// very first Token() call is guaranteed to trigger exactly one refresh.
-	// Asserting it hit the CCI refresh endpoint (rather than the legacy one,
-	// or none at all) confirms TokenSource is wired to refreshCCI.
+	// the freshly issued token is inside the expiry buffer, so this Token()
+	// call must trigger exactly one refresh against the CCI endpoint
 	token, err := identity.Token()
 	require.NoError(t, err)
 	assert.Equal(t, "ccs-token-2", token.AccessToken)
@@ -215,31 +198,6 @@ func TestLoginUsesCCIAndWiresRefreshCCI(t *testing.T) {
 	_, err = identity.Token()
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, atomic.LoadInt32(&refreshCalls), "unexpected additional refresh")
-}
-
-// TestLoginUsesCCIBundleFromPasswordField covers the cci1: compound-bundle
-// password: Login must use it directly via the CCI path without contacting
-// the login or CCI servers at all (both are left unreachable here; a valid,
-// non-expired bundle needs no network calls).
-func TestLoginUsesCCIBundleFromPasswordField(t *testing.T) {
-	deviceSrv := httptest.NewServer(http.HandlerFunc(deviceIDHandler))
-	defer deviceSrv.Close()
-
-	identity := newLoginTestIdentity(t, unreachable, deviceSrv.URL, unreachable, testCCIConfig())
-
-	valid := cciBundle{
-		AccessToken:  "bundle-ccs-token",
-		RefreshToken: "bundle-refresh",
-		Expiry:       time.Now().Add(time.Hour),
-		DeviceID:     "device-bundle",
-	}
-	password := encodeCCIBundleForTest(t, valid)
-
-	require.NoError(t, identity.Login("user@example.com", password, "en", "kia"))
-
-	token, err := identity.Token()
-	require.NoError(t, err)
-	assert.Equal(t, "bundle-ccs-token", token.AccessToken)
 }
 
 // TestLoginPropagatesLegacyError covers the legacy path: a failure there must
@@ -260,9 +218,8 @@ func TestLoginPropagatesLegacyError(t *testing.T) {
 	assert.True(t, strings.HasPrefix(err.Error(), "login failed:"), "got: %s", err.Error())
 }
 
-// TestLoginPropagatesCCIError covers the CCI path: a failure there (here, the
-// WAF-block detection from step 1) must also surface prefixed with
-// "login failed: ", the same convention as the legacy path.
+// TestLoginPropagatesCCIError covers the CCI path: a failure there must surface
+// prefixed with "login failed: ", the same convention as the legacy path
 func TestLoginPropagatesCCIError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/auth/api/v2/user/oauth2/authorize", func(w http.ResponseWriter, _ *http.Request) {

--- a/vehicle/bluelink/identity_test.go
+++ b/vehicle/bluelink/identity_test.go
@@ -1,0 +1,281 @@
+package bluelink
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCCSPApplicationID/testCfb are copied from the real production Kia EU
+// config (vehicle/bluelink.go) so Identity.stamp() succeeds during Login's
+// getDeviceID call - not secrets, both are already public there.
+const (
+	testCCSPApplicationID = "a2b8469b-30a3-4361-8e13-6fceea8fbe74"
+	testCfb               = "wLTVxwidmH8CfJYBWSnHD6E0huk0ozdiuygB4hLkM5XCgzAL1Dk5sE36d/bx5PFMbZs="
+)
+
+// deviceIDHandler serves Identity.getDeviceID's device registration endpoint,
+// which Login always calls after either auth path succeeds.
+func deviceIDHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, `{"RetCode":"S","ResMsg":{"DeviceID":"test-device-id"}}`)
+}
+
+// legacyTokenHandler serves the legacy refresh_token grant endpoint used by
+// Identity.refreshToken.
+func legacyTokenHandler(accessToken, refreshToken string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":%q,"refresh_token":%q,"expires_in":3600}`, accessToken, refreshToken)
+	}
+}
+
+// newLoginTestIdentity builds an Identity suitable for exercising the public
+// Login() method end to end, including the legacy getDeviceID call it always
+// makes. cci == nil mirrors a brand without CCI support (e.g. Genesis EU).
+func newLoginTestIdentity(t *testing.T, loginURL, deviceURL, cciURL string, cci *CCIConfig) *Identity {
+	t.Helper()
+
+	config := Config{
+		Brand:             "kia-login-test:" + t.Name(),
+		URI:               deviceURL,
+		CCSPServiceID:     "test-ccsp-service-id",
+		CCSPServiceSecret: "test-ccsp-secret",
+		CCSPApplicationID: testCCSPApplicationID,
+		Cfb:               testCfb,
+		LoginFormHost:     loginURL,
+		PushType:          "APNS",
+		CCI:               cci,
+	}
+	if cci != nil {
+		config.CCI.APIURL = cciURL
+	}
+
+	return NewIdentity(util.NewLogger("test"), config)
+}
+
+func testCCIConfig() *CCIConfig {
+	return &CCIConfig{
+		OneAppClientID:       "test-client-id",
+		OneAppRedirectURI:    "https://oneapp.kia.com/redirect",
+		PackageID:            "com.kia.oneapp.eu",
+		ClientName:           "kia",
+		OSVersion:            "27",
+		NotificationProvider: "IOS_APPSTORE",
+	}
+}
+
+// TestLoginUsesLegacyWhenCCIIsNil covers brands without CCI support (Genesis
+// EU, Hyundai AU): Login must always use the unmodified legacy refreshToken
+// path, regardless of whether the password happens to look like a legacy
+// token or a real account password.
+func TestLoginUsesLegacyWhenCCIIsNil(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		password string
+	}{
+		{"legacy-shaped password", strings.Repeat("A", 48)},
+		{"real-looking password", "s3cret-Passw0rd!"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/auth/api/v2/user/oauth2/token", legacyTokenHandler("legacy-access", "legacy-refresh"))
+			loginSrv := httptest.NewServer(mux)
+			defer loginSrv.Close()
+
+			deviceSrv := httptest.NewServer(http.HandlerFunc(deviceIDHandler))
+			defer deviceSrv.Close()
+
+			identity := newLoginTestIdentity(t, loginSrv.URL, deviceSrv.URL, "", nil)
+
+			require.NoError(t, identity.Login("user@example.com", tt.password, "en", "kia"))
+
+			token, err := identity.Token()
+			require.NoError(t, err)
+			assert.Equal(t, "legacy-access", token.AccessToken)
+		})
+	}
+}
+
+// TestLoginUsesLegacyWhenPasswordLooksLikeLegacyToken covers a CCI-capable
+// brand (Kia/Hyundai EU) where the configured password still has the shape
+// of a legacy refresh_token: this must keep using the unmodified legacy
+// path, not the CCI one, for users who still hold a valid pre-block token.
+// The CCI endpoint is deliberately left unreachable - if the code mistakenly
+// routed there, this test would fail with a connection error instead of the
+// expected legacy access token.
+func TestLoginUsesLegacyWhenPasswordLooksLikeLegacyToken(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/api/v2/user/oauth2/token", legacyTokenHandler("legacy-access-2", "legacy-refresh-2"))
+	loginSrv := httptest.NewServer(mux)
+	defer loginSrv.Close()
+
+	deviceSrv := httptest.NewServer(http.HandlerFunc(deviceIDHandler))
+	defer deviceSrv.Close()
+
+	identity := newLoginTestIdentity(t, loginSrv.URL, deviceSrv.URL, unreachable, testCCIConfig())
+
+	require.NoError(t, identity.Login("user@example.com", strings.Repeat("A", 48), "en", "kia"))
+
+	token, err := identity.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-access-2", token.AccessToken)
+}
+
+// TestLoginUsesCCIAndWiresRefreshCCI covers a CCI-capable brand with a real
+// account password: Login must perform the full CCI login and wire
+// TokenSource to refreshCCI (not the legacy refreshToken) for subsequent
+// refreshes. The mock CCS exchange deliberately returns a token that expires
+// in 5s, which lands inside oauth2's default 10s expiry buffer - so the very
+// next Token() call is guaranteed to trigger exactly one refresh, and
+// asserting it hit the CCI refresh endpoint (rather than the legacy one, or
+// none at all) confirms the wiring without needing internal hooks.
+func TestLoginUsesCCIAndWiresRefreshCCI(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	loginMux := http.NewServeMux()
+	loginMux.HandleFunc("/auth/api/v2/user/oauth2/authorize", okHandler)
+	loginMux.HandleFunc("/auth/api/v1/accounts/certs", certsHandler(priv))
+	loginMux.HandleFunc("/auth/account/signin", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		ciphertext, err := hex.DecodeString(r.FormValue("password"))
+		require.NoError(t, err)
+		_, err = rsa.DecryptPKCS1v15(rand.Reader, priv, ciphertext)
+		require.NoError(t, err)
+
+		w.Header().Set("Location", "https://oneapp.kia.com/redirect?code=testcode&state=ccsp")
+		w.WriteHeader(http.StatusFound)
+	})
+	loginSrv := httptest.NewServer(loginMux)
+	defer loginSrv.Close()
+
+	var refreshCalls int32
+	var exchangeCalls int32
+	cciMux := http.NewServeMux()
+	cciMux.HandleFunc("/domain/api/v1/auth/token", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "cci-access", "refreshToken": "cci-refresh",
+			"nonCcsToken": "non-ccs", "exchangeableAccessToken": "exch-access",
+			"exchangeableRefreshToken": "exch-refresh", "nonCcsRefreshToken": "non-ccs-refresh",
+			"idToken": "id-1", "expiresIn": 3599,
+		})
+	})
+	cciMux.HandleFunc("/domain/api/v1/auth/token-exchange", func(w http.ResponseWriter, _ *http.Request) {
+		// The first (login) exchange deliberately returns a token that
+		// expires in 5s - inside oauth2's default 10s expiry buffer, so it's
+		// already considered invalid by the time the test asks for it. Every
+		// later (post-refresh) exchange returns a long-lived token instead,
+		// so refreshing settles after exactly one round-trip.
+		resp := map[string]any{"accessToken": "ccs-token-2", "expiresTime": time.Now().Add(time.Hour).UnixMilli()}
+		if atomic.AddInt32(&exchangeCalls, 1) == 1 {
+			resp["accessToken"] = "ccs-token-1"
+			resp["expiresTime"] = time.Now().Add(5 * time.Second).UnixMilli()
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	cciMux.HandleFunc("/domain/api/v2/auth/token-refresh", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&refreshCalls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "cci-access-2", "refreshToken": "cci-refresh-2",
+		})
+	})
+	cciSrv := httptest.NewServer(cciMux)
+	defer cciSrv.Close()
+
+	deviceSrv := httptest.NewServer(http.HandlerFunc(deviceIDHandler))
+	defer deviceSrv.Close()
+
+	identity := newLoginTestIdentity(t, loginSrv.URL, deviceSrv.URL, cciSrv.URL, testCCIConfig())
+
+	require.NoError(t, identity.Login("user@example.com", "s3cret-Passw0rd!", "en", "kia"))
+
+	// The freshly issued token is already inside the expiry buffer, so this
+	// very first Token() call is guaranteed to trigger exactly one refresh.
+	// Asserting it hit the CCI refresh endpoint (rather than the legacy one,
+	// or none at all) confirms TokenSource is wired to refreshCCI.
+	token, err := identity.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "ccs-token-2", token.AccessToken)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&refreshCalls), "expected TokenSource to be wired to refreshCCI")
+
+	// the now long-lived token must not trigger a further refresh
+	_, err = identity.Token()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&refreshCalls), "unexpected additional refresh")
+}
+
+// TestLoginUsesCCIBundleFromPasswordField covers the cci1: compound-bundle
+// password: Login must use it directly via the CCI path without contacting
+// the login or CCI servers at all (both are left unreachable here; a valid,
+// non-expired bundle needs no network calls).
+func TestLoginUsesCCIBundleFromPasswordField(t *testing.T) {
+	deviceSrv := httptest.NewServer(http.HandlerFunc(deviceIDHandler))
+	defer deviceSrv.Close()
+
+	identity := newLoginTestIdentity(t, unreachable, deviceSrv.URL, unreachable, testCCIConfig())
+
+	valid := cciBundle{
+		AccessToken:  "bundle-ccs-token",
+		RefreshToken: "bundle-refresh",
+		Expiry:       time.Now().Add(time.Hour),
+		DeviceID:     "device-bundle",
+	}
+	password := encodeCCIBundleForTest(t, valid)
+
+	require.NoError(t, identity.Login("user@example.com", password, "en", "kia"))
+
+	token, err := identity.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "bundle-ccs-token", token.AccessToken)
+}
+
+// TestLoginPropagatesLegacyError covers the legacy path: a failure there must
+// surface through Login prefixed with evcc's existing "login failed: " convention.
+func TestLoginPropagatesLegacyError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/api/v2/user/oauth2/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	})
+	loginSrv := httptest.NewServer(mux)
+	defer loginSrv.Close()
+
+	identity := newLoginTestIdentity(t, loginSrv.URL, unreachable, "", nil)
+
+	err := identity.Login("user@example.com", strings.Repeat("A", 48), "en", "kia")
+	require.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "login failed:"), "got: %s", err.Error())
+}
+
+// TestLoginPropagatesCCIError covers the CCI path: a failure there (here, the
+// WAF-block detection from step 1) must also surface prefixed with
+// "login failed: ", the same convention as the legacy path.
+func TestLoginPropagatesCCIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/api/v2/user/oauth2/authorize", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Your request looks like abusing our system"))
+	})
+	loginSrv := httptest.NewServer(mux)
+	defer loginSrv.Close()
+
+	identity := newLoginTestIdentity(t, loginSrv.URL, unreachable, unreachable, testCCIConfig())
+
+	err := identity.Login("user@example.com", "s3cret-Passw0rd!", "en", "kia")
+	require.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "login failed:"), "got: %s", err.Error())
+	assert.Contains(t, err.Error(), "WAF")
+}


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/32867

## Problem

Since around 2026-08-11, Hyundai's IDPConnect WAF hard-blocks the legacy authorize endpoint for the legacy CCSP client_id used by evcc's Kia/Hyundai EU login (the request gets classified as "abusing" and rejected). This breaks **new** logins and re-logins for EU Kia/Hyundai accounts.

Existing users who already hold a valid legacy `refresh_token` are **not** affected - the refresh_token grant itself still works fine against the legacy endpoint; only obtaining a brand-new one via the legacy authorize flow is blocked. So this is specifically a "can't onboard/re-onboard" problem, not a "everyone's integration just broke" problem.

Genesis EU and Hyundai AU are not affected (different, non-WAF-blocked endpoints) and are untouched by this PR.

## Fix

Adds the OneApp/CCI login + refresh flow - the same auth flow the Kia/Hyundai mobile apps themselves use, whose client_id is not on the WAF block list - as an alternative login path for Kia/Hyundai EU only. Protocol details (OneApp client IDs, CCI endpoints, the 5-step login flow, and the token-refresh flow) follow the prior-art implementation in [hyundai_kia_connect_api#1277](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/1277).

- `vehicle/bluelink/cci.go` (new): the OneApp/CCI login (authorize → RSA cert fetch → encrypted-password signin → CCI token exchange → CCS token exchange) and CCI token refresh. The end result is a CCS Bearer token, used completely unchanged on the existing legacy `ccapi:8080` vehicle/control endpoints - only how that token is obtained changes.
- `vehicle/bluelink/identity.go`: `Login()` now routes to the CCI flow only when the brand supports it (`Config.CCI != nil`, i.e. Kia EU / Hyundai EU) *and* the configured password doesn't look like a legacy refresh_token. Every other case - Genesis EU, Hyundai AU, and any Kia/Hyundai EU user still holding a valid legacy refresh_token - goes through the exact same, unmodified `refreshToken()` call as before. Zero behavior change for existing users.
- `vehicle/bluelink.go`: wires the real OneApp/CCI parameters (client IDs, endpoints, package IDs) for Kia EU and Hyundai EU.
- The CCI token bundle (CCI access/refresh token, exchangeable token, non-CCS token, id token, device id) is persisted via evcc's existing `server/db/settings` mechanism - the same pattern already used by `vehicle/tesla` and `vehicle/mercedes` for their OAuth2 tokens - so an evcc restart reuses/refreshes the persisted session instead of requiring a fresh password login every time.
- As an alternative to storing a live account password in evcc's config at all, the password field can also directly hold a pre-obtained CCI token bundle (a `cci1:`-prefixed, base64url-encoded blob), for users who generate one via an external tool.
- `templates/definition/vehicle/{kia,hyundai}.yaml`: updated the requirements text (shown in evcc's config UI) to mention the password field now also accepts the real account password.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test ./vehicle/...` clean, including new unit tests in `vehicle/bluelink/cci_test.go` (httptest-mocked login/refresh flows, WAF-block detection, signin-rejected/consent-required error paths, token bundle encode/round-trip, and the legacy-vs-CCI credential detection), following the existing `vehicle/tesla` / `vehicle/porsche` testing conventions.
- Also live-tested end-to-end against a real Kia EU account: a fresh OneApp/CCI login succeeded, the resulting token survived an evcc restart without needing an unnecessary refresh, and `WakeUp()`/`StatusLatest()` calls against the real `ccapi:8080` backend returned real vehicle telemetry (SoC, range, timestamp). The existing web config UI (device add/test flow) uses the identical `vehicle.NewFromConfig` code path as static YAML config, so it's covered too. (Account details are intentionally not included here.)

Two bugs turned up during that live test, both now covered by regression tests:
- The legacy-vs-CCI credential detection initially only checked string length, which collided with short real account passwords (most passwords are shorter than legacy refresh_tokens too). It now also requires the legacy token's character class (uppercase letters/digits only), matching what a legacy token actually looks like.
- The CCS token-exchange response's expiry field was assumed to be a millisecond epoch (per the reference implementation), but the real backend appears to return seconds - which made every freshly-issued token look already expired, triggering a refresh on every single API call instead of roughly once an hour. `parseCCSExpiry()` now tries both interpretations and only trusts a result that lands in a plausible near-future window, falling back to a safe default otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)