### PR TITLE
E3DC (rscp): template requires sponsorship

### DIFF
--- a/templates/definition/charger/e3dc-rscp.yaml
+++ b/templates/definition/charger/e3dc-rscp.yaml
@@ -5,6 +5,7 @@ products:
       generic: Multi Connect II Wallbox
 capabilities: ["rfid", "1p3p", "meter", "dim"]
 requirements:
+  evcc: ["sponsorship"]
   description:
     de: |
       Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key (=RSCP-Passwort) muss im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt werden.


### PR DESCRIPTION
The `e3dc-rscp` charger constructor is sponsor-gated (`charger/e3dc.go`), but the template never declared `requirements: evcc: ["sponsorship"]`. It was missing since the device was added in #25703, so docs and the config UI stated no sponsorship was needed while startup failed with `sponsorship required`.

Reported in https://github.com/evcc-io/evcc/discussions/32417.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)