### PR TITLE
Tariff: add Energy Price Forecast CO2 regions

### DIFF
--- a/templates/definition/tariff/energypriceforecast-co2.yaml
+++ b/templates/definition/tariff/energypriceforecast-co2.yaml
@@ -34,7 +34,7 @@ params:
         "NO2",
         "NO3",
         "NO4",
-        "NO5"
+        "NO5",
       ]
     required: true
   - name: horizon

--- a/templates/definition/tariff/energypriceforecast-co2.yaml
+++ b/templates/definition/tariff/energypriceforecast-co2.yaml
@@ -6,15 +6,36 @@ products:
 requirements:
   description:
     de: "5 Tage Prognose [energypriceforecast.eu](https://energypriceforecast.eu/de/evcc-strompreis-co2-prognose/)"
-    en: "5 days prognosis [energypriceforecast.eu](https://energypriceforecast.eu)"
+    en: "5 days prognosis [energypriceforecast.eu](https://energypriceforecast.eu/en/evcc-electricity-price-co2-forecast/)"
   evcc: ["skiptest"]
 group: co2
-countries: ["DE", "NL", "BE", "DK"]
+countries: ["DE", "NL", "BE", "DK", "FR", "AT", "CZ", "PL", "FI", "SE", "NO"]
 params:
   - name: region
     example: DE
     type: choice
-    choice: ["DE", "NL", "BE", "DK1", "DK2"]
+    choice:
+      [
+        "DE",
+        "NL",
+        "BE",
+        "DK1",
+        "DK2",
+        "FR",
+        "AT",
+        "CZ",
+        "PL",
+        "FI",
+        "SE1",
+        "SE2",
+        "SE3",
+        "SE4",
+        "NO1",
+        "NO2",
+        "NO3",
+        "NO4",
+        "NO5"
+      ]
     required: true
   - name: horizon
     default: 120


### PR DESCRIPTION
## Summary
- add France, Austria, Czechia, Poland, Finland, Sweden, and Norway to the Energy Price Forecast CO2 template
- expose the corresponding bidding zones, including SE1-SE4 and NO1-NO5
- link the English setup guide directly

Existing regions remain unchanged.

## Testing
- queried the production CO2 tariff endpoint for every listed region
- verified that every request returned a non-empty evcc-compatible response