### PR TITLE
Planner: consider multiple plans and add absence option

### DIFF
--- a/api/plans.go
+++ b/api/plans.go
@@ -2,15 +2,72 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 )
 
 type RepeatingPlan struct {
-	Weekdays []int  `json:"weekdays"` // 0-6 (Sunday-Saturday)
-	Time     string `json:"time"`     // HH:MM
-	Tz       string `json:"tz"`       // timezone in IANA format
-	Soc      int    `json:"soc"`      // target soc
-	Active   bool   `json:"active"`   // active flag
+	Weekdays []int        `json:"weekdays"`          // 0-6 (Sunday-Saturday)
+	Time     string       `json:"time"`              // HH:MM
+	Tz       string       `json:"tz"`                // timezone in IANA format
+	Soc      int          `json:"soc"`               // target soc, optional if absence is set
+	Active   bool         `json:"active"`            // active flag
+	Absence  *PlanAbsence `json:"absence,omitempty"` // absence following the plan time
+}
+
+// PlanGoal describes a single charging goal for multi-goal planning
+type PlanGoal struct {
+	Duration time.Duration // required cumulative charging duration from now to reach the goal by Time
+	Time     time.Time     // target time
+	Absence  time.Duration // duration of absence following target time- no charging during absence
+}
+
+// PlanAbsence describes an absence following a plan's target time during which
+// the vehicle cannot charge and its soc drops, e.g. a trip
+type PlanAbsence struct {
+	Duration time.Duration `json:"duration"` // absence duration
+	Soc      int           `json:"soc"`      // expected soc drop during absence in %
+}
+
+type planAbsence struct {
+	Duration int64 `json:"duration"` // absence duration in seconds
+	Soc      int   `json:"soc"`      // expected soc drop during absence in %
+}
+
+func (pa PlanAbsence) MarshalJSON() ([]byte, error) {
+	return json.Marshal(planAbsence{
+		Duration: int64(pa.Duration.Seconds()),
+		Soc:      pa.Soc,
+	})
+}
+
+func (pa *PlanAbsence) UnmarshalJSON(data []byte) error {
+	var res planAbsence
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+
+	*pa = PlanAbsence{
+		Duration: time.Duration(res.Duration) * time.Second,
+		Soc:      res.Soc,
+	}
+
+	return nil
+}
+
+// Validate validates the absence
+func (pa *PlanAbsence) Validate() error {
+	if pa == nil {
+		return nil
+	}
+	if pa.Soc <= 0 || pa.Soc > 100 {
+		return fmt.Errorf("absence soc drop out of range: %d", pa.Soc)
+	}
+	if pa.Duration <= 0 {
+		return errors.New("absence duration must be positive")
+	}
+	return nil
 }
 
 type PlanStrategy struct {

--- a/core/keys/loadpoint.go
+++ b/core/keys/loadpoint.go
@@ -91,6 +91,7 @@ const (
 	PlanTime           = "planTime"           // charge plan finish time goal
 	PlanEnergy         = "planEnergy"         // charge plan energy goal
 	PlanSoc            = "planSoc"            // charge plan soc goal
+	PlanAbsence        = "planAbsence"        // charge plan absence (duration, soc drop)
 	PlanActive         = "planActive"         // charge plan has determined current slot to be an active slot
 	PlanProjectedStart = "planProjectedStart" // charge plan start time (earliest slot)
 	PlanProjectedEnd   = "planProjectedEnd"   // charge plan ends (end of last slot)

--- a/core/loadpoint/api.go
+++ b/core/loadpoint/api.go
@@ -139,8 +139,10 @@ type API interface {
 	SetPlanStrategy(api.PlanStrategy) error
 	// SocBasedPlanning determines if the planner is soc based
 	SocBasedPlanning() bool
-	// GetPlan creates a charging plan
-	GetPlan(targetTime time.Time, requiredDuration, precondition time.Duration, continuous bool) api.Rates
+	// GetPlan creates a charging plan for the given goals
+	GetPlan(goals []api.PlanGoal, precondition time.Duration, continuous bool) api.Rates
+	// GetPlannerGoals returns the planner goals: the next plan first, followed by later pending plans
+	GetPlannerGoals(planTime time.Time, requiredDuration time.Duration, maxPower float64) []api.PlanGoal
 
 	// GetSocConfig returns the soc poll settings
 	GetSocConfig() SocConfig

--- a/core/loadpoint/mock.go
+++ b/core/loadpoint/mock.go
@@ -502,17 +502,17 @@ func (mr *MockAPIMockRecorder) GetPhasesConfigured() *gomock.Call {
 }
 
 // GetPlan mocks base method.
-func (m *MockAPI) GetPlan(targetTime time.Time, requiredDuration, precondition time.Duration, continuous bool) api.Rates {
+func (m *MockAPI) GetPlan(goals []api.PlanGoal, precondition time.Duration, continuous bool) api.Rates {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlan", targetTime, requiredDuration, precondition, continuous)
+	ret := m.ctrl.Call(m, "GetPlan", goals, precondition, continuous)
 	ret0, _ := ret[0].(api.Rates)
 	return ret0
 }
 
 // GetPlan indicates an expected call of GetPlan.
-func (mr *MockAPIMockRecorder) GetPlan(targetTime, requiredDuration, precondition, continuous any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPlan(goals, precondition, continuous any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), targetTime, requiredDuration, precondition, continuous)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlan", reflect.TypeOf((*MockAPI)(nil).GetPlan), goals, precondition, continuous)
 }
 
 // GetPlanEnergy mocks base method.
@@ -571,6 +571,20 @@ func (m *MockAPI) GetPlanStrategy() api.PlanStrategy {
 func (mr *MockAPIMockRecorder) GetPlanStrategy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlanStrategy", reflect.TypeOf((*MockAPI)(nil).GetPlanStrategy))
+}
+
+// GetPlannerGoals mocks base method.
+func (m *MockAPI) GetPlannerGoals(planTime time.Time, requiredDuration time.Duration, maxPower float64) []api.PlanGoal {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlannerGoals", planTime, requiredDuration, maxPower)
+	ret0, _ := ret[0].([]api.PlanGoal)
+	return ret0
+}
+
+// GetPlannerGoals indicates an expected call of GetPlannerGoals.
+func (mr *MockAPIMockRecorder) GetPlannerGoals(planTime, requiredDuration, maxPower any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlannerGoals", reflect.TypeOf((*MockAPI)(nil).GetPlannerGoals), planTime, requiredDuration, maxPower)
 }
 
 // GetPriority mocks base method.

--- a/core/loadpoint_effective.go
+++ b/core/loadpoint_effective.go
@@ -35,15 +35,17 @@ func (lp *Loadpoint) EffectivePriority() int {
 }
 
 type plan struct {
-	Id    int
-	Start time.Time // last possible start time
-	End   time.Time // user-selected finish time
-	Soc   int
+	Id      int
+	Start   time.Time // last possible start time
+	End     time.Time // user-selected finish time
+	Soc     int       // user-selected (or absence-derived) target soc
+	Goal    int       // planning goal including accumulated absence soc drops, capped at 100
+	Absence *api.PlanAbsence
 }
 
 func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {
 	for i, p := range plans {
-		requiredDuration := lp.getPlanRequiredDuration(float64(p.Soc), maxPower)
+		requiredDuration := lp.getPlanRequiredDuration(float64(p.Goal), maxPower)
 		plans[i].Start = p.End.Add(-requiredDuration)
 	}
 
@@ -53,7 +55,7 @@ func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {
 	})
 
 	for _, p := range plans {
-		if lp.vehicleSoc == 0 || lp.vehicleSoc < float64(p.Soc) {
+		if lp.vehicleSoc == 0 || lp.vehicleSoc < float64(p.Goal) {
 			return &p
 		}
 	}
@@ -61,59 +63,87 @@ func (lp *Loadpoint) nextActivePlan(maxPower float64, plans []plan) *plan {
 	return nil
 }
 
-// nextVehiclePlan returns the next vehicle plan time, soc, id
+// vehiclePlans returns all vehicle plans sorted by target time. Absence plans without
+// explicit soc get a derived soc covering the drop plus min soc. Accumulated soc drops
+// of earlier absences increase the planning goal of later plans.
+func (lp *Loadpoint) vehiclePlans() []plan {
+	v := lp.GetVehicle()
+	if v == nil {
+		return nil
+	}
+
+	var plans []plan
+
+	// static plan
+	if planTime, soc, absence := vehicle.Settings(lp.log, v).GetPlanSoc(); soc != 0 || absence != nil {
+		plans = append(plans, plan{Id: 1, Soc: soc, End: planTime, Absence: absence})
+	}
+
+	// repeating plans
+	for index, rp := range vehicle.Settings(lp.log, v).GetRepeatingPlans() {
+		if !rp.Active || len(rp.Weekdays) == 0 {
+			continue
+		}
+
+		planTime, err := util.GetNextOccurrence(rp.Weekdays, rp.Time, rp.Tz)
+		if err != nil {
+			lp.log.DEBUG.Printf("invalid repeating plan: weekdays=%v, time=%s, tz=%s, error=%v", rp.Weekdays, rp.Time, rp.Tz, err)
+			continue
+		}
+
+		plans = append(plans, plan{Id: index + 2, Soc: rp.Soc, End: planTime, Absence: rp.Absence})
+	}
+
+	// sort plans by target time
+	slices.SortStableFunc(plans, func(i, j plan) int {
+		return i.End.Compare(j.End)
+	})
+
+	minSoc := lp.effectiveMinSoc()
+	var drops int
+	for i := range plans {
+		p := &plans[i]
+		if p.Soc == 0 && p.Absence != nil {
+			p.Soc = min(100, minSoc+p.Absence.Soc)
+		}
+		p.Goal = min(100, p.Soc+drops)
+		if p.Absence != nil {
+			drops += p.Absence.Soc
+		}
+	}
+
+	return plans
+}
+
+// nextVehiclePlan returns the next vehicle plan
 // Returns locked plan if available, otherwise calculates fresh
-func (lp *Loadpoint) nextVehiclePlan() (time.Time, int, int) {
+func (lp *Loadpoint) nextVehiclePlan() *plan {
 	// return locked plan if available
 	if p := lp.planLocked; p.Id > 0 {
-		return p.Time, p.Soc, p.Id
+		return &plan{Id: p.Id, End: p.Time, Soc: p.Soc, Goal: p.Goal}
 	}
 
-	// calculate fresh plan
-	if v := lp.GetVehicle(); v != nil {
-		var plans []plan
-
-		// static plan
-		if planTime, soc := vehicle.Settings(lp.log, v).GetPlanSoc(); soc != 0 {
-			plans = append(plans, plan{Id: 1, Soc: soc, End: planTime})
-		}
-
-		// repeating plans
-		for index, rp := range vehicle.Settings(lp.log, v).GetRepeatingPlans() {
-			if !rp.Active || len(rp.Weekdays) == 0 {
-				continue
-			}
-
-			planTime, err := util.GetNextOccurrence(rp.Weekdays, rp.Time, rp.Tz)
-			if err != nil {
-				lp.log.DEBUG.Printf("invalid repeating plan: weekdays=%v, time=%s, tz=%s, error=%v", rp.Weekdays, rp.Time, rp.Tz, err)
-				continue
-			}
-
-			plans = append(plans, plan{Id: index + 2, Soc: rp.Soc, End: planTime})
-		}
-
-		// calculate earliest required plan start
-		if plan := lp.nextActivePlan(lp.effectiveMaxPower(), plans); plan != nil {
-			return plan.End, plan.Soc, plan.Id
-		}
-	}
-	return time.Time{}, 0, 0
+	// calculate earliest required plan start
+	return lp.nextActivePlan(lp.effectiveMaxPower(), lp.vehiclePlans())
 }
 
 // EffectivePlanSoc returns the soc target for the current plan
 func (lp *Loadpoint) EffectivePlanSoc() int {
 	lp.RLock()
 	defer lp.RUnlock()
-	_, soc, _ := lp.nextVehiclePlan()
-	return soc
+	if p := lp.nextVehiclePlan(); p != nil {
+		return p.Soc
+	}
+	return 0
 }
 
 // getPlanId returns the plan id of the current/next plan
 func (lp *Loadpoint) getPlanId() int {
 	if lp.socBasedPlanning() {
-		_, _, id := lp.nextVehiclePlan()
-		return id
+		if p := lp.nextVehiclePlan(); p != nil {
+			return p.Id
+		}
+		return 0
 	}
 	if lp.planEnergy > 0 {
 		return 1
@@ -133,8 +163,10 @@ func (lp *Loadpoint) EffectivePlanTime() time.Time {
 	lp.RLock()
 	defer lp.RUnlock()
 	if lp.socBasedPlanning() {
-		ts, _, _ := lp.nextVehiclePlan()
-		return ts
+		if p := lp.nextVehiclePlan(); p != nil {
+			return p.End
+		}
+		return time.Time{}
 	}
 
 	ts, _ := lp.getPlanEnergy()

--- a/core/loadpoint_effective_test.go
+++ b/core/loadpoint_effective_test.go
@@ -173,32 +173,32 @@ func TestNextPlan(t *testing.T) {
 		plans  []plan
 	}{
 		{1, 0, []plan{
-			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
-			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 10},
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10, Goal: 10},
+			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 10, Goal: 10},
 		}},
 		{0, 20, []plan{
-			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
-			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 10},
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10, Goal: 10},
+			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 10, Goal: 10},
 		}},
 		{1, 0, []plan{
-			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 20},
-			{Id: 2, End: clock.Now().Add(9 * time.Hour), Soc: 20},
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 20, Goal: 20},
+			{Id: 2, End: clock.Now().Add(9 * time.Hour), Soc: 20, Goal: 20},
 		}},
 		{2, 0, []plan{
-			{Id: 2, End: clock.Now().Add(8 * time.Hour), Soc: 20},
-			{Id: 1, End: clock.Now().Add(9 * time.Hour), Soc: 20},
+			{Id: 2, End: clock.Now().Add(8 * time.Hour), Soc: 20, Goal: 20},
+			{Id: 1, End: clock.Now().Add(9 * time.Hour), Soc: 20, Goal: 20},
 		}},
 		{2, 0, []plan{
-			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
-			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 60},
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10, Goal: 10},
+			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 60, Goal: 60},
 		}},
 		{1, 5, []plan{
-			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
-			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 20},
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10, Goal: 10},
+			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 20, Goal: 20},
 		}},
 		{2, 15, []plan{
-			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10},
-			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 20},
+			{Id: 1, End: clock.Now().Add(8 * time.Hour), Soc: 10, Goal: 10},
+			{Id: 2, End: clock.Now().Add(10 * time.Hour), Soc: 20, Goal: 20},
 		}},
 	} {
 		lp.vehicleSoc = float64(tc.soc)
@@ -215,6 +215,38 @@ func TestNextPlan(t *testing.T) {
 	}
 }
 
