### PR TITLE
Vaillant/OHPCF: add support for energy demand profile

### DIFF
--- a/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
+++ b/templates/definition/charger/eebus-ohpcf-wolfvaillant.yaml
@@ -43,3 +43,4 @@ render: |
   {{ include "eebus" . }}
   reboost: {{ .reboost }}
   disablepowerlimiter: {{ .disablepowerlimiter }}
+  {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/eebus-ohpcf.yaml
+++ b/templates/definition/charger/eebus-ohpcf.yaml
@@ -31,3 +31,4 @@ render: |
   {{ include "eebus" . }}
   reboost: {{ .reboost }}
   disablepowerlimiter: {{ .disablepowerlimiter }}
+  {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/vaillant-bulex.yaml
+++ b/templates/definition/charger/vaillant-bulex.yaml
@@ -39,3 +39,4 @@ render: |
   {{- end }}
   heatingzone: {{ .zone }}
   heatingsetpoint: {{ .setpoint }}
+  {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/vaillant-demirdokum.yaml
+++ b/templates/definition/charger/vaillant-demirdokum.yaml
@@ -39,3 +39,4 @@ render: |
   {{- end }}
   heatingzone: {{ .zone }}
   heatingsetpoint: {{ .setpoint }}
+  {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/vaillant-glow-worm.yaml
+++ b/templates/definition/charger/vaillant-glow-worm.yaml
@@ -39,3 +39,4 @@ render: |
   {{- end }}
   heatingzone: {{ .zone }}
   heatingsetpoint: {{ .setpoint }}
+  {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/vaillant-saunier-duval.yaml
+++ b/templates/definition/charger/vaillant-saunier-duval.yaml
@@ -62,3 +62,4 @@ render: |
   {{- end }}
   heatingzone: {{ .zone }}
   heatingsetpoint: {{ .setpoint }}
+  {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/vaillant.yaml
+++ b/templates/definition/charger/vaillant.yaml
@@ -109,3 +109,4 @@ render: |
   heatingsetpoint: {{ .setpoint }}
   reboost: {{ .reboost }}
   hysteresis: {{ .hysteresis }}
+  {{ include "heatpumpswitch" . }}


### PR DESCRIPTION
Follow-up to #28232 which will add `demandtemperature` to `heatpumpswitch`.

~I only added the include to the `eebus-ohpcf-wolfvaillant` template because I am not sure whether the `sensoNET` or general OHPCF templates may also support pure DHW heat pumps.~ So what if a template supports both, central heating and pure DHW heat pumps?

/cc @daniel309