### PR TITLE
Add battery control for Zendure SolarFlow 800 Pro

### DIFF
--- a/templates/definition/meter/zendure-solarflow-pro.yaml
+++ b/templates/definition/meter/zendure-solarflow-pro.yaml
@@ -3,13 +3,31 @@ products:
   - brand: Zendure
     description:
       generic: Solarflow 800 Pro
+capabilities: ["battery-control"]
+requirements:
+  description:
+    de: |
+      Für die aktive Batteriesteuerung muss die lokale API über die Zendure App aktiviert werden (HEMS hinzufügen und wieder verlassen).
+      Die Seriennummer des Geräts ist in der Zendure App in den Geräteeinstellungen zu finden.
+    en: |
+      For active battery control, the local API must be enabled via the Zendure App (add HEMS and then exit to apply).
+      The device serial number can be found in the Zendure App in the device settings.
 params:
   - name: usage
     choice: ["pv", "battery"]
   - name: host
+  - name: serial
+    required: true
+    example: WOB1NHMAMXXXXX3
+    usages: ["battery"]
+    help:
+      de: Seriennummer des Geräts (zu finden in der Zendure App)
+      en: Device serial number (can be found in the Zendure App)
   - name: maxacpower
     default: 800 # W
   - preset: battery-params
+  - name: maxchargepower
+    default: 1000
   - name: capacity
     default: 1.92 # kWh
   - name: cache
@@ -35,5 +53,36 @@ render: |
     uri: http://{{ .host }}/properties/report
     jq: .properties.electricLevel
     cache: {{ .cache }}
+  batterymode:
+    source: watchdog
+    timeout: 60s
+    reset: 1 # reset to normal
+    set:
+      source: switch
+      switch:
+      - case: 1 # normal
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":0,"acMode":2,"outputLimit":0,"inputLimit":0}}'
+      - case: 2 # hold
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"acMode":2,"outputLimit":0,"inputLimit":0}}'
+      - case: 3 # charge
+        set:
+          source: http
+          uri: http://{{ .host }}/properties/write
+          method: POST
+          headers:
+          - content-type: application/json
+          body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"acMode":1,"outputLimit":0,"inputLimit":{{ .maxchargepower }}}}'
   {{- include "battery-params" . }}
   {{- end }}

--- a/templates/definition/meter/zendure-solarflow-pro.yaml
+++ b/templates/definition/meter/zendure-solarflow-pro.yaml
@@ -17,12 +17,11 @@ params:
     choice: ["pv", "battery"]
   - name: host
   - name: serial
-    required: true
     example: WOB1NHMAMXXXXX3
     usages: ["battery"]
     help:
-      de: Seriennummer des Geräts (zu finden in der Zendure App)
-      en: Device serial number (can be found in the Zendure App)
+      de: Nur für die aktive Batteriesteuerung. Seriennummer des Geräts (zu finden in der Zendure App)
+      en: Required only for active battery control. Device serial number (can be found in the Zendure App)
   - name: maxacpower
     default: 800 # W
   - preset: battery-params
@@ -53,6 +52,7 @@ render: |
     uri: http://{{ .host }}/properties/report
     jq: .properties.electricLevel
     cache: {{ .cache }}
+  {{- if .serial }}
   batterymode:
     source: watchdog
     timeout: 60s
@@ -84,5 +84,6 @@ render: |
           headers:
           - content-type: application/json
           body: '{"sn":"{{ .serial }}","properties":{"smartMode":1,"acMode":1,"outputLimit":0,"inputLimit":{{ .maxchargepower }}}}'
+  {{- end }}
   {{- include "battery-params" . }}
   {{- end }}


### PR DESCRIPTION
Add local API-based battery mode control to the Zendure SolarFlow 800 Pro meter template.

The template now exposes the battery-control capability and requires the device serial number for write requests. It maps evcc battery modes to the Zendure local API:

- normal: restore autonomous PV operation
- hold: disable AC charging and discharging
- charge: force AC/grid charging at the configured maxchargepower

The implementation uses a watchdog for temporary control states and documents the required local API activation in the Zendure app.