### PR TITLE
DaheimLaden: Move checkStation to after getting current

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -120,6 +120,12 @@ func NewDaheimLaden(ctx context.Context, settings modbus.TcpSettings, phases boo
 		wb.curr = curr
 	}
 
+	if !sponsor.IsAuthorized() {
+		if err := wb.checkStation(); err != nil {
+			return nil, err
+		}
+	}
+
 	// get failsafe timeout from charger
 	b, err := wb.conn.ReadHoldingRegisters(dlRegCommTimeout, 1)
 	if err != nil {
@@ -132,12 +138,6 @@ func NewDaheimLaden(ctx context.Context, settings modbus.TcpSettings, phases boo
 	if phases {
 		implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
 		implement.Has(wb, implement.PhaseGetter(wb.getPhases))
-	}
-
-	if !sponsor.IsAuthorized() {
-		if err := wb.checkStation(); err != nil {
-			return nil, err
-		}
 	}
 
 	return wb, nil

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -108,6 +108,9 @@ func NewDaheimLaden(ctx context.Context, settings modbus.TcpSettings, phases boo
 		phases: 3,  // assume 3p
 	}
 
+    // First Modbus read must be minimal (1 register) to avoid errors after charger reboot
+    // when no sponsor token is present. `checkStation` reads 22 registers and is intentionally
+    // called later.
 	// get initial state from charger
 	curr, err := wb.getCurrent()
 	if err != nil {

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -108,12 +108,6 @@ func NewDaheimLaden(ctx context.Context, settings modbus.TcpSettings, phases boo
 		phases: 3,  // assume 3p
 	}
 
-	if !sponsor.IsAuthorized() {
-		if err := wb.checkStation(); err != nil {
-			return nil, err
-		}
-	}
-
 	// get initial state from charger
 	curr, err := wb.getCurrent()
 	if err != nil {
@@ -135,6 +129,12 @@ func NewDaheimLaden(ctx context.Context, settings modbus.TcpSettings, phases boo
 	if phases {
 		implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
 		implement.Has(wb, implement.PhaseGetter(wb.getPhases))
+	}
+
+	if !sponsor.IsAuthorized() {
+		if err := wb.checkStation(); err != nil {
+			return nil, err
+		}
 	}
 
 	return wb, nil


### PR DESCRIPTION
fix #32907 

mit Token funktioniert der Neustart, ohne Token funktioniert er nicht.
Unterschied ist, dass der erste Aufruf "ohne Token" einen 22 Register Block umfasst, der erste Aufruf "mit Token" jedoch nur 1 Register. 