### PR TITLE
fox-ess-h3-smart: remove limitsoc so batterymode is applied

### DIFF
--- a/templates/definition/meter/fox-ess-h3-smart.yaml
+++ b/templates/definition/meter/fox-ess-h3-smart.yaml
@@ -125,16 +125,6 @@ render: |
       address: 37612 # Soc
       type: holding
       decode: int16
-  limitsoc:
-    source: convert
-    convert: float2int
-    set:
-      source: modbus
-      {{- include "modbus" . | indent 4 }}
-      register:
-        address: 46611 # Minimum SoC OnGrid
-        type: writesingle
-        decode: uint16
   batterymode:
     source: watchdog
     timeout: 30s


### PR DESCRIPTION
Fixes https://github.com/evcc-io/evcc/issues/27614

## Problem

The current `fox-ess-h3-smart` template defines BOTH `limitsoc` (reg. 46611) and `batterymode`. In evcc's `meter.go` this is an **exclusive switch**: when `limitsoc` is present, `batterymode` is silently ignored and only the `LimitController` runs (MinSoC/MaxSoC manipulation). On FoxESS H3-Smart (FW V1.24) this results in ~400W maintenance charge instead of full-power grid charging.

## Fix

Remove the `limitsoc` block so the template follows the working `fox-ess-avocado` pattern: only `batterymode` (`source: watchdog`, Remote-Control registers 46001/46002/46003). Verified live on H3-12.0-Smart (FW V1.24, Modbus TCP): `charge` now pulls ~9.5kW from grid.

## Verification

- `charge` → battery loads ~9.5kW from grid (`batPow=-9486`, `gridPow=+9029`)
- `hold` → PV routes into battery, house fed from grid (`batPow=-3941`, `gridPow=+1390`)
- `normal` → normal self-consumption
- Go template render tests pass; whole `util/templates` suite green.

No breaking config change: the template already required `maxchargepower`, which is a `battery-params` preset field.