### PR TITLE
chore: make the restored docker cache mounts writable

### DIFF
--- a/.github/actions/docker-cache/action.yml
+++ b/.github/actions/docker-cache/action.yml
@@ -32,6 +32,12 @@ runs:
           ${{ runner.os }}-docker-mounts-${{ inputs.cache-scope }}-
           ${{ runner.os }}-docker-mounts-main-
 
+    # the go module cache restores read-only, which fails the dance's cleanup
+    # of the source directory after injection
+    - name: Make cache mounts writable
+      shell: bash
+      run: test -d .docker-cache && chmod -R u+w .docker-cache || true
+
     - name: Inject cache mounts
       uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
       with:


### PR DESCRIPTION
follow-up to #32700

The docker build cache action logs a notice on every run:

```
##[notice]Error while cleaning cache source directory:
Error: EACCES: permission denied, unlink '.docker-cache/go-mod/dar…'
```

The Go module cache is stored read-only, so the cache dance cannot clean its source directory after injecting the mounts. Today this is cosmetic because `skip-extraction` is set on a cache hit, but a cache miss takes the same path.

- make the restored cache tree writable before the dance runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)