### PR TITLE
Shelly: no return energy register on gen1 relay and plug meters

### DIFF
--- a/meter/shelly/gen1.go
+++ b/meter/shelly/gen1.go
@@ -149,9 +149,11 @@ func (c *gen1) IsReversed() bool {
 	return false
 }
 
-// HasReturnEnergy reports whether the device measures energy in the return direction
+// HasReturnEnergy reports whether the device measures energy in the return direction.
+// Only the EM variants have a total_returned register, relay/plug meters don't.
 func (c *gen1) HasReturnEnergy() bool {
-	return true
+	res, err := c.status.Get()
+	return err == nil && c.channel >= len(res.Meters) && c.channel < len(res.EMeters)
 }
 
 // IsThreePhase reports whether the device is a three-phase energy meter.

--- a/meter/shelly/gen1_test.go
+++ b/meter/shelly/gen1_test.go
@@ -2,7 +2,10 @@ package shelly
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,5 +47,57 @@ func TestUnmarshalGen1Status(t *testing.T) {
 		g := &gen1{model: "SHEM"}
 		assert.Equal(t, 401472.9, g.energy(res.EMeters[0].Total))
 		assert.Equal(t, -620.34, res.EMeters[0].Power)
+	}
+}
+
+// gen1Server emulates a gen1 device serving the given /status response.
+func gen1Server(t *testing.T, model, status string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/shelly":
+			json.NewEncoder(w).Encode(map[string]any{"type": model})
+		case "/status":
+			w.Write([]byte(status))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+}
+
+// TestGen1ReturnEnergy asserts that only the EM variants report a return
+// register- a 1PM's production must not be booked in return direction (#33062).
+func TestGen1ReturnEnergy(t *testing.T) {
+	{
+		// Shelly 1PM: meters, no total_returned
+		srv := gen1Server(t, "SHSW-PM", `{"relays":[{"ison":true}],"meters":[{"power":198.0,"is_valid":true,"total":31510486}]}`)
+		defer srv.Close()
+
+		conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
+		require.NoError(t, err)
+
+		assert.False(t, conn.HasReturnEnergy(), "1PM has no return register")
+
+		total, err := conn.TotalEnergy()
+		require.NoError(t, err)
+		assert.InDelta(t, 525.17, total, 0.01)
+	}
+
+	{
+		// Shelly EM: emeters with total_returned
+		srv := gen1Server(t, "SHEM", `{"relays":[{"ison":true}],"emeters":[{"power":-620.34,"is_valid":true,"total":401472.9,"total_returned":653673.7}]}`)
+		defer srv.Close()
+
+		conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
+		require.NoError(t, err)
+
+		assert.True(t, conn.HasReturnEnergy())
+
+		ret, err := conn.ReturnEnergy()
+		require.NoError(t, err)
+		assert.InDelta(t, 653.67, ret, 0.01)
 	}
 }

--- a/meter/shelly/gen1_test.go
+++ b/meter/shelly/gen1_test.go
@@ -2,11 +2,10 @@ package shelly
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,54 +49,20 @@ func TestUnmarshalGen1Status(t *testing.T) {
 	}
 }
 
-// gen1Server emulates a gen1 device serving the given /status response.
-func gen1Server(t *testing.T, model, status string) *httptest.Server {
-	t.Helper()
-
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		switch r.URL.Path {
-		case "/shelly":
-			json.NewEncoder(w).Encode(map[string]any{"type": model})
-		case "/status":
-			w.Write([]byte(status))
-		default:
-			http.Error(w, "not found", http.StatusNotFound)
-		}
-	}))
-}
-
-// TestGen1ReturnEnergy asserts that only the EM variants report a return
-// register- a 1PM's production must not be booked in return direction (#33062).
-func TestGen1ReturnEnergy(t *testing.T) {
-	{
-		// Shelly 1PM: meters, no total_returned
-		srv := gen1Server(t, "SHSW-PM", `{"relays":[{"ison":true}],"meters":[{"power":198.0,"is_valid":true,"total":31510486}]}`)
-		defer srv.Close()
-
-		conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
-		require.NoError(t, err)
-
-		assert.False(t, conn.HasReturnEnergy(), "1PM has no return register")
-
-		total, err := conn.TotalEnergy()
-		require.NoError(t, err)
-		assert.InDelta(t, 525.17, total, 0.01)
+// TestGen1HasReturnEnergy asserts that only the EM variants report a return
+// register - a 1PM's production must not be booked in return direction (#33062).
+func TestGen1HasReturnEnergy(t *testing.T) {
+	status := func(s string) util.Cacheable[Gen1Status] {
+		var res Gen1Status
+		require.NoError(t, json.Unmarshal([]byte(s), &res))
+		return util.ResettableCached(func() (Gen1Status, error) { return res, nil }, time.Minute)
 	}
 
-	{
-		// Shelly EM: emeters with total_returned
-		srv := gen1Server(t, "SHEM", `{"relays":[{"ison":true}],"emeters":[{"power":-620.34,"is_valid":true,"total":401472.9,"total_returned":653673.7}]}`)
-		defer srv.Close()
+	// Shelly 1PM: meters without total_returned
+	g := &gen1{status: status(`{"meters":[{"power":198.0,"total":31510486}]}`)}
+	assert.False(t, g.HasReturnEnergy(), "1PM has no return register")
 
-		conn, err := NewConnection(srv.URL, "", "", 0, time.Second)
-		require.NoError(t, err)
-
-		assert.True(t, conn.HasReturnEnergy())
-
-		ret, err := conn.ReturnEnergy()
-		require.NoError(t, err)
-		assert.InDelta(t, 653.67, ret, 0.01)
-	}
+	// Shelly EM: emeters with total_returned
+	g = &gen1{status: status(`{"emeters":[{"power":-620.34,"total":401472.9,"total_returned":653673.7}]}`)}
+	assert.True(t, g.HasReturnEnergy())
 }


### PR DESCRIPTION
fixes #33062

Gen1 `HasReturnEnergy()` returned `true` unconditionally, but only the EM variants have a `total_returned` register — relay/plug meters (`meters[]`) do not.

For `usage: pv`, `meter/shelly.go` swaps the two registers, so a Shelly 1PM ended up with the always-zero `total_returned` as its energy register and its real production as return energy. Reported device: `total: 31510486` Wmin = 525.2 kWh, shown in the config UI as `Energie 0,0 kWh` / `Energie (rückwärts) 525,7 kWh`.

Downstream, the metrics collector books that production into `return_energy`, and the history view's PV total nets both directions — the reported PV total was short by exactly the balcony plant's production (18.8 − 4.8 = 14.0 kWh). The same series is drawn as negative bars, which the PV chart clips, which is why only one of the two greens was visible.

`HasReturnEnergy()` now resolves against the parsed status, mirroring the `Meters`-before-`EMeters` order already used by `TotalEnergy`/`ReturnEnergy`, and matching the gen2 plug handling from #32213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
