### PR TITLE
pvnode: resample against the preceding interval, not the following one

### DIFF
--- a/templates/definition/tariff/pvnode-v2.yaml
+++ b/templates/definition/tariff/pvnode-v2.yaml
@@ -51,15 +51,15 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
-      # values are the average power of the 15min interval ending at the timestamp.
+      # values are the average power of the 15min interval starting at the timestamp.
       # evcc expects the power at the timestamp, which is the mean of the intervals
-      # meeting there- the trailing interval is dropped as its successor is unknown.
+      # meeting there- the leading interval is dropped as its predecessor is unknown.
       [.values[] | {t: (.timestamp | fromdateiso8601), v: .pv_power}] as $s
-      | [ range(0; ($s|length)-1) |
+      | [ range(1; ($s|length)) |
           {
             start: ($s[.].t       | todateiso8601),
             end:   ($s[.].t + 900 | todateiso8601),
-            value: ((($s[.].v + $s[.+1].v) / 2) | round)
+            value: ((($s[.-1].v + $s[.].v) / 2) | round)
           }
         ] | tostring
   interval: {{ .interval }}

--- a/templates/definition/tariff/pvnode.yaml
+++ b/templates/definition/tariff/pvnode.yaml
@@ -54,15 +54,15 @@ render: |
       type: bearer
       token: {{ .apikey }}
     jq: |
-      # values are the average power of the 15min interval ending at the timestamp.
+      # values are the average power of the 15min interval starting at the timestamp.
       # evcc expects the power at the timestamp, which is the mean of the intervals
-      # meeting there- the trailing interval is dropped as its successor is unknown.
+      # meeting there- the leading interval is dropped as its predecessor is unknown.
       [.values[] | {t: (.dtm | sub(" "; "T") + "Z" | fromdateiso8601), v: .pv_watts}] as $s
-      | [ range(0; ($s|length)-1) |
+      | [ range(1; ($s|length)) |
           {
             start: ($s[.].t       | todateiso8601),
             end:   ($s[.].t + 900 | todateiso8601),
-            value: ((($s[.].v + $s[.+1].v) / 2) | round)
+            value: ((($s[.-1].v + $s[.].v) / 2) | round)
           }
         ] | tostring
   interval: {{ .interval }}


### PR DESCRIPTION
#32604 resampled the pvnode interval averages to power at the slot start on the premise that a value is *"the average power of the 15 minute interval ending at the timestamp"*. That premise is wrong — pvnode labels an interval by its **start**, so the resampling averages the wrong neighbour and shifts the whole forecast 15 minutes into the future.

Evidence:

- pvnode's official Home Assistant integration ([darwindaume/ha-pvnode](https://github.com/darwindaume/ha-pvnode), `custom_components/pvnode/forecast.py`) — `value_at` is documented as *"Value of `key` in the slot covering `when` (the latest slot at or before it)"*, and `energy_between` as *"Wh accumulated over `[start, end)` — power in W across a 15-minute grid"*, summing `power * SLOT_HOURS` for `start <= ts < end`.
- [pvnode docs, Home Assistant](https://pvnode.com/docs/en/v2/integrations/home-assistant): the *"Power forecast now"* sensor is *"forecast for the current 15-minute slot"*.
- [pvnode docs, data columns](https://pvnode.com/docs/en/guides/data-columns): *"Each value in the time series represents the average value over a 15-minute interval."*
- `api.pvnode.com/openapi.json`, `ForecastDaily.partial`: *"True when the day has fewer than 96 timesteps"* — 96 per calendar day is the `00:00…23:45` grid; an end-labelled day would run `00:15…24:00`.
- A live response with `past_days=0` starts at exactly `00:00` site-local, which an end label cannot produce.

So `V_k` is the mean over `[t_k, t_k+15min)`, i.e. the point value at `t_k + 7:30`. The old kernel `(V_k + V_{k+1})/2` estimates the point value at `t_k + 15:00` and labels it `t_k`.

The reasoning of #32604 otherwise holds — the timestamps are grid points, and the power at one is the mean of the two intervals meeting there. Only the direction changes:

```
p(t_k) = (V_{k-1} + V_k) / 2
```

Still a two-tap centred filter, still exact for a linear signal, still 900s grid-aligned so `SlotWrapper` passes the slots through. It now costs the *leading* interval, whose predecessor is unknown — midnight for a solar forecast, where the old kernel dropped the trailing one.

Energy behaviour is unchanged: on a `0,100,300,600,900,600,300,100,0` bell both kernels produce the same value sequence `50,200,450,750,750,450,200,50` and the same trapezoid total, one grid step apart. The difference is purely the 15 minute shift.

Affects `pvnode` (v1, `.dtm`/`.pv_watts`) and `pvnode-v2` (`.timestamp`/`.pv_power`).

@darwindaume you maintain the pvnode HA integration — can you confirm the interval labelling on the pvnode side? The API reference documents `pv_power` only as *"PV power output in W"* at a *"Single timestep"*, so both readings survive a literal read of the spec, and it would be good to have it stated once and for all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
