### PR TITLE
Fix site.pvPower estimation for battery without pv

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -1054,9 +1054,9 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 		residualPower = 100 // W
 	}
 
-	// allow using grid and charge as estimate for pv power
+	// allow using grid, charge and battery power as estimate for pv power
 	if site.pvMeters == nil {
-		site.pvPower = totalChargePower - site.gridPower + residualPower
+		site.pvPower = totalChargePower - site.gridPower - site.battery.Power + residualPower
 		if site.pvPower < 0 {
 			site.pvPower = 0
 		}

--- a/core/site.go
+++ b/core/site.go
@@ -1055,7 +1055,8 @@ func (site *Site) sitePower(totalChargePower, flexiblePower float64) (float64, b
 	}
 
 	// allow using grid, charge and battery power as estimate for pv power
-	if site.pvMeters == nil {
+	// needs a grid meter, otherwise grid power is itself derived from pv power (see above)
+	if site.pvMeters == nil && site.gridMeter != nil {
 		site.pvPower = totalChargePower - site.gridPower - site.battery.Power + residualPower
 		if site.pvPower < 0 {
 			site.pvPower = 0


### PR DESCRIPTION
Resolves:
- #32807
- #32808  

This specific issue only occurs when a battery is connected to EVCC, but no solar inverter.
This means EVCC still relies on creating it's own estimate of solar production.

## Root of the issue

It looks like site.pvPower means a different thing depending on if it's estimated or taken from the inverter directly.
When an inverter is connected to EVCC, pvPower is simply the production reported by the inverter.
When estimated, pvPower represents `pvPower = production - energy going into the battery`

So if I have:
- 1kw solar production
- 1kw going into home battery.

then we would have:

Without inverter connected: pvPower = 0
with inverter connected: pvPower = 1kw

The way pvPower is used, in code, it's always assumed to mean "production".
For example:  
`homePower := site.gridPower + max(0, site.pvPower) + site.battery.Power - totalChargePower`  


But this makes homePower wrong in cases where pvPower is estimated, as estimated pvPower already has the battery power added to it.

## The fix
The cleanest fix seems to be to make `pvPower` always mean the same thing, `production`.
We can simply make it:
`pvPower = totalChargePower - site.gridPower + residualPower - batteryPower`  
to achieve this. Only "- batteryPower" is added to this existing formula.
This will make the estimate accurate whether batteries are charging or discharging. If the battery is charging from grid, it will be compensated by the `site.gridPower` term in the formula.

##  SorrySorrySorry
I don't have Go set up on my desktop or anywhere else, given that it's a small change I'm hoping I can be forgiven that I have not yet ran a build and tested it out.