### PR TITLE
EEBus: clamp the curtailment percent to the documented maximum

### DIFF
--- a/hems/eebus/eebus.go
+++ b/hems/eebus/eebus.go
@@ -393,7 +393,8 @@ func (c *EEBus) CurtailedPercent() *int {
 
 	percent := 100
 	if limitActive(c.productionLimitActivated) {
-		percent = int(c.effectiveProductionLimit() / c.productionNominalMax * 100)
+		// the EG may state a limit above the nominal production power
+		percent = min(int(c.effectiveProductionLimit()/c.productionNominalMax*100), 100)
 	}
 
 	return &percent

--- a/hems/eebus/eebus_test.go
+++ b/hems/eebus/eebus_test.go
@@ -325,6 +325,21 @@ func TestProductionLimit_FailsafeUnconfigured(t *testing.T) {
 	assert.Equal(t, 0.0, *power)
 }
 
+// TestCurtailedPercent_AboveNominal verifies a limit above the nominal production
+// power reports 100%, not more - api.HEMS documents the percent as 0..100 and it
+// reaches the inverter unchecked.
+func TestCurtailedPercent_AboveNominal(t *testing.T) {
+	c := newTestEEBus(t)
+	c.heartbeat.Set(struct{}{})
+	c.productionLimit = ucapi.LoadLimit{Value: -2 * testProductionNominal, IsActive: true}
+
+	require.NoError(t, c.run())
+
+	percent := c.CurtailedPercent()
+	require.NotNil(t, percent)
+	assert.Equal(t, 100, *percent)
+}
+
 // TestMaxProductionPower verifies the api.HEMS export cap is a positive wattage,
 // while LPP states its limits as negative watts.
 func TestMaxProductionPower(t *testing.T) {


### PR DESCRIPTION
`api.HEMS` documents `CurtailedPercent()` as 0..100, but nothing validates an Energy Guard LPP limit against `productionNominalMax`. With `productionNominalMax: 8000` and an EG limit of 10 kW the getter returns 125, which `core/site_circuits.go` `curtailPV()` passes straight into `api.Curtailer.SetCurtailPercent()` — what a device does with an out-of-range percent is per-device.

Clamped to 100. The lower bound needs no clamp: every LPP limit write reaches evcc through `LimitWriteApprovalRequired`, and `productionWriteApprovalRequired()` denies positive values, so `productionLimit.Value` cannot be positive.

Split out of #33288 and rebased onto it now that it has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
