### PR TITLE
Sungrow-hybrid: add curtailment (BC)

### DIFF
--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -126,15 +126,15 @@ render: |
   maxacpower: {{ .maxacpower }} # W
   # EEG §9 curtailment via the power limitation registers
   #   13086 (doc 13087) power limitation switch, 0xAA enable / 0x55 disable
-  #   13087 (doc 13088) power limitation value, 0.1 % of nominal power
+  #   13087 (doc 13088) power limitation value, 0.1 % of nominal power => Does not work on SHX.0RS, use 13073 (doc 13074) instead, which is in W resolution
   curtail:
     source: sequence
     set:
       - source: go
         script: |
-          ena := 0xAA // enable limitation
+          ena := 170 // 0xAA - enable limitation
           if curtail == 100 {
-            ena = 0x55 // disable limitation
+            ena = 85 // 0x55 - disable limitation
           }
           ena
         out:
@@ -144,25 +144,23 @@ render: |
               source: modbus
               {{- include "modbus" . | indent 12 }}
               register:
-                address: 13086 # Feed-in Limitation switch
+                address: 13086 # Feed-in Limitation switch (doc 13087), 0xAA enable / 0x55 disable
                 type: writesingle
                 decode: uint16
-      - source: modbus
-        {{- include "modbus" . | indent 6 }}
-        register:
-          address: 13087 # Feed-in Limitation Ratio, 0.1 %
-          type: writesingle
-          decode: uint16
-        scale: 10
-      - source: const
-        value: 0
-        set:
-            source: modbus
-            {{- include "modbus" . | indent 10 }}
-            register:
-              address: 13073 # Feed-in Limitation Ratio, 0.1 %
-              type: writesingle
-              decode: uint16
+      - source: go
+        script: |
+          watts := curtail * {{ .maxacpower }} / 100
+          watts
+        out:
+          - name: watts
+            type: int
+            config:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 13073 # Feed-in Limitation Value (doc 13074), 1W resolution
+                type: writesingle
+                decode: uint16
   curtailed:
     source: go
     in:
@@ -175,20 +173,19 @@ render: |
             address: 13086
             type: holding
             decode: uint16
-      - name: ratio
+      - name: watts
         type: int
         config:
           source: modbus
           {{- include "modbus" . | indent 8 }}
           register:
-            address: 13087
+            address: 13073 # Feed-in Limitation Value (doc 13074), 1W
             type: holding
             decode: uint16
-          scale: 0.1
     script: |
       percent := 100
