### PR TITLE
[DRAFT] Session: split charging cost into grid import and solar opportunity cost

### DIFF
--- a/assets/js/components/Sessions/SessionDetailsModal.vue
+++ b/assets/js/components/Sessions/SessionDetailsModal.vue
@@ -104,6 +104,24 @@
 							{{ fmtPricePerKWh(session.pricePerKWh || 0, currency) }}
 						</td>
 					</tr>
+					<tr v-if="showPriceBreakdown" data-testid="session-details-grid-cost">
+						<th class="align-baseline text-muted">
+							{{ $t("session.priceGrid") }}
+						</th>
+						<td class="text-muted">
+							{{ fmtMoney(session.gridCost, currency) }}
+							{{ fmtCurrencySymbol(currency) }}
+						</td>
+					</tr>
+					<tr v-if="showPriceBreakdown" data-testid="session-details-solar-cost">
+						<th class="align-baseline text-muted">
+							{{ $t("session.priceSolar") }}
+						</th>
+						<td class="text-muted">
+							{{ fmtMoney(session.solarCost, currency) }}
+							{{ fmtCurrencySymbol(currency) }}
+						</td>
+					</tr>
 					<tr v-if="session.co2PerKWh != null" data-testid="session-details-co2">
 						<th class="align-baseline">
 							{{ $t("session.co2") }}
