### PR TITLE
Sponsor: include device serial in hardware check metadata

### DIFF
--- a/util/sponsor/hemspro_linux.go
+++ b/util/sponsor/hemspro_linux.go
@@ -20,10 +20,22 @@ package sponsor
 // SOFTWARE.
 
 import (
+	"os"
+	"strings"
+
 	i2c "github.com/d2r2/go-i2c"
 )
 
 const hemspro = "hemspro"
+
+// deviceSerial returns the device tree serial number or empty string
+func deviceSerial() string {
+	b, err := os.ReadFile("/sys/firmware/devicetree/base/serial-number")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.Trim(string(b), "\x00"))
+}
 
 // checkHemsPro checks if the hardware is a supported HEMS Pro device and returns sponsor subject
 func checkHemsPro() string {
@@ -49,5 +61,7 @@ func checkHemsPro() string {
 	}
 
 	// I2C succeeded — verify with server
-	return checkHardware(hemspro, nil)
+	return checkHardware(hemspro, map[string]string{
+		"serial": deviceSerial(),
+	})
 }


### PR DESCRIPTION
Report the device tree serial number as additional metadata during the hardware check. Helps identifying individual devices.

- read serial from `/sys/firmware/devicetree/base/serial-number`
- send as `serial` metadata field, empty if unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)