### PR TITLE
chore: accept both vite+ bin locations in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM --platform=$BUILDPLATFORM node:26-alpine AS node
 
 RUN apk update && apk add --no-cache make curl bash && curl -fsSL https://vite.plus | bash
 
-# the installer only wires vp into interactive shell rc files, which RUN steps don't source
-ENV PATH="/root/.local/share/vite-plus/bin:${PATH}"
+# the installer only wires vp into interactive shell rc files, which RUN steps don't source.
+# newer vite+ releases dropped the split directory layout, so accept both bin locations
+ENV PATH="/root/.vite-plus/bin:/root/.local/share/vite-plus/bin:${PATH}"
 
 WORKDIR /build
 


### PR DESCRIPTION
The nightly Docker build has been failing since 2026-08-25:

```
#64 0.157 vp run build
#64 0.157 make: vp: No such file or directory
#64 0.157 make: *** [Makefile:53: ui] Error 127
```

The `curl -fsSL https://vite.plus | bash` layer is unchanged, so the builder reuses a cached layer created before vite+ moved its data directory. That older install put `vp` in `~/.vite-plus/bin`, while #33142 pointed `PATH` at `~/.local/share/vite-plus/bin` only, so `make ui` no longer finds `vp`. A fresh install today does use `~/.local/share/vite-plus/bin`, so both locations are valid depending on when the layer was built.

Putting both directories on `PATH` works with either layer. Verified locally with `docker build --target node .`.

Side effect: no nightly image has been published since `nightly.20260824-56eccb0`, so fixes merged after that (e.g. #33164) never reached nightly users.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
