### PR TITLE
Templates: add ErrNotAvailable default to battery mode switches

### DIFF
--- a/templates/definition/meter/alpha-ess-smile.yaml
+++ b/templates/definition/meter/alpha-ess-smile.yaml
@@ -214,5 +214,8 @@ render: |
               address: 2133 # 0x855 Charge Cut Soc
               type: writemultiple
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/anker-solix-solarbank-max-ac.yaml
+++ b/templates/definition/meter/anker-solix-solarbank-max-ac.yaml
@@ -165,5 +165,8 @@ render: |
                     address: 10071
                     type: writemultiple
                     encoding: int32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/atmoce.yaml
+++ b/templates/definition/meter/atmoce.yaml
@@ -430,6 +430,9 @@ render: |
                   type: writemultiple
                   decode: uint32
             {{- end }}
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- if not ( eq .firmware "<01.01.00.28.15" ) }}
   dim:
     source: ifelse

--- a/templates/definition/meter/batterx.yaml
+++ b/templates/definition/meter/batterx.yaml
@@ -79,6 +79,9 @@ render: |
           uri: http://{{ .host }}:{{ .port }}/api.php?set=command&type=20738&text1=3&text2=1 # Battery Charge AC - ON
         - source: http
           uri: http://{{ .host }}:{{ .port }}/api.php?set=command&type=20738&text1=4&text2=0 # Battery Discharging - OFF
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}
   {{- end }}

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -608,5 +608,8 @@ render: |
               address: 109 # Battery Max Discharging Current
               type: writemultiple
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/ferroamp-energyhub.yaml
+++ b/templates/definition/meter/ferroamp-energyhub.yaml
@@ -227,6 +227,9 @@ render: |
               address: 6000 # Battery Mode (holding)
               type: writemultiple
               encoding: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-minmaxsoc" . }}
   {{- include "battery-power" . }}
   {{- end }}

--- a/templates/definition/meter/fox-ess-avocado.yaml
+++ b/templates/definition/meter/fox-ess-avocado.yaml
@@ -258,5 +258,8 @@ render: |
                 address: 46003 # Remote Active Power
                 type: writemultiple
                 encoding: int32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -262,5 +262,8 @@ render: |
                 address: 46003 # Remote Active Power, int32 across 46003 (high word) and 46004 (low word)
                 type: writemultiple
                 encoding: int32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fox-ess-h3.yaml
+++ b/templates/definition/meter/fox-ess-h3.yaml
@@ -226,5 +226,8 @@ render: |
                 address: 44002 # Remote Active Power
                 type: writemultiple
                 encoding: int32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-gen24.yaml
+++ b/templates/definition/meter/fronius-gen24.yaml
@@ -330,5 +330,8 @@ render: |
             uri: {{ .host }}:{{ .port }}
             id: 1
             value: 124:0:InWRte
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-solarapi-v1.yaml
+++ b/templates/definition/meter/fronius-solarapi-v1.yaml
@@ -119,6 +119,9 @@ render: |
       set:
         source: error
         error: ErrNotAvailable
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- end }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/fronius-vertoplus.yaml
+++ b/templates/definition/meter/fronius-vertoplus.yaml
@@ -277,5 +277,8 @@ render: |
             uri: {{ .host }}:{{ .port }}
             id: 1
             value: 124:0:InWRte
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/goodwe-hybrid.yaml
+++ b/templates/definition/meter/goodwe-hybrid.yaml
@@ -360,5 +360,8 @@ render: |
               address: 47512 # EMSPowerSet [0-10000]
               type: writemultiple
               encoding: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/goodwe-wifi-et.yaml
+++ b/templates/definition/meter/goodwe-wifi-et.yaml
@@ -224,5 +224,8 @@ render: |
               type: writemultiple
               encoding: uint16
             delay: {{ .delay }}
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/growatt-hybrid-tlxh.yaml
+++ b/templates/definition/meter/growatt-hybrid-tlxh.yaml
@@ -192,5 +192,8 @@ render: |
               address: 3049
               type: writemultiple
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/growatt-hybrid.yaml
+++ b/templates/definition/meter/growatt-hybrid.yaml
@@ -175,5 +175,8 @@ render: |
               address: 1092
               type: writemultiple
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/huawei-smartlogger.yaml
+++ b/templates/definition/meter/huawei-smartlogger.yaml
@@ -260,5 +260,8 @@ render: |
                 address: 47087 # Charge from grid
                 type: writesingle
                 encoding: uint16
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -622,6 +622,9 @@ render: |
                   out := rated
                   if limit < rated { out = limit }
                   out
