### PR TITLE
Issue: remove obsolete number input spinner styles

### DIFF
--- a/assets/js/views/Issue.vue
+++ b/assets/js/views/Issue.vue
@@ -262,7 +262,7 @@
 												<input
 													v-model.number="logCount"
 													type="number"
-													class="form-control text-end log-count-input"
+													class="form-control text-end"
 													min="0"
 													step="25"
 												/>
@@ -686,11 +686,6 @@ export default defineComponent({
 
 <style scoped>
 @import "../../css/breakpoints.css";
-
-.log-count-input::-webkit-outer-spin-button,
-.log-count-input::-webkit-inner-spin-button {
-	margin-left: 0.5rem;
-}
 
 @media (--md-and-up) {
 	.log-lines-input {


### PR DESCRIPTION
follow-up to #32541, extracted from #31072 (review)

#32541 already hides number input spinners globally, so the scoped spin-button margin rule in the issue view is dead code.

- remove unused `.log-count-input` spin-button rule and the now-orphaned class

🤖 Generated with [Claude Code](https://claude.com/claude-code)
