### PR TITLE
Solax X1/X3-HAC: add CurrentLimiter

### DIFF
--- a/charger/solax.go
+++ b/charger/solax.go
@@ -37,16 +37,20 @@ type Solax struct {
 	log        *util.Logger
 	conn       *modbus.Connection
 	enabled    bool
+	maxCurrent float64
 	isLegacyHw bool
 }
 
 const (
+	// register map per "X1/X3-HAC EV Charger Modbus TCP/RTU protocol V1.0.0"
+
 	// holding (FC 0x03, 0x06, 0x10)
-	solaxRegSerialNumber   = 0x0600 // 7x string
-	solaxRegDeviceMode     = 0x060D // uint16
-	solaxRegCommandControl = 0x0627 // uint16
-	solaxRegMaxCurrent     = 0x0628 // uint16 0.01A
-	solaxRegPhaseSwitch    = 0xA105 // uint16
+	solaxRegSerialNumber     = 0x0600 // 7x string
+	solaxRegDeviceMode       = 0x060D // uint16
+	solaxRegCommandControl   = 0x0627 // uint16
+	solaxRegMaxCurrent       = 0x0628 // uint16 0.01A, spec: adjust_charge_current
+	solaxRegMaxChargeCurrent = 0x0668 // uint16 0.01A, spec: MaxChargeCurrent, the device-side ceiling
+	solaxRegPhaseSwitch      = 0xA105 // uint16
 
 	// input (FC 0x04)
 	solaxRegVoltages           = 0x0000 // 3x uint16 0.01V
@@ -212,6 +216,25 @@ func (wb *Solax) MaxCurrentMillis(current float64) error {
 	return err
 }
 
+var _ api.CurrentLimiter = (*Solax)(nil)
+
+// GetMinMaxCurrent implements the api.CurrentLimiter interface
+func (wb *Solax) GetMinMaxCurrent() (float64, float64, error) {
+	b, err := wb.conn.ReadHoldingRegisters(solaxRegMaxChargeCurrent, 1)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// the device-side ceiling is set in the Solax app, not by evcc; log it on change
+	// so a loadpoint silently capped below its configured maximum is traceable
+	if max := float64(encoding.Uint16(b)) / 100; max != wb.maxCurrent {
+		wb.maxCurrent = max
+		wb.log.INFO.Printf("device max charge current: %.1fA", max)
+	}
+
+	return 6, wb.maxCurrent, nil
+}
+
 var _ api.Meter = (*Solax)(nil)
 
 // CurrentPower implements the api.Meter interface
@@ -323,6 +346,12 @@ func (wb *Solax) Diagnose() {
 		default:
 			fmt.Printf("\tLock State:\tUnknown (%d)\n", state)
 		}
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(solaxRegMaxCurrent, 1); err == nil {
+		fmt.Printf("\tAdjust Charge Current:\t%.2fA\n", float64(encoding.Uint16(b))/100)
+	}
+	if b, err := wb.conn.ReadHoldingRegisters(solaxRegMaxChargeCurrent, 1); err == nil {
+		fmt.Printf("\tMax Charge Current:\t%.2fA\n", float64(encoding.Uint16(b))/100)
 	}
 	if b, err := wb.conn.ReadHoldingRegisters(solaxRegDeviceMode, 1); err == nil {
 		switch state := encoding.Uint16(b); state {


### PR DESCRIPTION
## Problem
The Solax X3-HAC expose **two** current registers, and evcc currently only knows one of them:
| Register | Name | Range | Meaning |
|---|---|---|---|
| `0x0628` | `adjust_charge_current` | [600, 3500] | live modulation — what the driver writes |
| `0x0668` | `MaxChargeCurrent` | [600, 3200] | device-side ceiling, set within the device / SolaX app itself |

The charger delivers the **lower** one, and it does so silently: the write to `0x0628` is successful, but the wallbox's UI keeps showing its local setting.

Because evcc never reads `0x0668`, a loadpoint configured above the ceiling asks for more current than it can get, gets a successful write, and then keeps believing it. `setLimit` updates `lp.offeredCurrent` to the requested value, and since the next cycle computes the same target, `current != lp.offeredCurrent` is false and the write is never retried. There is no warning at any log level — `syncCharger`'s measured-current cross-check only fires when a charger draws **more** than expected:
```go
if current := lp.GetMaxPhaseCurrent(); current > lp.offeredCurrent+1.0 {
```

A charger delivering *less* than requested is invisible. In my case the ceiling had been configured at 8 A. evcc reported `offeredCurrent: 16` while the car
charged at 8 A. Every layer looked healthy in isolation, which made it hard to locate.

## Change

Implemented `api.CurrentLimiter` by reading `0x0668`, so `effectiveMinCurrent()` /  `effectiveMaxCurrent()` resolve against the real device limits and the device ceiling is logged instead of being silently ignored. `Diagnose()` now reports both registers.

Since the protocol document warns that certain registers are EEPROM-backed with write-cycle limits, and that "too frequent operation will lead to irreversible hardware damage", Device register `0x0668` is only ever **read**. 

## Verification

Register addresses and ranges are per *"X1/X3-HAC EV Charger Modbus TCP/RTU protocol V1.0.0"*.

Gen2/HAC support was previously added in #24243 without access to actual hardware. This was tested on an X3-HAC, firmware **V8.04**, Modbus TCP, with the device ceiling set to 14 A.

`evcc charger <name> --diagnose`:

```
Adjust Charge Current:  7.00A
Max Charge Current:     14.00A
Mix/Max Current:        6.0/14.0A
```

Loadpoint `maxCurrent` raised to 16 A, mode `now`:

```json
{"maxCurrent": 16, "effectiveMaxCurrent": 14, "effectiveMinCurrent": 6, "offeredCurrent": 14}
```

evcc now explicitly offers 14 A — the configured device maximum — instead of requesting 16 A.

The (hardcoded) 6 A lower bound matches the spec's [600, …] range.