### PR TITLE
Highlight and sort changelog entries by configured devices

### DIFF
--- a/assets/js/components/AboutModal.vue
+++ b/assets/js/components/AboutModal.vue
@@ -1,5 +1,5 @@
 <template>
-	<GenericModal id="aboutModal" @opened="acknowledge">
+	<GenericModal id="aboutModal" @open="loadActiveFeatures" @opened="acknowledge">
 		<template #title>
 			<a :href="websiteUrl" target="_blank" rel="noopener noreferrer">
 				<template v-if="customLogo">
@@ -84,6 +84,9 @@
 			<template v-if="newVersionAvailable">
 				<hr />
 				<h6>{{ $t("footer.version.modalNextRelease") }}</h6>
+				<p v-if="releaseNotes && hasRelevantEntries" class="text-muted small">
+					{{ $t("footer.version.modalRelevantEntries") }}
+				</p>
 				<!-- oxlint-disable vue/no-v-html -->
 				<div v-if="releaseNotes" class="release-notes" v-html="cleanedReleaseNotes"></div>
 				<!-- oxlint-enable vue/no-v-html -->
@@ -159,6 +162,8 @@ import api from "@/api";
 import settings from "@/settings";
 import { extractDomain } from "@/utils/extractDomain";
 import { isDevelopment, isNightly, getReleaseName, isNewVersionAvailable } from "@/utils/version";
+import { fetchActiveFeatureNames } from "@/utils/activeFeatures";
+import { highlightAndSortChangelog } from "@/utils/highlightChangelog";
 import { defineComponent } from "vue";
 
 const GITHUB_REPO = "https://github.com/evcc-io/evcc";
