### PR TITLE
Tariff (solar): resample sub-slots along the source curve

### DIFF
--- a/core/solar_test.go
+++ b/core/solar_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/tariff"
 	"github.com/jinzhu/now"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -111,4 +113,40 @@ func TestSolarEnergyNoRates(t *testing.T) {
 	now := time.Now()
 	assert.Equal(t, 0.0, solarEnergy(api.Rates{}, now, now.Add(time.Hour)))
 	assert.Equal(t, 0.0, solarEnergy(nil, now, now.Add(time.Hour)))
+}
+
+type solarTariff struct {
+	rates api.Rates
+}
+
+func (t *solarTariff) Rates() (api.Rates, error) { return t.rates, nil }
+func (t *solarTariff) Type() api.TariffType      { return api.TariffTypeSolar }
+
+// TestSolarSlotSplitPreservesEnergy asserts that splitting hourly solar rates into
+// 15min slots leaves the integrated energy untouched- the wrapper resamples the
+// curve, it does not change it
+func TestSolarSlotSplitPreservesEnergy(t *testing.T) {
+	start := time.Now().Truncate(tariff.SlotDuration)
+
+	var rr api.Rates
+	for i, v := range []float64{0, 1000, 2500, 3000, 1500, 0} {
+		s := start.Add(time.Duration(i) * time.Hour)
+		rr = append(rr, api.Rate{Start: s, End: s.Add(time.Hour), Value: v})
+	}
+
+	w := &tariff.SlotWrapper{Tariff: &solarTariff{rates: rr}}
+	res, err := w.Rates()
+	require.NoError(t, err)
+	require.Len(t, res, 6*4)
+
+	to := rr[len(rr)-1].Start
+	assert.InDelta(t, solarEnergy(rr, start, to), solarEnergy(res, start, to), 1e-9)
+
+	// every sub-interval integrates identically, not just the total
+	for i := range res {
+		assert.InDelta(t,
+			solarEnergy(rr, start, res[i].Start),
+			solarEnergy(res, start, res[i].Start),
+			1e-9, "slot %d", i)
+	}
 }

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -13,7 +13,7 @@ type SlotWrapper struct {
 }
 
 // Rates converts arbitrary slot lengths (multiples of SlotDuration) to 15m slots.
