### PR TITLE
EEBus: keep a configured device's ski trusted on connect timeout

### DIFF
--- a/charger/eebus-evse.go
+++ b/charger/eebus-evse.go
@@ -94,8 +94,7 @@ func newEEBus(ctx context.Context, ski, ip string) (*EEBus, error) {
 	}
 
 	if err := c.connector.Wait(ctx); err != nil {
-		// keep ski trusted, the device stays configured
-		inst.UnsubscribeDevice(ski, c)
+		inst.UnregisterDeviceKeepTrust(ski, c)
 		return nil, err
 	}
 

--- a/charger/eebus-evse.go
+++ b/charger/eebus-evse.go
@@ -94,7 +94,8 @@ func newEEBus(ctx context.Context, ski, ip string) (*EEBus, error) {
 	}
 
 	if err := c.connector.Wait(ctx); err != nil {
-		inst.UnregisterDevice(ski, c)
+		// keep ski trusted, the device stays configured
+		inst.UnsubscribeDevice(ski, c)
 		return nil, err
 	}
 

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -101,7 +101,8 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 	}
 
 	if err := c.connector.Wait(ctx); err != nil {
-		inst.UnregisterDevice(ski, c)
+		// keep ski trusted, the device stays configured
+		inst.UnsubscribeDevice(ski, c)
 		return nil, err
 	}
 

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -101,8 +101,7 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 	}
 
 	if err := c.connector.Wait(ctx); err != nil {
-		// keep ski trusted, the device stays configured
-		inst.UnsubscribeDevice(ski, c)
+		inst.UnregisterDeviceKeepTrust(ski, c)
 		return nil, err
 	}
 

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -122,7 +122,8 @@ func NewEEBus(ctx context.Context, ski string, limits Limits, passthrough func(b
 	}
 
 	if err := c.Wait(ctx); err != nil {
-		inst.UnregisterDevice(ski, c)
+		// keep ski trusted, the device stays configured
+		inst.UnsubscribeDevice(ski, c)
 		return nil, err
 	}
 

--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -122,8 +122,7 @@ func NewEEBus(ctx context.Context, ski string, limits Limits, passthrough func(b
 	}
 
 	if err := c.Wait(ctx); err != nil {
-		// keep ski trusted, the device stays configured
-		inst.UnsubscribeDevice(ski, c)
+		inst.UnregisterDeviceKeepTrust(ski, c)
 		return nil, err
 	}
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -130,8 +130,7 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	}
 
 	if err := c.connector.Wait(ctx); err != nil {
-		// keep ski trusted, the device stays configured
-		inst.UnsubscribeDevice(ski, c)
+		inst.UnregisterDeviceKeepTrust(ski, c)
 		return nil, err
 	}
 

--- a/meter/eebus.go
+++ b/meter/eebus.go
@@ -130,7 +130,8 @@ func NewEEBus(ctx context.Context, ski, ip string, usage *templates.Usage) (api.
 	}
 
 	if err := c.connector.Wait(ctx); err != nil {
-		inst.UnregisterDevice(ski, c)
+		// keep ski trusted, the device stays configured
+		inst.UnsubscribeDevice(ski, c)
 		return nil, err
 	}
 

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -440,7 +440,18 @@ func (c *EEBus) RegisterDevice(ski, ip string, device Device) error {
 	return nil
 }
 
+// UnregisterDevice unsubscribes device and drops trust for ski once no device is left
 func (c *EEBus) UnregisterDevice(ski string, device Device) {
+	c.unregisterDevice(ski, device, false)
+}
+
+// UnsubscribeDevice unsubscribes device but keeps ski trusted. The device remains
+// configured, so the remote service must still be able to connect later.
+func (c *EEBus) UnsubscribeDevice(ski string, device Device) {
+	c.unregisterDevice(ski, device, true)
+}
+
+func (c *EEBus) unregisterDevice(ski string, device Device, keepTrust bool) {
 	ski = shiputil.NormalizeSKI(ski)
 	c.log.TRACE.Printf("unregistering ski: %s", ski)
 
@@ -457,7 +468,7 @@ func (c *EEBus) UnregisterDevice(ski string, device Device) {
 			// acquire c.mux. Holding c.mux across this cross-layer call would
 			// deadlock the same goroutine on its own non-reentrant mutex. See #28942.
 			// The paired device (empty ski) stays trusted until unpaired.
-			if ski != "" {
+			if ski != "" && !keepTrust {
 				defer c.service.UnregisterRemoteService(shipapi.NewServiceIdentity(ski, "", ""))
 			}
 		}

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -445,15 +445,19 @@ func (c *EEBus) UnregisterDevice(ski string, device Device) {
 	c.unregisterDevice(ski, device, false)
 }
 
-// UnsubscribeDevice unsubscribes device but keeps ski trusted. The device remains
+// UnregisterDeviceKeepTrust unsubscribes device but keeps ski trusted. The device remains
 // configured, so the remote service must still be able to connect later.
-func (c *EEBus) UnsubscribeDevice(ski string, device Device) {
+func (c *EEBus) UnregisterDeviceKeepTrust(ski string, device Device) {
 	c.unregisterDevice(ski, device, true)
 }
 
 func (c *EEBus) unregisterDevice(ski string, device Device, keepTrust bool) {
 	ski = shiputil.NormalizeSKI(ski)
-	c.log.TRACE.Printf("unregistering ski: %s", ski)
+	if keepTrust {
+		c.log.TRACE.Printf("unregistering device for ski: %s, keeping trust", ski)
+	} else {
+		c.log.TRACE.Printf("unregistering ski: %s", ski)
+	}
 
 	c.mux.Lock()
 	if idx := slices.Index(c.clients[ski], device); idx != -1 {

--- a/server/eebus/eebus_test.go
+++ b/server/eebus/eebus_test.go
@@ -77,10 +77,10 @@ func TestUnregisterDevice_MutexNotHeldDuringShipCall(t *testing.T) {
 	c.UnregisterDevice("aabbcc", dev)
 }
 
-// TestUnsubscribeDeviceKeepsTrust guards that a device that could not connect
-// does not revoke the trust its configuration established- the remote service
-// must still be able to connect once it comes up.
-func TestUnsubscribeDeviceKeepsTrust(t *testing.T) {
+// TestUnregisterDeviceKeepTrust guards that a device that could not connect does
+// not revoke the trust its configuration established- the remote service must
+// still be able to connect once it comes up.
+func TestUnregisterDeviceKeepTrust(t *testing.T) {
 	dev := &mockDevice{}
 	c := &EEBus{
 		log:     util.NewLogger("test"),
@@ -88,7 +88,7 @@ func TestUnsubscribeDeviceKeepsTrust(t *testing.T) {
 		service: eebusmocks.NewServiceInterface(t), // no UnregisterRemoteService expected
 	}
 
-	c.UnsubscribeDevice("aabbcc", dev)
+	c.UnregisterDeviceKeepTrust("aabbcc", dev)
 
 	require.NotContains(t, c.clients, "aabbcc")
 }

--- a/server/eebus/eebus_test.go
+++ b/server/eebus/eebus_test.go
@@ -76,3 +76,19 @@ func TestUnregisterDevice_MutexNotHeldDuringShipCall(t *testing.T) {
 
 	c.UnregisterDevice("aabbcc", dev)
 }
+
+// TestUnsubscribeDeviceKeepsTrust guards that a device that could not connect
+// does not revoke the trust its configuration established- the remote service
+// must still be able to connect once it comes up.
+func TestUnsubscribeDeviceKeepsTrust(t *testing.T) {
+	dev := &mockDevice{}
+	c := &EEBus{
+		log:     util.NewLogger("test"),
+		clients: map[string][]Device{"aabbcc": {dev}},
+		service: eebusmocks.NewServiceInterface(t), // no UnregisterRemoteService expected
+	}
+
+	c.UnsubscribeDevice("aabbcc", dev)
+
+	require.NotContains(t, c.clients, "aabbcc")
+}


### PR DESCRIPTION
A configured EEBUS device that does not connect within `registerTimeout` (90s) currently revokes the trust its own configuration established:

```go
if err := c.connector.Wait(ctx); err != nil {
    inst.UnregisterDevice(ski, c)   // → service.UnregisterRemoteService(ski)
    return nil, err
}
```

From then on the ski is unknown to the SHIP hub, so `ServicePairingDetailUpdate` denies every later pairing request from that device — it stays locked out until evcc restarts, even though the user's configuration still names it.

Seen in the wild with a controlbox (EnergyGuard) that was denied on reconnect during an evcc restart, died, and left evcc waiting the full 90s before dropping the ski:

```
18:44:12  registering ski: 6988789f...
18:45:42  unregistering ski: 6988789f...
```

Trust follows the configuration, not the device instance, so the Wait path now unsubscribes the device without touching the trust store. `UnregisterDevice` (context cancellation, i.e. config removal or UI validation) is unchanged and still drops trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
