### PR TITLE
Charger (Stiebel Eltron WPM): optional inverter power

### DIFF
--- a/templates/definition/charger/stiebel-wpm.yaml
+++ b/templates/definition/charger/stiebel-wpm.yaml
@@ -13,6 +13,16 @@ params:
   - name: tempsource
     type: choice
     choice: ["warmwater", "buffer"]
+  - name: power
+    type: bool
+    default: false
+    advanced: true
+    description:
+      de: Leistungsaufnahme auslesen
+      en: Read power consumption
+    help:
+      de: Aufnahmeleistung des Inverters. Nur bei WPMsystem (WPM 4) verfügbar, nicht bei WPM 3/3i.
+      en: Inverter power consumption. Only available on WPMsystem (WPM 4), not on WPM 3/3i.
 render: |
   type: sgready
   getmode:
@@ -107,5 +117,15 @@ render: |
       type: input
       encoding: int16
     scale: 0.1
+  {{- end }}
+  {{- if .power }}
+  power:
+    source: modbus
+    {{- include "modbus" . | indent 2 }}
+    register:
+      address: 3679 # 3680 INVERTER AUFNAHMELEISTUNG IWS 1 (1-based)
+      type: input
+      encoding: int16nan
+    scale: 100 # 0.1 kW -> W
   {{- end }}
   {{ include "heatpumpswitch" . }}

--- a/templates/definition/charger/stiebel-wpm.yaml
+++ b/templates/definition/charger/stiebel-wpm.yaml
@@ -15,7 +15,6 @@ params:
     choice: ["warmwater", "buffer"]
   - name: power
     type: bool
-    default: false
     advanced: true
     description:
       de: Leistungsaufnahme auslesen


### PR DESCRIPTION
fixes #23345, retries #18505

Re-adds the inverter power reading to the Stiebel Eltron WPM template, this time behind an opt-in flag and with the addressing and scaling the ISG Modbus documentation actually specifies. The register only exists on WPMsystem (WPM 4), so WPM 3/3i answers `illegal data address` and must not read it at all, which is what broke the first attempt.

- new advanced `power` param, off by default
- register 3679, the documented 3680 minus the ISG's one-based offset that the rest of the template already applies
- `scale: 100`, since the raw value is kW with one decimal and evcc expects W
- `encoding: int16nan` drops the `32768 (0x8000H)` substitute value the ISG returns for unavailable objects, which previously surfaced as -3276.8

Register semantics per documentation: inverter power draw of heat pump 1 only, 0.1 kW resolution, pumps and immersion heater not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
