### PR TITLE
Deye 3p hybrid: fix curtailed script for whole-number limits

### DIFF
--- a/templates/definition/meter/deye-hybrid-3p.yaml
+++ b/templates/definition/meter/deye-hybrid-3p.yaml
@@ -311,8 +311,9 @@ render: |
           scale: 10
           {{- end }}
     script: |
+      // float64 is required: a whole-number input arrives as an int literal
       // round, the watt conversion does not reproduce the written percent exactly
-      p := int(limit*100/{{ maxf .maxacpower 1 }} + 0.5)
+      p := int(float64(limit)*100/{{ maxf .maxacpower 1 }} + 0.5)
       if p > 100 {
         p = 100
       }


### PR DESCRIPTION
`curtailed` fails on every single read since the script switched its input to `float` (#32798):

```
Deye 3p curtailed: 2:10: invalid operation: mismatched types int and untyped float
```

Register 143 holds watts as `uint16`, so `limit` is always a whole number. `plugin/go.go` hands parameters to the interpreter as Go source via `%#v`, which renders `float64(11000)` as `11000` - the interpreter infers `int`, and the `+ 0.5` rounding no longer type-checks. A value with a fractional part would work, but register 143 cannot produce one.

The consequence is worse than a failing readback: `curtailPV` (`core/site_circuits.go`) skips `SetCurtailPercent` when reading the state returns an error, so **nothing is written to the inverter at all**. Feed-in curtailment for `deye-hybrid-3p` has been inoperative since 0.314.0 - one log line per cycle is the only symptom.

Found in a user's debug log, reproduced against yaegi v0.16.1 with the injection from `plugin/go.go`:

```
limit := 11000;    -> 2:10: invalid operation: mismatched types int and untyped float
limit := 8880;     -> 2:10: invalid operation: mismatched types int and untyped float
limit := 11000.5;  -> ok: 73
```

This is the minimal template-side fix, so the next patch release restores curtailment. The root cause sits in the `go` plugin and is fixed in a companion PR; the explicit conversion here is redundant afterwards, but harmless.

The other templates feeding a `float` input into a `go` script - `goodwe-hybrid`, `solaredge-hybrid`, `curtailer/solaredge`, `enphase-modbus`, `fronius-gen24`, `kostal-plenticore-gen2`, `sunspec-hybrid-curtailable`, `sunspec-inverter-curtailable` - either convert with `int(limit)` or assign to a pre-declared float variable. Both are accepted by the interpreter, so `deye-hybrid-3p` is the only one affected.