### PR TITLE
Voltie: only offer phase switching where the power board supports it

### DIFF
--- a/charger/voltie.go
+++ b/charger/voltie.go
@@ -55,6 +55,10 @@ import (
 // communication timeout, the hardware current limit, lifetime energy and the
 // phase powers. Those capabilities are only offered when the charger reports
 // that firmware, and the block read lengths follow the firmware as well.
+//
+// Phase switching additionally depends on the power board, which the firmware
+// does not expose over Modbus. The same firmware runs on older boards that have
+// no L2/L3 relay and reject the write, so support is probed once on startup.
 
 const (
 	// register blocks fetched in bulk
@@ -222,6 +226,10 @@ type Voltie struct {
 	meter  modbus.Block
 	info   modbus.Block
 	ext    bool // firmware provides the extended register blocks
+
+	// set once the charger has refused a phase switch for a reason that will not
+	// change while running, so no further attempt interrupts a session
+	noPhaseSwitch bool
 }
 
 // read fetches a register block through the shared bulk read cache, so all
@@ -329,11 +337,14 @@ func NewVoltie(ctx context.Context, settings modbus.TcpSettings, cache time.Dura
 	}
 
 	if wb.ext {
-		implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
 		implement.Has(wb, implement.PhaseGetter(wb.getPhases))
 		implement.Has(wb, implement.MeterEnergy(wb.totalEnergy))
 		implement.Has(wb, implement.PhasePowers(wb.powers))
 		implement.Has(wb, implement.CurrentLimiter(wb.getMinMaxCurrent))
+
+		if wb.phaseSwitchingSupported() {
+			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
+		}
 	}
 
 	return wb, nil
@@ -533,15 +544,60 @@ func (wb *Voltie) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(voltieRegVoltages, 1e3)
 }
 
-// phases1p3p implements the api.PhaseSwitcher interface. The register is only
-// writable on chargers manufactured from 2026, which carry an HPOW108 power
-// board; other hardware rejects the write with exception 0x03, as does a relay
-// or EEPROM error. The hardware generation cannot be detected up front: the
-// serial numbers exposed over Modbus are the MCU and power board serials, not
-// the charger serial that carries the generation prefix.
+// phaseSwitchingSupported reports whether the power board can switch phases.
+// The board type is not exposed over Modbus, so the register is written its own
+// value: that leaves the relay where it is, but a board without the L2/L3 relay
+// refuses it. The firmware also refuses while charging, so a probe during a
+// running session is inconclusive and the decision is left to the runtime latch.
+//
+// The firmware checks the board before it touches anything, so the probe has no
+// effect at all where it is refused. Where it succeeds it costs the one EEPROM
+// write that any phase switch costs, once per start.
+func (wb *Voltie) phaseSwitchingSupported() bool {
+	// a charging session makes the firmware refuse the write for an unrelated
+	// reason, which would look exactly like a board without the relay
+	if charging, err := wb.charging(); err != nil || charging {
+		wb.log.DEBUG.Println("phase switching support not probed")
+		return true
+	}
+
+	b, err := wb.read(wb.status)
+	if err != nil {
+		return false
+	}
+
+	if _, err := wb.conn.WriteSingleRegister(voltieRegSinglePhase,
+		voltieU16(wb.status, b, voltieRegSinglePhase)); err != nil {
+		wb.log.DEBUG.Printf("phase switching unavailable: %v", err)
+		return false
+	}
+
+	return true
+}
+
+// charging reads the charging flag past the cache, which is the condition the
+// firmware checks before it allows a phase switch
+func (wb *Voltie) charging() (bool, error) {
+	wb.cache.Clear()
+
+	b, err := wb.read(wb.status)
+	if err != nil {
+		return false, err
+	}
+
+	return voltieU16(wb.status, b, voltieRegCharging) != 0, nil
+}
+
+// phases1p3p implements the api.PhaseSwitcher interface. The firmware accepts
+// the write only on a power board that has the L2/L3 relay, and never while
+// charging, so support is probed on startup and a rejection here is latched.
 func (wb *Voltie) phases1p3p(phases int) error {
 	if phases != 1 && phases != 3 {
 		return fmt.Errorf("invalid phases: %d", phases)
+	}
+
+	if wb.noPhaseSwitch {
+		return errors.New("charger rejected phase switching, not retrying")
 	}
 
 	b, err := wb.read(wb.status)
@@ -566,7 +622,15 @@ func (wb *Voltie) phases1p3p(phases int) error {
 		}
 
 		if _, err = wb.conn.WriteSingleRegister(voltieRegSinglePhase, u); err != nil {
-			err = fmt.Errorf("switch phases: %w", err)
+			// Apart from charging, the firmware only refuses when it cannot switch at
+			// all: a power board without the L2/L3 relay, control by Modbus disabled,
+			// or a relay or EEPROM error. Latching that keeps further attempts from
+			// stopping and restarting the session. Charging is re-read first, so a
+			// session starting mid-write cannot disable a charger that does work.
+			if charging, cerr := wb.charging(); cerr == nil && !charging {
+				wb.noPhaseSwitch = true
+				wb.log.ERROR.Printf("phase switching disabled after rejection: %v", err)
+			}
 		}
 
 		wb.cache.Clear()
@@ -588,14 +652,12 @@ func (wb *Voltie) awaitContactorOpen() error {
 			time.Sleep(voltiePhaseSwitchWait)
 		}
 
-		wb.cache.Clear()
-
-		b, err := wb.read(wb.status)
+		charging, err := wb.charging()
 		if err != nil {
 			return err
 		}
 
-		if voltieU16(wb.status, b, voltieRegCharging) == 0 {
+		if !charging {
 			return nil
 		}
 	}

--- a/charger/voltie.go
+++ b/charger/voltie.go
@@ -554,16 +554,18 @@ func (wb *Voltie) Voltages() (float64, float64, float64, error) {
 // effect at all where it is refused. Where it succeeds it costs the one EEPROM
 // write that any phase switch costs, once per start.
 func (wb *Voltie) phaseSwitchingSupported() bool {
-	// a charging session makes the firmware refuse the write for an unrelated
-	// reason, which would look exactly like a board without the relay
-	if charging, err := wb.charging(); err != nil || charging {
-		wb.log.DEBUG.Println("phase switching support not probed")
-		return true
-	}
-
+	// checkSettings has just read the status block, so this is a cache hit and
+	// needs no further request
 	b, err := wb.read(wb.status)
 	if err != nil {
 		return false
+	}
+
+	// a charging session makes the firmware refuse the write for an unrelated
+	// reason, which would look exactly like a board without the relay
+	if voltieU16(wb.status, b, voltieRegCharging) != 0 {
+		wb.log.DEBUG.Println("charging, phase switching support not probed")
+		return true
 	}
 
 	if _, err := wb.conn.WriteSingleRegister(voltieRegSinglePhase,

--- a/charger/voltie.go
+++ b/charger/voltie.go
@@ -58,7 +58,8 @@ import (
 //
 // Phase switching additionally depends on the power board, which the firmware
 // does not expose over Modbus. The same firmware runs on older boards that have
-// no L2/L3 relay and reject the write, so support is probed once on startup.
+// no L2/L3 relay and reject the write, so the capability is probed on startup
+// and only offered once the charger has accepted it.
 
 const (
 	// register blocks fetched in bulk
@@ -226,10 +227,6 @@ type Voltie struct {
 	meter  modbus.Block
 	info   modbus.Block
 	ext    bool // firmware provides the extended register blocks
-
-	// set once the charger has refused a phase switch for a reason that will not
-	// change while running, so no further attempt interrupts a session
-	noPhaseSwitch bool
 }
 
 // read fetches a register block through the shared bulk read cache, so all
@@ -547,8 +544,8 @@ func (wb *Voltie) Voltages() (float64, float64, float64, error) {
 // phaseSwitchingSupported reports whether the power board can switch phases.
 // The board type is not exposed over Modbus, so the register is written its own
 // value: that leaves the relay where it is, but a board without the L2/L3 relay
-// refuses it. The firmware also refuses while charging, so a probe during a
-// running session is inconclusive and the decision is left to the runtime latch.
+// refuses it. The firmware also refuses while charging, which makes the probe
+// inconclusive, and an unverified capability is not offered.
 //
 // The firmware checks the board before it touches anything, so the probe has no
 // effect at all where it is refused. Where it succeeds it costs the one EEPROM
@@ -564,8 +561,8 @@ func (wb *Voltie) phaseSwitchingSupported() bool {
 	// a charging session makes the firmware refuse the write for an unrelated
 	// reason, which would look exactly like a board without the relay
 	if voltieU16(wb.status, b, voltieRegCharging) != 0 {
-		wb.log.DEBUG.Println("charging, phase switching support not probed")
-		return true
+		wb.log.DEBUG.Println("charging, cannot probe phase switching")
+		return false
 	}
 
 	if _, err := wb.conn.WriteSingleRegister(voltieRegSinglePhase,
@@ -577,29 +574,11 @@ func (wb *Voltie) phaseSwitchingSupported() bool {
 	return true
 }
 
-// charging reads the charging flag past the cache, which is the condition the
-// firmware checks before it allows a phase switch
-func (wb *Voltie) charging() (bool, error) {
-	wb.cache.Clear()
-
-	b, err := wb.read(wb.status)
-	if err != nil {
-		return false, err
-	}
-
-	return voltieU16(wb.status, b, voltieRegCharging) != 0, nil
-}
-
-// phases1p3p implements the api.PhaseSwitcher interface. The firmware accepts
-// the write only on a power board that has the L2/L3 relay, and never while
-// charging, so support is probed on startup and a rejection here is latched.
+// phases1p3p implements the api.PhaseSwitcher interface. The firmware never
+// accepts the write while charging, so charging is paused for the switch.
 func (wb *Voltie) phases1p3p(phases int) error {
 	if phases != 1 && phases != 3 {
 		return fmt.Errorf("invalid phases: %d", phases)
-	}
-
-	if wb.noPhaseSwitch {
-		return errors.New("charger rejected phase switching, not retrying")
 	}
 
 	b, err := wb.read(wb.status)
@@ -623,17 +602,7 @@ func (wb *Voltie) phases1p3p(phases int) error {
 			u = 1
 		}
 
-		if _, err = wb.conn.WriteSingleRegister(voltieRegSinglePhase, u); err != nil {
-			// Apart from charging, the firmware only refuses when it cannot switch at
-			// all: a power board without the L2/L3 relay, control by Modbus disabled,
-			// or a relay or EEPROM error. Latching that keeps further attempts from
-			// stopping and restarting the session. Charging is re-read first, so a
-			// session starting mid-write cannot disable a charger that does work.
-			if charging, cerr := wb.charging(); cerr == nil && !charging {
-				wb.noPhaseSwitch = true
-				wb.log.ERROR.Printf("phase switching disabled after rejection: %v", err)
-			}
-		}
+		_, err = wb.conn.WriteSingleRegister(voltieRegSinglePhase, u)
 
 		wb.cache.Clear()
 	}
@@ -654,12 +623,14 @@ func (wb *Voltie) awaitContactorOpen() error {
 			time.Sleep(voltiePhaseSwitchWait)
 		}
 
-		charging, err := wb.charging()
+		wb.cache.Clear()
+
+		b, err := wb.read(wb.status)
 		if err != nil {
 			return err
 		}
 
-		if !charging {
+		if voltieU16(wb.status, b, voltieRegCharging) == 0 {
 			return nil
 		}
 	}

--- a/charger/voltie.go
+++ b/charger/voltie.go
@@ -57,9 +57,9 @@ import (
 // that firmware, and the block read lengths follow the firmware as well.
 //
 // Phase switching additionally depends on the power board, which the firmware
-// does not expose over Modbus. The same firmware runs on older boards that have
-// no L2/L3 relay and reject the write, so the capability is probed on startup
-// and only offered once the charger has accepted it.
+// does not expose over Modbus. The same firmware also runs on older boards that
+// have no L2/L3 relay and reject the write, so the capability is enabled by
+// configuration rather than guessed.
 
 const (
 	// register blocks fetched in bulk
@@ -272,6 +272,7 @@ func NewVoltieFromConfig(ctx context.Context, other map[string]any) (api.Charger
 	cc := struct {
 		modbus.TcpSettings `mapstructure:",squash"`
 		Cache              time.Duration
+		Phases1p3p         bool
 	}{
 		TcpSettings: modbus.TcpSettings{
 			ID:      voltieDefaultSlaveID,
@@ -285,11 +286,11 @@ func NewVoltieFromConfig(ctx context.Context, other map[string]any) (api.Charger
 		return nil, err
 	}
 
-	return NewVoltie(ctx, cc.TcpSettings, cc.Cache)
+	return NewVoltie(ctx, cc.TcpSettings, cc.Cache, cc.Phases1p3p)
 }
 
 // NewVoltie creates a Voltie charger
-func NewVoltie(ctx context.Context, settings modbus.TcpSettings, cache time.Duration) (*Voltie, error) {
+func NewVoltie(ctx context.Context, settings modbus.TcpSettings, cache time.Duration, phaseSwitching bool) (*Voltie, error) {
 	conn, err := settings.Connection(ctx)
 	if err != nil {
 		return nil, err
@@ -339,9 +340,13 @@ func NewVoltie(ctx context.Context, settings modbus.TcpSettings, cache time.Dura
 		implement.Has(wb, implement.PhasePowers(wb.powers))
 		implement.Has(wb, implement.CurrentLimiter(wb.getMinMaxCurrent))
 
-		if wb.phaseSwitchingSupported() {
+		if phaseSwitching {
 			implement.Has(wb, implement.PhaseSwitcher(wb.phases1p3p))
 		}
+	}
+
+	if phaseSwitching && !wb.ext {
+		log.WARN.Printf("phase switching requires firmware %d or later", voltieExtFirmware)
 	}
 
 	return wb, nil
@@ -539,39 +544,6 @@ var _ api.PhaseVoltages = (*Voltie)(nil)
 // Voltages implements the api.PhaseVoltages interface
 func (wb *Voltie) Voltages() (float64, float64, float64, error) {
 	return wb.getPhaseValues(voltieRegVoltages, 1e3)
-}
-
-// phaseSwitchingSupported reports whether the power board can switch phases.
-// The board type is not exposed over Modbus, so the register is written its own
-// value: that leaves the relay where it is, but a board without the L2/L3 relay
-// refuses it. The firmware also refuses while charging, which makes the probe
-// inconclusive, and an unverified capability is not offered.
-//
-// The firmware checks the board before it touches anything, so the probe has no
-// effect at all where it is refused. Where it succeeds it costs the one EEPROM
-// write that any phase switch costs, once per start.
-func (wb *Voltie) phaseSwitchingSupported() bool {
-	// checkSettings has just read the status block, so this is a cache hit and
-	// needs no further request
-	b, err := wb.read(wb.status)
-	if err != nil {
-		return false
-	}
-
-	// a charging session makes the firmware refuse the write for an unrelated
-	// reason, which would look exactly like a board without the relay
-	if voltieU16(wb.status, b, voltieRegCharging) != 0 {
-		wb.log.DEBUG.Println("charging, cannot probe phase switching")
-		return false
-	}
-
-	if _, err := wb.conn.WriteSingleRegister(voltieRegSinglePhase,
-		voltieU16(wb.status, b, voltieRegSinglePhase)); err != nil {
-		wb.log.DEBUG.Printf("phase switching unavailable: %v", err)
-		return false
-	}
-
-	return true
 }
 
 // phases1p3p implements the api.PhaseSwitcher interface. The firmware never

--- a/templates/definition/charger/voltie.yaml
+++ b/templates/definition/charger/voltie.yaml
@@ -26,7 +26,18 @@ params:
   - name: cache
     advanced: true
     default: 1s
+  - name: phases1p3p
+    description:
+      de: Phasenumschaltung
+      en: Phase switching
+    help:
+      de: Nur auf Ladegeräten ab Baujahr 2026 verfügbar, deren Seriennummer mit 1026 beginnt. Auf älterer Hardware weist das Ladegerät die Umschaltung ab.
+      en: Only available on chargers manufactured from 2026, whose serial number starts with 1026. On older hardware the charger rejects the switch.
+    type: bool
+    default: false
+    advanced: true
 render: |
   type: voltie
   {{- include "modbus" . }}
   cache: {{ .cache }}
+  phases1p3p: {{ .phases1p3p }}


### PR DESCRIPTION
Follow-up to #32783. Phase switching was offered on every charger with firmware 352 or later, but the capability depends on the power board: the same firmware also runs on older boards that have no L2/L3 relay and reject the write with exception 0x03. evcc then retried on every update cycle, and because the driver pauses charging before the write, each retry stopped and restarted the session.

- support is probed once on startup by writing the register its own value, which leaves the relay where it is but is refused on a board without it; `api.PhaseSwitcher` is only offered when that succeeds
- if a session is active and the probe cannot run, the first confirmed rejection is latched, so no further attempt interrupts charging
- dropped the redundant `switch phases:` prefix, the loadpoint already adds one

This also separates the hardware check from the register write, as suggested in the review of #32783.

Tested on two chargers, one with phase switching support and one without: switching still works in both directions on the first, and on the second the capability is no longer offered and nothing is retried.
