### PR TITLE
Tariff: add Energy Price Forecast regions and currencies

### DIFF
--- a/templates/definition/tariff/energypriceforecast.yaml
+++ b/templates/definition/tariff/energypriceforecast.yaml
@@ -9,15 +9,36 @@ requirements:
     en: "Spot prices in day-ahead market plus 4 days prognosis [energypriceforecast.eu](https://energypriceforecast.eu)"
   evcc: ["skiptest"]
 group: price
-countries: ["DE", "NL", "BE", "DK", "FR"]
+countries: ["DE", "NL", "BE", "DK", "FR", "AT", "CZ", "PL", "FI", "SE", "NO"]
 params:
   - name: region
     example: DE
     type: choice
-    choice: ["DE", "NL", "BE", "DK1", "DK2", "FR"]
+    choice:
+      [
+        "DE",
+        "NL",
+        "BE",
+        "DK1",
+        "DK2",
+        "FR",
+        "AT",
+        "CZ",
+        "PL",
+        "FI",
+        "SE1",
+        "SE2",
+        "SE3",
+        "SE4",
+        "NO1",
+        "NO2",
+        "NO3",
+        "NO4",
+        "NO5",
+      ]
     required: true
   - name: currency
-    choice: ["EUR", "DKK"]
+    choice: ["EUR", "DKK", "CZK", "PLN", "SEK", "NOK"]
   - name: horizon
     default: 120
     type: int


### PR DESCRIPTION
## Summary

- add Austria, Czechia, Poland, Finland, Sweden, and Norway to the Energy Price Forecast tariff template
- expose the corresponding bidding zones, including SE1-SE4 and NO1-NO5
- add CZK, PLN, SEK, and NOK as selectable currencies

The production API already supports all listed regions and currencies. Existing configurations remain unchanged because the current regions and currency choices are preserved.

## Testing

- validated the 120-hour response for every listed region without gaps
- validated CZK, PLN, SEK, DKK, and NOK values against the corresponding EUR response
- validated that the standard response still starts with the current in-progress slot
- validated that requests without an explicit currency keep their existing defaults