### PR TITLE
Tariff: add Energy Price Forecast API key

### DIFF
--- a/templates/definition/tariff/energypriceforecast.yaml
+++ b/templates/definition/tariff/energypriceforecast.yaml
@@ -40,11 +40,6 @@ params:
   - name: currency
     choice: ["EUR", "DKK", "CZK", "PLN", "SEK", "NOK"]
   - name: apikey
-    type: string
-    mask: true
-    description:
-      en: API key (optional)
-      de: API-Key (optional)
     help:
       en: "Optional for forecasts up to 120 hours. [Get an API key](https://energypriceforecast.eu/en/api-early-access/)."
       de: "Optional für Prognosen bis zu 120 Stunden. [API-Key erhalten](https://energypriceforecast.eu/de/api-early-access/)."
@@ -52,9 +47,6 @@ params:
     default: 120
     type: int
     unit: h
-    description:
-      en: Requested forecast horizon
-      de: Angefragter Prognosehorizont
     help:
       en: Anonymous access is limited to 48 hours from October 1, 2026. An API key allows up to 120 hours.
       de: Anonymer Zugriff ist ab 1. Oktober 2026 auf 48 Stunden begrenzt. Mit API-Key sind bis zu 120 Stunden möglich.

--- a/templates/definition/tariff/energypriceforecast.yaml
+++ b/templates/definition/tariff/energypriceforecast.yaml
@@ -63,7 +63,7 @@ render: |
   forecast:
     source: http
     uri: https://api.energypriceforecast.eu/api/v1/evcc/tariff?country={{.region}}&type=grid&currency={{.currency}}&hours={{.horizon}}
-    {{- if .apikey }}
+    {{ if .apikey }}
     auth:
       type: bearer
       token: {{ .apikey }}

--- a/templates/definition/tariff/energypriceforecast.yaml
+++ b/templates/definition/tariff/energypriceforecast.yaml
@@ -47,6 +47,9 @@ params:
     default: 120
     type: int
     unit: h
+    description:
+      en: Forecast horizon
+      de: Prognosehorizont
     help:
       en: Anonymous access is limited to 48 hours from October 1, 2026. An API key allows up to 120 hours.
       de: Anonymer Zugriff ist ab 1. Oktober 2026 auf 48 Stunden begrenzt. Mit API-Key sind bis zu 120 Stunden möglich.

--- a/templates/definition/tariff/energypriceforecast.yaml
+++ b/templates/definition/tariff/energypriceforecast.yaml
@@ -69,6 +69,7 @@ render: |
     source: http
     uri: https://api.energypriceforecast.eu/api/v1/evcc/tariff?country={{.region}}&type=grid&currency={{.currency}}&hours={{.horizon}}
     {{- if .apikey }}
-    headers:
-      - Authorization: Bearer {{ .apikey }}
+    auth:
+      type: bearer
+      token: {{ .apikey }}
     {{- end }}

--- a/templates/definition/tariff/energypriceforecast.yaml
+++ b/templates/definition/tariff/energypriceforecast.yaml
@@ -6,7 +6,7 @@ products:
 requirements:
   description:
     de: "Day-Ahead-Strompreise plus 4 Tage Prognose [energypriceforecast.eu](https://energypriceforecast.eu/de/evcc-strompreis-co2-prognose/)"
-    en: "Spot prices in day-ahead market plus 4 days prognosis [energypriceforecast.eu](https://energypriceforecast.eu)"
+    en: "Day-ahead spot prices plus a 4-day forecast [energypriceforecast.eu](https://energypriceforecast.eu/en/evcc-electricity-price-co2-forecast/)"
   evcc: ["skiptest"]
 group: price
 countries: ["DE", "NL", "BE", "DK", "FR", "AT", "CZ", "PL", "FI", "SE", "NO"]
@@ -39,13 +39,25 @@ params:
     required: true
   - name: currency
     choice: ["EUR", "DKK", "CZK", "PLN", "SEK", "NOK"]
+  - name: apikey
+    type: string
+    mask: true
+    description:
+      en: API key (optional)
+      de: API-Key (optional)
+    help:
+      en: "Optional for forecasts up to 120 hours. [Get an API key](https://energypriceforecast.eu/en/api-early-access/)."
+      de: "Optional für Prognosen bis zu 120 Stunden. [API-Key erhalten](https://energypriceforecast.eu/de/api-early-access/)."
   - name: horizon
     default: 120
     type: int
     unit: h
     description:
-      en: Forecast horizon
-      de: Prognosehorizont
+      en: Requested forecast horizon
+      de: Angefragter Prognosehorizont
+    help:
+      en: Anonymous access is limited to 48 hours from October 1, 2026. An API key allows up to 120 hours.
+      de: Anonymer Zugriff ist ab 1. Oktober 2026 auf 48 Stunden begrenzt. Mit API-Key sind bis zu 120 Stunden möglich.
     required: true
   - preset: tariff-base
   - preset: tariff-features
@@ -56,3 +68,7 @@ render: |
   forecast:
     source: http
     uri: https://api.energypriceforecast.eu/api/v1/evcc/tariff?country={{.region}}&type=grid&currency={{.currency}}&hours={{.horizon}}
+    {{- if .apikey }}
+    headers:
+      - Authorization: Bearer {{ .apikey }}
+    {{- end }}


### PR DESCRIPTION
## Summary
- add an optional masked API key field to the Energy Price Forecast tariff template
- use evcc's native bearer authentication for authenticated requests
- document the 48-hour anonymous horizon from October 1, 2026 and the 120-hour API key horizon
- link directly to the English evcc setup guide

Existing anonymous configurations remain compatible because the authentication block is omitted when no key is configured.

## Testing
- verified that the production API expects the same Authorization: Bearer header rendered by evcc
- verified that anonymous requests remain unchanged when the API key field is empty
- rebased the change onto the merged regions and currencies template