### PR TITLE
Tesla: add Fleet API onboarding via remote access 

### DIFF
--- a/assets/js/app.ts
+++ b/assets/js/app.ts
@@ -10,6 +10,7 @@ import tooltip from "./directives/tooltip.ts";
 import { watchThemeChanges } from "./theme.ts";
 import { applyUrlSettings } from "./urlSettings.ts";
 import { appDetection, sendToApp } from "./utils/native";
+import { cleanAuthStash } from "./utils/authStash";
 import store from "./store";
 import type { Notification } from "./types/evcc";
 
@@ -25,6 +26,8 @@ Dropdown.Default.popperConfig = (defaultConfig) => {
     ],
   };
 };
+
+cleanAuthStash();
 
 // lazy load smoothscroll polyfill. mainly for safari < 15.4
 if (!window.CSS.supports("scroll-behavior", "smooth")) {

--- a/assets/js/components/Config/ChargerModal.vue
+++ b/assets/js/components/Config/ChargerModal.vue
@@ -4,6 +4,7 @@
 		name="charger"
 		device-type="charger"
 		:is-sponsor="isSponsor"
+		:remote-enabled="remoteEnabled"
 		:modal-title="modalTitle"
 		tags-usage="charge"
 		:provide-template-options="provideTemplateOptions"
@@ -128,6 +129,7 @@ export default defineComponent({
 			default: () => ({ config: { port: 0 }, status: { stations: [] } }),
 		},
 		isSponsor: Boolean,
+		remoteEnabled: Boolean,
 	},
 	emits: ["changed", "close"],
 	data() {

--- a/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
+++ b/assets/js/components/Config/DeviceModal/DeviceModalBase.vue
@@ -65,8 +65,13 @@
 				<div v-else>
 					<p v-if="loadingTemplate">{{ $t("config.general.templateLoading") }}</p>
 					<SponsorTokenRequired v-if="sponsorTokenRequired" />
+					<RemoteAccessRequired v-if="remoteAccessRequired" @navigate="stashValues" />
 					<slot name="template-description">
-						<Markdown v-if="description" :markdown="description" class="my-4" />
+						<Markdown
+							v-if="description && (authRequired || !template?.Auth)"
+							:markdown="description"
+							class="my-4"
+						/>
 					</slot>
 
 					<div v-if="authRequired">
@@ -131,6 +136,7 @@
 								:provider-url="auth.providerUrl ?? undefined"
 								:loading="auth.loading"
 								@prepare="checkAuthStatus"
+								@external-click="stashValues"
 							/>
 						</div>
 					</div>
@@ -238,6 +244,7 @@ import ModbusAdvanced from "./ModbusAdvanced.vue";
 import DeviceModalActions from "./Actions.vue";
 import Markdown from "../Markdown.vue";
 import SponsorTokenRequired from "./SponsorTokenRequired.vue";
+import RemoteAccessRequired from "./RemoteAccessRequired.vue";
 import TemplateSelector, { type TemplateGroup } from "./TemplateSelector.vue";
 import YamlEntry from "./YamlEntry.vue";
 import AuthCodeDisplay from "../AuthCodeDisplay.vue";
@@ -245,6 +252,7 @@ import AuthConnectButton from "../AuthConnectButton.vue";
 import { initialTestState, performTest } from "../utils/test";
 import { reportValidityInModal } from "../utils/reportValidityInModal";
 import { initialAuthState, prepareAuthLogin } from "../utils/authProvider";
+import { popAuthValues, stashAuthValues } from "@/utils/authStash";
 import AdminPasswordPrompt from "@/components/Auth/AdminPasswordPrompt.vue";
 import sleep from "@/utils/sleep";
 import { ConfigType } from "@/types/evcc";
@@ -264,7 +272,6 @@ import {
 	fetchServiceValues,
 	ADMIN_PASSWORD_REQUIRED,
 } from "./index";
-import deepEqual from "@/utils/deepEqual";
 
 const CUSTOM_FIELDS = ["modbus"];
 
@@ -281,6 +288,7 @@ export default defineComponent({
 		DeviceModalActions,
 		Markdown,
 		SponsorTokenRequired,
+		RemoteAccessRequired,
 		TemplateSelector,
 		YamlEntry,
 		AuthCodeDisplay,
@@ -292,6 +300,7 @@ export default defineComponent({
 		id: Number as PropType<number | undefined>,
 		name: String,
 		isSponsor: Boolean,
+		remoteEnabled: Boolean,
 		// Computed/derived props that must be provided by parent
 		modalTitle: { type: String, required: true },
 		initialValues: { type: Object as PropType<DeviceValues>, required: true },
@@ -458,8 +467,12 @@ export default defineComponent({
 			}
 		},
 		sponsorTokenRequired() {
-			const requirements = this.template?.Requirements as any;
+			const requirements = this.template?.Requirements;
 			return requirements?.EVCC?.includes("sponsorship") && !this.isSponsor;
+		},
+		remoteAccessRequired() {
+			const requirements = this.template?.Requirements;
+			return requirements?.EVCC?.includes("remoteaccess") && !this.remoteEnabled;
 		},
 		apiData(): ApiData {
 			let data: ApiData = {
@@ -482,6 +495,10 @@ export default defineComponent({
 				delete data["modbus"];
 			}
 
+			for (const p of this.templateParams.filter((p) => p.Readonly)) {
+				delete data[p.Name];
+			}
+
 			// Allow parent to transform API data
 			if (this.transformApiData) {
 				data = this.transformApiData(data, this.values);
@@ -491,6 +508,9 @@ export default defineComponent({
 		},
 		isNew() {
 			return this.id === undefined;
+		},
+		stashKey(): string {
+			return `${this.deviceType}:${this.id ?? "new"}`;
 		},
 		isDeletable() {
 			return !this.isNew && !this.hideDelete;
@@ -529,22 +549,15 @@ export default defineComponent({
 			return this.template?.Auth && !this.auth.ok;
 		},
 		authValuesMissing() {
-			const authParamNames: string[] = this.template?.Auth?.params ?? [];
-			return (
-				authParamNames.length > 0 &&
-				this.templateParams
-					.filter((p: TemplateParam) => authParamNames.includes(p.Name) && p.Required)
-					.some((p: TemplateParam) => !this.values[p.Name])
-			);
+			return this.authParams
+				.filter((p: TemplateParam) => p.Required && !p.Readonly)
+				.some((p: TemplateParam) => !this.values[p.Name]);
 		},
 		authValues() {
-			const params = this.template?.Auth?.params ?? [];
-			return params.reduce(
-				(acc, param) => {
-					acc[param] = this.values[param];
-					return acc;
-				},
-				{} as Record<string, any>
+			return Object.fromEntries(
+				this.authParams
+					.filter((p: TemplateParam) => !p.Readonly)
+					.map((p: TemplateParam) => [p.Name, this.values[p.Name]])
 			);
 		},
 	},
@@ -558,10 +571,11 @@ export default defineComponent({
 				this.succeeded = false;
 				this.loadProducts();
 				if (this.id !== undefined) {
-					this.loadConfiguration();
+					this.loadConfiguration().then(() => this.restoreStash());
 				} else {
 					// For new devices, apply defaults immediately (e.g., default icons based on meter type)
 					this.applyDefaults();
+					this.restoreStash();
 				}
 			}
 		},
@@ -658,17 +672,6 @@ export default defineComponent({
 			// update on auth state change
 			this.updateServiceValues();
 		},
-		serviceValues: {
-			handler(newValue, oldValue) {
-				// Apply defaults only for specific params whose service values changed
-				Object.keys(newValue).forEach((paramName) => {
-					if (!deepEqual(newValue[paramName], oldValue[paramName])) {
-						this.applyServiceDefault(paramName);
-					}
-				});
-			},
-			deep: true,
-		},
 	},
 	methods: {
 		reset() {
@@ -677,6 +680,16 @@ export default defineComponent({
 			this.resetAuthStatus();
 			this.rebaseline();
 			this.$emit("reset");
+		},
+		// the provider login may return in a new tab, keep the entered values across it
+		stashValues() {
+			stashAuthValues(this.stashKey, this.templateName, this.values);
+		},
+		restoreStash() {
+			const stash = popAuthValues(this.stashKey);
+			if (!stash) return;
+			this.templateName = stash.templateName;
+			this.values = { ...stash.values } as DeviceValues;
 		},
 		rebaseline() {
 			this.baseline = JSON.stringify(this.values);
@@ -816,6 +829,7 @@ export default defineComponent({
 				}
 				this.saving = false;
 				this.succeeded = true;
+				popAuthValues(this.stashKey);
 				await sleep(500);
 				this.$emit("added", res.data.name);
 				await closeModal({ action: "added", name: res.data.name });
@@ -864,6 +878,7 @@ export default defineComponent({
 				}
 				this.saving = false;
 				this.succeeded = true;
+				popAuthValues(this.stashKey);
 				await sleep(500);
 				this.$emit("updated");
 				await closeModal({ action: "updated" });
@@ -937,14 +952,19 @@ export default defineComponent({
 					...this.modbusDefaults,
 					...this.values,
 				});
+				// values may have been reloaded since the last fetch
+				Object.keys(this.serviceValues).forEach((name) => this.applyServiceDefault(name));
 			}, 500);
 		},
 		applyServiceDefault(paramName: string) {
 			// Auto-apply single service value when field is empty and required
 			const values = this.serviceValues[paramName];
 			const param = this.templateParams.find((p) => p.Name === paramName);
-			// Only auto-apply if exactly one value is returned, field is empty, and field is required
-			if (values?.length === 1 && !this.values[paramName] && param?.Required) {
+			// single service value only, readonly fields always mirror it
+			if (
+				values?.length === 1 &&
+				(param?.Readonly || (!this.values[paramName] && param?.Required))
+			) {
 				// debounced auto-fill must not mark a clean form dirty
 				const wasClean = !this.dirty;
 				this.values[paramName] = values[0];

--- a/assets/js/components/Config/DeviceModal/RemoteAccessRequired.vue
+++ b/assets/js/components/Config/DeviceModal/RemoteAccessRequired.vue
@@ -1,0 +1,24 @@
+<template>
+	<div class="alert alert-warning my-4" data-testid="remote-access-required">
+		{{ $t("config.remote.required") }}
+		<a href="#" role="button" class="text-warning" @click.prevent="open">
+			{{ $t("config.remote.requiredEnable") }}
+		</a>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { openModal } from "@/configModal";
+
+export default defineComponent({
+	name: "RemoteAccessRequired",
+	emits: ["navigate"],
+	methods: {
+		open() {
+			this.$emit("navigate");
+			openModal("remote");
+		},
+	},
+});
+</script>

--- a/assets/js/components/Config/DeviceModal/index.ts
+++ b/assets/js/components/Config/DeviceModal/index.ts
@@ -29,6 +29,7 @@ export type Template = {
   };
   Requirements: {
     Description: string;
+    EVCC?: string[];
   };
 };
 
@@ -39,6 +40,7 @@ export type TemplateParam = {
   Required: boolean;
   Advanced: boolean;
   Deprecated: boolean;
+  Readonly?: boolean; // display-only service value, never sent to the backend
   Default?: string | number | boolean;
   Type?: string;
   Choice?: string[];

--- a/assets/js/components/Config/FormRow.vue
+++ b/assets/js/components/Config/FormRow.vue
@@ -7,7 +7,7 @@
 				<small v-if="deprecated" class="evcc-gray">{{
 					$t("config.form.deprecated")
 				}}</small>
-				<small v-else-if="optional" class="evcc-gray">{{
+				<small v-else-if="optional && !readonly" class="evcc-gray">{{
 					$t("config.form.optional")
 				}}</small>
 			</div>
@@ -49,6 +49,7 @@ export default {
 		help: String,
 		optional: Boolean,
 		deprecated: Boolean,
+		readonly: Boolean,
 		error: String,
 		warning: String,
 		danger: String,

--- a/assets/js/components/Config/MeterModal.vue
+++ b/assets/js/components/Config/MeterModal.vue
@@ -5,6 +5,7 @@
 		name="meter"
 		device-type="meter"
 		:is-sponsor="isSponsor"
+		:remote-enabled="remoteEnabled"
 		:modal-title="modalTitle"
 		:provide-template-options="provideTemplateOptions"
 		:initial-values="initialValues"
@@ -149,6 +150,7 @@ export default defineComponent({
 	},
 	props: {
 		isSponsor: Boolean,
+		remoteEnabled: Boolean,
 	},
 	emits: ["changed", "disable", "close"],
 	data() {

--- a/assets/js/components/Config/PropertyEntry.vue
+++ b/assets/js/components/Config/PropertyEntry.vue
@@ -3,11 +3,17 @@
 		:id="id"
 		:optional="!Required"
 		:deprecated="Deprecated"
+		:readonly="Readonly"
 		:label="label"
 		:help="help"
 		:example="example"
 	>
+		<template v-if="Readonly">
+			<input :id="id" type="text" class="form-control border" :value="value" readonly />
+			<CopyLink v-if="value" :text="String(value)" />
+		</template>
 		<PropertyField
+			v-else
 			:id="id"
 			v-model="value"
 			:masked="Mask"
@@ -28,18 +34,20 @@
 /* oxlint-disable vue/prop-name-casing */
 import FormRow from "./FormRow.vue";
 import PropertyField from "./PropertyField.vue";
+import CopyLink from "../Helper/CopyLink.vue";
 import formatter from "@/mixins/formatter";
 import { goDurationToUnit, goDurationUnit } from "@/utils/goDuration";
 
 export default {
 	name: "PropertyEntry",
-	components: { FormRow, PropertyField },
+	components: { FormRow, PropertyField, CopyLink },
 	mixins: [formatter],
 	props: {
 		id: String,
 		Name: String,
 		Required: Boolean,
 		Deprecated: Boolean,
+		Readonly: Boolean,
 		Description: String,
 		Help: String,
 		Example: String,

--- a/assets/js/components/Config/VehicleModal.vue
+++ b/assets/js/components/Config/VehicleModal.vue
@@ -4,6 +4,7 @@
 		name="vehicle"
 		device-type="vehicle"
 		:is-sponsor="isSponsor"
+		:remote-enabled="remoteEnabled"
 		:modal-title="$t(`config.vehicle.${isNew ? 'titleAdd' : 'titleEdit'}`)"
 		:provide-template-options="provideTemplateOptions"
 		:initial-values="initialValues"
@@ -43,6 +44,7 @@ export default defineComponent({
 	},
 	props: {
 		isSponsor: Boolean,
+		remoteEnabled: Boolean,
 	},
 	emits: ["vehicle-changed", "disable"],
 	data() {

--- a/assets/js/components/Config/utils/authProvider.ts
+++ b/assets/js/components/Config/utils/authProvider.ts
@@ -30,12 +30,8 @@ export const prepareAuthLogin = async (state: AuthState, providerId: string) => 
     state.loading = true;
     state.error = null;
 
-    let url = `providerauth/login?id=${encodeURIComponent(providerId)}`;
-    // restore the config modal stack on callback
-    const returnTo = window.location.hash.split("?")[1];
-    if (returnTo) {
-      url += `&return=${encodeURIComponent(returnTo)}`;
-    }
+    // come back to this page, the redirect uri may be on another origin
+    const url = `providerauth/login?id=${encodeURIComponent(providerId)}&return=${encodeURIComponent(window.location.href)}`;
     const { status, data } = await baseApi.get<ProviderLoginResponse>(url, {
       validateStatus: (code) => [200, 400].includes(code),
     });

--- a/assets/js/components/Top/AuthProviderModal.vue
+++ b/assets/js/components/Top/AuthProviderModal.vue
@@ -4,6 +4,7 @@
 		ref="modal"
 		:title="modalTitle"
 		data-testid="auth-provider-modal"
+		@open="prepareAuthentication"
 		@closed="handleClosed"
 	>
 		<div class="container mx-0 px-0">
@@ -159,8 +160,6 @@ export default defineComponent({
 		providerId(newId) {
 			if (newId) {
 				this.reset();
-				// auto-run the prepare step. no user input needed
-				this.prepareAuthentication();
 			}
 		},
 	},

--- a/assets/js/utils/authStash.test.ts
+++ b/assets/js/utils/authStash.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { popAuthValues, stashAuthValues } from "./authStash";
+
+describe("authStash", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("restores once for the same device", () => {
+    stashAuthValues("vehicle:new", "tesla-fleet", { clientid: "id" });
+    expect(popAuthValues("vehicle:new")).toMatchObject({
+      templateName: "tesla-fleet",
+      values: { clientid: "id" },
+    });
+    expect(popAuthValues("vehicle:new")).toBeNull();
+  });
+
+  it("keeps the stash for a different device", () => {
+    stashAuthValues("vehicle:new", "tesla-fleet", {});
+    expect(popAuthValues("meter:3")).toBeNull();
+    expect(popAuthValues("vehicle:new")).not.toBeNull();
+  });
+
+  it("drops an expired stash", () => {
+    stashAuthValues("vehicle:new", "tesla-fleet", {});
+    expect(popAuthValues("vehicle:new", Date.now() + 11 * 60 * 1000)).toBeNull();
+    expect(popAuthValues("vehicle:new")).toBeNull();
+  });
+});

--- a/assets/js/utils/authStash.test.ts
+++ b/assets/js/utils/authStash.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
-import { popAuthValues, stashAuthValues } from "./authStash";
+import { popAuthValues, stashAuthValues, cleanAuthStash } from "./authStash";
 
 describe("authStash", () => {
   beforeEach(() => window.localStorage.clear());
@@ -22,6 +22,16 @@ describe("authStash", () => {
   it("drops an expired stash", () => {
     stashAuthValues("vehicle:new", "tesla-fleet", {});
     expect(popAuthValues("vehicle:new", Date.now() + 11 * 60 * 1000)).toBeNull();
+    expect(popAuthValues("vehicle:new")).toBeNull();
+  });
+
+  it("cleans only an expired stash", () => {
+    stashAuthValues("vehicle:new", "tesla-fleet", {});
+    cleanAuthStash();
+    expect(popAuthValues("vehicle:new")).not.toBeNull();
+
+    stashAuthValues("vehicle:new", "tesla-fleet", {});
+    cleanAuthStash(Date.now() + 11 * 60 * 1000);
     expect(popAuthValues("vehicle:new")).toBeNull();
   });
 });

--- a/assets/js/utils/authStash.ts
+++ b/assets/js/utils/authStash.ts
@@ -1,0 +1,42 @@
+// Form values entered before an OAuth login survive the redirect back to evcc,
+// which may land in a new tab. Stored per device, consumed once, short-lived.
+
+const STORAGE_KEY = "evcc.authStash";
+const TTL_MS = 10 * 60 * 1000;
+
+export type AuthStash = {
+  key: string;
+  templateName: string | null;
+  values: Record<string, any>;
+  ts: number;
+};
+
+export function stashAuthValues(
+  key: string,
+  templateName: string | null,
+  values: Record<string, any>
+): void {
+  try {
+    const stash: AuthStash = { key, templateName, values, ts: Date.now() };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stash));
+  } catch {
+    // storage unavailable
+  }
+}
+
+export function popAuthValues(key: string, now = Date.now()): AuthStash | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const stash = JSON.parse(raw) as AuthStash;
+    if (now - stash.ts > TTL_MS) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    if (stash.key !== key) return null;
+    window.localStorage.removeItem(STORAGE_KEY);
+    return stash;
+  } catch {
+    return null;
+  }
+}

--- a/assets/js/utils/authStash.ts
+++ b/assets/js/utils/authStash.ts
@@ -24,19 +24,34 @@ export function stashAuthValues(
   }
 }
 
+// read the stash, dropping it once expired
+function readAuthStash(now: number): AuthStash | null {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  const stash = JSON.parse(raw) as AuthStash;
+  if (now - stash.ts > TTL_MS) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+  return stash;
+}
+
 export function popAuthValues(key: string, now = Date.now()): AuthStash | null {
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const stash = JSON.parse(raw) as AuthStash;
-    if (now - stash.ts > TTL_MS) {
-      window.localStorage.removeItem(STORAGE_KEY);
-      return null;
-    }
-    if (stash.key !== key) return null;
+    const stash = readAuthStash(now);
+    if (!stash || stash.key !== key) return null;
     window.localStorage.removeItem(STORAGE_KEY);
     return stash;
   } catch {
     return null;
+  }
+}
+
+// an abandoned login never pops, so the entered secrets are cleaned on app start
+export function cleanAuthStash(now = Date.now()): void {
+  try {
+    readAuthStash(now);
+  } catch {
+    // storage unavailable
   }
 }

--- a/assets/js/views/Config.vue
+++ b/assets/js/views/Config.vue
@@ -527,15 +527,22 @@
 				/>
 				<VehicleModal
 					:is-sponsor="isSponsor"
+					:remote-enabled="remoteEnabled"
 					@vehicle-changed="vehicleChanged"
 					@disable="({ id, disable }) => handleDisable('vehicle', id, disable)"
 				/>
 				<MeterModal
 					:is-sponsor="isSponsor"
+					:remote-enabled="remoteEnabled"
 					@changed="meterChanged"
 					@disable="({ id, disable }) => handleDisable('meter', id, disable)"
 				/>
-				<ChargerModal :is-sponsor="isSponsor" :ocpp="ocpp" @changed="chargerChanged" />
+				<ChargerModal
+					:is-sponsor="isSponsor"
+					:remote-enabled="remoteEnabled"
+					:ocpp="ocpp"
+					@changed="chargerChanged"
+				/>
 				<InfluxModal @changed="loadDirty" />
 				<MqttModal @changed="loadDirty" />
 				<NetworkModal @changed="loadDirty" />
@@ -1166,6 +1173,9 @@ export default defineComponent({
 		},
 		sponsor() {
 			return store.state?.sponsor;
+		},
+		remoteEnabled(): boolean {
+			return Boolean(this.remote?.config?.enabled);
 		},
 		isSponsor(): boolean {
 			return !!this.sponsor?.status?.name;

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1r
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/JuulLabs-OSS/cbgo v0.0.1 h1:A5JdglvFot1J9qYR0POZ4qInttpsVPN9lqatjaPp2ro=
+github.com/JuulLabs-OSS/cbgo v0.0.1/go.mod h1:L4YtGP+gnyD84w7+jN66ncspFRfOYB5aj9QSXaFHmBA=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
@@ -175,6 +177,8 @@ github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getkin/kin-openapi v0.149.0 h1:ZbhmVJ4yq5RZDUsyP8lcBcGMsjsaTqXEFt6isdtMDfA=
 github.com/getkin/kin-openapi v0.149.0/go.mod h1:1+BHDzstro+P5CKtPy1X4PfofnFgmRe6uvMy9+r9fKY=
+github.com/go-ble/ble v0.0.0-20240122180141-8c5522f54333 h1:bQK6D51cNzMSTyAf0HtM30V2IbljHTDam7jru9JNlJA=
+github.com/go-ble/ble v0.0.0-20240122180141-8c5522f54333/go.mod h1:fFJl/jD/uyILGBeD5iQ8tYHrPlJafyqCJzAyTHNJ1Uk=
 github.com/go-http-utils/etag v0.0.0-20161124023236-513ea8f21eb1 h1:zga7zaRE8HCbWjcXMDlfvmQtH0/kMVLo7cQ48dy6kWg=
 github.com/go-http-utils/etag v0.0.0-20161124023236-513ea8f21eb1/go.mod h1:PumS+5d59wmAGsZo6IfRpVNaJUq+6xjC4Utt/k8GO6Q=
 github.com/go-http-utils/fresh v0.0.0-20161124030543-7231e26a4b27 h1:O6yi4xa9b2DMosGsXzlMe2E9qXgXCVkRLCoRX+5amxI=
@@ -367,6 +371,8 @@ github.com/mergermarket/go-pkcs7 v0.0.0-20170926155232-153b18ea13c9 h1:j6boLfPkc
 github.com/mergermarket/go-pkcs7 v0.0.0-20170926155232-153b18ea13c9/go.mod h1:GH7jtq102ZiRB7LEKgqP54akN7GOVaNpCJrDWTeWSMY=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab h1:n8cgpHzJ5+EDyDri2s/GC7a9+qK3/YEGnBsd0uS/8PY=
+github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab/go.mod h1:y1pL58r5z2VvAjeG1VLGc8zOQgSOzbKN7kMHPvFXJ+8=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
 github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
@@ -449,6 +455,8 @@ github.com/quic-go/quic-go v0.61.0 h1:ui88A53s8MSVYLC56en0KQ17HARk+9986Dn0SBfKNv
 github.com/quic-go/quic-go v0.61.0/go.mod h1:9So2anK4Tp22URSQq00k+Vo2PNkle96ycDPDHL4s9vs=
 github.com/quic-go/webtransport-go v0.12.0 h1:CpnKNwZvdV0LD73xoHO8QaR0NI3llqpWRwnazdZS0sE=
 github.com/quic-go/webtransport-go v0.12.0/go.mod h1:GHne8aRFJ24h73pAMrcywXtuaz/ShBXCLXLvG/NPFdU=
+github.com/raff/goble v0.0.0-20190909174656-72afc67d6a99 h1:JtoVdxWJ3tgyqtnPq3r4hJ9aULcIDDnPXBWxZsdmqWU=
+github.com/raff/goble v0.0.0-20190909174656-72afc67d6a99/go.mod h1:CxaUhijgLFX0AROtH5mluSY71VqpjQBw9JXE2UKZmc4=
 github.com/relvacode/iso8601 v1.6.0 h1:eFXUhMJN3Gz8Rcq82f9DTMW0svjtAVuIEULglM7QHTU=
 github.com/relvacode/iso8601 v1.6.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -850,6 +850,8 @@
       "qrInstall": "Installiere die evcc-App für {ios} oder {android}.",
       "qrScan": "Scanne den Code mit der Kamera deines Smartphones, um dich zu verbinden. Klicke ihn an, wenn du bereits dein Handy nutzt.",
       "removeClient": "Client entfernen",
+      "required": "Dieses Gerät benötigt den Remotezugriff.",
+      "requiredEnable": "Remotezugriff aktivieren.",
       "title": "Remotezugriff",
       "url": "Öffentliche URL",
       "username": "Benutzername"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -850,6 +850,8 @@
       "qrInstall": "Install the evcc app for {ios} or {android}.",
       "qrScan": "Scan the code with your phone's camera to connect. Click it, if you're already using your phone.",
       "removeClient": "Remove client",
+      "required": "This device requires Remote Access.",
+      "requiredEnable": "Enable Remote Access.",
       "title": "Remote Access",
       "url": "Public URL",
       "username": "Username"

--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -54,6 +54,8 @@ type OAuth struct {
 	deviceFlow     bool
 	tokenRetriever func(string, *oauth2.Token) error
 	tokenStorer    func(*oauth2.Token) any
+	exchangeOpts   []oauth2.AuthCodeOption
+	loginHook      func(context.Context) error
 }
 
 func NewOAuthFromConfig(ctx context.Context, other map[string]any) (oauth2.TokenSource, error) {
@@ -224,7 +226,9 @@ func (o *OAuth) HandleCallback(params url.Values) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	token, err := o.oc.Exchange(o.ctx, code, oauth2.VerifierOption(o.cv))
+	opts := append([]oauth2.AuthCodeOption{oauth2.VerifierOption(o.cv)}, o.exchangeOpts...)
+
+	token, err := o.oc.Exchange(o.ctx, code, opts...)
 	if err != nil {
 		return err
 	}
@@ -236,6 +240,12 @@ func (o *OAuth) HandleCallback(params url.Values) error {
 
 // Login implements api.AuthProvider.
 func (o *OAuth) Login(state string) (string, *oauth2.DeviceAuthResponse, error) {
+	if o.loginHook != nil {
+		if err := o.loginHook(o.ctx); err != nil {
+			return "", nil, err
+		}
+	}
+
 	o.mu.Lock()
 	defer o.mu.Unlock()
 

--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -198,7 +198,10 @@ func (o *OAuth) updateToken(token *oauth2.Token) {
 		store = o.tokenStorer(token)
 	}
 
+	// flush right away, a restart before the periodic persist would lose the login
 	if err := settings.SetJson(o.subject, store); err != nil {
+		o.log.ERROR.Printf("error saving token: %v", err)
+	} else if err := settings.Persist(); err != nil {
 		o.log.ERROR.Printf("error saving token: %v", err)
 	}
 

--- a/plugin/auth/oauth_option.go
+++ b/plugin/auth/oauth_option.go
@@ -1,6 +1,24 @@
 package auth
 
-import "golang.org/x/oauth2"
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+)
+
+// WithExchangeOptions adds parameters to the authorization code exchange
+func WithExchangeOptions(opts ...oauth2.AuthCodeOption) func(o *OAuth) {
+	return func(o *OAuth) {
+		o.exchangeOpts = opts
+	}
+}
+
+// WithLoginHook runs before the login url is generated, e.g. to register with the provider
+func WithLoginHook(hook func(context.Context) error) func(o *OAuth) {
+	return func(o *OAuth) {
+		o.loginHook = hook
+	}
+}
 
 func WithOauthDeviceFlowOption() func(o *OAuth) {
 	return func(o *OAuth) {

--- a/server/http.go
+++ b/server/http.go
@@ -75,6 +75,10 @@ func NewHTTPd(addr string, hub *SocketHub, custom Customization) *HTTPd {
 	// websocket
 	router.HandleFunc("/ws", socketHandler(hub))
 
+	for path, h := range service.PublicRoutes() {
+		router.Methods(http.MethodGet).Path(path).Handler(h)
+	}
+
 	// static - individual handlers per root and folders
 	static := router.PathPrefix("/").Subrouter()
 	static.Use(handlers.CompressHandler)

--- a/server/network/service.go
+++ b/server/network/service.go
@@ -32,16 +32,22 @@ func Config() globalconfig.Network {
 	return config
 }
 
-// RemoteOrigin returns the remote access url as public https origin of this instance, empty if disabled
-func RemoteOrigin() string {
+func remoteSettings() (enabled bool, origin string) {
 	var remote struct {
 		Enabled bool   `json:"enabled"`
 		URL     string `json:"url"`
 	}
-	if err := settings.Json(keys.Remote, &remote); err != nil || !remote.Enabled {
-		return ""
+	if err := settings.Json(keys.Remote, &remote); err != nil {
+		return false, ""
 	}
-	return strings.TrimRight(remote.URL, "/")
+	return remote.Enabled, strings.TrimRight(remote.URL, "/")
+}
+
+// RemoteOrigin returns the remote access url as public https origin of this instance.
+// The url is kept while remote access is disabled, so devices set up through it keep working.
+func RemoteOrigin() string {
+	_, origin := remoteSettings()
+	return origin
 }
 
 // originHandler serves f(origin). With ?remote the origin is the remote access url, none while disabled.
@@ -49,7 +55,11 @@ func originHandler(f func(origin string) string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		origin := config.ExternalURL()
 		if req.URL.Query().Has("remote") {
-			origin = RemoteOrigin()
+			enabled, remote := remoteSettings()
+			origin = ""
+			if enabled {
+				origin = remote
+			}
 		}
 
 		res := []string{}

--- a/server/network/service.go
+++ b/server/network/service.go
@@ -3,8 +3,11 @@ package network
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/evcc-io/evcc/api/globalconfig"
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/db/settings"
 	"github.com/evcc-io/evcc/server/service"
 )
 
@@ -15,7 +18,8 @@ const CallbackPath = "/providerauth/callback"
 func init() {
 	// auth service is registered here to avoid import cycle
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /redirecturi", getRedirectUri)
+	mux.HandleFunc("GET /origin", originHandler(func(origin string) string { return origin }))
+	mux.HandleFunc("GET /redirecturi", originHandler(func(origin string) string { return origin + CallbackPath }))
 
 	service.Register("auth", mux)
 }
@@ -28,7 +32,30 @@ func Config() globalconfig.Network {
 	return config
 }
 
-func getRedirectUri(w http.ResponseWriter, req *http.Request) {
-	uri := config.ExternalURL() + CallbackPath
-	json.NewEncoder(w).Encode([]string{uri})
+// RemoteOrigin returns the remote access url as public https origin of this instance, empty if disabled
+func RemoteOrigin() string {
+	var remote struct {
+		Enabled bool   `json:"enabled"`
+		URL     string `json:"url"`
+	}
+	if err := settings.Json(keys.Remote, &remote); err != nil || !remote.Enabled {
+		return ""
+	}
+	return strings.TrimRight(remote.URL, "/")
+}
+
+// originHandler serves f(origin). With ?remote the origin is the remote access url, none while disabled.
+func originHandler(f func(origin string) string) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		origin := config.ExternalURL()
+		if req.URL.Query().Has("remote") {
+			origin = RemoteOrigin()
+		}
+
+		res := []string{}
+		if origin != "" {
+			res = append(res, f(origin))
+		}
+		json.NewEncoder(w).Encode(res)
+	}
 }

--- a/server/network/service_test.go
+++ b/server/network/service_test.go
@@ -25,4 +25,8 @@ func TestOriginHandlerPublic(t *testing.T) {
 	require.NoError(t, settings.SetJson(keys.Remote, map[string]any{"enabled": true, "url": "https://foo.evcc.io/"}))
 	assert.JSONEq(t, `["https://foo.evcc.io/x"]`, get("/origin?remote"))
 	assert.NotContains(t, get("/origin"), "foo.evcc.io", "local origin unaffected")
+
+	require.NoError(t, settings.SetJson(keys.Remote, map[string]any{"enabled": false, "url": "https://foo.evcc.io/"}))
+	assert.JSONEq(t, `[]`, get("/origin?remote"), "disabled remote access yields no remote origin")
+	assert.Equal(t, "https://foo.evcc.io", RemoteOrigin(), "origin survives disabling for existing devices")
 }

--- a/server/network/service_test.go
+++ b/server/network/service_test.go
@@ -1,0 +1,28 @@
+package network
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/db/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOriginHandlerPublic(t *testing.T) {
+	t.Cleanup(func() { settings.SetString(keys.Remote, "") })
+
+	get := func(url string) string {
+		rec := httptest.NewRecorder()
+		originHandler(func(origin string) string { return origin + "/x" })(rec, httptest.NewRequest(http.MethodGet, url, nil))
+		return rec.Body.String()
+	}
+
+	assert.JSONEq(t, `[]`, get("/origin?remote"), "disabled remote access yields no remote origin")
+
+	require.NoError(t, settings.SetJson(keys.Remote, map[string]any{"enabled": true, "url": "https://foo.evcc.io/"}))
+	assert.JSONEq(t, `["https://foo.evcc.io/x"]`, get("/origin?remote"))
+	assert.NotContains(t, get("/origin"), "foo.evcc.io", "local origin unaffected")
+}

--- a/server/providerauth/handler.go
+++ b/server/providerauth/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,9 +49,10 @@ type Handler struct {
 	updateC   chan string
 }
 
+// stateEntry remembers the page the login started from, the redirect uri may be on another origin
 type stateEntry struct {
 	id       string
-	returnTo string // config modal query to restore on callback
+	returnTo string // e.g. http://evcc.local:7070/#/config?vehicle=8
 }
 
 // TODO get status from update channel
@@ -102,7 +104,7 @@ func (a *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// Generate a new state and store the provider
 	state := NewState()
 	encryptedState := state.Encrypt(a.secret)
-	a.states[encryptedState] = stateEntry{id: id, returnTo: r.URL.Query().Get("return")}
+	a.states[encryptedState] = stateEntry{id: id, returnTo: returnURL(r.URL.Query().Get("return"))}
 
 	// Schedule cleanup for stale state entries after state becomes invalid
 	time.AfterFunc(stateValidity, func() {
@@ -157,23 +159,34 @@ func (a *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	jsonWrite(w, "OK")
 }
 
-func (a *Handler) redirectToError(w http.ResponseWriter, r *http.Request, message string) {
-	http.Redirect(w, r, "/#/config?callbackError="+url.QueryEscape(message), http.StatusFound)
+// returnURL validates the page to return to after the callback, empty if unusable
+func returnURL(s string) string {
+	if u, err := url.Parse(s); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return ""
+	}
+	return s
+}
+
+// redirectToConfig sends the browser back to the config page the login started from
+func redirectToConfig(w http.ResponseWriter, r *http.Request, returnTo, query string) {
+	if returnTo == "" {
+		returnTo = "/#/config"
+	}
+	sep := "?"
+	if strings.Contains(returnTo, "?") {
+		sep = "&"
+	}
+	http.Redirect(w, r, returnTo+sep+query, http.StatusFound)
 }
 
 func (a *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
-	if q.Has("error") {
-		errorMsg := q.Get("error") + ": " + q.Get("error_description")
-		a.redirectToError(w, r, errorMsg)
-		return
-	}
-
+	// the callback is reachable without session, only act on states issued by us
 	encryptedState := q.Get("state")
 	state, err := DecryptState(encryptedState, a.secret)
 	if err != nil || !state.Valid() {
-		a.redirectToError(w, r, "invalid state")
+		http.Error(w, "invalid state", http.StatusBadRequest)
 		return
 	}
 
@@ -183,32 +196,35 @@ func (a *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	// Find the corresponding provider
 	entry, ok := a.states[encryptedState]
 	if !ok {
-		a.redirectToError(w, r, "no provider found for state")
+		http.Error(w, "invalid state", http.StatusBadRequest)
 		return
 	}
 	id := entry.id
 
-	provider, ok := a.providers[id]
-	if !ok {
-		a.redirectToError(w, r, "internal provider state unexpected")
-		return
-	}
-
 	// Remove the state from the map
 	delete(a.states, encryptedState)
 
-	// Handle the callback
-	if err := provider.HandleCallback(r.URL.Query()); err != nil {
-		a.log.ERROR.Printf("callback for provider %s failed: %v", id, err)
-		a.redirectToError(w, r, err.Error())
+	redirectToError := func(message string) {
+		redirectToConfig(w, r, entry.returnTo, "callbackError="+url.QueryEscape(message))
+	}
+
+	if q.Has("error") {
+		redirectToError(q.Get("error") + ": " + q.Get("error_description"))
 		return
 	}
 
-	// restore the config modal stack alongside the completion marker
-	query := "callbackCompleted=" + url.QueryEscape(id)
-	if entry.returnTo != "" {
-		query = entry.returnTo + "&" + query
+	provider, ok := a.providers[id]
+	if !ok {
+		redirectToError("internal provider state unexpected")
+		return
 	}
 
-	http.Redirect(w, r, "/#/config?"+query, http.StatusFound)
+	// Handle the callback
+	if err := provider.HandleCallback(q); err != nil {
+		a.log.ERROR.Printf("callback for provider %s failed: %v", id, err)
+		redirectToError(err.Error())
+		return
+	}
+
+	redirectToConfig(w, r, entry.returnTo, "callbackCompleted="+url.QueryEscape(id))
 }

--- a/server/providerauth/handler.go
+++ b/server/providerauth/handler.go
@@ -104,7 +104,7 @@ func (a *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// Generate a new state and store the provider
 	state := NewState()
 	encryptedState := state.Encrypt(a.secret)
-	a.states[encryptedState] = stateEntry{id: id, returnTo: returnURL(r.URL.Query().Get("return"))}
+	a.states[encryptedState] = stateEntry{id: id, returnTo: returnURL(r.URL.Query().Get("return"), r.Host)}
 
 	// Schedule cleanup for stale state entries after state becomes invalid
 	time.AfterFunc(stateValidity, func() {
@@ -159,9 +159,10 @@ func (a *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	jsonWrite(w, "OK")
 }
 
-// returnURL validates the page to return to after the callback, empty if unusable
-func returnURL(s string) string {
-	if u, err := url.Parse(s); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+// returnURL validates the page to return to after the callback, empty if unusable.
+// The page must live on the host the login was requested from, the callback is reachable without session.
+func returnURL(s, host string) string {
+	if u, err := url.Parse(s); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host != host {
 		return ""
 	}
 	return s
@@ -172,8 +173,9 @@ func redirectToConfig(w http.ResponseWriter, r *http.Request, returnTo, query st
 	if returnTo == "" {
 		returnTo = "/#/config"
 	}
+	// the query must land in the fragment for the router to see it
 	sep := "?"
-	if strings.Contains(returnTo, "?") {
+	if strings.Contains(returnTo[strings.LastIndex(returnTo, "#")+1:], "?") {
 		sep = "&"
 	}
 	http.Redirect(w, r, returnTo+sep+query, http.StatusFound)

--- a/server/providerauth/providerauth_test.go
+++ b/server/providerauth/providerauth_test.go
@@ -1,13 +1,18 @@
 package providerauth
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 // stand-in auth middleware rejecting every request
@@ -17,7 +22,7 @@ func blockAll(next http.Handler) http.Handler {
 	})
 }
 
-// login/logout are gated, callback stays open (302 to error page, not middleware 401)
+// login/logout are gated, callback stays open but rejects unknown states
 func TestSetupGating(t *testing.T) {
 	router := mux.NewRouter()
 	Setup(router, make(chan util.Param, 1), blockAll)
@@ -30,5 +35,73 @@ func TestSetupGating(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, get("/login?id=x"), "login must be gated")
 	assert.Equal(t, http.StatusUnauthorized, get("/logout?id=x"), "logout must be gated")
-	assert.Equal(t, http.StatusFound, get("/callback"), "callback must stay open (gated by state token, not session)")
+	assert.Equal(t, http.StatusBadRequest, get("/callback"), "callback must stay open (gated by state token, not session)")
+	assert.Equal(t, http.StatusBadRequest, get("/callback?error=x&error_description=y"), "no reflection without state")
+}
+
+// fakeProvider hands the login state back as login uri so the test can use it
+type fakeProvider struct {
+	params url.Values
+}
+
+func (p *fakeProvider) Login(state string) (string, *oauth2.DeviceAuthResponse, error) {
+	return state, nil, nil
+}
+func (p *fakeProvider) Logout() error                     { return nil }
+func (p *fakeProvider) HandleCallback(q url.Values) error { p.params = q; return nil }
+func (p *fakeProvider) Authenticated() bool               { return true }
+func (p *fakeProvider) DisplayName() string               { return "fake" }
+
+// the callback redirects to the browser origin the login started from
+func TestCallbackRedirectsToOrigin(t *testing.T) {
+	h := &Handler{
+		log:       util.NewLogger("test"),
+		secret:    []byte("0123456789abcdef"),
+		providers: make(map[string]api.AuthProvider),
+		states:    make(map[string]stateEntry),
+		updateC:   make(chan string, 1),
+	}
+	provider := &fakeProvider{}
+	_, err := h.register("fake", provider)
+	require.NoError(t, err)
+
+	login := func(returnTo string) string {
+		rec := httptest.NewRecorder()
+		h.handleLogin(rec, httptest.NewRequest(http.MethodGet, "/login?id=fake&return="+url.QueryEscape(returnTo), nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var res loginResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&res))
+		return res.LoginUri
+	}
+
+	callback := func(query string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		h.handleCallback(rec, httptest.NewRequest(http.MethodGet, "/callback?"+query, nil))
+		return rec
+	}
+
+	// success lands on the page the login started from
+	state := login("http://evcc.local:7070/#/config?vehicle=1")
+	rec := callback("state=" + state + "&code=abc")
+	require.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "http://evcc.local:7070/#/config?vehicle=1&callbackCompleted=fake", rec.Header().Get("Location"))
+	assert.Equal(t, "abc", provider.params.Get("code"))
+
+	// state is single use
+	assert.Equal(t, http.StatusBadRequest, callback("state="+state+"&code=abc").Code)
+
+	// provider errors surface on the same page
+	state = login("http://evcc.local:7070/#/config")
+	rec = callback("state=" + state + "&error=access_denied&error_description=nope")
+	require.Equal(t, http.StatusFound, rec.Code)
+	assert.Equal(t, "http://evcc.local:7070/#/config?callbackError=access_denied%3A+nope", rec.Header().Get("Location"))
+
+	// unusable return urls fall back to the config page
+	for _, returnTo := range []string{"", "evcc.local", "javascript:alert(1)", "/#/config?vehicle=1"} {
+		state = login(returnTo)
+		rec = callback("state=" + state + "&code=abc")
+		require.Equal(t, http.StatusFound, rec.Code, returnTo)
+		assert.Equal(t, "/#/config?callbackCompleted=fake", rec.Header().Get("Location"), returnTo)
+	}
 }

--- a/server/providerauth/providerauth_test.go
+++ b/server/providerauth/providerauth_test.go
@@ -67,7 +67,7 @@ func TestCallbackRedirectsToOrigin(t *testing.T) {
 
 	login := func(returnTo string) string {
 		rec := httptest.NewRecorder()
-		h.handleLogin(rec, httptest.NewRequest(http.MethodGet, "/login?id=fake&return="+url.QueryEscape(returnTo), nil))
+		h.handleLogin(rec, httptest.NewRequest(http.MethodGet, "http://evcc.local:7070/login?id=fake&return="+url.QueryEscape(returnTo), nil))
 		require.Equal(t, http.StatusOK, rec.Code)
 
 		var res loginResponse
@@ -97,8 +97,13 @@ func TestCallbackRedirectsToOrigin(t *testing.T) {
 	require.Equal(t, http.StatusFound, rec.Code)
 	assert.Equal(t, "http://evcc.local:7070/#/config?callbackError=access_denied%3A+nope", rec.Header().Get("Location"))
 
-	// unusable return urls fall back to the config page
-	for _, returnTo := range []string{"", "evcc.local", "javascript:alert(1)", "/#/config?vehicle=1"} {
+	// a query before the fragment must not swallow the callback result
+	state = login("http://evcc.local:7070/?x=1#/config")
+	rec = callback("state=" + state + "&code=abc")
+	assert.Equal(t, "http://evcc.local:7070/?x=1#/config?callbackCompleted=fake", rec.Header().Get("Location"))
+
+	// unusable return urls and foreign hosts fall back to the config page
+	for _, returnTo := range []string{"", "evcc.local", "javascript:alert(1)", "/#/config?vehicle=1", "https://evil.example/#/config", "http://evcc.local:7071/#/config"} {
 		state = login(returnTo)
 		rec = callback("state=" + state + "&code=abc")
 		require.Equal(t, http.StatusFound, rec.Code, returnTo)

--- a/server/remote/tunnel.go
+++ b/server/remote/tunnel.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/coder/websocket"
+	"github.com/evcc-io/evcc/server/network"
+	"github.com/evcc-io/evcc/server/service"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/sponsor"
 	"github.com/hashicorp/yamux"
@@ -216,6 +218,12 @@ func (t *Tunnel) basicAuthMiddleware(next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// public routes and the OAuth redirect (state-token gated) need no credentials
+		if r.Method == http.MethodGet && (service.IsPublic(r.URL.Path) || r.URL.Path == network.CallbackPath) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		user, pass, ok := r.BasicAuth()
 		if !ok || t.authenticate == nil {
 			rejectAuth(w)

--- a/server/remote/tunnel_test.go
+++ b/server/remote/tunnel_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/evcc-io/evcc/server/service"
 	"github.com/evcc-io/evcc/util"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
@@ -169,5 +170,30 @@ func waitSession(t *testing.T, sessions <-chan *yamux.Session) *yamux.Session {
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for tunnel connection")
 		return nil
+	}
+}
+
+// TestBasicAuthMiddlewarePublicPath verifies only registered GET paths and the OAuth callback bypass credentials.
+func TestBasicAuthMiddlewarePublicPath(t *testing.T) {
+	service.RegisterPublic("/.well-known/public.pem", http.NotFoundHandler())
+
+	tun := NewTunnel("", "", nil, func(string, string) bool { return false }, nil, util.NewLogger("test"), nil)
+	h := tun.basicAuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, tc := range []struct {
+		method, path string
+		status       int
+	}{
+		{http.MethodGet, "/.well-known/public.pem", http.StatusOK},
+		{http.MethodPost, "/.well-known/public.pem", http.StatusUnauthorized},
+		{http.MethodGet, "/.well-known/other.pem", http.StatusUnauthorized},
+		{http.MethodGet, "/providerauth/callback", http.StatusOK},
+		{http.MethodGet, "/api/state", http.StatusUnauthorized},
+	} {
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
+		require.Equal(t, tc.status, rr.Code, "%s %s", tc.method, tc.path)
 	}
 }

--- a/server/service/registry.go
+++ b/server/service/registry.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"maps"
 	"net/http"
 	"sync"
 )
@@ -8,7 +9,38 @@ import (
 var (
 	mu       sync.Mutex
 	registry = make(map[string]http.Handler)
+	public   = make(map[string]http.Handler)
 )
+
+// RegisterPublic exposes an unauthenticated GET route on the root router,
+// also through remote access, e.g. for third parties fetching well-known files
+func RegisterPublic(path string, handler http.Handler) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, ok := public[path]; ok {
+		panic("public route " + path + " already registered")
+	}
+
+	public[path] = handler
+}
+
+// PublicRoutes returns the registered public routes by path
+func PublicRoutes() map[string]http.Handler {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return maps.Clone(public)
+}
+
+// IsPublic returns true if the path is a registered public route
+func IsPublic(path string) bool {
+	mu.Lock()
+	defer mu.Unlock()
+
+	_, ok := public[path]
+	return ok
+}
 
 func Register(name string, handler http.Handler) {
 	mu.Lock()

--- a/templates/definition/vehicle/tesla-fleet.yaml
+++ b/templates/definition/vehicle/tesla-fleet.yaml
@@ -1,0 +1,80 @@
+template: tesla-fleet
+products:
+  - brand: Tesla
+requirements:
+  evcc: ["skiptest", "remoteaccess"]
+  description:
+    de: |
+      Direkte Anbindung an die offizielle Tesla Fleet API mit eigenem Developer Account.
+
+      1. Kostenlosen Developer Account auf [developer.tesla.com](https://developer.tesla.com/) erstellen und eine Anwendung anlegen.
+      2. Genehmigungstyp *Autorisierungscode und Maschine-zu-Maschine* wählen. Die beiden URLs unten als *Zulässige Herkunfts-URL* und *Zulässige Weiterleitungs-URI* eintragen.
+      3. Berechtigungen *Profilinformationen*, *Fahrzeugdaten*, *Fahrzeugstandort*, *Fahrzeugbefehle* und *Fahrzeug-Ladeverwaltung* auswählen.
+      4. Rechnungsinfos überspringen.
+      5. *Einzelheiten ansehen* der Anwendung öffnen und *Kunden-ID* und *Kundengeheimnis* in die Felder unten kopieren.
+    en: |
+      Direct connection to the official Tesla Fleet API with your own developer account.
+
+      1. Create a free developer account at [developer.tesla.com](https://developer.tesla.com/) and add an application.
+      2. Select grant type *Authorization Code and Machine-to-Machine*. Enter the two URLs below as *Allowed Origin URL* and *Allowed Redirect URI*.
+      3. Select the scopes *Profile Information*, *Vehicle Information*, *Vehicle Location*, *Vehicle Commands* and *Vehicle Charging Management*.
+      4. Skip billing info.
+      5. Open *View details* of the application and copy *Client ID* and *Client Secret* into the fields below.
+params:
+  - preset: vehicle-common
+  - preset: vehicle-online
+  - name: allowedorigin
+    readonly: true
+    required: true
+    description:
+      de: Zulässige Herkunfts-URL
+      en: Allowed Origin URL
+    service: tesla/origin
+  - name: redirecturi
+    readonly: true
+    description:
+      de: Zulässige Weiterleitungs-URI
+      en: Allowed Redirect URI
+    service: tesla/redirecturi
+  - name: clientid
+    help:
+      de: Kunden-ID der Anwendung auf [developer.tesla.com](https://developer.tesla.com/dashboard).
+      en: Client ID of the application at [developer.tesla.com](https://developer.tesla.com/dashboard).
+  - name: clientsecret
+    help:
+      de: Kundengeheimnis der Anwendung auf [developer.tesla.com](https://developer.tesla.com/dashboard).
+      en: Client Secret of the application at [developer.tesla.com](https://developer.tesla.com/dashboard).
+  - name: origin
+    advanced: true
+    description:
+      generic: Origin URL
+    help:
+      de: Eigene öffentliche https-Adresse dieser evcc-Instanz statt der Remotezugriff-Adresse.
+      en: Own public https address of this evcc instance instead of the Remote Access address.
+    example: https://evcc.example.com
+  - name: vin
+  - name: cache
+    default: 15m
+  - name: virtualkey
+    readonly: true
+    advanced: true
+    description:
+      de: Virtueller Schlüssel
+      en: Virtual key
+    help:
+      de: Nur erforderlich für direkte Ladesteuerung am Fahrzeug, z. B. am Tesla Wall Connector. Link auf dem Smartphone öffnen und den Schlüssel in der Tesla-App auf jedem Fahrzeug installieren.
+      en: Only required for direct charge control via the vehicle, e.g. with a Tesla Wall Connector. Open the link on your phone and add the key to each vehicle in the Tesla app.
+    service: tesla/virtualkey
+auth:
+  type: tesla
+  params: [allowedorigin, redirecturi, clientid, clientsecret, origin]
+render: |
+  type: tesla
+  origin: {{ .origin }}
+  credentials:
+    id: {{ .clientid }}
+    secret: {{ .clientsecret }}
+  vin: {{ .vin }}
+  {{ include "common" . }}
+  {{ include "features" (merge (dict "basefeatures" (list "coarsecurrent")) .) }}
+  cache: {{ .cache }}

--- a/templates/definition/vehicle/tesla-fleet.yaml
+++ b/templates/definition/vehicle/tesla-fleet.yaml
@@ -29,13 +29,13 @@ params:
     description:
       de: Zulässige Herkunfts-URL
       en: Allowed Origin URL
-    service: tesla/origin
+    service: auth/origin?remote
   - name: redirecturi
     readonly: true
     description:
       de: Zulässige Weiterleitungs-URI
       en: Allowed Redirect URI
-    service: tesla/redirecturi
+    service: auth/redirecturi?remote
   - name: clientid
     help:
       de: Kunden-ID der Anwendung auf [developer.tesla.com](https://developer.tesla.com/dashboard).

--- a/templates/definition/vehicle/tesla-fleet.yaml
+++ b/templates/definition/vehicle/tesla-fleet.yaml
@@ -49,8 +49,8 @@ params:
     description:
       generic: Origin URL
     help:
-      de: Eigene öffentliche https-Adresse dieser evcc-Instanz statt der Remotezugriff-Adresse.
-      en: Own public https address of this evcc instance instead of the Remote Access address.
+      de: Eigene öffentliche https-Adresse dieser evcc-Instanz statt der Remotezugriff-Adresse. Eine Änderung erfordert eine erneute Anmeldung.
+      en: Own public https address of this evcc instance instead of the Remote Access address. Changing it requires logging in again.
     example: https://evcc.example.com
   - name: vin
   - name: cache

--- a/templates/definition/vehicle/tesla.yaml
+++ b/templates/definition/vehicle/tesla.yaml
@@ -2,6 +2,8 @@ template: tesla
 covers: ["tesla-command", "tesla-proxy"]
 products:
   - brand: Tesla
+    description:
+      generic: (MyTeslaMate)
 requirements:
   evcc: ["skiptest"]
   description:

--- a/tests/config-device-auth-demo.tpl.yaml
+++ b/tests/config-device-auth-demo.tpl.yaml
@@ -1,12 +1,14 @@
 template: device-auth-demo
 group: generic
+requirements:
+  evcc: ["remoteaccess"]
 products:
   - description:
       de: Auth Demo Zähler
       en: Auth Demo Meter
 auth:
   type: demo
-  params: ["server", "method", "redirectUri", "secret", "scope"]
+  params: ["server", "method", "redirectUri", "callback", "secret", "scope"]
 params:
   - name: usage
     choice: ["grid"]
@@ -20,6 +22,11 @@ params:
       generic: Redirect URI
     example: "http://localhost:7070/providerauth/callback"
     required: true
+  - name: callback
+    readonly: true
+    description:
+      generic: Callback URL
+    service: auth/redirecturi
   - name: method
     description:
       generic: Authentication Method

--- a/tests/config-device-auth.spec.ts
+++ b/tests/config-device-auth.spec.ts
@@ -50,6 +50,13 @@ test.describe("config device auth", async () => {
     await expect(meterModal.getByLabel("Power")).not.toBeVisible();
     await expect(meterModal.getByRole("button", { name: "Validate & save" })).not.toBeVisible();
     await expect(meterModal.getByRole("button", { name: "Save" })).not.toBeVisible();
+
+    // readonly param filled from service, copy only
+    const callback = meterModal.getByLabel("Callback URL");
+    await expect(callback).toHaveValue(/\/providerauth\/callback$/);
+    await expect(callback).toHaveAttribute("readonly", "");
+    await expect(meterModal.getByRole("link", { name: "Copy" })).toBeVisible();
+
     await meterModal.getByLabel("Server").fill(simulatorUrl());
     await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
     await meterModal.getByLabel("Authentication Method").selectOption("redirect");
@@ -79,21 +86,13 @@ test.describe("config device auth", async () => {
     await expect(successBanner).toContainText("Authorization Successful");
     await expect(successBanner).toContainText("Demo Auth is now connected and ready to use");
 
-    // modal reopens automatically after auth; continue configuration
+    // modal reopens with the entered values restored, auth is complete
     await expectModalVisible(meterModal);
-    await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
+    await expect(meterModal.getByLabel("Server")).toHaveValue(simulatorUrl());
+    await expect(meterModal.getByLabel("Authentication Method")).toHaveValue("redirect");
+    await expect(meterModal.getByRole("button", { name: "Prepare connection" })).not.toBeVisible();
 
-    // step 2: show regular device form - auth is complete, fill in server details again
-    await meterModal.getByLabel("Server").fill(simulatorUrl());
-    await meterModal.getByLabel("Redirect URI").fill(getRedirectUri(page.url()));
-    await meterModal.getByLabel("Authentication Method").selectOption("redirect");
-    await meterModal.getByLabel("Secret").fill(secret);
-
-    // Even though auth is already done, still need to click prepare connection to proceed to device fields
-    await meterModal.getByRole("button", { name: "Prepare connection" }).click();
-    await page.waitForTimeout(500);
-
-    // Now the Power field should be visible since auth is already complete
+    // step 2: regular device form
     await expect(meterModal.getByLabel("Power")).toBeVisible();
     await meterModal.getByLabel("Power").fill("5000");
     await expect(meterModal.getByRole("button", { name: "Validate & save" })).toBeVisible();
@@ -106,6 +105,10 @@ test.describe("config device auth", async () => {
     await expect(page.getByTestId("grid")).toBeVisible();
     await expect(page.getByTestId("grid")).toContainText("Grid meter");
     await expect(page.getByTestId("grid")).toContainText(["Power", "5.0 kW"].join(""));
+
+    // readonly params are not persisted
+    const [meter] = await (await page.request.get("/api/config/devices/meter")).json();
+    expect(meter.config).not.toHaveProperty("callback");
 
     // re-open meter for editing
     await page.getByTestId("grid").getByRole("button", { name: "edit" }).click();
@@ -166,6 +169,26 @@ test.describe("config device auth", async () => {
     // modal reopens automatically and success banner is shown
     await expectModalVisible(meterModal);
     await expect(page.getByTestId("auth-success-banner")).toBeVisible();
+  });
+
+  test("remote access requirement links to the remote access modal", async ({ page }) => {
+    await page.goto("/#/config");
+    await page.getByRole("button", { name: "Add grid meter" }).click();
+    const meterModal = page.getByTestId("meter-modal");
+    await expectModalVisible(meterModal);
+    await meterModal.getByLabel("Manufacturer").selectOption("Auth Demo Meter");
+
+    const hint = meterModal.getByTestId("remote-access-required");
+    await expect(hint).toContainText("This device requires Remote Access.");
+    await hint.getByRole("button", { name: "Enable Remote Access." }).click();
+
+    const remoteModal = page.getByTestId("remote-modal");
+    await expectModalVisible(remoteModal);
+    await expectModalHidden(meterModal);
+    await remoteModal.getByRole("button", { name: "Close" }).click();
+    await expectModalHidden(remoteModal);
+    await expectModalVisible(meterModal);
+    await expect(hint).toBeVisible();
   });
 
   test("advanced auth field is hidden until expanded", async ({ page }) => {

--- a/util/templates/documentation.go
+++ b/util/templates/documentation.go
@@ -64,10 +64,10 @@ func (t *Template) RenderDocumentation(product Product, lang string) ([]byte, er
 
 	var hasAdvancedParams bool
 
-	// remove usage and deprecated from params and check if there are advanced params
+	// remove usage, deprecated and readonly from params and check if there are advanced params
 	var filteredParams []Param
 	for _, param := range t.Params {
-		if param.IsDeprecated() || param.Name == ParamUsage {
+		if param.IsDeprecated() || param.Readonly || param.Name == ParamUsage {
 			continue
 		}
 

--- a/util/templates/documentation.tpl
+++ b/util/templates/documentation.tpl
@@ -110,7 +110,7 @@ render:
 {{- end }}
 params:
   {{- range .Params }}
-  {{- if and (not (eq .Name "usage")) (not .IsDeprecated) }}
+  {{- if and (not (eq .Name "usage")) (not .IsDeprecated) (not .Readonly) }}
   - name: {{ .Name | quote }}
     example: {{ .Example | quote }}
     default: {{ .Default | quote }}

--- a/util/templates/render_testing.go
+++ b/util/templates/render_testing.go
@@ -55,9 +55,12 @@ func testAuth(tmpl Template) error {
 
 	params := make(map[string]any)
 	for _, p := range cc.Params {
-		if _, param := tmpl.ParamByName(p); param.Type == TypeBool {
+		_, param := tmpl.ParamByName(p)
+		switch {
+		case param.Readonly:
+		case param.Type == TypeBool:
 			params[p] = true
-		} else {
+		default:
 			params[p] = "foo"
 		}
 	}

--- a/util/templates/template.go
+++ b/util/templates/template.go
@@ -426,7 +426,7 @@ func (t *Template) RenderResult(class Class, renderMode int, other map[string]an
 				}
 
 				// validate required fields from yaml
-				if p.IsRequired() && p.IsZero(s) && (renderMode == RenderModeUnitTest || renderMode == RenderModeInstance && !testing.Testing()) {
+				if p.IsRequired() && !p.Readonly && p.IsZero(s) && (renderMode == RenderModeUnitTest || renderMode == RenderModeInstance && !testing.Testing()) {
 					// validate required per usage
 					if len(p.Usages) == 0 || slices.Contains(p.Usages, usage) {
 						return nil, nil, fmt.Errorf("missing required `%s`", p.Name)

--- a/util/templates/types.go
+++ b/util/templates/types.go
@@ -62,11 +62,12 @@ var (
 )
 
 const (
-	RequirementSponsorship = "sponsorship" // Sponsorship is required
-	RequirementSkipTest    = "skiptest"    // Template should be rendered but not tested
+	RequirementSponsorship  = "sponsorship"  // Sponsorship is required
+	RequirementSkipTest     = "skiptest"     // Template should be rendered but not tested
+	RequirementRemoteAccess = "remoteaccess" // Remote access must be enabled, e.g. for public callback endpoints
 )
 
-var ValidRequirements = []string{RequirementSponsorship, RequirementSkipTest}
+var ValidRequirements = []string{RequirementSponsorship, RequirementSkipTest, RequirementRemoteAccess}
 
 var predefinedTemplateProperties = slices.Concat(
 	[]string{"type", "template", "name"}, ModbusParams, ModbusConnectionTypes,
@@ -221,6 +222,7 @@ type Param struct {
 	Private     bool         `json:",omitempty"` // value should be redacted in bug reports, e.g. email, locations, ...
 	Advanced    bool         `json:",omitempty"` // cli if the user does not need to be asked. Requires a "Default" to be defined.
 	Deprecated  bool         `json:",omitempty"` // if the parameter is deprecated and thus should not be presented in the cli or docs
+	Readonly    bool         `json:",omitempty"` // display-only service value for copying, never part of the config
 	Default     string       `json:",omitempty"` // default value if no user value is provided in the configuration
 	Example     string       `json:",omitempty"` // cli example value
 	Value       string       `json:"-"`          // user provided value via cli configuration

--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -12,11 +12,16 @@ import (
 	teslaclient "github.com/evcc-io/tesla-proxy-client"
 )
 
+type teslaController interface {
+	api.CurrentController
+	api.ChargeController
+}
+
 // Tesla is an api.Vehicle implementation for Tesla cars using the official Tesla vehicle-command api.
 type Tesla struct {
 	*embed
 	*tesla.Provider
-	*tesla.Controller
+	teslaController
 }
 
 func init() {
@@ -68,25 +73,38 @@ func NewTeslaFromConfig(other map[string]any) (api.Vehicle, error) {
 		return nil, err
 	}
 
-	// proxy client
-	pc := request.NewClient(log)
-	pc.Transport = &transport.Decorator{
-		Decorator: transport.DecorateHeaders(map[string]string{
-			"X-Authorization": "Bearer " + cc.ProxyToken,
-		}),
-		Base: fleet.HTTPClient.Transport,
-	}
+	var controller teslaController
 
-	tcc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(pc))
-	if err != nil {
-		return nil, err
+	if cc.Interactive() {
+		key, err := tesla.SigningKey()
+		if err != nil {
+			return nil, err
+		}
+
+		controller = tesla.NewSignedController(fleet.TokenSource, key, vehicle, fleet.Host)
+	} else {
+		// proxy client
+		pc := request.NewClient(log)
+		pc.Transport = &transport.Decorator{
+			Decorator: transport.DecorateHeaders(map[string]string{
+				"X-Authorization": "Bearer " + cc.ProxyToken,
+			}),
+			Base: fleet.HTTPClient.Transport,
+		}
+
+		tcc, err := teslaclient.NewClient(context.Background(), teslaclient.WithClient(pc))
+		if err != nil {
+			return nil, err
+		}
+		tcc.SetBaseUrl(cc.CommandProxy)
+
+		controller = tesla.NewController(vehicle.WithClient(tcc))
 	}
-	tcc.SetBaseUrl(cc.CommandProxy)
 
 	v := &Tesla{
-		embed:      &cc.embed,
-		Provider:   tesla.NewProvider(vehicle, cc.Cache),
-		Controller: tesla.NewController(vehicle.WithClient(tcc)),
+		embed:           &cc.embed,
+		Provider:        tesla.NewProvider(vehicle, cc.Cache),
+		teslaController: controller,
 	}
 
 	v.fromVehicle(vehicle.DisplayName, 0)

--- a/vehicle/tesla.go
+++ b/vehicle/tesla.go
@@ -12,16 +12,11 @@ import (
 	teslaclient "github.com/evcc-io/tesla-proxy-client"
 )
 
-type teslaController interface {
-	api.CurrentController
-	api.ChargeController
-}
-
 // Tesla is an api.Vehicle implementation for Tesla cars using the official Tesla vehicle-command api.
 type Tesla struct {
 	*embed
 	*tesla.Provider
-	teslaController
+	tesla.Commander
 }
 
 func init() {
@@ -73,7 +68,7 @@ func NewTeslaFromConfig(other map[string]any) (api.Vehicle, error) {
 		return nil, err
 	}
 
-	var controller teslaController
+	var controller tesla.Commander
 
 	if cc.Interactive() {
 		key, err := tesla.SigningKey()
@@ -102,9 +97,9 @@ func NewTeslaFromConfig(other map[string]any) (api.Vehicle, error) {
 	}
 
 	v := &Tesla{
-		embed:           &cc.embed,
-		Provider:        tesla.NewProvider(vehicle, cc.Cache),
-		teslaController: controller,
+		embed:     &cc.embed,
+		Provider:  tesla.NewProvider(vehicle, cc.Cache),
+		Commander: controller,
 	}
 
 	v.fromVehicle(vehicle.DisplayName, 0)

--- a/vehicle/tesla/controller.go
+++ b/vehicle/tesla/controller.go
@@ -10,6 +10,12 @@ import (
 
 const ProxyBaseUrl = "https://api.myteslamate.com"
 
+// Commander sends charge commands to the vehicle, via proxy or signed in-process
+type Commander interface {
+	api.CurrentController
+	api.ChargeController
+}
+
 type Controller struct {
 	vehicle *tesla.Vehicle
 }
@@ -23,14 +29,12 @@ func NewController(vehicle *tesla.Vehicle) *Controller {
 	return v
 }
 
-var _ api.CurrentController = (*Controller)(nil)
+var _ Commander = (*Controller)(nil)
 
 // MaxCurrent implements the api.CurrentController interface
 func (v *Controller) MaxCurrent(current int64) error {
 	return apiError(v.vehicle.SetChargingAmps(int(current)))
 }
-
-var _ api.ChargeController = (*Controller)(nil)
 
 // ChargeEnable implements the api.ChargeController interface
 func (v *Controller) ChargeEnable(enable bool) error {

--- a/vehicle/tesla/fleet.go
+++ b/vehicle/tesla/fleet.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/util"
@@ -14,16 +15,25 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// FleetConfig contains Tesla Fleet API credentials and tokens
+// FleetConfig contains Tesla Fleet API credentials and tokens.
+// Without tokens, they are obtained interactively via the evcc UI using the client secret.
 type FleetConfig struct {
 	Credentials oauth.ClientCredentials
 	Tokens      oauth.Tokens
+	Origin      string // public https address, defaults to the remote access url
+}
+
+// Interactive returns true when tokens are obtained via UI login instead of static config
+func (c FleetConfig) Interactive() bool {
+	return c.Tokens.Access == "" && c.Tokens.Refresh == "" && c.Credentials.Secret != ""
 }
 
 // FleetClient provides authenticated access to the Tesla Fleet API
 type FleetClient struct {
-	Client     *teslaclient.Client
-	HTTPClient *http.Client
+	Client      *teslaclient.Client
+	HTTPClient  *http.Client
+	TokenSource oauth2.TokenSource
+	Host        string // Fleet API host of the account region
 }
 
 // Validate checks that the required Tesla Fleet API credentials are configured
@@ -31,11 +41,34 @@ func (c FleetConfig) Validate() error {
 	if c.Credentials.ID == "" {
 		return errors.New("missing client id, see https://docs.evcc.io/en/docs/devices/vehicles#tesla")
 	}
+
+	if c.Interactive() {
+		if c.Origin == "" {
+			return nil
+		}
+		_, err := originHost(c.Origin)
+		return err
+	}
+
 	if c.Tokens.Access == "" || c.Tokens.Refresh == "" {
 		return api.ErrMissingToken
 	}
 
 	return nil
+}
+
+func (c FleetConfig) tokenSource(log *util.Logger) (oauth2.TokenSource, error) {
+	if c.Interactive() {
+		ctx := util.WithLogger(context.Background(), log)
+		return NewOAuth(ctx, c.Credentials.ID, c.Credentials.Secret, c.Origin)
+	}
+
+	token, err := c.Tokens.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewIdentity(log, OAuth2Config(c.Credentials.ID, c.Credentials.Secret), token)
 }
 
 // Client creates a Tesla Fleet API client for the configured account
@@ -44,12 +77,7 @@ func (c FleetConfig) Client(log *util.Logger) (*FleetClient, error) {
 		return nil, err
 	}
 
-	token, err := c.Tokens.Token()
-	if err != nil {
-		return nil, err
-	}
-
-	identity, err := NewIdentity(log, OAuth2Config(c.Credentials.ID, c.Credentials.Secret), token)
+	identity, err := c.tokenSource(log)
 	if err != nil {
 		return nil, fmt.Errorf("create Fleet identity: %w", err)
 	}
@@ -68,5 +96,10 @@ func (c FleetConfig) Client(log *util.Logger) (*FleetClient, error) {
 	}
 	tc.SetBaseUrl(region.FleetApiBaseUrl)
 
-	return &FleetClient{Client: tc, HTTPClient: hc}, nil
+	host, err := url.Parse(region.FleetApiBaseUrl)
+	if err != nil {
+		return nil, fmt.Errorf("get Fleet API region: %w", err)
+	}
+
+	return &FleetClient{Client: tc, HTTPClient: hc, TokenSource: identity, Host: host.Host}, nil
 }

--- a/vehicle/tesla/fleet_test.go
+++ b/vehicle/tesla/fleet_test.go
@@ -48,6 +48,20 @@ func TestFleetConfigValidate(t *testing.T) {
 				Tokens:      oauth.Tokens{Access: "access", Refresh: "refresh"},
 			},
 		},
+		{
+			name: "interactive",
+			config: FleetConfig{
+				Credentials: oauth.ClientCredentials{ID: "client", Secret: "secret"},
+			},
+		},
+		{
+			name: "interactive invalid origin",
+			config: FleetConfig{
+				Credentials: oauth.ClientCredentials{ID: "client", Secret: "secret"},
+				Origin:      "evcc.local",
+			},
+			want: "invalid origin",
+		},
 	}
 
 	for _, tc := range tests {

--- a/vehicle/tesla/key.go
+++ b/vehicle/tesla/key.go
@@ -1,0 +1,107 @@
+package tesla
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"net/http"
+
+	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/server/service"
+	"github.com/teslamotors/vehicle-command/pkg/protocol"
+)
+
+// tesla fetches the command signing public key from this path
+const publicKeyPath = "/.well-known/appspecific/com.tesla.3p.public-key.pem"
+
+const privateKeySetting = "tesla.privateKey"
+
+func init() {
+	service.RegisterPublic(publicKeyPath, http.HandlerFunc(publicKeyHandler))
+}
+
+func loadPrivateKey() (*ecdsa.PrivateKey, error) {
+	s, err := settings.String(privateKeySetting)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode([]byte(s))
+	if block == nil {
+		return nil, errors.New("invalid private key")
+	}
+
+	return x509.ParseECPrivateKey(block.Bytes)
+}
+
+func ensurePrivateKey() (*ecdsa.PrivateKey, error) {
+	if key, err := loadPrivateKey(); err == nil {
+		return key, nil
+	}
+
+	return generatePrivateKey()
+}
+
+func generatePrivateKey() (*ecdsa.PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	settings.SetString(privateKeySetting, string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})))
+
+	return key, nil
+}
+
+// SigningKey returns the command signing key in vehicle-command format
+func SigningKey() (protocol.ECDHPrivateKey, error) {
+	key, err := loadPrivateKey()
+	if err != nil {
+		return nil, errors.New("missing signing key, connect the Tesla account first")
+	}
+
+	scalar, err := key.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	skey := protocol.UnmarshalECDHPrivateKey(scalar)
+	if skey == nil {
+		return nil, errors.New("invalid signing key")
+	}
+
+	return skey, nil
+}
+
+func publicKeyPEM(key *ecdsa.PrivateKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}), nil
+}
+
+func publicKeyHandler(w http.ResponseWriter, r *http.Request) {
+	key, err := loadPrivateKey()
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	b, err := publicKeyPEM(key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-pem-file")
+	_, _ = w.Write(b)
+}

--- a/vehicle/tesla/key.go
+++ b/vehicle/tesla/key.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/evcc-io/evcc/server/db"
 	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/server/service"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
@@ -57,6 +58,13 @@ func generatePrivateKey() (*ecdsa.PrivateKey, error) {
 	}
 
 	settings.SetString(privateKeySetting, string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})))
+
+	// tesla holds the public key from now on, losing the private key means pairing again
+	if db.Instance != nil {
+		if err := settings.Persist(); err != nil {
+			return nil, err
+		}
+	}
 
 	return key, nil
 }

--- a/vehicle/tesla/key.go
+++ b/vehicle/tesla/key.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/evcc-io/evcc/db"
 	"github.com/evcc-io/evcc/db/settings"
 	"github.com/evcc-io/evcc/server/service"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
@@ -60,10 +59,8 @@ func generatePrivateKey() (*ecdsa.PrivateKey, error) {
 	settings.SetString(privateKeySetting, string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})))
 
 	// tesla holds the public key from now on, losing the private key means pairing again
-	if db.Instance != nil {
-		if err := settings.Persist(); err != nil {
-			return nil, err
-		}
+	if err := settings.Persist(); err != nil {
+		return nil, err
 	}
 
 	return key, nil

--- a/vehicle/tesla/key.go
+++ b/vehicle/tesla/key.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/evcc-io/evcc/server/db"
-	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/db"
+	"github.com/evcc-io/evcc/db/settings"
 	"github.com/evcc-io/evcc/server/service"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 )

--- a/vehicle/tesla/key_test.go
+++ b/vehicle/tesla/key_test.go
@@ -1,0 +1,58 @@
+package tesla
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSigningKey(t *testing.T) {
+	// no db in tests, blank the in-memory setting instead of deleting
+	t.Cleanup(func() { settings.SetString(privateKeySetting, "") })
+
+	rr := httptest.NewRecorder()
+	publicKeyHandler(rr, httptest.NewRequest(http.MethodGet, publicKeyPath, nil))
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	_, err := SigningKey()
+	require.Error(t, err)
+
+	key, err := ensurePrivateKey()
+	require.NoError(t, err)
+
+	again, err := ensurePrivateKey()
+	require.NoError(t, err)
+	require.True(t, key.Equal(again))
+
+	skey, err := SigningKey()
+	require.NoError(t, err)
+
+	rr = httptest.NewRecorder()
+	publicKeyHandler(rr, httptest.NewRequest(http.MethodGet, publicKeyPath, nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	block, _ := pem.Decode(rr.Body.Bytes())
+	require.NotNil(t, block)
+	require.Equal(t, "PUBLIC KEY", block.Type)
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	require.NoError(t, err)
+	require.True(t, key.PublicKey.Equal(pub))
+
+	ecdhPub, err := key.PublicKey.ECDH()
+	require.NoError(t, err)
+	require.Equal(t, ecdhPub.Bytes(), skey.PublicBytes())
+
+	rotated, err := generatePrivateKey()
+	require.NoError(t, err)
+	require.False(t, key.Equal(rotated))
+
+	again, err = ensurePrivateKey()
+	require.NoError(t, err)
+	require.True(t, rotated.Equal(again))
+}

--- a/vehicle/tesla/key_test.go
+++ b/vehicle/tesla/key_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/db/settings"
 	"github.com/stretchr/testify/require"
 )
 

--- a/vehicle/tesla/oauth.go
+++ b/vehicle/tesla/oauth.go
@@ -1,0 +1,98 @@
+package tesla
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/evcc-io/evcc/plugin/auth"
+	"github.com/evcc-io/evcc/server/network"
+	"github.com/evcc-io/evcc/util"
+	teslaclient "github.com/evcc-io/tesla-proxy-client"
+	"golang.org/x/oauth2"
+)
+
+func init() {
+	auth.Register("tesla", func(other map[string]any) (oauth2.TokenSource, error) {
+		var cc struct {
+			ClientID, ClientSecret, Origin string
+		}
+
+		if err := util.DecodeOther(other, &cc); err != nil {
+			return nil, err
+		}
+
+		log := util.NewLogger("tesla").Redact(cc.ClientID, cc.ClientSecret)
+		ctx := util.WithLogger(context.Background(), log)
+
+		return NewOAuth(ctx, cc.ClientID, cc.ClientSecret, cc.Origin)
+	})
+}
+
+// originHost returns the host of the public https origin, which is the domain registered with Tesla
+func originHost(origin string) (string, error) {
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return "", fmt.Errorf("invalid origin, expected https://host: %s", origin)
+	}
+	return u.Host, nil
+}
+
+// OAuthConfig returns the Fleet API OAuth2 config for a third-party app
+func OAuthConfig(clientID, clientSecret, origin string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  origin + network.CallbackPath,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   authURL,
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		// scopes cannot be widened later without revoking the app, energy scopes cover a later Powerwall
+		Scopes: []string{
+			"openid", "offline_access", "user_data",
+			"vehicle_device_data", "vehicle_location", "vehicle_cmds", "vehicle_charging_cmds",
+			"energy_device_data", "energy_cmds",
+		},
+	}
+}
+
+// NewOAuth creates the Fleet API token source. Login registers the origin host with Tesla first.
+// An empty origin defaults to the remote access url.
+func NewOAuth(ctx context.Context, clientID, clientSecret, origin string) (oauth2.TokenSource, error) {
+	log := util.ContextLoggerWithDefault(ctx, util.NewLogger("tesla"))
+
+	if origin == "" {
+		if origin = remoteOrigin(); origin == "" {
+			return nil, errors.New("missing origin, enable remote access or configure a public https address")
+		}
+	}
+
+	return auth.NewOAuth(ctx, "Tesla", "", OAuthConfig(clientID, clientSecret, origin),
+		// region is resolved from the account after login
+		auth.WithExchangeOptions(oauth2.SetAuthURLParam("audience", strings.TrimSuffix(teslaclient.FleetAudienceNA, "/"))),
+		auth.WithLoginHook(func(ctx context.Context) error {
+			domain, err := originHost(origin)
+			if err != nil {
+				return err
+			}
+			if _, err := ensurePrivateKey(); err != nil {
+				return err
+			}
+
+			err = registerPartner(ctx, log, clientID, clientSecret, domain)
+			if errors.Is(err, errKeyTaken) {
+				log.WARN.Printf("signing key is registered for another app or domain, replacing it, vehicles must pair again")
+				if _, err := generatePrivateKey(); err != nil {
+					return err
+				}
+				err = registerPartner(ctx, log, clientID, clientSecret, domain)
+			}
+
+			return err
+		}),
+	)
+}

--- a/vehicle/tesla/oauth.go
+++ b/vehicle/tesla/oauth.go
@@ -66,7 +66,7 @@ func NewOAuth(ctx context.Context, clientID, clientSecret, origin string) (oauth
 	log := util.ContextLoggerWithDefault(ctx, util.NewLogger("tesla"))
 
 	if origin == "" {
-		if origin = remoteOrigin(); origin == "" {
+		if origin = network.RemoteOrigin(); origin == "" {
 			return nil, errors.New("missing origin, enable remote access or configure a public https address")
 		}
 	}

--- a/vehicle/tesla/partner.go
+++ b/vehicle/tesla/partner.go
@@ -1,0 +1,93 @@
+package tesla
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	teslaclient "github.com/evcc-io/tesla-proxy-client"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const authURL = "https://auth.tesla.com/oauth2/v3/authorize"
+
+var (
+	tokenURL = "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token"
+
+	// the account region is unknown before login, register everywhere
+	fleetAudiences = []string{teslaclient.FleetAudienceEU, teslaclient.FleetAudienceNA}
+)
+
+// tesla binds a public key to a single app and domain
+var errKeyTaken = errors.New("public key already registered for another app or domain")
+
+// registerPartner registers the domain hosting the public key with the Fleet API.
+// Tesla fetches the key from the domain during this call. The call is idempotent.
+func registerPartner(ctx context.Context, log *util.Logger, clientID, clientSecret, domain string) error {
+	var errs []error
+
+	for _, audience := range fleetAudiences {
+		if err := registerPartnerRegion(ctx, log, clientID, clientSecret, domain, audience); err != nil {
+			log.DEBUG.Printf("register %s with %s: %v", domain, audience, err)
+			errs = append(errs, err)
+		}
+	}
+
+	// the account's vehicles live in one region
+	if len(errs) < len(fleetAudiences) {
+		return nil
+	}
+
+	for _, err := range errs {
+		switch {
+		case strings.Contains(err.Error(), "Public key hash has already been taken"):
+			return errKeyTaken
+		case strings.Contains(err.Error(), "Domain has already been taken"):
+			return fmt.Errorf("%s is registered with another Tesla app, use that app's client id and secret", domain)
+		}
+	}
+
+	return errs[0]
+}
+
+func registerPartnerRegion(ctx context.Context, log *util.Logger, clientID, clientSecret, domain, audience string) error {
+	cc := clientcredentials.Config{
+		ClientID:       clientID,
+		ClientSecret:   clientSecret,
+		TokenURL:       tokenURL,
+		Scopes:         []string{"openid", "vehicle_device_data", "vehicle_cmds", "vehicle_charging_cmds"},
+		EndpointParams: url.Values{"audience": {strings.TrimSuffix(audience, "/")}},
+		AuthStyle:      oauth2.AuthStyleInParams,
+	}
+
+	helper := request.NewHelper(log)
+	helper.Transport = &oauth2.Transport{
+		Source: cc.TokenSource(context.WithValue(ctx, oauth2.HTTPClient, request.NewClient(log))),
+		Base:   helper.Transport,
+	}
+
+	req, err := request.New(http.MethodPost, audience+"api/1/partner_accounts", request.MarshalJSON(map[string]string{
+		"domain": domain,
+	}), request.JSONEncoding)
+	if err != nil {
+		return err
+	}
+
+	if _, err := helper.DoBody(req); err != nil {
+		var se *request.StatusError
+		if errors.As(err, &se) {
+			return fmt.Errorf("register partner: %w: %s", err, strings.TrimSpace(string(se.Body())))
+		}
+		return fmt.Errorf("register partner: %w", err)
+	}
+
+	log.DEBUG.Printf("registered %s with %s", domain, audience)
+
+	return nil
+}

--- a/vehicle/tesla/partner_test.go
+++ b/vehicle/tesla/partner_test.go
@@ -1,0 +1,81 @@
+package tesla
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterPartner(t *testing.T) {
+	var tokenForm url.Values
+	var registered []string
+	status := http.StatusOK
+	errBody := `{"error":"key not found"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/token":
+			require.NoError(t, r.ParseForm())
+			tokenForm = r.PostForm
+			_, _ = w.Write([]byte(`{"access_token":"partner","token_type":"Bearer","expires_in":3600}`))
+
+		case "/api/1/partner_accounts":
+			require.Equal(t, "Bearer partner", r.Header.Get("Authorization"))
+
+			var body map[string]string
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			registered = append(registered, body["domain"])
+
+			w.WriteHeader(status)
+			if status != http.StatusOK {
+				_, _ = w.Write([]byte(errBody))
+				return
+			}
+			_, _ = w.Write([]byte(`{"response":{}}`))
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	audience := srv.URL + "/"
+	tokenURL, fleetAudiences = srv.URL+"/token", []string{audience}
+
+	log := util.NewLogger("test")
+
+	require.NoError(t, registerPartner(t.Context(), log, "id", "secret", "evcc.example"))
+	require.Equal(t, []string{"evcc.example"}, registered)
+	require.Equal(t, "client_credentials", tokenForm.Get("grant_type"))
+	require.Equal(t, "id", tokenForm.Get("client_id"))
+	require.Equal(t, "secret", tokenForm.Get("client_secret"))
+	require.Equal(t, srv.URL, tokenForm.Get("audience"), "audience without trailing slash")
+
+	// one region is enough
+	fleetAudiences = []string{srv.URL + "/missing/", audience}
+	require.NoError(t, registerPartner(t.Context(), log, "id", "secret", "evcc.example"))
+
+	// tesla rejects the domain, its explanation is passed on
+	fleetAudiences = []string{audience}
+	status = http.StatusUnprocessableEntity
+	err := registerPartner(t.Context(), log, "id", "secret", "evcc.example")
+	require.ErrorContains(t, err, "422")
+	require.ErrorContains(t, err, "key not found")
+
+	// key bound to another app or domain
+	errBody = `{"error":"Validation failed: Public key hash has already been taken"}`
+	err = registerPartner(t.Context(), log, "id", "secret", "evcc.example")
+	require.ErrorIs(t, err, errKeyTaken)
+
+	// domain bound to another app
+	errBody = `{"error":"Validation failed: Domain has already been taken"}`
+	err = registerPartner(t.Context(), log, "id", "secret", "evcc.example")
+	require.ErrorContains(t, err, "evcc.example is registered with another Tesla app")
+}

--- a/vehicle/tesla/service.go
+++ b/vehicle/tesla/service.go
@@ -1,0 +1,48 @@
+package tesla
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/evcc-io/evcc/core/keys"
+	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/server/network"
+	"github.com/evcc-io/evcc/server/service"
+)
+
+func init() {
+	mux := http.NewServeMux()
+
+	// values the user copies into the Tesla developer app, all derived from the remote access url
+	for path, f := range map[string]func(origin string) string{
+		"/origin":      func(origin string) string { return origin },
+		"/redirecturi": func(origin string) string { return origin + network.CallbackPath },
+		"/virtualkey": func(origin string) string {
+			host, _ := originHost(origin)
+			return "https://tesla.com/_ak/" + host
+		},
+	} {
+		mux.HandleFunc("GET "+path, func(w http.ResponseWriter, req *http.Request) {
+			res := []string{}
+			if origin := remoteOrigin(); origin != "" {
+				res = append(res, f(origin))
+			}
+			_ = json.NewEncoder(w).Encode(res)
+		})
+	}
+
+	service.Register("tesla", mux)
+}
+
+// remoteOrigin returns the remote access url as public origin of this instance, empty if disabled
+func remoteOrigin() string {
+	var remote struct {
+		Enabled bool   `json:"enabled"`
+		URL     string `json:"url"`
+	}
+	if err := settings.Json(keys.Remote, &remote); err != nil || !remote.Enabled {
+		return ""
+	}
+	return strings.TrimRight(remote.URL, "/")
+}

--- a/vehicle/tesla/service.go
+++ b/vehicle/tesla/service.go
@@ -3,10 +3,7 @@ package tesla
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
-	"github.com/evcc-io/evcc/core/keys"
-	"github.com/evcc-io/evcc/db/settings"
 	"github.com/evcc-io/evcc/server/network"
 	"github.com/evcc-io/evcc/server/service"
 )
@@ -14,35 +11,14 @@ import (
 func init() {
 	mux := http.NewServeMux()
 
-	// values the user copies into the Tesla developer app, all derived from the remote access url
-	for path, f := range map[string]func(origin string) string{
-		"/origin":      func(origin string) string { return origin },
-		"/redirecturi": func(origin string) string { return origin + network.CallbackPath },
-		"/virtualkey": func(origin string) string {
-			host, _ := originHost(origin)
-			return "https://tesla.com/_ak/" + host
-		},
-	} {
-		mux.HandleFunc("GET "+path, func(w http.ResponseWriter, req *http.Request) {
-			res := []string{}
-			if origin := remoteOrigin(); origin != "" {
-				res = append(res, f(origin))
-			}
-			_ = json.NewEncoder(w).Encode(res)
-		})
-	}
+	// virtual key link the user opens on the phone, derived from the domain registered with tesla
+	mux.HandleFunc("GET /virtualkey", func(w http.ResponseWriter, req *http.Request) {
+		res := []string{}
+		if host, err := originHost(network.RemoteOrigin()); err == nil {
+			res = append(res, "https://tesla.com/_ak/"+host)
+		}
+		_ = json.NewEncoder(w).Encode(res)
+	})
 
 	service.Register("tesla", mux)
-}
-
-// remoteOrigin returns the remote access url as public origin of this instance, empty if disabled
-func remoteOrigin() string {
-	var remote struct {
-		Enabled bool   `json:"enabled"`
-		URL     string `json:"url"`
-	}
-	if err := settings.Json(keys.Remote, &remote); err != nil || !remote.Enabled {
-		return ""
-	}
-	return strings.TrimRight(remote.URL, "/")
 }

--- a/vehicle/tesla/service.go
+++ b/vehicle/tesla/service.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/evcc-io/evcc/core/keys"
-	"github.com/evcc-io/evcc/server/db/settings"
+	"github.com/evcc-io/evcc/db/settings"
 	"github.com/evcc-io/evcc/server/network"
 	"github.com/evcc-io/evcc/server/service"
 )

--- a/vehicle/tesla/signed.go
+++ b/vehicle/tesla/signed.go
@@ -1,0 +1,124 @@
+package tesla
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/request"
+	teslaclient "github.com/evcc-io/tesla-proxy-client"
+	"github.com/teslamotors/vehicle-command/pkg/account"
+	"github.com/teslamotors/vehicle-command/pkg/cache"
+	"github.com/teslamotors/vehicle-command/pkg/protocol"
+	"github.com/teslamotors/vehicle-command/pkg/vehicle"
+	"golang.org/x/oauth2"
+)
+
+// SignedController sends commands via the Vehicle Command Protocol, signed with the instance key.
+// Vehicles without protocol support (pre-2021 Model S/X) fall back to the REST controller.
+type SignedController struct {
+	mu       sync.Mutex
+	ts       oauth2.TokenSource
+	key      protocol.ECDHPrivateKey
+	vin      string
+	host     string
+	sessions *cache.SessionCache
+	rest     *Controller
+}
+
+// NewSignedController creates a signing vehicle current and charge controller
+func NewSignedController(ts oauth2.TokenSource, key protocol.ECDHPrivateKey, vehicle *teslaclient.Vehicle, host string) *SignedController {
+	return &SignedController{
+		ts:       ts,
+		key:      key,
+		vin:      vehicle.Vin,
+		host:     host,
+		sessions: cache.New(1),
+		rest:     NewController(vehicle),
+	}
+}
+
+func (v *SignedController) exec(fn func(context.Context, *vehicle.Vehicle) error) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	defer cancel()
+
+	token, err := v.ts.Token()
+	if err != nil {
+		return err
+	}
+
+	acct, err := account.New(token.AccessToken, "evcc/"+util.Version)
+	if err != nil {
+		return err
+	}
+	acct.Host = v.host
+
+	car, err := acct.GetVehicle(ctx, v.vin, v.key, v.sessions)
+	if err != nil {
+		return err
+	}
+
+	if err := car.Connect(ctx); err != nil {
+		return err
+	}
+	defer car.Disconnect()
+
+	if err := car.StartSession(ctx, nil); err != nil {
+		return err
+	}
+	defer func() { _ = car.UpdateCachedSessions(v.sessions) }()
+
+	err = fn(ctx, car)
+
+	// command not applicable in current vehicle state, e.g. already charging
+	if protocol.IsNominalError(err) {
+		err = nil
+	}
+
+	return err
+}
+
+var _ api.CurrentController = (*SignedController)(nil)
+
+// MaxCurrent implements the api.CurrentController interface
+func (v *SignedController) MaxCurrent(current int64) error {
+	err := v.exec(func(ctx context.Context, car *vehicle.Vehicle) error {
+		return car.SetChargingAmps(ctx, int32(current))
+	})
+
+	if errors.Is(err, protocol.ErrProtocolNotSupported) {
+		return v.rest.MaxCurrent(current)
+	}
+
+	return apiError(err)
+}
+
+var _ api.ChargeController = (*SignedController)(nil)
+
+// ChargeEnable implements the api.ChargeController interface
+func (v *SignedController) ChargeEnable(enable bool) error {
+	err := v.exec(func(ctx context.Context, car *vehicle.Vehicle) error {
+		if enable {
+			return car.ChargeStart(ctx)
+		}
+		return car.ChargeStop(ctx)
+	})
+
+	if errors.Is(err, protocol.ErrProtocolNotSupported) {
+		return v.rest.ChargeEnable(enable)
+	}
+
+	err = apiError(err)
+
+	// ignore sleeping vehicle
+	if !enable && errors.Is(err, api.ErrAsleep) {
+		err = nil
+	}
+
+	return err
+}

--- a/vehicle/tesla/signed.go
+++ b/vehicle/tesla/signed.go
@@ -83,7 +83,7 @@ func (v *SignedController) exec(fn func(context.Context, *vehicle.Vehicle) error
 	return err
 }
 
-var _ api.CurrentController = (*SignedController)(nil)
+var _ Commander = (*SignedController)(nil)
 
 // MaxCurrent implements the api.CurrentController interface
 func (v *SignedController) MaxCurrent(current int64) error {
@@ -97,8 +97,6 @@ func (v *SignedController) MaxCurrent(current int64) error {
 
 	return apiError(err)
 }
-
-var _ api.ChargeController = (*SignedController)(nil)
 
 // ChargeEnable implements the api.ChargeController interface
 func (v *SignedController) ChargeEnable(enable bool) error {


### PR DESCRIPTION
Tesla vehicles can now be set up entirely inside evcc with the user's own Tesla developer app. Remote access provides the public https address Tesla requires for key hosting and the OAuth redirect, so MyTeslaMate is no longer needed as a middleman. Remote access is only required during setup (and again for re-login or pairing another vehicle), it can be disabled afterwards. The existing template stays as "Tesla (MyTeslaMate)".

- New "Tesla" template (`tesla-fleet`): origin and redirect URI shown for copying into the Tesla app, partner registration and key generation happen on Connect, commands are signed in-process with `vehicle-command` (REST fallback for pre-2021 S/X).
- Public key served at `/.well-known/appspecific/com.tesla.3p.public-key.pem`, instance key stored in settings.
- Virtual key link as advanced field, only needed for vehicle-side charge control.

General auth flow additions/improvements

- Template `readonly` params: service value with copy link, never persisted.
- Template `remoteaccess` requirement: hint linking to the Remote Access modal.
- Template description only on the first screen of auth templates.
- Device modal keeps entered values across the login redirect and the remote access modal.
- Callback returns to the page the login started from (redirect URI may be another origin), unknown state → 400 instead of a reflected error page.
- Remote access lets selected public routes through without login: the Tesla key file and the OAuth callback.

**Video**

[tesla-setup.webm](https://github.com/user-attachments/assets/bf34f597-0d02-4e90-bc74-1362261ea81e)

*Note: the credentials you see are decommissioned 😉*