### PR TITLE
SAJ H2: make forced charge power configurable

### DIFF
--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -17,6 +17,7 @@ params:
   # battery control
   - name: defaultmode
     default: 2
+  - name: maxchargerate
 render: |
   type: custom
   {{- if eq .usage "grid" }}
@@ -187,7 +188,7 @@ render: |
               type: writeholding
               decode: int16
         - source: const
-          value: 0x7F64 # end (0xFF / 100%)
+          value: {{ add 0x7F00 .maxchargerate }} # day mask 0x7F (all days) in high byte, charge power % in low byte
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}        

--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -188,7 +188,7 @@ render: |
               type: writeholding
               decode: int16
         - source: const
-          value: {{ add 0x7F00 .maxchargerate }} # day mask 0x7F (all days) in high byte, charge power % in low byte
+          value: {{ add 0x7F00 (max 0 (min 100 .maxchargerate)) }} # day mask 0x7F (all days) in high byte, charge power % in low byte
           set:
             source: modbus
             {{- include "modbus" . | indent 10 }}        


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/33013

Register `13832` (`First_charge_power_time`) packs the weekday mask into the high byte and the charge power percentage into the low byte. The `charge` battery mode wrote a hardcoded `0x7F64`, i.e. all days at 100 %, so forced grid charging always ran at full inverter power.

The template now takes `maxchargerate` for the low byte, matching how `sunspec-inverter-control` and `fronius-gen24` handle percentage-based forced charging. With the default of 100 % the written value is unchanged (`0x7F64`).

Byte layout cross-checked against the packed `day_mask_power` slot registers (`0x3606 + n*3 + 2`) in the SAJ H2 Home Assistant integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)