### PR TITLE
DaheimLaden: Improve error reporting in checkStation method

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -365,14 +365,24 @@ func (wb *DaheimLaden) getPhases() (int, error) {
 func (wb *DaheimLaden) checkStation() error {
 	b, err := wb.conn.ReadHoldingRegisters(dlRegEvseMaxCurrent, 22)
 	if err != nil {
-		return api.ErrSponsorRequired
-	}
-	// station id starts (dlRegStationId-dlRegEvseMaxCurrent) registers into the block
-	s, err := utf16BEBytesAsString(b[2*(dlRegStationId-dlRegEvseMaxCurrent):])
-	if err != nil || s == "" {
-		return api.ErrSponsorRequired
+		// communication error (timeout, connection refused, EOF, ...) is not
+		// a sponsorship problem - surface the actual cause instead of masking
+		// it as "sponsorship required"
+		return fmt.Errorf("station id: %w", err)
 	}
 
+	// station id starts (dlRegStationId-dlRegEvseMaxCurrent) registers into the block
+	s, err := utf16BEBytesAsString(b[2*(dlRegStationId-dlRegEvseMaxCurrent):])
+	if err != nil {
+		return fmt.Errorf("station id: %w", err)
+	}
+
+	// station id was read successfully - from here on, an empty/invalid id is
+	// treated as "sponsorship required" as before
+	if s == "" {
+		return api.ErrSponsorRequired
+	}
+	
 	for _, r := range s {
 		if r < 0x20 || r > 0x7e {
 			return api.ErrSponsorRequired

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -370,13 +370,11 @@ func (wb *DaheimLaden) checkStation() error {
 		// it as "sponsorship required"
 		return fmt.Errorf("station id: %w", err)
 	}
-
 	// station id starts (dlRegStationId-dlRegEvseMaxCurrent) registers into the block
 	s, err := utf16BEBytesAsString(b[2*(dlRegStationId-dlRegEvseMaxCurrent):])
 	if err != nil {
 		return fmt.Errorf("station id: %w", err)
 	}
-
 	// station id was read successfully - from here on, an empty/invalid id is
 	// treated as "sponsorship required" as before
 	if s == "" {

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -380,7 +380,7 @@ func (wb *DaheimLaden) checkStation() error {
 	if s == "" {
 		return api.ErrSponsorRequired
 	}
-	
+
 	for _, r := range s {
 		if r < 0x20 || r > 0x7e {
 			return api.ErrSponsorRequired


### PR DESCRIPTION
fix #32907 

## Daheimladen: fix misleading sponsorship error on station id communication failure

### Problem

`checkStation()` calls `wb.conn.ReadHoldingRegisters(...)` to read the station id and decide whether the connected DaheimLaden model requires a sponsor token. Any error from this read - including plain network/Modbus communication failures such as `connection refused`, `i/o timeout`, or `EOF` when the wallbox is temporarily unreachable at evcc startup - was unconditionally mapped to `api.ErrSponsorRequired`.

This produces a misleading `sponsorship required` error whenever the wallbox simply isn't reachable yet (e.g. still booting, brief network hiccup), even though all DaheimLaden models are sponsor-free. Users have reported that once this happens, restarting evcc does not resolve it - only an external Modbus request to the wallbox (from another tool) appears to reset the connection into a state where evcc's own check succeeds again.

Related history: #31956 attempted a fix for this, but was reverted (834c062). #32079 addressed a related hardware-check issue. The underlying error-masking in `checkStation()` itself was not changed by either.

### Fix

Distinguish between:
- a **communication error** while reading the station id block (timeout, connection refused, EOF, decode error) -> now returned as a wrapped `station id: %w` error, exposing the real cause instead of `sponsorship required`
- a **successfully read but empty/invalid/blocked station id** -> still correctly returns `api.ErrSponsorRequired`, unchanged behavior

No other logic changes. The sponsorship determination for genuinely unsupported/rebranded hardware (empty id, non-printable characters, "heidelbridge" marker) is untouched.

### Testing

- [ ] Verified that a wallbox unreachable at startup now surfaces `cannot create charger ...: station id: dial tcp ...: connect: connection refused` instead of `sponsorship required`
- [ ] Verified that a reachable wallbox still initializes without a sponsor token (as all DaheimLaden models are sponsor-free)

### Note

⚠️ This does not necessarily fix the reported "stuck until an external Modbus request is sent" behavior, which may be caused by a separate issue in connection handling further down in `util/modbus` (`TcpSettings.Connection(ctx)`). This PR only fixes the error message being wrong/misleading.


Created with the help of Claude AI