### PR TITLE
History: keep charge and discharge apart in entity legend sums

### DIFF
--- a/assets/js/components/History/groups.ts
+++ b/assets/js/components/History/groups.ts
@@ -1,5 +1,8 @@
 export const GROUP_ORDER = ["pv", "battery", "grid", "loadpoint", "consumer", "meter"] as const;
 
+// sums shown per direction instead of netted
+export const BIDIRECTIONAL_GROUPS: string[] = ["battery", "grid", "meter"];
+
 const COLOR_PICKER_GROUPS = ["loadpoint", "consumer", "meter"];
 
 export function hasColorPicker(group: string): boolean {

--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -106,7 +106,12 @@ import GroupChart, { type HistorySeries, stepAlpha } from "../components/History
 import type { Legend } from "../components/Sessions/types";
 import type { DeviceColors } from "@/types/evcc";
 import { PERIODS } from "../components/Sessions/types";
-import { GROUP_ORDER, groupColor, hasColorPicker } from "../components/History/groups";
+import {
+	BIDIRECTIONAL_GROUPS,
+	GROUP_ORDER,
+	groupColor,
+	hasColorPicker,
+} from "../components/History/groups";
 import colors, { resolveColors, deviceColorMap, darken, batteryColor } from "../colors";
 import LegendList from "../components/Sessions/LegendList.vue";
 import DownloadButton from "../components/Helper/DownloadButton.vue";
@@ -426,7 +431,8 @@ export default defineComponent({
 						s.group,
 						sumEnergy,
 						sumReturnEnergy,
-						POWER_UNIT.AUTO
+						POWER_UNIT.AUTO,
+						false
 					),
 					id: colorPicker && !s.virtual ? s.title : undefined,
 				};
@@ -462,26 +468,21 @@ export default defineComponent({
 			}
 			return this.directionSumLabel(group, sumEnergy, sumReturnEnergy, POWER_UNIT.KW);
 		},
-		// Bidirectional groups (battery, exporting meters) would net out to almost
-		// zero over longer periods, so keep both directions apart when both exist.
+		// keep directions apart, bidirectional sums net out to almost zero over longer periods
 		directionSumLabel(
 			group: string,
 			sumEnergy: number,
 			sumReturnEnergy: number,
-			unit: POWER_UNIT
+			unit: POWER_UNIT,
+			withLabels = true
 		): string {
 			const fmt = (v: number) => this.fmtWh(v * 1000, unit);
-			const directionKey = `main.history.direction.${group}`;
-			const energyKey = `${directionKey}.energy`;
-			const returnEnergyKey = `${directionKey}.returnEnergy`;
-			const energyLabel = this.$t(energyKey);
-			const returnEnergyLabel = this.$t(returnEnergyKey);
-			const hasDirectionLabels =
-				energyLabel !== energyKey && returnEnergyLabel !== returnEnergyKey;
-			if (sumEnergy > 0 && sumReturnEnergy > 0 && hasDirectionLabels) {
-				return `${fmt(sumEnergy)} ${energyLabel} · ${fmt(sumReturnEnergy)} ${returnEnergyLabel}`;
+			if (sumEnergy > 0 && sumReturnEnergy > 0 && BIDIRECTIONAL_GROUPS.includes(group)) {
+				const suffix = (key: string) =>
+					withLabels ? ` ${this.$t(`main.history.direction.${group}.${key}`)}` : "";
+				return `${fmt(sumEnergy)}${suffix("energy")} · ${fmt(sumReturnEnergy)}${suffix("returnEnergy")}`;
 			}
-			return fmt(Math.abs(sumEnergy - sumReturnEnergy) || sumEnergy + sumReturnEnergy);
+			return fmt(Math.abs(sumEnergy - sumReturnEnergy));
 		},
 		async fetchData() {
 			this.loading = true;

--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -410,16 +410,24 @@ export default defineComponent({
 				return darken(baseColor, stepAlpha(i, Math.max(n, 1)));
 			};
 			return list.map((s, i) => {
-				let sum = 0;
-				for (const slot of s.data) sum += slot.energy - slot.returnEnergy;
-				const watts = Math.abs(sum) * 1000;
+				let sumEnergy = 0;
+				let sumReturnEnergy = 0;
+				for (const slot of s.data) {
+					sumEnergy += slot.energy;
+					sumReturnEnergy += slot.returnEnergy;
+				}
 				return {
 					// Use stable paletteIndex as the focus identifier so that the
 					// selected entity keeps its identity across period navigations.
 					entityIndex: s.paletteIndex ?? i,
 					label: s.title,
 					color: colorFor(i, s),
-					value: this.fmtWh(watts, POWER_UNIT.AUTO),
+					value: this.directionSumLabel(
+						s.group,
+						sumEnergy,
+						sumReturnEnergy,
+						POWER_UNIT.AUTO
+					),
 					id: colorPicker && !s.virtual ? s.title : undefined,
 				};
 			});
@@ -452,7 +460,17 @@ export default defineComponent({
 					sumReturnEnergy += slot.returnEnergy;
 				}
 			}
-			const fmt = (v: number) => this.fmtWh(v * 1000, POWER_UNIT.KW);
+			return this.directionSumLabel(group, sumEnergy, sumReturnEnergy, POWER_UNIT.KW);
+		},
+		// Bidirectional groups (battery, exporting meters) would net out to almost
+		// zero over longer periods, so keep both directions apart when both exist.
+		directionSumLabel(
+			group: string,
+			sumEnergy: number,
+			sumReturnEnergy: number,
+			unit: POWER_UNIT
+		): string {
+			const fmt = (v: number) => this.fmtWh(v * 1000, unit);
 			const directionKey = `main.history.direction.${group}`;
 			const energyKey = `${directionKey}.energy`;
 			const returnEnergyKey = `${directionKey}.returnEnergy`;

--- a/tests/energy-history.spec.ts
+++ b/tests/energy-history.spec.ts
@@ -231,11 +231,9 @@ test.describe("battery legend", () => {
     await expect(battery.getByRole("heading")).toContainText(
       "10.5 kWh charged · 7.5 kWh discharged"
     );
+    await expect(battery.getByRole("button", { name: "Battery 6.0 kWh · 3.0 kWh" })).toBeVisible();
     await expect(
-      battery.getByRole("button", { name: "Battery 6.0 kWh charged · 3.0 kWh discharged" })
-    ).toBeVisible();
-    await expect(
-      battery.getByRole("button", { name: "Battery 2 4.5 kWh charged · 4.5 kWh discharged" })
+      battery.getByRole("button", { name: "Battery 2 4.5 kWh · 4.5 kWh" })
     ).toBeVisible();
   });
 });

--- a/tests/energy-history.spec.ts
+++ b/tests/energy-history.spec.ts
@@ -220,6 +220,26 @@ test.describe("consumption breakdown", () => {
   });
 });
 
