### PR TITLE
Plugchoice: derive enabled state and metering from device status

### DIFF
--- a/charger/plugchoice.go
+++ b/charger/plugchoice.go
@@ -169,6 +169,25 @@ func (c *Plugchoice) Status() (api.ChargeStatus, error) {
 	}
 }
 
+var _ api.StatusReasoner = (*Plugchoice)(nil)
+
+// StatusReason implements the api.StatusReasoner interface
+func (c *Plugchoice) StatusReason() (api.Reason, error) {
+	conn, err := c.conn()
+	if err != nil {
+		return api.ReasonUnknown, err
+	}
+
+	switch conn.Status {
+	case core.ChargePointStatusPreparing:
+		return api.ReasonWaitingForAuthorization, nil
+	case core.ChargePointStatusFinishing:
+		return api.ReasonDisconnectRequired, nil
+	default:
+		return api.ReasonUnknown, nil
+	}
+}
+
 // Enabled implements the api.Charger interface
 func (c *Plugchoice) Enabled() (bool, error) {
 	conn, err := c.conn()

--- a/charger/plugchoice.go
+++ b/charger/plugchoice.go
@@ -276,14 +276,19 @@ func (c *Plugchoice) GetMaxCurrent() (float64, error) {
 	return float64(*conn.CurrentLimit), nil
 }
 
-// active returns true if the connector may currently be delivering power
+// active returns true if a transaction is running on the connector
 func (c *Plugchoice) active() (bool, error) {
 	conn, err := c.conn()
 	if err != nil {
 		return false, err
 	}
 
-	return conn.Status == core.ChargePointStatusCharging, nil
+	switch conn.Status {
+	case core.ChargePointStatusCharging, core.ChargePointStatusSuspendedEV, core.ChargePointStatusSuspendedEVSE:
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 // parsePlugchoiceValue parses a measurement, handling surrounding whitespace
@@ -302,7 +307,7 @@ var _ api.Meter = (*Plugchoice)(nil)
 // CurrentPower implements the api.Meter interface
 func (c *Plugchoice) CurrentPower() (float64, error) {
 	// meter values are only sampled during a transaction, hence the API may keep
-	// serving the last known values- suppress them unless a session is active
+	// serving the last known values once it has ended- suppress those
 	if active, err := c.active(); err != nil || !active {
 		return 0, err
 	}

--- a/charger/plugchoice.go
+++ b/charger/plugchoice.go
@@ -133,56 +133,64 @@ func NewPlugchoice(uri, uuid, identity string, connector int, token string, cach
 	return c, nil
 }
 
+// conn returns the configured connector from the cached status response
+func (c *Plugchoice) conn() (plugchoice.Connector, error) {
+	res, err := c.statusG.Get()
+	if err != nil {
+		return plugchoice.Connector{}, err
+	}
+
+	for _, conn := range res.Data.Connectors {
+		if conn.ConnectorID == c.connector {
+			return conn, nil
+		}
+	}
+
+	return plugchoice.Connector{}, fmt.Errorf("connector with ID %d not found", c.connector)
+}
+
 // Status implements the api.Charger interface
 func (c *Plugchoice) Status() (api.ChargeStatus, error) {
-	res, err := c.statusG.Get()
+	conn, err := c.conn()
 	if err != nil {
 		return api.StatusNone, err
 	}
 
-	// Find the connector with the specified connector
-	for _, connector := range res.Data.Connectors {
-		if connector.ConnectorID == c.connector {
-			// Map the status codes as per specifications
-			switch status := connector.Status; status {
-			case core.ChargePointStatusAvailable:
-				return api.StatusA, nil
-			case core.ChargePointStatusPreparing, core.ChargePointStatusSuspendedEVSE, core.ChargePointStatusSuspendedEV, core.ChargePointStatusFinishing:
-				return api.StatusB, nil
-			case core.ChargePointStatusCharging:
-				return api.StatusC, nil
-			default:
-				return api.StatusNone, fmt.Errorf("invalid status: %s", status)
-			}
-		}
+	// Map the status codes as per specifications
+	switch status := conn.Status; status {
+	case core.ChargePointStatusAvailable:
+		return api.StatusA, nil
+	case core.ChargePointStatusPreparing, core.ChargePointStatusSuspendedEVSE, core.ChargePointStatusSuspendedEV, core.ChargePointStatusFinishing:
+		return api.StatusB, nil
+	case core.ChargePointStatusCharging:
+		return api.StatusC, nil
+	default:
+		return api.StatusNone, fmt.Errorf("invalid status: %s", status)
 	}
-
-	return api.StatusNone, fmt.Errorf("connector with ID %d not found", c.connector)
 }
 
 // Enabled implements the api.Charger interface
 func (c *Plugchoice) Enabled() (bool, error) {
-	res, err := c.statusG.Get()
+	conn, err := c.conn()
 	if err != nil {
 		return false, err
 	}
 
-	// Find the connector with the specified connector
-	for _, connector := range res.Data.Connectors {
-		if connector.ConnectorID == c.connector {
-			// Check status for enabled state
-			switch status := connector.Status; status {
-			case core.ChargePointStatusCharging, core.ChargePointStatusSuspendedEV:
-				return true, nil
-			case core.ChargePointStatusSuspendedEVSE:
-				return false, nil
-			default:
-				return c.enabled, nil
-			}
-		}
+	// Check status for enabled state
+	switch conn.Status {
+	case core.ChargePointStatusCharging, core.ChargePointStatusSuspendedEV:
+		return true, nil
+	case core.ChargePointStatusSuspendedEVSE:
+		return false, nil
 	}
 
-	return false, fmt.Errorf("connector with ID %d not found", c.connector)
+	// status is inconclusive- prefer the limit actually applied by the backend over
+	// the locally cached state which misses any change made outside of evcc
+	if conn.CurrentLimit != nil {
+		return *conn.CurrentLimit > 0, nil
+	}
+
+	return c.enabled, nil
 }
 
 // Enable implements the api.Charger interface
@@ -233,26 +241,61 @@ func (c *Plugchoice) MaxCurrent(current int64) error {
 	return err
 }
 
+var _ api.CurrentGetter = (*Plugchoice)(nil)
+
+// GetMaxCurrent implements the api.CurrentGetter interface
+func (c *Plugchoice) GetMaxCurrent() (float64, error) {
+	conn, err := c.conn()
+	if err != nil {
+		return 0, err
+	}
+
+	if conn.CurrentLimit == nil {
+		return 0, api.ErrNotAvailable
+	}
+
+	return float64(*conn.CurrentLimit), nil
+}
+
+// active returns true if the connector may currently be delivering power
+func (c *Plugchoice) active() (bool, error) {
+	conn, err := c.conn()
+	if err != nil {
+		return false, err
+	}
+
+	return conn.Status == core.ChargePointStatusCharging, nil
+}
+
+// parsePlugchoiceValue parses a measurement, handling surrounding whitespace
+// (e.g. " 0.0") and missing values ("-")
+func parsePlugchoiceValue(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "-" {
+		return 0, nil
+	}
+
+	return strconv.ParseFloat(s, 64)
+}
+
 var _ api.Meter = (*Plugchoice)(nil)
 
 // CurrentPower implements the api.Meter interface
 func (c *Plugchoice) CurrentPower() (float64, error) {
+	// meter values are only sampled during a transaction, hence the API may keep
+	// serving the last known values- suppress them unless a session is active
+	if active, err := c.active(); err != nil || !active {
+		return 0, err
+	}
+
 	res, err := c.powerG.Get()
 	if err != nil {
 		return 0, err
 	}
 
-	// the API may return values with surrounding whitespace (e.g. " 0.0")
-	kwVal := strings.TrimSpace(res.KW)
-
-	// Handle the case where power value is "-"
-	if kwVal == "-" {
-		return 0, nil
-	}
-
-	kw, err := strconv.ParseFloat(kwVal, 64)
+	kw, err := parsePlugchoiceValue(res.KW)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("parsing power: %w", err)
 	}
 
 	return kw * 1000, nil // Convert kW to W
@@ -262,39 +305,24 @@ var _ api.PhaseCurrents = (*Plugchoice)(nil)
 
 // Currents implements the api.PhaseCurrents interface
 func (c *Plugchoice) Currents() (float64, float64, float64, error) {
+	if active, err := c.active(); err != nil || !active {
+		return 0, 0, 0, err
+	}
+
 	res, err := c.powerG.Get()
 	if err != nil {
 		return 0, 0, 0, err
 	}
 
-	// Helper function to parse current values, handling "-" as 0
-	parsePhaseValue := func(val string, phase string) (float64, error) {
-		// the API may return values with surrounding whitespace (e.g. " 0.0")
-		val = strings.TrimSpace(val)
-		if val == "-" {
-			return 0, nil
-		}
-		res, err := strconv.ParseFloat(val, 64)
+	var currents [3]float64
+	for i, v := range []string{res.L1, res.L2, res.L3} {
+		f, err := parsePlugchoiceValue(v)
 		if err != nil {
-			return 0, fmt.Errorf("parsing %s current: %w", phase, err)
+			return 0, 0, 0, fmt.Errorf("parsing L%d current: %w", i+1, err)
 		}
-		return res, nil
+
+		currents[i] = f
 	}
 
-	l1, err := parsePhaseValue(res.L1, "L1")
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	l2, err := parsePhaseValue(res.L2, "L2")
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	l3, err := parsePhaseValue(res.L3, "L3")
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	return l1, l2, l3, nil
+	return currents[0], currents[1], currents[2], nil
 }

--- a/charger/plugchoice/types.go
+++ b/charger/plugchoice/types.go
@@ -61,8 +61,11 @@ type Connector struct {
 	Error       core.ChargePointErrorCode `json:"error"`
 	ErrorInfo   string                    `json:"error_info"`
 	MaxAmperage int                       `json:"max_amperage"`
-	CreatedAt   string                    `json:"created_at"`
-	UpdatedAt   string                    `json:"updated_at"`
+	// CurrentLimit is the limit currently applied by the backend, nil if not reported
+	CurrentLimit          *int   `json:"current_limit"`
+	CurrentLimitManagedBy string `json:"current_limit_managed_by"`
+	CreatedAt             string `json:"created_at"`
+	UpdatedAt             string `json:"updated_at"`
 }
 
 // PowerResponse is the power usage response

--- a/charger/plugchoice_test.go
+++ b/charger/plugchoice_test.go
@@ -108,6 +108,30 @@ func TestPlugchoiceEnabled(t *testing.T) {
 	}
 }
 
+func TestPlugchoiceStatusReason(t *testing.T) {
+	tc := []struct {
+		status   core.ChargePointStatus
+		expected api.Reason
+	}{
+		{core.ChargePointStatusPreparing, api.ReasonWaitingForAuthorization},
+		{core.ChargePointStatusFinishing, api.ReasonDisconnectRequired},
+		{core.ChargePointStatusAvailable, api.ReasonUnknown},
+		{core.ChargePointStatusCharging, api.ReasonUnknown},
+		{core.ChargePointStatusSuspendedEV, api.ReasonUnknown},
+		{core.ChargePointStatusSuspendedEVSE, api.ReasonUnknown},
+	}
+
+	for _, tc := range tc {
+		t.Run(string(tc.status), func(t *testing.T) {
+			c := newPlugchoiceFixture(plugchoice.Connector{Status: tc.status}, plugchoice.PowerResponse{})
+
+			reason, err := c.StatusReason()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, reason)
+		})
+	}
+}
+
 func TestPlugchoiceGetMaxCurrent(t *testing.T) {
 	c := newPlugchoiceFixture(plugchoice.Connector{CurrentLimit: lo.ToPtr(16)}, plugchoice.PowerResponse{})
 	current, err := c.GetMaxCurrent()

--- a/charger/plugchoice_test.go
+++ b/charger/plugchoice_test.go
@@ -36,7 +36,7 @@ func newPlugchoiceFixture(conn plugchoice.Connector, power plugchoice.PowerRespo
 func TestPlugchoiceMetering(t *testing.T) {
 	// the API only receives meter values during a transaction and may keep serving
 	// the last known sample afterwards
-	stale := plugchoice.PowerResponse{KW: "7.4", L1: "10.7", L2: "10.7", L3: "10.7"}
+	sample := plugchoice.PowerResponse{KW: "7.4", L1: "10.7", L2: "10.7", L3: "10.7"}
 
 	tc := []struct {
 		name     string
@@ -45,16 +45,17 @@ func TestPlugchoiceMetering(t *testing.T) {
 		expPower float64
 		expL1    float64
 	}{
-		{"charging", core.ChargePointStatusCharging, stale, 7400, 10.7},
+		{"charging", core.ChargePointStatusCharging, sample, 7400, 10.7},
 		// session started outside of evcc, so Enable() was never called
 		{"charging, single phase", core.ChargePointStatusCharging,
 			plugchoice.PowerResponse{KW: "3.6", L1: "16.0", L2: "-", L3: " 0.0"}, 3600, 16},
-		// not charging- stale values must not be reported
-		{"suspended by ev", core.ChargePointStatusSuspendedEV, stale, 0, 0},
-		{"preparing", core.ChargePointStatusPreparing, stale, 0, 0},
-		{"available", core.ChargePointStatusAvailable, stale, 0, 0},
-		{"finishing", core.ChargePointStatusFinishing, stale, 0, 0},
-		{"suspended by evse", core.ChargePointStatusSuspendedEVSE, stale, 0, 0},
+		// sampling continues while the transaction is suspended
+		{"suspended by ev", core.ChargePointStatusSuspendedEV, sample, 7400, 10.7},
+		{"suspended by evse", core.ChargePointStatusSuspendedEVSE, sample, 7400, 10.7},
+		// no transaction- stale values must not be reported
+		{"preparing", core.ChargePointStatusPreparing, sample, 0, 0},
+		{"available", core.ChargePointStatusAvailable, sample, 0, 0},
+		{"finishing", core.ChargePointStatusFinishing, sample, 0, 0},
 	}
 
 	for _, tc := range tc {

--- a/charger/plugchoice_test.go
+++ b/charger/plugchoice_test.go
@@ -1,0 +1,133 @@
+package charger
+
+import (
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/charger/plugchoice"
+	"github.com/evcc-io/evcc/util"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newPlugchoiceFixture creates a charger backed by static API responses
+func newPlugchoiceFixture(conn plugchoice.Connector, power plugchoice.PowerResponse) *Plugchoice {
+	conn.ConnectorID = 1
+
+	c := &Plugchoice{connector: 1, current: 6}
+
+	c.statusG = util.ResettableCached(func() (plugchoice.StatusResponse, error) {
+		return plugchoice.StatusResponse{
+			Data: plugchoice.ChargerData{Connectors: []plugchoice.Connector{conn}},
+		}, nil
+	}, 0)
+
+	c.powerG = util.ResettableCached(func() (plugchoice.PowerResponse, error) {
+		return power, nil
+	}, 0)
+
+	return c
+}
+
+// TestPlugchoiceMetering verifies that measurements follow the connector status rather
+// than the locally cached enable state (https://github.com/evcc-io/evcc/issues/32419)
+func TestPlugchoiceMetering(t *testing.T) {
+	// the API only receives meter values during a transaction and may keep serving
+	// the last known sample afterwards
+	stale := plugchoice.PowerResponse{KW: "7.4", L1: "10.7", L2: "10.7", L3: "10.7"}
+
+	tc := []struct {
+		name     string
+		status   core.ChargePointStatus
+		power    plugchoice.PowerResponse
+		expPower float64
+		expL1    float64
+	}{
+		{"charging", core.ChargePointStatusCharging, stale, 7400, 10.7},
+		// session started outside of evcc, so Enable() was never called
+		{"charging, single phase", core.ChargePointStatusCharging,
+			plugchoice.PowerResponse{KW: "3.6", L1: "16.0", L2: "-", L3: " 0.0"}, 3600, 16},
+		// not charging- stale values must not be reported
+		{"suspended by ev", core.ChargePointStatusSuspendedEV, stale, 0, 0},
+		{"preparing", core.ChargePointStatusPreparing, stale, 0, 0},
+		{"available", core.ChargePointStatusAvailable, stale, 0, 0},
+		{"finishing", core.ChargePointStatusFinishing, stale, 0, 0},
+		{"suspended by evse", core.ChargePointStatusSuspendedEVSE, stale, 0, 0},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPlugchoiceFixture(plugchoice.Connector{Status: tc.status}, tc.power)
+
+			power, err := c.CurrentPower()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expPower, power, "power")
+
+			l1, _, _, err := c.Currents()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expL1, l1, "l1")
+		})
+	}
+}
+
+func TestPlugchoiceEnabled(t *testing.T) {
+	tc := []struct {
+		name     string
+		status   core.ChargePointStatus
+		limit    *int
+		cached   bool // locally cached enable state
+		expected bool
+	}{
+		// conclusive status wins- covers sessions started outside of evcc
+		{"charging", core.ChargePointStatusCharging, lo.ToPtr(0), false, true},
+		{"suspended by ev", core.ChargePointStatusSuspendedEV, nil, false, true},
+		{"suspended by evse", core.ChargePointStatusSuspendedEVSE, lo.ToPtr(16), true, false},
+		// inconclusive status- applied limit beats the locally cached state
+		{"preparing, limit applied", core.ChargePointStatusPreparing, lo.ToPtr(16), false, true},
+		{"preparing, limit zero", core.ChargePointStatusPreparing, lo.ToPtr(0), true, false},
+		{"available, limit applied", core.ChargePointStatusAvailable, lo.ToPtr(6), false, true},
+		// API does not report the limit- fall back to the cached state
+		{"preparing, no limit reported", core.ChargePointStatusPreparing, nil, true, true},
+		{"available, no limit reported", core.ChargePointStatusAvailable, nil, false, false},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPlugchoiceFixture(plugchoice.Connector{
+				Status:       tc.status,
+				CurrentLimit: tc.limit,
+			}, plugchoice.PowerResponse{})
+			c.enabled = tc.cached
+
+			enabled, err := c.Enabled()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, enabled)
+		})
+	}
+}
+
+func TestPlugchoiceGetMaxCurrent(t *testing.T) {
+	c := newPlugchoiceFixture(plugchoice.Connector{CurrentLimit: lo.ToPtr(16)}, plugchoice.PowerResponse{})
+	current, err := c.GetMaxCurrent()
+	require.NoError(t, err)
+	assert.Equal(t, 16.0, current)
+
+	c = newPlugchoiceFixture(plugchoice.Connector{}, plugchoice.PowerResponse{})
+	_, err = c.GetMaxCurrent()
+	assert.ErrorIs(t, err, api.ErrNotAvailable)
+}
+
+func TestPlugchoiceConnectorNotFound(t *testing.T) {
+	c := newPlugchoiceFixture(plugchoice.Connector{Status: core.ChargePointStatusCharging}, plugchoice.PowerResponse{})
+	c.connector = 2
+
+	_, err := c.Status()
+	assert.Error(t, err)
+
+	// measurements must not be reported when the connector is unknown
+	power, err := c.CurrentPower()
+	assert.Error(t, err)
+	assert.Zero(t, power)
+}


### PR DESCRIPTION
Follow-up to #32419 / #32420.

#32420 fixed the reported symptom by dropping the `c.enabled` gate in `CurrentPower()`, but it removed the guarantee that gate provided — *report zero when nothing is being delivered* — without replacing it.

Measurements from a live installation ([comment](https://github.com/evcc-io/evcc/issues/32419#issuecomment-5334065171)) confirm the mechanism behind that concern: hours after a session ended, with the cable unplugged, `power-usage` still answers with the meter sample taken at the end of that session — `{"timestamp":"2026-08-18T14:15:53.885Z","L1":"0",...,"kW":"0.00"}`. The endpoint serves last-known values rather than live ones, despite what the API docs suggest. Here the retained sample happens to be zero because the charger sent a final zero reading on transaction stop, which is the common case; the gate therefore guards an edge case (a session ending without that final sample) rather than the everyday path. That edge case is worth guarding, because charge power feeds `availablePower := lp.chargePower - sitePower` and the session energy integration, so a retained non-zero value would inflate PV surplus and charged energy.

The underlying problem is broader than one `if`: the charger mirrors its control state locally (`c.enabled`), and that mirror is only ever written by evcc's own `Enable()`. In an integration whose purpose is that the device is shared with other controllers — RFID, another backoffice via the OCPP proxy, the Plugchoice app, load balancing, an evcc restart — the mirror is wrong by construction. `CurrentPower()` was one symptom; `Enabled()` still used it as a fallback.

This derives both from device state instead, following the convention in `charger/ocpp/connector.go`:

- **Measurements are gated on the live connector status** rather than on the cached enable flag. This fixes the reported case — an RFID-started session reports `Charging` no matter who started it, which is exactly where the old gate failed — and restores the zero-when-idle guarantee. The gate opens for `Charging`, `SuspendedEV` and `SuspendedEVSE`, i.e. whenever a transaction is running: sampling continues in the suspended states, so those readings are current and not retained. `Currents()` is covered too; it was never gated at all.
- **`Enabled()` prefers the applied limit.** The connector resource exposes `current_limit` ("the current limit of the connector"); it is now parsed as `*int` and used when the status is inconclusive (`Available`, `Preparing`, `Finishing`). The field is present in the API but reported as `null` on an idle connector, in which case behaviour is unchanged from today.
- **`api.CurrentGetter` implemented** from the same field, so `syncCharger` can verify the actually applied current instead of falling back to measured phase currents. A `null` limit yields `api.ErrNotAvailable`, which `syncCharger` already handles by falling back to measured phase currents.
- **`api.StatusReasoner` implemented**, mapping `Preparing` → waiting for authorization and `Finishing` → disconnect required, as in `charger/ocpp.go`.
- Deduplicated the threefold connector lookup and the duplicated value parsing, and added the first tests for this charger — it has now had two parsing/logic regressions (#30550, #32419).

Still to be confirmed from a live installation: whether `current_limit` is populated while a session is running under evcc control. If it stays `null` there as well, the last two items degrade silently to today's behaviour and only the first one takes effect.

Not addressed here, tracked separately: if the charger drops offline mid-session the connector status stays `Charging` while `power-usage` keeps serving the last sample, which the status gate does not catch. The native OCPP charger guards this with `cp.Connected()` and `isMeterTimeout()`; the equivalents here would be the currently unused `connection_status` and `timestamp` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
