### PR TITLE
Demo tariffs: increase forecast to 5 days

### DIFF
--- a/templates/definition/tariff/demo-co2-forecast.yaml
+++ b/templates/definition/tariff/demo-co2-forecast.yaml
@@ -36,7 +36,7 @@ render: |
   forecast:
     source: js
     script: |
-      // Generate CO₂ forecast for next 72 hours in 15-minute slots
+      // Generate CO₂ forecast for next 120 hours in 15-minute slots
       // Based on summer grid patterns with high solar penetration
       var now = new Date();
       var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
@@ -44,13 +44,13 @@ render: |
       var baseIntensity = parseFloat({{ .base }});
       var variation = parseFloat({{ .variation }});
 
-      // Generate 15-minute slots for 3 days
+      // Generate 15-minute slots for 5 days
       var slotMinutes = 15;
       var slotDuration = slotMinutes * 60 * 1000;
       var slotsPerHour = 60 / slotMinutes;
       var slotsPerDay = 24 * slotsPerHour;
 
-      for (var day = 0; day < 3; day++) {
+      for (var day = 0; day < 5; day++) {
         for (var slot = 0; slot < slotsPerDay; slot++) {
           var time = new Date(start.getTime() + (day * slotsPerDay + slot) * slotDuration);
           var hour = slot / slotsPerHour;

--- a/templates/definition/tariff/demo-dynamic-grid.yaml
+++ b/templates/definition/tariff/demo-dynamic-grid.yaml
@@ -48,8 +48,8 @@ render: |
   forecast:
     source: js
     script: |
-      // Generate deterministic dynamic grid prices for 3 days in 15-minute slots
-      // Pattern repeats every 3 days for predictability
+      // Generate deterministic dynamic grid prices for 5 days in 15-minute slots
+      // Daily pattern (by hour) repeats for predictability
       var now = new Date();
       var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
       var rates = [];
@@ -58,7 +58,7 @@ render: |
       var priceRange = maxPrice - minPrice;
       var noiseAmount = parseFloat({{ .noise }});
 
-      // Generate 15-minute slots for 3 days
+      // Generate 15-minute slots for 5 days
       var slotMinutes = 15;
       var slotDuration = slotMinutes * 60 * 1000;
       var slotsPerHour = 60 / slotMinutes;
@@ -95,7 +95,7 @@ render: |
         return ((n - Math.floor(n)) * 2 - 1) * noiseAmount;
       }
 
-      for (var day = 0; day < 3; day++) {
+      for (var day = 0; day < 5; day++) {
         for (var slot = 0; slot < slotsPerDay; slot++) {
           var time = new Date(start.getTime() + (day * slotsPerDay + slot) * slotDuration);
           var hour = slot / slotsPerHour;

--- a/templates/definition/tariff/demo-solar-forecast.yaml
+++ b/templates/definition/tariff/demo-solar-forecast.yaml
@@ -46,7 +46,7 @@ render: |
   forecast:
     source: js
     script: |
-      // Generate realistic solar forecast with bell curve for next 72 hours in 15-minute slots
+      // Generate realistic solar forecast with bell curve for next 120 hours in 15-minute slots
       var now = new Date();
       var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
       var rates = [];
@@ -73,13 +73,13 @@ render: |
         }
       }
 
-      // Generate 15-minute slots for 3 days
+      // Generate 15-minute slots for 5 days
       var slotMinutes = 15;
       var slotDuration = slotMinutes * 60 * 1000;
       var slotsPerHour = 60 / slotMinutes;
       var slotsPerDay = 24 * slotsPerHour;
 
-      for (var day = 0; day < 3; day++) {
+      for (var day = 0; day < 5; day++) {
         for (var slot = 0; slot < slotsPerDay; slot++) {
           var time = new Date(start.getTime() + (day * slotsPerDay + slot) * slotDuration);
           var hour = slot / slotsPerHour;

--- a/templates/definition/tariff/demo-temperature-forecast.yaml
+++ b/templates/definition/tariff/demo-temperature-forecast.yaml
@@ -30,7 +30,7 @@ render: |
   forecast:
     source: js
     script: |
-      // Generate temperature forecast for next 72 hours in 15-minute slots
+      // Generate temperature forecast for next 120 hours in 15-minute slots
       // Sinusoidal daily cycle between min and max: coldest around 05:00, warmest around 17:00
       var now = new Date();
       var start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
@@ -44,7 +44,7 @@ render: |
       var slotDuration = slotMinutes * 60 * 1000;
       var slotsPerDay = (24 * 60) / slotMinutes;
 
-      for (var day = 0; day < 3; day++) {
+      for (var day = 0; day < 5; day++) {
         for (var slot = 0; slot < slotsPerDay; slot++) {
           var time = new Date(start.getTime() + (day * slotsPerDay + slot) * slotDuration);
           var hour = (slot * slotMinutes) / 60;


### PR DESCRIPTION
## Summary

The frontend displays up to 96h of forecast data, but the demo tariffs only generated 3 days (72h). Combined with hourly cache refresh and daily-midnight truncation, worst-case coverage could drop to ~47h. Extended the demo co2, solar, temperature and dynamic-grid templates to generate 5 days (120h), so the chart consistently fills its full 96h display window with margin against cache staleness.