### PR TITLE
Sungrow: add grid returnenergy and battery returnenergy

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -56,7 +56,7 @@ render: |
     source: modbus
     {{- include "modbus" . | indent 2 }}
     register:
-      address: 13005 # Total export energy from PV, 0.1kWh
+      address: 13045 # Total export energy, 0.1kWh
       type: input
       decode: uint32s
     scale: 0.1

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -52,6 +52,14 @@ render: |
       type: input
       decode: uint32s
     scale: 0.1
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 13005 # Total export energy from PV, 0.1kWh
+      type: input
+      decode: uint32s
+    scale: 0.1
   currents:
   - source: calc
     div:
@@ -159,6 +167,14 @@ render: |
     {{- include "modbus" . | indent 2 }}
     register:
       address: 13026 # Total battery discharge energy, 0.1kWh
+      type: input
+      decode: uint32s
+    scale: 0.1
+  returnenergy:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 13040 # Total Charge Energy (Accumulated charge of batteries), 0.1kWh
       type: input
       decode: uint32s
     scale: 0.1


### PR DESCRIPTION
This implementation adds "grid returnenergy" and "battery returnenergy" to Sungrow devices.

From Communication Protocol of Residential and Small Industrial Hybrid Inverter_V1.1.16.pdf (register numbers are reduced by 1 in the source code):

| No. | Name                    | Register | Data type | Data range | Unit/Ratio | Remarks |
|-----|-------------------------|----------|-----------|------------|------------|---------|
| 117. | Total Charge Energy  | 13041~13042    | U32       |            | 0.1 kWh    |  Accumulated charge of batteries        |
| 121. | Total export energy   | 13046~13047    | U32       |            | 0.1 kWh    | Accumulated electricity delivered by the inverter to the grid through PV modules or batteries. (See note 1)   |

Edited: Wrong register used before