### PR TITLE
chore: install the goreleaser pro distribution for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,9 +138,11 @@ jobs:
       - name: Create Github Release
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
+          distribution: goreleaser-pro
           version: '~> v2'
           args: release --clean
         env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           # use RELEASE_DEPLOY_TOKEN for access to evcc-io/homebrew-tap
           GITHUB_TOKEN: ${{ secrets.RELEASE_DEPLOY_TOKEN }}
           # a bugfix release of an older line must not move the homebrew formula


### PR DESCRIPTION
The changelog `format` uses `reReplaceAll`, which only exists in goreleaser pro. `goreleaser-action` installs the open source binary unless `distribution: goreleaser-pro` is set, so the release fails with

```
⨯ release failed  error=template: failed to apply "{{ .SHA }} {{ reReplaceAll ... }}": function "reReplaceAll" not defined
```

Setting the `GORELEASER_KEY` secret alone does not help, the action has to be told which distribution to download and the key has to reach the binary through `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)