### PR TITLE
Huawei SUN2000 Hybrid: only read the feed-in limit in percentage mode

### DIFF
--- a/meter/huawei_sun2000_hybrid_test.go
+++ b/meter/huawei_sun2000_hybrid_test.go
@@ -1,0 +1,95 @@
+package meter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evcc-io/evcc/plugin"
+	"github.com/evcc-io/evcc/util/templates"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// huaweiCurtailedReader renders the pv usage of the huawei-sun2000-hybrid
+// template and returns its curtailed reader with the modbus inputs replaced
+// by the given constants, keyed by input name.
+func huaweiCurtailedReader(t *testing.T, inputs map[string]any) func() (int64, error) {
+	t.Helper()
+
+	tmpl, err := templates.ByName(templates.Meter, "huawei-sun2000-hybrid")
+	require.NoError(t, err)
+
+	b, _, err := tmpl.RenderResult(templates.Meter, templates.RenderModeInstance, map[string]any{
+		"usage":      "pv",
+		"modbus":     "tcpip",
+		"host":       "127.0.0.1",
+		"port":       502,
+		"maxacpower": 11000,
+	})
+	require.NoError(t, err)
+
+	var rendered struct {
+		Curtailed map[string]any `yaml:"curtailed"`
+	}
+	require.NoError(t, yaml.Unmarshal(b, &rendered))
+	require.NotEmpty(t, rendered.Curtailed, "curtailed reader missing")
+
+	in, ok := rendered.Curtailed["in"].([]any)
+	require.True(t, ok, "curtailed reader has no inputs")
+
+	seen := map[string]bool{}
+	for _, i := range in {
+		input := i.(map[string]any)
+		name := input["name"].(string)
+		value, ok := inputs[name]
+		require.True(t, ok, "no test value for input %s", name)
+		input["config"] = map[string]any{"source": "const", "value": value}
+		seen[name] = true
+	}
+	for name := range inputs {
+		require.True(t, seen[name], "template has no input %s", name)
+	}
+
+	delete(rendered.Curtailed, "source")
+
+	p, err := plugin.NewGoPluginFromConfig(context.Background(), rendered.Curtailed)
+	require.NoError(t, err)
+
+	g, err := p.(plugin.IntGetter).IntGetter()
+	require.NoError(t, err)
+
+	return g
+}
+
+// The curtailed reader must map every active power control mode (47415) to
+// the feed-in limit as percent of nominal, not just the percentage mode 7.
+func TestHuaweiSun2000HybridCurtailed(t *testing.T) {
+	for _, tc := range []struct {
+		name                       string
+		mode, percent, watt, rated int
+		want                       int64
+	}{
+		{"unlimited", 0, 0, 0, 11000, 100},
+		{"di scheduling is unknown, treat as uncurtailed", 1, 0, 0, 11000, 100},
+		{"zero export", 5, 0, 0, 11000, 0},
+		{"kw limit relative to nominal", 6, 0, 6300, 11000, 57},
+		{"kw limit above nominal clamps to 100", 6, 0, 12000, 11000, 100},
+		{"kw limit without nominal is uncurtailed", 6, 0, 6300, 0, 100},
+		{"negative kw limit clamps to 0", 6, 0, -1000, 11000, 0},
+		{"percent limit", 7, 63, 0, 11000, 63},
+		{"percent limit ignores stale kw register", 7, 63, 6300, 11000, 63},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := huaweiCurtailedReader(t, map[string]any{
+				"mode":    tc.mode,
+				"percent": tc.percent,
+				"watt":    tc.watt,
+				"rated":   tc.rated,
+			})
+
+			got, err := g()
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -266,7 +266,7 @@ render: |
         source: modbus
         {{- include "modbus" . | indent 6 }}
         register:
-          address: 47415 # Active power control mode (0=no curtailment)
+          address: 47415 # Active power control mode (7=percentage feed-in limit)
           type: holding
           decode: uint16
     - name: percent
@@ -279,10 +279,12 @@ render: |
           type: holding
           decode: uint16
         scale: 0.1
-    # the percentage register is only meaningful while a limit mode is active
+    # 47418 only holds the feed-in limit in mode 7, the same mode the curtail
+    # setter above writes. any other mode (unlimited, DI scheduling, zero
+    # export, kW limit) leaves it unused and it then reads 0
     script: |
       limit := percent
-      if mode == 0 {
+      if mode != 7 {
         limit = 100
       }
       limit

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -266,7 +266,7 @@ render: |
         source: modbus
         {{- include "modbus" . | indent 6 }}
         register:
-          address: 47415 # Active power control mode (7=percentage feed-in limit)
+          address: 47415 # Active power control mode
           type: holding
           decode: uint16
     - name: percent
@@ -275,17 +275,53 @@ render: |
         source: modbus
         {{- include "modbus" . | indent 6 }}
         register:
-          address: 47418 # Maximum Feed Grid Power (0-100 %)
+          address: 47418 # Maximum Feed Grid Power (0-100 %), mode 7
           type: holding
           decode: uint16
         scale: 0.1
-    # 47418 only holds the feed-in limit in mode 7, the same mode the curtail
-    # setter above writes. any other mode (unlimited, DI scheduling, zero
-    # export, kW limit) leaves it unused and it then reads 0
+    - name: watt
+      type: int
+      config:
+        source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 47416 # Maximum Feed Grid Power (W), mode 6
+          type: holding
+          decode: int32
+    - name: rated
+      type: int
+      config:
+        source: cached
+        cache: 1h # rated max is static
+        value:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 30075 # Maximum active power P_max (W)
+            type: holding
+            decode: uint32
+    # feed-in limit as percent of nominal, per active power control mode (47415):
+    #   7 percentage limit -> 47418 (the mode the curtail setter above writes)
+    #   6 kW limit         -> 47416 relative to the inverter rated power
+    #   5 zero export      -> 0
+    #   0 unlimited, 1 DI scheduling (limit not readable) -> 100
     script: |
-      limit := percent
-      if mode != 7 {
+      limit := 100
+      switch mode {
+      case 7:
+        limit = percent
+      case 6:
+        if rated > 0 {
+          limit = watt * 100 / rated
+        }
+      case 5:
+        limit = 0
+      }
+      if limit > 100 {
         limit = 100
+      }
+      if limit < 0 { // 47416 allows negative values
+        limit = 0
       }
       limit
   {{- end }}


### PR DESCRIPTION
The `curtailed` reader treats every non-zero active power control mode (47415) as a percentage feed-in limit and then reads 47418. That register only carries the limit in mode 7 — the very mode the `curtail` setter in the same template writes, and the same gate the emma template already uses.

With remote scheduling enabled ("Plan Remote-Stromversorgung"), 47415 is non-zero while 47418 is unused and reads 0. evcc then reports a 0% feed-in limit and flags the pv meter as curtailed although the inverter runs unrestricted.

Seen on my own SUN2000 hybrid: the installer app shows active power at 100%, 11 kW / 11 kVA, no derating and "shut down at 0% power limit" off — while evcc showed "Production limited, feed-in limit 0%". With this change the banner is gone and `curtailable: yes` remains, which is correct.

Not addressed here: the kW limit mode (47416) and zero export are now silently treated as uncurtailed rather than converted. That is the same behaviour as before for mode 0 and better than the current false 0%, but it would be worth handling explicitly in a follow-up.
