### PR TITLE
Add Ocular IQ Home to OCPP template

### DIFF
--- a/templates/definition/charger/ocpp.yaml
+++ b/templates/definition/charger/ocpp.yaml
@@ -3,6 +3,9 @@ products:
   - description:
       de: OCPP 1.6J kompatibel
       en: OCPP 1.6J compatible
+  - brand: Ocular
+    description:
+      generic: IQ Home
 group: generic
 capabilities: ["mA", "rfid", "1p3p", "dim"]
 requirements:


### PR DESCRIPTION
Closes #32575

Reported working with the generic OCPP 1.6J template, no device-specific settings needed — so listing the product on the plain `ocpp` template rather than adding a dedicated `ocpp-*` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)