### PR TITLE
fix: retry failed cardata container setup

### DIFF
--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -132,17 +132,17 @@ func (v *Provider) any(key string) (any, error) {
 
 	_, tokenErr := v.ts.Token()
 
-	switch {
-	case tokenErr == nil && v.updated.IsZero():
-		// this will only happen once
-		if err := v.setupContainer(); err != nil {
-			v.log.WARN.Println(err)
+	if tokenErr == nil && (v.updated.IsZero() || time.Since(v.updated) > v.cache) {
+		if v.container == "" {
+			if err := v.setupContainer(); err != nil {
+				v.log.WARN.Println(err)
+			}
 		}
-		fallthrough
 
-	case tokenErr == nil && time.Since(v.updated) > v.cache && v.container != "":
-		if err := v.updateContainerData(); err != nil {
-			v.log.WARN.Println(err)
+		if v.container != "" {
+			if err := v.updateContainerData(); err != nil {
+				v.log.WARN.Println(err)
+			}
 		}
 		v.updated = time.Now()
 	}

--- a/vehicle/bmw/cardata/provider_test.go
+++ b/vehicle/bmw/cardata/provider_test.go
@@ -15,7 +15,7 @@ func TestCardataStreaming(t *testing.T) {
 
 	p := NewProvider(ctx, util.NewLogger("foo"), nil, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: "at",
-	}), "client", "vin", 0)
+	}), "client", "vin", time.Hour)
 
 	// prevent container panic
 	p.updated = time.Now()
@@ -51,7 +51,7 @@ func TestSocFallback(t *testing.T) {
 
 	p := NewProvider(ctx, util.NewLogger("foo"), nil, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: "at",
-	}), "client", "vin", 0)
+	}), "client", "vin", time.Hour)
 
 	// prevent container panic
 	p.updated = time.Now()
@@ -108,7 +108,7 @@ func TestRangeFallback(t *testing.T) {
 
 	p := NewProvider(ctx, util.NewLogger("foo"), nil, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: "at",
-	}), "client", "vin", 0)
+	}), "client", "vin", time.Hour)
 
 	// prevent container panic
 	p.updated = time.Now()
@@ -165,7 +165,7 @@ func TestStatusFallback(t *testing.T) {
 
 	p := NewProvider(ctx, util.NewLogger("foo"), nil, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: "at",
-	}), "client", "vin", 0)
+	}), "client", "vin", time.Hour)
 
 	// prevent container panic
 	p.updated = time.Now()


### PR DESCRIPTION
Fixes a bug where a failed cardata container setup would cause requests to an empty container id. Also a failed setup will now be retried after the cache interval.