### PR TITLE
DaheimLaden: fix firmware init

### DIFF
--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -363,43 +363,37 @@ func (wb *DaheimLaden) getPhases() (int, error) {
 }
 
 func (wb *DaheimLaden) checkStation() error {
-	// first call triggers fw to populate the register map
-	if _, err := wb.conn.ReadHoldingRegisters(dlRegEvseMaxCurrent, 22); err != nil {
-		return err
-	}
-
-	var s string
-	var err error
-
 	// map may still be zero right after the wake-up call- poll briefly until populated
-	for i := 0; i < 5; i++ {
-		time.Sleep(200 * time.Millisecond)
-
-		var b []byte
-		b, err = wb.conn.ReadHoldingRegisters(dlRegEvseMaxCurrent, 22)
+	for range 5 {
+		b, err := wb.conn.ReadHoldingRegisters(dlRegEvseMaxCurrent, 22)
 		if err != nil {
+			return err
+		}
+
+		s, err := utf16BEBytesAsString(b[2*(dlRegStationId-dlRegEvseMaxCurrent):])
+		if err != nil {
+			return err
+		}
+
+		if len(s) == 0 {
+			time.Sleep(200 * time.Millisecond)
 			continue
 		}
 
-		s, err = utf16BEBytesAsString(b[2*(dlRegStationId-dlRegEvseMaxCurrent):])
-		if err == nil && s != "" {
-			break
-		}
-	}
-
-	if err != nil || s == "" {
-		return api.ErrSponsorRequired
-	}
-
-	for _, r := range s {
-		if r < 0x20 || r > 0x7e {
+		if strings.Contains(strings.ToLower(s), "heidelbridge") {
 			return api.ErrSponsorRequired
 		}
+
+		for _, r := range s {
+			if r < 0x20 || r > 0x7e {
+				return api.ErrSponsorRequired
+			}
+		}
+
+		return nil
 	}
-	if strings.Contains(strings.ToLower(s), "heidelbridge") {
-		return api.ErrSponsorRequired
-	}
-	return nil
+
+	return api.ErrSponsorRequired
 }
 
 var _ api.Diagnosis = (*DaheimLaden)(nil)

--- a/charger/daheimladen.go
+++ b/charger/daheimladen.go
@@ -363,16 +363,30 @@ func (wb *DaheimLaden) getPhases() (int, error) {
 }
 
 func (wb *DaheimLaden) checkStation() error {
-	// first call for fw init
+	// first call triggers fw to populate the register map
 	if _, err := wb.conn.ReadHoldingRegisters(dlRegEvseMaxCurrent, 22); err != nil {
 		return err
 	}
-	b, err := wb.conn.ReadHoldingRegisters(dlRegEvseMaxCurrent, 22)
-	if err != nil {
-		return api.ErrSponsorRequired
+
+	var s string
+	var err error
+
+	// map may still be zero right after the wake-up call- poll briefly until populated
+	for i := 0; i < 5; i++ {
+		time.Sleep(200 * time.Millisecond)
+
+		var b []byte
+		b, err = wb.conn.ReadHoldingRegisters(dlRegEvseMaxCurrent, 22)
+		if err != nil {
+			continue
+		}
+
+		s, err = utf16BEBytesAsString(b[2*(dlRegStationId-dlRegEvseMaxCurrent):])
+		if err == nil && s != "" {
+			break
+		}
 	}
-	// station id starts (dlRegStationId-dlRegEvseMaxCurrent) registers into the block
-	s, err := utf16BEBytesAsString(b[2*(dlRegStationId-dlRegEvseMaxCurrent):])
+
 	if err != nil || s == "" {
 		return api.ErrSponsorRequired
 	}
@@ -382,11 +396,9 @@ func (wb *DaheimLaden) checkStation() error {
 			return api.ErrSponsorRequired
 		}
 	}
-
 	if strings.Contains(strings.ToLower(s), "heidelbridge") {
 		return api.ErrSponsorRequired
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Test https://github.com/evcc-io/evcc/pull/33010 war nicht erfolgreich. Der zweite Aufruf kommt zu schnell.
 
Register Map ist vorhanden, aber die Werte sind noch nicht befüllt. Der Read ist syntaktisch/adressmäßig völlig gültig, es kommen nur lauter Nullen zurück, weil die Firmware die Werte noch nicht geschrieben hat.

Eine feste Pause von z.B. 300 ms wäre dabei nur eine Vermutung über die Dauer – es wird nicht wirklich geprüft, ob die Daten inzwischen da sind. Falls die Pause mal nicht reicht, kommen beim zweiten Aufruf wieder Nullen und man landest im api.ErrSponsorRequired-Zweig – was inhaltlich falsch ist, denn es ist ja kein Sponsor-Problem, sondern ein Timing-Problem.

Robuster wäre daher, statt einer festen Pause die zweite Abfrage in eine kleine Retry-Schleife zu packen, die so lange (mit kurzen Pausen) erneut liest, bis eine plausible Station-ID kommt oder ein Timeout erreicht ist.

Quelle: Claude AI