### PR TITLE
Add BYN, UAH, RUB and KZT to currency list

### DIFF
--- a/assets/js/mixins/formatter.ts
+++ b/assets/js/mixins/formatter.ts
@@ -75,6 +75,10 @@ const CURRENCY_SYMBOLS: Record<CURRENCY, string> = {
   TRY: "₺",
   MYR: "RM",
   THB: "฿",
+  BYN: "Br",
+  UAH: "₴",
+  RUB: "₽",
+  KZT: "₸",
 };
 
 // list of currencies where energy price should be displayed in subunits (factor 100)
@@ -94,6 +98,7 @@ const ENERGY_PRICE_IN_SUBUNIT: Partial<Record<CURRENCY, string>> = {
   SEK: "öre", // Swedish öre
   ZAR: "c", // South African cent
   TRY: "krş", // Türkiye kuruş
+  BYN: "к.", // Belarusian kapeyka
 };
 
 export enum POWER_UNIT {

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -816,6 +816,10 @@ export enum CURRENCY {
   TRY = "TRY",
   MYR = "MYR",
   THB = "THB",
+  BYN = "BYN",
+  UAH = "UAH",
+  RUB = "RUB",
+  KZT = "KZT",
 }
 
 export enum ICON_SIZE {

--- a/server/mcp/openapi.json
+++ b/server/mcp/openapi.json
@@ -3648,7 +3648,11 @@
           "ZAR",
           "TRY",
           "MYR",
-          "THB"
+          "THB",
+          "BYN",
+          "UAH",
+          "RUB",
+          "KZT"
         ]
       },
       "FatalError": {

--- a/server/openapi.state.yaml
+++ b/server/openapi.state.yaml
@@ -510,6 +510,10 @@ components:
         - TRY
         - MYR
         - THB
+        - BYN
+        - UAH
+        - RUB
+        - KZT
     DeviceColorEntry:
       description: Color assigned to a device for consistent UI display.
       type: object


### PR DESCRIPTION
- adds BYN, UAH, RUB and KZT to the currency list
- BYN is shown in kapeyka, like EUR in cent, since main-unit values stay below 1 per kWh (the electric heating tariff is 0.0487 BYN/kWh)
- UAH, RUB and KZT use their main unit, which is how tariffs are quoted on local bills and by the regulators

Rendered examples using current residential tariffs and a 40 kWh session:

| Currency | Price per kWh | Session cost |
| --- | --- | --- |
| BYN | 32.7 к./kWh | BYN 13.06 |
| UAH | 4.32 ₴/kWh | ₴172.80 |
| RUB | 8.9 ₽/kWh | ₽356.00 |
| KZT | 31.2 ₸/kWh | ₸1,248.00 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
