### PR TITLE
EEBus: log use case events as Evnt: <ski> <event>

### DIFF
--- a/server/eebus/eebus.go
+++ b/server/eebus/eebus.go
@@ -536,7 +536,7 @@ func (c *EEBus) ucCallback(ski string, device spineapi.DeviceRemoteInterface, en
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	c.log.DEBUG.Printf("ski %s event %s", ski, event)
+	c.log.DEBUG.Printf("Evnt: %s %s", ski, event)
 
 	for _, client := range c.clientsFor(ski) {
 		client.UseCaseEvent(device, entity, event)


### PR DESCRIPTION
EEBus use case events were logged as `ski <ski> event <event>`, which reads differently from the surrounding ship-go trace lines (`Send: <ski> ...`, `Recv: <ski> ...`). Log them as `Evnt: <ski> <event>` so a trace log lines up per ski:

```
[eebus ] TRACE Recv: f4872ae3... {"data":[...]}
[eebus ] DEBUG Evnt: f4872ae3... cem-ohpcf-DataUpdateConsumptionState
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
