### PR TITLE
chore: extract optimizer slot math into core/slots

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/metrics"
+	"github.com/evcc-io/evcc/core/slots"
 	"github.com/evcc-io/evcc/core/types"
 	"github.com/evcc-io/evcc/hems/hems"
 	"github.com/evcc-io/evcc/messenger"
@@ -26,7 +27,6 @@ import (
 	optimizer "github.com/evcc-io/optimizer/client"
 	"github.com/jinzhu/now"
 	"github.com/samber/lo"
-	"golang.org/x/exp/constraints"
 )
 
 const (
@@ -409,10 +409,10 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 	var details requestDetails
 
 	solarTariff := site.GetTariff(api.TariffUsageSolar)
-	solar := currentRates(solarTariff)
+	solar := slots.CurrentRates(solarTariff)
 
-	grid := currentRates(site.GetTariff(api.TariffUsageGrid))
-	feedIn := currentRates(site.GetTariff(api.TariffUsageFeedIn))
+	grid := slots.CurrentRates(site.GetTariff(api.TariffUsageGrid))
+	feedIn := slots.CurrentRates(site.GetTariff(api.TariffUsageFeedIn))
 
 	minLen := lo.Min([]int{len(grid), len(feedIn)})
 	// exclude empty solar forecast from minLen
@@ -421,7 +421,7 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 	}
 
 	if optimizerURI() == OPTIMIZER_URI {
-		minLen = slotsUntil(grid, optimizerHorizon(time.Now()), minLen)
+		minLen = slots.Until(grid, slots.Horizon(time.Now()), minLen)
 	}
 
 	if expectedSlots := 8; minLen < expectedSlots {
@@ -432,7 +432,7 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 	}
 
 	now := time.Now()
-	dt := timeSteps(minLen, now)
+	dt := slots.TimeSteps(minLen, now)
 	firstSlotDuration := time.Duration(dt[0]) * time.Second
 
 	site.log.DEBUG.Printf("optimizer: optimizing %d slots until %v: grid=%d, feedIn=%d, solar=%d, first slot: %v",
@@ -450,7 +450,7 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 	// blend measured energy of the last metrics slot into the first slots
 	if v := site.measuredSlotEnergy(metrics.Home); v > 0 {
 		orig := slices.Clone(gt[:min(optimizerDecaySlots, len(gt))])
-		blendMeasured(gt, v, optimizerDecaySlots)
+		slots.BlendMeasured(gt, v, optimizerDecaySlots)
 		site.log.DEBUG.Printf("optimizer: home slots updated with measured %.0fWh: %.0f -> %.0f", v, orig, gt[:len(orig)])
 	}
 
@@ -463,15 +463,15 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 		}
 
 		scale := site.effectiveSolarScale()
-		ftSlots := scaleAndPrune(solarEnergy, scale, minLen)
+		ftSlots := slots.ScaleAndPrune(solarEnergy, scale, minLen)
 
 		// decay the scale derived from measured vs forecasted energy of the last completed slot
 		if pv, fcst := site.measuredSlotEnergy(site.Meters.PVMetersRef...), site.measuredSlotEnergy(metrics.Forecast)*scale; pv > 0 && fcst > 0 {
 			orig := slices.Clone(ftSlots[:min(optimizerDecaySlots, len(ftSlots))])
-			blendScale(ftSlots, pv/fcst, optimizerDecaySlots)
+			slots.BlendScale(ftSlots, pv/fcst, optimizerDecaySlots)
 			site.log.DEBUG.Printf("optimizer: pv slots updated with scale %.2f: %.0f -> %.0f", pv/fcst, orig, ftSlots[:len(orig)])
 		}
