### PR TITLE
Vehicle (Fiat): return last known data when deep refresh is refused

### DIFF
--- a/vehicle/fiat/provider.go
+++ b/vehicle/fiat/provider.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -47,16 +48,25 @@ func NewProvider(api *API, vin, pin string, expiry, cache time.Duration) *Provid
 	return impl
 }
 
-func (v *Provider) deepRefresh() error {
+// deepRefresh triggers a deep refresh of the vehicle data. It returns true if the
+// refresh was accepted (pending). A vehicle that is not plugged in refuses the
+// refresh with 403 Forbidden; in that case retrying is pointless, so it returns
+// false without error. A 403 from the preceding pin authentication is a real
+// error and is surfaced instead of being masked.
+func (v *Provider) deepRefresh() (bool, error) {
 	res, err := v.action("ev", "DEEPREFRESH")
-	if err == nil && res.ResponseStatus != "pending" {
-		err = fmt.Errorf("invalid response status: %s", res.ResponseStatus)
-	} else {
+	if err != nil {
 		if se, ok := errors.AsType[*request.StatusError](err); ok && se.StatusCode() == http.StatusForbidden {
-			err = nil
+			if req := se.Response().Request; req == nil || !strings.HasSuffix(req.URL.Path, "/authenticate") {
+				return false, nil
+			}
 		}
+		return false, err
 	}
-	return err
+	if res.ResponseStatus != "pending" {
+		return false, fmt.Errorf("invalid response status: %s", res.ResponseStatus)
+	}
+	return true, nil
 }
 
 func (v *Provider) status(statusG func() (StatusResponse, error)) (StatusResponse, error) {
@@ -68,8 +78,15 @@ func (v *Provider) status(statusG func() (StatusResponse, error)) (StatusRespons
 		if res.Timestamp.Add(v.expiry).Before(time.Now()) {
 			// start refresh
 			if v.refreshTime.IsZero() {
-				if err = v.deepRefresh(); err != nil {
+				accepted, err := v.deepRefresh()
+				if err != nil {
 					return res, err
+				}
+
+				// vehicle refused the refresh (e.g. not plugged in); retrying is
+				// pointless, so return the last known data instead of blocking
+				if !accepted {
+					return res, nil
 				}
 
 				v.refreshTime = time.Now()

--- a/vehicle/fiat/provider_test.go
+++ b/vehicle/fiat/provider_test.go
@@ -1,0 +1,113 @@
+package fiat
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusErr builds a request.StatusError carrying the given HTTP status code and
+// request path.
+func statusErr(code int, path string) error {
+	req := &http.Request{Method: http.MethodPost, URL: &url.URL{Scheme: "https", Host: "example.invalid", Path: path}}
+	return request.NewStatusError(&http.Response{StatusCode: code, Request: req})
+}
+
+const (
+	pathDeepRefresh = "/v1/accounts/1/vehicles/1/ev"
+	pathPinAuth     = "/v1/accounts/1/ignite/pin/authenticate"
+)
+
+// staleStatus returns a status response older than the provider expiry.
+func staleStatus() StatusResponse {
+	var res StatusResponse
+	res.Timestamp = TimeMillis{time.Now().Add(-10 * time.Minute)}
+	res.VehicleInfo.Odometer.Odometer.Value = 31650
+	return res
+}
+
+func TestProviderStatus(t *testing.T) {
+	t.Run("fresh data is returned without refresh", func(t *testing.T) {
+		var res StatusResponse
+		res.Timestamp = TimeMillis{time.Now()}
+		res.VehicleInfo.Odometer.Odometer.Value = 31650
+
+		called := false
+		v := &Provider{
+			expiry: 5 * time.Minute,
+			action: func(action, cmd string) (ActionResponse, error) {
+				called = true
+				return ActionResponse{}, nil
+			},
+		}
+
+		got, err := v.status(func() (StatusResponse, error) { return res, nil })
+		require.NoError(t, err)
+		assert.False(t, called, "no refresh expected for fresh data")
+		assert.Equal(t, 31650, got.VehicleInfo.Odometer.Odometer.Value)
+	})
+
+	t.Run("refused refresh returns last known data without error", func(t *testing.T) {
+		// vehicle refuses DEEPREFRESH with 403 when it is not plugged in
+		calls := 0
+		v := &Provider{
+			expiry: 5 * time.Minute,
+			action: func(action, cmd string) (ActionResponse, error) {
+				calls++
+				return ActionResponse{}, statusErr(http.StatusForbidden, pathDeepRefresh)
+			},
+		}
+
+		got, err := v.status(func() (StatusResponse, error) { return staleStatus(), nil })
+		require.NoError(t, err, "a refused (not plugged in) refresh must not surface as error")
+		assert.Equal(t, 1, calls, "deep refresh should be attempted once")
+		assert.Equal(t, 31650, got.VehicleInfo.Odometer.Odometer.Value, "last known data must be preserved")
+		assert.True(t, v.refreshTime.IsZero(), "no retry loop should be started for a refused refresh")
+	})
+
+	t.Run("pin authentication failure is surfaced", func(t *testing.T) {
+		// a 403 from the pin authentication step must not be masked as a refusal
+		v := &Provider{
+			expiry: 5 * time.Minute,
+			action: func(action, cmd string) (ActionResponse, error) {
+				return ActionResponse{}, statusErr(http.StatusForbidden, pathPinAuth)
+			},
+		}
+
+		_, err := v.status(func() (StatusResponse, error) { return staleStatus(), nil })
+		require.Error(t, err, "a pin authentication failure must surface as error")
+		assert.NotErrorIs(t, err, api.ErrMustRetry)
+	})
+
+	t.Run("accepted refresh arms the retry window", func(t *testing.T) {
+		v := &Provider{
+			expiry: 5 * time.Minute,
+			action: func(action, cmd string) (ActionResponse, error) {
+				return ActionResponse{ResponseStatus: "pending"}, nil
+			},
+		}
+
+		_, err := v.status(func() (StatusResponse, error) { return staleStatus(), nil })
+		assert.ErrorIs(t, err, api.ErrMustRetry)
+		assert.False(t, v.refreshTime.IsZero(), "retry window should be armed after an accepted refresh")
+	})
+
+	t.Run("unexpected refresh error is surfaced", func(t *testing.T) {
+		v := &Provider{
+			expiry: 5 * time.Minute,
+			action: func(action, cmd string) (ActionResponse, error) {
+				return ActionResponse{}, statusErr(http.StatusInternalServerError, pathDeepRefresh)
+			},
+		}
+
+		_, err := v.status(func() (StatusResponse, error) { return staleStatus(), nil })
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, api.ErrMustRetry)
+	})
+}


### PR DESCRIPTION
fixes #33351

A Fiat/Jeep deep refresh is refused with HTTP 403 when the vehicle is not plugged in. That refusal was treated like a started refresh, so the provider stayed in a permanent retry loop and reported 0 for SoC, range and odometer instead of the still valid last-known values.

- Distinguish an accepted deep refresh (pending) from a refused one (403, not plugged in), and return the last-known data without error in the refused case instead of looping on `ErrMustRetry`.
- Add provider tests covering fresh data, a refused refresh, an accepted refresh and an unexpected error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
