### PR TITLE
Sungrow string inverters: add EEG §9 curtailment

### DIFF
--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -9,6 +9,7 @@ params:
   - name: modbus
     choice: ["rs485", "tcpip"]
     baudrate: 9600
+  - name: maxacpower
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -43,4 +44,72 @@ render: |
       address: 5003 # Total power yields, 1 kWh
       type: input
       decode: uint32s
+  maxacpower: {{ .maxacpower }} # W
+  # EEG §9 curtailment via the power limitation registers.
+  # Addresses below are 0-based, i.e. documentation register minus one:
+  #   5006 (doc 5007) power limitation switch, 0xAA enable / 0x55 disable
+  #   5007 (doc 5008) power limitation value, 0.1 % of nominal power
+  # Note the SH hybrid series uses a different map, where doc 5008 is the
+  # internal temperature - do not reuse these addresses there.
+  # Writes must use `writesingle`; `holding` would build a read operation.
+  curtail:
+    source: sequence
+    set:
+      - source: modbus
+        {{- include "modbus" . | indent 4 }}
+        register:
+          address: 5007 # Power limitation setting, 0.1 %
+          type: writesingle
+          decode: uint16
+        scale: 10
+      - source: switch
+        switch:
+          - case: 100 # uncurtailed - disable limitation
+            set:
+              source: const
+              value: 85 # 0x55
+              set:
+                source: modbus
+                {{- include "modbus" . | indent 8 }}
+                register:
+                  address: 5006 # Power limitation switch
+                  type: writesingle
+                  decode: uint16
+        default:
+          source: const
+          value: 170 # 0xAA
+          set:
+            source: modbus
+            {{- include "modbus" . | indent 6 }}
+            register:
+              address: 5006 # Power limitation switch
+              type: writesingle
+              decode: uint16
+  curtailed:
+    source: go
+    in:
+      - name: ena
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 6 }}
+          register:
+            address: 5006
+            type: holding
+            decode: uint16
+      - name: limit
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 6 }}
+          register:
+            address: 5007
+            type: holding
+            decode: uint16
+    script: |
+      percent := 100
+      if ena == 170 {
+        percent = limit / 10
+      }
+      percent
   {{- end }}

--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -3,6 +3,7 @@ products:
   - brand: Sungrow
     description:
       generic: SG Series Inverter
+capabilities: ["curtail"]
 params:
   - name: usage
     choice: ["grid", "pv"]
@@ -56,7 +57,7 @@ render: |
     source: sequence
     set:
       - source: modbus
-        {{- include "modbus" . | indent 4 }}
+        {{- include "modbus" . | indent 6 }}
         register:
           address: 5007 # Power limitation setting, 0.1 %
           type: writesingle
@@ -70,7 +71,7 @@ render: |
               value: 85 # 0x55
               set:
                 source: modbus
-                {{- include "modbus" . | indent 8 }}
+                {{- include "modbus" . | indent 14 }}
                 register:
                   address: 5006 # Power limitation switch
                   type: writesingle
@@ -80,7 +81,7 @@ render: |
           value: 170 # 0xAA
           set:
             source: modbus
-            {{- include "modbus" . | indent 6 }}
+            {{- include "modbus" . | indent 10 }}
             register:
               address: 5006 # Power limitation switch
               type: writesingle
@@ -92,7 +93,7 @@ render: |
         type: int
         config:
           source: modbus
-          {{- include "modbus" . | indent 6 }}
+          {{- include "modbus" . | indent 8 }}
           register:
             address: 5006
             type: holding
@@ -101,7 +102,7 @@ render: |
         type: int
         config:
           source: modbus
-          {{- include "modbus" . | indent 6 }}
+          {{- include "modbus" . | indent 8 }}
           register:
             address: 5007
             type: holding

--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -10,7 +10,6 @@ params:
   - name: modbus
     choice: ["rs485", "tcpip"]
     baudrate: 9600
-  - name: maxacpower
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -45,17 +44,33 @@ render: |
       address: 5003 # Total power yields, 1 kWh
       type: input
       decode: uint32s
