### PR TITLE
EEBus: keep pairing requests pending while devices are being configured

### DIFF
--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -87,6 +87,9 @@ type EEBus struct {
 	// unknown ski may still belong to a device that is not configured yet.
 	configured bool
 
+	// pending contains pairing requests received while still configuring
+	pending map[string]shipapi.ServiceIdentity
+
 	ski string
 
 	paired    []shipapi.ServiceIdentity // devices paired via SHIP Pairing Service
@@ -122,8 +125,21 @@ func ConfigComplete() {
 	}
 
 	instance.mux.Lock()
-	defer instance.mux.Unlock()
 	instance.configured = true
+
+	// deny requests left pending during configuration whose ski remained unknown
+	var deny []shipapi.ServiceIdentity
+	for _, identity := range instance.pending {
+		if len(instance.clients[identity.SKI]) == 0 {
+			deny = append(deny, identity)
+		}
+	}
+	clear(instance.pending)
+	instance.mux.Unlock()
+
+	for _, identity := range deny {
+		instance.service.CancelPairing(identity)
+	}
 }
 
 func GetStatus() any {
@@ -207,10 +223,16 @@ func NewServer(other Config) (*EEBus, error) {
 		ski:       ski,
 		clients:   make(map[string][]Device),
 		connected: make(map[string]bool),
+		pending:   make(map[string]shipapi.ServiceIdentity),
 	}
 
 	c.service = service.NewService(configuration, c)
 	c.service.SetLogging(c)
+
+	// keep pairing requests from unknown skis pending instead of aborting the ship
+	// handshake- the ski may still be registered by a device that is being configured
+	c.service.UserIsAbleToApproveOrCancelPairingRequests(true)
+
 	if err := c.service.Setup(); err != nil {
 		if errors.Is(err, shipapi.ErrInvalidSKI) {
 			const hint = "The stored EEBUS certificate has an invalid Subject Key Identifier (SKI).\n" +
@@ -587,6 +609,7 @@ func (c *EEBus) ServicePairingDetailUpdate(identity shipapi.ServiceIdentity, det
 			// device configuration is still running- leave the request pending
 			// instead of denying a ski that is about to be registered
 			c.log.DEBUG.Printf("pairing request from %s while configuring, left pending", identity.SKI)
+			c.pending[identity.SKI] = identity
 			return
 		}
 
@@ -601,16 +624,22 @@ func (c *EEBus) ServiceAutoTrusted(service eebusapi.ServiceInterface, identity s
 	c.log.INFO.Printf("service trusted: %s", identity.ShipID)
 
 	c.mux.Lock()
-	defer c.mux.Unlock()
 	c.upsertPairing(identity)
 
 	// connect may run before trust is established, so clientsFor skips consumers
 	// registered without ski; wake them now that the device is paired
+	var clients []Device
 	if c.connected[identity.SKI] {
-		for _, client := range c.clientsFor(identity.SKI) {
-			client.Connect(true)
-		}
+		clients = c.clientsFor(identity.SKI)
 	}
+	c.mux.Unlock()
+
+	for _, client := range clients {
+		client.Connect(true)
+	}
+
+	// registering the now trusted identity approves a handshake still pending trust
+	c.service.RegisterRemoteService(identity)
 }
 
 func (c *EEBus) ServiceAutoTrustFailed(service eebusapi.ServiceInterface, identity shipapi.ServiceIdentity, reason error) {

--- a/server/eebus/eebus_test.go
+++ b/server/eebus/eebus_test.go
@@ -88,13 +88,51 @@ func TestPairingDeniedOnlyWhenConfigured(t *testing.T) {
 	c := &EEBus{
 		log:     util.NewLogger("test"),
 		clients: make(map[string][]Device),
+		pending: make(map[string]shipapi.ServiceIdentity),
 		service: service,
 	}
 
 	// still configuring - no CancelPairing expected
 	c.ServicePairingDetailUpdate(identity, detail)
+	require.Len(t, c.pending, 1)
 
 	service.EXPECT().CancelPairing(identity).Once()
 	c.configured = true
 	c.ServicePairingDetailUpdate(identity, detail)
+}
+
+// TestConfigCompleteResolvesPending guards that a request left pending during
+// configuration is denied afterwards unless its ski belongs to a configured device-
+// ship-go keeps prolonging the pending handshake until somebody decides.
+func TestConfigCompleteResolvesPending(t *testing.T) {
+	identity := shipapi.NewServiceIdentity("aabbcc", "", "")
+
+	newInstance := func(t *testing.T, clients map[string][]Device) *eebusmocks.ServiceInterface {
+		service := eebusmocks.NewServiceInterface(t)
+		instance = &EEBus{
+			log:     util.NewLogger("test"),
+			clients: clients,
+			pending: map[string]shipapi.ServiceIdentity{identity.SKI: identity},
+			service: service,
+		}
+		t.Cleanup(func() { instance = nil })
+		return service
+	}
+
+	t.Run("unknown ski denied", func(t *testing.T) {
+		service := newInstance(t, make(map[string][]Device))
+		service.EXPECT().CancelPairing(identity).Once()
+
+		ConfigComplete()
+		require.True(t, instance.configured)
+		require.Empty(t, instance.pending)
+	})
+
+	t.Run("configured ski kept", func(t *testing.T) {
+		// no CancelPairing expected- the device registered its ski meanwhile
+		newInstance(t, map[string][]Device{identity.SKI: {&mockDevice{}}})
+
+		ConfigComplete()
+		require.True(t, instance.configured)
+	})
 }


### PR DESCRIPTION
Follow-up to #32966, which is ineffective as reported in https://github.com/evcc-io/evcc/pull/32966#issuecomment-5366410296.

Leaving an incoming pairing request pending in `ServicePairingDetailUpdate` never reached ship-go's decision point. `handshakeHello_PendingInit` sends `{"connectionHello":[{"phase":"pending"}]}` and then immediately aborts unless `AllowWaitingForTrust` is true, which resolves to eebus-go's `isPairingPossible` — a flag evcc never set. A control box connecting before its ski was registered was therefore aborted, and the reporter's device exits on denied trust:

```
09:06:18 Send: 6988… {"connectionHello":[{"phase":"pending"},{"waiting":60000}]}
09:06:18 Send: 6988… {"connectionHello":[{"phase":"aborted"}]}
09:06:18 pairing request from 6988… while configuring, left pending
09:06:18 registering ski: 6988…
```

Whether the incoming connection wins the race against device configuration decides it, hence roughly every second restart.

Changes:
- enable `UserIsAbleToApproveOrCancelPairingRequests`, so a pending handshake survives until evcc decides. `RegisterDevice` already registers the ski, which makes ship-go approve the pending handshake.
- track the requests left pending and deny those whose ski is still unknown once configuration completed, otherwise ship-go would prolong them indefinitely.
- register the identity in `ServiceAutoTrusted`, since establishing trust via the SHIP Pairing Service does not approve an already pending handshake. Previously the immediate abort plus reconnect masked this.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)