### PR TITLE
Afore: remove Modbus TCP option

### DIFF
--- a/templates/definition/meter/afore-hybrid.yaml
+++ b/templates/definition/meter/afore-hybrid.yaml
@@ -15,8 +15,7 @@ params:
   - name: usage
     choice: ["grid", "pv", "battery"]
   - name: modbus
-    choice: ["tcpip", "rs485"]
-    port: 502
+    choice: ["rs485"]
     id: 1
   - name: maxacpower
   - preset: battery-params


### PR DESCRIPTION
Replaces https://github.com/evcc-io/evcc/pull/32961