### PR TITLE
chore: wait for the pull request to merge in the backport command

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -57,11 +57,22 @@ jobs:
               core.setFailed(message);
             };
 
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: context.payload.issue.number,
-            });
+            // the command is usually posted right before hitting merge, so give the
+            // pull request time to land instead of failing on the race
+            const deadline = Date.now() + 5 * 60 * 1000;
+            let pr;
+            for (;;) {
+              ({ data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: context.payload.issue.number,
+              }));
+              // a closed pull request will never merge, no point in waiting it out
+              if (pr.merged || pr.state === 'closed' || Date.now() >= deadline) {
+                break;
+              }
+              await new Promise((resolve) => setTimeout(resolve, 15000));
+            }
             if (!pr.merged) {
               fail(`pull request #${pr.number} is not merged`);
               return;

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -62,13 +62,24 @@ jobs:
             const deadline = Date.now() + 5 * 60 * 1000;
             let pr;
             for (;;) {
-              ({ data: pr } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: context.payload.issue.number,
-              }));
-              // a closed pull request will never merge, no point in waiting it out
-              if (pr.merged || pr.state === 'closed' || Date.now() >= deadline) {
+              try {
+                ({ data: pr } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: context.payload.issue.number,
+                }));
+                // a closed pull request will never merge, no point in waiting it out
+                if (pr.merged || pr.state === 'closed') {
+                  break;
+                }
+              } catch (err) {
+                // a blip while polling must not fail the command, but a request that
+                // is still failing when the time is up is a real error
+                if (Date.now() >= deadline) {
+                  throw err;
+                }
+              }
+              if (Date.now() >= deadline) {
                 break;
               }
               await new Promise((resolve) => setTimeout(resolve, 15000));


### PR DESCRIPTION
`/backport` is usually posted on a pull request that is about to be merged rather than one that already is, and the command failed the run outright on that race.

- the merge check now polls the pull request every 15s for up to five minutes before giving up
- a pull request closed without being merged still fails immediately, no waiting it out
- everything downstream (label, `(BC)` title check, merge commit) runs against the re-fetched pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
