### PR TITLE
API: bound jq evaluation on /api/state against unauthenticated DoS

### DIFF
--- a/server/http_site_handler.go
+++ b/server/http_site_handler.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,13 @@ import (
 )
 
 var ignoreState = []string{"releaseNotes"} // excessive size
+
+// limits for the unauthenticated jq parameter of the state endpoint
+const (
+	maxJqQueryLen    = 512         // maximum length of the jq query
+	maxJqDuration    = time.Second // maximum jq evaluation time
+	maxJqResultBytes = 1 << 20     // maximum size of the encoded jq result
+)
 
 // getPreferredLanguage returns the preferred language as two letter code
 func getPreferredLanguage(header string) string {
@@ -115,6 +123,24 @@ func jsonHandler(h http.Handler) http.Handler {
 func jsonWrite(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(data)
+}
+
+// jsonWriteLimited writes data as json, failing if the encoded result exceeds limit bytes.
+// Encoding into a buffer keeps oversized results from reaching the client at all.
+func jsonWriteLimited(w http.ResponseWriter, data any, limit int) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(data); err != nil {
+		jsonError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if buf.Len() > limit {
+		jsonError(w, http.StatusBadRequest, errors.New("result too large"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	buf.WriteTo(w)
 }
 
 func jsonError(w http.ResponseWriter, status int, err error) {
@@ -256,6 +282,11 @@ func stateHandler(cache *util.ParamCache) http.HandlerFunc {
 		if q := r.URL.Query().Get("jq"); q != "" {
 			q = strings.TrimPrefix(q, ".result")
 
+			if len(q) > maxJqQueryLen {
+				jsonError(w, http.StatusBadRequest, errors.New("jq: query too long"))
+				return
+			}
+
 			query, err := gojq.Parse(q)
 			if err != nil {
 				jsonError(w, http.StatusBadRequest, err)
@@ -268,13 +299,21 @@ func stateHandler(cache *util.ParamCache) http.HandlerFunc {
 				return
 			}
 
-			res, err := jq.Query(query, b)
+			// the query is attacker-controlled, so bound evaluation time and result size
+			ctx, cancel := context.WithTimeout(r.Context(), maxJqDuration)
+			defer cancel()
+
+			res, err := jq.QueryContext(ctx, query, b)
 			if err != nil {
-				jsonError(w, http.StatusBadRequest, err)
+				status := http.StatusBadRequest
+				if ctx.Err() != nil {
+					status = http.StatusServiceUnavailable
+				}
+				jsonError(w, status, err)
 				return
 			}
 
-			jsonWrite(w, res)
+			jsonWriteLimited(w, res, maxJqResultBytes)
 			return
 		}
 

--- a/util/jq/jq.go
+++ b/util/jq/jq.go
@@ -1,6 +1,7 @@
 package jq
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,12 +11,19 @@ import (
 
 // Query executes a compiled jq query against given json. It expects a single result only.
 func Query(query *gojq.Query, input []byte) (any, error) {
+	return QueryContext(context.Background(), query, input)
+}
+
+// QueryContext executes a compiled jq query against given json, aborting when ctx is done.
+// It expects a single result only. Use this instead of Query whenever the query originates
+// from an untrusted source, since jq is turing-complete and evaluation may not terminate.
+func QueryContext(ctx context.Context, query *gojq.Query, input []byte) (any, error) {
 	var j any
 	if err := json.Unmarshal(input, &j); err != nil {
 		return j, err
 	}
 
-	iter := query.Run(j)
+	iter := query.RunWithContext(ctx, j)
 
 	v, ok := iter.Next()
 	if !ok {
@@ -23,6 +31,16 @@ func Query(query *gojq.Query, input []byte) (any, error) {
 	}
 
 	if err, ok := v.(error); ok {
+		// halt/halt_error do not terminate the iterator by themselves
+		var he *gojq.HaltError
+		if errors.As(err, &he) {
+			return nil, errors.New("jq: query halted")
+		}
+
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("jq: %w", ctxErr)
+		}
+
 		return nil, fmt.Errorf("jq: query failed: %v", err)
 	}
 

--- a/util/jq/jq_test.go
+++ b/util/jq/jq_test.go
@@ -1,0 +1,59 @@
+package jq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/itchyny/gojq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuery(t *testing.T) {
+	query, err := gojq.Parse(".foo")
+	require.NoError(t, err)
+
+	res, err := Query(query, []byte(`{"foo": 42}`))
+	require.NoError(t, err)
+	assert.Equal(t, float64(42), res)
+}
+
+// TestQueryContextTimeout ensures non-terminating queries are aborted instead of
+// running forever, exhausting cpu or memory
+func TestQueryContextTimeout(t *testing.T) {
+	for _, q := range []string{
+		`[range(1e9)]`, // unbounded allocation
+		`def f: f; f`,  // unbounded recursion
+		`[repeat(0)]`,  // infinite generator
+	} {
+		t.Run(q, func(t *testing.T) {
+			query, err := gojq.Parse(q)
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := QueryContext(ctx, query, []byte(`{}`))
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				assert.Error(t, err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("query did not terminate")
+			}
+		})
+	}
+}
+
+func TestQueryContextHalt(t *testing.T) {
+	query, err := gojq.Parse(`halt`)
+	require.NoError(t, err)
+
+	_, err = Query(query, []byte(`{}`))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Fix

Bound the attacker-controlled `?jq=` path three ways:

- **Time** — evaluate with a 1s context deadline via a new `jq.QueryContext` using `RunWithContext`, so non-terminating queries are aborted. The context is derived from the request, so a client disconnect cancels early too.
- **Query length** — reject queries over 512 chars before parsing.
- **Result size** — encode the result into a buffer and reject anything over 1 MB instead of streaming it out (the deadline stops the loop but does not reclaim what was already allocated, so a size bound is needed as well).

Timeouts now return `503` instead of `400`. `gojq.HaltError` is handled explicitly, since `halt`/`halt_error` can be raised from the query string without terminating the iterator.

`jq.Query` keeps its previous no-timeout behaviour, so the trusted, config-driven callers (`plugin/pipeline`, `util/service/http`, `cmd/detect`) are unchanged.

## Scope / compatibility

- The plain `/api/state` path (used by the UI, MQTT and the `http` plugin, which fetches full state and filters client-side) is **untouched** — all limits live inside the `?jq=` branch.
- gojq exposes no network/filesystem/exec primitives, and evcc enables none of the optional loaders (`WithModuleLoader`/`WithEnvironLoader`/`WithInputIter`), so the parameter cannot read env vars, files or the network. The threat is purely compute, which is what the bounds address.

## Tests

`util/jq/jq_test.go` pins the behaviour: `[range(1e9)]`, `def f: f; f` and `[repeat(0)]` each return an error within the deadline (with a watchdog that fails if a query survives cancellation), plus `halt` and a happy-path case.

Verified manually against a copy of a real database: the PoC now returns `503` in ~1s, oversized queries and oversized results return `400`, and normal selectors (`.siteTitle`, `.site.grid.power`, …) are unaffected.