### PR TITLE
Tariffs: support cron expressions for refresh scheduling

### DIFF
--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -502,7 +502,13 @@ export default {
 				this.$emit("update:modelValue", "");
 				return;
 			}
+
+			// read display value before override changes the getter's unit
+			const num = this.value;
 			this.unitOverride = unit;
+			if (typeof num === "number") {
+				this.$emit("update:modelValue", toGoDuration(num, unit));
+			}
 		},
 		onFieldChange(e) {
 			// unparsable input (e.g. locale decimal separator mismatch)

--- a/assets/js/components/Config/PropertyField.vue
+++ b/assets/js/components/Config/PropertyField.vue
@@ -94,7 +94,7 @@
 				:list="datalistId"
 				:type="inputType"
 				:step="step"
-				:placeholder="placeholder"
+				:placeholder="effectivePlaceholder"
 				:required="required"
 				:pattern="patternRegex"
 				:title="patternTitle"
@@ -191,13 +191,40 @@ export default {
 	},
 	emits: ["update:modelValue"],
 	data: () => {
-		return { selectMode: false, unitOverride: null };
+		return { selectMode: false, unitOverride: null, cronMode: false };
+	},
+	created() {
+		// start in cron mode if the existing value isn't a parseable duration
+		if (
+			this.cronCapable &&
+			typeof this.modelValue === "string" &&
+			this.modelValue !== "" &&
+			parseGoDuration(this.modelValue) === null
+		) {
+			this.cronMode = true;
+		}
 	},
 	computed: {
+		cronCapable() {
+			return this.property === "interval" && this.type === "Duration";
+		},
+		cronActive() {
+			return this.cronCapable && this.cronMode;
+		},
+		effectivePlaceholder() {
+			if (this.cronActive) return "15 0 * * *";
+			return this.placeholder;
+		},
+		// loose guardrail matching cron forms while rejecting a plain duration like "1h"; backend is authoritative
+		cronPattern() {
+			return "@(annually|yearly|monthly|weekly|daily|midnight|hourly|reboot)|@every\\s+\\S+|(\\S+\\s+){4,5}\\S+";
+		},
 		patternRegex() {
+			if (this.cronActive) return this.cronPattern;
 			return this.pattern.Regex || null;
 		},
 		patternTitle() {
+			if (this.cronActive) return this.$t("config.form.cronInvalid");
 			const examples = this.pattern.Examples || [];
 			if (!examples.length) return null;
 			return examples.join(", ");
@@ -229,6 +256,9 @@ export default {
 			if (this.masked) {
 				return "password";
 			}
+			if (this.cronActive) {
+				return "text";
+			}
 			if (["Int", "Float", "Duration", "PricePerKWh"].includes(this.type)) {
 				return "number";
 			}
@@ -254,6 +284,9 @@ export default {
 			return result;
 		},
 		endAlign() {
+			if (this.cronActive) {
+				return false;
+			}
 			return ["Int", "Float", "Duration", "PricePerKWh"].includes(this.type);
 		},
 		step() {
@@ -263,6 +296,9 @@ export default {
 			return null;
 		},
 		unitValue() {
+			if (this.cronActive) {
+				return this.$t("config.form.cron");
+			}
 			if (this.type === "Duration") {
 				return this.fmtDurationUnit(this.value, this.durationUnit);
 			}
@@ -324,16 +360,27 @@ export default {
 			return displayFactors[this.durationUnit] ?? 1;
 		},
 		durationUnit() {
+			if (this.cronActive) {
+				return "cron";
+			}
 			return this.unitOverride ?? goDurationUnit(this.modelValue) ?? this.unit ?? "second";
 		},
 		unitSelectable() {
 			return this.type === "Duration" && !this.legacyDuration && !this.disabled;
 		},
 		unitOptions() {
-			return durationUnits.map((value) => ({
+			const options = durationUnits.map((value) => ({
 				value,
 				name: this.fmtDurationUnit(2, value),
 			}));
+			// interval fields can also be driven by a cron expression
+			if (this.cronCapable) {
+				options.push({
+					value: "cron",
+					name: this.$t("config.form.cron"),
+				});
+			}
+			return options;
 		},
 		selectOptions() {
 			if (this.chargeModes) {
@@ -363,6 +410,10 @@ export default {
 		},
 		value: {
 			get() {
+				if (this.cronActive) {
+					return this.modelValue ?? "";
+				}
+
 				if (this.select && this.modelValue == null) {
 					return "";
 				}
@@ -399,6 +450,11 @@ export default {
 				return this.modelValue;
 			},
 			set(value) {
+				if (this.cronActive) {
+					this.$emit("update:modelValue", value);
+					return;
+				}
+
 				let newValue = value;
 
 				if (this.scale) {
@@ -431,12 +487,22 @@ export default {
 			return val;
 		},
 		onUnitChange(e) {
-			// read display value before override changes the getter's unit
-			const num = this.value;
-			this.unitOverride = e.target.value;
-			if (typeof num === "number") {
-				this.$emit("update:modelValue", toGoDuration(num, this.unitOverride));
+			const unit = e.target.value;
+
+			if (unit === "cron") {
+				this.cronMode = true;
+				this.$emit("update:modelValue", "");
+				return;
 			}
+
+			// a cron expression can't convert to a duration, so clear it
+			if (this.cronActive) {
+				this.cronMode = false;
+				this.unitOverride = unit;
+				this.$emit("update:modelValue", "");
+				return;
+			}
+			this.unitOverride = unit;
 		},
 		onFieldChange(e) {
 			// unparsable input (e.g. locale decimal separator mismatch)

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1
 	github.com/robertkrimen/otto v0.5.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.53.0
 	github.com/sandrolain/httpcache v1.4.2
 	github.com/sethvargo/go-password v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,8 @@ github.com/rickb777/plural v1.4.7 h1:rBRAxp9aTFYzWTLWIE/UTwKcaqSSAV2ml7aOUFYpAGo
 github.com/rickb777/plural v1.4.7/go.mod h1:DB19dtrplGS5s6VJVHn7tvmFYPoE83p1xqio3oVnNRM=
 github.com/robertkrimen/otto v0.5.1 h1:avDI4ToRk8k1hppLdYFTuuzND41n37vPGJU7547dGf0=
 github.com/robertkrimen/otto v0.5.1/go.mod h1:bS433I4Q9p+E5pZLu7r17vP6FkE6/wLxBdmKjoqJXF8=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -314,6 +314,8 @@
       "titleEdit": "Zusätzlichen Zähler bearbeiten"
     },
     "form": {
+      "cron": "Cron",
+      "cronInvalid": "Cron-Ausdruck wie 15 0 * * * oder @daily eingeben, keine Dauer",
       "danger": "Achtung",
       "deprecated": "veraltet",
       "durationUnit": "Zeiteinheit für {label}",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -314,6 +314,8 @@
       "titleEdit": "Edit Additional Meter"
     },
     "form": {
+      "cron": "cron",
+      "cronInvalid": "Enter a cron expression like 15 0 * * * or @daily, not a duration",
       "danger": "Danger",
       "deprecated": "deprecated",
       "durationUnit": "Time unit for {label}",

--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -23,6 +23,7 @@ type Amber struct {
 	uri     string
 	channel string
 	data    *util.Monitor[api.Rates]
+	timer   *refreshTimer
 }
 
 var _ api.Tariff = (*Amber)(nil)
@@ -33,10 +34,11 @@ func init() {
 
 func NewAmberFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
-		embed   `mapstructure:",squash"`
-		Token   string
-		SiteID  string
-		Channel string
+		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
+		Token    string
+		SiteID   string
+		Channel  string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -55,6 +57,11 @@ func NewAmberFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, errors.New("missing channel")
 	}
 
+	timer, err := cc.schedule.timer(time.Minute)
+	if err != nil {
+		return nil, err
+	}
+
 	log := util.NewLogger("amber").Redact(cc.Token)
 
 	t := &Amber{
@@ -63,7 +70,8 @@ func NewAmberFromConfig(other map[string]any) (api.Tariff, error) {
 		Helper:  request.NewHelper(log),
 		uri:     fmt.Sprintf(amber.URI, strings.ToUpper(cc.SiteID)),
 		channel: strings.ToLower(cc.Channel),
-		data:    util.NewMonitor[api.Rates](2 * time.Hour),
+		data:    util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:   timer,
 	}
 
 	t.Client.Transport = &transport.Decorator{
@@ -79,7 +87,7 @@ func NewAmberFromConfig(other map[string]any) (api.Tariff, error) {
 func (t *Amber) run(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Minute); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res []amber.PriceInfo
 
 		if err := backoff.Retry(func() error {

--- a/tariff/amber.go
+++ b/tariff/amber.go
@@ -87,6 +87,7 @@ func NewAmberFromConfig(other map[string]any) (api.Tariff, error) {
 func (t *Amber) run(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res []amber.PriceInfo
 

--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -16,9 +16,10 @@ import (
 
 type Awattar struct {
 	*embed
-	log  *util.Logger
-	uri  string
-	data *util.Monitor[api.Rates]
+	log   *util.Logger
+	uri   string
+	data  *util.Monitor[api.Rates]
+	timer *refreshTimer
 }
 
 var _ api.Tariff = (*Awattar)(nil)
@@ -29,8 +30,9 @@ func init() {
 
 func NewAwattarFromConfig(other map[string]any) (api.Tariff, error) {
 	cc := struct {
-		embed  `mapstructure:",squash"`
-		Region string
+		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
+		Region   string
 	}{
 		Region: "DE",
 	}
@@ -43,11 +45,17 @@ func NewAwattarFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	t := &Awattar{
 		embed: &cc.embed,
 		log:   util.NewLogger("awattar"),
 		uri:   fmt.Sprintf(awattar.RegionURI, strings.ToLower(cc.Region)),
-		data:  util.NewMonitor[api.Rates](2 * time.Hour),
+		data:  util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer: timer,
 	}
 
 	return runOrError(t)
@@ -58,7 +66,7 @@ func (t *Awattar) run(done chan error) {
 
 	client := request.NewHelper(t.log)
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res awattar.Prices
 
 		// Awattar publishes prices for next day around 13:00 CET/CEST, so up to 35h of price data are available

--- a/tariff/awattar.go
+++ b/tariff/awattar.go
@@ -66,6 +66,7 @@ func (t *Awattar) run(done chan error) {
 
 	client := request.NewHelper(t.log)
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res awattar.Prices
 

--- a/tariff/edf-tempo.go
+++ b/tariff/edf-tempo.go
@@ -27,6 +27,7 @@ type EdfTempo struct {
 	basic  string
 	data   *util.Monitor[api.Rates]
 	prices map[string]float64
+	timer  *refreshTimer
 }
 
 var _ api.Tariff = (*EdfTempo)(nil)
@@ -38,6 +39,7 @@ func init() {
 func NewEdfTempoFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
 		embed        `mapstructure:",squash"`
+		schedule     `mapstructure:",squash"`
 		ClientID     string
 		ClientSecret string
 		Prices       struct {
@@ -57,6 +59,11 @@ func NewEdfTempoFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	basic := transport.BasicAuthHeader(cc.ClientID, cc.ClientSecret)
 	log := util.NewLogger("edf-tempo").Redact(basic)
 
@@ -65,7 +72,8 @@ func NewEdfTempoFromConfig(other map[string]any) (api.Tariff, error) {
 		log:    log,
 		basic:  basic,
 		Helper: request.NewHelper(log),
-		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		data:   util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:  timer,
 	}
 
 	prices := structs.Map(cc.Prices)
@@ -103,7 +111,7 @@ func (t *EdfTempo) refreshToken() (*oauth2.Token, error) {
 func (t *EdfTempo) run(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res struct {
 			Data struct {
 				Values []struct {

--- a/tariff/edf-tempo.go
+++ b/tariff/edf-tempo.go
@@ -111,6 +111,7 @@ func (t *EdfTempo) refreshToken() (*oauth2.Token, error) {
 func (t *EdfTempo) run(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res struct {
 			Data struct {

--- a/tariff/electricitymaps.go
+++ b/tariff/electricitymaps.go
@@ -17,10 +17,11 @@ import (
 
 type ElectricityMaps struct {
 	*request.Helper
-	log  *util.Logger
-	uri  string
-	zone string
-	data *util.Monitor[api.Rates]
+	log   *util.Logger
+	uri   string
+	zone  string
+	data  *util.Monitor[api.Rates]
+	timer *refreshTimer
 }
 
 type CarbonIntensity struct {
@@ -42,14 +43,20 @@ func init() {
 
 func NewElectricityMapsFromConfig(other map[string]any) (api.Tariff, error) {
 	cc := struct {
-		Uri   string
-		Token string
-		Zone  string
+		schedule `mapstructure:",squash"`
+		Uri      string
+		Token    string
+		Zone     string
 	}{
 		Zone: "DE",
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
 		return nil, err
 	}
 
@@ -60,7 +67,8 @@ func NewElectricityMapsFromConfig(other map[string]any) (api.Tariff, error) {
 		Helper: request.NewHelper(log),
 		uri:    util.DefaultScheme(strings.TrimRight(cc.Uri, "/"), "https"),
 		zone:   strings.ToUpper(cc.Zone),
-		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		data:   util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:  timer,
 	}
 
 	t.Client.Transport = &transport.Decorator{
@@ -78,7 +86,7 @@ func (t *ElectricityMaps) run(done chan error) {
 
 	uri := fmt.Sprintf("%s/carbon-intensity/forecast?zone=%s", t.uri, t.zone)
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res CarbonIntensity
 
 		if err := backoff.Retry(func() error {

--- a/tariff/electricitymaps.go
+++ b/tariff/electricitymaps.go
@@ -86,6 +86,7 @@ func (t *ElectricityMaps) run(done chan error) {
 
 	uri := fmt.Sprintf("%s/carbon-intensity/forecast?zone=%s", t.uri, t.zone)
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res CarbonIntensity
 

--- a/tariff/elering.go
+++ b/tariff/elering.go
@@ -69,6 +69,7 @@ func (t *Elering) run(done chan error) {
 	var once sync.Once
 	client := request.NewHelper(t.log)
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res elering.NpsPrice
 

--- a/tariff/elering.go
+++ b/tariff/elering.go
@@ -21,6 +21,7 @@ type Elering struct {
 	log    *util.Logger
 	region string
 	data   *util.Monitor[api.Rates]
+	timer  *refreshTimer
 }
 
 var _ api.Tariff = (*Elering)(nil)
@@ -31,8 +32,9 @@ func init() {
 
 func NewEleringFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
-		embed  `mapstructure:",squash"`
-		Region string
+		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
+		Region   string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -47,11 +49,17 @@ func NewEleringFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	t := &Elering{
 		embed:  &cc.embed,
 		log:    util.NewLogger("elering"),
 		region: strings.ToLower(cc.Region),
-		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		data:   util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:  timer,
 	}
 
 	return runOrError(t)
@@ -61,7 +69,7 @@ func (t *Elering) run(done chan error) {
 	var once sync.Once
 	client := request.NewHelper(t.log)
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res elering.NpsPrice
 
 		ts := time.Now().Truncate(time.Hour)

--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -24,6 +24,7 @@ type Entsoe struct {
 	token  string
 	domain string
 	data   *util.Monitor[api.Rates]
+	timer  *refreshTimer
 }
 
 var _ api.Tariff = (*Entsoe)(nil)
@@ -35,6 +36,7 @@ func init() {
 func NewEntsoeFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
 		embed         `mapstructure:",squash"`
+		schedule      `mapstructure:",squash"`
 		Securitytoken string
 		Domain        string
 	}
@@ -55,6 +57,11 @@ func NewEntsoeFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	domain, err := entsoe.Area(entsoe.BZN, strings.ToUpper(cc.Domain))
 	if err != nil {
 		return nil, err
@@ -68,7 +75,8 @@ func NewEntsoeFromConfig(other map[string]any) (api.Tariff, error) {
 		embed:  &cc.embed,
 		token:  cc.Securitytoken,
 		domain: domain,
-		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		data:   util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:  timer,
 	}
 
 	// Wrap the client with a decorator that adds the security token to each request.
@@ -86,7 +94,7 @@ func (t *Entsoe) run(done chan error) {
 	var once sync.Once
 
 	// Data updated by ESO every half hour, but we only need data every hour to stay current.
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var tr entsoe.PublicationMarketDocument
 
 		if err := backoff.Retry(func() error {

--- a/tariff/entsoe.go
+++ b/tariff/entsoe.go
@@ -94,6 +94,7 @@ func (t *Entsoe) run(done chan error) {
 	var once sync.Once
 
 	// Data updated by ESO every half hour, but we only need data every hour to stay current.
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var tr entsoe.PublicationMarketDocument
 

--- a/tariff/gruenstromindex.go
+++ b/tariff/gruenstromindex.go
@@ -67,6 +67,7 @@ func (t *GrünStromIndex) run(done chan error) {
 	var once sync.Once
 	uri := fmt.Sprintf("https://api.corrently.io/v2.0/gsi/prediction?zip=%s", t.zip)
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res corrently.Forecast
 

--- a/tariff/gruenstromindex.go
+++ b/tariff/gruenstromindex.go
@@ -17,9 +17,10 @@ import (
 
 type GrünStromIndex struct {
 	*request.Helper
-	log  *util.Logger
-	zip  string
-	data *util.Monitor[api.Rates]
+	log   *util.Logger
+	zip   string
+	data  *util.Monitor[api.Rates]
+	timer *refreshTimer
 }
 
 var _ api.Tariff = (*GrünStromIndex)(nil)
@@ -30,11 +31,17 @@ func init() {
 
 func NewGrünStromIndexFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
-		Zip   string
-		Token string
+		schedule `mapstructure:",squash"`
+		Zip      string
+		Token    string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
 		return nil, err
 	}
 
@@ -44,7 +51,8 @@ func NewGrünStromIndexFromConfig(other map[string]any) (api.Tariff, error) {
 		log:    log,
 		zip:    cc.Zip,
 		Helper: request.NewHelper(log),
-		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		data:   util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:  timer,
 	}
 
 	t.Client.Transport = &oauth2.Transport{
@@ -59,7 +67,7 @@ func (t *GrünStromIndex) run(done chan error) {
 	var once sync.Once
 	uri := fmt.Sprintf("https://api.corrently.io/v2.0/gsi/prediction?zip=%s", t.zip)
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res corrently.Forecast
 
 		err := backoff.Retry(func() error {

--- a/tariff/ngeso.go
+++ b/tariff/ngeso.go
@@ -18,6 +18,7 @@ type Ngeso struct {
 	regionId       string
 	regionPostcode string
 	data           *util.Monitor[api.Rates]
+	timer          *refreshTimer
 }
 
 var _ api.Tariff = (*Ngeso)(nil)
@@ -28,6 +29,7 @@ func init() {
 
 func NewNgesoFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
+		schedule `mapstructure:",squash"`
 		Region   string
 		Postcode string
 	}
@@ -40,11 +42,17 @@ func NewNgesoFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, errors.New("cannot define region and postcode simultaneously")
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	t := &Ngeso{
 		log:            util.NewLogger("ngeso"),
 		regionId:       cc.Region,
 		regionPostcode: cc.Postcode,
-		data:           util.NewMonitor[api.Rates](2 * time.Hour),
+		data:           util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:          timer,
 	}
 
 	return runOrError(t)
@@ -69,7 +77,7 @@ func (t *Ngeso) run(done chan error) {
 	}
 
 	// Data updated by ESO every half hour, but we only need data every hour to stay current.
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		res, err := backoff.RetryWithData(func() (ngeso.CarbonForecastResponse, error) {
 			res, err := tReq.DoRequest(client)
 			return res, backoffPermanentError(err)

--- a/tariff/ngeso.go
+++ b/tariff/ngeso.go
@@ -77,6 +77,7 @@ func (t *Ngeso) run(done chan error) {
 	}
 
 	// Data updated by ESO every half hour, but we only need data every hour to stay current.
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		res, err := backoff.RetryWithData(func() (ngeso.CarbonForecastResponse, error) {
 			res, err := tReq.DoRequest(client)

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -25,6 +25,7 @@ type Octopus struct {
 	paymentMethod   string
 	tariffDirection octoGql.TariffDirection
 	data            *util.Monitor[api.Rates]
+	timer           *refreshTimer
 }
 
 var _ api.Tariff = (*Octopus)(nil)
@@ -47,6 +48,7 @@ func NewOctopusFromConfig(other map[string]any) (api.Tariff, error) {
 // Split out to allow for testing.
 func buildOctopusFromConfig(other map[string]any) (*Octopus, error) {
 	var cc struct {
+		schedule        `mapstructure:",squash"`
 		Region          string
 		Tariff          string // DEPRECATED: use ProductCode
 		ProductCode     string
@@ -59,6 +61,11 @@ func buildOctopusFromConfig(other map[string]any) (*Octopus, error) {
 	logger := util.NewLogger("octopus")
 
 	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
 		return nil, err
 	}
 
@@ -117,7 +124,8 @@ func buildOctopusFromConfig(other map[string]any) (*Octopus, error) {
 		accountnumber:   cc.AccountNumber,
 		paymentMethod:   paymentMethod,
 		tariffDirection: cc.TariffDirection,
-		data:            util.NewMonitor[api.Rates](2 * time.Hour),
+		data:            util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:           timer,
 	}
 
 	return t, nil
@@ -150,7 +158,7 @@ func (t *Octopus) run(done chan error) {
 	}
 
 	// TODO tick every 15 minutes if GraphQL is available to poll for Intelligent slots.
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res octoRest.UnitRates
 
 		if err := backoff.Retry(func() error {

--- a/tariff/octopus.go
+++ b/tariff/octopus.go
@@ -158,6 +158,7 @@ func (t *Octopus) run(done chan error) {
 	}
 
 	// TODO tick every 15 minutes if GraphQL is available to poll for Intelligent slots.
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res octoRest.UnitRates
 

--- a/tariff/octopusde.go
+++ b/tariff/octopusde.go
@@ -22,6 +22,7 @@ type OctopusDe struct {
 	log       *util.Logger
 	gqlClient *krakengql.Client
 	data      *util.Monitor[api.Rates]
+	timer     *refreshTimer
 }
 
 type planningHorizon struct {
@@ -49,6 +50,7 @@ func NewOctopusDeFromConfig(other map[string]any) (api.Tariff, error) {
 // Split out to allow for testing.
 func buildOctopusDeFromConfig(other map[string]any) (*OctopusDe, error) {
 	var cc struct {
+		schedule      `mapstructure:",squash"`
 		Email         string
 		Password      string
 		AccountNumber string
@@ -70,6 +72,11 @@ func buildOctopusDeFromConfig(other map[string]any) (*OctopusDe, error) {
 		return nil, errors.New("missing account number")
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	log := util.NewLogger("octopus-de")
 
 	// Create GraphQL client
@@ -81,7 +88,8 @@ func buildOctopusDeFromConfig(other map[string]any) (*OctopusDe, error) {
 	t := &OctopusDe{
 		log:       log,
 		gqlClient: gqlClient,
-		data:      util.NewMonitor[api.Rates](2 * time.Hour),
+		data:      util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:     timer,
 	}
 
 	return t, nil
@@ -90,7 +98,7 @@ func buildOctopusDeFromConfig(other map[string]any) (*OctopusDe, error) {
 func (t *OctopusDe) run(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var rates []RatePeriod
 
 		if err := backoff.Retry(func() error {

--- a/tariff/octopusde.go
+++ b/tariff/octopusde.go
@@ -98,6 +98,7 @@ func buildOctopusDeFromConfig(other map[string]any) (*OctopusDe, error) {
 func (t *OctopusDe) run(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var rates []RatePeriod
 

--- a/tariff/octopusit.go
+++ b/tariff/octopusit.go
@@ -89,6 +89,7 @@ func buildOctopusItFromConfig(other map[string]any) (*OctopusIt, error) {
 func (t *OctopusIt) run(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var rates []RatePeriod
 

--- a/tariff/octopusit.go
+++ b/tariff/octopusit.go
@@ -19,6 +19,7 @@ type OctopusIt struct {
 	log       *util.Logger
 	gqlClient *krakengql.Client
 	data      *util.Monitor[api.Rates]
+	timer     *refreshTimer
 }
 
 var _ api.Tariff = (*OctopusIt)(nil)
@@ -41,6 +42,7 @@ func NewOctopusItFromConfig(other map[string]any) (api.Tariff, error) {
 // Split out to allow for testing.
 func buildOctopusItFromConfig(other map[string]any) (*OctopusIt, error) {
 	var cc struct {
+		schedule      `mapstructure:",squash"`
 		Email         string
 		Password      string
 		AccountNumber string
@@ -62,6 +64,11 @@ func buildOctopusItFromConfig(other map[string]any) (*OctopusIt, error) {
 		return nil, errors.New("missing account number")
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	log := util.NewLogger("octopus-it")
 
 	gqlClient, err := krakengql.NewClient(log, krakengql.ItBaseURI, cc.Email, cc.Password, cc.AccountNumber)
@@ -72,7 +79,8 @@ func buildOctopusItFromConfig(other map[string]any) (*OctopusIt, error) {
 	t := &OctopusIt{
 		log:       log,
 		gqlClient: gqlClient,
-		data:      util.NewMonitor[api.Rates](2 * time.Hour),
+		data:      util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:     timer,
 	}
 
 	return t, nil
@@ -81,7 +89,7 @@ func buildOctopusItFromConfig(other map[string]any) (*OctopusIt, error) {
 func (t *OctopusIt) run(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var rates []RatePeriod
 
 		if err := backoff.Retry(func() error {

--- a/tariff/ostrom.go
+++ b/tariff/ostrom.go
@@ -31,6 +31,7 @@ type Ostrom struct {
 	cityId       int // Required for the Fair tariff types
 	basic        string
 	data         *util.Monitor[api.Rates]
+	timer        *refreshTimer
 }
 
 var _ api.Tariff = (*Ostrom)(nil)
@@ -60,6 +61,7 @@ func ensureContractEx(cid int64, contracts []ostrom.Contract) (ostrom.Contract, 
 
 func NewOstromFromConfig(other map[string]any) (api.Tariff, error) {
 	cc := struct {
+		schedule     `mapstructure:",squash"`
 		ClientId     string
 		ClientSecret string
 		Environment  string
@@ -76,6 +78,11 @@ func NewOstromFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, api.ErrMissingCredentials
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	basic := transport.BasicAuthHeader(cc.ClientId, cc.ClientSecret)
 	log := util.NewLogger("ostrom").Redact(basic)
 
@@ -84,7 +91,8 @@ func NewOstromFromConfig(other map[string]any) (api.Tariff, error) {
 		env:    cc.Environment,
 		basic:  basic,
 		Helper: request.NewHelper(log),
-		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		data:   util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:  timer,
 	}
 
 	t.Client.Transport = &oauth2.Transport{
@@ -204,7 +212,7 @@ func (t *Ostrom) refreshToken() (*oauth2.Token, error) {
 func (t *Ostrom) runStatic(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		price, err := t.getFixedPrice()
 		if err != nil {
 			if reportError(&once, done, err) {
@@ -234,7 +242,7 @@ func (t *Ostrom) runStatic(done chan error) {
 func (t *Ostrom) run(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res ostrom.Prices
 
 		start := now.BeginningOfDay()

--- a/tariff/ostrom.go
+++ b/tariff/ostrom.go
@@ -212,6 +212,7 @@ func (t *Ostrom) refreshToken() (*oauth2.Token, error) {
 func (t *Ostrom) runStatic(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		price, err := t.getFixedPrice()
 		if err != nil {
@@ -242,6 +243,7 @@ func (t *Ostrom) runStatic(done chan error) {
 func (t *Ostrom) run(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res ostrom.Prices
 

--- a/tariff/proxy_cache.go
+++ b/tariff/proxy_cache.go
@@ -21,12 +21,12 @@ type cachingProxy struct {
 	mu   sync.Mutex
 	hash [32]byte
 
-	key      string
-	ctx      context.Context
-	typ      string
-	config   map[string]any
-	interval time.Duration
-	updated  time.Time
+	key     string
+	ctx     context.Context
+	typ     string
+	config  map[string]any
+	timer   *refreshTimer
+	updated time.Time
 
 	cached *cached
 	tariff api.Tariff
@@ -41,23 +41,26 @@ func NewCachedFromConfig(ctx context.Context, typ string, other map[string]any) 
 		tariffType = template
 	}
 
-	cc := struct {
-		Interval time.Duration
+	var cc struct {
+		schedule `mapstructure:",squash"`
 		Other    map[string]any `mapstructure:",remain"`
-	}{
-		Interval: defaultInterval,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(defaultInterval)
+	if err != nil {
+		return nil, err
+	}
+
 	p := &cachingProxy{
-		ctx:      ctx,
-		typ:      typ,
-		config:   other,
-		interval: cc.Interval,
-		key:      tariffType + "-" + cacheKey(typ, other),
+		ctx:    ctx,
+		typ:    typ,
+		config: other,
+		timer:  timer,
+		key:    tariffType + "-" + cacheKey(typ, other),
 	}
 
 	// check if cached data is up to date
@@ -162,8 +165,8 @@ func (p *cachingProxy) cacheGet() (*cached, error) {
 		return nil, errors.New("no rates")
 	}
 
-	if d := time.Since(p.cached.Updated); d > p.interval {
-		return nil, fmt.Errorf("cache outdated: %v", d.Round(time.Second))
+	if p.timer.stale(p.cached.Updated) {
+		return nil, fmt.Errorf("cache outdated: %v", time.Since(p.cached.Updated).Round(time.Second))
 	}
 
 	return p.cached, nil
@@ -172,7 +175,7 @@ func (p *cachingProxy) cacheGet() (*cached, error) {
 // cachePut persists rates if changed or the update interval has elapsed
 func (p *cachingProxy) cachePut(typ api.TariffType, rates api.Rates) error {
 	hash := sha256.Sum256(fmt.Append(nil, rates))
-	if hash == p.hash && time.Since(p.updated) < p.interval {
+	if hash == p.hash && !p.timer.stale(p.updated) {
 		return nil
 	}
 

--- a/tariff/proxy_cache_test.go
+++ b/tariff/proxy_cache_test.go
@@ -12,7 +12,7 @@ import (
 func TestCacheInterval(t *testing.T) {
 	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
 
-	p := &cachingProxy{key: "test", interval: time.Hour}
+	p := &cachingProxy{key: "test", timer: &refreshTimer{interval: time.Hour}}
 	require.NoError(t, p.cachePut(api.TariffTypeSolar, api.Rates{
 		{Start: time.Now(), End: time.Now().Add(time.Hour), Value: 1},
 	}))

--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -28,9 +28,10 @@ var romeLocation *time.Location
 
 type Pun struct {
 	*embed
-	zone string
-	log  *util.Logger
-	data *util.Monitor[api.Rates]
+	zone  string
+	log   *util.Logger
+	data  *util.Monitor[api.Rates]
+	timer *refreshTimer
 }
 
 type NewDataSet struct {
@@ -64,8 +65,9 @@ func init() {
 
 func NewPunFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
-		embed `mapstructure:",squash"`
-		Zone  string
+		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
+		Zone     string
 	}
 
 	logger := util.NewLogger("pun")
@@ -78,6 +80,11 @@ func NewPunFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	var zone = strings.ToUpper(strings.TrimSpace(cc.Zone))
 	if cc.Zone == "" {
 		zone = "PUN"
@@ -87,7 +94,8 @@ func NewPunFromConfig(other map[string]any) (api.Tariff, error) {
 		log:   logger,
 		zone:  zone,
 		embed: &cc.embed,
-		data:  util.NewMonitor[api.Rates](2 * time.Hour),
+		data:  util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer: timer,
 	}
 
 	return runOrError(t)
@@ -96,7 +104,7 @@ func NewPunFromConfig(other map[string]any) (api.Tariff, error) {
 func (t *Pun) run(done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		// get today data
 		today, err := backoff.RetryWithData(func() (api.Rates, error) {
 			res, err := t.getData(time.Now())

--- a/tariff/pun.go
+++ b/tariff/pun.go
@@ -104,6 +104,7 @@ func NewPunFromConfig(other map[string]any) (api.Tariff, error) {
 func (t *Pun) run(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		// get today data
 		today, err := backoff.RetryWithData(func() (api.Rates, error) {

--- a/tariff/schedule.go
+++ b/tariff/schedule.go
@@ -1,0 +1,94 @@
+package tariff
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// schedule is squashed into a tariff's config struct so every tariff supports
+// the same interval option: a duration (e.g. "15m") or a cron expression
+// (e.g. "15 0 * * *").
+type schedule struct {
+	Interval string
+}
+
+// refreshTimer drives a tariff's refresh loop. A nil sched means interval-based.
+type refreshTimer struct {
+	interval time.Duration
+	sched    cron.Schedule
+}
+
+func (s schedule) timer(fallback time.Duration) (*refreshTimer, error) {
+	t := &refreshTimer{interval: fallback}
+	if s.Interval == "" {
+		return t, nil
+	}
+
+	if d, err := time.ParseDuration(s.Interval); err == nil {
+		if d <= 0 {
+			return nil, fmt.Errorf("interval: %q must be positive", s.Interval)
+		}
+		t.interval = d
+		return t, nil
+	}
+
+	// local time, optionally overridden per-expression with a CRON_TZ= prefix
+	sched, err := cron.ParseStandard(s.Interval)
+	if err != nil {
+		return nil, fmt.Errorf("interval: %q is neither a duration nor a cron expression: %w", s.Interval, err)
+	}
+	// a syntactically valid but impossible schedule (e.g. "0 0 30 2 *") yields
+	// a zero next-fire; reject it so C() cannot busy-loop
+	if sched.Next(time.Now()).IsZero() {
+		return nil, fmt.Errorf("interval: cron %q never matches", s.Interval)
+	}
+	t.sched = sched
+	return t, nil
+}
+
+// C returns a ticker-like channel so run loops keep the existing
+// `for tick := …; ; <-tick` shape as a drop-in replacement for time.Tick.
+func (t *refreshTimer) C() <-chan time.Time {
+	ch := make(chan time.Time, 1)
+
+	if t.sched == nil {
+		go func() {
+			for tt := range time.Tick(t.interval) {
+				ch <- tt
+			}
+		}()
+		return ch
+	}
+
+	go func() {
+		for {
+			next := t.sched.Next(time.Now())
+			if next.IsZero() {
+				return
+			}
+			tt := <-time.After(time.Until(next))
+			ch <- tt
+		}
+	}()
+	return ch
+}
+
+// window returns a staleness window for sizing util.Monitor, mirroring the
+// former 2*interval behaviour. For cron it spans two scheduled intervals,
+// measured between consecutive fires so it doesn't depend on when evcc starts.
+func (t *refreshTimer) window() time.Duration {
+	if t.sched == nil {
+		return 2 * t.interval
+	}
+	next := t.sched.Next(time.Now())
+	return 2 * t.sched.Next(next).Sub(next)
+}
+
+func (t *refreshTimer) stale(updated time.Time) bool {
+	if t.sched == nil {
+		return time.Since(updated) > t.interval
+	}
+	return time.Now().After(t.sched.Next(updated))
+}

--- a/tariff/schedule.go
+++ b/tariff/schedule.go
@@ -18,6 +18,7 @@ type schedule struct {
 type refreshTimer struct {
 	interval time.Duration
 	sched    cron.Schedule
+	stop     chan struct{}
 }
 
 func (s schedule) timer(fallback time.Duration) (*refreshTimer, error) {
@@ -50,13 +51,27 @@ func (s schedule) timer(fallback time.Duration) (*refreshTimer, error) {
 
 // C returns a ticker-like channel so run loops keep the existing
 // `for tick := …; ; <-tick` shape as a drop-in replacement for time.Tick.
+// Call Stop when the loop exits to release the driving goroutine and timer.
 func (t *refreshTimer) C() <-chan time.Time {
 	ch := make(chan time.Time, 1)
+	t.stop = make(chan struct{})
+	stop := t.stop
 
 	if t.sched == nil {
 		go func() {
-			for tt := range time.Tick(t.interval) {
-				ch <- tt
+			ticker := time.NewTicker(t.interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case tt := <-ticker.C:
+					select {
+					case ch <- tt:
+					case <-stop:
+						return
+					}
+				}
 			}
 		}()
 		return ch
@@ -68,11 +83,28 @@ func (t *refreshTimer) C() <-chan time.Time {
 			if next.IsZero() {
 				return
 			}
-			tt := <-time.After(time.Until(next))
-			ch <- tt
+			timer := time.NewTimer(time.Until(next))
+			select {
+			case <-stop:
+				timer.Stop()
+				return
+			case tt := <-timer.C:
+				select {
+				case ch <- tt:
+				case <-stop:
+					return
+				}
+			}
 		}
 	}()
 	return ch
+}
+
+// Stop releases the goroutine and timer started by C. Safe to call once per C.
+func (t *refreshTimer) Stop() {
+	if t.stop != nil {
+		close(t.stop)
+	}
 }
 
 // window returns a staleness window for sizing util.Monitor, mirroring the

--- a/tariff/schedule_test.go
+++ b/tariff/schedule_test.go
@@ -1,0 +1,87 @@
+package tariff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduleTimerDuration(t *testing.T) {
+	// empty -> fallback applies
+	timer, err := schedule{}.timer(3 * time.Hour)
+	require.NoError(t, err)
+	assert.Nil(t, timer.sched)
+	assert.Equal(t, 3*time.Hour, timer.interval)
+	assert.Equal(t, 6*time.Hour, timer.window())
+
+	// duration form wins over fallback
+	timer, err = schedule{Interval: "30m"}.timer(time.Hour)
+	require.NoError(t, err)
+	assert.Nil(t, timer.sched)
+	assert.Equal(t, 30*time.Minute, timer.interval)
+}
+
+func TestScheduleTimerDurationInvalid(t *testing.T) {
+	_, err := schedule{Interval: "0s"}.timer(time.Hour)
+	require.Error(t, err)
+}
+
+func TestScheduleTimerCron(t *testing.T) {
+	timer, err := schedule{Interval: "15 0 * * *"}.timer(time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, timer.sched)
+
+	// next fire is at 00:15 local time
+	base := time.Date(2026, 8, 23, 12, 0, 0, 0, time.Local)
+	next := timer.sched.Next(base)
+	assert.Equal(t, 0, next.Hour())
+	assert.Equal(t, 15, next.Minute())
+	assert.Equal(t, base.AddDate(0, 0, 1).Day(), next.Day())
+}
+
+func TestScheduleTimerCronDescriptor(t *testing.T) {
+	timer, err := schedule{Interval: "@daily"}.timer(time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, timer.sched)
+}
+
+func TestScheduleTimerCronImpossible(t *testing.T) {
+	// syntactically valid but never matches (Feb 30) -> zero next-fire.
+	// Must be rejected so C() cannot busy-loop.
+	_, err := schedule{Interval: "0 0 30 2 *"}.timer(time.Hour)
+	require.Error(t, err)
+}
+
+func TestScheduleTimerInvalid(t *testing.T) {
+	_, err := schedule{Interval: "nonsense"}.timer(time.Hour)
+	require.Error(t, err)
+}
+
+func TestScheduleTimerStale(t *testing.T) {
+	// duration-based: stale once interval has elapsed since updated
+	timer, err := schedule{Interval: "1h"}.timer(time.Hour)
+	require.NoError(t, err)
+	assert.False(t, timer.stale(time.Now().Add(-30*time.Minute)))
+	assert.True(t, timer.stale(time.Now().Add(-2*time.Hour)))
+
+	// cron-based: stale once a scheduled fire has passed since updated
+	timer, err = schedule{Interval: "15 0 * * *"}.timer(time.Hour)
+	require.NoError(t, err)
+	// updated a minute ago -> next 00:15 not yet reached (unless run at 00:14)
+	assert.False(t, timer.stale(time.Now().Add(-time.Minute)))
+	// updated more than a day ago -> a 00:15 fire has certainly passed
+	assert.True(t, timer.stale(time.Now().Add(-25*time.Hour)))
+}
+
+func TestScheduleTimerC(t *testing.T) {
+	timer, err := schedule{Interval: "10ms"}.timer(time.Hour)
+	require.NoError(t, err)
+
+	select {
+	case <-timer.C():
+	case <-time.After(time.Second):
+		t.Fatal("timer did not fire")
+	}
+}

--- a/tariff/smartenergy.go
+++ b/tariff/smartenergy.go
@@ -58,6 +58,7 @@ func (t *SmartEnergy) run(done chan error) {
 	var once sync.Once
 	client := request.NewHelper(t.log)
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res smartenergy.Prices
 

--- a/tariff/smartenergy.go
+++ b/tariff/smartenergy.go
@@ -14,8 +14,9 @@ import (
 
 type SmartEnergy struct {
 	*embed
-	log  *util.Logger
-	data *util.Monitor[api.Rates]
+	log   *util.Logger
+	data  *util.Monitor[api.Rates]
+	timer *refreshTimer
 }
 
 var _ api.Tariff = (*SmartEnergy)(nil)
@@ -26,7 +27,8 @@ func init() {
 
 func NewSmartEnergyFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
-		embed `mapstructure:",squash"`
+		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -37,10 +39,16 @@ func NewSmartEnergyFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	t := &SmartEnergy{
 		embed: &cc.embed,
 		log:   util.NewLogger("smartenergy"),
-		data:  util.NewMonitor[api.Rates](2 * time.Hour),
+		data:  util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer: timer,
 	}
 
 	return runOrError(t)
@@ -50,7 +58,7 @@ func (t *SmartEnergy) run(done chan error) {
 	var once sync.Once
 	client := request.NewHelper(t.log)
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res smartenergy.Prices
 
 		if err := backoff.Retry(func() error {

--- a/tariff/solcast.go
+++ b/tariff/solcast.go
@@ -82,6 +82,7 @@ func NewSolcastFromConfig(other map[string]any) (api.Tariff, error) {
 func (t *Solcast) run(done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		// ensure we don't run when not needed, but execute once at startup
 		select {

--- a/tariff/solcast.go
+++ b/tariff/solcast.go
@@ -22,6 +22,7 @@ type Solcast struct {
 	site   string
 	fromTo FromTo
 	data   *util.Monitor[api.Rates]
+	timer  *refreshTimer
 }
 
 var _ api.Tariff = (*Solcast)(nil)
@@ -31,16 +32,19 @@ func init() {
 }
 
 func NewSolcastFromConfig(other map[string]any) (api.Tariff, error) {
-	cc := struct {
+	var cc struct {
 		Site     string
 		Token    string
-		Interval time.Duration
+		schedule `mapstructure:",squash"`
 		FromTo   `mapstructure:",squash"`
-	}{
-		Interval: 3 * time.Hour,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	timer, err := cc.schedule.timer(3 * time.Hour)
+	if err != nil {
 		return nil, err
 	}
 
@@ -59,13 +63,14 @@ func NewSolcastFromConfig(other map[string]any) (api.Tariff, error) {
 		site:   cc.Site,
 		Helper: request.NewHelper(log),
 		fromTo: cc.FromTo,
-		data:   util.NewMonitor[api.Rates](2 * cc.Interval),
+		timer:  timer,
+		data:   util.NewMonitor[api.Rates](timer.window()),
 	}
 
 	t.Client.Transport = transport.BearerAuth(cc.Token, t.Client.Transport)
 
 	done := make(chan error)
-	go t.run(cc.Interval, done)
+	go t.run(done)
 
 	if err := <-done; err != nil {
 		return nil, err
@@ -74,10 +79,10 @@ func NewSolcastFromConfig(other map[string]any) (api.Tariff, error) {
 	return t, nil
 }
 
-func (t *Solcast) run(interval time.Duration, done chan error) {
+func (t *Solcast) run(done chan error) {
 	var once sync.Once
 
-	for ; true; <-time.Tick(interval) {
+	for tick := t.timer.C(); ; <-tick {
 		// ensure we don't run when not needed, but execute once at startup
 		select {
 		case <-t.data.Done():

--- a/tariff/stekker.go
+++ b/tariff/stekker.go
@@ -31,6 +31,7 @@ type Stekker struct {
 	interval time.Duration
 	log      *util.Logger
 	data     *util.Monitor[api.Rates]
+	timer    *refreshTimer
 }
 
 var _ api.Tariff = (*Stekker)(nil)
@@ -44,8 +45,9 @@ const stekkerURI = "https://stekker.app/epex-forecast"
 // NewStekkerFromConfig creates provider from config
 func NewStekkerFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
-		embed  `mapstructure:",squash"`
-		Region string
+		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
+		Region   string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -57,6 +59,11 @@ func NewStekkerFromConfig(other map[string]any) (api.Tariff, error) {
 	}
 
 	if err := cc.init(); err != nil {
+		return nil, err
+	}
+
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
 		return nil, err
 	}
 
@@ -76,7 +83,8 @@ func NewStekkerFromConfig(other map[string]any) (api.Tariff, error) {
 		region:   cc.Region,
 		interval: interval,
 		log:      util.NewLogger("stekker"),
-		data:     util.NewMonitor[api.Rates](2 * time.Hour),
+		data:     util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:    timer,
 	}
 
 	return runOrError(t)
@@ -86,7 +94,7 @@ func (t *Stekker) run(done chan error) {
 	var once sync.Once
 	client := request.NewHelper(t.log)
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		url := fmt.Sprintf("%s?advanced_view=&region=%s&unit=MWh", stekkerURI, t.region)
 		resp, err := client.Get(url)
 		if err != nil {

--- a/tariff/stekker.go
+++ b/tariff/stekker.go
@@ -94,6 +94,7 @@ func (t *Stekker) run(done chan error) {
 	var once sync.Once
 	client := request.NewHelper(t.log)
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		url := fmt.Sprintf("%s?advanced_view=&region=%s&unit=MWh", stekkerURI, t.region)
 		resp, err := client.Get(url)

--- a/tariff/tariff.go
+++ b/tariff/tariff.go
@@ -20,6 +20,7 @@ type Tariff struct {
 	data   *util.Monitor[api.Rates]
 	priceG func() (float64, error)
 	typ    api.TariffType
+	timer  *refreshTimer
 }
 
 var _ api.Tariff = (*Tariff)(nil)
@@ -31,17 +32,21 @@ func init() {
 func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.Tariff, error) {
 	cc := struct {
 		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
 		Price    *plugin.Config
 		Forecast *plugin.Config
 		Type     api.TariffType `mapstructure:"tariff"`
-		Interval time.Duration
 		Cache    time.Duration
 	}{
-		Interval: time.Hour,
-		Cache:    15 * time.Minute,
+		Cache: 15 * time.Minute,
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
+		return nil, err
+	}
+
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
 		return nil, err
 	}
 
@@ -71,12 +76,13 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.T
 		embed:  &cc.embed,
 		typ:    cc.Type,
 		priceG: priceG,
-		data:   util.NewMonitor[api.Rates](2 * cc.Interval),
+		timer:  timer,
+		data:   util.NewMonitor[api.Rates](timer.window()),
 	}
 
 	if forecastG != nil {
 		done := make(chan error)
-		go t.run(forecastG, done, cc.Interval)
+		go t.run(forecastG, done)
 
 		if err := <-done; err != nil {
 			return nil, err
@@ -86,10 +92,10 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.T
 	return t, nil
 }
 
-func (t *Tariff) run(forecastG func() (string, error), done chan error, interval time.Duration) {
+func (t *Tariff) run(forecastG func() (string, error), done chan error) {
 	var once sync.Once
 
-	for tick := time.Tick(interval); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var data api.Rates
 		if err := backoff.Retry(func() error {
 			s, err := forecastG()

--- a/tariff/tariff.go
+++ b/tariff/tariff.go
@@ -95,6 +95,7 @@ func NewConfigurableFromConfig(ctx context.Context, other map[string]any) (api.T
 func (t *Tariff) run(forecastG func() (string, error), done chan error) {
 	var once sync.Once
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var data api.Rates
 		if err := backoff.Retry(func() error {

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -84,6 +84,7 @@ func (t *Tibber) run(done chan error) {
 		"id": graphql.ID(t.homeID),
 	}
 
+	defer t.timer.Stop()
 	for tick := t.timer.C(); ; <-tick {
 		var res struct {
 			Viewer struct {

--- a/tariff/tibber.go
+++ b/tariff/tibber.go
@@ -20,6 +20,7 @@ type Tibber struct {
 	homeID string
 	client *tibber.Client
 	data   *util.Monitor[api.Rates]
+	timer  *refreshTimer
 }
 
 var _ api.Tariff = (*Tibber)(nil)
@@ -30,9 +31,10 @@ func init() {
 
 func NewTibberFromConfig(other map[string]any) (api.Tariff, error) {
 	var cc struct {
-		embed  `mapstructure:",squash"`
-		Token  string
-		HomeID string
+		embed    `mapstructure:",squash"`
+		schedule `mapstructure:",squash"`
+		Token    string
+		HomeID   string
 	}
 
 	if err := util.DecodeOther(other, &cc); err != nil {
@@ -47,6 +49,11 @@ func NewTibberFromConfig(other map[string]any) (api.Tariff, error) {
 		return nil, err
 	}
 
+	timer, err := cc.schedule.timer(time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
 	log := util.NewLogger("tibber").Redact(cc.Token, cc.HomeID)
 
 	t := &Tibber{
@@ -54,7 +61,8 @@ func NewTibberFromConfig(other map[string]any) (api.Tariff, error) {
 		log:    log,
 		homeID: cc.HomeID,
 		client: tibber.NewClient(log, cc.Token),
-		data:   util.NewMonitor[api.Rates](2 * time.Hour),
+		data:   util.NewMonitor[api.Rates](max(2*time.Hour, timer.window())),
+		timer:  timer,
 	}
 
 	if t.homeID == "" {
@@ -76,7 +84,7 @@ func (t *Tibber) run(done chan error) {
 		"id": graphql.ID(t.homeID),
 	}
 
-	for tick := time.Tick(time.Hour); ; <-tick {
+	for tick := t.timer.C(); ; <-tick {
 		var res struct {
 			Viewer struct {
 				Home struct {

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -458,8 +458,8 @@ params:
       de: Intervall
       en: Interval
     help:
-      en: 'How often to refresh: a duration like `15m`, `1h`, `24h`, or a cron expression `minute hour day month weekday` such as `15 0 * * *` (daily at 00:15, local time).'
-      de: 'Aktualisierungsrhythmus: eine Dauer wie `15m`, `1h`, `24h`, oder ein Cron-Ausdruck `Minute Stunde Tag Monat Wochentag` wie `15 0 * * *` (täglich um 00:15, Ortszeit).'
+      en: "How often to refresh: a duration like `15m`, `1h`, `24h`, or a cron expression `minute hour day month weekday` such as `15 0 * * *` (daily at 00:15, local time)."
+      de: "Aktualisierungsrhythmus: eine Dauer wie `15m`, `1h`, `24h`, oder ein Cron-Ausdruck `Minute Stunde Tag Monat Wochentag` wie `15 0 * * *` (täglich um 00:15, Ortszeit)."
   - name: mac
     private: true
     description:

--- a/util/templates/defaults.yaml
+++ b/util/templates/defaults.yaml
@@ -457,6 +457,9 @@ params:
     description:
       de: Intervall
       en: Interval
+    help:
+      en: 'How often to refresh: a duration like `15m`, `1h`, `24h`, or a cron expression `minute hour day month weekday` such as `15 0 * * *` (daily at 00:15, local time).'
+      de: 'Aktualisierungsrhythmus: eine Dauer wie `15m`, `1h`, `24h`, oder ein Cron-Ausdruck `Minute Stunde Tag Monat Wochentag` wie `15 0 * * *` (täglich um 00:15, Ortszeit).'
   - name: mac
     private: true
     description:

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -307,7 +307,8 @@ func (p *Param) IsZero(s string) bool {
 
 // yamlQuote quotes strings for yaml if they would otherwise by modified by the unmarshaler
 func (p *Param) yamlQuote(value string) string {
-	if p.Type != TypeString {
+	// TypeDuration may hold a cron expression, which needs quoting like a string
+	if p.Type != TypeString && p.Type != TypeDuration {
 		return value
 	}
 

--- a/util/templates/types_test.go
+++ b/util/templates/types_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestParamLogic(t *testing.T) {
@@ -73,5 +74,19 @@ func TestParamMarshal(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, `{"Name":"","Description":"foo","Help":"","Type":"String"}`, string(b))
 		}
+	}
+}
+
+func TestParamYamlQuoteDuration(t *testing.T) {
+	p := Param{Name: "interval", Type: TypeDuration}
+
+	for _, value := range []string{"3h", "15m", "15 0 * * *", "*/15 * * * *", "@daily", "@hourly"} {
+		rendered := "interval: " + p.yamlQuote(value)
+
+		var out struct {
+			Interval string `yaml:"interval"`
+		}
+		require.NoError(t, yaml.Unmarshal([]byte(rendered), &out), "value %q rendered invalid yaml: %q", value, rendered)
+		assert.Equal(t, value, out.Interval, "value %q did not round-trip", value)
 	}
 }


### PR DESCRIPTION
Most tariff providers refresh on a hardcoded interval (usually hourly), with no way to schedule a fetch at a fixed time of day. This adds a shared `schedule` config type: `interval` now accepts either a duration (`15m`, `1h`, `24h`) or a standard cron expression (`15 0 * * *`, `@daily`, `@every 1h30m`), evaluated in local time (`CRON_TZ=` prefix supported). It's squashed into every tariff provider's config, the generic `custom`/Configurable tariff, and the caching proxy, so any tariff can now be pinned to e.g. a single daily fetch instead of polling continuously.

- `tariff/schedule.go`: new `schedule`/`refreshTimer` types — auto-detects duration vs. cron, rejects impossible cron expressions (e.g. Feb 30) at config time so the refresh goroutine can't busy-loop
- all `time.Tick(fixedInterval)` refresh loops replaced with `timer.C()`
- fixed a related bug found along the way: most providers sized their `util.Monitor` staleness window as a hardcoded `2 * time.Hour`, independent of the actual refresh interval. With a day-long cron schedule that made `Rates()` report outdated data long before the next scheduled fetch. The window is now derived from the timer (`max(2h, timer.window())`, the floor keeps today's failure tolerance for fast-polling providers)
- `PropertyField.vue`: interval fields get a "cron" unit option that switches the input to free text with a loose client-side pattern check (backend stays authoritative)
- moved the interval help text into `util/templates/defaults.yaml` instead of duplicating it across the seven tariff templates