-      if ena == 0xAA {
-        percent = ratio
+      if ena == 170 {
+        percent = watts * 100 / {{ .maxacpower }}
       }
       percent
   {{- end }}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -132,9 +132,9 @@ render: |
     set:
       - source: go
         script: |
-          ena := 170 // 0xAA - enable limitation
+          ena := 0xAA // enable limitation
           if curtail == 100 {
-            ena = 85 // 0x55 - disable limitation
+            ena = 0x55 // disable limitation
           }
           ena
         out:
@@ -178,7 +178,7 @@ render: |
           scale: 0.1
     script: |
       percent := 100
-      if ena == 170 {
+      if ena == 0xAA {
         percent = ratio
       }
       percent

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -22,6 +22,7 @@ params:
     baudrate: 9600
   - name: maxacpower
     service: modbus/read?address=5000&type=input&encoding=uint16&scale=100&{modbus}
+    required: true
   - preset: battery-params
   - name: maxchargepower
     service: modbus/read?address=13051&type=holding&encoding=uint16&scale=1&{modbus}

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -124,6 +124,64 @@ render: |
       decode: uint32s
     scale: 0.1
   maxacpower: {{ .maxacpower }} # W
+  # EEG §9 curtailment via the power limitation registers
+  #   13086 (doc 13087) power limitation switch, 0xAA enable / 0x55 disable
+  #   13087 (doc 13088) power limitation value, 0.1 % of nominal power
+  curtail:
+    source: sequence
+    set:
+      - source: go
+        script: |
+          ena := 170 // 0xAA - enable limitation
+          if curtail == 100 {
+            ena = 85 // 0x55 - disable limitation
+          }
+          ena
+        out:
+          - name: ena
+            type: int
+            config:
+              source: modbus
+              {{- include "modbus" . | indent 12 }}
+              register:
+                address: 13086 # Feed-in Limitation switch
+                type: writesingle
+                decode: uint16
+      - source: modbus
+        {{- include "modbus" . | indent 6 }}
+        register:
+          address: 13087 # Feed-in Limitation Ratio, 0.1 %
+          type: writesingle
+          decode: uint16
+        scale: 10
+  curtailed:
+    source: go
+    in:
+      - name: ena
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 13086
+            type: holding
+            decode: uint16
+      - name: ratio
+        type: int
+        config:
+          source: modbus
+          {{- include "modbus" . | indent 8 }}
+          register:
+            address: 13087
+            type: holding
+            decode: uint16
+          scale: 0.1
+    script: |
+      percent := 100
+      if ena == 170 {
+        percent = ratio
+      }
+      percent
   {{- end }}
   {{- if eq .usage "battery" }}
   power:

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -147,8 +147,6 @@ render: |
                 address: 13086 # Feed-in Limitation switch
                 type: writesingle
                 decode: uint16
-      - source: sleep
-        duration: 1s
       - source: modbus
         {{- include "modbus" . | indent 6 }}
         register:
@@ -156,6 +154,15 @@ render: |
           type: writesingle
           decode: uint16
         scale: 10
+      - source: const
+        value: 0
+        set:
+            source: modbus
+            {{- include "modbus" . | indent 10 }}
+            register:
+              address: 13073 # Feed-in Limitation Ratio, 0.1 %
+              type: writesingle
+              decode: uint16
   curtailed:
     source: go
     in:

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -147,6 +147,8 @@ render: |
                 address: 13086 # Feed-in Limitation switch
                 type: writesingle
                 decode: uint16
+      - source: sleep
+        duration: 1s
       - source: modbus
         {{- include "modbus" . | indent 6 }}
         register:

--- a/templates/definition/meter/sungrow-hybrid.yaml
+++ b/templates/definition/meter/sungrow-hybrid.yaml
@@ -4,7 +4,7 @@ products:
   - brand: Sungrow
     description:
       generic: SH Series Hybrid Inverter
-capabilities: ["battery-control"]
+capabilities: ["battery-control", "curtail"]
 requirements:
   description:
     de: Verbindungen über das WiNet-S-Dongle (WiFi oder LAN) funktionieren nur mit aktueller Firmware. Ältere Versionen liefern nicht alle benötigten Daten (Leistung, Ladestand).


### PR DESCRIPTION
Sungrow: add EEG §9 curtailment support

What
Adds feed-in curtailment (capabilities: ["curtail"]) to the sungrow-hybrid PV meter template, so Sungrow SH-series hybrid inverters can be used as a curtailable device with evcc's [External Limit (§14a/§9)](https://docs.evcc.io/en/external-limit) feature — same mechanism already used by sunspec-inverter.yaml.

Implementation notes

Uses Feed-in Limitation (register 13087) to enable/disable the limiter, and Feed-in Limitation Value (register 13074, absolute Watts) rather than Feed-in Limitation Ratio (register 13088, 0.1% units) to express the target level. The percentage-based ratio register was only added to Sungrow's Modbus protocol in V1.1.7 (May 2025) and isn't reliably available across firmware versions; the Watt-based register has been present much longer and proved more broadly compatible in testing. The Watt target is derived from the existing maxacpower param (maxacpower * curtail / 100).
maxacpower is now a required param, since curtail/curtailed depend on it directly for the percentage↔Watt conversion.
Follows the same enable/disable convention Sungrow uses elsewhere in this template (0xAA/170 = enable, 0x55/85 = disable), and the same 100%-is-uncurtailed convention evcc's other curtailable templates use.

Testing

Verified against a Sungrow SH4.0RS (WiNet-S) — write and read round-trip correctly with the Watt-based approach.
Not yet tested against SH-RT/SH-T/MG-series units; feedback from owners of those models welcome before merge.