### PR TITLE
Loadpoint: ignore charge interruption during phase switch

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -61,6 +61,9 @@ const (
 	chargerSwitchDuration = 60 * time.Second // allow out of sync during this timespan
 	phaseSwitchDuration   = 60 * time.Second // allow out of sync and do not measure phases during this timespan
 
+	// chargers may briefly interrupt charging while switching phases
+	phaseSwitchInterruptDuration = 2 * time.Minute
+
 	// battery boost states
 	boostDisabled = 0
 	boostStart    = 1
@@ -1230,6 +1233,14 @@ func (lp *Loadpoint) getStatusChanges() ([]api.ChargeStatus, error) {
 
 	// detect if charger status changed
 	prevStatus := lp.GetStatus()
+
+	// ignore charge interruption while switching phases. Status is left unchanged,
+	// hence a real interruption is detected once the timespan has elapsed.
+	if status == api.StatusB && prevStatus == api.StatusC && !lp.phaseSwitchInterruptCompleted() {
+		lp.log.DEBUG.Println("ignoring charge interruption during phase switch")
+		return nil, nil
+	}
+
 	if status != prevStatus {
 		res = []api.ChargeStatus{status}
 	}
@@ -2105,6 +2116,11 @@ func (lp *Loadpoint) chargerUpdateCompleted() bool {
 // phaseSwitchCompleted returns true if phase switch command should be already processed by the charger (so we can try to sync charger and loadpoint and are able to measure currents)
 func (lp *Loadpoint) phaseSwitchCompleted() bool {
 	return time.Since(lp.phasesSwitched) > phaseSwitchDuration
+}
+
+// phaseSwitchInterruptCompleted returns true if the charger cannot be expected to interrupt charging due to phase switching any more
+func (lp *Loadpoint) phaseSwitchInterruptCompleted() bool {
+	return lp.clock.Since(lp.phasesSwitched) > phaseSwitchInterruptDuration
 }
 
 // Update is the main control function. It reevaluates meters and charger state

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -61,9 +61,6 @@ const (
 	chargerSwitchDuration = 60 * time.Second // allow out of sync during this timespan
 	phaseSwitchDuration   = 60 * time.Second // allow out of sync and do not measure phases during this timespan
 
-	// chargers may briefly interrupt charging while switching phases
-	phaseSwitchInterruptDuration = 2 * time.Minute
-
 	// battery boost states
 	boostDisabled = 0
 	boostStart    = 1
@@ -1236,7 +1233,7 @@ func (lp *Loadpoint) getStatusChanges() ([]api.ChargeStatus, error) {
 
 	// ignore charge interruption while switching phases. Status is left unchanged,
 	// hence a real interruption is detected once the timespan has elapsed.
-	if status == api.StatusB && prevStatus == api.StatusC && !lp.phaseSwitchInterruptCompleted() {
+	if status == api.StatusB && prevStatus == api.StatusC && lp.clock.Since(lp.phasesSwitched) <= phaseSwitchDuration {
 		lp.log.DEBUG.Println("ignoring charge interruption during phase switch")
 		return nil, nil
 	}
@@ -2116,11 +2113,6 @@ func (lp *Loadpoint) chargerUpdateCompleted() bool {
 // phaseSwitchCompleted returns true if phase switch command should be already processed by the charger (so we can try to sync charger and loadpoint and are able to measure currents)
 func (lp *Loadpoint) phaseSwitchCompleted() bool {
 	return time.Since(lp.phasesSwitched) > phaseSwitchDuration
-}
-
-// phaseSwitchInterruptCompleted returns true if the charger cannot be expected to interrupt charging due to phase switching any more
-func (lp *Loadpoint) phaseSwitchInterruptCompleted() bool {
-	return lp.clock.Since(lp.phasesSwitched) > phaseSwitchInterruptDuration
 }
 
 // Update is the main control function. It reevaluates meters and charger state

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1233,7 +1233,7 @@ func (lp *Loadpoint) getStatusChanges() ([]api.ChargeStatus, error) {
 
 	// ignore charge interruption while switching phases. Status is left unchanged,
 	// hence a real interruption is detected once the timespan has elapsed.
-	if status == api.StatusB && prevStatus == api.StatusC && lp.clock.Since(lp.phasesSwitched) <= phaseSwitchDuration {
+	if status == api.StatusB && prevStatus == api.StatusC && !lp.phaseSwitchCompleted() {
 		lp.log.DEBUG.Println("ignoring charge interruption during phase switch")
 		return nil, nil
 	}

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1233,12 +1233,12 @@ func (lp *Loadpoint) getStatusChanges() ([]api.ChargeStatus, error) {
 
 	// ignore charge interruption while switching phases. Status is left unchanged,
 	// hence a real interruption is detected once the timespan has elapsed.
-	if status == api.StatusB && prevStatus == api.StatusC && !lp.phaseSwitchCompleted() {
-		lp.log.DEBUG.Println("ignoring charge interruption during phase switch")
-		return nil, nil
-	}
+	ignore := status == api.StatusB && prevStatus == api.StatusC && !lp.phaseSwitchCompleted()
 
-	if status != prevStatus {
+	switch {
+	case ignore:
+		lp.log.DEBUG.Println("ignoring charge interruption during phase switch")
+	case status != prevStatus:
 		res = []api.ChargeStatus{status}
 	}
 
@@ -1252,7 +1252,7 @@ func (lp *Loadpoint) getStatusChanges() ([]api.ChargeStatus, error) {
 		defer func() { lp.connectedDuration = d }()
 
 		// connection duration dropped without disconnect status, indicates intermediate disconnect
-		if status != api.StatusA && prevStatus != api.StatusA && d < lp.connectedDuration {
+		if !ignore && status != api.StatusA && prevStatus != api.StatusA && d < lp.connectedDuration {
 			lp.log.DEBUG.Printf("connection duration drop detected (%s -> %v)", lp.connectedDuration.Round(time.Second), d.Round(time.Second))
 			res = []api.ChargeStatus{api.StatusA, status}
 		}

--- a/core/loadpoint_status_test.go
+++ b/core/loadpoint_status_test.go
@@ -45,8 +45,8 @@ func TestPhaseSwitchInterruption(t *testing.T) {
 		since    time.Duration
 		expected []api.ChargeStatus
 	}{
-		{"during phase switch", phaseSwitchInterruptDuration - time.Second, nil},
-		{"after phase switch", phaseSwitchInterruptDuration + time.Second, []api.ChargeStatus{api.StatusB}},
+		{"during phase switch", phaseSwitchDuration - time.Second, nil},
+		{"after phase switch", phaseSwitchDuration + time.Second, []api.ChargeStatus{api.StatusB}},
 	}
 
 	for _, tc := range tc {

--- a/core/loadpoint_status_test.go
+++ b/core/loadpoint_status_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
@@ -54,25 +53,16 @@ func TestPhaseSwitchInterruption(t *testing.T) {
 		charger := api.NewMockCharger(ctrl)
 		charger.EXPECT().Status().Return(api.StatusB, nil)
 
-		clck := clock.NewMock()
-
 		lp := &Loadpoint{
-			log:     util.NewLogger("foo"),
-			clock:   clck,
-			charger: charger,
-			status:  api.StatusC,
+			log:            util.NewLogger("foo"),
+			charger:        charger,
+			status:         api.StatusC,
+			phasesSwitched: time.Now().Add(-tc.since),
 		}
-
-		lp.phasesSwitched = clck.Now()
-		clck.Add(tc.since)
 
 		res, err := lp.getStatusChanges()
 		require.NoError(t, err, tc.desc)
 		assert.Equal(t, tc.expected, res, tc.desc)
-
-		// status is left unchanged, interruption is detected once the timespan has elapsed
 		assert.Equal(t, api.StatusC, lp.GetStatus(), tc.desc)
-
-		ctrl.Finish()
 	}
 }

--- a/core/loadpoint_status_test.go
+++ b/core/loadpoint_status_test.go
@@ -40,29 +40,42 @@ func TestStatusEvents(t *testing.T) {
 // switch is ignored while a real interruption is still detected
 func TestPhaseSwitchInterruption(t *testing.T) {
 	tc := []struct {
-		desc     string
-		since    time.Duration
-		expected []api.ChargeStatus
+		desc       string
+		since      time.Duration
+		connection time.Duration
+		expected   []api.ChargeStatus
 	}{
-		{"during phase switch", phaseSwitchDuration - time.Second, nil},
-		{"after phase switch", phaseSwitchDuration + time.Second, []api.ChargeStatus{api.StatusB}},
+		// the connection duration drops on interruption, too, and must not surface as intermediate disconnect
+		{"during phase switch", phaseSwitchDuration - time.Second, time.Minute, nil},
+		{"after phase switch", phaseSwitchDuration + time.Second, 2 * time.Hour, []api.ChargeStatus{api.StatusB}},
 	}
 
 	for _, tc := range tc {
 		ctrl := gomock.NewController(t)
+
 		charger := api.NewMockCharger(ctrl)
 		charger.EXPECT().Status().Return(api.StatusB, nil)
 
+		timer := api.NewMockConnectionTimer(ctrl)
+		timer.EXPECT().ConnectionDuration().Return(tc.connection, nil)
+
 		lp := &Loadpoint{
-			log:            util.NewLogger("foo"),
-			charger:        charger,
-			status:         api.StatusC,
-			phasesSwitched: time.Now().Add(-tc.since),
+			log: util.NewLogger("foo"),
+			charger: struct {
+				*api.MockCharger
+				*api.MockConnectionTimer
+			}{charger, timer},
+			status:            api.StatusC,
+			phasesSwitched:    time.Now().Add(-tc.since),
+			connectedDuration: time.Hour,
 		}
 
 		res, err := lp.getStatusChanges()
 		require.NoError(t, err, tc.desc)
 		assert.Equal(t, tc.expected, res, tc.desc)
 		assert.Equal(t, api.StatusC, lp.GetStatus(), tc.desc)
+
+		// connection duration is tracked even while the interruption is ignored
+		assert.Equal(t, tc.connection, lp.connectedDuration, tc.desc)
 	}
 }

--- a/core/loadpoint_status_test.go
+++ b/core/loadpoint_status_test.go
@@ -2,9 +2,14 @@ package core
 
 import (
 	"testing"
+	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestStatusEvents(t *testing.T) {
@@ -29,5 +34,45 @@ func TestStatusEvents(t *testing.T) {
 	for _, tc := range tc {
 		ev := statusEvents(tc.from, tc.to)
 		assert.Equalf(t, tc.events, ev, "from %s to %s got: %v", tc.from, tc.to, ev)
+	}
+}
+
+// TestPhaseSwitchInterruption verifies that a charge interruption right after a phase
+// switch is ignored while a real interruption is still detected
+func TestPhaseSwitchInterruption(t *testing.T) {
+	tc := []struct {
+		desc     string
+		since    time.Duration
+		expected []api.ChargeStatus
+	}{
+		{"during phase switch", phaseSwitchInterruptDuration - time.Second, nil},
+		{"after phase switch", phaseSwitchInterruptDuration + time.Second, []api.ChargeStatus{api.StatusB}},
+	}
+
+	for _, tc := range tc {
+		ctrl := gomock.NewController(t)
+		charger := api.NewMockCharger(ctrl)
+		charger.EXPECT().Status().Return(api.StatusB, nil)
+
+		clck := clock.NewMock()
+
+		lp := &Loadpoint{
+			log:     util.NewLogger("foo"),
+			clock:   clck,
+			charger: charger,
+			status:  api.StatusC,
+		}
+
+		lp.phasesSwitched = clck.Now()
+		clck.Add(tc.since)
+
+		res, err := lp.getStatusChanges()
+		require.NoError(t, err, tc.desc)
+		assert.Equal(t, tc.expected, res, tc.desc)
+
+		// status is left unchanged, interruption is detected once the timespan has elapsed
+		assert.Equal(t, api.StatusC, lp.GetStatus(), tc.desc)
+
+		ctrl.Finish()
 	}
 }


### PR DESCRIPTION
fixes #33090

Chargers may briefly drop the vehicle while switching between 1p and 3p. evcc treats the resulting C to B status change as a real charge interruption and fires `stop`/`start` push events, splits the charging session and resets the PV timer, even though charging continues. `phaseAction` is no help for filtering these in notification templates: it is already back to `inactive` when the charger status change is picked up on a later poll cycle.

- ignore a C to B status change within `phaseSwitchDuration` after a phase switch, in the loadpoint so all chargers benefit
- status is left unchanged rather than consumed, so a genuine interruption is detected once the timespan has elapsed
- no more spurious start/stop notifications, session splits and PV timer resets per phase switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
