### PR TITLE
Home Assistant: auto-detect Supervisor instance and token

### DIFF
--- a/util/homeassistant/instance.go
+++ b/util/homeassistant/instance.go
@@ -13,6 +13,7 @@ func init() {
 	auth.Register("homeassistant", NewHomeAssistantFromConfig)
 }
 
+// NewHomeAssistantFromConfig creates a Home Assistant token source from configuration
 func NewHomeAssistantFromConfig(other map[string]any) (oauth2.TokenSource, error) {
 	var cc struct {
 		URI      string

--- a/util/homeassistant/instance.go
+++ b/util/homeassistant/instance.go
@@ -4,8 +4,41 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/evcc-io/evcc/plugin/auth"
+	"github.com/evcc-io/evcc/util"
 	"golang.org/x/oauth2"
 )
+
+func init() {
+	auth.Register("homeassistant", NewHomeAssistantFromConfig)
+}
+
+func NewHomeAssistantFromConfig(other map[string]any) (oauth2.TokenSource, error) {
+	var cc struct {
+		URI      string
+		Home     string // TODO remove deprecated
+		Insecure bool
+	}
+
+	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	uri := cc.URI
+
+	if uri == "" && cc.Home != "" {
+		uri = instanceUriByName(cc.Home)
+		if uri == "" {
+			return nil, fmt.Errorf("unknown instance: %s", cc.Home)
+		}
+	}
+
+	if ts, ok := supervisorTokenSource(uri); ok {
+		return ts, nil
+	}
+
+	return NewOAuth(uri, cc.Insecure)
+}
 
 type proxyInstance struct {
 	mu        sync.Mutex
@@ -43,12 +76,15 @@ func (inst *proxyInstance) Token() (*oauth2.Token, error) {
 	defer inst.mu.Unlock()
 
 	if inst.TokenSource == nil {
-		ts, err := NewHomeAssistant(uri, inst.insecure)
-		if err != nil {
-			return nil, err
+		if ts, ok := supervisorTokenSource(uri); ok {
+			inst.TokenSource = ts
+		} else {
+			ts, err := NewOAuth(uri, inst.insecure)
+			if err != nil {
+				return nil, err
+			}
+			inst.TokenSource = ts
 		}
-
-		inst.TokenSource = ts
 	}
 
 	return inst.TokenSource.Token()

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -2,7 +2,6 @@ package homeassistant
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -17,34 +16,7 @@ import (
 
 // https://developers.home-assistant.io/docs/auth_api
 
-func init() {
-	auth.Register("homeassistant", NewHomeAssistantFromConfig)
-}
-
-func NewHomeAssistantFromConfig(other map[string]any) (oauth2.TokenSource, error) {
-	var cc struct {
-		URI      string
-		Home     string // TODO remove deprecated
-		Insecure bool
-	}
-
-	if err := util.DecodeOther(other, &cc); err != nil {
-		return nil, err
-	}
-
-	uri := cc.URI
-
-	if uri == "" && cc.Home != "" {
-		uri = instanceUriByName(cc.Home)
-		if uri == "" {
-			return nil, fmt.Errorf("unknown instance: %s", cc.Home)
-		}
-	}
-
-	return NewHomeAssistant(uri, cc.Insecure)
-}
-
-func NewHomeAssistant(uri string, insecure bool) (oauth2.TokenSource, error) {
+func NewOAuth(uri string, insecure bool) (oauth2.TokenSource, error) {
 	uri = strings.TrimRight(uri, "/") // normalize
 
 	extUrl := network.Config().ExternalURL()

--- a/util/homeassistant/oauth2.go
+++ b/util/homeassistant/oauth2.go
@@ -16,6 +16,7 @@ import (
 
 // https://developers.home-assistant.io/docs/auth_api
 
+// NewOAuth creates a Home Assistant OAuth token source
 func NewOAuth(uri string, insecure bool) (oauth2.TokenSource, error) {
 	uri = strings.TrimRight(uri, "/") // normalize
 

--- a/util/homeassistant/supervisor.go
+++ b/util/homeassistant/supervisor.go
@@ -13,7 +13,7 @@ const (
 	// SupervisorToken is the environment variable name containing the bearer token
 	SupervisorToken = "SUPERVISOR_TOKEN"
 	// SupervisorInstance is the discovered instance name for the Supervisor integration
-	SupervisorInstance = "HomeAssistant via EVCC App"
+	SupervisorInstance = "HomeAssistant Host"
 )
 
 func init() {

--- a/util/homeassistant/supervisor.go
+++ b/util/homeassistant/supervisor.go
@@ -1,0 +1,31 @@
+package homeassistant
+
+import (
+	"os"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	SupervisorURI      = "http://supervisor/core"
+	SupervisorToken    = "SUPERVISOR_TOKEN"
+	SupervisorInstance = "HomeAssistant via EVCC App"
+)
+
+func init() {
+	if hasSupervisorToken() {
+		addInstance(SupervisorInstance, SupervisorURI)
+	}
+}
+
+func hasSupervisorToken() bool {
+	return os.Getenv(SupervisorToken) != ""
+}
+
+func supervisorTokenSource(uri string) (oauth2.TokenSource, bool) {
+	if token := os.Getenv(SupervisorToken); token != "" && strings.TrimRight(uri, "/") == SupervisorURI {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}), true
+	}
+	return nil, false
+}

--- a/util/homeassistant/supervisor.go
+++ b/util/homeassistant/supervisor.go
@@ -8,8 +8,11 @@ import (
 )
 
 const (
-	SupervisorURI      = "http://supervisor/core"
-	SupervisorToken    = "SUPERVISOR_TOKEN"
+	// SupervisorURI is the Home Assistant Core API endpoint when running as a Home Assistant add-on
+	SupervisorURI = "http://supervisor/core"
+	// SupervisorToken is the environment variable name containing the bearer token
+	SupervisorToken = "SUPERVISOR_TOKEN"
+	// SupervisorInstance is the discovered instance name for the Supervisor integration
 	SupervisorInstance = "HomeAssistant via EVCC App"
 )
 

--- a/util/homeassistant/supervisor_test.go
+++ b/util/homeassistant/supervisor_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,8 +53,8 @@ func TestSupervisorToken(t *testing.T) {
 
 	_, err = ts4.Token()
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "login required")
-
+	var elr *api.ErrLoginRequired
+	assert.ErrorAs(t, err, &elr)
 	// connection requires uri
 	_, err = NewConnection(util.NewLogger("test"), "", "", false)
 	assert.Error(t, err)

--- a/util/homeassistant/supervisor_test.go
+++ b/util/homeassistant/supervisor_test.go
@@ -1,0 +1,73 @@
+package homeassistant
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupervisorToken(t *testing.T) {
+	t.Setenv(SupervisorToken, "test_supervisor_token")
+
+	ts, ok := supervisorTokenSource(SupervisorURI)
+	require.True(t, ok)
+
+	tok, err := ts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "test_supervisor_token", tok.AccessToken)
+
+	// empty uri does not match supervisor
+	_, ok = supervisorTokenSource("")
+	assert.False(t, ok)
+
+	// other uri does not match supervisor
+	_, ok = supervisorTokenSource("http://homeassistant.local:8123")
+	assert.False(t, ok)
+
+	// from config with SupervisorURI
+	ts3, err := NewHomeAssistantFromConfig(map[string]any{"uri": SupervisorURI})
+	require.NoError(t, err)
+
+	tok3, err := ts3.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "test_supervisor_token", tok3.AccessToken)
+
+	// connection requires uri
+	_, err = NewConnection(util.NewLogger("test"), "", "", false)
+	assert.Error(t, err)
+
+	conn, err := NewConnection(util.NewLogger("test"), SupervisorURI, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, SupervisorURI, conn.URI())
+
+	// test authenticated request using connection
+	var authHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"entity_id":"sensor.test","state":"10"}]`))
+	}))
+	defer srv.Close()
+
+	testConn, err := NewConnection(util.NewLogger("test"), srv.URL, "", false)
+	require.NoError(t, err)
+	// override instance token source directly or test via proxyInstance
+	testConn.instance.TokenSource = ts
+
+	states, err := testConn.GetStates()
+	require.NoError(t, err)
+	assert.Len(t, states, 1)
+	assert.Equal(t, "Bearer test_supervisor_token", authHeader)
+}
+
+func TestSupervisorDiscovery(t *testing.T) {
+	t.Setenv(SupervisorToken, "test_supervisor_token")
+
+	addInstance(SupervisorInstance, SupervisorURI)
+	assert.Equal(t, SupervisorURI, instanceUriByName(SupervisorInstance))
+	assert.Equal(t, SupervisorInstance, instanceNameByUri(SupervisorURI))
+}

--- a/util/homeassistant/supervisor_test.go
+++ b/util/homeassistant/supervisor_test.go
@@ -20,6 +20,14 @@ func TestSupervisorToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test_supervisor_token", tok.AccessToken)
 
+	// SupervisorURI variant with trailing slash should still match
+	tsSlash, ok := supervisorTokenSource(SupervisorURI + "/")
+	require.True(t, ok)
+	
+	tokSlash, err := tsSlash.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "test_supervisor_token", tokSlash.AccessToken)
+
 	// empty uri does not match supervisor
 	_, ok = supervisorTokenSource("")
 	assert.False(t, ok)
@@ -35,6 +43,17 @@ func TestSupervisorToken(t *testing.T) {
 	tok3, err := ts3.Token()
 	require.NoError(t, err)
 	assert.Equal(t, "test_supervisor_token", tok3.AccessToken)
+
+	// when SUPERVISOR_TOKEN is unset, NewHomeAssistantFromConfig should fall back to the standard OAuth token source
+	t.Setenv(SupervisorToken, "")
+
+	ts4, err := NewHomeAssistantFromConfig(map[string]any{"uri": SupervisorURI})
+	require.NoError(t, err)
+
+	tok4, err := ts4.Token()
+	require.NoError(t, err)
+	// ensure we did not use the supervisor token source
+	assert.NotEqual(t, "test_supervisor_token", tok4.AccessToken)
 
 	// connection requires uri
 	_, err = NewConnection(util.NewLogger("test"), "", "", false)

--- a/util/homeassistant/supervisor_test.go
+++ b/util/homeassistant/supervisor_test.go
@@ -23,7 +23,7 @@ func TestSupervisorToken(t *testing.T) {
 	// SupervisorURI variant with trailing slash should still match
 	tsSlash, ok := supervisorTokenSource(SupervisorURI + "/")
 	require.True(t, ok)
-	
+
 	tokSlash, err := tsSlash.Token()
 	require.NoError(t, err)
 	assert.Equal(t, "test_supervisor_token", tokSlash.AccessToken)
@@ -50,10 +50,9 @@ func TestSupervisorToken(t *testing.T) {
 	ts4, err := NewHomeAssistantFromConfig(map[string]any{"uri": SupervisorURI})
 	require.NoError(t, err)
 
-	tok4, err := ts4.Token()
-	require.NoError(t, err)
-	// ensure we did not use the supervisor token source
-	assert.NotEqual(t, "test_supervisor_token", tok4.AccessToken)
+	_, err = ts4.Token()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "login required")
 
 	// connection requires uri
 	_, err = NewConnection(util.NewLogger("test"), "", "", false)


### PR DESCRIPTION
This is the companion PR to https://github.com/evcc-io/hassio-addon/pull/142 . 

It automatically discovers the Home Assistant Core API endpoint and authenticates with the injected bearer token when evcc runs as a Home Assistant add-on, where after merging https://github.com/evcc-io/hassio-addon/pull/142 the `SUPERVISOR_TOKEN` environment variable will be set.

When this is the case, we call `addInstance` of the zeroconf-feature for HomeAssistant. This way it populates nicely as just another auto-discovered HomeAssistant in the UI.