-  maxacpower: {{ .maxacpower }} # W
-  # EEG §9 curtailment via the power limitation registers.
-  # Addresses below are 0-based, i.e. documentation register minus one:
+  # EEG §9 curtailment via the power limitation registers
   #   5006 (doc 5007) power limitation switch, 0xAA enable / 0x55 disable
   #   5007 (doc 5008) power limitation value, 0.1 % of nominal power
-  # Note the SH hybrid series uses a different map, where doc 5008 is the
-  # internal temperature - do not reuse these addresses there.
-  # Writes must use `writesingle`; `holding` would build a read operation.
   curtail:
     source: sequence
     set:
+      # Order matters: the switch must be set BEFORE the value. While the
+      # limitation is disabled the inverter resets register 5007 to its 110 %
+      # default, so writing the value first would be discarded when coming back
+      # from an uncurtailed state.
+      - source: go
+        script: |
+          ena := 170 // 0xAA - enable limitation
+          if curtail == 100 {
+            ena = 85 // 0x55 - disable limitation
+          }
+          ena
+        out:
+          - name: ena
+            type: int
+            config:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 5006 # Power limitation switch
+                type: writesingle
+                decode: uint16
       - source: modbus
         {{- include "modbus" . | indent 6 }}
         register:
@@ -63,29 +78,6 @@ render: |
           type: writesingle
           decode: uint16
         scale: 10
-      - source: switch
-        switch:
-          - case: 100 # uncurtailed - disable limitation
-            set:
-              source: const
-              value: 85 # 0x55
-              set:
-                source: modbus
-                {{- include "modbus" . | indent 14 }}
-                register:
-                  address: 5006 # Power limitation switch
-                  type: writesingle
-                  decode: uint16
-        default:
-          source: const
-          value: 170 # 0xAA
-          set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 5006 # Power limitation switch
-              type: writesingle
-              decode: uint16
   curtailed:
     source: go
     in:


### PR DESCRIPTION
Adds `api.Curtailer` support to the `sungrow-inverter` template, so SG series
string inverters can be curtailed per EEG §9. Previously only the hybrid (SH)
series was covered.

### Registers

From the Sungrow *Communication Protocol of PV Grid-Connected String Inverters*
(V1.1.37). Addresses are 0-based, i.e. documentation register minus one:

| address | documentation | meaning |
|---|---|---|
| 5006 | 5007 | power limitation switch, `0xAA` enable / `0x55` disable |
| 5007 | 5008 | power limitation value, 0.1 % of nominal power |

Note these differ from the SH hybrid map, where 5008 is the internal temperature.

### Tested

On an SG6.0RT (WiNet-S, Modbus TCP, slave 1), driven through
`hems: type: custom` with a constant `curtailedPercent`, reading the holding
registers back independently:

| commanded | switch (5006) | value (5007) | AC output |
|---|---|---|---|
| 60 % | `0xAA` | 600 | 2333 W (not binding, PV below limit) |
| 30 % | `0xAA` | 300 | 1833 W (curtailing as expected) |
| 0 % | `0xAA` | 0 | 0 W (production stopped) |
| 100 % | `0x55` | 1100 | 0 W (limitation disabled, still ramping up) |

The 30 % case is the clearest evidence: the inverter physically settled at
~1833 W against a ~1847 W setpoint. The 0 % case stops production entirely.

`scale: 10` applies correctly on the write path, and the `sequence` / `switch`
construct behaves as in `fronius-gen24`.

### Scope of testing

All of the above was verified on a **single SG6.0RT** (via WiNet-S, Modbus TCP).
The registers come from the Sungrow *Communication Protocol of PV Grid-Connected
String Inverters* and should apply across the SG series, but I can only vouch for
the one model I own. If anyone with a different SG inverter can confirm, that
would be worth having before this is relied upon broadly.

### Open question

After disabling the limitation at 100 %, the value register reads **1100**
rather than the 1000 that was written. This reproduced across separate test
runs, so it is consistent behaviour rather than a one-off. My assumption is that the inverter
restores its 110 % default when the limitation is switched off, but I have not
confirmed that against the documentation. It has no functional effect, since the
switch governs whether the value is applied at all — but I would rather flag it
than leave it unexplained.

### Note for other implementers

Write registers must use `type: writesingle`. With `type: holding` evcc builds a
read operation and fails with `invalid func code: 3`
(`util/modbus/register.go`). Cost me a debugging round; possibly worth a line in
the plugin docs.
