### PR TITLE
Modbus templates: share block reads

### DIFF
--- a/templates/definition/meter/anker-solix-x1.yaml
+++ b/templates/definition/meter/anker-solix-x1.yaml
@@ -32,6 +32,9 @@ render: |
       address: 10644 # Meter Total Active Power (W, positive = import, negative = export)
       type: input
       decode: int32s
+    block: # 10632-10645
+      register: 10632
+      count: 14
   energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -47,18 +50,27 @@ render: |
         address: 10638 # Meter Phase A Active Power
         type: input
         decode: int32s
+      block: # 10632-10645
+        register: 10632
+        count: 14
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 10640 # Meter Phase B Active Power
         type: input
         decode: int32s
+      block: # 10632-10645
+        register: 10632
+        count: 14
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 10642 # Meter Phase C Active Power
         type: input
         decode: int32s
+      block: # 10632-10645
+        register: 10632
+        count: 14
   currents:
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -66,6 +78,9 @@ render: |
         address: 10635 # Meter Phase A Current
         type: input
         decode: uint16
+      block: # 10632-10645
+        register: 10632
+        count: 14
       scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -73,6 +88,9 @@ render: |
         address: 10636 # Meter Phase B Current
         type: input
         decode: uint16
+      block: # 10632-10645
+        register: 10632
+        count: 14
       scale: 0.01
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -80,6 +98,9 @@ render: |
         address: 10637 # Meter Phase C Current
         type: input
         decode: uint16
+      block: # 10632-10645
+        register: 10632
+        count: 14
       scale: 0.01
   voltages:
     - source: modbus
@@ -88,6 +109,9 @@ render: |
         address: 10632 # Meter Phase A Voltage
         type: input
         decode: uint16
+      block: # 10632-10645
+        register: 10632
+        count: 14
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -95,6 +119,9 @@ render: |
         address: 10633 # Meter Phase B Voltage
         type: input
         decode: uint16
+      block: # 10632-10645
+        register: 10632
+        count: 14
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -102,6 +129,9 @@ render: |
         address: 10634 # Meter Phase C Voltage
         type: input
         decode: uint16
+      block: # 10632-10645
+        register: 10632
+        count: 14
       scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -84,6 +84,9 @@ render: |
       address: 60090 # Phase A Grid Current (A * 100)
       type: holding
       decode: int16
+    block: # 60089-60094
+      register: 60089
+      count: 6
     scale: 0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -91,6 +94,9 @@ render: |
       address: 60092 # Phase B Grid Current (A * 100)
       type: holding
       decode: int16
+    block: # 60089-60094
+      register: 60089
+      count: 6
     scale: 0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -98,6 +104,9 @@ render: |
       address: 60094 # Phase C Grid Current (A * 100)
       type: holding
       decode: int16
+    block: # 60089-60094
+      register: 60089
+      count: 6
     scale: 0.01
   voltages:
   - source: modbus
@@ -106,6 +115,9 @@ render: |
       address: 60089 # Phase A Grid Voltage (V * 10)
       type: holding
       decode: uint16
+    block: # 60089-60094
+      register: 60089
+      count: 6
     scale: 0.1
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -113,6 +125,9 @@ render: |
       address: 60091 # Phase B Grid Voltage (V * 10)
       type: holding
       decode: uint16
+    block: # 60089-60094
+      register: 60089
+      count: 6
     scale: 0.1
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -120,6 +135,9 @@ render: |
       address: 60093 # Phase C Grid Voltage (V * 10)
       type: holding
       decode: uint16
+    block: # 60089-60094
+      register: 60089
+      count: 6
     scale: 0.1
   {{- end }}
   {{- if eq .usage "pv" }}

--- a/templates/definition/meter/fox-ess-avocado.yaml
+++ b/templates/definition/meter/fox-ess-avocado.yaml
@@ -60,6 +60,9 @@ render: |
       address: 39123
       type: holding
       decode: int16
+    block: # 39123-39131
+      register: 39123
+      count: 9
     scale: 0.1
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -67,6 +70,9 @@ render: |
       address: 39124
       type: holding
       decode: int16
