### PR TITLE
Keba: add P30 Deutschland Edition (DE440) to modbus template

### DIFF
--- a/templates/definition/charger/keba-modbus.yaml
+++ b/templates/definition/charger/keba-modbus.yaml
@@ -9,6 +9,9 @@ products:
   - brand: KEBA
     description:
       generic: KeContact P30 X-Series
+  - brand: KEBA
+    description:
+      generic: KeContact P30 Deutschland Edition (DE440)
   - brand: BMW
     description:
       generic: i Wallbox


### PR DESCRIPTION
fixes #33089

The KEBA KeContact P30 "Deutschland Edition" (DE440) was not listed in the `keba-modbus` template, so users of that box could not find it in the device picker and concluded Modbus TCP was unsupported.

KEBA's DE440 datasheet (article 119857) lists `Kommunikationsprotokoll: UDP / Modbus TCP`, and it was confirmed working in the issue with firmware 3.10.80 on a `KC-P30-EC220112-000-DE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