@@ -253,6 +271,15 @@ export default defineComponent({
 		},
 		chargedEnergy() {
 			return this.session.chargedEnergy * 1e3;
+		},
+		// only show the grid/solar cost split when solar was actually used, otherwise
+		// gridCost simply equals the total price and the breakdown adds no information
+		showPriceBreakdown(): boolean {
+			return (
+				this.session.gridCost != null &&
+				this.session.solarCost != null &&
+				!!this.session.solarPercentage
+			);
 		},
 		totalCo2Formatted(): string {
 			const grams = (this.session.co2PerKWh ?? 0) * (this.session.chargedEnergy ?? 0);

--- a/assets/js/components/Sessions/SessionDetailsModal.vue
+++ b/assets/js/components/Sessions/SessionDetailsModal.vue
@@ -109,7 +109,7 @@
 							{{ $t("session.priceGrid") }}
 						</th>
 						<td class="text-muted">
-							{{ fmtMoney(session.gridCost, currency) }}
+							{{ fmtMoney(session.gridCost || 0, currency) }}
 							{{ fmtCurrencySymbol(currency) }}
 						</td>
 					</tr>
@@ -118,7 +118,7 @@
 							{{ $t("session.priceSolar") }}
 						</th>
 						<td class="text-muted">
-							{{ fmtMoney(session.solarCost, currency) }}
+							{{ fmtMoney(session.solarCost || 0, currency) }}
 							{{ fmtCurrencySymbol(currency) }}
 						</td>
 					</tr>

--- a/assets/js/components/Sessions/types.ts
+++ b/assets/js/components/Sessions/types.ts
@@ -16,6 +16,8 @@ export interface Session {
   solarPercentage: number;
   price: number | null;
   pricePerKWh: number | null;
+  gridCost: number | null;
+  solarCost: number | null;
   co2PerKWh?: number | null;
 }
 

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -708,10 +708,14 @@ export interface Loadpoint {
   sessionCo2PerKWh: number | null;
   /** Energy charged in the current charging session in kWh. */
   sessionEnergy: number;
+  /** Cost of grid-imported energy in the current charging session in the configured currency. */
+  sessionGridCost: number | null;
   /** Total cost of the current charging session in the configured currency. */
   sessionPrice: number | null;
   /** Average energy price of the current charging session per kWh in the configured currency. */
   sessionPricePerKWh: number | null;
+  /** Opportunity cost of self-consumed solar energy in the current charging session in the configured currency, i.e. the feed-in revenue foregone by using it for charging instead of exporting it. */
+  sessionSolarCost: number | null;
   /** Share of solar energy in the current charging session in %. */
   sessionSolarPercentage: number;
   /** Fast charging with cheap or clean grid energy is currently active. */

--- a/core/energy_metrics.go
+++ b/core/energy_metrics.go
@@ -2,19 +2,22 @@ package core
 
 // EnergyMetrics calculates stats about the charged energy and gives you details about price or co2s
 type EnergyMetrics struct {
-	totalKWh          float64  // Total amount of energy used (kWh)
-	solarKWh          float64  // Self-produced energy (kWh)
-	price             *float64 // Total cost (Currency)
-	co2               *float64 // Amount of emitted CO2 (gCO2eq)
-	currentGreenShare float64  // Current share of solar energy of site (0-1)
-	currentPrice      *float64 // Current price per kWh
-	currentCo2        *float64 // Current co2 emissions
+	totalKWh           float64  // Total amount of energy used (kWh)
+	solarKWh           float64  // Self-produced energy (kWh)
+	gridCost           *float64 // Cost of grid-imported energy (Currency)
+	solarCost          *float64 // Opportunity cost of self-consumed solar energy, i.e. foregone feed-in revenue (Currency)
+	co2                *float64 // Amount of emitted CO2 (gCO2eq)
+	currentGreenShare  float64  // Current share of solar energy of site (0-1)
+	currentGridPrice   *float64 // Current grid import price per kWh
+	currentFeedInPrice *float64 // Current feed-in price per kWh, used to value self-consumed solar energy
+	currentCo2         *float64 // Current co2 emissions
 }
 
-// SetEnvironment updates site information like solar share, price, co2 for use in later calculations
-func (em *EnergyMetrics) SetEnvironment(greenShare float64, effPrice, effCo2 *float64) {
+// SetEnvironment updates site information like solar share, grid and feed-in price, and co2 for use in later calculations
+func (em *EnergyMetrics) SetEnvironment(greenShare float64, gridPrice, feedInPrice, effCo2 *float64) {
 	em.currentGreenShare = greenShare
-	em.currentPrice = effPrice
+	em.currentGridPrice = gridPrice
+	em.currentFeedInPrice = feedInPrice
 	em.currentCo2 = effCo2
 }
 
@@ -28,15 +31,24 @@ func (em *EnergyMetrics) Update(chargedKWh float64) (float64, float64) {
 	}
 	em.totalKWh = chargedKWh
 	addedGreen := added * em.currentGreenShare
+	addedGrid := added - addedGreen
 	em.solarKWh += addedGreen
 	// optional values
-	if em.currentPrice != nil {
-		addedPrice := *em.currentPrice * added
-		newPrice := addedPrice
-		if em.price != nil {
-			newPrice = *em.price + newPrice
+	if em.currentGridPrice != nil {
+		addedCost := *em.currentGridPrice * addedGrid
+		newCost := addedCost
+		if em.gridCost != nil {
+			newCost = *em.gridCost + newCost
 		}
-		em.price = &newPrice
+		em.gridCost = &newCost
+	}
+	if em.currentFeedInPrice != nil {
+		addedCost := *em.currentFeedInPrice * addedGreen
+		newCost := addedCost
+		if em.solarCost != nil {
+			newCost = *em.solarCost + newCost
+		}
+		em.solarCost = &newCost
 	}
 	if em.currentCo2 != nil {
 		addedCo2 := *em.currentCo2 * added
@@ -53,7 +65,8 @@ func (em *EnergyMetrics) Update(chargedKWh float64) (float64, float64) {
 func (em *EnergyMetrics) Reset() {
 	em.totalKWh = 0
 	em.solarKWh = 0
-	em.price = nil
+	em.gridCost = nil
+	em.solarCost = nil
 	em.co2 = nil
 }
 
@@ -70,21 +83,46 @@ func (em *EnergyMetrics) SolarPercentage() float64 {
 	return 100 / em.totalKWh * em.solarKWh
 }
 
-// Price returns the total energy price in Currency
-func (em *EnergyMetrics) Price() *float64 {
-	if em.totalKWh == 0 || em.price == nil {
+// GridCost returns the cost of grid-imported energy in Currency
+func (em *EnergyMetrics) GridCost() *float64 {
+	if em.totalKWh == 0 || em.gridCost == nil {
 		return nil
 	}
-	return em.price
+	return em.gridCost
+}
+
+// SolarCost returns the opportunity cost of self-consumed solar energy in Currency,
+// i.e. the feed-in revenue foregone by using the solar energy for charging instead of exporting it
+func (em *EnergyMetrics) SolarCost() *float64 {
+	if em.totalKWh == 0 || em.solarCost == nil {
+		return nil
+	}
+	return em.solarCost
+}
+
+// Price returns the total energy price in Currency, the sum of grid cost and solar opportunity cost
+func (em *EnergyMetrics) Price() *float64 {
+	if em.totalKWh == 0 || (em.gridCost == nil && em.solarCost == nil) {
+		return nil
+	}
+	var price float64
+	if em.gridCost != nil {
+		price += *em.gridCost
+	}
+	if em.solarCost != nil {
+		price += *em.solarCost
+	}
+	return &price
 }
 
 // PricePerKWh returns the average energy price in Currency
 func (em *EnergyMetrics) PricePerKWh() *float64 {
-	if em.totalKWh == 0 || em.price == nil {
+	price := em.Price()
+	if em.totalKWh == 0 || price == nil {
 		return nil
 	}
-	price := *em.price / em.totalKWh
-	return &price
+	perKWh := *price / em.totalKWh
+	return &perKWh
 }
 
 // Co2PerKWh returns the average co2 emissions per kWh
@@ -102,5 +140,7 @@ func (em *EnergyMetrics) Publish(prefix string, p publisher) {
 	p.publish(prefix+"SolarPercentage", em.SolarPercentage())
 	p.publish(prefix+"PricePerKWh", em.PricePerKWh())
 	p.publish(prefix+"Price", em.Price())
+	p.publish(prefix+"GridCost", em.GridCost())
+	p.publish(prefix+"SolarCost", em.SolarCost())
 	p.publish(prefix+"Co2PerKWh", em.Co2PerKWh())
 }

--- a/core/energy_metrics_test.go
+++ b/core/energy_metrics_test.go
@@ -18,101 +18,101 @@ func TestEnergyMetrics(t *testing.T) {
 	f := func(f float64) *float64 { return &f }
 
 	type tcStep = struct {
-		kWh, greenShare  float64
-		effPrice, effCo2 *float64
+		kWh, greenShare                float64
+		gridPrice, feedInPrice, effCo2 *float64
 	}
 
 	tc := []struct {
-		title                         string
-		steps                         []tcStep
-		totalWh, solarPercentage      float64
-		price, pricePerKWh, co2PerKWh *float64
+		title                                              string
+		steps                                              []tcStep
+		totalWh, solarPercentage                           float64
+		price, pricePerKWh, gridCost, solarCost, co2PerKWh *float64
 	}{
 		{
 			"initial state",
 			[]tcStep{},
-			0, 0, nil, nil, nil,
+			0, 0, nil, nil, nil, nil, nil,
 		},
 		{
 			"energy value",
 			[]tcStep{
-				{0.1, 0, nil, nil},
-				{0.2, 0, nil, nil},
+				{0.1, 0, nil, nil, nil},
+				{0.2, 0, nil, nil, nil},
 			},
-			200, 0, nil, nil, nil,
+			200, 0, nil, nil, nil, nil, nil,
 		},
 		{
 			"ignore lower energy value",
 			[]tcStep{
-				{0.2, 0, nil, nil},
-				{0.1, 0, nil, nil},
+				{0.2, 0, nil, nil, nil},
+				{0.1, 0, nil, nil, nil},
 			},
-			200, 0, nil, nil, nil,
+			200, 0, nil, nil, nil, nil, nil,
 		},
 		{
 			"half solar",
 			[]tcStep{
-				{0.1, 1, nil, nil},
-				{0.2, 0, nil, nil},
+				{0.1, 1, nil, nil, nil},
+				{0.2, 0, nil, nil, nil},
 			},
-			200, 50, nil, nil, nil,
+			200, 50, nil, nil, nil, nil, nil,
 		},
 		{
 			"only solar",
 			[]tcStep{
-				{0.1, 1, nil, nil},
-				{0.2, 1, nil, nil},
+				{0.1, 1, nil, nil, nil},
+				{0.2, 1, nil, nil, nil},
 			},
-			200, 100, nil, nil, nil,
+			200, 100, nil, nil, nil, nil, nil,
 		},
 		{
-			"static price",
+			"static price, grid only",
 			[]tcStep{
-				{1, 0, f(0.5), nil},
+				{1, 0, f(0.5), nil, nil},
 			},
-			1000, 0, f(0.5), f(0.5), nil,
+			1000, 0, f(0.5), f(0.5), f(0.5), nil, nil,
 		},
 		{
-			"dynamic price",
+			"dynamic price, grid only",
 			[]tcStep{
-				{1, 0, f(1), nil},
-				{2, 0, f(0), nil},
+				{1, 0, f(1), nil, nil},
+				{2, 0, f(0), nil, nil},
 			},
-			2000, 0, f(1), f(0.5), nil,
+			2000, 0, f(1), f(0.5), f(1), nil, nil,
 		},
 		{
-			"dynamic price",
+			"dynamic price, grid only",
 			[]tcStep{
-				{2, 0, f(1), nil},
-				{4, 0, f(0), nil},
+				{2, 0, f(1), nil, nil},
+				{4, 0, f(0), nil, nil},
 			},
-			4000, 0, f(2), f(0.5), nil,
+			4000, 0, f(2), f(0.5), f(2), nil, nil,
 		},
 		{
 			"static co2",
 			[]tcStep{
-				{1, 0, nil, f(500)},
+				{1, 0, nil, nil, f(500)},
 			},
-			1000, 0, nil, nil, f(500),
+			1000, 0, nil, nil, nil, nil, f(500),
 		},
 		{
 			"dynamic co2",
 			[]tcStep{
-				{1, 0, nil, f(1000)},
-				{2, 0, nil, f(0)},
+				{1, 0, nil, nil, f(1000)},
+				{2, 0, nil, nil, f(0)},
 			},
-			2000, 0, nil, nil, f(500),
+			2000, 0, nil, nil, nil, nil, f(500),
 		},
 		{
-			"grid only, half, full solar, half, grid only",
+			"grid only, half solar w/ feed-in, full solar, half solar w/ feed-in, grid only",
 			[]tcStep{
-				{1, 0, f(2), f(200)},
-				{2, 0.5, f(1), f(50)},
-				{3, 1, f(0), f(0)},
-				{4, 0.5, f(1), f(50)},
-				{5, 0, f(2), f(200)},
+				{1, 0, f(2), f(1), f(200)},
+				{2, 0.5, f(1), f(1), f(50)},
+				{3, 1, f(0), f(1), f(0)},
+				{4, 0.5, f(1), f(1), f(50)},
+				{5, 0, f(2), f(1), f(200)},
 			},
-			5000, 40, f(6), f(1.2), f(100),
+			5000, 40, f(7), f(1.4), f(5), f(2), f(100),
 		},
 	}
 
@@ -120,7 +120,7 @@ func TestEnergyMetrics(t *testing.T) {
 		var s EnergyMetrics
 
 		for _, tc := range tc.steps {
-			s.SetEnvironment(tc.greenShare, tc.effPrice, tc.effCo2)
+			s.SetEnvironment(tc.greenShare, tc.gridPrice, tc.feedInPrice, tc.effCo2)
 			s.Update(tc.kWh)
 		}
 
@@ -132,24 +132,32 @@ func TestEnergyMetrics(t *testing.T) {
 		}
 		price := s.Price()
 		if !isEqualFloat64(price, tc.price) {
-			t.Errorf("%s: Price was incorrect, got: %v, want: %v.", tc.title, *price, *tc.price)
+			t.Errorf("%s: Price was incorrect, got: %v, want: %v.", tc.title, price, tc.price)
 		}
 		pricePerKWh := s.PricePerKWh()
 		if !isEqualFloat64(pricePerKWh, tc.pricePerKWh) {
-			t.Errorf("%s: PricePerKWh was incorrect, got: %v, want: %v.", tc.title, *pricePerKWh, *tc.pricePerKWh)
+			t.Errorf("%s: PricePerKWh was incorrect, got: %v, want: %v.", tc.title, pricePerKWh, tc.pricePerKWh)
+		}
+		gridCost := s.GridCost()
+		if !isEqualFloat64(gridCost, tc.gridCost) {
+			t.Errorf("%s: GridCost was incorrect, got: %v, want: %v.", tc.title, gridCost, tc.gridCost)
+		}
+		solarCost := s.SolarCost()
+		if !isEqualFloat64(solarCost, tc.solarCost) {
+			t.Errorf("%s: SolarCost was incorrect, got: %v, want: %v.", tc.title, solarCost, tc.solarCost)
 		}
 		co2PerKWh := s.Co2PerKWh()
 		if !isEqualFloat64(co2PerKWh, tc.co2PerKWh) {
-			t.Errorf("%s: Co2PerKWh was incorrect, got: %v, want: %v.", tc.title, *co2PerKWh, *tc.co2PerKWh)
+			t.Errorf("%s: Co2PerKWh was incorrect, got: %v, want: %v.", tc.title, co2PerKWh, tc.co2PerKWh)
 		}
 	}
 
 	// reset
 	var s EnergyMetrics
-	s.SetEnvironment(1, f(1), f(1))
+	s.SetEnvironment(1, f(1), f(1), f(1))
 	s.Update(1)
 	s.Reset()
-	if s.TotalWh() != 0 || s.SolarPercentage() != 0 || s.Co2PerKWh() != nil || s.Price() != nil || s.PricePerKWh() != nil {
+	if s.TotalWh() != 0 || s.SolarPercentage() != 0 || s.Co2PerKWh() != nil || s.Price() != nil || s.PricePerKWh() != nil || s.GridCost() != nil || s.SolarCost() != nil {
 		t.Errorf("Metrics not properly reset %+v", s)
 	}
 }

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -2132,7 +2132,7 @@ func (lp *Loadpoint) phaseSwitchCompleted() bool {
 }
 
 // Update is the main control function. It reevaluates meters and charger state
-func (lp *Loadpoint) Update(sitePower, batteryPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effPrice, effCo2 *float64, dim *bool) {
+func (lp *Loadpoint) Update(sitePower, batteryPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, gridPrice, feedInPrice, effCo2 *float64, dim *bool) {
 	// hold battery boost when SOC drops below the limit: stop draining the battery, but
 	// keep the vehicle prioritised over recharging it (via sitePower priorityAdjustment)
 	// until the vehicle disconnects or the limit is relaxed (see SetBatteryBoostLimit).
@@ -2163,7 +2163,7 @@ func (lp *Loadpoint) Update(sitePower, batteryPower float64, consumption, feedin
 	lp.updateChargeVoltages()
 	lp.phasesFromChargeCurrents()
 
-	lp.energyMetrics.SetEnvironment(greenShare, effPrice, effCo2)
+	lp.energyMetrics.SetEnvironment(greenShare, gridPrice, feedInPrice, effCo2)
 
 	// update ChargeRater here to make sure initial meter update is caught
 	lp.bus.Publish(evChargeCurrent, lp.offeredCurrent)

--- a/core/loadpoint_phases_test.go
+++ b/core/loadpoint_phases_test.go
@@ -709,11 +709,11 @@ func TestUpdatePhaseSwitchNotAvailable(t *testing.T) {
 	attachListeners(t, lp)
 
 	// first cycle attempts the switch, gets api.ErrNotAvailable, adopts 3p
-	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	require.Equal(t, 3, lp.GetPhases(), "configured phases should be adopted")
 
 	// second cycle must not attempt the switch again (Phases1p3p .Times(1))
-	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	require.Equal(t, 3, lp.GetPhases())
 }
 

--- a/core/loadpoint_session.go
+++ b/core/loadpoint_session.go
@@ -86,6 +86,8 @@ func (lp *Loadpoint) applyEnergyMetrics(s *session.Session) {
 	s.SolarPercentage = new(lp.energyMetrics.SolarPercentage())
 	s.Price = lp.energyMetrics.Price()
 	s.PricePerKWh = lp.energyMetrics.PricePerKWh()
+	s.GridCost = lp.energyMetrics.GridCost()
+	s.SolarCost = lp.energyMetrics.SolarCost()
 	s.Co2PerKWh = lp.energyMetrics.Co2PerKWh()
 	s.ChargedEnergy = lp.energyMetrics.TotalWh() / 1e3
 

--- a/core/loadpoint_test.go
+++ b/core/loadpoint_test.go
@@ -185,7 +185,7 @@ func TestUpdatePowerZero(t *testing.T) {
 		}
 
 		lp.mode = tc.mode
-		lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil) // false,sitePower false,0
+		lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil, nil) // false,sitePower false,0
 
 		ctrl.Finish()
 	}
@@ -430,7 +430,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Status().Return(api.StatusC, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
-	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	ctrl.Finish()
 
 	t.Log("charging above target - soc deactivates charger")
@@ -439,7 +439,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Status().Return(api.StatusC, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Enable(false).Return(nil)
-	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	ctrl.Finish()
 
 	t.Log("deactivated charger changes status to B")
@@ -447,14 +447,14 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	vehicle.EXPECT().Soc().Return(95.0, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
-	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	ctrl.Finish()
 
 	t.Log("soc has risen below target - soc update prevented by timer")
 	clock.Add(5 * time.Minute)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
-	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	ctrl.Finish()
 
 	t.Log("soc has fallen below target - soc update timer expired")
@@ -464,7 +464,7 @@ func TestDisableAndEnableAtTargetSoc(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
 	charger.EXPECT().Enable(true).Return(nil)
-	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-500, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	ctrl.Finish()
 }
 
@@ -499,14 +499,14 @@ func TestSetModeAndSocAtDisconnect(t *testing.T) {
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
 	charger.EXPECT().MaxCurrent(int64(maxA)).Return(nil)
-	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 
 	t.Log("switch off when disconnected")
 	clock.Add(5 * time.Minute)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusA, nil)
 	charger.EXPECT().Enable(false).Return(nil)
-	lp.Update(-300, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-300, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 
 	if mode := lp.GetMode(); mode != api.ModeOff {
 		t.Error("unexpected mode", mode)
@@ -568,14 +568,14 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(0.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 
 	t.Log("at 1:00h charging at 5 kWh")
 	clock.Add(time.Hour)
 	rater.EXPECT().ChargedEnergy().Return(5.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	expectCache("chargedEnergy", 5000.0)
 
 	t.Log("at 1:00h stop charging at 5 kWh")
@@ -583,7 +583,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(5.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
-	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	expectCache("chargedEnergy", 5000.0)
 
 	t.Log("at 1:00h restart charging at 5 kWh")
@@ -591,7 +591,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(5.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	expectCache("chargedEnergy", 5000.0)
 
 	t.Log("at 1:30h continue charging at 7.5 kWh")
@@ -599,7 +599,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(7.5, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusC, nil)
-	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	expectCache("chargedEnergy", 7500.0)
 
 	t.Log("at 2:00h stop charging at 10 kWh")
@@ -607,7 +607,7 @@ func TestChargedEnergyAtDisconnect(t *testing.T) {
 	rater.EXPECT().ChargedEnergy().Return(10.0, nil)
 	charger.EXPECT().Enabled().Return(lp.enabled, nil)
 	charger.EXPECT().Status().Return(api.StatusB, nil)
-	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(-1, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	expectCache("chargedEnergy", 10000.0)
 
 	ctrl.Finish()
@@ -808,7 +808,7 @@ func TestConnectionDurationDropDetection(t *testing.T) {
 	lp.connectedTime = connectedTime
 
 	ct.EXPECT().ConnectionDuration().Return(0*time.Second, nil)
-	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil)
+	lp.Update(500, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 	ctrl.Finish()
 
 	assert.NotEqual(t, connectedTime, lp.connectedTime)

--- a/core/loadpoint_vehicle_test.go
+++ b/core/loadpoint_vehicle_test.go
@@ -575,7 +575,7 @@ func TestReconnectVehicle(t *testing.T) {
 			// vehicle not updated yet
 			vehicle.MockChargeState.EXPECT().Status().Return(api.StatusA, nil)
 
-			lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil)
+			lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 			ctrl.Finish()
 
 			// detection started
@@ -589,7 +589,7 @@ func TestReconnectVehicle(t *testing.T) {
 			// vehicle not updated yet
 			vehicle.MockChargeState.EXPECT().Status().Return(api.StatusB, nil)
 
-			lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil)
+			lp.Update(0, 0, nil, nil, false, false, 0, nil, nil, nil, nil)
 			ctrl.Finish()
 
 			// vehicle detected

--- a/core/session/session.go
+++ b/core/session/session.go
@@ -25,6 +25,8 @@ type Session struct {
 	SolarPercentage      *float64       `json:"solarPercentage" csv:"Solar (%)" gorm:"column:solar_percentage"`
 	Price                *float64       `json:"price" csv:"Price" gorm:"column:price"`
 	PricePerKWh          *float64       `json:"pricePerKWh" csv:"Price/kWh" gorm:"column:price_per_kwh"`
+	GridCost             *float64       `json:"gridCost" csv:"Grid Cost" gorm:"column:grid_cost"`
+	SolarCost            *float64       `json:"solarCost" csv:"Solar Opportunity Cost" gorm:"column:solar_cost"`
 	Co2PerKWh            *float64       `json:"co2PerKWh" csv:"CO2/kWh (gCO2eq)" gorm:"column:co2_per_kwh"`
 	ReferencePricePerKWh *float64       `json:"referencePricePerKWh" csv:"Reference Price/kWh" gorm:"column:reference_price_per_kwh"`
 	ReferenceCo2PerKWh   *float64       `json:"referenceCo2PerKWh" csv:"Reference CO2/kWh (gCO2eq)" gorm:"column:reference_co2_per_kwh"`

--- a/core/site.go
+++ b/core/site.go
@@ -46,7 +46,7 @@ const standbyPower = 10 // consider less than 10W as charger in standby
 // updater abstracts the Loadpoint implementation for testing
 type updater interface {
 	loadpoint.API
-	Update(sitePower, batteryPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, effectivePrice, effectiveCo2 *float64, dim *bool)
+	Update(sitePower, batteryPower float64, consumption, feedin api.Rates, batteryBuffered, batteryStart bool, greenShare float64, gridPrice, feedInPrice, effectiveCo2 *float64, dim *bool)
 }
 
 var _ site.API = (*Site)(nil)
@@ -1332,7 +1332,7 @@ func (site *Site) updatePower(lp updater, state siteState, totalChargePower floa
 
 		lp.Update(
 			sitePower, state.battery.Power, consumption, feedin, res.batteryBuffered, res.batteryStart,
-			greenShareLoadpoints, site.effectivePrice(greenShareLoadpoints), site.effectiveCo2(greenShareLoadpoints),
+			greenShareLoadpoints, site.gridPrice(), site.feedInPrice(), site.effectiveCo2(greenShareLoadpoints),
 			hems.Dimmed(site.hems),
 		)
 	}

--- a/core/site_prioritize_test.go
+++ b/core/site_prioritize_test.go
@@ -156,7 +156,7 @@ func TestReservedPVPowerSmartFeedInPause(t *testing.T) {
 
 			// the pause holds across cycles, so must the absence of a reservation
 			for i := range 2 {
-				car.Update(-3500, 0, nil, feedin, false, false, 0, nil, nil, nil)
+				car.Update(-3500, 0, nil, feedin, false, false, 0, nil, nil, nil, nil)
 
 				if car.enabled {
 					t.Fatalf("cycle %d: car must be paused by the feed-in limit", i)

--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -95,6 +95,23 @@ func (site *Site) effectivePrice(greenShare float64) *float64 {
 	return nil
 }
 
+// gridPrice returns the current grid import price per kWh
+func (site *Site) gridPrice() *float64 {
+	if grid, err := tariff.Now(site.GetTariff(api.TariffUsageGrid)); err == nil {
+		return &grid
+	}
+	return nil
+}
+
+// feedInPrice returns the current feed-in price per kWh, used to value self-consumed
+// solar energy as the opportunity cost of not exporting it to the grid.
+func (site *Site) feedInPrice() *float64 {
+	if feedin, err := tariff.Now(site.GetTariff(api.TariffUsageFeedIn)); err == nil {
+		return &feedin
+	}
+	return nil
+}
+
 // effectiveCo2 calculates the amount of emitted co2 based on self-produced and grid-imported energy.
 func (site *Site) effectiveCo2(greenShare float64) *float64 {
 	if co2, err := tariff.Now(site.GetTariff(api.TariffUsageCo2)); err == nil {

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1641,6 +1641,8 @@
     "meterstop": "Endzählerstand",
     "odometer": "Kilometerstand",
     "price": "Kosten",
+    "priceGrid": "Netzbezug",
+    "priceSolar": "Opportunitätskosten für exportierten Solarstrom",
     "soc": "Ladung",
     "started": "Startzeit",
     "title": "Ladevorgang"
@@ -1678,6 +1680,7 @@
       "co2perkwh": "CO₂/kWh",
       "created": "Startzeit",
       "finished": "Endzeit",
+      "gridcost": "Netzkosten",
       "identifier": "Kennung",
       "loadpoint": "Ladepunkt",
       "meterstart": "Anfangszählerstand (kWh)",
@@ -1687,6 +1690,7 @@
       "priceperkwh": "Preis/kWh",
       "socend": "Ladestand Ende (%)",
       "socstart": "Ladestand Start (%)",
+      "solarcost": "Opportunitätskosten Solar",
       "solarpercentage": "Sonne (%)",
       "vehicle": "Fahrzeug"
     },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1641,6 +1641,8 @@
     "meterstop": "Meter stop",
     "odometer": "Mileage",
     "price": "Cost",
+    "priceGrid": "Imported power",
+    "priceSolar": "Opportunity cost of exported solar",
     "soc": "Charge",
     "started": "Started",
     "title": "Charging Session"
@@ -1678,6 +1680,7 @@
       "co2perkwh": "CO₂/kWh",
       "created": "Created",
       "finished": "Finished",
+      "gridcost": "Grid Cost",
       "identifier": "Identifier",
       "loadpoint": "Charging point",
       "meterstart": "Meter start (kWh)",
@@ -1687,6 +1690,7 @@
       "priceperkwh": "Price/kWh",
       "socend": "SoC end (%)",
       "socstart": "SoC start (%)",
+      "solarcost": "Solar Opportunity Cost",
       "solarpercentage": "Solar (%)",
       "vehicle": "Vehicle"
     },

--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -3318,6 +3318,11 @@
             "description": "Energy charged in the current charging session in kWh.",
             "type": "number"
           },
+          "sessionGridCost": {
+            "description": "Cost of grid-imported energy in the current charging session in the configured currency.",
+            "type": "number",
+            "nullable": true
+          },
           "sessionPrice": {
             "description": "Total cost of the current charging session in the configured currency.",
             "type": "number",
@@ -3325,6 +3330,11 @@
           },
           "sessionPricePerKWh": {
             "description": "Average energy price of the current charging session per kWh in the configured currency.",
+            "type": "number",
+            "nullable": true
+          },
+          "sessionSolarCost": {
+            "description": "Opportunity cost of self-consumed solar energy in the current charging session in the configured currency, i.e. the feed-in revenue foregone by using it for charging instead of exporting it.",
             "type": "number",
             "nullable": true
           },
@@ -3490,8 +3500,10 @@
           "pvRemaining",
           "sessionCo2PerKWh",
           "sessionEnergy",
+          "sessionGridCost",
           "sessionPrice",
           "sessionPricePerKWh",
+          "sessionSolarCost",
           "sessionSolarPercentage",
           "smartCostActive",
           "smartCostLimit",

--- a/server/openapi.state.yaml
+++ b/server/openapi.state.yaml
@@ -968,12 +968,20 @@ components:
         sessionEnergy:
           description: Energy charged in the current charging session in kWh.
           type: number
+        sessionGridCost:
+          description: Cost of grid-imported energy in the current charging session in the configured currency.
+          type: number
+          nullable: true
         sessionPrice:
           description: Total cost of the current charging session in the configured currency.
           type: number
           nullable: true
         sessionPricePerKWh:
           description: Average energy price of the current charging session per kWh in the configured currency.
+          type: number
+          nullable: true
+        sessionSolarCost:
+          description: Opportunity cost of self-consumed solar energy in the current charging session in the configured currency, i.e. the feed-in revenue foregone by using it for charging instead of exporting it.
           type: number
           nullable: true
         sessionSolarPercentage:
@@ -1113,8 +1121,10 @@ components:
         - pvRemaining
         - sessionCo2PerKWh
         - sessionEnergy
+        - sessionGridCost
         - sessionPrice
         - sessionPricePerKWh
+        - sessionSolarCost
         - sessionSolarPercentage
         - smartCostActive
         - smartCostLimit


### PR DESCRIPTION
Closes #33251

Previously a session's cost was a single blended value combining the price paid for grid-imported energy and the opportunity cost of self-consumed solar (the feed-in revenue foregone by charging instead of exporting).

- EnergyMetrics now tracks gridCost and solarCost separately instead of a single price accumulator; Price() remains the sum of both for compat
- Site passes raw grid and feed-in tariff rates to Loadpoint.Update instead of a pre-blended effective price, so the split can be computed downstream
- Session struct gains GridCost/SolarCost fields (auto-migrated, no manual DB migration needed) with CSV export headers and translations
- SessionDetailsModal shows two muted sub-rows under the existing Cost row breaking down grid vs. solar cost, only when the session actually used solar (avoids a meaningless 0.00 row on setups without solar/PV)
- Existing sessions keep their original Price/PricePerKWh; GridCost/ SolarCost are simply null until recalculated for new sessions