+    block: # 39123-39131
+      register: 39123
+      count: 9
     scale: 0.1
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -74,6 +80,9 @@ render: |
       address: 39125
       type: holding
       decode: int16
+    block: # 39123-39131
+      register: 39123
+      count: 9
     scale: 0.1
   currents:
   - source: modbus
@@ -82,6 +91,9 @@ render: |
       address: 39126
       type: holding
       decode: int32
+    block: # 39123-39131
+      register: 39123
+      count: 9
     scale: 0.001
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -89,6 +101,9 @@ render: |
       address: 39128
       type: holding
       decode: int32
+    block: # 39123-39131
+      register: 39123
+      count: 9
     scale: 0.001
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -96,6 +111,9 @@ render: |
       address: 39130
       type: holding
       decode: int32
+    block: # 39123-39131
+      register: 39123
+      count: 9
     scale: 0.001
   {{- end }}
   {{- if eq .usage "pv" }}

--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -60,36 +60,54 @@ render: |
         address: 39279 # PV1
         type: holding
         decode: int32
+      block: # 39279-39290
+        register: 39279
+        count: 12
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 39281 # PV2
         type: holding
         decode: int32
+      block: # 39279-39290
+        register: 39279
+        count: 12
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 39283 # PV3
         type: holding
         decode: int32
+      block: # 39279-39290
+        register: 39279
+        count: 12
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 39285 # PV4
         type: holding
         decode: int32
+      block: # 39279-39290
+        register: 39279
+        count: 12
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 39287 # PV5
         type: holding
         decode: int32
+      block: # 39279-39290
+        register: 39279
+        count: 12
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
         address: 39289 # PV6
         type: holding
         decode: int32
+      block: # 39279-39290
+        register: 39279
+        count: 12
   maxacpower: {{ .maxacpower }}
   {{- end }}
   {{- if eq .usage "battery" }}

--- a/templates/definition/meter/siemens-7kt1665.yaml
+++ b/templates/definition/meter/siemens-7kt1665.yaml
@@ -36,6 +36,9 @@ render: |
       address: 7
       type: input
       decode: uint32
+    block: # 1-12
+      register: 1
+      count: 12
     scale: 0.0001
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -43,6 +46,9 @@ render: |
       address: 9
       type: input
       decode: uint32
+    block: # 1-12
+      register: 1
+      count: 12
     scale: 0.0001
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -50,6 +56,9 @@ render: |
       address: 11
       type: input
       decode: uint32
+    block: # 1-12
+      register: 1
+      count: 12
     scale: 0.0001
   voltages:
   - source: modbus
@@ -58,6 +67,9 @@ render: |
       address: 1
       type: input
       decode: uint32
+    block: # 1-12
+      register: 1
+      count: 12
     scale: 0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -65,6 +77,9 @@ render: |
       address: 3
       type: input
       decode: uint32
+    block: # 1-12
+      register: 1
+      count: 12
     scale: 0.01
   - source: modbus
     {{- include "modbus" . | indent 2 }}
@@ -72,4 +87,7 @@ render: |
       address: 5
       type: input
       decode: uint32
+    block: # 1-12
+      register: 1
+      count: 12
     scale: 0.01

--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -88,6 +88,9 @@ render: |
             address: 31265 # SMA Modbus Profile: Metering.GridMs.WIn.phsA # Power drawn from grid phase L1, unsigned, zero if no consumption
             type: input
             decode: uint32nan
+          block: # 31259-31270
+            register: 31259
+            count: 12
           scale: 1
         - source: modbus
           {{- include "modbus" . | indent 8 }}
@@ -95,6 +98,9 @@ render: |
             address: 31259 # SMA Modbus Profile: Metering.GridMs.W.phsA # Power grid feeding L1, unsigned, zero if no feeding
             type: input
             decode: uint32nan
+          block: # 31259-31270
+            register: 31259
+            count: 12
           scale: -1
     - source: calc
       add:
@@ -104,6 +110,9 @@ render: |
             address: 31267 # SMA Modbus Profile: Metering.GridMs.WIn.phsB # Power drawn from grid phase L2, unsigned, zero if no consumption
             type: input
             decode: uint32nan
