### PR TITLE
chore: publish the homebrew package as a cask

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -126,7 +126,7 @@ nfpms:
       preremove: ./packaging/scripts/preremove.sh
       postremove: ./packaging/scripts/postremove.sh
 
-brews:
+homebrew_casks:
   - skip_upload: '{{ if eq (envOrDefault "MAKE_LATEST" "true") "true" }}false{{ else }}true{{ end }}'
     repository:
       owner: evcc-io
@@ -134,15 +134,14 @@ brews:
     commit_author:
       name: andig
       email: info@evcc.io
-    directory: Formula
     homepage: "https://evcc.io"
     description: "Sonne tanken ☀️🚘"
-    license: "MIT"
-    test: |
-      system "#{bin}/evcc --version"
-    service: |
-      run [opt_bin/"evcc"]
-      working_dir HOMEBREW_PREFIX
-      keep_alive true
-      log_path var/"log/evcc.log"
-      error_log_path var/"log/evcc.log"
+    binaries:
+      - evcc
+    hooks:
+      post:
+        # the binaries are not notarized, so gatekeeper would refuse to run them
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/evcc"]
+          end


### PR DESCRIPTION
goreleaser hard-deprecated the `brews` section in v2.16 and the release run logs `DEPRECATED:  brews  should not be used anymore`. Pre-compiled binaries belong in a Homebrew Cask, so the section moves to `homebrew_casks`.

Casks have no `test`, `license` or formula `directory` stanza, so those drop. The macOS binaries are not notarized, so the quarantine bit is removed in a postflight hook, otherwise gatekeeper refuses to run them.

**Behaviour change:** the formula shipped a `service` block, so `brew services start evcc` worked. Casks have no equivalent, that goes away.

**Follow-up in `evcc-io/homebrew-tap`,** otherwise existing installs stay on the stale formula:
- add `tap_migrations.json` with `{"evcc": "evcc-io/tap/evcc"}`
- delete `Formula/evcc.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)