### PR TITLE
Add 1SINQ OneKey heat pump template (sgready via MQTT)

### DIFF
--- a/templates/definition/charger/onekey.yaml
+++ b/templates/definition/charger/onekey.yaml
@@ -1,0 +1,66 @@
+template: onekey
+products:
+  - brand: 1SINQ
+    description:
+      generic: OneKey
+capabilities: ["meter", "dim"]
+group: heating
+requirements:
+  evcc: ["skiptest"]
+  description:
+    de: |
+      OneKey-Heizungsregelung mit aktivierter evcc-Anbindung. Die Wärmepumpe
+      wird über SG-Ready-Zustände geführt (1=Dimmen, 2=Normal, 3=Boost).
+      Dazu muss im OneKey-Gerät der Energiemanager im Modus SG-Ready laufen
+      und evcc als SG-Ready-Quelle eingestellt sein. Läuft evcc auf dem
+      OneKey-Gerät selbst, ist der Broker `localhost`.
+    en: |
+      OneKey heating controller with evcc integration enabled. The heat pump
+      is controlled via SG Ready states (1=dim, 2=normal, 3=boost). The
+      device's energy manager must run in SG Ready mode with evcc selected
+      as the SG Ready source. When evcc runs on the OneKey device itself the
+      broker is `localhost`.
+params:
+  - preset: mqtt
+  - name: topic
+    default: onekey
+    description:
+      de: Basis-Topic des OneKey-Geräts
+      en: Base topic of the OneKey device
+render: |
+  type: sgready
+  setmode:
+    source: mqtt
+    {{- include "mqtt" . | indent 2 }}
+    topic: {{ .topic }}/wp/sgmode/set
+    retained: true
+  setmaxpower:
+    source: mqtt
+    {{- include "mqtt" . | indent 2 }}
+    topic: {{ .topic }}/wp/maxpower/set
+    retained: true
+  getmode:
+    source: mqtt
+    {{- include "mqtt" . | indent 2 }}
+    topic: {{ .topic }}/wp/sgmode
+    timeout: 90s
+  power:
+    source: mqtt
+    {{- include "mqtt" . | indent 2 }}
+    topic: {{ .topic }}/wp/power
+    timeout: 90s
+  energy:
+    source: mqtt
+    {{- include "mqtt" . | indent 2 }}
+    topic: {{ .topic }}/wp/energy
+    timeout: 90s
+  temp:
+    source: mqtt
+    {{- include "mqtt" . | indent 2 }}
+    topic: {{ .topic }}/wp/temp
+    timeout: 90s
+  limittemp:
+    source: mqtt
+    {{- include "mqtt" . | indent 2 }}
+    topic: {{ .topic }}/wp/limittemp
+    timeout: 90s


### PR DESCRIPTION
The 1SINQ OneKey heating controller speaks the SG Ready contract over MQTT. This template wires its topics to the `sgready` charger.

**What the device publishes and subscribes**

| topic | direction | payload |
|---|---|---|
| `<topic>/wp/sgmode/set` | evcc → device | `1` \| `2` \| `3` |
| `<topic>/wp/maxpower/set` | evcc → device | integer watts |
| `<topic>/wp/sgmode` | device → evcc | `1` \| `2` \| `3` |
| `<topic>/wp/power` | device → evcc | W |
| `<topic>/wp/energy` | device → evcc | kWh, monotonic |
| `<topic>/wp/temp` | device → evcc | °C, leading storage |
| `<topic>/wp/limittemp` | device → evcc | °C, its target |

`setmaxpower` turns the three-state contract into continuous modulation: the heat pump has a power envelope with a minimum and maximum per outside temperature and modulates within it.

The read plugins use a 90s timeout, which is three times the device's publish heartbeat (it publishes on change or every 30s), so a stale value is detected without false positives on a single missed update.

**Testing**

Tested against a live device (OneKey controller with a 1SINQ ONE-10 heat pump):

- template renders as expected (`RenderResult`, all plugins resolved)
- read path: `evcc charger` reports `Temp: 48°C`, `Max Temp: 65°C`, `Power: 0W`, `Features: [Continuous Heating IntegratedDevice]` — matching the retained MQTT values
- write path: `evcc charger --enable` publishes `3` to `<topic>/wp/sgmode/set`, received by the device
- `charger: power ✓ energy ✓` on the loadpoint
- `go test ./util/templates/` passes, `go generate ./util/templates/...` produces valid metadata

The device runs evcc on the same box in the pilot installation, so the broker defaults to localhost there, but the template takes the broker from the standard `mqtt` preset and works with a remote broker as well.