+          block: # 31259-31270
+            register: 31259
+            count: 12
           scale: 1
         - source: modbus
           {{- include "modbus" . | indent 8 }}
@@ -111,6 +120,9 @@ render: |
             address: 31261 # SMA Modbus Profile: Metering.GridMs.W.phsB # Power grid feeding L2, unsigned, zero if no feeding
             type: input
             decode: uint32nan
+          block: # 31259-31270
+            register: 31259
+            count: 12
           scale: -1
     - source: calc
       add:
@@ -120,6 +132,9 @@ render: |
             address: 31269 # SMA Modbus Profile: Metering.GridMs.WIn.phsC # Power drawn from grid phase L3, unsigned, zero if no consumption
             type: input
             decode: uint32nan
+          block: # 31259-31270
+            register: 31259
+            count: 12
           scale: 1
         - source: modbus
           {{- include "modbus" . | indent 8 }}
@@ -127,6 +142,9 @@ render: |
             address: 31263 # SMA Modbus Profile: Metering.GridMs.W.phsC # Power grid feeding L3, unsigned, zero if no feeding
             type: input
             decode: uint32nan
+          block: # 31259-31270
+            register: 31259
+            count: 12
           scale: -1
   {{- end }}
   {{- if eq .usage "pv" }}

--- a/templates/definition/meter/storaxe.yaml
+++ b/templates/definition/meter/storaxe.yaml
@@ -34,6 +34,9 @@ render: |
         address: 6 # ACVoltageL1
         type: input
         decode: int16
+      block: # 6-11
+        register: 6
+        count: 6
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -41,6 +44,9 @@ render: |
         address: 7 # ACVoltageL2
         type: input
         decode: int16
+      block: # 6-11
+        register: 6
+        count: 6
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -48,6 +54,9 @@ render: |
         address: 8 # ACVoltageL3
         type: input
         decode: int16
+      block: # 6-11
+        register: 6
+        count: 6
       scale: 0.1  
   currents:
     - source: modbus
@@ -56,6 +65,9 @@ render: |
         address: 9 # ACCurrentL1
         type: input
         decode: int16
+      block: # 6-11
+        register: 6
+        count: 6
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -63,6 +75,9 @@ render: |
         address: 10 # ACCurrentL2
         type: input
         decode: int16
+      block: # 6-11
+        register: 6
+        count: 6
       scale: 0.1
     - source: modbus
       {{- include "modbus" . | indent 4 }}
@@ -70,6 +85,9 @@ render: |
         address: 11 # ACCurrentL3
         type: input
         decode: int16
+      block: # 6-11
+        register: 6
+        count: 6
       scale: 0.1
   soc:
     source: modbus

--- a/templates/definition/meter/victron-energy.yaml
+++ b/templates/definition/meter/victron-energy.yaml
@@ -91,6 +91,9 @@ render: |
         address: 808 # ACout pv power L1
         type: input
         decode: uint16
+      block: # 808-813
+        register: 808
+        count: 6
     - source: modbus
       uri: {{ joinHostPort .host .port }}
       id: 100 # com.victronenergy.system
@@ -98,6 +101,9 @@ render: |
         address: 809 # ACout pv power L2
         type: input
         decode: uint16
+      block: # 808-813
+        register: 808
+        count: 6
     - source: modbus
       uri: {{ joinHostPort .host .port }}
       id: 100 # com.victronenergy.system
@@ -105,6 +111,9 @@ render: |
         address: 810 # ACout pv power L3
         type: input
         decode: uint16
+      block: # 808-813
+        register: 808
+        count: 6
     - source: modbus
       uri: {{ joinHostPort .host .port }}
       id: 100 # com.victronenergy.system
@@ -112,6 +121,9 @@ render: |
         address: 811 # ACin pv power L1
         type: input
         decode: uint16
+      block: # 808-813
+        register: 808
+        count: 6
     - source: modbus
       uri: {{ joinHostPort .host .port }}
       id: 100 # com.victronenergy.system
@@ -119,6 +131,9 @@ render: |
         address: 812 # ACin pv power L2
         type: input
         decode: uint16
