### PR TITLE
Charts: prevent long-press text selection

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -951,3 +951,9 @@ input::-webkit-date-and-time-value {
 .sticky-bottom {
 	bottom: calc(var(--tab-bar-height) + 0.25rem);
 }
+
+[_echarts_instance_] {
+	user-select: none;
+	-webkit-user-select: none;
+	-webkit-touch-callout: none;
+}

--- a/assets/js/components/Forecast/chartStyles.css
+++ b/assets/js/components/Forecast/chartStyles.css
@@ -2,7 +2,4 @@
 	overflow-x: auto;
 	padding-bottom: 4px;
 	margin-bottom: 0.5rem;
-	user-select: none;
-	-webkit-user-select: none;
-	-webkit-touch-callout: none;
 }


### PR DESCRIPTION
fixes evcc-io/app#260

Long-press on chart labels (axis text, units) triggered iOS text selection because echarts renders SVG text nodes.

- global `user-select: none` rule for all echarts containers via the `_echarts_instance_` attribute
- covers Sessions, Optimize and Forecast charts; removes the previous Forecast-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)