+test.describe("battery legend", () => {
+  // 2026-07: Battery 6.0/3.0 kWh, Battery 2 balanced at 4.5/4.5 kWh. A net sum
+  // would collapse the balanced battery to zero, so both directions are shown.
+  test("month legend keeps charge and discharge apart", async ({ page }) => {
+    await gotoMonth(page, 2026, 7);
+    const battery = section(page, "battery");
+    await expect(battery).toBeVisible();
+
+    await expect(battery.getByRole("heading")).toContainText(
+      "10.5 kWh charged · 7.5 kWh discharged"
+    );
+    await expect(
+      battery.getByRole("button", { name: "Battery 6.0 kWh charged · 3.0 kWh discharged" })
+    ).toBeVisible();
+    await expect(
+      battery.getByRole("button", { name: "Battery 2 4.5 kWh charged · 4.5 kWh discharged" })
+    ).toBeVisible();
+  });
+});
+
 test.describe("additional meters", () => {
   // 2026-04-09: single ext meter "Submeter" = 1.2 kWh, no home data.
   test("standalone section without virtual Others", async ({ page }) => {

--- a/tests/energy-history.sql
+++ b/tests/energy-history.sql
@@ -160,6 +160,17 @@ INSERT INTO `meters` VALUES (3, 1781517600, 1.4, 1.0);
 INSERT INTO `meters` VALUES (3, 1781604000, 1.4, 1.0);
 INSERT INTO `meters` VALUES (3, 1781690400, 1.4, 1.0);
 
+-- =====================================================================
+-- Two batteries over a month: 2026-07-01..03. Battery charges more than it
+-- discharges, Battery 2 is exactly balanced so its net sum is zero.
+-- =====================================================================
+INSERT INTO `meters` VALUES (3, 1782900000, 2.0, 1.0);
+INSERT INTO `meters` VALUES (3, 1782986400, 2.0, 1.0);
+INSERT INTO `meters` VALUES (3, 1783072800, 2.0, 1.0);
+INSERT INTO `meters` VALUES (10, 1782900000, 1.5, 1.5);
+INSERT INTO `meters` VALUES (10, 1782986400, 1.5, 1.5);
+INSERT INTO `meters` VALUES (10, 1783072800, 1.5, 1.5);
+
 -- 2026-04-09 → additional meter (ext) standalone chart. Single entity 1.2 kWh,
 -- not home-combined, so no virtual "Others" series.
 INSERT INTO `meters` VALUES (11, 1775728800, 0.3, 0);


### PR DESCRIPTION
fixes #33297

The per-entity legend under a history chart summed `energy - returnEnergy`, i.e. the net. For bidirectional groups (battery, exporting additional meters) charge and discharge almost cancel over a month or a year, so a battery that moved hundreds of kWh showed up as `50 Wh`. Day view only looked correct because a single day's net is large enough to pass as a total.

The card subtitle already handles this via `groupTotalLabel()`, which keeps both directions apart. That formatting is now extracted into `directionSumLabel()` and reused for the entity legends, so a battery reads `380.5 kWh · 357.7 kWh` instead of a netted value. Unidirectional groups (pv, loadpoints, consumers) are unaffected, their net equals their total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
