### PR TITLE
EEBus: don't deny pairing while devices are still being configured

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -391,6 +391,9 @@ func runRoot(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// all device skis are registered, unknown ones may now be denied
+	eebus.ConfigComplete()
+
 	// setup MCP
 	if err == nil && isMcp() {
 		router := httpd.Router()

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"dario.cat/mergo"
@@ -86,7 +85,7 @@ type EEBus struct {
 
 	// configured is set once device configuration has finished. Until then, an
 	// unknown ski may still belong to a device that is not configured yet.
-	configured atomic.Bool
+	configured bool
 
 	ski string
 
@@ -118,9 +117,13 @@ func Instance() (*EEBus, error) {
 // being configured is not yet registered, and denying it would lock the remote
 // service out until the next restart.
 func ConfigComplete() {
-	if instance != nil {
-		instance.configured.Store(true)
+	if instance == nil {
+		return
 	}
+
+	instance.mux.Lock()
+	defer instance.mux.Unlock()
+	instance.configured = true
 }
 
 func GetStatus() any {
@@ -580,7 +583,7 @@ func (c *EEBus) ServicePairingDetailUpdate(identity shipapi.ServiceIdentity, det
 	defer c.mux.Unlock()
 
 	if clients, ok := c.clients[identity.SKI]; !ok || len(clients) == 0 {
-		if !c.configured.Load() {
+		if !c.configured {
 			// device configuration is still running- leave the request pending
 			// instead of denying a ski that is about to be registered
 			c.log.DEBUG.Printf("pairing request from %s while configuring, left pending", identity.SKI)

--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"dario.cat/mergo"
@@ -83,6 +84,10 @@ type EEBus struct {
 	mux sync.Mutex
 	log *util.Logger
 
+	// configured is set once device configuration has finished. Until then, an
+	// unknown ski may still belong to a device that is not configured yet.
+	configured atomic.Bool
+
 	ski string
 
 	paired    []shipapi.ServiceIdentity // devices paired via SHIP Pairing Service
@@ -106,6 +111,16 @@ func Instance() (*EEBus, error) {
 		return nil, err
 	}
 	return instance, nil
+}
+
+// ConfigComplete marks device configuration as finished. Pairing requests from
+// unknown skis are left pending until then- the ski of a device that is still
+// being configured is not yet registered, and denying it would lock the remote
+// service out until the next restart.
+func ConfigComplete() {
+	if instance != nil {
+		instance.configured.Store(true)
+	}
 }
 
 func GetStatus() any {
@@ -565,6 +580,13 @@ func (c *EEBus) ServicePairingDetailUpdate(identity shipapi.ServiceIdentity, det
 	defer c.mux.Unlock()
 
 	if clients, ok := c.clients[identity.SKI]; !ok || len(clients) == 0 {
+		if !c.configured.Load() {
+			// device configuration is still running- leave the request pending
+			// instead of denying a ski that is about to be registered
+			c.log.DEBUG.Printf("pairing request from %s while configuring, left pending", identity.SKI)
+			return
+		}
+
 		// this is an unknown SKI, so deny pairing
 		c.service.CancelPairing(identity)
 	}

--- a/server/eebus/eebus_test.go
+++ b/server/eebus/eebus_test.go
@@ -95,6 +95,6 @@ func TestPairingDeniedOnlyWhenConfigured(t *testing.T) {
 	c.ServicePairingDetailUpdate(identity, detail)
 
 	service.EXPECT().CancelPairing(identity).Once()
-	c.configured.Store(true)
+	c.configured = true
 	c.ServicePairingDetailUpdate(identity, detail)
 }

--- a/server/eebus/eebus_test.go
+++ b/server/eebus/eebus_test.go
@@ -76,3 +76,25 @@ func TestUnregisterDevice_MutexNotHeldDuringShipCall(t *testing.T) {
 
 	c.UnregisterDevice("aabbcc", dev)
 }
+
+// TestPairingDeniedOnlyWhenConfigured guards that an unknown ski is not denied
+// while device configuration is still running- its device may register the ski
+// moments later, and a denial locks the remote service out until the next restart.
+func TestPairingDeniedOnlyWhenConfigured(t *testing.T) {
+	identity := shipapi.NewServiceIdentity("aabbcc", "", "")
+	detail := shipapi.NewConnectionStateDetail(shipapi.ConnectionStateReceivedPairingRequest, nil)
+
+	service := eebusmocks.NewServiceInterface(t)
+	c := &EEBus{
+		log:     util.NewLogger("test"),
+		clients: make(map[string][]Device),
+		service: service,
+	}
+
+	// still configuring - no CancelPairing expected
+	c.ServicePairingDetailUpdate(identity, detail)
+
+	service.EXPECT().CancelPairing(identity).Once()
+	c.configured.Store(true)
+	c.ServicePairingDetailUpdate(identity, detail)
+}


### PR DESCRIPTION
The SHIP service starts on the first `eebus.Instance()` call — i.e. from the first EEBUS device constructor — while the skis of all remaining devices are still unregistered. Any peer that reconnects in that window hits `ServicePairingDetailUpdate` with no entry in `c.clients` and gets its pairing request cancelled.

The window is not short: eebus devices are constructed sequentially, each one blocks in `Wait` for up to 90s, and `hems` is configured after meters, chargers and loadpoints. One unreachable eebus meter therefore delays every later ski registration by a full 90s.

Observed with a controlbox reconnecting one second after evcc announced itself on mDNS, before the HEMS device that carries its ski was constructed:

```
18:44:11  mdns: avahi - process add service: EVCC_HEMS_01 ... ski:b28ad705...
18:44:12  registering ski: 6988789f...
```

An unknown ski is now left pending instead of denied until device configuration has finished. `eebus.ConfigComplete()` is called once setup is done; after that the deny behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
