### PR TITLE
GoodWe: list ESA series under hybrid template

### DIFF
--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -2,7 +2,7 @@ template: goodwe-hybrid
 products:
   - brand: GoodWe
     description:
-      generic: ET/EH/BH/BT Hybrid Inverter
+      generic: ET/EH/BH/BT/ESA Hybrid Inverter
 capabilities: ["battery-control", "curtail"]
 params:
   - name: usage


### PR DESCRIPTION
The ESA all-in-one storage series (single-phase, 3–10 kW) uses the same hybrid register map as ET/EH/BH/BT, including the 247 default slave id the template already sets. No template logic changes — only the product description, so the series shows up when searching for it in the device configuration.

Template-only change, `go test ./util/templates/...` passes.