### PR TITLE
Provider auth: require authenticated session for OAuth login/logout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -484,7 +484,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	authObject := auth.New()
 
 	// allow web access for vehicles
-	configureAuth(httpd.Router(), authObject, valueChan)
+	configureAuth(httpd.Router(), server.EnsureAuthHandler(authObject), valueChan)
 
 	if ok, _ := cmd.Flags().GetBool(flagDisableAuth); ok {
 		log.WARN.Println("❗❗❗ Authentication is disabled. This is dangerous. Your data and credentials are not protected.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -481,10 +481,11 @@ func runRoot(cmd *cobra.Command, args []string) {
 		once.Do(func() { close(stopC) }) // signal loop to end
 	}()
 
-	// allow web access for vehicles
-	configureAuth(httpd.Router(), valueChan)
-
 	authObject := auth.New()
+
+	// allow web access for vehicles
+	configureAuth(httpd.Router(), authObject, valueChan)
+
 	if ok, _ := cmd.Flags().GetBool(flagDisableAuth); ok {
 		log.WARN.Println("❗❗❗ Authentication is disabled. This is dangerous. Your data and credentials are not protected.")
 		authObject.SetAuthMode(auth.Disabled)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -42,7 +42,6 @@ import (
 	"github.com/evcc-io/evcc/server/providerauth"
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/auth"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/locale"
 	"github.com/evcc-io/evcc/util/machine"
@@ -1545,7 +1544,7 @@ func configureLoadpoints(conf globalconfig.All) error {
 }
 
 // configureAuth handles routing for devices. For now only api.AuthProvider related routes
-func configureAuth(router *mux.Router, authObject auth.Auth, paramC chan<- util.Param) {
+func configureAuth(router *mux.Router, authMiddleware mux.MiddlewareFunc, paramC chan<- util.Param) {
 	auth := router.PathPrefix("/providerauth").Subrouter()
 	auth.Use(handlers.CompressHandler)
 	auth.Use(handlers.CORS(
@@ -1556,7 +1555,7 @@ func configureAuth(router *mux.Router, authObject auth.Auth, paramC chan<- util.
 	router.PathPrefix("/oauth").Handler(auth)
 
 	// wire the handler; login/logout require an authenticated session
-	providerauth.Setup(auth, paramC, server.EnsureAuthHandler(authObject))
+	providerauth.Setup(auth, paramC, authMiddleware)
 }
 
 // isExperimental returns if experimental features are enabled

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -42,6 +42,7 @@ import (
 	"github.com/evcc-io/evcc/server/providerauth"
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/auth"
 	"github.com/evcc-io/evcc/util/config"
 	"github.com/evcc-io/evcc/util/locale"
 	"github.com/evcc-io/evcc/util/machine"
@@ -1544,7 +1545,7 @@ func configureLoadpoints(conf globalconfig.All) error {
 }
 
 // configureAuth handles routing for devices. For now only api.AuthProvider related routes
-func configureAuth(router *mux.Router, paramC chan<- util.Param) {
+func configureAuth(router *mux.Router, authObject auth.Auth, paramC chan<- util.Param) {
 	auth := router.PathPrefix("/providerauth").Subrouter()
 	auth.Use(handlers.CompressHandler)
 	auth.Use(handlers.CORS(
@@ -1554,8 +1555,8 @@ func configureAuth(router *mux.Router, paramC chan<- util.Param) {
 	// backwards-compatible revert of https://github.com/evcc-io/evcc/pull/21266
 	router.PathPrefix("/oauth").Handler(auth)
 
-	// wire the handler
-	providerauth.Setup(auth, paramC)
+	// wire the handler; login/logout require an authenticated session
+	providerauth.Setup(auth, paramC, server.EnsureAuthHandler(authObject))
 }
 
 // isExperimental returns if experimental features are enabled

--- a/server/http.go
+++ b/server/http.go
@@ -320,14 +320,14 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *uti
 		}
 
 		// API key endpoints require an authenticated session.
-		ensureAuth := ensureAuthHandler(auth)
+		ensureAuth := EnsureAuthHandler(auth)
 		api.Methods("GET").Path("/apikey").Handler(ensureAuth(apiKeyStatusHandler(auth)))
 		api.Methods("POST").Path("/apikey").Handler(ensureAuth(regenerateApiKeyHandler(auth)))
 	}
 
 	{ // api/config
 		api := api.PathPrefix("/config").Subrouter()
-		api.Use(ensureAuthHandler(auth))
+		api.Use(EnsureAuthHandler(auth))
 
 		routes := map[string]route{
 			"auth":               {"POST", "/auth", authHandler},
@@ -423,7 +423,7 @@ func (s *HTTPd) RegisterSystemHandler(site *core.Site, pub publisher, cache *uti
 
 	{ // api/system
 		api := api.PathPrefix("/system").Subrouter()
-		api.Use(ensureAuthHandler(auth))
+		api.Use(EnsureAuthHandler(auth))
 
 		routes := map[string]route{
 			"log":        {"GET", "/log", logHandler},

--- a/server/http_auth.go
+++ b/server/http_auth.go
@@ -186,12 +186,8 @@ func logoutHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// EnsureAuthHandler exposes the auth middleware for routers wired outside this package.
+// EnsureAuthHandler returns middleware that rejects unauthenticated requests
 func EnsureAuthHandler(authObject auth.Auth) mux.MiddlewareFunc {
-	return ensureAuthHandler(authObject)
-}
-
-func ensureAuthHandler(authObject auth.Auth) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if next == nil {

--- a/server/http_auth.go
+++ b/server/http_auth.go
@@ -186,6 +186,11 @@ func logoutHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// EnsureAuthHandler exposes the auth middleware for routers wired outside this package.
+func EnsureAuthHandler(authObject auth.Auth) mux.MiddlewareFunc {
+	return ensureAuthHandler(authObject)
+}
+
 func ensureAuthHandler(authObject auth.Auth) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/http_auth_test.go
+++ b/server/http_auth_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/util/auth"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,37 +76,14 @@ func TestRequireCriticalConfig(t *testing.T) {
 	}
 }
 
-// TestEnsureAuthHandler guards the gating configureAuth applies to the
-// /providerauth (+ /oauth) routes: unauthenticated requests are rejected while
-// auth.Disabled passes through.
 func TestEnsureAuthHandler(t *testing.T) {
-	newServer := func(a auth.Auth) *httptest.Server {
-		router := mux.NewRouter()
-		sub := router.PathPrefix("/providerauth").Subrouter()
-		sub.Use(EnsureAuthHandler(a))
-		sub.Methods(http.MethodGet).Path("/login").HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
-		return httptest.NewServer(router)
+	get := func(a auth.Auth) int {
+		next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		rec := httptest.NewRecorder()
+		EnsureAuthHandler(a)(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/login", nil))
+		return rec.Code
 	}
 
-	t.Run("enabled rejects without credentials", func(t *testing.T) {
-		srv := newServer(fakeAuth{mode: auth.Enabled})
-		defer srv.Close()
-
-		resp, err := http.Get(srv.URL + "/providerauth/login")
-		assert.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-	})
-
-	t.Run("disabled passes through", func(t *testing.T) {
-		srv := newServer(fakeAuth{mode: auth.Disabled})
-		defer srv.Close()
-
-		resp, err := http.Get(srv.URL + "/providerauth/login")
-		assert.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
+	assert.Equal(t, http.StatusUnauthorized, get(fakeAuth{mode: auth.Enabled}), "enabled must reject without credentials")
+	assert.Equal(t, http.StatusOK, get(fakeAuth{mode: auth.Disabled}), "disabled must pass through")
 }

--- a/server/http_auth_test.go
+++ b/server/http_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/util/auth"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,4 +75,39 @@ func TestRequireCriticalConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEnsureAuthHandler guards the gating configureAuth applies to the
+// /providerauth (+ /oauth) routes: unauthenticated requests are rejected while
+// auth.Disabled passes through.
+func TestEnsureAuthHandler(t *testing.T) {
+	newServer := func(a auth.Auth) *httptest.Server {
+		router := mux.NewRouter()
+		sub := router.PathPrefix("/providerauth").Subrouter()
+		sub.Use(EnsureAuthHandler(a))
+		sub.Methods(http.MethodGet).Path("/login").HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		return httptest.NewServer(router)
+	}
+
+	t.Run("enabled rejects without credentials", func(t *testing.T) {
+		srv := newServer(fakeAuth{mode: auth.Enabled})
+		defer srv.Close()
+
+		resp, err := http.Get(srv.URL + "/providerauth/login")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("disabled passes through", func(t *testing.T) {
+		srv := newServer(fakeAuth{mode: auth.Disabled})
+		defer srv.Close()
+
+		resp, err := http.Get(srv.URL + "/providerauth/login")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
 }

--- a/server/providerauth/providerauth.go
+++ b/server/providerauth/providerauth.go
@@ -33,8 +33,8 @@ func init() {
 }
 
 // Setup connects the redirect handler to the router and registers the callback channel.
-// authMiddleware gates login/logout; callback stays open because the IdP redirects to
-// it cross-site without a SameSite=Strict session cookie — it is gated by its state token.
+// Login/logout are gated by authMiddleware. Callback stays open: the cross-site IdP
+// redirect carries no SameSite=Strict cookie, the state token protects it instead.
 func Setup(router *mux.Router, paramC chan<- util.Param, authMiddleware mux.MiddlewareFunc) {
 	gate := func(h http.HandlerFunc) http.Handler { return authMiddleware(h) }
 

--- a/server/providerauth/providerauth.go
+++ b/server/providerauth/providerauth.go
@@ -33,8 +33,7 @@ func init() {
 }
 
 // Setup connects the redirect handler to the router and registers the callback channel.
-// Login/logout are gated by authMiddleware. Callback stays open: the cross-site IdP
-// redirect carries no SameSite=Strict cookie, the state token protects it instead.
+// Callback stays open: the cross-site IdP redirect carries no session cookie, the state token gates it.
 func Setup(router *mux.Router, paramC chan<- util.Param, authMiddleware mux.MiddlewareFunc) {
 	gate := func(h http.HandlerFunc) http.Handler { return authMiddleware(h) }
 

--- a/server/providerauth/providerauth.go
+++ b/server/providerauth/providerauth.go
@@ -32,14 +32,15 @@ func init() {
 	}
 }
 
-// Setup connects the redirect handler to the router and registers the callback channel
-func Setup(router *mux.Router, paramC chan<- util.Param) {
-	// callback?code=...&state=...
+// Setup connects the redirect handler to the router and registers the callback channel.
+// authMiddleware gates login/logout; callback stays open because the IdP redirects to
+// it cross-site without a SameSite=Strict session cookie — it is gated by its state token.
+func Setup(router *mux.Router, paramC chan<- util.Param, authMiddleware mux.MiddlewareFunc) {
+	gate := func(h http.HandlerFunc) http.Handler { return authMiddleware(h) }
+
 	router.Methods(http.MethodGet).Path("/callback").HandlerFunc(instance.handleCallback)
-	// login?id=...
-	router.Methods(http.MethodGet).Path("/login").HandlerFunc(instance.handleLogin)
-	// logout?id=...
-	router.Methods(http.MethodGet).Path("/logout").HandlerFunc(instance.handleLogout)
+	router.Methods(http.MethodGet).Path("/login").Handler(gate(instance.handleLogin))
+	router.Methods(http.MethodGet).Path("/logout").Handler(gate(instance.handleLogout))
 
 	go instance.run(paramC)
 }

--- a/server/providerauth/providerauth_test.go
+++ b/server/providerauth/providerauth_test.go
@@ -10,34 +10,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// blockAll is a stand-in auth middleware that rejects every request.
+// stand-in auth middleware rejecting every request
 func blockAll(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 	})
 }
 
-// TestSetupGating pins the wiring: login/logout are gated, callback stays open
-// (302 to the error page on the invalid state, not a middleware 401).
+// login/logout are gated, callback stays open (302 to error page, not middleware 401)
 func TestSetupGating(t *testing.T) {
 	router := mux.NewRouter()
-	paramC := make(chan util.Param, 1)
-	Setup(router, paramC, blockAll)
-
-	srv := httptest.NewServer(router)
-	defer srv.Close()
-
-	client := &http.Client{
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	Setup(router, make(chan util.Param, 1), blockAll)
 
 	get := func(path string) int {
-		resp, err := client.Get(srv.URL + path)
-		assert.NoError(t, err)
-		defer resp.Body.Close()
-		return resp.StatusCode
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		return rec.Code
 	}
 
 	assert.Equal(t, http.StatusUnauthorized, get("/login?id=x"), "login must be gated")

--- a/server/providerauth/providerauth_test.go
+++ b/server/providerauth/providerauth_test.go
@@ -1,0 +1,46 @@
+package providerauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// blockAll is a stand-in auth middleware that rejects every request.
+func blockAll(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	})
+}
+
+// TestSetupGating pins the wiring: login/logout are gated, callback stays open
+// (302 to the error page on the invalid state, not a middleware 401).
+func TestSetupGating(t *testing.T) {
+	router := mux.NewRouter()
+	paramC := make(chan util.Param, 1)
+	Setup(router, paramC, blockAll)
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	get := func(path string) int {
+		resp, err := client.Get(srv.URL + path)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusUnauthorized, get("/login?id=x"), "login must be gated")
+	assert.Equal(t, http.StatusUnauthorized, get("/logout?id=x"), "logout must be gated")
+	assert.Equal(t, http.StatusFound, get("/callback"), "callback must stay open (gated by state token, not session)")
+}


### PR DESCRIPTION
### Description
The `/providerauth/login` and `/providerauth/logout` routes (aliased under
`/oauth`) were wired without any authentication middleware. 
Any unauthenticated client could reach them and drive the provider OAuth flow —
initiating logins and forcing logouts for configured vehicle/energy providers.

This PR gates those routes behind the existing session auth middleware, so only
authenticated users can trigger provider login/logout.

### Impact
An unauthenticated attacker could send requests directly to these endpoints to
disrupt a user's connection to configured vehicle/energy providers (forced
logout) or initiate the provider OAuth flow (forced login) without holding a
valid session. No credentials or provider tokens were directly exposed, but the
missing authorization check allowed state-changing actions to be triggered by
unauthorized clients.

### Fix
- Expose the auth middleware via `server.EnsureAuthHandler` so routers wired
  outside the `server` package can reuse it.
- Pass the `auth.Auth` instance into `configureAuth` and thread it through to
  `providerauth.Setup` as an `authMiddleware` argument.
- Gate `/login` and `/logout` with the auth middleware in `providerauth.Setup`.
- Construct the `auth.Auth` object before `configureAuth` in `runRoot` (moved up
  a few lines) so it is available when wiring the routes.

### Callback stays open (by design)
`/callback` remains unauthenticated. The IdP redirects to it cross-site, and the
session cookie is `SameSite=Strict`, so it would not be sent on that redirect.
The callback is instead protected by its per-request `state` token, which is the
standard CSRF protection for the OAuth redirect leg. Gating it behind session
auth would break the flow rather than secure it.

### Tests
- `server/http_auth_test.go`: verifies `EnsureAuthHandler` rejects unauthenticated
  requests and passes authenticated ones.
- `server/providerauth/providerauth_test.go`: verifies login/logout are gated by
  the middleware while callback stays reachable.