### PR TITLE
chore: fix release notes changelog template

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -157,18 +157,15 @@ jobs:
           TITLE: ${{ steps.pr.outputs.title }}
           ACTOR: ${{ github.event.comment.user.login }}
         run: |
-          # the release line the branch was cut from, 0.313 for release/0.313.1
-          line=$(echo "${TARGET#release/}" | cut -d. -f1,2)
-
           # the pull request is authored by the deploy token, so assign the
           # requester. the body stays empty, squashing it would carry the text
           # into the release branch as the commit description.
-          # the marker trails the title so the changelog filters and groups still
-          # see the original prefix, goreleaser strips it from the release notes
+          # the title stays untouched so the changelog filters and groups still
+          # see the original prefix, the backport label identifies the pull request
           url=$(gh pr create \
             --base "$TARGET" \
             --head "$BRANCH" \
-            --title "$TITLE [$line backport]" \
+            --title "$TITLE" \
             --label backport \
             --assignee "$ACTOR" \
             --body "")

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -129,9 +129,6 @@ brews:
     repository:
       owner: evcc-io
       name: homebrew-tap
-      branch: "{{ .ProjectName }}-{{ .Version }}"
-      pull_request:
-        enabled: true
     commit_author:
       name: andig
       email: info@evcc.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,8 +71,6 @@ snapshot:
 
 changelog:
   sort: asc
-  # drop the marker the backport command appends to the pull request title
-  format: '{{ .SHA }} {{ reReplaceAll ` \[\d+\.\d+ backport\]` .Message "" }}'
   filters:
     exclude:
       - "^chore"
@@ -131,6 +129,9 @@ brews:
     repository:
       owner: evcc-io
       name: homebrew-tap
+      branch: "{{ .ProjectName }}-{{ .Version }}"
+      pull_request:
+        enabled: true
     commit_author:
       name: andig
       email: info@evcc.io


### PR DESCRIPTION
follow-up to #32392

The 0.314.0 release failed in `Create Github Release`: `reReplaceAll` is a GoReleaser Pro function, so the changelog template is undefined in the OSS binary. The 0.313.x tags were cut before #32392 landed, which is why the failure only surfaced now.

The template was never needed. Keeping the backport marker out of the pull request title lets the changelog filters and groups work on the untouched title, and the `backport` label already identifies the pull request.

- drop the `reReplaceAll` changelog format and the marker the backport command appended to the title

Note that 0.314.0 is half-released: the docker tags and the demo/hassio deployments went out, the Github release assets, homebrew formula and .deb did not. Rerunning the failed job replays the tagged commit and fails again, so the release needs to be redone once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)