+        default:
+          source: error
+          error: ErrNotAvailable
       # single watchdog wraps the ENTIRE 47100 lifecycle, not just case 3
       - source: watchdog
         timeout: 60s # re-write every timeout/2

--- a/templates/definition/meter/indevolt-battery.yaml
+++ b/templates/definition/meter/indevolt-battery.yaml
@@ -157,6 +157,9 @@ render: |
               method: POST
               {{- include "auth" . | indent 14 }}
               jq: .result
+    default:
+      source: error
+      error: ErrNotAvailable
     
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/kostal-plenticore-gen2.yaml
+++ b/templates/definition/meter/kostal-plenticore-gen2.yaml
@@ -172,5 +172,8 @@ render: |
               address: 1038 # Battery max. charge power limit, absolute [W]
               type: writemultiple
               encoding: {{ if (eq .endianness "big") }}float32{{ else }}float32s{{ end }}
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/mtec-eb-gen3.yaml
+++ b/templates/definition/meter/mtec-eb-gen3.yaml
@@ -84,5 +84,8 @@ render: |
             address: 50000
             type: writesingle
             decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/openems-modbus.yaml
+++ b/templates/definition/meter/openems-modbus.yaml
@@ -219,6 +219,9 @@ render: |
           source: error
           error: ErrNotAvailable
           {{- end }}
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- end }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/openems.yaml
+++ b/templates/definition/meter/openems.yaml
@@ -168,6 +168,9 @@ render: |
           source: error
           error: ErrNotAvailable
           {{- end }}
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- end }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/saj-h1.yaml
+++ b/templates/definition/meter/saj-h1.yaml
@@ -149,5 +149,8 @@ render: |
               address: 0x3608 # Battery first charging time (power)
               type: writeholding
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/saj-h2.yaml
+++ b/templates/definition/meter/saj-h2.yaml
@@ -195,5 +195,8 @@ render: |
               address: 13832 # First_charge_power_time 
               type: writeholding
               decode: int16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sax.yaml
+++ b/templates/definition/meter/sax.yaml
@@ -86,5 +86,8 @@ render: |
               address: 43 # 2Bh battery discharging power [W]
               type: writemultiple
               encoding: uint16
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/senec-home.yaml
+++ b/templates/definition/meter/senec-home.yaml
@@ -75,5 +75,8 @@ render: |
         headers:
         - content-type: application/json
         body: '{"ENERGY":{"SAFE_CHARGE_FORCE":"u8_01"}}'  # force to charge
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/senergy-hybrid.yaml
+++ b/templates/definition/meter/senergy-hybrid.yaml
@@ -219,5 +219,8 @@ render: |
               address: 0x214C # Time-based control Enable
               type: writesingle
               encoding: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sessy-smart-battery.yaml
+++ b/templates/definition/meter/sessy-smart-battery.yaml
@@ -158,4 +158,7 @@ render: |
           headers:
           - content-type: application/json
           body: '{"setpoint": -2200}'
+    default:
+      source: error
+      error: ErrNotAvailable
   capacity: {{ .capacity }}

--- a/templates/definition/meter/sma-hybrid.yaml
+++ b/templates/definition/meter/sma-hybrid.yaml
@@ -442,5 +442,8 @@ render: |
                 address: 40801 # CmpBMS.GridWSpt - Sollwert der Netzaustauschleistung
                 type: writemultiple
                 decode: uint32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sma-sbs-15-25-modbus.yaml
+++ b/templates/definition/meter/sma-sbs-15-25-modbus.yaml
@@ -227,4 +227,7 @@ render: |
                 address: 40801 # CmpBMS.GridWSpt - Sollwert der Netzaustauschleistung
                 type: writemultiple
                 decode: uint32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}

--- a/templates/definition/meter/sma-sbs-modbus.yaml
+++ b/templates/definition/meter/sma-sbs-modbus.yaml
@@ -227,4 +227,7 @@ render: |
                 address: 40801 # CmpBMS.GridWSpt - Sollwert der Netzaustauschleistung
                 type: writemultiple
                 decode: uint32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}