+func TestVehiclePlansAbsence(t *testing.T) {
+	config.Reset()
+	t.Cleanup(config.Reset)
+
+	ctrl := gomock.NewController(t)
+	v := api.NewMockVehicle(ctrl)
+
+	const name = "vehicle"
+	require.NoError(t, config.Vehicles().Add(
+		config.NewStaticDevice(config.Named{Name: name}, api.Vehicle(v)),
+	))
+
+	// static absence-only plan (no explicit soc)
+	planTime := time.Now().Add(2 * time.Hour).Truncate(time.Second)
+	settings.SetTime("vehicle."+name+"."+keys.PlanTime, planTime)
+	require.NoError(t, settings.SetJson("vehicle."+name+"."+keys.PlanAbsence, &api.PlanAbsence{Duration: 48 * time.Hour, Soc: 30}))
+
+	lp := NewLoadpoint(util.NewLogger("foo"), nil)
+	lp.vehicle = v
+	lp.minSoc = 10
+
+	plans := lp.vehiclePlans()
+	require.Len(t, plans, 1)
+
+	// derived soc covers min soc plus absence drop
+	assert.Equal(t, 40, plans[0].Soc)
+	assert.Equal(t, 40, plans[0].Goal)
+	assert.Equal(t, planTime, plans[0].End)
+	require.NotNil(t, plans[0].Absence)
+	assert.Equal(t, 48*time.Hour, plans[0].Absence.Duration)
+}
+
 func TestPlanLocking(t *testing.T) {
 	clk := clock.NewMock()
 	now := clk.Now()
@@ -225,28 +257,28 @@ func TestPlanLocking(t *testing.T) {
 	planTime := now.Add(2 * time.Hour)
 
 	t.Run("lock and unlock", func(t *testing.T) {
-		lp.lockPlanGoal(planTime, 80, 2)
+		lp.lockPlanGoal(planTime, 80, 80, 2)
 
 		// locked values returned before plan target
-		ts, soc, id := lp.nextVehiclePlan()
-		assert.Equal(t, planTime, ts)
-		assert.Equal(t, 80, soc)
-		assert.Equal(t, 2, id)
+		p := lp.nextVehiclePlan()
+		require.NotNil(t, p)
+		assert.Equal(t, planTime, p.End)
+		assert.Equal(t, 80, p.Soc)
+		assert.Equal(t, 80, p.Goal)
+		assert.Equal(t, 2, p.Id)
 
 		clk.Add(3 * time.Hour) // advance past plan target
 
 		// locked values persist during overrun
-		ts, soc, id = lp.nextVehiclePlan()
-		assert.Equal(t, planTime, ts)
-		assert.Equal(t, 80, soc)
-		assert.Equal(t, 2, id)
+		p = lp.nextVehiclePlan()
+		require.NotNil(t, p)
+		assert.Equal(t, planTime, p.End)
+		assert.Equal(t, 80, p.Soc)
+		assert.Equal(t, 2, p.Id)
 
 		// after clearing, lock is not returned
 		lp.clearPlanLock()
-		ts, soc, id = lp.nextVehiclePlan()
-		assert.True(t, ts.IsZero())
-		assert.Equal(t, 0, soc)
-		assert.Equal(t, 0, id)
+		assert.Nil(t, lp.nextVehiclePlan())
 	})
 }
 

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -18,6 +18,7 @@ import (
 type PlanLock struct {
 	Time time.Time // target time (committed goal, persists during overrun)
 	Soc  int       // target soc
+	Goal int       // planning goal including accumulated absence soc drops
 	Id   int       // id (0=none, 1=static, 2+=repeating), needed to highlight the plan in ui
 }
 
@@ -34,10 +35,11 @@ func (lp *Loadpoint) ClearPlanLock() {
 }
 
 // lockPlanGoal locks the current plan goal to handle overruns (soc-based plans)
-func (lp *Loadpoint) lockPlanGoal(planTime time.Time, soc int, id int) {
+func (lp *Loadpoint) lockPlanGoal(planTime time.Time, soc, goal, id int) {
 	lp.planLocked = PlanLock{
 		Time: planTime,
 		Soc:  soc,
+		Goal: goal,
 		Id:   id,
 	}
 }
@@ -62,7 +64,7 @@ func (lp *Loadpoint) finishPlan() {
 	} else if !lp.socBasedPlanning() {
 		lp.setPlanEnergy(time.Time{}, 0)
 	} else if v := lp.GetVehicle(); v != nil {
-		vehicle.Settings(lp.log, v).SetPlanSoc(time.Time{}, 0)
+		vehicle.Settings(lp.log, v).SetPlanSoc(time.Time{}, 0, nil)
 	}
 }
 
@@ -97,25 +99,61 @@ func (lp *Loadpoint) GetPlanGoal() (float64, bool) {
 	defer lp.RUnlock()
 
 	if lp.socBasedPlanning() {
-		_, soc, _ := lp.nextVehiclePlan()
-		return float64(soc), true
+		if p := lp.nextVehiclePlan(); p != nil {
+			return float64(p.Goal), true
+		}
+		return 0, true
 	}
 
 	_, limit := lp.getPlanEnergy()
 	return limit, false
 }
 
-// GetPlan creates a charging plan for given time and duration
+// GetPlan creates a charging plan for the given goals
 // The plan is sorted by time
-func (lp *Loadpoint) GetPlan(targetTime time.Time, requiredDuration, precondition time.Duration, continuous bool) api.Rates {
-	if lp.planner == nil || targetTime.IsZero() {
+func (lp *Loadpoint) GetPlan(goals []api.PlanGoal, precondition time.Duration, continuous bool) api.Rates {
+	if lp.planner == nil || len(goals) == 0 || goals[0].Time.IsZero() {
 		return nil
 	}
 
-	lp.log.TRACE.Printf("plan: creating plan with continuous=%v, precondition=%v, duration=%v, target=%v",
-		continuous, precondition, requiredDuration.Round(time.Second), targetTime.Round(time.Second).Local())
+	lp.log.TRACE.Printf("plan: creating plan with continuous=%v, precondition=%v, duration=%v, target=%v, goals=%d",
+		continuous, precondition, goals[0].Duration.Round(time.Second), goals[0].Time.Round(time.Second).Local(), len(goals))
 
-	return lp.planner.Plan(requiredDuration, precondition, targetTime, continuous)
+	return lp.planner.PlanGoals(goals, precondition, continuous)
+}
+
+// GetPlannerGoals returns the planner goals: the next plan first, followed by later
+// pending plans with their additional charging durations and absence windows
+func (lp *Loadpoint) GetPlannerGoals(planTime time.Time, requiredDuration time.Duration, maxPower float64) []api.PlanGoal {
+	lp.RLock()
+	defer lp.RUnlock()
+
+	goals := []api.PlanGoal{{Duration: requiredDuration, Time: planTime}}
+
+	if !lp.socBasedPlanning() {
+		return goals
+	}
+
+	for _, p := range lp.vehiclePlans() {
+		var absence time.Duration
+		if p.Absence != nil {
+			absence = p.Absence.Duration
+		}
+
+		// the next plan itself only contributes its absence window
+		if p.End.Equal(planTime) {
+			goals[0].Absence = absence
+			continue
+		}
+
+		goals = append(goals, api.PlanGoal{
+			Duration: lp.getPlanRequiredDuration(float64(p.Goal), maxPower),
+			Time:     p.End,
+			Absence:  absence,
+		})
+	}
+
+	return goals
 }
 
 // plannerActive checks if the charging plan has a currently active slot
@@ -169,7 +207,9 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 
 	strategy := lp.getEffectivePlanStrategy()
 
-	plan = lp.GetPlan(planTime, requiredDuration, strategy.Precondition, strategy.Continuous)
+	goals := lp.GetPlannerGoals(planTime, requiredDuration, maxPower)
+
+	plan = lp.GetPlan(goals, strategy.Precondition, strategy.Continuous)
 	if plan == nil {
 		lp.log.DEBUG.Println("!! plan: plan nil")
 		return false
@@ -208,7 +248,9 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 
 		// lock the goal when soc-based plan becomes active for the first time
 		if lp.planLocked.Id == 0 && isSocBased {
-			lp.lockPlanGoal(planTime, int(goal), lp.getPlanId())
+			if p := lp.nextVehiclePlan(); p != nil {
+				lp.lockPlanGoal(p.End, p.Soc, p.Goal, p.Id)
+			}
 		}
 
 		// remember last active plan's slot end time

--- a/core/planner/helper.go
+++ b/core/planner/helper.go
@@ -134,6 +134,37 @@ func clampRatesSeq(rates api.Rates, start, end time.Time) iter.Seq[api.Rate] {
 	}
 }
 
+// subtractRates removes the given windows from rates, splitting slots as needed
+func subtractRates(rates, windows api.Rates) api.Rates {
+	res := rates
+	for _, w := range windows {
+		if !w.End.After(w.Start) {
+			continue
+		}
+
+		next := make(api.Rates, 0, len(res))
+		for _, r := range res {
+			// no overlap
+			if !r.End.After(w.Start) || !r.Start.Before(w.End) {
+				next = append(next, r)
+				continue
+			}
+
+			// keep part before window
+			if r.Start.Before(w.Start) {
+				next = append(next, api.Rate{Start: r.Start, End: w.Start, Value: r.Value})
+			}
+
+			// keep part after window
+			if r.End.After(w.End) {
+				next = append(next, api.Rate{Start: w.End, End: r.End, Value: r.Value})
+			}
+		}
+		res = next
+	}
+	return res
+}
+
 // windowCost returns the cost of the given window. Durations are summed per price before
 // multiplication, hence the result does not depend on how the window's slots are clamped.
 func windowCost(rates api.Rates, start, end time.Time) float64 {

--- a/core/planner/planner.go
+++ b/core/planner/planner.go
@@ -94,6 +94,79 @@ func continuousPlan(rates api.Rates, start, end time.Time) api.Rates {
 	return res
 }
 
+// PlanGoals creates a charging plan covering multiple charging goals.
+// The first goal is the active one and is planned with full strategy support (precondition,
+// continuous). The remaining goals are planned cost-optimally in target time order using the
+// remaining slots outside of absence windows. Durations are cumulative, hence only each goal's
+// shortfall vs. the slots already planned before its target time is added.
+func (t *Planner) PlanGoals(goals []api.PlanGoal, precondition time.Duration, continuous bool) api.Rates {
+	if t == nil || len(goals) == 0 {
+		return nil
+	}
+
+	plan := t.Plan(goals[0].Duration, precondition, goals[0].Time, continuous)
+
+	// without tariff, later goals are planned just-in-time once they become due
+	if len(goals) == 1 || t.tariff == nil {
+		return plan
+	}
+
+	rates, err := t.tariff.Rates()
+	if len(rates) == 0 || err != nil {
+		return plan
+	}
+
+	now := t.clock.Now().Truncate(time.Second)
+	last := rates[len(rates)-1].End
+
+	// planned slots and absence windows are unavailable for other goals
+	unavailable := slices.Clone(plan)
+	for _, g := range goals {
+		if g.Absence > 0 {
+			unavailable = append(unavailable, api.Rate{Start: g.Time, End: g.Time.Add(g.Absence)})
+		}
+	}
+
+	remaining := slices.Clone(goals[1:])
+	slices.SortStableFunc(remaining, func(i, j api.PlanGoal) int {
+		return i.Time.Compare(j.Time)
+	})
+
+	for _, g := range remaining {
+		targetTime := g.Time
+
+		// charging before the target time already planned for other goals counts towards this goal
+		requiredDuration := g.Duration - Duration(clampRates(plan, now, targetTime))
+		if requiredDuration <= 0 {
+			continue
+		}
+
+		// reduce planning horizon to available rates
+		// ponytail: time after the rate horizon may overlap absence windows- over-estimates future capacity
+		if targetTime.After(last) {
+			durationAfterRates := targetTime.Sub(last)
+			if durationAfterRates >= requiredDuration {
+				// enough time for charging once rates cover the target time
+				continue
+			}
+
+			requiredDuration -= durationAfterRates
+			targetTime = last
+		}
+
+		avail := subtractRates(clampRates(rates, now, targetTime), unavailable)
+		slices.SortStableFunc(avail, sortByCost)
+
+		res := optimalPlan(avail, requiredDuration, targetTime)
+		plan = append(plan, res...)
+		unavailable = append(unavailable, res...)
+	}
+
+	plan.Sort()
+
+	return plan
+}
+
 func (t *Planner) Plan(requiredDuration, precondition time.Duration, targetTime time.Time, continuous bool) api.Rates {
 	if t == nil || requiredDuration <= 0 {
 		return nil

--- a/core/planner/planner_goals_test.go
+++ b/core/planner/planner_goals_test.go
@@ -1,0 +1,76 @@
+package planner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSubtractRates(t *testing.T) {
+	clock := clock.NewMock()
+	rr := rates([]float64{10, 20}, clock.Now(), time.Hour)
+
+	// window spanning both slots leaves the outer parts
+	res := subtractRates(rr, api.Rates{{Start: clock.Now().Add(30 * time.Minute), End: clock.Now().Add(90 * time.Minute)}})
+	require.Len(t, res, 2)
+	assert.Equal(t, api.Rate{Start: clock.Now(), End: clock.Now().Add(30 * time.Minute), Value: 10}, res[0])
+	assert.Equal(t, api.Rate{Start: clock.Now().Add(90 * time.Minute), End: clock.Now().Add(2 * time.Hour), Value: 20}, res[1])
+
+	// non-overlapping window is a no-op
+	assert.Equal(t, rr, subtractRates(rr, api.Rates{{Start: clock.Now().Add(3 * time.Hour), End: clock.Now().Add(4 * time.Hour)}}))
+
+	// window covering everything removes all slots
+	assert.Empty(t, subtractRates(rr, api.Rates{{Start: clock.Now(), End: clock.Now().Add(2 * time.Hour)}}))
+}
+
+func TestPlanGoals(t *testing.T) {
+	clock := clock.NewMock()
+	ctrl := gomock.NewController(t)
+
+	trf := api.NewMockTariff(ctrl)
+	trf.EXPECT().Rates().AnyTimes().Return(rates([]float64{20, 60, 10, 80, 40, 90}, clock.Now(), time.Hour), nil)
+
+	p := &Planner{
+		log:    util.NewLogger("foo"),
+		clock:  clock,
+		tariff: trf,
+	}
+
+	// the second goal's cumulative duration is partly covered by the first goal's plan,
+	// its shortfall may use cheap slots before the first goal's target time
+	plan := p.PlanGoals([]api.PlanGoal{
+		{Duration: time.Hour, Time: clock.Now().Add(3 * time.Hour)},
+		{Duration: 3 * time.Hour, Time: clock.Now().Add(6 * time.Hour)},
+	}, 0, false)
+
+	require.Len(t, plan, 3)
+	assert.Equal(t, 3*time.Hour, Duration(plan))
+	assert.Equal(t, []float64{20, 10, 40}, []float64{plan[0].Value, plan[1].Value, plan[2].Value})
+
+	// an already covered goal adds no slots
+	plan = p.PlanGoals([]api.PlanGoal{
+		{Duration: time.Hour, Time: clock.Now().Add(3 * time.Hour)},
+		{Duration: time.Hour, Time: clock.Now().Add(6 * time.Hour)},
+	}, 0, false)
+	assert.Equal(t, time.Hour, Duration(plan))
+
+	// no charging during the first goal's absence window
+	plan = p.PlanGoals([]api.PlanGoal{
+		{Duration: time.Hour, Time: clock.Now().Add(2 * time.Hour), Absence: 2 * time.Hour},
+		{Duration: 2 * time.Hour, Time: clock.Now().Add(6 * time.Hour)},
+	}, 0, false)
+
+	require.Len(t, plan, 2)
+	assert.Equal(t, []float64{20, 40}, []float64{plan[0].Value, plan[1].Value})
+	for _, slot := range plan {
+		if slot.Start.Before(clock.Now().Add(4*time.Hour)) && slot.End.After(clock.Now().Add(2*time.Hour)) {
+			t.Errorf("slot %v-%v overlaps absence window", slot.Start, slot.End)
+		}
+	}
+}

--- a/core/site_vehicles.go
+++ b/core/site_vehicles.go
@@ -13,8 +13,9 @@ import (
 )
 
 type planStruct struct {
-	Soc  int       `json:"soc"`
-	Time time.Time `json:"time"`
+	Soc     int              `json:"soc"`
+	Time    time.Time        `json:"time"`
+	Absence *api.PlanAbsence `json:"absence,omitempty"`
 }
 
 type vehicleStruct struct {
@@ -48,10 +49,11 @@ func (site *Site) publishVehicles() {
 		ac := instance.OnIdentified()
 
 		var plan *planStruct
-		if time, soc := v.GetPlanSoc(); !time.IsZero() {
+		if time, soc, absence := v.GetPlanSoc(); !time.IsZero() {
 			plan = &planStruct{
-				Soc:  soc,
-				Time: time,
+				Soc:     soc,
+				Time:    time,
+				Absence: absence,
 			}
 		}
 

--- a/core/vehicle/adapter.go
+++ b/core/vehicle/adapter.go
@@ -94,8 +94,8 @@ func (v *adapter) SetLimitSoc(soc int) {
 	v.publish()
 }
 
-// GetPlanSoc returns the charge plan soc
-func (v *adapter) GetPlanSoc() (time.Time, int) {
+// GetPlanSoc returns the charge plan time, soc and absence
+func (v *adapter) GetPlanSoc() (time.Time, int, *api.PlanAbsence) {
 	var ts time.Time
 	if v, err := settings.Time(v.key() + keys.PlanTime); err == nil {
 		ts = v
@@ -104,17 +104,25 @@ func (v *adapter) GetPlanSoc() (time.Time, int) {
 	if v, err := settings.Int(v.key() + keys.PlanSoc); err == nil {
 		soc = int(v)
 	}
-	return ts, soc
+	var absence *api.PlanAbsence
+	if err := settings.Json(v.key()+keys.PlanAbsence, &absence); err != nil {
+		absence = nil
+	}
+	return ts, soc, absence
 }
 
-// SetPlanSoc sets the charge plan soc
-func (v *adapter) SetPlanSoc(ts time.Time, soc int) error {
+// SetPlanSoc sets the charge plan time, soc and absence. Soc is optional if an absence is given.
+func (v *adapter) SetPlanSoc(ts time.Time, soc int, absence *api.PlanAbsence) error {
 	if !ts.IsZero() && ts.Before(time.Now()) {
 		return errors.New("timestamp is in the past")
 	}
 
+	if err := absence.Validate(); err != nil {
+		return err
+	}
+
 	// remove plan
-	if soc == 0 {
+	if soc == 0 && absence == nil {
 		ts = time.Time{}
 		v.log.DEBUG.Printf("delete %s plan", v.name)
 	} else {
@@ -123,6 +131,9 @@ func (v *adapter) SetPlanSoc(ts time.Time, soc int) error {
 
 	settings.SetTime(v.key()+keys.PlanTime, ts)
 	settings.SetInt(v.key()+keys.PlanSoc, int64(soc))
+	if err := settings.SetJson(v.key()+keys.PlanAbsence, absence); err != nil {
+		return err
+	}
 
 	// note: could be optimized by only clearing plan lock of the relevant loadpoint
 	v.clearPlanLocks()
@@ -144,6 +155,9 @@ func (v *adapter) SetRepeatingPlans(plans []api.RepeatingPlan) error {
 		}
 		if _, err := time.Parse("15:04", plan.Time); err != nil {
 			return fmt.Errorf("invalid time: %v", err)
+		}
+		if err := plan.Absence.Validate(); err != nil {
+			return err
 		}
 	}
 

--- a/core/vehicle/api.go
+++ b/core/vehicle/api.go
@@ -29,10 +29,10 @@ type API interface {
 	// SetLimitSoc sets the limit soc
 	SetLimitSoc(soc int)
 
-	// GetPlanSoc returns the charge plan soc
-	GetPlanSoc() (time.Time, int)
-	// SetPlanSoc sets the charge plan time and soc
-	SetPlanSoc(time.Time, int) error
+	// GetPlanSoc returns the charge plan time, soc and absence
+	GetPlanSoc() (time.Time, int, *api.PlanAbsence)
+	// SetPlanSoc sets the charge plan time, soc and absence
+	SetPlanSoc(time.Time, int, *api.PlanAbsence) error
 
 	// GetRepeatingPlans returns every repeating plan
 	GetRepeatingPlans() []api.RepeatingPlan

--- a/core/vehicle/dummy.go
+++ b/core/vehicle/dummy.go
@@ -47,13 +47,13 @@ func (v *dummy) GetLimitSoc() int {
 func (v *dummy) SetLimitSoc(soc int) {
 }
 
-// GetPlanSoc returns the charge plan soc
-func (v *dummy) GetPlanSoc() (time.Time, int) {
-	return time.Time{}, 0
+// GetPlanSoc returns the charge plan time, soc and absence
+func (v *dummy) GetPlanSoc() (time.Time, int, *api.PlanAbsence) {
+	return time.Time{}, 0, nil
 }
 
-// SetPlanSoc sets the charge plan soc
-func (v *dummy) SetPlanSoc(ts time.Time, soc int) error {
+// SetPlanSoc sets the charge plan time, soc and absence
+func (v *dummy) SetPlanSoc(ts time.Time, soc int, absence *api.PlanAbsence) error {
 	return nil
 }
 

--- a/core/vehicle/mock.go
+++ b/core/vehicle/mock.go
@@ -84,12 +84,13 @@ func (mr *MockAPIMockRecorder) GetMode() *gomock.Call {
 }
 
 // GetPlanSoc mocks base method.
-func (m *MockAPI) GetPlanSoc() (time.Time, int) {
+func (m *MockAPI) GetPlanSoc() (time.Time, int, *api.PlanAbsence) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPlanSoc")
 	ret0, _ := ret[0].(time.Time)
 	ret1, _ := ret[1].(int)
-	return ret0, ret1
+	ret2, _ := ret[2].(*api.PlanAbsence)
+	return ret0, ret1, ret2
 }
 
 // GetPlanSoc indicates an expected call of GetPlanSoc.
@@ -191,17 +192,17 @@ func (mr *MockAPIMockRecorder) SetMode(arg0 any) *gomock.Call {
 }
 
 // SetPlanSoc mocks base method.
-func (m *MockAPI) SetPlanSoc(arg0 time.Time, arg1 int) error {
+func (m *MockAPI) SetPlanSoc(arg0 time.Time, arg1 int, arg2 *api.PlanAbsence) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPlanSoc", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetPlanSoc", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPlanSoc indicates an expected call of SetPlanSoc.
-func (mr *MockAPIMockRecorder) SetPlanSoc(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetPlanSoc(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPlanSoc", reflect.TypeOf((*MockAPI)(nil).SetPlanSoc), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPlanSoc", reflect.TypeOf((*MockAPI)(nil).SetPlanSoc), arg0, arg1, arg2)
 }
 
 // SetPlanStrategy mocks base method.

--- a/messenger/hub.go
+++ b/messenger/hub.go
@@ -96,7 +96,7 @@ func (h *Hub) apply(ev Event, tmpl string) (string, error) {
 		if v, err := h.vehicles.ByName(name); err == nil {
 			attr["vehicleLimitSoc"] = v.GetLimitSoc()
 			attr["vehicleMinSoc"] = v.GetMinSoc()
-			attr["vehiclePlanTime"], attr["vehiclePlanSoc"] = v.GetPlanSoc()
+			attr["vehiclePlanTime"], attr["vehiclePlanSoc"], _ = v.GetPlanSoc()
 
 			instance := v.Instance()
 			attr["vehicleTitle"] = instance.GetTitle()

--- a/server/http.go
+++ b/server/http.go
@@ -216,6 +216,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 		"limitsoc":       {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/limitsoc/{value:[0-9]+}", limitSocHandler(site)},
 		"plan":           {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc/{value:[0-9]+}/{time:[0-9TZ:.+-]+}", planSocHandler(site)},
 		"plan2":          {"DELETE", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocRemoveHandler(site)},
+		"plan3":          {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/soc", planSocUpdateHandler(site)},
 		"repeatingPlans": {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/repeating", addRepeatingPlansHandler(site)},
 		"planStrategy":   {"POST", "/vehicles/{name:[a-zA-Z0-9_.:-]+}/plan/strategy", updatePlanStrategyHandler(site)},
 	}

--- a/server/http_loadpoint_handler.go
+++ b/server/http_loadpoint_handler.go
@@ -38,7 +38,7 @@ func planHandler(lp loadpoint.API) http.HandlerFunc {
 		goal, _ := lp.GetPlanGoal()
 		requiredDuration := lp.GetPlanRequiredDuration(goal, maxPower)
 		strategy := lp.EffectivePlanStrategy()
-		plan := lp.GetPlan(planTime, requiredDuration, strategy.Precondition, strategy.Continuous)
+		plan := lp.GetPlan(lp.GetPlannerGoals(planTime, requiredDuration, maxPower), strategy.Precondition, strategy.Continuous)
 
 		res := PlanResponse{
 			PlanId:   id,
@@ -89,7 +89,7 @@ func staticPlanPreviewHandler(lp loadpoint.API) http.HandlerFunc {
 		requiredDuration := lp.GetPlanRequiredDuration(goal, maxPower)
 		strategy := lp.EffectivePlanStrategy()
 
-		plan := lp.GetPlan(planTime, requiredDuration, strategy.Precondition, strategy.Continuous)
+		plan := lp.GetPlan([]api.PlanGoal{{Duration: requiredDuration, Time: planTime}}, strategy.Precondition, strategy.Continuous)
 
 		res := PlanPreviewResponse{
 			PlanTime: planTime,

--- a/server/http_vehicle_handler.go
+++ b/server/http_vehicle_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/site"
+	"github.com/evcc-io/evcc/core/vehicle"
 	"github.com/gorilla/mux"
 )
 
@@ -121,22 +122,49 @@ func planSocHandler(site site.API) http.HandlerFunc {
 			return
 		}
 
-		if err := v.SetPlanSoc(ts, soc); err != nil {
+		if err := v.SetPlanSoc(ts, soc, nil); err != nil {
 			jsonError(w, http.StatusBadRequest, err)
 			return
 		}
 
-		ts, soc = v.GetPlanSoc()
+		jsonWrite(w, staticPlanResponse(v))
+	}
+}
 
-		res := struct {
-			Soc  int       `json:"soc"`
-			Time time.Time `json:"time"`
-		}{
-			Soc:  soc,
-			Time: ts,
+type staticPlanStruct struct {
+	Soc     int              `json:"soc"`
+	Time    time.Time        `json:"time"`
+	Absence *api.PlanAbsence `json:"absence,omitempty"`
+}
+
+func staticPlanResponse(v vehicle.API) staticPlanStruct {
+	ts, soc, absence := v.GetPlanSoc()
+	return staticPlanStruct{Soc: soc, Time: ts, Absence: absence}
+}
+
+// planSocUpdateHandler updates the static plan from a json body. Soc is optional if an absence is given.
+func planSocUpdateHandler(site site.API) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		v, err := site.Vehicles().ByName(vars["name"])
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
 		}
 
-		jsonWrite(w, res)
+		var req staticPlanStruct
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		if err := v.SetPlanSoc(req.Time, req.Soc, req.Absence); err != nil {
+			jsonError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		jsonWrite(w, staticPlanResponse(v))
 	}
 }
 
@@ -207,7 +235,7 @@ func planSocRemoveHandler(site site.API) http.HandlerFunc {
 			return
 		}
 
-		if err := v.SetPlanSoc(time.Time{}, 0); err != nil {
+		if err := v.SetPlanSoc(time.Time{}, 0, nil); err != nil {
 			jsonError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -292,7 +292,9 @@ func (m *MQTT) listenVehicleSetters(topic string, v vehicle.API) error {
 		{"limitSoc", intSetter(pass(v.SetLimitSoc))},
 		{"minSoc", intSetter(pass(v.SetMinSoc))},
 		{"planStrategy", planStrategySetter(v.SetPlanStrategy)},
-		{"planSoc", planGoalSetter(v.SetPlanSoc)},
+		{"planSoc", planGoalSetter(func(ts time.Time, soc int) error {
+			return v.SetPlanSoc(ts, soc, nil)
+		})},
 	} {
 		if err := m.Handler.ListenSetter(topic+"/"+s.topic, s.fun); err != nil {
 			return err


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/32970

## What

- **Multiple plans per loadpoint**: the planner now builds the charging schedule from *all* pending vehicle plans instead of only the next one. The active plan keeps full strategy support (precondition, continuous); later plans are planned cost-optimally in target-time order. Durations are cumulative, so each later plan only adds its shortfall vs. slots already planned before its target time — which may place cheap slots *before* the next plan's deadline.
- **Absence option per plan** (`duration` + `soc` drop): models a trip following the plan's target time. No charging is scheduled inside the absence window, and the drop increases the charge required for plans after the absence (capped at 100%).
- **Optional required soc**: a plan with an absence may omit the soc. The goal is then derived as `min soc + absence drop`, i.e. charge enough to cover the trip and return at min soc.

## API

- `api.PlanAbsence {duration (s), soc (%)}`, validated (drop 1–100, duration > 0)
- `api.RepeatingPlan` gains optional `absence` — travels through the existing `POST /api/vehicles/{name}/plan/repeating` body
- new `POST /api/vehicles/{name}/plan/soc` with json body `{soc?, time, absence?}` for the static plan; legacy path-based `POST .../plan/soc/{value}/{time}` and `DELETE .../plan/soc` unchanged (legacy POST clears any absence)
- vehicle publication (`plan`) and static plan responses include `absence`
- `loadpoint.API`: `GetPlan` now takes `[]api.PlanGoal`; new `GetPlannerGoals`

UI is intentionally untouched (first step, APIs only).

## Notes

- `plan.Soc` (published/locked target) stays the user goal; the drop-adjusted planning goal is tracked separately, so overrun locking and `effectivePlanSoc` semantics are preserved.
- Time after the rate horizon may overlap absence windows and thus over-estimate future charging capacity; continuous replanning corrects this once rates cover the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)