### PR TITLE
Plugin: return ErrNotAvailable for unmatched switch value

### DIFF
--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -188,6 +188,7 @@ func (site *Site) applyBatteryMode(mode api.BatteryMode) error {
 			if !errors.Is(err, api.ErrNotAvailable) {
 				return err
 			}
+			site.log.DEBUG.Printf("battery %s does not support mode: %s", deviceTitleOrName(dev), devMode)
 			continue
 		}
 

--- a/plugin/switch.go
+++ b/plugin/switch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 )
 
@@ -84,6 +85,7 @@ func (o *switchPlugin) IntSetter(param string) (func(int64) error, error) {
 			return dflt(val)
 		}
 
-		return fmt.Errorf("switch: value not found: %d", val)
+		// an unmatched value means the device does not implement it
+		return fmt.Errorf("%w: switch value %d", api.ErrNotAvailable, val)
 	}, nil
 }

--- a/plugin/switch_test.go
+++ b/plugin/switch_test.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"context"
 	"testing"
 
 	"github.com/evcc-io/evcc/api"
@@ -9,28 +8,25 @@ import (
 )
 
 func TestSwitchUnmatchedValue(t *testing.T) {
-	cfg := map[string]any{
-		"switch": []map[string]any{
-			{"case": "1", "set": map[string]any{"source": "error", "error": "ErrAsleep"}},
-		},
+	// error plugins make the executed branch observable
+	cases := []map[string]any{
+		{"case": "1", "set": map[string]any{"source": "error", "error": "ErrAsleep"}},
 	}
 
-	p, err := NewSwitchFromConfig(context.TODO(), cfg)
+	p, err := NewSwitchFromConfig(t.Context(), map[string]any{"switch": cases})
 	require.NoError(t, err)
 
 	set, err := p.(IntSetter).IntSetter("mode")
 	require.NoError(t, err)
 
-	// matching case is executed
 	require.ErrorIs(t, set(1), api.ErrAsleep)
-
-	// unmatched value without default is not available
 	require.ErrorIs(t, set(3), api.ErrNotAvailable)
 
-	// default takes precedence over the not available error
-	cfg["default"] = map[string]any{"source": "error", "error": "ErrMustRetry"}
-
-	p, err = NewSwitchFromConfig(context.TODO(), cfg)
+	// explicit default wins over the not available error
+	p, err = NewSwitchFromConfig(t.Context(), map[string]any{
+		"switch":  cases,
+		"default": map[string]any{"source": "error", "error": "ErrMustRetry"},
+	})
 	require.NoError(t, err)
 
 	set, err = p.(IntSetter).IntSetter("mode")

--- a/plugin/switch_test.go
+++ b/plugin/switch_test.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwitchUnmatchedValue(t *testing.T) {
+	cfg := map[string]any{
+		"switch": []map[string]any{
+			{"case": "1", "set": map[string]any{"source": "error", "error": "ErrAsleep"}},
+		},
+	}
+
+	p, err := NewSwitchFromConfig(context.TODO(), cfg)
+	require.NoError(t, err)
+
+	set, err := p.(IntSetter).IntSetter("mode")
+	require.NoError(t, err)
+
+	// matching case is executed
+	require.ErrorIs(t, set(1), api.ErrAsleep)
+
+	// unmatched value without default is not available
+	require.ErrorIs(t, set(3), api.ErrNotAvailable)
+
+	// default takes precedence over the not available error
+	cfg["default"] = map[string]any{"source": "error", "error": "ErrMustRetry"}
+
+	p, err = NewSwitchFromConfig(context.TODO(), cfg)
+	require.NoError(t, err)
+
+	set, err = p.(IntSetter).IntSetter("mode")
+	require.NoError(t, err)
+
+	require.ErrorIs(t, set(3), api.ErrMustRetry)
+}


### PR DESCRIPTION
fixes #32994

A `switch` plugin value without matching case returned a hard error, so `applyBatteryMode` aborted the loop and never reached the remaining batteries. An unmatched case means the device does not implement that mode, which is what `api.ErrNotAvailable` expresses and what the site already tolerates per battery.

- unmatched switch value returns `api.ErrNotAvailable` (an explicit `default:` still wins)
- skipped batteries are logged at debug level

Only `sax` and `solarmax-maxstorage` lack `case: 3` today, but 45 `batterymode` switches have no `default:` at all, so `holdcharge` (mode 4, reachable via external battery control) currently breaks all of them the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)