### PR TITLE
Sungrow: remove coarse energy reading from inverter template

### DIFF
--- a/templates/definition/meter/sungrow-inverter.yaml
+++ b/templates/definition/meter/sungrow-inverter.yaml
@@ -37,13 +37,6 @@ render: |
       address: 5030 # Total Active Power
       type: input
       decode: uint32s
-  energy:
-    source: modbus
-    {{- include "modbus" . | indent 2 }}
-    register:
-      address: 5003 # Total power yields, 1 kWh
-      type: input
-      decode: uint32s
   # EEG §9 curtailment via the power limitation registers
   #   5006 (doc 5007) power limitation switch, 0xAA enable / 0x55 disable
   #   5007 (doc 5008) power limitation value, 0.1 % of nominal power


### PR DESCRIPTION
relates to #32711

The SG series inverter reports total PV yield (register 5003) in whole 1 kWh steps, so 15-minute energy history advances in coarse chunks. Instead of documenting that as a caveat (#32743), drop the energy reading altogether — no value is better than a misleadingly stepped one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)