+      block: # 808-813
+        register: 808
+        count: 6
     - source: modbus
       uri: {{ joinHostPort .host .port }}
       id: 100 # com.victronenergy.system
@@ -126,6 +141,9 @@ render: |
         address: 813 # ACin pv power L3
         type: input
         decode: uint16
+      block: # 808-813
+        register: 808
+        count: 6
     - source: modbus
       uri: {{ joinHostPort .host .port }}
       id: 100 # com.victronenergy.system

--- a/templates/definition/meter/victron-gx.yaml
+++ b/templates/definition/meter/victron-gx.yaml
@@ -63,6 +63,9 @@ render: |
         address: 3916 # L1 energy forward
         type: input
         decode: uint32
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.01
     - source: modbus
       uri: {{ joinHostPort .host .port }}
@@ -71,6 +74,9 @@ render: |
         address: 3918 # L2 energy forward
         type: input
         decode: uint32
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.01
     - source: modbus
       uri: {{ joinHostPort .host .port }}
@@ -79,6 +85,9 @@ render: |
         address: 3920 # L3 energy forward
         type: input
         decode: uint32
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.01
   currents:
     - source: modbus
@@ -88,6 +97,9 @@ render: |
         address: 3911 # L1 current
         type: input
         decode: int16
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.1
     - source: modbus
       uri: {{ joinHostPort .host .port }}
@@ -96,6 +108,9 @@ render: |
         address: 3913 # L2 current
         type: input
         decode: int16
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.1
     - source: modbus
       uri: {{ joinHostPort .host .port }}
@@ -104,6 +119,9 @@ render: |
         address: 3915 # L3 current
         type: input
         decode: int16
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.1
   voltages:
     - source: modbus
@@ -113,6 +131,9 @@ render: |
         address: 3910 # L1 voltage
         type: input
         decode: uint16
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.1
     - source: modbus
       uri: {{ joinHostPort .host .port }}
@@ -121,6 +142,9 @@ render: |
         address: 3912 # L2 voltage
         type: input
         decode: uint16
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.1
     - source: modbus
       uri: {{ joinHostPort .host .port }}
@@ -129,4 +153,7 @@ render: |
         address: 3914 # L3 voltage
         type: input
         decode: uint16
+      block: # 3910-3921
+        register: 3910
+        count: 12
       scale: 0.1


### PR DESCRIPTION
Follow-up to #31133, which introduced shared modbus block reading for `goodwe-hybrid`. Nine more meter templates issue six or more separate reads that fall inside one contiguous register range.

Declaring the enclosing `block:` lets `plugin/modbus.go` fetch the range once per poll cycle and serve every source from the shared cache: **61 reads become 9**, so 52 round trips per cycle disappear.

| template | usage | type | block | reads |
|---|---|---|---|---|
| anker-solix-x1 | grid | input | 10632 +14 | 10→1 |
| victron-gx | — | input | 3910 +12 | 9→1 |
| atmoce | grid | holding | 60089 +6 | 6→1 |
| fox-ess-avocado | grid | holding | 39123 +9 | 6→1 |
| fox-ess-h3-smart | pv | holding | 39279 +12 | 6→1 |
| siemens-7kt1665 | — | input | 1 +12 | 6→1 |
| sma-hybrid | grid | input | 31259 +12 | 6→1 |
| storaxe | — | input | 6 +6 | 6→1 |
| victron-energy | pv | input | 808 +6 | 6→1 |

**Every block here is gap-free** — each register in the range is read by some source, so no device is asked for an address it does not expose. That is stricter than the existing blocks in `goodwe-hybrid`, `deye-hybrid-3p` and `huawei-sun2000-hybrid`, which do span unread registers; I kept the tighter rule for templates I cannot test against hardware.

Verified mechanically: every block encloses its own register per `Block.Contains`, all are holding/input (`plugin/modbus.go:77`), none exceeds 125 registers, and the covered addresses exactly tile each range. `go test ./util/templates/... ./util/modbus/... ./plugin/... ./meter/...` passes.

Untested on hardware — worth a check from owners of these devices before merging.