### PR TITLE
OCPP: keep websocket alive between heartbeats

### DIFF
--- a/charger/ocpp/const.go
+++ b/charger/ocpp/const.go
@@ -5,12 +5,11 @@ import "time"
 var Timeout = time.Minute // default request / response timeout on protocol level
 
 const (
-	// HeartbeatInterval is the interval requested from the charge point in BootNotification
-	HeartbeatInterval = time.Minute
+	heartbeatInterval = time.Minute // heartbeat interval requested in BootNotification
 
-	// PingWait is the websocket inactivity timeout. Must exceed HeartbeatInterval,
-	// otherwise chargers that don't send websocket pings are disconnected while idle.
-	PingWait = 3 * HeartbeatInterval
+	// pingWait must exceed heartbeatInterval, otherwise chargers not sending
+	// websocket pings are disconnected while idle
+	pingWait = 3 * heartbeatInterval
 )
 
 // TriggerBootDelay defines how long to wait after WebSocket connect before

--- a/charger/ocpp/const.go
+++ b/charger/ocpp/const.go
@@ -4,6 +4,15 @@ import "time"
 
 var Timeout = time.Minute // default request / response timeout on protocol level
 
+const (
+	// HeartbeatInterval is the interval requested from the charge point in BootNotification
+	HeartbeatInterval = time.Minute
+
+	// PingWait is the websocket inactivity timeout. Must exceed HeartbeatInterval,
+	// otherwise chargers that don't send websocket pings are disconnected while idle.
+	PingWait = 3 * HeartbeatInterval
+)
+
 // TriggerBootDelay defines how long to wait after WebSocket connect before
 // proactively triggering a BootNotification. This allows the connection to
 // stabilize and gives the charger a chance to send a spontaneous BootNotification.

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -16,7 +16,7 @@ var (
 func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
 	res := &core.BootNotificationConfirmation{
 		CurrentTime: types.Now(),
-		Interval:    int(HeartbeatInterval.Seconds()),
+		Interval:    int(heartbeatInterval.Seconds()),
 		Status:      core.RegistrationStatusAccepted,
 	}
 

--- a/charger/ocpp/cp_core.go
+++ b/charger/ocpp/cp_core.go
@@ -16,7 +16,7 @@ var (
 func (cp *CP) OnBootNotification(request *core.BootNotificationRequest) (*core.BootNotificationConfirmation, error) {
 	res := &core.BootNotificationConfirmation{
 		CurrentTime: types.Now(),
-		Interval:    60,
+		Interval:    int(HeartbeatInterval.Seconds()),
 		Status:      core.RegistrationStatusAccepted,
 	}
 

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -28,6 +28,10 @@ func TestBootNotificationStoresResultAndConnects(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, core.RegistrationStatusAccepted, res.Status)
 
+	// requested heartbeat interval must stay below the websocket inactivity timeout,
+	// otherwise chargers not sending websocket pings are disconnected while idle
+	assert.Less(t, time.Duration(res.Interval)*time.Second, PingWait)
+
 	// should be connected after BootNotification
 	assert.True(t, cp.Connected(), "should be connected after BootNotification")
 	assert.Equal(t, bootReq, cp.BootNotificationResult, "should store boot result")

--- a/charger/ocpp/cp_core_test.go
+++ b/charger/ocpp/cp_core_test.go
@@ -28,9 +28,8 @@ func TestBootNotificationStoresResultAndConnects(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, core.RegistrationStatusAccepted, res.Status)
 
-	// requested heartbeat interval must stay below the websocket inactivity timeout,
-	// otherwise chargers not sending websocket pings are disconnected while idle
-	assert.Less(t, time.Duration(res.Interval)*time.Second, PingWait)
+	// heartbeat must stay below the websocket inactivity timeout
+	assert.Less(t, time.Duration(res.Interval)*time.Second, pingWait)
 
 	// should be connected after BootNotification
 	assert.True(t, cp.Connected(), "should be connected after BootNotification")

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -140,6 +140,10 @@ func NewServer(cfg Config, networkExternalUrl string) {
 	server := &interceptingServer{Server: ws.NewServer()}
 	server.SetCheckOriginHandler(func(r *http.Request) bool { return true })
 
+	timeouts := ws.NewServerTimeoutConfig()
+	timeouts.PingWait = PingWait
+	server.SetTimeoutConfig(timeouts)
+
 	dispatcher := ocppj.NewDefaultServerDispatcher(ocppj.NewFIFOQueueMap(0))
 
 	endpoint := ocppj.NewServer(server, dispatcher, nil, core.Profile, remotetrigger.Profile, smartcharging.Profile, security.Profile, firmware.Profile)

--- a/charger/ocpp/instance.go
+++ b/charger/ocpp/instance.go
@@ -141,7 +141,7 @@ func NewServer(cfg Config, networkExternalUrl string) {
 	server.SetCheckOriginHandler(func(r *http.Request) bool { return true })
 
 	timeouts := ws.NewServerTimeoutConfig()
-	timeouts.PingWait = PingWait
+	timeouts.PingWait = pingWait
 	server.SetTimeoutConfig(timeouts)
 
 	dispatcher := ocppj.NewDefaultServerDispatcher(ocppj.NewFIFOQueueMap(0))


### PR DESCRIPTION
fixes #32236

The websocket server used the ocpp-go default `PingWait` of 60s while `BootNotification` requests a 60s heartbeat interval. Every received frame resets the read deadline, so an idle charger that does not send websocket pings has to deliver its heartbeat within exactly one deadline period.

Trace from the issue (MENNEKES AMTRON 4You, idle, heartbeat and clock-aligned meter values both at 60s and landing in the same second):

```
disc 13:19:48  last message 13:18:48
disc 13:28:48  last message 13:27:48
disc 13:40:48  last message 13:39:48
disc 16:06:49  last message 16:05:49
```

All 17 disconnects in the trace occur exactly 60s after the last received message, i.e. the central system closes the connection, not the charger.

Heartbeat interval and websocket timeout are now derived from one constant, with `PingWait` at three heartbeats.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)