### PR TITLE
EEBus OHPCF: add disablepowerlimiter option

### DIFF
--- a/api/implement/implementations.go
+++ b/api/implement/implementations.go
@@ -378,6 +378,21 @@ func (i *iPhaseVoltages) Voltages() (float64, float64, float64, error) {
 	return i.phaseVoltages0()
 }
 
+func PowerLimiter(powerLimiter0 func() (float64, float64, error)) api.PowerLimiter {
+	if powerLimiter0 == nil {
+		return nil
+	}
+	return &iPowerLimiter{powerLimiter0}
+}
+
+type iPowerLimiter struct {
+	powerLimiter0 func() (float64, float64, error)
+}
+
+func (i *iPowerLimiter) GetMinMaxPower() (float64, float64, error) {
+	return i.powerLimiter0()
+}
+
 func Resurrector(resurrector0 func() error) api.Resurrector {
 	if resurrector0 == nil {
 		return nil

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -468,8 +468,7 @@ func (c *EEBusOHPCF) apply(enable bool) error {
 	return nil
 }
 
-// getMinMaxPower implements the api.PowerLimiter interface, reporting the
-// optional consumption as expected min/max or ErrNotAvailable if none.
+// getMinMaxPower is the callback used to provide the optional power limits.
 func (c *EEBusOHPCF) getMinMaxPower() (float64, float64, error) {
 	entity, ok := c.connectedCompressor()
 	if !ok {

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -60,11 +60,11 @@ func init() {
 // NewEEBusOHPCFFromConfig creates an EEBus OHPCF charger from generic config
 func NewEEBusOHPCFFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
 	cc := struct {
-		embed         `mapstructure:",squash"`
-		Ski           string
-		Ip            string
-		Reboost       time.Duration
-		DisableMinMax bool
+		embed               `mapstructure:",squash"`
+		Ski                 string
+		Ip                  string
+		Reboost             time.Duration
+		DisablePowerLimiter bool
 	}{
 		embed: embed{
 			Icon_:     "heatpump",
@@ -77,12 +77,12 @@ func NewEEBusOHPCFFromConfig(ctx context.Context, other map[string]any) (api.Cha
 		return nil, err
 	}
 
-	return NewEEBusOHPCF(ctx, &cc.embed, cc.Ski, cc.Ip, cc.Reboost, cc.DisableMinMax)
+	return NewEEBusOHPCF(ctx, &cc.embed, cc.Ski, cc.Ip, cc.Reboost, cc.DisablePowerLimiter)
 }
 
 // NewEEBusOHPCF creates an EEBus OHPCF charger, registers it with the EEBus
 // instance and waits for the connection.
-func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost time.Duration, disableMinMax bool) (api.Charger, error) {
+func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost time.Duration, disablePowerLimiter bool) (api.Charger, error) {
 	inst, err := eebus.Instance()
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		reboost:   reboost,
 	}
 
-	if !disableMinMax {
+	if !disablePowerLimiter {
 		implement.Has(c, implement.PowerLimiter(c.getMinMaxPower))
 	}
 

--- a/charger/eebus-ohpcf.go
+++ b/charger/eebus-ohpcf.go
@@ -15,6 +15,7 @@ import (
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/api/implement"
 	"github.com/evcc-io/evcc/server/eebus"
 	"github.com/evcc-io/evcc/util"
 )
@@ -27,6 +28,7 @@ import (
 // enabling the charger schedules or resumes the optional consumption, disabling
 // it pauses or aborts the running process.
 type EEBusOHPCF struct {
+	implement.Caps
 	*embed
 	cem *eebus.CustomerEnergyManagement
 	ma  *eebus.MonitoringAppliance
@@ -58,10 +60,11 @@ func init() {
 // NewEEBusOHPCFFromConfig creates an EEBus OHPCF charger from generic config
 func NewEEBusOHPCFFromConfig(ctx context.Context, other map[string]any) (api.Charger, error) {
 	cc := struct {
-		embed   `mapstructure:",squash"`
-		Ski     string
-		Ip      string
-		Reboost time.Duration
+		embed         `mapstructure:",squash"`
+		Ski           string
+		Ip            string
+		Reboost       time.Duration
+		DisableMinMax bool
 	}{
 		embed: embed{
 			Icon_:     "heatpump",
@@ -74,18 +77,19 @@ func NewEEBusOHPCFFromConfig(ctx context.Context, other map[string]any) (api.Cha
 		return nil, err
 	}
 
-	return NewEEBusOHPCF(ctx, &cc.embed, cc.Ski, cc.Ip, cc.Reboost)
+	return NewEEBusOHPCF(ctx, &cc.embed, cc.Ski, cc.Ip, cc.Reboost, cc.DisableMinMax)
 }
 
 // NewEEBusOHPCF creates an EEBus OHPCF charger, registers it with the EEBus
 // instance and waits for the connection.
-func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost time.Duration) (api.Charger, error) {
+func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost time.Duration, disableMinMax bool) (api.Charger, error) {
 	inst, err := eebus.Instance()
 	if err != nil {
 		return nil, err
 	}
 
 	c := &EEBusOHPCF{
+		Caps:      implement.New(),
 		embed:     embed,
 		log:       util.NewLogger("eebus-ohpcf"),
 		cem:       inst.CustomerEnergyManagement(),
@@ -94,6 +98,10 @@ func NewEEBusOHPCF(ctx context.Context, embed *embed, ski, ip string, reboost ti
 		connector: eebus.NewConnector(),
 		ctx:       ctx,
 		reboost:   reboost,
+	}
+
+	if !disableMinMax {
+		implement.Has(c, implement.PowerLimiter(c.getMinMaxPower))
 	}
 
 	if err := inst.RegisterDevice(ski, ip, c); err != nil {
@@ -460,11 +468,9 @@ func (c *EEBusOHPCF) apply(enable bool) error {
 	return nil
 }
 
-var _ api.PowerLimiter = (*EEBusOHPCF)(nil)
-
-// GetMinMaxPower implements the api.PowerLimiter interface, reporting the
+// getMinMaxPower implements the api.PowerLimiter interface, reporting the
 // optional consumption as expected min/max or ErrNotAvailable if none.
-func (c *EEBusOHPCF) GetMinMaxPower() (float64, float64, error) {
+func (c *EEBusOHPCF) getMinMaxPower() (float64, float64, error) {
 	entity, ok := c.connectedCompressor()
 	if !ok {
 		return 0, 0, errNotConnected

--- a/cmd/implement/implement.go
+++ b/cmd/implement/implement.go
@@ -86,6 +86,7 @@ func generate(out io.Writer) error {
 		reflect.TypeFor[api.PhasePowers](),
 		reflect.TypeFor[api.PhaseSwitcher](),
 		reflect.TypeFor[api.PhaseVoltages](),
+		reflect.TypeFor[api.PowerLimiter](),
 		reflect.TypeFor[api.Resurrector](),
 		reflect.TypeFor[api.SocLimiter](),
 		reflect.TypeFor[api.StatusReasoner](),

--- a/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
+++ b/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
@@ -29,7 +29,7 @@ params:
     help:
       de: Wartezeit, nach der eine neu angekündigte optionale Leistungsaufnahme erneut eingeplant wird.
       en: Wait time after which a newly announced optional power consumption is scheduled again.
-  - name: disableminmax
+  - name: disablepowerlimiter
     type: bool
     default: false
     advanced: true
@@ -43,4 +43,4 @@ render: |
   type: eebus-ohpcf
   {{ include "eebus" . }}
   reboost: {{ .reboost }}
-  disableminmax: {{ .disableminmax }}
+  disablepowerlimiter: {{ .disablepowerlimiter }}

--- a/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
+++ b/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
@@ -29,7 +29,18 @@ params:
     help:
       de: Wartezeit, nach der eine neu angekündigte optionale Leistungsaufnahme erneut eingeplant wird.
       en: Wait time after which a newly announced optional power consumption is scheduled again.
+  - name: disableminmax
+    type: bool
+    default: false
+    advanced: true
+    description:
+      de: Leistungsgrenzen ignorieren
+      en: Ignore power limits
+    help:
+      de: Die vom Gerät gemeldete optionale Leistungsaufnahme nicht als Min-/Max-Leistung verwenden.
+      en: Do not use the device's announced optional power consumption as min/max power.
 render: |
   type: eebus-ohpcf
   {{ include "eebus" . }}
   reboost: {{ .reboost }}
+  disableminmax: {{ .disableminmax }}

--- a/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
+++ b/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
@@ -31,7 +31,6 @@ params:
       en: Wait time after which a newly announced optional power consumption is scheduled again.
   - name: disablepowerlimiter
     type: bool
-    default: false
     advanced: true
     description:
       de: Leistungsgrenzen ignorieren

--- a/templates/definition/charger/eebus-ohpcf.yaml
+++ b/templates/definition/charger/eebus-ohpcf.yaml
@@ -17,7 +17,7 @@ params:
     help:
       de: Wartezeit, nach der eine neu angekündigte optionale Leistungsaufnahme erneut eingeplant wird.
       en: Wait time after which a newly announced optional power consumption is scheduled again.
-  - name: disableminmax
+  - name: disablepowerlimiter
     type: bool
     default: false
     advanced: true
@@ -31,4 +31,4 @@ render: |
   type: eebus-ohpcf
   {{ include "eebus" . }}
   reboost: {{ .reboost }}
-  disableminmax: {{ .disableminmax }}
+  disablepowerlimiter: {{ .disablepowerlimiter }}

--- a/templates/definition/charger/eebus-ohpcf.yaml
+++ b/templates/definition/charger/eebus-ohpcf.yaml
@@ -19,7 +19,6 @@ params:
       en: Wait time after which a newly announced optional power consumption is scheduled again.
   - name: disablepowerlimiter
     type: bool
-    default: false
     advanced: true
     description:
       de: Leistungsgrenzen ignorieren

--- a/templates/definition/charger/eebus-ohpcf.yaml
+++ b/templates/definition/charger/eebus-ohpcf.yaml
@@ -17,7 +17,18 @@ params:
     help:
       de: Wartezeit, nach der eine neu angekündigte optionale Leistungsaufnahme erneut eingeplant wird.
       en: Wait time after which a newly announced optional power consumption is scheduled again.
+  - name: disableminmax
+    type: bool
+    default: false
+    advanced: true
+    description:
+      de: Leistungsgrenzen ignorieren
+      en: Ignore power limits
+    help:
+      de: Die vom Gerät gemeldete optionale Leistungsaufnahme nicht als Min-/Max-Leistung verwenden.
+      en: Do not use the device's announced optional power consumption as min/max power.
 render: |
   type: eebus-ohpcf
   {{ include "eebus" . }}
   reboost: {{ .reboost }}
+  disableminmax: {{ .disableminmax }}


### PR DESCRIPTION
Adds a `disablepowerlimiter` template option to the EEBus OHPCF heat pump charger. When set, the device's announced optional power consumption is no longer exposed as `api.PowerLimiter`, so the loadpoint keeps its configured min/max power.

To make this switchable per device, `GetMinMaxPower` moved from a static interface implementation to a capability registered via `implement.Has` (`api.PowerLimiter` added to the `implement` generator).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)