@@ -185,6 +190,7 @@ export default defineComponent({
 		return {
 			updateStarted: false,
 			updateStatus: "",
+			activeFeatureNames: [] as string[],
 		};
 	},
 	computed: {
@@ -221,13 +227,20 @@ export default defineComponent({
 		},
 		cleanedReleaseNotes() {
 			if (!this.releaseNotes) return "";
-			return this.releaseNotes.replaceAll("<h2>Changelog</h2>", "");
+			const notes = this.releaseNotes.replaceAll("<h2>Changelog</h2>", "");
+			return highlightAndSortChangelog(notes, this.activeFeatureNames);
+		},
+		hasRelevantEntries() {
+			return this.cleanedReleaseNotes.includes("changelog-relevant");
 		},
 		newVersionAvailable() {
 			return isNewVersionAvailable(this.installed, this.availableVersion);
 		},
 	},
 	methods: {
+		async loadActiveFeatures() {
+			this.activeFeatureNames = await fetchActiveFeatureNames();
+		},
 		async update() {
 			try {
 				await api.post("update");
@@ -295,5 +308,12 @@ export default defineComponent({
 }
 .release-notes :deep(h1:first-child) {
 	margin-top: 0;
+}
+.release-notes :deep(.changelog-relevant) {
+	font-weight: bold;
+	background-color: color-mix(in srgb, var(--bs-primary) 12%, transparent);
+	border-radius: 0.25rem;
+	padding: 0.1rem 0.35rem;
+	margin: 0 -0.35rem;
 }
 </style>

--- a/assets/js/utils/activeFeatures.test.ts
+++ b/assets/js/utils/activeFeatures.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+import { normalizeFeatureName, fetchActiveFeatureNames } from "./activeFeatures";
+import api from "@/api";
+
+vi.mock("@/api", () => ({
+  default: { get: vi.fn() },
+  allowClientError: { validateStatus: (status: number) => status >= 200 && status < 500 },
+}));
+
+describe("normalizeFeatureName", () => {
+  test("normalizes to a comparable key", () => {
+    expect(normalizeFeatureName("Home Assistant")).toBe("homeassistant");
+    expect(normalizeFeatureName("homeassistant")).toBe("homeassistant");
+    expect(normalizeFeatureName("OpenDTU")).toBe("opendtu");
+  });
+});
+
+describe("fetchActiveFeatureNames", () => {
+  test("collects deviceProduct and type from all device classes", async () => {
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "config/devices/charger") {
+        return { status: 200, data: [{ type: "template", deviceProduct: "Home Assistant" }] };
+      }
+      if (url === "config/devices/meter") {
+        return { status: 200, data: [{ type: "opendtu", deviceProduct: "OpenDTU" }] };
+      }
+      return { status: 200, data: [] };
+    });
+
+    const names = await fetchActiveFeatureNames();
+    expect(names).toContain("Home Assistant");
+    expect(names).toContain("template");
+    expect(names).toContain("OpenDTU");
+    expect(names).toContain("opendtu");
+  });
+
+  test("resolves to an empty list when unauthenticated", async () => {
+    vi.mocked(api.get).mockResolvedValue({ status: 401, data: null });
+    const names = await fetchActiveFeatureNames();
+    expect(names).toEqual([]);
+  });
+
+  test("resolves to an empty list on request errors", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("network error"));
+    const names = await fetchActiveFeatureNames();
+    expect(names).toEqual([]);
+  });
+});

--- a/assets/js/utils/activeFeatures.ts
+++ b/assets/js/utils/activeFeatures.ts
@@ -1,0 +1,45 @@
+import api, { allowClientError } from "@/api";
+
+// device classes exposed via GET /api/config/devices/{class}
+const DEVICE_CLASSES = [
+  "charger",
+  "meter",
+  "vehicle",
+  "tariff",
+  "hems",
+  "circuit",
+  "messenger",
+  "curtailer",
+] as const;
+
+interface DeviceEntity {
+  type?: string;
+  deviceProduct?: string;
+}
+
+// normalize a product/type name for comparison, e.g. "Home Assistant" and
+// "homeassistant" both become "homeassistant"
+export function normalizeFeatureName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+// collects the product and type names of all devices the user actually configured.
+// requires an authenticated session; resolves to an empty list otherwise (e.g. a
+// password-protected instance viewed by a guest), so callers should treat an empty
+// result as "unknown" rather than "nothing configured".
+export async function fetchActiveFeatureNames(): Promise<string[]> {
+  const lists = await Promise.all(
+    DEVICE_CLASSES.map(async (cls) => {
+      try {
+        const { data, status } = await api.get(`config/devices/${cls}`, allowClientError);
+        if (status !== 200 || !Array.isArray(data)) return [];
+        return (data as DeviceEntity[]).flatMap((device) =>
+          [device.deviceProduct, device.type].filter((v): v is string => !!v)
+        );
+      } catch {
+        return [];
+      }
+    })
+  );
+  return lists.flat();
+}

--- a/assets/js/utils/highlightChangelog.test.ts
+++ b/assets/js/utils/highlightChangelog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vite-plus/test";
+import { highlightAndSortChangelog } from "./highlightChangelog";
+
+const html = `
+<h1>v0.303.1</h1>
+<h2>Changelog</h2>
+<h3>Other Changes</h3>
+<ul>
+<li>Home Assistant: allow switch for enable/disable</li>
+<li>Nexblue: remove broken 1p3p</li>
+<li>Optimizer: return infeasable error</li>
+</ul>
+<h3>Bug Fixes</h3>
+<ul>
+<li>HomeAssistant: fix changelog</li>
+<li>Optimizer: fix invalid battery capacity</li>
+</ul>
+`;
+
+describe("highlightAndSortChangelog", () => {
+  test("returns markup unchanged without active features", () => {
+    expect(highlightAndSortChangelog(html, [])).toBe(html);
+  });
+
+  test("returns empty string unchanged", () => {
+    expect(highlightAndSortChangelog("", ["OpenDTU"])).toBe("");
+  });
+
+  test("marks and moves matching entries to the top of each list", () => {
+    const result = highlightAndSortChangelog(html, ["Home Assistant"]);
+
+    const doc = new DOMParser().parseFromString(result, "text/html");
+    const lists = doc.querySelectorAll("ul");
+
+    // first list: "Home Assistant: ..." moved to the top and marked
+    const firstItems = Array.from(lists[0].children);
+    expect(firstItems[0].textContent).toContain("Home Assistant: allow switch");
+    expect(firstItems[0].classList.contains("changelog-relevant")).toBe(true);
+    expect(firstItems[1].classList.contains("changelog-relevant")).toBe(false);
+    expect(firstItems[2].classList.contains("changelog-relevant")).toBe(false);
+
+    // second list: "HomeAssistant: ..." (no space) still matches, moved to top
+    const secondItems = Array.from(lists[1].children);
+    expect(secondItems[0].textContent).toContain("HomeAssistant: fix changelog");
+    expect(secondItems[0].classList.contains("changelog-relevant")).toBe(true);
+  });
+
+  test("preserves relative order when nothing matches", () => {
+    const result = highlightAndSortChangelog(html, ["Sigenergy"]);
+    const doc = new DOMParser().parseFromString(result, "text/html");
+    const firstItems = Array.from(doc.querySelectorAll("ul")[0].children);
+    expect(firstItems[0].textContent).toContain("Home Assistant: allow switch");
+    expect(firstItems.some((li) => li.classList.contains("changelog-relevant"))).toBe(false);
+  });
+
+  test("matches type keys as well as product names", () => {
+    const result = highlightAndSortChangelog(html, ["opendtu", "nexblue"]);
+    const doc = new DOMParser().parseFromString(result, "text/html");
+    const firstItems = Array.from(doc.querySelectorAll("ul")[0].children);
+    expect(firstItems[0].textContent).toContain("Nexblue: remove broken");
+    expect(firstItems[0].classList.contains("changelog-relevant")).toBe(true);
+  });
+});

--- a/assets/js/utils/highlightChangelog.ts
+++ b/assets/js/utils/highlightChangelog.ts
@@ -1,0 +1,50 @@
+import { normalizeFeatureName } from "./activeFeatures";
+
+const RELEVANT_CLASS = "changelog-relevant";
+
+// evcc changelog entries conventionally start with the integration they affect,
+// e.g. "Home Assistant: allow switch for enable/disable". Extract that prefix.
+function entryPrefix(li: Element): string | null {
+  const text = li.textContent || "";
+  const idx = text.indexOf(":");
+  if (idx === -1) return null;
+  return normalizeFeatureName(text.slice(0, idx));
+}
+
+// highlights and reorders changelog list items so entries matching the user's
+// configured features (chargers, meters, vehicles, tariffs, ...) are marked and
+// moved to the top of their list. Leaves the markup untouched when no active
+// features are known, e.g. an unauthenticated session.
+export function highlightAndSortChangelog(html: string, activeFeatures: string[]): string {
+  if (!html || !activeFeatures.length) return html;
+
+  const activeSet = new Set(activeFeatures.map(normalizeFeatureName));
+
+  const doc = new DOMParser().parseFromString(`<div>${html}</div>`, "text/html");
+  const container = doc.body.firstElementChild;
+  if (!container) return html;
+
+  container.querySelectorAll("ul").forEach((ul) => {
+    const items = Array.from(ul.children).map((li, index) => {
+      const prefix = entryPrefix(li);
+      const relevant = prefix !== null && activeSet.has(prefix);
+      if (relevant) {
+        li.classList.add(RELEVANT_CLASS);
+      }
+      return { li, relevant, index };
+    });
+
+    // nothing to reorder if no entry matched
+    if (!items.some((item) => item.relevant)) return;
+
+    items
+      .slice()
+      .sort((a, b) => {
+        if (a.relevant !== b.relevant) return a.relevant ? -1 : 1;
+        return a.index - b.index;
+      })
+      .forEach((item) => ul.appendChild(item.li));
+  });
+
+  return container.innerHTML;
+}

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1134,6 +1134,7 @@
       "modalLatest": "Du verwendest bereits die aktuellste Version.",
       "modalNextRelease": "Was ist neu im nächsten Release",
       "modalNoReleaseNotes": "Keine Versionshinweise verfügbar. Mehr Informationen zur neuen Version:",
+      "modalRelevantEntries": "Hervorgehobene Einträge betreffen deine konfigurierten Geräte.",
       "modalTitle": "Neue Version verfügbar",
       "modalUpdate": "Installieren",
       "modalUpdateNow": "Jetzt installieren",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1134,6 +1134,7 @@
       "modalLatest": "You're running the latest version.",
       "modalNextRelease": "What's in the next release",
       "modalNoReleaseNotes": "No release notes available. More info about the new version:",
+      "modalRelevantEntries": "Highlighted entries are relevant to your configured devices.",
       "modalTitle": "New version available",
       "modalUpdate": "Install",
       "modalUpdateNow": "Install now",


### PR DESCRIPTION
Summary

This PR adds functionality to highlight and prioritize changelog entries that are relevant to the user's configured devices and integrations in the About modal's release notes section.
Key Changes

    New utility modules:
        activeFeatures.ts: Fetches the list of configured device products and types from the API (/api/config/devices/{class}) and provides a normalizeFeatureName() function for consistent comparison
        highlightChangelog.ts: Parses changelog HTML, identifies entries matching active features, marks them with a changelog-relevant class, and reorders them to the top of each list

    Updated AboutModal.vue:
        Loads active feature names when the modal opens via new @open event handler
        Applies changelog highlighting and sorting to release notes via highlightAndSortChangelog()
        Displays a hint message when relevant entries are found
        Added CSS styling for highlighted entries (bold text with subtle background color)

    Internationalization:
        Added modalRelevantEntries translation key to en.json and de.json

    Test coverage:
        Comprehensive test suites for both utility modules covering normalization, API fetching, changelog parsing, and sorting logic

Implementation Details

    Feature name normalization removes spaces and special characters for case-insensitive matching (e.g., "Home Assistant" and "homeassistant" both normalize to "homeassistant")
    Changelog entries are expected to follow the convention of starting with an integration name followed by a colon (e.g., "Home Assistant: allow switch...")
    The solution gracefully handles unauthenticated sessions by treating empty feature lists as "unknown" rather than "nothing configured"
    Relative order of non-matching entries is preserved; only matching entries are moved to the top
