### PR TITLE
Soc: extrapolate from charged energy when vehicle api is unavailable

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -2027,13 +2027,15 @@ func (lp *Loadpoint) publishSocAndRange() {
 		}
 	}
 
-	if socR != nil {
-		if socEstimator == nil {
-			lp.vehicleSoc = *socR
-		} else {
-			lp.vehicleSoc = socEstimator.Soc(socR, lp.GetChargedEnergy())
+	if socEstimator != nil {
+		// nil soc extrapolates from charged energy while vehicle api is unavailable;
+		// don't overwrite a known soc while a freshly created estimator returns 0
+		if soc := socEstimator.Soc(socR, lp.GetChargedEnergy()); socR != nil || soc > 0 {
+			lp.vehicleSoc = soc
 			lp.log.DEBUG.Printf("vehicle soc (estimator): %.0f%%", lp.vehicleSoc)
 		}
+	} else if socR != nil {
+		lp.vehicleSoc = *socR
 	}
 	lp.publish(keys.VehicleSoc, lp.vehicleSoc)
 

--- a/core/loadpoint_vehicle.go
+++ b/core/loadpoint_vehicle.go
@@ -166,6 +166,9 @@ func (lp *Loadpoint) setActiveVehicle(v api.Vehicle) {
 		// resolve optional config
 		if v.Capacity() > 0 && (lp.Soc.Estimate == nil || *lp.Soc.Estimate) {
 			lp.socEstimator = soc.NewEstimator(lp.log, v)
+		} else {
+			// drop the previous vehicle's estimator
+			lp.socEstimator = nil
 		}
 
 		lp.publish(keys.VehicleName, vehicle.Settings(lp.log, v).Name())

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -102,19 +102,19 @@ func (s *Estimator) Soc(fetchedSoc *float64, chargedEnergy float64) float64 {
 		return s.vehicleSoc
 	}
 
-	s.sampled = true
-
 	chargedEnergy = max(chargedEnergy, 0)
 	socDelta := *fetchedSoc - s.prevSoc
 	energyDelta := chargedEnergy - s.prevChargedEnergy
 
-	// no soc change and no energy reset: interpolate soc from charged energy
-	if socDelta == 0 && energyDelta >= 0 {
+	// no soc change and no energy reset: interpolate soc from charged energy.
+	// the first valid soc always takes the sampling path below to seed the baseline.
+	if s.sampled && socDelta == 0 && energyDelta >= 0 {
 		s.vehicleSoc = min(*fetchedSoc+energyDelta/s.energyPerSocStep, 100)
 		s.log.DEBUG.Printf("soc estimated: %.2f%% (vehicle: %.2f%%)", s.vehicleSoc, *fetchedSoc)
 		return s.vehicleSoc
 	}
 
+	s.sampled = true
 	s.vehicleSoc = *fetchedSoc
 
 	if s.initialSoc == 0 {

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -30,6 +30,7 @@ type Estimator struct {
 	initialEnergy     float64 // energy counter at first valid soc in Wh
 	prevSoc           float64 // vehicle soc at last soc change in %
 	prevChargedEnergy float64 // charged energy at last soc change in Wh
+	sampled           bool    // a valid vehicle soc was received
 }
 
 // NewEstimator creates new estimator
@@ -94,12 +95,14 @@ func (s *Estimator) Soc(fetchedSoc *float64, chargedEnergy float64) float64 {
 	if fetchedSoc == nil {
 		// extrapolate soc from charged energy while no vehicle soc is available,
 		// never below the current estimate to stay monotonic across energy resets
-		if energyDelta := max(chargedEnergy, 0) - s.prevChargedEnergy; s.initialSoc > 0 && energyDelta >= 0 {
+		if energyDelta := max(chargedEnergy, 0) - s.prevChargedEnergy; s.sampled && energyDelta >= 0 {
 			s.vehicleSoc = min(max(s.vehicleSoc, s.prevSoc+energyDelta/s.energyPerSocStep), 100)
 			s.log.DEBUG.Printf("soc extrapolated: %.2f%%", s.vehicleSoc)
 		}
 		return s.vehicleSoc
 	}
+
+	s.sampled = true
 
 	chargedEnergy = max(chargedEnergy, 0)
 	socDelta := *fetchedSoc - s.prevSoc

--- a/core/soc/estimator.go
+++ b/core/soc/estimator.go
@@ -92,7 +92,12 @@ func remainingChargeEnergy(targetSoc, vehicleSoc, virtualCapacity float64) float
 // Soc replaces the api.Vehicle.Soc interface to take charged energy into account
 func (s *Estimator) Soc(fetchedSoc *float64, chargedEnergy float64) float64 {
 	if fetchedSoc == nil {
-		s.log.WARN.Println("missing vehicle soc- ignored by estimator")
+		// extrapolate soc from charged energy while no vehicle soc is available,
+		// never below the current estimate to stay monotonic across energy resets
+		if energyDelta := max(chargedEnergy, 0) - s.prevChargedEnergy; s.initialSoc > 0 && energyDelta >= 0 {
+			s.vehicleSoc = min(max(s.vehicleSoc, s.prevSoc+energyDelta/s.energyPerSocStep), 100)
+			s.log.DEBUG.Printf("soc extrapolated: %.2f%%", s.vehicleSoc)
+		}
 		return s.vehicleSoc
 	}
 

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -99,8 +99,17 @@ func TestMissingSoc(t *testing.T) {
 	assert.Equal(t, 22.0, ce.Soc(nil, 200))
 	assert.Equal(t, 22.0, ce.Soc(&soc, 200))
 
-	// energy reset while soc is missing keeps the estimate
+	// energy reset while soc is missing keeps the estimate (monotonic clamp)
 	assert.Equal(t, 22.0, ce.Soc(nil, 50))
+
+	// resample the baseline at a higher energy, then reset the energy below it:
+	// the reset guard must hold the estimate
+	soc = 25.0
+	assert.Equal(t, 25.0, ce.Soc(&soc, 400))
+	assert.Equal(t, 25.0, ce.Soc(nil, 50))
+
+	// extrapolation resumes once the energy passes the sampled baseline again
+	assert.Equal(t, 26.0, ce.Soc(nil, 500))
 }
 
 func TestMissingSocFromZero(t *testing.T) {
@@ -114,6 +123,13 @@ func TestMissingSocFromZero(t *testing.T) {
 	soc := 0.0
 	assert.Equal(t, 0.0, ce.Soc(&soc, 0))
 	assert.Equal(t, 1.0, ce.Soc(nil, 100))
+
+	// the first sample seeds the energy baseline: a 0% soc at nonzero session
+	// energy must not jump ahead by the pre-baseline energy
+	vehicle.EXPECT().Capacity().Return(8.5)
+	ce = NewEstimator(util.NewLogger("foo"), vehicle)
+	assert.Equal(t, 0.0, ce.Soc(&soc, 5000))
+	assert.Equal(t, 1.0, ce.Soc(nil, 5100))
 }
 
 func TestImprovedEstimatorRemainingChargeDuration(t *testing.T) {

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -88,13 +88,19 @@ func TestMissingSoc(t *testing.T) {
 
 	ce := NewEstimator(util.NewLogger("foo"), vehicle)
 
+	// missing soc without any prior sample keeps the zero estimate
+	assert.Equal(t, 0.0, ce.Soc(nil, 100))
+
 	soc := 20.0
 	assert.Equal(t, 20.0, ce.Soc(&soc, 0))
 	assert.Equal(t, 21.0, ce.Soc(&soc, 100))
 
-	// missing soc keeps the estimate and must not corrupt the sampled state
-	assert.Equal(t, 21.0, ce.Soc(nil, 200))
+	// missing soc extrapolates from charged energy and must not corrupt the sampled state
+	assert.Equal(t, 22.0, ce.Soc(nil, 200))
 	assert.Equal(t, 22.0, ce.Soc(&soc, 200))
+
+	// energy reset while soc is missing keeps the estimate
+	assert.Equal(t, 22.0, ce.Soc(nil, 50))
 }
 
 func TestImprovedEstimatorRemainingChargeDuration(t *testing.T) {

--- a/core/soc/estimator_test.go
+++ b/core/soc/estimator_test.go
@@ -103,6 +103,19 @@ func TestMissingSoc(t *testing.T) {
 	assert.Equal(t, 22.0, ce.Soc(nil, 50))
 }
 
+func TestMissingSocFromZero(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vehicle := api.NewMockVehicle(ctrl)
+	vehicle.EXPECT().Capacity().Return(8.5)
+
+	ce := NewEstimator(util.NewLogger("foo"), vehicle)
+
+	// a fetched soc of exactly 0% must still enable extrapolation
+	soc := 0.0
+	assert.Equal(t, 0.0, ce.Soc(&soc, 0))
+	assert.Equal(t, 1.0, ce.Soc(nil, 100))
+}
+
 func TestImprovedEstimatorRemainingChargeDuration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	vehicle := api.NewMockVehicle(ctrl)


### PR DESCRIPTION
fixes #33116

When the vehicle backend becomes unavailable during charging, the estimator so far froze the last known soc, so a configured soc limit could be exceeded until the backend returned.

The estimator's `fetchedSoc == nil` branch now extrapolates the soc from charged energy using the already sampled state (`prevSoc + energyDelta/energyPerSocStep`) — the same formula as the existing interpolation branch, so the estimate stays continuous once the backend returns. The sampled state itself remains untouched and the next fetched soc always takes precedence. The estimate is clamped to 100% and kept monotonic so a mid-outage session energy reset cannot move it backwards. This implements the `nil | value | prevsoc + delta` case documented in `core/soc/README.md`.

`publishSocAndRange` now passes a missing soc through to the estimator instead of skipping it. A freshly created estimator without any prior sample returns 0 and does not overwrite a known soc (same-vehicle reconnect must keep the published value). As a side effect, the published soc now also advances with charged energy between regular soc polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)