--- a/templates/definition/meter/sma-si-modbus.yaml
+++ b/templates/definition/meter/sma-si-modbus.yaml
@@ -108,4 +108,7 @@ render: |
                 address: 40151 # SMA Modbus Profile: Inverter.WModCfg.WCtlComCfg.WCtlComAct
                 type: writemultiple
                 decode: uint32
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -289,5 +289,8 @@ render: |
                   address: 0x1187
                   type: writemultiple
                   decode: bytes
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solaredge-hybrid.yaml
+++ b/templates/definition/meter/solaredge-hybrid.yaml
@@ -320,5 +320,8 @@ render: |
                 address: 0xE010 # StorageRemoteCtrl_DischargeLimit
                 type: writemultiple
                 encoding: float32s
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solarmax-maxstorage.yaml
+++ b/templates/definition/meter/solarmax-maxstorage.yaml
@@ -126,5 +126,8 @@ render: |
                 address: 142
                 type: writemultiple
                 decode: int16
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -224,5 +224,8 @@ render: |
               address: 0x001F # SolarChargeUseMode
               type: writesingle
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solis-hybrid-s.yaml
+++ b/templates/definition/meter/solis-hybrid-s.yaml
@@ -204,5 +204,8 @@ render: |
               address: 43110
               type: writeholding
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solplanet-ai-dongle.yaml
+++ b/templates/definition/meter/solplanet-ai-dongle.yaml
@@ -80,5 +80,8 @@ render: |
             - source: http
               <<: *fdbg
               body: '{"data":"03060480ec78c412"}' # write reg 1152 (setpoint) = -5000 W
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/solplanet-modbus.yaml
+++ b/templates/definition/meter/solplanet-modbus.yaml
@@ -197,5 +197,8 @@ render: |
                   address: 1152
                   type: writesingle
                   encoding: int16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie.yaml
+++ b/templates/definition/meter/sonnenbatterie.yaml
@@ -128,6 +128,9 @@ render: |
           headers:
           - content-type: application/json
           - Auth-Token: {{ .token }}
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- end }}
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sonnenbatterie_eco56.yaml
+++ b/templates/definition/meter/sonnenbatterie_eco56.yaml
@@ -89,6 +89,9 @@ render: |
               method: PUT
               uri: http://{{ .host }}:{{ .port }}/rest/devices/battery/C06
               body: '55' # slave mode
+        default:
+          source: error
+          error: ErrNotAvailable
       # run the watchdog only on the charging power request to avoid making unnecessary mode changes
       - source: watchdog
         timeout: 30s # 3 minutes without setting a value will stop all charging, 30s was chosen to account for api instability
@@ -115,5 +118,8 @@ render: |
                     method: PUT
                     uri: http://{{ .host }}:{{ .port }}/rest/devices/battery/C24
                     body: {{ or .maxchargepower 99000 }}
+          default:
+            source: error
+            error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sunenergyxt-500.yaml
+++ b/templates/definition/meter/sunenergyxt-500.yaml
@@ -138,6 +138,9 @@ render: |
           - Content-Type: application/json
         # GS < 0 means grid import / grid charging
         body: '{"state":{"MM":0,"GS":-{{ .maxchargepower | int }}}}'
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-capacity" . }}
   {{- include "battery-minmaxsoc" . }}
   maxchargepower: {{ .maxchargepower | int }} # W

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -267,5 +267,8 @@ render: |
               address: 13051 # Battery max forced (dis)charge power
               type: writesingle
               decode: uint16
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/sunspec-inverter-control.yaml
+++ b/templates/definition/meter/sunspec-inverter-control.yaml
@@ -125,5 +125,8 @@ render: |
             source: sunspec
             {{- include "modbus" . | indent 10 }}
             value: 124:0:InOutWRte_RvrtTms
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/varta.yaml
+++ b/templates/definition/meter/varta.yaml
@@ -103,5 +103,8 @@ render: |
           set:
             source: error
             error: ErrNotAvailable
+      default:
+        source: error
+        error: ErrNotAvailable
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/youliq-one.yaml
+++ b/templates/definition/meter/youliq-one.yaml
@@ -66,4 +66,7 @@ render: |
           headers:
             - content-type: application/json
           body: '{"operating_mode":"manual_setpoint","inverter_manual_setpoint_w":{{ .maxchargepower }}}'
+    default:
+      source: error
+      error: ErrNotAvailable
   {{- include "battery-params" . }}


### PR DESCRIPTION
fixes #32994

A battery mode switch without matching case returned a hard error, and `applyBatteryMode` aborts on it, so one battery that does not implement a mode kept that mode from being applied to every battery configured after it. `api.ErrNotAvailable` is skipped per battery instead.

- `default` case added to all 48 `batterymode` switches, matching how varta already declares its unimplemented charge case
- only `sax` and `solarmax-maxstorage` lack `case: 3` today, but `holdcharge` (mode 4) is reachable through external battery control and fails the same way on the 39 templates that stop at `case: 3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)