### PR TITLE
Zaptec Go 2: stop retrying phase switching while APM is active

### DIFF
--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -113,7 +113,6 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 		}),
 		Base: c.Transport,
 	}
-	c.Transport = tr
 
 	// setup cached values
 	c.statusG = util.ResettableCached(func() (zaptec.StateResponse, error) {

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -25,7 +25,6 @@ import (
 	"math"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -57,7 +56,6 @@ type Zaptec struct {
 	passive         bool
 	startPrevention bool
 	lastStatus      int
-	apmActive       bool // installation updates are rejected while APM is active
 
 	session      string    // last seen SessionIdentifier
 	sessionStart time.Time // start of the current session
@@ -480,35 +478,12 @@ func (c *Zaptec) installation() (zaptec.Installation, error) {
 }
 
 func (c *Zaptec) installationUpdate(data zaptec.UpdateInstallation) error {
-	// APM is a property of the installation, so once rejected the update can only
-	// succeed again after APM has been turned off and evcc restarted
-	if c.apmActive {
-		return api.ErrNotAvailable
-	}
-
 	uri := fmt.Sprintf("%s/api/installation/%s/update", zaptec.ApiURL, c.instance.InstallationId)
 
 	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
-
-	var res struct {
-		Code    int
-		Details string
-	}
-
-	err := c.DoJSON(req, &res)
+	_, err := c.DoBody(req)
 	if err == nil {
 		c.statusG.Reset()
-		return nil
-	}
-
-	// 527 covers all rejected installation updates, so the details decide: when
-	// Zaptec's Adaptive Power Management is active, installation updates are
-	// blocked altogether and phase switching can never succeed
-	if res.Code == 527 && strings.Contains(strings.ToLower(res.Details), "apm") {
-		c.log.WARN.Printf("installation update rejected (%d: %s)- phase switching is not available and will not be retried until restart", res.Code, res.Details)
-		c.apmActive = true
-
-		return api.ErrNotAvailable
 	}
 
 	return err

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -90,7 +90,7 @@ func NewZaptecFromConfig(ctx context.Context, other map[string]any) (api.Charger
 }
 
 // NewZaptec creates Zaptec charger
-func NewZaptec(_ context.Context, user, password, id string, priority bool, passive bool, cache time.Duration, startPrevention bool) (api.Charger, error) {
+func NewZaptec(ctx context.Context, user, password, id string, priority bool, passive bool, cache time.Duration, startPrevention bool) (api.Charger, error) {
 	log := util.NewLogger("zaptec").Redact(user, password)
 
 	if !sponsor.IsAuthorized() {
@@ -107,12 +107,13 @@ func NewZaptec(_ context.Context, user, password, id string, priority bool, pass
 	}
 
 	// Add User-Agent header for Zaptec API compliance
-	c.Client.Transport = &transport.Decorator{
+	tr := &transport.Decorator{
 		Decorator: transport.DecorateHeaders(map[string]string{
 			"User-Agent": "evcc/" + util.Version,
 		}),
-		Base: c.Client.Transport,
+		Base: c.Transport,
 	}
+	c.Transport = tr
 
 	// setup cached values
 	c.statusG = util.ResettableCached(func() (zaptec.StateResponse, error) {
@@ -124,11 +125,8 @@ func NewZaptec(_ context.Context, user, password, id string, priority bool, pass
 		return res, err
 	}, cache)
 
-	// Create a separate HTTP client for OAuth token requests to avoid circular dependency
-	// (c.Transport will be modified to use oauth2.Transport, which would create a loop)
-	tsCtx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
-		Transport: c.Transport,
-	})
+	// token requests need their own client- c.Transport is wrapped in oauth2.Transport below
+	tsCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
 
 	// Get shared token source for this user (per-user uniqueness)
 	ts, err := zaptec.TokenSource(tsCtx, user, password)
@@ -138,7 +136,7 @@ func NewZaptec(_ context.Context, user, password, id string, priority bool, pass
 
 	c.Transport = &oauth2.Transport{
 		Source: ts,
-		Base:   c.Transport,
+		Base:   tr,
 	}
 
 	c.instance, err = ensureChargerEx(id, c.chargers, func(charger zaptec.Charger) (string, error) {
@@ -153,23 +151,27 @@ func NewZaptec(_ context.Context, user, password, id string, priority bool, pass
 		return nil, err
 	}
 
+	go2 := c.version == zaptec.ZaptecGo2
+
 	inst, err := c.installation()
 
-	// the Zaptec Go 2 switches phases by updating the installation, which is rejected
-	// as long as adaptive power management (APM) is active, so such an installation
-	// cannot offer phase switching at all
-	apm := err == nil && c.version != zaptec.ZaptecGo1_Pro && inst.EnabledFeatures.Has(zaptec.FeaturePowerManagementApm)
-	if apm {
-		c.log.WARN.Println("phase switching not available: installation uses adaptive power management (APM)")
-	}
-
-	if (err == nil || c.version == zaptec.ZaptecGo1_Pro) && !apm {
+	switch {
+	case !go2:
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
-	}
 
-	// the Zaptec Go 2 switches phases via the installation's per-phase available current;
-	// 1p->3p only works when all phases are set equal, so warn about an inconsistent setting
-	if err == nil && c.version != zaptec.ZaptecGo1_Pro && !apm {
+	case err != nil:
+		c.log.WARN.Println("phase switching not available:", err)
+
+	// the Zaptec Go 2 switches phases by updating the installation, which is rejected
+	// as long as adaptive power management (APM) is active
+	case inst.EnabledFeatures.Has(zaptec.FeaturePowerManagementApm):
+		c.log.WARN.Println("phase switching not available: installation uses adaptive power management (APM)")
+
+	default:
+		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
+
+		// the Zaptec Go 2 switches phases via the installation's per-phase available current;
+		// 1p->3p only works when all phases are set equal, so warn about an inconsistent setting
 		if p1, p2, p3 := inst.AvailableCurrentPhase1, inst.AvailableCurrentPhase2, inst.AvailableCurrentPhase3; p2 != p1 || p3 != p1 {
 			c.log.WARN.Printf("installation available current is unequal across phases (%.3gA/%.3gA/%.3gA); phase switching back to 3p requires available current on all phases", p1, p2, p3)
 		}

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -481,9 +481,22 @@ func (c *Zaptec) installationUpdate(data zaptec.UpdateInstallation) error {
 	uri := fmt.Sprintf("%s/api/installation/%s/update", zaptec.ApiURL, c.instance.InstallationId)
 
 	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
-	_, err := c.DoBody(req)
+
+	var res struct {
+		Code int
+	}
+
+	err := c.DoJSON(req, &res)
 	if err == nil {
 		c.statusG.Reset()
+		return nil
+	}
+
+	// 527: Cannot update installation when using APM- when Zaptec's Adaptive
+	// Power Management is active, installation updates are permanently blocked,
+	// so phase switching can never succeed
+	if res.Code == 527 {
+		return api.ErrNotAvailable
 	}
 
 	return err

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -56,6 +57,7 @@ type Zaptec struct {
 	passive         bool
 	startPrevention bool
 	lastStatus      int
+	apmActive       bool // installation updates are rejected while APM is active
 
 	session      string    // last seen SessionIdentifier
 	sessionStart time.Time // start of the current session
@@ -478,12 +480,19 @@ func (c *Zaptec) installation() (zaptec.Installation, error) {
 }
 
 func (c *Zaptec) installationUpdate(data zaptec.UpdateInstallation) error {
+	// APM is a property of the installation, so once rejected the update can only
+	// succeed again after APM has been turned off and evcc restarted
+	if c.apmActive {
+		return api.ErrNotAvailable
+	}
+
 	uri := fmt.Sprintf("%s/api/installation/%s/update", zaptec.ApiURL, c.instance.InstallationId)
 
 	req, _ := request.New(http.MethodPost, uri, request.MarshalJSON(data), request.JSONEncoding)
 
 	var res struct {
-		Code int
+		Code    int
+		Details string
 	}
 
 	err := c.DoJSON(req, &res)
@@ -492,10 +501,13 @@ func (c *Zaptec) installationUpdate(data zaptec.UpdateInstallation) error {
 		return nil
 	}
 
-	// 527: Cannot update installation when using APM- when Zaptec's Adaptive
-	// Power Management is active, installation updates are permanently blocked,
-	// so phase switching can never succeed
-	if res.Code == 527 {
+	// 527 covers all rejected installation updates, so the details decide: when
+	// Zaptec's Adaptive Power Management is active, installation updates are
+	// blocked altogether and phase switching can never succeed
+	if res.Code == 527 && strings.Contains(strings.ToLower(res.Details), "apm") {
+		c.log.WARN.Printf("installation update rejected (%d: %s)- phase switching is not available and will not be retried until restart", res.Code, res.Details)
+		c.apmActive = true
+
 		return api.ErrNotAvailable
 	}
 

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -150,12 +150,10 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 		return nil, err
 	}
 
-	go2 := c.version == zaptec.ZaptecGo2
-
 	inst, err := c.installation()
 
 	switch {
-	case !go2:
+	case c.version != zaptec.ZaptecGo2:
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
 
 	case err != nil:

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -154,13 +154,22 @@ func NewZaptec(_ context.Context, user, password, id string, priority bool, pass
 	}
 
 	inst, err := c.installation()
-	if err == nil || c.version == zaptec.ZaptecGo1_Pro {
+
+	// the Zaptec Go 2 switches phases by updating the installation, which is rejected
+	// as long as adaptive power management (APM) is active, so such an installation
+	// cannot offer phase switching at all
+	apm := err == nil && c.version != zaptec.ZaptecGo1_Pro && inst.EnabledFeatures.Has(zaptec.FeaturePowerManagementApm)
+	if apm {
+		c.log.WARN.Println("phase switching not available: installation uses adaptive power management (APM)")
+	}
+
+	if (err == nil || c.version == zaptec.ZaptecGo1_Pro) && !apm {
 		implement.Has(c, implement.PhaseSwitcher(c.phases1p3p))
 	}
 
 	// the Zaptec Go 2 switches phases via the installation's per-phase available current;
 	// 1p->3p only works when all phases are set equal, so warn about an inconsistent setting
-	if err == nil && c.version == zaptec.ZaptecGo2 {
+	if err == nil && c.version != zaptec.ZaptecGo1_Pro && !apm {
 		if p1, p2, p3 := inst.AvailableCurrentPhase1, inst.AvailableCurrentPhase2, inst.AvailableCurrentPhase3; p2 != p1 || p3 != p1 {
 			c.log.WARN.Printf("installation available current is unequal across phases (%.3gA/%.3gA/%.3gA); phase switching back to 3p requires available current on all phases", p1, p2, p3)
 		}

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -106,14 +106,6 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 		startPrevention: startPrevention,
 	}
 
-	// Add User-Agent header for Zaptec API compliance
-	tr := &transport.Decorator{
-		Decorator: transport.DecorateHeaders(map[string]string{
-			"User-Agent": "evcc/" + util.Version,
-		}),
-		Base: c.Transport,
-	}
-
 	// setup cached values
 	c.statusG = util.ResettableCached(func() (zaptec.StateResponse, error) {
 		var res zaptec.StateResponse
@@ -123,6 +115,14 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 
 		return res, err
 	}, cache)
+
+	// Add User-Agent header for Zaptec API compliance
+	tr := &transport.Decorator{
+		Decorator: transport.DecorateHeaders(map[string]string{
+			"User-Agent": "evcc/" + util.Version,
+		}),
+		Base: c.Transport,
+	}
 
 	// token requests need their own client- c.Transport is wrapped in oauth2.Transport below
 	tsCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})

--- a/charger/zaptec/const.go
+++ b/charger/zaptec/const.go
@@ -146,3 +146,16 @@ const (
 	ZaptecGo1_Pro = 0
 	ZaptecGo2     = 1
 )
+
+// Features is the installation's feature flag bitmask
+type Features int
+
+// See https://api.zaptec.com/swagger/v1/swagger.json
+const (
+	FeaturePowerManagementApm Features = 4 // adaptive power management
+)
+
+// Has reports whether the feature set contains the given feature
+func (f Features) Has(feature Features) bool {
+	return f&feature != 0
+}

--- a/charger/zaptec/types.go
+++ b/charger/zaptec/types.go
@@ -85,11 +85,12 @@ type SessionPriority struct {
 }
 
 type Installation struct {
-	Id                     string  `json:"id"`
-	MaxCurrent             float64 `json:"maxCurrent"`
-	AvailableCurrentPhase1 float64 `json:"availableCurrentPhase1"`
-	AvailableCurrentPhase2 float64 `json:"availableCurrentPhase2"`
-	AvailableCurrentPhase3 float64 `json:"availableCurrentPhase3"`
+	Id                     string   `json:"id"`
+	MaxCurrent             float64  `json:"maxCurrent"`
+	AvailableCurrentPhase1 float64  `json:"availableCurrentPhase1"`
+	AvailableCurrentPhase2 float64  `json:"availableCurrentPhase2"`
+	AvailableCurrentPhase3 float64  `json:"availableCurrentPhase3"`
+	EnabledFeatures        Features `json:"enabledFeatures"`
 }
 
 type UpdateInstallation struct {


### PR DESCRIPTION
This PR stops evcc from retrying a phase switch that the Zaptec API has already told us can never succeed. Fixes #33253, and supersedes #33254.

This means instead of trying to keep making requests to `api.zaptec.com` and flooding the logs every 30 seconds, this now shows up like this, once — only the first time it happens:

<img width="700" alt="screenshot of logs" src="https://github.com/user-attachments/assets/0f8dcacc-0793-4e21-a2ef-0f03852b228c" />

After that, retrying this will no longer be attempted (until after a restart), so it will no longer be hammering `api.zaptec.com` every 30 seconds.

By the way, a HTTP 527 looked like the generic "installation update rejected" code, which could be returned for more things than just APM-related errors, so only a rejection whose error message mentions "APM" is treated as permanent — anything else is passed on and still retried exactly as before.
