### PR TITLE
chore: build the release and nightly images on depot

### DIFF
--- a/.github/workflows/command-nightly.yml
+++ b/.github/workflows/command-nightly.yml
@@ -60,6 +60,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      id-token: write # depot OIDC
     secrets: inherit
 
   report:

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Publish
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
         with:
-          project: 0zz60925dv
+          project: ${{ secrets.DEPOT_PROJECT_ID }}
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -13,6 +13,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # depot OIDC
 
     steps:
       - uses: actions/checkout@v7
@@ -27,14 +28,10 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      - name: Restore build cache
-        uses: ./.github/actions/docker-cache
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
+      # depot builders keep the Dockerfile's cache mounts on their own volumes,
+      # so they need neither buildx nor the cache dance
+      - name: Setup Depot
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Define tags
         id: meta
@@ -46,8 +43,9 @@ jobs:
             type=raw,value=nightly.{{date 'YYYYMMDD'}}-{{sha}}
 
       - name: Publish
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
         with:
+          project: 0zz60925dv
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,6 +48,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      id-token: write # depot OIDC
     secrets: inherit
 
   hassio:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Publish
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
         with:
-          project: 0zz60925dv
+          project: ${{ secrets.DEPOT_PROJECT_ID }}
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     permissions:
       contents: read
+      id-token: write # depot OIDC
 
     steps:
       - uses: actions/checkout@v7
@@ -59,14 +60,10 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      - name: Restore build cache
-        uses: ./.github/actions/docker-cache
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
+      # depot builders keep the Dockerfile's cache mounts on their own volumes,
+      # so they need neither buildx nor the cache dance
+      - name: Setup Depot
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Meta
         id: meta
@@ -79,8 +76,9 @@ jobs:
             latest=${{ needs.guard.outputs.latest }}
 
       - name: Publish
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
         with:
+          project: 0zz60925dv
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
           push: true


### PR DESCRIPTION
follow-up to #32700

The docker jobs already run on depot runners, but the image build itself uses a plain buildx builder. BuildKit cannot export cache mounts, so #32700 works around that with `buildkit-cache-dance`, which costs ~100s per release: a 1.2 GB cache download plus three sequential injection builds. Depot builders keep the cache mounts on their own volumes, so the workaround becomes unnecessary.

- route the release and nightly image builds to the depot project, dropping the buildx setup and the cache dance
- authenticate through the OIDC trust relationship, no token secret
- fork pull request builds keep using the dance, so their cache stays isolated from the shared one

Requires the OIDC trust relationship for this repository in the depot project settings before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)