### PR TITLE
History: remove energy netting, unify bidirectional detection

### DIFF
--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -21,7 +21,7 @@ import formatter, { POWER_UNIT } from "@/mixins/formatter";
 import echartsChart from "@/mixins/echartsChart";
 import { PERIODS } from "../Sessions/types";
 import { is12hFormat } from "@/units";
-import { hasColorPicker } from "./groups";
+import { hasColorPicker, isBidirectional } from "./groups";
 
 export interface HistorySlot {
 	start: string;
@@ -52,9 +52,6 @@ export function stepAlpha(i: number, n: number): number {
 	const minAlpha = 0.5;
 	return Math.max(minAlpha, 1 - (n - 1 - i) * step);
 }
-
-// Symmetric axis regardless of whether the period contains both directions.
-const BIDIRECTIONAL_GROUPS: ReadonlySet<string> = new Set(["grid", "battery"]);
 
 // Multiple entities stack into one bar; grid and meter render side-by-side.
 const STACKED_GROUPS: ReadonlySet<string> = new Set(["loadpoint", "consumer", "pv", "battery"]);
@@ -144,7 +141,7 @@ export default defineComponent({
 			}
 			const overlay = this.showOverlay ? this.overlay : [];
 			return Math.max(
-				peak(this.visibleSeries, (slot) => Math.abs(slot.energy - slot.returnEnergy)),
+				peak(this.visibleSeries, (slot) => slot.energy),
 				peak(overlay, (slot) => slot.energy)
 			);
 		},
@@ -179,12 +176,7 @@ export default defineComponent({
 			return this.series.filter((s, i) => (s.paletteIndex ?? i) === idx);
 		},
 		isBidirectional(): boolean {
-			if (BIDIRECTIONAL_GROUPS.has(this.group)) return true;
-			// additional grid/battery meters can export
-			if (this.group === "meter") {
-				return this.series.some((s) => s.data.some((slot) => slot.returnEnergy > 0));
-			}
-			return false;
+			return isBidirectional(this.group, this.series);
 		},
 		categoryTimestamps(): number[] {
 			const out: number[] = [];
@@ -271,8 +263,7 @@ export default defineComponent({
 					for (const slot of s.data) {
 						const idx = index.get(slotKey(slot.start));
 						if (idx === undefined) continue;
-						const v = (slot.energy - slot.returnEnergy) * factor;
-						overlayValues[idx] = (overlayValues[idx] || 0) + v;
+						overlayValues[idx] = (overlayValues[idx] || 0) + slot.energy * factor;
 					}
 				}
 			}
@@ -313,7 +304,8 @@ export default defineComponent({
 						const idx = index.get(slotKey(slot.start));
 						if (idx === undefined) continue;
 						if (slot.energy > 0) energyValues[idx] = slot.energy * factor;
-						if (slot.returnEnergy > 0)
+						// non-bidirectional groups ignore return energy
+						if (this.isBidirectional && slot.returnEnergy > 0)
 							returnEnergyValues[idx] = -slot.returnEnergy * factor;
 					}
 				}
@@ -569,9 +561,7 @@ export default defineComponent({
 							Math.max(
 								0,
 								...rowValues.flatMap((t) =>
-									this.isBidirectional
-										? [t.energy, t.returnEnergy]
-										: [t.energy + t.returnEnergy]
+									this.isBidirectional ? [t.energy, t.returnEnergy] : [t.energy]
 								)
 							) * 1000
 						);
@@ -586,7 +576,7 @@ export default defineComponent({
 							const t = rowValues[idx] ?? { energy: 0, returnEnergy: 0 };
 							const values = this.isBidirectional
 								? [formatValue(t.energy), formatValue(t.returnEnergy)]
-								: [formatValue(t.energy + t.returnEnergy)];
+								: [formatValue(t.energy)];
 							return {
 								name: showName ? (nameByIdx.get(i) ?? "") : undefined,
 								values,
@@ -599,7 +589,7 @@ export default defineComponent({
 								name: this.$t("sessions.total"),
 								values: this.isBidirectional
 									? [formatValue(sum("energy")), formatValue(sum("returnEnergy"))]
-									: [formatValue(sum("energy") + sum("returnEnergy"))],
+									: [formatValue(sum("energy"))],
 								total: true,
 							});
 						}

--- a/assets/js/components/History/GroupChart.vue
+++ b/assets/js/components/History/GroupChart.vue
@@ -213,7 +213,8 @@ export default defineComponent({
 			const has = Array.from({ length: this.categoryKeys.length }, () => false);
 			for (const s of this.visibleSeries) {
 				for (const slot of s.data) {
-					if (slot.energy <= 0 && slot.returnEnergy <= 0) continue;
+					if (slot.energy <= 0 && (!this.isBidirectional || slot.returnEnergy <= 0))
+						continue;
 					const idx = index.get(this.timestampKey(new Date(slot.start).getTime()));
 					if (idx !== undefined) has[idx] = true;
 				}

--- a/assets/js/components/History/groups.ts
+++ b/assets/js/components/History/groups.ts
@@ -1,7 +1,15 @@
 export const GROUP_ORDER = ["pv", "battery", "grid", "loadpoint", "consumer", "meter"] as const;
 
-// sums shown per direction instead of netted
-export const BIDIRECTIONAL_GROUPS: string[] = ["battery", "grid", "meter"];
+const BIDIRECTIONAL_GROUPS: ReadonlySet<string> = new Set(["grid", "battery"]);
+
+// battery and grid are always bidirectional, additional meters when they export
+export function isBidirectional(
+  group: string,
+  series: { data: { returnEnergy: number }[] }[]
+): boolean {
+  if (BIDIRECTIONAL_GROUPS.has(group)) return true;
+  return group === "meter" && series.some((s) => s.data.some((slot) => slot.returnEnergy > 0));
+}
 
 const COLOR_PICKER_GROUPS = ["loadpoint", "consumer", "meter"];
 

--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -107,10 +107,10 @@ import type { Legend } from "../components/Sessions/types";
 import type { DeviceColors } from "@/types/evcc";
 import { PERIODS } from "../components/Sessions/types";
 import {
-	BIDIRECTIONAL_GROUPS,
 	GROUP_ORDER,
 	groupColor,
 	hasColorPicker,
+	isBidirectional,
 } from "../components/History/groups";
 import colors, { resolveColors, deviceColorMap, darken, batteryColor } from "../colors";
 import LegendList from "../components/Sessions/LegendList.vue";
@@ -256,7 +256,7 @@ export default defineComponent({
 				return !!list?.some((s) => s.data.length > 0);
 			});
 		},
-		// Consumer group: append virtual "Other consumers" = home.net − sum(consumers).
+		// Consumer group: append virtual "Other consumers" = home − sum(consumers).
 		// paletteIndex pins color across period navigation.
 		displaySeries(): (group: string) => HistorySeries[] {
 			const hasEnergy = (s: HistorySeries) =>
@@ -276,13 +276,12 @@ export default defineComponent({
 					.filter(hasEnergy);
 				if (!home) return active;
 				const totals = new Map<string, number>();
-				// Net per slot is computed from all consumers (incl. inactive ones), so
-				// dropping inactive entries from the display doesn't shift the
+				// Per-slot sum uses all consumers (incl. inactive ones), so dropping
+				// inactive entries from the display doesn't shift the
 				// "Other consumers" delta.
 				for (const s of consumers) {
 					for (const slot of s.data) {
-						const net = slot.energy - slot.returnEnergy;
-						totals.set(slot.start, (totals.get(slot.start) || 0) + net);
+						totals.set(slot.start, (totals.get(slot.start) || 0) + slot.energy);
 					}
 				}
 				const other: HistorySeries = {
@@ -291,8 +290,7 @@ export default defineComponent({
 					virtual: true,
 					paletteIndex: consumers.length,
 					data: home.data.map((slot) => {
-						const homeNet = slot.energy - slot.returnEnergy;
-						const v = Math.max(0, homeNet - (totals.get(slot.start) || 0));
+						const v = Math.max(0, slot.energy - (totals.get(slot.start) || 0));
 						return { start: slot.start, end: slot.end, energy: v, returnEnergy: 0 };
 					}),
 				};
@@ -303,17 +301,15 @@ export default defineComponent({
 		hasForecast(): boolean {
 			const list = this.seriesByGroup["forecast"];
 			if (!list?.length) return false;
-			return list.some((s) =>
-				s.data.some((slot) => slot.energy !== 0 || slot.returnEnergy !== 0)
-			);
+			return list.some((s) => s.data.some((slot) => slot.energy !== 0));
 		},
 		forecastTotalLabel(): string {
 			const list = this.seriesByGroup["forecast"] || [];
 			let sum = 0;
 			for (const s of list) {
-				for (const slot of s.data) sum += slot.energy - slot.returnEnergy;
+				for (const slot of s.data) sum += slot.energy;
 			}
-			return this.fmtWh(Math.abs(sum) * 1000, POWER_UNIT.AUTO);
+			return this.fmtWh(sum * 1000, POWER_UNIT.AUTO);
 		},
 	},
 	watch: {
@@ -414,9 +410,9 @@ export default defineComponent({
 				if (group === "battery") return batteryColor(s.paletteIndex ?? i);
 				return darken(baseColor, stepAlpha(i, Math.max(n, 1)));
 			};
-			// Any return energy makes the whole group show both directions so that
+			// Bidirectional groups show both directions for every entity so that
 			// a single-direction entity isn't mistaken for the other direction.
-			const split = list.some((s) => s.data.some((slot) => slot.returnEnergy > 0));
+			const split = isBidirectional(group, list);
 
 			return list.map((s, i) => {
 				let sumEnergy = 0;
@@ -471,7 +467,14 @@ export default defineComponent({
 					sumReturnEnergy += slot.returnEnergy;
 				}
 			}
-			return this.directionSumLabel(group, sumEnergy, sumReturnEnergy, POWER_UNIT.KW);
+			return this.directionSumLabel(
+				group,
+				sumEnergy,
+				sumReturnEnergy,
+				POWER_UNIT.KW,
+				true,
+				isBidirectional(group, list)
+			);
 		},
 		// keep directions apart, bidirectional sums net out to almost zero over longer periods
 		directionSumLabel(
@@ -480,16 +483,15 @@ export default defineComponent({
 			sumReturnEnergy: number,
 			unit: POWER_UNIT,
 			withLabels = true,
-			force = false
+			split = false
 		): string {
 			const fmt = (v: number) => this.fmtWh(v * 1000, unit);
-			const both = force || (sumEnergy > 0 && sumReturnEnergy > 0);
-			if (both && BIDIRECTIONAL_GROUPS.includes(group)) {
+			if (split) {
 				const suffix = (key: string) =>
 					withLabels ? ` ${this.$t(`main.history.direction.${group}.${key}`)}` : "";
 				return `${fmt(sumEnergy)}${suffix("energy")} · ${fmt(sumReturnEnergy)}${suffix("returnEnergy")}`;
 			}
-			return fmt(Math.abs(sumEnergy - sumReturnEnergy));
+			return fmt(sumEnergy);
 		},
 		async fetchData() {
 			this.loading = true;

--- a/assets/js/views/History.vue
+++ b/assets/js/views/History.vue
@@ -259,8 +259,12 @@ export default defineComponent({
 		// Consumer group: append virtual "Other consumers" = home − sum(consumers).
 		// paletteIndex pins color across period navigation.
 		displaySeries(): (group: string) => HistorySeries[] {
-			const hasEnergy = (s: HistorySeries) =>
-				s.data.some((slot) => slot.energy !== 0 || slot.returnEnergy !== 0);
+			const hasEnergy = (s: HistorySeries) => {
+				const bidi = isBidirectional(s.group, [s]);
+				return s.data.some(
+					(slot) => slot.energy !== 0 || (bidi && slot.returnEnergy !== 0)
+				);
+			};
 			return (group: string): HistorySeries[] => {
 				// Loadpoint and additional meters stack distinct entities without a
 				// home-derived "Others" series.

--- a/tests/energy-history.spec.ts
+++ b/tests/energy-history.spec.ts
@@ -201,16 +201,16 @@ test.describe("consumption breakdown", () => {
     await expect(consumption.getByRole("button")).toHaveCount(0);
   });
 
-  // 2026-04-12: consumers are not a bidirectional group. Return energy nets
-  // into the values instead of splitting them: home 1.0−0.2, Kitchen 0.4−0.1.
-  test("return energy nets instead of splitting", async ({ page }) => {
+  // 2026-04-12: consumers are not a bidirectional group. Return energy is
+  // ignored, not netted or split: home 1.0, Kitchen 0.4.
+  test("return energy is ignored", async ({ page }) => {
     await gotoDay(page, 2026, 4, 12);
     const consumption = section(page, "consumer");
     await expect(consumption).toBeVisible();
 
-    await expect(consumption.getByRole("heading")).toContainText("0.8 kWh");
-    await expect(consumption.getByRole("button", { name: "Kitchen 300 Wh" })).toBeVisible();
-    await expect(consumption.getByRole("button", { name: "Others 500 Wh" })).toBeVisible();
+    await expect(consumption.getByRole("heading")).toContainText("1.0 kWh");
+    await expect(consumption.getByRole("button", { name: "Kitchen 400 Wh" })).toBeVisible();
+    await expect(consumption.getByRole("button", { name: "Others 600 Wh" })).toBeVisible();
   });
 
   test("entity focus rescales axis and resets on unfocus", async ({ page }) => {

--- a/tests/energy-history.sql
+++ b/tests/energy-history.sql
@@ -204,7 +204,7 @@ INSERT INTO `meters` VALUES (13, 1775817000, 0, 0.3);
 INSERT INTO `meters` VALUES (13, 1775817900, 0, 0.3);
 
 -- 2026-04-12 → consumer with export data. Consumers are not a bidirectional
--- group, so heading and legend net: home 1.0−0.2, Kitchen 0.4−0.1.
+-- group, so return energy is ignored: home 1.0, Kitchen 0.4.
 INSERT INTO `meters` VALUES (1, 1775988000, 0.25, 0.05);
 INSERT INTO `meters` VALUES (1, 1775988900, 0.25, 0.05);
 INSERT INTO `meters` VALUES (1, 1775989800, 0.25, 0.05);


### PR DESCRIPTION
fixes #33333, follow-up to #33335

As raised in [#33299 (comment)](https://github.com/evcc-io/evcc/pull/33299#issuecomment-5478632385), `energy - returnEnergy` is never very meaningful: the netted sum loses its direction, so an export-only feed-in meter reads like consumption. This PR removes netting entirely instead of patching individual labels.

- One shared `isBidirectional()` rule: grid and battery always, additional meters when the period contains return energy. Chart axis, tooltips, headings and entity legends all follow it.
- Bidirectional sections show both directions for every entity, so single-direction siblings sit in the same two columns.
- Non-bidirectional groups (consumers, pv, loadpoints) ignore return energy.
- Test data: export-only meter next to a bidirectional one, export-only meter alone, consumer with return energy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
