### PR TITLE
Use math/rand/v2 and Go 1.27 generic rand.N

### DIFF
--- a/core/planner/helper_test.go
+++ b/core/planner/helper_test.go
@@ -1,7 +1,7 @@
 package planner
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 

--- a/plugin/watchdog_test.go
+++ b/plugin/watchdog_test.go
@@ -27,7 +27,7 @@ func TestWatchdogSetterConcurrency(t *testing.T) {
 			return errors.New("race")
 		}
 
-		time.Sleep(time.Duration(rand.Int32N(int32(p.timeout))))
+		time.Sleep(rand.N(p.timeout))
 
 		if !u.CompareAndSwap(1, 0) {
 			return errors.New("race")

--- a/server/modbus/proxy_test.go
+++ b/server/modbus/proxy_test.go
@@ -2,7 +2,7 @@ package modbus
 
 import (
 	"encoding/binary"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"sync"
 	"testing"
@@ -36,8 +36,8 @@ func TestConcurrentRead(t *testing.T) {
 			require.NoError(t, err)
 
 			for range 50 {
-				addr := uint16(rand.Int31n(200) + 1)
-				qty := uint16(rand.Int31n(32) + 1)
+				addr := uint16(rand.N(200) + 1)
+				qty := uint16(rand.N(32) + 1)
 
 				b, err := conn.ReadInputRegisters(addr, qty)
 				require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestConcurrentRead(t *testing.T) {
 					}
 				}
 
-				time.Sleep(time.Duration(rand.Int31n(1000)) * time.Microsecond)
+				time.Sleep(rand.N(time.Millisecond))
 			}
 		})
 	}

--- a/util/monitor_test.go
+++ b/util/monitor_test.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 


### PR DESCRIPTION
Migrate the remaining `math/rand` imports to `math/rand/v2` and replace conversion-wrapped `Int31n`/`Int32N` calls with the generic `rand.N` added in Go 1.27:

- `server/modbus/proxy_test.go`: `time.Duration(rand.Int31n(1000)) * time.Microsecond` becomes `rand.N(time.Millisecond)`
- `plugin/watchdog_test.go`: `time.Duration(rand.Int32N(int32(p.timeout)))` becomes `rand.N(p.timeout)`
- `core/planner/helper_test.go`, `util/monitor_test.go`: v2 import only, `Shuffle`/`Int` signatures are unchanged

`plugin/random.go` keeps `Int64N`: `rand.N(math.MaxInt64-1)` would infer `int` and overflow on 32-bit platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)