### PR TITLE
chore: narrow site interface used by loadpoint

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -22,7 +22,6 @@ import (
 	"github.com/evcc-io/evcc/core/planner"
 	"github.com/evcc-io/evcc/core/session"
 	"github.com/evcc-io/evcc/core/settings"
-	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/core/soc"
 	"github.com/evcc-io/evcc/core/wrapper"
 	"github.com/evcc-io/evcc/messenger"
@@ -77,12 +76,21 @@ const pollInterval = 60 * time.Minute
 // Task is the task type
 type Task = func()
 
+// siteAPI is the subset of site.API the loadpoint depends on
+type siteAPI interface {
+	Optimize()
+	GetBatterySoc() float64
+	GetBatteryMaxDischargePower() *float64
+	GetResidualPower() float64
+	GetTariff(api.TariffUsage) api.Tariff
+}
+
 // Loadpoint is responsible for controlling charge depending on
 // Soc needs and power availability.
 type Loadpoint struct {
 	clock    clock.Clock // mockable time
 	bus      evbus.Bus   // event bus
-	site     site.API
+	site     siteAPI
 	pushChan chan<- messenger.Event // notifications
 	uiChan   chan<- util.Param      // client push messages
 	lpChan   chan<- *Loadpoint      // update requests
@@ -707,7 +715,7 @@ func (lp *Loadpoint) defaultMode() {
 }
 
 // Prepare loadpoint configuration by adding missing helper elements
-func (lp *Loadpoint) Prepare(site site.API, uiChan chan<- util.Param, pushChan chan<- messenger.Event, lpChan chan<- *Loadpoint) {
+func (lp *Loadpoint) Prepare(site siteAPI, uiChan chan<- util.Param, pushChan chan<- messenger.Event, lpChan chan<- *Loadpoint) {
 	lp.site = site
 	lp.uiChan = uiChan
 	lp.pushChan = pushChan

--- a/core/loadpoint_boost_test.go
+++ b/core/loadpoint_boost_test.go
@@ -6,21 +6,26 @@ import (
 
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/settings"
-	"github.com/evcc-io/evcc/core/site"
 	"github.com/evcc-io/evcc/util"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
+var _ siteAPI = (*mockSite)(nil)
+
 type mockSite struct {
-	site.API
 	maxDischargePower *float64
 	residualPower     float64
+	batterySoc        float64
 	optimized         int
 }
 
 func (m *mockSite) Optimize() {
 	m.optimized++
+}
+
+func (m *mockSite) GetBatterySoc() float64 {
+	return m.batterySoc
 }
 
 func (m *mockSite) GetBatteryMaxDischargePower() *float64 {
@@ -29,6 +34,10 @@ func (m *mockSite) GetBatteryMaxDischargePower() *float64 {
 
 func (m *mockSite) GetResidualPower() float64 {
 	return m.residualPower
+}
+
+func (m *mockSite) GetTariff(api.TariffUsage) api.Tariff {
+	return nil
 }
 
 func TestBoostPower(t *testing.T) {


### PR DESCRIPTION
The loadpoint holds the site as `site.API`, an interface with 48 methods. It calls five of them: `Optimize`, `GetBatterySoc`, `GetBatteryMaxDischargePower`, `GetResidualPower` and `GetTariff`.

Declaring the dependency at its real width makes it visible what a loadpoint actually needs from its site, and removes the need for test doubles to embed a nil `site.API` just to satisfy the compiler. `Site` keeps satisfying it structurally, so nothing changes at the call site.

- new unexported `siteAPI` in `core`, used for the loadpoint field and the `Prepare` parameter
- the boost test double implements the five methods explicitly instead of embedding `site.API`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
