### PR TITLE
UI: fix blurred energy flow bar labels in Safari

### DIFF
--- a/assets/js/components/Energyflow/Visualization.vue
+++ b/assets/js/components/Energyflow/Visualization.vue
@@ -236,6 +236,8 @@ export default defineComponent({
 	display: flex;
 	overflow: hidden;
 	margin-right: 1.2rem;
+	/* Safari composites the width-animated bars without subpixel antialiasing, blurring labels on 1x displays */
+	-webkit-font-smoothing: antialiased;
 }
 .label-scale-name {
 	color: var(--evcc-gray);


### PR DESCRIPTION
fixes #33039, replaces #33057

Safari on macOS promotes the width-animated energy flow bars (overflow hidden, border radius, width transition) to a composited layer and rasterizes their labels without subpixel antialiasing, which blurs the text on standard-DPI displays. This forces grayscale antialiasing scoped to the bar container, avoiding the global typography change from the previous attempt.

- add `-webkit-font-smoothing: antialiased` to the energy flow bar container

🤖 Generated with [Claude Code](https://claude.com/claude-code)