### PR TITLE
chore: test loadpoint settings restore

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	evbus "github.com/asaskevich/EventBus"
@@ -303,15 +302,19 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, collec
 }
 
 // NewLoadpoint creates a Loadpoint with sane defaults
-func NewLoadpoint(log *util.Logger, settings settings.Settings) *Loadpoint {
+func NewLoadpoint(log *util.Logger, set settings.Settings) *Loadpoint {
 	clock := clock.New()
 	bus := evbus.New()
 
+	if set == nil {
+		set = settings.NewMemorySettings()
+	}
+
 	lp := &Loadpoint{
-		log:               log,      // logger
-		settings:          settings, // settings
-		clock:             clock,    // mockable time
-		bus:               bus,      // event bus
+		log:               log,   // logger
+		settings:          set,   // settings
+		clock:             clock, // mockable time
+		bus:               bus,   // event bus
 		mode:              api.ModeOff,
 		status:            api.StatusNone,
 		minCurrent:        6,   // A
@@ -335,10 +338,6 @@ func NewLoadpoint(log *util.Logger, settings settings.Settings) *Loadpoint {
 
 // restoreSettings restores loadpoint settings
 func (lp *Loadpoint) restoreSettings() {
-	if testing.Testing() {
-		return
-	}
-
 	// deprecated yaml properties
 	if lp.Phases_ > 0 {
 		lp.log.WARN.Printf("ignoring deprecated phases: %d. please configure via UI", lp.Phases_)
@@ -720,6 +719,11 @@ func (lp *Loadpoint) Prepare(site site.API, uiChan chan<- util.Param, pushChan c
 	_ = lp.bus.Subscribe(evVehicleDisconnect, lp.evVehicleDisconnectHandler)
 	_ = lp.bus.Subscribe(evChargeCurrent, lp.evChargeCurrentHandler)
 	_ = lp.bus.Subscribe(evVehicleSoc, lp.evVehicleSocProgressHandler)
+
+	// loadpoints built without the constructor have no settings store
+	if lp.settings == nil {
+		lp.settings = settings.NewMemorySettings()
+	}
 
 	// restore settings
 	lp.restoreSettings()

--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -302,19 +302,15 @@ func NewLoadpointFromConfig(log *util.Logger, settings settings.Settings, collec
 }
 
 // NewLoadpoint creates a Loadpoint with sane defaults
-func NewLoadpoint(log *util.Logger, set settings.Settings) *Loadpoint {
+func NewLoadpoint(log *util.Logger, settings settings.Settings) *Loadpoint {
 	clock := clock.New()
 	bus := evbus.New()
 
-	if set == nil {
-		set = settings.NewMemorySettings()
-	}
-
 	lp := &Loadpoint{
-		log:               log,   // logger
-		settings:          set,   // settings
-		clock:             clock, // mockable time
-		bus:               bus,   // event bus
+		log:               log,      // logger
+		settings:          settings, // settings
+		clock:             clock,    // mockable time
+		bus:               bus,      // event bus
 		mode:              api.ModeOff,
 		status:            api.StatusNone,
 		minCurrent:        6,   // A

--- a/core/loadpoint_settings_test.go
+++ b/core/loadpoint_settings_test.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/loadpoint"
+	"github.com/evcc-io/evcc/core/settings"
+	"github.com/evcc-io/evcc/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestSettingsRoundtrip asserts that settings written through the API are
+// restored into a fresh loadpoint sharing the same store.
+func TestSettingsRoundtrip(t *testing.T) {
+	store := settings.NewMemorySettings()
+	uiChan, pushChan, lpChan := createChannels(t)
+
+	planTime := time.Now().Add(4 * time.Hour).Round(time.Second)
+	smartCost := 0.25
+	feedInPriority := 0.15
+	estimate := true
+
+	soc := loadpoint.SocConfig{
+		Poll:     loadpoint.PollConfig{Mode: loadpoint.PollAlways, Interval: 42 * time.Minute},
+		Estimate: &estimate,
+	}
+	thresholds := loadpoint.ThresholdsConfig{
+		Enable:  loadpoint.ThresholdConfig{Delay: 2 * time.Minute, Threshold: -100},
+		Disable: loadpoint.ThresholdConfig{Delay: 4 * time.Minute, Threshold: 200},
+	}
+	strategy := api.PlanStrategy{Continuous: true, Precondition: 30 * time.Minute}
+
+	ctrl := gomock.NewController(t)
+	charger := api.NewMockCharger(ctrl)
+	charger.EXPECT().Enabled().Return(false, nil).AnyTimes()
+
+	// write
+	lp := NewLoadpoint(util.NewLogger("foo"), store)
+	lp.charger = charger
+	lp.Prepare(new(Site), uiChan, pushChan, lpChan)
+
+	lp.SetMode(api.ModePV)
+	lp.SetPriority(3)
+	require.NoError(t, lp.SetMinCurrent(8))
+	require.NoError(t, lp.SetMaxCurrent(12))
+	lp.SetLimitSoc(75)
+	lp.SetLimitEnergy(11)
+	lp.SetMinSoc(20)
+	lp.SetSmartCostLimit(&smartCost)
+	lp.SetSmartFeedInPriorityLimit(&feedInPriority)
+	lp.SetBatteryBoostLimit(90)
+	lp.SetThresholds(thresholds)
+	lp.SetSocConfig(soc)
+	require.NoError(t, lp.SetPlanEnergy(planTime, 7))
+	require.NoError(t, lp.SetPlanStrategy(strategy))
+
+	// read back into a fresh loadpoint
+	restored := NewLoadpoint(util.NewLogger("bar"), store)
+	restored.charger = charger
+	restored.Prepare(new(Site), uiChan, pushChan, lpChan)
+
+	assert.Equal(t, api.ModePV, restored.GetMode())
+	assert.Equal(t, 3, restored.GetPriority())
+	assert.Equal(t, 8.0, restored.GetMinCurrent())
+	assert.Equal(t, 12.0, restored.GetMaxCurrent())
+	assert.Equal(t, 75, restored.GetLimitSoc())
+	assert.Equal(t, 11.0, restored.GetLimitEnergy())
+	assert.Equal(t, 20, restored.GetMinSoc())
+	assert.Equal(t, &smartCost, restored.GetSmartCostLimit())
+	assert.Equal(t, &feedInPriority, restored.GetSmartFeedInPriorityLimit())
+	assert.Equal(t, 90, restored.GetBatteryBoostLimit())
+	assert.Equal(t, thresholds, restored.GetThresholds())
+	assert.Equal(t, soc, restored.GetSocConfig())
+	assert.Equal(t, strategy, restored.GetPlanStrategy())
+
+	ts, energy := restored.GetPlanEnergy()
+	assert.Equal(t, planTime, ts)
+	assert.Equal(t, 7.0, energy)
+}

--- a/core/settings/accessor.go
+++ b/core/settings/accessor.go
@@ -1,0 +1,78 @@
+package settings
+
+import (
+	"time"
+
+	"github.com/spf13/cast"
+)
+
+// accessor implements the typed scalar accessors on top of an untyped store.
+// Json handling is left to the implementations as their storage formats differ.
+type accessor struct {
+	get func(key string) (any, error)
+	set func(key string, val any)
+}
+
+func (s accessor) SetString(key string, val string) {
+	s.set(key, val)
+}
+
+func (s accessor) SetInt(key string, val int64) {
+	s.set(key, val)
+}
+
+func (s accessor) SetFloat(key string, val float64) {
+	s.set(key, val)
+}
+
+func (s accessor) SetFloatPtr(key string, val *float64) {
+	s.set(key, val)
+}
+
+func (s accessor) SetTime(key string, val time.Time) {
+	s.set(key, val)
+}
+
+func (s accessor) SetBool(key string, val bool) {
+	s.set(key, val)
+}
+
+func (s accessor) String(key string) (string, error) {
+	val, err := s.get(key)
+	if err != nil {
+		return "", err
+	}
+	return cast.ToStringE(val)
+}
+
+func (s accessor) Int(key string) (int64, error) {
+	val, err := s.get(key)
+	if err != nil {
+		return 0, err
+	}
+	return cast.ToInt64E(val)
+}
+
+func (s accessor) Float(key string) (float64, error) {
+	val, err := s.get(key)
+	if err != nil {
+		return 0, err
+	}
+	return cast.ToFloat64E(val)
+}
+
+func (s accessor) Time(key string) (time.Time, error) {
+	val, err := s.get(key)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return cast.ToTimeE(val)
+}
+
+func (s accessor) Bool(key string) (bool, error) {
+	val, err := s.get(key)
+	if err != nil {
+		return false, err
+	}
+	return cast.ToBoolE(val)
+}

--- a/core/settings/config.go
+++ b/core/settings/config.go
@@ -4,23 +4,24 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
-	"github.com/spf13/cast"
 )
 
 var _ Settings = (*ConfigSettings)(nil)
 
 type ConfigSettings struct {
+	accessor
 	mu   sync.Mutex
 	log  *util.Logger
 	conf *config.Config
 }
 
 func NewConfigSettingsAdapter(log *util.Logger, conf *config.Config) *ConfigSettings {
-	return &ConfigSettings{log: log, conf: conf}
+	s := &ConfigSettings{log: log, conf: conf}
+	s.accessor = accessor{s.get, s.set}
+	return s
 }
 
 func (s *ConfigSettings) get(key string) (any, error) {
@@ -44,73 +45,9 @@ func (s *ConfigSettings) set(key string, val any) {
 	}
 }
 
-func (s *ConfigSettings) SetString(key string, val string) {
-	s.set(key, val)
-}
-
-func (s *ConfigSettings) SetInt(key string, val int64) {
-	s.set(key, val)
-}
-
-func (s *ConfigSettings) SetFloat(key string, val float64) {
-	s.set(key, val)
-}
-
-func (s *ConfigSettings) SetFloatPtr(key string, val *float64) {
-	s.set(key, val)
-}
-
-func (s *ConfigSettings) SetTime(key string, val time.Time) {
-	s.set(key, val)
-}
-
-func (s *ConfigSettings) SetBool(key string, val bool) {
-	s.set(key, val)
-}
-
 func (s *ConfigSettings) SetJson(key string, val any) error {
 	s.set(key, val)
 	return nil
-}
-
-func (s *ConfigSettings) String(key string) (string, error) {
-	val, err := s.get(key)
-	if err != nil {
-		return "", err
-	}
-	return cast.ToStringE(val)
-}
-
-func (s *ConfigSettings) Int(key string) (int64, error) {
-	val, err := s.get(key)
-	if err != nil {
-		return 0, err
-	}
-	return cast.ToInt64E(val)
-}
-
-func (s *ConfigSettings) Float(key string) (float64, error) {
-	val, err := s.get(key)
-	if err != nil {
-		return 0, err
-	}
-	return cast.ToFloat64E(val)
-}
-
-func (s *ConfigSettings) Time(key string) (time.Time, error) {
-	val, err := s.get(key)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return cast.ToTimeE(val)
-}
-
-func (s *ConfigSettings) Bool(key string) (bool, error) {
-	val, err := s.get(key)
-	if err != nil {
-		return false, err
-	}
-	return cast.ToBoolE(val)
 }
 
 func (s *ConfigSettings) Json(key string, res any) error {

--- a/core/settings/memory.go
+++ b/core/settings/memory.go
@@ -1,0 +1,55 @@
+package settings
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+)
+
+var _ Settings = (*memorySettings)(nil)
+
+type memorySettings struct {
+	accessor
+	mu   sync.Mutex
+	vals map[string]any
+}
+
+// NewMemorySettings creates a non-persistent settings store
+func NewMemorySettings() Settings {
+	s := &memorySettings{vals: make(map[string]any)}
+	s.accessor = accessor{s.get, s.set}
+	return s
+}
+
+func (s *memorySettings) get(key string) (any, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	val, ok := s.vals[key]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return val, nil
+}
+
+func (s *memorySettings) set(key string, val any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.vals[key] = val
+}
+
+func (s *memorySettings) SetJson(key string, val any) error {
+	b, err := json.Marshal(val)
+	if err != nil {
+		return err
+	}
+	s.set(key, string(b))
+	return nil
+}
+
+func (s *memorySettings) Json(key string, res any) error {
+	str, err := s.String(key)
+	if str == "" || err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(str), &res)
+}


### PR DESCRIPTION
`restoreSettings` mirrors by hand the key and the type that each setter persists. Nothing ties the two together, so a setting can be persisted and silently never come back. The function also returned early under test, so the restore path had no coverage at all: tests pass a nil settings store, which any setter would have panicked on.

An in-memory store makes the path testable. A loadpoint built without one now falls back to it instead of holding nil, the test guard is gone, and a roundtrip test writes every persisted setting through the API and asserts a fresh loadpoint reads them all back. Removing a single restore branch fails that test.

- new non-persistent `settings.NewMemorySettings`, used when no store is passed
- `restoreSettings` no longer branches on `testing.Testing()`
- the typed scalar accessors move to a shared type so the memory and config stores stop repeating them, Json handling stays per store as the formats differ

The device refs and title are not restored here for configurable loadpoints, they arrive through mapstructure, so they are out of the roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
