### PR TITLE
Panasonic Aquarea (HeishaMon): add heating template

### DIFF
--- a/templates/definition/charger/heishamon.yaml
+++ b/templates/definition/charger/heishamon.yaml
@@ -28,18 +28,6 @@ params:
     advanced: true
     type: duration
     default: 5m
-  - preset: switchsocket
-  - name: heating
-    advanced: true
-    type: bool
-    default: true
-  - name: integrateddevice
-    advanced: true
-    type: bool
-    default: true
-  - name: icon
-    advanced: true
-    default: heatpump
 render: |
   type: switchsocket
   enabled:
@@ -62,4 +50,9 @@ render: |
     source: mqtt
     topic: {{ .topic }}/main/DHW_Target_Temp
     timeout: {{ .timeout }}
-  {{ include "switchsocket" . }}
+  standbypower: 15
+  features:
+    - switchdevice
+    - integrateddevice
+    - heating
+  icon: heatpump

--- a/templates/definition/charger/heishamon.yaml
+++ b/templates/definition/charger/heishamon.yaml
@@ -1,0 +1,65 @@
+template: heishamon
+products:
+  - brand: Panasonic
+    description:
+      generic: Aquarea (HeishaMon)
+capabilities: ["meter"]
+group: heating
+requirements:
+  description:
+    de: |
+      Warmwasserbereitung einer Panasonic Aquarea Wärmepumpe über [HeishaMon](https://github.com/HeishaMon/HeishaMon).
+
+      Voraussetzung ist ein konfigurierter MQTT Broker. Das Schreiben von Befehlen erfordert die Optional-PCB-Emulation von HeishaMon (`SetOptionalPCB`), im Listen-Only-Betrieb kann die Wärmepumpe nur gelesen werden.
+    en: |
+      Domestic hot water of a Panasonic Aquarea heat pump via [HeishaMon](https://github.com/HeishaMon/HeishaMon).
+
+      Requires a configured MQTT broker. Writing commands requires HeishaMon's optional PCB emulation (`SetOptionalPCB`), in listen-only mode the heat pump can only be read.
+params:
+  - name: topic
+    default: panasonic_heat_pump
+    description:
+      de: MQTT Topic
+      en: MQTT topic
+    help:
+      de: Basis-Topic von HeishaMon
+      en: Base topic of HeishaMon
+  - name: timeout
+    advanced: true
+    type: duration
+    default: 5m
+  - preset: switchsocket
+  - name: heating
+    advanced: true
+    type: bool
+    default: true
+  - name: integrateddevice
+    advanced: true
+    type: bool
+    default: true
+  - name: icon
+    advanced: true
+    default: heatpump
+render: |
+  type: switchsocket
+  enabled:
+    source: mqtt
+    topic: {{ .topic }}/main/Force_DHW_State
+    timeout: {{ .timeout }}
+  enable:
+    source: mqtt
+    topic: {{ .topic }}/commands/SetForceDHW
+    payload: ${enable:%d}
+  power:
+    source: mqtt
+    topic: {{ .topic }}/main/DHW_Power_Consumption
+    timeout: {{ .timeout }}
+  temp:
+    source: mqtt
+    topic: {{ .topic }}/main/DHW_Temp
+    timeout: {{ .timeout }}
+  limittemp:
+    source: mqtt
+    topic: {{ .topic }}/main/DHW_Target_Temp
+    timeout: {{ .timeout }}
+  {{ include "switchsocket" . }}

--- a/templates/definition/charger/heishamon.yaml
+++ b/templates/definition/charger/heishamon.yaml
@@ -12,7 +12,7 @@ requirements:
 
       Voraussetzung ist ein konfigurierter MQTT Broker. Das Schreiben von Befehlen erfordert die Optional-PCB-Emulation von HeishaMon (`SetOptionalPCB`), im Listen-Only-Betrieb kann die Wärmepumpe nur gelesen werden.
     en: |
-      Domestic hot water of a Panasonic Aquarea heat pump via [HeishaMon](https://github.com/HeishaMon/HeishaMon).
+      Domestic hot water for a Panasonic Aquarea heat pump via [HeishaMon](https://github.com/HeishaMon/HeishaMon).
 
       Requires a configured MQTT broker. Writing commands requires HeishaMon's optional PCB emulation (`SetOptionalPCB`), in listen-only mode the heat pump can only be read.
 params:


### PR DESCRIPTION
Integrates Panasonic Aquarea heat pumps via [HeishaMon](https://github.com/HeishaMon/HeishaMon) MQTT, without the detour through Home Assistant. Closes #32885 for the hot water part.

Domestic hot water only:

| evcc | topic |
| --- | --- |
| `enabled` | `<topic>/main/Force_DHW_State` |
| `enable` | `<topic>/commands/SetForceDHW` (0/1) |
| `power` | `<topic>/main/DHW_Power_Consumption` |
| `temp` | `<topic>/main/DHW_Temp` |
| `limittemp` | `<topic>/main/DHW_Target_Temp` |

- No SG-Ready/dimming. HeishaMon has no smart-grid contacts, quiet/powerful mode is not a power limit.
- No heating circuit control. Only the DHW side is switched, the heating curve stays with the heat pump.
- Writing requires HeishaMon's optional PCB emulation, listen-only setups can read but not control. Stated in the template requirements.
- Base topic is a parameter, HeishaMon's default `panasonic_heat_pump` is preset.

Untested on real hardware, topics taken from HeishaMon's `MQTT-Topics.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)