### PR TITLE
UI: add missing German date format translations

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1735,6 +1735,13 @@
     "vehicle": "Fahrzeug"
   },
   "settings": {
+    "dateFormat": {
+      "auto": "Auto",
+      "dmy": "TT/MM/JJJJ",
+      "label": "Datumsformat",
+      "mdy": "MM/TT/JJJJ",
+      "ymd": "JJJJ-MM-TT"
+    },
     "deviceInfo": "Einstellungen, die du in diesem Dialog vornimmst, gelten nur für dieses Gerät.",
     "fullscreen": {
       "enter": "Vollbild starten",


### PR DESCRIPTION
The settings dialog rendered Date format in English under German locale because settings.dateFormat keys were missing in i18n/de.json.