### PR TITLE
OpenDTU: tolerate missing radio_stats in energy filter

### DIFF
--- a/templates/definition/meter/hoymiles-opendtu.yaml
+++ b/templates/definition/meter/hoymiles-opendtu.yaml
@@ -16,4 +16,5 @@ render: |
   energy:
     source: http
     uri: http://{{ .host }}/api/livedata/status
-    jq: 'if all(.inverters[]; .radio_stats.rssi > -127) then .total.YieldTotal.v else empty end'
+    # skip partial sums until all inverters are contacted; radio_stats needs firmware 2024.10.22+
+    jq: 'if all(.inverters[]; .radio_stats.rssi == null or .radio_stats.rssi > -127) then .total.YieldTotal.v else empty end'


### PR DESCRIPTION
fixes #33267

The `energy` filter added in #31170 guards against partial `YieldTotal` sums while OpenDTU is still reconnecting to its inverters, by requiring every inverter to report `radio_stats.rssi > -127`.

`radio_stats` was only added to the `/api/livedata/status` inverter objects in OpenDTU 2024.10.22 (tbnobody/OpenDTU@a54b19bf, `rssi` in tbnobody/OpenDTU@edfe06e3). On older firmware the key is absent, `.radio_stats.rssi` is `null`, `null > -127` is false, so `all(...)` never holds and the filter always yields `empty` — `jq: empty result` on every poll.

Treat a missing `radio_stats` as "no information" instead of "not connected". Firmware that reports it keeps the original guard; older firmware behaves as it did before #31170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
