### PR TITLE
Solplanet: hybrid inverter Modbus TCP template

### DIFF
--- a/templates/definition/meter/solplanet-modbus.yaml
+++ b/templates/definition/meter/solplanet-modbus.yaml
@@ -3,15 +3,18 @@ products:
   - brand: Solplanet
     description:
       generic: Hybrid inverter (Modbus TCP)
+  - brand: KACO
+    description:
+      generic: Blueplanet Hybrid NH3 (Modbus TCP)
 requirements:
   description:
     de: |
-      Nur für Wechselrichter mit eigenem Modbus-TCP-Ethernet-Port (z.B. ASW-TH Serie, Port eth 5&6), Protokoll AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
+      Nur für Wechselrichter mit eigenem Modbus-TCP-Ethernet-Port (z.B. ASW-TH Serie, KACO Blueplanet Hybrid NH3, Port eth 5&6), Protokoll AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
       Ältere Geräte ohne diesen Port benötigen stattdessen das `solplanet-ai-dongle` Template.
       Die Import-/Export-Zählerstände des Netzzählers (46443/46445) werden von dieser Firmware nicht über Modbus TCP bereitgestellt.
       Bei zwei Batteriepaketen (BMS1 + BMS2) je einen Batteriezähler mit Batteriespeichernummer 1 und 2 anlegen.
     en: |
-      Only for inverters with a dedicated Modbus TCP ethernet port (e.g. ASW-TH series, port eth 5&6), protocol AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
+      Only for inverters with a dedicated Modbus TCP ethernet port (e.g. ASW-TH series, KACO Blueplanet Hybrid NH3, port eth 5&6), protocol AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
       Older devices without that port need the `solplanet-ai-dongle` template instead.
       The grid meter import/export energy counters (46443/46445) are not exposed over Modbus TCP by this firmware.
       With two battery packs (BMS1 + BMS2) add one battery meter each, using battery number 1 and 2.
@@ -33,7 +36,6 @@ params:
       en: Battery number
   - preset: battery-params
   - name: maxchargepower
-    default: 5000 # fixed charge power, as in solplanet-ai-dongle
     required: true
 render: |
   type: custom

--- a/templates/definition/meter/solplanet-modbus.yaml
+++ b/templates/definition/meter/solplanet-modbus.yaml
@@ -26,14 +26,15 @@ params:
   - name: battery
     type: choice
     choice: [1, 2]
-    default: 1
+    required: true
     usages: ["battery"]
     description:
       de: Batteriespeichernummer
       en: Battery number
   - preset: battery-params
   - name: maxchargepower
-    default: 5000
+    default: 5000 # fixed charge power, as in solplanet-ai-dongle
+    required: true
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -129,14 +130,14 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: {{ if eq .battery "1" }}1618{{ else }}1751{{ end }} # 31619/31752 BMS1/2 battery power
+      address: {{ if eq .battery "2" }}1751{{ else }}1618{{ end }} # 31752/31619 BMS2/1 battery power
       type: input
       decode: int32
   soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: {{ if eq .battery "1" }}1621{{ else }}1754{{ end }} # 31622/31755 BMS1/2 battery SoC
+      address: {{ if eq .battery "2" }}1754{{ else }}1621{{ end }} # 31755/31622 BMS2/1 battery SoC
       type: input
       decode: uint16
   batterymode:

--- a/templates/definition/meter/solplanet-modbus.yaml
+++ b/templates/definition/meter/solplanet-modbus.yaml
@@ -9,12 +9,12 @@ requirements:
       Nur für Wechselrichter mit eigenem Modbus-TCP-Ethernet-Port (z.B. ASW-TH Serie, Port eth 5&6), Protokoll AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
       Ältere Geräte ohne diesen Port benötigen stattdessen das `solplanet-ai-dongle` Template.
       Die Import-/Export-Zählerstände des Netzzählers (46443/46445) werden von dieser Firmware nicht über Modbus TCP bereitgestellt.
-      Bei zwei Batteriepaketen (BMS1 + BMS2) die Option "Zweites Batteriepaket" aktivieren, sonst wird nur BMS1 erfasst.
+      Bei zwei Batteriepaketen (BMS1 + BMS2) je einen Batteriezähler mit Batteriespeichernummer 1 und 2 anlegen.
     en: |
       Only for inverters with a dedicated Modbus TCP ethernet port (e.g. ASW-TH series, port eth 5&6), protocol AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
       Older devices without that port need the `solplanet-ai-dongle` template instead.
       The grid meter import/export energy counters (46443/46445) are not exposed over Modbus TCP by this firmware.
-      With two battery packs (BMS1 + BMS2) enable the "second battery pack" option, otherwise only BMS1 is counted.
+      With two battery packs (BMS1 + BMS2) add one battery meter each, using battery number 1 and 2.
 capabilities: ["battery-control", "curtail"]
 params:
   - name: usage
