### PR TITLE
MyŠkoda: fix sandbox bool comparison

### DIFF
--- a/templates/definition/vehicle/myskoda.yaml
+++ b/templates/definition/vehicle/myskoda.yaml
@@ -31,7 +31,7 @@ render: |
   type: myskoda
   vin: {{ .vin }}
   apikey: {{ .apikey }}
-  {{- if eq .sandbox "true" }}
+  {{- if .sandbox }}
   sandbox: true
   {{- end }}
   {{ include "common" . }}


### PR DESCRIPTION
Master is red: `myskoda.yaml` still uses the pre-#33153 string idiom `eq .sandbox "true"`, but `sandbox` is declared `type: bool`, so rendering fails with

```
template: $root:4:7: executing "$root" at <eq .sandbox "true">: error calling eq: incompatible types for comparison: bool and string
```

Two PRs raced: #33153 converted every `eq .x "true"` to a native bool test, the MyŠkoda template landed with the old idiom.

Breaks `TestAllTemplatesRenderWithBoolParams`, `TestVehicleFeatureParamsConsistent` and `TestTemplates/myskoda`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)