### PR TITLE
chore: expand GOROOT lazily in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ IMAGE_FILE := evcc_$(TAG_NAME).img
 PACKAGES = ./release
 
 # asn1-patch
-GOROOT := $(shell go env GOROOT)
+GOROOT = $(shell go env GOROOT)
 CURRDIR := $(shell pwd)
 
 default:: ui build


### PR DESCRIPTION
Every make invocation ran `go env GOROOT` at parse time because of the immediate `:=` assignment. In the Docker node stage `make ui` has no Go toolchain, so each build printed `make: go: No such file or directory`. `GOROOT` is only consumed by the `patch-asn1` targets, which run in the Go builder stage, so deferring expansion is enough.

- switch `GOROOT` to lazy `=` assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)