### PR TITLE
Templates: pass bool params as real booleans

### DIFF
--- a/assets/js/components/Config/DeviceModal/index.test.ts
+++ b/assets/js/components/Config/DeviceModal/index.test.ts
@@ -129,6 +129,17 @@ describe("applyDefaultsFromTemplate", () => {
     expect(values["phases1p3p"]).toBe(false);
   });
 
+  it("coerces stored string values of Bool params to booleans", () => {
+    const params = [
+      { ...buildParam("phases1p3p"), Type: "Bool", Default: "true" },
+      { ...buildParam("heating"), Type: "Bool" },
+    ];
+    const values: Record<string, any> = { phases1p3p: "false", heating: "true" };
+    applyDefaultsFromTemplate(template(params), values as any);
+    expect(values["phases1p3p"]).toBe(false);
+    expect(values["heating"]).toBe(true);
+  });
+
   it("applies plain defaults for other params", () => {
     const params = [{ ...buildParam("device_id"), Default: "0" }];
     const values: Record<string, any> = {};

--- a/assets/js/components/Config/DeviceModal/index.test.ts
+++ b/assets/js/components/Config/DeviceModal/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createServiceEndpoints, type TemplateParam } from "./index";
+import { applyDefaultsFromTemplate, createServiceEndpoints, type TemplateParam } from "./index";
 
 const buildParam = (name: string, service?: string): TemplateParam => ({
   Name: name,
@@ -98,5 +98,41 @@ describe("createServiceEndpoints", () => {
     expect(endpoints[0]!.url({ home: "" })).toBe("homes/{home}/sensors");
     // Non-empty value should replace placeholder
     expect(endpoints[0]!.url({ home: "main" })).toBe("homes/main/sensors");
+  });
+});
+
+describe("applyDefaultsFromTemplate", () => {
+  const template = (params: TemplateParam[]) => ({ Params: params }) as any;
+
+  it("coerces string defaults of Bool params to booleans", () => {
+    const params = [
+      { ...buildParam("measurements"), Type: "Bool", Default: "false" },
+      { ...buildParam("enabled"), Type: "Bool", Default: "true" },
+    ];
+    const values: Record<string, any> = {};
+    applyDefaultsFromTemplate(template(params), values as any);
+    expect(values["measurements"]).toBe(false);
+    expect(values["enabled"]).toBe(true);
+  });
+
+  it("initializes Bool params without default to false", () => {
+    const params = [{ ...buildParam("flag"), Type: "Bool" }];
+    const values: Record<string, any> = {};
+    applyDefaultsFromTemplate(template(params), values as any);
+    expect(values["flag"]).toBe(false);
+  });
+
+  it("keeps an explicitly stored false against a true default", () => {
+    const params = [{ ...buildParam("phases1p3p"), Type: "Bool", Default: "true" }];
+    const values: Record<string, any> = { phases1p3p: false };
+    applyDefaultsFromTemplate(template(params), values as any);
+    expect(values["phases1p3p"]).toBe(false);
+  });
+
+  it("applies plain defaults for other params", () => {
+    const params = [{ ...buildParam("device_id"), Default: "0" }];
+    const values: Record<string, any> = {};
+    applyDefaultsFromTemplate(template(params), values as any);
+    expect(values["device_id"]).toBe("0");
   });
 });

--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -103,10 +103,10 @@ export function applyDefaultsFromTemplate(template: Template | null, values: Dev
   const params = template?.Params || [];
   params.forEach((p) => {
     if (p.Type === "Bool") {
-      if (values[p.Name] === undefined) {
-        // template defaults are strings, the form model uses real booleans
-        values[p.Name] = p.Default === "true";
-      }
+      // template defaults are strings, and configs stored before bool params
+      // became real booleans hold "true"/"false" - the form model uses booleans
+      const v = values[p.Name] === undefined ? p.Default : values[p.Name];
+      values[p.Name] = v === true || v === "true";
     } else if (p.Default && !values[p.Name]) {
       values[p.Name] = p.Default;
     }

--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -102,10 +102,13 @@ export function handleError(e: any, msg: string) {
 export function applyDefaultsFromTemplate(template: Template | null, values: DeviceValues) {
   const params = template?.Params || [];
   params.forEach((p) => {
-    if (p.Default && !values[p.Name]) {
+    if (p.Type === "Bool") {
+      if (values[p.Name] === undefined) {
+        // template defaults are strings, the form model uses real booleans
+        values[p.Name] = p.Default === "true";
+      }
+    } else if (p.Default && !values[p.Name]) {
       values[p.Name] = p.Default;
-    } else if (p.Type === "Bool" && values[p.Name] === undefined) {
-      values[p.Name] = false; // initialize
     }
   });
 }

--- a/templates/definition/charger/demo-charger.yaml
+++ b/templates/definition/charger/demo-charger.yaml
@@ -62,7 +62,7 @@ render: |
   power:
     source: const
     value: {{ .power }}
-  {{ if eq .phases1p3p "true" }}
+  {{ if .phases1p3p }}
   phases1p3p:
     source: js
     script: |

--- a/templates/definition/charger/features.tpl
+++ b/templates/definition/charger/features.tpl
@@ -1,10 +1,10 @@
 {{ define "features" }}
-{{- if or (eq .heating "true") (eq .integrateddevice "true") }}
+{{- if or .heating .integrateddevice }}
 features:
-{{- if eq .heating "true" }}
+{{- if .heating }}
 - heating
 {{- end }}
-{{- if eq .integrateddevice "true" }}
+{{- if .integrateddevice }}
 - integrateddevice
 {{- end }}
 {{- end }}

--- a/templates/definition/charger/keba-modbus-p40.yaml
+++ b/templates/definition/charger/keba-modbus-p40.yaml
@@ -28,6 +28,6 @@ params:
 render: |
   type: keba-modbus
   {{- include "modbus" . }}
-  {{- if eq .welcomecharge "true" }}
+  {{- if .welcomecharge }}
   features: ["welcomecharge"]
   {{- end }}

--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -29,6 +29,6 @@ params:
 render: |
   type: keba-modbus
   {{- include "modbus" . }}
-  {{- if eq .welcomecharge "true" }}
+  {{- if .welcomecharge }}
   features: ["welcomecharge"]
   {{- end }}

--- a/templates/definition/charger/lg-therma.yaml
+++ b/templates/definition/charger/lg-therma.yaml
@@ -96,7 +96,7 @@ render: |
       address: {{ if eq .tempsource "water_inlet" -}} 2 {{ else }} 5 {{- end }} # 5 DHW Tank Temperatur, 2 Wassereinlasstemperatur
       type: input
       encoding: uint16
-  {{- if eq .haspower "true" }}
+  {{- if .haspower }}
   power:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/charger/nibe-s-series.yaml
+++ b/templates/definition/charger/nibe-s-series.yaml
@@ -57,7 +57,7 @@ render: |
           set:
             source: sequence
             set:
-  {{- if eq .powercontrol "true" }}
+  {{- if .powercontrol }}
               - source: const
                 value: 1
                 set:
@@ -80,7 +80,7 @@ render: |
           set:
             source: sequence
             set:
-  {{- if eq .powercontrol "true" }}
+  {{- if .powercontrol }}
               - source: const
                 value: 0
                 set:
@@ -103,7 +103,7 @@ render: |
           set:
             source: sequence
             set:
-  {{- if eq .powercontrol "true" }}
+  {{- if .powercontrol }}
               - source: const
                 value: 1
                 set:
@@ -160,7 +160,7 @@ render: |
       type: input
       encoding: uint16
     scale: 0.1
-  {{- if eq .powercontrol "true" }}
+  {{- if .powercontrol }}
   setmaxpower:
     source: modbus
     {{- include "modbus" . | indent 2 }}

--- a/templates/definition/charger/nrggen2.yaml
+++ b/templates/definition/charger/nrggen2.yaml
@@ -23,6 +23,6 @@ params:
 render: |
   type: nrggen2
   {{- include "modbus" . }}
-  {{- if ne .phases1p3p "false" }}
+  {{- if .phases1p3p }}
   phases1p3p: true
   {{- end }}

--- a/templates/definition/charger/ocpp-autel.yaml
+++ b/templates/definition/charger/ocpp-autel.yaml
@@ -30,6 +30,6 @@ params:
   - preset: ocpp
 render: |
   {{ include "ocpp" . }}
-  {{- if ne .remotestart "true" }}
+  {{- if not .remotestart }}
   remotestart: true # force remotestart
   {{- end }}

--- a/templates/definition/charger/ocpp-evbox-elvi.yaml
+++ b/templates/definition/charger/ocpp-evbox-elvi.yaml
@@ -22,7 +22,7 @@ render: |
   {{- $ocpp := . }}
   {{- if not .metervalues }}
   {{- $metervalues := "-Current.Offered,Power.Offered,SoC" }}
-  {{- if eq .meter "false" }}
+  {{- if not .meter }}
   {{- $metervalues = "Current.Offered" }}
   {{- end }}
   {{- $ocpp = merge . (dict "metervalues" $metervalues) }}

--- a/templates/definition/charger/ocpp.tpl
+++ b/templates/definition/charger/ocpp.tpl
@@ -9,7 +9,7 @@ connector: {{ .connector }}
 {{- if .idtag }}
 idtag: {{ .idtag }}
 {{- end }}
-{{- if and .remotestart (ne .remotestart "false") }}
+{{- if .remotestart }}
 remotestart: {{ .remotestart }}
 {{- end }}
 {{- if .metervalues }}

--- a/templates/definition/charger/openwb.yaml
+++ b/templates/definition/charger/openwb.yaml
@@ -22,6 +22,6 @@ render: |
   type: openwb
   broker: {{ .host }}
   id: {{ .connector }} # loadpoint id
-  {{- if ne .phases1p3p "false" }}
+  {{- if .phases1p3p }}
   phases1p3p: true
   {{- end }}

--- a/templates/definition/charger/phoenix-ev-eth.yaml
+++ b/templates/definition/charger/phoenix-ev-eth.yaml
@@ -54,6 +54,6 @@ params:
 render: |
   type: phoenix-ev-eth
   {{- include "modbus" . }}
-  {{- if eq .millicurrentsupported "true" }}
+  {{- if .millicurrentsupported }}
   millicurrentsupported: true
   {{- end }}

--- a/templates/definition/charger/switchsocket.tpl
+++ b/templates/definition/charger/switchsocket.tpl
@@ -2,10 +2,10 @@
 standbypower: {{ .standbypower }}
 features:
 - switchdevice
-{{- if and .integrateddevice (ne .integrateddevice "false") }}
+{{- if .integrateddevice }}
 - integrateddevice
 {{- end }}
-{{- if and .heating (ne .heating "false") }}
+{{- if .heating }}
 - heating
 {{- end }}
 {{- if .icon }}

--- a/templates/definition/meter/batterx.yaml
+++ b/templates/definition/meter/batterx.yaml
@@ -12,6 +12,7 @@ params:
     default: 80
   - name: externalpv
     type: bool
+    default: true
     description:
       de: |
         Benötigt bei ein weiterer Solarwechselrichter.
@@ -37,7 +38,7 @@ render: |
     jq: .["2913"].["0"] # Grid meter (Power Total in W)
   {{- end }}
   {{- if eq .usage "pv" }}
-  {{- if ne .externalpv "false" }}
+  {{- if .externalpv }}
     jq: .["2913"].["3"] + .["1634"].["0"] # External Solar + BatterX Solar (Power Total in W)
   {{- else }}
     jq: .["1634"].["0"] # BatterX Solar (Power Total in W)

--- a/templates/definition/meter/demo-meter.yaml
+++ b/templates/definition/meter/demo-meter.yaml
@@ -60,7 +60,7 @@ render: |
   power:
     source: const
     value: {{ .power }}
-  {{- if eq .curtailable "true" }}
+  {{- if .curtailable }}
   curtail:
     source: js
     vm: shared

--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -105,7 +105,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -118,7 +118,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   currents:
@@ -236,7 +236,7 @@ render: |
       {{- if eq .batterytype "hv" }}  
       scale: 10
       {{- end }}
-    {{- if eq .includegenport "true" }}
+    {{- if .includegenport }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -261,10 +261,10 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
+      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
       scale: 0.1
       {{- end }}
-    {{- if eq .includegenport "true" }}
+    {{- if .includegenport }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:
@@ -274,7 +274,7 @@ render: |
       block: # 516-538
         register: 516
         count: 23
-      {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
+      {{- if or (eq .batterytype "lv") (not .firmware1098) }}
       scale: 0.1
       {{- end }}
     {{- end }}
@@ -347,7 +347,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   returnenergy:
@@ -360,7 +360,7 @@ render: |
     block: # 516-538
       register: 516
       count: 23
-    {{- if or (eq .batterytype "lv") (ne .firmware1098 "true") }}
+    {{- if or (eq .batterytype "lv") (not .firmware1098) }}
     scale: 0.1
     {{- end }}
   soc:

--- a/templates/definition/meter/huawei-sun2000-hybrid.yaml
+++ b/templates/definition/meter/huawei-sun2000-hybrid.yaml
@@ -352,7 +352,7 @@ render: |
       source: convert
       convert: bool2int
       set:
-        {{- if eq .forceaccharging "true" }}
+        {{- if .forceaccharging }}
         source: const
         value: 1 # Enable
         set:

--- a/templates/definition/meter/sofarsolar-g3.yaml
+++ b/templates/definition/meter/sofarsolar-g3.yaml
@@ -143,7 +143,7 @@ render: |
           type: holding
           decode: uint16
         scale: 10
-      {{- if eq .externalpower "true" }}
+      {{- if .externalpower }}
       - source: modbus
         {{- include "modbus" . | indent 6 }}
         register: 

--- a/templates/definition/meter/solax.yaml
+++ b/templates/definition/meter/solax.yaml
@@ -108,7 +108,7 @@ render: |
         address: 11 # 0x000B Powerdc2
         type: input
         decode: uint16
-  {{- if eq .mppt3 "true" }}
+  {{- if .mppt3 }}
     - source: modbus
       {{- include "modbus" . | indent 4 }}
       register:

--- a/templates/definition/tariff/features.tpl
+++ b/templates/definition/tariff/features.tpl
@@ -1,10 +1,10 @@
 {{ define "features" }}
-{{- if or .basefeatures (eq .average "true") }}
+{{- if or .basefeatures .average }}
 features:
 {{- range .basefeatures }}
 - {{ . }}
 {{- end }}
-{{- if eq .average "true" }}
+{{- if .average }}
 - average
 {{- end }}
 {{- end }}

--- a/templates/definition/vehicle/features.tpl
+++ b/templates/definition/vehicle/features.tpl
@@ -1,25 +1,25 @@
 {{ define "features" }}
-{{- if or .basefeatures (eq .coarsecurrent "true") (eq .welcomecharge "true") (eq .streaming "true") (eq .climaterdisabled "true") (eq .autodetectdisabled "true") (eq .wakeupdisabled "true") }}
+{{- if or .basefeatures .coarsecurrent .welcomecharge .streaming .climaterdisabled .autodetectdisabled .wakeupdisabled }}
 features:
 {{- range .basefeatures }}
 - {{ . }}
 {{- end }}
-{{- if eq .coarsecurrent "true" }}
+{{- if .coarsecurrent }}
 - coarsecurrent
 {{- end }}
-{{- if eq .welcomecharge "true" }}
+{{- if .welcomecharge }}
 - welcomecharge
 {{- end }}
-{{- if eq .streaming "true" }}
+{{- if .streaming }}
 - streaming
 {{- end }}
-{{- if eq .climaterdisabled "true" }}
+{{- if .climaterdisabled }}
 - climaterdisabled
 {{- end }}
-{{- if eq .autodetectdisabled "true" }}
+{{- if .autodetectdisabled }}
 - autodetectdisabled
 {{- end }}
-{{- if eq .wakeupdisabled "true" }}
+{{- if .wakeupdisabled }}
 - wakeupdisabled
 {{- end }}
 {{- end }}

--- a/templates/definition/vehicle/flobz.yaml
+++ b/templates/definition/vehicle/flobz.yaml
@@ -19,6 +19,7 @@ params:
   - name: port
     deprecated: true
   - name: wakeup_alt
+    type: bool
     description:
       en: Alternative wakeup code
       de: Alternativer Wakeup-Code
@@ -53,13 +54,13 @@ render: |
   wakeup:
     source: http
     {{- if .host }}
-    {{- if eq .wakeup_alt "true" }}
+    {{- if .wakeup_alt }}
     uri: http://{{ .host }}{{ if .port }}:{{ .port }}{{ end }}/charge_now/{{ .vin }}/1
     {{- else }}
     uri: http://{{ .host }}{{ if .port }}:{{ .port }}{{ end }}/wakeup/{{ .vin }}
     {{- end }}
     {{- else }}
-    {{- if eq .wakeup_alt "true" }}
+    {{- if .wakeup_alt }}
     uri: {{ trimSuffix "/" .url }}/charge_now/{{ .vin }}/1
     {{- else }}
     uri: {{ trimSuffix "/" .url }}/wakeup/{{ .vin }}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -108,6 +108,12 @@ func (t *Template) Validate() error {
 			return fmt.Errorf("param %s: description can't be empty", p.Name)
 		}
 
+		// bool params are rendered as real booleans, so anything but true/false
+		// would render differently than it appears in the ui
+		if p.Type == TypeBool && p.Default != "" && p.Default != "true" && p.Default != "false" {
+			return fmt.Errorf("param %s: bool default must be true or false, got '%s'", p.Name, p.Default)
+		}
+
 		maxLength := 50
 		actualLength := max(len(p.Description.String("en")), len(p.Description.String("de")))
 		if actualLength > maxLength {
@@ -395,7 +401,7 @@ func (t *Template) RenderResult(class Class, renderMode int, other map[string]an
 			}
 
 		default:
-			if res[out] == nil || res[out].(string) == "" {
+			if prev, ok := res[out].(string); res[out] == nil || (ok && prev == "") {
 				// prevent rendering nil interfaces as "<nil>" string
 				var s string
 				if val != nil {
@@ -418,6 +424,16 @@ func (t *Template) RenderResult(class Class, renderMode int, other map[string]an
 				}
 
 				res[out] = s
+			}
+		}
+	}
+
+	// bool params are rendered as real booleans so templates can use
+	// `{{ if .param }}` instead of comparing against "true"/"false"
+	for _, p := range t.Params {
+		if p.Type == TypeBool {
+			if s, ok := res[p.Name].(string); ok {
+				res[p.Name] = s == "true"
 			}
 		}
 	}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -109,9 +109,14 @@ func (t *Template) Validate() error {
 		}
 
 		// bool params are rendered as real booleans, so anything but true/false
-		// would render differently than it appears in the ui
-		if p.Type == TypeBool && p.Default != "" && p.Default != "true" && p.Default != "false" {
-			return fmt.Errorf("param %s: bool default must be true or false, got '%s'", p.Name, p.Default)
+		// would render differently than it appears in the ui. the example is the
+		// default in docs and unit test mode, see Param.DefaultValue.
+		if p.Type == TypeBool {
+			for _, v := range []string{p.Default, p.Example} {
+				if v != "" && v != "true" && v != "false" {
+					return fmt.Errorf("param %s: bool default/example must be true or false, got '%s'", p.Name, v)
+				}
+			}
 		}
 
 		maxLength := 50
@@ -401,7 +406,7 @@ func (t *Template) RenderResult(class Class, renderMode int, other map[string]an
 			}
 
 		default:
-			if prev, ok := res[out].(string); res[out] == nil || (ok && prev == "") {
+			if res[out] == nil || res[out].(string) == "" {
 				// prevent rendering nil interfaces as "<nil>" string
 				var s string
 				if val != nil {
@@ -430,6 +435,9 @@ func (t *Template) RenderResult(class Class, renderMode int, other map[string]an
 
 	// bool params are rendered as real booleans so templates can use
 	// `{{ if .param }}` instead of comparing against "true"/"false"
+	//
+	// TODO the boolean predefinedTemplateProperties (tcpip, udp, rs485*) are not
+	// declared params, so modbus.tpl still mis-branches on a stored "false"
 	for _, p := range t.Params {
 		if p.Type == TypeBool {
 			if s, ok := res[p.Name].(string); ok {

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -112,10 +112,11 @@ func (t *Template) Validate() error {
 		// would render differently than it appears in the ui. the example is the
 		// default in docs and unit test mode, see Param.DefaultValue.
 		if p.Type == TypeBool {
-			for _, v := range []string{p.Default, p.Example} {
-				if v != "" && v != "true" && v != "false" {
-					return fmt.Errorf("param %s: bool default/example must be true or false, got '%s'", p.Name, v)
-				}
+			if v := p.Default; v != "" && v != "true" && v != "false" {
+				return fmt.Errorf("param %s: bool default must be true or false, got '%s'", p.Name, v)
+			}
+			if v := p.Example; v != "" && v != "true" && v != "false" {
+				return fmt.Errorf("param %s: bool example must be true or false, got '%s'", p.Name, v)
 			}
 		}
 
@@ -428,20 +429,15 @@ func (t *Template) RenderResult(class Class, renderMode int, other map[string]an
 					}
 				}
 
-				res[out] = s
-			}
-		}
-	}
-
-	// bool params are rendered as real booleans so templates can use
-	// `{{ if .param }}` instead of comparing against "true"/"false"
-	//
-	// TODO the boolean predefinedTemplateProperties (tcpip, udp, rs485*) are not
-	// declared params, so modbus.tpl still mis-branches on a stored "false"
-	for _, p := range t.Params {
-		if p.Type == TypeBool {
-			if s, ok := res[p.Name].(string); ok {
-				res[p.Name] = s == "true"
+				// bool params are passed as real booleans so templates can use
+				// `{{ if .param }}` instead of comparing against "true"/"false".
+				// TODO the boolean predefinedTemplateProperties (tcpip, udp, rs485*)
+				// are no params, so modbus.tpl still mis-branches on a stored "false"
+				if i != -1 && p.Type == TypeBool {
+					res[out] = s == "true"
+				} else {
+					res[out] = s
+				}
 			}
 		}
 	}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -429,11 +429,10 @@ func (t *Template) RenderResult(class Class, renderMode int, other map[string]an
 					}
 				}
 
-				// bool params are passed as real booleans so templates can use
-				// `{{ if .param }}` instead of comparing against "true"/"false".
-				// TODO the boolean predefinedTemplateProperties (tcpip, udp, rs485*)
-				// are no params, so modbus.tpl still mis-branches on a stored "false"
-				if i != -1 && p.Type == TypeBool {
+				// bool params become real booleans so templates can use `{{ if .param }}`.
+				// TODO tcpip/udp/rs485* are predefined properties, so modbus.tpl still
+				// compares strings and mis-branches on a stored "false"
+				if p.Type == TypeBool {
 					res[out] = s == "true"
 				} else {
 					res[out] = s

--- a/util/templates/template_test.go
+++ b/util/templates/template_test.go
@@ -200,3 +200,87 @@ func TestValidatePattern(t *testing.T) {
 		})
 	}
 }
+
+// bool params are passed to the template as real booleans so templates can use
+// `{{ if .param }}` instead of comparing against the string "true"
+func TestBoolParamRendersAsBool(t *testing.T) {
+	tmpl := &Template{
+		Params: []Param{{Name: "flag", Type: TypeBool}},
+		Render: "flag: {{ if .flag }}on{{ else }}off{{ end }}\nvalue: {{ .flag }}",
+	}
+
+	for _, tc := range []struct {
+		value any
+		want  string
+	}{
+		{nil, "flag: off\nvalue: false"},     // unset
+		{"true", "flag: on\nvalue: true"},    // string, as sent by the config ui
+		{"false", "flag: off\nvalue: false"}, // string
+		{true, "flag: on\nvalue: true"},      // yaml bool
+		{false, "flag: off\nvalue: false"},   // yaml bool
+	} {
+		values := map[string]any{}
+		if tc.value != nil {
+			values["flag"] = tc.value
+		}
+
+		b, _, err := tmpl.RenderResult(Charger, RenderModeInstance, values)
+		require.NoError(t, err, tc.value)
+		assert.Equal(t, tc.want, string(b), "value: %v", tc.value)
+	}
+}
+
+// a bool param default must be a valid bool, otherwise ui and rendering disagree
+func TestValidateBoolDefault(t *testing.T) {
+	tmpl := func(def string) *Template {
+		return &Template{
+			Params: []Param{{
+				Name: "flag", Type: TypeBool, Default: def,
+				Description: TextLanguage{DE: "Schalter", EN: "Flag"},
+			}},
+		}
+	}
+
+	for _, def := range []string{"", "true", "false"} {
+		require.NoError(t, tmpl(def).Validate(), def)
+	}
+
+	for _, def := range []string{"yes", "1", "True"} {
+		require.Error(t, tmpl(def).Validate(), def)
+	}
+}
+
+// every template must render with each of its bool params set to true and
+// false in every usage - comparing a bool param against a string (e.g.
+// `eq .flag "true"`) fails at execution time and would otherwise only show
+// up at runtime
+func TestAllTemplatesRenderWithBoolParams(t *testing.T) {
+	for _, class := range ClassValues() {
+		for _, tmpl := range ByClass(class, WithDeprecated()) {
+			usages := []string{""}
+			if i, p := tmpl.ParamByName("usage"); i >= 0 && len(p.Choice) > 0 {
+				usages = p.Choice
+			}
+
+			for _, p := range tmpl.Params {
+				if p.Type != TypeBool {
+					continue
+				}
+
+				for _, val := range []bool{true, false} {
+					for _, usage := range usages {
+						values := tmpl.Defaults(RenderModeUnitTest)
+						values["template"] = tmpl.Template
+						values[p.Name] = val
+						if usage != "" {
+							values["usage"] = usage
+						}
+
+						_, _, err := tmpl.RenderResult(class, RenderModeInstance, values)
+						assert.NoError(t, err, "%s/%s %s=%v usage=%q", class, tmpl.Template, p.Name, val, usage)
+					}
+				}
+			}
+		}
+	}
+}

--- a/util/templates/template_test.go
+++ b/util/templates/template_test.go
@@ -230,36 +230,52 @@ func TestBoolParamRendersAsBool(t *testing.T) {
 	}
 }
 
-// a bool param default must be a valid bool, otherwise ui and rendering disagree
-func TestValidateBoolDefault(t *testing.T) {
-	tmpl := func(def string) *Template {
+// a bool param default must be a valid bool, otherwise ui and rendering
+// disagree. the example is the default in docs and unit test mode.
+func TestValidateBoolParam(t *testing.T) {
+	tmpl := func(def, example string) *Template {
 		return &Template{
 			Params: []Param{{
-				Name: "flag", Type: TypeBool, Default: def,
+				Name: "flag", Type: TypeBool, Default: def, Example: example,
 				Description: TextLanguage{DE: "Schalter", EN: "Flag"},
 			}},
 		}
 	}
 
-	for _, def := range []string{"", "true", "false"} {
-		require.NoError(t, tmpl(def).Validate(), def)
+	for _, val := range []string{"", "true", "false"} {
+		require.NoError(t, tmpl(val, "").Validate(), val)
+		require.NoError(t, tmpl("", val).Validate(), val)
 	}
 
-	for _, def := range []string{"yes", "1", "True"} {
-		require.Error(t, tmpl(def).Validate(), def)
+	for _, val := range []string{"yes", "1", "True"} {
+		require.Error(t, tmpl(val, "").Validate(), val)
+		require.Error(t, tmpl("", val).Validate(), val)
 	}
 }
 
 // every template must render with each of its bool params set to true and
-// false in every usage - comparing a bool param against a string (e.g.
-// `eq .flag "true"`) fails at execution time and would otherwise only show
-// up at runtime
+// false in every usage and for every value of its other choice params -
+// comparing a bool param against a string (e.g. `eq .flag "true"`) fails at
+// execution time and would otherwise only show up at runtime
 func TestAllTemplatesRenderWithBoolParams(t *testing.T) {
 	for _, class := range ClassValues() {
 		for _, tmpl := range ByClass(class, WithDeprecated()) {
 			usages := []string{""}
-			if i, p := tmpl.ParamByName("usage"); i >= 0 && len(p.Choice) > 0 {
+			if i, p := tmpl.ParamByName(ParamUsage); i >= 0 && len(p.Choice) > 0 {
 				usages = p.Choice
+			}
+
+			// `and`/`or` short-circuit, so a comparison behind another choice param
+			// is only reached for the right value of it. Vary those one at a time,
+			// usage stays crossed with them as it selects whole render sections.
+			variants := []map[string]string{nil}
+			for _, p := range tmpl.Params {
+				if p.Name == ParamUsage {
+					continue
+				}
+				for _, c := range p.Choice {
+					variants = append(variants, map[string]string{p.Name: c})
+				}
 			}
 
 			for _, p := range tmpl.Params {
@@ -269,15 +285,20 @@ func TestAllTemplatesRenderWithBoolParams(t *testing.T) {
 
 				for _, val := range []bool{true, false} {
 					for _, usage := range usages {
-						values := tmpl.Defaults(RenderModeUnitTest)
-						values["template"] = tmpl.Template
-						values[p.Name] = val
-						if usage != "" {
-							values["usage"] = usage
-						}
+						for _, variant := range variants {
+							values := tmpl.Defaults(RenderModeUnitTest)
+							values["template"] = tmpl.Template
+							values[p.Name] = val
+							if usage != "" {
+								values[ParamUsage] = usage
+							}
+							for k, v := range variant {
+								values[k] = v
+							}
 
-						_, _, err := tmpl.RenderResult(class, RenderModeInstance, values)
-						assert.NoError(t, err, "%s/%s %s=%v usage=%q", class, tmpl.Template, p.Name, val, usage)
+							_, _, err := tmpl.RenderResult(class, RenderModeInstance, values)
+							assert.NoError(t, err, "%s/%s %s=%v usage=%q %v", class, tmpl.Template, p.Name, val, usage, variant)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Follow-up to the [discussion in #32219](https://github.com/evcc-io/evcc/pull/32219#discussion_r3812460553).

Bool params reached the template render as strings, so templates had to compare `eq .param "true"` and a plain `{{ if .param }}` was always true — the non-empty string `"false"` is truthy. Bool params are now real booleans, every comparison uses the boolean form, and a bool default is validated to be `true`/`false`.

**This fixes six toggles that never had an effect**, because their template used truthiness:

| template | param | effect until now |
|---|---|---|
| `meter/openems-modbus` | `battery` | `batterymode` block always rendered |
| `messenger/homeassistant` | `critical` | `ttl: 0` / `priority: high` always sent |
| `meter/demo-battery` | `controllable` | `batterymode` block always rendered |
| `meter/demo-meter` | `curtailable` | `curtail` block always rendered |
| `meter/deye-hybrid-3p` | `includegenport` | gen port always summed into pv |
| `charger/vehicle-api` | `geofence_enabled` | geofence keys always emitted (harmless, the block carries the flag itself) |

Every template was rendered with each of its bool params unset, `true` and `false` before and after the change and the outputs diffed — the table is the result of that comparison.

**Note for existing installations:** openems-modbus users relying on the unintended always-on battery control, and HA-messenger users relying on unconditional `ttl: 0`/`priority: high`, have to enable the respective toggle now.

Otherwise backward compatible. String `"true"`/`"false"` from stored configs keeps working, and an unset bool renders as `false` instead of empty, which decodes to the same zero value — verified that no affected Go struct pre-sets those fields. Two templates needed an explicit default to pin current behaviour: `meter/batterx` `externalpv` (unset previously matched `ne "false"`) and `vehicle/flobz` `wakeup_alt`, which was used as a bool but declared untyped.

The config UI seeded bool defaults as strings, which made its "field is empty" checks see a filled field; defaults are booleans there as well now.

`TestAllTemplatesRenderWithBoolParams` renders every template across all classes with each bool param set both ways in every usage, so a reintroduced string comparison fails the build. It earned its keep during the rebase: `demo-meter curtailable`, `deye-hybrid-3p includegenport` and `firmware1098` had picked up the string form in the meantime and were caught immediately.

Not covered: `util/templates/modbus.tpl` uses the same truthiness pattern on `.tcpip` / `.udp` / `.rs485serial` / `.rs485tcpip`. Those are `predefinedTemplateProperties` rather than declared params, so this change does not reach them and a config with `tcpip: false` still selects the wrong branch. Same bug class, but it needs its own fix.
