### PR TITLE
Keep access and refresh tokens out of the logs

### DIFF
--- a/charger/easee/identity.go
+++ b/charger/easee/identity.go
@@ -56,7 +56,7 @@ func TokenSource(log *util.Logger, user, password string) (oauth2.TokenSource, e
 			return nil, err
 		}
 
-		return oauth.RefreshTokenSource(token.AsOAuth2Token(), c.refreshToken), nil
+		return oauth.RefreshTokenSource(log, token.AsOAuth2Token(), c.refreshToken), nil
 	})
 }
 

--- a/charger/ghostone/identity.go
+++ b/charger/ghostone/identity.go
@@ -40,7 +40,7 @@ func TokenSource(ctx context.Context, log *util.Logger, uri, user, password stri
 		return nil, err
 	}
 
-	c.TokenSource = oauth.RefreshTokenSource(token, c.refresh)
+	c.TokenSource = oauth.RefreshTokenSource(log, token, c.refresh)
 
 	return c, nil
 }

--- a/charger/nexblue.go
+++ b/charger/nexblue.go
@@ -127,7 +127,7 @@ func NewNexblue(ctx context.Context, user, password, serial string, cache time.D
 
 	// Inject authHelper's client as base transport; oauth2.NewClient wraps it with oauth2.Transport.
 	authCtx := context.WithValue(ctx, oauth2.HTTPClient, authHelper.Client)
-	wb.Client = oauth2.NewClient(authCtx, oauth.RefreshTokenSource(tok, login))
+	wb.Client = oauth2.NewClient(authCtx, oauth.RefreshTokenSource(log, tok, login))
 
 	wb.serial, err = ensureCharger(serial, func() ([]string, error) {
 		return wb.chargerSerials()

--- a/charger/smaevcharger/identity.go
+++ b/charger/smaevcharger/identity.go
@@ -62,7 +62,7 @@ func TokenSource(log *util.Logger, uri, user, password string) (oauth2.TokenSour
 	if err == nil {
 		var token Token
 		if err = c.DoJSON(req, &token); err == nil {
-			c.TokenSource = oauth.RefreshTokenSource(token.AsOAuth2Token(), c.refreshToken)
+			c.TokenSource = oauth.RefreshTokenSource(log, token.AsOAuth2Token(), c.refreshToken)
 		}
 	}
 

--- a/charger/tessie.go
+++ b/charger/tessie.go
@@ -36,7 +36,7 @@ func NewTessieFromConfig(ctx context.Context, other map[string]any) (api.Charger
 		return nil, err
 	}
 
-	log := util.NewLogger("tessie")
+	log := util.NewLogger("tessie").Redact(cc.Token)
 
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: cc.Token})
 	oauthClient := oauth2.NewClient(ctx, tokenSource)

--- a/charger/zaptec.go
+++ b/charger/zaptec.go
@@ -128,7 +128,7 @@ func NewZaptec(ctx context.Context, user, password, id string, priority bool, pa
 	tsCtx := context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
 
 	// Get shared token source for this user (per-user uniqueness)
-	ts, err := zaptec.TokenSource(tsCtx, user, password)
+	ts, err := zaptec.TokenSource(tsCtx, log, user, password)
 	if err != nil {
 		return nil, err
 	}

--- a/charger/zaptec/auth.go
+++ b/charger/zaptec/auth.go
@@ -6,7 +6,9 @@ import (
 	"sync"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/cache"
+	"github.com/evcc-io/evcc/util/oauth"
 	"golang.org/x/oauth2"
 )
 
@@ -42,7 +44,7 @@ func getOIDCProvider(ctx context.Context) (*oidc.Provider, error) {
 }
 
 // TokenSource returns a shared oauth2.TokenSource for the given user.
-func TokenSource(ctx context.Context, user, pass string) (oauth2.TokenSource, error) {
+func TokenSource(ctx context.Context, log *util.Logger, user, pass string) (oauth2.TokenSource, error) {
 	return tokenSourceCache.GetOrCreate(user, func() (oauth2.TokenSource, error) {
 		provider, err := getOIDCProvider(ctx)
 		if err != nil {
@@ -70,6 +72,6 @@ func TokenSource(ctx context.Context, user, pass string) (oauth2.TokenSource, er
 			return nil, err
 		}
 
-		return oauth2.ReuseTokenSource(token, pts), nil
+		return oauth2.ReuseTokenSource(token, oauth.Redacted(log, pts)), nil
 	})
 }

--- a/plugin/auth/oauth.go
+++ b/plugin/auth/oauth.go
@@ -49,6 +49,7 @@ type OAuth struct {
 	cv      string
 	ctx     context.Context
 	onlineC chan<- bool
+	redact  func(...string)
 
 	deviceFlow     bool
 	tokenRetriever func(string, *oauth2.Token) error
@@ -104,6 +105,7 @@ func NewOAuth(ctx context.Context, name, device string, oc *oauth2.Config, opts 
 		ctx:     ctx,
 		subject: subject,
 		name:    name,
+		redact:  log.RotatingSlot(),
 	}
 
 	for _, opt := range opts {
@@ -137,6 +139,7 @@ func NewOAuth(ctx context.Context, name, device string, oc *oauth2.Config, opts 
 
 	if token.RefreshToken != "" {
 		o.token = &token
+		o.redact(token.AccessToken, token.RefreshToken)
 	}
 
 	// register auth redirect
@@ -198,6 +201,9 @@ func (o *OAuth) updateToken(token *oauth2.Token) {
 	}
 
 	o.token = token
+
+	// keep the token out of the logs, e.g. the Authorization header when logging headers
+	o.redact(token.AccessToken, token.RefreshToken)
 
 	o.setOnline(token.Valid())
 }

--- a/tariff/corrently/tokensource.go
+++ b/tariff/corrently/tokensource.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -14,7 +15,7 @@ type tokenSource struct {
 }
 
 func TokenSource(log *util.Logger, token *oauth2.Token) oauth2.TokenSource {
-	return oauth2.ReuseTokenSource(token, &tokenSource{log})
+	return oauth2.ReuseTokenSource(token, oauth.Redacted(log, &tokenSource{log}))
 }
 
 func (ts *tokenSource) Token() (*oauth2.Token, error) {

--- a/tariff/edf-tempo.go
+++ b/tariff/edf-tempo.go
@@ -79,7 +79,7 @@ func NewEdfTempoFromConfig(other map[string]any) (api.Tariff, error) {
 
 	t.Client.Transport = &oauth2.Transport{
 		Base:   t.Client.Transport,
-		Source: oauth2.ReuseTokenSource(nil, oauth.BootstrapTokenSource(t.refreshToken)),
+		Source: oauth2.ReuseTokenSource(nil, oauth.BootstrapTokenSource(log, t.refreshToken)),
 	}
 
 	return runOrError(t)

--- a/tariff/octopuskraken/graphql/api.go
+++ b/tariff/octopuskraken/graphql/api.go
@@ -32,6 +32,7 @@ type Client struct {
 // (other regional Octopus companies run the same platform under their own baseURI).
 func NewClient(log *util.Logger, baseURI, email, password, accountNumber string) (*Client, error) {
 	ts := oauth2.ReuseTokenSource(nil, oauth.Redacted(log, &tokenSource{
+		log:      log,
 		baseURI:  baseURI,
 		email:    email,
 		password: password,

--- a/tariff/octopuskraken/graphql/api.go
+++ b/tariff/octopuskraken/graphql/api.go
@@ -31,10 +31,10 @@ type Client struct {
 // (other regional Octopus companies run the same platform under their own baseURI).
 func NewClient(log *util.Logger, baseURI, email, password, accountNumber string) (*Client, error) {
 	ts := oauth2.ReuseTokenSource(nil, &tokenSource{
-		log:      log,
 		baseURI:  baseURI,
 		email:    email,
 		password: password,
+		redact:   log.RotatingSlot(),
 	})
 
 	cli := request.NewClient(log)

--- a/tariff/octopuskraken/graphql/api.go
+++ b/tariff/octopuskraken/graphql/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/evcc-io/evcc/util/transport"
 	"github.com/hasura/go-graphql-client"
@@ -30,12 +31,11 @@ type Client struct {
 // NewClient returns a new, authenticated instance for the given Kraken instance
 // (other regional Octopus companies run the same platform under their own baseURI).
 func NewClient(log *util.Logger, baseURI, email, password, accountNumber string) (*Client, error) {
-	ts := oauth2.ReuseTokenSource(nil, &tokenSource{
+	ts := oauth2.ReuseTokenSource(nil, oauth.Redacted(log, &tokenSource{
 		baseURI:  baseURI,
 		email:    email,
 		password: password,
-		redact:   log.RotatingSlot(),
-	})
+	}))
 
 	cli := request.NewClient(log)
 	cli.Transport = &transport.Decorator{

--- a/tariff/octopuskraken/graphql/tokensource.go
+++ b/tariff/octopuskraken/graphql/tokensource.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
-	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
+	"github.com/evcc-io/evcc/util/transport"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/hasura/go-graphql-client"
 	"golang.org/x/oauth2"
@@ -18,9 +19,9 @@ import (
 var ErrAuthFailed = errors.New("authentication failed")
 
 type tokenSource struct {
-	log             *util.Logger
 	baseURI         string
 	email, password string
+	redact          func(string)
 }
 
 var _ oauth2.TokenSource = (*tokenSource)(nil)
@@ -31,8 +32,13 @@ func (ts *tokenSource) Token() (*oauth2.Token, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	// Create a temporary client without authentication for the token request
-	cli := request.NewClient(ts.log)
+	// Create a temporary client without authentication for the token request.
+	// The response carries the JWT, so this request is not trace-logged - redaction
+	// cannot help here as the token is only known once the response has been logged.
+	cli := &http.Client{
+		Timeout:   request.Timeout,
+		Transport: transport.Default(),
+	}
 	tempClient := graphql.NewClient(ts.baseURI, cli)
 
 	var q krakenTokenAuthentication
@@ -50,6 +56,9 @@ func (ts *tokenSource) Token() (*oauth2.Token, error) {
 		}
 		return nil, fmt.Errorf("authentication failed: %w", err)
 	}
+
+	// keep the token out of the logs, e.g. the Authorization header when logging headers
+	ts.redact(q.ObtainKrakenToken.Token)
 
 	// Parse JWT to extract expiry time using RegisteredClaims
 	// We use ParseUnverified since we don't have the signing key and trust the token from the API

--- a/tariff/octopuskraken/graphql/tokensource.go
+++ b/tariff/octopuskraken/graphql/tokensource.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
+	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/request"
-	"github.com/evcc-io/evcc/util/transport"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/hasura/go-graphql-client"
 	"golang.org/x/oauth2"
@@ -19,6 +18,7 @@ import (
 var ErrAuthFailed = errors.New("authentication failed")
 
 type tokenSource struct {
+	log             *util.Logger
 	baseURI         string
 	email, password string
 }
@@ -31,13 +31,8 @@ func (ts *tokenSource) Token() (*oauth2.Token, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	// Create a temporary client without authentication for the token request.
-	// The response carries the JWT, so this request is not trace-logged - redaction
-	// cannot help here as the token is only known once the response has been logged.
-	cli := &http.Client{
-		Timeout:   request.Timeout,
-		Transport: transport.Default(),
-	}
+	// Create a temporary client without authentication for the token request
+	cli := request.NewClient(ts.log)
 	tempClient := graphql.NewClient(ts.baseURI, cli)
 
 	var q krakenTokenAuthentication

--- a/tariff/octopuskraken/graphql/tokensource.go
+++ b/tariff/octopuskraken/graphql/tokensource.go
@@ -21,7 +21,6 @@ var ErrAuthFailed = errors.New("authentication failed")
 type tokenSource struct {
 	baseURI         string
 	email, password string
-	redact          func(string)
 }
 
 var _ oauth2.TokenSource = (*tokenSource)(nil)
@@ -56,9 +55,6 @@ func (ts *tokenSource) Token() (*oauth2.Token, error) {
 		}
 		return nil, fmt.Errorf("authentication failed: %w", err)
 	}
-
-	// keep the token out of the logs, e.g. the Authorization header when logging headers
-	ts.redact(q.ObtainKrakenToken.Token)
 
 	// Parse JWT to extract expiry time using RegisteredClaims
 	// We use ParseUnverified since we don't have the signing key and trust the token from the API

--- a/tariff/ostrom.go
+++ b/tariff/ostrom.go
@@ -89,7 +89,7 @@ func NewOstromFromConfig(other map[string]any) (api.Tariff, error) {
 
 	t.Client.Transport = &oauth2.Transport{
 		Base:   t.Client.Transport,
-		Source: oauth2.ReuseTokenSource(nil, oauth.BootstrapTokenSource(t.refreshToken)),
+		Source: oauth2.ReuseTokenSource(nil, oauth.BootstrapTokenSource(log, t.refreshToken)),
 	}
 
 	contracts, err := t.getContracts()

--- a/util/homeassistant/supervisor.go
+++ b/util/homeassistant/supervisor.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/evcc-io/evcc/util"
 	"golang.org/x/oauth2"
 )
 
@@ -28,6 +29,7 @@ func hasSupervisorToken() bool {
 
 func supervisorTokenSource(uri string) (oauth2.TokenSource, bool) {
 	if token := os.Getenv(SupervisorToken); token != "" && strings.TrimRight(uri, "/") == SupervisorURI {
+		util.NewLogger("homeassistant").Redact(token)
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}), true
 	}
 	return nil, false

--- a/util/log_redactor.go
+++ b/util/log_redactor.go
@@ -23,8 +23,9 @@ func RedactDefaultHook(s string) []string {
 
 // Redactor implements log redaction
 type Redactor struct {
-	mu     sync.Mutex
-	redact []string
+	mu       sync.Mutex
+	redact   []string
+	rotating [][]string
 }
 
 // Redact adds items for redaction
@@ -39,10 +40,35 @@ func (l *Redactor) Redact(redact ...string) {
 	}
 }
 
+// RotatingSlot reserves a redaction slot for a periodically refreshed secret
+// like an access token. Updating the slot replaces the previous value instead
+// of appending, so the redaction list does not grow with every refresh.
+func (l *Redactor) RotatingSlot() func(string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	idx := len(l.rotating)
+	l.rotating = append(l.rotating, nil)
+
+	return func(s string) {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+
+		if RedactHook != nil && len(s) > 0 {
+			l.rotating[idx] = RedactHook(s)
+		}
+	}
+}
+
 func (l *Redactor) redacted(p []byte) []byte {
 	l.mu.Lock()
 	for _, s := range l.redact {
 		p = bytes.ReplaceAll(p, []byte(s), []byte(RedactReplacement))
+	}
+	for _, slot := range l.rotating {
+		for _, s := range slot {
+			p = bytes.ReplaceAll(p, []byte(s), []byte(RedactReplacement))
+		}
 	}
 	l.mu.Unlock()
 	return p

--- a/util/log_redactor.go
+++ b/util/log_redactor.go
@@ -21,11 +21,18 @@ func RedactDefaultHook(s string) []string {
 	return []string{s, url.QueryEscape(s)}
 }
 
+// maxRotatingSlots limits the number of rotating redaction slots per logger.
+// Loggers are shared per log area, so repeatedly re-created token sources would
+// otherwise keep reserving slots. Beyond the limit slots are reused in order,
+// evicting the oldest.
+const maxRotatingSlots = 32
+
 // Redactor implements log redaction
 type Redactor struct {
 	mu       sync.Mutex
 	redact   []string
 	rotating [][]string
+	nextSlot int
 }
 
 // Redact adds items for redaction
@@ -40,22 +47,37 @@ func (l *Redactor) Redact(redact ...string) {
 	}
 }
 
-// RotatingSlot reserves a redaction slot for a periodically refreshed secret
-// like an access token. Updating the slot replaces the previous value instead
-// of appending, so the redaction list does not grow with every refresh.
-func (l *Redactor) RotatingSlot() func(string) {
+// RotatingSlot reserves a redaction slot for periodically refreshed secrets
+// like access and refresh tokens. Updating the slot replaces the previous
+// values instead of appending, so the redaction list does not grow with every
+// refresh.
+func (l *Redactor) RotatingSlot() func(...string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	idx := len(l.rotating)
-	l.rotating = append(l.rotating, nil)
+	if idx < maxRotatingSlots {
+		l.rotating = append(l.rotating, nil)
+	} else {
+		idx = l.nextSlot
+		l.nextSlot = (l.nextSlot + 1) % maxRotatingSlots
+		l.rotating[idx] = nil
+	}
 
-	return func(s string) {
+	return func(s ...string) {
 		l.mu.Lock()
 		defer l.mu.Unlock()
 
-		if RedactHook != nil && len(s) > 0 {
-			l.rotating[idx] = RedactHook(s)
+		l.rotating[idx] = nil
+
+		if RedactHook == nil {
+			return
+		}
+
+		for _, v := range s {
+			if len(v) > 0 {
+				l.rotating[idx] = append(l.rotating[idx], RedactHook(v)...)
+			}
 		}
 	}
 }

--- a/util/log_redactor_test.go
+++ b/util/log_redactor_test.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRotatingSlot(t *testing.T) {
+	var r Redactor
+	r.Redact("static")
+	slot := r.RotatingSlot()
+
+	assert.Equal(t, "*** token", string(r.redacted([]byte("static token"))))
+
+	slot("first")
+	assert.Equal(t, "*** ***", string(r.redacted([]byte("static first"))))
+
+	// updating the slot replaces the previous value instead of appending
+	slot("second")
+	assert.Equal(t, "*** ***", string(r.redacted([]byte("static second"))))
+	assert.Equal(t, "*** first", string(r.redacted([]byte("static first"))))
+	assert.Len(t, r.rotating, 1)
+}

--- a/util/log_redactor_test.go
+++ b/util/log_redactor_test.go
@@ -13,12 +13,22 @@ func TestRotatingSlot(t *testing.T) {
 
 	assert.Equal(t, "*** token", string(r.redacted([]byte("static token"))))
 
-	slot("first")
-	assert.Equal(t, "*** ***", string(r.redacted([]byte("static first"))))
+	slot("access", "refresh")
+	assert.Equal(t, "*** *** ***", string(r.redacted([]byte("static access refresh"))))
 
-	// updating the slot replaces the previous value instead of appending
+	// updating the slot replaces the previous values instead of appending
 	slot("second")
 	assert.Equal(t, "*** ***", string(r.redacted([]byte("static second"))))
-	assert.Equal(t, "*** first", string(r.redacted([]byte("static first"))))
+	assert.Equal(t, "*** access refresh", string(r.redacted([]byte("static access refresh"))))
 	assert.Len(t, r.rotating, 1)
+}
+
+func TestRotatingSlotLimit(t *testing.T) {
+	var r Redactor
+
+	for range maxRotatingSlots + 1 {
+		r.RotatingSlot()
+	}
+
+	assert.Len(t, r.rotating, maxRotatingSlots)
 }

--- a/util/oauth/bootstraptokensource.go
+++ b/util/oauth/bootstraptokensource.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"sync"
 
+	"github.com/evcc-io/evcc/util"
 	"golang.org/x/oauth2"
 )
 
@@ -11,10 +12,10 @@ type bootstrapTokenSource struct {
 	refresher func() (*oauth2.Token, error)
 }
 
-func BootstrapTokenSource(refresher func() (*oauth2.Token, error)) oauth2.TokenSource {
-	return &bootstrapTokenSource{
+func BootstrapTokenSource(log *util.Logger, refresher func() (*oauth2.Token, error)) oauth2.TokenSource {
+	return Redacted(log, &bootstrapTokenSource{
 		refresher: refresher,
-	}
+	})
 }
 
 func (ts *bootstrapTokenSource) Token() (*oauth2.Token, error) {

--- a/util/oauth/redact.go
+++ b/util/oauth/redact.go
@@ -1,0 +1,43 @@
+package oauth
+
+import (
+	"sync"
+
+	"github.com/evcc-io/evcc/util"
+	"golang.org/x/oauth2"
+)
+
+type redactedTokenSource struct {
+	mu     sync.Mutex
+	ts     oauth2.TokenSource
+	access string
+	redact func(...string)
+}
+
+// Redacted keeps the source's access and refresh tokens out of the logs, where
+// they would otherwise show up in the Authorization header. The tokens share a
+// rotating redaction slot, so refreshing replaces them instead of growing the
+// redaction list.
+func Redacted(log *util.Logger, ts oauth2.TokenSource) oauth2.TokenSource {
+	return &redactedTokenSource{
+		ts:     ts,
+		redact: log.RotatingSlot(),
+	}
+}
+
+func (ts *redactedTokenSource) Token() (*oauth2.Token, error) {
+	token, err := ts.ts.Token()
+	if err != nil {
+		return token, err
+	}
+
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	if token.AccessToken != ts.access {
+		ts.access = token.AccessToken
+		ts.redact(token.AccessToken, token.RefreshToken)
+	}
+
+	return token, nil
+}

--- a/util/oauth/redact_test.go
+++ b/util/oauth/redact_test.go
@@ -1,0 +1,26 @@
+package oauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestRedacted(t *testing.T) {
+	var redacted [][]string
+
+	ts := &redactedTokenSource{
+		ts:     oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access", RefreshToken: "refresh"}),
+		redact: func(s ...string) { redacted = append(redacted, s) },
+	}
+
+	// the slot is only updated when the token has actually changed
+	for range 3 {
+		_, err := ts.Token()
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, [][]string{{"access", "refresh"}}, redacted)
+}

--- a/util/oauth/refreshtokensource.go
+++ b/util/oauth/refreshtokensource.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/evcc-io/evcc/util"
 	"golang.org/x/oauth2"
 )
 
@@ -13,7 +14,7 @@ type refreshTokenSource struct {
 	refresher func(token *oauth2.Token) (*oauth2.Token, error)
 }
 
-func RefreshTokenSource(token *oauth2.Token, refresher func(token *oauth2.Token) (*oauth2.Token, error)) oauth2.TokenSource {
+func RefreshTokenSource(log *util.Logger, token *oauth2.Token, refresher func(token *oauth2.Token) (*oauth2.Token, error)) oauth2.TokenSource {
 	if token == nil {
 		// allocate an (expired) token or mergeToken will fail
 		token = new(oauth2.Token)
@@ -24,7 +25,7 @@ func RefreshTokenSource(token *oauth2.Token, refresher func(token *oauth2.Token)
 		refresher: refresher,
 	}
 
-	return ts
+	return Redacted(log, ts)
 }
 
 func (ts *refreshTokenSource) Token() (*oauth2.Token, error) {

--- a/vehicle/bluelink/identity.go
+++ b/vehicle/bluelink/identity.go
@@ -195,7 +195,7 @@ func (v *Identity) Login(user, password, language, brand string) error {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(token, refresher)
+	v.TokenSource = oauth.RefreshTokenSource(v.log, token, refresher)
 
 	v.deviceID, err = v.getDeviceID()
 	if err != nil {

--- a/vehicle/bluelink_us/identity.go
+++ b/vehicle/bluelink_us/identity.go
@@ -42,6 +42,7 @@ func BaseHeaders() map[string]string {
 
 type Identity struct {
 	*request.Helper
+	log            *util.Logger
 	user, password string
 	oauth2.TokenSource
 }
@@ -49,6 +50,7 @@ type Identity struct {
 func NewIdentity(log *util.Logger, user, password string) *Identity {
 	return &Identity{
 		Helper:   request.NewHelper(log),
+		log:      log,
 		user:     user,
 		password: password,
 	}
@@ -64,7 +66,7 @@ func (v *Identity) Login() error {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
-	v.TokenSource = oauth2.ReuseTokenSource(token, oauth.BootstrapTokenSource(v.login))
+	v.TokenSource = oauth2.ReuseTokenSource(token, oauth.BootstrapTokenSource(v.log, v.login))
 	return nil
 }
 

--- a/vehicle/bmw/connected/identity.go
+++ b/vehicle/bmw/connected/identity.go
@@ -51,7 +51,7 @@ func (v *Identity) Login(user, password, hcaptcha string) (oauth2.TokenSource, e
 		v.log.DEBUG.Println("identity.Login - database token found")
 		tok, err := v.refreshToken(&tok)
 		if err == nil {
-			ts := oauth2.ReuseTokenSourceWithExpiry(tok, oauth.RefreshTokenSource(tok, v.refreshToken), 15*time.Minute)
+			ts := oauth2.ReuseTokenSourceWithExpiry(tok, oauth.RefreshTokenSource(v.log, tok, v.refreshToken), 15*time.Minute)
 			return ts, nil
 		}
 		v.log.DEBUG.Println("identity.Login - database token invalid. Proceeding to login via user, password and captcha.")
@@ -150,7 +150,7 @@ func (v *Identity) Login(user, password, hcaptcha string) (oauth2.TokenSource, e
 		return nil, err
 	}
 
-	ts := oauth2.ReuseTokenSourceWithExpiry(token, oauth.RefreshTokenSource(token, v.refreshToken), 15*time.Minute)
+	ts := oauth2.ReuseTokenSourceWithExpiry(token, oauth.RefreshTokenSource(v.log, token, v.refreshToken), 15*time.Minute)
 
 	return ts, nil
 }

--- a/vehicle/connectedcars/api.go
+++ b/vehicle/connectedcars/api.go
@@ -41,7 +41,7 @@ func NewAPI(log *util.Logger, domain, namespace, deviceToken string) *API {
 		RefreshToken: deviceToken,
 	}
 
-	ts := oauth.RefreshTokenSource(token, api.refreshToken)
+	ts := oauth.RefreshTokenSource(log, token, api.refreshToken)
 
 	// Install oauth2.Transport for Bearer token, plus a decorator for the
 	// namespace header required by all API endpoints.

--- a/vehicle/jlr/identity.go
+++ b/vehicle/jlr/identity.go
@@ -18,6 +18,7 @@ const IFAS_BASE_URL = "https://ifas.prod-row.jlrmotor.com/ifas/jlr"
 
 type Identity struct {
 	*request.Helper
+	log                    *util.Logger
 	user, password, device string
 	oauth2.TokenSource
 }
@@ -38,6 +39,7 @@ func Headers(device string, headers map[string]string) map[string]string {
 func NewIdentity(log *util.Logger, user, password, device string) *Identity {
 	return &Identity{
 		Helper:   request.NewHelper(log),
+		log:      log,
 		user:     user,
 		password: password,
 		device:   device,
@@ -71,7 +73,7 @@ func (v *Identity) Login() (Token, error) {
 
 	token, err := v.login(data)
 	if err == nil {
-		v.TokenSource = oauth.RefreshTokenSource(&token.Token, v.refreshToken)
+		v.TokenSource = oauth.RefreshTokenSource(v.log, &token.Token, v.refreshToken)
 	}
 
 	return token, err

--- a/vehicle/mercedes/identity.go
+++ b/vehicle/mercedes/identity.go
@@ -91,7 +91,7 @@ func NewIdentity(log *util.Logger, token *oauth2.Token, account string, region s
 		return nil, errors.New("token expired")
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(token, v.refreshToken)
+	v.TokenSource = oauth.RefreshTokenSource(log, token, v.refreshToken)
 
 	// add instance
 	addInstance(account, v)
@@ -125,8 +125,6 @@ func (v *Identity) refreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 	}
 
 	tok := util.TokenWithExpiry(&res)
-	v.TokenSource = oauth.RefreshTokenSource(tok, v.refreshToken)
-
 	err := settings.SetJson(v.settingsKey(), tok)
 
 	return tok, err

--- a/vehicle/nissan/identity.go
+++ b/vehicle/nissan/identity.go
@@ -77,7 +77,7 @@ func NewIdentity(log *util.Logger, user, password string) (oauth2.TokenSource, e
 		return nil, err
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(token, v.refresh)
+	v.TokenSource = oauth.RefreshTokenSource(log, token, v.refresh)
 
 	return v, nil
 }

--- a/vehicle/polestar/identity.go
+++ b/vehicle/polestar/identity.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"github.com/samber/lo"
 	"golang.org/x/oauth2"
@@ -51,7 +52,7 @@ func NewIdentity(log *util.Logger, user, password string) (oauth2.TokenSource, e
 	}
 
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, v.Client)
-	return oauth2.ReuseTokenSource(token, OAuth2Config.TokenSource(ctx, token)), nil
+	return oauth2.ReuseTokenSource(token, oauth.Redacted(log, OAuth2Config.TokenSource(ctx, token))), nil
 }
 
 func (v *Identity) login() (*oauth2.Token, error) {

--- a/vehicle/porsche/identity.go
+++ b/vehicle/porsche/identity.go
@@ -67,7 +67,7 @@ func NewIdentity(log *util.Logger, user, password string) (oauth2.TokenSource, e
 		return nil, fmt.Errorf("login failed: %w", err)
 	}
 
-	return oauth.RefreshTokenSource(token, v.refreshToken), nil
+	return oauth.RefreshTokenSource(log, token, v.refreshToken), nil
 }
 
 func (v *Identity) login() (*oauth2.Token, error) {

--- a/vehicle/psa/identity.go
+++ b/vehicle/psa/identity.go
@@ -54,7 +54,7 @@ func NewIdentity(log *util.Logger, brand, user string, oc *oauth2.Config, token 
 		return nil, errors.New("token expired")
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(token, v.refreshToken)
+	v.TokenSource = oauth.RefreshTokenSource(log, token, v.refreshToken)
 
 	// add instance
 	addInstance(v.subject, v)
@@ -77,7 +77,6 @@ func (v *Identity) refreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(tok, v.refreshToken)
 	err = settings.SetJson(v.subject, tok)
 
 	return tok, err

--- a/vehicle/saic/identity.go
+++ b/vehicle/saic/identity.go
@@ -18,6 +18,7 @@ import (
 
 type Identity struct {
 	*request.Helper
+	log         *util.Logger
 	TokenSource oauth2.TokenSource
 	User        string
 	Password    string
@@ -29,6 +30,7 @@ type Identity struct {
 func NewIdentity(log *util.Logger, user, password, baseUrl string) *Identity {
 	v := &Identity{
 		Helper:   request.NewHelper(log),
+		log:      log,
 		User:     user,
 		Password: requests.Sha1(password),
 		baseUrl:  baseUrl,
@@ -56,7 +58,7 @@ func (v *Identity) Login() error {
 		return err
 	}
 
-	v.TokenSource = oauth2.ReuseTokenSourceWithExpiry(token, oauth.RefreshTokenSource(token, v.refreshToken), 15*time.Minute)
+	v.TokenSource = oauth2.ReuseTokenSourceWithExpiry(token, oauth.RefreshTokenSource(v.log, token, v.refreshToken), 15*time.Minute)
 
 	return nil
 }

--- a/vehicle/skoda/tokenrefreshservice/endpoint.go
+++ b/vehicle/skoda/tokenrefreshservice/endpoint.go
@@ -21,6 +21,7 @@ var _ vag.TokenExchanger = (*Service)(nil)
 
 type Service struct {
 	*request.Helper
+	log  *util.Logger
 	data url.Values
 }
 
@@ -40,6 +41,7 @@ func (s *skodaTokenResponse) toVagToken(v *vag.Token) {
 func New(log *util.Logger, q url.Values) *Service {
 	return &Service{
 		Helper: request.NewHelper(log),
+		log:    log,
 		data:   q,
 	}
 }
@@ -91,5 +93,5 @@ func (v *Service) Refresh(token *vag.Token) (*vag.Token, error) {
 
 // TokenSource creates token source. Token is refreshed automatically.
 func (v *Service) TokenSource(token *vag.Token) vag.TokenSource {
-	return vag.RefreshTokenSource(token, v.Refresh)
+	return vag.RefreshTokenSource(v.log, token, v.Refresh)
 }

--- a/vehicle/smart/hello/identity.go
+++ b/vehicle/smart/hello/identity.go
@@ -67,7 +67,7 @@ func NewIdentity(log *util.Logger, user, password string) (*Identity, error) {
 		}
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(token, v.refreshToken)
+	v.TokenSource = oauth.RefreshTokenSource(log, token, v.refreshToken)
 	return v, nil
 }
 

--- a/vehicle/subaru/identity.go
+++ b/vehicle/subaru/identity.go
@@ -142,7 +142,7 @@ func (v *Identity) fetchTokenCredentials(code string) error {
 	}
 
 	v.uuid = uuid
-	v.TokenSource = oauth.RefreshTokenSource(util.TokenWithExpiry(&res.Token), v.refreshToken)
+	v.TokenSource = oauth.RefreshTokenSource(v.log, util.TokenWithExpiry(&res.Token), v.refreshToken)
 	return nil
 }
 

--- a/vehicle/tesla/identity.go
+++ b/vehicle/tesla/identity.go
@@ -88,7 +88,7 @@ func NewIdentity(log *util.Logger, oc *oauth2.Config, token *oauth2.Token) (oaut
 		return nil, errors.New("token expired")
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(token, v.refreshToken)
+	v.TokenSource = oauth.RefreshTokenSource(log, token, v.refreshToken)
 
 	// add instance
 	identities[claims.Subject] = v

--- a/vehicle/toyota/identity.go
+++ b/vehicle/toyota/identity.go
@@ -140,7 +140,7 @@ func (v *Identity) fetchTokenCredentials(code string) error {
 	}
 
 	v.uuid = uuid
-	v.TokenSource = oauth.RefreshTokenSource(util.TokenWithExpiry(&res.Token), v.refreshToken)
+	v.TokenSource = oauth.RefreshTokenSource(v.log, util.TokenWithExpiry(&res.Token), v.refreshToken)
 	return nil
 }
 

--- a/vehicle/tronity/tokensource.go
+++ b/vehicle/tronity/tokensource.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -14,7 +15,7 @@ type tokenSource struct {
 }
 
 func TokenSource(log *util.Logger, oc *oauth2.Config) oauth2.TokenSource {
-	return oauth2.ReuseTokenSource(nil, &tokenSource{log, oc})
+	return oauth2.ReuseTokenSource(nil, oauth.Redacted(log, &tokenSource{log, oc}))
 }
 
 func (ts *tokenSource) Token() (*oauth2.Token, error) {

--- a/vehicle/vag/tokensource.go
+++ b/vehicle/vag/tokensource.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"dario.cat/mergo"
+	"github.com/evcc-io/evcc/util"
 	"golang.org/x/oauth2"
 )
 
@@ -29,13 +30,23 @@ type TokenRefresher func(*Token) (*Token, error)
 var _ TokenSource = (*tokenSource)(nil)
 
 type tokenSource struct {
-	mu    sync.Mutex
-	token *Token
-	new   TokenRefresher
+	mu     sync.Mutex
+	token  *Token
+	new    TokenRefresher
+	redact func(...string)
 }
 
-func RefreshTokenSource(token *Token, refresher TokenRefresher) *tokenSource {
-	return &tokenSource{token: token, new: refresher}
+func RefreshTokenSource(log *util.Logger, token *Token, refresher TokenRefresher) *tokenSource {
+	ts := &tokenSource{token: token, new: refresher, redact: log.RotatingSlot()}
+	ts.redactToken()
+
+	return ts
+}
+
+// redactToken keeps the current tokens out of the logs, where they would
+// otherwise show up in the Authorization header
+func (ts *tokenSource) redactToken() {
+	ts.redact(ts.token.AccessToken, ts.token.RefreshToken, ts.token.IDToken)
 }
 
 // Token returns an oauth2 token or an error
@@ -56,7 +67,9 @@ func (ts *tokenSource) TokenEx() (*Token, error) {
 	if time.Until(ts.token.Expiry) < time.Minute {
 		var token *Token
 		if token, err = ts.new(ts.token); err == nil {
-			err = ts.mergeToken(token)
+			if err = ts.mergeToken(token); err == nil {
+				ts.redactToken()
+			}
 		}
 	}
 


### PR DESCRIPTION
Every device that authenticates with OAuth2 puts its access token into an `Authorization` header on every request. None of those tokens were registered for redaction, so a trace log taken with `--log-headers` — the kind users paste into issues — hands out valid credentials.

Tokens are now registered for redaction as they are obtained. Plain `Redact` is not suitable, as tokens expire and each refresh would append another entry to a list that is walked for every single log line. `Redactor` gains a rotating slot instead, which replaces the previous values in place.

`oauth.Redacted` wraps an `oauth2.TokenSource` and puts its access and refresh token into such a slot. The shared `RefreshTokenSource` and `BootstrapTokenSource` apply it for all their users, which covers most devices; the token sources that don't build on those — plugin oauth (and with it Home Assistant, Viessmann, Ford, Volvo, Tibber, CarData), vag/Škoda, Zaptec, Polestar, Octopus, Corrently, Tronity — register their tokens the same way. The static Tessie and Home Assistant supervisor tokens use plain redaction.

Two details worth flagging:

- Slots per logger are capped. Loggers are shared per log area, so a repeatedly re-created token source would otherwise keep reserving slots.
- Mercedes and PSA rebuilt their token source inside the refresher, on every refresh. The outer source already stores the refreshed token, so that assignment is dropped.

This covers the header only. A token endpoint's response body is still logged verbatim, as the value is only known once the round tripper has already written the body to the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)