### PR TITLE
Phases: disable instead of scaling down to 1p without sufficient surplus

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1447,6 +1447,13 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		insufficient := (sitePower > 0 || !lp.enabled) && powerToCurrent(availablePower, activePhases) < minCurrent
 		if insufficient {
 			lp.log.DEBUG.Printf("available power %.0fW < %.0fW min %dp threshold", availablePower, float64(activePhases)*Voltage*minCurrent, activePhases)
+
+			// while charging, scaling down is only worthwhile if 1p is sustainable,
+			// otherwise disabling is preferable over waiting for the phase timer
+			if lp.enabled && lp.charging() && powerToCurrent(availablePower, 1) < minCurrent {
+				lp.log.DEBUG.Printf("available power %.0fW < %.0fW min 1p threshold, disabling instead of scaling down", availablePower, Voltage*minCurrent)
+				insufficient = false
+			}
 		}
 
 		// scaling down also frees load management headroom for min power on activePhases

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1447,17 +1447,17 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		insufficient := (sitePower > 0 || !lp.enabled) && powerToCurrent(availablePower, activePhases) < minCurrent
 		if insufficient {
 			lp.log.DEBUG.Printf("available power %.0fW < %.0fW min %dp threshold", availablePower, float64(activePhases)*Voltage*minCurrent, activePhases)
+		}
 
-			// while charging, scaling down is only worthwhile if 1p is sustainable,
-			// otherwise disabling is preferable over waiting for the phase timer
-			if lp.enabled && lp.charging() && powerToCurrent(availablePower, 1) < minCurrent {
-				lp.log.DEBUG.Printf("available power %.0fW < %.0fW min 1p threshold, disabling instead of scaling down", availablePower, Voltage*minCurrent)
-				insufficient = false
-			}
+		// while charging, scaling down only helps if 1p is sustainable, otherwise it
+		// merely delays the pv disable timer by the phase timer duration
+		useful := !lp.enabled || !lp.charging() || powerToCurrent(availablePower, 1) >= minCurrent
+		if insufficient && !useful {
+			lp.log.DEBUG.Printf("available power %.0fW < %.0fW min 1p threshold, disabling instead of scaling down", availablePower, Voltage*minCurrent)
 		}
 
 		// scaling down also frees load management headroom for min power on activePhases
-		scalable = insufficient || !lp.circuitAllowsPhases(activePhases, minCurrent)
+		scalable = insufficient && useful || !lp.circuitAllowsPhases(activePhases, minCurrent)
 	}
 
 	// scale down phases

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -271,6 +271,7 @@ func TestPvScalePhases(t *testing.T) {
 			// scale down
 			min1p := 0.1
 			lp.phaseTimer = time.Time{}
+			lp.chargePower = float64(lp.ActivePhases()) * minA * Voltage // charging at min current
 
 			plainCharger.EXPECT().Enable(false).Return(nil).MaxTimes(1)
 			phaseCharger.EXPECT().Phases1p3p(1).Return(nil).MaxTimes(1)
@@ -370,6 +371,17 @@ func TestPvScalePhasesTimer(t *testing.T) {
 		}},
 		{"3/3->1, timer elapsed", 3, 3, 0.1, 1, 1, func(lp *Loadpoint) {
 			lp.phaseTimer = elapsed
+		}},
+
+		// charging with insufficient power for 1p: disable instead of scaling down
+		{"3/3->1, insufficient for 1p, charging", 3, 3, 0.1, 3, 0, func(lp *Loadpoint) {
+			lp.phaseTimer = elapsed
+			lp.enabled = true
+		}},
+		{"3/3->1, sufficient for 1p, charging", 3, 3, 3 * Voltage * minA / 2, 1, 1, func(lp *Loadpoint) {
+			lp.phaseTimer = elapsed
+			lp.enabled = true
+			lp.chargePower = 3 * Voltage * minA
 		}},
 
 		// switch down from 3p/0p while not yet charging

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -752,8 +752,9 @@ func TestPVHysteresisAfterPhaseSwitch(t *testing.T) {
 			Disable: loadpoint.ThresholdConfig{
 				Delay: dt,
 			},
-			status:  api.StatusC,
-			enabled: true,
+			status:      api.StatusC,
+			enabled:     true,
+			chargePower: 3 * Voltage * minA, // charging 3p at min current
 		}
 
 		start := clock.Now()


### PR DESCRIPTION
When charging on 3p and available power drops below the 3p minimum, the loadpoint starts the phase scale-down timer. If there is not enough surplus for 1p min current either, that timer only delays the inevitable disable — meanwhile charging continues at 3p min for the full disable delay, discharging the home battery (reported after battery boost ends at min soc).

Skip the scale-down when 1p is not sustainable, so the pv disable timer kicks in immediately instead. Once disabled, the existing not-charging path scales down to 1p right away.

See https://github.com/evcc-io/evcc/discussions/32834#discussioncomment-18082826

Test fixtures gained a realistic `chargePower` — they previously left it at 0 while asserting behaviour for a loadpoint charging at min current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)