### PR TITLE
Loadpoint: disable PV mode when idle integrated device lacks surplus

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1657,9 +1657,9 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryPower f
 			// notes: activePhases can be 1, 2 or 3 and phaseTimer can only be active if lp current is already at minCurrent
 			projectedSitePower -= Voltage * minCurrent * float64(activePhases-1)
 		}
-		// an integrated device that is enabled but not consuming keeps its demand out
+		// a continuous device that is enabled but not consuming keeps its demand out
 		// of site power, hiding insufficient surplus until it starts (#32282)
-		if lp.chargerHasFeature(api.IntegratedDevice) && !lp.charging() {
+		if lp.chargerHasFeature(api.Continuous) && !lp.charging() {
 			projectedSitePower += currentToPower(minCurrent, lp.minActivePhases())
 		}
 		// kick off disable sequence, unless climater keep-alive is holding

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1657,6 +1657,11 @@ func (lp *Loadpoint) pvMaxCurrent(mode api.ChargeMode, sitePower, batteryPower f
 			// notes: activePhases can be 1, 2 or 3 and phaseTimer can only be active if lp current is already at minCurrent
 			projectedSitePower -= Voltage * minCurrent * float64(activePhases-1)
 		}
+		// an integrated device that is enabled but not consuming keeps its demand out
+		// of site power, hiding insufficient surplus until it starts (#32282)
+		if lp.chargerHasFeature(api.IntegratedDevice) && !lp.charging() {
+			projectedSitePower += currentToPower(minCurrent, lp.minActivePhases())
+		}
 		// kick off disable sequence, unless climater keep-alive is holding
 		// charging at minCurrent — otherwise the "pausing soon" badge would
 		// flash on/off forever while climater is active (issue #29834).

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -908,3 +908,62 @@ func TestNewLoadpointFromConfigDisabledVehicle(t *testing.T) {
 	// disabled vehicle is filtered from instances
 	require.Empty(t, config.Instances(config.Vehicles().Devices()))
 }
+
+// TestPVDisableIdleIntegratedDevice is a regression test for #32282: an integrated
+// device that is enabled but not consuming (heat pump boost signalled, compressor
+// idle) does not show its demand in site power. Without projecting it, the disable
+// gate only trips on grid consumption which the idle device never causes.
+func TestPVDisableIdleIntegratedDevice(t *testing.T) {
+	const dt = time.Minute
+
+	tc := []struct {
+		name        string
+		status      api.ChargeStatus
+		chargePower float64
+		site        float64
+		current     float64
+	}{
+		// idle device, export below its 600W demand: disable
+		{"idle, insufficient surplus", api.StatusB, 0, -400, 0},
+		// idle device, export covers its demand: keep enabled
+		{"idle, sufficient surplus", api.StatusB, 0, -700, 7},
+		// consuming device: measured power reflects demand, keep lenient hysteresis
+		{"consuming, exporting", api.StatusC, 300, -200, minA},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := clock.NewMock()
+
+			Voltage = 100
+			lp := &Loadpoint{
+				log:              util.NewLogger("foo"),
+				clock:            clock,
+				charger:          &integratedDeviceCharger{},
+				minCurrent:       minA,
+				maxCurrent:       maxA,
+				phases:           1,
+				phasesConfigured: 1,
+				measuredPhases:   1,
+				status:           tc.status,
+				enabled:          true,
+				chargePower:      tc.chargePower,
+				Disable:          loadpoint.ThresholdConfig{Delay: dt},
+			}
+
+			start := clock.Now()
+			for _, delay := range []time.Duration{0, dt + 1} {
+				clock.Set(start.Add(delay))
+				current := lp.pvMaxCurrent(api.ModePV, tc.site, 0, false, false)
+
+				// before the disable delay elapses the device keeps running
+				if delay == 0 {
+					assert.Equal(t, max(tc.current, minA), current, "before disable delay")
+					continue
+				}
+
+				assert.Equal(t, tc.current, current, "after disable delay")
+			}
+		})
+	}
+}

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -909,11 +909,11 @@ func TestNewLoadpointFromConfigDisabledVehicle(t *testing.T) {
 	require.Empty(t, config.Instances(config.Vehicles().Devices()))
 }
 
-// TestPVDisableIdleIntegratedDevice is a regression test for #32282: an integrated
+// TestPVDisableIdleContinuousDevice is a regression test for #32282: a continuous
 // device that is enabled but not consuming (heat pump boost signalled, compressor
 // idle) does not show its demand in site power. Without projecting it, the disable
 // gate only trips on grid consumption which the idle device never causes.
-func TestPVDisableIdleIntegratedDevice(t *testing.T) {
+func TestPVDisableIdleContinuousDevice(t *testing.T) {
 	const dt = time.Minute
 
 	tc := []struct {
@@ -939,7 +939,7 @@ func TestPVDisableIdleIntegratedDevice(t *testing.T) {
 			lp := &Loadpoint{
 				log:              util.NewLogger("foo"),
 				clock:            clock,
-				charger:          &integratedDeviceCharger{},
+				charger:          &continuousCharger{},
 				minCurrent:       minA,
 				maxCurrent:       maxA,
 				phases:           1,

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -464,6 +464,15 @@ func (c *integratedDeviceCharger) Features() []api.Feature {
 	return []api.Feature{api.IntegratedDevice}
 }
 
+// continuousCharger is a minimal charger advertising the Continuous feature.
+type continuousCharger struct {
+	integratedDeviceCharger
+}
+
+func (c *continuousCharger) Features() []api.Feature {
+	return []api.Feature{api.IntegratedDevice, api.Continuous}
+}
+
 // TestDisconnectIntegratedDeviceKeepsMode is a regression test for #30187:
 // switching an integrated-device loadpoint to "off" makes a switch socket report
 // StatusA (disconnect). The disconnect handler must NOT reset the mode to the


### PR DESCRIPTION
An integrated device (heat pump, SG-ready, heating rod) can be enabled while consuming nothing- OHPCF reports `StatusB` until the compressor actually runs. Its demand is then absent from site power, so `pvMaxCurrent` never reaches the disable threshold:

- enabling requires `targetCurrent >= minCurrent`, i.e. surplus covering the full device power
- disabling requires `projectedSitePower >= Disable.Threshold`, i.e. grid consumption

An idle device causes no grid consumption, so the enable signal stays high all afternoon even when surplus has long dropped below what the device needs. When the device finally has demand it starts, immediately draws from the grid and is disabled again after the disable delay- one wasted compressor start. Reported in https://github.com/evcc-io/evcc/issues/32282#issuecomment-5379898255.

For an EV this cannot happen because an enabled loadpoint actually draws `minCurrent`, so site power carries the deficit and the loop self-corrects.

Projecting the min power of an enabled but idle integrated device into the disable check makes the gate symmetric with the enable gate. Devices that are consuming are untouched, keeping the lenient hysteresis that avoids cycling on a too-high power estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)