### PR TITLE
Home Assistant: link charge status docs

### DIFF
--- a/templates/definition/charger/homeassistant.yaml
+++ b/templates/definition/charger/homeassistant.yaml
@@ -41,8 +41,8 @@ params:
     example: not_plugged, disconnected
     advanced: true
     help:
-      en: Comma-separated list of additional states meaning ready
-      de: Komma-getrennte Liste zusätzlicher Zustände für bereit
+      en: Comma-separated list of additional states meaning ready, see [docs.evcc.io](https://docs.evcc.io/en/smarthome/home-assistant#charge-status)
+      de: Komma-getrennte Liste zusätzlicher Zustände für bereit, siehe [docs.evcc.io](https://docs.evcc.io/de/smarthome/home-assistant#charge-status)
   - name: statusB
     description:
       de: Zustände für Status B
@@ -50,8 +50,8 @@ params:
     example: charging_stopped, charging_completed
     advanced: true
     help:
-      en: Comma-separated list of additional states meaning connected
-      de: Komma-getrennte Liste zusätzlicher Zustände für verbunden
+      en: Comma-separated list of additional states meaning connected, see [docs.evcc.io](https://docs.evcc.io/en/smarthome/home-assistant#charge-status)
+      de: Komma-getrennte Liste zusätzlicher Zustände für verbunden, siehe [docs.evcc.io](https://docs.evcc.io/de/smarthome/home-assistant#charge-status)
   - name: statusC
     description:
       de: Zustände für Status C
@@ -59,8 +59,8 @@ params:
     example: instant_charging, fast_charging
     advanced: true
     help:
-      en: Comma-separated list of additional states meaning charging
-      de: Komma-getrennte Liste zusätzlicher Zustände für laden
+      en: Comma-separated list of additional states meaning charging, see [docs.evcc.io](https://docs.evcc.io/en/smarthome/home-assistant#charge-status)
+      de: Komma-getrennte Liste zusätzlicher Zustände für laden, siehe [docs.evcc.io](https://docs.evcc.io/de/smarthome/home-assistant#charge-status)
   - name: enabled
     description:
       de: Aktivierungsstatus-Sensor

--- a/templates/definition/vehicle/homeassistant.yaml
+++ b/templates/definition/vehicle/homeassistant.yaml
@@ -61,8 +61,8 @@ params:
     example: not_plugged, disconnected
     advanced: true
     help:
-      en: Comma-separated list of additional states meaning disconnected
-      de: Komma-getrennte Liste zusätzlicher Zustände für getrennt
+      en: Comma-separated list of additional states meaning disconnected, see [docs.evcc.io](https://docs.evcc.io/en/smarthome/home-assistant#charge-status)
+      de: Komma-getrennte Liste zusätzlicher Zustände für getrennt, siehe [docs.evcc.io](https://docs.evcc.io/de/smarthome/home-assistant#charge-status)
   - name: statusB
     description:
       de: Zustände für Status B
@@ -70,8 +70,8 @@ params:
     example: charging_stopped, charging_completed
     advanced: true
     help:
-      en: Comma-separated list of additional states meaning connected
-      de: Komma-getrennte Liste zusätzlicher Zustände für verbunden
+      en: Comma-separated list of additional states meaning connected, see [docs.evcc.io](https://docs.evcc.io/en/smarthome/home-assistant#charge-status)
+      de: Komma-getrennte Liste zusätzlicher Zustände für verbunden, siehe [docs.evcc.io](https://docs.evcc.io/de/smarthome/home-assistant#charge-status)
   - name: statusC
     description:
       de: Zustände für Status C
@@ -79,8 +79,8 @@ params:
     example: instant_charging, fast_charging
     advanced: true
     help:
-      en: Comma-separated list of additional states meaning charging
-      de: Komma-getrennte Liste zusätzlicher Zustände für laden
+      en: Comma-separated list of additional states meaning charging, see [docs.evcc.io](https://docs.evcc.io/en/smarthome/home-assistant#charge-status)
+      de: Komma-getrennte Liste zusätzlicher Zustände für laden, siehe [docs.evcc.io](https://docs.evcc.io/de/smarthome/home-assistant#charge-status)
   - name: limitSoc
     description:
       de: Ziel-Ladezustand [%]
@@ -124,8 +124,8 @@ params:
     service: homeassistant/entities?uri={uri}&insecure={insecure}&domain=script,switch
     example: "script.vehicle_start_charge; switch.vehicle_charger"
     help:
-      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger). If a switch is provided, Service to stop charging must be left empty.
-      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger). Wenn ein Schalter angegeben wird, muss der Service zum Stoppen des Ladens leer bleiben.
+      en: Entity ID for a script or a switch that starts charging the vehicle. Only useful with the [Vehicle API-only charger](https://docs.evcc.io/en/chargers/vehicle-api-only-charger). If a switch is provided, Service to stop charging must be left empty.
+      de: Entitäts-ID für ein Skript oder einen Schalter zum Starten des Ladevorgangs. Nur sinnvoll mit der [Fahrzeug-API Ladesteuerung](https://docs.evcc.io/de/chargers/vehicle-api-only-charger). Wenn ein Schalter angegeben wird, muss der Service zum Stoppen des Ladens leer bleiben.
   - name: stop_charging
     description:
       de: Service zum Laden stoppen
@@ -133,8 +133,8 @@ params:
     service: homeassistant/entities?uri={uri}&insecure={insecure}&domain=script
     example: "script.vehicle_stop_charge"
     help:
-      en: Entity ID for a script that stops charging the vehicle. Only useful with the [docs.evcc.io](https://docs.evcc.io/en/docs/devices/chargers#vehicle-api-only-charger).
-      de: Entitäts-ID für ein Skript zum Stoppen des Ladevorgangs. Nur sinnvoll mit der [docs.evcc.io](https://docs.evcc.io/docs/devices/chargers#vehicle-api-only-charger).
+      en: Entity ID for a script that stops charging the vehicle. Only useful with the [Vehicle API-only charger](https://docs.evcc.io/en/chargers/vehicle-api-only-charger).
+      de: Entitäts-ID für ein Skript zum Stoppen des Ladevorgangs. Nur sinnvoll mit der [Fahrzeug-API Ladesteuerung](https://docs.evcc.io/de/chargers/vehicle-api-only-charger).
   - name: wakeup
     description:
       de: Service zum Aufwecken


### PR DESCRIPTION
pairs with evcc-io/docs#1174, follows up #32136

The `statusA/B/C` help texts explain the syntax but not which states are built in, so users have no way to tell what they still need to add. The docs page now carries that mapping and the help links to it.

- `statusA/B/C` help in the Home Assistant charger and vehicle templates links to the charge status section of the docs
- the charge start/stop help in the vehicle template pointed at Docusaurus era URLs that have been dead since the docs migration, they now point at the vehicle API-only charger page and use its name as link text instead of the bare domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