@@ -23,21 +23,21 @@ params:
     choice: ["tcpip"]
     port: 502
     id: 1
-  - name: battery2
-    type: bool
-    advanced: true
+  - name: battery
+    type: choice
+    choice: [1, 2]
+    default: 1
     usages: ["battery"]
     description:
-      de: Zweites Batteriepaket (BMS2)
-      en: Second battery pack (BMS2)
-    help:
-      de: Aktivieren wenn ein zweites Batteriepaket installiert ist. Kapazität als Summe beider Pakete angeben.
-      en: Enable if a second battery pack is installed. Enter the capacity as the sum of both packs.
+      de: Batteriespeichernummer
+      en: Battery number
   - preset: battery-params
+  - name: maxchargepower
+    default: 5000
 render: |
   type: custom
   {{- if eq .usage "grid" }}
-  power: # power (W)
+  power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -46,14 +46,14 @@ render: |
       decode: int32
   {{- end }}
   {{- if eq .usage "pv" }}
-  power: # power (W)
+  power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
       address: 1600 # 31601 PV total power
       type: input
       decode: uint32
-  energy: # energy (kWh)
+  energy:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
@@ -64,38 +64,31 @@ render: |
   curtail: # allowed feed-in power as percent of nominal
     source: sequence
     set:
-      # 45403 active power set (%Pn * 100)
       - source: modbus
         {{- include "modbus" . | indent 6 }}
         register:
-          address: 5402
+          address: 5402 # 45403 active power set (%Pn * 100)
           type: writesingle
           encoding: uint16
         scale: 100
-      # 44001 active power control: disabled at 100% (unlimited), enabled while curtailed
+      # active power control: disabled at 100% (unlimited), enabled while curtailed
       - source: switch
         switch:
           - case: 100 # uncurtailed
             set:
               source: const
               value: 0
-              set:
+              set: &enable
                 source: modbus
                 {{- include "modbus" . | indent 14 }}
                 register:
-                  address: 4000
+                  address: 4000 # 44001 active power control function
                   type: writesingle
                   encoding: uint16
         default:
           source: const
           value: 1
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 4000
-              type: writesingle
-              encoding: uint16
+          set: *enable
   curtailed: # the power limit only applies while active power control is enabled
     source: go
     in:
@@ -105,7 +98,7 @@ render: |
           source: modbus
           {{- include "modbus" . | indent 8 }}
           register:
-            address: 4000 # 44001 active power control function
+            address: 4000
             type: holding
             decode: uint16
       - name: percent
@@ -114,7 +107,7 @@ render: |
           source: modbus
           {{- include "modbus" . | indent 8 }}
           register:
-            address: 5402 # 45403 active power set (%Pn * 100)
+            address: 5402
             type: holding
             decode: uint16
           scale: 0.01
@@ -126,56 +119,20 @@ render: |
       res
   {{- end }}
   {{- if eq .usage "battery" }}
-  power: # power (W)
-    {{- if .battery2 }}
-    source: calc
-    add:
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 1618 # 31619 BMS1 battery power
-          type: input
-          decode: int32
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 1751 # 31752 BMS2 battery power
-          type: input
-          decode: int32
-    {{- else }}
+  power:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 1618 # 31619 BMS1 battery power
+      address: {{ if eq .battery "1" }}1618{{ else }}1751{{ end }} # 31619/31752 BMS1/2 battery power
       type: input
       decode: int32
-    {{- end }}
-  soc: # state of charge (%)
-    {{- if .battery2 }}
-    source: calc # mean of both packs
-    add:
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 1621 # 31622 BMS1 battery SoC
-          type: input
-          decode: uint16
-        scale: 0.5
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 1754 # 31755 BMS2 battery SoC
-          type: input
-          decode: uint16
-        scale: 0.5
-    {{- else }}
+  soc:
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 1621 # 31622 BMS1 battery SoC
+      address: {{ if eq .battery "1" }}1621{{ else }}1754{{ end }} # 31622/31755 BMS1/2 battery SoC
       type: input
       decode: uint16
-    {{- end }}
   batterymode:
     source: switch
     switch:
@@ -190,7 +147,7 @@ render: |
               address: 1103 # 41104 battery working mode
               type: writesingle
               encoding: uint16
-      - case: 2 # hold - custom mode, 0 W
+      - case: 2 # hold
         set:
           source: sequence
           set:
@@ -209,18 +166,18 @@ render: |
                 source: modbus
                 {{- include "modbus" . | indent 14 }}
                 register:
-                  address: 1152 # 41153 charge/discharge power (negative charges)
+                  address: 1152 # 41153 charge/discharge power, negative charges
                   type: writesingle
                   encoding: int16
