### PR TITLE
Energyflow: clip collapsed details to remove phantom scroll area

### DIFF
--- a/assets/js/components/Energyflow/Energyflow.vue
+++ b/assets/js/components/Energyflow/Energyflow.vue
@@ -656,7 +656,7 @@ export default defineComponent({
 	height: 0;
 	opacity: 0;
 	transform: scale(0.98);
-	overflow: visible;
+	overflow: hidden;
 	transition-property: height, opacity, transform;
 	transition-duration: 0;
 	transition-timing-function: cubic-bezier(0.5, 0.5, 0.5, 1.15);


### PR DESCRIPTION
With the energy flow collapsed, the page could still scroll into empty space below the loadpoints. The collapsed details keep their full content in the document scroll extent because `.details` used `overflow: visible` with `height: 0`. Visible once the hidden content is taller than what follows, e.g. with consumer and charger groups expanded.

- `.details` now uses `overflow: hidden`, matching the nested `.expandable` groups
- Tooltips unaffected (rendered in body)

<img width="568" height="1084" alt="Bildschirmfoto 2026-08-27 um 15 16 38" src="https://github.com/user-attachments/assets/baa1e19a-abf4-4238-90cd-c6a810235d85" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)