### PR TITLE
Smart-hello: retry once with a fresh login when the api rejects the token

### DIFF
--- a/vehicle/smart/hello/api.go
+++ b/vehicle/smart/hello/api.go
@@ -2,6 +2,7 @@ package hello
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -94,16 +95,56 @@ func (v *API) request(method, path string, params url.Values, body io.Reader) (*
 	return req, err
 }
 
-func (v *API) Vehicles() ([]Vehicle, error) {
-	var res struct {
-		Code    Int
-		Message string
-		Error   Error
-		Data    struct {
-			List []Vehicle
+// response is the common envelope of all api responses
+type response[T any] struct {
+	Code    Int
+	Message string
+	Error   Error
+	Data    T
+}
+
+// do executes a signed request. A ResponseTokenInvalid answer means the backend
+// no longer accepts the token although it has not expired yet- retry once with a
+// fresh login. The body is built per attempt as it may embed the current token.
+func do[T any](v *API, method, path string, params url.Values, body func() ([]byte, error)) (T, error) {
+	var zero T
+	var res response[T]
+	var err error
+
+	for range 2 {
+		var rdr io.Reader
+		if body != nil {
+			b, err := body()
+			if err != nil {
+				return zero, err
+			}
+			rdr = bytes.NewReader(b)
 		}
+
+		var req *http.Request
+		req, err = v.request(method, path, params, rdr)
+		if err != nil {
+			return zero, err
+		}
+
+		res = response[T]{}
+		err = v.DoJSON(req, &res)
+
+		if res.Code != ResponseTokenInvalid && res.Error.Code != ResponseTokenInvalid {
+			break
+		}
+
+		v.identity.Invalidate()
 	}
 
+	if err := responseError(err, res.Code, res.Message, res.Error); err != nil {
+		return zero, err
+	}
+
+	return res.Data, nil
+}
+
+func (v *API) Vehicles() ([]Vehicle, error) {
 	userID, err := v.identity.UserID()
 	if err != nil {
 		return nil, err
@@ -115,64 +156,37 @@ func (v *API) Vehicles() ([]Vehicle, error) {
 	}
 
 	// vehicle list is fetched on V1: SetSeries runs only after this call
-	path := "/device-platform/user/vehicle/secure"
-	req, err := v.request(http.MethodGet, path, params, nil)
-	if err != nil {
-		return nil, err
-	}
+	res, err := do[struct{ List []Vehicle }](v, http.MethodGet, "/device-platform/user/vehicle/secure", params, nil)
 
-	err = v.DoJSON(req, &res)
-	if err := responseError(err, res.Code, res.Message, res.Error); err != nil {
-		return nil, err
-	}
-
-	return res.Data.List, err
+	return res.List, err
 }
 
 func (v *API) UpdateSession(vin string) error {
-	token, err := v.identity.Token()
-	if err != nil {
-		return err
-	}
-
 	params := url.Values{
 		"identity_type": {"smart"},
 	}
 
-	data := map[string]string{
-		"vin":          vin,
-		"sessionToken": token.AccessToken,
-		"language":     "",
+	body := func() ([]byte, error) {
+		token, err := v.identity.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(map[string]string{
+			"vin":          vin,
+			"sessionToken": token.AccessToken,
+			"language":     "",
+		})
 	}
 
-	path := "/device-platform/user/session/update"
-	req, err := v.request(http.MethodPost, path, params, request.MarshalJSON(data))
-	if err != nil {
-		return err
-	}
+	_, err := do[struct{}](v, http.MethodPost, "/device-platform/user/session/update", params, body)
 
-	var res struct {
-		Code    Int
-		Message string
-		Error   Error
-	}
-
-	err = v.DoJSON(req, &res)
-	return responseError(err, res.Code, res.Message, res.Error)
+	return err
 }
 
 func (v *API) Status(vin string) (VehicleStatus, error) {
 	if err := v.UpdateSession(vin); err != nil {
 		return VehicleStatus{}, fmt.Errorf("update session failed: %w", err)
-	}
-
-	var res struct {
-		Code    Int
-		Message string
-		Error   Error
-		Data    struct {
-			VehicleStatus VehicleStatus
-		}
 	}
 
 	userID, err := v.identity.UserID()
@@ -186,18 +200,9 @@ func (v *API) Status(vin string) (VehicleStatus, error) {
 		"userId": {userID},
 	}
 
-	path := "/remote-control/vehicle/status/" + vin
-	req, err := v.request(http.MethodGet, path, params, nil)
-	if err != nil {
-		return VehicleStatus{}, err
-	}
+	res, err := do[struct{ VehicleStatus VehicleStatus }](v, http.MethodGet, "/remote-control/vehicle/status/"+vin, params, nil)
 
-	err = v.DoJSON(req, &res)
-	if err := responseError(err, res.Code, res.Message, res.Error); err != nil {
-		return VehicleStatus{}, err
-	}
-
-	return res.Data.VehicleStatus, err
+	return res.VehicleStatus, err
 }
 
 func (v *API) SocStatus(vin string) (VehicleSocStatus, error) {
@@ -205,27 +210,9 @@ func (v *API) SocStatus(vin string) (VehicleSocStatus, error) {
 		return VehicleSocStatus{}, fmt.Errorf("update session failed: %w", err)
 	}
 
-	var res struct {
-		Code    Int
-		Message string
-		Error   Error
-		Data    VehicleSocStatus
-	}
-
 	params := url.Values{
 		"setting": {"charging"},
 	}
 
-	path := "/remote-control/vehicle/status/soc/" + vin
-	req, err := v.request(http.MethodGet, path, params, nil)
-	if err != nil {
-		return VehicleSocStatus{}, err
-	}
-
-	err = v.DoJSON(req, &res)
-	if err := responseError(err, res.Code, res.Message, res.Error); err != nil {
-		return VehicleSocStatus{}, err
-	}
-
-	return res.Data, err
+	return do[VehicleSocStatus](v, http.MethodGet, "/remote-control/vehicle/status/soc/"+vin, params, nil)
 }

--- a/vehicle/smart/hello/api_test.go
+++ b/vehicle/smart/hello/api_test.go
@@ -1,0 +1,53 @@
+package hello
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
+	"github.com/evcc-io/evcc/util/request"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// TestRetryTokenInvalid ensures a 1402 response triggers a fresh login and a retry
+// instead of failing the request.
+func TestRetryTokenInvalid(t *testing.T) {
+	var requests int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Write([]byte(`{"code":"1402","message":"The access token is invalid"}`))
+			return
+		}
+		w.Write([]byte(`{"code":"1000","data":{"list":[{"vin":"VIN"}]}}`))
+	}))
+	defer srv.Close()
+
+	log := util.NewLogger("test")
+
+	var logins int
+	identity := &Identity{
+		Helper: request.NewHelper(log),
+		log:    log,
+		userID: "user",
+	}
+	identity.refresher = func(*oauth2.Token) (*oauth2.Token, error) {
+		logins++
+		return &oauth2.Token{AccessToken: "fresh", Expiry: time.Now().Add(time.Hour)}, nil
+	}
+	identity.ts = oauth.RefreshTokenSource(log, &oauth2.Token{AccessToken: "stale", Expiry: time.Now().Add(time.Hour)}, identity.refresher)
+
+	api := NewAPI(log, identity)
+	api.baseURI = srv.URL
+
+	vehicles, err := api.Vehicles()
+	require.NoError(t, err)
+	require.Len(t, vehicles, 1)
+	require.Equal(t, 2, requests)
+	require.Equal(t, 1, logins)
+}

--- a/vehicle/smart/hello/identity.go
+++ b/vehicle/smart/hello/identity.go
@@ -26,12 +26,14 @@ type savedState struct {
 
 type Identity struct {
 	*request.Helper
-	oauth2.TokenSource
 	log              *util.Logger
 	user, password   string
 	userID, deviceID string
 	subject          string
 	mu               sync.Mutex
+	tsMu             sync.RWMutex
+	ts               oauth2.TokenSource
+	refresher        func(*oauth2.Token) (*oauth2.Token, error)
 }
 
 func NewIdentity(log *util.Logger, user, password string) (*Identity, error) {
@@ -67,8 +69,26 @@ func NewIdentity(log *util.Logger, user, password string) (*Identity, error) {
 		}
 	}
 
-	v.TokenSource = oauth.RefreshTokenSource(log, token, v.refreshToken)
+	v.refresher = v.refreshToken
+	v.ts = oauth.RefreshTokenSource(log, token, v.refresher)
 	return v, nil
+}
+
+// Token implements the oauth2.TokenSource interface
+func (v *Identity) Token() (*oauth2.Token, error) {
+	v.tsMu.RLock()
+	ts := v.ts
+	v.tsMu.RUnlock()
+
+	return ts.Token()
+}
+
+// Invalidate discards the current token. The next Token call performs a fresh login.
+func (v *Identity) Invalidate() {
+	v.tsMu.Lock()
+	defer v.tsMu.Unlock()
+
+	v.ts = oauth.RefreshTokenSource(v.log, nil, v.refresher)
 }
 
 func (v *Identity) refreshToken(_ *oauth2.Token) (*oauth2.Token, error) {

--- a/vehicle/smart/hello/types.go
+++ b/vehicle/smart/hello/types.go
@@ -5,7 +5,13 @@ import (
 	"strings"
 )
 
-const ResponseOK = 1000
+const (
+	ResponseOK = 1000
+
+	// ResponseTokenInvalid is returned when the backend rejects the token before
+	// its nominal expiry, e.g. after a server-side session reset.
+	ResponseTokenInvalid = 1402
+)
 
 type Int int
 


### PR DESCRIPTION
fixes #33366

The Smart backend can reject a persisted app token before its nominal expiry, e.g. after a server-side session reset. Since the token source only refreshes on expiry and every non-`1000` response code is fatal, the vehicle stayed broken across restarts and re-configuration — the persisted token was replayed forever.

- retry a request once with a fresh login when the api answers `1402`
- build the request body per attempt so `session/update` does not replay the rejected session token

🤖 Generated with [Claude Code](https://claude.com/claude-code)
