### PR TITLE
Fix tariff API route not matching co2

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -198,7 +198,7 @@ func (s *HTTPd) RegisterSiteHandlers(site site.API) {
 		"smartcostdelete":         {"DELETE", "/smartcostlimit", updateSmartCostLimit(site, smartCostLimit)},
 		"smartfeedin":             {"POST", "/smartfeedinprioritylimit/{value:-?[0-9.]+}", updateSmartCostLimit(site, smartFeedInPriorityLimit)},
 		"smartfeedindelete":       {"DELETE", "/smartfeedinprioritylimit", updateSmartCostLimit(site, smartFeedInPriorityLimit)},
-		"tariff":                  {"GET", "/tariff/{tariff:[a-z]+}", tariffHandler(site)},
+		"tariff":                  {"GET", "/tariff/{tariff:[a-z0-9]+}", tariffHandler(site)},
 		"sessions":                {"GET", "/sessions", sessionHandler},
 		"updatesession":           {"PUT", "/session/{id:[0-9]+}", updateSessionHandler},
 		"deletesession":           {"DELETE", "/session/{id:[0-9]+}", deleteSessionHandler},


### PR DESCRIPTION
The `/api/tariff/{tariff}` route constrains the parameter to `[a-z]+`, which never matches `co2` — the endpoint returns the router's plain "404 page not found" although the handler and `TariffUsageString` fully support it. Allow digits in the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)