### PR TITLE
fix(loadpoint): scale down in continuous modes (MinPV, battery boost)

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -1468,6 +1468,14 @@ func (lp *Loadpoint) pvScalePhases(sitePower, minCurrent, maxCurrent float64) in
 		// while charging, scaling down only helps if 1p is sustainable, otherwise it
 		// merely delays the pv disable timer by the phase timer duration
 		useful := !lp.enabled || !lp.charging() || powerToCurrent(availablePower, 1) >= minCurrent
+
+		// the pv disable sequence only runs in PV mode without battery boost; in
+		// continuous modes (MinPV, battery boost) the charger is never disabled,
+		// so scaling down to 1p is the only way to shed load when power is short
+		if mode := lp.GetMode(); mode != api.ModePV || lp.GetBatteryBoost() == boostContinue {
+			useful = true
+		}
+
 		if insufficient && !useful {
 			lp.log.DEBUG.Printf("available power %.0fW < %.0fW min 1p threshold, disabling instead of scaling down", availablePower, Voltage*minCurrent)
 		}

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -373,15 +373,30 @@ func TestPvScalePhasesTimer(t *testing.T) {
 			lp.phaseTimer = elapsed
 		}},
 
-		// charging with insufficient power for 1p: disable instead of scaling down
+		// charging with insufficient power for 1p: disable instead of scaling down (PV mode)
 		{"3/3->1, insufficient for 1p, charging", 3, 3, 0.1, 3, 0, func(lp *Loadpoint) {
 			lp.phaseTimer = elapsed
 			lp.enabled = true
+			lp.mode = api.ModePV
 		}},
 		{"3/3->1, sufficient for 1p, charging", 3, 3, 3 * Voltage * minA / 2, 1, 1, func(lp *Loadpoint) {
 			lp.phaseTimer = elapsed
 			lp.enabled = true
 			lp.chargePower = 3 * Voltage * minA
+			lp.mode = api.ModePV
+		}},
+
+		// continuous modes never run the pv disable sequence, so even if 1p is not
+		// sustainable they scale down instead of waiting for a (never happening) disable
+		{"3/3->1, insufficient for 1p, charging, MinPV", 3, 3, 0.1, 1, 1, func(lp *Loadpoint) {
+			lp.phaseTimer = elapsed
+			lp.enabled = true
+			lp.mode = api.ModeMinPV
+		}},
+		{"3/3->1, insufficient for 1p, charging, battery boost", 3, 3, 0.1, 1, 1, func(lp *Loadpoint) {
+			lp.phaseTimer = elapsed
+			lp.enabled = true
+			lp.batteryBoost = boostContinue
 		}},
 
 		// switch down from 3p/0p while not yet charging


### PR DESCRIPTION
Fixes #33208

## Problem
PR #32991 made phase scaling skip down-scaling when 1p is not sustainable, deferring to the PV disable sequence (`disabling instead of scaling down`). But that disable sequence only ever runs in `ModePV`. In continuous modes — MinPV and battery boost — the charger is never disabled, so it stays at 3 phases with insufficient power indefinitely.

## Fix
In `pvScalePhases`, only apply the "disable instead of scale" shortcut when the disable sequence will actually run, i.e. `ModePV` without an active battery boost. In continuous modes we scale down to 1p as before.

## Tests
Added `TestPvScalePhasesTimer` cases covering insufficient-1p charging in MinPV mode and battery boost — both now scale down to 1p — while the plain `ModePV` case keeps the PR #32991 disable behavior.