### PR TITLE
Optimizer: drop GetChargedEnergy from loadpoint API

### DIFF
--- a/core/optimizer.md
+++ b/core/optimizer.md
@@ -47,3 +47,7 @@ Use minimum of energy consumption cost.
 - home battery or loadpoint/vehicle...
   - capacity, soc and charge goals
   - charge/discharge power limits and efficiency
+
+Without vehicle capacity or soc a configured session energy limit is modelled instead:
+the battery starts empty and the limit is the goal. Loadpoints with neither are not
+modelled at all- their power is added to the base load.

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -522,8 +522,9 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 			continue
 		}
 
-		// unknown vehicle capacity: account for the consumption as uncontrollable load
-		if v := lp.GetVehicle(); v == nil || v.Capacity() == 0 {
+		// no vehicle capacity and no session energy limit to model against:
+		// account for the consumption as uncontrollable load
+		if v := lp.GetVehicle(); v == nil || (v.Capacity() == 0 && lp.GetLimitEnergy() == 0) {
 			unmodelled += unmodelledPower(lp)
 			continue
 		}
@@ -790,18 +791,21 @@ func (site *Site) loadpointRequest(lp loadpoint.API, minLen int, firstSlotDurati
 	// vehicle
 	v := lp.GetVehicle()
 
-	maxSoc := v.Capacity() * 1e3 // Wh
-	if v := lp.EffectiveLimitSoc(); v > 0 {
-		maxSoc *= float64(v) / 100
-	} else if v := lp.GetLimitEnergy(); v > 0 {
-		maxSoc = v * 1e3
+	capacity := v.Capacity() // kWh
+	soc := lp.GetSoc()       // percent
+
+	// without capacity or soc there is no battery state to model, but a session energy
+	// limit still bounds the charge- start empty and use the limit as goal
+	if limit := lp.GetLimitEnergy(); limit > 0 && (capacity == 0 || soc == 0) {
+		bat.SMax = float32(limit * 1e3) // Wh, SInitial remains 0
+	} else {
+		maxSoc := capacity * float64(lp.EffectiveLimitSoc()) * 10 // Wh
+		bat.SInitial = float32(capacity * soc * 10)               // Wh
+		bat.SMax = max(bat.SInitial, float32(maxSoc))             // prevent infeasible if current soc above maximum
 	}
 
-	bat.SInitial = float32(v.Capacity() * lp.GetSoc() * 10) // Wh
-	bat.SMax = max(bat.SInitial, float32(maxSoc))           // prevent infeasible if current soc above maximum
-
 	detail.Type = batteryTypeVehicle
-	detail.Capacity = v.Capacity()
+	detail.Capacity = capacity
 
 	if vt := v.GetTitle(); vt != "" {
 		if detail.Title != "" {

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -320,6 +320,51 @@ func TestBatteryRequestSocLimitsClamp(t *testing.T) {
 	})
 }
 
+// charge goal for vehicles with and without known capacity/soc, see #32890
+func TestLoadpointRequestChargeGoal(t *testing.T) {
+	site := &Site{log: util.NewLogger("foo")}
+
+	for _, tc := range []struct {
+		name                  string
+		capacity, soc         float64 // kWh, percent
+		limitSoc              int     // percent
+		limitEnergy           float64 // kWh
+		wantInitial, wantSMax float32 // Wh
+	}{
+		{"soc limit", 50, 20, 80, 0, 10000, 40000},
+		{"no capacity, energy limit", 0, 0, 100, 10, 0, 10000},
+		{"capacity but no soc, energy limit", 50, 0, 100, 10, 0, 10000},
+		{"capacity but no soc, no energy limit", 50, 0, 100, 0, 0, 50000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			v := api.NewMockVehicle(ctrl)
+			v.EXPECT().Capacity().Return(tc.capacity).AnyTimes()
+			v.EXPECT().GetTitle().Return("").AnyTimes()
+
+			lp := loadpoint.NewMockAPI(ctrl)
+			lp.EXPECT().GetVehicle().Return(v).AnyTimes()
+			lp.EXPECT().GetSoc().Return(tc.soc).AnyTimes()
+			lp.EXPECT().EffectiveLimitSoc().Return(tc.limitSoc).AnyTimes()
+			lp.EXPECT().GetLimitEnergy().Return(tc.limitEnergy).AnyTimes()
+			lp.EXPECT().GetTitle().Return("lp").AnyTimes()
+			lp.EXPECT().EffectiveMinPower().Return(1380.0).AnyTimes()
+			lp.EXPECT().EffectiveMaxPower().Return(11000.0).AnyTimes()
+			lp.EXPECT().GetMode().Return(api.ModePV).AnyTimes()
+			lp.EXPECT().GetStatus().Return(api.StatusB).AnyTimes()
+			lp.EXPECT().GetSmartCostLimit().Return(nil).AnyTimes()
+			lp.EXPECT().EffectivePlanStrategy().Return(api.PlanStrategy{}).AnyTimes()
+			lp.EXPECT().GetPlanGoal().Return(0.0, false).AnyTimes()
+
+			req, _ := site.loadpointRequest(lp, 8, 15*time.Minute, nil)
+
+			assert.Equal(t, tc.wantInitial, req.SInitial)
+			assert.Equal(t, tc.wantSMax, req.SMax)
+		})
+	}
+}
+
 func TestOptimizerChargingStrategy(t *testing.T) {
 	site := &Site{log: util.NewLogger("foo")}
 


### PR DESCRIPTION
Follow-up to #32895.

The optimizer only needs the charge *headroom*, not an absolute battery state — for a loadpoint `SMin` is 0 and `SCapacity` unset. So an energy-limited session can start from an empty battery with the limit as goal, which removes the `GetChargedEnergy()` addition to `loadpoint.API` again (mock regenerated).

```go
if limit := lp.GetLimitEnergy(); limit > 0 && (capacity == 0 || soc == 0) {
    bat.SMax = float32(limit * 1e3) // Wh, SInitial remains 0
}
```

Tradeoff: mid-session the goal is no longer reduced by the energy already charged, so the plan can schedule more than needed until the session ends. The charging loop still stops at the limit either way.

If the mid-session accuracy is wanted without growing the API, the alternative is filling the existing `GetRemainingEnergy()` from `remainingLimitEnergy()` in `publishSocAndRange` — it is currently 0 for energy-limited sessions, which also leaves `hems/shm` `maxEnergy` at 0. Happy to do that instead.