-      - case: 3 # charge - custom mode, max charge power
+      - case: 3 # charge
         set:
           source: sequence
           set:
             - source: const
-              value: 4 # custom
+              value: 4
               set: *mode
             - source: const
-              value: {{ mul .maxchargepower -1 }} # negative implies charging
+              value: {{ mul .maxchargepower -1 }}
               set: *setpoint
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solplanet-modbus.yaml
+++ b/templates/definition/meter/solplanet-modbus.yaml
@@ -1,0 +1,226 @@
+template: solplanet-modbus
+products:
+  - brand: Solplanet
+    description:
+      generic: Hybrid inverter (Modbus TCP)
+requirements:
+  description:
+    de: |
+      Nur für Wechselrichter mit eigenem Modbus-TCP-Ethernet-Port (z.B. ASW-TH Serie, Port eth 5&6), Protokoll AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
+      Ältere Geräte ohne diesen Port benötigen stattdessen das `solplanet-ai-dongle` Template.
+      Die Import-/Export-Zählerstände des Netzzählers (46443/46445) werden von dieser Firmware nicht über Modbus TCP bereitgestellt.
+      Bei zwei Batteriepaketen (BMS1 + BMS2) die Option "Zweites Batteriepaket" aktivieren, sonst wird nur BMS1 erfasst.
+    en: |
+      Only for inverters with a dedicated Modbus TCP ethernet port (e.g. ASW-TH series, port eth 5&6), protocol AISWEI "MB001_ASW GEN-Modbus" V2.1.7.
+      Older devices without that port need the `solplanet-ai-dongle` template instead.
+      The grid meter import/export energy counters (46443/46445) are not exposed over Modbus TCP by this firmware.
+      With two battery packs (BMS1 + BMS2) enable the "second battery pack" option, otherwise only BMS1 is counted.
+capabilities: ["battery-control", "curtail"]
+params:
+  - name: usage
+    choice: ["grid", "pv", "battery"]
+  - name: modbus
+    choice: ["tcpip"]
+    port: 502
+    id: 1
+  - name: battery2
+    type: bool
+    advanced: true
+    usages: ["battery"]
+    description:
+      de: Zweites Batteriepaket (BMS2)
+      en: Second battery pack (BMS2)
+    help:
+      de: Aktivieren wenn ein zweites Batteriepaket installiert ist. Kapazität als Summe beider Pakete angeben.
+      en: Enable if a second battery pack is installed. Enter the capacity as the sum of both packs.
+  - preset: battery-params
+render: |
+  type: custom
+  {{- if eq .usage "grid" }}
+  power: # power (W)
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 6433 # 46434 total system power (smart meter)
+      type: holding
+      decode: int32
+  {{- end }}
+  {{- if eq .usage "pv" }}
+  power: # power (W)
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 1600 # 31601 PV total power
+      type: input
+      decode: uint32
+  energy: # energy (kWh)
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 1604 # 31605 PV E-Total (0.1 kWh)
+      type: input
+      decode: uint32
+    scale: 0.1
+  curtail: # allowed feed-in power as percent of nominal
+    source: sequence
+    set:
+      # 45403 active power set (%Pn * 100)
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 5402
+          type: writesingle
+          encoding: uint16
+        scale: 100
+      # 44001 active power control: disabled at 100% (unlimited), enabled while curtailed
+      - source: switch
+        switch:
+          - case: 100 # uncurtailed
+            set:
+              source: const
+              value: 0
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 4000
+                  type: writesingle
+                  encoding: uint16
+        default:
+          source: const
+          value: 1
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 4000
+              type: writesingle
+              encoding: uint16
+  curtailed: # the power limit only applies while active power control is enabled
+    source: go
+    in:
+      - name: ena
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 4000 # 44001 active power control function
+            type: holding
+            decode: uint16
+      - name: percent
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 5402 # 45403 active power set (%Pn * 100)
+            type: holding
+            decode: uint16
+          scale: 0.01
+    script: |
+      res := 100
+      if ena != 0 && percent > 0 && percent < 100 {
+        res = percent
+      }
+      res
+  {{- end }}
+  {{- if eq .usage "battery" }}
+  power: # power (W)
+    {{- if .battery2 }}
+    source: calc
+    add:
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 1618 # 31619 BMS1 battery power
+          type: input
+          decode: int32
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 1751 # 31752 BMS2 battery power
+          type: input
+          decode: int32
+    {{- else }}
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 1618 # 31619 BMS1 battery power
+      type: input
+      decode: int32
+    {{- end }}
+  soc: # state of charge (%)
+    {{- if .battery2 }}
+    source: calc # mean of both packs
+    add:
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 1621 # 31622 BMS1 battery SoC
+          type: input
+          decode: uint16
+        scale: 0.5
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 1754 # 31755 BMS2 battery SoC
+          type: input
+          decode: uint16
+        scale: 0.5
+    {{- else }}
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 1621 # 31622 BMS1 battery SoC
+      type: input
+      decode: uint16
+    {{- end }}
+  batterymode:
+    source: switch
+    switch:
+      - case: 1 # normal
+        set:
+          source: const
+          value: 2 # normal
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 1103 # 41104 battery working mode
+              type: writesingle
+              encoding: uint16
+      - case: 2 # hold - custom mode, 0 W
+        set:
+          source: sequence
+          set:
+            - source: const
+              value: 4 # custom
+              set: &mode
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 1103
+                  type: writesingle
+                  encoding: uint16
+            - source: const
+              value: 0
+              set: &setpoint
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 1152 # 41153 charge/discharge power (negative charges)
+                  type: writesingle
+                  encoding: int16
+      - case: 3 # charge - custom mode, max charge power
+        set:
+          source: sequence
+          set:
+            - source: const
+              value: 4 # custom
+              set: *mode
+            - source: const
+              value: {{ mul .maxchargepower -1 }} # negative implies charging
+              set: *setpoint
+  {{- include "battery-params" . }}
+  {{- end }}

