### PR TITLE
Loadpoint: don't discard a pending scale-down when the vehicle stops drawing

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1470,7 +1470,7 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 
 	if scalable {
 		// negative site power while charging means the vehicle is not utilizing the offered
-		// current (#9581) - unless it stopped drawing with a scale-down already pending (#32815)
+		// current unless it stopped drawing with a scale-down already pending
 		pending := !lp.charging() && !lp.phaseTimer.IsZero()
 
 		insufficient := (sitePower > 0 || !lp.enabled || pending) && powerToCurrent(availablePower, activePhases) < minCurrent

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1469,7 +1469,11 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 	scalable := activePhases > 1 && lp.phasesConfigured < 3
 
 	if scalable {
-		insufficient := (sitePower > 0 || !lp.enabled) && powerToCurrent(availablePower, activePhases) < minCurrent
+		// negative site power while charging means the vehicle is not utilizing the offered
+		// current (#9581) - unless it stopped drawing with a scale-down already pending (#32815)
+		pending := !lp.charging() && !lp.phaseTimer.IsZero()
+
+		insufficient := (sitePower > 0 || !lp.enabled || pending) && powerToCurrent(availablePower, activePhases) < minCurrent
 		if insufficient {
 			lp.log.DEBUG.Printf("available power %.0fW < %.0fW min %dp threshold", availablePower, float64(activePhases)*Voltage*minCurrent, activePhases)
 		}

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -376,6 +376,22 @@ func TestPvScalePhasesTimer(t *testing.T) {
 		{"3/0->1, not enough power, not charging", 3, 0, 0, 1, 1, func(lp *Loadpoint) {
 			lp.status = api.StatusB
 		}},
+		// vehicle stops drawing while a scale-down is pending: complete it (#32815)
+		{"3/3->1, surplus below 3p min, scale1p pending, vehicle stopped", 3, 3, -1.5 * Voltage * minA, 1, 1, func(lp *Loadpoint) {
+			lp.status = api.StatusB
+			lp.enabled = true
+			lp.phaseTimer = lp.clock.Now()
+		}},
+		// idle vehicle without pending scale-down: don't scale on fluctuating surplus (#32815)
+		{"3/3->1, surplus below 3p min, no timer, vehicle idle", 3, 3, -1.5 * Voltage * minA, 3, 0, func(lp *Loadpoint) {
+			lp.status = api.StatusB
+			lp.enabled = true
+		}},
+		// same surplus while charging: vehicle is not utilizing the offered current (#9581)
+		{"3/3->1, surplus below 3p min, charging", 3, 3, -1.5 * Voltage * minA, 3, 0, func(lp *Loadpoint) {
+			lp.phaseTimer = elapsed
+			lp.enabled = true
+		}},
 		// switch up from 1p/0p while not yet charging
 		{"1/0->3, enough power, not charging", 1, 0, -3 * Voltage * minA, 3, 3, func(lp *Loadpoint) {
 			lp.status = api.StatusB


### PR DESCRIPTION
Refs #32815.

### Problem

When the vehicle stops drawing current on its own while the loadpoint is still enabled, a pending scale-down is discarded and evcc stays at 3p, even though the remaining surplus would be plenty for 1p charging.

From the reporter's log (Alfen 1p3p + Tesla, PV mode):

```
15:46:27  available power 3290W < 3450W min 3p threshold
15:46:27  start phase scale1p timer / phase scale1p in 3m0s
15:46:28  set charge current limit: 5A          (was 6.21A, clamped to minCurrent)
15:46:56  charger status: C -> B, charge power 0W   <- vehicle quits
15:46:58  phase timer inactive                  <- scale1p timer discarded
15:47..15:51  status B, 3p, 2.5-4.1 kW surplus exported, pv charge current 3.7-6A @3p
              -> never scales to 1p, never disables, vehicle never restarts
15:51:22  set phases: 1  (manually, by the user)
15:51:31  pv charge current: 10.2A @1p
15:51:57  charger status: C                     <- charging resumes
```

Once the vehicle stops, `sitePower` is necessarily negative (the surplus is no longer consumed), so the guard added in c369817d (#9581)

```go
insufficient := (sitePower > 0 || !lp.enabled) && powerToCurrent(availablePower, activePhases) < minCurrent
```

evaluates to false, `resetPhaseTimer()` runs and the switch that was already scheduled never happens. Since evcc also won't disable while there is surplus, the loadpoint is stuck at 3p / minCurrent until the user intervenes.

Vehicles dropping out at exactly this point is not a coincidence: the timer starts when available power falls below the 3p minimum, which is also when the offered current gets reduced towards `minCurrent`.

### Fix

The #9581 guard is correct while the vehicle is charging: negative site power then means the vehicle is not utilizing the offered current, and available power is not a meaningful indicator. But once a scale-down is already pending, the vehicle dropping out should not discard it — available power is then the actual surplus.

```go
pending := !lp.charging() && !lp.phaseTimer.IsZero()

insufficient := (sitePower > 0 || !lp.enabled || pending) && powerToCurrent(availablePower, activePhases) < minCurrent
```

Tying the exception to an already running timer deliberately keeps the behaviour narrow: a connected vehicle that never charges at all never starts the timer, so it never causes phase switching on fluctuating surplus. That matters because the scale-up and scale-down thresholds coincide while not charging and both bypass their timers (`if !lp.charging() { lp.phaseTimer = elapsed }`) — an unconditional exception here would let an idle vehicle flap phases with every passing cloud.

### Tests

`TestPvScalePhasesTimer` had no case for status B with `enabled == true` (the existing not-charging case runs with `enabled == false` and therefore passed through `!lp.enabled`). Added three:

- surplus below the 3p minimum, scale1p pending, vehicle stopped → scales to 1p (fails on master)
- same, but no timer running → stays at 3p (idle vehicle, no flapping)
- same surplus while charging → stays at 3p (guards the #9581 behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
