### PR TITLE
chore: sign and notarize macOS release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,12 @@ jobs:
           # a bugfix release of an older line must not move the homebrew formula
           # or the Github latest release marker
           MAKE_LATEST: ${{ needs.guard.outputs.latest }}
+          # macOS code signing and notarization
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
 
       - uses: actions/setup-python@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,19 @@ archives:
 universal_binaries:
   - replace: true
 
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      sign:
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
+        key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
+        key: "{{ .Env.MACOS_NOTARY_KEY }}"
+        wait: true
+        timeout: 20m
+
 checksum:
   name_template: "checksums.txt"
 
@@ -136,10 +149,3 @@ homebrew_casks:
     description: "Sonne tanken ☀️🚘"
     binaries:
       - evcc
-    hooks:
-      post:
-        # the binaries are not notarized, so gatekeeper would refuse to run them
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/evcc"]
-          end


### PR DESCRIPTION
Follow-up to #32874.

The macOS release binaries are now signed and notarized via goreleaser's cross-platform notarization (anchore/quill), so Gatekeeper accepts them without workarounds. The required repo secrets are set.

- add `notarize.macos` to `.goreleaser.yml`, guarded by `isEnvSet` so builds without secrets are unaffected
- pass the signing and notary secrets into the release workflow
- drop the quarantine-removal postflight hook from the homebrew cask

🤖 Generated with [Claude Code](https://claude.com/claude-code)