-		ft = prorate(ftSlots, firstSlotDuration)
+		ft = slots.Prorate(ftSlots, firstSlotDuration)
 	}
 
 	req = optimizer.OptimizationInput{
@@ -483,10 +483,10 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 		EtaD: eta,
 		TimeSeries: optimizer.TimeSeries{
 			Dt: dt,
-			Gt: prorate(gt, firstSlotDuration),
+			Gt: slots.Prorate(gt, firstSlotDuration),
 			Ft: ft,
-			PN: scaleAndPrune(grid, 0.001, minLen),
-			PE: scaleAndPrune(feedIn, 0.001, minLen),
+			PN: slots.ScaleAndPrune(grid, 0.001, minLen),
+			PE: slots.ScaleAndPrune(feedIn, 0.001, minLen),
 		},
 	}
 
@@ -494,7 +494,7 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 	pa := lo.Min(req.TimeSeries.PN) * eta * 0.99
 
 	details = requestDetails{
-		Timestamps: asTimestamps(dt, now),
+		Timestamps: slots.AsTimestamps(dt, now),
 	}
 
 	if site.circuit != nil {
@@ -549,11 +549,11 @@ func (site *Site) optimizerRequest(battery []types.Measurement) (optimizer.Optim
 	// without a capacity there is no fill point to assert it any further.
 	if unmodelled > 0 {
 		load := make([]float64, minLen)
-		blendMeasured(load, unmodelled/slotsPerHour, optimizerDecaySlots)
+		slots.BlendMeasured(load, unmodelled/slotsPerHour, optimizerDecaySlots)
 
 		site.log.DEBUG.Printf("optimizer: home slots updated with unmodelled %.0fW loadpoint load: %.0f", unmodelled, load[:min(optimizerDecaySlots, len(load))])
 
-		for i, v := range prorate(load, firstSlotDuration) {
+		for i, v := range slots.Prorate(load, firstSlotDuration) {
 			req.TimeSeries.Gt[i] += v
 		}
 	}
@@ -654,10 +654,10 @@ func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details 
 
 		batteries = append(batteries, batteryResult{
 			batteryDetail: detail,
-			Full: matchSoc(batRes.StateOfCharge, func(soc float32) bool {
+			Full: slots.MatchSoc(batRes.StateOfCharge, func(soc float32) bool {
 				return soc >= batReq.SMax
 			}),
-			Empty: matchSoc(batRes.StateOfCharge, func(soc float32) bool {
+			Empty: slots.MatchSoc(batRes.StateOfCharge, func(soc float32) bool {
 				return soc <= batReq.SMin
 			}),
 		})
@@ -786,7 +786,7 @@ func (site *Site) loadpointRequest(lp loadpoint.API, minLen int, firstSlotDurati
 	}
 
 	if profile := loadpointProfile(lp, minLen); profile != nil {
-		bat.PDemand = prorate(profile, firstSlotDuration)
+		bat.PDemand = slots.Prorate(profile, firstSlotDuration)
 	}
 
 	detail := batteryDetail{
@@ -858,7 +858,7 @@ func (site *Site) loadpointRequest(lp loadpoint.API, minLen int, firstSlotDurati
 
 	if demand != nil {
 		// after prorate, so the shortened first slot counts with the energy it really carries
-		bat.PDemand = clearDemandWhenFull(prorate(demand, firstSlotDuration), bat.SMax-bat.SInitial)
+		bat.PDemand = clearDemandWhenFull(slots.Prorate(demand, firstSlotDuration), bat.SMax-bat.SInitial)
 	}
 
 	return bat, detail
@@ -930,22 +930,11 @@ func (site *Site) batteryRequest(dev config.Device[api.Meter], b types.Measureme
 	// tariff forecast-based grid charging demand
 	if bat.ChargeFromGrid {
 		if demand := site.applyBatteryGridChargeLimit(bat.CMax, grid, minLen); demand != nil {
-			bat.PDemand = prorate(demand, firstSlotDuration)
+			bat.PDemand = slots.Prorate(demand, firstSlotDuration)
 		}
 	}
 
 	return bat, detail
-}
-
-func matchSoc(ts []float32, fun func(float32) bool) time.Time {
-	for i, soc := range ts {
-		if fun(soc) {
-			// TODO first slot
-			return time.Now().Add(time.Duration(i+1) * tariff.SlotDuration).Round(time.Second)
-		}
-	}
-
-	return time.Time{}
 }
 
 // continuousDemand creates a slice of power demands depending on loadpoint mode
@@ -1019,12 +1008,12 @@ func (site *Site) homeProfile(minLen int) ([]float64, error) {
 	}
 
 	// max 4 days
-	slots := make([]float64, 0, minLen+1)
-	for len(slots) <= minLen+24*4 { // allow for prorating first day
-		slots = append(slots, profile[:]...)
+	profileSlots := make([]float64, 0, minLen+1)
+	for len(profileSlots) <= minLen+24*4 { // allow for prorating first day
+		profileSlots = append(profileSlots, profile[:]...)
 	}
 
-	res := profileSlotsFromNow(slots)
+	res := slots.FromNow(profileSlots)
 	if len(res) < minLen {
 		return nil, fmt.Errorf("minimum home profile length %d is less than required %d", len(res), minLen)
 	}
@@ -1036,13 +1025,6 @@ func (site *Site) homeProfile(minLen int) ([]float64, error) {
 	return lo.Map(res, func(v float64, i int) float64 {
 		return v * 1e3
 	}), nil
-}
-
-// profileSlotsFromNow strips away any slots before "now".
-// The profile contains 48 15min slots (00:00-23:45) that repeat for multiple days.
-func profileSlotsFromNow(profile []float64) []float64 {
-	firstSlot := int(time.Now().Truncate(tariff.SlotDuration).Sub(now.BeginningOfDay()) / tariff.SlotDuration)
-	return profile[firstSlot:]
 }
 
 // measuredSlotEnergy returns the summed energy in Wh of the last completed
@@ -1065,39 +1047,6 @@ func (site *Site) measuredSlotEnergy(refs ...string) float64 {
 	return sum * 1e3
 }
 
-// blendMeasured decays the first slots from the measured value into the
-// forecast. Slot 0 uses the measured value, the forecast takes over from
-// slot decaySlots on.
-func blendMeasured[T constraints.Float](slots []T, measured T, decaySlots int) {
-	for i := range min(decaySlots, len(slots)) {
-		w := T(decaySlots-i) / T(decaySlots)
-		slots[i] = w*measured + (1-w)*slots[i]
-	}
-}
-
-// blendScale decays a scale factor towards 1 over the first slots.
-// Slot 0 is scaled by the full factor, from slot decaySlots on it is 1.
-func blendScale[T constraints.Float](slots []T, scale float64, decaySlots int) {
-	for i := range min(decaySlots, len(slots)) {
-		w := float64(decaySlots-i) / float64(decaySlots)
-		slots[i] = T(float64(slots[i]) * (w*scale + (1 - w)))
-	}
-}
-
-// prorate adjusts the first slot's energy amount according to remaining duration
-func prorate[T constraints.Float](slots []T, firstSlotDuration time.Duration) []float32 {
-	// return empty slice instead of nil to make api happy
-	if len(slots) == 0 {
-		return []float32{}
-	}
-
-	res := slices.Clone(slots)
-	res[0] = res[0] * T(firstSlotDuration) / T(tariff.SlotDuration)
-	return lo.Map(res, func(f T, _ int) float32 {
-		return float32(f)
-	})
-}
-
 func solarRatesToEnergy(rr api.Rates) (api.Rates, error) {
 	res := make(api.Rates, 0, len(rr))
 
@@ -1115,85 +1064,6 @@ func solarRatesToEnergy(rr api.Rates) (api.Rates, error) {
 	}
 
 	return res, nil
-}
-
-func currentRates(tariff api.Tariff) api.Rates {
-	if tariff == nil {
-		return nil
-	}
-
-	rates, err := tariff.Rates()
-	if err != nil {
-		return nil
-	}
-
-	// filter past slots
-	now := time.Now()
-	return lo.Filter(rates, func(slot api.Rate, _ int) bool {
-		return slot.End.After(now)
-	})
-}
-
-// optimizerHorizon is the timeframe the hosted optimizer is limited to for sake
-// of performance: 48 hours, extended to the end of that day. In the early hours
-// the extension would add almost a full day, hence it only applies past 6:00.
-func optimizerHorizon(t time.Time) time.Time {
-	horizon := t.Add(48 * time.Hour)
-	if t.Hour() < 6 {
-		return horizon
-	}
-	return now.With(horizon).EndOfDay()
-}
-
-// slotsUntil limits maxLen to the slots starting before the given horizon
-func slotsUntil(rates api.Rates, horizon time.Time, maxLen int) int {
-	if i := slices.IndexFunc(rates[:min(maxLen, len(rates))], func(slot api.Rate) bool {
-		return slot.Start.After(horizon)
-	}); i >= 0 {
-		return i
-	}
-	return maxLen
-}
-
-func timeSteps(minLen int, now time.Time) []int {
-	res := make([]int, 0, minLen)
-
-	eos := now.Truncate(tariff.SlotDuration).Add(tariff.SlotDuration)
-	if d := eos.Sub(now); d > time.Second && d < tariff.SlotDuration {
-		res = append(res, int(d.Seconds()))
-	}
-
-	for i := len(res); i < minLen; i++ {
-		res = append(res, int(tariff.SlotDuration.Seconds())) // 15min slots
-	}
-
-	return res
-}
-
-func asTimestamps(dt []int, now time.Time) []time.Time {
-	res := make([]time.Time, 0, len(dt))
-
-	eos := now.Truncate(tariff.SlotDuration).Add(tariff.SlotDuration)
-	res = append(res, eos.Add(-time.Duration(dt[0])*time.Second))
-
-	for i := range len(dt) - 1 {
-		res = append(res, res[i].Add(time.Duration(dt[i])*time.Second))
-	}
-
-	return res
-}
-
-func scaleAndPrune(rates api.Rates, scale float64, maxLen int) []float32 {
-	res := make([]float32, 0, maxLen)
-
-	for _, slot := range rates {
-		res = append(res, float32(slot.Value*scale))
-		if len(res) >= maxLen {
-			break
-		}
-	}
-
-	return res
 }
 
 func (site *Site) applyPlanGoal(lp loadpoint.API, bat *optimizer.BatteryConfig, minLen int) {

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/evcc-io/evcc/api"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/types"
-	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
 	optimizer "github.com/evcc-io/optimizer/client"
@@ -28,30 +27,6 @@ func TestLoadpointProfile(t *testing.T) {
 
 	// expected slots: 0.25 kWh...
 	require.Equal(t, []float64{250, 250, 250, 250, 250, 250, 250, 50}, loadpointProfile(lp, 8))
-}
-
-func TestOptimizerHorizon(t *testing.T) {
-	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.Local)
-	horizon := optimizerHorizon(ts)
-
-	// 48h plus end of day
-	assert.Equal(t, time.Date(2025, 1, 3, 23, 59, 59, int(time.Second-time.Nanosecond), time.Local), horizon)
-
-	// before 6:00 the day is not extended
-	assert.Equal(t, time.Date(2025, 1, 3, 5, 30, 0, 0, time.Local),
-		optimizerHorizon(time.Date(2025, 1, 1, 5, 30, 0, 0, time.Local)))
-
-	rates := make(api.Rates, 0, 4*96)
-	for slot := ts.Truncate(tariff.SlotDuration); len(rates) < cap(rates); slot = slot.Add(tariff.SlotDuration) {
-		rates = append(rates, api.Rate{Start: slot, End: slot.Add(tariff.SlotDuration)})
-	}
-
-	// 4 days of slots from 10:30, capped at the last slot of Jan 3rd
-	assert.Equal(t, 246, slotsUntil(rates, horizon, len(rates)))
-	assert.Equal(t, time.Date(2025, 1, 3, 23, 45, 0, 0, time.Local), rates[245].Start)
-
-	// shorter forecast is not extended
-	assert.Equal(t, 8, slotsUntil(rates, horizon, 8))
 }
 
 func TestApplyPrecondition(t *testing.T) {
@@ -128,26 +103,6 @@ func TestLoadpointCurrentAction(t *testing.T) {
 			assert.Equal(t, tc.want, loadpointCurrentAction(lp))
 		})
 	}
-}
-
-func TestAsTimestamps(t *testing.T) {
-	// now is 10 minutes into a 15-minute slot
-	now := time.Date(2025, 1, 1, 12, 10, 0, 0, time.UTC)
-
-	// dt[0]=300 means first event is 300s (5min) before end of current slot
-	// dt[1..] just mark subsequent slot boundaries
-	dt := []int{60 * 5, 60 * 15, 60 * 15}
-
-	got := asTimestamps(dt, now)
-
-	// current slot: 12:00–12:15
-	// first timestamp: 12:15 - 5min = 12:10
-	// subsequent: 12:15, 12:30
-	assert.Equal(t, []time.Time{
-		time.Date(2025, 1, 1, 12, 10, 0, 0, time.UTC),
-		time.Date(2025, 1, 1, 12, 15, 0, 0, time.UTC),
-		time.Date(2025, 1, 1, 12, 30, 0, 0, time.UTC),
-	}, got)
 }
 
 func TestUnmodelledPower(t *testing.T) {
@@ -442,28 +397,6 @@ func TestGridExportLimit(t *testing.T) {
 
 	require.NoError(t, site.SetGridExportLimit(7000))
 	assert.Equal(t, 7000.0, site.GetGridExportLimit())
-}
-
-func TestBlendMeasured(t *testing.T) {
-	slots := []float64{100, 100, 100, 100, 100, 100}
-	blendMeasured(slots, 200, 4)
-	assert.Equal(t, []float64{200, 175, 150, 125, 100, 100}, slots)
-
-	// fewer slots than decay length
-	short := []float32{100, 100}
-	blendMeasured(short, 200, 4)
-	assert.Equal(t, []float32{200, 175}, short)
-}
-
-func TestBlendScale(t *testing.T) {
-	slots := []float32{100, 100, 100, 100, 100, 100}
-	blendScale(slots, 2, 4)
-	assert.Equal(t, []float32{200, 175, 150, 125, 100, 100}, slots)
-
-	// fewer slots than decay length
-	short := []float64{100, 100}
-	blendScale(short, 0.5, 4)
-	assert.Equal(t, []float64{50, 62.5}, short)
 }
 
 func TestCurrentSlotSuggestion(t *testing.T) {

--- a/core/slots/slots.go
+++ b/core/slots/slots.go
@@ -12,7 +12,8 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
-// MatchSoc returns the end time of the first slot whose soc satisfies fun
+// MatchSoc returns when the first slot whose soc satisfies fun is reached,
+// counted from now rather than from the current slot boundary.
 func MatchSoc(ts []float32, fun func(float32) bool) time.Time {
 	for i, soc := range ts {
 		if fun(soc) {

--- a/core/slots/slots.go
+++ b/core/slots/slots.go
@@ -1,0 +1,147 @@
+// Package slots provides arithmetic over per-slot timeseries as used by the optimizer.
+package slots
+
+import (
+	"slices"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/tariff"
+	"github.com/jinzhu/now"
+	"github.com/samber/lo"
+	"golang.org/x/exp/constraints"
+)
+
+// MatchSoc returns the end time of the first slot whose soc satisfies fun
+func MatchSoc(ts []float32, fun func(float32) bool) time.Time {
+	for i, soc := range ts {
+		if fun(soc) {
+			// TODO first slot
+			return time.Now().Add(time.Duration(i+1) * tariff.SlotDuration).Round(time.Second)
+		}
+	}
+
+	return time.Time{}
+}
+
+// FromNow strips away any slots before "now".
+// The profile contains 48 15min slots (00:00-23:45) that repeat for multiple days.
+func FromNow(profile []float64) []float64 {
+	firstSlot := int(time.Now().Truncate(tariff.SlotDuration).Sub(now.BeginningOfDay()) / tariff.SlotDuration)
+	return profile[firstSlot:]
+}
+
+// BlendMeasured decays the first slots from the measured value into the forecast.
+// Slot 0 uses the measured value, the forecast takes over from slot decaySlots on.
+func BlendMeasured[T constraints.Float](slots []T, measured T, decaySlots int) {
+	for i := range min(decaySlots, len(slots)) {
+		w := T(decaySlots-i) / T(decaySlots)
+		slots[i] = w*measured + (1-w)*slots[i]
+	}
+}
+
+// BlendScale decays a scale factor towards 1 over the first slots.
+// Slot 0 is scaled by the full factor, from slot decaySlots on it is 1.
+func BlendScale[T constraints.Float](slots []T, scale float64, decaySlots int) {
+	for i := range min(decaySlots, len(slots)) {
+		w := float64(decaySlots-i) / float64(decaySlots)
+		slots[i] = T(float64(slots[i]) * (w*scale + (1 - w)))
+	}
+}
+
+// Prorate adjusts the first slot's energy amount according to remaining duration
+func Prorate[T constraints.Float](slots []T, firstSlotDuration time.Duration) []float32 {
+	// return empty slice instead of nil to make api happy
+	if len(slots) == 0 {
+		return []float32{}
+	}
+
+	res := slices.Clone(slots)
+	res[0] = res[0] * T(firstSlotDuration) / T(tariff.SlotDuration)
+	return lo.Map(res, func(f T, _ int) float32 {
+		return float32(f)
+	})
+}
+
+// CurrentRates returns the tariff's rates with past slots removed
+func CurrentRates(t api.Tariff) api.Rates {
+	if t == nil {
+		return nil
+	}
+
+	rates, err := t.Rates()
+	if err != nil {
+		return nil
+	}
+
+	// filter past slots
+	now := time.Now()
+	return lo.Filter(rates, func(slot api.Rate, _ int) bool {
+		return slot.End.After(now)
+	})
+}
+
+// Horizon limits the hosted optimizer to 48 hours, extended to the end of that day.
+// Before 6:00 the extension would add almost a full day, so it only applies past 6:00.
+func Horizon(t time.Time) time.Time {
+	horizon := t.Add(48 * time.Hour)
+	if t.Hour() < 6 {
+		return horizon
+	}
+	return now.With(horizon).EndOfDay()
+}
+
+// Until limits maxLen to the slots starting before the given horizon
+func Until(rates api.Rates, horizon time.Time, maxLen int) int {
+	if i := slices.IndexFunc(rates[:min(maxLen, len(rates))], func(slot api.Rate) bool {
+		return slot.Start.After(horizon)
+	}); i >= 0 {
+		return i
+	}
+	return maxLen
+}
+
+// TimeSteps returns the duration in seconds of each of the next minLen slots,
+// shortening the first one to the remainder of the current slot
+func TimeSteps(minLen int, now time.Time) []int {
+	res := make([]int, 0, minLen)
+
+	eos := now.Truncate(tariff.SlotDuration).Add(tariff.SlotDuration)
+	if d := eos.Sub(now); d > time.Second && d < tariff.SlotDuration {
+		res = append(res, int(d.Seconds()))
+	}
+
+	for i := len(res); i < minLen; i++ {
+		res = append(res, int(tariff.SlotDuration.Seconds())) // 15min slots
+	}
+
+	return res
+}
+
+// AsTimestamps converts slot durations in seconds to slot start times
+func AsTimestamps(dt []int, now time.Time) []time.Time {
+	res := make([]time.Time, 0, len(dt))
+
+	eos := now.Truncate(tariff.SlotDuration).Add(tariff.SlotDuration)
+	res = append(res, eos.Add(-time.Duration(dt[0])*time.Second))
+
+	for i := range len(dt) - 1 {
+		res = append(res, res[i].Add(time.Duration(dt[i])*time.Second))
+	}
+
+	return res
+}
+
+// ScaleAndPrune scales the rates' values and limits them to maxLen slots
+func ScaleAndPrune(rates api.Rates, scale float64, maxLen int) []float32 {
+	res := make([]float32, 0, maxLen)
+
+	for _, slot := range rates {
+		res = append(res, float32(slot.Value*scale))
+		if len(res) >= maxLen {
+			break
+		}
+	}
+
+	return res
+}

--- a/core/slots/slots_test.go
+++ b/core/slots/slots_test.go
@@ -1,0 +1,74 @@
+package slots
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/tariff"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHorizon(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.Local)
+	horizon := Horizon(ts)
+
+	// 48h plus end of day
+	assert.Equal(t, time.Date(2025, 1, 3, 23, 59, 59, int(time.Second-time.Nanosecond), time.Local), horizon)
+
+	// before 6:00 the day is not extended
+	assert.Equal(t, time.Date(2025, 1, 3, 5, 30, 0, 0, time.Local),
+		Horizon(time.Date(2025, 1, 1, 5, 30, 0, 0, time.Local)))
+
+	rates := make(api.Rates, 0, 4*96)
+	for slot := ts.Truncate(tariff.SlotDuration); len(rates) < cap(rates); slot = slot.Add(tariff.SlotDuration) {
+		rates = append(rates, api.Rate{Start: slot, End: slot.Add(tariff.SlotDuration)})
+	}
+
+	// 4 days of slots from 10:30, capped at the last slot of Jan 3rd
+	assert.Equal(t, 246, Until(rates, horizon, len(rates)))
+	assert.Equal(t, time.Date(2025, 1, 3, 23, 45, 0, 0, time.Local), rates[245].Start)
+
+	// shorter forecast is not extended
+	assert.Equal(t, 8, Until(rates, horizon, 8))
+}
+
+func TestAsTimestamps(t *testing.T) {
+	// now is 10 minutes into a 15-minute slot
+	now := time.Date(2025, 1, 1, 12, 10, 0, 0, time.UTC)
+
+	// dt[0]=300 means first event is 300s (5min) before end of current slot
+	// dt[1..] just mark subsequent slot boundaries
+	dt := []int{60 * 5, 60 * 15, 60 * 15}
+
+	got := AsTimestamps(dt, now)
+
+	// current slot 12:00-12:15, first timestamp 12:15 - 5min = 12:10
+	assert.Equal(t, []time.Time{
+		time.Date(2025, 1, 1, 12, 10, 0, 0, time.UTC),
+		time.Date(2025, 1, 1, 12, 15, 0, 0, time.UTC),
+		time.Date(2025, 1, 1, 12, 30, 0, 0, time.UTC),
+	}, got)
+}
+
+func TestBlendMeasured(t *testing.T) {
+	ss := []float64{100, 100, 100, 100, 100, 100}
+	BlendMeasured(ss, 200, 4)
+	assert.Equal(t, []float64{200, 175, 150, 125, 100, 100}, ss)
+
+	// fewer slots than decay length
+	short := []float32{100, 100}
+	BlendMeasured(short, 200, 4)
+	assert.Equal(t, []float32{200, 175}, short)
+}
+
+func TestBlendScale(t *testing.T) {
+	ss := []float32{100, 100, 100, 100, 100, 100}
+	BlendScale(ss, 2, 4)
+	assert.Equal(t, []float32{200, 175, 150, 125, 100, 100}, ss)
+
+	// fewer slots than decay length
+	short := []float64{100, 100}
+	BlendScale(short, 0.5, 4)
+	assert.Equal(t, []float64{50, 62.5}, short)
+}


### PR DESCRIPTION
`site_optimizer.go` mixes the stateful optimizer orchestration with plain arithmetic over per-slot timeseries. The arithmetic needs neither the site nor a loadpoint, but sitting in the same file it was only reachable through the surrounding request builder.

The eleven pure helpers move to `core/slots`, their tests along with them. Everything that touches site state, locking or publishing stays in `core`, so no site interface is needed and the split stays narrow.

- `core/slots` holds `Horizon`, `Until`, `TimeSteps`, `AsTimestamps`, `ScaleAndPrune`, `BlendMeasured`, `BlendScale`, `Prorate`, `FromNow`, `MatchSoc` and `CurrentRates`
- `site_optimizer.go` drops from 1361 to 1231 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
