### PR TITLE
OneKey: make mqtt timeout configurable, default 90s

### DIFF
--- a/templates/definition/charger/onekey.yaml
+++ b/templates/definition/charger/onekey.yaml
@@ -22,6 +22,11 @@ requirements:
       broker is `localhost`.
 params:
   - preset: mqtt
+  - name: timeout
+    default: 90s
+    help:
+      de: Ab wann ein Messwert als veraltet gilt — Standard 90 s, das Dreifache des 30-s-Herzschlags des Geräts
+      en: When a reading counts as stale — default 90 s, three times the device's 30 s heartbeat
   - name: topic
     default: onekey
     description:
@@ -43,24 +48,19 @@ render: |
     source: mqtt
     {{- include "mqtt" . | indent 2 }}
     topic: {{ .topic }}/wp/sgmode
-    timeout: 90s
   power:
     source: mqtt
     {{- include "mqtt" . | indent 2 }}
     topic: {{ .topic }}/wp/power
-    timeout: 90s
   energy:
     source: mqtt
     {{- include "mqtt" . | indent 2 }}
     topic: {{ .topic }}/wp/energy
-    timeout: 90s
   temp:
     source: mqtt
     {{- include "mqtt" . | indent 2 }}
     topic: {{ .topic }}/wp/temp
-    timeout: 90s
   limittemp:
     source: mqtt
     {{- include "mqtt" . | indent 2 }}
     topic: {{ .topic }}/wp/limittemp
-    timeout: 90s


### PR DESCRIPTION
The template writes `timeout: 90s` into each read plugin, after the `mqtt` preset include. That only works while the include suppresses its own `timeout` line when the value equals the preset default of `30s`.

#33084 makes the include always render the timeout. Both lines then land in the same mapping and yaml.v3 rejects the duplicate key — `TestTemplates/onekey` is the test currently failing on that PR:

```
yaml: construct errors: line 19: mapping key "timeout" already defined at line 17; line 25: ... line 31: ... line 37: ... line 43: ...
```

Overriding the preset parameter instead of writing the value into the render block keeps a single `timeout` key, and makes the value visible and editable instead of hardcoded.

The default stays `90s`: the device publishes on change and at least every 30s, so three heartbeats detect a stale value without a false alarm on a single missed update.

This is behaviour-neutral on master — the read plugins received 90s before and receive 90s now — so it stands on its own, and it clears the way for #33084.

One visible side effect: the two write plugins (`setmode`, `setmaxpower`) now carry the timeout as well, where previously they carried none. It is inert for a setter, and the same already happened for anyone configuring a non-default timeout.

**Testing**

- `go test ./charger/ -run 'TestTemplates/onekey'` passes on `master` and with #33084's one-line change applied locally
- rendered output carries `timeout: 90s` exactly once per plugin, and the resolved parameter value is `90s` (not the preset default), confirming the override takes effect
- `go test ./util/templates/` passes