--- a/templates/definition/meter/solplanet-modbus.yaml
+++ b/templates/definition/meter/solplanet-modbus.yaml
@@ -78,7 +78,7 @@ render: |
             set:
               source: const
               value: 0
-              set: &enable
+              set:
                 source: modbus
                 {{- include "modbus" . | indent 14 }}
                 register:
@@ -88,7 +88,13 @@ render: |
         default:
           source: const
           value: 1
-          set: *enable
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 4000
+              type: writesingle
+              encoding: uint16
   curtailed: # the power limit only applies while active power control is enabled
     source: go
     in:
@@ -153,7 +159,7 @@ render: |
           set:
             - source: const
               value: 4 # custom
-              set: &mode
+              set:
                 source: modbus
                 {{- include "modbus" . | indent 14 }}
                 register:
@@ -162,7 +168,7 @@ render: |
                   encoding: uint16
             - source: const
               value: 0
-              set: &setpoint
+              set:
                 source: modbus
                 {{- include "modbus" . | indent 14 }}
                 register:
@@ -175,9 +181,21 @@ render: |
           set:
             - source: const
               value: 4
-              set: *mode
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 1103
+                  type: writesingle
+                  encoding: uint16
             - source: const
               value: {{ mul .maxchargepower -1 }}
-              set: *setpoint
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 14 }}
+                register:
+                  address: 1152
+                  type: writesingle
+                  encoding: int16
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solplanet-modbus.yaml
+++ b/templates/definition/meter/solplanet-modbus.yaml
@@ -3,9 +3,6 @@ products:
   - brand: Solplanet
     description:
       generic: Hybrid inverter (Modbus TCP)
-  - brand: KACO
-    description:
-      generic: Blueplanet Hybrid NH3 (Modbus TCP)
 requirements:
   description:
     de: |


### PR DESCRIPTION
Adds a Modbus TCP meter template for newer Solplanet/AISWEI inverters (ASW-TH series) that expose a dedicated Modbus ethernet port (eth 5&6), protocol AISWEI `MB001_ASW GEN-Modbus` V2.1.7.

Register map contributed and verified on an ASW-25K-TH by @CHAPV in https://github.com/evcc-io/evcc/discussions/17680#discussioncomment-18037580.

### vs. the existing `solplanet-ai-dongle` template

Complementary, not a replacement — older devices have no Modbus port and still need the dongle template.

| | ai-dongle | this |
|---|---|---|
| transport | HTTP `:8484` + raw Modbus frames via `fdbg.cgi` | native Modbus TCP `:502` |
| extra param | inverter serial (`isn`) | none |
| pv energy | – | ✅ |
| curtail (§9) | – | ✅ |
| battery | BMS1 only | BMS1 or BMS2, selectable |
| grid energy | available via HTTP (not mapped) | not exposed by this firmware |

### Notes

- The contributed config hardcoded the reporter's installation (uri, `capacity: 30.72`, curtail `scale: 91.2` = 100 × 22800/25000). Replaced by the `modbus` and `battery-params` presets and a generic `scale: 100` (register is %Pn × 100).
- Two battery packs are configured as two battery meters via a battery number choice, as in `goodwe-hybrid`, so each pack reports its own capacity and SoC.
- `maxchargepower` needs an explicit default — the `battery-params` preset has none, which would render the force charge setpoint as 0 W.
- `batterymode` uses registers 1103 (mode 2 = normal, 4 = custom) and 1152 (setpoint, negative = charge), decoded from the `fdbg.cgi` frames the ai-dongle template already ships, instead of the 1151 flag register from the discussion whose hold/charge semantics the reporter flagged as unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)