-// Price sub-slots are constant, solar sub-slots interpolated around the slot center.
+// Price sub-slots are constant, solar sub-slots interpolated towards the next slot.
 func (t *SlotWrapper) Rates() (api.Rates, error) {
 	rates, err := t.Tariff.Rates()
 	if err != nil {
@@ -58,52 +58,20 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 	return res, nil
 }
 
-// shapeSolar interpolates solar sub-slots between the slot centers. The slot value
-// applies to the entire period, so sub-slots are centered and rescaled to it. Slot
-// edges meet the average of both neighbouring values, keeping the curve continuous.
+// shapeSolar samples the source curve at the sub-slot starts. A solar value is the
+// power at its Start (see core.solarEnergy), so splitting a slot must interpolate
+// towards the successor rather than redistribute the value across the sub-slots -
+// only then does the split leave the integrated energy untouched. The trailing slot
+// has no successor and stays flat.
 func shapeSolar(rates api.Rates, i int, vals []float64) {
-	if len(vals) < 2 {
-		return
-	}
-
 	cur := rates[i].Value
-	if cur <= 0 {
-		// empty slot stays empty, shaping a non-positive slot would flip signs when rescaling
-		return
-	}
 
-	prev, next := cur, cur
-	if i > 0 {
-		prev = rates[i-1].Value
-	}
+	next := cur
 	if i+1 < len(rates) {
 		next = rates[i+1].Value
 	}
 
-	var sum float64
 	for j := range vals {
-		// sub-slot midpoint relative to the slot midpoint, [-0.5,0.5)
-		f := (float64(j)+0.5)/float64(len(vals)) - 0.5
-
-		delta := next - cur
-		if f < 0 {
-			delta = cur - prev
-		}
-
-		vals[j] = max(cur+f*delta, 0)
-		sum += vals[j]
-	}
-
-	if sum <= 0 {
-		for j := range vals {
-			vals[j] = cur
-		}
-		return
-	}
-
-	// preserve the slot average
-	scale := cur * float64(len(vals)) / sum
-	for j := range vals {
-		vals[j] *= scale
+		vals[j] = cur + (next-cur)*float64(j)/float64(len(vals))
 	}
 }

--- a/tariff/slots.go
+++ b/tariff/slots.go
@@ -61,17 +61,29 @@ func (t *SlotWrapper) Rates() (api.Rates, error) {
 // shapeSolar samples the source curve at the sub-slot starts. A solar value is the
 // power at its Start (see core.solarEnergy), so splitting a slot must interpolate
 // towards the successor rather than redistribute the value across the sub-slots -
-// only then does the split leave the integrated energy untouched. The trailing slot
-// has no successor and stays flat.
+// only then does the split leave the integrated energy untouched. Interpolation runs
+// over the distance between the two starts, which is the slot length only for a gapless
+// series. The trailing slot has no successor and stays flat.
 func shapeSolar(rates api.Rates, i int, vals []float64) {
 	cur := rates[i].Value
 
-	next := cur
-	if i+1 < len(rates) {
-		next = rates[i+1].Value
+	for j := range vals {
+		vals[j] = cur
+	}
+
+	if i+1 >= len(rates) {
+		return
+	}
+
+	next := rates[i+1]
+	span := next.Start.Sub(rates[i].Start)
+	if span <= 0 {
+		return
 	}
 
 	for j := range vals {
-		vals[j] = cur + (next-cur)*float64(j)/float64(len(vals))
+		// beyond the successor's start the curve is the successor's business
+		d := min(time.Duration(j)*SlotDuration, span)
+		vals[j] = cur + (next.Value-cur)*float64(d)/float64(span)
 	}
 }

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -213,6 +213,29 @@ func TestSolarInterpolationInterior(t *testing.T) {
 	assertSourceValues(t, rr, res)
 }
 
+// TestSolarInterpolationGap verifies that the ramp spans the distance between the
+// two slot starts, not the slot length, when the series has a gap
+func TestSolarInterpolationGap(t *testing.T) {
+	now := time.Now().Truncate(SlotDuration)
+
+	// one hour, then a one hour gap before the successor
+	rr := api.Rates{
+		{Start: now, End: now.Add(time.Hour), Value: 0},
+		{Start: now.Add(2 * time.Hour), End: now.Add(3 * time.Hour), Value: 8},
+	}
+
+	w := &SlotWrapper{&testTariff{rates: rr, typ: api.TariffTypeSolar}}
+
+	res, err := w.Rates()
+	require.NoError(t, err)
+	require.Len(t, res, 8)
+
+	// ramp reaches the successor after two hours, not after one
+	for i, expected := range []float64{0, 1, 2, 3} {
+		assert.InDelta(t, expected, res[i].Value, 1e-9, "slot %d", i)
+	}
+}
+
 // TestSolarNegativeSlot verifies that a non-positive slot ramps like any other
 func TestSolarNegativeSlot(t *testing.T) {
 	now := time.Now().Truncate(SlotDuration)

--- a/tariff/slots_test.go
+++ b/tariff/slots_test.go
@@ -141,22 +141,18 @@ func TestDropOldRates(t *testing.T) {
 	require.Len(t, res, 0)
 }
 
-// assertSourceAverages verifies that the sub-slots preserve the average of their source slot
-func assertSourceAverages(t *testing.T, rr, res api.Rates) {
+// assertSourceValues verifies that each source slot start keeps its original value
+func assertSourceValues(t *testing.T, rr, res api.Rates) {
 	t.Helper()
 
 	n := len(res) / len(rr)
 	for i, r := range rr {
-		var sum float64
-		for _, sub := range res[i*n : (i+1)*n] {
-			sum += sub.Value
-		}
-		assert.InDelta(t, r.Value, sum/float64(n), 1e-9, "rate %d", i)
+		assert.InDelta(t, r.Value, res[i*n].Value, 1e-9, "rate %d", i)
 	}
 }
 
-// TestSolarInterpolation verifies that solar sub-slots follow the neighbouring
-// slots while preserving the average of the slot they originate from
+// TestSolarInterpolation verifies that solar sub-slots ramp towards the
+// following slot while keeping the source value at the source slot start
 func TestSolarInterpolation(t *testing.T) {
 	now := time.Now().Truncate(SlotDuration)
 
@@ -185,12 +181,12 @@ func TestSolarInterpolation(t *testing.T) {
 		assert.Equal(t, now.Add(time.Duration(i)*SlotDuration), r.Start, "slot %d", i)
 	}
 
-	// ramping up from the empty hour, flat towards the missing successor
-	for i, expected := range []float64{0, 0, 0, 0, 20.0 / 7, 4, 32.0 / 7, 32.0 / 7} {
+	// ramping up towards the next hour, flat towards the missing successor
+	for i, expected := range []float64{0, 1, 2, 3, 4, 4, 4, 4} {
 		assert.InDelta(t, expected, res[i].Value, 1e-9, "slot %d", i)
 	}
 
-	assertSourceAverages(t, api.Rates{r0, r1}, res)
+	assertSourceValues(t, api.Rates{r0, r1}, res)
 }
 
 // TestSolarInterpolationInterior verifies an interior slot with both neighbours differing
@@ -209,15 +205,15 @@ func TestSolarInterpolationInterior(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 12)
 
-	// interior slot ramps linearly between the neighbouring slot centers
-	for i, expected := range []float64{2.5, 3.5, 4.5, 5.5} {
+	// interior slot ramps linearly from its own value to the next one
+	for i, expected := range []float64{4, 5, 6, 7} {
 		assert.InDelta(t, expected, res[4+i].Value, 1e-9, "slot %d", i)
 	}
 
-	assertSourceAverages(t, rr, res)
+	assertSourceValues(t, rr, res)
 }
 
-// TestSolarNegativeSlot verifies that a non-positive slot is not shaped
+// TestSolarNegativeSlot verifies that a non-positive slot ramps like any other
 func TestSolarNegativeSlot(t *testing.T) {
 	now := time.Now().Truncate(SlotDuration)
 
@@ -232,7 +228,7 @@ func TestSolarNegativeSlot(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 8)
 
-	for i, r := range res[:4] {
-		assert.Equal(t, -1.0, r.Value, "slot %d", i)
+	for i, expected := range []float64{-1, 0.25, 1.5, 2.75} {
+		assert.InDelta(t, expected, res[i].Value, 1e-9, "slot %d", i)
 	}
 }


### PR DESCRIPTION
`SlotWrapper` splits source slots longer than 15min into 15min slots. Since #32116 the solar branch centres the sub-slots on the source slot and rescales them so their arithmetic mean equals the source value — it reads `Value` as the slot mean.

Nothing downstream reads it that way. `core.solarEnergy` treats a solar `Value` as the power sampled at `Start` and integrates trapezoidally between consecutive `Start`s, and it is the only path anything uses: the published timeseries and the today/tomorrow totals (`solarDetails`), the persisted forecast metric (`forecastSlotEnergy`) and the optimizer input (`solarRatesToEnergy`) all go through it.

So the split silently changes the curve it is supposed to resample. Hourly rates `0, 1000, 2500, 3000, 1500, 0` W, energy over the window from hour `h` to the end:

| from | source | after split |
|------|--------|-------------|
| h=0  | 8000 Wh | 8000 Wh |
| h=1  | 7500 Wh | 7927 Wh (+5.7%) |
| h=2  | 5750 Wh | 6745 Wh (+17.3%) |
| h=3  | 3000 Wh | 4117 Wh (+37.2%) |
| h=4  | 750 Wh | 1242 Wh (+65.6%) |

The full-day figure telescopes back to the correct value because a day starts and ends at zero, which is why the daily totals in the UI look right. Every partial window does not — and `solarDetails.Today` (`solarEnergy(solar, time.Now(), eod)`), the optimizer horizon and each individual 15min slot handed to the optimizer are all partial windows. Per-slot the error is a half-slot shift of the whole curve.

This restores the pre-#32116 direction — sample the source curve at the sub-slot starts — and states the property as a test in `core`, where both the wrapper and the integrator are visible: splitting must not change `solarEnergy` over *any* window, not just the day. Linear interpolation of a piecewise-linear curve is exactly that, so the assertion holds to floating point.

The `cur <= 0` and `sum <= 0` guards go with the rescaling that needed them: interpolating between two values cannot flip a sign or divide by anything.

### The sources with slots longer than 15min

Only these reach `shapeSolar`; open-meteo (`minutely_15`) and pvnode pass through unshaped.

**forecast.solar** (`resolution=60`) ships point samples, so interpolating between them is exactly right. Its docs claim `watts` is the *"average for the period ... from last timestamp to the timestamp in the key"*, but the response contradicts that — `watt_hours_period` is the trapezoid of `watts` between consecutive timestamps, to the watt-hour:

```
ts                   watts   whp   trapz(prev,cur)   watts*dt
2026-08-23T07:00:00Z  1041    726       726.0         1041.0
2026-08-23T08:00:00Z  2093   1567      1567.0         2093.0
2026-08-23T09:00:00Z  2533   2313      2313.0         2533.0
2026-08-23T12:00:00Z  2362   2505      2505.0         2362.0
```

`core.solarEnergy` computes exactly forecast.solar's own `watt_hours_period`. Mean-preserving shaping breaks that identity; linear interpolation preserves it.

**Solcast** (`tariff/solcast.go`) buckets the PT30M estimates by `BeginningOfHour(period_end)`, so the hourly value is the mean of the two half-hours meeting at the hour start — already a centred point sample, and again the shaping smears it.

**solarprognose** (`type=hourly`) and **api-akkudoktor-de** (`timecycle=hourly`) are not yet verified against their provider docs; that audit is separate from this change.

### On #32099

That report is a source delivering raw 30min period means (Solcast piped through Home Assistant — evcc's own Solcast integration never emits 30min slots). Its check is *"sum all slot values × 15min and compare with the raw forecast sum"*, which is a quantity evcc computes nowhere. #32116 preserves that sum and loses `solarEnergy`; this preserves `solarEnergy` and loses that sum.

For a genuine period-mean source `solarEnergy` is already off before any splitting — means `12500 @17:00`, `10750 @17:30`, `9000 @18:00` integrate to 10750 Wh over the hour where the true figure is 11625 Wh. `SlotWrapper` neither introduced that nor can fix it; normalising means to point samples belongs at the source, as pvnode (#33102) and `solcast.go` already do. That is #23184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
