### PR TITLE
Vehicle (PSA): login in the config ui

### DIFF
--- a/assets/js/components/BottomTabs/MoreMenu.vue
+++ b/assets/js/components/BottomTabs/MoreMenu.vue
@@ -167,7 +167,7 @@ export default defineComponent({
 	},
 	methods: {
 		handleAuthRequired() {
-			this.$router.push({ path: "/config" });
+			this.$router.push({ path: "/config", hash: "#integrations" });
 		},
 		openSettingsModal() {
 			const modal = Modal.getOrCreateInstance(

--- a/assets/js/components/Config/TestResult.vue
+++ b/assets/js/components/Config/TestResult.vue
@@ -11,6 +11,9 @@
 				<span v-if="!isRunning && isError" class="text-danger">
 					{{ $t("config.validation.failed") }}
 				</span>
+				<span v-if="!isRunning && loginRequired" class="text-warning">
+					{{ $t("config.validation.loginRequired") }}
+				</span>
 			</strong>
 			<div v-if="!showTokenRequired">
 				<span
@@ -29,6 +32,14 @@
 		<hr v-if="error" class="divider" />
 		<div v-if="error" class="text-danger" :class="{ 'opacity-25': isRunning }">
 			{{ error }}
+		</div>
+		<hr v-if="loginRequired" class="divider" />
+		<div v-if="loginRequired" :class="{ 'opacity-25': isRunning }">
+			{{
+				$t("config.validation.loginRequiredHint", {
+					section: $t("config.section.integrations"),
+				})
+			}}
 		</div>
 		<hr v-if="hasResult" class="divider" />
 		<div v-if="hasResult" :class="{ 'opacity-25': isRunning }">
@@ -56,6 +67,7 @@ export default defineComponent({
 		isSuccess: Boolean,
 		isError: Boolean,
 		isRunning: Boolean,
+		loginRequired: Boolean,
 		result: Object as PropType<Record<string, any> | null>,
 		error: String as PropType<string | null>,
 		sponsorTokenRequired: Boolean,

--- a/assets/js/components/Config/utils/test.ts
+++ b/assets/js/components/Config/utils/test.ts
@@ -8,6 +8,7 @@ export type TestState = {
   isSuccess: boolean;
   isError: boolean;
   isRunning: boolean;
+  loginRequired: boolean;
   result: Record<string, any> | null;
   error: string | null;
   errorLine: number | null;
@@ -18,6 +19,7 @@ export const initialTestState = (): TestState => ({
   isSuccess: false,
   isError: false,
   isRunning: false,
+  loginRequired: false,
   result: null,
   error: null,
   errorLine: null,
@@ -34,6 +36,7 @@ export const performTest = async (
   state.isUnknown = false;
   state.isSuccess = false;
   state.isRunning = true;
+  state.loginRequired = false;
   const startTime = Date.now();
   try {
     const res = await api();
@@ -45,7 +48,13 @@ export const performTest = async (
     state.error = null;
     state.errorLine = null;
     for (const [key, value] of Object.entries(res.data)) {
-      const { error } = value as { error?: string };
+      const { error, loginRequired } = value as { error?: string; loginRequired?: boolean };
+      // waiting for the user to log in is a pending state, not a failure
+      if (loginRequired) {
+        state.loginRequired = true;
+        state.result = res.data;
+        return false;
+      }
       if (error) {
         state.isError = true;
         state.error = `${key}: ${error}`;

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1053,6 +1053,8 @@
     "validation": {
       "failed": "fehlgeschlagen",
       "label": "Status",
+      "loginRequired": "Anmeldung erforderlich",
+      "loginRequiredHint": "Das Konto ist noch nicht verbunden. Speichere die Konfiguration und verbinde es anschließend unter {section}.",
       "running": "prüfe …",
       "success": "erfolgreich",
       "unknown": "unbekannt",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1053,6 +1053,8 @@
     "validation": {
       "failed": "failed",
       "label": "Status",
+      "loginRequired": "login required",
+      "loginRequiredHint": "The account is not connected yet. Save the configuration, then connect it under {section}.",
       "running": "validating…",
       "success": "successful",
       "unknown": "unknown",

--- a/server/http_config_helper.go
+++ b/server/http_config_helper.go
@@ -255,9 +255,10 @@ func deviceInstanceFromMergedConfig[T any](ctx context.Context, id int, class te
 }
 
 type testResult = struct {
-	Value  any    `json:"value"`
-	Error  string `json:"error"`
-	Asleep bool   `json:"asleep,omitempty"`
+	Value         any    `json:"value"`
+	Error         string `json:"error"`
+	Asleep        bool   `json:"asleep,omitempty"`
+	LoginRequired bool   `json:"loginRequired,omitempty"`
 }
 
 func hasFeature(instance any, f api.Feature) bool {
@@ -278,9 +279,14 @@ func testInstance(ctx context.Context, instance any) map[string]testResult {
 				return
 			}
 			// asleep is a valid vehicle state, not an error
-			if errors.Is(err, api.ErrAsleep) {
+			var loginRequired *api.ErrLoginRequired
+			switch {
+			case errors.Is(err, api.ErrAsleep):
 				tr.Asleep = true
-			} else {
+			// the device is waiting for the user to complete an interactive login
+			case errors.As(err, &loginRequired):
+				tr.LoginRequired = true
+			default:
 				tr.Error = err.Error()
 			}
 		}

--- a/server/http_config_helper_test.go
+++ b/server/http_config_helper_test.go
@@ -85,6 +85,20 @@ func TestInstanceAsleep(t *testing.T) {
 	assert.Equal(t, testResult{Value: int64(0), Asleep: true}, res["range"])
 }
 
+// loginRequiredVehicle waits for an interactive login to complete.
+type loginRequiredVehicle struct{}
+
+func (v loginRequiredVehicle) Soc() (float64, error) {
+	return 0, api.LoginRequiredError("psa.peugeot.user")
+}
+
+// TestInstanceLoginRequired ensures a pending login is flagged as state, not as error.
+func TestInstanceLoginRequired(t *testing.T) {
+	res := testInstance(context.Background(), loginRequiredVehicle{})
+	assert.Equal(t, testResult{Value: 0.0, LoginRequired: true}, res["soc"])
+	assert.Empty(t, res["soc"].Error, "a pending login must not surface as an error")
+}
+
 func TestConfigReqUnmarshal(t *testing.T) {
 	var req configReq
 	require.NoError(t, json.Unmarshal([]byte(`{

--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -31,7 +31,7 @@ params:
     default: 15m
 auth:
   type: citroen
-  params: [user, country]
+  params: [user, country, accessToken, refreshToken]
 render: |
   type: citroen
   vin: {{ .vin }}

--- a/templates/definition/vehicle/citroen.yaml
+++ b/templates/definition/vehicle/citroen.yaml
@@ -4,28 +4,39 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+      Beim Einrichten des Fahrzeugs dem Link folgen und im Browser mit dem Citroën-Konto anmelden.
+      Anschließend den Code oder die vollständige Weiterleitungs-URL in den Fahrzeugdialog kopieren.
     en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+      When configuring the vehicle, follow the link and sign in with your Citroën account in the browser.
+      Then paste the code or the full redirect URL into the vehicle dialog.
 params:
   - preset: vehicle-common
   - preset: vehicle-online
   - name: user
     required: true
+  - name: country
+    default: de
+    description:
+      de: Ländercode
+      en: Country code
   - name: password
     deprecated: true
   - name: accessToken
-    required: true
+    advanced: true
   - name: refreshToken
-    required: true
+    advanced: true
   - name: vin
     example: V...
   - name: cache
     default: 15m
+auth:
+  type: citroen
+  params: [user, country]
 render: |
   type: citroen
   vin: {{ .vin }}
   user: {{ .user }}
+  country: {{ .country }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -4,28 +4,39 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+      Beim Einrichten des Fahrzeugs dem Link folgen und im Browser mit dem DS-Konto anmelden.
+      Anschließend den Code oder die vollständige Weiterleitungs-URL in den Fahrzeugdialog kopieren.
     en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+      When configuring the vehicle, follow the link and sign in with your DS account in the browser.
+      Then paste the code or the full redirect URL into the vehicle dialog.
 params:
   - preset: vehicle-common
   - preset: vehicle-online
   - name: user
     required: true
+  - name: country
+    default: de
+    description:
+      de: Ländercode
+      en: Country code
   - name: password
     deprecated: true
   - name: accessToken
-    required: true
+    advanced: true
   - name: refreshToken
-    required: true
+    advanced: true
   - name: vin
     example: V...
   - name: cache
     default: 15m
+auth:
+  type: ds
+  params: [user, country]
 render: |
   type: ds
   vin: {{ .vin }}
   user: {{ .user }}
+  country: {{ .country }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}

--- a/templates/definition/vehicle/ds.yaml
+++ b/templates/definition/vehicle/ds.yaml
@@ -31,7 +31,7 @@ params:
     default: 15m
 auth:
   type: ds
-  params: [user, country]
+  params: [user, country, accessToken, refreshToken]
 render: |
   type: ds
   vin: {{ .vin }}

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -4,28 +4,39 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+      Beim Einrichten des Fahrzeugs dem Link folgen und im Browser mit dem Opel-Konto anmelden.
+      Anschließend den Code oder die vollständige Weiterleitungs-URL in den Fahrzeugdialog kopieren.
     en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+      When configuring the vehicle, follow the link and sign in with your Opel account in the browser.
+      Then paste the code or the full redirect URL into the vehicle dialog.
 params:
   - preset: vehicle-common
   - preset: vehicle-online
   - name: user
     required: true
+  - name: country
+    default: de
+    description:
+      de: Ländercode
+      en: Country code
   - name: password
     deprecated: true
   - name: accessToken
-    required: true
+    advanced: true
   - name: refreshToken
-    required: true
+    advanced: true
   - name: vin
     example: V...
   - name: cache
     default: 15m
+auth:
+  type: opel
+  params: [user, country]
 render: |
   type: opel
   vin: {{ .vin }}
   user: {{ .user }}
+  country: {{ .country }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}

--- a/templates/definition/vehicle/opel.yaml
+++ b/templates/definition/vehicle/opel.yaml
@@ -31,7 +31,7 @@ params:
     default: 15m
 auth:
   type: opel
-  params: [user, country]
+  params: [user, country, accessToken, refreshToken]
 render: |
   type: opel
   vin: {{ .vin }}

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -4,28 +4,39 @@ products:
 requirements:
   description:
     de: |
-      Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc token [name]` generiert werden.
+      Beim Einrichten des Fahrzeugs dem Link folgen und im Browser mit dem Peugeot-Konto anmelden.
+      Anschließend den Code oder die vollständige Weiterleitungs-URL in den Fahrzeugdialog kopieren.
     en: |
-      Requires `access` and `refresh` tokens. These can be generated with command `evcc token [name]`.
+      When configuring the vehicle, follow the link and sign in with your Peugeot account in the browser.
+      Then paste the code or the full redirect URL into the vehicle dialog.
 params:
   - preset: vehicle-common
   - preset: vehicle-online
   - name: user
     required: true
+  - name: country
+    default: de
+    description:
+      de: Ländercode
+      en: Country code
   - name: password
     deprecated: true
   - name: accessToken
-    required: true
+    advanced: true
   - name: refreshToken
-    required: true
+    advanced: true
   - name: vin
     example: V...
   - name: cache
     default: 15m
+auth:
+  type: peugeot
+  params: [user, country]
 render: |
   type: peugeot
   vin: {{ .vin }}
   user: {{ .user }}
+  country: {{ .country }}
   tokens:
     access: {{ .accessToken }}
     refresh: {{ .refreshToken }}

--- a/templates/definition/vehicle/peugeot.yaml
+++ b/templates/definition/vehicle/peugeot.yaml
@@ -31,7 +31,7 @@ params:
     default: 15m
 auth:
   type: peugeot
-  params: [user, country]
+  params: [user, country, accessToken, refreshToken]
 render: |
   type: peugeot
   vin: {{ .vin }}

--- a/tests/config-vehicle-psa.spec.ts
+++ b/tests/config-vehicle-psa.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { start, stop, baseUrl } from "./evcc";
+import { expectModalVisible } from "./utils";
+
+test.use({ baseURL: baseUrl() });
+test.beforeEach(async () => {
+  await start(undefined, undefined, ["--disable-auth"]);
+});
+test.afterEach(async () => {
+  await stop();
+});
+
+test.describe("PSA login", () => {
+  for (const brand of ["Citroën", "DS", "Opel", "Peugeot"]) {
+    test(brand, async ({ page }) => {
+      await page.goto("/#/config");
+      await page.getByTestId("add-vehicle").click();
+      const modal = page.getByTestId("vehicle-modal");
+      await expectModalVisible(modal);
+      await modal.getByLabel("Manufacturer").selectOption(brand);
+      await expect(modal.getByLabel("Country code")).toHaveValue("de");
+      await modal.getByLabel("Country code").fill("gb");
+      await modal.getByLabel("Username").fill("driver@example.com");
+      await modal.getByRole("button", { name: "Prepare connection" }).click();
+
+      const login = modal.getByRole("link", { name: "Open login page" });
+      await expect(login).toBeVisible();
+      const href = await login.getAttribute("href");
+      expect(new URL(href!).searchParams.get("redirect_uri")).toMatch(/\/gb$/);
+      await expect(
+        modal.getByLabel("Paste the code or the address of the page you were redirected to.")
+      ).toBeVisible();
+      await expect(modal.getByRole("button", { name: "Validate & save" })).not.toBeVisible();
+    });
+  }
+});

--- a/vehicle/psa.go
+++ b/vehicle/psa.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/vehicle/psa"
+	"golang.org/x/oauth2"
 )
 
 // https://github.com/TA2k/ioBroker.psa
@@ -55,38 +56,49 @@ func newPSA(brand, realm string, other map[string]any) (api.Vehicle, error) {
 		return nil, api.ErrMissingCredentials
 	}
 
-	token, err := cc.Tokens.Token()
-	if err != nil {
-		return nil, err
-	}
-
-	v := &PSA{
-		embed: &cc.embed,
-	}
-
 	log := util.NewLogger(brand)
 	log.Redact(cc.User, cc.Tokens.Access, cc.Tokens.Refresh)
 
-	oc := psa.Oauth2Config(brand, strings.ToLower(cc.Country))
-	identity, err := psa.NewIdentity(log, brand, cc.User, oc, token)
+	// optional seed token from `evcc token` (login happens in the ui)
+	var seed *oauth2.Token
+	if token, err := cc.Tokens.Token(); err == nil {
+		seed = token
+	}
+
+	identity, err := psa.NewIdentity(log, brand, cc.User, strings.ToLower(cc.Country), seed)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO still needed?
-	api := psa.NewAPI(log, identity, realm, oc.ClientID)
+	api := psa.NewAPI(log, identity, realm, identity.ClientID())
 
-	vehicle, err := ensureVehicleEx(
-		cc.VIN, api.Vehicles,
-		func(v psa.Vehicle) (string, error) {
-			return v.VIN, nil
-		},
-	)
-	if err != nil {
-		return nil, err
+	// resolved on first use so the vehicle can be created before login
+	var vid string
+	resolve := func() (string, error) {
+		if vid != "" {
+			return vid, nil
+		}
+
+		vehicle, err := ensureVehicleEx(
+			cc.VIN, api.Vehicles,
+			func(v psa.Vehicle) (string, error) {
+				return v.VIN, nil
+			},
+		)
+		if err != nil {
+			return "", err
+		}
+
+		vid = vehicle.ID
+
+		return vid, nil
 	}
 
-	v.Provider = psa.NewProvider(api, vehicle.ID, cc.Cache)
+	v := &PSA{
+		embed:    &cc.embed,
+		Provider: psa.NewProvider(api, resolve, cc.Cache),
+	}
 
-	return v, err
+	return v, nil
 }

--- a/vehicle/psa/helper.go
+++ b/vehicle/psa/helper.go
@@ -2,19 +2,17 @@ package psa
 
 import (
 	"sync"
-
-	"golang.org/x/oauth2"
 )
 
 var (
 	mu         sync.Mutex
-	identities = make(map[string]oauth2.TokenSource)
+	identities = make(map[string]*Identity)
 )
 
-func getInstance(subject string) oauth2.TokenSource {
+func getInstance(subject string) *Identity {
 	return identities[subject]
 }
 
-func addInstance(subject string, identity oauth2.TokenSource) {
+func addInstance(subject string, identity *Identity) {
 	identities[subject] = identity
 }

--- a/vehicle/psa/identity.go
+++ b/vehicle/psa/identity.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evcc-io/evcc/plugin/auth"
 	"github.com/evcc-io/evcc/server/providerauth"
 	"github.com/evcc-io/evcc/util"
+	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
@@ -29,7 +30,8 @@ func init() {
 	for brand := range brandNames {
 		auth.Register(brand, func(other map[string]any) (oauth2.TokenSource, error) {
 			var cc struct {
-				User, Country string
+				User, Country             string
+				AccessToken, RefreshToken string
 			}
 			if err := util.DecodeOther(other, &cc); err != nil {
 				return nil, err
@@ -37,7 +39,12 @@ func init() {
 			if cc.User == "" {
 				return nil, api.ErrMissingCredentials
 			}
-			return NewIdentity(util.NewLogger(brand), brand, cc.User, cc.Country, nil)
+			tokens := oauth.Tokens{Access: cc.AccessToken, Refresh: cc.RefreshToken}
+			var seed *oauth2.Token
+			if token, err := tokens.Token(); err == nil {
+				seed = token
+			}
+			return NewIdentity(util.NewLogger(brand), brand, cc.User, cc.Country, seed)
 		})
 	}
 }
@@ -97,6 +104,11 @@ func NewIdentity(log *util.Logger, brand, user, country string, seed *oauth2.Tok
 			instance.pending = nil
 		}
 		instance.loginMu.Unlock()
+		instance.mu.Lock()
+		if instance.token == nil && seed != nil && seed.RefreshToken != "" && !settings.Exists(subject) {
+			instance.update(seed)
+		}
+		instance.mu.Unlock()
 		return instance, nil
 	}
 

--- a/vehicle/psa/identity.go
+++ b/vehicle/psa/identity.go
@@ -2,55 +2,312 @@ package psa
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/url"
 	"strings"
+	"sync"
 
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/db/settings"
+	"github.com/evcc-io/evcc/plugin/auth"
+	"github.com/evcc-io/evcc/server/providerauth"
 	"github.com/evcc-io/evcc/util"
-	"github.com/evcc-io/evcc/util/oauth"
 	"github.com/evcc-io/evcc/util/request"
 	"golang.org/x/oauth2"
 )
 
-type Identity struct {
-	oauth2.TokenSource
-	oc      *oauth2.Config
-	log     *util.Logger
-	subject string
+// brandNames maps the registry name to the name shown in the ui
+var brandNames = map[string]string{
+	"citroen": "Citroën",
+	"ds":      "DS",
+	"opel":    "Opel",
+	"peugeot": "Peugeot",
 }
 
-// NewIdentity creates PSA identity
-func NewIdentity(log *util.Logger, brand, user string, oc *oauth2.Config, token *oauth2.Token) (oauth2.TokenSource, error) {
+func init() {
+	for brand := range brandNames {
+		auth.Register(brand, func(other map[string]any) (oauth2.TokenSource, error) {
+			var cc struct {
+				User, Country string
+			}
+			if err := util.DecodeOther(other, &cc); err != nil {
+				return nil, err
+			}
+			if cc.User == "" {
+				return nil, api.ErrMissingCredentials
+			}
+			return NewIdentity(util.NewLogger(brand), brand, cc.User, cc.Country, nil)
+		})
+	}
+}
+
+// pendingLogin is an interactive login waiting for the user-supplied code
+type pendingLogin struct {
+	oc       *oauth2.Config
+	verifier string
+}
+
+// Identity is the PSA auth provider. Login is interactive rather than a
+// redirect flow: the identity provider only accepts the mobile app's private
+// url scheme as redirect uri, so the user signs in in their own browser and
+// pastes the authorization code back into evcc.
+type Identity struct {
+	mu      sync.Mutex
+	log     *util.Logger
+	oc      *oauth2.Config
+	ctx     context.Context
+	brand   string
+	user    string
+	country string
+	subject string
+	token   *oauth2.Token
+	onlineC chan<- bool
+
+	loginMu sync.Mutex
+	pending *pendingLogin
+}
+
+var (
+	_ api.AuthProvider   = (*Identity)(nil)
+	_ api.AuthChallenger = (*Identity)(nil)
+	_ oauth2.TokenSource = (*Identity)(nil)
+)
+
+// NewIdentity creates the PSA identity for brand and user, registering it with
+// evcc's provider-auth handler on first creation. A non-nil seed token (e.g.
+// from `evcc token` in the config) is used when the database has none yet.
+func NewIdentity(log *util.Logger, brand, user, country string, seed *oauth2.Token) (*Identity, error) {
 	// serialise instance handling
 	mu.Lock()
 	defer mu.Unlock()
 
+	log.Redact(user)
+	country = strings.ToLower(strings.TrimSpace(country))
+	if country == "" {
+		country = "de"
+	}
+
 	// reuse identity instance
 	subject := "psa." + strings.ToLower(brand) + "." + strings.ToLower(user)
 	if instance := getInstance(subject); instance != nil {
+		instance.loginMu.Lock()
+		if instance.country != country {
+			instance.country = country
+			instance.pending = nil
+		}
+		instance.loginMu.Unlock()
 		return instance, nil
 	}
 
+	// the context outlives the caller, hence it must not be request-scoped
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, request.NewClient(log))
+
 	v := &Identity{
 		log:     log,
-		oc:      oc,
+		oc:      Oauth2Config(brand, country),
+		ctx:     ctx,
+		brand:   brand,
+		user:    user,
+		country: country,
 		subject: subject,
 	}
 
-	ts, err := oauth.PersistentTokenSource(log, v.subject, token, v.refreshToken)
+	// load persisted token, else fall back to the seed token
+	var token oauth2.Token
+	if settings.Exists(subject) {
+		if err := settings.Json(subject, &token); err != nil {
+			return nil, err
+		}
+	} else if seed != nil && seed.RefreshToken != "" {
+		token = *seed
+	}
+
+	if token.RefreshToken != "" {
+		v.token = &token
+		log.Redact(token.AccessToken, token.RefreshToken)
+		if !settings.Exists(subject) {
+			v.persist(&token)
+		}
+	}
+
+	onlineC, err := providerauth.Register(subject, v)
 	if err != nil {
 		return nil, err
 	}
-
-	v.TokenSource = ts
+	v.onlineC = onlineC
+	v.setOnline(v.token.Valid())
 
 	// add instance
-	addInstance(v.subject, v)
+	addInstance(subject, v)
 
 	return v, nil
 }
 
-func (v *Identity) refreshToken(token *oauth2.Token) (*oauth2.Token, error) {
-	client := request.NewClient(v.log)
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+// ClientID returns the brand's oauth client id
+func (v *Identity) ClientID() string {
+	return v.oc.ClientID
+}
 
-	return v.oc.TokenSource(ctx, token).Token()
+// Token implements oauth2.TokenSource
+func (v *Identity) Token() (*oauth2.Token, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if v.token == nil {
+		return nil, api.LoginRequiredError(v.subject)
+	}
+
+	if v.token.Valid() {
+		return v.token, nil
+	}
+
+	token, err := v.oc.TokenSource(v.ctx, v.token).Token()
+	if err != nil {
+		if strings.Contains(err.Error(), "invalid_grant") {
+			v.reset()
+			return nil, api.LoginRequiredError(v.subject)
+		}
+		return nil, err
+	}
+
+	v.update(token)
+
+	return token, nil
+}
+
+// StartChallenge implements api.AuthChallenger.
+func (v *Identity) StartChallenge() (*api.AuthChallenge, error) {
+	v.loginMu.Lock()
+	defer v.loginMu.Unlock()
+
+	if v.pending == nil {
+		v.pending = &pendingLogin{
+			oc:       Oauth2Config(v.brand, v.country),
+			verifier: oauth2.GenerateVerifier(),
+		}
+	}
+
+	return &api.AuthChallenge{
+		Kind: api.AuthChallengeCode,
+		Link: v.pending.oc.AuthCodeURL("", oauth2.S256ChallengeOption(v.pending.verifier)),
+	}, nil
+}
+
+// SubmitChallenge implements api.AuthChallenger.
+func (v *Identity) SubmitChallenge(answer string) (*api.AuthChallenge, error) {
+	v.loginMu.Lock()
+	defer v.loginMu.Unlock()
+
+	if v.pending == nil {
+		return nil, errors.New("no pending login")
+	}
+
+	code := authCode(answer)
+	if code == "" {
+		return nil, errors.New("missing authorization code")
+	}
+
+	token, err := v.pending.oc.Exchange(v.ctx, code, oauth2.VerifierOption(v.pending.verifier))
+	if err != nil {
+		return nil, err
+	}
+
+	v.pending = nil
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.update(token)
+
+	return nil, nil
+}
+
+// Login implements api.AuthProvider. PSA uses the interactive login instead.
+func (v *Identity) Login(string) (string, *oauth2.DeviceAuthResponse, error) {
+	return "", nil, api.ErrNotAvailable
+}
+
+// HandleCallback implements api.AuthProvider. PSA uses the interactive login instead.
+func (v *Identity) HandleCallback(url.Values) error {
+	return api.ErrNotAvailable
+}
+
+// Logout implements api.AuthProvider
+func (v *Identity) Logout() error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	v.reset()
+
+	return nil
+}
+
+// Authenticated implements api.AuthProvider
+func (v *Identity) Authenticated() bool {
+	token, err := v.Token()
+	return err == nil && token.Valid()
+}
+
+// DisplayName implements api.AuthProvider
+func (v *Identity) DisplayName() string {
+	name, ok := brandNames[v.brand]
+	if !ok {
+		name = v.brand
+	}
+	return fmt.Sprintf("%s (%s)", name, v.user)
+}
+
+// reset drops the token. Caller must hold v.mu.
+func (v *Identity) reset() {
+	v.token = nil
+
+	if settings.Exists(v.subject) {
+		if err := settings.Delete(v.subject); err != nil {
+			v.log.ERROR.Println(err)
+		}
+	}
+
+	v.setOnline(false)
+}
+
+// update stores the token and signals online status. Caller must hold v.mu.
+func (v *Identity) update(token *oauth2.Token) {
+	v.token = token
+	v.persist(token)
+	v.setOnline(token.Valid())
+}
+
+func (v *Identity) persist(token *oauth2.Token) {
+	v.log.Redact(token.AccessToken, token.RefreshToken)
+
+	if err := settings.SetJson(v.subject, token); err != nil {
+		v.log.ERROR.Printf("saving token: %v", err)
+		return
+	}
+
+	// flush immediately so the token survives a restart right after login
+	if err := settings.Persist(); err != nil {
+		v.log.ERROR.Printf("persisting token: %v", err)
+	}
+}
+
+// setOnline signals the auth handler without blocking (a blocking send under
+// v.mu would deadlock via Authenticated()->Token()).
+func (v *Identity) setOnline(online bool) {
+	select {
+	case v.onlineC <- online:
+	default:
+	}
+}
+
+// authCode accepts either the bare authorization code or the full redirect url
+// the user was sent to
+func authCode(s string) string {
+	s = strings.TrimSpace(s)
+
+	if u, err := url.Parse(s); err == nil && u.Query().Has("code") {
+		return u.Query().Get("code")
+	}
+
+	return s
 }

--- a/vehicle/psa/identity_test.go
+++ b/vehicle/psa/identity_test.go
@@ -109,3 +109,26 @@ func TestSubmitChallenge(t *testing.T) {
 	require.NoError(t, settings.Json(v.subject, &token))
 	assert.Equal(t, "refresh", token.RefreshToken)
 }
+
+func TestAuthSeedAfterPrepare(t *testing.T) {
+	config := map[string]any{"user": t.Name() + "@example.com", "country": "de"}
+	ts, err := auth.NewFromConfig(context.Background(), "peugeot", config)
+	require.NoError(t, err)
+	v := ts.(*Identity)
+	t.Cleanup(func() { settings.SetString(v.subject, "") })
+	require.Nil(t, v.token)
+
+	config["refreshToken"] = "seed"
+	reused, err := auth.NewFromConfig(context.Background(), "peugeot", config)
+	require.NoError(t, err)
+	assert.Same(t, v, reused)
+	var token oauth2.Token
+	require.NoError(t, settings.Json(v.subject, &token))
+	assert.Equal(t, "seed", token.RefreshToken)
+
+	config["refreshToken"] = "stale"
+	_, err = auth.NewFromConfig(context.Background(), "peugeot", config)
+	require.NoError(t, err)
+	require.NoError(t, settings.Json(v.subject, &token))
+	assert.Equal(t, "seed", token.RefreshToken)
+}

--- a/vehicle/psa/identity_test.go
+++ b/vehicle/psa/identity_test.go
@@ -1,0 +1,111 @@
+package psa
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/db/settings"
+	"github.com/evcc-io/evcc/plugin/auth"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestAuthCode(t *testing.T) {
+	tc := []struct {
+		in, out string
+	}{
+		{"abc", "abc"},
+		{"  abc  ", "abc"},
+		{"mymap://oauth2redirect/de?code=abc&scope=openid%20profile", "abc"},
+		{"mymap://oauth2redirect/de", "mymap://oauth2redirect/de"},
+	}
+
+	for _, tc := range tc {
+		assert.Equal(t, tc.out, authCode(tc.in), tc.in)
+	}
+}
+
+func TestAuthChallenge(t *testing.T) {
+	for brand := range brandNames {
+		t.Run(brand, func(t *testing.T) {
+			config := map[string]any{"user": t.Name() + "@example.com", "country": " FR "}
+			ts, err := auth.NewFromConfig(context.Background(), brand, config)
+			require.NoError(t, err)
+			identity := ts.(*Identity)
+			_, err = identity.Token()
+			require.Error(t, err)
+			assert.Equal(t, api.LoginRequiredError(identity.subject), err)
+
+			challenge, err := identity.StartChallenge()
+			require.NoError(t, err)
+			assert.Equal(t, api.AuthChallengeCode, challenge.Kind)
+			link, err := url.Parse(challenge.Link)
+			require.NoError(t, err)
+			assert.Equal(t, Oauth2Config(brand, "fr").RedirectURL, link.Query().Get("redirect_uri"))
+			assert.Equal(t, "S256", link.Query().Get("code_challenge_method"))
+			assert.NotEmpty(t, link.Query().Get("code_challenge"))
+
+			again, err := identity.StartChallenge()
+			require.NoError(t, err)
+			assert.Equal(t, challenge, again)
+
+			config["country"] = "gb"
+			reused, err := auth.NewFromConfig(context.Background(), brand, config)
+			require.NoError(t, err)
+			assert.Same(t, identity, reused)
+			changed, err := identity.StartChallenge()
+			require.NoError(t, err)
+			assert.NotEqual(t, challenge.Link, changed.Link)
+			link, err = url.Parse(changed.Link)
+			require.NoError(t, err)
+			assert.Equal(t, Oauth2Config(brand, "gb").RedirectURL, link.Query().Get("redirect_uri"))
+		})
+	}
+}
+
+func TestSubmitChallenge(t *testing.T) {
+	v := &Identity{
+		log: util.NewLogger("test"), ctx: context.Background(),
+		brand: "peugeot", country: "de", subject: "test." + t.Name(),
+	}
+	t.Cleanup(func() { settings.SetString(v.subject, "") })
+	_, err := v.SubmitChallenge("code")
+	require.EqualError(t, err, "no pending login")
+	_, err = v.StartChallenge()
+	require.NoError(t, err)
+
+	_, err = v.SubmitChallenge(" ")
+	require.EqualError(t, err, "missing authorization code")
+	verifier := v.pending.verifier
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		assert.Equal(t, verifier, r.Form.Get("code_verifier"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("code") != "valid" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"access","refresh_token":"refresh","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	v.pending.oc.Endpoint.TokenURL = srv.URL
+
+	_, err = v.SubmitChallenge("invalid")
+	require.Error(t, err)
+	require.NotNil(t, v.pending)
+	challenge, err := v.SubmitChallenge("mymap://oauth2redirect/de?code=valid")
+	require.NoError(t, err)
+	assert.Nil(t, challenge)
+	assert.Nil(t, v.pending)
+	assert.True(t, v.Authenticated())
+	var token oauth2.Token
+	require.NoError(t, settings.Json(v.subject, &token))
+	assert.Equal(t, "refresh", token.RefreshToken)
+}

--- a/vehicle/psa/provider.go
+++ b/vehicle/psa/provider.go
@@ -13,11 +13,16 @@ type Provider struct {
 	statusG func() (Status, error)
 }
 
-// NewProvider creates a vehicle api provider
-func NewProvider(api *API, vid string, cache time.Duration) *Provider {
+// NewProvider creates a vehicle api provider. The vehicle id is resolved
+// lazily since it requires an authenticated api call.
+func NewProvider(api *API, vid func() (string, error), cache time.Duration) *Provider {
 	impl := &Provider{
 		statusG: util.Cached(func() (Status, error) {
-			return api.Status(vid)
+			id, err := vid()
+			if err != nil {
+				return Status{}, err
+			}
+			return api.Status(id)
 		}, cache),
 	}
 	return impl


### PR DESCRIPTION
Depends on #31232. Must not be merged before it.

Moves PSA login (Citroën, DS, Opel, Peugeot) from `evcc token [name]` into the config UI, using the shared challenge flow from #31232. The base branch `porsche-connect` mirrors that PR at `6e7492929`; retarget to master after it merges.

The PSA identity provider only accepts the brand app's private redirect URI and protects its login page with reCAPTCHA, so users sign in in their own browser and paste the authorization code or full redirect URL back into the vehicle dialog.

- Configure the account and country before opening the browser login; reconnect through the existing authorization status card.
- Keep tokens persisted per brand and user under the existing settings key. Optional legacy tokens remain available as initial seeds, including during setup.
- Resolve the vehicle ID on first use so an account awaiting login does not prevent device construction.
- Show pending login separately from failed device validation, and link the authorization menu entry to integrations.

🤖 Generated with [OpenCode](https://opencode.ai)
