### PR TITLE
Deye 3p hybrid: fix energy scaling for HV pre-1098 firmware

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -105,7 +105,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -118,7 +118,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   currents:
@@ -236,7 +236,7 @@ render: |
       {{- if eq .batterytype "hv" }}  
       scale: 10
       {{- end }}
-    {{- if .includegenport }}
+    {{- if eq .includegenport "true" }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -261,10 +261,10 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+      {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
       scale: 0.1
       {{- end }}
-    {{- if .includegenport }}
+    {{- if eq .includegenport "true" }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -274,7 +274,7 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+      {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
       scale: 0.1
       {{- end }}
     {{- end }}
@@ -347,7 +347,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -360,7 +360,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
+    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
     scale: 0.1
     {{- end }}
   soc:


### PR DESCRIPTION
fixes #33061

Bool template params are rendered as strings (`"true"`/`"false"`), so `{{ if .boolparam }}` and `{{ not .boolparam }}` are truthy for *both* values — a bool only evaluates false when the param was never set.

Consequences in `deye-hybrid-3p`:

- `not .firmware1098` never matched, so an HV inverter with `firmware1098` explicitly unchecked got no `scale: 0.1` on the energy registers — history/energy values 10x too high. LV was unaffected because the `eq .batterytype "lv"` clause (added in #31543) already covered it.
- `if .includegenport` matched even when the option was explicitly disabled, so the GEN port was always added to PV power and energy.

Both now use the string comparison the other templates use (`eq .x "true"` / `ne .x "true"`). Behavior is unchanged for LV, for HV with firmware 1098+, and for configs where the options were never touched.

Same pattern is still present in `vehicle-api`, `demo-battery`, `demo-meter`, `fronius-gen24`, `openems-modbus` and `messenger/homeassistant` — left out here, happy to fix separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)