### PR TITLE
fix: align battery forecast times to slot boundaries

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -641,6 +641,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 // applyOptimizerResult maps the optimizer response onto suggestions, battery
 // forecast and notifications
 func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details []batteryDetail, res optimizer.OptimizationResult) {
+	now := time.Now()
 	slotHours := (time.Duration(req.TimeSeries.Dt[0]) * time.Second).Hours()
 	gridImporting := len(res.GridImport) > 0 && res.GridImport[0] > 0
 	gridExporting := len(res.GridExport) > 0 && res.GridExport[0] > 0
@@ -654,10 +655,10 @@ func (site *Site) applyOptimizerResult(req optimizer.OptimizationInput, details 
 
 		batteries = append(batteries, batteryResult{
 			batteryDetail: detail,
-			Full: matchSoc(batRes.StateOfCharge, func(soc float32) bool {
+			Full: matchSoc(batRes.StateOfCharge, now, func(soc float32) bool {
 				return soc >= batReq.SMax
 			}),
-			Empty: matchSoc(batRes.StateOfCharge, func(soc float32) bool {
+			Empty: matchSoc(batRes.StateOfCharge, now, func(soc float32) bool {
 				return soc <= batReq.SMin
 			}),
 		})
@@ -937,11 +938,14 @@ func (site *Site) batteryRequest(dev config.Device[api.Meter], b types.Measureme
 	return bat, detail
 }
 
-func matchSoc(ts []float32, fun func(float32) bool) time.Time {
+// matchSoc returns the end of the first slot whose soc satisfies fun.
+// Slot 0 is the remainder of the current slot, so it ends at the next slot boundary.
+func matchSoc(ts []float32, now time.Time, fun func(float32) bool) time.Time {
+	eos := now.Truncate(tariff.SlotDuration).Add(tariff.SlotDuration)
+
 	for i, soc := range ts {
 		if fun(soc) {
-			// TODO first slot
-			return time.Now().Add(time.Duration(i+1) * tariff.SlotDuration).Round(time.Second)
+			return eos.Add(time.Duration(i) * tariff.SlotDuration)
 		}
 	}
 

--- a/core/site_optimizer_matchsoc_test.go
+++ b/core/site_optimizer_matchsoc_test.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/tariff"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchSoc(t *testing.T) {
+	atLeast50 := func(soc float32) bool { return soc >= 50 }
+
+	// 10 minutes into the 12:00-12:15 slot
+	now := time.Date(2025, 1, 1, 12, 10, 0, 0, time.UTC)
+	eos := time.Date(2025, 1, 1, 12, 15, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		ts       []float32
+		expected time.Time
+	}{
+		// slot 0 is the remainder of the current slot, it ends at the boundary
+		{[]float32{50, 0, 0}, eos},
+		{[]float32{0, 50, 0}, eos.Add(tariff.SlotDuration)},
+		{[]float32{0, 0, 50}, eos.Add(2 * tariff.SlotDuration)},
+		// no match
+		{[]float32{0, 0, 0}, time.Time{}},
+		{nil, time.Time{}},
+	} {
+		assert.Equal(t, tc.expected, matchSoc(tc.ts, now, atLeast50), "%v", tc.ts)
+	}
+
+	// called exactly on a slot boundary the current slot is full length
+	onBoundary := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	assert.Equal(t, onBoundary.Add(tariff.SlotDuration), matchSoc([]float32{50}, onBoundary, atLeast50))
+}


### PR DESCRIPTION
spotted while reviewing #33381

`matchSoc` backs the battery forecast full and empty times. It measured the end of a matching slot from the current instant, but slot 0 covers only the remainder of the current slot and ends at the next boundary. Called mid-slot, every returned time was late by the elapsed part of the current slot, up to a full slot. The `TODO first slot` in that function marked this.

The request side already treats slot 0 as partial, both in the slot durations it sends and in the timestamps it derives from them, so the result side was the only place still counting from the wall clock.

- full and empty times now land on slot boundaries, matching the timestamps the optimizer request is built from
- `matchSoc` takes `now` as a parameter, like the other slot helpers, which makes it testable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
