### PR TITLE
SolarMax MAX.STORAGE: drop the whole-kWh energy register

### DIFF
--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -39,13 +39,7 @@ render: |
       address: 110 # PV-Leistung MAX.STORAGE
       type: input
       decode: int32s
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register: # manual non-sunspec register configuration
-      address: 150 # Produzierte PV-Energie
-      type: input
-      decode: int32s
+  # energy removed: register 150 (Produzierte PV-Energie) only resolves whole kWh (#32324)
   maxacpower: {{ .maxacpower }}
   {{- end }}
   {{- if eq .usage "battery" }}


### PR DESCRIPTION
Follow-up to #32497, same defect on the device that actually reported it.

Register 150 (`Produzierte PV-Energie`) is `int32s` with no scale — the meter reports whole kWh. In #32324 the affected device `db:6` ("PV Dach") is a `solarmax-maxstorage` in `pv` usage, and its `evcc meter` dump steps in whole units:

```
Power:  8091W        Energy: 53740.0kWh   11:53
Power:  8494W        Energy: 53740.0kWh   12:08
Power:  8686W        Energy: 53743.0kWh   12:23
```

History slots are 15min, so below 4 kW a slot's energy stays under 1 kWh and the counter does not move. That slot is stored as 0 and the next one absorbs the jump — only every other slot gets plotted while the daily footer sum stays correct.

#32497 removed the equivalent register from `solarmax-inverter-smt`, but left this template in place. Dropping `energy` here makes the pv usage a power-only meter, so evcc integrates power for the history. A comment in its place records why, so the register does not get added back.

## Trade-off

The meter no longer contributes to the lifetime PV energy total — that reading was whole-kWh anyway. Per-slot and per-day energy now come from power integration at the configured update interval.

`grid` and `battery` usages are untouched; neither exposes an energy register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
